### PR TITLE
Async load patrons' author list showcases

### DIFF
--- a/openlibrary/plugins/openlibrary/js/my-books/index.js
+++ b/openlibrary/plugins/openlibrary/js/my-books/index.js
@@ -29,11 +29,11 @@ export function initMyBooksAffordances(dropperElements, showcaseElements) {
         myBooksDropper.initialize()
 
         droppers.push(myBooksDropper)
-        seedKeys.push(myBooksDropper.getSeedKeys())
+        seedKeys.push(...myBooksDropper.getSeedKeys())
     }
 
     // Remove duplicate keys:
-    const seedKeySet = new Set(...seedKeys)
+    const seedKeySet = new Set(seedKeys)
 
     // Get user key from first Dropper and add to store:
     const userKey = droppers[0].readingLists.userKey

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -173,7 +173,7 @@ $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_userg
 
         $if "lists" in ctx.features:
             <div class="section Tools">
-                $:render_template("lists/widget", page, include_rating=False, exclude_own_lists=True, show_active_lists=True)
+                $:render_template("lists/widget", page, include_rating=False, async_load=True, show_active_lists=True, include_showcase=False)
             </div>
 
         <div class="section">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9268

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Updates the author page active lists showcase to:
1. Load asynchronously
2. Display only the patron's list items

### Technical
<!-- What should be noted about the implementation? -->
Fixes bug where arrays of seed keys were being added to the `seedKeys` array, which caused keys to be dropped later, when a set is created from this array.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While authenticated:
1. Navigate to an author page
2. Add the author to one of your lists
3. Refresh the page
4. Confirm that loading indicator is present on page load
5. Confirm that the loading indicator is replaced with a list showcase item that represents the list from step 2, above

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
