### PR TITLE
Imports: increase point penalty for non-matching publishers

### DIFF
--- a/openlibrary/catalog/add_book/match.py
+++ b/openlibrary/catalog/add_book/match.py
@@ -438,13 +438,15 @@ def compare_publisher(e1: dict, e2: dict):
                     return ('publisher', 'occur within the other', 100)
                 elif short_part_publisher_match(e1_norm, e2_norm):
                     return ('publisher', 'match', 100)
-        return ('publisher', 'mismatch', -25)
+        return ('publisher', 'mismatch', -51)
 
     if 'publishers' not in e1 or 'publishers' not in e2:
         return ('publisher', 'either missing', 0)
 
 
-def threshold_match(rec1: dict, rec2: dict, threshold: int, debug: bool = False):
+def threshold_match(
+    rec1: dict, rec2: dict, threshold: int, debug: bool = False
+) -> bool:
     """
     Determines (according to a threshold) whether two edition representations are
     sufficiently the same. Used when importing new books.
@@ -460,12 +462,12 @@ def threshold_match(rec1: dict, rec2: dict, threshold: int, debug: bool = False)
     level1 = level1_match(e1, e2)
     total = sum(i[2] for i in level1)
     if debug:
-        print(f"E1: {e1}\nE2: {e2}")
-        print(f"TOTAL 1 = {total} : {level1}")
+        print(f"E1: {e1}\nE2: {e2}", flush=True)
+        print(f"TOTAL 1 = {total} : {level1}", flush=True)
     if total >= threshold:
         return True
     level2 = level2_match(e1, e2)
     total = sum(i[2] for i in level2)
     if debug:
-        print(f"TOTAL 2 = {total} : {level2}")
+        print(f"TOTAL 2 = {total} : {level2}", flush=True)
     return total >= threshold


### PR DESCRIPTION
Closes #9387 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix.

This PR increases the penalty for a truthy and yet non-matching `publishers` field so that during import editions will not match when they have:
1. matching author;
2. matching title;
3. matching publish_date; and
4. do NOT have a matching truthy publishers field.

Edition matching uses a points system found in
`openlibrary/catalog/add_book/match.py`, and a match is made when the threshold of 875 points is met. This PR increases the penalty for non-matching publishers to stop a match from occurring in the above situation.

The rationale is that multiple editions can be published by different publishers in the same year, and all would have the same title, authors, and publish_date, yet they would be different editions if the truthy `publishers` field did not match.

If the `publishers` field is falsy, then a match should happen as it would before, though this does create the risk that the incoming edition could have an ISBN or other identifier that doesn't match the existing publisher from the original record; however, this was the case before and hitherto that has not appeared to be an issue.

### Technical
<!-- What should be noted about the implementation? -->
For reasons I have not yet determined, the `status` field is coming back `modified` for the Work when importing the record suggested in #9387. However, the Work record is itself not modified, which makes sense, as the code changes were to functions called by `editions_match`. Still, this is puzzling and I'm not yet sure if it's an artifact of `copydocs.py` import, or perhaps the fact that I've imported and deleted these records a few times, so their revision history is a bit odd.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Import the records as mentioned in #9387:
```
docker compose exec web bash
library@9f99aad1aca5:/openlibrary$ PYTHONPATH=. ./scripts/copydocs.py /works/OL31830589W?v=2 /authors/OL7636796A?v=1 /books/OL46219062M?v=3
fetching versioned [KeyVersionPair(key='/works/OL31830589W', version='2'), KeyVersionPair(key='/authors/OL7636796A', version='1'), KeyVersionPair(key='/books/OL46219062M', version='3')]
saving ['/works/OL31830589W', '/authors/OL7636796A', '/books/OL46219062M']
[{'key': '/works/OL31830589W', 'revision': 6}, {'key': '/authors/OL7636796A', 'revision': 3}, {'key': '/books/OL46219062M', 'revision': 11}]
```
```
❯ curl -X POST \
     -H "Content-Type: application/json" \
     -b ~/cookies.txt \
     -d '{
    "title": "Spoon River Anthology",
    "source_records": ["standard_ebooks:edgar-lee-masters/spoon-river-anthology"],
    "publishers": ["Standard Ebooks"],
    "publish_date": "2022",
    "authors": [{"name": "Edgar Lee Masters"}],
    "description": "<p><i>Spoon River Anthology</i> is a collection of short poems that reveals the true nature of the citizens of a fictional small town in Illinois. Each poem is a candid autobiography of a now-deceased resident that lies in the Oak Hill Cemetery\u2014often exposing their darkest secrets.</p> <p><a href=\"https://standardebooks.org/ebooks/edgar-lee-masters\">Edgar Lee Masters</a> was raised in Lewistown, Illinois and based these stories on the gossip he heard there. The book was a commercial success, but was banned from schools and libraries in the area due to the real-life citizens knowing exactly whom each poem was written about. As the years have passed and more generations now lie in Oak Hill Cemetery, Lewistown has forgiven Masters, and he\u2019s now celebrated there.</p> <p>The poems were originally published in the literary magazine <i>Reedy\u2019s Mirror</i> under the pseudonym Webster Ford. The first book edition was published in 1915 and contained 209 poems. Masters added 35 new poems, including the epilogue, for the 1916 edition, which is the edition that this Standard Ebooks edition is based on.</p>",
    "subjects": ["American poetry", "Poetry"],
    "identifiers": {
        "standard_ebooks": ["edgar-lee-masters/spoon-river-anthology"]
    },
    "languages": ["eng"],
    "cover": "https://standardebooks.org/ebooks/edgar-lee-masters/spoon-river-anthology/downloads/cover.jpg"
     }' \
     http://localhost:8080/api/import

{"authors": [{"key": "/authors/OL7636796A", "name": "Edgar Lee Masters", "status": "matched"}], "success": true, "edition": {"key": "/books/OL14M", "status": "created"}, "work": {"key": "/works/OL31830589W", "status": "modified"}}
```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
The new, matched, edition:
![image](https://github.com/internetarchive/openlibrary/assets/26524678/9b3f8b3d-d928-4b1f-af61-f3c8e6e14156)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@hornc, I'd especially appreciate any feedback you have.
@cdrini 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
