### PR TITLE
Asynchronously load search facets sidebar

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -62,7 +62,7 @@
     },
     {
       "path": "static/build/search.*.js",
-      "maxSize": "1KB"
+      "maxSize": "1.2KB"
     },
     {
       "path": "static/build/tabs.*.js",

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -613,12 +613,12 @@ msgstr ""
 
 #: SearchNavigation.html SubjectTags.html lib/nav_foot.html lib/nav_head.html
 #: subjects.html subjects/notfound.html type/author/view.html
-#: type/list/view_body.html work_search.html
+#: type/list/view_body.html
 msgid "Subjects"
 msgstr ""
 
 #: SubjectTags.html subjects.html type/author/view.html
-#: type/list/view_body.html work_search.html
+#: type/list/view_body.html
 msgid "Places"
 msgstr ""
 
@@ -628,7 +628,7 @@ msgstr ""
 msgid "People"
 msgstr ""
 
-#: SubjectTags.html subjects.html type/list/view_body.html work_search.html
+#: SubjectTags.html subjects.html type/list/view_body.html
 msgid "Times"
 msgstr ""
 
@@ -1006,6 +1006,11 @@ msgstr ""
 
 #: work_search.html
 msgid "Published by"
+msgstr ""
+
+#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html
+#: search/advancedsearch.html work_search.html
+msgid "Author"
 msgstr ""
 
 #: work_search.html
@@ -6042,6 +6047,10 @@ msgstr ""
 msgid "Person"
 msgstr ""
 
+#: search/advancedsearch.html type/edition/view.html type/work/view.html
+msgid "Publisher"
+msgstr ""
+
 #: search/advancedsearch.html
 msgid "How to search?"
 msgstr ""
@@ -6630,6 +6639,10 @@ msgstr ""
 #: type/edition/view.html type/work/view.html
 #, python-format
 msgid "Search for other books from %(publisher)s"
+msgstr ""
+
+#: type/edition/view.html type/work/view.html
+msgid "Language"
 msgstr ""
 
 #: type/edition/view.html type/work/view.html

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -624,7 +624,7 @@ msgstr ""
 
 #: SubjectTags.html admin/menu.html admin/people/index.html
 #: admin/people/view.html subjects.html type/author/view.html
-#: type/list/view_body.html work_search.html
+#: type/list/view_body.html
 msgid "People"
 msgstr ""
 
@@ -922,32 +922,6 @@ msgid "Search Books"
 msgstr ""
 
 #: work_search.html
-msgid "eBook?"
-msgstr ""
-
-#: type/edition/view.html type/work/view.html work_search.html
-msgid "Language"
-msgstr ""
-
-#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html
-#: search/advancedsearch.html work_search.html
-msgid "Author"
-msgstr ""
-
-#: work_search.html
-msgid "First published"
-msgstr ""
-
-#: publishers/view.html search/advancedsearch.html type/edition/view.html
-#: type/work/view.html work_search.html
-msgid "Publisher"
-msgstr ""
-
-#: work_search.html
-msgid "Classic eBooks"
-msgstr ""
-
-#: work_search.html
 msgid "Keywords"
 msgstr ""
 
@@ -969,57 +943,6 @@ msgstr ""
 
 #: work_search.html
 msgid "Solr Editions"
-msgstr ""
-
-#: work_search.html
-msgid "eBook"
-msgstr ""
-
-#: work_search.html
-msgid "Classic eBook"
-msgstr ""
-
-#: work_search.html
-msgid "Search facets"
-msgstr ""
-
-#: work_search.html
-msgid "Explore Classic eBooks"
-msgstr ""
-
-#: work_search.html
-msgid "Only Classic eBooks"
-msgstr ""
-
-#: work_search.html
-#, python-format
-msgid "Explore books about %(subject)s"
-msgstr ""
-
-#: merge/authors.html work_search.html
-msgid "First published in"
-msgstr ""
-
-#: work_search.html
-msgid "Written in"
-msgstr ""
-
-#: work_search.html
-msgid "Published by"
-msgstr ""
-
-#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html
-#: search/advancedsearch.html work_search.html
-msgid "Author"
-msgstr ""
-
-#: work_search.html
-msgid "Click to remove this facet"
-msgstr ""
-
-#: work_search.html
-#, python-format
-msgid "%(title)s - search"
 msgstr ""
 
 #: admin/inspect/store.html search/lists.html work_search.html
@@ -3352,6 +3275,11 @@ msgstr ""
 msgid "Required field"
 msgstr ""
 
+#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html
+#: search/advancedsearch.html search/work_search_selected_facets.html
+msgid "Author"
+msgstr ""
+
 #: books/add.html
 msgid ""
 "Like, \"Agatha Christie\" or \"Jean-Paul Sartre.\" We'll also do a live "
@@ -5611,6 +5539,10 @@ msgstr ""
 msgid "Open in a new window"
 msgstr ""
 
+#: merge/authors.html search/work_search_selected_facets.html
+msgid "First published in"
+msgstr ""
+
 #: merge/authors.html
 msgid "Visit this author's page in a new window"
 msgstr ""
@@ -5866,6 +5798,11 @@ msgstr ""
 msgid "Publisher: %(name)s"
 msgstr ""
 
+#: publishers/view.html search/advancedsearch.html type/edition/view.html
+#: type/work/view.html
+msgid "Publisher"
+msgstr ""
+
 #: publishers/view.html
 #, python-format
 msgid "%(count)s ebook"
@@ -6045,10 +5982,6 @@ msgstr ""
 
 #: search/advancedsearch.html
 msgid "Person"
-msgstr ""
-
-#: search/advancedsearch.html type/edition/view.html type/work/view.html
-msgid "Publisher"
 msgstr ""
 
 #: search/advancedsearch.html
@@ -6249,6 +6182,48 @@ msgstr ""
 
 #: search/work_search_facets.html
 msgid "Focus your results using these <a href=\"/search/howto\">filters</a>"
+msgstr ""
+
+#: search/work_search_selected_facets.html
+msgid "eBook"
+msgstr ""
+
+#: search/work_search_selected_facets.html
+msgid "Classic eBook"
+msgstr ""
+
+#: search/work_search_selected_facets.html
+msgid "Search facets"
+msgstr ""
+
+#: search/work_search_selected_facets.html
+msgid "Explore Classic eBooks"
+msgstr ""
+
+#: search/work_search_selected_facets.html
+msgid "Only Classic eBooks"
+msgstr ""
+
+#: search/work_search_selected_facets.html
+#, python-format
+msgid "Explore books about %(subject)s"
+msgstr ""
+
+#: search/work_search_selected_facets.html
+msgid "Written in"
+msgstr ""
+
+#: search/work_search_selected_facets.html
+msgid "Published by"
+msgstr ""
+
+#: search/work_search_selected_facets.html
+msgid "Click to remove this facet"
+msgstr ""
+
+#: search/work_search_selected_facets.html
+#, python-format
+msgid "%(title)s - search"
 msgstr ""
 
 #: site/alert.html

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1073,6 +1073,7 @@ class Partials(delegate.page):
                 'search/work_search_facets',
                 p,
                 facet_counts=search_response.facet_counts,
+                async_load=False
             )
             partial = {"partials": str(output)}
 

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1069,7 +1069,11 @@ class Partials(delegate.page):
             p = data.get('p', {})
             sort = None
             search_response = do_search(p, sort, rows=0, spellcheck_count=3)
-            output = render_template('search/work_search_facets', p, facet_counts=search_response.facet_counts)
+            output = render_template(
+                'search/work_search_facets',
+                p,
+                facet_counts=search_response.facet_counts,
+            )
             partial = {"partials": str(output)}
 
         return delegate.RawText(json.dumps(partial))

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1074,7 +1074,7 @@ class Partials(delegate.page):
             sort = None
             search_response = do_search(p, sort, rows=0, spellcheck_count=3)
 
-            output = render_template(
+            sidebar = render_template(
                 'search/work_search_facets',
                 p,
                 facet_counts=search_response.facet_counts,
@@ -1082,7 +1082,18 @@ class Partials(delegate.page):
                 path=path,
                 query=parsed_qs,
             )
-            partial = {"partials": str(output)}
+
+            active_facets = render_template(
+                'search/work_search_selected_facets',
+                p,
+                search_response,
+                p.get('q', ''),
+            )
+
+            partial = {
+                "sidebar": str(sidebar),
+                "activeFacets": str(active_facets)
+            }
 
         return delegate.RawText(json.dumps(partial))
 

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1092,9 +1092,11 @@ class Partials(delegate.page):
 
             partial = {
                 "sidebar": str(sidebar),
-                "activeFacets": str(active_facets),
                 "title": active_facets.title,
             }
+
+            if active_facets_markup := str(active_facets).strip():
+                partial["activeFacets"] = active_facets_markup
 
         return delegate.RawText(json.dumps(partial))
 

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1088,6 +1088,8 @@ class Partials(delegate.page):
                 p,
                 search_response,
                 p.get('q', ''),
+                path=path,
+                query=parsed_qs,
             )
 
             partial = {

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1092,7 +1092,8 @@ class Partials(delegate.page):
 
             partial = {
                 "sidebar": str(sidebar),
-                "activeFacets": str(active_facets)
+                "activeFacets": str(active_facets),
+                "title": active_facets.title,
             }
 
         return delegate.RawText(json.dumps(partial))

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1072,7 +1072,9 @@ class Partials(delegate.page):
             param = data.get('param', {})
 
             sort = None
-            search_response = do_search(param, sort, rows=0, spellcheck_count=3, facet=True)
+            search_response = do_search(
+                param, sort, rows=0, spellcheck_count=3, facet=True
+            )
 
             sidebar = render_template(
                 'search/work_search_facets',
@@ -1095,7 +1097,7 @@ class Partials(delegate.page):
             partial = {
                 "sidebar": str(sidebar),
                 "title": active_facets.title,
-                "activeFacets": str(active_facets).strip()
+                "activeFacets": str(active_facets).strip(),
             }
 
         return delegate.RawText(json.dumps(partial))

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1072,7 +1072,7 @@ class Partials(delegate.page):
             param = data.get('param', {})
 
             sort = None
-            search_response = do_search(param, sort, rows=0, spellcheck_count=3)
+            search_response = do_search(param, sort, rows=0, spellcheck_count=3, facet=True)
 
             sidebar = render_template(
                 'search/work_search_facets',

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -877,7 +877,7 @@ api and api.add_hook('new', new)
 
 
 @public
-def changequery(query=None, **kw):
+def changequery(query=None, _path=None, **kw):
     if query is None:
         query = web.input(_method='get', _unicode=False)
     for k, v in kw.items():
@@ -890,7 +890,7 @@ def changequery(query=None, **kw):
         k: [web.safestr(s) for s in v] if isinstance(v, list) else web.safestr(v)
         for k, v in query.items()
     }
-    out = web.ctx.get('readable_path', web.ctx.path)
+    out = _path or web.ctx.get('readable_path', web.ctx.path)
     if query:
         out += '?' + urllib.parse.urlencode(query, doseq=True)
     return out
@@ -1066,14 +1066,21 @@ class Partials(delegate.page):
             partial = {"partials": str(macro)}
         elif component == 'SearchFacets':
             data = json.loads(i.data)
+            path = data.get('path')
+            query = data.get('query', '')
+            parsed_qs = parse_qs(query.replace('?', ''))
             p = data.get('p', {})
+
             sort = None
             search_response = do_search(p, sort, rows=0, spellcheck_count=3)
+
             output = render_template(
                 'search/work_search_facets',
                 p,
                 facet_counts=search_response.facet_counts,
-                async_load=False
+                async_load=False,
+                path=path,
+                query=parsed_qs,
             )
             partial = {"partials": str(output)}
 

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1069,14 +1069,14 @@ class Partials(delegate.page):
             path = data.get('path')
             query = data.get('query', '')
             parsed_qs = parse_qs(query.replace('?', ''))
-            p = data.get('p', {})
+            param = data.get('param', {})
 
             sort = None
-            search_response = do_search(p, sort, rows=0, spellcheck_count=3)
+            search_response = do_search(param, sort, rows=0, spellcheck_count=3)
 
             sidebar = render_template(
                 'search/work_search_facets',
-                p,
+                param,
                 facet_counts=search_response.facet_counts,
                 async_load=False,
                 path=path,
@@ -1085,9 +1085,9 @@ class Partials(delegate.page):
 
             active_facets = render_template(
                 'search/work_search_selected_facets',
-                p,
+                param,
                 search_response,
-                p.get('q', ''),
+                param.get('q', ''),
                 path=path,
                 query=parsed_qs,
             )

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1095,10 +1095,8 @@ class Partials(delegate.page):
             partial = {
                 "sidebar": str(sidebar),
                 "title": active_facets.title,
+                "activeFacets": str(active_facets).strip()
             }
-
-            if active_facets_markup := str(active_facets).strip():
-                partial["activeFacets"] = active_facets_markup
 
         return delegate.RawText(json.dumps(partial))
 

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -44,6 +44,7 @@ import openlibrary.core.stats
 from openlibrary.plugins.openlibrary.home import format_work_data
 from openlibrary.plugins.openlibrary.stats import increment_error_count
 from openlibrary.plugins.openlibrary import processors
+from openlibrary.plugins.worksearch.code import do_search
 
 delegate.app.add_processor(processors.ReadableUrlProcessor())
 delegate.app.add_processor(processors.ProfileProcessor())
@@ -1063,6 +1064,13 @@ class Partials(delegate.page):
                 args[0], args[1]
             )
             partial = {"partials": str(macro)}
+        elif component == 'SearchFacets':
+            data = json.loads(i.data)
+            p = data.get('p', {})
+            sort = None
+            search_response = do_search(p, sort, rows=0, spellcheck_count=3)
+            output = render_template('search/work_search_facets', p, facet_counts=search_response.facet_counts)
+            partial = {"partials": str(output)}
 
         return delegate.RawText(json.dumps(partial))
 

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -328,9 +328,10 @@ jQuery(function () {
             .then((module) => module.initOfflineBanner());
     }
 
-    if (document.getElementById('searchFacets')) {
+    const searchFacets = document.getElementById('searchFacets')
+    if (searchFacets) {
         import(/* webpackChunkName: "search" */ './search')
-            .then((module) => module.initSearchFacets());
+            .then((module) => module.initSearchFacets(searchFacets));
     }
 
     // Conditionally load Integrated Librarian Environment

--- a/openlibrary/plugins/openlibrary/js/search.js
+++ b/openlibrary/plugins/openlibrary/js/search.js
@@ -74,6 +74,8 @@ export function initSearchFacets(facetsElem) {
                 const newFacetsElem = createElementFromMarkup(data.sidebar)
                 facetsElem.replaceWith(newFacetsElem)
                 hydrateFacets()
+
+                document.title = data.title
             })
             .catch(() => {
                 // XXX : Handle case where `/partials` response is not `2XX` here

--- a/openlibrary/plugins/openlibrary/js/search.js
+++ b/openlibrary/plugins/openlibrary/js/search.js
@@ -107,7 +107,11 @@ function hydrateFacets() {
  * @throws Will throw error if `/partials` response is not in 200-299 range.
  */
 function fetchPartials(param) {
-    const data = {p: param}
+    const data = {
+            p: param,
+            path: location.pathname,
+            query: document.location.search
+        }
     const dataString = JSON.stringify(data)
     const dataQueryParam = encodeURIComponent(dataString)
 

--- a/openlibrary/plugins/openlibrary/js/search.js
+++ b/openlibrary/plugins/openlibrary/js/search.js
@@ -1,5 +1,5 @@
 /**
- * Functionalities for templates/work_search.
+ * Functionalities for templates/work_search and related templates.
  */
 
 /**
@@ -50,13 +50,15 @@ export function less(header, start_facet_count, facet_inc) {
 }
 
 /**
- * Initializes the search page's facets sidebar.
+ * Initializes the search page's search facet affordances.
  *
- * If the search facets sidebar is in `asyncLoad` mode, the sidebar will contain loading
+ * If the search facets sidebar is in `asyncLoad` mode, the sidebar will initially contain loading
  * indicators instead of facet counts.  In this case, a request is made for sidebar markup
  * containing the actual counts, and the existing sidebar is replaced with the new sidebar.
  *
  * In either case, the sidebar is hydrated.
+ *
+ * In `asyncLoad` mode, the markup for selected facets is also loaded asynchronously.
  *
  * @param {HTMLElement} facetsElem Root element of the search facets sidebar component
  */
@@ -105,13 +107,21 @@ function hydrateFacets() {
 }
 
 /**
- * Makes call for a partially rendered facet counts sidebar, using the given search
- * parameters.
+ * A successful response from the partials request
+ *
+ * @typedef {Object} PartialsResponse
+ * @property {string} title - The new title for this page
+ * @property {string} sidebar - HTML string for the facets sidebar
+ * @property {string} [activeFacets] - HTML string for the selected facets
+ */
+/**
+ * Using the given search parameters, makes call for a partially rendered facet affordances
+ * and the new title for the page.
  *
  * @param {Object} param
- * @returns {Promise<Response>}
+ * @returns {Promise<PartialsResponse>}
  *
- * @throws Will throw error if `/partials` response is not in 200-299 range.
+ * @throws Error when `/partials` response is not in 200-299 range.
  */
 function fetchPartials(param) {
     const data = {

--- a/openlibrary/plugins/openlibrary/js/search.js
+++ b/openlibrary/plugins/openlibrary/js/search.js
@@ -127,7 +127,7 @@ function fetchPartials(param) {
     const data = {
             param: param,
             path: location.pathname,
-            query: document.location.search
+            query: location.search
         }
     const dataString = JSON.stringify(data)
 

--- a/openlibrary/plugins/openlibrary/js/search.js
+++ b/openlibrary/plugins/openlibrary/js/search.js
@@ -67,7 +67,11 @@ export function initSearchFacets(facetsElem) {
         const param = JSON.parse(facetsElem.dataset.param)
         fetchPartials(param)
             .then((data) => {
-                const newFacetsElem = createElementFromMarkup(data.partials)
+                const activeFacetsElem = createElementFromMarkup(data.activeFacets)
+                const activeFacetsContainer = document.querySelector('.selected-search-facets-container')
+                activeFacetsContainer.replaceChildren(activeFacetsElem)
+
+                const newFacetsElem = createElementFromMarkup(data.sidebar)
                 facetsElem.replaceWith(newFacetsElem)
                 hydrateFacets()
             })
@@ -114,6 +118,9 @@ function fetchPartials(param) {
         }
     const dataString = JSON.stringify(data)
     const dataQueryParam = encodeURIComponent(dataString)
+
+    console.log('data:')
+    console.log(data)
 
     return fetch(`/partials.json?_component=SearchFacets&data=${dataQueryParam}`)
         .then((resp) => {

--- a/openlibrary/plugins/openlibrary/js/search.js
+++ b/openlibrary/plugins/openlibrary/js/search.js
@@ -130,9 +130,11 @@ function fetchPartials(param) {
             query: document.location.search
         }
     const dataString = JSON.stringify(data)
-    const dataQueryParam = encodeURIComponent(dataString)
 
-    return fetch(`/partials.json?_component=SearchFacets&data=${dataQueryParam}`)
+    return fetch(`/partials.json?${new URLSearchParams({
+            _component: 'SearchFacets',
+            data: dataString
+        })}`)
         .then((resp) => {
             if (!resp.ok) {
                 throw new Error(`Failed to fetch partials. Status code: ${resp.status}`)

--- a/openlibrary/plugins/openlibrary/js/search.js
+++ b/openlibrary/plugins/openlibrary/js/search.js
@@ -125,16 +125,16 @@ function hydrateFacets() {
  */
 function fetchPartials(param) {
     const data = {
-            param: param,
-            path: location.pathname,
-            query: location.search
-        }
+        param: param,
+        path: location.pathname,
+        query: location.search
+    }
     const dataString = JSON.stringify(data)
 
     return fetch(`/partials.json?${new URLSearchParams({
-            _component: 'SearchFacets',
-            data: dataString
-        })}`)
+        _component: 'SearchFacets',
+        data: dataString
+    })}`)
         .then((resp) => {
             if (!resp.ok) {
                 throw new Error(`Failed to fetch partials. Status code: ${resp.status}`)

--- a/openlibrary/plugins/openlibrary/js/search.js
+++ b/openlibrary/plugins/openlibrary/js/search.js
@@ -115,7 +115,7 @@ function hydrateFacets() {
  */
 function fetchPartials(param) {
     const data = {
-            p: param,
+            param: param,
             path: location.pathname,
             query: document.location.search
         }

--- a/openlibrary/plugins/openlibrary/js/search.js
+++ b/openlibrary/plugins/openlibrary/js/search.js
@@ -67,10 +67,11 @@ export function initSearchFacets(facetsElem) {
         const param = JSON.parse(facetsElem.dataset.param)
         fetchPartials(param)
             .then((data) => {
-                const activeFacetsElem = createElementFromMarkup(data.activeFacets)
-                const activeFacetsContainer = document.querySelector('.selected-search-facets-container')
-                activeFacetsContainer.replaceChildren(activeFacetsElem)
-
+                if (data.activeFacets) {
+                    const activeFacetsElem = createElementFromMarkup(data.activeFacets)
+                    const activeFacetsContainer = document.querySelector('.selected-search-facets-container')
+                    activeFacetsContainer.replaceChildren(activeFacetsElem)
+                }
                 const newFacetsElem = createElementFromMarkup(data.sidebar)
                 facetsElem.replaceWith(newFacetsElem)
                 hydrateFacets()
@@ -120,9 +121,6 @@ function fetchPartials(param) {
         }
     const dataString = JSON.stringify(data)
     const dataQueryParam = encodeURIComponent(dataString)
-
-    console.log('data:')
-    console.log(data)
 
     return fetch(`/partials.json?_component=SearchFacets&data=${dataQueryParam}`)
         .then((resp) => {

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -19,6 +19,7 @@ from infogami.utils.view import public, render, render_template, safeint
 from openlibrary.core import cache
 from openlibrary.core.lending import add_availability
 from openlibrary.core.models import Edition
+from openlibrary.i18n import gettext as _
 from openlibrary.plugins.openlibrary.processors import urlsafe
 from openlibrary.plugins.upstream.utils import (
     get_language_name,
@@ -54,6 +55,22 @@ if hasattr(config, 'plugin_worksearch'):
     )
 
     default_spellcheck_count = config.plugin_worksearch.get('spellcheck_count', 10)
+
+
+@public
+def get_facet_map() -> tuple[tuple[str, str]]:
+    return (
+        ('has_fulltext', _('eBook?')),
+        ('language', _('Language')),
+        ('author_key', _('Author')),
+        ('subject_facet', _('Subjects')),
+        ('first_publish_year', _('First published')),
+        ('publisher_facet', _('Publisher')),
+        ('person_facet', _('People')),
+        ('place_facet', _('Places')),
+        ('time_facet', _('Times')),
+        ('public_scan_b', _('Classic eBooks')),
+    )
 
 
 @public

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -318,6 +318,7 @@ def do_search(
     sort: str | None,
     page=1,
     rows=100,
+    facet=True,
     spellcheck_count=None,
 ):
     """
@@ -338,6 +339,7 @@ def do_search(
         sort,
         spellcheck_count,
         fields=list(fields),
+        facet=facet,
     )
 
 
@@ -524,7 +526,7 @@ class search(delegate.page):
         rows = 20
         if param:
             search_response = do_search(
-                param, sort, page, rows=rows, spellcheck_count=3
+                param, sort, page, rows=rows, spellcheck_count=3, facet=False
             )
         else:
             search_response = SearchResponse(

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -318,7 +318,7 @@ def do_search(
     sort: str | None,
     page=1,
     rows=100,
-    facet=True,
+    facet=False,
     spellcheck_count=None,
 ):
     """
@@ -526,7 +526,7 @@ class search(delegate.page):
         rows = 20
         if param:
             search_response = do_search(
-                param, sort, page, rows=rows, spellcheck_count=3, facet=False
+                param, sort, page, rows=rows, spellcheck_count=3
             )
         else:
             search_response = SearchResponse(

--- a/openlibrary/templates/search/work_search_facets.html
+++ b/openlibrary/templates/search/work_search_facets.html
@@ -1,4 +1,4 @@
-$def with (facet_map, param, facet_counts=None)
+$def with (param, facet_counts=None)
 
 $code:
     async_load = facet_counts == None
@@ -77,7 +77,7 @@ $def facet_entry(display, count, facet_url, hide_entry=False):
     <div class="smallest lightgreen sansserif" style="margin-bottom:20px;">
         $:_('Focus your results using these <a href="/search/howto">filters</a>')
     </div>
-    $for header, label in facet_map:
+    $for header, label in get_facet_map():
         $if header=='has_fulltext' and 'has_fulltext' in param:
             $continue
         $if header=='public_scan_b':

--- a/openlibrary/templates/search/work_search_facets.html
+++ b/openlibrary/templates/search/work_search_facets.html
@@ -1,4 +1,4 @@
-$def with (param, facet_counts=None, async_load=True)
+$def with (param, facet_counts=None, async_load=True, path=None, query={})
 
 $code:
     start_facet_count = 5
@@ -6,9 +6,9 @@ $code:
 
     def add_facet_url(k, v):
         if k != 'has_fulltext':
-            return changequery(page=None, **{k:param.get(k, []) + [v]})
+            return changequery(query=dict(query), page=None, _path=path, **{k:param.get(k, []) + [v]})
         else:
-            return changequery(page=None, **{k:v})
+            return changequery(query=dict(query), page=None, _path=path, **{k:v})
 
     def add_track(key: str) -> str:
         """
@@ -71,7 +71,8 @@ $def facet_entry(display, count, facet_url, hide_entry=False):
             <span class="small"><a href="$facet_url" title="$link_title" data-ol-link-track="$add_track(header)">$display</a></span>&nbsp;<span class="smaller gray">$commify(count)</span>
     </div>
 
-<div id="searchFacets" data-config="$dumps({'start_facet_count': start_facet_count, 'facet_inc': facet_inc})" data-param="$dumps(param)" data-async-load="$dumps(async_load)">
+$ data_path = 'data-path=%s' % (changequery()) if not path else ''
+<div id="searchFacets" data-config="$dumps({'start_facet_count': start_facet_count, 'facet_inc': facet_inc})" data-param="$dumps(param)" data-async-load="$dumps(async_load)" $data_path>
     <h3 class="collapse">$_("Zoom In")</h3>
     <div class="smallest lightgreen sansserif" style="margin-bottom:20px;">
         $:_('Focus your results using these <a href="/search/howto">filters</a>')

--- a/openlibrary/templates/search/work_search_facets.html
+++ b/openlibrary/templates/search/work_search_facets.html
@@ -72,7 +72,7 @@ $def facet_entry(display, count, facet_url, hide_entry=False):
             <span class="small"><a href="$facet_url" title="$link_title" data-ol-link-track="$add_track(header)">$display</a></span>&nbsp;<span class="smaller gray">$commify(count)</span>
     </div>
 
-<div id="searchFacets" data-config="$dumps({'start_facet_count': start_facet_count, 'facet_inc': facet_inc})">
+<div id="searchFacets" data-config="$dumps({'start_facet_count': start_facet_count, 'facet_inc': facet_inc})" data-param="$dumps(param)" data-async-load="$dumps(async_load)">
     <h3 class="collapse">$_("Zoom In")</h3>
     <div class="smallest lightgreen sansserif" style="margin-bottom:20px;">
         $:_('Focus your results using these <a href="/search/howto">filters</a>')

--- a/openlibrary/templates/search/work_search_facets.html
+++ b/openlibrary/templates/search/work_search_facets.html
@@ -71,8 +71,7 @@ $def facet_entry(display, count, facet_url, hide_entry=False):
             <span class="small"><a href="$facet_url" title="$link_title" data-ol-link-track="$add_track(header)">$display</a></span>&nbsp;<span class="smaller gray">$commify(count)</span>
     </div>
 
-$ data_path = 'data-path=%s' % (changequery()) if not path else ''
-<div id="searchFacets" data-config="$dumps({'start_facet_count': start_facet_count, 'facet_inc': facet_inc})" data-param="$dumps(param)" data-async-load="$dumps(async_load)" $data_path>
+<div id="searchFacets" data-config="$dumps({'start_facet_count': start_facet_count, 'facet_inc': facet_inc})" data-param="$dumps(param)" data-async-load="$dumps(async_load)">
     <h3 class="collapse">$_("Zoom In")</h3>
     <div class="smallest lightgreen sansserif" style="margin-bottom:20px;">
         $:_('Focus your results using these <a href="/search/howto">filters</a>')

--- a/openlibrary/templates/search/work_search_facets.html
+++ b/openlibrary/templates/search/work_search_facets.html
@@ -1,15 +1,14 @@
-$def with (param, facet_counts=None)
+$def with (param, facet_counts=None, async_load=True)
 
 $code:
-    async_load = facet_counts == None
     start_facet_count = 5
     facet_inc = 10
 
     def add_facet_url(k, v):
         if k != 'has_fulltext':
-            return changequery(page=None,**{k:param.get(k, []) + [v]})
+            return changequery(page=None, **{k:param.get(k, []) + [v]})
         else:
-            return changequery(page=None,**{k:v})
+            return changequery(page=None, **{k:v})
 
     def add_track(key: str) -> str:
         """

--- a/openlibrary/templates/search/work_search_selected_facets.html
+++ b/openlibrary/templates/search/work_search_selected_facets.html
@@ -1,13 +1,13 @@
-$def with (param, search_response, q_param)
+$def with (param, search_response, q_param, path=None, query={})
 
 $code:
     fulltext_names = {'true': 'Ebooks', 'false': 'Exclude ebooks'}
     facet_map = get_facet_map()
     def del_facet_url(k, v):
         if k != 'has_fulltext':
-            return changequery(page=None,**{k:[i for i in param.get(k, []) if i != v]})
+            return changequery(page=None, _path=path, query=dict(query), **{k:[i for i in param.get(k, []) if i != v]})
         else:
-            return changequery(page=None,**{k:None})
+            return changequery(page=None, _path=path, query=dict(query), **{k:None})
 
 $if param and not search_response.error:
     $ title = []

--- a/openlibrary/templates/search/work_search_selected_facets.html
+++ b/openlibrary/templates/search/work_search_selected_facets.html
@@ -1,0 +1,57 @@
+$def with (param, search_response, q_param)
+
+$code:
+    fulltext_names = {'true': 'Ebooks', 'false': 'Exclude ebooks'}
+    facet_map = get_facet_map()
+    def del_facet_url(k, v):
+        if k != 'has_fulltext':
+            return changequery(page=None,**{k:[i for i in param.get(k, []) if i != v]})
+        else:
+            return changequery(page=None,**{k:None})
+
+$if param and not search_response.error:
+    $ title = []
+    $if q_param:
+        $title.append(q_param)
+    $if 'has_fulltext' in param:
+        $title.append(_('eBook'))
+    $if 'public_scan_b' in param:
+        $title.append(_('Classic eBook'))
+
+    $if any(header in param for header, label in facet_map):
+        <p class="collapse darkgray"><span class="tools"><img src="/images/icons/icon_search-facet.png" alt="$_('Search facets')" width="11" height="10" style="margin-right:5px;"/><strong>
+        $for header, label in facet_map:
+            $ counts = search_response.facet_counts[header]
+            $for k, display, count in counts:
+                $if k not in param.get(header, []):
+                    $continue
+
+                $if header not in ['has_fulltext', 'public_scan_b']:
+                    $title.append(display)
+
+                $if header == 'has_fulltext':
+                    $fulltext_names.get(k, '')
+                $elif header == 'public_scan_b':
+                    $if display == 'true':
+                        <a href="/read" title="$_('Explore Classic eBooks')">$_("Only Classic eBooks")</a>
+                    $else:
+                        Classic eBooks hidden
+                $elif header == 'subject_facet':
+                    <a href="/subjects/$display.replace(' ', '_')" title="$_('Explore books about %(subject)s', subject=display)" class="facetSubject">$display</a>
+                $elif header == 'person_facet':
+                    <a href="/subjects/person:$display.replace(' ', '_')" title="$_('Explore books about %(subject)s', subject=display)" class="facetSubject">$display</a>
+                $elif header == 'place_facet':
+                    <a href="/subjects/place:$display.replace(' ', '_')" title="$_('Explore books about %(subject)s', subject=display)" class="facetSubject">$display</a>
+                $elif header == 'time_facet':
+                    <a href="/subjects/time:$display.replace(' ', '_')" title="$_('Explore books about %(subject)s', subject=display)" class="facetSubject">$display</a>
+                $elif header == 'first_publish_year':
+                    <span title="$_('First published in')">$display</span>
+                $elif header == 'language':
+                    <span title="$_('Written in')">$display</span>
+                $elif header == 'publisher_facet':
+                    <span title="$_('Published by')">$display</span>
+                $elif header == 'author_key':
+                    <span title="$_('Author')">$display</span>
+                <span style="padding-right:15px;"><a href="$del_facet_url(header, k)" title="$_('Click to remove this facet')" class="facetRemove plain red">[x]</a></span>
+        </strong></span></p>
+    $var title: $_('%(title)s - search', title=', '.join(title))

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -153,7 +153,7 @@ $if search_response.error:
     <h3>$_("BARF! Search engine ERROR!")</h3>
     <pre>$search_response.error.decode('utf-8', 'ignore')</pre>
 $elif param and len(search_response.docs):
-    $:render_template('search/work_search_facets', param)
+    $:render_template('search/work_search_facets', param, facet_counts=search_response.facet_counts)
 <!-- /facets -->
     </div>
 

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -153,7 +153,7 @@ $if search_response.error:
     <h3>$_("BARF! Search engine ERROR!")</h3>
     <pre>$search_response.error.decode('utf-8', 'ignore')</pre>
 $elif param and len(search_response.docs):
-    $:render_template('search/work_search_facets', param, facet_counts=search_response.facet_counts)
+    $:render_template('search/work_search_facets', param)
 <!-- /facets -->
     </div>
 

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -1,20 +1,9 @@
 $def with (q_param, search_response, get_doc, param, page, rows)
 
-$ fulltext_names = {'true': 'Ebooks', 'false': 'Exclude ebooks'}
-
-$code:
-    def del_facet_url(k, v):
-        if k != 'has_fulltext':
-            return changequery(page=None,**{k:[i for i in param.get(k, []) if i != v]})
-        else:
-            return changequery(page=None,**{k:None})
-
 <div>
     <div id="contentHead">
       <h1>$_("Search Books")</h1>
     </div>
-
-$ facet_map = get_facet_map()
 
 <div id="contentBody">
   $:macros.SearchNavigation()
@@ -49,55 +38,10 @@ $ facet_map = get_facet_map()
         $for v in values if isinstance(values, list) else [values]:
           <input type="hidden" name="$k" value="$v.replace('"', '&quot;')" />
     </form>
-
-        $if param and not search_response.error:
-            $ title = []
-            $if q_param:
-                $title.append(q_param)
-            $if 'has_fulltext' in param:
-                $title.append(_('eBook'))
-
-            $if 'public_scan_b' in param:
-                $title.append(_('Classic eBook'))
-
-            $if any(header in param for header, label in facet_map):
-                <p class="collapse darkgray"><span class="tools"><img src="/images/icons/icon_search-facet.png" alt="$_('Search facets')" width="11" height="10" style="margin-right:5px;"/><strong>
-                $for header, label in facet_map:
-                    $ counts = search_response.facet_counts[header]
-                    $for k, display, count in counts:
-                        $if k not in param.get(header, []):
-                            $continue
-
-                        $if header not in ['has_fulltext', 'public_scan_b']:
-                            $title.append(display)
-
-                        $if header == 'has_fulltext':
-                            $fulltext_names.get(k, '')
-                        $elif header == 'public_scan_b':
-                            $if display == 'true':
-                                <a href="/read" title="$_('Explore Classic eBooks')">$_("Only Classic eBooks")</a>
-                            $else:
-                                Classic eBooks hidden
-                        $elif header == 'subject_facet':
-                            <a href="/subjects/$display.replace(' ', '_')" title="$_('Explore books about %(subject)s', subject=display)" class="facetSubject">$display</a>
-                        $elif header == 'person_facet':
-                            <a href="/subjects/person:$display.replace(' ', '_')" title="$_('Explore books about %(subject)s', subject=display)" class="facetSubject">$display</a>
-                        $elif header == 'place_facet':
-                            <a href="/subjects/place:$display.replace(' ', '_')" title="$_('Explore books about %(subject)s', subject=display)" class="facetSubject">$display</a>
-                        $elif header == 'time_facet':
-                            <a href="/subjects/time:$display.replace(' ', '_')" title="$_('Explore books about %(subject)s', subject=display)" class="facetSubject">$display</a>
-                        $elif header == 'first_publish_year':
-                            <span title="$_('First published in')">$display</span>
-                        $elif header == 'language':
-                            <span title="$_('Written in')">$display</span>
-                        $elif header == 'publisher_facet':
-                            <span title="$_('Published by')">$display</span>
-                        $elif header == 'author_key':
-                            <span title="$_('Author')">$display</span>
-                        <span style="padding-right:15px;"><a href="$del_facet_url(header, k)" title="$_('Click to remove this facet')" class="facetRemove plain red">[x]</a></span>
-                </strong></span></p>
-            $var title: $_('%(title)s - search', title=', '.join(title))
-
+        <span class="selected-search-facets-container">
+            $if search_response.facet_counts:
+              $:render_template('search/work_search_selected_facets', param, search_response, q_param)
+        </span>
     </div>
 
 

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -14,18 +14,7 @@ $code:
       <h1>$_("Search Books")</h1>
     </div>
 
-$ facet_map = (
-$    ('has_fulltext', _('eBook?')),
-$    ('language', _('Language')),
-$    ('author_key', _('Author')),
-$    ('subject_facet', _('Subjects')),
-$    ('first_publish_year', _('First published')),
-$    ('publisher_facet', _('Publisher')),
-$    ('person_facet', _('People')),
-$    ('place_facet', _('Places')),
-$    ('time_facet', _('Times')),
-$    ('public_scan_b', _('Classic eBooks')),
-$ )
+$ facet_map = get_facet_map()
 
 <div id="contentBody">
   $:macros.SearchNavigation()
@@ -164,7 +153,7 @@ $if search_response.error:
     <h3>$_("BARF! Search engine ERROR!")</h3>
     <pre>$search_response.error.decode('utf-8', 'ignore')</pre>
 $elif param and len(search_response.docs):
-    $:render_template('search/work_search_facets', facet_map, param, facet_counts=search_response.facet_counts)
+    $:render_template('search/work_search_facets', param, facet_counts=search_response.facet_counts)
 <!-- /facets -->
     </div>
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7271

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Search facets sidebar and selected facets are now asynchronously loaded.  On initial page load, the sidebar will contain a number of loading indicators, and no selected facets.  Once the `/partials` call has successfully returned, the sidebar is replaced with a new sidebar that includes that facet counts, and the selected facets are displayed below the search bar.

### Technical
<!-- What should be noted about the implementation? -->
`facet_map` no longer needs to be passed to the `work_search_facets` template, and is instead retrieved via a new `public` function.

The overridden `changequery` function has been updated to include a new `_path` keyword parameter.  When `_path` is present, it is used in place of the current `web.ctx` path.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
