### PR TITLE
9380/bug/My-Lists-Showcase-Breaking

### DIFF
--- a/openlibrary/core/lists/model.py
+++ b/openlibrary/core/lists/model.py
@@ -381,7 +381,11 @@ class List(Thing):
             'title': title,
             'count': self.seed_count,
             'covers': n_covers,
-            'last_mod': last_modified.isoformat(sep=' ', timespec="minutes"),
+            'last_mod': (
+                last_modified.isoformat(sep=' ', timespec="minutes")
+                if self.seed_count != 0
+                else ""
+            ),
         }
 
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9380 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This bug fixes an issue that occurs only when lists are empty. Currently, the caching of the list showcase checks for the date of the latest modification to one of the list's seeds, and stores it as `last_modified`. It then attempts to convert this value to ISOformat, which leads to an error when the list is empty. 

A line of code now checks whether or not the list is empty before attempting to convert the date, which prevents this bug from occurring.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Create an empty list, then return to your MyBooks page.
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/internetarchive/openlibrary/assets/131627264/5d0345ec-6b32-445e-9d24-f6d8d9b079a1)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
