### PR TITLE
Fixes to lists-showcase styling/code

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -507,9 +507,9 @@ msgstr ""
 msgid "See more books by, and learn about, this author"
 msgstr ""
 
-#: account/loans.html authors/index.html publishers/view.html
-#: search/authors.html search/publishers.html search/subjects.html
-#: subjects.html
+#: account/loans.html authors/index.html lists/showcase.html
+#: publishers/view.html search/authors.html search/publishers.html
+#: search/subjects.html subjects.html
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
@@ -4479,6 +4479,15 @@ msgstr ""
 
 #: lists/preview.html
 msgid "by <a href=\"$owner.key\">You</a>"
+msgstr ""
+
+#: lists/showcase.html
+#, python-format
+msgid "My Lists (%(count)d)"
+msgstr ""
+
+#: lists/showcase.html
+msgid "You have no lists."
 msgstr ""
 
 #: lists/widget.html

--- a/openlibrary/templates/lists/showcase.html
+++ b/openlibrary/templates/lists/showcase.html
@@ -30,9 +30,15 @@ $def list_card(list):
     </div>
     <div class="list-showcase">
         $if lists:
-            $ displayed_lists = lists[0:min(len(lists), 5)]
-            $for list in displayed_lists:
+            $ displayed_lists = 5
+            $for list in lists[:displayed_lists]
                 $:list_card(list)
+
+            $if len(lists) > displayed_lists:
+                <a
+                    class="list-showcase__see-all cta-btn cta-btn--vanilla"
+                    href="/people/$username/lists"
+                >$_("See all")</a>
         $else:
             <p>$_('You have no lists.')</p>
     </div>

--- a/openlibrary/templates/lists/showcase.html
+++ b/openlibrary/templates/lists/showcase.html
@@ -1,9 +1,8 @@
-$def with (lists = [], username = "")
+$def with (lists, username)
 
 
 $ default_image_url = "/images/icons/avatar_book-sm.png"
 $ total_lists = lists[0:min(len(lists), 5)]
-$ all_lists_url = "/people/%s/lists" % username
 
 $def list_card(list):
     $ cached_info = list.get_patron_showcase()
@@ -14,10 +13,9 @@ $def list_card(list):
     <a class="list-card" href="$list_url">
         <div class="list-card__name-tag">
             <p class="list-card__title">$title</p>
-            $if count == 1:
-                <p class="list-card__num-books"> $count book</p>
-            $else:
-                <p class="list-card__num-books"> $count books</p>
+            <p class="list-card__num-books">
+                $ungettext("%(count)d book", "%(count)d books", count, count=count)
+            </p>
         </div>
         <div class="list-card__covers">
             $for img_url in cover_urls:
@@ -29,7 +27,7 @@ $def list_card(list):
 <div class="carousel-section">
     <div class="carousel-section-header">
         <h2 class="home-h2">
-            <a href="$all_lists_url"> My Lists ($len(lists))</a>
+            <a href="/people/$username/lists">$_('My Lists (%(count)d)', count=len(lists))</a>
         </h2>
     </div>
     <div class="list-showcase">
@@ -37,6 +35,6 @@ $def list_card(list):
             $for list in total_lists:
                 $:list_card(list)
         $else:
-            <p>You have no lists.</p>
+            <p>$_('You have no lists.')</p>
     </div>
 </div>

--- a/openlibrary/templates/lists/showcase.html
+++ b/openlibrary/templates/lists/showcase.html
@@ -5,15 +5,19 @@ $def list_card(list):
     $ cached_info = list.get_patron_showcase()
     $ count = cached_info["count"]
     <a class="list-card" href="$list.get_url()">
-        <div class="list-card__name-tag">
-            <p class="list-card__title">$cached_info["title"]</p>
-            <p class="list-card__num-books">
-                $ungettext("%(count)d book", "%(count)d books", count, count=count)
-            </p>
-        </div>
         <div class="list-card__covers">
             $for img_url in cached_info["covers"]:
-                <img src="$(img_url or '/images/icons/avatar_book-sm.png')" loading="lazy">
+                $if img_url:
+                    $ img_url = img_url.replace("-S.jpg", "-M.jpg")
+                $else:
+                    $ img_url = '/images/icons/avatar_book-sm.png'
+                <img src="$img_url" loading="lazy" width="80">
+        </div>
+        <div class="list-card__name-tag">
+            <div class="list-card__title">$cached_info["title"]</div>
+            <div class="list-card__num-books">
+                $ungettext("%(count)d book", "%(count)d books", count, count=count)
+            </div>
         </div>
     </a>
 

--- a/openlibrary/templates/lists/showcase.html
+++ b/openlibrary/templates/lists/showcase.html
@@ -1,25 +1,19 @@
 $def with (lists, username)
 
 
-$ default_image_url = "/images/icons/avatar_book-sm.png"
-$ total_lists = lists[0:min(len(lists), 5)]
-
 $def list_card(list):
     $ cached_info = list.get_patron_showcase()
-    $ title = cached_info["title"] if len(cached_info["title"]) < 16 else cached_info["title"][0:16] + "..."
     $ count = cached_info["count"]
-    $ list_url = list.get_url()
-    $ cover_urls = [cover_url if cover_url else default_image_url for cover_url in cached_info["covers"]]
-    <a class="list-card" href="$list_url">
+    <a class="list-card" href="$list.get_url()">
         <div class="list-card__name-tag">
-            <p class="list-card__title">$title</p>
+            <p class="list-card__title">$cached_info["title"]</p>
             <p class="list-card__num-books">
                 $ungettext("%(count)d book", "%(count)d books", count, count=count)
             </p>
         </div>
         <div class="list-card__covers">
-            $for img_url in cover_urls:
-                <img src="$img_url" loading="lazy">
+            $for img_url in cached_info["covers"]:
+                <img src="$(img_url or '/images/icons/avatar_book-sm.png')" loading="lazy">
         </div>
     </a>
 
@@ -31,8 +25,9 @@ $def list_card(list):
         </h2>
     </div>
     <div class="list-showcase">
-        $if total_lists:
-            $for list in total_lists:
+        $if lists:
+            $ displayed_lists = lists[0:min(len(lists), 5)]
+            $for list in displayed_lists:
                 $:list_card(list)
         $else:
             <p>$_('You have no lists.')</p>

--- a/openlibrary/templates/lists/showcase.html
+++ b/openlibrary/templates/lists/showcase.html
@@ -5,41 +5,37 @@ $ default_image_url = "/images/icons/avatar_book-sm.png"
 $ total_lists = lists[0:min(len(lists), 5)]
 $ all_lists_url = "/people/%s/lists" % username
 
-$def showcase(list):
+$def list_card(list):
     $ cached_info = list.get_patron_showcase()
     $ title = cached_info["title"] if len(cached_info["title"]) < 16 else cached_info["title"][0:16] + "..."
     $ count = cached_info["count"]
     $ list_url = list.get_url()
     $ cover_urls = [cover_url if cover_url else default_image_url for cover_url in cached_info["covers"]]
-    <div class="my-list">
-        <a href = $list_url>
-            <div class = "my-lists-item">
-                <div class="my-list-name-tag">
-                    <p class = "my-list-title">$title</p>
-                    $if count == 1:
-                        <p class = "my-list-num-books"> $count book</p>
-                    $else:
-                        <p class = "my-list-num-books"> $count books</p>
-                </div>
-                <div class = "my-list-covers">
-                    $ cover = 0
-                    $for img_url in cover_urls:
-                        <img src = "$img_url" class ="book-cover my-list-cover cover-$cover" loading="lazy">
-                        $ cover +=1
-                </div>
-            </div>
-        </a>
-    </div>
-<div class = "carousel-section">
+    <a class="list-card" href="$list_url">
+        <div class="list-card__name-tag">
+            <p class="list-card__title">$title</p>
+            $if count == 1:
+                <p class="list-card__num-books"> $count book</p>
+            $else:
+                <p class="list-card__num-books"> $count books</p>
+        </div>
+        <div class="list-card__covers">
+            $for img_url in cover_urls:
+                <img src="$img_url" loading="lazy">
+        </div>
+    </a>
+
+
+<div class="carousel-section">
     <div class="carousel-section-header">
-        <h2 class = "home-h2">
-                <a href = $all_lists_url> My Lists ($len(lists))</a>
+        <h2 class="home-h2">
+            <a href="$all_lists_url"> My Lists ($len(lists))</a>
         </h2>
     </div>
-    <div class="my-lists showcase">
-        $if lists and len(total_lists)>0:
+    <div class="list-showcase">
+        $if total_lists:
             $for list in total_lists:
-                $:showcase(list)
+                $:list_card(list)
         $else:
             <p>You have no lists.</p>
     </div>

--- a/static/css/components/list-showcase.less
+++ b/static/css/components/list-showcase.less
@@ -2,8 +2,7 @@
 @import (less) "components/read-panel.less";
 @import (less) "components/book.less";
 
-@my-lists-item-border: black;
-.my-lists.showcase {
+.list-showcase {
   display: flex;
   overflow-x: clip;
   mask-image: linear-gradient(
@@ -14,7 +13,9 @@
   );
 }
 
-.my-lists-item {
+.list-card {
+  @name-tag-layer: 4;
+
   background-color: @beige;
   border: 1px solid @black;
   border-radius: 4px;
@@ -25,11 +26,8 @@
   padding-top: 20px;
   padding-bottom: 40px;
   margin: 20px 15px;
-}
 
-.my-list {
-  @name-tag-layer: 4;
-  &-name-tag {
+  &__name-tag {
     border: 1px solid @black;
     border-radius: 2px 2px 4px 4px;
     box-shadow: 2px 2px 5px @gray-a19b9e;
@@ -47,47 +45,44 @@
     }
   }
 
-  &-title {
+  &__title {
     margin: auto;
     color: @black;
     font-weight: bold;
   }
 
-  &-num-books {
+  &__num-books {
     margin: auto;
     padding: 0;
     color: @grey-555;
     font-size: .7em;
   }
 
-  &-cover {
+  &__cover {
     width: 33%;
     margin-left: -5px;
     box-shadow: 2.5px 2.5px 4px @gray-a19b9e;
   }
 
-  &-covers {
+  &__covers {
     display: flex;
     justify-content: center;
     width: 80%;
     margin: auto;
+
+    @top-cover: 3;
+    @mid-cover: 2;
+    @bottom-cover: 1;
+
+    img:nth-child(1) {
+      z-index: @top-cover;
+      margin-left: -5px;
+    }
+    img:nth-child(2) {
+      z-index: @mid-cover;
+    }
+    img:nth-child(3) {
+      z-index: @bottom-cover;
+    }
   }
-}
-
-@top-cover: 3;
-@mid-cover: 2;
-@bottom-cover: 1;
-.cover-0 {
-  z-index: @top-cover;
-  margin-left: -5px;
-}
-
-.cover-1 {
-  z-index: @mid-cover;
-
-}
-
-.cover-2 {
-  z-index: @bottom-cover;
-
 }

--- a/static/css/components/list-showcase.less
+++ b/static/css/components/list-showcase.less
@@ -40,28 +40,21 @@
     padding-left: 4px;
     z-index: @name-tag-layer;
     overflow: hidden;
-    &>p{
-      text-wrap: nowrap;
-    }
   }
 
   &__title {
     margin: auto;
     color: @black;
     font-weight: bold;
+
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   &__num-books {
-    margin: auto;
-    padding: 0;
     color: @grey-555;
     font-size: .7em;
-  }
-
-  &__cover {
-    width: 33%;
-    margin-left: -5px;
-    box-shadow: 2.5px 2.5px 4px @gray-a19b9e;
   }
 
   &__covers {

--- a/static/css/components/list-showcase.less
+++ b/static/css/components/list-showcase.less
@@ -1,51 +1,55 @@
 @import (less) "../less/colors.less";
+@import (less) "../less/font-families.less";
 @import (less) "components/read-panel.less";
 @import (less) "components/book.less";
 
 .list-showcase {
   display: flex;
-  overflow-x: clip;
+  overflow-x: auto;
+  padding: 8px 0;
   mask-image: linear-gradient(
     to right,
     rgba(0, 0, 0, 1) 0%,
     rgba(0, 0, 0, 1) calc(100% - 100px),
     rgba(0, 0, 0, 0) 100%
   );
+
+  .list-card {
+    margin-right: 24px;
+  }
 }
 
+// stylelint-disable-next-line no-descending-specificity
 .list-card {
-  @name-tag-layer: 4;
+  a& {
+    text-decoration: none;
+  }
+
+  display: flex;
+  flex-direction: column;
 
   background-color: @beige;
-  border: 1px solid @black;
+
+  @card-width: 215px;
+  width: @card-width;
+  height: 150px;
+
+  border: 1px solid fade(@black, 25%);
   border-radius: 4px;
-  box-shadow: 2px 2px 5px @gray-a19b9e;
-  width: 160px;
-  height: 120px;
-  position: relative;
-  padding-top: 20px;
-  padding-bottom: 40px;
-  margin: 20px 15px;
+  box-shadow: 2px 2px 4px fade(@black, 15%);
 
   &__name-tag {
-    border: 1px solid @black;
-    border-radius: 2px 2px 4px 4px;
-    box-shadow: 2px 2px 5px @gray-a19b9e;
-    background: @white;
-    position: absolute;
-    bottom: 0;
-    width: 100%;
-    height: 35%;
-    padding-top: 3px;
-    padding-left: 4px;
-    z-index: @name-tag-layer;
-    overflow: hidden;
+    background: @grey-f4f4f4;
+    padding: 7px 10px;
+
+    border-radius: 0 0 4px 4px;
+    box-shadow: 0 0 4px fade(@black, 25%);
   }
 
   &__title {
-    margin: auto;
-    color: @black;
     font-weight: bold;
+    font-size: @font-size-label-large;
+    color: @black;
 
     white-space: nowrap;
     overflow: hidden;
@@ -54,28 +58,44 @@
 
   &__num-books {
     color: @grey-555;
-    font-size: .7em;
+    font-size: @font-size-label-medium;
   }
 
   &__covers {
+    @cover-width: 64px;
+    @padding: 20px;
+
+    flex: 1;
+    min-height: 1px; // fallback
+    overflow: clip;
+
     display: flex;
-    justify-content: center;
-    width: 80%;
-    margin: auto;
+    align-items: center;
+    padding: 0 @padding;
+
+    img {
+      width: @cover-width;
+      border-radius: 4px;
+      box-shadow: 4px 4px 0 fade(@black, 25%);
+    }
 
     @top-cover: 3;
     @mid-cover: 2;
     @bottom-cover: 1;
 
+    @overlap: ((3 * @cover-width - (@card-width - 2 * @padding)) / 2);
+
     img:nth-child(1) {
       z-index: @top-cover;
-      margin-left: -5px;
+      transform: translate(0, @padding);
     }
     img:nth-child(2) {
       z-index: @mid-cover;
+      transform: translate(-@overlap, @padding);
     }
     img:nth-child(3) {
       z-index: @bottom-cover;
+      transform: translate(-2 * @overlap, @padding);
     }
   }
 }

--- a/static/css/components/list-showcase.less
+++ b/static/css/components/list-showcase.less
@@ -98,4 +98,13 @@
       transform: translate(-2 * @overlap, @padding);
     }
   }
+
+  // stylelint-disable-next-line no-descending-specificity
+  img {
+    transition: scale .2s;
+  }
+
+  &:hover img {
+    scale: 1.05;
+  }
 }

--- a/static/css/components/list-showcase.less
+++ b/static/css/components/list-showcase.less
@@ -6,16 +6,18 @@
 .list-showcase {
   display: flex;
   overflow-x: auto;
+  scrollbar-width: thin;
   padding: 8px 0;
-  mask-image: linear-gradient(
-    to right,
-    rgba(0, 0, 0, 1) 0%,
-    rgba(0, 0, 0, 1) calc(100% - 100px),
-    rgba(0, 0, 0, 0) 100%
-  );
 
   .list-card {
     margin-right: 24px;
+    flex-shrink: 0;
+  }
+
+  &__see-all {
+    margin-right: 24px;
+    align-self: center;
+    width: auto;
   }
 }
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7704 (Addendum)

Finished some of the design details in figma + DRYed up some of the code.

### Technical
Code:
- Used BEM notation correctly; the code was already structured BEM-like, but was using `-` instead of `__` to denote child relationship
- The HTML had a few unnecessary nesting/divs; dropped those
- I18n all the strings
- Fix some bugs in the code (eg default parameters cannot be lists)
- Used larger covers since they're displayed larger than the -S
- Used less `position: absolute` in the list-card
- Used CSS to truncate title, not manual limiting to 16 characters

UI:
- I removed the gradient at the end ; that's a pretty common UI affordance for scrolling; we should bring back now that scrolling is enabled, but it takes a bit of time since you have to make it appear/disappear as necessary.
- Added a "see all" button at end now that it's scrollable
- The covers ended up a touch easier staggered; I like the effect so kept it in


### Testing
Tested ~latest Chrome, FF, and Safari (iPad).

### Screenshot
![image](https://github.com/internetarchive/openlibrary/assets/6251786/7f8d3070-5341-4251-b4c8-1110d2907b44)


### Stakeholders
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
