### PR TITLE
Add Internet Archive cover option

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -3487,10 +3487,6 @@ msgid "Edit %(year)d Reading Goal"
 msgstr ""
 
 #: covers/add.html
-msgid "Uploading..."
-msgstr ""
-
-#: covers/add.html
 msgid "There are two ways to put an author's image on Open Library."
 msgstr ""
 
@@ -3526,6 +3522,10 @@ msgid "<strong>Pick one</strong> from the existing covers"
 msgstr ""
 
 #: covers/add.html
+msgid "Use this image"
+msgstr ""
+
+#: covers/add.html
 msgid "Choose a JPG, GIF or PNG on your computer"
 msgstr ""
 
@@ -3542,7 +3542,7 @@ msgid "Or, use the the cover from Internet Archive"
 msgstr ""
 
 #: covers/add.html
-msgid "Use this image"
+msgid "Uploading..."
 msgstr ""
 
 #: covers/author_photo.html

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -3500,7 +3500,7 @@ msgid "Image Guidelines"
 msgstr ""
 
 #: covers/add.html
-msgid "There are two ways to put a cover image on Open Library"
+msgid "There are a few ways to put a cover image on Open Library"
 msgstr ""
 
 #: covers/add.html
@@ -3520,11 +3520,19 @@ msgid "<strong>Pick one</strong> from the existing covers,"
 msgstr ""
 
 #: covers/add.html
-msgid "Choose a JPG, GIF or PNG on your computer,"
+msgid "Choose a JPG, GIF or PNG on your computer"
 msgstr ""
 
 #: covers/add.html
-msgid "Or, paste in the image URL if it's on the web."
+msgid "Or, paste in the image URL if it's on the web"
+msgstr ""
+
+#: covers/add.html
+msgid "Or, use the the cover from Internet Archive"
+msgstr ""
+
+#: covers/add.html
+msgid "Use this image"
 msgstr ""
 
 #: covers/add.html

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -594,9 +594,8 @@ msgstr ""
 
 #: CreateListModal.html EditButtons.html account/notifications.html
 #: account/password/reset.html account/privacy.html admin/imports-add.html
-#: admin/permissions.html books/add.html covers/add.html covers/manage.html
-#: databarEdit.html merge/authors.html my_books/dropdown_content.html
-#: support.html tag/add.html
+#: admin/permissions.html books/add.html covers/manage.html databarEdit.html
+#: merge/authors.html my_books/dropdown_content.html support.html tag/add.html
 msgid "Cancel"
 msgstr ""
 
@@ -3488,11 +3487,11 @@ msgid "Edit %(year)d Reading Goal"
 msgstr ""
 
 #: covers/add.html
-msgid "Please choose an image or provide a URL."
+msgid "Uploading..."
 msgstr ""
 
 #: covers/add.html
-msgid "There are two ways to put an author's image on Open Library"
+msgid "There are two ways to put an author's image on Open Library."
 msgstr ""
 
 #: covers/add.html
@@ -3500,7 +3499,7 @@ msgid "Image Guidelines"
 msgstr ""
 
 #: covers/add.html
-msgid "There are a few ways to put a cover image on Open Library"
+msgid "There are a few ways to put a cover image on Open Library."
 msgstr ""
 
 #: covers/add.html
@@ -3516,11 +3515,22 @@ msgid "Please provide an image URL."
 msgstr ""
 
 #: covers/add.html
-msgid "<strong>Pick one</strong> from the existing covers,"
+#, python-format
+msgid ""
+"Learn more by reading our <a href=\"/help/faq/editing#picture\" "
+"target=\"blank\">%(guidelines)s</a>."
+msgstr ""
+
+#: covers/add.html
+msgid "<strong>Pick one</strong> from the existing covers"
 msgstr ""
 
 #: covers/add.html
 msgid "Choose a JPG, GIF or PNG on your computer"
+msgstr ""
+
+#: covers/add.html
+msgid "Upload"
 msgstr ""
 
 #: covers/add.html
@@ -3533,10 +3543,6 @@ msgstr ""
 
 #: covers/add.html
 msgid "Use this image"
-msgstr ""
-
-#: covers/add.html
-msgid "Uploading..."
 msgstr ""
 
 #: covers/author_photo.html

--- a/openlibrary/plugins/openlibrary/js/covers.js
+++ b/openlibrary/plugins/openlibrary/js/covers.js
@@ -65,9 +65,10 @@ export function initCoversAddManage() {
         const i18nStrings = JSON.parse(document.querySelector('#errors').dataset.i18n);
         var file = val('#coverFile');
         var url = val('#imageUrl');
+        var coverIA = val('#coverIA');
         var coverid = val('#coverid');
 
-        if (!file && !url && !coverid) {
+        if (!file && !url && !coverIA && !coverid) {
             return error(i18nStrings['empty_cover_inputs'], event);
         }
 

--- a/openlibrary/plugins/openlibrary/js/covers.js
+++ b/openlibrary/plugins/openlibrary/js/covers.js
@@ -57,16 +57,6 @@ export function initCoversAddManage() {
         }
     })
 
-    // Clicking a cover should set the form value to the data-id of that cover
-    $('#popcovers .book').on('click', function () {
-        var coverid;
-        $(this).toggleClass('selected').siblings().removeClass('selected');
-        coverid = '';
-        if ($(this).hasClass('selected')) {
-            coverid = $(this).data('id');
-        }
-        $('#coverid').val(coverid);
-    });
 
     $('.column').sortable({
         connectWith: '.trash'
@@ -90,7 +80,7 @@ export function initCoversSaved() {
     const image = $('.imageSaved').data('imageId');
     var cover_url;
 
-    $('.formButtons button').on('click', closePopup);
+    $('.popClose').on('click', closePopup);
 
     // Update the image for the cover
     if (['/type/edition', '/type/work', '/edit'].includes(doc_type_key)) {

--- a/openlibrary/plugins/openlibrary/js/covers.js
+++ b/openlibrary/plugins/openlibrary/js/covers.js
@@ -45,7 +45,7 @@ function error(message, event) {
 
 function add_iframe(selector, src) {
     $(selector)
-        .append('<iframe frameborder="0" height="450" width="580" marginheight="0" marginwidth="0" scrolling="auto"></iframe>')
+        .append('<iframe frameborder="0" height="580" width="580" marginheight="0" marginwidth="0" scrolling="auto"></iframe>')
         .find('iframe')
         .attr('src', src);
 }

--- a/openlibrary/plugins/openlibrary/js/covers.js
+++ b/openlibrary/plugins/openlibrary/js/covers.js
@@ -38,15 +38,6 @@ export function initCoversChange() {
         });
 }
 
-function val(selector) {
-    const val = $(selector).val();
-    if (val) {
-        return val.trim();
-    } else {
-        return val;
-    }
-}
-
 function error(message, event) {
     $('#errors').show().html(message);
     event.preventDefault();
@@ -62,18 +53,15 @@ function add_iframe(selector, src) {
 // covers/manage.html and covers/add.html
 export function initCoversAddManage() {
     $('#addcover-form').on('submit', function (event) {
-        const i18nStrings = JSON.parse(document.querySelector('#errors').dataset.i18n);
-        var file = val('#coverFile');
-        var url = val('#imageUrl');
-        var coverIA = val('#coverIA');
-        var coverid = val('#coverid');
+        const i18nStrings = JSON.parse((event.target).dataset.i18n);
+        const data = Object.fromEntries(new FormData(event.target).entries());
 
-        if (!file && !url && !coverIA && !coverid) {
-            return error(i18nStrings['empty_cover_inputs'], event);
+        if (!data.file && !data.url) {
+            return error(i18nStrings.empty_cover_inputs, event);
         }
 
-        const btn = $('#imageUpload');
-        btn.prop('disabled', true).html(btn.data('loading-text'));
+        $('#coverIA').addClass('loading');
+        $('#imageUpload').prop('disabled', true).html(i18nStrings.loading_text);
     });
 
     // Clicking a cover should set the form value to the data-id of that cover

--- a/openlibrary/plugins/openlibrary/js/covers.js
+++ b/openlibrary/plugins/openlibrary/js/covers.js
@@ -47,6 +47,16 @@ function add_iframe(selector, src) {
 
 // covers/manage.html and covers/add.html
 export function initCoversAddManage() {
+    $('.ol-cover-form').on('submit', function () {
+        const loadingIndicator = document.querySelector('.loadingIndicator');
+        const formDivs = document.querySelectorAll('.ol-cover-form, .imageIntro');
+
+        if (loadingIndicator) {
+            loadingIndicator.classList.remove('hidden');
+            formDivs.forEach(div => div.classList.add('hidden'));
+        }
+    })
+
     // Clicking a cover should set the form value to the data-id of that cover
     $('#popcovers .book').on('click', function () {
         var coverid;

--- a/openlibrary/plugins/openlibrary/js/covers.js
+++ b/openlibrary/plugins/openlibrary/js/covers.js
@@ -38,11 +38,6 @@ export function initCoversChange() {
         });
 }
 
-function error(message, event) {
-    $('#errors').show().html(message);
-    event.preventDefault();
-}
-
 function add_iframe(selector, src) {
     $(selector)
         .append('<iframe frameborder="0" height="580" width="580" marginheight="0" marginwidth="0" scrolling="auto"></iframe>')
@@ -52,18 +47,6 @@ function add_iframe(selector, src) {
 
 // covers/manage.html and covers/add.html
 export function initCoversAddManage() {
-    $('#addcover-form').on('submit', function (event) {
-        const i18nStrings = JSON.parse((event.target).dataset.i18n);
-        const data = Object.fromEntries(new FormData(event.target).entries());
-
-        if (!data.file && !data.url) {
-            return error(i18nStrings.empty_cover_inputs, event);
-        }
-
-        $('#coverIA').addClass('loading');
-        $('#imageUpload').prop('disabled', true).html(i18nStrings.loading_text);
-    });
-
     // Clicking a cover should set the form value to the data-id of that cover
     $('#popcovers .book').on('click', function () {
         var coverid;

--- a/openlibrary/templates/covers/add.html
+++ b/openlibrary/templates/covers/add.html
@@ -84,3 +84,5 @@ $if doc.type.key == "/type/edition" and doc.ocaid:
             <button type="submit" id="coverIA" class="cta-btn cta-btn--vanilla" name="url" value="$img_url">$_("Use this image")</button>
         </div>
     </form>
+
+    $:macros.LoadingIndicator(_("Uploading..."))

--- a/openlibrary/templates/covers/add.html
+++ b/openlibrary/templates/covers/add.html
@@ -1,7 +1,6 @@
 $def with (doc, data={}, status=None)
 
 $ i18n_strings = {
-    $ "empty_cover_inputs": _("Please choose an image or provide a URL."),
     $ "loading_text": _("Uploading...")
     $ }
 
@@ -10,11 +9,11 @@ $putctx("show_ol_shell", False)
 $putctx('robots', 'noindex,nofollow')
 
 $if doc.type.key == "/type/author":
-    $ intro = _("There are two ways to put an author's image on Open Library")
+    $ intro = _("There are two ways to put an author's image on Open Library.")
     $ action = doc.url('/add-photo')
     $ guideline = _("Image Guidelines")
 $else:
-    $ intro = _("There are a few ways to put a cover image on Open Library")
+    $ intro = _("There are a few ways to put a cover image on Open Library.")
     $ action = doc.url('/add-cover')
     $ guideline = _("Cover Guidelines")
 
@@ -25,74 +24,63 @@ $if status:
     $elif status.code == 3: $_("Please provide a valid image.")
 </div>
 
-<div class="imageIntro">$intro</div>
-
-<form class="floatform" id="addcover-form" name="bookcover" method="post" data-i18n="$json_encode(i18n_strings)" enctype="multipart/form-data" action="$action">
-
-    <div class="floatform__body">
-        <div>
-            $if doc.type.key == "/type/work":
-                $if doc.get_edition_covers():
-                    <div class="formElement">
-                        <div class="label">
-                            <label>$:_("<strong>Pick one</strong> from the existing covers,")</label>
-                        </div>
-                        <div class="carousel-section">
-                            <div id="covers" class="carousel-container carousel-container-decorated carousel--minimal">
-                                <div id="popcovers" class="carousel carousel--progressively-enhanced"
-                                    data-config="$json_encode({'booksPerBreakpoint': [3, 3, 3, 3, 2, 1]})">
+<div class="imageIntro" data-i18n="$json_encode(i18n_strings)">$intro  $:_('Learn more by reading our <a href="/help/faq/editing#picture" target="blank">%(guidelines)s</a>.', guidelines=guideline)</div>
+$if doc.type.key == "/type/work":
+    $if doc.get_edition_covers():
+        <form class="floatform ol-cover-form ol-cover-form--id" method="post" enctype="multipart/form-data" action="$action">
+            <div class="floatform__body">
+                <div class="formElement">
+                    <div class="label">
+                        <label>$:_("<strong>Pick one</strong> from the existing covers")</label>
+                    </div>
+                    <div class="carousel-section">
+                        <div id="covers" class="carousel-container carousel-container-decorated carousel--minimal">
+                            <div id="popcovers" class="carousel carousel--progressively-enhanced" data-config="$json_encode({'booksPerBreakpoint': [3, 3, 3, 3, 2, 1]})">
                                 $for cover in doc.get_edition_covers():
                                     <div class="book carousel__item" data-id="$cover.id">
                                         <div class="book-cover">
-                                            <img src="$cover.url(size='M')"
-                                                width="100" class="bookcover"/>
+                                            <img src="$cover.url(size='M')" width="100" class="bookcover"/>
                                         </div>
                                     </div>
-                                </div>
                             </div>
                         </div>
-                        <input type="hidden" id="coverid" name="coverid" value=""/>
-                    </div>
-
-            <div class="formElement">
-                <div class="label">
-                    <label id="imageBrowse" for="coverFile">$_("Choose a JPG, GIF or PNG on your computer")</label>
-                </div>
-                <div class="input">
-                    <input type="file" name="file" id="coverFile" value="" accept=".jpg, .jpeg, .gif, .png"/>
-                </div>
-            </div>
-
-            <div class="formElement">
-                <div class="label">
-                    <label id="imageWeb" for="imageUrl">$_("Or, paste in the image URL if it's on the web")</label>
-                </div>
-                <div class="input">
-                    <input type="url" name="url" id="imageUrl" value="$data.get('url', '')" placeholder="https://..." />
-                </div>
-            </div>
-
-            $if doc.type.key == "/type/edition" and doc.ocaid:
-                $ img_url = "https://archive.org/services/img/%s/full/pct:600/0/default.jpg" % doc.ocaid
-                <div class="formElement floatform__IA-cover">
-                    <div class="label">
-                        <label>$_("Or, use the the cover from Internet Archive")</label>
-                    </div>
-                    <a href="$img_url" target="_blank">
-                        <img src="$img_url" style="height: 200px" />
-                    </a>
-                    <div class="input">
-                        <button type="submit" id="coverIA" name="url" value="$img_url">$_("Use this image")</button>
                     </div>
                 </div>
-
-            <div class="formElement" style="margin: $('15px 0px 0px 15px;' if doc.type.key == '/type/work' else '0px;')">
-                <button type="submit" name="upload" id="imageUpload" value="$_('Submit')" class="largest cta-btn cta-btn--primary" style="width:auto">
-                    $_("Submit")
-                </button>
+                <input type="hidden" id="coverid" name="coverid" value=""/>
+                <button type="submit" class="cta-btn cta-btn--vanilla">$_("Submit")</button>
             </div>
+        </form>
 
-        </div>
+<form class="floatform ol-cover-form ol-cover-form--upload" method="post" enctype="multipart/form-data" action="$action">
+    <div class="label">
+        <label id="imageBrowse" for="coverFile">$_("Choose a JPG, GIF or PNG on your computer")</label>
+    </div>
+    <div class="input">
+        <input type="file" name="file" id="coverFile" value="" accept=".jpg, .jpeg, .gif, .png" required/>
+        <button type="submit" class="cta-btn cta-btn--vanilla">$_("Upload")</button>
     </div>
 </form>
-<div class="imageIntro smallest"><a href="/help/faq/editing#picture" target="blank">$guideline</a></div>
+
+<form class="floatform ol-cover-form ol-cover-form--url" method="post" enctype="multipart/form-data" action="$action">
+    <div class="label">
+        <label id="imageWeb" for="imageUrl">$_("Or, paste in the image URL if it's on the web")</label>
+    </div>
+    <div class="input">
+        <input type="url" name="url" id="imageUrl" value="$data.get('url', '')" placeholder="https://..." required />
+        <button type="submit" class="cta-btn cta-btn--vanilla">$_("Submit")</button>
+    </div>
+</form>
+
+$if doc.type.key == "/type/edition" and doc.ocaid:
+    $ img_url = "https://archive.org/services/img/%s/full/pct:600/0/default.jpg" % doc.ocaid
+    <form class="floatform ol-cover-form ol-cover-form--ia" method="post" enctype="multipart/form-data" action="$action">
+        <div class="label">
+            <label>$_("Or, use the the cover from Internet Archive")</label>
+        </div>
+        <div class="input">
+            <a href="$img_url" target="_blank">
+                <img class="ol-cover-form--ia_image" src="$img_url" style="height: 200px" />
+            </a>
+            <button type="submit" id="coverIA" class="cta-btn cta-btn--vanilla" name="url" value="$img_url">$_("Use this image")</button>
+        </div>
+    </form>

--- a/openlibrary/templates/covers/add.html
+++ b/openlibrary/templates/covers/add.html
@@ -1,9 +1,5 @@
 $def with (doc, data={}, status=None)
 
-$ i18n_strings = {
-    $ "loading_text": _("Uploading...")
-    $ }
-
 $putctx('cssfile', 'form')
 $putctx("show_ol_shell", False)
 $putctx('robots', 'noindex,nofollow')
@@ -24,34 +20,31 @@ $if status:
     $elif status.code == 3: $_("Please provide a valid image.")
 </div>
 
-<div class="imageIntro" data-i18n="$json_encode(i18n_strings)">$intro  $:_('Learn more by reading our <a href="/help/faq/editing#picture" target="blank">%(guidelines)s</a>.', guidelines=guideline)</div>
+<div class="imageIntro">$intro  $:_('Learn more by reading our <a href="/help/faq/editing#picture" target="blank">%(guidelines)s</a>.', guidelines=guideline)</div>
 $if doc.type.key == "/type/work":
     $if doc.get_edition_covers():
-        <form class="floatform ol-cover-form ol-cover-form--id" method="post" enctype="multipart/form-data" action="$action">
-            <div class="floatform__body">
-                <div class="formElement">
-                    <div class="label">
-                        <label>$:_("<strong>Pick one</strong> from the existing covers")</label>
-                    </div>
-                    <div class="carousel-section">
-                        <div id="covers" class="carousel-container carousel-container-decorated carousel--minimal">
-                            <div id="popcovers" class="carousel carousel--progressively-enhanced" data-config="$json_encode({'booksPerBreakpoint': [3, 3, 3, 3, 2, 1]})">
-                                $for cover in doc.get_edition_covers():
-                                    <div class="book carousel__item" data-id="$cover.id">
-                                        <div class="book-cover">
-                                            <img src="$cover.url(size='M')" width="100" class="bookcover"/>
-                                        </div>
+        <form class="ol-cover-form ol-cover-form--id" method="post" enctype="multipart/form-data" action="$action">
+            <div class="formElement">
+                <div class="label">
+                    <label>$:_("<strong>Pick one</strong> from the existing covers")</label>
+                </div>
+                <div class="carousel-section">
+                    <div id="covers" class="carousel-container carousel-container-decorated carousel--minimal">
+                        <div id="popcovers" class="carousel carousel--progressively-enhanced" data-config="$json_encode({'booksPerBreakpoint': [3, 3, 3, 3, 2, 1]})">
+                            $for cover in doc.get_edition_covers():
+                                <div class="book carousel__item">
+                                    <div class="book-cover">
+                                        <img src="$cover.url(size='M')" width="100" class="bookcover"/>
                                     </div>
-                            </div>
+                                    <button type="submit" name="coverid" value="$cover.id" class="cta-btn cta-btn--vanilla">$_("Use this image")</button>
+                                </div>
                         </div>
                     </div>
                 </div>
-                <input type="hidden" id="coverid" name="coverid" value=""/>
-                <button type="submit" class="cta-btn cta-btn--vanilla">$_("Submit")</button>
             </div>
         </form>
 
-<form class="floatform ol-cover-form ol-cover-form--upload" method="post" enctype="multipart/form-data" action="$action">
+<form class="ol-cover-form ol-cover-form--upload" method="post" enctype="multipart/form-data" action="$action">
     <div class="label">
         <label id="imageBrowse" for="coverFile">$_("Choose a JPG, GIF or PNG on your computer")</label>
     </div>
@@ -61,7 +54,7 @@ $if doc.type.key == "/type/work":
     </div>
 </form>
 
-<form class="floatform ol-cover-form ol-cover-form--url" method="post" enctype="multipart/form-data" action="$action">
+<form class="ol-cover-form ol-cover-form--url" method="post" enctype="multipart/form-data" action="$action">
     <div class="label">
         <label id="imageWeb" for="imageUrl">$_("Or, paste in the image URL if it's on the web")</label>
     </div>
@@ -73,7 +66,7 @@ $if doc.type.key == "/type/work":
 
 $if doc.type.key == "/type/edition" and doc.ocaid:
     $ img_url = "https://archive.org/services/img/%s/full/pct:600/0/default.jpg" % doc.ocaid
-    <form class="floatform ol-cover-form ol-cover-form--ia" method="post" enctype="multipart/form-data" action="$action">
+    <form class="ol-cover-form ol-cover-form--ia" method="post" enctype="multipart/form-data" action="$action">
         <div class="label">
             <label>$_("Or, use the the cover from Internet Archive")</label>
         </div>
@@ -85,4 +78,4 @@ $if doc.type.key == "/type/edition" and doc.ocaid:
         </div>
     </form>
 
-    $:macros.LoadingIndicator(_("Uploading..."))
+$:macros.LoadingIndicator(_("Uploading..."))

--- a/openlibrary/templates/covers/add.html
+++ b/openlibrary/templates/covers/add.html
@@ -13,7 +13,7 @@ $if doc.type.key == "/type/author":
     $ action = doc.url('/add-photo')
     $ guideline = _("Image Guidelines")
 $else:
-    $ intro = _("There are two ways to put a cover image on Open Library")
+    $ intro = _("There are a few ways to put a cover image on Open Library")
     $ action = doc.url('/add-cover')
     $ guideline = _("Cover Guidelines")
 
@@ -55,7 +55,7 @@ $if status:
 
             <div class="formElement">
                 <div class="label">
-                    <label id="imageBrowse" for="coverFile">$_("Choose a JPG, GIF or PNG on your computer,")</label>
+                    <label id="imageBrowse" for="coverFile">$_("Choose a JPG, GIF or PNG on your computer")</label>
                 </div>
                 <div class="input">
                     <input type="file" name="file" id="coverFile" value="" accept=".jpg, .jpeg, .gif, .png"/>
@@ -64,12 +64,26 @@ $if status:
 
             <div class="formElement">
                 <div class="label">
-                    <label id="imageWeb" for="imageUrl">$_("Or, paste in the image URL if it's on the web.")</label>
+                    <label id="imageWeb" for="imageUrl">$_("Or, paste in the image URL if it's on the web")</label>
                 </div>
                 <div class="input">
                     <input type="url" name="url" id="imageUrl" value="$data.get('url', '')" placeholder="https://..." />
                 </div>
             </div>
+
+            $if doc.type.key == "/type/edition" and doc.ocaid:
+                $ img_url = "https://archive.org/services/img/%s/full/pct:600/0/default.jpg" % doc.ocaid
+                <div class="formElement" id="dc-ia-cover">
+                    <div class="label">
+                        <label>$_("Or, use the the cover from Internet Archive")</label>
+                    </div>
+                    <a href="$img_url">
+                        <img src="$img_url" style="height: 200px" />
+                    </a>
+                    <div class="input" style="padding-top: 0">
+                    <button type="submit" id="coverIA" name="url" value="$img_url">$_("Use this image")</button>
+                    </div>
+                </div>
 
             <div class="formElement" style="margin: $('15px 0px 0px 15px;' if doc.type.key == '/type/work' else '0px;')">
                 <button type="submit" name="upload" id="imageUpload" value="$_('Submit')" class="largest" data-loading-text='$_("Uploading...")'>

--- a/openlibrary/templates/covers/add.html
+++ b/openlibrary/templates/covers/add.html
@@ -30,13 +30,13 @@ $if doc.type.key == "/type/work":
                 </div>
                 <div class="carousel-section">
                     <div id="covers" class="carousel-container carousel-container-decorated carousel--minimal">
-                        <div id="popcovers" class="carousel carousel--progressively-enhanced" data-config="$json_encode({'booksPerBreakpoint': [3, 3, 3, 3, 2, 1]})">
+                        <div class="carousel carousel--progressively-enhanced" data-config="$json_encode({'booksPerBreakpoint': [3, 3, 3, 3, 2, 1]})">
                             $for cover in doc.get_edition_covers():
                                 <div class="book carousel__item">
                                     <div class="book-cover">
                                         <img src="$cover.url(size='M')" width="100" class="bookcover"/>
+                                        <button type="submit" name="coverid" value="$cover.id" class="cta-btn cta-btn--vanilla">$_("Use this image")</button>
                                     </div>
-                                    <button type="submit" name="coverid" value="$cover.id" class="cta-btn cta-btn--vanilla">$_("Use this image")</button>
                                 </div>
                         </div>
                     </div>
@@ -46,7 +46,7 @@ $if doc.type.key == "/type/work":
 
 <form class="ol-cover-form ol-cover-form--upload" method="post" enctype="multipart/form-data" action="$action">
     <div class="label">
-        <label id="imageBrowse" for="coverFile">$_("Choose a JPG, GIF or PNG on your computer")</label>
+        <label for="coverFile">$_("Choose a JPG, GIF or PNG on your computer")</label>
     </div>
     <div class="input">
         <input type="file" name="file" id="coverFile" value="" accept=".jpg, .jpeg, .gif, .png" required/>

--- a/openlibrary/templates/covers/add.html
+++ b/openlibrary/templates/covers/add.html
@@ -74,23 +74,22 @@ $if status:
 
             $if doc.type.key == "/type/edition" and doc.ocaid:
                 $ img_url = "https://archive.org/services/img/%s/full/pct:600/0/default.jpg" % doc.ocaid
-                <div class="formElement">
+                <div class="formElement floatform__IA-cover">
                     <div class="label">
                         <label>$_("Or, use the the cover from Internet Archive")</label>
                     </div>
-                    <a href="$img_url">
+                    <a href="$img_url" target="_blank">
                         <img src="$img_url" style="height: 200px" />
                     </a>
-                    <div class="input" style="padding-top: 0">
-                        <button type="submit" id="coverIA" class="cta-btn" name="url" value="$img_url">$_("Use this image")</button>
+                    <div class="input">
+                        <button type="submit" id="coverIA" name="url" value="$img_url">$_("Use this image")</button>
                     </div>
                 </div>
 
             <div class="formElement" style="margin: $('15px 0px 0px 15px;' if doc.type.key == '/type/work' else '0px;')">
-                <button type="submit" name="upload" id="imageUpload" value="$_('Submit')" class="largest cta-btn cta-btn--primary" data-loading-text='$_("Uploading...")'>
+                <button type="submit" name="upload" id="imageUpload" value="$_('Submit')" class="largest cta-btn cta-btn--primary" style="width:auto">
                     $_("Submit")
                 </button>
-                <a class="dialog--close-parent red" href="javascript:;">$_("Cancel")</a>
             </div>
 
         </div>

--- a/openlibrary/templates/covers/add.html
+++ b/openlibrary/templates/covers/add.html
@@ -1,7 +1,8 @@
 $def with (doc, data={}, status=None)
 
 $ i18n_strings = {
-    $ "empty_cover_inputs": _("Please choose an image or provide a URL.")
+    $ "empty_cover_inputs": _("Please choose an image or provide a URL."),
+    $ "loading_text": _("Uploading...")
     $ }
 
 $putctx('cssfile', 'form')
@@ -17,7 +18,7 @@ $else:
     $ action = doc.url('/add-cover')
     $ guideline = _("Cover Guidelines")
 
-<div class="popAlert" id="errors" style="display: $('block' if status else 'none')" data-i18n="$json_encode(i18n_strings)">
+<div class="popAlert" id="errors" style="display: $('block' if status else 'none')">
 $if status:
     $if status.code == 1: $_("Please provide a valid image.")
     $elif status.code == 2: $_("Please provide an image URL.")
@@ -26,7 +27,7 @@ $if status:
 
 <div class="imageIntro">$intro</div>
 
-<form class="floatform" id="addcover-form" name="bookcover" method="post" enctype="multipart/form-data" action="$action">
+<form class="floatform" id="addcover-form" name="bookcover" method="post" data-i18n="$json_encode(i18n_strings)" enctype="multipart/form-data" action="$action">
 
     <div class="floatform__body">
         <div>
@@ -73,7 +74,7 @@ $if status:
 
             $if doc.type.key == "/type/edition" and doc.ocaid:
                 $ img_url = "https://archive.org/services/img/%s/full/pct:600/0/default.jpg" % doc.ocaid
-                <div class="formElement" id="dc-ia-cover">
+                <div class="formElement">
                     <div class="label">
                         <label>$_("Or, use the the cover from Internet Archive")</label>
                     </div>
@@ -81,12 +82,12 @@ $if status:
                         <img src="$img_url" style="height: 200px" />
                     </a>
                     <div class="input" style="padding-top: 0">
-                    <button type="submit" id="coverIA" name="url" value="$img_url">$_("Use this image")</button>
+                        <button type="submit" id="coverIA" class="cta-btn" name="url" value="$img_url">$_("Use this image")</button>
                     </div>
                 </div>
 
             <div class="formElement" style="margin: $('15px 0px 0px 15px;' if doc.type.key == '/type/work' else '0px;')">
-                <button type="submit" name="upload" id="imageUpload" value="$_('Submit')" class="largest" data-loading-text='$_("Uploading...")'>
+                <button type="submit" name="upload" id="imageUpload" value="$_('Submit')" class="largest cta-btn cta-btn--primary" data-loading-text='$_("Uploading...")'>
                     $_("Submit")
                 </button>
                 <a class="dialog--close-parent red" href="javascript:;">$_("Cancel")</a>

--- a/openlibrary/templates/covers/saved.html
+++ b/openlibrary/templates/covers/saved.html
@@ -21,7 +21,7 @@ $putctx("show_ol_shell", False)
                     $else:
                         Uploaded anonymously on $datestr(d.created)<br/>
                     $if d.source_url:
-                        <a href="$d.source_url">$d.source_url</a><br/>
+                        <a href="$d.source_url" target="_blank">$d.source_url</a><br/>
                 <br/>
             <a href="$changequery()" class="imageSaved__button"><button class="cta-btn cta-btn--vanilla">$_("Add another image")</button></a>
             <button type="button" name="finished" id="popClose" value="Finished" class="largest cta-btn cta-btn--primary">$_("Finished")</button>

--- a/openlibrary/templates/covers/saved.html
+++ b/openlibrary/templates/covers/saved.html
@@ -23,11 +23,8 @@ $putctx("show_ol_shell", False)
                     $if d.source_url:
                         <a href="$d.source_url">$d.source_url</a><br/>
                 <br/>
-            <a href="$changequery()">$_("Add another image")</a>?
+            <a href="$changequery()" class="imageSaved__button"><button class="cta-btn cta-btn--vanilla">$_("Add another image")</button></a>
+            <button type="button" name="finished" id="popClose" value="Finished" class="largest cta-btn cta-btn--primary">$_("Finished")</button>
         </div>
     </div>
-</div>
-
-<div class="formButtons">
-    <button type="button" name="finished" id="popClose" value="Finished" class="largest">$_("Finished")</button>
 </div>

--- a/openlibrary/templates/covers/saved.html
+++ b/openlibrary/templates/covers/saved.html
@@ -24,7 +24,7 @@ $putctx("show_ol_shell", False)
                         <a href="$d.source_url" target="_blank">$d.source_url</a><br/>
                 <br/>
             <a href="$changequery()" class="imageSaved__button"><button class="cta-btn cta-btn--vanilla">$_("Add another image")</button></a>
-            <button type="button" name="finished" id="popClose" value="Finished" class="largest cta-btn cta-btn--primary popClose">$_("Finished")</button>
+            <button type="button" name="finished" value="Finished" class="largest cta-btn cta-btn--primary popClose">$_("Finished")</button>
         </div>
     </div>
 </div>

--- a/openlibrary/templates/covers/saved.html
+++ b/openlibrary/templates/covers/saved.html
@@ -24,7 +24,7 @@ $putctx("show_ol_shell", False)
                         <a href="$d.source_url" target="_blank">$d.source_url</a><br/>
                 <br/>
             <a href="$changequery()" class="imageSaved__button"><button class="cta-btn cta-btn--vanilla">$_("Add another image")</button></a>
-            <button type="button" name="finished" id="popClose" value="Finished" class="largest cta-btn cta-btn--primary">$_("Finished")</button>
+            <button type="button" name="finished" id="popClose" value="Finished" class="largest cta-btn cta-btn--primary popClose">$_("Finished")</button>
         </div>
     </div>
 </div>

--- a/static/css/components/cbox.less
+++ b/static/css/components/cbox.less
@@ -212,6 +212,10 @@ div.floater {
     font-size: 1.125em;
     width: auto !important;
     cursor: pointer;
+
+    &.loading {
+      pointer-events: none;
+    }
   }
   a {
     cursor: pointer;

--- a/static/css/components/cbox.less
+++ b/static/css/components/cbox.less
@@ -235,6 +235,33 @@ div.floater {
   button[type=submit] {
     margin-top: 0;
   }
+
+  .carousel-container {
+    padding: 10px 0;
+    margin: 0;
+    border-radius: 10px;
+  }
+
+  .carousel {
+    padding: 0;
+  }
+
+  .carousel__item {
+    margin: 0;
+  }
+
+  .book-cover {
+    height: auto;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .carousel button {
+    color: @grey;
+    border: 2px solid @light-grey;
+    border-radius: 6px;
+    position: relative;
+  }
 }
 
 .ol-cover-form--ia {

--- a/static/css/components/cbox.less
+++ b/static/css/components/cbox.less
@@ -24,6 +24,7 @@
   img {
     height: auto;
   }
+
   img,
   iframe {
     width: 100%;
@@ -131,7 +132,6 @@ div.coverFloat {
   }
   &Head {
     display: flex;
-    font-size: 1em;
     h2 {
       font-weight: normal;
       color: @dark-grey;
@@ -147,7 +147,7 @@ div.coverFloat {
 div.floater {
   position: relative;
   font-family: @lucida_sans_serif-1;
-  min-height: 550px;
+  min-height: 675px;
   background: @white;
   text-align: left;
   &Head {
@@ -180,6 +180,8 @@ div.floater {
   font-family: @lucida_sans_serif-2;
 
   .label {
+    padding-bottom: 5px;
+
     label {
       font-size: 1.0em;
       font-family: @lucida_sans_serif-5;
@@ -189,15 +191,18 @@ div.floater {
       font-weight: normal;
     }
   }
+
   .dialog--close-parent {
     cursor: pointer;
   }
+
   div#covers.input {
     max-height: 132px;
     overflow: hidden;
     margin-left: -80px;
     text-align: center;
   }
+
   input[type=text],
   input[type=url],
   input[type=file] {
@@ -205,6 +210,15 @@ div.floater {
     font-family: @lucida_sans_serif-1;
     padding: 3px;
   }
+
+  .floatform__IA-cover .input {
+    margin-top: 5px;
+  }
+
+  .formElement {
+    padding-top: 5px;
+  }
+
   input::file-selector-button{
     cursor: pointer;
   }
@@ -212,8 +226,10 @@ div.floater {
     font-size: 1.125em;
     width: auto !important;
     cursor: pointer;
+    display: inline-block;
 
     &.loading {
+      opacity: .5;
       pointer-events: none;
     }
   }

--- a/static/css/components/cbox.less
+++ b/static/css/components/cbox.less
@@ -184,11 +184,6 @@ div.floater {
     width: auto;
     cursor: pointer;
     display: inline-block;
-
-    &.loading {
-      opacity: .5;
-      pointer-events: none;
-    }
   }
 
   .label {

--- a/static/css/components/cbox.less
+++ b/static/css/components/cbox.less
@@ -179,6 +179,18 @@ div.floater {
 .floatform {
   font-family: @lucida_sans_serif-2;
 
+  button[type=submit] {
+    font-size: 1em;
+    width: auto;
+    cursor: pointer;
+    display: inline-block;
+
+    &.loading {
+      opacity: .5;
+      pointer-events: none;
+    }
+  }
+
   .label {
     padding-bottom: 5px;
 
@@ -192,6 +204,66 @@ div.floater {
     }
   }
 
+  input[type=text],
+  input[type=url],
+  input[type=file] {
+    font-size: 1.125em;
+    font-family: @lucida_sans_serif-1;
+    padding: 3px;
+  }
+
+  input::file-selector-button{
+    cursor: pointer;
+  }
+
+  a {
+    cursor: pointer;
+  }
+
+  &.ol-cover-form {
+    background-color: @lightest-grey;
+    border-radius: 10px;
+    padding: 10px;
+    margin-bottom: 10px;
+
+    .input {
+      display: flex;
+      gap: 10px;
+      align-items: center;
+    }
+
+    .input > :first-child {
+      flex: 1;
+    }
+
+    button[type=submit] {
+      margin-top: 0;
+    }
+  }
+
+  &.ol-cover-form--ia {
+    a {
+      text-decoration: none;
+    }
+
+    .ol-cover-form--ia_image {
+      display: block;
+    }
+
+    .input {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    button[type=submit] {
+      width: 135px;
+    }
+  }
+
+  #coverFile {
+    min-width: 1px;
+  }
+
   .dialog--close-parent {
     cursor: pointer;
   }
@@ -201,40 +273,6 @@ div.floater {
     overflow: hidden;
     margin-left: -80px;
     text-align: center;
-  }
-
-  input[type=text],
-  input[type=url],
-  input[type=file] {
-    font-size: 1.125em;
-    font-family: @lucida_sans_serif-1;
-    padding: 3px;
-  }
-
-  .floatform__IA-cover .input {
-    margin-top: 5px;
-  }
-
-  .formElement {
-    padding-top: 5px;
-  }
-
-  input::file-selector-button{
-    cursor: pointer;
-  }
-  button[type=submit] {
-    font-size: 1.125em;
-    width: auto !important;
-    cursor: pointer;
-    display: inline-block;
-
-    &.loading {
-      opacity: .5;
-      pointer-events: none;
-    }
-  }
-  a {
-    cursor: pointer;
   }
 }
 

--- a/static/css/components/cbox.less
+++ b/static/css/components/cbox.less
@@ -176,7 +176,7 @@ div.floater {
   }
 }
 
-.floatform {
+.floatform, .ol-cover-form {
   font-family: @lucida_sans_serif-2;
 
   button[type=submit] {
@@ -214,61 +214,61 @@ div.floater {
   a {
     cursor: pointer;
   }
+}
 
-  &.ol-cover-form {
-    background-color: @lightest-grey;
-    border-radius: 10px;
-    padding: 10px;
-    margin-bottom: 10px;
+.ol-cover-form {
+  background-color: @lightest-grey;
+  border-radius: 10px;
+  padding: 10px;
+  margin-bottom: 10px;
 
-    .input {
-      display: flex;
-      gap: 10px;
-      align-items: center;
-    }
-
-    .input > :first-child {
-      flex: 1;
-    }
-
-    button[type=submit] {
-      margin-top: 0;
-    }
+  .input {
+    display: flex;
+    gap: 10px;
+    align-items: center;
   }
 
-  &.ol-cover-form--ia {
-    a {
-      text-decoration: none;
-    }
-
-    .ol-cover-form--ia_image {
-      display: block;
-    }
-
-    .input {
-      flex-direction: column;
-      align-items: flex-start;
-    }
-
-    button[type=submit] {
-      width: 135px;
-    }
+  .input > :first-child {
+    flex: 1;
   }
 
-  #coverFile {
-    min-width: 1px;
+  button[type=submit] {
+    margin-top: 0;
+  }
+}
+
+.ol-cover-form--ia {
+  a {
+    text-decoration: none;
   }
 
-  .dialog--close-parent {
-    cursor: pointer;
+  .ol-cover-form--ia_image {
+    display: block;
   }
 
-  div#covers.input {
-    max-height: 132px;
-    overflow: hidden;
-    margin-left: -80px;
-    text-align: center;
+  .input {
+    flex-direction: column;
+    align-items: flex-start;
   }
+
+  button[type=submit] {
+    width: 135px;
+  }
+}
+
+#coverFile {
+  min-width: 1px;
+}
+
+.dialog--close-parent {
+  cursor: pointer;
+}
+
+div#covers.input {
+  max-height: 132px;
+  overflow: hidden;
+  margin-left: -80px;
+  text-align: center;
 }
 
 .floatform__body {

--- a/static/css/page-form.less
+++ b/static/css/page-form.less
@@ -98,6 +98,10 @@ div#revertLink,
   width: 300px;
   font-size: .75em;
   color: @grey;
+
+  .imageSaved__button {
+    text-decoration: none;
+  }
 }
 .saved {
   background: url(/images/icons/icon_saved.png) no-repeat;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9333.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature. Adds an option to use the book's cover from the Internet Archive site if applicable.

### Technical
<!-- What should be noted about the implementation? -->
Current progress:
✅ IA cover option is visible for books with an `ocaid` - i.e. `/books/OL24755423M/Odyssey_book_iv`
✅ IA cover option is not visible for books without an `ocaid` - i.e. `/books/OL9737752M/The_Odyssey`
✅ Selecting "Use this Image" successfully uploads the IA cover
✅ Entering a link or image file and selecting "Submit" successfully uploads the user-selected cover, not the IA one
✅ Error checks are modified to run only if the regular "Submit" button is clicked
✅ Button disabling is switched from built-in HTML to manual CSS to prevent IA upload failure
✅ Inline styles should be removed
✅ Hitting the "Enter" key should click the original "Submit" button, not the IA one
✅ Mysterious cropping in the event of an error message should be prevented
✅ Would be nice to do a little bit of CSS clean-up to distinguish the two buttons and improve form spacing
✅ Cover form divided into three parts and redesigned, unnecessary JavaScript validation removed
✅ Individual button loading indicators replaced with global loading indicator

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Log in (if not logged in)
2. Go to the cover modal for a book that has an `ocaid`, such as `/books/OL24755423M/Odyssey_book_iv`
3. You should see an option to select the Internet Archive cover
4. Selecting that option should upload the IA cover, even if a URL or file was included in the form
5. Selecting the original "Submit" button should upload the user-included URL or file, not the IA cover

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
**Cover modal:**
<img width="624" alt="Cover modal with new option" src="https://github.com/internetarchive/openlibrary/assets/140550988/5733ec3b-5d02-415b-a85e-a2ab25ab906c">

**Work cover form (`/add-cover`):**
<img width="611" alt="Screenshot 2024-06-20 at 2 39 59 PM" src="https://github.com/internetarchive/openlibrary/assets/140550988/4417eb95-55cb-48da-a48e-dcb2c5193d43">


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
