### PR TITLE
9141/feature/add share modal authors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
       - id: auto-walrus
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.4
+    rev: v0.4.5
     hooks:
       - id: ruff
 
@@ -42,7 +42,7 @@ repos:
       - id: black  # See pyproject.toml for args
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.3.0
     hooks:
       - id: codespell  # See pyproject.toml for args
         additional_dependencies:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,7 +6,7 @@ In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to make participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
+level of experience, education, socioeconomic status, nationality, personal
 appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards

--- a/openlibrary/catalog/marc/parse.py
+++ b/openlibrary/catalog/marc/parse.py
@@ -286,6 +286,8 @@ lang_map = {
     'fr ': 'fre',
     'it ': 'ita',
     # LOC MARC Deprecated code updates
+    # Only covers deprecated codes where there
+    # is a direct 1-to-1 mapping to a single new code.
     'cam': 'khm',  # Khmer
     'esp': 'epo',  # Esperanto
     'eth': 'gez',  # Ethiopic
@@ -308,7 +310,7 @@ lang_map = {
     'snh': 'sin',  # Sinhalese
     'sso': 'sot',  # Sotho
     'swz': 'ssw',  # Swazi
-    'tag': 'tgi',  # Tagalog
+    'tag': 'tgl',  # Tagalog
     'taj': 'tgk',  # Tajik
     'tar': 'tat',  # Tatar
     'tsw': 'tsn',  # Tswana

--- a/openlibrary/core/lists/model.py
+++ b/openlibrary/core/lists/model.py
@@ -321,7 +321,7 @@ class List(Thing):
         return d
 
     def get_seeds(self, sort=False, resolve_redirects=False) -> list['Seed']:
-        seeds: list['Seed'] = []
+        seeds: list[Seed] = []
         for s in self.seeds:
             seed = Seed.from_db(self, s)
             max_checks = 10

--- a/openlibrary/i18n/es/messages.po
+++ b/openlibrary/i18n/es/messages.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: Open Library VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2024-05-01 18:58-0400\n"
-"PO-Revision-Date: 2024-05-17 18:59+0200\n"
+"PO-Revision-Date: 2024-06-01 20:55+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
@@ -2803,20 +2803,31 @@ msgstr ""
 "impresos normales. "
 
 #: books/daisy.html
-#, python-format
 msgid ""
 "There are two types of DAISYs on Open Library: <i>open</i> and <i>protected</"
 "i>. Open DAISYs can be read by anyone in the world on many different "
-"devices. Protected DAISYs %(encrypted)s can only be opened using a key "
+"devices. Protected DAISYs like this one can only be opened using a key "
 "issued by the <a href=\"http://www.loc.gov/nls/\">Library of Congress NLS "
 "program</a>."
 msgstr ""
 "Hay dos tipos de DAISY en la Biblioteca Abierta: <i>abierto</i> and "
 "<i>protegido</i>. Los DAISY abiertos pueden ser leídos por cualquier persona "
-"del mundo en muchos dispositivos diferentes. Los DAISY protegidos "
-"%(encrypted)s solo pueden abrirse usando una clave emitida por el <a "
-"href=\"http://www.loc.gov/nls/\">programa NLS de la Biblioteca del Congreso</"
-"a>."
+"del mundo en muchos dispositivos diferentes. Los DAISY protegidos como este "
+"solo pueden abrirse usando una clave emitida por el <a href=\"http://www.loc."
+"gov/nls/\">programa NLS de la Biblioteca del Congreso</a>."
+
+#: books/daisy.html
+msgid ""
+"There are two types of DAISYs on Open Library: <i>open</i> and <i>protected</"
+"i>. Open DAISYs can be read by anyone in the world on many different "
+"devices. Protected DAISYs can only be opened using a key issued by the <a "
+"href=\"http://www.loc.gov/nls/\">Library of Congress NLS program</a>."
+msgstr ""
+"Hay dos tipos de DAISY en la Biblioteca Abierta: <i>abierto</i> y "
+"<i>protegido</i>. Los DAISY abiertos pueden ser leídos por cualquier persona "
+"del mundo en muchos dispositivos diferentes. Los DAISY protegidos solo "
+"pueden abrirse usando una clave emitida por el <a href=\"http://www.loc.gov/"
+"nls/\">programa NLS de la Biblioteca del Congreso</a>."
 
 #: books/daisy.html lists/home.html
 msgid "Enjoy!"
@@ -5010,7 +5021,7 @@ msgstr "Haz clic para cerrar esta solicitud de fusión"
 
 #: merge_request_table/table_row.html type/edition/modal_links.html
 msgid "Review"
-msgstr "Reseñar"
+msgstr "Revisar"
 
 #: merge_request_table/table_row.html
 msgid "comments"
@@ -5543,10 +5554,6 @@ msgid ""
 msgstr ""
 "Por favor, usa el orden natural. Por ejemplo: <strong>Leo Tolstoy</strong>, "
 "no <strong>Tolstoy, Leo</strong>."
-
-#: type/author/edit.html
-msgid "About"
-msgstr "Acerca de"
 
 #: type/author/edit.html
 msgid "A short bio?"
@@ -6615,6 +6622,18 @@ msgstr "Copiar icono URL"
 msgid "Copy URL"
 msgstr "Copiar URL"
 
+#: ShareModal.html
+msgid "Open QR code"
+msgstr "Abrir código QR"
+
+#: ShareModal.html
+msgid "QR code icon"
+msgstr "Icono de código QR"
+
+#: ShareModal.html
+msgid "QR Code"
+msgstr "Código QR"
+
 #: SponsorCarousel.html
 msgid "Books to Sponsor"
 msgstr "Libros para patrocinar"
@@ -6982,13 +7001,13 @@ msgstr ""
 msgid "Invalid password"
 msgstr "Contraseña inválida"
 
+#~ msgid "About"
+#~ msgstr "Acerca de"
+
 #, fuzzy
 #~| msgid "Continue"
 #~ msgid "Continue</a>."
 #~ msgstr "Continuar"
-
-#~ msgid "cancel icon"
-#~ msgstr "icono de cancelación"
 
 #~ msgid "Close this"
 #~ msgstr "Cerrar esto"

--- a/openlibrary/macros/databarView.html
+++ b/openlibrary/macros/databarView.html
@@ -36,6 +36,7 @@ $else:
             rel="nofollow"
         >$_("Edit")</a>
         </div>
+<<<<<<< Updated upstream
 
         $if page.type.key == "/type/author":
             <div class="editShareButton">
@@ -48,5 +49,18 @@ $else:
                     $:macros.ShareModal(share_links, page_url, share_content, "share-modal-wrapper", show_embed=False)
             </div>
 
+=======
+    
+    $if page.type.key == "/type/author":
+        <div class="editShareButton">
+            $set_share_links(url=request.canonical_url, title='', view_context=ctx)
+            $if ctx.get('share_links'):
+                $ share_str = _('')
+                $ share_content = '<a class="cta-btn cta-btn--unstyled share-modal-link icon-link" href="javascript:;" data-ol-link-track="MyBooksModalLinkClick|ShareIcon"><div class="share-icon__image"><img class="icon-link" src="/static/images/icons/share.svg" width="30"><div class="share-text">%s</div></div></a>' % share_str
+                $ page_url = request.home
+                $ share_links = ctx.get('share_links')
+                $:macros.ShareModal(share_links, page_url, share_content, "share-modal-wrapper", show_embed=False)
+        </div>
+>>>>>>> Stashed changes
 </div>
 

--- a/openlibrary/macros/databarView.html
+++ b/openlibrary/macros/databarView.html
@@ -26,8 +26,8 @@ $else:
     </div>
     $if edit and not page.is_fake_record():
         <div class="editButton">
-          <!-- FIXME: accesskey / keyboard shortcut needs i18n -->
-          <a
+        <!-- FIXME: accesskey / keyboard shortcut needs i18n -->
+        <a
             class="cta-btn cta-btn--vanilla"
             href="$edit_url"
             title="$_('Edit this page')"
@@ -36,4 +36,17 @@ $else:
             rel="nofollow"
         >$_("Edit")</a>
         </div>
+
+        $if page.type.key == "/type/author":
+            <div class="editShareButton">
+                $set_share_links(url=request.canonical_url, title='', view_context=ctx)
+                $if ctx.get('share_links'):
+                    $ share_str = _('')
+                    $ share_content = '<a class="cta-btn cta-btn--unstyled share-modal-link icon-link" href="javascript:;" data-ol-link-track="MyBooksModalLinkClick|ShareIcon"><div class="share-icon__image"><img class="icon-link" src="/static/images/icons/share.svg" width="30"><div class="share-text">%s</div></div></a>' % share_str
+                    $ page_url = request.home
+                    $ share_links = ctx.get('share_links')
+                    $:macros.ShareModal(share_links, page_url, share_content, "share-modal-wrapper", show_embed=False)
+            </div>
+
 </div>
+

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -1003,7 +1003,7 @@ class export_books(delegate.page):
         Gets work data for a given work ID (OLxxxxxW format), used to access work author, title, etc. for CSV generation.
         """
         work_key = f"/works/{work_id}"
-        work: "Work" = web.ctx.site.get(work_key)
+        work: Work = web.ctx.site.get(work_key)
         if not work:
             raise ValueError(f"No Work found for {work_key}.")
         if work.type.key == '/type/redirect':

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -44,15 +44,6 @@ $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_libra
 <div id="contentHead">
 
     $:macros.databarView(page)
-    <div class ="editShareButton">
-        $set_share_links(url=request.canonical_url, title='', view_context=ctx)
-            $if ctx.get('share_links'):
-            $ share_str = _('Share')
-            $ share_content = '<a class="cta-btn cta-btn--unstyled share-modal-link icon-link" href="javascript:;" data-ol-link-track="MyBooksModalLinkClick|ShareIcon"><img class="icon-link__image" src="/static/images/icons/share.svg" width="20"> %s</a>' % share_str
-            $ page_url = request.home
-            $ share_links = ctx.get('share_links')
-            $:macros.ShareModal(share_links, page_url, share_content, "share-modal-wrapper", show_embed=False)
-    </div>
 
     <h1 itemprop="name">$title</h1>
     $if show_librarian_extras:

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -44,6 +44,15 @@ $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_libra
 <div id="contentHead">
 
     $:macros.databarView(page)
+    <div class ="editShareButton">
+        $set_share_links(url=request.canonical_url, title='', view_context=ctx)
+            $if ctx.get('share_links'):
+            $ share_str = _('Share')
+            $ share_content = '<a class="cta-btn cta-btn--unstyled share-modal-link icon-link" href="javascript:;" data-ol-link-track="MyBooksModalLinkClick|ShareIcon"><img class="icon-link__image" src="/static/images/icons/share.svg" width="20"> %s</a>' % share_str
+            $ page_url = request.home
+            $ share_links = ctx.get('share_links')
+            $:macros.ShareModal(share_links, page_url, share_content, "share-modal-wrapper", show_embed=False)
+    </div>
 
     <h1 itemprop="name">$title</h1>
     $if show_librarian_extras:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ skip-string-normalization = true
 target-version = ["py311"]
 
 [tool.codespell]
-ignore-words-list = "beng,curren,datas,furst,nd,nin,ot,ser,spects,te,tha,ue,upto"
+ignore-words-list = "beng,curren,datas,furst,nd,nin,ot,ser,spects,te,tha,ue,upto,thirdparty"
 skip = "./.*,*/ocm00400866,*/read_toc.py,*.it,*.js,*.json,*.mrc,*.page,*.pg_dump,*.po,*.txt,*.xml,*.yml"
 
 [tool.mypy]

--- a/static/css/components/edit-toolbar.less
+++ b/static/css/components/edit-toolbar.less
@@ -7,11 +7,12 @@
 div#editTools,
 div#editHistory {
   width: auto;
+  align-items: center;
 }
 
-div.editButton {
-  width: auto;
-  display: inline-block;
+.editButton {
+  display: flex;
+  align-items: center;
 }
 
 div#editInfo {
@@ -34,11 +35,15 @@ div#editTools {
   padding: 0 0 1rem;
 }
 
-div.editShareButton {
+.editShareButton {
   display: flex;
-  justify-content: flex-end;
-  align-items: center;
+  align-items: center; 
+}
+
+.editShareButton .share-icon__image {
+  display: flex;
+  flex-direction: column;
+  align-items: center; 
 }
 
 @import "components/buttonLink.less";
-

--- a/static/css/components/edit-toolbar.less
+++ b/static/css/components/edit-toolbar.less
@@ -35,9 +35,10 @@ div#editTools {
 }
 
 div.editShareButton {
-  width: auto;
-  display: inline-block;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
 }
 
-
 @import "components/buttonLink.less";
+

--- a/static/css/components/edit-toolbar.less
+++ b/static/css/components/edit-toolbar.less
@@ -10,9 +10,15 @@ div#editHistory {
   align-items: center;
 }
 
+<<<<<<< Updated upstream
 .editButton {
   display: flex;
   align-items: center;
+=======
+div.editButton {
+  width: auto;
+  display: inline-block;
+>>>>>>> Stashed changes
 }
 
 div#editInfo {
@@ -36,14 +42,15 @@ div#editTools {
 }
 
 .editShareButton {
-  display: flex;
-  align-items: center; 
+  width: auto;
+  display: inline-block;
 }
 
 .editShareButton .share-icon__image {
-  display: flex;
+  display: inline-block;
   flex-direction: column;
   align-items: center; 
 }
+
 
 @import "components/buttonLink.less";

--- a/static/css/components/edit-toolbar.less
+++ b/static/css/components/edit-toolbar.less
@@ -33,4 +33,11 @@ div#editTools {
   white-space: nowrap;
   padding: 0 0 1rem;
 }
+
+div.editShareButton {
+  width: auto;
+  display: inline-block;
+}
+
+
 @import "components/buttonLink.less";


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9141

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This pull request is adding the Share Modal on the authors page next to the edit button and edit info. 


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
View the changes in any author's page.


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
before:
![image](https://github.com/internetarchive/openlibrary/assets/117905126/a034b0b2-71ba-4478-86cf-603183511452)

after:
![image](https://github.com/internetarchive/openlibrary/assets/117905126/501eebe1-2c41-4371-9454-928c3e3a1d92)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@jimchamp 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
