### PR TITLE
9318/fix/quickstart link update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ For instructions on setting up a local developer's instance of Open Library, ple
 [![archive org_details_openlibrary-developer-docs_zoom_0 mp4_autoplay=1 start=2](https://user-images.githubusercontent.com/978325/91351305-ef10ee00-e79c-11ea-9bfb-c2733696ec58.png)](https://archive.org/details/openlibrary-developer-docs/zoom_0.mp4)
 
 
-Also, refer to the [Quickstart Guide](https://github.com/internetarchive/openlibrary/wiki/Getting-Started).
+Also, refer to the [Quickstart Guide](https://github.com/internetarchive/openlibrary/wiki/1_Start-Here).
 [Here's a handy cheat sheet](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet) if you are new to using Git.
 
 ## Common Setup Tasks

--- a/Readme.md
+++ b/Readme.md
@@ -50,7 +50,7 @@ Warning: This integration is still experimental.
 
 ### Developer's Guide
 
-For instructions on administrating your Open Library instance, refer to the Developer's [Quickstart](https://github.com/internetarchive/openlibrary/wiki/Getting-Started) Guide.
+For instructions on administrating your Open Library instance, refer to the Developer's [Quickstart](https://github.com/internetarchive/openlibrary/wiki/1_Start-Here) Guide.
 
 You can also find more information regarding Developer Documentation for Open Library in the Open Library [Wiki](https://github.com/internetarchive/openlibrary/wiki/).
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9318 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes a dead link in the documentation. Previously pointed to the now outdated [Getting Started](https://github.com/internetarchive/openlibrary/wiki/OUTDATED-Getting-Started#quick-start-for-open-librarys-developers) page and now points to [Start Here](https://github.com/internetarchive/openlibrary/wiki/1_Start-Here) until the onboarding documentation is finished being overhauled.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Go to the [README](https://github.com/internetarchive/openlibrary?tab=readme-ov-file#developers-guide) or [CONTRIBUTING](https://github.com/internetarchive/openlibrary?tab=readme-ov-file#developers-guide) files.
2. Locate the [Quickstart](https://github.com/internetarchive/openlibrary/wiki/1_Start-Here) link and click on it.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@rebecca-shoptaw 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
