### PR TITLE
update contributor instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -54,5 +54,6 @@ body:
         #### Stakeholders
         <!-- @ tag stakeholders of this bug -->
 
-        <!-- Please leave the following reminder section as is to help new contributors -->
-        **Note:** Before [making a new branch](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#making-changes-and-creating-a-pull-request) _or_ updating an existing one, please [ensure your branch is up to date](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#working-on-your-branch).
+        #### Instructions for Contributors
+        <!-- Please leave the following reminder section as is to help new contributors and add instructions where necessary -->
+        - Please [run these commands](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#working-on-your-branch) to ensure your repository is up to date **before** [creating a new branch](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#making-changes-and-creating-a-pull-request) to work on this issue and **each time after** pushing code to github, because pre-commit bot may add commits to your PRs upstream.

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -53,7 +53,7 @@ body:
 
         #### Stakeholders
         <!-- @ tag stakeholders of this bug -->
-
+        <hr>
         #### Instructions for Contributors
         <!-- Please leave the following reminder section as is to help new contributors and add instructions where necessary -->
-        - Please [run these commands](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#working-on-your-branch) to ensure your repository is up to date **before** [creating a new branch](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#making-changes-and-creating-a-pull-request) to work on this issue and **each time after** pushing code to github, because pre-commit bot may add commits to your PRs upstream.
+        - Please [run these commands](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#working-on-your-branch) to ensure your repository is up to date **before** [creating a new branch](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#making-changes-and-creating-a-pull-request) to work on this issue and **each time after** pushing code to Github, because the pre-commit bot may add commits to your PRs upstream.

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -43,6 +43,6 @@ body:
         ### Stakeholders
         <!-- @ tag stakeholders of this feature if any -->
 
-        ### Instructions For Contributors
+        ### Instructions for Contributors
         <!-- Please leave the following reminder section as is to help new contributors and add instructions where necessary -->
         - Please [run these commands](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#working-on-your-branch) to ensure your repository is up to date **before** [creating a new branch](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#making-changes-and-creating-a-pull-request) to work on this issue and **each time after** pushing code to github, because pre-commit bot may add commits to your PRs upstream.

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -43,5 +43,6 @@ body:
         ### Stakeholders
         <!-- @ tag stakeholders of this feature if any -->
 
-        <!-- Please leave the following reminder section as is to help new contributors -->
-        **Note:** Before [making a new branch](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#making-changes-and-creating-a-pull-request) _or_ updating an existing one, please [ensure your branch is up to date](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#working-on-your-branch).
+        ### Instructions For Contributors
+        <!-- Please leave the following reminder section as is to help new contributors and add instructions where necessary -->
+        - Please [run these commands](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#working-on-your-branch) to ensure your repository is up to date **before** [creating a new branch](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#making-changes-and-creating-a-pull-request) to work on this issue and **each time after** pushing code to github, because pre-commit bot may add commits to your PRs upstream.

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -42,7 +42,7 @@ body:
 
         ### Stakeholders
         <!-- @ tag stakeholders of this feature if any -->
-
+        <hr>
         ### Instructions for Contributors
         <!-- Please leave the following reminder section as is to help new contributors and add instructions where necessary -->
-        - Please [run these commands](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#working-on-your-branch) to ensure your repository is up to date **before** [creating a new branch](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#making-changes-and-creating-a-pull-request) to work on this issue and **each time after** pushing code to github, because pre-commit bot may add commits to your PRs upstream.
+        - Please [run these commands](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#working-on-your-branch) to ensure your repository is up to date **before** [creating a new branch](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#making-changes-and-creating-a-pull-request) to work on this issue and **each time after** pushing code to Github, because the pre-commit bot may add commits to your PRs upstream.


### PR DESCRIPTION
The current instructions template for issues can be confusing because instructions to contributors shows up under `### Stakeholders` even if the section is blank. There should be a section specifically for `### Instructions for Contributors` and we may be able to make it a bit more clear / actionable: 

> ### Instructions for Contributors
<!-- Please leave the following reminder section as is to help new contributors and add instructions where necessary -->
> - Please [run these commands](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#working-on-your-branch) to ensure your repository is up to date **before** [creating a new branch](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#making-changes-and-creating-a-pull-request) to work on this issue and **each time after** pushing code to github, because pre-commit bot may add commits to your PRs upstream.
 
<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
