### PR TITLE
Remove extra checks from `extract_messages`

### DIFF
--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -159,9 +159,7 @@ def extract_templetor(fileobj, keywords, comment_tags, options):
     return extract_python(f, keywords, comment_tags, options)
 
 
-def extract_messages(
-    dirs: list[str], verbose: bool, forced: bool, skip_untracked: bool
-):
+def extract_messages(dirs: list[str], verbose: bool, skip_untracked: bool):
     # The creation date is fixed to prevent merge conflicts on this line as a result of i18n auto-updates
     # In the unlikely event we need to update the fixed creation date, you can change the hard-coded date below
     fixed_creation_date = datetime.fromisoformat('2024-05-01 18:58-0400')
@@ -173,9 +171,6 @@ def extract_messages(
     METHODS = [("**.py", "python"), ("**.html", "openlibrary.i18n:extract_templetor")]
     COMMENT_TAGS = ["NOTE:"]
 
-    template = read_po((Path(root) / 'messages.pot').open('rb'))
-    msg_set = {msg.id for msg in template if msg.id != ''}
-    new_set = set()
     skipped_files = set()
     if skip_untracked:
         skipped_files = get_untracked_files(dirs, ('.py', '.html'))
@@ -190,7 +185,6 @@ def extract_messages(
             file_path = Path(d) / filename
             if file_path in skipped_files:
                 continue
-            new_set.add(message)
             counts[filename] = counts.get(filename, 0) + 1
             catalog.add(message, None, [(filename, lineno)], auto_comments=comments)
 
@@ -199,18 +193,12 @@ def extract_messages(
                 path = filename if d == filename else os.path.join(d, filename)
                 print(f"{count}\t{path}", file=sys.stderr)
 
-    has_changed = msg_set != new_set
-    if has_changed or forced:
-        path = os.path.join(root, 'messages.pot')
-        f = open(path, 'wb')
-        write_po(f, catalog, include_lineno=False)
-        f.close()
+    path = os.path.join(root, 'messages.pot')
+    f = open(path, 'wb')
+    write_po(f, catalog, include_lineno=False)
+    f.close()
 
-        print('Updated strings written to', path)
-    else:
-        print(
-            'No modified strings discovered. To force a template update, re-run with --force-write.'
-        )
+    print('Updated strings written to', path)
 
 
 def compile_translations(locales: list[str]):

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -452,9 +452,8 @@ msgstr ""
 
 #: authors/index.html lib/nav_head.html lists/home.html
 #: publishers/notfound.html publishers/view.html search/advancedsearch.html
-#: search/authors.html search/inside.html search/lists.html
-#: search/publishers.html search/subjects.html subjects.html
-#: subjects/notfound.html type/local_id/view.html work_search.html
+#: search/publishers.html search/searchbox.html subjects.html
+#: subjects/notfound.html type/local_id/view.html
 msgid "Search"
 msgstr ""
 
@@ -4392,7 +4391,7 @@ msgstr ""
 msgid "Recent Activity"
 msgstr ""
 
-#: lists/home.html
+#: lists/home.html lists/showcase.html
 msgid "See all"
 msgstr ""
 

--- a/scripts/i18n-messages
+++ b/scripts/i18n-messages
@@ -35,7 +35,6 @@ def main(cmd, args):
         i18n.extract_messages(
             message_sources,
             verbose='--verbose' in args,
-            forced='--force-write' in args,
             skip_untracked='--skip-untracked' in args,
         )
     elif cmd == 'compile':


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9396.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix. Removes checks from the `extract_messages` function that are unnecessary now that the timestamp is standardized so as to catch a few more cases.

### Technical
<!-- What should be noted about the implementation? -->
Also removed the `--force-write` option, as the function will now always write a new template.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Make a change to onscreen text in an HTML/Python file and commit -- `pre-commit` should fail and auto-update the `messages.pot` file
2. Stage the `messages.pot` changes and commit again -- `pre-commit` should pass
3. Make a change to an HTML/Python file that does not change the position or contents of on-screen text -- `pre-commit` should simply pass
4. Make a change that involves moving on-screen text between files or changing the name of a file with on-screen text -- `pre-commit` should run the same process as steps 1 & 2 even though no text has been added, changed or deleted

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
