### PR TITLE
tidy some invalid HTML and rendered comments in edition view template

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -144,7 +144,7 @@ $def display_identifiers(label, ids, itemprop=None):
         $if (True in all_ids) and (1==len(all_ids)):
             $return
 
-        <!-- FIXME: Identifier names need to be translated (I18N) -->
+        $# FIXME: Identifier names need to be translated (I18N)
         <dt>$label</dt>
         <dd class="object" $:cond(itemprop, 'itemprop="%s"' % itemprop, '')>
             $for id in ids:
@@ -453,9 +453,7 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
               <div class="section">
               <h3>$_("Source records")</h3>
               $ get_source_html = render_template("history/sources").get_source_html
-              <dl class="meta">
-                  $:'<br/>'.join([get_source_html(s) for s in source_records])
-              </dl>
+              $:'<br/>'.join([get_source_html(s) for s in source_records])
               </div>
           $if work:
             $if not work.excerpts and work.first_sentence:
@@ -473,7 +471,7 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
 
             $if work.original_languages:
               <div class="sansserif smallest">$_("Original languages")</div>
-              <!-- TODO: Double check that these language names are localized -->
+              $# TODO: Double check that these language names are localized
               $', '.join(lang.name for lang in work.original_languages)<p>
 
             $if work.excerpts:
@@ -515,7 +513,7 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
         $ component_times['Review component'] = time()
         $:render_template("observations/review_component", work, reader_observations, page.key)
         $ component_times['Review component'] = time() - component_times['Review component']
-      <a id="lists-section" name="lists-section tab-section" class="section-anchor"></a>
+      <a id="lists-section" class="section-anchor"></a>
       <div class="workFooter tab-section">
         $# pages like /books/ia:foo00bar are fake records created from metadata API.
         $# Adding them to lists doesn't work. Disabling it to avoid any issues.
@@ -543,7 +541,7 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
             </div>
           </div>
       </div>
-      <a id="related-work-carousel" name="related-work-carousel tab-section" class="section-anchor"></a>
+      <a id="related-work-carousel" class="section-anchor"></a>
     </div>
   </div>
 


### PR DESCRIPTION
Mainly fixing some invalid nesting I introduced recently, there are many heading tags within spans which fail validation that might need some careful redesign.


<!-- What issue does this PR close? -->
follow up to  #9433

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
