### PR TITLE
Permit librarians to move editions to a new work

### DIFF
--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -2,6 +2,7 @@ $def with (work, book)
 
 $ edition_config = get_edition_config()
 $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_super_librarian())
+$ is_librarian = is_privileged_user or (ctx.user and ctx.user.is_librarian())
 
 $def radiobuttons(name, options, value):
     $for v in options:
@@ -378,7 +379,7 @@ $jsdef render_work_autocomplete_item(item):
                     $_("WARNING: Any edits made to the work from this page will be ignored.")
                 </span>
             </div>
-            $ config = {'addnew': is_privileged_user, 'new_name': _('-- Move to a new work')}
+            $ config = {'addnew': is_librarian, 'new_name': _('-- Move to a new work')}
             <div class="multi-input-autocomplete multi-input-autocomplete--works" data-config="$dumps(config)">
                 $if book.works:
                     $for i, work in enumerate(book.works):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9235

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

fix

### Technical
<!-- What should be noted about the implementation? -->

Adds a new page-local variable `is_librarian` which is then checked for in the call that decides whether to add the “-- Move to a new work” option in the Work move dropdown list.

### Testing

**NOTE:** I have _not_ run tests or manually tested this in a working environment, as I haven’t set one up (yet?), and the `pre-commit` hook failed due to an <q>Error getting the version from source `vcs`</q> which seems unrelated to this PR.

1. Edit an edition with a librarian account which is _neither_ super librarian _nor_ admin.
2. The “-- Move to new work” option should be available.

I didn’t find anywhere where the existing behaviour was tested in automated tests, and thus also haven’t edited or added any such tests.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->

@seabelis 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
