### PR TITLE
Reduce multiprocessing of importbot

### DIFF
--- a/scripts/manage-imports.py
+++ b/scripts/manage-imports.py
@@ -157,7 +157,7 @@ def import_all(args, **kwargs):
     require_marc = not kwargs.get('no_marc', False)
 
     # Use multiprocessing to call do_import on each item
-    with multiprocessing.Pool(processes=10) as pool:
+    with multiprocessing.Pool(processes=8) as pool:
         while True:
             logger.info("find_pending START")
             items = ImportItem.find_pending()


### PR DESCRIPTION
Was noticing high CPU load on our db server, so reduced the multiprocessing of importbot. I tried 6 but it seemed like it had room for more, so leaving it at 8 to see how it does. Either way better than 10!

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
