### PR TITLE
Move registration formatting checks to frontend

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -909,6 +909,14 @@ msgid "Must be between 3 and 20 characters"
 msgstr ""
 
 #: account/create.html
+msgid "Username may only contain numbers, letters, - or _"
+msgstr ""
+
+#: account/create.html forms.py
+msgid "Must be a valid email address"
+msgstr ""
+
+#: account/create.html
 msgid "Sign Up to Open Library"
 msgstr ""
 
@@ -6615,19 +6623,7 @@ msgid ""
 msgstr ""
 
 #: account.py
-msgid "Username must be between 3-20 characters"
-msgstr ""
-
-#: account.py
-msgid "Username may only contain numbers, letters, - or _"
-msgstr ""
-
-#: account.py
 msgid "Username unavailable"
-msgstr ""
-
-#: account.py forms.py
-msgid "Must be a valid email address"
 msgstr ""
 
 #: account.py forms.py

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -905,15 +905,15 @@ msgid "The Open Library Team"
 msgstr ""
 
 #: account/create.html forms.py
+msgid "Must be a valid email address"
+msgstr ""
+
+#: account/create.html forms.py
 msgid "Must be between 3 and 20 characters"
 msgstr ""
 
 #: account/create.html
 msgid "Username may only contain numbers, letters, - or _"
-msgstr ""
-
-#: account/create.html forms.py
-msgid "Must be a valid email address"
 msgstr ""
 
 #: account/create.html

--- a/openlibrary/plugins/openlibrary/js/realtime_account_validation.js
+++ b/openlibrary/plugins/openlibrary/js/realtime_account_validation.js
@@ -1,6 +1,12 @@
 export function initRealTimeValidation() {
     const signupForm = document.querySelector('form[name=signup]');
     const i18nStrings = JSON.parse(signupForm.dataset.i18n);
+    const VALID_EMAIL_RE = /.*@.*\..*/;
+    const VALID_USERNAME_RE = /^[a-z0-9-_]{3,20}$/i;
+    const PASSWORD_MINLENGTH = 3;
+    const PASSWORD_MAXLENGTH = 20;
+    const USERNAME_MINLENGTH = 3;
+    const USERNAME_MAXLENGTH = 20;
 
     if (window.grecaptcha) {
         // Callback that is called when grecaptcha.execute() is successful
@@ -49,62 +55,77 @@ export function initRealTimeValidation() {
 
     function validateUsername() {
         const value_username = $(this).val();
-        if (value_username !== '') {
-            if (value_username.length < 3 || value_username.length > 20) {
-                renderError('#username', '#usernameMessage', i18nStrings['input_length_err']);
-            } else if (!(/^[A-Za-z0-9-_]{3,20}$/.test(value_username))) {
-                renderError('#username', '#usernameMessage', i18nStrings['username_char_err']);
-            } else {
-                clearError('#username', '#usernameMessage');
 
-                $.ajax({
-                    url: '/account/validate',
-                    data: { username: value_username },
-                    type: 'GET',
-                    success: function(errors) {
-                        if (errors.username) {
-                            renderError('#username', '#usernameMessage', errors.username);
-                        }
-                    }
-                });
-            }
-        }
-        else {
+        if (value_username === '') {
             clearError('#username', '#usernameMessage');
+            return;
         }
+
+        if (value_username.length < USERNAME_MINLENGTH || value_username.length > USERNAME_MAXLENGTH) {
+            renderError('#username', '#usernameMessage', i18nStrings['username_length_err']);
+            return;
+        }
+
+        if (!(VALID_USERNAME_RE.test(value_username))) {
+            renderError('#username', '#usernameMessage', i18nStrings['username_char_err']);
+            return;
+        }
+
+        clearError('#username', '#usernameMessage');
+
+        $.ajax({
+            url: '/account/validate',
+            data: { username: value_username },
+            type: 'GET',
+            success: function(errors) {
+                if (errors.username) {
+                    renderError('#username', '#usernameMessage', errors.username);
+                }
+            }
+        });
     }
 
     function validateEmail() {
         const value_email = $(this).val();
-        if (value_email !== '') {
-            if (!(/.*@.*\..*/.test(value_email))) {
-                renderError('#emailAddr', '#emailAddrMessage', i18nStrings['invalid_email_format']);
-            } else {
-                clearError('#emailAddr', '#emailAddrMessage');
 
-                $.ajax({
-                    url: '/account/validate',
-                    data: { email: value_email },
-                    type: 'GET',
-                    success: function(errors) {
-                        if (errors.email) {
-                            renderError('#emailAddr', '#emailAddrMessage', errors.email);
-                        }
-                    }
-                });
-            }
-        }
-        else {
+        if (value_email === '') {
             clearError('#emailAddr', '#emailAddrMessage');
+            return;
         }
+
+        if (!VALID_EMAIL_RE.test(value_email)) {
+            renderError('#emailAddr', '#emailAddrMessage', i18nStrings['invalid_email_format']);
+            return;
+        }
+
+        clearError('#emailAddr', '#emailAddrMessage');
+
+        $.ajax({
+            url: '/account/validate',
+            data: { email: value_email },
+            type: 'GET',
+            success: function(errors) {
+                if (errors.email) {
+                    renderError('#emailAddr', '#emailAddrMessage', errors.email);
+                }
+            }
+        });
     }
 
     function validatePassword() {
         const value_password = $(this).val();
-        if (value_password !== '' && (value_password.length < 3 || value_password.length > 20)) {
-            renderError('#password', '#passwordMessage', i18nStrings['input_length_err']);
+
+        if (value_password === '') {
+            clearError('#password', '#passwordMessage');
+            return;
         }
-        else clearError('#password', '#passwordMessage');
+
+        if (value_password.length < PASSWORD_MINLENGTH || value_password.length > PASSWORD_MAXLENGTH) {
+            renderError('#password', '#passwordMessage', i18nStrings['password_length_err']);
+            return;
+        }
+
+        clearError('#password', '#passwordMessage');
     }
 
     $('#username').on('blur', validateUsername);

--- a/openlibrary/plugins/openlibrary/js/realtime_account_validation.js
+++ b/openlibrary/plugins/openlibrary/js/realtime_account_validation.js
@@ -50,18 +50,24 @@ export function initRealTimeValidation() {
     function validateUsername() {
         const value_username = $(this).val();
         if (value_username !== '') {
-            $.ajax({
-                url: '/account/validate',
-                data: { username: value_username },
-                type: 'GET',
-                success: function(errors) {
-                    if (errors.username) {
-                        renderError('#username', '#usernameMessage', errors.username);
-                    } else {
-                        clearError('#username', '#usernameMessage');
+            if (value_username.length < 3 || value_username.length > 20) {
+                renderError('#username', '#usernameMessage', i18nStrings['input_length_err']);
+            } else if (!(/^[A-Za-z0-9-_]{3,20}$/.test(value_username))) {
+                renderError('#username', '#usernameMessage', i18nStrings['username_char_err']);
+            } else {
+                clearError('#username', '#usernameMessage');
+
+                $.ajax({
+                    url: '/account/validate',
+                    data: { username: value_username },
+                    type: 'GET',
+                    success: function(errors) {
+                        if (errors.username) {
+                            renderError('#username', '#usernameMessage', errors.username);
+                        }
                     }
-                }
-            });
+                });
+            }
         }
         else {
             clearError('#username', '#usernameMessage');
@@ -71,18 +77,22 @@ export function initRealTimeValidation() {
     function validateEmail() {
         const value_email = $(this).val();
         if (value_email !== '') {
-            $.ajax({
-                url: '/account/validate',
-                data: { email: value_email },
-                type: 'GET',
-                success: function(errors) {
-                    if (errors.email) {
-                        renderError('#emailAddr', '#emailAddrMessage', errors.email);
-                    } else {
-                        clearError('#emailAddr', '#emailAddrMessage');
+            if (!(/.*@.*\..*/.test(value_email))) {
+                renderError('#emailAddr', '#emailAddrMessage', i18nStrings['invalid_email_format']);
+            } else {
+                clearError('#emailAddr', '#emailAddrMessage');
+
+                $.ajax({
+                    url: '/account/validate',
+                    data: { email: value_email },
+                    type: 'GET',
+                    success: function(errors) {
+                        if (errors.email) {
+                            renderError('#emailAddr', '#emailAddrMessage', errors.email);
+                        }
                     }
-                }
-            });
+                });
+            }
         }
         else {
             clearError('#emailAddr', '#emailAddrMessage');
@@ -92,7 +102,7 @@ export function initRealTimeValidation() {
     function validatePassword() {
         const value_password = $(this).val();
         if (value_password !== '' && (value_password.length < 3 || value_password.length > 20)) {
-            renderError('#password', '#passwordMessage', i18nStrings['password_length_err']);
+            renderError('#password', '#passwordMessage', i18nStrings['input_length_err']);
         }
         else clearError('#password', '#passwordMessage');
     }

--- a/openlibrary/plugins/openlibrary/js/realtime_account_validation.js
+++ b/openlibrary/plugins/openlibrary/js/realtime_account_validation.js
@@ -1,7 +1,8 @@
 export function initRealTimeValidation() {
     const signupForm = document.querySelector('form[name=signup]');
     const i18nStrings = JSON.parse(signupForm.dataset.i18n);
-    const VALID_EMAIL_RE = /.*@.*\..*/;
+    // Keep the same with openlibrary/plugins/upstream/forms.py
+    const VALID_EMAIL_RE = /^.*@.*\..*$/;
     const VALID_USERNAME_RE = /^[a-z0-9-_]{3,20}$/i;
     const PASSWORD_MINLENGTH = 3;
     const PASSWORD_MAXLENGTH = 20;

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -570,11 +570,6 @@ class account_validation(delegate.page):
 
     @staticmethod
     def validate_username(username):
-        if not 3 <= len(username) <= 20:
-            return _('Username must be between 3-20 characters')
-        if not re.match('^[A-Za-z0-9-_]{3,20}$', username):
-            return _('Username may only contain numbers, letters, - or _')
-
         ol_account = OpenLibraryAccount.get(username=username)
         if ol_account:
             return _("Username unavailable")
@@ -585,9 +580,6 @@ class account_validation(delegate.page):
 
     @staticmethod
     def validate_email(email):
-        if not (email and re.match(r'.*@.*\..*', email)):
-            return _('Must be a valid email address')
-
         ol_account = OpenLibraryAccount.get(email=email)
         if ol_account:
             return _('Email already registered')

--- a/openlibrary/plugins/upstream/forms.py
+++ b/openlibrary/plugins/upstream/forms.py
@@ -58,7 +58,10 @@ vlogin = RegexpValidator(
     r"^[A-Za-z0-9\-_]{3,20}$", _('Must be between 3 and 20 letters and numbers')
 )
 vpass = RegexpValidator(r".{3,20}", _('Must be between 3 and 20 characters'))
-vemail = RegexpValidator(r".*@.*", _("Must be a valid email address"))
+vemail = RegexpValidator(
+    r".*@.*\..*",
+    _("Must be a valid email address"),
+)
 
 
 class EqualToValidator(Validator):

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -3,9 +3,10 @@ $def with (form)
 $putctx("cssfile", "signup")
 
 $ i18n_strings = {
-    $ "input_length_err": _("Must be between 3 and 20 characters"),
+    $ "invalid_email_format": _("Must be a valid email address"),
+    $ "username_length_err": _("Must be between 3 and 20 characters"),
     $ "username_char_err": _("Username may only contain numbers, letters, - or _"),
-    $ "invalid_email_format": _("Must be a valid email address")
+    $ "password_length_err": _("Must be between 3 and 20 characters")
     $ }
 
 $# :param openlibrary.plugins.upstream.forms.RegisterForm form:

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -3,7 +3,9 @@ $def with (form)
 $putctx("cssfile", "signup")
 
 $ i18n_strings = {
-    $ "password_length_err": _("Must be between 3 and 20 characters")
+    $ "input_length_err": _("Must be between 3 and 20 characters"),
+    $ "username_char_err": _("Username may only contain numbers, letters, - or _"),
+    $ "invalid_email_format": _("Must be a valid email address")
     $ }
 
 $# :param openlibrary.plugins.upstream.forms.RegisterForm form:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9467.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature. Improves registration form performance by ensuring lightweight formatting checks (i.e. username field length, email format) all take place on the frontend before the backend query runs.

### Technical
<!-- What should be noted about the implementation? -->
In `realtime_account_validation.js` a set of formatting checks run first, and if any of them fail the appropriate error is rendered. 

If they all pass, any errors are cleared and the query to the API endpoint in `account.py` runs, to check whether the username/email address is taken. This meant I could remove the error-clearing `else` condition from the `ajax` call, as the errors will be auto-cleared before the call happens. 

It also allowed me to remove the formatting checks from the API endpoint entirely, as they are now duplicated by the js validation -- _but_ duplicative formatting checks do still run on the backend on submission (via `forms.py`) so all bad inputs will be caught even if the user has turned off JavaScript.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Log out (if logged in)
2. Go to `/account/create`
3. Try to enter a badly formatted email/username
4. You should see realtime errors appear on click/tab away as previously -- and they should appear/disappear much more quickly :) 

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini @mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
