### PR TITLE
Feature: normalize language codes on import via `load()`

### DIFF
--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -309,9 +309,9 @@ def build_query(rec):
             continue
         if k in ('languages', 'translated_from'):
             for language in v:
-                if web.ctx.site.get('/languages/' + language) is None:
-                    raise InvalidLanguage(language)
-            book[k] = [{'key': '/languages/' + language} for language in v]
+                if web.ctx.site.get('/languages/' + language.lower()) is None:
+                    raise InvalidLanguage(language.lower())
+            book[k] = [{'key': '/languages/' + language.lower()} for language in v]
             continue
         if k in type_map:
             t = '/type/' + type_map[k]

--- a/openlibrary/catalog/add_book/tests/test_load_book.py
+++ b/openlibrary/catalog/add_book/tests/test_load_book.py
@@ -53,7 +53,7 @@ def test_import_author_name_unchanged(author, new_import):
 def test_build_query(add_languages):
     rec = {
         'title': 'magic',
-        'languages': ['eng', 'fre'],
+        'languages': ['ENG', 'fre'],
         'translated_from': ['yid'],
         'authors': [{'name': 'Surname, Forename'}],
         'description': 'test',


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9482
Related #9480

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR normalizes the language code[s] on import via `load()`.

### Technical
<!-- What should be noted about the implementation? -->
This just ensures the language code is lower case, even if the incoming `rec` has a language code that is not lower case.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Without the PR, try to import something with an all-caps language code, such as this IA item: [270b51a0-d993-4be6-ae92-d3bb06a68955](https://archive.org/metadata/270b51a0-d993-4be6-ae92-d3bb06a68955/metadata/language)
```
❯ curl -X POST "http://localhost:8080/api/import/ia" \
     -b ~/cookies.txt \
     -d "identifier=270b51a0-d993-4be6-ae92-d3bb06a68955&require_marc=false"
{"success": false, "error": "invalid language code: 'ENG'"}
```

Try again with the PR:
```
❯ curl -X POST "http://localhost:8080/api/import/ia" \
     -b ~/cookies.txt \
     -d "identifier=270b51a0-d993-4be6-ae92-d3bb06a68955&require_marc=false"
{"authors": [{"key": "/authors/OL14A", "name": "Love Ekenberg", "status": "created"}], "success": true, "edition": {"key": "/books/OL26M", "status": "created"}, "work": {"key": "/works/OL10W", "status": "created"}}
```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/internetarchive/openlibrary/assets/26524678/ba5d0176-731e-43d5-b6b5-8d6695ae1dad)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
