### PR TITLE
Fix: renable autocomplete in searchbox

### DIFF
--- a/openlibrary/templates/search/searchbox.html
+++ b/openlibrary/templates/search/searchbox.html
@@ -1,6 +1,6 @@
 $def with (q)
 <div class="searchbox">
-    <input type="text" class="searchbox__input" name="q" size="100" placeholder="$_('Search')" aria-label="$_('Search')" autocomplete="off" value="$q">
+    <input type="text" class="searchbox__input" name="q" size="100" placeholder="$_('Search')" aria-label="$_('Search')" value="$q">
     <div>
         <input type="submit" value="" class="searchbox__btn-icon" aria-label="$_('Search')">
     </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9492

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This re-enables autocomplete in the searchbox.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@seabelis 
@cdrini 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
