### PR TITLE
Add new dismissible banner to site

### DIFF
--- a/openlibrary/templates/site/body.html
+++ b/openlibrary/templates/site/body.html
@@ -31,9 +31,9 @@ $if show_ol_shell and (ctx.path.startswith('/works/OL') or ctx.path.startswith('
       </div>
       $# Announcement banner will only be rendered if announcement and storage_key variables are set.
       $# Be sure to escape any single quotes inside of the announcement HTML string.
-      $ announcement = ''
+      $ announcement = 'We’re fighting to restore access to 500,000+ books in court this week. <a class="btn primary" href="https://blog.archive.org/2024/06/26/were-fighting-for-library-rights-in-court-this-friday-join-us/">Join us</a>'
       $# Include date in cookie name to avoid name collisions (something like '{prefix}{YY}{MM}{DD}' would work well)
-      $ cookie_name = ''
+      $ cookie_name = 'cta240626'
       $if announcement and cookie_name:
         $:render_template('site/banner', announcement, cookie_name, cookie_duration_days=30)
     $:page


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds a new dismissible banner to the site.  Cookie name for the banner's visibility settings is `cta240626` (short for "call to action" plus the current date).

This may need an `data-ol-link-track` attribute for Plausible.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/internetarchive/openlibrary/assets/28732543/13f220db-d5d1-4e46-b624-56ae4e567846)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
