### PR TITLE
Fix: `decode_ip.sh` returns more quickly and listens on port 443

### DIFF
--- a/scripts/decode_ip.sh
+++ b/scripts/decode_ip.sh
@@ -14,9 +14,10 @@ INTERFACE="eth0"
 MAX_RETRIES=60
 EXIT_FLAG=false
 TCPDUMP_PID=""
-MKTABLE_PATH="./obfi/mktable.py"
-REVEAL_PATH="./obfi/reveal.py"
-SHOWNAMES_PATH="./obfi/shownames.py"
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+MKTABLE_PATH="$SCRIPT_DIR/obfi/mktable.py"
+REVEAL_PATH="$SCRIPT_DIR/obfi/reveal.py"
+SHOWNAMES_PATH="$SCRIPT_DIR/obfi/shownames.py"
 
 # Function to print usage information
 usage() {
@@ -44,7 +45,6 @@ cleanup() {
   printf "\nCleaning up before exit\n"
   if [ -n "$TCPDUMP_PID" ]; then
     kill "$TCPDUMP_PID"
-    wait "$TCPDUMP_PID"
   fi
 
   find "$REAL_IP_MAP_DIR" -name "$MAP_PATTERN" -type f -mmin +60 -exec rm {} \;
@@ -62,13 +62,15 @@ trap handle_interrupt INT
 
 # Start tcpdump and send packets to mktable for processing
 start_tcpdump() {
-  tcpdump -i "$INTERFACE" -n dst port 80 | "$MKTABLE_PATH"
+  tcpdump -i "$INTERFACE" -n \(dst port 80 or dst port 443\) | "$MKTABLE_PATH"
 }
+
 
 # Start tcpdump in the background and send packets to mktable for processing
 start_tcpdump_background() {
-  nohup tcpdump -i "$INTERFACE" -n dst port 80 2>/dev/null | "$MKTABLE_PATH" > /dev/null 2>&1 &
+  nohup tcpdump -i "$INTERFACE" -n \(dst port 80 or dst port 443\) 2>/dev/null | "$MKTABLE_PATH" > /dev/null 2>&1 &
   TCPDUMP_PID=$!
+  sleep 1
 }
 
 # Search for an obfuscated IP in the mktable database.


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9478

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
The `dbm.ndbm` module doesn't flush very often, resulting in sometimes long waits for decoding an IP. These changes flush the database (by closing it and opening it, as there is no flush method) every 10 IPs.

Additionally, it has `tcpdump` listen on port 443, in addition to port 80.

Finally, there is a small fix for a race condition where the script would sometimes try to access the database file before it had been created.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Get an obfuscated IP (e.g. from tailing `/1/var/log/nginx/access.log`, and then, assuming `$SEED_PATH` has been exported, run `sudo -E decode_ip.sh <obfuscated IP here>` on it.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
