### PR TITLE
Update `i18n` warn regex and escape relevant files

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -5474,7 +5474,7 @@ msgid ""
 "href=\"%(url)s\">everything</a> by this author?"
 msgstr ""
 
-#: type/author/view.html
+#: Profile.html type/author/view.html
 msgid "Time"
 msgstr ""
 
@@ -6083,6 +6083,12 @@ msgstr ""
 msgid "Preview Book"
 msgstr ""
 
+#: DisplayCode.html
+msgid ""
+"Templates in the website are disabled now. Editing them will not have any"
+" effect on the live website."
+msgstr ""
+
 #: DonateModal.html
 msgid ""
 "Donate this book to the <a href=\"https://archive.org\">Internet "
@@ -6255,6 +6261,10 @@ msgstr ""
 
 #: Pager.html Pager_loanhistory.html
 msgid "First"
+msgstr ""
+
+#: Profile.html
+msgid "Component"
 msgstr ""
 
 #: ReadButton.html

--- a/openlibrary/macros/DisplayCode.html
+++ b/openlibrary/macros/DisplayCode.html
@@ -11,6 +11,7 @@ $def splitlines(text):
     <tr>
     <td>
     <pre>\
+    $# detect-missing-i18n-skip-line
     $for i in range(n): <span rel="#L$(i+1)">$("%4d" % (i+1))</span>
     </pre>
     </td>
@@ -20,7 +21,7 @@ $def splitlines(text):
     </table>
 
 <div class="contenttext">
-<div class="red" style="background-color: white; padding: 20px;">Templates in the website are disabled now. Editing them will not have any effect on the live website.</div>
+<div class="red" style="background-color: white; padding: 20px;">$_("Templates in the website are disabled now. Editing them will not have any effect on the live website.")</div>
 
 $:splitlines(code)
 </div>

--- a/openlibrary/macros/Profile.html
+++ b/openlibrary/macros/Profile.html
@@ -3,8 +3,8 @@ $def with (component_times)
 <table>
   <thead>
     <tr>
-      <th>Component</th>
-      <th>Time</th>
+      <th>$_("Component")</th>
+      <th>$_("Time")</th>
       <th>%</th>
     </tr>
   </thead>
@@ -12,7 +12,9 @@ $def with (component_times)
     $for component in sorted(component_times.items(), key=lambda x: x[1]):
       <tr>
         <td>$component[0]</td>
+        $# detect-missing-i18n-skip-line
         <td>$("%.2f" % component[1])</td>
+        $# detect-missing-i18n-skip-line
         <td>$("%.2f" % (component[1] / component_times['TotalTime'] * 100.))</td>
       </tr>
   </tbody>

--- a/openlibrary/templates/admin/index.html
+++ b/openlibrary/templates/admin/index.html
@@ -57,7 +57,9 @@ $ stats = get_admin_stats()
           <td class="type">$_("Total")</td>
           <td class="amount">$commify(counts.bot_edits.latest + counts.human_edits.latest)</td>
           <td class="amount">$commify(counts.bot_edits.previous + counts.human_edits.previous)</td>
+          $# detect-missing-i18n-skip-line
           <td class="amount">$commify(counts.bot_edits.get_summary(7) + counts.human_edits.get_summary(7))</td>
+          $# detect-missing-i18n-skip-line
           <td class="amount">$commify(counts.bot_edits.get_summary(28) + counts.human_edits.get_summary(28))</td>
         </tr>
       </tbody>

--- a/scripts/detect_missing_i18n.py
+++ b/scripts/detect_missing_i18n.py
@@ -11,9 +11,7 @@ import glob
 # This is a list of files that had pre-existing i18n errors/warnings at the time this script was created.
 # Chip away at these and remove them from the exclude list (except where otherwise noted).
 EXCLUDE_LIST = {
-    "openlibrary/admin/templates/admin/index.html",
     "openlibrary/templates/design.html",
-    "openlibrary/templates/diff.html",
     "openlibrary/templates/internalerror.html",
     "openlibrary/templates/login.html",
     "openlibrary/templates/permission_denied.html",
@@ -23,18 +21,15 @@ EXCLUDE_LIST = {
     "openlibrary/templates/showia.html",
     "openlibrary/templates/subjects.html",
     "openlibrary/templates/about/index.html",
-    "openlibrary/templates/account/create.html",
     "openlibrary/templates/account/import.html",
     "openlibrary/templates/account/readinglog_stats.html",
     "openlibrary/templates/account/email/forgot.html",
-    "openlibrary/templates/account/sidebar.html",
     "openlibrary/templates/admin/attach_debugger.html",
     "openlibrary/templates/admin/block.html",
     "openlibrary/templates/admin/graphs.html",
     "openlibrary/templates/admin/history.html",
     "openlibrary/templates/admin/imports.html",
     "openlibrary/templates/admin/imports_by_date.html",
-    "openlibrary/templates/admin/index.html",
     "openlibrary/templates/admin/loans.html",
     "openlibrary/templates/admin/loans_table.html",
     "openlibrary/templates/admin/solr.html",
@@ -50,16 +45,13 @@ EXCLUDE_LIST = {
     "openlibrary/templates/admin/people/view.html",
     "openlibrary/templates/books/add.html",
     "openlibrary/templates/books/custom_carousel.html",
-    "openlibrary/templates/books/edit.html",
     "openlibrary/templates/books/mobile_carousel.html",
     "openlibrary/templates/books/works-show.html",
     "openlibrary/templates/books/edit/edition.html",
     "openlibrary/templates/books/edit/web.html",
-    "openlibrary/templates/check_ins/check_in_form.html",
     "openlibrary/templates/contact/spam/sent.html",
     "openlibrary/templates/covers/add.html",
     "openlibrary/templates/email/case_created.html",
-    "openlibrary/templates/history/sources.html",
     "openlibrary/templates/home/loans.html",
     "openlibrary/templates/home/popular.html",
     "openlibrary/templates/home/returncart.html",
@@ -68,11 +60,9 @@ EXCLUDE_LIST = {
     "openlibrary/templates/languages/index.html",
     "openlibrary/templates/languages/language_list.html",
     "openlibrary/templates/lib/history.html",
-    "openlibrary/templates/lib/header_dropdown.html",
     "openlibrary/templates/lib/nav_foot.html",
     "openlibrary/templates/lists/export_as_html.html",
     "openlibrary/templates/lists/feed_updates.html",
-    "openlibrary/templates/lists/list_overview.html",
     "openlibrary/templates/lists/widget.html",
     "openlibrary/templates/my_books/dropdown_content.html",
     "openlibrary/templates/my_books/primary_action.html",
@@ -88,7 +78,6 @@ EXCLUDE_LIST = {
     "openlibrary/templates/recentchanges/merge/path.html",
     "openlibrary/templates/recentchanges/undo/view.html",
     "openlibrary/templates/search/snippets.html",
-    "openlibrary/templates/search/work_search_facets.html",
     "openlibrary/templates/site/alert.html",
     "openlibrary/templates/site/stats.html",
     "openlibrary/templates/type/about/view.html",
@@ -100,21 +89,16 @@ EXCLUDE_LIST = {
     "openlibrary/templates/type/list/edit.html",
     "openlibrary/templates/type/list/exports.html",
     "openlibrary/templates/type/local_id/view.html",
-    "openlibrary/templates/type/object/view.html",
     "openlibrary/templates/type/page/view.html",
     "openlibrary/templates/type/template/edit.html",
     "openlibrary/templates/type/template/view.html",
     "openlibrary/templates/type/type/view.html",
     "openlibrary/templates/type/work/editions_datatable.html",
     "openlibrary/templates/type/work/view.html",
-    "openlibrary/macros/databarView.html",
-    "openlibrary/macros/DisplayCode.html",
     "openlibrary/macros/FulltextSnippet.html",
     "openlibrary/macros/IABook.html",
     "openlibrary/macros/ManageLoansButtons.html",
     "openlibrary/macros/ManageWaitlistButton.html",
-    "openlibrary/macros/NotesModal.html",
-    "openlibrary/macros/Profile.html",
     "openlibrary/macros/QueryCarousel.html",
     "openlibrary/macros/RecentChangesAdmin.html",
     "openlibrary/macros/RecentChangesUsers.html",
@@ -123,6 +107,11 @@ EXCLUDE_LIST = {
     "openlibrary/macros/WorldcatLink.html",
     "openlibrary/macros/databarWork.html",
     "openlibrary/macros/WorkInfo.html",
+    # These are excluded because they require more info to fix
+    "openlibrary/templates/books/edit.html",
+    "openlibrary/templates/history/sources.html",
+    # This can't be fixed because it's not in the i18n directories
+    "openlibrary/admin/templates/admin/index.html",
     # These can't be fixed since they're rendered as static html
     "static/offline.html",
     "static/status-500.html",
@@ -166,7 +155,7 @@ ignore_after_opening_tag = (
 )
 
 i18n_element_missing_regex = opening_tag_syntax + ignore_after_opening_tag
-i18n_element_warn_regex = opening_tag_syntax + r"\$\((?!_\()"
+i18n_element_warn_regex = opening_tag_syntax + r"\$\(['\"]"
 
 attr_syntax = r"(title|placeholder|alt)="
 ignore_double_quote = (
@@ -197,7 +186,7 @@ i18n_attr_missing_regex = (
     + ignore_single_quote
     + r")[^>]*?>"
 )
-i18n_attr_warn_regex = opening_tag_open + attr_syntax + r"['\"]\$\((?!_\()"
+i18n_attr_warn_regex = opening_tag_open + attr_syntax + r"\"\$\(\'"
 
 
 def terminal_underline(text: str) -> str:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Sub-task of #9486. 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix. Adjusts the `i18n` `WARN` syntax to only flag text wrapped in `$(' ')` or `$(" ")`, the chosen syntax for intentionally untranslated text. This way, we avoid flagging Python insertions wrapped in parentheses, and can remove a number of files from the exclude list.

### Technical
<!-- What should be noted about the implementation? -->
Also involved adding the `skip_directive` to escape a few last Python lines still accidentally caught by the script.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Add a new line of Python into an HTML file wrapping it in the following: `$( )`
2. Run the script with `pre-commit run detect-missing-i18n --all-files`, you should not see a warning appear
3. Change existing `i18n` syntax or add a new line you think shouldn't be translated, using the preferred warning syntax, i.e. `$('https://www.google.com')`
4. Run the script again, the script should still pass but a warning will appear

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles @pidgezero-one 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
