### PR TITLE
`i18n` syntax additions with variables

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -1265,7 +1265,7 @@ msgstr[1] ""
 msgid "You have less than an hour to borrow it."
 msgstr ""
 
-#: ManageWaitlistButton.html account/loans.html
+#: account/loans.html
 #, python-format
 msgid "You have one more hour to borrow it."
 msgid_plural "You have %(hours)d more hours to borrow it."
@@ -1927,7 +1927,7 @@ msgstr ""
 
 #: admin/attach_debugger.html
 #, python-format
-msgid "Attach Debugger on Python %(version_number)d"
+msgid "Attach Debugger on Python %(version_number)s"
 msgstr ""
 
 #: admin/attach_debugger.html
@@ -2689,7 +2689,7 @@ msgstr ""
 #, python-format
 msgid ""
 "Activated on <span class=\"time\">%(date)s</span> from <a "
-"href=\"/admin/ip/$v.ip\">%(ip)s</a>."
+"href=\"/admin/ip/%(ip)s\">%(ip)s</a>."
 msgstr ""
 
 #: admin/people/view.html
@@ -4580,7 +4580,7 @@ msgstr ""
 
 #: jsdef/LazyWorkPreview.html
 #, python-format
-msgid "One edition"
+msgid "%(count)d edition"
 msgid_plural "%(count)d editions"
 msgstr[0] ""
 msgstr[1] ""
@@ -7078,8 +7078,10 @@ msgstr[1] ""
 
 #: ManageWaitlistButton.html
 #, python-format
-msgid "You have %(count)d more hours to borrow it."
-msgstr ""
+msgid "You have %(count)d more hour to borrow it."
+msgid_plural "You have %(count)d more hours to borrow it."
+msgstr[0] ""
+msgstr[1] ""
 
 #: NotesModal.html
 msgid "My Book Notes"

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -592,7 +592,7 @@ msgid "Name"
 msgstr ""
 
 #: account/loans.html admin/imports_by_date.html admin/loans_table.html
-#: admin/menu.html status.html
+#: admin/menu.html admin/sponsorship.html status.html
 msgid "Status"
 msgstr ""
 
@@ -607,8 +607,9 @@ msgstr ""
 msgid "Places"
 msgstr ""
 
-#: SubjectTags.html admin/menu.html admin/people/index.html subjects.html
-#: type/author/view.html type/list/view_body.html work_search.html
+#: SubjectTags.html admin/menu.html admin/people/index.html
+#: admin/people/view.html subjects.html type/author/view.html
+#: type/list/view_body.html work_search.html
 msgid "People"
 msgstr ""
 
@@ -920,8 +921,8 @@ msgstr ""
 msgid "First published"
 msgstr ""
 
-#: search/advancedsearch.html type/edition/view.html type/work/view.html
-#: work_search.html
+#: publishers/view.html search/advancedsearch.html type/edition/view.html
+#: type/work/view.html work_search.html
 msgid "Publisher"
 msgstr ""
 
@@ -1022,6 +1023,11 @@ msgstr[1] ""
 
 #: work_search.html
 msgid "BARF! Search engine ERROR!"
+msgstr ""
+
+#: work_search.html
+#, python-format
+msgid "Searching solr took %(count)s seconds"
 msgstr ""
 
 #: about/index.html
@@ -1203,11 +1209,11 @@ msgid_plural "There are %(count)d people waiting for this book."
 msgstr[0] ""
 msgstr[1] ""
 
-#: account/loans.html
+#: ManageLoansButtons.html account/loans.html
 msgid "Not yet downloaded."
 msgstr ""
 
-#: account/loans.html
+#: ManageLoansButtons.html account/loans.html
 msgid "Download Now"
 msgstr ""
 
@@ -1255,22 +1261,22 @@ msgid_plural "There are %(count)d people ahead of you in the waiting list."
 msgstr[0] ""
 msgstr[1] ""
 
-#: account/loans.html
+#: ManageWaitlistButton.html account/loans.html
 msgid "You have less than an hour to borrow it."
 msgstr ""
 
-#: account/loans.html
+#: ManageWaitlistButton.html account/loans.html
 #, python-format
 msgid "You have one more hour to borrow it."
 msgid_plural "You have %(hours)d more hours to borrow it."
 msgstr[0] ""
 msgstr[1] ""
 
-#: account/loans.html
+#: ManageWaitlistButton.html account/loans.html
 msgid "Borrow Now"
 msgstr ""
 
-#: account/loans.html
+#: ManageWaitlistButton.html account/loans.html
 msgid "Leave the waiting list?"
 msgstr ""
 
@@ -1394,12 +1400,12 @@ msgstr ""
 msgid "Title Missing"
 msgstr ""
 
-#: account/notes.html type/work/editions.html
+#: account/notes.html lists/export_as_html.html type/work/editions.html
 msgid "Publish date unknown"
 msgstr ""
 
 #: account/notes.html books/edition-sort.html books/works-show.html
-#: type/work/editions.html
+#: lists/export_as_html.html type/work/editions.html
 msgid "Publisher unknown"
 msgstr ""
 
@@ -1448,7 +1454,7 @@ msgid "Yes! Please!"
 msgstr ""
 
 #: EditButtons.html account/notifications.html account/privacy.html
-#: covers/manage.html
+#: admin/block.html covers/manage.html
 msgid "Save"
 msgstr ""
 
@@ -1489,11 +1495,11 @@ msgid ""
 "or have already read. Public accounts can be seen and followed by others."
 msgstr ""
 
-#: account/privacy.html
+#: account/privacy.html admin/people/view.html
 msgid "Yes"
 msgstr ""
 
-#: account/privacy.html books/edit/edition.html
+#: account/privacy.html admin/people/view.html books/edit/edition.html
 msgid "No"
 msgstr ""
 
@@ -1624,7 +1630,12 @@ msgstr ""
 msgid "My %(shelf_name)s Stats"
 msgstr ""
 
-#: account/readinglog_stats.html lib/nav_head.html
+#: SearchResultsWork.html account/readinglog_stats.html type/work/editions.html
+#, python-format
+msgid "First published in %(year)s"
+msgstr ""
+
+#: account/readinglog_stats.html home/loans.html lib/nav_head.html
 msgid "My Books"
 msgstr ""
 
@@ -1915,11 +1926,31 @@ msgid "Attach Debugger"
 msgstr ""
 
 #: admin/attach_debugger.html
+#, python-format
+msgid "Attach Debugger on Python %(version_number)d"
+msgstr ""
+
+#: admin/attach_debugger.html
+msgid "Start a debugger on port 3000."
+msgstr ""
+
+#: admin/attach_debugger.html
 msgid "Waiting for debugger to attach..."
 msgstr ""
 
 #: admin/attach_debugger.html
 msgid "Start"
+msgstr ""
+
+#: admin/block.html
+msgid "Block IP address"
+msgstr ""
+
+#: admin/block.html
+#, python-format
+msgid ""
+"IP address %(address)s has been added to the textarea. Please click Save "
+"to block that IP."
 msgstr ""
 
 #: admin/graphs.html
@@ -2175,6 +2206,10 @@ msgid "ePub"
 msgstr ""
 
 #: admin/loans_table.html
+msgid "No current loans."
+msgstr ""
+
+#: admin/loans_table.html
 #, python-format
 msgid "%d Current Loan"
 msgid_plural "%d Current Loans"
@@ -2185,6 +2220,21 @@ msgstr[1] ""
 #: admin/loans_table.html admin/people/edits.html recentchanges/render.html
 #: recentchanges/updated_records.html
 msgid "What"
+msgstr ""
+
+#: admin/loans_table.html
+#, python-format
+msgid "Waiting since %(date)s"
+msgstr ""
+
+#: admin/loans_table.html
+#, python-format
+msgid "#%(num_position)d among %(num_waitlist)d people waiting for this book"
+msgstr ""
+
+#: ManageLoansButtons.html admin/loans_table.html
+#, python-format
+msgid "Borrowed %(date)s"
 msgstr ""
 
 #: admin/menu.html
@@ -2294,6 +2344,101 @@ msgstr ""
 
 #: admin/spamwords.html
 msgid "[Admin Center] Spam Words"
+msgstr ""
+
+#: admin/sponsorship.html
+msgid "Book Sponsorship"
+msgstr ""
+
+#: admin/sponsorship.html
+#, python-format
+msgid "We've sponsored <strong>%(num)d</strong> books"
+msgstr ""
+
+#: admin/sponsorship.html
+msgid "Internet Archive Revenue"
+msgstr ""
+
+#: admin/sponsorship.html
+msgid "Better World Books Revenue"
+msgstr ""
+
+#: admin/sponsorship.html
+msgid "Book Costs"
+msgstr ""
+
+#: admin/sponsorship.html
+msgid "Est. Book Costs"
+msgstr ""
+
+#: admin/sponsorship.html
+msgid "Δ Book Costs"
+msgstr ""
+
+#: admin/sponsorship.html
+msgid "Scanning Costs"
+msgstr ""
+
+#: admin/sponsorship.html
+msgid "Est. Scanning Costs"
+msgstr ""
+
+#: admin/sponsorship.html
+msgid "Δ Scanning Costs"
+msgstr ""
+
+#: admin/sponsorship.html
+msgid "Profit/Los"
+msgstr ""
+
+#: admin/sponsorship.html
+msgid "Total Unscanned Books"
+msgstr ""
+
+#: admin/sponsorship.html
+msgid "Print Slips"
+msgstr ""
+
+#: admin/sponsorship.html
+msgid "Average Scan Cost"
+msgstr ""
+
+#: admin/sponsorship.html
+msgid "Est. Remaining Scanning Liability"
+msgstr ""
+
+#: admin/sponsorship.html
+msgid "Projected Profit/Loss"
+msgstr ""
+
+#: admin/sponsorship.html
+msgid "Cover"
+msgstr ""
+
+#: admin/sponsorship.html
+msgid "Sponsor Date"
+msgstr ""
+
+#: admin/sponsorship.html
+msgid "IDs"
+msgstr ""
+
+#: admin/sponsorship.html books/add.html books/edit.html
+#: books/edit/edition.html lib/nav_head.html search/advancedsearch.html
+#: type/about/edit.html type/page/edit.html type/template/edit.html
+msgid "Title"
+msgstr ""
+
+#: admin/sponsorship.html
+msgid "Donor"
+msgstr ""
+
+#: admin/sponsorship.html
+msgid "Edit XML"
+msgstr ""
+
+#: admin/sponsorship.html
+msgid "BWB Link"
 msgstr ""
 
 #: admin/inspect/memcache.html
@@ -2519,12 +2664,81 @@ msgstr ""
 msgid "Edit History"
 msgstr ""
 
+#: admin/people/view.html
+msgid "block and revert all edits"
+msgstr ""
+
+#: admin/people/view.html
+msgid "block this account"
+msgstr ""
+
+#: admin/people/view.html
+msgid "send password reset email"
+msgstr ""
+
+#: admin/people/view.html
+#, python-format
+msgid "Registered on <span class=\"time\">%(date)s</span>."
+msgstr ""
+
+#: admin/people/view.html
+msgid "login as this user"
+msgstr ""
+
+#: admin/people/view.html
+#, python-format
+msgid ""
+"Activated on <span class=\"time\">%(date)s</span> from <a "
+"href=\"/admin/ip/$v.ip\">%(ip)s</a>."
+msgstr ""
+
+#: admin/people/view.html
+msgid "unblock this account"
+msgstr ""
+
+#: admin/people/view.html
+msgid "activate account"
+msgstr ""
+
+#: admin/people/view.html
+#, python-format
+msgid "Activation link expiring on <span class=\"time\">%(date)s.</span>"
+msgstr ""
+
+#: admin/people/view.html
+msgid "Activation link expired"
+msgstr ""
+
+#: admin/people/view.html
+msgid "Resend activation link"
+msgstr ""
+
 #: CreateListModal.html admin/people/view.html my_books/dropdown_content.html
 msgid "Name:"
 msgstr ""
 
 #: admin/people/view.html
+msgid "view profile"
+msgstr ""
+
+#: admin/people/view.html
+msgid "Change"
+msgstr ""
+
+#: admin/people/view.html
 msgid "Admin"
+msgstr ""
+
+#: admin/people/view.html
+msgid "Make Human"
+msgstr ""
+
+#: admin/people/view.html
+msgid "Make Bot"
+msgstr ""
+
+#: admin/people/view.html
+msgid "Not available"
 msgstr ""
 
 #: admin/people/view.html
@@ -2548,7 +2762,15 @@ msgid "Anonymize Account:"
 msgstr ""
 
 #: admin/people/view.html
+msgid "Dry Run"
+msgstr ""
+
+#: admin/people/view.html
 msgid "Anonymize Account"
+msgstr ""
+
+#: admin/people/view.html
+msgid "Account not activated yet."
 msgstr ""
 
 #: admin/people/view.html
@@ -2556,7 +2778,24 @@ msgid "Waiting Loans"
 msgstr ""
 
 #: admin/people/view.html
+#, python-format
+msgid "%(num)d edits"
+msgstr ""
+
+#: admin/people/view.html
 msgid "Debug Info"
+msgstr ""
+
+#: admin/people/view.html
+msgid "Account Information"
+msgstr ""
+
+#: admin/people/view.html
+msgid "Verifications Links"
+msgstr ""
+
+#: admin/people/view.html
+msgid "None found"
 msgstr ""
 
 #: SearchNavigation.html authors/index.html lib/nav_foot.html
@@ -2851,12 +3090,6 @@ msgstr ""
 msgid ""
 "We require a minimum set of fields to create a new record. These are "
 "those fields."
-msgstr ""
-
-#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html
-#: search/advancedsearch.html type/about/edit.html type/page/edit.html
-#: type/template/edit.html
-msgid "Title"
 msgstr ""
 
 #: books/add.html books/edit.html
@@ -4171,6 +4404,23 @@ msgstr ""
 msgid "Textbooks"
 msgstr ""
 
+#: home/loans.html
+#, python-format
+msgid ""
+"You can still <a href=\"/borrow\">borrow</a> one more book until you've "
+"hit the limit!"
+msgid_plural ""
+"You can still <a href=\"/borrow\">borrow</a> %(count)d more books until "
+"you've hit the limit!"
+msgstr[0] ""
+msgstr[1] ""
+
+#: home/loans.html
+msgid ""
+"You have reached the borrowing limit. Please return a book to checkout "
+"something new."
+msgstr ""
+
 #: home/stats.html site/around_the_library.html
 msgid "Around the Library"
 msgstr ""
@@ -4296,6 +4546,44 @@ msgstr ""
 #: home/welcome.html
 msgid "Your feedback will help us improve these cards"
 msgstr ""
+
+#: jsdef/LazyAuthorPreview.html
+msgid "Select this author"
+msgstr ""
+
+#: jsdef/LazyAuthorPreview.html
+#, python-format
+msgid "No books associated with %(author)s"
+msgstr ""
+
+#: jsdef/LazyAuthorPreview.html
+#, python-format
+msgid ""
+"<span class=\"books\">One book</span> <span class=\"work\">titled "
+"<i>%(title)s</i></span>"
+msgstr ""
+
+#: jsdef/LazyAuthorPreview.html
+#, python-format
+msgid ""
+"<span class=\"books\">%(count)d books</span> <span "
+"class=\"work\">including <i>%(title)s</i></span>"
+msgstr ""
+
+#: jsdef/LazyAuthorPreview.html
+msgid "Subjects:"
+msgstr ""
+
+#: jsdef/LazyWorkPreview.html
+msgid "Select this work"
+msgstr ""
+
+#: jsdef/LazyWorkPreview.html
+#, python-format
+msgid "One edition"
+msgid_plural "%(count)d editions"
+msgstr[0] ""
+msgstr[1] ""
 
 #: languages/index.html
 #, python-format
@@ -4728,7 +5016,7 @@ msgstr ""
 msgid "My Open Library"
 msgstr ""
 
-#: lib/nav_head.html
+#: databarWork.html lib/nav_head.html
 msgid "Browse"
 msgstr ""
 
@@ -4768,6 +5056,27 @@ msgstr ""
 
 #: Pager.html Pager_loanhistory.html lib/pagination.html
 msgid "Previous"
+msgstr ""
+
+#: lists/export_as_html.html
+#, python-format
+msgid "%(list)s - Editions"
+msgstr ""
+
+#: lists/export_as_html.html type/list/embed.html type/list/view_body.html
+msgid "Unknown authors"
+msgstr ""
+
+#: lists/export_as_html.html
+msgid "Title unknown"
+msgstr ""
+
+#: lists/export_as_html.html
+msgid "First publish date unknown"
+msgstr ""
+
+#: lists/export_as_html.html
+msgid "Name unknown"
 msgstr ""
 
 #: lists/header.html
@@ -5294,6 +5603,10 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: publishers/view.html
+msgid "0 ebooks"
+msgstr ""
+
+#: publishers/view.html
 msgid ""
 "This is a chart to show the when this publisher published books. Along "
 "the X axis is time, and on the y axis is the count of editions published."
@@ -5308,6 +5621,11 @@ msgstr ""
 
 #: publishers/view.html
 msgid "Common Subjects"
+msgstr ""
+
+#: publishers/view.html
+#, python-format
+msgid "Search for books published by %(publisher)s"
 msgstr ""
 
 #: publishers/view.html
@@ -5373,7 +5691,17 @@ msgid "Review what's changed from the previous revision"
 msgstr ""
 
 #: recentchanges/default/view.html recentchanges/merge/view.html
+#: recentchanges/undo/view.html
 msgid "Updated Records"
+msgstr ""
+
+#: recentchanges/merge/comment.html
+#, python-format
+msgid "Merged duplicate %(record_type)s records."
+msgstr ""
+
+#: recentchanges/merge/comment.html
+msgid "See <a href=\"\">details</a>."
 msgstr ""
 
 #: recentchanges/merge/comment.html
@@ -5382,6 +5710,15 @@ msgid "Merged %(count)d duplicate %(type)s record into this primary."
 msgid_plural "Merged %(count)d duplicate %(type)s records into this primary."
 msgstr[0] ""
 msgstr[1] ""
+
+#: recentchanges/merge/comment.html
+msgid "Marked as duplicate."
+msgstr ""
+
+#: recentchanges/merge/comment.html
+#, python-format
+msgid "Merged %(page_type)s into primary %(record_type) record."
+msgstr ""
 
 #: recentchanges/merge/message.html
 #, python-format
@@ -5415,6 +5752,16 @@ msgid "%(count)d record modified."
 msgid_plural "%(count)d records modified."
 msgstr[0] ""
 msgstr[1] ""
+
+#: recentchanges/undo/view.html
+#, python-format
+msgid "Undo of <a href=\"$parent.url()\">%(kind)s</a>."
+msgstr ""
+
+#: recentchanges/undo/view.html
+#, python-format
+msgid "%(count)d records modified."
+msgstr ""
 
 #: search/advancedsearch.html
 msgid "ISBN"
@@ -5463,6 +5810,7 @@ msgid "Search Open Library for %s"
 msgstr ""
 
 #: BookSearchInside.html SearchNavigation.html search/inside.html
+#: search/snippets.html
 msgid "Search Inside"
 msgstr ""
 
@@ -5495,6 +5843,11 @@ msgstr ""
 
 #: search/publishers.html
 msgid "Publishers Search"
+msgstr ""
+
+#: search/snippets.html
+#, python-format
+msgid "On leaf number %(page_num)d:"
 msgstr ""
 
 #: search/sort_options.html
@@ -5905,6 +6258,11 @@ msgid ""
 "href=\"%(url)s\">everything</a> by this author?"
 msgstr ""
 
+#: type/author/view.html
+#, python-format
+msgid "Search %(author)s Books"
+msgstr ""
+
 #: Profile.html type/author/view.html
 msgid "Time"
 msgstr ""
@@ -5915,6 +6273,10 @@ msgstr ""
 
 #: type/author/view.html
 msgid "Links <span class=\"gray small sansserif\">(outside Open Library)"
+msgstr ""
+
+#: type/author/view.html type/edition/view.html type/work/view.html
+msgid "Wikipedia"
 msgstr ""
 
 #: type/author/view.html
@@ -6114,10 +6476,6 @@ msgid "Links <span class=\"gray small sansserif\">outside Open Library</span>"
 msgstr ""
 
 #: type/edition/view.html type/work/view.html
-msgid "Wikipedia"
-msgstr ""
-
-#: type/edition/view.html type/work/view.html
 msgid "This work does not appear on any lists."
 msgstr ""
 
@@ -6175,10 +6533,6 @@ msgstr ""
 
 #: type/list/embed.html
 msgid "Visit Open Library"
-msgstr ""
-
-#: type/list/embed.html type/list/view_body.html
-msgid "Unknown authors"
 msgstr ""
 
 #: type/list/embed.html
@@ -6467,11 +6821,6 @@ msgstr ""
 msgid "Members:"
 msgstr ""
 
-#: SearchResultsWork.html type/work/editions.html
-#, python-format
-msgid "First published in %(year)s"
-msgstr ""
-
 #: type/work/editions.html type/work/editions_datatable.html
 #, python-format
 msgid "Add another edition of %(work)s"
@@ -6726,6 +7075,11 @@ msgid "Waiting for %d day"
 msgid_plural "Waiting for %d days"
 msgstr[0] ""
 msgstr[1] ""
+
+#: ManageWaitlistButton.html
+#, python-format
+msgid "You have %(count)d more hours to borrow it."
+msgstr ""
 
 #: NotesModal.html
 msgid "My Book Notes"
@@ -7032,6 +7386,11 @@ msgstr ""
 
 #: databarTemplate.html
 msgid "Edit this template"
+msgstr ""
+
+#: databarWork.html
+#, python-format
+msgid "View Volume %(num)d"
 msgstr ""
 
 #: databarWork.html

--- a/openlibrary/macros/ManageLoansButtons.html
+++ b/openlibrary/macros/ManageLoansButtons.html
@@ -1,7 +1,7 @@
 $def with (loan, book)
 
 <div data-userid="$(loan['userid'])">
-  Borrowed $datestr(datetime_from_utc_timestamp(loan['loaned_at']))
+  $_('Borrowed %(date)s', date=datestr(datetime_from_utc_timestamp(loan['loaned_at'])))
 </div>
 $ wlsize = book.get_waitinglist_size()
 $if wlsize:
@@ -12,8 +12,8 @@ $if wlsize:
 <div>
     $if loan['expiry'] is None:
         $# Not yet fulfilled
-        <span class="red">Not yet downloaded. </span><br/>
-        <a href="$loan['loan_link']">Download Now</a>
+        <span class="red">$_("Not yet downloaded.") </span><br/>
+        <a href="$loan['loan_link']">$_("Download Now")</a>
     $else:
         $:macros.FormatExpiry(loan['expiry'])
 </div>

--- a/openlibrary/macros/ManageWaitlistButton.html
+++ b/openlibrary/macros/ManageWaitlistButton.html
@@ -24,10 +24,8 @@ $if status == "waiting":
     <div class="smaller" style="padding-top: 5px;">
       $if delta_hours == 0:
         $_("You have less than an hour to borrow it.")
-      $elif delta_hours == 1:
-        $_("You have one more hour to borrow it.")
       $else:
-       $_('You have %(count)d more hours to borrow it.', count=delta_hours)
+        $ungettext('You have %(count)d more hour to borrow it.', 'You have %(count)d more hours to borrow it.', delta_hours, count=delta_hours)
     </div>
 </div>
 

--- a/openlibrary/macros/ManageWaitlistButton.html
+++ b/openlibrary/macros/ManageWaitlistButton.html
@@ -23,11 +23,11 @@ $if status == "waiting":
     $ delta_hours = book.waitinglist_record.get_expiry_in_hours()
     <div class="smaller" style="padding-top: 5px;">
       $if delta_hours == 0:
-        You have less than an hour to borrow it.
+        $_("You have less than an hour to borrow it.")
       $elif delta_hours == 1:
-        You have one more hour to borrow it.
+        $_("You have one more hour to borrow it.")
       $else:
-        You have $delta_hours more hours to borrow it.
+       $_('You have %(count)d more hours to borrow it.', count=delta_hours)
     </div>
 </div>
 
@@ -35,10 +35,10 @@ $if status == "waiting":
   $if status == "available":
     <form action="$book.url('/borrow')" method="post">
       <input type="hidden" name="action" value="borrow" />
-      <input type="submit" value="Borrow Now" />
+      <input type="submit" value="$_('Borrow Now')" />
     </form>
   <form action="$book.url('/borrow?redirect=/account/loans')" method="POST" class="wlform">
     <input type="hidden" name="action" value="leave-waitinglist"/>
-    <a href="javascript:;" class="leave">Leave the waiting list?</a>
+    <a href="javascript:;" class="leave">$_("Leave the waiting list?")</a>
   </form>
 </div>

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -7,12 +7,12 @@ $ viewbook = "//%s/stream/XXX?ref=ol" % bookreader_host()
     $if page.volumes:
       <h3 class="header">
         <span class="icon read"></span>
-        <span class="head">Browse</span>
+        <span class="head">$_("Browse")</span>
       </h3>
       $for v in page.volumes:
         $if v.ia_id != "-":
           <div class="panel">
-            <p><a href="$viewbook.replace('XXX', v.ia_id)">View Volume $v.volume_number</a></p>
+            <p><a href="$viewbook.replace('XXX', v.ia_id)">$_('View Volume %(num)d', num=v.volume_number)</a></p>
           </div>
 
     <div class="panel">

--- a/openlibrary/templates/account/readinglog_stats.html
+++ b/openlibrary/templates/account/readinglog_stats.html
@@ -19,7 +19,7 @@ $jsdef render_works_list(works):
         <li>
             <a href="$work.key" style="font-style: oblique">$full_title</a>
             $ first_publish_year = work.first_publish_year or '????'
-            <span title="First published in $first_publish_year">($first_publish_year)</span>
+            <span title="$_('First published in %(year)s', year=first_publish_year)">($first_publish_year)</span>
             by
             $for author in work.authors:
                 <a href="$author.key">$author.name</a>$cond(not loop.last, ', ', '')

--- a/openlibrary/templates/admin/attach_debugger.html
+++ b/openlibrary/templates/admin/attach_debugger.html
@@ -4,7 +4,7 @@ $var title: $_("Attach Debugger")
 
 <div id="contentHead">
     $:render_template("admin/menu")
-    <h1>$_('Attach Debugger on Python %(version_number)d', version_number=python_version)</h1>
+    <h1>$_('Attach Debugger on Python %(version_number)s', version_number=python_version)</h1>
 </div>
 
 <div id="contentBody">

--- a/openlibrary/templates/admin/attach_debugger.html
+++ b/openlibrary/templates/admin/attach_debugger.html
@@ -4,12 +4,12 @@ $var title: $_("Attach Debugger")
 
 <div id="contentHead">
     $:render_template("admin/menu")
-    <h1>Attach Debugger on Python $python_version</h1>
+    <h1>$_('Attach Debugger on Python %(version_number)d', version_number=python_version)</h1>
 </div>
 
 <div id="contentBody">
     <div>
-        Start a debugger on port 3000.<br/>
+        $_("Start a debugger on port 3000.")<br/>
     </div>
 
     <form method="POST" class="olform">

--- a/openlibrary/templates/admin/block.html
+++ b/openlibrary/templates/admin/block.html
@@ -4,12 +4,12 @@ $var title: [Admin Center] Block IP
 
 <div id="contentHead">
     $:render_template("admin/menu")
-    <h1>Block IP address</h1>
+    <h1>$_("Block IP address")</h1>
 </div>
 
 <div id="contentBody">
     $if query_param("ip") != None:
-        <div>IP address $query_param("ip") has been added to the textarea. Please click Save to block that IP.
+        <div>$_('IP address %(address)s has been added to the textarea. Please click Save to block that IP.', address=query_param("ip"))
             <br/>
             <br/>
         </div>
@@ -26,7 +26,7 @@ $var title: [Admin Center] Block IP
         $:query_param("ip")
     </textarea>
     </div>
-    <input type="submit" name="_submit" value="Save"/>
+    <input type="submit" name="_submit" value="$_('Save')"/>
     </form>
 
 

--- a/openlibrary/templates/admin/loans_table.html
+++ b/openlibrary/templates/admin/loans_table.html
@@ -13,7 +13,7 @@ $def render_percents():
     - $epub_loans ($epub_percent%) $_("ePub")
 
 $if not loans:
-    <em>No current loans.</em>
+    <em>$_("No current loans.")</em>
 $else:
     <div class="borrow borrow-table collapse">
     <table>
@@ -67,10 +67,10 @@ $else:
                     </span>
                     <div class="date">
                     $if waiting_loan:
-                        Waiting since $datestr(parse_datetime(loan['since']))<br/>
-                        #$loan['position'] among $loan['wl_size'] people waiting for this book<br/>
+                        $_('Waiting since %(date)s', date=datestr(parse_datetime(loan['since'])))<br/>
+                        $_('#%(num_position)d among %(num_waitlist)d people waiting for this book', num_position=loan['position'], num_waitlist=loan['wl_size'])<br/>
                     $else:
-                        Borrowed $datestr(datetime_from_utc_timestamp(loan['loaned_at']))
+                        $_('Borrowed %(date)s', date=datestr(datetime_from_utc_timestamp(loan['loaned_at'])))
                     </div>
                 </td>
                 <td class="expires">
@@ -83,11 +83,11 @@ $else:
                     $if waiting_loan:
                         $loan['status']
                     $elif loan['resource_type'] == 'pdf':
-                        PDF
+                        $_('PDF')
                     $elif loan['resource_type'] == 'epub':
-                        ePub
+                        $_('ePub')
                     $elif loan['resource_type'] == 'bookreader':
-                        BookReader
+                        $_('BookReader')
                     $else:
                         $loan['resource_type']
                 </td>

--- a/openlibrary/templates/admin/people/view.html
+++ b/openlibrary/templates/admin/people/view.html
@@ -118,7 +118,7 @@ $ has_profile = person.get_user() is not None
             <div class="small">$:_('Registered on <span class="time">%(date)s</span>.', date=datestr(person.registered_on, relative=False))</div>
             $ v = person.get_creation_info()
             <button type="submit" name="action" value="su" style="float: right; background: #ffbbbb;">$_("login as this user")</button>
-            <div class="small">$:_('Activated on <span class="time">%(date)s</span> from <a href="/admin/ip/%(ip)s">%(ip)s</a>.', date=$datestr(person.activated_on, relative=False), ip=v.ip)</div>
+            <div class="small">$:_('Activated on <span class="time">%(date)s</span> from <a href="/admin/ip/%(ip)s">%(ip)s</a>.', date=datestr(person.activated_on, relative=False), ip=v.ip)</div>
         $if person.status == "blocked":
             <button type="submit" name="action" value="unblock_account">$_("unblock this account")</button>
         $elif person.status == "pending":

--- a/openlibrary/templates/admin/people/view.html
+++ b/openlibrary/templates/admin/people/view.html
@@ -97,7 +97,7 @@ a.tag.active {
 
 <div id="contentHead">
     $:render_template("admin/menu")
-    <h1><a class="plain" href="/admin/people">People</a> / $person.username</h1>
+    <h1><a class="plain" href="/admin/people">$_("People")</a> / $person.username</h1>
 </div>
 
 $ has_profile = person.get_user() is not None
@@ -110,29 +110,29 @@ $ has_profile = person.get_user() is not None
             Status: <span class="status">$person.status</span>
 
         $if person.status in ['active', 'verified']:
-            <button class="do-confirm" type="submit" name="action" value="block_account_and_revert" style="float: right; background: #ffbbbb;">block and revert all edits</button>
-            <button class="do-confirm" type="submit" name="action" value="block_account">block this account</button>
-            &nbsp;&nbsp;<button type="submit" name="action" value="send_password_reset_email">send password reset email</button>
+            <button class="do-confirm" type="submit" name="action" value="block_account_and_revert" style="float: right; background: #ffbbbb;">$_("block and revert all edits")</button>
+            <button class="do-confirm" type="submit" name="action" value="block_account">$_("block this account")</button>
+            &nbsp;&nbsp;<button type="submit" name="action" value="send_password_reset_email">$_("send password reset email")</button>
             <br/>
             <br/>
-            <div class="small">Registered on <span class="time">$datestr(person.registered_on, relative=False)</span>.</div>
+            <div class="small">$:_('Registered on <span class="time">%(date)s</span>.', date=datestr(person.registered_on, relative=False))</div>
             $ v = person.get_creation_info()
-            <button type="submit" name="action" value="su" style="float: right; background: #ffbbbb;">login as this user</button>
-            <div class="small">Activated on <span class="time">$datestr(person.activated_on, relative=False)</span> from <a href="/admin/ip/$v.ip">$v.ip</a>.</div>
+            <button type="submit" name="action" value="su" style="float: right; background: #ffbbbb;">$_("login as this user")</button>
+            <div class="small">$:_('Activated on <span class="time">%(date)s</span> from <a href="/admin/ip/$v.ip">%(ip)s</a>.', date=$datestr(person.activated_on, relative=False), ip=v.ip)</div>
         $if person.status == "blocked":
-            <button type="submit" name="action" value="unblock_account">unblock this account</button>
+            <button type="submit" name="action" value="unblock_account">$_("unblock this account")</button>
         $elif person.status == "pending":
-            <button type="submit" name="action" value="activate_account">activate account</button>
+            <button type="submit" name="action" value="activate_account">$_("activate account")</button>
             <br/>
             <br/>
-            <div class="small">Registered on <span class="time">$datestr(person.registered_on, relative=False).</span></div>
+            <div class="small">$:_('Registered on <span class="time">%(date)s</span>.', date=datestr(person.registered_on, relative=False))></div>
             <div class="small">
                 $if person.get_activation_link():
-                    Activation link expiring on <span class="time">$datestr(person.get_activation_link().get_expiration_time()).</span>
+                    $:_('Activation link expiring on <span class="time">%(date)s.</span>', date=datestr(person.get_activation_link().get_expiration_time()))
                 $else:
-                    <strong>Activation link expired.</strong>
+                    <strong>$_("Activation link expired").</strong>
 
-                <button type="submit" name="action" value="resend_link">Resend activation link</button>.
+                <button type="submit" name="action" value="resend_link">$_("Resend activation link")</button>.
             </div>
         </form>
     </div>
@@ -141,14 +141,14 @@ $ has_profile = person.get_user() is not None
     <tbody>
     <tr>
         <td>$_("Name:")</td>
-        <td>$person.displayname - <a href="/people/$person.username" style="color: #900; text-decoration: none;">view profile</a></td>
+        <td>$person.displayname - <a href="/people/$person.username" style="color: #900; text-decoration: none;">$_("view profile")</a></td>
     </tr>
     <tr>
         <td>$_("Email Address:")</td>
         <td>
             <form method="POST" name="form-email" id="form-email">
                 <input type="email" name="email" id="email" class="big" value="$input.get('email', person['email'])"/>
-                <button type="submit" name="action" value="update_email">Change</button>
+                <button type="submit" name="action" value="update_email">$_("Change")</button>
                 <span class="invalid" htmlfor="email" generated="true">$errors.get("email")</span>
             </form>
         </td>
@@ -158,13 +158,13 @@ $ has_profile = person.get_user() is not None
         <td>
             <form method="POST" name="form-password" id="form-password">
                 <input type="text" name="password" id="password" class="password big" value="$input.get('password')"/>
-                <button type="submit" name="action" value="update_password">Change</button>
+                <button type="submit" name="action" value="update_password">$_("Change")</button>
                 <span class="invalid" htmlfor="password" generated="true">$errors.get("password")</span>
             </form>
         </td>
     </tr>
     $if person.get_user().is_admin():
-        <tr><td>$_("Admin")</td><td>Yes</td></tr>
+        <tr><td>$_("Admin")</td><td>$_("Yes")</td></tr>
     <tr>
         <td>$_("Bot")</td>
         <td>
@@ -173,14 +173,14 @@ $ has_profile = person.get_user() is not None
                     <input type="hidden" name="action" value="set_bot_flag">
                     <input type="hidden" name="bot" value="$(not person.get('bot', False))">
                     $if person.get('bot'):
-                        Yes
-                        <button type="submit">Make Human</button>
+                        $_("Yes")
+                        <button type="submit">$_("Make Human")</button>
                     $else:
-                        No
-                        <button type="submit">Make Bot</button>
+                        $_("No")
+                        <button type="submit">$_("Make Bot")</button>
                 </form>
             $else:
-                <em>Not available</em>
+                <em>$_("Not available")</em>
         </td>
     </tr>
     <tr>
@@ -193,7 +193,7 @@ $ has_profile = person.get_user() is not None
             $if person.activated_on:
                 $datestr(person.activated_on)
             $else:
-                <em>Not available</em>
+                <em>$_("Not available")</em>
         </td>
     </tr>
     <tr>
@@ -202,7 +202,7 @@ $ has_profile = person.get_user() is not None
             $if person.last_login:
                 $datestr(person.last_login)
             $else:
-                <em>Not available</em>
+                <em>$_("Not available")</em>
         </td>
     </tr>
     <tr>
@@ -218,7 +218,7 @@ $ has_profile = person.get_user() is not None
         <td>
             <form method="POST" id="anonymize-form" action="?debug=true">
                 <input type="checkbox" id="dry-run-checkbox" name="dry_run">
-                <label for="dry-run-checkbox">Dry Run</label>
+                <label for="dry-run-checkbox">$_("Dry Run")</label>
                 <button type="submit" name="action" value="anonymize_account" style="float: right;" class="account-anonymization-button" data-display-name="$person.username">$_("Anonymize Account")</button>
             </form>
         </td>
@@ -232,7 +232,7 @@ $ user = person.get_user()
 $if user:
   $:render_template("admin/loans_table.html", user.get_loans())
 $else:
-  <em>Account not activated yet.</em>
+  <em>$_("Account not activated yet.")</em>
 </div>
 
 $if user:
@@ -241,21 +241,21 @@ $if user:
 
 <h2>
     $_("Edit History")
-    <span class="link"><a href="/admin/people/$person.username/edits">$person.get_edit_count() edits</a></span>
+    <span class="link"><a href="/admin/people/$person.username/edits">$_('%(num)d edits', num=person.get_edit_count())</a></span>
 </h2>
 $if person['status'] == "verified" or person['status'] == "active":
     $:render_template("admin/history", person.get_user().get_edit_history())
 $else:
-    <em>Account not activated yet.</em>
+    <em>$_("Account not activated yet.")</em>
 
 
 <h2>$_("Debug Info")</h2>
 
-<h3>Account Information</h3>
+<h3>$_("Account Information")</h3>
 $# detect-missing-i18n-skip-line
 <pre>$:json_encode(hasattr(person, "dict") and person.dict(), indent="    ", sort_keys=True)</pre>
 
-<h3>Verifications Links</h3>
+<h3>$_("Verifications Links")</h3>
 <div>
 $for link in person.get_links():
         <strong>$link['_key']</strong>
@@ -264,5 +264,5 @@ $for link in person.get_links():
     </li>
 </div>
 $if not person.get_links():
-    <em>None found</em>
+    <em>$_("None found")</em>
 </div>

--- a/openlibrary/templates/admin/people/view.html
+++ b/openlibrary/templates/admin/people/view.html
@@ -118,7 +118,7 @@ $ has_profile = person.get_user() is not None
             <div class="small">$:_('Registered on <span class="time">%(date)s</span>.', date=datestr(person.registered_on, relative=False))</div>
             $ v = person.get_creation_info()
             <button type="submit" name="action" value="su" style="float: right; background: #ffbbbb;">$_("login as this user")</button>
-            <div class="small">$:_('Activated on <span class="time">%(date)s</span> from <a href="/admin/ip/$v.ip">%(ip)s</a>.', date=$datestr(person.activated_on, relative=False), ip=v.ip)</div>
+            <div class="small">$:_('Activated on <span class="time">%(date)s</span> from <a href="/admin/ip/%(ip)s">%(ip)s</a>.', date=$datestr(person.activated_on, relative=False), ip=v.ip)</div>
         $if person.status == "blocked":
             <button type="submit" name="action" value="unblock_account">$_("unblock this account")</button>
         $elif person.status == "pending":

--- a/openlibrary/templates/admin/sponsorship.html
+++ b/openlibrary/templates/admin/sponsorship.html
@@ -6,12 +6,12 @@ $ sort_facet = input(sort='status').sort
 
 <div id="contentHead">
   $:render_template("admin/menu")
-  <h1>Book Sponsorship</h1>
+  <h1>$_("Book Sponsorship")</h1>
 </div>
 
 <div id="contentBody" class="page-admin--sponsorship">
 
-  <p>We've sponsored <strong>$len(summary['books'])</strong> books</p>
+  <p>$:_("We've sponsored <strong>%(num)d</strong> books", num=len(summary['books']))</p>
 
   <table class="sponsor">
     $for i, status in enumerate(summary['status_counts']):
@@ -25,29 +25,29 @@ $ sort_facet = input(sort='status').sort
 
   <table class="sponsor">
     <tr>
-      <th>Internet Archive Revenue</th>
+      <th>$_("Internet Archive Revenue")</th>
       <td class="earnings--profit">\$$('{:,.2f}'.format(summary['total_cost_cents'] / 100.))</td>
-      <th>Better World Books Revenue</th>
+      <th>$_("Better World Books Revenue")</th>
       <td class="earnings--profit">\$$('{:,.2f}'.format(summary['book_cost_cents'] / 100.))</td>
     </tr>
     <tr>
-      <th>Book Costs</th>
+      <th>$_("Book Costs")</th>
       <td>\$$('{:,.2f}'.format(summary['book_cost_cents'] / 100.))</td>
-      <th>Est. Book Costs</th>
+      <th>$_("Est. Book Costs")</th>
       <td>\$$('{:,.2f}'.format(summary['est_book_cost_cents'] / 100.))</td>
-      <th>Δ Book Costs</th>
+      <th>$_("Δ Book Costs")</th>
       <td class="earnings--$cond(summary['delta_book_cost_cents'] < 0, 'loss', 'profit')">\$$('{:,.2f}'.format(summary['delta_book_cost_cents'] / 100.))</td>
     </tr>
     <tr>
-      <th>Scanning Costs</th>
+      <th>$_("Scanning Costs")</th>
       <td>\$$('{:,.2f}'.format(summary['scan_cost_cents'] / 100.))</td>
-      <th>Est. Scanning Costs</th>
+      <th>$_("Est. Scanning Costs")</th>
       <td>\$$('{:,.2f}'.format(summary['est_scan_cost_cents'] / 100.))</td>
-      <th>Δ Scanning Costs</th>
+      <th>$_("Δ Scanning Costs")</th>
       <td class="earnings--$cond(summary['delta_scan_cost_cents'] < 0, 'loss', 'profit')">\$$('{:,.2f}'.format(summary['delta_scan_cost_cents'] / 100.))</td>
     </tr>
     <tr>
-      <th>Profit/Loss</th>
+      <th>$_("Profit/Los")s</th>
       $ profit_loss = (summary['total_cost_cents'] - summary['book_cost_cents'] - summary['scan_cost_cents'])
       <td class="earnings--$cond(profit_loss < 0, 'loss', 'profit')">\$$(profit_loss / 100.)</td>
     </tr>
@@ -57,24 +57,24 @@ $ sort_facet = input(sort='status').sort
 
   <table class="sponsor">
     <tr>
-      <th>Total Unscanned Books</th>
+      <th>$_("Total Unscanned Books")</th>
       <td>$summary['total_unscanned_books']</td>
       $if ctx.user and ctx.user.is_admin():
         $ isbns = '|'.join([s['identifier'].replace('isbn_', '') for s in summary['books'] if s.get('repub_state') == '-1' and s.get('book_price')])
         <!-- https://codesandbox.io/s/vue-template-8882k -->
-        <td><a href="https://8882k.codesandbox.io/#isbns=$isbns">Print Slips</a></td>
+        <td><a href="https://8882k.codesandbox.io/#isbns=$isbns">$_("Print Slips")</a></td>
     </tr>
     <tr>
-      <th>Average Scan Cost</th>
+      <th>$_("Average Scan Cost")</th>
       <td>\$$('{:,.2f}'.format(summary['avg_scan_cost'] / 100.))</td>
     </tr>
     <tr>
-      <th>Est. Remaining Scanning Liability</th>
+      <th>$_("Est. Remaining Scanning Liability")</th>
       $ scan_cost_liability = summary['avg_scan_cost'] * summary['total_unscanned_books']
       <td class="earnings--$('loss' if scan_cost_liability > 0 else 'profit')">\$$('{:,.2f}'.format(scan_cost_liability / 100.))</td>
     </tr>
     <tr>
-      <th>Projected Profit/Loss</th>
+      <th>$_("Projected Profit/Loss")</th>
       $ adj_profit_loss = profit_loss - scan_cost_liability
       <td class="earnings--$('loss' if adj_profit_loss < 0 else 'profit')">\$$(adj_profit_loss / 100.)</td>
     </tr>
@@ -86,12 +86,12 @@ $ sort_facet = input(sort='status').sort
     <thead>
       <tr>
         <th>#</th>
-        <th>Cover</th>
-        <th>Sponsor Date</th>
-        <th>IDs</th>
-        <th>Title</th>
-        <th>Donor</th>
-        <th>Status</th>
+        <th>$_("Cover")</th>
+        <th>$_("Sponsor Date")</th>
+        <th>$_("IDs")</th>
+        <th>$_("Title")</th>
+        <th>$_("Donor")</th>
+        <th>$_("Status")</th>
       </tr>
     </thead>
     <tbody>
@@ -116,10 +116,10 @@ $ sort_facet = input(sort='status').sort
                 <a href="https://archive.org/details/$book['identifier']">$book['identifier']</a>
               </li>
               <li>
-                <a href="https://archive.org/editxml/$book['identifier']">Edit XML</a>
+                <a href="https://archive.org/editxml/$book['identifier']">$_("Edit XML")</a>
               </li>
               <li>
-                <a href="https://www.betterworldbooks.com/product/detail/-$(isbn)">BWB Link</a>
+                <a href="https://www.betterworldbooks.com/product/detail/-$(isbn)">$_("BWB Link")</a>
               </li>
               $if book.get('openlibrary_edition'):
                 <li>

--- a/openlibrary/templates/home/loans.html
+++ b/openlibrary/templates/home/loans.html
@@ -2,15 +2,15 @@ $def with(loans)
 $ carousel = loans_carousel(loans)
 $if carousel:
     <div class="head">
-        <h2 class="home-h2"><a href="/account/loans">My Books</a></h2>
+        <h2 class="home-h2"><a href="/account/loans">$_("My Books")</a></h2>
         <hr/>
         <p class="sansserif large collapse">
           &nbsp;
           $if len(loans):
               $ loans_remaining = 5 - len(loans)
-              You can still <a href="/borrow">borrow</a> $loans_remaining more book$("" if loans_remaining == 1 else "s") until you've hit the limit!
+              $:ungettext('You can still <a href="/borrow">borrow</a> one more book until you\'ve hit the limit!', 'You can still <a href="/borrow">borrow</a> %(count)d more books until you\'ve hit the limit!', loans_remaining, count=loans_remaining)
           $else:
-              You have reached the borrowing limit. Please return a book to checkout something new.
+              $_("You have reached the borrowing limit. Please return a book to checkout something new.")
         </p>
     </div>
 

--- a/openlibrary/templates/jsdef/LazyAuthorPreview.html
+++ b/openlibrary/templates/jsdef/LazyAuthorPreview.html
@@ -2,7 +2,7 @@ $def with (author)
 
 $jsdef render_lazy_author_preview(item):
     $if item:
-        <div class="ac_author" title="Select this author">
+        <div class="ac_author" title="$_('Select this author')">
             <div class="olid">$item['key']</div>
             <span class="name">
                 $item['name']
@@ -10,16 +10,14 @@ $jsdef render_lazy_author_preview(item):
                     ($(item['birth_date'] or ' ')&ndash;$(item['death_date'] or ' '))
             </span>
             $if item['work_count'] == 0:
-                <span class="work">No books associated with $item['name']</span>
+                <span class="work">$_("No books associated with %(author)s", author=item['name'])</span>
             $elif item['work_count'] == 1:
-                <span class="books">1 book</span>
-                <span class="work">titled <i>$item['top_work']</i></span>
+                $:_('<span class="books">One book</span> <span class="work">titled <i>%(title)s</i></span>', title=item['top_work'])
             $else:
-                <span class="books">$item['work_count'] books</span>
-                <span class="work">including <i>$item['top_work']</i></span>
+                $:_('<span class="books">%(count)d books</span> <span class="work">including <i>%(title)s</i></span>', count=item['work_count'], title=item['top_work'])
 
             $if item['subjects']:
-                <span class="subject">Subjects: $(', '.join(item['subjects']))</span>
+                <span class="subject">$_("Subjects:") $(', '.join(item['subjects']))</span>
         </div>
 
 $if author:

--- a/openlibrary/templates/jsdef/LazyWorkPreview.html
+++ b/openlibrary/templates/jsdef/LazyWorkPreview.html
@@ -21,7 +21,7 @@ $jsdef render_lazy_work_preview(work):
                 $_('by') <span class="authors">${', '.join(work['author_name'])}</span>
         </span>
         &bull;
-        <span class="edition_count">$ungettext('One edition', '%(count)d editions', work['edition_count'], count=work['edition_count'])</span>
+        <span class="edition_count">$ungettext('%(count)d edition', '%(count)d editions', work['edition_count'], count=work['edition_count'])</span>
         <div class="clear"></div>
     </div>
 

--- a/openlibrary/templates/jsdef/LazyWorkPreview.html
+++ b/openlibrary/templates/jsdef/LazyWorkPreview.html
@@ -1,7 +1,7 @@
 $def with (work)
 
 $jsdef render_lazy_work_preview(work):
-    <div class="ac_work" title="Select this work">
+    <div class="ac_work" title="$_('Select this work')">
         <div class="cover">
             $if work['cover_i']:
                 <img
@@ -21,10 +21,7 @@ $jsdef render_lazy_work_preview(work):
                 $_('by') <span class="authors">${', '.join(work['author_name'])}</span>
         </span>
         &bull;
-        $if work['edition_count'] == 1:
-            <span class="edition_count">$work['edition_count'] edition</span>
-        $else:
-            <span class="edition_count">$work['edition_count'] editions</span>
+        <span class="edition_count">$ungettext('One edition', '%(count)d editions', work['edition_count'], count=work['edition_count'])</span>
         <div class="clear"></div>
     </div>
 

--- a/openlibrary/templates/lists/export_as_html.html
+++ b/openlibrary/templates/lists/export_as_html.html
@@ -1,7 +1,7 @@
 $def with (list, editions, works, authors)
 <html>
 <head>
-    <title>$list.name - Editions</title>
+    <title>$_('%(list)s - Editions', list=list.name)</title>
     <style type="text/css">
         h3.title {
             display: inline;
@@ -20,7 +20,7 @@ $def with (list, editions, works, authors)
                 $for a in authors:
                     <a href="$request.home$a.url()">$a.name</a>$cond(not loop.last, ", ")
             $else:
-                <em>Unknown authors</em>
+                <em>$_("Unknown authors")</em>
         </span>
     <ul>
     $for book in editions:
@@ -35,9 +35,9 @@ $def with (list, editions, works, authors)
                 $elif book.first_publish_date:
                     $book.publish_date
                 $elif book.publishers:
-                    <em>Publish date unknown</em>, $(', '.join(book.publishers))
+                    <em>$_("Publish date unknown")</em>, $(', '.join(book.publishers))
                 $else:
-                    <em>Publisher unknown</em>
+                    <em>$_("Publisher unknown")</em>
             </div>
             <br/>
         </li>
@@ -46,7 +46,7 @@ $def with (list, editions, works, authors)
     $for book in works:
         <li>
             <h3 class="title">
-                <a href="$request.home$book.url()">$book.get('title', 'Title unknown')</a>
+                <a href="$request.home$book.url()">$book.get('title', _('Title unknown'))</a>
             </h3>
             by $:render_authors(book)
 
@@ -54,7 +54,7 @@ $def with (list, editions, works, authors)
                 $if book.first_publish_year:
                     $book.first_publish_year
                 $else:
-                    <em>First publish date unknown</em>
+                    <em>$_("First publish date unknown")</em>
             </div>
             <br/>
         </li>
@@ -63,7 +63,7 @@ $def with (list, editions, works, authors)
     $for author in authors:
         <li>
             <h3 class="title">
-                <a href="$request.home$author.url()">$author.get('name', 'Name unknown')</a>
+                <a href="$request.home$author.url()">$author.get('name', _('Name unknown'))</a>
             </h3>
             $if author.birth_date:
                 ( $author.birth_date

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -44,8 +44,7 @@ $def render_head(page_lists, page_url):
       <h3 class="header">
         <span class="icon list heart-adjust"></span>
         $if len(page_lists) > 0:
-            $ msg = ungettext("%(count)d List", "%(count)d Lists", len(page_lists), count=len(page_lists))
-            <span class="head"><a href="$page_url/lists">$(msg)</a></span>
+            <span class="head"><a href="$page_url/lists">$ungettext("%(count)d List", "%(count)d Lists", len(page_lists), count=len(page_lists))</a></span>
         $else:
             <span class="head">$_("Lists")</span>
       </h3>

--- a/openlibrary/templates/publishers/view.html
+++ b/openlibrary/templates/publishers/view.html
@@ -10,11 +10,11 @@ $ subject_list = [('subjects', 20), ('places', 20), ('people', 10), ('times', 10
     <h1>
         $page.name
         <span class="count" id="coversCount">
-            <em>Publisher</em> - <strong><span>$ungettext("%(count)d work", "%(count)d works", page.work_count, count=page.work_count)</span></strong>
+            <em>$_("Publisher")</em> - <strong><span>$ungettext("%(count)d work", "%(count)d works", page.work_count, count=page.work_count)</span></strong>
             $if page.ebook_count > 0:
                 / <span class="ebookcount"><span id="ebooks">$ungettext("%(count)s ebook", "%(count)s ebooks", page.ebook_count, count=commify(page.ebook_count))</span></span>
             $else:
-                / 0 ebooks
+                / $_("0 ebooks")
             <span class="clickdata"></span>
         </span>
     </h1>
@@ -46,7 +46,7 @@ $ subject_list = [('subjects', 20), ('places', 20), ('people', 10), ('times', 10
 
         <div class="head" id="subjectRelated">
             <h2>$_("Common Subjects")
-                <span class="count"><a href="/search?${page.subject_type}_facet=$page.name.replace('&','%26')">Search for books published by $page.name</a></span>
+                <span class="count"><a href="/search?${page.subject_type}_facet=$page.name.replace('&','%26')">$_('Search for books published by %(publisher)s', publisher=page.name)</a></span>
             </h2>
         </div>
 

--- a/openlibrary/templates/recentchanges/merge/comment.html
+++ b/openlibrary/templates/recentchanges/merge/comment.html
@@ -3,7 +3,7 @@ $def with (change, page=None)
 $ type = change.kind.replace("merge-","")[:-1]
 
 $if page is None:
-    Merged duplicate $type records.
+    $_('Merged duplicate %(record_type)s records.', record_type=type)
 $else:
     $ primary = change.data.get("master")
     $ duplicates = change.data.get("duplicates", [])
@@ -13,7 +13,7 @@ $else:
         $ details = ''
     $else:
         $ context = page.key
-        $ details = 'See <a href="' + change.url() + '">details</a>.'
+        $ details = $:_('See <a href="' + change.url() + '">details</a>.')
 
     $if context == primary:
         $# comment in the primary record
@@ -21,7 +21,7 @@ $else:
         $:details
     $elif context in duplicates:
         $# comment in the duplicate record
-        Marked as duplicate. $:details
+        $_("Marked as duplicate.") $:details
     $else:
         $# comment in the affected records
-        Merged $pagetype into primary $type record. $:details
+        $_('Merged %(page_type)s into primary %(record_type) record.', page_type=pagetype, record_type=type) $:details

--- a/openlibrary/templates/recentchanges/undo/view.html
+++ b/openlibrary/templates/recentchanges/undo/view.html
@@ -7,11 +7,11 @@ $def with (change)
 <div id="contentBody">
     <div id="mergeHead" class="sansserif">
         $ parent = change.get_parent_changeset()
-        Undo of <a href="$parent.url()">$parent.kind</a>.
+        $:_('Undo of <a href="$parent.url()">%(kind)s</a>.', kind=parent.kind)
 
-        <p class="smallest gray sansserif">$len(change.changes) records modified.</p>
+        <p class="smallest gray sansserif">$_('%(count)d records modified.', count=len(change.changes))</p>
     </div>
 
-    <h3>Updated Records</h3>
+    <h3>$_("Updated Records")</h3>
     $:render_template("recentchanges/updated_records", change)
 </div>

--- a/openlibrary/templates/search/snippets.html
+++ b/openlibrary/templates/search/snippets.html
@@ -4,7 +4,7 @@ $ q = query_param('q')
 
 <div id="contentHead">
     <div class="small sansserif grey" style="margin-bottom:5px;">
-        <a href="/search/inside">Search Inside</a> /
+        <a href="/search/inside">$_("Search Inside")</a> /
         <a href="/search/inside?q=$q">$q</a>
     </div>
     <h1>
@@ -28,7 +28,7 @@ $for match in matches:
     $for par in match['par']:
         $ par_num = par_num + 1
         $ page = par['page']
-        <p class="lightgreen small sansserif">On leaf number $page:</p>
+        <p class="lightgreen small sansserif">$_('On leaf number %(page_num)d:', page_num=page)</p>
 
         $ t = (par['t'] / scale) - ypadding
         $ r = (par['r'] / scale) + xpadding

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -135,7 +135,7 @@ $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_libra
                     <input type="hidden" name="sort" value="$query_param('sort')"/>
                   $if (query_param('mode')):
                     <input type="hidden" name="mode" value="$query_param('mode')"/>
-                  <input type="text" placeholder="Search $title Books" name="q" value="$(query_param('q', ''))"/>
+                  <input type="text" placeholder="$_('Search %(author)s Books', author=title)" name="q" value="$(query_param('q', ''))"/>
                   <input type="submit"/>
                 </form>
 
@@ -187,7 +187,7 @@ $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_libra
                             $ href = id.url.replace('@@@', page.remote_ids[id.name])
                             <li>$id.label: <a itemprop="sameAs" href="$href">$page.remote_ids[id.name]</a></li>
                             $if id.name == 'wikidata' and 'inventaire' not in page.remote_ids:
-                              <li>Inventaire.io: <a
+                              <li>$('Inventaire.io:') <a
                                   itemprop="sameAs"
                                   href="https://inventaire.io/entity/wd:$page.remote_ids[id.name]"
                               >wd:$page.remote_ids[id.name]</a></li>
@@ -200,7 +200,7 @@ $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_libra
             $if page.links or (page.wikipedia and page.wikipedia.startswith("http")):
                 <ul class="booklinks sansserif">
                 $if page.wikipedia and page.wikipedia.startswith("http"):
-                    <li><a itemprop="sameAs" href="$page.wikipedia">Wikipedia</a></li>
+                    <li><a itemprop="sameAs" href="$page.wikipedia">$_("Wikipedia")</a></li>
                 $for link in page.links:
                     <li><a href="$link.url">$link.title</a></li>
                 </ul>

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -171,7 +171,7 @@ $elif param and len(search_response.docs):
     $if param and not search_response.error and len(search_response.docs):
         $if ctx.user and ctx.user.is_admin():
             <div id="adminTiming" class="small sansserif clearfix">
-                <br/><span class="adminOnly">Searching solr took $("%.2f" % search_response.time) seconds</span>
+                <br/><span class="adminOnly">$_('Searching solr took %(count)s seconds', number="%.2f" % search_response.time)</span>
             </div>
   </div>
 </div>

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -171,7 +171,7 @@ $elif param and len(search_response.docs):
     $if param and not search_response.error and len(search_response.docs):
         $if ctx.user and ctx.user.is_admin():
             <div id="adminTiming" class="small sansserif clearfix">
-                <br/><span class="adminOnly">$_('Searching solr took %(count)s seconds', number="%.2f" % search_response.time)</span>
+                <br/><span class="adminOnly">$_('Searching solr took %(count)s seconds', count="%.2f" % search_response.time)</span>
             </div>
   </div>
 </div>

--- a/scripts/detect_missing_i18n.py
+++ b/scripts/detect_missing_i18n.py
@@ -12,42 +12,22 @@ import glob
 # Chip away at these and remove them from the exclude list (except where otherwise noted).
 EXCLUDE_LIST = {
     "openlibrary/templates/permission_denied.html",
-    "openlibrary/templates/work_search.html",
     "openlibrary/templates/about/index.html",
     "openlibrary/templates/account/import.html",
-    "openlibrary/templates/account/readinglog_stats.html",
     "openlibrary/templates/account/email/forgot.html",
-    "openlibrary/templates/admin/attach_debugger.html",
-    "openlibrary/templates/admin/block.html",
     "openlibrary/templates/admin/imports.html",
     "openlibrary/templates/admin/loans.html",
-    "openlibrary/templates/admin/loans_table.html",
     "openlibrary/templates/admin/spamwords.html",
-    "openlibrary/templates/admin/sponsorship.html",
     "openlibrary/templates/admin/inspect/memcache.html",
-    "openlibrary/templates/admin/people/view.html",
     "openlibrary/templates/books/custom_carousel.html",
     "openlibrary/templates/books/mobile_carousel.html",
     "openlibrary/templates/books/edit/edition.html",
     "openlibrary/templates/books/edit/web.html",
-    "openlibrary/templates/home/loans.html",
-    "openlibrary/templates/jsdef/LazyAuthorPreview.html",
-    "openlibrary/templates/jsdef/LazyWorkPreview.html",
-    "openlibrary/templates/lists/export_as_html.html",
-    "openlibrary/templates/lists/widget.html",
     "openlibrary/templates/my_books/primary_action.html",
-    "openlibrary/templates/publishers/view.html",
     "openlibrary/templates/recentchanges/header.html",
-    "openlibrary/templates/recentchanges/merge/comment.html",
     "openlibrary/templates/recentchanges/merge/path.html",
-    "openlibrary/templates/recentchanges/undo/view.html",
-    "openlibrary/templates/search/snippets.html",
-    "openlibrary/templates/type/author/view.html",
     "openlibrary/templates/type/edition/view.html",
     "openlibrary/templates/type/work/view.html",
-    "openlibrary/macros/ManageLoansButtons.html",
-    "openlibrary/macros/ManageWaitlistButton.html",
-    "openlibrary/macros/databarWork.html",
     # These are excluded because they require more info to fix
     "openlibrary/templates/books/edit.html",
     "openlibrary/templates/history/sources.html",
@@ -99,7 +79,8 @@ ignore_after_opening_tag = (
 warn_after_opening_tag = r"\$\(['\"]"
 
 i18n_element_missing_regex = opening_tag_syntax + ignore_after_opening_tag
-i18n_element_warn_regex = opening_tag_syntax + warn_after_opening_tag
+i18n_element_warn_regex = opening_tag_syntax + r"\$\(['\"]"
+i18n_element_warn_regex = opening_tag_syntax + r"\$\(['\"]"
 
 attr_syntax = r"(title|placeholder|alt)="
 ignore_double_quote = (
@@ -130,7 +111,8 @@ i18n_attr_missing_regex = (
     + ignore_single_quote
     + r")[^>]*?>"
 )
-i18n_attr_warn_regex = opening_tag_open + attr_syntax + warn_after_opening_tag
+i18n_attr_warn_regex = opening_tag_open + attr_syntax + r"\"\$\(\'"
+i18n_attr_warn_regex = opening_tag_open + attr_syntax + r"\"\$\(\'"
 
 
 def terminal_underline(text: str) -> str:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Subtask of #9486.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix. This PR adds `i18n` syntax in cases where the text to be translated includes a variable or variables. See the i18n [guide](https://github.com/internetarchive/openlibrary/wiki/Internationalization#html-files) for full syntax info and instructions.

### Technical
<!-- What should be noted about the implementation? -->
Separated the PR's by `i18n` syntax type for ease of review, this one is scoped to cover all the `i18n` variable syntax.

Also includes removing relevant files from `i18n` exclude list so as to confirm they now pass the `detect-missing-i18n` check.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Find a newly `i18n`-ed phrase in one of the files that includes a variable
2. Confirm that the new variable is assigned to the correct variable name, i.e. `View $num_works works` should become `$_('View %(count)d works', count=num_works)`
3. Confirm that the new variable uses the correct format, i.e. `%( )s` if it will be assigned to a string, vs. `%( )d` if it will be assigned to a number
4. Check to see that the phrase appears correctly in the `messages.pot` file
5. Run the `i18n` detection script with `pre-commit run detect-missing-i18n  --all-files`
6. No errors or warnings should appear, and the check should pass

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles @cdrini @pidgezero-one 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
