### PR TITLE
Add (debounced) key-up validation and submit btn loading for registration

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -908,6 +908,11 @@ msgstr ""
 msgid "Must be between 3 and 20 characters"
 msgstr ""
 
+#: account/create.html books/custom_carousel.html
+#: search/work_search_facets.html
+msgid "Loading..."
+msgstr ""
+
 #: account/create.html
 msgid "Sign Up to Open Library"
 msgstr ""
@@ -2643,10 +2648,6 @@ msgstr ""
 
 #: NotInLibrary.html books/custom_carousel.html
 msgid "Not in Library"
-msgstr ""
-
-#: books/custom_carousel.html search/work_search_facets.html
-msgid "Loading..."
 msgstr ""
 
 #: books/custom_carousel.html books/mobile_carousel.html

--- a/openlibrary/plugins/openlibrary/js/realtime_account_validation.js
+++ b/openlibrary/plugins/openlibrary/js/realtime_account_validation.js
@@ -1,3 +1,5 @@
+import { debounce } from './nonjquery_utils.js';
+
 export function initRealTimeValidation() {
     const signupForm = document.querySelector('form[name=signup]');
     const i18nStrings = JSON.parse(signupForm.dataset.i18n);
@@ -7,6 +9,9 @@ export function initRealTimeValidation() {
         // Checks whether reportValidity exists for cross-browser compatibility
         // Includes invalid input count to account for checks not covered by reportValidity
         function submitCreateAccountForm() {
+            const submitBtn = $('button[name=signup]');
+            submitBtn.prop('disabled', true).text(i18nStrings['loading_text']);
+
             const numInvalidInputs = signupForm.querySelectorAll('input.invalid').length;
             const isFormattingValid = !signupForm.reportValidity || signupForm.reportValidity()
 
@@ -97,7 +102,11 @@ export function initRealTimeValidation() {
         else clearError('#password', '#passwordMessage');
     }
 
-    $('#username').on('blur', validateUsername);
-    $('#emailAddr').on('blur', validateEmail);
-    $('#password').on('blur', validatePassword);
+    $('#username').not('.invalid').on('blur', validateUsername);
+    $('#emailAddr').not('.invalid').on('blur', validateEmail);
+    $('#password').not('.invalid').on('blur', validatePassword);
+
+    $('#username.invalid').on('keyup', debounce(validateUsername, 50));
+    $('#emailAddr.invalid').on('keyup', debounce(validateEmail, 50));
+    $('#password.invalid').on('keyup', debounce(validatePassword, 50));
 }

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -3,7 +3,8 @@ $def with (form)
 $putctx("cssfile", "signup")
 
 $ i18n_strings = {
-    $ "password_length_err": _("Must be between 3 and 20 characters")
+    $ "password_length_err": _("Must be between 3 and 20 characters"),
+    $ "loading_text": _("Loading...")
     $ }
 
 $# :param openlibrary.plugins.upstream.forms.RegisterForm form:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9511.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature. Adds key-up validation for only invalid registration inputs, and adds loading for submit button.

### Technical
<!-- What should be noted about the implementation? -->
Very simple! Added a debounced keyup call to the validation functions for specifically inputs with the `invalid` class, and specified that on blur validation should only happen for elements without the `invalid` class to avoid duplicate API calls.

Also added a quick loading indicator to the submit button.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Enter a badly formatted email/username/password in the registration form
2. Click away, and you should see an error message appear
3. Go back to the input and the error message should disappear as soon as it is fixed
4. Try submitting the form, you should see the submit button become disabled and the button text be replaced with `Loading...`

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles @cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
