### PR TITLE
Fix: Always show reCAPTCHA for unauthenticated users

### DIFF
--- a/openlibrary/plugins/openlibrary/support.py
+++ b/openlibrary/plugins/openlibrary/support.py
@@ -24,7 +24,14 @@ class contact(delegate.page):
 
         hashed_ip = hashlib.md5(web.ctx.ip.encode('utf-8')).hexdigest()
         has_emailed_recently = get_memcache().get('contact-POST-%s' % hashed_ip)
-        recaptcha = has_emailed_recently and get_recaptcha()
+        # recaptcha = has_emailed_recently and get_recaptcha()
+
+        # # Always show recaptcha for unauthenticated users
+        if has_emailed_recently:
+            recaptcha = get_recaptcha()
+        else:
+            recaptcha = has_emailed_recently and get_recaptcha()
+
         return render_template("support", email=email, url=i.path, recaptcha=recaptcha)
 
     def POST(self):
@@ -42,7 +49,10 @@ class contact(delegate.page):
 
         hashed_ip = hashlib.md5(web.ctx.ip.encode('utf-8')).hexdigest()
         has_emailed_recently = get_memcache().get('contact-POST-%s' % hashed_ip)
-        if has_emailed_recently:
+
+        ## Always validate recaptcha for unauthenticated users
+        # if has_emailed_recently:
+        if not user:
             recap = get_recaptcha()
             if recap and not recap.validate():
                 return render_template(


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3826
This PR ensures that unauthenticated users always see and need to complete reCAPTCHA to reduce spam, while authenticated users only encounter reCAPTCHA if they have recently submitted the form.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->
- The implementation ensures that reCAPTCHA is always shown to unauthenticated users by updating the GET and POST methods of the `contact` class.
- For authenticated users, the existing logic is retained where reCAPTCHA is shown only if they have submitted a form recently.
- The `get_recaptcha` function is now called for unauthenticated users in the GET method to ensure they always see the reCAPTCHA challenge.
- In the POST method, reCAPTCHA validation is enforced for unauthenticated users, and the existing validation logic for authenticated users is maintained.
- This change aims to reduce spam submissions by requiring unauthenticated users
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
 @cdrini @mekarpeles @JeffKaplan 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
