### PR TITLE
refactor: Use Safe Parsers in `lxml` Parsing Functions

### DIFF
--- a/openlibrary/catalog/get_ia.py
+++ b/openlibrary/catalog/get_ia.py
@@ -7,6 +7,7 @@ from time import sleep
 from openlibrary.catalog.marc.marc_binary import MarcBinary
 from openlibrary.catalog.marc.marc_xml import MarcXml
 from openlibrary.core import ia
+import lxml.etree
 
 
 IA_BASE_URL = config.get('ia_base_url')
@@ -55,7 +56,7 @@ def get_marc_record_from_ia(
     # If that fails, try marc.xml
     if marc_xml_filename in filenames:
         data = urlopen_keep_trying(item_base + marc_xml_filename).content
-        root = etree.fromstring(data)
+        root = etree.fromstring(data, parser=lxml.etree.XMLParser(resolve_entities=False))
         return MarcXml(root)
     return None
 

--- a/openlibrary/catalog/marc/tests/test_get_subjects.py
+++ b/openlibrary/catalog/marc/tests/test_get_subjects.py
@@ -4,6 +4,7 @@ from openlibrary.catalog.marc.get_subjects import four_types, read_subjects
 from lxml import etree
 from pathlib import Path
 import pytest
+import lxml.etree
 
 xml_samples = [
     ('bijouorannualofl1828cole', {}),
@@ -241,7 +242,7 @@ class TestSubjects:
     @pytest.mark.parametrize('item,expected', xml_samples)
     def test_subjects_xml(self, item, expected):
         filepath = TEST_DATA / 'xml_input' / f'{item}_marc.xml'
-        element = etree.parse(filepath).getroot()
+        element = etree.parse(filepath, parser=lxml.etree.XMLParser(resolve_entities=False)).getroot()
         if element.tag != record_tag and element[0].tag == record_tag:
             element = element[0]
         rec = MarcXml(element)

--- a/openlibrary/catalog/marc/tests/test_parse.py
+++ b/openlibrary/catalog/marc/tests/test_parse.py
@@ -12,6 +12,7 @@ from openlibrary.catalog.marc.marc_xml import DataField, MarcXml
 from lxml import etree
 from pathlib import Path
 from collections.abc import Iterable
+import lxml.etree
 
 collection_tag = '{http://www.loc.gov/MARC21/slim}collection'
 record_tag = '{http://www.loc.gov/MARC21/slim}record'
@@ -94,7 +95,7 @@ class TestParseMARCXML:
     def test_xml(self, i):
         expect_filepath = (TEST_DATA / 'xml_expect' / i).with_suffix('.json')
         filepath = TEST_DATA / 'xml_input' / f'{i}_marc.xml'
-        element = etree.parse(filepath).getroot()
+        element = etree.parse(filepath, parser=lxml.etree.XMLParser(resolve_entities=False)).getroot()
         # Handle MARC XML collection elements in our test_data expectations:
         if element.tag == collection_tag and element[0].tag == record_tag:
             element = element[0]
@@ -172,7 +173,7 @@ class TestParse:
           <subfield code="a">Rein, Wilhelm,</subfield>
           <subfield code="d">1809-1865.</subfield>
         </datafield>"""
-        test_field = DataField(None, etree.fromstring(xml_author))
+        test_field = DataField(None, etree.fromstring(xml_author, parser=lxml.etree.XMLParser(resolve_entities=False)))
         result = read_author_person(test_field)
 
         # Name order remains unchanged from MARC order

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -37,6 +37,7 @@ from lxml import etree
 import logging
 
 import urllib
+import lxml.etree
 
 
 MARC_LENGTH_POS = 5
@@ -77,7 +78,7 @@ def parse_data(data: bytes) -> tuple[dict | None, str | None]:
     """
     data = data.strip()
     if b'<?xml' in data[:10]:
-        root = etree.fromstring(data)
+        root = etree.fromstring(data, parser=lxml.etree.XMLParser(resolve_entities=False))
         if root.tag == '{http://www.w3.org/1999/02/22-rdf-syntax-ns#}RDF':
             edition_builder = import_rdf.parse(root)
             format = 'rdf'

--- a/openlibrary/plugins/importapi/metaxml_to_json.py
+++ b/openlibrary/plugins/importapi/metaxml_to_json.py
@@ -33,6 +33,7 @@ usage:
 """
 
 from openlibrary.plugins.importapi.import_edition_builder import import_edition_builder
+import lxml.etree
 
 
 def parse_collection(collection):
@@ -94,7 +95,7 @@ if __name__ == '__main__':
 
     assert len(sys.argv) == 2
 
-    tree = etree.parse(sys.argv[1])
+    tree = etree.parse(sys.argv[1], parser=lxml.etree.XMLParser(resolve_entities=False))
     root = tree.getroot()
 
     edition_dict = metaxml_to_edition_dict(root)

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -31,6 +31,7 @@ from openlibrary.utils import dateutil
 from lxml import etree
 
 import urllib
+import lxml.etree
 
 
 logger = logging.getLogger("openlibrary.borrow")
@@ -373,7 +374,7 @@ class borrow_receive_notification(delegate.page):
     def POST(self):
         data = web.data()
         try:
-            etree.fromstring(data)
+            etree.fromstring(data, parser=lxml.etree.XMLParser(resolve_entities=False))
             output = json.dumps({'success': True})
         except Exception as e:
             output = json.dumps({'success': False, 'error': str(e)})

--- a/scripts/lc_marc_update.py
+++ b/scripts/lc_marc_update.py
@@ -10,6 +10,7 @@ import sys
 import httplib
 import json
 import argparse
+import lxml.etree
 
 parser = argparse.ArgumentParser(description='Library of Congress MARC update')
 parser.add_argument('--config', default='openlibrary.yml')
@@ -57,7 +58,7 @@ attempts = 10
 wait = 5
 for attempt in range(attempts):
     try:
-        root = etree.parse(url).getroot()
+        root = etree.parse(url, parser=lxml.etree.XMLParser(resolve_entities=False)).getroot()
         break
     except:
         if attempt == attempts - 1:


### PR DESCRIPTION
### Technical
<!-- What should be noted about the implementation? -->
This codemod sets the `parser` parameter in calls to  `lxml.etree.parse`  and `lxml.etree.fromstring` if omitted or set to `None` (the default value). Unfortunately, the default `parser=None` means `lxml` will rely on an unsafe parser, making your code potentially vulnerable to entity expansion attacks and external entity (XXE) attacks.

The changes look as follows:

```diff
  import lxml.etree
- lxml.etree.parse("path_to_file")
- lxml.etree.fromstring("xml_str")
+ lxml.etree.parse("path_to_file", parser=lxml.etree.XMLParser(resolve_entities=False))
+ lxml.etree.fromstring("xml_str", parser=lxml.etree.XMLParser(resolve_entities=False))
```

<details>
  <summary>More reading</summary>

  * [https://lxml.de/apidoc/lxml.etree.html#lxml.etree.XMLParser](https://lxml.de/apidoc/lxml.etree.html#lxml.etree.XMLParser)
  * [https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing](https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing)
  * [https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html)
</details>

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
n/a
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
n/a
### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
n/a
### Additional Info
This recommendation was Automated & Powered by [Pixeebot  ](https://github.com/apps/pixeebot) 🤖.

Codemod ID: [pixee:python/safe-lxml-parsing](https://docs.pixee.ai/codemods/python/pixee_python_safe-lxml-parsing) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Python%2Fopenlibrary%7C918c7fb176caed8257d41e305b95bbce4565adc7)


<!--{"type":"DRIP","codemod":"pixee:python/safe-lxml-parsing"}-->
