### PR TITLE
fix: Don’t autoselect identifier for UUIDs

### DIFF
--- a/openlibrary/components/AuthorIdentifiers.vue
+++ b/openlibrary/components/AuthorIdentifiers.vue
@@ -32,7 +32,6 @@
 const identifierPatterns  = {
     wikidata: /^Q[1-9]\d*$/i,
     isni: /^[0]{4} ?[0-9]{4} ?[0-9]{4} ?[0-9]{3}[0-9X]$/i,
-    storygraph: /^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i,
     amazon: /^B[0-9A-Za-z]{9}$/,
     youtube: /^@[A-Za-z0-9_\-.]{3,30}/,
 }


### PR DESCRIPTION
Storygraph was previously the only known identifier using UUIDs, but BookBrainz and MusicBrainz have recently been added to the known identifiers too, and they both use UUIDs as well.

<!-- What issue does this PR close? -->
Closes #9503

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

fix

### Technical
<!-- What should be noted about the implementation? -->

This simply removes the matching of UUIDs entirely.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Edit an author, paste in a UUID. Storygraph should _not_ get automatically selected.

(I have not done any actual testing of this myself as I don’t have a working environment running OL.)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->

@jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
