### PR TITLE
fix merge author url issue

### DIFF
--- a/openlibrary/templates/merge/authors.html
+++ b/openlibrary/templates/merge/authors.html
@@ -92,7 +92,7 @@ $if can_merge:
                         <p>No description.</p>
                     <ul>
                     $for doc in top.docs:
-                        <li><a href="$doc['key']'" target="new" title="$_('Open in a new window')">$doc['title']</a> <span class="smaller">$ungettext('%(count)s edition', '%(count)s editions', doc['edition_count'], count=doc['edition_count']),
+                        <li><a href="$doc['key']" target="new" title="$_('Open in a new window')">$doc['title']</a> <span class="smaller">$ungettext('%(count)s edition', '%(count)s editions', doc['edition_count'], count=doc['edition_count']),
                         $if doc.get('first_publish_year'):
                             <span title="$_('First published in')">$doc['first_publish_year']</span>
                         </span></li>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9476 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixed the issue that extra ' is added to the work URLs when authors are merged..

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
