### PR TITLE
Update failing `new_comment_digest` workflow

### DIFF
--- a/.github/workflows/new_comment_digest.yml
+++ b/.github/workflows/new_comment_digest.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       slack_channel:
-        description: 'Digest is published to this channel'
+        description: 'Digest is published to this channel. Entering an empty string will prevent publishing.'
         type: string
         default: '#team-abc'
       hours:
@@ -27,7 +27,7 @@ jobs:
         with:
           python-version: 3.x
       - run: pip install requests
-      - run: scripts/gh_scripts/issue_comment_bot.py ${{ inputs.hours }} -c .github/workflows/config/new_comment_digest.json -s "${{ inputs.slack_channel }}" -t "$SLACK_TOKEN"
+      - run: scripts/gh_scripts/issue_comment_bot.py ${{ inputs.hours }} -c .github/workflows/config/new_comment_digest.json -s "${{ inputs.slack_channel }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}

--- a/.github/workflows/new_comment_digest.yml
+++ b/.github/workflows/new_comment_digest.yml
@@ -19,6 +19,10 @@ on:
         options:
         - 'Yes'
         - 'No'
+      label_issues:
+        description: 'Add `Needs: Response` labels to issues?'
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -28,6 +32,7 @@ env:
   HOURS: 24
   CHANNEL_ARG: '-s #team-abc-plus'
   VERBOSE_FLAG: ''
+  NO_LABELS_FLAG: ''
 
 jobs:
   new_comment_digest:
@@ -46,6 +51,7 @@ jobs:
           HOURS: ${{ inputs.hours }}
           CHANNEL: ${{ inputs.slack_channel }}
           VERBOSE: ${{ inputs.verbose_mode }}
+          USE_LABELS: ${{ inputs.label_issues }}
         run: |
           # Set hours:
           echo "HOURS=$HOURS" >> $GITHUB_ENV
@@ -61,7 +67,13 @@ jobs:
             VERBOSE_FLAG="-v"
           fi
           echo "VERBOSE_FLAG=$VERBOSE_FLAG" >> $GITHUB_ENV
-      - run: scripts/gh_scripts/issue_comment_bot.py ${{ env.HOURS }} -c .github/workflows/config/new_comment_digest.json ${{ env.CHANNEL_ARG }} ${{ env.VERBOSE_FLAG }}
+          # Set no_labels flag:
+          NO_LABELS_FLAG=""
+          if [[ $USE_LABELS == false ]]; then
+            NO_LABELS_FLAG="--no-labels"
+          fi
+          echo "NO_LABELS_FLAG=$NO_LABELS_FLAG" >> $GITHUB_ENV
+      - run: scripts/gh_scripts/issue_comment_bot.py ${{ env.HOURS }} -c .github/workflows/config/new_comment_digest.json ${{ env.CHANNEL_ARG }} ${{ env.VERBOSE_FLAG }} ${{ env.NO_LABELS_FLAG }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}

--- a/.github/workflows/new_comment_digest.yml
+++ b/.github/workflows/new_comment_digest.yml
@@ -39,6 +39,8 @@ jobs:
     # Continue only if this executed on the main repo
     if: ${{ github.repository == 'internetarchive/openlibrary' }}
     runs-on: ubuntu-latest
+    outputs:
+      exit_code: ${{ steps.run_bot.outputs.exit_code }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -73,7 +75,35 @@ jobs:
             NO_LABELS_FLAG="--no-labels"
           fi
           echo "NO_LABELS_FLAG=$NO_LABELS_FLAG" >> $GITHUB_ENV
-      - run: scripts/gh_scripts/issue_comment_bot.py ${{ env.HOURS }} -c .github/workflows/config/new_comment_digest.json ${{ env.CHANNEL_ARG }} ${{ env.VERBOSE_FLAG }} ${{ env.NO_LABELS_FLAG }}
+      - id: run_bot
+        run: |
+          trap 'echo "exit_code=$?" >> "$GITHUB_OUTPUT"' EXIT
+          scripts/gh_scripts/issue_comment_bot.py ${{ env.HOURS }} -c .github/workflows/config/new_comment_digest.json ${{ env.CHANNEL_ARG }} ${{ env.VERBOSE_FLAG }} ${{ env.NO_LABELS_FLAG }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+        continue-on-error: true
+  publish_error_to_slack:
+    needs: new_comment_digest
+    if: ${{ needs.new_comment_digest.outputs.exit_code == 20 }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: pip install slack-sdk
+      - name: Publish message to Slack after failing to fetch GitHub issues
+        shell: python
+        env:
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+          SLACK_CHANNEL_ABC_TEAM_PLUS: ${{ secrets.SLACK_CHANNEL_ABC_TEAM_PLUS }}
+        run: |
+          import datetime, os, sys, slack_sdk
+          if os.getenv("SLACK_TOKEN") and os.getenv("SLACK_CHANNEL_ABC_TEAM_PLUS"):
+            now = datetime.datetime.now()
+            since = now - datetime.timedelta(hours=${{ env.HOURS }})
+            time_str = since.strftime('%Y-%m-%dT%H:%M:%S')
+            slack_sdk.WebClient(token=os.getenv("SLACK_TOKEN")).chat_postMessage(channel=os.getenv("SLACK_CHANNEL_ABC_TEAM_PLUS"),
+              text=f"Failed to fetch issues for Slack digest. <https://github.com/internetarchive/openlibrary/issues?q=is:issue+is:open+comments:%3E0+updated:%3E{time_str}|These issues> should be manually checked and labeled"
+            )
+          sys.exit(1)

--- a/.github/workflows/new_comment_digest.yml
+++ b/.github/workflows/new_comment_digest.yml
@@ -85,7 +85,7 @@ jobs:
         continue-on-error: true
   publish_error_to_slack:
     needs: new_comment_digest
-    if: ${{ needs.new_comment_digest.outputs.exit_code == 20 }}
+    if: ${{ needs.new_comment_digest.outputs.exit_code == 30 }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-python@v5

--- a/.github/workflows/new_comment_digest.yml
+++ b/.github/workflows/new_comment_digest.yml
@@ -5,9 +5,8 @@ on:
   workflow_dispatch:
     inputs:
       slack_channel:
-        description: 'Digest is published to this channel. Entering an empty string will prevent publishing.'
+        description: 'Digest is published to this channel. Include leading `#` symbol in channel name.  Entering an empty string will skip publishing to Slack.'
         type: string
-        default: '#team-abc-plus'
       hours:
         description: 'Search for issues that have new comments within this number of hours.'
         type: number
@@ -25,6 +24,11 @@ permissions:
   contents: read
   issues: write
 
+env:
+  HOURS: 24
+  CHANNEL_ARG: '-s #team-abc-plus'
+  VERBOSE_FLAG: ''
+
 jobs:
   new_comment_digest:
     runs-on: ubuntu-latest
@@ -34,16 +38,28 @@ jobs:
         with:
           python-version: 3.x
       - run: pip install requests
-      - name: Set environment variable for verbose flag
+      - name: Override environment variables with inputs when workflow is manually triggered
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         env:
+          HOURS: ${{ inputs.hours }}
+          CHANNEL: ${{ inputs.slack_channel }}
           VERBOSE: ${{ inputs.verbose_mode }}
         run: |
+          # Set hours:
+          echo "HOURS=$HOURS" >> $GITHUB_ENV
+          # Set Slack channel:
+          CHANNEL_ARG=""
+          if [[ -n $CHANNEL ]]; then
+            CHANNEL_ARG="-s \"$CHANNEL\""
+          fi
+          echo "CHANNEL_ARG=$CHANNEL_ARG" >> $GITHUB_ENV
+          # Set verbose flag:
           VERBOSE_FLAG=''
-          if [[ $VERBOSE == 'Yes' ]]; then
-            VERBOSE_FLAG='-v'
+          if [[ $VERBOSE == "Yes" ]]; then
+            VERBOSE_FLAG="-v"
           fi
           echo "VERBOSE_FLAG=$VERBOSE_FLAG" >> $GITHUB_ENV
-      - run: scripts/gh_scripts/issue_comment_bot.py ${{ inputs.hours }} -c .github/workflows/config/new_comment_digest.json -s "${{ inputs.slack_channel }}" ${{ env.VERBOSE_FLAG }}
+      - run: scripts/gh_scripts/issue_comment_bot.py ${{ env.HOURS }} -c .github/workflows/config/new_comment_digest.json ${{ env.CHANNEL_ARG }} ${{ env.VERBOSE_FLAG }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}

--- a/.github/workflows/new_comment_digest.yml
+++ b/.github/workflows/new_comment_digest.yml
@@ -31,6 +31,8 @@ env:
 
 jobs:
   new_comment_digest:
+    # Continue only if this executed on the main repo
+    if: ${{ github.repository == 'internetarchive/openlibrary' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/new_comment_digest.yml
+++ b/.github/workflows/new_comment_digest.yml
@@ -13,6 +13,13 @@ on:
         type: number
         required: true
         default: 24
+      verbose_mode:
+        description: 'Display detailed information about the issues that need responses? (Verbose mode)'
+        type: choice
+        default: 'No'
+        options:
+        - 'Yes'
+        - 'No'
 
 permissions:
   contents: read
@@ -27,7 +34,16 @@ jobs:
         with:
           python-version: 3.x
       - run: pip install requests
-      - run: scripts/gh_scripts/issue_comment_bot.py ${{ inputs.hours }} -c .github/workflows/config/new_comment_digest.json -s "${{ inputs.slack_channel }}"
+      - name: Set environment variable for verbose flag
+        env:
+          VERBOSE: ${{ inputs.verbose_mode }}
+        run: |
+          VERBOSE_FLAG=''
+          if [[ $VERBOSE == 'Yes' ]]; then
+            VERBOSE_FLAG='-v'
+          fi
+          echo "VERBOSE_FLAG=$VERBOSE_FLAG" >> $GITHUB_ENV
+      - run: scripts/gh_scripts/issue_comment_bot.py ${{ inputs.hours }} -c .github/workflows/config/new_comment_digest.json -s "${{ inputs.slack_channel }}" ${{ env.VERBOSE_FLAG }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}

--- a/.github/workflows/new_comment_digest.yml
+++ b/.github/workflows/new_comment_digest.yml
@@ -7,11 +7,11 @@ on:
       slack_channel:
         description: 'Digest is published to this channel. Entering an empty string will prevent publishing.'
         type: string
-        default: '#team-abc'
+        default: '#team-abc-plus'
       hours:
-        description: 'Search for issues that have new comments within this number of hours'
-        required: true
+        description: 'Search for issues that have new comments within this number of hours.'
         type: number
+        required: true
         default: 24
 
 permissions:

--- a/.github/workflows/new_comment_digest.yml
+++ b/.github/workflows/new_comment_digest.yml
@@ -3,6 +3,17 @@ on:
   schedule:  # 08:30 daily
     - cron: '30 8 * * *'
   workflow_dispatch:
+    inputs:
+      slack_channel:
+        description: 'Digest is published to this channel'
+        type: string
+        default: '#team-abc'
+      hours:
+        description: 'Search for issues that have new comments within this number of hours'
+        required: true
+        type: number
+        default: 24
+
 permissions:
   contents: read
   issues: write
@@ -16,8 +27,7 @@ jobs:
         with:
           python-version: 3.x
       - run: pip install requests
-      - run: scripts/gh_scripts/issue_comment_bot.py 24 -c .github/workflows/config/new_comment_digest.json -s "$SLACK_CHANNEL" -t "$SLACK_TOKEN"
+      - run: scripts/gh_scripts/issue_comment_bot.py ${{ inputs.hours }} -c .github/workflows/config/new_comment_digest.json -s "${{ inputs.slack_channel }}" -t "$SLACK_TOKEN"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-          SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ABC_TEAM_PLUS }}

--- a/scripts/gh_scripts/issue_comment_bot.py
+++ b/scripts/gh_scripts/issue_comment_bot.py
@@ -307,7 +307,8 @@ def publish_digest(
         r = post_message(
             {
                 'channel': slack_channel,
-                'text': 'Warning: some issues were not labeled "Needs: Response"  See the <https://github.com/internetarchive/openlibrary/actions/workflows/new_comment_digest.yml|log files> for more information',
+                'text': 'Warning: some issues were not labeled "Needs: Response". ' \
+                'See the <https://github.com/internetarchive/openlibrary/actions/workflows/new_comment_digest.yml|log files> for more information.',
             }
         )
 

--- a/scripts/gh_scripts/issue_comment_bot.py
+++ b/scripts/gh_scripts/issue_comment_bot.py
@@ -251,7 +251,7 @@ def publish_digest(
 
     d = response.json()
     if not d.get('ok', True):
-        print(f'Slack request not ok.  Error message: {d.get("error", '')}')
+        print(f'Slack request not ok.  Error message: {d.get("error", "")}')
 
     # Store timestamp, which, along with the channel, uniquely identifies the parent thread
     ts = d.get('ts')
@@ -301,7 +301,7 @@ def publish_digest(
         else:
             d = r.json()
             if not d.get('ok', True):
-                print(f'Slack request not ok.  Error message: {d.get("error", '')}')
+                print(f'Slack request not ok.  Error message: {d.get("error", "")}')
 
     if not all_issues_labeled:
         r = post_message(

--- a/scripts/gh_scripts/issue_comment_bot.py
+++ b/scripts/gh_scripts/issue_comment_bot.py
@@ -48,12 +48,11 @@ def fetch_issues():
     fail fast.
     """
     # Make initial query for open issues:
-    p = {
-        'state': 'open',
-        'per_page': 100
-    }
+    p = {'state': 'open', 'per_page': 100}
     response = requests.get(
-        'https://api.github.com/repos/internetarchive/openlibrary/issues', params=p, headers=github_headers
+        'https://api.github.com/repos/internetarchive/openlibrary/issues',
+        params=p,
+        headers=github_headers,
     )
     d = response.json()
     if response.status_code != 200:
@@ -239,10 +238,12 @@ def publish_digest(
         f'{len(issues)} new GitHub comment(s) since {hours_passed} hour(s) ago'
     )
 
-    response = post_message({
+    response = post_message(
+        {
             'channel': slack_channel,
             'text': parent_thread_msg,
-        })
+        }
+    )
 
     if response.status_code != 200:
         print(f'Failed to send message to Slack.  Status code: {response.status_code}')
@@ -270,7 +271,7 @@ def publish_digest(
                 for lead in leads
                 if lead['leadLabel'] == i['lead_label']
             ),
-            ''
+            '',
         )
         slack_id = username and next(
             (
@@ -288,11 +289,13 @@ def publish_digest(
             message += 'Unknown lead\n'
 
         message += f'Commenter: *{commenter}*'
-        r = post_message({
+        r = post_message(
+            {
                 'channel': slack_channel,
                 'text': message,
                 'thread_ts': ts,
-            })
+            }
+        )
         if r.status_code != 200:
             print(f'Failed to send message to Slack.  Status code: {r.status_code}')
         else:
@@ -301,10 +304,12 @@ def publish_digest(
                 print(f'Slack request not ok.  Error message: {d.get("error", '')}')
 
     if not all_issues_labeled:
-        r = post_message({
-            'channel': slack_channel,
-            'text': 'Warning: some issues were not labeled "Needs: Response"  See the <https://github.com/internetarchive/openlibrary/actions/workflows/new_comment_digest.yml|log files> for more information'
-        })
+        r = post_message(
+            {
+                'channel': slack_channel,
+                'text': 'Warning: some issues were not labeled "Needs: Response"  See the <https://github.com/internetarchive/openlibrary/actions/workflows/new_comment_digest.yml|log files> for more information',
+            }
+        )
 
 
 def time_since(hours):
@@ -330,7 +335,9 @@ def add_label_to_issues(issues) -> bool:
 
         if response.status_code != 200:
             all_issues_labeled = False
-            print(f'Failed to label issue #{issue["number"]} --- status code: {response.status_code}')
+            print(
+                f'Failed to label issue #{issue["number"]} --- status code: {response.status_code}'
+            )
             print(issue_labels_url)
 
     return all_issues_labeled
@@ -365,7 +372,9 @@ def token_verification(slack_channel: str = ''):
     if not os.environ.get('GITHUB_TOKEN', ''):
         raise AuthenticationError('Required GitHub token not found in environment.')
     if slack_channel and not os.environ.get('SLACK_TOKEN', ''):
-        raise AuthenticationError('Slack token must be included in environment if Slack channel is provided.')
+        raise AuthenticationError(
+            'Slack token must be included in environment if Slack channel is provided.'
+        )
 
 
 def start_job():
@@ -386,7 +395,9 @@ def start_job():
         config = read_config(args.config)
         leads = config.get('leads', [])
     except (OSError, json.JSONDecodeError):
-        raise ConfigurationError('An error occurred while parsing the configuration file.')
+        raise ConfigurationError(
+            'An error occurred while parsing the configuration file.'
+        )
 
     print('Fetching issues from GitHub...')
     issues = fetch_issues()

--- a/scripts/gh_scripts/issue_comment_bot.py
+++ b/scripts/gh_scripts/issue_comment_bot.py
@@ -307,8 +307,9 @@ def publish_digest(
         r = post_message(
             {
                 'channel': slack_channel,
-                'text': 'Warning: some issues were not labeled "Needs: Response". ' \
-                'See the <https://github.com/internetarchive/openlibrary/actions/workflows/new_comment_digest.yml|log files> for more information.',
+                'text': ('Warning: some issues were not labeled "Needs: Response". '
+                    'See the <https://github.com/internetarchive/openlibrary/actions/workflows/new_comment_digest.yml|log files> for more information.'
+                ),
             }
         )
 

--- a/scripts/gh_scripts/issue_comment_bot.py
+++ b/scripts/gh_scripts/issue_comment_bot.py
@@ -307,7 +307,8 @@ def publish_digest(
         r = post_message(
             {
                 'channel': slack_channel,
-                'text': ('Warning: some issues were not labeled "Needs: Response". '
+                'text': (
+                    'Warning: some issues were not labeled "Needs: Response". '
                     'See the <https://github.com/internetarchive/openlibrary/actions/workflows/new_comment_digest.yml|log files> for more information.'
                 ),
             }

--- a/scripts/gh_scripts/issue_comment_bot.py
+++ b/scripts/gh_scripts/issue_comment_bot.py
@@ -204,11 +204,14 @@ def publish_digest(
         message = f'<{comment_url}|Latest comment for: *{issue_title}*>\n'
 
         username = next(
-            lead['githubUsername']
-            for lead in leads
-            if lead['leadLabel'] == i['lead_label']
+            (
+                lead['githubUsername']
+                for lead in leads
+                if lead['leadLabel'] == i['lead_label']
+            ),
+            ''
         )
-        slack_id = next(
+        slack_id = username and next(
             (
                 lead['slackId']  # type: ignore[syntax]
                 for lead in leads
@@ -221,7 +224,7 @@ def publish_digest(
         elif i['lead_label']:
             message += f'{i["lead_label"]}\n'
         else:
-            message += 'Lead: N/A\n'
+            message += 'Unknown lead\n'
 
         message += f'Commenter: *{commenter}*'
         r = post_message({


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9513

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Makes several changes to our daily `new_comment_digest` GitHub workflow and related scripts:
- Switch heavily rate-limited site-wide GitHub search call to more permissive repo issues search call
- Add additional issue filtering to compensate for reduced search faceting on new search endpoint
- Add guard to workflow so that it only runs from this repo
- Configured workflow to allow maintainers to provide the following inputs when manually triggering the workflow:
  - Slack Channel
  - Hours until issue is stale
  - Verbose mode
  - Disable labeling issues https://github.com/internetarchive/openlibrary/labels/Needs%3A%20Response 
- Introduces a second of wait time between all GitHub API calls
- Add fail-fast conditions when:
  - A required token is not present in the environment (exit code `10`)
  - The configuration file cannot be read (exit code `20`)
  - Fetching issues from GitHub fails (exit code `30`)
- Publishes search URL to Slack when the script fails to fetch all issues from GitHub
  - Staff can manually label issues in this case
- Improved logging
- Set default value for `next` call that sets `username`

Labeled https://github.com/internetarchive/openlibrary/labels/Needs%3A%20Special%20Deploy as a reminder to re-run this for the past few weeks to catch anything that was missed while this workflow was broken.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
