### PR TITLE
Chunk keys in lazy-thing-preview; fix long lists editing

### DIFF
--- a/openlibrary/plugins/openlibrary/js/lazy-thing-preview.js
+++ b/openlibrary/plugins/openlibrary/js/lazy-thing-preview.js
@@ -1,5 +1,6 @@
 // @ts-check
 import debounce from 'lodash/debounce';
+import chunk from 'lodash/chunk';
 
 /**
  * Responds to HTML like:
@@ -68,17 +69,17 @@ export class LazyThingPreview {
         const authorKeys = keys.filter(key => key.startsWith('/authors/'));
         const fields = 'key,type,cover_i,first_publish_year,author_name,title,subtitle,edition_count,editions';
         let docs = [];
-        if (workKeys.length) {
+        for (const keys of chunk(workKeys, 100)) {
             const resp = await fetch(`/search.json?${new URLSearchParams({
-                q: `key:(${workKeys.join(' OR ')})`,
+                q: `key:(${keys.join(' OR ')})`,
                 fields,
                 limit: '100',
             })}`).then(r => r.json());
             docs = docs.concat(resp.docs);
         }
-        if (editionKeys.length) {
+        for (const keys of chunk(editionKeys, 100)) {
             const resp = await fetch(`/search.json?${new URLSearchParams({
-                q: `edition_key:(${editionKeys
+                q: `edition_key:(${keys
                     .map(key => key.split('/').pop())
                     .join(' OR ')})`,
                 fields,
@@ -86,9 +87,9 @@ export class LazyThingPreview {
             })}`).then(r => r.json());
             docs = docs.concat(resp.docs);
         }
-        if (authorKeys.length) {
+        for (const keys of chunk(authorKeys, 100)) {
             const resp = await fetch(`/search/authors.json?${new URLSearchParams({
-                q: `key:(${authorKeys.join(' OR ')})`,
+                q: `key:(${keys.join(' OR ')})`,
                 fields: 'key,type,name,top_work,top_subjects,birth_date,death_date',
                 limit: '100',
             })}`).then(r => r.json());


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9535 . Fixes lists with many items timing out when lazy-rendering the book titles/covers.


### Technical
- A _better_ solution might be make these load when they're rendered; since now we're fetching/rendering all 400 books when the user likely only ever be looking at max 10 at a time, but since this page is only viewable by one when logged in and looking at their own list, this is sufficient for now.

### Testing
Before: https://openlibrary.org/people/el4ctr0n/lists/OL235242L/Specific_History_Books/edit
After: https://testing.openlibrary.org/people/el4ctr0n/lists/OL235242L/Specific_History_Books/edit

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
