### PR TITLE
Hide sign-up form in the case of IA third-party login

### DIFF
--- a/openlibrary/plugins/openlibrary/js/ia_thirdparty_logins.js
+++ b/openlibrary/plugins/openlibrary/js/ia_thirdparty_logins.js
@@ -13,8 +13,10 @@ export function initMessageEventListener(element) {
         if (!/[./]archive\.org$$/.test(e.origin)) return;
 
         if (e.data.type === 'resize') {
+            const formDivs = document.querySelectorAll('form[name=signup], .ol-signup-form__big-or');
             element.setAttribute('scrolling', 'no');
             if (e.data.height) element.style.height = `${e.data.height}px`;
+            formDivs.forEach(div => div.style.display = 'none');
         }
         else if (e.data.type === 's3-keys') {
             fetch('/account/login.json', {


### PR DESCRIPTION
**Note:** Left as a draft because only partial testing was possible locally, will need to try it on testing to confirm the function works as expected.

<!-- What issue does this PR close? -->
Closes #9540.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature. Hides the sign-up form if the IA third-party login form expands.

### Technical
<!-- What should be noted about the implementation? -->
Uses the same implementation as in `covers.js` in #9418 to add a `display: none` to the two relevant elements `form[name=signup]` and `.ol-signup-form__big-or` to the existing function in `ia_thirdparty_logins.js` that handles a resize request.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Go to `/account/create`
2. Select the "Sign in with Google" button and use an email address that has an IA but not OL account
3. The `iframe` should expand with an IA login form, and the rest of the registration form should disappear

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
[to be added when on testing]

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
