### PR TITLE
Aggregate want to read counts by author

### DIFF
--- a/openlibrary/core/ratings.py
+++ b/openlibrary/core/ratings.py
@@ -114,11 +114,13 @@ class Ratings(db.CommonExtras):
         cls, rating_counts: list[int]
     ) -> WorkRatingsSummary:
         total_count = sum(rating_counts, 0)
+        ratings_average = (
+            (sum((k * n_k for k, n_k in enumerate(rating_counts, 1)), 0) / total_count)
+            if total_count != 0
+            else 0
+        )
         return {
-            'ratings_average': sum(
-                (k * n_k for k, n_k in enumerate(rating_counts, 1)), 0
-            )
-            / total_count,
+            'ratings_average': ratings_average,
             'ratings_sortable': cls.compute_sortable_rating(rating_counts),
             'ratings_count': total_count,
             'ratings_count_1': rating_counts[0],

--- a/openlibrary/solr/updater/author.py
+++ b/openlibrary/solr/updater/author.py
@@ -119,7 +119,7 @@ class AuthorSolrBuilder(AbstractSolrBuilder):
     def build_ratings(self) -> WorkRatingsSummary:
         return Ratings.work_ratings_summary_from_counts(
             [
-                self._solr_reply["facets"].get(f"ratings_count_{index}")
+                self._solr_reply["facets"].get(f"ratings_count_{index}", 0)
                 for index in range(1, 6)
             ]
         )

--- a/openlibrary/solr/updater/author.py
+++ b/openlibrary/solr/updater/author.py
@@ -43,20 +43,7 @@ class AuthorSolrUpdater(AbstractSolrUpdater):
                 "field": "%s_facet" % field,
             }
         async with httpx.AsyncClient() as client:
-            response = await client.post(
-                base_url,
-                params=[  # type: ignore[arg-type]
-                    ('wt', 'json'),
-                    ('json.nl', 'arrarr'),
-                    ('q', 'author_key:%s' % author_id),
-                    ('sort', 'edition_count desc'),
-                    ('rows', 1),
-                    ('fl', 'title,subtitle'),
-                    ('facet', 'true'),
-                    ('facet.mincount', 1),
-                ]
-                + [('facet.field', '%s_facet' % field) for field in facet_fields],
-            )
+            response = await client.post(base_url, json=json)
             reply = response.json()
 
         doc = AuthorSolrBuilder(author, reply).build()

--- a/openlibrary/tests/solr/updater/test_author.py
+++ b/openlibrary/tests/solr/updater/test_author.py
@@ -23,16 +23,19 @@ class TestAuthorUpdater:
             async def __aexit__(self, exc_type, exc_val, exc_tb):
                 pass
 
-            async def get(self, url, params):
+            async def post(self, url, json):
                 return MockResponse(
                     {
-                        "facet_counts": {
-                            "facet_fields": {
-                                "place_facet": [],
-                                "person_facet": [],
-                                "subject_facet": [],
-                                "time_facet": [],
-                            }
+                        "facets": {
+                            "ratings_count_1": 0.0,
+                            "ratings_count_2": 0.0,
+                            "ratings_count_3": 0.0,
+                            "ratings_count_4": 0.0,
+                            "ratings_count_5": 0.0,
+                            "subject_facet": {"buckets": []},
+                            "place_facet": {"buckets": []},
+                            "time_facet": {"buckets": []},
+                            "person_facet": {"buckets": []},
                         },
                         "response": {"numFound": 0},
                     }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9359 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR adds summed counts for each of an authors's works' readinglog counts to the author, which will be useful for popularity measures later down the line. 

### Technical
<!-- What should be noted about the implementation? -->
The request sent to Solr has been changed to use the Solr JSON endpoint, thus necessitating it to be a POST request rather than GET. This allows for aggregations like 'sum' to be easily executed within the request.  

A few changes to the return format were made, due to the way in which the Facet API returns data. Notably, each facet is now under the same category, with 'subject', 'place' and '
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Simply edit an author's page or reindex their key via the Admin  Solr endpoint, and look for the new 'want_to_read_count' or 'readinglog_facets` categories upon requesting their Solr data. 
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
