### PR TITLE
Fix Search Box Only Visible On Want To Read

### DIFF
--- a/openlibrary/templates/account/reading_log.html
+++ b/openlibrary/templates/account/reading_log.html
@@ -3,7 +3,7 @@ $def with (docs, key, shelf_count, doc_count, owners_page, current_page, sort_or
 $ username = user.key.split('/')[-1]
 $ meta_photo_url = "https://archive.org/services/img/%s" % get_internet_archive_id(user.key)
 $ userDisplayName = user.displayname or ctx.user.displayname
-$ readlog_keys = ['want-to-read', 'already-ready', 'current-reading']
+$ readlog_keys = ['want-to-read', 'already-read', 'currently-reading']
 
 $if key == 'currently-reading':
   $ og_title = _("Books %(username)s is reading", username=userDisplayName)


### PR DESCRIPTION

<!-- What issue does this PR close? -->
Closes #9547 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR achieves a quick fix to return the search bars to users' already-read and currently-reading pages. Somehow, the names of two of the keys used to check rendering  got changed, so the search bar was no longer loading. 

### Technical
<!-- What should be noted about the implementation? -->
There was very little technical about this issue, it just involved fixing some changes made to a template's variables. 
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Go to your already_read or currently_reading pages on your account, and see the search bar. 
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/internetarchive/openlibrary/assets/131627264/2ffe47e7-002e-4f7e-b510-671a88eee189)
![image](https://github.com/internetarchive/openlibrary/assets/131627264/8aa33b41-a04f-4e8b-94da-70002316e4f7)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
