### PR TITLE
Temporarily downscale 8XXXXXX-L.jpg covers

### DIFF
--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -255,10 +255,11 @@ class cover:
         elif key != 'id':
             value = self.query(category, key, value)
 
-        if not value or (value and safeint(value) in config.blocked_covers):
+        value = safeint(value)
+        if value is None or value in config.blocked_covers:
             return notfound()
 
-        if 9_000_000 > int(value) >= 8_000_000 and size == "L":
+        if 9_000_000 > value >= 8_000_000 and size == "L":
             # This item is currently offline due to heavy traffic;
             # Fix incoming in the next ~week; See:
             # - https://webarchive.jira.com/browse/PBOX-3879
@@ -267,20 +268,19 @@ class cover:
 
         # redirect to archive.org cluster for large size and original images whenever possible
         if size in ("L", "") and self.is_cover_in_cluster(value):
-            url = zipview_url_from_id(int(value), size)
+            url = zipview_url_from_id(value, size)
             return web.found(url)
 
         # covers_0008 batches [_00, _82] are tar'd / zip'd in archive.org items
-        if isinstance(value, int) or value.isnumeric():  # noqa: SIM102
-            if 8_820_000 > int(value) >= 8_000_000:
-                prefix = f"{size.lower()}_" if size else ""
-                pid = "%010d" % int(value)
-                item_id = f"{prefix}covers_{pid[:4]}"
-                item_tar = f"{prefix}covers_{pid[:4]}_{pid[4:6]}.tar"
-                item_file = f"{pid}{'-' + size.upper() if size else ''}"
-                path = f"{item_id}/{item_tar}/{item_file}.jpg"
-                protocol = web.ctx.protocol
-                return web.found(f"{protocol}://archive.org/download/{path}")
+        if 8_820_000 > value >= 8_000_000:
+            prefix = f"{size.lower()}_" if size else ""
+            pid = "%010d" % value
+            item_id = f"{prefix}covers_{pid[:4]}"
+            item_tar = f"{prefix}covers_{pid[:4]}_{pid[4:6]}.tar"
+            item_file = f"{pid}{'-' + size.upper() if size else ''}"
+            path = f"{item_id}/{item_tar}/{item_file}.jpg"
+            protocol = web.ctx.protocol
+            return web.found(f"{protocol}://archive.org/download/{path}")
 
         d = self.get_details(value, size.lower())
         if not d:
@@ -336,14 +336,9 @@ class cover:
             h,
         )
 
-    def get_details(self, coverid, size=""):
-        try:
-            coverid = int(coverid)
-        except ValueError:
-            return None
-
+    def get_details(self, coverid: int, size=""):
         # Use tar index if available to avoid db query. We have 0-6M images in tar balls.
-        if isinstance(coverid, int) and coverid < 6000000 and size in "sml":
+        if coverid < 6000000 and size in "sml":
             path = self.get_tar_filename(coverid, size)
 
             if path:
@@ -357,12 +352,12 @@ class cover:
 
         return db.details(coverid)
 
-    def is_cover_in_cluster(self, coverid):
+    def is_cover_in_cluster(self, coverid: int):
         """Returns True if the cover is moved to archive.org cluster.
         It is found by looking at the config variable max_coveritem_index.
         """
         try:
-            return int(coverid) < IMAGES_PER_ITEM * config.get("max_coveritem_index", 0)
+            return coverid < IMAGES_PER_ITEM * config.get("max_coveritem_index", 0)
         except (TypeError, ValueError):
             return False
 

--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -258,6 +258,13 @@ class cover:
         if not value or (value and safeint(value) in config.blocked_covers):
             return notfound()
 
+        if 9_000_000 > int(value) >= 8_000_000 and size == "L":
+            # This item is currently offline due to heavy traffic;
+            # Fix incoming in the next ~week; See:
+            # - https://webarchive.jira.com/browse/PBOX-3879
+            # - https://github.com/internetarchive/openlibrary/issues/9560
+            size = "M"
+
         # redirect to archive.org cluster for large size and original images whenever possible
         if size in ("L", "") and self.is_cover_in_cluster(value):
             url = zipview_url_from_id(int(value), size)

--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -259,7 +259,7 @@ class cover:
         if value is None or value in config.blocked_covers:
             return notfound()
 
-        if 9_000_000 > value >= 8_000_000 and size == "L":
+        if 8_820_000 > value >= 8_000_000 and size == "L":
             # This item is currently offline due to heavy traffic;
             # Fix incoming in the next ~week; See:
             # - https://webarchive.jira.com/browse/PBOX-3879


### PR DESCRIPTION
Work towards #9560 

The backing IA item is struggling with traffic, but will be re-enabled once it is switched from .tar to .zip in the next week or so

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
Previously erroring covers (eg https://covers.openlibrary.org/b/id/8791306-L.jpg) are no longer erroring and serving the smaller image

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles @hbromley


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
