### PR TITLE
Use new search box on reading log pages, author page 

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -1437,16 +1437,17 @@ msgstr ""
 
 #: account/reading_log.html
 #, python-format
+msgid "Books in %(username)s feed"
+msgstr ""
+
+#: account/reading_log.html
+#, python-format
 msgid "Books added by people %(username)s follows"
 msgstr ""
 
 #: account/reading_log.html
 #, python-format
 msgid "Books %(userdisplayname)s is sponsoring"
-msgstr ""
-
-#: account/reading_log.html
-msgid "Search your reading log"
 msgstr ""
 
 #: account/reading_log.html search/sort_options.html

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -1437,11 +1437,6 @@ msgstr ""
 
 #: account/reading_log.html
 #, python-format
-msgid "Books in %(username)s feed"
-msgstr ""
-
-#: account/reading_log.html
-#, python-format
 msgid "Books added by people %(username)s follows"
 msgstr ""
 

--- a/openlibrary/templates/account/reading_log.html
+++ b/openlibrary/templates/account/reading_log.html
@@ -44,8 +44,10 @@ $add_metatag(property="og:image", content=meta_photo_url)
   $if len(docs) > 0:
     $if key in readlog_keys:
       <form method="GET" class="olform pagesearchbox">
-        <input type="text" minlength="3" placeholder="$_('Search your reading log')" name="q" value="$(query_param('q', ''))"/>
-        <input type="submit"/>
+        $:render_template("search/searchbox", q=query_param('q'))
+        <script>
+          document.querySelector('.pagesearchbox input[name="q"]').placeholder = "Search your reading log";
+        </script>
       </form>
     $if q:
       <span class="search-results-stats">$ungettext('%(count)s hit', '%(count)s hits', doc_count, count=commify(doc_count))</span>

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -135,8 +135,15 @@ $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_libra
                     <input type="hidden" name="sort" value="$query_param('sort')"/>
                   $if (query_param('mode')):
                     <input type="hidden" name="mode" value="$query_param('mode')"/>
-                  <input type="text" placeholder="Search $title Books" name="q" value="$(query_param('q', ''))"/>
-                  <input type="submit"/>
+                  $:render_template("search/searchbox", q=query_param('q'))
+                  <script>
+                    document.addEventListener('DOMContentLoaded', function() {
+                      var searchInput = document.querySelector('.pagesearchbox input[type="text"]');
+                      if (searchInput) {
+                        searchInput.placeholder = "Search $title Books";
+                      }
+                    });
+                  </script>
                 </form>
 
                 $:macros.Pager(page=safeint(query_param('page'), default=1), num_found=books_count)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9557 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Substituted input tags with a render_template() invocation.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Navigate to 'My Books' -> 'Reading Log' (from the left-side menu) or directly access any author's page.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
Old Search Box (Reading Log):
![image](https://github.com/user-attachments/assets/5bd8ce1d-4c28-43e5-976f-e730a7160d7c)
New Search Box (Reading Log):
![reading_log](https://github.com/user-attachments/assets/00853cfd-a08f-441e-aeb3-655ca58b8cbf)

Old Search Box (Author Page):
![image](https://github.com/user-attachments/assets/7d792466-872b-41e5-a253-410f467db810)
New Search Box(Author Page):
![author_page](https://github.com/user-attachments/assets/50c00916-887a-473b-866f-ac20aff90f96)

Stakeholders
@cdrini @jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
