### PR TITLE
Improved Documentation Structure for New_Contributors

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,7 +20,7 @@ Are you looking to get started? [This is the guide](https://github.com/interneta
      - [The Service Architecture](https://github.com/internetarchive/openlibrary/wiki/Production-Service-Architecture)
    - [Developer's Guide](#developers-guide)
    - [Running Tests](#running-tests)
-   - [Contributing](CONTRIBUTING.md)
+   - [Contributing](#contributing)
    - [Public APIs](https://openlibrary.org/developers/api)
    - [FAQs](https://openlibrary.org/help/faq)
 
@@ -83,6 +83,27 @@ Open Library tests can be run using docker. Kindly look up on our [Testing Docum
 ```
 docker compose run --rm home make test
 ```
+
+## Contributing
+
+There are many ways volunteers can contribute to the Open Library project, from development and design to data management and community engagement. Here’s how you can get involved:
+
+### Developers
+- **Getting Started:** Check out our [Contributing Guide](https://github.com/internetarchive/openlibrary/blob/master/CONTRIBUTING.md) for instructions on how to set up your development environment, find issues to work on, and submit your contributions.
+- **Good First Issues:** Browse our [Good First Issues](https://github.com/internetarchive/openlibrary/issues?q=is%3Aissue+is%3Aopen+-linked%3Apr+label%3A%22Good+First+Issue%22+no%3Aassignee) to find beginner-friendly tasks.
+
+### Designers
+- **Design Contributions:** We welcome designers to help improve the user experience. You can start by looking at [design-related issues](https://github.com/internetarchive/openlibrary/labels/design).
+
+### Librarians and Data Enthusiasts
+- **Data Contributions:** Learn how to contribute to our catalog and help improve book data on Open Library. Visit our [volunteer page](https://openlibrary.org/volunteer) for more information.
+
+### Community Engagement
+- **Join our Community Calls:** Open Library hosts weekly community and design calls. Check the [community call schedule](https://github.com/internetarchive/openlibrary/wiki/Community-Call) for times and details.
+- **Ask Questions:** If you have any questions, join our [gitter chat](https://gitter.im/theopenlibrary/Lobby) or request an invitation to our Slack channel on our [volunteers page](https://openlibrary.org/volunteer).
+
+For more detailed information, refer to the [Contributing Guide](https://github.com/internetarchive/openlibrary/blob/master/CONTRIBUTING.md).
+
 
 ## License
 


### PR DESCRIPTION
Closes: #9091

## Summary
This PR improves the structure of the README.md file by adding a dedicated "Contributing" section. This section provides a brief introduction to the various ways volunteers can contribute to the Open Library project, making it easier for new contributors to get started and understand how they can help. The changes aim to make the documentation more organized and user-friendly.

## Changes Made
1. **Added a "Contributing" Section in README.md**:
   - Created a new section titled "Contributing" in the README file.
   - Provided a brief introduction to the various ways contributors can participate (e.g., developers, designers, librarians).
   - Included links to relevant documents and pages for each type of contributor:
     - Developers: Linked to `CONTRIBUTING.md`.
     - Librarians: Linked to the [volunteer page](https://openlibrary.org/volunteer).
     - Designers: Suggested checking specific issues.
   - Mentioned the different types of community calls and provided a link to the community call page for more details.

2. **Updated Table of Contents**:
   - Added the new "Contributing" section to the Table of Contents in the README file for better navigation.

## Reason for Changes
These changes are intended to make the README file more informative and welcoming for new contributors. By providing a clear overview of the various ways to contribute and linking to the appropriate resources, we aim to streamline the onboarding process and encourage more community participation.

## The collaborator suggested changes have been done

## Updated Readme screenshot-
![Screenshot from 2024-07-16 12-21-24](https://github.com/user-attachments/assets/24b1c8f9-737b-4d2d-af49-443d98ad6e4f)

