### PR TITLE
Create controllers.py

### DIFF
--- a/openlibrary/templates/covers/openlibrary/catalog/controllers.py
+++ b/openlibrary/templates/covers/openlibrary/catalog/controllers.py
@@ -1,0 +1,4 @@
+def get_cover_url(edition):
+    if edition.get('cover'):
+        return edition['cover']
+    return url_for('static', filename='images/no-cover.png')


### PR DESCRIPTION
The function ensures that a default 'no-cover' image is shown when no cover image is available for a book.

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
