### PR TITLE
Sort out Author types on import

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -679,8 +679,8 @@ def load_data(
 
     edits: list[dict] = []  # Things (Edition, Work, Authors) to be saved
     reply = {}
-    # edition.authors may have already been processed by import_authors() in build_query(), but not
-    # neccesarily
+    # edition.authors may have already been processed by import_authors() in build_query(),
+    # but not necessarily
     author_in = [
         import_author(a, eastern=east_in_by_statement(rec, a)) if isinstance(a, dict) else a
         for a in edition.get('authors', [])

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -682,7 +682,11 @@ def load_data(
     # edition.authors may have already been processed by import_authors() in build_query(),
     # but not necessarily
     author_in = [
-        import_author(a, eastern=east_in_by_statement(rec, a)) if isinstance(a, dict) else a
+        (
+            import_author(a, eastern=east_in_by_statement(rec, a))
+            if isinstance(a, dict)
+            else a
+        )
         for a in edition.get('authors', [])
     ]
     # build_author_reply() adds authors to edits

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -679,9 +679,10 @@ def load_data(
 
     edits: list[dict] = []  # Things (Edition, Work, Authors) to be saved
     reply = {}
-    # TOFIX: edition.authors has already been processed by import_authors() in build_query(), following line is a NOP?
+    # edition.authors may have already been processed by import_authors() in build_query(), but not
+    # neccesarily
     author_in = [
-        import_author(a, eastern=east_in_by_statement(rec, a))
+        import_author(a, eastern=east_in_by_statement(rec, a)) if isinstance(a, dict) else a
         for a in edition.get('authors', [])
     ]
     # build_author_reply() adds authors to edits

--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -263,7 +263,7 @@ class InvalidLanguage(Exception):
         self.code = code
 
     def __str__(self):
-        return "invalid language code: '%s'" % self.code
+        return f"invalid language code: '{self.code}'"
 
 
 type_map = {'description': 'text', 'notes': 'text', 'number_of_pages': 'int'}
@@ -275,7 +275,7 @@ def build_query(rec: dict[str, Any]) -> dict[str, Any]:
     suitable for saving.
     :return: Open Library style edition dict representation
     """
-    book = {
+    book: dict[str, Any] = {
         'type': {'key': '/type/edition'},
     }
     for k, v in rec.items():

--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -175,15 +175,9 @@ def find_entity(author: dict[str, Any]) -> "Author | None":
     :return: Existing Author record if found, or None.
     """
     assert isinstance(author, dict)
-    name = author['name']
     things = find_author(author)
-    et = author.get('entity_type')
-    if et and et != 'person':
-        if not things:
-            return None
-        db_entity = things[0]
-        assert db_entity.type.key == '/type/author'
-        return db_entity
+    if author.get('entity_type', 'person') != 'person':
+        return things[0] if things else None
     match = []
     seen = set()
     for a in things:

--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -3,7 +3,6 @@ import web
 from openlibrary.catalog.utils import flip_name, author_dates_match, key_int
 from openlibrary.core.helpers import extract_year
 
-
 if TYPE_CHECKING:
     from openlibrary.plugins.upstream.models import Author
 
@@ -65,17 +64,12 @@ HONORIFC_NAME_EXECPTIONS = frozenset(
 )
 
 
-def east_in_by_statement(rec, author):
+def east_in_by_statement(rec: dict[str, Any], author: dict[str, Any]) -> bool:
     """
     Returns False if there is no by_statement in rec.
     Otherwise returns whether author name uses eastern name order.
     TODO: elaborate on what this actually means, and how it is used.
-
-    :param dict rec: import source edition record
-    :param dict author: import source author dict: {"name": "Some One"}
-    :rtype: bool
     """
-
     if 'by_statement' not in rec:
         return False
     if 'authors' not in rec:
@@ -90,13 +84,10 @@ def east_in_by_statement(rec, author):
     return rec['by_statement'].find(name) != -1
 
 
-def do_flip(author):
+def do_flip(author: dict[str, Any]) -> None:
     """
     Given an author import dict, flip its name in place
     i.e. Smith, John => John Smith
-
-    :param dict author:
-    :rtype: None
     """
     if 'personal_name' in author and author['personal_name'] != author['name']:
         # Don't flip names if name is more complex than personal_name (legacy behaviour)
@@ -117,7 +108,7 @@ def do_flip(author):
         author['personal_name'] = name
 
 
-def pick_from_matches(author, match):
+def pick_from_matches(author: dict[str, Any], match: list["Author"]) -> "Author":
     """
     Finds the best match for author from a list of OL authors records, match.
 
@@ -140,11 +131,7 @@ def pick_from_matches(author, match):
 
 def find_author(author: dict[str, Any]) -> list["Author"]:
     """
-    Searches OL for an author by name.
-
-    :param str name: Author's name
-    :rtype: list
-    :return: A list of OL author representations than match name
+    Searches OL for an author by a range of queries.
     """
 
     def walk_redirects(obj, seen):
@@ -181,12 +168,13 @@ def find_author(author: dict[str, Any]) -> list["Author"]:
 
 def find_entity(author: dict[str, Any]) -> "Author | None":
     """
-    Looks for an existing Author record in OL by name
+    Looks for an existing Author record in OL
     and returns it if found.
 
     :param dict author: Author import dict {"name": "Some One"}
     :return: Existing Author record if found, or None.
     """
+    assert isinstance(author, dict)
     name = author['name']
     things = find_author(author)
     et = author.get('entity_type')
@@ -194,11 +182,11 @@ def find_entity(author: dict[str, Any]) -> "Author | None":
         if not things:
             return None
         db_entity = things[0]
-        assert db_entity['type']['key'] == '/type/author'
+        assert db_entity.type.key == '/type/author'
         return db_entity
     if ', ' in name:
-        flipped_name = flip_name(author["name"])
         author_flipped_name = author.copy()
+        author_flipped_name['name'] = flip_name(name)
         things += find_author(author_flipped_name)
     match = []
     seen = set()
@@ -241,7 +229,6 @@ def remove_author_honorifics(name: str) -> str:
         None,
     ):
         return name[len(f"{honorific} ") :].lstrip() or name
-
     return name
 
 
@@ -253,9 +240,10 @@ def import_author(author: dict[str, Any], eastern=False) -> "Author | dict[str, 
 
     :param dict author: Author import record {"name": "Some One"}
     :param bool eastern: Eastern name order
-    :return: Open Library style Author representation, either existing with "key",
-             or new candidate without "key".
+    :return: Open Library style Author representation, either existing Author with "key",
+             or new candidate dict without "key".
     """
+    assert isinstance(author, dict)
     if existing := find_entity(author):
         assert existing.type.key == '/type/author'
         for k in 'last_modified', 'id', 'revision', 'created':
@@ -285,19 +273,15 @@ class InvalidLanguage(Exception):
 type_map = {'description': 'text', 'notes': 'text', 'number_of_pages': 'int'}
 
 
-def build_query(rec):
+def build_query(rec: dict[str, Any]) -> dict[str, Any]:
     """
     Takes an edition record dict, rec, and returns an Open Library edition
     suitable for saving.
-
-    :param dict rec: Edition record to add to Open Library
-    :rtype: dict
-    :return: Open Library style edition representation
+    :return: Open Library style edition dict representation
     """
     book = {
         'type': {'key': '/type/edition'},
     }
-
     for k, v in rec.items():
         if k == 'authors':
             if v and v[0]:

--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -184,10 +184,6 @@ def find_entity(author: dict[str, Any]) -> "Author | None":
         db_entity = things[0]
         assert db_entity.type.key == '/type/author'
         return db_entity
-    if ', ' in name:
-        author_flipped_name = author.copy()
-        author_flipped_name['name'] = flip_name(name)
-        things += find_author(author_flipped_name)
     match = []
     seen = set()
     for a in things:
@@ -244,6 +240,8 @@ def import_author(author: dict[str, Any], eastern=False) -> "Author | dict[str, 
              or new candidate dict without "key".
     """
     assert isinstance(author, dict)
+    if author.get('entity_type') != 'org' and not eastern:
+        do_flip(author)
     if existing := find_entity(author):
         assert existing.type.key == '/type/author'
         for k in 'last_modified', 'id', 'revision', 'created':
@@ -253,8 +251,6 @@ def import_author(author: dict[str, Any], eastern=False) -> "Author | dict[str, 
         if 'death_date' in author and 'death_date' not in existing:
             new['death_date'] = author['death_date']
         return new
-    if author.get('entity_type') != 'org' and not eastern:
-        do_flip(author)
     a = {'type': {'key': '/type/author'}}
     for f in 'name', 'title', 'personal_name', 'birth_date', 'death_date', 'date':
         if f in author:

--- a/openlibrary/catalog/add_book/tests/test_load_book.py
+++ b/openlibrary/catalog/add_book/tests/test_load_book.py
@@ -7,6 +7,7 @@ from openlibrary.catalog.add_book.load_book import (
     InvalidLanguage,
     remove_author_honorifics,
 )
+from openlibrary.core.models import Author
 
 
 @pytest.fixture()
@@ -40,6 +41,7 @@ unchanged_names = [
 @pytest.mark.parametrize('author', natural_names)
 def test_import_author_name_natural_order(author, new_import):
     result = import_author(author)
+    assert isinstance(result, dict)
     assert result['name'] == 'Forename Surname'
 
 
@@ -47,6 +49,7 @@ def test_import_author_name_natural_order(author, new_import):
 def test_import_author_name_unchanged(author, new_import):
     expect = author['name']
     result = import_author(author)
+    assert isinstance(result, dict)
     assert result['name'] == expect
 
 
@@ -235,6 +238,7 @@ class TestImportAuthor:
             "death_date": "1881",
         }
         found = import_author(searched_author)
+        assert isinstance(found, Author)
         assert found.key == author_alternate_name_with_dates["key"]
 
     def test_last_match_on_surname_and_dates(self, mock_site):


### PR DESCRIPTION
fixes #9599

Corrects some expected type issues introduced in https://github.com/internetarchive/openlibrary/commit/53d376b148897466bb86d5accb51912bbbe9a8ed
and possibly a pre-existing inefficiency where in some cases existing `Author` objects were sent through the author matching process to find matches... 

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
