### PR TITLE
Reorganize JS for registration form and add loading indicator

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -429,7 +429,8 @@ msgstr ""
 msgid "Library Explorer"
 msgstr ""
 
-#: books/custom_carousel.html login.html search/work_search_facets.html
+#: account/create.html books/custom_carousel.html login.html
+#: search/work_search_facets.html
 msgid "Loading..."
 msgstr ""
 
@@ -1017,11 +1018,6 @@ msgstr ""
 
 #: account/create.html
 msgid "Username may only contain numbers, letters, - or _"
-msgstr ""
-
-#: account/create.html books/custom_carousel.html
-#: search/work_search_facets.html
-msgid "Loading..."
 msgstr ""
 
 #: account/create.html

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -1019,6 +1019,11 @@ msgstr ""
 msgid "Username may only contain numbers, letters, - or _"
 msgstr ""
 
+#: account/create.html books/custom_carousel.html
+#: search/work_search_facets.html
+msgid "Loading..."
+msgstr ""
+
 #: account/create.html
 msgid "Sign Up to Open Library"
 msgstr ""

--- a/openlibrary/plugins/openlibrary/js/signup.js
+++ b/openlibrary/plugins/openlibrary/js/signup.js
@@ -2,6 +2,7 @@ import { debounce } from './nonjquery_utils.js';
 
 export function initSignupForm() {
     const signupForm = document.querySelector('form[name=signup]');
+    const submitBtn = document.querySelector('button[name=signup]')
     const i18nStrings = JSON.parse(signupForm.dataset.i18n);
 
     // Keep the same with openlibrary/plugins/upstream/forms.py
@@ -14,18 +15,23 @@ export function initSignupForm() {
 
     if (window.grecaptcha) {
         // Callback that is called when grecaptcha.execute() is successful
-        // Checks whether reportValidity exists for cross-browser compatibility
-        // Includes invalid input count to account for checks not covered by reportValidity
         function submitCreateAccountForm() {
-            const numInvalidInputs = signupForm.querySelectorAll('input.invalid').length;
-            const isFormattingValid = !signupForm.reportValidity || signupForm.reportValidity()
-
-            if (numInvalidInputs === 0 && isFormattingValid) {
-                signupForm.submit();
-            }
+            signupForm.submit();
         }
         window.submitCreateAccountForm = submitCreateAccountForm
     }
+
+    // Checks whether reportValidity exists for cross-browser compatibility
+    // Includes invalid input count to account for checks not covered by reportValidity
+    $(signupForm).on('submit', function(e) {
+        e.preventDefault();
+        const numInvalidInputs = signupForm.querySelectorAll('input.invalid').length;
+        const isFormattingValid = !signupForm.reportValidity || signupForm.reportValidity();
+        if (numInvalidInputs === 0 && isFormattingValid && window.grecaptcha) {
+            $(submitBtn).prop('disabled', true).text(i18nStrings['loading_text']);
+            window.grecaptcha.execute();
+        }
+    });
 
     $('#username').on('keyup', function(){
         const value = $(this).val();

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -6,7 +6,8 @@ $ i18n_strings = {
     $ "invalid_email_format": _("Must be a valid email address"),
     $ "username_length_err": _("Must be between 3 and 20 characters"),
     $ "username_char_err": _("Username may only contain numbers, letters, - or _"),
-    $ "password_length_err": _("Must be between 3 and 20 characters")
+    $ "password_length_err": _("Must be between 3 and 20 characters"),
+    $ "loading_text": _("Loading...")
     $ }
 
 $# :param openlibrary.plugins.upstream.forms.RegisterForm form:
@@ -74,7 +75,8 @@ $var title: $_("Sign Up to Open Library")
                     $ classes = 'g-recaptcha'
                     $ sitekey = "data-sitekey=%s" % form['recaptcha'].public_key
                     $:render_template("recaptcha", form['recaptcha'].public_key, error=None, invisible=True)
-                <button type="submit" name="signup" id="signup" class="$classes cta-btn cta-btn--primary" $sitekey $callback>$_("Sign Up with Email")</button>
+                    <div class="$classes" $sitekey $callback data-size="invisible"></div>
+                <button type="submit" name="signup" id="signup" class="cta-btn cta-btn--primary">$_("Sign Up with Email")</button>
                 <small class="ol-signup-form__tos">$:_('By signing up, you agree to the Internet Archive\'s <a class="ol-signup-form__link" href="//archive.org/about/terms.php" target="_blank">Terms of Service</a>.')</small>
                 <p class="ol-signup-form__login-hint">$:_('Already have an account? <a href="/account/login">Log in</a>')</p>
             </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9603.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature. Reorganizes registration validation js to add a loading indicator at the correct point in the validation process and remove the delay between submission and validation.

### Technical
<!-- What should be noted about the implementation? -->
Fairly simple! Involved moving the recaptcha info to a div with `data-size="invisible"` per the [recaptcha docs](https://developers.google.com/recaptcha/docs/invisible#programmatic_execute) and adjusting the order of the JS checks.

The original `grecaptcha.execute()` implementation was nested in a click handler rather than a submit handler, as the latter never actually fired, but I'm hoping that now that the recaptcha is no longer linked directly to the submit button a submit handler should work just fine.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Go to `/account/create`
2. Enter badly formatted and/or incomplete data and hit submit (either directly or by hitting enter)
3. The submit button should remain enabled and you should immediately see an HTML error pop up
4. Fix the entires and submit again
5. The submit button should become disabled and replaced with the text "Loading..." and after a couple seconds, the page should refresh

**Results of partial GitPod testing:**
With the line `grecaptcha.execute()` replaced with `signupForm.submit()` since it doesn't work locally:
✅ If all inputs are valid, the submit button becomes a loading indicator and then the page refreshes
✅ HTML errors appear immediately following submit button press, and the submit button does not become a loading indicator

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="1032" alt="Registration loading indicator" src="https://github.com/user-attachments/assets/2fd0d5bd-55c2-4592-8b11-3c1fa05e97c6">


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
