### PR TITLE
Replace jQuery `validate` in admin and support forms

### DIFF
--- a/openlibrary/templates/admin/people/index.html
+++ b/openlibrary/templates/admin/people/index.html
@@ -28,8 +28,8 @@ input#ia-id {
     <tr>
         <td>$_("Email Address:")</td>
         <td>
-            <form method="GET" name="form-email" id="form-email" class="validate">
-                <input type="text" name="email" id="email" class="email" value="$email"/>
+            <form method="GET" name="form-email" id="form-email">
+                <input type="email" name="email" id="email" value="$email"/>
                 <button type="submit" name="" value="find">$_("Find")</button>
                 <span class="invalid" htmlfor="email" generated="true">
                     $if email:

--- a/openlibrary/templates/admin/people/view.html
+++ b/openlibrary/templates/admin/people/view.html
@@ -146,8 +146,8 @@ $ has_profile = person.get_user() is not None
     <tr>
         <td>$_("Email Address:")</td>
         <td>
-            <form method="POST" name="form-email" id="form-email" class="validate">
-                <input type="text" name="email" id="email" class="email big" value="$input.get('email', person['email'])"/>
+            <form method="POST" name="form-email" id="form-email">
+                <input type="email" name="email" id="email" class="big" value="$input.get('email', person['email'])"/>
                 <button type="submit" name="action" value="update_email">Change</button>
                 <span class="invalid" htmlfor="email" generated="true">$errors.get("email")</span>
             </form>

--- a/openlibrary/templates/support.html
+++ b/openlibrary/templates/support.html
@@ -11,7 +11,7 @@ $var title: $_('How can we help?')
  $if done:
    <em>$:_('Your question has been sent to our support team. We\'ll get back to you shortly. You can also <a href="https://twitter.com/openlibrary">contact us on Twitter</a>.')</em>
 
- <form action="" method="post" name="spamForm" class="olform validate">
+ <form action="" method="post" name="spamForm" class="olform">
 <p>$:_('Please check our <a href="/help/">Help Pages</a> and <a href="/help/faq">Frequently Asked Questions</a> (FAQ) to see if your question is answered there. Thank you.')</p>
 
  <div class="formElement">
@@ -21,7 +21,7 @@ $var title: $_('How can we help?')
 
  <div class="formElement">
  <div class="label"><label for="email">$_("Your Email Address")</label></div>
- <div class="input"><input type="email" class="email required" name="email" id="email" value="$email"/> ($_('We\'ll need this if you want a reply'))</div>
+ <div class="input"><input type="email" name="email" id="email" value="$email" required/> ($_('We\'ll need this if you want a reply'))</div>
  <p>$_("If you wish to be contacted by other means, please add your contact preference and details to your question.")</p>
  </div>
 
@@ -36,7 +36,7 @@ $var title: $_('How can we help?')
    <div class="label"><label for="question">$_("Your Question")</label></div>
    <p><strong>$_("Note: our staff will likely only be able respond in English.")</strong></p>
    <div class="input">
-     <textarea id="question" name="question" class="required" cols="40" rows="5"></textarea>
+     <textarea id="question" name="question" cols="40" rows="5" required></textarea>
    </div>
    <p>$_("If you encounter an error message, please include it. For questions about our books, please provide the title/author or Open Library ID.")</p>
  </div>

--- a/static/css/components/form.olform.less
+++ b/static/css/components/form.olform.less
@@ -107,7 +107,8 @@
   input[type=number],
   input[type=text],
   input[type=password],
-  input[type=url] {
+  input[type=url],
+  input[type=email] {
     margin: 0 10px 5px 0;
   }
 

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -495,7 +495,7 @@ textarea {
 }
 
 input {
-  &[type=text] {
+  &[type=text], &[type=email] {
     margin: 0 10px 5px 0;
   }
   &.repeat-add {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Subtask of #9605.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature. Replaces jQuery `validate` required field and email validation with built-in HTML validation to improve performance, JS-disabled functionality, and internationalization.

### Technical
<!-- What should be noted about the implementation? -->
Quite simple! Just removed the `validate` class (which triggers the plugin), and replaced each `class="required"` with the HTML `required` attribute and each `class="email"` with the HTML `type="email"` attribute.

Also involved some CSS fixes to keep input styling consistent, same fixes should hold for all relevant PRs.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Go to one of the relevant forms, i.e. `/contact`
2. Enter a badly formatted email and/or leave a required field blank, hit submit
3. The submission should fail and you should see an HTML-native error message

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
