### PR TITLE
Replace jQuery `validate` in book/author/tag edit forms

### DIFF
--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -51,7 +51,7 @@ $:macros.HiddenSaveButton("addWork")
 <div id="contentBody">
     $ work_key = query_param('work_key', None)
     $ action = '?work_key=%s' % work_key if work_key else ''
-    <form method="post" id="addWork" class="olform books validate" name="edit" action="$action">
+    <form method="post" id="addWork" class="olform books" name="edit" action="$action">
 
         <input type="hidden" name="work--key" value="$work.key">
         $ authors = work.authors and [a.author for a in work.authors]
@@ -87,7 +87,7 @@ $:macros.HiddenSaveButton("addWork")
                                         <label for="work-title">$_('Title')</label> <span class="tip">$:_("Use <b><i>Title: Subtitle</i></b> to add a subtitle.")</span> <span class="red">*<span class="tip">$_("Required field")</span></span>
                                     </div>
                                     <div class="input">
-                                        <input name="work--title" type="text" id="work-title" class="required" value="$this_title"/>
+                                        <input name="work--title" type="text" id="work-title" value="$this_title" required/>
                                     </div>
                                     <div class="label">
                                         <label for="author-$0">$_("Author")</label>

--- a/openlibrary/templates/tag/add.html
+++ b/openlibrary/templates/tag/add.html
@@ -13,14 +13,14 @@ $var title: $_("Add a tag")
 
 <div id="contentBody">
 
-    <form method="post" action="" id="addtag" class="olform addtag1 validate">
+    <form method="post" action="" id="addtag" class="olform addtag1">
 
         <div class="formElement">
             <div class="label">
                 <label for="tagname">$_("Name of Tag")</label>*<span class="tip">$_("Required field")</span>
             </div>
             <div class="input">
-                <input type="text" name="tag_name" id="tag_name"/>
+                <input type="text" name="tag_name" id="tag_name" required/>
             </div>
         </div>
 

--- a/openlibrary/templates/type/author/edit.html
+++ b/openlibrary/templates/type/author/edit.html
@@ -19,7 +19,7 @@ $:macros.HiddenSaveButton("addAuthor")
 
 <div id="contentBody">
 
-    <form id="addAuthor" name="edit" method="post" action="" class="olform books validate">
+    <form id="addAuthor" name="edit" method="post" action="" class="olform books">
 
 
     <div class="formElement title">
@@ -32,7 +32,7 @@ $:macros.HiddenSaveButton("addAuthor")
                 </span>
             </div>
             <div class="input">
-                <input type="text" name="author--name" id="name" value="$page.name" class="required"/>
+                <input type="text" name="author--name" id="name" value="$page.name" required/>
             </div>
         </div>
     </div>

--- a/openlibrary/templates/type/tag/edit.html
+++ b/openlibrary/templates/type/tag/edit.html
@@ -13,13 +13,13 @@ $putctx("robots", "noindex,nofollow")
 
 <div id="contentBody">
 
-    <form id="edittag" name="edit" method="post" action="" class="olform validate">
+    <form id="edittag" name="edit" method="post" action="" class="olform">
         <div class="formElement">
             <div class="label">
                 <label for="name">$_("Label")</label>*<span class="tip">$_("Required field")</span>
             </div>
             <div class="input">
-                <input type="text" name="name" id="tag_name" value="$page.name" />
+                <input type="text" name="name" id="tag_name" value="$page.name" required />
             </div>
         </div>
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Subtask of #9605.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature. Replaces jQuery `validate` required field and email validation with built-in HTML validation to improve performance, JS-disabled functionality, and internationalization.

### Technical
<!-- What should be noted about the implementation? -->
Quite simple! Just removed the `validate` class (which triggers the plugin), and replaced each `class="required"` with the HTML `required` attribute and each `class="email"` with the HTML `type="email"` attribute.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Go to one of the relevant forms, i.e. a book edit form
2. Enter a badly formatted email and/or leave a required field blank, hit submit
3. The submission should fail and you should see an HTML-native error message

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
