### PR TITLE
Combine the phrase "Preview Only" for internationalization

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -272,7 +272,7 @@ msgstr ""
 msgid "YAML Representation:"
 msgstr ""
 
-#: books/edit/edition.html editpage.html
+#: BookPreview.html books/edit/edition.html editpage.html
 msgid "Preview"
 msgstr ""
 
@@ -6556,7 +6556,7 @@ msgid "by an <em>unknown author</em>"
 msgstr ""
 
 #: BookPreview.html
-msgid "Preview <span>Only</span>"
+msgid "Preview Only"
 msgstr ""
 
 #: BookPreview.html

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -272,7 +272,7 @@ msgstr ""
 msgid "YAML Representation:"
 msgstr ""
 
-#: BookPreview.html books/edit/edition.html editpage.html
+#: books/edit/edition.html editpage.html
 msgid "Preview"
 msgstr ""
 
@@ -6556,7 +6556,7 @@ msgid "by an <em>unknown author</em>"
 msgstr ""
 
 #: BookPreview.html
-msgid "Only"
+msgid "Preview <span>Only</span>"
 msgstr ""
 
 #: BookPreview.html

--- a/openlibrary/macros/BookPreview.html
+++ b/openlibrary/macros/BookPreview.html
@@ -1,11 +1,11 @@
-$def with (ocaid, analytics_attr)
+$def with (ocaid, analytics_attr, show_only=False)
 $# :param str ocaid:
 
   <div class="cta-button-group">
     <a class="cta-btn cta-btn--preview"
       data-iframe-src="https://archive.org/details/$ocaid?view=theater&wrapper=false"
       data-iframe-link="https://archive.org/details/$ocaid"
-      $:analytics_attr('Preview') href="#bookPreview">$:_('Preview <span>Only</span>')</a>
+      $:analytics_attr('Preview') href="#bookPreview">$(_('Preview Only') if show_only else _('Preview'))</a>
   </div>
 
 $if render_once('book-preview-floater'):

--- a/openlibrary/macros/BookPreview.html
+++ b/openlibrary/macros/BookPreview.html
@@ -5,7 +5,7 @@ $# :param str ocaid:
     <a class="cta-btn cta-btn--preview"
       data-iframe-src="https://archive.org/details/$ocaid?view=theater&wrapper=false"
       data-iframe-link="https://archive.org/details/$ocaid"
-      $:analytics_attr('Preview') href="#bookPreview">$_('Preview') <span>$_('Only')</span></a>
+      $:analytics_attr('Preview') href="#bookPreview">$:_('Preview <span>Only</span>')</a>
   </div>
 
 $if render_once('book-preview-floater'):

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -66,12 +66,12 @@ $elif ocaid and ctx.user and ctx.user.is_printdisabled():
   $ pd_eligible = availability and availability.get('is_printdisabled')
   $ std_borrow = availability.get("available_to_borrow") or availability.get("available_to_browse")
   $if secondary_action and (availability.get('is_printdisabled') or availability.get('is_lendable')):
-    $:macros.BookPreview(ocaid, analytics_attr)
+    $:macros.BookPreview(ocaid, analytics_attr, show_only=False)
   $:macros.ReadButton(ocaid, analytics_attr, borrow=pd_eligible, printdisabled=not std_borrow, listen=listen)
 
 $elif availability.get('is_lendable'):
   $if secondary_action:
-    $:macros.BookPreview(ocaid, analytics_attr)
+    $:macros.BookPreview(ocaid, analytics_attr, show_only=False)
   $if availability.get("available_to_borrow") or availability.get("available_to_browse"):
     $:macros.ReadButton(ocaid, analytics_attr, borrow=True, listen=listen)
   $elif availability.get('available_to_waitlist'):
@@ -129,7 +129,7 @@ $elif availability.get('is_lendable'):
     </div>
 
 $elif ocaid and availability.get('is_previewable') and book_provider.short_name == 'ia':
-  $:macros.BookPreview(ocaid, analytics_attr)
+  $:macros.BookPreview(ocaid, analytics_attr, show_only=True)
   $if secondary_action:
       $:macros.BookSearchInside(ocaid)
 

--- a/static/css/components/read-panel.less
+++ b/static/css/components/read-panel.less
@@ -66,11 +66,6 @@
       mask-size: cover;
       background-color: @primary-blue;
     }
-
-    // Hide "Only" in preview link
-    span {
-      display: none;
-    }
     /* stylelint-enable selector-max-specificity */
   }
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9606.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix. Combines the phrase "Preview Only" in the `i18n` syntax instead of translating each word separately, which was messing with word order in translation.

### Technical
<!-- What should be noted about the implementation? -->
Very simple! Just moved start/finish of `i18n` syntax and switched to the `$:_(' ')` inner HTML version.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Check the `messages.pot` file
2. Confirm that it now includes "Preview Only" as a full phrase (with an HTML `span` element and its corresponding closing tag included)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
