### PR TITLE
Replace jQuery `validate` in book add form

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -3083,6 +3083,10 @@ msgid "Please enter a value for the selected identifier"
 msgstr ""
 
 #: books/add.html
+msgid "Are you sure that's the published date?"
+msgstr ""
+
+#: books/add.html
 msgid "Add a book to Open Library"
 msgstr ""
 

--- a/openlibrary/plugins/openlibrary/js/add-book.js
+++ b/openlibrary/plugins/openlibrary/js/add-book.js
@@ -15,16 +15,17 @@ let invalidLccn;
 let emptyId;
 
 const i18nStrings = JSON.parse(document.querySelector('form[name=edit]').dataset.i18n);
+const addBookForm = $('form#addbook');
 
 export function initAddBookImport () {
     $('.list-books a').on('click', function() {
         var li = $(this).parents('li').first();
         $('input#work').val(`/works/${li.attr('id')}`);
-        $('form#addbook').trigger('submit');
+        addBookForm.trigger('submit');
     });
     $('#bookAddCont').on('click', function() {
         $('input#work').val('none-of-these');
-        $('form#addbook').trigger('submit');
+        addBookForm.trigger('submit');
     });
 
     invalidChecksum = i18nStrings.invalid_checksum;
@@ -39,6 +40,13 @@ export function initAddBookImport () {
     $('#id_name').on('change', clearErrors);
 
     $('#publish_date').on('blur', validatePublishDate);
+
+    // Prevents submission if the publish date is > 1 year in the future
+    addBookForm.on('submit', function() {
+        if ($('#publish-date-errors').hasClass('hidden')) {
+            return true;
+        } else return false;
+    })
 }
 
 // a flag to make raiseIsbnError perform differently upon subsequent calls

--- a/openlibrary/plugins/openlibrary/js/add-book.js
+++ b/openlibrary/plugins/openlibrary/js/add-book.js
@@ -14,6 +14,8 @@ let invalidIsbn13;
 let invalidLccn;
 let emptyId;
 
+const i18nStrings = JSON.parse(document.querySelector('form[name=edit]').dataset.i18n);
+
 export function initAddBookImport () {
     $('.list-books a').on('click', function() {
         var li = $(this).parents('li').first();
@@ -25,7 +27,6 @@ export function initAddBookImport () {
         $('form#addbook').trigger('submit');
     });
 
-    const i18nStrings = JSON.parse(document.querySelector('#id-errors').dataset.i18n)
     invalidChecksum = i18nStrings.invalid_checksum;
     invalidIsbn10 = i18nStrings.invalid_isbn10;
     invalidIsbn13 = i18nStrings.invalid_isbn13;
@@ -36,6 +37,8 @@ export function initAddBookImport () {
     $('#addbook').on('submit', parseAndValidateId);
     $('#id_value').on('input', clearErrors);
     $('#id_name').on('change', clearErrors);
+
+    $('#publish_date').on('blur', validatePublishDate);
 }
 
 // a flag to make raiseIsbnError perform differently upon subsequent calls
@@ -152,5 +155,24 @@ function autoCompleteIdName(){
 
     else {
         document.getElementById('id_name').value = '';
+    }
+}
+
+function validatePublishDate() {
+    // validate publish-date to make sure the date is not in future
+    // used in templates/books/add.html
+    const publish_date = this.value;
+    // if it doesn't have even three digits then it can't be a future date
+    const tokens = /(\d{3,})/.exec(publish_date);
+    const year = new Date().getFullYear();
+    const isValidDate = tokens && tokens[1] && parseInt(tokens[1]) <= year + 1; // allow one year in future.
+
+    const errorDiv = document.getElementById('publish-date-errors');
+
+    if (!isValidDate) {
+        errorDiv.classList.remove('hidden');
+        errorDiv.textContent = i18nStrings['invalid_publish_date'];
+    } else {
+        errorDiv.classList.add('hidden');
     }
 }

--- a/openlibrary/templates/books/add.html
+++ b/openlibrary/templates/books/add.html
@@ -7,7 +7,8 @@ $ i18n_strings = {
     $ "invalid_isbn10": _("ID must be exactly 10 characters [0-9 or X]. For example 0-19-853453-1 or 0198534531"),
     $ "invalid_isbn13": _("ID must be exactly 13 characters [0-9]. For example 978-3-16-148410-0 or 9783161484100"),
     $ "invalid_lccn": _("Invalid LC Control Number format"),
-    $ "empty_id": _("Please enter a value for the selected identifier")
+    $ "empty_id": _("Please enter a value for the selected identifier"),
+    $ "invalid_publish_date": _("Are you sure that's the published date?")
     $ }
 
 <div id="contentHead">
@@ -21,7 +22,7 @@ $ i18n_strings = {
 
 <div id="contentBody">
 
-    <form method="post" action="" id="addbook" class="olform addbook1 validate" name="edit">
+    <form method="post" action="" id="addbook" class="olform addbook1" name="edit" data-i18n="$json_encode(i18n_strings)">
         <div class="formElement">
             <div class="label">
                 <label for="title">$_("Title")</label> <span class="tip">$:_('Use <b><i>Title: Subtitle</i></b> to add a subtitle.')</span> <span class="red">*<span class="tip">$_("Required field")</span></span>
@@ -31,7 +32,7 @@ $ i18n_strings = {
                     <input type="text" id="title" disabled="disabled" value="$work.title"/>
                     <input type="hidden" name="book_title" value="$work.title"/>
                 $else:
-                    <input type="text" name="book_title" id="title" class="required title" style="width:630px;" value="$(work and work.title)" $cond(work, 'readonly="readonly"')/>
+                    <input type="text" name="book_title" id="title" class="title" style="width:630px;" value="$(work and work.title)" $cond(work, 'readonly="readonly"') required/>
             </div>
         </div>
         <div class="formElement">
@@ -44,7 +45,7 @@ $ i18n_strings = {
                 <label for="publisher">$_("Who is the publisher?")</label> <span class="tip">$_("For example:") <em>$_("Oxford University Press; Penguin; W.W. Norton")</em></span><span class="red">*<span class="tip">$_("Required field")</span></span>
             </div>
             <div class="input">
-                <input type="text" name="publisher" class="required" id="publisher"/>
+                <input type="text" name="publisher" id="publisher" required/>
             </div>
         </div>
 
@@ -52,8 +53,9 @@ $ i18n_strings = {
             <div class="label">
                 <label for="publish_date">$_("When was it published?")</label> <span class="tip">$_("You should be able to find this in the first few pages of the book.")</span><span class="red">*<span class="tip">$_("Required field")</span></span>
             </div>
+            <div id="publish-date-errors" class="note hidden"></div>
             <div class="input">
-                <input type="text" name="publish_date" class="required publish-date" id="publish_date"/>
+                <input type="text" name="publish_date" id="publish_date" required/>
             </div>
         </div>
 
@@ -61,7 +63,7 @@ $ i18n_strings = {
         <div class="formElement">
             <div class="label"><label for="id_value">$:_("And optionally, an ID number &#151; like an ISBN &#151; would be helpful...")</label></div>
                 <label for="id_name" class="hidden">$_("ID Type")</label>
-                <div id="id-errors" class="note hidden" data-i18n="$json_encode(i18n_strings)"></div>
+                <div id="id-errors" class="note hidden"></div>
                 <div id="confirm-add" class="note hidden">$_('ISBN may be invalid. Click "Add" again to submit.')</div>
             <div class="input">
                 <select name="id_name" id="id_name">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Subtask of #9605.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature. Replaces jQuery `validate` required field and email validation with built-in HTML validation to improve performance, JS-disabled functionality, and internationalization. 

Also replaces the custom `publish-date` validation with a simple new on-blur function in `add-book.js` that reuses the same logic.

### Technical
<!-- What should be noted about the implementation? -->
Most of it was quite simple! 
- Switched out the `class="required"` for the HTML `required` attribute where applicable
- Created a quick validation function to show/hide errors if the publish date is in the future, reusing this logic from `validate.js`:
https://github.com/internetarchive/openlibrary/blob/800bcabfc535142da3a2ba2b4f5f9e39f66e6ecb/openlibrary/plugins/openlibrary/js/validate.js#L23-L28
- Had to move the `i18n_strings` around a bit in the form so they could include both id errors and publish date errors, updated all references as needed
- Kept the same styling (`note`) as the id errors for consistency

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Go to the add-book form
2. Leave a required field blank, hit submit
3. The submission should fail and you should see an HTML-native error message
4. Return to the form and try adding a date more than a year in the future, then click or tab away
5. You should see an error message appear re: the date
6. Fix the date and click away again
7. The error message should disappear

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="686" alt="Publish date error" src="https://github.com/user-attachments/assets/91818412-e796-469c-b6e6-8964999350e0">

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
