### PR TITLE
Remove broken "Cancel" button on author photos "manage" page

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -781,8 +781,8 @@ msgstr ""
 
 #: CreateListModal.html EditButtons.html account/notifications.html
 #: account/password/reset.html account/privacy.html admin/imports-add.html
-#: admin/permissions.html books/add.html covers/manage.html databarEdit.html
-#: merge/authors.html my_books/dropdown_content.html support.html tag/add.html
+#: admin/permissions.html books/add.html databarEdit.html merge/authors.html
+#: my_books/dropdown_content.html support.html tag/add.html
 msgid "Cancel"
 msgstr ""
 

--- a/openlibrary/templates/covers/manage.html
+++ b/openlibrary/templates/covers/manage.html
@@ -45,7 +45,6 @@ $putctx('robots', 'noindex,nofollow')
 
     <div class="formElement" style="margin:40px 0 0 30px;">
         <button type="submit" value="Save" class="largest">$_("Save")</button>
-        <a class="dialog--close-parent red">$_("Cancel")</a>
     </div>
 
 </form>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9602 

### Technical
<!-- What should be noted about the implementation? -->
Cancel Button has been removed from the author photos "manage" page.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Visit any author page, click on "Add Author Photos," then navigate to the manage tab and check if the cancel button has been removed from the bottom.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![cancel_removed](https://github.com/user-attachments/assets/5ad346c9-d0d4-4b4d-ae65-7cd9553a1435)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 
