### PR TITLE
Exclude `None` in `author_names` list

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -3245,6 +3245,10 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
+#: books/custom_carousel.html type/author/view.html
+msgid "name missing"
+msgstr ""
+
 #: books/custom_carousel.html books/mobile_carousel.html
 #, python-format
 msgid " by %(name)s"
@@ -6190,10 +6194,6 @@ msgstr ""
 
 #: type/author/edit.html
 msgid "Author Identifiers Purpose"
-msgstr ""
-
-#: type/author/view.html
-msgid "name missing"
 msgstr ""
 
 #: type/author/view.html type/edition/view.html type/work/view.html

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -41,7 +41,7 @@ $def render_carousel_cover(book, lazy, layout):
     $ cover_url = False
 
   $if book.get('authors'):
-    $ author_names = [author.name for author in book.authors]
+    $ author_names = [author.name for author in book.authors if author.name]
   $elif book.get('author_name'):
     $ author_names = book.get('author_name', [])
   $else:

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -41,7 +41,7 @@ $def render_carousel_cover(book, lazy, layout):
     $ cover_url = False
 
   $if book.get('authors'):
-    $ author_names = [author.name for author in book.authors if author.name]
+    $ author_names = [author.name or _('name missing') for author in book.authors]
   $elif book.get('author_name'):
     $ author_names = book.get('author_name', [])
   $else:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9614

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Prevents `None` entries from being added to the `author_names` list.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
