### PR TITLE
Altered BulkSearch to handle extractors in their own class

### DIFF
--- a/openlibrary/components/BulkSearch/components/BulkSearchControls.vue
+++ b/openlibrary/components/BulkSearch/components/BulkSearchControls.vue
@@ -8,17 +8,17 @@
             <textarea v-model="bulkSearchState.inputText"></textarea>
             <br />
             <label>Format: <select @change="selectAlgorithm">
-                    <option value="1">e.g. "The Wizard of Oz by L. Frank Baum"</option>
-                    <option value="2">e.g. "L. Frank Baum - The Wizard of Oz" </option>
-                    <option value="3">e.g. "The Wizard of Oz - L. Frank Baum" </option>
-                    <option value="4">e.g. "The Wizard of Oz (L. Frank Baum)"</option>
-                    <option value="5">Wikipedia Citation (e.g. Baum, Frank L. (1994). The Wizard of Oz)</option>
-                    <option value="6">✨ AI Extraction</option>
+                    <option value="0">e.g. "The Wizard of Oz by L. Frank Baum"</option>
+                    <option value="1">e.g. "L. Frank Baum - The Wizard of Oz" </option>
+                    <option value="2">e.g. "The Wizard of Oz - L. Frank Baum" </option>
+                    <option value="3">e.g. "The Wizard of Oz (L. Frank Baum)"</option>
+                    <option value="4">Wikipedia Citation (e.g. Baum, Frank L. (1994). The Wizard of Oz)</option>
+                    <option value="5">✨ AI Extraction</option>
                 </select></label>
-            <label v-if="bulkSearchState.extractionOptions.use_gpt">OpenAI API Key:
-                <input v-if="showPassword" type="password" @click="togglePasswordVisibility()" v-model="bulkSearchState.extractionOptions.api_key" />
+            <label v-if="this.showApiKey">OpenAI API Key:
+                <input v-if="showPassword" type="password" v-on:click="togglePasswordVisibility()" v-model="bulkSearchState.extractionOptions.api_key" />
 
-                <input v-else type="text" @click="togglePasswordVisibility()" v-model="bulkSearchState.extractionOptions.api_key" />
+                <input v-else type="text" v-on:click="togglePasswordVisibility" v-model="bulkSearchState.extractionOptions.api_key" />
             </label>
             <label>Sample Data:
                 <select v-model="selectedValue">
@@ -30,8 +30,8 @@
                 search query
             </label>
             <br>
-            <button @click="extractBooks">Extract Books</button>
-            <button @click="matchBooks">Match Books</button>
+            <button v-on:click="extractBooks">Extract Books</button>
+            <button v-on:click="matchBooks">Match Books</button>
         </div>
         <div v-if="bulkSearchState.errorMessage">
             <p v-for="error in bulkSearchState.errorMessage" :key="error">
@@ -42,7 +42,7 @@
 
 <script>
 import {sampleData} from '../utils/samples.js';
-import { BulkSearchState, ExtractedBook, BookMatch } from '../utils/classes.js';
+import { BulkSearchState, RegexExtractor, AIExtractor} from '../utils/classes.js';
 import { buildSearchUrl, buildListUrl } from '../utils/searchUtils.js'
 export default {
 
@@ -52,16 +52,18 @@ export default {
     data() {
         return {
             selectedValue: '',
+
             showPassword: true,
             sampleData: sampleData,
-            regexDict: {
-                '': '',
-                1: new RegExp('(^|>)(?<title>[A-Za-z][\\p{L}0-9\\- ,]{1,250})\\s+(by|[-\u2013\u2014\\t])\\s+(?<author>[\\p{L}][\\p{L}\\.\\- ]{3,70})( \\(.*)?($|<\\/)', 'gmu'),
-                2: new RegExp('(^|>)(?<author>[A-Za-z][\\p{L}0-9\\- ,]{1,250})\\s+[,-\u2013\u2014\\t]\\s+(?<title>[\\p{L}][\\p{L}\\.\\- ]{3,70})( \\(.*)?($|<\\/)', 'gmu'),
-                3: new RegExp('(^|>)(?<title>[A-Za-z][\\p{L}0-9\\- ,]{1,250})\\s+[,-\u2013\u2014\\t]\\s+(?<author>[\\p{L}][\\p{L}\\.\\- ]{3,70})( \\(.*)?($|<\\/)', 'gmu'),
-                4: new RegExp('^(?<title>[\\p{L}].{1,250})\\s\\(?<author>(.{3,70})\\)$$', 'gmu'),
-                5: new RegExp('^(?<author>[^.()]+).*?\\)\\. (?<title>[^.]+)', 'gmu')
-            }
+            extractors: [
+                new RegexExtractor('e.g. "The Wizard of Oz by L. Frank Baum"', '(^|>)(?<title>[A-Za-z][\\p{L}0-9\\- ,]{1,250})\\s+(by|[-\u2013\u2014\\t])\\s+(?<author>[\\p{L}][\\p{L}\\.\\- ]{3,70})( \\(.*)?($|<\\/)'),
+                new RegexExtractor('e.g. "L. Frank Baum - The Wizard of Oz"', '(^|>)(?<author>[A-Za-z][\\p{L}0-9\\- ,]{1,250})\\s+[,-\u2013\u2014\\t]\\s+(?<title>[\\p{L}][\\p{L}\\.\\- ]{3,70})( \\(.*)?($|<\\/)'),
+                new RegexExtractor('e.g. "The Wizard of Oz - L. Frank Baum"', '(^|>)(?<title>[A-Za-z][\\p{L}0-9\\- ,]{1,250})\\s+[,-\u2013\u2014\\t]\\s+(?<author>[\\p{L}][\\p{L}\\.\\- ]{3,70})( \\(.*)?($|<\\/)'),
+                new RegexExtractor('e.g. "The Wizard of Oz (L. Frank Baum)"', '^(?<title>[\\p{L}].{1,250})\\s\\(?<author>(.{3,70})\\)$$'),
+                new RegexExtractor('Wikipedia Citation (e.g. Baum, Frank L. (1994). The Wizard of Oz)', '^(?<author>[^.()]+).*?\\)\\. (?<title>[^.]+)'),
+                new AIExtractor('✨ AI Extraction', 'gpt-4o-mini')
+            ]
+
         }
     },
     watch: {
@@ -71,74 +73,22 @@ export default {
             }
         }
     },
+    computed: {
+        showApiKey(){
+            if (this.bulkSearchState.extractionMethod) return 'model' in this.bulkSearchState.extractionMethod
+            return false
+        }
+    },
     methods: {
         togglePasswordVisibility(){
             this.showPassword= !this.showPassword
         },
         selectAlgorithm(e) {
-            if (e.target.value === '6') {
-                this.bulkSearchState.extractionOptions.use_gpt = true
-            }
-            else {
-                this.bulkSearchState.extractionOptions.use_gpt = false
-                this.bulkSearchState.extractionOptions.regex = this.regexDict[e.target.value]
-            }
+            this.bulkSearchState.extractionMethod = this.extractors[e.target.value]
         },
         async extractBooks() {
-            this.bulkSearchState.errorMessage = []
-            if (this.bulkSearchState.extractionOptions.use_gpt) {
-                const request = {
-
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        Authorization: `Bearer ${this.bulkSearchState.extractionOptions.api_key}`
-                    },
-                    body: JSON.stringify({
-                        model: 'gpt-4o-mini',
-                        response_format: { type: 'json_object' },
-                        messages: [
-                            {
-                                role: 'system',
-                                content: 'You are a book extraction system. You will be given a free form passage of text containing references to books, and you will need to extract the book titles, author, and optionally ISBN in a JSON array.'
-                            },
-                            {
-                                role: 'user',
-                                content: `Please extract the books from the following text:\n\n${this.bulkSearchState.inputText}`,
-                            }
-                        ],
-                    })
-
-                }
-                try {
-                    const resp = await fetch('https://api.openai.com/v1/chat/completions', request)
-
-                    if (!resp.ok) {
-                        const status = resp.status
-                        if (status === 401) {
-
-                            this.bulkSearchState.errorMessage.push('Error: Incorrect Authorization key.')
-                        }
-                        throw new Error('Network response was not okay.')
-                    }
-                    const data = await resp.json()
-                    this.bulkSearchState.extractedBooks = JSON.parse(data.choices[0].message.content)['books'].map((entry) => new ExtractedBook(entry?.title, entry?.author))
-                    this.bulkSearchState.matchedBooks = JSON.parse(data.choices[0].message.content)['books'].map((entry) => new BookMatch(new ExtractedBook(entry?.title, entry?.author), {}))
-                }
-                catch (error) {
-
-                }
-
-            }
-            else {
-                const regex = this.bulkSearchState.extractionOptions.regex
-                if (regex && this.bulkSearchState.inputText) {
-                    const data = [...this.bulkSearchState.inputText.matchAll(regex)]
-
-                    this.bulkSearchState.extractedBooks = data.map((entry) => new ExtractedBook(entry.groups?.title, entry.groups?.author))
-                    this.bulkSearchState.matchedBooks = this.bulkSearchState.extractedBooks.map((entry) => new BookMatch(entry, []))
-                }
-            }
+            const extractedData = await this.bulkSearchState.extractionMethod.run(this.bulkSearchState.extractOptions, this.bulkSearchState.inputText)
+            this.bulkSearchState.matchedBooks = extractedData
         },
         async matchBooks() {
             const fetchSolrBook = async function (book, matchOptions) {

--- a/openlibrary/components/BulkSearch/components/BulkSearchControls.vue
+++ b/openlibrary/components/BulkSearch/components/BulkSearchControls.vue
@@ -8,12 +8,9 @@
             <textarea v-model="bulkSearchState.inputText"></textarea>
             <br />
             <label>Format: <select @change="selectAlgorithm">
-                    <option value="0">e.g. "The Wizard of Oz by L. Frank Baum"</option>
-                    <option value="1">e.g. "L. Frank Baum - The Wizard of Oz" </option>
-                    <option value="2">e.g. "The Wizard of Oz - L. Frank Baum" </option>
-                    <option value="3">e.g. "The Wizard of Oz (L. Frank Baum)"</option>
-                    <option value="4">Wikipedia Citation (e.g. Baum, Frank L. (1994). The Wizard of Oz)</option>
-                    <option value="5">✨ AI Extraction</option>
+                    <option v-for="extractor, index in extractors" :value = "index" :key="index">
+                        {{ extractor["name"] }}
+                    </option>
                 </select></label>
             <label v-if="this.showApiKey">OpenAI API Key:
                 <input v-if="showPassword" type="password" v-on:click="togglePasswordVisibility()" v-model="bulkSearchState.extractionOptions.api_key" />


### PR DESCRIPTION

<!-- What issue does this PR close? -->
Closes #9621

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This code refactors Bulk Search to handle the extraction of authors and titles from a text in a different manner. Previously, these methods were located within the `BulkSearchControls.vue` file, which was somewhat messy. Now, they're abstracted to inherit from a common `AbstractExtractor` class, and are imported from a different file. 

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Use Bulk Search, and test out the various samples. Each should function with at least one extraction algorithm. 
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
