### PR TITLE
Hide download options when book is unavailable.

### DIFF
--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -61,7 +61,6 @@ $ viewbook = "//%s/stream/XXX?ref=ol" % bookreader_host()
           $ book_provider = get_book_provider(page)
           $ availability = (page.availability or {}) if hasattr(page, 'availability') else {}
           $if book_provider and (availability.get('is_readable') or availability.get('status') == 'open') or book_provider.get_access(page).to_solr_str() == "public":
-
             $:book_provider.render_download_options(page)
           $ render_times['databarWork: Book provider'] = time() - render_times['databarWork: Book provider']
       </div>

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -60,7 +60,7 @@ $ viewbook = "//%s/stream/XXX?ref=ol" % bookreader_host()
           $ render_times['databarWork: Book provider'] = time()
           $ book_provider = get_book_provider(page)
           $ availability = (page.availability or {}) if hasattr(page, 'availability') else {}
-          $if book_provider and (availability.get('is_readable') or availability.get('status') == 'open') or book_provider.get_access(page).to_solr_str() == "public":
+          $if book_provider and ((availability.get('is_readable') or availability.get('status') == 'open') or book_provider.get_access(page).to_solr_str() == "public"):
             $:book_provider.render_download_options(page)
           $ render_times['databarWork: Book provider'] = time() - render_times['databarWork: Book provider']
       </div>

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -59,7 +59,8 @@ $ viewbook = "//%s/stream/XXX?ref=ol" % bookreader_host()
         $if editions_page:
           $ render_times['databarWork: Book provider'] = time()
           $ book_provider = get_book_provider(page)
-          $if book_provider:
+          $ availability = (page.availability or {}) if hasattr(page, 'availability') else {}
+          $if book_provider and (availability.get('is_readable') or availability.get('status') == 'open'):
             $:book_provider.render_download_options(page)
           $ render_times['databarWork: Book provider'] = time() - render_times['databarWork: Book provider']
       </div>

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -60,7 +60,8 @@ $ viewbook = "//%s/stream/XXX?ref=ol" % bookreader_host()
           $ render_times['databarWork: Book provider'] = time()
           $ book_provider = get_book_provider(page)
           $ availability = (page.availability or {}) if hasattr(page, 'availability') else {}
-          $if book_provider and (availability.get('is_readable') or availability.get('status') == 'open'):
+          $if book_provider and (availability.get('is_readable') or availability.get('status') == 'open') or book_provider.get_access(page).to_solr_str() == "public":
+
             $:book_provider.render_download_options(page)
           $ render_times['databarWork: Book provider'] = time() - render_times['databarWork: Book provider']
       </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9637

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Added extra check before rendering download option to avoid it's visibility when the book is not present in Internet Archive

### Technical
<!-- What should be noted about the implementation? -->
add same condition that was used to check if read button should be called in LoanStatus.html
```(availability.get('is_readable') or availability.get('status') == 'open')```

Assuming that If a book is no longer available on Internet Archive then it would be Not be readable anyways.
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Create a Book, search for the book by it's name and open it, by default it shows Not In Library, and you'll see that Download Options are not visible, while If you open any of the other Book which are available you'll be able to see Download options.
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
##### Available Book
![Screenshot from 2024-07-29 06-22-00](https://github.com/user-attachments/assets/82454c40-25f1-400c-8188-719c7d632731)
##### Unavailable Book
![Screenshot from 2024-07-29 06-22-54](https://github.com/user-attachments/assets/88ce4267-1d1d-4803-b8d0-3473b0f38d0a)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@scottbarnes 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
