### PR TITLE
Fix `/admin/people` pages for certain accounts

### DIFF
--- a/openlibrary/templates/admin/people/view.html
+++ b/openlibrary/templates/admin/people/view.html
@@ -163,7 +163,7 @@ $ has_profile = person.get_user() is not None
             </form>
         </td>
     </tr>
-    $if person.get_user().is_admin():
+    $if person.get_user() and person.get_user().is_admin():
         <tr><td>$_("Admin")</td><td>$_("Yes")</td></tr>
     <tr>
         <td>$_("Bot")</td>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9652

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Checks for `Account` object before seeing if the account has admin privileges.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
