### PR TITLE
Fix: Author search now shows work count instead of edition count

### DIFF
--- a/openlibrary/solr/updater/author.py
+++ b/openlibrary/solr/updater/author.py
@@ -19,6 +19,7 @@ class AuthorSolrUpdater(AbstractSolrUpdater):
                     ('wt', 'json'),
                     ('json.nl', 'arrarr'),
                     ('q', 'author_key:%s' % author_id),
+                    ('fq', 'type:work'),
                     ('sort', 'edition_count desc'),
                     ('rows', 1),
                     ('fl', 'title,subtitle'),


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9558 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR fixes a bug in the author Solr updater where both edition and work counts were mistakenly used instead of just work counts. By correcting this, author search results will be more accurate and meet user expectations, showing the correct number of works associated with each author rather than inflated counts that included editions.

### Technical
<!-- What should be noted about the implementation? -->
PR involves updating the Solr query logic to correctly count works instead of editions for authors.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
To verify the fix implemented in this PR, follow these steps:
1. Visit [this link](https://openlibrary.org/search/authors?q=chris+wiggins&mode=everything) on the Open Library website.
2. Observe that the author "Chris Wiggins" is currently shown to have 8 books.
3. After applying this PR, the author should correctly display only 2 books, reflecting the accurate work count instead of the inflated edition count.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Before:
On the author search page
![image](https://github.com/user-attachments/assets/a1f9dc78-47a4-4226-9294-0266cb6d2664)
After:
![image](https://github.com/user-attachments/assets/807c6c72-9fbf-450c-a873-0dd391f22b88)

The content being same for both:
In Open Library Website:
![image](https://github.com/user-attachments/assets/414b2698-5e77-4113-904c-a76b4019cc07)
In local:
![image](https://github.com/user-attachments/assets/41c5681c-5b54-49e5-a2b4-6f64da32e1ee)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
