### PR TITLE
Add wikisource trusted book provider

### DIFF
--- a/openlibrary/book_providers.py
+++ b/openlibrary/book_providers.py
@@ -482,6 +482,11 @@ class DirectProvider(AbstractBookProvider):
         )
 
 
+class WikisourceProvider(AbstractBookProvider):
+    short_name = 'wikisource'
+    identifier_key = 'wikisource'
+
+
 PROVIDER_ORDER: list[AbstractBookProvider] = [
     # These providers act essentially as their own publishers, so link to the first when
     # we're on an edition page
@@ -491,6 +496,7 @@ PROVIDER_ORDER: list[AbstractBookProvider] = [
     StandardEbooksProvider(),
     OpenStaxProvider(),
     CitaPressProvider(),
+    WikisourceProvider(),
     # Then link to IA
     InternetArchiveProvider(),
 ]

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -455,7 +455,8 @@ msgstr ""
 #: book_providers/gutenberg_read_button.html
 #: book_providers/librivox_read_button.html
 #: book_providers/openstax_read_button.html
-#: book_providers/standard_ebooks_read_button.html covers/author_photo.html
+#: book_providers/standard_ebooks_read_button.html
+#: book_providers/wikisource_read_button.html covers/author_photo.html
 #: covers/book_cover.html covers/book_cover_single_edition.html
 #: covers/book_cover_work.html covers/change.html lib/history.html
 #: my_books/dropdown_content.html native_dialog.html
@@ -855,7 +856,8 @@ msgstr ""
 #: book_providers/direct_read_button.html
 #: book_providers/gutenberg_read_button.html
 #: book_providers/openstax_read_button.html
-#: book_providers/standard_ebooks_read_button.html books/custom_carousel.html
+#: book_providers/standard_ebooks_read_button.html
+#: book_providers/wikisource_read_button.html books/custom_carousel.html
 #: books/edit/edition.html books/show.html books/works-show.html trending.html
 #: type/list/embed.html widget.html
 msgid "Read"
@@ -2362,7 +2364,8 @@ msgstr ""
 
 #: admin/loans_table.html book_providers/cita_press_download_options.html
 #: book_providers/ia_download_options.html
-#: book_providers/openstax_download_options.html books/edit/edition.html
+#: book_providers/openstax_download_options.html
+#: book_providers/wikisource_download_options.html books/edit/edition.html
 msgid "PDF"
 msgstr ""
 
@@ -3061,6 +3064,7 @@ msgstr ""
 #: book_providers/librivox_download_options.html
 #: book_providers/openstax_download_options.html
 #: book_providers/standard_ebooks_download_options.html
+#: book_providers/wikisource_download_options.html
 msgid "Download Options"
 msgstr ""
 
@@ -3090,6 +3094,7 @@ msgstr ""
 #: book_providers/librivox_read_button.html
 #: book_providers/openstax_read_button.html
 #: book_providers/standard_ebooks_read_button.html
+#: book_providers/wikisource_read_button.html
 #: check_ins/reading_goal_progress.html
 msgid "Learn more"
 msgstr ""
@@ -3284,6 +3289,45 @@ msgid ""
 " is a trusted book provider and a volunteer-driven project that produces "
 "new editions of public domain ebooks that are lovingly formatted, open "
 "source, free of copyright restrictions, and free of cost."
+msgstr ""
+
+#: book_providers/wikisource_download_options.html
+msgid "Download PDF from Wikisource"
+msgstr ""
+
+#: book_providers/wikisource_download_options.html
+msgid "Download MOBI from Wikisource"
+msgstr ""
+
+#: book_providers/wikisource_download_options.html
+msgid "MOBI (for Kindle)"
+msgstr ""
+
+#: book_providers/wikisource_download_options.html
+msgid "Download EPUB from Wikisource"
+msgstr ""
+
+#: book_providers/wikisource_download_options.html
+msgid "EPUB (for most other e-readers)"
+msgstr ""
+
+#: book_providers/wikisource_download_options.html
+msgid "Read at Wikisource"
+msgstr ""
+
+#: book_providers/wikisource_read_button.html
+msgid "Read eBook on Wikisource"
+msgstr ""
+
+#: book_providers/wikisource_read_button.html
+msgid ""
+"This book is available from <a "
+"href=\"https://wikisource.org/\">Wikisource</a>. Wikisource, a <a "
+"href=\"https://www.wikimedia.org/\">Wikimedia Foundation</a> project, is "
+"a trusted book provider of works available under the <a "
+"href=\"https://creativecommons.org/licenses/by-sa/4.0/\">CC-BY-SA</a> "
+"open content license, such as essays, historical documents, letters, "
+"speeches, and public domain books."
 msgstr ""
 
 #: books/RelatedWorksCarousel.html

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -365,6 +365,7 @@ def get_doc(doc: SolrDocument):
         id_standard_ebooks=doc.get('id_standard_ebooks', []),
         id_openstax=doc.get('id_openstax', []),
         id_cita_press=doc.get('id_cita_press', []),
+        id_wikisource=doc.get('id_wikisource', []),
         editions=[
             web.storage(
                 {

--- a/openlibrary/plugins/worksearch/schemes/works.py
+++ b/openlibrary/plugins/worksearch/schemes/works.py
@@ -187,6 +187,7 @@ class WorkSearchScheme(SearchScheme):
         'id_standard_ebooks',
         'id_openstax',
         'id_cita_press',
+        'id_wikisource',
     }
     facet_rewrites = {
         ('public_scan', 'true'): 'ebook_access:public',

--- a/openlibrary/plugins/worksearch/tests/test_worksearch.py
+++ b/openlibrary/plugins/worksearch/tests/test_worksearch.py
@@ -62,6 +62,7 @@ def test_get_doc():
             'id_standard_ebooks': [],
             'id_openstax': [],
             'id_cita_press': [],
+            'id_wikisource': [],
             'editions': [],
         }
     )

--- a/openlibrary/templates/book_providers/wikisource_download_options.html
+++ b/openlibrary/templates/book_providers/wikisource_download_options.html
@@ -1,33 +1,33 @@
 $def with(wikisource_id)
 
-$# TODO: I'm assuming that the wikisource_id will be formatted like lang:page_title.
-$# Example: en:The_Annotated_Strange_Case_of_Dr_Jekyll_and_Mr_Hyde
-$# When I build the import script, this is subject to change.
+$code:
+    # pardon this stupid way to avoid importing re in a html file
+    def is_langcode(string):
+        return all('a' <= char <= 'z' for char in string) and len(string) > 0
 
-$# pardon this stupid way to avoid importing re in a html file
-$def is_langcode(string):
-$  return all('a' <= char <= 'z' for char in string) and len(string) > 0
+    def split_id(string):
+        chunks = string.split(":")
+        if len(chunks) >= 2 and is_langcode(chunks[0]):
+            return chunks[0], ":".join(chunks[1:])
+        return 'en', string
 
-$def split_id(string):
-$  chunks = string.split(":")
-$  if len(chunks) >= 2 and is_langcode(chunks[0]):
-$    return chunks[0], ":".join(chunks[1:])
-$  return 'en', string
+    langcode, title = split_id(wikisource_id)
 
-$ langcode, title = split_id(wikisource_id)
+    def direct_url(type):
+        return 'https://ws-export.wmcloud.org/?format=' + type + '&lang=' + langcode + '&page=' + title
 
-$def direct_url(type):
-$  return f'https://ws-export.wmcloud.org/?format={type}&lang={langcode}&page={title}'
-
-$ outbound_url = 'https://wikisource.org/wiki/' + wikisource_id
+    outbound_url = 'https://wikisource.org/wiki/' + wikisource_id
+    pdf_url = direct_url('pdf')
+    mobi_url = direct_url('mobi')
+    epub_url = direct_url('epub')
 
 <hr>
 <div class="cta-section">
     <p class="cta-section-title">$_('Download Options')</p>
     <ul class="ebook-download-options">
-        <li><a title="$_('Download PDF from Wikisource')" href="$direct_url('pdf')">$_('PDF')</a></li>
-        <li><a title="$_('Download MOBI from Wikisource')" href="$direct_url('mobi')">$_('MOBI (for Kindle)')</a></li>
-        <li><a title="$_('Download EPUB from Wikisource')" href="$direct_url('epub')">$_('EPUB (for most other e-readers)')</a></li>
+        <li><a title="$_('Download PDF from Wikisource')" href="$pdf_url">$_('PDF')</a></li>
+        <li><a title="$_('Download MOBI from Wikisource')" href="$mobi_url">$_('MOBI (for Kindle)')</a></li>
+        <li><a title="$_('Download EPUB from Wikisource')" href="$epub_url">$_('EPUB (for most other e-readers)')</a></li>
         <li><a href="$outbound_url">$_('Read at Wikisource')</a></li>
     </ul>
 </div>

--- a/openlibrary/templates/book_providers/wikisource_download_options.html
+++ b/openlibrary/templates/book_providers/wikisource_download_options.html
@@ -1,0 +1,12 @@
+$def with(wikisource_id)
+
+$ # TODO: verify if lang code like en: is part of wikisource_id
+$ url = 'https://wikisource.org/wiki/' + wikisource_id
+
+<hr>
+<div class="cta-section">
+  <p class="cta-section-title">$_('Download Options')</p>
+    <ul class="ebook-download-options">
+      <li><a href="$url">$_('Read on Wikisource')</a></li>
+    </ul>
+</div>

--- a/openlibrary/templates/book_providers/wikisource_download_options.html
+++ b/openlibrary/templates/book_providers/wikisource_download_options.html
@@ -1,12 +1,33 @@
 $def with(wikisource_id)
 
-$ # TODO: verify if lang code like en: is part of wikisource_id
-$ url = 'https://wikisource.org/wiki/' + wikisource_id
+$ # TODO: I'm assuming that the wikisource_id will be formatted like lang:page_title.
+$ # Example: en:The_Annotated_Strange_Case_of_Dr_Jekyll_and_Mr_Hyde
+$ # When I build the import script, this is subject to change.
+
+$ # pardon this stupid way to avoid importing re in a html file
+$ def is_langcode(string):
+$   return all('a' <= char <= 'z' for char in string) and len(string) > 0
+
+$ def split_id(string):
+$   chunks = string.split(":")
+$   if len(chunks) >= 2 and is_langcode(chunks[0]):
+$     return chunks[0], ":".join(chunks[1:])
+$   return 'en', string
+
+$ langcode, title = split_id(wikisource_id)
+
+$ def direct_url(type):
+$   return f'https://ws-export.wmcloud.org/?format={type}&lang={langcode}&page={title}'
+
+$ outbound_url = 'https://wikisource.org/wiki/' + wikisource_id
 
 <hr>
 <div class="cta-section">
-  <p class="cta-section-title">$_('Download Options')</p>
+    <p class="cta-section-title">$_('Download Options')</p>
     <ul class="ebook-download-options">
-      <li><a href="$url">$_('Read on Wikisource')</a></li>
+        <li><a title="$_('Download PDF from Wikisource')" href="$direct_url('pdf')">$_('PDF')</a></li>
+        <li><a title="$_('Download MOBI from Wikisource')" href="$direct_url('mobi')">$_('MOBI (for Kindle)')</a></li>
+        <li><a title="$_('Download EPUB from Wikisource')" href="$direct_url('epub')">$_('EPUB (for most other e-readers)')</a></li>
+        <li><a href="$outbound_url">$_('Read at Wikisource')</a></li>
     </ul>
 </div>

--- a/openlibrary/templates/book_providers/wikisource_download_options.html
+++ b/openlibrary/templates/book_providers/wikisource_download_options.html
@@ -14,7 +14,9 @@ $code:
     langcode, title = split_id(wikisource_id)
 
     def direct_url(type):
-        return 'https://ws-export.wmcloud.org/?format=' + type + '&lang=' + langcode + '&page=' + title
+        params = {"format": type, "lang": langcode, "page": title}
+        base_url = "https://ws-export.wmcloud.org/"
+        return "%s?%s" % (base_url, urlencode(params))
 
     outbound_url = 'https://wikisource.org/wiki/' + wikisource_id
     pdf_url = direct_url('pdf')

--- a/openlibrary/templates/book_providers/wikisource_download_options.html
+++ b/openlibrary/templates/book_providers/wikisource_download_options.html
@@ -1,23 +1,23 @@
 $def with(wikisource_id)
 
-$ # TODO: I'm assuming that the wikisource_id will be formatted like lang:page_title.
-$ # Example: en:The_Annotated_Strange_Case_of_Dr_Jekyll_and_Mr_Hyde
-$ # When I build the import script, this is subject to change.
+$# TODO: I'm assuming that the wikisource_id will be formatted like lang:page_title.
+$# Example: en:The_Annotated_Strange_Case_of_Dr_Jekyll_and_Mr_Hyde
+$# When I build the import script, this is subject to change.
 
-$ # pardon this stupid way to avoid importing re in a html file
-$ def is_langcode(string):
-$   return all('a' <= char <= 'z' for char in string) and len(string) > 0
+$# pardon this stupid way to avoid importing re in a html file
+$def is_langcode(string):
+$  return all('a' <= char <= 'z' for char in string) and len(string) > 0
 
-$ def split_id(string):
-$   chunks = string.split(":")
-$   if len(chunks) >= 2 and is_langcode(chunks[0]):
-$     return chunks[0], ":".join(chunks[1:])
-$   return 'en', string
+$def split_id(string):
+$  chunks = string.split(":")
+$  if len(chunks) >= 2 and is_langcode(chunks[0]):
+$    return chunks[0], ":".join(chunks[1:])
+$  return 'en', string
 
 $ langcode, title = split_id(wikisource_id)
 
-$ def direct_url(type):
-$   return f'https://ws-export.wmcloud.org/?format={type}&lang={langcode}&page={title}'
+$def direct_url(type):
+$  return f'https://ws-export.wmcloud.org/?format={type}&lang={langcode}&page={title}'
 
 $ outbound_url = 'https://wikisource.org/wiki/' + wikisource_id
 

--- a/openlibrary/templates/book_providers/wikisource_read_button.html
+++ b/openlibrary/templates/book_providers/wikisource_read_button.html
@@ -5,7 +5,7 @@ $def with(wikisource_id, analytics_attr)
 </div>
 
 $if render_once('wikisource-toast'):
-    <div class="toast toast--book-provider" data-toast-trigger=".cta-btn--openstax" id="wikisource-toast" style="display:none">
+    <div class="toast toast--book-provider" data-toast-trigger=".cta-btn--wikisource" id="wikisource-toast" style="display:none">
         <div class="toast__body">
             $:_('This book is available from <a href="https://wikisource.org/">Wikisource</a>. Wikisource, a <a href="https://www.wikimedia.org/">Wikimedia Foundation</a> project, is a trusted book provider of works available under the <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC-BY-SA</a> open content license, such as essays, historical documents, letters, speeches, and public domain books.')
             <a href="https://wikisource.org/wiki/Wikisource:What_is_Wikisource%3F">$_('Learn more')</a>

--- a/openlibrary/templates/book_providers/wikisource_read_button.html
+++ b/openlibrary/templates/book_providers/wikisource_read_button.html
@@ -1,0 +1,21 @@
+$def with(wikisource_id)
+
+<div class="cta-button-group">
+    <a href="https://wikisource.org/wiki/$wikisource_id" title="$_('Read eBook on Wikisource')"
+        class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--cita-press" target="_blank"
+        aria-haspopup="true" aria-controls="wikisource-toast">$_('Read')</a>
+</div>
+
+$if render_once('wikisource-toast'):
+<div class="toast toast--book-provider" data-toast-trigger=".cta-btn--openstax" id="wikisource-toast"
+    style="display:none">
+    <div class="toast__body">
+        $:_('This book is available from <a href="https://wikisource.org/">Wikisource</a>. Wikisource, a <a
+            href="https://www.wikimedia.org/">Wikimedia Foundation</a> project, is a trusted book
+        provider of works available under the <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC-BY-SA</a>
+        open content license, such as essays,
+        historical documents, letters, speeches, and public domain books.')
+        <a href="https://wikisource.org/wiki/Wikisource:What_is_Wikisource%3F">$_('Learn more')</a>
+    </div>
+    <a class="toast__close">&times;<span class="shift">$_("Close")</span></a>
+</div>

--- a/openlibrary/templates/book_providers/wikisource_read_button.html
+++ b/openlibrary/templates/book_providers/wikisource_read_button.html
@@ -10,11 +10,7 @@ $if render_once('wikisource-toast'):
 <div class="toast toast--book-provider" data-toast-trigger=".cta-btn--openstax" id="wikisource-toast"
     style="display:none">
     <div class="toast__body">
-        $:_('This book is available from <a href="https://wikisource.org/">Wikisource</a>. Wikisource, a <a
-            href="https://www.wikimedia.org/">Wikimedia Foundation</a> project, is a trusted book
-        provider of works available under the <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC-BY-SA</a>
-        open content license, such as essays,
-        historical documents, letters, speeches, and public domain books.')
+        $:_('This book is available from <a href="https://wikisource.org/">Wikisource</a>. Wikisource, a <a href="https://www.wikimedia.org/">Wikimedia Foundation</a> project, is a trusted book provider of works available under the <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC-BY-SA</a> open content license, such as essays, historical documents, letters, speeches, and public domain books.')
         <a href="https://wikisource.org/wiki/Wikisource:What_is_Wikisource%3F">$_('Learn more')</a>
     </div>
     <a class="toast__close">&times;<span class="shift">$_("Close")</span></a>

--- a/openlibrary/templates/book_providers/wikisource_read_button.html
+++ b/openlibrary/templates/book_providers/wikisource_read_button.html
@@ -2,7 +2,7 @@ $def with(wikisource_id)
 
 <div class="cta-button-group">
     <a href="https://wikisource.org/wiki/$wikisource_id" title="$_('Read eBook on Wikisource')"
-        class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--cita-press" target="_blank"
+        class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--wikisource" target="_blank"
         aria-haspopup="true" aria-controls="wikisource-toast">$_('Read')</a>
 </div>
 

--- a/openlibrary/templates/book_providers/wikisource_read_button.html
+++ b/openlibrary/templates/book_providers/wikisource_read_button.html
@@ -1,17 +1,14 @@
-$def with(wikisource_id)
+$def with(wikisource_id, analytics_attr)
 
 <div class="cta-button-group">
-    <a href="https://wikisource.org/wiki/$wikisource_id" title="$_('Read eBook on Wikisource')"
-        class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--wikisource" target="_blank"
-        aria-haspopup="true" aria-controls="wikisource-toast">$_('Read')</a>
+    <a href="https://wikisource.org/wiki/$wikisource_id" title="$_('Read eBook on Wikisource')" class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--wikisource" target="_blank" aria-haspopup="true" aria-controls="wikisource-toast">$_('Read')</a>
 </div>
 
 $if render_once('wikisource-toast'):
-<div class="toast toast--book-provider" data-toast-trigger=".cta-btn--openstax" id="wikisource-toast"
-    style="display:none">
-    <div class="toast__body">
-        $:_('This book is available from <a href="https://wikisource.org/">Wikisource</a>. Wikisource, a <a href="https://www.wikimedia.org/">Wikimedia Foundation</a> project, is a trusted book provider of works available under the <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC-BY-SA</a> open content license, such as essays, historical documents, letters, speeches, and public domain books.')
-        <a href="https://wikisource.org/wiki/Wikisource:What_is_Wikisource%3F">$_('Learn more')</a>
+    <div class="toast toast--book-provider" data-toast-trigger=".cta-btn--openstax" id="wikisource-toast" style="display:none">
+        <div class="toast__body">
+            $:_('This book is available from <a href="https://wikisource.org/">Wikisource</a>. Wikisource, a <a href="https://www.wikimedia.org/">Wikimedia Foundation</a> project, is a trusted book provider of works available under the <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC-BY-SA</a> open content license, such as essays, historical documents, letters, speeches, and public domain books.')
+            <a href="https://wikisource.org/wiki/Wikisource:What_is_Wikisource%3F">$_('Learn more')</a>
+        </div>
+        <a class="toast__close">&times;<span class="shift">$_("Close")</span></a>
     </div>
-    <a class="toast__close">&times;<span class="shift">$_("Close")</span></a>
-</div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8545

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature: Adds web support for Wikisource as a trusted book provider

### Technical
The implementation itself is subject to change as I dig deeper into what options are available to us for importing. For example, Wikisource page titles are not necessarily static, but in this implementation they are effectively used as IDs.

### Testing
No data to test with yet! Do I need to do anything besides verify that OL builds and runs locally without crashing?

### Screenshot
All four of the links on the left hand side, as well as the read button, are fully functional upon testing with imported production data! I'm not sure how to test the read button toast, though.
<img width="795" alt="image" src="https://github.com/user-attachments/assets/e9a24ff2-8b63-4e73-b277-e1080f78f3e1">


### Stakeholders
@cdrini 


Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code.
