### PR TITLE
Standardize Styling for Search Inside Results

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -74,7 +74,7 @@
     },
     {
       "path": "static/build/page-admin.css",
-      "maxSize": "25KB"
+      "maxSize": "25.05KB"
     },
     {
       "path": "static/build/page-book.css",
@@ -102,7 +102,7 @@
     },
     {
       "path": "static/build/page-user.css",
-      "maxSize": "27.05KB"
+      "maxSize": "27.06KB"
     }
   ]
 }

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -7358,21 +7358,21 @@ msgstr ""
 msgid "right chevron"
 msgstr ""
 
-#: FulltextSnippet.html
-msgid "See All Results"
-msgstr ""
-
-#: FulltextSuggestionSnippet.html
+#: FulltextSnippet.html FulltextSuggestionSnippet.html
 msgid "❝"
 msgstr ""
 
-#: FulltextSuggestionSnippet.html
+#: FulltextSnippet.html FulltextSuggestionSnippet.html
 msgid "❞"
 msgstr ""
 
-#: FulltextSuggestionSnippet.html
+#: FulltextSnippet.html FulltextSuggestionSnippet.html
 #, python-format
 msgid "Page: %(page)s"
+msgstr ""
+
+#: FulltextSnippet.html
+msgid "See All Results"
 msgstr ""
 
 #: IABook.html

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -876,8 +876,8 @@ msgstr ""
 msgid "Borrow \"%(title)s\""
 msgstr ""
 
-#: FulltextSnippet.html ReadButton.html books/custom_carousel.html
-#: books/edit/edition.html type/list/embed.html widget.html
+#: ReadButton.html books/custom_carousel.html books/edit/edition.html
+#: type/list/embed.html widget.html
 msgid "Borrow"
 msgstr ""
 
@@ -7354,13 +7354,9 @@ msgstr ""
 msgid "❞"
 msgstr ""
 
-#: FulltextSnippet.html FulltextSuggestionSnippet.html
+#: FulltextSuggestionSnippet.html
 #, python-format
 msgid "Page: %(page)s"
-msgstr ""
-
-#: FulltextSnippet.html
-msgid "See All Results"
 msgstr ""
 
 #: IABook.html

--- a/openlibrary/macros/FulltextSnippet.html
+++ b/openlibrary/macros/FulltextSnippet.html
@@ -4,31 +4,15 @@ $ ia = doc.get('fields', {}).get('identifier', [''])[0]
 $ ia_base_url = "https://archive.org"
 $ availability = doc.get('availability', {})
 $ snippets = doc.get('highlight', {}).get('text', [''])[:2]
-$ page_nums = doc.get('fields', {}).get('page_num', [])
-$if len(page_nums) == 1 and isinstance(page_nums[0], list):
-    $ page_nums = page_nums[0]
-$ page = ', '.join(str(num) for num in page_nums)
 
 <ul class="fsi-snippet">
   $for snippet in snippets:
     $if snippet:
       <li class="fsi-snippet__main fsi-snippet__full-results">
         <div class="fsi-snippet__quotation-mark">$_('❝')</div>
-        <a class="fsi-snippet__link" href="$ia_base_url/details/$ia" data-ol-link-track="SearchInsideCard|QuoteClick">
+        <a class="fsi-snippet__link" href="$ia_base_url/stream/$(ia)?ref=ol&access=1#search/$(q)" data-ol-link-track="SearchInsideCard|QuoteClick">
           &hellip;$:(snippet.replace("<", "&laquo;").replace(">", "&raquo;").replace("{{{", "<mark class='highlight'><strong>").replace("}}}", "</strong></mark>"))&hellip;
         </a>&nbsp;
         <div class="fsi-snippet__quotation-mark">$_('❞')</div>
-        $if page:
-          <span class="fsi-snippet__page-num" href="$ia_base_url/details/$ia">
-            <a data-ol-link-track="SearchInsideCard|QuoteClick">$_('Page: %(page)s', page=page)</a>
-          </span>
       </li>
 </ul>
-
-
-
-$if availability.get('status') == 'open':
-  <p class="center"><a href="https://archive.org/stream/$(ia)?ref=ol&access=1#search/$(q)">$_("See All Results")</a></p>
-
-$if availability.get('status') == 'borrow_available':
-  <p class="center">$_("Borrow") &amp; <a href="https://archive.org/stream/$(ia)?ref=ol&access=1#search/$(q)">$_("See All Results")</a></p>

--- a/openlibrary/macros/FulltextSnippet.html
+++ b/openlibrary/macros/FulltextSnippet.html
@@ -1,21 +1,31 @@
 $def with (q, doc=None)
 
 $ ia = doc.get('fields', {}).get('identifier', [''])[0]
+$ ia_base_url = "https://archive.org"
 $ availability = doc.get('availability', {})
-$ snippets = doc.get('highlight', {}).get('text', [''])
+$ snippets = doc.get('highlight', {}).get('text', [''])[:2]
 $ page_nums = doc.get('fields', {}).get('page_num', [])
-$ page = ', '.join([str(num) for num in page_nums])
+$if len(page_nums) == 1 and isinstance(page_nums[0], list):
+    $ page_nums = page_nums[0]
+$ page = ', '.join(str(num) for num in page_nums)
 
-$if snippets:
-  <section class="fulltext-excerpts" aria-label="search results from: $doc['edition']['title']">
-    <ul>
-      $for snippet in snippets:
-        $if snippet:
-          <li class="fulltext-excerpt">
-            &hellip;$:(snippet.replace("<", "&laquo;").replace(">", "&raquo;").replace("{{{", "<mark class='highlight'><strong>").replace("}}}", "</strong></mark>"))&hellip;
-          </li>
-    </ul>
-  </section>
+<ul class="fsi-snippet">
+  $for snippet in snippets:
+    $if snippet:
+      <li class="fsi-snippet__main fsi-snippet__full-results">
+        <div class="fsi-snippet__quotation-mark">$_('❝')</div>
+        <a class="fsi-snippet__link" href="$ia_base_url/details/$ia" data-ol-link-track="SearchInsideCard|QuoteClick">
+          &hellip;$:(snippet.replace("<", "&laquo;").replace(">", "&raquo;").replace("{{{", "<mark class='highlight'><strong>").replace("}}}", "</strong></mark>"))&hellip;
+        </a>&nbsp;
+        <div class="fsi-snippet__quotation-mark">$_('❞')</div>
+        $if page:
+          <span class="fsi-snippet__page-num" href="$ia_base_url/details/$ia">
+            <a data-ol-link-track="SearchInsideCard|QuoteClick">$_('Page: %(page)s', page=page)</a>
+          </span>
+      </li>
+</ul>
+
+
 
 $if availability.get('status') == 'open':
   <p class="center"><a href="https://archive.org/stream/$(ia)?ref=ol&access=1#search/$(q)">$_("See All Results")</a></p>

--- a/openlibrary/macros/FulltextSuggestionSnippet.html
+++ b/openlibrary/macros/FulltextSuggestionSnippet.html
@@ -19,8 +19,8 @@ $if snippet:
           </a>&nbsp;
           <div class="fsi-snippet__quotation-mark">$_('❞')</div>
           $if page:
-          <div class="fsi-snippet__page-num" href="$ia_base_url/details/$ia">
+          <span class="fsi-snippet__page-num" href="$ia_base_url/details/$ia">
             <a data-ol-link-track="SearchInsideSuggestion|QuoteClick">$_('Page: %(page)s', page=page)</a>
-          </div>
+          </span>
         </div>
   </div>

--- a/openlibrary/macros/FulltextSuggestionSnippet.html
+++ b/openlibrary/macros/FulltextSuggestionSnippet.html
@@ -19,7 +19,7 @@ $if snippet:
           </a>&nbsp;
           <div class="fsi-snippet__quotation-mark">$_('❞')</div>
           $if page:
-          <span class="fsi-snippet__page-num" href="$ia_base_url/details/$ia">
+            <span class="fsi-snippet__page-num" href="$ia_base_url/details/$ia">
             <a data-ol-link-track="SearchInsideSuggestion|QuoteClick">$_('Page: %(page)s', page=page)</a>
           </span>
         </div>

--- a/static/css/components/fulltext-snippet.less
+++ b/static/css/components/fulltext-snippet.less
@@ -4,7 +4,7 @@
   padding: 5px;
   margin: 0;
   font-size: small;
-  @media (min-width: @width-breakpoint-mobile-m) {
+  @media (min-width: @width-breakpoint-mobile) {
     width: 90%;
   }
   @media (min-width: @width-breakpoint-tablet) {
@@ -37,6 +37,14 @@
 
     a:hover {
       color: @link-blue;
+    }
+  }
+  &__full-results {
+    border-bottom: 1px solid @lightest-grey;
+    font-size: 1em;
+    overflow: hidden;
+    &:last-child {
+      border-bottom: none;
     }
   }
 

--- a/static/css/components/search-results-container.less
+++ b/static/css/components/search-results-container.less
@@ -3,6 +3,7 @@
  * https://github.com/internetarchive/openlibrary/wiki/Design-Pattern-Library#searchresultcontainer
  */
 @import (less) "search-result-item.less";
+@import (less) "fulltext-snippet.less";
 
 @media only screen and (min-width: @width-breakpoint-desktop) {
   .resultsContainer {

--- a/static/css/page-user.less
+++ b/static/css/page-user.less
@@ -229,7 +229,7 @@ tr.table-row.selected{
 // Import styles for fulltext-search-suggestion card item
 @import (less) "components/fulltext-search-suggestion-item.less";
 // Import styles for fulltext-search-suggestion card item snippet
-@import (less) "components/fulltext-suggestion-snippet.less";
+@import (less) "components/fulltext-snippet.less";
 // Import styles for author infobox
 @import (less) "components/author-infobox.less";
 // Import all common components


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9479 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
- Updates styling to Search Inside Result to match the Search Inside Suggestion Card #1001 
- Eliminates inconsistent footer messages. 

### Technical
<!-- What should be noted about the implementation? -->
Merged in #9734 and combined the [fulltext-suggestion-snippet.less](https://github.com/internetarchive/openlibrary/blob/master/static/css/components/fulltext-suggestion-snippet.less) to [fulltext-snippet.less](https://github.com/merwhite11/openlibrary/blob/9479/standardize-search-inside-results/static/css/components/fulltext-snippet.less). 

When this PR gets merged in, there will be a merge conflict in page-user.less where the snippet styling files are being imported. 

I will need to resolve the conflict so that both [FulltextSuggestionSnippet.html](https://github.com/internetarchive/openlibrary/blob/master/openlibrary/macros/FulltextSuggestionSnippet.html) and [FulltextSnippet.html](https://github.com/merwhite11/openlibrary/blob/9479/standardize-search-inside-results/openlibrary/macros/FulltextSnippet.html) are styled by [fulltext-snippet.less](https://github.com/merwhite11/openlibrary/blob/9479/standardize-search-inside-results/static/css/components/fulltext-snippet.less) from this PR. 

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
I tested this by using a sample data json and a reference to the json in dev env: https://github.com/jimchamp/openlibrary/compare/master...jimchamp:openlibrary:sandbox-fulltext-search-results#diff-fb7667454719879be914be81c253b5dd9fc0dcbdb6afaada791b5091e80e8ec2

I input the test data to the web container by running these commands:
`docker compose exec -e PYTHONPATH=. web bash
./scripts/copydocs.py /books/OL24966433M
./scripts/copydocs.py /books/OL32090209M
./scripts/copydocs.py /books/OL24375865M
./scripts/copydocs.py /books/OL24204364M
./scripts/copydocs.py /books/OL7522718M`

The test search term is 'a cricket in the night'
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="1043" alt="Screenshot 2024-07-30 at 12 08 24 PM" src="https://github.com/user-attachments/assets/08ff2a6b-40f7-4289-b3c0-8b84c592bf84">

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
