### PR TITLE
Fix web book toast message not matching the web book read

### DIFF
--- a/openlibrary/book_providers.py
+++ b/openlibrary/book_providers.py
@@ -221,7 +221,7 @@ class AbstractBookProvider(Generic[TProviderMetadata]):
 
     def get_acquisitions(
         self,
-        edition: Edition,
+        edition: Edition | web.Storage,
     ) -> list[Acquisition]:
         if edition.providers:
             return [Acquisition.from_json(dict(p)) for p in edition.providers]
@@ -298,6 +298,20 @@ class InternetArchiveProvider(AbstractBookProvider[IALiteMetadata]):
             return EbookAccess.UNCLASSIFIED
         else:
             return EbookAccess.PUBLIC
+
+    def get_acquisitions(
+        self,
+        edition: Edition,
+    ) -> list[Acquisition]:
+        return [
+            Acquisition(
+                access='open-access',
+                format='web',
+                price=None,
+                url=f'https://archive.org/details/{self.get_best_identifier(edition)}',
+                provider_name=self.short_name,
+            )
+        ]
 
 
 class LibriVoxProvider(AbstractBookProvider):
@@ -425,21 +439,30 @@ class DirectProvider(AbstractBookProvider):
         return None
 
     def get_identifiers(self, ed_or_solr: Edition | dict) -> list[str]:
-        # It's an edition.
-        # `Acquisition` objects have a `provider_name` attribute, and search results are
-        # `Storage` objects with an `providers` being a list of `Acquisition`. Ensure
-        # `provider_name` is `None` so as not to match every web book as a DirectProvider.
-        # See `add_non_solr_fields` in `worksearch/schemes/works.py`.
-        providers = ed_or_solr.get('providers', [])
-        provider_name = (
-            providers[0].get("provider_name") if len(providers) >= 1 else None
-        )
-        if providers and provider_name is None:
-            return [
+        """
+        Note: This will only work for solr records if the provider field was fetched
+        in the solr request. (Note: this field is populated from db)
+        """
+        if providers := ed_or_solr.get('providers', []):
+            identifiers = [
                 provider.url
                 for provider in map(Acquisition.from_json, ed_or_solr['providers'])
                 if provider.ebook_access >= EbookAccess.PRINTDISABLED
             ]
+            to_remove = set()
+            for tbp in PROVIDER_ORDER:
+                # Avoid infinite recursion.
+                if isinstance(tbp, DirectProvider):
+                    continue
+                if not tbp.get_identifiers(ed_or_solr):
+                    continue
+                for acq in tbp.get_acquisitions(ed_or_solr):
+                    to_remove.add(acq.url)
+
+            return [
+                identifier for identifier in identifiers if identifier not in to_remove
+            ]
+
         else:
             # TODO: Not implemented for search/solr yet
             return []

--- a/openlibrary/templates/book_providers/direct_read_button.html
+++ b/openlibrary/templates/book_providers/direct_read_button.html
@@ -8,7 +8,7 @@ $if acquisition.access == 'open-access':
     <a
         href="$(acquisition.url)"
         title="$_('Read free online')"
-        class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--direct--$(clean_domain)"
+        class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--direct"
         target="_blank"
         aria-haspopup="true"
         aria-controls="direct-provider-toast-$(clean_domain)"
@@ -27,7 +27,7 @@ $elif acquisition.access == 'sample':
 $if render_once('direct-provider-toast-' + clean_domain):
   <div
     class="toast toast--book-provider"
-    data-toast-trigger=".cta-btn--direct--$(clean_domain)"
+    data-toast-trigger="[aria-controls=direct-provider-toast-$(clean_domain)]"
     id="direct-provider-toast-$(clean_domain)"
     style="display:none"
   >

--- a/openlibrary/templates/book_providers/direct_read_button.html
+++ b/openlibrary/templates/book_providers/direct_read_button.html
@@ -1,16 +1,17 @@
 $def with(acquisition, domain)
 $# :param Acquisition acquisition:
 $# :param domain str:
+$ clean_domain = domain.replace(".", "")
 
 $if acquisition.access == 'open-access':
   <div class="cta-button-group">
     <a
         href="$(acquisition.url)"
         title="$_('Read free online')"
-        class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--direct"
+        class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--direct--$(clean_domain)"
         target="_blank"
         aria-haspopup="true"
-        aria-controls="direct-provider-toast"
+        aria-controls="direct-provider-toast-$(clean_domain)"
     >$_('Read')</a>
   </div>
 
@@ -23,8 +24,13 @@ $elif acquisition.access == 'sample':
     >$_('Preview')</a>
   </div>
 
-$if render_once('direct-provider-toast'):
-  <div class="toast toast--book-provider" data-toast-trigger=".cta-btn--direct" id="direct-provider-toast" style="display:none">
+$if render_once('direct-provider-toast-' + clean_domain):
+  <div
+    class="toast toast--book-provider"
+    data-toast-trigger=".cta-btn--direct--$(clean_domain)"
+    id="direct-provider-toast-$(clean_domain)"
+    style="display:none"
+  >
     <div class="toast__body">
       $:_('This book is freely available from <a href="%s">%s</a>, an external third-party book provider.', acquisition.url, domain)
       <a href="/trusted-book-providers#web-books">$_('Learn more')<a>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9639 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR stops non-DirectProvider web books from being matched as `DirectProvider`s.

It also stops every `DirectProvider` book on a page from triggering the same toast message.

### Technical
<!-- What should be noted about the implementation? -->
With respect to the first issue:
The `Storage` objects that ultimately come from `SearchResponse` have `Acquisition` objects in their `providers` fields, so every web book search result will have a `providers` attribute.

This PR limits the matching for `DirectProvider` to cases where the `Acquisition` object has a value other than `None`, which is the default initialization value for `Acquisition.provider_name`.

More exploration will be needed to see whether a similar mis-match problem occurs when there is more than one `Acquisition` per `Work`.

With respect to the second issue:
The `direct_read_button.html` needs a unique `data-toast-trigger` per domain, otherwise every `DirectProvider` book, when multiple are displayed from different providers, will have trigger the same class id.
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Visit https://testing.openlibrary.org/search?q=format%3A%22Web+book%22&mode=everything&page=2
1. Click something other than the first result, or an OpenStax book, and verify the toast looks correct for that specific provider.
2. Now click an OpenStax book and ensure you see the OpenStax toast rather than the generic DirectProvider toast, which would simply mention the domain where the book is available, and not say anything about OpenStax specifically.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
