### PR TITLE
Add lang attribute to <html> tag for accessibility improvement.

### DIFF
--- a/openlibrary/data/sitemap.py
+++ b/openlibrary/data/sitemap.py
@@ -48,7 +48,7 @@ t_html_layout = t(
     """$def with (page)
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="robots" content="noindex,follow" />

--- a/openlibrary/data/sitemap.py
+++ b/openlibrary/data/sitemap.py
@@ -48,7 +48,7 @@ t_html_layout = t(
     """$def with (page)
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="${get_lang() or 'en'}">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="robots" content="noindex,follow" />

--- a/openlibrary/data/sitemap.py
+++ b/openlibrary/data/sitemap.py
@@ -48,7 +48,7 @@ t_html_layout = t(
     """$def with (page)
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="${get_lang() or 'en'}">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="robots" content="noindex,follow" />

--- a/openlibrary/templates/site/head.html
+++ b/openlibrary/templates/site/head.html
@@ -1,7 +1,7 @@
 $def with (page)
 
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="$get_lang() or 'en'">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="${get_lang() or 'en'}">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="title" content="" />

--- a/openlibrary/templates/site/head.html
+++ b/openlibrary/templates/site/head.html
@@ -1,7 +1,7 @@
 $def with (page)
 
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="${get_lang() or 'en'}">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="$(get_lang() or 'en')">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="title" content="" />

--- a/openlibrary/templates/site/head.html
+++ b/openlibrary/templates/site/head.html
@@ -1,7 +1,7 @@
 $def with (page)
 
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="$get_lang()">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="$get_lang() or 'en'">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="title" content="" />


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9634

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Description
<!-- What should be noted about the implementation? -->
This PR adds a `lang` attribute to the `<html>` tag to specify the primary language of the document. This attribute is crucial for accessibility, as it helps screen readers and other assistive technologies interpret the language correctly, ensuring proper pronunciation and comprehension for users. The `lang` attribute has been set to `"en"` for English, as this is the primary language of the content.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Open the modified HTML document in a browser.
2. Inspect the `<html>` tag to confirm the presence of the `lang="en"` attribute.
3. Use a screen reader or accessibility tool to verify that it recognizes the language of the document as English.

### Stakeholders
@cdrini 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
