### PR TITLE
Create `CacheableMacro` macro

### DIFF
--- a/openlibrary/macros/CacheableMacro.html
+++ b/openlibrary/macros/CacheableMacro.html
@@ -1,0 +1,3 @@
+$def with (macro_name, *args, **kwargs)
+
+$:render_cached_macro(macro_name, args, **kwargs)

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -212,6 +212,38 @@ def render_component(
     return html
 
 
+def render_macro(name, args, **kwargs):
+    return dict(web.template.Template.globals['macros'][name](*args, **kwargs))
+
+
+@public
+def render_cached_macro(name, args: tuple, **kwargs):
+    from openlibrary.plugins.openlibrary.home import caching_prethread
+
+    def get_key():
+        lang = web.ctx.lang
+        pd = web.cookies().get('pd', False)
+        key = f'{name}.{lang}'
+        if pd:
+            key += '.pd'
+        for arg in args:
+            key += f'.{arg}'
+        for k, v in kwargs.items():
+            key += f'.{k}:{v}'
+        return key
+    five_minutes = 5 * 60
+    key = get_key()
+    mc = cache.memcache_memoize(
+        render_macro, key, timeout=five_minutes, prethread=caching_prethread()
+    )
+
+    try:
+        page = mc(name, args, **kwargs)
+        return web.template.TemplateResult(page)
+    except (ValueError, TypeError) as e:
+        return '<span>Failed to render macro</span>'
+
+
 @public
 def get_error(name, *args):
     """Return error with the given name from errors.tmpl template."""

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -231,6 +231,7 @@ def render_cached_macro(name, args: tuple, **kwargs):
         for k, v in kwargs.items():
             key += f'.{k}:{v}'
         return key
+
     five_minutes = 5 * 60
     key = get_key()
     mc = cache.memcache_memoize(


### PR DESCRIPTION
In support of: #9058, #8279
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Creates new `CacheableMacro` macro, which is used for caching macros.

Usage:

```
$# Display a cached list of `/collections` page links:
{{CacheableMacro('PageList', '/collections')}}

$# Display cached carousel filled with classic Goosebumps books:
{{CacheableMacro('QueryCarousel', 'subject:"collectionID:goosebumps1"', title="Classic Goosebumps (1992-1997)")}}
```

To compare, here is how these same macros are called today:
```
$# Display a list of `/collections` page links:
{{PageList('/collections)}}

$# Display carousel filled with classic Goosebumps books:
{{QueryCarousel('subject:"collectionID:goosebumps1"', title="Classic Goosebumps (1992-1997)")}}
```

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
