### PR TITLE
Added new endpoint to create a user list from a link.

### DIFF
--- a/openlibrary/components/BulkSearch/utils/searchUtils.js
+++ b/openlibrary/components/BulkSearch/utils/searchUtils.js
@@ -34,7 +34,7 @@ export function buildSearchUrl(extractedBook, matchOptions, json = true) {
  */
 export function buildListUrl(bookMatches){
     const seeds = bookMatches.filter(bookMatch => bookMatch.solrDocs.numFound>0).map((bookMatch) => bookMatch.solrDocs.docs[0].key.split('/')[2])
-    const url = `https://openlibrary.org/lists/add?seeds=${seeds.join(',')}`
+    const url = `https://openlibrary.org/account/lists/add?seeds=${seeds.join(',')}`
     return url
 }
 

--- a/openlibrary/components/BulkSearch/utils/searchUtils.js
+++ b/openlibrary/components/BulkSearch/utils/searchUtils.js
@@ -34,7 +34,7 @@ export function buildSearchUrl(extractedBook, matchOptions, json = true) {
  */
 export function buildListUrl(bookMatches){
     const seeds = bookMatches.filter(bookMatch => bookMatch.solrDocs.numFound>0).map((bookMatch) => bookMatch.solrDocs.docs[0].key.split('/')[2])
-    const url = `https://openlibrary.org/account/lists/add?seeds=${seeds.join(',')}`
+    const url = `/account/lists/add?seeds=${seeds.join(',')}`
     return url
 }
 

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -9,7 +9,7 @@ from typing import Literal, cast
 import web
 
 from infogami.utils import delegate
-from infogami.utils.view import render_template, public
+from infogami.utils.view import render_template, public, require_login
 from infogami.infobase import client, common
 
 from openlibrary.accounts import get_current_user
@@ -354,20 +354,11 @@ class lists_edit(delegate.page):
 
 
 class lists_add_account(delegate.page):
-    path = r"/account/lists/add.*"
+    path = r"/account/lists/add"
 
+    @require_login
     def GET(self):
-        if user := get_current_user():
-            i = web.input(name=None)
-            return web.seeother(
-                f'{user.key}/lists/add{ "?seeds=" + i.seeds if i.seeds else ""}'
-            )
-        else:
-            return render_template(
-                "permission_denied",
-                web.ctx.fullpath,
-                "You have to be signed in to create a list. Please log in and try again.",
-            )
+        return web.seeother(f'{get_current_user().key}/lists/add{web.ctx.query}')
 
 
 class lists_add(delegate.page):

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -363,7 +363,7 @@ class lists_add_account(delegate.page):
             return render_template(
                 "permission_denied",
                 web.ctx.fullpath,
-                f"Permission denied to edit {user.user_key}.",
+                "Permission denied to create a user list. Please log in and try again.",
             )
 
 

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -354,11 +354,14 @@ class lists_edit(delegate.page):
 
 
 class lists_add_account(delegate.page):
-    path = r"/account/lists/add(.*)"
+    path = r"/account/lists/add.*"
 
-    def GET(self, extension: str | None):
+    def GET(self):
         if user := get_current_user():
-            return web.seeother(f'{user.key}/lists/add{extension}')
+            i = web.input(name=None)
+            return web.seeother(
+                f'{user.key}/lists/add{ '?seeds=' + i.seeds if i.seeds else ""}'
+            )
         else:
             return render_template(
                 "permission_denied",

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -353,6 +353,20 @@ class lists_edit(delegate.page):
             return safe_seeother(list_record.key)
 
 
+class lists_add_account(delegate.page):
+    path = r"/account/lists/add(.*)"
+
+    def GET(self, extension: str | None):
+        if user := get_current_user():
+            return web.seeother(f'{user.key}/lists/add{extension}')
+        else:
+            return render_template(
+                "permission_denied",
+                web.ctx.fullpath,
+                f"Permission denied to edit {user.user_key}.",
+            )
+
+
 class lists_add(delegate.page):
     path = r"(/people/[^/]+)?/lists/add"
 

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -363,7 +363,7 @@ class lists_add_account(delegate.page):
             return render_template(
                 "permission_denied",
                 web.ctx.fullpath,
-                "Permission denied to create a user list. Please log in and try again.",
+                "You have to be signed in to create a list. Please log in and try again.",
             )
 
 

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -360,7 +360,7 @@ class lists_add_account(delegate.page):
         if user := get_current_user():
             i = web.input(name=None)
             return web.seeother(
-                f'{user.key}/lists/add{ '?seeds=' + i.seeds if i.seeds else ""}'
+                f'{user.key}/lists/add{ "?seeds=" + i.seeds if i.seeds else ""}'
             )
         else:
             return render_template(


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9667

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Currently, there's no endpoint to allow a logged-in user to add a new list without pattern-checking for their name. This poses a problem in the new Bulk Search feature, as it has to build the list in Vue, and getting access to the `web.ctx.site` variable (where that information is stored) is a non-trivial task in javascript. This PR sidesteps the problem, by creating a new endpoint in python to automatically redirect to the list creation endpoint for the currently logged in user. 

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
To test, perform a bulksearch and create a list. With the current structure of how the Bulk Search component works, it'll always try to link to the main Open Library page. This will be fixed in a future PR, but for now, just edit the `openlibrary.org` portion of the URL to `localhost:8080`, or whatever you need for this particular test.
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/user-attachments/assets/7b1f108d-e8de-46c6-b548-f5236bba8870)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
