### PR TITLE
Add Arabic translation

### DIFF
--- a/openlibrary/i18n/ar/messages.po
+++ b/openlibrary/i18n/ar/messages.po
@@ -256,12 +256,12 @@ msgid ""
 "Please enter your <a href=\"https://archive.org\">Internet Archive</a> "
 "email and password to access your Open Library account."
 msgstr ""
-"يرجى إدخال بريدك الإلكتروني وكلمة المرور الخاصة بـ <a href=\"https://archive.org\">أرشيف الإنترنت</a> للوصول إلى حسابك في المكتبة المفتوحة."
+"يرجى إدخال بريدك الإلكتروني وكلمة المرور الخاصة بـ <a href=\"https://archive.org\">أرشيف الإنترنت</a> للوصول إلى حسابك في المكتبة الحرة."
 
 #: account/create.html login.html
 #, python-format
 msgid "You are already logged into Open Library as %(user)s."
-msgstr "أنت بالفعل مسجل الدخول إلى المكتبة المفتوحة كـ %(user)s."
+msgstr "أنت بالفعل مسجل الدخول إلى المكتبة الحرة كـ %(user)s."
 
 #: account/create.html login.html
 msgid ""
@@ -269,7 +269,7 @@ msgid ""
 "need to <a href=\"javascript:;\" onclick=\"document.forms['hamburger-"
 "logout'].submit()\">log out</a> and start the signup process afresh."
 msgstr ""
-"إذا كنت ترغب في إنشاء حساب جديد في المكتبة المفتوحة، ستحتاج إلى <a "
+"إذا كنت ترغب في إنشاء حساب جديد في المكتبة الحرة، ستحتاج إلى <a "
 "href=\"javascript:;\" onclick=\"document.forms['hamburger-logout'].submit()\">تسجيل الخروج</a> وبدء عملية التسجيل من جديد."
 
 #: login.html
@@ -310,7 +310,7 @@ msgstr "نسيت كلمة المرور؟"
 #: login.html
 msgid "Not a member of Open Library? <a href=\"/account/create\">Sign up now</a>."
 msgstr ""
-"لست عضوًا في المكتبة المفتوحة؟ <a href=\"/account/create\">سجل الآن</a>."
+"لست عضوًا في المكتبة الحرة؟ <a href=\"/account/create\">سجل الآن</a>."
 
 #: messages.html
 msgid "Created new author record."
@@ -605,7 +605,7 @@ msgid ""
 " our books, please provide the title/author or Open Library ID."
 msgstr ""
 "إذا صادفت رسالة خطأ، يرجى تضمينها. بالنسبة للأسئلة حول كتبنا، يرجى "
-"تقديم العنوان/المؤلف أو معرف المكتبة المفتوحة."
+"تقديم العنوان/المؤلف أو معرف المكتبة الحرة."
 
 #: support.html
 msgid "Send"
@@ -722,7 +722,7 @@ msgstr "الانضمام إلى قائمة الانتظار"
 #: widget.html
 #, python-format
 msgid "Learn more about \"%(title)s\" at OpenLibrary"
-msgstr "تعلم المزيد عن \"%(title)s\" في المكتبة المفتوحة"
+msgstr "تعلم المزيد عن \"%(title)s\" في المكتبة الحرة"
 
 #: widget.html
 msgid "Learn More"
@@ -731,7 +731,7 @@ msgstr "تعلم المزيد"
 #: widget.html
 #, python-format
 msgid "on <a target=\"_blank\" href=\"%(link)s\">openlibrary.org</a>"
-msgstr "على <a target=\"_blank\" href=\"%(link)s\">المكتبة المفتوحة</a>"
+msgstr "على <a target=\"_blank\" href=\"%(link)s\">المكتبة الحرة</a>"
 
 #: work_search.html
 msgid "Search Books"
@@ -844,7 +844,7 @@ msgstr "ابحث عن كتب تحتوي على العبارة \"%s\"؟"
 
 #: work_search.html
 msgid "Add a new book to Open Library?"
-msgstr "هل تريد إضافة كتاب جديد إلى المكتبة المفتوحة؟"
+msgstr "هل تريد إضافة كتاب جديد إلى المكتبة الحرة؟"
 
 #: account/reading_log.html search/authors.html search/subjects.html
 #: work_search.html
@@ -902,7 +902,7 @@ msgstr "أقل"
 # | msgid "Sign Up to Open Library"
 #: about/index.html
 msgid "The Open Library Team"
-msgstr "فريق المكتبة المفتوحة"
+msgstr "فريق المكتبة الحرة"
 
 #: account/create.html forms.py
 msgid "Must be between 3 and 20 characters"
@@ -910,7 +910,7 @@ msgstr "يجب أن يكون بين 3 و20 حرفًا"
 
 #: account/create.html
 msgid "Sign Up to Open Library"
-msgstr "سجل في المكتبة المفتوحة"
+msgstr "سجل في المكتبة الحرة"
 
 #: account/create.html lib/header_dropdown.html lib/nav_head.html
 msgid "Sign Up"
@@ -1299,7 +1299,7 @@ msgstr "لم يتم العثور على ملاحظات."
 
 #: account/notifications.html
 msgid "Notifications from Open Library"
-msgstr "إشعارات من المكتبة المفتوحة"
+msgstr "إشعارات من المكتبة الحرة"
 
 #: account/notifications.html
 msgid "Notifications"
@@ -1316,7 +1316,7 @@ msgstr ""
 
 #: account/notifications.html
 msgid "Would you like to receive very occasional emails from Open Library?"
-msgstr "هل ترغب في تلقي رسائل بريد إلكتروني نادرة من المكتبة المفتوحة؟"
+msgstr "هل ترغب في تلقي رسائل بريد إلكتروني نادرة من المكتبة الحرة؟"
 
 #: account/notifications.html
 msgid "No, thank you"
@@ -1350,7 +1350,7 @@ msgstr "لم يتم العثور على ملاحظات."
 
 #: account/privacy.html
 msgid "Your Privacy on Open Library"
-msgstr "خصوصيتك في المكتبة المفتوحة"
+msgstr "خصوصيتك في المكتبة الحرة"
 
 #: account/privacy.html
 msgid "Privacy & Content Moderation Settings"
@@ -1401,7 +1401,7 @@ msgid ""
 "OpenLibrary.org and tell the world what you're reading."
 msgstr ""
 "%(username)s يقرأ حاليًا %(total)d كتب. انضم إلى %(username)s على "
-"المكتبة المفتوحة وشارك العالم بما تقرأه."
+"المكتبة الحرة وشارك العالم بما تقرأه."
 
 #: account/reading_log.html
 #, python-format
@@ -1415,7 +1415,7 @@ msgid ""
 "OpenLibrary.org and share the books that you'll soon be reading!"
 msgstr ""
 "%(username)s يرغب في قراءة %(total)d كتب. انضم إلى %(username)s على "
-"المكتبة المفتوحة وشارك الكتب التي ستقرأها قريبًا!"
+"المكتبة الحرة وشارك الكتب التي ستقرأها قريبًا!"
 
 #: account/reading_log.html
 #, python-format
@@ -1429,7 +1429,7 @@ msgid ""
 "OpenLibrary.org and tell the world about the books that you care about."
 msgstr ""
 "%(username)s قرأ %(total)d كتب في %(year)d. انضم إلى %(username)s على "
-"المكتبة المفتوحة وشارك العالم بالكتب التي تهمك."
+"المكتبة الحرة وشارك العالم بالكتب التي تهمك."
 
 #: account/reading_log.html
 #, python-format
@@ -1443,7 +1443,7 @@ msgid ""
 "OpenLibrary.org and tell the world about the books that you care about."
 msgstr ""
 "%(username)s قرأ %(total)d كتب. انضم إلى %(username)s على "
-"المكتبة المفتوحة  وشارك العالم بالكتب التي تهمك."
+"المكتبة الحرة  وشارك العالم بالكتب التي تهمك."
 
 #: account/reading_log.html
 #, python-format
@@ -1484,7 +1484,7 @@ msgstr "لم يتم العثور على نتائج في هذا الرف"
 #: account/reading_log.html
 #, python-format
 msgid "Search all of Open Library for \"%s\"?"
-msgstr "ابحث في المكتبة المفتوحة عن \"%s\"؟"
+msgstr "ابحث في المكتبة الحرة عن \"%s\"؟"
 
 #: account/reading_log.html
 msgid "You haven't marked any books as read for this year."
@@ -1695,7 +1695,7 @@ msgid ""
 "Please enter your Open Library email and password, and we’ll retrieve "
 "your Archive.org email."
 msgstr ""
-"يرجى إدخال بريدك الإلكتروني في المكتبة المفتوحة وكلمة المرور، وسنسترجع بريدك الإلكتروني في موقع أرشيف الإنترنت."
+"يرجى إدخال بريدك الإلكتروني في المكتبة الحرة وكلمة المرور، وسنسترجع بريدك الإلكتروني في موقع أرشيف الإنترنت."
 
 #: account/email/forgot-ia.html
 msgid "Your email is:"
@@ -1707,7 +1707,7 @@ msgstr "العودة إلى تسجيل الدخول؟"
 
 #: account/email/forgot-ia.html
 msgid "Open Library Email"
-msgstr "بريد المكتبة المفتوحة الإلكتروني"
+msgstr "بريد المكتبة الحرة الإلكتروني"
 
 #: account/email/forgot-ia.html
 msgid "Retrieve Archive.org Email"
@@ -1719,7 +1719,7 @@ msgstr "نسيت كلمة مرور أرشيف الإنترنت؟"
 
 #: account/email/forgot.html
 msgid "Forgot Your Open Library Email?"
-msgstr "هل نسيت بريدك الإلكتروني في المكتبة المفتوحة؟"
+msgstr "هل نسيت بريدك الإلكتروني في المكتبة الحرة؟"
 
 #: account/password/forgot.html account/password/sent.html
 msgid "Username/Password Reminder"
@@ -2538,7 +2538,7 @@ msgstr "يرجى إدخال قيمة للمعرّف المحدد"
 
 #: books/add.html
 msgid "Add a book to Open Library"
-msgstr "أضف كتابًا إلى المكتبة المفتوحة"
+msgstr "أضف كتابًا إلى المكتبة الحرة"
 
 #: books/add.html tag/add.html
 msgid ""
@@ -2743,7 +2743,7 @@ msgid ""
 "using a key issued by the <a href=\"http://www.loc.gov/nls/\">Library of "
 "Congress NLS program</a>."
 msgstr ""
-"توجد نوعان من DAISYs في المكتبة المفتوحة: <i>مفتوح</i> و"
+"توجد نوعان من DAISYs في المكتبة الحرة: <i>مفتوح</i> و"
 "<i>محمي</i>. يمكن قراءة DAISYs المفتوحة من قبل أي شخص في العالم على العديد من "
 "الأجهزة المختلفة. DAISYs المحمية مثل هذه يمكن فتحها فقط باستخدام مفتاح صادر من <a href=\"http://www.loc.gov/nls/\">برنامج مكتبة الكونغرس NLS</a>."
 
@@ -2755,7 +2755,7 @@ msgid ""
 " by the <a href=\"http://www.loc.gov/nls/\">Library of Congress NLS "
 "program</a>."
 msgstr ""
-"توجد نوعان من DAISYs في المكتبة المفتوحة: <i>مفتوح</i> و"
+"توجد نوعان من DAISYs في المكتبة الحرة: <i>مفتوح</i> و"
 "<i>محمي</i>. يمكن قراءة DAISYs المفتوحة من قبل أي شخص في العالم على العديد من "
 "الأجهزة المختلفة. DAISYs المحمية يمكن فتحها فقط باستخدام مفتاح صادر من <a href=\"http://www.loc.gov/nls/\">برنامج مكتبة الكونغرس NLS</a>."
 
@@ -2804,7 +2804,7 @@ msgstr "هل أنت مؤهل للتسجيل؟"
 
 #: books/daisy.html
 msgid "How do I find DAISYs on Open Library?"
-msgstr "كيف أجد كتب DAISY على المكتبة المفتوحة؟"
+msgstr "كيف أجد كتب DAISY على المكتبة الحرة؟"
 
 #: books/daisy.html
 msgid ""
@@ -2815,7 +2815,7 @@ msgid ""
 " to those with a Library of Congress NLS key. These titles are brought to"
 " you by the<a href=\"//archive.org/\"> Internet Archive</a>."
 msgstr ""
-"بالإضافة إلى <a href=\"/subjects/accessible_book\" title=\"Subject: Accessible book\">الكثير من DAISYs المفتوحة</a>، تسرد المكتبة المفتوحة مجموعة أصغر من <a href=\"/subjects/protected_DAISY\" title=\"Subject: Protected DAISY\">عناوين DAISY المحمية</a> المتاحة لأولئك الذين لديهم مفتاح مكتبة الكونغرس NLS. هذه العناوين مقدمة لك من <a href=\"//archive.org/\">أرشيف الإنترنت</a>."
+"بالإضافة إلى <a href=\"/subjects/accessible_book\" title=\"Subject: Accessible book\">الكثير من DAISYs المفتوحة</a>، تسرد المكتبة الحرة مجموعة أصغر من <a href=\"/subjects/protected_DAISY\" title=\"Subject: Protected DAISY\">عناوين DAISY المحمية</a> المتاحة لأولئك الذين لديهم مفتاح مكتبة الكونغرس NLS. هذه العناوين مقدمة لك من <a href=\"//archive.org/\">أرشيف الإنترنت</a>."
 
 #: books/daisy.html
 msgid ""
@@ -2831,7 +2831,7 @@ msgstr "تحتاج إلى مساعدة؟"
 msgid ""
 " Please read our <a href=\"/help/faq\">FAQ on accessing books through "
 "Open Library</a>."
-msgstr "يرجى قراءة <a href=\"/help/faq\">الأسئلة الشائعة حول الوصول إلى الكتب عبر المكتبة المفتوحة</a>."
+msgstr "يرجى قراءة <a href=\"/help/faq\">الأسئلة الشائعة حول الوصول إلى الكتب عبر المكتبة الحرة</a>."
 
 #: books/edit.html
 msgid "Add a little more?"
@@ -2886,7 +2886,7 @@ msgid ""
 "Library ID (like <a href=\"/authors/OL23919A\" "
 "target=\"_blank\"><em>OL23919A</em></a>)."
 msgstr ""
-"يمكنك البحث حسب اسم المؤلف (مثل <em>j k rowling</em>) أو بواسطة معرف المكتبة المفتوحة (مثل <a href=\"/authors/OL23919A\" target=\"_blank\"><em>OL23919A</em></a>)."
+"يمكنك البحث حسب اسم المؤلف (مثل <em>j k rowling</em>) أو بواسطة معرف المكتبة الحرة (مثل <a href=\"/authors/OL23919A\" target=\"_blank\"><em>OL23919A</em></a>)."
 
 #: books/edit.html
 msgid "Author editing requires javascript"
@@ -3222,7 +3222,7 @@ msgstr ""
 
 #: books/edit/edition.html
 msgid "You can search by title or by Open Library ID (like"
-msgstr "يمكنك البحث حسب العنوان أو بواسطة معرف المكتبة المفتوحة (مثل"
+msgstr "يمكنك البحث حسب العنوان أو بواسطة معرف المكتبة الحرة (مثل"
 
 #: books/edit/edition.html
 msgid "WARNING: Any edits made to the work from this page will be ignored."
@@ -3480,7 +3480,7 @@ msgid ""
 "Please connect Open Library records to <u>good</u><span "
 "class=\"orange\">*</span> online resources."
 msgstr ""
-"يرجى ربط سجلات المكتبة المفتوحة بمصادر <u>جيدة</u><span "
+"يرجى ربط سجلات المكتبة الحرة بمصادر <u>جيدة</u><span "
 "class=\"orange\">*</span> على الإنترنت."
 
 #: books/edit/web.html
@@ -3650,7 +3650,7 @@ msgstr "يرجى اختيار صورة أو تقديم عنوان URL."
 
 #: covers/add.html
 msgid "There are two ways to put an author's image on Open Library"
-msgstr "هناك طريقتان لوضع صورة المؤلف على المكتبة المفتوحة"
+msgstr "هناك طريقتان لوضع صورة المؤلف على المكتبة الحرة"
 
 #: covers/add.html
 msgid "Image Guidelines"
@@ -3658,7 +3658,7 @@ msgstr "إرشادات الصورة"
 
 #: covers/add.html
 msgid "There are two ways to put a cover image on Open Library"
-msgstr "هناك طريقتان لوضع صورة الغلاف على المكتبة المفتوحة"
+msgstr "هناك طريقتان لوضع صورة الغلاف على المكتبة الحرة"
 
 #: covers/add.html
 msgid "Cover Guidelines"
@@ -3814,7 +3814,7 @@ msgid ""
 "Open Library is an open, editable library catalog, building towards a web"
 " page for every book ever published."
 msgstr ""
-"المكتبة المفتوحة هي كتالوج مكتبة مفتوح وقابل للتعديل، يهدف إلى إنشاء صفحة ويب"
+"المكتبة الحرة هي كتالوج مكتبة مفتوح وقابل للتعديل، يهدف إلى إنشاء صفحة ويب"
 " لكل كتاب تم نشره."
 
 #: AffiliateLinks.html home/about.html
@@ -3855,7 +3855,7 @@ msgstr[1] "%(count)s كتب"
 
 #: home/index.html home/welcome.html
 msgid "Welcome to Open Library"
-msgstr "مرحبًا بكم في المكتبة المفتوحة"
+msgstr "مرحبًا بكم في المكتبة الحرة"
 
 #: home/index.html
 msgid "Classic Books"
@@ -3895,7 +3895,7 @@ msgstr ""
 
 #: home/stats.html
 msgid "See all visitors to OpenLibrary.org"
-msgstr "عرض جميع زوار المكتبة المفتوحة"
+msgstr "عرض جميع زوار المكتبة الحرة"
 
 #: home/stats.html
 msgid "Area graph of recent unique visitors"
@@ -3903,7 +3903,7 @@ msgstr "مخطط المنطقة للزوار الفريدين الحديثين"
 
 #: home/stats.html
 msgid "How many new Open Library members have we welcomed?"
-msgstr "كم عدد أعضاء المكتبة المفتوحة الجدد الذين رحبنا بهم؟"
+msgstr "كم عدد أعضاء المكتبة الحرة الجدد الذين رحبنا بهم؟"
 
 #: home/stats.html
 
@@ -3997,7 +3997,7 @@ msgstr "عشرات الطرق التي يمكنك من خلالها المساع
 
 #: home/welcome.html
 msgid "Volunteer at Open Library"
-msgstr "تطوع في المكتبة المفتوحة"
+msgstr "تطوع في المكتبة الحرة"
 
 #: home/welcome.html
 msgid "Discover opportunities to improve the library"
@@ -4288,7 +4288,7 @@ msgstr "تطوير"
 
 #: lib/nav_foot.html
 msgid "Explore Open Library Developer Center"
-msgstr "استكشف مركز مطوري المكتبة المفتوحة"
+msgstr "استكشف مركز مطوري المكتبة الحرة"
 
 #: lib/nav_foot.html lib/nav_head.html
 msgid "Developer Center"
@@ -4340,7 +4340,7 @@ msgstr "اقتراح تعديلات"
 
 #: lib/nav_foot.html
 msgid "Add a new book to Open Library"
-msgstr "إضافة كتاب جديد إلى المكتبة المفتوحة"
+msgstr "إضافة كتاب جديد إلى المكتبة الحرة"
 
 #: lib/nav_foot.html
 msgid "Release Notes"
@@ -4360,7 +4360,7 @@ msgstr "تغيير لغة الموقع"
 
 #: lib/nav_foot.html lib/nav_head.html type/list/embed.html
 msgid "Open Library logo"
-msgstr "شعار المكتبة المفتوحة"
+msgstr "شعار المكتبة الحرة"
 
 #: lib/nav_foot.html
 msgid ""
@@ -4372,7 +4372,7 @@ msgid ""
 "href=\"//archive.org/\">archive.org</a> and <a href=\"//archive-it.org"
 "\">archive-it.org</a>"
 msgstr ""
-"المكتبة المفتوحة هي مبادرة من <a href=\"//archive.org/\">أرشيف الإنترنت</a>، "
+"المكتبة الحرة هي مبادرة من <a href=\"//archive.org/\">أرشيف الإنترنت</a>، "
 "منظمة غير ربحية 501(c)(3)، تبني مكتبة رقمية لمواقع الإنترنت والأشياء الثقافية الأخرى "
 "بشكل رقمي. تشمل المشاريع الأخرى <a href=\"//archive.org/projects/\">المشاريع</a> مثل "
 "<a href=\"//archive.org/web/\">آلة الزمن</a>، <a href=\"//archive.org/\">archive.org</a> و"
@@ -5402,7 +5402,7 @@ msgstr "أضف علامة"
 
 #: tag/add.html
 msgid "Add a tag to Open Library"
-msgstr "أضف علامة إلى المكتبة المفتوحة"
+msgstr "أضف علامة إلى المكتبة الحرة"
 
 #: tag/add.html
 msgid "Name of Tag"
@@ -5524,7 +5524,7 @@ msgstr "الاسم مفقود"
 #: type/author/view.html type/edition/view.html type/work/view.html
 #, python-format
 msgid "%(page_title)s | Open Library"
-msgstr "%(page_title)s | المكتبة المفتوحة"
+msgstr "%(page_title)s | المكتبة الحرة"
 
 #: type/author/view.html
 #, python-format
@@ -5598,7 +5598,7 @@ msgstr "OLID"
 
 #: type/author/view.html
 msgid "Links <span class=\"gray small sansserif\">(outside Open Library)"
-msgstr "روابط <span class=\"gray small sansserif\">(خارج المكتبة المفتوحة)</span>"
+msgstr "روابط <span class=\"gray small sansserif\">(خارج المكتبة الحرة)</span>"
 
 #: type/author/view.html
 msgid "No links yet."
@@ -5796,7 +5796,7 @@ msgstr "أضيف بشكل مجهول."
 
 #: type/edition/view.html type/work/view.html
 msgid "Links <span class=\"gray small sansserif\">outside Open Library</span>"
-msgstr "روابط <span class=\"gray small sansserif\">خارج المكتبة المفتوحة</span>"
+msgstr "روابط <span class=\"gray small sansserif\">خارج المكتبة الحرة</span>"
 
 #: type/edition/view.html type/work/view.html
 msgid "Wikipedia"
@@ -5860,7 +5860,7 @@ msgstr "إضافة كتاب آخر"
 # | msgid "Sign Up to Open Library"
 #: type/list/embed.html
 msgid "Visit Open Library"
-msgstr "زيارة المكتبة المفتوحة"
+msgstr "زيارة المكتبة الحرة"
 
 # | msgid "Explore authors"
 #: type/list/embed.html type/list/view_body.html
@@ -5940,7 +5940,7 @@ msgstr ""
 #: type/list/view_body.html
 #, python-format
 msgid "%(name)s | Lists | Open Library"
-msgstr "%(name)s | القوائم | المكتبة المفتوحة"
+msgstr "%(name)s | القوائم | المكتبة الحرة"
 
 #: type/list/view_body.html
 #, python-format
@@ -5949,7 +5949,7 @@ msgstr "%(title)s: %(description)s"
 
 #: type/list/view_body.html
 msgid "View the list on Open Library."
-msgstr "عرض القائمة على المكتبة المفتوحة."
+msgstr "عرض القائمة على المكتبة الحرة."
 
 #: type/list/view_body.html
 msgid "Remove this item?"
@@ -6307,7 +6307,7 @@ msgid ""
 "href=\"https://archive.org/about\">Internet Archive</a>, a 501(c)(3) non-"
 "profit"
 msgstr ""
-"المكتبة المفتوحة هي مشروع تابع لـ <a href=\"https://archive.org/about\">أرشيف الإنترنت</a>، وهو منظمة غير ربحية 501(c)(3)"
+"المكتبة الحرة هي مشروع تابع لـ <a href=\"https://archive.org/about\">أرشيف الإنترنت</a>، وهو منظمة غير ربحية 501(c)(3)"
 
 #: EditionNavBar.html
 msgid "Overview"
@@ -6586,7 +6586,7 @@ msgstr "مرحبا"
 
 #: Subnavigation.html
 msgid "Searching Open Library"
-msgstr "البحث في المكتبة المفتوحة"
+msgstr "البحث في المكتبة الحرة"
 
 #: Subnavigation.html
 msgid "Reading Books"
@@ -6602,7 +6602,7 @@ msgstr "استخدام المواضيع"
 
 #: Subnavigation.html
 msgid "Open Library F.A.Q."
-msgstr "الأسئلة الشائعة حول المكتبة المفتوحة"
+msgstr "الأسئلة الشائعة حول المكتبة الحرة"
 
 #: TableOfContents.html
 #, python-format
@@ -6625,7 +6625,7 @@ msgid ""
 "this for an existing page will alter its presentation and the data fields"
 " available for editing its content."
 msgstr ""
-"كل جزء من المكتبة المفتوحة يتم تعريفه بنوع المحتوى الذي يعرضه، عادةً عبر تعريف المحتوى (مثل: المؤلفين، الإصدارات، الأعمال)، ولكن في بعض الأحيان عبر استخدام المحتوى (مثل: الماكرو، القوالب، النصوص الخام). تغيير هذا في صفحة موجودة سيؤثر على عرضها والحقول المتاحة لتعديل محتواها."
+"كل جزء من المكتبة الحرة يتم تعريفه بنوع المحتوى الذي يعرضه، عادةً عبر تعريف المحتوى (مثل: المؤلفين، الإصدارات، الأعمال)، ولكن في بعض الأحيان عبر استخدام المحتوى (مثل: الماكرو، القوالب، النصوص الخام). تغيير هذا في صفحة موجودة سيؤثر على عرضها والحقول المتاحة لتعديل محتواها."
 
 #: TypeChanger.html
 msgid "Please use caution changing Page Type!"
@@ -6714,7 +6714,7 @@ msgstr "كلمة مرور خاطئة. يرجى المحاولة مرة أخرى"
 
 #: account.py
 msgid "Please verify your Open Library account before logging in"
-msgstr "يرجى التحقق من حسابك في المكتبة المفتوحة قبل تسجيل الدخول"
+msgstr "يرجى التحقق من حسابك في المكتبة الحرة قبل تسجيل الدخول"
 
 #: account.py
 msgid "Please verify your Internet Archive account before logging in"
@@ -6869,7 +6869,7 @@ msgid ""
 "href=\"https://archive.org/\">Internet Archive</a>, the non-profit that "
 "runs Open Library."
 msgstr ""
-"أرغب في تلقي الأخبار والإعلانات والموارد من <a href=\"https://archive.org/\">أرشيف الإنترنت</a>، وهي منظمة غير ربحية تدير المكتبة المفتوحة."
+"أرغب في تلقي الأخبار والإعلانات والموارد من <a href=\"https://archive.org/\">أرشيف الإنترنت</a>، وهي منظمة غير ربحية تدير المكتبة الحرة."
 
 #: forms.py
 msgid "Invalid password"

--- a/openlibrary/i18n/ar/messages.po
+++ b/openlibrary/i18n/ar/messages.po
@@ -1551,7 +1551,6 @@ msgid "Works by Author Country of Birth"
 msgstr "أعمال حسب بلد ميلاد المؤلفين"
 
 #: account/readinglog_stats.html
-#, fuzzy
 msgid ""
 "Demographic statistics powered by <a "
 "href=\"https://www.wikidata.org/\">Wikidata</a>. Here's a <a id=\"wd-"
@@ -1561,7 +1560,7 @@ msgid ""
 "purpose\">these instructions</a>."
 msgstr ""
 "الإحصاءات السكانية مدعومة من <a "
-"href=\"https://www.wikidata.org/\">Wikidata</a>. إليك <a id=\"wd-query-sample\" href=\"\">عينة</a> من الاستعلام المستخدم. <br />حسن هذه الإحصاءات بإضافة معرّف مؤلف Wikidata باتباع <a "
+"href=\"https://www.wikidata.org/\">ويكي بيانات</a>. إليك <a id=\"wd-query-sample\" href=\"\">عينة</a> من الاستعلام المستخدم. <br />حسن هذه الإحصاءات بإضافة معرّف مؤلف ويكي بيانات واتباع <a "
 "href=\"https://openlibrary.org/help/faq/editing.en#author-identifiers-purpose\">هذه التعليمات</a>."
 
 #: account/readinglog_stats.html
@@ -2679,7 +2678,6 @@ msgstr ""
 "لا شيء من هذه النتائج يتطابق مع الكتاب الذي أريد إضافته."
 
 #: books/check.html
-#, fuzzy
 msgid "Continue"
 msgstr "مواصلة"
 
@@ -2717,7 +2715,6 @@ msgstr ""
 "يمكن فتحها فقط على جهاز متخصص باستخدام مفتاح صادر عن مكتبة الكونغرس."
 
 #: books/daisy.html
-#, fuzzy, python-format
 msgid ""
 "<a href=\"%(daisy_url)s\"><strong>Download the DAISY.zip</strong></a> for"
 " <a href=\"%(url)s\">%(title)s</a>"
@@ -2739,7 +2736,6 @@ msgstr ""
 " مجانًا بصيغة DAISY، المصممة لأولئك منا الذين يجدون صعوبة في استخدام وسائل الطباعة التقليدية."
 
 #: books/daisy.html
-#, fuzzy, python-format
 msgid ""
 "There are two types of DAISYs on Open Library: <i>open</i> and "
 "<i>protected</i>. Open DAIS Ys can be read by anyone in the world on many "
@@ -2752,7 +2748,6 @@ msgstr ""
 "الأجهزة المختلفة. DAISYs المحمية مثل هذه يمكن فتحها فقط باستخدام مفتاح صادر من <a href=\"http://www.loc.gov/nls/\">برنامج مكتبة الكونغرس NLS</a>."
 
 #: books/daisy.html
-#, fuzzy, python-format
 msgid ""
 "There are two types of DAISYs on Open Library: <i>open</i> and "
 "<i>protected</i>. Open DAISYs can be read by anyone in the world on many "
@@ -2991,7 +2986,6 @@ msgid "Please separate with commas."
 msgstr "يرجى الفصل بفواصل."
 
 #: books/edit/about.html
-#, fuzzy
 msgid ""
 "For example: <i><a href=\"/subjects/cheese\">cheese</a>, <a "
 "href=\"/subjects/roman_empire\">Roman Empire</a>, <a "
@@ -3006,7 +3000,6 @@ msgid "A person? Or, people?"
 msgstr "شخص؟ أو أشخاص؟"
 
 #: books/edit/about.html
-#, fuzzy
 msgid ""
 "For example: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore "
 "Roosevelt</a>, <a href=\"/subjects/person:Julian_of_Norwich\">Julian of "
@@ -3021,14 +3014,13 @@ msgid "Note any places mentioned?"
 msgstr "هل تم ذكر أي أماكن؟"
 
 #: books/edit/about.html
-#, fuzzy
 msgid ""
 "For example: <i><a href=\"/subjects/place:London\">London</a>, <a "
 "href=\"/subjects/place:Atlantis\">Atlantis</a>, <a "
 "href=\"/subjects/place:Omaha\">Omaha</a></i>"
 msgstr ""
 "على سبيل المثال: <i><a href=\"/subjects/place:London\">لندن</a>, <a "
-"href=\"/subjects/place:Atlantis\">أتلانتس</a>, <a "
+"href=\"/subjects/place:Atlantis\">أطلانتس</a>, <a "
 "href=\"/subjects/place:Omaha\">أوماها</a></i>"
 
 #: books/edit/about.html
@@ -3036,7 +3028,6 @@ msgid "When is it set or about?"
 msgstr "متى تدور أحداثه أو عن ماذا؟"
 
 #: books/edit/about.html
-#, fuzzy
 msgid ""
 "For example: <i><a href=\"/subjects/time:1984\">1984</a>, <a "
 "href=\"/subjects/time:the_middle_ages\">The Middle Ages</a>, <a "
@@ -6241,12 +6232,11 @@ msgid "Preview Book"
 msgstr "معاينة الكتاب"
 
 #: DonateModal.html
-#, fuzzy
 msgid ""
 "Donate this book to the <a href=\"https://archive.org\">Internet "
 "Archive</a> library."
 msgstr ""
-"تبرع بهذا الكتاب إلى مكتبة <a href=\"https://archive.org\">الأرشيف الإلكتروني</a>."
+"تبرع بهذا الكتاب إلى مكتبة <a href=\"https://archive.org\">أرشيف الإنترنت</a>."
 
 #: DonateModal.html
 msgid ""
@@ -6284,7 +6274,6 @@ msgstr ""
 "عند التبرع بكتاب مادي إلى الأرشيف الإلكتروني، سيستفيد كتابك من:"
 
 #: DonateModal.html
-#, fuzzy
 msgid "Donation info"
 msgstr "معلومات التبرع"
 
@@ -6752,7 +6741,6 @@ msgid "Login attempted with invalid Internet Archive s3 credentials."
 msgstr "تمت محاولة تسجيل الدخول ببيانات اعتماد غير صالحة لـ Internet Archive s3."
 
 #: account.py
-#, fuzzy
 msgid "A problem occurred and we were unable to log you in"
 msgstr "حدثت مشكلة ولم نتمكن من تسجيل دخولك."
 

--- a/openlibrary/i18n/ar/messages.po
+++ b/openlibrary/i18n/ar/messages.po
@@ -256,7 +256,7 @@ msgid ""
 "Please enter your <a href=\"https://archive.org\">Internet Archive</a> "
 "email and password to access your Open Library account."
 msgstr ""
-"يرجى إدخال بريدك الإلكتروني وكلمة المرور الخاصة بـ <a href=\"https://archive.org\">Internet Archive</a> للوصول إلى حسابك في المكتبة المفتوحة."
+"يرجى إدخال بريدك الإلكتروني وكلمة المرور الخاصة بـ <a href=\"https://archive.org\">أرشيف الإنترنت</a> للوصول إلى حسابك في المكتبة المفتوحة."
 
 #: account/create.html login.html
 #, python-format
@@ -293,7 +293,7 @@ msgstr "البريد الإلكتروني"
 
 #: login.html
 msgid "Forgot your Internet Archive email?"
-msgstr "نسيت بريدك الإلكتروني في Internet Archive؟"
+msgstr "نسيت بريدك الإلكتروني في أرشيف الإنترنت؟"
 
 #: account/email/forgot-ia.html forms.py login.html
 msgid "Password"
@@ -722,7 +722,7 @@ msgstr "الانضمام إلى قائمة الانتظار"
 #: widget.html
 #, python-format
 msgid "Learn more about \"%(title)s\" at OpenLibrary"
-msgstr "تعلم المزيد عن \"%(title)s\" في OpenLibrary"
+msgstr "تعلم المزيد عن \"%(title)s\" في المكتبة المفتوحة"
 
 #: widget.html
 msgid "Learn More"
@@ -731,7 +731,7 @@ msgstr "تعلم المزيد"
 #: widget.html
 #, python-format
 msgid "on <a target=\"_blank\" href=\"%(link)s\">openlibrary.org</a>"
-msgstr "على <a target=\"_blank\" href=\"%(link)s\">openlibrary.org</a>"
+msgstr "على <a target=\"_blank\" href=\"%(link)s\">المكتبة المفتوحة</a>"
 
 #: work_search.html
 msgid "Search Books"
@@ -1401,7 +1401,7 @@ msgid ""
 "OpenLibrary.org and tell the world what you're reading."
 msgstr ""
 "%(username)s يقرأ حاليًا %(total)d كتب. انضم إلى %(username)s على "
-"OpenLibrary.org وشارك العالم بما تقرأه."
+"المكتبة المفتوحة وشارك العالم بما تقرأه."
 
 #: account/reading_log.html
 #, python-format
@@ -1415,7 +1415,7 @@ msgid ""
 "OpenLibrary.org and share the books that you'll soon be reading!"
 msgstr ""
 "%(username)s يرغب في قراءة %(total)d كتب. انضم إلى %(username)s على "
-"OpenLibrary.org وشارك الكتب التي ستقرأها قريبًا!"
+"المكتبة المفتوحة وشارك الكتب التي ستقرأها قريبًا!"
 
 #: account/reading_log.html
 #, python-format
@@ -1429,7 +1429,7 @@ msgid ""
 "OpenLibrary.org and tell the world about the books that you care about."
 msgstr ""
 "%(username)s قرأ %(total)d كتب في %(year)d. انضم إلى %(username)s على "
-"OpenLibrary.org وشارك العالم بالكتب التي تهمك."
+"المكتبة المفتوحة وشارك العالم بالكتب التي تهمك."
 
 #: account/reading_log.html
 #, python-format
@@ -1443,7 +1443,7 @@ msgid ""
 "OpenLibrary.org and tell the world about the books that you care about."
 msgstr ""
 "%(username)s قرأ %(total)d كتب. انضم إلى %(username)s على "
-"OpenLibrary.org وشارك العالم بالكتب التي تهمك."
+"المكتبة المفتوحة  وشارك العالم بالكتب التي تهمك."
 
 #: account/reading_log.html
 #, python-format
@@ -1688,14 +1688,14 @@ msgstr "تحديد هدفي"
 
 #: account/email/forgot-ia.html account/email/forgot.html
 msgid "Forgot Your Internet Archive Email?"
-msgstr "هل نسيت بريدك الإلكتروني في الأرشيف الرقمي؟"
+msgstr "هل نسيت بريدك الإلكتروني في أرشيف الإنترنت؟"
 
 #: account/email/forgot-ia.html
 msgid ""
 "Please enter your Open Library email and password, and we’ll retrieve "
 "your Archive.org email."
 msgstr ""
-"يرجى إدخال بريدك الإلكتروني في المكتبة المفتوحة وكلمة المرور، وسنسترجع بريدك الإلكتروني في Archive.org."
+"يرجى إدخال بريدك الإلكتروني في المكتبة المفتوحة وكلمة المرور، وسنسترجع بريدك الإلكتروني في موقع أرشيف الإنترنت."
 
 #: account/email/forgot-ia.html
 msgid "Your email is:"
@@ -1707,19 +1707,19 @@ msgstr "العودة إلى تسجيل الدخول؟"
 
 #: account/email/forgot-ia.html
 msgid "Open Library Email"
-msgstr "بريد Open Library الإلكتروني"
+msgstr "بريد المكتبة المفتوحة الإلكتروني"
 
 #: account/email/forgot-ia.html
 msgid "Retrieve Archive.org Email"
-msgstr "استرجاع بريد Archive.org الإلكتروني"
+msgstr "استرجاع بريدك الإلكتروني في أرشيف الإنترنت"
 
 #: account/email/forgot-ia.html account/password/forgot.html
 msgid "Forgot your Archive.org Password?"
-msgstr "نسيت كلمة مرور Archive.org؟"
+msgstr "نسيت كلمة مرور أرشيف الإنترنت؟"
 
 #: account/email/forgot.html
 msgid "Forgot Your Open Library Email?"
-msgstr "هل نسيت بريدك الإلكتروني في Open Library؟"
+msgstr "هل نسيت بريدك الإلكتروني في المكتبة المفتوحة؟"
 
 #: account/password/forgot.html account/password/sent.html
 msgid "Username/Password Reminder"
@@ -2732,7 +2732,7 @@ msgid ""
 "distributing over 1 million books free in a format called DAISY, designed"
 " for those of us who find it challenging to use regular printed media. "
 msgstr ""
-"الأرشيف الرقمي <a href=\"//archive.org\">Internet Archive</a> فخور بتوزيع أكثر من مليون كتاب"
+"أرشيف الإنترنت  <a href=\"//archive.org\">Internet Archive</a> فخور بتوزيع أكثر من مليون كتاب"
 " مجانًا بصيغة DAISY، المصممة لأولئك منا الذين يجدون صعوبة في استخدام وسائل الطباعة التقليدية."
 
 #: books/daisy.html
@@ -2815,7 +2815,7 @@ msgid ""
 " to those with a Library of Congress NLS key. These titles are brought to"
 " you by the<a href=\"//archive.org/\"> Internet Archive</a>."
 msgstr ""
-"بالإضافة إلى <a href=\"/subjects/accessible_book\" title=\"Subject: Accessible book\">الكثير من DAISYs المفتوحة</a>، تسرد المكتبة المفتوحة مجموعة أصغر من <a href=\"/subjects/protected_DAISY\" title=\"Subject: Protected DAISY\">عناوين DAISY المحمية</a> المتاحة لأولئك الذين لديهم مفتاح مكتبة الكونغرس NLS. هذه العناوين مقدمة لك من <a href=\"//archive.org/\">الأرشيف الرقمي</a>."
+"بالإضافة إلى <a href=\"/subjects/accessible_book\" title=\"Subject: Accessible book\">الكثير من DAISYs المفتوحة</a>، تسرد المكتبة المفتوحة مجموعة أصغر من <a href=\"/subjects/protected_DAISY\" title=\"Subject: Protected DAISY\">عناوين DAISY المحمية</a> المتاحة لأولئك الذين لديهم مفتاح مكتبة الكونغرس NLS. هذه العناوين مقدمة لك من <a href=\"//archive.org/\">أرشيف الإنترنت</a>."
 
 #: books/daisy.html
 msgid ""
@@ -3895,7 +3895,7 @@ msgstr ""
 
 #: home/stats.html
 msgid "See all visitors to OpenLibrary.org"
-msgstr "عرض جميع زوار OpenLibrary.org"
+msgstr "عرض جميع زوار المكتبة المفتوحة"
 
 #: home/stats.html
 msgid "Area graph of recent unique visitors"
@@ -5643,12 +5643,12 @@ msgstr "إضافة إلى اختيارات الموظفين"
 
 #: type/edition/admin_bar.html
 msgid "Sync Archive.org ID"
-msgstr "مزامنة معرف Archive.org"
+msgstr "مزامنة معرف أرشيف الإنترنت "
 
 # | msgid "Full-Text Search on Archive.org"
 #: type/edition/admin_bar.html
 msgid "View Book on Archive.org"
-msgstr "عرض الكتاب على Archive.org"
+msgstr "عرض الكتاب على أرشيف الإنترنت"
 
 # | msgid "This Edition"
 #: SearchResultsWork.html type/edition/admin_bar.html
@@ -6209,8 +6209,8 @@ msgid ""
 "When you buy books using these links the Internet Archive may earn a <a "
 "class=\"nostyle\" href=\"/help/faq/about#selling\">small commission</a>."
 msgstr ""
-"عند شراء الكتب باستخدام هذه الروابط، قد يكسب الأرشيف الإلكتروني <a class=\"nostyle\" "
-"href=\"/help/faq/about#selling\">عمولة صغيرة</a>."
+"عند شراء الكتب باستخدام هذه الروابط، قد يكسب أرشيف الإنترنت <a class=\"nostyle\" "
+"href=\"/help/faq/about#selling\">عمولة بسيطة</a>."
 
 #: BookByline.html
 #, python-format
@@ -6271,7 +6271,7 @@ msgid ""
 "When you donate a physical book to the Internet Archive, your book will "
 "enjoy:"
 msgstr ""
-"عند التبرع بكتاب مادي إلى الأرشيف الإلكتروني، سيستفيد كتابك من:"
+"عند التبرع بكتاب مادي إلى أرشيف الإنترنت، سيستفيد كتابك من:"
 
 #: DonateModal.html
 msgid "Donation info"
@@ -6307,7 +6307,7 @@ msgid ""
 "href=\"https://archive.org/about\">Internet Archive</a>, a 501(c)(3) non-"
 "profit"
 msgstr ""
-"المكتبة المفتوحة هي مشروع تابع لـ <a href=\"https://archive.org/about\">الأرشيف الإلكتروني</a>، وهو منظمة غير ربحية 501(c)(3)"
+"المكتبة المفتوحة هي مشروع تابع لـ <a href=\"https://archive.org/about\">أرشيف الإنترنت</a>، وهو منظمة غير ربحية 501(c)(3)"
 
 #: EditionNavBar.html
 msgid "Overview"
@@ -6346,7 +6346,7 @@ msgstr "تابع"
 #: IABook.html
 #, python-format
 msgid "Borrowed from Internet Archive: %(title)s"
-msgstr "مستعار من الأرشيف الإلكتروني: %(title)s"
+msgstr "مستعار من أرشيف الإنترنت: %(title)s"
 
 #: LoadingIndicator.html
 msgid "Loading indicator"
@@ -6421,15 +6421,15 @@ msgid ""
 "Special ebook access from the Internet Archive for patrons with "
 "qualifying print disabilities"
 msgstr ""
-"وصول خاص للكتب الإلكترونية من الأرشيف الإلكتروني للأشخاص ذوي الإعاقات البصرية المؤهلة"
+"وصول خاص للكتب الإلكترونية من أرشيف الإنترنت للأشخاص ذوي الإعاقات البصرية المؤهلة"
 
 #: ReadButton.html
 msgid "Borrow ebook from Internet Archive"
-msgstr "استعارة كتاب إلكتروني من الأرشيف الإلكتروني"
+msgstr "استعارة كتاب إلكتروني من أرشيف الإنترنت"
 
 #: ReadButton.html
 msgid "Read ebook from Internet Archive"
-msgstr "قراءة كتاب إلكتروني من الأرشيف الإلكتروني"
+msgstr "قراءة كتاب إلكتروني من أرشيف الإنترنت"
 
 #: ReadMore.html
 msgid "Read more"
@@ -6718,7 +6718,7 @@ msgstr "يرجى التحقق من حسابك في المكتبة المفتوح
 
 #: account.py
 msgid "Please verify your Internet Archive account before logging in"
-msgstr "يرجى التحقق من حسابك في الأرشيف الإلكتروني قبل تسجيل الدخول"
+msgstr "يرجى التحقق من حسابك في أرشيف الإنترنت قبل تسجيل الدخول"
 
 #: account.py
 msgid "Please fill out all fields and try again"
@@ -6774,7 +6774,7 @@ msgstr "البريد الإلكتروني مسجل بالفعل"
 
 #: account.py
 msgid "An Internet Archive account already exists with this email"
-msgstr "يوجد بالفعل حساب في الأرشيف الإلكتروني بهذا البريد الإلكتروني"
+msgstr "يوجد بالفعل حساب في أرشيف الإنترنت بهذا البريد الإلكتروني"
 
 #: account.py
 msgid "Email address is already used."
@@ -6869,7 +6869,7 @@ msgid ""
 "href=\"https://archive.org/\">Internet Archive</a>, the non-profit that "
 "runs Open Library."
 msgstr ""
-"أرغب في تلقي الأخبار والإعلانات والموارد من <a href=\"https://archive.org/\">الأرشيف الإلكتروني</a>، وهي منظمة غير ربحية تدير المكتبة المفتوحة."
+"أرغب في تلقي الأخبار والإعلانات والموارد من <a href=\"https://archive.org/\">أرشيف الإنترنت</a>، وهي منظمة غير ربحية تدير المكتبة المفتوحة."
 
 #: forms.py
 msgid "Invalid password"

--- a/openlibrary/i18n/ar/messages.po
+++ b/openlibrary/i18n/ar/messages.po
@@ -1,0 +1,6890 @@
+# Arabic translations for Open Library.
+# Copyright (C) 2024 Internet Archive
+# This file is distributed under the same license as the Open Library
+# project.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Open Library VERSION\n"
+"Report-Msgid-Bugs-To: avidseeker7@protonmail.com\n"
+"POT-Creation-Date: 2024-08-01 18:00+0000\n"
+"PO-Revision-Date: 2024-08-01 08:00+0200\n"
+"Last-Translator: AvidSeeker <avidseeker7@protonmail.com>\n"
+"Language: ar\n"
+"Language-Team: Arabic\n"
+"Plural-Forms: nplurals=3; plural=(n > 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.12.1\n"
+
+#: account.html account/notifications.html account/privacy.html
+#: lib/nav_head.html type/user/view.html
+msgid "Settings"
+msgstr "الإعدادات"
+
+#: account.html
+msgid "Settings & Privacy"
+msgstr "الإعدادات والخصوصية"
+
+#: account.html databarDiff.html
+msgid "View"
+msgstr "عرض"
+
+#: account.html
+msgid "or"
+msgstr "أو"
+
+#: account.html check_ins/check_in_prompt.html
+#: check_ins/reading_goal_progress.html databarHistory.html
+#: databarTemplate.html databarView.html subjects.html
+#: type/edition/compact_title.html type/user/view.html
+msgid "Edit"
+msgstr "تعديل"
+
+#: account.html
+msgid "Your Profile Page"
+msgstr "صفحة ملفك الشخصي"
+
+#: account.html
+msgid "View or Edit your Reading Log"
+msgstr "عرض أو تعديل سجل قراءتك"
+
+#: account.html
+msgid "View or Edit your Lists"
+msgstr "عرض أو تعديل قوائمك"
+
+#: account.html
+msgid "Import and Export Options"
+msgstr "خيارات الاستيراد والتصدير"
+
+#: account.html
+msgid "Manage Privacy & Content Moderation Settings"
+msgstr "إدارة إعدادات الخصوصية والإشراف على المحتوى"
+
+#: account.html
+msgid "Manage Notifications Settings"
+msgstr "إدارة إعدادات الإشعارات"
+
+#: account.html
+msgid "Manage Mailing List Subscriptions"
+msgstr "إدارة اشتراكات قوائم البريد"
+
+#: account.html
+msgid "Change Password"
+msgstr "تغيير كلمة المرور"
+
+#: account.html
+msgid "Update Email Address"
+msgstr "تحديث عنوان البريد الإلكتروني"
+
+#: account.html
+msgid "Deactivate Account"
+msgstr "تعطيل الحساب"
+
+#: account.html
+msgid "Please contact us if you need help with anything else."
+msgstr "يرجى الاتصال بنا إذا كنت بحاجة إلى مساعدة في أي شيء آخر."
+
+#: barcodescanner.html
+msgid "Barcode Scanner (Beta)"
+msgstr "ماسح الباركود (تجريبي)"
+
+#: barcodescanner.html lib/nav_head.html
+msgid "Advanced"
+msgstr "متقدم"
+
+#: barcodescanner.html
+msgid "Read Text ISBN"
+msgstr "قراءة نص ISBN"
+
+#: barcodescanner.html
+msgid "For books that print the ISBN without a barcode"
+msgstr "للكتب التي تطبع الـ ISBN بدون باركود"
+
+#: barcodescanner.html
+msgid "Point your camera at a barcode! 📷"
+msgstr "وجه كاميرتك نحو الباركود! 📷"
+
+#: diff.html
+#, python-format
+msgid "Diff on %s"
+msgstr "التغييرات على %s"
+
+#: diff.html
+msgid "Added"
+msgstr "تمت الإضافة"
+
+#: diff.html
+msgid "Modified"
+msgstr "تم التعديل"
+
+#: diff.html
+msgid "Removed"
+msgstr "تم الإزالة"
+
+#: diff.html
+msgid "Not changed"
+msgstr "لم يتغير"
+
+#: diff.html
+#, python-format
+msgid "Revision %d"
+msgstr "الإصدار %d"
+
+#: books/check.html books/show.html covers/book_cover.html
+#: covers/book_cover_single_edition.html covers/book_cover_work.html diff.html
+#: jsdef/LazyWorkPreview.html lists/preview.html
+msgid "by"
+msgstr "بواسطة"
+
+#: diff.html
+msgid "by Anonymous"
+msgstr "بواسطة مجهول"
+
+#: diff.html
+msgid "Differences"
+msgstr "الفروقات"
+
+#: diff.html
+msgid "Both the revisions are identical."
+msgstr "الإصداران متطابقان."
+
+#: edit_yaml.html lib/edit_head.html
+msgid "You're in edit mode."
+msgstr "أنت في وضع التحرير."
+
+#: edit_yaml.html lib/edit_head.html
+msgid "Cancel, and go back."
+msgstr "إلغاء والعودة."
+
+#: edit_yaml.html
+msgid "YAML Representation:"
+msgstr "تمثيل YAML:"
+
+#: BookPreview.html books/edit/edition.html editpage.html
+msgid "Preview"
+msgstr "معاينة"
+
+#: history.html
+msgid "History of edits to"
+msgstr "تاريخ التعديلات على"
+
+#: history.html
+msgid "Revision"
+msgstr "الإصدار"
+
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
+#: admin/ip/view.html admin/people/edits.html history.html
+#: recentchanges/render.html recentchanges/updated_records.html
+msgid "When"
+msgstr "متى"
+
+#: RecentChanges.html admin/ip/view.html admin/loans_table.html
+#: admin/people/edits.html admin/waitinglists.html history.html
+#: recentchanges/render.html
+msgid "Who"
+msgstr "من"
+
+#: RecentChanges.html RecentChangesUsers.html admin/ip/view.html
+#: admin/people/edits.html history.html recentchanges/render.html
+#: recentchanges/updated_records.html
+msgid "Comment"
+msgstr "تعليق"
+
+#: history.html
+msgid "Diff"
+msgstr "الاختلاف"
+
+#: history.html
+msgid "Compare"
+msgstr "قارن"
+
+#: history.html
+msgid "See Diff"
+msgstr "عرض الفروق"
+
+#: history.html lib/history.html
+#, python-format
+msgid "View revision %s"
+msgstr "عرض الإصدار %s"
+
+#: history.html
+msgid "Compare this version..."
+msgstr "قارن هذه النسخة..."
+
+#: history.html
+msgid "...to this version"
+msgstr "...مع هذه النسخة"
+
+#: books/daisy.html history.html
+msgid "Back"
+msgstr "عودة"
+
+#: Pager.html Pager_loanhistory.html history.html lib/pagination.html
+#: showmarc.html
+msgid "Next"
+msgstr "التالي"
+
+#: internalerror.html
+msgid "Sorry. There seems to be a problem with what you were just looking at."
+msgstr "عُذراً. يبدو أن هناك مشكلة في الصفحة التي كنت تقرأها ."
+
+#: internalerror.html
+#, python-format
+msgid ""
+"We've noted the error %s and will look into it as soon as possible. Head "
+"for <a href=\"/\">home</a>?"
+msgstr ""
+"لقد لاحظنا الخطأ %s وسنعمل على التحقق منه في أقرب وقت ممكن. انتقل إلى "
+"<a href=\"/\">الصفحة الرئيسية</a>؟"
+
+#: lib/nav_head.html library_explorer.html
+msgid "Library Explorer"
+msgstr "مستعرض المكتبة"
+
+#: lib/header_dropdown.html lib/nav_head.html login.html
+msgid "Log In"
+msgstr "تسجيل الدخول"
+
+#: account/create.html login.html
+msgid "OR"
+msgstr "أو"
+
+#: login.html
+msgid ""
+"Please enter your <a href=\"https://archive.org\">Internet Archive</a> "
+"email and password to access your Open Library account."
+msgstr ""
+"يرجى إدخال بريدك الإلكتروني وكلمة المرور الخاصة بـ <a href=\"https://archive.org\">Internet Archive</a> للوصول إلى حسابك في المكتبة المفتوحة."
+
+#: account/create.html login.html
+#, python-format
+msgid "You are already logged into Open Library as %(user)s."
+msgstr "أنت بالفعل مسجل الدخول إلى المكتبة المفتوحة كـ %(user)s."
+
+#: account/create.html login.html
+msgid ""
+"If you'd like to create a new, different Open Library account, you'll "
+"need to <a href=\"javascript:;\" onclick=\"document.forms['hamburger-"
+"logout'].submit()\">log out</a> and start the signup process afresh."
+msgstr ""
+"إذا كنت ترغب في إنشاء حساب جديد في المكتبة المفتوحة، ستحتاج إلى <a "
+"href=\"javascript:;\" onclick=\"document.forms['hamburger-logout'].submit()\">تسجيل الخروج</a> وبدء عملية التسجيل من جديد."
+
+#: login.html
+msgid ""
+"This is a development instance, the default credentials are automatically"
+" filled."
+msgstr ""
+"هذه نسخة تطويرية، بيانات المرور تُملأ تلقائيًا."
+
+#: login.html
+msgid "email:"
+msgstr "البريد الإلكتروني:"
+
+#: login.html
+msgid "password:"
+msgstr "كلمة المرور:"
+
+#: login.html
+msgid "Email"
+msgstr "البريد الإلكتروني"
+
+#: login.html
+msgid "Forgot your Internet Archive email?"
+msgstr "نسيت بريدك الإلكتروني في Internet Archive؟"
+
+#: account/email/forgot-ia.html forms.py login.html
+msgid "Password"
+msgstr "كلمة المرور"
+
+#: login.html
+msgid "Remember me"
+msgstr "تذكرني"
+
+#: account/email/forgot.html login.html
+msgid "Forgot your Password?"
+msgstr "نسيت كلمة المرور؟"
+
+#: login.html
+msgid "Not a member of Open Library? <a href=\"/account/create\">Sign up now</a>."
+msgstr ""
+"لست عضوًا في المكتبة المفتوحة؟ <a href=\"/account/create\">سجل الآن</a>."
+
+#: messages.html
+msgid "Created new author record."
+msgstr "تم إنشاء سجل مؤلف جديد."
+
+#: messages.html
+msgid "Created new edition record."
+msgstr "تم إنشاء سجل إصدار جديد."
+
+#: messages.html
+msgid "Created new work record."
+msgstr "تم إنشاء سجل عمل جديد."
+
+#: messages.html
+msgid "Added new book."
+msgstr "تمت إضافة كتاب جديد."
+
+#: messages.html
+msgid "Thank you very much for adding that new book!"
+msgstr "شكرًا جزيلاً لإضافة هذا الكتاب الجديد!"
+
+#: BookPreview.html CreateListModal.html DonateModal.html NotesModal.html
+#: ObservationsModal.html ShareModal.html
+#: book_providers/gutenberg_read_button.html
+#: book_providers/librivox_read_button.html
+#: book_providers/openstax_read_button.html
+#: book_providers/standard_ebooks_read_button.html covers/author_photo.html
+#: covers/book_cover.html covers/book_cover_single_edition.html
+#: covers/book_cover_work.html covers/change.html lib/history.html
+#: my_books/dropdown_content.html native_dialog.html
+msgid "Close"
+msgstr "إغلاق"
+
+#: notfound.html
+#, python-format
+msgid "%(path)s is not found"
+msgstr "%(path)s لم يُعثر عليه"
+
+#: languages/notfound.html notfound.html
+msgid "404 - Page Not Found"
+msgstr "404 - الصفحة غير موجودة"
+
+#: notfound.html
+#, python-format
+msgid "%(path)s does not exist."
+msgstr "%(path)s غير موجود."
+
+#: notfound.html
+msgid "Create it?"
+msgstr "أتود إنشاؤه؟"
+
+#: notfound.html
+msgid "Looking for a template/macro?"
+msgstr "تبحث عن قالب/ماكرو؟"
+
+#: permission.html
+msgid "Permission of"
+msgstr "إذن لـ"
+
+#: permission.html
+msgid "Permission"
+msgstr "إذن"
+
+#: permission.html
+msgid "Child Permission"
+msgstr "إذن فرعي"
+
+#: permission_denied.html
+msgid "Permission denied."
+msgstr "تم رفض الإذن."
+
+#: permission_denied.html
+#, python-format
+msgid "You may <a href=\"%s\">log in</a> if you have the required permissions."
+msgstr "يمكنك <a href=\"%s\">تسجيل الدخول</a> إذا كان لديك الأذونات المطلوبة."
+
+#: recaptcha.html
+msgid ""
+"Please satisfy the reCAPTCHA below. If you have security settings or "
+"privacy blockers installed, please disable them to see the reCAPTCHA."
+msgstr ""
+"يرجى إكمال الكابتشا أدناه. إذا كان لديك إعدادات أمان أو حاصرات خصوصية "
+"مثبتة، يرجى تعطيلها لرؤية الكابتشا."
+
+#: recaptcha.html
+msgid "Incorrect. Please try again."
+msgstr "غير صحيح. يرجى المحاولة مرة أخرى."
+
+#: showamazon.html showbwb.html
+msgid "Record details of"
+msgstr "تفاصيل السجل لـ"
+
+#: showamazon.html showbwb.html
+msgid "This record came from"
+msgstr "هذا السجل جاء من"
+
+#: showia.html showmarc.html
+msgid "Invalid MARC record."
+msgstr "سجل MARC غير صالح."
+
+#: status.html
+msgid "Server status"
+msgstr "حالة الخادم"
+
+#: SearchNavigation.html SubjectTags.html lib/nav_foot.html lib/nav_head.html
+#: subjects.html subjects/notfound.html type/author/view.html
+#: type/list/view_body.html work_search.html
+msgid "Subjects"
+msgstr "الموضوعات"
+
+#: SubjectTags.html subjects.html type/author/view.html
+#: type/list/view_body.html work_search.html
+msgid "Places"
+msgstr "الأماكن"
+
+#: SubjectTags.html admin/menu.html subjects.html type/author/view.html
+#: type/list/view_body.html work_search.html
+msgid "People"
+msgstr "الأشخاص"
+
+#: SubjectTags.html subjects.html type/list/view_body.html work_search.html
+msgid "Times"
+msgstr "الأوقات"
+
+#: subjects.html
+msgid "Edit Subject Tag"
+msgstr "تعديل علامة الموضوع"
+
+#: subjects.html
+msgid "See all works"
+msgstr "عرض جميع الأعمال"
+
+#: merge/authors.html publishers/view.html subjects.html type/author/view.html
+#, python-format
+msgid "%(count)d work"
+msgid_plural "%(count)d works"
+msgstr[0] "%(count)d عمل"
+msgstr[1] "%(count)d أعمال"
+
+#: subjects.html
+#, python-format
+msgid "Search for books with subject %(name)s."
+msgstr "ابحث عن كتب حول الموضوع %(name)s."
+
+#: authors/index.html lib/nav_head.html lists/home.html
+#: publishers/notfound.html publishers/view.html search/advancedsearch.html
+#: search/authors.html search/inside.html search/lists.html
+#: search/publishers.html search/subjects.html subjects.html
+#: subjects/notfound.html type/local_id/view.html work_search.html
+msgid "Search"
+msgstr "بحث"
+
+#: publishers/view.html subjects.html
+msgid "Publishing History"
+msgstr "تاريخ النشر"
+
+#: subjects.html
+msgid ""
+"This is a chart to show the publishing history of editions of works about"
+" this subject. Along the X axis is time, and on the y axis is the count "
+"of editions published. <a href=\"#subjectRelated\">Click here to skip the"
+" chart</a>."
+msgstr ""
+"هذا رسم بياني يظهر تاريخ نشر إصدارات الأعمال المتعلقة بهذا الموضوع. "
+"على المحور الأفقي هو الوقت، وعلى المحور الرأسي هو عدد الإصدارات المنشورة. "
+"<a href=\"#subjectRelated\">انقر هنا لتخطي الرسم البياني</a>."
+
+#: publishers/view.html subjects.html
+msgid "Reset chart"
+msgstr "إعادة تعيين الرسم البياني"
+
+#: publishers/view.html subjects.html
+msgid "or continue zooming in."
+msgstr "أو الاستمرار في التكبير."
+
+#: subjects.html
+msgid "This graph charts editions published on this subject."
+msgstr "هذا الرسم البياني يوضح الإصدارات التي نُشرت حول هذا الموضوع."
+
+#: publishers/view.html subjects.html
+msgid "Editions Published"
+msgstr "الإصدارات المنشورة"
+
+#: admin/imports.html publishers/view.html subjects.html
+msgid "You need to have JavaScript turned on to see the nifty chart!"
+msgstr "تحتاج إلى تفعيل JavaScript لرؤية الرسم البياني الممتاز!"
+
+#: publishers/view.html subjects.html
+msgid "Year of Publication"
+msgstr "سنة النشر"
+
+#: subjects.html
+msgid "Related..."
+msgstr "متعلق..."
+
+#: publishers/view.html subjects.html
+msgid "None found."
+msgstr "لم يتم العثور على أي شيء."
+
+#: publishers/view.html subjects.html
+msgid "See more books by, and learn about, this author"
+msgstr "عرض المزيد من الكتب بواسطة، وتعرف على، هذا المؤلف"
+
+#: account/loans.html authors/index.html publishers/view.html
+#: search/authors.html search/publishers.html search/subjects.html
+#: subjects.html
+#, python-format
+msgid "%(count)d book"
+msgid_plural "%(count)d books"
+msgstr[0] "%(count)d كتاب"
+msgstr[1] "%(count)d كتب"
+
+#: subjects.html
+msgid "Prolific Authors"
+msgstr "المؤلفون الأكثر إنتاجاً"
+
+#: subjects.html
+msgid "who have written the most books on this subject"
+msgstr "الذين كتبوا أكبر عدد من الكتب حول هذا الموضوع"
+
+#: publishers/view.html subjects.html
+msgid "Get more information about this publisher"
+msgstr "احصل على المزيد من المعلومات حول هذا الناشر"
+
+#: SearchResultsWork.html books/check.html merge/authors.html
+#: publishers/view.html subjects.html
+#, python-format
+msgid "%(count)s edition"
+msgid_plural "%(count)s editions"
+msgstr[0] "%(count)s إصدار"
+msgstr[1] "%(count)s إصدارات"
+
+#: support.html
+msgid "How can we help?"
+msgstr "كيف يمكننا المساعدة؟"
+
+#: support.html
+msgid ""
+"Your question has been sent to our support team. We'll get back to you "
+"shortly. You can also <a href=\"https://twitter.com/openlibrary\">contact"
+" us on Twitter</a>."
+msgstr ""
+"تم إرسال سؤالك إلى فريق الدعم لدينا. سنعود إليك قريباً. يمكنك أيضاً <a "
+"href=\"https://twitter.com/openlibrary\">الاتصال بنا عبر منصة إكس</a>."
+
+#: support.html
+msgid ""
+"Please check our <a href=\"/help/\">Help Pages</a> and <a "
+"href=\"/help/faq\">Frequently Asked Questions</a> (FAQ) to see if your "
+"question is answered there. Thank you."
+msgstr ""
+"يرجى التحقق من <a href=\"/help/\">صفحات المساعدة</a> و <a "
+"href=\"/help/faq\">الأسئلة المتكررة</a> (FAQ) لمعرفة ما إذا كانت "
+"سؤالك قد تم الرد عليه هناك. شكراً."
+
+#: support.html
+msgid "Your Name"
+msgstr "اسمك"
+
+#: support.html
+msgid "Your Email Address"
+msgstr "عنوان بريدك الإلكتروني"
+
+#: support.html
+msgid "We'll need this if you want a reply"
+msgstr "سنحتاج إلى ذلك إذا كنت تريد ردًا"
+
+#: support.html
+msgid ""
+"If you wish to be contacted by other means, please add your contact "
+"preference and details to your question."
+msgstr ""
+"إذا كنت ترغب في التواصل بوسائل أخرى، يرجى إضافة تفضيلاتك وتفاصيل الاتصال "
+"إلى سؤالك."
+
+#: lib/nav_head.html search/advancedsearch.html support.html
+msgid "Subject"
+msgstr "الموضوع"
+
+#: support.html
+msgid "Your Question"
+msgstr "سؤالك"
+
+#: support.html
+msgid "Note: our staff will likely only be able respond in English."
+msgstr ""
+"ملاحظة: قد يكون من الممكن لموظفينا الرد باللغة الإنجليزية فقط."
+
+#: support.html
+msgid ""
+"If you encounter an error message, please include it. For questions about"
+" our books, please provide the title/author or Open Library ID."
+msgstr ""
+"إذا صادفت رسالة خطأ، يرجى تضمينها. بالنسبة للأسئلة حول كتبنا، يرجى "
+"تقديم العنوان/المؤلف أو معرف المكتبة المفتوحة."
+
+#: support.html
+msgid "Send"
+msgstr "إرسال"
+
+#: CreateListModal.html EditButtons.html account/create.html
+#: account/notifications.html account/password/reset.html account/privacy.html
+#: admin/imports-add.html admin/permissions.html books/add.html covers/add.html
+#: covers/manage.html databarEdit.html merge/authors.html
+#: my_books/dropdown_content.html support.html tag/add.html
+msgid "Cancel"
+msgstr "إلغاء"
+
+#: trending.html
+msgid "Now"
+msgstr "الآن"
+
+#: admin/graphs.html admin/index.html check_ins/check_in_form.html
+#: check_ins/check_in_prompt.html trending.html
+msgid "Today"
+msgstr "اليوم"
+
+#: admin/graphs.html trending.html
+msgid "This Week"
+msgstr "هذا الأسبوع"
+
+# | msgid "This Edition"
+#: stats/readinglog.html trending.html
+msgid "This Month"
+msgstr "هذا الشهر"
+
+#: trending.html
+msgid "This Year"
+msgstr "هذا العام"
+
+#: account/view.html admin/index.html books/year_breadcrumb_select.html
+#: trending.html
+msgid "All Time"
+msgstr "على مر الزمن"
+
+#: home/index.html trending.html
+msgid "Trending Books"
+msgstr "الكتب الرائجة"
+
+#: trending.html
+msgid "See what readers from the community are adding to their bookshelves"
+msgstr "شاهد ما يضيفه القراء من المجتمع إلى رفوف كتبهم"
+
+#: trending.html
+msgid "Earliest trending data is from October 2017"
+msgstr "أقدم بيانات رائجة هي من أكتوبر 2017"
+
+#: account/mybooks.html account/sidebar.html my_books/dropdown_content.html
+#: my_books/primary_action.html search/sort_options.html trending.html
+msgid "Want to Read"
+msgstr "أريد قراءته"
+
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
+#: my_books/dropdown_content.html my_books/primary_action.html
+#: search/sort_options.html trending.html
+msgid "Currently Reading"
+msgstr "أقرأ حالياً"
+
+#: LoanReadForm.html ReadButton.html book_providers/gutenberg_read_button.html
+#: book_providers/openstax_read_button.html
+#: book_providers/standard_ebooks_read_button.html books/custom_carousel.html
+#: books/edit/edition.html books/show.html trending.html type/list/embed.html
+#: widget.html
+msgid "Read"
+msgstr "اقرأ"
+
+#: trending.html
+#, python-format
+msgid "Someone marked as %(shelf)s %(k_hours_ago)s"
+msgstr "شخص ما قام بتصنيفها كـ %(shelf)s منذ %(k_hours_ago)s"
+
+#: trending.html
+#, python-format
+msgid "Logged %(count)i times %(time_unit)s"
+msgstr "تم تسجيلها %(count)i مرة خلال %(time_unit)s"
+
+#: viewpage.html
+msgid "Revert to this revision?"
+msgstr "العودة إلى هذه النسخة؟"
+
+#: viewpage.html
+msgid "Revert to this revision"
+msgstr "العودة إلى هذه النسخة"
+
+#: widget.html
+#, python-format
+msgid "Read \"%(title)s\""
+msgstr "اقرأ \"%(title)s\""
+
+#: widget.html
+#, python-format
+msgid "Borrow \"%(title)s\""
+msgstr "استعِر \"%(title)s\""
+
+#: ReadButton.html books/custom_carousel.html books/edit/edition.html
+#: type/list/embed.html widget.html
+msgid "Borrow"
+msgstr "استعِر"
+
+#: widget.html
+#, python-format
+msgid "Join waitlist for \"%(title)s\""
+msgstr "الانضمام إلى قائمة الانتظار لـ \"%(title)s\""
+
+#: LoanStatus.html books/custom_carousel.html widget.html
+msgid "Join Waitlist"
+msgstr "الانضمام إلى قائمة الانتظار"
+
+#: widget.html
+#, python-format
+msgid "Learn more about \"%(title)s\" at OpenLibrary"
+msgstr "تعلم المزيد عن \"%(title)s\" في OpenLibrary"
+
+#: widget.html
+msgid "Learn More"
+msgstr "تعلم المزيد"
+
+#: widget.html
+#, python-format
+msgid "on <a target=\"_blank\" href=\"%(link)s\">openlibrary.org</a>"
+msgstr "على <a target=\"_blank\" href=\"%(link)s\">openlibrary.org</a>"
+
+#: work_search.html
+msgid "Search Books"
+msgstr "ابحث عن الكتب"
+
+#: work_search.html
+msgid "eBook?"
+msgstr "كتاب إلكتروني؟"
+
+#: type/edition/view.html type/work/view.html work_search.html
+msgid "Language"
+msgstr "اللغة"
+
+#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html
+#: search/advancedsearch.html work_search.html
+msgid "Author"
+msgstr "المؤلف"
+
+#: work_search.html
+msgid "First published"
+msgstr "أول نشر"
+
+#: search/advancedsearch.html type/edition/view.html type/work/view.html
+#: work_search.html
+msgid "Publisher"
+msgstr "الناشر"
+
+#: work_search.html
+msgid "Classic eBooks"
+msgstr "الكتب الإلكترونية الكلاسيكية"
+
+#: work_search.html
+msgid "Keywords"
+msgstr "الكلمات المفتاحية"
+
+#: RecentChanges.html recentchanges/index.html work_search.html
+msgid "Everything"
+msgstr "كل شيء"
+
+#: work_search.html
+msgid "Ebooks"
+msgstr "الكتب الإلكترونية"
+
+#: work_search.html
+msgid "Print Disabled"
+msgstr "تعطيل الطباعة"
+
+#: work_search.html
+msgid "This is only visible to super librarians."
+msgstr "هذا مرئي فقط لأمناء المكتبات المميزين."
+
+#: work_search.html
+msgid "Solr Editions"
+msgstr "إصدارات Solr"
+
+#: work_search.html
+msgid "eBook"
+msgstr "كتاب إلكتروني"
+
+#: work_search.html
+msgid "Classic eBook"
+msgstr "كتاب إلكتروني كلاسيكي"
+
+#: work_search.html
+msgid "Search facets"
+msgstr "بحث عن الفئات"
+
+#: work_search.html
+msgid "Explore Classic eBooks"
+msgstr "استكشف الكتب الإلكترونية الكلاسيكية"
+
+#: work_search.html
+msgid "Only Classic eBooks"
+msgstr "فقط الكتب الإلكترونية الكلاسيكية"
+
+#: work_search.html
+#, python-format
+msgid "Explore books about %(subject)s"
+msgstr "استكشف الكتب حول %(subject)s"
+
+#: merge/authors.html work_search.html
+msgid "First published in"
+msgstr "أول نشر في"
+
+#: work_search.html
+msgid "Written in"
+msgstr "مكتوب باللغة"
+
+#: work_search.html
+msgid "Published by"
+msgstr "نشر بواسطة"
+
+#: work_search.html
+msgid "Click to remove this facet"
+msgstr "انقر لإزالة هذه الفئة"
+
+#: work_search.html
+#, python-format
+msgid "%(title)s - search"
+msgstr "%(title)s – بحث"
+
+#: search/lists.html work_search.html
+msgid "No results found."
+msgstr "لم يتم العثور على نتائج."
+
+#: search/lists.html work_search.html
+#, python-format
+msgid "Search for books containing the phrase \"%s\"?"
+msgstr "ابحث عن كتب تحتوي على العبارة \"%s\"؟"
+
+#: work_search.html
+msgid "Add a new book to Open Library?"
+msgstr "هل تريد إضافة كتاب جديد إلى المكتبة المفتوحة؟"
+
+#: account/reading_log.html search/authors.html search/subjects.html
+#: work_search.html
+#, python-format
+msgid "%(count)s hit"
+msgid_plural "%(count)s hits"
+msgstr[0] "%(count)s نتيجة"
+msgstr[1] "%(count)s نتائج"
+
+#: work_search.html
+msgid "BARF! Search engine ERROR!"
+msgstr "فشل في محرك البحث!"
+
+#: work_search.html
+msgid "Zoom In"
+msgstr "تكبير"
+
+#: work_search.html
+msgid "Focus your results using these <a href=\"/search/howto\">filters</a>"
+msgstr "قم بتصفية نتائجك باستخدام هذه <a href=\"/search/howto\">الفلاتر</a>"
+
+#: work_search.html
+msgid "Merge duplicate authors from this search"
+msgstr "دمج المؤلفين المكررين من هذا البحث"
+
+#: type/work/editions.html work_search.html
+msgid "Merge duplicates"
+msgstr "دمج التكرارات"
+
+#: work_search.html
+msgid "yes"
+msgstr "نعم"
+
+#: work_search.html
+msgid "no"
+msgstr "لا"
+
+#: work_search.html
+msgid "Filter results for ebook availability"
+msgstr "تصفية النتائج حسب توافر الكتب الإلكترونية"
+
+#: work_search.html
+#, python-format
+msgid "Filter results for %(facet)s"
+msgstr "تصفية النتائج حسب %(facet)s"
+
+#: work_search.html
+msgid "more"
+msgstr "المزيد"
+
+#: work_search.html
+msgid "less"
+msgstr "أقل"
+
+# | msgid "Sign Up to Open Library"
+#: about/index.html
+msgid "The Open Library Team"
+msgstr "فريق المكتبة المفتوحة"
+
+#: account/create.html forms.py
+msgid "Must be between 3 and 20 characters"
+msgstr "يجب أن يكون بين 3 و20 حرفًا"
+
+#: account/create.html
+msgid "Sign Up to Open Library"
+msgstr "سجل في المكتبة المفتوحة"
+
+#: account/create.html lib/header_dropdown.html lib/nav_head.html
+msgid "Sign Up"
+msgstr "تسجيل"
+
+#: account/create.html
+msgid "Complete the form below to create a new Internet Archive account."
+msgstr "املأ النموذج أدناه لإنشاء حساب جديد في موقع أرشيف الإنترنت."
+
+#: account/create.html
+msgid "Each field is required"
+msgstr "كل حقل مطلوب"
+
+#: account/create.html
+msgid "Show password"
+msgstr "عرض كلمة المرور"
+
+#: account/create.html
+msgid "Hide password"
+msgstr "إخفاء كلمة المرور"
+
+#: account/create.html
+msgid "Your URL"
+msgstr "رابطك"
+
+#: account/create.html
+msgid "screenname"
+msgstr "اسم العرض"
+
+#: account/create.html
+msgid ""
+"By signing up, you agree to the Internet Archive's <a "
+"href='//archive.org/about/terms.php' target='_blank'>Terms of "
+"Service</a>."
+msgstr ""
+"بتسجيلك، فإنك توافق على <a "
+"href='//archive.org/about/terms.php' target='_blank'>شروط الخدمة</a> لأرشيف الإنترنت."
+
+#: account/delete.html
+msgid "Delete Account"
+msgstr "حذف الحساب"
+
+#: account/delete.html
+msgid "Sorry, this functionality is not yet implemented."
+msgstr "عذرًا، هذه الوظيفة لم تُطبق بعد."
+
+#: account/follows.html
+msgid "There is nothing to see here yet."
+msgstr "لا يوجد شيء هنا بعد."
+
+#: account/import.html
+msgid "Import from Goodreads"
+msgstr "استيراد من Goodreads"
+
+#: account/import.html
+msgid "File size limit 10MB and .csv file type only"
+msgstr "حد حجم الملف 10 ميجابايت ونوع الملف .csv فقط"
+
+#: account/import.html
+msgid "Load Books"
+msgstr "تحميل الكتب"
+
+#: account/import.html
+msgid "Export your Reading Log"
+msgstr "تصدير سجل قراءتك"
+
+#: account/import.html
+msgid "Download a copy of your reading log."
+msgstr "قم بتحميل نسخة من سجل قراءتك."
+
+#: account/import.html
+msgid "What is this?"
+msgstr "ما هو هذا؟"
+
+#: account/import.html
+msgid "Download (.csv format)"
+msgstr "تحميل (تنسيق .csv)"
+
+#: account/import.html
+msgid "Export your book notes"
+msgstr "تصدير ملاحظاتك عن الكتب"
+
+#: account/import.html
+msgid "Download a copy of your book notes."
+msgstr "قم بتحميل نسخة من ملاحظاتك عن الكتب."
+
+#: account/import.html
+msgid "What are book notes?"
+msgstr "ما هي ملاحظات الكتب؟"
+
+#: account/import.html
+msgid "Export your reviews"
+msgstr "تصدير مراجعاتك"
+
+#: account/import.html
+msgid "Download a copy of your review tags."
+msgstr "قم بتحميل نسخة من علامات مراجعاتك."
+
+#: account/import.html
+msgid "What are review tags?"
+msgstr "ما هي علامات المراجعات؟"
+
+#: account/import.html
+msgid "Export your list overview"
+msgstr "تصدير نظرة عامة على قوائمك"
+
+#: account/import.html
+msgid "Download a summary of your lists and their contents."
+msgstr "قم بتحميل ملخص لقوائمك ومحتوياتها."
+
+#: account/import.html
+msgid "What are lists?"
+msgstr "ما هي القوائم؟"
+
+#: account/import.html
+msgid "Export your star ratings"
+msgstr "تصدير تقييماتك بالنجوم"
+
+#: account/import.html
+msgid "Download a copy of your star ratings."
+msgstr "قم بتحميل نسخة من تقييماتك بالنجوم."
+
+#: account/import.html
+msgid "What are star ratings?"
+msgstr "ما هي تقييمات النجوم؟"
+
+#: account/loan_history.html
+msgid "No loans found in your borrow history."
+msgstr "لم يتم العثور على قروض في سجل استعاراتك."
+
+#: account/loan_history.html
+msgid "<a href=\"/search\">Search for a book</a> to borrow."
+msgstr "<a href=\"/search\">ابحث عن كتاب</a> للاستعارة."
+
+#: account/loans.html
+msgid "You've not checked out any books at this moment."
+msgstr "لم تقم باستعارة أي كتب في الوقت الحالي."
+
+#: account/loans.html
+#, python-format
+msgid "%(count)d Current Loan"
+msgid_plural "%(count)d Current Loans"
+msgstr[0] "%(count)d استعارة حالية"
+msgstr[1] "%(count)d استعارات حالية"
+
+#: account/loans.html admin/loans_table.html
+msgid "Loan Expires"
+msgstr "تاريخ انتهاء الاستعارة"
+
+#: account/loans.html
+msgid "Loan actions"
+msgstr "إجراءات الاستعارة"
+
+#: account/loans.html
+#, python-format
+msgid "There is %(count)d person waiting for this book."
+msgid_plural "There are %(count)d people waiting for this book."
+msgstr[0] "يوجد %(count)d شخص ينتظر هذا الكتاب."
+msgstr[1] "يوجد %(count)d شخصاً ينتظر هذا الكتاب."
+
+#: account/loans.html
+msgid "Not yet downloaded."
+msgstr "لم يتم تحميله بعد."
+
+#: account/loans.html
+msgid "Download Now"
+msgstr "حمل الآن"
+
+#: account/loans.html
+msgid "Return via<br/>Adobe Digital Editions"
+msgstr "الإرجاع عبر<br/>Adobe Digital Editions"
+
+#: account/loans.html
+msgid "Books You're Waiting For"
+msgstr "الكتب التي تنتظرها"
+
+#: account/loans.html
+msgid "You are not waiting for any books at this moment."
+msgstr "أنت لا تنتظر أي كتب في الوقت الحالي."
+
+#: account/loans.html
+msgid "Leave the Waiting List"
+msgstr "اترك قائمة الانتظار"
+
+#: account/loans.html
+msgid ""
+"Are you sure you want to leave the waiting list "
+"of<br/><strong>TITLE</strong>?"
+msgstr ""
+"هل أنت متأكد أنك تريد مغادرة قائمة الانتظار لـ<br/><strong>TITLE</strong>؟"
+
+#: account/loans.html admin/loans_table.html admin/menu.html
+msgid "Status"
+msgstr "الحالة"
+
+#: RecentChangesAdmin.html account/loans.html admin/loans_table.html
+msgid "Actions"
+msgstr "الإجراءات"
+
+#: account/loans.html
+#, python-format
+msgid "Waiting for 1 day"
+msgid_plural "Waiting for %(count)d days"
+msgstr[0] "انتظار يوم واحد"
+msgstr[1] "انتظار %(count)d أيام"
+
+#: account/loans.html
+msgid "You are the next person to receive this book."
+msgstr "أنت الشخص التالي الذي سيتلقى هذا الكتاب."
+
+#: ManageWaitlistButton.html account/loans.html
+#, python-format
+msgid "There is one person ahead of you in the waiting list."
+msgid_plural "There are %(count)d people ahead of you in the waiting list."
+msgstr[0] "هناك شخص واحد قبلك في قائمة الانتظار."
+msgstr[1] "يوجد %(count)d أشخاص قبلك في قائمة الانتظار."
+
+#: account/loans.html
+msgid "You have less than an hour to borrow it."
+msgstr "لديك أقل من ساعة لاستعاره."
+
+#: account/loans.html
+#, python-format
+msgid "You have one more hour to borrow it."
+msgid_plural "You have %(hours)d more hours to borrow it."
+msgstr[0] "لديك ساعة أخرى لاستعاره."
+msgstr[1] "لديك %(hours)d ساعات أخرى لاستعاره."
+
+#: account/loans.html
+msgid "Borrow Now"
+msgstr "استعِر الآن"
+
+#: account/loans.html
+msgid "Leave the waiting list?"
+msgstr "مغادرة قائمة الانتظار؟"
+
+#: account/loans.html
+msgid ""
+"Looking for a book to borrow?  Check out our staff picks, or search for a"
+" book on a specific subject:"
+msgstr ""
+"تبحث عن كتاب لاستعارته؟ تحقق من اختيارات موظفينا، أو ابحث عن كتاب في موضوع محدد:"
+
+#: account/loans.html home/index.html
+msgid "Books We Love"
+msgstr "الكتب التي نحبها"
+
+#: account/loans.html
+msgid "Or, check out our <a href=\"/collections\">special collections</a>."
+msgstr ""
+"أو تحقق من <a href=\"/collections\">المجموعات الخاصة</a> لدينا."
+
+#: account/mybooks.html
+#, python-format
+msgid "Set %(year_span)s reading goal"
+msgstr "حدد هدف القراءة لـ %(year_span)s"
+
+#: account/mybooks.html
+msgid "Yearly Reading Goal"
+msgstr "هدف القراءة السنوي"
+
+#: account/mybooks.html
+msgid "No books are on this shelf"
+msgstr "لا توجد كتب على هذه الرف"
+
+#: account/mybooks.html account/sidebar.html
+msgid "My Loans"
+msgstr "قروضى"
+
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
+#: my_books/dropdown_content.html my_books/primary_action.html mybooks.py
+#: search/sort_options.html
+msgid "Already Read"
+msgstr "قرأت بالفعل"
+
+#: account/mybooks.html type/user/view.html
+msgid "This reader has chosen to make their Reading Log private."
+msgstr "اختار هذا القارئ جعل سجل القراءة خاصًا."
+
+#: account/mybooks.html account/sidebar.html
+msgid "Untitled list"
+msgstr "قائمة بدون عنوان"
+
+#: account/mybooks.html
+msgid "View All Lists"
+msgstr "عرض جميع القوائم"
+
+#: account/mybooks.html
+msgid "My Stats"
+msgstr "إحصائياتي"
+
+#: account/mybooks.html account/sidebar.html account/topmenu.html
+msgid "My Reading Stats"
+msgstr "إحصائيات القراءة الخاصة بي"
+
+#: account.py account/mybooks.html account/sidebar.html
+#: books/mybooks_breadcrumb_select.html
+msgid "Loan History"
+msgstr "سجل القروض"
+
+#: account/mybooks.html account/sidebar.html
+msgid "My Notes"
+msgstr "ملاحظاتي"
+
+#: account/mybooks.html account/sidebar.html
+msgid "My Reviews"
+msgstr "مراجعاتي"
+
+#: account/mybooks.html account/sidebar.html
+msgid "Import & Export Options"
+msgstr "خيارات الاستيراد والتصدير"
+
+#: account/mybooks.html account/sidebar.html
+#: books/mybooks_breadcrumb_select.html mybooks.py
+msgid "Sponsorships"
+msgstr "الرعايات"
+
+#: account/not_verified.html account/verify/failed.html
+msgid "Oops!"
+msgstr "أوبس!"
+
+#: account/not_verified.html
+msgid "The email address you signed up with needs to be verified."
+msgstr "يجب التحقق من عنوان البريد الإلكتروني الذي سجلت به."
+
+#: account/not_verified.html
+#, python-format
+msgid ""
+"When you created your account, we sent an email to %(email)s that "
+"contained a link for you to verify your email address. We need you to "
+"click that link, please."
+msgstr ""
+"عندما أنشأت حسابك، أرسلنا بريدًا إلكترونيًا إلى %(email)s يحتوي على رابط لتأكيد عنوان بريدك الإلكتروني. نحتاج منك أن تضغط على هذا الرابط، من فضلك."
+
+#: account/not_verified.html
+msgid "If you can't find the email, just hit this button to send a fresh one:"
+msgstr ""
+"إذا لم تتمكن من العثور على البريد الإلكتروني، فقط اضغط على هذا الزر لإرسال بريد جديد:"
+
+#: account/not_verified.html account/verify/failed.html
+msgid "Resend the verification email"
+msgstr "إعادة إرسال بريد التحقق"
+
+#: account/not_verified.html account/verify/failed.html
+msgid "Thanks!"
+msgstr "شكرًا!"
+
+#: BookByline.html SearchResultsWork.html account/notes.html
+#: account/observations.html
+msgid "Unknown author"
+msgstr "مؤلف غير معروف"
+
+#: account/notes.html
+msgid "My notes for an edition of "
+msgstr "ملاحظاتي لإصدار من "
+
+#: account/notes.html
+msgid "Title Missing"
+msgstr "العنوان مفقود"
+
+#: account/notes.html type/work/editions.html
+msgid "Publish date unknown"
+msgstr "تاريخ النشر غير معروف"
+
+#: account/notes.html books/edition-sort.html books/works-show.html
+#: type/work/editions.html
+msgid "Publisher unknown"
+msgstr "الناشر غير معروف"
+
+#: account/notes.html
+#, python-format
+msgid "in %(language)s"
+msgstr "بـ %(language)s"
+
+#: NotesModal.html account/notes.html
+msgid "Delete Note"
+msgstr "حذف الملاحظة"
+
+#: NotesModal.html account/notes.html
+msgid "Save Note"
+msgstr "حفظ الملاحظة"
+
+#: account/notes.html
+msgid "No notes found."
+msgstr "لم يتم العثور على ملاحظات."
+
+#: account/notifications.html
+msgid "Notifications from Open Library"
+msgstr "إشعارات من المكتبة المفتوحة"
+
+#: account/notifications.html
+msgid "Notifications"
+msgstr "إشعارات"
+
+#: account/notifications.html
+msgid ""
+"Notifications are connected to Lists at the moment. If one of the books "
+"on your list gets edited, or a new book comes into the catalog, we'll let"
+" you know, if you want."
+msgstr ""
+"الإشعارات مرتبطة بالقوائم في الوقت الحالي. إذا تم تعديل أحد الكتب "
+"في قائمتك، أو تمت إضافة كتاب جديد إلى الكتالوج، سنعلمك إذا أردت."
+
+#: account/notifications.html
+msgid "Would you like to receive very occasional emails from Open Library?"
+msgstr "هل ترغب في تلقي رسائل بريد إلكتروني نادرة من المكتبة المفتوحة؟"
+
+#: account/notifications.html
+msgid "No, thank you"
+msgstr "لا، شكرًا"
+
+#: account/notifications.html
+msgid "Yes! Please!"
+msgstr "نعم! من فضلك!"
+
+#: EditButtons.html account/notifications.html account/privacy.html
+#: covers/manage.html
+msgid "Save"
+msgstr "حفظ"
+
+#: EditionNavBar.html account/observations.html
+#: books/mybooks_breadcrumb_select.html mybooks.py
+msgid "Reviews"
+msgstr "المراجعات"
+
+#: account/observations.html
+msgid "Delete"
+msgstr "حذف"
+
+#: account/observations.html
+msgid "Update Reviews"
+msgstr "تحديث المراجعات"
+
+#: account/observations.html
+msgid "No observations found."
+msgstr "لم يتم العثور على ملاحظات."
+
+#: account/privacy.html
+msgid "Your Privacy on Open Library"
+msgstr "خصوصيتك في المكتبة المفتوحة"
+
+#: account/privacy.html
+msgid "Privacy & Content Moderation Settings"
+msgstr "إعدادات الخصوصية وتدبير المحتوى"
+
+#: account/privacy.html
+msgid ""
+"Would you like to make your <a href=\"/account/books\">Reading Log</a> "
+"public?"
+msgstr ""
+"هل ترغب في جعل <a href=\"/account/books\">سجل القراءة</a> الخاص بك "
+"عامة؟"
+
+#: account/privacy.html
+msgid ""
+"This will enable others to see what books you want to read, are reading, "
+"or have already read. Public accounts can be seen and followed by others."
+msgstr "سيمكن هذا الآخرين من رؤية الكتب التي ترغب في قراءتها، أو التي تقرأها، أو التي قرأتها بالفعل. يمكن رؤية الحسابات العامة ومتابعتها من قبل الآخرين."
+
+#: account/privacy.html
+msgid "Yes"
+msgstr "نعم"
+
+#: account/privacy.html books/edit/edition.html
+msgid "No"
+msgstr "لا"
+
+#: account/privacy.html
+msgid "Enable Safe Mode?"
+msgstr "تفعيل وضع الأمان؟"
+
+#: account/privacy.html
+msgid ""
+"Safe Mode blurs book covers that have been flagged as having sensitive "
+"imagery."
+msgstr ""
+"وضع الأمان يطمس أغلفة الكتب التي تم الإبلاغ عنها لاحتوائها على صور حساسة."
+
+#: account/reading_log.html
+#, python-format
+msgid "Books %(username)s is reading"
+msgstr "الكتب التي يقرأها %(username)s"
+
+#: account/reading_log.html
+#, python-format
+msgid ""
+"%(username)s is reading %(total)d books. Join %(username)s on "
+"OpenLibrary.org and tell the world what you're reading."
+msgstr ""
+"%(username)s يقرأ حاليًا %(total)d كتب. انضم إلى %(username)s على "
+"OpenLibrary.org وشارك العالم بما تقرأه."
+
+#: account/reading_log.html
+#, python-format
+msgid "Books %(username)s wants to read"
+msgstr "الكتب التي يرغب %(username)s في قراءتها"
+
+#: account/reading_log.html
+#, python-format
+msgid ""
+"%(username)s wants to read %(total)d books. Join %(username)s on "
+"OpenLibrary.org and share the books that you'll soon be reading!"
+msgstr ""
+"%(username)s يرغب في قراءة %(total)d كتب. انضم إلى %(username)s على "
+"OpenLibrary.org وشارك الكتب التي ستقرأها قريبًا!"
+
+#: account/reading_log.html
+#, python-format
+msgid "Books %(username)s has read in %(year)d"
+msgstr "الكتب التي قرأها %(username)s في %(year)d"
+
+#: account/reading_log.html
+#, python-format
+msgid ""
+"%(username)s has read %(total)d books in %(year)d. Join %(username)s on "
+"OpenLibrary.org and tell the world about the books that you care about."
+msgstr ""
+"%(username)s قرأ %(total)d كتب في %(year)d. انضم إلى %(username)s على "
+"OpenLibrary.org وشارك العالم بالكتب التي تهمك."
+
+#: account/reading_log.html
+#, python-format
+msgid "Books %(username)s has read"
+msgstr "الكتب التي قرأها %(username)s"
+
+#: account/reading_log.html
+#, python-format
+msgid ""
+"%(username)s has read %(total)d books. Join %(username)s on "
+"OpenLibrary.org and tell the world about the books that you care about."
+msgstr ""
+"%(username)s قرأ %(total)d كتب. انضم إلى %(username)s على "
+"OpenLibrary.org وشارك العالم بالكتب التي تهمك."
+
+#: account/reading_log.html
+#, python-format
+msgid "Books in %(username)s feed"
+msgstr "الكتب في تغذية %(username)s"
+
+#: account/reading_log.html
+#, python-format
+msgid "Books added by people %(username)s follows"
+msgstr "الكتب التي أضافها الأشخاص الذين يتابعهم %(username)s"
+
+#: account/reading_log.html
+#, python-format
+msgid "Books %(userdisplayname)s is sponsoring"
+msgstr "الكتب التي يرعاها %(userdisplayname)s"
+
+#: account/reading_log.html
+msgid "Search your reading log"
+msgstr "ابحث في سجل القراءة الخاص بك"
+
+#: account/reading_log.html search/sort_options.html
+msgid "Sorting by"
+msgstr "الترتيب حسب"
+
+#: account/reading_log.html
+msgid "Date Added (newest)"
+msgstr "تاريخ الإضافة (الأحدث)"
+
+#: account/reading_log.html
+msgid "Date Added (oldest)"
+msgstr "تاريخ الإضافة (الأقدم)"
+
+#: account/reading_log.html
+msgid "No results found in this shelf"
+msgstr "لم يتم العثور على نتائج في هذا الرف"
+
+# | msgid "Welcome to Open Library"
+#: account/reading_log.html
+#, python-format
+msgid "Search all of Open Library for \"%s\"?"
+msgstr "ابحث في المكتبة المفتوحة عن \"%s\"؟"
+
+#: account/reading_log.html
+msgid "You haven't marked any books as read for this year."
+msgstr "لم تقم بعد بتمييز أي كتب على أنها مقروءة لهذا العام."
+
+#: account/reading_log.html
+msgid "You haven't added any books to this shelf yet."
+msgstr "لم تقم بإضافة أي كتب إلى هذا الرف بعد."
+
+#: account/reading_log.html
+msgid ""
+"<a href=\"/search\">Search for a book</a> to add to your reading log. <a "
+"href=\"/help/faq/reading-log\">Learn more</a> about the reading log."
+msgstr ""
+"<a href=\"/search\">ابحث عن كتاب</a> لإضافته إلى سجل القراءة الخاص بك. <a "
+"href=\"/help/faq/reading-log\">تعلم المزيد</a> عن سجل القراءة."
+
+#: account/reading_log.html
+msgid ""
+"There are no recent books in your feed. When you follow public accounts, "
+"their book updates will appear here."
+msgstr ""
+"لا توجد كتب جديدة في تغذيتك. عندما تتبع حسابات عامة، ستظهر تحديثات الكتب الخاصة بهم هنا."
+
+#: account/readinglog_shelf_name.html
+msgid "Want To Read"
+msgstr "قائمة القراءة"
+
+#: account/readinglog_stats.html
+#, python-format
+msgid "My %(shelf_name)s Stats"
+msgstr "إحصائيات %(shelf_name)s الخاصة بي"
+
+#: account/readinglog_stats.html lib/nav_head.html
+msgid "My Books"
+msgstr "كتبي"
+
+#: account/readinglog_stats.html
+#, python-format
+msgid ""
+"Displaying stats about <strong>%(works_count)d</strong> books. Note all "
+"charts show only the top 20 bars. Note reading log stats are private."
+msgstr ""
+"عرض الإحصائيات حول <strong>%(works_count)d</strong> كتب. لاحظ أن جميع الرسوم البيانية تعرض فقط أعلى 20 شريطًا. لاحظ أن إحصائيات سجل القراءة خاصة."
+
+#: account/readinglog_stats.html
+msgid "Author Stats"
+msgstr "إحصائيات المؤلفين"
+
+#: account/readinglog_stats.html
+msgid "Most Read Authors"
+msgstr "أكثر المؤلفين قراءة"
+
+#: account/readinglog_stats.html
+msgid "Works by Author Sex"
+msgstr "أعمال حسب جنس المؤلفين"
+
+#: account/readinglog_stats.html
+msgid "Works by Author Country of Citizenship"
+msgstr "أعمال حسب جنسية المؤلفين"
+
+#: account/readinglog_stats.html
+msgid "Works by Author Country of Birth"
+msgstr "أعمال حسب بلد ميلاد المؤلفين"
+
+#: account/readinglog_stats.html
+#, fuzzy
+msgid ""
+"Demographic statistics powered by <a "
+"href=\"https://www.wikidata.org/\">Wikidata</a>. Here's a <a id=\"wd-"
+"query-sample\" href=\"\">sample</a> of the query used. <br />Improve "
+"these stats by adding the Wikidata author identifier following <a "
+"href=\"https://openlibrary.org/help/faq/editing.en#author-identifiers-"
+"purpose\">these instructions</a>."
+msgstr ""
+"الإحصاءات السكانية مدعومة من <a "
+"href=\"https://www.wikidata.org/\">Wikidata</a>. إليك <a id=\"wd-query-sample\" href=\"\">عينة</a> من الاستعلام المستخدم. <br />حسن هذه الإحصاءات بإضافة معرّف مؤلف Wikidata باتباع <a "
+"href=\"https://openlibrary.org/help/faq/editing.en#author-identifiers-purpose\">هذه التعليمات</a>."
+
+#: account/readinglog_stats.html
+msgid "Work Stats"
+msgstr "إحصاءات الأعمال"
+
+#: account/readinglog_stats.html
+msgid "Works by Subject"
+msgstr "أعمال حسب الموضوع"
+
+#: account/readinglog_stats.html
+msgid "Works by People"
+msgstr "أعمال حسب الأشخاص"
+
+#: account/readinglog_stats.html
+msgid "Works by Places"
+msgstr "أعمال حسب الأماكن"
+
+#: account/readinglog_stats.html
+msgid "Works by Time Period"
+msgstr "أعمال حسب الفترة الزمنية"
+
+#: account/readinglog_stats.html
+msgid "Matching works"
+msgstr "أعمال مطابقة"
+
+#: account/readinglog_stats.html
+msgid "Click on a bar to see matching works"
+msgstr "انقر على شريط لرؤية الأعمال المطابقة"
+
+#: account/sidebar.html books/mybooks_breadcrumb_select.html mybooks.py
+msgid "My Feed"
+msgstr "تغذيتي"
+
+#: account/sidebar.html search/sort_options.html type/user/view.html
+msgid "Reading Log"
+msgstr "سجل القراءة"
+
+#: account/sidebar.html
+msgid "Sponsoring"
+msgstr "رعاية"
+
+#: account/sidebar.html
+msgid "My lists"
+msgstr "قوائمي"
+
+#: EditionNavBar.html SearchNavigation.html account/sidebar.html
+#: lib/nav_head.html lists/home.html lists/widget.html recentchanges/index.html
+#: type/edition/view.html type/list/embed.html type/list/view_body.html
+#: type/user/view.html type/work/view.html
+msgid "Lists"
+msgstr "قوائم"
+
+#: account/sidebar.html type/edition/view.html type/user/view.html
+#: type/work/view.html
+msgid "See All"
+msgstr "عرض الكل"
+
+#: account/sidebar.html type/list/edit.html
+msgid "Create a list"
+msgstr "إنشاء قائمة جديدة"
+
+#: account/topmenu.html
+msgid "Import & Export"
+msgstr "استيراد وتصدير"
+
+#: account/topmenu.html
+#, python-format
+msgid "Privacy settings: %(public)s"
+msgstr "إعدادات الخصوصية: %(public)s"
+
+#: account/verify.html
+msgid "Verification email sent"
+msgstr "تم إرسال بريد التحقق"
+
+#: account.py account/password/reset_success.html account/verify.html
+#: account/verify/activated.html account/verify/success.html
+#, python-format
+msgid "Hi, %(user)s"
+msgstr "مرحبًا، %(user)s"
+
+#: account/verify.html
+#, python-format
+msgid ""
+"We’ve sent an email to %(email)s containing a link to verify your "
+"account. Click/tap on the link to finish creating your Internet Archive "
+"account."
+msgstr ""
+"لقد أرسلنا بريدًا إلكترونيًا إلى %(email)s يحتوي على رابط للتحقق من حسابك. انقر/اضغط على الرابط لإنهاء إنشاء حسابك في الأرشيف الرقمي."
+
+#: account/verify.html
+msgid "Then, come back to Open Library and find some great books!"
+msgstr "ثم عد إلى Open Library وابحث عن بعض الكتب الرائعة!"
+
+#: account/view.html books/mybooks_breadcrumb_select.html
+msgid "Following"
+msgstr "المتابعين"
+
+#: account/view.html books/mybooks_breadcrumb_select.html
+msgid "Followers"
+msgstr "المتابعين"
+
+#: account/view.html type/edition/modal_links.html
+#: type/edition/title_and_author.html
+msgid "Share"
+msgstr "مشاركة"
+
+#: account/view.html
+msgid "Your book notes are private and cannot be viewed by other patrons."
+msgstr ""
+"ملاحظاتك على الكتب خاصة ولا يمكن مشاهدتها من قبل المستخدمين الآخرين."
+
+#: account/view.html
+msgid "Your book reviews will be shared anonymously with other patrons."
+msgstr "ستتم مشاركة مراجعاتك للكتب بشكل مجهول مع المستخدمين الآخرين."
+
+#: account/yrg_banner.html
+#, python-format
+msgid "Set your %(year)s Yearly Reading Goal:"
+msgstr "حدد هدفك السنوي للقراءة في %(year)s:"
+
+#: account/yrg_banner.html
+msgid "Set my goal"
+msgstr "تحديد هدفي"
+
+#: account/email/forgot-ia.html account/email/forgot.html
+msgid "Forgot Your Internet Archive Email?"
+msgstr "هل نسيت بريدك الإلكتروني في الأرشيف الرقمي؟"
+
+#: account/email/forgot-ia.html
+msgid ""
+"Please enter your Open Library email and password, and we’ll retrieve "
+"your Archive.org email."
+msgstr ""
+"يرجى إدخال بريدك الإلكتروني في المكتبة المفتوحة وكلمة المرور، وسنسترجع بريدك الإلكتروني في Archive.org."
+
+#: account/email/forgot-ia.html
+msgid "Your email is:"
+msgstr "بريدك الإلكتروني هو:"
+
+#: account/email/forgot-ia.html
+msgid "Return to Log In?"
+msgstr "العودة إلى تسجيل الدخول؟"
+
+#: account/email/forgot-ia.html
+msgid "Open Library Email"
+msgstr "بريد Open Library الإلكتروني"
+
+#: account/email/forgot-ia.html
+msgid "Retrieve Archive.org Email"
+msgstr "استرجاع بريد Archive.org الإلكتروني"
+
+#: account/email/forgot-ia.html account/password/forgot.html
+msgid "Forgot your Archive.org Password?"
+msgstr "نسيت كلمة مرور Archive.org؟"
+
+#: account/email/forgot.html
+msgid "Forgot Your Open Library Email?"
+msgstr "هل نسيت بريدك الإلكتروني في Open Library؟"
+
+#: account/password/forgot.html account/password/sent.html
+msgid "Username/Password Reminder"
+msgstr "تذكير باسم المستخدم/كلمة المرور"
+
+#: account/password/forgot.html
+msgid "Click here."
+msgstr "انقر هنا."
+
+#: account/password/forgot.html
+msgid "Send It"
+msgstr "إرساله"
+
+#: account/password/reset.html admin/people/view.html
+msgid "Reset Password"
+msgstr "إعادة تعيين كلمة المرور"
+
+#: account/password/reset.html
+msgid "Please enter a new password for your Open Library account."
+msgstr "يرجى إدخال كلمة مرور جديدة لحسابك في Open Library."
+
+#: account/password/reset.html
+msgid "Reset"
+msgstr "إعادة تعيين"
+
+#: account/password/reset_success.html
+msgid "Password Reset Successful"
+msgstr "تمت إعادة تعيين كلمة المرور بنجاح"
+
+#: account/password/reset_success.html
+msgid ""
+"Your password has been updated. Please <a "
+"href='/account/login?redirect=/'>log in to continue</a>."
+msgstr ""
+"تم تحديث كلمة المرور الخاصة بك. يرجى <a "
+"href='/account/login?redirect=/'>تسجيل الدخول للاستمرار</a>."
+
+#: account/password/sent.html
+msgid "Done."
+msgstr "تم."
+
+#: account/password/sent.html
+#, python-format
+msgid ""
+"We've sent an email to %(email)s with a reminder of your username and "
+"instructions to help you reset your Open Library password. Please check "
+"your inbox for a note from us."
+msgstr ""
+"لقد أرسلنا بريدًا إلكترونيًا إلى %(email)s يتضمن تذكيرًا باسم المستخدم الخاص بك وتعليمات لمساعدتك في إعادة تعيين كلمة مرور Open Library الخاصة بك. يرجى التحقق من صندوق الوارد الخاص بك للحصول على رسالة منا."
+
+#: account/verify/activated.html
+msgid "Account already activated"
+msgstr "تم تفعيل الحساب بالفعل"
+
+#: account/verify/activated.html
+#, python-format
+msgid ""
+"Your account has been activated already. Please <a href=\"%s\">log in to "
+"continue</a>."
+msgstr ""
+"تم تفعيل حسابك بالفعل. يرجى <a href=\"%s\">تسجيل الدخول للاستمرار</a>."
+
+#: account/verify/failed.html
+msgid "Email Verification Failed"
+msgstr "فشل التحقق من البريد الإلكتروني"
+
+#: account/verify/failed.html
+msgid ""
+"Your email address couldn't be verified. Your verification link seems "
+"invalid or expired."
+msgstr ""
+"لم يتمكن التحقق من عنوان بريدك الإلكتروني. يبدو أن رابط التحقق غير صالح أو منتهي الصلاحية."
+
+#: account/verify/failed.html
+msgid "Fill your email and hit this button to resend a fresh verification email:"
+msgstr ""
+"أدخل بريدك الإلكتروني واضغط على هذه الزر لإعادة إرسال بريد تحقق جديد:"
+
+#: account/verify/failed.html
+msgid "Enter your email address here"
+msgstr "أدخل عنوان بريدك الإلكتروني هنا"
+
+#: account/verify/failed.html
+msgid "No user registered with this email address."
+msgstr "لا يوجد مستخدم مسجل بهذا العنوان الإلكتروني."
+
+#: account/verify/success.html
+msgid "Email Verification Successful"
+msgstr "تم التحقق من البريد الإلكتروني بنجاح"
+
+#: account/verify/success.html
+#, python-format
+msgid ""
+"Yay! Your email address has been verified. Please <a href='%s'>log in to "
+"continue</a>."
+msgstr ""
+"رائع! تم التحقق من عنوان بريدك الإلكتروني. يرجى <a href='%s'>تسجيل الدخول للاستمرار</a>."
+
+#: admin/attach_debugger.html
+msgid "Waiting for debugger to attach..."
+msgstr "في انتظار توصيل المصحح..."
+
+#: admin/attach_debugger.html
+msgid "Start"
+msgstr "بدء"
+
+#: admin/imports-add.html admin/menu.html
+msgid "Imports"
+msgstr "الاستيراد"
+
+#: admin/imports-add.html books/add.html books/edit/edition.html
+#: books/edit/excerpts.html covers/change.html tag/add.html
+msgid "Add"
+msgstr "إضافة"
+
+#: admin/imports-add.html
+msgid "Add new books to import queue"
+msgstr "إضافة كتب جديدة إلى قائمة الاستيراد"
+
+#: admin/imports-add.html
+msgid "Please add IA identifiers to be imported, one per line."
+msgstr "يرجى إضافة معرّفات IA التي ترغب في استيرادها، واحدة في كل سطر."
+
+#: admin/imports-add.html admin/ip/view.html admin/people/edits.html
+#: admin/permissions.html check_ins/check_in_form.html
+#: check_ins/reading_goal_form.html covers/add.html
+msgid "Submit"
+msgstr "إرسال"
+
+#: admin/index.html
+msgid "Stats"
+msgstr "إحصاءات"
+
+#: admin/index.html
+msgid "Edits Per Day"
+msgstr "تعديلات يومية"
+
+#: admin/index.html admin/people/index.html
+msgid "Edits"
+msgstr "تعديلات"
+
+#: admin/index.html
+msgid "Yesterday"
+msgstr "أمس"
+
+#: admin/index.html
+msgid "Last 7 days"
+msgstr "آخر 7 أيام"
+
+#: admin/index.html
+msgid "Last 28 days"
+msgstr "آخر 28 يومًا"
+
+#: admin/index.html
+msgid "Human"
+msgstr "بشري"
+
+#: admin/index.html admin/people/view.html
+msgid "Bot"
+msgstr "روبوت"
+
+#: admin/index.html
+msgid "Total"
+msgstr "إجمالي"
+
+#: admin/index.html
+msgid "New Accounts Per Day"
+msgstr "حسابات جديدة يوميًا"
+
+#: admin/index.html
+msgid "Members"
+msgstr "أعضاء"
+
+#: admin/index.html
+msgid "Items Added"
+msgstr "عناصر مضافة"
+
+# | msgid "Added"
+#: admin/index.html
+msgid "Works Added"
+msgstr "أعمال مضافة"
+
+#: admin/index.html
+msgid "Editions Added"
+msgstr "إصدارات مضافة"
+
+#: admin/index.html
+msgid "Authors Added"
+msgstr "مؤلفون مضافون"
+
+#: admin/index.html recentchanges/index.html
+msgid "Covers Added"
+msgstr "أغلفة مضافة"
+
+#: admin/index.html home/stats.html
+msgid "New Members"
+msgstr "أعضاء جدد"
+
+#: admin/index.html
+msgid "Lists Added"
+msgstr "قوائم مضافة"
+
+#: admin/index.html
+msgid "Books Logged"
+msgstr "كتب مسجلة"
+
+#: admin/index.html
+msgid "Users Logging"
+msgstr "المستخدمون المسجلون"
+
+#: admin/index.html
+msgid "Books Review Tags"
+msgstr "علامات مراجعات الكتب"
+
+#: admin/index.html
+msgid "Books Reviewed"
+msgstr "كتب تمت مراجعتها"
+
+#: admin/index.html
+msgid "Users Reviewing"
+msgstr "المراجعين"
+
+#: admin/index.html
+msgid "Notes Created"
+msgstr "ملاحظات مضافة"
+
+#: admin/index.html
+msgid "Patrons Creating Notes"
+msgstr "المستخدمون الذين يضيفون ملاحظات"
+
+#: admin/index.html
+msgid "Books Starred"
+msgstr "كتب مميزة"
+
+#: admin/index.html
+msgid "Star Rating Patrons"
+msgstr "المستخدمون الذين يقيّمون الكتب"
+
+#: admin/index.html home/stats.html
+msgid "Unique Visitors"
+msgstr "زوار فريدون"
+
+#: admin/index.html
+msgid "Unique visitors IPs per day graph"
+msgstr "رسم بياني لعنوان IP للزوار الفريدين يوميًا"
+
+#: admin/index.html
+msgid "Borrows"
+msgstr "استعارات"
+
+#: admin/index.html
+msgid "Borrows, last 3 months graph"
+msgstr "استعارات، رسم بياني لآخر 3 أشهر"
+
+#: admin/index.html
+msgid "Borrows, last 2 years graph"
+msgstr "استعارات، رسم بياني لآخر سنتين"
+
+#: admin/loans_table.html
+msgid "BookReader"
+msgstr "قارئ الكتب"
+
+#: admin/loans_table.html book_providers/ia_download_options.html
+#: book_providers/openstax_download_options.html books/edit/edition.html
+msgid "PDF"
+msgstr "PDF"
+
+#: admin/loans_table.html book_providers/gutenberg_download_options.html
+#: book_providers/ia_download_options.html
+#: book_providers/standard_ebooks_download_options.html books/edit/edition.html
+msgid "ePub"
+msgstr "ePub"
+
+#: admin/loans_table.html
+#, python-format
+msgid "%d Current Loan"
+msgid_plural "%d Current Loans"
+msgstr[0] "%d كتاب مستعار حاليًا"
+msgstr[1] "%d كتب مستعارة حاليًا"
+
+#: RecentChanges.html RecentChangesUsers.html admin/ip/view.html
+#: admin/loans_table.html admin/people/edits.html recentchanges/render.html
+#: recentchanges/updated_records.html
+msgid "What"
+msgstr "ماذا"
+
+#: admin/menu.html
+msgid "Admin Center"
+msgstr "مركز الإدارة"
+
+#: admin/menu.html
+msgid "Sponsorship"
+msgstr "رعاية"
+
+#: account.py admin/menu.html admin/people/view.html
+#: books/mybooks_breadcrumb_select.html type/user/view.html
+msgid "Loans"
+msgstr "استعارات"
+
+#: admin/menu.html
+msgid "Waiting Lists"
+msgstr "قوائم الانتظار"
+
+#: admin/menu.html
+msgid "Block IPs"
+msgstr "حظر عناوين IP"
+
+#: admin/menu.html
+msgid "Spam Words"
+msgstr "كلمات عشوائية"
+
+#: admin/menu.html
+msgid "Solr"
+msgstr "Solr"
+
+#: admin/menu.html
+msgid "Graphs"
+msgstr "رسوم بيانية"
+
+#: admin/menu.html
+msgid "Inspect store"
+msgstr "فحص التخزين"
+
+#: admin/menu.html
+msgid "Inspect memcache"
+msgstr "فحص الذاكرة المؤقتة"
+
+#: admin/permissions.html
+msgid "Site Permissions"
+msgstr "أذونات الموقع"
+
+#: admin/permissions.html
+msgid "Change the policy of who can edit the site."
+msgstr "تغيير سياسة من يمكنه تحرير الموقع."
+
+#: admin/permissions.html
+msgid "Who can edit Open Library records?"
+msgstr "من يمكنه تحرير سجلات Open Library؟"
+
+#: admin/permissions.html
+msgid "This applies to /authors/*, /books/* and /works/* records."
+msgstr "يطبق هذا على سجلات /authors/* و /books/* و /works/*."
+
+#: admin/permissions.html
+msgid "Who can edit Open Library pages?"
+msgstr "من يمكنه تحرير صفحات Open Library؟"
+
+#: admin/permissions.html
+msgid "This applies to /about/*, /help/*, /dev/*, /docs/* etc."
+msgstr "يطبق هذا على /about/* و /help/* و /dev/* و /docs/*."
+
+#: admin/permissions.html
+msgid "Update permissions"
+msgstr "تحديث الأذونات"
+
+#: admin/permissions.html
+msgid ""
+"This updates and fields of /, /works, /books and /authors records in "
+"the database."
+msgstr ""
+"يقوم هذا بتحديث الحقول في سجلات / و /works و /books و /authors في قاعدة البيانات."
+
+#: admin/solr.html
+msgid "Enter the keys to reindex in Solr"
+msgstr "أدخل المفاتيح لإعادة الفهرسة في Solr"
+
+#: admin/solr.html
+msgid "Write one entry per line"
+msgstr "اكتب إدخالًا واحدًا في كل سطر"
+
+#: admin/solr.html
+msgid "Update"
+msgstr "تحديث"
+
+#: FormatExpiry.html admin/waitinglists.html
+msgid "Expires"
+msgstr "تاريخ الانتهاء"
+
+#: admin/waitinglists.html
+msgid "Loan Status"
+msgstr "حالة الاستعارة"
+
+#: admin/ip/index.html
+msgid "List of Banned IPs"
+msgstr "قائمة العناوين المحظورة"
+
+#: admin/ip/index.html admin/people/index.html
+msgid "Date/Time"
+msgstr "تاريخ/وقت"
+
+#: admin/ip/index.html
+msgid "IP address"
+msgstr "عنوان IP"
+
+#: admin/ip/index.html
+msgid "# of edits"
+msgstr "عدد التعديلات"
+
+#: admin/ip/view.html
+msgid "IP"
+msgstr "IP"
+
+#: admin/ip/view.html
+#, python-format
+msgid "IP %(ip)s is <a href=\"/admin/block\">blocked</a>."
+msgstr "عنوان IP %(ip)s هو <a href=\"/admin/block\">محظور</a>."
+
+#: admin/ip/view.html
+#, python-format
+msgid "Block %(ip)s"
+msgstr "حظر %(ip)s"
+
+#: admin/ip/view.html admin/people/edits.html
+msgid "Please select the changesets to revert."
+msgstr "يرجى تحديد مجموعات التغييرات التي تريد التراجع عنها."
+
+#: RecentChanges.html admin/ip/view.html admin/people/edits.html
+#: recentchanges/render.html
+msgid "When you see numbers here, that's the IP address of the anonymous editor"
+msgstr "عندما ترى أرقام هنا، فإنها عنوان IP للمحرر المجهول"
+
+#: admin/ip/view.html admin/people/edits.html
+#, python-format
+msgid "Reverted by %(revert_author)s"
+msgstr "تم التراجع بواسطة %(revert_author)s"
+
+#: EditButtons.html admin/ip/view.html admin/people/edits.html
+msgid ""
+"Please, leave a short note about what you changed: <span class=\"small "
+"gray\">(Optional, but very useful!)</span>"
+msgstr ""
+"يرجى ترك ملاحظة قصيرة حول ما قمت بتغييره: <span class=\"small "
+"gray\">(اختياري، ولكن مفيد جدًا!)</span>"
+
+#: admin/ip/view.html admin/people/edits.html
+msgid "Reverted spam"
+msgstr "تم التراجع عن البريد المزعج"
+
+#: admin/people/edits.html
+msgid "people"
+msgstr "أشخاص"
+
+#: admin/people/edits.html
+msgid "edits"
+msgstr "تعديلات"
+
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
+#: admin/people/edits.html recentchanges/render.html
+msgid "Older"
+msgstr "أقدم"
+
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
+#: admin/people/edits.html recentchanges/render.html
+msgid "Newer"
+msgstr "أحدث"
+
+#: admin/people/index.html
+msgid "Find Account"
+msgstr "ابحث عن حساب"
+
+#: admin/people/index.html admin/people/view.html
+msgid "Email Address:"
+msgstr "عنوان البريد الإلكتروني:"
+
+#: admin/people/index.html
+msgid "IA ID:"
+msgstr "معرّف IA:"
+
+#: admin/people/index.html
+msgid "Find"
+msgstr "بحث"
+
+#: admin/people/index.html
+msgid "No account found with this ID."
+msgstr "لم يتم العثور على حساب بهذا المعرّف."
+
+#: admin/people/index.html
+msgid "Recent Accounts"
+msgstr "الحسابات الأخيرة"
+
+#: admin/people/index.html type/author/edit.html type/language/view.html
+msgid "Name"
+msgstr "الاسم"
+
+#: admin/people/index.html
+msgid "email"
+msgstr "البريد الإلكتروني"
+
+#: admin/people/index.html admin/people/view.html
+msgid "Edit History"
+msgstr "تاريخ التعديلات"
+
+#: CreateListModal.html admin/people/view.html my_books/dropdown_content.html
+msgid "Name:"
+msgstr "الاسم:"
+
+#: admin/people/view.html
+msgid "Admin"
+msgstr "مشرف"
+
+#: admin/people/view.html
+msgid "# Edits"
+msgstr "# تعديلات"
+
+#: admin/people/view.html
+msgid "Member Since:"
+msgstr "عضو منذ:"
+
+#: admin/people/view.html
+msgid "Last Login:"
+msgstr "آخر تسجيل دخول:"
+
+#: admin/people/view.html
+msgid "Tags:"
+msgstr "العلامات:"
+
+#: admin/people/view.html
+msgid "Anonymize Account:"
+msgstr "إخفاء الهوية الحساب:"
+
+#: admin/people/view.html
+msgid "Anonymize Account"
+msgstr "إخفاء الهوية الحساب"
+
+#: admin/people/view.html
+msgid "Waiting Loans"
+msgstr "الاستعارات المعلقة"
+
+#: admin/people/view.html
+msgid "Debug Info"
+msgstr "معلومات تصحيح الأخطاء"
+
+#: SearchNavigation.html authors/index.html lib/nav_foot.html
+#: merge/authors.html publishers/view.html
+msgid "Authors"
+msgstr "مؤلفون"
+
+#: authors/index.html
+msgid "Search for an Author"
+msgstr "ابحث عن مؤلف"
+
+#: authors/index.html search/authors.html
+#, python-format
+msgid "about %(subjects)s"
+msgstr "عن %(subjects)s"
+
+#: authors/index.html search/authors.html
+#, python-format
+msgid "including <i>%(topwork)s</i>"
+msgstr "بما في ذلك <i>%(topwork)s</i>"
+
+#: authors/infobox.html
+msgid "Born"
+msgstr "ولد"
+
+#: authors/infobox.html
+msgid "Died"
+msgstr "توفي"
+
+#: authors/infobox.html type/author/edit.html
+msgid "Date"
+msgstr "تاريخ"
+
+#: book_providers/gutenberg_download_options.html
+#: book_providers/ia_download_options.html
+#: book_providers/librivox_download_options.html
+#: book_providers/openstax_download_options.html
+#: book_providers/standard_ebooks_download_options.html
+msgid "Download Options"
+msgstr "خيارات التنزيل"
+
+#: book_providers/gutenberg_download_options.html
+msgid "Download an HTML from Project Gutenberg"
+msgstr "تحميل HTML من مشروع جوتنبرج"
+
+#: book_providers/gutenberg_download_options.html
+#: book_providers/standard_ebooks_download_options.html
+msgid "HTML"
+msgstr "HTML"
+
+#: book_providers/gutenberg_download_options.html
+msgid "Download a text version from Project Gutenberg"
+msgstr "تحميل نسخة نصية من مشروع جوتنبرج"
+
+#: book_providers/gutenberg_download_options.html
+#: book_providers/ia_download_options.html
+msgid "Plain text"
+msgstr "نص عادي"
+
+#: book_providers/gutenberg_download_options.html
+msgid "Download an ePub from Project Gutenberg"
+msgstr "تحميل ePub من مشروع جوتنبرج"
+
+#: book_providers/gutenberg_download_options.html
+msgid "Download a Kindle file from Project Gutenberg"
+msgstr "تحميل ملف كيندل من مشروع جوتنبرج"
+
+#: book_providers/gutenberg_download_options.html
+msgid "Kindle"
+msgstr "كيندل"
+
+#: book_providers/gutenberg_download_options.html
+msgid "More at Project Gutenberg"
+msgstr "المزيد على مشروع جوتنبرج"
+
+#: book_providers/gutenberg_read_button.html
+msgid "Read eBook from Project Gutenberg"
+msgstr "اقرأ كتاب إلكتروني من مشروع جوتنبرج"
+
+#: book_providers/gutenberg_read_button.html
+msgid ""
+"This book is available from <a "
+"href=\"https://www.gutenberg.org/\">Project Gutenberg</a>. Project "
+"Gutenberg is a trusted book provider of classic ebooks, supporting "
+"thousands of volunteers in the creation and distribution of over 60,000 "
+"free eBooks."
+msgstr ""
+"هذا الكتاب متوفر على <a href=\"https://www.gutenberg.org/\">مشروع جوتنبرج</a>. "
+"مشروع جوتنبرج هو مزود موثوق للكتب الكلاسيكية بصيغة eBook، ويدعم آلاف المتطوعين في "
+"إنشاء وتوزيع أكثر من 60,000 eBook مجانية."
+
+#: book_providers/gutenberg_read_button.html
+#: book_providers/librivox_read_button.html
+#: book_providers/openstax_read_button.html
+#: book_providers/standard_ebooks_read_button.html
+#: check_ins/reading_goal_progress.html
+msgid "Learn more"
+msgstr "تعرف على المزيد"
+
+#: book_providers/ia_download_options.html
+msgid "Download a PDF from Internet Archive"
+msgstr "تحميل PDF من أرشيف الإنترنت"
+
+#: book_providers/ia_download_options.html
+msgid "Download a text version from Internet Archive"
+msgstr "تحميل نسخة نصية من أرشيف الإنترنت"
+
+#: book_providers/ia_download_options.html
+msgid "Download an ePub from Internet Archive"
+msgstr "تحميل كتاب إلكتروني من أرشيف الإنترنت"
+
+#: book_providers/ia_download_options.html
+msgid "Download a MOBI file from Internet Archive"
+msgstr "تحميل ملف MOBI من أرشيف الإنترنت"
+
+#: book_providers/ia_download_options.html
+msgid "MOBI"
+msgstr "MOBI"
+
+#: book_providers/ia_download_options.html
+msgid "Download open DAISY from Internet Archive (print-disabled format)"
+msgstr "تحميل DAISY مفتوح من أرشيف الإنترنت (تنسيق معطل للطباعة)"
+
+#: book_providers/ia_download_options.html type/list/embed.html
+msgid "DAISY"
+msgstr "DAISY"
+
+#: book_providers/librivox_download_options.html
+msgid "Download a ZIP file of the whole book from Internet Archive"
+msgstr "تحميل ملف ZIP للكتاب الكامل من أرشيف الإنترنت"
+
+#: book_providers/librivox_download_options.html
+msgid "Whole Book MP3"
+msgstr "الكتاب الكامل بصيغة MP3"
+
+#: book_providers/librivox_download_options.html
+msgid "Get the RSS Feed from LibriVox"
+msgstr "احصل على RSS Feed من LibriVox"
+
+#: book_providers/librivox_download_options.html
+msgid "RSS Feed"
+msgstr "RSS Feed"
+
+#: book_providers/librivox_download_options.html
+msgid "More at LibriVox"
+msgstr "المزيد على LibriVox"
+
+#: book_providers/librivox_read_button.html
+msgid "Listen to a reading from LibriVox"
+msgstr "استمع إلى قراءة من LibriVox"
+
+#: book_providers/librivox_read_button.html
+msgid "Audiobook"
+msgstr "كتاب صوتي"
+
+#: book_providers/librivox_read_button.html
+msgid ""
+"This book is available from <a "
+"href=\"https://librivox.org/\">LibriVox</a>. LibriVox is a trusted book "
+"provider of public domain audiobooks, narrated by volunteers, distributed"
+" for free on the internet."
+msgstr ""
+"هذا الكتاب متاح على <a href=\"https://librivox.org/\">LibriVox</a>. "
+"LibriVox هو مزود موثوق للكتب الصوتية في المجال العام، يتم سردها بواسطة "
+"متطوعين، وتوزع مجانًا على الإنترنت."
+
+#: book_providers/openstax_download_options.html
+msgid "Download PDF from OpenStax"
+msgstr "تحميل PDF من OpenStax"
+
+#: book_providers/openstax_download_options.html
+msgid "More at OpenStax"
+msgstr "المزيد على OpenStax"
+
+#: book_providers/openstax_read_button.html
+msgid "Read eBook from OpenStax"
+msgstr "اقرأ eBook من OpenStax"
+
+#: book_providers/openstax_read_button.html
+msgid ""
+"This book is available from <a "
+"href=\"https://www.openstax.org/\">OpenStax</a>. OpenStax is a trusted "
+"book provider and a 501(c)(3) nonprofit charitable corporation dedicated "
+"to providing free high-quality, peer-reviewed, openly licensed textbooks "
+"online."
+msgstr ""
+"هذا الكتاب متاح على <a href=\"https://www.openstax.org/\">OpenStax</a>. "
+"OpenStax هو مزود موثوق للكتب وهو مؤسسة غير ربحية 501(c)(3) مكرسة لتقديم "
+"كتب مدرسية مجانية وعالية الجودة، تمت مراجعتها من قبل الأقران، ومرخصة "
+"بشكل مفتوح على الإنترنت."
+
+#: book_providers/standard_ebooks_download_options.html
+msgid "Download an HTML from Standard Ebooks"
+msgstr "تحميل HTML من Standard Ebooks"
+
+#: book_providers/standard_ebooks_download_options.html
+msgid "Download an ePub from Standard Ebook."
+msgstr "تحميل ePub من Standard Ebooks."
+
+#: book_providers/standard_ebooks_download_options.html
+msgid "Download a Kindle file from Standard Ebooks"
+msgstr "تحميل ملف Kindle من Standard Ebooks"
+
+#: book_providers/standard_ebooks_download_options.html
+msgid "Kindle (azw3)"
+msgstr "كيندل (azw3)"
+
+#: book_providers/standard_ebooks_download_options.html
+msgid "Download a Kobo file from Standard Ebooks"
+msgstr "تحميل ملف Kobo من Standard Ebooks"
+
+#: book_providers/standard_ebooks_download_options.html
+msgid "Kobo (kepub)"
+msgstr "Kobo (kepub)"
+
+#: book_providers/standard_ebooks_download_options.html
+msgid "View the source code for this Standard Ebook at GitHub"
+msgstr "عرض الشيفرة المصدرية لهذا الكتاب القياسي على GitHub"
+
+#: Subnavigation.html book_providers/standard_ebooks_download_options.html
+msgid "Source Code"
+msgstr "الشيفرة المصدرية"
+
+#: book_providers/standard_ebooks_download_options.html
+msgid "More at Standard Ebooks"
+msgstr "المزيد على Standard Ebooks"
+
+#: book_providers/standard_ebooks_read_button.html
+msgid "Read eBook from Standard eBooks"
+msgstr "اقرأ كتاباً إلكترونياً من Standard eBooks"
+
+#: book_providers/standard_ebooks_read_button.html
+msgid ""
+"This book is available from <a "
+"href=\"https://standardebooks.org/\">Standard Ebooks</a>. Standard Ebooks"
+" is a trusted book provider and a volunteer-driven project that produces "
+"new editions of public domain ebooks that are lovingly formatted, open "
+"source, free of copyright restrictions, and free of cost."
+msgstr ""
+"هذا الكتاب متاح على <a href=\"https://standardebooks.org/\">Standard "
+"Ebooks</a>. Standard Ebooks هو مزود موثوق للكتب ومشروع مدفوع من قبل "
+"المتطوعين يقوم بإنتاج إصدارات جديدة من الكتب الإلكترونية في المجال العام"
+" التي تم تنسيقها بعناية، مفتوحة المصدر، خالية من قيود حقوق النشر، ومجانية."
+
+#: books/RelatedWorksCarousel.html
+msgid "You might also like"
+msgstr "قد تعجبك أيضًا"
+
+#: books/RelatedWorksCarousel.html
+msgid "More by this author"
+msgid_plural "More by these authors"
+msgstr[0] "المزيد من هذا المؤلف"
+msgstr[1] "المزيد من هؤلاء المؤلفين"
+
+#: books/add.html books/check.html
+msgid "Add a book"
+msgstr "أضف كتابًا"
+
+#: books/add.html
+msgid "Invalid ISBN checksum digit"
+msgstr "رقم التحقق ISBN غير صحيح"
+
+#: books/add.html
+msgid ""
+"ID must be exactly 10 characters [0-9 or X]. For example 0-19-853453-1 or"
+" 0198534531"
+msgstr ""
+"يجب أن يكون المعرّف مكونًا من 10 أحرف بالضبط [0-9 أو X]. على سبيل المثال 0-19-853453-1 أو "
+"0198534531"
+
+#: books/add.html
+msgid ""
+"ID must be exactly 13 characters [0-9]. For example 978-3-16-148410-0 or "
+"9783161484100"
+msgstr ""
+"يجب أن يكون المعرّف مكونًا من 13 حرفًا بالضبط [0-9]. على سبيل المثال 978-3-16-148410-0 أو "
+"9783161484100"
+
+#: books/add.html
+msgid "Invalid LC Control Number format"
+msgstr "تنسيق رقم التحكم LC غير صحيح"
+
+#: books/add.html
+msgid "Please enter a value for the selected identifier"
+msgstr "يرجى إدخال قيمة للمعرّف المحدد"
+
+#: books/add.html
+msgid "Add a book to Open Library"
+msgstr "أضف كتابًا إلى المكتبة المفتوحة"
+
+#: books/add.html tag/add.html
+msgid ""
+"We require a minimum set of fields to create a new record. These are "
+"those fields."
+msgstr ""
+"نحتاج إلى مجموعة أساسية من الحقول لإنشاء سجل جديد. وهذه هي الحقول المطلوبة."
+
+#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html
+#: search/advancedsearch.html type/about/edit.html type/page/edit.html
+#: type/template/edit.html
+msgid "Title"
+msgstr "العنوان"
+
+#: books/add.html books/edit.html
+msgid "Use <b><i>Title: Subtitle</i></b> to add a subtitle."
+msgstr ""
+"استخدم <b><i>العنوان: العنوان الفرعي</i></b> لإضافة عنوان فرعي."
+
+#: books/add.html books/edit.html tag/add.html type/author/edit.html
+#: type/tag/edit.html
+msgid "Required field"
+msgstr "حقل مطلوب"
+
+#: books/add.html
+msgid ""
+"Like, \"Agatha Christie\" or \"Jean-Paul Sartre.\" We'll also do a live "
+"check to see if we already know the author."
+msgstr "مثل، \"أجاثا كريستي\" أو \"جان بول سارتر.\" سنقوم أيضًا بالتحقق في الوقت الفعلي إذا كنا نعرف المؤلف بالفعل."
+
+#: books/add.html books/edit/edition.html
+msgid "Who is the publisher?"
+msgstr "من هو الناشر؟"
+
+#: books/add.html books/edit/edition.html
+msgid "For example"
+msgstr "على سبيل المثال"
+
+#: books/add.html books/edit/edition.html
+msgid "When was it published?"
+msgstr "متى تم نشره؟"
+
+#: books/add.html books/edit/edition.html
+msgid "You should be able to find this in the first few pages of the book."
+msgstr "يجب أن تكون قادرًا على العثور على ذلك في الصفحات الأولى من الكتاب."
+
+#: books/add.html
+msgid ""
+"And optionally, an ID number &#151; like an ISBN &#151; would be "
+"helpful..."
+msgstr "وبالإضافة إلى ذلك، قد يكون رقم معرّف &#151; مثل ISBN &#151; مفيدًا..."
+
+#: books/add.html
+msgid "ID Type"
+msgstr "نوع المعرف"
+
+#: books/add.html
+msgid "ISBN may be invalid. Click \"Add\" again to submit."
+msgstr "قد تكون ISBN غير صحيحة. اضغط على \"إضافة\" مرة أخرى لتقديمها."
+
+#: books/add.html tag/add.html
+msgid "Select"
+msgstr "اختيار"
+
+#: books/add.html books/edit/edition.html
+msgid "Book URL"
+msgstr "رابط الكتاب"
+
+#: books/add.html
+msgid "Only fill this out if this is a web book"
+msgstr "املأ هذا فقط إذا كان الكتاب على الويب"
+
+#: EditButtons.html books/add.html tag/add.html
+msgid ""
+"By saving a change to this wiki, you agree that your contribution is "
+"given freely to the world under <a "
+"href=\"https://creativecommons.org/publicdomain/zero/1.0/\" "
+"target=\"_blank\" title=\"This link to Creative Commons will open in a "
+"new window\">CC0</a>. Yippee!"
+msgstr ""
+"بمجرد حفظ تغيير في هذه الويكي، فإنك توافق على أن مساهمتك تُعطى بحرية للعالم تحت <a "
+"href=\"https://creativecommons.org/publicdomain/zero/1.0/\" "
+"target=\"_blank\" title=\"سيفتح هذا الرابط إلى Creative Commons في نافذة جديدة\">CC0</a>. ياي!"
+
+#: books/add.html
+msgid "Add this book now"
+msgstr "أضف هذا الكتاب الآن"
+
+#: books/author-autocomplete.html
+msgid "Add a new author"
+msgstr "إضافة مؤلف جديد"
+
+#: books/author-autocomplete.html
+msgid "Create a new record for"
+msgstr "إنشاء سجل جديد لـ"
+
+#: books/author-autocomplete.html
+msgid "Remove this author"
+msgstr "إزالة هذا المؤلف"
+
+#: books/author-autocomplete.html
+msgid "Add another author?"
+msgstr "هل تريد إضافة مؤلف آخر؟"
+
+#: books/check.html lib/nav_foot.html lib/nav_head.html
+msgid "Add a Book"
+msgstr "إضافة كتاب"
+
+#: books/check.html
+#, python-format
+msgid ""
+"One moment... It looks like we already have <em>some potential "
+"matches</em> for <b>%(title)s</b> by <b>%(author)s</b>."
+msgstr ""
+"لحظة من فضلك... يبدو أن لدينا بالفعل <em>بعض التطابقات المحتملة</em> لـ <b>%(title)s</b> "
+"بواسطة <b>%(author)s</b>."
+
+#: books/check.html
+msgid ""
+"Rather than creating a duplicate record, please click through the result "
+"you think best matches your book."
+msgstr ""
+"بدلاً من إنشاء سجل مكرر، يرجى النقر على النتيجة التي تعتقد أنها تتطابق مع كتابك."
+
+#: books/check.html
+msgid "Select this book"
+msgstr "حدد هذا الكتاب"
+
+#: books/check.html
+#, python-format
+msgid "First published in %(year)d"
+msgstr "نُشر لأول مرة في %(year)d"
+
+#: books/check.html
+msgid "None of these match the book I want to add."
+msgstr ""
+"لا شيء من هذه النتائج يتطابق مع الكتاب الذي أريد إضافته."
+
+#: books/check.html
+#, fuzzy
+msgid "Continue"
+msgstr "مواصلة"
+
+#: NotInLibrary.html books/custom_carousel.html
+msgid "Not in Library"
+msgstr "غير موجود في المكتبة"
+
+#: books/custom_carousel.html
+msgid "Loading..."
+msgstr "جاري التحميل..."
+
+#: books/custom_carousel.html books/mobile_carousel.html
+#, python-format
+msgid " by %(name)s"
+msgstr " بواسطة %(name)s"
+
+# | msgid "Sign Up to Open Library"
+#: books/daisy.html
+msgid "Open Library Home"
+msgstr "الصفحة الرئيسية للمكتبة المفتوحة"
+
+#: books/daisy.html
+msgid "There isn't a DAISY file available for "
+msgstr "لا توجد ملف DAISY متاح لـ "
+
+#: books/daisy.html
+msgid "This DAISY file is protected."
+msgstr "هذه DAISY محمية."
+
+#: books/daisy.html
+msgid ""
+"It can only be opened on a specialized device with a key issued by the "
+"Library of Congress."
+msgstr ""
+"يمكن فتحها فقط على جهاز متخصص باستخدام مفتاح صادر عن مكتبة الكونغرس."
+
+#: books/daisy.html
+#, fuzzy, python-format
+msgid ""
+"<a href=\"%(daisy_url)s\"><strong>Download the DAISY.zip</strong></a> for"
+" <a href=\"%(url)s\">%(title)s</a>"
+msgstr ""
+"<a href=\"%(daisy_url)s\"><strong>تحميل DAISY.zip</strong></a> لـ <a "
+"href=\"%(url)s\">%(title)s</a>"
+
+#: books/daisy.html
+msgid "Books for people who don't read print?"
+msgstr "كتب للأشخاص الذين لا يقرأون النصوص المطبوعة؟"
+
+#: books/daisy.html
+msgid ""
+"The <a href=\"//archive.org\">Internet Archive</a> is proud to be "
+"distributing over 1 million books free in a format called DAISY, designed"
+" for those of us who find it challenging to use regular printed media. "
+msgstr ""
+"الأرشيف الرقمي <a href=\"//archive.org\">Internet Archive</a> فخور بتوزيع أكثر من مليون كتاب"
+" مجانًا بصيغة DAISY، المصممة لأولئك منا الذين يجدون صعوبة في استخدام وسائل الطباعة التقليدية."
+
+#: books/daisy.html
+#, fuzzy, python-format
+msgid ""
+"There are two types of DAISYs on Open Library: <i>open</i> and "
+"<i>protected</i>. Open DAIS Ys can be read by anyone in the world on many "
+"different devices. Protected DAISYs like this one can only be opened "
+"using a key issued by the <a href=\"http://www.loc.gov/nls/\">Library of "
+"Congress NLS program</a>."
+msgstr ""
+"توجد نوعان من DAISYs في المكتبة المفتوحة: <i>مفتوح</i> و"
+"<i>محمي</i>. يمكن قراءة DAISYs المفتوحة من قبل أي شخص في العالم على العديد من "
+"الأجهزة المختلفة. DAISYs المحمية مثل هذه يمكن فتحها فقط باستخدام مفتاح صادر من <a href=\"http://www.loc.gov/nls/\">برنامج مكتبة الكونغرس NLS</a>."
+
+#: books/daisy.html
+#, fuzzy, python-format
+msgid ""
+"There are two types of DAISYs on Open Library: <i>open</i> and "
+"<i>protected</i>. Open DAISYs can be read by anyone in the world on many "
+"different devices. Protected DAISYs can only be opened using a key issued"
+" by the <a href=\"http://www.loc.gov/nls/\">Library of Congress NLS "
+"program</a>."
+msgstr ""
+"توجد نوعان من DAISYs في المكتبة المفتوحة: <i>مفتوح</i> و"
+"<i>محمي</i>. يمكن قراءة DAISYs المفتوحة من قبل أي شخص في العالم على العديد من "
+"الأجهزة المختلفة. DAISYs المحمية يمكن فتحها فقط باستخدام مفتاح صادر من <a href=\"http://www.loc.gov/nls/\">برنامج مكتبة الكونغرس NLS</a>."
+
+#: books/daisy.html lists/home.html
+msgid "Enjoy!"
+msgstr "استمتع!"
+
+#: books/daisy.html
+msgid "What is the DAISY format?"
+msgstr "ما هو تنسيق DAISY؟"
+
+#: books/daisy.html
+msgid ""
+"The DAISY digital format helps people who have challenges using regular "
+"printed media. DAISY digital <span class=\"highlight\">talking "
+"books</span> offer the benefits of regular audiobooks, with navigation "
+"within the book, to chapters or specific pages."
+msgstr ""
+"تنسيق DAISY الرقمي يساعد الأشخاص الذين يواجهون صعوبات في استخدام الوسائط المطبوعة التقليدية. "
+"كتب DAISY الرقمية <span class=\"highlight\">الصوتية</span> تقدم مزايا الكتب الصوتية التقليدية، مع إمكانية "
+"التنقل داخل الكتاب، إلى فصول أو صفحات محددة."
+
+#: books/daisy.html
+msgid "More information at daisy.org"
+msgstr "مزيد من المعلومات على daisy.org"
+
+#: books/daisy.html
+msgid "What is the NLS?"
+msgstr "ما هو NLS؟"
+
+#: books/daisy.html
+msgid ""
+"The Library of Congress <a href=\"http://www.loc.gov/nls/\">National "
+"Library Service for the Blind and Physically Handicapped (NLS)</a> "
+"administers a free library program of braille and audio materials "
+"circulated to eligible borrowers in the United States through a national "
+"network of cooperating libraries."
+msgstr ""
+"تدير مكتبة الكونغرس <a href=\"http://www.loc.gov/nls/\">الخدمة الوطنية للمكتبات للمكفوفين والمعاقين جسديًا (NLS)</a> "
+"برنامج مكتبة مجاني للمواد المطبوعة بطريقة بريل والصوتية يتم توزيعها على المقترضين المؤهلين في الولايات المتحدة عبر شبكة "
+"وطنية من المكتبات المتعاونة."
+
+#: books/daisy.html
+msgid "Are you eligible to register?"
+msgstr "هل أنت مؤهل للتسجيل؟"
+
+#: books/daisy.html
+msgid "How do I find DAISYs on Open Library?"
+msgstr "كيف أجد كتب DAISY على المكتبة المفتوحة؟"
+
+#: books/daisy.html
+msgid ""
+"In addition to<a href=\"/subjects/accessible_book\" title=\"Subject: "
+"Accessible book\"> loads of open DAISYs</a>, the Open Library lists a "
+"smaller selection of<a href=\"/subjects/protected_DAISY\" "
+"title=\"Subject: Protected DAISY\"> protected DAISY titles</a> accessible"
+" to those with a Library of Congress NLS key. These titles are brought to"
+" you by the<a href=\"//archive.org/\"> Internet Archive</a>."
+msgstr ""
+"بالإضافة إلى <a href=\"/subjects/accessible_book\" title=\"Subject: Accessible book\">الكثير من DAISYs المفتوحة</a>، تسرد المكتبة المفتوحة مجموعة أصغر من <a href=\"/subjects/protected_DAISY\" title=\"Subject: Protected DAISY\">عناوين DAISY المحمية</a> المتاحة لأولئك الذين لديهم مفتاح مكتبة الكونغرس NLS. هذه العناوين مقدمة لك من <a href=\"//archive.org/\">الأرشيف الرقمي</a>."
+
+#: books/daisy.html
+msgid ""
+"Looking for a specific title? The best way to find it is to<a "
+"href=\"/search\"> search for it</a>."
+msgstr "تبحث عن عنوان معين؟ أفضل طريقة للعثور عليه هي <a href=\"/search\">البحث عنه</a>."
+
+#: books/daisy.html lib/history.html
+msgid "Need help?"
+msgstr "تحتاج إلى مساعدة؟"
+
+#: books/daisy.html
+msgid ""
+" Please read our <a href=\"/help/faq\">FAQ on accessing books through "
+"Open Library</a>."
+msgstr "يرجى قراءة <a href=\"/help/faq\">الأسئلة الشائعة حول الوصول إلى الكتب عبر المكتبة المفتوحة</a>."
+
+#: books/edit.html
+msgid "Add a little more?"
+msgstr "هل يمكنك إضافة المزيد؟"
+
+#: books/edit.html
+msgid ""
+"Thank you for adding that book! Any more information you could provide "
+"would be wonderful!"
+msgstr "شكرًا لإضافة هذا الكتاب! أي معلومات إضافية يمكنك تقديمها ستكون رائعة!"
+
+#: books/edit.html
+#, python-format
+msgid ""
+"We already know about <b>%(work_title)s</b>, but not the <b>%(year)s "
+"%(publisher)s edition</b>. Thanks! Do you know any more about this "
+"edition?"
+msgstr ""
+"نحن نعرف بالفعل عن <b>%(work_title)s</b>، لكن ليس عن <b>%(year)s %(publisher)s edition</b>. شكرًا! هل تعرف المزيد عن هذه الطبعة؟"
+
+#: books/edit.html
+#, python-format
+msgid ""
+"We already know about the <b>%(year)s %(publisher)s edition</b> of "
+"<b>%(work_title)s</b>, but please, tell us more!"
+msgstr ""
+"نحن نعرف بالفعل عن <b>%(year)s %(publisher)s edition</b> من <b>%(work_title)s</b>، ولكن من فضلك، قل لنا المزيد!"
+
+#: books/edit.html
+msgid "Editing..."
+msgstr "يتم التحرير..."
+
+#: books/edit.html type/author/edit.html type/template/edit.html
+msgid "Delete Record"
+msgstr "حذف السجل"
+
+#: books/edit.html
+msgid "Work Details"
+msgstr "تفاصيل العمل"
+
+#: books/edit.html
+msgid "Unknown publisher edition"
+msgstr "طبعة من ناشر غير معروف"
+
+#: books/edit.html
+msgid "This Work"
+msgstr "هذا العمل"
+
+#: books/edit.html
+msgid ""
+"You can search by author name (like <em>j k rowling</em>) or by Open "
+"Library ID (like <a href=\"/authors/OL23919A\" "
+"target=\"_blank\"><em>OL23919A</em></a>)."
+msgstr ""
+"يمكنك البحث حسب اسم المؤلف (مثل <em>j k rowling</em>) أو بواسطة معرف المكتبة المفتوحة (مثل <a href=\"/authors/OL23919A\" target=\"_blank\"><em>OL23919A</em></a>)."
+
+#: books/edit.html
+msgid "Author editing requires javascript"
+msgstr "تحرير المؤلف يتطلب JavaScript"
+
+#: books/edit.html
+msgid "Add Excerpts"
+msgstr "إضافة مقتطفات"
+
+#: books/edit.html type/about/edit.html type/author/edit.html
+msgid "Links"
+msgstr "روابط"
+
+#: IABook.html SearchResultsWork.html books/edition-sort.html
+#: jsdef/LazyWorkPreview.html lists/list_overview.html lists/preview.html
+#: lists/snippet.html lists/widget.html my_books/dropdown_content.html
+#: type/work/editions.html
+#, python-format
+msgid "Cover of: %(title)s"
+msgstr "غلاف: %(title)s"
+
+#: books/edition-sort.html
+#, python-format
+msgid "%(title)s: %(subtitle)s"
+msgstr "%(title)s: %(subtitle)s"
+
+#: books/edition-sort.html
+#, python-format
+msgid "Publish date unknown, %(publisher)s"
+msgstr "تاريخ النشر غير معروف، %(publisher)s"
+
+#: books/edition-sort.html type/work/editions.html
+#, python-format
+msgid "in %(languagelist)s"
+msgstr "بـ %(languagelist)s"
+
+#: books/edition-sort.html
+msgid "Libraries near you:"
+msgstr "المكتبات القريبة منك:"
+
+#: books/edition-sort.html
+msgid "Look for this edition at WorldCat"
+msgstr "ابحث عن هذه الطبعة في WorldCat"
+
+#: SearchNavigation.html books/mybooks_breadcrumb_select.html lib/nav_foot.html
+#: mybooks.py
+msgid "Books"
+msgstr "كتب"
+
+#: books/mybooks_breadcrumb_select.html mybooks.py
+#, python-format
+msgid "Want to Read (%(count)d)"
+msgstr "أريد قراءته (%(count)d)"
+
+#: books/mybooks_breadcrumb_select.html mybooks.py
+#, python-format
+msgid "Currently Reading (%(count)d)"
+msgstr "أقرأ حاليا (%(count)d)"
+
+#: books/mybooks_breadcrumb_select.html mybooks.py
+#, python-format
+msgid "Already Read (%(count)d)"
+msgstr "تمت قراءته (%(count)d)"
+
+#: books/mybooks_breadcrumb_select.html
+#, python-format
+msgid "Lists (%(count)d)"
+msgstr "قوائم (%(count)d)"
+
+#: books/mybooks_breadcrumb_select.html mybooks.py
+#: type/edition/modal_links.html
+msgid "Notes"
+msgstr "ملاحظات"
+
+#: account.py books/mybooks_breadcrumb_select.html
+msgid "Imports and Exports"
+msgstr "الاستيراد والتصدير"
+
+#: books/edit/about.html
+msgid "Select this subject"
+msgstr "اختر هذا الموضوع"
+
+#: books/edit/about.html
+msgid "How would you describe this book?"
+msgstr "كيف تصف هذا الكتاب؟"
+
+#: books/edit/about.html tag/add.html
+msgid "There's no wrong answer here."
+msgstr "لا توجد إجابة خاطئة هنا."
+
+#: books/edit/about.html
+msgid "Subject keywords?"
+msgstr "كلمات مفتاحية للموضوع؟"
+
+#: books/edit/about.html
+msgid "Please separate with commas."
+msgstr "يرجى الفصل بفواصل."
+
+#: books/edit/about.html
+#, fuzzy
+msgid ""
+"For example: <i><a href=\"/subjects/cheese\">cheese</a>, <a "
+"href=\"/subjects/roman_empire\">Roman Empire</a>, <a "
+"href=\"/subjects/psychology\">psychology</a></i>"
+msgstr ""
+"على سبيل المثال: <i><a href=\"/subjects/cheese\">جبن</a>, <a "
+"href=\"/subjects/roman_empire\">الإمبراطورية الرومانية</a>, <a "
+"href=\"/subjects/psychology\">علم النفس</a></i>"
+
+#: books/edit/about.html
+msgid "A person? Or, people?"
+msgstr "شخص؟ أو أشخاص؟"
+
+#: books/edit/about.html
+#, fuzzy
+msgid ""
+"For example: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore "
+"Roosevelt</a>, <a href=\"/subjects/person:Julian_of_Norwich\">Julian of "
+"Norwich</a>, <a href=\"/subjects/person:Tintin\">Tintin</a></i>"
+msgstr ""
+"على سبيل المثال: <i><a href=\"/subjects/person:Theodore_Roosevelt\">ثيودور روزفلت</a>, <a "
+"href=\"/subjects/person:Julian_of_Norwich\">جوليان من نورويتش</a>, <a "
+"href=\"/subjects/person:Tintin\">تينتين</a></i>"
+
+#: books/edit/about.html
+msgid "Note any places mentioned?"
+msgstr "هل تم ذكر أي أماكن؟"
+
+#: books/edit/about.html
+#, fuzzy
+msgid ""
+"For example: <i><a href=\"/subjects/place:London\">London</a>, <a "
+"href=\"/subjects/place:Atlantis\">Atlantis</a>, <a "
+"href=\"/subjects/place:Omaha\">Omaha</a></i>"
+msgstr ""
+"على سبيل المثال: <i><a href=\"/subjects/place:London\">لندن</a>, <a "
+"href=\"/subjects/place:Atlantis\">أتلانتس</a>, <a "
+"href=\"/subjects/place:Omaha\">أوماها</a></i>"
+
+#: books/edit/about.html
+msgid "When is it set or about?"
+msgstr "متى تدور أحداثه أو عن ماذا؟"
+
+#: books/edit/about.html
+#, fuzzy
+msgid ""
+"For example: <i><a href=\"/subjects/time:1984\">1984</a>, <a "
+"href=\"/subjects/time:the_middle_ages\">The Middle Ages</a>, <a "
+"href=\"/subjects/time:1810-1890\">1810-1890</a></i>"
+msgstr ""
+"على سبيل المثال: <i><a href=\"/subjects/time:1984\">1984</a>, <a "
+"href=\"/subjects/time:the_middle_ages\">العصور الوسطى</a>, <a "
+"href=\"/subjects/time:1810-1890\">1810-1890</a></i>"
+
+#: books/edit/edition.html
+msgid "Select this language"
+msgstr "اختر هذه اللغة"
+
+#: books/edit/edition.html
+msgid "Remove this language"
+msgstr "إزالة هذه اللغة"
+
+#: books/edit/edition.html
+msgid "Remove this work"
+msgstr "إزالة هذا العمل"
+
+#: books/edit/edition.html
+msgid "-- Move to a new work"
+msgstr "-- نقل إلى عمل جديد"
+
+#: books/edit/edition.html
+msgid "This Edition"
+msgstr "هذه النسخة"
+
+#: books/edit/edition.html
+msgid "Enter the title of this specific edition."
+msgstr "أدخل عنوان هذه النسخة المحددة."
+
+#: books/edit/edition.html
+msgid "Subtitle"
+msgstr "العنوان الفرعي"
+
+#: books/edit/edition.html
+msgid "Usually distinguished by different or smaller type."
+msgstr "عادة ما يتم تمييزه بنوع خط مختلف أو أصغر."
+
+#: books/edit/edition.html books/edit/excerpts.html books/edit/web.html
+#: type/author/edit.html
+msgid "For example:"
+msgstr "على سبيل المثال:"
+
+#: books/edit/edition.html
+msgid "Publishing Info"
+msgstr "معلومات النشر"
+
+#: books/edit/edition.html
+msgid "Where was the book published?"
+msgstr "أين تم نشر الكتاب؟"
+
+#: books/edit/edition.html
+msgid "City, Country please."
+msgstr "المدينة، البلد من فضلك."
+
+#: books/edit/edition.html
+msgid "What is the copyright date?"
+msgstr "ما هو تاريخ حقوق النشر؟"
+
+#: books/edit/edition.html
+msgid "The year following the copyright statement."
+msgstr "السنة التي تلي بيان حقوق النشر."
+
+#: books/edit/edition.html
+msgid "Edition Name (if applicable):"
+msgstr "اسم النسخة (إن وجد):"
+
+#: books/edit/edition.html
+msgid "Series Name (if applicable)"
+msgstr "اسم السلسلة (إن وجد)"
+
+#: books/edit/edition.html
+msgid "The name of the publisher's series."
+msgstr "اسم سلسلة الناشر."
+
+#: books/edit/edition.html type/edition/view.html type/work/view.html
+msgid "Contributors"
+msgstr "المساهمون"
+
+#: books/edit/edition.html
+msgid "Please select a role."
+msgstr "يرجى اختيار وظيفة."
+
+#: books/edit/edition.html
+msgid "You need to give this ROLE a name."
+msgstr "يجب عليك إعطاء هذه الوظيفة اسمًا."
+
+#: books/edit/edition.html
+msgid "List the people involved"
+msgstr "قائمة الأشخاص المعنيين"
+
+#: books/edit/edition.html
+msgid "Select role"
+msgstr "اختر وظيفة"
+
+#: books/edit/edition.html
+msgid "Add a new role"
+msgstr "إضافة وظيفة جديدة"
+
+#: books/edit/edition.html
+msgid "Remove this contributor"
+msgstr "إزالة هذا المساهم"
+
+#: books/edit/edition.html
+msgid "By Statement:"
+msgstr "بواسطة:"
+
+#: books/edit/edition.html
+msgid "Languages"
+msgstr "اللغات"
+
+#: books/edit/edition.html
+msgid "What language is this edition written in?"
+msgstr "بأي لغة كُتِبت هذه النسخة؟"
+
+#: books/edit/edition.html
+msgid "Add another language?"
+msgstr "إضافة لغة أخرى؟"
+
+#: books/edit/edition.html
+msgid "Is it a translation of another book?"
+msgstr "هل هي ترجمة لكتاب آخر؟"
+
+#: books/edit/edition.html
+msgid "Yes, it's a translation"
+msgstr "نعم، إنها ترجمة"
+
+#: books/edit/edition.html
+msgid "What's the original book?"
+msgstr "ما هو الكتاب الأصلي؟"
+
+#: books/edit/edition.html
+msgid "What language was the original written in?"
+msgstr "بأي لغة كُتب الأصل؟"
+
+#: books/edit/edition.html
+msgid "Description of this edition"
+msgstr "وصف هذه النسخة"
+
+#: books/edit/edition.html
+msgid "Only if it's different from the work's description"
+msgstr "فقط إذا كان يختلف عن وصف العمل"
+
+#: books/edit/edition.html type/edition/view.html type/work/view.html
+msgid "Table of Contents"
+msgstr "فهرس المحتويات"
+
+#: books/edit/edition.html
+msgid ""
+"Use a \"*\" for an indent, a \"|\" to add a column, and line breaks for "
+"new lines. Like this:"
+msgstr ""
+"استخدم \"*\" لتحديد المسافة البادئة، و\"|\" لإضافة عمود، وفواصل الأسطر للأسطر الجديدة. مثل هذا:"
+
+#: books/edit/edition.html
+msgid "Any notes about this specific edition?"
+msgstr "هل هناك ملاحظات حول هذه النسخة المحددة؟"
+
+#: books/edit/edition.html
+msgid "Anything about the book that may be of interest."
+msgstr "أي شيء عن الكتاب قد يكون ذا أهمية."
+
+#: books/edit/edition.html
+msgid "Is it known by any other titles?"
+msgstr "هل يُعرف تحت أي عناوين أخرى؟"
+
+#: books/edit/edition.html
+msgid ""
+"Use this field if the title is different on the cover or spine. If the "
+"edition is a collection or anthology, you may also add the individual "
+"titles of each work here."
+msgstr ""
+"استخدم هذا الحقل إذا كان العنوان مختلفًا على الغلاف أو ظهر الكتاب. إذا كانت النسخة عبارة عن مجموعة أو أنطولوجيا، يمكنك أيضًا إضافة العناوين الفردية لكل عمل هنا."
+
+#: books/edit/edition.html
+msgid "is an alternate title for"
+msgstr "هو عنوان بديل لـ"
+
+#: books/edit/edition.html
+msgid "What work is this an edition of?"
+msgstr "من أي عمل هذه نسخة؟"
+
+#: books/edit/edition.html
+msgid ""
+"Sometimes editions can be associated with the wrong work. You can correct"
+" that here."
+msgstr ""
+"في بعض الأحيان يمكن أن تكون النسخ مرتبطة بالعمل الخطأ. يمكنك تصحيح ذلك هنا."
+
+#: books/edit/edition.html
+msgid "You can search by title or by Open Library ID (like"
+msgstr "يمكنك البحث حسب العنوان أو بواسطة معرف المكتبة المفتوحة (مثل"
+
+#: books/edit/edition.html
+msgid "WARNING: Any edits made to the work from this page will be ignored."
+msgstr ""
+"تحذير: سيتم تجاهل أي تعديلات تُجرى على العمل من هذه الصفحة."
+
+#: books/edit/edition.html
+msgid "Please select an identifier."
+msgstr "يرجى اختيار معرف."
+
+#: books/edit/edition.html
+msgid "You need to give a value to ID."
+msgstr "يجب عليك إعطاء قيمة للمعرف."
+
+#: books/edit/edition.html
+msgid "ID ids cannot contain whitespace."
+msgstr "المعرفات لا يمكن أن تحتوي على مسافات."
+
+#: books/edit/edition.html
+msgid "ID must be exactly 10 characters [0-9] or X."
+msgstr "يجب أن يكون المعرف بالضبط 10 أحرف [0-9] أو X."
+
+#: books/edit/edition.html
+msgid "That ID already exists for this edition."
+msgstr "هذا المعرف موجود بالفعل لهذه النسخة."
+
+#: books/edit/edition.html
+msgid "ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4"
+msgstr ""
+"يجب أن يكون المعرف بالضبط 13 رقما [0-9]. على سبيل المثال: 978-1-56619-909-4"
+
+#: books/edit/edition.html
+msgid "Invalid ID format"
+msgstr "تنسيق المعرف غير صحيح"
+
+#: books/edit/edition.html type/author/view.html type/edition/view.html
+#: type/work/view.html
+msgid "ID Numbers"
+msgstr "أرقام المعرف"
+
+#: books/edit/edition.html
+msgid "Do you know any identifiers for this edition?"
+msgstr "هل تعرف أي معرفات لهذه النسخة؟"
+
+#: books/edit/edition.html
+msgid "Like, ISBN?"
+msgstr "مثل، ISBN؟"
+
+#: books/edit/edition.html
+msgid "Select one of many..."
+msgstr "اختر واحدًا من العديد..."
+
+#: books/edit/edition.html
+msgid "Please select a classification."
+msgstr "يرجى اختيار تصنيف."
+
+#: books/edit/edition.html
+msgid "You need to give a value to CLASS."
+msgstr "يجب عليك إعطاء قيمة للتصنيف."
+
+#: books/edit/edition.html type/edition/view.html type/work/view.html
+msgid "Classifications"
+msgstr "التصنيفات"
+
+#: books/edit/edition.html
+msgid "Do you know any classifications of this edition?"
+msgstr
+
+ "هل تعرف أي تصنيفات لهذه النسخة؟"
+
+#: books/edit/edition.html
+msgid "Like, Dewey Decimal?"
+msgstr "مثل، تصنيف ديوي العشري؟"
+
+#: books/edit/edition.html
+msgid "Add a new classification type"
+msgstr "إضافة نوع تصنيف جديد"
+
+#: books/edit/edition.html
+msgid "Remove this classification"
+msgstr "إزالة هذا التصنيف"
+
+#: books/edit/edition.html type/edition/view.html type/work/view.html
+msgid "The Physical Object"
+msgstr "الشيء المادي"
+
+#: books/edit/edition.html
+msgid "What sort of book is it?"
+msgstr "ما نوع الكتاب؟"
+
+#: books/edit/edition.html
+msgid "Paperback; Hardcover, etc."
+msgstr "غلاف ورقي؛ غلاف صلب، إلخ."
+
+#: books/edit/edition.html
+msgid "How many pages?"
+msgstr "كم عدد الصفحات؟"
+
+#: books/edit/edition.html
+msgid "Pagination?"
+msgstr "ترقيم الصفحات؟"
+
+#: books/edit/edition.html
+msgid "Note the highest number in each pagination pattern."
+msgstr "لاحظ أعلى رقم في كل نمط ترقيم."
+
+#: books/edit/edition.html lib/nav_foot.html
+msgid "Help"
+msgstr "مساعدة"
+
+#: books/edit/edition.html
+msgid "How much does the book weigh?"
+msgstr "كم يزن الكتاب؟"
+
+#: books/edit/edition.html type/edition/view.html type/work/view.html
+msgid "Dimensions"
+msgstr "الأبعاد"
+
+#: books/edit/edition.html
+msgid "dimensions"
+msgstr "الأبعاد"
+
+#: books/edit/edition.html
+msgid "Height:"
+msgstr "الارتفاع:"
+
+#: books/edit/edition.html
+msgid "Width:"
+msgstr "العرض:"
+
+#: books/edit/edition.html
+msgid "Depth:"
+msgstr "العمق:"
+
+#: books/edit/edition.html
+msgid "Web Book Providers"
+msgstr "موفرو الكتب على الويب"
+
+#: books/edit/edition.html
+msgid "Access Type"
+msgstr "نوع الوصول"
+
+#: books/edit/edition.html
+msgid "File Format"
+msgstr "تنسيق الملف"
+
+#: books/edit/edition.html
+msgid "Provider Name"
+msgstr "اسم المزوّد"
+
+#: ReadButton.html books/edit/edition.html
+msgid "Listen"
+msgstr "استماع"
+
+#: books/edit/edition.html
+msgid "Buy"
+msgstr "شراء"
+
+#: books/edit/edition.html
+msgid "Web"
+msgstr "إنترنت"
+
+#: books/edit/edition.html
+msgid "Add a provider"
+msgstr "إضافة مزوّد"
+
+#: books/edit/edition.html
+msgid "First sentence"
+msgstr "الجملة الأولى"
+
+#: books/edit/edition.html
+msgid "The opening line that starts the lead paragraph"
+msgstr "الجملة الافتتاحية التي تبدأ الفقرة الرئيسية"
+
+#: books/edit/edition.html
+msgid "Admin Only"
+msgstr "للمسؤولين فقط"
+
+#: books/edit/edition.html
+msgid "Additional Metadata"
+msgstr "بيانات وصفية إضافية"
+
+#: books/edit/edition.html
+msgid "This field can accept arbitrary key:value pairs"
+msgstr "يمكن أن يحتوي هذا الحقل على أزواج مفتاح: قيمة عشوائية"
+
+#: books/edit/excerpts.html
+msgid "Please provide an excerpt."
+msgstr "يرجى تقديم مقتطف."
+
+#: books/edit/excerpts.html
+msgid "That excerpt is too long."
+msgstr "هذا المقتطف طويل جدًا."
+
+#: books/edit/excerpts.html
+msgid ""
+"If there are particular (short) passages you feel represent the book "
+"well, please feel free to transcribe them here."
+msgstr ""
+"إذا كانت هناك مقاطع (قصيرة) معينة تشعر أنها تمثل الكتاب بشكل جيد، "
+"يرجى كتابتها هنا."
+
+#: books/edit/excerpts.html
+msgid "Page number?"
+msgstr "رقم الصفحة؟"
+
+#: books/edit/excerpts.html
+msgid "This excerpt is the first sentence of the book."
+msgstr "هذا المقتطف هو الجملة الأولى من الكتاب."
+
+#: books/edit/excerpts.html
+msgid "Transcribe the excerpt"
+msgstr "اكتب المقتطف"
+
+#: books/edit/excerpts.html
+msgid "Maximum length is 2000 characters. No HTML allowed."
+msgstr "الحد الأقصى للطول هو 2000 حرف. لا يُسمح باستخدام HTML."
+
+#: books/edit/excerpts.html
+msgid "Why did you choose this excerpt?"
+msgstr "لماذا اخترت هذا المقتطف؟"
+
+#: books/edit/excerpts.html
+msgid "Add an optional note."
+msgstr "أضف ملاحظة اختيارية."
+
+#: books/edit/excerpts.html
+msgid "Excerpts so far..."
+msgstr "المقتطفات حتى الآن..."
+
+#: books/edit/excerpts.html
+msgid "noted:"
+msgstr "ملاحظة:"
+
+#: books/edit/excerpts.html
+msgid "An anonymous note:"
+msgstr "ملاحظة مجهولة:"
+
+#: books/edit/excerpts.html
+msgid "From page"
+msgstr "من الصفحة"
+
+#: books/edit/web.html
+msgid "Please provide a label."
+msgstr "يرجى تقديم تسمية."
+
+#: books/edit/web.html
+msgid "Please provide a URL."
+msgstr "يرجى تقديم عنوان URL."
+
+#: books/edit/web.html
+msgid "Please enter a valid URL."
+msgstr "يرجى إدخال عنوان URL صحيح."
+
+#: books/edit/web.html
+msgid ""
+"Please connect Open Library records to <u>good</u><span "
+"class=\"orange\">*</span> online resources."
+msgstr ""
+"يرجى ربط سجلات المكتبة المفتوحة بمصادر <u>جيدة</u><span "
+"class=\"orange\">*</span> على الإنترنت."
+
+#: books/edit/web.html
+msgid "Give your link a label"
+msgstr "أعطِ رابطك تسمية"
+
+#: books/edit/web.html
+msgid "URL"
+msgstr "عنوان URL"
+
+# | msgid "Add edition"
+#: books/edit/web.html
+msgid "Add Link"
+msgstr "إضافة رابط"
+
+#: books/edit/web.html
+msgid "Remove this link"
+msgstr "إزالة هذا الرابط"
+
+#: books/edit/web.html
+msgid ""
+"\"Good\" means no spammy links, please. Keep them relevant to the book. "
+"Irrelevant sites may be removed. Blatant spam will be deleted without "
+"remorse."
+msgstr ""
+"تعني \"جيدة\" عدم وجود روابط سبام، من فضلك. اجعلها ذات صلة بالكتاب. "
+"قد تتم إزالة المواقع غير ذات الصلة. سيتم حذف السبام الواضح بدون تردد."
+
+#: check_ins/check_in_form.html
+msgid "January"
+msgstr "يناير"
+
+#: check_ins/check_in_form.html
+msgid "February"
+msgstr "فبراير"
+
+#: check_ins/check_in_form.html
+msgid "March"
+msgstr "مارس"
+
+#: check_ins/check_in_form.html
+msgid "April"
+msgstr "أبريل"
+
+#: check_ins/check_in_form.html
+msgid "May"
+msgstr "مايو"
+
+#: check_ins/check_in_form.html
+msgid "June"
+msgstr "يونيو"
+
+#: check_ins/check_in_form.html
+msgid "July"
+msgstr "يوليو"
+
+#: check_ins/check_in_form.html
+msgid "August"
+msgstr "أغسطس"
+
+#: check_ins/check_in_form.html
+msgid "September"
+msgstr "سبتمبر"
+
+#: check_ins/check_in_form.html
+msgid "October"
+msgstr "أكتوبر"
+
+#: check_ins/check_in_form.html
+msgid "November"
+msgstr "نوفمبر"
+
+#: check_ins/check_in_form.html
+msgid "December"
+msgstr "ديسمبر"
+
+#: check_ins/check_in_form.html
+msgid ""
+"Add an optional check-in date.  Check-in dates are used to track yearly "
+"reading goals."
+msgstr ""
+"أضف تاريخ تسجيل اختياري. تُستخدم تواريخ التسجيل لتتبع أهداف القراءة السنوية."
+
+#: check_ins/check_in_form.html
+msgid "End Date:"
+msgstr "تاريخ النهاية:"
+
+#: check_ins/check_in_form.html
+msgid "Year:"
+msgstr "السنة:"
+
+#: check_ins/check_in_form.html
+msgid "Year"
+msgstr "السنة"
+
+# | msgid "This Edition"
+#: check_ins/check_in_form.html
+msgid "Month:"
+msgstr "الشهر:"
+
+# | msgid "This Edition"
+#: check_ins/check_in_form.html
+msgid "Month"
+msgstr "الشهر"
+
+#: check_ins/check_in_form.html
+msgid "Day:"
+msgstr "اليوم:"
+
+#: check_ins/check_in_form.html
+msgid "Day"
+msgstr "اليوم"
+
+#: check_ins/check_in_form.html
+msgid "Delete Event"
+msgstr "حذف الحدث"
+
+#: check_ins/check_in_prompt.html
+msgid "Read:"
+msgstr "قراءة:"
+
+#: check_ins/check_in_prompt.html
+msgid "When did you finish this book?"
+msgstr "متى أنهيت قراءة هذا الكتاب؟"
+
+#: check_ins/check_in_prompt.html
+msgid "Other"
+msgstr "أخرى"
+
+#: check_ins/check_in_prompt.html
+msgid "Check-In"
+msgstr "تسجيل الدخول"
+
+#: check_ins/reading_goal_form.html
+msgid "How many books would you like to read this year?"
+msgstr "كم عدد الكتب التي تود قراءتها هذا العام؟"
+
+#: check_ins/reading_goal_form.html
+msgid "Enter \"0\" to unset your reading goal. Your check-ins will be preserved."
+msgstr ""
+"ادخل \"0\" لإلغاء هدف القراءة الخاص بك. سيتم الاحتفاظ بتسجيلاتك."
+
+#: check_ins/reading_goal_progress.html
+#, python-format
+msgid "%(year)d Reading Goal:"
+msgstr "%(year)d هدف القراءة:"
+
+#: check_ins/reading_goal_progress.html
+#, python-format
+msgid ""
+"<span class=\"reading-goal-progress__books-"
+"read\">%(books_read)d</span>/<span class=\"reading-goal-"
+"progress__goal\">%(goal)d</span> books"
+msgstr ""
+"<span class=\"reading-goal-progress__books-"
+"read\">%(books_read)d</span>/<span class=\"reading-goal-"
+"progress__goal\">%(goal)d</span> كتب"
+
+#: check_ins/reading_goal_progress.html
+#, python-format
+msgid "Edit %(year)d Reading Goal"
+msgstr "%(year)d هدف القراءة"
+
+#: covers/add.html
+msgid "Please choose an image or provide a URL."
+msgstr "يرجى اختيار صورة أو تقديم عنوان URL."
+
+#: covers/add.html
+msgid "There are two ways to put an author's image on Open Library"
+msgstr "هناك طريقتان لوضع صورة المؤلف على المكتبة المفتوحة"
+
+#: covers/add.html
+msgid "Image Guidelines"
+msgstr "إرشادات الصورة"
+
+#: covers/add.html
+msgid "There are two ways to put a cover image on Open Library"
+msgstr "هناك طريقتان لوضع صورة الغلاف على المكتبة المفتوحة"
+
+#: covers/add.html
+msgid "Cover Guidelines"
+msgstr "إرشادات غلاف الكتاب"
+
+#: covers/add.html
+msgid "Please provide a valid image."
+msgstr "يرجى تقديم صورة صالحة."
+
+#: covers/add.html
+msgid "Please provide an image URL."
+msgstr "يرجى تقديم عنوان URL للصورة."
+
+#: covers/add.html
+msgid "<strong>Pick one</strong> from the existing covers,"
+msgstr "<strong>اختر واحدة</strong> من الأغطية الموجودة،"
+
+#: covers/add.html
+msgid "Choose a JPG, GIF or PNG on your computer,"
+msgstr "اختر صورة بصيغة JPG أو GIF أو PNG من جهاز الكمبيوتر الخاص بك،"
+
+#: covers/add.html
+msgid "Or, paste in the image URL if it's on the web."
+msgstr "أو، الصق عنوان URL للصورة إذا كانت على الإنترنت."
+
+#: covers/add.html
+msgid "Uploading..."
+msgstr "جارٍ التحميل..."
+
+#: covers/author_photo.html
+msgid "Pull up a larger author photo"
+msgstr "عرض صورة المؤلف بحجم أكبر"
+
+#: covers/author_photo.html search/authors.html
+#, python-format
+msgid "Photo of %(author)s"
+msgstr "صورة لـ %(author)s"
+
+#: covers/author_photo.html
+msgid "Click to close"
+msgstr "انقر للإغلاق"
+
+#: covers/author_photo.html
+#, python-format
+msgid "We need a photo of %(author)s"
+msgstr "نحتاج إلى صورة لـ %(author)s"
+
+#: covers/book_cover.html
+msgid "Pull up a bigger book cover"
+msgstr "عرض غلاف الكتاب بحجم أكبر"
+
+#: covers/book_cover.html covers/book_cover_single_edition.html
+#: covers/book_cover_small.html covers/book_cover_work.html
+#, python-format
+msgid "Cover of: %(title)s by %(authors)s"
+msgstr "غلاف: %(title)s بواسطة %(authors)s"
+
+#: covers/book_cover_single_edition.html covers/book_cover_work.html
+msgid "View a larger book cover"
+msgstr "عرض غلاف الكتاب بحجم أكبر"
+
+#: covers/book_cover_single_edition.html covers/book_cover_small.html
+#: covers/book_cover_work.html
+#, python-format
+msgid "We need a book cover for: %(title)s"
+msgstr "نحتاج إلى غلاف كتاب لـ: %(title)s"
+
+#: covers/book_cover_small.html
+#, python-format
+msgid "Go to the main page for %(title)s"
+msgstr "اذهب إلى الصفحة الرئيسية لـ %(title)s"
+
+#: covers/change.html
+msgid "Author Photos"
+msgstr "صور المؤلفين"
+
+#: covers/change.html
+msgid "Manage Author Photos"
+msgstr "إدارة صور المؤلفين"
+
+#: covers/change.html
+msgid "Add Author Photo"
+msgstr "إضافة صورة مؤلف"
+
+#: covers/change.html
+msgid "Book Covers"
+msgstr "أغلفة الكتب"
+
+#: covers/change.html
+msgid "Manage Covers"
+msgstr "إدارة الأغطية"
+
+#: covers/change.html
+msgid "Add Cover Image"
+msgstr "إضافة صورة غلاف"
+
+#: covers/change.html
+msgid "Manage"
+msgstr "إدارة"
+
+#: covers/manage.html
+msgid ""
+"You can drag and drop thumbnails to reorder, or into the trash to delete "
+"them."
+msgstr ""
+"يمكنك سحب وإفلات الصور المصغرة لإعادة ترتيبها، أو إلى سلة المهملات لحذفها."
+
+#: covers/saved.html
+msgid "New book cover"
+msgstr "غلاف كتاب جديد"
+
+#: covers/saved.html
+msgid "Saved!"
+msgstr "تم الحفظ!"
+
+#: covers/saved.html
+msgid "Notes:"
+msgstr "ملاحظات:"
+
+#: covers/saved.html
+msgid "Add another image"
+msgstr "إضافة صورة أخرى"
+
+#: covers/saved.html
+msgid "Finished"
+msgstr "تم"
+
+#: history/comment.html
+#, python-format
+msgid "Imported from %(source)s"
+msgstr "مستورد من %(source)s"
+
+#: history/comment.html
+#, python-format
+msgid "Imported from %(source)s  <a href=\"%(url)s\">%(type)s record</a>."
+msgstr "مستورد من %(source)s  <a href=\"%(url)s\">سجل %(type)s</a>."
+
+#: history/comment.html
+#, python-format
+msgid "Found a <a href=\"%(url)s\">matching record</a> from %(source)s."
+msgstr "تم العثور على <a href=\"%(url)s\">سجل مطابق</a> من %(source)s."
+
+#: history/comment.html
+msgid "Edited without comment."
+msgstr "تم التعديل بدون تعليق."
+
+#: home/about.html
+msgid "About the Project"
+msgstr "عن المشروع"
+
+#: home/about.html
+msgid ""
+"Open Library is an open, editable library catalog, building towards a web"
+" page for every book ever published."
+msgstr ""
+"المكتبة المفتوحة هي كتالوج مكتبة مفتوح وقابل للتعديل، يهدف إلى إنشاء صفحة ويب"
+" لكل كتاب تم نشره."
+
+#: AffiliateLinks.html home/about.html
+msgid "More"
+msgstr "المزيد"
+
+#: home/about.html
+msgid ""
+"Just like Wikipedia, you can contribute new information or corrections to"
+" the catalog. You can browse by <a href=\"/subjects\">subjects</a>, <a "
+"href=\"/authors\">authors</a> or <a href=\"/lists\">lists</a> members "
+"have created. If you love books, why not help build a library?"
+msgstr ""
+"تمامًا مثل ويكيبيديا، يمكنك المساهمة بمعلومات جديدة أو تصحيحات للكتالوج. يمكنك"
+" البحث حسب <a href=\"/subjects\">الموضوعات</a>، <a href=\"/authors\">المؤلفين</a>"
+" أو <a href=\"/lists\">القوائم</a> التي أنشأها الأعضاء. إذا كنت تحب الكتب، لماذا لا"
+" تساعد في بناء مكتبة؟"
+
+#: home/about.html
+msgid "Latest Blog Posts"
+msgstr "أحدث التدوينات"
+
+#: home/categories.html
+msgid "Browse by Subject"
+msgstr "تصفح حسب الموضوع"
+
+#: home/categories.html
+#, python-format
+msgid "browse %(subject)s books"
+msgstr "تصفح كتب %(subject)s"
+
+#: home/categories.html
+#, python-format
+msgid "%(count)s Book"
+msgid_plural "%(count)s Books"
+msgstr[0] "%(count)s كتاب"
+msgstr[1] "%(count)s كتب"
+
+#: home/index.html home/welcome.html
+msgid "Welcome to Open Library"
+msgstr "مرحبًا بكم في المكتبة المفتوحة"
+
+#: home/index.html
+msgid "Classic Books"
+msgstr "الكتب الكلاسيكية"
+
+#: home/index.html
+msgid "Recently Returned"
+msgstr "تمت إعادته مؤخرًا"
+
+#: home/index.html
+msgid "Romance"
+msgstr "رومانسي"
+
+#: home/index.html
+msgid "Kids"
+msgstr "الأطفال"
+
+#: home/index.html
+msgid "Thrillers"
+msgstr "إثارة"
+
+#: home/index.html
+msgid "Textbooks"
+msgstr "كتب مدرسية"
+
+#: home/stats.html site/around_the_library.html
+msgid "Around the Library"
+msgstr "حول المكتبة"
+
+#: home/stats.html
+msgid ""
+"Here's what's happened over the last 28 days. More <a "
+"href=\"/recentchanges\">recent changes</a>"
+msgstr ""
+"إليك ما حدث خلال الأيام الـ 28 الماضية. المزيد من <a "
+"href=\"/recentchanges\">التغييرات الأخيرة</a>"
+
+#: home/stats.html
+msgid "See all visitors to OpenLibrary.org"
+msgstr "عرض جميع زوار OpenLibrary.org"
+
+#: home/stats.html
+msgid "Area graph of recent unique visitors"
+msgstr "مخطط المنطقة للزوار الفريدين الحديثين"
+
+#: home/stats.html
+msgid "How many new Open Library members have we welcomed?"
+msgstr "كم عدد أعضاء المكتبة المفتوحة الجدد الذين رحبنا بهم؟"
+
+#: home/stats.html
+
+
+msgid "Area graph of new members"
+msgstr "مخطط المنطقة للأعضاء الجدد"
+
+#: home/stats.html
+msgid "People are constantly updating the catalog"
+msgstr "الأشخاص يقومون بتحديث الكتالوج باستمرار"
+
+#: home/stats.html
+msgid "Area graph of recent catalog edits"
+msgstr "مخطط المنطقة للتعديلات الحديثة على الكتالوج"
+
+#: home/stats.html
+msgid "Catalog Edits"
+msgstr "تعديلات الكتالوج"
+
+#: home/stats.html
+msgid "Members can create Lists"
+msgstr "يمكن للأعضاء إنشاء قوائم"
+
+#: home/stats.html
+msgid "Area graph of lists created recently"
+msgstr "مخطط المنطقة للقوائم التي تم إنشاؤها مؤخرًا"
+
+#: home/stats.html
+msgid "Lists Created"
+msgstr "القوائم التي تم إنشاؤها"
+
+#: home/stats.html
+msgid "We're a library, so we lend books, too"
+msgstr "نحن مكتبة، لذا نقوم أيضًا بإعارة الكتب"
+
+#: home/stats.html
+msgid "Area graph of ebooks borrowed recently"
+msgstr "مخطط المنطقة للكتب الإلكترونية المستعارة حديثًا"
+
+#: home/stats.html
+msgid "eBooks Borrowed"
+msgstr "الكتب الإلكترونية المستعارة"
+
+#: home/welcome.html
+msgid "Read Free Library Books Online"
+msgstr "اقرأ الكتب المجانية من المكتبة على الإنترنت"
+
+#: home/welcome.html
+msgid "Millions of books available through Controlled Digital Lending"
+msgstr "ملايين الكتب متاحة من خلال الإعارة الرقمية المُراقبة"
+
+#: home/welcome.html
+msgid "Set a Yearly Reading Goal"
+msgstr "حدد هدف القراءة السنوي"
+
+#: home/welcome.html
+msgid "Learn how to set a yearly reading goal and track what you read"
+msgstr "تعلم كيفية تحديد هدف قراءة سنوي وتتبع ما تقرأه"
+
+#: home/welcome.html
+msgid "Keep Track of your Favorite Books"
+msgstr "تابع كتبك المفضلة"
+
+#: home/welcome.html
+msgid "Organize your Books using Lists & the Reading Log"
+msgstr "نظم كتبك باستخدام القوائم وسجل القراءة"
+
+#: home/welcome.html
+msgid "Try the virtual Library Explorer"
+msgstr "جرب مستكشف المكتبة الافتراضي"
+
+#: home/welcome.html
+msgid "Digital shelves organized like a physical library"
+msgstr "رفوف رقمية منظمة مثل مكتبة حقيقية"
+
+#: home/welcome.html
+msgid "Try Fulltext Search"
+msgstr "جرب البحث النصي الكامل"
+
+#: home/welcome.html
+msgid "Find matching results within the text of millions of books"
+msgstr "ابحث عن نتائج مطابقة ضمن نصوص ملايين الكتب"
+
+#: home/welcome.html
+msgid "Be an Open Librarian"
+msgstr "كن أمين مكتبة مفتوحة"
+
+#: home/welcome.html
+msgid "Dozens of ways you can help improve the library"
+msgstr "عشرات الطرق التي يمكنك من خلالها المساعدة في تحسين المكتبة"
+
+#: home/welcome.html
+msgid "Volunteer at Open Library"
+msgstr "تطوع في المكتبة المفتوحة"
+
+#: home/welcome.html
+msgid "Discover opportunities to improve the library"
+msgstr "اكتشف الفرص لتحسين المكتبة"
+
+#: home/welcome.html
+msgid "Send us feedback"
+msgstr "أرسل لنا ملاحظاتك"
+
+#: home/welcome.html
+msgid "Your feedback will help us improve these cards"
+msgstr "ملاحظاتك ستساعدنا في تحسين هذه البطاقات"
+
+#: languages/index.html
+#, python-format
+msgid "%s book"
+msgid_plural "%s books"
+msgstr[0] "%s كتاب"
+msgstr[1] "%s كتب"
+
+#: languages/language_list.html
+msgid "Czech"
+msgstr "التشيكية"
+
+#: languages/language_list.html
+msgid "German"
+msgstr "الألمانية"
+
+#: languages/language_list.html
+msgid "English"
+msgstr "الإنجليزية"
+
+#: languages/language_list.html
+msgid "Spanish"
+msgstr "الإسبانية"
+
+#: languages/language_list.html
+msgid "French"
+msgstr "الفرنسية"
+
+#: languages/language_list.html
+msgid "Croatian"
+msgstr "الكرواتية"
+
+#: languages/language_list.html
+msgid "Italian"
+msgstr "الإيطالية"
+
+#: languages/language_list.html
+msgid "Portuguese"
+msgstr "البرتغالية"
+
+#: languages/language_list.html
+msgid "Hindi"
+msgstr "الهندية"
+
+#: languages/language_list.html
+msgid "Sardinian"
+msgstr "السردينية"
+
+#: languages/language_list.html
+msgid "Telugu"
+msgstr "التيلوجو"
+
+#: languages/language_list.html
+msgid "Ukrainian"
+msgstr "الأوكرانية"
+
+#: languages/language_list.html
+msgid "Chinese"
+msgstr "الصينية"
+
+#: languages/notfound.html
+#, python-format
+msgid "%s is not found"
+msgstr "%s غير موجود"
+
+#: languages/notfound.html
+#, python-format
+msgid "%s does not exist."
+msgstr "%s لا وجود له."
+
+#: lib/edit_head.html lib/view_head.html
+msgid "This doc was last edited by"
+msgstr "تمت آخر تعديل على هذا المستند بواسطة"
+
+#: lib/edit_head.html lib/view_head.html
+msgid "This doc was last edited anonymously"
+msgstr "تمت آخر تعديل على هذا المستند بشكل مجهول"
+
+#: lib/header_dropdown.html
+msgid "My account"
+msgstr "حسابي"
+
+#: lib/header_dropdown.html type/user/view.html
+#, python-format
+msgid "Joined %(date)s"
+msgstr "انضم في %(date)s"
+
+#: lib/header_dropdown.html
+msgid "Menu"
+msgstr "القائمة"
+
+#: lib/header_dropdown.html
+msgid "New!"
+msgstr "جديد!"
+
+#: databarDiff.html databarEdit.html databarTemplate.html databarView.html
+#: lib/history.html
+msgid "History"
+msgstr "التاريخ"
+
+#: lib/history.html
+#, python-format
+msgid "Created %(date)s"
+msgstr "أنشئ في %(date)s"
+
+#: lib/history.html
+#, python-format
+msgid "%(count)d revision"
+msgid_plural "%(count)d revisions"
+msgstr[0] "%(count)d تعديل"
+msgstr[1] "%(count)d تعديلات"
+
+#: lib/history.html
+msgid "Download catalog record:"
+msgstr "تحميل سجل الكتالوج:"
+
+#: lib/history.html
+msgid "Cite this on Wikipedia"
+msgstr "اقتبس هذا على ويكيبيديا"
+
+#: lib/history.html
+msgid "Wikipedia citation"
+msgstr "اقتباس ويكيبيديا"
+
+#: lib/history.html
+msgid "Copy and paste this code into your Wikipedia page."
+msgstr "انسخ والصق هذا الكود في صفحتك على ويكيبيديا."
+
+#: lib/history.html
+msgid "Get instructions at Wikipedia in a new window"
+msgstr "احصل على التعليمات في ويكيبيديا في نافذة جديدة"
+
+#: lib/history.html
+msgid "an anonymous user"
+msgstr "مستخدم مجهول"
+
+#: lib/history.html
+#, python-format
+msgid "Created by %(user)s"
+msgstr "أنشئ بواسطة %(user)s"
+
+#: lib/history.html
+#, python-format
+msgid "Edited by %(user)s"
+msgstr "تم تعديله بواسطة %(user)s"
+
+#: lib/message_addbook.html
+msgid "Super!"
+msgstr "رائع!"
+
+#: lib/message_addbook.html
+msgid " Your new record is in the library. Thank you!"
+msgstr "سجلك الجديد في المكتبة. شكرًا لك!"
+
+#: lib/message_addbook.html
+msgid ""
+"There are a few other simple things you can add while you're here to "
+"improve your new record quickly, and make it much easier for other people"
+" to find later."
+msgstr ""
+"هناك بعض الأشياء البسيطة الأخرى التي يمكنك إضافتها أثناء وجودك هنا "
+"لتحسين سجلك الجديد بسرعة، وجعل من السهل على الآخرين العثور عليه لاحقًا."
+
+#: lib/message_addbook.html
+msgid "Upload a cover image"
+msgstr "تحميل صورة الغلاف"
+
+#: lib/message_addbook.html
+msgid "Snap a quick photo of the cover to share?"
+msgstr "التقط صورة سريعة للغلاف لتشاركها؟"
+
+#: lib/message_addbook.html
+msgid "Add an ISBN"
+msgstr "إضافة رقم ISBN"
+
+#: lib/message_addbook.html
+msgid "Help the library connect with other systems, like Amazon."
+msgstr "ساعد المكتبة في الاتصال بأنظمة أخرى، مثل أمازون."
+
+#: lib/message_addbook.html
+msgid "Add some subjects"
+msgstr "أضف بعض المواضيع"
+
+#: lib/message_addbook.html
+msgid "They're just like tags."
+msgstr "إنها تشبه العلامات."
+
+#: lib/message_addbook.html
+msgid "Describe what the book's about"
+msgstr "صف موضوع الكتاب"
+
+#: lib/message_addbook.html
+msgid "Just a sentence or two is good."
+msgstr "جملة أو جملتان تكفي."
+
+#: lib/nav_foot.html
+msgid "Vision"
+msgstr "الرؤية"
+
+#: lib/nav_foot.html
+msgid "Volunteer"
+msgstr "تطوع"
+
+#: lib/nav_foot.html
+msgid "Partner With Us"
+msgstr "شارك معنا"
+
+#: lib/nav_foot.html
+msgid "Jobs"
+msgstr "وظائف"
+
+#: lib/nav_foot.html
+msgid "Careers"
+msgstr "المس careers"
+
+#: lib/nav_foot.html
+msgid "Blog"
+msgstr "مدونة"
+
+#: lib/nav_foot.html
+msgid "Terms of Service"
+msgstr "شروط الخدمة"
+
+#: lib/nav_foot.html site/alert.html
+msgid "Donate"
+msgstr "تبرع"
+
+#: lib/nav_foot.html
+msgid "Discover"
+msgstr "اكتشف"
+
+#: lib/nav_foot.html
+msgid "Go home"
+msgstr "اذهب إلى الصفحة الرئيسية"
+
+#: lib/nav_foot.html
+msgid "Home"
+msgstr "الرئيسية"
+
+#: lib/nav_foot.html
+msgid "Explore Books"
+msgstr "استكشف الكتب"
+
+#: lib/nav_foot.html
+msgid "Explore authors"
+msgstr "استكشف المؤلفين"
+
+#: lib/nav_foot.html
+msgid "Explore subjects"
+msgstr "استكشف المواضيع"
+
+#: lib/nav_foot.html
+msgid "Explore collections"
+msgstr "استكشف المجموعات"
+
+#: lib/nav_foot.html lib/nav_head.html
+msgid "Collections"
+msgstr "المجموعات"
+
+#: SearchNavigation.html lib/nav_foot.html lib/nav_head.html
+#: search/advancedsearch.html
+msgid "Advanced Search"
+msgstr "البحث المتقدم"
+
+#: lib/nav_foot.html
+msgid "Navigate to top of this page"
+msgstr "الانتقال إلى أعلى هذه الصفحة"
+
+#: lib/nav_foot.html
+msgid "Return to Top"
+msgstr "العودة إلى الأعلى"
+
+#: lib/nav_foot.html
+msgid "Develop"
+msgstr "تطوير"
+
+#: lib/nav_foot.html
+msgid "Explore Open Library Developer Center"
+msgstr "استكشف مركز مطوري المكتبة المفتوحة"
+
+#: lib/nav_foot.html lib/nav_head.html
+msgid "Developer Center"
+msgstr "مركز المطورين"
+
+#: lib/nav_foot.html
+msgid "Explore Open Library APIs"
+msgstr "استكشاف واجهات برمجة التطبيقات لمكتبة المفتوحة"
+
+#: lib/nav_foot.html
+msgid "API Documentation"
+msgstr "وثائق API"
+
+#: lib/nav_foot.html
+msgid "Bulk Open Library data"
+msgstr "بيانات مكتبة المفتوحة بالجملة"
+
+#: lib/nav_foot.html
+msgid "Bulk Data Dumps"
+msgstr "تفريغ البيانات بالجملة"
+
+#: lib/nav_foot.html
+msgid "Write a bot"
+msgstr "كتابة بوت"
+
+#: lib/nav_foot.html
+msgid "Writing Bots"
+msgstr "كتابة بوتات"
+
+#: lib/nav_foot.html
+msgid "Help Center"
+msgstr "مركز المساعدة"
+
+#: lib/nav_foot.html
+msgid "Problems"
+msgstr "مشاكل"
+
+#: lib/nav_foot.html
+msgid "Report A Problem"
+msgstr "الإبلاغ عن مشكلة"
+
+#: lib/nav_foot.html
+msgid "Suggest Edits"
+msgstr "اقتراح تعديلات"
+
+#: lib/nav_foot.html
+msgid "Suggesting Edits"
+msgstr "اقتراح تعديلات"
+
+#: lib/nav_foot.html
+msgid "Add a new book to Open Library"
+msgstr "إضافة كتاب جديد إلى المكتبة المفتوحة"
+
+#: lib/nav_foot.html
+msgid "Release Notes"
+msgstr "ملاحظات الإصدار"
+
+#: lib/nav_foot.html
+msgid "Twitter"
+msgstr "تويتر"
+
+#: lib/nav_foot.html
+msgid "GitHub"
+msgstr "GitHub"
+
+#: lib/nav_foot.html site/alert.html
+msgid "Change Website Language"
+msgstr "تغيير لغة الموقع"
+
+#: lib/nav_foot.html lib/nav_head.html type/list/embed.html
+msgid "Open Library logo"
+msgstr "شعار المكتبة المفتوحة"
+
+#: lib/nav_foot.html
+msgid ""
+"Open Library is an initiative of the <a href=\"//archive.org/\">Internet "
+"Archive</a>, a 501(c)(3) non-profit, building a digital library of "
+"Internet sites and other cultural artifacts in digital form. Other <a "
+"href=\"//archive.org/projects/\">projects</a> include the <a "
+"href=\"//archive.org/web/\">Wayback Machine</a>, <a "
+"href=\"//archive.org/\">archive.org</a> and <a href=\"//archive-it.org"
+"\">archive-it.org</a>"
+msgstr ""
+"المكتبة المفتوحة هي مبادرة من <a href=\"//archive.org/\">أرشيف الإنترنت</a>، "
+"منظمة غير ربحية 501(c)(3)، تبني مكتبة رقمية لمواقع الإنترنت والأشياء الثقافية الأخرى "
+"بشكل رقمي. تشمل المشاريع الأخرى <a href=\"//archive.org/projects/\">المشاريع</a> مثل "
+"<a href=\"//archive.org/web/\">آلة الزمن</a>، <a href=\"//archive.org/\">archive.org</a> و"
+"<a href=\"//archive-it.org\">archive-it.org</a>"
+
+#: lib/nav_foot.html
+#, python-format
+msgid ""
+"version <a "
+"href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</a>"
+msgstr ""
+"النسخة <a "
+"href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</a>"
+
+# | msgid "Reading Log"
+#: lib/nav_head.html
+msgid "Loans, Reading Log, Lists, Stats"
+msgstr "الاستعارات، سجل القراءة، القوائم، الإحصائيات"
+
+#: lib/nav_head.html
+msgid "My Profile"
+msgstr "ملفي الشخصي"
+
+#: lib/nav_head.html
+msgid "Log out"
+msgstr "تسجيل الخروج"
+
+#: lib/nav_head.html
+msgid "Pending Merge Requests"
+msgstr "طلبات الدمج المعلقة"
+
+#: lib/nav_head.html
+msgid "Trending"
+msgstr "رائج"
+
+#: lib/nav_head.html
+msgid "K-12 Student Library"
+msgstr "مكتبة الطلاب من الصفوف K-12"
+
+#: lib/nav_head.html
+msgid "Book Talks"
+msgstr "مناقشات الكتب"
+
+#: lib/nav_head.html
+msgid "Random Book"
+msgstr "كتاب عشوائي"
+
+#: lib/nav_head.html
+msgid "Recent Community Edits"
+msgstr "أحدث تعديلات المجتمع"
+
+#: lib/nav_head.html
+msgid "Help & Support"
+msgstr "المساعدة والدعم"
+
+#: lib/nav_head.html
+msgid "Librarians Portal"
+msgstr "بوابة الأمناء"
+
+#: lib/nav_head.html
+msgid "My Open Library"
+msgstr "مكتبتي المفتوحة"
+
+#: lib/nav_head.html
+msgid "Browse"
+msgstr "تصفح"
+
+#: lib/nav_head.html
+msgid "Contribute"
+msgstr "مساهمة"
+
+#: lib/nav_head.html
+msgid "Resources"
+msgstr "الموارد"
+
+#: lib/nav_head.html
+msgid "The Internet Archive's Open Library: One page for every book"
+msgstr "مكتبة المفتوحة من أرشيف الإنترنت: صفحة لكل كتاب"
+
+#: lib/nav_head.html
+msgid "All"
+msgstr "الكل"
+
+#: lib/nav_head.html
+msgid "Text"
+msgstr "نص"
+
+#: lib/nav_head.html
+msgid "Search by barcode"
+msgstr "البحث بواسطة الباركود"
+
+#: lib/not_logged.html
+msgid ""
+"<strong>You are not <a href=\"/account/login\" title=\"Log in "
+"now\">logged in</a>.</strong> Open Library will record your IP address "
+"and include it in this page's publicly accessible edit history. If you <a"
+" href=\"/account/create\" title=\"Create an Open Library account\">create"
+" an account</a>, your IP address is concealed and you can more easily "
+"keep track of all your edits and additions."
+msgstr ""
+
+#: Pager.html Pager_loanhistory.html lib/pagination.html
+msgid "Previous"
+msgstr "السابق"
+
+#: lists/header.html
+#, python-format
+msgid "<a href=\"%(href)s\">%(name)s</a> / Lists"
+msgstr "<a href=\"%(href)s\">%(name)s</a> / قوائم"
+
+#: lists/header.html
+#, python-format
+msgid "This author is on <strong>1 list</strong>."
+msgid_plural "This author is on <strong>%(count)s lists</strong>."
+msgstr[0] "هذا المؤلف موجود في <strong>1 قائمة</strong>."
+msgstr[1] "هذا المؤلف موجود في <strong>%(count)s قوائم</strong>."
+
+#: lists/header.html
+#, python-format
+msgid "This edition is on <strong>1 list</strong>."
+msgid_plural "This edition is on <strong>%(count)s lists</strong>."
+msgstr[0] "هذه النسخة موجودة في <strong>1 قائمة</strong>."
+msgstr[1] "هذه النسخة موجودة في <strong>%(count)s قوائم</strong>."
+
+#: lists/header.html
+#, python-format
+msgid "This work is on <strong>1 list</strong>."
+msgid_plural "This work is on <strong>%(count)s lists</strong>."
+msgstr[0] "هذا العمل موجود في <strong>1 قائمة</strong>."
+msgstr[1] "هذا العمل موجود في <strong>%(count)s قوائم</strong>."
+
+#: lists/header.html
+#, python-format
+msgid "%(name)s has 1 list."
+msgid_plural "%(name)s has %(count)s lists."
+msgstr[0] "%(name)s لديه 1 قائمة."
+msgstr[1] "%(name)s لديه %(count)s قوائم."
+
+#: lists/header.html
+#, python-format
+msgid "This subject is on <strong>1 list</strong>."
+msgid_plural "This subject is on <strong>%(count)s lists</strong>."
+msgstr[0] "هذا الموضوع موجود في <strong>1 قائمة</strong>."
+msgstr[1] "هذا الموضوع موجود في <strong>%(count)s قوائم</strong>."
+
+#: lists/header.html
+msgid "Hm. Can't find it."
+msgstr "همم. تعذر العثور عليه."
+
+#: lists/home.html
+msgid "Create a list of any Subjects, Authors, Works or specific Editions."
+msgstr "أنشئ قائمة بأي مواضيع أو مؤلفين أو أعمال أو نسخ محددة."
+
+#: lists/home.html
+msgid ""
+"Once you've made a list, you can <strong>watch for updates</strong> or "
+
+
+"<strong>export</strong> all the editions in a list as HTML, BibTeX or "
+"JSON. See all your lists and any activity using the \"Lists\" link on "
+"your Account page."
+msgstr ""
+"بمجرد إنشاء قائمة، يمكنك <strong>مراقبة التحديثات</strong> أو "
+"<strong>تصدير</strong> جميع النسخ في القائمة كـ HTML أو BibTeX أو "
+"JSON. شاهد جميع قوائمك وأي نشاط باستخدام رابط \"قوائم\" في "
+"صفحة حسابك."
+
+#: lists/home.html
+#, python-format
+msgid ""
+"For the top 2000+ most requested eBooks in California for the print "
+"disabled <a href=\"%(url)s\">click here</a>."
+msgstr ""
+"<a href=\"%(url)s\">انقر هنا</a> للحصول على قائمة بأكثر من 2000 من الكتب الإلكترونية "
+"الأكثر طلباً في كاليفورنيا لذوي الإعاقة البصرية."
+
+#: lists/home.html
+msgid "Find a list by name"
+msgstr "البحث عن قائمة بالاسم"
+
+#: lists/home.html
+msgid "Active Lists"
+msgstr "القوائم النشطة"
+
+#: lists/home.html
+#, python-format
+msgid "from <a href=\"%(key)s\">%(owner)s</a>"
+msgstr "من <a href=\"%(key)s\">%(owner)s</a>"
+
+#: lists/home.html lists/preview.html lists/snippet.html type/list/embed.html
+#: type/list/view_body.html
+#, python-format
+msgid "%(count)d item"
+msgid_plural "%(count)d items"
+msgstr[0] "%(count)d عنصر"
+msgstr[1] "%(count)d عناصر"
+
+#: lists/home.html lists/preview.html lists/snippet.html
+#, python-format
+msgid "Last modified %(date)s"
+msgstr "آخر تعديل في %(date)s"
+
+#: lists/home.html lists/snippet.html
+msgid "No description."
+msgstr "لا يوجد وصف."
+
+#: lists/home.html lists/lists.html type/user/view.html
+msgid "Recent Activity"
+msgstr "النشاطات الأخيرة"
+
+#: lists/home.html
+msgid "See all"
+msgstr "عرض الكل"
+
+#: lists/list_overview.html lists/widget.html my_books/dropdown_content.html
+msgid "See this list"
+msgstr "عرض هذه القائمة"
+
+#: lists/list_overview.html lists/widget.html my_books/dropdown_content.html
+msgid "Remove from your list?"
+msgstr "إزالة من قائمتك؟"
+
+#: lists/list_overview.html
+#, python-format
+msgid "from <a href=\"%(link)s\">You</a>"
+msgstr "من <a href=\"%(link)s\">أنت</a>"
+
+#: lists/list_overview.html
+#, python-format
+msgid "from <a href=\"%(link)s\">%(name)s</a>"
+msgstr "من <a href=\"%(link)s\">%(name)s</a>"
+
+#: lists/lists.html
+#, python-format
+msgid "%(owner)s / Lists"
+msgstr "%(owner)s / قوائم"
+
+#: lists/lists.html type/list/view_body.html
+msgid "Yes, I'm sure"
+msgstr "نعم، أنا متأكد"
+
+#: lists/lists.html type/list/view_body.html
+msgid "No, cancel"
+msgstr "لا، إلغاء"
+
+#: lists/lists.html
+msgid "Delete this list"
+msgstr "حذف هذه القائمة"
+
+#: lists/lists.html
+msgid "Delete list"
+msgstr "حذف القائمة"
+
+#: lists/lists.html
+msgid "Are you sure you want to delete this list?"
+msgstr "هل أنت متأكد أنك تريد حذف هذه القائمة؟"
+
+#: lists/lists.html
+msgid "Remove this seed?"
+msgstr "إزالة هذه البذور؟"
+
+#: lists/lists.html
+msgid "Remove"
+msgstr "إزالة"
+
+#: lists/lists.html
+#, python-format
+msgid "Are you sure you want to remove <strong>%(title)s</strong> from this list?"
+msgstr ""
+"هل أنت متأكد أنك تريد إزالة <strong>%(title)s</strong> من هذه القائمة؟"
+
+#: lists/lists.html
+msgid "This reader hasn't created any lists yet."
+msgstr "لم يقم هذا القارئ بإنشاء أي قوائم بعد."
+
+#: lists/lists.html
+msgid "You haven't created any lists yet."
+msgstr "لم تقم بإنشاء أي قوائم بعد."
+
+#: lists/lists.html
+msgid "Learn how to create your first list."
+msgstr "تعلم كيفية إنشاء قائمتك الأولى."
+
+#: lists/preview.html
+msgid "by <a href=\"$owner.key\">You</a>"
+msgstr "من <a href=\"$owner.key\">أنت</a>"
+
+#: lists/widget.html
+#, python-format
+msgid "%(count)d List"
+msgid_plural "%(count)d Lists"
+msgstr[0] "%(count)d قائمة"
+msgstr[1] "%(count)d قوائم"
+
+#: lists/widget.html my_books/dropdown_content.html
+msgid "from"
+msgstr "من"
+
+#: lists/widget.html my_books/dropdown_content.html
+msgid "You"
+msgstr "أنت"
+
+#: lists/widget.html
+msgid "Loading<span class=\"loading-ellipsis\">...</span>"
+msgstr "جارٍ التحميل<span class=\"loading-ellipsis\">...</span>"
+
+#: merge/authors.html
+msgid "Merge Authors"
+msgstr "دمج المؤلفين"
+
+#: merge/authors.html
+msgid "No authors selected."
+msgstr "لم يتم اختيار مؤلفين."
+
+#: merge/authors.html
+msgid "Please select a primary author record."
+msgstr "يرجى اختيار سجل مؤلف رئيسي."
+
+#: merge/authors.html
+msgid "Please select some authors to merge."
+msgstr "يرجى اختيار بعض المؤلفين لدمجهم."
+
+#: merge/authors.html
+msgid "Select the oldest profile as primary -"
+msgstr "حدد أقدم ملف شخصي كملف رئيسي -"
+
+#: merge/authors.html
+msgid "Select author records which should be merged with the primary"
+msgstr "حدد سجلات المؤلفين التي يجب دمجها مع السجل الرئيسي"
+
+#: merge/authors.html
+msgid "Press MERGE AUTHORS."
+msgstr "اضغط على دمج المؤلفين."
+
+#: merge/authors.html
+msgid "No primary record"
+msgstr "لا يوجد سجل رئيسي"
+
+#: merge/authors.html
+msgid "You must select a primary record to point the duplicates toward."
+msgstr "يجب عليك اختيار سجل رئيسي للإشارة إليه التكرارات."
+
+#: merge/authors.html
+msgid "Please Be Careful..."
+msgstr "يرجى الحذر..."
+
+#: merge/authors.html
+msgid "<b>Are you sure</b> you want to merge these records?"
+msgstr "<b>هل أنت متأكد</b> أنك تريد دمج هذه السجلات؟"
+
+#: merge/authors.html recentchanges/merge/view.html
+msgid "Primary"
+msgstr "رئيسي"
+
+#: merge/authors.html
+msgid "Merge"
+msgstr "دمج"
+
+#: merge/authors.html
+msgid "birth/death date"
+msgstr "تاريخ الميلاد/الوفاة"
+
+#: merge/authors.html
+msgid "Open in a new window"
+msgstr "فتح في نافذة جديدة"
+
+#: merge/authors.html
+msgid "Visit this author's page in a new window"
+msgstr "زيارة صفحة المؤلف في نافذة جديدة"
+
+#: merge/authors.html
+msgid "Comment:"
+msgstr "تعليق:"
+
+#: merge/authors.html
+msgid "Comment..."
+msgstr "علق..."
+
+# | msgid "Author Search"
+#: merge/authors.html
+msgid "Request Merge"
+msgstr "طلب دمج"
+
+#: merge/authors.html
+msgid "Reject Merge"
+msgstr "رفض الدمج"
+
+#: merge/works.html
+msgid "Merge Works"
+msgstr "دمج الأعمال"
+
+#: merge_request_table/merge_request_table.html
+msgid "Failed to submit comment. Please try again in a few moments."
+msgstr "فشل في إرسال التعليق. يرجى المحاولة مرة أخرى بعد قليل."
+
+#: merge_request_table/merge_request_table.html
+msgid "(Optional) Why are you closing this request?"
+msgstr "(اختياري) لماذا تقوم بإغلاق هذا الطلب؟"
+
+#: merge_request_table/merge_request_table.html
+#, python-format
+msgid "Showing %(username)s's requests only."
+msgstr "عرض طلبات %(username)s فقط."
+
+#: merge_request_table/merge_request_table.html
+msgid "Show all requests"
+msgstr "عرض جميع الطلبات"
+
+#: merge_request_table/merge_request_table.html
+msgid "Showing all requests."
+msgstr "عرض جميع الطلبات."
+
+#: merge_request_table/merge_request_table.html
+msgid "Show my requests"
+msgstr "عرض طلباتي"
+
+#: merge_request_table/merge_request_table.html
+msgid "Community Edit Requests"
+msgstr "طلبات تعديل المجتمع"
+
+#: merge_request_table/merge_request_table.html
+msgid "No entries here!"
+msgstr "لا توجد إدخالات هنا!"
+
+#: merge_request_table/table_header.html
+msgid "Open"
+msgstr "مفتوح"
+
+#: merge_request_table/table_header.html
+msgid "Closed"
+msgstr "مغلق"
+
+#: merge_request_table/table_header.html
+msgid "Status ▾"
+msgstr "الحالة ▾"
+
+#: merge_request_table/table_header.html
+msgid "Request Status"
+msgstr "حالة الطلب"
+
+#: merge_request_table/table_header.html
+msgid "Merged"
+msgstr "تم الدمج"
+
+#: merge_request_table/table_header.html
+msgid "Declined"
+msgstr "مرفوض"
+
+#: merge_request_table/table_header.html
+msgid "Submitter ▾"
+msgstr "الراسل ▾"
+
+#: merge_request_table/table_header.html
+msgid "Submitter"
+msgstr "الراسل"
+
+#: merge_request_table/table_header.html
+msgid "Filter submitters"
+msgstr "تصفية الرُسَل"
+
+#: merge_request_table/table_header.html
+msgid "Submitted by me"
+msgstr "مقدم من قبلي"
+
+#: merge_request_table/table_header.html
+msgid "Reviewer ▾"
+msgstr "المراجع ▾"
+
+#: merge_request_table/table_header.html
+msgid "Reviewer"
+msgstr "المراجع"
+
+#: merge_request_table/table_header.html
+msgid "Filter reviewers"
+msgstr "تصفية المراجعين"
+
+#: merge_request_table/table_header.html
+msgid "Assigned to nobody"
+msgstr "مخصص لأي شخص"
+
+#: merge_request_table/table_header.html
+msgid "Sort ▾"
+msgstr "ترتيب ▾"
+
+#: merge_request_table/table_header.html
+msgid "Sort"
+msgstr "ترتيب"
+
+#: merge_request_table/table_header.html
+msgid "Newest"
+msgstr "الأحدث"
+
+#: merge_request_table/table_header.html
+msgid "Oldest"
+msgstr "الأقدم"
+
+#: merge_request_table/table_row.html
+msgid "An untitled work"
+msgstr "عمل بدون عنوان"
+
+#: merge_request_table/table_row.html
+msgid "An unnamed author"
+msgstr "مؤلف غير مسمى"
+
+#: merge_request_table/table_row.html
+msgid "Open request"
+msgstr "طلب مفتوح"
+
+#: merge_request_table/table_row.html
+msgid "Closed request"
+msgstr "طلب مغلق"
+
+#: merge_request_table/table_row.html
+msgid "No comments yet."
+msgstr "لا توجد تعليقات بعد."
+
+#: merge_request_table/table_row.html
+msgid "Add a comment..."
+msgstr "إضافة تعليق..."
+
+#: merge_request_table/table_row.html
+msgid "Reply"
+msgstr "رد"
+
+#: merge_request_table/table_row.html
+#, python-format
+msgid ""
+"MR #%(id)s opened %(date)s by <a href=\"/people/%(submitter)s\" "
+"class=\"commenter\">@%(submitter)s</a>"
+msgstr ""
+
+#: merge_request_table/table_row.html
+msgid "Click to close this Merge Request"
+msgstr "انقر لإغلاق طلب الدمج هذا"
+
+#: merge_request_table/table_row.html type/edition/modal_links.html
+msgid "Review"
+msgstr "مراجعة"
+
+#: merge_request_table/table_row.html
+msgid "comments"
+msgstr "تعليقات"
+
+# | msgid "Removed"
+#: my_books/dropdown_content.html
+msgid "Remove From Shelf"
+msgstr "إزالة من الرف"
+
+#: my_books/dropdown_content.html
+msgid "My Reading Lists:"
+msgstr "قوائم قراءتي:"
+
+#: my_books/dropdown_content.html
+msgid "Use this Work"
+msgstr "استخدام هذا العمل"
+
+#: CreateListModal.html my_books/dropdown_content.html
+msgid "Create a new list"
+msgstr "إنشاء قائمة جديدة"
+
+#: CreateListModal.html my_books/dropdown_content.html
+#: type/permission/edit.html type/usergroup/edit.html
+msgid "Description:"
+msgstr "الوصف:"
+
+#: CreateListModal.html my_books/dropdown_content.html type/list/edit.html
+msgid "Create new list"
+msgstr "إنشاء قائمة جديدة"
+
+#: my_books/primary_action.html
+msgid "Add to List"
+msgstr "إضافة إلى القائمة"
+
+#: observations/review_component.html
+msgid "Community Reviews"
+msgstr "مراجعات المجتمع"
+
+#: observations/review_component.html
+msgid "No community reviews have been submitted for this work."
+msgstr "لم يتم تقديم أي مراجعات من المجتمع لهذا العمل."
+
+#: observations/review_component.html
+msgid "+ Add your community review"
+msgstr "+ أضف مراجعتك المجتمعية"
+
+#: observations/review_component.html
+msgid "+ Log in to add your community review"
+msgstr "+ تسجيل الدخول لإضافة مراجعتك المجتمعية"
+
+#: publishers/notfound.html
+msgid "Publishers"
+msgstr "الناشرون"
+
+# | msgid "We couldn't find any books published by %s."
+#: publishers/notfound.html
+#, python-format
+msgid "We couldn't find any books published by %(publisher)s."
+msgstr "لم نتمكن من العثور على أي كتب نشرتها %(publisher)s."
+
+#: publishers/notfound.html subjects/notfound.html
+msgid "Try something else?"
+msgstr "جرب شيئاً آخر؟"
+
+# | msgid "%s ebook"
+# | msgid_plural "%s ebooks"
+#: publishers/view.html
+#, python-format
+msgid "%(count)s ebook"
+msgid_plural "%(count)s ebooks"
+msgstr[0] "%(count)s كتاب إلكتروني"
+msgstr[1] "%(count)s كتب إلكترونية"
+
+#: publishers/view.html
+msgid ""
+"This is a chart to show the when this publisher published books. Along "
+"the X axis is time, and on the y axis is the count of editions published."
+" <a href=\"#subjectRelated\">Click here to skip the chart</a>."
+msgstr ""
+"هذا رسم بياني يوضح متى نشر هذا الناشر الكتب. على المحور X هو الزمن، وعلى "
+"المحور Y هو عدد الإصدارات المنشورة. <a href=\"#subjectRelated\">انقر هنا لتخطي الرسم البياني</a>."
+
+#: publishers/view.html
+msgid ""
+"This graph charts editions from this publisher over time. Click to view a"
+" single year, or drag across a range."
+msgstr ""
+"هذا الرسم البياني يوضح الإصدارات من هذا الناشر على مدى الزمن. انقر لعرض سنة واحدة، "
+"أو اسحب عبر نطاق."
+
+#: publishers/view.html
+msgid "Common Subjects"
+msgstr "المواضيع الشائعة"
+
+#: publishers/view.html
+msgid "published most by this publisher"
+msgstr "التي نُشرت أكثر من قبل هذا الناشر"
+
+#: publishers/view.html
+msgid "Publisher Search"
+msgstr "بحث في الناشرين"
+
+#: publishers/view.html
+msgid "Try a keyword."
+msgstr "جرب كلمة مفتاحية."
+
+#: recentchanges/header.html recentchanges/index.html
+msgid "Recent Changes"
+msgstr "التغييرات الأخيرة"
+
+#: recentchanges/index.html
+msgid "Books Edited"
+msgstr "كتب تم تحريرها"
+
+# | msgid "Authors"
+#: recentchanges/index.html
+msgid "Author Merges"
+msgstr "دمج المؤلفين"
+
+# | msgid "Authors"
+#: recentchanges/index.html
+msgid "Work Merges"
+msgstr "دمج الأعمال"
+
+# | msgid "Added"
+#: recentchanges/index.html
+msgid "Books Added"
+msgstr "كتب تمت إضافتها"
+
+#: RecentChanges.html recentchanges/index.html
+msgid "By Humans"
+msgstr "بواسطة الأشخاص"
+
+# | msgid "My Books"
+#: RecentChanges.html recentchanges/index.html
+msgid "By Bots"
+msgstr "بواسطة الروبوتات"
+
+#: recentchanges/updated_records.html
+msgid "Review what's changed in from the previous revision"
+msgstr "راجع التغييرات من النسخة السابقة"
+
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
+#: recentchanges/default/path.html recentchanges/updated_records.html
+msgid "diff"
+msgstr "مقارنة"
+
+#: recentchanges/default/message.html recentchanges/edit-book/message.html
+#: site/around_the_library.html
+msgid "opened a new Open Library account!"
+msgstr "أنشأ حساباً جديداً في Open Library!"
+
+#: recentchanges/default/path.html
+msgid "expand"
+msgstr "توسيع"
+
+# | msgid "View revision %s"
+#: RecentChanges.html RecentChangesUsers.html recentchanges/default/path.html
+msgid "Review what's changed from the previous revision"
+msgstr "راجع ما تغيّر منذ النسخة السابقة"
+
+#: recentchanges/merge/comment.html
+#, python-format
+msgid "Merged %(count)d duplicate %(type)s record into this primary."
+msgid_plural "Merged %(count)d duplicate %(type)s records into this primary."
+msgstr[0] "دمج %(count)d سجل مكرر من نوع %(type)s في هذا السجل الرئيسي."
+msgstr[1] "دمج %(count)d سجلات مكررة من نوع %(type)s في هذا السجل الرئيسي."
+
+#: recentchanges/merge/message.html
+#, python-format
+msgid "%(who)s merged one duplicate of %(master)s"
+msgid_plural "%(who)s merged %(count)d duplicates of %(master)s"
+msgstr[0] "%(who)s دمج تكرار واحد من %(master)s"
+msgstr[1] "%(who)s دمج %(count)d تكرارات من %(master)s"
+
+#: recentchanges/merge/message.html
+#, python-format
+msgid "one duplicate of %(master)s was merged anonymously"
+msgid_plural "%(count)d duplicates of %(master)s were merged anonymously"
+msgstr[0] "تم دمج تكرار واحد من %(master)s بشكل مجهول"
+msgstr[1] "تم دمج %(count)d تكرارات من %(master)s بشكل مجهول"
+
+#: recentchanges/merge/view.html
+msgid "This merge has been undone."
+msgstr "تم التراجع عن هذا الدمج."
+
+#: recentchanges/merge/view.html
+msgid "Details here"
+msgstr "التفاصيل هنا"
+
+# | msgid "Deprecated"
+#: recentchanges/merge/view.html type/author/view.html
+msgid "Duplicates"
+msgstr "تكرارات"
+
+#: recentchanges/merge/view.html
+#, python-format
+msgid "%(count)d record modified."
+msgid_plural "%(count)d records modified."
+msgstr[0] "%(count)d سجل تم تعديله."
+msgstr[1] "%(count)d سجلات تم تعديلها."
+
+# | msgid "Delete Record"
+#: recentchanges/merge/view.html
+msgid "Updated Records"
+msgstr "سجلات محدثة"
+
+#: search/advancedsearch.html
+msgid "ISBN"
+msgstr "رقم ISBN"
+
+#: search/advancedsearch.html
+msgid "Place"
+msgstr "مكان"
+
+#: search/advancedsearch.html
+msgid "Person"
+msgstr "شخص"
+
+#: search/advancedsearch.html
+msgid "How to search?"
+msgstr "كيف تبحث؟"
+
+# | msgid "Subject Search"
+#: search/advancedsearch.html
+msgid "Full Text Search?"
+msgstr "البحث النصي الكامل؟"
+
+#: search/authors.html
+msgid "Search Authors"
+msgstr "البحث عن المؤلفين"
+
+#: search/authors.html
+msgid "Is the same author listed twice?"
+msgstr "هل يتم إدراج نفس المؤلف مرتين؟"
+
+# | msgid "Explore authors"
+#: search/authors.html
+msgid "Merge authors"
+msgstr "دمج المؤلفين"
+
+#: search/authors.html
+msgid "No hits"
+msgstr "لا توجد نتائج"
+
+# | msgid "Welcome to Open Library"
+#: search/inside.html
+#, python-format
+msgid "Search Open Library for %s"
+msgstr "ابحث في Open Library عن %s"
+
+#: BookSearchInside.html SearchNavigation.html search/inside.html
+msgid "Search Inside"
+msgstr "البحث داخل"
+
+#: search/inside.html
+#, python-format
+msgid "No hits for: %(query)s"
+msgstr "لا توجد نتائج لـ: %(query)s"
+
+#: search/inside.html
+#, python-format
+msgid "About %(count)s result found"
+msgid_plural "About %(count)s results found"
+msgstr[0] "تم العثور على %(count)s نتيجة"
+msgstr[1] "تم العثور على %(count)s نتائج"
+
+#: search/inside.html
+#, python-format
+msgid "in %(seconds)s second"
+msgid_plural "in %(seconds)s seconds"
+msgstr[0] "في %(seconds)s ثانية"
+msgstr[1] "في %(seconds)s ثوانٍ"
+
+# | msgid "Search Results"
+#: search/lists.html
+msgid "Search results for Lists"
+msgstr "نتائج البحث للقوائم"
+
+#: search/lists.html
+msgid "Search Lists"
+msgstr "البحث في القوائم"
+
+#: search/publishers.html
+msgid "Publishers Search"
+msgstr "بحث في الناشرين"
+
+#: search/sort_options.html
+msgid "Sorted by"
+msgstr "مرتبة حسب"
+
+#: search/sort_options.html
+msgid "Relevance"
+msgstr "الأهمية"
+
+#: search/sort_options.html
+msgid "Work Count"
+msgstr "عدد الأعمال"
+
+# | msgid "Random Book"
+#: search/sort_options.html
+msgid "Random"
+msgstr "عشوائي"
+
+#: search/sort_options.html
+msgid "List Order"
+msgstr "ترتيب القائمة"
+
+#: search/sort_options.html
+msgid "Last Modified"
+msgstr "آخر تعديل"
+
+#: search/sort_options.html
+msgid "Most Editions"
+msgstr "أكثر الإصدارات"
+
+#: search/sort_options.html
+msgid "First Published"
+msgstr "تاريخ النشر الأول"
+
+#: search/sort_options.html
+msgid "Most Recent"
+msgstr "الأحدث"
+
+#: search/sort_options.html
+msgid "Top Rated"
+msgstr "الأعلى تقييماً"
+
+#: search/sort_options.html
+msgid "Any"
+msgstr "أي"
+
+#: search/sort_options.html
+msgid "Work Title (beta: Librarian only)"
+msgstr "عنوان العمل (بيتا: فقط للمكتبيين)"
+
+#: search/sort_options.html
+msgid "Shuffle"
+msgstr "تغيير عشوائي"
+
+#: search/subjects.html
+msgid "Search Subjects"
+msgstr "البحث في المواضيع"
+
+#: search/subjects.html
+msgid "time"
+msgstr "زمن"
+
+# | msgid "Subject"
+#: search/subjects.html
+msgid "subject"
+msgstr "موضوع"
+
+# | msgid "Place"
+#: search/subjects.html
+msgid "place"
+msgstr "مكان"
+
+# | msgid "or"
+#: search/subjects.html
+msgid "org"
+msgstr "منظمة"
+
+#: search/subjects.html
+msgid "event"
+msgstr "حدث"
+
+# | msgid "Person"
+#: search/subjects.html
+msgid "person"
+msgstr "شخص"
+
+# | msgid "%s work"
+# | msgid_plural "%s works"
+#: search/subjects.html
+msgid "work"
+msgstr "عمل"
+
+# | msgid "Recent Changes"
+#: site/around_the_library.html
+msgid "View all recent changes"
+msgstr "عرض جميع التغييرات الأخيرة"
+
+#: site/body.html
+msgid "It looks like you're offline."
+msgstr "يبدو أنك غير متصل بالإنترنت."
+
+# | msgid ""
+# | "Open Library is an open, editable library catalog, building towards a web
+# "
+# | "page for every book ever published."
+#: site/neck.html
+msgid ""
+"Open Library is an open, editable library catalog, building towards a web"
+" page for every book ever published. Read, borrow, and discover more than"
+" 3M books for free."
+msgstr ""
+"Open Library هو كتالوج مكتبة مفتوح وقابل للتعديل، يبني نحو صفحة ويب لكل كتاب تم نشره على الإطلاق. اقرأ، اقترض، واكتشف أكثر من 3 مليون كتاب مجاناً."
+
+# | msgid "Sign Up to Open Library"
+#: site/neck.html
+msgid "Open Library"
+msgstr "Open Library"
+
+# | msgid "Reading Log"
+#: stats/readinglog.html
+msgid "Reading Log Stats"
+msgstr "إحصائيات سجل القراءة"
+
+#: stats/readinglog.html
+msgid "# Books Logged"
+msgstr "# كتب تم تسجيلها"
+
+#: stats/readinglog.html
+msgid "The total number of books logged using the Reading Log feature"
+msgstr "العدد الإجمالي للكتب التي تم تسجيلها باستخدام ميزة سجل القراءة"
+
+#: stats/readinglog.html
+msgid "All time"
+msgstr "جميع الأوقات"
+
+#: stats/readinglog.html
+msgid "# Unique Users Logging Books"
+msgstr "عدد المستخدمين الفريدين الذين قاموا بتسجيل الكتب"
+
+#: stats/readinglog.html
+msgid ""
+"The total number of unique users who have logged at least one book using "
+"the Reading Log feature"
+msgstr ""
+"إجمالي عدد المستخدمين الفريدين الذين قاموا بتسجيل كتاب واحد على الأقل باستخدام "
+"ميزة سجل القراءة"
+
+#: stats/readinglog.html
+msgid "# Books Starred"
+msgstr "# الكتب المميزة"
+
+#: stats/readinglog.html
+msgid "The total number of books which have been starred"
+msgstr "إجمالي عدد الكتب التي تم تمييزها"
+
+#: stats/readinglog.html
+msgid "Total # Unique Raters (all time)"
+msgstr "إجمالي عدد المقيمين الفريدين (منذ البداية)"
+
+#: stats/readinglog.html
+msgid "Most Wanted Books (This Month)"
+msgstr "أكثر الكتب طلباً (هذا الشهر)"
+
+#: stats/readinglog.html
+#, python-format
+msgid "Added %(count)d time"
+msgid_plural "Added %(count)d times"
+msgstr[0] "أضيفت %(count)d مرة"
+msgstr[1] "أضيفت %(count)d مرات"
+
+#: stats/readinglog.html
+msgid "Most Wanted Books (All Time)"
+msgstr "أكثر الكتب طلباً (منذ البداية)"
+
+#: stats/readinglog.html
+msgid "Most Logged Books"
+msgstr "أكثر الكتب التي تم تسجيلها"
+
+#: stats/readinglog.html
+msgid "Most Read Books (All Time)"
+msgstr "أكثر الكتب قراءة (منذ البداية)"
+
+#: stats/readinglog.html
+msgid "Most Rated Books"
+msgstr "أكثر الكتب تقييماً"
+
+#: stats/readinglog.html
+msgid "Most Rated Books (All Time)"
+msgstr "أكثر الكتب تقييماً (منذ البداية)"
+
+#: subjects/notfound.html
+msgid "We couldn't find any books about"
+msgstr "لم نتمكن من العثور على أي كتب عن"
+
+#: swagger/swaggerui.html
+msgid "OpenAPI"
+msgstr "OpenAPI"
+
+#: tag/add.html
+msgid "Add a tag"
+msgstr "أضف علامة"
+
+#: tag/add.html
+msgid "Add a tag to Open Library"
+msgstr "أضف علامة إلى المكتبة المفتوحة"
+
+#: tag/add.html
+msgid "Name of Tag"
+msgstr "اسم العلامة"
+
+#: tag/add.html
+msgid "How would you describe this tag?"
+msgstr "كيف تصف هذه العلامة؟"
+
+#: tag/add.html type/tag/edit.html
+msgid "Tag type"
+msgstr "نوع العلامة"
+
+#: tag/add.html
+msgid "Add this tag now"
+msgstr "أضف هذه العلامة الآن"
+
+#: type/about/edit.html type/page/edit.html type/permission/edit.html
+#: type/template/edit.html type/usergroup/edit.html
+#, python-format
+msgid "Edit %(title)s"
+msgstr "تعديل %(title)s"
+
+#: type/about/edit.html
+msgid ""
+"This only appears in the document head, and gets attached to bookmark "
+"labels"
+msgstr ""
+"يظهر هذا فقط في رأس الوثيقة، ويتم إرفاقه بعلامات الإشارات المرجعية"
+
+#: type/about/edit.html
+msgid "Intro"
+msgstr "مقدمة"
+
+#: type/about/edit.html
+msgid "This appears in first column."
+msgstr "يظهر هذا في العمود الأول."
+
+#: type/about/edit.html
+msgid "This appears in the second column, at top."
+msgstr "يظهر هذا في العمود الثاني، في الأعلى."
+
+#: type/about/edit.html
+msgid "Mailing List"
+msgstr "قائمة البريد"
+
+#: type/about/edit.html
+msgid "This appears below the links list."
+msgstr "يظهر هذا أسفل قائمة الروابط."
+
+#: type/author/edit.html
+msgid "Edit Author"
+msgstr "تعديل المؤلف"
+
+#: type/author/edit.html
+msgid ""
+"Please use natural order. For example: <strong>Leo Tolstoy</strong> not "
+"<strong>Tolstoy, Leo</strong>."
+msgstr ""
+"يرجى استخدام الترتيب الطبيعي. على سبيل المثال: <strong>ليو تولستوي</strong> وليس "
+"<strong>تولستوي، ليو</strong>."
+
+#: type/author/edit.html
+msgid "About"
+msgstr "حول"
+
+#: type/author/edit.html
+msgid "A short bio?"
+msgstr "سيرة ذاتية قصيرة؟"
+
+#: type/author/edit.html
+msgid ""
+"If you \"borrow\" information from somewhere, please make sure to cite "
+"the source."
+msgstr ""
+"إذا كنت \"تستعير\" معلومات من مكان ما، يرجى التأكد من الإشارة إلى "
+"المصدر."
+
+#: type/author/edit.html
+msgid "Date of birth"
+msgstr "تاريخ الميلاد"
+
+#: type/author/edit.html
+msgid "Date of death"
+msgstr "تاريخ الوفاة"
+
+#: type/author/edit.html
+msgid ""
+"We're not storing structured dates (yet) so a date like \"21 May 2000\" "
+"is recommended."
+msgstr ""
+"نحن لا نخزن تواريخ منسقة (بعد) لذا يُوصى بتاريخ مثل \"21 مايو 2000\"."
+
+#: type/author/edit.html
+msgid ""
+"This is a deprecated field. You can help improve this record by removing "
+"this date and populating the \"Date of birth\" and \"Date of death\" "
+"fields. Thanks!"
+msgstr ""
+"هذا حقل منسوخ. يمكنك المساعدة في تحسين هذا السجل عن طريق إزالة "
+"هذا التاريخ وملء حقلي \"تاريخ الميلاد\" و\"تاريخ الوفاة\". شكراً!"
+
+#: type/author/edit.html
+msgid "Does this author go by any other names?"
+msgstr "هل يستخدم هذا المؤلف أسماء أخرى؟"
+
+#: type/author/edit.html
+msgid "Identifiers"
+msgstr "معرفات"
+
+#: type/author/edit.html
+msgid "Author Identifiers Purpose"
+msgstr "الغرض من معرفات المؤلف"
+
+#: type/author/view.html
+msgid "name missing"
+msgstr "الاسم مفقود"
+
+#: type/author/view.html type/edition/view.html type/work/view.html
+#, python-format
+msgid "%(page_title)s | Open Library"
+msgstr "%(page_title)s | المكتبة المفتوحة"
+
+#: type/author/view.html
+#, python-format
+msgid "Author of %(book_titles)s"
+msgstr "مؤلف %(book_titles)s"
+
+#: type/author/view.html
+msgid "Merging Authors..."
+msgstr "دمج المؤلفين…"
+
+#: type/author/view.html
+msgid "In progress..."
+msgstr "قيد التنفيذ…"
+
+#: type/author/view.html
+msgid "Refresh the page?"
+msgstr "تحديث الصفحة؟"
+
+#: type/author/view.html
+msgid "Success!"
+msgstr "نجاح!"
+
+#: type/author/view.html
+msgid ""
+"OK. The merge is in motion. <i>It will take <u>a few minutes to "
+"finish</u> the update.</i>"
+msgstr ""
+"حسنًا. الدمج جارٍ. <i>سيستغرق <u>بضع دقائق لإكمال</u> التحديث.</i>"
+
+#: type/author/view.html
+msgid "Argh!"
+msgstr "آه!"
+
+#: type/author/view.html
+msgid "That merge didn't work. It's our fault, and we've made a note of it."
+msgstr "لم ينجح الدمج. إنها مسؤوليتنا، وقد أخذنا ملاحظة بذلك."
+
+#: type/author/view.html
+msgid "Location"
+msgstr "الموقع"
+
+#: type/author/view.html
+msgid "Add another?"
+msgstr "أضف آخر؟"
+
+#: type/author/view.html
+#, python-format
+msgid ""
+"Showing all works by author. Would you like to see <a "
+"href=\"%(url)s\">only ebooks</a>?"
+msgstr ""
+"عرض جميع أعمال المؤلف. هل ترغب في رؤية <a "
+"href=\"%(url)s\">الكتب الإلكترونية فقط</a>؟"
+
+#: type/author/view.html
+#, python-format
+msgid ""
+"Showing ebooks only. Would you like to see <a "
+"href=\"%(url)s\">everything</a> by this author?"
+msgstr ""
+"عرض الكتب الإلكترونية فقط. هل ترغب في رؤية <a "
+"href=\"%(url)s\">كل شيء</a> من هذا المؤلف؟"
+
+#: type/author/view.html
+msgid "Time"
+msgstr "الوقت"
+
+#: type/author/view.html
+msgid "OLID"
+msgstr "OLID"
+
+#: type/author/view.html
+msgid "Links <span class=\"gray small sansserif\">(outside Open Library)"
+msgstr "روابط <span class=\"gray small sansserif\">(خارج المكتبة المفتوحة)</span>"
+
+#: type/author/view.html
+msgid "No links yet."
+msgstr "لا توجد روابط بعد."
+
+#: type/author/view.html
+msgid "Add one"
+msgstr "أضف واحداً"
+
+#: type/author/view.html
+msgid "Alternative names"
+msgstr "أسماء بديلة"
+
+#: type/delete/view.html
+msgid "This page has been deleted"
+msgstr "تم حذف هذه الصفحة"
+
+#: type/delete/view.html
+msgid "What would you like to do?"
+msgstr "ماذا تريد أن تفعل؟"
+
+#: type/delete/view.html
+msgid "Go back where I came from"
+msgstr "ارجع إلى المكان الذي جئت منه"
+
+#: type/delete/view.html
+msgid "View the previous version"
+msgstr "عرض النسخة السابقة"
+
+# | msgid "Create it?"
+#: type/delete/view.html
+msgid "Recreate it"
+msgstr "إعادة إنشائه"
+
+#: type/delete/view.html
+msgid "See the page's history"
+msgstr "عرض تاريخ الصفحة"
+
+#: type/edition/admin_bar.html
+msgid "Add to Staff Picks"
+msgstr "إضافة إلى اختيارات الموظفين"
+
+#: type/edition/admin_bar.html
+msgid "Sync Archive.org ID"
+msgstr "مزامنة معرف Archive.org"
+
+# | msgid "Full-Text Search on Archive.org"
+#: type/edition/admin_bar.html
+msgid "View Book on Archive.org"
+msgstr "عرض الكتاب على Archive.org"
+
+# | msgid "This Edition"
+#: SearchResultsWork.html type/edition/admin_bar.html
+msgid "Orphaned Edition"
+msgstr "النسخة اليتيمة"
+
+#: databarHistory.html databarView.html type/edition/compact_title.html
+msgid "Edit this page"
+msgstr "تعديل هذه الصفحة"
+
+#: type/edition/title_and_author.html
+msgid "An edition of"
+msgstr "نسخة من"
+
+# | msgid "First Published"
+#: type/edition/title_and_author.html
+#, python-format
+msgid "First published in %s"
+msgstr "نُشرت لأول مرة في %s"
+
+#: type/edition/view.html type/work/view.html
+#, python-format
+msgid ""
+"This edition doesn't have a description yet. Can you <b><a "
+"href='%(url)s'>add one</a></b>?"
+msgstr ""
+"لم يكن لهذه النسخة وصف بعد. هل يمكنك <b><a "
+"href='%(url)s'>إضافة واحد</a></b>؟"
+
+#: type/edition/view.html type/work/view.html
+msgid "Publish Date"
+msgstr "تاريخ النشر"
+
+# | msgid "Show for other books from %s"
+#: type/edition/view.html type/work/view.html
+#, python-format
+msgid "Show other books from %(publisher)s"
+msgstr "عرض كتب أخرى من %(publisher)s"
+
+# | msgid "Search for other books from"
+#: type/edition/view.html type/work/view.html
+#, python-format
+msgid "Search for other books from %(publisher)s"
+msgstr "ابحث عن كتب أخرى من %(publisher)s"
+
+#: type/edition/view.html type/work/view.html
+msgid "Pages"
+msgstr "الصفحات"
+
+#: databarWork.html type/edition/view.html type/work/view.html
+msgid "Buy this book"
+msgstr "اشترِ هذا الكتاب"
+
+#: type/edition/view.html type/work/view.html
+msgid "Book Details"
+msgstr "تفاصيل الكتاب"
+
+#: type/edition/view.html type/work/view.html
+msgid "First Sentence"
+msgstr "أول جملة"
+
+#: type/edition/view.html type/work/view.html
+msgid "Edition Notes"
+msgstr "ملاحظات النسخة"
+
+#: type/edition/view.html type/work/view.html
+msgid "Published in"
+msgstr "نُشر في"
+
+#: type/edition/view.html type/work/view.html
+msgid "Series"
+msgstr "سلسلة"
+
+#: type/edition/view.html type/work/view.html
+msgid "Volume"
+msgstr "مجلد"
+
+#: type/edition/view.html type/work/view.html
+msgid "Genre"
+msgstr "نوع"
+
+#: type/edition/view.html type/work/view.html
+msgid "Other Titles"
+msgstr "عناوين أخرى"
+
+#: type/edition/view.html type/work/view.html
+msgid "Copyright Date"
+msgstr "تاريخ حقوق الطبع والنشر"
+
+#: type/edition/view.html type/work/view.html
+msgid "Translation Of"
+msgstr "ترجمة من"
+
+#: type/edition/view.html type/work/view.html
+msgid "Translated From"
+msgstr "ترجم من"
+
+#: type/edition/view.html type/work/view.html
+msgid "External Links"
+msgstr "روابط خارجية"
+
+#: type/edition/view.html type/work/view.html
+msgid "Format"
+msgstr "تنسيق"
+
+#: type/edition/view.html type/work/view.html
+msgid "Pagination"
+msgstr "ترقيم الصفحات"
+
+#: type/edition/view.html type/work/view.html
+msgid "Number of pages"
+msgstr "عدد الصفحات"
+
+#: type/edition/view.html type/work/view.html
+msgid "Weight"
+msgstr "وزن"
+
+#: type/edition/view.html type/work/view.html
+msgid "Work Description"
+msgstr "وصف العمل"
+
+#: type/edition/view.html type/work/view.html
+msgid "Original languages"
+msgstr "اللغات الأصلية"
+
+# | msgid "Add Excerpts"
+#: type/edition/view.html type/work/view.html
+msgid "Excerpts"
+msgstr "مقتطفات"
+
+#: type/edition/view.html type/work/view.html
+#, python-format
+msgid "Page %(page)s"
+msgstr "الصفحة %(page)s"
+
+#: type/edition/view.html type/work/view.html
+#, python-format
+msgid "added by %(authorlink)s."
+msgstr "أضيف بواسطة %(authorlink)s."
+
+# | msgid "an anonymous user"
+#: type/edition/view.html type/work/view.html
+msgid "added anonymously."
+msgstr "أضيف بشكل مجهول."
+
+#: type/edition/view.html type/work/view.html
+msgid "Links <span class=\"gray small sansserif\">outside Open Library</span>"
+msgstr "روابط <span class=\"gray small sansserif\">خارج المكتبة المفتوحة</span>"
+
+#: type/edition/view.html type/work/view.html
+msgid "Wikipedia"
+msgstr "ويكيبيديا"
+
+#: type/edition/view.html type/work/view.html
+msgid "This work does not appear on any lists."
+msgstr "هذا العمل لا يظهر في أي قوائم."
+
+#: type/edition/view.html type/work/view.html
+msgid "Loading Related Books"
+msgstr "تحميل الكتب ذات الصلة"
+
+#: type/language/view.html
+msgid "Code"
+msgstr "رمز"
+
+#: type/language/view.html
+#, python-format
+msgid "Try a <a href=\"%(href)s\">search for readable books in %(language)s</a>?"
+msgstr "هل ترغب في تجربة <a href=\"%(href)s\">البحث عن كتب قابلة للقراءة باللغة %(language)s</a>؟"
+
+#: type/list/edit.html
+#, python-format
+msgid "Editing list: %(list_name)s"
+msgstr "تعديل القائمة: %(list_name)s"
+
+# | msgid "Reading Lists"
+#: type/list/edit.html
+msgid "Edit List"
+msgstr "تعديل القائمة"
+
+#: type/list/edit.html
+msgid ""
+"⚠️ Saving global lists is admin-only while the feature is under "
+"development."
+msgstr ""
+"⚠️ حفظ القوائم العالمية متاح فقط للمسؤولين بينما الميزة تحت "
+"التطوير."
+
+#: type/list/edit.html
+msgid "Search for a book"
+msgstr "ابحث عن كتاب"
+
+#: type/list/edit.html
+msgid "Notes (optional)"
+msgstr "ملاحظات (اختياري)"
+
+#: type/list/edit.html
+msgid "List Name"
+msgstr "اسم القائمة"
+
+#: type/list/edit.html
+msgid "Description (optional)"
+msgstr "الوصف (اختياري)"
+
+#: type/list/edit.html
+msgid "Add another book"
+msgstr "إضافة كتاب آخر"
+
+# | msgid "Sign Up to Open Library"
+#: type/list/embed.html
+msgid "Visit Open Library"
+msgstr "زيارة المكتبة المفتوحة"
+
+# | msgid "Explore authors"
+#: type/list/embed.html type/list/view_body.html
+msgid "Unknown authors"
+msgstr "مؤلفون مجهولون"
+
+#: type/list/embed.html
+msgid ""
+"Open in online Book Reader. Downloads available in ePub, DAISY, PDF, TXT "
+"formats from main book page"
+msgstr ""
+"عرض في قارئ الكتب الإلكتروني. التنزيلات متاحة بصيغ ePub و DAISY و PDF و TXT "
+"من الصفحة الرئيسية للكتاب"
+
+#: type/list/embed.html
+msgid "This book is checked out"
+msgstr "هذا الكتاب مُستعار"
+
+#: type/list/embed.html
+msgid "Checked out"
+msgstr "مستعار"
+
+#: type/list/embed.html
+msgid "Borrow book"
+msgstr "استعارة الكتاب"
+
+#: type/list/embed.html
+msgid "Protected DAISY"
+msgstr "DAISY محمي"
+
+#: BookByline.html type/list/embed.html
+#, python-format
+msgid "by %(name)s"
+msgstr "بواسطة %(name)s"
+
+#: type/list/exports.html
+msgid "Export"
+msgstr "تصدير"
+
+#: type/list/exports.html
+#, python-format
+msgid "as %(json_link)s, %(html_link)s, or %(bibtex_link)s"
+msgstr "كـ %(json_link)s أو %(html_link)s أو %(bibtex_link)s"
+
+#: type/list/exports.html
+msgid "Subscribe"
+msgstr "اشترك"
+
+#: type/list/exports.html
+#, python-format
+msgid "Watch activity via <a rel=\"nofollow\" href=\"%s\">Atom feed</a>"
+msgstr "تتبع النشاط عبر <a rel=\"nofollow\" href=\"%s\">خلاصة Atom</a>"
+
+#: type/list/exports.html
+msgid "Export Not Available"
+msgstr "التصدير غير متوفر"
+
+#: type/list/exports.html
+#, python-format
+msgid ""
+"Only lists with up to %(max)s editions can be exported. This one has "
+"%(count)s."
+msgstr ""
+"يمكن تصدير القوائم التي تحتوي على %(max)s نسخ كحد أقصى فقط. هذه القائمة تحتوي على "
+"%(count)s."
+
+#: type/list/exports.html
+#, python-format
+msgid ""
+"Try removing some seeds for more focus, or look at <a href=\"%s\">bulk "
+"download</a> of the catalog."
+msgstr ""
+"حاول إزالة بعض المصادر لمزيد من التركيز، أو اطلع على <a href=\"%s\">تنزيلات بالجملة</a> "
+"للكتالوج."
+
+# | msgid "Sign Up to Open Library"
+#: type/list/view_body.html
+#, python-format
+msgid "%(name)s | Lists | Open Library"
+msgstr "%(name)s | القوائم | المكتبة المفتوحة"
+
+#: type/list/view_body.html
+#, python-format
+msgid "%(title)s: %(description)s"
+msgstr "%(title)s: %(description)s"
+
+#: type/list/view_body.html
+msgid "View the list on Open Library."
+msgstr "عرض القائمة على المكتبة المفتوحة."
+
+#: type/list/view_body.html
+msgid "Remove this item?"
+msgstr "إزالة هذه العناصر؟"
+
+#: type/list/view_body.html
+#, python-format
+msgid "Last modified <span>%(date)s</span>"
+msgstr "آخر تعديل <span>%(date)s</span>"
+
+# | msgid "Removed"
+#: type/list/view_body.html
+msgid "Remove seed"
+msgstr "إزالة المصدر"
+
+#: type/list/view_body.html
+msgid "Are you sure you want to remove this item from the list?"
+msgstr "هل أنت متأكد أنك تريد إزالة هذه العناصر من القائمة؟"
+
+# | msgid "Removed"
+#: type/list/view_body.html
+msgid "Remove Seed"
+msgstr "إزالة المصدر"
+
+#: type/list/view_body.html
+msgid ""
+"You are about to remove the last item in the list. That will delete the "
+"whole list. Are you sure you want to continue?"
+msgstr ""
+"أنت على وشك إزالة آخر عنصر في القائمة. سيؤدي ذلك إلى حذف القائمة بالكامل. هل أنت "
+"متأكد أنك تريد الاستمرار؟"
+
+#: type/list/view_body.html
+msgid "There are no items on this list."
+msgstr "لا توجد عناصر في هذه القائمة."
+
+#: type/list/view_body.html
+msgid ""
+"<a href=\"/search\" target=\"_blank\">Search for book, subjects, or "
+"authors</a> to add to your list."
+msgstr ""
+"<a href=\"/search\" target=\"_blank\">ابحث عن كتب أو مواضيع أو مؤلفين</a> لإضافتها إلى قائمتك."
+
+#: type/list/view_body.html
+msgid "Learn more."
+msgstr "تعلم المزيد."
+
+#: type/list/view_body.html
+msgid "List Metadata"
+msgstr "بيانات القائمة"
+
+#: type/list/view_body.html
+msgid "Derived from seed metadata"
+msgstr "مستمدة من بيانات المصدر"
+
+#: type/local_id/view.html
+msgid "Source Item"
+msgstr "العنصر المصدر"
+
+#: type/local_id/view.html
+msgid "prefix"
+msgstr "بادئة"
+
+#: type/local_id/view.html
+msgid "Example"
+msgstr "مثال"
+
+#: type/page/edit.html
+msgid "Document Body:"
+msgstr "نص الوثيقة:"
+
+#: type/permission/edit.html
+msgid "Readers:"
+msgstr "القراء:"
+
+#: type/permission/edit.html
+msgid "Writers:"
+msgstr "الكتّاب:"
+
+#: type/permission/view.html
+msgid "Readers"
+msgstr "القراء"
+
+#: type/permission/view.html
+msgid "Writers"
+msgstr "الكتّاب"
+
+#: type/tag/edit.html
+msgid "Edit Tag"
+msgstr "تعديل الوسم"
+
+#: type/tag/edit.html
+msgid "Label"
+msgstr "علامة"
+
+#: type/tag/edit.html type/user/edit.html
+msgid "Description"
+msgstr "الوصف"
+
+#: type/tag/view.html
+#, python-format
+msgid "View subject page for %(name)s."
+msgstr "عرض صفحة الموضوع لـ %(name)s."
+
+#: type/template/edit.html
+msgid "Document Body"
+msgstr "نص الوثيقة"
+
+# | msgid "Delete this book?"
+#: type/template/edit.html
+msgid "Delete this template?"
+msgstr "حذف هذا القالب؟"
+
+#: type/type/view.html
+msgid "Kind"
+msgstr "نوع"
+
+# | msgid "Differences"
+#: type/type/view.html
+msgid "Backreferences"
+msgstr "الروابط العكسية"
+
+#: type/user/edit.html
+msgid "Currently Editing:"
+msgstr "تعديل حالي:"
+
+#: type/user/edit.html
+msgid "Display Name"
+msgstr "اسم العرض"
+
+#: type/user/view.html
+msgid "admin page"
+msgstr "صفحة الإدارة"
+
+#: type/user/view.html
+#, python-format
+msgid ""
+"You are publicly sharing the books you are <a href=\"%(username)s/books"
+"/currently-reading\">currently reading</a>, <a href=\"%(username)s/books"
+"/already-read\">have already read</a>, and <a href=\"%(username)s/books"
+"/want-to-read\">want to read</a>."
+msgstr ""
+"أنت تشارك علنًا الكتب التي <a href=\"%(username)s/books/currently-reading\">تقرأها حاليًا</a>، "
+"<a href=\"%(username)s/books/already-read\">التي قرأتها بالفعل</a>، و<a href=\"%(username)s/books/"
+"want-to-read\">التي ترغب في قراءتها</a>."
+
+#: type/user/view.html
+msgid "You have chosen to make your"
+msgstr "لقد اخترت جعل"
+
+#: type/user/view.html
+msgid "private"
+msgstr "خاص"
+
+#: type/user/view.html
+msgid "Manage your privacy settings"
+msgstr "إدارة إعدادات الخصوصية الخاصة بك"
+
+#: type/user/view.html
+#, python-format
+msgid ""
+"Here are the books %(user)s is <a href=\"%(username)s/books/currently-"
+"reading\">currently reading</a>, <a href=\"%(username)s/books/already-"
+"read\">have already read</a>, and <a href=\"%(username)s/books/want-to-"
+"read\">want to read</a>!"
+msgstr ""
+"إليك الكتب التي <a href=\"%(username)s/books/currently-reading\">يقرأها %(user)s حاليًا</a>، "
+"<a href=\"%(username)s/books/already-read\">التي قرأها بالفعل</a>، و<a href=\"%(username)s/books/"
+"want-to-read\">التي يرغب في قراءتها</a>!"
+
+#: type/user/view.html
+msgid "My Lists"
+msgstr "قوائمي"
+
+#: RecentChangesUsers.html type/user/view.html
+msgid "No edits. Yet."
+msgstr "لا توجد تعديلات. حتى الآن."
+
+#: type/usergroup/edit.html
+msgid "Members:"
+msgstr "الأعضاء:"
+
+#: SearchResultsWork.html type/work/editions.html
+#, python-format
+msgid "First published in %(year)s"
+msgstr "نُشرت لأول مرة في %(year)s"
+
+#: type/work/editions.html type/work/editions_datatable.html
+#, python-format
+msgid "Add another edition of %(work)s"
+msgstr "إضافة نسخة أخرى من %(work)s"
+
+#: UserEditRow.html type/work/editions.html
+msgid "Add another"
+msgstr "إضافة أخرى"
+
+#: type/work/editions.html
+msgid "Title missing"
+msgstr "العنوان مفقود"
+
+#: type/work/editions_datatable.html
+#, python-format
+msgid "Showing %(count)d featured edition."
+msgid_plural "Showing %(count)d featured editions."
+msgstr[0] "عرض %(count)d نسخة مميزة."
+msgstr[1] "عرض %(count)d نسخ مميزة."
+
+#: type/work/editions_datatable.html
+#, python-format
+msgid "View all %(count)d editions?"
+msgstr "عرض جميع %(count)d النسخ؟"
+
+#: type/work/editions_datatable.html
+msgid "Edition"
+msgstr "نسخة"
+
+#: type/work/editions_datatable.html
+msgid "Availability"
+msgstr "التوفر"
+
+# | msgid "editions in"
+#: type/work/editions_datatable.html
+msgid "No editions available"
+msgstr "لا توجد نسخ متاحة"
+
+#: type/work/editions_datatable.html
+msgid "Add another edition?"
+msgstr "إضافة نسخة أخرى؟"
+
+#: AffiliateLinks.html
+#, python-format
+msgid "Look for this edition for sale at %(store)s"
+msgstr "ابحث عن هذه النسخة للبيع في %(store)s"
+
+#: AffiliateLinks.html
+msgid "Fetching prices"
+msgstr "جلب الأسعار"
+
+#: AffiliateLinks.html
+msgid "Better World Books"
+msgstr "كتب عالم أفضل"
+
+#: AffiliateLinks.html
+msgid " - includes shipping"
+msgstr " - يشمل الشحن"
+
+#: AffiliateLinks.html
+msgid "Amazon"
+msgstr "أمازون"
+
+#: AffiliateLinks.html
+msgid "Bookshop.org"
+msgstr "Bookshop.org"
+
+#: AffiliateLinks.html
+msgid ""
+"When you buy books using these links the Internet Archive may earn a <a "
+"class=\"nostyle\" href=\"/help/faq/about#selling\">small commission</a>."
+msgstr ""
+"عند شراء الكتب باستخدام هذه الروابط، قد يكسب الأرشيف الإلكتروني <a class=\"nostyle\" "
+"href=\"/help/faq/about#selling\">عمولة صغيرة</a>."
+
+#: BookByline.html
+#, python-format
+msgid "%(n)s other"
+msgid_plural "%(n)s others"
+msgstr[0] "%(n)s أخرى"
+msgstr[1] "%(n)s أخرى"
+
+#: BookByline.html
+msgid "by an <em>unknown author</em>"
+msgstr "بواسطة <em>مؤلف غير معروف</em>"
+
+#: BookPreview.html
+msgid "Only"
+msgstr "فقط"
+
+#: BookPreview.html
+msgid "Preview Book"
+msgstr "معاينة الكتاب"
+
+#: DonateModal.html
+#, fuzzy
+msgid ""
+"Donate this book to the <a href=\"https://archive.org\">Internet "
+"Archive</a> library."
+msgstr ""
+"تبرع بهذا الكتاب إلى مكتبة <a href=\"https://archive.org\">الأرشيف الإلكتروني</a>."
+
+#: DonateModal.html
+msgid ""
+"Hooray! You've discovered a title that's missing from our <a "
+"href=\"https://help.archive.org/hc/en-us/articles/360016554912-Borrowing-"
+"From-The-Lending-Library\">library</a>. Can you help donate a copy?"
+msgstr ""
+"تهانينا! لقد اكتشفت عنوانًا مفقودًا من <a href=\"https://help.archive.org/hc/en-us/"
+"articles/360016554912-Borrowing-From-The-Lending-Library\">المكتبة</a> الخاصة بنا. هل يمكنك "
+"مساعدة في التبرع بنسخة؟"
+
+#: DonateModal.html
+msgid ""
+"If you own this book, you can<a "
+"href=\"https://store.usps.com/store/product/shipping-supplies/priority-"
+"mail-express-padded-flat-rate-envelope-P_EP13PE\">mail</a> it to our "
+"address below."
+msgstr ""
+"إذا كنت تمتلك هذا الكتاب، يمكنك <a href=\"https://store.usps.com/store/product/shipping-supplies/"
+"priority-mail-express-padded-flat-rate-envelope-P_EP 13PE\">إرساله بالبريد</a> إلى عنواننا أدناه."
+
+#: DonateModal.html
+msgid "You can also purchase this book from a vendor and ship it to our address:"
+msgstr "يمكنك أيضًا شراء هذا الكتاب من بائع وشحنه إلى عنواننا:"
+
+#: DonateModal.html
+msgid "Benefits of donating"
+msgstr "فوائد التبرع"
+
+#: DonateModal.html
+msgid ""
+"When you donate a physical book to the Internet Archive, your book will "
+"enjoy:"
+msgstr ""
+"عند التبرع بكتاب مادي إلى الأرشيف الإلكتروني، سيستفيد كتابك من:"
+
+#: DonateModal.html
+#, fuzzy
+msgid "Donation info"
+msgstr "معلومات التبرع"
+
+#: DonateModal.html
+msgid ""
+"Beautiful <a target=\"_blank\" href=\"https://archive.org/scanning"
+"\">high-fidelity digitization</a>"
+msgstr ""
+"رقمنة <a target=\"_blank\" href=\"https://archive.org/scanning\">عالية الدقة</a>"
+
+#: DonateModal.html
+msgid ""
+"Long-term <a href=\"https://blog.archive.org/2011/06/06/why-preserve-"
+"books-the-new-physical-archive-of-the-internet-archive/\">archival "
+"preservation</a>"
+msgstr ""
+"الحفظ <a href=\"https://blog.archive.org/2011/06/06/why-preserve-books-the-new-physical-archive-of-the-internet-archive/\">الآثاري طويل الأمد</a>"
+
+#: DonateModal.html
+msgid ""
+"Free <a href=\"https://controlleddigitallending.org/\">controlled digital"
+" library access</a> by the <a "
+"href=\"https://en.wikipedia.org/wiki/Print_disability\">print-"
+"disabled</a> public"
+msgstr ""
+"الوصول <a href=\"https://controlleddigitallending.org/\">الرقمي المسيطر عليه</a> مجاناً من قبل <a href=\"https://en.wikipedia.org/wiki/Print_disability\">الأشخاص ذوي الإعاقة البصرية</a>"
+
+#: DonateModal.html
+msgid ""
+"Open Library is a project of the <a "
+"href=\"https://archive.org/about\">Internet Archive</a>, a 501(c)(3) non-"
+"profit"
+msgstr ""
+"المكتبة المفتوحة هي مشروع تابع لـ <a href=\"https://archive.org/about\">الأرشيف الإلكتروني</a>، وهو منظمة غير ربحية 501(c)(3)"
+
+#: EditionNavBar.html
+msgid "Overview"
+msgstr "نظرة عامة"
+
+#: EditionNavBar.html
+#, python-format
+msgid "View %(count)s Edition"
+msgid_plural "View %(count)s Editions"
+msgstr[0] "عرض نسخة %(count)s"
+msgstr[1] "عرض نسخ %(count)s"
+
+#: EditionNavBar.html
+msgid "Details"
+msgstr "تفاصيل"
+
+#: EditionNavBar.html
+#, python-format
+msgid "%(reviews)s Review"
+msgid_plural "%(reviews)s Reviews"
+msgstr[0] "%(reviews)s مراجعة"
+msgstr[1] "%(reviews)s مراجعات"
+
+#: EditionNavBar.html
+msgid "Related Books"
+msgstr "كتب ذات صلة"
+
+#: Follow.html
+msgid "UnfollowFollow"
+msgstr "إلغاء المتابعةتابع"
+
+#: Follow.html
+msgid "Follow"
+msgstr "تابع"
+
+#: IABook.html
+#, python-format
+msgid "Borrowed from Internet Archive: %(title)s"
+msgstr "مستعار من الأرشيف الإلكتروني: %(title)s"
+
+#: LoadingIndicator.html
+msgid "Loading indicator"
+msgstr "مؤشر التحميل"
+
+#: LoanStatus.html
+msgid "You are <strong>next</strong> on the waiting list"
+msgstr "أنت <strong>التالي</strong> في قائمة الانتظار"
+
+#: LoanStatus.html
+#, python-format
+msgid "You are <strong>#%(spot)d</strong> of %(wlsize)d on the waiting list."
+msgstr "أنت <strong>#%(spot)d</strong> من %(wlsize)d في قائمة الانتظار."
+
+#: LoanStatus.html
+msgid "Leave waiting list"
+msgstr "ترك قائمة الانتظار"
+
+#: LoanStatus.html
+#, python-format
+msgid "Readers in line: %(count)s"
+msgstr "القراء في الانتظار: %(count)s"
+
+#: LoanStatus.html
+msgid "You'll be next in line."
+msgstr "ستكون التالي في القائمة."
+
+#: LoanStatus.html
+msgid "This book is currently checked out, please check back later."
+msgstr "هذا الكتاب مُعار حاليًا، يرجى العودة لاحقًا."
+
+#: LoanStatus.html
+msgid "Checked Out"
+msgstr "مُعار"
+
+#: ManageLoansButtons.html
+#, python-format
+msgid "There is one person waiting for this book."
+msgid_plural "There are %(n)s people waiting for this book."
+msgstr[0] "هناك شخص واحد ينتظر هذا الكتاب."
+msgstr[1] "يوجد %(n)s أشخاص ينتظرون هذا الكتاب."
+
+#: ManageWaitlistButton.html
+#, python-format
+msgid "Waiting for %d day"
+msgid_plural "Waiting for %d days"
+msgstr[0] "انتظار %d يوم"
+msgstr[1] "انتظار %d أيام"
+
+#: NotesModal.html
+msgid "My Book Notes"
+msgstr "ملاحظاتي حول الكتاب"
+
+#: NotesModal.html
+msgid "My private notes about this edition:"
+msgstr "ملاحظاتي الشخصية حول هذه النسخة:"
+
+#: ObservationsModal.html
+msgid "My Book Review"
+msgstr "مراجعتي للكتاب"
+
+#: Pager.html Pager_loanhistory.html
+msgid "First"
+msgstr "الأول"
+
+#: ReadButton.html
+msgid "Special Access"
+msgstr "وصول خاص"
+
+#: ReadButton.html
+msgid ""
+"Special ebook access from the Internet Archive for patrons with "
+"qualifying print disabilities"
+msgstr ""
+"وصول خاص للكتب الإلكترونية من الأرشيف الإلكتروني للأشخاص ذوي الإعاقات البصرية المؤهلة"
+
+#: ReadButton.html
+msgid "Borrow ebook from Internet Archive"
+msgstr "استعارة كتاب إلكتروني من الأرشيف الإلكتروني"
+
+#: ReadButton.html
+msgid "Read ebook from Internet Archive"
+msgstr "قراءة كتاب إلكتروني من الأرشيف الإلكتروني"
+
+#: ReadMore.html
+msgid "Read more"
+msgstr "اقرأ المزيد"
+
+#: ReadMore.html
+msgid "Read less"
+msgstr "اقرأ أقل"
+
+#: RecentChanges.html
+msgid "View MARC"
+msgstr "عرض MARC"
+
+#: RecentChangesAdmin.html
+msgid "Path"
+msgstr "المسار"
+
+#: RecentChangesAdmin.html
+msgid "Comments"
+msgstr "تعليقات"
+
+#: RecentChangesAdmin.html
+msgid "view"
+msgstr "عرض"
+
+#: RecentChangesAdmin.html
+msgid "edit"
+msgstr "تعديل"
+
+# | msgid "editions in"
+#: RecentChangesUsers.html
+msgid "No edit history available."
+msgstr "لا يوجد سجل للتعديلات."
+
+#: ReturnForm.html
+msgid "Really return this book?"
+msgstr "هل تريد حقًا إعادة هذا الكتاب؟"
+
+#: ReturnForm.html
+msgid "Return book"
+msgstr "إعادة الكتاب"
+
+#: SearchResultsWork.html
+msgid "added to"
+msgstr "أضيف إلى"
+
+#: SearchResultsWork.html
+#, python-format
+msgid "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d language</a>"
+msgid_plural "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d languages</a>"
+msgstr[0] "في <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d لغة</a>"
+msgstr[1] "في <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d لغات</a>"
+
+#: SearchResultsWork.html
+#, python-format
+msgid "%s previewable"
+msgstr "%s قابل للمعاينة"
+
+#: SearchResultsWork.html
+#, python-format
+msgid "Cover of edition %(id)s"
+msgstr "غلاف النسخة %(id)s"
+
+#: SearchResultsWork.html
+msgid "This is only visible to librarians."
+msgstr "هذا مرئي فقط للأمناء المكتبيين."
+
+#: SearchResultsWork.html
+msgid "Work Title"
+msgstr "عنوان العمل"
+
+#: ShareModal.html
+#, python-format
+msgid "Share on %(share_link)s"
+msgstr "مشاركة على %(share_link)s"
+
+#: ShareModal.html
+msgid "Embed this book in your website"
+msgstr "تضمين هذا الكتاب في موقعك الإلكتروني"
+
+#: ShareModal.html
+msgid "Embed icon"
+msgstr "رمز التضمين"
+
+#: ShareModal.html
+msgid "Embed"
+msgstr "تضمين"
+
+#: ShareModal.html
+msgid "Copy url to clipboard"
+msgstr "نسخ الرابط إلى الحافظة"
+
+#: ShareModal.html
+msgid "Copy URL icon"
+msgstr "رمز نسخ الرابط"
+
+#: ShareModal.html
+msgid "Copy URL"
+msgstr "نسخ الرابط"
+
+#: SponsorCarousel.html
+msgid "Books to Sponsor"
+msgstr "كتب للتبني"
+
+#: StarRatings.html
+msgid "Clear my rating"
+msgstr "مسح تقييمي"
+
+#: StarRatingsStats.html
+msgid "Rating"
+msgid_plural "Ratings"
+msgstr[0] "تقييم"
+msgstr[1] "تقييمات"
+
+#: StarRatingsStats.html
+msgid "Want to read"
+msgstr "أريد قراءته"
+
+#: StarRatingsStats.html
+msgid "Currently reading"
+msgstr "أقرأ حاليًا"
+
+#: StarRatingsStats.html
+msgid "Have read"
+msgstr "قرأت"
+
+#: Subnavigation.html
+msgid "Developer Center (Home)"
+msgstr "مركز المطورين (الرئيسية)"
+
+#: Subnavigation.html
+msgid "Web API"
+msgstr "واجهة برمجة التطبيقات (API) على الويب"
+
+#: Subnavigation
+msgid "Client Library"
+msgstr "مكتبة العميل"
+
+#: Subnavigation.html
+msgid "Data Dumps"
+msgstr "تفريغ البيانات"
+
+#: Subnavigation.html
+msgid "Report an Issue"
+msgstr "الإبلاغ عن مشكلة"
+
+#: Subnavigation.html
+msgid "Licensing"
+msgstr "الترخيص"
+
+#: Subnavigation.html
+msgid "Welcome"
+msgstr "مرحبا"
+
+#: Subnavigation.html
+msgid "Searching Open Library"
+msgstr "البحث في المكتبة المفتوحة"
+
+#: Subnavigation.html
+msgid "Reading Books"
+msgstr "قراءة الكتب"
+
+#: Subnavigation.html
+msgid "Adding & Editing Books"
+msgstr "إضافة وتحرير الكتب"
+
+#: Subnavigation.html
+msgid "Using Subjects"
+msgstr "استخدام المواضيع"
+
+#: Subnavigation.html
+msgid "Open Library F.A.Q."
+msgstr "الأسئلة الشائعة حول المكتبة المفتوحة"
+
+#: TableOfContents.html
+#, python-format
+msgid "Page %s"
+msgstr "الصفحة %s"
+
+#: TypeChanger.html
+msgid "Page Type"
+msgstr "نوع الصفحة"
+
+#: TypeChanger.html
+msgid "Huh?"
+msgstr "ماذا؟"
+
+#: TypeChanger.html
+msgid ""
+"Every piece of Open Library is defined by the type of content it "
+"displays, usually by content definition (e.g. Authors, Editions, Works) "
+"but sometimes by content use (e.g. macro, template, rawtext). Changing "
+"this for an existing page will alter its presentation and the data fields"
+" available for editing its content."
+msgstr ""
+"كل جزء من المكتبة المفتوحة يتم تعريفه بنوع المحتوى الذي يعرضه، عادةً عبر تعريف المحتوى (مثل: المؤلفين، الإصدارات، الأعمال)، ولكن في بعض الأحيان عبر استخدام المحتوى (مثل: الماكرو، القوالب، النصوص الخام). تغيير هذا في صفحة موجودة سيؤثر على عرضها والحقول المتاحة لتعديل محتواها."
+
+#: TypeChanger.html
+msgid "Please use caution changing Page Type!"
+msgstr "يرجى توخي الحذر عند تغيير نوع الصفحة!"
+
+#: TypeChanger.html
+msgid ""
+"(Simplest solution: If you aren't sure whether this should be changed, "
+"don't change it.)"
+msgstr ""
+"(أبسط حل: إذا لم تكن متأكدًا من أنه يجب تغيير هذا، فلا تقم بتغييره.)"
+
+#: WorldcatLink.html
+msgid "Check nearby libraries"
+msgstr "تحقق من المكتبات القريبة"
+
+#: WorldcatLink.html
+msgid "Check WorldCat for an edition near you"
+msgstr "تحقق من WorldCat عن إصدار قريب منك"
+
+#: databarDiff.html databarEdit.html
+msgid "View the editing history of this page"
+msgstr "عرض سجل تحرير هذه الصفحة"
+
+#: databarDiff.html
+msgid "View this page (exit Comparison view)"
+msgstr "عرض هذه الصفحة (خروج من وضع المقارنة)"
+
+#: databarEdit.html
+msgid "View this page (exit Edit mode)"
+msgstr "عرض هذه الصفحة (خروج من وضع التحرير)"
+
+#: databarHistory.html databarView.html
+#, python-format
+msgid "Last edited by %(author_link)s"
+msgstr "آخر تعديل بواسطة %(author_link)s"
+
+#: databarHistory.html databarView.html
+msgid "Last edited anonymously"
+msgstr "تم تعديل هذا الكتاب آخر مرة بشكل مجهول"
+
+#: databarTemplate.html databarView.html
+msgid "View this template's edit history"
+msgstr "عرض سجل تحرير هذه القالب"
+
+#: databarTemplate.html
+msgid "Edit this template"
+msgstr "تحرير هذه القالب"
+
+#: databarWork.html
+#, python-format
+msgid "This book was generously donated by %(donor)s"
+msgstr "تم التبرع بهذا الكتاب بسخاء من قبل %(donor)s"
+
+#: databarWork.html
+msgid "This book was generously donated anonymously"
+msgstr "تم التبرع بهذا الكتاب بسخاء بشكل مجهول"
+
+#: databarWork.html
+msgid "Learn more about Book Sponsorship"
+msgstr "تعرف على المزيد حول رعاية الكتب"
+
+#: account.py
+msgid "The email address you entered is invalid"
+msgstr "عنوان البريد الإلكتروني الذي أدخلته غير صالح"
+
+#: account.py
+msgid "This account has been blocked"
+msgstr "تم حظر هذا الحساب"
+
+#: account.py
+msgid "This account has been locked"
+msgstr "تم قفل هذا الحساب"
+
+#: account.py
+msgid "No account was found with this email. Please try again"
+msgstr "لم يتم العثور على حساب باستخدام هذا البريد الإلكتروني. يرجى المحاولة مرة أخرى"
+
+#: account.py
+msgid "The password you entered is incorrect. Please try again"
+msgstr "كلمة المرور التي أدخلتها غير صحيحة. يرجى المحاولة مرة أخرى"
+
+#: account.py
+msgid "Wrong password. Please try again"
+msgstr "كلمة مرور خاطئة. يرجى المحاولة مرة أخرى"
+
+#: account.py
+msgid "Please verify your Open Library account before logging in"
+msgstr "يرجى التحقق من حسابك في المكتبة المفتوحة قبل تسجيل الدخول"
+
+#: account.py
+msgid "Please verify your Internet Archive account before logging in"
+msgstr "يرجى التحقق من حسابك في الأرشيف الإلكتروني قبل تسجيل الدخول"
+
+#: account.py
+msgid "Please fill out all fields and try again"
+msgstr "يرجى ملء جميع الحقول والمحاولة مرة أخرى"
+
+#: account.py
+msgid "This email is already registered"
+msgstr "هذا البريد الإلكتروني مسجل بالفعل"
+
+#: account.py
+msgid "This username is already registered"
+msgstr "اسم المستخدم هذا مسجل بالفعل"
+
+#: account.py
+msgid "A problem occurred and we were unable to log you in."
+msgstr "حدثت مشكلة ولم نتمكن من تسجيل دخولك."
+
+#: account.py
+msgid "Login attempted with invalid Internet Archive s3 credentials."
+msgstr "تمت محاولة تسجيل الدخول ببيانات اعتماد غير صالحة لـ Internet Archive s3."
+
+#: account.py
+#, fuzzy
+msgid "A problem occurred and we were unable to log you in"
+msgstr "حدثت مشكلة ولم نتمكن من تسجيل دخولك."
+
+#: account.py
+#, python-format
+msgid ""
+"We've sent the verification email to %(email)s. You'll need to read that "
+"and click on the verification link to verify your email."
+msgstr ""
+"لقد أرسلنا بريد التحقق إلى %(email)s. ستحتاج إلى قراءة البريد والنقر على رابط التحقق للتحقق من بريدك الإلكتروني."
+
+#: account.py
+msgid "Username must be between 3-20 characters"
+msgstr "يجب أن يكون اسم المستخدم بين 3 و 20 حرفًا"
+
+#: account.py
+msgid "Username may only contain numbers and letters"
+msgstr "يمكن أن يحتوي اسم المستخدم على أرقام وحروف فقط"
+
+#: account.py
+msgid "Username unavailable"
+msgstr "اسم المستخدم غير متوفر"
+
+#: account.py forms.py
+msgid "Must be a valid email address"
+msgstr "يجب أن يكون عنوان بريد إلكتروني صالح"
+
+#: account.py forms.py
+msgid "Email already registered"
+msgstr "البريد الإلكتروني مسجل بالفعل"
+
+#: account.py
+msgid "An Internet Archive account already exists with this email"
+msgstr "يوجد بالفعل حساب في الأرشيف الإلكتروني بهذا البريد الإلكتروني"
+
+#: account.py
+msgid "Email address is already used."
+msgstr "عنوان البريد الإلكتروني مستخدم بالفعل."
+
+#: account.py
+msgid ""
+"Your email address couldn't be updated. The specified email address is "
+"already used."
+msgstr ""
+"لم يتمكن من تحديث عنوان بريدك الإلكتروني. عنوان البريد الإلكتروني المحدد مستخدم بالفعل."
+
+#: account.py
+msgid "Email verification successful."
+msgstr "تم التحقق من البريد الإلكتروني بنجاح."
+
+#: account.py
+msgid ""
+"Your email address has been successfully verified and updated in your "
+"account."
+msgstr "تم التحقق من عنوان بريدك الإلكتروني وتحديثه بنجاح في حسابك."
+
+#: account.py
+msgid "Email address couldn't be verified."
+msgstr "لم يتمكن من التحقق من عنوان البريد الإلكتروني."
+
+#: account.py
+msgid ""
+"Your email address couldn't be verified. The verification link seems "
+"invalid."
+msgstr ""
+"لم يتمكن من التحقق من عنوان بريدك الإلكتروني. يبدو أن رابط التحقق غير صالح."
+
+#: account.py
+msgid "Password reset failed."
+msgstr "فشل في إعادة تعيين كلمة المرور."
+
+#: account.py
+msgid "Notification preferences have been updated successfully."
+msgstr "تم تحديث تفضيلات الإشعارات بنجاح."
+
+#: borrow.py
+msgid ""
+"Your account has hit a lending limit. Please try again later or contact "
+"info@archive.org."
+msgstr ""
+"لقد وصلت حسابك إلى حد الإعارة. يرجى المحاولة مرة أخرى لاحقًا أو الاتصال بـ info@archive.org."
+
+#: forms.py
+msgid "Username"
+msgstr "اسم المستخدم"
+
+#: forms.py
+msgid "No user registered with this email address"
+msgstr "لا يوجد مستخدم مسجل بهذا البريد الإلكتروني"
+
+#: forms.py
+msgid "Disposable email not permitted"
+msgstr "البريد الإلكتروني القابل للتخلص منه غير مسموح به"
+
+#: forms.py
+msgid "Your email provider is not recognized."
+msgstr "موفر البريد الإلكتروني الخاص بك غير معترف به."
+
+#: forms.py
+msgid "Username already used"
+msgstr "اسم المستخدم مستخدم بالفعل"
+
+#: forms.py
+msgid "Must be between 3 and 20 letters and numbers"
+msgstr "يجب أن يكون بين 3 و 20 حرفًا ورقمًا"
+
+#: forms.py
+msgid "Your email address"
+msgstr "عنوان بريدك الإلكتروني"
+
+#: forms.py
+msgid "Choose a screen name. Screen names are public and cannot be changed later."
+msgstr "اختر اسم شاشة. أسماء الشاشة عامة ولا يمكن تغييرها لاحقًا."
+
+#: forms.py
+msgid "Letters and numbers only please, and at least 3 characters."
+msgstr "يرجى استخدام الأحرف والأرقام فقط، ويجب أن يكون الطول لا يقل عن 3 أحرف."
+
+#: forms.py
+msgid "Choose a password"
+msgstr "اختر كلمة مرور"
+
+#: forms.py
+msgid ""
+"I want to receive news, announcements, and resources from the <a "
+"href=\"https://archive.org/\">Internet Archive</a>, the non-profit that "
+"runs Open Library."
+msgstr ""
+"أرغب في تلقي الأخبار والإعلانات والموارد من <a href=\"https://archive.org/\">الأرشيف الإلكتروني</a>، وهي منظمة غير ربحية تدير المكتبة المفتوحة."
+
+#: forms.py
+msgid "Invalid password"
+msgstr "كلمة مرور غير صالحة"

--- a/openlibrary/i18n/ar/messages.po
+++ b/openlibrary/i18n/ar/messages.po
@@ -3298,9 +3298,7 @@ msgstr "التصنيفات"
 
 #: books/edit/edition.html
 msgid "Do you know any classifications of this edition?"
-msgstr
-
- "هل تعرف أي تصنيفات لهذه النسخة؟"
+msgstr "هل تعرف أي تصنيفات لهذه النسخة؟"
 
 #: books/edit/edition.html
 msgid "Like, Dewey Decimal?"


### PR DESCRIPTION
Translated with LLM. Reviewed and edited manually. "Open Library" is translated as "المكتبة المفتوحة", the same as the title of the article on [Arabic Wikipedia](https://ar.wikipedia.org/wiki/%D8%A7%D9%84%D9%85%D9%83%D8%AA%D8%A8%D8%A9_%D8%A7%D9%84%D9%85%D9%81%D8%AA%D9%88%D8%AD%D8%A9). However, I think it's a bit literal translation and "المكتبة الحرة" (~"Libre/Free library") is a better translation. 