### PR TITLE
Changed bulk search's 'Create a List' url to update continuously with new matched books

### DIFF
--- a/openlibrary/components/BulkSearch/components/BulkSearchControls.vue
+++ b/openlibrary/components/BulkSearch/components/BulkSearchControls.vue
@@ -87,7 +87,6 @@ export default {
             this.loadingExtractedBooks = false
         },
         async matchBooks() {
-            this.bulkSearchState.listUrl.resetSeeds()
             const fetchSolrBook = async function (book, matchOptions) {
                 try {
                     const data = await fetch(buildSearchUrl(book, matchOptions, true))
@@ -98,10 +97,8 @@ export default {
             this.loadingMatchedBooks = true
             for (const bookMatch of this.bulkSearchState.matchedBooks) {
                 bookMatch.solrDocs = await fetchSolrBook(bookMatch.extractedBook, this.bulkSearchState.matchOptions)
-                if (bookMatch.solrDocs.docs[0]) {
-                    this.bulkSearchState.listUrl.addSeed(bookMatch.solrDocs.docs[0].key.split('/')[2])
-                }
             }
+            this.loadingMatchedBooks = false
         },
 
     }

--- a/openlibrary/components/BulkSearch/components/BulkSearchControls.vue
+++ b/openlibrary/components/BulkSearch/components/BulkSearchControls.vue
@@ -40,7 +40,7 @@
 <script>
 import {sampleData} from '../utils/samples.js';
 import { BulkSearchState} from '../utils/classes.js';
-import { buildSearchUrl, buildListUrl } from '../utils/searchUtils.js'
+import { buildSearchUrl } from '../utils/searchUtils.js'
 export default {
 
     props: {
@@ -87,8 +87,8 @@ export default {
             this.loadingExtractedBooks = false
         },
         async matchBooks() {
+            this.bulkSearchState.listUrl.resetSeeds()
             const fetchSolrBook = async function (book, matchOptions) {
-
                 try {
                     const data = await fetch(buildSearchUrl(book, matchOptions, true))
                     return await data.json()
@@ -98,9 +98,10 @@ export default {
             this.loadingMatchedBooks = true
             for (const bookMatch of this.bulkSearchState.matchedBooks) {
                 bookMatch.solrDocs = await fetchSolrBook(bookMatch.extractedBook, this.bulkSearchState.matchOptions)
+                if (bookMatch.solrDocs.docs[0]) {
+                    this.bulkSearchState.listUrl.addSeed(bookMatch.solrDocs.docs[0].key.split('/')[2])
+                }
             }
-            this.bulkSearchState.listUrl = buildListUrl(this.bulkSearchState.matchedBooks)
-            this.loadingMatchedBooks = false
         },
 
     }

--- a/openlibrary/components/BulkSearch/components/MatchTable.vue
+++ b/openlibrary/components/BulkSearch/components/MatchTable.vue
@@ -18,7 +18,7 @@
           <td></td>
           <td></td>
           <td></td>
-          <td><a :href="bulkSearchState.listUrl.toString()" target="_blank" id="listMakerLink">Create list of first matches</a></td>
+          <td><a :href="bulkSearchState.listUrl" target="_blank" id="listMakerLink">Create list of first matches</a></td>
         </tr>
       </tfoot>
     </table>

--- a/openlibrary/components/BulkSearch/components/MatchTable.vue
+++ b/openlibrary/components/BulkSearch/components/MatchTable.vue
@@ -18,7 +18,7 @@
           <td></td>
           <td></td>
           <td></td>
-          <td><a :href="bulkSearchState.listUrl" target="_blank" id="listMakerLink">Create list of first matches</a></td>
+          <td><a :href="bulkSearchState.listUrl.toString()" target="_blank" id="listMakerLink">Create list of first matches</a></td>
         </tr>
       </tfoot>
     </table>

--- a/openlibrary/components/BulkSearch/utils/classes.js
+++ b/openlibrary/components/BulkSearch/utils/classes.js
@@ -149,6 +149,31 @@ export class BookMatch {
 }
 
 
+/** @type {string} */
+const BASE_URL = 'https://openlibrary.org/lists/add?seeds='
+
+export class ListUrl  {
+
+    constructor(){
+        this.base_url = BASE_URL
+        /** @type {string[]} */
+        this.seeds = []
+    }
+
+    /** @param {string} seed */
+    addSeed(seed) {
+        this.seeds.push(seed)
+    }
+
+    resetSeeds() {
+        this.seeds = []
+    }
+
+    toString() {
+        return this.base_url + this.seeds.join(',')
+    }
+}
+
 
 export class BulkSearchState{
     constructor(){
@@ -160,8 +185,6 @@ export class BulkSearchState{
         this.matchOptions =  new MatchOptions()
         /** @type {ExtractionOptions} */
         this.extractionOptions = new ExtractionOptions();
-        /** @type {string} */
-        this.listUrl = ''
         /** @type {AbstractExtractor[]} */
         this.extractors =  [
             new RegexExtractor('e.g. "The Wizard of Oz by L. Frank Baum"', '(^|>)(?<title>[A-Za-z][\\p{L}0-9\\- ,]{1,250})\\s+(by|[-\u2013\u2014\\t])\\s+(?<author>[\\p{L}][\\p{L}\\.\\- ]{3,70})( \\(.*)?($|<\\/)'),
@@ -173,6 +196,9 @@ export class BulkSearchState{
         ]
         /** @type {Number} */
         this._activeExtractorIndex = 0
+        /** @type {ListUrl} */
+        this.listUrl = new ListUrl();
+
     }
 
     /**@type {AbstractExtractor} */

--- a/openlibrary/components/BulkSearch/utils/classes.js
+++ b/openlibrary/components/BulkSearch/utils/classes.js
@@ -149,31 +149,7 @@ export class BookMatch {
 }
 
 
-/** @type {string} */
-const BASE_URL = 'https://openlibrary.org/lists/add?seeds='
-
-export class ListUrl  {
-
-    constructor(){
-        this.base_url = BASE_URL
-        /** @type {string[]} */
-        this.seeds = []
-    }
-
-    /** @param {string} seed */
-    addSeed(seed) {
-        this.seeds.push(seed)
-    }
-
-    resetSeeds() {
-        this.seeds = []
-    }
-
-    toString() {
-        return this.base_url + this.seeds.join(',')
-    }
-}
-
+const BASE_LIST_URL = 'https://openlibrary.org/account/lists/add?seeds='
 
 export class BulkSearchState{
     constructor(){
@@ -196,14 +172,17 @@ export class BulkSearchState{
         ]
         /** @type {Number} */
         this._activeExtractorIndex = 0
-        /** @type {ListUrl} */
-        this.listUrl = new ListUrl();
-
     }
 
     /**@type {AbstractExtractor} */
     get activeExtractor() {
         return this.extractors[this._activeExtractorIndex]
+    }
+    /**@type {String} */
+    get listUrl() {
+        return BASE_LIST_URL + this.matchedBooks
+            .map(bm => bm.solrDocs?.docs?.[0]?.key.split('/')[2])
+            .filter(key => key);
     }
 }
 

--- a/openlibrary/components/BulkSearch/utils/searchUtils.js
+++ b/openlibrary/components/BulkSearch/utils/searchUtils.js
@@ -29,12 +29,3 @@ export function buildSearchUrl(extractedBook, matchOptions, json = true) {
     return url;
 }
 
-/**
- * @param {BookMatch[]} bookMatches
- */
-export function buildListUrl(bookMatches){
-    const seeds = bookMatches.filter(bookMatch => bookMatch.solrDocs.numFound>0).map((bookMatch) => bookMatch.solrDocs.docs[0].key.split('/')[2])
-    const url = `/account/lists/add?seeds=${seeds.join(',')}`
-    return url
-}
-


### PR DESCRIPTION


<!-- What issue does this PR close? -->
Closes #9679 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This pull request fixes an oversight with Bulk Search, that caused the 'create a list' button to generate a new URL only once all attempts to find books in the OpenLibrary catalogue failed.  Now, each time that that the Solr request returns a book present in our catalog, the 'create a list' URL will immediately update to contain the new seed. 

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Select a sample in the BulkSearch, and click 'extract' and 'match'. Then, scroll down rapidly to the bottom of the page, and click 'create a list of full matches' before it finishes loading all of the books. 
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
