### PR TITLE
Add endpoint to view status of batch import

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -168,6 +168,77 @@ msgstr ""
 msgid "Not queued because they are already present in the queue:"
 msgstr ""
 
+#: batch_import.html
+msgid "View Batch Status"
+msgstr ""
+
+#: batch_import_view.html
+msgid "Batch Import Status"
+msgstr ""
+
+#: batch_import_view.html
+msgid "Batch ID:"
+msgstr ""
+
+#: batch_import_view.html
+msgid "Batch Name:"
+msgstr ""
+
+#: batch_import_view.html
+msgid "Submitter:"
+msgstr ""
+
+#: batch_import_view.html
+msgid "Submit Time:"
+msgstr ""
+
+#: batch_import_view.html
+msgid "Status Summary"
+msgstr ""
+
+#: batch_import_view.html
+msgid "Import Items"
+msgstr ""
+
+#: admin/imports.html admin/imports_by_date.html batch_import_view.html
+msgid "Added Time"
+msgstr ""
+
+#: batch_import_view.html
+msgid "Import Time"
+msgstr ""
+
+#: account/import.html account/loans.html admin/imports.html
+#: admin/imports_by_date.html admin/loans_table.html admin/menu.html
+#: admin/sponsorship.html batch_import_view.html status.html
+msgid "Status"
+msgstr ""
+
+#: account/import.html admin/imports.html admin/imports_by_date.html
+#: batch_import_view.html
+msgid "Error"
+msgstr ""
+
+#: batch_import_view.html
+msgid "IA ID"
+msgstr ""
+
+#: batch_import_view.html
+msgid "Data"
+msgstr ""
+
+#: admin/imports.html admin/imports_by_date.html batch_import_view.html
+msgid "OL Key"
+msgstr ""
+
+#: RecentChangesAdmin.html batch_import_view.html
+msgid "Comments"
+msgstr ""
+
+#: batch_import_view.html merge_request_table/table_header.html
+msgid "Submitter"
+msgstr ""
+
 #: design.html
 msgid "Design Pattern Library"
 msgstr ""
@@ -603,12 +674,6 @@ msgstr ""
 #: admin/inspect/store.html admin/people/index.html status.html
 #: type/author/edit.html type/language/view.html
 msgid "Name"
-msgstr ""
-
-#: account/import.html account/loans.html admin/imports.html
-#: admin/imports_by_date.html admin/loans_table.html admin/menu.html
-#: admin/sponsorship.html status.html
-msgid "Status"
 msgstr ""
 
 #: SearchNavigation.html SubjectTags.html lib/nav_foot.html lib/nav_head.html
@@ -1263,10 +1328,6 @@ msgstr ""
 
 #: account/import.html
 msgid "Reason"
-msgstr ""
-
-#: account/import.html admin/imports.html admin/imports_by_date.html
-msgid "Error"
 msgstr ""
 
 #: account/import.html
@@ -2182,14 +2243,6 @@ msgstr ""
 
 #: admin/imports.html admin/imports_by_date.html
 msgid "Identifier"
-msgstr ""
-
-#: admin/imports.html admin/imports_by_date.html
-msgid "OL Key"
-msgstr ""
-
-#: admin/imports.html admin/imports_by_date.html
-msgid "Added Time"
 msgstr ""
 
 #: admin/imports.html admin/imports_by_date.html
@@ -5692,10 +5745,6 @@ msgid "Submitter ▾"
 msgstr ""
 
 #: merge_request_table/table_header.html
-msgid "Submitter"
-msgstr ""
-
-#: merge_request_table/table_header.html
 msgid "Filter submitters"
 msgstr ""
 
@@ -7410,10 +7459,6 @@ msgstr ""
 
 #: RecentChangesAdmin.html
 msgid "Path"
-msgstr ""
-
-#: RecentChangesAdmin.html
-msgid "Comments"
 msgstr ""
 
 #: RecentChangesAdmin.html

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -239,6 +239,10 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
+#: batch_import_view.html
+msgid "Not yet imported"
+msgstr ""
+
 #: design.html
 msgid "Design Pattern Library"
 msgstr ""

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -14,6 +14,7 @@ import logging
 from time import time
 import math
 import infogami
+from openlibrary.core import db
 from openlibrary.core.batch_imports import (
     batch_import,
 )
@@ -504,6 +505,55 @@ class batch_imports(delegate.page):
         return render_template("batch_import.html", batch_result=batch_result)
 
 
+class BatchImportView(delegate.page):
+    path = r'/import/batch/(\d+)'
+
+    def GET(self, batch_id):
+        i = web.input(page=1, limit=10, sort='added_time asc')
+        page = int(i.page)
+        limit = int(i.limit)
+        sort = i.sort
+
+        valid_sort_fields = ['added_time', 'import_time', 'status']
+        sort_field, sort_order = sort.split()
+        if sort_field not in valid_sort_fields or sort_order not in ['asc', 'desc']:
+            sort_field = 'added_time'
+            sort_order = 'asc'
+
+        offset = (page - 1) * limit
+
+        batch = db.select('import_batch', where='id=$batch_id', vars=locals())[0]
+        total_rows = db.query(
+            'SELECT COUNT(*) AS count FROM import_item WHERE batch_id=$batch_id',
+            vars=locals()
+        )[0].count
+
+        rows = db.select(
+            'import_item',
+            where='batch_id=$batch_id',
+            order=f'{sort_field} {sort_order}',
+            limit=limit,
+            offset=offset,
+            vars=locals()
+        )
+
+        status_counts = db.query(
+            'SELECT status, COUNT(*) AS count FROM import_item WHERE batch_id=$batch_id GROUP BY status',
+            vars=locals()
+        )
+
+        return render_template(
+            'batch_import_view.html',
+            batch=batch,
+            rows=rows,
+            total_rows=total_rows,
+            page=page,
+            limit=limit,
+            sort=sort,
+            status_counts=status_counts
+        )
+
+
 class isbn_lookup(delegate.page):
     path = r'/(?:isbn|ISBN)/(.{10,})'
 
@@ -745,8 +795,8 @@ class _yaml_edit(_yaml):
             try:
                 p._save(i._comment)
             except (client.ClientException, ValidationException) as e:
-                add_flash_message('error', str(e))
-                return render.edit_yaml(key, i.body)
+                    add_flash_message('error', str(e))
+                    return render.edit_yaml(key, i.body)
             raise web.seeother(key + '.yml')
         elif '_preview' in i:
             add_flash_message('Preview not supported')

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -525,7 +525,7 @@ class BatchImportView(delegate.page):
         batch = db.select('import_batch', where='id=$batch_id', vars=locals())[0]
         total_rows = db.query(
             'SELECT COUNT(*) AS count FROM import_item WHERE batch_id=$batch_id',
-            vars=locals()
+            vars=locals(),
         )[0].count
 
         rows = db.select(
@@ -534,12 +534,12 @@ class BatchImportView(delegate.page):
             order=f'{sort_field} {sort_order}',
             limit=limit,
             offset=offset,
-            vars=locals()
+            vars=locals(),
         )
 
         status_counts = db.query(
             'SELECT status, COUNT(*) AS count FROM import_item WHERE batch_id=$batch_id GROUP BY status',
-            vars=locals()
+            vars=locals(),
         )
 
         return render_template(
@@ -550,7 +550,7 @@ class BatchImportView(delegate.page):
             page=page,
             limit=limit,
             sort=sort,
-            status_counts=status_counts
+            status_counts=status_counts,
         )
 
 
@@ -795,8 +795,8 @@ class _yaml_edit(_yaml):
             try:
                 p._save(i._comment)
             except (client.ClientException, ValidationException) as e:
-                    add_flash_message('error', str(e))
-                    return render.edit_yaml(key, i.body)
+                add_flash_message('error', str(e))
+                return render.edit_yaml(key, i.body)
             raise web.seeother(key + '.yml')
         elif '_preview' in i:
             add_flash_message('Preview not supported')

--- a/openlibrary/templates/batch_import.html
+++ b/openlibrary/templates/batch_import.html
@@ -35,5 +35,6 @@ $var title: $_("Batch Imports")
               <li>$item</li>
           </ol>
         </details>
+      <p><a href="/import/batch/$batch_result.batch.id">$_('View Batch Status')</a></p>
   </div>
 </div>

--- a/openlibrary/templates/batch_import_view.html
+++ b/openlibrary/templates/batch_import_view.html
@@ -8,7 +8,7 @@ $var title: $_("Batch Import Status")
     <p>$_('Batch ID:') $batch.id</p>
     <p>$_('Batch Name:') $batch.name</p>
     <p>$_('Submitter:') $batch.submitter</p>
-    <p>$_('Submit Time:') $datestr($batch.submit_time)</p>
+    <p>$_('Submit Time:') $datestr(batch.submit_time)</p>
 
     <h2>$_('Status Summary')</h2>
     <ul>

--- a/openlibrary/templates/batch_import_view.html
+++ b/openlibrary/templates/batch_import_view.html
@@ -35,7 +35,7 @@ $var title: $_("Batch Import Status")
             $for row in rows:
                 <tr>
                     <td>$datestr(row.added_time)</td>
-                    <td>$datestr(row.import_time)</td>
+                    <td>$(datestr(row.import_time) if row.import_time else _('Not yet imported'))</td>
                     <td>$row.status</td>
                     <td>$row.error</td>
                     <td>$row.ia_id</td>

--- a/openlibrary/templates/batch_import_view.html
+++ b/openlibrary/templates/batch_import_view.html
@@ -1,0 +1,53 @@
+$def with (batch, rows, total_rows, page, limit, sort, status_counts)
+$var title: $_("Batch Import Status")
+
+<div id="contentHead">
+    <h1>$_("Batch Import Status")</h1>
+</div>
+<div id="contentBody" class="batchImportStatus">
+    <p>$_('Batch ID:') $batch.id</p>
+    <p>$_('Batch Name:') $batch.name</p>
+    <p>$_('Submitter:') $batch.submitter</p>
+    <p>$_('Submit Time:') $datestr($batch.submit_time)</p>
+
+    <h2>$_('Status Summary')</h2>
+    <ul>
+        $for status_count in status_counts:
+            <li>$status_count.status: $status_count.count</li>
+    </ul>
+
+    <h2>$_('Import Items')</h2>
+    <table class="importItems">
+        <thead>
+            <tr>
+                <th><a href="$changequery(page=None, sort='added_time asc')">$_('Added Time')</a></th>
+                <th><a href="$changequery(page=None, sort='import_time asc')">$_('Import Time')</a></th>
+                <th><a href="$changequery(page=None, sort='status asc')">$_('Status')</a></th>
+                <th>$_('Error')</th>
+                <th>$_('IA ID')</th>
+                <th>$_('Data')</th>
+                <th>$_('OL Key')</th>
+                <th>$_('Comments')</th>
+                <th>$_('Submitter')</th>
+            </tr>
+        </thead>
+        <tbody>
+            $for row in rows:
+                <tr>
+                    <td>$datestr(row.added_time)</td>
+                    <td>$datestr(row.import_time)</td>
+                    <td>$row.status</td>
+                    <td>$row.error</td>
+                    <td>$row.ia_id</td>
+                    <td>$row.data</td>
+                    <td>$row.ol_key</td>
+                    <td>$row.comments</td>
+                    <td>$row.submitter</td>
+                </tr>
+        </tbody>
+    </table>
+
+    <div class="pagination">
+        $:macros.Pager(page, total_rows, limit)
+    </div>
+</div>

--- a/openlibrary/templates/batch_import_view.html
+++ b/openlibrary/templates/batch_import_view.html
@@ -17,7 +17,7 @@ $var title: $_("Batch Import Status")
     </ul>
 
     <h2>$_('Import Items')</h2>
-    <table class="importItems">
+    <table class="changeHistory">
         <thead>
             <tr>
                 <th><a href="$changequery(page=None, sort='added_time asc')">$_('Added Time')</a></th>
@@ -40,14 +40,17 @@ $var title: $_("Batch Import Status")
                     <td>$row.error</td>
                     <td>$row.ia_id</td>
                     <td>$row.data</td>
-                    <td>$row.ol_key</td>
+                    <td>
+                    $if row.ol_key:
+                        <a href="$row.ol_key">$row.ol_key</a>
+                    $else:
+                        $row.ol_key
+                    </td>
                     <td>$row.comments</td>
                     <td>$row.submitter</td>
                 </tr>
         </tbody>
     </table>
 
-    <div class="pagination">
-        $:macros.Pager(page, total_rows, limit)
-    </div>
+    $:macros.Pager(page, total_rows, limit)
 </div>


### PR DESCRIPTION
Closes #9681

Add endpoint to view status of batch import (`/import/batch/<id>`).

* **New Class and Endpoint:**
  - Add `BatchImportView` class in `openlibrary/plugins/openlibrary/code.py` for the path `/import/batch/(\d+)` with a `GET` handler.
  - Implement the `GET` handler to retrieve batch import status from the database.
  - Support pagination (`page` and `limit`) and sorting (`added_time`, `import_time`, `status`) in the handler.
  - Perform a `GROUP BY` query by `status` to get the total number of rows for the batch.

* **Template for Batch Import View:**
  - Create a new template file `openlibrary/templates/batch_import_view.html` to display the batch import status.
  - Include a table with columns for all fields in the `import_item` table.
  - Support pagination and sorting in the table.
  - Display the grouped status counts at the top.

* **Update Batch Import Template:**
  - Update `openlibrary/templates/batch_import.html` to link to the new endpoint after creating a batch.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/internetarchive/openlibrary/issues/9681?shareId=20035643-869b-4c13-b59d-a27fa5c63bf0).