### PR TITLE
Update description of Alternative names on Author Edit page

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -3358,7 +3358,6 @@ msgid "Who is the publisher?"
 msgstr ""
 
 #: books/add.html books/edit/edition.html books/edit/excerpts.html
-#: type/author/edit.html
 msgid "For example:"
 msgstr ""
 
@@ -6449,6 +6448,12 @@ msgstr ""
 
 #: type/author/edit.html
 msgid "Does this author go by any other names?"
+msgstr ""
+
+#: type/author/edit.html
+msgid ""
+"For example: Lev Nikolayevich Tolstoy was also known as Leo Tolstoy. "
+"Please list one name per line."
 msgstr ""
 
 #: type/author/edit.html

--- a/openlibrary/templates/type/author/edit.html
+++ b/openlibrary/templates/type/author/edit.html
@@ -97,7 +97,7 @@ $:macros.HiddenSaveButton("addAuthor")
                         <div class="formElement">
                             <div class="label">
                                 <label for="alternate_names">$_("Does this author go by any other names?")</label>
-                                <span class="tip">$_("For example:") Lev Nikolayevich Tolstoy; Yasnaya Polyana</span>
+                                <span class="tip">$_("For example:") Lev Nikolayevich Tolstoy was also known as Leo Tolstoy. Please list one name per line.</span>
                             </div>
                             <div class="input">
                                 <textarea name="author--alternate_names" id="alternate_names" rows="6">$"\n".join(page.alternate_names)</textarea>

--- a/openlibrary/templates/type/author/edit.html
+++ b/openlibrary/templates/type/author/edit.html
@@ -97,7 +97,7 @@ $:macros.HiddenSaveButton("addAuthor")
                         <div class="formElement">
                             <div class="label">
                                 <label for="alternate_names">$_("Does this author go by any other names?")</label>
-                                <span class="tip">$_("For example:") Lev Nikolayevich Tolstoy was also known as Leo Tolstoy. Please list one name per line.</span>
+                                <span class="tip">$_("For example: Lev Nikolayevich Tolstoy was also known as Leo Tolstoy. Please list one name per line.")</span>
                             </div>
                             <div class="input">
                                 <textarea name="author--alternate_names" id="alternate_names" rows="6">$"\n".join(page.alternate_names)</textarea>


### PR DESCRIPTION
### Description
This PR updates the placeholder text for the author names input field to reflect the new guidelines. The updated text provides a clearer example and instructions for listing names.

### Changes Made
- Updated the placeholder text to: "Does this author go by any other names? For example: Lev Nikolayevich Tolstoy was also known as Leo Tolstoy. Please list one name per line."

### Testing
- Verified that the updated text appears correctly in the input field.

### Issue Link
Fixes #9272

### Notes
Apologies for the delay in raising this PR. Please let me know if any further changes are required.
