### PR TITLE
#9253 Removed the "in English" link from the editions list on a work page.

### DIFF
--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -64,7 +64,7 @@ $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
           <!-- Formats are store as a raw string -->
           $book.physical_format.replace('[', '').replace(']','')
           $if book.languages:
-            $:_('in %(languagelist)s', languagelist=commify_list(l.name for l in book.languages))
+            $:_('in %(languagelist)s', languagelist=commify_list(websafe(l.name) for l in book.languages))
           $if book.edition_name:
             - $book.edition_name
         </div>

--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -64,7 +64,7 @@ $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
           <!-- Formats are store as a raw string -->
           $book.physical_format.replace('[', '').replace(']','')
           $if book.languages:
-            $:_('in %(languagelist)s', languagelist=commify_list(thingrepr(l) for l in book.languages))
+            $:_('in %(languagelist)s', languagelist=', '.join(l.name for l in book.languages))
           $if book.edition_name:
             - $book.edition_name
         </div>

--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -64,7 +64,7 @@ $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
           <!-- Formats are store as a raw string -->
           $book.physical_format.replace('[', '').replace(']','')
           $if book.languages:
-            $:_('in %(languagelist)s', languagelist=', '.join(l.name for l in book.languages))
+            $:_('in %(languagelist)s', languagelist=commify_list(l.name for l in book.languages))
           $if book.edition_name:
             - $book.edition_name
         </div>

--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -64,7 +64,7 @@ $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
           <!-- Formats are store as a raw string -->
           $book.physical_format.replace('[', '').replace(']','')
           $if book.languages:
-            $:_('in %(languagelist)s', languagelist=commify_list(websafe(l.name) for l in book.languages))
+            $:_('in %(languagelist)s', languagelist=commify_list(websafe(get_language_name(l.key)) for l in book.languages))
           $if book.edition_name:
             - $book.edition_name
         </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9253 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
hotfix

### Technical
<!-- What should be noted about the implementation? -->
This pull request addresses the issue of the "in English" link in the editions list on the work page. The link has been converted to plain text to improve the user experience by removing unnecessary navigation. The changes were made in the template file to render the language text as plain text instead of a hyperlink.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Pull the latest changes from this branch.
2. Start the application using Docker Compose.
3. Navigate to a work page with editions listed in different languages.
4. Confirm that the "in English" text is displayed as plain text and is not a clickable link.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Before changes:
![image](https://github.com/user-attachments/assets/cfc3e6d2-c610-489d-89ba-8232fe346a44)
After changes:
![image](https://github.com/user-attachments/assets/4a0d52e2-4e46-42c3-89ae-83cde257ec6f)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
