### PR TITLE
2723 Issue: Solr + List Search

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -26,9 +26,10 @@ from openlibrary.plugins.upstream.utils import (
 )
 from openlibrary.plugins.worksearch.schemes.editions import EditionSearchScheme
 from openlibrary.plugins.worksearch.search import get_solr
-from openlibrary.plugins.worksearch.schemes import SearchScheme
-from openlibrary.plugins.worksearch.schemes.authors import AuthorSearchScheme
-from openlibrary.plugins.worksearch.schemes.subjects import SubjectSearchScheme
+from openlibrary.plugins.worksearch.schemes import SearchScheme 
+from openlibrary.plugins.worksearch.schemes.authors import AuthorSearchScheme 
+from openlibrary.plugins.worksearch.schemes.subjects import SubjectSearchScheme 
+from openlibrary.plugins.worksearch.schemes.lists import ListSearchScheme
 from openlibrary.plugins.worksearch.schemes.works import (
     WorkSearchScheme,
     has_solr_editions_enabled,
@@ -572,29 +573,20 @@ class advancedsearch(delegate.page):
 
 
 class list_search(delegate.page):
-    path = '/search/lists'
+    path = '/search/lists' 
 
     def GET(self):
-        i = web.input(q='', offset='0', limit='10')
+        return render_template('search/lists', self.get_results)
 
-        lists = self.get_results(i.q, i.offset, i.limit)
-
-        return render_template('search/lists.tmpl', q=i.q, lists=lists)
-
-    def get_results(self, q, offset=0, limit=100):
-        if 'env' not in web.ctx:
-            delegate.fakeload()
-
-        keys = web.ctx.site.things(
-            {
-                "type": "/type/list",
-                "name~": q,
-                "limit": int(limit),
-                "offset": int(offset),
-            }
+    def get_results(self, q, offset=0, limit=10):
+        resp = run_solr_query(
+            ListSearchScheme(),
+            {'q': q},
+            offset=offset,
+            rows=limit,
         )
-
-        return web.ctx.site.get_many(keys)
+        
+        return resp
 
 
 class list_search_json(list_search):
@@ -602,14 +594,15 @@ class list_search_json(list_search):
     encoding = 'json'
 
     def GET(self):
-        i = web.input(q='', offset=0, limit=10)
+        i = web.input(q='', offset=0, limit=10) 
         offset = safeint(i.offset, 0)
         limit = safeint(i.limit, 10)
         limit = min(100, limit)
 
-        docs = self.get_results(i.q, offset=offset, limit=limit)
-
-        response = {'start': offset, 'docs': [doc.preview() for doc in docs]}
+        response = self.get_results(i.q, offset=offset, limit=limit)
+        
+        # Backward compatibility. Do I need to do this?
+        raw_resp = response.raw_resp['response']
 
         web.header('Content-Type', 'application/json')
         return delegate.RawText(json.dumps(response))

--- a/openlibrary/plugins/worksearch/schemes/lists.py
+++ b/openlibrary/plugins/worksearch/schemes/lists.py
@@ -1,0 +1,43 @@
+from datetime import datetime
+import logging
+from collections.abc import Callable
+
+from openlibrary.plugins.worksearch.schemes import SearchScheme
+
+logger = logging.getLogger("openlibrary.worksearch")
+
+
+class ListSearchScheme(SearchScheme):
+    universe = ['type:list']
+    all_fields = { #I have no idea what else to add.
+        'key',
+        'name',
+    }
+    facet_fields: set[str] = set()
+    field_name_map: dict[str, str] = {}
+    sorts = {
+        'work_count desc': 'work_count desc',
+        # Random
+        'random': 'random_1 asc',
+        'random asc': 'random_1 asc',
+        'random desc': 'random_1 desc',
+        'random.hourly': lambda: f'random_{datetime.now():%Y%m%dT%H} asc',
+        'random.daily': lambda: f'random_{datetime.now():%Y%m%d} asc',
+    }
+    default_fetched_fields = { 
+        'key',
+        'name',
+    }
+    facet_rewrites: dict[tuple[str, str], str | Callable[[], str]] = {}
+
+    def q_to_solr_params( 
+        self,
+        q: str,
+        solr_fields: set[str],
+        cur_solr_params: list[tuple[str, str]],
+    ) -> list[tuple[str, str]]:
+        return [ 
+            ('q', q),
+            ('q.op', 'AND'),
+            ('defType', 'edismax'),
+        ]

--- a/openlibrary/templates/search/lists.html
+++ b/openlibrary/templates/search/lists.html
@@ -1,30 +1,53 @@
-$def with (q, lists)
+$def with (get_results)
+
+$ q = query_param('q', '').strip()
+$ results_per_page = 10
+$ page = query_param('page')
+$if page:
+    $ page = int(page)
+$else:
+    $ page = 1
+$ offset = (page - 1) * results_per_page
 
 $var title: $_('Search results for Lists')
 
 <div id="contentHead">
-  <h1>$_("Search Lists")</h1>
+    <h1>$_("Search Lists")</h1>
 </div>
 
 <div id="contentBody">
-  $:macros.SearchNavigation()
-  <div class="section">
-    <form class="siteSearch olform" action="/search/lists">
-      $:render_template("search/searchbox", q=q)
-    </form>
-  </div>
-
-  $if lists:
-    <div class="mybooks-list">
-      <ul id="listResults" class="list-books">
-      $for list in lists:
-        <li class="searchResultItem" id="list-$loop.index">$:render_template("lists/preview", list)</li>
-      </ul>
-    </div>
-  $elif q:
-    <div>
-      <span class="red">$_("No results found.")</span>
-      <a href="/search/inside?$urlencode(dict(q=q))">$_('Search for books containing the phrase "%s"?', q)</a>
+    $:macros.SearchNavigation()
+  
+    <div class="section">
+        <form class="siteSearch olform" action="">
+            $:render_template("search/searchbox", q=q)
+        </form>
     </div>
 
+    <div id="contentMeta">
+        $ results = get_results(q, offset=offset, limit=results_per_page)
+
+        $if q and results.error:
+            <strong>
+                $for line in results.error.splitlines():
+                    $line
+                    $if not loop.last:
+                        <br>
+            </strong>
+
+        $if q and not results.error:
+            <div class="mybooks-list">
+                $if results.num_found:
+                    <ul id="listResults" class="list-books">
+                        $for list in lists:
+                            <li class="searchResultItem" id="list-$loop.index">$:render_template("lists/preview", list)</li>
+                    </ul>   
+                $else:
+                    <div>
+                        <span class="red">$_("No results found.")</span>
+                        <a href="/search/inside?$urlencode(dict(q=q))">$_('Search for books containing the phrase "%s"?', q)</a>
+                    </div> 
+            </div>     
+    </div>
+    <div class="clearfix"></div>   
 </div>


### PR DESCRIPTION
A feature request in [issue 2723](https://github.com/internetarchive/openlibrary/issues/2723) to replace lists search with Solr-backed list search. 

I have heavily used "Authors" codes and template for references. Therefore, 

- A **List.py** is created inside `plugins/worksearch/schemes`,
- In worksearch's **code.py**, `class list_search` and `class list_search_json` were edited,
- Lastly, the **lists.html** at `openlibrary/templates/search` got completely overhaul.

Sadly, when I created new lists, my codes didn't show any list search result although no errors are encountered. 

![Screenshot 2024-08-06 225911](https://github.com/user-attachments/assets/753df54c-505d-46c9-8ab7-b1e2e61ca2ba)
![Screenshot 2024-08-06 225914](https://github.com/user-attachments/assets/6e19defd-e700-4943-a5d7-9a5dec103004)
