### PR TITLE
Add "edition." prefix to search to only filter editions

### DIFF
--- a/openlibrary/solr/query_utils.py
+++ b/openlibrary/solr/query_utils.py
@@ -30,7 +30,9 @@ def luqum_remove_child(child: Item, parents: list[Item]):
         else:
             parent.children = new_children
     else:
-        raise ValueError("Not supported for generic class Item")
+        raise NotImplementedError(
+            f"Not implemented for Item subclass: {parent.__class__.__name__}"
+        )
 
 
 def luqum_replace_child(parent: Item, old_child: Item, new_child: Item):
@@ -270,9 +272,9 @@ def query_dict_to_str(
     return result
 
 
-def luqum_replace_field(query, replacer: Callable[[str], str]) -> str:
+def luqum_replace_field(query: Item, replacer: Callable[[str], str]) -> None:
     """
-    Replaces portions of a field, as indicated by the replacement function.
+    In-place replaces portions of a field, as indicated by the replacement function.
 
     :param query: Passed in the form of a luqum tree
     :param replacer: function called on each query.
@@ -280,4 +282,15 @@ def luqum_replace_field(query, replacer: Callable[[str], str]) -> str:
     for sf, _ in luqum_traverse(query):
         if isinstance(sf, SearchField):
             sf.name = replacer(sf.name)
-    return str(query)
+
+
+def luqum_remove_field(query: Item, predicate: Callable[[str], bool]) -> None:
+    """
+    In-place removes fields from a query, as indicated by the predicate function.
+
+    :param query: Passed in the form of a luqum tree
+    :param predicate: function called on each query.
+    """
+    for sf, parents in luqum_traverse(query):
+        if isinstance(sf, SearchField) and predicate(sf.name):
+            luqum_remove_child(sf, parents)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9585 . Adds a new optional prefix to search fields, `edition.` to mirror our `work.` prefix. This allows you to apply a certain field only to the editions during search.


### Technical
<!-- What should be noted about the implementation? -->


### Testing

Before: https://openlibrary.org/search?q=first_publish_year%3A%5B*+TO+1953%5D+language%3Aukr+-id_wikisource%3A*&mode=everything&sort=old&subject_facet=Nationalism
After: https://testing.openlibrary.org/search?q=first_publish_year%3A%5B*+TO+1953%5D+language%3Aukr+-edition.id_wikisource%3A*&mode=everything&sort=old&subject_facet=Nationalism

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
