### PR TITLE
Quote value of Slack channel in `new_comment_digest` workflow

### DIFF
--- a/.github/workflows/new_comment_digest.yml
+++ b/.github/workflows/new_comment_digest.yml
@@ -30,7 +30,7 @@ permissions:
 
 env:
   HOURS: 24
-  CHANNEL_ARG: '-s #team-abc-plus'
+  CHANNEL_ARG: '-s "#team-abc-plus"'
   VERBOSE_FLAG: ''
   NO_LABELS_FLAG: ''
 


### PR DESCRIPTION
When the new_comment_digest workflow is scheduled to run, it passes the Slack channel to the script without double quotes.  Since this string begins with a `#` character, the slack channel is being treated as a comment.  This, in turn, is causing the script to fail.

This PR quotes the default Slack channel that is passed to the script on scheduled, daily runs.

No change is needed for the code that overrides the Slack channel when this workflow is manually triggered, as the channel is quoted during that step.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
As this bug only manifests during scheduled runs of the workflow, manually testing this branch will not suffice for QA.

A reviewer could include this branch in their repo, adjust the scheduled run time of the workflow [here](https://github.com/internetarchive/openlibrary/blob/79dccb33ad74f3e9f16e69dce2bae7a568c8d3d0/.github/workflows/new_comment_digest.yml#L4), and remove [the guard](https://github.com/internetarchive/openlibrary/blob/79dccb33ad74f3e9f16e69dce2bae7a568c8d3d0/.github/workflows/new_comment_digest.yml#L40) that prevents the workflow from being executed on forks to test this script.  Note that publishing to Slack will fail without a `SLACK_TOKEN`.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
