### PR TITLE
Change `i18n` rendering for `edition_count` in lazy work preview

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -728,8 +728,8 @@ msgstr ""
 msgid "Get more information about this publisher"
 msgstr ""
 
-#: SearchResultsWork.html books/check.html merge/authors.html
-#: publishers/view.html subjects.html
+#: SearchResultsWork.html books/check.html jsdef/LazyWorkPreview.html
+#: merge/authors.html publishers/view.html subjects.html
 #, python-format
 msgid "%(count)s edition"
 msgid_plural "%(count)s editions"
@@ -4851,13 +4851,6 @@ msgstr ""
 #: jsdef/LazyWorkPreview.html
 msgid "Select this work"
 msgstr ""
-
-#: jsdef/LazyWorkPreview.html
-#, python-format
-msgid "%(count)d edition"
-msgid_plural "%(count)d editions"
-msgstr[0] ""
-msgstr[1] ""
 
 #: languages/index.html
 #, python-format

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -728,8 +728,8 @@ msgstr ""
 msgid "Get more information about this publisher"
 msgstr ""
 
-#: SearchResultsWork.html books/check.html jsdef/LazyWorkPreview.html
-#: merge/authors.html publishers/view.html subjects.html
+#: SearchResultsWork.html books/check.html merge/authors.html
+#: publishers/view.html subjects.html
 #, python-format
 msgid "%(count)s edition"
 msgid_plural "%(count)s editions"
@@ -4850,6 +4850,14 @@ msgstr ""
 
 #: jsdef/LazyWorkPreview.html
 msgid "Select this work"
+msgstr ""
+
+#: jsdef/LazyWorkPreview.html
+msgid "1 edition"
+msgstr ""
+
+#: jsdef/LazyWorkPreview.html
+msgid "editions"
 msgstr ""
 
 #: languages/index.html

--- a/openlibrary/templates/jsdef/LazyWorkPreview.html
+++ b/openlibrary/templates/jsdef/LazyWorkPreview.html
@@ -21,7 +21,10 @@ $jsdef render_lazy_work_preview(work):
                 $_('by') <span class="authors">${', '.join(work['author_name'])}</span>
         </span>
         &bull;
-        <span class="edition_count">$ungettext('%(count)s edition', '%(count)s editions', work['edition_count'], count=work['edition_count'])</span>
+        $if work['edition_count'] == 1:
+            <span class="edition_count">$_("1 edition")</span>
+        $else:
+            <span class="edition_count">$work['edition_count'] $_("editions")</span>
         <div class="clear"></div>
     </div>
 

--- a/openlibrary/templates/jsdef/LazyWorkPreview.html
+++ b/openlibrary/templates/jsdef/LazyWorkPreview.html
@@ -21,7 +21,7 @@ $jsdef render_lazy_work_preview(work):
                 $_('by') <span class="authors">${', '.join(work['author_name'])}</span>
         </span>
         &bull;
-        <span class="edition_count">$ungettext('%(count)d edition', '%(count)d editions', work['edition_count'], count=work['edition_count'])</span>
+        <span class="edition_count">$ungettext('%(count)s edition', '%(count)s editions', work['edition_count'], count=work['edition_count'])</span>
         <div class="clear"></div>
     </div>
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Subtask of #9486.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix. Ensures issue count renders correctly in list edit page. 

### Technical
<!-- What should be noted about the implementation? -->
As the result of a change in #9506 to improve the `i18n` in `LazyWorkPreview.html`, the list edit page displayed the following error and did not correctly substitute the variable in the `i18n` text:

<img width="1044" alt="Incorrectly rendered i18n" src="https://github.com/user-attachments/assets/de40c40e-6b69-4d5b-9a31-bf4e5859af2e">

I was able to clear the error with the first commit, by switching the `%(count)d` to `%(count)s` so as to correctly type the variable, but the incorrect text (`%(count)s editions`) was still rendering.

I confirmed by trying a variable substitution in the author field that the `jsdef` format does not seem to accept `%s` substitutions in `i18n` text, which would explain why for the author field the `by` is `i18n`-ed by itself, instead of following the more traditional `$_('by %(author)s', author=author.name)` pattern.

As a stop-gap measure, I switched the edition field to likewise be `i18n`-ed separately, so that the word "edition" or "editions" is displayed conditionally based on the edition count, and is translated separately from the number, so it will always appear after. 

This should be fine for many languages, but for languages with different word order and/or different numbering systems it's not ideal.

But if there's no other quick fix to improve the `jsdef` `i18n` process, this should definitely get the job done for now -- and it's a big advantage over both the error-ed version of the page and the original version in which the word "edition" was not translated at all.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Log in (if not logged in)
2. Go to your lists page and hit "Edit" on any list
3. Confirm that the page has no error banner and that the edition count renders correctly, as below:

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="416" alt="Correctly rendered i18n" src="https://github.com/user-attachments/assets/2166769e-5de6-4989-87a3-1f176d5a968c">

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
