### PR TITLE
Add Support for tabular data entry in Bulk Search

### DIFF
--- a/openlibrary/components/BulkSearch/components/BulkSearchControls.vue
+++ b/openlibrary/components/BulkSearch/components/BulkSearchControls.vue
@@ -5,6 +5,7 @@
     <details open class="bulk-search-controls">
         <summary>Input</summary>
         <div>
+            <p v-if="showColumnHint"> Please name your relevant columns "Title", "Author".</p>
             <textarea v-model="bulkSearchState.inputText"></textarea>
             <br />
             <label>Format: <select v-model="bulkSearchState._activeExtractorIndex">
@@ -74,7 +75,11 @@ export default {
         matchBooksText(){
             if (this.loadingMatchedBooks) return 'Loading...'
             return 'Match Books'
-        }
+        },
+        showColumnHint(){
+            if (this.bulkSearchState.activeExtractor) return this.bulkSearchState.activeExtractor.isTable
+            return false
+        },
     },
     methods: {
         togglePasswordVisibility(){

--- a/openlibrary/components/BulkSearch/components/BulkSearchControls.vue
+++ b/openlibrary/components/BulkSearch/components/BulkSearchControls.vue
@@ -5,12 +5,12 @@
     <details open class="bulk-search-controls">
         <summary>Input</summary>
         <div>
-            <p v-if="showColumnHint"> Please name your relevant columns "Title", "Author".</p>
+            <p v-if="showColumnHint">Please include a header row. Supported columns include: "Title", "Author".</p>
             <textarea v-model="bulkSearchState.inputText"></textarea>
             <br />
             <label>Format: <select v-model="bulkSearchState._activeExtractorIndex">
                     <option v-for="extractor, index in bulkSearchState.extractors" :value = "index" :key="index">
-                        {{ extractor["name"] }}
+                        {{ extractor["label"] }}
                     </option>
                 </select></label>
             <label v-if="this.showApiKey">OpenAI API Key:
@@ -77,7 +77,7 @@ export default {
             return 'Match Books'
         },
         showColumnHint(){
-            if (this.bulkSearchState.activeExtractor) return this.bulkSearchState.activeExtractor.isTable
+            if (this.bulkSearchState.activeExtractor) return this.bulkSearchState.activeExtractor.name === 'table_extractor'
             return false
         },
     },

--- a/openlibrary/components/BulkSearch/components/BulkSearchControls.vue
+++ b/openlibrary/components/BulkSearch/components/BulkSearchControls.vue
@@ -10,7 +10,7 @@
             <br />
             <label>Format: <select v-model="bulkSearchState._activeExtractorIndex">
                     <option v-for="extractor, index in bulkSearchState.extractors" :value = "index" :key="index">
-                        {{ extractor["label"] }}
+                        {{ extractor.label }}
                     </option>
                 </select></label>
             <label v-if="this.showApiKey">OpenAI API Key:

--- a/openlibrary/components/BulkSearch/utils/classes.js
+++ b/openlibrary/components/BulkSearch/utils/classes.js
@@ -129,6 +129,8 @@ export class TableExtractor extends AbstractExtractor{
      */
     constructor(name) {
         super(name)
+        /** @type {boolean} */
+        this.isTable = true
     }
 
     /**

--- a/openlibrary/components/BulkSearch/utils/classes.js
+++ b/openlibrary/components/BulkSearch/utils/classes.js
@@ -31,6 +31,7 @@ class AbstractExtractor {
 
 export class RegexExtractor extends AbstractExtractor {
 
+    name = 'regex_extractor'
     /**
      *
      * @param {string} label
@@ -57,6 +58,7 @@ export class RegexExtractor extends AbstractExtractor {
 
 export class AiExtractor extends AbstractExtractor{
 
+    name = 'ai_extractor'
     /**
      * @param {string} label
      * @param {string} model
@@ -149,22 +151,28 @@ export class TableExtractor extends AbstractExtractor{
         const lines = text.split('\n')
         /** @type {string[][]} */
         const cells = lines.map(line => line.split('\t'))
-        try {
-            /** @type {number} */
-            const authorIndex = cells[0].findIndex(columnName => columnName.trim().toLowerCase()  === this.authorColumn)
-            /** @type {number} */
-            const titleIndex = cells[0].findIndex(columnName => columnName.trim().toLowerCase() === this.titleColumn)
-            if (titleIndex < 0){
-                throw new Error(`Please have one column named ${this.titleColumn} and (optionally) one column named ${this.authorColumn}`)
+        /** @type {{columns: String[], rows: {columnName: string}[]}} */
+        const tableData = {
+            columns: cells[0],
+            rows: []
+        }
+        for (let i=1; i< cells.length; i++){
+            const row = {}
+            for (let j = 0; j < tableData.columns.length; j++){
+                row[tableData.columns[j].trim().toLowerCase()] = cells[i][j]
             }
-
-            return cells.slice(1).filter(row=> row[titleIndex]!== '').map(row => new BookMatch(new ExtractedBook(row[titleIndex], row[authorIndex]), {}))
+            // @ts-ignore
+            tableData.rows.push(row)
         }
-        catch (error){
-            return []
-        }
+        return tableData.rows.map(
+            row => new BookMatch(
+                new ExtractedBook(
+                    row[this.authorColumn] || '', row[this.titleColumn] || ''),
+                {})
+        )
     }
 }
+
 class ExtractionOptions {
     constructor() {
         /** @type {string} */

--- a/openlibrary/components/BulkSearch/utils/classes.js
+++ b/openlibrary/components/BulkSearch/utils/classes.js
@@ -167,7 +167,7 @@ export class TableExtractor extends AbstractExtractor{
         return tableData.rows.map(
             row => new BookMatch(
                 new ExtractedBook(
-                    row[this.authorColumn] || '', row[this.titleColumn] || ''),
+                    row[this.titleColumn] || '', row[this.authorColumn] || ''),
                 {})
         )
     }

--- a/openlibrary/components/BulkSearch/utils/classes.js
+++ b/openlibrary/components/BulkSearch/utils/classes.js
@@ -11,12 +11,13 @@ export class ExtractedBook {
 }
 
 class AbstractExtractor {
+
     /**
-     * @param {string} name
+     * @param {string} label
      */
-    constructor(name) {
+    constructor(label) {
         /** @type {string} */
-        this.name = name
+        this.label = label
     }
     /**
      * @param {ExtractionOptions} _extractOptions
@@ -32,11 +33,11 @@ export class RegexExtractor extends AbstractExtractor {
 
     /**
      *
-     * @param {string} name
+     * @param {string} label
      * @param {string} pattern
      */
-    constructor(name, pattern){
-        super(name)
+    constructor(label, pattern){
+        super(label)
         /** @type {RegExp} */
         this.pattern = new RegExp(pattern, 'gmu');
     }
@@ -57,11 +58,11 @@ export class RegexExtractor extends AbstractExtractor {
 export class AiExtractor extends AbstractExtractor{
 
     /**
-     * @param {string} name
+     * @param {string} label
      * @param {string} model
      */
-    constructor(name, model) {
-        super(name)
+    constructor(label, model) {
+        super(label)
         /** @type {string} */
         this.model = model
     }
@@ -123,14 +124,18 @@ export class AiExtractor extends AbstractExtractor{
 }
 
 export class TableExtractor extends AbstractExtractor{
+
+    name = 'table_extractor'
     /**
      *
-     * @param {string} name
+     * @param {string} label
      */
-    constructor(name) {
-        super(name)
-        /** @type {boolean} */
-        this.isTable = true
+    constructor(label) {
+        super(label)
+        /** @type {string} */
+        this.authorColumn = 'author'
+        /** @type {string} */
+        this.titleColumn = 'title'
     }
 
     /**
@@ -142,17 +147,15 @@ export class TableExtractor extends AbstractExtractor{
 
         /** @type {string[]} */
         const lines = text.split('\n')
-        /** @type {RegExp} */
-        const matcher = /([\w ]*)\t/g
         /** @type {string[][]} */
-        const cells = lines.map(textLine => [...textLine.matchAll(matcher)].map(entry => entry[1]))
+        const cells = lines.map(line => line.split('\t'))
         try {
             /** @type {number} */
-            const authorIndex = cells[0].findIndex(columnName => columnName.trim().toLowerCase()  === extractionOptions.authorColumn)
+            const authorIndex = cells[0].findIndex(columnName => columnName.trim().toLowerCase()  === this.authorColumn)
             /** @type {number} */
-            const titleIndex = cells[0].findIndex(columnName => columnName.trim().toLowerCase() === extractionOptions.titleColumn)
+            const titleIndex = cells[0].findIndex(columnName => columnName.trim().toLowerCase() === this.titleColumn)
             if (titleIndex < 0){
-                throw new Error(`Please have one column named ${extractionOptions.titleColumn} and (optionally) one column named ${extractionOptions.authorColumn}`)
+                throw new Error(`Please have one column named ${this.titleColumn} and (optionally) one column named ${this.authorColumn}`)
             }
 
             return cells.slice(1).filter(row=> row[titleIndex]!== '').map(row => new BookMatch(new ExtractedBook(row[titleIndex], row[authorIndex]), {}))
@@ -166,10 +169,6 @@ class ExtractionOptions {
     constructor() {
         /** @type {string} */
         this.openaiApiKey = ''
-        /** @type {string} */
-        this.authorColumn = 'author'
-        /** @type {string} */
-        this.titleColumn = 'title'
     }
 }
 class MatchOptions  {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9699

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR adds another new child of the AbstractExtractor class. The TableExtractor allows for data to be copy-pasted from Google Sheets or other spreadsheet services, and extracts the contents of the 'title' column and the 'author' column, if they exist. 
### Technical
<!-- What should be noted about the implementation? -->
Currently, the implementation allows for titles to be searched if the author column is empty. This has led to an odd interaction, where searching for 'Mark Twain' in the title ends up incorrectly pulling other books that he wrote.  I'll be debugging that over the next day or so, but I figured I might as well put it up for review. 
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Create a table in Google Spreadsheets, then copy it into the input area of the `/search/bulk` page. Select the bottom extraction option, and click 'extract books'. Please ensure that you have titled your columns appropriately. 
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
