### PR TITLE
Added links to Bulksearch in the header and the search bar.

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -5271,6 +5271,10 @@ msgid "Random Book"
 msgstr ""
 
 #: lib/nav_head.html
+msgid "Bulk Search"
+msgstr ""
+
+#: lib/nav_head.html
 msgid "Recent Community Edits"
 msgstr ""
 
@@ -5304,6 +5308,10 @@ msgstr ""
 
 #: lib/nav_head.html
 msgid "Text"
+msgstr ""
+
+#: lib/nav_head.html
+msgid "Bulk"
 msgstr ""
 
 #: lib/nav_head.html

--- a/openlibrary/plugins/openlibrary/js/SearchBar.js
+++ b/openlibrary/plugins/openlibrary/js/SearchBar.js
@@ -310,6 +310,10 @@ export class SearchBar {
         if (newFacet === 'advanced') {
             event.preventDefault();
             this.navigateTo('/advancedsearch');
+            9715
+        } else if (newFacet === 'bulk'){
+            event.preventDefault();
+            this.navigateTo('/search/bulk');
         } else {
             this.facet.write(newFacet);
         }

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -29,7 +29,8 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_super_li
   $     { "href": "/k-12", "text": _("K-12 Student Library"), "track": "K12Library" },
   $     { "href": "/booktalks", "text": _("Book Talks"), "track": "BookTalks" },
   $     { "href": "/random", "text": _("Random Book"), "track": "RandomBook" },
-  $     { "href": "/advancedsearch", "text": _("Advanced Search"), "track": "AdvancedSearch" }
+  $     { "href": "/advancedsearch", "text": _("Advanced Search"), "track": "AdvancedSearch" },
+  $     { "href": "/search/bulk", "text": _("Bulk Search"), "track": "BulkSearch"}
   $ ]
   $ contributeLinks = [
   $     { "href": "/books/add", "text": _("Add a Book"), "track": "AddBook" },
@@ -92,6 +93,7 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_super_li
               <option value="subject">$_("Subject")</option>
               <option value="lists">$_("Lists")</option>
               <option value="advanced">$_("Advanced")</option>
+              <option value="bulk">$_("Bulk")</option>
             </select>
           </label>
         </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9715 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This feature add some much needed linking to the new Bulk Search feature. It  can now be selected from either the 'browse' menu, or the searchbar, with either option redirecting you to the page itself. 

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
After loading up your local instance, try out both links. They should redirect you properly. 
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/user-attachments/assets/b05d7d0e-54b0-4895-a785-9eb0c55fa6de)
![image](https://github.com/user-attachments/assets/ccc787bb-1c38-4540-bebe-5d7ad23aad09)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
