### PR TITLE
Fix for jsdef not handling sprint style Python formatting

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -1795,9 +1795,9 @@ msgstr ""
 msgid "My %(shelf_name)s Stats"
 msgstr ""
 
-#: SearchResultsWork.html account/readinglog_stats.html type/work/editions.html
+#: account/readinglog_stats.html type/edition/title_and_author.html
 #, python-format
-msgid "First published in %(year)s"
+msgid "First published in %s"
 msgstr ""
 
 #: account/readinglog_stats.html home/loans.html lib/nav_head.html
@@ -4927,22 +4927,22 @@ msgstr ""
 
 #: jsdef/LazyAuthorPreview.html
 #, python-format
-msgid "No books associated with %(author)s"
+msgid "No books associated with %s"
 msgstr ""
+
+#: jsdef/LazyAuthorPreview.html languages/index.html
+#, python-format
+msgid "%s book"
+msgid_plural "%s books"
+msgstr[0] ""
+msgstr[1] ""
 
 #: jsdef/LazyAuthorPreview.html
 #, python-format
-msgid ""
-"<span class=\"books\">One book</span> <span class=\"work\">titled "
-"<i>%(title)s</i></span>"
-msgstr ""
-
-#: jsdef/LazyAuthorPreview.html
-#, python-format
-msgid ""
-"<span class=\"books\">%(count)d books</span> <span "
-"class=\"work\">including <i>%(title)s</i></span>"
-msgstr ""
+msgid "titled <i>%s</i>"
+msgid_plural "including <i>%s</i>"
+msgstr[0] ""
+msgstr[1] ""
 
 #: jsdef/LazyAuthorPreview.html
 msgid "Subjects:"
@@ -4959,13 +4959,6 @@ msgstr ""
 #: jsdef/LazyWorkPreview.html
 msgid "editions"
 msgstr ""
-
-#: languages/index.html
-#, python-format
-msgid "%s book"
-msgid_plural "%s books"
-msgstr[0] ""
-msgstr[1] ""
 
 #: languages/language_list.html
 msgid "Czech"
@@ -6709,11 +6702,6 @@ msgstr ""
 msgid "An edition of"
 msgstr ""
 
-#: type/edition/title_and_author.html
-#, python-format
-msgid "First published in %s"
-msgstr ""
-
 #: type/edition/view.html type/work/view.html
 #, python-format
 msgid ""
@@ -7189,6 +7177,11 @@ msgstr ""
 
 #: type/usergroup/edit.html
 msgid "Members:"
+msgstr ""
+
+#: SearchResultsWork.html type/work/editions.html
+#, python-format
+msgid "First published in %(year)s"
 msgstr ""
 
 #: type/work/editions.html type/work/editions_datatable.html

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -4921,33 +4921,6 @@ msgstr ""
 msgid "Your feedback will help us improve these cards"
 msgstr ""
 
-#: jsdef/LazyAuthorPreview.html
-msgid "Select this author"
-msgstr ""
-
-#: jsdef/LazyAuthorPreview.html
-#, python-format
-msgid "No books associated with %s"
-msgstr ""
-
-#: jsdef/LazyAuthorPreview.html languages/index.html
-#, python-format
-msgid "%s book"
-msgid_plural "%s books"
-msgstr[0] ""
-msgstr[1] ""
-
-#: jsdef/LazyAuthorPreview.html
-#, python-format
-msgid "titled <i>%s</i>"
-msgid_plural "including <i>%s</i>"
-msgstr[0] ""
-msgstr[1] ""
-
-#: jsdef/LazyAuthorPreview.html
-msgid "Subjects:"
-msgstr ""
-
 #: jsdef/LazyWorkPreview.html
 msgid "Select this work"
 msgstr ""
@@ -4959,6 +4932,13 @@ msgstr ""
 #: jsdef/LazyWorkPreview.html
 msgid "editions"
 msgstr ""
+
+#: languages/index.html
+#, python-format
+msgid "%s book"
+msgid_plural "%s books"
+msgstr[0] ""
+msgstr[1] ""
 
 #: languages/language_list.html
 msgid "Czech"

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -1795,11 +1795,6 @@ msgstr ""
 msgid "My %(shelf_name)s Stats"
 msgstr ""
 
-#: account/readinglog_stats.html type/edition/title_and_author.html
-#, python-format
-msgid "First published in %s"
-msgstr ""
-
 #: account/readinglog_stats.html home/loans.html lib/nav_head.html
 msgid "My Books"
 msgstr ""
@@ -6680,6 +6675,11 @@ msgstr ""
 
 #: type/edition/title_and_author.html
 msgid "An edition of"
+msgstr ""
+
+#: type/edition/title_and_author.html
+#, python-format
+msgid "First published in %s"
 msgstr ""
 
 #: type/edition/view.html type/work/view.html

--- a/openlibrary/templates/account/readinglog_stats.html
+++ b/openlibrary/templates/account/readinglog_stats.html
@@ -19,7 +19,8 @@ $jsdef render_works_list(works):
         <li>
             <a href="$work.key" style="font-style: oblique">$full_title</a>
             $ first_publish_year = work.first_publish_year or '????'
-            <span title="$_('First published in %(year)s', year=first_publish_year)">($first_publish_year)</span>
+            $ msg = _("First published in %s")
+            <span title="$sprintf(msg, first_publish_year)">($first_publish_year)</span>
             by
             $for author in work.authors:
                 <a href="$author.key">$author.name</a>$cond(not loop.last, ', ', '')

--- a/openlibrary/templates/account/readinglog_stats.html
+++ b/openlibrary/templates/account/readinglog_stats.html
@@ -19,8 +19,8 @@ $jsdef render_works_list(works):
         <li>
             <a href="$work.key" style="font-style: oblique">$full_title</a>
             $ first_publish_year = work.first_publish_year or '????'
-            $ msg = _("First published in %s")
-            <span title="$sprintf(msg, first_publish_year)">($first_publish_year)</span>
+            $# detect-missing-i18n-skip-line
+            <span title="First published in $first_publish_year">($first_publish_year)</span>
             by
             $for author in work.authors:
                 <a href="$author.key">$author.name</a>$cond(not loop.last, ', ', '')

--- a/openlibrary/templates/jsdef/LazyAuthorPreview.html
+++ b/openlibrary/templates/jsdef/LazyAuthorPreview.html
@@ -10,11 +10,12 @@ $jsdef render_lazy_author_preview(item):
                     ($(item['birth_date'] or ' ')&ndash;$(item['death_date'] or ' '))
             </span>
             $if item['work_count'] == 0:
-                <span class="work">$_("No books associated with %(author)s", author=item['name'])</span>
-            $elif item['work_count'] == 1:
-                $:_('<span class="books">One book</span> <span class="work">titled <i>%(title)s</i></span>', title=item['top_work'])
+                $ msg_book = _("No books associated with %s")
+                <span class="work">$sprintf(msg_book, item['name'])</span>
             $else:
-                $:_('<span class="books">%(count)d books</span> <span class="work">including <i>%(title)s</i></span>', count=item['work_count'], title=item['top_work'])
+                $ msg_book = ungettext("%s book", "%s books", item['work_count'])
+                $ msg_title = ungettext("titled <i>%s</i>", "including <i>%s</i>", item['work_count'])
+                <span class="books">$sprintf(msg_book, item['work_count'])</span> <span class="work">$:sprintf(msg_title, item['top_work'])</i></span>
 
             $if item['subjects']:
                 <span class="subject">$_("Subjects:") $(', '.join(item['subjects']))</span>

--- a/openlibrary/templates/jsdef/LazyAuthorPreview.html
+++ b/openlibrary/templates/jsdef/LazyAuthorPreview.html
@@ -15,7 +15,7 @@ $jsdef render_lazy_author_preview(item):
             $else:
                 $ msg_book = ungettext("%s book", "%s books", item['work_count'])
                 $ msg_title = ungettext("titled <i>%s</i>", "including <i>%s</i>", item['work_count'])
-                <span class="books">$sprintf(msg_book, item['work_count'])</span> <span class="work">$:sprintf(msg_title, item['top_work'])</i></span>
+                <span class="books">$sprintf(msg_book, item['work_count'])</span> <span class="work">$:sprintf(msg_title, item['works'])</i></span>
 
             $if item['subjects']:
                 <span class="subject">$_("Subjects:") $(', '.join(item['subjects']))</span>

--- a/openlibrary/templates/jsdef/LazyAuthorPreview.html
+++ b/openlibrary/templates/jsdef/LazyAuthorPreview.html
@@ -2,7 +2,10 @@ $def with (author)
 
 $jsdef render_lazy_author_preview(item):
     $if item:
-        <div class="ac_author" title="$_('Select this author')">
+        $# The autocomplete plugin moves `top_work` into `works`, but we should support both fields.
+        $ top_work = item['top_work'] or item['works'][0]
+
+        <div class="ac_author" title="Select this author">
             <div class="olid">$item['key']</div>
             <span class="name">
                 $item['name']
@@ -10,15 +13,16 @@ $jsdef render_lazy_author_preview(item):
                     ($(item['birth_date'] or ' ')&ndash;$(item['death_date'] or ' '))
             </span>
             $if item['work_count'] == 0:
-                $ msg_book = _("No books associated with %s")
-                <span class="work">$sprintf(msg_book, item['name'])</span>
+                <span class="work">No books associated with $item['name']</span>
+            $elif item['work_count'] == 1:
+                <span class="books">1 book</span>
+                <span class="work">titled <i>$top_work</i></span>
             $else:
-                $ msg_book = ungettext("%s book", "%s books", item['work_count'])
-                $ msg_title = ungettext("titled <i>%s</i>", "including <i>%s</i>", item['work_count'])
-                <span class="books">$sprintf(msg_book, item['work_count'])</span> <span class="work">$:sprintf(msg_title, item['works'])</i></span>
+                <span class="books">$item['work_count'] books</span>
+                <span class="work">including <i>$top_work</i></span>
 
-            $if item['subjects']:
-                <span class="subject">$_("Subjects:") $(', '.join(item['subjects']))</span>
+            $if item['work_count'] and item['subjects']:
+                <span class="subject">Subjects: $(', '.join(item['subjects']))</span>
         </div>
 
 $if author:

--- a/scripts/detect_missing_i18n.py
+++ b/scripts/detect_missing_i18n.py
@@ -20,6 +20,8 @@ EXCLUDE_LIST = {
     # These can't be fixed since they're rendered as static html
     "static/offline.html",
     "static/status-500.html",
+    # Uses jsdef and the current stance is no i18n in JS.
+    "openlibrary/templates/jsdef/LazyAuthorPreview.html",
 }
 
 default_directories = ('openlibrary/templates/', 'openlibrary/macros/')


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9718

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
It seems `jsdef` needs to use `sprintf` for `%s` string formatting, and the JavaScript implementation, unlike the Python one in `helpers.py`, doesn't support keywords, so multiple arguments must be passed with sequential `%s` replacements.

### Technical
<!-- What should be noted about the implementation? -->
This also fixes
- titles not displaying in the author preview, which has apparently been broken for over... 15 years. :(
- the word "subjects" displaying when there are no subjects.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Edit a work, attempt to edit the authors, and ensure that the book count _and_ titles show up properly, and that singular and plurals are handled appropriately for the book count.

For some reason, finding an author with only one book proved a challenge.
- 1 book: `Javier Ruiz Sierra` ("1 book titled...")
- 0 books: `Felipe Palacios Sierra` ("No books associated...")
- More than 1 book: `Sierra Club` ("542 books including...")

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/user-attachments/assets/429b7e41-06a8-49e9-94ae-6c8bf5f71533)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
