### PR TITLE
Fix: correct comment text on merge history

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -6081,7 +6081,7 @@ msgstr ""
 
 #: recentchanges/merge/comment.html
 #, python-format
-msgid "Merged %(page_type)s into primary %(record_type) record."
+msgid "Merged %(page_type)s into primary %(record_type)s record."
 msgstr ""
 
 #: recentchanges/merge/message.html

--- a/openlibrary/templates/recentchanges/merge/comment.html
+++ b/openlibrary/templates/recentchanges/merge/comment.html
@@ -24,4 +24,4 @@ $else:
         $_("Marked as duplicate.") $:details
     $else:
         $# comment in the affected records
-        $_('Merged %(page_type)s into primary %(record_type) record.', page_type=pagetype, record_type=type) $:details
+        $_('Merged %(page_type)s into primary %(record_type)s record.', page_type=pagetype, record_type=type) $:details


### PR DESCRIPTION
This commit fixes string interpolation on the merge history comment.

<!-- What issue does this PR close? -->
Closes #9728 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
See the following:
- This should have incorrect string interpolation in the comment: https://openlibrary.org/recentchanges/2024/08/07/merge-authors/135506063
- This should not: https://testing.openlibrary.org/recentchanges/2024/08/07/merge-authors/135506063

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
