### PR TITLE
Fix: minimum values for book dimensions and weight to prevent zero or negative inputs

### DIFF
--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -581,7 +581,7 @@ $ })
                 <div class="input">
                     $ weight = book.get_weight() or storage(value="", units="grams")
                     <input name="edition--weight--value" type="number" step="any"
-                           id="edition--weight--value" size="6" value="$weight.value"/>
+                           id="edition--weight--value" min="0.01" size="6" value="$weight.value"/>
                     <span class="tip">
                         $:radiobuttons("edition--weight--units", ["grams", "kilos", "ounces", "pounds"], weight.units)
                     </span>
@@ -603,17 +603,17 @@ $ })
                             <tr>
                                 <td rowspan="3"><img src="/images/dimensions.png" alt="$_('dimensions')" width="107" height="69" align="left"/></td>
                                 <td><span class="tip"><label for="dimensions-height">$_("Height:")</label> </span></td>
-                                <td><input name="edition--physical_dimensions--height" type="number" step="any"
+                                <td><input name="edition--physical_dimensions--height" type="number" step="any" min="0.1"
                                            id="dimensions-height" size="6" value="$dimensions.height"/></td>
                             </tr>
                             <tr>
                                 <td><span class="tip"><label for="dimensions-width">$_("Width:")</label> </span></td>
-                                <td><input name="edition--physical_dimensions--width" type="number" step="any"
+                                <td><input name="edition--physical_dimensions--width" type="number" step="any" min="0.1"
                                            id="dimensions-width" size="6" value="$dimensions.width"/></td>
                             </tr>
                             <tr>
                                 <td><span class="tip"><label for="dimensions-depth">$_("Depth:")</label> </span></td>
-                                <td><input name="edition--physical_dimensions--depth" type="number" step="any"
+                                <td><input name="edition--physical_dimensions--depth" type="number" step="any" min="0.1"
                                            id="dimensions-depth" size="6" value="$dimensions.depth"/></td>
                             </tr>
                         </tbody>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9731 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
**Fix**: Set minimum values for book dimensions and weight inputs to prevent zero or negative values

### Technical
<!-- What should be noted about the implementation? -->
Sets minimum values for the book's weight and dimensions inputs to ensure that users cannot enter zero or negative values.

Weight: Minimum value adjusted to 0.01
Dimensions: Minimum value set to 0.1

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Verify Weight Input: 
Navigate to the book weight input field.
Ensure the minimum allowed value is set to 0.01
Try entering value below minimum and ensure they are not accepted.
Check that the input fields correctly accept values at or above the minimum.

2. Verify Dimensions Input:
Navigate to the book dimensions inputs (height, width, depth).
Ensure the minimum allowed value is set to 0.1
Try entering value below minimum and ensure they are not accepted.
Check that the input fields correctly accept values at or above the minimum.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/user-attachments/assets/5c378818-432a-4973-a29a-f8c94837cb22)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
