### PR TITLE
Move mybooks List page title out of header

### DIFF
--- a/openlibrary/templates/account/view.html
+++ b/openlibrary/templates/account/view.html
@@ -23,9 +23,10 @@ $var title: $header_title
           <a href="$mb.user.key" class="username-avatar"><img src="$(mb.user.key)/avatar" class="account-avatar"></a>
           <h2 class="account-username"><a href="$mb.user.key">$mb.username</a> &rsaquo;</h2>
         </div>
-        $if mb.key == 'list':
+        <!-- $if mb.key == 'list':
           <h1 class="details-title">$header_title</h1>
-        $else:
+        $else: -->
+        $if mb.key != 'list':
           <div class="sansserif grey account-settings-menu navigation-breadcrumbs">
             $:render_template("books/mybooks_breadcrumb_select", mb, selected=header_title)
             $if header_title=="Already Read" and mb.reading_goals:
@@ -55,6 +56,8 @@ $var title: $header_title
       $if page:
         $:macros.databarView(page)
     </header>
+    $if mb.key == 'list':
+      <h1 class="details-title">$header_title</h1>
 
     $ mb.component_times['Details header'] = time() - mb.component_times['Details header']
     $ mb.component_times['Details content'] = time()

--- a/static/css/components/mybooks-details.less
+++ b/static/css/components/mybooks-details.less
@@ -19,7 +19,7 @@
 
 .breadcrumb-wrapper {
   display: flex;
-  flex:1;
+  flex: 1;
   flex-wrap: wrap;
   white-space: nowrap;
 }

--- a/static/css/components/mybooks-details.less
+++ b/static/css/components/mybooks-details.less
@@ -19,6 +19,7 @@
 
 .breadcrumb-wrapper {
   display: flex;
+  flex:1;
   flex-wrap: wrap;
   white-space: nowrap;
 }

--- a/tests/unit/js/readmore.test.js
+++ b/tests/unit/js/readmore.test.js
@@ -1,5 +1,5 @@
 import { initClampers, ReadMoreComponent } from '../../../openlibrary/plugins/openlibrary/js/readmore';
-import {clamperSample} from './html-test-data'
+import { clamperSample } from './html-test-data';
 
 describe('ReadMoreComponent', () => {
     /** @type {ReadMoreComponent} */
@@ -11,9 +11,10 @@ describe('ReadMoreComponent', () => {
                 <div class="read-more">
                     <div class="read-more__content" style="max-height:40px">
                     </div>
+                    <button class="read-more__toggle--more">More</button>
+                    <button class="read-more__toggle--less">Less</button>
                 </div>
-            `)
-                .appendTo(document.body)[0]
+            `).appendTo(document.body)[0]
         );
     });
 
@@ -50,10 +51,9 @@ describe('initClampers', () => {
             .mockImplementation(() => 100);
         initClampers([clamper]);
         expect(clamper.classList.contains('clamp')).toBe(false);
-
     });
 
-    test('clamp not removed if  needed', () => {
+    test('clamp not removed if needed', () => {
         const clamper = document.createElement('div');
         clamper.classList.add('clamp');
         jest
@@ -64,7 +64,6 @@ describe('initClampers', () => {
             .mockImplementation(() => 10);
         initClampers([clamper]);
         expect(clamper.classList.contains('clamp')).toBe(true);
-
     });
 
     test('Clicking anchor tag does not expand', () => {
@@ -79,6 +78,7 @@ describe('initClampers', () => {
         $($clamper).find('a').first().trigger('click');
         expect($clamper.css('display')).toBe('unset');
     });
+
     test('Clicking non-anchor tag does clamp', () => {
         const $clamper = $(clamperSample);
         jest
@@ -91,5 +91,4 @@ describe('initClampers', () => {
         $($clamper).find('h6').first().trigger('click');
         expect($clamper.css('display')).not.toBe('unset');
     });
-
 });


### PR DESCRIPTION
Closes# #9285
Move mybooks List page title out of header, avoid overflowing Follow & Edit widgets




<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
