### PR TITLE
remove special case for 8M range covers

### DIFF
--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -223,19 +223,6 @@ def zipview_url_from_id(coverid, size):
     return f"{protocol}://archive.org/download/{itemid}/{zipfile}/{filename}"
 
 
-def old_zipview_url_from_id(coverid: int, size: str | None) -> str:
-    """
-    The path for images in the old style, e.g. item `l_covers_0008` scheme
-    """
-    prefix = f"{size.lower()}_" if size else ""
-    pid = "%010d" % coverid
-    item_id = f"{prefix}covers_{pid[:4]}"
-    item_tar = f"{prefix}covers_{pid[:4]}_{pid[4:6]}.zip"
-    item_file = f"{pid}{'-' + size.upper() if size else ''}"
-    protocol = web.ctx.protocol
-    return f"{protocol}://archive.org/download/{item_id}/{item_tar}/{item_file}.jpg"
-
-
 class cover:
     def GET(self, category, key, value, size):
         i = web.input(default="true")

--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -277,14 +277,6 @@ class cover:
             url = zipview_url_from_id(value, size)
             return web.found(url)
 
-        # This chunk is unique:
-        #   - they are stores as both .zip and .tar files (for now)
-        #   - the naming scheme is the older scheme used by .tar files
-        #     (eg item `l_covers_0008` instead of `olcovers9`
-        #   - the db is not yet updated with their correct URLs
-        if 8_820_000 > value >= 8_000_000:
-            return web.found(old_zipview_url_from_id(value, size))
-
         d = self.get_details(value, size.lower())
         if not d:
             return notfound()
@@ -307,7 +299,7 @@ class cover:
         try:
             from openlibrary.coverstore import archive
 
-            if d.id >= 8_820_000 and d.uploaded and '.zip' in d.filename:
+            if d.id >= 8_000_000 and d.uploaded:
                 return web.found(
                     archive.Cover.get_cover_url(
                         d.id, size=size, protocol=web.ctx.protocol


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9560 (at least for critical items in the 8M range).

This does not update the database -- the `filename` field is the only field which requires an update, but they are kept as is in case there's any need to use the existing tar offsets. The zip filenames are automatically inferred by the cover id.

The following script can be used to generate db statements if we want to update the `filename` field:

```py
x = 10_000
for i in range(100):
     p = str(i).zfill(2)
     print(f"update cover set filename='covers_0008/covers_0008_{p}.zip' where id >={str(8_000_000 + (i * x))} and id < { str(8_000_000 + ((i+1) * x))};")
```

For the purpose of doing this in a non-breaking way, I've already added a field to the `coverstore.cover` table called `filename_old` which equals the current value of `filename` so if anything were to go wrong, we could overwrite `filename` with `filename_old`. After this work is completed, we likely want to delete the `filename_old` column as it takes up necessary space for the ~1M covers where these values have been backed up.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
