### PR TITLE
Small refactor of `Tag` code

### DIFF
--- a/openlibrary/plugins/upstream/addtag.py
+++ b/openlibrary/plugins/upstream/addtag.py
@@ -38,7 +38,9 @@ class addtag(delegate.page):
         """
         Can a tag be added?
         """
-        return user and (user.is_librarian() or user.is_super_librarian() or user.is_admin())
+        return user and (
+            user.is_librarian() or user.is_super_librarian() or user.is_admin()
+        )
 
     def POST(self):
         i = web.input(

--- a/openlibrary/plugins/upstream/addtag.py
+++ b/openlibrary/plugins/upstream/addtag.py
@@ -1,7 +1,6 @@
 """Handlers for adding and editing tags."""
 
 import web
-import json
 
 from typing import NoReturn
 
@@ -11,16 +10,10 @@ from infogami.utils.view import add_flash_message, public
 from infogami.infobase.client import ClientException
 from infogami.utils import delegate
 
-from openlibrary.plugins.openlibrary.processors import urlsafe
-from openlibrary.i18n import gettext as _
-import logging
-
 from openlibrary.plugins.upstream import spamcheck, utils
 from openlibrary.plugins.upstream.models import Tag
 from openlibrary.plugins.upstream.addbook import get_recaptcha, safe_seeother, trim_doc
 from openlibrary.plugins.upstream.utils import render_template
-
-logger = logging.getLogger("openlibrary.tag")
 
 
 @public

--- a/openlibrary/plugins/upstream/addtag.py
+++ b/openlibrary/plugins/upstream/addtag.py
@@ -102,15 +102,6 @@ class addtag(delegate.page):
         raise safe_seeother(key)
 
 
-# remove existing definitions of addtag
-delegate.pages.pop('/addtag', None)
-
-
-class addtag(delegate.page):  # type: ignore[no-redef] # noqa: F811
-    def GET(self):
-        raise web.redirect("/tag/add")
-
-
 class tag_edit(delegate.page):
     path = r"(/tags/OL\d+T)/edit"
 

--- a/openlibrary/plugins/upstream/addtag.py
+++ b/openlibrary/plugins/upstream/addtag.py
@@ -5,11 +5,11 @@ import web
 from typing import NoReturn
 
 from infogami.core.db import ValidationException
-from infogami.infobase import common
 from infogami.utils.view import add_flash_message, public
 from infogami.infobase.client import ClientException
 from infogami.utils import delegate
 
+from openlibrary.accounts import get_current_user
 from openlibrary.plugins.upstream import spamcheck, utils
 from openlibrary.plugins.upstream.models import Tag
 from openlibrary.plugins.upstream.addbook import get_recaptcha, safe_seeother, trim_doc
@@ -26,18 +26,19 @@ class addtag(delegate.page):
 
     def GET(self):
         """Main user interface for adding a tag to Open Library."""
+        if not (patron := get_current_user()):
+            raise web.seeother(f'/account/login?redirect={self.path}')
 
-        if not self.has_permission():
-            raise common.PermissionDenied(message='Permission denied to add tags')
+        if not self.has_permission(patron):
+            raise web.unauthorized(message='Permission denied to add tags')
 
         return render_template('tag/add', recaptcha=get_recaptcha())
 
-    def has_permission(self) -> bool:
+    def has_permission(self, user) -> bool:
         """
         Can a tag be added?
         """
-        user = web.ctx.site.get_user()
-        return user and (user.is_super_librarian())
+        return user and (user.is_librarian() or user.is_super_librarian() or user.is_admin())
 
     def POST(self):
         i = web.input(
@@ -52,14 +53,11 @@ class addtag(delegate.page):
                 "message.html", "Oops", 'Something went wrong. Please try again later.'
             )
 
-        if not web.ctx.site.get_user():
-            recap = get_recaptcha()
-            if recap and not recap.validate():
-                return render_template(
-                    'message.html',
-                    'Recaptcha solution was incorrect',
-                    'Please <a href="javascript:history.back()">go back</a> and try again.',
-                )
+        if not (patron := get_current_user()):
+            raise web.seeother(f'/account/login?redirect={self.path}')
+
+        if not self.has_permission(patron):
+            raise web.unauthorized(message='Permission denied to add tags')
 
         i = utils.unflatten(i)
         match = self.find_match(i)  # returns None or Tag (if match found)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9684

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Makes the following changes to our existing code for adding new Tags:
- Removes unused imports
- Removes unused logger
- Removes unused redirect
- Redirects patron to login on unauthenticated `/tag/add` request
- Raises unauthorized `HTTPError` when the patron makes a `/tag/add` request while not a member of either admin, super-librarian, or librarian usergroups.

Permissions were not modified on the [`Tag.create` method](https://github.com/internetarchive/openlibrary/blob/1a6fde92e3bbd921736d34581ad885c3e4d0e0a4/openlibrary/core/models.py#L1170), as I've noticed that our other models don't include methods for object creation.  I'm thinking that the `create` method can be replaced by some `Tag` creating object in `addtag.py` in the near future.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Ensure the `/addtag` page does not redirect to `/tag/add`.
2. Ensure that you are redirected when visiting `/tag/add` while logged-out.
3. Ensure that you can only create a new `Tag` via the `/tag/add` view when you are a member of a privileged usergroup.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
