### PR TITLE
Fix #9747 Remove LearnAwesome from identifiers.yml

### DIFF
--- a/openlibrary/plugins/openlibrary/config/edition/identifiers.yml
+++ b/openlibrary/plugins/openlibrary/config/edition/identifiers.yml
@@ -191,10 +191,6 @@ identifiers:
 -   label: LCCN
     name: lccn
     url: https://lccn.loc.gov/@@@
--   label: LearnAwesome.org
-    name: learnawesome
-    url: https://learnawesome.org/#/item/@@@
-    website: https://learnawesome.org
 -   label: Library Thing
     name: librarything
     url: https://www.librarything.com/work/@@@


### PR DESCRIPTION
LearnAwesome is no longer active and therefore, there is no need to maintain their identifiers any more. See #9747

<!-- What issue does this PR close? -->
Closes #9747 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
