### PR TITLE
Fix list edits not being correctly picked up by solr updater

### DIFF
--- a/scripts/solr_updater.py
+++ b/scripts/solr_updater.py
@@ -222,11 +222,7 @@ async def update_keys(keys):
     logger.debug("Args: %s" % str(args))
     update.load_configs(args['ol_url'], args['ol_config'], 'default')
 
-    keys = [
-        k
-        for k in keys
-        if k.count("/") == 2 and k.split("/")[1] in ("books", "authors", "works")
-    ]
+    keys = [k for k in keys if update.can_update_key(k)]
 
     count = 0
     for chunk in web.group(keys, 100):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9758 .

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

In a local dev environment, 

1. `docker compose logs --tail=10 -f solr-updater`
2. Create a new list and save it
- ✅ The list key appears in the solr-updater output
3. Go to http://localhost:8983/solr/openlibrary/update?commit=true to commit the changes to solr
4. http://localhost:8983/solr/#/openlibrary/query?q=type:list&q.op=OR&indent=true&wt=json&useParams= should show the list.


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/user-attachments/assets/6e76994a-f5b2-4566-9a08-d5aedc282667)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@jediD83 @benbdeitch 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
