### PR TITLE
Enumerate `mypy` stub dependencies for`pre-commit`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,11 @@ repos:
     hooks:
       - id: mypy  # See pyproject.toml for args
         additional_dependencies:
-          - types-all
+          - types-PyYAML
+          - types-aiofiles
+          - types-python-dateutil
+          - types-requests
+          - types-simplejson
 
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.18


### PR DESCRIPTION
Closes #9750

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This commit adds the stubs necessary for `pre-commit run --all-files` to run successfully.

`types-all` has been deprecated and removed from PyPI: https://github.com/asottile-archive/types-all

See
https://mypy.readthedocs.io/en/stable/running_mypy.html#library-stubs-not-installed for more.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Tested with:
```
❯ pre-commit clean
❯ pre-commit run --all-files
```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
