### PR TITLE
Prefill "Add Tag" form

### DIFF
--- a/openlibrary/plugins/upstream/addtag.py
+++ b/openlibrary/plugins/upstream/addtag.py
@@ -12,7 +12,7 @@ from infogami.utils import delegate
 from openlibrary.accounts import get_current_user
 from openlibrary.plugins.upstream import spamcheck, utils
 from openlibrary.plugins.upstream.models import Tag
-from openlibrary.plugins.upstream.addbook import get_recaptcha, safe_seeother, trim_doc
+from openlibrary.plugins.upstream.addbook import safe_seeother, trim_doc
 from openlibrary.plugins.upstream.utils import render_template
 
 
@@ -32,7 +32,7 @@ class addtag(delegate.page):
         if not self.has_permission(patron):
             raise web.unauthorized(message='Permission denied to add tags')
 
-        return render_template('tag/add', recaptcha=get_recaptcha())
+        return render_template('tag/add')
 
     def has_permission(self, user) -> bool:
         """

--- a/openlibrary/plugins/upstream/addtag.py
+++ b/openlibrary/plugins/upstream/addtag.py
@@ -32,7 +32,13 @@ class addtag(delegate.page):
         if not self.has_permission(patron):
             raise web.unauthorized(message='Permission denied to add tags')
 
-        return render_template('tag/add')
+        i = web.input(name=None, type=None, sub_type=None)
+
+        # Validate input:
+        if not i.name or not i.type:
+            raise web.badrequest('Tag name and type must be specified')
+
+        return render_template('tag/add', i.name, i.type, subject_type=i.sub_type)
 
     def has_permission(self, user) -> bool:
         """

--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -16,7 +16,9 @@ $ has_tag = 'tag' in page
 <div class="page-heading-search-box">
     $if can_add_tag:
       <div class="subjectTagEdit">
-        $ edit_tag_url = page.tag.get('id') + '/edit' if 'tag' in page else '/tag/add'
+        $ edit_tag_url = page.tag.get('id') + '/edit' if has_tag else '/tag/add'
+        $if not has_tag:
+          $ edit_tag_url += '?name=%s&type=subject&sub_type=%s' % (page.name, page.subject_type)
         <a
           class="editTagButton"
           href="$edit_tag_url"

--- a/openlibrary/templates/tag/add.html
+++ b/openlibrary/templates/tag/add.html
@@ -1,4 +1,4 @@
-$def with (tag=None, name=None, recaptcha=None)
+$def with ()
 
 $var title: $_("Add a tag")
 
@@ -47,9 +47,6 @@ $var title: $_("Add a tag")
                 </select>
             </div>
         </div>
-
-        $if recaptcha and not ctx.user:
-            $:render_template("recaptcha", recaptcha.public_key, error=None)
 
         <div class="formElement bottom">
             <br/>

--- a/openlibrary/templates/tag/add.html
+++ b/openlibrary/templates/tag/add.html
@@ -1,4 +1,4 @@
-$def with ()
+$def with (name, type, subject_type=None)
 
 $var title: $_("Add a tag")
 
@@ -20,7 +20,7 @@ $var title: $_("Add a tag")
                 <label for="tagname">$_("Name of Tag")</label>*<span class="tip">$_("Required field")</span>
             </div>
             <div class="input">
-                <input type="text" name="tag_name" id="tag_name" required/>
+                <input type="text" name="tag_name" id="tag_name" value="$name" required/>
             </div>
         </div>
 
@@ -43,7 +43,10 @@ $var title: $_("Add a tag")
                     <option value="">$_("Select")</option>
                     $ tag_types = get_tag_types()
                     $for tag_type in tag_types:
-                        <option value="$tag_type">$tag_type</option>
+                        $if tag_type == type:
+                            <option value="$tag_type" selected>$tag_type</option>
+                        $else:
+                            <option value="$tag_type">$tag_type</option>
                 </select>
             </div>
         </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Addresses #9685

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Passes Tag `name`, `type`, and optional `sub_type` (for subject type) from the subject page to the Tag creation template.

The `name` and `type` parameters are now required by the `/tag/add` GET handler.

Tag creation form is now prefilled with the `name` and `type`.  ReCaptcha has been removed from the "Add Tag" page, as this view is restricted to librarians.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in as a `super-librarian` (this is important and checked on subject page --- will be fixed later):
1. Navigate to a subject page that __does not__ have a linked subject.
2. Click the "Edit" button.
3. Ensure that the "Add Tag" page is displayed, and that the form's name input the subject type option are prefilled/selected.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
