### PR TITLE
Require Tag type on creation, update

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -3395,7 +3395,7 @@ msgstr ""
 msgid "ISBN may be invalid. Click \"Add\" again to submit."
 msgstr ""
 
-#: books/add.html tag/add.html
+#: books/add.html tag/add.html type/tag/edit.html
 msgid "Select"
 msgstr ""
 

--- a/openlibrary/plugins/upstream/addtag.py
+++ b/openlibrary/plugins/upstream/addtag.py
@@ -21,6 +21,10 @@ def get_tag_types():
     return ["subject", "work", "collection"]
 
 
+def validate_tag(tag):
+    return tag.get('name', '') and tag.get('tag_type', '')
+
+
 class addtag(delegate.page):
     path = '/tag/add'
 
@@ -62,6 +66,10 @@ class addtag(delegate.page):
             raise web.unauthorized(message='Permission denied to add tags')
 
         i = utils.unflatten(i)
+
+        if not i.tag_name or not i.tag_type:
+            raise web.badrequest()
+
         match = self.find_match(i)  # returns None or Tag (if match found)
 
         if match:
@@ -120,7 +128,7 @@ class tag_edit(delegate.page):
         i = web.input(_comment=None)
         formdata = self.process_input(i)
         try:
-            if not formdata:
+            if not formdata or not validate_tag(formdata):
                 raise web.badrequest()
             elif "_delete" in i:
                 tag = web.ctx.site.new(

--- a/openlibrary/templates/tag/add.html
+++ b/openlibrary/templates/tag/add.html
@@ -39,7 +39,7 @@ $var title: $_("Add a tag")
         <div class="formElement">
             <div class="label"><label for="id_value">$_("Tag type")</label></div>
             <div class="input">
-                <select name="tag_type" id="tag_type">
+                <select name="tag_type" id="tag_type" required>
                     <option value="">$_("Select")</option>
                     $ tag_types = get_tag_types()
                     $for tag_type in tag_types:

--- a/openlibrary/templates/type/tag/edit.html
+++ b/openlibrary/templates/type/tag/edit.html
@@ -36,10 +36,12 @@ $putctx("robots", "noindex,nofollow")
             <div class="label"><label for="id_value">$_("Tag type")</label></div>
             <div class="input">
                 <select name="tag_type" id="tag_type">
-                    <option value="$page.tag_type">$page.tag_type</option>
+                    <option value="">$_("Select")</option>
                     $ tag_types = get_tag_types()
                     $for tag_type in tag_types:
-                        $if tag_type != page.tag_type:
+                        $if tag_type == page.tag_type:
+                            <option value="$tag_type" selected>$tag_type</option>
+                        $else:
                             <option value="$tag_type">$tag_type</option>
                 </select>
             </div>

--- a/openlibrary/templates/type/tag/edit.html
+++ b/openlibrary/templates/type/tag/edit.html
@@ -35,7 +35,7 @@ $putctx("robots", "noindex,nofollow")
         <div class="formElement">
             <div class="label"><label for="id_value">$_("Tag type")</label></div>
             <div class="input">
-                <select name="tag_type" id="tag_type">
+                <select name="tag_type" id="tag_type" required>
                     <option value="">$_("Select")</option>
                     $ tag_types = get_tag_types()
                     $for tag_type in tag_types:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9780

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Changes to require `tag_type` and `name` whenever a Tag is created or updated.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
> [!IMPORTANT]
> Until #9776 is merged, validations will not occur when `?m=edit` is used to navigate to the edit view.

While logged in as a `librarian`, test the following:

1. Go to `/tag/add` page and attempt to submit the form without filling the Tag name input, or selecting a Tag type.  Expect to see "Required field" messages by these inputs.
2. Using your preferred tool, send some `POST` requests to the `/tag/add` endpoint.  Ensure that you receive a `400` when either the `name` or `tag_type` is missing from the request.
3. Repeat step 1 on an existing Tag's edit page.
4. Repeat step 2 on an existing Tag's edit page.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
