### PR TITLE
Create macros for subject pages

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -695,27 +695,6 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: SearchNavigation.html SubjectTags.html lib/nav_foot.html lib/nav_head.html
-#: subjects.html subjects/notfound.html type/author/view.html
-#: type/list/view_body.html
-msgid "Subjects"
-msgstr ""
-
-#: SubjectTags.html subjects.html type/author/view.html
-#: type/list/view_body.html
-msgid "Places"
-msgstr ""
-
-#: SubjectTags.html admin/menu.html admin/people/index.html
-#: admin/people/view.html subjects.html type/author/view.html
-#: type/list/view_body.html
-msgid "People"
-msgstr ""
-
-#: SubjectTags.html subjects.html type/list/view_body.html
-msgid "Times"
-msgstr ""
-
 #: subjects.html
 msgid "Edit Subject Tag"
 msgstr ""
@@ -742,83 +721,6 @@ msgstr ""
 #: subjects/notfound.html type/local_id/view.html
 msgid "Search"
 msgstr ""
-
-#: publishers/view.html subjects.html
-msgid "Publishing History"
-msgstr ""
-
-#: subjects.html
-msgid ""
-"This is a chart to show the publishing history of editions of works about"
-" this subject. Along the X axis is time, and on the y axis is the count "
-"of editions published. <a href=\"#subjectRelated\">Click here to skip the"
-" chart</a>."
-msgstr ""
-
-#: publishers/view.html subjects.html
-msgid "Reset chart"
-msgstr ""
-
-#: publishers/view.html subjects.html
-msgid "or continue zooming in."
-msgstr ""
-
-#: subjects.html
-msgid "This graph charts editions published on this subject."
-msgstr ""
-
-#: publishers/view.html subjects.html
-msgid "Editions Published"
-msgstr ""
-
-#: admin/imports.html publishers/view.html subjects.html
-msgid "You need to have JavaScript turned on to see the nifty chart!"
-msgstr ""
-
-#: publishers/view.html subjects.html
-msgid "Year of Publication"
-msgstr ""
-
-#: subjects.html
-msgid "Related..."
-msgstr ""
-
-#: publishers/view.html subjects.html
-msgid "None found."
-msgstr ""
-
-#: publishers/view.html subjects.html
-msgid "See more books by, and learn about, this author"
-msgstr ""
-
-#: account/loans.html authors/index.html lists/showcase.html
-#: publishers/view.html search/authors.html search/publishers.html
-#: search/subjects.html subjects.html
-#, python-format
-msgid "%(count)d book"
-msgid_plural "%(count)d books"
-msgstr[0] ""
-msgstr[1] ""
-
-#: subjects.html
-msgid "Prolific Authors"
-msgstr ""
-
-#: subjects.html
-msgid "who have written the most books on this subject"
-msgstr ""
-
-#: publishers/view.html subjects.html
-msgid "Get more information about this publisher"
-msgstr ""
-
-#: SearchResultsWork.html books/check.html merge/authors.html
-#: publishers/view.html subjects.html
-#, python-format
-msgid "%(count)s edition"
-msgid_plural "%(count)s editions"
-msgstr[0] ""
-msgstr[1] ""
 
 #: support.html
 msgid "How can we help?"
@@ -1337,6 +1239,15 @@ msgid ""
 "Are you sure you want to leave the waiting list "
 "of<br/><strong>TITLE</strong>?"
 msgstr ""
+
+#: ProlificAuthors.html account/loans.html authors/index.html
+#: lists/showcase.html publishers/view.html search/authors.html
+#: search/publishers.html search/subjects.html
+#, python-format
+msgid "%(count)d book"
+msgid_plural "%(count)d books"
+msgstr[0] ""
+msgstr[1] ""
 
 #: RecentChangesAdmin.html account/loans.html admin/loans_table.html
 msgid "Actions"
@@ -2100,6 +2011,10 @@ msgstr ""
 msgid "New Books Imported Per Day"
 msgstr ""
 
+#: PublishingHistory.html admin/imports.html publishers/view.html
+msgid "You need to have JavaScript turned on to see the nifty chart!"
+msgstr ""
+
 #: admin/imports.html admin/imports_by_date.html site/stats.html
 msgid "Summary"
 msgstr ""
@@ -2364,6 +2279,12 @@ msgstr ""
 
 #: admin/menu.html
 msgid "Admin Center"
+msgstr ""
+
+#: RelatedSubjects.html SubjectTags.html admin/menu.html
+#: admin/people/index.html admin/people/view.html type/author/view.html
+#: type/list/view_body.html
+msgid "People"
 msgstr ""
 
 #: admin/menu.html
@@ -3476,6 +3397,14 @@ msgstr ""
 #: books/check.html
 msgid "Select this book"
 msgstr ""
+
+#: SearchResultsWork.html books/check.html merge/authors.html
+#: publishers/view.html
+#, python-format
+msgid "%(count)s edition"
+msgid_plural "%(count)s editions"
+msgstr[0] ""
+msgstr[1] ""
 
 #: books/check.html
 #, python-format
@@ -5096,6 +5025,12 @@ msgstr ""
 msgid "Explore subjects"
 msgstr ""
 
+#: RelatedSubjects.html SearchNavigation.html SubjectTags.html
+#: lib/nav_foot.html lib/nav_head.html subjects/notfound.html
+#: type/author/view.html type/list/view_body.html
+msgid "Subjects"
+msgstr ""
+
 #: lib/nav_foot.html
 msgid "Explore collections"
 msgstr ""
@@ -5854,6 +5789,10 @@ msgstr[1] ""
 msgid "0 ebooks"
 msgstr ""
 
+#: PublishingHistory.html publishers/view.html
+msgid "Publishing History"
+msgstr ""
+
 #: publishers/view.html
 msgid ""
 "This is a chart to show the when this publisher published books. Along "
@@ -5861,10 +5800,26 @@ msgid ""
 " <a href=\"#subjectRelated\">Click here to skip the chart</a>."
 msgstr ""
 
+#: PublishingHistory.html publishers/view.html
+msgid "Reset chart"
+msgstr ""
+
+#: PublishingHistory.html publishers/view.html
+msgid "or continue zooming in."
+msgstr ""
+
 #: publishers/view.html
 msgid ""
 "This graph charts editions from this publisher over time. Click to view a"
 " single year, or drag across a range."
+msgstr ""
+
+#: PublishingHistory.html publishers/view.html
+msgid "Editions Published"
+msgstr ""
+
+#: PublishingHistory.html publishers/view.html
+msgid "Year of Publication"
 msgstr ""
 
 #: publishers/view.html
@@ -5876,8 +5831,20 @@ msgstr ""
 msgid "Search for books published by %(publisher)s"
 msgstr ""
 
+#: RelatedSubjects.html publishers/view.html
+msgid "None found."
+msgstr ""
+
+#: ProlificAuthors.html publishers/view.html
+msgid "See more books by, and learn about, this author"
+msgstr ""
+
 #: publishers/view.html
 msgid "published most by this publisher"
+msgstr ""
+
+#: publishers/view.html
+msgid "Get more information about this publisher"
 msgstr ""
 
 #: recentchanges/header.html
@@ -6563,6 +6530,11 @@ msgstr ""
 msgid "Search %(author)s books"
 msgstr ""
 
+#: RelatedSubjects.html SubjectTags.html type/author/view.html
+#: type/list/view_body.html
+msgid "Places"
+msgstr ""
+
 #: Profile.html type/author/view.html
 msgid "Time"
 msgstr ""
@@ -6971,6 +6943,10 @@ msgstr ""
 
 #: type/list/view_body.html
 msgid "Derived from seed metadata"
+msgstr ""
+
+#: RelatedSubjects.html SubjectTags.html type/list/view_body.html
+msgid "Times"
 msgstr ""
 
 #: type/local_id/view.html
@@ -7455,6 +7431,26 @@ msgstr ""
 msgid "Component"
 msgstr ""
 
+#: ProlificAuthors.html
+msgid "Prolific Authors"
+msgstr ""
+
+#: ProlificAuthors.html
+msgid "who have written the most books on this subject"
+msgstr ""
+
+#: PublishingHistory.html
+msgid ""
+"This is a chart to show the publishing history of editions of works about"
+" this subject. Along the X axis is time, and on the y axis is the count "
+"of editions published. <a href=\"#subjectRelated\">Click here to skip the"
+" chart</a>."
+msgstr ""
+
+#: PublishingHistory.html
+msgid "This graph charts editions published on this subject."
+msgstr ""
+
 #: QueryCarousel.html
 msgid "Search collection"
 msgstr ""
@@ -7507,6 +7503,10 @@ msgstr ""
 
 #: RecentChangesAdmin.html RecentChangesUsers.html
 msgid "No edit history available."
+msgstr ""
+
+#: RelatedSubjects.html
+msgid "Related..."
 msgstr ""
 
 #: ReturnForm.html

--- a/openlibrary/macros/ProlificAuthors.html
+++ b/openlibrary/macros/ProlificAuthors.html
@@ -1,0 +1,16 @@
+$def with (authors)
+
+<div id="resultsAuthors" class="widget-box">
+  <div class="head">
+    <h3>$_("Prolific Authors")</h3>
+    <div class="smallest lightgreen sansserif">$_("who have written the most books on this subject")</div>
+  </div>
+  <div class="unordered">
+    $for author in authors:
+      <span class="tag">
+        <a href="$author.key" title="$_('See more books by, and learn about, this author')">$author.name</a>,
+      </span>
+      <span class="count">$ungettext("%(count)d book", "%(count)d books", author.count, count=author.count)</span>
+      <br/>
+  </div>
+</div>

--- a/openlibrary/macros/PublishingHistory.html
+++ b/openlibrary/macros/PublishingHistory.html
@@ -1,0 +1,20 @@
+$def with (publishing_history)
+
+<div class="head">
+    <h2 class="inline">
+      $_("Publishing History")
+    </h2>
+    <span class="shift">$:_('This is a chart to show the publishing history of editions of works about this subject. Along the X axis is time, and on the y axis is the count of editions published. <a href="#subjectRelated">Click here to skip the chart</a>.')</span>
+    <span class="count hidden chartZoom">&nbsp;<a href="javascript:;" class="resetSelection small">$_("Reset chart")</a> $_("or continue zooming in.")</span>
+    <span class="count chartUnzoom">&nbsp;$_("This graph charts editions published on this subject.")</span>
+</div>
+
+<script type="text/json+graph" id="graph-json-chartPubHistory">$:json_encode(publishing_history)</script>
+
+<div class="chart">
+    <div class="chartYaxis">$_("Editions Published")</div>
+    <div id="chartPubHistory" class="thisChart">
+        <noscript>$_("You need to have JavaScript turned on to see the nifty chart!")</noscript>
+    </div>
+    <div class="chartXaxis">$_("Year of Publication")</div>
+</div>

--- a/openlibrary/macros/RelatedSubjects.html
+++ b/openlibrary/macros/RelatedSubjects.html
@@ -1,0 +1,22 @@
+$def with (page)
+
+$ subject_list = [('subjects', _('Subjects'), 20), ('places', _('Places'), 20), ('people', _('People'), 10), ('times', _('Times'), 10)]
+
+<div class="head" id="subjectRelated">
+  <h2>$_("Related...")</h2>
+</div>
+
+$def renderSubjects(subjects):
+    $if len(subjects) > 0:
+        <span class="subject">
+        $for s in subjects:
+            <a href="$s.key">$s.name</a>$cond(loop.last, '', ',')
+        </span>
+    $else:
+        <span class="title"><em>$_("None found.")</em></span>
+
+$for category, label, limit in subject_list:
+    <div class="contentQuarter link-box link-box--with-header">
+      <h6 class="black collapse uppercase">$label</h6>
+      $:renderSubjects(page[category][:limit])
+    </div>

--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -96,22 +96,7 @@ $ has_tag = 'tag' in page
 
     <div class="clearfix"></div>
 
-$jsdef renderAuthors(authors):
-    $for a in page.authors:
-        <span class="tag">
-            <a href="$a.key" title="$_('See more books by, and learn about, this author')">$a.name</a>,
-        </span>
-        <span class="count">$ungettext("%(count)d book", "%(count)d books", a.count, count=a.count)</span>
-        <br/>
-<div id="resultsAuthors" class="widget-box">
-  <div class="head">
-    <h3>$_("Prolific Authors")</h3>
-    <div class="smallest lightgreen sansserif">$_("who have written the most books on this subject")</div>
-  </div>
-  <div class="unordered">
-    $:renderAuthors(page.authors)
-  </div>
-</div>
+    $:macros.ProlificAuthors(page.authors)
     <div class="spacer"></div>
     <div class="section clearfix"></div>
 </div>

--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -2,7 +2,6 @@ $def with (page)
 
 $var title: $page.name
 
-$ subject_list = [('subjects', _('Subjects'), 20), ('places', _('Places'), 20), ('people', _('People'), 10), ('times', _('Times'), 10)]
 $ can_add_tag = ctx.user and (ctx.user.is_super_librarian())
 $ has_tag = 'tag' in page
 
@@ -72,31 +71,11 @@ $ has_tag = 'tag' in page
     </div>
 
     <div class="clearfix"></div>
-
-    <div class="head" id="subjectRelated">
-      <h2>$_("Related...")
-        <!-- <span class="count"><a href="/search?${page.subject_type}_facet=$page.name.replace('&','%26')">Search within $page.name</a></span> -->
-      </h2>
-    </div>
-
-    $jsdef renderSubjects(subjects):
-        $if len(subjects) > 0:
-            <span class="subject">
-            $for s in subjects:
-                <a href="$s.key">$s.name</a>$cond(loop.last, '', ',')
-            </span>
-        $else:
-            <span class="title"><em>$_("None found.")</em></span>
-
-    $for category, label, limit in subject_list:
-        <div class="contentQuarter link-box link-box--with-header">
-          <h6 class="black collapse uppercase">$label</h6>
-          $:renderSubjects(page[category][:limit])
-        </div>
+    $:macros.RelatedSubjects(page)
 
     <div class="clearfix"></div>
-
     $:macros.ProlificAuthors(page.authors)
+
     <div class="spacer"></div>
     <div class="section clearfix"></div>
 </div>

--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -112,21 +112,6 @@ $jsdef renderAuthors(authors):
     $:renderAuthors(page.authors)
   </div>
 </div>
-<div class="spacer"></div>
-
-$ publishers_feature_enabled = "publishers" in ctx.features
-
-$jsdef renderPublishers(publishers):
-    $for p in publishers:
-        <span class="tag">
-            $if publishers_feature_enabled:
-                <a href="$p.key">$p.name</a>,
-            $else:
-                <a href="/search?${page.subject_type}_facet=$page.name.replace('&','%26')&amp;publisher_facet=$p.name.replace('"', '\\"').replace('&','%26')" title="$_('Get more information about this publisher')">$p.name</a>,
-        </span>
-        <span class="count">$ungettext("%(count)s edition", "%(count)s editions", p.count, count=commify(p.count))</span>
-        <br/>
-
-<div class="section clearfix"></div>
-
+    <div class="spacer"></div>
+    <div class="section clearfix"></div>
 </div>

--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -49,26 +49,8 @@ $ has_tag = 'tag' in page
 
 <div class="contentBody">
 
-  $:render_template("books/custom_carousel", books=page.works, load_more={"url": page.key + ".json", "limit": len(page.works)})
-
-  <div class="head">
-    <h2 class="inline">
-      $_("Publishing History")
-    </h2>
-      <span class="shift">$:_('This is a chart to show the publishing history of editions of works about this subject. Along the X axis is time, and on the y axis is the count of editions published. <a href="#subjectRelated">Click here to skip the chart</a>.')</span>
-      <span class="count hidden chartZoom">&nbsp;<a href="javascript:;" class="resetSelection small">$_("Reset chart")</a> $_("or continue zooming in.")</span>
-      <span class="count chartUnzoom">&nbsp;$_("This graph charts editions published on this subject.")</span>
-  </div>
-
-    <script type="text/json+graph" id="graph-json-chartPubHistory">$:json_encode(page.publishing_history)</script>
-
-    <div class="chart">
-        <div class="chartYaxis">$_("Editions Published")</div>
-        <div id="chartPubHistory" class="thisChart">
-            <noscript>$_("You need to have JavaScript turned on to see the nifty chart!")</noscript>
-        </div>
-        <div class="chartXaxis">$_("Year of Publication")</div>
-    </div>
+    $:render_template("books/custom_carousel", books=page.works, load_more={"url": page.key + ".json", "limit": len(page.works)})
+    $:macros.PublishingHistory(page.publishing_history)
 
     <div class="clearfix"></div>
     $:macros.RelatedSubjects(page)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9785

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Extracts three subject page components into macros:
- `ProlificAuthors.html`: The list of prolific authors on a subject
- `PublishingHistory.html`: The publishing history graph for a subject
- `RelatedSubjects.html`: Links to related subject pages

Additionally, removes unreferenced `renderPublishers` `jsdef` function.

The existing carousel is a `custom_carousel` template, and hasn't modified.

### Technical
<!-- What should be noted about the implementation? -->
`renderSubjects` in the `RelatedSubjects` macro is no longer a `jsdef` function.  This function worked properly when called from the browser console, but wasn't referenced in our codebase.

The `renderAuthors` `jsdef` function was not included in the `ProlificAuthors` macro.  This function __did not__ work properly when called from the console, due to an `Uncaught ReferenceError: page is not defined` error.  Also, it isn't referenced in our codebase.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Before deploying these changes, navigate to a subject page.
2. Open another tab.
3. Deploy the branch.
4. Open the same subject page in your new tab.  Content, styling, and functionality should be the same when the tabs are compared.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
