### PR TITLE
Add Star Ratings & Want To Read counts to Search Result Cards

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -7545,20 +7545,15 @@ msgstr ""
 
 #: SearchResultsWork.html
 #, python-format
+msgid "Cover of edition %(id)s"
+msgstr ""
+
+#: SearchResultsWork.html
+#, python-format
 msgid "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d language</a>"
 msgid_plural "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d languages</a>"
 msgstr[0] ""
 msgstr[1] ""
-
-#: SearchResultsWork.html
-#, python-format
-msgid "%s previewable"
-msgstr ""
-
-#: SearchResultsWork.html
-#, python-format
-msgid "Cover of edition %(id)s"
-msgstr ""
 
 #: SearchResultsWork.html
 msgid "This is only visible to librarians."
@@ -7617,11 +7612,23 @@ msgstr ""
 msgid "Clear my rating"
 msgstr ""
 
-#: StarRatingsStats.html
-msgid "Rating"
-msgid_plural "Ratings"
-msgstr[0] ""
-msgstr[1] ""
+#: StarRatingsByline.html StarRatingsComponent.html
+msgid "rating"
+msgstr ""
+
+#: StarRatingsByline.html StarRatingsComponent.html
+msgid "ratings"
+msgstr ""
+
+#: StarRatingsByline.html
+#, python-format
+msgid "%(want_to_read_count)s Want to read"
+msgstr ""
+
+#: StarRatingsComponent.html
+#, python-format
+msgid "%(ratings_avg)s (%(ratings_count)s %(ratings_label)s)"
+msgstr ""
 
 #: StarRatingsStats.html
 msgid "Want to read"

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -91,6 +91,11 @@ $code:
             $:macros.BookByline(author_data, limit=max_rendered_authors, overflow_url=work_edition_url, attrs='class="results"')
         </span>
         <span class="resultPublisher">
+          $if doc.get('ratings_count') and doc.get('ratings_average') and doc.get('want_to_read_count'):
+            <span class="publishedYear--ratings">
+              $ ratings_label = _('rating') if doc.ratings_count == 1 else _('ratings')
+              $_('%(ratings_average)s (%(ratings_count)s %(ratings_label)s) — %(want_to_read)s Want to read', ratings_average=doc.ratings_average, ratings_count=doc.ratings_count, ratings_label=ratings_label, want_to_read=doc.want_to_read_count)
+            </span>
           $if doc.get('first_publish_year'):
             <span class="publishedYear">
               $_('First published in %(year)s', year=doc.first_publish_year)

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -61,12 +61,10 @@ $code:
     </span>
 
     <div class="details">
-        <div class="resultTitle">
-          <h3 itemprop="name" class="booktitle">
-            <a itemprop="url" href="$work_edition_url" class="results">$full_title</a>
-          </h3>
-        </div>
-        <span itemprop="author" itemscope itemtype="https://schema.org/Organization" class="bookauthor">
+        <h3 itemprop="name">
+          <a itemprop="url" href="$work_edition_url" class="results">$full_title</a>
+        </h3>
+        <span class="resultAuthor" itemprop="author" itemscope itemtype="https://schema.org/Organization" class="bookauthor">
           $ authors = None
           $if doc_type == 'infogami_work':
             $ authors = doc.get_authors()
@@ -88,23 +86,14 @@ $code:
                 }
                 for a in authors
               ]
-            $:macros.BookByline(author_data, limit=max_rendered_authors, overflow_url=work_edition_url, attrs='class="results"')
+            $:macros.BookByline(author_data, limit=max_rendered_authors, overflow_url=work_edition_url)
         </span>
-        <span class="resultPublisher">
-          $if doc.get('ratings_count') and doc.get('ratings_average') and doc.get('want_to_read_count'):
-            $:macros.StarRatingsByline(doc)
-          $if doc.get('first_publish_year'):
-            <span class="publishedYear">
-              $_('First published in %(year)s', year=doc.first_publish_year)
-            </span>
-          $if doc.get('edition_count'):
-            <a href="$work_edition_all_url#editions-list">$ungettext('%(count)s edition', '%(count)s editions', doc.edition_count, count=doc.edition_count)</a>
-          $if doc.get('languages'):
-            <span class="languages">
-              $:ungettext('in <a class="hoverlink" title="%(langs)s">%(count)d language</a>', 'in <a class="hoverlink" title="%(langs)s">%(count)d languages</a>', len(doc.languages), count=len(doc.languages), langs=commify_list([get_language_name('/languages/' + lang) for lang in doc.languages]))
-            </span>
+        <span class="resultStats">
+          $ ratings_count = doc.get('ratings_count', None)
+          $ ratings_avg = doc.get('ratings_average', None)
+          $ want_to_read_count = doc.get('want_to_read_count', None)
+          $:macros.StarRatingsByline(ratings_count, ratings_avg, want_to_read_count)
           $if doc.get('ia'):
-            &mdash; $_('%s previewable', len(doc.get('ia')))
             $if len(doc.get('ia')) > 1:
               $ blur_preview = "preview-covers--blur" if blur else ""
               <span class="preview-covers $blur_preview">
@@ -113,6 +102,20 @@ $code:
                     <img width="30" height="45" loading="lazy" src="//archive.org/services/img/$i" alt="$_('Cover of edition %(id)s', id=i)">
                   </a>
               </span>
+          <span class="resultDetails">
+            $if doc.get('first_publish_year'):
+              <span>
+                $_('First published in %(year)s', year=doc.first_publish_year)
+              </span>&mdash;
+            $if doc.get('edition_count'):
+              <span>
+                <a href="$work_edition_all_url#editions-list">$ungettext('%(count)s edition', '%(count)s editions', doc.edition_count, count=doc.edition_count)</a>
+              </span>
+            $if doc.get('languages'):
+              <span class="languages">
+                $:ungettext('in <a class="hoverlink" title="%(langs)s">%(count)d language</a>', 'in <a class="hoverlink" title="%(langs)s">%(count)d languages</a>', len(doc.languages), count=len(doc.languages), langs=commify_list([get_language_name('/languages/' + lang) for lang in doc.languages]))
+              </span>
+          </span>
         </span>
         $if show_librarian_extras:
           <div class="searchResultItem__librarian-extras" title="$_('This is only visible to librarians.')">

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -61,10 +61,12 @@ $code:
     </span>
 
     <div class="details">
-        <h3 itemprop="name">
+      <div class="resultTitle">
+        <h3 itemprop="name" class="booktitle">
           <a itemprop="url" href="$work_edition_url" class="results">$full_title</a>
         </h3>
-        <span class="resultAuthor" itemprop="author" itemscope itemtype="https://schema.org/Organization" class="bookauthor">
+      </div>
+        <span itemprop="author" itemscope itemtype="https://schema.org/Organization" class="bookauthor">
           $ authors = None
           $if doc_type == 'infogami_work':
             $ authors = doc.get_authors()

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -113,9 +113,10 @@ $code:
               <span>
                 <a href="$work_edition_all_url#editions-list">$ungettext('%(count)s edition', '%(count)s editions', doc.edition_count, count=doc.edition_count)</a>
               </span>
-            $if doc.get('languages'):
+            $if doc.get('languages') and doc_type in ['infogami_work', 'solr_work']:
               <span class="languages">
-                $:ungettext('in <a class="hoverlink" title="%(langs)s">%(count)d language</a>', 'in <a class="hoverlink" title="%(langs)s">%(count)d languages</a>', len(doc.languages), count=len(doc.languages), langs=commify_list([get_language_name('/languages/' + lang) for lang in doc.languages]))
+                $ langs = [get_language_name(lang.key if hasattr(lang, 'key') else '/languages' + lang) for lang in doc.languages]
+                $:ungettext('in <a class="hoverlink" title="%(langs)s">%(count)d language</a>', 'in <a class="hoverlink" title="%(langs)s">%(count)d languages</a>', len(doc.languages), count=len(doc.languages), langs=commify_list(langs))
               </span>
           </span>
         </span>

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -92,30 +92,27 @@ $code:
         </span>
         <span class="resultPublisher">
           $if doc.get('ratings_count') and doc.get('ratings_average') and doc.get('want_to_read_count'):
-            <span class="publishedYear--ratings">
-              $ ratings_label = _('rating') if doc.ratings_count == 1 else _('ratings')
-              $_('%(ratings_average)s (%(ratings_count)s %(ratings_label)s) — %(want_to_read)s Want to read', ratings_average=doc.ratings_average, ratings_count=doc.ratings_count, ratings_label=ratings_label, want_to_read=doc.want_to_read_count)
-            </span>
+            $:macros.StarRatingsByline(doc)
           $if doc.get('first_publish_year'):
             <span class="publishedYear">
               $_('First published in %(year)s', year=doc.first_publish_year)
             </span>
           $if doc.get('edition_count'):
             <a href="$work_edition_all_url#editions-list">$ungettext('%(count)s edition', '%(count)s editions', doc.edition_count, count=doc.edition_count)</a>
-            $if doc.get('languages'):
-              <span class="languages">
-                $:ungettext('in <a class="hoverlink" title="%(langs)s">%(count)d language</a>', 'in <a class="hoverlink" title="%(langs)s">%(count)d languages</a>', len(doc.languages), count=len(doc.languages), langs=commify_list([get_language_name('/languages/' + lang) for lang in doc.languages]))
+          $if doc.get('languages'):
+            <span class="languages">
+              $:ungettext('in <a class="hoverlink" title="%(langs)s">%(count)d language</a>', 'in <a class="hoverlink" title="%(langs)s">%(count)d languages</a>', len(doc.languages), count=len(doc.languages), langs=commify_list([get_language_name('/languages/' + lang) for lang in doc.languages]))
+            </span>
+          $if doc.get('ia'):
+            &mdash; $_('%s previewable', len(doc.get('ia')))
+            $if len(doc.get('ia')) > 1:
+              $ blur_preview = "preview-covers--blur" if blur else ""
+              <span class="preview-covers $blur_preview">
+                $for x, i in enumerate(doc.get('ia')[1:10]):
+                  <a href="$(book_url)?edition=ia:$(urlquote(i))">
+                    <img width="30" height="45" loading="lazy" src="//archive.org/services/img/$i" alt="$_('Cover of edition %(id)s', id=i)">
+                  </a>
               </span>
-            $if doc.get('ia'):
-              &mdash; $_('%s previewable', len(doc.get('ia')))
-              $if len(doc.get('ia')) > 1:
-                $ blur_preview = "preview-covers--blur" if blur else ""
-                <span class="preview-covers $blur_preview">
-                  $for x, i in enumerate(doc.get('ia')[1:10]):
-                    <a href="$(book_url)?edition=ia:$(urlquote(i))">
-                      <img width="30" height="45" loading="lazy" src="//archive.org/services/img/$i" alt="$_('Cover of edition %(id)s', id=i)">
-                    </a>
-                </span>
         </span>
         $if show_librarian_extras:
           <div class="searchResultItem__librarian-extras" title="$_('This is only visible to librarians.')">

--- a/openlibrary/macros/StarRatingsByline.html
+++ b/openlibrary/macros/StarRatingsByline.html
@@ -1,0 +1,17 @@
+$def with(doc)
+
+$ ratings_count = doc.get('ratings_count', None)
+$ ratings_average = doc.get('ratings_average', None)
+$ ratings_label = _('rating') if ratings_count == 1 else _('ratings')
+$ want_to_read_count = doc.get('want_to_read_count', None)
+
+<span class="publishedYear--ratings itemprop="aggregateRating" itemscope itemtype="https://schema.org/AggregateRating">
+  $if ratings_count:
+    $ stats_decimal = (float(ratings_average))-(int(ratings_average))
+    $:('<span class="reader-stats__star readers-stats__star--byline">★</span>' * int(ratings_average))
+    $if (stats_decimal >= 0.5) and (stats_decimal < 1):
+      $:('<span class="readers-stats__star--half reader-stats__star--byline">★</span>')
+    <span itemprop="ratingValue">$:_('%(ratings_avg)s (%(ratings_count)s %(ratings_label)s)', ratings_avg=ratings_average, ratings_count=ratings_count, ratings_label=ratings_label)</span>
+    <span class="dot">·</span>
+    <span itemprop="reviewCount">$_('%(want_to_read_count)s Want to read', want_to_read_count=want_to_read_count)</span>
+</span>

--- a/openlibrary/macros/StarRatingsByline.html
+++ b/openlibrary/macros/StarRatingsByline.html
@@ -1,13 +1,13 @@
 $def with(ratings_count, ratings_average, want_to_read_count)
 
-$ formatted_want_to_read_count = "{:,}".format(want_to_read_count)
+$ formatted_want_to_read_count = "{:,}".format(want_to_read_count) if want_to_read_count else ""
 $ ratings_label = _('rating') if ratings_count == 1 else _('ratings')
 
 <span class="ratingsByline itemprop="aggregateRating" itemscope itemtype="https://schema.org/AggregateRating">
   $if ratings_count:
     $:macros.StarRatingsComponent(ratings_count, ratings_average, 'results_page')
 </span>
-$if want_to_read_count > 0 and ratings_count > 0:
+$if want_to_read_count and ratings_count:
   <span class="dot">·</span>
-$if want_to_read_count > 0:
+$if want_to_read_count:
   <span class="ratingsByline" itemprop="reviewCount">$_('%(want_to_read_count)s Want to read', want_to_read_count=formatted_want_to_read_count)</span>

--- a/openlibrary/macros/StarRatingsByline.html
+++ b/openlibrary/macros/StarRatingsByline.html
@@ -1,17 +1,13 @@
-$def with(doc)
+$def with(ratings_count, ratings_average, want_to_read_count)
 
-$ ratings_count = doc.get('ratings_count', None)
-$ ratings_average = doc.get('ratings_average', None)
+$ formatted_want_to_read_count = "{:,}".format(want_to_read_count)
 $ ratings_label = _('rating') if ratings_count == 1 else _('ratings')
-$ want_to_read_count = doc.get('want_to_read_count', None)
 
-<span class="publishedYear--ratings itemprop="aggregateRating" itemscope itemtype="https://schema.org/AggregateRating">
+<span class="ratingsByline itemprop="aggregateRating" itemscope itemtype="https://schema.org/AggregateRating">
   $if ratings_count:
-    $ stats_decimal = (float(ratings_average))-(int(ratings_average))
-    $:('<span class="reader-stats__star readers-stats__star--byline">★</span>' * int(ratings_average))
-    $if (stats_decimal >= 0.5) and (stats_decimal < 1):
-      $:('<span class="readers-stats__star--half reader-stats__star--byline">★</span>')
-    <span itemprop="ratingValue">$:_('%(ratings_avg)s (%(ratings_count)s %(ratings_label)s)', ratings_avg=ratings_average, ratings_count=ratings_count, ratings_label=ratings_label)</span>
-    <span class="dot">·</span>
-    <span itemprop="reviewCount">$_('%(want_to_read_count)s Want to read', want_to_read_count=want_to_read_count)</span>
+    $:macros.StarRatingsComponent(ratings_count, ratings_average, 'results_page')
 </span>
+$if want_to_read_count > 0 and ratings_count > 0:
+  <span class="dot">·</span>
+$if want_to_read_count > 0:
+  <span class="ratingsByline" itemprop="reviewCount">$_('%(want_to_read_count)s Want to read', want_to_read_count=formatted_want_to_read_count)</span>

--- a/openlibrary/macros/StarRatingsComponent.html
+++ b/openlibrary/macros/StarRatingsComponent.html
@@ -1,7 +1,7 @@
 $def with(ratings_count, ratings_average, page_type)
 
 $ rounded_avg = "%.1f" % ratings_average
-$ formatted_ratings_count = "{:,}".format(ratings_count)
+$ formatted_ratings_count = "{:,}".format(ratings_count) if ratings_count else ""
 $ ratings_label = _('rating') if ratings_count == 1 else _('ratings')
 $ star_class = 'readers-stats__star' if page_type == 'book_page' else 'readers-stats__star--byline'
 $ half_star_class = 'readers-stats__star--half' if page_type == 'book_page' else 'readers-stats__star--byline-half'

--- a/openlibrary/macros/StarRatingsComponent.html
+++ b/openlibrary/macros/StarRatingsComponent.html
@@ -3,12 +3,11 @@ $def with(ratings_count, ratings_average, page_type)
 $ rounded_avg = "%.1f" % ratings_average
 $ formatted_ratings_count = "{:,}".format(ratings_count) if ratings_count else ""
 $ ratings_label = _('rating') if ratings_count == 1 else _('ratings')
-$ star_class = 'readers-stats__star' if page_type == 'book_page' else 'readers-stats__star--byline'
-$ half_star_class = 'readers-stats__star--half' if page_type == 'book_page' else 'readers-stats__star--byline-half'
+$ small = "star--small" if page_type != 'book_page' else ''
 
 $if ratings_average:
   $ stats_decimal = (float(ratings_average) - int(ratings_average))
-    $:('<span class="{}">★</span>'.format(star_class) * int(ratings_average))
+    $:('<span class="star {}">★</span>'.format(small) * int(ratings_average))
     $if (stats_decimal >= 0.5) and (stats_decimal < 1):
-      $:('<span class="{}">★</span>'.format(half_star_class))
+      <span class="star star--half $small">★</span>
     <span itemprop="ratingValue">$:_('%(ratings_avg)s (%(ratings_count)s %(ratings_label)s)', ratings_avg=rounded_avg, ratings_count=formatted_ratings_count, ratings_label=ratings_label)</span>

--- a/openlibrary/macros/StarRatingsComponent.html
+++ b/openlibrary/macros/StarRatingsComponent.html
@@ -1,0 +1,14 @@
+$def with(ratings_count, ratings_average, page_type)
+
+$ rounded_avg = "%.1f" % ratings_average
+$ formatted_ratings_count = "{:,}".format(ratings_count)
+$ ratings_label = _('rating') if ratings_count == 1 else _('ratings')
+$ star_class = 'readers-stats__star' if page_type == 'book_page' else 'readers-stats__star--byline'
+$ half_star_class = 'readers-stats__star--half' if page_type == 'book_page' else 'readers-stats__star--byline-half'
+
+$if ratings_average:
+  $ stats_decimal = (float(ratings_average) - int(ratings_average))
+    $:('<span class="{}">★</span>'.format(star_class) * int(ratings_average))
+    $if (stats_decimal >= 0.5) and (stats_decimal < 1):
+      $:('<span class="{}">★</span>'.format(half_star_class))
+    <span itemprop="ratingValue">$:_('%(ratings_avg)s (%(ratings_count)s %(ratings_label)s)', ratings_avg=rounded_avg, ratings_count=formatted_ratings_count, ratings_label=ratings_label)</span>

--- a/openlibrary/macros/StarRatingsStats.html
+++ b/openlibrary/macros/StarRatingsStats.html
@@ -4,11 +4,13 @@ $ rating_stats = work and work.get_rating_stats() or {}
 $ stats_by_bookshelf = work and work.get_num_users_by_bookshelf() or {}
 $ avg = rating_stats.get('avg_rating')
 $ ratings_count = rating_stats.get('num_ratings', 0)
-$ review_count_class = 'readers-stats__review-count--none' if ratings_count == 0 else ''
+$ want_to_read_count = "{:,}".format(stats_by_bookshelf.get('want-to-read', 0))
+$ currently_reading_count = "{:,}".format(stats_by_bookshelf.get('currently-reading', 0))
+$ already_read_count = "{:,}".format(stats_by_bookshelf.get('already-read', 0))
 $ id = '--mobile' if mobile else ''
 
 <ul class="readers-stats  $review_count_class" itemprop="aggregateRating" itemscope itemtype="https://schema.org/AggregateRating">
-  <li class="avg-ratings" onclick="location.href='#starRatingSection$id';" data-ol-link-track="StarRating|StatsComponentClick">
+  <li class="avg-ratings" onclick="location.href='#starRatingSection';" data-ol-link-track="StarRating|StatsComponentClick">
     $if avg:
       $ stats_decimal = (float(avg))-(int(avg))
       $:('<span class="readers-stats__star">★</span>' * int(avg))
@@ -17,11 +19,10 @@ $ id = '--mobile' if mobile else ''
       <span itemprop="ratingValue">$avg</span>
       <span class="dot">·</span>
   </li>
-
-  <li class="readers-stats__review-count">
-    <span itemprop="reviewCount">$ratings_count</span> $ungettext("Rating", "Ratings", ratings_count, count=ratings_count)
-  </li>
-  <li class="reading-log-stat"><span class="readers-stats__stat">$stats_by_bookshelf.get('want-to-read', 0)</span> <span class="readers-stats__label">$_("Want to read")</span></li>
-  <li class="reading-log-stat"><span class="readers-stats__stat">$stats_by_bookshelf.get('currently-reading', 0)</span> <span class="readers-stats__label">$_("Currently reading")</span></li>
-  <li class="reading-log-stat"><span class="readers-stats__stat">$stats_by_bookshelf.get('already-read', 0)</span> <span class="readers-stats__label">$_("Have read")</span></li>
+  $if want_to_read_count > 0:
+    <li class="reading-log-stat"><span class="readers-stats__stat">$want_to_read_count</span> <span class="readers-stats__label">$_("Want to read")</span></li>
+  $if currently_reading_count > 0:
+    <li class="reading-log-stat"><span class="readers-stats__stat">$currently_reading_count</span> <span class="readers-stats__label">$_("Currently reading")</span></li>
+  $if already_read_count > 0:
+    <li class="reading-log-stat"><span class="readers-stats__stat">$already_read_count</span> <span class="readers-stats__label">$_("Have read")</span></li>
 </ul>

--- a/openlibrary/macros/StarRatingsStats.html
+++ b/openlibrary/macros/StarRatingsStats.html
@@ -2,27 +2,24 @@ $def with(work, mobile=False)
 
 $ rating_stats = work and work.get_rating_stats() or {}
 $ stats_by_bookshelf = work and work.get_num_users_by_bookshelf() or {}
-$ avg = rating_stats.get('avg_rating')
-$ ratings_count = rating_stats.get('num_ratings', 0)
-$ want_to_read_count = "{:,}".format(stats_by_bookshelf.get('want-to-read', 0))
-$ currently_reading_count = "{:,}".format(stats_by_bookshelf.get('currently-reading', 0))
-$ already_read_count = "{:,}".format(stats_by_bookshelf.get('already-read', 0))
+$ ratings_average = rating_stats.get('avg_rating', None)
+$ ratings_count = rating_stats.get('num_ratings', None)
+$ want_to_read_count = "{:,}".format(stats_by_bookshelf.get('want-to-read', None))
+$ currently_reading_count = "{:,}".format(stats_by_bookshelf.get('currently-reading', None))
+$ already_read_count = "{:,}".format(stats_by_bookshelf.get('already-read', None))
+$ review_count_class = 'readers-stats__review-count--none' if ratings_count == None else ''
 $ id = '--mobile' if mobile else ''
 
 <ul class="readers-stats  $review_count_class" itemprop="aggregateRating" itemscope itemtype="https://schema.org/AggregateRating">
   <li class="avg-ratings" onclick="location.href='#starRatingSection';" data-ol-link-track="StarRating|StatsComponentClick">
-    $if avg:
-      $ stats_decimal = (float(avg))-(int(avg))
-      $:('<span class="readers-stats__star">★</span>' * int(avg))
-      $if (stats_decimal >= 0.5) and (stats_decimal < 1):
-        $:('<span class="readers-stats__star--half">★</span>')
-      <span itemprop="ratingValue">$avg</span>
+    $if ratings_count:
+      $:macros.StarRatingsComponent(ratings_count, ratings_average, 'results_page')
       <span class="dot">·</span>
   </li>
-  $if want_to_read_count > 0:
+  $if want_to_read_count:
     <li class="reading-log-stat"><span class="readers-stats__stat">$want_to_read_count</span> <span class="readers-stats__label">$_("Want to read")</span></li>
-  $if currently_reading_count > 0:
+  $if currently_reading_count:
     <li class="reading-log-stat"><span class="readers-stats__stat">$currently_reading_count</span> <span class="readers-stats__label">$_("Currently reading")</span></li>
-  $if already_read_count > 0:
+  $if already_read_count:
     <li class="reading-log-stat"><span class="readers-stats__stat">$already_read_count</span> <span class="readers-stats__label">$_("Have read")</span></li>
 </ul>

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -326,8 +326,14 @@ def do_search(
     :param sort: csv sort ordering
     :param spellcheck_count: Not really used; should probably drop
     """
-      # If you want work_search page html to extend default_fetched_fields:
-    extra_fields = {'editions', 'providers', 'ratings_average', 'ratings_count', 'want_to_read_count'}
+    # If you want work_search page html to extend default_fetched_fields:
+    extra_fields = {
+        'editions',
+        'providers',
+        'ratings_average',
+        'ratings_count',
+        'want_to_read_count',
+    }
     fields = WorkSearchScheme.default_fetched_fields | extra_fields
 
     if web.cookies(sfw="").sfw == 'yes':
@@ -399,7 +405,7 @@ def get_doc(doc: SolrDocument):
         ],
         ratings_average=doc.get('ratings_average', None),
         ratings_count=doc.get('ratings_count', None),
-        want_to_read_count=doc.get('want_to_read_count', None)
+        want_to_read_count=doc.get('want_to_read_count', None),
     )
 
 
@@ -520,7 +526,7 @@ class search(delegate.page):
             'place',
             'person',
             'time',
-            'editions.sort'
+            'editions.sort',
         } | WorkSearchScheme.facet_fields:
             if web_input.get(p):
                 param[p] = web_input[p]

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -326,8 +326,10 @@ def do_search(
     :param sort: csv sort ordering
     :param spellcheck_count: Not really used; should probably drop
     """
+      # If you want work_search page html to extend default_fetched_fields:
+    extra_fields = {'editions', 'providers', 'ratings_average', 'ratings_count', 'want_to_read_count'}
+    fields = WorkSearchScheme.default_fetched_fields | extra_fields
 
-    fields = WorkSearchScheme.default_fetched_fields | {'editions', 'providers'}
     if web.cookies(sfw="").sfw == 'yes':
         fields |= {'subject'}
 
@@ -395,6 +397,9 @@ def get_doc(doc: SolrDocument):
             )
             for ed in doc.get('editions', {}).get('docs', [])
         ],
+        ratings_average=doc.get('ratings_average', None),
+        ratings_count=doc.get('ratings_count', None),
+        want_to_read_count=doc.get('want_to_read_count', None)
     )
 
 
@@ -515,7 +520,7 @@ class search(delegate.page):
             'place',
             'person',
             'time',
-            'editions.sort',
+            'editions.sort'
         } | WorkSearchScheme.facet_fields:
             if web_input.get(p):
                 param[p] = web_input[p]

--- a/openlibrary/plugins/worksearch/tests/test_worksearch.py
+++ b/openlibrary/plugins/worksearch/tests/test_worksearch.py
@@ -27,6 +27,9 @@ def test_get_doc():
             'lending_edition_s': 'OL1111795M',
             'public_scan_b': False,
             'title': 'The computer glossary',
+            'ratings_average': None,
+            'ratings_count': None,
+            'want_to_read_count': None,
         }
     )
     assert doc == web.storage(
@@ -64,5 +67,8 @@ def test_get_doc():
             'id_cita_press': [],
             'id_wikisource': [],
             'editions': [],
+            'ratings_average': None,
+            'ratings_count': None,
+            'want_to_read_count': None
         }
     )

--- a/openlibrary/plugins/worksearch/tests/test_worksearch.py
+++ b/openlibrary/plugins/worksearch/tests/test_worksearch.py
@@ -69,6 +69,6 @@ def test_get_doc():
             'editions': [],
             'ratings_average': None,
             'ratings_count': None,
-            'want_to_read_count': None
+            'want_to_read_count': None,
         }
     )

--- a/static/css/components/readerStats.less
+++ b/static/css/components/readerStats.less
@@ -28,8 +28,8 @@
     font-size: 1.5em;
   }
   &__star--half {
+    color: @gold;
     margin: 0 0 0 -5px;
-    font-size: 1.5em;
     background: linear-gradient(90deg, @gold 50%, @light-grey 50%);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;

--- a/static/css/components/readerStats.less
+++ b/static/css/components/readerStats.less
@@ -12,7 +12,7 @@
     display: inline-block;
     padding-bottom: 10px;
 
-    &:not(:first-child,:last-child):after {
+    &:not(:last-child):after {
       content: "·";
       margin: 0 4px;
     }
@@ -35,6 +35,11 @@
     -webkit-text-fill-color: transparent;
   }
   &__star--byline {
+    color: @gold;
+    font-size: 1em;
+  }
+  &__star--byline-half {
+    color: @gold;
     font-size: 1em;
   }
 }

--- a/static/css/components/readerStats.less
+++ b/static/css/components/readerStats.less
@@ -3,6 +3,21 @@
  * https://github.com/internetarchive/openlibrary/wiki/Design-Pattern-Library#readerstats
  */
 
+.star {
+  color: @gold;
+  font-size: 1.5em;
+  &__small {
+    font-size: 1em;
+  }
+  &--half {
+    color: @gold;
+    margin: 0 0 0 -5px;
+    background: linear-gradient(90deg, @gold 50%, @light-grey 50%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+}
+
 .readers-stats {
   color: @grey;
   font-size: @font-size-label-large;
@@ -12,7 +27,7 @@
     display: inline-block;
     padding-bottom: 10px;
 
-    &:not(:last-child):after {
+    &:not(:first-child,:last-child):after {
       content: "·";
       margin: 0 4px;
     }
@@ -21,25 +36,5 @@
     list-style-type: none;
     display: inline-block;
     margin: 0 4px;
-  }
-
-  &__star {
-    color: @gold;
-    font-size: 1.5em;
-  }
-  &__star--half {
-    color: @gold;
-    margin: 0 0 0 -5px;
-    background: linear-gradient(90deg, @gold 50%, @light-grey 50%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-  }
-  &__star--byline {
-    color: @gold;
-    font-size: 1em;
-  }
-  &__star--byline-half {
-    color: @gold;
-    font-size: 1em;
   }
 }

--- a/static/css/components/readerStats.less
+++ b/static/css/components/readerStats.less
@@ -27,11 +27,14 @@
     color: @gold;
     font-size: 1.5em;
   }
-  &__star--half{
+  &__star--half {
     margin: 0 0 0 -5px;
     font-size: 1.5em;
     background: linear-gradient(90deg, @gold 50%, @light-grey 50%);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
+  }
+  &__star--byline {
+    font-size: 1em;
   }
 }

--- a/static/css/components/search-result-item.less
+++ b/static/css/components/search-result-item.less
@@ -69,6 +69,9 @@
   .publishedYear {
     display: block;
   }
+  .publishedYear--ratings {
+    color: @black;
+  }
   .preview-covers {
     display: block;
     height: 45px;

--- a/static/css/components/search-result-item.less
+++ b/static/css/components/search-result-item.less
@@ -40,9 +40,10 @@
     margin: 0;
     padding: 0;
     color: @dark-grey;
-    font-size: 1.0em;
+    font-size: 1.1em;
     font-weight: 700;
-    font-family: @lucida_sans_serif-6;
+    font-family: @georgia_serif-1;
+    overflow: auto;
   }
   .details {
     overflow: auto;
@@ -51,13 +52,8 @@
     padding: 5px;
     margin: 0;
   }
-  .resultTitle {
-    overflow: auto;
-    margin: 0 !important;
-    font-family: @lucida_sans_serif-1;
-    color: @grey;
-  }
-  span.resultPublisher {
+
+  span.resultStats {
     font-size: .75em;
     color: @grey;
     font-family: @lucida_sans_serif-6;
@@ -66,16 +62,18 @@
   span.resultType {
     font-size: .6875em;
   }
-  .publishedYear {
+  .resultDetails {
     display: block;
   }
-  .publishedYear--ratings {
+  .ratingsByline {
     color: @black;
   }
   .preview-covers {
     display: block;
     height: 45px;
     overflow: hidden;
+    margin-top: 10px;
+    margin-bottom: 5px;
   }
   .preview-covers img {
     border-radius: 4px;

--- a/static/css/components/search-result-item.less
+++ b/static/css/components/search-result-item.less
@@ -53,7 +53,7 @@
     margin: 0;
   }
 
-  span.resultStats {
+  .resultStats {
     font-size: .75em;
     color: @grey;
     font-family: @lucida_sans_serif-6;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9463 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Pulls ratings_count, ratings_average and want_to_read_count fields from Solr. 
Creates a new macro that accesses these fields and displays ratings_count in star graphic and ratings_count and want_to_read_count in Search Results cards. 

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
When testing in my local environment, I manually updated the star ratings on the books page to trigger the StarRatingsByline macro to display. 

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="835" alt="Screenshot 2024-08-22 at 3 02 10 PM" src="https://github.com/user-attachments/assets/79878d5e-becb-44f9-acb4-bfb880d0cb85">

### Questions
I created a conditional that requires a minimum of 1 ratings_count and 1 want_to_read_count in order for the StarRatingsByline to display. Should I split up the conditional so that star ratings will display, even if there is no want_to_read_count ? 

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
