### PR TITLE
Read Work identifiers from file

### DIFF
--- a/openlibrary/plugins/openlibrary/config/work/identifiers.yml
+++ b/openlibrary/plugins/openlibrary/config/work/identifiers.yml
@@ -1,0 +1,22 @@
+identifiers:
+-   label: BookBrainz
+    name: bookbrainz
+    url: https://bookbrainz.org/work/@@@
+    website: https://bookbrainz.org
+-   label: Книга Файнфиков
+    name: ficbook
+    notes: ''
+    url: https://ficbook.net/readfic/@@@
+-   label: MusicBrainz
+    name: musicbrainz
+    url: https://musicbrainz.org/work/@@@
+    website: https://musicbrainz.org
+-   label: MyAnimeList
+    name: myanimelist
+    notes: ''
+    url: https://myanimelist.net/manga/@@@
+-   label: Wikidata
+    name: wikidata
+    notes: ''
+    url: https://www.wikidata.org/wiki/@@@
+    website: https://wikidata.org

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -1264,6 +1264,32 @@ def _get_edition_config():
     )
 
 
+@public
+def get_work_config() -> Storage:
+    """Returns the work config.
+
+    This just calls _get_work_config(). See that
+    function's documentation for further details.
+    """
+    return _get_work_config()
+
+
+@web.memoize
+def _get_work_config() -> Storage:
+    """Returns the work config.
+
+    The results are cached on the first invocation.
+    The /config/work page currently has no unique options so we
+    don't load/fetch it here currently.
+    """
+    with open('openlibrary/plugins/openlibrary/config/work/identifiers.yml') as in_file:
+        id_config = yaml.safe_load(in_file)
+        identifiers = [
+            Storage(id) for id in id_config.get('identifiers', []) if 'name' in id
+        ]
+    return Storage(identifiers=identifiers)
+
+
 from openlibrary.core.olmarkdown import OLMarkdown
 
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes https://github.com/internetarchive/openlibrary/issues/9234

feature/fix/refactor

### Technical

This is taking the same steps applied to editions[1] and authors[2] and applying it to works. `get_work_config()` is currently not used for anything, probably because we’re still waiting for an actual [interface to edit the Work identifiers](https://github.com/internetarchive/openlibrary/issues/3430), so this is more of a preliminary step to ensure that Works will be handled in the same way that Editions and Authors are. (And to allow for PRs to add Work identifiers while waiting for that UI, rather than limiting that to OL admins.)

[1] https://github.com/internetarchive/openlibrary/issues/9234
    https://github.com/internetarchive/openlibrary/pull/9483
[2] https://github.com/internetarchive/openlibrary/issues/9666
    https://github.com/internetarchive/openlibrary/pull/9769

([I asked 3 weeks ago](https://github.com/internetarchive/openlibrary/issues/9234#issuecomment-2269721158) whether a PR for this would be welcome or not, and never got a response, so now I just made the PR.)

### Testing

Only the `pre-commit` hooks were done. The `mypy` hook failed, but Idk if it’s a local issue that `/infogami` isn’t found or not.

```
mypy.....................................................................Failed
- hook id: mypy
- duration: 0.37s
- exit code: 2

mypy: can't read file '[…]/openlibrary/infogami': No such file or directory
```

### Stakeholders

@jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->