### PR TITLE
redirecting twitter and github logos to new tabs

### DIFF
--- a/openlibrary/templates/lib/nav_foot.html
+++ b/openlibrary/templates/lib/nav_foot.html
@@ -46,8 +46,8 @@ $def with (page)
           <li><a href="https://github.com/internetarchive/openlibrary/releases" title="$_('Release Notes')">$_("Release Notes")</a></li>
         </ul>
         <aside>
-          <a class="footer-icon" title="$_('Twitter')" href="https://twitter.com/OpenLibrary"><img src="/static/images/tweet.svg" alt="" loading="lazy"></a>
-          <a class="footer-icon" title="$_('GitHub')" href="https://github.com/internetarchive/openlibrary"><img src="/static/images/github.svg" alt="" loading="lazy"></a>
+          <a class="footer-icon" title="$_('Twitter')" href="https://twitter.com/OpenLibrary" target="_blank"><img src="/static/images/tweet.svg" alt="" loading="lazy"></a>
+          <a class="footer-icon" title="$_('GitHub')" href="https://github.com/internetarchive/openlibrary" target="_blank"><img src="/static/images/github.svg" alt="" loading="lazy"></a>
         </aside>
       </div>
       <div>


### PR DESCRIPTION
closes #9799 

### Description:
This PR addresses the issue where Twitter and Github links in the footer were opening in the same tab instead of a new one. It adds the target="_blank"  attribute to these links to ensure they open in new tabs, consistent with the behavior of the Mastodon link.

### Changes made:
Added target="_blank" to Twitter and Github footer links

#### Before: Twitter and Github links opened in the same tab
#### After: All social media links in the footer now open in new tabs
 
### Testing:
Navigate to any page with the footer visible
Click on each social media icon (Twitter, Github)
Verify that each link opens in a new tab