### PR TITLE
Pass in mobile parameter to conditionally render star ratings form

### DIFF
--- a/openlibrary/macros/StarRatings.html
+++ b/openlibrary/macros/StarRatings.html
@@ -6,7 +6,7 @@ $if rating is None and work and username:
 $ edition_key = edition.key if edition else ""
 $ form_id = "ratingsForm%s" % id
 
-<form class="star-rating-form" id="$form_id" method="POST" action="$(work.key)/ratings.json"
+<form class="star-rating-form $('mobile' if id == '--mobile' else 'desktop')" id="$form_id" method="POST" action="$(work.key)/ratings.json"
       property="reviewRating" typeof="Rating" vocab="http://schema.org/" data-work-key="$work.key">
   <meta property="worstRating" content="1"/>
   <meta property="bestRating" content="5"/>

--- a/openlibrary/macros/StarRatings.html
+++ b/openlibrary/macros/StarRatings.html
@@ -17,7 +17,7 @@ $ form_id = "ratingsForm%s" % id
     $if safeint(page) > 1:
       <input type="hidden" value="$page" name="page"/>
     <input type="hidden" value="$redir_url" name="redir_url"/>
-  <div class="review" id="starRatingSection">
+  <div class="review" id="starRatingSection$id">
     <div class="stars" data-ol-link-track="StarRating|BookRated">
       $ NUM_STARS = 5
       $for star in range(1, NUM_STARS + 1)

--- a/openlibrary/macros/StarRatingsStats.html
+++ b/openlibrary/macros/StarRatingsStats.html
@@ -1,13 +1,14 @@
-$def with(work)
+$def with(work, mobile=False)
 
 $ rating_stats = work and work.get_rating_stats() or {}
 $ stats_by_bookshelf = work and work.get_num_users_by_bookshelf() or {}
 $ avg = rating_stats.get('avg_rating')
 $ ratings_count = rating_stats.get('num_ratings', 0)
 $ review_count_class = 'readers-stats__review-count--none' if ratings_count == 0 else ''
+$ id = '--mobile' if mobile else ''
 
 <ul class="readers-stats  $review_count_class" itemprop="aggregateRating" itemscope itemtype="https://schema.org/AggregateRating">
-  <li class="avg-ratings" onclick="location.href='#starRatingSection';" data-ol-link-track="StarRating|StatsComponentClick">
+  <li class="avg-ratings" onclick="location.href='#starRatingSection$id';" data-ol-link-track="StarRating|StatsComponentClick">
     $if avg:
       $ stats_decimal = (float(avg))-(int(avg))
       $:('<span class="readers-stats__star">★</span>' * int(avg))

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -47,12 +47,12 @@ $ viewbook = "//%s/stream/XXX?ref=ol" % bookreader_host()
         $ render_times['databarWork: Modal Links - Desktop'] = time() - render_times['databarWork: Modal Links - Desktop']
 
         <div class="readers-stats__wrapper mobile">
-          $ star_ratings_stats = macros.StarRatingsStats(work)
+          $ star_ratings_stats = macros.StarRatingsStats(work, mobile=True)
           $:star_ratings_stats
 
           <hr>
           $ render_times['databarWork: Modal Links - Mobile'] = time()
-          $:render_template("type/edition/modal_links", work, edition, share_url)
+          $:render_template("type/edition/modal_links", work, edition, share_url, mobile=True)
           $ render_times['databarWork: Modal Links - Mobile'] = time() - render_times['databarWork: Modal Links - Mobile']
         </div>
 

--- a/openlibrary/templates/type/edition/modal_links.html
+++ b/openlibrary/templates/type/edition/modal_links.html
@@ -13,7 +13,7 @@ $def icon_link(link_class, img_src, link_text, login_redirect=True, ga_data=None
     <div class="icon-link__text">$link_text</div>
   </a>
 
-<div class="modal-links">
+<div class="modal-links $('mobile' if mobile else 'desktop')">
   $if work and work.get('key', ''):
     $ review_content = icon_link("observations-modal-link", "/static/images/icons/reviews.svg", _("Review"), ga_data="ModalLinkClick|ReviewIcon")
     $:macros.ObservationsModal(work, review_content, 'sidebar-review')

--- a/openlibrary/templates/type/edition/modal_links.html
+++ b/openlibrary/templates/type/edition/modal_links.html
@@ -1,4 +1,4 @@
-$def with (work, edition, page_url)
+$def with (work, edition, page_url, mobile=False)
 
 $def icon_link(link_class, img_src, link_text, login_redirect=True, ga_data=None):
   $ href = 'javascript:;'
@@ -18,7 +18,8 @@ $def icon_link(link_class, img_src, link_text, login_redirect=True, ga_data=None
     $ review_content = icon_link("observations-modal-link", "/static/images/icons/reviews.svg", _("Review"), ga_data="ModalLinkClick|ReviewIcon")
     $:macros.ObservationsModal(work, review_content, 'sidebar-review')
 
-    $:macros.StarRatings(work, edition)
+    $if mobile:
+      $:macros.StarRatings(work, edition, id="--mobile")
 
     $ notes_content = icon_link("notes-modal-link", "/static/images/icons/notes.svg", _("Notes"), ga_data="ModalLinkClick|NoteIcon")
     $:macros.NotesModal(work, edition, notes_content, 'sidebar-notes')

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -171,6 +171,7 @@ $if is_privileged_user:
 
 $ component_times['ReadlogStats'] = time()
 $ star_ratings_stats = macros.StarRatingsStats(work)
+$ star_ratings_stats_mobile = macros.StarRatingsStats(work, mobile=True)
 $ component_times['ReadlogStats'] = time() - component_times['ReadlogStats']
 
 $ component_times['get_observation_metrics'] = time()
@@ -205,7 +206,7 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
     <!-- (mobile only) -->
     $:macros.EditionNavBar(reader_observations, work.edition_count, show_observations)
     <a id="overview-mobile" name="overview-mobile" class="section-anchor section-anchor--no-height"></a>
-    $:render_template("type/edition/title_and_author", page, work, edition, ocaid, work_title, star_ratings_stats, for_desktop=False)
+    $:render_template("type/edition/title_and_author", page, work, edition, ocaid, work_title, star_ratings_stats_mobile, for_desktop=False)
     <div class="editionCover">
       $:macros.databarWork(edition or work, worldcat_links, affiliate_links, editions_page=True, render_times=component_times)
     </div>

--- a/static/css/components/read-panel.less
+++ b/static/css/components/read-panel.less
@@ -166,8 +166,6 @@
   /* stylelint-disable selector-max-specificity */
   .mobile-vendor,
   .cta-button-group.mobile,
-  #read-options > .modal-links > .star-rating-form,
-  .lists-widget-container > #ratingsForm > .star-rating__not-rated,
   .readers-stats__wrapper.mobile {
     display: none;
   }
@@ -192,16 +190,16 @@
   .Tools .btn-notice,
   .read-options {
     border: none;
-    // Hide desktop version of modal links and ratings form on mobile
-    /* stylelint-disable selector-max-specificity */
+    // Hide border for desktop version of modal links and ratings form on mobile
     /* stylelint-disable no-descending-specificity */
-    &> hr,
-    &> .lists-widget-container > #ratingsForm,
-    &> .modal-links {
+    &> hr {
       display: none;
     }
     /* stylelint-enable no-descending-specificity */
-    /* stylelint-enable selector-max-specificity */
+  }
+
+  .star-rating-form.desktop, .modal-links.desktop {
+    display: none;
   }
 
   .cta-button-group.mobile {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9632.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix. Prevents the star ratings form (with corresponding id's) from being repeated 3x in the work page, which was a problem for accessibility and code organization/simplicity.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Go the page for any book, ideally one that already has at least one star rating
2. Expand to desktop view and inspect the page, confirming that the IDs `starRatingSection` and `ratingsForm` each only appear once
3. Confirm that clicking on the book's star ratings takes you to the star ratings form
4. Adjust the page width until it switches to mobile view, confirming that the IDs `starRatingSection--mobile` and `ratingsForm--mobile` each appear just once on the page
5. Confirm that clicking on the book's star ratings takes you to the star ratings form

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
