### PR TITLE
Cache all query carousels

### DIFF
--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -186,9 +186,8 @@ class memcache_memoize:
         a = self.json_encode(list(args))[1:-1]
 
         if kw:
-            return f"{hashlib.md5(a.encode('utf-8')).hexdigest()}${hashlib.md5(self.json_encode(kw).encode('utf-8')).hexdigest()}"
-        else:
-            return f"{hashlib.md5(a.encode('utf-8')).hexdigest()}"
+            a += self.json_encode(kw)
+        return f"{hashlib.md5(a.encode('utf-8')).hexdigest()}"
 
     def compute_key(self, args, kw):
         """Computes memcache key for storing result of function call with given arguments."""

--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -177,20 +177,21 @@ class memcache_memoize:
             thread.join()
 
     def encode_args(self, args, kw=None):
-        kw = kw or {}
         """Encodes arguments to construct the memcache key.
         """
+        kw = kw or {}
+
         # strip [ and ] from key
         a = self.json_encode(list(args))[1:-1]
 
         if kw:
-            return a + "-" + self.json_encode(kw)
+            return f"{hash(a)}${hash(self.json_encode(kw))}"
         else:
-            return a
+            return f"{hash(a)}"
 
     def compute_key(self, args, kw):
         """Computes memcache key for storing result of function call with given arguments."""
-        key = self.key_prefix + "-" + self.encode_args(args, kw)
+        key = self.key_prefix + "$" + self.encode_args(args, kw)
         return key.replace(
             " ", "_"
         )  # XXX: temporary fix to handle spaces in the arguments

--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -1,6 +1,7 @@
 """Caching utilities.
 """
 
+import hashlib
 import random
 import string
 import time
@@ -185,9 +186,9 @@ class memcache_memoize:
         a = self.json_encode(list(args))[1:-1]
 
         if kw:
-            return f"{hash(a)}${hash(self.json_encode(kw))}"
+            return f"{hashlib.md5(a.encode('utf-8')).hexdigest()}${hashlib.md5(self.json_encode(kw).encode('utf-8')).hexdigest()}"
         else:
-            return f"{hash(a)}"
+            return f"{hashlib.md5(a.encode('utf-8')).hexdigest()}"
 
     def compute_key(self, args, kw):
         """Computes memcache key for storing result of function call with given arguments."""

--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -178,8 +178,7 @@ class memcache_memoize:
             thread.join()
 
     def encode_args(self, args, kw=None):
-        """Encodes arguments to construct the memcache key.
-        """
+        """Encodes arguments to construct the memcache key."""
         kw = kw or {}
 
         # strip [ and ] from key

--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -60,7 +60,7 @@ class memcache_memoize:
         key_prefix: str | None = None,
         timeout: int = MINUTE_SECS,
         prethread: Callable | None = None,
-        hash_args: boolean = False,
+        hash_args: bool = False,
     ):
         """Creates a new memoized function for ``f``."""
         self.f = f

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -7467,7 +7467,7 @@ msgstr ""
 msgid "This graph charts editions published on this subject."
 msgstr ""
 
-#: QueryCarousel.html
+#: RawQueryCarousel.html
 msgid "Search collection"
 msgstr ""
 

--- a/openlibrary/macros/QueryCarousel.html
+++ b/openlibrary/macros/QueryCarousel.html
@@ -1,4 +1,4 @@
-$def with(query, title=None, sort='new', key='', limit=20, search=False, has_fulltext_only=True, url=None, layout='carousel')
+$def with(query, title=None, sort='new', key='', limit=20, search=False, has_fulltext_only=True, url=None, layout='carousel', use_cache=True)
 
 $# Takes following parameters
 $# * query (str) -- Any arbitrary Open Library search query, e.g. subject:"Textbooks"
@@ -9,4 +9,7 @@ $# * limit (int) -- initial number of books to pull
 $# * search (bool) -- whether to include search within collection
 $# * layout (str) -- layout type, default 'carousel', currently also supports 'grid'
 
-$:macros.CacheableMacro("RawQueryCarousel", query, title=title, sort=sort, key=key, limit=limit, search=search, has_fulltext_only=has_fulltext_only, url=url, layout=layout)
+$if use_cache:
+    $:macros.CacheableMacro("RawQueryCarousel", query, title=title, sort=sort, key=key, limit=limit, search=search, has_fulltext_only=has_fulltext_only, url=url, layout=layout)
+$else:
+    $:macros.RawQueryCarousel(query, title=title, sort=sort, key=key, limit=limit, search=search, has_fulltext_only=has_fulltext_only, url=url, layout=layout)

--- a/openlibrary/macros/QueryCarousel.html
+++ b/openlibrary/macros/QueryCarousel.html
@@ -9,26 +9,4 @@ $# * limit (int) -- initial number of books to pull
 $# * search (bool) -- whether to include search within collection
 $# * layout (str) -- layout type, default 'carousel', currently also supports 'grid'
 
-$# Enable search within this query
-$if search:
-  <form action="/search" class="olform pagesearchbox">
-    <input type="hidden" name="q" value="$query"/>
-    $if has_fulltext_only:
-      <input type="hidden" name="has_fulltext" value="true"/>
-    <input type="text" placeholder="$_('Search collection')" name="q2"/>
-    <input type="submit"/>
-  </form>
-
-$code:
-  # Limit to just fields needed to render carousels
-  params = { 'q': query, 'fields': 'key,title,subtitle,author_name,cover_i,ia,availability,id_project_gutenberg,id_librivox,id_standard_ebooks,id_openstax' }
-  # Don't need fields in the search UI url, since they don't do anything there
-  url = url or "/search?" + urlencode({'q': query})
-  if has_fulltext_only:
-    params['has_fulltext'] = 'true'
-
-  results = work_search(params, sort=sort, limit=limit, facet=False)
-  books = [storage(b) for b in (results.get('docs', []))]
-  load_more = {"url": "/search.json?" + urlencode(params), "limit": limit }
-
-$:render_template("books/custom_carousel", books=books, title=title, url=url, key=key, load_more=load_more, layout=layout)
+$:macros.CacheableMacro("RawQueryCarousel", query, title=title, sort=sort, key=key, limit=limit, search=search, has_fulltext_only=has_fulltext_only, url=url, layout=layout)

--- a/openlibrary/macros/RawQueryCarousel.html
+++ b/openlibrary/macros/RawQueryCarousel.html
@@ -1,0 +1,34 @@
+$def with(query, title=None, sort='new', key='', limit=20, search=False, has_fulltext_only=True, url=None, layout='carousel')
+
+$# Takes following parameters
+$# * query (str) -- Any arbitrary Open Library search query, e.g. subject:"Textbooks"
+$# * title (str) -- A title to show above the carousel (links to /search?q=query)
+$# * sort (str) -- optional sort param defined within work_search.py `work_search`
+$# * key (str) -- unique name of the carousel in analytics
+$# * limit (int) -- initial number of books to pull
+$# * search (bool) -- whether to include search within collection
+$# * layout (str) -- layout type, default 'carousel', currently also supports 'grid'
+
+$# Enable search within this query
+$if search:
+  <form action="/search" class="olform pagesearchbox">
+    <input type="hidden" name="q" value="$query"/>
+    $if has_fulltext_only:
+      <input type="hidden" name="has_fulltext" value="true"/>
+    <input type="text" placeholder="$_('Search collection')" name="q2"/>
+    <input type="submit"/>
+  </form>
+
+$code:
+  # Limit to just fields needed to render carousels
+  params = { 'q': query, 'fields': 'key,title,subtitle,author_name,cover_i,ia,availability,id_project_gutenberg,id_librivox,id_standard_ebooks,id_openstax' }
+  # Don't need fields in the search UI url, since they don't do anything there
+  url = url or "/search?" + urlencode({'q': query})
+  if has_fulltext_only:
+    params['has_fulltext'] = 'true'
+
+  results = work_search(params, sort=sort, limit=limit, facet=False)
+  books = [storage(b) for b in (results.get('docs', []))]
+  load_more = {"url": "/search.json?" + urlencode(params), "limit": limit }
+
+$:render_template("books/custom_carousel", books=books, title=title, url=url, key=key, load_more=load_more, layout=layout)

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -232,7 +232,10 @@ def render_cached_macro(name: str, args: tuple, **kwargs):
     five_minutes = 5 * 60
     key_prefix = get_key_prefix()
     mc = cache.memcache_memoize(
-        render_macro, key_prefix=key_prefix, timeout=five_minutes, prethread=caching_prethread()
+        render_macro,
+        key_prefix=key_prefix,
+        timeout=five_minutes,
+        prethread=caching_prethread(),
     )
 
     try:

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -220,22 +220,19 @@ def render_macro(name, args, **kwargs):
 def render_cached_macro(name, args: tuple, **kwargs):
     from openlibrary.plugins.openlibrary.home import caching_prethread
 
-    def get_key():
+    def get_key_prefix():
         lang = web.ctx.lang
-        pd = web.cookies().get('pd', False)
-        key = f'{name}.{lang}'
-        if pd:
-            key += '.pd'
-        for arg in args:
-            key += f'.{arg}'
-        for k, v in kwargs.items():
-            key += f'.{k}:{v}'
-        return key
+        key_prefix = f'macro.{lang}'
+        if web.cookies().get('pd', False):
+            key_prefix += '.pd'
+        if web.cookies().get('sfw', ''):
+            key_prefix += '.sfw'
+        return key_prefix
 
     five_minutes = 5 * 60
-    key = get_key()
+    key_prefix = get_key_prefix()
     mc = cache.memcache_memoize(
-        render_macro, key, timeout=five_minutes, prethread=caching_prethread()
+        render_macro, key_prefix=key_prefix, timeout=five_minutes, prethread=caching_prethread()
     )
 
     try:

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -236,6 +236,7 @@ def render_cached_macro(name: str, args: tuple, **kwargs):
         key_prefix=key_prefix,
         timeout=five_minutes,
         prethread=caching_prethread(),
+        hash_args=True,  # this avoids cache key length overflow
     )
 
     try:

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -217,12 +217,12 @@ def render_macro(name, args, **kwargs):
 
 
 @public
-def render_cached_macro(name, args: tuple, **kwargs):
+def render_cached_macro(name: str, args: tuple, **kwargs):
     from openlibrary.plugins.openlibrary.home import caching_prethread
 
     def get_key_prefix():
         lang = web.ctx.lang
-        key_prefix = f'macro.{lang}'
+        key_prefix = f'{name}.{lang}'
         if web.cookies().get('pd', False):
             key_prefix += '.pd'
         if web.cookies().get('sfw', ''):

--- a/openlibrary/templates/books/RelatedWorksCarousel.html
+++ b/openlibrary/templates/books/RelatedWorksCarousel.html
@@ -12,12 +12,12 @@ $if work and not is_bot():
             $ )
             $if author_keys:
                 $ query += ' -author_key:(%s)' % ' OR '.join(['%s' % a for a in author_keys])
-            $:macros.QueryCarousel(query=query, title=_("You might also like"), key="related-subjects-carousel", limit=12)
+            $:macros.QueryCarousel(query=query, title=_("You might also like"), key="related-subjects-carousel", limit=12, use_cache=False)
         $if author_keys:
             $ query = 'ebook_access:[borrowable TO *] -key:"%s" author_key:(%s)' % (
             $    work.key,
             $    ' OR '.join(['%s' % a for a in author_keys]),
             $ )
             $ title = ungettext("More by this author", "More by these authors", len(author_keys))
-            $:macros.QueryCarousel(query=query, title=title, key="related-authors-carousel", limit=12)
+            $:macros.QueryCarousel(query=query, title=title, key="related-authors-carousel", limit=12, use_cache=False)
     </div>

--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -22,7 +22,7 @@ $add_metatag(name="twitter:card", content="homepage_summary")
   $if not test:
     $:render_template("books/custom_carousel", key="trending", books=get_trending_books(books_only=True, since_days=0, since_hours=24, minimum=3, sort_by_count=False), title=_('Trending Books'), url="/trending/daily", test=test, load_more={"url": "/trending/hours.json?hours=24&minimum=3&sort_by_count=false", "mode": "page", "limit": 18})
 
-    $:macros.QueryCarousel(query="ddc:8* first_publish_year:[* TO 1950] publish_year:[2000 TO *] NOT public_scan_b:false", title=_('Classic Books'), key="public_domain", url="/read", sort='random.hourly')
+    $:macros.QueryCarousel(query="ddc:8* first_publish_year:[* TO 1950] publish_year:[2000 TO *] NOT public_scan_b:false", title=_('Classic Books'), key="public_domain", url="/read", sort='random.hourly', use_cache=False)
 
   $:render_template("home/custom_ia_carousel", title=_('Books We Love'), key="staff_picks", query='languageSorter:("English")', subject="openlibrary_staff_picks", sorts=["lending___last_browse desc"], limit=18, test=test)
 

--- a/openlibrary/tests/core/test_cache.py
+++ b/openlibrary/tests/core/test_cache.py
@@ -5,16 +5,6 @@ from openlibrary.mocks import mock_memcache
 
 
 class Test_memcache_memoize:
-    def test_encode_args(self):
-        m = cache.memcache_memoize(None, key_prefix="foo")
-
-        assert m.encode_args([]) == ''
-        assert m.encode_args(["a"]) == '"a"'
-        assert m.encode_args([1]) == '1'
-        assert m.encode_args(["a", 1]) == '"a",1'
-        assert m.encode_args([{"a": 1}]) == '{"a":1}'
-        assert m.encode_args([["a", 1]]) == '["a",1]'
-
     def test_generate_key_prefix(self):
         def foo():
             pass

--- a/openlibrary/tests/core/test_cache.py
+++ b/openlibrary/tests/core/test_cache.py
@@ -5,6 +5,16 @@ from openlibrary.mocks import mock_memcache
 
 
 class Test_memcache_memoize:
+    def test_encode_args(self):
+        m = cache.memcache_memoize(None, key_prefix="foo")
+
+        assert m.encode_args([]) == ''
+        assert m.encode_args(["a"]) == '"a"'
+        assert m.encode_args([1]) == '1'
+        assert m.encode_args(["a", 1]) == '"a",1'
+        assert m.encode_args([{"a": 1}]) == '{"a":1}'
+        assert m.encode_args([["a", 1]]) == '["a",1]'
+
     def test_generate_key_prefix(self):
         def foo():
             pass


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9058

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This branch does the following:
1. Updates the `QueryCarousel` macro template to, by default, request a cached copy of the carousel's markup
2. Updates the function that generates cache keys such that the cached function's `args` and `kwargs` are hashed
3. Adds a `use_cache` keyword argument to the `QueryCarousel` macro, which allows us to avoid caching select query carousel
4. Updated the book page's "Related Works" carousel and the home page's "Classic Books" carousel to __not__ be cached
5. Updates cache key prefix to include the macro name when macros are cached

### Technical
<!-- What should be noted about the implementation? -->
The "Classic Books" carousel is not cached, as it appears on our cached homepage.  Also, both the homepage and our macros are cached for the same amount of time (five minutes).

The "Related Works" carousel is always fetched asynchronously, and therefore not cached.

#### Cache key protocol
Cache keys will now be in the following `$` delimited form:

```
{key_prefix}${hashed_args}${hashed_kwargs)
```

If there are no `kwargs`, the key will not include the second `$` character and the hashed `kwargs`:
```
{key_prefix}${hashed_args}
```

##### Examples:
__Cache key containing hashed key word arguments:__
`RawQueryCarousel.en$4587276919764249206$-1969269941747307046`

__Cache key when no key word arguments are provided:__
`ia.get_metadata$6232568801773938868`

#### Unit test changes
The `test_encode_args` unit test has been removed.  I'm not sure how to best test the updated `encode_args`.  The tests that were removed asserted that `encode_args` returned a specific expected result.  Now that we are hashing the arguments, testing by string comparisons will fail if the hash algorithm is ever updated.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Once deployed, load some of our `/collections` pages.  Note how long the initial load for each page takes.  Then, refresh the pages.  Expect the load time to decrease noticeably.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
