### PR TITLE
Fix compact title scrolling issue

### DIFF
--- a/openlibrary/plugins/openlibrary/js/compact-title/index.js
+++ b/openlibrary/plugins/openlibrary/js/compact-title/index.js
@@ -6,12 +6,6 @@
 import { updateSelectedNavItem } from '../edition-nav-bar';
 
 /**
- * True if compact title component is visible on screen.
- * @type {boolean}
- */
-let isTitleVisible = false
-
-/**
  * Reference to the book page's main work title.
  * @type {HTMLElement}
  */
@@ -54,9 +48,8 @@ function onScroll(navbar, title) {
     const compactTitleBounds = title.getBoundingClientRect()
     const navbarBounds = navbar.getBoundingClientRect()
     const mainTitleBounds = mainTitleElem.getBoundingClientRect()
-
     if (mainTitleBounds.bottom < navbarBounds.bottom) {  // The main title is off-screen
-        if (!isTitleVisible && !navbar.classList.contains('sticky--lowest')) {  // Compact title not displayed
+        if (!navbar.classList.contains('sticky--lowest')) {  // Compact title not displayed
             // Display compact title
             title.classList.remove('hidden')
             // Animate navbar
@@ -64,7 +57,6 @@ function onScroll(navbar, title) {
                 .one('animationend', () => {
                     $(navbar).addClass('sticky--lowest')
                     $(navbar).removeClass('nav-bar-wrapper--slidedown')
-                    isTitleVisible = true
                     // Ensure correct nav item is selected after compact title slides in:
                     updateSelectedNavItem()
                 })
@@ -76,9 +68,8 @@ function onScroll(navbar, title) {
             }
         }
     } else {  // At least some of the main title is below the navbar
-        if (isTitleVisible) {
+        if (!title.classList.contains('hidden')) {
             title.classList.add('hidden')
-            isTitleVisible = false
             $(navbar).addClass('nav-bar-wrapper--slideup')
                 .one('animationend', () => {
                     $(navbar).removeClass('sticky--lowest')


### PR DESCRIPTION
Closes #9584

Fix

### Technical
<!-- What should be noted about the implementation? -->
Removes ```isTitleVisible``` boolean in favor of directly checking if the compact element does not contain the ```.hidden``` class for more reliable behavior.

### Testing
Manually replicated erratic scrolling behavior as seen in #9584 

### Stakeholders
@RayBB


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
