### PR TITLE
Add Library of Congress NAF as Author identifier

### DIFF
--- a/openlibrary/components/AuthorIdentifiers.vue
+++ b/openlibrary/components/AuthorIdentifiers.vue
@@ -32,6 +32,7 @@
 const identifierPatterns  = {
     wikidata: /^Q[1-9]\d*$/i,
     isni: /^[0]{4} ?[0-9]{4} ?[0-9]{4} ?[0-9]{3}[0-9X]$/i,
+    loc_naf: /^n[a-z]?[1-9][0-9]+$/,
     amazon: /^B[0-9A-Za-z]{9}$/,
     youtube: /^@[A-Za-z0-9_\-.]{3,30}/,
 }

--- a/openlibrary/components/AuthorIdentifiers.vue
+++ b/openlibrary/components/AuthorIdentifiers.vue
@@ -32,7 +32,7 @@
 const identifierPatterns  = {
     wikidata: /^Q[1-9]\d*$/i,
     isni: /^[0]{4} ?[0-9]{4} ?[0-9]{4} ?[0-9]{3}[0-9X]$/i,
-    loc_naf: /^n[a-z]?[1-9][0-9]+$/,
+    lc_naf: /^n[bors]?[0-9]+$/,
     amazon: /^B[0-9A-Za-z]{9}$/,
     youtube: /^@[A-Za-z0-9_\-.]{3,30}/,
 }

--- a/openlibrary/plugins/openlibrary/config/author/identifiers.yml
+++ b/openlibrary/plugins/openlibrary/config/author/identifiers.yml
@@ -22,6 +22,11 @@ identifiers:
     notes: two formats depending on if the author exists in wikidata, wd:Q42 or inv:914ad8068b8711ead0cc2efbed56e53c
     url: https://inventaire.io/entity/@@@
     website: https://inventaire.io/
+-   label: Library of Congress
+    name: loc_naf
+    notes: Should be something like nr92001540, no97027235, etc. (/^n[a-z]?[0-9]+$/)
+    url: https://id.loc.gov/authorities/names/@@@
+    website: https://id.loc.gov/authorities/names.html
 -   label: LibraryThing
     name: librarything
     notes: Should be something like kingstephen-1

--- a/openlibrary/plugins/openlibrary/config/author/identifiers.yml
+++ b/openlibrary/plugins/openlibrary/config/author/identifiers.yml
@@ -22,8 +22,8 @@ identifiers:
     notes: two formats depending on if the author exists in wikidata, wd:Q42 or inv:914ad8068b8711ead0cc2efbed56e53c
     url: https://inventaire.io/entity/@@@
     website: https://inventaire.io/
--   label: Library of Congress
-    name: loc_naf
+-   label: Library of Congress Names
+    name: lc_naf
     notes: Should be something like nr92001540, no97027235, etc. (/^n[a-z]?[0-9]+$/)
     url: https://id.loc.gov/authorities/names/@@@
     website: https://id.loc.gov/authorities/names.html


### PR DESCRIPTION
Closes https://github.com/internetarchive/openlibrary/issues/9791

feature

### Technical

Adds Library of Congress Name Authority File (LC NAF) as an Author identifier in `author/identifiers.yml`.

The `label` has been shortened to just “Library of Congress” to avoid having an obscenely long label in the drop-down lists and also avoid obscure acronyms (“NAF”) in it that are likely to cause more confusion than clarity.

The URI identifiers given by LoC themselves start with “http://” but I have opted to use “https://” for the `url` so patrons etc. won’t need a redirect or similar to get to the page.

**Update:** Also added an entry for autoselection of LoC when added the ID on the author editing page.

### Testing

1. Apply patch
2. Restart app
3. Check that “Library of Congress” appears in the Author identifier dropdown
4. Copy an identifier into the field (e.g., `no97027235`) and verify that the LoC entry gets selected
5. Check that an added `loc_naf` identifier gets shown on the Author page

### Stakeholders

@mekarpeles

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->