### PR TITLE
Disallow Open AI from scraping site data

### DIFF
--- a/static/coverstore-robots.txt
+++ b/static/coverstore-robots.txt
@@ -2,3 +2,5 @@
 User-Agent: *
 Crawl-delay: 5
 
+User-agent: GPTBot
+Disallow: /

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -12,3 +12,6 @@ Crawl-delay: 0.5
 
 User-agent: Googlebot
 Disallow: /*.rdf$
+
+User-agent: GPTBot
+Disallow: /


### PR DESCRIPTION
### Technical

Adds entries for `Disallow`ing Open AI `GPTBot` everywhere in relevant `robots.txt` files.

### Testing

I don’t know. :) I guess you could write a bot and claim to be `GPTBot` and see if it respects the policy?

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->

@cdrini maybe?

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
