### PR TITLE
Clearer message for merging works without correct permissions

### DIFF
--- a/openlibrary/components/MergeUI.vue
+++ b/openlibrary/components/MergeUI.vue
@@ -99,6 +99,10 @@ export default {
                         throw new Error(`Could not merge: ${unmergeable_works.join(', ')} has more than ${DEFAULT_EDITION_LIMIT} editions.`);
                     }
                     const r = await do_merge(master, dupes, editions_to_move, this.mrid);
+                    if (r.status === 403)
+                    {
+                        throw new Error('Merge failed, you may not have the correct permissions to perform a merge');
+                    }
                     this.mergeOutput = await r.json();
                     if (this.mrid) {
                         await update_merge_request(this.mrid, 'approve', this.comment)

--- a/openlibrary/components/MergeUI.vue
+++ b/openlibrary/components/MergeUI.vue
@@ -101,7 +101,7 @@ export default {
                     const r = await do_merge(master, dupes, editions_to_move, this.mrid);
                     if (r.status === 403)
                     {
-                        throw new Error('Merge failed, you may not have the correct permissions to perform a merge');
+                        throw new Error('Merge failed, your account may be missing the /usergroup/api permission.');
                     }
                     this.mergeOutput = await r.json();
                     if (this.mrid) {


### PR DESCRIPTION
Closes #9760

Fix

### Technical
Checks the status code of a works merge request and warns users that they may not have the correct permissions to do the merge. A 403 status code is returned by the function ```do_merge``` within ```components/MergeUI/utils.js``` if the user does not have the ```/usergroup/api``` assigned to their account.

### Testing
Create a user account with only super librarian permissions (see Project Breakdown for instructions), and attempt to merge works.

### Screenshot
![image](https://github.com/user-attachments/assets/b152d0c4-2c3a-4d2d-b5fc-b8a74ed5f6ce)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@scottbarnes 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
