### PR TITLE
DRY `Tag` form inputs

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -3266,8 +3266,8 @@ msgstr ""
 msgid "Use <b><i>Title: Subtitle</i></b> to add a subtitle."
 msgstr ""
 
-#: books/add.html books/edit.html tag/add.html type/author/edit.html
-#: type/tag/edit.html
+#: books/add.html books/edit.html type/author/edit.html
+#: type/tag/tag_form_inputs.html
 msgid "Required field"
 msgstr ""
 
@@ -3316,7 +3316,7 @@ msgstr ""
 msgid "ISBN may be invalid. Click \"Add\" again to submit."
 msgstr ""
 
-#: books/add.html tag/add.html type/tag/edit.html
+#: books/add.html type/tag/tag_form_inputs.html
 msgid "Select"
 msgstr ""
 
@@ -3690,7 +3690,7 @@ msgstr ""
 msgid "How would you describe this book?"
 msgstr ""
 
-#: books/edit/about.html tag/add.html
+#: books/edit/about.html
 msgid "There's no wrong answer here."
 msgstr ""
 
@@ -6353,18 +6353,6 @@ msgid "Add a tag to Open Library"
 msgstr ""
 
 #: tag/add.html
-msgid "Name of Tag"
-msgstr ""
-
-#: tag/add.html
-msgid "How would you describe this tag?"
-msgstr ""
-
-#: tag/add.html type/tag/edit.html
-msgid "Tag type"
-msgstr ""
-
-#: tag/add.html
 msgid "Add this tag now"
 msgstr ""
 
@@ -7001,12 +6989,16 @@ msgstr ""
 msgid "Edit Tag"
 msgstr ""
 
-#: type/tag/edit.html
-msgid "Label"
+#: type/tag/tag_form_inputs.html
+msgid "Tag Name"
 msgstr ""
 
-#: type/tag/edit.html type/user/edit.html
-msgid "Description"
+#: type/tag/tag_form_inputs.html
+msgid "Tag Description"
+msgstr ""
+
+#: type/tag/tag_form_inputs.html
+msgid "Tag type"
 msgstr ""
 
 #: type/tag/view.html
@@ -7057,6 +7049,10 @@ msgstr ""
 
 #: type/user/edit.html
 msgid "Display Name"
+msgstr ""
+
+#: type/user/edit.html
+msgid "Description"
 msgstr ""
 
 #: type/user/view.html

--- a/openlibrary/plugins/upstream/addtag.py
+++ b/openlibrary/plugins/upstream/addtag.py
@@ -50,7 +50,7 @@ class addtag(delegate.page):
 
     def POST(self):
         i = web.input(
-            tag_name="",
+            name="",
             tag_type="",
             tag_description="",
             tag_plugins="",
@@ -69,7 +69,7 @@ class addtag(delegate.page):
 
         i = utils.unflatten(i)
 
-        if not i.tag_name or not i.tag_type:
+        if not validate_tag(i):
             raise web.badrequest()
 
         match = self.find_match(i)  # returns None or Tag (if match found)
@@ -85,7 +85,7 @@ class addtag(delegate.page):
         """
         Tries to find an existing tag that matches the data provided by the user.
         """
-        return Tag.find(i.tag_name, i.tag_type)
+        return Tag.find(i.name, i.tag_type)
 
     def tag_match(self, match: list) -> NoReturn:
         """
@@ -101,7 +101,7 @@ class addtag(delegate.page):
         Creates a new Tag.
         Redirects the user to the tag's home page
         """
-        key = Tag.create(i.tag_name, i.tag_description, i.tag_type, i.tag_plugins)
+        key = Tag.create(i.name, i.tag_description, i.tag_type, i.tag_plugins)
         raise safe_seeother(key)
 
 

--- a/openlibrary/plugins/upstream/addtag.py
+++ b/openlibrary/plugins/upstream/addtag.py
@@ -38,10 +38,6 @@ class addtag(delegate.page):
 
         i = web.input(name=None, type=None, sub_type=None)
 
-        # Validate input:
-        if not i.name or not i.type:
-            raise web.badrequest('Tag name and type must be specified')
-
         return render_template('tag/add', i.name, i.type, subject_type=i.sub_type)
 
     def has_permission(self, user) -> bool:

--- a/openlibrary/templates/tag/add.html
+++ b/openlibrary/templates/tag/add.html
@@ -6,9 +6,7 @@ $var title: $_("Add a tag")
     <div class="head">
         <h1>$_("Add a tag to Open Library")</h1>
     </div>
-        <p class="instruct">$_("We require a minimum set of fields to create a new record. These are those fields.")</p>
-    $if not ctx.user:
-        $:render_template("lib/not_logged")
+    <p class="instruct">$_("We require a minimum set of fields to create a new record. These are those fields.")</p>
 </div>
 
 <div id="contentBody">

--- a/openlibrary/templates/tag/add.html
+++ b/openlibrary/templates/tag/add.html
@@ -12,45 +12,8 @@ $var title: $_("Add a tag")
 </div>
 
 <div id="contentBody">
-
     <form method="post" action="" id="addtag" class="olform addtag1">
-
-        <div class="formElement">
-            <div class="label">
-                <label for="tagname">$_("Name of Tag")</label>*<span class="tip">$_("Required field")</span>
-            </div>
-            <div class="input">
-                <input type="text" name="tag_name" id="tag_name" value="$name" required/>
-            </div>
-        </div>
-
-        <fieldset class="major">
-            <div class="formElement">
-                <div class="label">
-                    <label for="tag-description">$_("How would you describe this tag?")</label>
-                    <span class="tip">$_("There's no wrong answer here.")</span>
-                </div>
-                <div class="input">
-                    <textarea name="tag_description" id="tag_description" class="markdown" cols="55" rows="5" tabindex="0"></textarea>
-                </div>
-            </div>
-        </fieldset>
-
-        <div class="formElement">
-            <div class="label"><label for="id_value">$_("Tag type")</label></div>
-            <div class="input">
-                <select name="tag_type" id="tag_type" required>
-                    <option value="">$_("Select")</option>
-                    $ tag_types = get_tag_types()
-                    $for tag_type in tag_types:
-                        $if tag_type == type:
-                            <option value="$tag_type" selected>$tag_type</option>
-                        $else:
-                            <option value="$tag_type">$tag_type</option>
-                </select>
-            </div>
-        </div>
-
+        $:render_template("type/tag/tag_form_inputs", tag_name=name, tag_type=type)
         <div class="formElement bottom">
             <br/>
             <div class="cclicense">

--- a/openlibrary/templates/type/tag/edit.html
+++ b/openlibrary/templates/type/tag/edit.html
@@ -14,39 +14,7 @@ $putctx("robots", "noindex,nofollow")
 <div id="contentBody">
 
     <form id="edittag" name="edit" method="post" action="" class="olform">
-        <div class="formElement">
-            <div class="label">
-                <label for="name">$_("Label")</label>*<span class="tip">$_("Required field")</span>
-            </div>
-            <div class="input">
-                <input type="text" name="name" id="tag_name" value="$page.name" required />
-            </div>
-        </div>
-
-        <div class="formElement">
-            <div class="label">
-                <label for="tag_description">$_("Description")</label>
-            </div>
-            <div class="input">
-                <textarea id="tag_description" name="tag_description" class="markdown" rows="5" cols="80" style="width: 100%">$page.tag_description</textarea>
-            </div>
-        </div>
-
-        <div class="formElement">
-            <div class="label"><label for="id_value">$_("Tag type")</label></div>
-            <div class="input">
-                <select name="tag_type" id="tag_type" required>
-                    <option value="">$_("Select")</option>
-                    $ tag_types = get_tag_types()
-                    $for tag_type in tag_types:
-                        $if tag_type == page.tag_type:
-                            <option value="$tag_type" selected>$tag_type</option>
-                        $else:
-                            <option value="$tag_type">$tag_type</option>
-                </select>
-            </div>
-        </div>
-
+        $:render_template("type/tag/tag_form_inputs", tag_name=page.name, tag_type=page.tag_type, tag_description=page.tag_description)
         <div class="clearfix"></div>
 
         <div class="formElement bottom">

--- a/openlibrary/templates/type/tag/tag_form_inputs.html
+++ b/openlibrary/templates/type/tag/tag_form_inputs.html
@@ -1,0 +1,36 @@
+$def with (tag_name='', tag_type='', tag_description='')
+
+<div class="formElement">
+    <div class="label">
+        <label for="tag_name">$_("Tag Name")</label>*<span class="tip">$_("Required field")</span>
+    </div>
+    <div class="input">
+        <input type="text" name="name" id="tag_name" value="$tag_name" required/>
+    </div>
+</div>
+
+<fieldset class="major">
+    <div class="formElement">
+        <div class="label">
+            <label for="tag_description">$_("Tag Description")</label>
+        </div>
+        <div class="input">
+            <textarea id="tag_description" name="tag_description" class="markdown" rows="5" cols="80">$tag_description</textarea>
+        </div>
+    </div>
+</fieldset>
+
+<div class="formElement">
+    <div class="label"><label for="tag_type">$_("Tag type")</label></div>
+    <div class="input">
+        <select name="tag_type" id="tag_type" required>
+            <option value="">$_("Select")</option>
+            $ tag_types = get_tag_types()
+            $for t_type in tag_types:
+                $if t_type == tag_type:
+                    <option value="$t_type" selected>$t_type</option>
+                $else:
+                    <option value="$t_type">$t_type</option>
+        </select>
+    </div>
+</div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Addresses #9784

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Creates a new template for our "Add Tag" and "Edit Tag" form inputs.  Now, the labels for each form will contain the same copy.  The "Add Tag" `POST` handler has been updated to set a tag's name using the `name` form data (updated from `tag_name`).

Other changes:
- Removed conditional [`not_logged`](https://github.com/internetarchive/openlibrary/blob/master/openlibrary/templates/lib/not_logged.html) message from "Add Tag" form, as patrons must always be logged in to see this page.
- Removed Tag `name` and `type` validations from the "Add Tag" `GET` handler.  This allows us to navigate directly to the `/tag/add` page ("Bad Request" responses are raised, otherwise).

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in as a `super-librarian`:
1. Add a Tag.  Verify the new Tag's name, description, and type.
2. Edit the Tag.  Verify the new Tag's name, description, and type.
3. Navigate directly to the `/tag/add` page from your browser's address bar.  Expect to see the form, not an error.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
