### PR TITLE
Check for `comments` before accessing

### DIFF
--- a/scripts/gh_scripts/issue_comment_bot.py
+++ b/scripts/gh_scripts/issue_comment_bot.py
@@ -168,6 +168,8 @@ def filter_issues(issues: list, hours: int, leads: list[dict[str, str]]):
 
         # Get last comment
         comments = resp.json()
+        if not comments:
+            continue
         last_comment = comments[-1]
 
         # Determine if last comment meets our criteria for Slack notifications


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Updates the `filter_issues` function to skip issues when list fetched from the comments URL is empty.

### Technical
<!-- What should be noted about the implementation? -->
Early in the issue filtering flow, we drop issues that have a `comments` count of `0`.  It appears that it is possible for an issue to have a positive comment count, but not have comments.  This code change drops such issues when such cases are encountered.

Here are archived API responses for one such [issue](https://web.archive.org/web/20240828203723/https://api.github.com/repos/internetarchive/openlibrary/issues/6234), and its [comments](https://web.archive.org/web/20240828203802/https://api.github.com/repos/internetarchive/openlibrary/issues/6234/comments).

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
The results of running these changes manually can be seen [here](https://github.com/internetarchive/openlibrary/actions/runs/10603850490).  After running, the digest was published to our Slack channel.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
