### PR TITLE
Added link tracks to all download options

### DIFF
--- a/openlibrary/templates/book_providers/cita_press_download_options.html
+++ b/openlibrary/templates/book_providers/cita_press_download_options.html
@@ -6,7 +6,7 @@ $ url = 'https://citapress.org/' + cita_press_id
 <div class="cta-section">
   <p class="cta-section-title">$_('Download Options')</p>
     <ul class="ebook-download-options">
-      <li><a href="$url" title="$_('Download PDF from Cita Press')">$_('PDF')</a></li>
+      <li><a href="$url" data-ol-link-track="SideBar|Download" title="$_('Download PDF from Cita Press')">$_('PDF')</a></li>
       <li><a href="$url">$_('More at Cita Press')</a></li>
     </ul>
 </div>

--- a/openlibrary/templates/book_providers/cita_press_download_options.html
+++ b/openlibrary/templates/book_providers/cita_press_download_options.html
@@ -6,7 +6,7 @@ $ url = 'https://citapress.org/' + cita_press_id
 <div class="cta-section">
   <p class="cta-section-title">$_('Download Options')</p>
     <ul class="ebook-download-options">
-      <li><a href="$url" data-ol-link-track="SideBar|Download" title="$_('Download PDF from Cita Press')">$_('PDF')</a></li>
+      <li><a href="$url" data-ol-link-track="Download|pdf_cita" title="$_('Download PDF from Cita Press')">$_('PDF')</a></li>
       <li><a href="$url">$_('More at Cita Press')</a></li>
     </ul>
 </div>

--- a/openlibrary/templates/book_providers/gutenberg_download_options.html
+++ b/openlibrary/templates/book_providers/gutenberg_download_options.html
@@ -8,10 +8,10 @@ $ gutenberg_url = 'https://www.gutenberg.org/ebooks/' + gutenberg_id
 <ul class="ebook-download-options">
   $# There's no reliable way to determine the url for a given format, but these formats
   $# are usually available. See https://www.gutenberg.org/policy/linking.html
-  <li><a href="$gutenberg_url" title="$_('Download an HTML from Project Gutenberg')">$_("HTML")</a></li>
-  <li><a href="$gutenberg_url" title="$_('Download a text version from Project Gutenberg')">$_("Plain text")</a></li>
-  <li><a href="$gutenberg_url" title="$_('Download an ePub from Project Gutenberg')">$_("ePub")</a></li>
-  <li><a href="$gutenberg_url" title="$_('Download a Kindle file from Project Gutenberg')">$_("Kindle")</a></li>
+  <li><a href="$gutenberg_url" data-ol-link-track="SideBar|Download" title="$_('Download an HTML from Project Gutenberg')">$_("HTML")</a></li>
+  <li><a href="$gutenberg_url" data-ol-link-track="SideBar|Download" title="$_('Download a text version from Project Gutenberg')">$_("Plain text")</a></li>
+  <li><a href="$gutenberg_url" data-ol-link-track="SideBar|Download" title="$_('Download an ePub from Project Gutenberg')">$_("ePub")</a></li>
+  <li><a href="$gutenberg_url" data-ol-link-track="SideBar|Download" title="$_('Download a Kindle file from Project Gutenberg')">$_("Kindle")</a></li>
   <li><a href="$gutenberg_url">$_("More at Project Gutenberg")</a></li>
 </ul>
 </div>

--- a/openlibrary/templates/book_providers/gutenberg_download_options.html
+++ b/openlibrary/templates/book_providers/gutenberg_download_options.html
@@ -8,10 +8,10 @@ $ gutenberg_url = 'https://www.gutenberg.org/ebooks/' + gutenberg_id
 <ul class="ebook-download-options">
   $# There's no reliable way to determine the url for a given format, but these formats
   $# are usually available. See https://www.gutenberg.org/policy/linking.html
-  <li><a href="$gutenberg_url" data-ol-link-track="SideBar|Download" title="$_('Download an HTML from Project Gutenberg')">$_("HTML")</a></li>
-  <li><a href="$gutenberg_url" data-ol-link-track="SideBar|Download" title="$_('Download a text version from Project Gutenberg')">$_("Plain text")</a></li>
-  <li><a href="$gutenberg_url" data-ol-link-track="SideBar|Download" title="$_('Download an ePub from Project Gutenberg')">$_("ePub")</a></li>
-  <li><a href="$gutenberg_url" data-ol-link-track="SideBar|Download" title="$_('Download a Kindle file from Project Gutenberg')">$_("Kindle")</a></li>
+  <li><a href="$gutenberg_url" data-ol-link-track="Download|html_gutenberg" title="$_('Download an HTML from Project Gutenberg')">$_("HTML")</a></li>
+  <li><a href="$gutenberg_url" data-ol-link-track="Download|text_gutenberg" title="$_('Download a text version from Project Gutenberg')">$_("Plain text")</a></li>
+  <li><a href="$gutenberg_url" data-ol-link-track="Download|epub_gutenburg" title="$_('Download an ePub from Project Gutenberg')">$_("ePub")</a></li>
+  <li><a href="$gutenberg_url" data-ol-link-track="Download|kindle_gutenberg" title="$_('Download a Kindle file from Project Gutenberg')">$_("Kindle")</a></li>
   <li><a href="$gutenberg_url">$_("More at Project Gutenberg")</a></li>
 </ul>
 </div>

--- a/openlibrary/templates/book_providers/ia_download_options.html
+++ b/openlibrary/templates/book_providers/ia_download_options.html
@@ -5,13 +5,13 @@ $def with(formats, daisy)
   <p class="cta-section-title">$_("Download Options")</p>
   <ul class="ebook-download-options">
     $if formats.get('pdf'):
-      <li><a href="$formats['pdf']" title="$_('Download a PDF from Internet Archive')">$_("PDF")</a></li>
+      <li><a href="$formats['pdf']" data-ol-link-track="SideBar|Download" title="$_('Download a PDF from Internet Archive')">$_("PDF")</a></li>
     $if formats['txt']:
-      <li><a href="$formats['txt']" title="$_('Download a text version from Internet Archive')">$_("Plain text")</a></li>
+      <li><a href="$formats['txt']" data-ol-link-track="SideBar|Download" title="$_('Download a text version from Internet Archive')">$_("Plain text")</a></li>
     $if formats['epub']:
-      <li><a href="$formats['epub']" title="$_('Download an ePub from Internet Archive')">$_("ePub")</a></li>
+      <li><a href="$formats['epub']" data-ol-link-track="SideBar|Download" title="$_('Download an ePub from Internet Archive')">$_("ePub")</a></li>
     $if formats['mobi']:
-      <li><a href="$formats['mobi']" title="$_('Download a MOBI file from Internet Archive')">$_("MOBI")</a></li>
-    <li><a href="$daisy" title="$_('Download open DAISY from Internet Archive (print-disabled format)')">$_("DAISY")</a></li>
+      <li><a href="$formats['mobi']" data-ol-link-track="SideBar|Download" title="$_('Download a MOBI file from Internet Archive')">$_("MOBI")</a></li>
+    <li><a href="$daisy" data-ol-link-track="SideBar|Download" title="$_('Download open DAISY from Internet Archive (print-disabled format)')">$_("DAISY")</a></li>
   </ul>
 </div>

--- a/openlibrary/templates/book_providers/ia_download_options.html
+++ b/openlibrary/templates/book_providers/ia_download_options.html
@@ -5,13 +5,13 @@ $def with(formats, daisy)
   <p class="cta-section-title">$_("Download Options")</p>
   <ul class="ebook-download-options">
     $if formats.get('pdf'):
-      <li><a href="$formats['pdf']" data-ol-link-track="SideBar|Download" title="$_('Download a PDF from Internet Archive')">$_("PDF")</a></li>
+      <li><a href="$formats['pdf']" data-ol-link-track="Download|pdf_ia" title="$_('Download a PDF from Internet Archive')">$_("PDF")</a></li>
     $if formats['txt']:
-      <li><a href="$formats['txt']" data-ol-link-track="SideBar|Download" title="$_('Download a text version from Internet Archive')">$_("Plain text")</a></li>
+      <li><a href="$formats['txt']" data-ol-link-track="Download|text_ia" title="$_('Download a text version from Internet Archive')">$_("Plain text")</a></li>
     $if formats['epub']:
-      <li><a href="$formats['epub']" data-ol-link-track="SideBar|Download" title="$_('Download an ePub from Internet Archive')">$_("ePub")</a></li>
+      <li><a href="$formats['epub']" data-ol-link-track="Download|epub_ia" title="$_('Download an ePub from Internet Archive')">$_("ePub")</a></li>
     $if formats['mobi']:
-      <li><a href="$formats['mobi']" data-ol-link-track="SideBar|Download" title="$_('Download a MOBI file from Internet Archive')">$_("MOBI")</a></li>
-    <li><a href="$daisy" data-ol-link-track="SideBar|Download" title="$_('Download open DAISY from Internet Archive (print-disabled format)')">$_("DAISY")</a></li>
+      <li><a href="$formats['mobi']" data-ol-link-track="Download|mobi_ia" title="$_('Download a MOBI file from Internet Archive')">$_("MOBI")</a></li>
+    <li><a href="$daisy" data-ol-link-track="Download|daisy_ia" title="$_('Download open DAISY from Internet Archive (print-disabled format)')">$_("DAISY")</a></li>
   </ul>
 </div>

--- a/openlibrary/templates/book_providers/librivox_download_options.html
+++ b/openlibrary/templates/book_providers/librivox_download_options.html
@@ -5,7 +5,7 @@ $def with(librivox_id, ocaid)
 <p class="cta-section-title">$_("Download Options")</p>
 <ul class="ebook-download-options">
   $if ocaid:
-    <li><a href="http://www.archive.org/download/$(ocaid)/$(ocaid)_64kb_mp3.zip" title="$_('Download a ZIP file of the whole book from Internet Archive')">$_("Whole Book MP3")</a></li>
+    <li><a href="http://www.archive.org/download/$(ocaid)/$(ocaid)_64kb_mp3.zip" data-ol-link-track="SideBar|Download" title="$_('Download a ZIP file of the whole book from Internet Archive')">$_("Whole Book MP3")</a></li>
   <li><a href="https://librivox.org/rss/$librivox_id" title="$_('Get the RSS Feed from LibriVox')">$_("RSS Feed")</a></li>
   <li><a href="https://librivox.org/$librivox_id">$_("More at LibriVox")</a></li>
 </ul>

--- a/openlibrary/templates/book_providers/librivox_download_options.html
+++ b/openlibrary/templates/book_providers/librivox_download_options.html
@@ -5,7 +5,7 @@ $def with(librivox_id, ocaid)
 <p class="cta-section-title">$_("Download Options")</p>
 <ul class="ebook-download-options">
   $if ocaid:
-    <li><a href="http://www.archive.org/download/$(ocaid)/$(ocaid)_64kb_mp3.zip" data-ol-link-track="SideBar|Download" title="$_('Download a ZIP file of the whole book from Internet Archive')">$_("Whole Book MP3")</a></li>
+    <li><a href="http://www.archive.org/download/$(ocaid)/$(ocaid)_64kb_mp3.zip" data-ol-link-track="Download|mp3zip_librivox_ia" title="$_('Download a ZIP file of the whole book from Internet Archive')">$_("Whole Book MP3")</a></li>
   <li><a href="https://librivox.org/rss/$librivox_id" title="$_('Get the RSS Feed from LibriVox')">$_("RSS Feed")</a></li>
   <li><a href="https://librivox.org/$librivox_id">$_("More at LibriVox")</a></li>
 </ul>

--- a/openlibrary/templates/book_providers/openstax_download_options.html
+++ b/openlibrary/templates/book_providers/openstax_download_options.html
@@ -6,7 +6,7 @@ $ url = 'https://openstax.org/details/books/' + openstax_id
 <div class="cta-section">
   <p class="cta-section-title">$_("Download Options")</p>
     <ul class="ebook-download-options">
-      <li><a href="$url" title="$_('Download PDF from OpenStax')">$_("PDF")</a></li>
+      <li><a href="$url" data-ol-link-track="SideBar|Download" title="$_('Download PDF from OpenStax')">$_("PDF")</a></li>
       <li><a href="$url">$_("More at OpenStax")</a></li>
     </ul>
 </div>

--- a/openlibrary/templates/book_providers/openstax_download_options.html
+++ b/openlibrary/templates/book_providers/openstax_download_options.html
@@ -6,7 +6,7 @@ $ url = 'https://openstax.org/details/books/' + openstax_id
 <div class="cta-section">
   <p class="cta-section-title">$_("Download Options")</p>
     <ul class="ebook-download-options">
-      <li><a href="$url" data-ol-link-track="SideBar|Download" title="$_('Download PDF from OpenStax')">$_("PDF")</a></li>
+      <li><a href="$url" data-ol-link-track="Download|pdf_openstax" title="$_('Download PDF from OpenStax')">$_("PDF")</a></li>
       <li><a href="$url">$_("More at OpenStax")</a></li>
     </ul>
 </div>

--- a/openlibrary/templates/book_providers/standard_ebooks_download_options.html
+++ b/openlibrary/templates/book_providers/standard_ebooks_download_options.html
@@ -7,10 +7,10 @@ $ flat_id = standard_ebooks_id.replace('/', '_')
 <div class="cta-section">
 <p class="cta-section-title">$_("Download Options")</p>
 <ul class="ebook-download-options">
-  <li><a href="$base_url/text/single-page" title="$_('Download an HTML from Standard Ebooks')">$_("HTML")</a></li>
-  <li><a href="$base_url/downloads/$(flat_id).epub" title="$_('Download an ePub from Standard Ebook.')">$_("ePub")</a></li>
-  <li><a href="$base_url/downloads/$(flat_id).azw3" title="$_('Download a Kindle file from Standard Ebooks')">$_("Kindle (azw3)")</a></li>
-  <li><a href="$base_url/downloads/$(flat_id).kepub.epub" title="$_('Download a Kobo file from Standard Ebooks')">$_("Kobo (kepub)")</a></li>
+  <li><a href="$base_url/text/single-page" data-ol-link-track="SideBar|Download" title="$_('Download an HTML from Standard Ebooks')">$_("HTML")</a></li>
+  <li><a href="$base_url/downloads/$(flat_id).epub" data-ol-link-track="SideBar|Download" title="$_('Download an ePub from Standard Ebook.')">$_("ePub")</a></li>
+  <li><a href="$base_url/downloads/$(flat_id).azw3" data-ol-link-track="SideBar|Download" title="$_('Download a Kindle file from Standard Ebooks')">$_("Kindle (azw3)")</a></li>
+  <li><a href="$base_url/downloads/$(flat_id).kepub.epub" data-ol-link-track="SideBar|Download" title="$_('Download a Kobo file from Standard Ebooks')">$_("Kobo (kepub)")</a></li>
   <li><a href="https://github.com/standardebooks/$flat_id" title="$_('View the source code for this Standard Ebook at GitHub')">$_("Source Code")</a></li>
   <li><a href="$base_url">$_("More at Standard Ebooks")</a></li>
 </ul>

--- a/openlibrary/templates/book_providers/standard_ebooks_download_options.html
+++ b/openlibrary/templates/book_providers/standard_ebooks_download_options.html
@@ -7,10 +7,10 @@ $ flat_id = standard_ebooks_id.replace('/', '_')
 <div class="cta-section">
 <p class="cta-section-title">$_("Download Options")</p>
 <ul class="ebook-download-options">
-  <li><a href="$base_url/text/single-page" data-ol-link-track="SideBar|Download" title="$_('Download an HTML from Standard Ebooks')">$_("HTML")</a></li>
-  <li><a href="$base_url/downloads/$(flat_id).epub" data-ol-link-track="SideBar|Download" title="$_('Download an ePub from Standard Ebook.')">$_("ePub")</a></li>
-  <li><a href="$base_url/downloads/$(flat_id).azw3" data-ol-link-track="SideBar|Download" title="$_('Download a Kindle file from Standard Ebooks')">$_("Kindle (azw3)")</a></li>
-  <li><a href="$base_url/downloads/$(flat_id).kepub.epub" data-ol-link-track="SideBar|Download" title="$_('Download a Kobo file from Standard Ebooks')">$_("Kobo (kepub)")</a></li>
+  <li><a href="$base_url/text/single-page" data-ol-link-track="Download|html_standardebooks" title="$_('Download an HTML from Standard Ebooks')">$_("HTML")</a></li>
+  <li><a href="$base_url/downloads/$(flat_id).epub" data-ol-link-track="Download|epub_standardebooks" title="$_('Download an ePub from Standard Ebook.')">$_("ePub")</a></li>
+  <li><a href="$base_url/downloads/$(flat_id).azw3" data-ol-link-track="Download|kindle_standardebooks" title="$_('Download a Kindle file from Standard Ebooks')">$_("Kindle (azw3)")</a></li>
+  <li><a href="$base_url/downloads/$(flat_id).kepub.epub" data-ol-link-track="Download|kobo_standardebooks" title="$_('Download a Kobo file from Standard Ebooks')">$_("Kobo (kepub)")</a></li>
   <li><a href="https://github.com/standardebooks/$flat_id" title="$_('View the source code for this Standard Ebook at GitHub')">$_("Source Code")</a></li>
   <li><a href="$base_url">$_("More at Standard Ebooks")</a></li>
 </ul>

--- a/openlibrary/templates/book_providers/wikisource_download_options.html
+++ b/openlibrary/templates/book_providers/wikisource_download_options.html
@@ -27,9 +27,9 @@ $code:
 <div class="cta-section">
     <p class="cta-section-title">$_('Download Options')</p>
     <ul class="ebook-download-options">
-        <li><a title="$_('Download PDF from Wikisource')" href="$pdf_url">$_('PDF')</a></li>
-        <li><a title="$_('Download MOBI from Wikisource')" href="$mobi_url">$_('MOBI (for Kindle)')</a></li>
-        <li><a title="$_('Download EPUB from Wikisource')" href="$epub_url">$_('EPUB (for most other e-readers)')</a></li>
+        <li><a title="$_('Download PDF from Wikisource')" href="$pdf_url" data-ol-link-track="SideBar|Download">$_('PDF')</a></li>
+        <li><a title="$_('Download MOBI from Wikisource')" href="$mobi_url" data-ol-link-track="SideBar|Download">$_('MOBI (for Kindle)')</a></li>
+        <li><a title="$_('Download EPUB from Wikisource')" href="$epub_url" data-ol-link-track="SideBar|Download">$_('EPUB (for most other e-readers)')</a></li>
         <li><a href="$outbound_url">$_('Read at Wikisource')</a></li>
     </ul>
 </div>

--- a/openlibrary/templates/book_providers/wikisource_download_options.html
+++ b/openlibrary/templates/book_providers/wikisource_download_options.html
@@ -27,9 +27,9 @@ $code:
 <div class="cta-section">
     <p class="cta-section-title">$_('Download Options')</p>
     <ul class="ebook-download-options">
-        <li><a title="$_('Download PDF from Wikisource')" href="$pdf_url" data-ol-link-track="SideBar|Download">$_('PDF')</a></li>
-        <li><a title="$_('Download MOBI from Wikisource')" href="$mobi_url" data-ol-link-track="SideBar|Download">$_('MOBI (for Kindle)')</a></li>
-        <li><a title="$_('Download EPUB from Wikisource')" href="$epub_url" data-ol-link-track="SideBar|Download">$_('EPUB (for most other e-readers)')</a></li>
+        <li><a title="$_('Download PDF from Wikisource')" href="$pdf_url" data-ol-link-track="Download|pdf_wikisource">$_('PDF')</a></li>
+        <li><a title="$_('Download MOBI from Wikisource')" href="$mobi_url" data-ol-link-track="Download|mobi_wikisource">$_('MOBI (for Kindle)')</a></li>
+        <li><a title="$_('Download EPUB from Wikisource')" href="$epub_url" data-ol-link-track="Download|epub_wikisource">$_('EPUB (for most other e-readers)')</a></li>
         <li><a href="$outbound_url">$_('Read at Wikisource')</a></li>
     </ul>
 </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9782 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds link tracks to all download options in sidebar so that we can have a baseline reading of patron activity. This reading will then be used to compare the effectiveness of the work-in-progress [Read dropdown redesign
](https://github.com/internetarchive/openlibrary/issues/5831). 

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Click a download option and ensure that data for SideBar|Download is being recorded in stats. 

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini @mekarpeles 
@SivanC -- just letting you know about this one for when you want to compare SideBar|Download with your eventual ReadDropper|Download feature. 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
