### PR TITLE
Add 'locate' endpoint to borrow API

### DIFF
--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -199,14 +199,7 @@ class borrow(delegate.page):
             stats.increment('ol.loans.leaveWaitlist')
             raise web.redirect(edition_redirect)
         elif action == 'locate':
-            redirect_url = 'https://search.worldcat.org/'
-            if edition.get('oclc_numbers', None):
-                redirect_url += f'title/{edition.oclc_numbers[0]}'
-            elif edition.get('isbn_13', edition.get('isbn_10', None)):
-                redirect_url += f'isbn/{edition.isbn_13[0] or edition.isbn_10[0]}'
-            else:
-                redirect_url += f'search?q={edition.title}'
-            raise web.seeother(redirect_url)
+            raise web.seeother(edition.get_worldcat_url())
 
         elif action in ('borrow', 'browse') and not user.has_borrowed(edition):
             borrow_access = user_can_borrow_edition(user, edition)

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -198,6 +198,15 @@ class borrow(delegate.page):
             lending.s3_loan_api(s3_keys, ocaid=edition.ocaid, action='leave_waitlist')
             stats.increment('ol.loans.leaveWaitlist')
             raise web.redirect(edition_redirect)
+        elif action == 'locate':
+            redirect_url = 'https://search.worldcat.org/'
+            if edition.get('oclc_numbers', None):
+                redirect_url += f'title/{edition.oclc_numbers[0]}'
+            elif edition.get('isbn_13', edition.get('isbn_10', None)):
+                redirect_url += f'isbn/{edition.isbn_13[0] or edition.isbn_10[0]}'
+            else:
+                redirect_url += f'search?q={edition.title}'
+            raise web.seeother(redirect_url)
 
         elif action in ('borrow', 'browse') and not user.has_borrowed(edition):
             borrow_access = user_can_borrow_edition(user, edition)

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -106,11 +106,11 @@ class Edition(models.Edition):
     def get_worldcat_url(self):
         url = 'https://search.worldcat.org/'
         if self.get('oclc_numbers'):
-            return f'{url}/title/{edition.oclc_numbers[0]}'
+            return f'{url}/title/{self.oclc_numbers[0]}'
         elif self.get_isbn13():
             # Handles both isbn13 & 10
             return f'{url}/isbn/{self.get_isbn13()}'
-        return f'{url}/search?q={edition.title}'
+        return f'{url}/search?q={self.title}'
 
     def get_isbnmask(self):
         """Returns a masked (hyphenated) ISBN if possible."""

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -103,6 +103,15 @@ class Edition(models.Edition):
             return isbn_10 and isbn_10_to_isbn_13(isbn_10)
         return isbn_13
 
+    def get_worldcat_url(self):
+        url = 'https://search.worldcat.org/'
+        if self.get('oclc_numbers'):
+            return f'{url}/title/{edition.oclc_numbers[0]}'
+        elif self.get_isbn13():
+            # Handles both isbn13 & 10
+            return f'{url}/isbn/{self.get_isbn13()}'
+        return f'{url}/search?q={edition.title}'
+
     def get_isbnmask(self):
         """Returns a masked (hyphenated) ISBN if possible."""
         isbns = self.get('isbn_13', []) + self.get('isbn_10', [None])


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9829

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature. Adds a new endpoint to redirect to a worldcat page based on identifier data provided for a given edition. Prioritizes oclc, then isbn 13, isbn 10, and finally title.

### Technical
<!-- What should be noted about the implementation? -->
Adds an extra check to the `plugins/upstream/borrow.py` borrow class. If the endpoint /books/{olid}/{title}/borrow is reached with the parameter `action=locate`, a redirect URL is constructed and redirected to.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Navigate to an edition page
- Add `/borrow?action=locate` to the end of the url
- Be redirected to worldcat, ensuring that the identifier with the highest priority has been chosen (oclc, isbn13, isbn10, title). If the edition has an oclc identifier, you should be directed to a book page, otherwise the search page.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
