### PR TITLE
Save subject page body to `Tag.body` when tags are created

### DIFF
--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -1182,6 +1182,7 @@ class Tag(Thing):
         tag_description,
         tag_type,
         tag_plugins,
+        fkey=None,
         ip='127.0.0.1',
         comment='New Tag',
     ):
@@ -1201,6 +1202,7 @@ class Tag(Thing):
                     'tag_type': tag_type,
                     'tag_plugins': json.loads(tag_plugins or "[]"),
                     'type': {"key": '/type/tag'},
+                    'fkey': fkey,
                 },
                 comment=comment,
             )

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -1181,7 +1181,7 @@ class Tag(Thing):
         tag_name,
         tag_description,
         tag_type,
-        tag_plugins,
+        body='',
         fkey=None,
         ip='127.0.0.1',
         comment='New Tag',
@@ -1194,19 +1194,19 @@ class Tag(Thing):
 
         with RunAs(patron):
             web.ctx.ip = web.ctx.ip or ip
-            web.ctx.site.save(
+            t = web.ctx.site.save(
                 {
                     'key': key,
                     'name': tag_name,
                     'tag_description': tag_description,
                     'tag_type': tag_type,
-                    'tag_plugins': json.loads(tag_plugins or "[]"),
                     'type': {"key": '/type/tag'},
                     'fkey': fkey,
+                    'body': body.strip(),
                 },
                 comment=comment,
             )
-            return key
+            return web.ctx.site.get(key)
 
 
 @dataclass

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -691,7 +691,15 @@ msgid "Name"
 msgstr ""
 
 #: subjects.html
+msgid "Promote to Tag"
+msgstr ""
+
+#: subjects.html
 msgid "Edit Subject Tag"
+msgstr ""
+
+#: subjects.html
+msgid "Create Tag from this subject"
 msgstr ""
 
 #: subjects.html
@@ -7007,12 +7015,15 @@ msgid "Tag Description"
 msgstr ""
 
 #: type/tag/tag_form_inputs.html
-msgid "Tag type"
+msgid "Page Body"
 msgstr ""
 
-#: type/tag/view.html
-#, python-format
-msgid "View subject page for %(name)s."
+#: type/tag/tag_form_inputs.html
+msgid "Subject Key"
+msgstr ""
+
+#: type/tag/tag_form_inputs.html
+msgid "Tag type"
 msgstr ""
 
 #: type/template/edit.html

--- a/openlibrary/plugins/upstream/addtag.py
+++ b/openlibrary/plugins/upstream/addtag.py
@@ -36,9 +36,9 @@ class addtag(delegate.page):
         if not self.has_permission(patron):
             raise web.unauthorized(message='Permission denied to add tags')
 
-        i = web.input(name=None, type=None, sub_type=None)
+        i = web.input(name=None, type=None, sub_type=None, fkey=None)
 
-        return render_template('tag/add', i.name, i.type, subject_type=i.sub_type)
+        return render_template('tag/add', i.name, i.type, subject_type=i.sub_type, fkey=i.fkey)
 
     def has_permission(self, user) -> bool:
         """
@@ -54,6 +54,7 @@ class addtag(delegate.page):
             tag_type="",
             tag_description="",
             tag_plugins="",
+            fkey=None,
         )
 
         if spamcheck.is_spam(i, allow_privileged_edits=True):
@@ -101,7 +102,7 @@ class addtag(delegate.page):
         Creates a new Tag.
         Redirects the user to the tag's home page
         """
-        key = Tag.create(i.name, i.tag_description, i.tag_type, i.tag_plugins)
+        key = Tag.create(i.name, i.tag_description, i.tag_type, i.tag_plugins, i.fkey)
         raise safe_seeother(key)
 
 

--- a/openlibrary/plugins/upstream/addtag.py
+++ b/openlibrary/plugins/upstream/addtag.py
@@ -54,6 +54,7 @@ class addtag(delegate.page):
             name="",
             tag_type="",
             tag_description="",
+            body="",
             fkey=None,
         )
 
@@ -102,8 +103,8 @@ class addtag(delegate.page):
         Creates a new Tag.
         Redirects the user to the tag's home page
         """
-        tag = Tag.create(i.name, i.tag_description, i.tag_type, fkey=i.fkey)
-        if i.fkey:
+        tag = Tag.create(i.name, i.tag_description, i.tag_type, fkey=i.fkey, body=i.body)
+        if i.fkey and not i.body:
             subject = get_subject(
                 i.fkey,
                 details=True,

--- a/openlibrary/plugins/upstream/addtag.py
+++ b/openlibrary/plugins/upstream/addtag.py
@@ -21,8 +21,14 @@ from openlibrary.plugins.worksearch.subjects import get_subject
 def get_tag_types():
     return ["subject", "work", "collection"]
 
+
 def validate_tag(tag, for_promotion=False):
-    return (tag.get('name', '') and tag.get('fkey', None)) if for_promotion else (tag.get('name', '') and tag.get('tag_type', ''))
+    return (
+        (tag.get('name', '') and tag.get('fkey', None))
+        if for_promotion
+        else (tag.get('name', '') and tag.get('tag_type', ''))
+    )
+
 
 def has_permission(user) -> bool:
     """
@@ -32,14 +38,17 @@ def has_permission(user) -> bool:
         user.is_librarian() or user.is_super_librarian() or user.is_admin()
     )
 
-def create_subject_tag(name: str, description: str, fkey: str | None = None, body: str = '') -> Tag:
+
+def create_subject_tag(
+    name: str, description: str, fkey: str | None = None, body: str = ''
+) -> Tag:
     tag = Tag.create(name, description, 'subject', fkey=fkey, body=body)
     if fkey and not body:
         subject = get_subject(
             fkey,
             details=True,
             filters={'public_scan_b': 'false', 'lending_edition_s': '*'},
-            sort='readinglog'
+            sort='readinglog',
         )
         if subject and subject.work_count > 0:
             tag.body = str(render_template('subjects', page=subject))
@@ -54,7 +63,9 @@ class promotetag(delegate.page):
         if not (patron := get_current_user()):
             raise web.seeother(f'/account/login?redirect={self.path}')
         if not has_permission(patron):
-            raise web.unauthorized(message='Permission denied to promote subject to tags')
+            raise web.unauthorized(
+                message='Permission denied to promote subject to tags'
+            )
 
         i = web.input(name="", fkey=None, description="")
 
@@ -78,7 +89,9 @@ class addtag(delegate.page):
 
         i = web.input(name=None, type=None, sub_type=None, fkey=None)
 
-        return render_template('tag/add', i.name, i.type, subject_type=i.sub_type, fkey=i.fkey)
+        return render_template(
+            'tag/add', i.name, i.type, subject_type=i.sub_type, fkey=i.fkey
+        )
 
     def POST(self):
         i = web.input(

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -32,8 +32,7 @@ class subjects(delegate.page):
             raise web.redirect(nkey)
 
         q = {"type": "/type/tag", "fkey": key, "tag_type": "subject"}
-        match = web.ctx.site.things(q)
-        if match:
+        if match := web.ctx.site.things(q):
             tag = web.ctx.site.get(match[0])
             raise web.redirect(tag.key)
 

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -31,6 +31,12 @@ class subjects(delegate.page):
         if (nkey := self.normalize_key(key)) != key:
             raise web.redirect(nkey)
 
+        q = {"type": "/type/tag", "fkey": key, "tag_type": "subject"}
+        match = web.ctx.site.things(q)
+        if match:
+            tag = web.ctx.site.get(match[0])
+            raise web.redirect(tag.key)
+
         # this needs to be updated to include:
         # q=public_scan_b:true+OR+lending_edition_s:*
         subj = get_subject(
@@ -337,17 +343,11 @@ class SubjectEngine:
                     subject[meta.key].pop(i)
                     break
 
-            q = {"type": "/type/tag", "name": subject.name, "tag_type": "subject"}
+            q = {"type": "/type/tag", "fkey": subject.key, "tag_type": "subject"}
             match = web.ctx.site.things(q)
             if match:
                 tag = web.ctx.site.get(match[0])
-                match = {
-                    'name': tag.name,
-                    'id': tag.key,
-                    'description': tag.tag_description,
-                    'plugins': tag.tag_plugins,
-                }
-                subject.tag = match
+                subject.tag = tag
 
         return subject
 

--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -17,7 +17,7 @@ $ q = query_param('q')
       <div class="subjectTagEdit">
         $ edit_tag_url = page.tag.get('id') + '/-/edit' if 'tag' in page else '/tag/add'
         $if not has_tag:
-          $ edit_tag_url += '?name=%s&type=subject&sub_type=%s' % (page.name, page.subject_type)
+          $ edit_tag_url += '?name=%s&type=subject&sub_type=%s&fkey=%s' % (page.name, page.subject_type, page.key)
         <a
           class="editTagButton"
           href="$edit_tag_url"

--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -10,7 +10,7 @@ $ q = query_param('q')
 <div class="page-heading-search-box">
     $if can_add_tag:
       <div class="subjectTagEdit">
-        $ edit_tag_url = page.tag.get('key') + '/-/edit' if has_tag else '/tag/add?name=%s&type=subject&sub_type=%s&fkey=%s' % (page.name, page.subject_type, page.key)
+        $ edit_tag_url = page.tag.get('key') + '/-/edit' if has_tag else '/tag/promote?name=%s&type=subject&sub_type=%s&fkey=%s' % (page.name, page.subject_type, page.key)
         $ btn_cta = _("Edit") if has_tag else _("Promote to Tag")
         $ elem_title = _("Edit Subject Tag") if has_tag else _("Create Tag from this subject")
         $ link_track = "CTAClick|SubjectTagEdit" if has_tag else "CTAClick|SubjectTagAdd"

--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -11,8 +11,8 @@ $ q = query_param('q')
     $if can_add_tag:
       <div class="subjectTagEdit">
         $ edit_tag_url = page.tag.get('key') + '/-/edit' if has_tag else '/tag/add?name=%s&type=subject&sub_type=%s&fkey=%s' % (page.name, page.subject_type, page.key)
-        $ btn_cta = _("Edit") if has_tag else _("Create Tag")
-        $ elem_title = _("Edit Subject Tag") if has_tag else _("Create Tag from Subject")
+        $ btn_cta = _("Edit") if has_tag else _("Promote to Tag")
+        $ elem_title = _("Edit Subject Tag") if has_tag else _("Create Tag from this subject")
         $ link_track = "CTAClick|SubjectTagEdit" if has_tag else "CTAClick|SubjectTagAdd"
         <a
           class="editTagButton"

--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -7,25 +7,21 @@ $ has_tag = 'tag' in page
 $ q = query_param('q')
 
 <div id="scrollHere"></div>
-
-<!--
-  Able to fetch Tag with the same name as the subject and use it's data to enrich the page via page.tag
--->
-
 <div class="page-heading-search-box">
     $if can_add_tag:
       <div class="subjectTagEdit">
-        $ edit_tag_url = page.tag.get('id') + '/-/edit' if 'tag' in page else '/tag/add'
-        $if not has_tag:
-          $ edit_tag_url += '?name=%s&type=subject&sub_type=%s&fkey=%s' % (page.name, page.subject_type, page.key)
+        $ edit_tag_url = page.tag.get('key') + '/-/edit' if has_tag else '/tag/add?name=%s&type=subject&sub_type=%s&fkey=%s' % (page.name, page.subject_type, page.key)
+        $ btn_cta = _("Edit") if has_tag else _("Create Tag")
+        $ elem_title = _("Edit Subject Tag") if has_tag else _("Create Tag from Subject")
+        $ link_track = "CTAClick|SubjectTagEdit" if has_tag else "CTAClick|SubjectTagAdd"
         <a
           class="editTagButton"
           href="$edit_tag_url"
-          title="$_('Edit Subject Tag')"
-          data-ol-link-track="CTAClick|Edit"
+          title="$elem_title"
+          data-ol-link-track="$link_track"
           accesskey="e"
           rel="nofollow"
-        >$_("Edit")</a>
+        >$btn_cta</a>
       </div>
     <h1 class="inline">
         $page.name
@@ -35,12 +31,7 @@ $ q = query_param('q')
             <strong><span><a href="/search?$page.subject_type=$page.name.replace('&','%26')" title="$_('See all works')">$ungettext("%(count)d work", "%(count)d works", page.work_count, count=page.work_count)</a></span></strong>
         </span>
     </span>
-    $if has_tag:
-      <h3 itemprop="description">
-        $page.tag['description']
-      </h3>
     <a href="#search" class="shift">$_("Search for books with subject %(name)s.", name=page.name)</a>
-
     <form action="/search" class="olform pagesearchbox">
       $:render_template("search/searchbox", q=q)
       <input type="hidden" name="${page.subject_type}_facet" value="$page.name"/>

--- a/openlibrary/templates/tag/add.html
+++ b/openlibrary/templates/tag/add.html
@@ -1,4 +1,4 @@
-$def with (name, type, subject_type=None)
+$def with (name, type, subject_type=None, fkey=None)
 
 $var title: $_("Add a tag")
 
@@ -11,7 +11,7 @@ $var title: $_("Add a tag")
 
 <div id="contentBody">
     <form method="post" action="" id="addtag" class="olform addtag1">
-        $:render_template("type/tag/tag_form_inputs", tag_name=name, tag_type=type)
+        $:render_template("type/tag/tag_form_inputs", tag_name=name, tag_type=type, fkey=fkey)
         <div class="formElement bottom">
             <br/>
             <div class="cclicense">

--- a/openlibrary/templates/type/tag/edit.html
+++ b/openlibrary/templates/type/tag/edit.html
@@ -14,7 +14,7 @@ $putctx("robots", "noindex,nofollow")
 <div id="contentBody">
 
     <form id="edittag" name="edit" method="post" action="" class="olform">
-        $:render_template("type/tag/tag_form_inputs", tag_name=page.name, tag_type=page.tag_type, tag_description=page.tag_description, fkey=page.fkey, body=page.body)
+        $:render_template("type/tag/tag_form_inputs", tag_name=page.name, tag_type=page.tag_type, tag_description=page.tag_description, fkey=page.fkey, body=page.body, show_type_picker=False)
         <div class="clearfix"></div>
 
         <div class="formElement bottom">

--- a/openlibrary/templates/type/tag/edit.html
+++ b/openlibrary/templates/type/tag/edit.html
@@ -14,7 +14,7 @@ $putctx("robots", "noindex,nofollow")
 <div id="contentBody">
 
     <form id="edittag" name="edit" method="post" action="" class="olform">
-        $:render_template("type/tag/tag_form_inputs", tag_name=page.name, tag_type=page.tag_type, tag_description=page.tag_description)
+        $:render_template("type/tag/tag_form_inputs", tag_name=page.name, tag_type=page.tag_type, tag_description=page.tag_description, fkey=page.fkey)
         <div class="clearfix"></div>
 
         <div class="formElement bottom">

--- a/openlibrary/templates/type/tag/edit.html
+++ b/openlibrary/templates/type/tag/edit.html
@@ -14,7 +14,7 @@ $putctx("robots", "noindex,nofollow")
 <div id="contentBody">
 
     <form id="edittag" name="edit" method="post" action="" class="olform">
-        $:render_template("type/tag/tag_form_inputs", tag_name=page.name, tag_type=page.tag_type, tag_description=page.tag_description, fkey=page.fkey)
+        $:render_template("type/tag/tag_form_inputs", tag_name=page.name, tag_type=page.tag_type, tag_description=page.tag_description, fkey=page.fkey, body=page.body)
         <div class="clearfix"></div>
 
         <div class="formElement bottom">

--- a/openlibrary/templates/type/tag/tag_form_inputs.html
+++ b/openlibrary/templates/type/tag/tag_form_inputs.html
@@ -1,4 +1,4 @@
-$def with (tag_name='', tag_type='', tag_description='', fkey=None, body='')
+$def with (tag_name='', tag_type='', tag_description='', fkey=None, body='', show_type_picker=True)
 
 <div class="formElement">
     <div class="label">
@@ -40,17 +40,18 @@ $def with (tag_name='', tag_type='', tag_description='', fkey=None, body='')
     </div>
 </div>
 
-<div class="formElement">
-    <div class="label"><label for="tag_type">$_("Tag type")</label></div>
-    <div class="input">
-        <select name="tag_type" id="tag_type" required>
-            <option value="">$_("Select")</option>
-            $ tag_types = get_tag_types()
-            $for t_type in tag_types:
-                $if t_type == tag_type:
-                    <option value="$t_type" selected>$t_type</option>
-                $else:
-                    <option value="$t_type">$t_type</option>
-        </select>
+$if show_type_picker:
+    <div class="formElement">
+        <div class="label"><label for="tag_type">$_("Tag type")</label></div>
+        <div class="input">
+            <select name="tag_type" id="tag_type" required>
+                <option value="">$_("Select")</option>
+                $ tag_types = get_tag_types()
+                $for t_type in tag_types:
+                    $if t_type == tag_type:
+                        <option value="$t_type" selected>$t_type</option>
+                    $else:
+                        <option value="$t_type">$t_type</option>
+            </select>
+        </div>
     </div>
-</div>

--- a/openlibrary/templates/type/tag/tag_form_inputs.html
+++ b/openlibrary/templates/type/tag/tag_form_inputs.html
@@ -1,4 +1,4 @@
-$def with (tag_name='', tag_type='', tag_description='')
+$def with (tag_name='', tag_type='', tag_description='', fkey=None)
 
 <div class="formElement">
     <div class="label">
@@ -19,6 +19,15 @@ $def with (tag_name='', tag_type='', tag_description='')
         </div>
     </div>
 </fieldset>
+
+<div class="formElement">
+    <div class="label">
+        <label for="fkey">$_("Subject Key")</label>
+    </div>
+    <div class="input">
+        <input type="text" value="$fkey" disabled>
+    </div>
+</div>
 
 <div class="formElement">
     <div class="label"><label for="tag_type">$_("Tag type")</label></div>

--- a/openlibrary/templates/type/tag/tag_form_inputs.html
+++ b/openlibrary/templates/type/tag/tag_form_inputs.html
@@ -1,4 +1,4 @@
-$def with (tag_name='', tag_type='', tag_description='', fkey=None)
+$def with (tag_name='', tag_type='', tag_description='', fkey=None, body='')
 
 <div class="formElement">
     <div class="label">
@@ -16,6 +16,17 @@ $def with (tag_name='', tag_type='', tag_description='', fkey=None)
         </div>
         <div class="input">
             <textarea id="tag_description" name="tag_description" class="markdown" rows="5" cols="80">$tag_description</textarea>
+        </div>
+    </div>
+</fieldset>
+
+<fieldset class="major">
+    <div class="formElement">
+        <div class="label">
+            <label for="page_body">$_("Page Body")</label>
+        </div>
+        <div class="input">
+            <textarea id="page_body" name="page_body" rows="5" cols="50" class="markdown">$body</textarea>
         </div>
     </div>
 </fieldset>

--- a/openlibrary/templates/type/tag/tag_form_inputs.html
+++ b/openlibrary/templates/type/tag/tag_form_inputs.html
@@ -15,7 +15,7 @@ $def with (tag_name='', tag_type='', tag_description='', fkey=None, body='')
             <label for="tag_description">$_("Tag Description")</label>
         </div>
         <div class="input">
-            <textarea id="tag_description" name="tag_description" class="markdown" rows="5" cols="80">$tag_description</textarea>
+            <textarea id="tag_description" name="tag_description" rows="5" cols="80">$tag_description</textarea>
         </div>
     </div>
 </fieldset>

--- a/openlibrary/templates/type/tag/view.html
+++ b/openlibrary/templates/type/tag/view.html
@@ -14,11 +14,4 @@ $else:
         <h3 itemprop="description">
             $tag.tag_description
         </h3>
-        $if tag.tag_type == 'subject':
-            $ subject_name = title.replace(' ', "_")
-            <footer>
-                <a href="/subjects/$subject_name">
-                    $_('View subject page for %(name)s.', name=title)
-                </a>
-            </footer>
     </div>

--- a/openlibrary/templates/type/tag/view.html
+++ b/openlibrary/templates/type/tag/view.html
@@ -3,19 +3,22 @@ $def with (tag)
 $var title: $tag.name
 $ title = tag.name
 
-<div id="contentHead">
-    $:macros.databarView(tag)
-    <h1 itemprop="name">
-        $title
-    </h1>
-    <h3 itemprop="description">
-        $tag.tag_description
-    </h3>
-    $if tag.tag_type == 'subject':
-        $ subject_name = title.replace(' ', "_")
-        <footer>
-            <a href="/subjects/$subject_name">
-                $_('View subject page for %(name)s.', name=title)
-            </a>
-        </footer>
-</div>
+$if tag.body:
+    $:tag.body
+$else:
+    <div id="contentHead">
+        $:macros.databarView(tag)
+        <h1 itemprop="name">
+            $title
+        </h1>
+        <h3 itemprop="description">
+            $tag.tag_description
+        </h3>
+        $if tag.tag_type == 'subject':
+            $ subject_name = title.replace(' ', "_")
+            <footer>
+                <a href="/subjects/$subject_name">
+                    $_('View subject page for %(name)s.', name=title)
+                </a>
+            </footer>
+    </div>


### PR DESCRIPTION
Addresses: #9685

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Makes the following changes to the subject page editing flow:
- Saves the subject key to the `fkey` field when a tag is created from a `/subjects/*` page
- Stores the subject page HTML on new Tag as `body`
- Adds a "Page Body" `textarea` to the tag form inputs
- Patrons are redirected to the `/tags/*` page when they navigate to a subject page that is linked to a `Tag`
- Updates subject page template edit button's copy to "Create Tag" when no linked tag is found

#### Limitations
- The "Page Body" field is not pre-populated with the subject page HTML

### Technical
<!-- What should be noted about the implementation? -->
`fkey` is meant to be immutable, and is displayed in a read-only input.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Try the following:
1. Navigate to a subject page that has no associated `Tag`.  Ensure that there is a "Create Tag" button in the upper-right corner of the content body.
2. Click the "Create Tag" button.  Leaving the "Page Body" field blank, submit the form.
3. Verify that you are viewing a `/tags/*` page, and that the subject page's body is being rendered.
4. Attempt to navigate back to the original subject page.  Verify that you are redirected to the linked `Tag` page.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/user-attachments/assets/72109d60-7771-409d-bde4-c11555b6c009)
_The "Create Tag" button_

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
