### PR TITLE
Attach keydown listeners to searchbar

### DIFF
--- a/openlibrary/plugins/openlibrary/js/SearchBar.js
+++ b/openlibrary/plugins/openlibrary/js/SearchBar.js
@@ -27,7 +27,7 @@ const RENDER_AUTOCOMPLETE_RESULT = {
     ['/search'](work) {
         const author_name = work.author_name ? work.author_name[0] : '';
         return `
-            <li>
+            <li tabindex=0>
                 <a href="${work.key}">
                     <img src="//covers.openlibrary.org/b/id/${work.cover_i}-S.jpg?default=https://openlibrary.org/static/images/icons/avatar_book-sm.png" alt=""/>
                     <span class="book-desc">
@@ -82,6 +82,51 @@ export class SearchBar {
         this.facet.sync(this.handleFacetValueChange.bind(this));
         this.$facetSelect.on('change', this.handleFacetSelectChange.bind(this));
         this.$form.on('submit', this.submitForm.bind(this));
+
+        // Shift + Tabbing out of the search facet to clear results list
+        this.$facetSelect.on('keydown', (e) => {
+            if (e.key === 'Tab' && e.shiftKey) {
+                this.clearAutocompletionResults();
+            }
+        })
+
+        this.$input.on('keydown', (e) => {
+            if (e.key === 'ArrowUp') {
+                this.$results.children().last().trigger('focus');
+                return false;
+            } else if (e.key === 'ArrowDown') {
+                this.$results.children().first().trigger('focus');
+                return false;
+            } else if (e.key === 'Escape') {
+                this.$input.trigger('blur');
+                this.clearAutocompletionResults();
+            }
+        })
+
+        this.$results.on('keydown', (e) => {
+            if (e.key === 'ArrowUp' || (e.key === 'Tab' && e.shiftKey)) {
+                if (!e.target.previousElementSibling) {
+                    this.$input.trigger('focus');
+                    return false;
+                } else {
+                    $(e.target.previousElementSibling).trigger('focus');
+                    return false;
+                }
+            } else if (e.key === 'ArrowDown' || (e.key === 'Tab' && !e.shiftKey)) {
+                if (!e.target.nextElementSibling) {
+                    this.$input.trigger('focus');
+                    return false;
+                } else {
+                    $(e.target.nextElementSibling).trigger('focus');
+                    return false;
+                }
+            } else if (e.key === 'Enter') {
+                e.target.firstElementChild.click();
+            } else if (e.key === 'Escape') {
+                this.$input.trigger('blur');
+                this.clearAutocompletionResults();
+            }
+        })
 
         this.initAutocompletionLogic();
     }


### PR DESCRIPTION
Closes #7916 
I have implemented the suggested behaviors from #7916 but would like to know if there are additional navigation features/more preferred navigation flows for this component. 

I wasn't entirely sure what the intended behavior should be when a user presses Tab while focused on the Form input field and left it as the default behavior.

Fix

### Technical
Implements the suggested keyboard functionality by attaching jQuery ```.on``` event handlers to listen for ```ArrowUp, ArrowDown, Escape, Tab, and Shift + Tab``` keycodes. ```tabindex``` has been attached to each ```li``` element to allow users to navigate the search bar results with their keyboard.

### Testing
Go to ```localhost:8080``` and use a search term that returns at least 3 titles. 
The expected behaviors are:
Form input <ArrowUp/ArrowDown> - Goes to the first or last item in the results list 
Form input <Escape\> - Removes focus from the search bar input, clears search results

Result li element <ArrowUp/Shift + Tab> - Navigates to the previous list sibling if exists, otherwise will focus on the Form input
Result li element <ArrowDown/Tab> - Navigates to the next list sibling if exists, otherwise will loop focus back to the Form input
Result li element <Enter> - Redirects the user to the title
Result li element <Escape> - Blurs focus from ```input[type="text"]``` and clears the results list.

Search facet <Shift + Tab> - Clears the results list since focus is no longer within the relevant search bar component

### Screenshot
This video demos all but the Result li element <Enter> keyboard behaviors.
https://github.com/user-attachments/assets/aa4c8261-b888-43b6-806a-5b4e28ff7424

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
