### PR TITLE
Fix /borrow?action=locate not working for logged out users

### DIFF
--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -132,6 +132,9 @@ class borrow(delegate.page):
 
         from openlibrary.book_providers import get_book_provider
 
+        if action == 'locate':
+            raise web.seeother(edition.get_worldcat_url())
+
         # Direct to the first web book if at least one is available.
         if (
             action in ["borrow", "read"]
@@ -198,8 +201,6 @@ class borrow(delegate.page):
             lending.s3_loan_api(s3_keys, ocaid=edition.ocaid, action='leave_waitlist')
             stats.increment('ol.loans.leaveWaitlist')
             raise web.redirect(edition_redirect)
-        elif action == 'locate':
-            raise web.seeother(edition.get_worldcat_url())
 
         elif action in ('borrow', 'browse') and not user.has_borrowed(edition):
             borrow_access = user_can_borrow_edition(user, edition)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9829, followup to #9842

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

Before, the `action=locate` check took place after authentication check meaning it required patrons to be logged in before using this method. We want /borrow?action=locate to be public (not be blocked by auth)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Incognito: https://testing.openlibrary.org/books/OL7826547M/A_Game_of_Thrones/borrow?action=locate

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
