### PR TITLE
Fix Polish messages.po to remove xpassing test results (all tests now pass)

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -6543,8 +6543,8 @@ msgstr ""
 msgid "Inventaire.io:"
 msgstr ""
 
-#: type/author/view.html
-msgid "Links <span class=\"gray small sansserif\">(outside Open Library)"
+#: type/author/view.html type/edition/view.html type/work/view.html
+msgid "Links <span class=\"gray small sansserif\">outside Open Library</span>"
 msgstr ""
 
 #: type/author/view.html type/edition/view.html type/work/view.html
@@ -6745,10 +6745,6 @@ msgstr ""
 
 #: type/edition/view.html type/work/view.html
 msgid "added anonymously."
-msgstr ""
-
-#: type/edition/view.html type/work/view.html
-msgid "Links <span class=\"gray small sansserif\">outside Open Library</span>"
 msgstr ""
 
 #: type/edition/view.html type/work/view.html

--- a/openlibrary/i18n/pl/messages.po
+++ b/openlibrary/i18n/pl/messages.po
@@ -341,7 +341,7 @@ msgid ""
 "href=\"%(url)s\">only ebooks</a>?"
 msgstr ""
 "Wczytywanie wszystkich prac autora. Czy chesz zobaczyć <a "
-"href=%(url)s>tylko e-booki</a>?"
+"href=\"%(url)s\">tylko e-booki</a>?"
 
 #: view.html:154
 #, fuzzy, python-format
@@ -350,7 +350,7 @@ msgid ""
 "href=\"%(url)s\">everything</a> by this author?"
 msgstr ""
 "Wczytywanie tylko e-booków. Czy chesz zobaczyć <a "
-"href=%(url)s>wszystkie</a> prace tego autora?"
+"href=\"%(url)s\">wszystkie</a> prace tego autora?"
 
 #: nav_foot.html:27 nav_head.html:72 openlibrary/templates/subjects.html:9
 #: openlibrary/templates/work_search.html:123 view.html:136 view.html:190
@@ -375,8 +375,8 @@ msgid "Time"
 msgstr "Okres"
 
 #: view.html:202
-msgid "Links <span class=\"gray small sansserif\">(outside Open Library)"
-msgstr "Linki <span class=\"gray small sansserif\">(spoza Open Library)"
+msgid "Links <span class=\"gray small sansserif\">(outside Open Library)</span>"
+msgstr "Linki <span class=\"gray small sansserif\">(spoza Open Library)</span>"
 
 #: view.html:221
 msgid "No links yet."
@@ -985,11 +985,6 @@ msgstr "%(title)s autorstwa %(authorlist)s"
 msgid "added anonymously."
 msgstr "dodana anonimowo"
 
-#: view.html:170
-#, fuzzy
-msgid "Links <span class=\"gray small sansserif\">outside Open Library</span>"
-msgstr "Linki <span class=\"gray small sansserif\">(spoza Open Library)"
-
 #: view.html:173
 msgid "Wikipedia"
 msgstr "Wikipedia"
@@ -1430,8 +1425,7 @@ msgid ""
 msgstr ""
 "Potwierdzam, że moje korzystanie z Open Library podlega warunkom Internet"
 " Archive<a href='//archive.org/about/terms.php' "
-"target='_new'title=„'Przeczytaj warunki użytkowania w nowej "
-"przeglądarce.'>Warunki użytkowania</a>."
+"target='_blank'>Warunki użytkowania</a>."
 
 #: add.html:79 add.html:135 authors.html:125 create.html:97
 #: edit/addfield.html:87 edit/addfield.html:133 edit/addfield.html:177
@@ -1759,9 +1753,9 @@ msgid ""
 "%(publisher)s edition</b>. Thanks! Do you know any more about this "
 "edition?"
 msgstr ""
-"<p class=\"alert thanks\">Już mamy tę książkę <b>%s</b>, ale nie te "
-"wydanie<b>%s %s edition</b>. Dziękujemy! Czy wiesz coś więcej o tym "
-"wydaniu?</p>"
+"Już mamy tę książkę <b>%(work_titles)s</b>, ale nie te "
+"wydanie<b>%(year)s %(publisher)s edition</b>. Dziękujemy! Czy wiesz coś więcej o tym "
+"wydaniu?"
 
 #: edit.html:75
 #, fuzzy, python-format
@@ -1769,8 +1763,8 @@ msgid ""
 "We already know about the <b>%(year)s %(publisher)s edition</b> of "
 "<b>%(work_title)s</b>, but please, tell us more!"
 msgstr ""
-"<p class=\"alert info\">Już znamy wydanie tej <b>%s %s edition</b> "
-"książki <b>%s</b>, ale prosimy o podanie więcej informacji!</p>"
+"Już znamy wydanie tej <b>%(year)s %(publisher)s edition</b> "
+"książki <b>%(work_title)s</b>, ale prosimy o podanie więcej informacji!"
 
 #: edit.html:77
 msgid "Editing..."
@@ -3791,7 +3785,7 @@ msgstr "Brak wyników."
 #: openlibrary/templates/work_search.html:220
 #, fuzzy, python-format
 msgid "Showing books with similar text to: <strong>%(query)s</strong>"
-msgstr "Książki zawierające tekst podobny do:"
+msgstr "Książki zawierające tekst podobny do: <strong>%(query)s</strong>"
 
 #: openlibrary/templates/work_search.html:258
 msgid "Zoom In"

--- a/openlibrary/i18n/test_po_files.py
+++ b/openlibrary/i18n/test_po_files.py
@@ -8,7 +8,7 @@ from openlibrary.i18n import get_locales
 
 root = os.path.dirname(__file__)
 # Fix these and then remove them from this list
-ALLOW_FAILURES = {'pl'}
+ALLOW_FAILURES = {}
 
 
 def trees_equal(el1: ET.Element, el2: ET.Element, error=True):

--- a/openlibrary/i18n/test_po_files.py
+++ b/openlibrary/i18n/test_po_files.py
@@ -8,7 +8,7 @@ from openlibrary.i18n import get_locales
 
 root = os.path.dirname(__file__)
 # Fix these and then remove them from this list
-ALLOW_FAILURES = {}
+ALLOW_FAILURES = []
 
 
 def trees_equal(el1: ET.Element, el2: ET.Element, error=True):

--- a/openlibrary/i18n/test_po_files.py
+++ b/openlibrary/i18n/test_po_files.py
@@ -7,8 +7,6 @@ import xml.etree.ElementTree as ET
 from openlibrary.i18n import get_locales
 
 root = os.path.dirname(__file__)
-# Fix these and then remove them from this list
-ALLOW_FAILURES = []
 
 
 def trees_equal(el1: ET.Element, el2: ET.Element, error=True):
@@ -72,13 +70,7 @@ def gen_html_entries():
     for locale, msgid, msgstr in gen_po_msg_pairs():
         if '</' not in msgid:
             continue
-
-        if locale in ALLOW_FAILURES:
-            yield pytest.param(
-                locale, msgid, msgstr, id=f'{locale}-{msgid}', marks=pytest.mark.xfail
-            )
-        else:
-            yield pytest.param(locale, msgid, msgstr, id=f'{locale}-{msgid}')
+        yield pytest.param(locale, msgid, msgstr, id=f'{locale}-{msgid}')
 
 
 @pytest.mark.parametrize("locale,msgid,msgstr", gen_html_entries())

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -194,7 +194,7 @@ $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_libra
         </div>
 
         <div class="section">
-            <h3>$:_('Links <span class="gray small sansserif">(outside Open Library)</span>')</h3>
+            <h3>$:_('Links <span class="gray small sansserif">outside Open Library</span>')</h3>
 
             $if page.links or (page.wikipedia and page.wikipedia.startswith("http")):
                 <ul class="booklinks sansserif">

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -194,7 +194,7 @@ $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_libra
         </div>
 
         <div class="section">
-            <h3>$:_('Links <span class="gray small sansserif">(outside Open Library)')</span></h3>
+            <h3>$:_('Links <span class="gray small sansserif">(outside Open Library)</span>')</h3>
 
             $if page.links or (page.wikipedia and page.wikipedia.startswith("http")):
                 <ul class="booklinks sansserif">


### PR DESCRIPTION
There were 54 xpassing tests (marked as expected to fail, but were passing).

They were caused by translation tests that had marked all messages.po Polish tests as failing, when most were passing.

Turns out there were 7 tests failing because quotation marks weren't present in the translated strings, and other minor XML closing / quoting issues.

This PR fixes them and enables all the tests to remove the xpassed count in the results.

BEFORE:
```
2099 passed, 9 skipped, 16 xfailed, 54 xpassed, 4842 warnings in 7.02s
```

AFTER:
```
2160 passed, 9 skipped, 9 xfailed, 4842 warnings in 6.72s
```

fix incorrectly quoted Polish translated strings
to remove xpassing test messages

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

I noticed this in another PR where I was using xpassing tests to notify when I'd fixed the bug. The 54 constantly xpassing tests were distracting.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
