### PR TITLE
Move `searchbox` default placeholder to body of template

### DIFF
--- a/openlibrary/templates/search/searchbox.html
+++ b/openlibrary/templates/search/searchbox.html
@@ -1,4 +1,7 @@
-$def with (q, placeholder=_('Search'))
+$def with (q, placeholder="")
+
+$ placeholder = placeholder or _('Search')
+
 <div class="searchbox">
     <input type="text" class="searchbox__input" name="q" size="100" placeholder="$placeholder" aria-label="$_('Search')" value="$q">
     <div>


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
May fix issue where the incorrect placeholder text is cached for pages that use the new search box component.

To reproduce the bug:
1. Navigate to https://openlibrary.org/search and verify that the placeholder text is the same in both the top nav search box and the search box in the content area.
2. Use the language selector to switch to another language.  Expect the placeholder text in the top nav to be localized, and the other box's placeholder text to remain unchanged.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Navigate to https://openlibrary.org/search
2. Use the language selector to switch languages
3. Verify that the placeholder text is correct

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
