### PR TITLE
more ad-hoc title filtering to avoid non-book imports, and exclude OTHER product class

### DIFF
--- a/scripts/partner_batch_imports.py
+++ b/scripts/partner_batch_imports.py
@@ -120,10 +120,7 @@ class Biblio:
     def __init__(self, data):
         self.primary_format = data[6]
         self.product_type = data[121]
-        assert (
-            self.primary_format not in self.NONBOOK
-            and 'OTH' not in self.product_type
-        ), f"{self.primary_format}/{self.product_type} is NONBOOK"
+        assert not self.isnonbook(), f"{self.primary_format}/{self.product_type} is NONBOOK"
 
         self.isbn = data[124]
         self.source_id = f'bwb:{self.isbn}'
@@ -187,6 +184,9 @@ class Biblio:
         # form list of author dicts
         authors = [make_author(*c) for c in contributors if c[0]]
         return authors
+
+    def isnonbook(self):
+        return self.primary_format in self.NONBOOK or 'OTH' in self.product_type
 
     def json(self):
         return {

--- a/scripts/partner_batch_imports.py
+++ b/scripts/partner_batch_imports.py
@@ -67,7 +67,9 @@ EXCLUDED_INDEPENDENTLY_PUBLISHED_TITLES = {
         'version',
         # Not a book
         'calendar',
+        'copy bin',
         'diary',
+        'dumpbin',
         'journal',
         'logbook',
         'notebook',

--- a/scripts/partner_batch_imports.py
+++ b/scripts/partner_batch_imports.py
@@ -120,7 +120,9 @@ class Biblio:
     def __init__(self, data):
         self.primary_format = data[6]
         self.product_type = data[121]
-        assert not self.isnonbook(), f"{self.primary_format}/{self.product_type} is NONBOOK"
+        assert (
+            not self.isnonbook()
+        ), f"{self.primary_format}/{self.product_type} is NONBOOK"
 
         self.isbn = data[124]
         self.source_id = f'bwb:{self.isbn}'

--- a/scripts/partner_batch_imports.py
+++ b/scripts/partner_batch_imports.py
@@ -118,11 +118,17 @@ class Biblio:
     VU VY VZ WA WC WI WL WM WP WT WX XL XZ ZF ZZ""".split()
 
     def __init__(self, data):
+        self.primary_format = data[6]
+        self.product_type = data[121]
+        assert (
+            self.primary_format not in self.NONBOOK
+            and 'OTH' not in self.product_type
+        ), f"{self.primary_format}/{self.product_type} is NONBOOK"
+
         self.isbn = data[124]
         self.source_id = f'bwb:{self.isbn}'
         self.isbn_13 = [self.isbn]
         self.title = data[10]
-        self.primary_format = data[6]
         self.publish_date = data[20][:4]  # YYYY
         self.publishers = [data[135]]
         self.weight = data[39]
@@ -161,9 +167,6 @@ class Biblio:
         # Assert importable
         for field in self.REQUIRED_FIELDS + ['isbn_13']:
             assert getattr(self, field), field
-        assert (
-            self.primary_format not in self.NONBOOK
-        ), f"{self.primary_format} is NONBOOK"
 
     @staticmethod
     def contributors(data):

--- a/scripts/tests/test_partner_batch_imports.py
+++ b/scripts/tests/test_partner_batch_imports.py
@@ -67,7 +67,8 @@ class TestBiblio:
     def test_non_books_rejected(self, input_):
         data = input_.strip().split('|')
         code = data[6]
-        with pytest.raises(AssertionError, match=f'{code} is NONBOOK'):
+        pclass = data[121]
+        with pytest.raises(AssertionError, match=f'{code}/{pclass} is NONBOOK'):
             _ = Biblio(data)
 
 


### PR DESCRIPTION
closes #9768

From looking at one recent data file, there were 264 titles containing "Dumpbin". Most of them were marked as 'Trade Paper'. 3 were marked as e-books.... so that kills my idea of having a format accept-list rather than the current NONBOOK reject list.

The data is not accurately annotated to be clear about what kind of item is being imported, which is disappointing.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

This PR 

* rejects 'Dumpbin' and 'Copy bin' titles, and confirms that the supplied format codes aren't sufficient to filter accurately because dumpbins look like books in this field.
* Adds a new 'Product class' check where `OTH` is included in these dumpbin items

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
