### PR TITLE
Add IMDb identifier support for Authors

### DIFF
--- a/openlibrary/plugins/openlibrary/config/author/identifiers.yml
+++ b/openlibrary/plugins/openlibrary/config/author/identifiers.yml
@@ -17,6 +17,11 @@ identifiers:
     notes: ''
     url: https://isni.org/isni/@@@
     website: https://isni.org/
+-   label: IMDb
+    name: imdb
+    notes: Should be something like nm0393654
+    url: https://www.imdb.com/name/@@@
+    website: https://www.imdb.com/
 -   label: Inventaire
     name: inventaire
     notes: two formats depending on if the author exists in wikidata, wd:Q42 or inv:914ad8068b8711ead0cc2efbed56e53c


### PR DESCRIPTION
Closes https://github.com/internetarchive/openlibrary/issues/9856

feature

### Technical

Adds support for IMDb identifiers in the `author/identifiers.yml` file.

### Testing

Edit an author and check that IMDb is available as an identifier.

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->

@jimchamp maybe?

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
