### PR TITLE
Add two more MARC21 language codes: den and mga

### DIFF
--- a/openlibrary/plugins/openlibrary/pages/languages.page
+++ b/openlibrary/plugins/openlibrary/pages/languages.page
@@ -617,6 +617,12 @@
     "key": "/languages/del"
   },
   {
+    "code": "den",
+    "type": "/type/language",
+    "name": "Slavey",
+    "key": "/languages/den"
+  },
+  {
     "code": "din",
     "type": "/type/language",
     "name": "Dinka",
@@ -1694,6 +1700,12 @@
     "type": "/type/language",
     "name": "Mende",
     "key": "/languages/men"
+  },
+  {
+    "code": "mga",
+    "type": "/type/language",
+    "name": "Irish, Middle (ca. 1100-1550)",
+    "key": "/languages/mga"
   },
   {
     "code": "mic",


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Adds language codes:
* den / Slavey https://en.wikipedia.org/wiki/Slavey_language
* mga / Middle Irish, https://en.wikipedia.org/wiki/Middle_Irish

Recent partner MARC record imports included some books in these languages. The MARC 21 codes are valid and listed at 
https://www.loc.gov/marc/languages/language_code.html

I have already added the data to the live site.

This PR commits the codes as a record of what codes OL currently recognises.


<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Successfully imported `mga` record:

https://openlibrary.org/books/OL53772901M/The_Book_of_Ballymote

Successfully imported `den` record:

https://openlibrary.org/books/OL53772927M/Dictionnaire_de_la_langue_d%C3%A8n%C3%A8-dindji%C3%A9



### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
