### PR TITLE
Remove ineffective strings in "Independently Published" exclusion list

### DIFF
--- a/scripts/partner_batch_imports.py
+++ b/scripts/partner_batch_imports.py
@@ -67,9 +67,7 @@ EXCLUDED_INDEPENDENTLY_PUBLISHED_TITLES = {
         'version',
         # Not a book
         'calendar',
-        'copy bin',
         'diary',
-        'dumpbin',
         'journal',
         'logbook',
         'notebook',


### PR DESCRIPTION
Reverts some recently added title match strings -- dumpbins are not independently published. These strings are very unlikely to match, but there is another method to reject these still in place, the `OTH` product class test. This removes the strings to avoid any confusion about whether they are effective.

via @cdrini 's comment:
https://github.com/internetarchive/openlibrary/pull/9850/files/eb3f33645b247c8fe70c3a71215b05e272f42c61#r1752032348

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
