### PR TITLE
No longer fail importing MARC records on unrecognised lang code

### DIFF
--- a/openlibrary/catalog/marc/parse.py
+++ b/openlibrary/catalog/marc/parse.py
@@ -337,18 +337,16 @@ def read_languages(rec: MarcBase, lang_008: str | None = None) -> list[str]:
     for f in rec.get_fields('041'):
         if f.ind2() == '7':
             code_source = ' '.join(f.get_subfield_values('2'))
-            # TODO: What's the best way to handle these?
-            raise MarcException("Non-MARC language code(s), source = ", code_source)
-            continue  # Skip anything which is using a non-MARC code source e.g. iso639-1
+            # TODO: Log or WARN rather than raise an exception.
+            # raise MarcException("Non-MARC language code(s), source = ", code_source)
         for value in f.get_subfield_values('a'):
+            value = value.replace(' ', '').replace('-', '')  # remove pad/separators
             if len(value) % 3 == 0:
                 # Obsolete cataloging practice was to concatenate all language codes in a single subfield
                 for k in range(0, len(value), 3):
                     code = value[k : k + 3].lower()
                     if code != 'zxx' and code not in found:
                         found.append(code)
-            else:
-                raise MarcException("Got non-multiple of three language code")
     return [lang_map.get(code, code) for code in found]
 
 

--- a/openlibrary/catalog/marc/parse.py
+++ b/openlibrary/catalog/marc/parse.py
@@ -340,6 +340,7 @@ def read_languages(rec: MarcBase, lang_008: str | None = None) -> list[str]:
         if f.ind2() == '7':
             code_source = ' '.join(f.get_subfield_values('2'))
             logger.error(f'Unrecognised language source = {code_source}')
+            continue  # Skip anything which is using a non-MARC code source e.g. iso639-1
         for value in f.get_subfield_values('a'):
             value = value.replace(' ', '').replace('-', '')  # remove pad/separators
             if len(value) % 3 == 0:


### PR DESCRIPTION
A handful of partner MARC records imports failed due to unrecognised values is `041$a`

Some were caused by spacing padding characters `" "` and `-`, others where just typos or single instances of data entered in the wrong field e.g.
`041    $aspine title: return re provincial subsidies, 1906.`

In these cases it would be better just to skip the unrecognised language value but still import the rest of the record. Language is not a required field.
Previously, the entire record was being rejected with an `Invalid MARC` exception, which is too extreme (and not correct -- the MARC is otherwise totally valid)

@cdrini Is there an existing mechanism to log warnings somewhere to record when some of these unexpected values  are encountered? Sometimes they can indicate missing language codes we should add, or other systematic issues we should consider handling.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
