### PR TITLE
Fixed Read More Button Display Logic to Avoid Unnecessary Display

### DIFF
--- a/openlibrary/plugins/openlibrary/js/readmore.js
+++ b/openlibrary/plugins/openlibrary/js/readmore.js
@@ -55,7 +55,7 @@ export class ReadMoreComponent {
         this.fullHeight = this.$content.scrollHeight;
         // Fudge factor to account for non-significant read/more
         // (e.g missing a bit of padding)
-        if (this.$content.scrollHeight <= (this.collapsedHeight + 1)) {
+        if (this.$content.scrollHeight <= (this.collapsedHeight + this.$readMoreButton.offsetHeight + 1)) {
             this.expand();
             this.$container.classList.add('read-more--unnecessary');
         } else {

--- a/openlibrary/plugins/openlibrary/js/readmore.js
+++ b/openlibrary/plugins/openlibrary/js/readmore.js
@@ -55,7 +55,7 @@ export class ReadMoreComponent {
         this.fullHeight = this.$content.scrollHeight;
         // Fudge factor to account for non-significant read/more
         // (e.g missing a bit of padding)
-        if (this.$content.scrollHeight <= (this.collapsedHeight + this.$readMoreButton.offsetHeight + 1)) {
+        if (this.$content.scrollHeight <= (this.collapsedHeight + (this.$readMoreButton?.offsetHeight | 0) + 1)) {
             this.expand();
             this.$container.classList.add('read-more--unnecessary');
         } else {

--- a/openlibrary/plugins/openlibrary/js/readmore.js
+++ b/openlibrary/plugins/openlibrary/js/readmore.js
@@ -55,7 +55,7 @@ export class ReadMoreComponent {
         this.fullHeight = this.$content.scrollHeight;
         // Fudge factor to account for non-significant read/more
         // (e.g missing a bit of padding)
-        if (this.$content.scrollHeight <= (this.collapsedHeight + (this.$readMoreButton?.offsetHeight | 0) + 1)) {
+        if (this.$content.scrollHeight <= (this.collapsedHeight + (this.$readMoreButton.offsetHeight || 0) + 1)) {
             this.expand();
             this.$container.classList.add('read-more--unnecessary');
         } else {


### PR DESCRIPTION
Closes #9329
## Description

This PR addresses an issue where the "Read more" button was displayed even when it made the section longer than the fully expanded content. This led to a confusing user experience, as the "Read more" button was not serving its intended purpose. The following changes have been made to resolve this issue:

## Changes

1. **Capture "Read More" Button Height**:
    - The height of the "Read more" button is now captured during initialization to ensure accurate calculations.

2. **Update Condition in `reset` Method**:
    - The logic that determines whether the "Read more" button should be displayed has been updated to include the height of the button. This ensures the button is only shown when it makes sense.

## Impact

- **Improved User Experience**: The "Read more" button is now only displayed when necessary, preventing unnecessary clutter and confusion.
- **Correct Layout Behavior**: Ensures the layout behaves as expected, with the "Read more" button enhancing usability rather than detracting from it.

## Testing
To test visit a link like https://testing.openlibrary.org/books/OL8978501M/Robin_Hood


## Screenshots
![Screenshot from 2024-07-25 18-43-42](https://github.com/user-attachments/assets/fd72ad9e-2e81-4208-9622-44f93840f087)


