### PR TITLE
Changed h6 to h3 in subject tags for better accessibility, and updated CSS

### DIFF
--- a/openlibrary/macros/RelatedSubjects.html
+++ b/openlibrary/macros/RelatedSubjects.html
@@ -17,6 +17,6 @@ $def renderSubjects(subjects):
 
 $for category, label, limit in subject_list:
     <div class="contentQuarter link-box link-box--with-header">
-      <h6 class="black collapse uppercase">$label</h6>
+      <h3 class="black collapse uppercase">$label</h3>
       $:renderSubjects(page[category][:limit])
     </div>

--- a/openlibrary/macros/SubjectTags.html
+++ b/openlibrary/macros/SubjectTags.html
@@ -4,7 +4,7 @@ $def render_subjects(label, subjects, track_value, prefix=""):
   $if subjects:
     <div class="section link-box">
       <span class="clamp" data-before="&#9656; ">
-      <h6>$label</h6>
+      <h3>$label</h3>
         $for subject in subjects:
           <a href="/subjects/$prefix$utf8(subject.lower().replace(' ', '_').replace(',', '').replace('/', ''))" data-ol-link-track="$track_value">$subject</a>$cond(not loop.last, ",", "")
       </span>

--- a/openlibrary/templates/publishers/view.html
+++ b/openlibrary/templates/publishers/view.html
@@ -61,7 +61,7 @@ $ subject_list = [('subjects', 20), ('places', 20), ('people', 10), ('times', 10
 
     $for s, limit in subject_list:
         <div class="contentQuarter link-box link-box--with-header">
-            <h6>$s</h6>
+            <h3>$s</h3>
             $:renderSubjects(page[s][:limit])
         </div>
         $if s != 'times':

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -157,7 +157,7 @@ $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_libra
         $def render_subjects(label, subjects, prefix):
             $if subjects:
                 <div class="section link-box link-box--with-header">
-                    <h6 class="collapse black uppercase">$label</h6>
+                    <h3 class="collapse black uppercase">$label</h3>
                     $for _, subject, count in subjects:
                         <a itemprop="knowsAbout" href="/subjects/$prefix$subject.lower().replace(' ', '_')">$subject</a>$cond(not loop.last, ",", "")
                 </div>

--- a/static/css/components/link-box.less
+++ b/static/css/components/link-box.less
@@ -7,7 +7,7 @@
   white-space: normal;
   word-wrap: break-word;
 
-  h6 {
+  h3 {
     color: @grey;
     margin: 0;
     padding: 0;
@@ -16,7 +16,7 @@
     font-size: @font-size-label-medium;
   }
 
-  &.link-box--with-header h6 {
+  &.link-box--with-header h3 {
     display: block;
   }
 }


### PR DESCRIPTION
### Summary

This request addresses issue #9636, where subject tags and headings were incorrectly marked with `h6` tags. The changes improve accessibility and SEO by updating heading structure to use `h3` instead of `h6`.

### Changes:
- Updated `h6` tags to `h3` in the following:
  - `author/view.html`
  - `publishers/view.html`
  - `macros/SubjectTags.html`
  - `macros/RelatedSubjects.html`
- Updated CSS in `link-box.less` to apply styles to `h3` instead of `h6`.

### Testing
- Verified that tags are now h3 on local web.
- No visual changes in appearance.
