### PR TITLE
Fix find by IA id failing due to un-escaped $

### DIFF
--- a/openlibrary/templates/admin/people/index.html
+++ b/openlibrary/templates/admin/people/index.html
@@ -42,7 +42,7 @@ input#ia-id {
         <td>$_("IA ID:")</td>
         <td>
             <form method="GET" name="form-ia-id">
-                <input type="text" name="ia_id" id="ia-id" pattern="^@.*$" placeholder="$_('e.g. @foobar')">
+                <input type="text" name="ia_id" id="ia-id" pattern="^@.*\$" placeholder="$_('e.g. @foobar')">
                 <button type="submit">$_("Find")</button>
                 <span class="invalid">
                     $if ia_id:


### PR DESCRIPTION
The un-escaped $ was causing the `"` to effectively be ignored.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
