### PR TITLE
Unescape HTML entities in search result page titles.

### DIFF
--- a/openlibrary/plugins/openlibrary/js/search.js
+++ b/openlibrary/plugins/openlibrary/js/search.js
@@ -78,7 +78,9 @@ export function initSearchFacets(facetsElem) {
                 facetsElem.replaceWith(newFacetsElem)
                 hydrateFacets()
 
-                document.title = data.title
+                // Replace HTML entities with plaintext equivalent
+                const titleElem = new DOMParser().parseFromString(data.title, 'text/html').documentElement;
+                document.title = titleElem.textContent;
             })
             .catch(() => {
                 // XXX : Handle case where `/partials` response is not `2XX` here


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9787.

### Technical
<!-- What should be noted about the implementation? -->
This parses the title with [DOMParser](https://developer.mozilla.org/en-US/docs/Web/API/DOMParser) to unescape any HTML entities that might get mistakenly created in the search process. This implementation avoids XSS attempts as it takes advantage of the browser's HTML parser directly as opposed to fiddling with the document's DOM to make a workaround.

I attempted to seek out why this might be the case to begin with but admittedly I didn't get very far. It's unclear to me whether the fetched partials are always escaped HTML (even to the extent of the title), but I'm not sure if that's due to my unfamiliarity with the codebase or if this is intended behavior to avoid XSS.

Also, just to note, in my local testing I had to coerce the search box to display the query in the title. Most of the time it just displayed "search" until I managed to get it to show up by adding a subject.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
| Before | After |
| ------ | ----- |
| <img width="852" alt="image" src="https://github.com/user-attachments/assets/19038225-5090-4774-8135-e06e31175112"> | <img width="850" alt="image" src="https://github.com/user-attachments/assets/c5b34f67-1b3c-4d6c-9ef2-e0e2581172dd"> |

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
