### PR TITLE
Update pagination style and kb navigation for editions table

### DIFF
--- a/openlibrary/plugins/openlibrary/js/editions-table/index.js
+++ b/openlibrary/plugins/openlibrary/js/editions-table/index.js
@@ -41,6 +41,37 @@ export function initEditionsTable() {
         localStorage.setItem(LS_RESULTS_LENGTH_KEY, length);
     });
 
+    $('#editions thead tr th').attr('tabindex', '0');
+    $('#editions thead tr th a').attr('tabindex', '-1');
+
+    $('#editions th').on('keydown', function(e) {
+        if (e.key === 'Tab' && !e.shiftKey) {
+            if (e.target.nextElementSibling) {
+                e.preventDefault();
+                $(e.target.nextElementSibling).trigger('focus');
+            }
+        }
+        if (e.key === 'ArrowLeft') {
+            if (e.target.previousElementSibling) {
+                $(e.target.previousElementSibling).trigger('focus');
+            }
+        }
+        if (e.key === 'ArrowRight') {
+            if (e.target.nextElementSibling) {
+                $(e.target.nextElementSibling).trigger('focus');
+            }
+        }
+        if (e.key === 'Enter') {
+            $('#editions th span').html('');
+            $(this).find('span').html('&nbsp;&uarr;');
+            if ($(this).hasClass('sorting_asc')) {
+                $(this).find('span').html('&nbsp;&darr;');
+            } else if ($(this).hasClass('sorting_desc')) {
+                $(this).find('span').html('&nbsp;&uarr;');
+            }
+        }
+    })
+
     rowCount = $('#editions tbody tr').length;
     if (rowCount < 4) {
         $('#editions').DataTable({
@@ -54,7 +85,6 @@ export function initEditionsTable() {
         });
     } else {
         currentLength = Number(localStorage.getItem(LS_RESULTS_LENGTH_KEY));
-
         $('#editions').DataTable({
             aoColumns: [{sType: 'html'},null],
             order: [ [1,'asc'] ],

--- a/static/css/components/editions.less
+++ b/static/css/components/editions.less
@@ -23,6 +23,12 @@ table#editions,
 
     tr {
       background: linear-gradient(0deg, @lightest-grey, transparent);
+      th.read:focus {
+        outline: revert
+      }
+      th.title:focus {
+        outline: revert
+      }
     }
   }
 
@@ -237,4 +243,14 @@ tbody {
 
 .editions-table__links {
   text-align: center;
+}
+
+a.paginate_button.current {
+  background-color: @lightest-grey;
+  border: 1px solid @lighter-grey;
+  color: @black;
+}
+
+#editions_paginate a.paginate_button {
+  border: none;
 }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Addresses #9853 tasks 1 and 3
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Refactor

### Technical
<!-- What should be noted about the implementation? -->
Adds a background to pagination button to make it easier for users to see which page they are currently viewing.

Prevents users from tabbing into the ```a``` element within the editions table header row, and adds an outline for the currently focused element within the row. Arrow keys left and right can be also used to switch between the two header rows.

Pressing enter within a section of the table header row will now update the arrow indicator for ascending/descending order.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Go to a works page and scroll down to the editions table. 

Verify that the current paginated button has a grey background with black text. 

Tab into the editions table header row and use Enter/ArrowLeft/ArrowRight/Tab/Shift + Tab to test added keyboard navigation.
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

https://github.com/user-attachments/assets/3dc352db-800c-449c-bf64-1aff3e42ebd7


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
