### PR TITLE
Fix Magic Select binding for Editions DataTable

### DIFF
--- a/openlibrary/plugins/openlibrary/js/editions-table/index.js
+++ b/openlibrary/plugins/openlibrary/js/editions-table/index.js
@@ -80,9 +80,28 @@ export function initEditionsTable() {
             bAutoWidth: false,
             pageLength: currentLength ? currentLength : DEFAULT_LENGTH,
             drawCallback: function() {
-                if ($('#ile-toolbar').css('display') === 'none') {
-                    for (const elem of $('.ile-selected')) {
-                        elem.classList.remove('ile-selected');
+                if ($('#ile-toolbar')) {
+                    const editionStorage = JSON.parse(sessionStorage.getItem('ile-items'))['edition']
+                    const matchEdition = (string) => {
+                        return string.match(/OL[0-9]+[a-zA-Z]/)
+                    }
+                    for (const el of $('.ile-selected')) {
+                        const anchor = el.getElementsByTagName('a');
+                        if (anchor.length) {
+                            const edIdentifier = matchEdition(anchor[0].getAttribute('href'))
+                            if (!editionStorage.includes(edIdentifier[0])) {
+                                el.classList.remove('ile-selected');
+                            }
+                        }
+                    }
+                    for (const el of $('.ile-selectable')) {
+                        const anchor = el.getElementsByTagName('a');
+                        if (anchor.length) {
+                            const edIdentifier = matchEdition(anchor[0].getAttribute('href'));
+                            if (editionStorage.includes(edIdentifier[0])) {
+                                el.classList.add('ile-selected');
+                            }
+                        }
                     }
                 }
             }

--- a/openlibrary/plugins/openlibrary/js/editions-table/index.js
+++ b/openlibrary/plugins/openlibrary/js/editions-table/index.js
@@ -6,7 +6,11 @@ const LS_RESULTS_LENGTH_KEY = 'editions-table.resultsLength';
 
 export function initEditionsTable() {
     var rowCount;
-
+    let currentLength;
+    // Prevent reinitialization of the editions datatable
+    if ($.fn.DataTable.isDataTable($('#editions'))) {
+        return;
+    }
     $('#editions th.title').on('mouseover', function(){
         if ($(this).hasClass('sorting_asc')) {
             $(this).attr('title','Sort latest to earliest');
@@ -42,7 +46,6 @@ export function initEditionsTable() {
     });
 
     $('#editions').on('length.dt', function(e, settings, length) {
-        togglePaginationVisibility(length);
         localStorage.setItem(LS_RESULTS_LENGTH_KEY, length);
     });
 
@@ -53,31 +56,36 @@ export function initEditionsTable() {
     })
 
     rowCount = $('#editions tbody tr').length;
-    const currentLength = Number(localStorage.getItem(LS_RESULTS_LENGTH_KEY)) || DEFAULT_LENGTH;
-
-    $('#editions').DataTable({
-        aoColumns: [{ sType: 'html' }, null],
-        order: [[1, 'asc']],
-        lengthMenu: [[3, 10, 25, 50, 100, -1], [3, 10, 25, 50, 100, 'All']],
-        bPaginate: true, // Always allow pagination initially
-        bInfo: true,
-        sPaginationType: 'full_numbers',
-        bFilter: true,
-        bStateSave: false,
-        bAutoWidth: false,
-        pageLength: currentLength,
-    });
-
-    // Toggle pagination visibility based on row count and selected length
-    function togglePaginationVisibility(selectedLength) {
-        const paginationElement = $('.dataTables_paginate.paging_full_numbers');
-        if (rowCount <= selectedLength || selectedLength === -1) {
-            paginationElement.hide();
-        } else {
-            paginationElement.show();
-        }
+    if (rowCount < 4) {
+        $('#editions').DataTable({
+            aoColumns: [{sType: 'html'},null],
+            order: [ [1,'asc'] ],
+            bPaginate: false,
+            bInfo: false,
+            bFilter: false,
+            bStateSave: false,
+            bAutoWidth: false
+        });
+    } else {
+        currentLength = Number(localStorage.getItem(LS_RESULTS_LENGTH_KEY));
+        $('#editions').DataTable({
+            aoColumns: [{sType: 'html'},null],
+            order: [ [1,'asc'] ],
+            lengthMenu: [ [3, 10, 25, 50, 100, -1], [3, 10, 25, 50, 100, 'All'] ],
+            bPaginate: true,
+            bInfo: true,
+            sPaginationType: 'full_numbers',
+            bFilter: true,
+            bStateSave: false,
+            bAutoWidth: false,
+            pageLength: currentLength ? currentLength : DEFAULT_LENGTH,
+            drawCallback: function() {
+                if ($('#ile-toolbar').css('display') === 'none') {
+                    for (const elem of $('.ile-selected')) {
+                        elem.classList.remove('ile-selected');
+                    }
+                }
+            }
+        })
     }
-
-    // Initial pagination visibility toggle
-    togglePaginationVisibility(currentLength);
 }

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -79,11 +79,11 @@ jQuery(function () {
 
     init($);
 
-    // conditionally load functionality based on what's in the page
-    if (document.getElementsByClassName('editions-table--progressively-enhanced').length) {
-        import(/* webpackChunkName: "editions-table" */ './editions-table')
-            .then(module => module.initEditionsTable());
-    }
+    // // conditionally load functionality based on what's in the page
+    // if (document.getElementsByClassName('editions-table--progressively-enhanced').length) {
+    //     import(/* webpackChunkName: "editions-table" */ './editions-table')
+    //         .then(module => module.initEditionsTable());
+    // }
 
     const edition = document.getElementById('addWork');
     const autocompleteAuthor = document.querySelector('.multi-input-autocomplete--author');
@@ -329,8 +329,17 @@ jQuery(function () {
     if (document.getElementsByClassName('show-librarian-tools').length) {
         import(/* webpackChunkName: "ile" */ './ile')
             .then((module) => module.init());
+        // Import ile then the datatable to apply clickable classes to all listed editions
+        if (document.getElementsByClassName('editions-table--progressively-enhanced').length) {
+            import(/* webpackChunkName: "editions-table" */ './editions-table')
+                .then(module => module.initEditionsTable())
+        }
     }
-
+    // conditionally load functionality based on what's in the page
+    if (document.getElementsByClassName('editions-table--progressively-enhanced').length) {
+        import(/* webpackChunkName: "editions-table" */ './editions-table')
+            .then(module => module.initEditionsTable());
+    }
     if ($('#cboxPrevious').length) {
         $('#cboxPrevious').attr({'aria-label': 'Previous button', 'aria-hidden': 'true'});
     }

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -79,12 +79,6 @@ jQuery(function () {
 
     init($);
 
-    // // conditionally load functionality based on what's in the page
-    // if (document.getElementsByClassName('editions-table--progressively-enhanced').length) {
-    //     import(/* webpackChunkName: "editions-table" */ './editions-table')
-    //         .then(module => module.initEditionsTable());
-    // }
-
     const edition = document.getElementById('addWork');
     const autocompleteAuthor = document.querySelector('.multi-input-autocomplete--author');
     const autocompleteLanguage = document.querySelector('.multi-input-autocomplete--language');

--- a/static/css/components/editions.less
+++ b/static/css/components/editions.less
@@ -48,7 +48,7 @@ table#editions,
 
   td.book {
     vertical-align: top;
-    display: inline-flex;
+    display: table-cell;
   }
 
   div.cover {
@@ -164,6 +164,15 @@ table#editions,
       float: left;
     }
 
+  }
+}
+
+@media only screen and (max-width: @width-breakpoint-desktop) {
+  table#editions {
+    td.book {
+      width: 100%;
+      display: inline-flex;
+    }
   }
 }
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Addresses #9853 Task 5

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix

### Technical
<!-- What should be noted about the implementation? -->
Initializes the ILE/SelectionManager classes before the Editions DataTable to allow the ILE to bind the click events and add class names to the relevant DOM elements. 

Prevents the Editions DataTable from re-initialization with .isDataTable method.

Utilizes the ```drawCallback``` option for DataTables to remove visual inconsistencies when a user selects editions from multiple pages, clicks on clear selection, and re-navigates to a page that had a previously selected edition by checking the sessionStorage object.


### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Sign in with the admin account and navigate to a work that has >3 editions (the more the better).

Verify that the magic select editions beyond the first page of the Editions Table.

Press the ```Clear Selection``` button within the magic select toolbar on the bottom of the page.

Navigate back to the pages where the editions were previously selected. The magic select classes and styling should not be present anymore.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

https://github.com/user-attachments/assets/9e4dd155-e41a-4a91-902c-8c6a84939cf2


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
