### PR TITLE
use dictionary to generate language list

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -4775,55 +4775,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: languages/language_list.html
-msgid "Czech"
-msgstr ""
-
-#: languages/language_list.html
-msgid "German"
-msgstr ""
-
-#: languages/language_list.html
-msgid "English"
-msgstr ""
-
-#: languages/language_list.html
-msgid "Spanish"
-msgstr ""
-
-#: languages/language_list.html
-msgid "French"
-msgstr ""
-
-#: languages/language_list.html
-msgid "Croatian"
-msgstr ""
-
-#: languages/language_list.html
-msgid "Italian"
-msgstr ""
-
-#: languages/language_list.html
-msgid "Portuguese"
-msgstr ""
-
-#: languages/language_list.html
-msgid "Hindi"
-msgstr ""
-
-#: languages/language_list.html
-msgid "Sardinian"
-msgstr ""
-
-#: languages/language_list.html
-msgid "Telugu"
-msgstr ""
-
-#: languages/language_list.html
-msgid "Ukrainian"
-msgstr ""
-
-#: languages/language_list.html
-msgid "Chinese"
+msgid "localized"
 msgstr ""
 
 #: languages/notfound.html

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -4774,10 +4774,6 @@ msgid_plural "%s books"
 msgstr[0] ""
 msgstr[1] ""
 
-#: languages/language_list.html
-msgid "localized"
-msgstr ""
-
 #: languages/notfound.html
 #, python-format
 msgid "%s is not found"

--- a/openlibrary/templates/languages/language_list.html
+++ b/openlibrary/templates/languages/language_list.html
@@ -1,17 +1,6 @@
 $def with (classes='')
 
 <ul class="locale-options $classes">
-  <li><a href="#" lang="cs" data-lang-id="cs" title="$_('Czech')">Čeština (cs)</a></li> $# detect-missing-i18n-skip-line
-  <li><a href="#" lang="de" data-lang-id="de" title="$_('German')">Deutsch (de)</a></li> $# detect-missing-i18n-skip-line
-  <li><a href="#" lang="en" data-lang-id="en" title="$_('English')">English (en)</a></li> $# detect-missing-i18n-skip-line
-  <li><a href="#" lang="es" data-lang-id="es" title="$_('Spanish')">Español (es)</a></li> $# detect-missing-i18n-skip-line
-  <li><a href="#" lang="fr" data-lang-id="fr" title="$_('French')">Français (fr)</a></li> $# detect-missing-i18n-skip-line
-  <li><a href="#" lang="hr" data-lang-id="hr" title="$_('Croatian')">Hrvatski (hr)</a></li> $# detect-missing-i18n-skip-line
-  <li><a href="#" lang="it" data-lang-id="it" title="$_('Italian')">Italiano (it)</a></li> $# detect-missing-i18n-skip-line
-  <li><a href="#" lang="pt" data-lang-id="pt" title="$_('Portuguese')">Português (pt)</a></li> $# detect-missing-i18n-skip-line
-  <li><a href="#" lang="hi" data-lang-id="hi" title="$_('Hindi')">हिंदी (hi)</a></li> $# detect-missing-i18n-skip-line
-  <li><a href="#" lang="sc" data-lang-id="sc" title="$_('Sardinian')">Sardu (sc)</a></li> $# detect-missing-i18n-skip-line
-  <li><a href="#" lang="te" data-lang-id="te" title="$_('Telugu')">తెలుగు (te)</a></li> $# detect-missing-i18n-skip-line
-  <li><a href="#" lang="uk" data-lang-id="uk" title="$_('Ukrainian')">Українська (uk)</a></li> $# detect-missing-i18n-skip-line
-  <li><a href="#" lang="zh" data-lang-id="zh" title="$_('Chinese')">中文 (zh)</a></li> $# detect-missing-i18n-skip-line
+  $for lang_code, lang_data in supported_langs.items():
+    <li><a href="#" lang="$lang_code" data-lang-id="$lang_code" title="$_(lang_data['localized'])">$(lang_data['native']) ($lang_code)</a></li> $# detect-missing-i18n-skip-line
 </ul>

--- a/openlibrary/templates/languages/language_list.html
+++ b/openlibrary/templates/languages/language_list.html
@@ -1,6 +1,6 @@
 $def with (classes='')
 
 <ul class="locale-options $classes">
-  $for lang_code, lang_data in supported_langs.items():
-    <li><a href="#" lang="$lang_code" data-lang-id="$lang_code" title="$_(lang_data['localized'])">$(lang_data['native']) ($lang_code)</a></li> $# detect-missing-i18n-skip-line
+  $for lang in get_supported_languages().values():
+    <li><a href="#" lang="$lang['code']" data-lang-id="$lang['code']" title="$lang['localized']">$lang['native'] ($lang['code'])</a></li> $# detect-missing-i18n-skip-line
 </ul>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Related to #9864 #9868

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Now that we have a dictionary with the list of languages

https://github.com/internetarchive/openlibrary/blob/3b89202a3618dbc6c077f76da900f55a4ec024dd/openlibrary/plugins/openlibrary/code.py#L1255C1-L1269C6

We can refactor the language list

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot (360)](https://github.com/user-attachments/assets/6a30efe4-dfa1-4a47-a4c4-1a6e4bc77488)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
