### PR TITLE
Fix `BulkTagger` menu option bug

### DIFF
--- a/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
+++ b/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
@@ -324,7 +324,7 @@ export class BulkTagger {
         let stagedTagIndex
         switch (menuOption.optionState) {
         case MenuOptionState.NONE_TAGGED:
-            stagedTagIndex = this.tagsToRemove.findIndex((tag) => (tag.tagName === menuOption.tag.tagname && tag.tagType === menuOption.tag.tagType))
+            stagedTagIndex = this.tagsToRemove.findIndex((tag) => (tag.tagName === menuOption.tag.tagName && tag.tagType === menuOption.tag.tagType))
             if (stagedTagIndex > -1) {
                 this.tagsToRemove.splice(stagedTagIndex, 1)
             }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9891

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Corrects misspelled tag property, which was preventing tags from being removed from the `tagsToRemove` array.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged-in with an account that can use the bulk tagger:
1. Navigate to a search result page.
2. Select at least one work.
3. Click the "Tag Works" button to open the bulk tagger.
4. Click on an existing menu option to stage the tag for removal.
5. Click the same menu option to stage the tag for addition.
6. Close the bulk tagger.
7. Open the bulk tagger again.  Verify that there are no duplicate menu options.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
