### PR TITLE
Add current page's path to component times table

### DIFF
--- a/openlibrary/macros/Profile.html
+++ b/openlibrary/macros/Profile.html
@@ -17,5 +17,10 @@ $def with (component_times)
         $# detect-missing-i18n-skip-line
         <td>$("%.2f" % (component[1] / component_times['TotalTime'] * 100.))</td>
       </tr>
+    <tr>
+        $# detect-missing-i18n-skip-line
+        <td>Path:</td>
+        <td colspan="2">$ctx.path</td>
+    </tr>
   </tbody>
 </table>


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds the current page's path to the bottom of the component times table.  This may help when screenshots of the table are included with requests for assistance.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/user-attachments/assets/f204dc37-a9ea-4ac4-bdb2-3282282424d7)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
