### PR TITLE
Remove deprecated naive datetime warnings

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -122,7 +122,7 @@ def create_link_doc(key, username, email):
     """
     code = generate_uuid()
 
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now()
     expires = now + datetime.timedelta(days=14)
 
     return {

--- a/openlibrary/core/bookshelves_events.py
+++ b/openlibrary/core/bookshelves_events.py
@@ -141,7 +141,7 @@ class BookshelvesEvents(db.CommonExtras):
                 cls.TABLENAME,
                 where='id=$id',
                 vars={'id': pid},
-                updated=datetime.utcnow(),
+                updated=datetime.now(),
                 **updates,
             )
         return 0
@@ -152,7 +152,7 @@ class BookshelvesEvents(db.CommonExtras):
 
         where_clause = 'id=$id'
         where_vars = {'id': pid}
-        update_time = datetime.utcnow()
+        update_time = datetime.now()
 
         return oldb.update(
             cls.TABLENAME,
@@ -167,7 +167,7 @@ class BookshelvesEvents(db.CommonExtras):
 
         where_clause = 'id=$id'
         where_vars = {'id': pid}
-        update_time = datetime.utcnow()
+        update_time = datetime.now()
 
         return oldb.update(
             cls.TABLENAME,

--- a/openlibrary/core/processors/invalidation.py
+++ b/openlibrary/core/processors/invalidation.py
@@ -74,7 +74,7 @@ class InvalidationProcessor:
         self.timeout = datetime.timedelta(0, timeout)
 
         self.cookie_name = cookie_name
-        self.last_poll_time = datetime.datetime.utcnow()
+        self.last_poll_time = datetime.datetime.now()
         self.last_update_time = self.last_poll_time
 
         # set expire_time slightly more than timeout
@@ -106,7 +106,7 @@ class InvalidationProcessor:
         return handler()
 
     def is_timeout(self):
-        t = datetime.datetime.utcnow()
+        t = datetime.datetime.now()
         dt = t - self.last_poll_time
         return dt > self.timeout
 
@@ -124,7 +124,7 @@ class InvalidationProcessor:
 
     def reload(self):
         """Triggers on_new_version event for all the documents modified since last_poll_time."""
-        t = datetime.datetime.utcnow()
+        t = datetime.datetime.now()
         reloaded = False
 
         keys = []

--- a/openlibrary/core/yearly_reading_goals.py
+++ b/openlibrary/core/yearly_reading_goals.py
@@ -100,7 +100,7 @@ class YearlyReadingGoals:
             where=where,
             vars=data,
             current=current_count,
-            updated=datetime.utcnow(),
+            updated=datetime.now(),
         )
 
     @classmethod
@@ -118,7 +118,7 @@ class YearlyReadingGoals:
             where=where,
             vars=data,
             target=new_target,
-            updated=datetime.utcnow(),
+            updated=datetime.now(),
         )
 
     # Delete methods:

--- a/openlibrary/mocks/mock_infobase.py
+++ b/openlibrary/mocks/mock_infobase.py
@@ -1,13 +1,14 @@
 """Simple implementation of mock infogami site to use in testing.
 """
 
-import datetime
 import glob
 import itertools
 import json
 import re
 import pytest
 import web
+
+from datetime import datetime
 
 from infogami.infobase import client, common, account, config as infobase_config
 from infogami import config
@@ -79,7 +80,7 @@ class MockSite:
     def save(
         self, query, comment=None, action=None, data=None, timestamp=None, author=None
     ):
-        timestamp = timestamp or datetime.datetime.utcnow()
+        timestamp = timestamp or datetime.now()
 
         if author:
             author = {"key": author.key}
@@ -102,7 +103,7 @@ class MockSite:
     def save_many(
         self, query, comment=None, action=None, data=None, timestamp=None, author=None
     ):
-        timestamp = timestamp or datetime.datetime.utcnow()
+        timestamp = timestamp or datetime.now()
         docs = [self._save_doc(doc, timestamp) for doc in query]
 
         if author:

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from datetime import datetime, timezone
+import datetime
 import functools
 from pathlib import Path
 import re
@@ -110,7 +110,7 @@ def setup():
         "Software version": get_software_version(),
         "Python version": sys.version.split()[0],
         "Host": host,
-        "Start time": datetime.now(timezone.utc),
+        "Start time": datetime.datetime.now(datetime.UTC),
     }
     feature_flags = get_features_enabled()
 

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-import datetime
+from datetime import datetime, timezone
 import functools
 from pathlib import Path
 import re
@@ -110,7 +110,7 @@ def setup():
         "Software version": get_software_version(),
         "Python version": sys.version.split()[0],
         "Host": host,
-        "Start time": datetime.datetime.utcnow(),
+        "Start time": datetime.now(timezone.utc),
     }
     feature_flags = get_features_enabled()
 

--- a/openlibrary/solr/updater/work.py
+++ b/openlibrary/solr/updater/work.py
@@ -233,9 +233,9 @@ def datetimestr_to_int(datestr):
         try:
             t = h.parse_datetime(datestr)
         except (TypeError, ValueError):
-            t = datetime.datetime.utcnow()
+            t = datetime.datetime.now()
     else:
-        t = datetime.datetime.utcnow()
+        t = datetime.datetime.now()
 
     return int(time.mktime(t.timetuple()))
 

--- a/openlibrary/tests/core/test_processors_invalidation.py
+++ b/openlibrary/tests/core/test_processors_invalidation.py
@@ -17,12 +17,12 @@ class MockHook:
 
 
 class MockDatetime:
-    """Class to mock datetime.datetime to overwrite utcnow method."""
+    """Class to mock datetime.datetime to overwrite now() method."""
 
-    def __init__(self, utcnow):
-        self._now = utcnow
+    def __init__(self, mock_now):
+        self._now = mock_now
 
-    def utcnow(self):
+    def now(self):
         return self._now
 
 
@@ -73,7 +73,7 @@ class TestInvalidationProcessor:
 
     def test_reload_on_timeout(self, monkeypatch):
         # create the processor at 60 seconds past in time
-        mock_now = datetime.datetime.utcnow() - datetime.timedelta(seconds=60)
+        mock_now = datetime.datetime.now() - datetime.timedelta(seconds=60)
         monkeypatch.setattr(datetime, "datetime", MockDatetime(mock_now))
 
         p = invalidation.InvalidationProcessor(prefixes=['/templates'], timeout=60)
@@ -99,7 +99,7 @@ class TestInvalidationProcessor:
 
     def test_is_timeout(self, monkeypatch):
         # create the processor at 60 seconds past in time
-        mock_now = datetime.datetime.utcnow() - datetime.timedelta(seconds=60)
+        mock_now = datetime.datetime.now() - datetime.timedelta(seconds=60)
         monkeypatch.setattr(datetime, "datetime", MockDatetime(mock_now))
 
         p = invalidation.InvalidationProcessor(prefixes=['/templates'], timeout=60)
@@ -135,7 +135,7 @@ class TestInvalidationProcessor:
         assert self.hook.call_count == 0
 
         web.ctx.env['HTTP_COOKIE'] = (
-            "invalidation_cookie=" + datetime.datetime.utcnow().isoformat()
+            "invalidation_cookie=" + datetime.datetime.now().isoformat()
         )
         # Clear parsed cookie cache to force our new value to be parsed
         if "_parsed_cookies" in web.ctx:


### PR DESCRIPTION
DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).

These warnings were appearing ~4000 times in test results, `datetime.utcnow()` is deprecated in Python 3.12
For some background: https://blog.miguelgrinberg.com/post/it-s-time-for-a-change-datetime-utcnow-is-now-deprecated

This fixes the warnings caused by code in this repo. I _think_ it doesn't introduce any new problems, but `utcnow()` was used in a range of places, having others review these changes would be helpful, in case there is a subtle impact from format changes I have missed.

**BEFORE:**

2162 passed, 9 skipped, 9 xfailed, 4891 warnings in 6.21s 


**AFTER:**

2162 passed, 9 skipped, 9 xfailed, 20 warnings in 6.18s 



Remaining utcnow() deprecation warnings are in external repos: Infogami and webpy:
```
openlibrary/plugins/admin/tests/test_code.py::TestRevertAllUserEdits::test_no_edits
openlibrary/plugins/admin/tests/test_code.py::TestRevertAllUserEdits::test_deletes_spam_works
openlibrary/plugins/admin/tests/test_code.py::TestRevertAllUserEdits::test_deletes_spam_works
openlibrary/plugins/admin/tests/test_code.py::TestRevertAllUserEdits::test_reverts_spam_edits
openlibrary/plugins/admin/tests/test_code.py::TestRevertAllUserEdits::test_reverts_spam_edits
openlibrary/plugins/admin/tests/test_code.py::TestRevertAllUserEdits::test_does_not_undelete
openlibrary/plugins/admin/tests/test_code.py::TestRevertAllUserEdits::test_two_spammy_editors
openlibrary/plugins/admin/tests/test_code.py::TestRevertAllUserEdits::test_two_spammy_editors
  /openlibrary/infogami/infobase/account.py:87: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    now = datetime.utcnow()

openlibrary/tests/core/test_db.py::TestCheckIns::test_update_event_date
openlibrary/tests/core/test_db.py::TestYearlyReadingGoals::test_update_current_count
openlibrary/tests/core/test_db.py::TestYearlyReadingGoals::test_update_target
openlibrary/tests/core/test_imports.py::TestBatchItem::test_add_items_legacy
  /home/openlibrary/.local/lib/python3.12/site-packages/web/db.py:487: DeprecationWarning: The default timestamp converter is deprecated as of Python 3.12; see the sqlite3 documentation for suggested replacement recipes
    row = self.cursor.fetchone()
```



<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
