### PR TITLE
Add authors, subtitle, and description to TOC on books page

### DIFF
--- a/openlibrary/core/lists/model.py
+++ b/openlibrary/core/lists/model.py
@@ -14,7 +14,7 @@ from infogami.utils import stats
 
 from openlibrary.core import helpers as h
 from openlibrary.core import cache
-from openlibrary.core.models import Image, Subject, Thing, ThingKey
+from openlibrary.core.models import Image, Subject, Thing, ThingKey, ThingReferenceDict
 from openlibrary.plugins.upstream.models import Author, Changeset, Edition, User, Work
 
 from openlibrary.plugins.worksearch.search import get_solr
@@ -22,10 +22,6 @@ from openlibrary.plugins.worksearch.subjects import get_subject
 import contextlib
 
 logger = logging.getLogger("openlibrary.lists.model")
-
-
-class ThingReferenceDict(TypedDict):
-    key: ThingKey
 
 
 SeedSubjectString = str

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -8,7 +8,7 @@ from openlibrary.core.vendors import get_amazon_metadata
 import web
 import json
 import requests
-from typing import Any
+from typing import Any, TypedDict
 from collections import defaultdict
 from dataclasses import dataclass, field
 
@@ -217,6 +217,10 @@ class Thing(client.Thing):
             "h": self._get_history_preview(),
             "l": self._get_lists_cached(),
         }
+
+
+class ThingReferenceDict(TypedDict):
+    key: ThingKey
 
 
 class Edition(Thing):

--- a/openlibrary/macros/TableOfContents.html
+++ b/openlibrary/macros/TableOfContents.html
@@ -1,4 +1,4 @@
-$def with (table_of_contents, ocaid=None, highlighting=False, cls='', attrs='')
+$def with (table_of_contents, ocaid=None, cls='', attrs='')
 
 $ min_level = min(chapter.level for chapter in table_of_contents)
 <div class="toc $cls" $:attrs>
@@ -19,17 +19,13 @@ $ min_level = min(chapter.level for chapter in table_of_contents)
           $ label = chapter.label
           $if label and not label.endswith('.'):
             $ label = label.strip() + '. '
-          $if highlighting:
-            $# This isn't html injection, because solr returns everything already html escaped except for the em of the highlight
-            $:label
-            $:chapter.title
-          $else:
-            <div class="toc__title">$label $chapter.title</div>
 
-            $if chapter.subtitle:
-              <div class="toc__subtitle">$chapter.subtitle</div>
-            $if chapter.authors:
-              <div class="toc__authors">$:macros.BookByline(chapter.authors)</div>
+          <div class="toc__title">$label $chapter.title</div>
+
+          $if chapter.subtitle:
+            <div class="toc__subtitle">$chapter.subtitle</div>
+          $if chapter.authors:
+            <div class="toc__authors">$:macros.BookByline(chapter.authors)</div>
         </div>
         $if chapter.pagenum:
           <span class="toc__dots"></span>

--- a/openlibrary/macros/TableOfContents.html
+++ b/openlibrary/macros/TableOfContents.html
@@ -3,29 +3,40 @@ $def with (table_of_contents, ocaid=None, highlighting=False, cls='', attrs='')
 $ min_level = min(chapter.level for chapter in table_of_contents)
 <div class="toc $cls" $:attrs>
   $for chapter in table_of_contents:
-    $ is_link = ocaid and chapter.pagenum and chapter.pagenum.isdigit()
-    $ tag = 'a' if is_link else 'div'
-    <$tag
+    <div
       class="toc__entry"
-      $:cond(is_link, 'href="//archive.org/details/%s/page/%s"' % (ocaid, chapter.pagenum))
-      $:cond(is_link, 'data-ol-link-track="BookPage|TOCClick"')
       data-level="$chapter.level"
       style="margin-left:$((chapter.level - min_level) * 2)ch"
     >
-      <span class="toc__name">
-        $ label = chapter.label
-        $if label and not label.endswith('.'):
-          $ label = label.strip() + '. '
-        $if highlighting:
-          $# This isn't html injection, because solr returns everything already html escaped except for the em of the highlight
-          $:label
-          $:chapter.title
-        $else:
-          $label
-          $chapter.title
-      </span>
-      $if chapter.pagenum:
-        <span class="toc__dots" style="flex:1; border-bottom: 1px dotted;"></span>
-        <span class="toc__pagenum">$_('Page %s', chapter.pagenum)</span>
-    </$tag>
+      $ is_link = ocaid and chapter.pagenum and chapter.pagenum.isdigit()
+      $ tag = 'a' if is_link else 'div'
+      <$tag
+        class="toc__main"
+        $:cond(is_link, 'href="//archive.org/details/%s/page/%s"' % (ocaid, chapter.pagenum))
+        $:cond(is_link, 'data-ol-link-track="BookPage|TOCClick"')
+      >
+        <div class="toc__name">
+          $ label = chapter.label
+          $if label and not label.endswith('.'):
+            $ label = label.strip() + '. '
+          $if highlighting:
+            $# This isn't html injection, because solr returns everything already html escaped except for the em of the highlight
+            $:label
+            $:chapter.title
+          $else:
+            <div class="toc__title">$label $chapter.title</div>
+
+            $if chapter.subtitle:
+              <div class="toc__subtitle">$chapter.subtitle</div>
+            $if chapter.authors:
+              <div class="toc__authors">$:macros.BookByline(chapter.authors)</div>
+        </div>
+        $if chapter.pagenum:
+          <span class="toc__dots"></span>
+          <span class="toc__pagenum">$_('Page %s', chapter.pagenum)</span>
+      </$tag>
+
+      $if chapter.description:
+        <div class="toc__description">$chapter.description</div>
+    </div>
 </div>

--- a/openlibrary/plugins/upstream/table_of_contents.py
+++ b/openlibrary/plugins/upstream/table_of_contents.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass
+from typing import TypedDict
+
+from openlibrary.core.models import ThingReferenceDict
+
+
+class AuthorRecord(TypedDict):
+    name: str
+    author: ThingReferenceDict | None
+
+
+@dataclass
+class TocEntry:
+    level: int
+    label: str | None = None
+    title: str | None = None
+    pagenum: str | None = None
+
+    authors: list[AuthorRecord] | None = None
+    subtitle: str | None = None
+    description: str | None = None
+
+    @staticmethod
+    def from_dict(d: dict) -> 'TocEntry':
+        return TocEntry(
+            level=d.get('level', 0),
+            label=d.get('label'),
+            title=d.get('title'),
+            pagenum=d.get('pagenum'),
+            authors=d.get('authors'),
+            subtitle=d.get('subtitle'),
+            description=d.get('description'),
+        )
+
+    def is_empty(self) -> bool:
+        return all(
+            getattr(self, field) is None
+            for field in self.__annotations__
+            if field != 'level'
+        )

--- a/static/css/components/toc.less
+++ b/static/css/components/toc.less
@@ -2,28 +2,71 @@
 @import (reference) "../less/colors.less";
 
 .toc__entry {
+  line-height: 1.2em;
+
   border-radius: 4px;
   padding: 3px 8px;
   @media only screen and (hover: none) {
-    padding: 6px 8px; /* Increase padding for touch-only devices */
+    padding: 8px; /* Increase padding for touch-only devices */
   }
-  display: flex;
-  gap: 4px;
-  line-height: 1.2em;
-  transition: background-color .2s;
 
   em {
     font-weight: bold;
   }
+
+  .toc__main {
+    display: flex;
+    gap: 4px;
+    position: relative;
+  }
+
+  .toc__dots {
+    flex: 1;
+    border-bottom: 1px dotted;
+    height: 1.2em;
+  }
+
+  .toc__subtitle {
+    font-style: oblique;
+    color: @accessible-grey;
+  }
+
+  .toc__subtitle, .toc__authors, .toc__description {
+    font-size: @font-size-label-large;
+    text-decoration: none;
+  }
+
+  .toc__description {
+    margin-top: 5px;
+  }
 }
 
-a.toc__entry {
+a.toc__main {
   text-decoration: none;
-  .toc__name {
+  border-radius: 4px;
+
+  .toc__title {
     text-decoration: underline;
   }
-  &:hover {
-    background: rgba(0, 124, 255, .2);
+
+  &:hover:after {
+    display: block;
+    content: "";
+    inset: -2px;
+    position: absolute;
+    border-radius: 4px;
+    pointer-events: none;
+    animation: fade-in .2s;
+    background-color: rgba(0, 124, 255, .15);
+  }
+}
+
+@keyframes fade-in {
+  from {
+    background-color: rgba(0, 124, 255, 0);
+  }
+  to {
+    background-color: rgba(0, 124, 255, .15);
   }
 }
 
@@ -33,6 +76,10 @@ a.toc__entry {
 
 @media (max-width: @width-breakpoint-mobile) {
   .toc__entry {
+    padding: 8px 0;
+  }
+
+  .toc__main {
     flex-direction: column;
     gap: 0;
   }
@@ -42,7 +89,7 @@ a.toc__entry {
   }
 
   .toc__pagenum {
-    font-size: .9em;
+    font-size: @font-size-label-large;
     color: @accessible-grey;
   }
 }

--- a/static/css/components/toc.less
+++ b/static/css/components/toc.less
@@ -10,10 +10,6 @@
     padding: 8px; /* Increase padding for touch-only devices */
   }
 
-  em {
-    font-weight: bold;
-  }
-
   .toc__main {
     display: flex;
     gap: 4px;


### PR DESCRIPTION
Part of #8756
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Update the UI to handler rendering a table of contents chapter's subtitle, author, and description.

### Technical
- Also removed an unused argument, `highlighting`
- Create a dataclass to contain `TocEntry` logic. This will be expanded in future PRs as part of this project to handle things like markdown parsing, etc.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
eg
- https://testing.openlibrary.org/books/OL9462467M/Great_Irish_Stories_of_Childhood

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/user-attachments/assets/148a357a-e92d-42c5-9320-b3a898b9170a)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
