### PR TITLE
Nginx: add rate limiting

### DIFF
--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -73,6 +73,8 @@ services:
       - ../olsystem:/olsystem
       - /1:/1
     deploy:
+      # Note: the replicas here must be kept in sync with the `upstream covers_backend`
+      # value in `docker/covers_nginx.conf`.
       replicas: 2
 
   covers_nginx:

--- a/docker/covers_nginx.conf
+++ b/docker/covers_nginx.conf
@@ -38,7 +38,7 @@ server {
       error_page 429 = @429;
       location @429 {
         default_type application/json;
-        return 429 '{"status": 429, "message": "Too Many Requests. Consider using https://openlibrary.org/developers/dumps."}';
+        return 429 '{"status": 429, "message": "Too Many Requests. Please email us at info@archive.org"}';
       }
 
       location / {

--- a/docker/covers_nginx.conf
+++ b/docker/covers_nginx.conf
@@ -60,12 +60,6 @@ server {
            return 444;
         }
 
-        # Handle denied requests by returning a 444 response instead of 403
-        error_page 403 =444 /empty;
-        location = /empty {
-            internal;
-            return 444;
-        }
 
         # Covers rate limit.
         limit_req zone=cover_limit burst=400 nodelay;

--- a/docker/covers_nginx.conf
+++ b/docker/covers_nginx.conf
@@ -17,6 +17,8 @@ server {
 }
 
 # Docker's internal load balancing ends up with unbalanced connections eventually.
+# This must be kept in sync with the `replicas` value in `compose.production.yaml`
+# for the `covers` service.
 upstream covers_backend {
   least_conn;
   server openlibrary-covers-1:7075;

--- a/docker/covers_nginx.conf
+++ b/docker/covers_nginx.conf
@@ -16,6 +16,13 @@ server {
     ssl_prefer_server_ciphers on;
 }
 
+# Docker's internal load balancing ends up with unbalanced connections eventually.
+upstream covers_backend {
+  least_conn;
+  server openlibrary-covers-1:7075;
+  server openlibrary-covers-2:7075;
+}
+
 server {
       listen 80;
       listen 443;
@@ -25,8 +32,15 @@ server {
 
       keepalive_timeout 5;
 
+      # Return 429 errors as JSON.
+      error_page 429 = @429;
+      location @429 {
+        default_type application/json;
+        return 429 '{"status": 429, "message": "Too Many Requests. Consider using https://openlibrary.org/developers/dumps."}';
+      }
+
       location / {
-        proxy_pass http://covers:7075;
+        proxy_pass http://covers_backend;
         proxy_set_header Host $http_host;
 
         # Gunicorn takes IP from this header
@@ -37,8 +51,23 @@ server {
         proxy_set_header X-Scheme $scheme;
 
         if ($http_user_agent ~ (Bytespider) ) {
-           return 429;
+           return 444;
         }
+
+        if ($http_user_agent ~ (CloudFront) ) {
+           return 444;
+        }
+
+        # Handle denied requests by returning a 444 response instead of 403
+        error_page 403 =444 /empty;
+        location = /empty {
+            internal;
+            return 444;
+        }
+
+        # Covers rate limit.
+        limit_req zone=cover_limit burst=400 nodelay;
+        limit_req_status 444;
       }
 
       location ^~ /.well-known/acme-challenge/ {

--- a/docker/covers_nginx.conf
+++ b/docker/covers_nginx.conf
@@ -69,7 +69,7 @@ server {
 
         # Covers rate limit.
         limit_req zone=cover_limit burst=400 nodelay;
-        limit_req_status 444;
+        limit_req_status 429;
       }
 
       location ^~ /.well-known/acme-challenge/ {

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -11,7 +11,7 @@ error_log  /var/log/nginx/error.log;
 pid        /var/run/nginx.pid;
 
 events {
-    worker_connections  1024;
+    worker_connections  2048;
     # multi_accept on;
 }
 
@@ -43,6 +43,25 @@ http {
 
     # Black-listed IPs
     include /olsystem/etc/nginx/deny.conf;
+
+    # Rate limiting: https://nginx.org/en/docs/http/ngx_http_limit_req_module.html
+    # No rate limit when IP obfuscation is not applied, as every IP is 255.0.0.0.
+    # These rules only do anything if invoked, e.g., in web_nginx.conf.
+    # TLDR: these rules can be disabled in `docker/web_nginx.conf`
+    # and `docker/covers_nginx.conf`.
+    geo $should_apply_limit {
+      255.0.0.0 0;
+      default 1;
+    }
+
+    map $should_apply_limit $rate_limit_key {
+      0 '';
+      1 $binary_remote_addr;
+    }
+
+    limit_req_zone $rate_limit_key zone=web_limit:10m rate=200r/m;
+    # Set a more permissive limit for covers because some pages might load 20+ covers.
+    limit_req_zone $rate_limit_key zone=cover_limit:10m rate=400r/m;
 
     # Things are mounted into here by the docker compose file
     include /etc/nginx/sites-enabled/*;

--- a/docker/web_nginx.conf
+++ b/docker/web_nginx.conf
@@ -84,7 +84,7 @@ server {
         proxy_set_header X-Scheme $scheme;
 
         if ($http_user_agent ~ (Bytespider) ) {
-           return 429;
+           return 444;
         }
 
 

--- a/docker/web_nginx.conf
+++ b/docker/web_nginx.conf
@@ -96,7 +96,7 @@ server {
 
         # Web rate limit.
         limit_req zone=web_limit burst=200 nodelay;
-        limit_req_status 444;
+        limit_req_status 429;
     }
 
     location ^~ /.well-known/acme-challenge/ {

--- a/docker/web_nginx.conf
+++ b/docker/web_nginx.conf
@@ -87,12 +87,6 @@ server {
            return 429;
         }
 
-        # Handle denied requests by returning a 444 response instead of 403
-        error_page 403 =444 /empty;
-        location = /empty {
-            internal;
-            return 444;
-        }
 
         # Web rate limit.
         limit_req zone=web_limit burst=200 nodelay;

--- a/docker/web_nginx.conf
+++ b/docker/web_nginx.conf
@@ -64,6 +64,14 @@ server {
     if ($api_call = "http:noapi") {
         rewrite ^(.*)$ https://$http_host$1 last;
     }
+
+    # Return 429 errors as JSON.
+    error_page 429 = @429;
+    location @429 {
+      default_type application/json;
+      return 429 '{"status": 429, "message": "Too Many Requests. Consider using https://openlibrary.org/developers/dumps."}';
+    }
+
     location / {
         proxy_pass http://webnodes;
         proxy_set_header Host $http_host;
@@ -78,6 +86,17 @@ server {
         if ($http_user_agent ~ (Bytespider) ) {
            return 429;
         }
+
+        # Handle denied requests by returning a 444 response instead of 403
+        error_page 403 =444 /empty;
+        location = /empty {
+            internal;
+            return 444;
+        }
+
+        # Web rate limit.
+        limit_req zone=web_limit burst=200 nodelay;
+        limit_req_status 444;
     }
 
     location ^~ /.well-known/acme-challenge/ {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9562 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature. Adds rate limiting. See https://blog.nginx.org/blog/rate-limiting-nginx and https://nginx.org/en/docs/http/ngx_http_limit_req_module.html

### Technical
<!-- What should be noted about the implementation? -->
We may wish to rely on `429` and `403` as distinct status codes rather than commingle them in `444`.

We may also wish to revisit whether blocking CloudFront could actually increase load on our servers, given as a CDN it _may_ be closer to some patrons.

Additionally, and probably as distinct from this PR, we may wish to consider drastically increasing the `cache-control` value for cover images, as it's currently 10800 seconds, or 3 hours, when it could probably be a year, on the perhaps mistaken theory cover images don't change. Though perhaps that would just fill up patron's caches, unless we conditionally set the `cache-control` value for CDNs. Anyway, another issue.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Make a lot of requests and observe the responses (it can take a while to finally start getting rate limited): `seq 2000 | xargs -n 1 -P 100 bash -c 'curl https://openlibrary.org/api/books.json\?bibkeys\=ISBN:9781094376196\&jscmd\=data\&format\=json'`

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles
@cdrini 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
