### PR TITLE
reject Amazon dvd imports

### DIFF
--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -291,6 +291,12 @@ class AmazonAPI:
                 ).lower()
             ),
         }
+
+        if (
+            book['product_group'].lower() == 'dvd'
+            or book['physical_format'].lower() == 'dvd'
+        ):
+            return {}
         return book
 
 

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -292,12 +292,29 @@ class AmazonAPI:
             ),
         }
 
-        if (
-            book['product_group'].lower() == 'dvd'
-            or book['physical_format'].lower() == 'dvd'
-        ):
+        if is_dvd(book):
             return {}
         return book
+
+
+def is_dvd(book) -> bool:
+    """
+    If product_group or physical_format is a dvd, it will return True.
+    """
+    product_group = book['product_group']
+    physical_format = book['physical_format']
+
+    try:
+        product_group = product_group.lower()
+    except AttributeError:
+        product_group = None
+
+    try:
+        physical_format = physical_format.lower()
+    except AttributeError:
+        physical_format = None
+
+    return 'dvd' in [product_group, physical_format]
 
 
 @public

--- a/openlibrary/tests/core/test_vendors.py
+++ b/openlibrary/tests/core/test_vendors.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from unittest.mock import patch
 
 import pytest
@@ -6,6 +7,7 @@ from openlibrary.core.vendors import (
     split_amazon_title,
     clean_amazon_metadata_for_load,
     betterworldbooks_fmt,
+    AmazonAPI,
 )
 
 
@@ -257,3 +259,91 @@ def test_get_amazon_metadata() -> None:
     ):
         got = get_amazon_metadata(id_=isbn, id_type="isbn")
         assert got == expected
+
+
+@dataclass
+class ProductGroup:
+    display_value: str | None
+
+
+@dataclass
+class Binding:
+    display_value: str | None
+
+
+@dataclass
+class Classifications:
+    product_group: ProductGroup | None
+    binding: Binding
+
+
+@dataclass
+class ItemInfo:
+    classifications: Classifications | None
+    content_info: str
+    by_line_info: str
+    title: str
+
+
+@dataclass
+class AmazonAPIReply:
+    item_info: ItemInfo
+    images: str
+    offers: str
+    asin: str
+
+
+@pytest.mark.parametrize(
+    ("product_group", "expected"),
+    [
+        ('dvd', {}),
+        ('DVD', {}),
+        ('Dvd', {}),
+    ],
+)
+def test_clean_amazon_metadata_does_not_load_DVDS_product_group(
+    product_group, expected
+) -> None:
+    """Ensure data load does not load dvds and relies on fake API response objects"""
+    dvd_product_group = ProductGroup(product_group)
+    classification = Classifications(
+        product_group=dvd_product_group, binding=Binding('')
+    )
+    item_info = ItemInfo(
+        classifications=classification, content_info='', by_line_info='', title=''
+    )
+    amazon_metadata = AmazonAPIReply(
+        item_info=item_info,
+        images='',
+        offers='',
+        asin='',
+    )
+    result = AmazonAPI.serialize(amazon_metadata)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    ("physical_format", "expected"),
+    [
+        ('dvd', {}),
+        ('DVD', {}),
+        ('Dvd', {}),
+    ],
+)
+def test_clean_amazon_metadata_does_not_load_DVDS_physical_format(
+    physical_format, expected
+) -> None:
+    dvd_product_group = ProductGroup('isolate_physical_format')
+    binding = Binding(physical_format)
+    classification = Classifications(product_group=dvd_product_group, binding=binding)
+    item_info = ItemInfo(
+        classifications=classification, content_info='', by_line_info='', title=''
+    )
+    amazon_metadata = AmazonAPIReply(
+        item_info=item_info,
+        images='',
+        offers='',
+        asin='',
+    )
+    result = AmazonAPI.serialize(amazon_metadata)
+    assert result == expected

--- a/openlibrary/tests/core/test_vendors.py
+++ b/openlibrary/tests/core/test_vendors.py
@@ -8,6 +8,7 @@ from openlibrary.core.vendors import (
     clean_amazon_metadata_for_load,
     betterworldbooks_fmt,
     AmazonAPI,
+    is_dvd,
 )
 
 
@@ -347,3 +348,28 @@ def test_clean_amazon_metadata_does_not_load_DVDS_physical_format(
     )
     result = AmazonAPI.serialize(amazon_metadata)
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    ("physical_format", "product_group", "expected"),
+    [
+        ('dvd', 'dvd', True),
+        (None, None, False),
+        ('Book', 'Book', False),
+        ('DVD', None, True),
+        ('Dvd', None, True),
+        ('dvd', None, True),
+        ('Book', 'dvd', True),
+        (None, 'dvd', True),
+        (None, 'Book', False),
+        ('dvd', 'book', True),
+    ],
+)
+def test_is_dvd(physical_format, product_group, expected):
+    book = {
+        'physical_format': physical_format,
+        'product_group': product_group,
+    }
+
+    got = is_dvd(book)
+    assert got is expected


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9879 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Prevents dvds from being imported from the Amazon API. They were previously being imported as books.

### Technical
If Product_group OR Physical_format match 'dvd' it will not be imported.

### Testing
unit tests included in tests_vendors.py 


### Stakeholders
@scottbarnes 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
