### PR TITLE
Update bulk tagger for collections

### DIFF
--- a/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
+++ b/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
@@ -16,6 +16,12 @@ import { FadingToast } from '../Toast'
 const maxDisplayResults = 25;
 
 /**
+ * Subject labels that begin with this string are identified as type `collection`.
+ * @type {string}
+ */
+const COLLECTION_PREFIX = "collectionID:";
+
+/**
  * Represents the Bulk Tagger tool.
  *
  * The Bulk Tagger tool allows librarians to add or remove subjects in batches.
@@ -245,6 +251,13 @@ export class BulkTagger {
                         subject_people: data.subject_people || [],
                         subject_places: data.subject_places || [],
                         subject_times: data.subject_times || []
+                    }
+                    // Move collection labels from `subjects` to `collections`
+                    entry.collections = entry.subjects.filter((label) => label.startsWith(COLLECTION_PREFIX))
+                    entry.subjects = entry.subjects.filter((label) => !entry.collections.includes(label))
+                    for (let i = 0; i < entry.collections.length; ++i) {
+                        // Remove collection prefix from label
+                        entry.collections[i] = entry.collections[i].substring(COLLECTION_PREFIX.length)
                     }
                     if (!this.existingSubjects.has(id)) {
                         this.existingSubjects.set(id, [])
@@ -551,6 +564,8 @@ export class BulkTagger {
             subject_places: this.findMatches(this.tagsToAdd, 'subject_places'),
             subject_times: this.findMatches(this.tagsToAdd, 'subject_times')
         }
+        const collectionsToAdd = this.findMatches(this.tagsToAdd, 'collections')
+        collectionsToAdd.forEach(label => addSubjectsValue.subjects.push(`${COLLECTION_PREFIX}${label}`))
         this.addSubjectsInput.value = JSON.stringify(addSubjectsValue)
 
         const removeSubjectsValue = {
@@ -559,6 +574,8 @@ export class BulkTagger {
             subject_places: this.findMatches(this.tagsToRemove, 'subject_places'),
             subject_times: this.findMatches(this.tagsToRemove, 'subject_times')
         }
+        const collectionsToRemove = this.findMatches(this.tagsToRemove, 'collections')
+        collectionsToRemove.forEach(label => removeSubjectsValue.subjects.push(`${COLLECTION_PREFIX}${label}`))
         this.removeSubjectsInput.value = JSON.stringify(removeSubjectsValue)
     }
 

--- a/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
+++ b/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
@@ -19,7 +19,7 @@ const maxDisplayResults = 25;
  * Subject labels that begin with this string are identified as type `collection`.
  * @type {string}
  */
-const COLLECTION_PREFIX = 'collectionID:';
+const COLLECTION_PREFIX = 'collection:';
 
 /**
  * Represents the Bulk Tagger tool.

--- a/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
+++ b/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
@@ -19,7 +19,7 @@ const maxDisplayResults = 25;
  * Subject labels that begin with this string are identified as type `collection`.
  * @type {string}
  */
-const COLLECTION_PREFIX = "collectionID:";
+const COLLECTION_PREFIX = 'collectionID:';
 
 /**
  * Represents the Bulk Tagger tool.

--- a/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger/MenuOption.js
+++ b/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger/MenuOption.js
@@ -5,7 +5,8 @@ const classTypeSuffixes = {
     subjects: '--subject',
     subject_people: '--person',
     subject_places: '--place',
-    subject_times: '--time'
+    subject_times: '--time',
+    collections: '--collection'
 }
 
 /**

--- a/openlibrary/plugins/openlibrary/js/bulk-tagger/index.js
+++ b/openlibrary/plugins/openlibrary/js/bulk-tagger/index.js
@@ -28,6 +28,7 @@ export function renderBulkTagger() {
                     <div class="subject-type-option subject-type-option--person" data-tag-type="subject_people">person</div>
                     <div class="subject-type-option subject-type-option--place" data-tag-type="subject_places">place</div>
                     <div class="subject-type-option subject-type-option--time" data-tag-type="subject_times">time</div>
+                    <div class="subject-type-option subject-type-option--collection" data-tag-type="collections">collection</div>
                 </div>
             </div>
         </div>

--- a/openlibrary/plugins/openlibrary/js/bulk-tagger/models/Tag.js
+++ b/openlibrary/plugins/openlibrary/js/bulk-tagger/models/Tag.js
@@ -6,7 +6,8 @@ const displayTypeMapping = {
     subjects: 'subject',
     subject_people: 'person',
     subject_places: 'place',
-    subject_times: 'time'
+    subject_times: 'time',
+    collections: 'collection',
 }
 
 /**
@@ -17,7 +18,8 @@ export const subjectTypeMapping = {
     subject: 'subjects',
     person: 'subject_people',
     place: 'subject_places',
-    time: 'subject_times'
+    time: 'subject_times',
+    collection: 'collections'
 }
 
 /**

--- a/static/css/components/tagging-menu.less
+++ b/static/css/components/tagging-menu.less
@@ -115,6 +115,9 @@
   &--subject {
     background-color: @primary-blue;
   }
+  &--collection {
+    background-color: @black;
+  }
 }
 
 .search-subject-row-name {
@@ -243,6 +246,10 @@
 
     &--subject {
       background-color: @primary-blue;
+    }
+
+    &--collection {
+      background-color: @black;
     }
   }
 


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds new `collection` type to the bulk tagger.

![Screenshot 2024-09-24 144859](https://github.com/user-attachments/assets/17a020de-d4e4-421b-bb37-6d22a8bc3ef9)
_After adding new collection tag named `some-collection-identifier`._

When changes are submitted, the `collection` tags are added to the form, with the `collectionID:` prefix, in the `subjects` array.  For example, if the changes in the above image were submitted, there would be a `collectionID:some-collection-identifier` label in the affected works' `subjects` field.

![underlined_subject](https://github.com/user-attachments/assets/be1a5e79-a50f-4934-a981-00b5fc80ac87)
_New label with prefix is appended to the work's `subjects` list (__underlined in red, above__)._

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Create a new `collection` tag with the bulk tagger.
2. Add the tag to a work by pressing the "Submit" button.
3. View the updated work's `subjects` field, and verify that the new collection is present.
4. Verify that the new label has the `collectionID:` prefix.
5. Remove the new label via the bulk tagger.
6. Ensure that the work record has been updated, and that the collection subject has been removed from `subjects`.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
