### PR TITLE
Fixed issue with author name display in merge view

### DIFF
--- a/openlibrary/components/MergeUI/AuthorRoleTable.vue
+++ b/openlibrary/components/MergeUI/AuthorRoleTable.vue
@@ -16,10 +16,10 @@
                         </div>
                         <div v-else-if="field == 'author'">
                             <a :href="`${role[field].key}`" target="_blank">
-                                {{role[field].key.slice("/authors/".length)}}
+                                {{role[field].name || role[field].key.slice("/authors/".length)}}
                             </a>
                         </div>
-                        <div v-else>{{a[k]}}</div>
+                        <div v-else>{{role[field]}}</div>
                     </div>
                 </td>
             </tr>


### PR DESCRIPTION
**Closes #9811**

This PR addresses an issue where the merge view for works in OpenLibrary only displays the OL...A identifiers of authors. It now updates the view to display both the author names (and the OL in the tooltips)...Displaying the author’s name instead of the OL identifier makes it easier to distinguish between works by different authors or detect duplicate authors.

### Technical
---
- **Updated `utils.js`:**
    - Created a new `get_author_names(works)` function. This function extracts the unique author keys from the works, makes a call to fetch the authors' details via the `/search/authors.json` endpoint, and returns an object mapping author keys to their corresponding name and other metadata.

- **Updated `MergeTable.vue`:**
    - Created an `augmentedRecords` asynchronous computed property. It clones the records, fetches the author names using the `get_author_names` function, and augments the author objects in the records with the retrieved names to avoid modifying the original records.
    - Updated the template to render `augmentedRecords` instead of `records` to ensure the author names are displayed alongside the OL...A identifiers.
    - Updated the `merge` method to use the `augmentedRecords` to merge the works.

- **Updated `AuthorRoleTable.vue`:**
    - Enhanced the rendering logic to display both the author name and the OLID. If the author’s name is available, it will show the name along with the OLID in a link. If no name is available, it defaults to displaying just the OLID.


### Testing
---

To verify these changes:
1. Serve the application using `npm run serve --component=MergeUI`.
2. Navigate to the merge view (e.g., [http://localhost:8080/static/components/?records=OL1233242W,OL12312W](http://localhost:8080/static/components/?records=OL1233242W,OL12312W)).
3. Ensure that the merge view now displays the author names next to the OLIDs.
4. Verify that the merging functionality works as expected and does not introduce any errors.


### Screenshot
---

![Screenshot_1](https://github.com/user-attachments/assets/c98733ff-b4ac-4061-8687-fc3590782bb2)


### Stakeholders

@cdrini
