### PR TITLE
Add ability to sort of edit TOCs with authors/etc

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -3886,6 +3886,13 @@ msgid ""
 msgstr ""
 
 #: books/edit/edition.html
+msgid ""
+"This table of contents contains extra information like authors or "
+"descriptions. We don't have a great user interface for this yet, so "
+"editing this data could be difficult. Watch out!"
+msgstr ""
+
+#: books/edit/edition.html
 msgid "Any notes about this specific edition?"
 msgstr ""
 

--- a/openlibrary/macros/TableOfContents.html
+++ b/openlibrary/macros/TableOfContents.html
@@ -1,12 +1,11 @@
 $def with (table_of_contents, ocaid=None, cls='', attrs='')
 
-$ min_level = min(chapter.level for chapter in table_of_contents.entries)
 <div class="toc $cls" $:attrs>
   $for chapter in table_of_contents.entries:
     <div
       class="toc__entry"
       data-level="$chapter.level"
-      style="margin-left:$((chapter.level - min_level) * 2)ch"
+      style="margin-left:$((chapter.level - table_of_contents.min_level) * 2)ch"
     >
       $ is_link = ocaid and chapter.pagenum and chapter.pagenum.isdigit()
       $ tag = 'a' if is_link else 'div'

--- a/openlibrary/plugins/upstream/tests/test_table_of_contents.py
+++ b/openlibrary/plugins/upstream/tests/test_table_of_contents.py
@@ -60,6 +60,35 @@ class TestTableOfContents:
             {"level": 1, "title": "Chapter 2"},
         ]
 
+    def test_from_db_complex(self):
+        db_table_of_contents = [
+            {
+                "level": 1,
+                "title": "Chapter 1",
+                "authors": [{"name": "Author 1"}],
+                "subtitle": "Subtitle 1",
+                "description": "Description 1",
+            },
+            {"level": 2, "title": "Section 1.1"},
+            {"level": 2, "title": "Section 1.2"},
+            {"level": 1, "title": "Chapter 2"},
+        ]
+
+        toc = TableOfContents.from_db(db_table_of_contents)
+
+        assert toc.entries == [
+            TocEntry(
+                level=1,
+                title="Chapter 1",
+                authors=[{"name": "Author 1"}],
+                subtitle="Subtitle 1",
+                description="Description 1",
+            ),
+            TocEntry(level=2, title="Section 1.1"),
+            TocEntry(level=2, title="Section 1.2"),
+            TocEntry(level=1, title="Chapter 2"),
+        ]
+
     def test_from_markdown(self):
         text = """\
             | Chapter 1 | 1
@@ -162,12 +191,21 @@ class TestTocEntry:
         entry = TocEntry.from_markdown(line)
         assert entry == TocEntry(level=0, title="Chapter missing pipe")
 
+        line = ' | Just title |  | {"authors": [{"name": "Author 1"}]}'
+        entry = TocEntry.from_markdown(line)
+        assert entry == TocEntry(
+            level=0, title="Just title", authors=[{"name": "Author 1"}]
+        )
+
     def test_to_markdown(self):
         entry = TocEntry(level=0, title="Chapter 1", pagenum="1")
-        assert entry.to_markdown() == "  | Chapter 1 | 1"
+        assert entry.to_markdown() == " | Chapter 1 | 1"
 
         entry = TocEntry(level=2, title="Chapter 1", pagenum="1")
-        assert entry.to_markdown() == "**  | Chapter 1 | 1"
+        assert entry.to_markdown() == "** | Chapter 1 | 1"
 
         entry = TocEntry(level=0, title="Just title")
-        assert entry.to_markdown() == "  | Just title | "
+        assert entry.to_markdown() == " | Just title | "
+
+        entry = TocEntry(level=0, title="", authors=[{"name": "Author 1"}])
+        assert entry.to_markdown() == ' |  |  | {"authors": [{"name": "Author 1"}]}'

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -22,7 +22,7 @@ $# Render the ith language input field
 $jsdef render_language_field(i, language, i18n_name):
     $ lang_name = i18n_name or language.name
     <div class="input ac-input mia__input">
-      <div class="mia__reorder">≡</div>
+      <div class="mia__reorder">≡</div>  $# detect-missing-i18n-skip-line
       <input class="ac-input__visible" name="languages--$i" type="text" value="$lang_name"/>
       <input class="ac-input__value" name="edition--languages--$i--key" type="hidden" value="$language.key" />
       <a class="mia__remove" href="javascript:;" title="$_('Remove this language')">[x]</a>
@@ -338,10 +338,21 @@ $jsdef render_work_autocomplete_item(item):
         ** Chapter 1 | Of the Nature of Flatland | 3
         ** Chapter 2 | Of the Climate and Houses in Flatland | 5
         * Part 2 | OTHER WORLDS | 42</pre>
-        <br/>
+                <br/>
+                $ toc = book.get_table_of_contents()
+                $if toc and toc.is_complex():
+                    <div class="ol-message ol-message--warning">
+                        $_("This table of contents contains extra information like authors or descriptions. We don't have a great user interface for this yet, so editing this data could be difficult. Watch out!")
+                    </div>
             </div>
             <div class="input">
-                <textarea name="edition--table_of_contents" id="edition-toc" rows="5" cols="50">$book.get_toc_text()</textarea>
+                <textarea
+                    name="edition--table_of_contents"
+                    id="edition-toc"
+                    rows="$(5 if not toc else min(20, len(toc.entries)))"
+                    cols="50"
+                    class="toc-editor"
+                >$book.get_toc_text()</textarea>
             </div>
         </div>
 

--- a/static/css/components/ol-message.less
+++ b/static/css/components/ol-message.less
@@ -1,0 +1,32 @@
+@import (less) "less/colors.less";
+@import (less) "less/font-families.less";
+
+.ol-message {
+  font-size: @font-size-body-medium;
+  border-radius: 8px;
+  padding: 8px;
+
+  &, &--info {
+    background-color: hsl(hue(@primary-blue), saturation(@primary-blue), 90%);
+    color: hsl(hue(@primary-blue), saturation(@primary-blue), 35%);
+    border: 1px solid currentColor;
+  }
+
+  &--warning {
+    background-color: hsl(hue(@orange), saturation(@orange), 90%);
+    color: hsl(hue(@orange), saturation(@orange), 35%);
+    border: 1px solid currentColor;
+  }
+
+  &--success {
+    background-color: hsl(hue(@olive), saturation(@olive), 90%);
+    color: hsl(hue(@olive), saturation(@olive), 35%);
+    border: 1px solid currentColor;
+  }
+
+  &--error {
+    background-color: hsl(hue(@red), saturation(@red), 90%);
+    color: hsl(hue(@red), saturation(@red), 35%);
+    border: 1px solid currentColor;
+  }
+}

--- a/static/css/page-user.less
+++ b/static/css/page-user.less
@@ -224,6 +224,11 @@ tr.table-row.selected{
   transform: translateY(-50%);
 }
 
+textarea.toc-editor {
+  white-space: pre;
+}
+
+@import (less) "components/ol-message.less";
 // Import styles for fulltext-search-suggestion card
 @import (less) "components/fulltext-search-suggestion.less";
 // Import styles for fulltext-search-suggestion card item


### PR DESCRIPTION
Part of #8756

Adds the new fields to a new column in the markdown as JSON. This isn't a _great_ UI, but, more importantly, it makes it so that the extra fields aren't erased when someone edits an openlibrary record with authors/etc already in the TOC field.

~Depends on #9910 .~

### Technical
<!-- What should be noted about the implementation? -->
- Add an `ol-message` CSS component for small messages; inspired by https://primevue.org/message/
- Add space indenting to table of contents editor for easier legilibity

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

- ✅ books without table of contents render correctly
    - https://testing.openlibrary.org/books/OL10324632M/STOWELL_SYSTEMS_SCIENCE
- ✅ books with "normal" table of contents render correctly
    - https://testing.openlibrary.org/works/OL27482W/The_Hobbit?edition=key%3A/books/OL27289715M
- ✅ books with "normal" table of contents don't show warning
- ✅ books with table of contents + extra fields render correctly
    - https://testing.openlibrary.org/books/OL9462467M/Great_Irish_Stories_of_Childhood
- ✅ books without table of contents can be edited/saved
- ✅ books with "normal" table of contents can be edited/saved
- ✅ books with table of contents + extra fields can be edited/saved

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/user-attachments/assets/4225dc74-b6e7-4c7b-98f7-0437a4c813ad)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
