### PR TITLE
adding independent publisher check

### DIFF
--- a/openlibrary/catalog/utils/__init__.py
+++ b/openlibrary/catalog/utils/__init__.py
@@ -322,8 +322,9 @@ def is_independently_published(publishers: list[str]) -> bool:
     """
     Return True if the book is independently published.
     """
+    independent_publisher_names = ['independently published', 'independent publisher']
     return any(
-        publisher.casefold() == "independently published" for publisher in publishers
+        publisher.casefold() in independent_publisher_names for publisher in publishers
     )
 
 

--- a/openlibrary/tests/catalog/test_utils.py
+++ b/openlibrary/tests/catalog/test_utils.py
@@ -289,7 +289,9 @@ def test_publication_too_old_and_not_exempt(name, rec, expected) -> None:
     'publishers, expected',
     [
         (['INDEPENDENTLY PUBLISHED'], True),
+        (['Independent publisher'], True),
         (['Another Publisher', 'independently published'], True),
+        (['Another Publisher', 'independent publisher'], True),
         (['Another Publisher'], False),
     ],
 )


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9462 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Prevents independent publisher from importing. Previously only independently published was prevented. This PR expands this criteria to ensure independent publisher is not imported.

### Technical
This PR only adds independent publisher as requested in issue #9462. However, we might want to add more publishers to this list as per https://openlibrary.org/search/publishers?q=independent+publisher

### Testing
Testing is included. See tests.



### Stakeholders
@scottbarnes @seabelis 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
