### PR TITLE
Displays author name on merge

### DIFF
--- a/openlibrary/components/MergeUI/AuthorRoleTable.vue
+++ b/openlibrary/components/MergeUI/AuthorRoleTable.vue
@@ -15,9 +15,10 @@
                             {{(role[field].key || role[field]).slice("/type/".length)}}
                         </div>
                         <div v-else-if="field == 'author'">
-                            <a :href="`${role[field].key}`" target="_blank">
+                            <a :href="`${role[field].key}`" target="_blank" class="author-author-children">
                                 {{role[field].key.slice("/authors/".length)}}
                             </a>
+                            <p class="author-author-children"><b>{{role[field].name}}</b></p>
                         </div>
                         <div v-else>{{a[k]}}</div>
                     </div>

--- a/openlibrary/components/MergeUI/AuthorRoleTable.vue
+++ b/openlibrary/components/MergeUI/AuthorRoleTable.vue
@@ -20,7 +20,7 @@
                             </a>
                         </div>
                         <div v-else-if="field == 'name'">
-                            <b>{{role[field]}}</b>
+                            {{role[field]}}
                         </div>
                         <div v-else>{{a[k]}}</div>
                     </div>

--- a/openlibrary/components/MergeUI/AuthorRoleTable.vue
+++ b/openlibrary/components/MergeUI/AuthorRoleTable.vue
@@ -19,10 +19,7 @@
                                 {{role[field].key.slice("/authors/".length)}}
                             </a>
                         </div>
-                        <div v-else-if="field == 'name'">
-                            {{role[field]}}
-                        </div>
-                        <div v-else>{{a[k]}}</div>
+                        <div v-else>{{role[field]}}</div>
                     </div>
                 </td>
             </tr>

--- a/openlibrary/components/MergeUI/AuthorRoleTable.vue
+++ b/openlibrary/components/MergeUI/AuthorRoleTable.vue
@@ -15,10 +15,12 @@
                             {{(role[field].key || role[field]).slice("/type/".length)}}
                         </div>
                         <div v-else-if="field == 'author'">
-                            <a :href="`${role[field].key}`" target="_blank" class="author-author-children">
+                            <a :href="`${role[field].key}`" target="_blank">
                                 {{role[field].key.slice("/authors/".length)}}
                             </a>
-                            <p class="author-author-children"><b>{{role[field].name}}</b></p>
+                        </div>
+                        <div v-else-if="field == 'name'">
+                            <b>{{role[field]}}</b>
                         </div>
                         <div v-else>{{a[k]}}</div>
                     </div>

--- a/openlibrary/components/MergeUI/MergeTable.vue
+++ b/openlibrary/components/MergeUI/MergeTable.vue
@@ -8,7 +8,7 @@
     </thead>
     <tbody>
       <MergeRow
-        v-for="record in records"
+        v-for="record in enhancedRecords"
         :key="record.key"
         :record="record"
         :fields="fields"
@@ -47,7 +47,7 @@ import _ from 'lodash';
 import Vue from 'vue';
 import AsyncComputed from 'vue-async-computed';
 import MergeRow from './MergeRow.vue';
-import { merge, get_editions, get_lists, get_bookshelves, get_ratings } from './utils.js';
+import { merge, get_editions, get_lists, get_bookshelves, get_ratings, get_author_names } from './utils.js';
 import CONFIGS from '../configs.js';
 
 Vue.use(AsyncComputed);
@@ -111,6 +111,26 @@ export default {
             this.selected = _.fromPairs(records.map(record => [record.key, record.type.key.includes('work')]));
 
             return records;
+        },
+
+        async enhancedRecords(){
+            if (!this.records) return null;
+
+            const author_names = await get_author_names(this.records)
+
+            const enhanced_records = _.cloneDeep(this.records)
+
+            enhanced_records.flatMap(record =>
+                record.authors.map(entry=> {
+                    for (const [key, value] of Object.entries(author_names)) {
+                        if (entry.author.key === `/authors/${key}`){
+                            entry.author.name = value
+                        }
+                    }
+                })
+            )
+
+            return enhanced_records
         },
 
         async editions() {

--- a/openlibrary/components/MergeUI/MergeTable.vue
+++ b/openlibrary/components/MergeUI/MergeTable.vue
@@ -113,6 +113,7 @@ export default {
             return records;
         },
 
+        /** The records, with extra helpful metadata attached for display. Should NOT be saved to Open Library */
         async enhancedRecords(){
             if (!this.records) return null;
 

--- a/openlibrary/components/MergeUI/MergeTable.vue
+++ b/openlibrary/components/MergeUI/MergeTable.vue
@@ -192,8 +192,8 @@ export default {
             if (!this.master_key || !this.records || !this.editions)
                 return undefined;
 
-            const master = this.enhancedRecords.find(r => r.key === this.master_key);
-            const all_dupes = this.enhancedRecords
+            const master = this.records.find(r => r.key === this.master_key);
+            const all_dupes = this.records
                 .filter(r => this.selected[r.key])
                 .filter(r => r.key !== this.master_key);
             const dupes = all_dupes.filter(r => r.type.key === '/type/work');

--- a/openlibrary/components/MergeUI/MergeTable.vue
+++ b/openlibrary/components/MergeUI/MergeTable.vue
@@ -129,10 +129,9 @@ export default {
 
             for (const record of enhanced_records) {
                 for (const entry of record.authors) {
-                    entry.author.name = author_names[entry.author.key];
+                    entry.name = author_names[entry.author.key.slice('/authors/'.length)];
                 }
             }
-
             return enhanced_records
         },
 
@@ -497,7 +496,7 @@ li.excerpt-item {
 }
 
 .field-authors {
-  .author-author-children {
+  td.author-author, td.author-name {
     display: inline-block;
     padding-right: 2em;
   }

--- a/openlibrary/components/MergeUI/MergeTable.vue
+++ b/openlibrary/components/MergeUI/MergeTable.vue
@@ -117,7 +117,13 @@ export default {
         async enhancedRecords(){
             if (!this.records) return null;
 
-            const author_names = await get_author_names(this.records)
+            let author_names;
+
+            try {
+                author_names = await get_author_names(this.records);
+            } catch (error) {
+                console.error('Error creating enhancedRecords:', error);
+            }
 
             const enhanced_records = _.cloneDeep(this.records)
 

--- a/openlibrary/components/MergeUI/MergeTable.vue
+++ b/openlibrary/components/MergeUI/MergeTable.vue
@@ -496,9 +496,14 @@ li.excerpt-item {
 }
 
 .field-authors {
-  td.author-author, td.author-name {
+  td.author-author {
     display: inline-block;
     padding-right: 2em;
+  }
+
+  td.author-name {
+    display: inline-block;
+    font-weight: bold;
   }
 
   thead, td.author-index, td.author-type {

--- a/openlibrary/components/MergeUI/MergeTable.vue
+++ b/openlibrary/components/MergeUI/MergeTable.vue
@@ -494,6 +494,11 @@ li.excerpt-item {
 }
 
 .field-authors {
+  .author-author-children {
+    display: inline-block;
+    padding-right: 2em;
+  }
+
   thead, td.author-index, td.author-type {
     display: none;
   }

--- a/openlibrary/components/MergeUI/MergeTable.vue
+++ b/openlibrary/components/MergeUI/MergeTable.vue
@@ -192,8 +192,8 @@ export default {
             if (!this.master_key || !this.records || !this.editions)
                 return undefined;
 
-            const master = this.records.find(r => r.key === this.master_key);
-            const all_dupes = this.records
+            const master = this.enhancedRecords.find(r => r.key === this.master_key);
+            const all_dupes = this.enhancedRecords
                 .filter(r => this.selected[r.key])
                 .filter(r => r.key !== this.master_key);
             const dupes = all_dupes.filter(r => r.type.key === '/type/work');

--- a/openlibrary/components/MergeUI/MergeTable.vue
+++ b/openlibrary/components/MergeUI/MergeTable.vue
@@ -127,15 +127,11 @@ export default {
 
             const enhanced_records = _.cloneDeep(this.records)
 
-            enhanced_records.flatMap(record =>
-                record.authors.map(entry=> {
-                    for (const [key, value] of Object.entries(author_names)) {
-                        if (entry.author.key === `/authors/${key}`){
-                            entry.author.name = value
-                        }
-                    }
-                })
-            )
+            for (const record of enhanced_records) {
+                for (const entry of record.authors) {
+                    entry.author.name = author_names[entry.author.key];
+                }
+            }
 
             return enhanced_records
         },

--- a/openlibrary/components/MergeUI/MergeTable.vue
+++ b/openlibrary/components/MergeUI/MergeTable.vue
@@ -128,7 +128,7 @@ export default {
             const enhanced_records = _.cloneDeep(this.records)
 
             for (const record of enhanced_records) {
-                for (const entry of record.authors) {
+                for (const entry of (record.authors || [])) {
                     entry.name = author_names[entry.author.key.slice('/authors/'.length)];
                 }
             }

--- a/openlibrary/components/MergeUI/MergeTable.vue
+++ b/openlibrary/components/MergeUI/MergeTable.vue
@@ -497,13 +497,7 @@ li.excerpt-item {
 
 .field-authors {
   td.author-author {
-    display: inline-block;
-    padding-right: 2em;
-  }
-
-  td.author-name {
-    display: inline-block;
-    font-weight: bold;
+    padding-right: 6px;
   }
 
   thead, td.author-index, td.author-type {

--- a/openlibrary/components/MergeUI/utils.js
+++ b/openlibrary/components/MergeUI/utils.js
@@ -237,7 +237,7 @@ function save_many(items, comment, action, data) {
  */
 export async function get_author_names(works) {
     const authorIds = _.uniq(works).flatMap(record =>
-        record.authors.map(authorEntry => authorEntry.author.key)
+        (record.authors || []).map(authorEntry => authorEntry.author.key)
     )
 
     const queryParams = new URLSearchParams({

--- a/openlibrary/components/MergeUI/utils.js
+++ b/openlibrary/components/MergeUI/utils.js
@@ -248,7 +248,9 @@ export async function get_author_names(works) {
 
     const response = await fetch(`${CONFIGS.OL_BASE_SEARCH}/search/authors.json?${queryParams}`)
 
-    if (!response.ok) return {error: true};
+    if (!response.ok) {
+        throw new Error('Failed to fetch author data');
+    }
 
     const results = await response.json()
 

--- a/openlibrary/components/MergeUI/utils.js
+++ b/openlibrary/components/MergeUI/utils.js
@@ -246,7 +246,7 @@ export async function get_author_names(works) {
         fields: 'key,name',
     })
 
-    const response = await fetch(`${CONFIGS.OL_BASE_BOOKS}/search/authors.json?${queryParams}`)
+    const response = await fetch(`${CONFIGS.OL_BASE_SEARCH}/search/authors.json?${queryParams}`)
 
     if (!response.ok) return {error: true};
 

--- a/openlibrary/components/MergeUI/utils.js
+++ b/openlibrary/components/MergeUI/utils.js
@@ -230,6 +230,38 @@ function save_many(items, comment, action, data) {
     });
 }
 
+/**
+ * Fetches name associated with the author key
+ * @param {Object[]} works
+ * @returns {Promise<Record<string,object>} A response to the request
+ */
+export async function get_author_names(works) {
+    const authorIds = _.uniq(works).flatMap(record =>
+        record.authors.map(authorEntry => authorEntry.author.key)
+    )
+
+    const queryParams = new URLSearchParams({
+        q: `key:(${authorIds.join(' OR ')})`,
+        mode: 'everything',
+        fields: 'key,name',
+    })
+
+    const response = await fetch(`${CONFIGS.OL_BASE_BOOKS}/search/authors.json?${queryParams}`)
+
+    if (!response.ok) return {error: true};
+
+    const results = await response.json()
+
+    const authorDirectory = {}
+
+    for (const doc of results.docs) {
+        authorDirectory[doc.key] = doc.name;
+    }
+
+    return authorDirectory
+}
+
+
 // /**
 //  * @param {Object} record
 //  * @param {string} comment

--- a/openlibrary/components/MergeUI/utils.js
+++ b/openlibrary/components/MergeUI/utils.js
@@ -240,6 +240,8 @@ export async function get_author_names(works) {
         (record.authors || []).map(authorEntry => authorEntry.author.key)
     )
 
+    if (!authorIds.length) return {};
+
     const queryParams = new URLSearchParams({
         q: `key:(${authorIds.join(' OR ')})`,
         mode: 'everything',


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9811 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Displaying the author’s name next to the OL...A identifier making it easier to distinguish between works by different authors.

### Technical
**utils.js**
Added ```get_author_name``` function to fetch the name of the author associated with the id and append to the record. 

**AuthorRoleTable.vue**
Added p tag to display authors name, as well as class to formate with CSS.

**MergeTable.vue**
Created ```enhancedRecords``` to include author name and added to template in order to display. Added CSS to display name next to ID.

*** I've not added ```enhancedRecords``` to the ```merge``` function in this file as I couldn't verify if this would impact what is saved when merging works. Can someone please clarify?***

### Testing
1. Run command  ```npm run serve --component=MergeUI```.
2. Open merge view  (http://localhost:8080/static/components/?records=OL1233242W,OL12312W)
3. Verify merge view now displays the author names next to the ids
4. Verify merging works as expected.

*** I was not able to find any JS tests for the files associated with this ticket. If needed, I can create if directed to the correct directory.***

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot 2024-10-01 at 17 23 46](https://github.com/user-attachments/assets/b9c59f3b-38e0-4d60-bb0d-3a3c98a50844)

### Stakeholders
@cdrini 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
