### PR TITLE
hotfix search star ratings null case

### DIFF
--- a/openlibrary/macros/StarRatingsStats.html
+++ b/openlibrary/macros/StarRatingsStats.html
@@ -4,9 +4,9 @@ $ rating_stats = work and work.get_rating_stats() or {}
 $ stats_by_bookshelf = work and work.get_num_users_by_bookshelf() or {}
 $ ratings_average = rating_stats.get('avg_rating', None)
 $ ratings_count = rating_stats.get('num_ratings', None)
-$ want_to_read_count = "{:,}".format(stats_by_bookshelf.get('want-to-read', None))
-$ currently_reading_count = "{:,}".format(stats_by_bookshelf.get('currently-reading', None))
-$ already_read_count = "{:,}".format(stats_by_bookshelf.get('already-read', None))
+$ want_to_read_count = "{:,}".format(stats_by_bookshelf.get('want-to-read', ''))
+$ currently_reading_count = "{:,}".format(stats_by_bookshelf.get('currently-reading', ''))
+$ already_read_count = "{:,}".format(stats_by_bookshelf.get('already-read', ''))
 $ review_count_class = 'readers-stats__review-count--none' if ratings_count == None else ''
 $ id = '--mobile' if mobile else ''
 

--- a/openlibrary/macros/StarRatingsStats.html
+++ b/openlibrary/macros/StarRatingsStats.html
@@ -4,7 +4,7 @@ $ rating_stats = work and work.get_rating_stats() or {}
 $ stats_by_bookshelf = work and work.get_num_users_by_bookshelf() or {}
 $ ratings_average = rating_stats.get('avg_rating', None)
 $ ratings_count = rating_stats.get('num_ratings', None)
-$ want_to_read_count = stats_by_bookshelf.get('want-to-read') and {:,}".format(stats_by_bookshelf['want-to-read'])
+$ want_to_read_count = stats_by_bookshelf.get('want-to-read') and "{:,}".format(stats_by_bookshelf['want-to-read'])
 $ currently_reading_count = stats_by_bookshelf.get('currently-reading') and "{:,}".format(stats_by_bookshelf['currently-reading'])
 $ already_read_count = stats_by_bookshelf.get('already-read') and "{:,}".format(stats_by_bookshelf['already-read'])
 $ review_count_class = 'readers-stats__review-count--none' if ratings_count == None else ''

--- a/openlibrary/macros/StarRatingsStats.html
+++ b/openlibrary/macros/StarRatingsStats.html
@@ -4,9 +4,9 @@ $ rating_stats = work and work.get_rating_stats() or {}
 $ stats_by_bookshelf = work and work.get_num_users_by_bookshelf() or {}
 $ ratings_average = rating_stats.get('avg_rating', None)
 $ ratings_count = rating_stats.get('num_ratings', None)
-$ want_to_read_count = "{:,}".format(stats_by_bookshelf.get('want-to-read', ''))
-$ currently_reading_count = "{:,}".format(stats_by_bookshelf.get('currently-reading', ''))
-$ already_read_count = "{:,}".format(stats_by_bookshelf.get('already-read', ''))
+$ want_to_read_count = stats_by_bookshelf.get('want-to-read') and {:,}".format(stats_by_bookshelf['want-to-read'])
+$ currently_reading_count = stats_by_bookshelf.get('currently-reading') and "{:,}".format(stats_by_bookshelf['currently-reading'])
+$ already_read_count = stats_by_bookshelf.get('already-read') and "{:,}".format(stats_by_bookshelf['already-read'])
 $ review_count_class = 'readers-stats__review-count--none' if ratings_count == None else ''
 $ id = '--mobile' if mobile else ''
 


### PR DESCRIPTION
This is the result of investigating why we have so many docker errors -- followup to and re Closes #2405 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

**Please squash :)** 

### Technical
<!-- What should be noted about the implementation? -->

In certain cases where there were no star ratings, we were falling back to None and trying to format a None value as a string. This performs a `.get` with a fallback to empty string.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

```
>>> stats_by_bookshelf = {}
>>> stats_by_bookshelf.get('want-to-read') and "{:,}".format(stats_by_bookshelf['want-to-read'])
>>> 
>>> stats_by_bookshelf = {'want-to-read': 1000}
>>> stats_by_bookshelf.get('want-to-read') and "{:,}".format(stats_by_bookshelf['want-to-read'])
>>> '1,000'
```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
