### PR TITLE
Added displaying of selected language

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1252,6 +1252,49 @@ def setup_template_globals():
         get_cover_url,
     )
 
+    def get_languages_dict(): #Returns languages as a dictionary mapping the codes to names and displaying both
+        return {
+             "cs": {
+                 "localized": 'Czech', 
+                 "native": "Čeština"},
+             "de": {
+                 "localized": 'German', 
+                 "native": "Deutsch"},
+            "en": {
+                "localized": 'English', 
+                "native": "English"},
+            "es": {
+                "localized": 'Spanish', 
+                "native": "Español"},
+            "fr": {
+                "localized": 'French', 
+                "native": "Français"},
+            "hr": {
+                "localized": 'Croatian', 
+                "native": "Hrvatski"},
+            "it": {
+                "localized": 'Italian', 
+                "native": "Italiano"},
+            "pt": {
+                "localized": 'Portuguese', 
+                "native": "Português"},
+            "hi": {
+                "localized": 'Hindi', 
+                "native": "हिंदी"},
+            "sc": {
+                "localized": 'Sardinian', 
+                "native": "Sardu"},
+            "te": {
+                "localized": 'Telugu', 
+                "native": "తెలుగు"},
+            "uk": {
+                "localized": 'Ukrainian', 
+                "native": "Українська"},
+            "zh": {
+                "localized": 'Chinese', 
+                "native": "中文"},
+        }
+
     web.template.Template.globals.update(
         {
             'cookies': web.cookies,
@@ -1267,6 +1310,7 @@ def setup_template_globals():
             'random': random.Random(),
             'choose_random_from': random.choice,
             'get_lang': lambda: web.ctx.lang,
+            'get_supported_languages': get_languages_dict,
             'ceil': math.ceil,
             'get_best_edition': get_best_edition,
             'get_book_provider': get_book_provider,

--- a/openlibrary/templates/site/alert.html
+++ b/openlibrary/templates/site/alert.html
@@ -1,6 +1,10 @@
 $if not is_bot():
   $:get_donation_include()
 
+  $ lang = get_lang() or 'en'
+$ supported_languages = get_supported_languages()
+$ active_ui_lang = supported_languages.get(lang) or supported_languages.get('en')
+
 <div id="topNotice">
   <div class="page-banner page-banner-black page-banner-center">
     <div class="iaBar">
@@ -9,6 +13,7 @@ $if not is_bot():
       <div class="language-component header-dropdown">
         <details>
           <summary>
+            <span>$(supported_languages[get_lang() or 'en']['native']) ($(get_lang() or 'en'))</span>
             <img class="translate-icon" src="/static/images/language-icon.svg" title="$_('Change Website Language')" alt="$_('Change Website Language')"/>
           </summary>
           <div class="language-dropdown-component">

--- a/static/css/components/language.less
+++ b/static/css/components/language.less
@@ -49,6 +49,9 @@
 .iaBar .language-component {
   position: relative;
   display: block;
+  border: 1px solid @mid-grey;
+  border-radius: 5px;
+  padding: .2rem .4rem;
   // stylelint-disable selector-max-specificity, max-nesting-depth
   .language-dropdown-component {
     position: absolute;


### PR DESCRIPTION
Selected language is now displayed in the top right corner.

<!-- What issue does this PR close? -->
Would have closed #9868 (Done for a class after-the-fact)

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
When a user selects a language from the dropdown menu, their choice is now displayed.

### Technical
<!-- What should be noted about the implementation? -->
This implementation has not been tested extensively and could behave incorrectly under certain circumstances.  Additionally, there may be a more dynamic way to add languages to the dictionary for scalability.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Run the app, and change your language.  You should now see the language you selected displayed in the top right corner.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot 2024-10-03 163819](https://github.com/user-attachments/assets/afc1ca7c-9b39-4069-bdb8-6b3947a47f4e)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
Not going to tag stakeholders because this pull request is for demonstration purposes only.

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
