### PR TITLE
hotfix login view

### DIFF
--- a/openlibrary/templates/login.html
+++ b/openlibrary/templates/login.html
@@ -58,7 +58,7 @@ $if "dev" in ctx.features:
                 </div>
                 <div class="input">
                     <input type="password" placeholder="$_('Password')" id="password" name="password" value="$form.password.value" required />
-                    <a href="javascript:;" class="password-visibility-toggle">
+                    <a href="javascript:;" class="password-visibility-toggle ol-signup-form__icon-wrap">
                         <img src="/static/images/icons/icon_eye-closed.svg" title="$_('Toggle Password Visibility')" alt="$_('Toggle Password Visibility')"/>
                     </a>
                 </div>


### PR DESCRIPTION
Hotfix for #9593 which applies `ol-signup-form__icon-wrap` on login.html, not just account/create.html to fix eyeball size + pos for password show/hide

<!-- What issue does this PR close? -->
re Closes #9593

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Before
![image](https://github.com/user-attachments/assets/c5886898-bb06-47b3-99c1-f20aa60f3477)


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
