### PR TITLE
mvp of SuperReadButton

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -824,8 +824,8 @@ msgstr ""
 msgid "Currently Reading"
 msgstr ""
 
-#: LoanReadForm.html ReadButton.html admin/inspect/memcache.html
-#: book_providers/cita_press_read_button.html
+#: LoanReadForm.html ReadButton.html SuperReadButton.html
+#: admin/inspect/memcache.html book_providers/cita_press_read_button.html
 #: book_providers/direct_read_button.html
 #: book_providers/gutenberg_read_button.html
 #: book_providers/openstax_read_button.html
@@ -864,8 +864,8 @@ msgstr ""
 msgid "Borrow \"%(title)s\""
 msgstr ""
 
-#: ReadButton.html books/custom_carousel.html books/edit/edition.html
-#: type/list/embed.html widget.html
+#: ReadButton.html SuperReadButton.html books/custom_carousel.html
+#: books/edit/edition.html type/list/embed.html widget.html
 msgid "Borrow"
 msgstr ""
 
@@ -7460,21 +7460,21 @@ msgstr ""
 msgid "Search collection"
 msgstr ""
 
-#: ReadButton.html
+#: ReadButton.html SuperReadButton.html
 msgid "Special Access"
 msgstr ""
 
-#: ReadButton.html
+#: ReadButton.html SuperReadButton.html
 msgid ""
 "Special ebook access from the Internet Archive for patrons with "
 "qualifying print disabilities"
 msgstr ""
 
-#: ReadButton.html
+#: ReadButton.html SuperReadButton.html
 msgid "Borrow ebook from Internet Archive"
 msgstr ""
 
-#: ReadButton.html
+#: ReadButton.html SuperReadButton.html
 msgid "Read ebook from Internet Archive"
 msgstr ""
 

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -37,7 +37,7 @@ $ get_loan_for_start_time = time()
 $ user_loan = doc.get('loan') or (check_loan_status and ocaid and ctx.user and ctx.user.get_loan_for(ocaid, use_cache=True))
 $ get_loan_for_total_time = time() - get_loan_for_start_time
 
-$ is_edition = doc.key.split('/')[1] == 'books'
+$ olid = doc.key.split('/')[1] == 'books'
 
 $def analytics_attr(action):
   $if analytics_override:
@@ -57,9 +57,7 @@ $elif book_provider and book_provider.short_name != 'ia':
 
 $elif availability.get('is_readable') or availability.get('status') == 'open':
   $# Open / Publicly Readable (Unrestricted)
-  $:macros.ReadButton(ocaid, analytics_attr, listen=listen)
-  $if secondary_action:
-    $:macros.BookSearchInside(ocaid)
+  $:macros.SuperReadButton(ocaid, olid)
 
 $elif ocaid and ctx.user and ctx.user.is_printdisabled():
   $# Exemptions for patrons with Print Disabilities
@@ -73,7 +71,7 @@ $elif availability.get('is_lendable'):
   $if secondary_action:
     $:macros.BookPreview(ocaid, analytics_attr, show_only=False)
   $if availability.get("available_to_borrow") or availability.get("available_to_browse"):
-    $:macros.ReadButton(ocaid, analytics_attr, borrow=True, listen=listen)
+    $:macros.SuperReadButton(ocaid, olid, borrow=True, listen=listen)
   $elif availability.get('available_to_waitlist'):
     $if waiting_loan:
       $if secondary_action:
@@ -136,8 +134,8 @@ $elif ocaid and availability.get('is_previewable') and book_provider.short_name 
 $else:
   $# Only render clickable NotInLibrary when not on an edition's page, for that specific edition.
   $# secondary_action means we're on a book page and it's the button under the cover image.
-  $ key = doc.key if is_edition else work_key
-  $if (is_edition and is_book_page) or secondary_action:
+  $ key = doc.key if olid else work_key
+  $if (olid and is_book_page) or secondary_action:
       $:macros.NotInLibrary(None, analytics_attr)
   $else:
       $:macros.NotInLibrary(key, analytics_attr)

--- a/openlibrary/macros/SuperReadButton.html
+++ b/openlibrary/macros/SuperReadButton.html
@@ -1,0 +1,154 @@
+$def with(ocaid, olid, borrow=False, listen=False, loan=None, label='', printdisabled=False)
+
+$ stream_url = "/borrow/ia/%s?ref=ol" % ocaid
+
+$if printdisabled:
+  $ action = "read"
+  $ label = _("Special Access")
+  $ title = _("Special ebook access from the Internet Archive for patrons with qualifying print disabilities")
+  $ analytics_action = "PrintDisabled"
+$elif (borrow and not loan):
+  $ action = "borrow"
+  $ label = label or _("Borrow")
+  $ title = _("Borrow ebook from Internet Archive")
+  $ analytics_action = "Borrow"
+$else:
+  $ action = "read"
+  $ label = _("Read")
+  $ title = _("Read ebook from Internet Archive")
+  $ analytics_action = "Read"
+
+<style type="text/css">
+
+.fullwidth {
+  width: 100%;
+}
+
+.cta-button-group details.cta-dropper {
+    margin-bottom: 10px;
+}
+
+details.cta-dropper.cta-selector input.cta-btn {
+    margin: 0;
+}
+
+/* Override cta-btn */
+details.cta-dropper.cta-selector a.cta-btn {
+    border-radius: 0;
+    margin: 0;
+    border: none;
+    font-size: 16px;
+    cursor: pointer;
+    display: inline-block;
+    border-right: 1px solid #fff;
+    border-top-left-radius: 5px;
+    border-bottom-left-radius: 5px;
+}
+
+/* Style for the details component */
+details.cta-dropper {
+    display: inline-block;
+    position: relative;
+    border-radius: 5px;
+}
+
+/* Summary element (button + dropper arrow) */
+details.cta-dropper.cta-selector summary {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    margin: 0;
+    background-color: #0376b8;
+    border-radius: 5px;
+}
+
+/* Right arrow (triangle) styling */
+.dropper-arrow {
+    width: 0;
+    height: 0;
+    border-left: 6px solid transparent;
+    border-right: 6px solid transparent;
+    border-top: 6px solid white;
+    margin: 10px;
+}
+
+/* Rotating arrow when details is open */
+details.cta-dropper[open] .dropper-arrow {
+    border-top: none;
+    border-bottom: 6px solid white;
+}
+
+.cta-dropper ul.dropper-menu {
+    margin: 0;
+}
+
+.cta-dropper ul.dropper-menu li {
+    list-style-type: none;
+    margin: 0;
+    padding: 5px 10px;
+}
+
+/* Dropper menu */
+.dropper-menu {
+    margin: 0;
+    padding: 0;
+    position: absolute;
+    background-color: white;
+    border: 1px solid lightgrey;
+    width: 200px;
+    display: none;
+    border-radius: 5px;
+    z-index: 999999;
+}
+
+/* Show menu when details is open */
+details.cta-dropper[open] .dropper-menu {
+    display: block;
+}
+
+/* Menu item styling */
+ul.dropper-menu li {
+    padding: 10px;
+    border-bottom: 1px solid lightgrey;
+    cursor: pointer;
+    list-style: none;
+}
+
+/* Last item without border */
+.dropper-menu li:last-child {
+    border-bottom: none;
+}
+
+/* Hover effect for dropper menu items */
+.dropper-menu li:hover {
+    background-color: #f0f0f0;
+}
+
+ul.dropper-menu {
+  margin: 0;
+}
+
+.dropper-menu li a {
+    text-decoration: none;
+    color: black;
+    font-family: arial;
+}
+
+</style>
+
+<div class="cta-button-group">
+  <details class="cta-dropper cta-selector fullwidth">
+    <summary>
+      <a href="$(stream_url)" title="$title" class="cta-btn cta-btn--ia cta-btn--available cta-btn--$(action)" data-ol-link-track="CTAClick|$action"
+      $if loan:
+        data-userid="$(loan['userid'])"
+      >$label</a>
+      <span class="dropper-arrow"></span>
+    </summary>
+    <ul class="dropper-menu">
+      <li><a href="">Listen</a></li>
+      <li>$:macros.BookSearchInside(ocaid)</li>
+      <li><a class="cta-btn--external" href="">Locate</a></li>
+    </ul>
+  </details>
+</div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5831 

This breaks in carousels... But it works on the Books page and also mostly in Search Results.

The HTML and CSS is fairly compartmentalized as to not require the existence of outside classes... And has been reinforced (with high specificity rules) in some places to be robust *against* some specific book page classes from affecting its stying.

<img width="280" alt="Screenshot 2024-10-05 at 1 56 06 PM" src="https://github.com/user-attachments/assets/13566b39-a6f6-4f6f-bffd-6d847127c6ff">

<img width="282" alt="Screenshot 2024-10-05 at 1 56 21 PM" src="https://github.com/user-attachments/assets/9e125d3e-8772-424c-9ee3-96330860c3bb">

<img width="835" alt="Screenshot 2024-10-05 at 1 56 42 PM" src="https://github.com/user-attachments/assets/fade7516-d0f9-4502-b06e-87d20ed0dd03">

😵 
<img width="408" alt="Screenshot 2024-10-05 at 1 56 58 PM" src="https://github.com/user-attachments/assets/691f5ae9-b1b3-469d-b872-7181aa1e3f1f">

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
