### PR TITLE
Restore barcode scanner page

### DIFF
--- a/openlibrary/templates/barcodescanner.html
+++ b/openlibrary/templates/barcodescanner.html
@@ -2,7 +2,6 @@ $def with ()
 
 $var title: $_('Barcode Scanner (Beta)')
 
-$ ctx.setdefault('cssfile', 'barcodescanner')
 $ ctx.setdefault("show_ol_shell", False)
 
 $:render_component('BarcodeScanner')


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Hotfix for #9873

Removes reference to deleted barcode scanner styles, fixing the barcode scanner page.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Navigate to the `/barcodescanner` page, and ensure that there is no `Unable to render this page` message.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/user-attachments/assets/d6174063-a37c-45d1-b077-1e615c1762da)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
