### PR TITLE
Add configuration to disable lending buttons

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -192,3 +192,5 @@ sentry_cron_jobs:
 
 # Observations cache settings:
 observation_cache_duration: 86400
+
+disable_lending: False

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -70,6 +70,7 @@ config_http_request_timeout = None
 config_loanstatus_url = None
 config_bookreader_host = None
 config_internal_tests_api_key = None
+config_disable_lending = None
 
 
 def setup(config):
@@ -80,7 +81,7 @@ def setup(config):
     global config_ia_availability_api_v2_url, config_ia_ol_metadata_write_s3
     global config_ia_xauth_api_url, config_http_request_timeout, config_ia_s3_auth_url
     global config_ia_users_loan_history, config_ia_loan_api_developer_key
-    global config_ia_civicrm_api, config_ia_domain
+    global config_ia_civicrm_api, config_ia_domain, config_disable_lending
 
     config_loanstatus_url = config.get('loanstatus_url')
     config_bookreader_host = config.get('bookreader_host', 'archive.org')
@@ -101,6 +102,12 @@ def setup(config):
     config_ia_civicrm_api = config.get('ia_civicrm_api')
     config_internal_tests_api_key = config.get('internal_tests_api_key')
     config_http_request_timeout = config.get('http_request_timeout')
+    config_disable_lending = config.get('disable_lending', False)
+
+
+@public
+def is_lending_disabled():
+    return config_disable_lending
 
 
 @public

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -7721,6 +7721,10 @@ msgid ""
 "don't change it.)"
 msgstr ""
 
+#: UnavailableButton.html
+msgid "Currently Unavailable"
+msgstr ""
+
 #: WorkInfo.html
 msgid "No link to Wikipedia in your language"
 msgstr ""

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -10,6 +10,9 @@ $# * check_sponsorship - whether to check if the book is eligible for sponsorshi
 $# * sponsorship_help - whether to show the sponsorship help text
 $# * check_loan_status - whether to check the user's loan status to determine read button
 
+$if is_lending_disabled():
+  $return macros.UnavailableButton()
+
 $ loanstatus_start_time = time()
 
 $ availability = (doc.availability or {}) if hasattr(doc, 'availability') else {}

--- a/openlibrary/macros/UnavailableButton.html
+++ b/openlibrary/macros/UnavailableButton.html
@@ -1,0 +1,5 @@
+$def with ()
+
+<div class="cta-button-group">
+  <span class="cta-btn cta-btn--no-pointer">$_("Currently Unavailable")</span>
+</div>


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds `disable_lending` configuration and new `public` function that returns this configuration's value.

Adds new `UnavailbleButton` macro, which is returned by `LoanStatus` when `disable_lending` is true.

The suggested call to action overflowed for all buttons in desktop views.  As a result, the copy has been updated to read "Currently Unavailable."  Unfortunately, this copy overflows in carousels, but fits in other contexts.

![Screenshot 2024-10-17 083437](https://github.com/user-attachments/assets/eb59d676-72b1-4aac-879a-f6c7098cb5ae)

![Screenshot 2024-10-17 083527](https://github.com/user-attachments/assets/7d89edeb-b2a2-424a-99ce-e25441bdfb0e)
_Book page desktop_

![Screenshot 2024-10-17 090904](https://github.com/user-attachments/assets/052384be-c79b-4336-ac2e-64bc918cc7f6)
_In carousel_

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Set the `disable_lending` configuration to `True`
2. Verify that lending buttons have the expected call to action.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
