### PR TITLE
Fixed Read More Button Display Logic to Avoid Unnecessary Display

### DIFF
--- a/openlibrary/plugins/openlibrary/js/readmore.js
+++ b/openlibrary/plugins/openlibrary/js/readmore.js
@@ -52,13 +52,16 @@ export class ReadMoreComponent {
     }
 
     reset() {
-        const fullHeight = this.$content.scrollHeight;
+        this.fullHeight = this.$content.scrollHeight;
+        if (this.$readMoreButton && this.$readMoreButton.offsetHeight) {
+            this.readMoreHeight = this.$readMoreButton.offsetHeight;
+        }
         const collapsedHeight = this.collapsedHeight;
-        const readMoreButtonHeight = this.$readMoreButton ? this.$readMoreButton.offsetHeight : 0;
+        const readMoreButtonHeight = this.readMoreHeight || 0;
 
         // Fudge factor to account for non-significant read/more
         // (e.g missing a bit of padding)
-        if (fullHeight <= (collapsedHeight + readMoreButtonHeight + 1)) {
+        if (this.fullHeight <= (collapsedHeight + readMoreButtonHeight + 1)) {
             this.expand();
             this.$container.classList.add('read-more--unnecessary');
         } else {

--- a/openlibrary/plugins/openlibrary/js/readmore.js
+++ b/openlibrary/plugins/openlibrary/js/readmore.js
@@ -52,10 +52,13 @@ export class ReadMoreComponent {
     }
 
     reset() {
-        this.fullHeight = this.$content.scrollHeight;
+        const fullHeight = this.$content.scrollHeight;
+        const collapsedHeight = this.collapsedHeight;
+        const readMoreButtonHeight = this.$readMoreButton ? this.$readMoreButton.offsetHeight : 0;
+
         // Fudge factor to account for non-significant read/more
         // (e.g missing a bit of padding)
-        if (this.$content.scrollHeight <= (this.collapsedHeight + 1)) {
+        if (fullHeight <= (collapsedHeight + readMoreButtonHeight + 1)) {
             this.expand();
             this.$container.classList.add('read-more--unnecessary');
         } else {


### PR DESCRIPTION
---
## Description

This PR addresses an issue where the "Read more" button was displayed even when it extended the section beyond its fully expanded content. This led to a confusing user experience, as the "Read more" button was not serving its intended purpose. The following changes have been made to resolve this issue:

**Closes #9329**

## Changes

1. **Capture "Read More" Button Height**:
    - The height of the "Read more" button is now captured during initialization to ensure accurate layout calculations.

2. **Updated Condition in `reset` Method**:
    - The logic determining whether the "Read more" button should be displayed has been updated to account for the button's height. This ensures the button is only shown when necessary.

## Impact

- **Improved User Experience**: The "Read more" button is now displayed only when needed, reducing unnecessary clutter and confusion.
- **Correct Layout Behavior**: The layout now behaves as expected, with the "Read more" button enhancing usability instead of detracting from it.

## Testing
To test visit a link like https://testing.openlibrary.org/books/OL8978501M/Robin_Hood
---

## Screenshots
![Screenshot from 2024-07-25 18-43-42](https://github.com/user-attachments/assets/fd72ad9e-2e81-4208-9622-44f93840f087)


