### PR TITLE
Add flash messages to login, registration views

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -455,6 +455,12 @@ msgstr ""
 
 #: login.html
 msgid ""
+"Open Library is currently in limited-availability mode. During this time,"
+" patrons will be unable to log in."
+msgstr ""
+
+#: login.html
+msgid ""
 "This is a development instance, the default credentials are automatically"
 " filled."
 msgstr ""
@@ -1037,6 +1043,12 @@ msgstr ""
 
 #: account/create.html
 msgid "Sign Up to Open Library"
+msgstr ""
+
+#: account/create.html
+msgid ""
+"Open Library is currently in limited-availability mode. During this time,"
+" patrons will be unable to register for an account."
 msgstr ""
 
 #: account/create.html lib/header_dropdown.html lib/nav_head.html

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -14,6 +14,14 @@ $# :param openlibrary.plugins.upstream.forms.RegisterForm form:
 
 $var title: $_("Sign Up to Open Library")
 
+<div class="flash-messages">
+    <div class="info ol-signup-form__info-box error">
+        <span>
+            $_("Open Library is currently in limited-availability mode. During this time, patrons will be unable to register for an account.")
+        </span>
+    </div>
+</div>
+
 <div class="ol-page-signup">
     <div id="contentHead" class="ol-signup-hero">
         <h1 class="ol-signup-hero__title">$_("Sign Up")</h1>

--- a/openlibrary/templates/login.html
+++ b/openlibrary/templates/login.html
@@ -8,6 +8,14 @@ $putctx("cssfile", "signup")
 
 $var title: $_("Log In")
 
+<div class="flash-messages">
+    <div class="info ol-signup-form__info-box error">
+        <span>
+            $_("Open Library is currently in limited-availability mode. During this time, patrons will be unable to log in.")
+        </span>
+    </div>
+</div>
+
 $if "dev" in ctx.features:
     <div class="flash-messages" id="autofill-dev-credentials">
         <div class="info ol-signup-form__info-box">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds error flash messages to our login and registration pages.  Messages are as follows:

__Login message__: `Open Library is currently in limited-availability mode. During this time, patrons will be unable to log in.`

__Registration message__: `Open Library is currently in limited-availability mode. During this time, patrons will be unable to register for an account.`

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/user-attachments/assets/545872bc-84d1-401f-aeb7-5711cfee8c23)
_Login flash message_

![image](https://github.com/user-attachments/assets/a1ed00ff-8491-4bdf-8bcf-df5eddd3ec81)
_Registration flash message_
### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
