### PR TITLE
Unescape search result title and set via `textContent`

### DIFF
--- a/openlibrary/plugins/openlibrary/js/search.js
+++ b/openlibrary/plugins/openlibrary/js/search.js
@@ -2,6 +2,8 @@
  * Functionalities for templates/work_search and related templates.
  */
 
+import unescape from 'lodash/unescape'
+
 /**
  * Displays more facets by removing the ui-helper-hidden class.
  *
@@ -78,7 +80,7 @@ export function initSearchFacets(facetsElem) {
                 facetsElem.replaceWith(newFacetsElem)
                 hydrateFacets()
 
-                document.title = data.title
+                setTitle(data.title)
             })
             .catch(() => {
                 // XXX : Handle case where `/partials` response is not `2XX` here
@@ -88,6 +90,10 @@ export function initSearchFacets(facetsElem) {
     }
 }
 
+function setTitle(title) {
+    const titleElem = document.querySelector('title')
+    titleElem.textContent = unescape(title)
+}
 
 /**
  * Adds click listeners to the "show more" and "show less" facet affordances.


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9787

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Unescapes the search result title, then updates the title via the `title` element's `textContent` property.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
