### PR TITLE
fix cover image loading on author page

### DIFF
--- a/openlibrary/book_providers.py
+++ b/openlibrary/book_providers.py
@@ -550,14 +550,8 @@ def get_cover_url(ed_or_solr: Edition | dict) -> str | None:
         return cover.url(size) if cover else None
 
     # Solr edition
-    elif ed_or_solr['key'].startswith('/books/'):
-        if ed_or_solr.get('cover_i'):
-            return (
-                get_coverstore_public_url()
-                + f'/b/id/{ed_or_solr["cover_i"]}-{size}.jpg'
-            )
-        else:
-            return None
+    elif ed_or_solr['key'].startswith('/books/') and ed_or_solr.get('cover_i'):
+        return get_coverstore_public_url() + f'/b/id/{ed_or_solr["cover_i"]}-{size}.jpg'
 
     # Solr document augmented with availability
     availability = ed_or_solr.get('availability', {}) or {}
@@ -567,7 +561,7 @@ def get_cover_url(ed_or_solr: Edition | dict) -> str | None:
         return f"{get_coverstore_public_url()}/b/olid/{olid}-{size}.jpg"
     if availability.get('identifier'):
         ocaid = ed_or_solr['availability']['identifier']
-        return f"//archive.org/services/img/{ocaid}"
+        return f"https://archive.org/download/{ocaid}/page/cover_w180_h360.jpg"
 
     # Plain solr - we don't know which edition is which here, so this is most
     # preferable


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9064 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fixes the cover image visiblity on the authors page

### Technical
<!-- What should be noted about the implementation? -->
In the `book_providers.py`, combining  the conditional statements `ed_or_solr['key'].startswith('/books/')` and `ed_or_solr.get('cover_i')` makes sure that if either of them fails, code continues to next `elif` block instead of returning `None` 

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Run the docker image with terminal using the command `docker compose exec web bash`
- load the book and author data using `PYTHONPATH=. python ./scripts/copydocs.py /books/OL45606286M /authors/OL12180252A`
- to see other book covers, change the covers url in `openlibrary.yml`

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![fix](https://github.com/user-attachments/assets/9ff8501b-b8a7-4818-b606-529a43091058)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@scottbarnes 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
