### PR TITLE
Temporarily disable erroring network requests

### DIFF
--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -798,6 +798,7 @@ class Author(Thing):
     def wikidata(
         self, bust_cache: bool = False, fetch_missing: bool = False
     ) -> WikidataEntity | None:
+        return None
         if wd_id := self.remote_ids.get("wikidata"):
             return get_wikidata_entity(
                 qid=wd_id, bust_cache=bust_cache, fetch_missing=fetch_missing

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -2011,7 +2011,7 @@ msgstr ""
 
 #: admin/imports-add.html admin/inspect/store.html admin/ip/view.html
 #: admin/people/edits.html admin/permissions.html check_ins/check_in_form.html
-#: check_ins/reading_goal_form.html covers/add.html
+#: check_ins/reading_goal_form.html
 msgid "Submit"
 msgstr ""
 
@@ -4428,10 +4428,6 @@ msgstr ""
 
 #: covers/add.html
 msgid "Upload"
-msgstr ""
-
-#: covers/add.html
-msgid "Or, paste in the image URL if it's on the web"
 msgstr ""
 
 #: covers/add.html

--- a/openlibrary/macros/AffiliateLinks.html
+++ b/openlibrary/macros/AffiliateLinks.html
@@ -46,7 +46,7 @@ $def affiliate_link(key, analytics_key, name, link, price='', price_note=''):
       } if isbn else None
 
       # Fetch price data
-      if not is_bot() and prices and isbn:
+      if False and not is_bot() and prices and isbn:
         bwb_metadata = get_betterworldbooks_metadata(isbn)
         bwb['price'] = bwb_metadata and bwb_metadata.get('price')
         if amazon:

--- a/openlibrary/templates/covers/add.html
+++ b/openlibrary/templates/covers/add.html
@@ -54,15 +54,15 @@ $if doc.type.key == "/type/work":
     </div>
 </form>
 
-<form class="ol-cover-form ol-cover-form--url" method="post" enctype="multipart/form-data" action="$action">
-    <div class="label">
-        <label id="imageWeb" for="imageUrl">$_("Or, paste in the image URL if it's on the web")</label>
-    </div>
-    <div class="input">
-        <input type="url" name="url" id="imageUrl" value="$data.get('url', '')" placeholder="https://..." required />
-        <button type="submit" class="cta-btn cta-btn--vanilla">$_("Submit")</button>
-    </div>
-</form>
+$#<form class="ol-cover-form ol-cover-form--url" method="post" enctype="multipart/form-data" action="$action">
+$#    <div class="label">
+$#        <label id="imageWeb" for="imageUrl">$_("Or, paste in the image URL if it's on the web")</label>
+$#    </div>
+$#    <div class="input">
+$#        <input type="url" name="url" id="imageUrl" value="$data.get('url', '')" placeholder="https://..." required />
+$#        <button type="submit" class="cta-btn cta-btn--vanilla">$_("Submit")</button>
+$#    </div>
+$#</form>
 
 $if doc.type.key == "/type/edition" and doc.ocaid:
     $ img_url = "https://archive.org/services/img/%s/full/pct:600/0/default.jpg" % doc.ocaid


### PR DESCRIPTION
Disables prices rendering, wikidata fetching (which can cause timeouts), and cover add by url.

### Technical
These requests were hanging around, timing out after like 30s, causing our haproxy's queue to fill up and resulting in a lot of 500s. Disabling them for now. Patch deployed this ~a week ago; not only this chunk, not the covers UI change has been patch deployed.

Also disabling the covers upload by URL UI, since it won't work for the time being.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
