### PR TITLE
Added 'beta' tag to Bulk Search AI Extractor'

### DIFF
--- a/openlibrary/components/BulkSearch/utils/classes.js
+++ b/openlibrary/components/BulkSearch/utils/classes.js
@@ -219,7 +219,7 @@ export class BulkSearchState{
             new RegexExtractor('Pattern: Title - Author', '(^|>)(?<title>[A-Za-z][\\p{L}0-9\\- ,]{1,250})\\s+[,-\u2013\u2014\\t]\\s+(?<author>[\\p{L}][\\p{L}\\.\\- ]{3,70})( \\(.*)?($|<\\/)'),
             new RegexExtractor('Pattern: Title (Author)', '^(?<title>[\\p{L}].{1,250})\\s\\(?<author>(.{3,70})\\)$$'),
             new RegexExtractor('Wikipedia Citation Pattern: (e.g. Baum, Frank L. (1994). The Wizard of Oz)', '^(?<author>[^.()]+).*?\\)\\. (?<title>[^.]+)'),
-            new AiExtractor('✨ AI Extraction', 'gpt-4o-mini'),
+            new AiExtractor('✨ AI Extraction (Beta)', 'gpt-4o-mini'),
             new TableExtractor('Extract from a Table/Spreadsheet')
         ]
         /** @type {Number} */


### PR DESCRIPTION

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR adds the 'beta' tag to the Bulk Search AI selector. It's an extremely minor change, that should not have any effects on functionality or the rest of the codebase. 

### Technical
<!-- What should be noted about the implementation? -->
Six characters were added within a string. 
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Simply run up the local instance, head to '/search/bulk', and check to see that AI Extractor has been renamed to AI Extractor (Beta).
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/user-attachments/assets/1162aebe-a49b-4f83-8832-54fe3179fde2)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
