### PR TITLE
fail calls to openlibrary.php gracefully

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -1103,9 +1103,9 @@ class IA_Lending_API:
             ).json()
             logger.info("POST response: %s", jsontext)
             return jsontext
-        except Exception:  # TODO: Narrow exception scope
+        except (JSONDecodeError, Exception):  # TODO: Narrow exception scope
             logger.exception("POST failed")
-            raise
+            return {}
 
 
 ia_lending_api = IA_Lending_API()

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -1103,9 +1103,12 @@ class IA_Lending_API:
             ).json()
             logger.info("POST response: %s", jsontext)
             return jsontext
-        except (JSONDecodeError, Exception):  # TODO: Narrow exception scope
-            logger.exception("POST failed")
+        except JSONDecodeError:
+            logger.exception("POST failed to openlibrary.php, no json")
             return {}
+        except Exception:  # TODO: Narrow exception scope
+            logger.exception("POST failed")
+            raise
 
 
 ia_lending_api = IA_Lending_API()


### PR DESCRIPTION
Categorically fixes `IA_Lending_API` issue where Open Library breaks when `archive.org/services/openlibrary.php` not reachable

Was discovered when trying to hit https://openlibrary.org/account/loans. Because `archive.org/services/openlibrary.php` is currently blocked by mod_security WAF, the API was hitting non-json 403 response and dying.

Thie code path here was: `get_waitinglist_for_user` in `/openlibrary/openlibrary/core/waitinglist.py` which died while trying to call `waitlist.extend(WaitingLoan.query(userid=account.itemname))`. The `WaitingLoan.query` uses `core.lending.IA_Lending_API` which has a `_post` method https://github.com/internetarchive/openlibrary/compare/master...php-graceful-failure?quick_pull=1#diff-896c18b3ccfadfa425c7e24a86226343314fce7957d14a8023d3e159156b224bL1092 which has been patched to return `{}` instead of `raise` when a failure occurs.

