### PR TITLE
Add Project Runeberg author+edition identifiers

### DIFF
--- a/openlibrary/plugins/openlibrary/config/author/identifiers.yml
+++ b/openlibrary/plugins/openlibrary/config/author/identifiers.yml
@@ -55,6 +55,11 @@ identifiers:
     notes: Should be a number
     url: https://www.gutenberg.org/ebooks/author/@@@
     website: https://www.gutenberg.org
+-   label: Project Runeberg
+    name: project_runeberg
+    notes: Should be a string of alphanumeric characters (/[0-9a-z/.-]+/)
+    url: https://runeberg.org/authors/@@@.html
+    website: https://runeberg.org/
 -   label: SBN/ICCU (National Library Service of Italy)
     name: opac_sbn
     notes: format is /^\D{2}[A-Z0-3]V\d{6}$/

--- a/openlibrary/plugins/openlibrary/config/edition/identifiers.yml
+++ b/openlibrary/plugins/openlibrary/config/edition/identifiers.yml
@@ -241,6 +241,11 @@ identifiers:
     name: project_gutenberg
     url: https://www.gutenberg.org/ebooks/@@@
     website: https://www.gutenberg.org
+-   label: Project Runeberg
+    name: project_runeberg
+    notes: Should be a string of alphanumeric characters (/[0-9a-z/.-]+/)
+    url: https://runeberg.org/@@@/
+    website: https://runeberg.org/
 -   label: Scribd
     name: scribd
     url: https://www.scribd.com/doc/@@@/


### PR DESCRIPTION
Project Runeberg is similar to Project Gutenberg, but focuses on Nordic and Scandinavian authors and literature.

These identifiers basically correspond to
https://www.wikidata.org/wiki/Property:P3154 and
https://www.wikidata.org/wiki/Property:P3155
in Wikidata.

<!-- What issue does this PR close? -->
Closes https://github.com/internetarchive/openlibrary/issues/9981

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

feature

### Technical
<!-- What should be noted about the implementation? -->

Adds additional blocks to identifier YAML files. Doesn’t touch any (logic) code otherwise.

### Testing

* Edit an author, verify that the Project Runeberg identifier is present in the identifier dropdown list.
* Edit an edition, verify that the Project Runeberg identifier is present in the identifier dropdown list.

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
