### PR TITLE
Fix Browse Menu Padding

### DIFF
--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -77,7 +77,7 @@
         color: @dark-grey;
         white-space: nowrap;
         font-size: .9em;
-        padding: 10px;
+        padding: 15px 10px;
         display: block;
       }
 
@@ -347,7 +347,7 @@
     li {
       -ms-flex-preferred-size: 100%;
       flex-basis: 100%;
-      padding: 5px 0;
+      padding: 0;
       font-size: 1em;
 
       // stylelint-disable max-nesting-depth, selector-max-specificity


### PR DESCRIPTION
Shift padding from li wrapper to button element to increase clickable area of buttons in header browse menu.

<!-- What issue does this PR close? -->
Closes #9971 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes an issue where some vertical space on button in the header Browse dropdown menu was unclickable.

### Technical
<!-- What should be noted about the implementation? -->
Shifted padding from `li` wrapper to `a` inner element in `header-bar.less`

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Open the Browse menu on any screen
- Confirm that, for each button, the top and bottom 5px are now clickable (excluding the border)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Image shows the new boundaries of the `a` clickable element in the browse menu: 
![image](https://github.com/user-attachments/assets/996847a1-bd2b-49a5-ba0b-dd90f779c3d8)




### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
