### PR TITLE
Swap order of isActive and coverUrl in updateDroppersOnListCreation.

### DIFF
--- a/openlibrary/plugins/openlibrary/js/my-books/CreateListForm.js
+++ b/openlibrary/plugins/openlibrary/js/my-books/CreateListForm.js
@@ -124,7 +124,7 @@ export class CreateListForm {
 
         for (const dropper of droppers) {
             const isActive = dropper === openDropper
-            dropper.readingLists.onListCreationSuccess(listKey, listTitle, coverUrl, isActive)
+            dropper.readingLists.onListCreationSuccess(listKey, listTitle, isActive, coverUrl)
         }
     }
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #[9701](https://github.com/internetarchive/openlibrary/issues/9701)

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes the issue where lists created on search page initially appear checked in every dropper

### Technical
<!-- What should be noted about the implementation? -->
- Minor changes made where `isActive` and `coverUrl's` order are swapped in `updateDroppersOnListCreation` to match `onListCreationSuccess(listKey, listTitle, isActive, coverUrl)`

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Go to the /search page, and ensure that there are multiple search results.
- Using the "My Books" dropper found in the first search result, create a new list.
- Expected behavior: The new list appears in each dropper, but is only checked in the first dropper.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
