### PR TITLE
Include OCLC ids on the Add Book page

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -3145,6 +3145,10 @@ msgid "Invalid LC Control Number format"
 msgstr ""
 
 #: books/add.html
+msgid "Invalid OCLC/WorldCat Control Number format"
+msgstr ""
+
+#: books/add.html
 msgid "Please enter a value for the selected identifier"
 msgstr ""
 

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -3243,6 +3243,10 @@ msgid "LibriVox"
 msgstr ""
 
 #: books/add.html
+msgid "OCLC/WorldCat"
+msgstr ""
+
+#: books/add.html
 msgid "Project Gutenberg"
 msgstr ""
 

--- a/openlibrary/plugins/openlibrary/js/add-book.js
+++ b/openlibrary/plugins/openlibrary/js/add-book.js
@@ -1,17 +1,20 @@
 import {
     parseIsbn,
     parseLccn,
+    parseOclc,
     isChecksumValidIsbn10,
     isChecksumValidIsbn13,
     isFormatValidIsbn10,
     isFormatValidIsbn13,
-    isValidLccn
+    isValidLccn,
+    isValidOclc
 } from './idValidation.js'
 
 let invalidChecksum;
 let invalidIsbn10;
 let invalidIsbn13;
 let invalidLccn;
+let invalidOclc;
 let emptyId;
 
 const i18nStrings = JSON.parse(document.querySelector('form[name=edit]').dataset.i18n);
@@ -32,6 +35,7 @@ export function initAddBookImport () {
     invalidIsbn10 = i18nStrings.invalid_isbn10;
     invalidIsbn13 = i18nStrings.invalid_isbn13;
     invalidLccn = i18nStrings.invalid_lccn;
+    invalidOclc = i18nStrings.invalid_oclc;
     emptyId = i18nStrings.empty_id;
 
     $('#id_value').on('change',autoCompleteIdName);
@@ -69,7 +73,7 @@ function displayIsbnError(event, errorMessage) {
     document.getElementById('id_value').value = parseIsbn(document.getElementById('id_value').value);
 }
 
-function displayLccnError(event, errorMessage) {
+function displayIdentifierError(event, errorMessage) {
     const errorDiv = document.getElementById('id-errors');
     errorDiv.classList.remove('hidden');
     errorDiv.textContent = errorMessage;
@@ -97,6 +101,9 @@ function parseAndValidateId(event) {
     }
     else if (fieldName === 'lccn') {
         parseAndValidateLccn(event, idValue);
+    }
+    else if (fieldName === 'oclc_numbers') {
+        parseAndValidateOclc(event, idValue);
     }
     else if (!fieldName || !isEmptyId(event, idValue)) {
         document.getElementById('id_value').value = idValue.trim();
@@ -140,7 +147,15 @@ function parseAndValidateIsbn13(event, idValue) {
 function parseAndValidateLccn(event, idValue) {
     idValue = parseLccn(idValue);
     if (!isValidLccn(idValue)) {
-        return displayLccnError(event, invalidLccn);
+        return displayIdentifierError(event, invalidLccn);
+    }
+    document.getElementById('id_value').value = idValue;
+}
+
+function parseAndValidateOclc(event, idValue) {
+    idValue = parseOclc(idValue);
+    if (!isValidOclc(idValue)) {
+        return displayIdentifierError(event, invalidOclc);
     }
     document.getElementById('id_value').value = idValue;
 }

--- a/openlibrary/plugins/openlibrary/js/idValidation.js
+++ b/openlibrary/plugins/openlibrary/js/idValidation.js
@@ -105,6 +105,35 @@ export function isValidLccn(lccn) {
 }
 
 /**
+ * Parses and cleans up OCLC/WorldCat identifier input.
+ * @param {String} oclc  OCLC string for parsing
+ * @returns {String}  parsed OCLC string
+ */
+export function parseOclc(oclc) {
+    // cleaning initial oclc entry
+    return oclc
+        // remove any whitespace
+        .replace(/\s/g, '')
+        // remove leading/padding zeroes
+        .replace(/^0+/, '');
+}
+
+/**
+ * Verify OCLC Control Number syntax. OCLC Numbers are “unique, sequentially
+ * assigned number[s] associated with a record in WorldCat.”
+ * They only contains digits and aren’t normally 0-padded.
+ * See https://help.oclc.org/Metadata_Services/OCLC_MARC_records/Summary_of_processing_changes/History_of_the_OCLC_number
+ * and https://help.oclc.org/Library_Management/WorldShare_Reports/Report_objects/Report_objects_A_to_Z/Report_objects_M-P#O
+ * @param {String} oclc  OCLC string to test for valid syntax
+ * @returns {boolean}  true if given OCLC is valid syntax, false otherwise
+ */
+export function isValidOclc(oclc) {
+    // matching parsed entry to regex representing valid oclc
+    const regex = /^[1-9][0-9]*$/;
+    return regex.test(oclc);
+}
+
+/**
  * Given a list of identifier entries from edition page form and a new
  * identifier, determines if the new identifier has already been entered
  * under the same type as an existing identifier entry.

--- a/openlibrary/templates/books/add.html
+++ b/openlibrary/templates/books/add.html
@@ -74,6 +74,7 @@ $ i18n_strings = {
                 <option value="isbn_13">$_("ISBN 13")</option>
                 <option value="lccn">$_("LCCN")</option>
                 <option value="librivox">$_("LibriVox")</option>
+                <option value="oclc_numbers">$_("OCLC/WorldCat")</option>
                 <option value="project_gutenberg">$_("Project Gutenberg")</option>
                 </select>
                 &nbsp;

--- a/openlibrary/templates/books/add.html
+++ b/openlibrary/templates/books/add.html
@@ -7,6 +7,7 @@ $ i18n_strings = {
     $ "invalid_isbn10": _("ID must be exactly 10 characters [0-9 or X]. For example 0-19-853453-1 or 0198534531"),
     $ "invalid_isbn13": _("ID must be exactly 13 characters [0-9]. For example 978-3-16-148410-0 or 9783161484100"),
     $ "invalid_lccn": _("Invalid LC Control Number format"),
+    $ "invalid_oclc": _("Invalid OCLC/WorldCat Control Number format"),
     $ "empty_id": _("Please enter a value for the selected identifier"),
     $ "invalid_publish_date": _("Are you sure that's the published date?")
     $ }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes https://github.com/internetarchive/openlibrary/issues/8719

<!-- What does this PR achieve? [|hotfix|fix|refactor] -->

feature

### Technical

Adds another option to the dropdown, using the same ordering used in the [`$popular` array for adding identifiers on the book editing page](https://github.com/internetarchive/openlibrary/blob/0621e75c0cea30be3902b606198247d6c1b2dc23/openlibrary/templates/books/edit/edition.html#L444).

Validation is based on that of the LCCN identifiers, but also generalises the `displayLccnError()` function into a generic `displayIdentifierError()` since there wasn’t anything LCCN specific about it – and I didn’t want to WET the code by copy/pasting the code for an identical `displayOclcError()` function. :) (This PR already WETs a fair deal. A lot of the LCCN and OCLC could be abstracted a bit more to be usable for both case.)

### Testing

1. Go to the add a new book page
2. Verify that the OCLC is in the dropdown
3. Try adding add an invalid OCLC id and submit the book
4. Verify that you get an error and book wasn’t added
5. Add a valid OCLC id and submit
6. Verify the OCLC id was saved along with the book

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->

@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
