### PR TITLE
Use proxy for external requests

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1388,8 +1388,12 @@ def setup_requests():
 
     logger.info("Setting up proxy")
     if infogami.config.get("http_proxy", ""):
-        os.environ['HTTP_PROXY'] = os.environ['http_proxy'] = infogami.config.get('http_proxy')
-        os.environ['HTTPS_PROXY'] = os.environ['https_proxy'] = infogami.config.get('http_proxy')
+        os.environ['HTTP_PROXY'] = os.environ['http_proxy'] = infogami.config.get(
+            'http_proxy'
+        )
+        os.environ['HTTPS_PROXY'] = os.environ['https_proxy'] = infogami.config.get(
+            'http_proxy'
+        )
         logger.info('Proxy environment variables are set')
     else:
         logger.info("No proxy configuration found")

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1383,6 +1383,28 @@ def setup_context_defaults():
     context.defaults.update({'features': [], 'user': None, 'MAX_VISIBLE_BOOKS': 5})
 
 
+def setup_requests():
+    logger.info("Setting up requests")
+
+    logger.info("Setting up proxy")
+    if infogami.config.get("http_proxy", ""):
+        os.environ['HTTP_PROXY'] = os.environ['http_proxy'] = infogami.config.get('http_proxy')
+        os.environ['HTTPS_PROXY'] = os.environ['https_proxy'] = infogami.config.get('http_proxy')
+        logger.info('Proxy environment variables are set')
+    else:
+        logger.info("No proxy configuration found")
+
+    logger.info("Setting up proxy bypass")
+    if infogami.config.get("no_proxy_addresses", []):
+        no_proxy = ",".join(infogami.config.get("no_proxy_addresses"))
+        os.environ['NO_PROXY'] = os.environ['no_proxy'] = no_proxy
+        logger.info('Proxy bypass environment variables are set')
+    else:
+        logger.info("No proxy bypass configuration found")
+
+    logger.info("Requests set up")
+
+
 def setup():
     from openlibrary.plugins.openlibrary import (
         sentry,
@@ -1421,6 +1443,7 @@ def setup():
 
     setup_context_defaults()
     setup_template_globals()
+    setup_requests()
 
 
 setup()


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10002

Adds ability to configure `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables via `conf/openlibrary.yml` entries.

New configuration entry `http_proxy` is a string URL for an HTTP proxy.  If included in the configuration file, the `HTTPS_PROXY` and `HTTP_PROXY` environment variables will be set with this value.

The new `no_proxy_addresses` configuration is a list of addresses that should not be passed through the proxy.  If this configuration is present, the addresses will be combined in a comma-separated string and used to set the `NO_PROXY` environment variable.


<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
https://github.com/internetarchive/openlibrary/labels/Needs%3A%20Special%20Deploy label added because new configuration entry is required.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
