### PR TITLE
Update to fix view on image validation failure

### DIFF
--- a/openlibrary/plugins/upstream/covers.py
+++ b/openlibrary/plugins/upstream/covers.py
@@ -34,10 +34,10 @@ class ImageValidator:
         self.max_file_size = 10 * 1024 * 1024  # 10 MB
         self.allowed_extensions = {'.jpg', '.jpeg', '.gif', '.png'}
 
-    def validate(self, file):
-        self.validate_extension(file.filename)
-        self.validate_size(file.file)
-        self.validate_image(file.file)
+    def validate(self, filename, data):
+        self.validate_extension(filename)
+        self.validate_size(data)
+        self.validate_image(data)
 
     def validate_size(self, file_data):
         file_size = len(file_data.read())
@@ -100,10 +100,9 @@ class add_cover(delegate.page):
         olid = key.split("/")[-1]
 
         if i.file is not None and hasattr(i.file, 'file'):
-            validator = ImageValidator()
-            validator.validate(i.file)
-
             data = i.file.file
+            validator = ImageValidator()
+            validator.validate(i.file.filename, data)
         else:
             data = None
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes: #10086
Follow-up to #9966
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes "Unable to render this page" message being rendered in cover modal when image validation fails.

### Technical
<!-- What should be noted about the implementation? -->
Adds `validate` method to image validator.  Replaces existing image validation calls with a single `validate` call in the `upload` method.

Validation errors are now propagated from `upload` to the image upload handler.  When a validation error occurs, the `covers/add` template is rendered with an error message.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Attempt to upload an invalid image to the covers service.  Expect to see a generic error message.

An invalid image has at least one of the following properties:
- Is greater than 10MB size
- Ends with an invalid file extension
- Is not actually an image

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot 2024-11-07 171051](https://github.com/user-attachments/assets/394e311f-c924-4798-900d-159d81ae9552)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
