### PR TITLE
Make debug=true use the features config in openlibrary.yml

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -56,6 +56,7 @@ http_request_timeout: 10
 
 features:
     cache_most_recent: enabled
+    debug: enabled
     dev: enabled
     history_v2: admin
     inlibrary: enabled

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -25,7 +25,7 @@ if not hasattr(infogami.config, 'features'):
     infogami.config.features = []  # type: ignore[attr-defined]
 
 from infogami.utils.app import metapage
-from infogami.utils import delegate
+from infogami.utils import delegate, features
 from openlibrary.utils import dateutil
 from infogami.utils.view import (
     render,
@@ -1127,7 +1127,6 @@ def save_error():
 
 
 def internalerror():
-    i = web.input(_method='GET', debug='false')
     name = save_error()
 
     # TODO: move this stats stuff to plugins\openlibrary\stats.py
@@ -1141,7 +1140,7 @@ def internalerror():
     if sentry.enabled:
         sentry.capture_exception_webpy()
 
-    if i.debug.lower() == 'true':
+    if features.is_enabled('debug'):
         raise web.debugerror()
     else:
         msg = render.site(render.internalerror(name))

--- a/openlibrary/templates/admin/people/view.html
+++ b/openlibrary/templates/admin/people/view.html
@@ -106,7 +106,7 @@ $ has_profile = person.get_user() is not None
 <div id="contentBody">
 
     <div class="status status-$person.status">
-        <form method="POST" action="?debug=true">
+        <form method="POST">
             Status: <span class="status">$person.status</span>
 
         $if person.status in ['active', 'verified']:
@@ -216,7 +216,7 @@ $ has_profile = person.get_user() is not None
     <tr>
         <td>$_("Anonymize Account:")</td>
         <td>
-            <form method="POST" id="anonymize-form" action="?debug=true">
+            <form method="POST" id="anonymize-form">
                 <input type="checkbox" id="dry-run-checkbox" name="dry_run">
                 <label for="dry-run-checkbox">$_("Dry Run")</label>
                 <button type="submit" name="action" value="anonymize_account" style="float: right;" class="account-anonymization-button" data-display-name="$person.username">$_("Anonymize Account")</button>

--- a/openlibrary/templates/type/list/edit.html
+++ b/openlibrary/templates/type/list/edit.html
@@ -97,7 +97,7 @@ $jsdef lazy_thing_preview(key, render_fn_name):
     </div>
 
 <div id="contentBody">
-    <form method="post" id="list-edit" class="olform" $:cond(query_param('debug'), 'action="?debug=true"')>
+    <form method="post" id="list-edit" class="olform">
         $if not new:
             <input
                 required


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes https://github.com/internetarchive/olsystem/issues/223

Also has parts:
- https://github.com/internetarchive/infogami/pull/224
- https://github.com/internetarchive/olsystem/pull/239

### Technical

We have a `features` section in our openlibrary.yml, which has a `debug` feature which specifies the query parameter / value. But this was never being read from, and instead the literal value `true` was used. This lets the configuration work correctly so we can control the parameter from the openlibrary.yml file.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
Note: This requires the infogami changes to be merged in first! Locally you can test this with the docker compose infogami local file.

Tested:

Add to openlibrary.yml:

```yaml
features:
    debug:
        filter: queryparam
        name: debug
        value: "true"  # Note the quotes are important! Otherwise it'll never match :P
```
Introducing an error to an html template, `$ x = 7 / 0` to status.html, and :
- going to http://localhost:8080/status does not show debug
- going to http://localhost:8080/status?debug=true does not show debug
- going to http://localhost:8080/status?debug=foobar does show debug

Introducing an error to an API page,
- going to http://localhost:8080/search.json?q=the does not show debug
- going to http://localhost:8080/search.json?q=the&debug=true does not show debug
- going to http://localhost:8080/search.json?q=the&debug=foobar does show debug


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
