### PR TITLE
Conditionally fetch blog RSS feed 

### DIFF
--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -1410,7 +1410,7 @@ def _get_blog_feeds():
             }
 
         try:
-            headers = { "If-Modified-Since": modified_date }
+            headers = {"If-Modified-Since": modified_date}
             stats.begin("get_blog_feeds", url=url)
             result = requests.get(url, headers=headers)
             if result.status_code == 304:
@@ -1434,6 +1434,7 @@ def _get_blog_feeds():
             stats.end()
 
         return items
+
     return parse_xml
 
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2831

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
refactor!  This wraps the existing `_get_blog_feeds` functionality via an enclosure that caches the result and date so a conditional get request can be performed.

### Technical
<!-- What should be noted about the implementation? -->
This was done under an assumption that I probably should not change `cache.memcache_memoize` and leave it as is.  This technically uses an alternate sort of 'cache' mechanism in that we're leaving the results inside the closure.

Also?  It's been a hot minute since I've changed some python code, so help testing this PR to make sure it works would be really appreciated!

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
