### PR TITLE
Temporarily remove "Add cover" affordance

### DIFF
--- a/openlibrary/templates/covers/change.html
+++ b/openlibrary/templates/covers/change.html
@@ -1,8 +1,7 @@
 $def with (doc, cover_selector=".bookCover img", imagesId=0)
 
-$# If user is not logged-in don't show add/manage link.
-$if not ctx.user:
-    $return
+$# Temporarily disable cover management
+$return
 
 
 $if doc.type.key == '/type/author':


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Related to #10012

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes "Add cover"/"Manage cover" affordances temporarily.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in:
1. Go to a book page.
2. Hover over the book's cover image.  Expect nothing to change (_i.e._ "Add cover" affordance doesn't appear).

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
