### PR TITLE
Revert renovate.json changes -- causing too much auto-merging

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,12 +32,13 @@
       "automerge": true
     },
     {
-      "fileMatch": [
-        "requirements_test.txt"
-      ],
       "automerge": true,
       "matchPackageNames": [
-        "*"
+        "mypy",
+        "pytest",
+        "pytest-asyncio",
+        "ruff",
+        "safety"
       ]
     },
     {


### PR DESCRIPTION
Reverts #10024 .


### Technical
<!-- What should be noted about the implementation? -->

I think the `-r requirements.txt` in our `requirements_test.txt` is causing everything to be included! Eg this auto-merge enabled simplejson update, which shouldn't be auto-merge enabled.
![image](https://github.com/user-attachments/assets/0201ccbd-aede-4f23-800d-1f20a82fe676)


### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
