### PR TITLE
Use IdentifiersInput Vue component for work identifier UI

### DIFF
--- a/openlibrary/components/IdentifiersInput.vue
+++ b/openlibrary/components/IdentifiersInput.vue
@@ -170,7 +170,7 @@ export default {
                     return;
                 }
             } else if (this.assignedIdentifiers[this.selectedIdentifier]) {
-                errorDisplay(`An author identifier for ${this.identifierConfigsByKey[this.selectedIdentifier].label} already exists.`)
+                errorDisplay(`An identifier for ${this.identifierConfigsByKey[this.selectedIdentifier].label} already exists.`)
                 return;
             } else { errorDisplay() }
             // We use $set otherwise we wouldn't get the reactivity desired
@@ -227,6 +227,10 @@ export default {
     },
     created: function(){
         this.assignedIdentifiers = JSON.parse(decodeURIComponent(this.assigned_ids_string));
+        if (this.assignedIdentifiers.length === 0) {
+            this.assignedIdentifiers = {}
+            return;
+        }
         if (this.isEdition) {
             const edition_identifiers = {};
             this.assignedIdentifiers.forEach(entry => {
@@ -237,6 +241,12 @@ export default {
                 }
             })
             this.assignedIdentifiers = edition_identifiers;
+        } else if (this.input_prefix === 'work--identifiers'){
+            const work_identifiers = {};
+            this.assignedIdentifiers.forEach(entry => {
+                work_identifiers[entry.name] = entry.value;
+            })
+            this.assignedIdentifiers = work_identifiers;
         }
     },
     watch: {

--- a/openlibrary/components/IdentifiersInput.vue
+++ b/openlibrary/components/IdentifiersInput.vue
@@ -28,14 +28,14 @@
       </th>
     </tr>
       <template v-for="(value, name) in assignedIdentifiers">
-        <tr :key="name" v-if="value && !isEdition">
+        <tr :key="name" v-if="value && !saveIdentifiersAsList">
           <td>{{ identifierConfigsByKey[name].label }}</td>
           <td>{{ value }}</td>
           <td>
             <button class="form-control" @click="removeIdentifier(name)">Remove</button>
           </td>
         </tr>
-        <template v-else-if="value && isEdition">
+        <template v-else-if="value && saveIdentifiersAsList">
           <tr v-for="(item, idx) in value" :key="name + idx">
             <td>{{ identifierConfigsByKey[name].label }}</td>
             <td>{{ item }}</td>
@@ -76,7 +76,9 @@ export default {
         id_config_string: {
             type: String
         },
-        /** see createHiddenInputs function for usage */
+        /** see createHiddenInputs function for usage
+         * #hiddenEditionIdentifiers, #hiddenWorkIdentifiers
+         */
         output_selector: {
             type: String
         },
@@ -108,20 +110,20 @@ export default {
         return {
             selectedIdentifier: '', // Which identifier is selected in dropdown
             inputValue: '', // What user put into input
-            assignedIdentifiers: {}, // IDs assigned to the entity Ex: {'viaf': '12632978'}
+            assignedIdentifiers: {}, // IDs assigned to the entity Ex: {'viaf': '12632978'} or {'abaa': ['123456','789012']}
         }
     },
 
     computed: {
         popularEditionConfigs: function() {
-            if (this.isEdition) {
+            if (this.edition_popular) {
                 const popularConfigs = JSON.parse(decodeURIComponent(this.edition_popular));
                 return Object.fromEntries(popularConfigs.map(e => [e.name, e]));
             }
             return {};
         },
         secondaryEditionConfigs: function() {
-            if (this.isEdition) {
+            if (this.secondary_identifiers) {
                 const secondConfigs = JSON.parse(decodeURIComponent(this.secondary_identifiers));
                 return Object.fromEntries(secondConfigs.map(e => [e.name, e]));
             }
@@ -139,6 +141,9 @@ export default {
             return this.admin.toLowerCase() === 'true';
         },
         isEdition() {
+            return this.multiple.toLowerCase() === 'true' && this.edition_popular;
+        },
+        saveIdentifiersAsList() {
             return this.multiple.toLowerCase() === 'true';
         },
         setButtonEnabled: function(){
@@ -154,10 +159,10 @@ export default {
             if (this.selectedIdentifier === 'isni') {
                 this.inputValue = this.inputValue.replace(/\s/g, '')
             }
-            if (this.isEdition) {
+            if (this.saveIdentifiersAsList) {
                 // collect id values of matching type, or empty array if none present
                 const existingIds = this.assignedIdentifiers[this.selectedIdentifier] ?? [];
-                const validEditionId = validateEditionIdentifiers(this.selectedIdentifier, this.inputValue, existingIds);
+                const validEditionId = validateEditionIdentifiers(this.selectedIdentifier, this.inputValue, existingIds, this.output_selector);
                 if (validEditionId) {
                     if (!this.assignedIdentifiers[this.selectedIdentifier]) {
                         this.inputValue = [this.inputValue];
@@ -170,9 +175,9 @@ export default {
                     return;
                 }
             } else if (this.assignedIdentifiers[this.selectedIdentifier]) {
-                errorDisplay(`An identifier for ${this.identifierConfigsByKey[this.selectedIdentifier].label} already exists.`)
+                errorDisplay(`An identifier for ${this.identifierConfigsByKey[this.selectedIdentifier].label} already exists.`, this.output_selector)
                 return;
-            } else { errorDisplay() }
+            } else { errorDisplay('', this.output_selector) }
             // We use $set otherwise we wouldn't get the reactivity desired
             // See https://vuejs.org/v2/guide/reactivity.html#Change-Detection-Caveats
             this.$set(this.assignedIdentifiers, this.selectedIdentifier, this.inputValue);
@@ -180,8 +185,8 @@ export default {
             this.selectedIdentifier = '';
         },
         /** Removes an identifier with value from memory and it will be deleted from database on save */
-        removeIdentifier: function(identifierName, idx = 0){
-            if (this.isEdition) {
+        removeIdentifier: function(identifierName, idx = 0) {
+            if (this.saveIdentifiersAsList) {
                 this.assignedIdentifiers[identifierName].splice(idx, 1);
             } else {
                 this.$set(this.assignedIdentifiers, identifierName, '');
@@ -194,7 +199,8 @@ export default {
               * So for now this just drops the hidden inputs into the the parent form anytime there is a change
               */
             let html = '';
-            if (this.isEdition) {
+            // should save a list of ids for work + edition identifiers
+            if (this.saveIdentifiersAsList) {
                 let num = 0;
                 for (const [key, value] of Object.entries(this.assignedIdentifiers)) {
                     for (const idx in value) {
@@ -231,7 +237,7 @@ export default {
             this.assignedIdentifiers = {}
             return;
         }
-        if (this.isEdition) {
+        if (this.saveIdentifiersAsList) {
             const edition_identifiers = {};
             this.assignedIdentifiers.forEach(entry => {
                 if (!edition_identifiers[entry.name]) {
@@ -241,12 +247,6 @@ export default {
                 }
             })
             this.assignedIdentifiers = edition_identifiers;
-        } else if (this.input_prefix === 'work--identifiers'){
-            const work_identifiers = {};
-            this.assignedIdentifiers.forEach(entry => {
-                work_identifiers[entry.name] = entry.value;
-            })
-            this.assignedIdentifiers = work_identifiers;
         }
     },
     watch: {

--- a/openlibrary/components/IdentifiersInput.vue
+++ b/openlibrary/components/IdentifiersInput.vue
@@ -52,7 +52,7 @@
 </template>
 
 <script>
-import { errorDisplay, validateEditionIdentifiers } from './IdentifiersInput/utils/utils.js';
+import { errorDisplay, validateIdentifiers } from './IdentifiersInput/utils/utils.js';
 const identifierPatterns  = {
     wikidata: /^Q[1-9]\d*$/i,
     isni: /^[0]{4} ?[0-9]{4} ?[0-9]{4} ?[0-9]{3}[0-9X]$/i,
@@ -162,7 +162,7 @@ export default {
             if (this.saveIdentifiersAsList) {
                 // collect id values of matching type, or empty array if none present
                 const existingIds = this.assignedIdentifiers[this.selectedIdentifier] ?? [];
-                const validEditionId = validateEditionIdentifiers(this.selectedIdentifier, this.inputValue, existingIds, this.output_selector);
+                const validEditionId = validateIdentifiers(this.selectedIdentifier, this.inputValue, existingIds, this.output_selector);
                 if (validEditionId) {
                     if (!this.assignedIdentifiers[this.selectedIdentifier]) {
                         this.inputValue = [this.inputValue];

--- a/openlibrary/components/IdentifiersInput/utils/utils.js
+++ b/openlibrary/components/IdentifiersInput/utils/utils.js
@@ -64,7 +64,7 @@ function validateLccn(value) {
     return true;
 }
 
-export function validateEditionIdentifiers(name, value, entries, error_output) {
+export function validateIdentifiers(name, value, entries, error_output) {
     let validId = true;
     errorDisplay('', error_output);
     if (name === '' || name === '---') {

--- a/openlibrary/components/IdentifiersInput/utils/utils.js
+++ b/openlibrary/components/IdentifiersInput/utils/utils.js
@@ -8,8 +8,15 @@ import {
     isValidLccn,
 } from '../../../plugins/openlibrary/js/idValidation.js';
 
-export function errorDisplay(message) {
-    const errorSelector = document.querySelector('#id-errors');
+export function errorDisplay(message, error_output) {
+    let errorSelector;
+    if (error_output === '#hiddenAuthorIdentifiers') {
+        errorSelector = document.querySelector('#id-errors-author')
+    } else if (error_output === '#hiddenWorkIdentifiers') {
+        errorSelector = document.querySelector('#id-errors-work')
+    } else if (error_output === '#hiddenEditionIdentifiers') {
+        errorSelector = document.querySelector('#id-errors-edition')
+    }
     if (message) {
         errorSelector.style.display = '';
         errorSelector.innerHTML = `<div>${message}</div>`;
@@ -23,10 +30,12 @@ export function errorDisplay(message) {
 function validateIsbn10(value) {
     const isbn10_value = parseIsbn(value);
     if (!isFormatValidIsbn10(isbn10_value)) {
-        errorDisplay('ID must be exactly 10 characters [0-9] or X.');
+        errorDisplay('ID must be exactly 10 characters [0-9] or X.', '#hiddenEditionIdentifiers');
         return false;
-    } else if (isFormatValidIsbn10(isbn10_value) === true && isChecksumValidIsbn10(isbn10_value) === false) {
-        errorDisplay(`ISBN ${isbn10_value} may be invalid. Please confirm if you'd like to add it before saving all changes`);
+    } else if (
+        isFormatValidIsbn10(isbn10_value) && !isChecksumValidIsbn10(isbn10_value)
+    ) {
+        errorDisplay(`ISBN ${isbn10_value} may be invalid. Please confirm if you'd like to add it before saving all changes`, '#hiddenEditionIdentifiers');
     }
     return true;
 }
@@ -35,10 +44,12 @@ function validateIsbn13(value) {
     const isbn13_value = parseIsbn(value);
 
     if (!isFormatValidIsbn13(isbn13_value)) {
-        errorDisplay('ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4');
+        errorDisplay('ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4', '#hiddenEditionIdentifiers');
         return false;
-    } else if (isFormatValidIsbn13(isbn13_value) === true && isChecksumValidIsbn13(isbn13_value) === false) {
-        errorDisplay(`ISBN ${isbn13_value} may be invalid. Please confirm if you'd like to add it before saving all changes`);
+    } else if (
+        isFormatValidIsbn13(isbn13_value) && !isChecksumValidIsbn13(isbn13_value)
+    ) {
+        errorDisplay(`ISBN ${isbn13_value} may be invalid. Please confirm if you'd like to add it before saving all changes`, '#hiddenEditionIdentifiers');
     }
     return true;
 }
@@ -47,18 +58,18 @@ function validateLccn(value) {
     const lccn_value = parseLccn(value);
 
     if (!isValidLccn(lccn_value)) {
-        errorDisplay('Invalid ID format');
+        errorDisplay('Invalid ID format', '#hiddenEditionIdentifiers');
         return false;
     }
     return true;
 }
 
-export function validateEditionIdentifiers(name, value, entries) {
+export function validateEditionIdentifiers(name, value, entries, error_output) {
     let validId = true;
-    errorDisplay('');
+    errorDisplay('', error_output);
     if (name === '' || name === '---') {
     // if somehow an invalid identifier is passed through
-        errorDisplay('Invalid identifier');
+        errorDisplay('Invalid identifier', error_output);
         return false;
     }
     if (name === 'isbn_10') {
@@ -70,7 +81,7 @@ export function validateEditionIdentifiers(name, value, entries) {
     }
     if (Array.from(entries).some(entry => entry === value) === true) {
         validId = false;
-        errorDisplay('That ID already exists for this edition');
+        errorDisplay('That ID already exists for an identifier.', error_output);
     }
     return validId;
 }

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -3613,7 +3613,10 @@ msgid "Do you know any identifiers for this work?"
 msgstr ""
 
 #: books/edit.html
-msgid "Like, Wikidata?"
+msgid ""
+"These identifiers apply to all editions of this work, for example "
+"Wikidata work identifiers. For edition-specific identifiers, like ISBN or"
+" LCCN, go to the edition tab."
 msgstr ""
 
 #: FulltextSearchSuggestionItem.html IABook.html SearchResultsWork.html

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -3604,6 +3604,18 @@ msgstr ""
 msgid "Links"
 msgstr ""
 
+#: books/edit.html
+msgid "Work Identifiers"
+msgstr ""
+
+#: books/edit.html
+msgid "Do you know any identifiers for this work?"
+msgstr ""
+
+#: books/edit.html
+msgid "Like, Wikidata?"
+msgstr ""
+
 #: FulltextSearchSuggestionItem.html IABook.html SearchResultsWork.html
 #: books/edition-sort.html jsdef/LazyWorkPreview.html lists/list_overview.html
 #: lists/preview.html lists/snippet.html lists/widget.html

--- a/openlibrary/plugins/openlibrary/config/work/identifiers.yml
+++ b/openlibrary/plugins/openlibrary/config/work/identifiers.yml
@@ -1,0 +1,28 @@
+identifiers:
+-   label: BookBrainz
+    name: bookbrainz
+    notes: ''
+    url:  https://bookbrainz.org/work/@@@
+    website:  https://bookbrainz.org
+-   label: Книга Файнфиков
+    name: ficbook
+    notes: ''
+    url: https://ficbook.net/readfic/@@@
+-   label: MusicBrainz
+    name: musicbrainz
+    url: https://musicbrainz.org/artist/@@@
+    website: https://musicbrainz.org
+-   label: MyAnimeList
+    name: myanimelist
+    notes: ''
+    url: https://myanimelist.net/manga/@@@
+-   label: Wikidata
+    name: wikidata
+    notes: ''
+    url: https://www.wikidata.org/wiki/@@@
+    website: https://wikidata.org
+-   label: SBN/ICCU (National Library Service of Italy)
+    name: opac_sbn
+    notes: format is /^\D{2}[A-Z0-3]V\d{6}$/
+    url: https://opac.sbn.it/risultati-autori/-/opac-autori/detail/@@@
+    website: https://opac.sbn.it/

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -595,8 +595,9 @@ class SaveBookHelper:
                 elif self.work is not None and new_work_key is None:
                     # we're trying to create an orphan; let's not do that
                     edition_data.works = [{'key': self.work.key}]
-
             if self.work is not None:
+                work_identifiers = work_data.pop('identifiers', [])
+                self.work.set_identifiers(work_identifiers)
                 self.work.update(work_data)
                 saveutil.save(self.work)
 
@@ -782,8 +783,8 @@ class SaveBookHelper:
         else:
             work.subtitle = None
 
-        for k in ('excerpts', 'links'):
-            work[k] = work.get(k) or []
+        for k in ['excerpts', 'links', 'identifiers']:
+            work[k] = work.get(k, [])
 
         # ignore empty authors
         work.authors = [

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -596,7 +596,7 @@ class SaveBookHelper:
                     # we're trying to create an orphan; let's not do that
                     edition_data.works = [{'key': self.work.key}]
             if self.work is not None:
-                work_identifiers = work_data.pop('identifiers', [])
+                work_identifiers = work_data.pop('identifiers', {})
                 self.work.set_identifiers(work_identifiers)
                 self.work.update(work_data)
                 saveutil.save(self.work)
@@ -784,7 +784,7 @@ class SaveBookHelper:
             work.subtitle = None
 
         for k in ['excerpts', 'links', 'identifiers']:
-            work[k] = work.get(k, [])
+            work[k] = work.get(k, {})
 
         # ignore empty authors
         work.authors = [

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -361,7 +361,9 @@ class Edition(models.Edition):
     def get_classifications(self):
         names = ["dewey_decimal_class", "lc_classifications"]
         return self._process_identifiers(
-            get_identifier_config('edition').classifications, names, self.classifications
+            get_identifier_config('edition').classifications,
+            names,
+            self.classifications,
         )
 
     def set_classifications(self, classifications):
@@ -810,7 +812,9 @@ class Work(models.Work):
                 if not isinstance(value, list):
                     value = [value]
 
-                id = id_map.get(name) or web.storage(name=name, label=name, url_format=None)
+                id = id_map.get(name) or web.storage(
+                    name=name, label=name, url_format=None
+                )
                 for v in value:
                     d[id.name] = web.storage(
                         name=id.name,
@@ -818,6 +822,7 @@ class Work(models.Work):
                         value=v,
                         url=id.get('url') and id.url.replace('@@@', v.replace(' ', '')),
                     )
+
         for name in names:
             process(name, self[name])
 
@@ -825,6 +830,7 @@ class Work(models.Work):
             process(name, values[name])
 
         return d
+
 
 class Subject(client.Thing):
     pass

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -358,6 +358,9 @@ class Edition(models.Edition):
             else:
                 self.identifiers[name] = value
 
+        if not d.items():
+            self.identifiers = None
+
     def get_classifications(self):
         names = ["dewey_decimal_class", "lc_classifications"]
         return self._process_identifiers(
@@ -387,6 +390,9 @@ class Edition(models.Edition):
                 self[name] = value
             else:
                 self.classifications[name] = value
+
+        if not self.classifications.items():
+            self.classifications = None
 
     def get_weight(self):
         """returns weight as a storage object with value and units fields."""
@@ -779,7 +785,6 @@ class Work(models.Work):
 
     def set_identifiers(self, identifiers):
         """Updates the work from identifiers specified as (name, value) pairs."""
-        names = ()
 
         d = {}
         if identifiers:
@@ -793,10 +798,10 @@ class Work(models.Work):
         self.identifiers = {}
 
         for name, value in d.items():
-            if name in names:
-                self[name] = value
-            else:
-                self.identifiers[name] = value
+            self.identifiers[name] = value
+
+        if not d.items():
+            self.identifiers = None
 
     def _process_identifiers(self, config_, names, values):
         id_map = {}

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -1190,7 +1190,7 @@ def _get_identifier_config(identifier: Literal['work', 'edition', 'author']) -> 
     if identifier == 'edition':
         thing = web.ctx.site.get('/config/edition')
         classifications = [
-            Storage(t.dict()) for t in thing.classifications if 'name in t'
+            Storage(t.dict()) for t in thing.classifications if 'name' in t
         ]
         roles = thing.roles
         return Storage(

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -1216,6 +1216,25 @@ def _get_edition_config():
         classifications=classifications, identifiers=identifiers, roles=roles
     )
 
+@public
+def get_work_config() -> Storage:
+    return _get_work_config()
+
+@web.memoize
+def _get_work_config() -> Storage:
+    """
+    Pulls the list of all work identifiers from the identifiers.yml file
+    and inserts them into a Storage object?
+    """
+    with open(
+        'openlibrary/plugins/openlibrary/config/work/identifiers.yml'
+    ) as in_file:
+        id_config = yaml.safe_load(in_file)
+        identifiers = [
+            Storage(id) for id in id_config.get('identifiers', []) if 'name' in id
+        ]
+    return Storage(identifiers=identifiers)
+
 
 from openlibrary.core.olmarkdown import OLMarkdown
 

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 from collections.abc import Callable, Generator, Iterable, Iterator, MutableMapping
 from html import unescape
 from html.parser import HTMLParser
-from typing import TYPE_CHECKING, Any, Protocol, TypeVar, Literal
+from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar
 from urllib.parse import (
     parse_qs,
     urlparse,
@@ -1164,9 +1164,11 @@ def convert_iso_to_marc(iso_639_1: str) -> str | None:
             return lang.code
     return None
 
+
 @public
 def get_identifier_config(identifier: Literal['work', 'edition', 'author']) -> Storage:
     return _get_identifier_config(identifier)
+
 
 @web.memoize
 def _get_identifier_config(identifier: Literal['work', 'edition', 'author']) -> Storage:
@@ -1187,9 +1189,13 @@ def _get_identifier_config(identifier: Literal['work', 'edition', 'author']) -> 
 
     if identifier == 'edition':
         thing = web.ctx.site.get('/config/edition')
-        classifications= [Storage(t.dict()) for t in thing.classifications if 'name in t']
+        classifications = [
+            Storage(t.dict()) for t in thing.classifications if 'name in t'
+        ]
         roles = thing.roles
-        return Storage(classifications=classifications, identifiers=identifiers, roles=roles)
+        return Storage(
+            classifications=classifications, identifiers=identifiers, roles=roles
+        )
 
     return Storage(identifiers=identifiers)
 

--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -1,5 +1,6 @@
 $def with (work, edition=None, recaptcha=None)
 
+$ work_config = get_work_config()
 $ this_title = work.title + ': ' + work.subtitle if work.get('subtitle', None) else work.title
 
 $var title: $this_title
@@ -118,6 +119,23 @@ $:macros.HiddenSaveButton("addWork")
                     <legend>$_("Links")</legend>
                     <div class="formBack">
                         $:render_template("books/edit/web", work, prefix="work--")
+                    </div>
+                </fieldset>
+                <fieldset class="major" id="identifiers">
+                    <legend>$_("Work Identifiers")</legend>
+                    <div class="formBack">
+                        <div id="id-errors" class="note" style="display:none"></div>
+                        <div class="formElement">
+                            <div class="label">
+                                <label for="select-id">$_("Do you know any identifiers for this work?")</label>
+                                <span class="tip">$_("Like, Wikidata?")</span>
+                            </div>
+                        </div>
+                    </div>
+                    <div id="hiddenIdentifiers"></div>
+                    <div id="identifiers-display-works">
+                        $ admin = str(ctx.user.is_admin() or ctx.user.is_super_librarian())
+                        $:render_component('IdentifiersInput', attrs=dict(assigned_ids_string=work.get_identifiers().values(), output_selector='#hiddenIdentifiers', id_config_string=work_config, input_prefix='work--identifiers', admin=admin))
                     </div>
                 </fieldset>
             </div>

--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -128,7 +128,7 @@ $:macros.HiddenSaveButton("addWork")
                         <div class="formElement">
                             <div class="label">
                                 <label for="select-id">$_("Do you know any identifiers for this work?")</label>
-                                <span class="tip">$_("Like, Wikidata?")</span>
+                                <span class="tip">$_("These identifiers apply to all editions of this work, for example Wikidata work identifiers. For edition-specific identifiers, like ISBN or LCCN, go to the edition tab.")</span>
                             </div>
                         </div>
                     </div>

--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -1,6 +1,6 @@
 $def with (work, edition=None, recaptcha=None)
 
-$ work_config = get_work_config()
+$ work_config = get_identifier_config('work')
 $ this_title = work.title + ': ' + work.subtitle if work.get('subtitle', None) else work.title
 
 $var title: $this_title
@@ -124,7 +124,7 @@ $:macros.HiddenSaveButton("addWork")
                 <fieldset class="major" id="identifiers">
                     <legend>$_("Work Identifiers")</legend>
                     <div class="formBack">
-                        <div id="id-errors" class="note" style="display:none"></div>
+                        <div id="id-errors-work" class="note" style="display:none"></div>
                         <div class="formElement">
                             <div class="label">
                                 <label for="select-id">$_("Do you know any identifiers for this work?")</label>
@@ -132,10 +132,10 @@ $:macros.HiddenSaveButton("addWork")
                             </div>
                         </div>
                     </div>
-                    <div id="hiddenIdentifiers"></div>
+                    <div id="hiddenWorkIdentifiers"></div>
                     <div id="identifiers-display-works">
                         $ admin = str(ctx.user.is_admin() or ctx.user.is_super_librarian())
-                        $:render_component('IdentifiersInput', attrs=dict(assigned_ids_string=work.get_identifiers().values(), output_selector='#hiddenIdentifiers', id_config_string=work_config, input_prefix='work--identifiers', admin=admin))
+                        $:render_component('IdentifiersInput', attrs=dict(assigned_ids_string=work.get_identifiers().values(), output_selector='#hiddenWorkIdentifiers', id_config_string=work_config, input_prefix='work--identifiers', multiple='true', admin=admin))
                     </div>
                 </fieldset>
             </div>

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -1,6 +1,6 @@
 $def with (work, book)
 
-$ edition_config = get_edition_config()
+$ edition_config = get_identifier_config('edition')
 $ is_librarian = ctx.user and ctx.user.is_librarian()
 $ is_admin = ctx.user and ctx.user.is_admin()
 $ is_privileged_user = is_librarian or is_admin
@@ -428,13 +428,13 @@ $ })
     <legend>$_("ID Numbers")</legend>
     <div class="formBack">
 
-        <div id="id-errors" class="note" style="display: none"></div>
+        <div id="id-errors-edition" class="note" style="display: none"></div>
         <div class="formElement">
             <div class="label">
                 <label for="select-id">$_("Do you know any identifiers for this edition?")</label>
                 <span class="tip">$_("Like, ISBN?")</span>
             </div>
-            <div id="hiddenIdentifiers"></div>
+            <div id="hiddenEditionIdentifiers"></div>
             <div class="identifiers-display">
                 $ id_labels = dict((d.name, d.label) for d in edition_config.identifiers)
                 $ id_dict = dict((id.name, id) for id in edition_config.identifiers)
@@ -447,7 +447,7 @@ $ })
                 $ set1 = [id_dict[name] for name in popular if name in id_dict and name not in exclude]
                 $ set2 = sorted([id for id in edition_config.identifiers if id.name not in popular and id.name not in exclude], key=lambda id:id.label)
 
-                $:render_component('IdentifiersInput', attrs=dict(id_config_string=edition_config.identifiers, assigned_ids_string=book.get_identifiers().values(), input_prefix='edition--identifiers', output_selector='#hiddenIdentifiers', multiple='true', admin=str(is_privileged_user), edition_popular=set1,secondary_identifiers=set2))
+                $:render_component('IdentifiersInput', attrs=dict(id_config_string=edition_config.identifiers, assigned_ids_string=book.get_identifiers().values(), input_prefix='edition--identifiers', output_selector='#hiddenEditionIdentifiers', multiple='true', admin=str(is_privileged_user), edition_popular=set1,secondary_identifiers=set2))
             </div>
         </div>
     </div>

--- a/openlibrary/templates/merge/authors.html
+++ b/openlibrary/templates/merge/authors.html
@@ -79,7 +79,7 @@ $if can_merge:
                             <span class="metaDate">$a.date</span>
                         $if a.remote_ids:
                             <div>
-                            $ configured_ids = get_author_config()['identifiers']
+                            $ configured_ids = get_identifier_config('author')['identifiers']
                             $for id in configured_ids:
                                 $if id.name in a.remote_ids:
                                     $ href = id.url.replace('@@@', a.remote_ids[id.name])

--- a/openlibrary/templates/type/author/edit.html
+++ b/openlibrary/templates/type/author/edit.html
@@ -103,11 +103,11 @@ $:macros.HiddenSaveButton("addAuthor")
                             </div>
                         </div>
                         <div class="label">$_("Identifiers") <a href="/help/faq/editing.en#author-identifiers-purpose"><img src="/images/icons/icon_help.png" alt="$_('Author Identifiers Purpose')"/></a> </div>
-                        <div id="id-errors" class="note" style="display: none"></div>
-                        <div id="hiddenIdentifierInputs"></div>
+                        <div id="id-errors-author" class="note" style="display: none"></div>
+                        <div id="hiddenAuthorIdentifiers"></div>
                         <div id="identifiers-display">
                             $ admin = ctx.user.is_admin() or ctx.user.is_super_librarian()
-                            $:render_component('IdentifiersInput', attrs=dict(assigned_ids_string=dict(page.remote_ids),output_selector='#hiddenIdentifierInputs', admin=str(admin), input_prefix='author--remote_ids', id_config_string=dict(get_author_config())))
+                            $:render_component('IdentifiersInput', attrs=dict(assigned_ids_string=dict(page.remote_ids),output_selector='#hiddenAuthorIdentifiers', admin=str(admin), input_prefix='author--remote_ids', id_config_string=dict(get_identifier_config('author'))))
                         </div>
                         <br>
                         <fieldset class="major">

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -180,7 +180,7 @@ $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_libra
             <ul class="booklinks sansserif">
                 <li>$_('OLID'): $olid</li>
                 $if page.remote_ids:
-                    $ configured_ids = get_author_config()['identifiers']
+                    $ configured_ids = get_identifier_config('author')['identifiers']
                     $for id in configured_ids:
                         $if id.name in page.remote_ids:
                             $ href = id.url.replace('@@@', page.remote_ids[id.name])


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3430

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature

### Technical
<!-- What should be noted about the implementation? -->
DRY implementation of work identifiers but currently unable to save the changes made by users into Solr. 

The work identifiers currently displayed in this component are based off of this list: https://openlibrary.org/config/work
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Navigate to a work/book and click on the edit button
2. Switch from the edition edit tab to the `Work Details` edit tab
![image](https://github.com/user-attachments/assets/f2d515fc-fb9e-4cde-ad25-4ade06a821c5)
3. Scroll to Work Identifiers section and add/remove work identifiers.
    - ~~Duplicates are currently not allowed for work identifiers. Adding a duplicate will warn the user that an identifier already exists.~~
    - ~~Work Identifiers should be saved as a list, allowing more than one ID per identifier. Duplicate ID numbers across different identifiers is not allowed i.e BookBrainz ID:123456 vs Amazon ID:123456.~~
    
![image](https://github.com/user-attachments/assets/0be7b550-9e53-48fa-896a-0fe2bf87e739)


4. After adding new work identifiers, save the changes and return to the editing page -> Work Details tab to check that the newly added work identifiers are still present.

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
