### PR TITLE
set fixed image height for offline page

### DIFF
--- a/static/offline.html
+++ b/static/offline.html
@@ -13,7 +13,7 @@
         </style>
     </head>
     <body>
-    <div id="logo"><img src="static/images/logo_OL-err.png" alt="The Open Library is closed!" width="219"/></div>
+    <div id="logo"><img src="static/images/logo_OL-err.png" alt="The Open Library is closed!" width="220" height="140"/></div>
     <p><strong>Looks like you lost your connection. Please check it and try again.</strong></p>
     <a class="goback" href="javascript:history.back()">Go Back</a>
     <a href="javascript:location.reload()">Retry</a>

--- a/static/offline.html
+++ b/static/offline.html
@@ -13,7 +13,7 @@
         </style>
     </head>
     <body>
-    <div id="logo"><img src="static/images/logo_OL-err.png" alt="The Open Library is closed!" width="220" height="140"/></div>
+    <div id="logo"><img src="/static/images/logo_OL-err.png" alt="The Open Library is closed!" width="219" height="131"/></div>
     <p><strong>Looks like you lost your connection. Please check it and try again.</strong></p>
     <a class="goback" href="javascript:history.back()">Go Back</a>
     <a href="javascript:location.reload()">Retry</a>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
I noticed the offline page always reflows when you refresh because the image height isn't fixed.
Set the image height to be fixed.

No visual changes.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
