### PR TITLE
improve offline page by autoloading

### DIFF
--- a/static/offline.html
+++ b/static/offline.html
@@ -11,6 +11,19 @@
         a{margin: 8px; padding: 4px 8px; background: #e44028; color: white; border-radius: 4px; text-decoration: none;}
         a.goback{background: #0376b8;}
         </style>
+        <script>
+        window.addEventListener('online', () => location.reload());
+        if (location.hostname === 'localhost') {
+            setInterval(async () => {
+                try {
+                    const response = await fetch('/');
+                    if (response.ok) location.reload();
+                } catch (e) {
+                    // Connection still not available
+                }
+            }, 1000);
+        }
+        </script>
     </head>
     <body>
     <div id="logo"><img src="static/images/logo_OL-err.png" alt="The Open Library is closed!" width="219"/></div>

--- a/static/offline.html
+++ b/static/offline.html
@@ -11,19 +11,7 @@
         a{margin: 8px; padding: 4px 8px; background: #e44028; color: white; border-radius: 4px; text-decoration: none;}
         a.goback{background: #0376b8;}
         </style>
-        <script>
-        window.addEventListener('online', () => location.reload());
-        if (location.hostname === 'localhost') {
-            setInterval(async () => {
-                try {
-                    const response = await fetch('/');
-                    if (response.ok) location.reload();
-                } catch (e) {
-                    // Connection still not available
-                }
-            }, 1000);
-        }
-        </script>
+        <script>window.addEventListener('online', () => location.reload());</script>
     </head>
     <body>
     <div id="logo"><img src="static/images/logo_OL-err.png" alt="The Open Library is closed!" width="219"/></div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Related to #10034 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
1. If the user's device comes online (they connect to wifi/data/etc) then we automatically reload the page

I think this minor change will lead to a great improvement in the experience for users with intermittent connections (such as being on a metro).


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini what do you think about this.

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
