### PR TITLE
Re-enable Google sign-in

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -1049,10 +1049,6 @@ msgid ""
 "nonprofit Internet Archive"
 msgstr ""
 
-#: account/create.html
-msgid "Google sign-in is temporarily unavailable, sorry for the inconvenience."
-msgstr ""
-
 #: account/create.html type/author/view.html
 msgid "Success!"
 msgstr ""

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -23,14 +23,7 @@ $var title: $_("Sign Up to Open Library")
     <div id="contentBody" class="ol-signup-form">
 
     $if not ctx.user:
-        <div class="flash-messages">
-            <div class="info ol-signup-form__info-box error">
-                <span>
-                    $_("Google sign-in is temporarily unavailable, sorry for the inconvenience.")
-                </span>
-            </div>
-        </div>
-        $#:render_template("account/ia_thirdparty_logins")
+        $:render_template("account/ia_thirdparty_logins")
         <div class="ol-signup-form__big-or">$_('OR')</div>
 
     $def field(input, suffix=''):

--- a/openlibrary/templates/login.html
+++ b/openlibrary/templates/login.html
@@ -27,15 +27,7 @@ $if "dev" in ctx.features:
 
     <div id="contentBody" class="ol-signup-form">
     $if not ctx.user:
-        <div class="flash-messages">
-            <div class="info ol-signup-form__info-box error">
-            <span>
-                Google sign-in is temporarily unavailable, sorry for the inconvenience.
-            </span>
-            </div>
-        </div>
-        $# Temporarily disable google signin
-        $#:render_template("account/ia_thirdparty_logins")
+        $:render_template("account/ia_thirdparty_logins")
         <div class="ol-signup-form__big-or">$_('OR')</div>
         <div class="ol-signup-form__info">$:_('Please enter your <a href="https://archive.org">Internet Archive</a> email and password to access your Open Library account.')</div>
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10042

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes error message and re-enables Google sign-in on login and new account registration pages.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged out:
1. Attempt to login with your Google account.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
