### PR TITLE
Add support for Integrated Authority File (GND) identifiers on Authors

### DIFF
--- a/openlibrary/plugins/openlibrary/config/author/identifiers.yml
+++ b/openlibrary/plugins/openlibrary/config/author/identifiers.yml
@@ -17,6 +17,11 @@ identifiers:
     notes: ''
     url: https://isni.org/isni/@@@
     website: https://isni.org/
+-   label: Integrated Authority File (GND)
+    name: gnd
+    notes: ''
+    url: https://d-nb.info/gnd/@@@
+    website: https://gnd.network/
 -   label: IMDb
     name: imdb
     notes: Should be something like nm0393654


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes https://github.com/internetarchive/openlibrary/issues/8037

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
feature

### Technical

Using “Integrated Authority File” rather than the “Universal” from the ticket, since “Integrated” is [the translation the DNB themselves use](https://www.dnb.de/EN/Professionell/Standardisierung/GND/gnd_node.html).

DNB editions generally use DNB identifiers, which seem to be different from GND ones, so no need to add those for Editions; but GND is used for Works too, so this should also be added for them when we get those into code.

Note that there are still some potential Authors that are still using DNB identifiers, but the DNB’s plan is to transition all persons, organisations, etc. to use GND ids, so not adding DNB ids here for now unless it turns out they’re actually needed/desired for something.

Corresponds to [Wikidata’s P227](https://www.wikidata.org/wiki/Property:P227) and is part of [MusicBrainz’s Other databases](https://musicbrainz.org/relationship/d94fb61c-fa20-4e3c-a19a-71a949fb2c55).

### Testing
* Edit an author
* Verify that “Integrated Authority File (GND)” is in the identifier list
* Set an ““Integrated Authority File (GND)” identifier and save the artist
* Check that the artist has the `gnd` identifier set

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@hornc @bitnapper

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
