### PR TITLE
Adding "?" support in the search as # and @

### DIFF
--- a/conf/solr/conf/wordtypes.txt
+++ b/conf/solr/conf/wordtypes.txt
@@ -21,3 +21,5 @@
 \u00A9 => ALPHANUM
 # number sign (#), only as alphabetic for case like 'C#'
 \u0023 => ALPHA
+# Question mark (?), treated as alphanumeric
+\u003F => ALPHANUM


### PR DESCRIPTION
After going through the previous support to the special characters i have check the changes it needs

<!-- What issue does this PR close? -->
Closes #10046 


### Technical
hey  i'm new with open source contribution here, as of now i have check the need with the support for the "?" like previous addons were made for "@" and "#" i have added the support to "?" for the search. the code fix is added on 10046/fix/question-char-not-searchable branch you can check and merge it :)


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
