### PR TITLE
Remove the extra blank under the Author's search

### DIFF
--- a/openlibrary/templates/search/authors.html
+++ b/openlibrary/templates/search/authors.html
@@ -17,66 +17,66 @@ $ sort = query_param('sort', None)
 </div>
 
 <div id="contentBody">
-    $:macros.SearchNavigation()
+  $:macros.SearchNavigation()
 
-    <div class="section">
-        <form class="siteSearch olform" action="">
-            $:render_template("search/searchbox", q=q)
-        </form>
-    </div>
+  <div class="section">
+    <form class="siteSearch olform" action="">
+        $:render_template("search/searchbox", q=q)
+    </form>
+  </div>
 
-        $ results = get_results(q, offset=offset, limit=results_per_page, sort=sort)
+    $ results = get_results(q, offset=offset, limit=results_per_page, sort=sort)
 
-        $if q and results.error:
-            <strong>
-                $for line in results.error.splitlines():
-                    $line
-                    $if not loop.last:
-                        <br>
-            </strong>
+    $if q and results.error:
+        <strong>
+            $for line in results.error.splitlines():
+                $line
+                $if not loop.last:
+                    <br>
+        </strong>
 
-        $if q and not results.error:
-            $if results.num_found:
-                <div class="search-results-stats">$ungettext('%(count)s hit', '%(count)s hits', results.num_found, count=commify(results.num_found))
-                    $if results.num_found > 1:
-                        $:render_template("search/sort_options.html", selected_sort=sort, search_scheme="authors")
-                        $ user_can_merge = ctx.user and ("merge-authors" in ctx.features or ctx.user.is_admin())
-                    $if results.num_found >= 2 and user_can_merge:
-                        $ keys = '&'.join('key=%s' % doc['key'].split("/")[-1] for doc in results.docs)
-                    <div class="mergeThis">$_('Is the same author listed twice?') <a class="large sansserif" href="/authors/merge?$keys">$_('Merge authors')</a></div>
-                </div>
-            $else:
-                <center>
-                    <div class="red">$:_('No <strong>authors</strong> directly matched your search')</div>
-                    <hr>
-                </center>
-                <div id="fulltext-search-suggestion" data-query="$q">
-                    $:macros.LoadingIndicator(_("Checking Search Inside matches"))
-                </div>
+    $if q and not results.error:
+        $if results.num_found:
+            <div class="search-results-stats">$ungettext('%(count)s hit', '%(count)s hits', results.num_found, count=commify(results.num_found))
+              $if results.num_found > 1:
+                $:render_template("search/sort_options.html", selected_sort=sort, search_scheme="authors")
+              $ user_can_merge = ctx.user and ("merge-authors" in ctx.features or ctx.user.is_admin())
+              $if results.num_found >= 2 and user_can_merge:
+                $ keys = '&'.join('key=%s' % doc['key'].split("/")[-1] for doc in results.docs)
+                <div class="mergeThis">$_('Is the same author listed twice?') <a class="large sansserif" href="/authors/merge?$keys">$_('Merge authors')</a></div>
+            </div>
+        $else:
+            <center>
+                <div class="red">$:_('No <strong>authors</strong> directly matched your search')</div>
+                <hr>
+              </center>
+              <div id="fulltext-search-suggestion" data-query="$q">
+                  $:macros.LoadingIndicator(_("Checking Search Inside matches"))
+              </div>
 
-            <ul class="authorList list-books">
-            $for doc in results.docs:
-                $ n = doc['name']
-                $ num = doc['work_count']
-                $ wc = ungettext("%(count)d book", "%(count)d books", num, count=num)
-                $ date = ''
-                $if 'birth_date' in doc or 'death_date' in doc:
-                    $ date = doc.get('birth_date', '') + ' - ' + doc.get('death_date', '')
-                $elif 'date' in doc:
-                    $ date = doc['date']
-                <li class="searchResultItem">
-                    <img src="$get_coverstore_public_url()/a/olid/$(doc['key'].split('/')[-1])-M.jpg" itemprop="image" class="cover author" alt="$_('Photo of %(author)s', author=n)">
-                    <div class="details">
-                        <a href="$doc['key']" class="larger">$n</a>&nbsp;<span class="brown small">$date</span><br />
-                        <span class="small grey"><b>$wc</b>
-                        $if 'top_subjects' in doc:
-                            $_('about %(subjects)s', subjects=', '.join(doc['top_subjects'])),
-                        $:_('including <i>%(topwork)s</i>', topwork=doc.get('top_work', ''))</span>
-                    </div>
-                </li>
-            </ul>
+        <ul class="authorList list-books">
+        $for doc in results.docs:
+            $ n = doc['name']
+            $ num = doc['work_count']
+            $ wc = ungettext("%(count)d book", "%(count)d books", num, count=num)
+            $ date = ''
+            $if 'birth_date' in doc or 'death_date' in doc:
+                $ date = doc.get('birth_date', '') + ' - ' + doc.get('death_date', '')
+            $elif 'date' in doc:
+                $ date = doc['date']
+            <li class="searchResultItem">
+	      <img src="$get_coverstore_public_url()/a/olid/$(doc['key'].split('/')[-1])-M.jpg" itemprop="image" class="cover author" alt="$_('Photo of %(author)s', author=n)">
+	      <div class="details">
+		<a href="$doc['key']" class="larger">$n</a>&nbsp;<span class="brown small">$date</span><br />
+		<span class="small grey"><b>$wc</b>
+                $if 'top_subjects' in doc:
+                  $_('about %(subjects)s', subjects=', '.join(doc['top_subjects'])),
+                $:_('including <i>%(topwork)s</i>', topwork=doc.get('top_work', ''))</span>
+	      </div>
+            </li>
+        </ul>
 
-            $:macros.Pager(page, results.num_found, results_per_page)
-    </div>
-    <div class="clearfix"></div>
+        $:macros.Pager(page, results.num_found, results_per_page)
+  </div>
+  <div class="clearfix"></div>
 </div>

--- a/openlibrary/templates/search/authors.html
+++ b/openlibrary/templates/search/authors.html
@@ -17,68 +17,66 @@ $ sort = query_param('sort', None)
 </div>
 
 <div id="contentBody">
-  $:macros.SearchNavigation()
+    $:macros.SearchNavigation()
 
-  <div class="section">
-    <form class="siteSearch olform" action="">
-        $:render_template("search/searchbox", q=q)
-    </form>
-  </div>
-</div>
+    <div class="section">
+        <form class="siteSearch olform" action="">
+            $:render_template("search/searchbox", q=q)
+        </form>
+    </div>
 
-<div id="contentMeta">
-    $ results = get_results(q, offset=offset, limit=results_per_page, sort=sort)
+        $ results = get_results(q, offset=offset, limit=results_per_page, sort=sort)
 
-    $if q and results.error:
-        <strong>
-            $for line in results.error.splitlines():
-                $line
-                $if not loop.last:
-                    <br>
-        </strong>
+        $if q and results.error:
+            <strong>
+                $for line in results.error.splitlines():
+                    $line
+                    $if not loop.last:
+                        <br>
+            </strong>
 
-    $if q and not results.error:
-        $if results.num_found:
-            <div class="search-results-stats">$ungettext('%(count)s hit', '%(count)s hits', results.num_found, count=commify(results.num_found))
-              $if results.num_found > 1:
-                $:render_template("search/sort_options.html", selected_sort=sort, search_scheme="authors")
-              $ user_can_merge = ctx.user and ("merge-authors" in ctx.features or ctx.user.is_admin())
-              $if results.num_found >= 2 and user_can_merge:
-                $ keys = '&'.join('key=%s' % doc['key'].split("/")[-1] for doc in results.docs)
-                <div class="mergeThis">$_('Is the same author listed twice?') <a class="large sansserif" href="/authors/merge?$keys">$_('Merge authors')</a></div>
-            </div>
-        $else:
-            <center>
-                <div class="red">$:_('No <strong>authors</strong> directly matched your search')</div>
-                <hr>
-              </center>
-              <div id="fulltext-search-suggestion" data-query="$q">
-                  $:macros.LoadingIndicator(_("Checking Search Inside matches"))
-              </div>
+        $if q and not results.error:
+            $if results.num_found:
+                <div class="search-results-stats">$ungettext('%(count)s hit', '%(count)s hits', results.num_found, count=commify(results.num_found))
+                    $if results.num_found > 1:
+                        $:render_template("search/sort_options.html", selected_sort=sort, search_scheme="authors")
+                        $ user_can_merge = ctx.user and ("merge-authors" in ctx.features or ctx.user.is_admin())
+                    $if results.num_found >= 2 and user_can_merge:
+                        $ keys = '&'.join('key=%s' % doc['key'].split("/")[-1] for doc in results.docs)
+                    <div class="mergeThis">$_('Is the same author listed twice?') <a class="large sansserif" href="/authors/merge?$keys">$_('Merge authors')</a></div>
+                </div>
+            $else:
+                <center>
+                    <div class="red">$:_('No <strong>authors</strong> directly matched your search')</div>
+                    <hr>
+                </center>
+                <div id="fulltext-search-suggestion" data-query="$q">
+                    $:macros.LoadingIndicator(_("Checking Search Inside matches"))
+                </div>
 
-        <ul class="authorList list-books">
-        $for doc in results.docs:
-            $ n = doc['name']
-            $ num = doc['work_count']
-            $ wc = ungettext("%(count)d book", "%(count)d books", num, count=num)
-            $ date = ''
-            $if 'birth_date' in doc or 'death_date' in doc:
-                $ date = doc.get('birth_date', '') + ' - ' + doc.get('death_date', '')
-            $elif 'date' in doc:
-                $ date = doc['date']
-            <li class="searchResultItem">
-	      <img src="$get_coverstore_public_url()/a/olid/$(doc['key'].split('/')[-1])-M.jpg" itemprop="image" class="cover author" alt="$_('Photo of %(author)s', author=n)">
-	      <div class="details">
-		<a href="$doc['key']" class="larger">$n</a>&nbsp;<span class="brown small">$date</span><br />
-		<span class="small grey"><b>$wc</b>
-                $if 'top_subjects' in doc:
-                  $_('about %(subjects)s', subjects=', '.join(doc['top_subjects'])),
-                $:_('including <i>%(topwork)s</i>', topwork=doc.get('top_work', ''))</span>
-	      </div>
-            </li>
-        </ul>
+            <ul class="authorList list-books">
+            $for doc in results.docs:
+                $ n = doc['name']
+                $ num = doc['work_count']
+                $ wc = ungettext("%(count)d book", "%(count)d books", num, count=num)
+                $ date = ''
+                $if 'birth_date' in doc or 'death_date' in doc:
+                    $ date = doc.get('birth_date', '') + ' - ' + doc.get('death_date', '')
+                $elif 'date' in doc:
+                    $ date = doc['date']
+                <li class="searchResultItem">
+                    <img src="$get_coverstore_public_url()/a/olid/$(doc['key'].split('/')[-1])-M.jpg" itemprop="image" class="cover author" alt="$_('Photo of %(author)s', author=n)">
+                    <div class="details">
+                        <a href="$doc['key']" class="larger">$n</a>&nbsp;<span class="brown small">$date</span><br />
+                        <span class="small grey"><b>$wc</b>
+                        $if 'top_subjects' in doc:
+                            $_('about %(subjects)s', subjects=', '.join(doc['top_subjects'])),
+                        $:_('including <i>%(topwork)s</i>', topwork=doc.get('top_work', ''))</span>
+                    </div>
+                </li>
+            </ul>
 
-        $:macros.Pager(page, results.num_found, results_per_page)
-  </div>
-  <div class="clearfix"></div>
+            $:macros.Pager(page, results.num_found, results_per_page)
+    </div>
+    <div class="clearfix"></div>
 </div>

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -229,7 +229,6 @@ em {
 }
 
 #contentBody,
-#contentMeta,
 .floaterBody {
   ol,
   ul {
@@ -259,7 +258,6 @@ em {
 
 #content,
 #contentBody,
-#contentMeta,
 .floaterBody {
   ol li {
     list-style: decimal;
@@ -898,8 +896,7 @@ div.verify {
 @import (less) "components/language.less";
 
 /* CONTENT */
-div.contentWide,
-div#contentMeta {
+div.contentWide {
   padding: 10px 20px 20px;
 }
 
@@ -1850,8 +1847,7 @@ div#subjectLists {
   * - /search/subjects
   * To be deleted in https://github.com/internetarchive/openlibrary/issues/1821
   */
-  div.contentWide,
-  div#contentMeta {
+  div.contentWide {
     float: left;
     clear: both;
     width: 918px;


### PR DESCRIPTION
Closes: #10050 

### This PR does these things:

1. Removes the unnecessary blank space on the author search page.
2. Ensures the layout is consistent with the rest of the pages.

### Technical Details

1. Adjusted HTML by removing a div tag to remove excess margins and padding on the author search page.
2. Reused existing layout styles where possible to maintain consistency and reduce redundancy.
3. Verified that the changes do not affect other pages or components.

### Testing

1. Use the automatic testing.
2. Confirm that the blank space is removed and the layout matches the rest of the pages.
3. Cross-check for any visual inconsistencies on related pages.

### Result
https://github.com/user-attachments/assets/8ab9b24f-e36a-4407-97f2-1eff78bc4d9a

### Stakeholders
@RayBB 
