### PR TITLE
Add missing translation for yearly goal

### DIFF
--- a/openlibrary/i18n/fr/messages.po
+++ b/openlibrary/i18n/fr/messages.po
@@ -3425,6 +3425,10 @@ msgstr "Envoyer nous vos impressions"
 msgid "Your feedback will help us improve these cards"
 msgstr "Votre retour nous aidera à améliorer ces encarts"
 
+#: home/welcome.html
+msgid "Set a Yearly Reading Goal"
+msgstr "Fixer un objectif annuel de lecture"
+
 #: languages/index.html:15
 #, python-format
 msgid "%s book"


### PR DESCRIPTION
The welcome invite to set a yearly goal was missing in french

### Screenshot
![image](https://github.com/user-attachments/assets/2907a06f-9d62-4e94-9338-f7a7129cc055)
