### PR TITLE
Centered the Google Login button

### DIFF
--- a/openlibrary/templates/account/ia_thirdparty_logins.html
+++ b/openlibrary/templates/account/ia_thirdparty_logins.html
@@ -4,5 +4,5 @@ $ params = {'origin': request.home.replace('http:', 'https:')}
 <iframe
     id="ia-third-party-logins"
     src="https://$get_ia_host(allow_dev=True)/account/login.thirdparty.php?$(urlencode(params))"
-    style="border:0; width: 250px; height: 44px"
+    style="border:0; width: auto; max-width: 250px; height: 44px"
 ></iframe>

--- a/openlibrary/templates/account/ia_thirdparty_logins.html
+++ b/openlibrary/templates/account/ia_thirdparty_logins.html
@@ -4,5 +4,5 @@ $ params = {'origin': request.home.replace('http:', 'https:')}
 <iframe
     id="ia-third-party-logins"
     src="https://$get_ia_host(allow_dev=True)/account/login.thirdparty.php?$(urlencode(params))"
-    style="border:0; width: auto; height: 44px"
+    style="border:0; width: auto; max-width: 250px; height: 44px"
 ></iframe>

--- a/openlibrary/templates/account/ia_thirdparty_logins.html
+++ b/openlibrary/templates/account/ia_thirdparty_logins.html
@@ -4,5 +4,5 @@ $ params = {'origin': request.home.replace('http:', 'https:')}
 <iframe
     id="ia-third-party-logins"
     src="https://$get_ia_host(allow_dev=True)/account/login.thirdparty.php?$(urlencode(params))"
-    style="border:0; width: auto; max-width: 250px; height: 44px"
+    style="border:0; width: auto; height: 44px"
 ></iframe>

--- a/openlibrary/templates/account/ia_thirdparty_logins.html
+++ b/openlibrary/templates/account/ia_thirdparty_logins.html
@@ -4,5 +4,5 @@ $ params = {'origin': request.home.replace('http:', 'https:')}
 <iframe
     id="ia-third-party-logins"
     src="https://$get_ia_host(allow_dev=True)/account/login.thirdparty.php?$(urlencode(params))"
-    style="border:0; width: auto; height: 44px"
+    style="border:0; width: 250px; height: 44px"
 ></iframe>

--- a/static/css/page-signup.less
+++ b/static/css/page-signup.less
@@ -88,11 +88,6 @@
     display: flex;
   }
 
-  #g_id_signin {
-    display: flex;
-    justify-content: center;
-  }
-
   .ol-signup-form__big-or {
     display: flex;
     gap: 10px;

--- a/static/css/page-signup.less
+++ b/static/css/page-signup.less
@@ -88,6 +88,11 @@
     display: flex;
   }
 
+  #g_id_signin {
+    display: flex;
+    justify-content: center;
+  }
+
   .ol-signup-form__big-or {
     display: flex;
     gap: 10px;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10071 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR aims to center the third party Google login button across different views.

### Technical
<!-- What should be noted about the implementation? -->
Previously, the width attribute of the ia-third-party-logins ID was set to auto. This was causing it to occupy a width of 300px by default, and leaving a gap of 50px after the right end of the Google button, whose width was measured to be 250px. This was confirmed by using the box model upon inspecting elements. As a result, even though the 300px 'outer container' seemed to be centered, because the Google button's iFrame only occupied 250px, it did not appear to be centered.

I modified the width attribute to 250px, which does not leave any gap, and properly centers the Google login button across all viewing configurations, desktop and mobile included.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Tester/reviewer can launch the login page, and compare the third party Google login button's location in comparison to when this issue was reported. It can be observed the button is now centered. Tester can also test different devices by toggling device toolbar, and selecting different devices to confirm this PR fixes the issue.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/user-attachments/assets/6dda0847-22c9-4dd1-9a8a-9f4cbba69008)
Previously, with width being set to auto for the iframe, there was a gap of 50px leftover after the end of the iframe, resulting in the Google login button not being centered.
![image](https://github.com/user-attachments/assets/3dc43628-70b4-43fb-9921-85d52b7157fd)
After setting the width correctly to 250px, the Google login button is now centered. (iPhone view)
![image](https://github.com/user-attachments/assets/ea01d85a-2131-47e2-beb9-7a1dd6862fc1)
After setting the width correctly to 250px, the Google login button is now centered. (Desktop view)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB - tagging you for now as you assigned me this issue. Please let me know if someone else needs to be tagged, and i will do so.

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
