### PR TITLE
Mac M2 Air docker config support

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -68,7 +68,7 @@ cd openlibrary
 ```
 ls docker/
 ```
-I notice from your directory listing that the file is named `Dockerfile.olbase`, not `Dockerfile.base`. 
+I notice from your directory listing that the file is named `Dockerfile.olbase`, not `Dockerfile.base`.
 ```
 docker build -f docker/Dockerfile.olbase -t openlibrary/olbase:latest .
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -59,6 +59,22 @@ Please use [Docker Desktop >= 4.3.0](https://docs.docker.com/desktop/mac/release
 
 If you are experiencing issues building JS, you may need to increase the RAM available to Docker. The defaults of 2GB ram and 1GB Swap are not enough. We recommend requirements of 4GB ram and 2GB swap. This resolved the error message of `Killed` when running `build-assets`.
 
+### For Users of Macs Containing an m@ chip
+
+please use following commands to build docker on your local machine! to avoild compability issues.
+```
+cd openlibrary
+```
+```
+ls docker/
+```
+I notice from your directory listing that the file is named `Dockerfile.olbase`, not `Dockerfile.base`. 
+```
+docker build -f docker/Dockerfile.olbase -t openlibrary/olbase:latest .
+```
+The error was occurring because we were trying to use `Dockerfile.base` when the actual file is named `Dockerfile.olbase`. Try running this corrected command and This should start building the base image correctly. Once this completes successfully, we can proceed with the docker compose build command.
+
+
 ### For All Users
 All commands are from the project root directory, where `compose.yaml` is (i.e. `path/to/your/forked/and/cloned/openlibrary`):
 


### PR DESCRIPTION
i have found that while doing docker compose build it was giving an error in .olbase becase it was not reading the extension properly i have made changes in the readme file to config the docker file correctly

<!-- What issue does this PR close? -->
Closes #10078 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
local developer docker support for mac air m2 

### Technical
<!-- What should be noted about the implementation? -->
docker build file code changes 

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
<img width="725" alt="Screenshot 2024-11-23 at 7 21 05 PM" src="https://github.com/user-attachments/assets/73551b00-bff5-4b33-a992-e1182c6f4e3e">

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
