### PR TITLE
Move Yearly Reading Goal to sidebar

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -898,7 +898,7 @@ msgstr ""
 msgid "Learn more about \"%(title)s\" at OpenLibrary"
 msgstr ""
 
-#: widget.html
+#: check_ins/reading_goal_form.html widget.html
 msgid "Learn More"
 msgstr ""
 
@@ -1312,15 +1312,6 @@ msgid "Or, check out our <a href=\"/collections\">special collections</a>."
 msgstr ""
 
 #: account/mybooks.html
-#, python-format
-msgid "Set %(year_span)s reading goal"
-msgstr ""
-
-#: account/mybooks.html
-msgid "Yearly Reading Goal"
-msgstr ""
-
-#: account/mybooks.html
 msgid "No books are on this shelf"
 msgstr ""
 
@@ -1708,6 +1699,20 @@ msgstr ""
 
 #: account/sidebar.html books/mybooks_breadcrumb_select.html mybooks.py
 msgid "My Feed"
+msgstr ""
+
+#: account/sidebar.html
+#, python-format
+msgid "%(year)d Reading Goal"
+msgstr ""
+
+#: account/sidebar.html
+#, python-format
+msgid "Set %(year_span)s reading goal"
+msgstr ""
+
+#: account/sidebar.html
+msgid "Yearly Reading Goal"
 msgstr ""
 
 #: account/sidebar.html search/sort_options.html type/user/view.html
@@ -2875,7 +2880,6 @@ msgstr ""
 #: book_providers/openstax_read_button.html
 #: book_providers/standard_ebooks_read_button.html
 #: book_providers/wikisource_read_button.html
-#: check_ins/reading_goal_progress.html
 msgid "Learn more"
 msgstr ""
 
@@ -4259,15 +4263,10 @@ msgstr ""
 
 #: check_ins/reading_goal_progress.html
 #, python-format
-msgid "%(year)d Reading Goal:"
-msgstr ""
-
-#: check_ins/reading_goal_progress.html
-#, python-format
 msgid ""
 "<span class=\"reading-goal-progress__books-"
 "read\">%(books_read)d</span>/<span class=\"reading-goal-"
-"progress__goal\">%(goal)d</span> books"
+"progress__goal\">%(goal)d</span> Books"
 msgstr ""
 
 #: check_ins/reading_goal_progress.html

--- a/openlibrary/plugins/openlibrary/js/check-ins/index.js
+++ b/openlibrary/plugins/openlibrary/js/check-ins/index.js
@@ -530,8 +530,12 @@ function addGoalSubmissionListener(submitButton) {
                     if (isDeleted) {
                         const chipGroup = yearlyGoalSection.querySelector('.chip-group')
                         const goalContainer = yearlyGoalSection.querySelector('#reading-goal-container')
-                        goalContainer.remove()
-                        chipGroup.classList.remove('hidden')
+                        if (chipGroup) {
+                            chipGroup.classList.remove('hidden')
+                        }
+                        if (goalContainer) {
+                            goalContainer.remove()
+                        }
                     } else {
                         const progressComponent = modal.closest('.reading-goal-progress')
                         updateProgressComponent(progressComponent, Number(formData.get('goal')))
@@ -563,10 +567,8 @@ function updateProgressComponent(elem, goal) {
 
     // Update view:
     const goalSpan = elem.querySelector('.reading-goal-progress__goal')
-    const percentageSpan = elem.querySelector('.reading-goal-progress__percentage')
     const completedBar = elem.querySelector('.reading-goal-progress__completed')
     goalSpan.textContent = goal
-    percentageSpan.textContent = `(${percentComplete}%)`
     completedBar.style.width = `${Math.min(100, percentComplete)}%`
 }
 

--- a/openlibrary/templates/account/mybooks.html
+++ b/openlibrary/templates/account/mybooks.html
@@ -10,26 +10,6 @@ $def year_span(year, use_local_year=False):
 
 <div class="mybooks-details-specific">
 
-  $if owners_page:
-    $ year = current_year()
-    $ current_goal = get_reading_goals(year=year)
-    $ hidden = 'hidden' if current_goal else ''
-    <div class="yearly-goal-section">
-      $# Hide "Set reading goal" call to action with `hidden` class if a goal has already been set:
-      <div class="chip-group $hidden">
-        <span class="chip value-chip category-chip chip--selectable goal-chip">
-          $ year_markup = year_span(year)
-          <a class="set-reading-goal-link" data-ol-link-track="MyBooksLandingPage|SetReadingGoal"href="javascript:;">$:_('Set %(year_span)s reading goal', year_span=year_markup)</a>
-        </span>
-        $ reading_goal_form = render_template('check_ins/reading_goal_form', year=year)
-        $:render_template('native_dialog', 'yearly-goal-modal', reading_goal_form, title=_('Yearly Reading Goal'))
-      </div>
-      $if current_goal:
-        <span id="reading-goal-container">
-          $:render_template('check_ins/reading_goal_progress', [current_goal])
-        </span>
-    </div>
-
   $code:
       def compact_carousel(data):
           key, title, url = data

--- a/openlibrary/templates/account/reading_log.html
+++ b/openlibrary/templates/account/reading_log.html
@@ -30,11 +30,6 @@ $add_metatag(property="og:description", content=og_description)
 $add_metatag(property="og:image", content=meta_photo_url)
 
 <div class="mybooks-list">
-  $ yearly_goal = get_reading_goals(year=checkin_year)
-  $if yearly_goal and owners_page and key in readlog_keys:
-    <div class="yearly-goal-section">
-      $:render_template('check_ins/reading_goal_progress', [yearly_goal])
-    </div>
 
   $# The reading log search is only displayed on non-empty shelves because some patrons were confused and searching empty reading lists, perhaps thinking they could add books that way. See #7143.
 

--- a/openlibrary/templates/account/sidebar.html
+++ b/openlibrary/templates/account/sidebar.html
@@ -1,5 +1,10 @@
 $def with (username, key=None, owners_page=False, public=False, counts=None, lists=None, component_times={})
 
+  $def year_span(year, use_local_year=False):
+    $if use_local_year:
+      <span class="use-local-year" data-server-year="$year">$year</span>
+    $else:
+      <span>$year</span>
   $ component_times['Sidebar'] = time()
   <div class="mybooks-menu">
     $if owners_page:
@@ -14,6 +19,30 @@ $def with (username, key=None, owners_page=False, public=False, counts=None, lis
 	<li><a data-ol-link-track="MyBooksSidebar|MyFeed" $('class=selected' if key=='feed' else '') href="/people/$username/books/feed">$_('My Feed')</a></li>
       </ul>
     </ul>
+    $if owners_page:
+      $ year = current_year()
+      $ current_goal = get_reading_goals(year=year)
+      $ hidden = 'hidden' if current_goal else ''
+      <ul class="sidebar-section">
+        <li class="section-header">$_("%(year)d Reading Goal", year=year)</li>
+        <li>
+          <div class="yearly-goal-section">
+            <div class="chip-group $hidden">
+              <span class="">
+                $ year_markup = year_span(year)
+                <a class="set-reading-goal-link" data-ol-link-track="MyBooksLandingPage|SetReadingGoal"href="javascript:;">$:_('Set %(year_span)s reading goal', year_span=year_markup)</a>
+              </span>
+              $ reading_goal_form = render_template('check_ins/reading_goal_form', year=year)
+              $:render_template('native_dialog', 'yearly-goal-modal', reading_goal_form, title=_('Yearly Reading Goal'))
+            </div>
+            $if current_goal:
+            <span id="reading-goal-container">
+              $:render_template('check_ins/reading_goal_progress', [current_goal])
+            </span>
+          </div>
+        </li>
+      </ul>
+
     $if public or owners_page:
       <ul class="sidebar-section">
         <li class="section-header">$_('Reading Log')</li>

--- a/openlibrary/templates/account/view.html
+++ b/openlibrary/templates/account/view.html
@@ -12,8 +12,6 @@ $var title: $header_title
 
   $ css = 'no-padding' if mb.key == 'mybooks' else ''
   <div class="mybooks-details $css">
-    $if mb.key == 'mybooks' and mb.is_my_page:
-      $:render_template("account/yrg_banner", mb.component_times)
 
     $ mb.component_times['Details header'] = time()
     <header>

--- a/openlibrary/templates/check_ins/reading_goal_form.html
+++ b/openlibrary/templates/check_ins/reading_goal_form.html
@@ -12,4 +12,6 @@ $def with (goal=None, year=None, update=False)
   <button class="cta-btn cta-btn--shell reading-goal-submit-button" type="submit" data-ol-link-track="YearlyReadingGoals|SubmitGoal">$_("Submit")</button>
   $if goal:
     <div class="small">$_('Enter "0" to unset your reading goal. Your check-ins will be preserved.')</div>
+  $else:
+    <a class="small" href="https://blog.openlibrary.org/2022/12/31/reach-your-2023-reading-goals-with-open-library" target="_blank">$_('Learn More')</a>
 </form>

--- a/openlibrary/templates/check_ins/reading_goal_progress.html
+++ b/openlibrary/templates/check_ins/reading_goal_progress.html
@@ -10,23 +10,20 @@ $# YearlyGoal.progress : int : Percent of goal achieved
 
 <div class="reading-goal-progress-container">
   $for goal in goals:
-    <div class="reading-goal-progress">
-      <div class="reading-goal-progress__heading">$_("%(year)d Reading Goal:", year=goal.year)</div>
-      <div class="reading-goal-progress__body">
-        <div class="reading-goal-progress__progress-bar">
-          $ completed = 100 if goal.progress > 100 else goal.progress
-          <span class="reading-goal-progress__completed" style="width: $(completed)%;"></span>
-        </div>
-        <div class="reading-goal-progress__details">
-          <a href="/account/books/already-read/year/$(goal.year)" data-ol-link-track="ReadingGoalProgress|AnnualSummaryLink">$:_('<span class="reading-goal-progress__books-read">%(books_read)d</span>/<span class="reading-goal-progress__goal">%(goal)d</span> books', books_read=goal.books_read, goal=goal.goal)</a>
-          <span class="reading-goal-progress__percentage">($goal.progress%)</span>
-          <a class="edit-reading-goal-link" href="javascript:;">$_('Edit')</a> or
-	  <a href="https://blog.openlibrary.org/2022/12/31/reach-your-2023-reading-goals-with-open-library">$_('Learn more')</a>
-        </div>
+  <div class="reading-goal-progress">
+    <div class="reading-goal-progress__body">
+      <div class="reading-goal-progress__progress-bar">
+        $ completed = 100 if goal.progress > 100 else goal.progress
+        <span class="reading-goal-progress__completed" style="width: $(completed)%;"></span>
+      </div>
+      <div class="reading-goal-progress__details">
+          <a href="/account/books/already-read/year/$(goal.year)" data-ol-link-track="ReadingGoalProgress|AnnualSummaryLink">$:_('<span class="reading-goal-progress__books-read">%(books_read)d</span>/<span class="reading-goal-progress__goal">%(goal)d</span> Books', books_read=goal.books_read, goal=goal.goal)</a>
+          <a class="edit-reading-goal-link" href="javascript:;">$_('Edit')</a>
       </div>
       $ reading_goal_form = render_template('check_ins/reading_goal_form', goal=goal.goal, year=goal.year, update=True)
       $ id = 'yearly-goal-modal-%d' % loop.index
       $ title = _('Edit %(year)d Reading Goal', year=goal.year)
       $:render_template('native_dialog', id, reading_goal_form, title=title)
     </div>
+  </div>
 </div>

--- a/static/css/components/check-in.less
+++ b/static/css/components/check-in.less
@@ -149,27 +149,17 @@
   color: @dark-grey;
   padding: 5px 0;
 
-  &__heading,
-  &__details {
-    width: fit-content;
-  }
-
-  &__heading {
-    font-weight: 900;
-  }
-
   &__body {
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
+    justify-content: center;
   }
 
   &__progress-bar {
     background-color: @light-grey;
     border-radius: 5px;
     height: 20px;
-    margin: 5px 5px 0 0;
-    width: 50%;
+    margin: auto;
+    width: 85%;
+    margin-bottom: 10px;
   }
 
   &__completed {
@@ -180,21 +170,9 @@
   }
 
   &__details {
-    align-self: unset;
-    margin-left: 5px;
-  }
-}
-
-@media only screen and (min-width: @width-breakpoint-tablet) {
-  .reading-goal-progress {
-    &__body {
-      flex-direction: row;
-    }
-    &__progress-bar {
-      width: 33%;
-    }
-    &__details {
-      align-self: center;
-    }
+    display: flex;
+    justify-content: space-between;
+    width: 97%;
+    margin: auto;
   }
 }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10011  

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Design

### Technical
<!-- What should be noted about the implementation? -->
Moves the Yearly Reading Goal bar from the My Books and Reading Log pages into the sidebar, removes modal/alert banner from the My Books page, add Learn More redirect into the `reading_goal_form` modal.
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Log in as a OL user and navigate to the My Books/Reading Log page.
2. If the account does not have a reading goal, `Set 2024 reading goal` should be shown underneath the Reading Goal section header.
3. Click on `Set 2024 reading goal` and input a valid reading goal value (1 - 10000). The reading goal progress bar and details should be visible.
4. Mark books within the OL catalogue as already read within 2024. Refresh the page to see the progress bar and reading goal details update.
5. Click on `Edit` and set the reading goal to 0, the reading goal progress bar and details should revert back to `Set 2024 reading goal`.
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/user-attachments/assets/aef95399-1a9f-432e-937c-701c7c6465d6)
![image](https://github.com/user-attachments/assets/eb167235-4fff-4c01-bf19-fefa1b793363)
![image](https://github.com/user-attachments/assets/b4a69f96-a274-44de-835b-98a92d77b204)
![image](https://github.com/user-attachments/assets/cdcfbeba-2650-48db-8ff4-067b1dbd42fa)




### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
