### PR TITLE
fix the issue comment bot mypy bug

### DIFF
--- a/scripts/gh_scripts/issue_comment_bot.py
+++ b/scripts/gh_scripts/issue_comment_bot.py
@@ -249,7 +249,7 @@ def publish_digest(
 
     if response.status_code != 200:
         print(f'Failed to send message to Slack.  Status code: {response.status_code}')
-        sys.exit(errno.ECOMM)
+        sys.exit(errno.EPIPE)
 
     d = response.json()
     if not d.get('ok', True):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Part of #10075
I keep getting this error in my mypy locally
```
scripts/gh_scripts/issue_comment_bot.py:251: error: Module has no attribute
"ECOMM"  [attr-defined]
            sys.exit(errno.ECOMM)
```
The reason the ECOMM isn't supported on mac (darwin)
<img width="559" alt="image" src="https://github.com/user-attachments/assets/64ccbe19-e4ff-4dd5-bc44-e3f1844ea10b">

This is a problem because I'm trying to update the imports with isort for the whole script.

Chatgpt recommended changing it to EPIPE. I don't think it matters much but it does work.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@jimchamp @cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
