### PR TITLE
improve searchbar keyboard input

### DIFF
--- a/openlibrary/plugins/openlibrary/js/SearchBar.js
+++ b/openlibrary/plugins/openlibrary/js/SearchBar.js
@@ -310,7 +310,9 @@ export class SearchBar {
 
         this.$input.on('focus', debounce(event => {
             event.stopPropagation();
-            if (this.escapeInput) {
+            // don't render on focus if there are already results showing, avoid flashing
+            const resultsAreRendered = this.$results.children().length > 0;
+            if (this.escapeInput || resultsAreRendered) {
                 return;
             }
             this.renderAutocompletionResults();

--- a/openlibrary/plugins/openlibrary/js/SearchBar.js
+++ b/openlibrary/plugins/openlibrary/js/SearchBar.js
@@ -137,6 +137,12 @@ export class SearchBar {
             }
         })
 
+        this.$form.on('keydown', (e) => {
+            if (e.key === 'Tab') {
+                this.clearAutocompletionResults();
+            }
+        });
+
         this.initAutocompletionLogic();
     }
 

--- a/openlibrary/plugins/openlibrary/js/SearchBar.js
+++ b/openlibrary/plugins/openlibrary/js/SearchBar.js
@@ -63,6 +63,7 @@ export class SearchBar {
         this.$results = this.$component.find('ul.search-results');
         this.$facetSelect = this.$component.find('.search-facet-selector select');
         this.$barcodeScanner = this.$component.find('#barcode_scanner_link');
+        this.$searchSubmit = this.$component.find('.search-bar-submit')
 
         /** State */
         /** Whether the bar is in collapsible mode */
@@ -112,20 +113,24 @@ export class SearchBar {
         })
 
         this.$results.on('keydown', (e) => {
-            if (e.key === 'ArrowUp' || (e.key === 'Tab' && e.shiftKey)) {
-                if (!e.target.previousElementSibling) {
+            if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+                // On arrow keys focus on the next item unless there is none, then focus on input
+                const direction = e.key === 'ArrowUp' ? 'previousElementSibling' : 'nextElementSibling';
+                if (!e.target[direction]) {
                     this.$input.trigger('focus');
                     return false;
                 } else {
-                    $(e.target.previousElementSibling).trigger('focus');
+                    $(e.target[direction]).trigger('focus');
                     return false;
                 }
-            } else if (e.key === 'ArrowDown' || (e.key === 'Tab' && !e.shiftKey)) {
-                if (!e.target.nextElementSibling) {
-                    this.$input.trigger('focus');
+            } else if (e.key === 'Tab') {
+                // On tab, always go to the next selector (instead of next result), like wikipedia
+                this.clearAutocompletionResults();
+                if (e.shiftKey) {
+                    this.$facetSelect.trigger('focus');
                     return false;
                 } else {
-                    $(e.target.nextElementSibling).trigger('focus');
+                    this.$searchSubmit.trigger('focus');
                     return false;
                 }
             } else if (e.key === 'Enter') {

--- a/tests/unit/js/SearchBar.test.js
+++ b/tests/unit/js/SearchBar.test.js
@@ -27,31 +27,31 @@ describe('SearchBar', () => {
 
         test('Updates facet from params', () => {
             expect(sb.facet.read()).not.toBe('title');
-            sb.initFromUrlParams({ facet: 'title' });
+            sb.initFromUrlParams({facet: 'title'});
             expect(sb.facet.read()).toBe('title');
         });
 
         test('Ignore invalid facets', () => {
             const originalValue = sb.facet.read();
-            sb.initFromUrlParams({ facet: 'spam' });
+            sb.initFromUrlParams({facet: 'spam'});
             expect(sb.facet.read()).toBe(originalValue);
         });
 
         test('Sets input value from q param', () => {
-            sb.initFromUrlParams({ q: 'Harry Potter' });
+            sb.initFromUrlParams({q: 'Harry Potter'});
             expect(sb.$input.val()).toBe('Harry Potter');
         });
 
         test('Remove title prefix from q param', () => {
-            sb.initFromUrlParams({ q: 'title:"Harry Potter"', facet: 'title' });
+            sb.initFromUrlParams({q: 'title:"Harry Potter"', facet: 'title'});
             expect(sb.$input.val()).toBe('Harry Potter');
-            sb.initFromUrlParams({ q: 'title: "Harry"', facet: 'title' });
+            sb.initFromUrlParams({q: 'title: "Harry"', facet: 'title'});
             expect(sb.$input.val()).toBe('Harry');
         });
 
         test('Persists value in url param', () => {
             expect(localStorage.getItem('facet')).not.toBe('title');
-            sb.initFromUrlParams({ facet: 'title' });
+            sb.initFromUrlParams({facet: 'title'});
             expect(localStorage.getItem('facet')).toBe('title');
         });
     });
@@ -64,7 +64,7 @@ describe('SearchBar', () => {
         afterEach(() => localStorage.clear());
 
         test('Queries are marshalled before submit for titles', () => {
-            sb.initFromUrlParams({ facet: 'title' });
+            sb.initFromUrlParams({facet: 'title'});
             const spy = sinon.spy(SearchBar, 'marshalBookSearchQuery');
             sb.submitForm();
             expect(spy.callCount).toBe(1);
@@ -72,7 +72,7 @@ describe('SearchBar', () => {
         });
 
         test('Form action is updated on submit', () => {
-            sb.initFromUrlParams({ facet: 'title' });
+            sb.initFromUrlParams({facet: 'title'});
             const originalAction = sb.$form[0].action;
             sb.submitForm();
             expect(sb.$form[0].action).not.toBe(originalAction);
@@ -168,7 +168,7 @@ describe('SearchBar', () => {
         test('Title searches tigger autocomplete even if containing title: prefix', () => {
             // Stub debounce to avoid have to manipulate time (!)
             sandbox.stub(nonjquery_utils, 'debounce').callsFake(fn => fn);
-            const sb = new SearchBar($(DUMMY_COMPONENT_HTML), { facet: 'title' });
+            const sb = new SearchBar($(DUMMY_COMPONENT_HTML), {facet: 'title'});
             const getJSONStub = sandbox.stub($, 'getJSON');
             sb.$input.val('title:"Harry"');
             sb.$input.triggerHandler('focus');
@@ -178,7 +178,7 @@ describe('SearchBar', () => {
         test('Focussing on input when empty does not trigger autocomplete', () => {
             // Stub debounce to avoid have to manipulate time (!)
             sandbox.stub(nonjquery_utils, 'debounce').callsFake(fn => fn);
-            const sb = new SearchBar($(DUMMY_COMPONENT_HTML), { facet: 'title' });
+            const sb = new SearchBar($(DUMMY_COMPONENT_HTML), {facet: 'title'});
             const getJSONStub = sandbox.stub($, 'getJSON');
             sb.$input.val('');
             sb.$input.triggerHandler('focus');

--- a/tests/unit/js/SearchBar.test.js
+++ b/tests/unit/js/SearchBar.test.js
@@ -9,6 +9,7 @@ describe('SearchBar', () => {
             <form class="search-bar-input" action="https://openlibrary.org/search?q=foo">
                 <input type="text">
             </form>
+            <ul class="search-results"></ul>
         </div>`;
 
     describe('initFromUrlParams', () => {
@@ -210,6 +211,23 @@ describe('SearchBar', () => {
 
             // Verify clearAutocompletionResults was called
             expect(clearResultsSpy.callCount).toBe(1);
+        });
+
+        test('Autocomplete rendering behavior depends on existing results', () => {
+            sandbox.stub(nonjquery_utils, 'debounce').callsFake(fn => fn);
+            const sb = new SearchBar($(DUMMY_COMPONENT_HTML), {facet: 'title'});
+            const renderSpy = sandbox.spy(sb, 'renderAutocompletionResults');
+
+            // Should render when results are empty
+            sb.$input.triggerHandler('focus');
+            expect(renderSpy.callCount).toBe(1, 'Should render when no results exist');
+
+            renderSpy.resetHistory();
+
+            // Should not render when results exist
+            sb.$results.append('<li>Some result</li>');
+            sb.$input.triggerHandler('focus');
+            expect(renderSpy.callCount).toBe(0, 'Should not render when results exist');
         });
     });
 });

--- a/tests/unit/js/SearchBar.test.js
+++ b/tests/unit/js/SearchBar.test.js
@@ -197,5 +197,19 @@ describe('SearchBar', () => {
                 expect(getJSONStub.callCount).toBe(0);
             });
         }
+
+        test('Tabbing out of search input clears autocomplete results', () => {
+            const sb = new SearchBar($(DUMMY_COMPONENT_HTML));
+
+            // Spy on the clearAutocompletionResults method
+            const clearResultsSpy = sandbox.spy(sb, 'clearAutocompletionResults');
+
+            // Simulate tab keydown event on the form
+            const tabEvent = $.Event('keydown', { key: 'Tab' });
+            sb.$form.trigger(tabEvent);
+
+            // Verify clearAutocompletionResults was called
+            expect(clearResultsSpy.callCount).toBe(1);
+        });
     });
 });


### PR DESCRIPTION
- **clear search results on tab**
- **stop rerending on focus of input**
- **fixed tabbing when on search results + working test**

<!-- What issue does this PR close? -->
Closes #10103

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Added some tests but see video for demo

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

https://github.com/user-attachments/assets/4458081b-d160-401a-ad4a-5aef0c6caac0



### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
