### PR TITLE
Changed CSS so that the audiobook text does not overlap with the icon

### DIFF
--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -40,7 +40,6 @@ a.cta-btn {
 
   .btn-label { padding: 0 10px; }
 
-
   &:link, &:visited {
     color: @white;
     text-decoration: none;
@@ -141,7 +140,7 @@ a.cta-btn {
   white-space: nowrap;
   text-overflow: ellipsis;
   font-size: 14px;
-  text-align: center; 
+  text-align: center;
 }
 
 // Top margin to button coming after another button

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -134,13 +134,18 @@ a.cta-btn {
 }
 
 // Button inside carousel
-.carousel-section .cta-btn .btn-label {
-  padding: 8px 10px;
-  padding-right: 25px;
+.carousel-section .cta-btn {
   white-space: nowrap;
   text-overflow: ellipsis;
   font-size: 14px;
   text-align: center;
+
+  &.cta-btn--external {
+    padding-right: 25px;
+    .btn-label {
+       padding: 8px 10px;
+    }
+  }
 }
 
 // Top margin to button coming after another button

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -38,7 +38,14 @@ a.cta-btn {
     background-position: center;
   }
 
-  .btn-label { padding: 0 10px; }
+  .btn-label { 
+    padding: 8px 10px;
+    padding-right: 25px;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    font-size: 14px;
+    text-align: center; 
+  }
 
   &:link, &:visited {
     color: @white;

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -143,7 +143,7 @@ a.cta-btn {
   &.cta-btn--external {
     padding-right: 25px;
     .btn-label {
-       padding: 8px 10px;
+      padding: 8px 10px;
     }
   }
 }

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -38,14 +38,8 @@ a.cta-btn {
     background-position: center;
   }
 
-  .btn-label {
-    padding: 8px 10px;
-    padding-right: 25px;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    font-size: 14px;
-    text-align: center;
-  }
+  .btn-label { padding: 0 10px; }
+
 
   &:link, &:visited {
     color: @white;
@@ -138,6 +132,16 @@ a.cta-btn {
     border-radius: 5px;
     font-size: .7em;
   }
+}
+
+// Button inside carousel
+.carousel-section .cta-btn .btn-label {
+  padding: 8px 10px;
+  padding-right: 25px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: 14px;
+  text-align: center; 
 }
 
 // Top margin to button coming after another button

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -38,13 +38,13 @@ a.cta-btn {
     background-position: center;
   }
 
-  .btn-label { 
+  .btn-label {
     padding: 8px 10px;
     padding-right: 25px;
     white-space: nowrap;
     text-overflow: ellipsis;
     font-size: 14px;
-    text-align: center; 
+    text-align: center;
   }
 
   &:link, &:visited {

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -134,7 +134,6 @@ a.cta-btn {
 }
 
 // Button inside carousel
-// stylelint-disable-next-line selector-max-specificity
 .carousel-section .cta-btn {
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -143,6 +142,7 @@ a.cta-btn {
 
   &.cta-btn--external {
     padding-right: 25px;
+    // stylelint-disable-next-line selector-max-specificity
     .btn-label {
       padding: 8px 10px;
     }

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -140,6 +140,7 @@ a.cta-btn {
   font-size: 14px;
   text-align: center;
 
+  // stylelint-disable-next-line selector-max-specificity
   &.cta-btn--external {
     padding-right: 25px;
     .btn-label {

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -134,13 +134,13 @@ a.cta-btn {
 }
 
 // Button inside carousel
+// stylelint-disable-next-line selector-max-specificity
 .carousel-section .cta-btn {
   white-space: nowrap;
   text-overflow: ellipsis;
   font-size: 14px;
   text-align: center;
 
-  // stylelint-disable-next-line selector-max-specificity
   &.cta-btn--external {
     padding-right: 25px;
     .btn-label {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes https://github.com/internetarchive/openlibrary/issues/8899

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix: Fixes issue with the text overlapping in mobile

### Technical
<!-- What should be noted about the implementation? -->
Changed css as directed in https://github.com/internetarchive/openlibrary/pull/9066, this seems to work to resize the text so that there is no issue with the overlap with the icon. 

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

docker compose up
// For running site
docker compose exec -e PYTHONPATH=. web bash -c "./scripts/copydocs.py --search 'author_key:OL9411725A' --search-limit 100"
// Adding data
http://localhost:8080/works/OL36891831W/
Start changing screen width

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/user-attachments/assets/0a37299a-3e46-4c40-996a-35661a4e3935)
![image](https://github.com/user-attachments/assets/0c35ccf0-745d-42cd-aa73-932b8ce62a70)
![image](https://github.com/user-attachments/assets/3479d524-791e-4e80-8d92-8e0fef9b5868)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini
@RayBB

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
