### PR TITLE
Remove no longer needed identifier jquery repeat

### DIFF
--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -231,14 +231,6 @@ export function validateIdentifiers(data) {
     return true;
 }
 
-export function initIdentifierValidation() {
-    initJqueryRepeat();
-    $('#identifiers').repeat({
-        vars: {prefix: 'edition--'},
-        validate: function(data) {return validateIdentifiers(data)},
-    });
-}
-
 export function initClassificationValidation() {
     initJqueryRepeat();
     const dataConfig = JSON.parse(document.querySelector('#classifications').dataset.config);

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -99,7 +99,6 @@ jQuery(function () {
     const autocompleteSubjects = document.querySelector('.csv-autocomplete--subjects');
     const addRowButton = document.getElementById('add_row_button');
     const roles = document.querySelector('#roles');
-    const identifiers = document.querySelector('#identifiers');
     const classifications = document.querySelector('#classifications');
     const excerpts = document.getElementById('excerpts');
     const links = document.getElementById('links');
@@ -109,7 +108,7 @@ jQuery(function () {
         edition ||
         autocompleteAuthor || autocompleteLanguage || autocompleteWorks ||
         autocompleteSeeds || autocompleteSubjects ||
-        addRowButton || roles || identifiers || classifications ||
+        addRowButton || roles || classifications ||
         excerpts || links
     ) {
         import(/* webpackChunkName: "user-website" */ './edit')
@@ -131,9 +130,6 @@ jQuery(function () {
                 }
                 if (roles) {
                     module.initRoleValidation();
-                }
-                if (identifiers) {
-                    module.initIdentifierValidation();
                 }
                 if (classifications) {
                     module.initClassificationValidation();


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10126
Closes #10125

Since this was removed in #10032 , this is triggering an error which is causing issues for downstream JS
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
- Autocomplete appears for work, language on book edit page
- Can remove classification rows

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
