### PR TITLE
Fix Jenkins oldev build

### DIFF
--- a/docker/Dockerfile.oldev
+++ b/docker/Dockerfile.oldev
@@ -1,4 +1,11 @@
 FROM openlibrary/olbase:latest
+
+# Allow for nexus overrides (used in testing/staging builds)
+ARG NPM_CONFIG_REGISTRY
+ARG PIP_INDEX_URL
+ARG PIP_TRUSTED_HOST
+ARG HTTPS_PROXY
+
 WORKDIR /openlibrary
 
 COPY --chown=openlibrary:openlibrary requirements*.txt ./


### PR DESCRIPTION
Jenkins rebuilds the oldev image when pip dependencies change, so it needs to be able to set the nexus URL for package repos in the build.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
