### PR TITLE
Make textarea on edit pages full width

### DIFF
--- a/static/css/page-edit.less
+++ b/static/css/page-edit.less
@@ -157,7 +157,7 @@ div.adminDelete {
       width: 580px;
     }
   }
-  textarea {
+  .olform textarea {
     width: 100%;
     height: 500px;
     resize: vertical;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10058 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR addresses a bug where the text area in the edit page was expected to be full width, but actually filled only half of it instead due to the conflicting textarea style defined in the component forms.olform.less.

### Technical
<!-- What should be noted about the implementation? -->

This change increases the specificity of the textarea element in edit-pages.less by adding a class selector, ensuring that the text area for the edit page follows the style from page-edit.less.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

1. Login & go to your profile page by clicking the hamburger icon and selecting "My Profile"
2. Click Edit
3. Scroll to Description section. Expect for the text area to take 100% width as shown in the screenshot.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Before:
![before](https://github.com/user-attachments/assets/c2e7b628-f618-42b5-8187-91b7b1a5447e)

After:
<img width="1160" alt="fix" src="https://github.com/user-attachments/assets/04a83984-75a5-4918-98ff-f4f0723d32a5">


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
