### PR TITLE
Using book cover sizes to prevent layout shifting

### DIFF
--- a/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
+++ b/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
@@ -255,6 +255,7 @@ export default {
 };
 </script>
 
+
 <style scoped>
 .load-books {
   width: 100%;

--- a/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
+++ b/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
@@ -6,7 +6,11 @@
       </template>
 
       <template v-slot:cover="{book}">
-        <slot name="cover" v-bind:book="book"/>
+        <div class="cover-container">
+          <slot name="cover" v-bind:book="book">
+            <img :src="`https://covers.openlibrary.org/b/id/${book.cover_i}-L.jpg`" alt="Cover" class="cover"/>
+          </slot>
+        </div>
       </template>
 
       <template #book-end-start>
@@ -251,7 +255,6 @@ export default {
 };
 </script>
 
-
 <style scoped>
 .load-books {
   width: 100%;
@@ -319,4 +322,42 @@ export default {
   overflow: clip;
   position: relative;
 }
+
+.cover-container {
+  width: 180px;
+  height: 220px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+}
+
+img.cover {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 8px;
+}
+
+@media (max-width: 600px) {
+  .cover-container {
+    width: 100px;
+    height: 150px;
+  }
+}
+
+@media (min-width: 601px) and (max-width: 1200px) {
+  .cover-container {
+    width: 120px;
+    height: 180px;
+  }
+}
+
+@media (min-width: 1201px) {
+  .cover-container {
+    width: 150px;
+    height: 200px;
+  }
+}
+
 </style>

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -87,11 +87,12 @@ class Image:
         """Get the width of the image."""
         info = self.info()
         return info["width"] if info else None
-    
+
     def height(self):
         """Get the height of the image."""
         info = self.info()
         return info["height"] if info else None
+
 
 ThingKey = str
 

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -83,6 +83,15 @@ class Image:
     def __repr__(self):
         return "<image: %s/%d>" % (self.category, self.id)
 
+    def width(self):
+        """Get the width of the image."""
+        info = self.info()
+        return info["width"] if info else None
+    
+    def height(self):
+        """Get the height of the image."""
+        info = self.info()
+        return info["height"] if info else None
 
 ThingKey = str
 

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -77,7 +77,7 @@ $code:
               img {
                 width: 100%;
                 aspect-ratio: $aspect_ratio;
-                object-fit: cover;
+                object-fit: contain;
               }
             }
           }

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -52,12 +52,47 @@ $code:
   <div class="sri__main">
     <span class="bookcover $blur_cover">
       $ cover = get_cover_url(selected_ed) or "/images/icons/avatar_book-sm.png"
-      <a href="$work_edition_url"><img
+      $ cover_dimensions = get_dimensions_cover(cover)
+      $ aspect_ratio = 1
+      $if cover_dimensions:
+        $ cover_height = cover_dimensions[1]
+        $ cover_width = cover_dimensions[0]
+      $else:
+        $ cover_height = 360
+        $ cover_width = 180
+      $ aspect_ratio = cover_width / cover_height
+
+      $ fixed_width = 175
+      $ desired_height_for_fixed_width = fixed_width / aspect_ratio
+      <a href="$work_edition_url">
+        <img
               itemprop="image"
               src="$cover"
               alt="$_('Cover of: %(title)s', title=full_title)"
               title="$_('Cover of: %(title)s', title=full_title)"
-      /></a>
+        />
+        <style>
+          .searchResultItem {
+            .bookcover {
+              img {
+                width: 100%;
+                aspect-ratio: $aspect_ratio;
+                object-fit: cover;
+              }
+            }
+          }
+          @media only screen and (max-width: 768px) {
+            .searchResultItem {
+              .bookcover {
+                img {
+                  width: ${fixed_width}px;
+                  height: ${desired_height_for_fixed_width}px;
+                }
+              }
+            }
+          }
+        </style>
+      </a>
     </span>
 
     <div class="details">

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1329,6 +1329,7 @@ def setup_template_globals():
         get_book_provider,
         get_book_provider_by_name,
         get_cover_url,
+        get_dimensions_cover,
     )
 
     def get_supported_languages():
@@ -1369,6 +1370,7 @@ def setup_template_globals():
             'get_book_provider': get_book_provider,
             'get_book_provider_by_name': get_book_provider_by_name,
             'get_cover_url': get_cover_url,
+            'get_dimensions_cover': get_dimensions_cover,
             # bad use of globals
             'is_bot': is_bot,
             'time': time,

--- a/openlibrary/plugins/openlibrary/js/lists/ShowcaseItem.js
+++ b/openlibrary/plugins/openlibrary/js/lists/ShowcaseItem.js
@@ -231,9 +231,10 @@ function getSeedType(seed) {
  * @param {string} seedKey
  * @param {string} listTitle
  * @param {string} [coverUrl]
+ * @param {string} desiredHeight 
  * @returns {HTMLLIElement}
  */
-export function createActiveShowcaseItem(listKey, seedKey, listTitle, coverUrl = DEFAULT_COVER_URL) {
+export function createActiveShowcaseItem(listKey, seedKey, listTitle, coverUrl = DEFAULT_COVER_URL, desiredHeight = "") {
     if (!i18nStrings) {
         const i18nInput = document.querySelector('input[name=list-i18n-strings]')
         i18nStrings = JSON.parse(i18nInput.value)
@@ -244,7 +245,7 @@ export function createActiveShowcaseItem(listKey, seedKey, listTitle, coverUrl =
     const seedType = getSeedType(seedKey)
 
     const itemMarkUp = `<span class="image">
-                <a href="${listKey}"><img src="${coverUrl}" alt="${i18nStrings['cover_of']}${listTitle}" title="${i18nStrings['cover_of']}${listTitle}"/></a>
+                <a href="${listKey}"><img src="${coverUrl}" alt="${i18nStrings['cover_of']}${listTitle}" title="${i18nStrings['cover_of']}${listTitle}" width="22px" height="${desiredHeight}"/></a>
             </span>
             <span class="data">
                 <span class="label">

--- a/openlibrary/plugins/openlibrary/js/lists/ShowcaseItem.js
+++ b/openlibrary/plugins/openlibrary/js/lists/ShowcaseItem.js
@@ -231,10 +231,10 @@ function getSeedType(seed) {
  * @param {string} seedKey
  * @param {string} listTitle
  * @param {string} [coverUrl]
- * @param {string} desiredHeight 
+ * @param {string} desiredHeight
  * @returns {HTMLLIElement}
  */
-export function createActiveShowcaseItem(listKey, seedKey, listTitle, coverUrl = DEFAULT_COVER_URL, desiredHeight = "") {
+export function createActiveShowcaseItem(listKey, seedKey, listTitle, coverUrl = DEFAULT_COVER_URL, desiredHeight = '') {
     if (!i18nStrings) {
         const i18nInput = document.querySelector('input[name=list-i18n-strings]')
         i18nStrings = JSON.parse(i18nInput.value)

--- a/openlibrary/plugins/openlibrary/js/my-books/index.js
+++ b/openlibrary/plugins/openlibrary/js/my-books/index.js
@@ -7,7 +7,7 @@ import { removeChildren } from '../utils'
 
 // XXX : jsdoc
 // XXX : decompose
-export function initMyBooksAffordances(dropperElements, showcaseElements) {
+export async function initMyBooksAffordances(dropperElements, showcaseElements) {
     const showcases = []
     for (const elem of showcaseElements) {
         const showcase = new ShowcaseItem(elem)
@@ -42,7 +42,7 @@ export function initMyBooksAffordances(dropperElements, showcaseElements) {
 
     getListPartials()
         .then(response => response.json())
-        .then((data) => {
+        .then(async (data) => {
             // XXX : convert this block to one or two function calls
             const listData = data.listData
             const activeShowcaseItems = []
@@ -55,8 +55,18 @@ export function initMyBooksAffordances(dropperElements, showcaseElements) {
                         const key = listData[listKey].members[0]
                         const coverID = key.slice(key.indexOf('OL'))
                         const cover = `https://covers.openlibrary.org/b/olid/${coverID}-S.jpg`
-
-                        activeShowcaseItems.push(createActiveShowcaseItem(listKey, seedKey, listData[listKey].listName, cover))
+                        
+                        const img = new Image()
+                        img.src = cover
+                        
+                        await new Promise((resolve) => {
+                            img.onload = () => {
+                                let desiredHeight = 22 * img.height / img.width
+                                desiredHeight = desiredHeight.toFixed(2)
+                                activeShowcaseItems.push(createActiveShowcaseItem(listKey, seedKey, listData[listKey].listName, cover, desiredHeight))
+                                resolve()
+                            }
+                        })
                     }
                 }
             }

--- a/openlibrary/plugins/openlibrary/js/my-books/index.js
+++ b/openlibrary/plugins/openlibrary/js/my-books/index.js
@@ -55,10 +55,10 @@ export async function initMyBooksAffordances(dropperElements, showcaseElements) 
                         const key = listData[listKey].members[0]
                         const coverID = key.slice(key.indexOf('OL'))
                         const cover = `https://covers.openlibrary.org/b/olid/${coverID}-S.jpg`
-                        
+
                         const img = new Image()
                         img.src = cover
-                        
+
                         await new Promise((resolve) => {
                             img.onload = () => {
                                 let desiredHeight = 22 * img.height / img.width

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -55,11 +55,14 @@ $def render_carousel_cover(book, lazy, layout):
   $ modifier = ''
   $ work_key = book.key if book.key.startswith('/work') else book.get('work_key')
 
+  $ cover_dimensions = (180, 360)
+  $ aspect_ratio = cover_dimensions and cover_dimensions[0] / cover_dimensions[1] or 1
+
   <div class="book carousel__item">
     <div class="book-cover">
       <a href="$(url)" data-ol-link-track="BookCarousel|CoverClick|$key">
         $if cover_url:
-          <img class="bookcover" loading="lazy"
+          <img class="bookcover covers-in-carousel" loading="lazy"
             title="$('%s%s'%(title,byline))"
             alt="$('%s%s'%(title,byline))"
           $if lazy and layout == 'carousel':
@@ -67,6 +70,12 @@ $def render_carousel_cover(book, lazy, layout):
             src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="/>
           $else:
             src="$(cover_url)"/>
+          <style>
+            .covers-in-carousel {
+              aspect-ratio: $aspect_ratio;
+              object-fit: contain;
+            }
+          </style>
         $else:
           <div class="carousel__item__blankcover"  title="$(title)">
             <div class="carousel__item__blankcover--title">$:macros.TruncateString(title, 70)</div>

--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -38,10 +38,10 @@ $ aspect_ratio = cover_dimensions and cover_dimensions[0] / cover_dimensions[1] 
               alt="$_('Cover of: %(title)s', title=book.title)"
               title="$_('Cover of: %(title)s', title=book.title)"
               loading="lazy"
-              class="aspect-ratio-covers-in-editions"
+              class="covers-in-editions"
             />
             <style>
-              .aspect-ratio-covers-in-editions {
+              .covers-in-editions {
                 width: 100%;
                 aspect-ratio: $aspect_ratio;
                 object-fit: contain;

--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -26,16 +26,28 @@ $ isbn = isbn_10 or isbn_13
 $ asin = isbn_10 or None
 
 $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
+$ cover_dimensions = get_dimensions_cover(url) or (44, 60)
+$ aspect_ratio = cover_dimensions and cover_dimensions[0] / cover_dimensions[1] or 1
 
     <td class="book">
       <span class="hidden sort-key">$edition_sort_key</span>
       <div class="cover">
-          <a href="$book.url()"><img
-            src="$url"
-            alt="$_('Cover of: %(title)s', title=book.title)"
-            title="$_('Cover of: %(title)s', title=book.title)"
-            loading="lazy"
-          /></a>
+          <a href="$book.url()">
+            <img
+              src="$url"
+              alt="$_('Cover of: %(title)s', title=book.title)"
+              title="$_('Cover of: %(title)s', title=book.title)"
+              loading="lazy"
+              class="aspect-ratio-covers-in-editions"
+            />
+            <style>
+              .aspect-ratio-covers-in-editions {
+                width: 100%;
+                aspect-ratio: $aspect_ratio;
+                object-fit: contain;
+              }
+            </style>
+          </a>
       </div>
 
       <div class="title">

--- a/openlibrary/templates/covers/book_cover.html
+++ b/openlibrary/templates/covers/book_cover.html
@@ -13,10 +13,30 @@ $ cover_lg = book.get_cover_url("L")
 $ src = cover_url or '/images/icons/avatar_book.png'
 $ srcset = '%s 2x' % (cover_lg or '/images/icons/avatar_book-lg.png')
 
+$ cover_height = None
+$ cover_width = 180  # Fixed width of the image
+$ aspect_ratio = 1
+$ cover = book.get_cover()
+$if cover:
+    $ cover_height = cover.height()
+    $ cover_width = cover.width()
+    $ aspect_ratio = cover.width() / cover.height()
+$else:
+    $ ia_cover_url = book.get_ia_cover(book.ocaid, "M")
+    $ parts = ia_cover_url.split('_h')
+    $ cover_height_str = parts[1].split('.')[0]
+    $ cover_height = int(cover_height_str)
+    $ cover_width_str = parts[0].split('_w')[1]
+    $ cover_width = int(cover_width_str)
+    $ aspect_ratio = cover_width / cover_height
+
+$ fixed_width = 180  # Fixed width of the container
+$ calculated_height = fixed_width / aspect_ratio
+
 $if preload:
     $add_metatag(tag="link", **{'rel': 'preload', 'as': 'image', 'href': src, 'imagesrcset': srcset})
 
-<div class="coverMagic cover-animation">
+<div class="coverMagic cover-animation" style="min-height: ${calculated_height}px;">
     <div class="SRPCover bookCover" style="display: $cond(cover_url, 'block', 'none');">
         <a
             href="$cover_lg"

--- a/openlibrary/templates/lists/home.html
+++ b/openlibrary/templates/lists/home.html
@@ -36,7 +36,12 @@ $var title: $_('Lists')
                         <div class="cover">
                             $ cover = list.get_cover() or list.get_default_cover()
                             $ cover_url = cover and cover.url("S") or "/images/icons/avatar_book-sm.png"
-                            <img src="$cover_url" alt=""/>
+                            $ cover_width = cover.width()
+                            $ cover_height = cover.height()
+                            $ cover_aspect_ratio = cover_width and cover_height and cover_width / cover_height
+                            $ cover_width_for_58px_height = cover_aspect_ratio and int(58 * cover_aspect_ratio)
+                            $ cover_height_for_25px_width = cover_width_for_58px_height and round(1450 / cover_width_for_58px_height)
+                            <img src="$cover_url" alt="" width="25px" height="$cover_height_for_25px_width" />
                         </div>
                         $list.name
                     </a>

--- a/static/css/components/book.less
+++ b/static/css/components/book.less
@@ -29,7 +29,7 @@
     margin: 0 auto;
     box-shadow: 1px 2px 5px 0 @book-cover-shadow-color;
     border-radius: 3px;
-    max-width: 100%;
-    max-height: 200px;
+    width: 100%;
+    height: 12rem;
   }
 }

--- a/static/css/components/book.less
+++ b/static/css/components/book.less
@@ -27,9 +27,9 @@
 
   img.bookcover {
     margin: 0 auto;
-    box-shadow: 1px 2px 5px 0 @book-cover-shadow-color;
+    filter: drop-shadow(1px 2px 5px @book-cover-shadow-color);
     border-radius: 3px;
     width: 100%;
-    height: 12rem;
+    max-height: 200px;
   }
 }

--- a/static/css/components/listLists.less
+++ b/static/css/components/listLists.less
@@ -29,7 +29,7 @@ ul.listLists {
       /* stylelint-disable max-nesting-depth */
       img {
         width: 32px;
-        max-width: 100%;
+        // max-width: 100%;
       }
       /* stylelint-enable max-nesting-depth */
     }

--- a/static/css/components/listLists.less
+++ b/static/css/components/listLists.less
@@ -29,7 +29,6 @@ ul.listLists {
       /* stylelint-disable max-nesting-depth */
       img {
         width: 22px;
-        // max-width: 100%;
       }
       /* stylelint-enable max-nesting-depth */
     }

--- a/static/css/components/listLists.less
+++ b/static/css/components/listLists.less
@@ -28,7 +28,7 @@ ul.listLists {
       padding: 0 10px;
       /* stylelint-disable max-nesting-depth */
       img {
-        width: 32px;
+        width: 22px;
         // max-width: 100%;
       }
       /* stylelint-enable max-nesting-depth */

--- a/static/css/components/search-result-item.less
+++ b/static/css/components/search-result-item.less
@@ -84,14 +84,12 @@
       filter: blur(2px);
     }
   }
-  .bookcover {
-    width: 100%;
+  .git {
     margin: 10px 10px 0 5px;
     text-align: center;
     overflow: hidden;
     img {
       border-radius: 4px;
-      max-width: 100%;
       max-height: 300px;
       width: 175px;
     }

--- a/static/css/components/search-result-item.less
+++ b/static/css/components/search-result-item.less
@@ -84,12 +84,14 @@
       filter: blur(2px);
     }
   }
-  .git {
+  .bookcover {
+    width: 100%;
     margin: 10px 10px 0 5px;
     text-align: center;
     overflow: hidden;
     img {
       border-radius: 4px;
+      max-width: 100%;
       max-height: 300px;
       width: 175px;
     }

--- a/static/css/layout/index.less
+++ b/static/css/layout/index.less
@@ -12,9 +12,6 @@
 div.contentBody,
 div#contentBody {
   padding: 0 @contentBody-padding @contentBody-padding;
-  img {
-    // max-width: 100%;
-  }
   pre {
     overflow-x: auto;
   }

--- a/static/css/layout/index.less
+++ b/static/css/layout/index.less
@@ -13,7 +13,7 @@ div.contentBody,
 div#contentBody {
   padding: 0 @contentBody-padding @contentBody-padding;
   img {
-    max-width: 100%;
+    // max-width: 100%;
   }
   pre {
     overflow-x: auto;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9739 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
feature

### Technical
<!-- What should be noted about the implementation? -->
#### Improvements to cover image handling:

* [`openlibrary/book_providers.py`](diffhunk://#diff-a22c26e2bff473fa98e28eba10d068eb3fcba5aedb9beeec81de159677fcdd22R584-R601): Added the `get_dimensions_cover` function to retrieve the dimensions of cover images from a given URL.
* [`openlibrary/core/models.py`](diffhunk://#diff-9a03e714bd068dae76b2a99fdde09aff001fd7c547b11b0ea016079d3a567c8eR86-R95): Added `width` and `height` methods to the `Image` class to get the dimensions of an image.

#### Updates to CSS styles:

* [`openlibrary/components/LibraryExplorer/components/OLCarousel.vue`](diffhunk://#diff-67252238cf1f4e1386c9d41f7416ed52fd6d72e5effb8d2273b539942a65f4c3R326-R363): Added styles for the `.cover-container` class to handle different screen sizes and ensure images fit properly.
* [`static/css/components/book.less`](diffhunk://#diff-f8c91bc33e93b164d4442976576b0679323989637ec608962259b856a78a1bc1L30-R32): Changed `img.bookcover` to use `filter: drop-shadow` instead of `box-shadow` and ensured the width is set to 100%.
* [`static/css/components/listLists.less`](diffhunk://#diff-9330540670a576916c8aca593f67f793a5c8706bafe2db882f8d46a4d48c8d1fL31-R31): Adjusted the width of images in lists to 22px.

#### Template modifications:

* [`openlibrary/macros/SearchResultsWork.html`](diffhunk://#diff-1c0a702d7b1bad810adce7c001416b5996968d117077f629ff52ddff4668f56fL55-R95): Incorporated the `get_dimensions_cover` function to dynamically set the aspect ratio and size of cover images.
* [`openlibrary/templates/books/custom_carousel.html`](diffhunk://#diff-837c205806c961dffc8411d2f2016f3b494b2a10e21f226d2d0afcaebe25ff5dR58-R78): Apply the aspect ratio for book covers in the carousel.
* [`openlibrary/templates/covers/book_cover.html`](diffhunk://#diff-ae840263902ba714fdbe05dc376927bd4a4e47204ecd9fd34fabd8acea4b0a36R16-R39): Added logic to calculate the height based on the aspect ratio and fixed width for book covers.
* [`openlibrary/templates/lists/home.html`](diffhunk://#diff-3af339688142a7d7391c1d94afa83e2e645514dbffe21b7bdb3712ee11619442): Added logic to calculate the height based on the aspect ratio and fixed width for book covers in the section of Active Lists.
* [`openlibrary/templates/books/edition-sort.html`](diffhunk://#diff-3604ab94e1e89f0de259f67ff749f17f79baad88c3b7c802b944f8dc4095c7d4): Apply the aspect ratio for book covers in Edition table.


### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Navigate to pages where book covers are displayed:
* http://localhost:8080/search?q=mark&mode=everything
* http://localhost:8080/works/OL13101191W/Alice%27s_Adventures_in_Wonderland?edition=key%3A/books/OL23269118M
* http://localhost:8080/books/OL24375501M/Program_or_be_Programmed
* http://localhost:8080/authors/OL22098A/Lewis_Carroll
* Create a new list and add one or more books to the list: http://localhost:8080/people/openlibrary/lists/OL1L/new_list
* http://localhost:8080/lists: Maybe, you will need to modify the code of the function `_get_active_lists_in_random(limit=20, preload=True)` as follows:
![image](https://github.com/user-attachments/assets/685ee0ae-62b7-4cec-995d-4ded22cdbb8d)
This is to show all the lists in the "Active Lists" section if you have few lists in your database.
3. Verified that the book covers load with the correct dimensions.
4. Ensured that the layout remains stable and does not shift when the images are loaded.
5. Tested the changes on various devices and screen sizes to confirm responsiveness.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
We have make videos demonstrating the changes and comparing with the real website of OpenLibrary;
https://drive.google.com/file/d/1RrzodyWAFDAS--mk5Y222Hjk95FYgMla/view?usp=sharing
https://drive.google.com/file/d/1BF7YWPcys6Ny2EuJ9ahkiIexsC1JjmCH/view?usp=sharing
https://drive.google.com/file/d/1UU0nRT32Oa0Bu_27FD6cN8tQES-QUqpQ/view?usp=sharing
https://drive.google.com/file/d/1qe68bcZtBNh2cbOEbi93z4s2u9XHgDtD/view?usp=sharing
https://drive.google.com/file/d/1rOheT5PNJi6iveGhcGpb589YsG9uEqXb/view?usp=drive_link

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
