### PR TITLE
Make locate button open worldcat in new tab

### DIFF
--- a/openlibrary/macros/LocateButton.html
+++ b/openlibrary/macros/LocateButton.html
@@ -2,5 +2,5 @@ $def with(edition_key)
 
 $ locateUrl = "/books/XXX/-/borrow?action=locate".replace('XXX', edition_key or '')
 
-<a class="cta-btn cta-btn--available cta-btn--w-icon cta-btn--external" href="$locateUrl"
+<a class="cta-btn cta-btn--available cta-btn--w-icon cta-btn--external" href="$locateUrl" target="_blank"
   data-ol-link-track="CTAClick|Locate">$_('Locate')</a>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10144 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Makes the locate button open worldcat in a new tab

### Technical
<!-- What should be noted about the implementation? -->
Added `target=_blank` to `macros/LocateButton.html`

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Navigate to a Locate cta button
2. Ensure that clicking on it opens a worldcat link in a new tab

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
