### PR TITLE
Allow publishing docker images from non-master branches for testing

### DIFF
--- a/.github/workflows/olbase.yaml
+++ b/.github/workflows/olbase.yaml
@@ -28,10 +28,22 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push
+      # If on master, use the latest tag, otherwise use the branch name
+      - name: Master Build and push
         uses: docker/build-push-action@v6
+        if: github.ref == 'refs/heads/master'
         with:
           context: "."
           file: "./docker/Dockerfile.olbase"
           tags: openlibrary/olbase:latest
+          push: true
+
+      # If on another branch, use the branch name -- just the branch name, not the full ref
+      - name: Test Branch Build and push
+        uses: docker/build-push-action@v6
+        if: github.ref != 'refs/heads/master'
+        with:
+          context: "."
+          file: "./docker/Dockerfile.olbase"
+          tags: openlibrary/olbase:${{ github.ref_name }}
           push: true


### PR DESCRIPTION
Add option to create olbase image with non-latest (ie master) tag for testing. Needed for testing the nginx changes in #10149 

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
