### PR TITLE
10067/fix/search result

### DIFF
--- a/static/css/layout/v2.less
+++ b/static/css/layout/v2.less
@@ -2,16 +2,16 @@
   box-sizing: border-box;
   max-width: 1060px;
   width: 100%;
-  min-height: 300px; 
+  min-height: 300px;
   margin: 0 auto;
-  background-color: @white; 
+  background-color: @white;
   border-radius: 5px;
-  border: 1px solid @dark-beige; 
-  z-index: @z-index-level-1; 
+  border: 1px solid @dark-beige;
+  z-index: @z-index-level-1;
   position: relative;
   display: flex;
   flex-direction: column;
-  height: auto; 
+  height: auto;
 }
 
 // stylelint-disable-next-line no-descending-specificity

--- a/static/css/layout/v2.less
+++ b/static/css/layout/v2.less
@@ -2,12 +2,16 @@
   box-sizing: border-box;
   max-width: 1060px;
   width: 100%;
+  min-height: 300px; 
   margin: 0 auto;
-  background-color: @white;
+  background-color: @white; 
   border-radius: 5px;
-  border: 1px solid @dark-beige;
-  z-index: @z-index-level-1;
+  border: 1px solid @dark-beige; 
+  z-index: @z-index-level-1; 
   position: relative;
+  display: flex;
+  flex-direction: column;
+  height: auto; 
 }
 
 // stylelint-disable-next-line no-descending-specificity


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10067 Unify whitespace on search results pages (when no search results). 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix - This PR ensures consistent whitespace when no search results are found on the search results pages.

### Technical
<!-- What should be noted about the implementation? -->
Adjusted the CSS and layout for the "no search results" page state.
Verified styling consistency with other search result states.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
To verify the fix:

Visit the search results page.
Enter a query that does not yield any results.
Observe the following:
Whitespace above and below the "no results" message is consistent.
The layout remains visually appealing and aligned.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="1512" alt="Screenshot 2024-12-17 at 04 14 25" src="https://github.com/user-attachments/assets/d8be86d2-b890-458e-81b1-0110dd4e394b" />
<img width="1512" alt="Screenshot 2024-12-17 at 04 14 16" src="https://github.com/user-attachments/assets/a19bff32-d1d4-4cf9-88e9-c9841faf8def" />


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
