### PR TITLE
Fix search facet from mirepresenting the amount of ebook results

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -533,6 +533,9 @@ class search(delegate.page):
         if list(param) == ['has_fulltext']:
             param = {}
 
+        if web_input.get('mode') != 'printdisabled' and not web.cookies().get('pd'):
+            param['q'] += ' AND -ebook_access:printdisabled'
+
         page = int(param.get('page', 1))
         sort = param.get('sort', None)
         rows = 20


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9575 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Hides printdisabled results for users not explicitly searching for them who do not have printdisabled settings stored in cookies. 

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Ensure that ebook facet counts match the amount of actual ebook results, with or without 'pd' set to true in cookies. 

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini  @RayBB 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
