### PR TITLE
Improve `refer` checks for `/account/login`

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -4,6 +4,7 @@ from collections.abc import Callable, Iterable, Mapping
 from datetime import datetime
 from math import ceil
 from typing import TYPE_CHECKING, Any, Final
+from urllib.parse import urlparse
 
 import requests
 import web
@@ -413,7 +414,12 @@ class account_login(delegate.page):
     def GET(self):
         referer = web.ctx.env.get('HTTP_REFERER', '')
         # Don't set referer if request is from offsite
-        if 'openlibrary.org' not in referer or referer.endswith('openlibrary.org/'):
+        parsed_referer = urlparse(referer)
+        this_host = web.ctx.host
+        if ':' in this_host:
+            # Remove port number
+            this_host = this_host.split(':', 1)[0]
+        if parsed_referer.hostname != this_host:
             referer = None
         i = web.input(redirect=referer)
         f = forms.Login()


### PR DESCRIPTION
Ensures that we avoid redirecting to something like `not-really-openlibrary.org` on login.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
