### PR TITLE
Trigger Slack notifications when `cron_watcher` fails

### DIFF
--- a/.github/workflows/cron_watcher.yml
+++ b/.github/workflows/cron_watcher.yml
@@ -35,6 +35,6 @@ jobs:
           channel = os.getenv("SLACK_CHANNEL_ABC_TEAM_PLUS")
           if token and channel:
             slack_sdk.WebClient(token=token).chat_postMessage(channel=channel,
-              text="<https://github.com/internetarchive/openlibrary/actions/workflows/cron_watcher.yml|`cron_watcher`> has failed.",
+              text="<!channel>: <https://github.com/internetarchive/openlibrary/actions/workflows/cron_watcher.yml|`cron_watcher`> has failed.",
             )
           sys.exit(1)


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Notifies Open Library's staff Slack channel when the `cron_watcher` workflow fails.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
