### PR TITLE
Cache fulltext search results

### DIFF
--- a/openlibrary/plugins/inside/code.py
+++ b/openlibrary/plugins/inside/code.py
@@ -41,5 +41,16 @@ class search_inside_json(delegate.page):
         query = i.q
         page = int(i.page)
         results = fulltext_search(query, page=page, limit=limit, js=True, facets=True)
+
+        # Add caching headers only if there's no error
+        if 'error' not in results:
+            # Cache for 5 minutes (300 seconds)
+            web.header('Cache-Control', 'public, max-age=300')
+            web.header('Expires', web.http.expires(300))
+        else:
+            # No caching for error responses
+            web.header('Cache-Control', 'no-store, no-cache, must-revalidate')
+            web.header('Pragma', 'no-cache')
+
         web.header('Content-Type', 'application/json')
         return delegate.RawText(json.dumps(results, indent=4))

--- a/openlibrary/plugins/inside/code.py
+++ b/openlibrary/plugins/inside/code.py
@@ -41,16 +41,5 @@ class search_inside_json(delegate.page):
         query = i.q
         page = int(i.page)
         results = fulltext_search(query, page=page, limit=limit, js=True, facets=True)
-
-        # Add caching headers only if there's no error
-        if 'error' not in results:
-            # Cache for 5 minutes (300 seconds)
-            web.header('Cache-Control', 'public, max-age=300')
-            web.header('Expires', web.http.expires(300))
-        else:
-            # No caching for error responses
-            web.header('Cache-Control', 'no-store, no-cache, must-revalidate')
-            web.header('Pragma', 'no-cache')
-
         web.header('Content-Type', 'application/json')
         return delegate.RawText(json.dumps(results, indent=4))

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1245,7 +1245,7 @@ class Partials(delegate.page):
             data = fulltext_search(query)
             # Add caching headers only if there were no errors in the search results
             if 'error' not in data:
-                # Cache for 5 minutes (300 seconds) 
+                # Cache for 5 minutes (300 seconds)
                 web.header('Cache-Control', 'public, max-age=300')
             hits = data.get('hits', [])
             if not hits['hits']:

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1251,8 +1251,14 @@ class Partials(delegate.page):
                     'macros'
                 ].FulltextSearchSuggestion(query, data)
             partial = {"partials": str(macro)}
-
-        return delegate.RawText(json.dumps(partial))
+        
+            # Add caching headers only if there were no errors in the search results
+            if 'error' not in data:
+                # Cache for 5 minutes (300 seconds) 
+                web.header('Cache-Control', 'public, max-age=300')
+                web.header('Expires', web.http.expires(300))
+        
+            return delegate.RawText(json.dumps(partial))
 
 
 def is_bot():

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1243,6 +1243,10 @@ class Partials(delegate.page):
         elif component == "FulltextSearchSuggestion":
             query = i.get('data', '')
             data = fulltext_search(query)
+            # Add caching headers only if there were no errors in the search results
+            if 'error' not in data:
+                # Cache for 5 minutes (300 seconds) 
+                web.header('Cache-Control', 'public, max-age=300')
             hits = data.get('hits', [])
             if not hits['hits']:
                 macro = '<div></div>'
@@ -1251,13 +1255,6 @@ class Partials(delegate.page):
                     'macros'
                 ].FulltextSearchSuggestion(query, data)
             partial = {"partials": str(macro)}
-        
-            # Add caching headers only if there were no errors in the search results
-            if 'error' not in data:
-                # Cache for 5 minutes (300 seconds) 
-                web.header('Cache-Control', 'public, max-age=300')
-                web.header('Expires', web.http.expires(300))
-        
             return delegate.RawText(json.dumps(partial))
 
 

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1255,7 +1255,8 @@ class Partials(delegate.page):
                     'macros'
                 ].FulltextSearchSuggestion(query, data)
             partial = {"partials": str(macro)}
-            return delegate.RawText(json.dumps(partial))
+
+        return delegate.RawText(json.dumps(partial))
 
 
 def is_bot():


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes # 10051

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR achives reduction in time taken to show no results by about 0.5-0.8 s

### Technical
<!-- What should be noted about the implementation? -->
- The modification is done in the openlibrary\plugins\openlibrary\code.py
- Added caching for search suggestion responses using `Cache-Control` header
- Set cache duration to 5 minutes (max-age=300)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Open browser developer tools (F12)
2. Go to Network tab
3. Perform a search query
4. Verify response headers:
   - Should see `Cache-Control: public, max-age=300`
5. Changing the subsection of search
   - Response should be served from browser cache
   - The rendering of loading bar is not there while switching to different subsections (like Authors, Lists etc.)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
I have worked on this issue with @jimchamp as lead.


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
