### PR TITLE
Fixed arrow alignment in covers modal

### DIFF
--- a/static/css/components/carousel--js.less
+++ b/static/css/components/carousel--js.less
@@ -8,6 +8,7 @@
   .slick-slider {
     // allow overflow now the carousel has been initialised.
     overflow: visible;
+    display: flex;
   }
 }
 .carousel {

--- a/static/css/components/carousel--js.less
+++ b/static/css/components/carousel--js.less
@@ -8,7 +8,6 @@
   .slick-slider {
     // allow overflow now the carousel has been initialised.
     overflow: visible;
-    display: flex;
   }
 }
 .carousel {
@@ -16,7 +15,7 @@
   .slick-next {
     width: auto;
     height: auto;
-
+    z-index: @z-index-level-4;
     &:before {
       color: @primary-blue;
       font-size: 35px;

--- a/static/css/components/cbox.less
+++ b/static/css/components/cbox.less
@@ -261,6 +261,7 @@ div.floater {
     border: 2px solid @light-grey;
     border-radius: 6px;
     position: relative;
+    margin: auto;
   }
 }
 

--- a/static/css/components/cbox.less
+++ b/static/css/components/cbox.less
@@ -256,12 +256,11 @@ div.floater {
     gap: 10px;
   }
 
-  .carousel button {
+  .carousel .cta-btn {
     color: @grey;
     border: 2px solid @light-grey;
     border-radius: 6px;
     position: relative;
-    margin: auto;
   }
 }
 

--- a/static/css/lib/slick-theme.css
+++ b/static/css/lib/slick-theme.css
@@ -97,7 +97,7 @@
 
 .slick-next
 {
-    right: -25px;
+    right: -11px;
 }
 [dir='rtl'] .slick-next
 {

--- a/static/css/lib/slick-theme.css
+++ b/static/css/lib/slick-theme.css
@@ -97,7 +97,7 @@
 
 .slick-next
 {
-    right: -11px;
+    right: -25px;
 }
 [dir='rtl'] .slick-next
 {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10134 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Align/Fix the navigation arrows, positioning them on the sides of the covers for better usability.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1) Go to the add-cover section of a book (eg. https://openlibrary.org/works/OL69166W/Italian_journeys/add-cover)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

**Before:**
![Screenshot 2024-12-19 121132](https://github.com/user-attachments/assets/79d3c9c3-81ff-4049-8943-6931fb92cb37)

**After:**
![Screenshot 2024-12-19 121909](https://github.com/user-attachments/assets/73c1a061-457f-4f27-8847-707c271a2cbc)



### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
