### PR TITLE
Update deprecated method in `expire_accounts.py`

### DIFF
--- a/scripts/expire_accounts.py
+++ b/scripts/expire_accounts.py
@@ -1,12 +1,13 @@
-from datetime import datetime
-
+from datetime import datetime, UTC
 import web
 
 
 def delete_old_links():
     for doc in web.ctx.site.store.values(type="account-link"):
         expiry_date = datetime.strptime(doc["expires_on"], "%Y-%m-%dT%H:%M:%S.%f")
-        now = datetime.utcnow()
+        # Make expiry_date timezone-aware:
+        expiry_date = expiry_date.replace(tzinfo=UTC)
+        now = datetime.now(UTC)
         key = doc["_key"]
         if expiry_date > now:
             print("Deleting link %s" % (key))

--- a/scripts/expire_accounts.py
+++ b/scripts/expire_accounts.py
@@ -1,4 +1,5 @@
-from datetime import datetime, UTC
+from datetime import datetime
+from datetime import UTC
 
 import web
 

--- a/scripts/expire_accounts.py
+++ b/scripts/expire_accounts.py
@@ -1,5 +1,4 @@
-from datetime import datetime
-from datetime import UTC
+from datetime import UTC, datetime
 
 import web
 

--- a/scripts/expire_accounts.py
+++ b/scripts/expire_accounts.py
@@ -1,4 +1,5 @@
 from datetime import datetime, UTC
+
 import web
 
 


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
I noticed some deprecation warnings for `datetime.datetime.utcnow()` while looking through our logs today.  This PR updates the deprecated method, and makes the `expiry_date` object timezone-aware.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
