### PR TITLE
Use mock data for homepage charts to reduce startup loading time

### DIFF
--- a/openlibrary/core/admin.py
+++ b/openlibrary/core/admin.py
@@ -154,20 +154,65 @@ def _get_count_docs(ndays):
     return [d for d in docs if d]
 
 
-def get_stats(ndays=30):
+def get_stats(ndays=30, dev_prod=False):
     """Returns the stats for the past `ndays`"""
-    docs = _get_count_docs(ndays)
-    return {
-        'human_edits': Stats(docs, "human_edits", "human_edits"),
-        'bot_edits': Stats(docs, "bot_edits", "bot_edits"),
-        'lists': Stats(docs, "lists", "total_lists"),
-        'visitors': VisitorStats(docs, "visitors", "visitors"),
-        'loans': LoanStats(docs, "loans", "loans"),
-        'members': Stats(docs, "members", "total_members"),
-        'works': Stats(docs, "works", "total_works"),
-        'editions': Stats(docs, "editions", "total_editions"),
-        'ebooks': Stats(docs, "ebooks", "total_ebooks"),
-        'covers': Stats(docs, "covers", "total_covers"),
-        'authors': Stats(docs, "authors", "total_authors"),
-        'subjects': Stats(docs, "subjects", "total_subjects"),
-    }
+    if dev_prod:
+        docs = mock_get_stats()
+        return {
+            'human_edits': Stats(docs, "human_edits", "human_edits"),
+            'bot_edits': Stats(docs, "bot_edits", "bot_edits"),
+            'lists': Stats(docs, "lists", "total_lists"),
+            'visitors': Stats(docs, "visitors", "visitors"),
+            'loans': Stats(docs, "loans", "loans"),
+            'members': Stats(docs, "members", "total_members"),
+            'works': Stats(docs, "works", "total_works"),
+            'editions': Stats(docs, "editions", "total_editions"),
+            'ebooks': Stats(docs, "ebooks", "total_ebooks"),
+            'covers': Stats(docs, "covers", "total_covers"),
+            'authors': Stats(docs, "authors", "total_authors"),
+            'subjects': Stats(docs, "subjects", "total_subjects"),
+        }
+    else:
+        docs = _get_count_docs(ndays)
+        return {
+            'human_edits': Stats(docs, "human_edits", "human_edits"),
+            'bot_edits': Stats(docs, "bot_edits", "bot_edits"),
+            'lists': Stats(docs, "lists", "total_lists"),
+            'visitors': VisitorStats(docs, "visitors", "visitors"),
+            'loans': LoanStats(docs, "loans", "loans"),
+            'members': Stats(docs, "members", "total_members"),
+            'works': Stats(docs, "works", "total_works"),
+            'editions': Stats(docs, "editions", "total_editions"),
+            'ebooks': Stats(docs, "ebooks", "total_ebooks"),
+            'covers': Stats(docs, "covers", "total_covers"),
+            'authors': Stats(docs, "authors", "total_authors"),
+            'subjects': Stats(docs, "subjects", "total_subjects"),
+        }
+
+
+def mock_get_stats():
+    keyNames = [
+        "human_edits",
+        "bot_edits",
+        "lists",
+        "visitors",
+        "loans",
+        "members",
+        "works",
+        "editions",
+        "ebooks",
+        "covers",
+        "authors",
+        "subjects",
+    ]
+    mockKeyValues = [[(1 + x) * y for x in range(len(keyNames))] for y in range(28)][
+        ::-1
+    ]
+
+    docs = [dict(zip(keyNames, mockKeyValues[x])) for x in range(len(mockKeyValues))]
+    today = datetime.date.today()
+    for x in range(28):
+        docs[x]["_key"] = (today - datetime.timedelta(days=x + 1)).strftime(
+            'counts-%Y-%m-%d'
+        )
+    return docs

--- a/openlibrary/core/admin.py
+++ b/openlibrary/core/admin.py
@@ -156,13 +156,15 @@ def _get_count_docs(ndays):
 
 def get_stats(ndays=30, use_mock_data=False):
     """Returns the stats for the past `ndays`"""
-    docs = mock_get_stats() if use_mock_data else _get_count_docs(ndays)
+    if use_mock_data:
+        return mock_get_stats()
+    docs = _get_count_docs(ndays)
     return {
         'human_edits': Stats(docs, "human_edits", "human_edits"),
         'bot_edits': Stats(docs, "bot_edits", "bot_edits"),
         'lists': Stats(docs, "lists", "total_lists"),
-        'visitors': Stats(docs, "visitors", "visitors"),
-        'loans': Stats(docs, "loans", "loans"),
+        'visitors': VisitorStats(docs, "visitors", "visitors"),
+        'loans': LoanStats(docs, "loans", "loans"),
         'members': Stats(docs, "members", "total_members"),
         'works': Stats(docs, "works", "total_works"),
         'editions': Stats(docs, "editions", "total_editions"),
@@ -198,4 +200,17 @@ def mock_get_stats():
         docs[x]["_key"] = (today - datetime.timedelta(days=x + 1)).strftime(
             'counts-%Y-%m-%d'
         )
-    return docs
+    return {
+        'human_edits': Stats(docs, "human_edits", "human_edits"),
+        'bot_edits': Stats(docs, "bot_edits", "bot_edits"),
+        'lists': Stats(docs, "lists", "total_lists"),
+        'visitors': Stats(docs, "visitors", "visitors"),
+        'loans': Stats(docs, "loans", "loans"),
+        'members': Stats(docs, "members", "total_members"),
+        'works': Stats(docs, "works", "total_works"),
+        'editions': Stats(docs, "editions", "total_editions"),
+        'ebooks': Stats(docs, "ebooks", "total_ebooks"),
+        'covers': Stats(docs, "covers", "total_covers"),
+        'authors': Stats(docs, "authors", "total_authors"),
+        'subjects': Stats(docs, "subjects", "total_subjects"),
+    }

--- a/openlibrary/core/admin.py
+++ b/openlibrary/core/admin.py
@@ -154,40 +154,23 @@ def _get_count_docs(ndays):
     return [d for d in docs if d]
 
 
-def get_stats(ndays=30, dev_prod=False):
+def get_stats(ndays=30, use_mock_data=False):
     """Returns the stats for the past `ndays`"""
-    if dev_prod:
-        docs = mock_get_stats()
-        return {
-            'human_edits': Stats(docs, "human_edits", "human_edits"),
-            'bot_edits': Stats(docs, "bot_edits", "bot_edits"),
-            'lists': Stats(docs, "lists", "total_lists"),
-            'visitors': Stats(docs, "visitors", "visitors"),
-            'loans': Stats(docs, "loans", "loans"),
-            'members': Stats(docs, "members", "total_members"),
-            'works': Stats(docs, "works", "total_works"),
-            'editions': Stats(docs, "editions", "total_editions"),
-            'ebooks': Stats(docs, "ebooks", "total_ebooks"),
-            'covers': Stats(docs, "covers", "total_covers"),
-            'authors': Stats(docs, "authors", "total_authors"),
-            'subjects': Stats(docs, "subjects", "total_subjects"),
-        }
-    else:
-        docs = _get_count_docs(ndays)
-        return {
-            'human_edits': Stats(docs, "human_edits", "human_edits"),
-            'bot_edits': Stats(docs, "bot_edits", "bot_edits"),
-            'lists': Stats(docs, "lists", "total_lists"),
-            'visitors': VisitorStats(docs, "visitors", "visitors"),
-            'loans': LoanStats(docs, "loans", "loans"),
-            'members': Stats(docs, "members", "total_members"),
-            'works': Stats(docs, "works", "total_works"),
-            'editions': Stats(docs, "editions", "total_editions"),
-            'ebooks': Stats(docs, "ebooks", "total_ebooks"),
-            'covers': Stats(docs, "covers", "total_covers"),
-            'authors': Stats(docs, "authors", "total_authors"),
-            'subjects': Stats(docs, "subjects", "total_subjects"),
-        }
+    docs = mock_get_stats() if use_mock_data else _get_count_docs(ndays)
+    return {
+        'human_edits': Stats(docs, "human_edits", "human_edits"),
+        'bot_edits': Stats(docs, "bot_edits", "bot_edits"),
+        'lists': Stats(docs, "lists", "total_lists"),
+        'visitors': Stats(docs, "visitors", "visitors"),
+        'loans': Stats(docs, "loans", "loans"),
+        'members': Stats(docs, "members", "total_members"),
+        'works': Stats(docs, "works", "total_works"),
+        'editions': Stats(docs, "editions", "total_editions"),
+        'ebooks': Stats(docs, "ebooks", "total_ebooks"),
+        'covers': Stats(docs, "covers", "total_covers"),
+        'authors': Stats(docs, "authors", "total_authors"),
+        'subjects': Stats(docs, "subjects", "total_subjects"),
+    }
 
 
 def mock_get_stats():

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -1,8 +1,8 @@
 # Translations template for Open Library.
-# Copyright (C) 2024 Internet Archive
+# Copyright (C) 2025 Internet Archive
 # This file is distributed under the same license as the Open Library
 # project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
 #, fuzzy
 msgid ""

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -39,14 +39,11 @@ CAROUSELS_PRESETS = {
 
 
 def get_homepage():
-    if "dev" in web.ctx.features:
-        stats = admin.get_stats(dev_prod=True)
-    else:
-        try:
-            stats = admin.get_stats()
-        except Exception:
-            logger.error("Error in getting stats", exc_info=True)
-            stats = None
+    try:
+        stats = admin.get_stats(use_mock_data=("dev" in web.ctx.features))
+    except Exception:
+        logger.error("Error in getting stats", exc_info=True)
+        stats = None
     blog_posts = get_blog_feeds()
 
     # render template should be setting ctx.cssfile

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -39,11 +39,14 @@ CAROUSELS_PRESETS = {
 
 
 def get_homepage():
-    try:
-        stats = admin.get_stats()
-    except Exception:
-        logger.error("Error in getting stats", exc_info=True)
-        stats = None
+    if "dev" in web.ctx.features:
+        stats = admin.get_stats(dev_prod=True)
+    else:
+        try:
+            stats = admin.get_stats()
+        except Exception:
+            logger.error("Error in getting stats", exc_info=True)
+            stats = None
     blog_posts = get_blog_feeds()
 
     # render template should be setting ctx.cssfile

--- a/openlibrary/plugins/openlibrary/js/graphs/plot.js
+++ b/openlibrary/plugins/openlibrary/js/graphs/plot.js
@@ -217,7 +217,8 @@ export function plot_tooltip_graph(node, data, tooltip_message, color='#748d36')
             fontSize: '11px',
             webkitBoxShadow: '1px 1px 3px #333',
             mozBoxShadow: '1px 1px 1px #000',
-            boxShadow: '1px 1px 1px #000'
+            boxShadow: '1px 1px 1px #000',
+            'z-index': 100
         }).appendTo('body').fadeIn(200);
     }
     node.bind('plothover', function (event, pos, item) {

--- a/openlibrary/plugins/openlibrary/js/graphs/plot.js
+++ b/openlibrary/plugins/openlibrary/js/graphs/plot.js
@@ -217,8 +217,7 @@ export function plot_tooltip_graph(node, data, tooltip_message, color='#748d36')
             fontSize: '11px',
             webkitBoxShadow: '1px 1px 3px #333',
             mozBoxShadow: '1px 1px 1px #000',
-            boxShadow: '1px 1px 1px #000',
-            'z-index': 100
+            boxShadow: '1px 1px 1px #000'
         }).appendTo('body').fadeIn(200);
     }
     node.bind('plothover', function (event, pos, item) {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10118 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix

### Technical
<!-- What should be noted about the implementation? -->
Checks if the current running instance is a dev environment using ```web.ctx.features``` and utilizes mock data to display the charts on the front page. Minor CSS styling issue fix for chart labels. 

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Run ```docker compose up -d```
2. Open your browser's developer tools and select the Network tab before navigating to localhost:8080
3. Check how long it takes for the homepage to completely load
    -   My local instance loading time dropped from roughly ~22 seconds to ~2 seconds, timings for other machines and browsers will most likely vary

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Before
--- 
![image](https://github.com/user-attachments/assets/9e120423-31d4-4350-9f5b-79411af2a5c5)
After
---
![image](https://github.com/user-attachments/assets/1162624d-6a5a-4a31-8195-bfc0f5032b3a)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@jimchamp @RayBB 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
