### PR TITLE
fix ruff SIM910 by fixing kwargs get

### DIFF
--- a/scripts/manage-imports.py
+++ b/scripts/manage-imports.py
@@ -87,7 +87,7 @@ def import_ocaids(*ocaids, **kwargs):
                 --config /olsystem/etc/openlibrary.yml \
                 import-all
     """
-    servername = kwargs.get('servername', None)
+    servername = kwargs.get('servername')
     require_marc = not kwargs.get('no_marc', False)
 
     date = datetime.date.today()
@@ -128,7 +128,7 @@ def add_new_scans(args):
 
 
 def import_batch(args, **kwargs):
-    servername = kwargs.get('servername', None)
+    servername = kwargs.get('servername')
     require_marc = not kwargs.get('no_marc', False)
     batch_name = args[0]
     batch = Batch.find(batch_name)
@@ -141,7 +141,7 @@ def import_batch(args, **kwargs):
 
 
 def import_item(args, **kwargs):
-    servername = kwargs.get('servername', None)
+    servername = kwargs.get('servername')
     require_marc = not kwargs.get('no_marc', False)
     ia_id = args[0]
     if item := ImportItem.find_by_identifier(ia_id):
@@ -153,7 +153,7 @@ def import_item(args, **kwargs):
 def import_all(args, **kwargs):
     import multiprocessing
 
-    servername = kwargs.get('servername', None)
+    servername = kwargs.get('servername')
     require_marc = not kwargs.get('no_marc', False)
 
     # Use multiprocessing to call do_import on each item


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Needed for #10187 

https://docs.astral.sh/ruff/rules/dict-get-with-none-default/#dict-get-with-none-default-sim910

Ruff suggests not setting none when doing a get as it's already the default.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
