### PR TITLE
Fixed: Persist Book IDs Across Add Book Dialogs for Regular Users

### DIFF
--- a/openlibrary/plugins/openlibrary/js/add-book.js
+++ b/openlibrary/plugins/openlibrary/js/add-book.js
@@ -148,6 +148,7 @@ function parseAndValidateLccn(event, idValue) {
 function autoCompleteIdName(){
     const idValue = document.querySelector('input#id_value').value.trim();
     const idValueIsbn = parseIsbn(idValue);
+    const currentSelection = document.getElementById('id_name').value;
 
     if (isFormatValidIsbn10(idValueIsbn) && isChecksumValidIsbn10(idValueIsbn)){
         document.getElementById('id_name').value = 'isbn_10';
@@ -162,7 +163,7 @@ function autoCompleteIdName(){
     }
 
     else {
-        document.getElementById('id_name').value = '';
+        document.getElementById('id_name').value = currentSelection || '';
     }
 }
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10148 - "Added Book IDs on new books aren't set"

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix: This PR ensures that the "Internet Archive ID" field in the "Add Book" dialog is correctly persisted across different stages for regular users. 


### Technical
<!-- What should be noted about the implementation? -->
->Fixed the issue where the "Internet Archive ID" field would not retain its value for regular users after switching steps in the "Add Book" form.
->Ensured that the value entered in the "Internet Archive ID" field is preserved when moving between steps in both admin and user portals.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Tested locally by logging in as both an admin and a regular user.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/user-attachments/assets/87138db7-86c8-4d04-973e-2c049429ee37)
![image](https://github.com/user-attachments/assets/4fa46da2-2ef2-4604-b47b-0f590e1a1396)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
I have worked on this issue with @scottbarnes as lead


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
