### PR TITLE
FIxed IA toolbar overflows/wraps on mobile #10063

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -95,7 +95,7 @@
     },
     {
       "path": "static/build/page-subject.css",
-      "maxSize": "9KB"
+      "maxSize": "9.1KB"
     },
     {
       "path": "static/build/page-user.css",

--- a/openlibrary/templates/site/alert.html
+++ b/openlibrary/templates/site/alert.html
@@ -10,8 +10,8 @@ $ active_ui_lang = supported_languages.get(lang) or supported_languages.get('en'
     <div class="iaBar">
         <a class="iaLogo" href="https://archive.org"><img alt="$_('Internet Archive logo')" src="/static/images/ia-logo.svg" width="160"></a>
         $# detect-missing-i18n-skip-line
-        <a class="ghost-btn" href="https://archive.org/donate/?platform=ol&origin=olwww-TopNavDonateButton" data-ol-link-track="IABar|DonateButton">$_('Donate') <span class="heart" aria-hidden="true">♥</span></a>
-      <div class="language-component header-dropdown">
+        <a class="ghost-btn iabar-mobile" href="https://archive.org/donate/?platform=ol&origin=olwww-TopNavDonateButton" data-ol-link-track="IABar|DonateButton">$_('Donate') <span class="heart" aria-hidden="true">♥</span></a>
+        <div class="language-component header-dropdown iabar-mobile">
         <details>
           <summary>
             <span>$active_ui_lang['localized'] ($active_ui_lang['code'])</span>

--- a/static/css/components/iaBar.less
+++ b/static/css/components/iaBar.less
@@ -50,4 +50,15 @@
   .topNotice-logo {
     font-size: 24px;
   }
+
+  @media only screen and (max-width: @width-breakpoint-mobile) {
+    .iabar-mobile {
+      font-size: .9em;
+    }
+    .ghost-btn.iabar-mobile {
+      padding: 5px 7px;
+      margin-right: 10px;
+      margin-left: 10px;
+    }
+  }
 }

--- a/static/css/components/iaBar.less
+++ b/static/css/components/iaBar.less
@@ -59,6 +59,7 @@
       padding: 5px 7px;
       margin-right: 10px;
       margin-left: 10px;
+      white-space: nowrap;
     }
   }
 }

--- a/static/css/components/page-banner.less
+++ b/static/css/components/page-banner.less
@@ -13,7 +13,8 @@
   padding: 15px;
   border-bottom: 1px solid @beige;
   z-index: @z-index-level-2;
-
+  overflow-y: hidden;
+  
   &-mybooks {
     color: @black;
     background: @grey-blue;

--- a/static/css/components/page-banner.less
+++ b/static/css/components/page-banner.less
@@ -14,7 +14,7 @@
   border-bottom: 1px solid @beige;
   z-index: @z-index-level-2;
   overflow-y: hidden;
-  
+
   &-mybooks {
     color: @black;
     background: @grey-blue;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10063 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
@mekarpeles check this out i have Fixed the AI toolbar overflow which gets warps on mobile as you have mentioned me to go ahead with where, `iabar-mobile` and create a mobile breakpoint where the `font-size` of these components becomes `.9em` and the padding of the `ghost-button` becomes padding: `5px 7px;` we get our desired effect on mobile.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="837" alt="Screenshot 2024-12-26 at 1 21 08 AM" src="https://github.com/user-attachments/assets/4323b880-02b1-470e-89b6-4dd0d2df3252" />


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
