### PR TITLE
Language imports consistently on re-imports of books

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -787,6 +787,14 @@ def find_match(rec: dict, edition_pool: dict) -> str | None:
     """Use rec to try to find an existing edition key that matches."""
     return find_quick_match(rec) or find_threshold_match(rec, edition_pool)
 
+def format_languages(languages):
+    """Format language data to match Open Library's expected format."""
+    if not languages:
+        return []
+    formatted_languages = []
+    for language in languages:
+        formatted_languages.append({'key': f'/languages/{language.lower()}'})
+    return formatted_languages
 
 def update_edition_with_rec_data(
     rec: dict, account_key: str | None, edition: "Edition"
@@ -796,7 +804,7 @@ def update_edition_with_rec_data(
     in edition.
 
     NOTE: This modifies the passed-in Edition in place.
-    """
+    """   
     need_edition_save = False
     # Add cover to edition
     if 'cover' in rec and not edition.get_covers():
@@ -818,19 +826,33 @@ def update_edition_with_rec_data(
         'lc_classifications',
         'oclc_numbers',
         'source_records',
+        'languages',
     ]
     for f in edition_list_fields:
         if f not in rec or not rec[f]:
             continue
         # ensure values is a list
         values = rec[f] if isinstance(rec[f], list) else [rec[f]]
-        if f in edition:
-            # get values from rec field that are not currently on the edition
-            case_folded_values = {v.casefold() for v in edition[f]}
-            to_add = [v for v in values if v.casefold() not in case_folded_values]
-            edition[f] += to_add
-        else:
-            edition[f] = to_add = values
+        
+        if f == 'languages':
+            formatted_languages = format_languages(values)
+            
+            if f in edition:
+                # get values from rec field that are not currently on the edition
+                case_folded_values = {v['key'].casefold() for v in edition[f]}
+                to_add = [v for v in formatted_languages if v['key'].casefold() not in case_folded_values]
+                edition[f] += to_add
+            else:
+                edition[f] = to_add = formatted_languages
+        else: 
+            if f in edition:
+                # get values from rec field that are not currently on the edition
+                case_folded_values = {v.casefold() for v in edition[f]}
+                to_add = [v for v in values if v.casefold() not in case_folded_values]
+                edition[f] += to_add
+            else:
+                edition[f] = to_add = values
+                
         if to_add:
             need_edition_save = True
 

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -787,6 +787,7 @@ def find_match(rec: dict, edition_pool: dict) -> str | None:
     """Use rec to try to find an existing edition key that matches."""
     return find_quick_match(rec) or find_threshold_match(rec, edition_pool)
 
+
 def format_languages(languages):
     """Format language data to match Open Library's expected format."""
     if not languages:
@@ -796,6 +797,7 @@ def format_languages(languages):
         formatted_languages.append({'key': f'/languages/{language.lower()}'})
     return formatted_languages
 
+
 def update_edition_with_rec_data(
     rec: dict, account_key: str | None, edition: "Edition"
 ) -> bool:
@@ -804,7 +806,7 @@ def update_edition_with_rec_data(
     in edition.
 
     NOTE: This modifies the passed-in Edition in place.
-    """   
+    """
     need_edition_save = False
     # Add cover to edition
     if 'cover' in rec and not edition.get_covers():
@@ -833,18 +835,22 @@ def update_edition_with_rec_data(
             continue
         # ensure values is a list
         values = rec[f] if isinstance(rec[f], list) else [rec[f]]
-        
+
         if f == 'languages':
             formatted_languages = format_languages(values)
-            
+
             if f in edition:
                 # get values from rec field that are not currently on the edition
                 case_folded_values = {v['key'].casefold() for v in edition[f]}
-                to_add = [v for v in formatted_languages if v['key'].casefold() not in case_folded_values]
+                to_add = [
+                    v
+                    for v in formatted_languages
+                    if v['key'].casefold() not in case_folded_values
+                ]
                 edition[f] += to_add
             else:
                 edition[f] = to_add = formatted_languages
-        else: 
+        else:
             if f in edition:
                 # get values from rec field that are not currently on the edition
                 case_folded_values = {v.casefold() for v in edition[f]}
@@ -852,7 +858,7 @@ def update_edition_with_rec_data(
                 edition[f] += to_add
             else:
                 edition[f] = to_add = values
-                
+
         if to_add:
             need_edition_save = True
 

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -44,6 +44,7 @@ from openlibrary.catalog.add_book.load_book import (
 from openlibrary.catalog.add_book.match import editions_match, mk_norm
 from openlibrary.catalog.utils import (
     EARLIEST_PUBLISH_YEAR_FOR_BOOKSELLERS,
+    format_languages,
     get_non_isbn_asin,
     get_publication_year,
     is_independently_published,
@@ -786,16 +787,6 @@ def validate_record(rec: dict) -> None:
 def find_match(rec: dict, edition_pool: dict) -> str | None:
     """Use rec to try to find an existing edition key that matches."""
     return find_quick_match(rec) or find_threshold_match(rec, edition_pool)
-
-
-def format_languages(languages):
-    """Format language data to match Open Library's expected format."""
-    if not languages:
-        return []
-    formatted_languages = []
-    for language in languages:
-        formatted_languages.append({'key': f'/languages/{language.lower()}'})
-    return formatted_languages
 
 
 def update_edition_with_rec_data(

--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -2,7 +2,12 @@ from typing import TYPE_CHECKING, Any, Final
 
 import web
 
-from openlibrary.catalog.utils import author_dates_match, flip_name, key_int
+from openlibrary.catalog.utils import (
+    author_dates_match,
+    flip_name,
+    format_languages,
+    key_int,
+)
 from openlibrary.core.helpers import extract_year
 
 if TYPE_CHECKING:
@@ -272,7 +277,6 @@ def build_query(rec: dict[str, Any]) -> dict[str, Any]:
     :return: Open Library style edition dict representation
     """
     # import format_languages function from __init__.py to avoid circular import
-    from . import format_languages
 
     book: dict[str, Any] = {
         'type': {'key': '/type/edition'},

--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -259,14 +259,6 @@ def import_author(author: dict[str, Any], eastern=False) -> "Author | dict[str, 
     return a
 
 
-class InvalidLanguage(Exception):
-    def __init__(self, code):
-        self.code = code
-
-    def __str__(self):
-        return f"invalid language code: '{self.code}'"
-
-
 type_map = {'description': 'text', 'notes': 'text', 'number_of_pages': 'int'}
 
 
@@ -276,8 +268,6 @@ def build_query(rec: dict[str, Any]) -> dict[str, Any]:
     suitable for saving.
     :return: Open Library style edition dict representation
     """
-    # import format_languages function from __init__.py to avoid circular import
-
     book: dict[str, Any] = {
         'type': {'key': '/type/edition'},
     }
@@ -291,20 +281,8 @@ def build_query(rec: dict[str, Any]) -> dict[str, Any]:
                     book['authors'].append(import_author(author, eastern=east))
             continue
 
-        if k == 'languages':  # Special handling for languages
-            if not v:
-                continue
-            formatted_languages = format_languages(v)
-            for language in v:
-                if web.ctx.site.get('/languages/' + language.lower()) is None:
-                    raise InvalidLanguage(language.lower())
-            book[k] = formatted_languages
-            continue
-
-        if k in ('translated_from',):  # Handle translated_from if necessary
-            if not v:
-                continue
-            formatted_languages = format_languages(v)
+        if k in ('languages', 'translated_from'):
+            formatted_languages = format_languages(languages=v)
             book[k] = formatted_languages
             continue
 

--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -273,7 +273,7 @@ def build_query(rec: dict[str, Any]) -> dict[str, Any]:
     """
     # import format_languages function from __init__.py to avoid circular import
     from . import format_languages
-    
+
     book: dict[str, Any] = {
         'type': {'key': '/type/edition'},
     }
@@ -286,7 +286,7 @@ def build_query(rec: dict[str, Any]) -> dict[str, Any]:
                     east = east_in_by_statement(rec, author)
                     book['authors'].append(import_author(author, eastern=east))
             continue
-        
+
         if k == 'languages':  # Special handling for languages
             if not v:
                 continue
@@ -296,14 +296,14 @@ def build_query(rec: dict[str, Any]) -> dict[str, Any]:
                     raise InvalidLanguage(language.lower())
             book[k] = formatted_languages
             continue
-        
+
         if k in ('translated_from',):  # Handle translated_from if necessary
             if not v:
                 continue
             formatted_languages = format_languages(v)
             book[k] = formatted_languages
             continue
-        
+
         if k in type_map:
             t = '/type/' + type_map[k]
             if isinstance(v, list):

--- a/openlibrary/catalog/add_book/tests/test_add_book.py
+++ b/openlibrary/catalog/add_book/tests/test_add_book.py
@@ -321,7 +321,7 @@ def test_duplicate_ia_book(mock_site, add_languages, ia_writeback):
     }
     reply = load(rec)
     assert reply['success'] is True
-    assert reply['edition']['status'] == 'matched'
+    assert reply['edition']['status'] in ['matched', 'modified']
 
 
 class Test_From_MARC:

--- a/openlibrary/catalog/add_book/tests/test_load_book.py
+++ b/openlibrary/catalog/add_book/tests/test_load_book.py
@@ -2,12 +2,12 @@ import pytest
 
 from openlibrary.catalog.add_book import load_book
 from openlibrary.catalog.add_book.load_book import (
-    InvalidLanguage,
     build_query,
     find_entity,
     import_author,
     remove_author_honorifics,
 )
+from openlibrary.catalog.utils import InvalidLanguage
 from openlibrary.core.models import Author
 
 

--- a/openlibrary/catalog/utils/__init__.py
+++ b/openlibrary/catalog/utils/__init__.py
@@ -445,7 +445,7 @@ class InvalidLanguage(Exception):
         return f"invalid language code: '{self.code}'"
 
 
-def format_languages(languages: Iterable) -> list[dict]:
+def format_languages(languages: Iterable) -> list[dict[str, str]]:
     """
     Format language data to match Open Library's expected format.
     >>> format_languages(["eng", "fre"])

--- a/openlibrary/catalog/utils/__init__.py
+++ b/openlibrary/catalog/utils/__init__.py
@@ -1,5 +1,6 @@
 import datetime
 import re
+from collections.abc import Iterable
 from typing import TYPE_CHECKING
 from unicodedata import normalize
 
@@ -434,3 +435,13 @@ def get_missing_fields(rec: dict) -> list[str]:
         'source_records',
     ]
     return [field for field in required_fields if rec.get(field) is None]
+
+
+def format_languages(languages: Iterable) -> list[dict]:
+    """Format language data to match Open Library's expected format."""
+    if not languages:
+        return []
+    formatted_languages = []
+    for language in languages:
+        formatted_languages.append({'key': f'/languages/{language.lower()}'})
+    return formatted_languages

--- a/openlibrary/catalog/utils/__init__.py
+++ b/openlibrary/catalog/utils/__init__.py
@@ -437,11 +437,28 @@ def get_missing_fields(rec: dict) -> list[str]:
     return [field for field in required_fields if rec.get(field) is None]
 
 
+class InvalidLanguage(Exception):
+    def __init__(self, code):
+        self.code = code
+
+    def __str__(self):
+        return f"invalid language code: '{self.code}'"
+
+
 def format_languages(languages: Iterable) -> list[dict]:
-    """Format language data to match Open Library's expected format."""
+    """
+    Format language data to match Open Library's expected format.
+    >>> format_languages(["eng", "fre"])
+    [{'key': '/languages/eng'}, {'key': '/languages/fre'}]
+    """
     if not languages:
         return []
+
     formatted_languages = []
     for language in languages:
+        if web.ctx.site.get(f"/languages/{language.lower()}") is None:
+            raise InvalidLanguage(language.lower())
+
         formatted_languages.append({'key': f'/languages/{language.lower()}'})
+
     return formatted_languages

--- a/openlibrary/tests/catalog/test_utils.py
+++ b/openlibrary/tests/catalog/test_utils.py
@@ -5,6 +5,7 @@ import pytest
 from openlibrary.catalog.utils import (
     author_dates_match,
     flip_name,
+    format_languages,
     get_missing_fields,
     get_non_isbn_asin,
     get_publication_year,
@@ -421,4 +422,17 @@ def test_get_missing_field(name, rec, expected) -> None:
 )
 def test_remove_trailing_number_dot(date: str, expected: str) -> None:
     got = remove_trailing_number_dot(date)
+    assert got == expected
+
+
+@pytest.mark.parametrize(
+    ("languages", "expected"),
+    [
+        (["eng"], [{'key': '/languages/eng'}]),
+        (["eng", "FRE"], [{'key': '/languages/eng'}, {'key': '/languages/fre'}]),
+        ([], []),
+    ],
+)
+def test_format_languages(languages: list[str], expected: list[dict[str, str]]) -> None:
+    got = format_languages(languages)
     assert got == expected

--- a/openlibrary/tests/catalog/test_utils.py
+++ b/openlibrary/tests/catalog/test_utils.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 import pytest
 
 from openlibrary.catalog.utils import (
+    InvalidLanguage,
     author_dates_match,
     flip_name,
     format_languages,
@@ -436,3 +437,9 @@ def test_remove_trailing_number_dot(date: str, expected: str) -> None:
 def test_format_languages(languages: list[str], expected: list[dict[str, str]]) -> None:
     got = format_languages(languages)
     assert got == expected
+
+
+@pytest.mark.parametrize(("languages"), [(["wtf"]), (["eng", "wtf"])])
+def test_format_language_rasise_for_invalid_language(languages: list[str]) -> None:
+    with pytest.raises(InvalidLanguage):
+        format_languages(languages)


### PR DESCRIPTION
Closes #10141 Internet Archive imports often missing language 

**Fix**

Fixes language import issue by ensuring that language is correctly added to existing editions during import

**Technical**

Previously, the issue was that when importing an edition, the language field was not being correctly added to existing editions if it was missing, even if the import record contained a language.

To address this I added a helper function format_languages() to openlibrary/openlibrary/catalog/add_book/__init__.py,
to format the languages field, called by update_edition_with_rec_data() and build_query() in openlibrary/openlibrary/catalog/add_book/load_book.py, along with changes to both functions. 

**Testing**

Tested this issue locally and reproduced the bug by running the following commands (generate command and import book).

$ curl -c cookies.txt -X POST "http://localhost:8080/account/login" -d "username=openlibrary@example.com&password=admin123"
$ curl -L -v -X POST "http://localhost:8080/api/import/ia" \
     -b ./cookies.txt \
     -d "identifier=isbn_9781849353946&require_marc=false&force_import=true"

The book should now appear under http://localhost:8080/books/OL5M/

<img width="1437" alt="Screenshot 2024-12-27 at 4 18 29 PM" src="https://github.com/user-attachments/assets/96ec6705-f3c3-4016-a958-2bb5901fe243" />

However, if we delete the language field and reimport the book, the language fields remains missing. 
http://localhost:8080/books/OL5M.yml?m=edit 

<img width="1081" alt="Screenshot 2024-12-27 at 4 22 12 PM" src="https://github.com/user-attachments/assets/4ee009ff-4b85-4ef5-9cbc-55cc0d6498fe" />
<img width="1089" alt="Screenshot 2024-12-27 at 4 23 39 PM" src="https://github.com/user-attachments/assets/36d0a158-f699-4b48-bf9c-f3b687261ccb" />

After the changes, languages should now be correctly added. 

### Stakeholders
@scottbarnes 