### PR TITLE
Fix(#10210):  Hide pager when there is only one page (#10210)

### DIFF
--- a/openlibrary/plugins/openlibrary/js/editions-table/index.js
+++ b/openlibrary/plugins/openlibrary/js/editions-table/index.js
@@ -4,40 +4,26 @@ import '../../../../../static/css/legacy-datatables.less';
 const DEFAULT_LENGTH = 3;
 const LS_RESULTS_LENGTH_KEY = 'editions-table.resultsLength';
 
-// Function to add the custom CSS for hiding pagination
-function addCustomPaginationCSS() {
-    const style = document.createElement('style');
-    style.innerHTML = `
-        .dataTables_paginate.paging_full_numbers:has(.paginate_button.previous.disabled):has(.paginate_button.next.disabled):has(.paginate_button.first.disabled):has(.paginate_button.last.disabled) {
-            display: none;
-        }
-    `;
-    document.head.appendChild(style);
-}
-
 export function initEditionsTable() {
-    // Add the custom CSS for pagination
-    addCustomPaginationCSS();
-
     var rowCount;
     let currentLength;
 
-    $('#editions th.title').on('mouseover', function(){
+    $('#editions th.title').on('mouseover', function () {
         if ($(this).hasClass('sorting_asc')) {
-            $(this).attr('title','Sort latest to earliest');
+            $(this).attr('title', 'Sort latest to earliest');
         } else if ($(this).hasClass('sorting_desc')) {
-            $(this).attr('title','Sort earliest to latest');
+            $(this).attr('title', 'Sort earliest to latest');
         } else {
-            $(this).attr('title','Sort by publish date');
+            $(this).attr('title', 'Sort by publish date');
         }
     });
-    $('#editions th.read').on('mouseover', function(){
+    $('#editions th.read').on('mouseover', function () {
         if ($(this).hasClass('sorting_asc')) {
-            $(this).attr('title','Push readable versions to the bottom');
+            $(this).attr('title', 'Push readable versions to the bottom');
         } else if ($(this).hasClass('sorting_desc')) {
-            $(this).attr('title','Sort by editions to read');
+            $(this).attr('title', 'Sort by editions to read');
         } else {
-            $(this).attr('title','Available to read');
+            $(this).attr('title', 'Available to read');
         }
     });
 
@@ -52,44 +38,46 @@ export function initEditionsTable() {
     }
 
     $('#editions th.read span').html('&nbsp;&uarr;');
-    $('#editions th').on('mouseup', function() {
-        toggleSorting(this)
+    $('#editions th').on('mouseup', function () {
+        toggleSorting(this);
     });
 
-    $('#editions').on('length.dt', function(e, settings, length) {
+    $('#editions').on('length.dt', function (e, settings, length) {
         localStorage.setItem(LS_RESULTS_LENGTH_KEY, length);
+        togglePaginationVisibility(length);
     });
 
-    $('#editions th').on('keydown', function(e) {
+    $('#editions th').on('keydown', function (e) {
         if (e.key === 'Enter') {
             toggleSorting(this);
         }
-    })
+    });
 
     rowCount = $('#editions tbody tr').length;
-    if (rowCount < 4) {
-        $('#editions').DataTable({
-            aoColumns: [{sType: 'html'},null],
-            order: [ [1,'asc'] ],
-            bPaginate: false,
-            bInfo: false,
-            bFilter: false,
-            bStateSave: false,
-            bAutoWidth: false
-        });
-    } else {
-        currentLength = Number(localStorage.getItem(LS_RESULTS_LENGTH_KEY));
-        $('#editions').DataTable({
-            aoColumns: [{sType: 'html'},null],
-            order: [ [1,'asc'] ],
-            lengthMenu: [ [3, 10, 25, 50, 100, -1], [3, 10, 25, 50, 100, 'All'] ],
-            bPaginate: true,
-            bInfo: true,
-            sPaginationType: 'full_numbers',
-            bFilter: true,
-            bStateSave: false,
-            bAutoWidth: false,
-            pageLength: currentLength ? currentLength : DEFAULT_LENGTH
-        });
+    currentLength = Number(localStorage.getItem(LS_RESULTS_LENGTH_KEY)) || DEFAULT_LENGTH;
+
+    const dataTable = $('#editions').DataTable({
+        aoColumns: [{ sType: 'html' }, null],
+        order: [[1, 'asc']],
+        lengthMenu: [[3, 10, 25, 50, 100, -1], [3, 10, 25, 50, 100, 'All']],
+        bPaginate: rowCount > currentLength ,
+        bInfo: true,
+        sPaginationType: 'full_numbers',
+        bFilter: true,
+        bStateSave: false,
+        bAutoWidth: false,
+        pageLength: currentLength
+    });
+
+    // Toggle pagination visibility based on row count and selected length
+    function togglePaginationVisibility(selectedLength) {
+        if (rowCount <= selectedLength || selectedLength === -1) {
+            $('.dataTables_paginate').hide();
+        } else {
+            $('.dataTables_paginate').show();
+        }
     }
+
+    // Initial pagination visibility toggle
+    togglePaginationVisibility(currentLength);
 }

--- a/openlibrary/plugins/openlibrary/js/editions-table/index.js
+++ b/openlibrary/plugins/openlibrary/js/editions-table/index.js
@@ -5,25 +5,23 @@ const DEFAULT_LENGTH = 3;
 const LS_RESULTS_LENGTH_KEY = 'editions-table.resultsLength';
 
 export function initEditionsTable() {
-    var rowCount;
-    let currentLength;
-
-    $('#editions th.title').on('mouseover', function () {
+    
+    $('#editions th.title').on('mouseover', function(){
         if ($(this).hasClass('sorting_asc')) {
-            $(this).attr('title', 'Sort latest to earliest');
+            $(this).attr('title','Sort latest to earliest');
         } else if ($(this).hasClass('sorting_desc')) {
-            $(this).attr('title', 'Sort earliest to latest');
+            $(this).attr('title','Sort earliest to latest');
         } else {
-            $(this).attr('title', 'Sort by publish date');
+            $(this).attr('title','Sort by publish date');
         }
     });
-    $('#editions th.read').on('mouseover', function () {
+    $('#editions th.read').on('mouseover', function(){
         if ($(this).hasClass('sorting_asc')) {
-            $(this).attr('title', 'Push readable versions to the bottom');
+            $(this).attr('title','Push readable versions to the bottom');
         } else if ($(this).hasClass('sorting_desc')) {
-            $(this).attr('title', 'Sort by editions to read');
+            $(this).attr('title','Sort by editions to read');
         } else {
-            $(this).attr('title', 'Available to read');
+            $(this).attr('title','Available to read');
         }
     });
 
@@ -38,43 +36,44 @@ export function initEditionsTable() {
     }
 
     $('#editions th.read span').html('&nbsp;&uarr;');
-    $('#editions th').on('mouseup', function () {
-        toggleSorting(this);
+    $('#editions th').on('mouseup', function() {
+        toggleSorting(this)
     });
 
-    $('#editions').on('length.dt', function (e, settings, length) {
-        localStorage.setItem(LS_RESULTS_LENGTH_KEY, length);
+    $('#editions').on('length.dt', function(e, settings, length) {
         togglePaginationVisibility(length);
+        localStorage.setItem(LS_RESULTS_LENGTH_KEY, length);
     });
 
-    $('#editions th').on('keydown', function (e) {
+    $('#editions th').on('keydown', function(e) {
         if (e.key === 'Enter') {
             toggleSorting(this);
         }
-    });
+    })
 
-    rowCount = $('#editions tbody tr').length;
-    currentLength = Number(localStorage.getItem(LS_RESULTS_LENGTH_KEY)) || DEFAULT_LENGTH;
+   var rowCount = $('#editions tbody tr').length;
+   let currentLength = Number(localStorage.getItem(LS_RESULTS_LENGTH_KEY)) || DEFAULT_LENGTH;
 
-    const dataTable = $('#editions').DataTable({
+    $('#editions').DataTable({
         aoColumns: [{ sType: 'html' }, null],
         order: [[1, 'asc']],
         lengthMenu: [[3, 10, 25, 50, 100, -1], [3, 10, 25, 50, 100, 'All']],
-        bPaginate: rowCount > currentLength ,
+        bPaginate: true, // Always allow pagination initially
         bInfo: true,
         sPaginationType: 'full_numbers',
         bFilter: true,
         bStateSave: false,
         bAutoWidth: false,
-        pageLength: currentLength
+        pageLength: currentLength,
     });
 
     // Toggle pagination visibility based on row count and selected length
     function togglePaginationVisibility(selectedLength) {
+        const paginationElement = $('.dataTables_paginate.paging_full_numbers');
         if (rowCount <= selectedLength || selectedLength === -1) {
-            $('.dataTables_paginate').hide();
+            paginationElement.hide();
         } else {
-            $('.dataTables_paginate').show();
+            paginationElement.show();
         }
     }
 

--- a/openlibrary/plugins/openlibrary/js/editions-table/index.js
+++ b/openlibrary/plugins/openlibrary/js/editions-table/index.js
@@ -6,7 +6,7 @@ const LS_RESULTS_LENGTH_KEY = 'editions-table.resultsLength';
 
 export function initEditionsTable() {
     var rowCount;
-    
+
     $('#editions th.title').on('mouseover', function(){
         if ($(this).hasClass('sorting_asc')) {
             $(this).attr('title','Sort latest to earliest');
@@ -52,8 +52,8 @@ export function initEditionsTable() {
         }
     })
 
-   rowCount = $('#editions tbody tr').length;
-   let currentLength = Number(localStorage.getItem(LS_RESULTS_LENGTH_KEY)) || DEFAULT_LENGTH;
+    rowCount = $('#editions tbody tr').length;
+    const currentLength = Number(localStorage.getItem(LS_RESULTS_LENGTH_KEY)) || DEFAULT_LENGTH;
 
     $('#editions').DataTable({
         aoColumns: [{ sType: 'html' }, null],

--- a/openlibrary/plugins/openlibrary/js/editions-table/index.js
+++ b/openlibrary/plugins/openlibrary/js/editions-table/index.js
@@ -4,7 +4,21 @@ import '../../../../../static/css/legacy-datatables.less';
 const DEFAULT_LENGTH = 3;
 const LS_RESULTS_LENGTH_KEY = 'editions-table.resultsLength';
 
+// Function to add the custom CSS for hiding pagination
+function addCustomPaginationCSS() {
+    const style = document.createElement('style');
+    style.innerHTML = `
+        .dataTables_paginate.paging_full_numbers:has(.paginate_button.previous.disabled):has(.paginate_button.next.disabled):has(.paginate_button.first.disabled):has(.paginate_button.last.disabled) {
+            display: none;
+        }
+    `;
+    document.head.appendChild(style);
+}
+
 export function initEditionsTable() {
+    // Add the custom CSS for pagination
+    addCustomPaginationCSS();
+
     var rowCount;
     let currentLength;
 

--- a/openlibrary/plugins/openlibrary/js/editions-table/index.js
+++ b/openlibrary/plugins/openlibrary/js/editions-table/index.js
@@ -5,6 +5,7 @@ const DEFAULT_LENGTH = 3;
 const LS_RESULTS_LENGTH_KEY = 'editions-table.resultsLength';
 
 export function initEditionsTable() {
+    var rowCount;
     
     $('#editions th.title').on('mouseover', function(){
         if ($(this).hasClass('sorting_asc')) {
@@ -51,7 +52,7 @@ export function initEditionsTable() {
         }
     })
 
-   var rowCount = $('#editions tbody tr').length;
+   rowCount = $('#editions tbody tr').length;
    let currentLength = Number(localStorage.getItem(LS_RESULTS_LENGTH_KEY)) || DEFAULT_LENGTH;
 
     $('#editions').DataTable({

--- a/static/css/legacy-datatables.less
+++ b/static/css/legacy-datatables.less
@@ -423,8 +423,3 @@ tr.even.gradeU td.sorting_3 {
     margin: 10px;
   }
 }
-
-
-.dataTables_paginate.paging_full_numbers:has(.paginate_button.previous.disabled):has(.paginate_button.next.disabled):has(.paginate_button.first.disabled):has(.paginate_button.last.disabled) {
-  display: none;
-}

--- a/static/css/legacy-datatables.less
+++ b/static/css/legacy-datatables.less
@@ -423,3 +423,8 @@ tr.even.gradeU td.sorting_3 {
     margin: 10px;
   }
 }
+
+
+.dataTables_paginate.paging_full_numbers:has(.paginate_button.previous.disabled):has(.paginate_button.next.disabled):has(.paginate_button.first.disabled):has(.paginate_button.last.disabled) {
+  display: none;
+}


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10210 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix: Hides the pager when there is only one page in the `legacy-datatables` UI. This prevents unnecessary pagination buttons that serve no purpose for users.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Navigate to any book and go to the "View Editions" tab.
2. If the allowed entries exceed the available data (e.g., only 8 entries), verify that the pager is hidden.
3. If the dataset exceeds the allowed entries, verify that the pager is displayed as expected.


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
**Pager Hidden (Single Page):**  
The pager is hidden because the allowed entries are more than the actual dataset (8 entries).  
![image](https://github.com/user-attachments/assets/6725bea3-9f1f-451e-907c-2af2e7022d5c)
**Pager Visible (Multiple Pages):**  
The pager is shown when the dataset exceeds the allowed entries.  
![image](https://github.com/user-attachments/assets/bb66088d-5b14-48c5-ae2a-125935a7e8ca)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
