### PR TITLE
Fix: Removed old password reset email feature from admin panel

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -2690,10 +2690,6 @@ msgid "block this account"
 msgstr ""
 
 #: admin/people/view.html
-msgid "send password reset email"
-msgstr ""
-
-#: admin/people/view.html
 #, python-format
 msgid "Registered on <span class=\"time\">%(date)s</span>."
 msgstr ""

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -35,7 +35,6 @@ from openlibrary.core import (
 )
 from openlibrary.core.models import Work
 from openlibrary.plugins.upstream import forms, spamcheck
-from openlibrary.plugins.upstream.account import send_forgot_password_email
 
 logger = logging.getLogger("openlibrary.admin")
 

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -350,8 +350,6 @@ class people_view:
             return self.POST_resend_link(user)
         elif i.action == "activate_account":
             return self.POST_activate_account(user)
-        elif i.action == "send_password_reset_email":
-            return self.POST_send_password_reset_email(user)
         elif i.action == "block_account":
             return self.POST_block_account(user)
         elif i.action == "block_account_and_revert":
@@ -374,10 +372,6 @@ class people_view:
 
     def POST_activate_account(self, user):
         user.activate()
-        raise web.seeother(web.ctx.path)
-
-    def POST_send_password_reset_email(self, user):
-        send_forgot_password_email(user.username, user.email)
         raise web.seeother(web.ctx.path)
 
     def POST_block_account(self, account):

--- a/openlibrary/templates/admin/people/view.html
+++ b/openlibrary/templates/admin/people/view.html
@@ -112,7 +112,7 @@ $ has_profile = person.get_user() is not None
         $if person.status in ['active', 'verified']:
             <button class="do-confirm" type="submit" name="action" value="block_account_and_revert" style="float: right; background: #ffbbbb;">$_("block and revert all edits")</button>
             <button class="do-confirm" type="submit" name="action" value="block_account">$_("block this account")</button>
-            &nbsp;&nbsp;<button type="submit" name="action" value="send_password_reset_email">$_("send password reset email")</button>
+            <!-- &nbsp;&nbsp;<button type="submit" name="action" value="send_password_reset_email">$_("send password reset email")</button> -->
             <br/>
             <br/>
             <div class="small">$:_('Registered on <span class="time">%(date)s</span>.', date=datestr(person.registered_on, relative=False))</div>

--- a/openlibrary/templates/admin/people/view.html
+++ b/openlibrary/templates/admin/people/view.html
@@ -112,7 +112,6 @@ $ has_profile = person.get_user() is not None
         $if person.status in ['active', 'verified']:
             <button class="do-confirm" type="submit" name="action" value="block_account_and_revert" style="float: right; background: #ffbbbb;">$_("block and revert all edits")</button>
             <button class="do-confirm" type="submit" name="action" value="block_account">$_("block this account")</button>
-            <!-- &nbsp;&nbsp;<button type="submit" name="action" value="send_password_reset_email">$_("send password reset email")</button> -->
             <br/>
             <br/>
             <div class="small">$:_('Registered on <span class="time">%(date)s</span>.', date=datestr(person.registered_on, relative=False))</div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10201

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix: Removed the legacy feature that allowed sending password reset emails from the pre-2017 system

### Technical
<!-- What should be noted about the implementation? -->
->Removed the "send password reset email" button from the admin panel
->Deleted the corresponding backend function to ensure no unintended calls to this feature.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
->Navigate to /admin/people/{username} and verify that the "send password reset email" button is no longer present.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
What I Changed :-
![image](https://github.com/user-attachments/assets/67e9a4ab-de53-425d-9a7a-a1753bfae91c)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
