### PR TITLE
Preserve mrid when deprecated keys are passed in merge_authors

### DIFF
--- a/openlibrary/plugins/upstream/merge_authors.py
+++ b/openlibrary/plugins/upstream/merge_authors.py
@@ -263,6 +263,8 @@ class merge_authors(delegate.page):
         # key is deprecated in favor of records but we will support both
         if deprecated_keys := uniq(i.key):
             redir_url = f'/authors/merge/?records={",".join(deprecated_keys)}'
+            if i.mrid:
+                redir_url = f'{redir_url}&mrid={i.mrid}'
             raise web.redirect(redir_url)
 
         keys = uniq(i.records.strip(',').split(','))


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Addresses #10131

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Part of the problem with completed author merges being stuck in the merge queue is that there's no way to remove these entries once they appear. I noticed that the problem entries were all using the deprecated /authors/merge?key=A001&key=A002&mrid=1 format. 

The code in merge_authors that redirects to the preferred /authors/merge?records=A001,A002 doesn't preserve the mrid parameter, which takes the merge out of the merge queue context so that the Reject Merge button isn't available to close the request.

### Technical
This change preserves the mrid parameter in the redirect and maintains the merge queue context.

### Testing
With this change in place, review one of the stuck author merges in the queue. The Reject Merge button should now appear and allow you to close the request.

### Stakeholders
@jimchamp 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
