### PR TITLE
Increase search path for shift-click common parent

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -1,8 +1,8 @@
 # Translations template for Open Library.
-# Copyright (C) 2024 Internet Archive
+# Copyright (C) 2025 Internet Archive
 # This file is distributed under the same license as the Open Library
 # project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
 #, fuzzy
 msgid ""

--- a/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
+++ b/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
@@ -128,8 +128,8 @@ export default class SelectionManager {
     getSelectableRange(clicked) {
         let commonParent = undefined;
         const curEls = { clicked, lastClicked: this.lastClicked };
-        // Only check up to 2 levels up in the tree
-        for (let i = 0; i < 2; i++) {
+        // Only check up to 3 levels up in the tree
+        for (let i = 0; i < 3; i++) {
             if (!curEls.clicked || !curEls.lastClicked) {
                 break;
             } else if (curEls.clicked === curEls.lastClicked) {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10246 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This fixes shift-clicking to select a range of editions in the ILE

### Technical
I didn't dig deeply into the details, but it looks like a change to the HTML of the work page broke shift clicking for edition selection.

I resolved the problem by having the range selection algorithm search one more level up the DOM for the common parent of the clicked elements. I verified that this solves the problem and doesn't affect the behavior of shift-clicking other selectable types.

### Testing

1. While logged in as a librarian, visit a work with multiple editions (e.g. https://openlibrary.org/works/OL63996W/The_Alhambra)
2. Click the first edition to select it.
3. Hold down the shift key and click an edition further down the page.

Expected behavior: All of the editions between the first and second clicks should be selected.

### Stakeholders
@cdrini @mheiman 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
