### PR TITLE
10130/feature/stripping leading and trailing whitespaces from form input

### DIFF
--- a/openlibrary/plugins/openlibrary/js/add-book.js
+++ b/openlibrary/plugins/openlibrary/js/add-book.js
@@ -7,6 +7,7 @@ import {
     isFormatValidIsbn13,
     isValidLccn
 } from './idValidation.js'
+import { trimInputValues } from './utils.js';
 
 let invalidChecksum;
 let invalidIsbn10;
@@ -40,6 +41,8 @@ export function initAddBookImport () {
     $('#id_name').on('change', clearErrors);
 
     $('#publish_date').on('blur', validatePublishDate);
+
+    trimInputValues('input')
 
     // Prevents submission if the publish date is > 1 year in the future
     addBookForm.on('submit', function() {
@@ -184,13 +187,4 @@ function validatePublishDate() {
     } else {
         errorDiv.classList.add('hidden');
     }
-}
-
-export function trimInputValues() {
-    const inputs = document.querySelectorAll('input');
-    inputs.forEach(input => {
-        input.addEventListener('blur', function() {
-            this.value = this.value.trim();
-        });
-    });
 }

--- a/openlibrary/plugins/openlibrary/js/add-book.js
+++ b/openlibrary/plugins/openlibrary/js/add-book.js
@@ -185,3 +185,12 @@ function validatePublishDate() {
         errorDiv.classList.add('hidden');
     }
 }
+
+export function trimInputValues() {
+    const inputs = document.querySelectorAll('input');
+    inputs.forEach(input => {
+        input.addEventListener('blur', function() {
+            this.value = this.value.trim();
+        });
+    });
+}

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -515,3 +515,12 @@ function isValidURL(url) {
         return false;
     }
 }
+
+export function trimInputValues() {
+    const inputs = document.querySelectorAll('.olform input');
+    inputs.forEach(input => {
+        input.addEventListener('blur', function() {
+            this.value = this.value.trim();
+        });
+    });
+}

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -11,6 +11,7 @@ import {
 } from './idValidation';
 import { init as initAutocomplete } from './autocomplete';
 import { init as initJqueryRepeat } from './jquery.repeat';
+import { trimInputValues } from './utils.js';
 
 /* global render_seed_field, render_language_field, render_lazy_work_preview, render_language_autocomplete_item, render_work_field, render_work_autocomplete_item */
 /* Globals are provided by the edit edition template */
@@ -490,6 +491,8 @@ export function initEdit() {
     var link = `#link_${tab.substring(1)}`;
     var fieldname = `:input${hash.replace('/', '-')}`;
 
+    trimInputValues('.olform input');
+
     $(link).trigger('click');
 
     // input field is enabled only after the tab is selected and that takes some time after clicking the link.
@@ -514,13 +517,4 @@ function isValidURL(url) {
     } catch (e) {
         return false;
     }
-}
-
-export function trimInputValues() {
-    const inputs = document.querySelectorAll('.olform input');
-    inputs.forEach(input => {
-        input.addEventListener('blur', function() {
-            this.value = this.value.trim();
-        });
-    });
 }

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -109,6 +109,7 @@ jQuery(function () {
             .then(module => {
                 if (edition) {
                     module.initEdit();
+                    module.trimInputValues();
                 }
                 if (addRowButton) {
                     module.initEditRow();
@@ -288,7 +289,10 @@ jQuery(function () {
 
     if (document.getElementById('addbook')) {
         import(/* webpackChunkName: "add-book" */ './add-book')
-            .then(module => module.initAddBookImport());
+            .then(module => {
+                module.initAddBookImport();
+                module.trimInputValues();
+            });
     }
 
     if (document.getElementById('autofill-dev-credentials')) {

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -109,7 +109,6 @@ jQuery(function () {
             .then(module => {
                 if (edition) {
                     module.initEdit();
-                    module.trimInputValues();
                 }
                 if (addRowButton) {
                     module.initEditRow();
@@ -289,10 +288,7 @@ jQuery(function () {
 
     if (document.getElementById('addbook')) {
         import(/* webpackChunkName: "add-book" */ './add-book')
-            .then(module => {
-                module.initAddBookImport();
-                module.trimInputValues();
-            });
+            .then(module => module.initAddBookImport());
     }
 
     if (document.getElementById('autofill-dev-credentials')) {

--- a/openlibrary/plugins/openlibrary/js/utils.js
+++ b/openlibrary/plugins/openlibrary/js/utils.js
@@ -59,3 +59,16 @@ export function updateURLParameters(params) {
     // Use history.pushState to update the URL without reloading
     window.history.pushState({ path: url.href }, '', url.href);
 }
+
+/**
+ * Remove leading/trailing empty space on field deselect.
+ * @param string a value for document.querySelectorAll()
+ */
+export function trimInputValues(param) {
+    const inputs = document.querySelectorAll(param);
+    inputs.forEach(input => {
+        input.addEventListener('blur', function() {
+            this.value = this.value.trim();
+        });
+    });
+}


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10130 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
feature

### Technical
<!-- What should be noted about the implementation? -->
The implementation deals solely with changes in the frontend JavaScript for the add.html and edit.html pages.
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
The PR affects the pages required for adding a new book, editing an existing edition and adding a new edition to existing book.
1. Opening the page 
   - Adding a New Book - go to the bottom of the home page and click on the "Add a new book" option.
   - Editing the edition of a book - visit any book's page and click on the "Edit" button on the top right.
   - Adding a new edition of a book - visit any book's page and scroll down to the editions table and click on the "Add another edition?" option.

3. Fill any of the input fields while intentionally adding leading and/or trailing white-spaces, and deselect the field. 
4. If the leading and trailing white-spaces disappear, the intended behavior has been achieved.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@scottbarnes 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
