### PR TITLE
Fix solr-restarter erroring/not working

### DIFF
--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -49,7 +49,7 @@ services:
     environment:
       - TEST_URL=http://openlibrary.org/search.json?q=hello&mode=everything&limit=0
       - CONTAINER_NAMES=openlibrary-solr-1 openlibrary-solr_haproxy-1
-      - SEND_SLACK_MESSAGE=true
+      - SEND_SLACK_MESSAGE=false
     env_file:
       - ../olsystem/etc/solr_restarter.env
     volumes:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10239 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
Apparently node's fetch module does not respect the HTTP_PROXY environment variable -_- so getting that working is tricky. Disabling for now since the new security changes mean these requests fail, preventing solr restarter from working.

Even with changes to pass the HTTP_PROXY foreward, the Dockerfile that powers the solr-restarted can no longer build because it uses alpine `apk` commands, which isn't allowed through nexus.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
