### PR TITLE
Add retry logic to author merge request status update

### DIFF
--- a/openlibrary/plugins/upstream/merge_authors.py
+++ b/openlibrary/plugins/upstream/merge_authors.py
@@ -399,7 +399,9 @@ class merge_authors_json(delegate.page):
             )(update_request)
         except MaxRetriesExceeded as e:
             raise web.badrequest(str(e.last_exception))
-        return delegate.RawText(json.dumps(merge_result), content_type="application/json")
+        return delegate.RawText(
+            json.dumps(merge_result), content_type="application/json"
+        )
 
 
 def setup():


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10131

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Attempts to prevent hanging author merges by adding retry logic to the request status update.  This, plus @mheiman's improvement, #10237, should prevent this from being a problem any further.

### Technical
<!-- What should be noted about the implementation? -->
The records involved in the merge are first updated and saved to the db. After, the merge request is updated with a new status reflecting the completed operation. Hanging merge requests were being created since the records could be merged and saved with the status update failing. Adding retries to the status update will hopefully give the record a better chance to be updated properly.

I separated the merge and status update apart into their own separate methods and added the existing [RetryStrategy](https://github.com/internetarchive/openlibrary/blob/dbd4d759adcb63c5b4f91f037264a63e24fe4057/openlibrary/utils/retry.py#L11) object to the status update method. The parameters are fairly arbitrary, 5 tries with 2 second delay. Would like some input on what others think would be the best. Let me know if this seems like a reasonable approach or if anything else is required!

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Simulate `ClientException` error(s) in `update_request()` while completing an author merge, then verify that the merge request closes as expected.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mheiman @mekarpeles

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
