### PR TITLE
Fix duplicate IDs of different types not being accepted on edition edit page

### DIFF
--- a/openlibrary/components/IdentifiersInput.vue
+++ b/openlibrary/components/IdentifiersInput.vue
@@ -155,7 +155,8 @@ export default {
                 this.inputValue = this.inputValue.replace(/\s/g, '')
             }
             if (this.isEdition) {
-                const existingIds = Object.values(this.assignedIdentifiers).flat();
+                // collect id values of matching type, or empty array if none present
+                const existingIds = this.assignedIdentifiers[this.selectedIdentifier] ?? [];
                 const validEditionId = validateEditionIdentifiers(this.selectedIdentifier, this.inputValue, existingIds);
                 if (validEditionId) {
                     if (!this.assignedIdentifiers[this.selectedIdentifier]) {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10274

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Allows the same ID of different types to be entered on the edition edit page.

### Technical
<!-- What should be noted about the implementation? -->
All ID values were being checked previously. Now, only the ID values of the matching type will be checked.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

- Navigate to edition edit page for any edition
- Add an ID of any type (ex. OCAID)
- Add the same ID under a different type (ex. LibriVox)
- Verify that the ID is added and no error is displayed
- Duplicate IDs for the same ID type should still be invalid

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@seabelis 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
