### PR TITLE
Fix deploys: Only have one docker/build-push-action block in olbase yml

### DIFF
--- a/.github/workflows/olbase.yaml
+++ b/.github/workflows/olbase.yaml
@@ -16,17 +16,17 @@ jobs:
         with:
           submodules: true
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       # If on master, use the latest tag, otherwise use the branch name
       - name: Master Build and push

--- a/.github/workflows/olbase.yaml
+++ b/.github/workflows/olbase.yaml
@@ -16,34 +16,22 @@ jobs:
         with:
           submodules: true
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # If on master, use the latest tag, otherwise use the branch name
-      - name: Master Build and push
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
         uses: docker/build-push-action@v6
-        if: github.ref == 'refs/heads/master'
         with:
           context: "."
           file: "./docker/Dockerfile.olbase"
           tags: openlibrary/olbase:latest
-          push: true
-
-      # If on another branch, use the branch name -- just the branch name, not the full ref
-      - name: Test Branch Build and push
-        uses: docker/build-push-action@v6
-        if: github.ref != 'refs/heads/master'
-        with:
-          context: "."
-          file: "./docker/Dockerfile.olbase"
-          tags: openlibrary/olbase:${{ github.ref_name }}
           push: true


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10255

Not sure why this seems to have fixed it... Had two successive olbase successfully push to docker hub :/


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
