### PR TITLE
Fix compose.production.yaml rm cron-jobs.env

### DIFF
--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -126,8 +126,6 @@ services:
     user: root
     command: docker/ol-cron-start.sh
     restart: unless-stopped
-    env_file:
-      - ../olsystem/etc/cron-jobs.env
     volumes:
       - ../olsystem/etc/cron.d/openlibrary.ol_home0:/etc/cron.d/openlibrary.ol_home0:ro
       - ../olsystem:/olsystem


### PR DESCRIPTION
removing deleted /opt/olsystem/etc/cron-jobs.env removed in https://github.com/internetarchive/olsystem/pull/247/files

<!-- What issue does this PR close? -->
Related to #10065 

