### PR TITLE
SIM115 on CoverStore

### DIFF
--- a/openlibrary/coverstore/archive.py
+++ b/openlibrary/coverstore/archive.py
@@ -10,8 +10,8 @@ import zipfile
 
 import internetarchive as ia
 import web
-
 from infogami.infobase import utils
+
 from openlibrary.coverstore import config, db
 from openlibrary.coverstore.coverlib import (
     find_image_path,  # noqa: F401 side effects may be needed

--- a/openlibrary/coverstore/archive.py
+++ b/openlibrary/coverstore/archive.py
@@ -10,8 +10,8 @@ import zipfile
 
 import internetarchive as ia
 import web
-from infogami.infobase import utils
 
+from infogami.infobase import utils
 from openlibrary.coverstore import config, db
 from openlibrary.coverstore.coverlib import (
     find_image_path,  # noqa: F401 side effects may be needed

--- a/openlibrary/coverstore/disk.py
+++ b/openlibrary/coverstore/disk.py
@@ -36,9 +36,8 @@ class Disk:
         prefix = params.get('olid', '')
         filename = self.make_filename(prefix)
         path = os.path.join(self.root, filename)
-        f = open(path, 'w')
-        f.write(data)
-        f.close()
+        with open(path, 'w') as f:
+            f.write(data)
         return filename
 
     def read(self, filename):

--- a/openlibrary/coverstore/tests/test_coverstore.py
+++ b/openlibrary/coverstore/tests/test_coverstore.py
@@ -80,7 +80,7 @@ def test_serve_file(image_dir):
         assert coverlib.read_file(path) == file.read()
 
     with open(path, "rb") as file:
-        assert coverlib.read_file(path + ":10:20") == file.read()[10:10 + 20]
+        assert coverlib.read_file(path + ":10:20") == file.read()[10 : 10 + 20]
 
 
 def test_server_image(image_dir):

--- a/openlibrary/coverstore/tests/test_coverstore.py
+++ b/openlibrary/coverstore/tests/test_coverstore.py
@@ -29,7 +29,8 @@ def image_dir(tmpdir):
 @pytest.mark.parametrize(('prefix', 'path'), image_formats)
 def test_write_image(prefix, path, image_dir):
     """Test writing jpg, gif and png images"""
-    data = open(join(static_dir, path), 'rb').read()
+    with open(join(static_dir, path), 'rb') as file:
+        data = file.read()
     assert coverlib.write_image(data, prefix) is not None
 
     def _exists(filename):
@@ -40,7 +41,8 @@ def test_write_image(prefix, path, image_dir):
     assert _exists(prefix + '-M.jpg')
     assert _exists(prefix + '-L.jpg')
 
-    assert open(coverlib.find_image_path(prefix + '.jpg'), 'rb').read() == data
+    with open(coverlib.find_image_path(prefix + '.jpg'), 'rb') as file:
+        assert file.read() == data
 
 
 def test_bad_image(image_dir):
@@ -74,9 +76,11 @@ def test_serve_file(image_dir):
     path = static_dir + "/logos/logo-en.png"
 
     assert coverlib.read_file('/dev/null') == b''
-    assert coverlib.read_file(path) == open(path, "rb").read()
+    with open(path, "rb") as file:
+        assert coverlib.read_file(path) == file.read()
 
-    assert coverlib.read_file(path + ":10:20") == open(path, "rb").read()[10 : 10 + 20]
+    with open(path, "rb") as file:
+        assert coverlib.read_file(path + ":10:20") == file.read()[10:10 + 20]
 
 
 def test_server_image(image_dir):

--- a/openlibrary/coverstore/tests/test_webapp.py
+++ b/openlibrary/coverstore/tests/test_webapp.py
@@ -65,7 +65,8 @@ class WebTestCase:
         b = self.browser
 
         path = join(static_dir, path)
-        content_type, data = utils.urlencode({'olid': olid, 'data': open(path).read()})
+        with open(path) as file:
+            content_type, data = utils.urlencode({'olid': olid, 'data': file.read()})
         b.open('/b/upload2', data, {'Content-Type': content_type})
         return json.loads(b.data)['id']
 
@@ -88,12 +89,14 @@ class WebTestCase:
 class TestDB:
     def test_write(self, setup_db, image_dir):
         path = static_dir + '/logos/logo-en.png'
-        data = open(path).read()
+        with open(path) as file:
+            data = file.read()
         d = coverlib.save_image(data, category='b', olid='OL1M')
 
         assert 'OL1M' in d.filename
         path = config.data_root + '/localdisk/' + d.filename
-        assert open(path).read() == data
+        with open(path) as file:
+            assert file.read() == data
 
 
 class TestWebapp(WebTestCase):
@@ -114,16 +117,18 @@ class TestWebappWithDB(WebTestCase):
         id2 = self.upload('OL1M', 'logos/logo-it.png')
 
         assert id1 < id2
-        assert (
-            b.open('/b/olid/OL1M.jpg').read()
-            == open(static_dir + '/logos/logo-it.png').read()
-        )
+        with open(static_dir + '/logos/logo-it.png') as file:
+            assert (
+        b.open('/b/olid/OL1M.jpg').read()
+        == file.read()
+            )
 
         b.open('/b/touch', urllib.parse.urlencode({'id': id1}))
-        assert (
-            b.open('/b/olid/OL1M.jpg').read()
-            == open(static_dir + '/logos/logo-en.png').read()
-        )
+        with open(static_dir + '/logos/logo-en.png') as file:
+            assert (
+        b.open('/b/olid/OL1M.jpg').read()
+        == file.read()
+            )
 
     def test_delete(self, setup_db):
         b = self.browser
@@ -137,7 +142,8 @@ class TestWebappWithDB(WebTestCase):
         b = self.browser
 
         path = join(static_dir, 'logos/logo-en.png')
-        filedata = open(path).read()
+        with open(path) as file:
+            filedata = file.read()
         content_type, data = utils.urlencode({'olid': 'OL1234M', 'data': filedata})
         b.open('/b/upload2', data, {'Content-Type': content_type})
         assert b.status == 200
@@ -147,7 +153,8 @@ class TestWebappWithDB(WebTestCase):
 
     def test_upload_with_url(self, monkeypatch):
         b = self.browser
-        filedata = open(join(static_dir, 'logos/logo-en.png')).read()
+        with open(join(static_dir, 'logos/logo-en.png')) as file:
+            filedata = file.read()
         source_url = 'http://example.com/bookcovers/1.jpg'
 
         mock = Mock()
@@ -201,11 +208,13 @@ class TestWebappWithDB(WebTestCase):
         for f in files:
             f.id = self.upload(f.olid, f.filename)
             f.path = join(static_dir, f.filename)
-            assert b.open('/b/id/%d.jpg' % f.id).read() == open(f.path).read()
+            with open(f.path) as file:
+                assert b.open('/b/id/%d.jpg' % f.id).read() == file.read()
 
         archive.archive()
 
         for f in files:
             d = self.jsonget('/b/id/%d.json' % f.id)
             assert 'tar:' in d['filename']
-            assert b.open('/b/id/%d.jpg' % f.id).read() == open(f.path).read()
+            with open(f.path) as file:
+                assert b.open('/b/id/%d.jpg' % f.id).read() == file.read()

--- a/openlibrary/coverstore/tests/test_webapp.py
+++ b/openlibrary/coverstore/tests/test_webapp.py
@@ -118,17 +118,11 @@ class TestWebappWithDB(WebTestCase):
 
         assert id1 < id2
         with open(static_dir + '/logos/logo-it.png') as file:
-            assert (
-        b.open('/b/olid/OL1M.jpg').read()
-        == file.read()
-            )
+            assert b.open('/b/olid/OL1M.jpg').read() == file.read()
 
         b.open('/b/touch', urllib.parse.urlencode({'id': id1}))
         with open(static_dir + '/logos/logo-en.png') as file:
-            assert (
-        b.open('/b/olid/OL1M.jpg').read()
-        == file.read()
-            )
+            assert b.open('/b/olid/OL1M.jpg').read() == file.read()
 
     def test_delete(self, setup_db):
         b = self.browser


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Part of #10196 

NOTE: These are NOT automated changes, they are done by hand

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR addresses SIM115 by handling open files with context manager inside openlibrary/coverstore/.. --> 14 occurrences 

### Technical
<!-- What should be noted about the implementation? -->
- Ensures compliance with SIM115 rule.
- Improves code readability and consistency.
- guaranteed that all files opened, will be closed

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Ran `ruff check .` in openlibrary/coverstore/, attaching a screenshot below
![Screenshot from 2025-01-09 04-17-20](https://github.com/user-attachments/assets/032b71c2-9718-42e8-8dfa-6ec66551c66a)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
