### PR TITLE
update vue import extensions to use .vue

### DIFF
--- a/openlibrary/components/LibraryExplorer.vue
+++ b/openlibrary/components/LibraryExplorer.vue
@@ -15,8 +15,8 @@
 </template>
 
 <script>
-import BookRoom from './LibraryExplorer/components/BookRoom';
-import LibraryToolbar from './LibraryExplorer/components/LibraryToolbar';
+import BookRoom from './LibraryExplorer/components/BookRoom.vue';
+import LibraryToolbar from './LibraryExplorer/components/LibraryToolbar.vue';
 import DDC from './LibraryExplorer/ddc.json';
 import LCC from './LibraryExplorer/lcc.json';
 import { recurForEach } from './LibraryExplorer/utils.js';

--- a/openlibrary/components/LibraryExplorer/components/BookCover3D.vue
+++ b/openlibrary/components/LibraryExplorer/components/BookCover3D.vue
@@ -22,8 +22,8 @@
 </template>
 
 <script>
-import CSSBox from './CSSBox';
-import FlatBookCover from './FlatBookCover';
+import CSSBox from './CSSBox.vue';
+import FlatBookCover from './FlatBookCover.vue';
 import { hashCode } from '../utils.js';
 
 export default {

--- a/openlibrary/components/LibraryExplorer/components/BooksCarousel.vue
+++ b/openlibrary/components/LibraryExplorer/components/BooksCarousel.vue
@@ -21,7 +21,7 @@
 </template>
 
 <script>
-import FlatBookCover from './FlatBookCover';
+import FlatBookCover from './FlatBookCover.vue';
 import CONFIGS from '../../configs';
 
 export default {

--- a/openlibrary/components/LibraryExplorer/components/Bookshelf.vue
+++ b/openlibrary/components/LibraryExplorer/components/Bookshelf.vue
@@ -16,7 +16,7 @@
 </template>
 
 <script>
-import Shelf from './Shelf';
+import Shelf from './Shelf.vue';
 
 
 export default {

--- a/openlibrary/components/LibraryExplorer/components/ClassSlider.vue
+++ b/openlibrary/components/LibraryExplorer/components/ClassSlider.vue
@@ -28,8 +28,8 @@
 </template>
 
 <script>
-import RightArrowIcon from './icons/RightArrowIcon';
-import ShelfProgressBar from './ShelfProgressBar';
+import RightArrowIcon from './icons/RightArrowIcon.vue';
+import ShelfProgressBar from './ShelfProgressBar.vue';
 export default {
     components: { RightArrowIcon, ShelfProgressBar },
     props: {

--- a/openlibrary/components/LibraryExplorer/components/LibraryToolbar.vue
+++ b/openlibrary/components/LibraryExplorer/components/LibraryToolbar.vue
@@ -201,10 +201,10 @@
 
 <script>
 import lucenerQueryParser from 'lucene-query-parser';
-import SettingsIcon from './icons/SettingsIcon';
-import FilterIcon from './icons/FilterIcon';
-import SortIcon from './icons/SortIcon';
-import FeedbackIcon from './icons/FeedbackIcon';
+import SettingsIcon from './icons/SettingsIcon.vue';
+import FilterIcon from './icons/FilterIcon.vue';
+import SortIcon from './icons/SortIcon.vue';
+import FeedbackIcon from './icons/FeedbackIcon.vue';
 import CONFIGS from '../../configs';
 import Multiselect from 'vue-multiselect';
 

--- a/openlibrary/components/LibraryExplorer/components/Shelf.vue
+++ b/openlibrary/components/LibraryExplorer/components/Shelf.vue
@@ -88,12 +88,12 @@
 </template>
 
 <script>
-import OLCarousel from './OLCarousel';
-import ClassSlider from './ClassSlider';
-import ShelfLabel from './ShelfLabel';
-import BookCover3D from './BookCover3D';
-import FlatBookCover from './FlatBookCover';
-import ShelfIndex from './ShelfIndex';
+import OLCarousel from './OLCarousel.vue';
+import ClassSlider from './ClassSlider.vue';
+import ShelfLabel from './ShelfLabel.vue';
+import BookCover3D from './BookCover3D.vue';
+import FlatBookCover from './FlatBookCover.vue';
+import ShelfIndex from './ShelfIndex.vue';
 import ExpandIcon from './icons/ExpandIcon.vue';
 import IndexIcon from './icons/IndexIcon.vue';
 import maxBy from 'lodash/maxBy';

--- a/openlibrary/components/ObservationForm.vue
+++ b/openlibrary/components/ObservationForm.vue
@@ -27,9 +27,9 @@
 </template>
 
 <script>
-import CategorySelector from './ObservationForm/components/CategorySelector'
-import SavedTags from './ObservationForm/components/SavedTags'
-import ValueCard from './ObservationForm/components/ValueCard'
+import CategorySelector from './ObservationForm/components/CategorySelector.vue'
+import SavedTags from './ObservationForm/components/SavedTags.vue'
+import ValueCard from './ObservationForm/components/ValueCard.vue'
 
 import { decodeAndParseJSON, resizeColorbox } from './ObservationForm/Utils'
 

--- a/openlibrary/components/ObservationForm/components/CardBody.vue
+++ b/openlibrary/components/ObservationForm/components/CardBody.vue
@@ -16,7 +16,7 @@
 <script>
 import Vue from 'vue'
 
-import OLChip from './OLChip'
+import OLChip from './OLChip.vue'
 
 import { updateObservation } from '../ObservationService'
 

--- a/openlibrary/components/ObservationForm/components/SavedTags.vue
+++ b/openlibrary/components/ObservationForm/components/SavedTags.vue
@@ -37,7 +37,7 @@
 <script>
 import Vue from 'vue'
 
-import OLChip from './OLChip'
+import OLChip from './OLChip.vue'
 
 import { updateObservation } from '../ObservationService'
 

--- a/openlibrary/components/ObservationForm/components/ValueCard.vue
+++ b/openlibrary/components/ObservationForm/components/ValueCard.vue
@@ -16,8 +16,8 @@
 </template>
 
 <script>
-import CardBody from './CardBody'
-import CardHeader from './CardHeader';
+import CardBody from './CardBody.vue'
+import CardHeader from './CardHeader.vue';
 
 export default {
     name: 'ValueCard',


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Implements part of #7547

This PR adds explicit `.vue` file extensions to component imports to ensure compatibility with Vite's module resolution requirements (see [Vite issue #178](https://github.com/vitejs/vite/issues/178)). While webpack is more lenient with extension resolution, Vite strictly requires these extensions.

This change is a prerequisite for the Vue 3 migration (#10298) and has been implemented incrementally to maintain code clarity. Similar changes have been previously made in other parts of the codebase (see [PR #10303](https://github.com/internetarchive/openlibrary/pull/10303/files#diff-8072cfd31b3fafb1534902ed7a78ca0a13e1d38ebaddf27efcd7b7b43003282aR97-R98)).

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Type: refactor

### Technical
<!-- What should be noted about the implementation? -->
- Adds explicit `.vue` extensions to all component imports
- No functional changes to component behavior
- Maintains consistent import syntax across the codebase

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Run `make components` to verify successful component compilation
2. Verify that all components render and function as expected

The changes are isolated to import statements and pose minimal risk to application functionality.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A - No UI changes

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
