### PR TITLE
Support HTTP Proxy on BookWorm

### DIFF
--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -115,7 +115,7 @@ class AmazonAPI:
             access_key=key, secret_key=secret, host=host, region=region
         )
 
-        # Replace the api object with one that supports the HTTP proxy. See #10308.
+        # Replace the api object with one that supports the HTTP proxy. See #10310.
         configuration = Configuration()
         configuration.proxy = http_proxy_url
         rest_client = RESTClientObject(configuration=configuration)


### PR DESCRIPTION
Closes #10230

This commit allows BookWorm to use the HTTP proxy when fetching metadata from Amazon.

BookWorm relies on an Amazon API client that itself relies on `urllib3` which explicitly does not and will not support the HTTP_PROXY environment variable.

`urllib3` does support HTTP Proxies, but it needs a specific object, and the underlying code for the API does support all of this, but the library provides no way to pass the proxy value through to `urllib3`.

The workaround here is to create the `Configuration` object in the Amazon API client, add a proxy object after init, then use that to create a REST client, and then replace the original `api_client` object with this one, so that there is proxy support.

Note: if trying to create an `vendors.AmazonAPI` object in a REPL, one will need the 'magic incantation' with `infogami._setup()` after the config has been loaded, or the `http_proxy_url` value will be `None`.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
This isn't easy to test, but the following will work from `ol-home0`, inside the testing affiliate server container, as this code is currently applied there (once `amz_key` and `amz_secret` have the relevant values:
```
import infogami
from openlibrary.config import load_config
load_config('/olsystem/etc/openlibrary.yml')
infogami._setup()
import os
amz_key=os.getenv("amz_key")
amz_secret=os.getenv("amz_secret")
from openlibrary.core.vendors import AmazonAPI
amazon = AmazonAPI(key=amz_key, secret=amz_secret, tag="internetarchi-20")
amazon.get_product("9351950972")
```
Without this PR, request for `amazon_get_product()` will simply time out.

NOTE: this does NOT fix the `/isbn` endpoint. That still is not working for an unknown reason, and is the next follow up to this.

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
