### PR TITLE
Include "Submitter" Column in Auto-Loaded Data for Local Environment

### DIFF
--- a/scripts/dev-instance/dev_db.pg_dump
+++ b/scripts/dev-instance/dev_db.pg_dump
@@ -450,7 +450,8 @@ CREATE TABLE public.import_item (
     ia_id text,
     data text,
     ol_key text,
-    comments text
+    comments text,
+    submitter text
 );
 
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10295 

**Description:**
This PR adds the missing submitter column to the import_item table in the local development environment schema, ensuring compatibility with the production schema.

**Changes:**
Added submitter column to import_item table in `dev_db.pg_dump.`

**Testing:**

- Stopped the app, removed openlibrary_ol-postgres volume, and restarted.
- Verified http://localhost:8080/import/batch/pending loads without errors.

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@jimchamp @RayBB 