### PR TITLE
BookWorm: allow imports via BookWorm again

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -327,10 +327,9 @@ def add_cover(cover_url, ekey, account_key=None):
         'ip': web.ctx.ip,
     }
     reply = None
-    for attempt in range(10):
+    for _ in range(10):
         try:
-            payload = requests.compat.urlencode(params).encode('utf-8')
-            response = requests.post(upload_url, data=payload)
+            response = requests.post(upload_url, data=params)
         except requests.HTTPError:
             sleep(2)
             continue

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -583,10 +583,6 @@ def load_data(
         }
     """
 
-    cover_url = None
-    if 'cover' in rec:
-        cover_url = rec['cover']
-        del rec['cover']
     try:
         # get an OL style edition dict
         rec_as_edition = build_query(rec)
@@ -617,6 +613,11 @@ def load_data(
 
     if not (edition_key := edition.get('key')):
         edition_key = web.ctx.site.new_key('/type/edition')
+
+    cover_url = None
+    if 'cover' in edition:
+        cover_url = edition['cover']
+        del edition['cover']
 
     cover_id = None
     if cover_url:

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -53,7 +53,7 @@ from openlibrary.catalog.utils import (
     published_in_future_year,
 )
 from openlibrary.core import lending
-from openlibrary.plugins.upstream.utils import safeget, strip_accents
+from openlibrary.plugins.upstream.utils import safeget, setup_requests, strip_accents
 from openlibrary.utils import dicthash, uniq
 from openlibrary.utils.isbn import normalize_isbn
 from openlibrary.utils.lccn import normalize_lccn
@@ -1012,3 +1012,10 @@ def load(rec: dict, account_key=None, from_marc_record: bool = False) -> dict:
     if 'ocaid' in rec:
         update_ia_metadata_for_ol_edition(match.split('/')[-1])
     return reply
+
+
+def setup():
+    setup_requests()
+
+
+setup()

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -75,7 +75,7 @@ SUSPECT_PUBLICATION_DATES: Final = [
 ]
 SUSPECT_AUTHOR_NAMES: Final = ["unknown", "n/a"]
 SOURCE_RECORDS_REQUIRING_DATE_SCRUTINY: Final = ["amazon", "bwb", "promise"]
-ALLOWED_COVER_HOSTS: Final = ("m.media-amazon.com",)
+ALLOWED_COVER_HOSTS: Final = ("m.media-amazon.com", "books.google.com")
 
 
 type_map = {

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -26,9 +26,11 @@ A record is loaded by calling the load function.
 import itertools
 import re
 from collections import defaultdict
+from collections.abc import Iterable
 from copy import copy
 from time import sleep
 from typing import TYPE_CHECKING, Any, Final
+from urllib.parse import urlparse
 
 import requests
 import web
@@ -73,6 +75,7 @@ SUSPECT_PUBLICATION_DATES: Final = [
 ]
 SUSPECT_AUTHOR_NAMES: Final = ["unknown", "n/a"]
 SOURCE_RECORDS_REQUIRING_DATE_SCRUTINY: Final = ["amazon", "bwb", "promise"]
+ALLOWED_COVER_HOSTS: Final = ("m.media-amazon.com",)
 
 
 type_map = {
@@ -551,6 +554,31 @@ def find_threshold_match(rec: dict, edition_pool: dict) -> str | None:
     return None
 
 
+def process_cover_url(
+    edition: dict, allowed_cover_hosts: Iterable[str] = ALLOWED_COVER_HOSTS
+) -> tuple[str | None, dict]:
+    """
+    Extract and validate a cover URL and remove the key from the edition.
+
+    :param edition: the dict-style edition to import, possibly with a 'cover' key.
+    :allowed_cover_hosts: the hosts added to the HTTP Proxy from which covers
+        can be downloaded
+    :returns: a valid cover URL (or None) and the updated edition with the 'cover'
+        key removed.
+    """
+    if not (cover_url := edition.pop("cover", None)):
+        return None, edition
+
+    parsed_url = urlparse(url=cover_url)
+
+    if parsed_url.netloc.casefold() in (
+        host.casefold() for host in allowed_cover_hosts
+    ):
+        return cover_url, edition
+
+    return None, edition
+
+
 def load_data(
     rec: dict,
     account_key: str | None = None,
@@ -614,10 +642,9 @@ def load_data(
     if not (edition_key := edition.get('key')):
         edition_key = web.ctx.site.new_key('/type/edition')
 
-    cover_url = None
-    if 'cover' in edition:
-        cover_url = edition['cover']
-        del edition['cover']
+    cover_url, edition = process_cover_url(
+        edition=edition, allowed_cover_hosts=ALLOWED_COVER_HOSTS
+    )
 
     cover_id = None
     if cover_url:

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -44,8 +44,6 @@ ISBD_UNIT_PUNCT = ' : '  # ISBD cataloging title-unit separator punctuation
 def setup(config):
     global affiliate_server_url
     affiliate_server_url = config.get('affiliate_server')
-    global http_proxy_url
-    http_proxy_url = config.get('http_proxy')
 
 
 def get_lexile(isbn):
@@ -93,12 +91,13 @@ class AmazonAPI:
         host: str = 'webservices.amazon.com',
         region: str = 'us-east-1',
         throttling: float = 0.9,
+        proxy_url: str = "",
     ) -> None:
         """
         Creates an instance containing your API credentials.
 
-        Instantiating this object in a REPL requires the `infogami._setup()`
-        magic incantation to set `http_proxy_url`.
+        Instantiating this class requires a `proxy_url` parameter as of January
+        10th, 2025 because `ol-home0` has no direct internet access.
 
         :param str key: affiliate key
         :param str secret: affiliate secret
@@ -116,10 +115,11 @@ class AmazonAPI:
         )
 
         # Replace the api object with one that supports the HTTP proxy. See #10310.
-        configuration = Configuration()
-        configuration.proxy = http_proxy_url
-        rest_client = RESTClientObject(configuration=configuration)
-        self.api.api_client.rest_client = rest_client
+        if proxy_url:
+            configuration = Configuration()
+            configuration.proxy = http_proxy_url
+            rest_client = RESTClientObject(configuration=configuration)
+            self.api.api_client.rest_client = rest_client
 
     def search(self, keywords):
         """Adding method to test amz searches from the CLI, unused otherwise"""

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -33,7 +33,6 @@ BETTERWORLDBOOKS_API_URL = (
     'https://products.betterworldbooks.com/service.aspx?IncludeAmazon=True&ItemId='
 )
 affiliate_server_url = None
-http_proxy_url = None
 BWB_AFFILIATE_LINK = 'http://www.anrdoezrs.net/links/{}/type/dlg/http://www.betterworldbooks.com/-id-%s'.format(
     h.affiliate_id('betterworldbooks')
 )
@@ -94,9 +93,8 @@ class AmazonAPI:
         proxy_url: str = "",
     ) -> None:
         """
-        Creates an instance containing your API credentials.
-
-        Instantiating this class requires a `proxy_url` parameter as of January
+        Creates an instance containing your API credentials. Additionally,
+        instantiating this class requires a `proxy_url` parameter as of January
         10th, 2025 because `ol-home0` has no direct internet access.
 
         :param str key: affiliate key
@@ -117,7 +115,7 @@ class AmazonAPI:
         # Replace the api object with one that supports the HTTP proxy. See #10310.
         if proxy_url:
             configuration = Configuration()
-            configuration.proxy = http_proxy_url
+            configuration.proxy = proxy_url
             rest_client = RESTClientObject(configuration=configuration)
             self.api.api_client.rest_client = rest_client
 

--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -12,6 +12,7 @@ from PIL import Image, ImageDraw, ImageFont
 
 from openlibrary.coverstore import config, db
 from openlibrary.coverstore.coverlib import read_file, read_image, save_image
+from openlibrary.coverstore.server import load_config
 from openlibrary.coverstore.utils import (
     changequery,
     download,
@@ -20,6 +21,10 @@ from openlibrary.coverstore.utils import (
     safeint,
 )
 from openlibrary.plugins.openlibrary.processors import CORSProcessor
+from openlibrary.plugins.upstream.utils import setup_requests
+
+if coverstore_config := os.getenv('COVERSTORE_CONFIG'):
+    load_config(coverstore_config)
 
 logger = logging.getLogger("coverstore")
 
@@ -558,3 +563,10 @@ def render_list_preview_image(lst_key):
     with io.BytesIO() as buf:
         background.save(buf, format='PNG')
         return buf.getvalue()
+
+
+def setup():
+    setup_requests(config)
+
+
+setup()

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -43,9 +43,6 @@ from openlibrary.core import cache
 from openlibrary.core.fulltext import fulltext_search
 from openlibrary.core.lending import get_availability
 from openlibrary.core.models import Edition
-from openlibrary.core.vendors import (
-    create_edition_from_amazon_metadata,  # noqa: F401 side effects may be needed
-)
 from openlibrary.plugins.openlibrary import processors
 from openlibrary.plugins.openlibrary.home import format_work_data
 from openlibrary.plugins.openlibrary.stats import increment_error_count

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -21,6 +21,7 @@ from openlibrary.core.batch_imports import (
     batch_import,
 )
 from openlibrary.i18n import gettext as _
+from openlibrary.plugins.upstream.utils import setup_requests
 
 # make sure infogami.config.features is set
 if not hasattr(infogami.config, 'features'):
@@ -647,6 +648,7 @@ class BatchImportPendingView(delegate.page):
 
 class isbn_lookup(delegate.page):
     """The endpoint for /isbn"""
+
     path = r'/(?:isbn|ISBN)/(.{10,})'
 
     def GET(self, isbn: str):
@@ -1387,32 +1389,6 @@ def setup_context_defaults():
     from infogami.utils import context
 
     context.defaults.update({'features': [], 'user': None, 'MAX_VISIBLE_BOOKS': 5})
-
-
-def setup_requests():
-    logger.info("Setting up requests")
-
-    logger.info("Setting up proxy")
-    if infogami.config.get("http_proxy", ""):
-        os.environ['HTTP_PROXY'] = os.environ['http_proxy'] = infogami.config.get(
-            'http_proxy'
-        )
-        os.environ['HTTPS_PROXY'] = os.environ['https_proxy'] = infogami.config.get(
-            'http_proxy'
-        )
-        logger.info('Proxy environment variables are set')
-    else:
-        logger.info("No proxy configuration found")
-
-    logger.info("Setting up proxy bypass")
-    if infogami.config.get("no_proxy_addresses", []):
-        no_proxy = ",".join(infogami.config.get("no_proxy_addresses"))
-        os.environ['NO_PROXY'] = os.environ['no_proxy'] = no_proxy
-        logger.info('Proxy bypass environment variables are set')
-    else:
-        logger.info("No proxy bypass configuration found")
-
-    logger.info("Requests set up")
 
 
 def setup():

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -646,6 +646,7 @@ class BatchImportPendingView(delegate.page):
 
 
 class isbn_lookup(delegate.page):
+    """The endpoint for /isbn"""
     path = r'/(?:isbn|ISBN)/(.{10,})'
 
     def GET(self, isbn: str):

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -1617,7 +1617,7 @@ def get_location_and_publisher(loc_pub: str) -> tuple[list[str], list[str]]:
     return ([], [loc_pub.strip(STRIP_CHARS)])
 
 
-def setup_requests():
+def setup_requests(config=config) -> None:
     logger.info("Setting up requests")
 
     logger.info("Setting up proxy")

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -56,6 +56,8 @@ if TYPE_CHECKING:
 STRIP_CHARS = ",'\" "
 REPLACE_CHARS = "]["
 
+logger = logging.getLogger('openlibrary')
+
 
 class LanguageMultipleMatchError(Exception):
     """Exception raised when more than one possible language match is found."""
@@ -1613,6 +1615,28 @@ def get_location_and_publisher(loc_pub: str) -> tuple[list[str], list[str]]:
 
     # Fall back to making the input a list returning that and an empty location.
     return ([], [loc_pub.strip(STRIP_CHARS)])
+
+
+def setup_requests():
+    logger.info("Setting up requests")
+
+    logger.info("Setting up proxy")
+    if config.get("http_proxy", ""):
+        os.environ['HTTP_PROXY'] = os.environ['http_proxy'] = config.get('http_proxy')
+        os.environ['HTTPS_PROXY'] = os.environ['https_proxy'] = config.get('http_proxy')
+        logger.info('Proxy environment variables are set')
+    else:
+        logger.info("No proxy configuration found")
+
+    logger.info("Setting up proxy bypass")
+    if config.get("no_proxy_addresses", []):
+        no_proxy = ",".join(config.get("no_proxy_addresses"))
+        os.environ['NO_PROXY'] = os.environ['no_proxy'] = no_proxy
+        logger.info('Proxy bypass environment variables are set')
+    else:
+        logger.info("No proxy bypass configuration found")
+
+    logger.info("Requests set up")
 
 
 def setup() -> None:

--- a/scripts/affiliate_server.py
+++ b/scripts/affiliate_server.py
@@ -57,7 +57,7 @@ from openlibrary.config import load_config as openlibrary_load_config
 from openlibrary.core import cache, stats
 from openlibrary.core.imports import Batch, ImportItem
 from openlibrary.core.vendors import AmazonAPI, clean_amazon_metadata_for_load
-from openlibrary.plugins.openlibrary.code import setup_requests
+from openlibrary.plugins.upstream.utils import setup_requests
 from openlibrary.utils.dateutil import WEEK_SECS
 from openlibrary.utils.isbn import (
     isbn_10_to_isbn_13,

--- a/scripts/affiliate_server.py
+++ b/scripts/affiliate_server.py
@@ -689,6 +689,7 @@ class Submit:
 def load_config(configfile):
     # This loads openlibrary.yml + infobase.yml
     openlibrary_load_config(configfile)
+    http_proxy_url = config.get('http_proxy')
 
     stats.client = stats.create_stats_client(cfg=config)
 
@@ -699,7 +700,7 @@ def load_config(configfile):
         config.amazon_api.get('id'),
     ]
     if all(args):
-        web.amazon_api = AmazonAPI(*args, throttling=0.9)
+        web.amazon_api = AmazonAPI(*args, throttling=0.9, proxy_url=http_proxy_url)
         logger.info("AmazonAPI Initialized")
     else:
         raise RuntimeError(f"{configfile} is missing required keys.")

--- a/scripts/partner_batch_imports.py
+++ b/scripts/partner_batch_imports.py
@@ -22,7 +22,7 @@ import requests
 from infogami import config  # noqa: F401 side effects may be needed
 from openlibrary.config import load_config
 from openlibrary.core.imports import Batch
-from openlibrary.plugins.openlibrary.code import setup_requests
+from openlibrary.plugins.upstream.utils import setup_requests
 from scripts.solr_builder.solr_builder.fn_to_cli import FnToCLI
 
 logger = logging.getLogger("openlibrary.importer.bwb")


### PR DESCRIPTION
Closes #10230, #10316
Related: internetarchive/olsystem#253

This commit reenables `/isbn` on BookWorm and by extension openlibrary.org.

Note: this changes the signature of `vendors.AmazonAPI()` to add a `proxy_url` parameter for passing in an HTTP Proxy URL.

It will be passed by default when loaded by BookWorm, but if using `AmazonAPI()` in the REPL on `ol-home0`, then `proxy_url` will need to be passed when instantiating `AmazonAPI()`.

I checked 1000 `staged` items from Amazon and every one had the cover hosted at `m.media-amazon.com`. I had fewer Google Books items to check, but they _seem_ to all have covers coming from `books.google.com`.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

The BookWorm/`/isbn` part of this was tested by visiting https://openlibrary.org/isbn/6610742898 with the relevant part of the code patch deployed to BookWorm.

That resulted in importing https://openlibrary.org/books/OL57448379M/Environmental_Enrichment_for_Captive_Animals, as the Amazon record has no `'cover'` field.

The HTTP Proxy having been updated, the following was imported (with cover) from `/isbn/<isbn>`: https://testing.openlibrary.org/books/OL57494524M/Postcolonial_Hauntings. 

Possibly follow up: numerous ISBNs will have failed import over the past few months, when tried via `/isbn`. They will not now import as they've been marked as failed. It may be desirable to fix this in the database. A staff member will need to do it.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
