### PR TITLE
Opposite direction arrow button for Omnibar

### DIFF
--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -8,10 +8,11 @@ from typing import Any, Literal
 import requests
 from dateutil import parser as isoparser
 from paapi5_python_sdk.api.default_api import DefaultApi
+from paapi5_python_sdk.api_client import Configuration
 from paapi5_python_sdk.get_items_request import GetItemsRequest
 from paapi5_python_sdk.get_items_resource import GetItemsResource
 from paapi5_python_sdk.partner_type import PartnerType
-from paapi5_python_sdk.rest import ApiException
+from paapi5_python_sdk.rest import ApiException, RESTClientObject
 from paapi5_python_sdk.search_items_request import SearchItemsRequest
 
 from infogami.utils.view import public
@@ -32,6 +33,7 @@ BETTERWORLDBOOKS_API_URL = (
     'https://products.betterworldbooks.com/service.aspx?IncludeAmazon=True&ItemId='
 )
 affiliate_server_url = None
+http_proxy_url = None
 BWB_AFFILIATE_LINK = 'http://www.anrdoezrs.net/links/{}/type/dlg/http://www.betterworldbooks.com/-id-%s'.format(
     h.affiliate_id('betterworldbooks')
 )
@@ -42,6 +44,8 @@ ISBD_UNIT_PUNCT = ' : '  # ISBD cataloging title-unit separator punctuation
 def setup(config):
     global affiliate_server_url
     affiliate_server_url = config.get('affiliate_server')
+    global http_proxy_url
+    http_proxy_url = config.get('http_proxy')
 
 
 def get_lexile(isbn):
@@ -93,6 +97,9 @@ class AmazonAPI:
         """
         Creates an instance containing your API credentials.
 
+        Instantiating this object in a REPL requires the `infogami._setup()`
+        magic incantation to set `http_proxy_url`.
+
         :param str key: affiliate key
         :param str secret: affiliate secret
         :param str tag: affiliate string
@@ -107,6 +114,12 @@ class AmazonAPI:
         self.api = DefaultApi(
             access_key=key, secret_key=secret, host=host, region=region
         )
+
+        # Replace the api object with one that supports the HTTP proxy. See #10310.
+        configuration = Configuration()
+        configuration.proxy = http_proxy_url
+        rest_client = RESTClientObject(configuration=configuration)
+        self.api.api_client.rest_client = rest_client
 
     def search(self, keywords):
         """Adding method to test amz searches from the CLI, unused otherwise"""

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -7287,7 +7287,7 @@ msgid ""
 msgstr ""
 
 #: EditionNavBar.html
-msgid "Go to next section"
+msgid "Go to previous section"
 msgstr ""
 
 #: EditionNavBar.html
@@ -7310,6 +7310,10 @@ msgstr[1] ""
 
 #: EditionNavBar.html
 msgid "Related Books"
+msgstr ""
+
+#: EditionNavBar.html
+msgid "Go to next section"
 msgstr ""
 
 #: Follow.html

--- a/openlibrary/macros/EditionNavBar.html
+++ b/openlibrary/macros/EditionNavBar.html
@@ -36,7 +36,7 @@ $ display_for = 'desktop-only' if desktop_only else 'mobile-only'
     </li>
   </ul>
   $if not desktop_only:
-    <button class="nav-arrow" title="$_('Go to next section')">
+    <button class="nav-arrow-right" title="$_('Go to next section')">
       <img src="/static/images/nav-arrow.svg" alt="">
     </button>
 </span>

--- a/openlibrary/macros/EditionNavBar.html
+++ b/openlibrary/macros/EditionNavBar.html
@@ -4,6 +4,10 @@ $ total_reviews = reader_observations.get('total_respondents', 0)
 
 $ display_for = 'desktop-only' if desktop_only else 'mobile-only'
 <span class="nav-bar-wrapper sticky $display_for">
+  $if not desktop_only:
+    <button class="nav-arrow-left" title="$_('Go to next section')">
+      <img src="/static/images/nav-arrow.svg" alt="">
+    </button>
   <ul class="nav-bar work-menu">
     <li class="selected">
       <a href="#overview$('-mobile' if not desktop_only else '')" data-ol-link-track="BookPageNav|Overview">$_("Overview")</a>

--- a/openlibrary/macros/EditionNavBar.html
+++ b/openlibrary/macros/EditionNavBar.html
@@ -5,7 +5,7 @@ $ total_reviews = reader_observations.get('total_respondents', 0)
 $ display_for = 'desktop-only' if desktop_only else 'mobile-only'
 <span class="nav-bar-wrapper sticky $display_for">
   $if not desktop_only:
-    <button class="nav-arrow-left" title="$_('Go to next section')">
+    <button class="nav-arrow-left" title="$_('Go to previous section')">
       <img src="/static/images/nav-arrow.svg" alt="">
     </button>
   <ul class="nav-bar work-menu">

--- a/openlibrary/plugins/openlibrary/js/edition-nav-bar/EditionNavBar.js
+++ b/openlibrary/plugins/openlibrary/js/edition-nav-bar/EditionNavBar.js
@@ -23,6 +23,11 @@ export default class EdtionNavBar {
          * The mobile-only navigation arrow. Not guaranteed to exist.
          * @type {HTMLElement|null}
          */
+        this.navArrowLeft = navbarWrapper.querySelector('.nav-arrow-left')
+        /**
+         * The mobile-only navigation arrow. Not guaranteed to exist.
+         * @type {HTMLElement|null}
+         */
         this.navArrow = navbarWrapper.querySelector('.nav-arrow')
         /**
          * References each nav item in this navbar.
@@ -64,6 +69,15 @@ export default class EdtionNavBar {
         }
 
         // Add click listener to mobile-only navigation arrow:
+        if (this.navArrowLeft) {
+            this.navArrowLeft.addEventListener('click', () => {
+                if (this.selectedIndex > 0) {
+                    --this.selectedIndex
+                    this.navItems[this.selectedIndex].children[0].click()
+                }
+            })
+        }
+ 
         if (this.navArrow) {
             this.navArrow.addEventListener('click', () => {
                 if (this.selectedIndex < this.navItems.length - 1) {

--- a/openlibrary/plugins/openlibrary/js/edition-nav-bar/EditionNavBar.js
+++ b/openlibrary/plugins/openlibrary/js/edition-nav-bar/EditionNavBar.js
@@ -77,7 +77,7 @@ export default class EdtionNavBar {
                 }
             })
         }
- 
+
         if (this.navArrowRight) {
             this.navArrowRight.addEventListener('click', () => {
                 if (this.selectedIndex < this.navItems.length - 1) {
@@ -103,7 +103,7 @@ export default class EdtionNavBar {
         if (navbarHeight > 0) {
             let i = this.navItems.length
             // 10 is for a little bit of padding
-            while (--i > 0 && this.navbarWrapper.offsetTop + navbarHeight < (this.targetAnchors[i].offsetTop - 10)) {}
+            while (--i > 0 && this.navbarWrapper.offsetTop + navbarHeight < (this.targetAnchors[i].offsetTop - 10)) { }
             if (i !== this.selectedIndex) {
                 this.selectedIndex = i
                 this.selectElement(this.navItems[i])
@@ -123,7 +123,8 @@ export default class EdtionNavBar {
 
         this.navbarElem.scrollTo({
             left: selectedItem.offsetLeft - (this.navbarElem.clientWidth - selectedItem.offsetWidth) / 2,
-            behavior: 'instant'})
+            behavior: 'instant'
+        })
     }
 
     /**

--- a/openlibrary/plugins/openlibrary/js/edition-nav-bar/EditionNavBar.js
+++ b/openlibrary/plugins/openlibrary/js/edition-nav-bar/EditionNavBar.js
@@ -28,7 +28,7 @@ export default class EdtionNavBar {
          * The mobile-only navigation arrow. Not guaranteed to exist.
          * @type {HTMLElement|null}
          */
-        this.navArrow = navbarWrapper.querySelector('.nav-arrow')
+        this.navArrowRight = navbarWrapper.querySelector('.nav-arrow-right')
         /**
          * References each nav item in this navbar.
          * @type {Array<HTMLLIElement>}
@@ -78,8 +78,8 @@ export default class EdtionNavBar {
             })
         }
  
-        if (this.navArrow) {
-            this.navArrow.addEventListener('click', () => {
+        if (this.navArrowRight) {
+            this.navArrowRight.addEventListener('click', () => {
                 if (this.selectedIndex < this.navItems.length - 1) {
                     // Simulate click on the next nav item:
                     ++this.selectedIndex

--- a/static/css/components/nav-bar.less
+++ b/static/css/components/nav-bar.less
@@ -55,7 +55,7 @@
     margin-right: -20px;
   }
 
-  .nav-arrow {
+  .nav-arrow-right {
     border: none;
     position: absolute;
     padding: 0;

--- a/static/css/components/nav-bar.less
+++ b/static/css/components/nav-bar.less
@@ -74,6 +74,23 @@
     }
   }
 
+  .nav-arrow-left{
+    border: none;
+    position: absolute;
+    padding: 0;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    z-index: @z-index-level-14;
+    width: 44px;
+    background: linear-gradient(to left, transparent, @white 10px);
+
+    img{
+      transform: rotate(180deg);
+    }
+
+  }
+
   .nav-bar.work-menu {
     padding: 8px 20px 0;
     background: @white;

--- a/static/css/components/nav-bar.less
+++ b/static/css/components/nav-bar.less
@@ -109,6 +109,9 @@
       padding: 4px 15px;
       vertical-align: text-top;
     }
+    li:first-child{
+      margin-left: 22px;
+    }
     li:last-child {
       margin-right: 44px;
     }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10240

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Opposite direction arrow button for Omnibar:
1) Add's new arrow in HTML, CSS, and JS with functionality.
2) Avoid clipping of the first element due to the arrows.
3) Renamed arrows to "nav-arrow-left" and "nav-arrow-right" to avoid confusion in the future.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1)Go to any book page (eg. https://openlibrary.org/works/OL69166W/Italian_journeys)
2)Resize the screen and see the arrow only for one direction

### Screenshot/Video
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

Video of implementation:

https://github.com/user-attachments/assets/433cb952-d81e-4045-bb52-70e863e15083

Screenshot:
![image](https://github.com/user-attachments/assets/1f035295-7fe2-4158-9157-74ab9c1ead52)



### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
