### PR TITLE
Renamed Id numbers and added work identifiers with work id

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -3604,7 +3604,7 @@ msgstr ""
 msgid "Links"
 msgstr ""
 
-#: books/edit.html
+#: books/edit.html type/edition/view.html type/work/view.html
 msgid "Work Identifiers"
 msgstr ""
 
@@ -3974,8 +3974,7 @@ msgstr ""
 msgid "Invalid ID format"
 msgstr ""
 
-#: books/edit/edition.html type/author/view.html type/edition/view.html
-#: type/work/view.html
+#: books/edit/edition.html type/author/view.html
 msgid "ID Numbers"
 msgstr ""
 
@@ -6686,6 +6685,10 @@ msgstr ""
 
 #: type/edition/view.html type/work/view.html
 msgid "Weight"
+msgstr ""
+
+#: type/edition/view.html type/work/view.html
+msgid "Edition Identifiers"
 msgstr ""
 
 #: type/edition/view.html type/work/view.html

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -438,7 +438,7 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
 
 
           <div class="section">
-            <h3>$_("ID Numbers")</h3>
+            <h3>$_("Edition Identifiers")</h3>
             <dl class="meta">
                 $:display_identifiers("Open Library", [storage(url=None, value=edition.key.split("/")[-1])])
                 $ no_index = edition.get_ia_meta_fields().get('noindex', False)
@@ -451,6 +451,13 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
             $for name, values in edition.get_identifiers().multi_items():
                 $:display_goodreads(values[0].label, values)
             </dl>
+            <h3>$_("Work Identifiers")</h3> 
+            <dl class="meta"> 
+                $:display_identifiers("Work ID", [storage(url=None, value=work.key.split("/")[-1])]) 
+                $for name, values in work.get_identifiers().multi_items(): 
+                    $ identifier_label = values[0].label 
+                    $:display_identifiers(identifier_label, values) 
+            </dl> 
           </div>
 	  $ source_records = edition.get('source_records')
           $if source_records:

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -451,13 +451,13 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
             $for name, values in edition.get_identifiers().multi_items():
                 $:display_goodreads(values[0].label, values)
             </dl>
-            <h3>$_("Work Identifiers")</h3> 
-            <dl class="meta"> 
-                $:display_identifiers("Work ID", [storage(url=None, value=work.key.split("/")[-1])]) 
-                $for name, values in work.get_identifiers().multi_items(): 
-                    $ identifier_label = values[0].label 
-                    $:display_identifiers(identifier_label, values) 
-            </dl> 
+            <h3>$_("Work Identifiers")</h3>
+            <dl class="meta">
+                $:display_identifiers("Work ID", [storage(url=None, value=work.key.split("/")[-1])])
+                $for name, values in work.get_identifiers().multi_items():
+                    $ identifier_label = values[0].label
+                    $:display_identifiers(identifier_label, values)
+            </dl>
           </div>
 	  $ source_records = edition.get('source_records')
           $if source_records:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10302

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
1) Renamed "ID Numbers" to "Edition Identifiers"
2) Added a new section named "Work Identifiers" and also added "Work ID" as well

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Visit any book page and scroll down to se "ID numbers"

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/user-attachments/assets/b0f32d08-18fa-4486-ab13-69eb4993a771)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
