### PR TITLE
Fix My Loans count for My Books #10041

### DIFF
--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -61,7 +61,7 @@ class mybooks_home(delegate.page):
 
         if mb.me:
             myloans = get_loans_of_user(mb.me.key)
-            loans = web.Storage({"docs": [], "total_results": len(loans)})
+            loans = web.Storage({"docs": [], "total_results": len(myloans)})
             # TODO: should do in one web.ctx.get_many fetch
             for loan in myloans:
                 # Book will be None if no OL edition exists for the book


### PR DESCRIPTION
Uses correct variable `myloans` when counting patron's loans, rather than the uninitialized `loans` variable

<!-- What issue does this PR close? -->
Closes #10041 with @OutstandingWork 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

What we know is that the problem occurs on the My Books page (e.g. https://openlibrary.org/people/mekBot/books) for a logged in patron.

When a patrons navigated to the My Books page, their request is matches and responded to by the mybooks plugin: https://github.com/internetarchive/openlibrary/blob/master/openlibrary/plugins/upstream/mybooks.py#L43-L58

We see something strange going on in https://github.com/internetarchive/openlibrary/blob/master/openlibrary/plugins/upstream/mybooks.py#L62-L64 where we fetch `myloans` but then seemingly take the `len` of `loans` which is an empty list defined just above:
https://github.com/internetarchive/openlibrary/blob/master/openlibrary/plugins/upstream/mybooks.py#L60

This seems like a bug and https://github.com/internetarchive/openlibrary/blob/master/openlibrary/plugins/upstream/mybooks.py#L64 is probably supposed to be 

`loans = web.Storage({"docs": [], "total_results": len(myloans)})`

This might alone fix the problem!

Let's continue...

So, next, we take each of the loans from `myloans` and we move it into the `loans` object (which has the wrong length at this point, I think): https://github.com/internetarchive/openlibrary/blob/master/openlibrary/plugins/upstream/mybooks.py#L66-L70

Finally, we pass our loans as one of our `docs` (https://github.com/internetarchive/openlibrary/blob/master/openlibrary/plugins/upstream/mybooks.py#L89C9-L97) to the front-end template: https://github.com/internetarchive/openlibrary/blob/master/openlibrary/templates/account/mybooks.html

Now we're suddenly in the html template, and we know that `docs` from the plugins controller is getting passed into the template in the second parameter position, which maps to `mybook`: https://github.com/internetarchive/openlibrary/blob/master/openlibrary/plugins/upstream/mybooks.py#L97

So, mybooks['loans'] or mybooks.loans is going to have our loans in it.

Now, we may not know where to start in this template, but we know we are trying to find a section with the title "My Loans (#)" because that's the component with the wrong number we're trying to fix.

By searching for "My Loans", we find https://github.com/internetarchive/openlibrary/blob/master/openlibrary/templates/account/mybooks.html#L38 which is using a variable called `loans`.

On https://github.com/internetarchive/openlibrary/blob/master/openlibrary/templates/account/mybooks.html#L45, we see that this `loans` object https://github.com/internetarchive/openlibrary/blob/master/openlibrary/templates/account/mybooks.html#L38 is being passed into a function called `compact_carousel(loans)` that will build our carousel: https://github.com/internetarchive/openlibrary/blob/master/openlibrary/templates/account/mybooks.html#L45

This `compact_carousel` function is defined just above: https://github.com/internetarchive/openlibrary/blob/master/openlibrary/templates/account/mybooks.html#L13-L27

It takes in our `loans` as `data` (i.e. `$ loans = ["loans", _('My Loans'), "/account/loans"]`) -- the first element is the `key` for which data we're talking about within our `docs` dict (or in this template, `mybooks`)  carousel, the second element is the internationalized title for the carousel, and the third element is the link the title will go to.

Finally, we see https://github.com/internetarchive/openlibrary/blob/master/openlibrary/templates/account/mybooks.html#L17 the `loans` key is used to fetch the loans and the number of loans from `mybooks`

This all looks good... `count = mybooks[key].total_results` here is actually `mybooks["loans"]` ... and `mybooks` is the same as `docs` from our plugins controller here: https://github.com/internetarchive/openlibrary/blob/master/openlibrary/plugins/upstream/mybooks.py#L90...  which is coming from our `loans` object here: https://github.com/internetarchive/openlibrary/blob/master/openlibrary/plugins/upstream/mybooks.py#L64-L70... Which we've determined has the wrong length because it was set using the wrong variable!

Confirmed on testing.openlibrary.org!
<img src="https://github.com/user-attachments/assets/f9ed9b8a-18f5-475a-aa29-815459120c91" height=400>


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
