### PR TITLE
Clarify Privacy Page Wording

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -1366,7 +1366,8 @@ msgstr ""
 #: account/privacy.html
 msgid ""
 "This will enable others to see what books you want to read, are reading, "
-"or have already read. Public accounts can be seen and followed by others."
+"or have already read. Patrons with reading logs set to public may be "
+"followed."
 msgstr ""
 
 #: account/privacy.html

--- a/openlibrary/templates/account/privacy.html
+++ b/openlibrary/templates/account/privacy.html
@@ -23,7 +23,7 @@ $ safe_mode = d.get('safe_mode', 'no')
 
         <div class="formElement">
             <h3 class="collapse">$:_('Would you like to make your <a href="/account/books">Reading Log</a> public?')</h3>
-            <p>$_("This will enable others to see what books you want to read, are reading, or have already read. Public accounts can be seen and followed by others.")</p>
+            <p>$_("This will enable others to see what books you want to read, are reading, or have already read. Patrons with reading logs set to public may be followed.")</p>
         </div>
         <br/>
         <div class="formElement">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10304

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR addresses an issue with unclear wording on the privacy page. The previous text, "Public accounts can be seen and followed by others," implied that accounts could be hidden, which is incorrect.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
