### PR TITLE
Make scrollbar thin on books page + fix link underlines regression

### DIFF
--- a/static/css/components/mybooks-menu.less
+++ b/static/css/components/mybooks-menu.less
@@ -19,13 +19,24 @@
   height: 100vh;
   top: 0;
   overflow-y: auto;
+  scrollbar-width: thin;
 
+  @media (hover: hover) {
+    overflow: hidden;
+
+    &:hover {
+      overflow: auto;
+    }
+  }
+  
   .external-link {
     text-decoration: underline;
   }
 
-  a {
+  a:link, a:hover, a:visited {
     text-decoration: none;
+  }
+  a {
     color: @link-blue;
   }
   /*all uls */

--- a/static/css/components/mybooks-menu.less
+++ b/static/css/components/mybooks-menu.less
@@ -33,12 +33,13 @@
     text-decoration: underline;
   }
 
-  a:link, a:hover, a:visited {
-    text-decoration: none;
-  }
   a {
     color: @link-blue;
   }
+  a:link, a:hover, a:visited {
+    text-decoration: none;
+  }
+
   /*all uls */
   .sidebar-section {
     padding: 0 0 10px;

--- a/static/css/components/mybooks-menu.less
+++ b/static/css/components/mybooks-menu.less
@@ -34,6 +34,7 @@
   }
 
   a {
+    display: block;
     color: @link-blue;
   }
   a:link, a:hover, a:visited {
@@ -65,12 +66,8 @@
       font-weight: bold;
     }
   }
-  ul li a {
-    display: block;
-  }
 
   ul li:not(.section-header) a {
-    display: block;
     padding: 4px 15px;
 
     @media (pointer: coarse) {

--- a/static/css/components/mybooks-menu.less
+++ b/static/css/components/mybooks-menu.less
@@ -22,10 +22,10 @@
   scrollbar-width: thin;
 
   @media (hover: hover) {
-    overflow: hidden;
+    scrollbar-color: transparent transparent;
 
     &:hover {
-      overflow: auto;
+      scrollbar-color: auto;
     }
   }
   

--- a/static/css/components/mybooks-menu.less
+++ b/static/css/components/mybooks-menu.less
@@ -20,13 +20,9 @@
   top: 0;
   overflow-y: auto;
   scrollbar-width: thin;
-
-  @media (hover: hover) {
-    scrollbar-color: transparent transparent;
-
-    &:hover {
-      scrollbar-color: auto;
-    }
+  scrollbar-color: transparent transparent;
+  &:hover {
+    scrollbar-color: auto;
   }
 
   .external-link {

--- a/static/css/components/mybooks-menu.less
+++ b/static/css/components/mybooks-menu.less
@@ -28,7 +28,7 @@
       scrollbar-color: auto;
     }
   }
-  
+
   .external-link {
     text-decoration: underline;
   }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Fix; the underlines was a regression in a previous PR.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot

Before:
![image](https://github.com/user-attachments/assets/76e23a5b-1460-4cf2-8bec-4f756694ca3b)

After (scrollbar appears on hover):
![image](https://github.com/user-attachments/assets/98c4b68f-5996-4623-8d54-717ea1fab64a)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
