### PR TITLE
Added respective responses discerning between unauthorized (not logged-in) and forbidden responses.

### DIFF
--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -139,11 +139,14 @@ class merge_work(delegate.page):
     def GET(self):
         i = web.input(records='', mrid=None, primary=None)
         user = web.ctx.site.get_user()
+
+        if user is None:
+            raise web.unauthorized()
         has_access = user and (
             (user.is_admin() or user.is_librarian()) or user.is_super_librarian()
         )
         if not has_access:
-            raise web.HTTPError('403 Forbidden')
+            raise web.forbidden()
 
         optional_kwargs = {}
         if not (user.is_admin() or user.is_super_librarian()):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10224 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

### Technical
<!-- What should be noted about the implementation? -->
It simply changes the response returned for a authenticated user without the necessary clearance (admin, librarian or super-librarian) to see the /merge/works and adds a condition for responding to a request sent by unauthenticated users.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
The PR affects two cases:
1. Attempt to access the http://localhost:8080/works/merge?records=OL15941796W,OL15400921W by logging into a user type that is not a super-librarian, librarian or admin. If a forbidden response is received, the PR works as expected.
2. Attempt to access the http://localhost:8080/works/merge?records=OL15941796W,OL15400921W without logging-in. If an "unauthorized" response is received, the PR works as expected.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Case 1 - Logged-in but not admin, librarian or super-librarian:
![image](https://github.com/user-attachments/assets/462eb3e7-7269-438e-af1b-d15786dc7e85)

Case 2 - Not logged-in
![image](https://github.com/user-attachments/assets/fad65304-63c7-49b9-81b3-b7f19a514bc7)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
