### PR TITLE
Add to Want to Read list button enabled for registered users

### DIFF
--- a/openlibrary/templates/barcodescanner.html
+++ b/openlibrary/templates/barcodescanner.html
@@ -3,5 +3,6 @@ $def with ()
 $var title: $_('Barcode Scanner (Beta)')
 
 $ ctx.setdefault("show_ol_shell", False)
+$ current_user = ctx.user.key if ctx.user else ""
 
-$:render_component('BarcodeScanner')
+$:render_component('BarcodeScanner', attrs=dict(user_key=current_user))


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4728 

Thought it would be good to start with just the Want to Read reading log before expanding this to user lists. If 'Add to Want to Read list' is enabled, scanned books won't automatically redirect to their OL page until the feature is disabled again.
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature

### Technical
<!-- What should be noted about the implementation? -->
Allow signed in users to add scanned books to their Want to Read list. 
Button is disabled for barcode scanner users that are not logged into their OL account. 
Prevents books that are already present in the WtR list from being removed with the ```dont_remove``` POST body argument.
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Sign in using the OpenLibrary admin account, empty the 'Want to Read' list if books already exist within the list.
2. Acquire the ISBN barcodes or ISBN numbers that are within the OL dev database for the barcode scanner.
3. Navigate to ```http://localhost:8080/barcodescanner```, enable your device's camera permissions within the settings menu and click on the 'Add to my Want to Read List'. The subtext should say 'Currently enabled' when the feature is active.
4. Scan the ISBN barcodes or use the text ISBN feature, the LazyBookCard components should appear at the bottom. Go back to the WtR list and verify that the scanned books are present in the list.

    - Refresh the barcode scanner page, enable the 'Add to my Want to Read list' button, and scan the barcodes again. There should be no changes to the 'Want to Read' list.
5. Navigate to ```http://localhost:8080/barcodescanner?returnTo=/isbn/$$$```, enable 'Add to my Want to Read List' and scan an ISBN. The intended behavior to navigate the user to the work's OL page is disabled in favor of adding the book to the 'Want to Read' list

    - The fetch request to add the book to the WtR reading log requires the work id gotten within the ```LazyBookCard``` component. Not sure how to make ```submitISBN``` await the add to WtR fetch request since that function is bound to ```submitISBNThrottled```. Open to suggestions on how to handle this situation if this isn't ideal behavior

6. Sign out of the OpenLibrary account and view the barcode scanner page again. Add to my Want to Read list should be disabled and contain the subtext 'You must be signed in to enable this feature'
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

Will update with video

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini @mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
