### PR TITLE
Fix seed retrieval to use seed strings from already defined fuctions 

### DIFF
--- a/openlibrary/core/lists/model.py
+++ b/openlibrary/core/lists/model.py
@@ -198,7 +198,7 @@ class List(Thing):
         things = cast(
             list[Thing],
             web.ctx.site.get_many(
-                [seed.key for seed in self.seeds if isinstance(seed, Thing)]
+                [seed for seed in self._get_seed_strings() if seed.startswith("/")]
             ),
         )
 

--- a/openlibrary/core/lists/model.py
+++ b/openlibrary/core/lists/model.py
@@ -198,7 +198,7 @@ class List(Thing):
         things = cast(
             list[Thing],
             web.ctx.site.get_many(
-                [seed for seed in self._get_seed_strings() if seed.startswith("/")]
+                [seed.key for seed in self.get_seeds() if seed._type != "subject"]
             ),
         )
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10322 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes the `get_export_list()` for seeds that contain notes

### Technical
<!-- What should be noted about the implementation? -->
The functionality and logic of the previous version and this PR remains the same. Using `_get_seed_details()` instead of `self.seeds`.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
The export functionality now works as expected.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles @cdrini 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
