### PR TITLE
add read stats in addition to borrows

### DIFF
--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -158,6 +158,7 @@ class borrow(delegate.page):
         response = lending.get_availability_of_ocaid(edition.ocaid)
         availability = response[edition.ocaid] if response else {}
         if availability and availability['status'] == 'open':
+            stats.increment('ol.reads.bookreader')
             raise web.seeother(archive_url)
 
         error_redirect = archive_url

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -159,6 +159,7 @@ class borrow(delegate.page):
         availability = response[edition.ocaid] if response else {}
         if availability and availability['status'] == 'open':
             from openlibrary.plugins.openlibrary.code import is_bot
+
             if not is_bot():
                 stats.increment('ol.loans.openaccess')
             raise web.seeother(archive_url)

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -33,7 +33,6 @@ from openlibrary.core import (
     waitinglist,
 )
 from openlibrary.i18n import gettext as _
-from openlibrary.plugins.openlibrary.code import is_bot
 from openlibrary.utils import dateutil
 
 logger = logging.getLogger("openlibrary.borrow")
@@ -159,6 +158,7 @@ class borrow(delegate.page):
         response = lending.get_availability_of_ocaid(edition.ocaid)
         availability = response[edition.ocaid] if response else {}
         if availability and availability['status'] == 'open':
+            from openlibrary.plugins.openlibrary.code import is_bot
             if not is_bot():
                 stats.increment('ol.loans.openaccess')
             raise web.seeother(archive_url)

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -33,8 +33,8 @@ from openlibrary.core import (
     waitinglist,
 )
 from openlibrary.i18n import gettext as _
-from openlibrary.utils import dateutil
 from openlibrary.plugins.openlibrary.code import is_bot
+from openlibrary.utils import dateutil
 
 logger = logging.getLogger("openlibrary.borrow")
 

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -34,6 +34,7 @@ from openlibrary.core import (
 )
 from openlibrary.i18n import gettext as _
 from openlibrary.utils import dateutil
+from openlibrary.plugins.openlibrary.code import is_bot
 
 logger = logging.getLogger("openlibrary.borrow")
 
@@ -158,7 +159,8 @@ class borrow(delegate.page):
         response = lending.get_availability_of_ocaid(edition.ocaid)
         availability = response[edition.ocaid] if response else {}
         if availability and availability['status'] == 'open':
-            stats.increment('ol.reads.bookreader')
+            if not is_bot():
+                stats.increment('ol.loans.openaccess')
             raise web.seeother(archive_url)
 
         error_redirect = archive_url


### PR DESCRIPTION
Historically, we've only counted borrowing stats and not access to open materials.

One line improvement to track how often open access materials are read from Open Library.


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
