### PR TITLE
Increasing solr haproxy maxconn from 10 to 75

### DIFF
--- a/conf/solr/haproxy.cfg
+++ b/conf/solr/haproxy.cfg
@@ -34,4 +34,4 @@ listen solr
 	balance	roundrobin
     #option httpchk GET /solr/
     option httpchk GET /solr/openlibrary/select?rows=0&q=*:*
-    server  solr-8983 solr:8983 maxconn 10 check inter 5000 rise 2 fall 2
+    server  solr-8983 solr:8983 maxconn 75 check inter 5000 rise 2 fall 2


### PR DESCRIPTION
Researching w/ chatgpt, suggested to reduce queuing by increasing this number to ~200 and we choose 75 and monitored on sentry + grafana + cpu

<!-- What issue does this PR close? -->
Related to #7673 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
