### PR TITLE
Move web.ctx check outside of cached function #10318

### DIFF
--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -38,9 +38,9 @@ CAROUSELS_PRESETS = {
 }
 
 
-def get_homepage():
+def get_homepage(devmode=False):
     try:
-        stats = admin.get_stats(use_mock_data=("dev" in web.ctx.features))
+        stats = admin.get_stats(use_mock_data=devmode)
     except Exception:
         logger.error("Error in getting stats", exc_info=True)
         stats = None
@@ -65,8 +65,7 @@ def get_cached_homepage():
     mc = cache.memcache_memoize(
         get_homepage, key, timeout=five_minutes, prethread=caching_prethread()
     )
-
-    page = mc()
+    page = mc(devmode=("dev" in web.ctx.features))
 
     if not page:
         mc(_cache='delete')

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -38,7 +38,7 @@ CAROUSELS_PRESETS = {
 }
 
 
-def get_homepage(devmode=False):
+def get_homepage(devmode):
     try:
         stats = admin.get_stats(use_mock_data=devmode)
     except Exception:


### PR DESCRIPTION
Moves `("dev" in web.ctx.features)` check to a `devmode` function param so `web.ctx` is no longer needed within our cached function.

While the initial computer of the `get_homepage()` function works fine (because `web.ctx` is in scope) the `web.ctx` `ThreadedDict` may no longer be accessible once passed to a memcache thread for it's subsequent re-compute after timeout hit)

<!-- What issue does this PR close? -->
Closes #10318 

**Resolves** https://sentry.archive.org/organizations/ia-ux/issues/541018/?query=is%3Aunresolved+threadeddict&referrer=issue-stream&statsPeriod=14d

Addresses instance of #10341

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

See investigation here: https://github.com/internetarchive/openlibrary/issues/10318#issuecomment-2598903078

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

hotfix patch deploy should show a drop in errors on sentry and hopefully stats showing up again on prod.


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@schu96 @cdrini @RayBB @jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
