### PR TITLE
Add `cron_wrapper` script to improve cron job monitoring

### DIFF
--- a/scripts/cron_wrapper.py
+++ b/scripts/cron_wrapper.py
@@ -3,24 +3,28 @@ Executes the given script with the given arguments, adding profiling and error r
 """
 
 import argparse
-from configparser import ConfigParser
-from pathlib import Path
 import subprocess
 import sys
+from configparser import ConfigParser
+from pathlib import Path
 
 import sentry_sdk
 from statsd import StatsClient
 
 DEFAULT_CONFIG_PATH = "/olsystem/etc/cron-wrapper.ini"
 
+
 class MonitoredJob:
     def __init__(self, command, sentry_cfg, statsd_cfg):
         self.command = command
-        self.statsd_client = self._setup_statsd(statsd_cfg.get("host", ""), statsd_cfg.get("port", "")) if statsd_cfg else None
+        self.statsd_client = (
+            self._setup_statsd(statsd_cfg.get("host", ""), statsd_cfg.get("port", ""))
+            if statsd_cfg
+            else None
+        )
         self._setup_sentry(sentry_cfg.get("dns", ""))
         self.job_name = self._get_job_name(command[0])
         self.job_failed = False
-
 
     def run(self):
         self._before_run()
@@ -45,19 +49,20 @@ class MonitoredJob:
             self.statsd_client.incr(f'cron.{self.job_name}.{status}')
 
     def _run_script(self):
-        return subprocess.run(self.command, text=True, stdout=sys.stdout, stderr=sys.stderr, check=True)
+        return subprocess.run(
+            self.command, text=True, stdout=sys.stdout, stderr=sys.stderr, check=True
+        )
 
     def _setup_sentry(self, dns):
-        sentry_sdk.init(
-            dns=dns,
-            trace_sample_rate=1.0  # Configure?
-        )
+        sentry_sdk.init(dns=dns, trace_sample_rate=1.0)  # Configure?
 
     def _setup_statsd(self, host, port):
         return StatsClient(host, port)
 
     def _get_job_name(self):
-        script_path = next(s for s in self.command if s.startswith("/openlibrary/scripts/"))
+        script_path = next(
+            s for s in self.command if s.startswith("/openlibrary/scripts/")
+        )
         script_name = script_path.split('/')[-1]
         job_name = script_name.split('.')[0]
         return job_name
@@ -87,11 +92,10 @@ def _parse_args():
         "-c",
         "--config",
         default=DEFAULT_CONFIG_PATH,
-        help=f"Path to cron-wrapper configuration file. Defaults to \"{DEFAULT_CONFIG_PATH}\""
+        help=f"Path to cron-wrapper configuration file. Defaults to \"{DEFAULT_CONFIG_PATH}\"",
     )
     _parser.add_argument(
-        "script",
-        help="Path to script that will be wrapped and monitored"
+        "script", help="Path to script that will be wrapped and monitored"
     )
     _parser.add_argument(
         "script_args",

--- a/scripts/cron_wrapper.py
+++ b/scripts/cron_wrapper.py
@@ -1,0 +1,109 @@
+"""
+Executes the given script with the given arguments, adding profiling and error reporting.
+"""
+
+import argparse
+from configparser import ConfigParser
+from pathlib import Path
+import subprocess
+import sys
+
+import sentry_sdk
+from statsd import StatsClient
+
+DEFAULT_CONFIG_PATH = "/olsystem/etc/cron-wrapper.ini"
+
+class MonitoredJob:
+    def __init__(self, command, sentry_cfg, statsd_cfg):
+        self.command = command
+        self.statsd_client = self._setup_statsd(statsd_cfg.get("host", ""), statsd_cfg.get("port", "")) if statsd_cfg else None
+        self._setup_sentry(sentry_cfg.get("dns", ""))
+        self.job_name = self._get_job_name(command[0])
+        self.job_failed = False
+
+
+    def run(self):
+        self._before_run()
+        try:
+            self._run_script()
+        except subprocess.CalledProcessError as e:
+            sentry_sdk.capture_exception(e)
+            self.job_failed = True
+        finally:
+            self._after_run()
+
+    def _before_run(self):
+        if self.statsd_client:
+            self.statsd_client.incr(f'cron.{self.job_name}.start')
+            self.job_timer = self.statsd_client.timer(f'cron.{self.job_name}.duration')
+            self.job_timer.start()
+
+    def _after_run(self):
+        if self.statsd_client:
+            self.job_timer.stop()
+            status = "failure" if self.job_failed else "stop"
+            self.statsd_client.incr(f'cron.{self.job_name}.{status}')
+
+    def _run_script(self):
+        return subprocess.run(self.command, text=True, stdout=sys.stdout, stderr=sys.stderr, check=True)
+
+    def _setup_sentry(self, dns):
+        sentry_sdk.init(
+            dns=dns,
+            trace_sample_rate=1.0  # Configure?
+        )
+
+    def _setup_statsd(self, host, port):
+        return StatsClient(host, port)
+
+    def _get_job_name(self):
+        script_path = next(s for s in self.command if s.startswith("/openlibrary/scripts/"))
+        script_name = script_path.split('/')[-1]
+        job_name = script_name.split('.')[0]
+        return job_name
+
+
+def main(args):
+    config = _read_config(args.config)
+    sentry_cfg = dict(config["sentry"]) if config.has_section("sentry") else None
+    statsd_cfg = dict(config["statsd"]) if config.has_section("statsd") else None
+    command = [args.script] + args.script_args
+
+    job = MonitoredJob(command, sentry_cfg, statsd_cfg)
+    job.run()
+
+
+def _read_config(config_path):
+    if not Path(config_path).exists():
+        raise FileNotFoundError("Missing cron-wrapper configuration file")
+    config_parser = ConfigParser()
+    config_parser.read(config_path)
+    return config_parser
+
+
+def _parse_args():
+    _parser = argparse.ArgumentParser(description=__doc__)
+    _parser.add_argument(
+        "-c",
+        "--config",
+        default=DEFAULT_CONFIG_PATH,
+        help=f"Path to cron-wrapper configuration file. Defaults to \"{DEFAULT_CONFIG_PATH}\""
+    )
+    _parser.add_argument(
+        "script",
+        help="Path to script that will be wrapped and monitored"
+    )
+    _parser.add_argument(
+        "script_args",
+        nargs="*",
+        help="Arguments for the wrapped script",
+    )
+    _parser.set_defaults(func=main)
+
+    return _parser
+
+
+if __name__ == '__main__':
+    parser = _parse_args()
+    args = parser.parse_args()
+    args.func(args)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Addresses #10206

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds a new script that will run a given script and arguments as a subprocess while adding additional monitoring:

1. Before the subprocess starts, a `statsd` `cron.{job_name}.start` count is incremented, and a `cron.{job_name}.duration` timer is started 
2. On subprocess error, the error is captured and sent to Sentry and a `cron.{job_name}.failure` count is incremented.  Also, the `cron.{job_name}.duration` timer is stopped and the duration is recorded.
3. On subprocess success, a `cron.{job_name}.stop` count is incremented and the `cron.{job_name}.duration` timer is stopped and the delta is recorded.

`job_name` is automatically set to be the wrapped script's name, with the file extension stripped off.

The subprocess's `STDOUT` and `STDERR` are forwarded to the wrapper script's respective `STDOUT` and `STDERR`.

This script requires a configuration file.  The path to this file can be set with the `-c` or `--config` option.  For example, the following command will use `/path/to/config.ini` as the wrapper's config file:

`python3 /openlibrary/scripts/cron_wrapper.py -c /path/to/config.ini /openlibrary/scripts/foo.py arg1 arg2`

### Special Deployment Instructions
Ensure that the linked `olsystem` PR is merged before this is deployed.  That branch contains a necessary configuration file.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
