### PR TITLE
Fix: disable doctest in format_languages()

### DIFF
--- a/openlibrary/catalog/utils/__init__.py
+++ b/openlibrary/catalog/utils/__init__.py
@@ -448,7 +448,7 @@ class InvalidLanguage(Exception):
 def format_languages(languages: Iterable) -> list[dict[str, str]]:
     """
     Format language data to match Open Library's expected format.
-    >>> format_languages(["eng", "fre"])
+    For an input of ["eng", "fre"], return:
     [{'key': '/languages/eng'}, {'key': '/languages/fre'}]
     """
     if not languages:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10356

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Hopefully this stops the doctests from failing.

### Technical
<!-- What should be noted about the implementation? -->
The doc tests are cursed:
```
450     Format language data to match Open Library's expected format.451
>>> format_languages(["eng", "fre"])UNEXPECTED EXCEPTION:
AttributeError("'ThreadedDict' object has no attribute 'site'")Traceback
(most recent call last):  File
"/opt/hostedtoolcache/Python/3.12.2/x64/lib/python3.12/doctest.py", line
1361, in __run    exec(compile(example.source, filename, "single",  File
"<doctest openlibrary.catalog.utils.format_languages[0]>", line 1, in
<module>  File
"/home/runner/work/openlibrary/openlibrary/openlibrary/catalog/utils/__init__.py",
line 459, in format_languages    if
web.ctx.site.get(f"/languages/{language.lower()}") is None:
^^^^^^^^^^^^AttributeError: 'ThreadedDict' object has no attribute
'site'
```

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
