### PR TITLE
Add post login action - follow

### DIFF
--- a/openlibrary/core/follows.py
+++ b/openlibrary/core/follows.py
@@ -1,6 +1,7 @@
 import logging
 from typing import cast
 
+from openlibrary.accounts import OpenLibraryAccount
 from openlibrary.core.bookshelves import Bookshelves
 from openlibrary.utils.dateutil import DATE_ONE_MONTH_AGO, DATE_ONE_WEEK_AGO
 
@@ -16,7 +17,8 @@ class PubSub:
     @classmethod
     def subscribe(cls, subscriber, publisher):
         oldb = db.get_db()
-        return oldb.insert(cls.TABLENAME, subscriber=subscriber, publisher=publisher)
+        if not cls.is_subscribed(subscriber, publisher):
+            return oldb.insert(cls.TABLENAME, subscriber=subscriber, publisher=publisher)
 
     @classmethod
     def unsubscribe(cls, subscriber, publisher):

--- a/openlibrary/core/follows.py
+++ b/openlibrary/core/follows.py
@@ -1,7 +1,6 @@
 import logging
 from typing import cast
 
-from openlibrary.accounts import OpenLibraryAccount
 from openlibrary.core.bookshelves import Bookshelves
 from openlibrary.utils.dateutil import DATE_ONE_MONTH_AGO, DATE_ONE_WEEK_AGO
 
@@ -18,7 +17,9 @@ class PubSub:
     def subscribe(cls, subscriber, publisher):
         oldb = db.get_db()
         if not cls.is_subscribed(subscriber, publisher):
-            return oldb.insert(cls.TABLENAME, subscriber=subscriber, publisher=publisher)
+            return oldb.insert(
+                cls.TABLENAME, subscriber=subscriber, publisher=publisher
+            )
 
     @classmethod
     def unsubscribe(cls, subscriber, publisher):

--- a/openlibrary/macros/Follow.html
+++ b/openlibrary/macros/Follow.html
@@ -14,5 +14,5 @@ $ subscriber = ctx.user and ctx.user.key
       <button type="submit" class="cta-btn cta-btn--$(css_treatment)">$_("Unfollow" if following else "Follow")</button>
     </form>
   $else:
-    <a class="cta-btn cta-btn--primary" href="/account/login?redir_url=$(ctx.path)">$_("Follow")</a>
+    <a class="cta-btn cta-btn--primary" href="/account/login?redir_url=$(ctx.path)&action=follow">$_("Follow")</a>
 </div>

--- a/openlibrary/macros/Follow.html
+++ b/openlibrary/macros/Follow.html
@@ -14,5 +14,5 @@ $ subscriber = ctx.user and ctx.user.key
       <button type="submit" class="cta-btn cta-btn--$(css_treatment)">$_("Unfollow" if following else "Follow")</button>
     </form>
   $else:
-    <a class="cta-btn cta-btn--primary" href="/account/login?redir_url=$(ctx.path)&action=follow">$_("Follow")</a>
+    <a class="cta-btn cta-btn--primary" href="/account/login?redir_url=$(ctx.path)&action=follow:$(publisher)">$_("Follow")</a>
 </div>

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -4,7 +4,7 @@ from collections.abc import Callable, Iterable, Mapping
 from datetime import datetime
 from math import ceil
 from typing import TYPE_CHECKING, Any, Final
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import urlparse
 
 import requests
 import web
@@ -414,14 +414,15 @@ class account_login(delegate.page):
         f.note = get_login_error(error_key)
         return render.login(f)
 
-
     def perform_post_login_action(self, i, ol_account):
         if i.action:
             op, args = i.action.split(":")
             if op == "follow" and args:
                 publisher = args
                 if publisher_account := OpenLibraryAccount.get_by_username(publisher):
-                    PubSub.subscribe(subscriber=ol_account.username, publisher=publisher)
+                    PubSub.subscribe(
+                        subscriber=ol_account.username, publisher=publisher
+                    )
 
                     publisher_name = publisher_account["data"]["displayname"]
                     flash_message = f"You are now following {publisher_name}!"

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -4,7 +4,7 @@ from collections.abc import Callable, Iterable, Mapping
 from datetime import datetime
 from math import ceil
 from typing import TYPE_CHECKING, Any, Final
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import parse_qs, urlparse
 
 import requests
 import web
@@ -415,16 +415,15 @@ class account_login(delegate.page):
         return render.login(f)
 
     def get_post_login_action(self, web, referer):
-        """Extract the 'action' parameter from the query string. 
-            Return the action if it is valid, else return None
+        """Extract the 'action' parameter from the query string.
+        Return the action if it is valid, else return None
         """
         allowed_actions = ["follow"]
         if not referer:
             return None
         qs = web.ctx.env.get('QUERY_STRING', "")
         parsed_query = parse_qs(qs)
-        action = parsed_query.get("action", [None])[0]
-        if action in allowed_actions:
+        if (action := parsed_query.get("action", [None])[0]) in allowed_actions:
             return action
         return None
 
@@ -444,7 +443,7 @@ class account_login(delegate.page):
         if not OpenLibraryAccount.get_by_username(publisher):
             return None
 
-        # Check is user has already following the publisher 
+        # Check is user has already following the publisher
         if PubSub.is_subscribed(subscriber=ol_account.username, publisher=publisher):
             flash_message = "You are already following this user!"
         else:
@@ -515,8 +514,7 @@ class account_login(delegate.page):
         ]
 
         # Processing post login action
-        flash_message = self.perform_post_login_action(i, ol_account)
-        if flash_message:
+        if flash_message := self.perform_post_login_action(i, ol_account):
             add_flash_message('note', _(flash_message))
 
         if i.redirect == "" or any(path in i.redirect for path in blacklist):

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -6,10 +6,9 @@ from math import ceil
 from typing import TYPE_CHECKING, Any, Final
 from urllib.parse import parse_qs, urlparse
 
+import infogami.core.code as core  # noqa: F401 side effects may be needed
 import requests
 import web
-
-import infogami.core.code as core  # noqa: F401 side effects may be needed
 from infogami import config
 from infogami.infobase.client import ClientException
 from infogami.utils import delegate
@@ -19,6 +18,7 @@ from infogami.utils.view import (
     render_template,
     require_login,
 )
+
 from openlibrary import accounts
 from openlibrary.accounts import (
     InternetArchiveAccount,

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -6,9 +6,10 @@ from math import ceil
 from typing import TYPE_CHECKING, Any, Final
 from urllib.parse import parse_qs, urlparse
 
-import infogami.core.code as core  # noqa: F401 side effects may be needed
 import requests
 import web
+
+import infogami.core.code as core  # noqa: F401 side effects may be needed
 from infogami import config
 from infogami.infobase.client import ClientException
 from infogami.utils import delegate
@@ -18,7 +19,6 @@ from infogami.utils.view import (
     render_template,
     require_login,
 )
-
 from openlibrary import accounts
 from openlibrary.accounts import (
     InternetArchiveAccount,

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -439,7 +439,9 @@ class account_login(delegate.page):
             return None
 
         # Check is user has already following the publisher
-        if not PubSub.is_subscribed(subscriber=ol_account.username, publisher=publisher):
+        if not PubSub.is_subscribed(
+            subscriber=ol_account.username, publisher=publisher
+        ):
             PubSub.subscribe(subscriber=ol_account.username, publisher=publisher)
 
         publisher_name = publisher_info["data"]["displayname"]

--- a/openlibrary/plugins/upstream/forms.py
+++ b/openlibrary/plugins/upstream/forms.py
@@ -32,7 +32,7 @@ Login = Form(
     Textbox('username', description=_('Username'), klass='required'),
     Password('password', description=_('Password'), klass='required'),
     Hidden('redirect'),
-    Hidden('action')
+    Hidden('action'),
 )
 forms.login = Login
 

--- a/openlibrary/plugins/upstream/forms.py
+++ b/openlibrary/plugins/upstream/forms.py
@@ -32,6 +32,7 @@ Login = Form(
     Textbox('username', description=_('Username'), klass='required'),
     Password('password', description=_('Password'), klass='required'),
     Hidden('redirect'),
+    Hidden('action')
 )
 forms.login = Login
 

--- a/openlibrary/templates/login.html
+++ b/openlibrary/templates/login.html
@@ -70,6 +70,7 @@ $if "dev" in ctx.features:
             </div>
 
             <input type="hidden" id="redirect" value="$form.redirect.value" name="redirect" />
+            <input type="hidden" id="action" value="$form.action.value" name="action" />
             <input type="hidden" id="debug_token" value="" name="debug_token"/>
 
             <div class="formElement bottom">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10338

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR is a `feature`

### Technical
<!-- What should be noted about the implementation? -->
Currently, the website does not allow users to follow a publisher if they are not logged in. After logging in, the user must manually return to the publisher's profile to follow them.

With this PR, the follow operation will be handled by the backend.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
To test this, go to any user profile and try to follow them while logged out. You will be redirected to the login page, and after logging in, the backend will automatically complete the follow operation for you and display a flash message.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Before:

https://github.com/user-attachments/assets/ecbe24b8-719e-4091-a1b9-cf9aed49da9c

After:

https://github.com/user-attachments/assets/67138661-6a21-4660-8b6b-18965db6ed71

Already following: 

https://github.com/user-attachments/assets/d2a10ff7-ed7f-45b4-899f-cd2182b71665


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
