### PR TITLE
Add "Preview" link beneath bookcover on Search Result Cards

### DIFF
--- a/openlibrary/macros/BookPreview.html
+++ b/openlibrary/macros/BookPreview.html
@@ -1,11 +1,13 @@
-$def with (ocaid, analytics_attr, show_only=False)
+$def with (ocaid, analytics_attr=None, show_only=False)
 $# :param str ocaid:
+
+$ analytics = analytics_attr('Preview') if analytics_attr else "CTAClick|Preview"
 
   <div class="cta-button-group">
     <a class="cta-btn cta-btn--preview"
       data-iframe-src="https://archive.org/details/$ocaid?view=theater&wrapper=false"
-      data-iframe-link="https://archive.org/details/$ocaid"
-      $:analytics_attr('Preview') href="#bookPreview">$(_('Preview Only') if show_only else _('Preview'))</a>
+      data-iframe-link="https://archive.org/details/$ocaid"   
+      $:analytics href="#bookPreview">$(_('Preview Only') if show_only else _('Preview'))</a>
   </div>
 
 $if render_once('book-preview-floater'):

--- a/openlibrary/macros/BookPreview.html
+++ b/openlibrary/macros/BookPreview.html
@@ -2,10 +2,10 @@ $def with (ocaid, analytics_attr=None, show_only=False, vanilla=True)
 $# :param str ocaid:
 
 $ analytics = analytics_attr('Preview') if analytics_attr else "CTAClick|Preview"
-$ button = "cta-btn cta-btn--preview" if vanilla else "cta-btn--preview-link"
+$ button = "cta-btn--preview" if vanilla else "cta-btn--preview-link"
 
   <div class="cta-button-group">
-    <a class="$button"
+    <a class="cta-btn $button"
       data-iframe-src="https://archive.org/details/$ocaid?view=theater&wrapper=false"
       data-iframe-link="https://archive.org/details/$ocaid"   
       $:analytics href="#bookPreview">$(_('Preview Only') if show_only else _('Preview'))</a>

--- a/openlibrary/macros/BookPreview.html
+++ b/openlibrary/macros/BookPreview.html
@@ -1,10 +1,11 @@
-$def with (ocaid, analytics_attr=None, show_only=False)
+$def with (ocaid, analytics_attr=None, show_only=False, vanilla=True)
 $# :param str ocaid:
 
 $ analytics = analytics_attr('Preview') if analytics_attr else "CTAClick|Preview"
+$ button = "cta-btn cta-btn--preview" if vanilla else "cta-btn--preview-link"
 
   <div class="cta-button-group">
-    <a class="cta-btn cta-btn--preview"
+    <a class="$button"
       data-iframe-src="https://archive.org/details/$ocaid?view=theater&wrapper=false"
       data-iframe-link="https://archive.org/details/$ocaid"   
       $:analytics href="#bookPreview">$(_('Preview Only') if show_only else _('Preview'))</a>

--- a/openlibrary/macros/BookPreview.html
+++ b/openlibrary/macros/BookPreview.html
@@ -7,7 +7,7 @@ $ button = "cta-btn--preview" if vanilla else "cta-btn--preview-link"
   <div class="cta-button-group">
     <a class="cta-btn $button"
       data-iframe-src="https://archive.org/details/$ocaid?view=theater&wrapper=false"
-      data-iframe-link="https://archive.org/details/$ocaid"   
+      data-iframe-link="https://archive.org/details/$ocaid"
       $:analytics href="#bookPreview">$(_('Preview Only') if show_only else _('Preview'))</a>
   </div>
 

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -126,8 +126,8 @@ $elif availability.get('is_lendable'):
       >$_("Checked Out")</a>
     </div>
 
-$elif ocaid and availability.get('is_previewable') and book_provider.short_name == 'ia':
-  $:macros.BookPreview(ocaid, analytics_attr, show_only=True)
+$elif True:
+  $:macros.BookPreview(ocaid,show_only=True, vanilla=False)
   $if secondary_action:
       $:macros.BookSearchInside(ocaid)
 

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -1,5 +1,8 @@
 $def with (doc, decorations=None, cta=True, availability=None, extra=None, attrs=None, rating=None, show_librarian_extras=False, include_dropper=False, blur=False, footer=None)
 
+$ availability = (doc.availability or {}) if hasattr(doc, 'availability') else {}
+$ ocaid = doc.get('ocaid') or availability.get('identifier')
+
 $code:
   max_rendered_authors = 9
   doc_type = (
@@ -58,6 +61,7 @@ $code:
               alt="$_('Cover of: %(title)s', title=full_title)"
               title="$_('Cover of: %(title)s', title=full_title)"
       /></a>
+      $:macros.BookPreview(ocaid,show_only=False)
     </span>
 
     <div class="details">

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -61,7 +61,7 @@ $code:
               alt="$_('Cover of: %(title)s', title=full_title)"
               title="$_('Cover of: %(title)s', title=full_title)"
       /></a>
-      $:macros.BookPreview(ocaid,show_only=False)
+      $:macros.BookPreview(ocaid,show_only=False, vanilla=False)
     </span>
 
     <div class="details">

--- a/openlibrary/plugins/openlibrary/js/dialog.js
+++ b/openlibrary/plugins/openlibrary/js/dialog.js
@@ -51,7 +51,7 @@ function initConfirmationDialogs() {
 
 export function initPreviewDialogs() {
     // Colorbox modal + iframe for Book Preview Button
-    const $buttons = $('.cta-btn--preview');
+    const $buttons = $('.cta-btn--preview, .cta-btn--preview-link');
     $buttons.each((i, button) => {
         const $button = $(button);
         $button.colorbox({

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -363,7 +363,7 @@ jQuery(function () {
     }
 
     // TODO: Make these selectors a consistent interface
-    const $dialogs = $('.dialog--open,.dialog--close,#noMaster,#confirmMerge,#leave-waitinglist-dialog,.cta-btn--preview');
+    const $dialogs = $('.dialog--open,.dialog--close,#noMaster,#confirmMerge,#leave-waitinglist-dialog,.cta-btn--preview,.cta-btn--preview-link');
     if ($dialogs.length) {
         import(/* webpackChunkName: "dialog" */ './dialog')
             .then(module => module.initDialogs())

--- a/static/css/components/read-panel.less
+++ b/static/css/components/read-panel.less
@@ -14,6 +14,45 @@
   display: none;
 }
 
+.cta-btn--preview-link {
+  color: @primary-blue;
+  text-decoration: none;
+  position: relative;
+  margin-top: -15px; // offsets Illustration margin-bottom: 10px
+  margin-bottom: 5px;
+  padding: 5px 20px 10px; // Increasing click area for mobile text link
+  background-color: transparent;
+
+  // When Preview button is a text link, have it take up only the width
+  // of the content (not full 100% width)
+  flex-basis: content;
+  flex-grow: 0;
+  width: auto;
+
+  /* stylelint-disable selector-max-specificity */
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &::before {
+    width: 22px;
+    height: 18px;
+    display: inline-block;
+    margin-right: 6px;
+    position: relative;
+    top: 2px;
+
+    // Setting pseudo-element content to book icon; mask is used to allow for a 'fill' color
+    content: "";
+    -webkit-mask: url(../images/icons/open-book.svg);
+    mask: url(../images/icons/open-book.svg);
+    -webkit-mask-size: cover;
+    mask-size: cover;
+    background-color: @primary-blue;
+  }
+  /* stylelint-enable selector-max-specificity */
+}
+
 .read-options,
 .Tools .btn-notice {
   font-size: 1em;


### PR DESCRIPTION
**What issue does this PR address?**
Addresses #10199

**What does this PR achieve?**
**Feature:** Added a preview button on the search result cards.

The button is visible on all the books because it hasn't been fully integrated with the ocaid availability condition yet. This will be added once the rest of the work is completed.

![Screenshot from 2025-01-20 01-26-45](https://github.com/user-attachments/assets/753a140e-9537-4c16-91e0-2ecfe100389e)

**Next Steps:**
- Address styling concerns, particularly regarding the vanilla=true argument to adjust the button to use the book page style instead of the default.
- analytics for tracking preview button clicks from search result cards (v. books page)
- Add the condition for ocaid availability to properly display the button only when conditions are met.

**Note:**
This is a Draft pull request to discuss further steps.

**Stakeholders:**
@mekarpeles

Let me know if this works, so I can go ahead and implement the next steps.