### PR TITLE
Use as-is name of nonstandard identifier for IdentifiersInput

### DIFF
--- a/openlibrary/components/IdentifiersInput.vue
+++ b/openlibrary/components/IdentifiersInput.vue
@@ -29,7 +29,7 @@
     </tr>
       <template v-for="(value, name) in assignedIdentifiers">
         <tr :key="name" v-if="value && !saveIdentifiersAsList">
-          <td>{{ identifierConfigsByKey[name].label }}</td>
+          <td>{{ identifierConfigsByKey[name] ? identifierConfigsByKey[name].label : name }}</td>
           <td>{{ value }}</td>
           <td>
             <button class="form-control" @click="removeIdentifier(name)">Remove</button>
@@ -37,7 +37,7 @@
         </tr>
         <template v-else-if="value && saveIdentifiersAsList">
           <tr v-for="(item, idx) in value" :key="name + idx">
-            <td>{{ identifierConfigsByKey[name].label }}</td>
+            <td>{{ identifierConfigsByKey[name] ? identifierConfigsByKey[name].label : name }}</td>
             <td>{{ item }}</td>
             <td v-if="!isAdmin">
               <button v-if="name !== 'ocaid'" class="form-control" @click="removeIdentifier(name, idx)">Remove</button>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10367 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix

### Technical
<!-- What should be noted about the implementation? -->
Checks if an assigned identifier's name exists in `identifierConfigsByKey` and uses the unaltered name if not found.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Sign as OpenLibrary dev, find a book that already has identifiers and click on the edit button
2. Open your browser's developer console and modify an edition/work identifier name using JavaScript. The name value should be changed into one that is not already present within `identifiers.yml`

    - `document.querySelector('#hiddenWorkIdentifiers :nth-last-child(2)').value = "non-existent work identifier"`


3. Press save, verify that the name chosen in step 3 appears in the details section.
4. Click on edit again and scroll down to the ID numbers section. The dropdown menu and assigned identifiers should be visible
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/user-attachments/assets/e05da708-dad4-4727-b185-45055f8999d0)
![image](https://github.com/user-attachments/assets/6c1c2173-651f-41e6-95ab-e300be73534b)
![image](https://github.com/user-attachments/assets/697a3107-c4ae-4021-b0ce-254aa4e143c6)



### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
