### PR TITLE
Add support for author parameter to recentchanges/YEAR endpoint

### DIFF
--- a/openlibrary/plugins/upstream/recentchanges.py
+++ b/openlibrary/plugins/upstream/recentchanges.py
@@ -61,7 +61,7 @@ class index(delegate.page):
         return render_template("recentchanges/index", query)
 
     def handle_encoding(self, query, encoding):
-        i = web.input(bot="", limit=100, offset=0, text="false")
+        i = web.input(bot="", limit=100, offset=0, text="false", author="")
 
         # The bot stuff is handled in the template for the regular path.
         # We need to handle it here for api.
@@ -69,6 +69,10 @@ class index(delegate.page):
             query['bot'] = True
         elif i.bot.lower() == "false":
             query['bot'] = False
+
+        # Handle author query parameter
+        if i.author:
+            query['author'] = i.author
 
         # and limit and offset business too
         limit = safeint(i.limit, 100)


### PR DESCRIPTION
Small endpoint tweak to support gathering some tocky stats. `/recentchanges.json` supports the author field ([eg](https://openlibrary.org/recentchanges.json?author=/people/ScarTissue&limit=10)), but if you also specify the date prefix, eg `2025/01`, it will not support the author prefix. Extend the `/recentchanges/DATE` endpoint to also support the author parameter.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
- https://testing.openlibrary.org/recentchanges/2025/01.json?limit=1000&offset=0&author=/people/ScarTissue now works!

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
