### PR TITLE
Switched cover importing IA endpoint

### DIFF
--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -115,6 +115,15 @@ def edition_from_item_metadata(itemid, metadata):
 
 
 def get_cover_url(item_id):
+    """Gets the URL of the archive.org item's cover page."""
+    base_url = f'{IA_BASE_URL}/services/img/{item_id}/full/pct:600/0/'
+    cover_response = requests.head(base_url + 'default.jpg', allow_redirects=True)
+    if cover_response.status_code == 404:
+        return get_fallback_cover_url(item_id)
+    return base_url + 'default.jpg'
+
+
+def get_fallback_cover_url(item_id):
     """Gets the URL of the archive.org item's title (or cover) page."""
     base_url = f'{IA_BASE_URL}/download/{item_id}/page/'
     title_response = requests.head(base_url + 'title.jpg', allow_redirects=True)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7616

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

### Technical
<!-- What should be noted about the implementation? -->
The cover importing IA endpoint has been changed.
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Go to any book's page.
2. Click on the "Add Cover Image" option.
3. Hover your mouse pointer on the cover imported from the Internet Archive.
4. If you see the url of the image beginning from ```archive.org/services/img```, the code works as expected.
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/user-attachments/assets/6166c1ca-0003-4fbd-8ec0-a804f7635206)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@scottbarnes 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
