### PR TITLE
Fixed rendering of ISBN to phone numer in Safari

### DIFF
--- a/openlibrary/templates/site/head.html
+++ b/openlibrary/templates/site/head.html
@@ -3,6 +3,7 @@ $def with (page)
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="$(get_lang() or 'en')">
 <head>
+    <meta name="format-detection" content="telephone=no">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="title" content="" />
     <meta name="keywords" content="free books, books to read, free ebooks, audio books, read books for free, read books online, online library">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10364 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes the wrong rendering of ISBNs (and possibly other ID numbers) as phone number on Safari for iOS.

### Technical
<!-- What should be noted about the implementation? -->
A simple `<meta name="format-detection" content="telephone=no">` was added to the `templates/site/head.html`.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/user-attachments/assets/61cd3893-d011-4546-a4d8-0151532ca037)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@jimchamp @mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
