### PR TITLE
Fix copy authors/subjects when moving edition to new work

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -617,10 +617,7 @@ class SaveBookHelper:
                     },
                 )
 
-                if (
-                    new_work_options.get('copy_authors') == 'yes'
-                    and 'authors' in self.work
-                ):
+                if new_work_options.get('copy_authors') == 'yes' and self.work.authors:
                     new_work.authors = self.work.authors
                 if new_work_options.get('copy_subjects') == 'yes':
                     for field in (
@@ -629,8 +626,8 @@ class SaveBookHelper:
                         'subject_times',
                         'subject_people',
                     ):
-                        if field in self.work:
-                            new_work[field] = self.work[field]
+                        if val := getattr(self.work, field, None):
+                            new_work[field] = val
 
                 self.work = new_work
                 saveutil.save(self.work)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10193 


### Technical

This was a bit tricky to test, since it only happens on prod/testing. I think it's something to do with `self.work` being a lazy `Thing`, and hence not having any fields. I believe these lazy `Thing`s aren't fetch from the db until data is requests from via `__getattr__` or other methods (see https://github.com/internetarchive/infogami/blob/f9538c06003361ea22b0d23f278bee10250139e2/infogami/infobase/client.py#L901-L917 ).

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
I put these changes on testing and confirmed they work there :+1:  Tested copying just authors, authors and subjects, and just subjects. All worked now!

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
