### PR TITLE
Expose account creation `xauthn` response to Sentry

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -689,9 +689,9 @@ class InternetArchiveAccount(web.storage):
                 return ia_account
 
             elif 'screenname' not in response.get('values', {}):
-                err = OLAuthenticationError('undefined_error')
-                err.response = response
-                raise err
+                error = OLAuthenticationError('undefined_error')
+                error.response = response
+                raise error
 
             elif attempt >= retries:
                 e = OLAuthenticationError('username_registered')

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -689,7 +689,11 @@ class InternetArchiveAccount(web.storage):
                 return ia_account
 
             elif 'screenname' not in response.get('values', {}):
-                raise OLAuthenticationError('undefined_error')
+                from openlibrary.plugins.openlibrary.sentry import sentry
+                err = OLAuthenticationError('undefined_error')
+                if sentry.enabled:
+                    sentry.capture_exception(err, extra=('response', response))
+                raise err
 
             elif attempt >= retries:
                 e = OLAuthenticationError('username_registered')

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -689,10 +689,8 @@ class InternetArchiveAccount(web.storage):
                 return ia_account
 
             elif 'screenname' not in response.get('values', {}):
-                from openlibrary.plugins.openlibrary.sentry import sentry
                 err = OLAuthenticationError('undefined_error')
-                if sentry.enabled:
-                    sentry.capture_exception(err, extra=('response', response))
+                err.response = response
                 raise err
 
             elif attempt >= retries:

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -328,7 +328,8 @@ class account_create(delegate.page):
                 from openlibrary.plugins.openlibrary.sentry import sentry
 
                 if sentry.enabled:
-                    sentry.capture_exception(e)
+                    extra = ('response', e.response) if hasattr(e, 'response') else None
+                    sentry.capture_exception(e, extra=extra)
 
         return render['account/create'](f)
 

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -328,8 +328,8 @@ class account_create(delegate.page):
                 from openlibrary.plugins.openlibrary.sentry import sentry
 
                 if sentry.enabled:
-                    extra = ('response', e.response) if hasattr(e, 'response') else None
-                    sentry.capture_exception(e, extra=extra)
+                    extra = {'response': e.response} if hasattr(e, 'response') else None
+                    sentry.capture_exception(e, extras=extra)
 
         return render['account/create'](f)
 

--- a/openlibrary/utils/sentry.py
+++ b/openlibrary/utils/sentry.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from dataclasses import dataclass
-from typing import Any
+from typing import Optional
 
 import sentry_sdk
 import web
@@ -88,10 +88,11 @@ class Sentry:
             scope.add_event_processor(add_web_ctx_to_event)
             sentry_sdk.capture_exception()
 
-    def capture_exception(self, ex, extra: tuple[str, Any]=None):
+    def capture_exception(self, ex, extras: Optional[dict]=None):
         with sentry_sdk.push_scope() as scope:
-            if extra:
-                scope.set_extra(extra[0], extra[1])
+            if extras:
+                for key, value in extras.items():
+                    scope.set_extra(key, value)
             scope.add_event_processor(add_web_ctx_to_event)
             sentry_sdk.capture_exception(ex)
 

--- a/openlibrary/utils/sentry.py
+++ b/openlibrary/utils/sentry.py
@@ -1,7 +1,6 @@
 import logging
 import re
 from dataclasses import dataclass
-from typing import Optional
 
 import sentry_sdk
 import web
@@ -88,7 +87,7 @@ class Sentry:
             scope.add_event_processor(add_web_ctx_to_event)
             sentry_sdk.capture_exception()
 
-    def capture_exception(self, ex, extras: Optional[dict]=None):
+    def capture_exception(self, ex, extras: dict | None = None):
         with sentry_sdk.push_scope() as scope:
             if extras:
                 for key, value in extras.items():

--- a/openlibrary/utils/sentry.py
+++ b/openlibrary/utils/sentry.py
@@ -1,6 +1,7 @@
 import logging
 import re
 from dataclasses import dataclass
+from typing import Any
 
 import sentry_sdk
 import web
@@ -87,8 +88,10 @@ class Sentry:
             scope.add_event_processor(add_web_ctx_to_event)
             sentry_sdk.capture_exception()
 
-    def capture_exception(self, ex):
+    def capture_exception(self, ex, extra: tuple[str, Any]=None):
         with sentry_sdk.push_scope() as scope:
+            if extra:
+                scope.set_extra(extra[0], extra[1])
             scope.add_event_processor(add_web_ctx_to_event)
             sentry_sdk.capture_exception(ex)
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10380

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Logs `xauthn` response to Sentry whenever an `undefined_error` `OLAuthenticationError` is raised during account creation.

The `response` will be in the ["Additional Data"](https://sentry.archive.org/organizations/ia-ux/issues/541313/?environment=ol-dev&query=is%3Aunresolved&referrer=issue-stream#extra) section of such error logs. 

### Technical
<!-- What should be noted about the implementation? -->
Due to a maximum of ten fields per error stack frame limit in Sentry, the `response` had to be added to the "Additional Details" section.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
