### PR TITLE
add webp support to coverstore

### DIFF
--- a/openlibrary/plugins/upstream/covers.py
+++ b/openlibrary/plugins/upstream/covers.py
@@ -29,7 +29,7 @@ def setup():
 class image_validator:
     def __init__(self):
         self.max_file_size = 10 * 1024 * 1024  # 10 MB
-        self.allowed_extensions = {'.jpg', '.jpeg', '.gif', '.png'}
+        self.allowed_extensions = {'.jpg', '.jpeg', '.gif', '.png', '.webp'}
 
     def validate_size(self, file_data):
         file_size = len(file_data.read())

--- a/openlibrary/templates/covers/add.html
+++ b/openlibrary/templates/covers/add.html
@@ -49,7 +49,7 @@ $if doc.type.key == "/type/work":
         <label for="coverFile">$_("Choose a JPG, GIF or PNG on your computer")</label>
     </div>
     <div class="input">
-        <input type="file" name="file" id="coverFile" value="" accept=".jpg, .jpeg, .gif, .png" required/>
+        <input type="file" name="file" id="coverFile" value="" accept=".jpg, .jpeg, .gif, .png, .webp" required/>
         <button type="submit" class="cta-btn cta-btn--vanilla">$_("Upload")</button>
     </div>
 </form>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Part of #7250

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Turns out with PIL webp just works. No changes needed other than allowing the format.

Unfortunately, AVIF support just isn't there yet :/
https://github.com/python-pillow/Pillow/issues/7983 


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Upload a cover that's webp, like: https://www.gstatic.com/webp/gallery/1.webp

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
