### PR TITLE
Ensure that context is loaded before caching waitlist

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -655,6 +655,9 @@ def get_user_waiting_loans(user_key):
     """
     from .waitinglist import WaitingLoan
 
+    if "site" not in web.ctx:
+        delegate.fakeload()
+
     try:
         account = OpenLibraryAccount.get(key=user_key)
         itemname = account.itemname


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Related to #10341

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Seems to correct our most frequently logged [error](https://sentry.archive.org/organizations/ia-ux/issues/366884/events/?project=7&referrer=issue-stream&sort=freq&statsPeriod=14d) in Sentry.

Updates code such that `delegate.fakeload()` is called if `web.ctx.site` is not ready before a patron's waiting list is cached.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
