### PR TITLE
Fixed The  Clipping of heading titles in 'merges' page

### DIFF
--- a/static/css/components/merge-request-table.less
+++ b/static/css/components/merge-request-table.less
@@ -32,7 +32,7 @@
   background-color: @grey-f4f4f4;
   font-size: 13px;
   box-sizing: border-box;
-  padding-left: 41px;
+  padding-left: 15px;
   padding-right: 27px;
 
   a {
@@ -64,7 +64,7 @@
   position: absolute;
   z-index: @z-index-level-1;
   height: 275px;
-  width: 296px;
+  width: 269px;
   background: @white;
   border: 1px solid @light-grey;
   box-shadow: 0 4px 4px @light-mid-grey, 0 4px 4px @light-mid-grey;
@@ -73,6 +73,7 @@
   font-size: 13px;
   cursor: default;
   overflow: auto;
+  transform: translateX(-195px);
 
   .dropdown-header {
     display: flex;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10386

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix

### Technical
<!-- What should be noted about the implementation? -->
This PR addresses the issue by resolving The Clipping of heading title's in "Merge" Page
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Pull this branch locally.
2. Start the development server using `make up`.
3. Navigate to [affected part of the app].
4. Verify that the bug described in #10386 no longer occurs.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/user-attachments/assets/2d626974-1ffc-4455-9058-691d26dece02)