### PR TITLE
perf(carousel): reduce Solr load via lazy loading Related Books Carousels (dev-mohit06)

### DIFF
--- a/openlibrary/plugins/openlibrary/js/carousels_partials.js
+++ b/openlibrary/plugins/openlibrary/js/carousels_partials.js
@@ -1,29 +1,66 @@
 import {Carousel} from './carousel/Carousel';
 
 export function initCarouselsPartials() {
+    const carousels = document.querySelectorAll('.RelatedWorksCarousel');
 
-    const fetchRelatedWorks = function() {
+    const fetchRelatedWorks = function(carouselElement) {
+        const loadingIndicator = carouselElement.querySelector('.loadingIndicator.carousel-loading');
+        loadingIndicator.classList.remove('hidden');
+
         $.ajax({
             url: '/partials.json',
             type: 'GET',
             data: {
-                workid: $('.RelatedWorksCarousel').data('workid'),
+                workid: carouselElement.dataset.workid,
                 _component: 'RelatedWorkCarousel'
             },
             datatype: 'json',
             success: function (response) {
-                $('.loadingIndicator.carousel-loading').addClass('hidden');
-                if (response){
-                    response = JSON.parse(response)
-                    $('.RelatedWorksCarousel').append(response[0]);
-                    $('.RelatedWorksCarousel .carousel--progressively-enhanced')
-                        .each((_i, el) => new Carousel($(el)).init());
+                loadingIndicator.classList.add('hidden');
+                if (response) {
+                    response = JSON.parse(response);
+                    carouselElement.insertAdjacentHTML('beforeend', response[0]);
+                    carouselElement.querySelectorAll('.carousel--progressively-enhanced')
+                        .forEach(el => new Carousel($(el)).init());
                 }
             }
         });
     };
 
-    $('.loadingIndicator.carousel-loading').removeClass('hidden');
+    // Fallback for browsers without Intersection Observer
+    const fallbackLoadCarousels = () => {
+        carousels.forEach(carousel => fetchRelatedWorks(carousel));
+    };
 
-    fetchRelatedWorks();
+    // Check if Intersection Observer is supported
+    if ('IntersectionObserver' in window) {
+        const observerOptions = {
+            root: null,
+            rootMargin: '200px',
+            threshold: 0
+        };
+
+        const observerCallback = (entries, observer) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    fetchRelatedWorks(entry.target);
+                    observer.unobserve(entry.target);
+                }
+            });
+        };
+
+        const observer = new IntersectionObserver(observerCallback, observerOptions);
+
+        carousels.forEach(carousel => {
+            // Handle anchor link navigation
+            if (window.location.hash && window.location.hash === `#${carousel.id}`) {
+                fetchRelatedWorks(carousel);
+            } else {
+                observer.observe(carousel);
+            }
+        });
+    } else {
+        // Fallback for older browsers
+        fallbackLoadCarousels();
+    }
 }


### PR DESCRIPTION
## Reduce Solr Load via Lazy Loading Related Books Carousels (dev-mohit06)

<!-- What issue does this PR close? -->
Closes #10354

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
### Performance Optimization
Implement lazy loading for Related Books Carousels to reduce unnecessary Solr API calls and improve page load performance.

### Technical
- Used Intersection Observer API for viewport-based loading
- Added fallback mechanism for browsers without Intersection Observer support
- Modified `carousels_partials.js` to fetch carousel data only when visible
- Minimal changes to existing carousel initialization logic

### Testing
1. Open book pages with Related Books Carousels
2. Verify carousels do not load immediately on page load
3. Scroll to trigger carousel loading
4. Check browser network tab for reduced initial API calls
5. Test anchor link navigation to carousels
6. Verify functionality in browsers with and without Intersection Observer

### Screenshot
*No UI changes - performance optimization*

### Stakeholders
@RayBB @mekarpeles

### Attribution
Code implementation based on recommended approach in issue discussion.