### PR TITLE
fixed overlapping of logo in 'merges' page

### DIFF
--- a/static/css/components/merge-request-table.less
+++ b/static/css/components/merge-request-table.less
@@ -164,6 +164,7 @@
   td {
     vertical-align: top;
     padding: 1%;
+    width: auto;
   }
 }
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10337

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR aims to fix the buggy  UI on '/merges' page

### Technical
<!-- What should be noted about the implementation? -->
Visit https://openlibrary.org/merges
Click on the icon and see the overlapping issue

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Video of solution:

https://github.com/user-attachments/assets/2dc49fd3-bfd5-4f74-a966-ee4abce691ea



### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
