### PR TITLE
remove unneeded scoped styles from vue

### DIFF
--- a/openlibrary/components/LibraryExplorer/components/CSSBox.vue
+++ b/openlibrary/components/LibraryExplorer/components/CSSBox.vue
@@ -80,7 +80,7 @@ export default {
 };
 </script>
 
-<style scoped>
+<style>
 .css-box {
   position: relative;
   /* Performance optimization, since the size of the css-box is independent of any of its children */

--- a/openlibrary/components/LibraryExplorer/components/FlatBookCover.vue
+++ b/openlibrary/components/LibraryExplorer/components/FlatBookCover.vue
@@ -69,7 +69,7 @@ export default {
 };
 </script>
 
-<style scoped>
+<style>
 div.cover {
   height: 100%;
   padding: 5px;

--- a/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
+++ b/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
@@ -252,7 +252,7 @@ export default {
 </script>
 
 
-<style scoped>
+<style>
 .load-books {
   width: 100%;
   height: 50px;

--- a/openlibrary/components/MergeUI/MergeRowField.vue
+++ b/openlibrary/components/MergeUI/MergeRowField.vue
@@ -122,7 +122,7 @@ export default {
 };
 </script>
 
-<style scoped>
+<style>
 .cover img {
   min-height: 80px; /* Min Height added for lazy loading so that the lazy loaded images are not 1 pixel and start having many books start loading */
   height: auto; /* Maintain aspect ratio */

--- a/openlibrary/components/MergeUI/TextDiff.vue
+++ b/openlibrary/components/MergeUI/TextDiff.vue
@@ -32,7 +32,7 @@ export default {
 }
 </script>
 
-<style scoped>
+<style>
 .value { background: rgba(0,0,255, .1); }
 .added { color: green; background: rgba(0,255,0, .1); }
 .removed { color: red; text-decoration: line-through; background: rgba(255,0,0, .1); user-select: none; }

--- a/openlibrary/components/ObservationForm.vue
+++ b/openlibrary/components/ObservationForm.vue
@@ -162,7 +162,7 @@ export default {
 }
 </script>
 
-<style scoped>
+<style>
 .observation-form {
   padding: .5em;
 }

--- a/openlibrary/components/ObservationForm/components/CardBody.vue
+++ b/openlibrary/components/ObservationForm/components/CardBody.vue
@@ -140,7 +140,7 @@ export default {
 }
 </script>
 
-<style scoped>
+<style>
 .card-body {
   display: flex;
   flex-wrap: wrap;

--- a/openlibrary/components/ObservationForm/components/CardHeader.vue
+++ b/openlibrary/components/ObservationForm/components/CardHeader.vue
@@ -19,7 +19,7 @@ export default {
 }
 </script>
 
-<style scoped>
+<style>
 .card-header {
   border-bottom: 1px solid #999;
   margin: 1em;

--- a/openlibrary/components/ObservationForm/components/CategorySelector.vue
+++ b/openlibrary/components/ObservationForm/components/CategorySelector.vue
@@ -129,7 +129,7 @@ export default {
 }
 </script>
 
-<style scoped>
+<style>
 h3 {
   margin-bottom: 0;
 }

--- a/openlibrary/components/ObservationForm/components/OLChip.vue
+++ b/openlibrary/components/ObservationForm/components/OLChip.vue
@@ -100,7 +100,7 @@ export default {
 }
 </script>
 
-<style scoped>
+<style>
 .chip {
   padding: 4px 12px;
   border: 1px solid #999999;

--- a/openlibrary/components/ObservationForm/components/SavedTags.vue
+++ b/openlibrary/components/ObservationForm/components/SavedTags.vue
@@ -164,7 +164,7 @@ export default {
 }
 </script>
 
-<style scoped>
+<style>
 .no-selections-message {
   margin-bottom: 1em;
 }

--- a/openlibrary/components/ObservationForm/components/ValueCard.vue
+++ b/openlibrary/components/ObservationForm/components/ValueCard.vue
@@ -97,7 +97,7 @@ export default {
 }
 </script>
 
-<style scoped>
+<style>
 .value-card {
   border: 1px solid #999999;
   border-radius: 4px;


### PR DESCRIPTION


- **remove vue style scoped from mergeUI**
- **library explorer scoped removed**
- **observation form working without scoped styles**

<!-- What issue does this PR close? -->
Follow up to #10298

We generally don't need scoped styles in vue 3. Removed all the unneeded ones.
https://github.com/vitejs/vite-plugin-vue/tree/main/packages/plugin-vue

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
