### PR TITLE
Fix registration errors from xauthn

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -697,14 +697,13 @@ class InternetArchiveAccount(web.storage):
                     error = OLAuthenticationError(f'bad_{field}')
                     error.response = response
                     raise error
+            elif attempt < retries:
+                _screenname = append_random_suffix(screenname)
+                attempt += 1
             else:
-                if attempt < retries:
-                    _screenname = append_random_suffix(screenname)
-                    attempt += 1
-                else:
-                    e = OLAuthenticationError('username_registered')
-                    e.value = _screenname
-                    raise e
+                e = OLAuthenticationError('username_registered')
+                e.value = _screenname
+                raise e
 
     @classmethod
     def xauth(cls, op, test=None, s3_key=None, s3_secret=None, xauth_url=None, **data):

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -688,18 +688,23 @@ class InternetArchiveAccount(web.storage):
                     ia_account.test = True
                 return ia_account
 
-            elif 'screenname' not in response.get('values', {}):
-                error = OLAuthenticationError('undefined_error')
-                error.response = response
-                raise error
-
-            elif attempt >= retries:
-                e = OLAuthenticationError('username_registered')
-                e.value = _screenname
-                raise e
-
-            _screenname = append_random_suffix(screenname)
-            attempt += 1
+            # Response has returned "failure" with reasons in "values"
+            failures = response.get('values', {})
+            if 'screenname' not in failures:
+                for field in failures:
+                    # raise the first error if multiple
+                    # e.g. bad_email, bad_password
+                    error = OLAuthenticationError(f'bad_{field}')
+                    error.response = response
+                    raise error
+            else:
+                if attempt < retries:
+                    _screenname = append_random_suffix(screenname)
+                    attempt += 1
+                else:
+                    e = OLAuthenticationError('username_registered')
+                    e.value = _screenname
+                    raise e
 
     @classmethod
     def xauth(cls, op, test=None, s3_key=None, s3_secret=None, xauth_url=None, **data):

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -485,12 +485,6 @@ msgstr ""
 msgid "OR"
 msgstr ""
 
-#: login.html
-msgid ""
-"Please enter your <a href=\"https://archive.org\">Internet Archive</a> "
-"email and password to access your Open Library account."
-msgstr ""
-
 #: account/create.html login.html
 #, python-format
 msgid "You are already logged into Open Library as %(user)s."
@@ -501,6 +495,12 @@ msgid ""
 "If you'd like to create a new, different Open Library account, you'll "
 "need to <a href=\"javascript:;\" onclick=\"document.forms['hamburger-"
 "logout'].submit()\">log out</a> and start the signup process afresh."
+msgstr ""
+
+#: login.html
+msgid ""
+"Please enter your <a href=\"https://archive.org\">Internet Archive</a> "
+"email and password to access your Open Library account."
 msgstr ""
 
 #: forms.py login.html
@@ -7829,7 +7829,20 @@ msgid ""
 msgstr ""
 
 #: account.py
+msgid "Email provider not recognized."
+msgstr ""
+
+#: account.py
+msgid "Password requirements not met."
+msgstr ""
+
+#: account.py
 msgid "A problem occurred and we were unable to log you in"
+msgstr ""
+
+#: account.py
+#, python-format
+msgid "Request failed with error code: %(error_code)s"
 msgstr ""
 
 #: account.py

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -93,9 +93,11 @@ def get_login_error(error_key):
         "request_timeout": _(
             "Servers are experiencing unusually high traffic, please try again later or email openlibrary@archive.org for help."
         ),
+        "bad_email": _("Email provider not recognized."),
+        "bad_password": _("Password requirements not met."),
         "undefined_error": _('A problem occurred and we were unable to log you in'),
     }
-    return LOGIN_ERRORS[error_key]
+    return LOGIN_ERRORS[error_key] if error_key in LOGIN_ERRORS else _("Request failed with error code: %(error_code)s", error_code=error_key)
 
 
 class availability(delegate.page):

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -97,7 +97,11 @@ def get_login_error(error_key):
         "bad_password": _("Password requirements not met."),
         "undefined_error": _('A problem occurred and we were unable to log you in'),
     }
-    return LOGIN_ERRORS[error_key] if error_key in LOGIN_ERRORS else _("Request failed with error code: %(error_code)s", error_code=error_key)
+    return (
+        LOGIN_ERRORS[error_key]
+        if error_key in LOGIN_ERRORS
+        else _("Request failed with error code: %(error_code)s", error_code=error_key)
+    )
 
 
 class availability(delegate.page):

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -60,7 +60,13 @@ $var title: $_("Sign Up to Open Library")
     $else:
         <form class="olform create create-form" name="signup" method="post" data-i18n="$json_encode(i18n_strings)" action="">
             $if form.note:
-                <div class="ol-signup-form__note">$form.note</div>
+                <div class="flash-messages">
+                    <div class="error ol-signup-form__info-box">
+                        <span>
+                            $:form.note
+                        </span>
+                    </div>
+                </div>
 
             $def screenname_url(): $_('Your URL'): https://openlibrary.org/people/<span id="userUrl">$(form.username.value or _('screenname'))</span>
 

--- a/openlibrary/templates/login.html
+++ b/openlibrary/templates/login.html
@@ -29,7 +29,6 @@ $if "dev" in ctx.features:
     $if not ctx.user:
         $:render_template("account/ia_thirdparty_logins")
         <div class="ol-signup-form__big-or">$_('OR')</div>
-        <div class="ol-signup-form__info">$:_('Please enter your <a href="https://archive.org">Internet Archive</a> email and password to access your Open Library account.')</div>
 
     $if ctx.user:
         <p>$:_("You are already logged into Open Library as %(user)s.", user='<a href="%s">%s</a>' % (ctx.user.key, ctx.user.displayname))</p>
@@ -38,8 +37,14 @@ $if "dev" in ctx.features:
     $else:
         <form id="register" class="login olform" name="login" method="post" data-i18n="$json_encode(i18n_strings)">
             $if form.note:
-                <div class="note">$form.note</div>
-
+                <div class="flash-messages">
+                    <div class="error ol-signup-form__info-box">
+                        <span>
+                            $:form.note
+                        </span>
+                    </div>
+                </div>
+            <div class="ol-signup-form__info">$:_('Please enter your <a href="https://archive.org">Internet Archive</a> email and password to access your Open Library account.')</div>
             <div class="formElement ol-signup-form__input">
                 <div class="label">
                 <label for="username">$_("Email")</label>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10035 

The errors in `get_login_error` need to be updated to include `bad_email`, `bad_password`

https://github.com/internetarchive/openlibrary/blob/master/openlibrary/plugins/upstream/account.py#L64-L98

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

@jimchamp can you also investigate whether we may be able to add errors using the `add_flash_message` (some are currently hidden on the page) as per #10045 ?

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
