### PR TITLE
Fix `cron_wrapper.py` bugs

### DIFF
--- a/scripts/cron_wrapper.py
+++ b/scripts/cron_wrapper.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 Executes the given script with the given arguments, adding profiling and error reporting.
 """

--- a/scripts/cron_wrapper.py
+++ b/scripts/cron_wrapper.py
@@ -23,7 +23,7 @@ class MonitoredJob:
             else None
         )
         self._setup_sentry(sentry_cfg.get("dns", ""))
-        self.job_name = self._get_job_name(command[0])
+        self.job_name = self._get_job_name()
         self.job_failed = False
 
     def run(self):
@@ -99,7 +99,7 @@ def _parse_args():
     )
     _parser.add_argument(
         "script_args",
-        nargs="*",
+        nargs=argparse.REMAINDER,
         help="Arguments for the wrapped script",
     )
     _parser.set_defaults(func=main)


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
While preparing to update our crontab, I found and corrected some errors in `cron_wrapper.py`:

1. A `_get_job_name` function was being passed an expected parameter
2. `cron_wrapper.py` was treating `--options` for wrapped scripts as if they applied to `cron_wrapper.py`
3. Script was missing a shebang

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
