### PR TITLE
Add `Needs: Response` labels to PRs

### DIFF
--- a/scripts/gh_scripts/issue_comment_bot.py
+++ b/scripts/gh_scripts/issue_comment_bot.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-Fetches Open Library GitHub issues that have been commented on
+Fetches Open Library GitHub issues and PRs that have been commented on
 within some amount of time, in hours.
 
 If called with a Slack token and channel, publishes a digest of
@@ -99,7 +99,6 @@ def fetch_issues():
 def filter_issues(issues: list, hours: int, leads: list[dict[str, str]]):
     """
     Returns list of issues that have the following criteria:
-    - Are issues, not pull requests
     - Issues have at least one comment
     - Issues have been last updated since the given number of hours
     - Latest comment is not from an issue lead
@@ -125,11 +124,7 @@ def filter_issues(issues: list, hours: int, leads: list[dict[str, str]]):
         updated = datetime.fromisoformat(i['updated_at'])
         updated = updated.replace(tzinfo=None)
         if updated < since:
-            # Issues is stale
-            continue
-
-        if i.get('pull_request', {}):
-            # Issue is actually a pull request
+            # Issue not recently updated
             continue
 
         if i['comments'] == 0:


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Updates the https://github.com/internetarchive/openlibrary/labels/Needs%3A%20Response labeler to include PRs.

### Technical
<!-- What should be noted about the implementation? -->
The API that this script uses to fetch issues also returns PRs.  These changes remove the code that filtered out PRs from all fetched issues.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
