### PR TITLE
Display autocomplete results on search facet change

### DIFF
--- a/openlibrary/plugins/openlibrary/js/SearchBar.js
+++ b/openlibrary/plugins/openlibrary/js/SearchBar.js
@@ -364,8 +364,8 @@ export class SearchBar {
         const text = this.$facetSelect.find('option:selected').text();
         $('header#header-bar .search-facet-value').html(text);
 
-        // Get new results
-        if (this.$input.is(':focus')) {
+        // Add immediate refresh when input has value
+        if (this.$input.val()) {
             this.renderAutocompletionResults();
         }
     }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10359

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

### Technical
<!-- What should be noted about the implementation? -->
It changes the JS handler for displaying the autocomplete results.
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Search for any keyword in the search bar.
2. Change the facet, if the autocomplete results for that facet are displayed, the PR works as expected.
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<video src="https://github.com/user-attachments/assets/b011c860-4c7a-4fd5-b69d-b4baff22ab5d" width="320" height="240" controls></video>

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
