### PR TITLE
replaced push_scope with new_scope in sentry.py

### DIFF
--- a/openlibrary/utils/sentry.py
+++ b/openlibrary/utils/sentry.py
@@ -4,14 +4,14 @@ from dataclasses import dataclass
 
 import sentry_sdk
 import web
+from sentry_sdk.tracing import TRANSACTION_SOURCE_ROUTE, Transaction
+from sentry_sdk.utils import capture_internal_exceptions
+
 from infogami.utils.app import (
     find_page,
     modes,
 )
 from infogami.utils.types import type_patterns
-from sentry_sdk.tracing import TRANSACTION_SOURCE_ROUTE, Transaction
-from sentry_sdk.utils import capture_internal_exceptions
-
 from openlibrary.utils import get_software_version
 
 

--- a/openlibrary/utils/sentry.py
+++ b/openlibrary/utils/sentry.py
@@ -4,14 +4,14 @@ from dataclasses import dataclass
 
 import sentry_sdk
 import web
-from sentry_sdk.tracing import TRANSACTION_SOURCE_ROUTE, Transaction
-from sentry_sdk.utils import capture_internal_exceptions
-
 from infogami.utils.app import (
     find_page,
     modes,
 )
 from infogami.utils.types import type_patterns
+from sentry_sdk.tracing import TRANSACTION_SOURCE_ROUTE, Transaction
+from sentry_sdk.utils import capture_internal_exceptions
+
 from openlibrary.utils import get_software_version
 
 
@@ -83,12 +83,12 @@ class Sentry:
         app.add_processor(WebPySentryProcessor(app))
 
     def capture_exception_webpy(self):
-        with sentry_sdk.push_scope() as scope:
+        with sentry_sdk.new_scope() as scope:
             scope.add_event_processor(add_web_ctx_to_event)
             sentry_sdk.capture_exception()
 
     def capture_exception(self, ex, extras: dict | None = None):
-        with sentry_sdk.push_scope() as scope:
+        with sentry_sdk.new_scope() as scope:
             if extras:
                 for key, value in extras.items():
                     scope.set_extra(key, value)


### PR DESCRIPTION
Closes #10381


This PR is a `fix`

### Technical
Replaced the depreciated  `sentry_sdk.push_scope` with `sentry_sdk.new_scope` in [openlibrary/utils/sentry.py](openlibrary/utils/sentry.py) 

[I have replaced `sentry_sdk.push_scope` calls here](https://github.com/openlibrary/openlibrary/blob/a5d1648fb7b6bdd9fbfe44508fe84621ee17d7d5/openlibrary/utils/sentry.py#L85-L93)
![image](https://github.com/user-attachments/assets/4f4996c5-6e65-47f5-a87f-0f01d8993f57)


### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Can view changed files to verify the changes.
No behavioural changes are expected as this is just updating to the new recommended Sentry SDK method.


### Stakeholders
@jimchamp @mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
