### PR TITLE
Fix: Display correct author dates when birth/death years contain non-numeric characters

### DIFF
--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -335,12 +335,19 @@ def private_collection_in(collections: list[str]) -> bool:
     return any(x in private_collections() for x in collections)
 
 
-def extract_year(input: str) -> str:
-    """Extracts the year from an author's birth or death date."""
-    if result := re.search(r'\d{4}', input):
-        return result.group()
-    else:
-        return ''
+def extract_year(input: str, int_only: bool = True) -> str:
+
+    if not input:
+        return '' 
+
+    match = re.search(r'\b(\d{4})\b', input)
+    if match:
+        return match.group(1)  
+
+    if not int_only:
+        return input
+
+    return ''
 
 
 def _get_helpers():

--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -338,10 +338,10 @@ def private_collection_in(collections: list[str]) -> bool:
 def extract_year(input: str, int_only: bool = True) -> str:
     """Extracts the year from an author's birth or death date."""
     if not input:
-        return '' 
+        return ''
 
     if int_only:
-        pattern = r'\d{4}' 
+        pattern = r'\d{4}'
     else:
         pattern = r'[0-9xX?]{4}'
 

--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -336,16 +336,17 @@ def private_collection_in(collections: list[str]) -> bool:
 
 
 def extract_year(input: str, int_only: bool = True) -> str:
-
+    """Extracts the year from an author's birth or death date."""
     if not input:
         return '' 
 
-    match = re.search(r'\b(\d{4})\b', input)
-    if match:
-        return match.group(1)  
+    if int_only:
+        pattern = r'\d{4}' 
+    else:
+        pattern = r'[0-9xX?]{4}'
 
-    if not int_only:
-        return input
+    if result := re.search(pattern, input):
+        return result.group()
 
     return ''
 

--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -337,9 +337,6 @@ def private_collection_in(collections: list[str]) -> bool:
 
 def extract_year(input: str, int_only: bool = True) -> str:
     """Extracts the year from an author's birth or death date."""
-    if not input:
-        return ''
-
     if int_only:
         pattern = r'\d{4}'
     else:

--- a/openlibrary/macros/BookByline.html
+++ b/openlibrary/macros/BookByline.html
@@ -13,8 +13,8 @@ $def render_author_link(author):
   $rendered_name
 
   $if show_years:
-    $ birth_year = extract_year(author.get('birth_date', ''), int_only=False)
-    $ death_year = extract_year(author.get('death_date', ''), int_only=False)
+    $ birth_year = extract_year(author.get('birth_date') or '', int_only=False)
+    $ death_year = extract_year(author.get('death_date') or '', int_only=False)
 
     $if birth_year or death_year:
       ($birth_year – $death_year)

--- a/openlibrary/macros/BookByline.html
+++ b/openlibrary/macros/BookByline.html
@@ -4,24 +4,33 @@ $def render_author_link(author):
   $ name = author.get('name')
   $ url = author.get('url')
   $ rendered_name = cond(name, truncate(name, 40), _("Unknown author"))
-  $if show_years and author.get('birth_date'):
-    $ birth_date_formatted = extract_year(author.get('birth_date'), int_only=False) 
-    $if author.get('death_date'):
-      $ death_date_formatted = extract_year(author.get('death_date'), int_only=False)
-    $else:
-      $ death_date_formatted = ''
-  $if show_years and url and author.get('birth_date') and author.get('death_date'):
-    <a href="$url" $:attrs>$rendered_name ($birth_date_formatted - $death_date_formatted)</a>
-  $elif show_years and url and author.get('birth_date') :
-    <a href="$url" $:attrs>$rendered_name ($birth_date_formatted - )</a>
-  $elif show_years and author.get('birth_date') and author.get('death_date'):
-    <span $:attrs>$rendered_name ($birth_date_formatted - $death_date_formatted)</span>
-  $elif show_years and author.get('birth_date') :
-    <span $:attrs>$rendered_name ($birth_date_formatted - )</span>
-  $elif url:
-    <a href="$url" $:attrs>$rendered_name</a>
+
+  $if url:
+    <a href="$url" $:attrs>
   $else:
-    <span $:attrs>$rendered_name</span>
+    <span $:attrs>
+
+  $rendered_name
+
+  $if show_years:
+    $ birth_year = ''
+    $ death_year = ''
+    $if author.get('birth_date'):
+      $ birth_year = extract_year(author.get('birth_date'), int_only=False)
+    $if author.get('death_date'):
+      $ death_year = extract_year(author.get('death_date'), int_only=False)
+
+    $if birth_year and death_year:
+      ($birth_year – $death_year)
+    $elif birth_year:
+      ($birth_year - )
+    $elif death_year:
+      ( - $death_year)
+
+  $if url:
+    </a>
+  $else:
+    </span>
 
 $def render_overflow_link(remaining_authors, overflow_url):
   <small><em><a href="$overflow_url" $:attrs>$ungettext('%(n)s other', '%(n)s others', remaining_authors, n=remaining_authors)</a></em></small>

--- a/openlibrary/macros/BookByline.html
+++ b/openlibrary/macros/BookByline.html
@@ -5,15 +5,19 @@ $def render_author_link(author):
   $ url = author.get('url')
   $ rendered_name = cond(name, truncate(name, 40), _("Unknown author"))
   $if show_years and author.get('birth_date'):
-    $ birth_date_formatted = extract_year(author.get('birth_date'))
+    $ birth_date_formatted = extract_year(author.get('birth_date'), int_only=False) 
     $if author.get('death_date'):
-      $ death_date_formatted = extract_year(author.get('death_date'))
+      $ death_date_formatted = extract_year(author.get('death_date'), int_only=False)
     $else:
       $ death_date_formatted = ''
-  $if show_years and url and author.get('birth_date'):
+  $if show_years and url and author.get('birth_date') and author.get('death_date'):
     <a href="$url" $:attrs>$rendered_name ($birth_date_formatted - $death_date_formatted)</a>
-  $elif show_years and author.get('birth_date'):
+  $elif show_years and url and author.get('birth_date') :
+    <a href="$url" $:attrs>$rendered_name ($birth_date_formatted - )</a>
+  $elif show_years and author.get('birth_date') and author.get('death_date'):
     <span $:attrs>$rendered_name ($birth_date_formatted - $death_date_formatted)</span>
+  $elif show_years and author.get('birth_date') :
+    <span $:attrs>$rendered_name ($birth_date_formatted - )</span>
   $elif url:
     <a href="$url" $:attrs>$rendered_name</a>
   $else:

--- a/openlibrary/macros/BookByline.html
+++ b/openlibrary/macros/BookByline.html
@@ -13,19 +13,11 @@ $def render_author_link(author):
   $rendered_name
 
   $if show_years:
-    $ birth_year = ''
-    $ death_year = ''
-    $if author.get('birth_date'):
-      $ birth_year = extract_year(author.get('birth_date'), int_only=False)
-    $if author.get('death_date'):
-      $ death_year = extract_year(author.get('death_date'), int_only=False)
+    $ birth_year = extract_year(author.get('birth_date', ''), int_only=False)
+    $ death_year = extract_year(author.get('death_date', ''), int_only=False)
 
-    $if birth_year and death_year:
+    $if birth_year or death_year:
       ($birth_year – $death_year)
-    $elif birth_year:
-      ($birth_year - )
-    $elif death_year:
-      ( - $death_year)
 
   $if url:
     </a>

--- a/openlibrary/tests/core/test_helpers.py
+++ b/openlibrary/tests/core/test_helpers.py
@@ -108,6 +108,17 @@ def test_commify():
     assert h.commify(1234, lang="te") == "1,234"
     assert h.commify(1234567, lang="te") == "12,34,567"
 
+def test_extract_year():
+    assert h.extract_year("1980") == "1980"
+    assert h.extract_year("2005-03-14") == "2005"
+    assert h.extract_year("7 Dec 1999") == "1999"   
+
+    assert h.extract_year("19xx", int_only=False) == "19xx"
+    assert h.extract_year("6 Jan 19??", int_only=False) == "19??"
+    assert h.extract_year("Year 20XX", int_only=False) == "20XX"
+    
+    assert h.extract_year("No year here") == ""
+    assert h.extract_year("Year 123", int_only=False) == ""
 
 def test_truncate():
     assert h.truncate("hello", 6) == "hello"

--- a/openlibrary/tests/core/test_helpers.py
+++ b/openlibrary/tests/core/test_helpers.py
@@ -108,17 +108,19 @@ def test_commify():
     assert h.commify(1234, lang="te") == "1,234"
     assert h.commify(1234567, lang="te") == "12,34,567"
 
+
 def test_extract_year():
     assert h.extract_year("1980") == "1980"
     assert h.extract_year("2005-03-14") == "2005"
-    assert h.extract_year("7 Dec 1999") == "1999"   
+    assert h.extract_year("7 Dec 1999") == "1999"
 
     assert h.extract_year("19xx", int_only=False) == "19xx"
     assert h.extract_year("6 Jan 19??", int_only=False) == "19??"
     assert h.extract_year("Year 20XX", int_only=False) == "20XX"
-    
+
     assert h.extract_year("No year here") == ""
     assert h.extract_year("Year 123", int_only=False) == ""
+
 
 def test_truncate():
     assert h.truncate("hello", 6) == "hello"


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10352 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix: Display correct author dates when birth/death years contain non-numeric characters

### Technical
<!-- What should be noted about the implementation? -->
-> Updated the `extract_year` method in `helpers.py` to handle non-numeric characters in birth/death dates.
-> Modified the `BookByline.html` template to ensure proper display of dates, even when non-numeric characters (e.g., "19xx") are present.
-> Added an optional `int_only` parameter to the `extract_year` method to avoid breaking changes in other parts of the codebase.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
->  Verify that the author's dates are displayed correctly without empty brackets.
->  Run the test suite to ensure no regressions:

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
What I changed -:
![image](https://github.com/user-attachments/assets/31e5427f-ebaa-4b84-962d-8c55fcc7f3bb)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
