### PR TITLE
fixed Developer Quickstart Guide link takes to contributing page now

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -50,7 +50,7 @@ Warning: This integration is still experimental.
 
 ### Developer's Guide
 
-For instructions on administrating your Open Library instance, refer to the Developer's [Quickstart](https://github.com/internetarchive/openlibrary/wiki/Getting-Started) Guide.
+For instructions on administrating your Open Library instance, refer to the Developer's [Quickstart](https://github.com/internetarchive/openlibrary/blob/master/CONTRIBUTING.md) Guide.
 
 You can also find more information regarding Developer Documentation for Open Library in the Open Library [Wiki](https://github.com/internetarchive/openlibrary/wiki/).
 


### PR DESCRIPTION
# **Fix: Corrected Developer Quickstart Guide Link**
## Closes - https://github.com/internetarchive/openlibrary/issues/10422
### **Description:**  
This PR fixes the broken link in the `README.md` file. The Developer's Quickstart Guide link previously redirected to the Open Library Wiki's Getting Started page. It has now been updated to correctly point to the [[Contributing Guide](https://github.com/internetarchive/openlibrary/blob/master/CONTRIBUTING.md)](https://github.com/internetarchive/openlibrary/blob/master/CONTRIBUTING.md).

### **Changes Made:**  
- **Modified:** Replaced the incorrect Quickstart Guide link with the correct Contributing Guide link.  

### **Impact:**  
Ensures that developers are directed to the correct resource for contributing guidelines, improving the onboarding experience for new contributors.