### PR TITLE
Update data dump logging statements to avoid `UnboundLocalError`s

### DIFF
--- a/openlibrary/data/dump.py
+++ b/openlibrary/data/dump.py
@@ -36,7 +36,9 @@ def log(*args) -> None:
 def print_dump(json_records, filter=None):
     """Print the given json_records in the dump format."""
     start_time = datetime.now()
+    total = 0
     for i, raw_json_data in enumerate(json_records):
+        total += 1
         if i % 1_000_000 == 0:
             log(f"print_dump {i:,}")
         d = json.loads(raw_json_data)
@@ -69,7 +71,7 @@ def print_dump(json_records, filter=None):
 
         print("\t".join([type_key, key, str(d["revision"]), timestamp, json_data]))
     minutes = (datetime.now() - start_time).seconds // 60
-    log(f"    print_dump() processed {i:,} records in {minutes:,} minutes.")
+    log(f"    print_dump() processed {total:,} records in {minutes:,} minutes.")
 
 
 def read_data_file(filename: str, max_lines: int = 0):
@@ -79,13 +81,15 @@ def read_data_file(filename: str, max_lines: int = 0):
     """
     start_time = datetime.now()
     log(f"read_data_file({filename}, max_lines={max_lines if max_lines else 'all'})")
+    total = 0
     for i, line in enumerate(xopen(filename, "rt")):
+        total += 1
         thing_id, revision, json_data = line.strip().split("\t")
         yield pgdecode(json_data)
         if max_lines and i >= max_lines:
             break
     minutes = (datetime.now() - start_time).seconds // 60
-    log(f"read_data_file() processed {i:,} records in {minutes:,} minutes.")
+    log(f"read_data_file() processed {total:,} records in {minutes:,} minutes.")
 
 
 def xopen(path: str, mode: str):
@@ -105,14 +109,16 @@ def read_tsv(file, strip=True):
     if isinstance(file, str):
         file = xopen(file, "rt")
 
+    total = 0
     for i, line in enumerate(file):
+        total += 1
         if i % 1_000_000 == 0:
             log(f"read_tsv {i:,}")
         if strip:
             line = line.strip()
         yield line.split("\t")
     minutes = (datetime.now() - start_time).seconds // 60
-    log(f" read_tsv() processed {i:,} records in {minutes:,} minutes.")
+    log(f" read_tsv() processed {total:,} records in {minutes:,} minutes.")
 
 
 def generate_cdump(data_file, date=None):
@@ -149,7 +155,9 @@ def sort_dump(dump_file=None, tmpdir="/tmp/", buffer_size="1G"):
 
     # split the file into 256 chunks using hash of key
     log("sort_dump", dump_file or "stdin")
+    total = 0
     for i, line in enumerate(stdin):
+        total += 1
         if i % 1_000_000 == 0:
             log(f"sort_dump {i:,}")
 
@@ -170,7 +178,7 @@ def sort_dump(dump_file=None, tmpdir="/tmp/", buffer_size="1G"):
         if status != 0:
             raise Exception("sort failed with status %d" % status)
     minutes = (datetime.now() - start_time).seconds // 60
-    log(f"sort_dump() processed {i:,} records in {minutes:,} minutes.")
+    log(f"sort_dump() processed {total:,} records in {minutes:,} minutes.")
 
 
 def generate_dump(cdump_file=None):
@@ -231,7 +239,9 @@ def split_dump(dump_file=None, format="oldump_%s.txt"):
         files[t] = xopen(format % tname, "wt")
 
     stdin = xopen(dump_file, "rt") if dump_file else sys.stdin
+    total = 0
     for i, line in enumerate(stdin):
+        total += 1
         if i % 1_000_000 == 0:
             log(f"split_dump {i:,}")
         type, rest = line.split("\t", 1)
@@ -243,14 +253,16 @@ def split_dump(dump_file=None, format="oldump_%s.txt"):
     for f in files.values():
         f.close()
     minutes = (datetime.now() - start_time).seconds // 60
-    log(f"split_dump() processed {i:,} records in {minutes:,} minutes.")
+    log(f"split_dump() processed {total:,} records in {minutes:,} minutes.")
 
 
 def make_index(dump_file):
     """Make index with "path", "title", "created" and "last_modified" columns."""
     log(f"make_index({dump_file})")
     start_time = datetime.now()
+    total = 0
     for i, line in enumerate(read_tsv(dump_file)):
+        total += 1
         type, key, revision, timestamp, json_data = line
         data = json.loads(json_data)
         if type in ("/type/edition", "/type/work"):
@@ -271,7 +283,7 @@ def make_index(dump_file):
             created = "-"
         print("\t".join([web.safestr(path), web.safestr(title), created, timestamp]))
     minutes = (datetime.now() - start_time).seconds // 60
-    log(f"make_index() processed {i:,} records in {minutes:,} minutes.")
+    log(f"make_index() processed {total:,} records in {minutes:,} minutes.")
 
 
 def _process_key(key):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Related to #9521

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Updates `dump.py` logging statements that are throwing `UnboundLocalError`s.  These `log` calls were each attempting to access a nonextant variable `i`.

For each of these cases, a new variable `total` was created at the appropriate scope.  `total` is incremented each time a record is processed, and replaces `i` in each failing logging statement.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
