### PR TITLE
Permit `Needs: Response` labeling for PRs

### DIFF
--- a/.github/workflows/new_comment_digest.yml
+++ b/.github/workflows/new_comment_digest.yml
@@ -27,6 +27,7 @@ on:
 permissions:
   contents: read
   issues: write
+  pull-requests: write
 
 env:
   HOURS: 24


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Follow-up to #10411

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Updates the `new_comment_digest` workflow such that it allows writing to PRs.  API calls that add the `Needs: Response` label to PRs will no longer fail once this is merged.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
