### PR TITLE
Increase recaptcha verification timeout for account registration

### DIFF
--- a/openlibrary/plugins/recaptcha/recaptcha.py
+++ b/openlibrary/plugins/recaptcha/recaptcha.py
@@ -7,6 +7,7 @@ import web
 
 DEFAULT_RECAPTCHA_TIMEOUT = 3
 
+
 class Recaptcha(web.form.Input):
     def __init__(self, public_key, private_key, timeout=DEFAULT_RECAPTCHA_TIMEOUT):
         self.public_key = public_key

--- a/openlibrary/plugins/recaptcha/recaptcha.py
+++ b/openlibrary/plugins/recaptcha/recaptcha.py
@@ -5,11 +5,13 @@ import logging
 import requests
 import web
 
+DEFAULT_RECAPTCHA_TIMEOUT = 3
 
 class Recaptcha(web.form.Input):
-    def __init__(self, public_key, private_key):
+    def __init__(self, public_key, private_key, timeout=DEFAULT_RECAPTCHA_TIMEOUT):
         self.public_key = public_key
         self._private_key = private_key
+        self._timeout = timeout
         validator = web.form.Validator('Recaptcha failed', self.validate)
 
         web.form.Input.__init__(self, 'recaptcha', validator)
@@ -28,7 +30,7 @@ class Recaptcha(web.form.Input):
         }
 
         try:
-            r = requests.get(url, params=params, timeout=3)
+            r = requests.get(url, params=params, timeout=self._timeout)
         except requests.exceptions.RequestException as e:
             logging.getLogger("openlibrary").exception(
                 'Recaptcha call failed: letting user through'

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -292,7 +292,7 @@ class account_create(delegate.page):
             public_key = config.plugin_invisible_recaptcha.public_key
             private_key = config.plugin_invisible_recaptcha.private_key
             if public_key and private_key:
-                return recaptcha.Recaptcha(public_key, private_key)
+                return recaptcha.Recaptcha(public_key, private_key, timeout=4)
 
     def is_plugin_enabled(self, name):
         return (


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Increases the `Recaptcha` verification timeout to 4 seconds for the account registration page.  The `Recaptcha` timeout for the "Add Book" form remains 3 seconds.

### Technical
<!-- What should be noted about the implementation? -->
These changes may help mitigate some [proxy timeout errors](https://sentry.archive.org/organizations/ia-ux/issues/540641/?query=is%3Aunresolved+%2Faccount%2Fcreate&referrer=issue-stream&statsPeriod=14d) that we've been seeing.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
