### PR TITLE
Display error message when Google sign-in fails during account registration

### DIFF
--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -58,7 +58,7 @@ $var title: $_("Sign Up to Open Library")
         <p>$:_("You are already logged into Open Library as %(user)s.", user=str(user_link()))</p>
         <p>$:_('If you\'d like to create a new, different Open Library account, you\'ll need to <a href="javascript:;" onclick="document.forms[\'hamburger-logout\'].submit()">log out</a> and start the signup process afresh.')</p>
     $else:
-        <form class="olform create create-form" name="signup" method="post" data-i18n="$json_encode(i18n_strings)" action="">
+        <form id="register" class="olform create create-form" name="signup" method="post" data-i18n="$json_encode(i18n_strings)" action="">
             $if form.note:
                 <div class="flash-messages">
                     <div class="error ol-signup-form__info-box">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10404

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Updates code such that an error message is displayed whenever a Google sign-in attempt fails during account registration.

### Technical
<!-- What should be noted about the implementation? -->
The client-side third-party authentication code handles errors by


### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
