### PR TITLE
merging proposal and justify sections of feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -39,8 +39,8 @@ body:
 
         ### Requirements Checklist
         Checklist of requirements that need to be satisfied in order for this issue to be closed:
-        * [ ]      
-       
+        * [ ]
+
         ### Stakeholders
         <!-- @ tag stakeholders of this feature, clarify their stake, and specify what checkoff is required from them -->
         *

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -10,48 +10,46 @@ body:
 
   - type: textarea
     attributes:
-      label: Proposal
+      label: Feature Request
       description: Provide a brief summary of the proposed feature and any details, designs, or screenshots that may be relevant.
       value: |
-        <!-- Brief overview of the proposal -->
+        ### Problem / Opportunity
+        <!-- Describe: What is the problem this proposal addresses & for which audience(s)? -->
 
-        <!-- Designs / screenshots that may help reviewers understand your proposal -->
+        <!-- Justify: Why should we work on this and what is the measurable impact? -->
 
-  - type: textarea
-    attributes:
-      label: Justification
-      description: Help us understand, what problem(s) the proposal addresses, what is the predicted impact and how might it be measured, which audiences are served, are there precedents for the feature, and any other context we might consider.
-      value: |
-        <!-- Problem: What problem does this proposal address & for what audience(s)? -->
+        <!-- Define Success: How will we know when the problem is solved? -->
 
-        <!-- Impact: What's the predicted impact, how do we measure, & what does success look like? -->
+        ### Proposal
+        <!-- Brief overview of your proposed solution -->
 
-        <!-- Research: Are there any precedents or findings from other projects or studies that support this feature? (link or screenshot if possible) -->
+        <!-- Relevant designs, screenshots, or reference implementations that may help reviewers evaluate your proposal -->
+    validations:
+      required: true
 
   - type: textarea
     attributes:
       label: Breakdown
-      description: |
-        Instructions for completing this feature. Please leave this section blank for leads/maintainers if you are unsure what to enter
+      description: If you are unsure what to enter, please leave this section blank for leads/maintainers
       value: |
-
-        #### Requirements Checklist
-        <!-- What steps, functional pieces, or requirements need to be met to satisfy the proposal? -->
-        * [ ]
-
-        #### Related files
-        <!-- Files related to the implementation of feature; useful for good first issues -->
+        ### Related files
+        <!-- Add links to files relevant to the implementation of this proposal; useful for good first issues -->
+        Refer to [this map of common Endpoints](https://github.com/internetarchive/openlibrary/wiki/Endpoints):
         *
 
-        #### Stakeholders
-        <!-- @ tag stakeholders of this feature w/ questions or context as necessary -->
+        ### Requirements Checklist
+        Checklist of requirements that need to be satisfied in order for this issue to be closed:
+        * [ ]      
+       
+        ### Stakeholders
+        <!-- @ tag stakeholders of this feature, clarify their stake, and specify what checkoff is required from them -->
         *
 
         <hr>
 
-        #### Instructions for Contributors
+        ### Instructions for Contributors
         <!-- Please leave the following reminder section as is to help new contributors and add instructions where necessary -->
-        Please [run these commands](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#working-on-your-branch) to ensure your repository is up to date **before** [creating a new branch](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#making-changes-and-creating-a-pull-request) to work on this issue and **each time after** pushing code to Github, because the pre-commit bot may add commits to your PRs upstream.
+        * **Before** [creating a new branch](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#making-changes-and-creating-a-pull-request) or pushing up changes to a PR, please first [run these commands](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#working-on-your-branch) to ensure your repository is up to date, as the pre-commit bot may add commits to your PRs upstream.
 
   - type: markdown
     attributes:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Improvements, similar to #8894 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

simple improvements
- merges proposal and justification sections
- puts justification and problem statement fist (hopefully, in a more logical order)
- adds Endpoints link next to related files

## Considerations

I wanted to add `relevant files` to the proposal section as I'd love if more contributors added files, though I felt ultimately it might make more sense at the top of `Breakdown`

## Tested

On fork https://github.com/mekarpeles/openlibrary/issues/new?template=feature_request.yaml

<img width="894" alt="Screenshot 2025-02-11 at 3 35 26 PM" src="https://github.com/user-attachments/assets/7c72ed15-47d3-4436-bf23-435d379cc25e" />


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
