### PR TITLE
Remove prominent but non-existent subject filter

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -948,10 +948,6 @@ msgid "Ebooks"
 msgstr ""
 
 #: work_search.html
-msgid "Print Disabled"
-msgstr ""
-
-#: work_search.html
 msgid "This is only visible to super librarians."
 msgstr ""
 

--- a/openlibrary/plugins/openlibrary/js/SearchUtils.js
+++ b/openlibrary/plugins/openlibrary/js/SearchUtils.js
@@ -8,7 +8,6 @@ import $ from 'jquery';
  * @param {String} searchMode
  */
 export function addModeInputsToForm($form, searchMode) {
-    $('input[value=\'Protected DAISY\']').remove();
     $('input[name=\'has_fulltext\']').remove();
 
     let url = $form.attr('action');
@@ -20,10 +19,6 @@ export function addModeInputsToForm($form, searchMode) {
         if (searchMode !== 'everything') {
             $form.append('<input type="hidden" name="has_fulltext" value="true"/>');
             url = `${url + (url.indexOf('?') > -1 ? '&' : '?')}has_fulltext=true`;
-        }
-        if (searchMode === 'printdisabled') {
-            $form.append('<input type="hidden" name="subject_facet" value="Protected DAISY"/>');
-            url += `${url.indexOf('?') > -1 ? '&' : '?'}subject_facet=Protected DAISY`;
         }
 
         $form.attr('action', url);
@@ -115,7 +110,7 @@ PersistentValue.DEFAULT_OPTIONS = {
 };
 
 
-const MODES = ['everything', 'ebooks', 'printdisabled'];
+const MODES = ['everything', 'ebooks'];
 const DEFAULT_MODE = 'everything';
 /** Search mode; {@see MODES} */
 export const mode = new PersistentValue('mode', {

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -17,8 +17,6 @@ $def with (q_param, search_response, get_doc, param, page, rows)
         <label for="mode-search-everything">$_('Everything')</label>
         <input type="radio" name="mode" value="ebooks" id="mode-search-ebooks" class="search-mode" $('checked="checked"' if 'has_fulltext' in param else '')>
         <label for="mode-search-ebooks">$_('Ebooks')</label>
-        <input type="radio" name="mode" value="printdisabled" id="mode-search-printdisabled" class="search-mode">
-        <label for="mode-search-printdisabled">$_('Print Disabled')</label>
       </span>
       $if ctx.user and (ctx.user.is_admin() or ctx.user.is_super_librarian() or ctx.user.is_librarian()):
         <div style="display: flex; justify-content: flex-end"  title="$_('This is only visible to super librarians.')">


### PR DESCRIPTION
relates to #9439

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
It removes a non-functioning filter for a subject which no longer exists:

https://openlibrary.org/subjects/protected_daisy

It it unclear how this filter is supposed to work to display 'printdisabled' books, but the method of filtering by subject has not worked for some time. See #9439

Removing a UI element that does nothing to avoid clutter.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Before:
https://openlibrary.org/search?q=book&mode=printdisabled&has_fulltext=true&subject_facet=Protected+DAISY

![image](https://github.com/user-attachments/assets/c801be4d-14a5-4d8d-942e-1930c2796440)

After:
http://0.0.0.0:8080/search
![image](https://github.com/user-attachments/assets/7322b809-bc33-44b8-8938-7844320c6020)



### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
