### PR TITLE
Remove `is:issue` from links in "Recent Comments" section of weekly PM digests

### DIFF
--- a/scripts/gh_scripts/weekly_status_report.mjs
+++ b/scripts/gh_scripts/weekly_status_report.mjs
@@ -144,7 +144,7 @@ async function prepareRecentComments(leads) {
             }
             return false
         })
-        const searchResultsUrl = `https://github.com/internetarchive/openlibrary/issues?q=is%3Aopen+is%3Aissue+label%3A%22Needs%3A+Response%22+label%3A${encodeURIComponent('"' + lead.leadLabel + '"')}`
+        const searchResultsUrl = `https://github.com/internetarchive/openlibrary/issues?q=is%3Aopen+label%3A%22Needs%3A+Response%22+label%3A${encodeURIComponent('"' + lead.leadLabel + '"')}`
         if (leadIssuesAwaitingComments.length > 0) {
             output.push(`  • <${searchResultsUrl}|${leadIssuesAwaitingComments.length} issue(s)> need response from ${lead.slackId}`)
             isUpToDate = false


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes `is:issue` from links in the "Recent Comments" section of the weekly project management digest.  Once merged, clicking the `X issue(s) need response from lead` link will show both issues and PRs that need response.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
