### PR TITLE
Capture Wikidata API errors in Sentry

### DIFF
--- a/openlibrary/core/wikidata.py
+++ b/openlibrary/core/wikidata.py
@@ -190,16 +190,24 @@ def get_wikidata_entity(
 
 
 def _get_from_web(id: str) -> WikidataEntity | None:
-    response = requests.get(f'{WIKIDATA_API_URL}{id}')
-    if response.status_code == 200:
-        entity = WikidataEntity.from_dict(
-            response=response.json(), updated=datetime.now()
-        )
-        _add_to_cache(entity)
-        return entity
-    else:
-        logger.error(f'Wikidata Response: {response.status_code}, id: {id}')
-        return None
+    try:
+        response = requests.get(f'{WIKIDATA_API_URL}{id}')
+        response.raise_for_status()
+        if response.status_code == 200:
+            entity = WikidataEntity.from_dict(
+                response=response.json(), updated=datetime.now()
+            )
+            _add_to_cache(entity)
+            return entity
+    except requests.exceptions.HTTPError as err:
+        from openlibrary.plugins.openlibrary.sentry import sentry
+
+        if sentry.enabled:
+            sentry.capture_exception(err)
+
+        logger.error(f'Wikidata Response: {err.response.status_code}, id: {id}')
+
+    return None
     # Responses documented here https://doc.wikimedia.org/Wikibase/master/js/rest-api/
 
 

--- a/openlibrary/core/wikidata.py
+++ b/openlibrary/core/wikidata.py
@@ -202,7 +202,7 @@ def _get_from_web(id: str) -> WikidataEntity | None:
     except requests.exceptions.HTTPError as err:
         from openlibrary.plugins.openlibrary.sentry import sentry
 
-        if sentry.enabled:
+        if sentry and sentry.enabled:
             sentry.capture_exception(err)
 
         logger.error(f'Wikidata Response: {err.response.status_code}, id: {id}')


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Addresses #10444

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Updates `_get_from_web()` such that any HTTP error responses from Wikidata API calls are captured by Sentry.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
