### PR TITLE
Fix issue #2723: Improve list search functionality

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -936,8 +936,8 @@ msgstr ""
 msgid "Checking Search Inside matches"
 msgstr ""
 
-#: account/reading_log.html search/authors.html search/subjects.html
-#: work_search.html
+#: account/reading_log.html search/authors.html search/lists.html
+#: search/subjects.html work_search.html
 #, python-format
 msgid "%(count)s hit"
 msgid_plural "%(count)s hits"

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -332,7 +332,7 @@ msgstr ""
 
 #: books/check.html books/show.html covers/book_cover.html
 #: covers/book_cover_single_edition.html covers/book_cover_work.html diff.html
-#: jsdef/LazyWorkPreview.html lists/preview.html
+#: jsdef/LazyWorkPreview.html
 msgid "by"
 msgstr ""
 
@@ -5293,7 +5293,8 @@ msgid "Learn how to create your first list."
 msgstr ""
 
 #: lists/preview.html
-msgid "by <a href=\"$owner.key\">You</a>"
+#, python-format
+msgid "by <a href=\"%s\">You</a>"
 msgstr ""
 
 #: lists/showcase.html

--- a/openlibrary/plugins/worksearch/schemes/lists.py
+++ b/openlibrary/plugins/worksearch/schemes/lists.py
@@ -1,0 +1,57 @@
+import logging
+from collections.abc import Callable
+from datetime import datetime
+
+from openlibrary.plugins.worksearch.schemes import SearchScheme
+
+logger = logging.getLogger("openlibrary.worksearch")
+
+
+# define a search scheme for lists, similar to SubjectSearchScheme
+class ListSearchScheme(SearchScheme):
+    universe = ['type:list']  # this search only applies to list type documents
+    all_fields = {
+        'key',  # unique identifier for the list
+        'name',  # name/title of the list
+        'description',  # short description of the list
+        'created',  # timestamp when the list was created
+    }
+
+    # kept the same form SubjectSearchScheme
+    non_solr_fields: set[str] = set()
+    facet_fields: set[str] = set()
+    field_name_map: dict[str, str] = {}
+
+    sorts = {
+        'created desc': 'created desc',  # sort by newest lists first (default)
+        'created asc': 'created asc',  # sort by oldest lists first
+        'name asc': 'name asc',  # sort alphabetically
+        # Random (kept from SubjectSearchScheme)
+        'random': 'random_1 asc',
+        'random asc': 'random_1 asc',
+        'random desc': 'random_1 desc',
+        'random.hourly': lambda: f'random_{datetime.now():%Y%m%dT%H} asc',
+        'random.daily': lambda: f'random_{datetime.now():%Y%m%d} asc',
+    }
+    default_fetched_fields = {
+        'key',
+        'name',
+        'description',
+        'created',
+    }
+
+    # kept from SubjectSearchScheme for rewriting facet values (not used in this case)
+    facet_rewrites: dict[tuple[str, str], str | Callable[[], str]] = {}
+
+    # converts user search query into a Solr-compatible query
+    def q_to_solr_params(
+        self,
+        q: str,
+        solr_fields: set[str],
+        cur_solr_params: list[tuple[str, str]],
+    ) -> list[tuple[str, str]]:
+        return [
+            ('q', q),  # actual query string
+            ('q.op', 'AND'),  # use 'AND" for matching multiple words in search queries
+            ('defType', 'edismax'),  # use edismax parser for better full-text search
+        ]

--- a/openlibrary/plugins/worksearch/schemes/lists.py
+++ b/openlibrary/plugins/worksearch/schemes/lists.py
@@ -13,18 +13,25 @@ class ListSearchScheme(SearchScheme):
     all_fields = {
         'key',  # unique identifier for the list
         'name',  # name/title of the list
-        'description',  # short description of the list
-        'created',  # timestamp when the list was created
+        'seed',
+        'subject',
+        'subject_key',
+        'person',
+        'person_key',
+        'place',
+        'place_key',
+        'time',
+        'time_key',
     }
 
     # kept the same form SubjectSearchScheme
-    non_solr_fields: set[str] = set()
+    non_solr_fields: set[str] = {
+        'description',  # short description of the list
+    }
     facet_fields: set[str] = set()
     field_name_map: dict[str, str] = {}
 
     sorts = {
-        'created desc': 'created desc',  # sort by newest lists first (default)
-        'created asc': 'created asc',  # sort by oldest lists first
         'name asc': 'name asc',  # sort alphabetically
         # Random (kept from SubjectSearchScheme)
         'random': 'random_1 asc',
@@ -36,8 +43,6 @@ class ListSearchScheme(SearchScheme):
     default_fetched_fields = {
         'key',
         'name',
-        'description',
-        'created',
     }
 
     # kept from SubjectSearchScheme for rewriting facet values (not used in this case)

--- a/openlibrary/templates/lists/preview.html
+++ b/openlibrary/templates/lists/preview.html
@@ -7,14 +7,15 @@ $def with (list)
     <span class="details">
         <span class="resultTitle">
             $ owner = list.get_owner()
+            <h3><a href="$list.key">$list.name</a></h3>
             $if owner:
                 $ is_owner = ctx.user and ctx.user.key == owner.key
-                $if is_owner:
-                    <h3><a href="$list.key">$list.name</a></h3>
-                    <span class="list-owner small grey"> $:_('by <a href="$owner.key">You</a>')</span>
-                $else:
-                    <h3><a href="$list.key">$list.name</a></h3>
-                    <span class="list-owner small grey"> $_('by') <a href="$owner.key">$owner.displayname</a></span>
+                <span class="list-owner small grey">
+                    $if is_owner:
+                        $:_('by <a href="%s">You</a>', websafe(owner.key))
+                    $else:
+                        $:macros.BookByline([{'name': owner.name, 'url': owner.key}])
+                </span>
 
             <div class="editions smaller">
                 $ungettext("%(count)d item", "%(count)d items", len(list.seeds), count=len(list.seeds))

--- a/openlibrary/templates/search/lists.html
+++ b/openlibrary/templates/search/lists.html
@@ -1,14 +1,4 @@
-$def with (get_results)
-
-# added pagination (used subjects.html as a reference)
-$ q = query_param('q', '').strip()
-$ results_per_page = 100
-$ page = query_param('page')
-$if page:
-    $ page = int(page)
-$else:
-    $ page = 1
-$ offset = (page - 1) * results_per_page
+$def with (search_request, search_response, lists)
 
 $var title: $_('Search results for Lists')
 
@@ -21,41 +11,39 @@ $var title: $_('Search results for Lists')
 
   <div class="section">
     <form class="siteSearch olform" action="/search/lists">
-      $:render_template("search/searchbox", q=q)
+      $:render_template("search/searchbox", q=search_request.q)
     </form>
   </div>
 
-  $ results = get_results(q, offset=offset, limit=results_per_page)
-
-  $if q and results.error: # added error handling (used subjects.html as a reference)
+  $if search_request.q and search_response.error:
     <strong>
-      $for line in results.error.splitlines():
+      $for line in search_response.error.splitlines():
         $line
         $if not loop.last:
           <br>
     </strong>
 
-  $if q and not results.error:
-    $if results.num_found: # displays total number of results found
+  $if search_request.q and not search_response.error:
+    $if search_response.num_found:
       <div class="search-results-stats">
-        $ungettext('%(count)s hit', '%(count)s hits', results.num_found, count=commify(results.num_found))
+        $ungettext('%(count)s hit', '%(count)s hits', search_response.num_found, count=commify(search_response.num_found))
       </div>
 
       <div class="mybooks-list">
         <ul id="listResults" class="list-books">
-          $for list in results.docs: # iterates over result.docs instead of lists for consistency with authors.html and subjects.html
-            <li class="searchResultItem" id="list-$loop.index">$:render_template("lists/preview", list)</li>
+          $for list in lists:
+            <li class="searchResultItem">$:render_template("lists/preview", list)</li>
         </ul>
       </div>
 
-      $:macros.Pager(page, results.num_found, results_per_page)
+      $:macros.Pager(search_request.page, search_response.num_found, search_request.limit)
 
     $else:
       <center>
         <div class="red">$:_('No <strong>lists</strong> directly matched your search')</div>
         <hr>
       </center>
-      <div id="fulltext-search-suggestion" data-query="$q">
+      <div id="fulltext-search-suggestion" data-query="$search_request.q">
         $:macros.LoadingIndicator(_("Checking Search Inside matches"))
       </div>
 </div>

--- a/openlibrary/templates/search/lists.html
+++ b/openlibrary/templates/search/lists.html
@@ -1,4 +1,14 @@
-$def with (q, lists)
+$def with (get_results)
+
+# added pagination (used subjects.html as a reference)
+$ q = query_param('q', '').strip()
+$ results_per_page = 100
+$ page = query_param('page')
+$if page:
+    $ page = int(page)
+$else:
+    $ page = 1
+$ offset = (page - 1) * results_per_page
 
 $var title: $_('Search results for Lists')
 
@@ -8,25 +18,44 @@ $var title: $_('Search results for Lists')
 
 <div id="contentBody">
   $:macros.SearchNavigation()
+
   <div class="section">
     <form class="siteSearch olform" action="/search/lists">
       $:render_template("search/searchbox", q=q)
     </form>
   </div>
 
-  $if lists:
-    <div class="mybooks-list">
-      <ul id="listResults" class="list-books">
-      $for list in lists:
-        <li class="searchResultItem" id="list-$loop.index">$:render_template("lists/preview", list)</li>
-      </ul>
-    </div>
-  $elif q:
-    <center>
-      <div class="red">$:_('No <strong>lists</strong> directly matched your search')</div>
-      <hr>
-    </center>
-    <div id="fulltext-search-suggestion" data-query="$q">
+  $ results = get_results(q, offset=offset, limit=results_per_page)
+
+  $if q and results.error: # added error handling (used subjects.html as a reference)
+    <strong>
+      $for line in results.error.splitlines():
+        $line
+        $if not loop.last:
+          <br>
+    </strong>
+
+  $if q and not results.error:
+    $if results.num_found: # displays total number of results found
+      <div class="search-results-stats">
+        $ungettext('%(count)s hit', '%(count)s hits', results.num_found, count=commify(results.num_found))
+      </div>
+
+      <div class="mybooks-list">
+        <ul id="listResults" class="list-books">
+          $for list in results.docs: # iterates over result.docs instead of lists for consistency with authors.html and subjects.html
+            <li class="searchResultItem" id="list-$loop.index">$:render_template("lists/preview", list)</li>
+        </ul>
+      </div>
+
+      $:macros.Pager(page, results.num_found, results_per_page)
+
+    $else:
+      <center>
+        <div class="red">$:_('No <strong>lists</strong> directly matched your search')</div>
+        <hr>
+      </center>
+      <div id="fulltext-search-suggestion" data-query="$q">
         $:macros.LoadingIndicator(_("Checking Search Inside matches"))
-    </div>
+      </div>
 </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2723

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix: Improves list search functionality to allow partial matches in list titles.

### Technical
<!-- What should be noted about the implementation? -->
- Added a new `ListSearchScheme` to leverage Solr for list searches.
- Updated `/search/lists` controller to use the new Solr-backed search.
- Refactored the template (lists.html) to align with patterns used in other templates like authors.html and subjects.html to display improved search results.
- Added pagination support to /search/lists, allowing users to navigate through large sets of search results.
- Implemented error handling for list searches, displaying errors when they occur.
- Changes were made in:
  - `openlibrary/plugins/worksearch/code.py`
  - `openlibrary/plugins/worksearch/schemes/lists.py` (new file)
  - `openlibrary/templates/search/lists.html`

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Navigate to `/search/lists`.
2. Search for a term that is part of a list title (e.g., "banned").
3. Verify that all lists containing the search term in their titles are displayed, not just exact matches.

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 
@seabelis 
@el4ctr0n

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
