### PR TITLE
Reduce edition match score if one edition is missing a date

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -137,7 +137,7 @@ class SourceNeedsISBN(Exception):
 subject_fields = ['subjects', 'subject_places', 'subject_times', 'subject_people']
 
 
-def normalize(s):
+def normalize(s: str) -> str:
     """Strip non-alphanums and truncate at 25 chars."""
     norm = strip_accents(s).lower()
     norm = norm.replace(' and ', ' ')
@@ -160,7 +160,7 @@ def is_redirect(thing):
     return thing.type.key == '/type/redirect'
 
 
-def split_subtitle(full_title):
+def split_subtitle(full_title: str):
     """
     Splits a title into (title, subtitle),
     strips parenthetical tags. Used for bookseller
@@ -220,7 +220,6 @@ def build_author_reply(authors_in, edits, source):
     :rtype: tuple
     :return: (list, list) authors [{"key": "/author/OL..A"}, ...], author_reply
     """
-
     authors = []
     author_reply = []
     for a in authors_in:
@@ -386,7 +385,7 @@ def update_ia_metadata_for_ol_edition(edition_id):
     return data
 
 
-def normalize_record_bibids(rec):
+def normalize_record_bibids(rec: dict):
     """
     Returns the Edition import record with all ISBN fields and LCCNs cleaned.
 
@@ -406,7 +405,7 @@ def normalize_record_bibids(rec):
     return rec
 
 
-def isbns_from_record(rec):
+def isbns_from_record(rec: dict) -> list[str]:
     """
     Returns a list of all isbns from the various possible isbn fields.
 
@@ -417,7 +416,7 @@ def isbns_from_record(rec):
     return isbns
 
 
-def build_pool(rec):
+def build_pool(rec: dict) -> dict[str, list[str]]:
     """
     Searches for existing edition matches on title and bibliographic keys.
 
@@ -440,7 +439,6 @@ def build_pool(rec):
     # Find records with matching ISBNs
     if isbns := isbns_from_record(rec):
         pool['isbn'] = set(editions_matched(rec, 'isbn_', isbns))
-
     return {k: list(v) for k, v in pool.items() if v}
 
 
@@ -451,7 +449,6 @@ def find_quick_match(rec: dict) -> str | None:
     :param dict rec: Edition record
     :return: First key matched of format "/books/OL..M" or None if no match found.
     """
-
     if 'openlibrary' in rec:
         return '/books/' + rec['openlibrary']
 
@@ -480,14 +477,14 @@ def find_quick_match(rec: dict) -> str | None:
     return None
 
 
-def editions_matched(rec, key, value=None):
+def editions_matched(rec: dict, key: str, value=None) -> list[str]:
     """
     Search OL for editions matching record's 'key' value.
 
     :param dict rec: Edition import record
     :param str key: Key to search on, e.g. 'isbn_'
     :param list|str value: Value or Values to use, overriding record values
-    :rtpye: list
+    :rtype: list
     :return: List of edition keys ["/books/OL..M",]
     """
     if value is None and key not in rec:
@@ -500,11 +497,11 @@ def editions_matched(rec, key, value=None):
     return ekeys
 
 
-def find_threshold_match(rec: dict, edition_pool: dict) -> str | None:
+def find_threshold_match(rec: dict, edition_pool: dict[str, list[str]]) -> str | None:
     """
     Find the best match for rec in edition_pool and return its key.
     :param dict rec: the new edition we are trying to match.
-    :param list edition_pool: list of possible edition key matches, output of build_pool(import record)
+    :param dict edition_pool: edition key matches, output of build_pool(import record)
     :return: None or the edition key '/books/OL...M' of the best edition match for enriched_rec in edition_pool
     """
     seen = set()

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -396,11 +396,11 @@ def normalize_record_bibids(rec: dict):
     for field in ('isbn_13', 'isbn_10', 'isbn'):
         if rec.get(field):
             rec[field] = [
-                normalize_isbn(isbn) for isbn in rec.get(field) if normalize_isbn(isbn)
+                normalize_isbn(isbn) for isbn in rec.get(field, '') if normalize_isbn(isbn)
             ]
     if rec.get('lccn'):
         rec['lccn'] = [
-            normalize_lccn(lccn) for lccn in rec.get('lccn') if normalize_lccn(lccn)
+            normalize_lccn(lccn) for lccn in rec.get('lccn', '') if normalize_lccn(lccn)
         ]
     return rec
 
@@ -727,7 +727,7 @@ def normalize_import_record(rec: dict) -> None:
 
     # Split subtitle if required and not already present
     if ':' in rec.get('title', '') and not rec.get('subtitle'):
-        title, subtitle = split_subtitle(rec.get('title'))
+        title, subtitle = split_subtitle(rec.get('title', ''))
         if subtitle:
             rec['title'] = title
             rec['subtitle'] = subtitle

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -396,7 +396,9 @@ def normalize_record_bibids(rec: dict):
     for field in ('isbn_13', 'isbn_10', 'isbn'):
         if rec.get(field):
             rec[field] = [
-                normalize_isbn(isbn) for isbn in rec.get(field, '') if normalize_isbn(isbn)
+                normalize_isbn(isbn)
+                for isbn in rec.get(field, '')
+                if normalize_isbn(isbn)
             ]
     if rec.get('lccn'):
         rec['lccn'] = [

--- a/openlibrary/catalog/add_book/match.py
+++ b/openlibrary/catalog/add_book/match.py
@@ -152,7 +152,7 @@ def expand_record(rec: dict) -> dict[str, str | list[str]]:
     return expanded_rec
 
 
-def build_titles(title: str) -> dict[str, str | list[str]]:
+def build_titles(title: str) -> dict:
     """
     Uses a full title to create normalized and short title versions.
     Used for expanding a set of title variants for matching,
@@ -432,9 +432,7 @@ def compare_publisher(e1: dict, e2: dict) -> tuple:
                 elif short_part_publisher_match(e1_norm, e2_norm):
                     return ('publisher', 'match', 100)
         return ('publisher', 'mismatch', -51)
-
-    if 'publishers' not in e1 or 'publishers' not in e2:
-        return ('publisher', 'either missing', 0)
+    return ('publisher', 'either missing', 0)
 
 
 def threshold_match(

--- a/openlibrary/catalog/add_book/match.py
+++ b/openlibrary/catalog/add_book/match.py
@@ -10,6 +10,7 @@ re_whitespace_and_punct = re.compile(r'[-\s,;:.]+')
 
 type ThresholdResult = tuple[str, str, int]  # (field/category, result, score)
 
+DATE_MISMATCH = -800
 ISBN_MATCH = 85
 THRESHOLD = 875
 
@@ -211,7 +212,7 @@ def compare_date(e1: dict, e2: dict) -> ThresholdResult:
     if ('publish_date' not in e1) and ('publish_date' not in e2):
         return ('date', 'values missing', 0)
     if ('publish_date' in e1) ^ ('publish_date' in e2):
-        return ('date', 'value missing', -250)
+        return ('date', 'value missing', DATE_MISMATCH)
     if e1['publish_date'] == e2['publish_date']:
         return ('date', 'exact match', 200)
     try:
@@ -221,7 +222,7 @@ def compare_date(e1: dict, e2: dict) -> ThresholdResult:
             return ('date', '+/-2 years', -25)
     except (ValueError, TypeError):
         pass
-    return ('date', 'mismatch', -250)
+    return ('date', 'mismatch', DATE_MISMATCH)
 
 
 def compare_isbn(e1: dict, e2: dict) -> ThresholdResult:
@@ -232,9 +233,6 @@ def compare_isbn(e1: dict, e2: dict) -> ThresholdResult:
             if i == j:
                 return ('ISBN', 'match', ISBN_MATCH)
     return ('ISBN', 'mismatch', -225)
-
-
-# 450 + 200 + 85 + 200
 
 
 def level1_match(e1: dict, e2: dict) -> list[ThresholdResult]:

--- a/openlibrary/catalog/add_book/tests/test_add_book.py
+++ b/openlibrary/catalog/add_book/tests/test_add_book.py
@@ -1151,7 +1151,10 @@ def test_preisbn_import_does_not_match_existing_undated_isbn_record(mock_site) -
     }
     existing_work = {
         'authors': [
-            {'author': {'key': '/authors/OL21594A'}, 'type': {'key': '/type/author_role'}}
+            {
+                'author': {'key': '/authors/OL21594A'},
+                'type': {'key': '/type/author_role'},
+            }
         ],
         'key': '/works/OL16W',
         'title': 'Sense and Sensibility',
@@ -1181,7 +1184,9 @@ def test_preisbn_import_does_not_match_existing_undated_isbn_record(mock_site) -
     assert reply['authors'][0]['key'] == '/authors/OL21594A'
     assert reply['work']['status'] == 'matched'
     assert reply['work']['key'] == '/works/OL16W'
-    assert reply['edition']['status'] == 'created'  # New edition is created, not matched
+    assert (
+        reply['edition']['status'] == 'created'
+    )  # New edition is created, not matched
 
 
 def test_covers_are_added_to_edition(mock_site, monkeypatch) -> None:

--- a/openlibrary/catalog/add_book/tests/test_add_book.py
+++ b/openlibrary/catalog/add_book/tests/test_add_book.py
@@ -1871,7 +1871,8 @@ class TestNormalizeImportRecord:
 
 
 def test_find_match_title_only_promiseitem_against_noisbn_marc(mock_site):
-    # An existing light title + ISBN only record
+    # An existing light title + ISBN only record should not match an
+    # incoming pre-ISBN record.
     existing_edition = {
         'key': '/books/OL113M',
         # NO author


### PR DESCRIPTION
Closes #10461

It turns out this scenario "importing a pre~1970, without ISBN, record into OpenLibrary, it should never be matched to _ANY_ post-1970 edition with an ISBN" was already covered, and seemingly has been since late 2024. 

This PR
* adds more tests to confirm this
* add typehints and documentation to related methods
* makes the difference between a record with a date and one without _more_ negative to potentially avoid false matches (although it was already making the correct determination..)

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
