### PR TITLE
Disable mobile reading goal listener when goal is set

### DIFF
--- a/openlibrary/plugins/openlibrary/js/check-ins/index.js
+++ b/openlibrary/plugins/openlibrary/js/check-ins/index.js
@@ -606,7 +606,7 @@ function fetchProgressAndUpdateViews(yearlyGoalElems, goalYear) {
                 if (link) {
                     if (link.classList.contains('li-title-desktop')) {
                         // Remove click listener in mobile views
-                        link.removeEventListener("click", onYearlyGoalClick)
+                        link.removeEventListener('click', onYearlyGoalClick)
                     } else {
                         // Hide desktop "set 20XX reading goal" link
                         link.classList.add('hidden');

--- a/openlibrary/plugins/openlibrary/js/check-ins/index.js
+++ b/openlibrary/plugins/openlibrary/js/check-ins/index.js
@@ -416,7 +416,9 @@ function deleteEvent(rootElem, workOlid, eventId) {
  */
 export function initYearlyGoalPrompt(links) {
     for (const link of links) {
-        link.addEventListener('click', onYearlyGoalClick)
+        if (!link.classList.contains('goal-set')) {
+            link.addEventListener('click', onYearlyGoalClick)
+        }
     }
 }
 

--- a/openlibrary/plugins/openlibrary/js/check-ins/index.js
+++ b/openlibrary/plugins/openlibrary/js/check-ins/index.js
@@ -412,19 +412,20 @@ function deleteEvent(rootElem, workOlid, eventId) {
 /**
  * Adds listener to open reading goal modal.
  *
- * Updates yearly goal form's current year to the patron's
- * local year.
- *
  * @param {HTMLCollection<HTMLElement>} links Prompts for adding a reading goal
  */
 export function initYearlyGoalPrompt(links) {
-    const yearlyGoalModal = document.querySelector('#yearly-goal-modal')
-
     for (const link of links) {
-        link.addEventListener('click', function() {
-            yearlyGoalModal.showModal()
-        })
+        link.addEventListener('click', onYearlyGoalClick)
     }
+}
+
+/**
+ * Finds and shows the yearly goal modal.
+ */
+function onYearlyGoalClick() {
+    const yearlyGoalModal = document.querySelector('#yearly-goal-modal')
+    yearlyGoalModal.showModal()
 }
 
 /**
@@ -599,10 +600,15 @@ function fetchProgressAndUpdateViews(yearlyGoalElems, goalYear) {
                 progress.innerHTML = html
                 yearlyGoalElem.appendChild(progress)
 
-                // Hide the desktop "Set 20XX reading goal" link:
-                const link = yearlyGoalElem.querySelector('.set-reading-goal-link:not(.li-title-desktop)');
+                const link = yearlyGoalElem.querySelector('.set-reading-goal-link');
                 if (link) {
-                    link.classList.add('hidden'); // To handle the specific link element
+                    if (link.classList.contains('li-title-desktop')) {
+                        // Remove click listener in mobile views
+                        link.removeEventListener("click", onYearlyGoalClick)
+                    } else {
+                        // Hide desktop "set 20XX reading goal" link
+                        link.classList.add('hidden');
+                    }
                 }
 
                 const progressEditLink = progress.querySelector('.edit-reading-goal-link')

--- a/openlibrary/templates/account/mybooks.html
+++ b/openlibrary/templates/account/mybooks.html
@@ -85,13 +85,13 @@ $def empty_mobile_carousel(data):
         <li>
           $ year = current_year()
           $ current_goal = get_reading_goals(year=year)
-          $ hidden = 'hidden' if current_goal else ''
           <div class="yearly-goal-section carousel-section-header">
             $# Hide "Set reading goal" call to action with hidden class if a goal has already been set:
             <div class="">
               <span class="">
                 $ year_markup = year_span(year)
-                <a class="set-reading-goal-link li-title-desktop" data-ol-link-track="MyBooksLandingPage|SetReadingGoal"href="javascript:;">
+                $ goal_set = "goal-set" if current_goal else ""
+                <a class="set-reading-goal-link li-title-desktop  $goal_set" data-ol-link-track="MyBooksLandingPage|SetReadingGoal" href="javascript:;">
                   $:_('%(year_span)s reading goal', year_span=year_markup)
                   <img class="icon-link__image li-count" src="/static/images/icons/right-chevron.svg">
                 </a>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10469

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Makes the following changes to the `20XX Reading Goals` link in mobile "My Books" pages:
- Removes the `click` listener from the link whenever a reading goal is set
- Prevents the `click` listener from being added to the link when a goal is already set

The aforementioned `click` listener opens the "Yearly Reading Goal" modal, from which a patron can set a reading goal.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
