### PR TITLE
Fix: Distinguish ‘Review’ for merge requests vs. book reviews

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -5714,8 +5714,8 @@ msgstr ""
 msgid "Click to close this Merge Request"
 msgstr ""
 
-#: merge_request_table/table_row.html type/edition/modal_links.html
-msgid "Review"
+#: merge_request_table/table_row.html
+msgid "Review <!-- (merge request) -->"
 msgstr ""
 
 #: merge_request_table/table_row.html
@@ -6592,6 +6592,10 @@ msgstr ""
 
 #: databarHistory.html databarView.html type/edition/compact_title.html
 msgid "Edit this page"
+msgstr ""
+
+#: type/edition/modal_links.html
+msgid "Review"
 msgstr ""
 
 #: type/edition/title_and_author.html

--- a/openlibrary/templates/merge_request_table/table_row.html
+++ b/openlibrary/templates/merge_request_table/table_row.html
@@ -78,7 +78,7 @@ $code:
         <span class="mr-review-actions__assignee-name">$request_reviewer</span>
         <span class="$icon_classes">$:icon_content</span>
         </div>
-        <a href="$review_url" target="_blank" class="cta-btn mr-review-actions__review-btn $('' if show_review_button else 'hidden')">$_('Review')</a>
+        <a href="$review_url" target="_blank" class="cta-btn mr-review-actions__review-btn $('' if show_review_button else 'hidden')">$:_('Review <!-- (merge request) -->')</a>
     </td>
     <td class="mr-comment-toggle">
         <a href="javascript:;" class="mr-comment-toggle__comment-expand cta-btn">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10333 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Separates "Review" translation for merge requests vs. book reviews in Spanish.

### Technical
<!-- What should be noted about the implementation? -->
Added a unique string ID `$:_('Review <!-- (merge request) -->')` in `table_row.html`.
This allows translators to provide a separate translation (e.g., "Revisar") for merge requests.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
I attempted to create a new author and generate a merge request locally but encountered 404 errors in my environment. As a result, I was unable to fully verify the “Review” button changes in a merge-request scenario. 

However, these changes were recommended by the maintainers, and the updated translation string (`"Review <!-- (merge request) -->"`) is now in place.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
