### PR TITLE
Set default `action` value on login `POST`

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -461,6 +461,7 @@ class account_login(delegate.page):
             test=False,
             access=None,
             secret=None,
+            action=""
         )
         email = i.username  # XXX username is now email
         audit = audit_accounts(

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -461,7 +461,7 @@ class account_login(delegate.page):
             test=False,
             access=None,
             secret=None,
-            action=""
+            action="",
         )
         email = i.username  # XXX username is now email
         audit = audit_accounts(


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10480 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Sets default `action` in `web.input` for the login `POST` handler.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
