### PR TITLE
Pass ReCaptcha checks when verification calls fail

### DIFF
--- a/openlibrary/plugins/recaptcha/recaptcha.py
+++ b/openlibrary/plugins/recaptcha/recaptcha.py
@@ -38,5 +38,6 @@ class Recaptcha(web.form.Input):
         data = r.json()
         if not data.get('success', False) and 'error-codes' in data:
             logger.error(f"Recaptcha Error: {data['error-codes']}")
+            return True
 
         return data.get('success', '')


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Follow-up to #10476

Allows Open Library's ReCaptcha validations to pass whenever the verification call contains errors.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
