### PR TITLE
Remove helper methods for get_availability to make code easier to trace

### DIFF
--- a/openlibrary/core/fulltext.py
+++ b/openlibrary/core/fulltext.py
@@ -6,7 +6,7 @@ import requests
 import web
 
 from infogami import config
-from openlibrary.core.lending import get_availability_of_ocaids
+from openlibrary.core.lending import get_availability
 from openlibrary.plugins.openlibrary.home import format_book_data
 
 logger = logging.getLogger("openlibrary.inside")
@@ -57,7 +57,7 @@ def fulltext_search(q, page=1, limit=100, js=False, facets=False):
     if 'error' not in ia_results and ia_results['hits']:
         hits = ia_results['hits'].get('hits', [])
         ocaids = [hit['fields'].get('identifier', [''])[0] for hit in hits]
-        availability = get_availability_of_ocaids(ocaids)
+        availability = get_availability('identifier', ocaids)
         if 'error' in availability:
             return []
         editions = web.ctx.site.get_many(

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -473,7 +473,7 @@ def get_ocaid(item: dict) -> str | None:
 def get_availabilities(items: list) -> dict:
     result = {}
     ocaids = [ocaid for ocaid in map(get_ocaid, items) if ocaid]
-    availabilities = get_availability_of_ocaids(ocaids)
+    availabilities = get_availability('identifier', ocaids)
     for item in items:
         ocaid = get_ocaid(item)
         if ocaid:
@@ -492,7 +492,7 @@ def add_availability(
     """
     if mode == "identifier":
         ocaids = [ocaid for ocaid in map(get_ocaid, items) if ocaid]
-        availabilities = get_availability_of_ocaids(ocaids)
+        availabilities = get_availability('identifier', ocaids)
         for item in items:
             ocaid = get_ocaid(item)
             if ocaid:
@@ -507,25 +507,13 @@ def add_availability(
     return items
 
 
-def get_availability_of_ocaid(ocaid):
-    """Retrieves availability based on ocaid/archive.org identifier"""
-    return get_availability('identifier', [ocaid])
-
-
-def get_availability_of_ocaids(ocaids: list[str]) -> dict[str, AvailabilityStatusV2]:
-    """
-    Retrieves availability based on ocaids/archive.org identifiers
-    """
-    return get_availability('identifier', ocaids)
-
-
 def get_items_and_add_availability(ocaids: list[str]) -> dict[str, "Edition"]:
     """
     Get Editions from OCAIDs and attach their availabiliity.
 
     Returns a dict of the form: `{"ocaid1": edition1, "ocaid2": edition2, ...}`
     """
-    ocaid_availability = get_availability_of_ocaids(ocaids=ocaids)
+    ocaid_availability = get_availability('identifier', ocaids)
     editions = web.ctx.site.get_many(
         [
             f"/books/{item.get('openlibrary_edition')}"
@@ -725,7 +713,7 @@ def sync_loan(identifier, loan=NOT_INITIALIZED):
         'book': loan['book'],
     }
 
-    responses = get_availability_of_ocaid(identifier)
+    responses = get_availability('identifier', [identifier])
     response = responses[identifier] if responses else {}
     if response:
         num_waiting = int(response.get('num_waitlist', 0) or 0)

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -155,7 +155,7 @@ class borrow(delegate.page):
 
         # Make a call to availability v2 update the subjects according
         # to result if `open`, redirect to bookreader
-        response = lending.get_availability_of_ocaid(edition.ocaid)
+        response = lending.get_availability('identifier', [edition.ocaid])
         availability = response[edition.ocaid] if response else {}
         if availability and availability['status'] == 'open':
             from openlibrary.plugins.openlibrary.code import is_bot

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -743,7 +743,7 @@ class Work(models.Work):
         # via editions-search, we can sidestep get_availability to only
         # check availability for borrowable editions
         ocaids = [ed.ocaid for ed in editions if ed.ocaid]
-        availability = lending.get_availability_of_ocaids(ocaids) if ocaids else {}
+        availability = lending.get_availability('identifier', ocaids)
         for ed in editions:
             ed.availability = availability.get(ed.ocaid) or {"status": "error"}
 

--- a/openlibrary/tests/core/test_lending.py
+++ b/openlibrary/tests/core/test_lending.py
@@ -5,12 +5,10 @@ from openlibrary.core import lending
 
 class TestAddAvailability:
     def test_reads_ocaids(self, monkeypatch):
-        def mock_get_availability_of_ocaids(ocaids):
+        def mock_get_availability(id_type, ocaids):
             return {'foo': {'status': 'available'}}
 
-        monkeypatch.setattr(
-            lending, "get_availability_of_ocaids", mock_get_availability_of_ocaids
-        )
+        monkeypatch.setattr(lending, "get_availability", mock_get_availability)
 
         f = lending.add_availability
         assert f([{'ocaid': 'foo'}]) == [
@@ -31,12 +29,10 @@ class TestAddAvailability:
         assert f([{}]) == [{}]
 
     def test_handles_availability_none(self, monkeypatch):
-        def mock_get_availability_of_ocaids(ocaids):
+        def mock_get_availability(id_type, ocaids):
             return {'foo': {'status': 'error'}}
 
-        monkeypatch.setattr(
-            lending, "get_availability_of_ocaids", mock_get_availability_of_ocaids
-        )
+        monkeypatch.setattr(lending, "get_availability", mock_get_availability)
 
         f = lending.add_availability
         r = f([{'ocaid': 'foo'}])


### PR DESCRIPTION
The API call in get_availability is often a topic of interest, and it ends up being difficult to debug where it's used. Removing these wrappers will help make it a little easier, since now we can just search for get_availability

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
