### PR TITLE
Avoid showing autocomplete search results on page load

### DIFF
--- a/openlibrary/plugins/openlibrary/js/SearchBar.js
+++ b/openlibrary/plugins/openlibrary/js/SearchBar.js
@@ -164,17 +164,6 @@ export class SearchBar {
         if (urlParams.facet in FACET_TO_ENDPOINT) {
             this.facet.write(urlParams.facet);
         }
-
-        if (urlParams.q && window.location.pathname.match(/^\/search/)) {
-            let q = urlParams.q.replace(/\+/g, ' ');
-            if (this.facet.read() === 'title' && q.indexOf('title:') !== -1) {
-                const parts = q.split('"');
-                if (parts.length === 3) {
-                    q = parts[1];
-                }
-            }
-            this.$input.val(q);
-        }
     }
 
     submitForm() {

--- a/tests/unit/js/SearchBar.test.js
+++ b/tests/unit/js/SearchBar.test.js
@@ -37,18 +37,6 @@ describe('SearchBar', () => {
             expect(sb.facet.read()).toBe(originalValue);
         });
 
-        test('Sets input value from q param', () => {
-            sb.initFromUrlParams({q: 'Harry Potter'});
-            expect(sb.$input.val()).toBe('Harry Potter');
-        });
-
-        test('Remove title prefix from q param', () => {
-            sb.initFromUrlParams({q: 'title:"Harry Potter"', facet: 'title'});
-            expect(sb.$input.val()).toBe('Harry Potter');
-            sb.initFromUrlParams({q: 'title: "Harry"', facet: 'title'});
-            expect(sb.$input.val()).toBe('Harry');
-        });
-
         test('Persists value in url param', () => {
             expect(localStorage.getItem('facet')).not.toBe('title');
             sb.initFromUrlParams({facet: 'title'});


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10484

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes code that populates the top nav search bar's input on page load.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
