### PR TITLE
Tighten account creation validations

### DIFF
--- a/openlibrary/plugins/recaptcha/recaptcha.py
+++ b/openlibrary/plugins/recaptcha/recaptcha.py
@@ -8,13 +8,14 @@ import web
 logger = logging.getLogger("openlibrary")
 
 INVALIDATING_ERRORS = [
-                "invalid-input-secret",
-                "missing-input-secret",
-                "missing-input-response",
-                "invalid-input-response",
-                "bad-request",
-                "timeout-or-duplicate",
-            ]
+    "invalid-input-secret",
+    "missing-input-secret",
+    "missing-input-response",
+    "invalid-input-response",
+    "bad-request",
+    "timeout-or-duplicate",
+]
+
 
 class Recaptcha(web.form.Input):
     def __init__(self, public_key, private_key):


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Ensures that legitimately invalid ReCaptcha tests cause account creation form validations to fail.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
