### PR TITLE
Fix i18n not running for some python files

### DIFF
--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -12,6 +12,7 @@ import web
 from babel.messages import Catalog, Message
 from babel.messages.extract import (
     extract_from_dir,
+    extract_from_file,
     extract_python,
 )
 from babel.messages.mofile import write_mo
@@ -38,7 +39,9 @@ def warning_color_fn(text: str) -> str:
     return '\033[93m' + text + '\033[0m'
 
 
-def get_untracked_files(dirs: list[str], extensions: tuple[str, str] | str) -> set:
+def get_untracked_files(
+    dirs: list[str], extensions: tuple[str, str] | str
+) -> set[Path]:
     """Returns a set of all currently untracked files with specified extension(s)."""
     untracked_files = {
         Path(line)
@@ -162,7 +165,7 @@ def extract_templetor(fileobj, keywords, comment_tags, options):
     return extract_python(f, keywords, comment_tags, options)
 
 
-def extract_messages(dirs: list[str], verbose: bool, skip_untracked: bool):
+def extract_messages(sources: list[str], verbose: bool, skip_untracked: bool):
     # The creation date is fixed to prevent merge conflicts on this line as a result of i18n auto-updates
     # In the unlikely event we need to update the fixed creation date, you can change the hard-coded date below
     fixed_creation_date = datetime.fromisoformat('2024-05-01 18:58-0400')
@@ -176,25 +179,43 @@ def extract_messages(dirs: list[str], verbose: bool, skip_untracked: bool):
 
     skipped_files = set()
     if skip_untracked:
-        skipped_files = get_untracked_files(dirs, ('.py', '.html'))
+        skipped_files = get_untracked_files(sources, ('.py', '.html'))
 
-    for d in dirs:
-        extracted = extract_from_dir(
-            d, METHODS, comment_tags=COMMENT_TAGS, strip_comment_tags=True
-        )
+    for source in map(Path, sources):
+        counts: dict[Path, int] = {}
 
-        counts: dict[str, int] = {}
-        for filename, lineno, message, comments, context in extracted:
-            file_path = Path(d) / filename
+        if source.is_file():
+            extracted = extract_from_file(
+                next(method for (glb, method) in METHODS if source.match(glb)),
+                source,
+                comment_tags=COMMENT_TAGS,
+                strip_comment_tags=True,
+            )
+
+            # Make it have the same shape as extract_from_dir
+            extracted = ((source, source, *x) for x in extracted)
+        else:
+            extracted = extract_from_dir(
+                source,
+                METHODS,
+                comment_tags=COMMENT_TAGS,
+                strip_comment_tags=True,
+            )
+
+            # Make it have the same shape as extract_from_file
+            extracted = ((source / x[0], x[0], *x[1:]) for x in extracted)
+
+        for file_path, partial_path, lineno, message, comments, context in extracted:
             if file_path in skipped_files:
                 continue
-            counts[filename] = counts.get(filename, 0) + 1
-            catalog.add(message, None, [(filename, lineno)], auto_comments=comments)
+            counts[file_path] = counts.get(file_path, 0) + 1
+            catalog.add(
+                message, None, [(str(partial_path), lineno)], auto_comments=comments
+            )
 
         if verbose:
-            for filename, count in counts.items():
-                path = filename if d == filename else os.path.join(d, filename)
-                print(f"{count}\t{path}", file=sys.stderr)
+            for file_path, count in counts.items():
+                print(f"{count}\t{file_path}", file=sys.stderr)
 
     path = os.path.join(root, 'messages.pot')
     with open(path, 'wb') as f:

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -7769,115 +7769,6 @@ msgstr ""
 msgid "View Volume %(num)d"
 msgstr ""
 
-#: openlibrary/core/edits.py
-msgid "Unknown"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/lists.py
-#, python-format
-msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Czech"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "German"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "English"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Spanish"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "French"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Croatian"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Italian"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Portuguese"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Hindi"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Sardinian"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Telugu"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Ukrainian"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Chinese"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Art"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Science Fiction"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Fantasy"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Biographies"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Recipes"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Children"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Medicine"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Religion"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Mystery and Detective Stories"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Plays"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Music"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Science"
-msgstr ""
-
 #: openlibrary/plugins/upstream/forms.py
 msgid "Username"
 msgstr ""
@@ -8016,6 +7907,7 @@ msgid ""
 "or contact info@archive.org"
 msgstr ""
 
+#: openlibrary/plugins/upstream/account.py
 #, python-format
 msgid "Request failed with error code: %(error_code)s"
 msgstr ""
@@ -8073,6 +7965,111 @@ msgstr ""
 msgid "Notification preferences have been updated successfully."
 msgstr ""
 
+#: openlibrary/plugins/openlibrary/lists.py
+#, python-format
+msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Czech"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "German"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "English"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Spanish"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "French"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Croatian"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Italian"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Portuguese"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Hindi"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Sardinian"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Telugu"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Ukrainian"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Chinese"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Art"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Science Fiction"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Fantasy"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Biographies"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Recipes"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Children"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Medicine"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Religion"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Mystery and Detective Stories"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Plays"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Music"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Science"
+msgstr ""
+
 #: openlibrary/plugins/worksearch/code.py
 msgid "eBook?"
 msgstr ""
@@ -8083,5 +8080,9 @@ msgstr ""
 
 #: openlibrary/plugins/worksearch/code.py
 msgid "Classic eBooks"
+msgstr ""
+
+#: openlibrary/core/edits.py
+msgid "Unknown"
 msgstr ""
 

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -509,7 +509,7 @@ msgid ""
 "email and password to access your Open Library account."
 msgstr ""
 
-#: forms.py login.html
+#: login.html openlibrary/plugins/upstream/forms.py
 msgid "Email"
 msgstr ""
 
@@ -517,7 +517,8 @@ msgstr ""
 msgid "Forgot your Internet Archive email?"
 msgstr ""
 
-#: account/email/forgot-ia.html forms.py login.html
+#: account/email/forgot-ia.html login.html
+#: openlibrary/plugins/upstream/forms.py
 msgid "Password"
 msgstr ""
 
@@ -1047,11 +1048,11 @@ msgid ""
 "information form</a>."
 msgstr ""
 
-#: account/create.html forms.py
+#: account/create.html openlibrary/plugins/upstream/forms.py
 msgid "Must be a valid email address"
 msgstr ""
 
-#: account/create.html forms.py
+#: account/create.html openlibrary/plugins/upstream/forms.py
 msgid "Must be between 3 and 20 characters"
 msgstr ""
 
@@ -1344,8 +1345,8 @@ msgid "My Loans"
 msgstr ""
 
 #: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
-#: my_books/dropdown_content.html my_books/primary_action.html mybooks.py
-#: search/sort_options.html
+#: my_books/dropdown_content.html my_books/primary_action.html
+#: openlibrary/plugins/upstream/mybooks.py search/sort_options.html
 msgid "Already Read"
 msgstr ""
 
@@ -1374,8 +1375,8 @@ msgstr ""
 msgid "My Reading Stats"
 msgstr ""
 
-#: account.py account/mybooks.html account/sidebar.html
-#: books/mybooks_breadcrumb_select.html
+#: account/mybooks.html account/sidebar.html
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
 msgid "Loan History"
 msgstr ""
 
@@ -1491,7 +1492,7 @@ msgid "Save"
 msgstr ""
 
 #: EditionNavBar.html account/observations.html
-#: books/mybooks_breadcrumb_select.html mybooks.py
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 msgid "Reviews"
 msgstr ""
 
@@ -1727,7 +1728,8 @@ msgstr ""
 msgid "Click on a bar to see matching works"
 msgstr ""
 
-#: account/sidebar.html books/mybooks_breadcrumb_select.html mybooks.py
+#: account/sidebar.html books/mybooks_breadcrumb_select.html
+#: openlibrary/plugins/upstream/mybooks.py
 msgid "My Feed"
 msgstr ""
 
@@ -1778,8 +1780,9 @@ msgstr ""
 msgid "Verification email sent"
 msgstr ""
 
-#: account.py account/password/reset_success.html account/verify.html
+#: account/password/reset_success.html account/verify.html
 #: account/verify/activated.html account/verify/success.html
+#: openlibrary/plugins/upstream/account.py
 #, python-format
 msgid "Hi, %(user)s"
 msgstr ""
@@ -2112,7 +2115,7 @@ msgstr ""
 msgid "Failed"
 msgstr ""
 
-#: admin/imports_by_date.html
+#: admin/imports_by_date.html openlibrary/core/edits.py
 msgid "Pending"
 msgstr ""
 
@@ -2310,7 +2313,8 @@ msgid "Admin Center"
 msgstr ""
 
 #: RelatedSubjects.html SubjectTags.html admin/menu.html
-#: admin/people/index.html admin/people/view.html type/author/view.html
+#: admin/people/index.html admin/people/view.html
+#: openlibrary/plugins/worksearch/code.py type/author/view.html
 #: type/list/view_body.html
 msgid "People"
 msgstr ""
@@ -2802,8 +2806,8 @@ msgstr ""
 msgid "Anonymize Account"
 msgstr ""
 
-#: account.py admin/people/view.html books/mybooks_breadcrumb_select.html
-#: type/user/view.html
+#: admin/people/view.html books/mybooks_breadcrumb_select.html
+#: openlibrary/plugins/upstream/account.py type/user/view.html
 msgid "Loans"
 msgstr ""
 
@@ -3267,7 +3271,8 @@ msgid "Required field"
 msgstr ""
 
 #: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html
-#: search/advancedsearch.html search/work_search_selected_facets.html
+#: openlibrary/plugins/worksearch/code.py search/advancedsearch.html
+#: search/work_search_selected_facets.html
 msgid "Author"
 msgstr ""
 
@@ -3651,36 +3656,37 @@ msgid "in %(languagelist)s"
 msgstr ""
 
 #: SearchNavigation.html books/mybooks_breadcrumb_select.html lib/nav_foot.html
-#: mybooks.py
+#: openlibrary/plugins/upstream/mybooks.py
 msgid "Books"
 msgstr ""
 
-#: books/mybooks_breadcrumb_select.html mybooks.py
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #, python-format
 msgid "Want to Read (%(count)d)"
 msgstr ""
 
-#: books/mybooks_breadcrumb_select.html mybooks.py
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #, python-format
 msgid "Currently Reading (%(count)d)"
 msgstr ""
 
-#: books/mybooks_breadcrumb_select.html mybooks.py
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #, python-format
 msgid "Already Read (%(count)d)"
 msgstr ""
 
 #: books/mybooks_breadcrumb_select.html
+#: openlibrary/plugins/openlibrary/lists.py
 #, python-format
 msgid "Lists (%(count)d)"
 msgstr ""
 
-#: books/mybooks_breadcrumb_select.html mybooks.py
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #: type/edition/modal_links.html
 msgid "Notes"
 msgstr ""
 
-#: account.py books/mybooks_breadcrumb_select.html
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
 msgid "Imports and Exports"
 msgstr ""
 
@@ -4614,7 +4620,7 @@ msgstr ""
 msgid "Recently Returned"
 msgstr ""
 
-#: home/index.html
+#: home/index.html openlibrary/plugins/openlibrary/home.py
 msgid "Romance"
 msgstr ""
 
@@ -4626,7 +4632,7 @@ msgstr ""
 msgid "Thrillers"
 msgstr ""
 
-#: home/index.html
+#: home/index.html openlibrary/plugins/openlibrary/home.py
 msgid "Textbooks"
 msgstr ""
 
@@ -4828,7 +4834,7 @@ msgid "New!"
 msgstr ""
 
 #: databarDiff.html databarEdit.html databarTemplate.html databarView.html
-#: lib/history.html
+#: lib/history.html openlibrary/plugins/openlibrary/home.py
 msgid "History"
 msgstr ""
 
@@ -4998,8 +5004,8 @@ msgid "Explore subjects"
 msgstr ""
 
 #: RelatedSubjects.html SearchNavigation.html SubjectTags.html
-#: lib/nav_foot.html lib/nav_head.html subjects/notfound.html
-#: type/author/view.html type/list/view_body.html
+#: lib/nav_foot.html lib/nav_head.html openlibrary/plugins/worksearch/code.py
+#: subjects/notfound.html type/author/view.html type/list/view_body.html
 msgid "Subjects"
 msgstr ""
 
@@ -5571,11 +5577,11 @@ msgstr ""
 msgid "Request Status"
 msgstr ""
 
-#: merge_request_table/table_header.html
+#: merge_request_table/table_header.html openlibrary/core/edits.py
 msgid "Merged"
 msgstr ""
 
-#: merge_request_table/table_header.html
+#: merge_request_table/table_header.html openlibrary/core/edits.py
 msgid "Declined"
 msgstr ""
 
@@ -5745,8 +5751,8 @@ msgstr ""
 msgid "Publisher: %(name)s"
 msgstr ""
 
-#: publishers/view.html search/advancedsearch.html type/edition/view.html
-#: type/work/view.html
+#: openlibrary/plugins/worksearch/code.py publishers/view.html
+#: search/advancedsearch.html type/edition/view.html type/work/view.html
 msgid "Publisher"
 msgstr ""
 
@@ -6465,8 +6471,8 @@ msgstr ""
 msgid "Search %(author)s books"
 msgstr ""
 
-#: RelatedSubjects.html SubjectTags.html type/author/view.html
-#: type/list/view_body.html
+#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py
+#: type/author/view.html type/list/view_body.html
 msgid "Places"
 msgstr ""
 
@@ -6583,7 +6589,8 @@ msgstr ""
 msgid "Search for other books from %(publisher)s"
 msgstr ""
 
-#: type/edition/view.html type/work/view.html
+#: openlibrary/plugins/worksearch/code.py type/edition/view.html
+#: type/work/view.html
 msgid "Language"
 msgstr ""
 
@@ -6899,7 +6906,8 @@ msgstr ""
 msgid "Derived from seed metadata"
 msgstr ""
 
-#: RelatedSubjects.html SubjectTags.html type/list/view_body.html
+#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py
+#: type/list/view_body.html
 msgid "Times"
 msgstr ""
 
@@ -7753,192 +7761,314 @@ msgstr ""
 msgid "View Volume %(num)d"
 msgstr ""
 
-#: account.py
-msgid "The email address you entered is invalid"
+#: openlibrary/core/edits.py
+msgid "Unknown"
 msgstr ""
 
-#: account.py
-msgid "This account has been blocked"
-msgstr ""
-
-#: account.py
-msgid "This account has been locked"
-msgstr ""
-
-#: account.py
-msgid "No account was found with this email. Please try again"
-msgstr ""
-
-#: account.py
-msgid "The password you entered is incorrect. Please try again"
-msgstr ""
-
-#: account.py
-msgid "Wrong password. Please try again"
-msgstr ""
-
-#: account.py
-msgid "Please verify your Open Library account before logging in"
-msgstr ""
-
-#: account.py
-msgid "Please verify your Internet Archive account before logging in"
-msgstr ""
-
-#: account.py
-msgid "Please fill out all fields and try again"
-msgstr ""
-
-#: account.py
-msgid "This email is already registered"
-msgstr ""
-
-#: account.py
-msgid "This username is already registered"
-msgstr ""
-
-#: account.py
-msgid "A problem occurred and we were unable to log you in."
-msgstr ""
-
-#: account.py
-msgid "Login attempted with invalid Internet Archive s3 credentials."
-msgstr ""
-
-#: account.py
-msgid ""
-"Servers are experiencing unusually high traffic, please try again later "
-"or email openlibrary@archive.org for help."
-msgstr ""
-
-#: account.py
-msgid "Email provider not recognized."
-msgstr ""
-
-#: account.py
-msgid "Password requirements not met."
-msgstr ""
-
-#: account.py
-msgid "A problem occurred and we were unable to log you in"
-msgstr ""
-
-#: account.py
+#: openlibrary/plugins/openlibrary/lists.py
 #, python-format
-msgid "Request failed with error code: %(error_code)s"
+msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
 msgstr ""
 
-#: account.py
-#, python-format
-msgid ""
-"We've sent the verification email to %(email)s. You'll need to read that "
-"and click on the verification link to verify your email."
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Czech"
 msgstr ""
 
-#: account.py
-msgid "Username unavailable"
+#: openlibrary/plugins/openlibrary/code.py
+msgid "German"
 msgstr ""
 
-#: account.py forms.py
-msgid "Email already registered"
+#: openlibrary/plugins/openlibrary/code.py
+msgid "English"
 msgstr ""
 
-#: account.py
-msgid "An Internet Archive account already exists with this email"
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Spanish"
 msgstr ""
 
-#: account.py
-msgid "Email address is already used."
+#: openlibrary/plugins/openlibrary/code.py
+msgid "French"
 msgstr ""
 
-#: account.py
-msgid ""
-"Your email address couldn't be updated. The specified email address is "
-"already used."
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Croatian"
 msgstr ""
 
-#: account.py
-msgid "Email verification successful."
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Italian"
 msgstr ""
 
-#: account.py
-msgid ""
-"Your email address has been successfully verified and updated in your "
-"account."
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Portuguese"
 msgstr ""
 
-#: account.py
-msgid "Email address couldn't be verified."
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Hindi"
 msgstr ""
 
-#: account.py
-msgid ""
-"Your email address couldn't be verified. The verification link seems "
-"invalid."
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Sardinian"
 msgstr ""
 
-#: account.py
-msgid "Password reset failed."
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Telugu"
 msgstr ""
 
-#: account.py
-msgid "Notification preferences have been updated successfully."
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Ukrainian"
 msgstr ""
 
-#: borrow.py
-msgid ""
-"Your account has hit a lending limit. Please try again later or contact "
-"info@archive.org."
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Chinese"
 msgstr ""
 
-#: forms.py
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Art"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Science Fiction"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Fantasy"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Biographies"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Recipes"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Children"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Medicine"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Religion"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Mystery and Detective Stories"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Plays"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Music"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Science"
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
 msgid "Username"
 msgstr ""
 
-#: forms.py
+#: openlibrary/plugins/upstream/forms.py
 msgid "No user registered with this email address"
 msgstr ""
 
-#: forms.py
+#: openlibrary/plugins/upstream/account.py
+#: openlibrary/plugins/upstream/forms.py
+msgid "Email already registered"
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
 msgid "Disposable email not permitted"
 msgstr ""
 
-#: forms.py
+#: openlibrary/plugins/upstream/forms.py
 msgid "Your email provider is not recognized."
 msgstr ""
 
-#: forms.py
+#: openlibrary/plugins/upstream/forms.py
 msgid "Username already used"
 msgstr ""
 
-#: forms.py
+#: openlibrary/plugins/upstream/forms.py
 msgid "Must be between 3 and 20 letters and numbers"
 msgstr ""
 
-#: forms.py
+#: openlibrary/plugins/upstream/forms.py
 msgid "Screen Name"
 msgstr ""
 
-#: forms.py
+#: openlibrary/plugins/upstream/forms.py
 msgid "Public and cannot be changed later."
 msgstr ""
 
-#: forms.py
+#: openlibrary/plugins/upstream/forms.py
 msgid ""
 "I want to receive news, announcements, and resources from the <a "
 "href=\"https://archive.org/\">Internet Archive</a>, the non-profit that "
 "runs Open Library."
 msgstr ""
 
-#: forms.py
+#: openlibrary/plugins/upstream/forms.py
 msgid "Invalid password"
 msgstr ""
 
-#: forms.py
+#: openlibrary/plugins/upstream/forms.py
 msgid "Your email address"
 msgstr ""
 
-#: forms.py
+#: openlibrary/plugins/upstream/forms.py
 msgid "Choose a password"
+msgstr ""
+
+#: openlibrary/plugins/upstream/borrow.py
+msgid ""
+"Your account has hit a lending limit. Please try again later or contact "
+"info@archive.org."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "The email address you entered is invalid"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "This account has been blocked"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "This account has been locked"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "No account was found with this email. Please try again"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "The password you entered is incorrect. Please try again"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Wrong password. Please try again"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Please verify your Open Library account before logging in"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Please verify your Internet Archive account before logging in"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Please fill out all fields and try again"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "This email is already registered"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "This username is already registered"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "A problem occurred and we were unable to log you in."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Login attempted with invalid Internet Archive s3 credentials."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid ""
+"Servers are experiencing unusually high traffic, please try again later "
+"or email openlibrary@archive.org for help."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Email provider not recognized."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Password requirements not met."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "A problem occurred and we were unable to log you in"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+#, python-format
+msgid "Request failed with error code: %(error_code)s"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+#, python-format
+msgid ""
+"We've sent the verification email to %(email)s. You'll need to read that "
+"and click on the verification link to verify your email."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Username unavailable"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "An Internet Archive account already exists with this email"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Email address is already used."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid ""
+"Your email address couldn't be updated. The specified email address is "
+"already used."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Email verification successful."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid ""
+"Your email address has been successfully verified and updated in your "
+"account."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Email address couldn't be verified."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid ""
+"Your email address couldn't be verified. The verification link seems "
+"invalid."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Password reset failed."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Notification preferences have been updated successfully."
+msgstr ""
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "eBook?"
+msgstr ""
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "First published"
+msgstr ""
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "Classic eBooks"
 msgstr ""
 

--- a/scripts/i18n-messages
+++ b/scripts/i18n-messages
@@ -2,6 +2,7 @@
 """Utility script to extract all translatable messages from templates and
 macros and write to openlibrary/i18n/messages.pot file.
 """
+import subprocess
 import sys
 
 import _init_path  # noqa: F401  Imported for its side effect of setting PYTHONPATH
@@ -27,12 +28,22 @@ def help():
 
 def main(cmd, args):
     if cmd == 'extract':
+        # Using shell=True, because otherwise the *.py seems to cause trouble
+        # on some systems, resulting in no python files being extracted.
+        py_sources = subprocess.run(
+            "grep -rlF ' _(' openlibrary/ --include '*.py'",
+            shell=True,
+            capture_output=True,
+            check=False,
+            text=True,
+        ).stdout.splitlines()
+
         message_sources = [
             'openlibrary/templates/',
             'openlibrary/macros/',
-            # TODO: We should check all python files somehow, but too slow
-            'openlibrary/plugins/upstream',
+            *py_sources,
         ]
+
         i18n.extract_messages(
             message_sources,
             verbose='--verbose' in args,


### PR DESCRIPTION
Closes #10489

Addendum to #9889 ; I realized that a few of our python files aren't being picked up the i18n script; so extended it to also grep for ` _(` which should find anything python file that needs to be processed.

### Technical
- I tried adding `openlibrary/` to the `message_sources` list, but it was muuch slower. The grep approach is about the same amount of time, <5s.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
