### PR TITLE
Better handle/display solr errors/debug info on search

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -956,6 +956,18 @@ msgid "Solr Editions"
 msgstr ""
 
 #: work_search.html
+msgid "The search engine returned an error."
+msgstr ""
+
+#: work_search.html
+msgid "Solr Debugging:"
+msgstr ""
+
+#: work_search.html
+msgid "Full URL:"
+msgstr ""
+
+#: work_search.html
 #, python-format
 msgid "No <strong>%(path_id)s</strong> directly matched your search."
 msgstr ""
@@ -975,10 +987,6 @@ msgid "%(count)s hit"
 msgid_plural "%(count)s hits"
 msgstr[0] ""
 msgstr[1] ""
-
-#: work_search.html
-msgid "BARF! Search engine ERROR!"
-msgstr ""
 
 #: work_search.html
 #, python-format

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -33,7 +33,7 @@ from web.utils import Storage
 
 from infogami import config
 from infogami.infobase.client import Changeset, Nothing, Thing, storify
-from infogami.utils import delegate, stats, view
+from infogami.utils import delegate, features, stats, view
 from infogami.utils.context import InfogamiContext, context
 from infogami.utils.macro import macro
 from infogami.utils.view import (
@@ -311,8 +311,13 @@ def commify_list(items: Iterable[Any]) -> str:
 
 
 @public
-def json_encode(d) -> str:
-    return json.dumps(d)
+def json_encode(d, indent=0) -> str:
+    return json.dumps(d, indent=indent)
+
+
+@public
+def is_feature_enabled(feature_name: str) -> bool:
+    return features.is_enabled(feature_name)
 
 
 def unflatten(d: dict, separator: str = "--") -> dict:

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -45,6 +45,16 @@ $def with (q_param, search_response, get_doc, param, page, rows)
 
 <!-- results -->
 
+    $if search_response.error:
+      $ add_flash_message("error", _("The search engine returned an error."))
+      $if is_feature_enabled('debug'):
+        <div class="ol-message ol-message--warning">
+          <h3>$_("Solr Debugging:")</h3>
+          $search_response.error['msg']
+          <hr>
+          $_("Full URL:") <a href="$search_response.solr_select" target="_blank">$search_response.solr_select</a>
+        </div>
+
     $if param and not search_response.docs:
         $if ctx.path == '/search':
             $ path_id = 'books'
@@ -94,18 +104,18 @@ $def with (q_param, search_response, get_doc, param, page, rows)
 
 <!-- facets -->
 
-$if search_response.error:
-    <h3>$_("BARF! Search engine ERROR!")</h3>
-    <pre>$search_response.error.decode('utf-8', 'ignore')</pre>
-$elif param and len(search_response.docs):
+
+$if not search_response.error and param and len(search_response.docs):
     $:render_template('search/work_search_facets', param, facet_counts=search_response.facet_counts)
 <!-- /facets -->
     </div>
-
-    $if param and not search_response.error and len(search_response.docs):
-        $if ctx.user and ctx.user.is_admin():
-            <div id="adminTiming" class="small sansserif clearfix">
-                <br/><span class="adminOnly">$_('Searching solr took %(count)s seconds', count="%.2f" % search_response.time)</span>
-            </div>
+    $if search_response and ctx.user and ctx.user.is_admin():
+      <div id="adminTiming" class="small sansserif clearfix">
+        <a
+          class="adminOnly"
+          href="$search_response.solr_select"
+          target="_blank"
+        >$_('Searching solr took %(count)s seconds', count="%.2f" % search_response.time)</a>
+      </div>
   </div>
 </div>

--- a/static/css/components/ol-message.less
+++ b/static/css/components/ol-message.less
@@ -29,4 +29,8 @@
     color: hsl(hue(@red), saturation(@red), 35%);
     border: 1px solid currentColor;
   }
+
+  h1, h2, h3, h4, h5, h6 {
+    color: inherit;
+  }
 }


### PR DESCRIPTION
Some debugging utils added while working on #10405 .

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

If solr returns an error, all users will see a flash message:
![image](https://github.com/user-attachments/assets/e43948c9-25ec-4f9b-9f25-9bf476609f0f)

Users with the debug=KEY parameter will see an exact error + url:
![image](https://github.com/user-attachments/assets/8842c6c6-fda6-42da-823f-3335820209f2)

And regardless of error, all admins will now be able to view the full solr url used by clicking on the timing info at the bottom of the page:

![image](https://github.com/user-attachments/assets/ffb4aa80-a5bf-482c-8ad4-9923baffdb57)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
