### PR TITLE
Fix autocomplete results showing up on pageload

### DIFF
--- a/openlibrary/plugins/openlibrary/js/SearchBar.js
+++ b/openlibrary/plugins/openlibrary/js/SearchBar.js
@@ -364,8 +364,8 @@ export class SearchBar {
         const text = this.$facetSelect.find('option:selected').text();
         $('header#header-bar .search-facet-value').html(text);
 
-        // Add immediate refresh when input has value
-        if (this.$input.val()) {
+        // Add immediate refresh when input has value and focus is on the facet selector
+        if (this.$input.val() && this.$facetSelect.is(':focus')) {
             this.renderAutocompletionResults();
         }
     }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10484
Closes #10485

Addendum to #10415 ; we only want to show the results if the user has focus in the search bar component.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

https://testing.openlibrary.org/search?q=harry+potter&mode=everything does not auto-show the auto complete, but changing the search type selector _does_ cause them to appear.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
