### PR TITLE
Return correct type on failed availability enrichment

### DIFF
--- a/openlibrary/core/fulltext.py
+++ b/openlibrary/core/fulltext.py
@@ -59,7 +59,7 @@ def fulltext_search(q, page=1, limit=100, js=False, facets=False):
         ocaids = [hit['fields'].get('identifier', [''])[0] for hit in hits]
         availability = get_availability_of_ocaids(ocaids)
         if 'error' in availability:
-            return []
+            return {"hits": {"hits": []}}
         editions = web.ctx.site.get_many(
             [
                 '/books/%s' % availability[ocaid].get('openlibrary_edition')


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10499

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Ensures that `fulltext_search()` returns a `dict` when availability enrichment fails.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
