### PR TITLE
Prevent `data-config` sanitization on subject page macros.

### DIFF
--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -60,7 +60,9 @@ __all__ = [
 __docformat__ = "restructuredtext en"
 
 
-def sanitize(html: str, encoding: str = 'utf8', accept_attrs: None | list = None) -> str:
+def sanitize(
+    html: str, encoding: str = 'utf8', accept_attrs: None | list = None
+) -> str:
     """Removes unsafe tags and attributes from html and adds
     ``rel="nofollow"`` attribute to all external links.
     Using encoding=None if passing Unicode strings.

--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -60,7 +60,7 @@ __all__ = [
 __docformat__ = "restructuredtext en"
 
 
-def sanitize(html: str, encoding: str = 'utf8') -> str:
+def sanitize(html: str, encoding: str = 'utf8', accept_attrs: None | list = None) -> str:
     """Removes unsafe tags and attributes from html and adds
     ``rel="nofollow"`` attribute to all external links.
     Using encoding=None if passing Unicode strings.
@@ -98,10 +98,11 @@ def sanitize(html: str, encoding: str = 'utf8') -> str:
                 return html
         else:
             raise
-
+    _accept_attrs = set(accept_attrs) if accept_attrs else set()
+    safe_attrs = genshi.filters.HTMLSanitizer.SAFE_ATTRS | _accept_attrs
     stream = (
         html
-        | genshi.filters.HTMLSanitizer()
+        | genshi.filters.HTMLSanitizer(safe_attrs=safe_attrs)
         | genshi.filters.Transformer("//a").attr("rel", get_nofollow)
     )
     return stream.render()

--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -33,7 +33,7 @@ $ q = query_param('q')
     </span>
     $if has_tag:
       <p class="tag-description" itemprop="description">
-        $:sanitize(format(page.tag['tag_description']))
+        $:sanitize(format(page.tag['tag_description']), accept_attrs=['data-config'])
       </p>
     <a href="#search" class="shift">$_("Search for books with subject %(name)s.", name=page.name)</a>
 
@@ -54,7 +54,7 @@ $ q = query_param('q')
 </div>
 <div class="contentBody">
     $if has_tag:
-      $:sanitize(format(page.tag.body))
+      $:sanitize(format(page.tag.body), accept_attrs=['data-config'])
     $:render_template("books/custom_carousel", books=page.works, load_more={"url": page.key + ".json", "limit": len(page.works)})
     $:macros.PublishingHistory(page.publishing_history)
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10502

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Subject page `sanitize` calls were stripping the required `data-config` attribute from tag carousels, preventing them from being initialized successfully. This branch updates `sanitize`, adding a new `accept_attrs` parameter.  Any string in the `accept_attrs` list will be combined with the existing safe attributes set before the HTML is sanitized.

Noting that this will solve the issue at hand, but will potentially become cumbersome if/when new `data-*` attributes are used in macros which are rendered on this page (or other pages where input containing rendered macros is sanitized.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
