### PR TITLE
Sanitize tag body before rendering macros

### DIFF
--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -33,7 +33,7 @@ $ q = query_param('q')
     </span>
     $if has_tag:
       <p class="tag-description" itemprop="description">
-        $:sanitize(format(page.tag['tag_description']))
+        $:format(sanitize(page.tag['tag_description']))
       </p>
     <a href="#search" class="shift">$_("Search for books with subject %(name)s.", name=page.name)</a>
 
@@ -54,7 +54,7 @@ $ q = query_param('q')
 </div>
 <div class="contentBody">
     $if has_tag:
-      $:sanitize(format(page.tag.body))
+      $:format(sanitize(page.tag.body))
     $:render_template("books/custom_carousel", books=page.works, load_more={"url": page.key + ".json", "limit": len(page.works)})
     $:macros.PublishingHistory(page.publishing_history)
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10502

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
HTML sanitation was stripping a required `data-config` attribute from tag body carousels on the subject page.  This branch reverses the order of operations such that tag body HTML is sanitized before any macros are rendered.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
