### PR TITLE
Fix `if` block indentation in template

### DIFF
--- a/openlibrary/templates/account/view.html
+++ b/openlibrary/templates/account/view.html
@@ -8,8 +8,8 @@ $var title: $header_title
 
 <div class="mybooks">
   $if mb.is_my_page:
-  $ reading_goal_form = render_template('check_ins/reading_goal_form', year=current_year())
-  $:render_template('native_dialog', 'yearly-goal-modal', reading_goal_form, title=_('Yearly Reading Goal'))
+    $ reading_goal_form = render_template('check_ins/reading_goal_form', year=current_year())
+    $:render_template('native_dialog', 'yearly-goal-modal', reading_goal_form, title=_('Yearly Reading Goal'))
   $:mb.render_sidebar()
 
   $ css = 'no-padding' if mb.key == 'mybooks' else ''


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10508

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
A non-indented block of logic was preventing all content from rendering whenever the patron was not the my books page owner.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged out, visit a list page.  Does it render correctly?

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
