### PR TITLE
Throw `OLAuthenticationError` on `xauthn` `403` error

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -733,6 +733,8 @@ class InternetArchiveAccount(web.storage):
             params['developer'] = test
 
         response = requests.post(url, params=params, json=data)
+        if response.status_code == 403:
+            raise OLAuthenticationError("security_error")
         if response.status_code == 504 and op == "create":
             response.raise_for_status()
 

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -7832,6 +7832,12 @@ msgid "A problem occurred and we were unable to log you in"
 msgstr ""
 
 #: account.py
+msgid ""
+"Login or registration attempt hit an unexpected error, please try again "
+"or contact info@archive.org"
+msgstr ""
+
+#: account.py
 #, python-format
 msgid "Request failed with error code: %(error_code)s"
 msgstr ""

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -96,6 +96,7 @@ def get_login_error(error_key):
         "bad_email": _("Email provider not recognized."),
         "bad_password": _("Password requirements not met."),
         "undefined_error": _('A problem occurred and we were unable to log you in'),
+        "security_error": _("Login or registration attempt hit an unexpected error, please try again or contact info@archive.org"),
     }
     return (
         LOGIN_ERRORS[error_key]

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -96,7 +96,9 @@ def get_login_error(error_key):
         "bad_email": _("Email provider not recognized."),
         "bad_password": _("Password requirements not met."),
         "undefined_error": _('A problem occurred and we were unable to log you in'),
-        "security_error": _("Login or registration attempt hit an unexpected error, please try again or contact info@archive.org"),
+        "security_error": _(
+            "Login or registration attempt hit an unexpected error, please try again or contact info@archive.org"
+        ),
     }
     return (
         LOGIN_ERRORS[error_key]


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Creates new `security_error` authentication error code and message.  Throws `OLAuthenticationError` with the same status code whenever `InternetArchiveAccount.xauthn` calls return `403`s.

Providing a custom error code for these situations allows us to more easily find such errors in Sentry.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
