### PR TITLE
Normalize ISBN before masking

### DIFF
--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -22,7 +22,11 @@ from openlibrary.plugins.upstream.utils import MultiDict, get_identifier_config
 from openlibrary.plugins.worksearch.code import works_by_author
 from openlibrary.plugins.worksearch.search import get_solr
 from openlibrary.utils import dateutil  # noqa: F401 side effects may be needed
-from openlibrary.utils.isbn import isbn_10_to_isbn_13, isbn_13_to_isbn_10, normalize_isbn
+from openlibrary.utils.isbn import (
+    isbn_10_to_isbn_13,
+    isbn_13_to_isbn_10,
+    normalize_isbn,
+)
 from openlibrary.utils.lccn import normalize_lccn
 
 

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -22,7 +22,7 @@ from openlibrary.plugins.upstream.utils import MultiDict, get_identifier_config
 from openlibrary.plugins.worksearch.code import works_by_author
 from openlibrary.plugins.worksearch.search import get_solr
 from openlibrary.utils import dateutil  # noqa: F401 side effects may be needed
-from openlibrary.utils.isbn import isbn_10_to_isbn_13, isbn_13_to_isbn_10
+from openlibrary.utils.isbn import isbn_10_to_isbn_13, isbn_13_to_isbn_10, normalize_isbn
 from openlibrary.utils.lccn import normalize_lccn
 
 
@@ -114,11 +114,12 @@ class Edition(models.Edition):
     def get_isbnmask(self):
         """Returns a masked (hyphenated) ISBN if possible."""
         isbns = self.get('isbn_13', []) + self.get('isbn_10', [None])
-        try:
-            isbn = mask(isbns[0])
-        except NotValidISBNError:
-            return isbns[0]
-        return isbn or isbns[0]
+        if isbn := normalize_isbn(isbns[0]):
+            try:
+                isbn = mask(isbns[0])
+            except NotValidISBNError:
+                return isbn
+        return isbn
 
     def get_identifiers(self):
         """Returns (name, value) pairs of all available identifiers."""


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10516

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
@mekarpeles provided a different approach: Normalize ISBNs before attempting to mask them.  This will significantly cut down the number of invalid ISBN events being logged, and help surface more problematic errors.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
