### PR TITLE
Fix i18n redirect $path for book edit -> login

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -626,15 +626,17 @@ msgid "Permission denied."
 msgstr ""
 
 #: permission_denied.html
+#, python-format
 msgid ""
 "Only logged users are allowed to add records on Open Library. Please <a "
-"href=\"/account/login?redirect=$path\">log in</a> to add a book."
+"href=\"%s\">log in</a> to add a book."
 msgstr ""
 
 #: permission_denied.html
+#, python-format
 msgid ""
 "Only logged users are allowed to modify records on Open Library. Please "
-"<a href=\"/account/login?redirect=$path\">log in</a> to edit this page."
+"<a href=\"%s\">log in</a> to edit this page."
 msgstr ""
 
 #: permission_denied.html

--- a/openlibrary/templates/permission_denied.html
+++ b/openlibrary/templates/permission_denied.html
@@ -13,9 +13,9 @@ $var title: $_("Permission Denied")
 
 $if not ctx.user:
     $if path == "/books/add":
-        <p>$:_('Only logged users are allowed to add records on Open Library. Please <a href="/account/login?redirect=$path">log in</a> to add a book.')</p>
+        <p>$:_('Only logged users are allowed to add records on Open Library. Please <a href="%s">log in</a> to add a book.', "/account/login?redirect=" + path)</p>
     $elif path.startswith("/books/") or path.startswith("/works/") or path.startswith("/authors/"):
-        <p>$:_('Only logged users are allowed to modify records on Open Library. Please <a href="/account/login?redirect=$path">log in</a> to edit this page.')</p>
+        <p>$:_('Only logged users are allowed to modify records on Open Library. Please <a href="%s">log in</a> to edit this page.', "/account/login?redirect=" + path)</p></p>
     $else:
         <p>$:_('You may <a href="%s">log in</a> if you have the required permissions.', "/account/login?" + urlencode(dict(redirect=path)))</p>
 

--- a/openlibrary/templates/permission_denied.html
+++ b/openlibrary/templates/permission_denied.html
@@ -13,9 +13,9 @@ $var title: $_("Permission Denied")
 
 $if not ctx.user:
     $if path == "/books/add":
-        <p>$:_('Only logged users are allowed to add records on Open Library. Please <a href="%s">log in</a> to add a book.', "/account/login?redirect=" + path)</p>
+        <p>$:_('Only logged users are allowed to add records on Open Library. Please <a href="%s">log in</a> to add a book.', "/account/login?" + urlencode(dict(redirect=path)))</p>
     $elif path.startswith("/books/") or path.startswith("/works/") or path.startswith("/authors/"):
-        <p>$:_('Only logged users are allowed to modify records on Open Library. Please <a href="%s">log in</a> to edit this page.', "/account/login?redirect=" + path)</p></p>
+        <p>$:_('Only logged users are allowed to modify records on Open Library. Please <a href="%s">log in</a> to edit this page.', "/account/login?" + urlencode(dict(redirect=path)))</p>
     $else:
         <p>$:_('You may <a href="%s">log in</a> if you have the required permissions.', "/account/login?" + urlencode(dict(redirect=path)))</p>
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10524

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

See [Breakdown](https://github.com/internetarchive/openlibrary/issues/10524#:~:text=Breakdown) 

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

While logged out / incognito, go to https://openlibrary.org/books/OL51322877M/Averting_the_Digital_Dark_Age/edit

The `log in` link should redirect to something like: `https://openlibrary.org/account/login?redirect=/books/OL51322877M/Averting_the_Digital_Dark_Age/edit`

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

https://testing.openlibrary.org/books/OL51322877M/Averting_the_Digital_Dark_Age/edit

<img width="888" alt="Screenshot 2025-03-01 at 9 35 07 AM" src="https://github.com/user-attachments/assets/587af0fc-0d85-4dde-93b7-87031a44c916" />

### Problems

Considering out of scope for this PR; The `$path` now works correctly, but because the `$path` resolved to `/books/OL51322877M/edit`, the url preprocessor considers `edit` to be the (wrong) title and thus redirects the patron to https://openlibrary.org/books/OL51322877M/Averting_the_Digital_Dark_Age instead of https://openlibrary.org/books/OL51322877M/Averting_the_Digital_Dark_Age/edit

This is because
https://github.com/internetarchive/openlibrary/blob/fa5693fc23ffb01191942d847c4f6e959927feea/openlibrary/core/processors/readableurls.py#L24-L26

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
