### PR TITLE
guard against web.ctx.features AttributeError in cache contexts

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -30,7 +30,7 @@ if not hasattr(infogami.config, 'features'):
 import openlibrary.core.stats
 from infogami.core.db import ValidationException
 from infogami.infobase import client
-from infogami.utils import delegate, features
+from infogami.utils import delegate
 from infogami.utils.app import metapage
 from infogami.utils.view import (
     add_flash_message,

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1141,7 +1141,7 @@ def internalerror():
     if sentry.enabled:
         sentry.capture_exception_webpy()
 
-    if web.ctx and features.is_enabled('debug'):
+    if getattr(web, 'ctx') and features.is_enabled('debug'):
         raise web.debugerror()
     else:
         msg = render.site(

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1141,10 +1141,7 @@ def internalerror():
     if sentry.enabled:
         sentry.capture_exception_webpy()
 
-    # Protect against ThreadedDict memcache issues
-    if not hasattr(web, 'ctx'):
-        delegate.fakeload()
-    if features.is_enabled('debug'):
+    if 'debug' in infogami.config.features:
         raise web.debugerror()
     else:
         msg = render.site(

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1141,7 +1141,7 @@ def internalerror():
     if sentry.enabled:
         sentry.capture_exception_webpy()
 
-    if getattr(web, 'ctx') and features.is_enabled('debug'):
+    if web.ctx and features.is_enabled('debug'):
         raise web.debugerror()
     else:
         msg = render.site(

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -30,7 +30,7 @@ if not hasattr(infogami.config, 'features'):
 import openlibrary.core.stats
 from infogami.core.db import ValidationException
 from infogami.infobase import client
-from infogami.utils import delegate
+from infogami.utils import delegate, features
 from infogami.utils.app import metapage
 from infogami.utils.view import (
     add_flash_message,
@@ -1141,7 +1141,7 @@ def internalerror():
     if sentry.enabled:
         sentry.capture_exception_webpy()
 
-    if 'debug' in infogami.config.features:
+    if getattr(web, 'ctx') and features.is_enabled('debug'):
         raise web.debugerror()
     else:
         msg = render.site(

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1141,7 +1141,7 @@ def internalerror():
     if sentry.enabled:
         sentry.capture_exception_webpy()
 
-    # Protect against ThreadedDict memcache issues                                                                                             
+    # Protect against ThreadedDict memcache issues
     if not hasattr(web, 'ctx'):
         delegate.fakeload()
     if features.is_enabled('debug'):

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1141,7 +1141,7 @@ def internalerror():
     if sentry.enabled:
         sentry.capture_exception_webpy()
 
-    if web.ctx and features.is_enabled('debug'):
+    if hasattr(web, 'ctx') and features.is_enabled('debug'):
         raise web.debugerror()
     else:
         msg = render.site(

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1141,6 +1141,9 @@ def internalerror():
     if sentry.enabled:
         sentry.capture_exception_webpy()
 
+    # Protect against ThreadedDict memcache issues                                                                                             
+    if not hasattr(web, 'ctx'):
+        delegate.fakeload()
     if features.is_enabled('debug'):
         raise web.debugerror()
     else:


### PR DESCRIPTION
Guard against the `features.is_enabled` failures in cache (when recomputed in threads), check `hasattr(web, 'ctx')`

* should only work on testing/prod if queryparam matches `value` for `debug` feature.

<!-- What issue does this PR close? -->
Closes #10341

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

Tested on mek / staging.

See [technical notes here](https://github.com/internetarchive/openlibrary/issues/10341#issuecomment-2692826036)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Confirmed debug page still works (may require a few attempts to trigger solr timeout, requires correct debug key) https://openlibrary.org/search?q=language:eng&debug=xxx

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
