### PR TITLE
Add Wikidata table export to data dumps (#10383)

### DIFF
--- a/scripts/dump-wikidata.sql
+++ b/scripts/dump-wikidata.sql
@@ -1,0 +1,6 @@
+-- Script to export Wikidata table from the Open Library database
+-- When called, this will export the entire wikidata table as a TSV file
+-- Usage: psql $PSQL_PARAMS -f dump-wikidata.sql | gzip -c > ol_dump_wikidata_YYYY-MM-DD.txt.gz
+
+-- Export all rows from the wikidata table as tab-separated values
+COPY wikidata TO STDOUT WITH (FORMAT csv, DELIMITER E'\t');

--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -134,8 +134,8 @@ then
       log "Skipping: $(compgen -G "ol_dump_ratings_$yyyymm*.txt.gz")"
   fi
 
-  # New step for Wikidata dump
-  log "=== Step 3.5 ===" # Using 3.5 to insert between existing steps
+  log "=== Step 4 ==="
+  # Generate Wikidata dump
   if [[ ! -f $(compgen -G "ol_dump_wikidata_$yyyymm*.txt.gz") ]]
   then
       log "generating wikidata table: ol_dump_wikidata_$yyyymmdd.txt.gz"
@@ -144,7 +144,7 @@ then
       log "Skipping: $(compgen -G "ol_dump_wikidata_$yyyymm*.txt.gz")"
   fi
 
-  log "=== Step 4 ==="
+  log "=== Step 5 ==="
   if [[ ! -f "data.txt.gz" ]]
   then
       log "generating the data table: data.txt.gz -- takes approx. 110 minutes..."
@@ -158,7 +158,7 @@ then
   fi
 
 
-  log "=== Step 5 ==="
+  log "=== Step 6 ==="
   if [[ ! -f $(compgen -G "ol_cdump_$yyyymm*.txt.gz") ]]
   then
       # generate cdump, sort and generate dump
@@ -171,7 +171,7 @@ then
   fi
 
 
-  log "=== Step 6 ==="
+  log "=== Step 7 ==="
   if [[ ! -f $(compgen -G "ol_dump_*.txt.gz") ]]
   then
       log "generating the dump -- takes approx. 485 minutes for 173,000,000+ records..."
@@ -182,7 +182,7 @@ then
   fi
 
 
-  log "=== Step 7 ==="
+  log "=== Step 8 ==="
   if [[ ! -f $(compgen -G "ol_dump_*_$yyyymm*.txt.gz") ]]
   then
       mkdir -p $TMPDIR/oldumpsort

--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -134,6 +134,15 @@ then
       log "Skipping: $(compgen -G "ol_dump_ratings_$yyyymm*.txt.gz")"
   fi
 
+  # New step for Wikidata dump
+  log "=== Step 3.5 ===" # Using 3.5 to insert between existing steps
+  if [[ ! -f $(compgen -G "ol_dump_wikidata_$yyyymm*.txt.gz") ]]
+  then
+      log "generating wikidata table: ol_dump_wikidata_$yyyymmdd.txt.gz"
+      time psql $PSQL_PARAMS -f $SCRIPTS/dump-wikidata.sql | gzip -c > ol_dump_wikidata_$yyyymmdd.txt.gz
+  else
+      log "Skipping: $(compgen -G "ol_dump_wikidata_$yyyymm*.txt.gz")"
+  fi
 
   log "=== Step 4 ==="
   if [[ ! -f "data.txt.gz" ]]


### PR DESCRIPTION
Add wikidata dump to included dumps (#10383)

This adds support for generating Wikidata dumps alongside existing dumps like ratings and reading logs. The new dumps follow the ol_dump_wikidata_YYYY-MM-DD.txt.gz naming convention.
- Creates new dump-wikidata.sql script for TSV export
- Updates oldump.sh to include Wikidata dump generation
- Follows existing patterns for file naming and processing

<!-- What issue does this PR close? -->
Closes #10383

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
### Technical
- Added a new SQL script (dump-wikidata.sql) that exports the wikidata table as TSV
- Modified oldump.sh to add a new step for generating the wikidata dump
- Used the same conditional logic as other dumps to prevent regenerating existing dumps

### Testing
- Run the oldump.sh script locally with a test database
- Verify the wikidata dump is created with the correct naming convention
- Confirm the dump contains the expected TSV data from the wikidata table

### Screenshot
N/A - Backend feature

### Stakeholders
@cdrini