### PR TITLE
Change Thriller + Textbooks query carousels (homepage) 

### DIFF
--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -18,12 +18,6 @@ from openlibrary.utils import dateutil
 logger = logging.getLogger("openlibrary.home")
 
 CAROUSELS_PRESETS = {
-    'preset:thrillers': (
-        '(creator:"Clancy, Tom" OR creator:"King, Stephen" OR creator:"Clive Cussler" '
-        'OR creator:("Cussler, Clive") OR creator:("Dean Koontz") OR creator:("Koontz, '
-        'Dean") OR creator:("Higgins, Jack")) AND !publisher:"Pleasantville, N.Y. : '
-        'Reader\'s Digest Association" AND languageSorter:"English"'
-    ),
     'preset:comics': (
         '(subject:"comics" OR creator:("Gary Larson") OR creator:("Larson, Gary") '
         'OR creator:("Charles M Schulz") OR creator:("Schulz, Charles M") OR '

--- a/openlibrary/plugins/openlibrary/tests/test_home.py
+++ b/openlibrary/plugins/openlibrary/tests/test_home.py
@@ -127,9 +127,7 @@ class TestHomeTemplates:
             "Books We Love",
             "Recently Returned",
             "Kids",
-            "Thrillers",
             "Romance",
-            "Textbooks",
         ]
         for h in headers:
             assert h in html

--- a/openlibrary/plugins/openlibrary/tests/test_home.py
+++ b/openlibrary/plugins/openlibrary/tests/test_home.py
@@ -127,6 +127,7 @@ class TestHomeTemplates:
             "Books We Love",
             "Recently Returned",
             "Kids",
+            "Thrillers",
             "Romance",
             "Textbooks",
         ]

--- a/openlibrary/plugins/openlibrary/tests/test_home.py
+++ b/openlibrary/plugins/openlibrary/tests/test_home.py
@@ -127,7 +127,6 @@ class TestHomeTemplates:
             "Books We Love",
             "Recently Returned",
             "Kids",
-            "Thrillers",
             "Romance",
             "Textbooks",
         ]

--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -34,7 +34,7 @@ $add_metatag(name="twitter:card", content="homepage_summary")
 
   $if not test:
     $:macros.QueryCarousel(query="subject:thrillers ratings_count:[10 TO *] ebook_access:[borrowable TO *]", title=_('Thrillers'), key="thrillers", url="/subjects/thrillers", sort='random.hourly', use_cache=False)
-    $:macros.QueryCarousel(query="subject:textbooks ratings_count:[10 TO *] ebook_access:[borrowable TO *]", title=_('Textbooks'), key="textbooks", url="/subjects/textbooks", sort='random.hourly', use_cache=False)
+    $:macros.QueryCarousel(query="subject_key:textbooks publish_year:[1990 TO *] readinglog_count :[5 TO *] ebook_access:[borrowable TO *]", title=_('Textbooks'), key="textbooks", url="/subjects/textbooks", sort='random.hourly', use_cache=False)
 
   $:render_template("home/custom_ia_carousel", title="Authors Alliance & MIT Press", key="authorsalliance_mit_press", query="preset:authorsalliance_mitpress", limit=18, test=test)
 

--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -32,7 +32,7 @@ $add_metatag(name="twitter:card", content="homepage_summary")
 
   $:render_template("home/custom_ia_carousel", title=_('Kids'), key="children", query="subject:(Juvenile Fiction)", sorts=["lending___last_browse desc"], limit=18, test=test)
 
-  $:render_template("home/custom_ia_carousel", title=_('Thrillers'), key="thrillers", query="preset:thrillers", sorts=["downloads desc"], limit=18, test=test)
+  $:macros.QueryCarousel(query="subject:thrillers ratings_count:[10 TO *] ebook_access:[borrowable TO *]", title=_('Thrillers'), key="thrillers", url="/subjects/thrillers", sort='random.hourly', use_cache=False)
 
   $:render_template("home/custom_ia_carousel", title=_('Textbooks'), key="textbooks", subject="textbooks", sorts=["lending___last_browse desc"], limit=18, test=test)
 

--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -32,10 +32,10 @@ $add_metatag(name="twitter:card", content="homepage_summary")
 
   $:render_template("home/custom_ia_carousel", title=_('Kids'), key="children", query="subject:(Juvenile Fiction)", sorts=["lending___last_browse desc"], limit=18, test=test)
 
-  $:macros.QueryCarousel(query="subject:thrillers ratings_count:[10 TO *] ebook_access:[borrowable TO *]", title=_('Thrillers'), key="thrillers", url="/subjects/thrillers", sort='random.hourly', use_cache=False)
-
-  $:render_template("home/custom_ia_carousel", title=_('Textbooks'), key="textbooks", subject="textbooks", sorts=["lending___last_browse desc"], limit=18, test=test)
-
+  $if not test:
+    $:macros.QueryCarousel(query="subject:thrillers ratings_count:[10 TO *] ebook_access:[borrowable TO *]", title=_('Thrillers'), key="thrillers", url="/subjects/thrillers", sort='random.hourly', use_cache=False)
+    $:macros.QueryCarousel(query="subject:textbooks ratings_count:[10 TO *] ebook_access:[borrowable TO *]", title=_('Textbooks'), key="textbooks", url="/subjects/textbooks", sort='random.hourly', use_cache=False)
+  
   $:render_template("home/custom_ia_carousel", title="Authors Alliance & MIT Press", key="authorsalliance_mit_press", query="preset:authorsalliance_mitpress", limit=18, test=test)
 
   $:render_template("home/categories", test=test)

--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -35,7 +35,7 @@ $add_metatag(name="twitter:card", content="homepage_summary")
   $if not test:
     $:macros.QueryCarousel(query="subject:thrillers ratings_count:[10 TO *] ebook_access:[borrowable TO *]", title=_('Thrillers'), key="thrillers", url="/subjects/thrillers", sort='random.hourly', use_cache=False)
     $:macros.QueryCarousel(query="subject:textbooks ratings_count:[10 TO *] ebook_access:[borrowable TO *]", title=_('Textbooks'), key="textbooks", url="/subjects/textbooks", sort='random.hourly', use_cache=False)
-  
+
   $:render_template("home/custom_ia_carousel", title="Authors Alliance & MIT Press", key="authorsalliance_mit_press", query="preset:authorsalliance_mitpress", limit=18, test=test)
 
   $:render_template("home/categories", test=test)


### PR DESCRIPTION
Closes #9043

Thriller Carousel in the homepage is populated based on a query instead of using presets based on specific authors. 