### PR TITLE
Add multiple platform support for olbase build

### DIFF
--- a/.github/workflows/olbase.yaml
+++ b/.github/workflows/olbase.yaml
@@ -36,6 +36,7 @@ jobs:
         with:
           context: "."
           file: "./docker/Dockerfile.olbase"
+          platforms: linux/amd64,linux/arm64
           tags: openlibrary/olbase:latest
           push: true
 
@@ -46,5 +47,6 @@ jobs:
         with:
           context: "."
           file: "./docker/Dockerfile.olbase"
+          platforms: linux/amd64,linux/arm64
           tags: openlibrary/olbase:${{ github.ref_name }}
           push: true

--- a/.github/workflows/olbase.yaml
+++ b/.github/workflows/olbase.yaml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
+      # To test this GitHub action, you can create an upstream branch, and manually trigger
+      # it from GitHub. The tag name of the image will be your branch name, so don't use
+      # any weird characters. Note this will not work with a fork ; you need an upstream branch!
       TAG_NAME: ${{ github.ref == 'refs/heads/master' && 'latest' || github.ref_name }}
 
     steps:

--- a/.github/workflows/olbase.yaml
+++ b/.github/workflows/olbase.yaml
@@ -12,13 +12,14 @@ jobs:
   docker:
     if: github.repository_owner == 'internetarchive'
     runs-on: ubuntu-latest
+
+    env:
+      TAG_NAME: ${{ github.ref == 'refs/heads/master' && 'latest' || github.ref_name }}
+
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -29,72 +30,68 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # If on master, use the latest tag, otherwise use the branch name
-      - name: Master Build and push amd64
+      - name: Build and push amd64
         uses: docker/build-push-action@v6
-        if: github.ref == 'refs/heads/master'
         with:
           context: "."
           file: "./docker/Dockerfile.olbase"
           platforms: linux/amd64
-          tags: openlibrary/olbase:latest
+          tags: openlibrary/olbase:${{ env.TAG_NAME }}
           push: true
 
-      - name: Master Build and push arm64
+  docker-arm64:
+    if: github.repository_owner == 'internetarchive'
+    runs-on: ubuntu-24.04-arm
+
+    env:
+      TAG_NAME: ${{ github.ref == 'refs/heads/master' && 'latest' || github.ref_name }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
         uses: docker/build-push-action@v6
-        if: github.ref == 'refs/heads/master'
         with:
           context: "."
           file: "./docker/Dockerfile.olbase"
           platforms: linux/arm64
-          tags: openlibrary/olbase:latest-arm64
+          tags: openlibrary/olbase:${{ env.TAG_NAME }}-arm64
           push: true
+
+  combine-manifests:
+    needs: [docker, docker-arm64]
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'internetarchive'
+    env:
+      TAG_NAME: ${{ github.ref == 'refs/heads/master' && 'latest' || github.ref_name }}
+
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Combine the manifests of the amd and arm images in a manifest
-        if: github.ref == 'refs/heads/master'
         run: |
           # Pull out the digests
-          AMD64_DIGEST=$(docker manifest inspect openlibrary/olbase:latest | jq -r '.manifests[0].digest')
-          ARM64_DIGEST=$(docker manifest inspect openlibrary/olbase:latest-arm64 | jq -r '.manifests[0].digest')
+          AMD64_DIGEST=$(docker manifest inspect openlibrary/olbase:${{ env.TAG_NAME }} | jq -r '.manifests[0].digest')
+          ARM64_DIGEST=$(docker manifest inspect openlibrary/olbase:${{ env.TAG_NAME }}-arm64 | jq -r '.manifests[0].digest')
 
-          docker manifest create openlibrary/olbase:latest \
+          docker manifest create openlibrary/olbase:${{ env.TAG_NAME }} \
             openlibrary/olbase@${AMD64_DIGEST} \
             openlibrary/olbase@${ARM64_DIGEST}
-          docker manifest annotate openlibrary/olbase:latest openlibrary/olbase@${AMD64_DIGEST}
-          docker manifest annotate openlibrary/olbase:latest openlibrary/olbase@${ARM64_DIGEST}
-          docker manifest push openlibrary/olbase:latest
-
-      # If on another branch, use the branch name -- just the branch name, not the full ref
-      - name: Test Branch Build and push amd64
-        uses: docker/build-push-action@v6
-        if: github.ref != 'refs/heads/master'
-        with:
-          context: "."
-          file: "./docker/Dockerfile.olbase"
-          platforms: linux/amd64
-          tags: openlibrary/olbase:${{ github.ref_name }}
-          push: true
-
-      - name: Test Branch Build and push arm64
-        uses: docker/build-push-action@v6
-        if: github.ref != 'refs/heads/master'
-        with:
-          context: "."
-          file: "./docker/Dockerfile.olbase"
-          platforms: linux/arm64
-          tags: openlibrary/olbase:${{ github.ref_name }}-arm64
-          push: true
-
-      - name: Test Branch Combine the manifests of the amd and arm images in a manifest
-        if: github.ref != 'refs/heads/master'
-        run: |
-          # Pull out the digests
-          AMD64_DIGEST=$(docker manifest inspect openlibrary/olbase:${{ github.ref_name }} | jq -r '.manifests[0].digest')
-          ARM64_DIGEST=$(docker manifest inspect openlibrary/olbase:${{ github.ref_name }}-arm64 | jq -r '.manifests[0].digest')
-
-          docker manifest create openlibrary/olbase:${{ github.ref_name }} \
-            openlibrary/olbase@${AMD64_DIGEST} \
-            openlibrary/olbase@${ARM64_DIGEST}
-          docker manifest annotate openlibrary/olbase:${{ github.ref_name }} openlibrary/olbase@${AMD64_DIGEST}
-          docker manifest annotate openlibrary/olbase:${{ github.ref_name }} openlibrary/olbase@${ARM64_DIGEST}
-          docker manifest push openlibrary/olbase:${{ github.ref_name }}
+          docker manifest annotate openlibrary/olbase:${{ env.TAG_NAME }} openlibrary/olbase@${AMD64_DIGEST}
+          docker manifest annotate openlibrary/olbase:${{ env.TAG_NAME }} openlibrary/olbase@${ARM64_DIGEST}
+          docker manifest push openlibrary/olbase:${{ env.TAG_NAME }}

--- a/.github/workflows/olbase.yaml
+++ b/.github/workflows/olbase.yaml
@@ -30,23 +30,71 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # If on master, use the latest tag, otherwise use the branch name
-      - name: Master Build and push
+      - name: Master Build and push amd64
         uses: docker/build-push-action@v6
         if: github.ref == 'refs/heads/master'
         with:
           context: "."
           file: "./docker/Dockerfile.olbase"
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: openlibrary/olbase:latest
           push: true
 
+      - name: Master Build and push arm64
+        uses: docker/build-push-action@v6
+        if: github.ref == 'refs/heads/master'
+        with:
+          context: "."
+          file: "./docker/Dockerfile.olbase"
+          platforms: linux/arm64
+          tags: openlibrary/olbase:latest-arm64
+          push: true
+
+      - name: Combine the manifests of the amd and arm images in a manifest
+        if: github.ref == 'refs/heads/master'
+        run: |
+          # Pull out the digests
+          AMD64_DIGEST=$(docker manifest inspect openlibrary/olbase:latest | jq -r '.manifests[0].digest')
+          ARM64_DIGEST=$(docker manifest inspect openlibrary/olbase:latest-arm64 | jq -r '.manifests[0].digest')
+
+          docker manifest create openlibrary/olbase:latest \
+            openlibrary/olbase@${AMD64_DIGEST} \
+            openlibrary/olbase@${ARM64_DIGEST}
+          docker manifest annotate openlibrary/olbase:latest openlibrary/olbase@${AMD64_DIGEST}
+          docker manifest annotate openlibrary/olbase:latest openlibrary/olbase@${ARM64_DIGEST}
+          docker manifest push openlibrary/olbase:latest
+
       # If on another branch, use the branch name -- just the branch name, not the full ref
-      - name: Test Branch Build and push
+      - name: Test Branch Build and push amd64
         uses: docker/build-push-action@v6
         if: github.ref != 'refs/heads/master'
         with:
           context: "."
           file: "./docker/Dockerfile.olbase"
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: openlibrary/olbase:${{ github.ref_name }}
           push: true
+
+      - name: Test Branch Build and push arm64
+        uses: docker/build-push-action@v6
+        if: github.ref != 'refs/heads/master'
+        with:
+          context: "."
+          file: "./docker/Dockerfile.olbase"
+          platforms: linux/arm64
+          tags: openlibrary/olbase:${{ github.ref_name }}-arm64
+          push: true
+
+      - name: Test Branch Combine the manifests of the amd and arm images in a manifest
+        if: github.ref != 'refs/heads/master'
+        run: |
+          # Pull out the digests
+          AMD64_DIGEST=$(docker manifest inspect openlibrary/olbase:${{ github.ref_name }} | jq -r '.manifests[0].digest')
+          ARM64_DIGEST=$(docker manifest inspect openlibrary/olbase:${{ github.ref_name }}-arm64 | jq -r '.manifests[0].digest')
+
+          docker manifest create openlibrary/olbase:${{ github.ref_name }} \
+            openlibrary/olbase@${AMD64_DIGEST} \
+            openlibrary/olbase@${ARM64_DIGEST}
+          docker manifest annotate openlibrary/olbase:${{ github.ref_name }} openlibrary/olbase@${AMD64_DIGEST}
+          docker manifest annotate openlibrary/olbase:${{ github.ref_name }} openlibrary/olbase@${ARM64_DIGEST}
+          docker manifest push openlibrary/olbase:${{ github.ref_name }}


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10276

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->
The solution is highly duplicative; in a future issue/PR we might want to see how we could potentially DRY up the approaches, but we need to ensure that the amd64 build finishes/pushes as quickly as possible! I think our best bet is seeing how can basically do `tag = 'latest' if master else branch_name`, and then the Master/Test duplication disappears.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

To test locally:
- ✅ On an amd machine, run: `docker run --rm --pull always openlibrary/olbase:olbase-platforms echo Success`
- On an arm machine, run: `docker run --rm --pull always openlibrary/olbase:olbase-platforms echo Success`

The CI job passess!! https://github.com/internetarchive/openlibrary/actions/runs/15350887215/job/43198548359

And the docker hub lists both the arch's in its build!

![image](https://github.com/user-attachments/assets/64aca110-a0e1-418f-af3d-0c394912a8fd)

https://hub.docker.com/r/openlibrary/olbase/tags

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
