### PR TITLE
Send all Sentry events before `cron_wrapper` script exits

### DIFF
--- a/scripts/cron_wrapper.py
+++ b/scripts/cron_wrapper.py
@@ -32,8 +32,11 @@ class MonitoredJob:
         try:
             self._run_script()
         except subprocess.CalledProcessError as e:
-            sentry_sdk.capture_exception(e)
+            se = RuntimeError(f"Subprocess failed: {e}\n{e.stderr}")
+            sentry_sdk.capture_exception(se)
             self.job_failed = True
+            sys.stderr.write(e.stderr)
+            sys.stderr.flush()            
         finally:
             self._after_run()
             sentry_sdk.flush()

--- a/scripts/cron_wrapper.py
+++ b/scripts/cron_wrapper.py
@@ -52,7 +52,11 @@ class MonitoredJob:
 
     def _run_script(self):
         return subprocess.run(
-            self.command, text=True, stdout=sys.stdout, stderr=subprocess.PIPE, check=True
+            self.command,
+            text=True,
+            stdout=sys.stdout,
+            stderr=subprocess.PIPE,
+            check=True,
         )
 
     def _setup_sentry(self, dsn):

--- a/scripts/cron_wrapper.py
+++ b/scripts/cron_wrapper.py
@@ -66,6 +66,7 @@ class MonitoredJob:
         return StatsClient(host, port)
 
     def _get_job_name(self):
+        # TODO: Change to specify a --script as argparse arg (instead of scripts path)
         script_path = next(
             s for s in self.command if s.startswith("/openlibrary/scripts/")
         )

--- a/scripts/cron_wrapper.py
+++ b/scripts/cron_wrapper.py
@@ -52,7 +52,7 @@ class MonitoredJob:
 
     def _run_script(self):
         return subprocess.run(
-            self.command, text=True, stdout=sys.stdout, stderr=sys.stderr, check=True
+            self.command, text=True, stdout=sys.stdout, stderr=subprocess.PIPE, check=True
         )
 
     def _setup_sentry(self, dsn):

--- a/scripts/cron_wrapper.py
+++ b/scripts/cron_wrapper.py
@@ -36,6 +36,7 @@ class MonitoredJob:
             self.job_failed = True
         finally:
             self._after_run()
+            sentry_sdk.flush()
 
     def _before_run(self):
         if self.statsd_client:


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Whenever wrapped cron jobs fail today, we see the following message in our logs:

```
Sentry is attempting to send 2 pending events
Waiting up to 2 seconds
Press Ctrl-C to quit
```

This is indicative of the script shutting down before all events can be sent to Sentry.

This PR uses `sentry_sdk.flush()` to wait until all events are sent after a monitored cron job has run.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
