### PR TITLE
Exclude search time from `/search` pages if no search occurred

### DIFF
--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -109,7 +109,7 @@ $if not search_response.error and param and len(search_response.docs):
     $:render_template('search/work_search_facets', param, facet_counts=search_response.facet_counts)
 <!-- /facets -->
     </div>
-    $if search_response and ctx.user and ctx.user.is_admin():
+    $if search_response.time and ctx.user and ctx.user.is_admin():
       <div id="adminTiming" class="small sansserif clearfix">
         <a
           class="adminOnly"


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10541

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
On `/search` pages, checks for the existence of `search_response.time` before formatting the same as a number.  If this `search_response.time` does not exist, the `Search solr took {n} seconds` message will not be displayed.

This change should only affect admins.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
