### PR TITLE
Show deployment script override hint when critical crons are running

### DIFF
--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -71,6 +71,9 @@ check_crons() {
         echo "✗"
         echo "Critical cron jobs are currently running. Halting deployment:"
         echo "$RUNNING_CRONS"
+        echo ""
+        echo "Set KILL_CRON=1 and run script again to override."
+        echo ""
         exit 1
     else
         echo "✓"


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Prints deployment script override hint before exiting when critical cron jobs are running.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
