### PR TITLE
On search results, show preview beneath cover

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -83,7 +83,7 @@
     },
     {
       "path": "static/build/page-form.css",
-      "maxSize": "25.2KB"
+      "maxSize": "25.3KB"
     },
     {
       "path": "static/build/page-home.css",

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -79,7 +79,7 @@
     },
     {
       "path": "static/build/page-edit.css",
-      "maxSize": "25.1KB"
+      "maxSize": "25.2KB"
     },
     {
       "path": "static/build/page-form.css",

--- a/openlibrary/macros/BookPreview.html
+++ b/openlibrary/macros/BookPreview.html
@@ -1,7 +1,7 @@
 $def with (ocaid, analytics_attr=None, show_only=False)
 $# :param str ocaid:
 
-$ analytics = analytics_attr('Preview') if analytics_attr else "CTAClick|Preview"
+$ analytics = analytics_attr('Preview') if analytics_attr else 'data-ol-link-track="CTAClick|Preview"'
 
   <div class="cta-button-group">
     <a class="cta-btn cta-btn--preview"

--- a/openlibrary/macros/BookPreview.html
+++ b/openlibrary/macros/BookPreview.html
@@ -1,11 +1,13 @@
-$def with (ocaid, analytics_attr, show_only=False)
+$def with (ocaid, analytics_attr=None, show_only=False)
 $# :param str ocaid:
+
+$ analytics = analytics_attr('Preview') if analytics_attr else "CTAClick|Preview"
 
   <div class="cta-button-group">
     <a class="cta-btn cta-btn--preview"
       data-iframe-src="https://archive.org/details/$ocaid?view=theater&wrapper=false"
-      data-iframe-link="https://archive.org/details/$ocaid"
-      $:analytics_attr('Preview') href="#bookPreview">$(_('Preview Only') if show_only else _('Preview'))</a>
+       data-iframe-link="https://archive.org/details/$ocaid"
+      $:analytics href="#bookPreview">$(_('Preview Only') if show_only else _('Preview'))</a>
   </div>
 
 $if render_once('book-preview-floater'):

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -13,6 +13,9 @@ $code:
   if doc_type == 'solr_edition':
     selected_ed = doc.get('editions')[0]
 
+  selected_ed['availability'] = selected_ed.get('availability', {}) or doc.get('availability', {}) or availability or {}
+  ocaid = (selected_ed.get('ia') and selected_ed['ia'][0]) or selected_ed.get('ocaid')
+
   book_url = doc.url() if doc_type.startswith('infogami_') else doc.key
   if doc_type == 'solr_edition':
     work_edition_url = book_url + '?edition=' + urlquote('key:' + selected_ed.key)
@@ -52,12 +55,15 @@ $code:
   <div class="sri__main">
     <span class="bookcover $blur_cover">
       $ cover = get_cover_url(selected_ed) or "/images/icons/avatar_book-sm.png"
-      <a href="$work_edition_url"><img
-              itemprop="image"
-              src="$cover"
-              alt="$_('Cover of: %(title)s', title=full_title)"
-              title="$_('Cover of: %(title)s', title=full_title)"
-      /></a>
+      <a href="$work_edition_url">
+	<img
+          itemprop="image"
+          src="$cover"
+          alt="$_('Cover of: %(title)s', title=full_title)"
+          title="$_('Cover of: %(title)s', title=full_title)"
+	  /></a>
+      $if ocaid:
+        $:macros.BookPreview(ocaid, show_only=False)
     </span>
 
     <div class="details">
@@ -141,7 +147,6 @@ $code:
 
         <div class="searchResultItemCTA-lending">
           $if cta:
-            $ selected_ed['availability'] = selected_ed.get('availability', {}) or doc.get('availability', {}) or availability or {}
             $:macros.LoanStatus(selected_ed, work_key=doc.key)
         </div>
 

--- a/static/css/components/search-result-item.less
+++ b/static/css/components/search-result-item.less
@@ -18,6 +18,45 @@
   margin-bottom: 3px;
   border-bottom: 1px solid @light-beige;
 
+  // Some preview rules are too specific and need to be rewritten
+  // Preview button appears styled as a text link with a book icon
+  .bookcover .cta-btn.cta-btn--preview {
+    color: @primary-blue;
+    text-decoration: none;
+    position: relative;
+    background-color: transparent;
+    margin: -5px auto;
+
+    // When Preview button is a text link, have it take up only the width
+    // of the content (not full 100% width)
+    flex-basis: content;
+    flex-grow: 0;
+    width: auto;
+
+    /* stylelint-disable selector-max-specificity */
+    &:hover {
+      text-decoration: underline;
+    }
+
+    &::before {
+      width: 22px;
+      height: 18px;
+      display: inline-block;
+      margin-right: 6px;
+      position: relative;
+      top: 2px;
+
+      // Setting pseudo-element content to book icon; mask is used to allow for a 'fill' color
+      content: "";
+      -webkit-mask: url(../images/icons/open-book.svg);
+      mask: url(../images/icons/open-book.svg);
+      -webkit-mask-size: cover;
+      mask-size: cover;
+      background-color: @primary-blue;
+    }
+    /* stylelint-enable selector-max-specificity */
+  }
+
   &, .sri__main {
     .display-flex();
     align-items: center;

--- a/static/css/components/search-result-item.less
+++ b/static/css/components/search-result-item.less
@@ -9,6 +9,44 @@
   font-family: @lucida_sans_serif-6;
 }
 
+// Some preview rules are too specific and need to be rewritten
+// Preview button appears styled as a text link with a book icon
+.bookcover .cta-btn.cta-btn--preview {
+  color: @primary-blue;
+  text-decoration: none;
+  position: relative;
+  background-color: transparent;
+  margin: -5px auto;
+
+  // When Preview button is a text link, have it take up only the width
+  // of the content (not full 100% width)
+  flex-basis: content;
+  flex-grow: 0;
+  width: auto;
+
+  /* stylelint-disable selector-max-specificity */
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &::before {
+    width: 22px;
+    height: 18px;
+    display: inline-block;
+    margin-right: 6px;
+    position: relative;
+    top: 2px;
+
+    // Setting pseudo-element content to book icon; mask is used to allow for a 'fill' color
+    content: "";
+    -webkit-mask: url(../images/icons/open-book.svg);
+    mask: url(../images/icons/open-book.svg);
+    -webkit-mask-size: cover;
+    mask-size: cover;
+    background-color: @primary-blue;
+  }
+  /* stylelint-enable selector-max-specificity */
+}
 .searchResultItem {
   list-style-type: none;
   line-height: 1.5em;
@@ -17,45 +55,6 @@
   padding: 10px;
   margin-bottom: 3px;
   border-bottom: 1px solid @light-beige;
-
-  // Some preview rules are too specific and need to be rewritten
-  // Preview button appears styled as a text link with a book icon
-  .bookcover .cta-btn.cta-btn--preview {
-    color: @primary-blue;
-    text-decoration: none;
-    position: relative;
-    background-color: transparent;
-    margin: -5px auto;
-
-    // When Preview button is a text link, have it take up only the width
-    // of the content (not full 100% width)
-    flex-basis: content;
-    flex-grow: 0;
-    width: auto;
-
-    /* stylelint-disable selector-max-specificity */
-    &:hover {
-      text-decoration: underline;
-    }
-
-    &::before {
-      width: 22px;
-      height: 18px;
-      display: inline-block;
-      margin-right: 6px;
-      position: relative;
-      top: 2px;
-
-      // Setting pseudo-element content to book icon; mask is used to allow for a 'fill' color
-      content: "";
-      -webkit-mask: url(../images/icons/open-book.svg);
-      mask: url(../images/icons/open-book.svg);
-      -webkit-mask-size: cover;
-      mask-size: cover;
-      background-color: @primary-blue;
-    }
-    /* stylelint-enable selector-max-specificity */
-  }
 
   &, .sri__main {
     .display-flex();


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10199 #10366 

This modifies the Preview button so that each previewable book on the search results page has a preview link, styled like on the book page.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Instructions
<!-- What should be noted about the implementation? -->
Squash

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Please note that the css was changed between commit 1 and 2 in order to fix specificity but may now need to be quickly re-tested to ensure it's still doing the right thing.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

<img width="274" alt="Screenshot 2025-03-08 at 9 54 36 AM" src="https://github.com/user-attachments/assets/56ef2c53-a577-4de3-959a-d69c4418bb1e" />

![image](https://github.com/user-attachments/assets/22c09d23-7f2d-4787-baf1-8b803000da2f)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
