### PR TITLE
Prevent comments when issues marked stale

### DIFF
--- a/.github/workflows/pm_stale_ticket_labeler.yml
+++ b/.github/workflows/pm_stale_ticket_labeler.yml
@@ -20,5 +20,5 @@ jobs:
           days-before-pr-stale: -1
           include-only-assigned: true
           stale-issue-label: "Needs: Review Assignee"
-          stale-issue-message: 'This issue has been marked "Needs: Review Assignee" since there have been no updates within the past two weeks'
+          stale-issue-message: ""
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Whenever a stale issue is commented upon by the GitHub action bot, the issue's `updated_at` date is updated, making the issue no longer stale.  As a result, the `Needs: Review Assignee` is automatically removed from such issues the next time the stale issue workflow runs.

By passing an empty string as [`stale-issue-message`](https://github.com/actions/stale?tab=readme-ov-file#stale-issue-message), this PR updates the workflow such that _no_ comment will be left by the GitHub actions bot.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
