### PR TITLE
Mark upstream only github workflows

### DIFF
--- a/.github/workflows/olbase.yaml
+++ b/.github/workflows/olbase.yaml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   docker:
+    if: github.repository_owner == 'internetarchive'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pm_stale_ticket_labeler.yml
+++ b/.github/workflows/pm_stale_ticket_labeler.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   label-stale:
+    if: github.repository_owner == 'internetarchive'
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/pr_update_labeler.yml
+++ b/.github/workflows/pr_update_labeler.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - master
 jobs:
+  if: github.repository_owner == 'internetarchive'
   labeler:
     permissions:
       contents: read

--- a/.github/workflows/pr_update_labeler.yml
+++ b/.github/workflows/pr_update_labeler.yml
@@ -6,8 +6,8 @@ on:
     branches:
       - master
 jobs:
-  if: github.repository_owner == 'internetarchive'
   labeler:
+    if: github.repository_owner == 'internetarchive'
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/weekly_status_report.yml
+++ b/.github/workflows/weekly_status_report.yml
@@ -12,6 +12,7 @@ env:
   LEADS_G_CONFIG: '.github/workflows/config/weekly_status_report_openlibrary_leads_g.json'
 jobs:
   create_and_publish_report:
+    if: github.repository_owner == 'internetarchive'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
<!-- What issue does this PR close? -->
split from #10504

This PR:

*  Prevents internetarchive project only github workflows (slack bot integrations and github issue monitoring) from running on forks
