### PR TITLE
Remove redundant og: tags

### DIFF
--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -12,9 +12,6 @@ $add_metatag(property="og:image", content=meta_image_url)
 $add_metatag(property="og:url", content="https://openlibrary.org")
 $add_metatag(property="og:site_name", content="Open Library")
 
-$add_metatag(name="twitter:image:alt", content="Open Library Logo")
-$add_metatag(name="twitter:card", content="homepage_summary")
-
 <div id="contentBody">
 
   $:render_template("home/welcome", test=test)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
split from #10504

* removes duplicate og: tags from source, there are more general purpose tags already present

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

