### PR TITLE
move check-in form inside conditionally hidden div

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -4241,7 +4241,7 @@ msgstr ""
 
 #: check_ins/check_in_form.html
 msgid ""
-"Add an optional check-in date.  Check-in dates are used to track yearly "
+"Add an optional check-in date. Check-in dates are used to track yearly "
 "reading goals."
 msgstr ""
 

--- a/openlibrary/templates/check_ins/check_in_form.html
+++ b/openlibrary/templates/check_ins/check_in_form.html
@@ -26,12 +26,12 @@ $if last_read_date:
   $ day_read = int(split_date[2]) if len(split_date) > 2 else ''
 
 <div class="check-in" data-work-olid="$(work_olid)" data-event-type="3">
-  <form method="dialog" class="check-in__form" action="$(work_key)/check-ins" method="post">
+  <form class="check-in__form" action="$(work_key)/check-ins" method="post">
     <input type="hidden" name="event_id" value="$(event_id)">
     $if edition_key:
       <input type="hidden" name="edition_key" value="$(edition_key)">
     <div>
-      $_('Add an optional check-in date.  Check-in dates are used to track yearly reading goals.')
+      $_('Add an optional check-in date. Check-in dates are used to track yearly reading goals.')
     </div>
     <div class="check-in__inputs">
       <label class="check-in__label">$_('End Date:')</label>

--- a/openlibrary/templates/check_ins/check_in_prompt.html
+++ b/openlibrary/templates/check_ins/check_in_prompt.html
@@ -31,7 +31,6 @@ $ display_prompt = read_status == 3
     <a class="prompt-today" href="javascript:;" data-ol-link-track="CheckInPrompt|SetDateToday">$_("Today")</a>
     <a class="prompt-custom" href="javascript:;" data-ol-link-track="CheckInPrompt|SetDateCustom">$_("Other")</a>
   </span>
-</div>
-
 $ check_in_form = render_template('check_ins/check_in_form', work_olid, work_key, edition_key=edition_key, last_read_date=last_read_date, event_id=event_id)
 $:render_template('native_dialog', modal_id, check_in_form, title=_("Check-In"))
+</div>


### PR DESCRIPTION
**Problem:**  On my (older) Safari iOS mobile browser, the 'Check in' options, with lengthy description and 3 drop-downs, appears for _every_ item in a search result list, and cannot be hidden. This makes the results list considerably longer than it needs to be, and distracts from the useful page content.
 
**This PR:**
* Prevents the book check-in form from displaying on older mobile safari browsers. I'm not sure what other browsers are affected.
* Removes a duplicate `method` attribute from the form that broke HTML validation (not sure if it is directly related to the original rendering problem, but it may be?)

All lists of books in search results and author pages had a rendered check-in form for _every_ book.
It looks like the conditional for whether a book is currently being read was not covering the form?

I don't understand how it appears to work on all my desktop browsers.



### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Before, on an older mobile Safari:
![IMG_3008](https://github.com/user-attachments/assets/3bf326da-fd22-454c-973d-8ac7596d2dd6)

After this change:

![IMG_3007](https://github.com/user-attachments/assets/7186a0dd-3805-4a21-abbc-f586af89d68a)


After the change I can complete the 'Already Read' workflow using the drop down on a desktop browser, so nothing breaks:

![image](https://github.com/user-attachments/assets/e64532f0-0d02-4010-a436-e30d77389b96)




### Stakeholders
<!-- @ tag the lead (as labelled on the issue) and other stakeholders -->

@cdrini 
<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
