### PR TITLE
Migrate to Interstitial for Trusted Book Provider read actions

### DIFF
--- a/openlibrary/book_providers.py
+++ b/openlibrary/book_providers.py
@@ -189,10 +189,14 @@ class AbstractBookProvider(Generic[TProviderMetadata]):
         return f"book_providers/{self.short_name}_{typ}.html"
 
     def render_read_button(
-        self, ed_or_solr: Edition | dict, analytics_attr: Callable[[str], str]
+        self,
+        edition_key: str,
+        ed_or_solr: Edition | dict,
+        analytics_attr: Callable[[str], str],
     ) -> TemplateResult:
         return render_template(
             self.get_template_path('read_button'),
+            edition_key,
             self.get_best_identifier(ed_or_solr),
             analytics_attr,
         )
@@ -495,7 +499,10 @@ class DirectProvider(AbstractBookProvider):
             return []
 
     def render_read_button(
-        self, ed_or_solr: Edition | dict, analytics_attr: Callable[[str], str]
+        self,
+        edition_key: str,
+        ed_or_solr: Edition | dict,
+        analytics_attr: Callable[[str], str],
     ) -> TemplateResult | str:
         acq_sorted = sorted(
             (
@@ -519,7 +526,7 @@ class DirectProvider(AbstractBookProvider):
         parsed_url = parse.urlparse(url)
         domain = parsed_url.netloc
         return render_template(
-            self.get_template_path('read_button'), acquisition, domain
+            self.get_template_path('read_button'), edition_key, acquisition, domain
         )
 
     def render_download_options(self, edition: Edition, extra_args: list | None = None):

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -7800,16 +7800,6 @@ msgstr ""
 msgid "View Volume %(num)d"
 msgstr ""
 
-#: openlibrary/core/edits.py
-msgid "Unknown"
-msgstr ""
-
-#: openlibrary/plugins/upstream/borrow.py
-msgid ""
-"Your account has hit a lending limit. Please try again later or contact "
-"info@archive.org."
-msgstr ""
-
 #: openlibrary/plugins/upstream/forms.py
 msgid "Username"
 msgstr ""
@@ -7864,6 +7854,12 @@ msgstr ""
 
 #: openlibrary/plugins/upstream/forms.py
 msgid "Choose a password"
+msgstr ""
+
+#: openlibrary/plugins/upstream/borrow.py
+msgid ""
+"Your account has hit a lending limit. Please try again later or contact "
+"info@archive.org."
 msgstr ""
 
 #: openlibrary/plugins/upstream/account.py
@@ -8005,54 +8001,6 @@ msgstr ""
 msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
 msgstr ""
 
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Art"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Science Fiction"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Fantasy"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Biographies"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Recipes"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Children"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Medicine"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Religion"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Mystery and Detective Stories"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Plays"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Music"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Science"
-msgstr ""
-
 #: openlibrary/plugins/openlibrary/code.py
 msgid "Czech"
 msgstr ""
@@ -8109,6 +8057,54 @@ msgstr ""
 msgid "Chinese"
 msgstr ""
 
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Art"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Science Fiction"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Fantasy"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Biographies"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Recipes"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Children"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Medicine"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Religion"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Mystery and Detective Stories"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Plays"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Music"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Science"
+msgstr ""
+
 #: openlibrary/plugins/worksearch/code.py
 msgid "eBook?"
 msgstr ""
@@ -8119,5 +8115,9 @@ msgstr ""
 
 #: openlibrary/plugins/worksearch/code.py
 msgid "Classic eBooks"
+msgstr ""
+
+#: openlibrary/core/edits.py
+msgid "Unknown"
 msgstr ""
 

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -594,8 +594,7 @@ msgid "Thank you very much for improving that record!"
 msgstr ""
 
 #: BookPreview.html CreateListModal.html DonateModal.html NotesModal.html
-#: ObservationsModal.html ShareModal.html
-#: book_providers/librivox_read_button.html covers/author_photo.html
+#: ObservationsModal.html ShareModal.html covers/author_photo.html
 #: covers/book_cover.html covers/book_cover_single_edition.html
 #: covers/book_cover_work.html covers/change.html lib/history.html
 #: my_books/dropdown_content.html native_dialog.html
@@ -3025,18 +3024,6 @@ msgstr ""
 
 #: book_providers/librivox_read_button.html
 msgid "Audiobook"
-msgstr ""
-
-#: book_providers/librivox_read_button.html
-msgid ""
-"This book is available from <a "
-"href=\"https://librivox.org/\">LibriVox</a>. LibriVox is a trusted book "
-"provider of public domain audiobooks, narrated by volunteers, distributed"
-" for free on the internet."
-msgstr ""
-
-#: book_providers/librivox_read_button.html
-msgid "Learn more"
 msgstr ""
 
 #: book_providers/openstax_download_options.html
@@ -7782,12 +7769,6 @@ msgstr ""
 msgid "Choose a password"
 msgstr ""
 
-#: openlibrary/plugins/upstream/borrow.py
-msgid ""
-"Your account has hit a lending limit. Please try again later or contact "
-"info@archive.org."
-msgstr ""
-
 #: openlibrary/plugins/upstream/account.py
 msgid "The email address you entered is invalid"
 msgstr ""
@@ -7922,9 +7903,22 @@ msgstr ""
 msgid "Notification preferences have been updated successfully."
 msgstr ""
 
-#: openlibrary/plugins/openlibrary/lists.py
-#, python-format
-msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
+#: openlibrary/plugins/upstream/borrow.py
+msgid ""
+"Your account has hit a lending limit. Please try again later or contact "
+"info@archive.org."
+msgstr ""
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "eBook?"
+msgstr ""
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "First published"
+msgstr ""
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "Classic eBooks"
 msgstr ""
 
 #: openlibrary/plugins/openlibrary/code.py
@@ -8031,16 +8025,9 @@ msgstr ""
 msgid "Science"
 msgstr ""
 
-#: openlibrary/plugins/worksearch/code.py
-msgid "eBook?"
-msgstr ""
-
-#: openlibrary/plugins/worksearch/code.py
-msgid "First published"
-msgstr ""
-
-#: openlibrary/plugins/worksearch/code.py
-msgid "Classic eBooks"
+#: openlibrary/plugins/openlibrary/lists.py
+#, python-format
+msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
 msgstr ""
 
 #: openlibrary/core/edits.py

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -461,19 +461,23 @@ msgstr ""
 #: interstitial.html
 #, python-format
 msgid ""
-"This book is provided by %s, a third-party Open Library Trusted Book "
-"Provider"
+"This book is provided by <strong>%(book_provider)s</strong>, a third-"
+"party Open Library Trusted Book Provider"
 msgstr ""
 
 #: interstitial.html
 #, python-format
-msgid "You will be automatically redirected to %s in %s seconds..."
+msgid ""
+"You will be automatically redirected to "
+"<strong>%(book_provider_url)s</strong> in <span id=\"timer\">5</span> "
+"seconds..."
 msgstr ""
 
 #: CreateListModal.html EditButtons.html account/notifications.html
 #: account/password/reset.html account/privacy.html admin/imports-add.html
 #: admin/permissions.html books/add.html databarEdit.html interstitial.html
-#: merge/authors.html my_books/dropdown_content.html type/tag/form.html
+#: merge/authors.html my_books/dropdown_content.html support.html
+#: type/tag/form.html
 msgid "Cancel"
 msgstr ""
 
@@ -834,13 +838,6 @@ msgstr ""
 
 #: support.html
 msgid "Send"
-msgstr ""
-
-#: CreateListModal.html EditButtons.html account/notifications.html
-#: account/password/reset.html account/privacy.html admin/imports-add.html
-#: admin/permissions.html books/add.html databarEdit.html merge/authors.html
-#: my_books/dropdown_content.html support.html type/tag/form.html
-msgid "Cancel"
 msgstr ""
 
 #: trending.html
@@ -7803,6 +7800,16 @@ msgstr ""
 msgid "View Volume %(num)d"
 msgstr ""
 
+#: openlibrary/core/edits.py
+msgid "Unknown"
+msgstr ""
+
+#: openlibrary/plugins/upstream/borrow.py
+msgid ""
+"Your account has hit a lending limit. Please try again later or contact "
+"info@archive.org."
+msgstr ""
+
 #: openlibrary/plugins/upstream/forms.py
 msgid "Username"
 msgstr ""
@@ -7857,12 +7864,6 @@ msgstr ""
 
 #: openlibrary/plugins/upstream/forms.py
 msgid "Choose a password"
-msgstr ""
-
-#: openlibrary/plugins/upstream/borrow.py
-msgid ""
-"Your account has hit a lending limit. Please try again later or contact "
-"info@archive.org."
 msgstr ""
 
 #: openlibrary/plugins/upstream/account.py
@@ -8004,6 +8005,54 @@ msgstr ""
 msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
 msgstr ""
 
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Art"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Science Fiction"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Fantasy"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Biographies"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Recipes"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Children"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Medicine"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Religion"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Mystery and Detective Stories"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Plays"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Music"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Science"
+msgstr ""
+
 #: openlibrary/plugins/openlibrary/code.py
 msgid "Czech"
 msgstr ""
@@ -8060,54 +8109,6 @@ msgstr ""
 msgid "Chinese"
 msgstr ""
 
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Art"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Science Fiction"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Fantasy"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Biographies"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Recipes"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Children"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Medicine"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Religion"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Mystery and Detective Stories"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Plays"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Music"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Science"
-msgstr ""
-
 #: openlibrary/plugins/worksearch/code.py
 msgid "eBook?"
 msgstr ""
@@ -8118,9 +8119,5 @@ msgstr ""
 
 #: openlibrary/plugins/worksearch/code.py
 msgid "Classic eBooks"
-msgstr ""
-
-#: openlibrary/core/edits.py
-msgid "Unknown"
 msgstr ""
 

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -7726,16 +7726,6 @@ msgstr ""
 msgid "View Volume %(num)d"
 msgstr ""
 
-#: openlibrary/core/edits.py
-msgid "Unknown"
-msgstr ""
-
-#: openlibrary/plugins/upstream/borrow.py
-msgid ""
-"Your account has hit a lending limit. Please try again later or contact "
-"info@archive.org."
-msgstr ""
-
 #: openlibrary/plugins/upstream/forms.py
 msgid "Username"
 msgstr ""
@@ -7790,6 +7780,12 @@ msgstr ""
 
 #: openlibrary/plugins/upstream/forms.py
 msgid "Choose a password"
+msgstr ""
+
+#: openlibrary/plugins/upstream/borrow.py
+msgid ""
+"Your account has hit a lending limit. Please try again later or contact "
+"info@archive.org."
 msgstr ""
 
 #: openlibrary/plugins/upstream/account.py
@@ -7931,54 +7927,6 @@ msgstr ""
 msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
 msgstr ""
 
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Art"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Science Fiction"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Fantasy"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Biographies"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Recipes"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Children"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Medicine"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Religion"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Mystery and Detective Stories"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Plays"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Music"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Science"
-msgstr ""
-
 #: openlibrary/plugins/openlibrary/code.py
 msgid "Czech"
 msgstr ""
@@ -8035,6 +7983,54 @@ msgstr ""
 msgid "Chinese"
 msgstr ""
 
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Art"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Science Fiction"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Fantasy"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Biographies"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Recipes"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Children"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Medicine"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Religion"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Mystery and Detective Stories"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Plays"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Music"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Science"
+msgstr ""
+
 #: openlibrary/plugins/worksearch/code.py
 msgid "eBook?"
 msgstr ""
@@ -8045,5 +8041,9 @@ msgstr ""
 
 #: openlibrary/plugins/worksearch/code.py
 msgid "Classic eBooks"
+msgstr ""
+
+#: openlibrary/core/edits.py
+msgid "Unknown"
 msgstr ""
 

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -7710,16 +7710,6 @@ msgstr ""
 msgid "View Volume %(num)d"
 msgstr ""
 
-#: openlibrary/core/edits.py
-msgid "Unknown"
-msgstr ""
-
-#: openlibrary/plugins/upstream/borrow.py
-msgid ""
-"Your account has hit a lending limit. Please try again later or contact "
-"info@archive.org."
-msgstr ""
-
 #: openlibrary/plugins/upstream/forms.py
 msgid "Username"
 msgstr ""
@@ -7910,57 +7900,22 @@ msgstr ""
 msgid "Notification preferences have been updated successfully."
 msgstr ""
 
-#: openlibrary/plugins/openlibrary/lists.py
-#, python-format
-msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
+#: openlibrary/plugins/upstream/borrow.py
+msgid ""
+"Your account has hit a lending limit. Please try again later or contact "
+"info@archive.org."
 msgstr ""
 
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Art"
+#: openlibrary/plugins/worksearch/code.py
+msgid "eBook?"
 msgstr ""
 
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Science Fiction"
+#: openlibrary/plugins/worksearch/code.py
+msgid "First published"
 msgstr ""
 
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Fantasy"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Biographies"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Recipes"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Children"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Medicine"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Religion"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Mystery and Detective Stories"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Plays"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Music"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Science"
+#: openlibrary/plugins/worksearch/code.py
+msgid "Classic eBooks"
 msgstr ""
 
 #: openlibrary/plugins/openlibrary/code.py
@@ -8019,15 +7974,60 @@ msgstr ""
 msgid "Chinese"
 msgstr ""
 
-#: openlibrary/plugins/worksearch/code.py
-msgid "eBook?"
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Art"
 msgstr ""
 
-#: openlibrary/plugins/worksearch/code.py
-msgid "First published"
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Science Fiction"
 msgstr ""
 
-#: openlibrary/plugins/worksearch/code.py
-msgid "Classic eBooks"
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Fantasy"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Biographies"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Recipes"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Children"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Medicine"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Religion"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Mystery and Detective Stories"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Plays"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Music"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Science"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/lists.py
+#, python-format
+msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
+msgstr ""
+
+#: openlibrary/core/edits.py
+msgid "Unknown"
 msgstr ""
 

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -595,14 +595,7 @@ msgstr ""
 
 #: BookPreview.html CreateListModal.html DonateModal.html NotesModal.html
 #: ObservationsModal.html ShareModal.html
-#: book_providers/cita_press_read_button.html
-#: book_providers/direct_read_button.html
-#: book_providers/gutenberg_read_button.html
-#: book_providers/librivox_read_button.html
-#: book_providers/openstax_read_button.html
-#: book_providers/runeberg_read_button.html
-#: book_providers/standard_ebooks_read_button.html
-#: book_providers/wikisource_read_button.html covers/author_photo.html
+#: book_providers/librivox_read_button.html covers/author_photo.html
 #: covers/book_cover.html covers/book_cover_single_edition.html
 #: covers/book_cover_work.html covers/change.html lib/history.html
 #: my_books/dropdown_content.html native_dialog.html
@@ -2935,34 +2928,8 @@ msgstr ""
 msgid "Read eBook from Cita Press"
 msgstr ""
 
-#: book_providers/cita_press_read_button.html
-msgid ""
-"This book is available from <a href=\"https://citapress.org/\">Cita "
-"Press</a>. Cita Press is a trusted book provider of works written by "
-"women, pairing contemporary authors and designers with open access texts "
-"to make carefully designed books available for free and open source."
-msgstr ""
-
-#: book_providers/cita_press_read_button.html
-#: book_providers/direct_read_button.html
-#: book_providers/gutenberg_read_button.html
-#: book_providers/librivox_read_button.html
-#: book_providers/openstax_read_button.html
-#: book_providers/runeberg_read_button.html
-#: book_providers/standard_ebooks_read_button.html
-#: book_providers/wikisource_read_button.html
-msgid "Learn more"
-msgstr ""
-
 #: book_providers/direct_read_button.html
 msgid "Read free online"
-msgstr ""
-
-#: book_providers/direct_read_button.html
-#, python-format
-msgid ""
-"This book is freely available from <a href=\"%s\">%s</a>, an external "
-"third-party book provider."
 msgstr ""
 
 #: book_providers/gutenberg_download_options.html
@@ -3002,15 +2969,6 @@ msgstr ""
 
 #: book_providers/gutenberg_read_button.html
 msgid "Read eBook from Project Gutenberg"
-msgstr ""
-
-#: book_providers/gutenberg_read_button.html
-msgid ""
-"This book is available from <a "
-"href=\"https://www.gutenberg.org/\">Project Gutenberg</a>. Project "
-"Gutenberg is a trusted book provider of classic ebooks, supporting "
-"thousands of volunteers in the creation and distribution of over 60,000 "
-"free eBooks."
 msgstr ""
 
 #: book_providers/ia_download_options.html
@@ -3077,6 +3035,10 @@ msgid ""
 " for free on the internet."
 msgstr ""
 
+#: book_providers/librivox_read_button.html
+msgid "Learn more"
+msgstr ""
+
 #: book_providers/openstax_download_options.html
 msgid "Download PDF from OpenStax"
 msgstr ""
@@ -3087,15 +3049,6 @@ msgstr ""
 
 #: book_providers/openstax_read_button.html
 msgid "Read eBook from OpenStax"
-msgstr ""
-
-#: book_providers/openstax_read_button.html
-msgid ""
-"This book is available from <a "
-"href=\"https://www.openstax.org/\">OpenStax</a>. OpenStax is a trusted "
-"book provider and a 501(c)(3) nonprofit charitable corporation dedicated "
-"to providing free high-quality, peer-reviewed, openly licensed textbooks "
-"online."
 msgstr ""
 
 #: book_providers/runeberg_download_options.html
@@ -3142,13 +3095,6 @@ msgstr ""
 msgid "Read eBook from Project Runeberg"
 msgstr ""
 
-#: book_providers/runeberg_read_button.html
-msgid ""
-"This book is available from <a href=\"https://runeberg.org/\">Project "
-"Runeberg</a>. Project Runeberg is a trusted book provider of classic "
-"Nordic (Scandinavian) literature in electronic form."
-msgstr ""
-
 #: book_providers/standard_ebooks_download_options.html
 msgid "Download an HTML from Standard Ebooks"
 msgstr ""
@@ -3189,15 +3135,6 @@ msgstr ""
 msgid "Read eBook from Standard eBooks"
 msgstr ""
 
-#: book_providers/standard_ebooks_read_button.html
-msgid ""
-"This book is available from <a "
-"href=\"https://standardebooks.org/\">Standard Ebooks</a>. Standard Ebooks"
-" is a trusted book provider and a volunteer-driven project that produces "
-"new editions of public domain ebooks that are lovingly formatted, open "
-"source, free of copyright restrictions, and free of cost."
-msgstr ""
-
 #: book_providers/wikisource_download_options.html
 msgid "Download PDF from Wikisource"
 msgstr ""
@@ -3224,17 +3161,6 @@ msgstr ""
 
 #: book_providers/wikisource_read_button.html
 msgid "Read eBook on Wikisource"
-msgstr ""
-
-#: book_providers/wikisource_read_button.html
-msgid ""
-"This book is available from <a "
-"href=\"https://wikisource.org/\">Wikisource</a>. Wikisource, a <a "
-"href=\"https://www.wikimedia.org/\">Wikimedia Foundation</a> project, is "
-"a trusted book provider of works available under the <a "
-"href=\"https://creativecommons.org/licenses/by-sa/4.0/\">CC-BY-SA</a> "
-"open content license, such as essays, historical documents, letters, "
-"speeches, and public domain books."
 msgstr ""
 
 #: books/RelatedWorksCarousel.html
@@ -7800,6 +7726,16 @@ msgstr ""
 msgid "View Volume %(num)d"
 msgstr ""
 
+#: openlibrary/core/edits.py
+msgid "Unknown"
+msgstr ""
+
+#: openlibrary/plugins/upstream/borrow.py
+msgid ""
+"Your account has hit a lending limit. Please try again later or contact "
+"info@archive.org."
+msgstr ""
+
 #: openlibrary/plugins/upstream/forms.py
 msgid "Username"
 msgstr ""
@@ -7854,12 +7790,6 @@ msgstr ""
 
 #: openlibrary/plugins/upstream/forms.py
 msgid "Choose a password"
-msgstr ""
-
-#: openlibrary/plugins/upstream/borrow.py
-msgid ""
-"Your account has hit a lending limit. Please try again later or contact "
-"info@archive.org."
 msgstr ""
 
 #: openlibrary/plugins/upstream/account.py
@@ -8001,6 +7931,54 @@ msgstr ""
 msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
 msgstr ""
 
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Art"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Science Fiction"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Fantasy"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Biographies"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Recipes"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Children"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Medicine"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Religion"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Mystery and Detective Stories"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Plays"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Music"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Science"
+msgstr ""
+
 #: openlibrary/plugins/openlibrary/code.py
 msgid "Czech"
 msgstr ""
@@ -8057,54 +8035,6 @@ msgstr ""
 msgid "Chinese"
 msgstr ""
 
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Art"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Science Fiction"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Fantasy"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Biographies"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Recipes"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Children"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Medicine"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Religion"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Mystery and Detective Stories"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Plays"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Music"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Science"
-msgstr ""
-
 #: openlibrary/plugins/worksearch/code.py
 msgid "eBook?"
 msgstr ""
@@ -8115,9 +8045,5 @@ msgstr ""
 
 #: openlibrary/plugins/worksearch/code.py
 msgid "Classic eBooks"
-msgstr ""
-
-#: openlibrary/core/edits.py
-msgid "Unknown"
 msgstr ""
 

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -461,16 +461,13 @@ msgstr ""
 #: interstitial.html
 #, python-format
 msgid ""
-"This book is provided by <strong>%(book_provider)s</strong>, a third-"
-"party Open Library Trusted Book Provider"
+"This book is provided by %(book_provider)s, a third-party Open Library "
+"Trusted Book Provider"
 msgstr ""
 
 #: interstitial.html
 #, python-format
-msgid ""
-"You will be automatically redirected to "
-"<strong>%(book_provider_url)s</strong> in <span id=\"timer\">5</span> "
-"seconds..."
+msgid "In %(time)s seconds, you will be automatically redirected to: %(url)s"
 msgstr ""
 
 #: CreateListModal.html EditButtons.html account/notifications.html
@@ -7713,6 +7710,16 @@ msgstr ""
 msgid "View Volume %(num)d"
 msgstr ""
 
+#: openlibrary/core/edits.py
+msgid "Unknown"
+msgstr ""
+
+#: openlibrary/plugins/upstream/borrow.py
+msgid ""
+"Your account has hit a lending limit. Please try again later or contact "
+"info@archive.org."
+msgstr ""
+
 #: openlibrary/plugins/upstream/forms.py
 msgid "Username"
 msgstr ""
@@ -7903,22 +7910,57 @@ msgstr ""
 msgid "Notification preferences have been updated successfully."
 msgstr ""
 
-#: openlibrary/plugins/upstream/borrow.py
-msgid ""
-"Your account has hit a lending limit. Please try again later or contact "
-"info@archive.org."
+#: openlibrary/plugins/openlibrary/lists.py
+#, python-format
+msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
 msgstr ""
 
-#: openlibrary/plugins/worksearch/code.py
-msgid "eBook?"
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Art"
 msgstr ""
 
-#: openlibrary/plugins/worksearch/code.py
-msgid "First published"
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Science Fiction"
 msgstr ""
 
-#: openlibrary/plugins/worksearch/code.py
-msgid "Classic eBooks"
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Fantasy"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Biographies"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Recipes"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Children"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Medicine"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Religion"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Mystery and Detective Stories"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Plays"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Music"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Science"
 msgstr ""
 
 #: openlibrary/plugins/openlibrary/code.py
@@ -7977,60 +8019,15 @@ msgstr ""
 msgid "Chinese"
 msgstr ""
 
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Art"
+#: openlibrary/plugins/worksearch/code.py
+msgid "eBook?"
 msgstr ""
 
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Science Fiction"
+#: openlibrary/plugins/worksearch/code.py
+msgid "First published"
 msgstr ""
 
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Fantasy"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Biographies"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Recipes"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Children"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Medicine"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Religion"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Mystery and Detective Stories"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Plays"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Music"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Science"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/lists.py
-#, python-format
-msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
-msgstr ""
-
-#: openlibrary/core/edits.py
-msgid "Unknown"
+#: openlibrary/plugins/worksearch/code.py
+msgid "Classic eBooks"
 msgstr ""
 

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -56,7 +56,7 @@ $if user_loan:
 
 $elif book_provider and book_provider.short_name != 'ia':
   $# Partner Trusted Book Provider Read Buttons
-  $:book_provider.render_read_button(doc, analytics_attr)
+  $:book_provider.render_read_button(edition_key, doc, analytics_attr)
 
 $elif availability.get('is_readable') or availability.get('status') == 'open':
   $# Open / Publicly Readable (Unrestricted)

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -518,6 +518,12 @@ jQuery(function () {
             .then(module => module.initBreadcrumbSelect(crumbs));
     }
 
+    const interstitial = document.querySelector('.interstitial');
+    if (interstitial) {
+        import (/* webpackChunkName: "interstitial" */ './interstitial')
+            .then(module => module.initInterstitial(interstitial));
+    }
+
     const leaveWaitlistLinks = document.querySelectorAll('a.leave');
     if (leaveWaitlistLinks.length && document.getElementById('leave-waitinglist-dialog')) {
         import(/* webpackChunkName: "waitlist" */ './waitlist')

--- a/openlibrary/plugins/openlibrary/js/interstitial.js
+++ b/openlibrary/plugins/openlibrary/js/interstitial.js
@@ -1,0 +1,13 @@
+export function initInterstitial(elem) {
+    let seconds = elem.dataset.wait // Assumes `elem` has `data-wait`.  May need to be cast to Number
+    const url = elem.dataset.url // Assumes that `elem` has `data-url`
+    const timerElement = elem.querySelector('#timer')
+    const countdown = setInterval(() => {
+        seconds--
+        timerElement.textContent = seconds
+        if (seconds === 0) {
+            clearInterval(countdown)
+            window.location.href = url
+        }
+    }, 1000) // 1 second interval
+}

--- a/openlibrary/plugins/openlibrary/js/interstitial.js
+++ b/openlibrary/plugins/openlibrary/js/interstitial.js
@@ -1,6 +1,6 @@
 export function initInterstitial(elem) {
-    let seconds = elem.dataset.wait // Assumes `elem` has `data-wait`.  May need to be cast to Number
-    const url = elem.dataset.url // Assumes that `elem` has `data-url`
+    let seconds = elem.dataset.wait
+    const url = elem.dataset.url
     const timerElement = elem.querySelector('#timer')
     const countdown = setInterval(() => {
         seconds--

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -25,6 +25,7 @@ from infogami.utils.view import (
 )
 from openlibrary import accounts
 from openlibrary.accounts.model import OpenLibraryAccount
+from openlibrary.app import render_template
 from openlibrary.core import (
     lending,
     models,  # noqa: F401 side effects may be needed
@@ -143,11 +144,12 @@ class borrow(delegate.page):
             and acquisitions[0].access == "open-access"
         ):
             stats.increment('ol.loans.webbook')
-            # Change this to a template call, e.g.
-            # not sure if provider.name is a thing...
-            # XXX The problem with this approach is it will not open in a new window (maybe that's okay)
-            # render_template("interstitial", url=acquisitions[0].url, provider=provider.name, wait=5)
-            raise web.seeother(acquisitions[0].url)
+            # def with(url, provider_name="", wait=5)
+            return render_template(
+                "interstitial",
+                url=acquisitions[0].url,
+                provider_name=acquisitions[0].provider_name,
+            )
 
         archive_url = get_bookreader_stream_url(edition.ocaid) + '?ref=ol'
         if i._autoReadAloud is not None:

--- a/openlibrary/templates/book_providers/cita_press_read_button.html
+++ b/openlibrary/templates/book_providers/cita_press_read_button.html
@@ -1,7 +1,7 @@
 $def with(edition_key, cita_press_id)
 
 <div class="cta-button-group">
-  <a href="http://openlibrary.org/books/${edition_key}/-/borrow?action=read"
+  <a href="/books/${edition_key}/-/borrow?action=read"
       title="$_('Read eBook from Cita Press')"
       class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--cita-press"
       target="_blank"

--- a/openlibrary/templates/book_providers/cita_press_read_button.html
+++ b/openlibrary/templates/book_providers/cita_press_read_button.html
@@ -1,13 +1,12 @@
-$def with(cita_press_id)
+$def with(edition_key, cita_press_id)
 
 <div class="cta-button-group">
-  <a
-      href="https://citapress.org/$cita_press_id"
+  <a href="http://openlibrary.org/books/${edition_key}/-/borrow?action=read"
       title="$_('Read eBook from Cita Press')"
       class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--cita-press"
       target="_blank"
-       aria-haspopup="true"
-       aria-controls="cita-press-toast"
+      aria-haspopup="true"
+      aria-controls="cita-press-toast"
   >$_('Read')</a>
 </div>
 

--- a/openlibrary/templates/book_providers/cita_press_read_button.html
+++ b/openlibrary/templates/book_providers/cita_press_read_button.html
@@ -5,7 +5,5 @@ $def with(edition_key, cita_press_id)
       title="$_('Read eBook from Cita Press')"
       class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--cita-press"
       target="_blank"
-      aria-haspopup="true"
-      aria-controls="cita-press-toast"
   >$_('Read')</a>
 </div>

--- a/openlibrary/templates/book_providers/cita_press_read_button.html
+++ b/openlibrary/templates/book_providers/cita_press_read_button.html
@@ -9,12 +9,3 @@ $def with(edition_key, cita_press_id)
       aria-controls="cita-press-toast"
   >$_('Read')</a>
 </div>
-
-$if render_once('cita-press-toast'):
-  <div class="toast toast--book-provider" data-toast-trigger=".cta-btn--openstax" id="cita-press-toast" style="display:none">
-    <div class="toast__body">
-      $:_('This book is available from <a href="https://citapress.org/">Cita Press</a>. Cita Press is a trusted book provider of works written by women, pairing contemporary authors and designers with open access texts to make carefully designed books available for free and open source.')
-      <a href="https://citapress.org/about/">$_('Learn more')</a>
-    </div>
-    <a class="toast__close">&times;<span class="shift">$_("Close")</span></a>
-  </div>

--- a/openlibrary/templates/book_providers/direct_read_button.html
+++ b/openlibrary/templates/book_providers/direct_read_button.html
@@ -6,7 +6,7 @@ $ clean_domain = domain.replace(".", "")
 
 $if acquisition.access == 'open-access':
   <div class="cta-button-group">
-    <a href="http://openlibrary.org/books/${edition_key}/-/borrow?action=read"
+    <a href="/books/${edition_key}/-/borrow?action=read"
         title="$_('Read free online')"
         class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--direct"
         target="_blank"

--- a/openlibrary/templates/book_providers/direct_read_button.html
+++ b/openlibrary/templates/book_providers/direct_read_button.html
@@ -10,8 +10,6 @@ $if acquisition.access == 'open-access':
         title="$_('Read free online')"
         class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--direct"
         target="_blank"
-        aria-haspopup="true"
-        aria-controls="direct-provider-toast-$(clean_domain)"
     >$_('Read')</a>
   </div>
 

--- a/openlibrary/templates/book_providers/direct_read_button.html
+++ b/openlibrary/templates/book_providers/direct_read_button.html
@@ -23,17 +23,3 @@ $elif acquisition.access == 'sample':
       href="$(acquisition.url)"
     >$_('Preview')</a>
   </div>
-
-$if render_once('direct-provider-toast-' + clean_domain):
-  <div
-    class="toast toast--book-provider"
-    data-toast-trigger="[aria-controls=direct-provider-toast-$(clean_domain)]"
-    id="direct-provider-toast-$(clean_domain)"
-    style="display:none"
-  >
-    <div class="toast__body">
-      $:_('This book is freely available from <a href="%s">%s</a>, an external third-party book provider.', acquisition.url, domain)
-      <a href="/trusted-book-providers#web-books">$_('Learn more')<a>
-    </div>
-    <a class="toast__close">&times;<span class="shift">$_("Close")</span></a>
-  </div>

--- a/openlibrary/templates/book_providers/direct_read_button.html
+++ b/openlibrary/templates/book_providers/direct_read_button.html
@@ -1,12 +1,12 @@
-$def with(acquisition, domain)
+$def with(edition_key, acquisition, domain)
+$# :param edition_key str:
 $# :param Acquisition acquisition:
 $# :param domain str:
 $ clean_domain = domain.replace(".", "")
 
 $if acquisition.access == 'open-access':
   <div class="cta-button-group">
-    <a
-        href="$(acquisition.url)"
+    <a href="http://openlibrary.org/books/${edition_key}/-/borrow?action=read"
         title="$_('Read free online')"
         class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--direct"
         target="_blank"

--- a/openlibrary/templates/book_providers/direct_read_button.html
+++ b/openlibrary/templates/book_providers/direct_read_button.html
@@ -17,9 +17,9 @@ $if acquisition.access == 'open-access':
 
 $elif acquisition.access == 'sample':
   <div class="cta-button-group">
-    <a class="cta-btn cta-btn--shell cta-btn--external"
+    <a href="http://openlibrary.org/books/${edition_key}/-/borrow?action=read"
+      class="cta-btn cta-btn--shell cta-btn--external"
       data-ol-link-track="CTAClick|Preview"
       target="_blank"
-      href="$(acquisition.url)"
     >$_('Preview')</a>
   </div>

--- a/openlibrary/templates/book_providers/gutenberg_read_button.html
+++ b/openlibrary/templates/book_providers/gutenberg_read_button.html
@@ -6,7 +6,5 @@ $def with(edition_key, gutenberg_id, analytics_attr)
       class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--gutenberg"
       target="_blank"
       $:analytics_attr('Read')
-      aria-haspopup="true"
-      aria-controls="gutenberg-toast"
   >$_('Read')</a>
 </div>

--- a/openlibrary/templates/book_providers/gutenberg_read_button.html
+++ b/openlibrary/templates/book_providers/gutenberg_read_button.html
@@ -10,12 +10,3 @@ $def with(edition_key, gutenberg_id, analytics_attr)
       aria-controls="gutenberg-toast"
   >$_('Read')</a>
 </div>
-
-$if render_once('gutenberg-toast'):
-  <div class="toast toast--book-provider" data-toast-trigger=".cta-btn--gutenberg" id="gutenberg-toast" style="display:none">
-    <div class="toast__body">
-      $:_('This book is available from <a href="https://www.gutenberg.org/">Project Gutenberg</a>. Project Gutenberg is a trusted book provider of classic ebooks, supporting thousands of volunteers in the creation and distribution of over 60,000 free eBooks.')
-      <a href="https://www.gutenberg.org/about/">$_("Learn more")</a>
-    </div>
-    <a class="toast__close">&times;<span class="shift">$_("Close")</span></a>
-  </div>

--- a/openlibrary/templates/book_providers/gutenberg_read_button.html
+++ b/openlibrary/templates/book_providers/gutenberg_read_button.html
@@ -1,8 +1,7 @@
-$def with(gutenberg_id, analytics_attr)
+$def with(edition_key, gutenberg_id, analytics_attr)
 
 <div class="cta-button-group">
-  <a
-      href="https://www.gutenberg.org/ebooks/$gutenberg_id"
+  <a href="http://openlibrary.org/books/${edition_key}/-/borrow?action=read"
       title="$_('Read eBook from Project Gutenberg')"
       class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--gutenberg"
       target="_blank"

--- a/openlibrary/templates/book_providers/gutenberg_read_button.html
+++ b/openlibrary/templates/book_providers/gutenberg_read_button.html
@@ -1,7 +1,7 @@
 $def with(edition_key, gutenberg_id, analytics_attr)
 
 <div class="cta-button-group">
-  <a href="http://openlibrary.org/books/${edition_key}/-/borrow?action=read"
+  <a href="/books/${edition_key}/-/borrow?action=read"
       title="$_('Read eBook from Project Gutenberg')"
       class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--gutenberg"
       target="_blank"

--- a/openlibrary/templates/book_providers/librivox_read_button.html
+++ b/openlibrary/templates/book_providers/librivox_read_button.html
@@ -6,8 +6,6 @@ $def with(edition_key, librivox_id, analytics_attr)
    $:analytics_attr('Listen')
    class="cta-btn cta-btn--available cta-btn--w-icon cta-btn--external cta-btn--librivox"
    target="_blank"
-   aria-haspopup="true"
-   aria-controls="librivox-toast"
 >
   <span class="btn-icon read-aloud"></span>
   <span class="btn-label">$_("Audiobook")</span>

--- a/openlibrary/templates/book_providers/librivox_read_button.html
+++ b/openlibrary/templates/book_providers/librivox_read_button.html
@@ -1,7 +1,7 @@
 $def with(edition_key, librivox_id, analytics_attr)
 
 <div class="cta-button-group">
-<a href="http://openlibrary.org/books/${edition_key}/-/borrow?action=read"
+<a href="/books/${edition_key}/-/borrow?action=read"
    title="$_('Listen to a reading from LibriVox')"
    $:analytics_attr('Listen')
    class="cta-btn cta-btn--available cta-btn--w-icon cta-btn--external cta-btn--librivox"

--- a/openlibrary/templates/book_providers/librivox_read_button.html
+++ b/openlibrary/templates/book_providers/librivox_read_button.html
@@ -1,7 +1,7 @@
-$def with(librivox_id, analytics_attr)
+$def with(edition_key, librivox_id, analytics_attr)
 
 <div class="cta-button-group">
-<a href="https://librivox.org/$librivox_id"
+<a href="http://openlibrary.org/books/${edition_key}/-/borrow?action=read"
    title="$_('Listen to a reading from LibriVox')"
    $:analytics_attr('Listen')
    class="cta-btn cta-btn--available cta-btn--w-icon cta-btn--external cta-btn--librivox"
@@ -13,12 +13,3 @@ $def with(librivox_id, analytics_attr)
   <span class="btn-label">$_("Audiobook")</span>
 </a>
 </div>
-
-$if render_once('librivox-toast'):
-  <div class="toast toast--book-provider" data-toast-trigger=".cta-btn--librivox" id="librivox-toast" style="display:none">
-    <div class="toast__body">
-      $:_('This book is available from <a href="https://librivox.org/">LibriVox</a>. LibriVox is a trusted book provider of public domain audiobooks, narrated by volunteers, distributed for free on the internet.')
-      <a href="https://librivox.org/pages/about-librivox/">$_("Learn more")</a>
-    </div>
-    <a class="toast__close">&times;<span class="shift">$_("Close")</span></a>
-  </div>

--- a/openlibrary/templates/book_providers/openstax_read_button.html
+++ b/openlibrary/templates/book_providers/openstax_read_button.html
@@ -10,12 +10,3 @@ $def with(edition_key, openstax_id, analytics_attr)
       aria-controls="openstax-toast"
   >$_('Read')</a>
 </div>
-
-$if render_once('openstax-toast'):
-  <div class="toast toast--book-provider" data-toast-trigger=".cta-btn--openstax" id="openstax-toast" style="display:none">
-    <div class="toast__body">
-      $:_('This book is available from <a href="https://www.openstax.org/">OpenStax</a>. OpenStax is a trusted book provider and a 501(c)(3) nonprofit charitable corporation dedicated to providing free high-quality, peer-reviewed, openly licensed textbooks online.')
-      <a href="https://www.openstax.org/about/">$_("Learn more")</a>
-    </div>
-    <a class="toast__close">&times;<span class="shift">$_("Close")</span></a>
-  </div>

--- a/openlibrary/templates/book_providers/openstax_read_button.html
+++ b/openlibrary/templates/book_providers/openstax_read_button.html
@@ -6,7 +6,5 @@ $def with(edition_key, openstax_id, analytics_attr)
       class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--openstax"
       target="_blank"
       $:analytics_attr('Read')
-      aria-haspopup="true"
-      aria-controls="openstax-toast"
   >$_('Read')</a>
 </div>

--- a/openlibrary/templates/book_providers/openstax_read_button.html
+++ b/openlibrary/templates/book_providers/openstax_read_button.html
@@ -1,8 +1,7 @@
-$def with(openstax_id, analytics_attr)
+$def with(edition_key, openstax_id, analytics_attr)
 
 <div class="cta-button-group">
-  <a
-      href="https://openstax.org/details/books/$openstax_id"
+  <a href="http://openlibrary.org/books/${edition_key}/-/borrow?action=read"
       title="$_('Read eBook from OpenStax')"
       class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--openstax"
       target="_blank"

--- a/openlibrary/templates/book_providers/openstax_read_button.html
+++ b/openlibrary/templates/book_providers/openstax_read_button.html
@@ -1,7 +1,7 @@
 $def with(edition_key, openstax_id, analytics_attr)
 
 <div class="cta-button-group">
-  <a href="http://openlibrary.org/books/${edition_key}/-/borrow?action=read"
+  <a href="/books/${edition_key}/-/borrow?action=read"
       title="$_('Read eBook from OpenStax')"
       class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--openstax"
       target="_blank"

--- a/openlibrary/templates/book_providers/runeberg_read_button.html
+++ b/openlibrary/templates/book_providers/runeberg_read_button.html
@@ -10,12 +10,3 @@ $def with(edition_key, runeberg_id, analytics_attr)
       aria-controls="runeberg-toast"
   >$_('Read')</a>
 </div>
-
-$if render_once('runeberg-toast'):
-  <div class="toast toast--book-provider" data-toast-trigger=".cta-btn--runeberg" id="runeberg-toast" style="display:none">
-    <div class="toast__body">
-      $:_('This book is available from <a href="https://runeberg.org/">Project Runeberg</a>. Project Runeberg is a trusted book provider of classic Nordic (Scandinavian) literature in electronic form.')
-      <a href="https://runeberg.org/admin/">$_("Learn more")</a>
-    </div>
-    <a class="toast__close">&times;<span class="shift">$_("Close")</span></a>
-  </div>

--- a/openlibrary/templates/book_providers/runeberg_read_button.html
+++ b/openlibrary/templates/book_providers/runeberg_read_button.html
@@ -1,8 +1,7 @@
-$def with(runeberg_id, analytics_attr)
+$def with(edition_key, runeberg_id, analytics_attr)
 
 <div class="cta-button-group">
-  <a
-      href="https://runeberg.org/$runeberg_id/"
+  <a href="http://openlibrary.org/books/${edition_key}/-/borrow?action=read"
       title="$_('Read eBook from Project Runeberg')"
       class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--runeberg"
       target="_blank"

--- a/openlibrary/templates/book_providers/runeberg_read_button.html
+++ b/openlibrary/templates/book_providers/runeberg_read_button.html
@@ -6,7 +6,5 @@ $def with(edition_key, runeberg_id, analytics_attr)
       class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--runeberg"
       target="_blank"
       $:analytics_attr('Read')
-      aria-haspopup="true"
-      aria-controls="runeberg-toast"
   >$_('Read')</a>
 </div>

--- a/openlibrary/templates/book_providers/runeberg_read_button.html
+++ b/openlibrary/templates/book_providers/runeberg_read_button.html
@@ -1,7 +1,7 @@
 $def with(edition_key, runeberg_id, analytics_attr)
 
 <div class="cta-button-group">
-  <a href="http://openlibrary.org/books/${edition_key}/-/borrow?action=read"
+  <a href="/books/${edition_key}/-/borrow?action=read"
       title="$_('Read eBook from Project Runeberg')"
       class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--runeberg"
       target="_blank"

--- a/openlibrary/templates/book_providers/standard_ebooks_read_button.html
+++ b/openlibrary/templates/book_providers/standard_ebooks_read_button.html
@@ -6,7 +6,5 @@ $def with(edition_key, standard_ebooks_id, analytics_attr)
       class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--standard-ebooks"
       target="_blank"
       $:analytics_attr('Read')
-      aria-haspopup="true"
-      aria-controls="standard-ebooks-toast"
   >$_('Read')</a>
 </div>

--- a/openlibrary/templates/book_providers/standard_ebooks_read_button.html
+++ b/openlibrary/templates/book_providers/standard_ebooks_read_button.html
@@ -10,12 +10,3 @@ $def with(edition_key, standard_ebooks_id, analytics_attr)
       aria-controls="standard-ebooks-toast"
   >$_('Read')</a>
 </div>
-
-$if render_once('standard-ebooks-toast'):
-  <div class="toast toast--book-provider" data-toast-trigger=".cta-btn--standard-ebooks" id="standard-ebooks-toast" style="display:none">
-    <div class="toast__body">
-      $:_('This book is available from <a href="https://standardebooks.org/">Standard Ebooks</a>. Standard Ebooks is a trusted book provider and a volunteer-driven project that produces new editions of public domain ebooks that are lovingly formatted, open source, free of copyright restrictions, and free of cost.')
-      <a href="https://standardebooks.org/about">$_("Learn more")</a>
-    </div>
-    <a class="toast__close">&times;<span class="shift">$_("Close")</span></a>
-  </div>

--- a/openlibrary/templates/book_providers/standard_ebooks_read_button.html
+++ b/openlibrary/templates/book_providers/standard_ebooks_read_button.html
@@ -1,8 +1,7 @@
-$def with(standard_ebooks_id, analytics_attr)
+$def with(edition_key, standard_ebooks_id, analytics_attr)
 
 <div class="cta-button-group">
-  <a
-      href="https://standardebooks.org/ebooks/$standard_ebooks_id/text/single-page"
+  <a href="http://openlibrary.org/books/${edition_key}/-/borrow?action=read"
       title="$_('Read eBook from Standard eBooks')"
       class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--standard-ebooks"
       target="_blank"

--- a/openlibrary/templates/book_providers/standard_ebooks_read_button.html
+++ b/openlibrary/templates/book_providers/standard_ebooks_read_button.html
@@ -1,7 +1,7 @@
 $def with(edition_key, standard_ebooks_id, analytics_attr)
 
 <div class="cta-button-group">
-  <a href="http://openlibrary.org/books/${edition_key}/-/borrow?action=read"
+  <a href="/books/${edition_key}/-/borrow?action=read"
       title="$_('Read eBook from Standard eBooks')"
       class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--standard-ebooks"
       target="_blank"

--- a/openlibrary/templates/book_providers/wikisource_read_button.html
+++ b/openlibrary/templates/book_providers/wikisource_read_button.html
@@ -5,6 +5,5 @@ $def with(edition_key, wikisource_id, analytics_attr)
       title="$_('Read eBook on Wikisource')"
       class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--wikisource"
       target="_blank"
-      aria-haspopup="true"
-      aria-controls="wikisource-toast">$_('Read')</a>
+      >$_('Read')</a>
 </div>

--- a/openlibrary/templates/book_providers/wikisource_read_button.html
+++ b/openlibrary/templates/book_providers/wikisource_read_button.html
@@ -1,7 +1,12 @@
-$def with(wikisource_id, analytics_attr)
+$def with(edition_key, wikisource_id, analytics_attr)
 
 <div class="cta-button-group">
-    <a href="https://wikisource.org/wiki/$wikisource_id" title="$_('Read eBook on Wikisource')" class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--wikisource" target="_blank" aria-haspopup="true" aria-controls="wikisource-toast">$_('Read')</a>
+    <a href="http://openlibrary.org/books/${edition_key}/-/borrow?action=read"
+      title="$_('Read eBook on Wikisource')"
+      class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--wikisource"
+      target="_blank"
+      aria-haspopup="true"
+      aria-controls="wikisource-toast">$_('Read')</a>
 </div>
 
 $if render_once('wikisource-toast'):

--- a/openlibrary/templates/book_providers/wikisource_read_button.html
+++ b/openlibrary/templates/book_providers/wikisource_read_button.html
@@ -1,7 +1,7 @@
 $def with(edition_key, wikisource_id, analytics_attr)
 
 <div class="cta-button-group">
-    <a href="http://openlibrary.org/books/${edition_key}/-/borrow?action=read"
+    <a href="/books/${edition_key}/-/borrow?action=read"
       title="$_('Read eBook on Wikisource')"
       class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--wikisource"
       target="_blank"

--- a/openlibrary/templates/book_providers/wikisource_read_button.html
+++ b/openlibrary/templates/book_providers/wikisource_read_button.html
@@ -8,12 +8,3 @@ $def with(edition_key, wikisource_id, analytics_attr)
       aria-haspopup="true"
       aria-controls="wikisource-toast">$_('Read')</a>
 </div>
-
-$if render_once('wikisource-toast'):
-    <div class="toast toast--book-provider" data-toast-trigger=".cta-btn--wikisource" id="wikisource-toast" style="display:none">
-        <div class="toast__body">
-            $:_('This book is available from <a href="https://wikisource.org/">Wikisource</a>. Wikisource, a <a href="https://www.wikimedia.org/">Wikimedia Foundation</a> project, is a trusted book provider of works available under the <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC-BY-SA</a> open content license, such as essays, historical documents, letters, speeches, and public domain books.')
-            <a href="https://wikisource.org/wiki/Wikisource:What_is_Wikisource%3F">$_('Learn more')</a>
-        </div>
-        <a class="toast__close">&times;<span class="shift">$_("Close")</span></a>
-    </div>

--- a/openlibrary/templates/interstitial.html
+++ b/openlibrary/templates/interstitial.html
@@ -1,14 +1,17 @@
-$def with(url, provider="", wait=5)
+$def with(url, provider_name="", wait=5)
+
+$if provider_name == None:
+  $ provider_name = ""
 
 <h1>$_("You are being redirected to your book")</h1>
 
-<p id="countdown">$_("This book is provided by %s, a third-party Open Library Trusted Book Provider", "<strong>" + provider= "</strong>")</p>
+<p id="countdown">$:_('This book is provided by <strong>%(book_provider)s</strong>, a third-party Open Library Trusted Book Provider', book_provider=websafe(provider_name))</p>
 
-<p>$_("You will be automatically redirected to %s in %s seconds...", url, '<span id="timer">5</span>')</p>
+<p>$:_('You will be automatically redirected to <strong>%(book_provider_url)s</strong> in <span id="timer">5</span> seconds...', book_provider_url=url)</p>
 
 <p>
   <a href="#" onclick="window.close(); return false;">$_("Cancel")</a> |
-  <a href="">$_("Continue without waiting")</a>
+  <a href="${url}">$_("Continue without waiting")</a>
 </p>
 
 <script>
@@ -21,9 +24,7 @@ $def with(url, provider="", wait=5)
 
     if (count === 0) {
       clearInterval(countdown);
-      // Open in a new tab and then return to Open Library
-      window.open("$url", "_blank"); // Open in new tab
-      history.back(); // Return to previous page on Open Library
+      window.location.href = '$url';
     }
   }, 1000);
 </script>

--- a/openlibrary/templates/interstitial.html
+++ b/openlibrary/templates/interstitial.html
@@ -3,7 +3,7 @@ $def with(url, provider_name="", wait=5)
 $if provider_name is None:
   $ provider_name = ""
 
-<div class="interstitial">
+<div id="contentBody" class="interstitial" data-url="${url}" data-wait="${wait}">
   <h1>$_("You are being redirected to your book")</h1>
 
   <p id="countdown">$:_('This book is provided by %(book_provider)s, a third-party Open Library Trusted Book Provider', book_provider='<strong>' + websafe(provider_name).replace('_', ' ').title() + '</strong>')</p>
@@ -15,18 +15,3 @@ $if provider_name is None:
     <a href="${url}">$_("Continue without waiting")</a>
   </p>
 </div>
-<script>
-  let count = $wait;
-  const timerElement = document.getElementById("timer");
-
-  const countdown = setInterval(() => {
-    count--;
-    timerElement.textContent = count;
-
-    if (count === 0) {
-      clearInterval(countdown);
-      window.location.href = '$url';
-    }
-  }, 1000);
-</script>
-

--- a/openlibrary/templates/interstitial.html
+++ b/openlibrary/templates/interstitial.html
@@ -1,19 +1,20 @@
 $def with(url, provider_name="", wait=5)
 
-$if provider_name == None:
+$if provider_name is None:
   $ provider_name = ""
 
-<h1>$_("You are being redirected to your book")</h1>
+<div class="interstitial">
+  <h1>$_("You are being redirected to your book")</h1>
 
-<p id="countdown">$:_('This book is provided by <strong>%(book_provider)s</strong>, a third-party Open Library Trusted Book Provider', book_provider=websafe(provider_name))</p>
+  <p id="countdown">$:_('This book is provided by %(book_provider)s, a third-party Open Library Trusted Book Provider', book_provider='<strong>' + websafe(provider_name).replace('_', ' ').title() + '</strong>')</p>
 
-<p>$:_('You will be automatically redirected to <strong>%(book_provider_url)s</strong> in <span id="timer">5</span> seconds...', book_provider_url=url)</p>
+  <p>$:_('In %(time)s seconds, you will be automatically redirected to: %(url)s', time='<span id="timer">{}</span>'.format(wait), url='<a href="{0}">{0}</a>'.format(url))</p>
 
-<p>
-  <a href="#" onclick="window.close(); return false;">$_("Cancel")</a> |
-  <a href="${url}">$_("Continue without waiting")</a>
-</p>
-
+  <p>
+    <a href="#" onclick="window.close(); return false;">$_("Cancel")</a> |
+    <a href="${url}">$_("Continue without waiting")</a>
+  </p>
+</div>
 <script>
   let count = $wait;
   const timerElement = document.getElementById("timer");


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10561 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature/refactor

### Technical
<!-- What should be noted about the implementation? -->
Add new behavior to borrow API to redirect to an interstitial page in the case that a read/borrow action is requested on a non-IA provided edition. Also removes the existing toasts that are generated when using a direct provider read button link.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Click a read/borrow button for an edition provided by a trusted third party provider
2. Observe that you are now redirected to an interstitial page, and that you can observe the countdown timer, cancel the redirection, or immediately follow to the link.
3. Observe that there is no longer a toast on the original page after clicking the button.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/user-attachments/assets/ea2a43fc-481a-456d-b7cd-0b364a23f810)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
