### PR TITLE
Fix broken dropper arrow on iOS

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -7778,12 +7778,6 @@ msgstr ""
 msgid "Choose a password"
 msgstr ""
 
-#: openlibrary/plugins/upstream/borrow.py
-msgid ""
-"Your account has hit a lending limit. Please try again later or contact "
-"info@archive.org."
-msgstr ""
-
 #: openlibrary/plugins/upstream/account.py
 msgid "The email address you entered is invalid"
 msgstr ""
@@ -7918,9 +7912,22 @@ msgstr ""
 msgid "Notification preferences have been updated successfully."
 msgstr ""
 
-#: openlibrary/plugins/openlibrary/lists.py
-#, python-format
-msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
+#: openlibrary/plugins/upstream/borrow.py
+msgid ""
+"Your account has hit a lending limit. Please try again later or contact "
+"info@archive.org."
+msgstr ""
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "eBook?"
+msgstr ""
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "First published"
+msgstr ""
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "Classic eBooks"
 msgstr ""
 
 #: openlibrary/plugins/openlibrary/code.py
@@ -8027,16 +8034,9 @@ msgstr ""
 msgid "Science"
 msgstr ""
 
-#: openlibrary/plugins/worksearch/code.py
-msgid "eBook?"
-msgstr ""
-
-#: openlibrary/plugins/worksearch/code.py
-msgid "First published"
-msgstr ""
-
-#: openlibrary/plugins/worksearch/code.py
-msgid "Classic eBooks"
+#: openlibrary/plugins/openlibrary/lists.py
+#, python-format
+msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
 msgstr ""
 
 #: openlibrary/core/edits.py

--- a/static/css/components/generic-dropper.less
+++ b/static/css/components/generic-dropper.less
@@ -116,6 +116,14 @@
     &:hover { background-color: darken(@primary-blue, 20%); }
     border-radius: 2px 5px 5px 2px;
   }
+  // hide extra arrow on iOS
+  summary::marker {
+    content: "";
+  }
+  summary::-webkit-details-marker {
+    display: none;
+  }
+
   summary::after {
     margin: 0 8px;
     width: 24px;

--- a/static/css/components/language.less
+++ b/static/css/components/language.less
@@ -8,6 +8,9 @@
 .language-component summary::marker {
   content: "";
 }
+.language-component summary::-webkit-details-marker {
+  display: none;
+}
 .language-component summary:after {
   content: " ▼";
   zoom: 70%;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10584 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix broken arrow styling on `summary` elements on iOS

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini - Let me know if this works for you (if you are able)! I didn't actually use `summary::marker` in the read button update, so I added it and `summary::-webkit-details-marker` so hopefully that fixes it. Language selector was the only other place I found that only `summary::marker` was defined.


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
