### PR TITLE
(Closes #8343) Create update_stale_ocaid_references.py script

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -7778,12 +7778,6 @@ msgstr ""
 msgid "Choose a password"
 msgstr ""
 
-#: openlibrary/plugins/upstream/borrow.py
-msgid ""
-"Your account has hit a lending limit. Please try again later or contact "
-"info@archive.org."
-msgstr ""
-
 #: openlibrary/plugins/upstream/account.py
 msgid "The email address you entered is invalid"
 msgstr ""
@@ -7918,9 +7912,22 @@ msgstr ""
 msgid "Notification preferences have been updated successfully."
 msgstr ""
 
-#: openlibrary/plugins/openlibrary/lists.py
-#, python-format
-msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
+#: openlibrary/plugins/upstream/borrow.py
+msgid ""
+"Your account has hit a lending limit. Please try again later or contact "
+"info@archive.org."
+msgstr ""
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "eBook?"
+msgstr ""
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "First published"
+msgstr ""
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "Classic eBooks"
 msgstr ""
 
 #: openlibrary/plugins/openlibrary/code.py
@@ -8027,16 +8034,9 @@ msgstr ""
 msgid "Science"
 msgstr ""
 
-#: openlibrary/plugins/worksearch/code.py
-msgid "eBook?"
-msgstr ""
-
-#: openlibrary/plugins/worksearch/code.py
-msgid "First published"
-msgstr ""
-
-#: openlibrary/plugins/worksearch/code.py
-msgid "Classic eBooks"
+#: openlibrary/plugins/openlibrary/lists.py
+#, python-format
+msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
 msgstr ""
 
 #: openlibrary/core/edits.py

--- a/scripts/update_stale_ocaid_references.py
+++ b/scripts/update_stale_ocaid_references.py
@@ -8,6 +8,7 @@ PYTHONPATH=. python ./scripts/update_dark_ocaid_references.py /olsystem/etc/open
 import _init_path  # noqa: F401  Imported for its side effect of setting PYTHONPATH
 import requests
 import web
+from typing import Optional
 
 import infogami
 from infogami import config
@@ -75,7 +76,7 @@ def disassociate_dark_ocaids(s3_keys, since=None, until=None, test=True):
     return editions_fetched, editions_dirty, editions_updated
 
 
-def main(ol_config: str, since: str = None, until: str = None, test: bool = True):
+def main(ol_config: str, since: Optional[str] = None, until: Optional[str] = None, test: bool = True):
     load_config(ol_config)
     infogami._setup()
     s3_keys = config.get('ia_ol_metadata_write_s3')  # XXX needs dark scope

--- a/scripts/update_stale_ocaid_references.py
+++ b/scripts/update_stale_ocaid_references.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""
+PYTHONPATH=. python ./scripts/update_dark_ocaid_references.py /olsystem/etc/openlibrary.yml --since "2025-03"
+
+# e.g. https://openlibrary.org/recentchanges/2025/03/16/bulk_update/146351306
+"""
+
+import _init_path  # noqa: F401  Imported for its side effect of setting PYTHONPATH
+import requests
+import web
+import infogami
+from infogami import config  # noqa: F401 side effects may be needed
+from openlibrary.config import load_config
+from openlibrary.accounts import RunAs
+from scripts.solr_builder.solr_builder.fn_to_cli import FnToCLI
+
+def get_dark_ol_editions(s3_keys, cursor=None, rows=1000, since=None, until=None):
+    if not s3_keys or not all(k in s3_keys for k in ("s3_key", "s3_secret")):
+        raise ValueError("Invalid S3 keys provided")
+    scrape_api_url = "https://archive.org/services/search/v1/scrape"
+    headers = {"authorization": "LOW {s3_key}:{s3_secret}".format(**s3_keys)}
+    fields = ["identifier", "curatenote", "curatedate", "openlibrary_edition"]
+    q = "openlibrary_edition:*"
+    if since or until:
+        q = ' AND '.join((q, f"curatedate:[{since or '*'} TO {until or '*'}]"))
+
+    query_params = {
+        "q": q,
+        "count": rows,
+        "scope": "dark",
+        "service": "metadata__dark",
+        "fields": ",".join(fields),
+    }
+    if cursor:
+        query_params['cursor'] = cursor
+
+    response = requests.get(scrape_api_url, headers=headers, params=query_params)
+    response.raise_for_status()
+    data = response.json()
+    cursor = data.get("cursor")
+    editions = {
+        # Edition key `/books/OL123M` mapped to its ES dark item metadata
+        f'/books/{doc["openlibrary_edition"]}': doc for doc in data.get("items", [])
+    }
+    return editions, cursor
+
+
+def disassociate_dark_ocaids(s3_keys, since=None, until=None, test=True):
+    cursor = ""
+    editions_fetched, editions_dirty, editions_updated = (0, 0, 0)
+    while cursor is not None:
+        es_editions, cursor = get_dark_ol_editions(
+            s3_keys, since=since, until=until, cursor=cursor
+        )
+        editions_fetched += len(es_editions)
+        ol_editions = web.ctx.site.get_many(list(es_editions.keys()))
+        updated_eds = []
+        for ed in ol_editions:
+            es_id = es_editions[ed.key]['identifier']
+            ed_dict = ed.dict()
+            if ed_dict.get('ocaid') and es_id == ed_dict['ocaid']:
+                editions_dirty += 1
+                del ed_dict['ocaid']
+                updated_eds.append(ed_dict)
+                print(f"Dirty: {ed.key}")
+
+        if updated_eds and not test:
+            editions_updated += len(updated_eds)
+            with RunAs('ImportBot'):
+                web.ctx.ip = web.ctx.ip or '127.0.0.1'
+                web.ctx.site.save_many(updated_eds, comment="Redacting ocaids")
+    return editions_fetched, editions_dirty, editions_updated
+
+
+def main(ol_config: str, since: str=None, until: str=None, test: bool=True):
+    load_config(ol_config)
+    infogami._setup()
+    s3_keys = config.get('ia_ol_metadata_write_s3') # XXX needs dark scope
+    editions_fetched, editions_dirty, editions_updated = disassociate_dark_ocaids(
+        s3_keys, since=since, until=until, test=test
+    )
+    print(f"{editions_fetched} editions fetched, "
+          f"{editions_dirty} editions dirty, "
+          f"{editions_updated} editions updated")
+
+
+if __name__ == '__main__':
+    FnToCLI(main).run()

--- a/scripts/update_stale_ocaid_references.py
+++ b/scripts/update_stale_ocaid_references.py
@@ -8,11 +8,13 @@ PYTHONPATH=. python ./scripts/update_dark_ocaid_references.py /olsystem/etc/open
 import _init_path  # noqa: F401  Imported for its side effect of setting PYTHONPATH
 import requests
 import web
+
 import infogami
-from infogami import config  # noqa: F401 side effects may be needed
-from openlibrary.config import load_config
+from infogami import config
 from openlibrary.accounts import RunAs
+from openlibrary.config import load_config
 from scripts.solr_builder.solr_builder.fn_to_cli import FnToCLI
+
 
 def get_dark_ol_editions(s3_keys, cursor=None, rows=1000, since=None, until=None):
     if not s3_keys or not all(k in s3_keys for k in ("s3_key", "s3_secret")):
@@ -40,7 +42,8 @@ def get_dark_ol_editions(s3_keys, cursor=None, rows=1000, since=None, until=None
     cursor = data.get("cursor")
     editions = {
         # Edition key `/books/OL123M` mapped to its ES dark item metadata
-        f'/books/{doc["openlibrary_edition"]}': doc for doc in data.get("items", [])
+        f'/books/{doc["openlibrary_edition"]}': doc
+        for doc in data.get("items", [])
     }
     return editions, cursor
 
@@ -72,16 +75,18 @@ def disassociate_dark_ocaids(s3_keys, since=None, until=None, test=True):
     return editions_fetched, editions_dirty, editions_updated
 
 
-def main(ol_config: str, since: str=None, until: str=None, test: bool=True):
+def main(ol_config: str, since: str = None, until: str = None, test: bool = True):
     load_config(ol_config)
     infogami._setup()
-    s3_keys = config.get('ia_ol_metadata_write_s3') # XXX needs dark scope
+    s3_keys = config.get('ia_ol_metadata_write_s3')  # XXX needs dark scope
     editions_fetched, editions_dirty, editions_updated = disassociate_dark_ocaids(
         s3_keys, since=since, until=until, test=test
     )
-    print(f"{editions_fetched} editions fetched, "
-          f"{editions_dirty} editions dirty, "
-          f"{editions_updated} editions updated")
+    print(
+        f"{editions_fetched} editions fetched, "
+        f"{editions_dirty} editions dirty, "
+        f"{editions_updated} editions updated"
+    )
 
 
 if __name__ == '__main__':

--- a/scripts/update_stale_ocaid_references.py
+++ b/scripts/update_stale_ocaid_references.py
@@ -5,10 +5,10 @@ PYTHONPATH=. python ./scripts/update_dark_ocaid_references.py /olsystem/etc/open
 # e.g. https://openlibrary.org/recentchanges/2025/03/16/bulk_update/146351306
 """
 
+
 import _init_path  # noqa: F401  Imported for its side effect of setting PYTHONPATH
 import requests
 import web
-from typing import Optional
 
 import infogami
 from infogami import config
@@ -76,7 +76,12 @@ def disassociate_dark_ocaids(s3_keys, since=None, until=None, test=True):
     return editions_fetched, editions_dirty, editions_updated
 
 
-def main(ol_config: str, since: Optional[str] = None, until: Optional[str] = None, test: bool = True):
+def main(
+    ol_config: str,
+    since: str | None = None,
+    until: str | None = None,
+    test: bool = True,
+):
     load_config(ol_config)
     infogami._setup()
     s3_keys = config.get('ia_ol_metadata_write_s3')  # XXX needs dark scope

--- a/scripts/update_stale_ocaid_references.py
+++ b/scripts/update_stale_ocaid_references.py
@@ -62,11 +62,10 @@ def disassociate_dark_ocaids(s3_keys, since=None, until=None, test=True):
         for ed in ol_editions:
             es_id = es_editions[ed.key]['identifier']
             ed_dict = ed.dict()
-            if ed_dict.get('ocaid') and es_id == ed_dict['ocaid']:
+            if ed_dict.get('ocaid') == es_id:
                 editions_dirty += 1
                 del ed_dict['ocaid']
                 updated_eds.append(ed_dict)
-                print(f"Dirty: {ed.key}")
 
         if updated_eds and not test:
             editions_updated += len(updated_eds)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8343

Tested on `ol-dev1` on `ol-mek-web-1` with:

```
PYTHONPATH=. python ./scripts/update_dark_ocaid_references.py /olsystem/etc/openlibrary.yml --since "2025-03"
```

Then I modified the function `get_dark_ol_editions` to use `q = "openlibrary_edition:* AND identifier:a*"` which limited the results to a single page of about 120 instead of several thousand (for testing)

i.e. the equivalent of:
https://archive.org/services/search/v1/scrape?q=openlibrary_edition%3A*%20AND%20identifier:a*%20AND%20curatedate:[2025-03%20TO%20*]&scope=dark&service=metadata__dark&count=1000&fields=identifier,openlibrary_edition

![Screenshot 2025-03-16 at 5 06 03 PM](https://github.com/user-attachments/assets/70da8ed6-db0b-4453-b8d9-9a67f574259f)

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

Note, I added special s3 keys to our olsystem openlibrary.yml to get this to work because the `ia_ol_metadata_write_s3` keys don't have access to `dark`. We should discuss with @ximm how we want to handle this case with respect to running this within our infrastructure daily as a cron (similar to update_stale_work_references.py).

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
