### PR TITLE
Enable nginx application/json gzipping

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -43,7 +43,7 @@ http {
 
     gzip  on;
     gzip_disable "MSIE [1-6]\.(?!.*SV1)";
-    gzip_types       text/plain text/css application/x-javascript application/javascript application/xml;
+    gzip_types       text/plain text/css application/x-javascript application/javascript application/xml application/json;
 
     # Black-listed IPs
     include /olsystem/etc/nginx/deny.conf;


### PR DESCRIPTION
Noticed this wasn't enabled, and thought it might make sense to enable it. Should make our search.json/etc API calls smaller. Worth patch deploying to monitor performance.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
