### PR TITLE
Enable Already Read year read drop-down

### DIFF
--- a/openlibrary/core/bookshelves_events.py
+++ b/openlibrary/core/bookshelves_events.py
@@ -67,6 +67,27 @@ class BookshelvesEvents(db.CommonExtras):
         return results[0] if results else None
 
     @classmethod
+    def get_user_yearly_read_counts(cls, username: str) -> list[tuple[int, int]]:
+        """Returns books read by year for a given user."""
+        results = db.get_db().query(
+            """
+                SELECT
+                    substring(event_date from 1 for 4) as year,
+                    count(*) as count
+                FROM bookshelves_events
+                WHERE username=$username AND event_type=$event_type
+                GROUP BY year
+                ORDER BY year DESC
+            """,
+            vars={
+                'username': username,
+                'event_type': BookshelfEvent.FINISH,
+            },
+        )
+
+        return [(int(row.year), row.count) for row in results]
+
+    @classmethod
     def select_by_book_user_and_type(cls, username, work_id, edition_id, event_type):
         oldb = db.get_db()
 

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -14,6 +14,7 @@ from openlibrary.accounts.model import (
 )
 from openlibrary.core.booknotes import Booknotes
 from openlibrary.core.bookshelves import Bookshelves
+from openlibrary.core.bookshelves_events import BookshelvesEvents
 from openlibrary.core.follows import PubSub
 from openlibrary.core.lending import (
     add_availability,
@@ -21,7 +22,6 @@ from openlibrary.core.lending import (
 )
 from openlibrary.core.models import LoggedBooksData, User
 from openlibrary.core.observations import Observations, convert_observation_ids
-from openlibrary.core.yearly_reading_goals import YearlyReadingGoals
 from openlibrary.i18n import gettext as _
 from openlibrary.utils import extract_numeric_id_from_olid
 from openlibrary.utils.dateutil import current_year
@@ -261,12 +261,7 @@ class mybooks_readinglog(delegate.page):
 
         # Add yearly reading goals to the MyBooksTemplate
         if mb.key == 'already-read' and mb.is_my_page:
-            mb.reading_goals = [
-                str(result.year)
-                for result in YearlyReadingGoals.select_by_username(
-                    mb.username, order='year DESC'
-                )
-            ]
+            mb.yearly_reads = BookshelvesEvents.get_user_yearly_read_counts(mb.username)
 
         ratings = logged_book_data.ratings
         return render['account/reading_log'](
@@ -420,7 +415,7 @@ class MyBooksTemplate:
             else {}
         )
 
-        self.reading_goals: list = []
+        self.yearly_reads: list[tuple[int, int]] = []
         self.selected_year = None
 
         if (self.me and self.is_my_page) or self.is_public:

--- a/openlibrary/templates/account/view.html
+++ b/openlibrary/templates/account/view.html
@@ -28,9 +28,10 @@ $var title: $header_title
         $else:
           <div class="sansserif grey account-settings-menu navigation-breadcrumbs">
             $:render_template("books/mybooks_breadcrumb_select", mb, selected=header_title)
-            $if header_title=="Already Read" and mb.yearly_reads:
+
+            $if mb.key == 'already-read' and mb.yearly_reads:
               $ selected_year = mb.selected_year if mb.selected_year else _("All Time")
-              $:render_template("books/year_breadcrumb_select", mb, selected= selected_year)
+              $:render_template("books/year_breadcrumb_select", mb, selected=selected_year)
 
           </div>
       </div>

--- a/openlibrary/templates/account/view.html
+++ b/openlibrary/templates/account/view.html
@@ -28,8 +28,7 @@ $var title: $header_title
         $else:
           <div class="sansserif grey account-settings-menu navigation-breadcrumbs">
             $:render_template("books/mybooks_breadcrumb_select", mb, selected=header_title)
-            $if header_title=="Already Read" and mb.reading_goals:
-
+            $if header_title=="Already Read" and mb.yearly_reads:
               $ selected_year = mb.selected_year if mb.selected_year else _("All Time")
               $:render_template("books/year_breadcrumb_select", mb, selected= selected_year)
 

--- a/openlibrary/templates/books/year_breadcrumb_select.html
+++ b/openlibrary/templates/books/year_breadcrumb_select.html
@@ -6,6 +6,6 @@ $ readlog_url = url_prefix + "/year/%s/"
 
 $ options = [(_("All Time"), url_prefix)]
 $if mb.is_my_page or mb.is_public:
-  $for year in mb.reading_goals:
-    $ options += [ (year, readlog_url % year)]
+  $for (year, count) in mb.yearly_reads:
+    $ options += [("%d (%d)" % (year, count), readlog_url % year)]
 $:render_template("books/breadcrumb_select", selected, options)

--- a/openlibrary/templates/books/year_breadcrumb_select.html
+++ b/openlibrary/templates/books/year_breadcrumb_select.html
@@ -1,11 +1,10 @@
 $def with (mb, selected=_("All Time"))
 
 $ url_prefix = "/people/%s/books/already-read/" % mb.username
-$ readlog_url = url_prefix + "/year/%s/"
-
 
 $ options = [(_("All Time"), url_prefix)]
 $if mb.is_my_page or mb.is_public:
   $for (year, count) in mb.yearly_reads:
-    $ options += [("%d (%d)" % (year, count), readlog_url % year)]
+    $ options += [("%d (%d)" % (year, count), url_prefix + "/year/%d/" % year)]
+
 $:render_template("books/breadcrumb_select", selected, options)


### PR DESCRIPTION
The dropper was never actually displaying, since I think the header_title has been changed to include a count. This fixes it to use the `key`, and also switched it to use BookshelvesEvents, since people can log year read without necessarily using the yearly reading goals feature.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Tested the query on prod and no Seq Scans:

```
 Sort  (cost=17.87..17.87 rows=1 width=9) (actual time=0.130..0.132 rows=5 loops=1)
   Sort Key: ("substring"(event_date, 1, 4))
   Sort Method: quicksort  Memory: 25kB
   ->  HashAggregate  (cost=17.84..17.86 rows=1 width=9) (actual time=0.106..0.109 rows=5 loops=1)
         ->  Index Only Scan using bookshelves_events_user_checkins_idx on bookshelves_events  (cost=0.42..17.76 rows=16 width=9) (actual time=0.032..0.089 rows=19 loops=1)
               Index Cond: ((username = 'ScarTissue'::text) AND (event_type = 3))
               Heap Fetches: 19
 Total runtime: 0.176 ms
```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/user-attachments/assets/cd5bf313-7d1c-4f4c-b386-06a80d7f799a)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
