### PR TITLE
Add `production` git tag when code is deployed

### DIFF
--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -279,6 +279,8 @@ deploy_openlibrary() {
     DEPLOY_TAG="deploy-$(date +%Y-%m-%d)"
     git -C openlibrary tag $DEPLOY_TAG
     git -C openlibrary push git@github.com:internetarchive/openlibrary.git $DEPLOY_TAG
+    git -C openlibrary tag -f production
+    git -C openlibrary push -f git@github.com:internetarchive/openlibrary.git production
 
     check_server_access
     check_crons


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds an additional `production` tag to the latest commit whenever Open Library is deployed to production.  The `deploy-YYYY-MM-DD` tags will remain unchanged.

Adding a `production` tag to the releae commit will allow us to use a static URL when doing our pre-deployment code checks:

https://github.com/internetarchive/openlibrary/compare/production...master

### Technical
<!-- What should be noted about the implementation? -->
We could simplify this by pushing once with the `--tags` flag, but that will push _all_ local tags to the remote repo.  This would be problematic for maintains who use tags.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
