### PR TITLE
10600/fix/read panel read button spacing

### DIFF
--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -183,7 +183,6 @@ a.cta-btn {
   }
 
   .cta-btn {
-    margin: 0;
     padding: 8px 0;
 
     &:first-child {
@@ -203,5 +202,10 @@ a.cta-btn {
     &:not(:last-child) { border-radius: 6px 2px 2px 6px; }
     // stylelint-disable-next-line selector-max-specificity
     &:not(:first-child):hover { width: 100%; }
+  }
+
+  &.cta-dropper-button { // only read dropper buttons
+    // stylelint-disable-next-line no-descending-specificity
+    .cta-btn { margin: 0; }
   }
 }

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -205,6 +205,7 @@ a.cta-btn {
   }
 
   &.cta-dropper-button { // only read dropper buttons
+    // Rule broken by .cta-btn:not(:first-child):hover
     // stylelint-disable-next-line no-descending-specificity
     .cta-btn { margin: 0; }
   }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10600

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Re-adds 10px margin to direct provider read buttons in the read panel

### Technical
<!-- What should be noted about the implementation? -->
Reformat CSS to only specify `margin: 0` for `.cta-button-group .cta-btn` elements that also have the `cta-dropper-button` tag.

I decided to disable the `no-descending-specificity` rule for the new line, as the layout of the existing CSS necessitated either:
1. A rewrite of an already-stylelint-disabled too-specific line (the source of the descending specificity error)
2. Bisecting a group of styles with the new line
3. Disabling `no-descending-specificity` on the new line

The first approach felt outside the scope of the PR, and the second one was much uglier than a 1 line comment. I referenced the reason for disabling so that if the offending line gets reformatted in the future, this one can be changed too.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Observe that direct providers read buttons in the read panel on the books page now have a 10px bottom margin 

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/user-attachments/assets/8eab606c-0fe7-4894-9393-b4104443086b)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@jimchamp 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
