### PR TITLE
Fix global lists erroring when rendering

### DIFF
--- a/openlibrary/templates/type/list/view.html
+++ b/openlibrary/templates/type/list/view.html
@@ -2,15 +2,19 @@ $def with (lst, check_owner=True, owns_page=False)
 
 $var title: $lst.name
 
-$ is_owner = owns_page
-$ username = ctx.user and ctx.user['key'].split('/')[-1]
+$if lst['key'].startswith('/people/'):
+    $ is_owner = owns_page
+    $ username = ctx.user and ctx.user['key'].split('/')[-1]
 
-$if check_owner and username:
-    $ is_owner = username == lst['key'].split('/')[2]
+    $if check_owner and username:
+        $ is_owner = username == lst['key'].split('/')[2]
 
-$ template = MyBooksTemplate(lst['key'].split('/')[2], 'list').render(
-    $   header_title= "",
-    $   template=render_template("type/list/view_body", lst, is_owner),
-    $   page=lst
-    $ )
+    $ template = MyBooksTemplate(lst['key'].split('/')[2], 'list').render(
+        $   header_title= "",
+        $   template=render_template("type/list/view_body", lst, is_owner),
+        $   page=lst
+        $ )
+$else:
+    $ template = render_template("type/list/view_body", lst, False)
+
 $:template

--- a/openlibrary/templates/type/list/view_body.html
+++ b/openlibrary/templates/type/list/view_body.html
@@ -37,7 +37,7 @@ $jsdef render_seed_count(seed_count):
 
 $if not is_owner:
     <div id="contentHead" style="margin-bottom:0;">
-        $ owner = list.get_owner()
+        $:macros.databarView(list, edit=list.key.startswith('/lists/'))
         <h1>$list.name</h1>
         <p class="collapse sansserif">
             $ component_times['render_seed_count'] = time()


### PR DESCRIPTION
Global lists failing to render at all on prod.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
~Before: https://openlibrary.org/lists/OL286201L/International_Booker_Prize_2025_Longlist~ Patch deployed, so no longer erroring.
After: https://testing.openlibrary.org/lists/OL286201L/International_Booker_Prize_2025_Longlist

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Before:
![image](https://github.com/user-attachments/assets/8b8ff6e6-ec52-415f-ab40-31442dc19180)

After:
![image](https://github.com/user-attachments/assets/b6e809aa-6d54-47b3-91fe-0f7c77d44cad)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
