### PR TITLE
Fix some small Bulk Search bugs

### DIFF
--- a/openlibrary/components/BulkSearch/components/BulkSearchControls.vue
+++ b/openlibrary/components/BulkSearch/components/BulkSearchControls.vue
@@ -1,6 +1,3 @@
-
-
-
 <template>
     <div class="bulk-search-controls">
 
@@ -27,9 +24,14 @@
                         </select></label>
 
                         <label v-if="this.showApiKey"><strong >OpenAI API Key</strong> <br>
-                            <input class="api-key-bar" v-if="showPassword" placeholder= "Enter your OpenAI API key to use this feature." type="password" @click="togglePasswordVisibility()" v-model="bulkSearchState.extractionOptions.openaiApiKey" />
-
-                            <input class="api-key-bar" v-else type="text" placeholder= "OpenAI API key here...." @click="togglePasswordVisibility" v-model="bulkSearchState.extractionOptions.openaiApiKey" />
+                            <input
+                                class="api-key-bar"
+                                :type="showPassword ? 'password' : 'text'"
+                                placeholder="OpenAI API key here...."
+                                @focus="showPassword = false"
+                                @blur="showPassword = true"
+                                v-model="bulkSearchState.extractionOptions.openaiApiKey"
+                            />
                         </label>
 
 

--- a/openlibrary/components/BulkSearch/utils/searchUtils.js
+++ b/openlibrary/components/BulkSearch/utils/searchUtils.js
@@ -12,7 +12,10 @@ const OL_SEARCH_BASE = 'openlibrary.org'
 export function buildSearchUrl(extractedBook, matchOptions, json = true) {
     let title = extractedBook.title?.split(/[:(?]/)[0].replace(/’/g, '\'');
     const author = extractedBook.author
-    title = title.replace(/^the\b/i, '').trim();
+    // Remove leading articles from title; these can sometimes be missing from OL records,
+    // and will hence cause a failed match.
+    // Taken from https://github.com/internetarchive/openlibrary/blob/4d880c1bf3e2391dd001c7818052fd639d38ff58/conf/solr/conf/managed-schema.xml#L526
+    title = title.replace(/^(an? |the |l[aeo]s? |l'|de la |el |il |un[ae]? |du |de[imrst]? |das |ein |eine[mnrs]? |bir )/i, '').trim();
     let query = `title:"${title}"`;
     if (matchOptions.includeAuthor && author  && author.toLowerCase() !== 'null' && author.toLowerCase() !== 'unknown') {
         const authorParts = author.replace(/^\S+\./, '').trim().split(/\s/);


### PR DESCRIPTION
- Fix the OpenAI API Key box being unclick-able
- Extends leading article removal to exclude more than just `the`

### Technical
<!-- What should be noted about the implementation? -->
- The issue was that using `v-if` to render one input when `showPassword` is true, and another when it's false, causes the input element to be swapped out! This results in the input field just clicked on, losing focus, meaning you can't type in it :P
- The article thing was to handle a common metadata bug we observer with articles missing from imports. So stripping e.g. "The" and "A", etc from the query casts a wider net that's more likely to match books.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Tested locally, and articles are correctly removed, and the OpenAI API input can be clicked.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
