### PR TITLE
added key interception to prevent form submission on enter key

### DIFF
--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -235,29 +235,34 @@ export function validateIdentifiers(data) {
 export function initClassificationValidation() {
     initJqueryRepeat();
     const dataConfig = JSON.parse(document.querySelector('#classifications').dataset.config);
+
+    // Prevent form submission on Enter for classification fields
+    $('#select-classification, #classification-value').on('keydown', function(e) {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            $('#classifications').repeat('add');
+            return false;
+        }
+    });
+
     $('#classifications').repeat({
         vars: {prefix: 'edition--'},
         validate: function (data) {
             if (data.name === '' || data.name === '---') {
-                return error('#classification-errors', '#select-classification', dataConfig['Please select a classification.']);
+                return error('#classification-errors', '#select-classification',
+                    dataConfig['Please select a classification.']);
             }
             if (data.value === '') {
-                const label = $('#select-classification').find(`option[value='${data.name}']`).html();
-                return error('#classification-errors', '#classification-value', dataConfig['You need to give a value to CLASS.'].replace(/CLASS/, label));
+                const label = $('#select-classification')
+                    .find(`option[value='${data.name}']`).html();
+                return error('#classification-errors', '#classification-value',
+                    dataConfig['You need to give a value to CLASS.'].replace(/CLASS/, label));
             }
             $('#classification-errors').hide();
             $('#select-classification, #classification-value').val('');
             return true;
         }
     });
-
-    // intercepting enter keypress to stop form submission and trigger classification addition only
-    $('#classifications').on('keydown', function (e) {
-        if (e.key === 'Enter') {
-            e.preventDefault(); //this is to stop full form save
-            $('#classifications').repeat('add'); //trigger classification addition
-        }
-    })
 }
 
 export function initLanguageMultiInputAutocomplete() {

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -250,6 +250,14 @@ export function initClassificationValidation() {
             return true;
         }
     });
+
+    // intercepting enter keypress to stop form submission and trigger classification addition only
+    $('#classifications').on('keydown', function (e) {
+        if (e.key === 'Enter') {
+            e.preventDefault(); //this is to stop full form save
+            $('#classifications').repeat('add'); //trigger classification addition
+        }
+    })
 }
 
 export function initLanguageMultiInputAutocomplete() {

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -240,7 +240,7 @@ export function initClassificationValidation() {
     $('#classification-value').on('keydown', function(e) {
         if (e.key === 'Enter') {
             e.preventDefault();
-            $('#classifications .repeat-add').click();
+            $('#classifications .repeat-add').trigger('click');
             return false;
         }
     });

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -237,10 +237,10 @@ export function initClassificationValidation() {
     const dataConfig = JSON.parse(document.querySelector('#classifications').dataset.config);
 
     // Prevent form submission on Enter for classification fields
-    $('#select-classification, #classification-value').on('keydown', function(e) {
+    $('#classification-value').on('keydown', function(e) {
         if (e.key === 'Enter') {
             e.preventDefault();
-            $('#classifications').repeat('add');
+            $('#classifications .repeat-add').click();
             return false;
         }
     });
@@ -249,14 +249,11 @@ export function initClassificationValidation() {
         vars: {prefix: 'edition--'},
         validate: function (data) {
             if (data.name === '' || data.name === '---') {
-                return error('#classification-errors', '#select-classification',
-                    dataConfig['Please select a classification.']);
+                return error('#classification-errors', '#select-classification', dataConfig['Please select a classification.']);
             }
             if (data.value === '') {
-                const label = $('#select-classification')
-                    .find(`option[value='${data.name}']`).html();
-                return error('#classification-errors', '#classification-value',
-                    dataConfig['You need to give a value to CLASS.'].replace(/CLASS/, label));
+                const label = $('#select-classification').find(`option[value='${data.name}']`).html();
+                return error('#classification-errors', '#classification-value', dataConfig['You need to give a value to CLASS.'].replace(/CLASS/, label));
             }
             $('#classification-errors').hide();
             $('#select-classification, #classification-value').val('');


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10401
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
- Fixed inconsistent return key behavior in Classifications editing
- Added proper event handling to prevent form submission
- Made behavior consistent with ID Numbers field functionality

### Technical
<!-- What should be noted about the implementation? -->
Modified `initClassificationValidation()` in `edit.js`:
- Added `preventDefault()` to stop form submission on Enter
- Added `repeat('add')` call to trigger classification addition
- Returns `false` to prevent event bubbling

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Go to any edition's edit page
2. Focus on Classifications input field
3. Type valid classification details
4. Press Enter/Return key
5. Verify:
   Input is added as new classification
   Page does not save/reload
   Behavior matches ID Numbers field
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
