### PR TITLE
Avoid redirect when clicking on books in search results by including title slug in URL

### DIFF
--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -19,7 +19,7 @@ $code:
   if doc_type.startswith('infogami_'):
     book_url = doc.url()
   else:
-    book_url = doc.key + '/' + urlsafe(doc.title)
+    book_url = doc.key + '/' + urlsafe(doc.get('title', '-'))
 
   if doc_type == 'solr_edition':
     work_edition_url = book_url + '?edition=' + urlquote('key:' + selected_ed.key)

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -16,7 +16,11 @@ $code:
   selected_ed['availability'] = selected_ed.get('availability', {}) or doc.get('availability', {}) or availability or {}
   ocaid = (selected_ed.get('ia') and selected_ed['ia'][0]) or selected_ed.get('ocaid')
 
-  book_url = doc.url() if doc_type.startswith('infogami_') else doc.key
+  if doc_type.startswith('infogami_'):
+    book_url = doc.url()
+  else:
+    book_url = doc.key + '/' + urlsafe(doc.title)
+
   if doc_type == 'solr_edition':
     work_edition_url = book_url + '?edition=' + urlquote('key:' + selected_ed.key)
   else:


### PR DESCRIPTION
Small perf tweaks to avoid sending people to 301 redirects in search, authors pages, lists, etc. Eg no more `/works/OL123W`, no anchors list `/works/OL123W/Work_title` directly.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Before (prod):
![image](https://github.com/user-attachments/assets/03ed289e-a8ff-4eca-8d65-0e0d4d8635af)

After (testing):
![image](https://github.com/user-attachments/assets/173de496-e300-492f-8324-f3a02e9a3569)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
