### PR TITLE
Make Want to Read also edition-specific to avoid language confusion

### DIFF
--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -248,7 +248,8 @@ class Bookshelves(db.CommonExtras):
     # Iterates through a list of solr docs, and for all items with a 'logged edition'
     # it will remove an item with the matching edition key from the list, and add it to
     # doc["editions"]["docs"]
-    def link_editions_to_works(solr_docs):
+    @classmethod
+    def link_editions_to_works(cls, solr_docs: list[web.storage]):
         """
         :param solr_docs: Solr work/edition docs, augmented with reading log data
         """
@@ -372,8 +373,6 @@ class Bookshelves(db.CommonExtras):
         from openlibrary.plugins.worksearch.code import run_solr_query
         from openlibrary.plugins.worksearch.schemes.works import WorkSearchScheme
 
-        # Sets the function to fetch editions as well, if not accessing the Want to Read shelf.
-        show_editions: bool = bookshelf_id != 1
         shelf_totals = cls.count_total_books_logged_by_user_per_shelf(username)
         oldb = db.get_db()
         page = int(page or 1)
@@ -473,22 +472,18 @@ class Bookshelves(db.CommonExtras):
             )
             total_results = solr_resp.num_found
             solr_docs = solr_resp.docs
-            if show_editions:
-                edition_data = get_solr().get_many(
-                    [work_to_edition_keys[work["key"]] for work in solr_resp.docs],
-                    fields=WorkSearchScheme.default_fetched_fields
-                    | {'subject', 'person', 'place', 'time', 'edition_key'},
-                )
+            edition_data = get_solr().get_many(
+                [work_to_edition_keys[work["key"]] for work in solr_resp.docs],
+                fields=WorkSearchScheme.default_fetched_fields
+                | {'subject', 'person', 'place', 'time', 'edition_key'},
+            )
 
-                solr_docs.extend(edition_data)
+            solr_docs.extend(edition_data)
 
             # Downstream many things expect a list of web.storage docs.
             solr_docs = [web.storage(doc) for doc in solr_resp.docs]
             solr_docs = add_reading_log_data(reading_log_books, solr_docs)
-
-            # This function is only necessary if edition data was fetched.
-            if show_editions:
-                solr_docs = cls.link_editions_to_works(solr_docs)
+            solr_docs = cls.link_editions_to_works(solr_docs)
 
             return LoggedBooksData(
                 username=username,
@@ -543,7 +538,7 @@ class Bookshelves(db.CommonExtras):
             reading_log_keys = [
                 (
                     ['/works/OL%sW' % i['work_id'], '/books/OL%sM' % i['edition_id']]
-                    if show_editions and i['edition_id']
+                    if i['edition_id']
                     else ['/works/OL%sW' % i['work_id'], ""]
                 )
                 for i in reading_log_books
@@ -558,10 +553,7 @@ class Bookshelves(db.CommonExtras):
             solr_docs = cls.add_storage_items_for_redirects(reading_log_keys, solr_docs)
             total_results = shelf_totals.get(bookshelf_id, 0)
             solr_docs = add_reading_log_data(reading_log_books, solr_docs)
-
-            # Attaches returned editions to works.
-            if show_editions:
-                solr_docs = cls.link_editions_to_works(solr_docs)
+            solr_docs = cls.link_editions_to_works(solr_docs)
 
             assert len(solr_docs) == len(reading_log_keys), (
                 "solr_docs is missing an item/items from reading_log_keys; "


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10623

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Compare the books on my want to read on prod vs on testing.

Before:
![image](https://github.com/user-attachments/assets/4b734358-c457-42c6-8a3e-fab163a2c258)

After:
![image](https://github.com/user-attachments/assets/534e25b3-1d03-4086-a300-453c97179c59)

The exact edition I chose is presented. You can also see on hover, the edition ID that I chose is shown.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
