### PR TITLE
Fix list querying case when out of results

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -774,7 +774,8 @@ def rewrite_list_query(q, page, offset, limit):
             cached_get_list_book_keys, "search.list_books_query", timeout=5 * 60
         )(q, offset, limit)
 
-        q = f"key:({' OR '.join(book_keys)})"
+        # Compose a query for book_keys or fallback special query w/ no results
+        q = f"key:({' OR '.join(book_keys)})" if book_keys else "-key:*"
 
         # We've applied the offset to fetching get_list_editions to
         # produce the right set of discrete work IDs. We don't want


### PR DESCRIPTION
When a ListQuery carousel exhausts all its IDs, the query fallback to something that produces lots of results when instead none should be returned. This commit checks if no book keys remain in the list and falls back to a special query that will return no results.

<!-- What issue does this PR close? -->
Closes #7552

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
