### PR TITLE
Add new carousel read button definition

### DIFF
--- a/openlibrary/macros/ReadButton.html
+++ b/openlibrary/macros/ReadButton.html
@@ -18,17 +18,17 @@ $else:
   $ title = _("Read ebook from Internet Archive")
   $ analytics_action = "Read"
 
-<div class="cta-dropper">
-  <div class="cta-button-group cta-dropper-button">
-    <a href="$(stream_url)" title="$title" class="cta-btn cta-btn--ia cta-btn--available cta-btn--$(action)"
-        $:analytics_attr(analytics_action)
-        $if loan:
-          data-userid="$(loan['userid'])"
-        >$label</a>
-  </div>
-  $ menu_items = [listen, edition_key]
-  $ is_carousel = "BookCarousel" in str(analytics_attr(analytics_action))
-  $if any(menu_items) and not is_carousel:
+$ menu_items = [listen, edition_key]
+$ is_carousel = "BookCarousel" in str(analytics_attr(analytics_action))
+$if any(menu_items) and not is_carousel:
+  <div class="cta-dropper">
+    <div class="cta-button-group cta-dropper-button">
+      <a href="$(stream_url)" title="$title" class="cta-btn cta-btn--ia cta-btn--available cta-btn--$(action)"
+          $:analytics_attr(analytics_action)
+          $if loan:
+            data-userid="$(loan['userid'])"
+          >$label</a>
+    </div>
     <details>
       <summary>
       </summary>
@@ -49,4 +49,12 @@ $else:
           </li>
       </ul>
     </details>
-</div>
+  </div>
+$else:
+  <div class="cta-button-group">
+    <a href="$(stream_url)" title="$title" class="cta-btn cta-btn--ia cta-btn--available cta-btn--$(action)"
+        $:analytics_attr(analytics_action)
+        $if loan:
+          data-userid="$(loan['userid'])"
+        >$label</a>
+  </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10628

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes squared corners and improper padding of read buttons in carousels

### Technical
<!-- What should be noted about the implementation? -->
Instead of using the `isCarousel` flag in `macros/ReadButton.html` to toggle the rendering of the `<details>` element within the attached-dropdown read button, instead determine whether to generate the attached-dropdown read button at all or instead a "vanilla" read button that doesn't have the `<details>` element or any dropper-related class tags.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Go [here](https://testing.openlibrary.org/collections/Understanding-Artificial-Intelligence) (testing link)
2. Observe that IA read buttons (e.g. Read, Borrow) are identical in shape and positioning to other buttons (Preview, non-IA provider, etc.) in carousels

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles - Let me know if this works! Looks alright to me with the primitive testing method I have available


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
