### PR TITLE
Make messages.pot order deterministic

### DIFF
--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -181,7 +181,8 @@ def extract_messages(sources: list[str], verbose: bool, skip_untracked: bool):
     if skip_untracked:
         skipped_files = get_untracked_files(sources, ('.py', '.html'))
 
-    for source in map(Path, sources):
+    # Note the must be sorted to avoid the messages.pot file constantly jumping around
+    for source in map(Path, sorted(sources)):
         counts: dict[Path, int] = {}
 
         if source.is_file():

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -18,6 +18,1446 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.12.1\n"
 
+#: merge_request_table/table_header.html openlibrary/core/edits.py
+msgid "Declined"
+msgstr ""
+
+#: admin/imports_by_date.html openlibrary/core/edits.py
+msgid "Pending"
+msgstr ""
+
+#: merge_request_table/table_header.html openlibrary/core/edits.py
+msgid "Merged"
+msgstr ""
+
+#: openlibrary/core/edits.py
+msgid "Unknown"
+msgstr ""
+
+#: AffiliateLinks.html
+#, python-format
+msgid "Look for this edition for sale at %(store)s"
+msgstr ""
+
+#: AffiliateLinks.html
+msgid "Fetching prices"
+msgstr ""
+
+#: AffiliateLinks.html
+msgid "Better World Books"
+msgstr ""
+
+#: AffiliateLinks.html
+msgid " - includes shipping"
+msgstr ""
+
+#: AffiliateLinks.html
+msgid "Amazon"
+msgstr ""
+
+#: AffiliateLinks.html
+msgid "Bookshop.org"
+msgstr ""
+
+#: AffiliateLinks.html home/about.html
+msgid "More"
+msgstr ""
+
+#: AffiliateLinks.html
+msgid ""
+"When you buy books using these links the Internet Archive may earn a <a "
+"class=\"nostyle\" href=\"/help/faq/about#selling\">small commission</a>."
+msgstr ""
+
+#: BatchImportNavigation.html batch_import.html
+msgid "New Batch Import"
+msgstr ""
+
+#: BatchImportNavigation.html
+msgid "Pending Imports"
+msgstr ""
+
+#: BookByline.html FulltextSearchSuggestionItem.html SearchResultsWork.html
+#: account/notes.html account/observations.html
+msgid "Unknown author"
+msgstr ""
+
+#: BookByline.html
+#, python-format
+msgid "%(n)s other"
+msgid_plural "%(n)s others"
+msgstr[0] ""
+msgstr[1] ""
+
+#: BookByline.html type/list/embed.html
+#, python-format
+msgid "by %(name)s"
+msgstr ""
+
+#: BookByline.html
+msgid "by an <em>unknown author</em>"
+msgstr ""
+
+#: BookPreview.html
+msgid "Preview Only"
+msgstr ""
+
+#: BookPreview.html book_providers/direct_read_button.html
+#: books/edit/edition.html editpage.html
+msgid "Preview"
+msgstr ""
+
+#: BookPreview.html
+msgid "Preview Book"
+msgstr ""
+
+#: BookPreview.html CreateListModal.html DonateModal.html NotesModal.html
+#: ObservationsModal.html ShareModal.html covers/author_photo.html
+#: covers/book_cover.html covers/book_cover_single_edition.html
+#: covers/book_cover_work.html covers/change.html lib/history.html
+#: my_books/dropdown_content.html native_dialog.html
+msgid "Close"
+msgstr ""
+
+#: BookSearchInside.html FulltextSearchSuggestion.html SearchNavigation.html
+#: search/inside.html search/snippets.html
+msgid "Search Inside"
+msgstr ""
+
+#: CreateListModal.html my_books/dropdown_content.html
+msgid "Create a new list"
+msgstr ""
+
+#: CreateListModal.html admin/people/view.html my_books/dropdown_content.html
+msgid "Name:"
+msgstr ""
+
+#: CreateListModal.html my_books/dropdown_content.html
+#: type/permission/edit.html type/usergroup/edit.html
+msgid "Description:"
+msgstr ""
+
+#: CreateListModal.html my_books/dropdown_content.html type/list/edit.html
+msgid "Create new list"
+msgstr ""
+
+#: CreateListModal.html EditButtons.html account/notifications.html
+#: account/password/reset.html account/privacy.html admin/imports-add.html
+#: admin/permissions.html books/add.html databarEdit.html interstitial.html
+#: merge/authors.html my_books/dropdown_content.html type/tag/form.html
+msgid "Cancel"
+msgstr ""
+
+#: DisplayCode.html
+msgid ""
+"Templates in the website are disabled now. Editing them will not have any"
+" effect on the live website."
+msgstr ""
+
+#: DonateModal.html
+msgid ""
+"Donate this book to the <a href=\"https://archive.org\">Internet "
+"Archive</a> library."
+msgstr ""
+
+#: DonateModal.html
+msgid ""
+"Hooray! You've discovered a title that's missing from our <a "
+"href=\"https://help.archive.org/hc/en-us/articles/360016554912-Borrowing-"
+"From-The-Lending-Library\">library</a>. Can you help donate a copy?"
+msgstr ""
+
+#: DonateModal.html
+msgid ""
+"If you own this book, you can<a "
+"href=\"https://store.usps.com/store/product/shipping-supplies/priority-"
+"mail-express-padded-flat-rate-envelope-P_EP13PE\">mail</a> it to our "
+"address below."
+msgstr ""
+
+#: DonateModal.html
+msgid "You can also purchase this book from a vendor and ship it to our address:"
+msgstr ""
+
+#: DonateModal.html
+msgid "Benefits of donating"
+msgstr ""
+
+#: DonateModal.html
+msgid ""
+"When you donate a physical book to the Internet Archive, your book will "
+"enjoy:"
+msgstr ""
+
+#: DonateModal.html
+msgid "Donation info"
+msgstr ""
+
+#: DonateModal.html
+msgid ""
+"Beautiful <a target=\"_blank\" href=\"https://archive.org/scanning"
+"\">high-fidelity digitization</a>"
+msgstr ""
+
+#: DonateModal.html
+msgid ""
+"Long-term <a href=\"https://blog.archive.org/2011/06/06/why-preserve-"
+"books-the-new-physical-archive-of-the-internet-archive/\">archival "
+"preservation</a>"
+msgstr ""
+
+#: DonateModal.html
+msgid ""
+"Free <a href=\"https://controlleddigitallending.org/\">controlled digital"
+" library access</a> by the <a "
+"href=\"https://en.wikipedia.org/wiki/Print_disability\">print-"
+"disabled</a> public"
+msgstr ""
+
+#: DonateModal.html
+msgid ""
+"Open Library is a project of the <a "
+"href=\"https://archive.org/about\">Internet Archive</a>, a 501(c)(3) non-"
+"profit"
+msgstr ""
+
+#: EditButtons.html admin/ip/view.html admin/people/edits.html
+msgid ""
+"Please, leave a short note about what you changed: <span class=\"small "
+"gray\">(Optional, but very useful!)</span>"
+msgstr ""
+
+#: EditButtons.html books/add.html type/tag/form.html
+msgid ""
+"By saving a change to this wiki, you agree that your contribution is "
+"given freely to the world under <a "
+"href=\"https://creativecommons.org/publicdomain/zero/1.0/\" "
+"target=\"_blank\" title=\"This link to Creative Commons will open in a "
+"new window\">CC0</a>. Yippee!"
+msgstr ""
+
+#: EditButtons.html account/notifications.html account/privacy.html
+#: admin/block.html admin/spamwords.html covers/manage.html
+msgid "Save"
+msgstr ""
+
+#: EditionNavBar.html
+msgid "Go to previous section"
+msgstr ""
+
+#: EditionNavBar.html
+msgid "Overview"
+msgstr ""
+
+#: EditionNavBar.html
+#, python-format
+msgid "View %(count)s Edition"
+msgid_plural "View %(count)s Editions"
+msgstr[0] ""
+msgstr[1] ""
+
+#: EditionNavBar.html site/stats.html
+msgid "Details"
+msgstr ""
+
+#: EditionNavBar.html
+#, python-format
+msgid "%(reviews)s Review"
+msgid_plural "%(reviews)s Reviews"
+msgstr[0] ""
+msgstr[1] ""
+
+#: EditionNavBar.html account/observations.html
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+msgid "Reviews"
+msgstr ""
+
+#: EditionNavBar.html SearchNavigation.html account/sidebar.html
+#: lib/nav_head.html lists/home.html lists/widget.html recentchanges/index.html
+#: type/edition/view.html type/list/embed.html type/user/view.html
+#: type/work/view.html
+msgid "Lists"
+msgstr ""
+
+#: EditionNavBar.html
+msgid "Related Books"
+msgstr ""
+
+#: EditionNavBar.html
+msgid "Go to next section"
+msgstr ""
+
+#: Follow.html
+msgid "UnfollowFollow"
+msgstr ""
+
+#: Follow.html
+msgid "Follow"
+msgstr ""
+
+#: FormatExpiry.html
+msgid "Expires"
+msgstr ""
+
+#: FulltextSearchSuggestion.html
+msgid "Checking for Search Inside matches"
+msgstr ""
+
+#: FulltextSearchSuggestion.html
+msgid "Search Inside Icon"
+msgstr ""
+
+#: FulltextSearchSuggestion.html
+msgid "search inside icon"
+msgstr ""
+
+#: FulltextSearchSuggestion.html
+#, python-format
+msgid "%(book_count)s books found with matching passages"
+msgstr ""
+
+#: FulltextSearchSuggestion.html
+#, python-format
+msgid "See all %(results_count)s Search Inside Matches"
+msgstr ""
+
+#: FulltextSearchSuggestion.html
+msgid "right chevron"
+msgstr ""
+
+#: FulltextSearchSuggestionItem.html IABook.html SearchResultsWork.html
+#: books/edition-sort.html jsdef/LazyWorkPreview.html lists/list_overview.html
+#: lists/preview.html lists/snippet.html lists/widget.html
+#: my_books/dropdown_content.html type/work/editions.html
+#, python-format
+msgid "Cover of: %(title)s"
+msgstr ""
+
+#: FulltextSnippet.html FulltextSuggestionSnippet.html
+msgid "❝"
+msgstr ""
+
+#: FulltextSnippet.html FulltextSuggestionSnippet.html
+msgid "❞"
+msgstr ""
+
+#: FulltextSuggestionSnippet.html
+#, python-format
+msgid "Page: %(page)s"
+msgstr ""
+
+#: IABook.html
+#, python-format
+msgid "Borrowed from Internet Archive: %(title)s"
+msgstr ""
+
+#: LoadingIndicator.html
+msgid "Loading indicator"
+msgstr ""
+
+#: LoanReadForm.html ReadButton.html admin/inspect/memcache.html
+#: book_providers/cita_press_read_button.html
+#: book_providers/direct_read_button.html
+#: book_providers/gutenberg_read_button.html
+#: book_providers/openstax_read_button.html
+#: book_providers/runeberg_read_button.html
+#: book_providers/standard_ebooks_read_button.html
+#: book_providers/wikisource_read_button.html books/edit/edition.html
+#: books/show.html books/works-show.html trending.html type/list/embed.html
+#: widget.html
+msgid "Read"
+msgstr ""
+
+#: LoanStatus.html
+msgid "You are <strong>next</strong> on the waiting list"
+msgstr ""
+
+#: LoanStatus.html
+#, python-format
+msgid "You are <strong>#%(spot)d</strong> of %(wlsize)d on the waiting list."
+msgstr ""
+
+#: LoanStatus.html
+msgid "Leave waiting list"
+msgstr ""
+
+#: LoanStatus.html widget.html
+msgid "Join Waitlist"
+msgstr ""
+
+#: LoanStatus.html
+#, python-format
+msgid "Readers in line: %(count)s"
+msgstr ""
+
+#: LoanStatus.html
+msgid "You'll be next in line."
+msgstr ""
+
+#: LoanStatus.html
+msgid "This book is currently checked out, please check back later."
+msgstr ""
+
+#: LoanStatus.html
+msgid "Checked Out"
+msgstr ""
+
+#: LocateButton.html
+msgid "Locate"
+msgstr ""
+
+#: ManageLoansButtons.html admin/loans_table.html
+#, python-format
+msgid "Borrowed %(date)s"
+msgstr ""
+
+#: ManageLoansButtons.html
+#, python-format
+msgid "There is one person waiting for this book."
+msgid_plural "There are %(n)s people waiting for this book."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ManageLoansButtons.html account/loans.html
+msgid "Not yet downloaded."
+msgstr ""
+
+#: ManageLoansButtons.html account/loans.html
+msgid "Download Now"
+msgstr ""
+
+#: ManageWaitlistButton.html
+#, python-format
+msgid "Waiting for %d day"
+msgid_plural "Waiting for %d days"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ManageWaitlistButton.html account/loans.html
+#, python-format
+msgid "There is one person ahead of you in the waiting list."
+msgid_plural "There are %(count)d people ahead of you in the waiting list."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ManageWaitlistButton.html account/loans.html
+msgid "You have less than an hour to borrow it."
+msgstr ""
+
+#: ManageWaitlistButton.html
+#, python-format
+msgid "You have %(count)d more hour to borrow it."
+msgid_plural "You have %(count)d more hours to borrow it."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ManageWaitlistButton.html account/loans.html
+msgid "Borrow Now"
+msgstr ""
+
+#: ManageWaitlistButton.html account/loans.html
+msgid "Leave the waiting list?"
+msgstr ""
+
+#: NotInLibrary.html
+msgid "Not in Library"
+msgstr ""
+
+#: NotesModal.html
+msgid "My Book Notes"
+msgstr ""
+
+#: NotesModal.html
+msgid "My private notes about this edition:"
+msgstr ""
+
+#: NotesModal.html account/notes.html
+msgid "Delete Note"
+msgstr ""
+
+#: NotesModal.html account/notes.html
+msgid "Save Note"
+msgstr ""
+
+#: OLID.html
+#, python-format
+msgid "by  %(authors)s"
+msgstr ""
+
+#: ObservationsModal.html
+msgid "My Book Review"
+msgstr ""
+
+#: Pager.html Pager_loanhistory.html
+msgid "First"
+msgstr ""
+
+#: Pager.html Pager_loanhistory.html lib/pagination.html
+msgid "Previous"
+msgstr ""
+
+#: Pager.html Pager_loanhistory.html admin/memory/index.html history.html
+#: lib/pagination.html showmarc.html
+msgid "Next"
+msgstr ""
+
+#: Profile.html
+msgid "Component"
+msgstr ""
+
+#: Profile.html type/author/view.html
+msgid "Time"
+msgstr ""
+
+#: ProlificAuthors.html
+msgid "Prolific Authors"
+msgstr ""
+
+#: ProlificAuthors.html
+msgid "who have written the most books on this subject"
+msgstr ""
+
+#: ProlificAuthors.html publishers/view.html
+msgid "See more books by, and learn about, this author"
+msgstr ""
+
+#: ProlificAuthors.html account/loans.html authors/index.html
+#: lists/showcase.html publishers/view.html search/authors.html
+#: search/publishers.html search/subjects.html
+#, python-format
+msgid "%(count)d book"
+msgid_plural "%(count)d books"
+msgstr[0] ""
+msgstr[1] ""
+
+#: PublishingHistory.html publishers/view.html
+msgid "Publishing History"
+msgstr ""
+
+#: PublishingHistory.html
+msgid ""
+"This is a chart to show the publishing history of editions of works about"
+" this subject. Along the X axis is time, and on the y axis is the count "
+"of editions published. <a href=\"#subjectRelated\">Click here to skip the"
+" chart</a>."
+msgstr ""
+
+#: PublishingHistory.html publishers/view.html
+msgid "Reset chart"
+msgstr ""
+
+#: PublishingHistory.html publishers/view.html
+msgid "or continue zooming in."
+msgstr ""
+
+#: PublishingHistory.html
+msgid "This graph charts editions published on this subject."
+msgstr ""
+
+#: PublishingHistory.html publishers/view.html
+msgid "Editions Published"
+msgstr ""
+
+#: PublishingHistory.html admin/imports.html publishers/view.html
+msgid "You need to have JavaScript turned on to see the nifty chart!"
+msgstr ""
+
+#: PublishingHistory.html publishers/view.html
+msgid "Year of Publication"
+msgstr ""
+
+#: RawQueryCarousel.html
+msgid "Search collection"
+msgstr ""
+
+#: ReadButton.html
+msgid "Special Access"
+msgstr ""
+
+#: ReadButton.html
+msgid ""
+"Special ebook access from the Internet Archive for patrons with "
+"qualifying print disabilities"
+msgstr ""
+
+#: ReadButton.html books/edit/edition.html type/list/embed.html widget.html
+msgid "Borrow"
+msgstr ""
+
+#: ReadButton.html
+msgid "Borrow ebook from Internet Archive"
+msgstr ""
+
+#: ReadButton.html
+msgid "Read ebook from Internet Archive"
+msgstr ""
+
+#: ReadButton.html
+msgid "Listen"
+msgstr ""
+
+#: ReadMore.html
+msgid "Read more"
+msgstr ""
+
+#: ReadMore.html
+msgid "Read less"
+msgstr ""
+
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
+#: admin/ip/view.html admin/people/edits.html history.html
+#: recentchanges/render.html recentchanges/updated_records.html
+msgid "When"
+msgstr ""
+
+#: RecentChanges.html RecentChangesUsers.html admin/ip/view.html
+#: admin/loans_table.html admin/people/edits.html recentchanges/render.html
+#: recentchanges/updated_records.html
+msgid "What"
+msgstr ""
+
+#: RecentChanges.html admin/history.html admin/ip/view.html
+#: admin/loans_table.html admin/people/edits.html history.html
+#: recentchanges/render.html
+msgid "Who"
+msgstr ""
+
+#: RecentChanges.html RecentChangesUsers.html admin/history.html
+#: admin/ip/view.html admin/people/edits.html history.html
+#: recentchanges/render.html recentchanges/updated_records.html
+msgid "Comment"
+msgstr ""
+
+#: RecentChanges.html RecentChangesUsers.html recentchanges/default/path.html
+msgid "Review what's changed from the previous revision"
+msgstr ""
+
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
+#: admin/memory/index.html recentchanges/default/path.html
+#: recentchanges/updated_records.html
+msgid "diff"
+msgstr ""
+
+#: RecentChanges.html admin/ip/view.html admin/people/edits.html
+#: recentchanges/render.html
+msgid "When you see numbers here, that's the IP address of the anonymous editor"
+msgstr ""
+
+#: RecentChanges.html
+msgid "View MARC"
+msgstr ""
+
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
+#: admin/people/edits.html recentchanges/render.html
+msgid "Older"
+msgstr ""
+
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
+#: admin/people/edits.html recentchanges/render.html
+msgid "Newer"
+msgstr ""
+
+#: RecentChanges.html recentchanges/index.html
+msgid "By Humans"
+msgstr ""
+
+#: RecentChanges.html recentchanges/index.html
+msgid "By Bots"
+msgstr ""
+
+#: RecentChanges.html recentchanges/index.html work_search.html
+msgid "Everything"
+msgstr ""
+
+#: RecentChangesAdmin.html
+msgid "Path"
+msgstr ""
+
+#: RecentChangesAdmin.html batch_import_pending_view.html
+#: batch_import_view.html
+msgid "Comments"
+msgstr ""
+
+#: RecentChangesAdmin.html account/loans.html admin/loans_table.html
+msgid "Actions"
+msgstr ""
+
+#: RecentChangesAdmin.html
+msgid "view"
+msgstr ""
+
+#: RecentChangesAdmin.html
+msgid "edit"
+msgstr ""
+
+#: RecentChangesAdmin.html RecentChangesUsers.html
+msgid "No edit history available."
+msgstr ""
+
+#: RecentChangesUsers.html lists/home.html lists/lists.html type/user/view.html
+msgid "Recent Activity"
+msgstr ""
+
+#: RecentChangesUsers.html type/user/view.html
+msgid "No edits. Yet."
+msgstr ""
+
+#: RelatedSubjects.html SearchNavigation.html SubjectTags.html
+#: lib/nav_foot.html lib/nav_head.html openlibrary/plugins/worksearch/code.py
+#: subjects/notfound.html type/author/view.html type/list/view_body.html
+msgid "Subjects"
+msgstr ""
+
+#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py
+#: type/author/view.html type/list/view_body.html
+msgid "Places"
+msgstr ""
+
+#: RelatedSubjects.html SubjectTags.html admin/menu.html
+#: admin/people/index.html admin/people/view.html
+#: openlibrary/plugins/worksearch/code.py type/author/view.html
+#: type/list/view_body.html
+msgid "People"
+msgstr ""
+
+#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py
+#: type/list/view_body.html
+msgid "Times"
+msgstr ""
+
+#: RelatedSubjects.html
+msgid "Related..."
+msgstr ""
+
+#: RelatedSubjects.html publishers/view.html
+msgid "None found."
+msgstr ""
+
+#: ReturnForm.html
+msgid "Really return this book?"
+msgstr ""
+
+#: ReturnForm.html
+msgid "Return book"
+msgstr ""
+
+#: SearchNavigation.html books/mybooks_breadcrumb_select.html lib/nav_foot.html
+#: openlibrary/plugins/upstream/mybooks.py
+msgid "Books"
+msgstr ""
+
+#: SearchNavigation.html authors/index.html lib/nav_foot.html
+#: merge/authors.html publishers/view.html
+msgid "Authors"
+msgstr ""
+
+#: SearchNavigation.html lib/nav_foot.html lib/nav_head.html
+#: search/advancedsearch.html
+msgid "Advanced Search"
+msgstr ""
+
+#: SearchResultsWork.html
+msgid "added to"
+msgstr ""
+
+#: SearchResultsWork.html
+#, python-format
+msgid "Cover of edition %(id)s"
+msgstr ""
+
+#: SearchResultsWork.html type/work/editions.html
+#, python-format
+msgid "First published in %(year)s"
+msgstr ""
+
+#: SearchResultsWork.html books/check.html merge/authors.html
+#: publishers/view.html
+#, python-format
+msgid "%(count)s edition"
+msgid_plural "%(count)s editions"
+msgstr[0] ""
+msgstr[1] ""
+
+#: SearchResultsWork.html
+#, python-format
+msgid "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d language</a>"
+msgid_plural "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d languages</a>"
+msgstr[0] ""
+msgstr[1] ""
+
+#: SearchResultsWork.html
+msgid "This is only visible to librarians."
+msgstr ""
+
+#: SearchResultsWork.html
+msgid "Work Title"
+msgstr ""
+
+#: SearchResultsWork.html type/edition/admin_bar.html
+msgid "Orphaned Edition"
+msgstr ""
+
+#: ShareModal.html
+#, python-format
+msgid "Share on %(share_link)s"
+msgstr ""
+
+#: ShareModal.html
+msgid "Embed this book in your website"
+msgstr ""
+
+#: ShareModal.html
+msgid "Embed icon"
+msgstr ""
+
+#: ShareModal.html
+msgid "Embed"
+msgstr ""
+
+#: ShareModal.html
+msgid "Copy url to clipboard"
+msgstr ""
+
+#: ShareModal.html
+msgid "Copy URL icon"
+msgstr ""
+
+#: ShareModal.html
+msgid "Copy URL"
+msgstr ""
+
+#: ShareModal.html
+msgid "Open QR code"
+msgstr ""
+
+#: ShareModal.html
+msgid "QR code icon"
+msgstr ""
+
+#: ShareModal.html
+msgid "QR Code"
+msgstr ""
+
+#: StarRatings.html
+msgid "Clear my rating"
+msgstr ""
+
+#: StarRatingsByline.html StarRatingsComponent.html
+msgid "rating"
+msgstr ""
+
+#: StarRatingsByline.html StarRatingsComponent.html
+msgid "ratings"
+msgstr ""
+
+#: StarRatingsByline.html
+#, python-format
+msgid "%(want_to_read_count)s Want to read"
+msgstr ""
+
+#: StarRatingsComponent.html
+#, python-format
+msgid "%(ratings_avg)s (%(ratings_count)s %(ratings_label)s)"
+msgstr ""
+
+#: StarRatingsStats.html
+msgid "Want to read"
+msgstr ""
+
+#: StarRatingsStats.html
+msgid "Currently reading"
+msgstr ""
+
+#: StarRatingsStats.html
+msgid "Have read"
+msgstr ""
+
+#: Subnavigation.html
+msgid "Developer Center (Home)"
+msgstr ""
+
+#: Subnavigation.html
+msgid "Web API"
+msgstr ""
+
+#: Subnavigation.html
+msgid "Client Library"
+msgstr ""
+
+#: Subnavigation.html
+msgid "Data Dumps"
+msgstr ""
+
+#: Subnavigation.html book_providers/standard_ebooks_download_options.html
+msgid "Source Code"
+msgstr ""
+
+#: Subnavigation.html
+msgid "Report an Issue"
+msgstr ""
+
+#: Subnavigation.html
+msgid "Licensing"
+msgstr ""
+
+#: Subnavigation.html
+msgid "Welcome"
+msgstr ""
+
+#: Subnavigation.html
+msgid "Searching Open Library"
+msgstr ""
+
+#: Subnavigation.html
+msgid "Reading Books"
+msgstr ""
+
+#: Subnavigation.html
+msgid "Adding & Editing Books"
+msgstr ""
+
+#: Subnavigation.html
+msgid "Using Subjects"
+msgstr ""
+
+#: Subnavigation.html
+msgid "Open Library F.A.Q."
+msgstr ""
+
+#: TableOfContents.html
+#, python-format
+msgid "Page %s"
+msgstr ""
+
+#: TypeChanger.html
+msgid "Page Type"
+msgstr ""
+
+#: TypeChanger.html
+msgid "Huh?"
+msgstr ""
+
+#: TypeChanger.html
+msgid ""
+"Every piece of Open Library is defined by the type of content it "
+"displays, usually by content definition (e.g. Authors, Editions, Works) "
+"but sometimes by content use (e.g. macro, template, rawtext). Changing "
+"this for an existing page will alter its presentation and the data fields"
+" available for editing its content."
+msgstr ""
+
+#: TypeChanger.html
+msgid "Please use caution changing Page Type!"
+msgstr ""
+
+#: TypeChanger.html
+msgid ""
+"(Simplest solution: If you aren't sure whether this should be changed, "
+"don't change it.)"
+msgstr ""
+
+#: UserEditRow.html type/work/editions.html
+msgid "Add another"
+msgstr ""
+
+#: WorkInfo.html
+msgid "No link to Wikipedia in your language"
+msgstr ""
+
+#: WorldcatLink.html
+msgid "Check nearby libraries"
+msgstr ""
+
+#: WorldcatLink.html
+msgid "Library.link"
+msgstr ""
+
+#: WorldcatLink.html
+msgid "Check WorldCat for an edition near you"
+msgstr ""
+
+#: WorldcatLink.html
+msgid "WorldCat"
+msgstr ""
+
+#: databarDiff.html databarEdit.html
+msgid "View the editing history of this page"
+msgstr ""
+
+#: databarDiff.html databarEdit.html databarTemplate.html databarView.html
+#: lib/history.html openlibrary/plugins/openlibrary/home.py
+msgid "History"
+msgstr ""
+
+#: databarDiff.html
+msgid "View this page (exit Comparison view)"
+msgstr ""
+
+#: account.html databarDiff.html
+msgid "View"
+msgstr ""
+
+#: databarEdit.html
+msgid "View this page (exit Edit mode)"
+msgstr ""
+
+#: databarHistory.html databarView.html
+#, python-format
+msgid "Last edited by %(author_link)s"
+msgstr ""
+
+#: databarHistory.html databarView.html
+msgid "Last edited anonymously"
+msgstr ""
+
+#: databarHistory.html databarView.html type/edition/compact_title.html
+msgid "Edit this page"
+msgstr ""
+
+#: account.html check_ins/check_in_prompt.html
+#: check_ins/reading_goal_progress.html databarHistory.html
+#: databarTemplate.html databarView.html subjects.html
+#: type/edition/compact_title.html type/user/view.html
+msgid "Edit"
+msgstr ""
+
+#: databarTemplate.html databarView.html
+msgid "View this template's edit history"
+msgstr ""
+
+#: databarTemplate.html
+msgid "Edit this template"
+msgstr ""
+
+#: databarWork.html lib/nav_head.html
+msgid "Browse"
+msgstr ""
+
+#: databarWork.html
+#, python-format
+msgid "View Volume %(num)d"
+msgstr ""
+
+#: databarWork.html type/edition/view.html type/work/view.html
+msgid "Buy this book"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Czech"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "German"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "English"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Spanish"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "French"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Hindi"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Croatian"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Italian"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Portuguese"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Romanian"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Sardinian"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Telugu"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Ukrainian"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Chinese"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Art"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Science Fiction"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Fantasy"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Biographies"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Recipes"
+msgstr ""
+
+#: home/index.html openlibrary/plugins/openlibrary/home.py
+msgid "Romance"
+msgstr ""
+
+#: home/index.html openlibrary/plugins/openlibrary/home.py
+msgid "Textbooks"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Children"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Medicine"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Religion"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Mystery and Detective Stories"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Plays"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Music"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Science"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/lists.py
+#, python-format
+msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
+msgstr ""
+
+#: books/mybooks_breadcrumb_select.html
+#: openlibrary/plugins/openlibrary/lists.py
+#, python-format
+msgid "Lists (%(count)d)"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "The email address you entered is invalid"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "This account has been blocked"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "This account has been locked"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "No account was found with this email. Please try again"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "The password you entered is incorrect. Please try again"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Wrong password. Please try again"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Please verify your Open Library account before logging in"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Please verify your Internet Archive account before logging in"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Please fill out all fields and try again"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "This email is already registered"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "This username is already registered"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "A problem occurred and we were unable to log you in."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Login attempted with invalid Internet Archive s3 credentials."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid ""
+"Servers are experiencing unusually high traffic, please try again later "
+"or email openlibrary@archive.org for help."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Email provider not recognized."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Password requirements not met."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "A problem occurred and we were unable to log you in"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid ""
+"Login or registration attempt hit an unexpected error, please try again "
+"or contact info@archive.org"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+#, python-format
+msgid "Request failed with error code: %(error_code)s"
+msgstr ""
+
+#: account/password/reset_success.html account/verify.html
+#: account/verify/activated.html account/verify/success.html
+#: openlibrary/plugins/upstream/account.py
+#, python-format
+msgid "Hi, %(user)s"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+#, python-format
+msgid ""
+"We've sent the verification email to %(email)s. You'll need to read that "
+"and click on the verification link to verify your email."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Username unavailable"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+#: openlibrary/plugins/upstream/forms.py
+msgid "Email already registered"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "An Internet Archive account already exists with this email"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Email address is already used."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid ""
+"Your email address couldn't be updated. The specified email address is "
+"already used."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Email verification successful."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid ""
+"Your email address has been successfully verified and updated in your "
+"account."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Email address couldn't be verified."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid ""
+"Your email address couldn't be verified. The verification link seems "
+"invalid."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Password reset failed."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Notification preferences have been updated successfully."
+msgstr ""
+
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
+msgid "Imports and Exports"
+msgstr ""
+
+#: admin/people/view.html books/mybooks_breadcrumb_select.html
+#: openlibrary/plugins/upstream/account.py type/user/view.html
+msgid "Loans"
+msgstr ""
+
+#: account/mybooks.html account/sidebar.html
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
+msgid "Loan History"
+msgstr ""
+
+#: openlibrary/plugins/upstream/borrow.py
+msgid ""
+"Your account has hit a lending limit. Please try again later or contact "
+"info@archive.org."
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Username"
+msgstr ""
+
+#: account/email/forgot-ia.html login.html
+#: openlibrary/plugins/upstream/forms.py
+msgid "Password"
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "No user registered with this email address"
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Disposable email not permitted"
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Your email provider is not recognized."
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Username already used"
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Must be between 3 and 20 letters and numbers"
+msgstr ""
+
+#: account/create.html openlibrary/plugins/upstream/forms.py
+msgid "Must be between 3 and 20 characters"
+msgstr ""
+
+#: account/create.html openlibrary/plugins/upstream/forms.py
+msgid "Must be a valid email address"
+msgstr ""
+
+#: login.html openlibrary/plugins/upstream/forms.py
+msgid "Email"
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Screen Name"
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Public and cannot be changed later."
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid ""
+"I want to receive news, announcements, and resources from the <a "
+"href=\"https://archive.org/\">Internet Archive</a>, the non-profit that "
+"runs Open Library."
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Invalid password"
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Your email address"
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Choose a password"
+msgstr ""
+
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#: type/edition/modal_links.html
+msgid "Notes"
+msgstr ""
+
+#: account/sidebar.html books/mybooks_breadcrumb_select.html
+#: openlibrary/plugins/upstream/mybooks.py
+msgid "My Feed"
+msgstr ""
+
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
+#: my_books/dropdown_content.html my_books/primary_action.html
+#: openlibrary/plugins/upstream/mybooks.py search/sort_options.html
+msgid "Already Read"
+msgstr ""
+
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#, python-format
+msgid "Currently Reading (%(count)d)"
+msgstr ""
+
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#, python-format
+msgid "Want to Read (%(count)d)"
+msgstr ""
+
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#, python-format
+msgid "Already Read (%(count)d)"
+msgstr ""
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "eBook?"
+msgstr ""
+
+#: openlibrary/plugins/worksearch/code.py type/edition/view.html
+#: type/work/view.html
+msgid "Language"
+msgstr ""
+
+#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html
+#: openlibrary/plugins/worksearch/code.py search/advancedsearch.html
+#: search/work_search_selected_facets.html
+msgid "Author"
+msgstr ""
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "First published"
+msgstr ""
+
+#: openlibrary/plugins/worksearch/code.py publishers/view.html
+#: search/advancedsearch.html type/edition/view.html type/work/view.html
+msgid "Publisher"
+msgstr ""
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "Classic eBooks"
+msgstr ""
+
 #: account.html account/notifications.html account/privacy.html
 #: lib/nav_head.html type/user/view.html
 msgid "Settings"
@@ -27,19 +1467,8 @@ msgstr ""
 msgid "Settings & Privacy"
 msgstr ""
 
-#: account.html databarDiff.html
-msgid "View"
-msgstr ""
-
 #: account.html
 msgid "or"
-msgstr ""
-
-#: account.html check_ins/check_in_prompt.html
-#: check_ins/reading_goal_progress.html databarHistory.html
-#: databarTemplate.html databarView.html subjects.html
-#: type/edition/compact_title.html type/user/view.html
-msgid "Edit"
 msgstr ""
 
 #: account.html
@@ -92,10 +1521,6 @@ msgstr ""
 
 #: batch_import.html
 msgid "Batch Imports"
-msgstr ""
-
-#: BatchImportNavigation.html batch_import.html
-msgid "New Batch Import"
 msgstr ""
 
 #: batch_import.html
@@ -192,11 +1617,6 @@ msgstr ""
 #: batch_import_pending_view.html batch_import_view.html
 #: merge_request_table/table_header.html
 msgid "Submitter"
-msgstr ""
-
-#: RecentChangesAdmin.html batch_import_pending_view.html
-#: batch_import_view.html
-msgid "Comments"
 msgstr ""
 
 #: batch_import_view.html
@@ -364,35 +1784,12 @@ msgstr ""
 msgid "YAML Representation:"
 msgstr ""
 
-#: BookPreview.html book_providers/direct_read_button.html
-#: books/edit/edition.html editpage.html
-msgid "Preview"
-msgstr ""
-
 #: history.html
 msgid "History of edits to"
 msgstr ""
 
 #: history.html
 msgid "Revision"
-msgstr ""
-
-#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
-#: admin/ip/view.html admin/people/edits.html history.html
-#: recentchanges/render.html recentchanges/updated_records.html
-msgid "When"
-msgstr ""
-
-#: RecentChanges.html admin/history.html admin/ip/view.html
-#: admin/loans_table.html admin/people/edits.html history.html
-#: recentchanges/render.html
-msgid "Who"
-msgstr ""
-
-#: RecentChanges.html RecentChangesUsers.html admin/history.html
-#: admin/ip/view.html admin/people/edits.html history.html
-#: recentchanges/render.html recentchanges/updated_records.html
-msgid "Comment"
 msgstr ""
 
 #: history.html
@@ -422,11 +1819,6 @@ msgstr ""
 
 #: books/daisy.html history.html
 msgid "Back"
-msgstr ""
-
-#: Pager.html Pager_loanhistory.html admin/memory/index.html history.html
-#: lib/pagination.html showmarc.html
-msgid "Next"
 msgstr ""
 
 #: internalerror.html
@@ -468,13 +1860,6 @@ msgstr ""
 #: interstitial.html
 #, python-format
 msgid "In %(time)s seconds, you will be automatically redirected to: %(url)s"
-msgstr ""
-
-#: CreateListModal.html EditButtons.html account/notifications.html
-#: account/password/reset.html account/privacy.html admin/imports-add.html
-#: admin/permissions.html books/add.html databarEdit.html interstitial.html
-#: merge/authors.html my_books/dropdown_content.html type/tag/form.html
-msgid "Cancel"
 msgstr ""
 
 #: interstitial.html
@@ -536,17 +1921,8 @@ msgid ""
 "email and password to access your Open Library account."
 msgstr ""
 
-#: login.html openlibrary/plugins/upstream/forms.py
-msgid "Email"
-msgstr ""
-
 #: login.html
 msgid "Forgot your Internet Archive email?"
-msgstr ""
-
-#: account/email/forgot-ia.html login.html
-#: openlibrary/plugins/upstream/forms.py
-msgid "Password"
 msgstr ""
 
 #: login.html
@@ -587,14 +1963,6 @@ msgstr ""
 
 #: messages.html
 msgid "Thank you very much for improving that record!"
-msgstr ""
-
-#: BookPreview.html CreateListModal.html DonateModal.html NotesModal.html
-#: ObservationsModal.html ShareModal.html covers/author_photo.html
-#: covers/book_cover.html covers/book_cover_single_edition.html
-#: covers/book_cover_work.html covers/change.html lib/history.html
-#: my_books/dropdown_content.html native_dialog.html
-msgid "Close"
 msgstr ""
 
 #: notfound.html
@@ -819,19 +2187,6 @@ msgstr ""
 msgid "Currently Reading"
 msgstr ""
 
-#: LoanReadForm.html ReadButton.html admin/inspect/memcache.html
-#: book_providers/cita_press_read_button.html
-#: book_providers/direct_read_button.html
-#: book_providers/gutenberg_read_button.html
-#: book_providers/openstax_read_button.html
-#: book_providers/runeberg_read_button.html
-#: book_providers/standard_ebooks_read_button.html
-#: book_providers/wikisource_read_button.html books/edit/edition.html
-#: books/show.html books/works-show.html trending.html type/list/embed.html
-#: widget.html
-msgid "Read"
-msgstr ""
-
 #: trending.html
 #, python-format
 msgid "Someone marked as %(shelf)s %(k_hours_ago)s"
@@ -860,17 +2215,9 @@ msgstr ""
 msgid "Borrow \"%(title)s\""
 msgstr ""
 
-#: ReadButton.html books/edit/edition.html type/list/embed.html widget.html
-msgid "Borrow"
-msgstr ""
-
 #: widget.html
 #, python-format
 msgid "Join waitlist for \"%(title)s\""
-msgstr ""
-
-#: LoanStatus.html widget.html
-msgid "Join Waitlist"
 msgstr ""
 
 #: widget.html
@@ -893,10 +2240,6 @@ msgstr ""
 
 #: work_search.html
 msgid "Keywords"
-msgstr ""
-
-#: RecentChanges.html recentchanges/index.html work_search.html
-msgid "Everything"
 msgstr ""
 
 #: work_search.html
@@ -1009,14 +2352,6 @@ msgid ""
 " the team, then complete the <a "
 "href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">Open Library team "
 "information form</a>."
-msgstr ""
-
-#: account/create.html openlibrary/plugins/upstream/forms.py
-msgid "Must be a valid email address"
-msgstr ""
-
-#: account/create.html openlibrary/plugins/upstream/forms.py
-msgid "Must be between 3 and 20 characters"
 msgstr ""
 
 #: account/create.html
@@ -1205,14 +2540,6 @@ msgid_plural "There are %(count)d people waiting for this book."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ManageLoansButtons.html account/loans.html
-msgid "Not yet downloaded."
-msgstr ""
-
-#: ManageLoansButtons.html account/loans.html
-msgid "Download Now"
-msgstr ""
-
 #: account/loans.html
 msgid "Return via<br/>Adobe Digital Editions"
 msgstr ""
@@ -1235,19 +2562,6 @@ msgid ""
 "of<br/><strong>TITLE</strong>?"
 msgstr ""
 
-#: ProlificAuthors.html account/loans.html authors/index.html
-#: lists/showcase.html publishers/view.html search/authors.html
-#: search/publishers.html search/subjects.html
-#, python-format
-msgid "%(count)d book"
-msgid_plural "%(count)d books"
-msgstr[0] ""
-msgstr[1] ""
-
-#: RecentChangesAdmin.html account/loans.html admin/loans_table.html
-msgid "Actions"
-msgstr ""
-
 #: account/loans.html
 #, python-format
 msgid "Waiting for 1 day"
@@ -1259,31 +2573,12 @@ msgstr[1] ""
 msgid "You are the next person to receive this book."
 msgstr ""
 
-#: ManageWaitlistButton.html account/loans.html
-#, python-format
-msgid "There is one person ahead of you in the waiting list."
-msgid_plural "There are %(count)d people ahead of you in the waiting list."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ManageWaitlistButton.html account/loans.html
-msgid "You have less than an hour to borrow it."
-msgstr ""
-
 #: account/loans.html
 #, python-format
 msgid "You have one more hour to borrow it."
 msgid_plural "You have %(hours)d more hours to borrow it."
 msgstr[0] ""
 msgstr[1] ""
-
-#: ManageWaitlistButton.html account/loans.html
-msgid "Borrow Now"
-msgstr ""
-
-#: ManageWaitlistButton.html account/loans.html
-msgid "Leave the waiting list?"
-msgstr ""
 
 #: account/loans.html
 msgid ""
@@ -1305,12 +2600,6 @@ msgstr ""
 
 #: account/mybooks.html account/sidebar.html
 msgid "My Loans"
-msgstr ""
-
-#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
-#: my_books/dropdown_content.html my_books/primary_action.html
-#: openlibrary/plugins/upstream/mybooks.py search/sort_options.html
-msgid "Already Read"
 msgstr ""
 
 #: account/mybooks.html type/user/view.html
@@ -1336,11 +2625,6 @@ msgstr ""
 
 #: account/mybooks.html account/sidebar.html account/topmenu.html
 msgid "My Reading Stats"
-msgstr ""
-
-#: account/mybooks.html account/sidebar.html
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
-msgid "Loan History"
 msgstr ""
 
 #: account/mybooks.html account/sidebar.html
@@ -1383,11 +2667,6 @@ msgstr ""
 msgid "Thanks!"
 msgstr ""
 
-#: BookByline.html FulltextSearchSuggestionItem.html SearchResultsWork.html
-#: account/notes.html account/observations.html
-msgid "Unknown author"
-msgstr ""
-
 #: account/notes.html
 msgid "My notes for an edition of "
 msgstr ""
@@ -1408,14 +2687,6 @@ msgstr ""
 #: account/notes.html
 #, python-format
 msgid "in %(language)s"
-msgstr ""
-
-#: NotesModal.html account/notes.html
-msgid "Delete Note"
-msgstr ""
-
-#: NotesModal.html account/notes.html
-msgid "Save Note"
 msgstr ""
 
 #: account/notes.html
@@ -1447,16 +2718,6 @@ msgstr ""
 
 #: account/notifications.html
 msgid "Yes! Please!"
-msgstr ""
-
-#: EditButtons.html account/notifications.html account/privacy.html
-#: admin/block.html admin/spamwords.html covers/manage.html
-msgid "Save"
-msgstr ""
-
-#: EditionNavBar.html account/observations.html
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
-msgid "Reviews"
 msgstr ""
 
 #: account/observations.html admin/inspect/memcache.html
@@ -1691,11 +2952,6 @@ msgstr ""
 msgid "Click on a bar to see matching works"
 msgstr ""
 
-#: account/sidebar.html books/mybooks_breadcrumb_select.html
-#: openlibrary/plugins/upstream/mybooks.py
-msgid "My Feed"
-msgstr ""
-
 #: account/sidebar.html
 #, python-format
 msgid "%(year)d Reading Goal"
@@ -1712,13 +2968,6 @@ msgstr ""
 
 #: account/sidebar.html
 msgid "My lists"
-msgstr ""
-
-#: EditionNavBar.html SearchNavigation.html account/sidebar.html
-#: lib/nav_head.html lists/home.html lists/widget.html recentchanges/index.html
-#: type/edition/view.html type/list/embed.html type/user/view.html
-#: type/work/view.html
-msgid "Lists"
 msgstr ""
 
 #: account/sidebar.html type/edition/view.html type/user/view.html
@@ -1741,13 +2990,6 @@ msgstr ""
 
 #: account/verify.html
 msgid "Verification email sent"
-msgstr ""
-
-#: account/password/reset_success.html account/verify.html
-#: account/verify/activated.html account/verify/success.html
-#: openlibrary/plugins/upstream/account.py
-#, python-format
-msgid "Hi, %(user)s"
 msgstr ""
 
 #: account/verify.html
@@ -2005,10 +3247,6 @@ msgstr ""
 msgid "New Books Imported Per Day"
 msgstr ""
 
-#: PublishingHistory.html admin/imports.html publishers/view.html
-msgid "You need to have JavaScript turned on to see the nifty chart!"
-msgstr ""
-
 #: admin/imports.html admin/imports_by_date.html site/stats.html
 msgid "Summary"
 msgstr ""
@@ -2076,10 +3314,6 @@ msgstr ""
 
 #: admin/imports_by_date.html
 msgid "Failed"
-msgstr ""
-
-#: admin/imports_by_date.html openlibrary/core/edits.py
-msgid "Pending"
 msgstr ""
 
 #: admin/imports_by_date.html
@@ -2250,12 +3484,6 @@ msgid_plural "%d Current Loans"
 msgstr[0] ""
 msgstr[1] ""
 
-#: RecentChanges.html RecentChangesUsers.html admin/ip/view.html
-#: admin/loans_table.html admin/people/edits.html recentchanges/render.html
-#: recentchanges/updated_records.html
-msgid "What"
-msgstr ""
-
 #: admin/loans_table.html
 #, python-format
 msgid "Waiting since %(date)s"
@@ -2266,20 +3494,8 @@ msgstr ""
 msgid "#%(num_position)d among %(num_waitlist)d people waiting for this book"
 msgstr ""
 
-#: ManageLoansButtons.html admin/loans_table.html
-#, python-format
-msgid "Borrowed %(date)s"
-msgstr ""
-
 #: admin/menu.html
 msgid "Admin Center"
-msgstr ""
-
-#: RelatedSubjects.html SubjectTags.html admin/menu.html
-#: admin/people/index.html admin/people/view.html
-#: openlibrary/plugins/worksearch/code.py type/author/view.html
-#: type/list/view_body.html
-msgid "People"
 msgstr ""
 
 #: admin/menu.html
@@ -2543,20 +3759,9 @@ msgstr ""
 msgid "Please select the changesets to revert."
 msgstr ""
 
-#: RecentChanges.html admin/ip/view.html admin/people/edits.html
-#: recentchanges/render.html
-msgid "When you see numbers here, that's the IP address of the anonymous editor"
-msgstr ""
-
 #: admin/ip/view.html admin/people/edits.html
 #, python-format
 msgid "Reverted by %(revert_author)s"
-msgstr ""
-
-#: EditButtons.html admin/ip/view.html admin/people/edits.html
-msgid ""
-"Please, leave a short note about what you changed: <span class=\"small "
-"gray\">(Optional, but very useful!)</span>"
 msgstr ""
 
 #: admin/ip/view.html admin/people/edits.html
@@ -2577,12 +3782,6 @@ msgstr ""
 
 #: admin/memory/index.html
 msgid "mark"
-msgstr ""
-
-#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
-#: admin/memory/index.html recentchanges/default/path.html
-#: recentchanges/updated_records.html
-msgid "diff"
 msgstr ""
 
 #: admin/memory/index.html
@@ -2608,16 +3807,6 @@ msgstr ""
 
 #: admin/people/edits.html
 msgid "edits"
-msgstr ""
-
-#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
-#: admin/people/edits.html recentchanges/render.html
-msgid "Older"
-msgstr ""
-
-#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
-#: admin/people/edits.html recentchanges/render.html
-msgid "Newer"
 msgstr ""
 
 #: admin/people/index.html
@@ -2713,10 +3902,6 @@ msgstr ""
 msgid "Resend activation link"
 msgstr ""
 
-#: CreateListModal.html admin/people/view.html my_books/dropdown_content.html
-msgid "Name:"
-msgstr ""
-
 #: admin/people/view.html
 msgid "view profile"
 msgstr ""
@@ -2769,11 +3954,6 @@ msgstr ""
 msgid "Anonymize Account"
 msgstr ""
 
-#: admin/people/view.html books/mybooks_breadcrumb_select.html
-#: openlibrary/plugins/upstream/account.py type/user/view.html
-msgid "Loans"
-msgstr ""
-
 #: admin/people/view.html
 msgid "Account not activated yet."
 msgstr ""
@@ -2801,11 +3981,6 @@ msgstr ""
 
 #: admin/people/view.html
 msgid "None found"
-msgstr ""
-
-#: SearchNavigation.html authors/index.html lib/nav_foot.html
-#: merge/authors.html publishers/view.html
-msgid "Authors"
 msgstr ""
 
 #: authors/index.html
@@ -3047,10 +4222,6 @@ msgstr ""
 msgid "View the source code for this Standard Ebook at GitHub"
 msgstr ""
 
-#: Subnavigation.html book_providers/standard_ebooks_download_options.html
-msgid "Source Code"
-msgstr ""
-
 #: book_providers/standard_ebooks_download_options.html
 msgid "More at Standard Ebooks"
 msgstr ""
@@ -3154,12 +4325,6 @@ msgstr ""
 msgid "Required field"
 msgstr ""
 
-#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html
-#: openlibrary/plugins/worksearch/code.py search/advancedsearch.html
-#: search/work_search_selected_facets.html
-msgid "Author"
-msgstr ""
-
 #: books/add.html
 msgid ""
 "Like, \"Agatha Christie\" or \"Jean-Paul Sartre.\" We'll also do a live "
@@ -3232,15 +4397,6 @@ msgstr ""
 msgid "Only fill this out if this is a web book"
 msgstr ""
 
-#: EditButtons.html books/add.html type/tag/form.html
-msgid ""
-"By saving a change to this wiki, you agree that your contribution is "
-"given freely to the world under <a "
-"href=\"https://creativecommons.org/publicdomain/zero/1.0/\" "
-"target=\"_blank\" title=\"This link to Creative Commons will open in a "
-"new window\">CC0</a>. Yippee!"
-msgstr ""
-
 #: books/add.html
 msgid "Add this book now"
 msgstr ""
@@ -3281,14 +4437,6 @@ msgstr ""
 #: books/check.html
 msgid "Select this book"
 msgstr ""
-
-#: SearchResultsWork.html books/check.html merge/authors.html
-#: publishers/view.html
-#, python-format
-msgid "%(count)s edition"
-msgid_plural "%(count)s editions"
-msgstr[0] ""
-msgstr[1] ""
 
 #: books/check.html
 #, python-format
@@ -3512,14 +4660,6 @@ msgid ""
 " LCCN, go to the edition tab."
 msgstr ""
 
-#: FulltextSearchSuggestionItem.html IABook.html SearchResultsWork.html
-#: books/edition-sort.html jsdef/LazyWorkPreview.html lists/list_overview.html
-#: lists/preview.html lists/snippet.html lists/widget.html
-#: my_books/dropdown_content.html type/work/editions.html
-#, python-format
-msgid "Cover of: %(title)s"
-msgstr ""
-
 #: books/edition-sort.html
 #, python-format
 msgid "%(title)s: %(subtitle)s"
@@ -3533,41 +4673,6 @@ msgstr ""
 #: books/edition-sort.html type/work/editions.html
 #, python-format
 msgid "in %(languagelist)s"
-msgstr ""
-
-#: SearchNavigation.html books/mybooks_breadcrumb_select.html lib/nav_foot.html
-#: openlibrary/plugins/upstream/mybooks.py
-msgid "Books"
-msgstr ""
-
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
-#, python-format
-msgid "Want to Read (%(count)d)"
-msgstr ""
-
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
-#, python-format
-msgid "Currently Reading (%(count)d)"
-msgstr ""
-
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
-#, python-format
-msgid "Already Read (%(count)d)"
-msgstr ""
-
-#: books/mybooks_breadcrumb_select.html
-#: openlibrary/plugins/openlibrary/lists.py
-#, python-format
-msgid "Lists (%(count)d)"
-msgstr ""
-
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
-#: type/edition/modal_links.html
-msgid "Notes"
-msgstr ""
-
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
-msgid "Imports and Exports"
 msgstr ""
 
 #: books/edit/about.html
@@ -4456,10 +5561,6 @@ msgid ""
 " page for every book ever published."
 msgstr ""
 
-#: AffiliateLinks.html home/about.html
-msgid "More"
-msgstr ""
-
 #: home/about.html
 msgid ""
 "Just like Wikipedia, you can contribute new information or corrections to"
@@ -4500,20 +5601,12 @@ msgstr ""
 msgid "Recently Returned"
 msgstr ""
 
-#: home/index.html openlibrary/plugins/openlibrary/home.py
-msgid "Romance"
-msgstr ""
-
 #: home/index.html
 msgid "Kids"
 msgstr ""
 
 #: home/index.html
 msgid "Thrillers"
-msgstr ""
-
-#: home/index.html openlibrary/plugins/openlibrary/home.py
-msgid "Textbooks"
 msgstr ""
 
 #: home/loans.html
@@ -4713,11 +5806,6 @@ msgstr ""
 msgid "New!"
 msgstr ""
 
-#: databarDiff.html databarEdit.html databarTemplate.html databarView.html
-#: lib/history.html openlibrary/plugins/openlibrary/home.py
-msgid "History"
-msgstr ""
-
 #: lib/history.html
 #, python-format
 msgid "Created %(date)s"
@@ -4883,23 +5971,12 @@ msgstr ""
 msgid "Explore subjects"
 msgstr ""
 
-#: RelatedSubjects.html SearchNavigation.html SubjectTags.html
-#: lib/nav_foot.html lib/nav_head.html openlibrary/plugins/worksearch/code.py
-#: subjects/notfound.html type/author/view.html type/list/view_body.html
-msgid "Subjects"
-msgstr ""
-
 #: lib/nav_foot.html
 msgid "Explore collections"
 msgstr ""
 
 #: lib/nav_foot.html lib/nav_head.html
 msgid "Collections"
-msgstr ""
-
-#: SearchNavigation.html lib/nav_foot.html lib/nav_head.html
-#: search/advancedsearch.html
-msgid "Advanced Search"
 msgstr ""
 
 #: lib/nav_foot.html
@@ -5056,10 +6133,6 @@ msgstr ""
 msgid "My Open Library"
 msgstr ""
 
-#: databarWork.html lib/nav_head.html
-msgid "Browse"
-msgstr ""
-
 #: lib/nav_head.html
 msgid "Contribute"
 msgstr ""
@@ -5096,10 +6169,6 @@ msgid ""
 " href=\"/account/create\" title=\"Create an Open Library account\">create"
 " an account</a>, your IP address is concealed and you can more easily "
 "keep track of all your edits and additions."
-msgstr ""
-
-#: Pager.html Pager_loanhistory.html lib/pagination.html
-msgid "Previous"
 msgstr ""
 
 #: lists/export_as_html.html
@@ -5214,10 +6283,6 @@ msgstr ""
 
 #: lists/home.html lists/snippet.html
 msgid "No description."
-msgstr ""
-
-#: RecentChangesUsers.html lists/home.html lists/lists.html type/user/view.html
-msgid "Recent Activity"
 msgstr ""
 
 #: lists/home.html lists/showcase.html
@@ -5462,14 +6527,6 @@ msgstr ""
 msgid "Request Status"
 msgstr ""
 
-#: merge_request_table/table_header.html openlibrary/core/edits.py
-msgid "Merged"
-msgstr ""
-
-#: merge_request_table/table_header.html openlibrary/core/edits.py
-msgid "Declined"
-msgstr ""
-
 #: merge_request_table/table_header.html
 msgid "Submitter ▾"
 msgstr ""
@@ -5577,19 +6634,6 @@ msgstr ""
 msgid "Use this Work"
 msgstr ""
 
-#: CreateListModal.html my_books/dropdown_content.html
-msgid "Create a new list"
-msgstr ""
-
-#: CreateListModal.html my_books/dropdown_content.html
-#: type/permission/edit.html type/usergroup/edit.html
-msgid "Description:"
-msgstr ""
-
-#: CreateListModal.html my_books/dropdown_content.html type/list/edit.html
-msgid "Create new list"
-msgstr ""
-
 #: my_books/primary_action.html
 msgid "Add to List"
 msgstr ""
@@ -5636,11 +6680,6 @@ msgstr ""
 msgid "Publisher: %(name)s"
 msgstr ""
 
-#: openlibrary/plugins/worksearch/code.py publishers/view.html
-#: search/advancedsearch.html type/edition/view.html type/work/view.html
-msgid "Publisher"
-msgstr ""
-
 #: publishers/view.html
 #, python-format
 msgid "%(count)s ebook"
@@ -5652,10 +6691,6 @@ msgstr[1] ""
 msgid "0 ebooks"
 msgstr ""
 
-#: PublishingHistory.html publishers/view.html
-msgid "Publishing History"
-msgstr ""
-
 #: publishers/view.html
 msgid ""
 "This is a chart to show the when this publisher published books. Along "
@@ -5663,26 +6698,10 @@ msgid ""
 " <a href=\"#subjectRelated\">Click here to skip the chart</a>."
 msgstr ""
 
-#: PublishingHistory.html publishers/view.html
-msgid "Reset chart"
-msgstr ""
-
-#: PublishingHistory.html publishers/view.html
-msgid "or continue zooming in."
-msgstr ""
-
 #: publishers/view.html
 msgid ""
 "This graph charts editions from this publisher over time. Click to view a"
 " single year, or drag across a range."
-msgstr ""
-
-#: PublishingHistory.html publishers/view.html
-msgid "Editions Published"
-msgstr ""
-
-#: PublishingHistory.html publishers/view.html
-msgid "Year of Publication"
 msgstr ""
 
 #: publishers/view.html
@@ -5692,14 +6711,6 @@ msgstr ""
 #: publishers/view.html
 #, python-format
 msgid "Search for books published by %(publisher)s"
-msgstr ""
-
-#: RelatedSubjects.html publishers/view.html
-msgid "None found."
-msgstr ""
-
-#: ProlificAuthors.html publishers/view.html
-msgid "See more books by, and learn about, this author"
 msgstr ""
 
 #: publishers/view.html
@@ -5738,14 +6749,6 @@ msgstr ""
 msgid "Books Added"
 msgstr ""
 
-#: RecentChanges.html recentchanges/index.html
-msgid "By Humans"
-msgstr ""
-
-#: RecentChanges.html recentchanges/index.html
-msgid "By Bots"
-msgstr ""
-
 #: recentchanges/render.html
 msgid "Admin view"
 msgstr ""
@@ -5761,10 +6764,6 @@ msgstr ""
 
 #: recentchanges/default/message.html recentchanges/edit-book/message.html
 msgid "opened a new Open Library account!"
-msgstr ""
-
-#: RecentChanges.html RecentChangesUsers.html recentchanges/default/path.html
-msgid "Review what's changed from the previous revision"
 msgstr ""
 
 #: recentchanges/default/view.html recentchanges/merge/view.html
@@ -5885,11 +6884,6 @@ msgstr ""
 #: search/inside.html
 #, python-format
 msgid "Search Open Library for %s"
-msgstr ""
-
-#: BookSearchInside.html FulltextSearchSuggestion.html SearchNavigation.html
-#: search/inside.html search/snippets.html
-msgid "Search Inside"
 msgstr ""
 
 #: search/inside.html
@@ -6115,10 +7109,6 @@ msgstr ""
 
 #: site/stats.html
 msgid "Debug Stats"
-msgstr ""
-
-#: EditionNavBar.html site/stats.html
-msgid "Details"
 msgstr ""
 
 #: stats/readinglog.html
@@ -6356,15 +7346,6 @@ msgstr ""
 msgid "Search %(author)s books"
 msgstr ""
 
-#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py
-#: type/author/view.html type/list/view_body.html
-msgid "Places"
-msgstr ""
-
-#: Profile.html type/author/view.html
-msgid "Time"
-msgstr ""
-
 #: type/author/view.html
 msgid "OLID"
 msgstr ""
@@ -6425,14 +7406,6 @@ msgstr ""
 msgid "View Book on Archive.org"
 msgstr ""
 
-#: SearchResultsWork.html type/edition/admin_bar.html
-msgid "Orphaned Edition"
-msgstr ""
-
-#: databarHistory.html databarView.html type/edition/compact_title.html
-msgid "Edit this page"
-msgstr ""
-
 #: type/edition/modal_links.html
 msgid "Review"
 msgstr ""
@@ -6474,21 +7447,12 @@ msgstr ""
 msgid "Search for other books from %(publisher)s"
 msgstr ""
 
-#: openlibrary/plugins/worksearch/code.py type/edition/view.html
-#: type/work/view.html
-msgid "Language"
-msgstr ""
-
 #: type/edition/view.html type/work/view.html
 msgid "Pages"
 msgstr ""
 
 #: type/edition/view.html type/work/view.html
 msgid "ISBNs"
-msgstr ""
-
-#: databarWork.html type/edition/view.html type/work/view.html
-msgid "Buy this book"
 msgstr ""
 
 #: type/edition/view.html type/work/view.html
@@ -6677,11 +7641,6 @@ msgstr ""
 msgid "Protected DAISY"
 msgstr ""
 
-#: BookByline.html type/list/embed.html
-#, python-format
-msgid "by %(name)s"
-msgstr ""
-
 #: type/list/exports.html
 msgid "BibTex"
 msgstr ""
@@ -6783,11 +7742,6 @@ msgstr ""
 
 #: type/list/view_body.html
 msgid "Derived from seed metadata"
-msgstr ""
-
-#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py
-#: type/list/view_body.html
-msgid "Times"
 msgstr ""
 
 #: type/local_id/view.html
@@ -6975,26 +7929,13 @@ msgstr ""
 msgid "My Lists"
 msgstr ""
 
-#: RecentChangesUsers.html type/user/view.html
-msgid "No edits. Yet."
-msgstr ""
-
 #: type/usergroup/edit.html
 msgid "Members:"
-msgstr ""
-
-#: SearchResultsWork.html type/work/editions.html
-#, python-format
-msgid "First published in %(year)s"
 msgstr ""
 
 #: type/work/editions.html type/work/editions_datatable.html
 #, python-format
 msgid "Add another edition of %(work)s"
-msgstr ""
-
-#: UserEditRow.html type/work/editions.html
-msgid "Add another"
 msgstr ""
 
 #: type/work/editions.html
@@ -7027,946 +7968,5 @@ msgstr ""
 
 #: type/work/editions_datatable.html
 msgid "Add another edition?"
-msgstr ""
-
-#: AffiliateLinks.html
-#, python-format
-msgid "Look for this edition for sale at %(store)s"
-msgstr ""
-
-#: AffiliateLinks.html
-msgid "Fetching prices"
-msgstr ""
-
-#: AffiliateLinks.html
-msgid "Better World Books"
-msgstr ""
-
-#: AffiliateLinks.html
-msgid " - includes shipping"
-msgstr ""
-
-#: AffiliateLinks.html
-msgid "Amazon"
-msgstr ""
-
-#: AffiliateLinks.html
-msgid "Bookshop.org"
-msgstr ""
-
-#: AffiliateLinks.html
-msgid ""
-"When you buy books using these links the Internet Archive may earn a <a "
-"class=\"nostyle\" href=\"/help/faq/about#selling\">small commission</a>."
-msgstr ""
-
-#: BatchImportNavigation.html
-msgid "Pending Imports"
-msgstr ""
-
-#: BookByline.html
-#, python-format
-msgid "%(n)s other"
-msgid_plural "%(n)s others"
-msgstr[0] ""
-msgstr[1] ""
-
-#: BookByline.html
-msgid "by an <em>unknown author</em>"
-msgstr ""
-
-#: BookPreview.html
-msgid "Preview Only"
-msgstr ""
-
-#: BookPreview.html
-msgid "Preview Book"
-msgstr ""
-
-#: DisplayCode.html
-msgid ""
-"Templates in the website are disabled now. Editing them will not have any"
-" effect on the live website."
-msgstr ""
-
-#: DonateModal.html
-msgid ""
-"Donate this book to the <a href=\"https://archive.org\">Internet "
-"Archive</a> library."
-msgstr ""
-
-#: DonateModal.html
-msgid ""
-"Hooray! You've discovered a title that's missing from our <a "
-"href=\"https://help.archive.org/hc/en-us/articles/360016554912-Borrowing-"
-"From-The-Lending-Library\">library</a>. Can you help donate a copy?"
-msgstr ""
-
-#: DonateModal.html
-msgid ""
-"If you own this book, you can<a "
-"href=\"https://store.usps.com/store/product/shipping-supplies/priority-"
-"mail-express-padded-flat-rate-envelope-P_EP13PE\">mail</a> it to our "
-"address below."
-msgstr ""
-
-#: DonateModal.html
-msgid "You can also purchase this book from a vendor and ship it to our address:"
-msgstr ""
-
-#: DonateModal.html
-msgid "Benefits of donating"
-msgstr ""
-
-#: DonateModal.html
-msgid ""
-"When you donate a physical book to the Internet Archive, your book will "
-"enjoy:"
-msgstr ""
-
-#: DonateModal.html
-msgid "Donation info"
-msgstr ""
-
-#: DonateModal.html
-msgid ""
-"Beautiful <a target=\"_blank\" href=\"https://archive.org/scanning"
-"\">high-fidelity digitization</a>"
-msgstr ""
-
-#: DonateModal.html
-msgid ""
-"Long-term <a href=\"https://blog.archive.org/2011/06/06/why-preserve-"
-"books-the-new-physical-archive-of-the-internet-archive/\">archival "
-"preservation</a>"
-msgstr ""
-
-#: DonateModal.html
-msgid ""
-"Free <a href=\"https://controlleddigitallending.org/\">controlled digital"
-" library access</a> by the <a "
-"href=\"https://en.wikipedia.org/wiki/Print_disability\">print-"
-"disabled</a> public"
-msgstr ""
-
-#: DonateModal.html
-msgid ""
-"Open Library is a project of the <a "
-"href=\"https://archive.org/about\">Internet Archive</a>, a 501(c)(3) non-"
-"profit"
-msgstr ""
-
-#: EditionNavBar.html
-msgid "Go to previous section"
-msgstr ""
-
-#: EditionNavBar.html
-msgid "Overview"
-msgstr ""
-
-#: EditionNavBar.html
-#, python-format
-msgid "View %(count)s Edition"
-msgid_plural "View %(count)s Editions"
-msgstr[0] ""
-msgstr[1] ""
-
-#: EditionNavBar.html
-#, python-format
-msgid "%(reviews)s Review"
-msgid_plural "%(reviews)s Reviews"
-msgstr[0] ""
-msgstr[1] ""
-
-#: EditionNavBar.html
-msgid "Related Books"
-msgstr ""
-
-#: EditionNavBar.html
-msgid "Go to next section"
-msgstr ""
-
-#: Follow.html
-msgid "UnfollowFollow"
-msgstr ""
-
-#: Follow.html
-msgid "Follow"
-msgstr ""
-
-#: FormatExpiry.html
-msgid "Expires"
-msgstr ""
-
-#: FulltextSearchSuggestion.html
-msgid "Checking for Search Inside matches"
-msgstr ""
-
-#: FulltextSearchSuggestion.html
-msgid "Search Inside Icon"
-msgstr ""
-
-#: FulltextSearchSuggestion.html
-msgid "search inside icon"
-msgstr ""
-
-#: FulltextSearchSuggestion.html
-#, python-format
-msgid "%(book_count)s books found with matching passages"
-msgstr ""
-
-#: FulltextSearchSuggestion.html
-#, python-format
-msgid "See all %(results_count)s Search Inside Matches"
-msgstr ""
-
-#: FulltextSearchSuggestion.html
-msgid "right chevron"
-msgstr ""
-
-#: FulltextSnippet.html FulltextSuggestionSnippet.html
-msgid "❝"
-msgstr ""
-
-#: FulltextSnippet.html FulltextSuggestionSnippet.html
-msgid "❞"
-msgstr ""
-
-#: FulltextSuggestionSnippet.html
-#, python-format
-msgid "Page: %(page)s"
-msgstr ""
-
-#: IABook.html
-#, python-format
-msgid "Borrowed from Internet Archive: %(title)s"
-msgstr ""
-
-#: LoadingIndicator.html
-msgid "Loading indicator"
-msgstr ""
-
-#: LoanStatus.html
-msgid "You are <strong>next</strong> on the waiting list"
-msgstr ""
-
-#: LoanStatus.html
-#, python-format
-msgid "You are <strong>#%(spot)d</strong> of %(wlsize)d on the waiting list."
-msgstr ""
-
-#: LoanStatus.html
-msgid "Leave waiting list"
-msgstr ""
-
-#: LoanStatus.html
-#, python-format
-msgid "Readers in line: %(count)s"
-msgstr ""
-
-#: LoanStatus.html
-msgid "You'll be next in line."
-msgstr ""
-
-#: LoanStatus.html
-msgid "This book is currently checked out, please check back later."
-msgstr ""
-
-#: LoanStatus.html
-msgid "Checked Out"
-msgstr ""
-
-#: LocateButton.html
-msgid "Locate"
-msgstr ""
-
-#: ManageLoansButtons.html
-#, python-format
-msgid "There is one person waiting for this book."
-msgid_plural "There are %(n)s people waiting for this book."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ManageWaitlistButton.html
-#, python-format
-msgid "Waiting for %d day"
-msgid_plural "Waiting for %d days"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ManageWaitlistButton.html
-#, python-format
-msgid "You have %(count)d more hour to borrow it."
-msgid_plural "You have %(count)d more hours to borrow it."
-msgstr[0] ""
-msgstr[1] ""
-
-#: NotInLibrary.html
-msgid "Not in Library"
-msgstr ""
-
-#: NotesModal.html
-msgid "My Book Notes"
-msgstr ""
-
-#: NotesModal.html
-msgid "My private notes about this edition:"
-msgstr ""
-
-#: OLID.html
-#, python-format
-msgid "by  %(authors)s"
-msgstr ""
-
-#: ObservationsModal.html
-msgid "My Book Review"
-msgstr ""
-
-#: Pager.html Pager_loanhistory.html
-msgid "First"
-msgstr ""
-
-#: Profile.html
-msgid "Component"
-msgstr ""
-
-#: ProlificAuthors.html
-msgid "Prolific Authors"
-msgstr ""
-
-#: ProlificAuthors.html
-msgid "who have written the most books on this subject"
-msgstr ""
-
-#: PublishingHistory.html
-msgid ""
-"This is a chart to show the publishing history of editions of works about"
-" this subject. Along the X axis is time, and on the y axis is the count "
-"of editions published. <a href=\"#subjectRelated\">Click here to skip the"
-" chart</a>."
-msgstr ""
-
-#: PublishingHistory.html
-msgid "This graph charts editions published on this subject."
-msgstr ""
-
-#: RawQueryCarousel.html
-msgid "Search collection"
-msgstr ""
-
-#: ReadButton.html
-msgid "Special Access"
-msgstr ""
-
-#: ReadButton.html
-msgid ""
-"Special ebook access from the Internet Archive for patrons with "
-"qualifying print disabilities"
-msgstr ""
-
-#: ReadButton.html
-msgid "Borrow ebook from Internet Archive"
-msgstr ""
-
-#: ReadButton.html
-msgid "Read ebook from Internet Archive"
-msgstr ""
-
-#: ReadButton.html
-msgid "Listen"
-msgstr ""
-
-#: ReadMore.html
-msgid "Read more"
-msgstr ""
-
-#: ReadMore.html
-msgid "Read less"
-msgstr ""
-
-#: RecentChanges.html
-msgid "View MARC"
-msgstr ""
-
-#: RecentChangesAdmin.html
-msgid "Path"
-msgstr ""
-
-#: RecentChangesAdmin.html
-msgid "view"
-msgstr ""
-
-#: RecentChangesAdmin.html
-msgid "edit"
-msgstr ""
-
-#: RecentChangesAdmin.html RecentChangesUsers.html
-msgid "No edit history available."
-msgstr ""
-
-#: RelatedSubjects.html
-msgid "Related..."
-msgstr ""
-
-#: ReturnForm.html
-msgid "Really return this book?"
-msgstr ""
-
-#: ReturnForm.html
-msgid "Return book"
-msgstr ""
-
-#: SearchResultsWork.html
-msgid "added to"
-msgstr ""
-
-#: SearchResultsWork.html
-#, python-format
-msgid "Cover of edition %(id)s"
-msgstr ""
-
-#: SearchResultsWork.html
-#, python-format
-msgid "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d language</a>"
-msgid_plural "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d languages</a>"
-msgstr[0] ""
-msgstr[1] ""
-
-#: SearchResultsWork.html
-msgid "This is only visible to librarians."
-msgstr ""
-
-#: SearchResultsWork.html
-msgid "Work Title"
-msgstr ""
-
-#: ShareModal.html
-#, python-format
-msgid "Share on %(share_link)s"
-msgstr ""
-
-#: ShareModal.html
-msgid "Embed this book in your website"
-msgstr ""
-
-#: ShareModal.html
-msgid "Embed icon"
-msgstr ""
-
-#: ShareModal.html
-msgid "Embed"
-msgstr ""
-
-#: ShareModal.html
-msgid "Copy url to clipboard"
-msgstr ""
-
-#: ShareModal.html
-msgid "Copy URL icon"
-msgstr ""
-
-#: ShareModal.html
-msgid "Copy URL"
-msgstr ""
-
-#: ShareModal.html
-msgid "Open QR code"
-msgstr ""
-
-#: ShareModal.html
-msgid "QR code icon"
-msgstr ""
-
-#: ShareModal.html
-msgid "QR Code"
-msgstr ""
-
-#: StarRatings.html
-msgid "Clear my rating"
-msgstr ""
-
-#: StarRatingsByline.html StarRatingsComponent.html
-msgid "rating"
-msgstr ""
-
-#: StarRatingsByline.html StarRatingsComponent.html
-msgid "ratings"
-msgstr ""
-
-#: StarRatingsByline.html
-#, python-format
-msgid "%(want_to_read_count)s Want to read"
-msgstr ""
-
-#: StarRatingsComponent.html
-#, python-format
-msgid "%(ratings_avg)s (%(ratings_count)s %(ratings_label)s)"
-msgstr ""
-
-#: StarRatingsStats.html
-msgid "Want to read"
-msgstr ""
-
-#: StarRatingsStats.html
-msgid "Currently reading"
-msgstr ""
-
-#: StarRatingsStats.html
-msgid "Have read"
-msgstr ""
-
-#: Subnavigation.html
-msgid "Developer Center (Home)"
-msgstr ""
-
-#: Subnavigation.html
-msgid "Web API"
-msgstr ""
-
-#: Subnavigation.html
-msgid "Client Library"
-msgstr ""
-
-#: Subnavigation.html
-msgid "Data Dumps"
-msgstr ""
-
-#: Subnavigation.html
-msgid "Report an Issue"
-msgstr ""
-
-#: Subnavigation.html
-msgid "Licensing"
-msgstr ""
-
-#: Subnavigation.html
-msgid "Welcome"
-msgstr ""
-
-#: Subnavigation.html
-msgid "Searching Open Library"
-msgstr ""
-
-#: Subnavigation.html
-msgid "Reading Books"
-msgstr ""
-
-#: Subnavigation.html
-msgid "Adding & Editing Books"
-msgstr ""
-
-#: Subnavigation.html
-msgid "Using Subjects"
-msgstr ""
-
-#: Subnavigation.html
-msgid "Open Library F.A.Q."
-msgstr ""
-
-#: TableOfContents.html
-#, python-format
-msgid "Page %s"
-msgstr ""
-
-#: TypeChanger.html
-msgid "Page Type"
-msgstr ""
-
-#: TypeChanger.html
-msgid "Huh?"
-msgstr ""
-
-#: TypeChanger.html
-msgid ""
-"Every piece of Open Library is defined by the type of content it "
-"displays, usually by content definition (e.g. Authors, Editions, Works) "
-"but sometimes by content use (e.g. macro, template, rawtext). Changing "
-"this for an existing page will alter its presentation and the data fields"
-" available for editing its content."
-msgstr ""
-
-#: TypeChanger.html
-msgid "Please use caution changing Page Type!"
-msgstr ""
-
-#: TypeChanger.html
-msgid ""
-"(Simplest solution: If you aren't sure whether this should be changed, "
-"don't change it.)"
-msgstr ""
-
-#: WorkInfo.html
-msgid "No link to Wikipedia in your language"
-msgstr ""
-
-#: WorldcatLink.html
-msgid "Check nearby libraries"
-msgstr ""
-
-#: WorldcatLink.html
-msgid "Library.link"
-msgstr ""
-
-#: WorldcatLink.html
-msgid "Check WorldCat for an edition near you"
-msgstr ""
-
-#: WorldcatLink.html
-msgid "WorldCat"
-msgstr ""
-
-#: databarDiff.html databarEdit.html
-msgid "View the editing history of this page"
-msgstr ""
-
-#: databarDiff.html
-msgid "View this page (exit Comparison view)"
-msgstr ""
-
-#: databarEdit.html
-msgid "View this page (exit Edit mode)"
-msgstr ""
-
-#: databarHistory.html databarView.html
-#, python-format
-msgid "Last edited by %(author_link)s"
-msgstr ""
-
-#: databarHistory.html databarView.html
-msgid "Last edited anonymously"
-msgstr ""
-
-#: databarTemplate.html databarView.html
-msgid "View this template's edit history"
-msgstr ""
-
-#: databarTemplate.html
-msgid "Edit this template"
-msgstr ""
-
-#: databarWork.html
-#, python-format
-msgid "View Volume %(num)d"
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Username"
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "No user registered with this email address"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-#: openlibrary/plugins/upstream/forms.py
-msgid "Email already registered"
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Disposable email not permitted"
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Your email provider is not recognized."
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Username already used"
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Must be between 3 and 20 letters and numbers"
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Screen Name"
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Public and cannot be changed later."
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid ""
-"I want to receive news, announcements, and resources from the <a "
-"href=\"https://archive.org/\">Internet Archive</a>, the non-profit that "
-"runs Open Library."
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Invalid password"
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Your email address"
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Choose a password"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "The email address you entered is invalid"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "This account has been blocked"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "This account has been locked"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "No account was found with this email. Please try again"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "The password you entered is incorrect. Please try again"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Wrong password. Please try again"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Please verify your Open Library account before logging in"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Please verify your Internet Archive account before logging in"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Please fill out all fields and try again"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "This email is already registered"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "This username is already registered"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "A problem occurred and we were unable to log you in."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Login attempted with invalid Internet Archive s3 credentials."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid ""
-"Servers are experiencing unusually high traffic, please try again later "
-"or email openlibrary@archive.org for help."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Email provider not recognized."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Password requirements not met."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "A problem occurred and we were unable to log you in"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid ""
-"Login or registration attempt hit an unexpected error, please try again "
-"or contact info@archive.org"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-#, python-format
-msgid "Request failed with error code: %(error_code)s"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-#, python-format
-msgid ""
-"We've sent the verification email to %(email)s. You'll need to read that "
-"and click on the verification link to verify your email."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Username unavailable"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "An Internet Archive account already exists with this email"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Email address is already used."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid ""
-"Your email address couldn't be updated. The specified email address is "
-"already used."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Email verification successful."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid ""
-"Your email address has been successfully verified and updated in your "
-"account."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Email address couldn't be verified."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid ""
-"Your email address couldn't be verified. The verification link seems "
-"invalid."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Password reset failed."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Notification preferences have been updated successfully."
-msgstr ""
-
-#: openlibrary/plugins/upstream/borrow.py
-msgid ""
-"Your account has hit a lending limit. Please try again later or contact "
-"info@archive.org."
-msgstr ""
-
-#: openlibrary/plugins/worksearch/code.py
-msgid "eBook?"
-msgstr ""
-
-#: openlibrary/plugins/worksearch/code.py
-msgid "First published"
-msgstr ""
-
-#: openlibrary/plugins/worksearch/code.py
-msgid "Classic eBooks"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Czech"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "German"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "English"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Spanish"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "French"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Hindi"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Croatian"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Italian"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Portuguese"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Romanian"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Sardinian"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Telugu"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Ukrainian"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Chinese"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Art"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Science Fiction"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Fantasy"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Biographies"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Recipes"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Children"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Medicine"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Religion"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Mystery and Detective Stories"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Plays"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Music"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Science"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/lists.py
-#, python-format
-msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
-msgstr ""
-
-#: openlibrary/core/edits.py
-msgid "Unknown"
 msgstr ""
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10634

I think the changes adding the `grep` to find python i18n caused this file to output things in an inconsistent order, likely based on OS. Force the file to be entirely sorted by file.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@SivanC 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
