### PR TITLE
8325/support/modify trending url to support fields

### DIFF
--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -75,10 +75,13 @@ class trending_books_api(delegate.page):
 
     def GET(self, period="/daily"):
         from openlibrary.views.loanstats import SINCE_DAYS
+        from openlibrary.plugins.worksearch.schemes.works import WorkSearchScheme
 
         period = period[1:]  # remove slash
         i = web.input(
-            page=1, limit=100, days=0, hours=0, sort_by_count=False, minimum=0
+            page=1, limit=100, days=0, hours=0, sort_by_count=False, minimum=0,
+              fields=list( WorkSearchScheme.default_fetched_fields
+                | {'subject', 'person', 'place', 'time', 'edition_key'})
         )
         days = SINCE_DAYS.get(period, int(i.days))
         works = get_trending_books(
@@ -89,6 +92,7 @@ class trending_books_api(delegate.page):
             books_only=True,
             sort_by_count=i.sort_by_count != "false",
             minimum=i.minimum,
+            fields = i.fields.split(','),
         )
         result = {
             'query': f"/trending/{period}",

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -92,7 +92,7 @@ class trending_books_api(delegate.page):
             books_only=True,
             sort_by_count=i.sort_by_count != "false",
             minimum=i.minimum,
-            fields = i.fields.split(','),
+            fields = i.fields,
         )
         result = {
             'query': f"/trending/{period}",

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -76,13 +76,14 @@ def get_facet_map() -> tuple[tuple[str, str]]:
 
 
 @public
-def get_solr_works(work_key: Iterable[str]) -> dict[str, dict]:
+def get_solr_works(work_key: Iterable[str],
+                   fields = WorkSearchScheme.default_fetched_fields) -> dict[str, dict]:
     from openlibrary.plugins.worksearch.search import get_solr
 
     return {
         doc['key']: doc
         for doc in get_solr().get_many(
-            set(work_key), fields=WorkSearchScheme.default_fetched_fields
+            set(work_key), fields
         )
     }
 

--- a/openlibrary/views/loanstats.py
+++ b/openlibrary/views/loanstats.py
@@ -63,8 +63,7 @@ def get_trending_books(
                 | {'subject', 'person', 'place', 'time', 'edition_key'})
 ):
     logged_books = (
-        Bookshelves.fetch(get_activity_stream(limit=limit, page=page,  fields=list( WorkSearchScheme.default_fetched_fields
-                | {'subject', 'person', 'place', 'time', 'edition_key'}))  # i.e. "now"
+        Bookshelves.fetch(get_activity_stream(limit=limit, page=page,  fields = fields))  # i.e. "now"
         if (since_days == 0 and since_hours == 0)
         else Bookshelves.most_logged_books(
             since=dateutil.todays_date_minus(days=since_days, hours=since_hours),
@@ -73,8 +72,7 @@ def get_trending_books(
             fetch=True,
             sort_by_count=sort_by_count,
             minimum=minimum,
-            fields=list( WorkSearchScheme.default_fetched_fields
-                | {'subject', 'person', 'place', 'time', 'edition_key'}
+            fields= fields,
         )
     )
     return (
@@ -162,7 +160,7 @@ class lending_stats(app.view):
 
 
 def get_activity_stream(limit=None, page=1,  fields=list( WorkSearchScheme.default_fetched_fields
-                | {'subject', 'person', 'place', 'time', 'edition_key'}):
+                | {'subject', 'person', 'place', 'time', 'edition_key'})):
     # enable to work w/ cached
     if 'env' not in web.ctx:
         delegate.fakeload()

--- a/openlibrary/views/loanstats.py
+++ b/openlibrary/views/loanstats.py
@@ -17,7 +17,7 @@ from ..core.yearly_reading_goals import YearlyReadingGoals
 from ..plugins.admin.code import get_counts
 from ..plugins.worksearch.code import get_solr_works
 from ..utils import dateutil
-
+from openlibrary.plugins.worksearch.schemes.works import WorkSearchScheme
 LENDING_TYPES = '(libraries|regions|countries|collections|subjects|format)'
 
 
@@ -59,9 +59,12 @@ def get_trending_books(
     books_only=False,
     sort_by_count=True,
     minimum=None,
+    fields=list( WorkSearchScheme.default_fetched_fields
+                | {'subject', 'person', 'place', 'time', 'edition_key'})
 ):
     logged_books = (
-        Bookshelves.fetch(get_activity_stream(limit=limit, page=page))  # i.e. "now"
+        Bookshelves.fetch(get_activity_stream(limit=limit, page=page,  fields=list( WorkSearchScheme.default_fetched_fields
+                | {'subject', 'person', 'place', 'time', 'edition_key'}))  # i.e. "now"
         if (since_days == 0 and since_hours == 0)
         else Bookshelves.most_logged_books(
             since=dateutil.todays_date_minus(days=since_days, hours=since_hours),
@@ -70,10 +73,12 @@ def get_trending_books(
             fetch=True,
             sort_by_count=sort_by_count,
             minimum=minimum,
+            fields=list( WorkSearchScheme.default_fetched_fields
+                | {'subject', 'person', 'place', 'time', 'edition_key'}
         )
     )
     return (
-        [book['work'] for book in logged_books if book.get('work')]
+        [book['work'] for book in logged_books if book.get('work,')]
         if books_only
         else logged_books
     )
@@ -156,7 +161,8 @@ class lending_stats(app.view):
         raise web.seeother("/")
 
 
-def get_activity_stream(limit=None, page=1):
+def get_activity_stream(limit=None, page=1,  fields=list( WorkSearchScheme.default_fetched_fields
+                | {'subject', 'person', 'place', 'time', 'edition_key'}):
     # enable to work w/ cached
     if 'env' not in web.ctx:
         delegate.fakeload()


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8325 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] --> 
Allows fields attribute to be passed as an argument when trying to query trending books 


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
I tried running trending queries locally 
http://localhost:8080/trending/monthly.json?limit=10&page=1&fields=key,title,edition_count
They are not erroring out per se, but want to know how to test this change better. 

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
