### PR TITLE
Update create and update permissions for Tags

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -7828,6 +7828,10 @@ msgstr ""
 msgid "Tag type"
 msgstr ""
 
+#: type/tag/tag_form_inputs.html
+msgid "Tag Deputy"
+msgstr ""
+
 #: type/tag/view.html
 #, python-format
 msgid "<strong>Type:</strong> %(tag_type)s"

--- a/openlibrary/plugins/upstream/addtag.py
+++ b/openlibrary/plugins/upstream/addtag.py
@@ -215,7 +215,9 @@ class tag_edit(delegate.page):
         is_in_permitted_group = patron.is_admin()
         is_deputy = patron.key == tag.get("deputy", None)
 
-        if not is_in_permitted_group and (tag.tag_type in SUBJECT_SUB_TYPES and not is_deputy):
+        if not is_in_permitted_group and (
+            tag.tag_type in SUBJECT_SUB_TYPES and not is_deputy
+        ):
             return False
 
         return True

--- a/openlibrary/plugins/upstream/addtag.py
+++ b/openlibrary/plugins/upstream/addtag.py
@@ -215,12 +215,10 @@ class tag_edit(delegate.page):
         is_in_permitted_group = patron.is_admin()
         is_deputy = patron.key == tag.get("deputy", None)
 
-        if not is_in_permitted_group and (
-            tag.tag_type in SUBJECT_SUB_TYPES and not is_deputy
-        ):
-            return False
+        if is_in_permitted_group:
+            return True
 
-        return True
+        return tag.tag_type in SUBJECT_SUB_TYPES and is_deputy
 
 
 class tag_search(delegate.page):

--- a/openlibrary/plugins/upstream/addtag.py
+++ b/openlibrary/plugins/upstream/addtag.py
@@ -93,11 +93,9 @@ class addtag(delegate.page):
 
     def has_permission(self, user) -> bool:
         """
-        Can a tag be added?
+        Returns True if the given user can create a new Tag
         """
-        return user and (
-            user.is_librarian() or user.is_super_librarian() or user.is_admin()
-        )
+        return user and user.is_admin()
 
     def POST(self):
         i = web.input(
@@ -142,29 +140,31 @@ class tag_edit(delegate.page):
     path = r"(/tags/OL\d+T)/edit"
 
     def GET(self, key):
-        if not web.ctx.site.can_write(key):
+        tag = web.ctx.site.get(key)
+        if tag is None:
+            raise web.notfound()
+
+        if not self.has_permission(tag):
             return render_template(
                 "permission_denied",
                 web.ctx.fullpath,
                 "Permission denied to edit " + key + ".",
             )
-        i = web.input(redir=None)
-        tag = web.ctx.site.get(key)
-        if tag is None:
-            raise web.notfound()
 
+        i = web.input(redir=None)
         return render_template("type/tag/form", tag, redirect=i.redir)
 
     def POST(self, key):
-        if not web.ctx.site.can_write(key):
+        tag = web.ctx.site.get(key)
+        if tag is None:
+            raise web.notfound()
+
+        if not self.has_permission(tag):
             return render_template(
                 "permission_denied",
                 web.ctx.fullpath,
                 "Permission denied to edit " + key + ".",
             )
-        tag = web.ctx.site.get(key)
-        if tag is None:
-            raise web.notfound()
 
         i = web.input(_comment=None, redir=None)
         formdata = trim_doc(i)
@@ -199,6 +199,26 @@ class tag_edit(delegate.page):
             return validate_subject_tag(data)
         else:
             return validate_tag(data)
+
+    def has_permission(self, tag):
+        """
+        Returns `True` if the current user is permitted to edit a tag.
+
+        :param tag: A Tag object
+        :return: True if current user can edit a tag, False otherwise
+        """
+        if not web.ctx.site.can_write(tag.key):
+            return False
+        if not (patron := get_current_user()):
+            return False
+
+        is_in_permitted_group = patron.is_admin()
+        is_deputy = patron.key == tag.get("deputy", None)
+
+        if not is_in_permitted_group and (tag.tag_type in SUBJECT_SUB_TYPES and not is_deputy):
+            return False
+
+        return True
 
 
 class tag_search(delegate.page):

--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -2,7 +2,7 @@ $def with (page)
 
 $var title: $page.name
 
-$ can_add_tag = ctx.user and (ctx.user.is_super_librarian())
+$ can_add_tag = ctx.user and (ctx.user.is_admin())
 $ has_tag = 'tag' in page
 $ q = query_param('q')
 

--- a/openlibrary/templates/type/tag/tag_form_inputs.html
+++ b/openlibrary/templates/type/tag/tag_form_inputs.html
@@ -14,7 +14,7 @@ $ tag_description = page and page.get('tag_description', '')
 <fieldset class="major">
     <div class="formElement">
         <div class="label">
-            <label for="tag_description">$_("Tag Description")</label>
+            <label for="tag_description">$_("Tag Description")</label>*<span class="tip">$_("Required field")</span>
         </div>
         <div class="input">
             <textarea id="tag_description" name="tag_description" rows="5" cols="80" required>$tag_description</textarea>
@@ -26,7 +26,7 @@ $ body = page and page.get('body', '')
 <fieldset class="major">
     <div class="formElement">
         <div class="label">
-            <label for="page_body">$_("Page Body")</label>
+            <label for="page_body">$_("Page Body")</label>*<span class="tip">$_("Required field")</span>
         </div>
         <div class="input">
             <textarea id="page_body" name="body" rows="5" cols="50" class="markdown" required>$body</textarea>
@@ -36,7 +36,7 @@ $ body = page and page.get('body', '')
 
 $ tag_type = page and page.get('tag_type', '')
 <div class="formElement">
-    <div class="label"><label for="tag_type">$_("Tag type")</label></div>
+    <div class="label"><label for="tag_type">$_("Tag type")</label>*<span class="tip">$_("Required field")</span></div>
     <div class="input">
         <select name="tag_type" required aria-label="Select a tag type">
             <option value="">$_("Select")</option>

--- a/openlibrary/templates/type/tag/tag_form_inputs.html
+++ b/openlibrary/templates/type/tag/tag_form_inputs.html
@@ -49,3 +49,11 @@ $ tag_type = page and page.get('tag_type', '')
         </select>
     </div>
 </div>
+
+$ deputy = page and page.get('deputy', '')
+<div class="formElement">
+    <div class="label"><label for="deputy">$_("Tag Deputy")</label></div>
+    <div class="input">
+        <input type="text" name="deputy" id="deputy" value="$deputy">
+    </div>
+</div>


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Makes the following changes:

1. Adds a new `deputy` field to tag create and edit forms
2. Updates permissions for adding and editing tags
3. Changes validation order in tag editing handlers
4. Better denotes what fields are required in tag create/edit forms

New permissions are as follows:
| Action | Permitted Parties |
|---|---|
| Creating a new tag (any type) | `/usergroup/admin` members |
| Editing a non-subject type tag | `/usergroup/admin` members |
| Editing a subject tag | `/usergroup/admin` members and the tag's designated `deputy` |

### Technical
<!-- What should be noted about the implementation? -->
`deputy` is not a required field for any tag type, so all tags can be created without one.  The `deputy` field stores a patron's `User` key (`/people/{person}`) if a deputy exists.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
