### PR TITLE
Refactor year breadcrumb select to take in yearly_reads

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -2159,8 +2159,7 @@ msgstr ""
 msgid "This Year"
 msgstr ""
 
-#: account/view.html admin/index.html books/year_breadcrumb_select.html
-#: trending.html
+#: admin/index.html books/year_breadcrumb_select.html trending.html
 msgid "All Time"
 msgstr ""
 

--- a/openlibrary/templates/account/view.html
+++ b/openlibrary/templates/account/view.html
@@ -30,7 +30,7 @@ $var title: $header_title
             $:render_template("books/mybooks_breadcrumb_select", mb, selected=header_title)
 
             $if mb.key == 'already-read' and mb.yearly_reads:
-              $ url_prefix = "/people/%s/books/already-read/" % yearly_reads.username
+              $ url_prefix = "/people/%s/books/already-read" % yearly_reads.username
               $:render_template("books/year_breadcrumb_select", mb.yearly_reads, url_prefix, url_prefix + "/year/%d", selected=selected_year)
 
           </div>

--- a/openlibrary/templates/account/view.html
+++ b/openlibrary/templates/account/view.html
@@ -31,7 +31,7 @@ $var title: $header_title
 
             $if mb.key == 'already-read' and mb.yearly_reads:
               $ url_prefix = "/people/%s/books/already-read" % yearly_reads.username
-              $:render_template("books/year_breadcrumb_select", mb.yearly_reads, url_prefix, url_prefix + "/year/%d", selected=selected_year)
+              $:render_template("books/year_breadcrumb_select", mb.yearly_reads, url_prefix, url_prefix + "/year/%d", selected=mb.selected_year)
 
           </div>
       </div>

--- a/openlibrary/templates/account/view.html
+++ b/openlibrary/templates/account/view.html
@@ -30,7 +30,7 @@ $var title: $header_title
             $:render_template("books/mybooks_breadcrumb_select", mb, selected=header_title)
 
             $if mb.key == 'already-read' and mb.yearly_reads:
-              $ url_prefix = "/people/%s/books/already-read" % yearly_reads.username
+              $ url_prefix = "/people/%s/books/already-read" % mb.username
               $:render_template("books/year_breadcrumb_select", mb.yearly_reads, url_prefix, url_prefix + "/year/%d", selected=mb.selected_year)
 
           </div>

--- a/openlibrary/templates/account/view.html
+++ b/openlibrary/templates/account/view.html
@@ -30,8 +30,8 @@ $var title: $header_title
             $:render_template("books/mybooks_breadcrumb_select", mb, selected=header_title)
 
             $if mb.key == 'already-read' and mb.yearly_reads:
-              $ selected_year = mb.selected_year if mb.selected_year else _("All Time")
-              $:render_template("books/year_breadcrumb_select", mb, selected=selected_year)
+              $ url_prefix = "/people/%s/books/already-read/" % yearly_reads.username
+              $:render_template("books/year_breadcrumb_select", mb.yearly_reads, url_prefix, url_prefix + "/year/%d", selected=selected_year)
 
           </div>
       </div>

--- a/openlibrary/templates/books/year_breadcrumb_select.html
+++ b/openlibrary/templates/books/year_breadcrumb_select.html
@@ -1,10 +1,8 @@
-$def with (mb, selected=_("All Time"))
+$def with (yearly_reads, all_time_url, year_url, selected=_("All Time"))
 
-$ url_prefix = "/people/%s/books/already-read/" % mb.username
-
-$ options = [(_("All Time"), url_prefix)]
-$if mb.is_my_page or mb.is_public:
-  $for (year, count) in mb.yearly_reads:
-    $ options += [("%d (%d)" % (year, count), url_prefix + "/year/%d/" % year)]
+$ selected = selected or _("All Time")
+$ options = [(_("All Time"), all_time_url)]
+$for (year, count) in yearly_reads:
+  $ options += [("%d (%d)" % (year, count), year_url % year)]
 
 $:render_template("books/breadcrumb_select", selected, options)


### PR DESCRIPTION
Small refactor to make #10648 easier. Make `year_breadcrumb_select` more configurable so it can be used from other pages.

### Technical
<!-- What should be noted about the implementation? -->
Please squash before merging.

### Testing
Confirmed working on testing.
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
