### PR TITLE
Lazy-load book page "Lists" section

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -1165,6 +1165,10 @@ msgstr ""
 msgid "Lists (%(count)d)"
 msgstr ""
 
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "This work does not appear on any lists."
+msgstr ""
+
 #: openlibrary/plugins/upstream/account.py
 msgid "The email address you entered is invalid"
 msgstr ""
@@ -7558,7 +7562,7 @@ msgid "Wikipedia"
 msgstr ""
 
 #: type/edition/view.html type/work/view.html
-msgid "This work does not appear on any lists."
+msgid "Loading Lists"
 msgstr ""
 
 #: type/edition/view.html type/work/view.html

--- a/openlibrary/plugins/openlibrary/js/book-page-lists.js
+++ b/openlibrary/plugins/openlibrary/js/book-page-lists.js
@@ -5,8 +5,8 @@
  */
 export function initListsSection(elem) {
     // Show loading indicator
-    const loadingIndicator = elem.querySelector(".loadingIndicator")
-    loadingIndicator.classList.remove("hidden")
+    const loadingIndicator = elem.querySelector('.loadingIndicator')
+    loadingIndicator.classList.remove('hidden')
 
     const ids = JSON.parse(elem.dataset.ids)
 
@@ -27,7 +27,7 @@ export function initListsSection(elem) {
                         const fragment = document.createDocumentFragment()
 
                         for (const htmlString of data.partials) {
-                            const template = document.createElement("template")
+                            const template = document.createElement('template')
                             template.innerHTML = htmlString
                             fragment.append(...template.content.childNodes)
                         }
@@ -36,9 +36,9 @@ export function initListsSection(elem) {
 
                         // Show "See All" link
                         if (data.hasLists) {
-                            const showAllLink = elem.querySelector(".lists-heading a")
+                            const showAllLink = elem.querySelector('.lists-heading a')
                             if (showAllLink) {
-                                showAllLink.classList.remove("hidden")
+                                showAllLink.classList.remove('hidden')
                             }
                         }
                     })
@@ -46,7 +46,7 @@ export function initListsSection(elem) {
         })
     }, {
         root: null,
-        rootMargin: "200px",
+        rootMargin: '200px',
         threshold: 0
     })
 
@@ -54,7 +54,7 @@ export function initListsSection(elem) {
 }
 
 async function fetchPartials(workId, editionId) {
-    const params = { _component: "BPListsSection" }
+    const params = { _component: 'BPListsSection' }
     if (workId) {
         params.workId = workId
     }

--- a/openlibrary/plugins/openlibrary/js/book-page-lists.js
+++ b/openlibrary/plugins/openlibrary/js/book-page-lists.js
@@ -1,0 +1,66 @@
+/**
+ * Initializes lazy-loading the "Lists" section of Open Library book pages.
+ *
+ * @param elem {HTMLElement} Container for book page lists section
+ */
+export function initListsSection(elem) {
+    // Show loading indicator
+    const loadingIndicator = elem.querySelector(".loadingIndicator")
+    loadingIndicator.classList.remove("hidden")
+
+    const ids = JSON.parse(elem.dataset.ids)
+
+    const intersectionObserver = new IntersectionObserver((entries) => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                // Unregister intersection listener
+                intersectionObserver.unobserve(entries[0].target)
+                fetchPartials(ids.work, ids.edition)
+                    .then((resp) => {
+                        // Check response code, continue if not 4XX or 5XX
+
+                        return resp.json()
+                    })
+                    .then((data) => {
+                        // Replace loading indicator with partials
+                        const listSection = loadingIndicator.parentElement
+                        const fragment = document.createDocumentFragment()
+
+                        for (const htmlString of data.partials) {
+                            const template = document.createElement("template")
+                            template.innerHTML = htmlString
+                            fragment.append(...template.content.childNodes)
+                        }
+
+                        listSection.replaceChildren(fragment)
+
+                        // Show "See All" link
+                        if (data.hasLists) {
+                            const showAllLink = elem.querySelector(".lists-heading a")
+                            if (showAllLink) {
+                                showAllLink.classList.remove("hidden")
+                            }
+                        }
+                    })
+            }
+        })
+    }, {
+        root: null,
+        rootMargin: "200px",
+        threshold: 0
+    })
+
+    intersectionObserver.observe(elem)
+}
+
+async function fetchPartials(workId, editionId) {
+    const params = { _component: "BPListsSection" }
+    if (workId) {
+        params.workId = workId
+    }
+    if (editionId) {
+        params.editionId = editionId
+    }
+    const searchParams = new URLSearchParams(params)
+    return fetch(`/partials.json?${searchParams.toString()}`)
+}

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -563,4 +563,11 @@ jQuery(function () {
         import (/* webpackChunkName: "go-back-links" */ './go-back-links')
             .then(module => module.initGoBackLinks(backLinks))
     }
+
+    // Lazy-load book page lists section
+    const listSection = document.querySelector(".lists-section")
+    if (listSection) {
+        import(/* webpackChunkName: "book-page-lists" */ "./book-page-lists")
+            .then(module => module.initListsSection(listSection))
+    }
 });

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -565,9 +565,9 @@ jQuery(function () {
     }
 
     // Lazy-load book page lists section
-    const listSection = document.querySelector(".lists-section")
+    const listSection = document.querySelector('.lists-section')
     if (listSection) {
-        import(/* webpackChunkName: "book-page-lists" */ "./book-page-lists")
+        import(/* webpackChunkName: "book-page-lists" */ './book-page-lists')
             .then(module => module.initListsSection(listSection))
     }
 });

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -231,17 +231,26 @@ class Partials(delegate.page):
             edition = web.ctx.site.get(edition_id) or {}
 
             # Do checks and render
-            has_lists = (work and work.get_lists(limit=1)) or (edition and edition.get_lists(limit=1))
+            has_lists = (work and work.get_lists(limit=1)) or (
+                edition and edition.get_lists(limit=1)
+            )
             partial["hasLists"] = bool(has_lists)
 
             if not has_lists:
                 partial["partials"].append(_('This work does not appear on any lists.'))
             else:
                 if work and work.key:
-                    work_list_template = render_template("lists/widget", work, include_header=False, include_widget=False)
+                    work_list_template = render_template(
+                        "lists/widget", work, include_header=False, include_widget=False
+                    )
                     partial["partials"].append(str(work_list_template))
                 if edition and edition.get("type", "") != "/type/edition":
-                    edition_list_template = render_template("lists/widget", edition, include_header=False, include_widget=False)
+                    edition_list_template = render_template(
+                        "lists/widget",
+                        edition,
+                        include_header=False,
+                        include_widget=False,
+                    )
                     partial["partials"].append(str(edition_list_template))
 
         return delegate.RawText(json.dumps(partial), content_type='application/json')

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -8,6 +8,7 @@ from infogami.utils.view import render_template
 from openlibrary.core import cache
 from openlibrary.core.fulltext import fulltext_search
 from openlibrary.core.lending import compose_ia_url, get_available
+from openlibrary.i18n import gettext as _
 from openlibrary.plugins.worksearch.code import do_search, work_search
 from openlibrary.plugins.worksearch.subjects import get_subject
 from openlibrary.utils import dateutil
@@ -219,6 +220,29 @@ class Partials(delegate.page):
                     'macros'
                 ].FulltextSearchSuggestion(query, data)
             partial = {"partials": str(macro)}
+        elif component == "BPListsSection":
+            partial = {"partials": []}
+
+            # Get work and edition
+            work_id = i.get("workId", "")
+            edition_id = i.get("editionId", "")
+
+            work = web.ctx.site.get(work_id) or {}
+            edition = web.ctx.site.get(edition_id) or {}
+
+            # Do checks and render
+            has_lists = (work and work.get_lists(limit=1)) or (edition and edition.get_lists(limit=1))
+            partial["hasLists"] = bool(has_lists)
+
+            if not has_lists:
+                partial["partials"].append(_('This work does not appear on any lists.'))
+            else:
+                if work and work.key:
+                    work_list_template = render_template("lists/widget", work, include_header=False, include_widget=False)
+                    partial["partials"].append(str(work_list_template))
+                if edition and edition.get("type", "") != "/type/edition":
+                    edition_list_template = render_template("lists/widget", edition, include_header=False, include_widget=False)
+                    partial["partials"].append(str(edition_list_template))
 
         return delegate.RawText(json.dumps(partial), content_type='application/json')
 

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -79,7 +79,6 @@ $if editions and not edition:
 
 $# Just in case edition is not set, treat as work
 $ edition = edition or page
-$ is_editionless_work = edition.type != '/type/edition'
 
 $if not edition.get('availability'):
   $ edition['availability'] = edition.get('ocaid') and availabilities.get(edition['ocaid']) or {}
@@ -524,33 +523,29 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
         $:render_template("observations/review_component", work, reader_observations, page.key)
         $ component_times['Review component'] = time() - component_times['Review component']
       <a id="lists-section" class="section-anchor"></a>
-      <div class="workFooter tab-section">
-        $# pages like /books/ia:foo00bar are fake records created from metadata API.
-        $# Adding them to lists doesn't work. Disabling it to avoid any issues.
-        $if "lists" in ctx.features and not page.is_fake_record():
+      $# pages like /books/ia:foo00bar are fake records created from metadata API.
+      $# Adding them to lists doesn't work. Disabling it to avoid any issues.
+      $if "lists" in ctx.features and not page.is_fake_record():
+        $ component_times['Lists section'] = time()
+        $code:
+          data_ids = {}
+          if work and work.key:
+            data_ids["work"] = work.key
+          if edition and edition.key:
+            data_ids["edition"] = edition.key
+        <div class="workFooter tab-section lists-section" data-ids="$json_encode(data_ids)">
           <div class="lists-heading">
             <h2 class="lists-title">$_('Lists')</h2>
-            $ has_lists = False
-            $if (work and work.get_lists()) or (edition and edition.get_lists()):
-              $ has_lists = True
-            $if has_lists:
-              <a href="$page.url()/lists">$_('See All')</a>
+            <a class="hidden" href="$page.url()/lists">$_('See All')</a>
           </div>
           <div class="user-book-options">
             <div class="Tools tools-override">
-              $if work and work.key:
-                $ component_times['lists widget: WorkListTime'] = time()
-                $:render_template("lists/widget", work, include_header=False, include_widget=False)
-                $ component_times['lists widget: WorkListTime'] = time() - component_times['lists widget: WorkListTime']
-              $if edition and is_editionless_work:
-                $ component_times['lists widget: EditionListTime'] = time()
-                $:render_template("lists/widget", edition, include_header=False, include_widget=False)
-                $ component_times['lists widget: EditionListTime'] = time() - component_times['lists widget: EditionListTime']
-              $if not has_lists:
-                $_('This work does not appear on any lists.')
+                $:macros.LoadingIndicator(_("Loading Lists"))
             </div>
           </div>
-      </div>
+        </div>
+        $ component_times['Lists section'] = time() - component_times['Lists section']
+
       <a id="related-work-carousel" class="section-anchor"></a>
     </div>
   </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10653

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Replaces initial book page "Lists" section with a loading indicator. Whenever a patron scroll withing `200px` of the "Lists" section, a `/partials` request is made for the section's content and the view is updated with the results.

If either the work or edition is on a list, the "See All" link becomes visible.  This link was previously conditionally rendered, but is now always rendered with the `hidden` class.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
