### PR TITLE
Update i18n-messages regex to match any word boundary

### DIFF
--- a/scripts/i18n-messages
+++ b/scripts/i18n-messages
@@ -31,7 +31,7 @@ def main(cmd, args):
         # Using shell=True, because otherwise the *.py seems to cause trouble
         # on some systems, resulting in no python files being extracted.
         py_sources = subprocess.run(
-            "grep -rlF ' _(' openlibrary/ --include '*.py'",
+            "grep -wrlF '_(' openlibrary/ --include '*.py'",
             shell=True,
             capture_output=True,
             check=False,


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10655

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

Use grep's `-w, --word-regexp` option to make the pattern only match between word boundaries.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Before:

1. Add `foo.append(_("FOO"))` to `openlibrary/core/db.py` 
2. Run `python ./scripts/i18n-messages extract --skip-untracked`

db.py does not get added to messages.pot

After:

db.py appears in messages.pot!

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
