### PR TITLE
Ensure OLID exists before fetching book data

### DIFF
--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -227,8 +227,8 @@ class Partials(delegate.page):
             work_id = i.get("workId", "")
             edition_id = i.get("editionId", "")
 
-            work = work_id and web.ctx.site.get(work_id) or {}
-            edition = edition_id and web.ctx.site.get(edition_id) or {}
+            work = (work_id and web.ctx.site.get(work_id)) or {}
+            edition = (edition_id and web.ctx.site.get(edition_id)) or {}
 
             # Do checks and render
             has_lists = (work and work.get_lists(limit=1)) or (

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -227,8 +227,8 @@ class Partials(delegate.page):
             work_id = i.get("workId", "")
             edition_id = i.get("editionId", "")
 
-            work = web.ctx.site.get(work_id) or {}
-            edition = web.ctx.site.get(edition_id) or {}
+            work = work_id and web.ctx.site.get(work_id) or {}
+            edition = edition_id and web.ctx.site.get(edition_id) or {}
 
             # Do checks and render
             has_lists = (work and work.get_lists(limit=1)) or (


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Follow-up to #10654 

As per this new Sentry [event](https://sentry.archive.org/organizations/ia-ux/issues/546262/events/f20e51d84cfe4390bb45d7e8cd6f8772/), some list section partial requests are failing when empty strings are passed to `web.ctx.site.get()`.  These changes ensure that a `work_id` or `edition_id` exist before making the `get()` call.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
