### PR TITLE
Access book `title` safely

### DIFF
--- a/openlibrary/templates/books/custom_carousel_card.html
+++ b/openlibrary/templates/books/custom_carousel_card.html
@@ -3,7 +3,7 @@ $def with(book, lazy, layout, key="", secondary_action=False)
 $ fallback_cover = 'https://openlibrary.org/images/icons/avatar_book.png'
 $ cover_host = '//covers.openlibrary.org'
 $ url = book.get('key') or book.url
-$ title = book.title
+$ title = book.get("title", "")
 
 $ cover_id = book.get('cover_id') or book.get('cover_i') or book.get('covers') and book['covers'][0]
 $if book.get('cover_url'):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Follow-up to #10580 

Addresses this [Sentry event](https://sentry.archive.org/organizations/ia-ux/issues/545353/events/26b911937c53424cb6971758be9ebdcc/), in which a book's `title` is accessed but not extant.

These changes default a book's `title` to an empty string when carsousel cards are rendered.  Is this what we want to do, or is there a more appropriate default? 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
