### PR TITLE
Restore MIT Press carousel

### DIFF
--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -39,7 +39,7 @@ $add_metatag(property="og:site_name", content="Open Library")
     $:macros.QueryCarousel(query="subject:thrillers ratings_count:[10 TO *] ebook_access:[borrowable TO *]", title=_('Thrillers'), key="thrillers", url="/subjects/thrillers", sort='random.hourly', use_cache=False)
     $:macros.QueryCarousel(query="subject_key:textbooks publish_year:[1990 TO *] readinglog_count :[5 TO *] ebook_access:[borrowable TO *]", title=_('Textbooks'), key="textbooks", url="/subjects/textbooks", sort='random.hourly', use_cache=False)
 
-  $:render_template("home/custom_ia_carousel", title="Authors Alliance & MIT Press", key="authorsalliance_mit_press", query="preset:authorsalliance_mitpress", limit=18, test=test)
+  $:render_template("home/custom_ia_carousel", title="Authors Alliance & MIT Press", key="authorsalliance_mit_press", query="preset:authorsalliance_mitpress", sorts=["lending___last_browse desc"], limit=18, test=test)
 
   $:render_template("home/categories", test=test)
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10659

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Restores Authors Alliance / MIT Press carousel by adding sorting criteria.  Without a value for `sorts`, the `/advancedsearch.php` request ended with `sort[]=`.  Such requests resulted in `400`s.

All other homepage `custom_ia_carousels` use `["lending___last_browse desc"]` as the sorts value.  Adding the same to the MIT Press carousel fixed the issue.  I'm not sure if this is exactly how we want to sort these books --- reviewers should feel free to suggest another way if they are so moved.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot 2025-04-03 144824](https://github.com/user-attachments/assets/a3206caa-8d60-4fb9-a2cb-0af82de046da)
_Screenshot from testing environment_

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
