### PR TITLE
Allow Reading Stats to filter stats by year

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -2159,7 +2159,8 @@ msgstr ""
 msgid "This Year"
 msgstr ""
 
-#: account/view.html admin/index.html books/year_breadcrumb_select.html
+#: account/readinglog_stats.html account/view.html admin/index.html
+#: books/stats_year_breadcrumb_select.html books/year_breadcrumb_select.html
 #: trending.html
 msgid "All Time"
 msgstr ""

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -2163,8 +2163,7 @@ msgstr ""
 msgid "This Year"
 msgstr ""
 
-
-#: account/readinglog_stats.html account/view.html admin/index.html
+#: account/readinglog_stats.html admin/index.html
 #: books/stats_year_breadcrumb_select.html books/year_breadcrumb_select.html
 #: trending.html
 msgid "All Time"

--- a/openlibrary/templates/account/readinglog_stats.html
+++ b/openlibrary/templates/account/readinglog_stats.html
@@ -1,4 +1,4 @@
-$def with (works_json, authors_json, works_count, owner_key, owner_name, shelf_path, shelf_key, lang='en')
+$def with (works_json, authors_json, works_count, owner_key, owner_name, shelf_path, shelf_key, year, yearly_reads, lang='en')
 
 $ reading_log_stats_config = {
 $    'works': works_json,
@@ -104,6 +104,15 @@ $jsdef render_excluded_works_list(works, total):
         &raquo;
     </div>
     <h1>$_('My %(shelf_name)s Stats', shelf_name=shelf_name)</h1>
+    $code:
+        mb=MyBooksTemplate(username=owner_key.split('/')[-1] ,key='mybooks')
+    $if shelf_key == 'already-read' and yearly_reads:
+    <div class="breadcrumb-wrapper">
+        <div class="sansserif grey account-settings-menu navigation-breadcrumbs">
+            $ selected_year = str(year) if year else _("All Time")
+            $:render_template("books/stats_year_breadcrumb_select",mb, yearly_reads, selected= selected_year)
+        </div>
+    </div>
 
     <p>$:_('Displaying stats about <strong>%(works_count)d</strong> books. Note all charts show only the top 20 bars. Note reading log stats are private.', works_count=works_count)</p>
 </div>

--- a/openlibrary/templates/books/stats_year_breadcrumb_select.html
+++ b/openlibrary/templates/books/stats_year_breadcrumb_select.html
@@ -1,0 +1,10 @@
+$def with (mb, yearly_reads,selected=_("All Time"))
+
+$ url_prefix = "/people/%s/books/already-read/stats/" % mb.username
+
+$ options = [(_("All Time"), url_prefix)]
+$if mb.is_my_page or mb.is_public:
+  $for (year, count) in yearly_reads:
+    $ options += [("%s (%s)" % (year, count), url_prefix + "/%s/" % year)]
+
+$:render_template("books/breadcrumb_select", selected, options)


### PR DESCRIPTION
Addressed Issue #10648, added filter by year dropdown to the "already read" stats page. I needed to add a new html template for the breadcrumbing as it uesd a different url prefix than that of year_breadcrumb_select.html (and I didn't want to change the interface) 