### PR TITLE
Replace partials handler conditional with factory

### DIFF
--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -1,5 +1,6 @@
 import json
 from abc import abstractmethod, ABC
+from typing import Type, cast
 from urllib.parse import parse_qs
 
 import web
@@ -262,12 +263,12 @@ class BookPageListsPartial(PartialDataHandler):
         self.i = web.input(workId="", editionId="")
 
     def generate(self) -> dict:
-        results = {"partials": []}
+        results: dict = {"partials": []}
         work_id = self.i.workId
         edition_id = self.i.editionId
 
-        work = (work_id and web.ctx.site.get(work_id)) or {}
-        edition = (edition_id and web.ctx.site.get(edition_id)) or {}
+        work = (work_id and web.ctx.site.get(work_id)) or None
+        edition = (edition_id and web.ctx.site.get(edition_id)) or None
 
         # Do checks and render
         has_lists = (work and work.get_lists(limit=1)) or (
@@ -352,7 +353,8 @@ class PartialRequestResolver:
     def get_handler(cls, component: str) -> PartialDataHandler:
         """Instantiates and returns the requested handler"""
         if klass := cls.component_mapping.get(component):
-            return klass()
+            concrete_class = cast(Type[PartialDataHandler], klass)
+            return concrete_class()
         raise PartialResolutionError(f'No handler found for key "{component}"')
 
 

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -1,6 +1,6 @@
 import json
-from abc import abstractmethod, ABC
-from typing import Type, cast
+from abc import ABC, abstractmethod
+from typing import cast
 from urllib.parse import parse_qs
 
 import web
@@ -28,6 +28,7 @@ class PartialDataHandler(ABC):
     JSON-serializable dict that contains data necessary to update
     a page.
     """
+
     @abstractmethod
     def generate(self) -> dict:
         pass
@@ -35,6 +36,7 @@ class PartialDataHandler(ABC):
 
 class RelatedWorksPartial(PartialDataHandler):
     """Handler for the related works carousels."""
+
     def __init__(self):
         self.i = web.input(workid=None)
 
@@ -58,6 +60,7 @@ class RelatedWorksPartial(PartialDataHandler):
             memoized_get_component_metadata(*args, **kwargs)
             or memoized_get_component_metadata.update(*args, **kwargs)[0]
         )
+
 
 class CarouselCardPartial(PartialDataHandler):
     """Handler for carousel "load_more" requests"""
@@ -184,9 +187,7 @@ class AffiliateLinksPartial(PartialDataHandler):
         if len(args) < 2:
             raise PartialResolutionError("Unexpected amount of arguments")
 
-        macro = web.template.Template.globals['macros'].AffiliateLinks(
-            args[0], args[1]
-        )
+        macro = web.template.Template.globals['macros'].AffiliateLinks(args[0], args[1])
         return {"partials": str(macro)}
 
 
@@ -204,9 +205,7 @@ class SearchFacetsPartial(PartialDataHandler):
         param = data.get('param', {})
 
         sort = None
-        search_response = do_search(
-            param, sort, rows=0, spellcheck_count=3, facet=True
-        )
+        search_response = do_search(param, sort, rows=0, spellcheck_count=3, facet=True)
 
         sidebar = render_template(
             'search/work_search_facets',
@@ -250,9 +249,9 @@ class FullTextSuggestionsPartial(PartialDataHandler):
         if not hits['hits']:
             macro = '<div></div>'
         else:
-            macro = web.template.Template.globals[
-                'macros'
-            ].FulltextSearchSuggestion(query, data)
+            macro = web.template.Template.globals['macros'].FulltextSearchSuggestion(
+                query, data
+            )
         return {"partials": str(macro)}
 
 
@@ -272,7 +271,7 @@ class BookPageListsPartial(PartialDataHandler):
 
         # Do checks and render
         has_lists = (work and work.get_lists(limit=1)) or (
-                edition and edition.get_lists(limit=1)
+            edition and edition.get_lists(limit=1)
         )
         results["hasLists"] = bool(has_lists)
 
@@ -301,16 +300,16 @@ class LazyCarouselPartial(PartialDataHandler):
 
     def __init__(self):
         self.i = web.input(
-                query="",
-                title=None,
-                sort="new",
-                key="",
-                limit=20,
-                search=False,
-                has_fulltext_only=True,
-                url=None,
-                layout="carousel",
-            )
+            query="",
+            title=None,
+            sort="new",
+            key="",
+            limit=20,
+            search=False,
+            has_fulltext_only=True,
+            url=None,
+            layout="carousel",
+        )
         self.i.search = self.i.search != "false"
         self.i.has_fulltext_only = self.i.has_fulltext_only != "false"
 
@@ -353,7 +352,7 @@ class PartialRequestResolver:
     def get_handler(cls, component: str) -> PartialDataHandler:
         """Instantiates and returns the requested handler"""
         if klass := cls.component_mapping.get(component):
-            concrete_class = cast(Type[PartialDataHandler], klass)
+            concrete_class = cast(type[PartialDataHandler], klass)
             return concrete_class()
         raise PartialResolutionError(f'No handler found for key "{component}"')
 
@@ -365,7 +364,10 @@ class Partials(delegate.page):
     def GET(self):
         i = web.input(_component=None)
         component = i.pop("_component")
-        return delegate.RawText(json.dumps(PartialRequestResolver.resolve(component)), content_type='application/json')
+        return delegate.RawText(
+            json.dumps(PartialRequestResolver.resolve(component)),
+            content_type='application/json',
+        )
 
 
 def setup():

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -1,4 +1,5 @@
 import json
+from abc import abstractmethod, ABC
 from urllib.parse import parse_qs
 
 import web
@@ -15,27 +16,51 @@ from openlibrary.utils import dateutil
 from openlibrary.views.loanstats import get_trending_books
 
 
-def _get_relatedcarousels_component(workid):
-    if 'env' not in web.ctx:
-        delegate.fakeload()
-    work = web.ctx.site.get('/works/%s' % workid) or {}
-    component = render_template('books/RelatedWorksCarousel', work)
-    return {0: str(component)}
+class PartialResolutionError(Exception):
+    pass
 
 
-def get_cached_relatedcarousels_component(*args, **kwargs):
-    memoized_get_component_metadata = cache.memcache_memoize(
-        _get_relatedcarousels_component,
-        "book.bookspage.component.relatedcarousels",
-        timeout=dateutil.HALF_DAY_SECS,
-    )
-    return (
-        memoized_get_component_metadata(*args, **kwargs)
-        or memoized_get_component_metadata.update(*args, **kwargs)[0]
-    )
+class PartialDataHandler(ABC):
+    """Base class for partial data handlers.
+
+    Has a single method, `generate`, that is expected to return a
+    JSON-serializable dict that contains data necessary to update
+    a page.
+    """
+    @abstractmethod
+    def generate(self) -> dict:
+        pass
 
 
-class CarouselCardPartial:
+class RelatedWorksPartial(PartialDataHandler):
+    """Handler for the related works carousels."""
+    def __init__(self):
+        self.i = web.input(workid=None)
+
+    def generate(self) -> dict:
+        return self._get_relatedcarousels_component(self.i.workid)
+
+    def _get_relatedcarousels_component(self, workid) -> dict:
+        if 'env' not in web.ctx:
+            delegate.fakeload()
+        work = web.ctx.site.get('/works/%s' % workid) or {}
+        component = render_template('books/RelatedWorksCarousel', work)
+        return {0: str(component)}
+
+    def _get_cached_relatedcarousels_component(self, *args, **kwargs):
+        memoized_get_component_metadata = cache.memcache_memoize(
+            self._get_relatedcarousels_component,
+            "book.bookspage.component.relatedcarousels",
+            timeout=dateutil.HALF_DAY_SECS,
+        )
+        return (
+            memoized_get_component_metadata(*args, **kwargs)
+            or memoized_get_component_metadata.update(*args, **kwargs)[0]
+        )
+
+class CarouselCardPartial(PartialDataHandler):
+    """Handler for carousel "load_more" requests"""
+
     MAX_VISIBLE_CARDS = 5
 
     def __init__(self):
@@ -145,116 +170,136 @@ class CarouselCardPartial:
         return subject.get("works", [])
 
 
-class Partials(delegate.page):
-    path = '/partials'
-    encoding = 'json'
+class AffiliateLinksPartial(PartialDataHandler):
+    """Handler for affiliate links"""
 
-    def GET(self):
-        # `data` is meant to be a dict with two keys: `args` and `kwargs`.
-        # `data['args']` is meant to be a list of a template's positional arguments, in order.
-        # `data['kwargs']` is meant to be a dict containing a template's keyword arguments.
-        i = web.input(workid=None, _component=None, data=None)
-        component = i.pop("_component")
-        partial = {}
-        if component == "RelatedWorkCarousel":
-            partial = _get_relatedcarousels_component(i.workid)
-        elif component == "CarouselLoadMore":
-            partial = CarouselCardPartial().generate()
-        elif component == "AffiliateLinks":
-            data = json.loads(i.data)
-            args = data.get('args', [])
-            # XXX : Throw error if args length is less than 2
-            macro = web.template.Template.globals['macros'].AffiliateLinks(
-                args[0], args[1]
-            )
-            partial = {"partials": str(macro)}
+    def __init__(self):
+        self.i = web.input(data=None)
 
-        elif component == 'SearchFacets':
-            data = json.loads(i.data)
-            path = data.get('path')
-            query = data.get('query', '')
-            parsed_qs = parse_qs(query.replace('?', ''))
-            param = data.get('param', {})
+    def generate(self) -> dict:
+        data = json.loads(self.i.data)
+        args = data.get("args", [])
 
-            sort = None
-            search_response = do_search(
-                param, sort, rows=0, spellcheck_count=3, facet=True
-            )
+        if len(args) < 2:
+            raise PartialResolutionError("Unexpected amount of arguments")
 
-            sidebar = render_template(
-                'search/work_search_facets',
-                param,
-                facet_counts=search_response.facet_counts,
-                async_load=False,
-                path=path,
-                query=parsed_qs,
-            )
+        macro = web.template.Template.globals['macros'].AffiliateLinks(
+            args[0], args[1]
+        )
+        return {"partials": str(macro)}
 
-            active_facets = render_template(
-                'search/work_search_selected_facets',
-                param,
-                search_response,
-                param.get('q', ''),
-                path=path,
-                query=parsed_qs,
-            )
 
-            partial = {
-                "sidebar": str(sidebar),
-                "title": active_facets.title,
-                "activeFacets": str(active_facets).strip(),
-            }
+class SearchFacetsPartial(PartialDataHandler):
+    """Handler for search facets sidebar and "selected facets" affordances."""
 
-        elif component == "FulltextSearchSuggestion":
-            query = i.get('data', '')
-            data = fulltext_search(query)
-            # Add caching headers only if there were no errors in the search results
-            if 'error' not in data:
-                # Cache for 5 minutes (300 seconds)
-                web.header('Cache-Control', 'public, max-age=300')
-            hits = data.get('hits', [])
-            if not hits['hits']:
-                macro = '<div></div>'
-            else:
-                macro = web.template.Template.globals[
-                    'macros'
-                ].FulltextSearchSuggestion(query, data)
-            partial = {"partials": str(macro)}
-        elif component == "BPListsSection":
-            partial = {"partials": []}
+    def __init__(self):
+        self.i = web.input(data=None)
 
-            # Get work and edition
-            work_id = i.get("workId", "")
-            edition_id = i.get("editionId", "")
+    def generate(self) -> dict:
+        data = json.loads(self.i.data)
+        path = data.get('path')
+        query = data.get('query', '')
+        parsed_qs = parse_qs(query.replace('?', ''))
+        param = data.get('param', {})
 
-            work = (work_id and web.ctx.site.get(work_id)) or {}
-            edition = (edition_id and web.ctx.site.get(edition_id)) or {}
+        sort = None
+        search_response = do_search(
+            param, sort, rows=0, spellcheck_count=3, facet=True
+        )
 
-            # Do checks and render
-            has_lists = (work and work.get_lists(limit=1)) or (
+        sidebar = render_template(
+            'search/work_search_facets',
+            param,
+            facet_counts=search_response.facet_counts,
+            async_load=False,
+            path=path,
+            query=parsed_qs,
+        )
+
+        active_facets = render_template(
+            'search/work_search_selected_facets',
+            param,
+            search_response,
+            param.get('q', ''),
+            path=path,
+            query=parsed_qs,
+        )
+
+        return {
+            "sidebar": str(sidebar),
+            "title": active_facets.title,
+            "activeFacets": str(active_facets).strip(),
+        }
+
+
+class FullTextSuggestionsPartial(PartialDataHandler):
+    """Handler for rendering full-text search suggestions."""
+
+    def __init__(self):
+        self.i = web.input(data=None)
+
+    def generate(self) -> dict:
+        query = self.i.get("data", "")
+        data = fulltext_search(query)
+        # Add caching headers only if there were no errors in the search results
+        if 'error' not in data:
+            # Cache for 5 minutes (300 seconds)
+            web.header('Cache-Control', 'public, max-age=300')
+        hits = data.get('hits', [])
+        if not hits['hits']:
+            macro = '<div></div>'
+        else:
+            macro = web.template.Template.globals[
+                'macros'
+            ].FulltextSearchSuggestion(query, data)
+        return {"partials": str(macro)}
+
+
+class BookPageListsPartial(PartialDataHandler):
+    """Handler for rendering the book page "Lists" section"""
+
+    def __init__(self):
+        self.i = web.input(workId="", editionId="")
+
+    def generate(self) -> dict:
+        results = {"partials": []}
+        work_id = self.i.workId
+        edition_id = self.i.editionId
+
+        work = (work_id and web.ctx.site.get(work_id)) or {}
+        edition = (edition_id and web.ctx.site.get(edition_id)) or {}
+
+        # Do checks and render
+        has_lists = (work and work.get_lists(limit=1)) or (
                 edition and edition.get_lists(limit=1)
-            )
-            partial["hasLists"] = bool(has_lists)
+        )
+        results["hasLists"] = bool(has_lists)
 
-            if not has_lists:
-                partial["partials"].append(_('This work does not appear on any lists.'))
-            else:
-                if work and work.key:
-                    work_list_template = render_template(
-                        "lists/widget", work, include_header=False, include_widget=False
-                    )
-                    partial["partials"].append(str(work_list_template))
-                if edition and edition.get("type", "") != "/type/edition":
-                    edition_list_template = render_template(
-                        "lists/widget",
-                        edition,
-                        include_header=False,
-                        include_widget=False,
-                    )
-                    partial["partials"].append(str(edition_list_template))
+        if not has_lists:
+            results["partials"].append(_('This work does not appear on any lists.'))
+        else:
+            if work and work.key:
+                work_list_template = render_template(
+                    "lists/widget", work, include_header=False, include_widget=False
+                )
+                results["partials"].append(str(work_list_template))
+            if edition and edition.get("type", "") != "/type/edition":
+                edition_list_template = render_template(
+                    "lists/widget",
+                    edition,
+                    include_header=False,
+                    include_widget=False,
+                )
+                results["partials"].append(str(edition_list_template))
 
-        elif component == "LazyCarousel":
-            i = web.input(
+        return results
+
+
+class LazyCarouselPartial(PartialDataHandler):
+    """Handler for lazily-loaded query carousels."""
+
+    def __init__(self):
+        self.i = web.input(
                 query="",
                 title=None,
                 sort="new",
@@ -265,24 +310,60 @@ class Partials(delegate.page):
                 url=None,
                 layout="carousel",
             )
-            i.search = i.search != "false"
-            i.has_fulltext_only = i.has_fulltext_only != "false"
-            macro = web.template.Template.globals['macros'].CacheableMacro(
-                "RawQueryCarousel",
-                i.query,
-                lazy=False,
-                title=i.title,
-                sort=i.sort,
-                key=i.key,
-                limit=i.limit,
-                search=i.search,
-                has_fulltext_only=i.has_fulltext_only,
-                url=i.url,
-                layout=i.layout,
-            )
-            partial = {"partials": str(macro)}
+        self.i.search = self.i.search != "false"
+        self.i.has_fulltext_only = self.i.has_fulltext_only != "false"
 
-        return delegate.RawText(json.dumps(partial), content_type='application/json')
+    def generate(self) -> dict:
+        macro = web.template.Template.globals['macros'].CacheableMacro(
+            "RawQueryCarousel",
+            self.i.query,
+            lazy=False,
+            title=self.i.title,
+            sort=self.i.sort,
+            key=self.i.key,
+            limit=self.i.limit,
+            search=self.i.search,
+            has_fulltext_only=self.i.has_fulltext_only,
+            url=self.i.url,
+            layout=self.i.layout,
+        )
+        return {"partials": str(macro)}
+
+
+class PartialRequestResolver:
+    # Maps `_component` values to PartialDataHandler subclasses
+    component_mapping = {
+        "RelatedWorkCarousel": RelatedWorksPartial,
+        "CarouselLoadMore": CarouselCardPartial,
+        "AffiliateLinks": AffiliateLinksPartial,
+        "SearchFacets": SearchFacetsPartial,
+        "FulltextSearchSuggestion": FullTextSuggestionsPartial,
+        "BPListsSection": BookPageListsPartial,
+        "LazyCarousel": LazyCarouselPartial,
+    }
+
+    @staticmethod
+    def resolve(component: str) -> dict:
+        """Gets an instantiated PartialDataHandler and returns its generated dict"""
+        handler = PartialRequestResolver.get_handler(component)
+        return handler.generate()
+
+    @classmethod
+    def get_handler(cls, component: str) -> PartialDataHandler:
+        """Instantiates and returns the requested handler"""
+        if klass := cls.component_mapping.get(component):
+            return klass()
+        raise PartialResolutionError(f'No handler found for key "{component}"')
+
+
+class Partials(delegate.page):
+    path = '/partials'
+    encoding = 'json'
+
+    def GET(self):
+        i = web.input(_component=None)
+        component = i.pop("_component")
+        return delegate.RawText(json.dumps(PartialRequestResolver.resolve(component)), content_type='application/json')
 
 
 def setup():


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Followup to #10669 

Updates the /partials.json handler in hopes of making future partial development less error prone.

Each type of partial request is now handled by a subclass of `PartialDataHandler`, which has a `generate` method that returns a JSON-serializable `dict` containing the required data. Passing a valid `_component` key to `PartialRequestResolver.resolve()` will return the correct `PartialDataHandler.generate()` output.  If the `_component` key is unrecognized, a `PartialResolutionError` is raised.

With this in place, we can update the `/partials.json` handler to return new partials by doing the following:

1. Create a new subclass of `PartialDataHandler`
2. Write a `generate()` method for the new class
3. Add the new class and `_component` name to the `PartialRequestResolver.component_mapping` dict

__Example:__
Adding the following would cause `/partials.json?_component=new_partial` to return `{"partials": "<div>New partial</div>}`:

```python
class NewPartial(PartialDataHandler):
  def generate(self):
    return {"partials": "<div>New partial</div>"}


class PartialRequestResolver:
  # Add the new class and `_component` key to `component_mapping`
  component_mapping = {
    # Other entries omitted
    "new_partial": NewPartial,
  }
```

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
The `/partials.json` endpoint should continue to serve the correct partials without error.

- [ ] Do the book page related work carousels load?
- [ ] Do the book page affiliate links load?
- [ ] Can carousels load more cards?
- [ ] Do the facets load on search pages?
- [ ] Are full-text search suggestions displayed when there are no search results?
- [ ] Does the book page "List" section load?
- [ ] Are query carousels lazy-loaded?

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
