### PR TITLE
Read DOI identifier from MARC 024 fields

### DIFF
--- a/openlibrary/catalog/marc/parse.py
+++ b/openlibrary/catalog/marc/parse.py
@@ -95,6 +95,16 @@ def read_dnb(rec: MarcBase) -> dict[str, list[str]] | None:
     return None
 
 
+def read_doi(rec: MarcBase) -> dict[str, list[str]] | None:
+    fields = rec.get_fields('024')
+    for f in fields:
+        (source,) = f.get_subfield_values('2') or ['']
+        (control_number,) = f.get_subfield_values('a') or ['']
+        if source == 'doi' and control_number:
+            return {'doi': [control_number]}
+    return None
+
+
 def read_issn(rec: MarcBase) -> dict[str, list[str]] | None:
     fields = rec.get_fields('022')
     if not fields:
@@ -686,6 +696,7 @@ def read_edition(rec: MarcBase) -> dict[str, Any]:
 
     update_edition(rec, edition, read_lccn, 'lccn')
     update_edition(rec, edition, read_dnb, 'identifiers')
+    update_edition(rec, edition, read_doi, 'identifiers')
     update_edition(rec, edition, read_issn, 'identifiers')
     update_edition(rec, edition, read_authors, 'authors')
     update_edition(rec, edition, read_oclc, 'oclc_numbers')

--- a/openlibrary/catalog/marc/parse.py
+++ b/openlibrary/catalog/marc/parse.py
@@ -86,6 +86,7 @@ FIELDS_WANTED = (
 
 
 def read_dnb(rec: MarcBase) -> dict[str, list[str]] | None:
+    # 016: National Bibliographic Agency Control Number
     fields = rec.get_fields('016')
     for f in fields:
         (source,) = f.get_subfield_values('2') or ['']
@@ -96,6 +97,7 @@ def read_dnb(rec: MarcBase) -> dict[str, list[str]] | None:
 
 
 def read_doi(rec: MarcBase) -> dict[str, list[str]] | None:
+    # 024: Other Standard Identifier
     fields = rec.get_fields('024')
     for f in fields:
         (source,) = f.get_subfield_values('2') or ['']


### PR DESCRIPTION
Closes #10652

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Import DOI (digital object identifier) from MARC records 


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
