### PR TITLE
Add option to filter reading stats by year read

### DIFF
--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -157,7 +157,7 @@ class mybooks_feed(delegate.page):
 
 
 class readinglog_stats(delegate.page):
-    path = "/people/([^/]+)/books/(want-to-read|currently-reading|already-read)/stats(/\\d{4})?"
+    path = "/people/([^/]+)/books/(want-to-read|currently-reading|already-read)(/year/\\d{4})?/stats"
 
     def GET(self, username, key='want-to-read', year=None):
         user = web.ctx.site.get('/people/%s' % username)

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -170,10 +170,8 @@ class readinglog_stats(delegate.page):
 
         yearly_reads = BookshelvesEvents.get_user_yearly_read_counts(username)
         if year:
-            # Skip the '/'
-            year = int(year[1:])
-            # This takes a substring of year (from the GET request) starting at index 1
-            # Thus, the / is removed
+            # eg '/year/2025'; skip the '/year/'
+            year = int(year.split('/')[-1])
 
         readlog = ReadingLog(user=user)
         works = readlog.get_works(key, page=1, limit=2000, year=year).docs

--- a/openlibrary/templates/account/readinglog_stats.html
+++ b/openlibrary/templates/account/readinglog_stats.html
@@ -107,8 +107,8 @@ $jsdef render_excluded_works_list(works, total):
     $if shelf_key == 'already-read' and yearly_reads:
     <div class="breadcrumb-wrapper">
         <div class="sansserif grey account-settings-menu navigation-breadcrumbs">
-            $ all_url = '/people/openlibrary/books/already-read/stats'
-            $ year_url = '/people/openlibrary/books/already-read/stats/%d'
+            $ all_url = owner_key + '/books/already-read/stats'
+            $ year_url = owner_key + '/books/already-read/stats/%d'
             $if year:
                 $:render_template("books/year_breadcrumb_select", yearly_reads, all_url, year_url, selected= str(year))
             $else:

--- a/openlibrary/templates/account/readinglog_stats.html
+++ b/openlibrary/templates/account/readinglog_stats.html
@@ -104,8 +104,6 @@ $jsdef render_excluded_works_list(works, total):
         &raquo;
     </div>
     <h1>$_('My %(shelf_name)s Stats', shelf_name=shelf_name)</h1>
-    $code:
-        mb=MyBooksTemplate(username=owner_key.split('/')[-1] ,key='mybooks')
     $if shelf_key == 'already-read' and yearly_reads:
     <div class="breadcrumb-wrapper">
         <div class="sansserif grey account-settings-menu navigation-breadcrumbs">

--- a/openlibrary/templates/account/readinglog_stats.html
+++ b/openlibrary/templates/account/readinglog_stats.html
@@ -1,4 +1,4 @@
-$def with (works_json, authors_json, works_count, owner_key, owner_name, shelf_path, shelf_key, lang='en')
+$def with (works_json, authors_json, works_count, owner_key, owner_name, shelf_path, shelf_key, year,yearly_reads, lang='en')
 
 $ reading_log_stats_config = {
 $    'works': works_json,
@@ -104,6 +104,21 @@ $jsdef render_excluded_works_list(works, total):
         &raquo;
     </div>
     <h1>$_('My %(shelf_name)s Stats', shelf_name=shelf_name)</h1>
+    $code:
+        mb=MyBooksTemplate(username=owner_key.split('/')[-1] ,key='mybooks')
+    $if shelf_key == 'already-read' and yearly_reads:
+    <div class="breadcrumb-wrapper">
+        <div class="sansserif grey account-settings-menu navigation-breadcrumbs">
+            $ all_url = '/people/openlibrary/books/already-read/stats'
+            $ year_url = '/people/openlibrary/books/already-read/stats/%d'
+            $if year:
+                $:render_template("books/year_breadcrumb_select", yearly_reads, all_url, year_url, selected= str(year))
+            $else:
+
+                $:render_template("books/year_breadcrumb_select", yearly_reads, all_url, year_url )
+
+        </div>
+    </div>
 
     <p>$:_('Displaying stats about <strong>%(works_count)d</strong> books. Note all charts show only the top 20 bars. Note reading log stats are private.', works_count=works_count)</p>
 </div>

--- a/openlibrary/templates/account/readinglog_stats.html
+++ b/openlibrary/templates/account/readinglog_stats.html
@@ -108,7 +108,7 @@ $jsdef render_excluded_works_list(works, total):
     <div class="breadcrumb-wrapper">
         <div class="sansserif grey account-settings-menu navigation-breadcrumbs">
             $ all_url = owner_key + '/books/already-read/stats'
-            $ year_url = owner_key + '/books/already-read/stats/%d'
+            $ year_url = owner_key + '/books/already-read/year/%d/stats'
             $if year:
                 $:render_template("books/year_breadcrumb_select", yearly_reads, all_url, year_url, selected= str(year))
             $else:


### PR DESCRIPTION
Added filter by year dropdown to the "already read" stats page. Fixing a previous PR by using year_breadcrumb_select.html

<!-- What issue does this PR close? -->
Closes #10648

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] --> Adding dropdown to readinglog stats page so the user can be filtered by year


### Technical
<!-- What should be noted about the implementation? -->
Edited the stats GET request in the mybooks.py file to also process the year that each book was read. I also edited the readinglog_stats.html template page to add in the year drop down and properly change the URL endpoint to filter the books. 


### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
docker compose run --rm home make test

tested on my localhost -screenshots below


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![stats_2025](https://github.com/user-attachments/assets/a95bb0b7-d9ee-490a-b61f-b93de563ba62)
![stats_page](https://github.com/user-attachments/assets/20242676-fc58-4c8b-a0ec-b094667f0b9b)


### Stakeholders
<!--  tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
