### PR TITLE
wiki style page when redirect has occured

### DIFF
--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -46,6 +46,11 @@ $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_libra
     $:macros.databarView(page)
 
     <h1 itemprop="name">$title</h1>
+    $if page.type.key in ["/type/redirect"]:
+        <div class="pageRedirect">
+            $if page.location:
+                <p>Redirected from <a href="$page.url()" rel="nofollow" title="$page.title">$page.title</a></p>
+        </div>
     $if show_librarian_extras:
         <h2 class="author collapse">
             $if page.birth_date or page.death_date:
@@ -54,7 +59,6 @@ $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_libra
                 $if page.date:
                     $page.date
         </h2>
-
 </div>
 
 <div id="contentBody">

--- a/openlibrary/templates/type/edition/title_and_author.html
+++ b/openlibrary/templates/type/edition/title_and_author.html
@@ -23,6 +23,11 @@ $ view_type = 'desktop' if for_desktop else 'mobile'
     </div>
     $ book_title = edition.get('title', '') or (work.title if work else '')
     <h1 class="work-title" itemprop="name">$book_title</h1>
+    $if page.type.key in ["/type/redirect"]:
+        <div class="pageRedirect">
+            $if page.location:
+                <p>Redirected from <a href="$page.url()" rel="nofollow" title="$page.title">$page.title</a></p>
+        </div>
 
     $if edition:
       $if edition.subtitle:

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -136,6 +136,11 @@ $def display_value(label, value, itemprop=None):
             <dd itemprop="$itemprop" class="object">$:thingrepr(value)</dd>
         $else:
             <dd class="object">$:thingrepr(value)</dd>
+    $if page.type.key in ["/type/redirect"]:
+        <div class="pageRedirect">
+            $if page.location:
+                <p>Redirected from <a href="$page.url()" rel="nofollow" title="$page.title">$page.title</a></p>
+        </div>
 
 $def display_identifiers(label, ids, itemprop=None):
     $if label != "Goodreads":


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #183

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
adding a wiki style notification for redirected pages

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="750" alt="wikistyle redirect author" src="https://github.com/user-attachments/assets/703dee53-0eaa-4cfa-83b4-8e72e649c7e4" />
<img width="752" alt="wikistyle redirect edition" src="https://github.com/user-attachments/assets/5f923394-7d16-48b1-8c33-efb4e97e08be" />


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini @seabelis 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
