### PR TITLE
Improve work identifiers

### DIFF
--- a/openlibrary/plugins/openlibrary/config/edition/identifiers.yml
+++ b/openlibrary/plugins/openlibrary/config/edition/identifiers.yml
@@ -191,7 +191,7 @@ identifiers:
 -   label: LCCN
     name: lccn
     url: https://lccn.loc.gov/@@@
--   label: Library Thing
+-   label: LibraryThing
     name: librarything
     url: https://www.librarything.com/work/@@@
 -   label: Lulu

--- a/openlibrary/plugins/openlibrary/config/work/identifiers.yml
+++ b/openlibrary/plugins/openlibrary/config/work/identifiers.yml
@@ -8,7 +8,7 @@ identifiers:
     name: ficbook
     notes: ''
     url: https://ficbook.net/readfic/@@@
--   label: Library Thing
+-   label: LibraryThing
     name: librarything
     url: https://www.librarything.com/work/@@@
 -   label: MusicBrainz

--- a/openlibrary/plugins/openlibrary/config/work/identifiers.yml
+++ b/openlibrary/plugins/openlibrary/config/work/identifiers.yml
@@ -10,7 +10,7 @@ identifiers:
     url: https://ficbook.net/readfic/@@@
 -   label: MusicBrainz
     name: musicbrainz
-    url: https://musicbrainz.org/artist/@@@
+    url: https://musicbrainz.org/work/@@@
     website: https://musicbrainz.org
 -   label: MyAnimeList
     name: myanimelist

--- a/openlibrary/plugins/openlibrary/config/work/identifiers.yml
+++ b/openlibrary/plugins/openlibrary/config/work/identifiers.yml
@@ -2,8 +2,8 @@ identifiers:
 -   label: BookBrainz
     name: bookbrainz
     notes: ''
-    url:  https://bookbrainz.org/work/@@@
-    website:  https://bookbrainz.org
+    url: https://bookbrainz.org/work/@@@
+    website: https://bookbrainz.org
 -   label: Книга Файнфиков
     name: ficbook
     notes: ''

--- a/openlibrary/plugins/openlibrary/config/work/identifiers.yml
+++ b/openlibrary/plugins/openlibrary/config/work/identifiers.yml
@@ -8,6 +8,9 @@ identifiers:
     name: ficbook
     notes: ''
     url: https://ficbook.net/readfic/@@@
+-   label: Goodreads
+    name: goodreads
+    url: https://www.goodreads.com/work/editions/@@@
 -   label: LibraryThing
     name: librarything
     url: https://www.librarything.com/work/@@@

--- a/openlibrary/plugins/openlibrary/config/work/identifiers.yml
+++ b/openlibrary/plugins/openlibrary/config/work/identifiers.yml
@@ -8,6 +8,9 @@ identifiers:
     name: ficbook
     notes: ''
     url: https://ficbook.net/readfic/@@@
+-   label: Library Thing
+    name: librarything
+    url: https://www.librarything.com/work/@@@
 -   label: MusicBrainz
     name: musicbrainz
     url: https://musicbrainz.org/work/@@@


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix/feature

### Technical
<!-- What should be noted about the implementation? -->

This adds `goodreads` and `librarything` work identifier entries as well as some minor cleaning up of the `work/identifiers.yml` file (and also one minor thing in `edition/identifiers.yml`). (For further details, see individual commits.)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Check that Goodreads and LibraryThing show up in the identifier list for Works.

Check that MusicBrainz Work IDs link to MusicBrainz Works rather than Artists.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->

@cdrini (as lead of https://github.com/internetarchive/openlibrary/issues/497 which this will be a prerequisite of)

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
