### PR TITLE
Fix lazily-loaded ListCarousels

### DIFF
--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -321,7 +321,7 @@ class LazyCarouselPartial(PartialDataHandler):
             title=self.i.title,
             sort=self.i.sort,
             key=self.i.key,
-            limit=self.i.limit,
+            limit=int(self.i.limit),
             search=self.i.search,
             has_fulltext_only=self.i.has_fulltext_only,
             url=self.i.url,


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
`offset` and `limit` are being added together in `cached_get_list_book_keys` calls ([here](https://github.com/internetarchive/openlibrary/blob/6897abce39bfa845f06fc99ff1a3a2779dc55ced/openlibrary/plugins/worksearch/code.py#L828)).  These changes ensure that `limit` is a number when this method is called while lazily-loading list carousels.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
