### PR TITLE
Add new `QueryCarousel` options to `ListCarousel`

### DIFF
--- a/openlibrary/macros/ListCarousel.html
+++ b/openlibrary/macros/ListCarousel.html
@@ -1,4 +1,4 @@
-$def with (list_key, title=None, sort='new', key='', limit=20, has_fulltext_only=True, url=None, layout='carousel')
+$def with (list_key, title=None, sort='new', key='', limit=20, has_fulltext_only=True, url=None, layout='carousel', use_cache=True, lazy=True)
 
 $# Takes following parameters
 $# * list_key (str) -- A list key e.g. /people/mekBot/lists/OL104041L
@@ -9,5 +9,7 @@ $# * limit (int) -- initial number of books to pull
 $# * has_fulltext_only (bool) -- only include readable titles
 $# * url (str) -- whether to make title a link to url
 $# * layout (str) -- layout type, default 'carousel', currently also supports 'grid'
+$# * use_cache (bool) -- Attempt to use cached version if `True`
+$# * lazy (bool) -- Lazy load this carousel when `True`
 
-$:macros.QueryCarousel(query=list_key, title=title, sort=sort, key=key, limit=limit, has_fulltext_only=has_fulltext_only, url=url, layout=layout)
+$:macros.QueryCarousel(query=list_key, title=title, sort=sort, key=key, limit=limit, has_fulltext_only=has_fulltext_only, url=url, layout=layout, use_cache=use_cache, lazy=lazy)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Follow-up to:
#9807
#10669

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds `use_cache` and `lazy` keyword parameters to the `ListCarousel` template.  These are passed through to the `QueryCarousel` call.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
