### PR TITLE
Fix author page regression

### DIFF
--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -130,16 +130,14 @@ $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_libra
         <div class="clearfix"></div>
 
                 $if books_count > 1:
-                <div id="books">
-                    <label for="sortOptions">$_('Sort by: ')</label>
-                    $:render_template("search/sort_options.html", books.sort, exclude='relevance', default_sort='editions')
-                    $if input(mode="everything").mode == "everything":
-                        <span>$:_('— Show <a href="%(url)s">only ebooks</a>?', url=changequery(mode='ebooks'))</span>
-                    $else:
-                        <span>$:_('— Show <a href="%(url)s">everything</a> by this author?', url=changequery(mode='everything'))</span>
-                </div>
-
-
+                    <div id="books">
+                        <label for="sortOptions">$_('Sort by: ')</label>
+                        $:render_template("search/sort_options.html", books.sort, exclude='relevance', default_sort='editions')
+                        $if input(mode="everything").mode == "everything":
+                            <span>$:_('— Show <a href="%(url)s">only ebooks</a>?', url=changequery(mode='ebooks'))</span>
+                        $else:
+                            <span>$:_('— Show <a href="%(url)s">everything</a> by this author?', url=changequery(mode='everything'))</span>
+                    </div>
 
                 $:macros.Pager(page=safeint(query_param('page'), default=1), num_found=books_count)
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10696

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Renders list of works to all author pages (if the author has written at least one work).

### Technical
<!-- What should be noted about the implementation? -->
The sort options HTML block was not properly indented following the `$if books_count > 1` conditional.  As a result the `.searchResults` div, which had the same indentation level as the sort options, was also conditionally rendered.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/user-attachments/assets/eb8cc7e7-7767-4ef7-ae49-a6d20bdba2f0)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
