### PR TITLE
Fixed Preview button being cropped

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -75,7 +75,7 @@
     },
     {
       "path": "static/build/page-edit.css",
-      "maxSize": "25.2KB"
+      "maxSize": "26KB"
     },
     {
       "path": "static/build/page-form.css",
@@ -87,7 +87,7 @@
     },
     {
       "path": "static/build/page-plain.css",
-      "maxSize": "25.3KB"
+      "maxSize": "26KB"
     },
     {
       "path": "static/build/page-subject.css",

--- a/static/css/components/search-result-item.less
+++ b/static/css/components/search-result-item.less
@@ -17,6 +17,7 @@
   position: relative;
   background-color: transparent;
   margin: -5px auto;
+  font-size: @font-size-label-large;
 
   // When Preview button is a text link, have it take up only the width
   // of the content (not full 100% width)
@@ -126,7 +127,7 @@
     width: 100%;
     margin: 10px 10px 0 5px;
     text-align: center;
-    overflow: visible;
+
     img {
       border-radius: 4px;
       max-width: 100%;

--- a/static/css/components/search-result-item.less
+++ b/static/css/components/search-result-item.less
@@ -126,7 +126,7 @@
     width: 100%;
     margin: 10px 10px 0 5px;
     text-align: center;
-    overflow: hidden;
+    overflow: visible;
     img {
       border-radius: 4px;
       max-width: 100%;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10667

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR attempts to fix the issue where the "Preview" button in the Author page was cropped off.

### Technical
<!-- What should be noted about the implementation? -->
After going through the code, I figured a single CSS change to `openlibrary\static\css\components\search-result-item.less` should do the trick and prevent the "Preview" button from being clipped off.

What I did was essentially changed the `overflow` attribute of `.bookcover` from `hidden` to `visible`.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
**Before:**
![image](https://github.com/user-attachments/assets/f47c3bf2-ed5a-4c91-b7da-db1caef65fa4)

**After**
![image](https://github.com/user-attachments/assets/4c4df43f-f0ca-417e-98f0-aebc8493694e)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
