### PR TITLE
Remove ???? from publish_date after going through validation

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -754,6 +754,13 @@ def normalize_import_record(rec: dict) -> None:
         for source_record in rec['source_records']
     ):
         rec.pop('publish_date')
+    
+    # Validation by parse_data(), prior to calling load(), requires facially
+    # valid publish_date. If data are unavailable, we provide throw-away data
+    # which validates. We use "????" as an override, but this must be
+    # removed prior to import.
+    if rec.get('publish_date') == "????":
+        rec.pop('publish_date')
 
 
 def validate_record(rec: dict) -> None:

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -71,7 +71,6 @@ SUSPECT_PUBLICATION_DATES: Final = [
     "1900",
     "January 1, 1900",
     "1900-01-01",
-    "????",
     "01-01-1900",
 ]
 SUSPECT_DATE_EXEMPT_SOURCES: Final = ["wikisource"]

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -754,7 +754,7 @@ def normalize_import_record(rec: dict) -> None:
         for source_record in rec['source_records']
     ):
         rec.pop('publish_date')
-    
+
     # Validation by parse_data(), prior to calling load(), requires facially
     # valid publish_date. If data are unavailable, we provide throw-away data
     # which validates. We use "????" as an override, but this must be

--- a/openlibrary/catalog/add_book/tests/test_add_book.py
+++ b/openlibrary/catalog/add_book/tests/test_add_book.py
@@ -1781,6 +1781,21 @@ class TestNormalizeImportRecord:
                     'publish_date': '2000',
                 },
             ),
+            (
+                {
+                    'title': 'second title',
+                    'source_records': ['ia:someid'],
+                    'publishers': ['a publisher'],
+                    'authors': [{'name': 'an author'}],
+                    'publish_date': '????',
+                },
+                {
+                    'title': 'second title',
+                    'source_records': ['ia:someid'],
+                    'publishers': ['a publisher'],
+                    'authors': [{'name': 'an author'}],
+                },
+            ),
         ],
     )
     def test_dummy_data_to_satisfy_parse_data_is_removed(self, rec, expected):

--- a/openlibrary/plugins/importapi/tests/test_import_validator.py
+++ b/openlibrary/plugins/importapi/tests/test_import_validator.py
@@ -266,7 +266,6 @@ class TestRecordTooMinimal:
         ({"publish_date": "January 1, 1900"}),
         ({"publish_date": "1900-01-01"}),
         ({"publish_date": "01-01-1900"}),
-        ({"publish_date": "????"}),
     ],
 )
 def test_records_with_substantively_bad_dates_should_not_validate(

--- a/openlibrary/plugins/importapi/tests/test_import_validator.py
+++ b/openlibrary/plugins/importapi/tests/test_import_validator.py
@@ -260,16 +260,17 @@ class TestRecordTooMinimal:
 
 
 @pytest.mark.parametrize(
-    ("publish_date"),
+    ("publish_date", "should_error"),
     [
-        ({"publish_date": "1900"}),
-        ({"publish_date": "January 1, 1900"}),
-        ({"publish_date": "1900-01-01"}),
-        ({"publish_date": "01-01-1900"}),
+        ({"publish_date": "1900"}, True),
+        ({"publish_date": "January 1, 1900"}, True),
+        ({"publish_date": "1900-01-01"}, True),
+        ({"publish_date": "01-01-1900"}, True),
+        ({"publish_date": "????"}, False),
     ],
 )
 def test_records_with_substantively_bad_dates_should_not_validate(
-    publish_date: dict,
+    publish_date: dict, should_error: bool
 ) -> None:
     """
     Certain publish_dates are known to be suspect, so remove them prior to
@@ -285,8 +286,11 @@ def test_records_with_substantively_bad_dates_should_not_validate(
 
     record = record | publish_date
 
-    with pytest.raises(ValidationError):
-        validator.validate(record)
+    if should_error:
+        with pytest.raises(ValidationError):
+            validator.validate(record)
+    else:
+        assert validator.validate(record) is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Required for #10519 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Remove publisher_date as a required field for a complete record by allowing the `????` value as an indicator that this field is missing (which was included as a suspect field before). Also, remove the `????` test case in the `test_records_with_substantively_bad_dates_should_not_validate()` test function since this value is no longer a suspect value.

Removing this will help the `import_validator` not remove it prior to validation, which will mark this record as an incomplete book record. Since certain `publish_dates` are known to be suspect, remove them prior to attempting validation. If a date is removed, the record will fail to validate as a complete record.

### Technical
<!-- What should be noted about the implementation? -->
Ideally, this makes the requirements easier for #10519 to import books since most of the books here are not actual books (it could be a website, books from a small class, or an impossible algorithm to get the books' information on the website)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Run the tests.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
