### PR TITLE
Avoid `IndexError` during `work_search` availability enrichment

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -884,7 +884,11 @@ def work_search(
     if fields == '*' or 'availability' in fields:
         add_availability(
             [
-                work['editions']['docs'][0] if work.get('editions', {}).get('docs') else work
+                (
+                    work['editions']['docs'][0]
+                    if work.get('editions', {}).get('docs')
+                    else work
+                )
                 for work in response['docs']
             ]
         )

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -884,7 +884,7 @@ def work_search(
     if fields == '*' or 'availability' in fields:
         add_availability(
             [
-                work.get('editions', {}).get('docs', [None])[0] or work
+                work['editions']['docs'][0] if work.get('editions', {}).get('docs') else work
                 for work in response['docs']
             ]
         )


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Follows up #10680 ([comment](https://github.com/internetarchive/openlibrary/issues/10680#issuecomment-2813785988))

The list comprehension passed to the `work_search` `add_availability` call fails with an `IndexError` when `work.editions.docs` is an empty list.  This bug is being tracked in three separate Sentry issues ([1](https://sentry.archive.org/organizations/ia-ux/issues/545351/?environment=production&project=7&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D%20list%20index%20out%20of%20range&referrer=issue-stream&stream_index=1), [2](https://sentry.archive.org/organizations/ia-ux/issues/547719/?environment=production&project=7&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D%20list%20index%20out%20of%20range&referrer=issue-stream&stream_index=4), [3](https://sentry.archive.org/organizations/ia-ux/issues/545365/?environment=production&project=7&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D%20list%20index%20out%20of%20range&referrer=issue-stream&stream_index=8)).

This update defaults to the `work` whenever such cases occur.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
