### PR TITLE
Show author names next to final result in author merge tool

### DIFF
--- a/openlibrary/components/MergeUI/MergeTable.vue
+++ b/openlibrary/components/MergeUI/MergeTable.vue
@@ -272,50 +272,50 @@ export default {
             ];
         },
         merge() {
-  if (!this.records || !this.editions || !this.master_key) return undefined;
-  return this.build_merge(this.records);
-},
-enhancedMergeRecord() {
-  if (!this.enhancedRecords || !this.editions || !this.master_key) return undefined;
-  return this.build_merge(this.enhancedRecords)?.record;
-}
+            if (!this.records || !this.editions || !this.master_key) return undefined;
+            return this.build_merge(this.records);
+        },
+        enhancedMergeRecord() {
+            if (!this.enhancedRecords || !this.editions || !this.master_key) return undefined;
+            return this.build_merge(this.enhancedRecords)?.record;
+        }
     },
     methods: {
-  isCellUsed(record, field) {
-    if (!this.merge) return false;
-    return field in this.merge.sources
-      ? this.merge.sources[field].includes(record.key)
-      : record.key === this.master_key;
-  },
+        isCellUsed(record, field) {
+            if (!this.merge) return false;
+            return field in this.merge.sources
+                ? this.merge.sources[field].includes(record.key)
+                : record.key === this.master_key;
+        },
 
-  build_merge(records) {
-    const master = records.find(r => r.key === this.master_key);
-    const all_dupes = records
-      .filter(r => this.selected[r.key])
-      .filter(r => r.key !== this.master_key);
-    const dupes = all_dupes.filter(r => r.type.key === '/type/work');
-    const editions_to_move = _.flatMap(
-      all_dupes,
-      work => this.editions[work.key].entries
-    );
+        build_merge(records) {
+            const master = records.find(r => r.key === this.master_key);
+            const all_dupes = records
+                .filter(r => this.selected[r.key])
+                .filter(r => r.key !== this.master_key);
+            const dupes = all_dupes.filter(r => r.type.key === '/type/work');
+            const editions_to_move = _.flatMap(
+                all_dupes,
+                work => this.editions[work.key].entries
+            );
 
-    const [record, sources] = merge(master, dupes);
+            const [record, sources] = merge(master, dupes);
 
-    const extras = {
-      edition_count: _.sum(records.map(r => this.editions[r.key].size)),
-      list_count: (this.lists) ? _.sum(records.map(r => this.lists[r.key].size)) : null
-    };
+            const extras = {
+                edition_count: _.sum(records.map(r => this.editions[r.key].size)),
+                list_count: (this.lists) ? _.sum(records.map(r => this.lists[r.key].size)) : null
+            };
 
-    const unmergeable_works = records
-      .filter(work => work.type.key === '/type/work' &&
+            const unmergeable_works = records
+                .filter(work => work.type.key === '/type/work' &&
         this.selected[work.key] &&
         work.key !== this.master_key &&
         this.editions[work.key].entries.length < this.editions[work.key].size)
-      .map(r => r.key);
+                .map(r => r.key);
 
-    return { record, sources, ...extras, dupes, editions_to_move, unmergeable_works };
-  }
-}
+            return { record, sources, ...extras, dupes, editions_to_move, unmergeable_works };
+        }
+    }
 
 };
 </script>

--- a/openlibrary/components/MergeUI/MergeTable.vue
+++ b/openlibrary/components/MergeUI/MergeTable.vue
@@ -316,7 +316,6 @@ export default {
             return { record, sources, ...extras, dupes, editions_to_move, unmergeable_works };
         }
     }
-
 };
 </script>
 

--- a/openlibrary/components/MergeUI/MergeTable.vue
+++ b/openlibrary/components/MergeUI/MergeTable.vue
@@ -51,10 +51,10 @@
     <tfoot>
       <MergeRow
         v-if="merge"
-        :record="enhancedMergeRecord"
+        :record="enhancedMergeRecord.record"
         :selected="selected"
         :fields="fields"
-        :merged="merge"
+        :merged="enhancedMergeRecord"
       >
         <template #pre>
           <td />
@@ -277,7 +277,7 @@ export default {
         },
         enhancedMergeRecord() {
             if (!this.enhancedRecords || !this.editions || !this.master_key) return undefined;
-            return this.build_merge(this.enhancedRecords)?.record;
+            return this.build_merge(this.enhancedRecords);
         }
     },
     methods: {

--- a/openlibrary/components/MergeUI/MergeTable.vue
+++ b/openlibrary/components/MergeUI/MergeTable.vue
@@ -51,7 +51,7 @@
     <tfoot>
       <MergeRow
         v-if="merge"
-        :record="merge.record"
+        :record="enhancedMergeRecord"
         :selected="selected"
         :fields="fields"
         :merged="merge"
@@ -214,38 +214,6 @@ export default {
                 this.records.map((work, i) => [work.key, responses[i]])
             );
         },
-
-        async merge() {
-            if (!this.master_key || !this.records || !this.editions)
-                return undefined;
-
-            const master = this.records.find(r => r.key === this.master_key);
-            const all_dupes = this.records
-                .filter(r => this.selected[r.key])
-                .filter(r => r.key !== this.master_key);
-            const dupes = all_dupes.filter(r => r.type.key === '/type/work');
-            const records = [master, ...all_dupes];
-            const editions_to_move = _.flatMap(
-                all_dupes,
-                work => this.editions[work.key].entries
-            );
-
-            const [record, sources] = merge(master, dupes);
-
-            const extras = {
-                edition_count: _.sum(records.map(r => this.editions[r.key].size)),
-                list_count: (this.lists) ? _.sum(records.map(r => this.lists[r.key].size)) : null
-            };
-
-            const unmergeable_works = this.records
-                .filter(work => work.type.key === '/type/work' &&
-                this.selected[work.key] &&
-                work.key !== this.master_key &&
-                this.editions[work.key].entries.length < this.editions[work.key].size)
-                .map(r => r.key);
-
-            return { record, sources, ...extras, dupes, editions_to_move, unmergeable_works };
-        }
     },
     computed: {
         fields() {
@@ -302,16 +270,53 @@ export default {
                 ...usedTextData,
                 ...otherFields
             ];
-        }
+        },
+        merge() {
+  if (!this.records || !this.editions || !this.master_key) return undefined;
+  return this.build_merge(this.records);
+},
+enhancedMergeRecord() {
+  if (!this.enhancedRecords || !this.editions || !this.master_key) return undefined;
+  return this.build_merge(this.enhancedRecords)?.record;
+}
     },
     methods: {
-        isCellUsed(record, field) {
-            if (!this.merge) return false;
-            return field in this.merge.sources
-                ? this.merge.sources[field].includes(record.key)
-                : record.key === this.master_key;
-        }
-    }
+  isCellUsed(record, field) {
+    if (!this.merge) return false;
+    return field in this.merge.sources
+      ? this.merge.sources[field].includes(record.key)
+      : record.key === this.master_key;
+  },
+
+  build_merge(records) {
+    const master = records.find(r => r.key === this.master_key);
+    const all_dupes = records
+      .filter(r => this.selected[r.key])
+      .filter(r => r.key !== this.master_key);
+    const dupes = all_dupes.filter(r => r.type.key === '/type/work');
+    const editions_to_move = _.flatMap(
+      all_dupes,
+      work => this.editions[work.key].entries
+    );
+
+    const [record, sources] = merge(master, dupes);
+
+    const extras = {
+      edition_count: _.sum(records.map(r => this.editions[r.key].size)),
+      list_count: (this.lists) ? _.sum(records.map(r => this.lists[r.key].size)) : null
+    };
+
+    const unmergeable_works = records
+      .filter(work => work.type.key === '/type/work' &&
+        this.selected[work.key] &&
+        work.key !== this.master_key &&
+        this.editions[work.key].entries.length < this.editions[work.key].size)
+      .map(r => r.key);
+
+    return { record, sources, ...extras, dupes, editions_to_move, unmergeable_works };
+  }
+}
+
 };
 </script>
 


### PR DESCRIPTION
Closes #10292 ( #10297)

Adds author names next to the merged works in the merge view, improving clarity by making it easier to identify duplicate authors. It ensures author names are shown consistently throughout the process, not just next to unmerged works.

Technical
Added enhancedRecords to the merge function in MergeTable.vue

![image](https://github.com/user-attachments/assets/126552d2-2ec0-4cc6-86ed-e1c18059fbe1)

Stakeholders
@RayBB @cdrini 

