### PR TITLE
Ensure `pd` cookie is set on login

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -385,6 +385,7 @@ class account_login_json(delegate.page):
                 }
                 raise olib.code.BadRequest(json.dumps(resp))
             expires = 3600 * 24 * 365 if remember.lower() == 'true' else ""
+            web.setcookie('pd', int(audit.get('special_access')) or '', expires=expires)
             web.setcookie(config.login_cookie_name, web.ctx.conn.get_auth_token())
             if audit.get('ia_email'):
                 ol_account = OpenLibraryAccount.get(email=audit['ia_email'])


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Sets `pd` cookie in `/account/login.json` `POST` handler.  This handler is used by our Google sign-in flow.

### Technical
<!-- What should be noted about the implementation? -->
This sets `pd` in the same way that it is set in the non-json `/account/login` `POST` handler, here:
https://github.com/internetarchive/openlibrary/blob/f0ec88c73e218d4d848825241501ec59a196ec1c/openlibrary/plugins/upstream/account.py#L482

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Log in via Google sign-in using a print-disabled account
2. Verify that the `pd` cookie is set, and that it's value is as expected
3. Log out, then log in via Google sign-in using a _non_-print-disabled account
4. Verify that the `pd` cookie is set with an empty string `value`

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
