### PR TITLE
Use our Wikidata IDs for reading stat demographics

### DIFF
--- a/openlibrary/plugins/openlibrary/js/readinglog_stats.js
+++ b/openlibrary/plugins/openlibrary/js/readinglog_stats.js
@@ -142,9 +142,11 @@ export function init(config) {
     SPARQL_FIELDS.map(f => `?${f.name} ${f.type === 'uri' ? `?${f.name}Label ` : ''}`).join('')
 }
             WHERE {
-              VALUES ?olids { ${authors.map(a => `"${a.key.split('/')[2]}"`).join(' ')} }
-              ?x wdt:P648 ?olids;
-                 wdt:P648 ?olid.
+              VALUES (?x ?olid) {
+                ${authors.filter(a => a.remote_ids.wikidata).map(
+                  a => `"(wd:${a.remote_ids.wikidata} ${a.key.split('/')[2]})"`
+                ).join(' ')}
+              }
 
               ${
     SPARQL_FIELDS.map(f => (f.render || defaultFieldRender)(f))


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes https://github.com/internetarchive/openlibrary/issues/6552

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

### Technical
<!-- What should be noted about the implementation? -->

Previously, we’ve done a reverse lookup of Open Library IDs in Wikidata to fetch demographic data for the reading stats page. This is prone to fail as OLIDs “change” due to merges and not getting updated in Wikidata.

This commit changes the logic to instead use the Wikidata IDs we have on our side and use those to look up data from Wikidata, regardless of what OLIDs are assigned there—if any.

This change makes it more immediately possible for OL librarians to fix authors missing Wikidata links (or being wrongly linked), without having to (additionally) learn how to edit Wikidata.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

1. Go to your “My Already Read Stats” page (e.g., https://openlibrary.org/people/freso/books/already-read/stats )
2. Check that authors with Wikidata IDs in OL are accounted for and that authors without are left out

(I have not tested this myself; not sure if I’ll be able to try and get an OL server running anytime soon to test it.)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->

@cdrini (lead of #6552)
@bicolino34 (reporter of #6552)
@RayBB (wikidata :))

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
