### PR TITLE
Avoid breaking when author name is ""

### DIFF
--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -288,7 +288,9 @@ def import_author(author: dict[str, Any], eastern=False) -> "Author | dict[str, 
 
     # Validate that the author dictionary contains a valid name
     if not author.get('name', '').strip() and not author.get('remote_ids'):
-        raise ValueError("Author dictionary must contain a valid 'name' or 'remote_ids' field.")
+        raise ValueError(
+            "Author dictionary must contain a valid 'name' or 'remote_ids' field."
+        )
 
     if author.get('entity_type') != 'org' and not eastern:
         do_flip(author)

--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -196,7 +196,7 @@ def find_author(author: dict[str, Any]) -> list["Author"]:
     name = author.get("name", "").strip().replace("*", r"\*")
     if not name:
         return []
-        
+
     # Fall back to name/date matching, which we did before introducing identifiers.
     queries = [
         {"type": "/type/author", "name~": name},

--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -287,7 +287,7 @@ def import_author(author: dict[str, Any], eastern=False) -> "Author | dict[str, 
     assert isinstance(author, dict), "Author must be a dictionary."
 
     # Validate that the author dictionary contains a valid name
-    if not author.get('name'):
+    if not author.get('name', '').strip():
         raise ValueError("Author dictionary must contain a valid 'name' field.")
 
     if author.get('entity_type') != 'org' and not eastern:

--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -165,12 +165,6 @@ def find_author(author: dict[str, Any]) -> list["Author"]:
         # Always match on OL ID, even if remote identifiers don't match.
         return get_redirected_authors([record])
 
-    # Fall back to name/date matching, which we did before introducing identifiers.
-    # Validate that the author name is not empty
-    name = author.get("name", "").strip().replace("*", r"\*")
-    if not name:
-        return []
-
     # Try other identifiers next.
     if remote_ids := author.get("remote_ids"):
         queries = []
@@ -197,6 +191,12 @@ def find_author(author: dict[str, Any]) -> list["Author"]:
             )[0]
             return [selected_match]
 
+    # Fall back to name/date matching, which we did before introducing identifiers.
+    # Validate that the author name is not empty
+    name = author.get("name", "").strip().replace("*", r"\*")
+    if not name:
+        return []
+        
     # Fall back to name/date matching, which we did before introducing identifiers.
     queries = [
         {"type": "/type/author", "name~": name},

--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -165,8 +165,8 @@ def find_author(author: dict[str, Any]) -> list["Author"]:
         # Always match on OL ID, even if remote identifiers don't match.
         return get_redirected_authors([record])
 
-        # Fall back to name/date matching, which we did before introducing identifiers.
-        # Validate that the author name is not empty
+    # Fall back to name/date matching, which we did before introducing identifiers.
+    # Validate that the author name is not empty
     name = author.get("name", "").strip().replace("*", r"\*")
     if not name:
         return []

--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -166,7 +166,7 @@ def find_author(author: dict[str, Any]) -> list["Author"]:
         return get_redirected_authors([record])
 
     # Validate that the author name is not empty
-    if not author.get("name"):
+    if not author.get("name", "").strip():
         return []
 
     name = author["name"].replace("*", r"\*")

--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -165,6 +165,12 @@ def find_author(author: dict[str, Any]) -> list["Author"]:
         # Always match on OL ID, even if remote identifiers don't match.
         return get_redirected_authors([record])
 
+    # Validate that the author name is not empty
+    if not author.get("name"):
+        return []
+
+    name = author["name"].replace("*", r"\*")
+
     # Try other identifiers next.
     if remote_ids := author.get("remote_ids"):
         queries = []
@@ -192,7 +198,6 @@ def find_author(author: dict[str, Any]) -> list["Author"]:
             return [selected_match]
 
     # Fall back to name/date matching, which we did before introducing identifiers.
-    name = author["name"].replace("*", r"\*")
     queries = [
         {"type": "/type/author", "name~": name},
         {"type": "/type/author", "alternate_names~": name},
@@ -279,7 +284,12 @@ def import_author(author: dict[str, Any], eastern=False) -> "Author | dict[str, 
     :return: Open Library style Author representation, either existing Author with "key",
              or new candidate dict without "key".
     """
-    assert isinstance(author, dict)
+    assert isinstance(author, dict), "Author must be a dictionary."
+
+    # Validate that the author dictionary contains a valid name
+    if not author.get('name'):
+        raise ValueError("Author dictionary must contain a valid 'name' field.")
+
     if author.get('entity_type') != 'org' and not eastern:
         do_flip(author)
     if existing := find_entity(author):

--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -165,7 +165,8 @@ def find_author(author: dict[str, Any]) -> list["Author"]:
         # Always match on OL ID, even if remote identifiers don't match.
         return get_redirected_authors([record])
 
-    # Validate that the author name is not empty
+        # Fall back to name/date matching, which we did before introducing identifiers.
+        # Validate that the author name is not empty
     name = author.get("name", "").strip().replace("*", r"\*")
     if not name:
         return []

--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -287,8 +287,8 @@ def import_author(author: dict[str, Any], eastern=False) -> "Author | dict[str, 
     assert isinstance(author, dict), "Author must be a dictionary."
 
     # Validate that the author dictionary contains a valid name
-    if not author.get('name', '').strip():
-        raise ValueError("Author dictionary must contain a valid 'name' field.")
+    if not author.get('name', '').strip() and not author.get('remote_ids'):
+        raise ValueError("Author dictionary must contain a valid 'name' or 'remote_ids' field.")
 
     if author.get('entity_type') != 'org' and not eastern:
         do_flip(author)

--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -166,10 +166,9 @@ def find_author(author: dict[str, Any]) -> list["Author"]:
         return get_redirected_authors([record])
 
     # Validate that the author name is not empty
-    if not author.get("name", "").strip():
+    name = author.get("name", "").strip().replace("*", r"\*")
+    if not name:
         return []
-
-    name = author["name"].replace("*", r"\*")
 
     # Try other identifiers next.
     if remote_ids := author.get("remote_ids"):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10716

The issue arises because the find_author function attempts to split the name field of the author dictionary and access the last element, which fails when name is an empty string. To fix this, we need to add a validation check to ensure that name is not empty before attempting to split it.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
