### PR TITLE
Feature: better explain /api/import/ia errors

### DIFF
--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -26,6 +26,7 @@ from openlibrary.plugins.importapi import (
     import_edition_builder,
     import_opds,
     import_rdf,
+    import_validator,
 )
 from openlibrary.plugins.openlibrary.code import can_write
 from openlibrary.plugins.upstream.utils import (
@@ -283,6 +284,8 @@ class ia_importapi(importapi):
                 edition_data = cls.get_ia_record(metadata)
             except KeyError:
                 raise BookImportError('invalid-ia-metadata')
+            except ValidationError as e:
+                raise BookImportError('not-differentiable', str(e))
 
         # Add IA specific fields: ocaid, source_records, and cover
         edition_data = cls.populate_edition_data(edition_data, identifier)
@@ -446,6 +449,8 @@ class ia_importapi(importapi):
             if publishers:
                 d['publishers'] = publishers
 
+        d['source_records'] = ['ia:' + metadata['identifier']]
+        import_validator.import_validator().validate(d)
         return d
 
     @staticmethod

--- a/openlibrary/plugins/importapi/tests/test_code.py
+++ b/openlibrary/plugins/importapi/tests/test_code.py
@@ -51,6 +51,7 @@ def test_get_ia_record(monkeypatch, mock_site, add_languages) -> None:  # noqa F
         "publishers": ["Simon & Schuster"],
         "subjects": ["Red Cloud, 1822-1909", "Oglala Indians"],
         "title": "The heart of everything that is",
+        "source_records": ["ia:heartofeverythin0000drur_j2n5"],
     }
 
     result = code.ia_importapi.get_ia_record(ia_metadata)
@@ -87,6 +88,7 @@ def test_get_ia_record_logs_warning_when_language_has_multiple_matches(
         "publish_date": "2013",
         "publishers": ["The Publisher"],
         "title": "Frisian is Fun",
+        "source_records": ["ia:ia_frisian001"],
     }
 
     result = code.ia_importapi.get_ia_record(ia_metadata)


### PR DESCRIPTION
  <!-- What issue does this PR close? -->
  Closes #10716 
  
  The error isn't super pretty, but it at least helps explain why an import fails.
  
  Note: this applies the requirements from #9440, insofar as the record must be differentiable (i.e. complete or it has a strong identifier).
  
  Hitherto, these IA imports have been evading that requirement.
  
  Example:
  ```
  curl -L -v -X POST "http://localhost:8080/api/import/ia" -b ~/cookies.txt -d "identifier=autonomicimbalan0000unse&require_marc=false&force_import=false"
  
  {"success": false, "error_code": "not-differentiable", "error": "2 validation errors for CompleteBook\nauthors.0.name\n  String should have at least 1 characters [type=string_too_short, input_value='', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.4/v/string_too_short\npublishers\n  Field required [type=missing, input_value={'title': 'Autonomic Imba...onomicimbalan0000unse']}, input_type=dict]\n    For further information visit https://errors.pydantic.dev/2.4/v/missing"}
  ```
  
  @hornc, this pipeline has been pretty ignored since #9440. What are your thoughts on what should be required here? The same requirements, or something different?
  
  ### Stakeholders
  <!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
  @mekarpeles, @hornc 
  
  <!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
