### PR TITLE
Unbreak tests, pin to stable pip

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -37,11 +37,21 @@ jobs:
       - name: Check if pip is broken and reinstall if needed
         run: |
           set -e
-          if ! python -m pip --version > /dev/null 2>&1; then
-            echo "pip is missing or broken, reinstalling..."
-            curl -sS https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-            python get-pip.py "pip<23.2" "setuptools<68" "wheel<0.41"
-          fi
+          # Try to upgrade pip, setuptools, and wheel
+          python -m pip install --upgrade pip setuptools wheel || {
+            # Try to get current versions of pip, setuptools, and wheel
+            PIP_VERSION=$(pip freeze | grep '^pip==' | cut -d'=' -f3 || echo "")
+            SETUPTOOLS_VERSION=$(pip freeze | grep '^setuptools==' | cut -d'=' -f3 || echo "")
+            WHEEL_VERSION=$(pip freeze | grep '^wheel==' | cut -d'=' -f3 || echo "")
+        
+            # If pip is broken or missing, reinstall using the found versions (if available)
+            if [[ -z "$PIP_VERSION" || -z "$SETUPTOOLS_VERSION" || -z "$WHEEL_VERSION" ]]; then
+              echo "pip is broken or missing, reinstalling..."
+              curl -sS https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+              python get-pip.py "$PIP_VERSION" "$SETUPTOOLS_VERSION" "$WHEEL_VERSION"
+              rm -f get-pip.py
+            fi
+          }
       - name: Install dependencies
         run: |
           pip install --upgrade pip setuptools wheel

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -34,9 +34,17 @@ jobs:
           sudo apt-get update
           # https://lxml.de/installation.html#requirements
           sudo apt-get install -y libxml2 libxslt-dev
+      - name: Check if pip is broken and reinstall if needed
+        run: |
+          set -e
+          if ! python -m pip --version > /dev/null 2>&1; then
+            echo "pip is missing or broken, reinstalling..."
+            curl -sS https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+            python get-pip.py "pip<23.2" "setuptools<68" "wheel<0.41"
+          fi
       - name: Install dependencies
         run: |
-          pip install --upgrade "pip<23.2" "setuptools<68" "wheel<0.41"
+          pip install --upgrade pip setuptools wheel
           pip install -r requirements_test.txt
           pip list --outdated
       - run: make git

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -34,27 +34,16 @@ jobs:
           sudo apt-get update
           # https://lxml.de/installation.html#requirements
           sudo apt-get install -y libxml2 libxslt-dev
-      - name: Check if pip is broken and reinstall if needed
-        run: |
-          set -e
-          # Try to upgrade pip, setuptools, and wheel
-          python -m pip install --upgrade pip setuptools wheel || {
-            # Try to get current versions of pip, setuptools, and wheel
-            PIP_VERSION=$(pip freeze | grep '^pip==' | cut -d'=' -f3 || echo "")
-            SETUPTOOLS_VERSION=$(pip freeze | grep '^setuptools==' | cut -d'=' -f3 || echo "")
-            WHEEL_VERSION=$(pip freeze | grep '^wheel==' | cut -d'=' -f3 || echo "")
-
-            # If pip is broken or missing, reinstall using the found versions (if available)
-            if [[ -z "$PIP_VERSION" || -z "$SETUPTOOLS_VERSION" || -z "$WHEEL_VERSION" ]]; then
-              echo "pip is broken or missing, reinstalling..."
-              curl -sS https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-              python get-pip.py "$PIP_VERSION" "$SETUPTOOLS_VERSION" "$WHEEL_VERSION"
-              rm -f get-pip.py
-            fi
-          }
       - name: Install dependencies
         run: |
-          pip install --upgrade pip setuptools wheel
+          # Try to upgrade pip, setuptools, and wheel
+          python -m pip install --upgrade pip setuptools wheel || {
+            echo "pip is broken or missing, reinstalling..."
+            curl -sS https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+            python get-pip.py
+            rm -f get-pip.py
+            python -m pip install --upgrade pip setuptools wheel
+          }
           pip install -r requirements_test.txt
           pip list --outdated
       - run: make git

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -36,7 +36,7 @@ jobs:
           sudo apt-get install -y libxml2 libxslt-dev
       - name: Install dependencies
         run: |
-          pip install --upgrade pip setuptools wheel
+          pip install --upgrade "pip<23.2" "setuptools<68" "wheel<0.41"
           pip install -r requirements_test.txt
           pip list --outdated
       - run: make git

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -43,7 +43,7 @@ jobs:
             PIP_VERSION=$(pip freeze | grep '^pip==' | cut -d'=' -f3 || echo "")
             SETUPTOOLS_VERSION=$(pip freeze | grep '^setuptools==' | cut -d'=' -f3 || echo "")
             WHEEL_VERSION=$(pip freeze | grep '^wheel==' | cut -d'=' -f3 || echo "")
-        
+
             # If pip is broken or missing, reinstall using the found versions (if available)
             if [[ -z "$PIP_VERSION" || -z "$SETUPTOOLS_VERSION" || -z "$WHEEL_VERSION" ]]; then
               echo "pip is broken or missing, reinstalling..."


### PR DESCRIPTION
<!-- What issue does this PR close? -->
## Suspected Issue

Copilot suggests: The GitHub Actions environment for Python 3.12.2 has a broken pip preinstalled.

Specifically, pip internally vendors (bundles its own copy of) a library called resolvelib.

Somehow, the resolvelib inside that pip is missing or mismatched — it’s trying to import RequirementInformation, but it doesn’t exist.

So even before you install anything, the base pip in GitHub Actions is already corrupted.

## Solution

Uses **copilot suggestion** to attempt to unbreak tests by pinning `pip` to stable version:

https://github.com/internetarchive/openlibrary/actions/runs/14699560888/job/41274914506#step:6:1

```
0s
Run pip install --upgrade pip setuptools wheel
ERROR: Exception:
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.[1](https://github.com/internetarchive/openlibrary/actions/runs/14699560888/job/41274914506#step:6:1)2.2/x64/lib/python3.12/site-packages/pip/_internal/cli/base_command.py", line 106, in _run_wrapper
    status = _inner_run()
             ^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.2/x64/lib/python3.12/site-packages/pip/_internal/cli/base_command.py", line 97, in _inner_run
    return self.run(options, args)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.2/x64/lib/python3.12/site-packages/pip/_internal/cli/req_command.py", line 67, in wrapper
    return func(self, options, args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.2/x64/lib/python3.12/site-packages/pip/_internal/commands/install.py", line 370, in run
    resolver = self.make_resolver(
               ^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.2/x64/lib/python3.12/site-packages/pip/_internal/cli/req_command.py", line [17](https://github.com/internetarchive/openlibrary/actions/runs/14699560888/job/41274914506#step:6:18)5, in make_resolver
    import pip._internal.resolution.resolvelib.resolver
  File "/opt/hostedtoolcache/Python/3.12.2/x64/lib/python3.12/site-packages/pip/_internal/resolution/resolvelib/resolver.py", line 8, in <module>
    from pip._vendor.resolvelib import BaseReporter, ResolutionImpossible
  File "/opt/hostedtoolcache/Python/3.12.2/x64/lib/python3.12/site-packages/pip/_vendor/resolvelib/__init__.py", line [19](https://github.com/internetarchive/openlibrary/actions/runs/14699560888/job/41274914506#step:6:20), in <module>
    from .resolvers import (
  File "/opt/hostedtoolcache/Python/3.12.2/x64/lib/python3.12/site-packages/pip/_vendor/resolvelib/resolvers/__init__.py", line 1, in <module>
    from ..structs import RequirementInformation
ImportError: cannot import name 'RequirementInformation' from 'pip._vendor.resolvelib.structs' (/opt/hostedtoolcache/Python/3.12.2/x64/lib/python3.12/site-packages/pip/_vendor/resolvelib/structs.py)
Error: Process completed with exit code 2.
```

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
