### PR TITLE
PD registration flow

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -1181,6 +1181,10 @@ msgstr ""
 msgid "This work does not appear on any lists."
 msgstr ""
 
+#: openlibrary/plugins/openlibrary/pd.py
+msgid "I don't have one yet"
+msgstr ""
+
 #: openlibrary/plugins/upstream/account.py
 msgid "The email address you entered is invalid"
 msgstr ""
@@ -1260,6 +1264,13 @@ msgstr ""
 #: openlibrary/plugins/upstream/account.py
 #, python-format
 msgid "Request failed with error code: %(error_code)s"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid ""
+"Thank you for registering an Open Library account and requesting special "
+"print disability access. You should receive an email detailing next steps"
+" in the process."
 msgstr ""
 
 #: account/password/reset_success.html account/verify.html
@@ -1404,15 +1415,10 @@ msgid ""
 msgstr ""
 
 #: openlibrary/plugins/upstream/forms.py
-#, python-format
 msgid ""
-"I require <a href=\"https://help.archive.org/help/program-"
-"overview/\">special access</a> for a <a "
-"href=\"https://en.wikipedia.org/wiki/Print_disability\">print "
-"disability</a> offered by one of these <a href=\"https://blog.archive.org"
-"/internet-archive-beta-program-for-competent-authority-"
-"registration/#:~:text=Qualifying%20Authorities-,Qualifying%20Authorities,-certify%20users%20as\">qualifying"
-" programs</a>"
+"I would like to apply for <a href=\"https://help.archive.org/help"
+"/program-overview/\">special print disability access</a> through a "
+"qualifying program."
 msgstr ""
 
 #: openlibrary/plugins/upstream/forms.py
@@ -2386,6 +2392,10 @@ msgid "Username may only contain numbers, letters, - or _"
 msgstr ""
 
 #: account/create.html
+msgid "Must select a qualifying authority"
+msgstr ""
+
+#: account/create.html
 msgid "Sign Up to Open Library"
 msgstr ""
 
@@ -2412,11 +2422,13 @@ msgid "screenname"
 msgstr ""
 
 #: account/create.html
-msgid "I have qualified through this program"
+msgid "Select qualifying authority"
 msgstr ""
 
 #: account/create.html
-msgid "Select qualifying authority"
+msgid ""
+"* Please use the email address associated with this qualifying program. "
+"You will receive an email after activation with next steps."
 msgstr ""
 
 #: account/create.html

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -1416,9 +1416,9 @@ msgstr ""
 
 #: openlibrary/plugins/upstream/forms.py
 msgid ""
-"I would like to apply for <a href=\"https://help.archive.org/help"
-"/program-overview/\">special print disability access</a> through a "
-"qualifying program."
+"I want to apply for <a href=\"https://help.archive.org/help/program-"
+"overview/\">special print disability access</a> through a qualifying "
+"program."
 msgstr ""
 
 #: openlibrary/plugins/upstream/forms.py
@@ -2392,7 +2392,7 @@ msgid "Username may only contain numbers, letters, - or _"
 msgstr ""
 
 #: account/create.html
-msgid "Must select a qualifying authority"
+msgid "A qualifying program must be selected"
 msgstr ""
 
 #: account/create.html

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -5571,7 +5571,7 @@ msgid ""
 msgstr ""
 
 #: email/account/pd_request.html
-msgid "PLACEHOLDER_BODY"
+msgid "Qualifying for Print Disability Special Access"
 msgstr ""
 
 #: history/comment.html

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -1404,6 +1404,18 @@ msgid ""
 msgstr ""
 
 #: openlibrary/plugins/upstream/forms.py
+#, python-format
+msgid ""
+"I require <a href=\"https://help.archive.org/help/program-"
+"overview/\">special access</a> for a <a "
+"href=\"https://en.wikipedia.org/wiki/Print_disability\">print "
+"disability</a> offered by one of these <a href=\"https://blog.archive.org"
+"/internet-archive-beta-program-for-competent-authority-"
+"registration/#:~:text=Qualifying%20Authorities-,Qualifying%20Authorities,-certify%20users%20as\">qualifying"
+" programs</a>"
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
 msgid "Invalid password"
 msgstr ""
 
@@ -2397,6 +2409,14 @@ msgstr ""
 
 #: account/create.html
 msgid "screenname"
+msgstr ""
+
+#: account/create.html
+msgid "I have qualified through this program"
+msgstr ""
+
+#: account/create.html
+msgid "Select qualifying authority"
 msgstr ""
 
 #: account/create.html
@@ -5548,6 +5568,10 @@ msgid ""
 "It might take us a little while to read it because we receive lots of "
 "messages, but rest assured we will, and we'll get back to you if "
 "required."
+msgstr ""
+
+#: email/account/pd_request.html
+msgid "PLACEHOLDER_BODY"
 msgstr ""
 
 #: history/comment.html

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -2422,7 +2422,7 @@ msgid "screenname"
 msgstr ""
 
 #: account/create.html
-msgid "Select qualifying authority"
+msgid "Select qualifying program"
 msgstr ""
 
 #: account/create.html

--- a/openlibrary/plugins/openlibrary/js/signup.js
+++ b/openlibrary/plugins/openlibrary/js/signup.js
@@ -159,15 +159,15 @@ export function initSignupForm() {
 
     function validatePDSelection() {
         if (!rpdCheckbox.checked) {
-            clearError("#pd_program", "#pd_programMessage")
+            clearError('#pd_program', '#pd_programMessage')
             return
         }
-        if (pdaSelector.value === "") {
-            renderError("#pd_program", "#pd_programMessage", i18nStrings["missing_pda_err"])
+        if (pdaSelector.value === '') {
+            renderError('#pd_program', '#pd_programMessage', i18nStrings['missing_pda_err'])
             return
         }
 
-        clearError("#pd_program", "#pd_programMessage")
+        clearError('#pd_program', '#pd_programMessage')
     }
 
     // Maps input ID attribute to corresponding validation function
@@ -201,12 +201,12 @@ export function initSignupForm() {
     });
 
     // Validates the print-disability authority selection when the selection changes
-    $("form[name=signup] select").on("change", function() {
+    $('form[name=signup] select').on('change', function() {
         validatePDSelection()
     })
 
     // Validates the print-disability authority selection when the PD request checkbox is updated
-    $("#pd_request").on("input", function() {
+    $('#pd_request').on('input', function() {
         validatePDSelection()
     })
 

--- a/openlibrary/plugins/openlibrary/js/signup.js
+++ b/openlibrary/plugins/openlibrary/js/signup.js
@@ -4,7 +4,7 @@ export function initSignupForm() {
     const signupForm = document.querySelector('form[name=signup]');
     const submitBtn = document.querySelector('button[name=signup]');
     const rpdCheckbox = document.querySelector('#pd_request')
-    const pdaSelector = document.querySelector('#pda-selector')
+    const pdaSelectorContainer = document.querySelector('#pda-selector')
     const i18nStrings = JSON.parse(signupForm.dataset.i18n);
     const emailLoadingIcon = $('.ol-signup-form__input--emailAddr .ol-signup-form__icon--loading');
     const usernameLoadingIcon = $('.ol-signup-form__input--username .ol-signup-form__icon--loading');
@@ -184,13 +184,16 @@ export function initSignupForm() {
         }
     });
 
-    rpdCheckbox.addEventListener('change', (event) => {
-        if (event.target.checked) {
-            pdaSelector.classList.remove('hidden')
+    function updateSelectorVisibility() {
+        if (rpdCheckbox.checked) {
+            pdaSelectorContainer.classList.remove('hidden')
         } else {
-            pdaSelector.classList.add('hidden')
+            pdaSelectorContainer.classList.add('hidden')
         }
-    })
+    }
+
+    updateSelectorVisibility()
+    rpdCheckbox.addEventListener('change', updateSelectorVisibility)
 }
 
 export function initLoginForm() {

--- a/openlibrary/plugins/openlibrary/js/signup.js
+++ b/openlibrary/plugins/openlibrary/js/signup.js
@@ -2,7 +2,9 @@ import { debounce } from './nonjquery_utils.js';
 
 export function initSignupForm() {
     const signupForm = document.querySelector('form[name=signup]');
-    const submitBtn = document.querySelector('button[name=signup]')
+    const submitBtn = document.querySelector('button[name=signup]');
+    const rpdCheckbox = document.querySelector("#rpd-checkbox")
+    const pdaSelector = document.querySelector("#pda-selector")
     const i18nStrings = JSON.parse(signupForm.dataset.i18n);
     const emailLoadingIcon = $('.ol-signup-form__input--emailAddr .ol-signup-form__icon--loading');
     const usernameLoadingIcon = $('.ol-signup-form__input--username .ol-signup-form__icon--loading');
@@ -181,6 +183,14 @@ export function initSignupForm() {
             validateInput(this);
         }
     });
+
+    rpdCheckbox.addEventListener("change", (event) => {
+        if (event.target.checked) {
+            pdaSelector.classList.remove("hidden")
+        } else {
+            pdaSelector.classList.add("hidden")
+        }
+    })
 }
 
 export function initLoginForm() {

--- a/openlibrary/plugins/openlibrary/js/signup.js
+++ b/openlibrary/plugins/openlibrary/js/signup.js
@@ -3,7 +3,7 @@ import { debounce } from './nonjquery_utils.js';
 export function initSignupForm() {
     const signupForm = document.querySelector('form[name=signup]');
     const submitBtn = document.querySelector('button[name=signup]');
-    const rpdCheckbox = document.querySelector("#rpd-checkbox")
+    const rpdCheckbox = document.querySelector("#pd_request")
     const pdaSelector = document.querySelector("#pda-selector")
     const i18nStrings = JSON.parse(signupForm.dataset.i18n);
     const emailLoadingIcon = $('.ol-signup-form__input--emailAddr .ol-signup-form__icon--loading');
@@ -165,7 +165,7 @@ export function initSignupForm() {
             validateUsername();
         } else if (id === 'password') {
             validatePassword();
-        } else {
+        } else if (id !== "pd_request") {
             throw new Error('Input validation function not found');
         }
     }

--- a/openlibrary/plugins/openlibrary/js/signup.js
+++ b/openlibrary/plugins/openlibrary/js/signup.js
@@ -3,8 +3,8 @@ import { debounce } from './nonjquery_utils.js';
 export function initSignupForm() {
     const signupForm = document.querySelector('form[name=signup]');
     const submitBtn = document.querySelector('button[name=signup]');
-    const rpdCheckbox = document.querySelector("#pd_request")
-    const pdaSelector = document.querySelector("#pda-selector")
+    const rpdCheckbox = document.querySelector('#pd_request')
+    const pdaSelector = document.querySelector('#pda-selector')
     const i18nStrings = JSON.parse(signupForm.dataset.i18n);
     const emailLoadingIcon = $('.ol-signup-form__input--emailAddr .ol-signup-form__icon--loading');
     const usernameLoadingIcon = $('.ol-signup-form__input--username .ol-signup-form__icon--loading');
@@ -165,7 +165,7 @@ export function initSignupForm() {
             validateUsername();
         } else if (id === 'password') {
             validatePassword();
-        } else if (id !== "pd_request") {
+        } else if (id !== 'pd_request') {
             throw new Error('Input validation function not found');
         }
     }
@@ -184,11 +184,11 @@ export function initSignupForm() {
         }
     });
 
-    rpdCheckbox.addEventListener("change", (event) => {
+    rpdCheckbox.addEventListener('change', (event) => {
         if (event.target.checked) {
-            pdaSelector.classList.remove("hidden")
+            pdaSelector.classList.remove('hidden')
         } else {
-            pdaSelector.classList.add("hidden")
+            pdaSelector.classList.add('hidden')
         }
     })
 }

--- a/openlibrary/plugins/openlibrary/js/signup.js
+++ b/openlibrary/plugins/openlibrary/js/signup.js
@@ -30,6 +30,7 @@ export function initSignupForm() {
     // Includes invalid input count to account for checks not covered by reportValidity
     $(signupForm).on('submit', function(e) {
         e.preventDefault();
+        validatePDSelection()
         const numInvalidInputs = signupForm.querySelectorAll('.invalid').length;
         const isFormattingValid = !signupForm.reportValidity || signupForm.reportValidity();
         if (numInvalidInputs === 0 && isFormattingValid && window.grecaptcha) {
@@ -205,11 +206,6 @@ export function initSignupForm() {
         validatePDSelection()
     })
 
-    // Validates the print-disability authority selection when the PD request checkbox is updated
-    $('#pd_request').on('input', function() {
-        validatePDSelection()
-    })
-
     function updateSelectorVisibility() {
         if (rpdCheckbox.checked) {
             pdaSelectorContainer.classList.remove('hidden')
@@ -218,8 +214,11 @@ export function initSignupForm() {
         }
     }
 
-    updateSelectorVisibility()
     rpdCheckbox.addEventListener('change', updateSelectorVisibility)
+
+    // On page reload, display PD program options and validate selection
+    updateSelectorVisibility()
+    validatePDSelection()
 }
 
 export function initLoginForm() {

--- a/openlibrary/plugins/openlibrary/pd.py
+++ b/openlibrary/plugins/openlibrary/pd.py
@@ -66,9 +66,7 @@ def make_pd_org_query() -> list:
 
 
 def cached_pd_org_query() -> list:
-    mc = cache.memcache_memoize(
-        make_pd_org_query, "pd-org-query", timeout=DAY_SECS 
-    )
+    mc = cache.memcache_memoize(make_pd_org_query, "pd-org-query", timeout=DAY_SECS)
     if not (results := mc() or []):
         mc(_cache="delete")
     return results

--- a/openlibrary/plugins/openlibrary/pd.py
+++ b/openlibrary/plugins/openlibrary/pd.py
@@ -65,9 +65,13 @@ def make_pd_org_query() -> list:
     return response.json().get("response", {}).get("docs", []) or []
 
 
-@cache.memoize(engine="memcache", key="pd-org-query", expires=DAY_SECS)
 def cached_pd_org_query() -> list:
-    return make_pd_org_query()
+    mc = cache.memcache_memoize(
+        make_pd_org_query, "pd-org-query", timeout=DAY_SECS 
+    )
+    if not (results := mc() or []):
+        mc(_cache="delete")
+    return results
 
 
 def setup():

--- a/openlibrary/plugins/openlibrary/pd.py
+++ b/openlibrary/plugins/openlibrary/pd.py
@@ -36,12 +36,14 @@ def get_pd_org(identifier: str) -> str | None:
     Falls back to vtmas_disabilityresources if no match is found.
     """
     orgs = cached_pd_org_query()
-    vtmas = None
+    vtmas = {
+        "identifier": "vtmas_disabilityresources",
+        "title": "Vermont Mutual Aid Society",
+    }
     for org in orgs:
         if org['identifier'] == identifier:
             return org
-        if org['identifier'] == 'vtmas_disabilityresources':
-            vtmas = org
+
     return vtmas
 
 

--- a/openlibrary/plugins/openlibrary/pd.py
+++ b/openlibrary/plugins/openlibrary/pd.py
@@ -1,0 +1,64 @@
+from dataclasses import dataclass
+
+import requests
+
+from infogami import config
+from openlibrary.core import cache
+from openlibrary.i18n import gettext as _
+from openlibrary.utils.dateutil import DAY_SECS
+
+
+@dataclass
+class PDOption:
+    """Represents an option in a print-disability qualifying organization select element"""
+
+    label: str
+    value: str
+
+
+def get_pd_options() -> list[PDOption]:
+    """Returns a list of all print-disability qualifying organization options"""
+    options = [
+        PDOption("BARD", "ia_nlsbardaccess_disabilityresources"),
+        PDOption("BookShare", "ia_bookshareaccess_disabilityresources"),
+        PDOption("ACE", "aceportalocul_disabilityresources"),
+        PDOption(_("I don't have one yet"), "unqualified"),
+    ]
+
+    pd_orgs = cached_pd_org_query()
+    options += [PDOption(org.get("title"), org.get("identifier")) for org in pd_orgs]
+
+    return options
+
+
+def get_pd_org(identifier: str) -> str|None:
+    """Returns the name of the organization associated with the given identifier."""
+    orgs = cached_pd_org_query()
+    return next((org for org in orgs if org['identifier'] == identifier), None)
+
+
+def make_pd_org_query() -> list:
+    """Returns a list of items found in the "Qualifying Authorities for Print-Disabled Access" collection"""
+    base_url = config.get("bookreader_host", "")
+    if not base_url:
+        return []
+    params = "q=collection:print_disability_access&fl[]=identifier,title&rows=1000&page=1&output=json"
+    url = f"https://{base_url}/advancedsearch.php?{params}"
+    try:
+        response = requests.get(url)
+        response.raise_for_status()
+    except requests.HTTPError:
+        return []
+    except requests.exceptions.JSONDecodeError:
+        return []
+
+    return response.json().get("response", {}).get("docs", []) or []
+
+
+@cache.memoize(engine="memcache", key="pd-org-query", expires=DAY_SECS)
+def cached_pd_org_query() -> list:
+    return make_pd_org_query()
+
+
+def setup():
+    pass

--- a/openlibrary/plugins/openlibrary/pd.py
+++ b/openlibrary/plugins/openlibrary/pd.py
@@ -32,9 +32,17 @@ def get_pd_options() -> list[PDOption]:
 
 
 def get_pd_org(identifier: str) -> str|None:
-    """Returns the name of the organization associated with the given identifier."""
+    """Returns the name of the organization associated with the given identifier.
+    Falls back to vtmas_disabilityresources if no match is found.
+    """
     orgs = cached_pd_org_query()
-    return next((org for org in orgs if org['identifier'] == identifier), None)
+    vtmas = None
+    for org in orgs:
+        if org['identifier'] == identifier:
+            return org
+        if org['identifier'] == 'vtmas_disabilityresources':
+            vtmas = org
+    return vtmas
 
 
 def make_pd_org_query() -> list:

--- a/openlibrary/plugins/openlibrary/pd.py
+++ b/openlibrary/plugins/openlibrary/pd.py
@@ -31,7 +31,7 @@ def get_pd_options() -> list[PDOption]:
     return options
 
 
-def get_pd_org(identifier: str) -> str|None:
+def get_pd_org(identifier: str) -> str | None:
     """Returns the name of the organization associated with the given identifier.
     Falls back to vtmas_disabilityresources if no match is found.
     """

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -441,7 +441,9 @@ class account_login_json(delegate.page):
                     add_flash_message(
                         "info",
                         _(
-                            "Thank you for registering an Open Library account and requesting special print disability access. You should receive an email detailing next steps in the process."
+                            "Thank you for registering an Open Library account and "
+                            "requesting special print disability access. You should receive "
+                            "an email detailing next steps in the process."
                         ),
                     )
 

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -292,8 +292,11 @@ def get_pd_options():
     return options
 
 def make_pd_org_query():
-    # TODO : Configure URL
-    url = "https://archive.org/advancedsearch.php?q=collection%3Aprint_disability_access&fl[]=identifier,title&rows=1000&page=1&output=json"
+    base_url = config.get("pda_org_search_url", "")
+    if not base_url:
+        return []
+    params = "q=collection:print_disability_access&fl[]=identifier,title&rows=1000&page=1&output=json"
+    url = f"{base_url}?{params}"
     try:
         response = requests.get(url)
         response.raise_for_status()

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -29,8 +29,8 @@ from openlibrary.accounts import (
     valid_email,
 )
 from openlibrary.accounts.model import sendmail
-from openlibrary.core import lending, stats
 from openlibrary.core import helpers as h
+from openlibrary.core import lending, stats
 from openlibrary.core.booknotes import Booknotes
 from openlibrary.core.bookshelves import Bookshelves
 from openlibrary.core.follows import PubSub
@@ -438,7 +438,12 @@ class account_login_json(delegate.page):
                         ol_account, get_pd_org(web.cookies().get("pda"))
                     )
                     _handle_pd_cookies(ol_account)
-                    add_flash_message("info", _("Thank you for registering an Open Library account and requesting special print disability access. You should receive an email detailing next steps in the process."))
+                    add_flash_message(
+                        "info",
+                        _(
+                            "Thank you for registering an Open Library account and requesting special print disability access. You should receive an email detailing next steps in the process."
+                        ),
+                    )
 
         # Fallback to infogami user/pass
         else:
@@ -533,7 +538,12 @@ class account_login(delegate.page):
                     ol_account, get_pd_org(web.cookies().get("pda"))
                 )
                 _handle_pd_cookies(ol_account)
-                add_flash_message("info", _("Thank you for registering an Open Library account and requesting special print disability access. You should receive an email detailing next steps in the process."))
+                add_flash_message(
+                    "info",
+                    _(
+                        "Thank you for registering an Open Library account and requesting special print disability access. You should receive an email detailing next steps in the process."
+                    ),
+                )
 
         blacklist = [
             "/account/login",

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -436,6 +436,7 @@ class account_login_json(delegate.page):
                         ol_account, get_pd_org(web.cookies().get("pda"))
                     )
                     _handle_pd_cookies(ol_account)
+                    add_flash_message("info", _("Thank you for registering an Open Library account and requesting special print disability access. You should receive an email detailing next steps in the process."))
 
         # Fallback to infogami user/pass
         else:
@@ -530,6 +531,7 @@ class account_login(delegate.page):
                     ol_account, get_pd_org(web.cookies().get("pda"))
                 )
                 _handle_pd_cookies(ol_account)
+                add_flash_message("info", _("Thank you for registering an Open Library account and requesting special print disability access. You should receive an email detailing next steps in the process."))
 
         blacklist = [
             "/account/login",

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -392,7 +392,7 @@ class account_create(delegate.page):
                     extra = {'response': e.response} if hasattr(e, 'response') else None
                     sentry.capture_exception(e, extras=extra)
 
-        return render['account/create'](f)
+        return render['account/create'](f, pd_options=get_pd_options())
 
 
 del delegate.pages['/account/register']

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -438,14 +438,6 @@ class account_login_json(delegate.page):
                         ol_account, get_pd_org(web.cookies().get("pda"))
                     )
                     _handle_pd_cookies(ol_account)
-                    add_flash_message(
-                        "info",
-                        _(
-                            "Thank you for registering an Open Library account and "
-                            "requesting special print disability access. You should receive "
-                            "an email detailing next steps in the process."
-                        ),
-                    )
 
         # Fallback to infogami user/pass
         else:

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -362,6 +362,8 @@ def _set_account_cookies(ol_account: OpenLibraryAccount, expires: int | str) -> 
 
 def _handle_pd_cookies(ol_account: OpenLibraryAccount) -> None:
     pda = web.cookies().get("pda")
+    if pda == "unqualified":
+        pda = "vtmas_disabilityresources"
     ol_account.get_user().save_preferences(
         {
             "rpd": 1,

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -543,7 +543,9 @@ class account_login(delegate.page):
                 add_flash_message(
                     "info",
                     _(
-                        "Thank you for registering an Open Library account and requesting special print disability access. You should receive an email detailing next steps in the process."
+                        "Thank you for registering an Open Library account and "
+                        "requesting special print disability access. You should receive "
+                        "an email detailing next steps in the process."
                     ),
                 )
 

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -411,6 +411,12 @@ def _handle_pd_cookies(ol_account: OpenLibraryAccount) -> None:
     web.setcookie("pda", "", expires=1)
 
 
+def _notify_slack_on_rpd_verification(email: str, pda: str):
+    msg = f"Patron with email {email} has selected {pda} as their `pda`"
+    channel = config.get("slack_pd_request_channel", "")
+    if channel:
+        post_to_slack(msg, channel)
+
 class account_login_json(delegate.page):
     encoding = "json"
     path = "/account/login"
@@ -458,6 +464,8 @@ class account_login_json(delegate.page):
 
                     if web.cookies().get("rpd"):
                         _handle_pd_cookies(ol_account)
+                        _notify_slack_on_rpd_verification(audit.get("ia_email"),
+                                                          ol_account.get_user().preferences()["pda"])
 
         # Fallback to infogami user/pass
         else:
@@ -549,6 +557,7 @@ class account_login(delegate.page):
 
             if web.cookies().get("rpd"):
                 _handle_pd_cookies(ol_account)
+                _notify_slack_on_rpd_verification(audit.get("ia_email"), ol_account.get_user().preferences()["pda"])
 
         blacklist = [
             "/account/login",
@@ -1416,3 +1425,32 @@ def get_loan_history_data(page: int, mb: "MyBooksTemplate") -> dict[str, Any]:
         'limit': limit,
         'page': page,
     }
+
+class SlackAPIError(Exception):
+    pass
+
+def post_to_slack(text, channel):
+    if not config.get("slack_auth_token"):
+        return
+
+    payload = {
+        "text": text,
+        "channel": channel,
+    }
+    response =  requests.post(
+        "https://slack.com/api/chat.postMessage",
+        headers={
+            "Content-Type": "application/json; charset=utf-8",
+            "Authorization": f"Bearer {config.get('slack_auth_token')}"
+        },
+        json=payload,
+    )
+
+    if not response.ok:
+        response.raise_for_status()
+
+    result = response.json()
+    if not result.get('ok'):
+        raise SlackAPIError(result.get("error", "Unknown Slack API error"))
+
+    return result

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -417,7 +417,6 @@ def _handle_pd_cookies(ol_account: OpenLibraryAccount) -> None:
             "pda": pda,
         }
     )
-    web.setcookie("rpd", "", expires=1)
     web.setcookie("pda", "", expires=1)
 
 

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -379,8 +379,8 @@ class account_create(delegate.page):
                     verified=False,
                     retries=USERNAME_RETRIES,
                 )
-                if f.pd_request.checked:
-                    web.setcookie("pda", web.input().get("pd_program"), expires=-1)
+                if "pd_request" in web.input() and web.input().get("pd_program"):
+                    web.setcookie("pda", web.input().get("pd_program"))
                 return render['account/verify'](
                     username=f.username.value, email=f.email.value
                 )

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -460,8 +460,7 @@ class account_login_json(delegate.page):
             expires = 3600 * 24 * 365 if remember.lower() == 'true' else ""
             web.setcookie('pd', int(audit.get('special_access')) or '', expires=expires)
             web.setcookie(config.login_cookie_name, web.ctx.conn.get_auth_token())
-            if audit.get('ia_email'):
-                if ol_account := OpenLibraryAccount.get(email=audit['ia_email']):
+            if audit.get('ia_email') and (ol_account := OpenLibraryAccount.get(email=audit['ia_email'])):
                     _set_account_cookies(ol_account, expires)
 
                     if web.cookies().get("rpd"):

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -21,7 +21,6 @@ from infogami.utils.view import (
     require_login,
 )
 from openlibrary import accounts
-from openlibrary.accounts.model import sendmail
 from openlibrary.accounts import (
     InternetArchiveAccount,
     OLAuthenticationError,
@@ -30,6 +29,7 @@ from openlibrary.accounts import (
     clear_cookies,
     valid_email,
 )
+from openlibrary.accounts.model import sendmail
 from openlibrary.core import cache, lending, stats
 from openlibrary.core import helpers as h
 from openlibrary.core.booknotes import Booknotes
@@ -283,6 +283,7 @@ def get_pd_org(identifier):
     orgs = cached_pd_org_query()
     return next((org for org in orgs if org['identifier'] == identifier), None)
 
+
 def get_pd_options():
     options = [
         PDOption("BARD", "ia_nlsbardaccess_disabilityresources"),
@@ -423,8 +424,16 @@ def _handle_pd_cookies(ol_account: OpenLibraryAccount) -> None:
 def _notify_on_rpd_verification(ol_account, org):
     if org:
         displayname = web.safestr(ol_account.displayname)
-        msg = render_template("email/account/pd_request", displayname=displayname, org=org)
-        web.sendmail(config.from_address, ol_account.email, subject=msg.subject.strip(), message=msg)
+        msg = render_template(
+            "email/account/pd_request", displayname=displayname, org=org
+        )
+        web.sendmail(
+            config.from_address,
+            ol_account.email,
+            subject=msg.subject.strip(),
+            message=msg,
+        )
+
 
 class account_login_json(delegate.page):
     encoding = "json"
@@ -474,7 +483,8 @@ class account_login_json(delegate.page):
 
                 if web.cookies().get("pda"):
                     _notify_on_rpd_verification(
-                        ol_account, get_pd_org(web.cookies().get("pda")))
+                        ol_account, get_pd_org(web.cookies().get("pda"))
+                    )
                     _handle_pd_cookies(ol_account)
 
         # Fallback to infogami user/pass

--- a/openlibrary/plugins/upstream/forms.py
+++ b/openlibrary/plugins/upstream/forms.py
@@ -123,7 +123,7 @@ class RegisterForm(Form):
         Checkbox(
             "pd_request",
             description=_(
-                'I would like to apply for <a href="https://help.archive.org/help/program-overview/">'
+                'I want to apply for <a href="https://help.archive.org/help/program-overview/">'
                 'special print disability access</a> through a qualifying program.'
             ),
         ),

--- a/openlibrary/plugins/upstream/forms.py
+++ b/openlibrary/plugins/upstream/forms.py
@@ -123,11 +123,8 @@ class RegisterForm(Form):
         Checkbox(
             "pd_request",
             description=_(
-                'I require <a href="https://help.archive.org/help/program-overview/">special access'
-                '</a> for a <a href="https://en.wikipedia.org/wiki/Print_disability">print disability'
-                '</a> offered by one of these '
-                '<a href="https://blog.archive.org/internet-archive-beta-program-for-competent-authority-registration/#:~:text=Qualifying%20Authorities-,Qualifying%20Authorities,-certify%20users%20as">'
-                'qualifying programs</a>'
+                'I would like to apply for <a href="https://help.archive.org/help/program-overview/">'
+                'special print disability access</a> through a qualifying program.'
             ),
         ),
     )

--- a/openlibrary/plugins/upstream/forms.py
+++ b/openlibrary/plugins/upstream/forms.py
@@ -120,6 +120,16 @@ class RegisterForm(Form):
                 'that runs Open Library.'
             ),
         ),
+        Checkbox(
+            "pd_request",
+            description=_(
+                'I require <a href="https://help.archive.org/help/program-overview/">special access'
+                '</a> for a <a href="https://en.wikipedia.org/wiki/Print_disability">print disability'
+                '</a> offered by one of these '
+                '<a href="https://blog.archive.org/internet-archive-beta-program-for-competent-authority-registration/#:~:text=Qualifying%20Authorities-,Qualifying%20Authorities,-certify%20users%20as">'
+                'qualifying programs</a>'
+            ),
+        )
     )
 
     def __init__(self):

--- a/openlibrary/plugins/upstream/forms.py
+++ b/openlibrary/plugins/upstream/forms.py
@@ -129,7 +129,7 @@ class RegisterForm(Form):
                 '<a href="https://blog.archive.org/internet-archive-beta-program-for-competent-authority-registration/#:~:text=Qualifying%20Authorities-,Qualifying%20Authorities,-certify%20users%20as">'
                 'qualifying programs</a>'
             ),
-        )
+        ),
     )
 
     def __init__(self):

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -7,6 +7,7 @@ $ i18n_strings = {
     $ "username_length_err": _("Must be between 3 and 20 characters"),
     $ "username_char_err": _("Username may only contain numbers, letters, - or _"),
     $ "password_length_err": _("Must be between 3 and 20 characters"),
+    $ "missing_pda_err": _("Must select a qualifying authority"),
     $ "loading_text": _("Loading...")
     $ }
 
@@ -81,8 +82,9 @@ $var title: $_("Sign Up to Open Library")
                 $:form.pd_request.render() <label for="pd_request">$:form.pd_request.description</label>
             </div>
             <div id="pda-selector" class="ol-signup-form__select hidden">
+                <div class="ol-signup-form__error" id="pd_programMessage"></div>
                 <select id="pd_program" name="pd_program" aria-label="$_('Select qualifying authority')">
-                    <option value="placeholder" disabled selected>$_("Select qualifying authority")</option>
+                    <option value="" disabled selected>$_("Select qualifying authority")</option>
                     $for option in pd_options:
                         <option value="$option.value" label="$option.label"></option>
                 </select>

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -83,8 +83,8 @@ $var title: $_("Sign Up to Open Library")
             </div>
             <div id="pda-selector" class="ol-signup-form__select hidden">
                 <div class="ol-signup-form__error" id="pd_programMessage"></div>
-                <select id="pd_program" name="pd_program" aria-label="$_('Select qualifying authority')">
-                    <option value="" disabled selected>$_("Select qualifying authority")</option>
+                <select id="pd_program" name="pd_program" aria-label="$_('Select qualifying program')">
+                    <option value="" disabled selected>$_("Select qualifying program")</option>
                     $for option in pd_options:
                         <option value="$option.value" label="$option.label"></option>
                 </select>

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -77,10 +77,10 @@ $var title: $_("Sign Up to Open Library")
             <div class="ol-signup-form__checkbox">
                 $:form.ia_newsletter.render() <label for="ia_newsletter">$:form.ia_newsletter.description</label>
             </div>
-            <div class="ol-signup-form__checkbox">
+            <div id="rpd-checkbox" class="ol-signup-form__checkbox">
                 $:form.pd_request.render() <label for="pd_request">$:form.pd_request.description</label>
             </div>
-            <div class="ol-signup-form__select">
+            <div id="pda-selector" class="ol-signup-form__select hidden">
                 <label for="pd_program">$_('I have qualified through this program')</label>
                 <select id="pd_program">
                     <option value="placeholder" disabled selected>$_("Select qualifying authority")</option>

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -82,7 +82,7 @@ $var title: $_("Sign Up to Open Library")
             </div>
             <div id="pda-selector" class="ol-signup-form__select hidden">
                 <label for="pd_program">$_('I have qualified through this program')</label>
-                <select id="pd_program">
+                <select id="pd_program" name="pd_program">
                     <option value="placeholder" disabled selected>$_("Select qualifying authority")</option>
                     $for option in pd_options:
                         <option value="$option.value" label="$option.label"></option>

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -87,6 +87,7 @@ $var title: $_("Sign Up to Open Library")
                     $for option in pd_options:
                         <option value="$option.value" label="$option.label"></option>
                 </select>
+                <span class="email-advisory">$_("* Please use the email address associated with this qualifying program. You will receive an email after activation with next steps.")</span>
             </div>
             <div class="formElement bottom">
                 <br/>

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -92,6 +92,9 @@ $var title: $_("Sign Up to Open Library")
             </div>
             <div class="formElement bottom">
                 <br/>
+                <button type="submit" name="signup" id="signup" class="cta-btn cta-btn--primary">$_("Sign Up with Email")</button>
+                <small class="ol-signup-form__tos">$:_('By signing up, you agree to the Internet Archive\'s <a class="ol-signup-form__link" href="//archive.org/about/terms.php" target="_blank">Terms of Service</a>.')</small>
+                <p class="ol-signup-form__login-hint">$:_('Already have an account? <a href="/account/login">Log in</a>')</p>
                 $ sitekey = classes = callback = ''
                 $if form.has_recaptcha:
                     $ callback = "data-callback=submitCreateAccountForm"
@@ -99,9 +102,6 @@ $var title: $_("Sign Up to Open Library")
                     $ sitekey = "data-sitekey=%s" % form['recaptcha'].public_key
                     $:render_template("recaptcha", form['recaptcha'].public_key, error=None, invisible=True)
                     <div class="$classes" $sitekey $callback data-size="invisible"></div>
-                <button type="submit" name="signup" id="signup" class="cta-btn cta-btn--primary">$_("Sign Up with Email")</button>
-                <small class="ol-signup-form__tos">$:_('By signing up, you agree to the Internet Archive\'s <a class="ol-signup-form__link" href="//archive.org/about/terms.php" target="_blank">Terms of Service</a>.')</small>
-                <p class="ol-signup-form__login-hint">$:_('Already have an account? <a href="/account/login">Log in</a>')</p>
             </div>
         </form>
     </div>

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -1,4 +1,4 @@
-$def with (form)
+$def with (form, pd_options=[])
 
 $putctx("cssfile", "signup")
 
@@ -77,7 +77,17 @@ $var title: $_("Sign Up to Open Library")
             <div class="ol-signup-form__checkbox">
                 $:form.ia_newsletter.render() <label for="ia_newsletter">$:form.ia_newsletter.description</label>
             </div>
-
+            <div class="ol-signup-form__checkbox">
+                $:form.pd_request.render() <label for="pd_request">$:form.pd_request.description</label>
+            </div>
+            <div class="ol-signup-form__select">
+                <label for="pd_program">$_('I have qualified through this program')</label>
+                <select id="pd_program">
+                    <option value="placeholder" disabled selected>$_("Select qualifying authority")</option>
+                    $for option in pd_options:
+                        <option value="$option.value" label="$option.label"></option>
+                </select>
+            </div>
             <div class="formElement bottom">
                 <br/>
                 $ sitekey = classes = callback = ''

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -7,7 +7,7 @@ $ i18n_strings = {
     $ "username_length_err": _("Must be between 3 and 20 characters"),
     $ "username_char_err": _("Username may only contain numbers, letters, - or _"),
     $ "password_length_err": _("Must be between 3 and 20 characters"),
-    $ "missing_pda_err": _("Must select a qualifying authority"),
+    $ "missing_pda_err": _("A qualifying program must be selected"),
     $ "loading_text": _("Loading...")
     $ }
 

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -81,8 +81,7 @@ $var title: $_("Sign Up to Open Library")
                 $:form.pd_request.render() <label for="pd_request">$:form.pd_request.description</label>
             </div>
             <div id="pda-selector" class="ol-signup-form__select hidden">
-                <label for="pd_program">$_('I have qualified through this program')</label>
-                <select id="pd_program" name="pd_program">
+                <select id="pd_program" name="pd_program" aria-label="$_('Select qualifying authority')">
                     <option value="placeholder" disabled selected>$_("Select qualifying authority")</option>
                     $for option in pd_options:
                         <option value="$option.value" label="$option.label"></option>

--- a/openlibrary/templates/email/account/pd_request.html
+++ b/openlibrary/templates/email/account/pd_request.html
@@ -1,5 +1,16 @@
-$def with ()
+$def with (displayname, org)
 
-$var subject: _("PLACEHOLDER_SUBJECT")
+$var subject: $_("Qualifying for Print Disability Special Access")
 
-$_("PLACEHOLDER_BODY")
+Hello $(displayname),
+
+Thank you for registering an account with the Internet Archive's Open Library. During registration, special account access was requested for accommodating a print disability.
+
+$(org['title']) was selected as the organization to certify this request.
+
+As a next step, click https://archive.org/details/$(org['identifier'])?tab=about and follow the instructions to be connected with a representative from $(org['title']) who will be happy to review your request to add special access to your Internet Archive Open Library account.
+
+Should you have any questions while completing this process, please email info@archive.org.
+
+Regards,
+The Open Library Team

--- a/openlibrary/templates/email/account/pd_request.html
+++ b/openlibrary/templates/email/account/pd_request.html
@@ -1,0 +1,5 @@
+$def with ()
+
+$var subject: _("PLACEHOLDER_SUBJECT")
+
+$_("PLACEHOLDER_BODY")

--- a/openlibrary/templates/email/account/pd_request.html
+++ b/openlibrary/templates/email/account/pd_request.html
@@ -8,7 +8,7 @@ Thank you for registering an account with the Internet Archive's Open Library. D
 
 $(org['title']) was selected as the organization to certify this request.
 
-As a next step, click https://archive.org/details/$(org['identifier'])?tab=about and follow the instructions to be connected with a representative from $(org['title']) who will be happy to review your request to add special access to your Internet Archive Open Library account.
+As a next step, click https://archive.org/details/$(org['identifier'])?tab=about and follow the instructions to be connected with a representative from $(org['title']) who will be happy to review your request for Internet Archive special access.
 
 Should you have any questions while completing this process, please email info@archive.org.
 

--- a/static/css/page-signup.less
+++ b/static/css/page-signup.less
@@ -221,7 +221,7 @@
     padding-left: 16px;
 
     select {
-      margin-top: 8px;
+      margin: 8px 0;
       width: 100%;
     }
   }

--- a/static/css/page-signup.less
+++ b/static/css/page-signup.less
@@ -221,7 +221,7 @@
     padding-left: 16px;
 
     select {
-      margin: 8px 0;
+      margin-bottom: 8px;
       width: 100%;
     }
   }

--- a/static/css/page-signup.less
+++ b/static/css/page-signup.less
@@ -214,4 +214,13 @@
       color: @link-blue;
     }
   }
+
+  .ol-signup-form__select {
+    padding-top: 16px;
+    padding-left: 16px;
+
+    select {
+      margin-top: 8px;
+    }
+  }
 }

--- a/static/css/page-signup.less
+++ b/static/css/page-signup.less
@@ -216,11 +216,13 @@
   }
 
   .ol-signup-form__select {
+    font-size: 14px;
     padding-top: 16px;
     padding-left: 16px;
 
     select {
       margin-top: 8px;
+      width: 100%;
     }
   }
 }

--- a/tests/unit/js/signup.test.js
+++ b/tests/unit/js/signup.test.js
@@ -12,6 +12,11 @@ beforeEach(() => {
       <div id="passwordMessage" class="ol-signup-form__error"></div>
       <label for="password">Password</label>
       <input type="password" id="password">
+      <div id="rpd-checkbox" class="ol-signup-form__checkbox">
+        <input id="pd_request" type="checkbox">
+        <label for="pd_request">PD Checkbox</label>
+      </div>
+      <div id="pda-selector" class="ol-signup-form__select hidden"></div>
     </form>
   `;
 });
@@ -211,3 +216,24 @@ describe('Password tests', () => {
         expect(passwordLabel.classList.contains('invalid')).toBe(true);
     });
 });
+
+describe("Print disability tests", () => {
+    let checkbox, selector;
+
+    beforeEach(() => {
+        initSignupForm();
+
+        checkbox = document.querySelector("#pd_request");
+        selector = document.querySelector("#pda-selector")
+    })
+
+    test("Qualifying authority selector only visible when PD checkbox is checked", () => {
+        checkbox.checked = false
+        checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+        expect(selector.classList.contains("hidden")).toBe(true);
+
+        checkbox.checked = true
+        checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+        expect(selector.classList.contains("hidden")).toBe(false);
+    })
+})

--- a/tests/unit/js/signup.test.js
+++ b/tests/unit/js/signup.test.js
@@ -217,23 +217,23 @@ describe('Password tests', () => {
     });
 });
 
-describe("Print disability tests", () => {
+describe('Print disability tests', () => {
     let checkbox, selector;
 
     beforeEach(() => {
         initSignupForm();
 
-        checkbox = document.querySelector("#pd_request");
-        selector = document.querySelector("#pda-selector")
+        checkbox = document.querySelector('#pd_request');
+        selector = document.querySelector('#pda-selector')
     })
 
-    test("Qualifying authority selector only visible when PD checkbox is checked", () => {
+    test('Qualifying authority selector only visible when PD checkbox is checked', () => {
         checkbox.checked = false
         checkbox.dispatchEvent(new Event('change', { bubbles: true }));
-        expect(selector.classList.contains("hidden")).toBe(true);
+        expect(selector.classList.contains('hidden')).toBe(true);
 
         checkbox.checked = true
         checkbox.dispatchEvent(new Event('change', { bubbles: true }));
-        expect(selector.classList.contains("hidden")).toBe(false);
+        expect(selector.classList.contains('hidden')).toBe(false);
     })
 })


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10457

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds new checkbox to account registration form which will allow patrons to self-identify as print-disabled.  When the checkbox is clicked, a selector containing all registered print-disability authorities appears below the checkbox.

When the form is submitted, the chosen authority is set as a `pda` cookie.  After verifying their account, a patron's `pda` cookie (should one exist) is added to their account and an email containing further instruction is sent to the patron.

### Outstanding TODOs
- [x] Replace placeholder copy in new email template
- [x] Failing JavaScript tests are updated
- [x] Populate qualifying authority drop-down when `/account/create` `POST` fails ([commit](https://github.com/internetarchive/openlibrary/pull/10724/commits/9891938879ca322875bb7e258ecc98b612da6bd4))
- [x] Verify that `pda` cookie is being set ([commit](https://github.com/internetarchive/openlibrary/pull/10724/commits/be4c63c52a68d384a2b1995b9fe9266f184fb9bc))
- [x] Update copy of new checkbox label ([commit](https://github.com/internetarchive/openlibrary/pull/10724/commits/efa27d62273134b6650ce159958095e8c9a4c519))
- [x] Add email advisory beneath selector ([commit](https://github.com/internetarchive/openlibrary/pull/10724/commits/b41b61ec83ddb8573db483adeda472d65bd12323))
- [x] Move PD organization code out of `/upstream/account.py` ([commit](https://github.com/internetarchive/openlibrary/pull/10724/commits/819b630e1392b2eae128d4389f92c909217cc4d2))
- [x] Add flash message on `pda` patron's first log in ([commit](https://github.com/internetarchive/openlibrary/pull/10724/commits/6689260a2cdc3dab982071b54aa1e92aa62be712))
- [x] Set `pda` for patrons who selected `unqualified` ([commit](https://github.com/internetarchive/openlibrary/pull/10724/commits/158e585aa22c052f4c9af1c6374fd229b3d629e6))
- [x] Validate `pda` selection before form submission ([commit](https://github.com/internetarchive/openlibrary/pull/10724/commits/4aacc9e872a0f9b061420d5cec87566ae1a70542))
- [x] Update tab order of account creation form elements ([commit](https://github.com/internetarchive/openlibrary/pull/10724/commits/b536afce3bbb89e7706395750dc1a0a4368691c2))
- [x] Update PD program validation flow ([commit](https://github.com/internetarchive/openlibrary/pull/10724/commits/03145ba4d0ff2f352977dfb10dfeb59bbac19420))
- [ ] Add `aria-*` attributes
- [ ] Ensure `get_pd_org` returns fallback organization when organization query fails
- [x] Fix failing CI/CD checks

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
