### PR TITLE
Exclude MARC notes field 583

### DIFF
--- a/openlibrary/catalog/marc/parse.py
+++ b/openlibrary/catalog/marc/parse.py
@@ -583,7 +583,7 @@ def read_series(rec: MarcBase) -> list[str]:
 def read_notes(rec: MarcBase) -> str:
     found = []
     for tag in range(500, 590):
-        if tag in (505, 520):
+        if tag in (505, 520, 583):
             continue
         fields = rec.get_fields(str(tag))
         for f in fields:


### PR DESCRIPTION
https://www.loc.gov/marc/bibliographic/bd583.html
too holding specific, not relevant for a general record

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Example:

https://openlibrary.org/books/OL58796639M/NATO_a_%C4%8Cesk%C3%A1_republika

contains an overly specific https://www.loc.gov/marc/bibliographic/bd583.html Action Note

"committed to retain 20181001 in perpetuity ReCAP Shared Collection"

This PR add this notes field to the excluded notes list.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
