### PR TITLE
Streamline deploy.sh

### DIFF
--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -227,13 +227,20 @@ deploy_olsystem() {
     done
 
     echo "Finished $REPO deployment at $(date)"
-    echo "To reboot the servers, please run scripts/deployments/restart_all_servers.sh"
+    echo "[Info] To reboot the servers, please run scripts/deployments/restart_all_servers.sh"
     if [ $CLEANUP -eq 1 ]; then
         cleanup "$TMP_DIR"
     fi
 
+    # Present follow-up options
     echo "[Next] Run openlibrary deploy (~12m00 as of 2024-12-09):"
     echo "time SERVER_SUFFIX='.us.archive.org' ./scripts/deployment/deploy.sh openlibrary"
+
+    read -p "[Now] Run openlibrary deploy & audit now? [Y/n]..." answer
+    answer=${answer:-Y}
+    if [[ "$answer" =~ ^[Yy]$ ]]; then
+	time SERVER_SUFFIX='.us.archive.org' ./scripts/deployment/deploy.sh openlibrary review
+    fi
 }
 
 date_to_timestamp() {
@@ -250,6 +257,17 @@ date_to_timestamp() {
     else
         date -d "$1" +%s
     fi
+
+    read -p "[Now] Run olsystem deploy now? [Y/n]..." answer
+}
+
+tag_deploy() {
+    DEPLOY_TAG="deploy-$(date +%Y-%m-%d-at-%H-%M)"
+    echo "[Info] Tagging deploy as $DEPLOY_TAG"
+    git -C openlibrary tag $DEPLOY_TAG
+    git -C openlibrary push git@github.com:internetarchive/openlibrary.git $DEPLOY_TAG
+    git -C openlibrary tag -f production
+    git -C openlibrary push -f git@github.com:internetarchive/openlibrary.git production
 }
 
 deploy_openlibrary() {
@@ -281,12 +299,6 @@ deploy_openlibrary() {
     else
         echo "✓ Docker image is up-to-date"
     fi
-
-    DEPLOY_TAG="deploy-$(date +%Y-%m-%d)"
-    git -C openlibrary tag $DEPLOY_TAG
-    git -C openlibrary push git@github.com:internetarchive/openlibrary.git $DEPLOY_TAG
-    git -C openlibrary tag -f production
-    git -C openlibrary push -f git@github.com:internetarchive/openlibrary.git production
 
     check_server_access
     check_crons
@@ -363,6 +375,9 @@ deploy_openlibrary() {
 
     cleanup $TMP_DIR
 
+    tag_deploy
+
+    echo "[Info] Skipping booklending utils; see \`deploy.sh utils\`"
     echo "[Next] Run review aka are_servers_in_sync.sh (~50s as of 2024-12-09):"
     echo "time SERVER_SUFFIX='.us.archive.org' ./scripts/deployment/deploy.sh review"
 }
@@ -372,16 +387,30 @@ check_servers_in_sync() {
     time SERVER_SUFFIX='.us.archive.org' ./scripts/deployment/are_servers_in_sync.sh
     echo "[Next] Run restart on all servers (~3m as of 2024-12-09):"
     echo "time SERVER_SUFFIX='.us.archive.org' ./scripts/deployment/deploy.sh finalize"
+    read -p "[Now] Restart services and finalize deploy now? [N/y]..." answer
+    answer=${answer:-N}
+    if [[ "$answer" =~ ^[Yy]$ ]]; then
+	time SERVER_SUFFIX='.us.archive.org' ./scripts/deployment/deploy.sh finalize
+    fi
 }
 
 clone_booklending_utils() {
-    echo "[Info] In case you need to clone booklending utils manually..."
-    echo "parallel --quote ssh {1} \"echo -e '\\\\n\\\\n{}'; if [ -d /opt/booklending_utils ]; then cd {2} && sudo git pull git@git.archive.org:jake/booklending_utils.git master; fi\" ::: \$SERVERS ::: /opt/booklending_utils"
-    read -p "[Now] Clone booklending utils? (usually not necessary) [N/y]" answer
-    answer=${answer:-N}
-    if [[ "$answer" =~ ^[Yy]$ ]]; then
-	parallel --quote ssh {1} "echo -e '\n\n{}'; if [ -d /opt/booklending_utils ]; then cd {2} && sudo git pull git@git.archive.org:jake/booklending_utils.git master; fi" ::: $SERVERS ::: /opt/booklending_utils
-    fi
+    parallel --quote ssh {1} "echo -e '\n\n{}'; if [ -d /opt/booklending_utils ]; then cd {2} && sudo git pull git@git.archive.org:jake/booklending_utils.git master; fi" ::: $SERVERS ::: /opt/booklending_utils
+}
+
+recreate_services() {
+    echo "[Now] Rebuilding & restarting services, keep an eye on sentry/grafana (~3m as of 2024-12-09)"
+    echo "- Sentry: https://sentry.archive.org/organizations/ia-ux/issues/?project=7&statsPeriod=1d"
+    echo "- Grafana: https://grafana.us.archive.org/d/000000176/open-library-dev?orgId=1&refresh=1m&from=now-6h&to=now"
+    time SERVER_SUFFIX='.us.archive.org' ./scripts/deployment/restart_servers.sh
+}
+
+post_deploy() {
+    echo "[Now] Generate release: https://github.com/internetarchive/openlibrary/releases/new?tag=$LATEST_TAG"
+    read -p "Once announced, press Enter to continue..."
+
+    echo "[Now] Deploy complete, announce in #openlibrary-g, #openlibrary, and #open-librarians-g:"
+    echo "The Open Library weekly deploy is now complete. See changes here: https://github.com/internetarchive/openlibrary/releases/tag/$LATEST_TAG. Please let us know @here if anything seems broken or delightful!"
 }
 
 # See deployment documentation at https://github.com/internetarchive/olsystem/wiki/Deployments
@@ -390,7 +419,6 @@ if [ "$1" == "olsystem" ]; then
     deploy_olsystem
 elif [ "$1" == "openlibrary" ]; then
     deploy_openlibrary
-    clone_booklending_utils
 
     if [ "$2" == "review" ]; then
 	check_servers_in_sync
@@ -401,17 +429,16 @@ elif [ "$1" == "openlibrary" ]; then
 	    time SERVER_SUFFIX='.us.archive.org' ./scripts/deployment/deploy.sh review
 	fi
     fi
+elif [ "$1" == "utils" ]; then
+    clone_booklending_utils
 elif [ "$1" == "review" ]; then
     check_servers_in_sync
 elif [ "$1" == "finalize" ]; then
-    echo "[Now] Rebuilding & restarting services, keep an eye on sentry/grafana (~3m as of 2024-12-09)"
-    echo "- Sentry: https://sentry.archive.org/organizations/ia-ux/issues/?project=7&statsPeriod=1d"
-    echo "- Grafana: https://grafana.us.archive.org/d/000000176/open-library-dev?orgId=1&refresh=1m&from=now-6h&to=now"
-    time SERVER_SUFFIX='.us.archive.org' ./scripts/deployment/restart_servers.sh
-    echo "[Now] Deploy complete, announce in #openlibrary-g, #openlibrary, and #open-librarians-g:"
-    echo "The Open Library weekly deploy is now complete. Please let us know @here if anything seems broken or delightful!"
+    recreate_services
+    post_deploy
 else
     echo "Usage: $0 [announce|olsystem|openlibrary|review|finalize]"
+    echo "e.g: time SERVER_SUFFIX='.us.archive.org' ./scripts/deployment/deploy.sh [command]"
 
     # Pull openlibrary before continuing so we have latest deploy.sh
     read -p "[Now] Switching to main branch and pulling latest changes? [Y/n]..." answer
@@ -424,11 +451,13 @@ else
     # Announce the deploy
     echo "[Now] Announce deploy to #openlibrary-g, #openlibrary, and #open-librarians-g:"
     echo "@here, Open Library is in the process of deploying its weekly release. See what's changed: $RELEASE_DIFF_URL"
-    read -p "Once complete, press Enter to continue..."
+    read -p "Once announced, press Enter to continue..."
 
-    echo "[Now] Kick off a fresh docker build: https://github.com/internetarchive/openlibrary/actions/workflows/olbase.yaml"
-    read -p "Once complete, press Enter to continue..."
+    # Dockerhub workflow build
+    echo "[Now] Start a fresh docker build: https://github.com/internetarchive/openlibrary/actions/workflows/olbase.yaml"
+    read -p "Once built, press Enter to continue..."
 
+    # Deploy olsystem
     echo "[Next] Run olsystem deploy (~2m30 as of 2024-12-06):"
     echo "time SERVER_SUFFIX='.us.archive.org' ./scripts/deployment/deploy.sh olsystem"
     read -p "[Now] Run olsystem deploy now? [Y/n]..." answer

--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -256,19 +256,19 @@ date_to_timestamp() {
 
 tag_deploy() {
     DEPLOY_TAG="deploy-$(date +%Y-%m-%d-at-%H-%M)"
-
+    OL_REPO="$1"
     # Check if tag does NOT exist
-    if ! git -C openlibrary rev-parse "$DEPLOY_TAG" >/dev/null 2>&1; then
+    if ! git -C "$OL_REPO" rev-parse "$DEPLOY_TAG" >/dev/null 2>&1; then
         echo "[Info] Tagging deploy as $DEPLOY_TAG"
-        git -C openlibrary tag "$DEPLOY_TAG"
-        git -C openlibrary push git@github.com:internetarchive/openlibrary.git "$DEPLOY_TAG"
+        git -C "$OL_REPO" tag "$DEPLOY_TAG"
+        git -C "$OL_REPO" push git@github.com:internetarchive/openlibrary.git "$DEPLOY_TAG"
     else
         echo "[Info] Tag '$DEPLOY_TAG' already exists. Skipping creation."
     fi
 
     # Always update and push the 'production' tag
-    git -C openlibrary tag -f production
-    git -C openlibrary push -f git@github.com:internetarchive/openlibrary.git production
+    git -C "$OL_REPO" tag -f production
+    git -C "$OL_REPO" push -f git@github.com:internetarchive/openlibrary.git production
 }
 
 check_olbase_image_up_to_date() {
@@ -377,7 +377,7 @@ deploy_openlibrary() {
     wait
     echo "   ... Done ✓"
 
-    tag_deploy
+    tag_deploy openlibrary
 
     echo "Finished production deployment at $(date)"
     echo "To reboot the servers, please run scripts/deployments/restart_all_servers.sh"

--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -464,15 +464,18 @@ deploy_wizard() {
         git checkout master
         git pull https://github.com/internetarchive/openlibrary.git master
     fi
+    echo ""
 
     # Announce the deploy
     echo "[Now] Announce deploy to #openlibrary-g, #openlibrary, and #open-librarians-g:"
     echo "@here, Open Library is in the process of deploying its weekly release. See what's changed: $RELEASE_DIFF_URL"
     read -p "Once announced, press Enter to continue..."
+    echo ""
 
     if ! check_olbase_image_up_to_date; then
         read -p "Once you've clicked 'Run workflow', press Enter to continue..."
     fi
+    echo ""
 
     # Deploy olsystem
     echo "[Next] Run olsystem deploy (~2m30 as of 2024-12-06):"
@@ -482,25 +485,32 @@ deploy_wizard() {
     if [[ "$answer" =~ ^[Yy]$ ]]; then
         time olsystem
     fi
+    echo ""
 
     until check_olbase_image_up_to_date; do
         read -p "Once built, press Enter to continue..."
     done
+    echo ""
 
     read -p "[Info] Skipping clone_booklending_utils, run manually if needed" answer
+    echo ""
 
     read -p "[Now] Run openlibrary deploy & audit now? [N/y]..." answer
     answer=${answer:-Y}
     if [[ "$answer" =~ ^[Yy]$ ]]; then
         time deploy_openlibrary
+        echo ""
         time check_servers_in_sync
+        echo ""
     fi
 
     read -p "[Now] Restart services and finalize deploy now? [N/y]..." answer
     answer=${answer:-N}
     if [[ "$answer" =~ ^[Yy]$ ]]; then
         time recreate_services
+        echo ""
         time post_deploy
+        echo ""
     fi
 }
 

--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -236,12 +236,6 @@ deploy_olsystem() {
     # Present follow-up options
     echo "[Next] Run openlibrary deploy (~12m00 as of 2024-12-09):"
     echo "time SERVER_SUFFIX='.us.archive.org' ./scripts/deployment/deploy.sh openlibrary"
-
-    read -p "[Now] Run openlibrary deploy & audit now? [Y/n]..." answer
-    answer=${answer:-Y}
-    if [[ "$answer" =~ ^[Yy]$ ]]; then
-	time SERVER_SUFFIX='.us.archive.org' "$SCRIPT_DIR/deploy.sh" openlibrary review
-    fi
 }
 
 date_to_timestamp() {
@@ -258,17 +252,6 @@ date_to_timestamp() {
     else
         date -d "$1" +%s
     fi
-
-    read -p "[Now] Run olsystem deploy now? [Y/n]..." answer
-}
-
-tag_deploy() {
-    DEPLOY_TAG="deploy-$(date +%Y-%m-%d-at-%H-%M)"
-    echo "[Info] Tagging deploy as $DEPLOY_TAG"
-    git -C openlibrary tag $DEPLOY_TAG
-    git -C openlibrary push git@github.com:internetarchive/openlibrary.git $DEPLOY_TAG
-    git -C openlibrary tag -f production
-    git -C openlibrary push -f git@github.com:internetarchive/openlibrary.git production
 }
 
 tag_deploy() {
@@ -286,6 +269,33 @@ tag_deploy() {
     # Always update and push the 'production' tag
     git -C openlibrary tag -f production
     git -C openlibrary push -f git@github.com:internetarchive/openlibrary.git production
+}
+
+check_olbase_image_up_to_date() {
+    echo "[Now] Checking if Docker image is up-to-date"
+
+    # Get latest commit timestamp from GitHub API
+    GITHUB_COMMIT_API="https://api.github.com/repos/internetarchive/openlibrary/commits/master"
+    GIT_LAST_UPDATED=$(curl -s "$GITHUB_COMMIT_API" | jq -r '.commit.committer.date')
+    echo "Latest Git commit: $GIT_LAST_UPDATED"
+
+    # Get latest Docker image timestamp from Docker Hub
+    IMAGE_META=$(curl -s https://hub.docker.com/v2/repositories/openlibrary/olbase/tags/latest)
+    IMAGE_LAST_UPDATED=$(echo "$IMAGE_META" | jq -r '.last_updated')
+    echo "Latest Docker image: $IMAGE_LAST_UPDATED"
+
+    # Convert to timestamps
+    GIT_LAST_UPDATED_TS=$(date_to_timestamp "$GIT_LAST_UPDATED")
+    IMAGE_LAST_UPDATED_TS=$(date_to_timestamp "$IMAGE_LAST_UPDATED")
+
+    if [ "$GIT_LAST_UPDATED_TS" -gt "$IMAGE_LAST_UPDATED_TS" ]; then
+        echo "✗ Docker image is NOT up-to-date."
+        echo -e "[Now] Manage docker image build status at: https://github.com/internetarchive/openlibrary/actions/workflows/olbase.yaml"
+	return 1
+    else
+        echo "✓ Docker image is up-to-date."
+	return 0
+    fi
 }
 
 deploy_openlibrary() {
@@ -388,10 +398,10 @@ deploy_openlibrary() {
     wait
     echo "   ... Done ✓"
 
+    tag_deploy
+
     echo "Finished production deployment at $(date)"
     echo "To reboot the servers, please run scripts/deployments/restart_all_servers.sh"
-
-    tag_deploy
 
     cleanup $TMP_DIR
 
@@ -405,11 +415,6 @@ check_servers_in_sync() {
     time SERVER_SUFFIX='.us.archive.org' "$SCRIPT_DIR/are_servers_in_sync.sh"
     echo "[Next] Run restart on all servers (~3m as of 2024-12-09):"
     echo "time SERVER_SUFFIX='.us.archive.org' ./scripts/deployment/deploy.sh finalize"
-    read -p "[Now] Restart services and finalize deploy now? [N/y]..." answer
-    answer=${answer:-N}
-    if [[ "$answer" =~ ^[Yy]$ ]]; then
-	time SERVER_SUFFIX='.us.archive.org' "$SCRIPT_DIR/deploy.sh" finalize
-    fi
 }
 
 clone_booklending_utils() {
@@ -424,11 +429,12 @@ recreate_services() {
 }
 
 post_deploy() {
-    echo "[Now] Generate release: https://github.com/internetarchive/openlibrary/releases/new?tag=$LATEST_TAG"
+    LATEST_TAG_NAME=$(git tag --sort=-creatordate | head -n 1)
+    echo "[Now] Generate release: https://github.com/internetarchive/openlibrary/releases/new?tag=$LATEST_TAG_NAME"
     read -p "Once announced, press Enter to continue..."
 
     echo "[Now] Deploy complete, announce in #openlibrary-g, #openlibrary, and #open-librarians-g:"
-    echo "The Open Library weekly deploy is now complete. See changes here: https://github.com/internetarchive/openlibrary/releases/tag/$LATEST_TAG. Please let us know @here if anything seems broken or delightful!"
+    echo "The Open Library weekly deploy is now complete. See changes here: https://github.com/internetarchive/openlibrary/releases/tag/$LATEST_TAG_NAME. Please let us know @here if anything seems broken or delightful!"
 }
 
 # See deployment documentation at https://github.com/internetarchive/olsystem/wiki/Deployments
@@ -437,15 +443,8 @@ if [ "$1" == "olsystem" ]; then
     deploy_olsystem
 elif [ "$1" == "openlibrary" ]; then
     deploy_openlibrary
-
     if [ "$2" == "review" ]; then
 	check_servers_in_sync
-    else
-	read -p "[Now] Run review audit of servers now? [Y/n]" answer
-	answer=${answer:-Y}
-	if [[ "$answer" =~ ^[Yy]$ ]]; then
-	    time SERVER_SUFFIX='.us.archive.org' "$SCRIPT_DIR/deploy.sh" review
-	fi
     fi
 elif [ "$1" == "utils" ]; then
     clone_booklending_utils
@@ -453,7 +452,6 @@ elif [ "$1" == "review" ]; then
     check_servers_in_sync
 elif [ "$1" == "finalize" ]; then
     recreate_services
-    post_deploy
 else
     echo "Usage: $0 [announce|olsystem|openlibrary|review|finalize]"
     echo "e.g: time SERVER_SUFFIX='.us.archive.org' ./scripts/deployment/deploy.sh [command]"
@@ -471,18 +469,34 @@ else
     echo "@here, Open Library is in the process of deploying its weekly release. See what's changed: $RELEASE_DIFF_URL"
     read -p "Once announced, press Enter to continue..."
 
-    # Dockerhub workflow build
-    echo "[Now] Start a fresh docker build: https://github.com/internetarchive/openlibrary/actions/workflows/olbase.yaml"
-    read -p "Once built, press Enter to continue..."
+    if ! check_olbase_image_up_to_date; then
+	read -p "Once you've clicked 'Run workflow', press Enter to continue..."
+    fi
 
     # Deploy olsystem
     echo "[Next] Run olsystem deploy (~2m30 as of 2024-12-06):"
     echo "time SERVER_SUFFIX='.us.archive.org' ./scripts/deployment/deploy.sh olsystem"
     read -p "[Now] Run olsystem deploy now? [Y/n]..." answer
-    answer=${answer:-N}
+    answer=${answer:-Y}
     if [[ "$answer" =~ ^[Yy]$ ]]; then
 	time SERVER_SUFFIX='.us.archive.org' "$SCRIPT_DIR/deploy.sh" olsystem
     fi
 
+    until check_olbase_image_up_to_date; do
+	read -p "Once built, press Enter to continue..."
+    done
+
+    read -p "[Now] Run openlibrary deploy & audit now? [N/y]..." answer
+    answer=${answer:-Y}
+    if [[ "$answer" =~ ^[Yy]$ ]]; then
+	time SERVER_SUFFIX='.us.archive.org' "$SCRIPT_DIR/deploy.sh" openlibrary review
+    fi
+
+    read -p "[Now] Restart services and finalize deploy now? [N/y]..." answer
+    answer=${answer:-N}
+    if [[ "$answer" =~ ^[Yy]$ ]]; then
+	time SERVER_SUFFIX='.us.archive.org' "$SCRIPT_DIR/deploy.sh" finalize
+	post_deploy
+    fi
     exit 1
 fi


### PR DESCRIPTION
<!-- What issue does this PR close? -->
This doesn't close an issue but is related to #10394 and making it easier for the team to deploy and announce code without having to look up separate documentation.

For those who prefer the previous deploy style, the core 4 commands (`olsystem`, `openlibrary`, `review`, and `finalize` will still work.

Enhancements make it so one can run `./deploy.sh` and the flow will prompt in order:
- announcement
- do git pull? Y/n
- do docker image build (before openlibrary)
- proceed to olsystem deploy? Y/n

The commands are echo'd in the flow and so the docs are no longer needed for performing a deploy.

Adds function for cloning booklending utils (if/when needed)

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
