### PR TITLE
Serve solr-based availability for bots

### DIFF
--- a/openlibrary/book_providers.py
+++ b/openlibrary/book_providers.py
@@ -32,6 +32,13 @@ class EbookAccess(OrderedEnum):
         return self.name.lower()
 
     @staticmethod
+    def from_solr_str(literal: str) -> 'EbookAccess':
+        try:
+            return EbookAccess[literal.upper()]
+        except KeyError:
+            raise ValueError(f'Unknown access literal: {literal}')
+
+    @staticmethod
     def from_acquisition_access(literal: AcquisitionAccessLiteral) -> 'EbookAccess':
         if literal == 'sample':
             # We need to update solr to handle these! Requires full reindex

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -22,6 +22,7 @@ from . import helpers as h
 from . import ia
 
 if TYPE_CHECKING:
+    from openlibrary.book_providers import EbookAccess
     from openlibrary.plugins.upstream.models import Edition
 
 
@@ -336,6 +337,40 @@ class AvailabilityStatusV2(AvailabilityStatus):
     __src__: str
 
 
+def get_ebook_access_availability(
+    ocaid: str, ebook_access: 'EbookAccess'
+) -> AvailabilityStatusV2:
+    from openlibrary.book_providers import EbookAccess
+
+    status: Literal["borrow_available", "borrow_unavailable", "open", "error"] = "error"
+    if ebook_access == EbookAccess.BORROWABLE:
+        status = "borrow_available"
+    elif ebook_access == EbookAccess.PUBLIC:
+        status = "open"
+    return {
+        'status': status,
+        'error_message': None,
+        'available_to_browse': ebook_access == EbookAccess.BORROWABLE,
+        'available_to_borrow': ebook_access == EbookAccess.BORROWABLE,
+        'available_to_waitlist': False,
+        'is_printdisabled': ebook_access >= EbookAccess.PRINTDISABLED,
+        'is_readable': ebook_access == EbookAccess.PUBLIC,
+        'is_lendable': ebook_access == EbookAccess.BORROWABLE,
+        'is_previewable': ebook_access >= EbookAccess.PRINTDISABLED,
+        'identifier': ocaid,
+        'isbn': None,
+        'oclc': None,
+        'openlibrary_work': None,
+        'openlibrary_edition': None,
+        'last_loan_date': None,
+        'num_waitlist': None,
+        'last_waitlist_date': None,
+        'is_restricted': ebook_access <= EbookAccess.BORROWABLE,
+        'is_browseable': ebook_access == EbookAccess.BORROWABLE,
+        '__src__': 'core.models.lending.get_ebook_access_availability',
+    }
+
+
 def update_availability_schema_to_v2(
     v1_resp: AvailabilityStatus,
     ocaid: str | None,
@@ -504,12 +539,23 @@ def add_availability(
     :param items: items with fields containing ocaids
     """
     if mode == "identifier":
-        ocaids = [ocaid for ocaid in map(get_ocaid, items) if ocaid]
-        availabilities = get_availability('identifier', ocaids)
-        for item in items:
-            ocaid = get_ocaid(item)
-            if ocaid:
-                item['availability'] = availabilities.get(ocaid)
+        from openlibrary.book_providers import EbookAccess
+        from openlibrary.plugins.openlibrary.code import is_bot
+
+        if is_bot() and items and 'ebook_access' in items[0]:
+            for item in items:
+                ocaid = get_ocaid(item)
+                if ocaid:
+                    item['availability'] = get_ebook_access_availability(
+                        ocaid, EbookAccess.from_solr_str(item['ebook_access'])
+                    )
+        else:
+            ocaids = [ocaid for ocaid in map(get_ocaid, items) if ocaid]
+            availabilities = get_availability('identifier', ocaids)
+            for item in items:
+                ocaid = get_ocaid(item)
+                if ocaid:
+                    item['availability'] = availabilities.get(ocaid)
     elif mode == "openlibrary_work":
         _ids = [item['key'].split('/')[-1] for item in items]
         availabilities = get_availability('openlibrary_work', _ids)

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1168,6 +1168,9 @@ def is_bot():
 
     Manually removed singleton `bot` (to avoid overly complex grep regex)
     """
+    if 'is_bot' in web.ctx:
+        return web.ctx.is_bot
+
     user_agent_bots = [
         'sputnikbot',
         'dotbot',

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -230,15 +230,19 @@ def render_macro(name, args, **kwargs):
 
 @public
 def render_cached_macro(name: str, args: tuple, **kwargs):
+    from openlibrary.plugins.openlibrary.code import is_bot
     from openlibrary.plugins.openlibrary.home import caching_prethread
 
     def get_key_prefix():
         lang = web.ctx.lang
         key_prefix = f'{name}.{lang}'
-        if web.cookies().get('pd', False):
+        cookies = web.cookies()
+        if cookies.get('pd', False):
             key_prefix += '.pd'
-        if web.cookies().get('sfw', ''):
+        if cookies.get('sfw', ''):
             key_prefix += '.sfw'
+        if is_bot():
+            key_prefix += '.bot'
         return key_prefix
 
     five_minutes = 5 * 60

--- a/openlibrary/plugins/worksearch/schemes/works.py
+++ b/openlibrary/plugins/worksearch/schemes/works.py
@@ -173,6 +173,7 @@ class WorkSearchScheme(SearchScheme):
         'title',
         'subtitle',
         'edition_count',
+        'ebook_access',
         'ia',
         'has_fulltext',
         'first_publish_year',


### PR DESCRIPTION
Bots don't need real-time availability, so switch to serving ebook_access from solr, which avoids an extra network request.

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
