### PR TITLE
Removed unused waitingloan table

### DIFF
--- a/openlibrary/core/infobase_schema.sql
+++ b/openlibrary/core/infobase_schema.sql
@@ -493,24 +493,6 @@ CREATE INDEX stats_type_idx ON stats(type);
 CREATE INDEX stats_created_idx ON stats(created);
 CREATE INDEX stats_updated_idx ON stats(updated);
 
-CREATE TABLE waitingloan (
-    id serial primary key,
-    book_key text,
-    user_key text,
-    status text default 'waiting',
-    position integer,
-    wl_size integer,
-    since timestamp without time zone default (current_timestamp at time zone 'utc'),
-    last_update timestamp without time zone default (current_timestamp at time zone 'utc'),
-    expiry timestamp without time zone,
-    available_email_sent boolean default 'f',
-    UNIQUE (book_key, user_key)
-);
-
-CREATE INDEX waitingloan_user_key_idx ON waitingloan(user_key);
-CREATE INDEX waitingloan_status_idx ON waitingloan(status);
-
-
 CREATE TABLE import_batch (
     id serial primary key,
     name text,

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -647,36 +647,6 @@ get_cached_loans_of_user = cache.memcache_memoize(
     timeout=5 * dateutil.MINUTE_SECS,  # time to live for cached loans = 5 minutes
 )
 
-
-def get_user_waiting_loans(user_key):
-    """Gets the waitingloans of the patron.
-
-    Returns [] if user has no waitingloans.
-    """
-    from .waitinglist import WaitingLoan
-
-    if "site" not in web.ctx:
-        delegate.fakeload()
-
-    try:
-        account = OpenLibraryAccount.get(key=user_key)
-        itemname = account.itemname
-        result = WaitingLoan.query(userid=itemname)
-        get_cached_user_waiting_loans.memcache_set(
-            [user_key], {}, result or {}, time.time()
-        )  # rehydrate cache
-        return result or []
-    except JSONDecodeError as e:
-        return []
-
-
-get_cached_user_waiting_loans = cache.memcache_memoize(
-    get_user_waiting_loans,
-    key_prefix='waitinglist.user_waiting_loans',
-    timeout=10 * dateutil.MINUTE_SECS,
-)
-
-
 def _get_ia_loans_of_user(userid):
     ia_loans = ia_lending_api.find_loans(userid=userid)
     return [Loan.from_ia_loan(d) for d in ia_loans]

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -38,7 +38,6 @@ from ..accounts import OpenLibraryAccount  # noqa: F401 side effects may be need
 from ..plugins.upstream.utils import get_coverstore_public_url, get_coverstore_url
 from . import cache, waitinglist
 from .ia import get_metadata
-from .waitinglist import WaitingLoan
 
 logger = logging.getLogger("openlibrary.core")
 
@@ -1023,12 +1022,6 @@ class User(Thing):
             if ocaid == loan['ocaid']:
                 return loan
 
-    def get_waiting_loan_for(self, ocaid):
-        """
-        :param str or None ocaid: edition ocaid
-        :rtype: dict (e.g. {position: number})
-        """
-        return ocaid and WaitingLoan.find(self.key, ocaid)
 
     def get_user_waiting_loans(self, ocaid=None, use_cache=False):
         """

--- a/openlibrary/core/schema.py
+++ b/openlibrary/core/schema.py
@@ -55,23 +55,6 @@ def get_schema():
     CREATE INDEX stats_created_idx ON stats(created);
     CREATE INDEX stats_updated_idx ON stats(updated);
 
-    CREATE TABLE waitingloan (
-        id serial primary key,
-        book_key text,
-        user_key text,
-        status text default 'waiting',
-        position integer,
-        wl_size integer,
-        since timestamp without time zone default (current_timestamp at time zone 'utc'),
-        last_update timestamp without time zone default (current_timestamp at time zone 'utc'),
-        expiry timestamp without time zone,
-        available_email_sent boolean default 'f',
-        UNIQUE (book_key, user_key)
-    );
-
-    CREATE INDEX waitingloan_user_key_idx ON waitingloan(user_key);
-    CREATE INDEX waitingloan_status_idx ON waitingloan(status);
-
 
     CREATE TABLE import_batch (
         id serial primary key,


### PR DESCRIPTION
**Closes #9424** 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
[refactor] As @cdrini noted in #9404 the `waitingloan` table is now unused. A previous PR was attempted for this issue to remove this table but deleted an extra class. This PR solely removes the waitingloan table from the schema and associated code.

### Technical
<!-- What should be noted about the implementation? -->
Removed waitingloan table in infobase_schema and schema and associated code in core/lending.py and core/models.py. Passes full test suite and builds correctly.

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
