### PR TITLE
Capture `ia_newsletter` checkbox value

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -320,7 +320,7 @@ class account_create(delegate.page):
                 `ml_updates`
                 """  # nopep8
                 mls = ['ml_best_of', 'ml_updates']
-                notifications = mls if f.ia_newsletter.checked else []
+                notifications = mls if "ia_newsletter" in web.input() else []
                 InternetArchiveAccount.create(
                     screenname=f.username.value,
                     email=f.email.value,


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Interim solution for #10731

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Correctly captures the `checked` value of the `ia_newsletter` checkbox, found on the `/account/create` view.

This solution is a stopgap that is meant to avoid merge conflicts with #10724.  Once that branch has been merged, myself or others can work towards the solution outlined in #10731.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
