### PR TITLE
Fix `get_pd_org ` type hint

### DIFF
--- a/openlibrary/plugins/openlibrary/pd.py
+++ b/openlibrary/plugins/openlibrary/pd.py
@@ -31,7 +31,7 @@ def get_pd_options() -> list[PDOption]:
     return options
 
 
-def get_pd_org(identifier: str) -> str | None:
+def get_pd_org(identifier: str) -> dict:
     """Returns the name of the organization associated with the given identifier.
     Falls back to vtmas_disabilityresources if no match is found.
     """


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Follow-up to #10724 

Corrects type hinting on `get_pd_org` function.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
