### PR TITLE
Fix: handle and log UnknownLocale errors in commify_list

### DIFF
--- a/openlibrary/plugins/upstream/tests/test_utils.py
+++ b/openlibrary/plugins/upstream/tests/test_utils.py
@@ -1,4 +1,5 @@
-from typing import Sequence
+from collections.abc import Sequence
+
 import pytest
 import web
 
@@ -306,12 +307,22 @@ def test_get_location_and_publisher() -> None:
     assert utils.get_location_and_publisher(loc_pub) == ([], ["BARBOUR PUB INC"])
 
 
-@pytest.mark.parametrize(("name", "seq", "locale", "expected"), [
-    ("English", ["apples", "oranges", "pears"], "en", "apples, oranges, and pears"),
-    ("Chinese", ["apples", "oranges", "pears"], "zh", "apples、oranges和pears"),
-    ("non existent locale", ["apples", "oranges", "pears"], "nope", "apples, oranges, and pears"),
-])
-def test_commify_list(name: str, seq: Sequence[str], locale: str, expected: str) -> None:
+@pytest.mark.parametrize(
+    ("name", "seq", "locale", "expected"),
+    [
+        ("English", ["apples", "oranges", "pears"], "en", "apples, oranges, and pears"),
+        ("Chinese", ["apples", "oranges", "pears"], "zh", "apples、oranges和pears"),
+        (
+            "non existent locale",
+            ["apples", "oranges", "pears"],
+            "nope",
+            "apples, oranges, and pears",
+        ),
+    ],
+)
+def test_commify_list(
+    name: str, seq: Sequence[str], locale: str, expected: str
+) -> None:
     web.ctx.lang = locale
     got = utils.commify_list(seq)
     assert got == expected

--- a/openlibrary/plugins/upstream/tests/test_utils.py
+++ b/openlibrary/plugins/upstream/tests/test_utils.py
@@ -1,3 +1,4 @@
+from typing import Sequence
 import pytest
 import web
 
@@ -303,3 +304,14 @@ def test_get_location_and_publisher() -> None:
     # Separating a not identified place with a comma
     loc_pub = "[Place of publication not identified], BARBOUR PUB INC"
     assert utils.get_location_and_publisher(loc_pub) == ([], ["BARBOUR PUB INC"])
+
+
+@pytest.mark.parametrize(("name", "seq", "locale", "expected"), [
+    ("English", ["apples", "oranges", "pears"], "en", "apples, oranges, and pears"),
+    ("Chinese", ["apples", "oranges", "pears"], "zh", "apples、oranges和pears"),
+    ("non existent locale", ["apples", "oranges", "pears"], "nope", "apples, oranges, and pears"),
+])
+def test_commify_list(name: str, seq: Sequence[str], locale: str, expected: str) -> None:
+    web.ctx.lang = locale
+    got = utils.commify_list(seq)
+    assert got == expected

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -307,7 +307,13 @@ def commify_list(items: Iterable[Any]) -> str:
     lang = web.ctx.lang or 'en'
     # If the list item is a template/html element, we strip it
     # so that there is no space before the comma.
-    return format_list([str(x).strip() for x in items], locale=lang)
+    try:
+        commified_list = format_list([str(x).strip() for x in items], locale=lang)
+    except babel.UnknownLocaleError as e:
+        logger.warning(f"unknown language for commify_list: {lang}. {e}")
+        commified_list = format_list([str(x).strip() for x in items], locale="en")
+
+    return commified_list
 
 
 @public


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10749

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This addresses the second most common error in Sentry at the moment.

The strategy is to handle the `UnknownLocaleError` from Babel and simply default to using English to commify the list.

### Technical
<!-- What should be noted about the implementation? -->
It's entirely possible, perhaps even likely, the comma format will be wrong, but it's not clear we can easily correctly commify when Babel doesn't recognize the locale.

It may be that an incorrectly commified list is better than an error and no list at all for the patron, which is the production outcome at the moment.

If we are not looking at the logged warnings, we will have no sense of how often this is happening. Perhaps it should be logged with `statsd`?

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
See the unit tests.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
