### PR TITLE
Feature: use statsd for availability errors

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -14,7 +14,7 @@ from simplejson.errors import JSONDecodeError
 from infogami.utils import delegate
 from infogami.utils.view import public
 from openlibrary.accounts.model import OpenLibraryAccount
-from openlibrary.core import cache
+from openlibrary.core import cache, stats
 from openlibrary.plugins.upstream.utils import urlencode
 from openlibrary.utils import dateutil, uniq
 
@@ -410,7 +410,9 @@ def get_availability(
         response = cast(AvailabilityServiceResponse, resp.json())
 
         if not response['success']:
-            raise AvailabilityServiceError(response['error'])
+            logger.warning(f"AvailabilityServiceError: {response['error']}")
+            stats.increment('ol.availability.service_error', rate=0.01)
+            return {}
 
         uncached_values = {
             _id: update_availability_schema_to_v2(


### PR DESCRIPTION
Instead of relying on Sentry to keep track of the number of availability errors from a service Open Library can't control, this instead opts to log a warning, increment a `statsd` counter at a 1% sample rate, and returns an empty dictionary.

<!-- What issue does this PR close? -->
Closes #10754

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature.

### Technical
<!-- What should be noted about the implementation? -->
This logs a warning rather than raising an error and increments a counter with a 1% sampling rate. This could then be graphed in Grafana.

Assuming this overall approach makes sense, it makes sense to take a moment to think about whether this should be logging a warning, an error, etc., and also the name should be for the counter that's incremented. Additionally, it's possible another sampling rate would make more sense.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Verify the counter increments when there are lending errors, and that they correspond to the logged warnings.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
