### PR TITLE
Make all homepage carousels edition-aware

### DIFF
--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -165,19 +165,19 @@ class Bookshelves(db.CommonExtras):
         Bookshelves.most_logged_books, fetch the corresponding Open Library
         book records from solr with availability
         """
-        from openlibrary.core.lending import get_availabilities
+        from openlibrary.core.lending import add_availability
         from openlibrary.plugins.worksearch.code import get_solr_works
 
         # This gives us a dict of all the works representing
         # the logged_books, keyed by work_id
         work_index = get_solr_works(
-            f"/works/OL{i['work_id']}W" for i in readinglog_items
+            {f"/works/OL{i['work_id']}W" for i in readinglog_items},
+            editions=True,
         )
 
-        # Loop over each work in the index and inject its availability
-        availability_index = get_availabilities(work_index.values())
-        for work_key in availability_index:
-            work_index[work_key]['availability'] = availability_index[work_key]
+        add_availability(
+            [(w.get('editions') or [None])[0] or w for w in work_index.values()]
+        )
 
         # Return items from the work_index in the order
         # they are represented by the trending logged books

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -274,9 +274,8 @@ def format_book_data(book, fetch_availability=True):
     work = book.works and book.works[0]
     d.authors = get_authors(work if work else book)
     d.work_key = work.key if work else book.key
-    cover = work.get_cover() if work and work.get_cover() else book.get_cover()
 
-    if cover:
+    if cover := book.get_cover():
         d.cover_url = cover.url("M")
     elif d.ocaid:
         d.cover_url = 'https://archive.org/services/img/%s' % d.ocaid

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -53,8 +53,17 @@ class CarouselCardPartial(PartialDataHandler):
         layout = params.get("layout")
         key = params.get("key") or ""
 
-        for index, book in enumerate(search_results):
+        for index, work in enumerate(search_results):
             lazy = index > self.MAX_VISIBLE_CARDS
+            editions = work.get('editions', {})
+            if not editions:
+                book = work
+            elif isinstance(editions, list):
+                book = editions[0]
+            else:
+                book = editions.get('docs', [None])[0]
+            book['authors'] = work.get('authors', [])
+
             cards.append(
                 render_template(
                     "books/custom_carousel_card",

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -76,15 +76,27 @@ def get_facet_map() -> tuple[tuple[str, str]]:
 
 
 @public
-def get_solr_works(work_key: Iterable[str]) -> dict[str, dict]:
+def get_solr_works(work_keys: set[str], editions=False) -> dict[str, dict]:
     from openlibrary.plugins.worksearch.search import get_solr
 
-    return {
-        doc['key']: doc
-        for doc in get_solr().get_many(
-            set(work_key), fields=WorkSearchScheme.default_fetched_fields
+    if editions:
+        # To get the top matching edition, need to do a proper query
+        resp = run_solr_query(
+            WorkSearchScheme(),
+            {'q': 'key:(%s)' % ' OR '.join(work_keys)},
+            rows=len(work_keys),
+            fields=list(WorkSearchScheme.default_fetched_fields | {'editions'}),
+            facet=False,
         )
-    }
+        return {doc['key']: get_doc(doc) for doc in resp.docs}
+    else:
+        return {
+            doc['key']: doc
+            for doc in get_solr().get_many(
+                work_keys,
+                fields=WorkSearchScheme.default_fetched_fields,
+            )
+        }
 
 
 def read_author_facet(author_facet: str) -> tuple[str, str]:

--- a/openlibrary/templates/type/list/view_body.html
+++ b/openlibrary/templates/type/list/view_body.html
@@ -102,7 +102,7 @@ $def seed_attrs(seed):
                 <a href="/help/faq/reading-log#lists" target="_blank">$_('Learn more.')</a>
             </p>
 
-        $ solr_works = get_solr_works(s.key for s in seeds if s.type == 'work')
+        $ solr_works = get_solr_works({s.key for s in seeds if s.type == 'work'})
         $ availabilities = get_availabilities([solr_works.get(seed.key) or seed.document for seed in seeds if seed.type in ['edition', 'work']])
         $for seed in seeds:
             $ default_image = "https://openlibrary.org/images/icons/avatar_book-sm.png"

--- a/openlibrary/views/loanstats.py
+++ b/openlibrary/views/loanstats.py
@@ -206,9 +206,11 @@ class readinglog_stats(app.view):
         stats = get_cached_reading_log_stats(limit=limit)
 
         solr_docs = get_solr_works(
-            f"/works/OL{item['work_id']}W"
-            for leaderboard in stats['leaderboard'].values()
-            for item in leaderboard
+            {
+                f"/works/OL{item['work_id']}W"
+                for leaderboard in stats['leaderboard'].values()
+                for item in leaderboard
+            }
         )
 
         # Fetch works from solr and inject into leaderboard


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10762 : Make Trending carousel edition-aware
Closes #10742  : Fix IA carousel covers not edition-aware
Closes #2906 : Epic, make homepage carousels edition-aware
Closes #10710 : Fix second page of books not edition-aware

### Technical

Note this also resulted in the trending pages themselves becoming edition-aware: https://testing.openlibrary.org/trending/daily?lang=es

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

Before:

![image](https://github.com/user-attachments/assets/cf2a4e1b-92ab-4cbc-87e1-b80cf29a6e28)

After:

![image](https://github.com/user-attachments/assets/8ce90737-08df-46e9-9872-700340778d41)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
