### PR TITLE
[Librarian Dashboard] Add data quality table to work search and author pages

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -71,7 +71,7 @@
     },
     {
       "path": "static/build/page-book.css",
-      "maxSize": "14.2KB"
+      "maxSize": "15KB"
     },
     {
       "path": "static/build/page-edit.css",
@@ -79,7 +79,7 @@
     },
     {
       "path": "static/build/page-form.css",
-      "maxSize": "25.4KB"
+      "maxSize": "26KB"
     },
     {
       "path": "static/build/page-home.css",

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -6237,7 +6237,7 @@ msgid ""
 msgstr ""
 
 #: librarian_dashboard/data_quality_table.html
-msgid "Retry"
+msgid "Reload"
 msgstr ""
 
 #: librarian_dashboard/data_quality_table.html

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -1166,6 +1166,54 @@ msgstr ""
 msgid "Science"
 msgstr ""
 
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "At least 1 subject"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "At least 1 author"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "At least 1 edition"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has work (orphaned)"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has publication year"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has cover"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has language"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has publisher"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "At least 2 editions"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has dewey decimal"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has LoC classification"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has number of pages"
+msgstr ""
+
 #: openlibrary/plugins/openlibrary/lists.py
 #, python-format
 msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
@@ -1626,7 +1674,8 @@ msgstr ""
 
 #: account/import.html account/loans.html admin/imports.html
 #: admin/imports_by_date.html admin/loans_table.html admin/menu.html
-#: batch_import_pending_view.html batch_import_view.html status.html
+#: batch_import_pending_view.html batch_import_view.html
+#: librarian_dashboard/data_quality_table.html status.html
 msgid "Status"
 msgstr ""
 
@@ -1672,7 +1721,7 @@ msgid "Import Time"
 msgstr ""
 
 #: account/import.html admin/imports.html admin/imports_by_date.html
-#: batch_import_view.html
+#: batch_import_view.html librarian_dashboard/data_quality_table.html
 msgid "Error"
 msgstr ""
 
@@ -1886,7 +1935,8 @@ msgstr ""
 msgid "Library Explorer"
 msgstr ""
 
-#: account/create.html books/custom_carousel.html login.html
+#: account/create.html books/custom_carousel.html
+#: librarian_dashboard/data_quality_table.html login.html
 #: search/work_search_facets.html
 msgid "Loading..."
 msgstr ""
@@ -6184,6 +6234,22 @@ msgid ""
 " href=\"/account/create\" title=\"Create an Open Library account\">create"
 " an account</a>, your IP address is concealed and you can more easily "
 "keep track of all your edits and additions."
+msgstr ""
+
+#: librarian_dashboard/data_quality_table.html
+msgid "Retry"
+msgstr ""
+
+#: librarian_dashboard/data_quality_table.html
+msgid "failing"
+msgstr ""
+
+#: librarian_dashboard/data_quality_table.html
+msgid "Data quality table"
+msgstr ""
+
+#: librarian_dashboard/data_quality_table.html
+msgid "Quality Criteria"
 msgstr ""
 
 #: lists/export_as_html.html

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1320,6 +1320,7 @@ def setup():
 
     from openlibrary.plugins.openlibrary import (
         api,  # noqa: F401 side effects may be needed
+        librarian_dashboard,  # noqa: F401 import required
     )
 
     delegate.app.add_processor(web.unloadhook(stats.stats_hook))

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -568,9 +568,9 @@ jQuery(function () {
     }
 
     // Librarian Dashboard
-    const librarianDashboard = document.querySelector(".librarian-dashboard")
+    const librarianDashboard = document.querySelector('.librarian-dashboard')
     if (librarianDashboard) {
-        import(/* webpackChunkName: "librarian-dashboard" */ "./librarian-dashboard")
+        import(/* webpackChunkName: "librarian-dashboard" */ './librarian-dashboard')
             .then(module => module.initLibrarianDashboard(librarianDashboard))
     }
 });

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -566,4 +566,11 @@ jQuery(function () {
         import(/* webpackChunkName: "lazy-carousels" */ './lazy-carousel')
             .then(module => module.initLazyCarousel(lazyCarousels))
     }
+
+    // Librarian Dashboard
+    const librarianDashboard = document.querySelector(".librarian-dashboard")
+    if (librarianDashboard) {
+        import(/* webpackChunkName: "librarian-dashboard" */ "./librarian-dashboard")
+            .then(module => module.initLibrarianDashboard(librarianDashboard))
+    }
 });

--- a/openlibrary/plugins/openlibrary/js/librarian-dashboard/index.js
+++ b/openlibrary/plugins/openlibrary/js/librarian-dashboard/index.js
@@ -6,7 +6,7 @@ let i18nStrings;
  * Adds click listener to root details element of the dashboard that
  * triggers the data quality queries.
  *
- * @param rootElement {HTMLDetailsElement}
+ * @param {HTMLDetailsElement} rootElement
  */
 export function initLibrarianDashboard(rootElement) {
     i18nStrings = JSON.parse(rootElement.dataset.i18n)
@@ -19,7 +19,7 @@ export function initLibrarianDashboard(rootElement) {
 /**
  * Updates each row of the given data quality table.
  *
- * @param table {HTMLTableElement}
+ * @param {HTMLTableElement} table
  * @returns {Promise<void>}
  */
 async function populateTable(table) {
@@ -36,8 +36,8 @@ async function populateTable(table) {
 /**
  * Fetches data quality information and updates the given row accordingly.
  *
- * @param row {HTMLTableRowElement} A row in the data quality table
- * @param totalCount {number} Total number of search results
+ * @param {HTMLTableRowElement} row A row in the data quality table
+ * @param {number} totalCount Total number of search results
  * @returns {Promise<void>}
  */
 async function updateRow(row, totalCount) {
@@ -94,10 +94,9 @@ async function updateRow(row, totalCount) {
 /**
  * Returns an HTML string containing the data quality results of the given row.
  *
- * @param row {HTMLTableRowElement}
- * @param results {Record} Search results
- * @param totalCount {Number} Total number of results
- * @param failingHref {string} URL of the `/search` page for the row's query
+ * @param {Record} results Search results
+ * @param {Number} totalCount Total number of results
+ * @param {string} failingHref URL of the `/search` page for the row's query
  *
  * @returns {string} HTML string
  */
@@ -130,7 +129,7 @@ function renderRetryCell() {
 /**
  * Returns an HTML string containing an error message.
  *
- * @param href {string}
+ * @param {string} href
  * @returns {string}
  */
 function renderErrorCell(href) {

--- a/openlibrary/plugins/openlibrary/js/librarian-dashboard/index.js
+++ b/openlibrary/plugins/openlibrary/js/librarian-dashboard/index.js
@@ -138,8 +138,8 @@ function renderResultsCells(results, totalCount, failingHref) {
  */
 function renderRetryCell() {
     return `<td>
-        <button class="dqs-run-again" title="${i18nStrings['retry']}">
-            ${i18nStrings['retry']}
+        <button class="dqs-run-again">
+            ${i18nStrings['reload']}
         </button>
     </td>`
 }

--- a/openlibrary/plugins/openlibrary/js/librarian-dashboard/index.js
+++ b/openlibrary/plugins/openlibrary/js/librarian-dashboard/index.js
@@ -1,0 +1,159 @@
+let i18nStrings;
+
+/**
+ * Initializes the given librarian dashboard component.
+ *
+ * Adds click listener to root details element of the dashboard that
+ * triggers the data quality queries.
+ *
+ * @param rootElement {HTMLDetailsElement}
+ */
+export function initLibrarianDashboard(rootElement) {
+    i18nStrings = JSON.parse(rootElement.dataset.i18n)
+    const table = rootElement.querySelector(".dq-table")
+    rootElement.addEventListener("click", () => {
+        populateTable(table)
+    }, {once: true})
+}
+
+/**
+ * Updates each row of the given data quality table.
+ *
+ * @param table {HTMLTableElement}
+ * @returns {Promise<void>}
+ */
+async function populateTable(table) {
+    const bookCount = Number(table.dataset.totalBooks)
+    const rows = table.querySelectorAll(".dq-table__row")
+
+    for (const row of rows) {
+        updateRow(row, bookCount)
+        // Wait before updating next row
+        await new Promise(resolve => setTimeout(resolve, 500))
+    }
+}
+
+/**
+ * Fetches data quality information and updates the given row accordingly.
+ *
+ * @param row {HTMLTableRowElement} A row in the data quality table
+ * @param totalCount {number} Total number of search results
+ * @returns {Promise<void>}
+ */
+async function updateRow(row, totalCount) {
+    const apiUrl = row.dataset.apiUrl
+    const searchPageUrl = row.dataset.searchUiUrl
+
+    // Make query
+    const data = await makeQuery(apiUrl)
+        .then((resp) => {
+            if (!resp.ok) {
+                throw new Error(`Data quality response status : ${resp.status}`)
+            }
+            return resp.json()
+        })
+        .catch(() => {
+            return null;
+        })
+
+    // Update row with results
+    let newCellMarkup
+    if (data === null) {
+        newCellMarkup = renderErrorCell(row)
+    } else {
+        newCellMarkup = renderResultsCells(row, data, totalCount, searchPageUrl)
+    }
+
+    newCellMarkup += renderRetryCell()
+
+    const mutableCells = row.querySelectorAll("td:not(.dq-table__criterion-cell)")
+    for (const cell of mutableCells) {
+        cell.remove()
+    }
+
+    const template = document.createElement("template")
+    template.innerHTML = newCellMarkup
+    row.append(...template.content.children)
+
+    // Add listener to retry affordance
+    const retryAffordance = row.querySelector(".dqs-run-again")
+    retryAffordance.addEventListener("click", () => {
+        // Update view to "pending"
+        const oldCells = row.querySelectorAll("td:not(.dq-table__criterion-cell)")
+        for (const cell of oldCells) {
+            cell.remove()
+        }
+        template.innerHTML = renderPendingCell()
+        row.append(...template.content.children)
+
+        // Retry query
+        updateRow(row, totalCount)
+    })
+}
+
+/**
+ * Makes a `GET` query to the given URL.
+ *
+ * @param url {string}
+ * @returns {Promise<Response>}
+ */
+async function makeQuery(url) {
+    return fetch(url)
+}
+
+/**
+ * Returns an HTML string containing the data quality results of the given row.
+ *
+ * @param row {HTMLTableRowElement}
+ * @param results {Record} Search results
+ * @param totalCount {Number} Total number of results
+ * @param failingHref {string} URL of the `/search` page for the row's query
+ *
+ * @returns {string} HTML string
+ */
+function renderResultsCells(row, results, totalCount, failingHref) {
+    const numFound = results.numFound
+    const percentage = Math.floor(((totalCount - numFound) / totalCount) * 100)
+
+    return `<td class="dq-table__results-cell">
+        <meter title="${numFound} of ${totalCount}" min="0" max="100" value="${percentage}"></meter>
+        <span>${percentage}%</span>
+    </td>
+    <td style="text-align:right">
+        <a href="${failingHref}">${numFound} ${i18nStrings['failing']}</a>
+    </td>`
+}
+
+/**
+ * Returns an HTML string containing a retry button.
+ *
+ * @returns {string} HTML string
+ */
+function renderRetryCell() {
+    return `<td>
+        <button class="dqs-run-again" title="${i18nStrings['retry']}">
+            ${i18nStrings["retry"]}
+        </button>
+    </td>`
+}
+
+/**
+ * Returns an HTML string containing an error message.
+ *
+ * @param href {string}
+ * @returns {string}
+ */
+function renderErrorCell(href) {
+    return `<td colspan="2">
+        <a href="${href}">${i18nStrings['error']}</a>
+    </td>`
+}
+
+/**
+ * Returns an HTML string containing a loading message.
+ *
+ * @returns {string}
+ */
+function renderPendingCell() {
+    return `<td colspan="3">${i18nStrings['loading']}</td>`
+}

--- a/openlibrary/plugins/openlibrary/js/librarian-dashboard/index.js
+++ b/openlibrary/plugins/openlibrary/js/librarian-dashboard/index.js
@@ -10,8 +10,8 @@ let i18nStrings;
  */
 export function initLibrarianDashboard(rootElement) {
     i18nStrings = JSON.parse(rootElement.dataset.i18n)
-    const table = rootElement.querySelector(".dq-table")
-    rootElement.addEventListener("click", () => {
+    const table = rootElement.querySelector('.dq-table')
+    rootElement.addEventListener('click', () => {
         populateTable(table)
     }, {once: true})
 }
@@ -24,7 +24,7 @@ export function initLibrarianDashboard(rootElement) {
  */
 async function populateTable(table) {
     const bookCount = Number(table.dataset.totalBooks)
-    const rows = table.querySelectorAll(".dq-table__row")
+    const rows = table.querySelectorAll('.dq-table__row')
 
     await Promise.all([...rows].map(row => updateRow(row, bookCount)))
 }
@@ -67,8 +67,8 @@ async function updateRow(row, totalCount) {
     replaceStatusCells(row, newCellMarkup)
 
     // Add listener to retry affordance
-    const retryAffordance = row.querySelector(".dqs-run-again")
-    retryAffordance.addEventListener("click", () => {
+    const retryAffordance = row.querySelector('.dqs-run-again')
+    retryAffordance.addEventListener('click', () => {
         // Update view to "pending"
         replaceStatusCells(row, renderPendingCell())
 
@@ -88,7 +88,7 @@ function buildUrl(queryFragment, forUi = true) {
     const queryParamString = match ? `?q=author_key:${match[1]}` : window.location.search
 
     const params = new URLSearchParams(queryParamString)
-    params.set("q", `${params.get("q")} ${queryFragment}`)
+    params.set('q', `${params.get('q')} ${queryFragment}`)
     return `/search${forUi ? '' : '.json'}?${params.toString()}`
 }
 
@@ -99,12 +99,12 @@ function buildUrl(queryFragment, forUi = true) {
  * @param {string} newCellMarkup Markup for the new status cells
  */
 function replaceStatusCells(row, newCellMarkup) {
-    const statusCells = row.querySelectorAll("td:not(.dq-table__criterion-cell)")
+    const statusCells = row.querySelectorAll('td:not(.dq-table__criterion-cell)')
     for (const cell of statusCells) {
         cell.remove()
     }
 
-    const template = document.createElement("template")
+    const template = document.createElement('template')
     template.innerHTML = newCellMarkup
     row.append(...template.content.children)
 }
@@ -139,7 +139,7 @@ function renderResultsCells(results, totalCount, failingHref) {
 function renderRetryCell() {
     return `<td>
         <button class="dqs-run-again" title="${i18nStrings['retry']}">
-            ${i18nStrings["retry"]}
+            ${i18nStrings['retry']}
         </button>
     </td>`
 }

--- a/openlibrary/plugins/openlibrary/js/librarian-dashboard/index.js
+++ b/openlibrary/plugins/openlibrary/js/librarian-dashboard/index.js
@@ -45,7 +45,7 @@ async function updateRow(row, totalCount) {
     const searchPageUrl = row.dataset.searchUiUrl
 
     // Make query
-    const data = await makeQuery(apiUrl)
+    const data = await fetch(apiUrl)
         .then((resp) => {
             if (!resp.ok) {
                 throw new Error(`Data quality response status : ${resp.status}`)
@@ -89,16 +89,6 @@ async function updateRow(row, totalCount) {
         // Retry query
         updateRow(row, totalCount)
     })
-}
-
-/**
- * Makes a `GET` query to the given URL.
- *
- * @param url {string}
- * @returns {Promise<Response>}
- */
-async function makeQuery(url) {
-    return fetch(url)
 }
 
 /**

--- a/openlibrary/plugins/openlibrary/librarian_dashboard.py
+++ b/openlibrary/plugins/openlibrary/librarian_dashboard.py
@@ -1,8 +1,8 @@
 from urllib.parse import parse_qs, urlencode, urlparse
+
 import web
 
 from infogami.utils.view import public
-
 from openlibrary.i18n import gettext as _
 
 
@@ -11,7 +11,11 @@ def get_quality_criteria():
     def build_url(query_fragment, for_ui=True):
         page_path = web.ctx.path
         on_author_page = page_path.startswith('/authors/OL')
-        base_query = f"?q=author_key:{page_path.split('/')[2]}" if on_author_page else web.ctx.query
+        base_query = (
+            f"?q=author_key:{page_path.split('/')[2]}"
+            if on_author_page
+            else web.ctx.query
+        )
 
         parsed_query = urlparse(base_query)
         params = parse_qs(parsed_query.query)

--- a/openlibrary/plugins/openlibrary/librarian_dashboard.py
+++ b/openlibrary/plugins/openlibrary/librarian_dashboard.py
@@ -20,70 +20,58 @@ def get_quality_criteria():
         params["q"] = [q]
 
         if for_ui:
-            params["rows"] = ["0"]
             return f"/search?{urlencode(params, doseq=True)}"
 
+        params["rows"] = ["0"]
         return f"/search.json?{urlencode(params, doseq=True)}"
 
     return [
         {
             "name": _("At least 1 subject"),
-            "apiUrl": build_url("NOT subject:*", for_ui=False),
-            "searchPageUrl": build_url("NOT subject:*"),
+            "queryFragment": "NOT subject:*",
         },
         {
             "name": _("At least 1 author"),
-            "apiUrl": build_url("NOT author_key:*", for_ui=False),
-            "searchPageUrl": build_url("NOT author_key:*"),
+            "queryFragment": "NOT author_key:*",
         },
         {
             "name": _("At least 1 edition"),
-            "apiUrl": build_url("edition_count:0", for_ui=False),
-            "searchPageUrl": build_url("edition_count:0"),
+            "queryFragment": "edition_count:0",
         },
         {
             "name": _("Has work (orphaned)"),
-            "apiUrl": build_url("key:*M", for_ui=False),
-            "searchPageUrl": build_url("key:*M"),
+            "queryFragment": "key:*M",
         },
         {
             "name": _("Has publication year"),
-            "apiUrl": build_url("NOT publish_year:*", for_ui=False),
-            "searchPageUrl": build_url("NOT publish_year:*"),
+            "queryFragment": "NOT publish_year:*",
         },
         {
             "name": _("Has cover"),
-            "apiUrl": build_url("NOT cover_i:*", for_ui=False),
-            "searchPageUrl": build_url("NOT cover_i:*"),
+            "queryFragment": "NOT cover_i:*",
         },
         {
             "name": _("Has language"),
-            "apiUrl": build_url("NOT language:*", for_ui=False),
-            "searchPageUrl": build_url("NOT language:*"),
+            "queryFragment": "NOT language:*",
         },
         {
             "name": _("Has publisher"),
-            "apiUrl": build_url("NOT publisher:*", for_ui=False),
-            "searchPageUrl": build_url("NOT publisher:*"),
+            "queryFragment": "NOT publisher:*",
         },
         {
             "name": _("At least 2 editions"),
-            "apiUrl": build_url("edition_count:[0 TO 1]", for_ui=False),
-            "searchPageUrl": build_url("edition_count:[0 TO 1]"),
+            "queryFragment": "edition_count:[0 TO 1]",
         },
         {
             "name": _("Has dewey decimal"),
-            "apiUrl": build_url("NOT ddc:*", for_ui=False),
-            "searchPageUrl": build_url("NOT ddc:*"),
+            "queryFragment": "NOT ddc:*",
         },
         {
             "name": _("Has LoC classification"),
-            "apiUrl": build_url("NOT lcc:*", for_ui=False),
-            "searchPageUrl": build_url("NOT lcc:*"),
+            "queryFragment": "NOT lcc:*",
         },
         {
             "name": _("Has number of pages"),
-            "apiUrl": build_url("OT number_of_pages_median:*", for_ui=False),
-            "searchPageUrl": build_url("OT number_of_pages_median:*"),
+            "queryFragment": "NOT number_of_pages_median:*",
         },
     ]

--- a/openlibrary/plugins/openlibrary/librarian_dashboard.py
+++ b/openlibrary/plugins/openlibrary/librarian_dashboard.py
@@ -8,99 +8,82 @@ from openlibrary.i18n import gettext as _
 
 @public
 def get_quality_criteria():
-    def build_work_search_url(query_fragment):
+    def build_url(query_fragment, for_ui=True):
         page_path = web.ctx.path
         on_author_page = page_path.startswith('/authors/OL')
-        if on_author_page:
-            base_query = f"?q=author_key:{page_path.split('/')[2]}"
-        else:
-            base_query = f"{web.ctx.query}"
+        base_query = f"?q=author_key:{page_path.split('/')[2]}" if on_author_page else web.ctx.query
 
         parsed_query = urlparse(base_query)
         params = parse_qs(parsed_query.query)
         q = params.get("q", [""])[0]
         q += f" {query_fragment}"
         params["q"] = [q]
+
+        if for_ui:
+            params["rows"] = ["0"]
+            return f"/search?{urlencode(params, doseq=True)}"
 
         return f"/search.json?{urlencode(params, doseq=True)}"
-
-
-    def build_search_page_url(query_fragment):
-        page_path = web.ctx.path
-        on_author_page = page_path.startswith('/authors/OL')
-        if on_author_page:
-            base_query = f"?q=author_key:{page_path.split('/')[2]}"
-        else:
-            base_query = f"{web.ctx.query}"
-
-        parsed_query = urlparse(base_query)
-        params = parse_qs(parsed_query.query)
-        q = params.get("q", [""])[0]
-        q += f" {query_fragment}"
-        params["q"] = [q]
-        params["rows"] = ["0"]
-
-        return f"/search?{urlencode(params, doseq=True)}"
 
     return [
         {
             "name": _("At least 1 subject"),
-            "apiUrl": build_work_search_url("NOT subject:*"),
-            "searchPageUrl": build_search_page_url("NOT subject:*"),
+            "apiUrl": build_url("NOT subject:*", for_ui=False),
+            "searchPageUrl": build_url("NOT subject:*"),
         },
         {
             "name": _("At least 1 author"),
-            "apiUrl": build_work_search_url("NOT author_key:*"),
-            "searchPageUrl": build_search_page_url("NOT author_key:*"),
+            "apiUrl": build_url("NOT author_key:*", for_ui=False),
+            "searchPageUrl": build_url("NOT author_key:*"),
         },
         {
             "name": _("At least 1 edition"),
-            "apiUrl": build_work_search_url("edition_count:0"),
-            "searchPageUrl": build_search_page_url("edition_count:0"),
+            "apiUrl": build_url("edition_count:0", for_ui=False),
+            "searchPageUrl": build_url("edition_count:0"),
         },
         {
             "name": _("Has work (orphaned)"),
-            "apiUrl": build_work_search_url("key:*M"),
-            "searchPageUrl": build_search_page_url("key:*M"),
+            "apiUrl": build_url("key:*M", for_ui=False),
+            "searchPageUrl": build_url("key:*M"),
         },
         {
             "name": _("Has publication year"),
-            "apiUrl": build_work_search_url("NOT publish_year:*"),
-            "searchPageUrl": build_search_page_url("NOT publish_year:*"),
+            "apiUrl": build_url("NOT publish_year:*", for_ui=False),
+            "searchPageUrl": build_url("NOT publish_year:*"),
         },
         {
             "name": _("Has cover"),
-            "apiUrl": build_work_search_url("NOT cover_i:*"),
-            "searchPageUrl": build_search_page_url("NOT cover_i:*"),
+            "apiUrl": build_url("NOT cover_i:*", for_ui=False),
+            "searchPageUrl": build_url("NOT cover_i:*"),
         },
         {
             "name": _("Has language"),
-            "apiUrl": build_work_search_url("NOT language:*"),
-            "searchPageUrl": build_search_page_url("NOT language:*"),
+            "apiUrl": build_url("NOT language:*", for_ui=False),
+            "searchPageUrl": build_url("NOT language:*"),
         },
         {
             "name": _("Has publisher"),
-            "apiUrl": build_work_search_url("NOT publisher:*"),
-            "searchPageUrl": build_search_page_url("NOT publisher:*"),
+            "apiUrl": build_url("NOT publisher:*", for_ui=False),
+            "searchPageUrl": build_url("NOT publisher:*"),
         },
         {
             "name": _("At least 2 editions"),
-            "apiUrl": build_work_search_url("edition_count:[0 TO 1]"),
-            "searchPageUrl": build_search_page_url("edition_count:[0 TO 1]"),
+            "apiUrl": build_url("edition_count:[0 TO 1]", for_ui=False),
+            "searchPageUrl": build_url("edition_count:[0 TO 1]"),
         },
         {
             "name": _("Has dewey decimal"),
-            "apiUrl": build_work_search_url("NOT ddc:*"),
-            "searchPageUrl": build_search_page_url("NOT ddc:*"),
+            "apiUrl": build_url("NOT ddc:*", for_ui=False),
+            "searchPageUrl": build_url("NOT ddc:*"),
         },
         {
             "name": _("Has LoC classification"),
-            "apiUrl": build_work_search_url("NOT lcc:*"),
-            "searchPageUrl": build_search_page_url("NOT lcc:*"),
+            "apiUrl": build_url("NOT lcc:*", for_ui=False),
+            "searchPageUrl": build_url("NOT lcc:*"),
         },
         {
             "name": _("Has number of pages"),
-            "apiUrl": build_work_search_url("OT number_of_pages_median:*"),
-            "searchPageUrl": build_search_page_url("OT number_of_pages_median:*"),
+            "apiUrl": build_url("OT number_of_pages_median:*", for_ui=False),
+            "searchPageUrl": build_url("OT number_of_pages_median:*"),
         },
     ]

--- a/openlibrary/plugins/openlibrary/librarian_dashboard.py
+++ b/openlibrary/plugins/openlibrary/librarian_dashboard.py
@@ -1,0 +1,106 @@
+from urllib.parse import parse_qs, urlencode, urlparse
+import web
+
+from infogami.utils.view import public
+
+from openlibrary.i18n import gettext as _
+
+
+@public
+def get_quality_criteria():
+    def build_work_search_url(query_fragment):
+        page_path = web.ctx.path
+        on_author_page = page_path.startswith('/authors/OL')
+        if on_author_page:
+            base_query = f"?q=author_key:{page_path.split('/')[2]}"
+        else:
+            base_query = f"{web.ctx.query}"
+
+        parsed_query = urlparse(base_query)
+        params = parse_qs(parsed_query.query)
+        q = params.get("q", [""])[0]
+        q += f" {query_fragment}"
+        params["q"] = [q]
+
+        return f"/search.json?{urlencode(params, doseq=True)}"
+
+
+    def build_search_page_url(query_fragment):
+        page_path = web.ctx.path
+        on_author_page = page_path.startswith('/authors/OL')
+        if on_author_page:
+            base_query = f"?q=author_key:{page_path.split('/')[2]}"
+        else:
+            base_query = f"{web.ctx.query}"
+
+        parsed_query = urlparse(base_query)
+        params = parse_qs(parsed_query.query)
+        q = params.get("q", [""])[0]
+        q += f" {query_fragment}"
+        params["q"] = [q]
+        params["rows"] = ["0"]
+
+        return f"/search?{urlencode(params, doseq=True)}"
+
+    return [
+        {
+            "name": _("At least 1 subject"),
+            "apiUrl": build_work_search_url("NOT subject:*"),
+            "searchPageUrl": build_search_page_url("NOT subject:*"),
+        },
+        {
+            "name": _("At least 1 author"),
+            "apiUrl": build_work_search_url("NOT author_key:*"),
+            "searchPageUrl": build_search_page_url("NOT author_key:*"),
+        },
+        {
+            "name": _("At least 1 edition"),
+            "apiUrl": build_work_search_url("edition_count:0"),
+            "searchPageUrl": build_search_page_url("edition_count:0"),
+        },
+        {
+            "name": _("Has work (orphaned)"),
+            "apiUrl": build_work_search_url("key:*M"),
+            "searchPageUrl": build_search_page_url("key:*M"),
+        },
+        {
+            "name": _("Has publication year"),
+            "apiUrl": build_work_search_url("NOT publish_year:*"),
+            "searchPageUrl": build_search_page_url("NOT publish_year:*"),
+        },
+        {
+            "name": _("Has cover"),
+            "apiUrl": build_work_search_url("NOT cover_i:*"),
+            "searchPageUrl": build_search_page_url("NOT cover_i:*"),
+        },
+        {
+            "name": _("Has language"),
+            "apiUrl": build_work_search_url("NOT language:*"),
+            "searchPageUrl": build_search_page_url("NOT language:*"),
+        },
+        {
+            "name": _("Has publisher"),
+            "apiUrl": build_work_search_url("NOT publisher:*"),
+            "searchPageUrl": build_search_page_url("NOT publisher:*"),
+        },
+        {
+            "name": _("At least 2 editions"),
+            "apiUrl": build_work_search_url("edition_count:[0 TO 1]"),
+            "searchPageUrl": build_search_page_url("edition_count:[0 TO 1]"),
+        },
+        {
+            "name": _("Has dewey decimal"),
+            "apiUrl": build_work_search_url("NOT ddc:*"),
+            "searchPageUrl": build_search_page_url("NOT ddc:*"),
+        },
+        {
+            "name": _("Has LoC classification"),
+            "apiUrl": build_work_search_url("NOT lcc:*"),
+            "searchPageUrl": build_search_page_url("NOT lcc:*"),
+        },
+        {
+            "name": _("Has number of pages"),
+            "apiUrl": build_work_search_url("OT number_of_pages_median:*"),
+            "searchPageUrl": build_search_page_url("OT number_of_pages_median:*"),
+        },
+    ]

--- a/openlibrary/templates/librarian_dashboard/data_quality_table.html
+++ b/openlibrary/templates/librarian_dashboard/data_quality_table.html
@@ -10,7 +10,7 @@ $ quality_criteria = get_quality_criteria()
 $ i18n_strings = {
 $     "error": _("Error"),
 $     "loading": _("Loading..."),
-$     "retry": _("Retry"),
+$     "reload": _("Reload"),
 $     "failing": _("failing"),
 $ }
 

--- a/openlibrary/templates/librarian_dashboard/data_quality_table.html
+++ b/openlibrary/templates/librarian_dashboard/data_quality_table.html
@@ -1,0 +1,37 @@
+$def with(total_books)
+
+$# Template for the librarian data quality table.
+$# Each row in the table is meant to display the amount of books that do not
+$# meet a specific data quality criterion.
+$# Queries for the data scores are expected to be made client-side.  Query URLs
+$# for each row are added as data attributes.
+
+$# total_books : number : Total number of books in the universe of books represented by the table
+
+$ checklist = get_quality_criteria()
+$ i18n_strings = {
+$     "error": _("Error"),
+$     "loading": _("Loading..."),
+$     "retry": _("Retry"),
+$     "failing": _("failing"),
+$ }
+
+<details class="librarian-dashboard" data-i18n="$json_encode(i18n_strings)">
+  <summary>$_("Data quality table")</summary>
+  <table class="dq-table" data-total-books="$total_books">
+    <colgroup>
+      <col />
+      <col span="3" />
+    </colgroup>
+    <tr class="dq-table__table-header">
+      <th scope="col">$_("Quality Criteria")</th>
+      <th scope="colgroup" colspan="3">$_("Status")</th>
+    </tr>
+    $for item in checklist:
+      $# Each row starts in a "Pending" state
+      <tr class="dq-table__row" data-api-url="$item.get('apiUrl')" data-search-ui-url="$item.get('searchPageUrl')">
+          <td class="dq-table__criterion-cell">$item.get("name")</td>
+          <td colspan="3">$_("Loading...")</td>
+      </tr>
+  </table>
+</details>

--- a/openlibrary/templates/librarian_dashboard/data_quality_table.html
+++ b/openlibrary/templates/librarian_dashboard/data_quality_table.html
@@ -3,12 +3,10 @@ $def with(total_books)
 $# Template for the librarian data quality table.
 $# Each row in the table is meant to display the amount of books that do not
 $# meet a specific data quality criterion.
-$# Queries for the data scores are expected to be made client-side.  Query URLs
-$# for each row are added as data attributes.
 
 $# total_books : number : Total number of books in the universe of books represented by the table
 
-$ checklist = get_quality_criteria()
+$ quality_criteria = get_quality_criteria()
 $ i18n_strings = {
 $     "error": _("Error"),
 $     "loading": _("Loading..."),
@@ -27,9 +25,9 @@ $ }
       <th scope="col">$_("Quality Criteria")</th>
       <th scope="colgroup" colspan="3">$_("Status")</th>
     </tr>
-    $for item in checklist:
+    $for item in quality_criteria:
       $# Each row starts in a "Pending" state
-      <tr class="dq-table__row" data-api-url="$item.get('apiUrl')" data-search-ui-url="$item.get('searchPageUrl')">
+      <tr class="dq-table__row" data-query-fragment="$item.get('queryFragment')">
           <td class="dq-table__criterion-cell">$item.get("name")</td>
           <td colspan="3">$_("Loading...")</td>
       </tr>

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -99,7 +99,9 @@ $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_libra
         </div>
 
     <div class="contentTwothird" style="margin-bottom:0;">
-
+        $ show_dashboard = ctx.user and (ctx.user.is_librarian() or ctx.user.is_super_librarian() or ctx.user.is_admin())
+        $if show_dashboard:
+          $:render_template("librarian_dashboard/data_quality_table", books_count)
         <div itemprop="description">
             $:format(page.get('bio', ''))
         </div>

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -6,6 +6,10 @@ $def with (q_param, search_response, get_doc, param, page, rows)
     </div>
 
 <div id="contentBody">
+  $ show_dashboard = ctx.user and (ctx.user.is_librarian() or ctx.user.is_super_librarian() or ctx.user.is_admin())
+  $if show_dashboard:
+    $:render_template("librarian_dashboard/data_quality_table", search_response.num_found)
+
   $:macros.SearchNavigation()
   <div class="section">
 

--- a/static/css/components/librarian-dashboard.less
+++ b/static/css/components/librarian-dashboard.less
@@ -1,0 +1,59 @@
+details.librarian-dashboard {
+  color: @grey;
+  margin-bottom: 15px;
+
+  summary {
+    font-weight: 700;
+  }
+}
+
+.dq-table {
+  min-width: 75%;
+  border: 1px solid @grey;
+  margin: 10px;
+
+  th {
+    background: @white;
+    font-weight: 700;
+    text-align: center;
+    padding: 8px;
+  }
+
+  .dq-table__row {
+    display: table-row;
+    background: @white;
+
+    td {
+      display: table-cell;
+      padding: 8px;
+    }
+
+    .dq-table__criterion-cell {
+      font-weight: 700;
+      width: 30%;
+    }
+
+    .dq-table__results-cell {
+      display: flex;
+      justify-content: flex-end;
+
+      span {
+        width: 60px;
+        text-align: right;
+      }
+    }
+
+    &:nth-child(even) {
+      background: @lightest-grey;
+    }
+  }
+
+  .dqs-run-again {
+    border: 0;
+    background: none;
+    text-decoration: underline;
+    color: @link-blue;
+    cursor: pointer;
+    float: right;
+  }
+}

--- a/static/css/components/librarian-dashboard.less
+++ b/static/css/components/librarian-dashboard.less
@@ -19,35 +19,6 @@ details.librarian-dashboard {
     padding: 8px;
   }
 
-  .dq-table__row {
-    display: table-row;
-    background: @white;
-
-    td {
-      display: table-cell;
-      padding: 8px;
-    }
-
-    .dq-table__criterion-cell {
-      font-weight: 700;
-      width: 30%;
-    }
-
-    .dq-table__results-cell {
-      display: flex;
-      justify-content: flex-end;
-
-      span {
-        width: 60px;
-        text-align: right;
-      }
-    }
-
-    &:nth-child(even) {
-      background: @lightest-grey;
-    }
-  }
-
   .dqs-run-again {
     border: 0;
     background: none;
@@ -55,5 +26,34 @@ details.librarian-dashboard {
     color: @link-blue;
     cursor: pointer;
     float: right;
+  }
+}
+
+.dq-table__row {
+  display: table-row;
+  background: @white;
+
+  td {
+    display: table-cell;
+    padding: 8px;
+  }
+
+  .dq-table__criterion-cell {
+    font-weight: 700;
+    width: 30%;
+  }
+
+  .dq-table__results-cell {
+    display: flex;
+    justify-content: flex-end;
+
+    span {
+      width: 60px;
+      text-align: right;
+    }
+  }
+
+  &:nth-child(even) {
+    background: @lightest-grey;
   }
 }

--- a/static/css/components/librarian-dashboard.less
+++ b/static/css/components/librarian-dashboard.less
@@ -1,11 +1,12 @@
 details.librarian-dashboard {
   color: @grey;
   margin-bottom: 15px;
+  max-width: 700px;
 }
 
 .dq-table {
-  min-width: 75%;
   border: 1px solid @grey;
+  width: 100%;
   margin: 10px;
 
   th {
@@ -40,6 +41,11 @@ details.librarian-dashboard {
   .dq-table__results-cell {
     display: flex;
     justify-content: flex-end;
+
+    span {
+      width: 60px;
+      text-align: right;
+    }
   }
 
   &:nth-child(even) {

--- a/static/css/components/librarian-dashboard.less
+++ b/static/css/components/librarian-dashboard.less
@@ -1,10 +1,6 @@
 details.librarian-dashboard {
   color: @grey;
   margin-bottom: 15px;
-
-  summary {
-    font-weight: 700;
-  }
 }
 
 .dq-table {
@@ -30,12 +26,10 @@ details.librarian-dashboard {
 }
 
 .dq-table__row {
-  display: table-row;
   background: @white;
 
   td {
-    display: table-cell;
-    padding: 8px;
+    padding: 4px 8px;
   }
 
   .dq-table__criterion-cell {
@@ -46,11 +40,6 @@ details.librarian-dashboard {
   .dq-table__results-cell {
     display: flex;
     justify-content: flex-end;
-
-    span {
-      width: 60px;
-      text-align: right;
-    }
   }
 
   &:nth-child(even) {

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -1,5 +1,6 @@
 @import (less) "base/dl.less";
 @import (less) "components/nav-bar.less";
+@import (less) "components/librarian-dashboard.less";
 
 @sidebar-width: 225px;
 @sidebar-width-with-margin: 60px + @sidebar-width;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7661

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds a `details` element containing a book data quality table to work search and author pages.

Data quality queries criteria and queries are returned as a list by the `get_quality_criteria` public function.  Adding a new `dict` with the following key-value pairs to this list will auotmatically include the new quality criterion to the table:

`name`: Describes the criterion (e.g. "Has number of pages")
`apiUrl`: URL that will return books that fit the criteria
`searchPageUrl`: URL for a `/search` containing books that fit the criteria

Each row in the data quality table can have one of three states:
- __Pending:__ Shows a loading message.
- __Error:__ Shows an error message, and a retry affordance.
- __Success:__ Displays the number of quality books, a link to the `/search` page containing the query results, and a retry affordance.

Each row is initially in a `Pending` state on page load.  No data quality queries are made until the `details` element is first expanded.  Afterwards, the query for each row is executed and the table is updated.  There is a small delay between each query in order to avoid overwhelming the server with requests.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot 2025-05-12 163111](https://github.com/user-attachments/assets/8cf6da38-9fe8-42f2-989d-3c8c7e4167a0)
_Data quality table after successfully querying for each criterion._

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
