### PR TITLE
Forward ?lang param when rendering partials

### DIFF
--- a/openlibrary/plugins/openlibrary/js/affiliate-links.js
+++ b/openlibrary/plugins/openlibrary/js/affiliate-links.js
@@ -1,3 +1,5 @@
+import { buildPartialsUrl } from './utils'
+
 /**
  * Adds functionality to fetch affialite links asyncronously.
  *
@@ -49,9 +51,8 @@ function showLoadingIndicators(linkSections) {
  */
 async function getPartials(data, affiliateLinksSections) {
     const dataString = JSON.stringify(data)
-    const dataQueryParam = encodeURIComponent(dataString)
 
-    return fetch(`/partials.json?_component=AffiliateLinks&data=${dataQueryParam}`)
+    return fetch(buildPartialsUrl('/partials.json', {_component: 'AffiliateLinks', data: dataString}))
         .then((resp) => {
             if (resp.status !== 200) {
                 throw new Error(`Failed to fetch partials. Status code: ${resp.status}`)

--- a/openlibrary/plugins/openlibrary/js/book-page-lists.js
+++ b/openlibrary/plugins/openlibrary/js/book-page-lists.js
@@ -1,3 +1,5 @@
+import { buildPartialsUrl } from './utils'
+
 /**
  * Initializes lazy-loading the "Lists" section of Open Library book pages.
  *
@@ -61,6 +63,6 @@ async function fetchPartials(workId, editionId) {
     if (editionId) {
         params.editionId = editionId
     }
-    const searchParams = new URLSearchParams(params)
-    return fetch(`/partials.json?${searchParams.toString()}`)
+
+    return fetch(buildPartialsUrl('/partials.json', params));
 }

--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -1,6 +1,7 @@
 // Slick#1.6.0 is not on npm
 import 'slick-carousel';
 import '../../../../../static/css/components/carousel--js.less';
+import { buildPartialsUrl } from  '../utils.js';
 
 /**
  * @typedef {Object} CarouselConfig
@@ -142,9 +143,8 @@ export class Carousel {
     }
 
     fetchPartials() {
-        const url = new URL(`${location.origin}/partials.json`)
         const loadMore = this.loadMore
-        const params = {
+        const url = buildPartialsUrl('/partials.json', {
             _component: 'CarouselLoadMore',
             queryType: loadMore.queryType,
             q: loadMore.q,
@@ -156,8 +156,7 @@ export class Carousel {
             hasFulltextOnly: loadMore.hasFulltextOnly,
             secondaryAction: loadMore.secondaryAction,
             key: loadMore.key
-        }
-        url.search = new URLSearchParams(params).toString()
+        });
         this.appendLoadingSlide();
         $.ajax({url: url, type: 'GET'})
             .then((results) => {

--- a/openlibrary/plugins/openlibrary/js/check-ins/index.js
+++ b/openlibrary/plugins/openlibrary/js/check-ins/index.js
@@ -4,6 +4,7 @@
  */
 import { PersistentToast } from '../Toast'
 import { initDialogs } from '../native-dialog'
+import { buildPartialsUrl } from '../utils'
 
 /**
  * Enum for check-in event types.
@@ -587,7 +588,7 @@ function updateProgressComponent(elem, goal) {
  * @param {string} goalYear Year that the goal is set for.
  */
 function fetchProgressAndUpdateViews(yearlyGoalElems, goalYear) {
-    fetch(`/reading-goal/partials.json?year=${goalYear}`)
+    fetch(buildPartialsUrl('/reading-goal/partials.json', {year: goalYear}))
         .then((response) => {
             if (!response.ok) {
                 throw new Error('Failed to fetch progress element')

--- a/openlibrary/plugins/openlibrary/js/fulltext-search-suggestion.js
+++ b/openlibrary/plugins/openlibrary/js/fulltext-search-suggestion.js
@@ -1,3 +1,5 @@
+import { buildPartialsUrl } from './utils'
+
 export function initFulltextSearchSuggestion(fulltextSearchSuggestion) {
     const isLoading = showLoadingIndicators(fulltextSearchSuggestion)
     if (isLoading) {
@@ -16,8 +18,7 @@ function showLoadingIndicators(fulltextSearchSuggestion) {
     return isLoading
 }
 async function getPartials(fulltextSearchSuggestion, query) {
-    const queryParam = encodeURIComponent(query)
-    return fetch(`/partials.json?_component=FulltextSearchSuggestion&data=${queryParam}`)
+    return fetch(buildPartialsUrl('/partials.json', {_component: 'FulltextSearchSuggestion', data: query}))
         .then((resp) => {
             if (resp.status !== 200) {
                 throw new Error(`Failed to fetch partials. Status code: ${resp.status}`)

--- a/openlibrary/plugins/openlibrary/js/lazy-carousel.js
+++ b/openlibrary/plugins/openlibrary/js/lazy-carousel.js
@@ -1,4 +1,5 @@
 import {initialzeCarousels} from './carousel';
+import { buildPartialsUrl } from './utils';
 
 /**
  * Adds functionality that allows carousels to lazy-load when a patron
@@ -34,8 +35,7 @@ export function initLazyCarousel(elems) {
  * @returns {Promise<Response>}
  */
 async function fetchPartials(data) {
-    const searchParams = new URLSearchParams({...data, _component: 'LazyCarousel'})
-    return fetch(`/partials.json?${searchParams.toString()}`)
+    return fetch(buildPartialsUrl('/partials.json', {...data, _component: 'LazyCarousel'}))
 }
 
 /**

--- a/openlibrary/plugins/openlibrary/js/lists/ListService.js
+++ b/openlibrary/plugins/openlibrary/js/lists/ListService.js
@@ -3,6 +3,8 @@
  * @module lists/ListService
  */
 
+import { buildPartialsUrl } from '../utils';
+
 /**
  * Makes a POST to a `.json` endpoint.
  * @param {object} data Configurations and payload for POST request.
@@ -158,14 +160,14 @@ export function updateReadingLog(formElem, success) {
 export function fetchPartials(key, success) {
     $.ajax({
         type: 'GET',
-        url: `/lists/partials.json?key=${key}`,
+        url: buildPartialsUrl('/lists/partials.json', {key}),
         success: success
     })
 }
 
 // XXX : jsdoc
 export async function getListPartials() {
-    return await fetch('/lists/partials.json', {
+    return await fetch(buildPartialsUrl('/lists/partials.json'), {
         method: 'GET',
         headers: {
             'Content-Type': 'application/json',

--- a/openlibrary/plugins/openlibrary/js/search.js
+++ b/openlibrary/plugins/openlibrary/js/search.js
@@ -2,6 +2,8 @@
  * Functionalities for templates/work_search and related templates.
  */
 
+import { buildPartialsUrl } from './utils';
+
 /**
  * Displays more facets by removing the ui-helper-hidden class.
  *
@@ -129,12 +131,11 @@ function fetchPartials(param) {
         path: location.pathname,
         query: location.search
     }
-    const dataString = JSON.stringify(data)
 
-    return fetch(`/partials.json?${new URLSearchParams({
+    return fetch(buildPartialsUrl('/partials.json', {
         _component: 'SearchFacets',
-        data: dataString
-    })}`)
+        data: JSON.stringify(data),
+    }))
         .then((resp) => {
             if (!resp.ok) {
                 throw new Error(`Failed to fetch partials. Status code: ${resp.status}`)

--- a/openlibrary/plugins/openlibrary/js/utils.js
+++ b/openlibrary/plugins/openlibrary/js/utils.js
@@ -72,3 +72,17 @@ export function trimInputValues(param) {
         });
     });
 }
+
+export function buildPartialsUrl(path, params) {
+    const curUrl = new URL(window.location.href);
+    const url = new URL(location.origin + path);
+    if (curUrl.searchParams.has('lang')) {
+        url.searchParams.set('lang', curUrl.searchParams.get('lang'));
+    }
+
+    for (const key in params) {
+        url.searchParams.set(key, params[key]);
+    }
+
+    return url;
+}


### PR DESCRIPTION
Small feature to make i18n changes easier to test. Changing the language dropper works for the languages in that list, but we often want to test other languages.

Without this change, e.g. the second fetched page of a carousel will ignore the ?lang value.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@jimchamp 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
