### PR TITLE
Update Print Disability checkbox label copy

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -1416,7 +1416,7 @@ msgstr ""
 
 #: openlibrary/plugins/upstream/forms.py
 msgid ""
-"I want to apply for <a href=\"https://help.archive.org/help/program-"
+"I want to apply* for <a href=\"https://help.archive.org/help/program-"
 "overview/\">special print disability access</a> through a qualifying "
 "program."
 msgstr ""

--- a/openlibrary/plugins/upstream/forms.py
+++ b/openlibrary/plugins/upstream/forms.py
@@ -123,7 +123,7 @@ class RegisterForm(Form):
         Checkbox(
             "pd_request",
             description=_(
-                'I want to apply for <a href="https://help.archive.org/help/program-overview/">'
+                'I want to apply* for <a href="https://help.archive.org/help/program-overview/">'
                 'special print disability access</a> through a qualifying program.'
             ),
         ),


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds an asterisk after the word `apply` in the print disability access request checkbox's label.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
