### PR TITLE
use cover aspect ratio on works page

### DIFF
--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -58,7 +58,7 @@ class Image:
         self.category = category
         self.id = id
 
-    def info(self):
+    def info(self) -> dict[str, Any] | None:
         url = f'{get_coverstore_url()}/{self.category}/id/{self.id}.json'
         if url.startswith("//"):
             url = "http:" + url
@@ -74,7 +74,13 @@ class Image:
             # coverstore is down
             return None
 
-    def url(self, size="M"):
+    def get_aspect_ratio(self) -> float | None:
+        info = self.info()
+        if info and "width" in info and "height" in info:
+            return info["width"] / info["height"]
+        return None
+
+    def url(self, size="M") -> str:
         """Get the public URL of the image."""
         coverstore_url = get_coverstore_public_url()
         return f"{coverstore_url}/{self.category}/id/{self.id}-{size.upper()}.jpg"

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -76,7 +76,7 @@ class Image:
 
     def get_aspect_ratio(self) -> float | None:
         info = self.info()
-        if info and "width" in info and "height" in info:
+        if info and item.get('width') and item.get('height'):
             return info["width"] / info["height"]
         return None
 

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -76,7 +76,7 @@ class Image:
 
     def get_aspect_ratio(self) -> float | None:
         info = self.info()
-        if info and item.get('width') and item.get('height'):
+        if info and info.get('width') and info.get('height'):
             return info["width"] / info["height"]
         return None
 

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -82,6 +82,11 @@ class Edition(models.Edition):
         elif self.ocaid:
             return self.get_ia_cover(self.ocaid, size)
 
+    def get_cover_aspect_ratio(self) -> float | None:
+        if cover := self.get_cover():
+            return cover.get_aspect_ratio()
+        return None
+
     def get_ia_cover(self, itemid, size):
         image_sizes = {"S": (116, 58), "M": (180, 360), "L": (500, 500)}
         w, h = image_sizes[size.upper()]

--- a/openlibrary/templates/covers/book_cover.html
+++ b/openlibrary/templates/covers/book_cover.html
@@ -9,6 +9,8 @@ $if not author_names:
 
 $ cover_url = book.get_cover_url("M")
 $ cover_lg = book.get_cover_url("L")
+$ cover_aspect_ratio = book.get_cover_aspect_ratio()
+$ cover_aspect_ratio_str = 'aspect-ratio: ' + str(cover_aspect_ratio) if cover_aspect_ratio else ""
 
 $ src = cover_url or '/images/icons/avatar_book.png'
 $ srcset = '%s 2x' % (cover_lg or '/images/icons/avatar_book-lg.png')
@@ -30,6 +32,7 @@ $if preload:
                 src="$src"
                 srcset="$srcset"
                 class="cover"
+                style="$cover_aspect_ratio_str"
                 alt="$_('Cover of: %(title)s by %(authors)s', title=title, authors=author_names)"
             >
         </a>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Part of #9739

This is a continuation of https://github.com/internetarchive/openlibrary/pull/10145

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

- [ ] After this PR we can do the same for author pages

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
You can test it on a works page like: 
https://openlibrary.org/books/OL32856480M/A_Court_of_Mist_and_Fury

If you inspect the source you should see the aspect ratio added to the image style

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

https://github.com/user-attachments/assets/0260f9a1-757e-46aa-b44f-1dd44d695060



### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
