### PR TITLE
Updates to PD registration flow

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -362,8 +362,6 @@ def _set_account_cookies(ol_account: OpenLibraryAccount, expires: int | str) -> 
 
 def _handle_pd_cookies(ol_account: OpenLibraryAccount) -> None:
     pda = web.cookies().get("pda")
-    if pda == "unqualified":
-        pda = "vtmas_disabilityresources"
     ol_account.get_user().save_preferences(
         {
             "rpd": 1,
@@ -375,6 +373,7 @@ def _handle_pd_cookies(ol_account: OpenLibraryAccount) -> None:
 
 def _notify_on_rpd_verification(ol_account, org):
     if org:
+        org = "vtmas_disabilityresources" if org == "unqualified" else org
         displayname = web.safestr(ol_account.displayname)
         msg = render_template(
             "email/account/pd_request", displayname=displayname, org=org


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Makes the following changes to the PD flow when a patron first logs in:

- `unqualifed` `pda` values are captured on the account
- `pda` and `rpd` values are written to the account before the email is sent
- Adds a new `rpd` status code (this may require discussion), and encodes these as an `Enum`

#### New login flow:
1. Patron with `pda` cookie logs in.
2. The `pda` value is added to the patron's account
3. `rpd` is added to the account, with a value of `0` (signifying that they are requesting special access).
4. "Next steps" email is sent to patron.
5. Account's `rpd` value is updated to `1` (meaning that the email has been sent).
6. `pda` cookie is unset and expired.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
