### PR TITLE
avoid repaint on manage covers page by hiding text until needed

### DIFF
--- a/openlibrary/plugins/openlibrary/js/covers.js
+++ b/openlibrary/plugins/openlibrary/js/covers.js
@@ -10,13 +10,10 @@ import { closePopup } from './utils';
 //cover/change.html
 export function initCoversChange() {
     // Pull data from data-config of class "manageCovers" in covers/manage.html
-    const manageCoversElement = $('.manageCovers');
-    const data_config_json = manageCoversElement.data('config');
+    const data_config_json = $('.manageCovers').data('config');
     const doc_type_key = data_config_json['key'];
     const add_url = data_config_json['add_url'];
     const manage_url = data_config_json['manage_url'];
-    // Hide the covers module until we run this function to avoid repaints.
-    manageCoversElement.removeClass('hidden');
 
     // Add iframes lazily when the popup is loaded.
     // This avoids fetching the iframes along with main page.

--- a/openlibrary/plugins/openlibrary/js/covers.js
+++ b/openlibrary/plugins/openlibrary/js/covers.js
@@ -10,10 +10,13 @@ import { closePopup } from './utils';
 //cover/change.html
 export function initCoversChange() {
     // Pull data from data-config of class "manageCovers" in covers/manage.html
-    const data_config_json = $('.manageCovers').data('config');
+    const manageCoversElement = $('.manageCovers');
+    const data_config_json = manageCoversElement.data('config');
     const doc_type_key = data_config_json['key'];
     const add_url = data_config_json['add_url'];
     const manage_url = data_config_json['manage_url'];
+    // Hide the covers module until we run this function to avoid repaints.
+    manageCoversElement.removeClass('hidden');
 
     // Add iframes lazily when the popup is loaded.
     // This avoids fetching the iframes along with main page.

--- a/openlibrary/templates/covers/change.html
+++ b/openlibrary/templates/covers/change.html
@@ -27,9 +27,10 @@ $else:
         $ change = _('Add Cover Image')
         $ size = "smallest"
 
-<div class="$size sansserif manageCoversContainer hidden--nojs">
-  <a aria-controls="addImage-$imagesId" class="coverPop dialog--open">
-    <div class="manageCovers hidden" data-config="$dumps({'key': doc.type.key, 'url': get_coverstore_public_url(), 'selector': cover_selector, 'add_url': add_url, 'manage_url': manage_url})">$change</div>
+<!-- The below style is inlined to avoid repaints -->
+<div class="$size sansserif manageCoversContainer" style="position: absolute; bottom: 15px">
+  <a aria-controls="addImage-$imagesId" class="coverPop dialog--open" href="$(manage_url if doc.get_cover() else add_url)">
+    <div class="manageCovers" data-config="$dumps({'key': doc.type.key, 'url': get_coverstore_public_url(), 'selector': cover_selector, 'add_url': add_url, 'manage_url': manage_url})">$change</div>
   </a>
 </div>
 

--- a/openlibrary/templates/covers/change.html
+++ b/openlibrary/templates/covers/change.html
@@ -29,7 +29,7 @@ $else:
 
 <div class="$size sansserif manageCoversContainer hidden--nojs">
   <a aria-controls="addImage-$imagesId" class="coverPop dialog--open">
-    <div class="manageCovers" data-config="$dumps({'key': doc.type.key, 'url': get_coverstore_public_url(), 'selector': cover_selector, 'add_url': add_url, 'manage_url': manage_url})">$change</div>
+    <div class="manageCovers hidden" data-config="$dumps({'key': doc.type.key, 'url': get_coverstore_public_url(), 'selector': cover_selector, 'add_url': add_url, 'manage_url': manage_url})">$change</div>
   </a>
 </div>
 

--- a/static/css/components/manage-covers.less
+++ b/static/css/components/manage-covers.less
@@ -20,8 +20,6 @@
   &Container {
     width: 100%;
     z-index: @z-index-level-16;
-    position: absolute;
-    bottom: 15px;
     a {
       display: block;
       text-decoration: none;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Very similar to #10778 

We avoid repainting by hiding this text until we're ready to init the page.
See video

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

https://github.com/user-attachments/assets/35d03421-3a5e-4465-a90e-da2cd2e48ab4



### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
