### PR TITLE
update bundlesize name for automerge config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,7 @@
     {
       "matchPackageNames": [
         "jest",
-        "bundlesize",
+        "bundlesize2",
         "sinon",
         "stylelint",
         "stylelint-declaration-strict-value"


### PR DESCRIPTION
<!-- What issue does this PR close? -->
I noticed that when I updated bundlesize [a few years back](https://github.com/internetarchive/openlibrary/pull/8322/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L54) I didn't realize we also needed to update the name in the renovate config. So this PR does that!

After this PR is merged then #10789 will auto merge.
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
