### PR TITLE
don't fetch author with cover aspect ratio

### DIFF
--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -59,16 +59,17 @@ class Image:
         self.category = category
         self.id = id
 
-    def info(self) -> dict[str, Any] | None:
+    def info(self, fetch_author: bool = True) -> dict[str, Any] | None:
         url = f'{get_coverstore_url()}/{self.category}/id/{self.id}.json'
         if url.startswith("//"):
             url = "http:" + url
         try:
             d = requests.get(url).json()
             d['created'] = parse_datetime(d['created'])
-            if d['author'] == 'None':
-                d['author'] = None
-            d['author'] = d['author'] and self._site.get(d['author'])
+            if fetch_author:
+                if d['author'] == 'None':
+                    d['author'] = None
+                d['author'] = d['author'] and self._site.get(d['author'])
 
             return web.storage(d)
         except OSError:
@@ -76,7 +77,7 @@ class Image:
             return None
 
     def get_aspect_ratio(self) -> float | None:
-        info = self.info()
+        info = self.info(fetch_author=False)
         if info and info.get('width') and info.get('height'):
             return info["width"] / info["height"]
         return None


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Followup to #10776

See also: #10796
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
We were getting an error in some cases:
```

<class 'AssertionError'> at /books/OL32849056M
key account/ImportBot does not start with '/'
Python 	/openlibrary/infogami/infobase/client.py in get, line 324
Web 	GET http://testing.openlibrary.org/books/OL32849056M
Traceback (innermost first)

    /openlibrary/infogami/infobase/client.py in get
                assert key.startswith('/'), f"key {key} does not start with '/'" ...
    ▶ Local vars
    /openlibrary/openlibrary/core/models.py in info
                    d['author'] = d['author'] and self._site.get(d['author']) ...
    ▶ Local vars
    /openlibrary/openlibrary/core/models.py in get_aspect_ratio
                info = self.info() ...
    ▶ Local vars
    /openlibrary/openlibrary/plugins/upstream/models.py in get_cover_aspect_ratio
                    return cover.get_aspect_ratio() ...
    ▶ Local vars
    /openlibrary/openlibrary/templates/covers/book_cover.html in __template__
        $ cover_aspect_ratio = book.get_cover_aspect_ratio() ...
    ▶ Local vars
    /openlibrary/infogami/utils/template.py in saferender
                    result = t(*a, **kw) ...
    ▶ Local vars
    /openlibrary/infogami/utils/template.py in g
                    return f(*a, **kw) ...
    ▶ Local vars
    /openlibrary/infogami/utils/template.py in <lambda>
                    return lambda *a, **kw: saferender(templates, *a, **kw) ...
    ▶ Local vars
    /openlibrary/openlibrary/app.py in render_template
            return render[name](*a, **kw) ...
    ▶ Local vars
    /openlibrary/openlibrary/macros/databarWork.html in __template__
                  $:render_template('covers/book_cover', page, preload=True) ...
    ▶ Local vars
    /openlibrary/openlibrary/templates/type/edition/view.html in __template__
              $:macros.databarWork(edition or work, worldcat_links, affiliate_links, editions_page=True, render_times=component_times) ...
    ▶ Local vars
    /openlibrary/infogami/utils/template.py in saferender
                    result = t(*a, **kw) ...
    ▶ Local vars
    /openlibrary/infogami/utils/template.py in g
                    return f(*a, **kw) ...
    ▶ Local vars
    /openlibrary/infogami/utils/template.py in <lambda>
                    return lambda *a, **kw: saferender(templates, *a, **kw) ...
    ▶ Local vars
    /openlibrary/infogami/utils/template.py in template
                return t(page, *a, **kw) ...
    ▶ Local vars
    /openlibrary/infogami/utils/view.py in thingview
            return render.view(page) ...
    ▶ Local vars
    /openlibrary/openlibrary/templates/viewpage.html in __template__
        $ view = thingview(page) ...
    ▶ Local vars
    /openlibrary/infogami/utils/template.py in saferender
                    result = t(*a, **kw) ...
    ▶ Local vars
    /openlibrary/infogami/utils/template.py in g
                    return f(*a, **kw) ...
    ▶ Local vars
    /openlibrary/infogami/utils/template.py in <lambda>
                    return lambda *a, **kw: saferender(templates, *a, **kw) ...
    ▶ Local vars
    /openlibrary/infogami/core/code.py in GET
                    return render.viewpage(p) ...
    ▶ Local vars
    /openlibrary/infogami/utils/app.py in delegate
                return getattr(cls(), method)(*args) ...
    ▶ Local vars
    /openlibrary/infogami/utils/app.py in <lambda>
            HEAD = GET = POST = PUT = DELETE = lambda self: delegate() ...
    ▶ Local vars
    /home/openlibrary/.local/lib/python3.12/site-packages/web/application.py in handle_class
                    return tocall(*args) ...
    ▶ Local vars
    /home/openlibrary/.local/lib/python3.12/site-packages/web/application.py in _delegate
                    return handle_class(cls) ...
    ▶ Local vars
    /home/openlibrary/.local/lib/python3.12/site-packages/web/application.py in handle
                return self._delegate(fn, self.fvars, args) ...
    ▶ Local vars
    /home/openlibrary/.local/lib/python3.12/site-packages/web/application.py in process
                            return self.handle() ...
    ▶ Local vars 
```

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
