### PR TITLE
Fix homepage carousels lazy loading

### DIFF
--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -25,7 +25,7 @@ $add_metatag(property="og:site_name", content="Open Library")
       }
     $:render_template("books/custom_carousel", key="trending", books=get_trending_books(books_only=True, since_days=0, since_hours=24, minimum=3, sort_by_count=False), title=_('Trending Books'), url="/trending/daily", test=test, load_more=load_more)
 
-    $:macros.QueryCarousel(query="ddc:8* first_publish_year:[* TO 1950] publish_year:[2000 TO *] NOT public_scan_b:false", url="/search?q=ddc%3A8*+first_publish_year%3A%5B*+TO+1950%5D+publish_year%3A%5B2000+TO+*%5D+NOT+public_scan_b%3Afalse&mode=ebooks&has_fulltext=true", title=_('Classic Books'), key="public_domain", sort='random.hourly', use_cache=False, user_lang_only=True)
+    $:macros.QueryCarousel(query="ddc:8* first_publish_year:[* TO 1950] publish_year:[2000 TO *] NOT public_scan_b:false", url="/search?q=ddc%3A8*+first_publish_year%3A%5B*+TO+1950%5D+publish_year%3A%5B2000+TO+*%5D+NOT+public_scan_b%3Afalse&mode=ebooks&has_fulltext=true", title=_('Classic Books'), key="public_domain", sort='random.hourly', use_cache=False, lazy=False, user_lang_only=True)
 
   $:render_template("home/custom_ia_carousel", title=_('Books We Love'), key="staff_picks", subject="openlibrary_staff_picks", sorts=["lending___last_browse desc"], limit=18, test=test, user_lang_only=True)
 
@@ -36,8 +36,8 @@ $add_metatag(property="og:site_name", content="Open Library")
   $:render_template("home/custom_ia_carousel", title=_('Kids'), key="children", query="subject:(Juvenile Fiction)", sorts=["lending___last_browse desc"], limit=18, test=test, user_lang_only=True)
 
   $if not test:
-    $:macros.QueryCarousel(query="subject:thrillers ratings_count:[10 TO *] ebook_access:[borrowable TO *]", title=_('Thrillers'), key="thrillers", url="/subjects/thrillers", sort='random.hourly', use_cache=False, user_lang_only=True)
-    $:macros.QueryCarousel(query="subject_key:textbooks publish_year:[1990 TO *] readinglog_count :[5 TO *] ebook_access:[borrowable TO *]", title=_('Textbooks'), key="textbooks", url="/subjects/textbooks", sort='random.hourly', use_cache=False, user_lang_only=True)
+    $:macros.QueryCarousel(query="subject:thrillers ratings_count:[10 TO *] ebook_access:[borrowable TO *]", title=_('Thrillers'), key="thrillers", url="/subjects/thrillers", sort='random.hourly', use_cache=False, lazy=False, user_lang_only=True)
+    $:macros.QueryCarousel(query="subject_key:textbooks publish_year:[1990 TO *] readinglog_count :[5 TO *] ebook_access:[borrowable TO *]", title=_('Textbooks'), key="textbooks", url="/subjects/textbooks", sort='random.hourly', use_cache=False, lazy=False, user_lang_only=True)
 
   $:render_template("home/custom_ia_carousel", title="Authors Alliance & MIT Press", key="authorsalliance_mit_press", query="preset:authorsalliance_mitpress", sorts=["lending___last_browse desc"], limit=18, test=test, user_lang_only=True)
 


### PR DESCRIPTION
These entire homepage is cached, so the carousels there shouldn't be lazy loading.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
