### PR TITLE
Remove extra dot star rating stats component

### DIFF
--- a/openlibrary/macros/StarRatingsStats.html
+++ b/openlibrary/macros/StarRatingsStats.html
@@ -18,7 +18,6 @@ $ id = '--mobile' if mobile else ''
   <li class="avg-ratings" onclick="location.href='#starRatingSection';" data-ol-link-track="StarRating|StatsComponentClick">
     $if ratings_count:
       $:macros.StarRatingsComponent(ratings_count, ratings_average, 'results_page')
-      <span class="dot">·</span>
   </li>
   $if want_to_read_count:
     <li class="reading-log-stat"><span class="readers-stats__stat">$want_to_read_count</span> <span class="readers-stats__label">$_("Want to read")</span></li>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10812

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix: Remove extra dot between ratings and want to read

### Technical
<!-- What should be noted about the implementation? -->
remove line 21

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/user-attachments/assets/bef558e3-6fd7-4295-946b-3ad09887448b)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
