### PR TITLE
Print disability access request dashboard for admins

### DIFF
--- a/openlibrary/core/pd.py
+++ b/openlibrary/core/pd.py
@@ -1,5 +1,6 @@
 from . import db
 
+
 def make_pd_request_query():
     oldb = db.get_db()
 
@@ -28,9 +29,9 @@ def make_pd_request_query():
                 status_key ON status.key_id = status_key.key_id
             GROUP BY
                 pda.value
-        
+
             UNION ALL
-        
+
             -- Total row
             SELECT
                 'TOTAL' AS pda,
@@ -47,7 +48,7 @@ def make_pd_request_query():
             JOIN
                 status_key ON status.key_id = status_key.key_id
         )
-        
+
         SELECT
             pda,
             requested,

--- a/openlibrary/core/pd.py
+++ b/openlibrary/core/pd.py
@@ -1,0 +1,24 @@
+from . import db
+
+def make_pd_request_query() -> list:
+    oldb = db.get_db()
+
+    query = """
+        SELECT
+            pda.value AS pda,
+            COUNT(CASE WHEN status.value = 0 THEN 1 END) AS requested,
+            COUNT(CASE WHEN status.value = 1 THEN 1 END) AS emailed,
+            COUNT(CASE WHEN status.value = 2 THEN 1 END) AS fulfilled
+        FROM
+            datum_str AS pda
+        JOIN
+            datum_int AS status
+            ON pda.thing_id = status.thing_id
+        WHERE
+            pda.key_id = (SELECT id FROM property WHERE name = 'notifications.pda')
+            AND status.key_id = (SELECT id FROM property WHERE name = 'notifications.rpd')
+        GROUP BY
+            pda.value;
+    """
+
+    return list(oldb.query(query))

--- a/openlibrary/core/pd.py
+++ b/openlibrary/core/pd.py
@@ -1,24 +1,62 @@
 from . import db
 
-def make_pd_request_query() -> list:
+def make_pd_request_query():
     oldb = db.get_db()
 
     query = """
+        WITH pda_key AS (
+            SELECT id AS key_id FROM property WHERE name = 'notifications.pda'
+        ),
+        status_key AS (
+            SELECT id AS key_id FROM property WHERE name = 'notifications.rpd'
+        ),
+        combined AS (
+            -- Per-qualifying authority rows
+            SELECT
+                pda.value AS pda,
+                COUNT(CASE WHEN status.value = 0 THEN 1 END) AS requested,
+                COUNT(CASE WHEN status.value = 1 THEN 1 END) AS emailed,
+                COUNT(CASE WHEN status.value = 2 THEN 1 END) AS fulfilled,
+                1 AS sort_order
+            FROM
+                datum_str AS pda
+            JOIN
+                datum_int AS status ON pda.thing_id = status.thing_id
+            JOIN
+                pda_key ON pda.key_id = pda_key.key_id
+            JOIN
+                status_key ON status.key_id = status_key.key_id
+            GROUP BY
+                pda.value
+        
+            UNION ALL
+        
+            -- Total row
+            SELECT
+                'TOTAL' AS pda,
+                COUNT(CASE WHEN status.value = 0 THEN 1 END),
+                COUNT(CASE WHEN status.value = 1 THEN 1 END),
+                COUNT(CASE WHEN status.value = 2 THEN 1 END),
+                0 AS sort_order
+            FROM
+                datum_str AS pda
+            JOIN
+                datum_int AS status ON pda.thing_id = status.thing_id
+            JOIN
+                pda_key ON pda.key_id = pda_key.key_id
+            JOIN
+                status_key ON status.key_id = status_key.key_id
+        )
+        
         SELECT
-            pda.value AS pda,
-            COUNT(CASE WHEN status.value = 0 THEN 1 END) AS requested,
-            COUNT(CASE WHEN status.value = 1 THEN 1 END) AS emailed,
-            COUNT(CASE WHEN status.value = 2 THEN 1 END) AS fulfilled
+            pda,
+            requested,
+            emailed,
+            fulfilled
         FROM
-            datum_str AS pda
-        JOIN
-            datum_int AS status
-            ON pda.thing_id = status.thing_id
-        WHERE
-            pda.key_id = (SELECT id FROM property WHERE name = 'notifications.pda')
-            AND status.key_id = (SELECT id FROM property WHERE name = 'notifications.rpd')
-        GROUP BY
-            pda.value;
+            combined
+        ORDER BY
+            sort_order, pda
     """
 
     return list(oldb.query(query))

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -3328,7 +3328,8 @@ msgstr ""
 msgid "New Books Imported Per Day"
 msgstr ""
 
-#: admin/imports.html admin/imports_by_date.html site/stats.html
+#: admin/imports.html admin/imports_by_date.html admin/pd_dashboard.html
+#: site/stats.html
 msgid "Summary"
 msgstr ""
 
@@ -3580,6 +3581,10 @@ msgid "Admin Center"
 msgstr ""
 
 #: admin/menu.html
+msgid "PD Access Requests"
+msgstr ""
+
+#: admin/menu.html
 msgid "Block IPs"
 msgstr ""
 
@@ -3601,6 +3606,10 @@ msgstr ""
 
 #: admin/menu.html
 msgid "Inspect memcache"
+msgstr ""
+
+#: admin/pd_dashboard.html
+msgid "Print Disability Access Requests"
 msgstr ""
 
 #: admin/permissions.html

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -33,7 +33,7 @@ from openlibrary.core import (
     imports,
 )
 from openlibrary.core.models import Work
-from openlibrary.core.pd import make_pd_request_query
+from openlibrary.plugins.openlibrary.pd import get_pd_dashboard_data
 from openlibrary.plugins.upstream import forms, spamcheck
 
 logger = logging.getLogger("openlibrary.admin")
@@ -832,14 +832,9 @@ class show_log:
 
 class pd_dashboard:
     def GET(self):
-        results = {
-            "requested_access": [],
-            "emailed": [],
-            "fulfilled": [],
-        }
-        request_data = make_pd_request_query()
+        dashboard_data = get_pd_dashboard_data()
 
-        return render_template("admin/pd_dashboard", request_data)
+        return render_template("admin/pd_dashboard", dashboard_data)
 
 
 def setup():

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -33,6 +33,7 @@ from openlibrary.core import (
     imports,
 )
 from openlibrary.core.models import Work
+from openlibrary.core.pd import make_pd_request_query
 from openlibrary.plugins.upstream import forms, spamcheck
 
 logger = logging.getLogger("openlibrary.admin")
@@ -831,30 +832,14 @@ class show_log:
 
 class pd_dashboard:
     def GET(self):
-        keys = web.ctx.site.things({
-                "type": "/type/object",
-                "key~": "/people/*/preferences",
-                "notifications": {
-                    "pda~": "*"
-                }
-            }
-        )
+        results = {
+            "requested_access": [],
+            "emailed": [],
+            "fulfilled": [],
+        }
+        request_data = make_pd_request_query()
 
-        def sort_requests(pd_requests):
-            results = {
-                "requested_access": [],
-                "emailed": []
-            }
-            for r in pd_requests:
-                status = r.get("notifications", {}).get("rpd")
-                if status == 0:
-                    results["requested_access"].append(r)
-                else:
-                    results["emailed"].append(r)
-            return results
-
-        pd_requests = web.ctx.site.get_many(keys)
-        return render_template("admin/pd_dashboard", sort_requests(pd_requests))
+        return render_template("admin/pd_dashboard", request_data)
 
 
 def setup():

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -829,6 +829,34 @@ class show_log:
                 return f.read()
 
 
+class pd_dashboard:
+    def GET(self):
+        keys = web.ctx.site.things({
+                "type": "/type/object",
+                "key~": "/people/*/preferences",
+                "notifications": {
+                    "pda~": "*"
+                }
+            }
+        )
+
+        def sort_requests(pd_requests):
+            results = {
+                "requested_access": [],
+                "emailed": []
+            }
+            for r in pd_requests:
+                status = r.get("notifications", {}).get("rpd")
+                if status == 0:
+                    results["requested_access"].append(r)
+                else:
+                    results["emailed"].append(r)
+            return results
+
+        pd_requests = web.ctx.site.get_many(keys)
+        return render_template("admin/pd_dashboard", sort_requests(pd_requests))
+
+
 def setup():
     register_admin_page('/admin/git-pull', gitpull, label='git-pull')
     register_admin_page('/admin/reload', reload, label='Reload Templates')
@@ -862,6 +890,7 @@ def setup():
         r'/admin/imports/(\d\d\d\d-\d\d-\d\d)', imports_by_date, label=""
     )
     register_admin_page('/admin/spamwords', spamwords, label="")
+    register_admin_page("/admin/pd", pd_dashboard)
 
     from openlibrary.plugins.admin import mem
 

--- a/openlibrary/plugins/openlibrary/pd.py
+++ b/openlibrary/plugins/openlibrary/pd.py
@@ -77,7 +77,11 @@ def get_pd_dashboard_data() -> dict:
     def enrich_data(_request_data):
         for d in _request_data:
             pda = d['pda']
-            d['display_name'] = "No Qualifying Authority Selected" if pda == "unqualified" else get_pd_org(pda)['title']
+            d['display_name'] = (
+                "No Qualifying Authority Selected"
+                if pda == "unqualified"
+                else get_pd_org(pda)['title']
+            )
 
     request_data = make_pd_request_query()
     totals = request_data and request_data.pop(0)

--- a/openlibrary/plugins/openlibrary/pd.py
+++ b/openlibrary/plugins/openlibrary/pd.py
@@ -4,6 +4,7 @@ import requests
 
 from infogami import config
 from openlibrary.core import cache
+from openlibrary.core.pd import make_pd_request_query
 from openlibrary.i18n import gettext as _
 from openlibrary.utils.dateutil import DAY_SECS
 
@@ -70,6 +71,26 @@ def cached_pd_org_query() -> list:
     if not (results := mc() or []):
         mc(_cache="delete")
     return results
+
+
+def get_pd_dashboard_data() -> dict:
+    def enrich_data(_request_data):
+        for d in _request_data:
+            pda = d['pda']
+            d['display_name'] = "No Qualifying Authority Selected" if pda == "unqualified" else get_pd_org(pda)['title']
+
+    request_data = make_pd_request_query()
+    totals = request_data and request_data.pop(0)
+    enrich_data(request_data)
+    return {
+        "data": request_data,
+        "totals": {
+            'requested': totals['requested'],
+            'emailed': totals['emailed'],
+            'fulfilled': totals['fulfilled'],
+            'total': totals['requested'] + totals['emailed'] + totals['fulfilled'],
+        },
+    }
 
 
 def setup():

--- a/openlibrary/templates/admin/menu.html
+++ b/openlibrary/templates/admin/menu.html
@@ -11,6 +11,7 @@ $def link(url, title):
 <div class="superNav" id="adminLinks">
     $:link("/admin", _("Admin Center"))
     | $:link("/admin/people", _("People"))
+    | $:link("/admin/pd", _("PD Access Requests"))
     | $:link("/admin/block", _("Block IPs"))
     | $:link("/admin/spamwords", _("Spam Words"))
     | $:link("/admin/solr", _("Solr"))

--- a/openlibrary/templates/admin/pd_dashboard.html
+++ b/openlibrary/templates/admin/pd_dashboard.html
@@ -1,4 +1,9 @@
-$def with(pd_requests)
+$def with(request_data)
+
+$code:
+  requested = 0
+  emailed = 0
+  fulfilled = 0
 
 <div id="contentHead">
     $:render_template("admin/menu")
@@ -6,16 +11,41 @@ $def with(pd_requests)
 </div>
 
 <div id="contentBody" class="pd-access-dashboard">
-    <h2>Stats</h2>
-    <div class="pd-access-stat">
-        Total patrons that have requested print-disability access: <span class="pd-access-total">$(len(pd_requests.get("requested_access")) + len(pd_requests.get("emailed")))</span>
-    </div>
-    <hr>
-    <div class="pd-access-stat">
-        Total number of patrons awaiting follow-up email: <span class="pd-access-total">$(len(pd_requests.get("requested_access")))</span>
-    </div>
-    <hr>
-    <div class="pd-access-stat">
-        Total number of patrons emailed: <span class="pd-access-total">$(len(pd_requests.get("emailed")))</span>
-    </div>
+    <h2>$_("Stats")</h2>
+    <table class="pd-request-table">
+        <thead>
+            <th class="table-header" scope="col">PDA</th>
+            <th class="table-header" scope="col">Requested</th>
+            <th class="table-header" scope="col">Emailed</th>
+            <th class="table-header" scope="col">Fulfilled</th>
+            <th class="table-header" scope="col">Total</th>
+        </thead>
+        <tbody>
+            $for d in request_data:
+              $ pda = d['pda']
+              $ requested_count = d['requested']
+              $ emailed_count = d['emailed']
+              $ fulfilled_count = d['fulfilled']
+              $ total = requested_count + emailed_count + fulfilled_count
+              $ requested += requested_count
+              $ emailed += emailed_count
+              $ fulfilled += fulfilled_count
+              <tr>
+                  <td>
+                      <a href="https://archive.org/details/$(pda)">$pda</a>
+                  </td>
+                  <td>$requested_count</td>
+                  <td>$emailed_count</td>
+                  <td>$fulfilled_count</td>
+                  <td>$total</td>
+              </tr>
+          <tr class="totals">
+              <td>Totals</td>
+              <td>$requested</td>
+              <td>$emailed</td>
+              <td>$fulfilled</td>
+              <td>$(requested + emailed + fulfilled)</td>
+          </tr>
+        </tbody>
+    </table>
 </div>

--- a/openlibrary/templates/admin/pd_dashboard.html
+++ b/openlibrary/templates/admin/pd_dashboard.html
@@ -1,18 +1,11 @@
 $def with(pd_requests)
 
-<style>
-    .pd-access-stat {
-        display: flex;
-        justify-content: space-between;
-    }
-</style>
-
 <div id="contentHead">
     $:render_template("admin/menu")
     <h1>$_("Print Disability Access Requests")</h1>
 </div>
 
-<div id="contentBody">
+<div id="contentBody" class="pd-access-dashboard">
     <h2>Stats</h2>
     <div class="pd-access-stat">
         Total patrons that have requested print-disability access: <span class="pd-access-total">$(len(pd_requests.get("requested_access")) + len(pd_requests.get("emailed")))</span>

--- a/openlibrary/templates/admin/pd_dashboard.html
+++ b/openlibrary/templates/admin/pd_dashboard.html
@@ -1,0 +1,28 @@
+$def with(pd_requests)
+
+<style>
+    .pd-access-stat {
+        display: flex;
+        justify-content: space-between;
+    }
+</style>
+
+<div id="contentHead">
+    $:render_template("admin/menu")
+    <h1>$_("Print Disability Access Requests")</h1>
+</div>
+
+<div id="contentBody">
+    <h2>Stats</h2>
+    <div class="pd-access-stat">
+        Total patrons that have requested print-disability access: <span class="pd-access-total">$(len(pd_requests.get("requested_access")) + len(pd_requests.get("emailed")))</span>
+    </div>
+    <hr>
+    <div class="pd-access-stat">
+        Total number of patrons awaiting follow-up email: <span class="pd-access-total">$(len(pd_requests.get("requested_access")))</span>
+    </div>
+    <hr>
+    <div class="pd-access-stat">
+        Total number of patrons emailed: <span class="pd-access-total">$(len(pd_requests.get("emailed")))</span>
+    </div>
+</div>

--- a/openlibrary/templates/admin/pd_dashboard.html
+++ b/openlibrary/templates/admin/pd_dashboard.html
@@ -1,9 +1,11 @@
-$def with(request_data)
+$def with(dashboard_data)
 
 $code:
-  requested = 0
-  emailed = 0
-  fulfilled = 0
+  request_data = dashboard_data.get('data', [])
+  totals = dashboard_data.get('totals')
+  requested_total = 0
+  emailed_total = 0
+  fulfilled_total = 0
 
 <div id="contentHead">
     $:render_template("admin/menu")
@@ -11,7 +13,26 @@ $code:
 </div>
 
 <div id="contentBody" class="pd-access-dashboard">
-    <h2>$_("Stats")</h2>
+    <h2>$_("Summary")</h2>
+    <div class="dashboard-summary">
+        <div class="pd-access-stat">
+            Total number of patrons awaiting follow-up email: <span class="pd-access-total">$totals['requested']</span>
+        </div>
+        <hr>
+        <div class="pd-access-stat">
+            Total number of patrons emailed: <span class="pd-access-total">$totals['emailed']</span>
+        </div>
+        <hr>
+        <div class="pd-access-stat">
+            Total number of patron requests fulfilled: <span class="pd-access-total">$totals['fulfilled']</span>
+        </div>
+        <hr>
+        <div class="pd-access-stat">
+            Total patrons that have requested print-disability access: <span class="pd-access-total">$totals['total']</span>
+        </div>
+    </div>
+
+    <h2>Breakdown by Qualifying Authority</h2>
     <table class="pd-request-table">
         <thead>
             <th class="table-header" scope="col">PDA</th>
@@ -23,16 +44,17 @@ $code:
         <tbody>
             $for d in request_data:
               $ pda = d['pda']
+              $ display_name = d['display_name']
               $ requested_count = d['requested']
               $ emailed_count = d['emailed']
               $ fulfilled_count = d['fulfilled']
               $ total = requested_count + emailed_count + fulfilled_count
-              $ requested += requested_count
-              $ emailed += emailed_count
-              $ fulfilled += fulfilled_count
+              $ requested_total += requested_count
+              $ emailed_total += emailed_count
+              $ fulfilled_total += fulfilled_count
               <tr>
                   <td>
-                      <a href="https://archive.org/details/$(pda)">$pda</a>
+                      <a href="https://archive.org/details/$(pda)">$display_name</a>
                   </td>
                   <td>$requested_count</td>
                   <td>$emailed_count</td>
@@ -41,10 +63,10 @@ $code:
               </tr>
           <tr class="totals">
               <td>Totals</td>
-              <td>$requested</td>
-              <td>$emailed</td>
-              <td>$fulfilled</td>
-              <td>$(requested + emailed + fulfilled)</td>
+              <td>$requested_total</td>
+              <td>$emailed_total</td>
+              <td>$fulfilled_total</td>
+              <td>$(requested_total + emailed_total + fulfilled_total)</td>
           </tr>
         </tbody>
     </table>

--- a/scripts/detect_missing_i18n.py
+++ b/scripts/detect_missing_i18n.py
@@ -24,6 +24,8 @@ EXCLUDE_LIST = {
     "static/status-500.html",
     # Uses jsdef and the current stance is no i18n in JS.
     "openlibrary/templates/jsdef/LazyAuthorPreview.html",
+    # Admin-only dashboard
+    "openlibrary/templates/admin/pd_dashboard.html",
 }
 
 default_directories = ('openlibrary/templates/', 'openlibrary/macros/')

--- a/static/css/components/pd-dashboard.less
+++ b/static/css/components/pd-dashboard.less
@@ -1,0 +1,42 @@
+.pd-access-dashboard {
+  .dashboard-summary {
+      margin-bottom: 40px;
+
+      .pd-access-stat {
+        display: flex;
+        justify-content: space-between;
+    }
+  }
+
+  .pd-request-table {
+    border: 1px solid @black;
+    width: 100%;
+     /* stylelint-disable selector-max-specificity */
+    .table-header,
+    tr.totals {
+      font-weight: 700;
+    }
+    /* stylelint-enable selector-max-specificity */
+    .table-header {
+      background: @white;
+      text-align: center;
+      padding: 8px;
+    }
+    td {
+      padding: 4px 8px;
+    }
+    /* stylelint-disable selector-max-specificity */
+    td:not(:first-child) {
+      text-align: right;
+    }
+    /* stylelint-enable selector-max-specificity */
+    tr {
+      background: @white;
+    }
+    /* stylelint-disable selector-max-specificity */
+    tr:nth-child(odd) {
+      background: @lightest-grey;
+    }
+    /* stylelint-enable selector-max-specificity */
+  }
+}

--- a/static/css/components/pd-dashboard.less
+++ b/static/css/components/pd-dashboard.less
@@ -1,17 +1,17 @@
 .pd-access-dashboard {
   .dashboard-summary {
-      margin-bottom: 40px;
+    margin-bottom: 40px;
 
-      .pd-access-stat {
-        display: flex;
-        justify-content: space-between;
+    .pd-access-stat {
+      display: flex;
+      justify-content: space-between;
     }
   }
 
   .pd-request-table {
     border: 1px solid @black;
     width: 100%;
-     /* stylelint-disable selector-max-specificity */
+    /* stylelint-disable selector-max-specificity */
     .table-header,
     tr.totals {
       font-weight: 700;

--- a/static/css/page-admin.less
+++ b/static/css/page-admin.less
@@ -219,10 +219,12 @@ div.sparkDisplay {
   }
 }
 
-.pd-access-dashboard {
-  .pd-access-stat {
-    display: flex;
-    justify-content: space-between;
+.pd-request-table {
+  width: 100%;
+
+  .table-header,
+  tr.totals {
+    font-weight: 700;
   }
 }
 

--- a/static/css/page-admin.less
+++ b/static/css/page-admin.less
@@ -219,15 +219,6 @@ div.sparkDisplay {
   }
 }
 
-.pd-request-table {
-  width: 100%;
-
-  .table-header,
-  tr.totals {
-    font-weight: 700;
-  }
-}
-
 @media all and ( min-width: @width-breakpoint-desktop ) {
   // Graph shown on /stats
   // openlibrary/templates/admin/index.html
@@ -236,3 +227,5 @@ div.sparkDisplay {
     height: 50px;
   }
 }
+
+@import (less) "components/pd-dashboard.less";

--- a/static/css/page-admin.less
+++ b/static/css/page-admin.less
@@ -219,7 +219,7 @@ div.sparkDisplay {
   }
 }
 
-@media all and ( min-width: @width-breakpoint-desktop ) {
+@media all and (min-width: @width-breakpoint-desktop) {
   // Graph shown on /stats
   // openlibrary/templates/admin/index.html
   .canvas-graph {

--- a/static/css/page-admin.less
+++ b/static/css/page-admin.less
@@ -219,7 +219,14 @@ div.sparkDisplay {
   }
 }
 
-@media all and (min-width: @width-breakpoint-desktop) {
+.pd-access-dashboard {
+  .pd-access-stat {
+    display: flex;
+    justify-content: space-between;
+  }
+}
+
+@media all and ( min-width: @width-breakpoint-desktop ) {
   // Graph shown on /stats
   // openlibrary/templates/admin/index.html
   .canvas-graph {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Related to #10724

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds a new dashboard for tracking print disability access requests.  The new dashboard is available at `/admin/pd`, and can only be viewed by admins.

#### Remaining Tasks
- [x] Style table
- [x] Include short summary of totals, above table
- [x] Show qualifying authorities' names in table

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot 2025-05-19 163947](https://github.com/user-attachments/assets/321339a5-fb85-4539-ab3e-5acb43e405fe)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
