### PR TITLE
remove unused Deprecated lib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ APScheduler==3.11.0
 Babel==2.12.1
 beautifulsoup4==4.12.2
 DBUtils==1.4
-Deprecated==1.2.14
 eventer==0.1.1
 feedparser==6.0.11
 flup-py3==1.0.3


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes https://github.com/internetarchive/openlibrary/pull/10809

I saw renovate was trying to upgrade this lib and hadn't seen it used anywhere.
So I took a look and it doesn't seem we use it anywhere at all so we can remove it.

Originally added and used in this PR https://github.com/internetarchive/openlibrary/pull/2865

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
