### PR TITLE
use db directly for cover dimensions

### DIFF
--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -84,7 +84,7 @@ class Image:
         config.load_from_file("conf/coverstore.yml")
         info = get_cover_details(self.id)
         if info and info.get('width') and info.get('height'):
-            return info['width'] / info['height']
+            return info["width"] / info["height"]
         return None
 
     def url(self, size="M") -> str:

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -31,6 +31,7 @@ from openlibrary.core.observations import Observations
 from openlibrary.core.ratings import Ratings
 from openlibrary.core.vendors import get_amazon_metadata
 from openlibrary.core.wikidata import WikidataEntity, get_wikidata_entity
+from openlibrary.coverstore.db import details as get_cover_details
 from openlibrary.plugins.upstream.utils import get_identifier_config
 from openlibrary.utils import extract_numeric_id_from_olid
 from openlibrary.utils.isbn import canonical, isbn_13_to_isbn_10, to_isbn_13
@@ -77,9 +78,9 @@ class Image:
             return None
 
     def get_aspect_ratio(self) -> float | None:
-        info = self.info(fetch_author=False)
-        if info and info.get('width') and info.get('height'):
-            return info["width"] / info["height"]
+        d = get_cover_details(self.id)
+        if d and d.get('width') and d.get('height'):
+            return d['width'] / d['height']
         return None
 
     def url(self, size="M") -> str:

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -78,6 +78,10 @@ class Image:
             return None
 
     def get_aspect_ratio(self) -> float | None:
+
+        from openlibrary.coverstore import config
+
+        config.load_from_file("conf/coverstore.yml")
         d = get_cover_details(self.id)
         if d and d.get('width') and d.get('height'):
             return d['width'] / d['height']

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -82,9 +82,9 @@ class Image:
         from openlibrary.coverstore import config
 
         config.load_from_file("conf/coverstore.yml")
-        d = get_cover_details(self.id)
-        if d and d.get('width') and d.get('height'):
-            return d['width'] / d['height']
+        info = get_cover_details(self.id)
+        if info and info.get('width') and info.get('height'):
+            return info['width'] / info['height']
         return None
 
     def url(self, size="M") -> str:

--- a/openlibrary/coverstore/config.py
+++ b/openlibrary/coverstore/config.py
@@ -14,3 +14,13 @@ blocked_covers: list[str] = []
 
 def get(name, default=None):
     return globals().get(name, default)
+
+
+def load_from_file(configfile: str) -> None:
+    """Load configuration from a file."""
+    import yaml
+
+    with open(configfile) as in_file:
+        d = yaml.safe_load(in_file)
+    for k, v in d.items():
+        globals()[k] = v


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Right now we're getting ratelimited by our own cover api after https://github.com/internetarchive/openlibrary/pull/10776

This PR has one approach to fix it but we're hitting the error:

`module 'openlibrary.coverstore.config' has no attribute 'db_parameters'`

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
