### PR TITLE
Revert changes that broke the book page

### DIFF
--- a/openlibrary/templates/history/sources.html
+++ b/openlibrary/templates/history/sources.html
@@ -56,11 +56,11 @@ $code:
             source_url = "https://openalex.org/" + item[9:]
         else:
             source_name = names.get(item, item)
-            source_url = f"//archive.org/details/{item}"
+            source_url = "//archive.org/details/" + item
         return storage(id=record_id, url=url, source_name=source_name, source_url=source_url)
 
     def link(url, label):
-        return f'<a href="{url}">{label}</a>' if url else label
+        return '<a href="' + url + '">' + label + '</a>' if url else label
 
     def get_source_html(record_id):
         record_type = _('record')


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Follow up to #10771

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
I forgot that f-string literals cannot be used in templates, and merged such a change in.  Now, book pages do not render.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Visit a book page.  If this isn't working, you'll see a flash message containing `execution of 'FormattedValue' statements is denied` messages.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
