### PR TITLE
Don't render check in form if logged out

### DIFF
--- a/openlibrary/templates/my_books/dropper.html
+++ b/openlibrary/templates/my_books/dropper.html
@@ -29,7 +29,7 @@ $ primary_action = render_template('my_books/primary_action', work_key, edition_
 $ dropdown_content = render_template('my_books/dropdown_content', user_lists, seed_key, work_key, edition_key, users_work_read_status, async_load=async_load)
 $:render_template('lib/dropper', primary_action, dropdown_content, classes=additional_classes, data=data)
 
-$if work_key:
+$if ctx.user and work_key:
     $ last_read_date = get_latest_read_date(work_key)
     $ date = last_read_date['event_date'] if last_read_date else None
     $ event_id = last_read_date['id'] if last_read_date else None


### PR DESCRIPTION
Partial fix for #10582 .

This seems to be taking ~10% of /search rendering time according to [sentry](https://sentry.archive.org/organizations/ia-ux/profiling/profile/ol-web/94402b67366f4a40aa4bb9dda79ed32a/flamegraph/?colorCoding=by%20system%20vs%20application%20frame&fov=0%2C92%2C633091904%2C12&query=&sorting=call%20order&tid=140224039467904&view=top%20down). Small fix, but could hopefully help alleviate some of the pressure on our systems.

![image](https://github.com/user-attachments/assets/81432ca7-93f2-4117-b277-d2aa7647374e)

### Technical
<!-- What should be noted about the implementation? -->

### Testing

Before: Incognito/logged out, observe https://openlibrary.org/search?q=sherlock+holmes&mode=everything has `check-in__form` in it's html making up ~46% of the HTML.

After: No check-ins

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
