### PR TITLE
Add nginx blocks for older browsers + rejigger nginx conf

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -74,12 +74,6 @@ http {
     # Set a more permissive limit for covers because some pages might load 20+ covers.
     limit_req_zone $rate_limit_key zone=cover_limit:10m rate=400r/m;
 
-    # For returning 200 when someone tries to randomly sort author results.
-    map $arg_sort $is_random_sort {
-      default 0;
-      ~^random_.* 1;
-    }
-
     # Things are mounted into here by the docker compose file
     include /etc/nginx/sites-enabled/*;
 }

--- a/docker/web_nginx.conf
+++ b/docker/web_nginx.conf
@@ -16,6 +16,38 @@ upstream webnodes {
     server web_haproxy:7072;
 }
 
+map $http_user_agent $is_sus_user_agent {
+    default 0;
+    "~ByteSpider" 1;
+    # Check for ancient browser user agents
+    "~Firefox/([1-7]\.)" 1;
+    "~Chrome/([1-9]|10)\." 1;
+}
+
+# Log likely bots caught in /authors random loop.
+map $request_uri$args $is_sus_random_sort {
+    default 0;
+    "~^/authors/.*sort=random_" 1;
+}
+
+# Check empty referer
+map $http_referer $is_empty_referer {
+    default 0;
+    "" 1;
+}
+
+map $request_uri$args $requires_referer {
+    default 0;
+    "~*^/(qrcode|admin|wp-login|show-records)" 1;
+    "~*/edit" 1;
+    "~*(v|m|action|redirect)=" 1;
+}
+
+map $is_empty_referer$requires_referer $is_sus_referer {
+    default 0;
+    "11" 1;
+}
+
 # Keep in sync with covers_nginx.conf
 server {
     listen 80 default;
@@ -85,37 +117,18 @@ server {
         limit_req zone=web_limit burst=100 delay=10;
         limit_req_status 429;
 
-        if ($http_user_agent ~ (Bytespider) ) {
-           return 444;
+        # For returning 200 when someone tries to randomly sort author results.
+        if ($is_sus_random_sort) {
+            return 200;
         }
 
-
-        # ===========================================
-        # Block certain patterns when no referer set:
-        # ===========================================
-
-        # Create a variable to track if referer is empty
-        set $suspect_arg 0;
-
-        # These requests should not be hit without referrer
-        if ($request_uri ~* "/(qrcode|admin|wp-login|show-records|edit)") {
-            set $suspect_arg 1;
-        }
-        if ($args ~* "(v=|m=|action=)") {
-            set $suspect_arg 1;
+        if ($is_sus_user_agent) {
+            return 403;
         }
 
-        # AND if the referer is set...
-        if ($http_referer = "" ) {
-            set $suspect_arg "${suspect_arg}1";
-        }
-
-        # Block requests with m= v= or action= parameters and empty referer
-        if ($suspect_arg = "11") {
+        if ($is_sus_referer) {
             return 444;
         }
-
-        # -------------------------------------------
 
         proxy_pass http://webnodes;
         proxy_set_header Host $http_host;
@@ -132,27 +145,6 @@ server {
     location ~ ^(/api/.*|.*\.json)$ {
         limit_req zone=api_limit burst=200 nodelay;
         limit_req_status 429;
-
-        if ($http_user_agent ~ (Bytespider) ) {
-            return 444;
-        }
-
-        proxy_pass http://webnodes;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $remote_addr;
-        proxy_set_header X-Scheme $scheme;
-    }
-
-    # Log likely bots caught in /authors random loop.
-    location ~* ^/authors/.* {
-        # Web rate limit.
-        limit_req zone=web_limit burst=100 delay=10;
-        limit_req_status 429;
-
-        # randomly sorting will be removed. For now just return 200
-        if ($is_random_sort = 1) {
-            return 200 "";
-        }
 
         if ($http_user_agent ~ (Bytespider) ) {
             return 444;


### PR DESCRIPTION
A marker of suspicious traffic we see is veeeery old browsers making a ton of requests. Eg Firefox 4 pre-release :P So block those.

### Technical
<!-- What should be noted about the implementation? -->
- Also re-jiggered / DRY'd our nginx files to make adding these sort of things easier.
- And DRY the authors location block, so our checks now also apply to author pages.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Patch deployed onto ol-www0 ; we see the new blocks in orange:

![image](https://github.com/user-attachments/assets/e3b63ac2-12c3-4404-b856-55a44a26e1c7)


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@scottbarnes 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
