### PR TITLE
adjusted Bulk Search to use POST endpoint when url limits would be ex…

### DIFF
--- a/openlibrary/components/BulkSearch/components/BulkSearchControls.vue
+++ b/openlibrary/components/BulkSearch/components/BulkSearchControls.vue
@@ -105,12 +105,36 @@
                 <i> Now that you've found your books, why not save them to your reading log? Or a list?</i>
               </p>
             </div>
-            <a
-              id="listMakerLink"
-              :href="bulkSearchState.listUrl"
-              target="_blank"
-            ><button :disabled="createListDisabled">Add to list</button></a>
-          </div>
+            <div v-if="bulkSearchState?.matchedBooks.length <50">
+              <a
+                id="listMakerLink"
+                :href="bulkSearchState.listUrl"
+                target="_blank"
+              ><button :disabled="createListDisabled">Add to list</button></a>
+            </div>
+            <div v-else>
+              Hello
+              <form
+                method="POST"
+                action="/account/lists/add?preview=true"
+                target="_blank"
+              >
+                <input
+                  type="hidden"
+                  name="seeds"
+                  :value="bulkSearchState?.listString"
+                >
+                <input
+                  type="hidden"
+                  name="preview"
+                  :value="true"
+                >
+                <button type="submit">
+                  Add to List
+                </button>
+              </form>
+            </div>
+          </div>v
         </div>
       </div>
     </div>

--- a/openlibrary/components/BulkSearch/components/BulkSearchControls.vue
+++ b/openlibrary/components/BulkSearch/components/BulkSearchControls.vue
@@ -112,29 +112,22 @@
                 target="_blank"
               ><button :disabled="createListDisabled">Add to list</button></a>
             </div>
-            <div v-else>
-              Hello
-              <form
-                method="POST"
-                action="/account/lists/add?preview=true"
-                target="_blank"
+            <form
+              v-else
+              method="POST"
+              action="/account/lists/add"
+              target="_blank"
+            >
+              <input
+                type="hidden"
+                name="seeds"
+                :value="bulkSearchState?.listString"
               >
-                <input
-                  type="hidden"
-                  name="seeds"
-                  :value="bulkSearchState?.listString"
-                >
-                <input
-                  type="hidden"
-                  name="preview"
-                  :value="true"
-                >
-                <button type="submit">
-                  Add to List
-                </button>
-              </form>
-            </div>
-          </div>v
+              <button type="submit">
+                Add to List
+              </button>
+            </form>
+          </div>
         </div>
       </div>
     </div>

--- a/openlibrary/components/BulkSearch/utils/classes.js
+++ b/openlibrary/components/BulkSearch/utils/classes.js
@@ -236,6 +236,12 @@ export class BulkSearchState{
             .map(bm => bm.solrDocs?.docs?.[0]?.key.split('/')[2])
             .filter(key => key);
     }
+    /**@type {String} */
+    get listString(){
+        return `${this.matchedBooks
+            .map(bm => bm.solrDocs?.docs?.[0]?.key.split('/')[2])
+            .filter(key => key)}`;
+    }
 }
 
 

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -360,6 +360,10 @@ class lists_add_account(delegate.page):
     def GET(self):
         return web.seeother(f'{get_current_user().key}/lists/add{web.ctx.query}')
 
+    @require_login
+    def POST(self):
+        return web.tempredirect(f'{get_current_user().key}/lists/add{web.ctx.query}')
+
 
 class lists_add(delegate.page):
     path = r"(/people/[^/]+)?/lists/add"
@@ -375,6 +379,15 @@ class lists_add(delegate.page):
         return render_template("type/list/edit", list_record, new=True)
 
     def POST(self, user_key: str | None):  # type: ignore[override]
+        val = parse_qs(bytes.decode(web.data()))
+        if val.get("preview", []) == ["true"]:
+            list_record = ListRecord(
+                seeds=[
+                    ListRecord.normalize_input_seed(seed)
+                    for seed in val.get("seeds", [])[0].split(",")
+                ]
+            )
+            return render_template("type/list/edit", list_record, new=True)
         return lists_edit().POST(user_key, None)
 
 

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -366,10 +366,13 @@ class lists_add_account(delegate.page):
 
     @require_login
     def POST(self):
-        # Force this to be preview mode, otherwise folks can create links that create
-        # lists without the clicker realizing a list is being created!
-        # Note: Temporary redirect is require to forward along the POST data.
-        return web.tempredirect(f'{get_current_user().key}/lists/add?preview=true')
+        list_record = ListRecord.from_input()
+        return render_template(
+            "type/list/edit",
+            list_record,
+            new=True,
+            action=f'{get_current_user().key}/lists/add',
+        )
 
 
 class lists_add(delegate.page):
@@ -386,9 +389,6 @@ class lists_add(delegate.page):
         return render_template("type/list/edit", list_record, new=True)
 
     def POST(self, user_key: str | None):  # type: ignore[override]
-        if web.input().get('preview') == 'true':
-            list_record = ListRecord.from_input()
-            return render_template("type/list/edit", list_record, new=True)
         return lists_edit().POST(user_key, None)
 
 

--- a/openlibrary/templates/type/list/edit.html
+++ b/openlibrary/templates/type/list/edit.html
@@ -1,4 +1,4 @@
-$def with (lst, new=False)
+$def with (lst, new=False, action=None)
 $putctx('cssfile', 'list-edit')
 $var title: $(_("Create a list") if new else _("Editing list: %(list_name)s", list_name=lst.name))
 
@@ -91,7 +91,12 @@ $jsdef lazy_thing_preview(key, render_fn_name):
     </div>
 
 <div id="contentBody">
-    <form method="post" id="list-edit" class="olform">
+    <form
+        method="post"
+        id="list-edit"
+        class="olform"
+        $:cond(action, 'action="%s"' % action)
+    >
         $if not new:
             <input
                 required


### PR DESCRIPTION
…ceeded.

<!-- What issue does this PR close? -->
Closes #10835 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR  adjusts the functionality of  Bulk Search's list creation function, to instead  redirect to a new POST  endpoint,  when  more than 50 works would  be added to a new list. This prevents limits on URL size from interfering with the creation of lists.  

### Technical
<!-- What should be noted about the implementation? -->
In ```openlibrary/plugins/openlibrary/lists.py```, the POST method was changed to optionally check for a new parameter. if the POST request contains a 'preview' parameter, then if it is set to 'True', the new functionality of heading to the list creation page is implemented. If it does not exist, or is instead set to a different value, the old functionality of immediately creating the list is preserved. 
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1) After switching to the branch, navigate to BulkSearch.

2) Attempt to create a list using the samples, and see if it functions as normal.   You can inspect the elements on the page to insure that the relevant button is a link. Take note of the page that it takes you to, on clicking it. 

3) Attempt to create a list of at least 50 works using Bulk Search. (Alternatively, go to line 108 of ```openlibrary/components/BulkSearch/components/BulkSearchControls.vueopenlibrary/components/BulkSearch/components/BulkSearchControls.vue```.and adjust the number to something less than 50. About 5 will work with the samples.)  If you perform this edit, make sure you rebuild your vue components before continuing onto the next step. 

4) Inspect the element on the page to ensure that the button is now a form element. Upon clicking it, it should take you to the same page as step 2. 

5) Attempt to create a link via a post request without preview set to 'true'. This can be performed by commenting out lines 127-131 of ```openlibrary/components/BulkSearch/components/BulkSearchControls.vue```. As before, make sure that you are rebuilding your Vue components before continuing onto the next step. 
6) Upon clicking the button this time, the list should be created without further input. You should navigate to your profile's lists, and ensure that it is there.   ### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
