### PR TITLE
Lazy load below-the-fold covers in SearchResultWork

### DIFF
--- a/openlibrary/macros/FulltextResults.html
+++ b/openlibrary/macros/FulltextResults.html
@@ -10,9 +10,9 @@ $if results and results.get('hits'):
   $ num_found = results['hits'].get('total', 0)
   <div id="searchResults">
     <ul class="list-books">
-      $for doc in hits:
-        $if doc.get('edition'):
-          $:macros.SearchResultsWork(doc['edition'], availability=doc['availability'], extra=render_snippet(query, doc), include_dropper=True)
+      $ docs = (doc for doc in hits if doc.get('edition'))
+      $for doc in docs:
+        $:macros.SearchResultsWork(doc['edition'], availability=doc['availability'], extra=render_snippet(query, doc), include_dropper=True, seq_index=loop.index0)
     </ul>
     $:macros.Pager(page, num_found)
   </div>

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -1,4 +1,4 @@
-$def with (doc, decorations=None, cta=True, availability=None, extra=None, attrs=None, rating=None, show_librarian_extras=False, include_dropper=False, blur=False, footer=None)
+$def with (doc, decorations=None, cta=True, availability=None, extra=None, attrs=None, rating=None, show_librarian_extras=False, include_dropper=False, blur=False, footer=None, seq_index=None)
 
 $code:
   max_rendered_authors = 9
@@ -65,6 +65,7 @@ $code:
           src="$cover"
           alt="$_('Cover of: %(title)s', title=full_title)"
           title="$_('Cover of: %(title)s', title=full_title)"
+          $:cond(seq_index is not None and seq_index > 3, 'loading="lazy"')
 	  /></a>
       $if ocaid:
         $:macros.BookPreview(ocaid, show_only=False)

--- a/openlibrary/templates/account/loan_history.html
+++ b/openlibrary/templates/account/loan_history.html
@@ -11,7 +11,7 @@ $def with (docs, current_page, include_ratings=False, ratings=[], show_next=Fals
             $:macros.IABook(doc=doc, ia_base_url=ia_base_url)
           $else:
             $ star_rating = macros.StarRatings(doc, redir_url='/account/books/already-read', id=idx+1, rating=ratings[idx]) if include_ratings else None
-            $:macros.SearchResultsWork(doc, availability=doc.get('availability'), rating=star_rating)
+            $:macros.SearchResultsWork(doc, availability=doc.get('availability'), rating=star_rating, seq_index=loop.index0)
     </ul>
     $:macros.Pager_loanhistory(page=current_page, show_next=show_next)
   $else:

--- a/openlibrary/templates/account/reading_log.html
+++ b/openlibrary/templates/account/reading_log.html
@@ -68,7 +68,7 @@ $add_metatag(property="og:image", content=meta_photo_url)
           $else:
             $ work = doc
           $ star_rating = macros.StarRatings(work, redir_url='/account/books/already-read', id=doc_number, rating=ratings[idx]) if include_ratings else None
-          $:macros.SearchResultsWork(work, availability=doc.get('availability'), rating=star_rating, include_dropper=(bookshelf_id and owners_page))
+          $:macros.SearchResultsWork(work, availability=doc.get('availability'), rating=star_rating, include_dropper=(bookshelf_id and owners_page), seq_index=loop.index0)
           $ doc_number = doc_number + 1
     </ul>
     $if not checkin_year:

--- a/openlibrary/templates/stats/readinglog.html
+++ b/openlibrary/templates/stats/readinglog.html
@@ -59,12 +59,13 @@ $def with (stats)
   </div>
 
   <div class="admin-section">
-
+    $ book_idx = 0
     <h3>$_('Most Wanted Books (This Month)')</h3>
     <div class="mybooks-list">
      <ul class="list-books">
         $for book in stats['leaderboard']['most_wanted_month']:
-            $:macros.SearchResultsWork(book['work'], decorations=ungettext("Added %(count)d time", "Added %(count)d times", book['cnt'], count=book['cnt']), availability=book.get('availability'))
+            $:macros.SearchResultsWork(book['work'], decorations=ungettext("Added %(count)d time", "Added %(count)d times", book['cnt'], count=book['cnt']), availability=book.get('availability'), seq_index=book_idx)
+            $ book_idx += 1
       </ul>
     </div>
 
@@ -72,7 +73,8 @@ $def with (stats)
     <div class="mybooks-list">
       <ul class="list-books">
         $for book in stats['leaderboard']['most_wanted_all']:
-            $:macros.SearchResultsWork(book['work'], decorations=ungettext("Added %(count)d time", "Added %(count)d times", book['cnt'], count=book['cnt']), availability=book.get('availability'))
+            $:macros.SearchResultsWork(book['work'], decorations=ungettext("Added %(count)d time", "Added %(count)d times", book['cnt'], count=book['cnt']), availability=book.get('availability'), seq_index=book_idx)
+            $ book_idx += 1
       </ul>
     </div>
 
@@ -81,7 +83,8 @@ $def with (stats)
     <div class="mybooks-list">
       <ul class="list-books">
         $for book in stats['leaderboard']['most_read']:
-            $:macros.SearchResultsWork(book['work'], decorations=ungettext("Added %(count)d time", "Added %(count)d times", book['cnt'], count=book['cnt']), availability=book.get('availability'))
+            $:macros.SearchResultsWork(book['work'], decorations=ungettext("Added %(count)d time", "Added %(count)d times", book['cnt'], count=book['cnt']), availability=book.get('availability'), seq_index=book_idx)
+            $ book_idx += 1
       </ul>
     </div>
 
@@ -90,7 +93,8 @@ $def with (stats)
     <div class="mybooks-list">
       <ul class="list-books">
         $for book in stats['leaderboard']['most_rated_all']:
-            $:macros.SearchResultsWork(book['work'], decorations=ungettext("Added %(count)d time", "Added %(count)d times", book['cnt'], count=book['cnt']), availability=book.get('availability'))
+            $:macros.SearchResultsWork(book['work'], decorations=ungettext("Added %(count)d time", "Added %(count)d times", book['cnt'], count=book['cnt']), availability=book.get('availability'), seq_index=book_idx)
+            $ book_idx += 1
       </ul>
     </div>
   </div>

--- a/openlibrary/templates/trending.html
+++ b/openlibrary/templates/trending.html
@@ -20,14 +20,15 @@ $ page = int(input(page=1).page)
   <div class="mybooks-list">
     <ul class="list-books">
       $if logged_books:
-        $for entry in logged_books:
+        $ valid_entries = [entry for entry in logged_books if entry.get('work')]
+        $for entry in valid_entries:
           $if 'bookshelf_id' in entry:
             $ shelf = {1: _("Want to Read"), 2: _("Currently Reading"), 3: _("Read")}[entry['bookshelf_id']]
             $ extra = _("Someone marked as %(shelf)s %(k_hours_ago)s", shelf=shelf, k_hours_ago=datestr(entry['created']))
           $else:
             $ extra = _('Logged %(count)i times %(time_unit)s', count=entry['cnt'], time_unit=pages[mode])
-          $if entry.get('work'):
-            $:macros.SearchResultsWork(entry['work'], extra=extra, availability=entry['work'].get('availability'))
+
+          $:macros.SearchResultsWork(entry['work'], extra=extra, availability=entry['work'].get('availability'), seq_index=loop.index0)
     </ul>
   </div>
   <div class="pager">

--- a/openlibrary/templates/trending.html
+++ b/openlibrary/templates/trending.html
@@ -20,7 +20,7 @@ $ page = int(input(page=1).page)
   <div class="mybooks-list">
     <ul class="list-books">
       $if logged_books:
-        $ valid_entries = [entry for entry in logged_books if entry.get('work')]
+        $ valid_entries = (entry for entry in logged_books if entry.get('work'))
         $for entry in valid_entries:
           $if 'bookshelf_id' in entry:
             $ shelf = {1: _("Want to Read"), 2: _("Currently Reading"), 3: _("Read")}[entry['bookshelf_id']]

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -144,7 +144,7 @@ $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_libra
                 <div id="searchResults">
                     <ul class="list-books">
                       $for doc in books.docs:
-                         $:macros.SearchResultsWork(doc, show_librarian_extras=show_librarian_extras, include_dropper=True)
+                         $:macros.SearchResultsWork(doc, show_librarian_extras=show_librarian_extras, include_dropper=True, seq_index=loop.index0)
                     </ul>
                 </div>
 

--- a/openlibrary/templates/type/list/view_body.html
+++ b/openlibrary/templates/type/list/view_body.html
@@ -114,7 +114,7 @@ $def seed_attrs(seed):
 
             $if seed.type in ['edition', 'work']:
                 $ doc = solr_works.get(seed.key) or seed.document
-                $:macros.SearchResultsWork(doc, attrs=seed_attrs(seed), availability=availabilities.get(seed.key), decorations=remove_item_link(), extra=seed_meta_line(seed), include_dropper=True, footer=seed.notes and sanitize(format(seed.notes)))
+                $:macros.SearchResultsWork(doc, attrs=seed_attrs(seed), availability=availabilities.get(seed.key), decorations=remove_item_link(), extra=seed_meta_line(seed), include_dropper=True, footer=seed.notes and sanitize(format(seed.notes)), seq_index=loop.index0)
             $else:
                 <li class="searchResultItem sri--w-main" $:seed_attrs(seed)>
                     <div class="sri__main">

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -96,7 +96,7 @@ $def with (q_param, search_response, get_doc, param, page, rows)
             $ subject_keys = [d.get('subject', []) for d in search_response.docs]
             $for work, subjects in zip(works, subject_keys):
                 $ content_warning = len([s for s in subjects if s.startswith("content_warning:")]) != 0
-                $:macros.SearchResultsWork(work, show_librarian_extras=show_librarian_extras, include_dropper=True, blur=content_warning)
+                $:macros.SearchResultsWork(work, show_librarian_extras=show_librarian_extras, include_dropper=True, blur=content_warning, seq_index=loop.index0)
           </ul>
           $:macros.Pager(page, search_response.num_found, rows)
         </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10864


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Confirmed on testing, the covers requests now happen after you scroll down.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
