### PR TITLE
Update Dockerfile.olbase to use new ENV syntax

### DIFF
--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -1,9 +1,9 @@
 FROM python:3.12.2-slim-bookworm
 
-ENV LANG en_US.UTF-8
+ENV LANG=en_US.UTF-8
 
 # required for postgres
-ENV LC_ALL POSIX
+ENV LC_ALL=POSIX
 
 # Create openlibrary users
 # We use 999:999 for the openlibrary user. Any volume mounts which require read/write


### PR DESCRIPTION
Small refactor/linting, keep seeing these warnings:

> docker: docker/Dockerfile.olbase#L6
> LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format
> More info: https://docs.docker.com/go/dockerfile/rule/legacy-key-value-format/



### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
