### PR TITLE
Add option to view lists/other search results as grid

### DIFF
--- a/openlibrary/components/BarcodeScanner.vue
+++ b/openlibrary/components/BarcodeScanner.vue
@@ -328,6 +328,7 @@ export default {
 
       &::marker {
         content: none;
+        font-size: 0;
       }
 
       &::-webkit-details-marker {

--- a/openlibrary/components/LibraryExplorer/components/ShelfLabel.vue
+++ b/openlibrary/components/LibraryExplorer/components/ShelfLabel.vue
@@ -74,7 +74,7 @@ export default {
   padding: 10px;
 }
 
-.shelf-label--classes > summary::marker { display: none; }
+.shelf-label--classes > summary::marker { display: none; font-size: 0; }
 .shelf-label--classes > summary::-webkit-details-marker { display: none; }
 
 .shelf-label--classes .shelf-label--right-arrow {

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -7051,7 +7051,7 @@ msgid "Grid"
 msgstr ""
 
 #: search/layout_options.html
-msgid "View as:"
+msgid "View as: "
 msgstr ""
 
 #: search/lists.html
@@ -7488,10 +7488,6 @@ msgstr ""
 #: type/author/view.html
 #, python-format
 msgid "Search %(author)s books"
-msgstr ""
-
-#: type/author/view.html
-msgid "Sort by: "
 msgstr ""
 
 #: type/author/view.html

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -256,7 +256,7 @@ msgid_plural "View %(count)s Editions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: EditionNavBar.html site/stats.html
+#: EditionNavBar.html search/layout_options.html site/stats.html
 msgid "Details"
 msgstr ""
 
@@ -7045,6 +7045,14 @@ msgid "in %(seconds)s second"
 msgid_plural "in %(seconds)s seconds"
 msgstr[0] ""
 msgstr[1] ""
+
+#: search/layout_options.html
+msgid "Grid"
+msgstr ""
+
+#: search/layout_options.html
+msgid "View as:"
+msgstr ""
 
 #: search/lists.html
 msgid "Search results for Lists"

--- a/openlibrary/macros/AffiliateLinks.html
+++ b/openlibrary/macros/AffiliateLinks.html
@@ -72,5 +72,5 @@ $def affiliate_link(key, analytics_key, name, link, price='', price_note=''):
             </details>
           </li>
     </ul>
-    <p>$:_('When you buy books using these links the Internet Archive may earn a <a class="nostyle" href="/help/faq/about#selling">small commission</a>.')</p>
+    <small>$:_('When you buy books using these links the Internet Archive may earn a <a class="nostyle" href="/help/faq/about#selling">small commission</a>.')</small>
 </span>

--- a/openlibrary/macros/LocateButton.html
+++ b/openlibrary/macros/LocateButton.html
@@ -10,5 +10,5 @@ $if icon:
     <span class="btn-label">$_("Locate")</span>
   </a>
 $else:
-  <a class="cta-btn cta-btn--available cta-btn--w-icon cta-btn--external" href="$locateUrl" target="_blank"
+  <a class="cta-btn cta-btn--available cta-btn--external" href="$locateUrl" target="_blank"
     data-ol-link-track="CTAClick|Locate">$_('Locate')</a>

--- a/openlibrary/macros/ReadButton.html
+++ b/openlibrary/macros/ReadButton.html
@@ -21,17 +21,14 @@ $else:
 $ menu_items = [listen, edition_key]
 $ is_carousel = "BookCarousel" in str(analytics_attr(analytics_action))
 $if any(menu_items) and not is_carousel:
-  <div class="cta-dropper">
-    <div class="cta-button-group cta-dropper-button">
-      <a href="$(stream_url)" title="$title" class="cta-btn cta-btn--ia cta-btn--available cta-btn--$(action)"
-          $:analytics_attr(analytics_action)
-          $if loan:
-            data-userid="$(loan['userid'])"
-          >$label</a>
-    </div>
-    <details>
-      <summary>
-      </summary>
+  <div class="cta-dropper cta-button-group">
+    <a href="$(stream_url)" title="$title" class="cta-btn cta-btn--ia cta-btn--available cta-btn--$(action)"
+        $:analytics_attr(analytics_action)
+        $if loan:
+          data-userid="$(loan['userid'])"
+        >$label</a>
+    <details class="cta-btn cta-btn--available">
+      <summary></summary>
       <ul class="dropper-menu">
         $if listen:
           <li>

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -573,4 +573,10 @@ jQuery(function () {
         import(/* webpackChunkName: "librarian-dashboard" */ './librarian-dashboard')
             .then(module => module.initLibrarianDashboard(librarianDashboard))
     }
+
+    // List books
+    if (document.querySelector('.list-books')) {
+        import(/* webpackChunkName: "list-books" */ './list_books')
+            .then(module => module.ListBooks.init());
+    }
 });

--- a/openlibrary/plugins/openlibrary/js/list_books.js
+++ b/openlibrary/plugins/openlibrary/js/list_books.js
@@ -1,0 +1,36 @@
+export class ListBooks {
+    /**
+     * @param {HTMLElement} listBooks
+     * @param {HTMLElement} layoutToolbar
+     **/
+    constructor(listBooks, layoutToolbar) {
+        this.listBooks = listBooks;
+        this.layoutToolbar = layoutToolbar;
+
+        this.activeLayout = this.layoutToolbar.querySelector('a.active');
+    }
+
+    attach() {
+        $(this.layoutToolbar).on('click', 'a', this.updateLayout.bind(this));
+    }
+
+    /**
+     * @param {MouseEvent} event
+     */
+    updateLayout(event) {
+        event.preventDefault();
+        const layoutAnchor = event.target;
+        this.layoutToolbar.querySelector('a.active').classList.remove('active');
+        layoutAnchor.classList.add('active');
+        const layout = layoutAnchor.dataset.value;
+        this.listBooks.classList.toggle('list-books--grid', layout === 'grid');
+    }
+
+    static init() {
+        // Assume only one list-books/layout per page
+        new ListBooks(
+            document.querySelector('.list-books'),
+            document.querySelector('.tools--layout'),
+        ).attach();
+    }
+}

--- a/openlibrary/plugins/openlibrary/js/list_books.js
+++ b/openlibrary/plugins/openlibrary/js/list_books.js
@@ -24,6 +24,7 @@ export class ListBooks {
         layoutAnchor.classList.add('active');
         const layout = layoutAnchor.dataset.value;
         this.listBooks.classList.toggle('list-books--grid', layout === 'grid');
+        document.cookie = `LIST_BOOKS_LAYOUT=${layout}; path=/; max-age=31536000`;
     }
 
     static init() {

--- a/openlibrary/plugins/openlibrary/js/list_books.js
+++ b/openlibrary/plugins/openlibrary/js/list_books.js
@@ -24,7 +24,7 @@ export class ListBooks {
         layoutAnchor.classList.add('active');
         const layout = layoutAnchor.dataset.value;
         this.listBooks.classList.toggle('list-books--grid', layout === 'grid');
-        document.cookie = `LIST_BOOKS_LAYOUT=${layout}; path=/; max-age=31536000`;
+        document.cookie = `LBL=${layout}; path=/; max-age=31536000`;
     }
 
     static init() {

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -177,8 +177,8 @@ def get_remembered_layout():
         return web.input(layout=None).get('layout')
 
     def read_cookie():
-        if "LIST_BOOKS_LAYOUT" in web.ctx.env.get("HTTP_COOKIE", ""):
-            return web.cookies().get('LIST_BOOKS_LAYOUT')
+        if "LBL" in web.ctx.env.get("HTTP_COOKIE", ""):
+            return web.cookies().get('LBL')
 
     if (qs_value := read_query_string()) is not None:
         return qs_value

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -171,6 +171,24 @@ def execute_solr_query(
 public(has_solr_editions_enabled)
 
 
+@public
+def get_remembered_layout():
+    def read_query_string():
+        return web.input(layout=None).get('layout')
+
+    def read_cookie():
+        if "LIST_BOOKS_LAYOUT" in web.ctx.env.get("HTTP_COOKIE", ""):
+            return web.cookies().get('LIST_BOOKS_LAYOUT')
+
+    if (qs_value := read_query_string()) is not None:
+        return qs_value
+
+    if (cookie_value := read_cookie()) is not None:
+        return cookie_value
+
+    return 'details'
+
+
 def run_solr_query(  # noqa: PLR0912
     scheme: SearchScheme,
     param: dict | None = None,

--- a/openlibrary/templates/account/reading_log.html
+++ b/openlibrary/templates/account/reading_log.html
@@ -52,9 +52,12 @@ $add_metatag(property="og:image", content=meta_photo_url)
           <strong class="lightgreen">$_("Date Added (oldest)")</strong>
       </span>
 
+    $ layout = get_remembered_layout()
+    $:render_template("search/layout_options.html", selected_layout=layout)
+
     $if not checkin_year:
       $:macros.Pager(int(current_page), doc_count, results_per_page=results_per_page)
-    <ul class="list-books">
+    <ul class="list-books $cond(layout == 'grid', 'list-books--grid')">
       $if docs:
         $ bookshelf_id = {'want-to-read': 1, 'currently-reading': 2, 'already-read': 3}.get(key, None)
         $ doc_number = 1

--- a/openlibrary/templates/account/reading_log.html
+++ b/openlibrary/templates/account/reading_log.html
@@ -38,22 +38,25 @@ $add_metatag(property="og:image", content=meta_photo_url)
       <form method="GET" class="olform pagesearchbox">
         $:render_template("search/searchbox", q=query_param('q'), placeholder=_('Search your reading log'))
       </form>
-    $if q:
-      <span class="search-results-stats">$ungettext('%(count)s hit', '%(count)s hits', doc_count, count=commify(doc_count))</span>
-    $else:
-      <span class="mybooks-tools"><img src="/images/icons/icon_sort.png" alt="$_('Sorting by')" style="margin-right:10px;" width="9" height="11">
-        $if sort_order == 'desc':
-          <strong class="lightgreen">$_("Date Added (newest)")</strong>
-          |
-          <a href="$changequery(sort='asc')">$_("Date Added (oldest)")</a>
-        $else:
-          <a href="$changequery(sort='desc')">$_("Date Added (newest)")</a>
-          |
-          <strong class="lightgreen">$_("Date Added (oldest)")</strong>
-      </span>
 
-    $ layout = get_remembered_layout()
-    $:render_template("search/layout_options.html", selected_layout=layout)
+    <div class="search-results-stats">
+      $if q:
+        $ungettext('%(count)s hit', '%(count)s hits', doc_count, count=commify(doc_count))
+      $else:
+        <span class="mybooks-tools"><img src="/images/icons/icon_sort.png" alt="$_('Sorting by')" style="margin-right:10px;" width="9" height="11">
+          $if sort_order == 'desc':
+            <strong class="lightgreen">$_("Date Added (newest)")</strong>
+            |
+            <a href="$changequery(sort='asc')">$_("Date Added (oldest)")</a>
+          $else:
+            <a href="$changequery(sort='desc')">$_("Date Added (newest)")</a>
+            |
+            <strong class="lightgreen">$_("Date Added (oldest)")</strong>
+        </span>
+
+      $ layout = get_remembered_layout()
+      $:render_template("search/layout_options.html", selected_layout=layout)
+    </div>
 
     $if not checkin_year:
       $:macros.Pager(int(current_page), doc_count, results_per_page=results_per_page)

--- a/openlibrary/templates/books/custom_carousel_card.html
+++ b/openlibrary/templates/books/custom_carousel_card.html
@@ -51,7 +51,5 @@ $ work_key = book['key'] if book['key'].startswith('/work') else book.get('work_
         </div>
     </a>
   </div>
-  <div class="book-cta">
-    $:macros.LoanStatus(book, work_key=work_key, listen=False, secondary_action=secondary_action, analytics_override="BookCarousel|CTAClick|%s" % key)
-  </div>
+  $:macros.LoanStatus(book, work_key=work_key, listen=False, secondary_action=secondary_action, analytics_override="BookCarousel|CTAClick|%s" % key)
 </div>

--- a/openlibrary/templates/my_books/dropdown_content.html
+++ b/openlibrary/templates/my_books/dropdown_content.html
@@ -66,9 +66,7 @@ $def list_selections(user_lists, work_key, edition_key, async_load):
           <span>$_('Use this Work')</span>
         </label>
       </p>
-    <p class="create">
-      <a href="javascript:;" class="create-new-list" aria-controls="addList">$_('Create a new list')</a>
-    </p>
+    <a href="javascript:;" class="create create-new-list" aria-controls="addList">$_('Create a new list')</a>
   </div>
 
 $def new_list_modal_content():

--- a/openlibrary/templates/search/layout_options.html
+++ b/openlibrary/templates/search/layout_options.html
@@ -1,6 +1,7 @@
-$def with (selected_layout, default_layout='details')
+$def with (selected_layout)
 
 $code:
+  default_layout = 'details'
   layout_options = [
     { 'layout': 'details', 'name': _("Details"), 'ga_key': 'Details' },
     { 'layout': 'grid', 'name': _("Grid"), 'ga_key': 'Grid' },

--- a/openlibrary/templates/search/layout_options.html
+++ b/openlibrary/templates/search/layout_options.html
@@ -1,0 +1,21 @@
+$def with (selected_layout, default_layout='details')
+
+$code:
+  layout_options = [
+    { 'layout': 'details', 'name': _("Details"), 'ga_key': 'Details' },
+    { 'layout': 'grid', 'name': _("Grid"), 'ga_key': 'Grid' },
+  ]
+
+<span class="tools tools--layout">
+  $_('View as:')
+  $for layout_option in layout_options:
+    $ is_selected = layout_option['layout'] == selected_layout or (selected_layout is None and layout_option['layout'] == default_layout)
+    $if is_selected:
+      <a><strong>$layout_option['name']</strong></a>
+    $else:
+      <a href="$changequery(layout=cond(layout_option['layout'] == default_layout, None, layout_option['layout']))"
+        data-ol-link-track="SearchLayout|$layout_option['ga_key']"
+      >$layout_option['name']</a>
+    $if not loop.last:
+      |
+</span>

--- a/openlibrary/templates/search/layout_options.html
+++ b/openlibrary/templates/search/layout_options.html
@@ -6,16 +6,18 @@ $code:
     { 'layout': 'grid', 'name': _("Grid"), 'ga_key': 'Grid' },
   ]
 
-<span class="tools tools--layout">
-  $_('View as:')
+<span class="tool-button tool-button--group" title="$_('View as: ')">
   $for layout_option in layout_options:
     $ is_selected = layout_option['layout'] == selected_layout or (selected_layout is None and layout_option['layout'] == default_layout)
     $if is_selected:
-      <a><strong>$layout_option['name']</strong></a>
+      <a
+        class="tool-button tool-button--selected"
+        href="javascript:void(0);"
+      >$layout_option['name']</a>
     $else:
-      <a href="$changequery(layout=cond(layout_option['layout'] == default_layout, None, layout_option['layout']))"
+      <a
+        class="tool-button"
+        href="$changequery(layout=cond(layout_option['layout'] == default_layout, None, layout_option['layout']))"
         data-ol-link-track="SearchLayout|$layout_option['ga_key']"
       >$layout_option['name']</a>
-    $if not loop.last:
-      |
 </span>

--- a/openlibrary/templates/search/layout_options.html
+++ b/openlibrary/templates/search/layout_options.html
@@ -6,18 +6,13 @@ $code:
     { 'layout': 'grid', 'name': _("Grid"), 'ga_key': 'Grid' },
   ]
 
-<span class="tool-button tool-button--group" title="$_('View as: ')">
+<span class="tools--layout tool-button tool-button--group" title="$_('View as: ')">
   $for layout_option in layout_options:
     $ is_selected = layout_option['layout'] == selected_layout or (selected_layout is None and layout_option['layout'] == default_layout)
-    $if is_selected:
-      <a
-        class="tool-button tool-button--selected"
-        href="javascript:void(0);"
-      >$layout_option['name']</a>
-    $else:
-      <a
-        class="tool-button"
-        href="$changequery(layout=cond(layout_option['layout'] == default_layout, None, layout_option['layout']))"
-        data-ol-link-track="SearchLayout|$layout_option['ga_key']"
-      >$layout_option['name']</a>
+    <a
+      class="tool-button $cond(is_selected, 'active', '')"
+      data-value="$layout_option['layout']"
+      href="$changequery(layout=cond(layout_option['layout'] == default_layout, None, layout_option['layout']))"
+      data-ol-link-track="SearchLayout|$layout_option['ga_key']"
+    >$layout_option['name']</a>
 </span>

--- a/openlibrary/templates/search/sort_options.html
+++ b/openlibrary/templates/search/sort_options.html
@@ -57,45 +57,43 @@ $code:
          sort_options.append({ 'sort': 'title', 'name': _("Work Title (beta: Librarian only)"), 'ga_key': 'Title' })
 
      selected_sort_option = get_selected_sort_option(sort_options, selected_sort) or get_selected_sort_option(sort_options, default_sort)
-    <span class="sort-dropper">
-      <details>
-        <summary>
-          <img src="/images/icons/icon_sort.png" alt="$_('Sorting by')" width="9" height="11" />
-          <p>$selected_sort_option['name']</p>
-        </summary>
-        <span class="sort-content">
-          <span class="sort-content-inner">
-            $for sort_option in sort_options:
-              $if exclude and sort_option['sort'] in exclude:
-                $continue
-              $ is_selected = sort_option.get('selected') or sort_option['sort'] == selected_sort
-              $ sub_sorts = sort_option.get('sub_sorts', [])
-              $ sub_sort_selected = any(sub_sort.get('selected') or sub_sort['sort'] == selected_sort for sub_sort in sub_sorts)
-              $if is_selected:
-                <a class="sort-selected">$sort_option['name']</a>
-              $else:
-                <a href="$changequery(page=None, sort=cond(sort_option['sort'] == default_sort, None, sort_option['sort']))"
-                   data-ol-link-track="SearchSort|$sort_option['ga_key']"
-                   rel="nofollow"
-                >
-                  $sort_option['name']
-                </a>
-              $if sub_sorts and (is_selected or sub_sort_selected):
-                $for sub_sort in sort_option['sub_sorts']:
-                  $ is_selected = sub_sort.get('selected') or sub_sort['sort'] == selected_sort
-                  $if is_selected:
-                    <a class="sort-subsort-selected">$sub_sort['name']</a>
-                  $else:
-                    <a class="sort-subsort"
-                       href="$changequery(page=None, sort=cond(sub_sort['sort'] == default_sort, None, sub_sort['sort']))"
-                       data-ol-link-track="SearchSort|$sort_option['ga_key']SubSort"
-                    >
-                      $sub_sort['name']
-                    </a>
-          </span>
+    <details class="sort-dropper">
+      <summary class="tool-button">
+        <img src="/images/icons/icon_sort.png" alt="$_('Sorting by')" width="9" height="11" />
+        $selected_sort_option['name']
+      </summary>
+      <span class="sort-content">
+        <span class="sort-content-inner">
+          $for sort_option in sort_options:
+            $if exclude and sort_option['sort'] in exclude:
+              $continue
+            $ is_selected = sort_option.get('selected') or sort_option['sort'] == selected_sort
+            $ sub_sorts = sort_option.get('sub_sorts', [])
+            $ sub_sort_selected = any(sub_sort.get('selected') or sub_sort['sort'] == selected_sort for sub_sort in sub_sorts)
+            $if is_selected:
+              <a class="sort-selected">$sort_option['name']</a>
+            $else:
+              <a href="$changequery(page=None, sort=cond(sort_option['sort'] == default_sort, None, sort_option['sort']))"
+                  data-ol-link-track="SearchSort|$sort_option['ga_key']"
+                  rel="nofollow"
+              >
+                $sort_option['name']
+              </a>
+            $if sub_sorts and (is_selected or sub_sort_selected):
+              $for sub_sort in sort_option['sub_sorts']:
+                $ is_selected = sub_sort.get('selected') or sub_sort['sort'] == selected_sort
+                $if is_selected:
+                  <a class="sort-subsort-selected">$sub_sort['name']</a>
+                $else:
+                  <a class="sort-subsort"
+                      href="$changequery(page=None, sort=cond(sub_sort['sort'] == default_sort, None, sub_sort['sort']))"
+                      data-ol-link-track="SearchSort|$sort_option['ga_key']SubSort"
+                  >
+                    $sub_sort['name']
+                  </a>
         </span>
-      </details>
-    </span>
+      </span>
+    </details>
     $if selected_sort and selected_sort.startswith('random') and not is_bot():
           <a class="sort-random-shuffle"
              href="$changequery(page=None, sort='random_%s' % today().timestamp())"

--- a/openlibrary/templates/type/about/view.html
+++ b/openlibrary/templates/type/about/view.html
@@ -10,7 +10,7 @@ $ text = format(page.title)
     <h1>$page.title</h1>
 </div>
 
-<div id="contentBody">
+<div id="contentBody" class="markdown-content">
 
     <div class="contentHalf">
         $:format(page.intro)

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -40,7 +40,7 @@ $add_metatag(property="og:description", content=description)
 
 $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
 
-$ layout = query_param('layout', None)
+$ layout = get_remembered_layout()
 $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian())
 <div id="contentHead">
 
@@ -135,7 +135,7 @@ $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_libra
                 $if books_count > 1:
                     <div id="books">
                         $:render_template("search/sort_options.html", books.sort, exclude='relevance', default_sort='editions')
-                        $:render_template("search/layout_options.html", selected_layout=layout, default_layout='details')
+                        $:render_template("search/layout_options.html", selected_layout=layout)
 
                         $if input(mode="everything").mode == "everything":
                             <span>$:_('— Show <a href="%(url)s">only ebooks</a>?', url=changequery(mode='ebooks'))</span>

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -135,6 +135,10 @@ $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_libra
                     <div id="books">
                         <label for="sortOptions">$_('Sort by: ')</label>
                         $:render_template("search/sort_options.html", books.sort, exclude='relevance', default_sort='editions')
+
+                        $ layout = query_param('layout', None)
+                        $:render_template("search/layout_options.html", selected_layout=layout, default_layout='details')
+
                         $if input(mode="everything").mode == "everything":
                             <span>$:_('— Show <a href="%(url)s">only ebooks</a>?', url=changequery(mode='ebooks'))</span>
                         $else:
@@ -144,7 +148,7 @@ $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_libra
                 $:macros.Pager(page=safeint(query_param('page'), default=1), num_found=books_count)
 
                 <div id="searchResults">
-                    <ul class="list-books">
+                    <ul class="list-books $cond(layout == 'grid', 'list-books--grid')">
                       $for doc in books.docs:
                          $:macros.SearchResultsWork(doc, show_librarian_extras=show_librarian_extras, include_dropper=True, seq_index=loop.index0)
                     </ul>

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -40,6 +40,7 @@ $add_metatag(property="og:description", content=description)
 
 $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
 
+$ layout = query_param('layout', None)
 $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian())
 <div id="contentHead">
 
@@ -133,10 +134,7 @@ $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_libra
 
                 $if books_count > 1:
                     <div id="books">
-                        <label for="sortOptions">$_('Sort by: ')</label>
                         $:render_template("search/sort_options.html", books.sort, exclude='relevance', default_sort='editions')
-
-                        $ layout = query_param('layout', None)
                         $:render_template("search/layout_options.html", selected_layout=layout, default_layout='details')
 
                         $if input(mode="everything").mode == "everything":

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -133,7 +133,7 @@ $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_libra
         <div class="clearfix"></div>
 
                 $if books_count > 1:
-                    <div id="books">
+                    <div class="search-results-stats">
                         $:render_template("search/sort_options.html", books.sort, exclude='relevance', default_sort='editions')
                         $:render_template("search/layout_options.html", selected_layout=layout)
 

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -237,7 +237,7 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
         $else:
           $ overview_desc = work.description
         <div class="book-description read-more">
-            <div class="read-more__content" style="max-height:81px">
+            <div class="read-more__content markdown-content" style="max-height:81px">
                 $:sanitize(format(overview_desc))
             </div>
             $:macros.ReadMore()

--- a/openlibrary/templates/type/list/view_body.html
+++ b/openlibrary/templates/type/list/view_body.html
@@ -87,10 +87,14 @@ $def seed_attrs(seed):
             $:format(list.description)
 
         $:render_template("search/sort_options.html", selected_sort=sort, default_sort='index', search_scheme="lists_seeds")
+        <br />
+        $ layout = query_param('layout', None)
+        $:render_template("search/layout_options.html", selected_layout=layout, default_layout='details')
+
         $:macros.Pager(page+1, len(list.seeds), page_size)
         <div class="clearfix"></div>
 
-        <ul id="listResults" class="list-books clearfix">
+        <ul id="listResults" class="list-books clearfix $cond(layout == 'grid', 'list-books--grid')">
             $ component_times['get_seeds'] = time()
             $ seeds = list.get_seeds(sort=(sort == 'last_modified'), resolve_redirects=True)[page*page_size:page*page_size+page_size]
             $ component_times['get_seeds'] = time() - component_times['get_seeds']

--- a/openlibrary/templates/type/list/view_body.html
+++ b/openlibrary/templates/type/list/view_body.html
@@ -85,6 +85,7 @@ $def seed_attrs(seed):
 
         $if list.description:
             $:format(list.description)
+            <div class="clearfix"></div>
 
         $:render_template("search/sort_options.html", selected_sort=sort, default_sort='index', search_scheme="lists_seeds")
         <br />

--- a/openlibrary/templates/type/list/view_body.html
+++ b/openlibrary/templates/type/list/view_body.html
@@ -87,9 +87,11 @@ $def seed_attrs(seed):
             $:format(list.description)
             <div class="clearfix"></div>
 
-        $:render_template("search/sort_options.html", selected_sort=sort, default_sort='index', search_scheme="lists_seeds")
-        $ layout = get_remembered_layout()
-        $:render_template("search/layout_options.html", selected_layout=layout)
+        <div class="search-results-stats">
+            $:render_template("search/sort_options.html", selected_sort=sort, default_sort='index', search_scheme="lists_seeds")
+            $ layout = get_remembered_layout()
+            $:render_template("search/layout_options.html", selected_layout=layout)
+        </div>
 
         $:macros.Pager(page+1, len(list.seeds), page_size)
         <div class="clearfix"></div>

--- a/openlibrary/templates/type/list/view_body.html
+++ b/openlibrary/templates/type/list/view_body.html
@@ -88,8 +88,8 @@ $def seed_attrs(seed):
             <div class="clearfix"></div>
 
         $:render_template("search/sort_options.html", selected_sort=sort, default_sort='index', search_scheme="lists_seeds")
-        $ layout = query_param('layout', None)
-        $:render_template("search/layout_options.html", selected_layout=layout, default_layout='details')
+        $ layout = get_remembered_layout()
+        $:render_template("search/layout_options.html", selected_layout=layout)
 
         $:macros.Pager(page+1, len(list.seeds), page_size)
         <div class="clearfix"></div>

--- a/openlibrary/templates/type/list/view_body.html
+++ b/openlibrary/templates/type/list/view_body.html
@@ -88,7 +88,6 @@ $def seed_attrs(seed):
             <div class="clearfix"></div>
 
         $:render_template("search/sort_options.html", selected_sort=sort, default_sort='index', search_scheme="lists_seeds")
-        <br />
         $ layout = query_param('layout', None)
         $:render_template("search/layout_options.html", selected_layout=layout, default_layout='details')
 

--- a/openlibrary/templates/type/object/view.html
+++ b/openlibrary/templates/type/object/view.html
@@ -3,9 +3,12 @@ $def with (page)
 $var title: $page.key
 
 <style type="text/css">
+#contentBody ul {
+    margin-bottom: 20px;
+}
 #contentBody li {
-    list-style-type:none!important;
     line-height: 1em;
+    margin-left: 20px;
 }
 .dict {
     margin-bottom: 2px;

--- a/openlibrary/templates/type/page/view.html
+++ b/openlibrary/templates/type/page/view.html
@@ -21,7 +21,7 @@ $if '<!--suppress-title-->' not in page.body:
 
 $ text = format(page.body)
 
-<div id="contentBody">
+<div id="contentBody" class="markdown-content">
 
     $:macros.Subnavigation(page)
 

--- a/openlibrary/templates/type/user/view.html
+++ b/openlibrary/templates/type/user/view.html
@@ -45,8 +45,9 @@ $else:
             <a href="$url" rel="nofollow">$url</a><br/>
         </p>
 
-    $:sanitize(format(page.description))
-
+    <div class="markdown-content">
+        $:sanitize(format(page.description))
+    </div>
 
     <h2>$_('Reading Log')</h2>
     $if owners_page:

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -86,8 +86,8 @@ $def with (q_param, search_response, get_doc, param, page, rows)
           $if search_response.num_found > 1:
             $:render_template("search/sort_options.html", search_response.sort)
 
-            $ layout = query_param('layout', None)
-            $:render_template("search/layout_options.html", selected_layout=layout, default_layout='details')
+            $ layout = get_remembered_layout()
+            $:render_template("search/layout_options.html", selected_layout=layout)
         </div>
         <div class="resultsContainer search-results-container">
         <div id="searchResults">

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -85,10 +85,13 @@ $def with (q_param, search_response, get_doc, param, page, rows)
 
           $if search_response.num_found > 1:
             $:render_template("search/sort_options.html", search_response.sort)
+
+            $ layout = query_param('layout', None)
+            $:render_template("search/layout_options.html", selected_layout=layout, default_layout='details')
         </div>
         <div class="resultsContainer search-results-container">
         <div id="searchResults">
-          <ul class="list-books">
+          <ul class="list-books $cond(layout == 'grid', 'list-books--grid')">
             $ works = [get_doc(d) for d in search_response.docs]
             $ add_availability([(w.get('editions') or [None])[0] or w for w in works])
             $ username = ctx.user and ctx.user.key.split('/')[-1]

--- a/static/css/base/common.less
+++ b/static/css/base/common.less
@@ -90,16 +90,6 @@ div.head {
   }
 }
 
-#contentBody {
-  li {
-    line-height: 1.5em;
-  }
-  ol li {
-    list-style: decimal;
-    list-style-position: inside;
-  }
-}
-
 @media only screen and (max-width: @width-breakpoint-tablet) {
   tr,
   tbody,

--- a/static/css/base/common.less
+++ b/static/css/base/common.less
@@ -45,7 +45,6 @@ fieldset {
   width: 100%;
 }
 p {
-  font-size: 0.875em;
   line-height: 1.5em;
 }
 hr {

--- a/static/css/components/book.less
+++ b/static/css/components/book.less
@@ -1,15 +1,11 @@
 // https://github.com/internetarchive/openlibrary/wiki/Design-Pattern-Library#book
 
 .book {
-  .book-cta {
-    margin: 5px auto 0;
-    font-size: 0.9em;
-    padding: 5px 0;
-
-    a {
-      display: block;
-    }
+  & > .cta-button-group,
+  & > .cta-btn {
+    margin-top: 10px;
   }
+
   .book-cover {
     height: 200px;
     display: flex;

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -3,11 +3,12 @@
  * https://github.com/internetarchive/openlibrary/wiki/Design-Pattern-Library#ctabtn
  */
 @import "../less/index.less";
+@import "../less/font-families.less";
 
 // `a` specificity is needed to override default anchor styles
 .cta-btn,
 a.cta-btn {
-  font-size: 16px;
+  font-size: @font-size-label-large;
   color: @white;
   width: 100%;
   display: block;

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -196,45 +196,31 @@ a.cta-btn {
 
 .cta-button-group {
   display: flex;
-  align-items: center;
   position: relative;
 
-  .cta-btn--w-icon {
-    display: flex;
-  }
-
   .cta-btn {
-    padding: 8px 0;
+    padding: 8px;
+    margin: 0;
 
-    &:first-child {
-      flex: 1;
-      padding: 8px;
-      overflow: hidden;
-    }
-
-    &:not(:first-child) {
-      margin-left: 1px;
-      width: 40px;
-      transition: width 0.2s;
-      overflow: hidden;
-      border-radius: 2px 6px 6px 2px;
-    }
-
-    &:not(:last-child) {
-      border-radius: 6px 2px 2px 6px;
-    }
-    // stylelint-disable-next-line selector-max-specificity
-    &:not(:first-child):hover {
-      width: 100%;
-    }
+    // Avoid text wrapping
+    text-overflow: ellipsis;
+    overflow: hidden;
   }
 
-  &.cta-dropper-button {
-    // only read dropper buttons
-    // Rule broken by .cta-btn:not(:first-child):hover
-    // stylelint-disable-next-line no-descending-specificity
-    .cta-btn {
-      margin: 0;
-    }
+  // stylelint-disable-next-line selector-max-specificity
+  > .cta-btn:first-child:not(:last-child) {
+    border-radius: 6px 2px 2px 6px;
+  }
+
+  // stylelint-disable-next-line selector-max-specificity
+  > .cta-btn:not(:first-child):not(:last-child) {
+    margin-left: 1px;
+    border-radius: 2px;
+  }
+
+  // stylelint-disable-next-line selector-max-specificity
+  > .cta-btn:last-child:not(:first-child) {
+    margin-left: 1px;
+    border-radius: 2px 6px 6px 2px;
   }
 }

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -28,7 +28,8 @@ a.cta-btn {
   transition: background-color 0.2s;
 
   .btn-icon {
-    width: 40px;
+    width: 22px;
+    height: 22px;
     flex-shrink: 0;
   }
   // stylelint-disable-next-line selector-max-specificity
@@ -40,7 +41,8 @@ a.cta-btn {
   }
 
   .btn-label {
-    padding: 0 10px;
+    padding: 8px;
+    padding-right: 0;
   }
 
   &:link,
@@ -135,6 +137,12 @@ a.cta-btn {
     }
   }
 
+  &.cta-btn--w-icon {
+    display: flex;
+    align-items: center;
+    padding: 0 8px;
+  }
+
   &--sponsor:link,
   &--sponsor:visited {
     color: @link-blue;
@@ -163,10 +171,6 @@ a.cta-btn {
 
   &.cta-btn--external {
     padding-right: 25px;
-    // stylelint-disable-next-line selector-max-specificity
-    .btn-label {
-      padding: 8px 10px;
-    }
   }
 }
 

--- a/static/css/components/editions.less
+++ b/static/css/components/editions.less
@@ -18,18 +18,6 @@ table#editions,
     margin: 0 auto;
   }
 
-  // make cta with dropper same size as cta with no dropper
-  .cta-dropper {
-    width: fit-content;
-    margin: 0 auto;
-    .cta-dropper-button {
-      width: 145px;
-    }
-    .dropper-menu {
-      width: 185px;
-    }
-  }
-
   thead {
     border: 1px solid @light-grey;
 

--- a/static/css/components/generic-dropper.less
+++ b/static/css/components/generic-dropper.less
@@ -103,8 +103,16 @@
     flex-shrink: 0;
   }
   summary {
-    display: flex;
     height: 100%;
+    margin: auto;
+    width: 24px;
+    // style for animated arrow on dropdown button. Copied from "Want to Read" dropper above
+    content: "";
+    background: url(/static/images/icons/icon_dropit.png) no-repeat center;
+    background-position: 0;
+    background-size: 45px;
+    // whiten arrow png
+    filter: brightness(0) invert(1);
   }
 
   // hide extra arrow on iOS
@@ -116,21 +124,8 @@
     display: none;
   }
 
-  summary::after {
-    display: block;
-    margin: auto;
-    width: 24px;
-    height: 20px;
-    // style for animated arrow on dropdown button. Copied from "Want to Read" dropper above
-    content: "";
-    background: url(/images/icons/icon_dropit.png) no-repeat center;
-    background-position: 0;
-    background-size: 45px;
-    // whiten arrow png
-    filter: brightness(0) invert(1);
-  }
-  details[open] summary::after {
-    background-position: -22px -1px;
+  details[open] summary {
+    background-position: -22px 48%;
   }
 }
 // dropdown containing Listen/Search/Download/Locate buttons
@@ -159,6 +154,7 @@
   }
   .cta-btn .btn-label {
     padding: 0;
+    flex: 1;
   }
   .cta-btn:hover {
     background-color: @lighter-grey;
@@ -184,7 +180,7 @@
   .btn-icon {
     display: inline-block;
     filter: invert(1);
-    margin: 5px 2px -4px;
+    margin-right: 5px;
     width: 1.25em;
     height: 1.25em;
   }

--- a/static/css/components/generic-dropper.less
+++ b/static/css/components/generic-dropper.less
@@ -1,3 +1,5 @@
+@import "../less/font-families.less";
+
 .generic-dropper-wrapper {
   position: relative;
   z-index: @z-index-level-3;
@@ -38,7 +40,7 @@
       button {
         border: none;
         cursor: pointer;
-        font-size: 1rem;
+        font-size: @font-size-label-large;
         height: 100%;
         width: 100%;
       }
@@ -82,6 +84,7 @@
     width: 100%;
     border-top: 1px solid @lighter-grey;
     position: absolute;
+    font-size: @font-size-label-medium;
   }
 }
 .book-progress-btn {

--- a/static/css/components/generic-dropper.less
+++ b/static/css/components/generic-dropper.less
@@ -110,6 +110,7 @@
   // hide extra arrow on iOS
   summary::marker {
     content: "";
+    font-size: 0;
   }
   summary::-webkit-details-marker {
     display: none;

--- a/static/css/components/generic-dropper.less
+++ b/static/css/components/generic-dropper.less
@@ -50,7 +50,7 @@
       border-left: 1px solid @lighter-grey;
       text-decoration: none;
       height: inherit;
-      width: 40px;
+      width: 32px;
 
       .display-flex();
       justify-content: center;
@@ -95,32 +95,18 @@
 /* Unified Read Button Styling */
 .cta-dropper {
   display: flex;
-  margin-bottom: 10px;
-  // main cta button
-  .cta-dropper-button {
-    .cta-btn {
-      border-radius: 5px 2px 2px 5px;
-    }
-    border-right: 1px solid transparent;
-    flex-grow: 1;
-  }
+
   // dropdown button
-  details {
-    position: relative;
-    background-color: @primary-blue;
-    border-radius: 2px 5px 5px 2px;
+  details.cta-btn {
+    padding: 0;
+    width: 32px;
+    flex-shrink: 0;
   }
   summary {
     display: flex;
-    align-items: center;
     height: 100%;
-    cursor: pointer;
-    list-style-type: none;
-    &:hover {
-      background-color: darken(@primary-blue, 20%);
-    }
-    border-radius: 2px 5px 5px 2px;
   }
+
   // hide extra arrow on iOS
   summary::marker {
     content: "";
@@ -130,9 +116,10 @@
   }
 
   summary::after {
-    margin: 0 8px;
+    display: block;
+    margin: auto;
     width: 24px;
-    height: 24px;
+    height: 20px;
     // style for animated arrow on dropdown button. Copied from "Want to Read" dropper above
     content: "";
     background: url(/images/icons/icon_dropit.png) no-repeat center;
@@ -142,13 +129,22 @@
     filter: brightness(0) invert(1);
   }
   details[open] summary::after {
-    content: "";
-    background-position: -22px 50%;
+    background-position: -22px -1px;
   }
 }
 // dropdown containing Listen/Search/Download/Locate buttons
 .dropper-menu {
   z-index: @z-index-level-4;
+  border: 1px solid @lighter-grey;
+  border-radius: 5px;
+  background-color: @white;
+  position: absolute;
+  // align dropper menu with buttons
+  right: 0;
+  margin-top: 6px;
+  width: 100%;
+  max-width: 200px;
+
   .cta-btn.cta-btn--w-icon,
   .cta-btn:link,
   .cta-btn:visited {
@@ -167,6 +163,9 @@
     background-color: @lighter-grey;
   }
   li {
+    list-style: none;
+    margin: 0;
+
     & + li {
       border-top: 1px solid @lighter-grey;
     }
@@ -185,7 +184,7 @@
     display: inline-block;
     filter: invert(1);
     margin: 5px 2px -4px;
-    // width uses higher specificity below
+    width: 1.25em;
     height: 1.25em;
   }
   // icons
@@ -200,23 +199,5 @@
     background-repeat: no-repeat;
     background-size: contain;
     background-position: center;
-  }
-}
-// extra specificity needed for style overrides
-.cta-dropper .dropper-menu {
-  margin: 5px 0 0;
-  border: 1px solid @lighter-grey;
-  border-radius: 5px;
-  background-color: @white;
-  position: absolute;
-  // align dropper menu with buttons
-  right: 0;
-  width: 194px;
-  li {
-    list-style: none;
-    margin: 0;
-  }
-  .btn-icon {
-    width: 1.25em;
   }
 }

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -242,6 +242,7 @@
 
     summary::marker {
       content: "";
+      font-size: 0;
     }
 
     summary::-webkit-details-marker {
@@ -627,6 +628,7 @@ div.search-facet:focus-within {
 
   summary::marker {
     content: "";
+    font-size: 0;
   }
 
   summary::-webkit-details-marker {

--- a/static/css/components/language.less
+++ b/static/css/components/language.less
@@ -7,6 +7,7 @@
 }
 .language-component summary::marker {
   content: "";
+  font-size: 0;
 }
 .language-component summary::-webkit-details-marker {
   display: none;

--- a/static/css/components/mybooks-dropper.less
+++ b/static/css/components/mybooks-dropper.less
@@ -49,22 +49,18 @@
 
 /* Styling for the My Books dropper's dropdown content: */
 .generic-dropper__dropdown {
+  min-width: 200px;
+  max-width: 100vw;
   border: 1px solid @mid-grey;
   background-color: @lightest-grey;
 
   p {
-    font-size: 0.875em;
     margin-bottom: 5px;
     margin-top: 0;
     color: @grey;
 
     a {
-      font-size: 0.875em;
       display: block;
-    }
-
-    span {
-      font-size: 0.8125em;
     }
   }
 
@@ -76,17 +72,14 @@
     /* stylelint-enable selector-max-specificity */
   }
 
-  p.create {
+  .create {
     border-top: 1px solid @lightest-grey;
     padding: 5px 10px;
     text-decoration: none;
     font-weight: bold;
     margin-bottom: 0;
-
-    a {
-      color: @dark-grey;
-      text-decoration: none;
-    }
+    display: block; // For <a> links
+    color: inherit;
   }
 
   .reading-lists {
@@ -94,7 +87,7 @@
       background: @white;
       padding: 5px 0 0 10px;
       margin: 0;
-      font-size: 0.8em;
+      font-size: @font-size-label-medium;
     }
     .my-lists {
       background: @white;

--- a/static/css/components/nav-bar.less
+++ b/static/css/components/nav-bar.less
@@ -45,7 +45,11 @@
   align-items: stretch;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
   clip-path: inset(0 0 -15px 0);
-  margin-bottom: 10px;
+  margin-bottom: 20px;
+
+  .nav-bar {
+    margin-bottom: 0;
+  }
 
   background: @white;
   z-index: @z-index-level-5;

--- a/static/css/components/nav-bar.less
+++ b/static/css/components/nav-bar.less
@@ -1,6 +1,7 @@
 @import (less) "components/compact-title.less";
 
 .nav-bar {
+  margin-bottom: 20px;
   font-weight: bold;
 
   display: block;
@@ -18,6 +19,7 @@
     color: @grey;
     padding: 12px 15px 8px;
     display: inline-block;
+    line-height: 1.5em;
   }
 
   /* stylelint-disable selector-max-specificity */

--- a/static/css/components/read-panel.less
+++ b/static/css/components/read-panel.less
@@ -16,7 +16,6 @@
 
 .read-options,
 .btn-notice {
-  line-height: 1.5em;
   font-size: 1em;
   padding: 15px;
   margin-bottom: 10px;

--- a/static/css/components/read-panel.less
+++ b/static/css/components/read-panel.less
@@ -25,6 +25,7 @@
   margin-top: 0;
 
   .cta-btn,
+  .cta-button-group,
   .cta-btn.cta-btn--no-pointer {
     margin-bottom: 10px;
   }
@@ -103,13 +104,7 @@
     display: block;
     font-weight: bold;
   }
-  ul {
-    margin-left: 8px;
-  }
-  li {
-    list-style: disc;
-    margin: 5px 10px 0;
-  }
+
   // stylelint-disable selector-max-specificity
   table {
     width: 100%;
@@ -119,6 +114,11 @@
     width: 49%;
   }
   // stylelint-enable selector-max-specificity
+}
+
+ul.book-locate-options li,
+ul.ebook-download-options li {
+  margin: 5px 0;
 }
 
 .buy-options-table {

--- a/static/css/components/read-panel.less
+++ b/static/css/components/read-panel.less
@@ -36,20 +36,18 @@
     color: @primary-blue;
     text-decoration: none;
     position: relative;
+    margin: 0 auto;
     margin-top: -15px; // offsets Illustration margin-bottom: 10px
-    margin-bottom: 5px;
-    padding: 5px 20px 10px; // Increasing click area for mobile text link
     background-color: transparent;
+    transition: background-color 0.2s;
 
     // When Preview button is a text link, have it take up only the width
     // of the content (not full 100% width)
-    flex-basis: content;
-    flex-grow: 0;
     width: auto;
 
     /* stylelint-disable selector-max-specificity */
     &:hover {
-      text-decoration: underline;
+      background-color: fade(@primary-blue, 10%);
     }
 
     &::before {
@@ -125,10 +123,16 @@ ul.ebook-download-options li {
   .more {
     margin-left: 0;
     cursor: pointer;
+  }
 
-    &::marker {
-      content: "";
-    }
+  a,
+  summary {
+    padding: 8px 0;
+  }
+
+  + small {
+    display: block;
+    margin-top: 10px;
   }
 }
 

--- a/static/css/components/read-statuses.less
+++ b/static/css/components/read-statuses.less
@@ -23,7 +23,7 @@
     font-weight: bold;
     width: 100%;
     text-align: left;
-    font-size: 0.8em;
+    font-size: @font-size-label-medium;
     padding: 10px;
     border-bottom: 1px solid @lightest-grey;
     &:hover {

--- a/static/css/components/sort-dropper.less
+++ b/static/css/components/sort-dropper.less
@@ -81,7 +81,7 @@
     text-decoration: none;
   }
 
-  &.tool-button--selected {
+  &.active {
     font-weight: bold;
   }
 }

--- a/static/css/components/sort-dropper.less
+++ b/static/css/components/sort-dropper.less
@@ -1,7 +1,3 @@
-.sort-dropper {
-  display: inline-flex;
-}
-
 .sort-content {
   display: flex;
   background: @white;
@@ -11,7 +7,7 @@
   display: flex;
   flex-direction: column;
   position: absolute;
-  margin-top: 10px;
+  margin-top: 5px;
   background-color: @lightest-grey;
   border: 1px solid;
   border-radius: 5px;
@@ -68,47 +64,69 @@
   }
 }
 
-.sort details {
+.tool-button {
   border-radius: 5px;
-  background: @lightest-grey;
-  border: 1px solid;
-  border-color: @mid-grey;
+  background-color: @lightest-grey;
+  border: 1px solid @mid-grey;
+  padding: 4px 9px;
+  display: inline-flex;
+  transition: background-color 0.2s;
+  cursor: pointer;
+
+  &:not(.tool-button--group):hover {
+    background: @grey-f3f3f3;
+  }
+
+  a& {
+    text-decoration: none;
+  }
+
+  &.tool-button--selected {
+    font-weight: bold;
+  }
+}
+
+.tool-button--group {
+  padding: 0;
+
+  // stylelint-disable-next-line no-descending-specificity
+  > .tool-button {
+    border: 0;
+    border-left: 1px solid @gray-d1cfd0;
+
+    &:first-child {
+      border-left: 0;
+      border-radius: 5px 0 0 5px;
+    }
+
+    &:last-child {
+      border-radius: 0 5px 5px 0;
+    }
+  }
+}
+
+details.sort-dropper {
+  display: inline;
 
   summary {
-    font-size: 1rem;
-    color: @black;
-    display: inline-flex;
     list-style-type: none;
-    cursor: pointer;
     align-items: center;
     justify-content: center;
-    text-align: center;
+    gap: 7px;
+
+    &::after {
+      content: "▾";
+      color: @dark-grey;
+      width: 9px;
+      font-size: 24px;
+      line-height: 0;
+      transform: translateX(-50%);
+    }
   }
 
-  summary p {
-    padding: 2px 10px;
-    margin: 0;
-    border-right: 1px solid;
-    border-color: @gray-d1cfd0;
+  &[open] summary::after {
+    content: "▴";
   }
-
-  &[open] {
-    background: @lighter-grey;
-  }
-}
-
-.sort details summary img {
-  margin-left: 10px;
-}
-
-.sort details summary::after {
-  content: "▾";
-  color: @dark-grey;
-  padding: 2px 10px;
-}
-
-.sort details[open] summary::after {
-  content: "▴";
 }
 
 .sort-random-shuffle {

--- a/static/css/legacy-tools.less
+++ b/static/css/legacy-tools.less
@@ -110,29 +110,6 @@
     }
   }
 
-  ul {
-    &.book-locate-options {
-      ul {
-        margin-left: 17px;
-      }
-      li {
-        padding-left: 0;
-        margin: 5px 10px 0;
-      }
-    }
-    &.ebook-download-options li {
-      padding-left: 0;
-      margin: 5px 10px 0;
-    }
-  }
-
-  li {
-    font-size: 0.6875em;
-    font-family: @lucida_sans_serif-1;
-    padding-left: 42px;
-    margin-bottom: 5px;
-  }
-
   table {
     width: 250px;
     td {

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -1470,6 +1470,49 @@ ul.list-books {
   }
 }
 
+.list-books--grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  grid-gap: 30px 5px;
+  padding: 10px;
+
+  .searchResultItem {
+    padding: 0 5px;
+    background: transparent;
+    border: 0;
+    display: flex;
+    flex-direction: column;
+    position: relative;
+
+    .bookcover {
+      width: 100%;
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-end;
+      margin: 0;
+    }
+
+    > .details {
+      display: none;
+    }
+
+    .searchResultItemCTA {
+      font-size: 0.85em;
+      padding: 0;
+      margin: 0;
+      min-width: unset;
+      width: 100%;
+    }
+
+    .cta-btn,
+    a.cta-btn {
+      border-radius: 5px;
+      font-size: unset;
+    }
+  }
+}
+
 div.pop {
   // openlibrary/templates/covers/add.html
   &Alert {

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -228,16 +228,6 @@ em {
 }
 
 #contentBody {
-  ul,
-  ol {
-    margin-bottom: 20px;
-    margin-left: 0.5em;
-    margin-right: 0.5em;
-  }
-  li,
-  blockquote {
-    line-height: 1.5em;
-  }
   input[type="submit"] {
     font-size: 1.125em;
   }
@@ -929,15 +919,11 @@ div.editThis {
 /* SEARCH RESULTS */
 
 div#searchResults,
-div#searchResults ul {
+div#searchResults .list-books {
   min-width: 0;
   flex: 1;
   margin-left: 0;
   margin-bottom: 0;
-  .dropper-menu {
-    width: 190px;
-    margin-right: 0;
-  }
 }
 
 // openlibrary/templates/books/check.html

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -227,17 +227,20 @@ em {
   font-style: italic;
 }
 
-#contentBody {
-  input[type="submit"] {
-    font-size: 1.125em;
+// Styles that should apply to markdown documents
+.markdown-content {
+  ol,
+  ul {
+    padding-left: 40px;
   }
-  &.map {
-    width: 958px !important;
-    padding: 0 !important;
-    position: relative;
-  }
+
   ol li {
     list-style: decimal;
+    color: @dark-grey;
+    line-height: 1.5em;
+  }
+  ul li {
+    list-style: disc;
     color: @dark-grey;
     line-height: 1.5em;
   }

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -241,11 +241,6 @@ em {
     color: @dark-grey;
     line-height: 1.5em;
   }
-  ul li {
-    list-style: disc;
-    color: @dark-grey;
-    line-height: 1.5em;
-  }
 }
 
 pre,

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -497,8 +497,10 @@ input {
   display: flex;
   gap: 10px;
   align-items: center;
-  margin-bottom: 10px;
+  padding-bottom: 10px;
   font-size: 0.9em;
+  white-space: nowrap;
+  overflow-x: auto;
 }
 
 /* Search v2 */
@@ -1512,9 +1514,9 @@ ul.list-books {
       width: 100%;
     }
 
-    .cta-btn,
-    a.cta-btn {
-      font-size: unset;
+    .check-in-prompt,
+    .star-rating-form {
+      display: none;
     }
   }
 }

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -494,9 +494,10 @@ input {
 
 // openlibrary/templates/search/inside.html
 .search-results-stats {
-  margin: 0;
+  display: flex;
+  gap: 10px;
+  align-items: center;
   margin-bottom: 10px;
-  color: @grey;
   font-size: 0.9em;
 }
 
@@ -1480,9 +1481,14 @@ ul.list-books {
     padding: 0 5px;
     background: transparent;
     border: 0;
-    display: flex;
-    flex-direction: column;
     position: relative;
+
+    &:not(.sri--w-main),
+    .sri__main {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
 
     .bookcover {
       width: 100%;
@@ -1493,7 +1499,8 @@ ul.list-books {
       margin: 0;
     }
 
-    > .details {
+    > .details,
+    .sri__main > .details {
       display: none;
     }
 
@@ -1507,7 +1514,6 @@ ul.list-books {
 
     .cta-btn,
     a.cta-btn {
-      border-radius: 5px;
       font-size: unset;
     }
   }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10877

Pulled out of #8564 , which expands to make a lot of other styling changes.


### Technical
<!-- What should be noted about the implementation? -->

I recommend viewing the diff ignoring whitespace changes: https://github.com/internetarchive/openlibrary/pull/10878/files?diff=unified&w=1

- Solidified two "components" based on our existing classes
    - `.list-books` - a list of books. CSS is in legacy.less and now has some corresponding JS in list_books.js
    - `.search-result-stats` - the toolbar that appears above the search results. A CSS-only component. CSS is in legacy.less

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

![image](https://github.com/user-attachments/assets/6fd7e3e8-edaf-4117-a717-13868adf0de2)

![image](https://github.com/user-attachments/assets/6e1115b2-ed47-4a93-8d9d-fd84c23c03e6)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
