### PR TITLE
Remove some dead legacy CSS

### DIFF
--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -971,39 +971,6 @@ div#searchResults {
       text-decoration: none;
     }
   }
-  &.work,
-  &.work ul,
-  &.work li {
-    width: 700px !important;
-  }
-  &.narrow,
-  &.narrow ul,
-  &.narrow li {
-    width: 610px !important;
-  }
-  &.wide,
-  &.wide ul,
-  &.wide li {
-    width: 920px !important;
-  }
-  &.add,
-  &.add ul,
-  &.add li {
-    width: 860px !important;
-    margin: 0 30px !important;
-  }
-  &.narrow .resultTitle {
-    max-width: 480px !important;
-  }
-  &.wide .resultTitle {
-    max-width: 780px;
-  }
-  &.add .resultTitle {
-    max-width: 720px;
-  }
-  &.work .resultTitle {
-    max-width: 570px !important;
-  }
 }
 
 // openlibrary/templates/work_search.html
@@ -1303,15 +1270,6 @@ ul {
       }
     }
   }
-  &.wide {
-    li span.resultTitle {
-      width: 813px;
-      max-width: 813px;
-      .subjects {
-        font-size: 0.8em;
-      }
-    }
-  }
   // openlibrary/templates/type/user/view.html
   &.clean {
     border-top: none !important;
@@ -1509,27 +1467,6 @@ ul.list-books {
   // openlibrary/templates/books/show.html
   span.resultType {
     font-size: 0.6875em;
-  }
-}
-
-// openlibrary/templates/search/lists.html
-// openlibrary/templates/lists/lists.html
-div.wide {
-  ul.list-books {
-    span.resultTitle {
-      max-width: 850px;
-    }
-  }
-}
-
-// openlibrary/templates/type/list/embed.html
-// openlibrary/templates/type/list/view.html
-// openlibrary/templates/type/work/editions.html
-div.narrow {
-  ul.list-books {
-    span.resultTitle {
-      max-width: 500px !important;
-    }
   }
 }
 


### PR DESCRIPTION
Small refactor. No matches for `wide` or `narrow` css classes, or the others.

Did a search for `searchResults` in the codebase, and it never has any classes associated with it.

Pulled out of #8564 .

### Technical
<!-- What should be noted about the implementation? -->

### Testing
Confirmed the removed classes don't match anything + also loaded on testing, moved around a bit, all looked good.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
