### PR TITLE
Create list via ILE

### DIFF
--- a/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
+++ b/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
@@ -473,6 +473,13 @@ SelectionManager.ACTIONS = [
         onclick: true,
     },
     {
+        applies_to_type: ['work', 'edition', 'author'],
+        requires_type: [],
+        multiple_only: false,
+        name: 'Create list...',
+        href: olids => `/account/lists/add?seeds=${olids.join(',')}`,
+    },
+    {
         applies_to_type: ['work','edition'],
         requires_type: ['work'],
         multiple_only: true,


### PR DESCRIPTION
Pulled out of #7804 . Small feature; when selecting works or editions, you will now see an option in the ILE toolbar to create a new list with the selected items.


### Technical
Note this links to create a user list, not a global list.

### Testing
Test on testing with works, authors, and editions :+1: There's a bug if you select multiple editions from the same work in the rendering of the lists page, but it will save correctly.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
