### PR TITLE
fix(#10859): commented the Library.linkd

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -981,10 +981,6 @@ msgid "Check nearby libraries"
 msgstr ""
 
 #: WorldcatLink.html
-msgid "Library.link"
-msgstr ""
-
-#: WorldcatLink.html
 msgid "Check WorldCat for an edition near you"
 msgstr ""
 

--- a/openlibrary/macros/WorldcatLink.html
+++ b/openlibrary/macros/WorldcatLink.html
@@ -4,9 +4,6 @@ $if oclc_numbers or isbn:
   <div class="cta-section">
     <p class="cta-section-title world-cat-link">$_("Check nearby libraries")</p>
     <ul class="book-locate-options">
-      <!-- comment out this until the public API is confirmed to work -->
-      <!-- $if isbn: -->
-        <!-- <li><a href="https://labs.library.link/services/borrow/?isbn=$isbn&embed=True&radius=500&refer=$(referer)">$_("Library.link")</a></li> -->
       <li><a class="worldcat-link" data-ol-link-track="worldcat-search" href="$macros.WorldcatUrl(isbn=isbn, oclc_numbers=oclc_numbers)" title="$_('Check WorldCat for an edition near you')">$_("WorldCat")</a></li>
     </ul>
   </div>

--- a/openlibrary/macros/WorldcatLink.html
+++ b/openlibrary/macros/WorldcatLink.html
@@ -5,7 +5,8 @@ $if oclc_numbers or isbn:
     <p class="cta-section-title world-cat-link">$_("Check nearby libraries")</p>
     <ul class="book-locate-options">
       $if isbn:
-        <li><a href="https://labs.library.link/services/borrow/?isbn=$isbn&embed=True&radius=500&refer=$(referer)">$_("Library.link")</a></li>
+        <!-- comment out this until the public API is confirmed to work -->
+        <!-- <li><a href="https://labs.library.link/services/borrow/?isbn=$isbn&embed=True&radius=500&refer=$(referer)">$_("Library.link")</a></li> -->
       <li><a class="worldcat-link" data-ol-link-track="worldcat-search" href="$macros.WorldcatUrl(isbn=isbn, oclc_numbers=oclc_numbers)" title="$_('Check WorldCat for an edition near you')">$_("WorldCat")</a></li>
     </ul>
   </div>

--- a/openlibrary/macros/WorldcatLink.html
+++ b/openlibrary/macros/WorldcatLink.html
@@ -4,8 +4,8 @@ $if oclc_numbers or isbn:
   <div class="cta-section">
     <p class="cta-section-title world-cat-link">$_("Check nearby libraries")</p>
     <ul class="book-locate-options">
-      $if isbn:
-        <!-- comment out this until the public API is confirmed to work -->
+      <!-- comment out this until the public API is confirmed to work -->
+      <!-- $if isbn: -->
         <!-- <li><a href="https://labs.library.link/services/borrow/?isbn=$isbn&embed=True&radius=500&refer=$(referer)">$_("Library.link")</a></li> -->
       <li><a class="worldcat-link" data-ol-link-track="worldcat-search" href="$macros.WorldcatUrl(isbn=isbn, oclc_numbers=oclc_numbers)" title="$_('Check WorldCat for an edition near you')">$_("WorldCat")</a></li>
     </ul>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10859 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
### Description
This PR fixes a UI issue by commenting out the `<li>` tag that displays a link to a public inactive API. This prevents users from seeing or clicking on a broken or deprecated link.

### Technical
- Commented out the `<li>` element in the relevant template to hide the inactive API link.
- No functional changes beyond UI adjustment.

### Testing
- Verified locally that the link is no longer visible in the UI.
- Checked that no other UI elements are affected.

### Screenshot
![Screenshot from 2025-06-02 17-17-32](https://github.com/user-attachments/assets/4e16680a-9b20-4354-a0e3-6d86067dc3f8)


### Stakeholders
@mekarpeles  

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
