### PR TITLE
Also check language aliases when checking for language names

### DIFF
--- a/openlibrary/plugins/upstream/tests/test_utils.py
+++ b/openlibrary/plugins/upstream/tests/test_utils.py
@@ -223,11 +223,24 @@ def test_get_abbrev_from_full_lang_name(
         }
     )
 
+    web.ctx.site.save(
+        {
+            "code": "por",
+            "key": "/languages/por",
+            "name": "Portuguese",
+            "type": {"key": "/type/language"},
+            "name_translated": {
+                "en": ["Portuguese", "Portuguese Brazilian"],
+            },
+        }
+    )
+
     assert utils.get_abbrev_from_full_lang_name("EnGlish") == "eng"
     assert utils.get_abbrev_from_full_lang_name("Dorerin Ingerand") == "eng"
     assert utils.get_abbrev_from_full_lang_name("ингилисӣ") == "eng"
     assert utils.get_abbrev_from_full_lang_name("ингилиси") == "eng"
     assert utils.get_abbrev_from_full_lang_name("Anglais") == "fre"
+    assert utils.get_abbrev_from_full_lang_name("Portuguese Brazilian") == "por"
 
     # See openlibrary/catalog/add_book/tests/conftest.py for imported languages.
     with pytest.raises(utils.LanguageMultipleMatchError):

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -1,5 +1,6 @@
 import datetime
 import functools
+import itertools
 import json
 import logging
 import os
@@ -787,17 +788,17 @@ def get_abbrev_from_full_lang_name(input_lang_name: str, languages=None) -> str:
         return strip_accents(s).lower()
 
     for language in languages:
-        if normalize(language.name) == normalize(input_lang_name):
-            if target_abbrev:
-                raise LanguageMultipleMatchError(input_lang_name)
+        language_names = itertools.chain(
+            (language.name,),
+            (
+                name
+                for key in language.name_translated
+                for name in language.name_translated[key]
+            ),
+        )
 
-            target_abbrev = language.code
-            continue
-
-        for key in language.name_translated:
-            if normalize(language.name_translated[key][0]) == normalize(
-                input_lang_name
-            ):
+        for name in language_names:
+            if normalize(name) == normalize(input_lang_name):
                 if target_abbrev:
                     raise LanguageMultipleMatchError(input_lang_name)
                 target_abbrev = language.code


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10893 .

Previously it only checked the first `name_translated` for each language. This makes it check everything, allowing us to have aliased like "Portuguese Brazilian" for Portuguese.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

The previously failing import now works on testing:

![image](https://github.com/user-attachments/assets/4596dd4b-8fef-4c62-a8e9-0c9839f79314)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
