### PR TITLE
Add `FULFILLED` special access status

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -456,7 +456,11 @@ class account_login_json(delegate.page):
                     _expire_pd_cookies()
 
                 has_special_access = audit.get('special_access')
-                if has_special_access and ol_account.get_user().preferences().get('rpd') != PDRequestStatus.FULFILLED.value:
+                if (
+                    has_special_access
+                    and ol_account.get_user().preferences().get('rpd')
+                    != PDRequestStatus.FULFILLED.value
+                ):
                     _update_account_on_pd_fulfillment(ol_account)
 
         # Fallback to infogami user/pass
@@ -563,7 +567,11 @@ class account_login(delegate.page):
                 )
 
             has_special_access = audit.get('special_access')
-            if has_special_access and ol_account.get_user().preferences().get('rpd') != PDRequestStatus.FULFILLED.value:
+            if (
+                has_special_access
+                and ol_account.get_user().preferences().get('rpd')
+                != PDRequestStatus.FULFILLED.value
+            ):
                 _update_account_on_pd_fulfillment(ol_account)
 
         blacklist = [


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10871

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds new `FULFILLED` special access request status.  Upon first login after being granted special access, we update the patron's account `rpd` status to `2`.  Additionally, an existing function was renamed for clarity.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
