### PR TITLE
Change privs for adding web books

### DIFF
--- a/openlibrary/templates/books/add.html
+++ b/openlibrary/templates/books/add.html
@@ -77,8 +77,7 @@ $ i18n_strings = {
             </div>
         </div>
 
-        $ is_admin = ctx.user and ctx.user.is_admin()
-        $if is_admin:
+        $if ctx.user and (ctx.user.is_admin() or ctx.user.is_super_librarian() or ctx.user.is_librarian()):
             <div class="formElement">
                 <div class="label">
                     <label for="web_book_url">$_("Book URL")</label> <span class="tip">$_("Only fill this out if this is a web book")</span></span>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10895

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Expands privileges for adding web books to `librarians` and `super-librarians`.  Admin privileges remain unchanged.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
