### PR TITLE
Add support for wikidata data dump link

### DIFF
--- a/openlibrary/plugins/upstream/data.py
+++ b/openlibrary/plugins/upstream/data.py
@@ -43,6 +43,7 @@ DUMP_PREFIXES = (
     '_deworks',
     '_ratings',
     '_reading-log',
+    '_wikidata',
 )
 
 


### PR DESCRIPTION
Now that the dump added in #10531 has run, we can add a link to it! This will make links like https://openlibrary.org/data/ol_dump_wikidata_latest.txt.gz resolve, matching our other dumps.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
