### PR TITLE
Expand web book editing privileges

### DIFF
--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -3,7 +3,8 @@ $def with (work, book)
 $ edition_config = get_identifier_config('edition')
 $ is_librarian = ctx.user and ctx.user.is_librarian()
 $ is_admin = ctx.user and ctx.user.is_admin()
-$ is_privileged_user = is_librarian or is_admin
+$ is_super_librarian = ctx.user and ctx.user.is_super_librarian()
+$ is_privileged_user = is_librarian or is_super_librarian or is_admin
 
 $def radiobuttons(name, options, value):
     $for v in options:
@@ -597,7 +598,7 @@ $code:
             return True
         return False
 
-$if is_admin:
+$if is_privileged_user:
     $ extra_class = ' hidden' if len(book.providers) == 0 else ''
     $ provider_index = 0
     <fieldset class="major">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10895

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This makes the following changes to the book edit form:

1. Includes `super-librarians` in `is_privileged_user` guard
2. Expands web book editing to `librarians` and `super-librarians`

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
