### PR TITLE
Add `/admin` page as Hamburger link

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -6191,6 +6191,10 @@ msgid "Pending Merge Requests"
 msgstr ""
 
 #: lib/nav_head.html
+msgid "Admin Page"
+msgstr ""
+
+#: lib/nav_head.html
 msgid "Trending"
 msgstr ""
 

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -12,6 +12,8 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_super_li
     $ ]
       $if is_privileged_user:
         $ loginLinks.insert(2, { "href": homepath() + "/merges", "text": _("Pending Merge Requests"),"track": "MyRequests", "badge": True })
+      $if ctx.user.is_admin():
+        $ loginLinks.append({ "href": "/admin", "text": _("Admin Page"), "track": "Admin"})
   $else:
     $ loginLinks = [
     $     { "loginClass": "login-links" }


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds a link to the `/admin` page to the hamburger menu for members of `/usergroup/admin`.

These changes were tested locally, but not in our `testing` environment.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in as an admin:

1. Expand the hamburger menu
2. Expect an "Admin Page" link to appear in the menu
3. Click the link and verify that it takes you to `/admin`

While logged in without admin privs:

1. Expand the hamburger menu
2. Verify that there is not an "Admin Page" link in the menu

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/user-attachments/assets/6542a067-da79-4f3e-bb6e-18b528ec1931)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
