### PR TITLE
Save preferences to store

### DIFF
--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -872,7 +872,7 @@ class Author(Thing):
 
 class User(Thing):
     def get_default_preferences(self):
-        return {'update': 'no', 'public_readlog': 'no'}
+        return {'update': 'no', 'public_readlog': 'no', 'type': 'preferences'}
         # New users are now public by default for new patrons
         # As of 2020-05, OpenLibraryAccount.create will
         # explicitly set public_readlog: 'yes'.
@@ -900,24 +900,37 @@ class User(Thing):
     def get_username(self):
         return self.key.split("/")[-1]
 
-    def preferences(self):
+    def preferences(self, use_store=False):
         key = f"{self.key}/preferences"
+        if use_store:
+            prefs = web.ctx.site.store.get(key)
+            return prefs or self.get_default_preferences()
+
         prefs = web.ctx.site.get(key)
         return (
             prefs and prefs.dict().get('notifications')
         ) or self.get_default_preferences()
 
-    def save_preferences(self, new_prefs, msg='updating user preferences'):
+    def save_preferences(self, new_prefs, msg='updating user preferences', use_store=False):
         key = f'{self.key}/preferences'
-        old_prefs = web.ctx.site.get(key)
-        prefs = (old_prefs and old_prefs.dict()) or {
-            'key': key,
-            'type': {'key': '/type/object'},
-        }
-        if 'notifications' not in prefs:
-            prefs['notifications'] = self.get_default_preferences()
-        prefs['notifications'].update(new_prefs)
-        web.ctx.site.save(prefs, msg)
+        if use_store:
+            old_prefs = self.preferences(use_store=use_store)
+            old_prefs.update(new_prefs)
+            old_prefs['_rev'] = None
+            old_prefs['type'] = 'preferences'
+            web.ctx.site.store[key] = old_prefs
+        else:
+            old_prefs = web.ctx.site.get(key)
+            prefs = (old_prefs and old_prefs.dict()) or {
+                'key': key,
+                'type': {'key': '/type/object'},
+            }
+            if 'notifications' not in prefs:
+                prefs['notifications'] = self.get_default_preferences()
+            prefs['notifications'].update(new_prefs)
+            web.ctx.site.save(prefs, msg)
+            # Save a copy of the patron's preferences to the store
+            self.save_preferences(new_prefs, msg=msg, use_store=True)
 
     def is_usergroup_member(self, usergroup):
         if not usergroup.startswith('/usergroup/'):

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -911,7 +911,9 @@ class User(Thing):
             prefs and prefs.dict().get('notifications')
         ) or self.get_default_preferences()
 
-    def save_preferences(self, new_prefs, msg='updating user preferences', use_store=False):
+    def save_preferences(
+        self, new_prefs, msg='updating user preferences', use_store=False
+    ):
         key = f'{self.key}/preferences'
         if use_store:
             old_prefs = self.preferences(use_store=use_store)


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Makes the following changes to `User` preference methods:

1. Adds a `use_store` keyword parameter to `preferences()`.  When `True`, we attempt to fetch a patron's preferences from the store.
2. Adds `use_store` keyword parameter to `save_preferences()`.  When `True`, we save the data to the store.  When `False`, we save the typical way, then recursively call `save_preferences(use_store=True)` to also save the preference to the store.

When this is merged, we will continue fetching from and saving to the business as usual (BAU) tables.  The only difference is that we will also save a copy of the preferences to the store when preferences are saved.

#### Next steps (after this is deployed)
1. Run job to copy all existing preferences to the store
2. At this point, all existing and new patrons will have preferences in the store, so we can change `use_store` to `True` by default
3. Once we're sure that everything is working properly, we can run a job to delete all preferences from the BAU tables
4. Remove code that writes preferences to non-store tables

### Technical
<!-- What should be noted about the implementation? -->
Setting `_rev` to `None` allows us to overwrite an existing `store` record w/o error, but a new `id` is generated for the updated record.  I wonder if setting a value for `_ref` and incrementing it on update would avoid burning an id?

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
