### PR TITLE
Admin PD dashboard improvements

### DIFF
--- a/openlibrary/templates/admin/pd_dashboard.html
+++ b/openlibrary/templates/admin/pd_dashboard.html
@@ -36,7 +36,6 @@ $code:
     <table class="pd-request-table">
         <thead>
             <th class="table-header" scope="col">PDA</th>
-            <th class="table-header" scope="col">Requested</th>
             <th class="table-header" scope="col">Emailed</th>
             <th class="table-header" scope="col">Fulfilled</th>
             <th class="table-header" scope="col">Total</th>
@@ -56,14 +55,12 @@ $code:
                   <td>
                       <a href="https://archive.org/details/$(pda)">$display_name</a>
                   </td>
-                  <td>$requested_count</td>
                   <td>$emailed_count</td>
                   <td>$fulfilled_count</td>
                   <td>$total</td>
               </tr>
           <tr class="totals">
               <td>Totals</td>
-              <td>$requested_total</td>
               <td>$emailed_total</td>
               <td>$fulfilled_total</td>
               <td>$(requested_total + emailed_total + fulfilled_total)</td>

--- a/openlibrary/templates/admin/pd_dashboard.html
+++ b/openlibrary/templates/admin/pd_dashboard.html
@@ -3,9 +3,9 @@ $def with(dashboard_data)
 $code:
   request_data = dashboard_data.get('data', [])
   totals = dashboard_data.get('totals')
-  requested_total = 0
-  emailed_total = 0
-  fulfilled_total = 0
+  requested_total = dashboard_data.get('totals').get('requested')
+  emailed_total = dashboard_data.get('totals').get('emailed')
+  fulfilled_total = dashboard_data.get('totals').get('fulfilled')
 
 <div id="contentHead">
     $:render_template("admin/menu")
@@ -16,15 +16,15 @@ $code:
     <h2>$_("Summary")</h2>
     <div class="dashboard-summary">
         <div class="pd-access-stat">
-            Total number of patrons awaiting follow-up email: <span class="pd-access-total">$totals['requested']</span>
+            Total number of patrons awaiting follow-up email: <span class="pd-access-total">$requested_total</span>
         </div>
         <hr>
         <div class="pd-access-stat">
-            Total number of patrons emailed: <span class="pd-access-total">$totals['emailed']</span>
+            Total number of patrons emailed: <span class="pd-access-total">$emailed_total</span>
         </div>
         <hr>
         <div class="pd-access-stat">
-            Total number of patron requests fulfilled: <span class="pd-access-total">$totals['fulfilled']</span>
+            Total number of patron requests fulfilled: <span class="pd-access-total">$fulfilled_total</span>
         </div>
         <hr>
         <div class="pd-access-stat">
@@ -48,9 +48,6 @@ $code:
               $ emailed_count = d['emailed']
               $ fulfilled_count = d['fulfilled']
               $ total = requested_count + emailed_count + fulfilled_count
-              $ requested_total += requested_count
-              $ emailed_total += emailed_count
-              $ fulfilled_total += fulfilled_count
               <tr>
                   <td>
                       <a href="https://archive.org/details/$(pda)">$display_name</a>
@@ -63,7 +60,7 @@ $code:
               <td>Totals</td>
               <td>$emailed_total</td>
               <td>$fulfilled_total</td>
-              <td>$(requested_total + emailed_total + fulfilled_total)</td>
+              <td>$totals.get('total')</td>
           </tr>
         </tbody>
     </table>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Follow-up to #10822

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Makes the following updates to the print disability special access dashboard template:
1. Removes the "Requested" column from the table.  The total requested count __is still__ available in the summary section.
2. Request table totals are no longer calculated in the template.  Instead, the totals that are passed to the template are displayed in the table.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
