### PR TITLE
Remove unused import

### DIFF
--- a/scripts/delete_import_items.py
+++ b/scripts/delete_import_items.py
@@ -23,9 +23,6 @@ from pathlib import Path
 import _init_path  # noqa: F401 Imported for its side effect of setting PYTHONPATH
 
 from openlibrary.config import load_config
-from openlibrary.core.edits import (
-    CommunityEditsQueue,  # noqa: F401 side effects may be needed
-)
 from openlibrary.core.imports import ImportItem
 
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Follow-up to #9997

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes unused import from the `delete_import_items` script.

The affected script is used to delete items from the `import_item` table.  The `CommunityEditsQueue` is the API for the librarian merge queue table, which, as of writing, is completely unrelated to Open Library's import process.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
