### PR TITLE
Improve UX for pasting images to upload

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -5510,7 +5510,7 @@ msgid "Paste image from clipboard"
 msgstr ""
 
 #: covers/add.html
-msgid "No Image Pasted"
+msgid "Paste Image"
 msgstr ""
 
 #: covers/add.html

--- a/openlibrary/templates/covers/add.html
+++ b/openlibrary/templates/covers/add.html
@@ -90,6 +90,6 @@ $if doc.type.key == "/type/edition" and doc.ocaid:
             <a href="$img_url" target="_blank">
                 <img class="ol-cover-form--ia_image" src="$img_url" style="height: 200px" />
             </a>
-            <button type="submit" id="coverIA" class="cta-btn cta-btn--vanilla" name="url" value="$img_url">$_("Use this image")</button>
+            <button type="submit" id="coverIA" class="cta-btn cta-btn--vanilla" name="url" value="$img_url">$_("Upload Image")</button>
         </div>
     </form>

--- a/openlibrary/templates/covers/add.html
+++ b/openlibrary/templates/covers/add.html
@@ -58,14 +58,14 @@ $if doc.type.key == "/type/work":
     <div class="label">
         <label for="coverClipboard">$_("Or, paste an image from your clipboard")</label>
     </div>
+    <div class="input">
+        <div class="button-container">
+            <button type="button" id="pasteButton" class="cta-btn cta-btn--vanilla paste-button" aria-label="$_('Paste image from clipboard')">$_("Paste Image")</button>
+            <button id="uploadButtonPaste" type="submit" class="cta-btn cta-btn--vanilla upload-button hidden" aria-label="$_('Upload image')">$_("Upload Image")</button>
+        </div>
+        <div class="image-container"></div>
 
-    <div class="image-container"></div>
-
-    <input type="file" name="file" id="hiddenFileInput" aria-label="Hidden file input" />
-
-    <div class="button-container">
-        <button type="button" id="pasteButton" class="cta-btn cta-btn--vanilla paste-button" aria-label="$_('Paste image from clipboard')">$_("No Image Pasted")</button>
-        <button id="uploadButtonPaste" type="submit" class="cta-btn cta-btn--vanilla upload-button hidden" aria-label="$_('Upload image')">$_("Upload Image")</button>
+        <input type="file" name="file" id="hiddenFileInput" aria-label="Hidden file input" />
     </div>
 </form>
 

--- a/static/css/page-form.less
+++ b/static/css/page-form.less
@@ -176,6 +176,11 @@ div#revertLink,
       display: none;
     }
 
+    .input {
+      flex-direction: column;
+      align-items: flex-start !important;
+    }
+
     .paste-button,
     .upload-button {
       width: auto;

--- a/static/css/page-form.less
+++ b/static/css/page-form.less
@@ -169,7 +169,7 @@ div#revertLink,
   &--clipboard {
     .image-container img {
       max-width: 100%;
-      max-height: 400px;
+      max-height: 200px;
     }
 
     #hiddenFileInput {


### PR DESCRIPTION
- **set max height of pasted image to 200px**
- **improve IA upload button text**
- **move buttons above image and improve spacing**

Based on discussions with Drini I've made a few improvements to the cover uploading experience when pasting.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

https://github.com/user-attachments/assets/cf1f0d73-d6a5-4b44-915e-c800df2d4917



### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
