### PR TITLE
Add script to delete `merge-authors-debug` store entries

### DIFF
--- a/scripts/delete_merge_debug.py
+++ b/scripts/delete_merge_debug.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""
+Deletes all store entries with type `merge-authors-debug`.
+"""
+import argparse
+import time
+import web
+from pathlib import Path
+
+import infogami
+from openlibrary.config import load_config
+
+DEFAULT_CONFIG_PATH = "/opt/olsystem/etc/openlibrary.yml"
+RECORD_TYPE = "merge-authors-debug"
+
+
+def setup(config_path):
+    if not Path(config_path).exists():
+        raise FileNotFoundError(f'no config file at {config_path}')
+    load_config(config_path)
+    infogami._setup()
+
+
+def delete_records():
+    while keys := web.ctx.site.store.keys(type=RECORD_TYPE):
+        for key in keys:
+            web.ctx.site.store.delete(key)
+            time.sleep(0.5)
+
+
+def main(args):
+    setup(args.config)
+    delete_records()
+
+
+def _parse_args():
+    _parser = argparse.ArgumentParser(description=__doc__)
+    _parser.add_argument(
+        "-c",
+        "--config",
+        default=DEFAULT_CONFIG_PATH,
+        help="Path to the `openlibrary.yml` configuration file",
+    )
+    _parser.set_defaults(func=main)
+    return _parser.parse_args()
+
+if __name__ == '__main__':
+    _args = _parse_args()
+    _args.func(_args)

--- a/scripts/delete_merge_debug.py
+++ b/scripts/delete_merge_debug.py
@@ -25,7 +25,6 @@ def delete_records():
     while keys := web.ctx.site.store.keys(type=RECORD_TYPE):
         for key in keys:
             web.ctx.site.store.delete(key)
-            time.sleep(0.5)
 
 
 def main(args):

--- a/scripts/migrations/README.md
+++ b/scripts/migrations/README.md
@@ -1,0 +1,7 @@
+# Migration Scripts
+
+Scripts found in this directory are meant to support a one-time task (such as a data migration), and __do not__ require long-term maintenance.
+
+## `delete_merge_debug.py`
+
+This script was created in support of [issue #10887](https://github.com/internetarchive/openlibrary/issues/10887).  When executed, it will delete all entries having `type` `merge-authors-debug` from the `store` and `store_index` tables.

--- a/scripts/migrations/delete_merge_debug.py
+++ b/scripts/migrations/delete_merge_debug.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 """
-Deletes all store entries with type `merge-authors-debug`.
+Deletes all store entries that have the type `merge-authors-debug`.
 """
 import argparse
-import time
 import web
 from pathlib import Path
 

--- a/scripts/migrations/delete_merge_debug.py
+++ b/scripts/migrations/delete_merge_debug.py
@@ -5,8 +5,9 @@ Deletes store entries that have the type `merge-authors-debug`.
 WARNING: This will delete all of the records if the `--batches` argument is excluded.
 """
 import argparse
-import web
 from pathlib import Path
+
+import web
 
 import infogami
 from openlibrary.config import load_config
@@ -61,6 +62,7 @@ def _parse_args():
     )
     _parser.set_defaults(func=main)
     return _parser.parse_args()
+
 
 if __name__ == '__main__':
     _args = _parse_args()


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Addresses #10887 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds a script that will delete all `merge-authors-debug` entries from the store tables.

__I would prefer that this script be approved for execution, but not be merged into `master`__.  There's no point in maintaining a script that will only be used once.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
