### PR TITLE
Fix next page of carousel not edition-aware

### DIFF
--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -108,15 +108,18 @@ class CarouselCardPartial(PartialDataHandler):
         sort = params.get("sorts", "new")  # XXX : check "new" assumption
         limit = int(params.get("limit", 20))
         page = int(params.get("page", 1))
-        query_params = {
-            "q": query,
-            "fields": ",".join(fields),
-        }
-        if fulltext := params.get("hasFulltextOnly"):
+        query_params = {"q": query}
+
+        if params.get("hasFulltextOnly"):
             query_params['has_fulltext'] = 'true'
 
         results = work_search(
-            query_params, sort=sort, limit=limit, facet=False, offset=page
+            query_params,
+            sort=sort,
+            fields=','.join(fields),
+            limit=limit,
+            facet=False,
+            offset=page,
         )
         return results.get("docs", [])
 


### PR DESCRIPTION
Closes #10710 . Addendum to #10763 . This was apparently only partially fixed there. That fixed the rendering, but the queries themselves were not requesting the editions field.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

One homepage, scroll through one of the solr-carousels (eg Classics). Scrolling past 40 books, the URLs should still point to editions, not works.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
