### PR TITLE
improve admin bar spacing and conditional display

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -7540,7 +7540,7 @@ msgid "See the page's history"
 msgstr ""
 
 #: type/edition/admin_bar.html
-msgid "Add to Staff Picks"
+msgid "Add IA Book to Staff Picks"
 msgstr ""
 
 #: type/edition/admin_bar.html

--- a/openlibrary/templates/type/edition/admin_bar.html
+++ b/openlibrary/templates/type/edition/admin_bar.html
@@ -11,7 +11,7 @@ $ edition_id = edition and edition.key.split('/')[2]
         <form action="/admin/staffpicks" method="POST">
           <input type="hidden" value="add" name="action"/>
           <input type="hidden" name="work_id" value="$work_id"/>
-          <input type="submit" class="cta-btn cta-btn--small cta-btn--vanilla" value="$_('Add to Staff Picks')"/>
+          <input type="submit" class="cta-btn cta-btn--small cta-btn--vanilla" value="$_('Add IA Book to Staff Picks')"/>
         </form>
       <form method="GET" action="/admin/sync">
         <input type="hidden" name="edition_id" value="$edition_id"/>

--- a/openlibrary/templates/type/edition/admin_bar.html
+++ b/openlibrary/templates/type/edition/admin_bar.html
@@ -5,14 +5,14 @@ $ edition_id = edition and edition.key.split('/')[2]
 
   <!-- Don't need to translate admin only buttons (at least initially)-->
   <div class="admin-bar">
-    $if work_id:
-      <!-- Add this whole work to staff picks -->
-      <form action="/admin/staffpicks" method="POST">
-        <input type="hidden" value="add" name="action"/>
-        <input type="hidden" name="work_id" value="$work_id"/>
-        <input type="submit" class="cta-btn cta-btn--small cta-btn--vanilla" value="$_('Add to Staff Picks')"/>
-      </form>
     $if ocaid:
+      $if work_id:
+        <!-- Add this whole work to staff picks -->
+        <form action="/admin/staffpicks" method="POST">
+          <input type="hidden" value="add" name="action"/>
+          <input type="hidden" name="work_id" value="$work_id"/>
+          <input type="submit" class="cta-btn cta-btn--small cta-btn--vanilla" value="$_('Add to Staff Picks')"/>
+        </form>
       <form method="GET" action="/admin/sync">
         <input type="hidden" name="edition_id" value="$edition_id"/>
         <input type="submit" class="cta-btn cta-btn--small cta-btn--vanilla" value="$_('Sync Archive.org ID')"/>

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -216,10 +216,12 @@ div.editionTools {
 }
 
 .admin-bar {
-  padding: 5px;
   background-color: @lightest-grey;
   form {
     display: inline-block;
+    input {
+      margin: 5px 0 5px 5px;
+    }
   }
 }
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Based on [this](https://internetarchive.slack.com/archives/C0119PRDV46/p1749718917414249?thread_ts=1749664106.262099&cid=C0119PRDV46) discussion I am proposing the following changes:

- Only show the add to staff picks button when there is an ocaid 
- Improved spacing

I've always wondered why that button was there and after some digging I learned it does nothing unless there's an ocaid. Which is quite often for me. So lets hide and and fix up spacing at the same time.

PS: This is just a PoC. Maybe we don't actually want this change?

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/e04e9630-d61e-4aeb-884f-49fb9e3edd10) | ![image](https://github.com/user-attachments/assets/0a8c0eeb-9430-47c0-9e30-bd0744970483) |
| ![image](https://github.com/user-attachments/assets/1fa8ca92-1c22-4645-a14b-6b4b18600f02) | ![image](https://github.com/user-attachments/assets/2f1994ad-9678-4066-bb6a-a92a36154214) |

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
