### PR TITLE
use bulk endpoint for mergeUI works

### DIFF
--- a/openlibrary/components/MergeUI/MergeTable.vue
+++ b/openlibrary/components/MergeUI/MergeTable.vue
@@ -87,8 +87,18 @@ function olidToKey(olid) {
 }
 
 async function fetchRecords(olids) {
-    const query = {key: olids.map(olidToKey), '*': null}
-    return (await fetch(`${CONFIGS.OL_BASE_BOOKS}/query.json?query=${JSON.stringify(query)}`)).json()
+    if (olids.length > 1000) {
+        throw new Error("Cannot fetch more than 1000 records at a time");
+    }
+
+    const query = {
+        key: olids.map(olidToKey),
+        limit: olids.length,
+        '*': null,
+    };
+    const params = new URLSearchParams({query});
+
+    return (await fetch(`${CONFIGS.OL_BASE_BOOKS}/query.json?${params}`)).json()
 }
 
 export default {

--- a/openlibrary/components/MergeUI/MergeTable.vue
+++ b/openlibrary/components/MergeUI/MergeTable.vue
@@ -96,7 +96,7 @@ async function fetchRecords(olids) {
         limit: olids.length,
         '*': null,
     };
-    const params = new URLSearchParams({query});
+    const params = new URLSearchParams({query: JSON.stringify(query)});
 
     return (await fetch(`${CONFIGS.OL_BASE_BOOKS}/query.json?${params}`)).json()
 }

--- a/openlibrary/components/MergeUI/MergeTable.vue
+++ b/openlibrary/components/MergeUI/MergeTable.vue
@@ -77,26 +77,18 @@ import { merge, get_editions, get_lists, get_bookshelves, get_ratings, get_autho
 import CONFIGS from '../configs.js';
 
 
-/**
- * @param {string} olid
- */
-function fetchRecord(olid) {
+function olidToKey(olid) {
     const type = {
         W: 'works',
         M: 'books',
         A: 'authors'
     }[olid[olid.length - 1]];
-    let base = '';
-    if (CONFIGS.OL_BASE_BOOKS) {
-        base = CONFIGS.OL_BASE_BOOKS;
-    } else {
-        // FIXME Fetch from prod openlibrary.org, otherwise it's outdated
-        base = location.host.endsWith('.openlibrary.org') ? 'https://openlibrary.org' : '';
-    }
-    const record_key = `/${type}/${olid}`;
-    return fetch(`${base}${record_key}.json`).then(r => {
-        return (r.ok) ? r.json() : {key: record_key, type: {key: '/type/none'}, error: r.statusText};
-    });
+    return `/${type}/${olid}`;
+}
+
+async function fetchRecords(olids) {
+    const query = {key: olids.map(olidToKey), '*': null}
+    return (await fetch(`${CONFIGS.OL_BASE_BOOKS}/query.json?query=${JSON.stringify(query)}`)).json()
 }
 
 export default {
@@ -123,7 +115,7 @@ export default {
             );
             // Ensure orphaned editions are at the bottom of the list
             const records = _.orderBy(
-                await Promise.all(olids_sorted.map(fetchRecord)),
+                await fetchRecords(olids_sorted),
                 record => record.type.key, 'desc');
 
             let masterIndex = 0

--- a/openlibrary/components/MergeUI/MergeTable.vue
+++ b/openlibrary/components/MergeUI/MergeTable.vue
@@ -88,7 +88,7 @@ function olidToKey(olid) {
 
 async function fetchRecords(olids) {
     if (olids.length > 1000) {
-        throw new Error("Cannot fetch more than 1000 records at a time");
+        throw new Error('Cannot fetch more than 1000 records at a time');
     }
 
     const query = {

--- a/openlibrary/components/MergeUI/utils.js
+++ b/openlibrary/components/MergeUI/utils.js
@@ -126,14 +126,7 @@ export function make_redirect(master_key, dupe) {
 
 export function get_editions(work_key) {
     const endpoint = `${work_key}/editions.json`;
-    let base = '';
-    if (CONFIGS.OL_BASE_BOOKS) {
-        base = CONFIGS.OL_BASE_BOOKS;
-    } else {
-        // FIXME Fetch from prod openlibrary.org, otherwise it's outdated
-        base = location.host.endsWith('.openlibrary.org') ? 'https://openlibrary.org' : '';
-    }
-    return fetch(`${base}${endpoint}?${new URLSearchParams({limit: DEFAULT_EDITION_LIMIT})}`).then(r => {
+    return fetch(`${CONFIGS.OL_BASE_BOOKS}${endpoint}?${new URLSearchParams({limit: DEFAULT_EDITION_LIMIT})}`).then(r => {
         if (r.ok) return r.json();
         if (confirm(`Network error; failed to load editions for ${work_key}. Click OK to reload.`)) location.reload();
     });

--- a/openlibrary/components/MergeUI/utils.js
+++ b/openlibrary/components/MergeUI/utils.js
@@ -126,7 +126,14 @@ export function make_redirect(master_key, dupe) {
 
 export function get_editions(work_key) {
     const endpoint = `${work_key}/editions.json`;
-    return fetch(`${CONFIGS.OL_BASE_BOOKS}${endpoint}?${new URLSearchParams({limit: DEFAULT_EDITION_LIMIT})}`).then(r => {
+    let base = '';
+    if (CONFIGS.OL_BASE_BOOKS) {
+        base = CONFIGS.OL_BASE_BOOKS;
+    } else {
+        // FIXME Fetch from prod openlibrary.org, otherwise it's outdated
+        base = location.host.endsWith('.openlibrary.org') ? 'https://openlibrary.org' : '';
+    }
+    return fetch(`${base}${endpoint}?${new URLSearchParams({limit: DEFAULT_EDITION_LIMIT})}`).then(r => {
         if (r.ok) return r.json();
         if (confirm(`Network error; failed to load editions for ${work_key}. Click OK to reload.`)) location.reload();
     });


### PR DESCRIPTION
<!-- What issue does this PR close? -->
I learned [here](https://internetarchive.slack.com/archives/C0ETZV72L/p1749229724892069) that we can use this endpoint to get many works in one query. So I implemented it to make our mergeUI faster and less likely to error!

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
