### PR TITLE
Add post-login handler

### DIFF
--- a/openlibrary/plugins/openlibrary/js/ia_thirdparty_logins.js
+++ b/openlibrary/plugins/openlibrary/js/ia_thirdparty_logins.js
@@ -24,7 +24,14 @@ export function initMessageEventListener(element) {
             })
                 .then((resp) => {
                     if (resp.ok) {
-                        window.location = new URLSearchParams(window.location.search).get('redirect') || '/account/books';
+                        const searchParams = {
+                            redirect: new URLSearchParams(window.location.search).get('redirect') || '/account/books'
+                        }
+                        const action = new URLSearchParams(window.location.search).get('action')
+                        if (action) {
+                            searchParams.action = action
+                        }
+                        window.location = `/account/login/success?${searchParams.toString()}`
                     }
                     return resp.json()
                 })

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -423,6 +423,7 @@ def _login(
     :return: 2-tuple containing the patron's OpenLibraryAccount and a boolean that signifies whether a post-login PD action should be taken
     :raises OLAuthenticationError: on authentication failure
     """
+
     def _set_cookies(_ol_account, _special_access: str, _remember: bool) -> None:
         expires = 3600 * 24 * 365 if remember else ""
 
@@ -453,13 +454,13 @@ def _login(
             _update_account_on_pd_request(ol_account)
 
     audit = audit_accounts(
-            email,
-            password,
-            require_link=require_link,
-            s3_access_key=s3_access_key,
-            s3_secret_key=s3_secret_key,
-            test=test,
-        )
+        email,
+        password,
+        require_link=require_link,
+        s3_access_key=s3_access_key,
+        s3_secret_key=s3_secret_key,
+        test=test,
+    )
     if error := audit.get("error"):
         raise OLAuthenticationError(error)
 
@@ -496,7 +497,9 @@ class account_login_json(delegate.page):
         if not access or not secret:
             raise Exception("Infogami username/password is deprecated")
         try:
-            _, set_pd_action = _login(None, None, True, access, secret, remember=bool(remember), test=test)
+            _, set_pd_action = _login(
+                None, None, True, access, secret, remember=bool(remember), test=test
+            )
             stats.increment('ol.account.xauth.login')
             stats.increment("ol.account.login.json")
         except OLAuthenticationError as err:
@@ -578,11 +581,9 @@ class account_login(delegate.page):
 
 class post_login_handler(delegate.page):
     path = "/account/login/success"
-    deny_list = frozenset([
-        "/account/login",
-        "/account/create",
-        "/account/login/success"
-    ])
+    deny_list = frozenset(
+        ["/account/login", "/account/create", "/account/login/success"]
+    )
     default_redirect = "/account/books"
 
     def GET(self):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10870

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
1. Adds a new post-login `GET` handler, which performs any post-login actions and redirects the patron to their desired page.
2. Extracts common login code into a new `_login` function.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
