### PR TITLE
make docker shutdown faster with graceful sigint handling

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -89,6 +89,7 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.oldev
+    init: true # this is needed for docker sigints to work without modifying the many scripts within
     command: docker/ol-home-start.sh
     networks:
       - webnet

--- a/docker/ol-covers-start.sh
+++ b/docker/ol-covers-start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 python --version
-scripts/coverstore-server "$COVERSTORE_CONFIG" \
+exec scripts/coverstore-server "$COVERSTORE_CONFIG" \
     --gunicorn $GUNICORN_OPTS \
     --bind :7075

--- a/docker/ol-home-start.sh
+++ b/docker/ol-home-start.sh
@@ -6,5 +6,5 @@
 python --version
 
 echo "Waiting for postgres..."
-until pg_isready --host db; do sleep 5; done
+exec until pg_isready --host db; do sleep 5; done
 make reindex-solr

--- a/docker/ol-home-start.sh
+++ b/docker/ol-home-start.sh
@@ -6,5 +6,5 @@
 python --version
 
 echo "Waiting for postgres..."
-exec until pg_isready --host db; do sleep 5; done
+until pg_isready --host db; do sleep 5; done
 make reindex-solr

--- a/docker/ol-infobase-start.sh
+++ b/docker/ol-infobase-start.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 python --version
-scripts/infobase-server "$INFOBASE_CONFIG" $INFOBASE_OPTS 7000
+exec scripts/infobase-server "$INFOBASE_CONFIG" $INFOBASE_OPTS 7000

--- a/docker/ol-solr-updater-start.sh
+++ b/docker/ol-solr-updater-start.sh
@@ -9,7 +9,7 @@ curl -L --output $OSP_DUMP_LOCATION \
     https://archive.org/download/2023_openlibrary_osp_counts/osp_totals.db
 
 ls -la /solr-updater-data/
-PYTHONPATH=. python scripts/solr_updater/solr_updater.py $OL_CONFIG \
+PYTHONPATH=. exec python scripts/solr_updater/solr_updater.py $OL_CONFIG \
     --state-file /solr-updater-data/$STATE_FILE \
     --ol-url "$OL_URL" \
     --osp-dump "$OSP_DUMP_LOCATION" \

--- a/docker/ol-web-start.sh
+++ b/docker/ol-web-start.sh
@@ -8,6 +8,5 @@ if [ -n "$BEFORE_START" ] ; then
 fi
 
 PYTHONPATH=. exec scripts/openlibrary-server "$OL_CONFIG" \
-  --gunicorn \
   $GUNICORN_OPTS \
   --bind :8080

--- a/docker/ol-web-start.sh
+++ b/docker/ol-web-start.sh
@@ -7,7 +7,7 @@ if [ -n "$BEFORE_START" ] ; then
   $BEFORE_START
 fi
 
-exec scripts/openlibrary-server "$OL_CONFIG" \
+PYTHONPATH=. exec scripts/openlibrary-server "$OL_CONFIG" \
   --gunicorn \
   $GUNICORN_OPTS \
   --bind :8080

--- a/docker/ol-web-start.sh
+++ b/docker/ol-web-start.sh
@@ -7,7 +7,7 @@ if [ -n "$BEFORE_START" ] ; then
   $BEFORE_START
 fi
 
-scripts/openlibrary-server "$OL_CONFIG" \
+exec scripts/openlibrary-server "$OL_CONFIG" \
   --gunicorn \
   $GUNICORN_OPTS \
   --bind :8080

--- a/openlibrary/utils/shutdown.py
+++ b/openlibrary/utils/shutdown.py
@@ -1,0 +1,14 @@
+"""Utility to setup graceful shutdown for a process. This enables docker to shutdown faster rather than waiting 10 seconds."""
+
+import signal
+import sys
+
+
+def setup_graceful_shutdown():
+    def shutdown_handler(signum, frame):
+        print("Shutting down")
+        sys.exit(0)
+
+    # catch SIGINT and SIGTERM to allow graceful shutdown
+    signal.signal(signal.SIGINT, shutdown_handler)
+    signal.signal(signal.SIGTERM, shutdown_handler)

--- a/scripts/infobase-server
+++ b/scripts/infobase-server
@@ -20,8 +20,10 @@ import _init_path  # noqa: F401  Imported for its side effect of setting PYTHONP
 import web
 
 from openlibrary.utils.sentry import Sentry
+from openlibrary.utils.shutdown import setup_graceful_shutdown
 
 logger = logging.getLogger("openlibrary." + __file__)
+setup_graceful_shutdown()
 
 
 def setup_env():

--- a/scripts/infobase-server
+++ b/scripts/infobase-server
@@ -23,7 +23,6 @@ from openlibrary.utils.sentry import Sentry
 from openlibrary.utils.shutdown import setup_graceful_shutdown
 
 logger = logging.getLogger("openlibrary." + __file__)
-setup_graceful_shutdown()
 
 
 def setup_env():
@@ -68,6 +67,8 @@ def start(config_file, *args):
         else:
             return runfcgi(wsgifunc, None)
     else:
+        # Plain server does not correctly handle SIGTERM/SIGINT
+        setup_graceful_shutdown()
         server.run()
 
 

--- a/scripts/openlibrary-server
+++ b/scripts/openlibrary-server
@@ -16,25 +16,13 @@ USAGE:
     $ ./scripts/openlibrary-server infogami.yml startserver --gunicorn -b 0.0.0.0:8080
 """
 import os
-import signal
 import sys
 
 import web
 import yaml
 from gunicorn.app.base import Application
 
-
-# TODO: idk why this import fails
-# from openlibrary.utils.shutdown import setup_graceful_shutdown
-def setup_graceful_shutdown():
-    def shutdown_handler(signum, frame):
-        print("Shutting down")
-        sys.exit(0)
-
-    # catch SIGINT and SIGTERM to allow graceful shutdown
-    signal.signal(signal.SIGINT, shutdown_handler)
-    signal.signal(signal.SIGTERM, shutdown_handler)
-
+from openlibrary.utils.shutdown import setup_graceful_shutdown
 
 setup_graceful_shutdown()
 

--- a/scripts/openlibrary-server
+++ b/scripts/openlibrary-server
@@ -3,17 +3,10 @@
 
 USAGE:
 
-* Run openlibrary http server at port 8080.
-
-    $ ./scripts/openlibrary-server infogami.yml startserver 8080
-
-* Run openlibrary as fastcgi server at port 7070
-
-    $ ./scripts/openlibrary-server infogami.yml startserver fastcgi 8080
-
 * Run openlibrary as gunicorn server at port 8080
 
-    $ ./scripts/openlibrary-server infogami.yml startserver --gunicorn -b 0.0.0.0:8080
+    $ PYTHONPATH=. scripts/openlibrary-server conf/openlibrary.yml $GUNICORN_OPTS --bind :8080
+
 """
 import os
 import sys
@@ -21,10 +14,6 @@ import sys
 import web
 import yaml
 from gunicorn.app.base import Application
-
-from openlibrary.utils.shutdown import setup_graceful_shutdown
-
-setup_graceful_shutdown()
 
 
 def setup_env():
@@ -35,26 +24,6 @@ def setup_env():
     os.environ['REAL_SCRIPT_NAME'] = ""
 
     sys.path.append('conf')
-
-
-def start_server():
-    import _init_path  # noqa: F401  Imported for its side effect of setting PYTHONPATH
-
-    args = sys.argv[1:]
-
-    if len(args) < 1 or sys.argv[0] in ['-h', '--help']:
-        print(
-            "USAGE: %s configfile [subcommand] [arguments]" % (sys.argv[0]),
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
-    configfile, args = args[0], args[1:]
-    load_infogami(configfile)
-
-    import infogami
-
-    infogami.run(args)
 
 
 def load_infogami(config_file):
@@ -83,17 +52,15 @@ def setup_infobase_config(config_file):
             config.infobase = yaml.safe_load(f)
 
 
-class BaseWSGIServer(Application):
+class OLWSGIServer(Application):
     def __init__(self, config_file):
         self.config_file = config_file
-        Application.__init__(self)
+        super().__init__()
 
     def init(self, parser, opts, args):
         pass
 
     def load(self):
-        import _init_path  # noqa: F401  Imported for side effect of setting PYTHONPATH
-
         load_infogami(self.config_file)
 
         import infogami
@@ -104,11 +71,6 @@ class BaseWSGIServer(Application):
         wsgi_app = web.httpserver.StaticMiddleware(wsgi_app)
         return wsgi_app
 
-    def get_wsgi_app(self):
-        raise NotImplementedError
-
-
-class OLWSGIServer(BaseWSGIServer):
     def get_wsgi_app(self):
         from infogami import config
         from infogami.utils import delegate
@@ -139,14 +101,9 @@ def https_middleware(app):
 
 def main():
     setup_env()
-
-    if "--gunicorn" in sys.argv:
-        sys.argv.pop(sys.argv.index("--gunicorn"))
-        configfile = sys.argv.pop(1)
-        server = OLWSGIServer(configfile)
-        server.run()
-    else:
-        start_server()
+    configfile = sys.argv.pop(1)
+    server = OLWSGIServer(configfile)
+    server.run()
 
 
 if __name__ == "__main__":

--- a/scripts/openlibrary-server
+++ b/scripts/openlibrary-server
@@ -22,6 +22,10 @@ import web
 import yaml
 from gunicorn.app.base import Application
 
+from openlibrary.utils.shutdown import setup_graceful_shutdown
+
+setup_graceful_shutdown()
+
 
 def setup_env():
     # make sure PYTHON_EGG_CACHE is writable

--- a/scripts/openlibrary-server
+++ b/scripts/openlibrary-server
@@ -16,13 +16,25 @@ USAGE:
     $ ./scripts/openlibrary-server infogami.yml startserver --gunicorn -b 0.0.0.0:8080
 """
 import os
+import signal
 import sys
 
 import web
 import yaml
 from gunicorn.app.base import Application
 
-from openlibrary.utils.shutdown import setup_graceful_shutdown
+
+# TODO: idk why this import fails
+# from openlibrary.utils.shutdown import setup_graceful_shutdown
+def setup_graceful_shutdown():
+    def shutdown_handler(signum, frame):
+        print("Shutting down")
+        sys.exit(0)
+
+    # catch SIGINT and SIGTERM to allow graceful shutdown
+    signal.signal(signal.SIGINT, shutdown_handler)
+    signal.signal(signal.SIGTERM, shutdown_handler)
+
 
 setup_graceful_shutdown()
 

--- a/scripts/solr_updater/solr_updater.py
+++ b/scripts/solr_updater/solr_updater.py
@@ -28,10 +28,12 @@ from openlibrary.utils.open_syllabus_project import set_osp_dump_location
 from scripts.solr_updater.trending_updater_daily import main as trending_daily_main
 from scripts.solr_updater.trending_updater_hourly import main as trending_hourly_main
 from scripts.utils.scheduler import OlAsyncIOScheduler
+from openlibrary.utils.shutdown import setup_graceful_shutdown
 
 logger = logging.getLogger("openlibrary.solr-updater")
 # FIXME: Some kind of hack introduced to work around DB connectivity issue
 args: dict = {}
+setup_graceful_shutdown()
 
 
 def read_state_file(path, initial_state: str | None = None):

--- a/scripts/solr_updater/solr_updater.py
+++ b/scripts/solr_updater/solr_updater.py
@@ -25,10 +25,10 @@ from infogami import config
 from openlibrary.config import load_config
 from openlibrary.solr import update
 from openlibrary.utils.open_syllabus_project import set_osp_dump_location
+from openlibrary.utils.shutdown import setup_graceful_shutdown
 from scripts.solr_updater.trending_updater_daily import main as trending_daily_main
 from scripts.solr_updater.trending_updater_hourly import main as trending_hourly_main
 from scripts.utils.scheduler import OlAsyncIOScheduler
-from openlibrary.utils.shutdown import setup_graceful_shutdown
 
 logger = logging.getLogger("openlibrary.solr-updater")
 # FIXME: Some kind of hack introduced to work around DB connectivity issue


### PR DESCRIPTION
<!-- What issue does this PR close? -->
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Lately I've been restarting docker a lot (because I'm working with carousels that are cached).
It takes 10+ seconds to do a docker compose down.
So I asked why, and it turns out we just don't have our scripts setup to handle the sigint/sigterm and so we get the default docker timeout of 10 seconds before a force shutdown.

This PR updates it.

Run `docker compose up -d && docker compose stop` to test.
Before: 15+ seconds
After: ~3 seconds

Edit: Sometimes that fails for unclear reasons but if it sleeps for 2 seconds then shutdown happens right away. But for normal use cases this is still a success. `docker compose up -d && sleep 2 && docker compose sto`


### Technical
<!-- What should be noted about the implementation? -->
We need to exec to pass down the sigint. Then handle the sigint in python.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
