### PR TITLE
i18n/de: Fix typing error in message string.

### DIFF
--- a/openlibrary/i18n/de/messages.po
+++ b/openlibrary/i18n/de/messages.po
@@ -1660,7 +1660,7 @@ msgstr "Alles anzeigen"
 
 #: account/sidebar.html type/list/edit.html
 msgid "Create a list"
-msgstr "Nuee Liste erstellen"
+msgstr "Neue Liste erstellen"
 
 #: account/topmenu.html
 msgid "Import & Export"


### PR DESCRIPTION
There was a typo In the German translation of msgid "Create a list". It is "Neue Liste erstellen", not "Nuee Liste erstellen"

<!-- What issue does this PR close? -->
No issue created due to triviality.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix typo.

### Technical
<!-- What should be noted about the implementation? -->
Not relevant.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Not relevant.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Not relevant.

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
Not relevant.

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
