### PR TITLE
Route Google SSO authentication requests to `HTML` login handler

### DIFF
--- a/openlibrary/plugins/openlibrary/js/ia_thirdparty_logins.js
+++ b/openlibrary/plugins/openlibrary/js/ia_thirdparty_logins.js
@@ -17,24 +17,13 @@ export function initMessageEventListener(element) {
             if (e.data.height) element.style.height = `${e.data.height}px`;
         }
         else if (e.data.type === 's3-keys') {
-            fetch('/account/login.json', {
-                method: 'POST',
-                credentials: 'include',
-                body: JSON.stringify(e.data.s3)
-            })
-                .then((resp) => {
-                    if (resp.ok) {
-                        window.location = new URLSearchParams(window.location.search).get('redirect') || '/account/books';
-                    }
-                    return resp.json()
-                })
-                .then((error) => {
-                    const loginForm = document.querySelector('#register')
-                    const errorDiv = document.createElement('div')
-                    errorDiv.classList.add('note')
-                    errorDiv.textContent = error.errorDisplayString
-                    loginForm.insertAdjacentElement('afterbegin', errorDiv)
-                })
+            const s3AccessInput = document.querySelector('#access')
+            const s3SecretInput = document.querySelector('#secret')
+            s3AccessInput.value = e.data.s3.access
+            s3SecretInput.value = e.data.s3.secret
+
+            const loginForm = document.querySelector('#register')
+            loginForm.submit()
         }
     }
 

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -417,8 +417,6 @@ class account_login_json(delegate.page):
         )
 
         d = json.loads(web.data())
-        email = d.get('email', "")
-        remember = d.get('remember', "")
         access = d.get('access', None)
         secret = d.get('secret', None)
         test = d.get('test', False)
@@ -440,29 +438,7 @@ class account_login_json(delegate.page):
                     'errorDisplayString': get_login_error(error),
                 }
                 raise olib.code.BadRequest(json.dumps(resp))
-            expires = 3600 * 24 * 365 if remember.lower() == 'true' else ""
-            web.setcookie('pd', int(audit.get('special_access')) or '', expires=expires)
             web.setcookie(config.login_cookie_name, web.ctx.conn.get_auth_token())
-            if audit.get('ia_email') and (
-                ol_account := OpenLibraryAccount.get(email=audit['ia_email'])
-            ):
-                _set_account_cookies(ol_account, expires)
-
-                if web.cookies().get("pda"):
-                    _update_account_on_pd_request(ol_account)
-                    _notify_on_rpd_verification(
-                        ol_account, get_pd_org(web.cookies().get("pda"))
-                    )
-                    _expire_pd_cookies()
-
-                has_special_access = audit.get('special_access')
-                if (
-                    has_special_access
-                    and ol_account.get_user().preferences().get('rpd')
-                    != PDRequestStatus.FULFILLED.value
-                ):
-                    _update_account_on_pd_fulfillment(ol_account)
-
         # Fallback to infogami user/pass
         else:
             from infogami.plugins.api.code import login as infogami_login

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -517,7 +517,7 @@ class account_login(delegate.page):
         )
         if error := audit.get('error'):
             return self.render_error(error, i)
-        email = email or audit.get('ol_email')
+        email = email or audit.get('ia_email') or audit.get('ol_email')
 
         expires = 3600 * 24 * 365 if i.remember else ""
         web.setcookie('pd', int(audit.get('special_access')) or '', expires=expires)

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -530,7 +530,7 @@ class account_login(delegate.page):
             secret=None,
             action="",
         )
-        email = i.username  # XXX username is now email
+        email = '' if (i.access and i.secret) else i.username
         audit = audit_accounts(
             email,
             i.password,
@@ -541,6 +541,7 @@ class account_login(delegate.page):
         )
         if error := audit.get('error'):
             return self.render_error(error, i)
+        email = email or audit.get('ol_email')
 
         expires = 3600 * 24 * 365 if i.remember else ""
         web.setcookie('pd', int(audit.get('special_access')) or '', expires=expires)

--- a/openlibrary/templates/login.html
+++ b/openlibrary/templates/login.html
@@ -74,6 +74,8 @@ $if "dev" in ctx.features:
                     <label for="remember" class="small">$_("Remember me")</label>
             </div>
 
+            <input type="hidden" id="secret" value="" name="secret" />
+            <input type="hidden" id="access" value="" name="access" />
             <input type="hidden" id="redirect" value="$form.redirect.value" name="redirect" />
             <input type="hidden" id="action" value="$form.action.value" name="action" />
             <input type="hidden" id="debug_token" value="" name="debug_token"/>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10870
Supplants #10944

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Updates code such that Google SSO authentication requests are routed to the HTML login handler.  Now, all logins via the `/account/login` page are handled by `account_login.POST`.

Any code that supported web application features has been removed from the JSON login handler (i.e. "Remember Me" option, `pd` cookies, etc.).

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
I believe that some CSP configurations are preventing us from using Google SSO in testing, so that will need to be updated before this can be properly tested.

I have tested submitting the form with the S3 key inputs filled, and that seemed to work as expected.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
