### PR TITLE
Remove HTML comment from "My Books" template

### DIFF
--- a/openlibrary/templates/account/mybooks.html
+++ b/openlibrary/templates/account/mybooks.html
@@ -116,34 +116,6 @@ $def empty_mobile_carousel(data):
           $# Render carousel
           $:(mobile_carousel(already_read) or empty_mobile_carousel(already_read))
         </li>
-<!--
-        <div class="list-overflow">
-          $ placeholder_name = _('Untitled list')
-          $ i = 0
-          $for lst in lists:
-          $# e.g. OL1L from /people/mekBot/lists/OL1L
-            $if i >= 3:
-              $ break
-            $ list_id = lst.key.split('/')[-1]
-            $ class_list = ''
-            $ i += 1
-            $if key == 'list':
-              $# e.g. /people/openlibrary/lists/OL1L/MyList
-              $ path_id = ctx.path.split('/')[4]
-              $if list_id == path_id:
-                $ class_list = class_list + 'selected'
-            <li></li>
-            <li>
-              <div class="carousel-section-header">
-                <a class="$class_list" data-ol-link-track="MyBooksSidebar|PatronList" href="/people/$username/lists/$list_id">
-                  $(lst['name'] if lst['name'] else '[%s]' % placeholder_name)
-                  ($(len(lst.seeds)))
-                  <img class="icon-link__image li-count" src="/static/images/icons/right-chevron.svg">
-                </a>
-              </div>
-            </li>
-        </div>
-         -->
         <li>
           <div class="carousel-section-header">
             <a data-ol-link-track="MyBooksSidebar|AllLists" href="/people/$username/lists">


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes sizeable HTML comment from the template for `/account/books`.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
