### PR TITLE
annotate disabled ruff rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,21 +41,29 @@ extend-exclude = [
   "vendor",
 ]
 ignore = [
-  "B007",
-  "B023",
-  "B904",
-  "B905",
-  "E402",
-  "F841",
-  "PERF401",
-  "PIE790",
-  "PLW0603",
-  "PLW2901",
-  "RUF005",
-  "SIM108",
-  "SLF001",
-  "UP031",
-  "UP038",
+  "B007",    # unused-loop-control-variable - not a big deal for us
+  "B023",    # function-uses-loop-variable - doesn't matter for our lambdas but it's a good rule
+  "B904",    # raise-without-from-inside-except - not sure but it seems fine for now
+  "PERF401", # manual-list-comprehension - we prefer readability
+  "PIE790",  # unnecessary-placeholder - could be removed but not much gain
+  "PLW0603", # global-statement - we use it a lot...
+  "PLW2901", # redefined-loop-name - would be a lot of work to fix
+  "RUF005",  # collection-literal-concatenation - this works for us as is
+  "SIM108",  # if-else-block-instead-of-if-exp - we prefer the readability instead of ternaries
+  "SLF001",  # private-member-access - unfortunately we use these quite often for infogami
+  "UP031",   # printf-string-formatting - a ton of work to fix to 224 errors
+  # TODO: these could be fixed one day
+  "F841",    # unused-variable - currently has 60 errors. Would be good to fix
+  "B905",    # zip-without-explicit-strict - TODO: seems like we should fix this one
+  "UP038",   # non-pep604-isinstance - This rule is deprecated and will be removed in a future ruff release.
+  "E402",    # module-import-not-at-top-of-file - TODO: we should probably enable this and and add exceptions
+    # openlibrary/plugins/admin/code.py - maybe it can be fixed
+    # openlibrary/plugins/openlibrary/code.py - unclear but has many
+    # openlibrary/plugins/openlibrary/filters.py - can fix
+    # openlibrary/plugins/upstream/jsdef.py - can remove
+    # openlibrary/plugins/upstream/utils.py - unclear but it's huge
+    # scripts/tests/test_affiliate_server.py - probably needed for side effects
+    # scripts/tests/test_solr_updater.p - probably needed for side effects
 ]
 line-length = 162
 select = [


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10196

With this final PR, we can close that issue to open some old ruff rules.
I've gone through all the rules and added their description and why we're ok with them being disabled.
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
