### PR TITLE
fix: added escape character for +

### DIFF
--- a/openlibrary/plugins/worksearch/schemes/__init__.py
+++ b/openlibrary/plugins/worksearch/schemes/__init__.py
@@ -93,6 +93,7 @@ class SearchScheme:
                     # Also escape unexposed lucene features
                     .replace('?', '\\?')
                     .replace('~', '\\~')
+                    .replace('+', '\\+')
                 ),
                 self.is_search_field,
                 lower=True,


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10951 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] --> bug-fix

### Technical
<!-- What should be noted about the implementation? --> 
Single line change to escape + as \\\+ for solr query

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Test on Local: 

akanksha@Akanksha:/mnt/c/Users/joshi/openlibrary$ curl "[http://localhost:8983/solr/openlibrary/select?q=subject_facet:%22%5C%2BLand%20value%20taxation%22&wt=json](http://localhost:8983/solr/openlibrary/select?q=subject_facet%3A%22%5C%2BLand%20value%20taxation%22&wt=json)"
{
  "responseHeader":{
    "status":0,
    "QTime":3,
    "params":{
      "q":"subject_facet:\"\\+Land value taxation\"",
      "wt":"json"
    }
  },
  "response":{
    "numFound":1,
    "start":0,
    "numFoundExact":true,
    "docs":[{
      "id":["subject_1"],
      "name":"+Land value taxation",
      "type":"subject",
      "key":"4db14f98-d3c9-445b-b8d7-7b01e45e1c7b",
      "subject_facet":["+Land value taxation"],
      "_version_":1835896817846321152
    }]
  }


corresponding to solr documents:

[
  {
    "id": "subject_1",
    "subject_facet": "+Land value taxation",
    "name": "+Land value taxation",
    "type": "subject"
  },
  {
    "id": "subject_2",
    "subject_facet": "Land value taxation",
    "name": "Land value taxation",
    "type": "subject"
  }
]

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
