### PR TITLE
support s3 import for logged out patrons

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -49,7 +49,9 @@ def valid_email(email):
     return validate_email(email)
 
 
-def extract_s3_credentials_from_header(auth_header: str) -> tuple[str | None, str | None]:
+def extract_s3_credentials_from_header(
+    auth_header: str,
+) -> tuple[str | None, str | None]:
     """Extract S3 credentials from LOW authorization header format: "LOW key:secret"."""
     if auth_header and auth_header.startswith('LOW '):
         try:
@@ -59,7 +61,7 @@ def extract_s3_credentials_from_header(auth_header: str) -> tuple[str | None, st
                 return credentials[0], credentials[1]
         except Exception:
             pass
-    
+
     return None, None
 
 
@@ -766,7 +768,7 @@ class InternetArchiveAccount(web.storage):
     @classmethod
     def s3auth(cls, access_key=None, secret_key=None, _raw_response=False):
         """Authenticates an Archive.org user based on s3 keys.
-        
+
         If no keys are provided, attempts to extract them from web.ctx authorization header.
         Returns OpenLibraryAccount by default, or raw response if _raw_response=True.
         """
@@ -774,7 +776,9 @@ class InternetArchiveAccount(web.storage):
 
         # If no keys provided, try to extract from web context header
         if not access_key or not secret_key:
-            auth_header = web.ctx.env.get('HTTP_AUTHORIZATION', '') if hasattr(web, 'ctx') else ''
+            auth_header = (
+                web.ctx.env.get('HTTP_AUTHORIZATION', '') if hasattr(web, 'ctx') else ''
+            )
             access_key, secret_key = extract_s3_credentials_from_header(auth_header)
 
         url = lending.config_ia_s3_auth_url
@@ -788,17 +792,17 @@ class InternetArchiveAccount(web.storage):
             )
             response.raise_for_status()
             result = response.json()
-            
+
             # Return raw response for backward compatibility if requested
             if _raw_response:
                 return result
-            
+
             # Otherwise return OpenLibraryAccount if authorized
             if result.get('authorized') and (email := result.get('username')):
                 return OpenLibraryAccount.get(email=email)
-            
+
             return None
-            
+
         except requests.HTTPError as e:
             if _raw_response:
                 return {'error': e.response.text, 'code': e.response.status_code}
@@ -863,7 +867,9 @@ def audit_accounts(
     """
 
     if s3_access_key and s3_secret_key:
-        r = InternetArchiveAccount.s3auth(s3_access_key, s3_secret_key, _raw_response=True)
+        r = InternetArchiveAccount.s3auth(
+            s3_access_key, s3_secret_key, _raw_response=True
+        )
         if not r.get('authorized', False):
             return {'error': 'invalid_s3keys'}
         ia_login = {

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -12,9 +12,11 @@ import web
 from lxml import etree
 from pydantic import ValidationError
 
+from infogami import config
 from infogami.infobase.client import ClientException
 from infogami.plugins.api.code import add_hook
 from openlibrary import accounts, records
+from openlibrary.accounts import InternetArchiveAccount, OpenLibraryAccount
 from openlibrary.catalog import add_book
 from openlibrary.catalog.get_ia import get_from_archive_bulk, get_marc_record_from_ia
 from openlibrary.catalog.marc.marc_binary import MarcBinary, MarcException
@@ -178,8 +180,15 @@ class importapi:
 
     def POST(self):
         web.header('Content-Type', 'application/json')
+
         if not can_write():
-            raise web.HTTPError('403 Forbidden')
+            # Try S3 authentication as fallback
+            if ol_account := InternetArchiveAccount.s3auth():
+                # Log the user in with S3 credentials
+                web.ctx.conn.set_auth_token(ol_account.generate_login_code())
+                web.setcookie(config.login_cookie_name, web.ctx.conn.get_auth_token())
+            else:
+                raise web.HTTPError('403 Forbidden')
 
         i = web.input()
         preview = i.get('preview') == 'true'
@@ -187,7 +196,6 @@ class importapi:
 
         try:
             edition, _ = parse_data(data)
-
         except (DataError, json.JSONDecodeError) as e:
             return self.error(str(e), 'Failed to parse import data')
         except ValidationError as e:

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -16,7 +16,7 @@ from infogami import config
 from infogami.infobase.client import ClientException
 from infogami.plugins.api.code import add_hook
 from openlibrary import accounts, records
-from openlibrary.accounts import InternetArchiveAccount, OpenLibraryAccount
+from openlibrary.accounts import InternetArchiveAccount
 from openlibrary.catalog import add_book
 from openlibrary.catalog.get_ia import get_from_archive_bulk, get_marc_record_from_ia
 from openlibrary.catalog.marc.marc_binary import MarcBinary, MarcException


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Towards #9405 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Questions
<!-- What should be noted about the implementation? -->

- if `ol_account` (i.e. s3 keys present in headers) should the patron be logged out after import?
- are cookies necessary in this flow? I figured something about import flow might use some value associated with web.ctx

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
