### PR TITLE
fix pydantic warnings

### DIFF
--- a/openlibrary/plugins/importapi/import_validator.py
+++ b/openlibrary/plugins/importapi/import_validator.py
@@ -1,7 +1,7 @@
 from typing import Annotated, Any, Final, TypeVar
 
 from annotated_types import MinLen
-from pydantic import BaseModel, ValidationError, model_validator, root_validator
+from pydantic import BaseModel, ValidationError, model_validator
 
 from openlibrary.catalog.add_book import (
     SUSPECT_AUTHOR_NAMES,
@@ -35,7 +35,8 @@ class CompleteBook(BaseModel):
     publishers: NonEmptyList[NonEmptyStr]
     publish_date: NonEmptyStr
 
-    @root_validator(pre=True)
+    @model_validator(mode='before')
+    @classmethod
     def remove_invalid_dates(cls, values):
         """Remove known bad dates prior to validation."""
         is_exempt = any(
@@ -50,7 +51,8 @@ class CompleteBook(BaseModel):
 
         return values
 
-    @root_validator(pre=True)
+    @model_validator(mode='before')
+    @classmethod
     def remove_invalid_authors(cls, values):
         """Remove known bad authors (e.g. an author of "N/A") prior to validation."""
         authors = values.get("authors", [])


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

When running tests two of the warnings we get are:
```
openlibrary/plugins/importapi/import_validator.py:38 /openlibrary/openlibrary/plugins/importapi/import_validator.py:38: PydanticDeprecatedSince20: Pydantic V1 style @root_validator validators are deprecated. You should migrate to Pydantic V2 style @model_validator validators, see the migration guide for more details. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.4/migration/ @root_validator(pre=True)

openlibrary/plugins/importapi/import_validator.py:53 /openlibrary/openlibrary/plugins/importapi/import_validator.py:53: PydanticDeprecatedSince20: Pydantic V1 style @root_validator validators are deprecated. You should migrate to Pydantic V2 style @model_validator validators, see the migration guide for more details. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.4/migration/ @root_validator(pre=True)
```

This PR follows the [migration guide](https://docs.pydantic.dev/2.4/migration/#validator-and-root_validator-are-deprecated) and removes the warning.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
