### PR TITLE
fix: add semicolon to startup script

### DIFF
--- a/openlibrary/core/schema.sql
+++ b/openlibrary/core/schema.sql
@@ -110,7 +110,7 @@ CREATE TABLE wikidata (
     id text not null primary key,
     data json,
     updated timestamp without time zone default (current_timestamp at time zone 'utc')
-)
+);
 
 CREATE TABLE bestbooks (
     award_id serial not null primary key,


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #
(none opened)

### Technical
Adds a missing semicolon to ol-db-init.sh, the startup process was failing to create openlibrary postgres user on a new development machine. Worked after this change.

### Testing
Might be hard to reproduce without a machine that has never run OL locally before, but this happened when I was setting up for the first time in WSL2 Ubuntu (line endings are correct).

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@cdrini 


Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code.
