### PR TITLE
Fix log_workers_cur_fn monitor not catch openlibrary-server

### DIFF
--- a/scripts/monitoring/utils.sh
+++ b/scripts/monitoring/utils.sh
@@ -59,7 +59,7 @@ log_workers_cur_fn() {
     #       related to requests connection pooling
     # - get_availability|get_api_response: Main time block for IA requests
 
-    for pid in $(ps aux | grep 'gunicorn' | grep -v 'grep' | awk '{print $2}'); do
+    for pid in $(ps aux | grep -E 'openlibrary-server|coverstore-server' | grep -v 'grep' | awk '{print $2}'); do
         echo "$pid $(py_spy_cur_fn $pid)";
     done 2>/dev/null \
         | awk '{print $2}' \


### PR DESCRIPTION
Hotfix to last deploy; openlibrary-server no longer has a --gunicorn option.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
