### PR TITLE
Add indices for common import_item table operations

### DIFF
--- a/openlibrary/core/infobase_schema.sql
+++ b/openlibrary/core/infobase_schema.sql
@@ -539,4 +539,6 @@ CREATE TABLE import_item (
 CREATE INDEX import_item_batch_id ON import_item(batch_id);
 CREATE INDEX import_item_import_time ON import_item(import_time);
 CREATE INDEX import_item_status ON import_item(status);
+CREATE INDEX import_item_status_id ON import_item(status, id);
+CREATE INDEX import_item_submitter ON import_item(submitter);
 CREATE INDEX import_item_ia_id ON import_item(ia_id);


### PR DESCRIPTION
Performance fix for slow import_item queries.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
