### PR TITLE
Add hidden S3 inputs to account registration form

### DIFF
--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -90,6 +90,8 @@ $var title: $_("Sign Up to Open Library")
                 </select>
                 <span class="email-advisory">$_("* Please use the email address associated with this qualifying program. You will receive an email after activation with next steps.")</span>
             </div>
+            <input type="hidden" id="secret" value="" name="secret" />
+            <input type="hidden" id="access" value="" name="access" />
             <div class="formElement bottom">
                 <br/>
                 <button type="submit" name="signup" id="signup" class="cta-btn cta-btn--primary">$_("Sign Up with Email")</button>


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
__Hotfix__

I highly suspect that people using Google SSO for account registration are not being redirected.

This branch adds hidden S3 `secret` and `access` keys to the account registration form.  The values of these fields are set via JS [here](https://github.com/internetarchive/openlibrary/blob/b95657c13b19da6293d6bb4aa5cec75d7003639d/openlibrary/plugins/openlibrary/js/ia_thirdparty_logins.js#L19-L27), so it looks like the form is not being submitted.  That is to say, new patrons _are_ being registered via OL Google SSO, but no redirect/login is happening afterwards.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
