### PR TITLE
Add CONTAINER option + tighten output of patchdeploy.sh

### DIFF
--- a/scripts/deployment/patchdeploy.sh
+++ b/scripts/deployment/patchdeploy.sh
@@ -3,58 +3,87 @@
 # usage: ./scripts/deployment/patchdeploy.sh 1234
 
 # Check if PR number is provided
-if [ -z "$1" ]; then
+if [[ -z "$1" || "$1" == "--help" ]]; then
+    echo "This script applies a patch from a GitHub PR to the Open Library servers."
+    echo ""
     echo "Usage: $0 <pr_number>"
+    echo ""
+    echo "Environment variables:"
+    echo "  SERVERS=ol-web0 ol-web1 ol-web2  List of servers to apply the patch to."
+    echo "  PATCH_ON=host|container          Whether to apply the patch on the host or inside"
+    echo "                                   the container."
+    echo "                                   Default: container unless patching www nginx changes"
+    echo "  CONTAINER=container_name         Default: openlibrary-web-1 for ol-web hosts,"
+    echo "                                   openlibrary-web_nginx-1 for ol-www0"
+    echo "  APPLY_OPTIONS=''                 Options to pass to git apply. E.g. use -R to"
+    echo "                                   un-apply a patch. See 'git apply --help' for options."
     exit 1
 fi
 
 PR_NUMBER=$1
 PATCH_URL="https://patch-diff.githubusercontent.com/raw/internetarchive/openlibrary/pull/${PR_NUMBER}.diff"
 echo "Note: Patch Deploys cannot rebuild js/css"
+echo
 
 # Iterate over hosts
-SERVERS=${SERVERS:-"ol-web0 ol-web1 ol-web1 ol-www0"}
+SERVERS=${SERVERS:-"ol-web0 ol-web1 ol-web2"}
 PROXY="http://http-proxy.us.archive.org:8080"
+APPLY_OPTIONS=${APPLY_OPTIONS:-""}
+
+echo "Applying patch #${PR_NUMBER} to ${SERVERS}:"
 
 for host in $SERVERS; do
-    echo "Applying patch on ${host}.us.archive.org..."
-
-    # Determine container name based on host
+    # Determine default container name based on host
     if [[ "$host" == "ol-www0" ]]; then
-        CONTAINER="openlibrary-web_nginx-1"
-        ssh -T "${host}.us.archive.org" <<EOF
-        set-e  # Exit immediately if any command fails
-
-        cd /opt/openlibrary
-        export HTTPS_PROXY=${PROXY}
-
-        if curl -sSL --compressed "${PATCH_URL}" | tee >(cat) | tee >(git apply --check) | git apply; then
-          echo "Patch is applicable, applying..."
-          echo "Patch applied successfully, restarting ${CONTAINER} on ${host}."
-          docker restart ${CONTAINER}
+        CONTAINER=${CONTAINER:-"openlibrary-web_nginx-1"}
+        if [[ "$CONTAINER" == "openlibrary-web_nginx-1" ]]; then
+            # If deploying nginx configs, must apply only to host
+            PATCH_ON=${PATCH_ON:-host}
         else
-          echo "Patch already applied or not applicable cleanly — skipping patch on ${host}."
+            PATCH_ON=${PATCH_ON:-container}
         fi
-EOF
     else
-        CONTAINER="openlibrary-web-1"
-        ssh ${host}.us.archive.org <<EOF
-        set -e  # Exit immediately if any command fails
-        PATCH_CMD='docker exec -i ${container} openlibrary-web-1 bash -c "HTTPS_PROXY=${PROXY} curl -sS ${PATCH_URL} | git apply"'
-        if eval "\$PATCH_CMD"; then
-            echo "Patch applied successfully on ${host}, restarting container..."
-            docker restart ${CONTAINER}
-        else
-            echo "Failed to apply patch on ${host}. Exiting..."
-            exit 1
-        fi
-EOF
+        PATCH_ON=${PATCH_ON:-container}
+        CONTAINER=${CONTAINER:-"openlibrary-web-1"}
     fi
 
-    echo "# ================="
-    echo "# FINISHING ${host}"
-    echo "# ================="
+    TMP_OUTPUT_FILE=$(mktemp)
+    STATUS=0
+    if [ "$PATCH_ON" == "host" ]; then
+        echo -n "  $host ... "
+        ssh ${host}.us.archive.org "
+            set -e
+            cd /opt/openlibrary
+            HTTPS_PROXY=${PROXY} curl -sL "${PATCH_URL}" | git apply $APPLY_OPTIONS
+        " > $TMP_OUTPUT_FILE
+        STATUS=$?
+    else
+        echo -n "  $host $CONTAINER ... "
+        ssh ${host}.us.archive.org "
+            docker exec ${CONTAINER} bash -c '
+                HTTPS_PROXY=${PROXY} curl -sL ${PATCH_URL} | git apply $APPLY_OPTIONS
+            ' 2>&1
+        " > $TMP_OUTPUT_FILE
+        STATUS=$?
+    fi
 
+    if [ $STATUS -eq 0 ]; then
+        rm $TMP_OUTPUT_FILE
+
+        echo -n '✓. Restarting ... '
+        ssh ${host}.us.archive.org "docker restart ${CONTAINER} 2>&1" > $TMP_OUTPUT_FILE
+        if [ $? -eq 0 ]; then
+            echo '✓'
+            rm $TMP_OUTPUT_FILE
+        else
+            echo '✗'
+            cat $TMP_OUTPUT_FILE
+            rm $TMP_OUTPUT_FILE
+            exit 1
+        fi
+    else
+        echo '✗ (Skipping)'
+        cat $TMP_OUTPUT_FILE
+        rm $TMP_OUTPUT_FILE
+    fi
 done
-
-echo "Patch successfully applied on all web nodes."


### PR DESCRIPTION
While patch deploying #10980 , needed an option to patch deploy to the monitoring container. Added that option, and dried the script to have output more like our other deploy script.

Also added an option APPLY_OPTIONS to let use un-apply a patch easily.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

```
$ CONTAINER="openlibrary-monitoring-1" ./scripts/deployment/patchdeploy.sh 10987
Note: Patch Deploys cannot rebuild js/css

Applying patch #10987 to ol-web0 ol-web1 ol-web2:
  ol-web0 openlibrary-monitoring-1 ... ✓. Restarting ... ✓
  ol-web1 openlibrary-monitoring-1 ... ✓. Restarting ... ✓
  ol-web2 openlibrary-monitoring-1 ... ✓. Restarting ... ✓
Patch successfully applied on all web nodes.
```

Or if there's an error:

```
$ APPLY_OPTIONS="-R" SERVERS="ol-web0 ol-web1" CONTAINER="openlibrary-monitoring-1" ./scripts/deployment/patchdeploy.sh 10987
Note: Patch Deploys cannot rebuild js/css

Applying patch #10987 to ol-web0 ol-web1:
  ol-web0 openlibrary-monitoring-1 ... ✓. Restarting ... ✓
  ol-web1 openlibrary-monitoring-1 ... ✗ (Skipping)
error: patch failed: openlibrary/templates/account/create.html:90
error: openlibrary/templates/account/create.html: patch does not apply
error: patch failed: openlibrary/plugins/openlibrary/js/ia_thirdparty_logins.js:23
error: openlibrary/plugins/openlibrary/js/ia_thirdparty_logins.js: patch does not apply
```

Haven't tested with the nginx flow but will test when I patch deploy #10988 on Monday.

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
