### PR TITLE
fix makefile for arm machines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,6 @@ ACCESS_LOG_FORMAT='%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s"'
 COMPONENTS_DIR=openlibrary/components
 OSP_DUMP_LOCATION=/solr-updater-data/osp_totals.db
 
-# Use python from local env if it exists or else default to python in the path.
-PYTHON=$(if $(wildcard env),env/bin/python,python)
 
 .PHONY: all clean distclean git css js components i18n lint
 
@@ -36,7 +34,7 @@ components:
 
 
 i18n:
-	$(PYTHON) ./scripts/i18n-messages compile
+	python ./scripts/i18n-messages compile
 
 git:
 	git submodule init
@@ -50,10 +48,6 @@ distclean:
 	git clean -fdx
 	git submodule foreach git clean -fdx
 
-load_sample_data:
-	@echo "loading sample docs from openlibrary.org website"
-	$(PYTHON) scripts/copydocs.py --list /people/anand/lists/OL1815L
-	curl http://localhost:8080/_dev/process_ebooks # hack to show books in returncart
 
 reindex-solr:
     # Keep link in sync with ol-solr-updater-start and Jenkinsfile
@@ -67,14 +61,14 @@ reindex-solr:
 
 lint:
 	# See the pyproject.toml file for ruff's settings
-	$(PYTHON) -m ruff --no-cache .
+	python -m ruff check .
 
 test-py:
 	pytest . --ignore=infogami --ignore=vendor --ignore=node_modules
 
 test-i18n:
 	# Valid locale codes should be added as arguments to validate
-	$(PYTHON) ./scripts/i18n-messages validate de es fr hr it ja zh
+	python ./scripts/i18n-messages validate de es fr hr it ja zh
 
 test:
 	make test-py && npm run test && make test-i18n


### PR DESCRIPTION
<!-- What issue does this PR close? -->
`docker build -f docker/Dockerfile.olbase -t openlibrary/olbase:latest .` was failing only on arm machines.

Removing this legacy python info in the makefile fixed it.

Also removed the old load prod data command because we recommend running it in docker now.

https://docs.openlibrary.org/2_Developers/misc/Loading-Production-Book-Data.html#loading-production-data-into-local-developer-environment

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
