### PR TITLE
add safe typehints from autotyping

### DIFF
--- a/openlibrary/accounts/__init__.py
+++ b/openlibrary/accounts/__init__.py
@@ -1,3 +1,4 @@
+from types import TracebackType
 from typing import TYPE_CHECKING
 
 import web
@@ -44,7 +45,12 @@ class RunAs:
         web.ctx.conn.set_auth_token(self.tmp_account.generate_login_code())
         return self.tmp_account
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         # Return auth token to original user or no-user
         web.ctx.conn.set_auth_token(self.calling_user_auth_token)
 
@@ -92,17 +98,17 @@ def find(
     return doc and Account(doc)
 
 
-def register(username, email, password, displayname):
+def register(username, email, password, displayname) -> None:
     web.ctx.site.register(
         username=username, email=email, password=password, displayname=displayname
     )
 
 
-def login(username, password):
+def login(username, password) -> None:
     web.ctx.site.login(username, password)
 
 
-def update_account(username, **kargs):
+def update_account(username, **kargs) -> None:
     web.ctx.site.update_account(username, **kargs)
 
 

--- a/openlibrary/actions.py
+++ b/openlibrary/actions.py
@@ -6,7 +6,7 @@ import infogami
 
 
 @infogami.action
-def runmain(modulename, *args):
+def runmain(modulename, *args) -> None:
     print("run_main", modulename, sys.argv)
     mod = __import__(modulename, globals(), locals(), modulename.split("."))
     mod.main(*args)

--- a/openlibrary/admin/code.py
+++ b/openlibrary/admin/code.py
@@ -26,7 +26,7 @@ class static(app.page):  # type: ignore[name-defined]
         raise web.seeother("/static/upstream" + path)
 
 
-def setup():
+def setup() -> None:
     # load templates from this package so that they are available via render_template
     from infogami.utils import template
 

--- a/openlibrary/admin/numbers.py
+++ b/openlibrary/admin/numbers.py
@@ -161,7 +161,7 @@ def admin_total__authors(**kargs):
     return _count_things(db, "/type/author")
 
 
-def admin_total__subjects(**kargs):
+def admin_total__subjects(**kargs) -> int:
     # Anand - Dec 2014 - TODO
     # Earlier implementation that uses couchdb is gone now
     return 0
@@ -235,13 +235,13 @@ def admin_total__members(**kargs):
     return _count_things(db, '/type/user')
 
 
-def admin_delta__ebooks(**kargs):
+def admin_delta__ebooks(**kargs) -> int:
     # Anand - Dec 2014 - TODO
     # Earlier implementation that uses couchdb is gone now
     return 0
 
 
-def admin_delta__subjects(**kargs):
+def admin_delta__subjects(**kargs) -> int:
     # Anand - Dec 2014 - TODO
     # Earlier implementation that uses couchdb is gone now
     return 0

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -93,50 +93,50 @@ type_map = {
 
 
 class CoverNotSaved(Exception):
-    def __init__(self, f):
+    def __init__(self, f) -> None:
         self.f = f
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"coverstore responded with: '{self.f}'"
 
 
 class RequiredFields(Exception):
-    def __init__(self, fields: Iterable[str]):
+    def __init__(self, fields: Iterable[str]) -> None:
         self.fields = fields
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"missing required field(s): {self.fields}"
 
 
 class PublicationYearTooOld(Exception):
-    def __init__(self, year):
+    def __init__(self, year) -> None:
         self.year = year
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"publication year is too old (i.e. earlier than {EARLIEST_PUBLISH_YEAR_FOR_BOOKSELLERS}): {self.year}"
 
 
 class PublishedInFutureYear(Exception):
-    def __init__(self, year):
+    def __init__(self, year) -> None:
         self.year = year
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"published in future year: {self.year}"
 
 
 class IndependentlyPublished(Exception):
-    def __init__(self):
+    def __init__(self) -> None:
         pass
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "book is independently published"
 
 
 class SourceNeedsISBN(Exception):
-    def __init__(self):
+    def __init__(self) -> None:
         pass
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "this source needs an ISBN"
 
 
@@ -354,7 +354,7 @@ def modify_ia_item(item, data):
     return item.modify_metadata(data, access_key=access_key, secret_key=secret_key)
 
 
-def create_ol_subjects_for_ocaid(ocaid, subjects):
+def create_ol_subjects_for_ocaid(ocaid, subjects) -> str:
     item = get_ia_item(ocaid)
     openlibrary_subjects = copy(item.metadata.get('openlibrary_subject')) or []
 
@@ -1093,7 +1093,7 @@ def load(
     return reply
 
 
-def setup():
+def setup() -> None:
     setup_requests()
 
 

--- a/openlibrary/catalog/add_book/tests/conftest.py
+++ b/openlibrary/catalog/add_book/tests/conftest.py
@@ -4,7 +4,7 @@ from openlibrary.plugins.upstream.utils import convert_iso_to_marc, get_language
 
 
 @pytest.fixture
-def add_languages(mock_site):
+def add_languages(mock_site) -> None:
     # A lot of these are cached in the utils module with functools.cache,
     # so wipe that cache out first.
     get_languages.cache_clear()

--- a/openlibrary/catalog/add_book/tests/test_add_book.py
+++ b/openlibrary/catalog/add_book/tests/test_add_book.py
@@ -36,12 +36,12 @@ def open_test_data(filename):
 
 
 @pytest.fixture
-def ia_writeback(monkeypatch):
+def ia_writeback(monkeypatch) -> None:
     """Prevent ia writeback from making live requests."""
     monkeypatch.setattr(add_book, 'update_ia_metadata_for_ol_edition', lambda olid: {})
 
 
-def test_isbns_from_record():
+def test_isbns_from_record() -> None:
     rec = {'title': 'test', 'isbn_13': ['9780190906764'], 'isbn_10': ['0190906766']}
     result = isbns_from_record(rec)
     assert isinstance(result, list)
@@ -96,11 +96,11 @@ bookseller_titles = [
 
 
 @pytest.mark.parametrize(('full_title', 'title', 'subtitle'), bookseller_titles)
-def test_split_subtitle(full_title, title, subtitle):
+def test_split_subtitle(full_title, title, subtitle) -> None:
     assert split_subtitle(full_title) == (title, subtitle)
 
 
-def test_editions_matched_no_results(mock_site):
+def test_editions_matched_no_results(mock_site) -> None:
     rec = {'title': 'test', 'isbn_13': ['9780190906764'], 'isbn_10': ['0190906766']}
     isbns = isbns_from_record(rec)
     result = editions_matched(rec, 'isbn_', isbns)
@@ -108,7 +108,7 @@ def test_editions_matched_no_results(mock_site):
     assert result == []
 
 
-def test_editions_matched(mock_site, add_languages, ia_writeback):
+def test_editions_matched(mock_site, add_languages, ia_writeback) -> None:
     rec = {
         'title': 'test',
         'isbn_13': ['9780190906764'],
@@ -129,7 +129,7 @@ def test_editions_matched(mock_site, add_languages, ia_writeback):
     assert result == ['/books/OL1M']
 
 
-def test_force_new_wikisource_edition(mock_site, add_languages, ia_writeback):
+def test_force_new_wikisource_edition(mock_site, add_languages, ia_writeback) -> None:
     rec = {
         'title': 'test an import that is not from wikisource',
         'isbn_10': ['0190906767'],
@@ -150,7 +150,7 @@ def test_force_new_wikisource_edition(mock_site, add_languages, ia_writeback):
     assert pool == {}
 
 
-def test_match_wikisource_edition(mock_site, add_languages, ia_writeback):
+def test_match_wikisource_edition(mock_site, add_languages, ia_writeback) -> None:
     rec = {
         'title': 'test an import that already has a wikisource identifier',
         'isbn_10': ['0190906768'],
@@ -171,12 +171,12 @@ def test_match_wikisource_edition(mock_site, add_languages, ia_writeback):
     assert result == ['/books/OL1M']
 
 
-def test_load_without_required_field():
+def test_load_without_required_field() -> None:
     rec = {'ocaid': 'test item'}
     pytest.raises(RequiredFields, load, {'ocaid': 'test_item'})
 
 
-def test_load_test_item(mock_site, add_languages, ia_writeback):
+def test_load_test_item(mock_site, add_languages, ia_writeback) -> None:
     rec = {
         'ocaid': 'test_item',
         'source_records': ['ia:test_item'],
@@ -201,7 +201,7 @@ def test_load_test_item(mock_site, add_languages, ia_writeback):
     assert w.type.key == '/type/work'
 
 
-def test_load_deduplicates_authors(mock_site, add_languages, ia_writeback):
+def test_load_deduplicates_authors(mock_site, add_languages, ia_writeback) -> None:
     """
     Testings that authors are deduplicated before being added
     This will only work if all the author dicts are identical
@@ -220,7 +220,7 @@ def test_load_deduplicates_authors(mock_site, add_languages, ia_writeback):
     assert len(reply['authors']) == 1
 
 
-def test_load_with_subjects(mock_site, ia_writeback):
+def test_load_with_subjects(mock_site, ia_writeback) -> None:
     rec = {
         'ocaid': 'test_item',
         'title': 'Test item',
@@ -234,7 +234,7 @@ def test_load_with_subjects(mock_site, ia_writeback):
     assert w.subjects == ['Protected DAISY', 'In library']
 
 
-def test_load_with_new_author(mock_site, ia_writeback):
+def test_load_with_new_author(mock_site, ia_writeback) -> None:
     rec = {
         'ocaid': 'test_item',
         'title': 'Test item',
@@ -296,7 +296,7 @@ def test_load_with_new_author(mock_site, ia_writeback):
     assert len(e.authors) == 1
 
 
-def test_load_with_redirected_author(mock_site, add_languages):
+def test_load_with_redirected_author(mock_site, add_languages) -> None:
     """Test importing existing editions without works
     which have author redirects. A work should be created with
     the final author.
@@ -341,7 +341,7 @@ def test_load_with_redirected_author(mock_site, add_languages):
     assert w.authors[0].author.key == '/authors/OL10A'
 
 
-def test_duplicate_ia_book(mock_site, add_languages, ia_writeback):
+def test_duplicate_ia_book(mock_site, add_languages, ia_writeback) -> None:
     """
     Here all fields that are 'used' (i.e. read and contribute to the edition)
     are the same.
@@ -373,7 +373,7 @@ def test_duplicate_ia_book(mock_site, add_languages, ia_writeback):
 
 def test_matched_edition_with_new_language_in_rec_adds_language(
     mock_site, add_languages, ia_writeback
-):
+) -> None:
     """
     When records match, but the record has a new language, the new language
     should be added to the existing edition, but existing languages should
@@ -409,7 +409,7 @@ def test_matched_edition_with_new_language_in_rec_adds_language(
 
 def test_matched_edition_with_new_language_is_added_even_if_no_existing_language(
     mock_site, add_languages, ia_writeback
-):
+) -> None:
     """
     Ensure a new language is added even if the existing edition has no language
     field.
@@ -443,7 +443,7 @@ def test_matched_edition_with_new_language_is_added_even_if_no_existing_language
 
 def test_matched_edition_properly_updates_non_language_fields(
     mock_site, add_languages, ia_writeback
-):
+) -> None:
     """
     Ensure a new language is added even if the existing edition has no language
     field.
@@ -479,7 +479,7 @@ def test_matched_edition_properly_updates_non_language_fields(
 
 
 class Test_From_MARC:
-    def test_from_marc_author(self, mock_site, add_languages):
+    def test_from_marc_author(self, mock_site, add_languages) -> None:
         ia = 'flatlandromanceo00abbouoft'
         marc = MarcBinary(open_test_data(ia + '_meta.mrc').read())
 
@@ -505,7 +505,7 @@ class Test_From_MARC:
             'treatiseonhistor00dixo',
         ),
     )
-    def test_from_marc(self, ia, mock_site, add_languages):
+    def test_from_marc(self, ia, mock_site, add_languages) -> None:
         data = open_test_data(ia + '_meta.mrc').read()
         assert len(data) == int(data[:5])
         rec = read_edition(MarcBinary(data))
@@ -519,7 +519,7 @@ class Test_From_MARC:
         assert reply['success'] is True
         assert reply['edition']['status'] == 'matched'
 
-    def test_author_from_700(self, mock_site, add_languages):
+    def test_author_from_700(self, mock_site, add_languages) -> None:
         ia = 'sexuallytransmit00egen'
         data = open_test_data(ia + '_meta.mrc').read()
         rec = read_edition(MarcBinary(data))
@@ -533,7 +533,7 @@ class Test_From_MARC:
         assert a.name == 'Laura K. Egendorf'
         assert a.birth_date == '1973'
 
-    def test_editior_role_from_700(self, mock_site, add_languages):
+    def test_editior_role_from_700(self, mock_site, add_languages) -> None:
         marc = '../../../marc/tests/test_data/bin_input/ithaca_college_75002321.mrc'
         data = open_test_data(marc).read()
         rec = read_edition(MarcBinary(data))
@@ -559,7 +559,7 @@ class Test_From_MARC:
         # Last has no role specified, general "author"
         assert isinstance(roles[2], Nothing)
 
-    def test_from_marc_reimport_modifications(self, mock_site, add_languages):
+    def test_from_marc_reimport_modifications(self, mock_site, add_languages) -> None:
         src = 'v38.i37.records.utf8--16478504-1254'
         marc = MarcBinary(open_test_data(src).read())
         rec = read_edition(marc)
@@ -578,7 +578,7 @@ class Test_From_MARC:
         assert reply['success'] is True
         assert reply['edition']['status'] == 'modified'
 
-    def test_missing_ocaid(self, mock_site, add_languages, ia_writeback):
+    def test_missing_ocaid(self, mock_site, add_languages, ia_writeback) -> None:
         ia = 'descendantsofhug00cham'
         src = ia + '_meta.mrc'
         marc = MarcBinary(open_test_data(src).read())
@@ -594,7 +594,7 @@ class Test_From_MARC:
         assert e.ocaid == ia
         assert 'ia:' + ia in e.source_records
 
-    def test_from_marc_fields(self, mock_site, add_languages):
+    def test_from_marc_fields(self, mock_site, add_languages) -> None:
         ia = 'isbn_9781419594069'
         data = open_test_data(ia + '_meta.mrc').read()
         rec = read_edition(MarcBinary(data))
@@ -639,7 +639,7 @@ class Test_From_MARC:
         assert work['description'] == desc
 
 
-def test_build_pool(mock_site):
+def test_build_pool(mock_site) -> None:
     assert build_pool({'title': 'test'}) == {}
     etype = '/type/edition'
     ekey = mock_site.new_key(etype)
@@ -676,7 +676,7 @@ def test_build_pool(mock_site):
     }
 
 
-def test_load_multiple(mock_site):
+def test_load_multiple(mock_site) -> None:
     rec = {
         'title': 'Test item',
         'lccn': ['123'],
@@ -706,7 +706,7 @@ def test_load_multiple(mock_site):
     assert ekey1 == ekey2 == ekey4
 
 
-def test_extra_author(mock_site, add_languages):
+def test_extra_author(mock_site, add_languages) -> None:
     mock_site.save(
         {
             "name": "Hubert Howe Bancroft",
@@ -863,7 +863,7 @@ def test_extra_author(mock_site, add_languages):
     assert len(w['authors']) == 1
 
 
-def test_missing_source_records(mock_site, add_languages):
+def test_missing_source_records(mock_site, add_languages) -> None:
     mock_site.save(
         {
             'key': '/authors/OL592898A',
@@ -938,7 +938,7 @@ def test_missing_source_records(mock_site, add_languages):
     assert 'source_records' in e
 
 
-def test_no_extra_author(mock_site, add_languages):
+def test_no_extra_author(mock_site, add_languages) -> None:
     author = {
         "name": "Paul Michael Boothe",
         "key": "/authors/OL1A",
@@ -1009,7 +1009,7 @@ def test_no_extra_author(mock_site, add_languages):
     assert len(w['authors']) == 1
 
 
-def test_same_twice(mock_site, add_languages):
+def test_same_twice(mock_site, add_languages) -> None:
     rec = {
         'source_records': ['ia:test_item'],
         "publishers": ["Ten Speed Press"],
@@ -1043,7 +1043,7 @@ def test_same_twice(mock_site, add_languages):
     assert reply['work']['status'] == 'matched'
 
 
-def test_existing_work(mock_site, add_languages):
+def test_existing_work(mock_site, add_languages) -> None:
     author = {
         'type': {'key': '/type/author'},
         'name': 'John Smith',
@@ -1076,7 +1076,7 @@ def test_existing_work(mock_site, add_languages):
     assert e.works[0]['key'] == '/works/OL16W'
 
 
-def test_existing_work_with_subtitle(mock_site, add_languages):
+def test_existing_work_with_subtitle(mock_site, add_languages) -> None:
     author = {
         'type': {'key': '/type/author'},
         'name': 'John Smith',
@@ -1803,7 +1803,7 @@ class TestNormalizeImportRecord:
             ("9999-01-01", False),
         ],
     )
-    def test_future_publication_dates_are_deleted(self, year, expected):
+    def test_future_publication_dates_are_deleted(self, year, expected) -> None:
         """It should be impossible to import books publish_date in a future year."""
         rec = {
             'title': 'test book',
@@ -1850,7 +1850,7 @@ class TestNormalizeImportRecord:
             ),
         ],
     )
-    def test_dummy_data_to_satisfy_parse_data_is_removed(self, rec, expected):
+    def test_dummy_data_to_satisfy_parse_data_is_removed(self, rec, expected) -> None:
         normalize_import_record(rec=rec)
         assert rec == expected
 
@@ -1973,7 +1973,9 @@ class TestNormalizeImportRecord:
             ),
         ],
     )
-    def test_year_1900_removed_from_amz_and_bwb_promise_items(self, rec, expected):
+    def test_year_1900_removed_from_amz_and_bwb_promise_items(
+        self, rec, expected
+    ) -> None:
         """
         A few import sources (e.g. promise items, BWB, and Amazon) have `publish_date`
         values that are known to be inaccurate, so those `publish_date` values are
@@ -1983,7 +1985,7 @@ class TestNormalizeImportRecord:
         assert rec == expected
 
 
-def test_find_match_title_only_promiseitem_against_noisbn_marc(mock_site):
+def test_find_match_title_only_promiseitem_against_noisbn_marc(mock_site) -> None:
     # An existing light title + ISBN only record should not match an
     # incoming pre-ISBN record.
     existing_edition = {

--- a/openlibrary/catalog/marc/html.py
+++ b/openlibrary/catalog/marc/html.py
@@ -19,7 +19,7 @@ def subfields(line):
 
 
 class html_record:
-    def __init__(self, data):
+    def __init__(self, data) -> None:
         assert len(data) == int(data[:5])
         self.data = data
         self.record = Record(data)

--- a/openlibrary/catalog/marc/tests/test_get_subjects.py
+++ b/openlibrary/catalog/marc/tests/test_get_subjects.py
@@ -242,7 +242,7 @@ TEST_DATA = Path(__file__).with_name('test_data')
 
 class TestSubjects:
     @pytest.mark.parametrize(('item', 'expected'), xml_samples)
-    def test_subjects_xml(self, item, expected):
+    def test_subjects_xml(self, item, expected) -> None:
         filepath = TEST_DATA / 'xml_input' / f'{item}_marc.xml'
         element = etree.parse(
             filepath, parser=lxml.etree.XMLParser(resolve_entities=False)
@@ -253,17 +253,17 @@ class TestSubjects:
         assert read_subjects(rec) == expected
 
     @pytest.mark.parametrize(('item', 'expected'), bin_samples)
-    def test_subjects_bin(self, item, expected):
+    def test_subjects_bin(self, item, expected) -> None:
         filepath = TEST_DATA / 'bin_input' / item
         rec = MarcBinary(filepath.read_bytes())
         assert read_subjects(rec) == expected
 
-    def test_four_types_combine(self):
+    def test_four_types_combine(self) -> None:
         subjects = {'subject': {'Science': 2}, 'event': {'Party': 1}}
         expect = {'subject': {'Science': 2, 'Party': 1}}
         assert four_types(subjects) == expect
 
-    def test_four_types_event(self):
+    def test_four_types_event(self) -> None:
         subjects = {'event': {'Party': 1}}
         expect = {'subject': {'Party': 1}}
         assert four_types(subjects) == expect

--- a/openlibrary/catalog/marc/tests/test_marc_html.py
+++ b/openlibrary/catalog/marc/tests/test_marc_html.py
@@ -5,7 +5,7 @@ from openlibrary.catalog.marc.html import html_record
 TEST_DATA = Path(__file__).with_name('test_data') / 'bin_input'
 
 
-def test_html_line_marc8():
+def test_html_line_marc8() -> None:
     filepath = TEST_DATA / 'uoft_4351105_1626.mrc'
     expected_utf8 = (
         '<b>700</b> <code>1  <b>$a</b>Ovsi︠a︡nnikov, Mikhail Fedotovich.</code><br>'

--- a/openlibrary/catalog/marc/tests/test_mnemonics.py
+++ b/openlibrary/catalog/marc/tests/test_mnemonics.py
@@ -1,7 +1,7 @@
 from openlibrary.catalog.marc.mnemonics import read
 
 
-def test_read_conversion_to_marc8():
+def test_read_conversion_to_marc8() -> None:
     input_ = b'Tha{mllhring}{macr}alib{macr}i, {mllhring}Abd al-Malik ibn Mu{dotb}hammad,'  # codespell:ignore
     output = (
         b'Tha\xb0\xe5alib\xe5i, \xb0Abd al-Malik ibn Mu\xf2hammad,'  # codespell:ignore
@@ -9,6 +9,6 @@ def test_read_conversion_to_marc8():
     assert read(input_) == output
 
 
-def test_read_no_change():
+def test_read_no_change() -> None:
     input_ = b'El Ing.{eniero} Federico E. Capurro y el nacimiento de la profesi\xe2on bibliotecaria en el Uruguay.'
     assert read(input_) == input_

--- a/openlibrary/catalog/utils/__init__.py
+++ b/openlibrary/catalog/utils/__init__.py
@@ -447,10 +447,10 @@ def get_missing_fields(rec: dict) -> list[str]:
 
 
 class InvalidLanguage(Exception):
-    def __init__(self, code):
+    def __init__(self, code) -> None:
         self.code = code
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"invalid language code: '{self.code}'"
 
 

--- a/openlibrary/catalog/utils/edit.py
+++ b/openlibrary/catalog/utils/edit.py
@@ -41,7 +41,7 @@ def has_dot(s):
     return s.endswith('.') and not re_skip.search(s)
 
 
-def fix_toc(e):
+def fix_toc(e) -> None:
     toc = e.get('table_of_contents', None)
     if not toc:
         return
@@ -53,13 +53,13 @@ def fix_toc(e):
     e['table_of_contents'] = new_toc
 
 
-def fix_subject(e):
+def fix_subject(e) -> None:
     if e.get('subjects', None) and any(has_dot(s) for s in e['subjects']):
         subjects = [s[:-1] if has_dot(s) else s for s in e['subjects']]
         e['subjects'] = subjects
 
 
-def undelete_author(a, ol):
+def undelete_author(a, ol) -> None:
     key = a['key']
     assert a['type'] == '/type/delete'
     url = 'http://openlibrary.org' + key + '.json?v=' + str(a['revision'] - 1)
@@ -68,7 +68,7 @@ def undelete_author(a, ol):
     ol.save(key, prev, 'undelete author')
 
 
-def undelete_authors(authors, ol):
+def undelete_authors(authors, ol) -> None:
     for a in authors:
         if a['type'] == '/type/delete':
             undelete_author(a, ol)
@@ -76,7 +76,7 @@ def undelete_authors(authors, ol):
             assert a['type'] == '/type/author'
 
 
-def fix_authors(e, ol):
+def fix_authors(e, ol) -> None:
     if 'authors' not in e:
         return
     authors = [get_with_retry(ol, akey) for akey in e['authors']]

--- a/openlibrary/catalog/utils/query.py
+++ b/openlibrary/catalog/utils/query.py
@@ -25,7 +25,7 @@ def urlread(url):
     return urlopen(url).content
 
 
-def set_query_host(host):
+def set_query_host(host) -> None:
     global query_host
     query_host = host
 

--- a/openlibrary/code.py
+++ b/openlibrary/code.py
@@ -23,7 +23,7 @@ old_plugins = [
 ]
 
 
-def setup():
+def setup() -> None:
     setup_logging()
 
     logger = logging.getLogger("openlibrary")
@@ -62,7 +62,7 @@ def setup_logging():
         raise
 
 
-def load_views():
+def load_views() -> None:
     """Registers all views by loading all view modules."""
     from .views import showmarc  # noqa: F401 side effects may be needed
 

--- a/openlibrary/conftest.py
+++ b/openlibrary/conftest.py
@@ -18,7 +18,7 @@ from openlibrary.mocks.mock_memcache import (
 
 
 @pytest.fixture(autouse=True)
-def no_requests(monkeypatch):
+def no_requests(monkeypatch) -> None:
     def mock_request(*args, **kwargs):
         raise Warning('Network requests are blocked in the testing environment')
 
@@ -26,7 +26,7 @@ def no_requests(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def no_sleep(monkeypatch):
+def no_sleep(monkeypatch) -> None:
     def mock_sleep(*args, **kwargs):
         raise Warning(
             '''
@@ -47,13 +47,13 @@ def no_sleep(monkeypatch):
 
 
 @pytest.fixture
-def monkeytime(monkeypatch):
+def monkeytime(monkeypatch) -> None:
     cur_time = 1
 
     def time():
         return cur_time
 
-    def sleep(secs):
+    def sleep(secs) -> None:
         nonlocal cur_time
         cur_time += secs
 

--- a/openlibrary/core/admin.py
+++ b/openlibrary/core/admin.py
@@ -11,7 +11,7 @@ from openlibrary.core import cache
 
 
 class Stats:
-    def __init__(self, docs, key, total_key):
+    def __init__(self, docs, key, total_key) -> None:
         self.key = key
         self.docs = docs
         try:

--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -150,7 +150,7 @@ def get_item_status(itemid, metadata, **server):
 class ItemEdition(dict):
     """Class to convert item metadata into edition dict."""
 
-    def __init__(self, itemid):
+    def __init__(self, itemid) -> None:
         dict.__init__(self)
         self.itemid = itemid
 
@@ -169,7 +169,7 @@ class ItemEdition(dict):
         )
 
     @classmethod
-    def get_item_status(cls, itemid, metadata, item_server=None, item_path=None):
+    def get_item_status(cls, itemid, metadata, item_server=None, item_path=None) -> str:
         """Returns the status of the item related to importing it in OL.
 
         Possible return values are:
@@ -233,7 +233,7 @@ class ItemEdition(dict):
         """
         return cls.get_item_status(itemid, metadata) == 'ok'
 
-    def add_metadata(self, metadata):
+    def add_metadata(self, metadata) -> None:
         self.metadata = metadata
         self.add('title')
         self.add('description', 'description')
@@ -242,7 +242,7 @@ class ItemEdition(dict):
         self.add('date', 'publish_date')
         self.add_isbns()
 
-    def add(self, key, key2=None):
+    def add(self, key, key2=None) -> None:
         metadata = self.metadata
 
         key2 = key2 or key
@@ -260,7 +260,7 @@ class ItemEdition(dict):
 
             self[key2] = value
 
-    def add_list(self, key, key2):
+    def add_list(self, key, key2) -> None:
         metadata = self.metadata
 
         key2 = key2 or key
@@ -269,7 +269,7 @@ class ItemEdition(dict):
                 value = [value]
             self[key2] = value
 
-    def add_isbns(self):
+    def add_isbns(self) -> None:
         isbn_10 = []
         isbn_13 = []
         if isbns := self.metadata.get('isbn'):

--- a/openlibrary/core/imports.py
+++ b/openlibrary/core/imports.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 class Batch(web.storage):
 
-    def __init__(self, mapping, *requires, **defaults):
+    def __init__(self, mapping, *requires, **defaults) -> None:
         """
         Initialize some statistics instance attributes yet retain web.storage's __init__ method.
         """
@@ -52,7 +52,7 @@ class Batch(web.storage):
         db.insert("import_batch", name=name, submitter=submitter)
         return Batch.find(name=name)
 
-    def load_items(self, filename):
+    def load_items(self, filename) -> None:
         """Adds all the items specified in the filename to this batch."""
         with open(filename) as file:
             items = [line.strip() for line in file if line.strip()]
@@ -254,7 +254,7 @@ class ImportItem(web.storage):
     @staticmethod
     def bulk_mark_pending(
         identifiers: list[str], sources: Iterable[str] = STAGED_SOURCES
-    ):
+    ) -> None:
         """
         Given a list of ISBNs, creates list of `ia_ids` and queries the import_item
         table the `ia_ids`.
@@ -274,7 +274,7 @@ class ImportItem(web.storage):
         )
         db.query(query, vars={'ia_ids': ia_ids})
 
-    def set_status(self, status, error=None, ol_key=None):
+    def set_status(self, status, error=None, ol_key=None) -> None:
         id_ = self.ia_id or f"{self.batch_id}:{self.id}"
         logger.info("set-status %s - %s %s %s", id_, status, error, ol_key)
         d = {
@@ -288,16 +288,16 @@ class ImportItem(web.storage):
         db.update("import_item", where="id=$id", vars=self, **d)
         self.update(d)
 
-    def mark_failed(self, error):
+    def mark_failed(self, error) -> None:
         self.set_status(status='failed', error=error)
 
-    def mark_found(self, ol_key):
+    def mark_found(self, ol_key) -> None:
         self.set_status(status='found', ol_key=ol_key)
 
-    def mark_created(self, ol_key):
+    def mark_created(self, ol_key) -> None:
         self.set_status(status='created', ol_key=ol_key)
 
-    def mark_modified(self, ol_key):
+    def mark_modified(self, ol_key) -> None:
         self.set_status(status='modified', ol_key=ol_key)
 
     @classmethod

--- a/openlibrary/core/lists/model.py
+++ b/openlibrary/core/lists/model.py
@@ -103,7 +103,7 @@ class List(Thing):
 
     def add_seed(
         self, seed: ThingReferenceDict | AnnotatedSeedDict | SeedSubjectString
-    ):
+    ) -> bool:
         """Adds a new seed to this list."""
         seed_object = Seed.from_json(self, seed)
 
@@ -116,7 +116,7 @@ class List(Thing):
 
     def remove_seed(
         self, seed: ThingReferenceDict | AnnotatedSeedDict | SeedSubjectString
-    ):
+    ) -> bool:
         """Removes a seed for the list."""
         seed_key = Seed.from_json(self, seed).key
         if (index := self._index_of_seed(seed_key)) >= 0:
@@ -131,7 +131,7 @@ class List(Thing):
                 return i
         return -1
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<List: {self.key} ({self.name!r})>"
 
     def _get_seed_strings(self) -> list[SeedSubjectString | ThingKey]:
@@ -223,7 +223,7 @@ class List(Thing):
             a.author.key for w in works for a in w.get("authors", []) if "author" in a
         )
 
-    def load_changesets(self, editions):
+    def load_changesets(self, editions) -> None:
         """Adds "recent_changeset" to each edition.
 
         The recent_changeset will be of the form:
@@ -295,7 +295,7 @@ class List(Thing):
         return sorted(process_all(), reverse=True, key=lambda s: s["count"])
 
     def get_subjects(self, limit=20):
-        def get_subject_type(s):
+        def get_subject_type(s) -> str:
             if s.url.startswith("/subjects/place:"):
                 return "places"
             elif s.url.startswith("/subjects/person:"):
@@ -404,7 +404,7 @@ class Seed:
         self,
         list: List,
         value: Thing | SeedSubjectString | AnnotatedSeed,
-    ):
+    ) -> None:
         self._list = list
         self._type = None
 
@@ -592,7 +592,7 @@ class Seed:
             d['picture'] = {"url": cover.url("S")}
         return d
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<seed: {self.type} {self.key}>"
 
     __str__ = __repr__
@@ -619,6 +619,6 @@ class ListChangeset(Changeset):
         return Seed.from_db(self.get_list(), seed)
 
 
-def register_models():
+def register_models() -> None:
     client.register_thing_class('/type/list', List)
     client.register_changeset_class('lists', ListChangeset)

--- a/openlibrary/core/middleware.py
+++ b/openlibrary/core/middleware.py
@@ -9,7 +9,7 @@ import web
 class GZipMiddleware:
     """WSGI middleware to gzip the response."""
 
-    def __init__(self, app):
+    def __init__(self, app) -> None:
         self.app = app
 
     def __call__(self, environ, start_response):

--- a/openlibrary/core/olmarkdown.py
+++ b/openlibrary/core/olmarkdown.py
@@ -65,11 +65,11 @@ class OLMarkdown(markdown.Markdown):
     * generated HTML is sanitized
     """
 
-    def __init__(self, *a, **kw):
+    def __init__(self, *a, **kw) -> None:
         markdown.Markdown.__init__(self, *a, **kw)
         self._patch()
 
-    def _patch(self):
+    def _patch(self) -> None:
         patterns = self.inlinePatterns
         autolink = markdown.AutolinkPattern(
             markdown.AUTOLINK_RE.replace('http', 'https?')

--- a/openlibrary/core/processors/invalidation.py
+++ b/openlibrary/core/processors/invalidation.py
@@ -70,7 +70,7 @@ class InvalidationProcessor:
       process.
     """
 
-    def __init__(self, prefixes, timeout=60, cookie_name="lastupdate"):
+    def __init__(self, prefixes, timeout=60, cookie_name="lastupdate") -> None:
         self.prefixes = prefixes
         self.timeout = datetime.timedelta(0, timeout)
 
@@ -158,7 +158,7 @@ class _InvalidationHook:
     This sets a cookie when any of the documents under the given prefixes is modified.
     """
 
-    def __init__(self, prefixes, cookie_name, expire_time):
+    def __init__(self, prefixes, cookie_name, expire_time) -> None:
         self.prefixes = prefixes
         self.cookie_name = cookie_name
         self.expire_time = expire_time
@@ -166,7 +166,7 @@ class _InvalidationHook:
     def __call__(self):
         return self
 
-    def on_new_version(self, doc):
+    def on_new_version(self, doc) -> None:
         if web.ctx.get("_invalidation_inprogress"):
             # This event is triggered from invalidation. ignore it.
             return

--- a/openlibrary/core/processors/readableurls.py
+++ b/openlibrary/core/processors/readableurls.py
@@ -15,7 +15,7 @@ try:
     from booklending_utils.openlibrary import is_exclusion
 except ImportError:
 
-    def is_exclusion(obj):
+    def is_exclusion(obj) -> bool:
         """Processor for determining whether records require exclusion"""
         return False
 

--- a/openlibrary/core/schema.py
+++ b/openlibrary/core/schema.py
@@ -109,7 +109,7 @@ def get_schema():
     return schema
 
 
-def register_schema():
+def register_schema() -> None:
     """Register the schema defined in this module as the default schema."""
     dbstore.default_schema = get_schema()
 

--- a/openlibrary/core/sendmail.py
+++ b/openlibrary/core/sendmail.py
@@ -4,12 +4,12 @@ from infogami import config
 from infogami.utils.view import render_template
 
 
-def sendmail_with_template(template, to, cc=None, frm=None, **kwargs):
+def sendmail_with_template(template, to, cc=None, frm=None, **kwargs) -> None:
     msg = render_template(template, **kwargs)
     _sendmail(to, msg, cc=cc, frm=frm)
 
 
-def _sendmail(to, msg, cc=None, frm=None):
+def _sendmail(to, msg, cc=None, frm=None) -> None:
     cc = cc or []
     frm = frm or config.from_address
     if config.get('dummy_sendmail'):

--- a/openlibrary/core/stats.py
+++ b/openlibrary/core/stats.py
@@ -36,7 +36,7 @@ def create_stats_client(cfg=config):
         return False
 
 
-def put(key, value, rate=1.0):
+def put(key, value, rate=1.0) -> None:
     "Records this ``value`` with the given ``key``. It is stored as a millisecond count"
 
     if client:
@@ -44,7 +44,7 @@ def put(key, value, rate=1.0):
         client.timing(key, value, rate)
 
 
-def increment(key, n=1, rate=1.0):
+def increment(key, n=1, rate=1.0) -> None:
     "Increments the value of ``key`` by ``n``"
 
     if client:

--- a/openlibrary/core/statsdb.py
+++ b/openlibrary/core/statsdb.py
@@ -22,7 +22,7 @@ from .db import get_db
 logger = logging.getLogger("openlibrary.statsdb")
 
 
-def add_entry(key, data, timestamp=None):
+def add_entry(key, data, timestamp=None) -> None:
     """Adds a new entry to the stats table.
 
     If an entry is already present in the table, a warn message is logged
@@ -48,7 +48,7 @@ def get_entry(key):
         return result[0]
 
 
-def update_entry(key, data, timestamp=None):
+def update_entry(key, data, timestamp=None) -> None:
     """Updates an already existing entry in the stats table.
 
     If there is no entry with the given key, a new one will be added

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -41,7 +41,7 @@ AMAZON_FULL_DATE_RE = re.compile(r'\d{4}-\d\d-\d\d')
 ISBD_UNIT_PUNCT = ' : '  # ISBD cataloging title-unit separator punctuation
 
 
-def setup(config):
+def setup(config) -> None:
     global affiliate_server_url
     affiliate_server_url = config.get('affiliate_server')
 

--- a/openlibrary/coverstore/coverlib.py
+++ b/openlibrary/coverstore/coverlib.py
@@ -47,7 +47,7 @@ def save_image(data, category, olid, author=None, ip=None, source_url=None):
     return d
 
 
-def make_path_prefix(olid, date=None):
+def make_path_prefix(olid, date=None) -> str:
     """Makes a file prefix for storing an image."""
     date = date or datetime.date.today()
     return "%04d/%02d/%02d/%s-%s" % (

--- a/openlibrary/coverstore/disk.py
+++ b/openlibrary/coverstore/disk.py
@@ -26,7 +26,7 @@ class Disk:
     'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
     """
 
-    def __init__(self, root):
+    def __init__(self, root) -> None:
         self.root = root
         if not os.path.exists(root):
             os.makedirs(root)
@@ -61,7 +61,7 @@ class LayeredDisk:
     read happens on the first disk where the file is available.
     """
 
-    def __init__(self, disks):
+    def __init__(self, disks) -> None:
         self.disks = disks
 
     def read(self, filename):

--- a/openlibrary/coverstore/server.py
+++ b/openlibrary/coverstore/server.py
@@ -26,7 +26,7 @@ def runfcgi(func, addr=('localhost', 8000)):
 web.wsgi.runfcgi = runfcgi
 
 
-def load_config(configfile):
+def load_config(configfile) -> None:
     with open(configfile) as in_file:
         d = yaml.safe_load(in_file)
     for k, v in d.items():
@@ -44,7 +44,7 @@ def setup(configfile: str) -> None:
         sentry.bind_to_webpy_app(code.app)
 
 
-def main(configfile, *args):
+def main(configfile, *args) -> None:
     setup(configfile)
 
     if '--archive' in args:

--- a/openlibrary/coverstore/tests/test_archive.py
+++ b/openlibrary/coverstore/tests/test_archive.py
@@ -1,7 +1,7 @@
 from .. import archive
 
 
-def test_get_filename():
+def test_get_filename() -> None:
     # Basic usage
     assert archive.Batch.get_relpath("0008", "80") == "covers_0008/covers_0008_80"
 
@@ -32,9 +32,9 @@ def test_get_filename():
     )
 
 
-def test_get_batch_end_id():
+def test_get_batch_end_id() -> None:
     assert archive.CoverDB._get_batch_end_id(start_id=8820500) == 8830000
 
 
-def test_id_to_item_and_batch_id():
+def test_id_to_item_and_batch_id() -> None:
     assert archive.Cover.id_to_item_and_batch_id(987_654_321) == ('0987', '65')

--- a/openlibrary/coverstore/tests/test_doctests.py
+++ b/openlibrary/coverstore/tests/test_doctests.py
@@ -12,7 +12,7 @@ modules = [
 
 
 @pytest.mark.parametrize('module', modules)
-def test_doctest(module):
+def test_doctest(module) -> None:
     mod = __import__(module, None, None, ['x'])
     finder = doctest.DocTestFinder()
     tests = finder.find(mod, mod.__name__)

--- a/openlibrary/data/db.py
+++ b/openlibrary/data/db.py
@@ -42,7 +42,7 @@ db = None
 mc = None
 
 
-def setup_database(**db_params):
+def setup_database(**db_params) -> None:
     """Setup the database. This must be called before using any other functions in this module."""
     global db, db_parameters
     db_params.setdefault('dbn', 'postgres')
@@ -51,7 +51,7 @@ def setup_database(**db_params):
     db_parameters = db_params
 
 
-def setup_memcache(servers):
+def setup_memcache(servers) -> None:
     """Setup the memcached servers.
     This must be called along with setup_database, if memcached servers are used in the system.
     """
@@ -220,7 +220,7 @@ def update_docs(docs, comment, author, ip="127.0.0.1"):
         debug("MC SET")
 
 
-def debug(*a):
+def debug(*a) -> None:
     print(time.asctime(), a, file=sys.stderr)
 
 

--- a/openlibrary/data/mapreduce.py
+++ b/openlibrary/data/mapreduce.py
@@ -29,7 +29,7 @@ class Task:
     Each task should extend this class and implement map and reduce functions.
     """
 
-    def __init__(self, tmpdir="/tmp/mapreduce", filecount=100, hashfunc=None):
+    def __init__(self, tmpdir="/tmp/mapreduce", filecount=100, hashfunc=None) -> None:
         self.tmpdir = tmpdir
         self.filecount = 100
         self.hashfunc = None
@@ -53,7 +53,7 @@ class Task:
             key, value = line.strip().split("\t", 1)
             yield key, value
 
-    def map_all(self, records, disk):
+    def map_all(self, records, disk) -> None:
         for key, value in records:
             for k, v in self.map(key, value):
                 disk.write(k, v)
@@ -83,7 +83,9 @@ class Disk:
     The data is stored over multiple files based on the key. All records with same key will fall in the same file.
     """
 
-    def __init__(self, dir, prefix="shard", filecount=100, hashfunc=None, mode="r"):
+    def __init__(
+        self, dir, prefix="shard", filecount=100, hashfunc=None, mode="r"
+    ) -> None:
         self.dir = dir
         self.prefix = prefix
         self.hashfunc = hashfunc or (lambda key: hash(key))
@@ -98,12 +100,12 @@ class Disk:
         path = os.path.join(self.dir, filename)
         return gzip.open(path, mode)
 
-    def write(self, key, value):
+    def write(self, key, value) -> None:
         index = self.hashfunc(key) % len(self.files)
         f = self.files[index]
         f.write(key + "\t" + value + "\n")
 
-    def close(self):
+    def close(self) -> None:
         for f in self.files:
             f.close()
 

--- a/openlibrary/data/sitemap.py
+++ b/openlibrary/data/sitemap.py
@@ -79,7 +79,7 @@ $for path, title in docs:
 )
 
 
-def gzwrite(path, data):
+def gzwrite(path, data) -> None:
     with gzopen(path, 'w') as file:
         file.write(data)
 
@@ -99,7 +99,7 @@ def write_sitemaps(data, outdir, prefix):
         yield filename, timestamp
 
 
-def write_siteindex(data, outdir, prefix):
+def write_siteindex(data, outdir, prefix) -> None:
     rows = write_sitemaps(data, outdir, prefix)
     base_url = "http://openlibrary.org/static/sitemaps/"
 
@@ -119,17 +119,17 @@ def parse_index_file(index_file):
     return data
 
 
-def generate_sitemaps(index_file, outdir, prefix):
+def generate_sitemaps(index_file, outdir, prefix) -> None:
     data = parse_index_file(index_file)
     write_siteindex(data, outdir, prefix)
 
 
-def mkdir_p(dir):
+def mkdir_p(dir) -> None:
     if not os.path.exists(dir):
         os.makedirs(dir)
 
 
-def write(path, data):
+def write(path, data) -> None:
     print("writing", path)
     mkdir_p(os.path.dirname(path))
 
@@ -137,7 +137,7 @@ def write(path, data):
         file.write(data)
 
 
-def dirindex(dir, back=".."):
+def dirindex(dir, back="..") -> None:
     data = [(f, f) for f in sorted(os.listdir(dir))]
     index = t_html_layout(t_html_sitemap(back, data))
 
@@ -145,7 +145,7 @@ def dirindex(dir, back=".."):
     write(path, web.safestr(index))
 
 
-def generate_html_index(index_file, outdir):
+def generate_html_index(index_file, outdir) -> None:
     data = parse_index_file(index_file)
     data = ((d[0], d[1]) for d in data)
 

--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -165,7 +165,7 @@ def extract_templetor(fileobj, keywords, comment_tags, options):
     return extract_python(f, keywords, comment_tags, options)
 
 
-def extract_messages(sources: list[str], verbose: bool, skip_untracked: bool):
+def extract_messages(sources: list[str], verbose: bool, skip_untracked: bool) -> None:
     # The creation date is fixed to prevent merge conflicts on this line as a result of i18n auto-updates
     # In the unlikely event we need to update the fixed creation date, you can change the hard-coded date below
     fixed_creation_date = datetime.fromisoformat('2024-05-01 18:58-0400')
@@ -225,7 +225,7 @@ def extract_messages(sources: list[str], verbose: bool, skip_untracked: bool):
     print('Updated strings written to', path)
 
 
-def compile_translations(locales: list[str]):
+def compile_translations(locales: list[str]) -> None:
     locales_to_update = locales or get_locales()
 
     for locale in locales_to_update:
@@ -236,7 +236,7 @@ def compile_translations(locales: list[str]):
             _compile_translation(po_path, mo_path)
 
 
-def update_translations(locales: list[str]):
+def update_translations(locales: list[str]) -> None:
     locales_to_update = locales or get_locales()
     print(f"Updating {locales_to_update}")
 
@@ -261,7 +261,7 @@ def update_translations(locales: list[str]):
     compile_translations(locales_to_update)
 
 
-def check_status(locales: list[str]):
+def check_status(locales: list[str]) -> None:
     locales_to_update = locales or get_locales()
     pot_path = os.path.join(root, 'messages.pot')
 
@@ -323,7 +323,7 @@ def check_status(locales: list[str]):
             print(f"ERROR: {po_path} does not exist...")
 
 
-def generate_po(args):
+def generate_po(args) -> None:
     if args:
         po_dir = os.path.join(root, args[0])
         pot_src = os.path.join(root, 'messages.pot')
@@ -391,13 +391,13 @@ class LazyGetText:
 
 
 class LazyObject:
-    def __init__(self, creator):
+    def __init__(self, creator) -> None:
         self._creator = creator
 
-    def __str__(self):
+    def __str__(self) -> str:
         return web.safestr(self._creator())
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return repr(self._creator())
 
     def __add__(self, other):

--- a/openlibrary/i18n/test_po_files.py
+++ b/openlibrary/i18n/test_po_files.py
@@ -9,7 +9,7 @@ from openlibrary.i18n import get_locales
 root = os.path.dirname(__file__)
 
 
-def trees_equal(el1: ET.Element, el2: ET.Element, error=True):
+def trees_equal(el1: ET.Element, el2: ET.Element, error=True) -> bool:
     """
     Check if the tree data is the same
     >>> trees_equal(ET.fromstring('<root />'), ET.fromstring('<root />'))
@@ -75,7 +75,7 @@ def gen_html_entries():
 
 
 @pytest.mark.parametrize(('locale', 'msgid', 'msgstr'), gen_html_entries())
-def test_html_format(locale: str, msgid: str, msgstr: str):
+def test_html_format(locale: str, msgid: str, msgstr: str) -> None:
     # Need this to support &nbsp;, since ET only parses XML.
     # Find a better solution?
     entities = '<!DOCTYPE text [ <!ENTITY nbsp "&#160;"> ]>'

--- a/openlibrary/mocks/mock_ia.py
+++ b/openlibrary/mocks/mock_ia.py
@@ -20,7 +20,7 @@ def mock_ia(request, monkeypatch):
     metadata = {}
 
     class IA:
-        def set_metadata(self, itemid, meta):
+        def set_metadata(self, itemid, meta) -> None:
             metadata[itemid] = meta
 
         def get_metadata(self, itemid):

--- a/openlibrary/mocks/tests/test_mock_infobase.py
+++ b/openlibrary/mocks/tests/test_mock_infobase.py
@@ -4,7 +4,7 @@ import web
 
 
 class TestMockSite:
-    def test_new_key(self, mock_site):
+    def test_new_key(self, mock_site) -> None:
         ekey = mock_site.new_key('/type/edition')
         assert ekey == '/books/OL1M'
         ekey = mock_site.new_key('/type/edition')
@@ -20,7 +20,7 @@ class TestMockSite:
         akey = mock_site.new_key('/type/author')
         assert akey == '/authors/OL2A'
 
-    def test_get(self, mock_site):
+    def test_get(self, mock_site) -> None:
         doc = {
             "key": "/books/OL1M",
             "type": {"key": "/type/edition"},
@@ -41,7 +41,7 @@ class TestMockSite:
         }
         assert mock_site.get("/books/OL1M").__class__.__name__ == "Edition"
 
-    def test_query(self, mock_site):
+    def test_query(self, mock_site) -> None:
         doc = {
             "key": "/books/OL1M",
             "type": {"key": "/type/edition"},
@@ -76,7 +76,7 @@ class TestMockSite:
         assert mock_site.things({"isbn_": "0123456789"}) == ["/books/OL1M"]
         assert mock_site.things({"isbn_": ["0123456789abc"]}) == ["/books/OL1M"]
 
-    def test_work_authors(self, mock_site):
+    def test_work_authors(self, mock_site) -> None:
         a2 = mock_site.quicksave("/authors/OL2A", "/type/author", name="A2")
         work = mock_site.quicksave(
             "/works/OL1W",

--- a/openlibrary/mocks/tests/test_mock_memcache.py
+++ b/openlibrary/mocks/tests/test_mock_memcache.py
@@ -4,7 +4,7 @@ from .. import mock_memcache
 
 
 class Test_mock_memcache:
-    def test_set(self):
+    def test_set(self) -> None:
         m = mock_memcache.Client([])
 
         m.set("a", 1)
@@ -16,7 +16,7 @@ class Test_mock_memcache:
         m.set("a", ["foo", "bar"])
         assert m.get("a") == ["foo", "bar"]
 
-    def test_add(self):
+    def test_add(self) -> None:
         m = mock_memcache.Client([])
 
         assert m.add("a", 1) is True
@@ -28,6 +28,6 @@ class Test_mock_memcache:
 mc = memcache.Client(servers=[])
 
 
-def test_mock_memcache_func_arg(mock_memcache):
+def test_mock_memcache_func_arg(mock_memcache) -> None:
     mc.set("a", 1)
     assert mc.get("a") == 1

--- a/openlibrary/olbase/__init__.py
+++ b/openlibrary/olbase/__init__.py
@@ -4,6 +4,6 @@ from ..plugins import ol_infobase
 from . import events
 
 
-def init_plugin():
+def init_plugin() -> None:
     ol_infobase.init_plugin()
     events.setup()

--- a/openlibrary/olbase/tests/test_events.py
+++ b/openlibrary/olbase/tests/test_events.py
@@ -2,7 +2,7 @@ from .. import events
 
 
 class TestMemcacheInvalidater:
-    def test_seed_to_key(self):
+    def test_seed_to_key(self) -> None:
         m = events.MemcacheInvalidater()
         assert m.seed_to_key({"key": "/books/OL1M"}) == "/books/OL1M"
         assert m.seed_to_key("subject:love") == "/subjects/love"
@@ -10,7 +10,7 @@ class TestMemcacheInvalidater:
         assert m.seed_to_key("person:mark_twain") == "/subjects/person:mark_twain"
         assert m.seed_to_key("time:2000") == "/subjects/time:2000"
 
-    def test_find_lists(self):
+    def test_find_lists(self) -> None:
         changeset = {
             "changes": [{"key": "/people/anand/lists/OL1L", "revision": 1}],
             "old_docs": [None],
@@ -30,7 +30,7 @@ class TestMemcacheInvalidater:
             "d/subjects/love",
         ]
 
-    def test_find_lists2(self):
+    def test_find_lists2(self) -> None:
         changeset = {
             "changes": [{"key": "/people/anand/lists/OL1L", "revision": 2}],
             "old_docs": [
@@ -65,7 +65,7 @@ class TestMemcacheInvalidater:
             "d/subjects/place:san_francisco",
         ]
 
-    def test_edition_count_for_doc(self):
+    def test_edition_count_for_doc(self) -> None:
         m = events.MemcacheInvalidater()
 
         assert m.find_edition_counts_for_doc(None) == []
@@ -77,7 +77,7 @@ class TestMemcacheInvalidater:
         }
         assert m.find_edition_counts_for_doc(doc) == ["d/works/OL1W"]
 
-    def test_find_keys(self):
+    def test_find_keys(self) -> None:
         m = events.MemcacheInvalidater()
 
         changeset = {

--- a/openlibrary/olbase/tests/test_ol_infobase.py
+++ b/openlibrary/olbase/tests/test_ol_infobase.py
@@ -2,7 +2,7 @@ from openlibrary.plugins.ol_infobase import OLIndexer
 
 
 class TestOLIndexer:
-    def test_expand_isbns(self):
+    def test_expand_isbns(self) -> None:
         indexer = OLIndexer()
         isbn_10 = ['123456789X']
         isbn_13 = ['9781234567897']

--- a/openlibrary/plugins/admin/mem.py
+++ b/openlibrary/plugins/admin/mem.py
@@ -12,7 +12,7 @@ def render_template(name, *a, **kw):
 
 
 class Object:
-    def __init__(self, obj, name=None):
+    def __init__(self, obj, name=None) -> None:
         self.obj = obj
         self.name = name
 

--- a/openlibrary/plugins/admin/services.py
+++ b/openlibrary/plugins/admin/services.py
@@ -11,7 +11,7 @@ from bs4 import BeautifulSoup
 
 
 class Nagios:
-    def __init__(self, url):
+    def __init__(self, url) -> None:
         try:
             self.data = BeautifulSoup(requests.get(url).content, "lxml")
         except Exception as m:
@@ -46,14 +46,14 @@ class Service:
     manipulate it.
     """
 
-    def __init__(self, node, name, nagios, logs=False):
+    def __init__(self, node, name, nagios, logs=False) -> None:
         self.node = node
         self.name = name
         self.logs = logs
         self.status = "Service status(TBD)"
         self.nagios = nagios.get_service_status(name)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"Service(name = '{self.name}', node = '{self.node}', logs = '{self.logs}')"
         )

--- a/openlibrary/plugins/admin/tests/test_code.py
+++ b/openlibrary/plugins/admin/tests/test_code.py
@@ -47,12 +47,12 @@ def make_thing(key: str, title: str = '', thing_type: str | None = None) -> dict
 
 
 class TestRevertAllUserEdits:
-    def test_no_edits(self, mock_site):
+    def test_no_edits(self, mock_site) -> None:
         alice = make_test_account("alice")
 
         revert_all_user_edits(alice)
 
-    def test_deletes_spam_works(self, mock_site):
+    def test_deletes_spam_works(self, mock_site) -> None:
         good_alice = make_test_account("good_alice")
         spam_alice = make_test_account("spam_alice")
 
@@ -91,7 +91,7 @@ class TestRevertAllUserEdits:
         assert web.ctx.site.get("/works/OL345W").revision == 2
         assert web.ctx.site.get("/works/OL345W").type.key == "/type/delete"
 
-    def test_reverts_spam_edits(self, mock_site):
+    def test_reverts_spam_edits(self, mock_site) -> None:
         good_alice = make_test_account("good_alice")
         spam_alice = make_test_account("spam_alice")
 
@@ -113,7 +113,7 @@ class TestRevertAllUserEdits:
         assert web.ctx.site.get("/works/OL123W").title == "Good Book Title"
         assert web.ctx.site.get("/works/OL123W").type.key == "/type/work"
 
-    def test_does_not_undelete(self, mock_site):
+    def test_does_not_undelete(self, mock_site) -> None:
         spam_alice = make_test_account("spam_alice")
 
         web.ctx.site.save(
@@ -137,7 +137,7 @@ class TestRevertAllUserEdits:
             == "/type/delete"
         )
 
-    def test_two_spammy_editors(self, mock_site):
+    def test_two_spammy_editors(self, mock_site) -> None:
         spam_alice = make_test_account("spam_alice")
         spam_bob = make_test_account("spam_bob")
 

--- a/openlibrary/plugins/books/dynlinks.py
+++ b/openlibrary/plugins/books/dynlinks.py
@@ -395,7 +395,7 @@ def process_result_for_viewapi(result):
     return {k: process_doc_for_viewapi(k, doc) for k, doc in result.items()}
 
 
-def get_ia_availability(itemid):
+def get_ia_availability(itemid) -> str:
     collections = ia.get_metadata(itemid).get('collection', [])
 
     if 'inlibrary' in collections:

--- a/openlibrary/plugins/books/readlinks.py
+++ b/openlibrary/plugins/books/readlinks.py
@@ -102,7 +102,7 @@ def get_solr_edition_records(iaids):
 
 
 class ReadProcessor:
-    def __init__(self, options):
+    def __init__(self, options) -> None:
         self.options = options
 
     def get_item_status(self, ekey, iaid, collections) -> str:

--- a/openlibrary/plugins/books/tests/test_doctests.py
+++ b/openlibrary/plugins/books/tests/test_doctests.py
@@ -11,7 +11,7 @@ def find_doctests(modules):
 
 
 @pytest.mark.parametrize('test', find_doctests(["openlibrary.plugins.books.dynlinks"]))
-def test_doctest(test):
+def test_doctest(test) -> None:
     runner = doctest.DocTestRunner(verbose=True)
     failures, tries = runner.run(test)
     if failures:

--- a/openlibrary/plugins/books/tests/test_readlinks.py
+++ b/openlibrary/plugins/books/tests/test_readlinks.py
@@ -12,7 +12,7 @@ from openlibrary.plugins.books import readlinks
         (['some other collection'], {}, 'full access'),
     ],
 )
-def test_get_item_status(collections, options, expected, mock_site):
+def test_get_item_status(collections, options, expected, mock_site) -> None:
     read_processor = readlinks.ReadProcessor(options=options)
     status = read_processor.get_item_status('ekey', 'iaid', collections)
     assert status == expected
@@ -25,7 +25,9 @@ def test_get_item_status(collections, options, expected, mock_site):
         ('false', 'lendable'),
     ],
 )
-def test_get_item_status_monkeypatched(borrowed, expected, monkeypatch, mock_site):
+def test_get_item_status_monkeypatched(
+    borrowed, expected, monkeypatch, mock_site
+) -> None:
     read_processor = readlinks.ReadProcessor(options={})
     monkeypatch.setattr(web.ctx.site.store, 'get', lambda _, __: {'borrowed': borrowed})
     collections = ['inlibrary']

--- a/openlibrary/plugins/importapi/import_ui.py
+++ b/openlibrary/plugins/importapi/import_ui.py
@@ -243,7 +243,7 @@ class RawMarcMetadataProvider(AbstractMetadataProvider):
 
 
 class MetadataProviderFactory:
-    def __init__(self):
+    def __init__(self) -> None:
         providers = [
             AmazonMetadataProvider(),
             IaMetadataProvider(),
@@ -262,7 +262,7 @@ class MetadataProviderFactory:
 metadata_provider_factory = MetadataProviderFactory()
 
 
-def setup():
+def setup() -> None:
     pass
 
 

--- a/openlibrary/plugins/importapi/tests/test_import_edition_builder.py
+++ b/openlibrary/plugins/importapi/tests/test_import_edition_builder.py
@@ -81,7 +81,7 @@ import_examples = [
 
 
 @pytest.mark.parametrize('data', import_examples)
-def test_import_edition_builder_JSON(data):
+def test_import_edition_builder_JSON(data) -> None:
     edition = import_edition_builder(init_dict=data)
     assert isinstance(edition, import_edition_builder)
     # JSON with the fields above is NOT altered by import_edition_builder

--- a/openlibrary/plugins/importapi/tests/test_import_validator.py
+++ b/openlibrary/plugins/importapi/tests/test_import_validator.py
@@ -25,7 +25,7 @@ valid_values_strong_identifier = {
 validator = import_validator()
 
 
-def test_validate_both_complete_and_strong():
+def test_validate_both_complete_and_strong() -> None:
     """
     A record that is both complete and that has a strong identifier should
     validate.
@@ -37,7 +37,7 @@ def test_validate_both_complete_and_strong():
 @pytest.mark.parametrize(
     'field', ["title", "source_records", "authors", "publishers", "publish_date"]
 )
-def test_validate_record_with_missing_required_fields(field):
+def test_validate_record_with_missing_required_fields(field) -> None:
     """Ensure a record will not validate as complete without each required field."""
     invalid_values = complete_values.copy()
     del invalid_values[field]
@@ -46,7 +46,7 @@ def test_validate_record_with_missing_required_fields(field):
 
 
 @pytest.mark.parametrize('field', ['title', 'publish_date'])
-def test_cannot_validate_with_empty_string_values(field):
+def test_cannot_validate_with_empty_string_values(field) -> None:
     """Ensure the title and publish_date are not mere empty strings."""
     invalid_values = complete_values.copy()
     invalid_values[field] = ""
@@ -55,7 +55,7 @@ def test_cannot_validate_with_empty_string_values(field):
 
 
 @pytest.mark.parametrize('field', ['source_records', 'authors'])
-def test_cannot_validate_with_with_empty_lists(field):
+def test_cannot_validate_with_with_empty_lists(field) -> None:
     """Ensure list values will not validate if they are empty."""
     invalid_values = complete_values.copy()
     invalid_values[field] = []
@@ -64,7 +64,7 @@ def test_cannot_validate_with_with_empty_lists(field):
 
 
 @pytest.mark.parametrize('field', ['source_records'])
-def test_cannot_validate_list_with_an_empty_string(field):
+def test_cannot_validate_list_with_an_empty_string(field) -> None:
     """Ensure lists will not validate with empty string values."""
     invalid_values = complete_values.copy()
     invalid_values[field] = [""]
@@ -73,7 +73,7 @@ def test_cannot_validate_list_with_an_empty_string(field):
 
 
 @pytest.mark.parametrize('field', ['isbn_10', 'lccn'])
-def test_validate_multiple_strong_identifiers(field):
+def test_validate_multiple_strong_identifiers(field) -> None:
     """Records with more than one strong identifier should still validate."""
     multiple_valid_values = valid_values_strong_identifier.copy()
     multiple_valid_values[field] = ["non-empty"]
@@ -81,7 +81,7 @@ def test_validate_multiple_strong_identifiers(field):
 
 
 @pytest.mark.parametrize('field', ['isbn_13'])
-def test_validate_not_complete_no_strong_identifier(field):
+def test_validate_not_complete_no_strong_identifier(field) -> None:
     """
     Ensure a record cannot validate if it lacks both (1) complete and (2) a title
     and strong identifier, in addition to a source_records field.

--- a/openlibrary/plugins/openlibrary/authors.py
+++ b/openlibrary/plugins/openlibrary/authors.py
@@ -2,7 +2,7 @@ from infogami.utils import delegate
 from infogami.utils.view import render_template
 
 
-def setup():
+def setup() -> None:
     pass
 
 

--- a/openlibrary/plugins/openlibrary/borrow_home.py
+++ b/openlibrary/plugins/openlibrary/borrow_home.py
@@ -34,7 +34,7 @@ class borrow_json(delegate.page):
 class read(delegate.page):
     path = "/read"
 
-    def GET(self):
+    def GET(self) -> None:
         web.seeother('/subjects/accessible_book#ebooks=true')
 
 
@@ -42,11 +42,11 @@ class read_json(delegate.page):
     path = "/read"
     encoding = "json"
 
-    def GET(self):
+    def GET(self) -> None:
         web.seeother('/subjects/accessible_book.json' + web.ctx.query)
 
 
-def on_loan_created_statsdb(loan):
+def on_loan_created_statsdb(loan) -> None:
     """Adds the loan info to the stats database."""
     key = _get_loan_key(loan)
     t_start = datetime.datetime.utcfromtimestamp(loan['loaned_at'])
@@ -62,7 +62,7 @@ def on_loan_created_statsdb(loan):
     statsdb.add_entry(key, d)
 
 
-def on_loan_completed_statsdb(loan):
+def on_loan_completed_statsdb(loan) -> None:
     """Marks the loan as completed in the stats database."""
     key = _get_loan_key(loan)
     t_start = datetime.datetime.utcfromtimestamp(loan['loaned_at'])
@@ -89,6 +89,6 @@ def _get_loan_key(loan):
     return "loans/" + loan.get("uuid") or loan["_key"]
 
 
-def setup():
+def setup() -> None:
     eventer.bind("loan-created", on_loan_created_statsdb)
     eventer.bind("loan-completed", on_loan_completed_statsdb)

--- a/openlibrary/plugins/openlibrary/bulk_tag.py
+++ b/openlibrary/plugins/openlibrary/bulk_tag.py
@@ -72,5 +72,5 @@ class bulk_tag_works(delegate.page):
         return response('Tagged works successfully')
 
 
-def setup():
+def setup() -> None:
     pass

--- a/openlibrary/plugins/openlibrary/design.py
+++ b/openlibrary/plugins/openlibrary/design.py
@@ -13,5 +13,5 @@ class home(delegate.page):
         return render_template("design")
 
 
-def setup():
+def setup() -> None:
     pass

--- a/openlibrary/plugins/openlibrary/events.py
+++ b/openlibrary/plugins/openlibrary/events.py
@@ -10,14 +10,14 @@ from infogami.infobase import client
 logger = logging.getLogger("openlibrary.events")
 
 
-def on_page_edit(page):
+def on_page_edit(page) -> None:
     pass
 
 
 class EditHook(client.hook):
     """Ugly Interface provided by Infobase to get event notifications."""
 
-    def on_new_version(self, page):
+    def on_new_version(self, page) -> None:
         """Fires page.edit event using msg broker."""
         # The argument passes by Infobase is not a thing object.
         # Create a thing object to pass to event listeners.
@@ -25,6 +25,6 @@ class EditHook(client.hook):
         eventer.trigger("page.edit", page)
 
 
-def setup():
+def setup() -> None:
     """Installs handlers for various events."""
     eventer.bind("page.edit", on_page_edit)

--- a/openlibrary/plugins/openlibrary/filters.py
+++ b/openlibrary/plugins/openlibrary/filters.py
@@ -12,7 +12,7 @@ import web
 from infogami import config
 
 
-def all(**params):
+def all(**params) -> bool:
     "Returns true for all requests"
     return True
 
@@ -22,13 +22,13 @@ def url(**params):
     return bool(re.search(params["pattern"], web.ctx.path))
 
 
-def loggedin(**kw):
+def loggedin(**kw) -> bool:
     """Returns True if any user is logged in."""
     # Assuming that presence of cookie is an indication of logged-in user.
     # Avoiding validation or calling web.ctx.site.get_user() as they are expensive.
     return config.login_cookie_name in web.cookies()
 
 
-def not_loggedin(**kw):
+def not_loggedin(**kw) -> bool:
     """Returns True if no user is logged in."""
     return not loggedin()

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -84,7 +84,7 @@ def caching_prethread():
     lang = web.ctx.lang
     _is_bot = is_bot()
 
-    def main():
+    def main() -> None:
         # Leaving this in since this is a bit strange, but you can see it clearly
         # in action with this debug line:
         # web.debug(f'XXXXXXXXXXX web.ctx.lang={web.ctx.get("lang")}; {lang=}')
@@ -242,5 +242,5 @@ def format_book_data(book, fetch_availability=True):
     return d
 
 
-def setup():
+def setup() -> None:
     pass

--- a/openlibrary/plugins/openlibrary/infobase_hook.py
+++ b/openlibrary/plugins/openlibrary/infobase_hook.py
@@ -13,7 +13,7 @@ root = getattr(config, 'booklogroot', 'booklog')
 _logger = Logger(root)
 
 
-def hook(object):
+def hook(object) -> None:
     """
     Add this hook to infobase.hooks to log all book modifications.
     """

--- a/openlibrary/plugins/openlibrary/librarian_dashboard.py
+++ b/openlibrary/plugins/openlibrary/librarian_dashboard.py
@@ -8,7 +8,7 @@ from openlibrary.i18n import gettext as _
 
 @public
 def get_quality_criteria():
-    def build_url(query_fragment, for_ui=True):
+    def build_url(query_fragment, for_ui=True) -> str:
         page_path = web.ctx.path
         on_author_page = page_path.startswith('/authors/OL')
         base_query = (

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -277,7 +277,7 @@ class lists(delegate.page):
 
     path = "(/(?:people|books|works|authors|subjects)/[^/]+)/lists"
 
-    def is_enabled(self):
+    def is_enabled(self) -> bool:
         return "lists" in web.ctx.features
 
     def GET(self, path):
@@ -871,7 +871,7 @@ class feeds(delegate.page):
         return render_template("lists/feed_updates.xml", lst)
 
 
-def setup():
+def setup() -> None:
     pass
 
 
@@ -907,7 +907,7 @@ def get_cached_recently_modified_lists(limit, offset=0):
     return f(limit, offset=offset)
 
 
-def _preload_lists(lists):
+def _preload_lists(lists) -> None:
     """Preloads all referenced documents for each list.
     List can be either a dict of a model object.
     """

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -37,7 +37,7 @@ class CarouselCardPartial(PartialDataHandler):
 
     MAX_VISIBLE_CARDS = 5
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.i = web.input(params=None)
 
     def generate(self) -> dict:
@@ -159,7 +159,7 @@ class CarouselCardPartial(PartialDataHandler):
 class AffiliateLinksPartial(PartialDataHandler):
     """Handler for affiliate links"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.i = web.input(data=None)
 
     def generate(self) -> dict:
@@ -176,7 +176,7 @@ class AffiliateLinksPartial(PartialDataHandler):
 class SearchFacetsPartial(PartialDataHandler):
     """Handler for search facets sidebar and "selected facets" affordances."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.i = web.input(data=None)
 
     def generate(self) -> dict:
@@ -217,7 +217,7 @@ class SearchFacetsPartial(PartialDataHandler):
 class FullTextSuggestionsPartial(PartialDataHandler):
     """Handler for rendering full-text search suggestions."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.i = web.input(data=None)
 
     def generate(self) -> dict:
@@ -240,7 +240,7 @@ class FullTextSuggestionsPartial(PartialDataHandler):
 class BookPageListsPartial(PartialDataHandler):
     """Handler for rendering the book page "Lists" section"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.i = web.input(workId="", editionId="")
 
     def generate(self) -> dict:
@@ -280,7 +280,7 @@ class BookPageListsPartial(PartialDataHandler):
 class LazyCarouselPartial(PartialDataHandler):
     """Handler for lazily-loaded query carousels."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.i = web.input(
             query="",
             title=None,
@@ -351,5 +351,5 @@ class Partials(delegate.page):
         )
 
 
-def setup():
+def setup() -> None:
     pass

--- a/openlibrary/plugins/openlibrary/pd.py
+++ b/openlibrary/plugins/openlibrary/pd.py
@@ -75,7 +75,7 @@ def cached_pd_org_query() -> list:
 
 
 def get_pd_dashboard_data() -> dict:
-    def enrich_data(_request_data):
+    def enrich_data(_request_data) -> None:
         for d in _request_data:
             pda = d['pda']
             d['display_name'] = (
@@ -98,5 +98,5 @@ def get_pd_dashboard_data() -> dict:
     }
 
 
-def setup():
+def setup() -> None:
     pass

--- a/openlibrary/plugins/openlibrary/processors.py
+++ b/openlibrary/plugins/openlibrary/processors.py
@@ -49,7 +49,7 @@ class CORSProcessor:
     Cross Origin Resource Sharing.
     """
 
-    def __init__(self, cors_prefixes=None):
+    def __init__(self, cors_prefixes=None) -> None:
         self.cors_prefixes = cors_prefixes
 
     def __call__(self, handler):
@@ -67,7 +67,7 @@ class CORSProcessor:
             web.ctx.path.startswith(path_segment) for path_segment in self.cors_prefixes
         )
 
-    def add_cors_headers(self):
+    def add_cors_headers(self) -> None:
         # Allow anyone to access GET and OPTIONS requests
         allowed = "GET, OPTIONS"
         # unless the path is /account/* or /admin/*
@@ -92,7 +92,7 @@ class CORSProcessor:
 class PreferenceProcessor:
     """Processor to handle unauthorized patron preference reads"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.pref_pattern = re.compile(r'^\/people\/([^/]+)\/preferences(.json|.yml)?$')
 
     def __call__(self, handler):

--- a/openlibrary/plugins/openlibrary/sentry.py
+++ b/openlibrary/plugins/openlibrary/sentry.py
@@ -5,7 +5,7 @@ from openlibrary.utils.sentry import InfogamiSentryProcessor, Sentry, init_sentr
 sentry: Sentry | None = None
 
 
-def setup():
+def setup() -> None:
     global sentry
     if sentry is not None:
         # Avoid attaching exception hooks multiple times

--- a/openlibrary/plugins/openlibrary/swagger.py
+++ b/openlibrary/plugins/openlibrary/swagger.py
@@ -2,7 +2,7 @@ from infogami.utils import delegate
 from infogami.utils.view import render_template
 
 
-def setup():
+def setup() -> None:
     pass
 
 

--- a/openlibrary/plugins/openlibrary/tests/conftest.py
+++ b/openlibrary/plugins/openlibrary/tests/conftest.py
@@ -1,13 +1,13 @@
 collect_ignore = ['test_listapi.py', 'test_ratingsapi.py']
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser) -> None:
     parser.addoption("--server", default=None)
     parser.addoption("--username")
     parser.addoption("--password")
 
 
-def pytest_configure(config):
+def pytest_configure(config) -> None:
     print("pytest_configure", config.getvalue("server"))
 
     if config.getvalue("server"):

--- a/openlibrary/plugins/openlibrary/tests/test_bestbookapi.py
+++ b/openlibrary/plugins/openlibrary/tests/test_bestbookapi.py
@@ -27,7 +27,7 @@ has_read_book = 'openlibrary.core.bookshelves.Bookshelves.get_users_read_status_
 
 
 class FakeUser:
-    def __init__(self, key):
+    def __init__(self, key) -> None:
         self.key = f'/users/{key}'
 
 
@@ -38,7 +38,7 @@ def mock_web_input_func(data):
     return _mock_web_input
 
 
-def test_bestbook_add_award():
+def test_bestbook_add_award() -> None:
     """Test adding a best book award."""
 
     with (
@@ -66,7 +66,7 @@ def test_bestbook_add_award():
         assert result["award"] == "Awarded the book"
 
 
-def test_bestbook_award_removal():
+def test_bestbook_award_removal() -> None:
     """Test removing a best book award."""
     with (
         patch('web.input') as mock_web_input,
@@ -90,7 +90,7 @@ def test_bestbook_award_removal():
         assert result["rows"] == 1
 
 
-def test_bestbook_award_limit():
+def test_bestbook_award_limit() -> None:
     """Test award limit - one award per book/topic."""
     with (
         patch('web.input') as mock_web_input,
@@ -125,7 +125,7 @@ def test_bestbook_award_limit():
             assert result["errors"] == "Award already exists"
 
 
-def test_bestbook_award_not_authenticated():
+def test_bestbook_award_not_authenticated() -> None:
     """Test awarding a book without authentication."""
     with (
         patch('web.input') as mock_web_input,
@@ -150,7 +150,7 @@ def test_bestbook_award_not_authenticated():
         assert "Authentication failed" in result.get("errors", [])
 
 
-def test_bestbook_add_unread_award():
+def test_bestbook_add_unread_award() -> None:
     """Test awarding a book that hasn't been read by reader."""
     with (
         patch('web.input') as mock_web_input,
@@ -183,7 +183,7 @@ def test_bestbook_add_unread_award():
         )
 
 
-def test_bestbook_count():
+def test_bestbook_count() -> None:
     """Test fetching best book award count."""
     with (
         patch('openlibrary.core.bestbook.Bestbook.get_count') as mock_get_count,

--- a/openlibrary/plugins/openlibrary/tests/test_home.py
+++ b/openlibrary/plugins/openlibrary/tests/test_home.py
@@ -9,18 +9,18 @@ from openlibrary.plugins.openlibrary import home
 
 
 class MockDoc(dict):
-    def __init__(self, _id, *largs, **kargs):
+    def __init__(self, _id, *largs, **kargs) -> None:
         self.id = _id
         kargs['_key'] = _id
         super().__init__(*largs, **kargs)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         o = super().__repr__()
         return f"<{self.id} - {o}>"
 
 
 class TestHomeTemplates:
-    def setup_monkeypatch(self, monkeypatch):
+    def setup_monkeypatch(self, monkeypatch) -> None:
         ctx = web.storage()
         monkeypatch.setattr(web, "ctx", ctx)
         monkeypatch.setattr(web.webapi, "ctx", web.ctx)
@@ -29,7 +29,7 @@ class TestHomeTemplates:
         web.ctx.lang = 'en'
         web.ctx.site = MockSite()
 
-    def _load_fake_context(self):
+    def _load_fake_context(self) -> None:
         self.app = web.application()
         self.env = {
             "PATH_INFO": "/",
@@ -37,7 +37,7 @@ class TestHomeTemplates:
         }
         self.app.load(self.env)
 
-    def test_about_template(self, monkeypatch, render_template):
+    def test_about_template(self, monkeypatch, render_template) -> None:
         self.setup_monkeypatch(monkeypatch)
         html = str(render_template("home/about"))
         assert "About the Project" in html
@@ -64,12 +64,12 @@ class TestHomeTemplates:
         assert blog is not None
         assert len(blog.findAll("li")) == 1
 
-    def test_stats_template(self, render_template):
+    def test_stats_template(self, render_template) -> None:
         # Make sure that it works fine without any input (skipping section)
         html = str(render_template("home/stats"))
         assert html == ""
 
-    def test_home_template(self, render_template, mock_site, monkeypatch):
+    def test_home_template(self, render_template, mock_site, monkeypatch) -> None:
         self.setup_monkeypatch(monkeypatch)
         docs = [
             MockDoc(
@@ -130,11 +130,11 @@ class TestHomeTemplates:
 
 
 class Test_format_book_data:
-    def test_all(self, mock_site, mock_ia):
+    def test_all(self, mock_site, mock_ia) -> None:
         book = mock_site.quicksave("/books/OL1M", "/type/edition", title="Foo")
         work = mock_site.quicksave("/works/OL1W", "/type/work", title="Foo")
 
-    def test_authors(self, mock_site, mock_ia):
+    def test_authors(self, mock_site, mock_ia) -> None:
         a1 = mock_site.quicksave("/authors/OL1A", "/type/author", name="A1")
         a2 = mock_site.quicksave("/authors/OL2A", "/type/author", name="A2")
         work = mock_site.quicksave(

--- a/openlibrary/plugins/openlibrary/tests/test_lists.py
+++ b/openlibrary/plugins/openlibrary/tests/test_lists.py
@@ -7,7 +7,7 @@ from openlibrary.plugins.openlibrary.lists import ListRecord
 
 
 class TestListRecord:
-    def test_from_input_no_data(self):
+    def test_from_input_no_data(self) -> None:
         with (
             patch('web.input') as mock_web_input,
             patch('web.data') as mock_web_data,
@@ -26,7 +26,7 @@ class TestListRecord:
                 seeds=[],
             )
 
-    def test_from_input_with_data(self):
+    def test_from_input_with_data(self) -> None:
         with (
             patch('web.input') as mock_web_input,
             patch('web.data') as mock_web_data,
@@ -45,7 +45,7 @@ class TestListRecord:
                 seeds=[{'key': '/books/OL1M'}, {'key': '/books/OL2M'}],
             )
 
-    def test_from_input_with_json_data(self):
+    def test_from_input_with_json_data(self) -> None:
         with (
             patch('web.input') as mock_web_input,
             patch('web.data') as mock_web_data,
@@ -80,7 +80,7 @@ class TestListRecord:
     )
 
     @pytest.mark.parametrize(('seeds', 'expected'), SEED_TESTS)
-    def test_from_input_seeds(self, seeds, expected):
+    def test_from_input_seeds(self, seeds, expected) -> None:
         with (
             patch('web.input') as mock_web_input,
             patch('web.data') as mock_web_data,
@@ -99,7 +99,7 @@ class TestListRecord:
                 seeds=expected,
             )
 
-    def test_normalize_input_seed(self):
+    def test_normalize_input_seed(self) -> None:
         f = ListRecord.normalize_input_seed
 
         assert f("/books/OL1M") == {"key": "/books/OL1M"}

--- a/openlibrary/plugins/openlibrary/tests/test_ratingsapi.py
+++ b/openlibrary/plugins/openlibrary/tests/test_ratingsapi.py
@@ -12,7 +12,7 @@ def pytest_funcarg__config(request):
 
 
 class RatingsAPI:
-    def __init__(self, config):
+    def __init__(self, config) -> None:
         self.server = config.getvalue('server')
         self.username = config.getvalue("username")
         self.password = config.getvalue("password")
@@ -29,7 +29,7 @@ class RatingsAPI:
         req = requests.Request(method, self.server + path, data=data, headers=headers)
         return self.session.send(req)
 
-    def login(self):
+    def login(self) -> None:
         data = {'username': self.username, 'password': self.password}
         self.urlopen("/account/login", data=data, method="POST")
 
@@ -40,7 +40,7 @@ class RatingsAPI:
         return json.loads(r.read())
 
 
-def test_rating(config, monkeypatch):
+def test_rating(config, monkeypatch) -> None:
     api = RatingsAPI(config)
     api.login()
 
@@ -48,7 +48,7 @@ def test_rating(config, monkeypatch):
     data = {"rating": "5"}
 
     class FakeUser:
-        def __init__(self, key):
+        def __init__(self, key) -> None:
             self.key = '/users/%s' % key
 
     monkeypatch.setattr(accounts, "get_current_user", FakeUser('test'))

--- a/openlibrary/plugins/openlibrary/tests/test_stats.py
+++ b/openlibrary/plugins/openlibrary/tests/test_stats.py
@@ -11,17 +11,17 @@ from .. import stats
 
 
 class MockDoc(dict):
-    def __init__(self, _id, *largs, **kargs):
+    def __init__(self, _id, *largs, **kargs) -> None:
         self.id = _id
         kargs['_key'] = _id
         super().__init__(*largs, **kargs)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         o = super().__repr__()
         return f"<{self.id} - {o}>"
 
 
-def test_format_stats_entry():
+def test_format_stats_entry() -> None:
     "Tests the stats performance entries"
     ps = stats.process_stats
     assert ps({"total": {"time": 0.1}}) == [("TT", 0, 0.1)]
@@ -35,13 +35,13 @@ def test_format_stats_entry():
     assert ps({"something-else": {"count": 2, "time": 0.1}}) == [("OT", 2, 0.100)]
 
 
-def test_format_stats():
+def test_format_stats() -> None:
     "Tests whether the performance status are output properly in the the X-OL-Stats header"
     performance_stats = {"total": {"time": 0.2}, "infobase": {"count": 2, "time": 0.13}}
     assert stats.format_stats(performance_stats) == '"IB 2 0.130 TT 0 0.200"'
 
 
-def test_stats_container():
+def test_stats_container() -> None:
     "Tests the Stats container used in the templates"
     # Test basic API and null total count
     ipdata = [{"foo": 1}] * 100
@@ -52,7 +52,7 @@ def test_stats_container():
     assert s.total == ""
 
 
-def test_status_total():
+def test_status_total() -> None:
     "Tests the total attribute of the stats container used in the templates"
     ipdata = [{"foo": 1, "total": x * 2} for x in range(1, 100)]
     s = Stats(ipdata, "foo", "total")
@@ -66,7 +66,7 @@ def test_status_total():
     assert s.total == 2
 
 
-def test_status_timerange():
+def test_status_timerange() -> None:
     "Tests the stats container with a time X-axis"
     d = datetime.datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
     ipdata = []

--- a/openlibrary/plugins/recaptcha/recaptcha.py
+++ b/openlibrary/plugins/recaptcha/recaptcha.py
@@ -18,7 +18,7 @@ INVALIDATING_ERRORS = [
 
 
 class Recaptcha(web.form.Input):
-    def __init__(self, public_key, private_key):
+    def __init__(self, public_key, private_key) -> None:
         self.public_key = public_key
         self._private_key = private_key
         validator = web.form.Validator('Recaptcha failed', self.validate)

--- a/openlibrary/plugins/upstream/addtag.py
+++ b/openlibrary/plugins/upstream/addtag.py
@@ -233,6 +233,6 @@ class tag_search(delegate.page):
         return render_template("notfound", f"/tags/-/{type}:{name}", create=False)
 
 
-def setup():
+def setup() -> None:
     """Do required setup."""
     pass

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -385,7 +385,7 @@ class ia_borrow_notify(delegate.page):
 
     path = "/borrow/notify"
 
-    def POST(self):
+    def POST(self) -> None:
         payload = web.data()
         d = json.loads(payload)
         identifier = d and d.get('identifier')

--- a/openlibrary/plugins/upstream/checkins.py
+++ b/openlibrary/plugins/upstream/checkins.py
@@ -250,7 +250,7 @@ def get_reading_goals(year=None):
 
 
 class YearlyGoal:
-    def __init__(self, year, goal, books_read):
+    def __init__(self, year, goal, books_read) -> None:
         self.year = year
         self.goal = goal
         self.books_read = books_read
@@ -274,5 +274,5 @@ class ui_partials(delegate.page):
         return delegate.RawText(json.dumps(partials))
 
 
-def setup():
+def setup() -> None:
     pass

--- a/openlibrary/plugins/upstream/covers.py
+++ b/openlibrary/plugins/upstream/covers.py
@@ -21,12 +21,12 @@ from openlibrary.plugins.upstream.utils import (
 logger = getLogger("openlibrary.plugins.upstream.covers")
 
 
-def setup():
+def setup() -> None:
     pass
 
 
 class image_validator:
-    def __init__(self):
+    def __init__(self) -> None:
         self.max_file_size = 10 * 1024 * 1024  # 10 MB
         self.allowed_extensions = {'.jpg', '.jpeg', '.gif', '.png', '.webp'}
 
@@ -127,7 +127,7 @@ class add_cover(delegate.page):
             logger.exception("Covers upload failed")
             return web.storage({'error': str(e)})
 
-    def save(self, book, coverid, url=None):
+    def save(self, book, coverid, url=None) -> None:
         book.covers = [coverid] + [cover.id for cover in book.get_covers()]
         book._save(
             f'{get_coverstore_public_url()}/b/id/{coverid}-S.jpg',
@@ -160,7 +160,7 @@ class add_photo(add_cover):
             'covers/add', author, {'wikidata_images': wikidata_images}
         )
 
-    def save(self, author, photoid, url=None):
+    def save(self, author, photoid, url=None) -> None:
         author.photos = [photoid] + [photo.id for photo in author.get_photos()]
         author._save("Added new photo", action="add-photo", data={"url": url})
 
@@ -180,7 +180,7 @@ class manage_covers(delegate.page):
     def get_image(self, book):
         return book.get_cover()
 
-    def save_images(self, book, covers):
+    def save_images(self, book, covers) -> None:
         book.covers = covers
         book._save('Update covers')
 
@@ -212,6 +212,6 @@ class manage_photos(manage_covers):
     def get_image(self, author):
         return author.get_photo()
 
-    def save_images(self, author, photos):
+    def save_images(self, author, photos) -> None:
         author.photos = photos
         author._save('Update photos')

--- a/openlibrary/plugins/upstream/data.py
+++ b/openlibrary/plugins/upstream/data.py
@@ -25,7 +25,7 @@ get_ol_dumps = web.memoize(get_ol_dumps, 30 * 60, background=True)
 # public(get_ol_dumps)
 
 
-def download_url(item, filename):
+def download_url(item, filename) -> str:
     return f"{IA_BASE_URL}/download/{item}/{filename}"
 
 
@@ -95,5 +95,5 @@ class ol_cdumps(delegate.page):
             raise web.found(download_url(item, item + ".txt.gz"))
 
 
-def setup():
+def setup() -> None:
     pass

--- a/openlibrary/plugins/upstream/edits.py
+++ b/openlibrary/plugins/upstream/edits.py
@@ -88,10 +88,10 @@ class community_edits_queue(delegate.page):
         comment: str | None = None,
         primary: str | None = None,
     ):
-        def is_valid_action(action):
+        def is_valid_action(action) -> bool:
             return action in ('create-pending', 'create-merged')
 
-        def needs_unique_url(mr_type):
+        def needs_unique_url(mr_type) -> bool:
             return mr_type in (
                 CommunityEditsQueue.TYPE['WORK_MERGE'],
                 CommunityEditsQueue.TYPE['AUTHOR_MERGE'],
@@ -204,5 +204,5 @@ class community_edits_queue(delegate.page):
         return 'Unknown record'
 
 
-def setup():
+def setup() -> None:
     pass

--- a/openlibrary/plugins/upstream/forms.py
+++ b/openlibrary/plugins/upstream/forms.py
@@ -67,7 +67,7 @@ vemail = RegexpValidator(
 
 
 class EqualToValidator(Validator):
-    def __init__(self, fieldname, message):
+    def __init__(self, fieldname, message) -> None:
         Validator.__init__(self, message, None)
         self.fieldname = fieldname
         self.form = None
@@ -129,7 +129,7 @@ class RegisterForm(Form):
         ),
     )
 
-    def __init__(self):
+    def __init__(self) -> None:
         Form.__init__(self, *self.INPUTS)
 
     def validates(self, source):
@@ -145,7 +145,7 @@ Register = RegisterForm()
 forms.register = RegisterForm()
 
 
-def verify_password(password):
+def verify_password(password) -> bool:
     user = accounts.get_current_user()
     if user is None:
         return False

--- a/openlibrary/plugins/upstream/merge_authors.py
+++ b/openlibrary/plugins/upstream/merge_authors.py
@@ -71,7 +71,7 @@ class BasicMergeEngine:
     Generic merge functionality useful for all types of merges.
     """
 
-    def __init__(self, redirect_engine):
+    def __init__(self, redirect_engine) -> None:
         """
         :param BasicRedirectEngine redirect_engine:
         """
@@ -366,5 +366,5 @@ class merge_authors_json(delegate.page):
         )
 
 
-def setup():
+def setup() -> None:
     pass

--- a/openlibrary/plugins/upstream/recentchanges.py
+++ b/openlibrary/plugins/upstream/recentchanges.py
@@ -146,7 +146,7 @@ class recentchanges_view(delegate.page):
     def is_enabled(self):
         return features.is_enabled("recentchanges_v2")
 
-    def get_change_url(self, change):
+    def get_change_url(self, change) -> str:
         t = change.timestamp
         return "/recentchanges/%04d/%02d/%02d/%s/%s" % (
             t.year,

--- a/openlibrary/plugins/upstream/tests/test_account.py
+++ b/openlibrary/plugins/upstream/tests/test_account.py
@@ -14,7 +14,7 @@ def open_test_data(filename):
     return open(fullpath, mode='rb')
 
 
-def test_create_list_doc(wildcard):
+def test_create_list_doc(wildcard) -> None:
     key = "account/foo/verify"
     username = "foo"
     email = "foo@example.com"
@@ -34,7 +34,7 @@ def test_create_list_doc(wildcard):
 
 
 class TestGoodReadsImport:
-    def setup_method(self, method):
+    def setup_method(self, method) -> None:
         with open_test_data('goodreads_library_export.csv') as reader:
             self.csv_data = reader.read()
 
@@ -146,14 +146,14 @@ class TestGoodReadsImport:
     @pytest.mark.skipif(
         sys.version_info < (3, 0), reason="Python2's csv module doesn't support Unicode"
     )
-    def test_process_goodreads_csv_with_utf8(self):
+    def test_process_goodreads_csv_with_utf8(self) -> None:
         books, books_wo_isbns = account.process_goodreads_csv(
             web.storage({'csv': self.csv_data.decode('utf-8')})
         )
         assert books == self.expected_books
         assert books_wo_isbns == self.expected_books_wo_isbns
 
-    def test_process_goodreads_csv_with_bytes(self):
+    def test_process_goodreads_csv_with_bytes(self) -> None:
         # Note: In Python2, reading data as bytes returns a string, which should
         # also be supported by account.process_goodreads_csv()
         books, books_wo_isbns = account.process_goodreads_csv(

--- a/openlibrary/plugins/upstream/tests/test_forms.py
+++ b/openlibrary/plugins/upstream/tests/test_forms.py
@@ -2,7 +2,7 @@ from .. import forms, spamcheck
 
 
 class TestRegister:
-    def test_validate(self, monkeypatch):
+    def test_validate(self, monkeypatch) -> None:
         monkeypatch.setattr(forms, 'find_account', lambda **kw: None)
         monkeypatch.setattr(forms, 'find_ia_account', lambda **kw: None)
         monkeypatch.setattr(spamcheck, "get_spam_domains", list)

--- a/openlibrary/plugins/upstream/tests/test_related_carousels.py
+++ b/openlibrary/plugins/upstream/tests/test_related_carousels.py
@@ -1,7 +1,7 @@
 from .. import models
 
 
-def test_related_subjects():
+def test_related_subjects() -> None:
     subjects = {
         "In library",
         "Conduct of life",

--- a/openlibrary/plugins/upstream/tests/test_utils.py
+++ b/openlibrary/plugins/upstream/tests/test_utils.py
@@ -9,14 +9,14 @@ from openlibrary.mocks.mock_infobase import MockSite
 from .. import utils
 
 
-def test_url_quote():
+def test_url_quote() -> None:
     assert utils.url_quote('https://foo bar') == 'https%3A%2F%2Ffoo+bar'
     assert utils.url_quote('abc') == 'abc'
     assert utils.url_quote('Kabitā') == 'Kabit%C4%81'
     assert utils.url_quote('Kabit\u0101') == 'Kabit%C4%81'
 
 
-def test_urlencode():
+def test_urlencode() -> None:
     f = utils.urlencode
     assert f({}) == '', 'empty dict'
     assert f([]) == '', 'empty list'
@@ -36,14 +36,14 @@ def test_urlencode():
     assert f({'q': 'αβγ'}) == 'q=%CE%B1%CE%B2%CE%B3', 'unicode'
 
 
-def test_entity_decode():
+def test_entity_decode() -> None:
     assert utils.entity_decode('&gt;foo') == '>foo'
     assert utils.entity_decode('<h1>') == '<h1>'
 
 
-def test_set_share_links():
+def test_set_share_links() -> None:
     class TestContext:
-        def __init__(self):
+        def __init__(self) -> None:
             self.share_links = None
 
     test_context = TestContext()
@@ -64,10 +64,10 @@ def test_set_share_links():
     ]
 
 
-def test_set_share_links_unicode():
+def test_set_share_links_unicode() -> None:
     # example work that has a unicode title: https://openlibrary.org/works/OL14930766W/Kabit%C4%81
     class TestContext:
-        def __init__(self):
+        def __init__(self) -> None:
             self.share_links = None
 
     test_context = TestContext()
@@ -90,13 +90,13 @@ def test_set_share_links_unicode():
     ]
 
 
-def test_item_image():
+def test_item_image() -> None:
     assert utils.item_image('//foo') == 'https://foo'
     assert utils.item_image(None, 'bar') == 'bar'
     assert utils.item_image(None) is None
 
 
-def test_canonical_url():
+def test_canonical_url() -> None:
     web.ctx.path = '/authors/Ayn_Rand'
     web.ctx.query = ''
     web.ctx.host = 'www.openlibrary.org'
@@ -134,7 +134,7 @@ def test_canonical_url():
     assert request.canonical_url == url
 
 
-def test_get_coverstore_url(monkeypatch):
+def test_get_coverstore_url(monkeypatch) -> None:
     from infogami import config
 
     monkeypatch.delattr(config, "coverstore_url", raising=False)
@@ -148,7 +148,7 @@ def test_get_coverstore_url(monkeypatch):
     assert utils.get_coverstore_url() == "https://0.0.0.0:80"
 
 
-def test_reformat_html():
+def test_reformat_html() -> None:
     f = utils.reformat_html
 
     input_string = '<p>This sentence has 32 characters.</p>'
@@ -168,7 +168,7 @@ def test_reformat_html():
     assert f("&lt;script&gt;") == "&lt;script&gt;"
 
 
-def test_strip_accents():
+def test_strip_accents() -> None:
     f = utils.strip_accents
     assert f('Plain ASCII text') == 'Plain ASCII text'
     assert f('Des idées napoléoniennes') == 'Des idees napoleoniennes'

--- a/openlibrary/plugins/worksearch/autocomplete.py
+++ b/openlibrary/plugins/worksearch/autocomplete.py
@@ -34,7 +34,7 @@ class autocomplete(delegate.page):
         else:
             return None
 
-    def doc_wrap(self, doc: dict):
+    def doc_wrap(self, doc: dict) -> None:
         """Modify the returned solr document in place."""
         if 'name' not in doc:
             doc['name'] = doc.get('title')
@@ -116,7 +116,7 @@ class works_autocomplete(autocomplete):
         # reasons.
         return doc['key'][-1] == 'W'
 
-    def doc_wrap(self, doc: dict):
+    def doc_wrap(self, doc: dict) -> None:
         doc['full_title'] = doc['title']
         if 'subtitle' in doc:
             doc['full_title'] += ": " + doc['subtitle']
@@ -130,7 +130,7 @@ class authors_autocomplete(autocomplete):
     olid_suffix = 'A'
     query = 'name:({q}*) OR alternate_names:({q}*) OR name:"{q}"^2 OR alternate_names:"{q}"^2'
 
-    def doc_wrap(self, doc: dict):
+    def doc_wrap(self, doc: dict) -> None:
         if 'top_work' in doc:
             doc['works'] = [doc.pop('top_work')]
         else:
@@ -155,6 +155,6 @@ class subjects_autocomplete(autocomplete):
         return super().direct_get(fq=fq)
 
 
-def setup():
+def setup() -> None:
     """Do required setup."""
     pass

--- a/openlibrary/plugins/worksearch/bulk_search.py
+++ b/openlibrary/plugins/worksearch/bulk_search.py
@@ -10,5 +10,5 @@ class bulk_search(delegate.page):
         return render['bulk_search/bulk_search']()
 
 
-def setup():
+def setup() -> None:
     pass

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -489,7 +489,7 @@ class search(delegate.page):
         if need_redirect:
             raise web.seeother(web.changequery(**params))
 
-    def isbn_redirect(self, isbn_param):
+    def isbn_redirect(self, isbn_param) -> None:
         isbn = normalize_isbn(isbn_param)
         if not isbn:
             return
@@ -1000,7 +1000,7 @@ class search_json(delegate.page):
         return delegate.RawText(json.dumps(response, indent=4))
 
 
-def setup():
+def setup() -> None:
     from openlibrary.plugins.worksearch import (
         autocomplete,
         bulk_search,

--- a/openlibrary/plugins/worksearch/languages.py
+++ b/openlibrary/plugins/worksearch/languages.py
@@ -20,7 +20,7 @@ logger = logging.getLogger("openlibrary.worksearch")
 class languages(subjects.subjects):
     path = '(/languages/[^_][^/]*)'
 
-    def is_enabled(self):
+    def is_enabled(self) -> bool:
         return "languages" in web.ctx.features
 
 
@@ -28,7 +28,7 @@ class languages_json(subjects.subjects_json):
     path = '(/languages/[^_][^/]*)'
     encoding = "json"
 
-    def is_enabled(self):
+    def is_enabled(self) -> bool:
         return "languages" in web.ctx.features
 
     def normalize_key(self, key):
@@ -96,7 +96,7 @@ class index(delegate.page):
 
         return render_template("languages/index", get_top_languages(500, sort=sort))
 
-    def is_enabled(self):
+    def is_enabled(self) -> bool:
         return True
 
 
@@ -158,7 +158,7 @@ class LanguageEngine(subjects.SubjectEngine):
         return counts.get('true')
 
 
-def setup():
+def setup() -> None:
     subjects.SUBJECTS.append(
         subjects.SubjectMeta(
             name="language",

--- a/openlibrary/plugins/worksearch/publishers.py
+++ b/openlibrary/plugins/worksearch/publishers.py
@@ -25,7 +25,7 @@ class publishers(subjects.subjects):
 
         return render_template("publishers/view", page)
 
-    def is_enabled(self):
+    def is_enabled(self) -> bool:
         return "publishers" in web.ctx.features
 
 
@@ -33,7 +33,7 @@ class publishers_json(subjects.subjects_json):
     path = '(/publishers/[^/]+)'
     encoding = "json"
 
-    def is_enabled(self):
+    def is_enabled(self) -> bool:
         return "publishers" in web.ctx.features
 
     def normalize_key(self, key):
@@ -49,7 +49,7 @@ class index(delegate.page):
     def GET(self):
         return render_template("publishers/index")
 
-    def is_enabled(self):
+    def is_enabled(self) -> bool:
         return "publishers" in web.ctx.features
 
 
@@ -101,7 +101,7 @@ class PublisherEngine(subjects.SubjectEngine):
         return counts.get('true')
 
 
-def setup():
+def setup() -> None:
     subjects.SUBJECTS.append(
         subjects.SubjectMeta(
             name="publisher",

--- a/openlibrary/plugins/worksearch/schemes/__init__.py
+++ b/openlibrary/plugins/worksearch/schemes/__init__.py
@@ -32,7 +32,7 @@ class SearchScheme:
     # Fields that should be rewritten
     facet_rewrites: MappingProxyType[tuple[str, str], str | Callable[[], str]]
 
-    def is_search_field(self, field: str):
+    def is_search_field(self, field: str) -> bool:
         return field in self.all_fields or field in self.field_name_map
 
     def process_user_sort(self, user_sort: str) -> str:

--- a/openlibrary/plugins/worksearch/schemes/tests/test_works.py
+++ b/openlibrary/plugins/worksearch/schemes/tests/test_works.py
@@ -117,7 +117,7 @@ QUERY_PARSER_TESTS = {
     QUERY_PARSER_TESTS.values(),
     ids=QUERY_PARSER_TESTS.keys(),
 )
-def test_process_user_query(query, parsed_query):
+def test_process_user_query(query, parsed_query) -> None:
     s = WorkSearchScheme()
     assert s.process_user_query(query) == parsed_query
 
@@ -132,7 +132,7 @@ EDITION_KEY_TESTS = {
 
 
 @pytest.mark.parametrize(('query', 'edQuery'), EDITION_KEY_TESTS.items())
-def test_q_to_solr_params_edition_key(query, edQuery):
+def test_q_to_solr_params_edition_key(query, edQuery) -> None:
     import web
 
     web.ctx.lang = 'en'

--- a/openlibrary/plugins/worksearch/schemes/works.py
+++ b/openlibrary/plugins/worksearch/schemes/works.py
@@ -608,7 +608,7 @@ class WorkSearchScheme(SearchScheme):
                         ed_doc[field] = val if isinstance(val, str) else val.value
 
 
-def lcc_transform(sf: luqum.tree.SearchField):
+def lcc_transform(sf: luqum.tree.SearchField) -> None:
     # e.g. lcc:[NC1 TO NC1000] to lcc:[NC-0001.00000000 TO NC-1000.00000000]
     # for proper range search
     val = sf.children[0]
@@ -662,7 +662,7 @@ def ddc_transform(sf: luqum.tree.SearchField):
         logger.warning(f"Unexpected ddc SearchField value type: {type(val)}")
 
 
-def isbn_transform(sf: luqum.tree.SearchField):
+def isbn_transform(sf: luqum.tree.SearchField) -> None:
     field_val = sf.children[0]
     if isinstance(field_val, luqum.tree.Word) and '*' not in field_val.value:
         isbn = normalize_isbn(field_val.value)
@@ -672,7 +672,7 @@ def isbn_transform(sf: luqum.tree.SearchField):
         logger.warning(f"Unexpected isbn SearchField value type: {type(field_val)}")
 
 
-def ia_collection_s_transform(sf: luqum.tree.SearchField):
+def ia_collection_s_transform(sf: luqum.tree.SearchField) -> None:
     """
     Because this field is not a multi-valued field in solr, but a simple ;-separate
     string, we have to do searches like this for now.

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -467,7 +467,7 @@ SUBJECTS = [
 ]
 
 
-def setup():
+def setup() -> None:
     """Placeholder for doing any setup required.
 
     This function is called from code.py.

--- a/openlibrary/plugins/worksearch/tests/test_autocomplete.py
+++ b/openlibrary/plugins/worksearch/tests/test_autocomplete.py
@@ -7,7 +7,7 @@ from openlibrary.plugins.worksearch.autocomplete import autocomplete, works_auto
 from openlibrary.utils.solr import Solr
 
 
-def test_autocomplete():
+def test_autocomplete() -> None:
     ac = autocomplete()
     with (
         patch('web.input') as mock_web_input,
@@ -30,7 +30,7 @@ def test_autocomplete():
         assert mock_solr_select.call_args.kwargs['rows'] == 5
 
 
-def test_works_autocomplete():
+def test_works_autocomplete() -> None:
     ac = works_autocomplete()
     with (
         patch('web.input') as mock_web_input,

--- a/openlibrary/records/driver.py
+++ b/openlibrary/records/driver.py
@@ -83,7 +83,7 @@ def run_filter(matched_keys, params):
      equivalent).
     """
 
-    def compare(i1, i2):
+    def compare(i1, i2) -> bool:
         """Compares `i1` to see if it matches `i2`
         according to the rules stated above.
 

--- a/openlibrary/solr/update.py
+++ b/openlibrary/solr/update.py
@@ -131,7 +131,7 @@ async def update_keys(
     return net_update
 
 
-async def do_updates(keys):
+async def do_updates(keys) -> None:
     logging.basicConfig(
         level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s"
     )
@@ -172,7 +172,7 @@ async def main(
     solr_base: str | None = None,
     solr_next=False,
     update: Literal['update', 'print', 'pprint'] = 'update',
-):
+) -> None:
     """
     Insert the documents with the given keys into Solr.
 

--- a/openlibrary/solr/updater/abstract.py
+++ b/openlibrary/solr/updater/abstract.py
@@ -12,13 +12,13 @@ class AbstractSolrUpdater:
     thing_type: str
     data_provider: DataProvider
 
-    def __init__(self, data_provider: DataProvider):
+    def __init__(self, data_provider: DataProvider) -> None:
         self.data_provider = data_provider
 
     def key_test(self, key: str) -> bool:
         return key.startswith(self.key_prefix)
 
-    async def preload_keys(self, keys: Iterable[str]):
+    async def preload_keys(self, keys: Iterable[str]) -> None:
         await self.data_provider.preload_documents(keys)
 
     async def update_key(self, thing: dict) -> tuple[SolrUpdateRequest, list[str]]:

--- a/openlibrary/solr/updater/author.py
+++ b/openlibrary/solr/updater/author.py
@@ -59,7 +59,7 @@ class AuthorSolrUpdater(AbstractSolrUpdater):
 
 
 class AuthorSolrBuilder(AbstractSolrBuilder):
-    def __init__(self, author: dict, solr_reply: dict):
+    def __init__(self, author: dict, solr_reply: dict) -> None:
         self._author = author
         self._solr_reply = solr_reply
 

--- a/openlibrary/solr/updater/edition.py
+++ b/openlibrary/solr/updater/edition.py
@@ -100,7 +100,7 @@ class EditionSolrBuilder(AbstractSolrBuilder):
         edition: dict,
         solr_work: 'WorkSolrBuilder | None' = None,
         ia_metadata: bp.IALiteMetadata | None = None,
-    ):
+    ) -> None:
         self._edition = edition
         self._solr_work = solr_work
         self._ia_metadata = ia_metadata

--- a/openlibrary/solr/updater/list.py
+++ b/openlibrary/solr/updater/list.py
@@ -70,7 +70,7 @@ async def fetch_seeds_facets(seeds: list[str]):
 
 
 class ListSolrBuilder(AbstractSolrBuilder):
-    def __init__(self, list: dict, solr_reply: dict | None = None):
+    def __init__(self, list: dict, solr_reply: dict | None = None) -> None:
         self._list = list
         self._solr_reply = solr_reply
 

--- a/openlibrary/solr/updater/work.py
+++ b/openlibrary/solr/updater/work.py
@@ -36,7 +36,7 @@ class WorkSolrUpdater(AbstractSolrUpdater):
     key_prefix = '/works/'
     thing_type = '/type/work'
 
-    async def preload_keys(self, keys: Iterable[str]):
+    async def preload_keys(self, keys: Iterable[str]) -> None:
         await super().preload_keys(keys)
         self.data_provider.preload_editions_of_works(keys)
 
@@ -268,7 +268,7 @@ class WorkSolrBuilder(AbstractSolrBuilder):
         data_provider: DataProvider,
         ia_metadata: dict[str, Optional['bp.IALiteMetadata']],
         trending_data: dict,
-    ):
+    ) -> None:
         self._work = work
         self._editions = editions
         self._authors = authors
@@ -297,7 +297,7 @@ class WorkSolrBuilder(AbstractSolrBuilder):
         return self._work['key']
 
     @property
-    def type(self):
+    def type(self) -> str:
         return 'work'
 
     @property

--- a/openlibrary/solr/utils.py
+++ b/openlibrary/solr/utils.py
@@ -18,7 +18,7 @@ solr_base_url = None
 solr_next: bool | None = None
 
 
-def load_config(c_config='conf/openlibrary.yml'):
+def load_config(c_config='conf/openlibrary.yml') -> None:
     if not config.runtime_config:
         config.load(c_config)
         config.load_config(c_config)
@@ -44,7 +44,7 @@ def get_solr_base_url():
     return solr_base_url
 
 
-def set_solr_base_url(solr_url: str):
+def set_solr_base_url(solr_url: str) -> None:
     global solr_base_url
     solr_base_url = solr_url
 
@@ -69,7 +69,7 @@ def get_solr_next() -> bool:
     return solr_next
 
 
-def set_solr_next(val: bool):
+def set_solr_next(val: bool) -> None:
     global solr_next
     solr_next = val
 
@@ -187,7 +187,7 @@ async def solr_insert_documents(
     documents: list[dict],
     solr_base_url: str | None = None,
     skip_id_check=False,
-):
+) -> None:
     """
     Note: This has only been tested with Solr 8, but might work with Solr 3 as well.
     """

--- a/openlibrary/tests/accounts/test_models.py
+++ b/openlibrary/tests/accounts/test_models.py
@@ -9,13 +9,13 @@ def get_username(account):
     return account and account.value
 
 
-def test_verify_hash():
+def test_verify_hash() -> None:
     secret_key = b"aqXwLJVOcV"
     hash = model.generate_hash(secret_key, b"foo")
     assert model.verify_hash(secret_key, b"foo", hash)
 
 
-def test_xauth_http_error_without_json(monkeypatch):
+def test_xauth_http_error_without_json(monkeypatch) -> None:
     xauth = InternetArchiveAccount.xauth
     resp = Response()
     resp.status_code = 500
@@ -27,7 +27,7 @@ def test_xauth_http_error_without_json(monkeypatch):
     }
 
 
-def test_xauth_http_error_with_json(monkeypatch):
+def test_xauth_http_error_with_json(monkeypatch) -> None:
     xauth = InternetArchiveAccount.xauth
     resp = Response()
     resp.status_code = 400
@@ -39,7 +39,7 @@ def test_xauth_http_error_with_json(monkeypatch):
 
 
 @mock.patch("openlibrary.accounts.model.web")
-def test_get(mock_web):
+def test_get(mock_web) -> None:
     test = True
     email = "test@example.com"
     account = OpenLibraryAccount.get_by_email(email)

--- a/openlibrary/tests/catalog/test_utils.py
+++ b/openlibrary/tests/catalog/test_utils.py
@@ -27,7 +27,7 @@ from openlibrary.catalog.utils import (
 )
 
 
-def test_author_dates_match():
+def test_author_dates_match() -> None:
     _atype = {'key': '/type/author'}
     basic = {
         'name': 'John Smith',
@@ -82,13 +82,13 @@ def test_author_dates_match():
     )  # this shows matches are only occurring on year, full dates are ignored!
 
 
-def test_flip_name():
+def test_flip_name() -> None:
     assert flip_name('Smith, John.') == 'John Smith'
     assert flip_name('Smith, J.') == 'J. Smith'
     assert flip_name('No comma.') == 'No comma'
 
 
-def test_pick_first_date():
+def test_pick_first_date() -> None:
     assert pick_first_date(["Mrs.", "1839-"]) == {'birth_date': '1839'}
     assert pick_first_date(["1882-."]) == {'birth_date': '1882'}
     assert pick_first_date(["1900-1990.."]) == {
@@ -98,7 +98,7 @@ def test_pick_first_date():
     assert pick_first_date(["4th/5th cent."]) == {'date': '4th/5th cent.'}
 
 
-def test_pick_best_name():
+def test_pick_best_name() -> None:
     names = [
         'Andre\u0301 Joa\u0303o Antonil',
         'Andr\xe9 Jo\xe3o Antonil',
@@ -116,7 +116,7 @@ def test_pick_best_name():
     assert pick_best_name(names) == best
 
 
-def test_pick_best_author():
+def test_pick_best_author() -> None:
     a1 = {
         'name': 'Bretteville, Etienne Dubois abb\xe9 de',
         'death_date': '1688',
@@ -147,7 +147,7 @@ def combinations(items, n):
                 yield [items[i]] + cc
 
 
-def test_match_with_bad_chars():
+def test_match_with_bad_chars() -> None:
     samples = [
         ['Machiavelli, Niccolo, 1469-1527', 'Machiavelli, Niccol\xf2 1469-1527'],
         ['Humanitas Publica\xe7\xf5es', 'Humanitas Publicac?o?es'],
@@ -177,7 +177,7 @@ def test_match_with_bad_chars():
             assert match_with_bad_chars(a, b)
 
 
-def test_strip_count():
+def test_strip_count() -> None:
     input = [
         ('Side by side', ['a', 'b', 'c', 'd']),
         ('Side by side.', ['e', 'f', 'g']),
@@ -190,7 +190,7 @@ def test_strip_count():
     assert strip_count(input) == expect
 
 
-def test_remove_trailing_dot():
+def test_remove_trailing_dot() -> None:
     data = [
         ('Test', 'Test'),
         ('Test.', 'Test'),

--- a/openlibrary/tests/core/test_db.py
+++ b/openlibrary/tests/core/test_db.py
@@ -85,19 +85,19 @@ CREATE TABLE yearly_reading_goals (
 
 class TestUpdateWorkID:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         web.config.db_parameters = {"dbn": "sqlite", "db": ":memory:"}
         db = get_db()
         db.query(READING_LOG_DDL)
         db.query(BOOKNOTES_DDL)
 
     @classmethod
-    def teardown_class(cls):
+    def teardown_class(cls) -> None:
         db = get_db()
         db.query("delete from bookshelves_books;")
         db.query("delete from booknotes;")
 
-    def setup_method(self, method):
+    def setup_method(self, method) -> None:
         self.db = get_db()
         self.source_book = {
             "username": "@cdrini",
@@ -108,10 +108,10 @@ class TestUpdateWorkID:
         assert not list(self.db.select("bookshelves_books"))
         self.db.insert("bookshelves_books", **self.source_book)
 
-    def teardown_method(self):
+    def teardown_method(self) -> None:
         self.db.query("delete from bookshelves_books;")
 
-    def test_update_collision(self):
+    def test_update_collision(self) -> None:
         existing_book = {
             "username": "@cdrini",
             "work_id": "2",
@@ -136,11 +136,11 @@ class TestUpdateWorkID:
             )
         ), "old work_id 1 present"
 
-    def test_update_simple(self):
+    def test_update_simple(self) -> None:
         assert len(list(self.db.select("bookshelves_books"))) == 1
         Bookshelves.update_work_id(self.source_book['work_id'], "2")
 
-    def test_no_allow_delete_on_conflict(self):
+    def test_no_allow_delete_on_conflict(self) -> None:
         rows = [
             {"username": "@mek", "work_id": 1, "edition_id": 1, "notes": "Jimmeny"},
             {"username": "@mek", "work_id": 2, "edition_id": 1, "notes": "Cricket"},
@@ -246,27 +246,27 @@ EDITS_QUEUE_SETUP_ROWS = [
 
 class TestUsernameUpdate:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         web.config.db_parameters = {"dbn": "sqlite", "db": ":memory:"}
         db = get_db()
         db.query(RATINGS_DDL)
         db.query(OBSERVATIONS_DDL)
         db.query(COMMUNITY_EDITS_QUEUE_DDL)
 
-    def setup_method(self):
+    def setup_method(self) -> None:
         self.db = get_db()
         self.db.multiple_insert("bookshelves_books", READING_LOG_SETUP_ROWS)
         self.db.multiple_insert("booknotes", BOOKNOTES_SETUP_ROWS)
         self.db.multiple_insert("ratings", RATINGS_SETUP_ROWS)
         self.db.multiple_insert("observations", OBSERVATIONS_SETUP_ROWS)
 
-    def teardown_method(self):
+    def teardown_method(self) -> None:
         self.db.query("delete from bookshelves_books;")
         self.db.query("delete from booknotes;")
         self.db.query("delete from ratings;")
         self.db.query("delete from observations;")
 
-    def test_delete_all_by_username(self):
+    def test_delete_all_by_username(self) -> None:
         assert len(list(self.db.select("bookshelves_books"))) == 3
         Bookshelves.delete_all_by_username("@kilgore_trout")
         assert len(list(self.db.select("bookshelves_books"))) == 1
@@ -283,7 +283,7 @@ class TestUsernameUpdate:
         Observations.delete_all_by_username("@kilgore_trout")
         assert len(list(self.db.select("observations"))) == 1
 
-    def test_update_username(self):
+    def test_update_username(self) -> None:
         self.db.multiple_insert("community_edits_queue", EDITS_QUEUE_SETUP_ROWS)
         before_where = {"username": "@kilgore_trout"}
         after_where = {"username": "@anonymous"}
@@ -381,19 +381,19 @@ BOOKSHELVES_EVENTS_SETUP_ROWS = [
 
 class TestCheckIns:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         web.config.db_parameters = {"dbn": "sqlite", "db": ":memory:"}
         db = get_db()
         db.query(BOOKSHELVES_EVENTS_DDL)
 
-    def setup_method(self):
+    def setup_method(self) -> None:
         self.db = get_db()
         self.db.multiple_insert('bookshelves_events', BOOKSHELVES_EVENTS_SETUP_ROWS)
 
-    def teardown_method(self):
+    def teardown_method(self) -> None:
         self.db.query("delete from bookshelves_events;")
 
-    def test_create_event(self):
+    def test_create_event(self) -> None:
         assert len(list(self.db.select('bookshelves_events'))) == 6
         assert (
             len(
@@ -418,7 +418,7 @@ class TestCheckIns:
             == 2
         )
 
-    def test_select_all_by_username(self):
+    def test_select_all_by_username(self) -> None:
         assert len(list(self.db.select('bookshelves_events'))) == 6
         assert (
             len(
@@ -445,7 +445,7 @@ class TestCheckIns:
             == 4
         )
 
-    def test_update_event_date(self):
+    def test_update_event_date(self) -> None:
         assert len(list(self.db.select('bookshelves_events', where={"id": 1}))) == 1
         row = self.db.select('bookshelves_events', where={"id": 1})[0]
         assert row['event_date'] == "2022-04-17"
@@ -454,14 +454,14 @@ class TestCheckIns:
         row = self.db.select('bookshelves_events', where={"id": 1})[0]
         assert row['event_date'] == new_date
 
-    def test_delete_by_id(self):
+    def test_delete_by_id(self) -> None:
         assert len(list(self.db.select('bookshelves_events'))) == 6
         assert len(list(self.db.select('bookshelves_events', where={"id": 1}))) == 1
         BookshelvesEvents.delete_by_id(1)
         assert len(list(self.db.select('bookshelves_events'))) == 5
         assert len(list(self.db.select('bookshelves_events', where={"id": 1}))) == 0
 
-    def test_delete_by_username(self):
+    def test_delete_by_username(self) -> None:
         assert len(list(self.db.select('bookshelves_events'))) == 6
         assert (
             len(
@@ -486,7 +486,7 @@ class TestCheckIns:
             == 0
         )
 
-    def test_get_latest_event_date(self):
+    def test_get_latest_event_date(self) -> None:
         assert (
             BookshelvesEvents.get_latest_event_date('@eliot_rosewater', 3, 3)[
                 'event_date'
@@ -526,19 +526,19 @@ class TestYearlyReadingGoals:
     TABLENAME = YearlyReadingGoals.TABLENAME
 
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         web.config.db_parameters = {"dbn": 'sqlite', "db": ':memory:'}
         db = get_db()
         db.query(YEARLY_READING_GOALS_DDL)
 
-    def setup_method(self):
+    def setup_method(self) -> None:
         self.db = get_db()
         self.db.multiple_insert(self.TABLENAME, SETUP_ROWS)
 
-    def teardown_method(self):
+    def teardown_method(self) -> None:
         self.db.query('delete from yearly_reading_goals')
 
-    def test_create(self):
+    def test_create(self) -> None:
         assert len(list(self.db.select(self.TABLENAME))) == 3
         assert (
             len(
@@ -565,18 +565,18 @@ class TestYearlyReadingGoals:
         assert len(new_row) == 1
         assert new_row[0]['current'] == 0
 
-    def test_select_by_username_and_year(self):
+    def test_select_by_username_and_year(self) -> None:
         assert (
             len(YearlyReadingGoals.select_by_username_and_year('@billy_pilgrim', 2022))
             == 1
         )
 
-    def test_has_reached_goal(self):
+    def test_has_reached_goal(self) -> None:
         assert YearlyReadingGoals.has_reached_goal('@billy_pilgrim', 2022)
         assert not YearlyReadingGoals.has_reached_goal('@billy_pilgrim', 2023)
         assert YearlyReadingGoals.has_reached_goal('@kilgore_trout', 2022)
 
-    def test_update_current_count(self):
+    def test_update_current_count(self) -> None:
         assert (
             next(
                 iter(
@@ -601,7 +601,7 @@ class TestYearlyReadingGoals:
             == 10
         )
 
-    def test_update_target(self):
+    def test_update_target(self) -> None:
         assert (
             next(
                 iter(
@@ -626,7 +626,7 @@ class TestYearlyReadingGoals:
             == 14
         )
 
-    def test_delete_by_username(self):
+    def test_delete_by_username(self) -> None:
         assert (
             len(
                 list(

--- a/openlibrary/tests/core/test_helpers.py
+++ b/openlibrary/tests/core/test_helpers.py
@@ -4,7 +4,7 @@ from openlibrary.core import helpers as h
 from openlibrary.mocks.mock_infobase import MockSite
 
 
-def _load_fake_context():
+def _load_fake_context() -> None:
     app = web.application()
     env = {
         "PATH_INFO": "/",
@@ -13,7 +13,7 @@ def _load_fake_context():
     app.load(env)
 
 
-def _monkeypatch_web(monkeypatch):
+def _monkeypatch_web(monkeypatch) -> None:
     monkeypatch.setattr(web, "ctx", web.storage(x=1))
     monkeypatch.setattr(web.webapi, "ctx", web.ctx)
 
@@ -22,7 +22,7 @@ def _monkeypatch_web(monkeypatch):
     web.ctx.site = MockSite()
 
 
-def test_sanitize():
+def test_sanitize() -> None:
     # plain html should pass through
     assert h.sanitize("hello") == "hello"
     assert h.sanitize("<p>hello</p>") == "<p>hello</p>"
@@ -54,7 +54,7 @@ def test_sanitize():
     assert h.sanitize('<a href="relpath">hello</a>') == '<a href="relpath">hello</a>'
 
 
-def test_safesort():
+def test_safesort() -> None:
     from datetime import datetime
 
     y2000 = datetime(2000, 1, 1)
@@ -72,7 +72,7 @@ def test_safesort():
     assert h.safesort([[y2005], [None]], key=lambda x: x[0]) == [[None], [y2005]]
 
 
-def test_datestr(monkeypatch):
+def test_datestr(monkeypatch) -> None:
     from datetime import datetime
 
     then = datetime(2010, 1, 1, 0, 0, 0)
@@ -94,12 +94,12 @@ def test_datestr(monkeypatch):
     assert h.datestr(then, datetime(2010, 1, 9, 0, 0, 1), lang='fr') == '1 janvier 2010'
 
 
-def test_sprintf():
+def test_sprintf() -> None:
     assert h.sprintf('hello %s', 'python') == 'hello python'
     assert h.sprintf('hello %(name)s', name='python') == 'hello python'
 
 
-def test_commify():
+def test_commify() -> None:
     assert h.commify(123) == "123"
     assert h.commify(1234) == "1,234"
     assert h.commify(1234567) == "1,234,567"
@@ -109,7 +109,7 @@ def test_commify():
     assert h.commify(1234567, lang="te") == "12,34,567"
 
 
-def test_extract_year():
+def test_extract_year() -> None:
     assert h.extract_year("1980") == "1980"
     assert h.extract_year("2005-03-14") == "2005"
     assert h.extract_year("7 Dec 1999") == "1999"
@@ -122,13 +122,13 @@ def test_extract_year():
     assert h.extract_year("Year 123", int_only=False) == ""
 
 
-def test_truncate():
+def test_truncate() -> None:
     assert h.truncate("hello", 6) == "hello"
     assert h.truncate("hello", 5) == "hello"
     assert h.truncate("hello", 4) == "hell..."
 
 
-def test_urlsafe():
+def test_urlsafe() -> None:
     assert h.urlsafe("a b") == "a_b"
     assert h.urlsafe("a?b") == "a_b"
     assert h.urlsafe("a?&b") == "a_b"
@@ -137,12 +137,12 @@ def test_urlsafe():
     assert h.urlsafe("a?") == "a"
 
 
-def test_texsafe():
+def test_texsafe() -> None:
     assert h.texsafe("hello") == r"hello"
     assert h.texsafe("a_b") == r"a\_{}b"
     assert h.texsafe("a < b") == r"a \textless{} b"
 
 
-def test_percentage():
+def test_percentage() -> None:
     assert h.percentage(1, 10) == 10.0
     assert h.percentage(0, 0) == 0

--- a/openlibrary/tests/core/test_i18n.py
+++ b/openlibrary/tests/core/test_i18n.py
@@ -20,12 +20,12 @@ class MockLoadTranslations(dict):
     def __call__(self, lang):
         return self.get(lang)
 
-    def init(self, lang, translations):
+    def init(self, lang, translations) -> None:
         self[lang] = MockTranslations(translations)
 
 
 class Test_ungettext:
-    def setup_monkeypatch(self, monkeypatch):
+    def setup_monkeypatch(self, monkeypatch) -> None:
         self.d = MockLoadTranslations()
         ctx = web.storage()
 
@@ -37,7 +37,7 @@ class Test_ungettext:
         web.ctx.lang = 'en'
         web.ctx.site = MockSite()
 
-    def _load_fake_context(self):
+    def _load_fake_context(self) -> None:
         self.app = web.application()
         self.env = {
             "PATH_INFO": "/",
@@ -45,7 +45,7 @@ class Test_ungettext:
         }
         self.app.load(self.env)
 
-    def test_ungettext(self, monkeypatch):
+    def test_ungettext(self, monkeypatch) -> None:
         self.setup_monkeypatch(monkeypatch)
 
         assert i18n.ungettext("book", "books", 1) == "book"
@@ -67,7 +67,7 @@ class Test_ungettext:
         assert i18n.ungettext("book", "books", 1) == "book"
         assert i18n.ungettext("book", "books", 2) == "books"
 
-    def test_ungettext_with_args(self, monkeypatch):
+    def test_ungettext_with_args(self, monkeypatch) -> None:
         self.setup_monkeypatch(monkeypatch)
 
         assert i18n.ungettext("one book", "%(n)d books", 1, n=1) == "one book"

--- a/openlibrary/tests/core/test_ia.py
+++ b/openlibrary/tests/core/test_ia.py
@@ -1,7 +1,7 @@
 from openlibrary.core import ia
 
 
-def test_get_metadata(monkeypatch, mock_memcache):
+def test_get_metadata(monkeypatch, mock_memcache) -> None:
     metadata = {
         "metadata": {
             "title": "Foo",
@@ -20,6 +20,6 @@ def test_get_metadata(monkeypatch, mock_memcache):
     }
 
 
-def test_get_metadata_empty(monkeypatch, mock_memcache):
+def test_get_metadata_empty(monkeypatch, mock_memcache) -> None:
     monkeypatch.setattr(ia, 'get_api_response', lambda *args: {})
     assert ia.get_metadata('foo02bar') == {}

--- a/openlibrary/tests/core/test_imports.py
+++ b/openlibrary/tests/core/test_imports.py
@@ -124,13 +124,13 @@ def import_item_db_staged_and_pending(setup_item_db):
 
 
 class TestImportItem:
-    def test_delete(self, import_item_db):
+    def test_delete(self, import_item_db) -> None:
         assert len(list(import_item_db.select('import_item'))) == 3
 
         ImportItem.delete_items(['unique_id_1'])
         assert len(list(import_item_db.select('import_item'))) == 1
 
-    def test_delete_with_batch_id(self, import_item_db):
+    def test_delete_with_batch_id(self, import_item_db) -> None:
         assert len(list(import_item_db.select('import_item'))) == 3
 
         ImportItem.delete_items(['unique_id_1'], batch_id=1)
@@ -139,11 +139,13 @@ class TestImportItem:
         ImportItem.delete_items(['unique_id_1'], batch_id=2)
         assert len(list(import_item_db.select('import_item'))) == 1
 
-    def test_find_pending_returns_none_with_no_results(self, import_item_db_staged):
+    def test_find_pending_returns_none_with_no_results(
+        self, import_item_db_staged
+    ) -> None:
         """Try with only staged items in the DB."""
         assert ImportItem.find_pending() is None
 
-    def test_find_pending_returns_pending(self, import_item_db):
+    def test_find_pending_returns_pending(self, import_item_db) -> None:
         """Try with some pending items now."""
         items = ImportItem.find_pending()
         assert isinstance(items, map)
@@ -158,7 +160,7 @@ class TestImportItem:
     )
     def test_find_staged_or_pending(
         self, import_item_db_staged_and_pending, ia_id, expected
-    ):
+    ) -> None:
         """Get some staged and pending items by ia_id identifiers."""
         items = ImportItem.find_staged_or_pending([ia_id], sources=["idb"])
         assert [item['id'] for item in items] == expected
@@ -174,7 +176,7 @@ def setup_batch_db():
 
 
 class TestBatchItem:
-    def test_add_items_legacy(self, setup_batch_db):
+    def test_add_items_legacy(self, setup_batch_db) -> None:
         """This tests the legacy format of list[str] for items."""
         legacy_items = ["ocaid_1", "ocaid_2"]
         batch = Batch.new("test-legacy-batch")

--- a/openlibrary/tests/core/test_lending.py
+++ b/openlibrary/tests/core/test_lending.py
@@ -4,7 +4,7 @@ from openlibrary.core import lending
 
 
 class TestAddAvailability:
-    def test_reads_ocaids(self, monkeypatch):
+    def test_reads_ocaids(self, monkeypatch) -> None:
         def mock_get_availability(id_type, ocaids):
             return {'foo': {'status': 'available'}}
 
@@ -24,11 +24,11 @@ class TestAddAvailability:
             {'ia': ['foo'], 'availability': {'status': 'available'}}
         ]
 
-    def test_handles_ocaid_none(self):
+    def test_handles_ocaid_none(self) -> None:
         f = lending.add_availability
         assert f([{}]) == [{}]
 
-    def test_handles_availability_none(self, monkeypatch):
+    def test_handles_availability_none(self, monkeypatch) -> None:
         def mock_get_availability(id_type, ocaids):
             return {'foo': {'status': 'error'}}
 
@@ -41,7 +41,7 @@ class TestAddAvailability:
 
 
 class TestGetAvailability:
-    def test_cache(self):
+    def test_cache(self) -> None:
         with patch("openlibrary.core.ia.session.get") as mock_get:
             mock_get.return_value = Mock()
             mock_get.return_value.json.return_value = {

--- a/openlibrary/tests/core/test_lists_model.py
+++ b/openlibrary/tests/core/test_lists_model.py
@@ -3,7 +3,7 @@ from typing import cast
 from openlibrary.core.lists.model import List, Seed, ThingReferenceDict
 
 
-def test_seed_with_string():
+def test_seed_with_string() -> None:
     lst = List(None, "/list/OL1L", None)
     seed = Seed(lst, "subject/Politics and government")
     assert seed._list == lst
@@ -12,7 +12,7 @@ def test_seed_with_string():
     assert seed.type == "subject"
 
 
-def test_seed_with_nonstring():
+def test_seed_with_nonstring() -> None:
     lst = List(None, "/list/OL1L", None)
     not_a_string = cast(ThingReferenceDict, {"key": "not_a_string.key"})
     seed = Seed.from_json(lst, not_a_string)

--- a/openlibrary/tests/core/test_models.py
+++ b/openlibrary/tests/core/test_models.py
@@ -26,7 +26,7 @@ class TestEdition:
         data = {"key": "/books/OL1M", "type": {"key": "/type/edition"}, "title": "foo"}
         return edition_class(MockSite(), "/books/OL1M", data=data)
 
-    def test_url(self):
+    def test_url(self) -> None:
         e = self.mock_edition(models.Edition)
         assert e.url() == "/books/OL1M/foo"
         assert e.url(v=1) == "/books/OL1M/foo?v=1"
@@ -39,23 +39,23 @@ class TestEdition:
         e = models.Edition(MockSite(), "/books/OL1M", data=data)
         assert e.url() == "/books/OL1M/untitled"
 
-    def test_get_ebook_info(self):
+    def test_get_ebook_info(self) -> None:
         e = self.mock_edition(models.Edition)
         assert e.get_ebook_info() == {}
 
-    def test_is_not_in_private_collection(self):
+    def test_is_not_in_private_collection(self) -> None:
         e = self.mock_edition(MockLendableEdition)
         assert not e.is_in_private_collection()
 
-    def test_in_borrowable_collection_cuz_not_in_private_collection(self):
+    def test_in_borrowable_collection_cuz_not_in_private_collection(self) -> None:
         e = self.mock_edition(MockLendableEdition)
         assert e.in_borrowable_collection()
 
-    def test_is_in_private_collection(self):
+    def test_is_in_private_collection(self) -> None:
         e = self.mock_edition(MockPrivateEdition)
         assert e.is_in_private_collection()
 
-    def test_not_in_borrowable_collection_cuz_in_private_collection(self):
+    def test_not_in_borrowable_collection_cuz_in_private_collection(self) -> None:
         e = self.mock_edition(MockPrivateEdition)
         assert not e.in_borrowable_collection()
 
@@ -113,7 +113,7 @@ class TestEdition:
 
 
 class TestAuthor:
-    def test_url(self):
+    def test_url(self) -> None:
         data = {"key": "/authors/OL1A", "type": {"key": "/type/author"}, "name": "foo"}
 
         e = models.Author(MockSite(), "/authors/OL1A", data=data)
@@ -131,14 +131,14 @@ class TestAuthor:
 
 
 class TestSubject:
-    def test_url(self):
+    def test_url(self) -> None:
         subject = models.Subject({"key": "/subjects/love"})
         assert subject.url() == "/subjects/love"
         assert subject.url("/lists") == "/subjects/love/lists"
 
 
 class TestWork:
-    def test_resolve_redirect_chain(self, monkeypatch):
+    def test_resolve_redirect_chain(self, monkeypatch) -> None:
         # e.g. https://openlibrary.org/works/OL2163721W.json
 
         # Chain:

--- a/openlibrary/tests/core/test_observations.py
+++ b/openlibrary/tests/core/test_observations.py
@@ -1,7 +1,7 @@
 from openlibrary.core.observations import _sort_values
 
 
-def test_sort_values():
+def test_sort_values() -> None:
     orders_list = [3, 4, 2, 1]
     values_list = [
         {'id': 1, 'name': 'order'},

--- a/openlibrary/tests/core/test_olmarkdown.py
+++ b/openlibrary/tests/core/test_olmarkdown.py
@@ -1,11 +1,11 @@
 from openlibrary.core.olmarkdown import OLMarkdown
 
 
-def test_olmarkdown():
+def test_olmarkdown() -> None:
     def md(text):
         return OLMarkdown(text).convert().strip()
 
-    def p(html):
+    def p(html) -> str:
         # markdown always wraps the result in <p>.
         return "<p>%s\n</p>" % html
 

--- a/openlibrary/tests/core/test_ratings.py
+++ b/openlibrary/tests/core/test_ratings.py
@@ -1,3 +1,3 @@
 class TestRating:
-    def test_rate(self):
+    def test_rate(self) -> None:
         pass

--- a/openlibrary/tests/core/test_unmarshal.py
+++ b/openlibrary/tests/core/test_unmarshal.py
@@ -9,14 +9,14 @@ from openlibrary.api import unmarshal
 class Text(str):
     __slots__ = ()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<text: %s>" % str.__repr__(self)
 
 
 class Reference(str):
     __slots__ = ()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<ref: %s>" % str.__repr__(self)
 
 

--- a/openlibrary/tests/core/test_waitinglist.py
+++ b/openlibrary/tests/core/test_waitinglist.py
@@ -7,7 +7,7 @@ from openlibrary.core.waitinglist import WaitingLoan
 
 
 class TestWaitingLoan:
-    def test_new(self, monkeypatch):
+    def test_new(self, monkeypatch) -> None:
         user_key = '/people/user1'
         identifier = 'foobar'
         monkeypatch.setattr(
@@ -24,7 +24,7 @@ class TestWaitingLoan:
         assert w['status'] == 'waiting'
 
     @pytest.mark.xfail(run=False)
-    def test_update(self):
+    def test_update(self) -> None:
         w = WaitingLoan.new(user_key="U1", identifier="B1")
         assert w['status'] == 'waiting'
         w.update(status='available')
@@ -34,13 +34,13 @@ class TestWaitingLoan:
         assert w2['status'] == 'available'
 
     @pytest.mark.xfail(run=False)
-    def test_dict(self):
+    def test_dict(self) -> None:
         user_key = '/people/user1'
         book_key = '/books/OL1234M'
         w = WaitingLoan.new(user_key=user_key, identifier=book_key)
         # ensure that w.dict() is JSON-able
         json.dumps(w.dict())
 
-    def test_prune_expired(self):
+    def test_prune_expired(self) -> None:
         # prune_expired does nothing now but 'return'
         assert WaitingLoan.prune_expired() is None

--- a/openlibrary/tests/data/test_dump.py
+++ b/openlibrary/tests/data/test_dump.py
@@ -4,7 +4,7 @@ from openlibrary.data.dump import pgdecode, print_dump
 
 
 class TestPrintDump:
-    def test_fixes_prefixes(self, capsys):
+    def test_fixes_prefixes(self, capsys) -> None:
         records = [
             {
                 "key": "/b/OL1M",
@@ -32,7 +32,7 @@ class TestPrintDump:
             ]
         )
 
-    def test_excludes_sensitive_pages(self, capsys):
+    def test_excludes_sensitive_pages(self, capsys) -> None:
         records = [
             {"key": "/people/foo"},
             {"key": "/user/foo"},
@@ -41,7 +41,7 @@ class TestPrintDump:
         print_dump(map(json.dumps, records))
         assert capsys.readouterr().out == ""
 
-    def test_excludes_obsolete_pages(self, capsys):
+    def test_excludes_obsolete_pages(self, capsys) -> None:
         records = [
             {"key": "/scan_record/foo"},
             {"key": "/old/what"},
@@ -52,10 +52,10 @@ class TestPrintDump:
 
 
 class TestPgDecode:
-    def test_pgdecode_substitute(self):
+    def test_pgdecode_substitute(self) -> None:
         assert pgdecode(r"\n\r\t\\") == "\n\r\t\\"
 
-    def test_pgdecode_ascii_printable(self):
+    def test_pgdecode_ascii_printable(self) -> None:
         import string
 
         assert pgdecode(string.printable) == string.printable

--- a/openlibrary/tests/solr/test_data_provider.py
+++ b/openlibrary/tests/solr/test_data_provider.py
@@ -8,7 +8,7 @@ from openlibrary.solr.data_provider import BetterDataProvider
 
 class TestBetterDataProvider:
     @pytest.mark.asyncio
-    async def test_get_document(self):
+    async def test_get_document(self) -> None:
         mock_site = MagicMock()
         dp = BetterDataProvider(
             site=mock_site,
@@ -31,7 +31,7 @@ class TestBetterDataProvider:
         assert mock_site.get_many.call_count == 1
 
     @pytest.mark.asyncio
-    async def test_clear_cache(self):
+    async def test_clear_cache(self) -> None:
         mock_site = MagicMock()
         dp = BetterDataProvider(
             site=mock_site,

--- a/openlibrary/tests/solr/test_query_utils.py
+++ b/openlibrary/tests/solr/test_query_utils.py
@@ -22,7 +22,7 @@ REMOVE_TESTS = {
 @pytest.mark.parametrize(
     ('query', 'to_rem', 'expected'), REMOVE_TESTS.values(), ids=REMOVE_TESTS.keys()
 )
-def test_luqum_remove_child(query: str, to_rem: str, expected: str):
+def test_luqum_remove_child(query: str, to_rem: str, expected: str) -> None:
     def fn(query: str, remove: str) -> str:
         q_tree = luqum_parser(query)
         for node, parents in luqum_traverse(q_tree):
@@ -57,7 +57,9 @@ REPLACE_TESTS = {
     REPLACE_TESTS.values(),
     ids=REPLACE_TESTS.keys(),
 )
-def test_luqum_replace_child(query: str, to_rep: str, rep_with: str, expected: str):
+def test_luqum_replace_child(
+    query: str, to_rep: str, rep_with: str, expected: str
+) -> None:
     def fn(query: str, to_replace: str, replace_with: str) -> str:
         q_tree = luqum_parser(query)
         for node, parents in luqum_traverse(q_tree):
@@ -69,7 +71,7 @@ def test_luqum_replace_child(query: str, to_rep: str, rep_with: str, expected: s
     assert fn(query, to_rep, rep_with) == expected
 
 
-def test_luqum_parser():
+def test_luqum_parser() -> None:
     def fn(query: str) -> str:
         return str(luqum_parser(query))
 
@@ -92,7 +94,7 @@ def test_luqum_parser():
     assert fn('NOT title:foo bar') == 'NOT title:foo bar'
 
 
-def test_luqum_replace_field():
+def test_luqum_replace_field() -> None:
     def replace_work_prefix(string: str):
         return string.partition(".")[2] if string.startswith("work.") else string
 
@@ -107,7 +109,7 @@ def test_luqum_replace_field():
     assert fn('edition_key:Joe OR work.title:Bob') == 'edition_key:Joe OR title:Bob'
 
 
-def test_luqum_remove_field():
+def test_luqum_remove_field() -> None:
     def fn(query: str) -> str:
         q = luqum_parser(query)
         try:

--- a/openlibrary/tests/solr/test_types_generator.py
+++ b/openlibrary/tests/solr/test_types_generator.py
@@ -5,7 +5,7 @@ from openlibrary.solr.types_generator import generate
 root = os.path.dirname(__file__)
 
 
-def test_up_to_date():
+def test_up_to_date() -> None:
     types_path = os.path.join(root, '..', '..', 'solr', 'solr_types.py')
     with open(types_path) as file:
         assert (

--- a/openlibrary/tests/solr/test_utils.py
+++ b/openlibrary/tests/solr/test_utils.py
@@ -79,7 +79,7 @@ class TestSolrUpdate:
             content=b"<html><body><h1>503 Service Unavailable</h1>",
         )
 
-    def test_successful_response(self, monkeypatch, monkeytime):
+    def test_successful_response(self, monkeypatch, monkeytime) -> None:
         mock_post = MagicMock(return_value=self.sample_response_200())
         monkeypatch.setattr(httpx, "post", mock_post)
 
@@ -90,7 +90,7 @@ class TestSolrUpdate:
 
         assert mock_post.call_count == 1
 
-    def test_non_json_solr_503(self, monkeypatch, monkeytime):
+    def test_non_json_solr_503(self, monkeypatch, monkeytime) -> None:
         mock_post = MagicMock(return_value=self.sample_response_503())
         monkeypatch.setattr(httpx, "post", mock_post)
 
@@ -101,7 +101,7 @@ class TestSolrUpdate:
 
         assert mock_post.call_count > 1
 
-    def test_solr_offline(self, monkeypatch, monkeytime):
+    def test_solr_offline(self, monkeypatch, monkeytime) -> None:
         mock_post = MagicMock(side_effect=ConnectError('', request=None))
         monkeypatch.setattr(httpx, "post", mock_post)
 
@@ -112,7 +112,7 @@ class TestSolrUpdate:
 
         assert mock_post.call_count > 1
 
-    def test_invalid_solr_request(self, monkeypatch, monkeytime):
+    def test_invalid_solr_request(self, monkeypatch, monkeytime) -> None:
         mock_post = MagicMock(return_value=self.sample_global_error())
         monkeypatch.setattr(httpx, "post", mock_post)
 
@@ -123,7 +123,7 @@ class TestSolrUpdate:
 
         assert mock_post.call_count == 1
 
-    def test_bad_apple_in_solr_request(self, monkeypatch, monkeytime):
+    def test_bad_apple_in_solr_request(self, monkeypatch, monkeytime) -> None:
         mock_post = MagicMock(return_value=self.sample_individual_error())
         monkeypatch.setattr(httpx, "post", mock_post)
 
@@ -134,7 +134,7 @@ class TestSolrUpdate:
 
         assert mock_post.call_count == 1
 
-    def test_other_non_ok_status(self, monkeypatch, monkeytime):
+    def test_other_non_ok_status(self, monkeypatch, monkeytime) -> None:
         mock_post = MagicMock(
             return_value=Response(500, request=MagicMock(), content="{}")
         )

--- a/openlibrary/tests/solr/updater/test_author.py
+++ b/openlibrary/tests/solr/updater/test_author.py
@@ -1,3 +1,5 @@
+from types import TracebackType
+
 import httpx
 import pytest
 
@@ -6,7 +8,7 @@ from openlibrary.tests.solr.test_update import FakeDataProvider, make_author
 
 
 class MockResponse:
-    def __init__(self, json_data, status_code=200):
+    def __init__(self, json_data, status_code=200) -> None:
         self.json_data = json_data
         self.status_code = status_code
 
@@ -16,12 +18,17 @@ class MockResponse:
 
 class TestAuthorUpdater:
     @pytest.mark.asyncio
-    async def test_workless_author(self, monkeypatch):
+    async def test_workless_author(self, monkeypatch) -> None:
         class MockAsyncClient:
             async def __aenter__(self):
                 return self
 
-            async def __aexit__(self, exc_type, exc_val, exc_tb):
+            async def __aexit__(
+                self,
+                exc_type: type[BaseException] | None,
+                exc_val: BaseException | None,
+                exc_tb: TracebackType | None,
+            ) -> None:
                 pass
 
             async def post(self, *a, **kw):

--- a/openlibrary/tests/solr/updater/test_edition.py
+++ b/openlibrary/tests/solr/updater/test_edition.py
@@ -6,7 +6,7 @@ from openlibrary.tests.solr.test_update import FakeDataProvider
 
 class TestEditionSolrUpdater:
     @pytest.mark.asyncio
-    async def test_deletes_old_orphans(self):
+    async def test_deletes_old_orphans(self) -> None:
         req, new_keys = await EditionSolrUpdater(FakeDataProvider()).update_key(
             {
                 'key': '/books/OL1M',
@@ -20,7 +20,7 @@ class TestEditionSolrUpdater:
         assert new_keys == ['/works/OL1W']
 
     @pytest.mark.asyncio
-    async def test_enqueues_orphans_as_works(self):
+    async def test_enqueues_orphans_as_works(self) -> None:
         req, new_keys = await EditionSolrUpdater(FakeDataProvider()).update_key(
             {'key': '/books/OL1M', 'type': {'key': '/type/edition'}}
         )

--- a/openlibrary/tests/test_templates.py
+++ b/openlibrary/tests/test_templates.py
@@ -29,6 +29,6 @@ def try_parse_template(
 
 
 @pytest.mark.parametrize('filename', get_template_filenames(), ids=str)
-def test_valid_template(filename: Path):
+def test_valid_template(filename: Path) -> None:
     parsed, err = try_parse_template(filename.read_text(encoding='utf-8'), filename)
     assert parsed, err

--- a/openlibrary/utils/__init__.py
+++ b/openlibrary/utils/__init__.py
@@ -181,7 +181,7 @@ def extract_numeric_id_from_olid(olid):
     return olid
 
 
-def is_number(s):
+def is_number(s) -> bool:
     """
     >>> all(is_number(n) for n in (1234, "1234", -1234, "-1234", 123.4, -123.4))
     True

--- a/openlibrary/utils/compress.py
+++ b/openlibrary/utils/compress.py
@@ -34,7 +34,7 @@ some_record, and restored_record being identical to some_record.
 
 
 class Compressor:
-    def __init__(self, seed):
+    def __init__(self, seed) -> None:
         c = zlib.compressobj(9)
         d_seed = c.compress(seed.encode())
         d_seed += c.flush(zlib.Z_SYNC_FLUSH)
@@ -64,7 +64,7 @@ class Compressor:
         return t.decode()
 
 
-def test_compressor():
+def test_compressor() -> None:
     """
     >>> test_compressor()  # Self-doctest this code.
     """

--- a/openlibrary/utils/form.py
+++ b/openlibrary/utils/form.py
@@ -22,15 +22,15 @@ class AttributeList(dict):
     def copy(self):
         return AttributeList(self)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return " ".join(f'{k}="{web.websafe(v)}"' for k, v in self.items())
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '<attrs: %s>' % repr(str(self))
 
 
 class Input:
-    def __init__(self, name, description=None, value=None, **kw):
+    def __init__(self, name, description=None, value=None, **kw) -> None:
         self.name = name
         self.description = description or ""
         self.value = value
@@ -50,7 +50,7 @@ class Input:
     def get_type(self):
         raise NotImplementedError
 
-    def is_hidden(self):
+    def is_hidden(self) -> bool:
         return False
 
     def render(self):
@@ -62,7 +62,7 @@ class Input:
 
         return '<input ' + str(attrs) + ' />'
 
-    def validate(self, value):
+    def validate(self, value) -> bool:
         self.value = value
         for v in self.validators:
             if not v.valid(value):
@@ -83,7 +83,7 @@ class Textbox(Input):
     '<input name="name" value="joe" class="input" type="text" id="name" size="10" />'
     """
 
-    def get_type(self):
+    def get_type(self) -> str:
         return "text"
 
 
@@ -94,7 +94,7 @@ class Password(Input):
     '<input type="password" id="password" value="secret" name="password" />'
     """
 
-    def get_type(self):
+    def get_type(self) -> str:
         return "password"
 
 
@@ -105,7 +105,7 @@ class Email(Input):
     '<input type="email" id="email" value="joe@archive.org" name="email" />'
     """
 
-    def get_type(self):
+    def get_type(self) -> str:
         return "email"
 
 
@@ -113,10 +113,10 @@ class Checkbox(Input):
     """Checkbox input."""
 
     @property
-    def checked(self):
+    def checked(self) -> bool:
         return self.value is not None
 
-    def get_type(self):
+    def get_type(self) -> str:
         return "checkbox"
 
     def render(self):
@@ -129,15 +129,15 @@ class Checkbox(Input):
 class Hidden(Input):
     """Hidden input."""
 
-    def is_hidden(self):
+    def is_hidden(self) -> bool:
         return True
 
-    def get_type(self):
+    def get_type(self) -> str:
         return "hidden"
 
 
 class Form:
-    def __init__(self, *inputs, **kw):
+    def __init__(self, *inputs, **kw) -> None:
         self.inputs = inputs
         self.validators = kw.pop('validators', [])
         self.note = None
@@ -145,7 +145,7 @@ class Form:
     def __call__(self):
         return copy.deepcopy(self)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return web.safestr(self.render())
 
     def __getitem__(self, key):
@@ -178,7 +178,7 @@ class Form:
 
     fill = validates
 
-    def _validate(self, value):
+    def _validate(self, value) -> bool:
         for v in self.validators:
             if not v.valid(value):
                 self.note = v.msg
@@ -187,7 +187,7 @@ class Form:
 
 
 class Validator:
-    def __init__(self, msg, test):
+    def __init__(self, msg, test) -> None:
         self.msg = msg
         self.test = test
 
@@ -201,7 +201,7 @@ class Validator:
             raise
             return False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<validator: %r >" % self.msg
 
 
@@ -209,7 +209,7 @@ notnull = Validator("Required", bool)
 
 
 class RegexpValidator(Validator):
-    def __init__(self, rexp, msg):
+    def __init__(self, rexp, msg) -> None:
         self.rexp = re.compile(rexp)
         self.msg = msg
 

--- a/openlibrary/utils/olmemcache.py
+++ b/openlibrary/utils/olmemcache.py
@@ -11,7 +11,7 @@ class Client:
     Compatible with memcache Client API.
     """
 
-    def __init__(self, servers):
+    def __init__(self, servers) -> None:
         self._client = memcache.Client(servers)
         compressor = OLCompressor()
         self.compress = compressor.compress

--- a/openlibrary/utils/open_syllabus_project.py
+++ b/openlibrary/utils/open_syllabus_project.py
@@ -17,7 +17,7 @@ def get_osp_dump_location() -> Path | None:
     return osp_dump_location
 
 
-def set_osp_dump_location(val: Path | None):
+def set_osp_dump_location(val: Path | None) -> None:
     global osp_dump_location
     osp_dump_location = val
 

--- a/openlibrary/utils/retry.py
+++ b/openlibrary/utils/retry.py
@@ -4,7 +4,7 @@ import time
 class MaxRetriesExceeded(Exception):
     last_exception: Exception
 
-    def __init__(self, last_exception: Exception):
+    def __init__(self, last_exception: Exception) -> None:
         self.last_exception = last_exception
 
 
@@ -12,7 +12,9 @@ class RetryStrategy:
     retry_count = 0
     last_exception: Exception | None = None
 
-    def __init__(self, exceptions: list[type[Exception]], max_retries=3, delay=1):
+    def __init__(
+        self, exceptions: list[type[Exception]], max_retries=3, delay=1
+    ) -> None:
         self.exceptions = exceptions
         self.max_retries = max_retries
         self.delay = delay

--- a/openlibrary/utils/sentry.py
+++ b/openlibrary/utils/sentry.py
@@ -63,7 +63,7 @@ class Sentry:
         self.logger = logging.getLogger("sentry")
         self.logger.info(f"Setting up sentry (enabled={self.enabled})")
 
-    def init(self):
+    def init(self) -> None:
         sentry_sdk.init(
             dsn=self.config['dsn'],
             environment=self.config['environment'],
@@ -82,12 +82,12 @@ class Sentry:
         app.internalerror = capture_exception
         app.add_processor(WebPySentryProcessor(app))
 
-    def capture_exception_webpy(self):
+    def capture_exception_webpy(self) -> None:
         with sentry_sdk.new_scope() as scope:
             scope.add_event_processor(add_web_ctx_to_event)
             sentry_sdk.capture_exception()
 
-    def capture_exception(self, ex, extras: dict | None = None):
+    def capture_exception(self, ex, extras: dict | None = None) -> None:
         with sentry_sdk.new_scope() as scope:
             if extras:
                 for key, value in extras.items():
@@ -111,7 +111,7 @@ class InfogamiRoute:
 
 
 class WebPySentryProcessor:
-    def __init__(self, app: web.application):
+    def __init__(self, app: web.application) -> None:
         self.app = app
 
     def find_route_name(self) -> str:

--- a/openlibrary/utils/shutdown.py
+++ b/openlibrary/utils/shutdown.py
@@ -4,8 +4,8 @@ import signal
 import sys
 
 
-def setup_graceful_shutdown():
-    def shutdown_handler(signum, frame):
+def setup_graceful_shutdown() -> None:
+    def shutdown_handler(signum, frame) -> None:
         print("Shutting down")
         sys.exit(0)
 

--- a/openlibrary/utils/solr.py
+++ b/openlibrary/utils/solr.py
@@ -16,7 +16,7 @@ T = TypeVar('T')
 
 
 class Solr:
-    def __init__(self, base_url):
+    def __init__(self, base_url) -> None:
         """
         :param base_url: The base url of the solr server/collection. E.g. http://localhost:8983/solr/openlibrary
         """
@@ -204,7 +204,7 @@ class Solr:
             # TODO: improve this
             return v.replace('"', r'\"').replace("(", "\\(").replace(")", "\\)")
 
-        def escape_value(v):
+        def escape_value(v) -> str:
             if isinstance(v, tuple):  # hack for supporting range
                 return f"[{escape(v[0])} TO {escape(v[1])}]"
             elif isinstance(v, list):  # one of

--- a/openlibrary/utils/tests/test_dateutil.py
+++ b/openlibrary/utils/tests/test_dateutil.py
@@ -3,13 +3,13 @@ import datetime
 from .. import dateutil
 
 
-def test_parse_date():
+def test_parse_date() -> None:
     assert dateutil.parse_date("2010") == datetime.date(2010, 1, 1)
     assert dateutil.parse_date("2010-02") == datetime.date(2010, 2, 1)
     assert dateutil.parse_date("2010-02-03") == datetime.date(2010, 2, 3)
 
 
-def test_nextday():
+def test_nextday() -> None:
     assert dateutil.nextday(datetime.date(2008, 1, 1)) == datetime.date(2008, 1, 2)
     assert dateutil.nextday(datetime.date(2008, 1, 31)) == datetime.date(2008, 2, 1)
 
@@ -19,19 +19,19 @@ def test_nextday():
     assert dateutil.nextday(datetime.date(2008, 12, 31)) == datetime.date(2009, 1, 1)
 
 
-def test_nextmonth():
+def test_nextmonth() -> None:
     assert dateutil.nextmonth(datetime.date(2008, 1, 1)) == datetime.date(2008, 2, 1)
     assert dateutil.nextmonth(datetime.date(2008, 1, 12)) == datetime.date(2008, 2, 1)
 
     assert dateutil.nextmonth(datetime.date(2008, 12, 12)) == datetime.date(2009, 1, 1)
 
 
-def test_nextyear():
+def test_nextyear() -> None:
     assert dateutil.nextyear(datetime.date(2008, 1, 1)) == datetime.date(2009, 1, 1)
     assert dateutil.nextyear(datetime.date(2008, 2, 12)) == datetime.date(2009, 1, 1)
 
 
-def test_parse_daterange():
+def test_parse_daterange() -> None:
     assert dateutil.parse_daterange("2010") == (
         datetime.date(2010, 1, 1),
         datetime.date(2011, 1, 1),

--- a/openlibrary/utils/tests/test_ddc.py
+++ b/openlibrary/utils/tests/test_ddc.py
@@ -102,7 +102,7 @@ TESTS = [
 @pytest.mark.parametrize(
     ("raw_ddc", "expected", "name"), TESTS, ids=[t[2] for t in TESTS]
 )
-def test_noramlize_ddc(raw_ddc, expected, name):
+def test_noramlize_ddc(raw_ddc, expected, name) -> None:
     assert normalize_ddc(raw_ddc) == expected
 
 
@@ -111,7 +111,7 @@ def test_noramlize_ddc(raw_ddc, expected, name):
     TESTS_FROM_OCLC,
     ids=[t[2] for t in TESTS_FROM_OCLC],
 )
-def test_normalize_ddc_with_oclc_spec(raw_ddc, expected, name):
+def test_normalize_ddc_with_oclc_spec(raw_ddc, expected, name) -> None:
     assert normalize_ddc(raw_ddc) == expected
 
 
@@ -130,7 +130,7 @@ PREFIX_TESTS = [
 @pytest.mark.parametrize(
     ("prefix", "normed", "name"), PREFIX_TESTS, ids=[t[-1] for t in PREFIX_TESTS]
 )
-def test_normalize_ddc_prefix(prefix, normed, name):
+def test_normalize_ddc_prefix(prefix, normed, name) -> None:
     assert normalize_ddc_prefix(prefix) == normed
 
 
@@ -144,7 +144,7 @@ RANGE_TESTS = [
 @pytest.mark.parametrize(
     ("raw", "normed", "name"), RANGE_TESTS, ids=[t[-1] for t in RANGE_TESTS]
 )
-def test_normalize_ddc_range(raw, normed, name):
+def test_normalize_ddc_range(raw, normed, name) -> None:
     assert normalize_ddc_range(*raw) == normed
 
 
@@ -159,5 +159,5 @@ SORTING_DDC_TEST = [
 @pytest.mark.parametrize(
     ("ddcs", "outpt", "name"), SORTING_DDC_TEST, ids=[t[-1] for t in SORTING_DDC_TEST]
 )
-def test_choose_sorting_ddc(ddcs, outpt, name):
+def test_choose_sorting_ddc(ddcs, outpt, name) -> None:
     assert choose_sorting_ddc(ddcs) == outpt

--- a/openlibrary/utils/tests/test_lcc.py
+++ b/openlibrary/utils/tests/test_lcc.py
@@ -31,14 +31,14 @@ TESTS = [
 @pytest.mark.parametrize(
     ('sortable_lcc', 'raw_lcc', 'short_lcc', 'name'), TESTS, ids=[t[-1] for t in TESTS]
 )
-def test_to_sortable(sortable_lcc, raw_lcc, short_lcc, name):
+def test_to_sortable(sortable_lcc, raw_lcc, short_lcc, name) -> None:
     assert short_lcc_to_sortable_lcc(raw_lcc) == sortable_lcc
 
 
 @pytest.mark.parametrize(
     ('sortable_lcc', 'raw_lcc', 'short_lcc', 'name'), TESTS, ids=[t[-1] for t in TESTS]
 )
-def test_to_short_lcc(sortable_lcc, raw_lcc, short_lcc, name):
+def test_to_short_lcc(sortable_lcc, raw_lcc, short_lcc, name) -> None:
     assert sortable_lcc_to_short_lcc(sortable_lcc) == short_lcc
 
 
@@ -64,7 +64,7 @@ INVALID_TESTS = [
 @pytest.mark.parametrize(
     ('text', 'name'), INVALID_TESTS, ids=[t[-1] for t in INVALID_TESTS]
 )
-def test_invalid_lccs(text, name):
+def test_invalid_lccs(text, name) -> None:
     assert short_lcc_to_sortable_lcc(text) is None
 
 
@@ -90,7 +90,7 @@ WAGNER_2019_EXAMPLES = [
     WAGNER_2019_EXAMPLES,
     ids=[t[-1] for t in WAGNER_2019_EXAMPLES],
 )
-def test_wagner_2019_to_sortable(sortable_lcc, short_lcc, name):
+def test_wagner_2019_to_sortable(sortable_lcc, short_lcc, name) -> None:
     assert short_lcc_to_sortable_lcc(short_lcc) == sortable_lcc
 
 
@@ -99,7 +99,7 @@ def test_wagner_2019_to_sortable(sortable_lcc, short_lcc, name):
     WAGNER_2019_EXAMPLES,
     ids=[t[-1] for t in WAGNER_2019_EXAMPLES],
 )
-def test_wagner_2019_to_short_lcc(sortable_lcc, short_lcc, name):
+def test_wagner_2019_to_short_lcc(sortable_lcc, short_lcc, name) -> None:
     assert sortable_lcc_to_short_lcc(sortable_lcc) == short_lcc.strip()
 
 
@@ -121,7 +121,7 @@ PREFIX_TESTS = [
 @pytest.mark.parametrize(
     ('prefix', 'normed', 'name'), PREFIX_TESTS, ids=[t[-1] for t in PREFIX_TESTS]
 )
-def test_normalize_lcc_prefix(prefix, normed, name):
+def test_normalize_lcc_prefix(prefix, normed, name) -> None:
     assert normalize_lcc_prefix(prefix) == normed
 
 
@@ -138,7 +138,7 @@ RANGE_TESTS = [
 @pytest.mark.parametrize(
     ('raw', 'normed', 'name'), RANGE_TESTS, ids=[t[-1] for t in RANGE_TESTS]
 )
-def test_normalize_lcc_range(raw, normed, name):
+def test_normalize_lcc_range(raw, normed, name) -> None:
     assert normalize_lcc_range(*raw) == normed
 
 
@@ -151,5 +151,5 @@ SORTING_TESTS = [
 @pytest.mark.parametrize(
     ('lccs', 'result', 'name'), SORTING_TESTS, ids=[t[-1] for t in SORTING_TESTS]
 )
-def test_choose_sorting_lcc(lccs, result, name):
+def test_choose_sorting_lcc(lccs, result, name) -> None:
     assert choose_sorting_lcc(lccs) == lccs[result]

--- a/openlibrary/utils/tests/test_lccn.py
+++ b/openlibrary/utils/tests/test_lccn.py
@@ -3,7 +3,7 @@ import pytest
 from openlibrary.utils.lccn import normalize_lccn
 
 
-def test_normalize_lccn_prenormalized():
+def test_normalize_lccn_prenormalized() -> None:
     prenormalized = '94200274'
     assert normalize_lccn(prenormalized) == prenormalized
 
@@ -30,5 +30,5 @@ lccns += [
 
 
 @pytest.mark.parametrize(('raw', 'norm'), lccns)
-def test_normalize_lccn(raw, norm):
+def test_normalize_lccn(raw, norm) -> None:
     assert normalize_lccn(raw) == norm

--- a/openlibrary/utils/tests/test_processors.py
+++ b/openlibrary/utils/tests/test_processors.py
@@ -8,10 +8,10 @@ from ..processors import RateLimitProcessor
 class TestRateLimitProcessor:
     """py.test testcase for testing RateLimitProcessor."""
 
-    def setup_method(self, method):
+    def setup_method(self, method) -> None:
         web.ctx.ip = "127.0.0.1"
 
-    def test_check_rate(self, monkeypatch):
+    def test_check_rate(self, monkeypatch) -> None:
         monkeypatch.setattr(time, "time", lambda: 123456)
         p = RateLimitProcessor(10)
 
@@ -19,7 +19,7 @@ class TestRateLimitProcessor:
             assert p.check_rate() is True
         assert p.check_rate() is False
 
-    def test_get_window(self, monkeypatch):
+    def test_get_window(self, monkeypatch) -> None:
         p = RateLimitProcessor(10, window_size=10)
 
         d = web.storage(time=1)

--- a/openlibrary/utils/tests/test_retry.py
+++ b/openlibrary/utils/tests/test_retry.py
@@ -6,26 +6,26 @@ from openlibrary.utils.retry import MaxRetriesExceeded, RetryStrategy
 
 
 class TestRetryStrategy:
-    def test_exception_filter(self, monkeytime):
+    def test_exception_filter(self, monkeytime) -> None:
         foo = Mock(side_effect=ZeroDivisionError)
         retry = RetryStrategy([ZeroDivisionError], max_retries=3)
         with pytest.raises(MaxRetriesExceeded):
             retry(foo)
         assert foo.call_count == 4
 
-    def test_no_retry(self):
+    def test_no_retry(self) -> None:
         foo = Mock(return_value=1)
         retry = RetryStrategy([ZeroDivisionError], max_retries=3)
         assert retry(foo) == 1
         assert foo.call_count == 1
 
-    def test_retry(self, monkeytime):
+    def test_retry(self, monkeytime) -> None:
         foo = Mock(side_effect=[ZeroDivisionError, 1])
         retry = RetryStrategy([ZeroDivisionError], max_retries=3)
         assert retry(foo) == 1
         assert foo.call_count == 2
 
-    def test_unhandled_error(self):
+    def test_unhandled_error(self) -> None:
         foo = Mock(side_effect=ZeroDivisionError)
         retry = RetryStrategy([ValueError], max_retries=3)
         with pytest.raises(ZeroDivisionError):

--- a/openlibrary/utils/tests/test_solr.py
+++ b/openlibrary/utils/tests/test_solr.py
@@ -1,7 +1,7 @@
 from ..solr import Solr
 
 
-def test_prepare_select():
+def test_prepare_select() -> None:
     solr = Solr("http://localhost:8983/solr")
     assert solr._prepare_select("foo") == "foo"
 

--- a/openlibrary/utils/tests/test_utils.py
+++ b/openlibrary/utils/tests/test_utils.py
@@ -4,7 +4,7 @@ from openlibrary.utils import (
 )
 
 
-def test_str_to_key():
+def test_str_to_key() -> None:
     assert str_to_key('x') == 'x'
     assert str_to_key('X') == 'x'
     assert str_to_key('[X]') == 'x'
@@ -12,6 +12,6 @@ def test_str_to_key():
     assert str_to_key('!@(X);:') == '!(x)'
 
 
-def test_extract_numeric_id_from_olid():
+def test_extract_numeric_id_from_olid() -> None:
     assert extract_numeric_id_from_olid('/works/OL123W') == '123'
     assert extract_numeric_id_from_olid('OL123W') == '123'

--- a/scripts/affiliate_server.py
+++ b/scripts/affiliate_server.py
@@ -178,7 +178,7 @@ class BaseLookupWorker(threading.Thread):
         self.logger = logger
         self.name = name
 
-    def run(self):
+    def run(self) -> None:
         while True:
             try:
                 item = self.queue.get(timeout=API_MAX_WAIT_SECONDS)
@@ -200,7 +200,7 @@ class AmazonLookupWorker(BaseLookupWorker):
     passes them to process_amazon_batch()
     """
 
-    def run(self):
+    def run(self) -> None:
         while True:
             start_time = time.time()
             asins: set[PrioritizedIdentifier] = set()  # no duplicates in the batch
@@ -706,7 +706,7 @@ def load_config(configfile):
         raise RuntimeError(f"{configfile} is missing required keys.")
 
 
-def setup_env():
+def setup_env() -> None:
     # make sure PYTHON_EGG_CACHE is writable
     os.environ['PYTHON_EGG_CACHE'] = "/tmp/.python-eggs"
 
@@ -714,7 +714,7 @@ def setup_env():
     os.environ['REAL_SCRIPT_NAME'] = ""
 
 
-def start_server():
+def start_server() -> None:
     sysargs = sys.argv[1:]
     configfile, args = sysargs[0], sysargs[1:]
     web.ol_configfile = configfile
@@ -740,14 +740,14 @@ def start_server():
     app.run()
 
 
-def start_gunicorn_server():
+def start_gunicorn_server() -> None:
     """Starts the affiliate server using gunicorn server."""
     from gunicorn.app.base import Application
 
     configfile = sys.argv.pop(1)
 
     class WSGIServer(Application):
-        def init(self, parser, opts, args):
+        def init(self, parser, opts, args) -> None:
             pass
 
         def load(self):

--- a/scripts/bulk_load_ia_query.py
+++ b/scripts/bulk_load_ia_query.py
@@ -195,7 +195,7 @@ def get_candidate_ocaids(s3_keys, rows=10_000, idfile=None):
     return ids
 
 
-def import_ocaids(ocaids: list[str], batch_size=5_000):
+def import_ocaids(ocaids: list[str], batch_size=5_000) -> None:
     # get the month for yesterday
     date = datetime.date.today() - datetime.timedelta(days=1)
     batch_name = f"new-scans-{date.year:04}{date.month:02}"
@@ -209,7 +209,7 @@ def main(
     ol_config: str,
     idfile: str | None = None,
     test: bool = True,
-):
+) -> None:
     load_config(ol_config)
     infogami._setup()
     s3_keys = config.get('ia_ol_metadata_write_s3')

--- a/scripts/coverstore-server
+++ b/scripts/coverstore-server
@@ -26,7 +26,7 @@ import web
 web.config.debug = False
 
 
-def setup_env():
+def setup_env() -> None:
     # make sure PYTHON_EGG_CACHE is writable
     os.environ['PYTHON_EGG_CACHE'] = "/tmp/.python-eggs"
 
@@ -34,20 +34,20 @@ def setup_env():
     os.environ['REAL_SCRIPT_NAME'] = ""
 
 
-def start_server():
+def start_server() -> None:
     from openlibrary.coverstore import server
 
     server.main(*sys.argv[1:])
 
 
-def start_gunicorn_server():
+def start_gunicorn_server() -> None:
     """Starts the coverstore server using gunicorn server."""
     from gunicorn.app.base import Application
 
     configfile = sys.argv.pop(1)
 
     class WSGIServer(Application):
-        def init(self, parser, opts, args):
+        def init(self, parser, opts, args) -> None:
             pass
 
         def load(self):

--- a/scripts/cron_wrapper.py
+++ b/scripts/cron_wrapper.py
@@ -16,7 +16,7 @@ DEFAULT_CONFIG_PATH = "/olsystem/etc/cron-wrapper.ini"
 
 
 class MonitoredJob:
-    def __init__(self, command, sentry_cfg, statsd_cfg):
+    def __init__(self, command, sentry_cfg, statsd_cfg) -> None:
         self.command = command
         self.statsd_client = (
             self._setup_statsd(statsd_cfg.get("host", ""), statsd_cfg.get("port", ""))
@@ -27,7 +27,7 @@ class MonitoredJob:
         self.job_name = self._get_job_name()
         self.job_failed = False
 
-    def run(self):
+    def run(self) -> None:
         self._before_run()
         try:
             self._run_script()
@@ -41,13 +41,13 @@ class MonitoredJob:
             self._after_run()
             sentry_sdk.flush()
 
-    def _before_run(self):
+    def _before_run(self) -> None:
         if self.statsd_client:
             self.statsd_client.incr(f'cron.{self.job_name}.start')
             self.job_timer = self.statsd_client.timer(f'cron.{self.job_name}.duration')
             self.job_timer.start()
 
-    def _after_run(self):
+    def _after_run(self) -> None:
         if self.statsd_client:
             self.job_timer.stop()
             status = "failure" if self.job_failed else "stop"
@@ -62,7 +62,7 @@ class MonitoredJob:
             check=True,
         )
 
-    def _setup_sentry(self, dsn):
+    def _setup_sentry(self, dsn) -> None:
         sentry_sdk.init(dsn=dsn, traces_sample_rate=1.0)  # Configure?
 
     def _setup_statsd(self, host, port):
@@ -78,7 +78,7 @@ class MonitoredJob:
         return job_name
 
 
-def main(args):
+def main(args) -> None:
     config = _read_config(args.config)
     sentry_cfg = dict(config["sentry"]) if config.has_section("sentry") else None
     statsd_cfg = dict(config["statsd"]) if config.has_section("statsd") else None

--- a/scripts/delete_import_items.py
+++ b/scripts/delete_import_items.py
@@ -29,7 +29,7 @@ from openlibrary.core.imports import ImportItem
 class DeleteImportItemJob:
     def __init__(
         self, in_file='', state_file='', error_file='', batch_size=1000, dry_run=False
-    ):
+    ) -> None:
         self.in_file = in_file
         self.state_file = state_file
         self.error_file = error_file
@@ -87,7 +87,7 @@ class DeleteImportItemJob:
         }
 
 
-def write_to(filepath, s, mode='w+'):
+def write_to(filepath, s, mode='w+') -> None:
     print(mode)
     path = Path(filepath)
     path.parent.mkdir(exist_ok=True, parents=True)
@@ -115,7 +115,7 @@ def read_args_from_config(config_path):
     }
 
 
-def init_and_start(args):
+def init_and_start(args) -> None:
     # Read arguments from config file:
     config_args = read_args_from_config(args.config_file)
 

--- a/scripts/detect_missing_i18n.py
+++ b/scripts/detect_missing_i18n.py
@@ -112,7 +112,7 @@ def print_analysis(
     spacing_base: int,
     line_number: int = 0,
     line_position: int = 0,
-):
+) -> None:
     linestr = (
         f":{line_number}:{line_position}"
         if line_number > 0 and line_position > 0
@@ -126,7 +126,7 @@ def print_analysis(
     )
 
 
-def main(files: list[Path], skip_excluded: bool = True):
+def main(files: list[Path], skip_excluded: bool = True) -> None:
     """
     :param files: The html files to check for missing i18n. Leave empty to run over all html files.
     :param skip_excluded: If --no-skip-excluded is supplied as an arg, files in the EXCLUDE_LIST slice will be processed

--- a/scripts/expire_accounts.py
+++ b/scripts/expire_accounts.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 import web
 
 
-def delete_old_links():
+def delete_old_links() -> None:
     for doc in web.ctx.site.store.values(type="account-link"):
         expiry_date = datetime.strptime(doc["expires_on"], "%Y-%m-%dT%H:%M:%S.%f")
         # Make expiry_date timezone-aware:
@@ -18,7 +18,7 @@ def delete_old_links():
             print("Retaining link %s" % (key))
 
 
-def main():
+def main() -> int:
     delete_old_links()
     return 0
 

--- a/scripts/fake_loan_server.py
+++ b/scripts/fake_loan_server.py
@@ -9,7 +9,7 @@ app = web.application(urls, globals())
 
 
 class is_loaned_out:
-    def GET(self, resource_id):
+    def GET(self, resource_id) -> str:
         web.header("Content-type", "application/json")
         return "[]"
 

--- a/scripts/generate-api-docs.py
+++ b/scripts/generate-api-docs.py
@@ -40,7 +40,7 @@ def modname(path):
     return path.replace(".py", "").replace("/__init__", "").replace("/", ".")
 
 
-def write(path, text):
+def write(path, text) -> None:
     dirname = os.path.dirname(path)
     if not os.path.exists(dirname):
         os.makedirs(dirname)
@@ -71,7 +71,7 @@ def find_python_sources(dir):
                 yield os.path.join(dirpath, f)
 
 
-def generate_docs(dir):
+def generate_docs(dir) -> None:
     shutil.rmtree(docpath(dir), ignore_errors=True)
 
     paths = list(find_python_sources(dir))
@@ -106,7 +106,7 @@ def generate_docs(dir):
         os.utime(docpath(path), (mtime, mtime))
 
 
-def generate_index():
+def generate_index() -> None:
     filenames = sorted(os.listdir("docs/api"))
 
     with open("docs/api/index.rst", "w") as f:
@@ -119,7 +119,7 @@ def generate_index():
         f.write("\n".join("   " + filename for filename in filenames))
 
 
-def main():
+def main() -> None:
     generate_docs("openlibrary")
     generate_docs("infogami")
     # generate_index()

--- a/scripts/gh_scripts/issue_comment_bot.py
+++ b/scripts/gh_scripts/issue_comment_bot.py
@@ -107,7 +107,7 @@ def filter_issues(issues: list, hours: int, leads: list[dict[str, str]]):
     GitHub's REST API.
     """
 
-    def log_api_failure(_resp):
+    def log_api_failure(_resp) -> None:
         print(f'Failed to fetch comments for issue #{i["number"]}')
         print(f'URL: {i["html_url"]}')
         _d = _resp.json()
@@ -211,7 +211,7 @@ def publish_digest(
     hours_passed: int,
     leads: list[dict[str, str]],
     all_issues_labeled: bool,
-):
+) -> None:
     """
     Creates a threaded Slack messaged containing a digest of recently commented GitHub issues.
 
@@ -342,7 +342,7 @@ def add_label_to_issues(issues) -> bool:
     return all_issues_labeled
 
 
-def verbose_output(issues):
+def verbose_output(issues) -> None:
     """
     Prints detailed information about the given issues.
     """

--- a/scripts/i18n-messages
+++ b/scripts/i18n-messages
@@ -10,7 +10,7 @@ import _init_path  # noqa: F401  Imported for its side effect of setting PYTHONP
 from openlibrary import i18n
 
 
-def help():
+def help() -> None:
     print("utility to manage i18n messages")
     print()
     print("USAGE: %s [extract|compile|update|validate]" % sys.argv[0])
@@ -26,7 +26,7 @@ def help():
     print("  help     - display this help message")
 
 
-def main(cmd, args):
+def main(cmd, args) -> None:
     if cmd == 'extract':
         # Using shell=True, because otherwise the *.py seems to cause trouble
         # on some systems, resulting in no python files being extracted.

--- a/scripts/import_pressbooks.py
+++ b/scripts/import_pressbooks.py
@@ -117,7 +117,7 @@ def convert_pressbooks_to_ol(data):
     return book
 
 
-def main(ol_config: str, filename: str, batch_size=5000, dry_run=False):
+def main(ol_config: str, filename: str, batch_size=5000, dry_run=False) -> None:
     if not dry_run:
         load_config(ol_config)
         date = datetime.date.today()

--- a/scripts/infobase-server
+++ b/scripts/infobase-server
@@ -25,7 +25,7 @@ from openlibrary.utils.shutdown import setup_graceful_shutdown
 logger = logging.getLogger("openlibrary." + __file__)
 
 
-def setup_env():
+def setup_env() -> None:
     # make sure PYTHON_EGG_CACHE is writable
     os.environ['PYTHON_EGG_CACHE'] = "/tmp/.python-eggs"
 
@@ -33,7 +33,7 @@ def setup_env():
     os.environ['REAL_SCRIPT_NAME'] = ""
 
 
-def main(args):
+def main(args) -> None:
     if len(args) < 1 or args[0] in ['-h', '--help']:
         print("USAGE: %s configfile [port]" % (sys.argv[0]), file=sys.stderr)
         sys.exit(1)
@@ -83,14 +83,14 @@ def runfcgi(func, addr=('localhost', 8000)):
     ).run()
 
 
-def start_gunicorn_server():
+def start_gunicorn_server() -> None:
     """Starts the infobase server using gunicorn server."""
     from gunicorn.app.base import Application
 
     configfile = sys.argv.pop(1)
 
     class WSGIServer(Application):
-        def init(self, parser, opts, args):
+        def init(self, parser, opts, args) -> None:
             pass
 
         def load(self):

--- a/scripts/lc_marc_update.py
+++ b/scripts/lc_marc_update.py
@@ -79,12 +79,12 @@ host = 'rs7.loc.gov'
 to_upload = set()
 
 
-def print_line(f):
+def print_line(f) -> None:
     if 'books.test' not in f and f not in existing:
         to_upload.add(f)
 
 
-def read_block(block):
+def read_block(block) -> None:
     global data
     data += block
 

--- a/scripts/manage-imports.py
+++ b/scripts/manage-imports.py
@@ -50,7 +50,7 @@ def ol_import_request(item, retries=5, servername=None, require_marc=True):
                 return e.text
 
 
-def do_import(item, servername=None, require_marc=True):
+def do_import(item, servername=None, require_marc=True) -> None:
     import os
 
     logger.info(f"do_import START (pid:{os.getpid()})")
@@ -71,7 +71,7 @@ def do_import(item, servername=None, require_marc=True):
     logger.info(f"do_import END (pid:{os.getpid()})")
 
 
-def add_items(batch_name, filename):
+def add_items(batch_name, filename) -> None:
     batch = Batch.find(batch_name) or Batch.new(batch_name)
     batch.load_items(filename)
 
@@ -111,7 +111,7 @@ def import_ocaids(*ocaids, **kwargs):
             logger.error(f"{ocaid} is not found in the import queue")
 
 
-def add_new_scans(args):
+def add_new_scans(args) -> None:
     """Adds new scans from yesterday."""
     if args:
         datestr = args[0]
@@ -127,7 +127,7 @@ def add_new_scans(args):
     batch.add_items(items)
 
 
-def import_batch(args, **kwargs):
+def import_batch(args, **kwargs) -> None:
     servername = kwargs.get('servername')
     require_marc = not kwargs.get('no_marc', False)
     batch_name = args[0]
@@ -140,7 +140,7 @@ def import_batch(args, **kwargs):
         do_import(item, servername=servername, require_marc=require_marc)
 
 
-def import_item(args, **kwargs):
+def import_item(args, **kwargs) -> None:
     servername = kwargs.get('servername')
     require_marc = not kwargs.get('no_marc', False)
     ia_id = args[0]
@@ -150,7 +150,7 @@ def import_item(args, **kwargs):
         logger.error(f"{ia_id} is not found in the import queue")
 
 
-def import_all(args, **kwargs):
+def import_all(args, **kwargs) -> None:
     import multiprocessing
 
     servername = kwargs.get('servername')

--- a/scripts/migrations/delete_merge_debug.py
+++ b/scripts/migrations/delete_merge_debug.py
@@ -23,7 +23,7 @@ def setup(config_path):
     infogami._setup()
 
 
-def delete_records(batches):
+def delete_records(batches) -> None:
     """
     Deletes batches of `merge-authors-debug` records.
 
@@ -40,7 +40,7 @@ def delete_records(batches):
         batches -= 1
 
 
-def main(args):
+def main(args) -> None:
     setup(args.config)
     delete_records(args.batches)
 

--- a/scripts/monitoring/monitor.py
+++ b/scripts/monitoring/monitor.py
@@ -24,7 +24,7 @@ scheduler = OlAsyncIOScheduler("OL-MONITOR")
 
 @limit_server(["ol-web*", "ol-covers0"], scheduler)
 @scheduler.scheduled_job('interval', seconds=60)
-def log_workers_cur_fn():
+def log_workers_cur_fn() -> None:
     """Logs the state of the gunicorn workers."""
     bash_run(f"log_workers_cur_fn stats.{SERVER}.workers.cur_fn", sources=["utils.sh"])
 
@@ -91,7 +91,7 @@ def log_top_ip_counts():
 
 @limit_server(["ol-www0"], scheduler)
 @scheduler.scheduled_job('interval', seconds=60)
-async def monitor_haproxy():
+async def monitor_haproxy() -> None:
     # Note this is a long-running job that does its own scheduling.
     # But by having it on a 60s interval, we ensure it restarts if it fails.
     from scripts.monitoring.haproxy_monitor import main
@@ -109,7 +109,7 @@ async def monitor_haproxy():
     )
 
 
-async def main():
+async def main() -> None:
     scheduler.start()
 
     # Keep the main coroutine alive

--- a/scripts/monitoring/tests/test_utils_py.py
+++ b/scripts/monitoring/tests/test_utils_py.py
@@ -4,7 +4,7 @@ from scripts.monitoring.utils import bash_run, limit_server
 from scripts.utils.scheduler import OlAsyncIOScheduler
 
 
-def test_bash_run():
+def test_bash_run() -> None:
     with patch("subprocess.run") as mock_subprocess_run:
         # Test without sources
         bash_run("echo 'Hello, World!'")
@@ -24,13 +24,13 @@ def test_bash_run():
         ]
 
 
-def test_limit_server():
+def test_limit_server() -> None:
     with patch("os.environ.get", return_value="allowed-server"):
         scheduler = OlAsyncIOScheduler("X")
 
         @limit_server(["allowed-server"], scheduler)
         @scheduler.scheduled_job("interval", seconds=60)
-        def sample_job():
+        def sample_job() -> None:
             pass
 
         sample_job()
@@ -41,7 +41,7 @@ def test_limit_server():
 
         @limit_server(["allowed-server"], scheduler)
         @scheduler.scheduled_job("interval", seconds=60)
-        def sample_job():
+        def sample_job() -> None:
             pass
 
         sample_job()
@@ -52,7 +52,7 @@ def test_limit_server():
 
         @limit_server(["allowed-server*"], scheduler)
         @scheduler.scheduled_job("interval", seconds=60)
-        def sample_job():
+        def sample_job() -> None:
             pass
 
         sample_job()
@@ -63,7 +63,7 @@ def test_limit_server():
 
         @limit_server(["ol-web0"], scheduler)
         @scheduler.scheduled_job("interval", seconds=60)
-        def sample_job():
+        def sample_job() -> None:
             pass
 
         sample_job()

--- a/scripts/monitoring/tests/test_utils_sh.py
+++ b/scripts/monitoring/tests/test_utils_sh.py
@@ -3,7 +3,7 @@ import tempfile
 from scripts.monitoring.utils import bash_run
 
 
-def test_bash_run():
+def test_bash_run() -> None:
     # Test without sources
     output = bash_run("echo 'Hello, World!'", capture_output=True)
     assert output.stdout.strip() == "Hello, World!"
@@ -26,7 +26,7 @@ def test_bash_run():
         assert output.stdout.strip() == "source1 source2"
 
 
-def test_log_recent_bot_traffic():
+def test_log_recent_bot_traffic() -> None:
     with (
         tempfile.NamedTemporaryFile(mode='w', delete_on_close=False) as aliases_fp,
         tempfile.NamedTemporaryFile(delete_on_close=False) as nc_fp,
@@ -67,7 +67,7 @@ stats.ol-covers0.bot_traffic.non_bot 6 1741054377
             assert f.read().strip() == expected_output
 
 
-def test_log_recent_http_statuses():
+def test_log_recent_http_statuses() -> None:
     with (
         tempfile.NamedTemporaryFile(mode='w', delete_on_close=False) as aliases_fp,
         tempfile.NamedTemporaryFile(delete_on_close=False) as nc_fp,

--- a/scripts/obfi/mktable.py
+++ b/scripts/obfi/mktable.py
@@ -111,7 +111,7 @@ class HashIP:
             self.real_ips.close()
 
 
-def main():
+def main() -> None:
     hash_ip = HashIP()
     hash_ip.process_input()
 

--- a/scripts/obfi/reveal.py
+++ b/scripts/obfi/reveal.py
@@ -12,7 +12,7 @@ import time
 class IPRevealer:
     """A class to reveal obscured IP addresses obscured by hide.py."""
 
-    def __init__(self, real_ips, replace: bool):
+    def __init__(self, real_ips, replace: bool) -> None:
         self.real_ips = real_ips
         self.replace = replace
 

--- a/scripts/oclc_to_marc.py
+++ b/scripts/oclc_to_marc.py
@@ -27,7 +27,7 @@ def find_marc_url(d):
         return ""
 
 
-def main(oclc):
+def main(oclc) -> None:
     query = urllib.parse.urlencode(
         {'type': '/type/edition', 'oclc_numbers': oclc, '*': ''}
     )

--- a/scripts/pr_slack_digest.py
+++ b/scripts/pr_slack_digest.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import requests
 
 
-def send_slack_message(message: str):
+def send_slack_message(message: str) -> None:
     response = requests.post(
         'https://slack.com/api/chat.postMessage',
         headers={

--- a/scripts/promise_batch_imports.py
+++ b/scripts/promise_batch_imports.py
@@ -147,7 +147,7 @@ def stage_incomplete_records_for_import(olbooks: list[dict[str, Any]]) -> None:
     stats.gauge(f"ol.imports.bwb.{timestamp}.incomplete_records", incomplete_records)
 
 
-def batch_import(promise_id, batch_size=1000, dry_run=False):
+def batch_import(promise_id, batch_size=1000, dry_run=False) -> None:
     url = "https://archive.org/download/"
     date = promise_id.split("_")[-1]
     resp = requests.get(f"{url}{promise_id}/DailyPallets__{date}.json", stream=True)
@@ -201,7 +201,7 @@ def get_promise_items_url(start_date: str, end_date: str):
     )
 
 
-def main(ol_config: str, dates: str, dry_run: bool = False):
+def main(ol_config: str, dates: str, dry_run: bool = False) -> None:
     """
     :param ol_config: Path to openlibrary.yml
     :param dates: Get all promise items for this date or date range.

--- a/scripts/providers/import_wikisource.py
+++ b/scripts/providers/import_wikisource.py
@@ -415,7 +415,7 @@ def fetch_until_successful(url: str) -> dict:
 
 def update_record_with_wikisource_metadata(
     book: BookRecord, book_id: str, new_data: dict, author_map: dict[str, list[str]]
-):
+) -> None:
     if "categories" in new_data:
         book.add_categories([cat["title"] for cat in new_data["categories"]])
 
@@ -499,7 +499,7 @@ def update_record_with_wikisource_metadata(
         pass
 
 
-def print_records(records: list[BookRecord]):
+def print_records(records: list[BookRecord]) -> None:
     for rec in records:
         # Don't know why a few records are turning out like this yet
         if rec.title is None or rec.publish_date is None or len(rec.authors) == 0:
@@ -512,7 +512,7 @@ def scrape_wikisource_api(
     url: str,
     imports: dict[str, BookRecord],
     author_map: dict[str, list[str]],
-):
+) -> None:
     cont_url = url
 
     # Continue until you've reached the end of paginated results
@@ -554,7 +554,7 @@ def scrape_wikisource_api(
 
 def update_import_with_wikidata_api_response(
     impt: BookRecord, book_id: str, obj: Any, author_map: dict[str, list[str]]
-):
+) -> None:
 
     # Author ID: Fetch more data about authors at a later time. WD query times out if we include author data
     if "author" in obj and "value" in obj["author"]:
@@ -630,7 +630,7 @@ def scrape_wikidata_api(
     cfg: LangConfig,
     imports: dict[str, BookRecord],
     author_map: dict[str, list[str]],
-):
+) -> None:
     # Unsure if this is supposed to be paginated. Validated Texts only returns one page of JSON results.
     # The "while true" here is simply to retry requests that fail due to API limits.
     data = fetch_until_successful(url)
@@ -811,7 +811,7 @@ WHERE {
 
 def fix_contributor_data(
     imports: dict[str, BookRecord], map: dict[str, list[str]], cfg: LangConfig
-):
+) -> None:
     contributor_ids = list(map.keys())
     for batch in itertools.batched(contributor_ids, 50):
         query = (
@@ -926,7 +926,7 @@ WHERE {
 
 
 # If we want to process all Wikisource pages in more than one category, we have to do one API call per category per language.
-def process_all_books(cfg: LangConfig):
+def process_all_books(cfg: LangConfig) -> None:
     imports: dict[str, BookRecord] = {}
     author_map: dict[str, list[str]] = {}
 
@@ -948,7 +948,7 @@ def process_all_books(cfg: LangConfig):
         print_records(batch)
 
 
-def main(ol_config: str):
+def main(ol_config: str) -> None:
     """
     :param str ol_config: Path to openlibrary.yml file
     """

--- a/scripts/providers/isbndb.py
+++ b/scripts/providers/isbndb.py
@@ -60,7 +60,7 @@ class ISBNdb:
     )
     REQUIRED_FIELDS = requests.get(SCHEMA_URL).json()['required']
 
-    def __init__(self, data: dict[str, Any]):
+    def __init__(self, data: dict[str, Any]) -> None:
         self.isbn_13 = [data.get('isbn13')]
         self.source_id = f'idb:{self.isbn_13[0]}'
         self.title = data.get('title')
@@ -200,7 +200,9 @@ def update_state(logfile: str, fname: str, line_num: int = 0) -> None:
 
 # TODO: It's possible `batch_import()` could be modified to take a parsing function
 # and a filter function instead of hardcoding in `csv_to_ol_json_item()` and some filters.
-def batch_import(path: str, batch: Batch, import_status: str, batch_size: int = 5000):
+def batch_import(
+    path: str, batch: Batch, import_status: str, batch_size: int = 5000
+) -> None:
     logfile = os.path.join(path, 'import.log')
     filenames, offset = load_state(path, logfile)
 

--- a/scripts/solr_builder/solr_builder/fn_to_cli.py
+++ b/scripts/solr_builder/solr_builder/fn_to_cli.py
@@ -33,7 +33,7 @@ class FnToCLI:
         FnToCLI(my_func).run()
     """
 
-    def __init__(self, fn: typing.Callable):
+    def __init__(self, fn: typing.Callable) -> None:
         self.fn = fn
         arg_names = fn.__code__.co_varnames[: fn.__code__.co_argcount]
         annotations = typing.get_type_hints(fn)
@@ -128,7 +128,7 @@ class FnToCLI:
 
 if __name__ == '__main__':
 
-    def fn(nums: list[int]):
+    def fn(nums: list[int]) -> None:
         print(sum(nums))
 
     cli = FnToCLI(fn)

--- a/scripts/solr_builder/solr_builder/index_subjects.py
+++ b/scripts/solr_builder/solr_builder/index_subjects.py
@@ -96,7 +96,7 @@ async def index_all_subjects(
     instances=2,
     solr_base_url='http://solr:8983/solr/openlibrary',
     skip_id_check=False,
-):
+) -> None:
     done = False
     active_workers: set[Future] = set()
     offset = 0

--- a/scripts/solr_dump_xisbn.py
+++ b/scripts/solr_dump_xisbn.py
@@ -144,7 +144,7 @@ async def main(
     # which we can use to make multiple queries in parallel
 
     # Now create an async worker pool to fetch the actual data
-    async def fetch_bounds(bounds):
+    async def fetch_bounds(bounds) -> None:
         print(f'[ ] FETCH {bounds=}', file=sys.stderr)
         start, end = bounds
         result = ''

--- a/scripts/solr_updater/solr_updater.py
+++ b/scripts/solr_updater/solr_updater.py
@@ -50,7 +50,7 @@ def get_default_offset():
 
 
 class InfobaseLog:
-    def __init__(self, hostname: str, exclude: str | None = None):
+    def __init__(self, hostname: str, exclude: str | None = None) -> None:
         """
         :param str hostname:
         :param str|None exclude: if specified, excludes records that include the string
@@ -62,7 +62,7 @@ class InfobaseLog:
     def tell(self):
         return self.offset
 
-    def seek(self, offset):
+    def seek(self, offset) -> None:
         self.offset = offset.strip()
 
     def read_records(self, max_fetches=10):
@@ -249,7 +249,7 @@ async def main(
     socket_timeout: int = 10,
     load_ia_scans: bool = False,
     initial_state: str | None = None,
-):
+) -> None:
     """
     Useful environment variables:
     - OL_SOLR_BASE_URL: Override the Solr base URL

--- a/scripts/solr_updater/tests/test_trending_updater_hourly.py
+++ b/scripts/solr_updater/tests/test_trending_updater_hourly.py
@@ -1,7 +1,7 @@
 from scripts.solr_updater.trending_updater_hourly import compute_trending_z_score
 
 
-def test_compute_trending_z_score_zero_for_low_past():
+def test_compute_trending_z_score_zero_for_low_past() -> None:
     past = [0, 0, 0, 3, 0, 0, 0]
     current = 500
     z = compute_trending_z_score(current, past)

--- a/scripts/solr_updater/tests/test_trending_updater_init.py
+++ b/scripts/solr_updater/tests/test_trending_updater_init.py
@@ -9,10 +9,10 @@ class TestTrendingUpdaterInit:
     def _run_main(self, fake_now, main_kwargs):
         calls = []
 
-        def fake_daily(timestamp, dry_run):
+        def fake_daily(timestamp, dry_run) -> None:
             calls.append(("daily", timestamp))
 
-        def fake_hourly(timestamp, dry_run):
+        def fake_hourly(timestamp, dry_run) -> None:
             calls.append(("hourly", timestamp))
 
         class PatchedDateTime(datetime.datetime):
@@ -38,7 +38,7 @@ class TestTrendingUpdaterInit:
 
         return calls
 
-    def test_main_calls_hourly_and_daily_correctly(self):
+    def test_main_calls_hourly_and_daily_correctly(self) -> None:
         fake_now = datetime.datetime(2025, 6, 27, 3, 0, 0)
         start = datetime.datetime(2025, 6, 26, 0, 5, 0)
         actual_calls = self._run_main(
@@ -50,7 +50,7 @@ class TestTrendingUpdaterInit:
         assert num_hourly == 27
         assert num_daily == 2
 
-    def test_main_default_7_days(self):
+    def test_main_default_7_days(self) -> None:
         fake_now = datetime.datetime(2025, 6, 27, 0, 0, 0)
         actual_calls = self._run_main(fake_now, {"dry_run": True})
         # There should be 168 hourly events (7 days * 24 hours) and 7 daily events
@@ -59,7 +59,7 @@ class TestTrendingUpdaterInit:
         assert num_hourly == 168
         assert num_daily == 7
 
-    def test_main_less_than_one_hour(self):
+    def test_main_less_than_one_hour(self) -> None:
         fake_now = datetime.datetime(2025, 6, 27, 3, 0, 0)
         # Start is 2025-06-27 02:30:00, less than an hour before fake_now
         start = datetime.datetime(2025, 6, 27, 2, 30, 0)
@@ -72,7 +72,7 @@ class TestTrendingUpdaterInit:
         ]
         assert actual_calls == expected_calls
 
-    def test_main_three_hours(self):
+    def test_main_three_hours(self) -> None:
         fake_now = datetime.datetime(2025, 6, 27, 3, 0, 0)
         start = datetime.datetime(2025, 6, 27, 0, 30, 0)
 

--- a/scripts/solr_updater/trending_updater.py
+++ b/scripts/solr_updater/trending_updater.py
@@ -22,7 +22,7 @@ logger = logging.getLogger("openlibrary.trending-updater")
 async def main(
     ol_config: str,
     trending_offset_file: Path | None = None,
-):
+) -> None:
     """
     Useful environment variables:
     - OL_SOLR_BASE_URL: Override the Solr base URL
@@ -49,7 +49,7 @@ async def main(
     if trending_offset_file:
         # If an offset file is specified, add an event listener to the scheduler
         # to update the offset file whenever a job is run.
-        def update_offset(event):
+        def update_offset(event) -> None:
             new_offset = datetime.datetime.now().isoformat()
             print(f"Updating {trending_offset_file} to {new_offset}")
             trending_offset_file.write_text(new_offset + '\n')

--- a/scripts/solr_updater/trending_updater_daily.py
+++ b/scripts/solr_updater/trending_updater_daily.py
@@ -28,7 +28,7 @@ def form_inplace_updates(work_id: str, current_day: int, new_value: int):
     return {"key": work_id, f'trending_score_daily_{current_day}': {"set": new_value}}
 
 
-def run_daily_update(timestamp: str | None = None, dry_run: bool = False):
+def run_daily_update(timestamp: str | None = None, dry_run: bool = False) -> None:
     if timestamp:
         ts = datetime.datetime.fromisoformat(timestamp)
     else:

--- a/scripts/solr_updater/trending_updater_hourly.py
+++ b/scripts/solr_updater/trending_updater_hourly.py
@@ -88,7 +88,7 @@ def get_logs_for_hour(dt: datetime.datetime, extra_grep: str | None = None):
     ) as proc:
         assert proc.stdout
 
-        def print_stderr(stderr):
+        def print_stderr(stderr) -> None:
             for err_line in stderr:
                 err_line = err_line.strip()
                 if err_line:
@@ -297,7 +297,7 @@ def form_inplace_trending_update(
     return request_body
 
 
-def run_hourly_update(timestamp: str | None = None, dry_run: bool = False):
+def run_hourly_update(timestamp: str | None = None, dry_run: bool = False) -> None:
     if timestamp:
         ts = datetime.datetime.fromisoformat(timestamp)
     else:

--- a/scripts/solr_updater/trending_updater_init.py
+++ b/scripts/solr_updater/trending_updater_init.py
@@ -12,7 +12,7 @@ def main(
     timestamp: str | None = None,
     dry_run: bool = False,
     trending_offset_file: Path | None = None,
-):
+) -> None:
     """
     Script to initialize the trending data in Solr.
 

--- a/scripts/tests/test_import_open_textbook_library.py
+++ b/scripts/tests/test_import_open_textbook_library.py
@@ -210,6 +210,6 @@ from ..import_open_textbook_library import map_data
         ),
     ],
 )
-def test_map_data(input_data, expected_output):
+def test_map_data(input_data, expected_output) -> None:
     result = map_data(input_data)
     assert result == expected_output

--- a/scripts/tests/test_isbndb.py
+++ b/scripts/tests/test_isbndb.py
@@ -73,7 +73,7 @@ def get_isbndb_data():
     }
 
 
-def test_isbndb_to_ol_item(tmp_path):
+def test_isbndb_to_ol_item(tmp_path) -> None:
     # Set up a three-line file to read.
     isbndb_file: Path = tmp_path / "isbndb.jsonl"
     data = '\n'.join(sample_lines)
@@ -114,7 +114,7 @@ def test_is_nonbook(binding, expected) -> None:
         (None, None),
     ],
 )
-def test_isbndb_get_languages(language, expected, get_isbndb_data):
+def test_isbndb_get_languages(language, expected, get_isbndb_data) -> None:
     isbndb_line = get_isbndb_data
     isbndb_line['language'] = language
     item = ISBNdb(isbndb_line)
@@ -132,7 +132,7 @@ def test_isbndb_get_languages(language, expected, get_isbndb_data):
         (None, None),
     ],
 )
-def test_isbndb_get_year(year, expected, get_isbndb_data):
+def test_isbndb_get_year(year, expected, get_isbndb_data) -> None:
     isbndb_line = get_isbndb_data
     item = ISBNdb(isbndb_line)
     # Do this 'out of order' to instantiate the class with a valid date; the

--- a/scripts/tests/test_obfi.py
+++ b/scripts/tests/test_obfi.py
@@ -25,7 +25,7 @@ def mock_get(*args, **kwargs):
         def __enter__(self):
             return self
 
-        def __exit__(self, *args):
+        def __exit__(self, *args) -> None:
             pass
 
     return MockResponse()

--- a/scripts/tests/test_obfi_sh.py
+++ b/scripts/tests/test_obfi_sh.py
@@ -21,7 +21,7 @@ def bash_w_obfi(cmd: str):
 
 
 class TestObfiMatchRange:
-    def test_obfi_match_range_multi_day(self):
+    def test_obfi_match_range_multi_day(self) -> None:
         # All lines in the sample log are between 2025-06-27 00:28:46 and 2025-06-28 01:01:46
         start_iso = '2025-06-27T00:00:00Z'
         end_iso = '2025-06-28T23:59:59Z'
@@ -30,7 +30,7 @@ class TestObfiMatchRange:
         output = bash_w_obfi(f"cat {SAMPLE_LOG} | obfi_match_range {start} {end}")
         assert output.stdout == SAMPLE_LOG.read_text()
 
-    def test_obfi_match_range_first_hour(self):
+    def test_obfi_match_range_first_hour(self) -> None:
         # Only lines on 2025-06-27 between 00:00:00 and 00:59:59 should match (first line only)
         start_iso = '2025-06-27T00:00:00Z'
         end_iso = '2025-06-27T00:59:59Z'
@@ -40,7 +40,7 @@ class TestObfiMatchRange:
         expected = SAMPLE_LOG.read_text().splitlines()[0] + '\n'
         assert output.stdout == expected
 
-    def test_obfi_match_range_second_day_same_hour(self):
+    def test_obfi_match_range_second_day_same_hour(self) -> None:
         # Only lines on 2025-06-28 between 00:00:00 and 00:59:59 should match (third line only)
         start_iso = '2025-06-28T00:00:00Z'
         end_iso = '2025-06-28T00:59:59Z'
@@ -50,7 +50,7 @@ class TestObfiMatchRange:
         expected = SAMPLE_LOG.read_text().splitlines()[2] + '\n'
         assert output.stdout == expected
 
-    def test_obfi_match_range_no_lines(self):
+    def test_obfi_match_range_no_lines(self) -> None:
         start_iso = '2001-09-09T01:46:40Z'
         end_iso = '2001-09-09T01:46:41Z'
         start = iso_to_ms(start_iso)

--- a/scripts/tests/test_solr_updater.py
+++ b/scripts/tests/test_solr_updater.py
@@ -8,7 +8,7 @@ from scripts.solr_updater.solr_updater import parse_log
 
 
 class TestParseLog:
-    def test_action_save(self):
+    def test_action_save(self) -> None:
         sample_record = {
             'action': 'save',
             'site': 'openlibrary.org',
@@ -86,7 +86,7 @@ class TestParseLog:
             '/authors/OL9352911A',
         ]
 
-    def test_move_edition(self):
+    def test_move_edition(self) -> None:
         sample_record = {
             'action': 'save_many',
             'site': 'openlibrary.org',
@@ -164,7 +164,7 @@ class TestParseLog:
             '/works/OL362427W',
         ]
 
-    def test_new_account(self):
+    def test_new_account(self) -> None:
         sample_record = {
             'action': 'save_many',
             'site': 'openlibrary.org',

--- a/scripts/update_stale_ocaid_references.py
+++ b/scripts/update_stale_ocaid_references.py
@@ -148,7 +148,7 @@ def main(
     until: str | None = None,
     statefile: str | None = None,
     test: bool = True,
-):
+) -> None:
     load_config(ol_config)
     infogami._setup()
     s3_keys = config.get('ia_ol_metadata_write_s3')  # XXX needs dark scope

--- a/scripts/update_stale_work_references.py
+++ b/scripts/update_stale_work_references.py
@@ -10,7 +10,7 @@ from openlibrary.core.models import Work
 from scripts.solr_builder.solr_builder.fn_to_cli import FnToCLI
 
 
-def main(ol_config: str, days=1, skip=7):
+def main(ol_config: str, days=1, skip=7) -> None:
     load_config(ol_config)
     infogami._setup()
     Work.resolve_redirects_bulk(

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -9,7 +9,7 @@ def p(*paths):
 
 
 class TestDockerCompose:
-    def test_all_root_services_must_be_in_prod(self):
+    def test_all_root_services_must_be_in_prod(self) -> None:
         """
         Each service in compose.yaml should also be in
         compose.production.yaml with a profile. Services without profiles will
@@ -24,7 +24,7 @@ class TestDockerCompose:
         missing = root_services - prod_services
         assert missing == set(), "compose.production.yaml missing services"
 
-    def test_all_prod_services_need_profile(self):
+    def test_all_prod_services_need_profile(self) -> None:
         """
         Without the profiles field, a service will get deployed to _every_ server. That
         is not likely what you want. If that is what you want, add all server names to
@@ -35,7 +35,7 @@ class TestDockerCompose:
         for serv, opts in prod_dc['services'].items():
             assert 'profiles' in opts, f"{serv} is missing 'profiles' field"
 
-    def test_shared_constants(self):
+    def test_shared_constants(self) -> None:
         # read the value in compose.yaml
         with open(p('..', 'compose.yaml')) as f:
             prod_dc: dict = yaml.safe_load(f)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

This is a PR full of automated changes using the autotyping --safe flag
https://github.com/JelleZijlstra/autotyping

In short to get this PR I:
- Added the autotyping pre-commit hook
- Ran `pre-commit run --all-files`
- Ran it again to get all the new errors from mypy checking functions with types
- Did some grepping to get a list of all files with mypy errors and ran `git checkout -- file.py` to revert them to master
- Pushed up the remaining, uncontroversial changes

I did do any manual edits to code.
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
