### PR TITLE
Move `/lists/partials.json` handler to `partials.py`

### DIFF
--- a/openlibrary/plugins/openlibrary/js/lists/ListService.js
+++ b/openlibrary/plugins/openlibrary/js/lists/ListService.js
@@ -62,15 +62,6 @@ export async function removeItem(listKey, seed) {
 }
 
 // XXX : jsdoc
-// export async function getListPartials() {
-//     return await fetch(buildPartialsUrl('/lists/partials.json'), {
-//         method: 'GET',
-//         headers: {
-//             'Content-Type': 'application/json',
-//             Accept: 'application/json',
-//         },
-//     });
-// }
 export async function getListPartials() {
     return await fetch(buildPartialsUrl('/partials.json', {
         _component: 'MyBooksDropperLists'

--- a/openlibrary/plugins/openlibrary/js/lists/ListService.js
+++ b/openlibrary/plugins/openlibrary/js/lists/ListService.js
@@ -62,8 +62,19 @@ export async function removeItem(listKey, seed) {
 }
 
 // XXX : jsdoc
+// export async function getListPartials() {
+//     return await fetch(buildPartialsUrl('/lists/partials.json'), {
+//         method: 'GET',
+//         headers: {
+//             'Content-Type': 'application/json',
+//             Accept: 'application/json',
+//         },
+//     });
+// }
 export async function getListPartials() {
-    return await fetch(buildPartialsUrl('/lists/partials.json'), {
+    return await fetch(buildPartialsUrl('/partials.json', {
+        _component: 'MyBooksDropperLists'
+    }), {
         method: 'GET',
         headers: {
             'Content-Type': 'application/json',
@@ -71,3 +82,4 @@ export async function getListPartials() {
         },
     });
 }
+

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -246,31 +246,6 @@ def convert_list(list):
     return newList
 
 
-class lists_partials(delegate.page):
-    path = "/lists/partials"
-    encoding = "json"
-
-    def GET(self):
-        partials = self.get_partials()
-        return delegate.RawText(json.dumps(partials))
-
-    def get_partials(self):
-        user_lists = get_user_lists(None)
-
-        dropper = render_template('lists/dropper_lists', user_lists)
-        list_data = {
-            list_data['key']: {
-                'members': list_data['list_items'],
-                'listName': list_data['name'],
-            }
-            for list_data in user_lists
-        }
-
-        return {
-            'dropper': str(dropper),
-            'listData': list_data,
-        }
-
 
 class lists(delegate.page):
     """Controller for displaying lists of a seed or lists of a person."""

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -246,7 +246,6 @@ def convert_list(list):
     return newList
 
 
-
 class lists(delegate.page):
     """Controller for displaying lists of a seed or lists of a person."""
 

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -14,6 +14,9 @@ from openlibrary.plugins.worksearch.code import do_search, work_search
 from openlibrary.plugins.worksearch.subjects import get_subject
 from openlibrary.views.loanstats import get_trending_books
 
+# partials.py
+from infogami.utils.view import render_template
+from openlibrary.plugins.openlibrary.lists import get_user_lists
 
 class PartialResolutionError(Exception):
     pass
@@ -30,6 +33,36 @@ class PartialDataHandler(ABC):
     @abstractmethod
     def generate(self) -> dict:
         pass
+    
+    
+
+
+class MyBooksDropperListsPartial(PartialDataHandler):
+    """Handler for the MyBooks dropper list component."""
+
+    def __init__(self):
+        self.i = web.input()  
+
+    def generate(self) -> dict:
+        print("Generating MyBooks dropper lists partial")
+        user_lists = get_user_lists(None)
+
+        dropper = render_template("lists/dropper_lists", user_lists)
+        list_data = {
+            list_data['key']: {
+                'members': list_data['list_items'],
+                'listName': list_data['name'],
+            }
+            for list_data in user_lists
+        }
+
+        return {
+            'dropper': str(dropper),
+            'listData': list_data,
+        }
+
+        
+    
 
 
 class CarouselCardPartial(PartialDataHandler):
@@ -321,6 +354,7 @@ class PartialRequestResolver:
         "FulltextSearchSuggestion": FullTextSuggestionsPartial,
         "BPListsSection": BookPageListsPartial,
         "LazyCarousel": LazyCarouselPartial,
+        "MyBooksDropperLists": MyBooksDropperListsPartial,
     }
 
     @staticmethod

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -16,8 +16,7 @@ from openlibrary.plugins.openlibrary.lists import get_user_lists
 from openlibrary.plugins.worksearch.code import do_search, work_search
 from openlibrary.plugins.worksearch.subjects import get_subject
 from openlibrary.views.loanstats import get_trending_books
-from infogami.utils.view import render_template
-from openlibrary.plugins.openlibrary.lists import get_user_lists
+
 
 class PartialResolutionError(Exception):
     pass
@@ -37,7 +36,7 @@ class PartialDataHandler(ABC):
 
 
 class MyBooksDropperListsPartial(PartialDataHandler):
-    """Handler for the MyBooks dropper list component."""  
+    """Handler for the MyBooks dropper list component."""
 
     def generate(self) -> dict:
         user_lists = get_user_lists(None)

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -10,13 +10,13 @@ from infogami.utils.view import render_template
 from openlibrary.core.fulltext import fulltext_search
 from openlibrary.core.lending import compose_ia_url, get_available
 from openlibrary.i18n import gettext as _
+
+# partials.py
+from openlibrary.plugins.openlibrary.lists import get_user_lists
 from openlibrary.plugins.worksearch.code import do_search, work_search
 from openlibrary.plugins.worksearch.subjects import get_subject
 from openlibrary.views.loanstats import get_trending_books
 
-# partials.py
-from infogami.utils.view import render_template
-from openlibrary.plugins.openlibrary.lists import get_user_lists
 
 class PartialResolutionError(Exception):
     pass
@@ -33,15 +33,13 @@ class PartialDataHandler(ABC):
     @abstractmethod
     def generate(self) -> dict:
         pass
-    
-    
 
 
 class MyBooksDropperListsPartial(PartialDataHandler):
     """Handler for the MyBooks dropper list component."""
 
     def __init__(self):
-        self.i = web.input()  
+        self.i = web.input()
 
     def generate(self) -> dict:
         print("Generating MyBooks dropper lists partial")
@@ -60,9 +58,6 @@ class MyBooksDropperListsPartial(PartialDataHandler):
             'dropper': str(dropper),
             'listData': list_data,
         }
-
-        
-    
 
 
 class CarouselCardPartial(PartialDataHandler):

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -10,8 +10,6 @@ from infogami.utils.view import render_template
 from openlibrary.core.fulltext import fulltext_search
 from openlibrary.core.lending import compose_ia_url, get_available
 from openlibrary.i18n import gettext as _
-
-# partials.py
 from openlibrary.plugins.openlibrary.lists import get_user_lists
 from openlibrary.plugins.worksearch.code import do_search, work_search
 from openlibrary.plugins.worksearch.subjects import get_subject

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -16,7 +16,8 @@ from openlibrary.plugins.openlibrary.lists import get_user_lists
 from openlibrary.plugins.worksearch.code import do_search, work_search
 from openlibrary.plugins.worksearch.subjects import get_subject
 from openlibrary.views.loanstats import get_trending_books
-
+from infogami.utils.view import render_template
+from openlibrary.plugins.openlibrary.lists import get_user_lists
 
 class PartialResolutionError(Exception):
     pass
@@ -36,13 +37,9 @@ class PartialDataHandler(ABC):
 
 
 class MyBooksDropperListsPartial(PartialDataHandler):
-    """Handler for the MyBooks dropper list component."""
-
-    def __init__(self):
-        self.i = web.input()
+    """Handler for the MyBooks dropper list component."""  
 
     def generate(self) -> dict:
-        print("Generating MyBooks dropper lists partial")
         user_lists = get_user_lists(None)
 
         dropper = render_template("lists/dropper_lists", user_lists)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10986 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR achieves to refactor the `partials.py` file to include `MyBooksDropperListsPartial` as an extension to `PartialDataHandler`.


### Technical
<!-- What should be noted about the implementation? -->
The implementation is pretty straight forward and migrates the functionality of `get_lists` method to `MyBooksDropperListsPartial`

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
All tests have been passes the screenshot for the same have been attested.
<img width="436" height="117" alt="Screenshot 2025-07-10 225513" src="https://github.com/user-attachments/assets/734f8ea8-f302-4c87-82de-af71c7ff8d70" />


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
