### PR TITLE
Ensure `account-email` store key is deleted on account anonymize

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -386,6 +386,7 @@ class Account(web.storage):
             del web.ctx.site.store[f'account/{username}/verify']
             del web.ctx.site.store[f'account/{username}/password']
             del web.ctx.site.store[f'account-email/{email}']
+            del web.ctx.site.store[f'account-email/{email.lower()}']
 
         return results
 


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
The account anonymization function is sometimes not removing the associated `account-email` store entry, due to the email not being converted to lowercase in the store key.  Since 10 June 2014, all `account-email` store keys contain the lowercase email.

### Technical
<!-- What should be noted about the implementation? -->
There are around 42,000 `account-email` store entries that a mixed-case `key`.  To be sure that these folks can successfully anonymize their accounts, the original `del web.ctx.site.store[f'account-email/{email}']` statement remains unchanged.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
