### PR TITLE
unbreak my books for deleted books

### DIFF
--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -558,8 +558,7 @@ class Bookshelves(db.CommonExtras):
             solr_docs = cls.link_editions_to_works(solr_docs)
 
             if len(solr_docs) < len(reading_log_keys):
-                missing = set(w for w, e in reading_log_keys) - set(
-                    [doc['key'] for doc in solr_docs]
+                missing = set(w for w, e in reading_log_keys) - {doc['key'] for doc in solr_docs}
                 )
                 logger.warning(f"Missing items in Solr: {missing}")
 

--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -557,10 +557,9 @@ class Bookshelves(db.CommonExtras):
             solr_docs = add_reading_log_data(reading_log_books, solr_docs)
             solr_docs = cls.link_editions_to_works(solr_docs)
 
-            assert len(solr_docs) == len(reading_log_keys), (
-                "solr_docs is missing an item/items from reading_log_keys; "
-                "see add_storage_items_for_redirects()"
-            )
+            if len(solr_docs) <= len(reading_log_keys):
+                missing = set(w for w, e in reading_log_keys) - set([doc['key'] for doc in solr_docs])
+                logger.warning(f"Missing items in Solr: {missing}")
 
             return LoggedBooksData(
                 username=username,

--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -559,7 +559,6 @@ class Bookshelves(db.CommonExtras):
 
             if len(solr_docs) < len(reading_log_keys):
                 missing = set(w for w, e in reading_log_keys) - {doc['key'] for doc in solr_docs}
-                )
                 logger.warning(f"Missing items in Solr: {missing}")
 
             return LoggedBooksData(

--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -557,7 +557,7 @@ class Bookshelves(db.CommonExtras):
             solr_docs = add_reading_log_data(reading_log_books, solr_docs)
             solr_docs = cls.link_editions_to_works(solr_docs)
 
-            if len(solr_docs) <= len(reading_log_keys):
+            if len(solr_docs) < len(reading_log_keys):
                 missing = set(w for w, e in reading_log_keys) - set(
                     [doc['key'] for doc in solr_docs]
                 )

--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -558,7 +558,9 @@ class Bookshelves(db.CommonExtras):
             solr_docs = cls.link_editions_to_works(solr_docs)
 
             if len(solr_docs) < len(reading_log_keys):
-                missing = set(w for w, e in reading_log_keys) - {doc['key'] for doc in solr_docs}
+                missing = set(w for w, e in reading_log_keys) - {
+                    doc['key'] for doc in solr_docs
+                }
                 logger.warning(f"Missing items in Solr: {missing}")
 
             return LoggedBooksData(

--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -558,7 +558,7 @@ class Bookshelves(db.CommonExtras):
             solr_docs = cls.link_editions_to_works(solr_docs)
 
             if len(solr_docs) < len(reading_log_keys):
-                missing = set(w for w, e in reading_log_keys) - {
+                missing = {w for w, e in reading_log_keys} - {
                     doc['key'] for doc in solr_docs
                 }
                 logger.warning(f"Missing items in Solr: {missing}")

--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -558,7 +558,9 @@ class Bookshelves(db.CommonExtras):
             solr_docs = cls.link_editions_to_works(solr_docs)
 
             if len(solr_docs) <= len(reading_log_keys):
-                missing = set(w for w, e in reading_log_keys) - set([doc['key'] for doc in solr_docs])
+                missing = set(w for w, e in reading_log_keys) - set(
+                    [doc['key'] for doc in solr_docs]
+                )
                 logger.warning(f"Missing items in Solr: {missing}")
 
             return LoggedBooksData(


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10970

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

My Books reading log pages breaks when books deleted; a deletion should probably cascade and remove related books from reading log table (similar to how we update redirects). In the interim, this solution should unbreak book pages by changing the `assertion` to an `if` check.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Tested on testing.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
