### PR TITLE
Add trending to sort options, sort subject pages by trending, and other trending tweaks

### DIFF
--- a/openlibrary/components/LibraryExplorer/components/LibraryToolbar.vue
+++ b/openlibrary/components/LibraryExplorer/components/LibraryToolbar.vue
@@ -267,13 +267,6 @@
                   value="trending"
                 >Trending Score
               </label>
-              <label>
-                <input
-                  v-model="sortState.order"
-                  type="radio"
-                  value="trending_points_today"
-                >Trending Points Today
-              </label>
               <label title="I.e. Classification order. Note some books maybe missing when sorting by shelf order–we're working on it.">
                 <input
                   v-model="sortState.order"

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -579,6 +579,14 @@ msgid "Retry?"
 msgstr ""
 
 #: RawQueryCarousel.html
+msgid "No books match the current filters."
+msgstr ""
+
+#: RawQueryCarousel.html
+msgid "Retry without filters?"
+msgstr ""
+
+#: RawQueryCarousel.html
 msgid "Search collection"
 msgstr ""
 

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -6227,7 +6227,7 @@ msgstr ""
 msgid "Pending Merge Requests"
 msgstr ""
 
-#: lib/nav_head.html
+#: lib/nav_head.html search/sort_options.html
 msgid "Trending"
 msgstr ""
 

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -805,7 +805,7 @@ msgid_plural "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d languages<
 msgstr[0] ""
 msgstr[1] ""
 
-#: SearchResultsWork.html
+#: SearchResultsWork.html TrendingBadge.html
 msgid "This is only visible to librarians."
 msgstr ""
 
@@ -947,6 +947,11 @@ msgstr ""
 #: TableOfContents.html
 #, python-format
 msgid "Page %s"
+msgstr ""
+
+#: TrendingBadge.html
+#, python-format
+msgid "Trending: %(score).2f"
 msgstr ""
 
 #: TypeChanger.html

--- a/openlibrary/macros/QueryCarousel.html
+++ b/openlibrary/macros/QueryCarousel.html
@@ -1,4 +1,4 @@
-$def with(query, title=None, sort='new', key='', limit=20, search=False, has_fulltext_only=True, url=None, layout='carousel', use_cache=True, lazy=True, user_lang_only=False)
+$def with(query, title=None, sort='new', key='', limit=20, search=False, has_fulltext_only=True, url=None, layout='carousel', use_cache=True, lazy=True, user_lang_only=False, fallback=False)
 
 $# Takes following parameters
 $# * query (str) -- Any arbitrary Open Library search query, e.g. subject:"Textbooks"
@@ -8,13 +8,23 @@ $# * key (str) -- unique name of the carousel in analytics
 $# * limit (int) -- initial number of books to pull
 $# * search (bool) -- whether to include search within collection
 $# * layout (str) -- layout type, default 'carousel', currently also supports 'grid'
+$# * lazy (bool) -- When True, lazy-load this carousel
+$# * use_cache (bool) -- Whether to cache this macro
+$# * user_lang_only (bool) -- Whether to filter results by the user's language
+$# * fallback (bool) -- Whether to show a fallback message if no results are found
 
+$ fallback_query = None
 $if user_lang_only:
   $ web_lang = get_lang() or 'en'
   $ user_lang= convert_iso_to_marc(web_lang)
   $if user_lang and user_lang in get_populated_languages():
+        $ fallback_query = query
         $ query = query + ' language:' + user_lang
+
+$ fallback = fallback and fallback_query
+
 $if use_cache and not lazy:
-    $:macros.CacheableMacro("RawQueryCarousel", query, title=title, sort=sort, key=key, limit=limit, search=search, has_fulltext_only=has_fulltext_only, url=url, layout=layout)
+    $# Note this won't work with fallback; the JS that handles retries is in lazy-carousel.js
+    $:macros.CacheableMacro("RawQueryCarousel", query, title=title, sort=sort, key=key, limit=limit, search=search, has_fulltext_only=has_fulltext_only, url=url, layout=layout, fallback=fallback)
 $else:
-    $:macros.RawQueryCarousel(query, title=title, sort=sort, key=key, limit=limit, search=search, has_fulltext_only=has_fulltext_only, url=url, layout=layout, lazy=lazy)
+    $:macros.RawQueryCarousel(query, title=title, sort=sort, key=key, limit=limit, search=search, has_fulltext_only=has_fulltext_only, url=url, layout=layout, lazy=lazy, fallback=fallback)

--- a/openlibrary/macros/RawQueryCarousel.html
+++ b/openlibrary/macros/RawQueryCarousel.html
@@ -1,4 +1,4 @@
-$def with(query, title=None, sort='new', key='', limit=20, search=False, has_fulltext_only=True, url=None, layout='carousel', lazy=True)
+$def with(query, title=None, sort='new', key='', limit=20, search=False, has_fulltext_only=True, url=None, layout='carousel', lazy=True, fallback=None)
 
 $# Takes following parameters
 $# * query (str) -- Any arbitrary Open Library search query, e.g. subject:"Textbooks"
@@ -19,7 +19,8 @@ $if lazy:
             "limit": limit,
             "search": search,
             "has_fulltext_only": has_fulltext_only,
-            "layout": layout
+            "layout": layout,
+            "fallback": fallback,
         }
         if title:
             config["title"] = title
@@ -30,6 +31,10 @@ $if lazy:
         <div class="lazy-carousel-retry hidden">
             $_("Failed to fetch carousel.") <a href="#" class="retry-btn">$_("Retry?")</a>
         </div>
+        $if fallback:
+          <div class="lazy-carousel-fallback hidden">
+              $_("No books match the current filters.") <a href="#" class="retry-btn">$_("Retry without filters?")</a>
+          </div>
     </div>
 $else:
     $# Enable search within this query

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -112,6 +112,8 @@ $code:
           $ ratings_avg = doc.get('ratings_average', None)
           $ want_to_read_count = doc.get('want_to_read_count', None)
           $:macros.StarRatingsByline(ratings_count, ratings_avg, want_to_read_count)
+          $if show_librarian_extras and doc.get('trending_z_score') is not None:
+            $:macros.TrendingBadge(doc)
           $if doc.get('ia'):
             $if len(doc.get('ia')) > 1:
               $ blur_preview = "preview-covers--blur" if blur else ""

--- a/openlibrary/macros/TrendingBadge.html
+++ b/openlibrary/macros/TrendingBadge.html
@@ -1,0 +1,32 @@
+$def with (doc)
+
+$ weekday = today().weekday()
+$ scores = [doc.get('trending_score_daily_%d' % (i % 7), 0) for i in range(weekday, weekday - 7, -1)]
+$ scores.reverse()
+$ scores.append(doc.get('trending_score_hourly_sum', 0))
+$ max_score = max(scores) if scores else 1
+$ max_score = max(max_score, 40)
+<div class="trending-badge" title="$_('This is only visible to librarians.')">
+    $if doc.trending_z_score >= 4:
+        🡽
+    $elif doc.trending_z_score >= 2:
+        ⇗
+    $elif doc.trending_z_score >= 0.5:
+        ↗
+    $elif doc.trending_z_score >= -0.5:
+        ↔
+    $elif doc.trending_z_score >= -2:
+        ↘
+    $elif doc.trending_z_score >= -4:
+        ⇘
+    $else:
+        🡾
+
+    $_('Trending: %(score).2f', score=doc.trending_z_score)
+    <span class="trending-badge__chart">
+        $for score in scores:
+            $ height = int((score / max_score) * 16) if max_score else 1
+            $ height = max(height, 2)
+            <span title="$score" style="height:$(height)px;"></span>
+    </span>
+</div>

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -375,6 +375,8 @@ def do_search(
         'ratings_count',
         'want_to_read_count',
     }
+    if sort and 'trending' in sort:
+        extra_fields.add('trending_*')
     fields = WorkSearchScheme.default_fetched_fields | extra_fields
 
     if web.cookies(sfw="").sfw == 'yes':
@@ -398,7 +400,7 @@ def get_doc(doc: SolrDocument):
 
     called from work_search template
     """
-    return web.storage(
+    result = web.storage(
         key=doc['key'],
         title=doc['title'],
         url=f"{doc['key']}/{urlsafe(doc['title'])}",
@@ -447,6 +449,11 @@ def get_doc(doc: SolrDocument):
         ratings_count=doc.get('ratings_count', None),
         want_to_read_count=doc.get('want_to_read_count', None),
     )
+    for field in doc:
+        if field.startswith('trending_'):
+            result[field] = doc[field]
+
+    return result
 
 
 class scan(delegate.page):

--- a/openlibrary/templates/books/RelatedWorksCarousel.html
+++ b/openlibrary/templates/books/RelatedWorksCarousel.html
@@ -12,12 +12,12 @@ $if work and not is_bot():
             $ )
             $if author_keys:
                 $ query += ' -author_key:(%s)' % ' OR '.join(['%s' % a for a in author_keys])
-            $:macros.QueryCarousel(query=query, title=_("You might also like"), key="related-subjects-carousel", limit=12, user_lang_only=True)
+            $:macros.QueryCarousel(query=query, title=_("You might also like"), key="related-subjects-carousel", limit=12, user_lang_only=True, sort='')
         $if author_keys:
             $ query = 'ebook_access:[borrowable TO *] -key:"%s" author_key:(%s)' % (
             $    work.key,
             $    ' OR '.join(['%s' % a for a in author_keys]),
             $ )
             $ title = ungettext("More by this author", "More by these authors", len(author_keys))
-            $:macros.QueryCarousel(query=query, title=title, key="related-authors-carousel", limit=12, user_lang_only=True)
+            $:macros.QueryCarousel(query=query, title=title, key="related-authors-carousel", limit=12, user_lang_only=True, sort='trending,trending_score_hourly_sum')
     </div>

--- a/openlibrary/templates/publishers/view.html
+++ b/openlibrary/templates/publishers/view.html
@@ -21,13 +21,7 @@ $ subject_list = [('subjects', 20), ('places', 20), ('people', 10), ('times', 10
 </div>
 
 <div class="contentBody">
-  $code:
-    load_more = {
-      "q": page.key,
-      "queryType": "SUBJECTS",
-      "limit": len(page.works)
-    }
-  $:render_template("books/custom_carousel", books=page.works, load_more=load_more)
+    $:macros.QueryCarousel(query='publisher_facet:"%s"' % page.name.replace('"', '\\"'), sort='trending,trending_score_hourly_sum', user_lang_only=False, has_fulltext_only=False)
 
 	<div class="head">
 	    <h2>

--- a/openlibrary/templates/search/sort_options.html
+++ b/openlibrary/templates/search/sort_options.html
@@ -51,6 +51,7 @@ $code:
               { 'sort': 'already_read', 'name': _("Already Read"), 'ga_key': 'ReadingLogAlreadyRead' },
             ]
           },
+         { 'sort': 'trending', 'name': _("Trending"), 'ga_key': 'Trending' },
          { 'sort': 'random', 'name': _("Random"), 'ga_key': 'Random', 'selected': selected_sort and selected_sort.startswith('random') },
        ]
        if selected_sort == 'title' or (ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian())):

--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -56,7 +56,7 @@ $ q = query_param('q')
     $if has_tag:
       $:format(sanitize(page.tag.body))
 
-    $:macros.QueryCarousel(query="subject_key:%s" % page.key.split('/')[-1], sort='trending,trending_score_hourly_sum', user_lang_only=True)
+    $:macros.QueryCarousel(query="subject_key:%s" % page.key.split('/')[-1], sort='trending,trending_score_hourly_sum', user_lang_only=True, fallback=True)
     $:macros.PublishingHistory(page.publishing_history)
 
     <div class="clearfix"></div>

--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -55,13 +55,8 @@ $ q = query_param('q')
 <div class="contentBody">
     $if has_tag:
       $:format(sanitize(page.tag.body))
-    $code:
-      load_more = {
-        "q": page.key,
-        "queryType": "SUBJECTS",
-        "limit": len(page.works)
-      }
-    $:render_template("books/custom_carousel", books=page.works, load_more=load_more)
+
+    $:macros.QueryCarousel(query="subject_key:%s" % page.key.split('/')[-1], sort='trending,trending_score_hourly_sum', user_lang_only=True)
     $:macros.PublishingHistory(page.publishing_history)
 
     <div class="clearfix"></div>

--- a/static/css/components/carousel.less
+++ b/static/css/components/carousel.less
@@ -215,7 +215,8 @@
     margin: 0 auto;
   }
 
-  &-retry {
+  &-retry,
+  &-fallback {
     border: 1px @grey solid;
     background: @lightest-grey;
     margin: 0 auto;

--- a/static/css/components/carousel.less
+++ b/static/css/components/carousel.less
@@ -202,7 +202,8 @@
 
 /* Styles for lazy-loading carousel placeholder element */
 .lazy-carousel {
-  height: 200px;
+  // Same height as the loaded carousel to avoid layout shift
+  height: 278.6px;
   background: @book-cover-carousel-background;
   display: flex;
   flex-direction: column;

--- a/static/css/components/search-result-item.less
+++ b/static/css/components/search-result-item.less
@@ -197,6 +197,26 @@
   }
 }
 
+.trending-badge {
+  display: inline-block;
+  background-color: fade(@olive, 12%);
+  border-radius: 50px;
+  padding: 0 13px;
+
+  .trending-badge__chart {
+    display: inline-block;
+    margin-left: 4px;
+    letter-spacing: -2px;
+  }
+
+  // stylelint-disable-next-line no-descending-specificity
+  .trending-badge__chart > span {
+    display: inline-block;
+    width: 4px;
+    background: @green;
+  }
+}
+
 @media only screen and (min-width: @width-breakpoint-tablet) {
   .list-books {
     .searchResultItem {


### PR DESCRIPTION
Closes #8548 , but mainly continuation of #10947 .

- Adds "Trending" as a sort option to the search page
- Switches subjects/publishers pages to use `QueryCarousel` powered by the edition-aware search.json endpoint
- Sorts subjects/publishers pages by Trending by default
- Adds a librarian-only UI to the search results to verify trending 


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot

Trending dropdown:

<img width="415" height="351" alt="image" src="https://github.com/user-attachments/assets/836c43f7-b636-4466-9cea-a3b27d98949f" />

French users will now see French horror books:

https://testing.openlibrary.org/subjects/horror?lang=fr
| Before | After | 
| ---- | ---- |
| <img width="1398" height="549" alt="image" src="https://github.com/user-attachments/assets/97c07817-7fd0-4a9c-a812-028a9d873709" /> | <img width="1378" height="555" alt="image" src="https://github.com/user-attachments/assets/11510abd-2ff1-4c37-a6db-2367a5a7deaa" /> |


The Standard Ebooks publisher page now shows the Standard Ebooks editions:

https://testing.openlibrary.org/publishers/Standard_Ebooks

| Before | After | 
| ------ | ----- |
| <img width="1451" height="472" alt="image" src="https://github.com/user-attachments/assets/54b20659-600e-4f9a-836d-16da8bac2a78" /> | <img width="1417" height="480" alt="image" src="https://github.com/user-attachments/assets/a9402de5-538a-4a23-b894-2db74c0afb87" /> |


Librarian-visible trending badge for debugging:

https://testing.openlibrary.org/search?q=trending_score_hourly_sum%3A[1+TO+*]+language%3Aeng&sort=trending

<img width="1032" height="596" alt="image" src="https://github.com/user-attachments/assets/d846c58c-476f-4d1f-9dd0-f54b92a2bf47" />


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
