### PR TITLE
Remove empty `<h1>` element from profile page

### DIFF
--- a/openlibrary/templates/type/user/view.html
+++ b/openlibrary/templates/type/user/view.html
@@ -15,7 +15,6 @@ $else:
     $ lists = []
 
 <div id="contentHead">
-    <h1>$settings.get('username')</h1>
     $if is_public and not owners_page:
         <div class="right">$:macros.Follow(username, following=is_subscribed)</div>
     $:macros.databarView(page)


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes `<h1>` element that displays `settings.username` from patron profile pages.  `username` is not stored in patron preferences, so this is always empty (unless the profile page fails to render, which can happen when a patron deletes their own preferences...).

The `<h1>` element that displays the patron's display name remains unchanged.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
