### PR TITLE
use UV in GitHub Actions

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -46,13 +46,7 @@ jobs:
       - name: Install dependencies
         run: |
           # Try to upgrade pip, setuptools, and wheel
-          uv pip install --upgrade setuptools wheel || {
-            echo "pip is broken or missing, reinstalling..."
-            curl -sS https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-            python get-pip.py
-            rm -f get-pip.py
-            uv pip install --upgrade setuptools wheel
-          }
+          uv pip install --upgrade setuptools wheel
           uv pip install -r requirements_test.txt
           uv pip list --outdated
       - run: make git

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -25,6 +25,8 @@ jobs:
       # - uses: actions/setup-python@v5
       #   with:
       #     python-version-file: pyproject.toml
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
       - uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
@@ -34,8 +36,6 @@ jobs:
           sudo apt-get update
           # https://lxml.de/installation.html#requirements
           sudo apt-get install -y libxml2 libxslt-dev
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
       - name: Set up Python
         run: uv python install
       - name: Install dependencies

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -22,9 +22,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions/setup-python@v5
-        with:
-          python-version-file: pyproject.toml
+      # - uses: actions/setup-python@v5
+      #   with:
+      #     python-version-file: pyproject.toml
       - uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
@@ -36,6 +36,8 @@ jobs:
           sudo apt-get install -y libxml2 libxslt-dev
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+      - name: Set up Python
+        run: uv python install
       - name: Install dependencies
         env:
           UV_SYSTEM_PYTHON: 1

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -15,9 +15,6 @@ on:
 permissions:
   contents: read
 
-env:
-  UV_SYSTEM_PYTHON: 1 #install packages into system python instead of venv
-
 jobs:
   python_tests:
     runs-on: ubuntu-latest
@@ -25,28 +22,32 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      # - uses: actions/setup-python@v5
-      #   with:
-      #     python-version-file: pyproject.toml
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
+      - uses: actions/setup-python@v5
         with:
-          enable-cache: true
-      # - uses: actions/cache@v4
-      #   with:
-      #     path: ${{ env.pythonLocation }}
-      #     key: ${{ runner.os }}-venv-${{ env.pythonLocation }}-${{ hashFiles('requirements*.txt') }}
+          python-version-file: pyproject.toml
+      - uses: actions/cache@v4
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ runner.os }}-venv-${{ env.pythonLocation }}-${{ hashFiles('requirements*.txt') }}
       - if: "contains(matrix.python-version, '-dev')"
         run: |
           sudo apt-get update
           # https://lxml.de/installation.html#requirements
           sudo apt-get install -y libxml2 libxslt-dev
-      - name: Set up Python
-        run: uv python install
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
       - name: Install dependencies
+        env:
+          UV_SYSTEM_PYTHON: 1
         run: |
           # Try to upgrade pip, setuptools, and wheel
-          uv pip install --upgrade setuptools wheel
+          uv pip install --upgrade pip setuptools wheel || {
+            echo "pip is broken or missing, reinstalling..."
+            curl -sS https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+            python get-pip.py
+            rm -f get-pip.py
+            uv pip install --upgrade pip setuptools wheel
+          }
           uv pip install -r requirements_test.txt
           uv pip list --outdated
       - run: make git

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -32,10 +32,10 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
-      - uses: actions/cache@v4
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ runner.os }}-venv-${{ env.pythonLocation }}-${{ hashFiles('requirements*.txt') }}
+      # - uses: actions/cache@v4
+      #   with:
+      #     path: ${{ env.pythonLocation }}
+      #     key: ${{ runner.os }}-venv-${{ env.pythonLocation }}-${{ hashFiles('requirements*.txt') }}
       - if: "contains(matrix.python-version, '-dev')"
         run: |
           sudo apt-get update

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -15,6 +15,9 @@ on:
 permissions:
   contents: read
 
+env:
+  UV_SYSTEM_PYTHON: 1 #install packages into system python instead of venv
+
 jobs:
   python_tests:
     runs-on: ubuntu-latest
@@ -39,8 +42,6 @@ jobs:
       - name: Set up Python
         run: uv python install
       - name: Install dependencies
-        env:
-          UV_SYSTEM_PYTHON: 1
         run: |
           # Try to upgrade pip, setuptools, and wheel
           uv pip install --upgrade pip setuptools wheel || {

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -41,12 +41,12 @@ jobs:
           UV_SYSTEM_PYTHON: 1
         run: |
           # Try to upgrade pip, setuptools, and wheel
-          python -m pip install --upgrade pip setuptools wheel || {
+          uv pip install --upgrade pip setuptools wheel || {
             echo "pip is broken or missing, reinstalling..."
             curl -sS https://bootstrap.pypa.io/get-pip.py -o get-pip.py
             python get-pip.py
             rm -f get-pip.py
-            python -m pip install --upgrade pip setuptools wheel
+            uv pip install --upgrade pip setuptools wheel
           }
           uv pip install -r requirements_test.txt
           uv pip list --outdated

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -37,6 +37,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
       - name: Install dependencies
+        env:
+          UV_SYSTEM_PYTHON: 1
         run: |
           # Try to upgrade pip, setuptools, and wheel
           python -m pip install --upgrade pip setuptools wheel || {

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -34,6 +34,8 @@ jobs:
           sudo apt-get update
           # https://lxml.de/installation.html#requirements
           sudo apt-get install -y libxml2 libxslt-dev
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
       - name: Install dependencies
         run: |
           # Try to upgrade pip, setuptools, and wheel
@@ -44,8 +46,8 @@ jobs:
             rm -f get-pip.py
             python -m pip install --upgrade pip setuptools wheel
           }
-          pip install -r requirements_test.txt
-          pip list --outdated
+          uv pip install -r requirements_test.txt
+          uv pip list --outdated
       - run: make git
       - name: Run make i18n
         run: |

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -30,6 +30,8 @@ jobs:
       #     python-version-file: pyproject.toml
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
       - uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -46,12 +46,12 @@ jobs:
       - name: Install dependencies
         run: |
           # Try to upgrade pip, setuptools, and wheel
-          uv pip install --upgrade pip setuptools wheel || {
+          uv pip install --upgrade setuptools wheel || {
             echo "pip is broken or missing, reinstalling..."
             curl -sS https://bootstrap.pypa.io/get-pip.py -o get-pip.py
             python get-pip.py
             rm -f get-pip.py
-            uv pip install --upgrade pip setuptools wheel
+            uv pip install --upgrade setuptools wheel
           }
           uv pip install -r requirements_test.txt
           uv pip list --outdated


### PR DESCRIPTION
<!-- What issue does this PR close? -->
We can speed up our CI times a bit by using UV.



How I got the numbers.
Go to the history of the workflow runs [here](https://github.com/internetarchive/openlibrary/actions/workflows/python_tests.yml?page=2&query=is%3Asuccess).
Run some js to extract the times.
```js
Array.from(document.querySelectorAll(".octicon-stopwatch")).map(e=>e.nextElementSibling.innerText.trim()).map(str => (parseInt(str.match(/(\d+)\s*m/)?.[1] || 0) * 60) + parseInt(str.match(/(\d+)\s*s/)?.[1] || 0)).join("\n")
```
Plug the numbers into:
https://www.calculatorsoup.com/calculators/statistics/statistics.php

Without UV:
```
Minimum = 52
Maximum = 89
Range = 37
n = 50
sum = 3112
Mean = 62.24
Median = 60
mode = 56
```

With UV: it takes 50 or 53 seconds to run. So saving ~10 seconds on average.
I don't have a large sample but that's a solid improvement for a tiny change.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
