### PR TITLE
Migrating the /reading-goals/partials.json handler to /partials.py

### DIFF
--- a/openlibrary/plugins/openlibrary/js/check-ins/index.js
+++ b/openlibrary/plugins/openlibrary/js/check-ins/index.js
@@ -590,7 +590,7 @@ function updateProgressComponent(elem, goal) {
 function fetchProgressAndUpdateViews(yearlyGoalElems, goalYear) {
     fetch(buildPartialsUrl('/partials.json', {
         _component: 'ReadingGoalProgress',
-        data: JSON.stringify({ year: goalYear}),
+        year: goalYear
     }))
         .then((response) => {
             if (!response.ok) {

--- a/openlibrary/plugins/openlibrary/js/check-ins/index.js
+++ b/openlibrary/plugins/openlibrary/js/check-ins/index.js
@@ -588,7 +588,10 @@ function updateProgressComponent(elem, goal) {
  * @param {string} goalYear Year that the goal is set for.
  */
 function fetchProgressAndUpdateViews(yearlyGoalElems, goalYear) {
-    fetch(buildPartialsUrl('/reading-goal/partials.json', {year: goalYear}))
+    fetch(buildPartialsUrl('/partials.json', {
+        _component: 'ReadingGoalProgress',
+        data: JSON.stringify({ year: goalYear}),
+    }))
         .then((response) => {
             if (!response.ok) {
                 throw new Error('Failed to fetch progress element')

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -38,9 +38,11 @@ class PartialDataHandler(ABC):
 class ReadingGoalProgressPartial(PartialDataHandler):
     """Handler for reading goal progress."""
 
+    def __init__(self):
+        self.i = web.input(year=None)
+
     def generate(self) -> dict:
-        i = web.input(year=None)
-        year = i.year or datetime.now().year
+        year = self.i.year or datetime.now().year
         goal = get_reading_goals(year=year)
         component = render_template('check_ins/reading_goal_progress', [goal])
 

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -1,5 +1,6 @@
 import json
 from abc import ABC, abstractmethod
+from datetime import datetime
 from typing import cast
 from urllib.parse import parse_qs
 
@@ -11,6 +12,7 @@ from openlibrary.core.fulltext import fulltext_search
 from openlibrary.core.lending import compose_ia_url, get_available
 from openlibrary.i18n import gettext as _
 from openlibrary.plugins.openlibrary.lists import get_user_lists
+from openlibrary.plugins.upstream.checkins import get_reading_goals
 from openlibrary.plugins.worksearch.code import do_search, work_search
 from openlibrary.plugins.worksearch.subjects import get_subject
 from openlibrary.views.loanstats import get_trending_books
@@ -31,6 +33,18 @@ class PartialDataHandler(ABC):
     @abstractmethod
     def generate(self) -> dict:
         pass
+
+
+class ReadingGoalProgressPartial(PartialDataHandler):
+    """Handler for reading goal progress."""
+
+    def generate(self) -> dict:
+        i = web.input(year=None)
+        year = i.year or datetime.now().year
+        goal = get_reading_goals(year=year)
+        component = render_template('check_ins/reading_goal_progress', [goal])
+
+        return {"partials": str(component)}
 
 
 class MyBooksDropperListsPartial(PartialDataHandler):
@@ -344,6 +358,7 @@ class PartialRequestResolver:
         "BPListsSection": BookPageListsPartial,
         "LazyCarousel": LazyCarouselPartial,
         "MyBooksDropperLists": MyBooksDropperListsPartial,
+        "ReadingGoalProgress": ReadingGoalProgressPartial,
     }
 
     @staticmethod

--- a/openlibrary/plugins/upstream/checkins.py
+++ b/openlibrary/plugins/upstream/checkins.py
@@ -9,7 +9,6 @@ import web
 from infogami.utils import delegate
 from infogami.utils.view import public
 from openlibrary.accounts import get_current_user
-from openlibrary.app import render_template
 from openlibrary.core.bookshelves_events import BookshelfEvent, BookshelvesEvents
 from openlibrary.core.yearly_reading_goals import YearlyReadingGoals
 from openlibrary.utils import extract_numeric_id_from_olid
@@ -259,19 +258,6 @@ class YearlyGoal:
     @classmethod
     def calc_progress(cls, books_read, goal):
         return floor((books_read / goal) * 100)
-
-
-class ui_partials(delegate.page):
-    path = '/reading-goal/partials'
-    encoding = 'json'
-
-    def GET(self):
-        i = web.input(year=None)
-        year = i.year or datetime.now().year
-        goal = get_reading_goals(year=year)
-        component = render_template('check_ins/reading_goal_progress', [goal])
-        partials = {"partials": str(component)}
-        return delegate.RawText(json.dumps(partials))
 
 
 def setup():


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10985 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Refactors the codebase to migrate `/reading-goals/partials.json` handler to `partials.py`. 



### Technical
<!-- What should be noted about the implementation? -->
- Created new `ReadingGoalProgressPartial` handler that extends from `PartialDataHandler` in `partials.py`
- Update `PartialRequestResolver.component_mapping`, adding the new handler
- Update existing `/reading-goal/partials.json` calls to use `/partials.json`
- Deleted `/reading-goal/partials.json` handler

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- For testing the functionality one can navigate to `MyBooks` section on the main page.
- Then can toggle `set Reading Goal` from the left pane and notice `Networks` tab though inspect.
- After setting a goal value user can click [SET].
- A `reading-goal.json` object can be seen in the `networks` tab. Refer to Screenshot attached.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="852" height="179" alt="Screenshot 2025-07-16 230148" src="https://github.com/user-attachments/assets/2bd3dd44-b139-4266-b2cd-1b4a715b2f05" />


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
