### PR TITLE
Closes #10965; fix resolve redirect chain in export

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -909,7 +909,7 @@ class export_books(delegate.page):
         Gets work data for a given work ID (OLxxxxxW format), used to access work author, title, etc. for CSV generation.
         """
         work_key = f"/works/{work_id}"
-        work: Work = web.ctx.site.get(work_key)
+        work: "Work" = web.ctx.site.get(work_key)
         if not work:
             raise ValueError(f"No Work found for {work_key}.")
         if work.type.key == '/type/redirect':

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -915,10 +915,9 @@ class export_books(delegate.page):
         if work.type.key == '/type/redirect':
             # Resolve the redirect before exporting:
             from openlibrary.core.models import Work
+
             work = web.ctx.site.get(
-                Work.resolve_redirect_chain(
-                    work_key
-                ).get('resolved_key')
+                Work.resolve_redirect_chain(work_key).get('resolved_key')
             )
         return work
 

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -908,14 +908,14 @@ class export_books(delegate.page):
         """
         Gets work data for a given work ID (OLxxxxxW format), used to access work author, title, etc. for CSV generation.
         """
+        # Can't put at top due to cyclical imports
+        from openlibrary.plugins.upstream.models import Work
+
         work_key = f"/works/{work_id}"
         work: Work = web.ctx.site.get(work_key)
         if not work:
             raise ValueError(f"No Work found for {work_key}.")
         if work.type.key == '/type/redirect':
-            # Can't put at top due to cyclical imports
-            from openlibrary.core.models import Work
-
             # Resolve the redirect before exporting
             work = web.ctx.site.get(
                 Work.resolve_redirect_chain(work_key).get('resolved_key')

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -909,7 +909,7 @@ class export_books(delegate.page):
         Gets work data for a given work ID (OLxxxxxW format), used to access work author, title, etc. for CSV generation.
         """
         work_key = f"/works/{work_id}"
-        work: "Work" = web.ctx.site.get(work_key)
+        work: Work = web.ctx.site.get(work_key)
         if not work:
             raise ValueError(f"No Work found for {work_key}.")
         if work.type.key == '/type/redirect':

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -913,9 +913,13 @@ class export_books(delegate.page):
         if not work:
             raise ValueError(f"No Work found for {work_key}.")
         if work.type.key == '/type/redirect':
-            # Fetch actual work and resolve redirects before exporting:
-            work = web.ctx.site.get(work.location)
-            work.resolve_redirect_chain(work_key)
+            # Resolve the redirect before exporting:
+            from openlibrary.core.models import Work
+            work = web.ctx.site.get(
+                Work.resolve_redirect_chain(
+                    work_key
+                ).get('resolved_key')
+            )
         return work
 
     def generate_reading_log(self, username: str) -> str:

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -908,14 +908,15 @@ class export_books(delegate.page):
         """
         Gets work data for a given work ID (OLxxxxxW format), used to access work author, title, etc. for CSV generation.
         """
+        # Can't put at top due to cyclical imports
+        from openlibrary.core.models import Work
+
         work_key = f"/works/{work_id}"
         work: Work = web.ctx.site.get(work_key)
         if not work:
             raise ValueError(f"No Work found for {work_key}.")
         if work.type.key == '/type/redirect':
-            # Resolve the redirect before exporting:
-            from openlibrary.core.models import Work
-
+            # Resolve the redirect before exporting
             work = web.ctx.site.get(
                 Work.resolve_redirect_chain(work_key).get('resolved_key')
             )

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -908,14 +908,14 @@ class export_books(delegate.page):
         """
         Gets work data for a given work ID (OLxxxxxW format), used to access work author, title, etc. for CSV generation.
         """
-        # Can't put at top due to cyclical imports
-        from openlibrary.core.models import Work
-
         work_key = f"/works/{work_id}"
-        work: Work = web.ctx.site.get(work_key)
+        work: "Work" = web.ctx.site.get(work_key)
         if not work:
             raise ValueError(f"No Work found for {work_key}.")
         if work.type.key == '/type/redirect':
+            # Can't put at top due to cyclical imports
+            from openlibrary.core.models import Work
+
             # Resolve the redirect before exporting
             work = web.ctx.site.get(
                 Work.resolve_redirect_chain(work_key).get('resolved_key')


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10965

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

The `work` we were getting back from infogami was actually a type `redirect` and was not hydrated by the core.models.Work class (and returned `Nothing`).

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
