### PR TITLE
Update `buildPartialsUrl` for single `/partials.json` endpoint

### DIFF
--- a/openlibrary/plugins/openlibrary/js/affiliate-links.js
+++ b/openlibrary/plugins/openlibrary/js/affiliate-links.js
@@ -52,7 +52,7 @@ function showLoadingIndicators(linkSections) {
 async function getPartials(data, affiliateLinksSections) {
     const dataString = JSON.stringify(data)
 
-    return fetch(buildPartialsUrl('/partials.json', {_component: 'AffiliateLinks', data: dataString}))
+    return fetch(buildPartialsUrl('AffiliateLinks', {data: dataString}))
         .then((resp) => {
             if (resp.status !== 200) {
                 throw new Error(`Failed to fetch partials. Status code: ${resp.status}`)

--- a/openlibrary/plugins/openlibrary/js/book-page-lists.js
+++ b/openlibrary/plugins/openlibrary/js/book-page-lists.js
@@ -56,7 +56,7 @@ export function initListsSection(elem) {
 }
 
 async function fetchPartials(workId, editionId) {
-    const params = { _component: 'BPListsSection' }
+    const params = {}
     if (workId) {
         params.workId = workId
     }
@@ -64,5 +64,5 @@ async function fetchPartials(workId, editionId) {
         params.editionId = editionId
     }
 
-    return fetch(buildPartialsUrl('/partials.json', params));
+    return fetch(buildPartialsUrl('BPListsSection', params));
 }

--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -144,8 +144,7 @@ export class Carousel {
 
     fetchPartials() {
         const loadMore = this.loadMore
-        const url = buildPartialsUrl('/partials.json', {
-            _component: 'CarouselLoadMore',
+        const url = buildPartialsUrl('CarouselLoadMore', {
             queryType: loadMore.queryType,
             q: loadMore.q,
             limit: loadMore.limit,

--- a/openlibrary/plugins/openlibrary/js/check-ins/index.js
+++ b/openlibrary/plugins/openlibrary/js/check-ins/index.js
@@ -588,10 +588,7 @@ function updateProgressComponent(elem, goal) {
  * @param {string} goalYear Year that the goal is set for.
  */
 function fetchProgressAndUpdateViews(yearlyGoalElems, goalYear) {
-    fetch(buildPartialsUrl('/partials.json', {
-        _component: 'ReadingGoalProgress',
-        year: goalYear
-    }))
+    fetch(buildPartialsUrl('ReadingGoalProgress', {year: goalYear}))
         .then((response) => {
             if (!response.ok) {
                 throw new Error('Failed to fetch progress element')

--- a/openlibrary/plugins/openlibrary/js/fulltext-search-suggestion.js
+++ b/openlibrary/plugins/openlibrary/js/fulltext-search-suggestion.js
@@ -18,7 +18,7 @@ function showLoadingIndicators(fulltextSearchSuggestion) {
     return isLoading
 }
 async function getPartials(fulltextSearchSuggestion, query) {
-    return fetch(buildPartialsUrl('/partials.json', {_component: 'FulltextSearchSuggestion', data: query}))
+    return fetch(buildPartialsUrl('FulltextSearchSuggestion', {data: query}))
         .then((resp) => {
             if (resp.status !== 200) {
                 throw new Error(`Failed to fetch partials. Status code: ${resp.status}`)

--- a/openlibrary/plugins/openlibrary/js/lazy-carousel.js
+++ b/openlibrary/plugins/openlibrary/js/lazy-carousel.js
@@ -35,7 +35,7 @@ export function initLazyCarousel(elems) {
  * @returns {Promise<Response>}
  */
 async function fetchPartials(data) {
-    return fetch(buildPartialsUrl('/partials.json', {...data, _component: 'LazyCarousel'}))
+    return fetch(buildPartialsUrl('LazyCarousel', {...data}))
 }
 
 /**

--- a/openlibrary/plugins/openlibrary/js/lists/ListService.js
+++ b/openlibrary/plugins/openlibrary/js/lists/ListService.js
@@ -63,10 +63,7 @@ export async function removeItem(listKey, seed) {
 
 // XXX : jsdoc
 export async function getListPartials() {
-    return await fetch(buildPartialsUrl('/partials.json', {
-        _component: 'MyBooksDropperLists'
-    }), {
-        method: 'GET',
+    return await fetch(buildPartialsUrl('MyBooksDropperLists'), {
         headers: {
             'Content-Type': 'application/json',
             Accept: 'application/json',

--- a/openlibrary/plugins/openlibrary/js/search.js
+++ b/openlibrary/plugins/openlibrary/js/search.js
@@ -132,10 +132,7 @@ function fetchPartials(param) {
         query: location.search
     }
 
-    return fetch(buildPartialsUrl('/partials.json', {
-        _component: 'SearchFacets',
-        data: JSON.stringify(data),
-    }))
+    return fetch(buildPartialsUrl('SearchFacets', {data: JSON.stringify(data)}))
         .then((resp) => {
             if (!resp.ok) {
                 throw new Error(`Failed to fetch partials. Status code: ${resp.status}`)

--- a/openlibrary/plugins/openlibrary/js/utils.js
+++ b/openlibrary/plugins/openlibrary/js/utils.js
@@ -73,9 +73,12 @@ export function trimInputValues(param) {
     });
 }
 
-export function buildPartialsUrl(path, params) {
+export function buildPartialsUrl(component, params = {}) {
     const curUrl = new URL(window.location.href);
-    const url = new URL(location.origin + path);
+    const url = new URL(location.origin + '/partials.json');
+
+    url.searchParams.set('_component', component)
+
     if (curUrl.searchParams.has('lang')) {
         url.searchParams.set('lang', curUrl.searchParams.get('lang'));
     }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11040

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Replaces the `buildPartialsUrl` `path` parameter with `component`.  Makes `params` optional, for partials requests that require no query parameters (aside from `_component`).

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
