### PR TITLE
Fixed a Bug in Padding of CSS in HomePage

### DIFF
--- a/static/css/components/carousel--js.less
+++ b/static/css/components/carousel--js.less
@@ -23,4 +23,9 @@
   .slick-next {
     margin-right: 11px;
   }
+
+  .slick-slide.carousel__item {
+    margin: 0 5px;
+    padding: 2px;
+  }
 }


### PR DESCRIPTION
I've implemented adds specific spacing for carousel items when they have the slick-slide class applied. This ensures that- 
Each carousel item has a margin 0 5px which provides 10px total spacing between items , The padding 2px is maintained for consistent internal spacing.

Closes #11036

### Technical

### Testing

### Screenshot

### Stakeholders
