### PR TITLE
Account anonymization `POST` handler

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -1199,10 +1199,14 @@ class account_anonymization_json(delegate.page):
 
         try:
             result = ol_account.anonymize(test=test)
-        except Exception as e:
-            raise web.HTTPError("500 Internal Server Error", {"Content-Type": "application/json"})
+        except Exception:
+            raise web.HTTPError(
+                "500 Internal Server Error", {"Content-Type": "application/json"}
+            )
 
-        raise web.HTTPError("200 OK", {"Content-Type": "application/json"}, data=json.dumps(result))
+        raise web.HTTPError(
+            "200 OK", {"Content-Type": "application/json"}, data=json.dumps(result)
+        )
 
     def _validate_headers(self):
         origin = web.ctx.env.get('HTTP_ORIGIN') or web.ctx.env.get('HTTP_REFERER')

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -1175,6 +1175,9 @@ class account_anonymization_json(delegate.page):
     encoding = "json"
 
     def POST(self):
+        i = web.input(test='false')
+        test = i.test == "true"
+
         # Validate request origin
         if not self._validate_headers():
             raise web.HTTPError("403 Forbidden", {"Content-Type": "application/json"})
@@ -1196,11 +1199,11 @@ class account_anonymization_json(delegate.page):
             raise web.HTTPError("404 Not Found", {"Content-Type": "application/json"})
 
         try:
-            ol_account.anonymize()
+            result = ol_account.anonymize(test=test)
         except Exception as e:
             raise web.HTTPError("500 Internal Server Error", {"Content-Type": "application/json"})
 
-        raise web.HTTPError("200 OK", {"Content-Type": "application/json"})
+        raise web.HTTPError("200 OK", {"Content-Type": "application/json"}, data=json.dumps(result))
 
     def _validate_headers(self):
         origin = web.ctx.env.get('HTTP_ORIGIN') or web.ctx.env.get('HTTP_REFERER')


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Addresses #10976

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds new `POST` handler that can be used to anonymize Open Library accounts via archive.org.

`POST` requests to `/account/anonymize.json` containing valid `x-s3-access` and `x-s3-secret` headers trigger an account anonymization action on the associated account.

### Technical
<!-- What should be noted about the implementation? -->

#### `/account/anonymize.json` responses
| Response | Meaning |
|---|---|
| `200 OK` | The account anonymization request was successful |
| `400 Bad Request` | The authorization header was malformed |
| `403 Forbidden` | The request did not originate from archive.org |
| `404 Not Found` | No account associated with the given S3 keys was not found |
| `500 Internal Server Error` | The account anonymization operation failed for some reason |

Adding `?test=true` to account anonymization requests will trigger the account anonymization in `test` mode, which will prevent the account from actually being anonymized.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
