### PR TITLE
Fixed the bug to handle global and community lists

### DIFF
--- a/openlibrary/templates/lists/list_follow.html
+++ b/openlibrary/templates/lists/list_follow.html
@@ -23,32 +23,41 @@ $def list_card(list, owner, own_list):
                    $ img_url = '/images/icons/avatar_book-sm.png'
                <img src="$img_url" loading="lazy" width="80"/>
         </a>
-        <div class="list-follow-card__bottom">
-            <div class="list-follow-card__user">
-                 <a href="$owner.key">
-                  <img src="$(owner.key)/avatar" />
-                 </a>
-                <div class="list-follow-card__username">
-                    <a class="list-follow-card__username-link" href="$owner.key">
-                      $if not own_list:
-                        $ owner_username = owner.key.split('/')[-1]
-                        $('@' + owner_username)
-                      $else:
-                        $_('You')
+
+        <!-- Bottom section: owner info or community label -->
+        $if owner:
+            <div class="list-follow-card__bottom">
+                <div class="list-follow-card__user">
+                    <a href="$owner.key">
+                        <img src="$(owner.key)/avatar" />
                     </a>
+                    <div class="list-follow-card__username">
+                        <a class="list-follow-card__username-link" href="$owner.key">
+                            $if not own_list:
+                                $ owner_username = owner.key.split('/')[-1]
+                                $('@' + owner_username)
+                            $else:
+                                $_('You')
+                        </a>
+                    </div>
+                </div>
+                <div class="list-follow-card__follow-button">
+                    $if not own_list:
+                        $ owner_username = owner.key.split('/')[-1]
+                        $ owner_account = get_user_object(owner_username)
+                        $ is_subscribed = ctx.user and ctx.user.is_subscribed_user(owner_username)
+                        $ settings = owner_account.get_users_settings()
+                        $ is_public = settings and settings.get('public_readlog', 'no') == "yes"
+                        $if is_public:
+                            $:render_follow_button(owner_username, is_subscribed)
                 </div>
             </div>
-            <div class="list-follow-card__follow-button">
-               $if not own_list:
-                 $ owner_username = owner.key.split('/')[-1]
-                 $ owner_account = get_user_object(owner_username)
-                 $ is_subscribed = ctx.user and ctx.user.is_subscribed_user(owner_username)
-                 $ settings = owner_account.get_users_settings()
-                 $ is_public = settings and settings.get('public_readlog', 'no') == "yes"
-                 $if is_public:
-                    $:render_follow_button(owner_username, is_subscribed)
+        $else:
+            <div class="list-follow-card__bottom">
+                <div class="list-follow-card__community-label">
+                    <i>Community List</i>
+                </div>
             </div>
-        </div>
     </div>
 
 $ count = 0


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11037 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes the issue of handling `owner` in **GLOBAL LISTS** and **COMMUNITY LISTS**.


### Technical
<!-- What should be noted about the implementation? -->
Added a check for `owner` present or not for a particular list. If not then don't render the bottom section.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
For testing one can view a book that is in community list.
Earlier behavior before fix: Lists were not rendered due to owner not present
After fix: The list is rendering with the implementation as suggested.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

<img width="1263" height="499" alt="Screenshot 2025-07-24 at 4 17 24 PM" src="https://github.com/user-attachments/assets/1e35c5cd-2121-45a2-8595-3de28d60a5a2" />

https://testing.openlibrary.org/works/OL831059W/Pet_show!?edition=ia%3Apetshowreadingra0000unse#lists-section

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
