### PR TITLE
Note book deletions in patron's reading log

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -18,6 +18,10 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.12.1\n"
 
+#: openlibrary/core/bookshelves.py
+msgid "[Record deleted]"
+msgstr ""
+
 #: merge_request_table/table_header.html openlibrary/core/edits.py
 msgid "Declined"
 msgstr ""
@@ -7537,11 +7541,11 @@ msgid "View the previous version"
 msgstr ""
 
 #: type/delete/view.html
-msgid "Recreate it"
+msgid "See the page's history"
 msgstr ""
 
 #: type/delete/view.html
-msgid "See the page's history"
+msgid "Recreate it"
 msgstr ""
 
 #: type/edition/admin_bar.html

--- a/openlibrary/templates/type/delete/view.html
+++ b/openlibrary/templates/type/delete/view.html
@@ -13,9 +13,11 @@ $var title: $page.key
 
     <ul>
       <li><a href="javascript:;" class="go-back-link">$_("Go back where I came from")</a></li>
-      $if ctx.user and ctx.user.is_admin():
+      $if ctx.user:
+        $# Prevent crawling; only show to logged-in users
         <li><a href="$url(v=page.revision - 1)">$_("View the previous version")</a></li>
-        <li><a href="$url(m='edit', v=page.revision - 1)">$_("Recreate it")</a></li>
         <li><a href="$url(m='history')">$_("See the page's history")</a></li>
+        $if (ctx.user.is_librarian() or ctx.user.is_super_librarian() or ctx.user.is_admin()):
+            <li><a href="$url(m='edit', v=page.revision - 1)">$_("Recreate it")</a></li>
     </ul>
 </div>


### PR DESCRIPTION
Closes #11059

Addendum to #10970


### Technical
<!-- What should be noted about the implementation? -->

- Also made sure the delete page UI shows the "View previous version link" for logged in users.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

Now shows a stub record for a deletion:

<img width="994" height="679" alt="image" src="https://github.com/user-attachments/assets/28c4b815-0376-47e2-8db0-896223cff6ae" />

Clicking on the link will take the user to a page like this:

<img width="711" height="322" alt="image" src="https://github.com/user-attachments/assets/59215116-a8bb-47c5-8ed9-2826ea14c71e" />


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
