### PR TITLE
Remediation script for anonymized `account-email` store entries

### DIFF
--- a/scripts/migrations/README.md
+++ b/scripts/migrations/README.md
@@ -1,6 +1,10 @@
 # Migration Scripts
 
-Scripts found in this directory are meant to support a one-time task (such as a data migration), and __do not__ require long-term maintenance.
+Scripts found in this directory are meant to support a one-time task (such as a data migration), and likely __do not__ require long-term maintenance.
+
+## `ananymous_store_remediation.py`
+
+Created as a follow-up to [issue #11024](https://github.com/internetarchive/openlibrary/pull/11024), this script identifies and removes any remaining `account-email` store entries that are associated with anonymized accounts.
 
 ## `delete_merge_debug.py`
 

--- a/scripts/migrations/anonymous_store_remediation.py
+++ b/scripts/migrations/anonymous_store_remediation.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Identifies and deletes any remaining `account-email` store entries that are associated
+with anonymized accounts.
+"""
+import argparse
+from pathlib import Path
+
+import db
+import web
+
+import infogami
+from openlibrary.config import load_config
+
+DEFAULT_CONFIG_PATH = "/olsystem/etc/openlibrary.yml"
+
+def setup(config_path):
+    if not Path(config_path).exists():
+        raise FileNotFoundError(f'no config file at {config_path}')
+
+    load_config(config_path)
+    infogami._setup()
+
+def remediate():
+    def fetch_usernames():
+        oldb = db.get_db()
+
+        query = """
+            SELECT SUBSTRING(key FROM 9) as username from thing
+            WHERE type IN (SELECT id FROM thing WHERE key = '/type/delete' LIMIT 1)
+            AND key LIKE '/people/%'
+            AND LENGTH(key) - LENGTH(REPLACE(key, '/', '')) = 2
+            ORDER BY id ASC
+            """
+
+        return list(oldb.query(query))
+
+    def fetch_store_key(_username):
+        oldb = db.get_db()
+        data = {
+            'username': _username,
+        }
+        query = """
+            SELECT s2.value as key_value
+            FROM store_index s1
+            JOIN store_index s2
+              ON s1.store_id = s2.store_id
+            WHERE s1.type = 'account-email'
+              AND s1.name = 'username'
+              AND s1.value = $username
+              AND s2.type = 'account-email'
+              AND s2.name = '_key'
+            """
+
+        result = list(oldb.query(query, vars=data))
+        return (result and result[0]['key_value']) or ''
+
+    def is_account_active(store_key: str) -> bool:
+        """
+        Returns `True` if there is a store entry associated with `store_key`.
+        """
+        oldb = db.get_db()
+        data = {
+            'key': store_key,
+        }
+        query = "SELECT id FROM store WHERE key = $key"
+        result = list(oldb.query(query, vars=data))
+        return bool(result)
+
+    deleted_entries = 0
+    usernames = fetch_usernames()
+
+    for record in usernames:
+        if not is_account_active(f"account/{record['username']}") and (key := fetch_store_key(record['username'])):
+            web.ctx.site.store.delete(key)
+            deleted_entries += 1
+
+    print(f"Remediated {deleted_entries} `account-email` store entries.")
+
+def main(args):
+    setup(args.config)
+    remediate()
+
+def _parse_args():
+    _parser = argparse.ArgumentParser(description=__doc__)
+    _parser.add_argument(
+        "-c",
+        "--config",
+        default=DEFAULT_CONFIG_PATH,
+        help="Path to the `openlibrary.yml` configuration file",
+    )
+    _parser.set_defaults(func=main)
+    return _parser.parse_args()
+
+if __name__ == '__main__':
+    _args = _parse_args()
+    _args.func(_args)

--- a/scripts/migrations/anonymous_store_remediation.py
+++ b/scripts/migrations/anonymous_store_remediation.py
@@ -21,7 +21,7 @@ def setup(config_path):
     load_config(config_path)
     infogami._setup()
 
-def remediate():
+def remediate(test=False):
     def fetch_usernames():
         oldb = db.get_db()
 
@@ -72,14 +72,16 @@ def remediate():
 
     for record in usernames:
         if not is_account_active(f"account/{record['username']}") and (key := fetch_store_key(record['username'])):
-            web.ctx.site.store.delete(key)
+            print(f"Found affected record with key: {key}")
+            if not test:
+                web.ctx.site.store.delete(key)
             deleted_entries += 1
 
     print(f"Remediated {deleted_entries} `account-email` store entries.")
 
 def main(args):
     setup(args.config)
-    remediate()
+    remediate(args.test)
 
 def _parse_args():
     _parser = argparse.ArgumentParser(description=__doc__)
@@ -88,6 +90,12 @@ def _parse_args():
         "--config",
         default=DEFAULT_CONFIG_PATH,
         help="Path to the `openlibrary.yml` configuration file",
+    )
+    _parser.add_argument(
+        "-t",
+        "--test",
+        action="store_true",
+        help="Runs the script without deleting any entries",
     )
     _parser.set_defaults(func=main)
     return _parser.parse_args()

--- a/scripts/migrations/anonymous_store_remediation.py
+++ b/scripts/migrations/anonymous_store_remediation.py
@@ -14,12 +14,14 @@ from openlibrary.config import load_config
 
 DEFAULT_CONFIG_PATH = "/olsystem/etc/openlibrary.yml"
 
+
 def setup(config_path):
     if not Path(config_path).exists():
         raise FileNotFoundError(f'no config file at {config_path}')
 
     load_config(config_path)
     infogami._setup()
+
 
 def remediate(test=False):
     def fetch_usernames():
@@ -71,7 +73,9 @@ def remediate(test=False):
     usernames = fetch_usernames()
 
     for record in usernames:
-        if not is_account_active(f"account/{record['username']}") and (key := fetch_store_key(record['username'])):
+        if not is_account_active(f"account/{record['username']}") and (
+            key := fetch_store_key(record['username'])
+        ):
             print(f"Found affected record with key: {key}")
             if not test:
                 web.ctx.site.store.delete(key)
@@ -79,9 +83,11 @@ def remediate(test=False):
 
     print(f"Remediated {deleted_entries} `account-email` store entries.")
 
+
 def main(args):
     setup(args.config)
     remediate(args.test)
+
 
 def _parse_args():
     _parser = argparse.ArgumentParser(description=__doc__)
@@ -99,6 +105,7 @@ def _parse_args():
     )
     _parser.set_defaults(func=main)
     return _parser.parse_args()
+
 
 if __name__ == '__main__':
     _args = _parse_args()


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds a script that finds and removes any `account-email` store entries that were not deleted during our account anonymization process.  The script does the following:

1. Fetches all `/people/{username}` `/type/delete` entries from the store, extracting `username`.
2. For each `username`, we check if the associated account has been deactivated by querying `store`
3. If the account was deactivated, we search for its `account-email` store key
4. Deletes the `account-email` store entry if a store key was found

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
