### PR TITLE
Update sources.html

### DIFF
--- a/openlibrary/templates/history/sources.html
+++ b/openlibrary/templates/history/sources.html
@@ -28,9 +28,14 @@ $code:
         names["SanFranPL%02d" % i] = "San Francisco Public Library"
 
     def get_source_record(record_id):
-        if '/' not in record_id and '_meta.mrc:' in record_id:
-            record_id = 'ia:' + record_id.split('_')[0]
-        item = record_id.split("/")[0]
+        if ':' in record_id:
+            source, record = record_id.split(':', 1)
+        else:
+            source, record = record_id, ''
+
+        if '/' not in record and '_meta.mrc:' in record:
+            record = 'ia:' + record.split('_')[0]
+        item = record.split("/")[0]
         url = "/show-records/" + record_id
 
         if item.startswith("ia:"):


### PR DESCRIPTION
Adds a logic to only split on first colon in the get_source_record() function in sources.html to fix issue 11008

<!-- What issue does this PR close? -->
Closes #11008

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR updates the get_source_record function in sources.html to correctly parse Press Books source records. It now splits only on the first colon , ensuring links are well-formed and meaningful.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
