### PR TITLE
Fix date filtering for main subject page carousel

### DIFF
--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -154,7 +154,8 @@ export class Carousel {
             pageMode: loadMore.pageMode,
             hasFulltextOnly: loadMore.hasFulltextOnly,
             secondaryAction: loadMore.secondaryAction,
-            key: loadMore.key
+            key: loadMore.key,
+            ...loadMore.extraParams
         });
         this.appendLoadingSlide();
         $.ajax({url: url, type: 'GET'})

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -14,7 +14,7 @@ from openlibrary.i18n import gettext as _
 from openlibrary.plugins.openlibrary.lists import get_user_lists
 from openlibrary.plugins.upstream.checkins import get_reading_goals
 from openlibrary.plugins.worksearch.code import do_search, work_search
-from openlibrary.plugins.worksearch.subjects import get_subject
+from openlibrary.plugins.worksearch.subjects import date_range_to_publish_year_filter, get_subject
 from openlibrary.views.loanstats import get_trending_books
 
 
@@ -189,8 +189,10 @@ class CarouselCardPartial(PartialDataHandler):
         pseudoKey = params.get("q", "")
         offset = int(params.get("page", 1))
         limit = int(params.get("limit", 18))
+        published_in = params.get("published_in", "")
+        publish_year = date_range_to_publish_year_filter(published_in)
 
-        subject = get_subject(pseudoKey, offset=offset, limit=limit)
+        subject = get_subject(pseudoKey, offset=offset, limit=limit, publish_year=publish_year)
         return subject.get("works", [])
 
 

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -112,16 +112,8 @@ class subjects_json(delegate.page):
         if i.get('has_fulltext') == 'true':
             filters['has_fulltext'] = 'true'
 
-        if i.get('published_in'):
-            if '-' in i.published_in:
-                begin, end = i.published_in.split('-', 1)
-
-                if safeint(begin, None) is not None and safeint(end, None) is not None:
-                    filters['publish_year'] = f'[{begin} TO {end}]'
-            else:
-                y = safeint(i.published_in, None)
-                if y is not None:
-                    filters['publish_year'] = i.published_in
+        if publish_year_filter := date_range_to_publish_year_filter(i.get('published_in')):
+            filters['publish_year'] = publish_year_filter
 
         subject_results = get_subject(
             key,
@@ -140,6 +132,19 @@ class subjects_json(delegate.page):
 
     def process_key(self, key):
         return key
+
+
+def date_range_to_publish_year_filter(published_in: str) -> str:
+    if published_in:
+        if '-' in published_in:
+            begin, end = published_in.split('-', 1)
+            if safeint(begin, None) is not None and safeint(end, None) is not None:
+                return f'[{begin} TO {end}]'
+        else:
+            year = safeint(published_in, None)
+            if year is not None:
+                return published_in
+    return ''
 
 
 SubjectType = Literal["subject", "place", "person", "time"]


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10971

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes date filtering for the main subject page carousel.

Whenever a date range is selected via the publishing history graph, it is now included in the `/partials.json` request for carousels as `published_in`.  This range then gets converted into a `publish_year` filter for the subject Solr query used to populate the carousel.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
