### PR TITLE
Add link to status page to view PRs in GH

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -2173,6 +2173,10 @@ msgid "Staged"
 msgstr ""
 
 #: status.html
+msgid "View PRs on GitHub"
+msgstr ""
+
+#: status.html
 msgid "Show changed files"
 msgstr ""
 

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -55,6 +55,16 @@ class DevMergedStatus:
             return DevMergedStatus.from_output(contents)
         return None
 
+    def get_github_search_link(self) -> str:
+        """Constructs a GitHub search URL for all PRs in pr_statuses."""
+        from urllib.parse import urlencode
+
+        pull_ids = [pr.pull_id for pr in self.pr_statuses if pr.pull_id]
+
+        return f"https://github.com/internetarchive/openlibrary/pulls?{urlencode({
+            "q": "is:pr is:open " + " ".join([f"#{num}" for num in pull_ids])
+        })}"
+
 
 @dataclass
 class PRStatus:

--- a/openlibrary/templates/status.html
+++ b/openlibrary/templates/status.html
@@ -57,7 +57,15 @@ $var title: $_("Open Library server status")
       <h2> $_("Staged") </h2>
       <pre>$dev_merged_status.git_status</pre>
 
+      <br>
 
+      <a
+        href="$dev_merged_status.get_github_search_link()"
+      >$_("View PRs on GitHub")</a>
+
+      &bull;
+
+      $# Note the checkbox works entirely via CSS and needs to be adjacent to the table
       <input type="checkbox" id="show_changed"> <label for="show_changed">$_("Show changed files")</label>
       <table>
         <thead>


### PR DESCRIPTION
Small extension to make deploying PRs a little bit easier. This way we can deploy the past commits as well as the current ones.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="1221" height="488" alt="image" src="https://github.com/user-attachments/assets/c267fc2a-91b3-42c8-9cec-a93a5a63a5a8" />


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
