### PR TITLE
Disallow crawling of /merges

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -3,6 +3,7 @@ User-agent: *
 Disallow: /api
 Disallow: /edit
 Disallow: /account
+Disallow: /merges
 Disallow: /search
 Disallow: /search/publishers
 Disallow: /search/authors


### PR DESCRIPTION
Google keeps trying to index this page for some reason? I don't think we even link to this publicly... so not sure how or why...

<img width="1117" height="669" alt="image" src="https://github.com/user-attachments/assets/90030203-1825-4321-a347-178c02036f07" />


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
