### PR TITLE
10933/fix/use cover and title endpoints

### DIFF
--- a/openlibrary/templates/covers/add.html
+++ b/openlibrary/templates/covers/add.html
@@ -81,9 +81,11 @@ $#    </div>
 $#</form>
 
 $if doc.type.key == "/type/edition" and doc.ocaid:
-    $ img_url = "https://archive.org/services/img/%s/full/pct:600/0/default.jpg" % doc.ocaid
-    $:render_template("covers/external_image", action, img_url, _("Internet Archive"))
+    $ img_url_cover = "https://archive.org/download/%s/page/cover" % doc.ocaid
+    $ img_url_title = "https://archive.org/download/%s/page/title" % doc.ocaid
+    $:render_template("covers/external_image", action, img_url_cover, img_url_title, _("Internet Archive"))
 
 $if doc.type.key == "/type/author" and data.get('wikidata_images'):
-    $ img_url = data.get('wikidata_images')[0]
-    $:render_template("covers/external_image", action, img_url, _("Wikidata"))
+    $ img_url_cover = data.get('wikidata_images')[0]
+    $ img_url_title = None
+    $:render_template("covers/external_image", action, img_url_cover, img_url_title, _("Wikidata"))

--- a/openlibrary/templates/covers/external_image.html
+++ b/openlibrary/templates/covers/external_image.html
@@ -1,13 +1,22 @@
-$def with (action, img_url, source_name)
+$def with (action, img_url_cover, img_url_title, source_name)
 
 <form class="ol-cover-form ol-cover-form--external" method="post" enctype="multipart/form-data" action="$action">
     <div class="label">
-        <label>$_("Or, use the cover from %s", source_name)</label>
+        <label>$_("Or, use a cover from %s", source_name)</label>
     </div>
-    <div class="input">
-        <a href="$img_url" target="_blank">
-            <img class="ol-cover-form--external_image" src="$img_url" style="height: 200px" alt="" />
-        </a>
-        <button type="submit" class="cta-btn cta-btn--vanilla" name="url" value="$img_url">$_("Upload Image")</button>
+    <div style="display: flex; flex-direction: row;">
+        <div class="input">
+            <a href="$img_url_cover" target="_blank" style="flex-direction: column;">
+                <img class="ol-cover-form--external_image" src="$img_url_cover" style="height: 200px" alt="" />
+            </a>
+            <button type="submit" class="cta-btn cta-btn--vanilla" name="url" style="flex-direction: column;" value="$img_url_cover">$_("Upload Image")</button>
+        </div>
+        <div class="input">
+                $if img_url_title != None:
+                    <a href="$img_url_title" target="_blank">
+                        <img class="ol-cover-form--external_image" src="$img_url_title" style="height: 200px" alt="" />
+                    </a>
+                    <button type="submit" class="cta-btn cta-btn--vanilla" name="url" value="$img_url_title">$_("Upload Image")</button>
+        </div>
     </div>
 </form>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Addresses part of the feedback on [this](https://github.com/internetarchive/openlibrary/pull/10967) pull request. It is a part of the solution for issue #10933 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Gets covers from cover and title endpoints from Internet Archive instead of specifying `default.jpg`.

Example:

> cover endpoint: https://archive.org/download/mariachapdelaine00hemo/page/cover
> title endpoint: https://archive.org/download/mariachapdelaine00hemo/page/title
> default endpoint: https://archive.org/services/img/mariachapdelaine00hemo/full/pct:600/0/default.jpg

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="1582" height="843" alt="Screenshot 2025-07-25 204313" src="https://github.com/user-attachments/assets/8f39681d-5a31-4613-a8ea-a41f731480aa" />

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
