### PR TITLE
Fix Waitlist button padding issue

### DIFF
--- a/static/css/components/book.less
+++ b/static/css/components/book.less
@@ -1,12 +1,9 @@
 // https://github.com/internetarchive/openlibrary/wiki/Design-Pattern-Library#book
 
 .book {
+  form .cta-button-group,
   & > .cta-button-group,
   & > .cta-btn {
-    margin-top: 10px;
-  }
-
-  &.form-has-cta .cta-button-group {
     margin-top: 10px;
   }
 

--- a/static/css/components/book.less
+++ b/static/css/components/book.less
@@ -1,7 +1,7 @@
 // https://github.com/internetarchive/openlibrary/wiki/Design-Pattern-Library#book
 
 .book {
-  & > .cta-button-group,
+  & > .form .cta-button-group & > .cta-button-group,
   & > .cta-btn {
     margin-top: 10px;
   }

--- a/static/css/components/book.less
+++ b/static/css/components/book.less
@@ -1,8 +1,12 @@
 // https://github.com/internetarchive/openlibrary/wiki/Design-Pattern-Library#book
 
 .book {
-  & > .form .cta-button-group & > .cta-button-group,
+  & > .cta-button-group,
   & > .cta-btn {
+    margin-top: 10px;
+  }
+  
+  &.form-has-cta .cta-button-group {
     margin-top: 10px;
   }
 

--- a/static/css/components/book.less
+++ b/static/css/components/book.less
@@ -1,9 +1,9 @@
 // https://github.com/internetarchive/openlibrary/wiki/Design-Pattern-Library#book
 
 .book {
-  form .cta-button-group,
   & > .cta-button-group,
-  & > .cta-btn {
+  & > .cta-btn,
+  form .cta-button-group {
     margin-top: 10px;
   }
 

--- a/static/css/components/book.less
+++ b/static/css/components/book.less
@@ -5,7 +5,7 @@
   & > .cta-btn {
     margin-top: 10px;
   }
-  
+
   &.form-has-cta .cta-button-group {
     margin-top: 10px;
   }


### PR DESCRIPTION
Join waitlist had a padding error; i've added the join waitlist form as a specification of cta-button-group in book.less; this change should make all paddings uniform.

<!-- What issue does this PR close? -->
Issue #11036

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix

### Technical
<!-- What should be noted about the implementation? -->
The padding for all form buttons should be uniform after merging this fix.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Refer to https://github.com/internetarchive/openlibrary/issues/11036#issuecomment-3092714921

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
I am not entirely sure how to check the browser/UI implementation of the issue.

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB @mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
