### PR TITLE
Fix title overflows in new list cards

### DIFF
--- a/openlibrary/templates/lists/list_follow.html
+++ b/openlibrary/templates/lists/list_follow.html
@@ -10,7 +10,7 @@ $def list_card(list, owner, own_list):
     $ count = cached_info["count"]
     <div class="list-follow-card">
         <a class="list-follow-card__header" href="$list.get_url()">
-             <div class="list-follow-card__title">$cached_info["title"]</div>
+                <div class="list-follow-card__title" title="${cached_info['title']}">$cached_info['title']</div>
              <div class="list-follow-card__num-books">
                  $ungettext("%(count)d book", "%(count)d books", count, count=count)
              </div>

--- a/static/css/components/list-follow.less
+++ b/static/css/components/list-follow.less
@@ -47,6 +47,7 @@
     align-items: center;
     padding: 7px 10px;
     border-radius: 0 0 4px 4px;
+    width: 100%;
     a& {
       text-decoration: none;
     }
@@ -116,10 +117,18 @@
     font-weight: bold;
     font-size: @font-size-label-large;
     color: @black;
-
-    white-space: nowrap;
+    width: 100%;
+    max-height: 2.8em;
     overflow: hidden;
     text-overflow: ellipsis;
+    line-height: 1.4em;
+    white-space: normal;
+    word-break: break-word;
+    position: relative;
+    text-align: center;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
   }
 
   &__num-books {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11055 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR fixes the overflowing texts in Global Lists title.

### Technical
<!-- What should be noted about the implementation? -->
- There are up to 2 lines of text
- If it overflows beyond 2 lines, it is truncated with ellipsis (...)
- The full title is visible as a tooltip (hover tip) when the user hovers over it.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Click on any book of your choice.
- Navigate down to `Lists` section.
- If the length of the `title` is big, then it appears in two lines and truncated with ellipsis.
- Hover over it to view complete title.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="1321" height="506" alt="Screenshot 2025-07-29 140121" src="https://github.com/user-attachments/assets/1ef816b3-147c-4a09-8139-951016c9d35e" />


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
