### PR TITLE
Update `Bestbook.PRIMARY_KEY` to production value

### DIFF
--- a/openlibrary/core/bestbook.py
+++ b/openlibrary/core/bestbook.py
@@ -7,7 +7,7 @@ class Bestbook(db.CommonExtras):
     """Best book award operations"""
 
     TABLENAME = "bestbooks"
-    PRIMARY_KEY = "nomination_id"
+    PRIMARY_KEY = "award_id"
     ALLOW_DELETE_ON_CONFLICT = False
 
     class AwardConditionsError(Exception):


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Updates `Bestbook.PRIMARY_KEY` to `award_id`, which is the column name of the `bestbooks` table's primary key in production and local development environments.

Leaving `PRIMARY_KEY` unchanged may cause some `db.CommonExtras` methods to fail when they are invoked by a `Bestbooks` object (specifically, [`update_work_ids_individually`](https://github.com/internetarchive/openlibrary/blob/baf7303c2ee8d14c68ce02bb7f0232f467496e53/openlibrary/core/db.py#L65) and [`update_work_ids`](https://github.com/internetarchive/openlibrary/blob/baf7303c2ee8d14c68ce02bb7f0232f467496e53/openlibrary/core/db.py#L32)).

No change to [`core/schema.sql`](https://github.com/internetarchive/openlibrary/blob/baf7303c2ee8d14c68ce02bb7f0232f467496e53/openlibrary/core/schema.sql#L116) was needed.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
