### PR TITLE
Fix author page lists not loading

### DIFF
--- a/openlibrary/plugins/openlibrary/js/my-books/MyBooksDropper.js
+++ b/openlibrary/plugins/openlibrary/js/my-books/MyBooksDropper.js
@@ -69,7 +69,11 @@ export class MyBooksDropper extends Dropper {
 
         const splitKey = this.workKey ? this.workKey.split('/') : ['']
         const workOlid = splitKey[splitKey.length - 1]
-        this.checkInComponents = new CheckInComponents(document.querySelector(`#check-in-container-${workOlid}`))
+
+        /**
+         * @type {CheckInComponents|null}
+         */
+        this.checkInComponents = workOlid ? new CheckInComponents(document.querySelector(`#check-in-container-${workOlid}`)) : null
 
         /**
          * References this dropper's reading log buttons.
@@ -86,7 +90,9 @@ export class MyBooksDropper extends Dropper {
 
         this.readingLogForms.initialize()
         this.readingLists.initialize()
-        this.checkInComponents.initialize()
+        if (this.checkInComponents) {
+            this.checkInComponents.initialize()
+        }
 
         this.loadingAnimationId = this.initLoadingAnimation(this.dropper.querySelector('.loading-ellipsis'))
     }


### PR DESCRIPTION
Closes #11085
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Addresses bug which prevents lists from loading on author and orphaned edition pages.

### Technical
<!-- What should be noted about the implementation? -->
The My Books Droppers that are rendered on author page sidebars are not associated with a work ID (the same is true for droppers on orphaned edition pages).  The HTML for the check-in components is not rendered for these droppers, as check-ins require a work ID.

Whenever `this.checkInComponents.initialize()` was called by a dropper that didn't include the check-in HTML, it threw an exception that prevented the [`initMyBooksAffordances`](https://github.com/internetarchive/openlibrary/blob/baf7303c2ee8d14c68ce02bb7f0232f467496e53/openlibrary/plugins/openlibrary/js/my-books/index.js#L10C17-L10C39) function from fetching the list data and updating the view.

Now, if there is no check-in HTML included with a dropper, we set `this.checkInComponents` to `null` and check for the object before calling `initialize()`.  This null check is only needed here, as it is present in all other places where `this.checkInComponents` is referenced.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
