### PR TITLE
fix: support "dummy" works for orphaned editions

### DIFF
--- a/openlibrary/solr/update.py
+++ b/openlibrary/solr/update.py
@@ -135,9 +135,6 @@ async def update_keys(
                         },
                     )
                     update_state.adds.append(doc)
-                    # Does not seem to work.
-                    # Data is in the solr update request which responds with code 200, but not found in solr.
-                    # Noticing that books I import from copydocs are also not in solr.
                     continue
 
                 thing = await data_provider.get_document(key)

--- a/openlibrary/solr/update.py
+++ b/openlibrary/solr/update.py
@@ -1,6 +1,7 @@
 import functools
 import json
 import logging
+import re
 from pathlib import Path
 from typing import Literal, cast
 
@@ -13,6 +14,7 @@ from openlibrary.solr.data_provider import (
     ExternalDataProvider,
     get_data_provider,
 )
+from openlibrary.solr.solr_types import SolrDocument
 from openlibrary.solr.updater.abstract import AbstractSolrUpdater
 from openlibrary.solr.updater.author import AuthorSolrUpdater
 from openlibrary.solr.updater.edition import EditionSolrUpdater
@@ -49,6 +51,13 @@ def get_solr_updaters() -> list[AbstractSolrUpdater]:
 
 def can_update_key(key: str) -> bool:
     return any(updater.key_test(key) for updater in get_solr_updaters())
+
+
+def extract_year(date_string: str | None) -> str | None:
+    if date_string:
+        match = re.match(r'(\d{4})', date_string)
+        return match.group(1) if match else None
+    return None
 
 
 async def update_keys(
@@ -92,8 +101,46 @@ async def update_keys(
         for key in updater_keys:
             logger.debug(f"processing {key}")
             try:
-                thing = await data_provider.get_document(key)
+                fake_work = re.fullmatch(r'^/works/(OL\d+M)$', key)
+                if fake_work:
+                    # This is a "fake" work key made from processing an orphaned edition. We know this doesn't exist, don't try to fetch it.
+                    root_key = fake_work.group(1)
+                    edition = await data_provider.get_document(f"/books/{root_key}")
+                    if not edition:
+                        logger.warning(
+                            "No edition found for fake work %r, somehow", key
+                        )
+                        continue
+                    year = extract_year(edition.get('publish_date'))
+                    doc = cast(
+                        SolrDocument,
+                        {
+                            "key": key,
+                            "type": "work",
+                            "publisher": edition.get('publishers'),
+                            "title": edition.get('title'),
+                            "number_of_pages_median": edition.get('number_of_pages'),
+                            "isbn": edition.get('isbn_10', [])
+                            + edition.get('isbn_13', []),
+                            "format": (
+                                [edition.get('physical_format')]
+                                if edition.get('physical_format')
+                                else None
+                            ),
+                            "publish_date": edition.get('publish_date'),
+                            "publish_year": [year] if year else None,
+                            "first_publish_year": year,
+                            "oclc": edition.get('oclc_numbers'),
+                            "edition_key": [fake_work.group(1)],
+                        },
+                    )
+                    update_state.adds.append(doc)
+                    # Does not seem to work.
+                    # Data is in the solr update request which responds with code 200, but not found in solr.
+                    # Noticing that books I import from copydocs are also not in solr.
+                    continue
 
+                thing = await data_provider.get_document(key)
                 if thing and thing['type']['key'] == '/type/redirect':
                     logger.warning("Found redirect to %r", thing['location'])
                     # When the given key is not found or redirects to another thing,


### PR DESCRIPTION
Closes #9710 (I think)

During solr_update, when editions are identified as having no base works (orphaned), the script checks for a (nonexistent) `works` key using that edition's ID. Later, when it is looping through works to update, it detects that this "fake" work does not exist and just flags it for deletion. Orphaned editions continue to not show up in search results.

This PR adds some logic to detect when a work key was created by an orphaned edition, and create a "dummy" base work for it using information extracted from the edition. This makes the book show up in search results.

### Testing
I ran `copydocs` on the orphaned edition originally identified for testing in the issue ticket (`/books/OL10021046M`). In my local solr admin UI, it did not show up in search results.
Then, with my updates to the solr_update script, I ran the script against `/books/OL10021046M`. It then started appearing in search results.

### Stakeholders
@cdrini 
@seabelis 


Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code.
