### PR TITLE
add typehints to memcache_memoize

### DIFF
--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -169,7 +169,7 @@ class memcache_memoize[**P, T]:
         for name, thread in list(self.active_threads.items()):
             thread.join()
 
-    def encode_args(self, args: tuple, kw: dict) -> str:
+    def encode_args(self, args: tuple, kw: dict | None = None) -> str:
         """Encodes arguments to construct the memcache key."""
         kw = kw or {}
 

--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -216,7 +216,7 @@ class memcache_memoize[**P, T]:
         stats.end()
 
     def memcache_delete_by_args(self, *args, **kw):
-        "A helper method to let you pass in arguments normally instead of as a tuple and dict"
+        """A helper method to let you pass in arguments normally instead of as a tuple and dict"""
         self.memcache_delete(args, kw)
 
     def memcache_get(self, args: tuple, kw: dict) -> tuple[T, float] | None:

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -67,7 +67,8 @@ def get_cached_homepage():
     page = mc(devmode=("dev" in web.ctx.features))
 
     if not page:
-        mc(_cache='delete')
+        mc.memcache_delete_by_args()
+        mc()
 
     return page
 

--- a/openlibrary/plugins/openlibrary/pd.py
+++ b/openlibrary/plugins/openlibrary/pd.py
@@ -70,7 +70,8 @@ def make_pd_org_query() -> list:
 def cached_pd_org_query() -> list:
     mc = cache.memcache_memoize(make_pd_org_query, "pd-org-query", timeout=DAY_SECS)
     if not (results := mc() or []):
-        mc(_cache="delete")
+        mc.memcache_delete_by_args()
+        mc()
     return results
 
 

--- a/openlibrary/tests/core/test_cache.py
+++ b/openlibrary/tests/core/test_cache.py
@@ -83,7 +83,8 @@ class Test_memcache_memoize:
         assert m.stats.updates == 1
 
         # this should clear the cache and the next call should update the cache.
-        m(10, _cache="delete")
+        m.memcache_delete_by_args(10)
+        m(10)
 
         m(10)
         assert m.stats.updates == 2


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Followup to https://github.com/internetarchive/openlibrary/pull/11003#issuecomment-3098468324

One of the things mentioned there was adding typed dicts. However, in some of the cases where I was trying I'd eventually run into the memoized functions that have no types.

I did a little research and learned that we can add typehints for memoized functions. And it turns out it works just fine to do so without much change.

The one change that is made here is removing the `_cache = 'delete'` option.
Basically, it's not possible to faithfully show the type of the function you're caching and allow for extra args.
Also, deleting manually is much better for separation of concerns. Besides, we only used that arg in a few places so it's not much to fix.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
