### PR TITLE
use modern ruff config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ extend-exclude = [
   "./.*",
   "vendor",
 ]
-ignore = [
+lint.ignore = [
   "B007",    # unused-loop-control-variable - not a big deal for us
   "B023",    # function-uses-loop-variable - doesn't matter for our lambdas but it's a good rule
   "B904",    # raise-without-from-inside-except - not sure but it seems fine for now
@@ -65,7 +65,7 @@ ignore = [
     # scripts/tests/test_solr_updater.p - probably needed for side effects
 ]
 line-length = 162
-select = [
+lint.select = [
   "ASYNC",   # flake8-async
   "B",       # flake8-bugbear
   "BLE",     # flake8-blind-except
@@ -126,17 +126,18 @@ select = [
   # "TRY",   # tryceratops
 ]
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 28
 
-[tool.ruff.pylint]
+
+[tool.ruff.lint.pylint]
 allow-magic-value-types = ["bytes", "float", "int", "str"]
 max-args = 15
 max-branches = 23
 max-returns = 14
 max-statements = 70
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "openlibrary/admin/stats.py" = ["BLE001"]
 "openlibrary/catalog/add_book/tests/test_add_book.py" = ["PT007"]
 "openlibrary/catalog/get_ia.py" = ["BLE001", "E722"]


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

Ever notice how ruff always warns us about updated configs settings?
This fixes that!

Warning in question:
```
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
  - 'mccabe' -> 'lint.mccabe'
  - 'pylint' -> 'lint.pylint'
  - 'per-file-ignores' -> 'lint.per-file-ignores'
```


<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
