### PR TITLE
Improved Card Component for Community Lists

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -6300,6 +6300,10 @@ msgstr ""
 msgid "You"
 msgstr ""
 
+#: lists/list_follow.html
+msgid "Community List"
+msgstr ""
+
 #: lists/list_overview.html lists/widget.html my_books/dropdown_content.html
 msgid "See this list"
 msgstr ""

--- a/openlibrary/templates/lists/list_follow.html
+++ b/openlibrary/templates/lists/list_follow.html
@@ -53,9 +53,12 @@ $def list_card(list, owner, own_list):
                 </div>
             </div>
         $else:
-            <div class="list-follow-card__bottom">
-                <div class="list-follow-card__community-label">
-                    <i>Community List</i>
+            <div class="list-follow-card__bottom-community">
+                <div class="list-follow-card__user">
+                    <img src="/static/images/openlibrary-128x128.png" />
+                    <div class="list-follow-card__community-label">
+                        <i>$_("Community List")</i>
+                    </div>
                 </div>
             </div>
     </div>

--- a/static/css/components/list-follow.less
+++ b/static/css/components/list-follow.less
@@ -122,6 +122,24 @@
     text-overflow: ellipsis;
   }
 
+  &__bottom-community {
+    background: @grey-f4f4f4;
+    display: flex;
+    justify-content: space-between;
+    padding-bottom: 5px;
+    padding-top: 5px;
+    margin-bottom: -3px;
+    border-radius: 0 0 3px 3px;
+  }
+  &__community-label {
+    font-weight: normal;
+    font-size: @font-size-label-large;
+    color: @black;
+
+    white-space: nowrap;
+    overflow: hidden;
+    padding-bottom: 2px;
+  }
   &__num-books {
     color: @grey-555;
     font-size: @font-size-label-medium;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11075 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] --> 
Fixes the Lists card component bottom section to render `Community Lists`. 


### Technical
<!-- What should be noted about the implementation? -->
- Added ** OpenLibrary ** logo for Community Lists.
- Improved the styling for Community Lists.
- Changed `Community Lists` to `$_("Community List")` to support language changes.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- One can move to any book section and scroll down to Lists.
- Can then check for community lists.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="629" height="309" alt="473806953-c9e2c42c-e942-493e-8389-9a4d6c3917da" src="https://github.com/user-attachments/assets/fdde10db-b83e-4d0c-ad6d-0146a079d585" />


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
