### PR TITLE
Fix I/O errors during sitemap generation

### DIFF
--- a/scripts/sitemaps/sitemap.py
+++ b/scripts/sitemaps/sitemap.py
@@ -146,18 +146,18 @@ def generate_sitemaps(filename: str) -> None:
     with open(filename) as f:
         rows = (line.strip().split("\t") for line in f)
 
-    for sortkey, chunk in itertools.groupby(rows, lambda row: row[0]):
-        things = []
+        for sortkey, chunk in itertools.groupby(rows, lambda row: row[0]):
+            things = []
 
-        _chunk = list(chunk)
-        for segment in _chunk:
-            sortkey = segment.pop(0)
-            last_modified = segment.pop(-1)
-            path = ''.join(segment)
-            things.append(web.storage(path=path, last_modified=last_modified))
+            _chunk = list(chunk)
+            for segment in _chunk:
+                sortkey = segment.pop(0)
+                last_modified = segment.pop(-1)
+                path = ''.join(segment)
+                things.append(web.storage(path=path, last_modified=last_modified))
 
-        if things:
-            write(f"sitemaps/sitemap_{sortkey}.xml.gz", sitemap(things))
+            if things:
+                write(f"sitemaps/sitemap_{sortkey}.xml.gz", sitemap(things))
 
 
 @elapsed_time("generate_siteindex")


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes I/O error that is being thrown by [`generate_sitemaps()`](https://github.com/internetarchive/openlibrary/blob/386544244b9ec5b1cabe54d7be1201745aecd7e7/scripts/sitemaps/sitemap.py#L145-L160) during our sitemap generation process.

The generator `rows`, which lazily reads from a file, was being consumed outside of the `with` block (after the file was closed).

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
