### PR TITLE
Feature: log when a cover URL is disallowed

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -24,6 +24,7 @@ A record is loaded by calling the load function.
 """
 
 import itertools
+import logging
 import re
 import uuid
 from collections import defaultdict
@@ -64,6 +65,8 @@ from openlibrary.utils.lccn import normalize_lccn
 
 if TYPE_CHECKING:
     from openlibrary.plugins.upstream.models import Edition
+
+logger = logging.getLogger("add_book")
 
 re_normalize = re.compile('[^[:alphanum:] ]', re.UNICODE)
 re_lang = re.compile('^/languages/([a-z]{3})$')
@@ -577,9 +580,15 @@ def check_cover_url_host(
 
     parsed_url = urlparse(url=cover_url)
 
-    return parsed_url.netloc.casefold() in (
+    host_is_allowed = parsed_url.netloc.casefold() in (
         host.casefold() for host in allowed_cover_hosts
     )
+
+    if not host_is_allowed:
+        logger.info(f"disallowed cover url: {cover_url}")
+        return False
+
+    return True
 
 
 def load_data(  # noqa: PLR0912, PLR0915


### PR DESCRIPTION
The idea with this commit is that one could grep the logs for `disallowed cover url` to see which cover URLs have been disallowed.

We could also integrate this into Sentry as a separate issue.

<!-- What issue does this PR close? -->
Closes #11106

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature

### Technical
<!-- What should be noted about the implementation? -->
This just logs when a cover URL is disallowed so we can more easily audit URLs that are being disallowed.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
```
>>> import logging
>>> logging.basicConfig(level=logging.DEBUG)
>>> logger = logging.getLogger("add_book")
>>> from openlibrary.catalog.add_book import check_cover_url_host
Couldn't find statsd_server section in config
CRITICAL:pystatsd.client:Couldn't find statsd_server section in config
INFO:openlibrary:Setting up requests
INFO:openlibrary:Setting up proxy
INFO:openlibrary:No proxy configuration found
INFO:openlibrary:Setting up proxy bypass
INFO:openlibrary:No proxy bypass configuration found
INFO:openlibrary:Requests set up
>>> check_cover_url_host("http://m.media-amazon.com/blah")
True
>>> check_cover_url_host("http://blah.com")
INFO:add_book:disallowed cover url: http://blah.com
False
>>>
```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
