### PR TITLE
Added pvt button

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -6302,7 +6302,9 @@ msgstr ""
 
 #: lists/list_follow.html
 msgid "Private"
-=======
+msgstr ""
+
+#: lists/list_follow.html
 msgid "OpenLibrary Logo"
 msgstr ""
 

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -6300,6 +6300,10 @@ msgstr ""
 msgid "You"
 msgstr ""
 
+#: lists/list_follow.html
+msgid "Private"
+msgstr ""
+
 #: lists/list_overview.html lists/widget.html my_books/dropdown_content.html
 msgid "See this list"
 msgstr ""

--- a/openlibrary/templates/lists/list_follow.html
+++ b/openlibrary/templates/lists/list_follow.html
@@ -52,6 +52,10 @@ $def list_card(list, owner, own_list):
                         $ is_public = settings and settings.get('public_readlog', 'no') == "yes"
                         $if is_public:
                             $:render_follow_button(owner_username, is_subscribed)
+                        $else:
+                            <button class="list-follow-card__private-button" disabled>
+                                <span class="pvt-text">$_('Private')</span>
+                            </button>
                 </div>
             </div>
         $else:

--- a/static/css/components/list-follow.less
+++ b/static/css/components/list-follow.less
@@ -126,6 +126,25 @@
       margin: 0;
     }
   }
+  &__private-button {
+    background-color: @grey;
+    border: none;
+    cursor: not-allowed;
+    pointer-events: none;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding-bottom: 1px;
+    border-radius: 4px;
+    .pvt-text {
+      color: @white;
+      font-size: 12px; // Override base size
+      padding: 2px 4px; // Less padding
+      box-shadow: none; // Remove default shadow if present
+      margin: 0;
+      letter-spacing: 0.2px;
+    }
+  }
   &__title {
     font-weight: bold;
     font-size: @font-size-label-large;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11110 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR adds a _feature_ for showing an unclickable `Private` for lists by patrons who have Private accounts. 


### Technical
<!-- What should be noted about the implementation? -->
- Added an **else** condition when patron account isn't public.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Click on any book.
- Scroll down to `Lists`.
- For **private** accounts one can now see an unclickable Private button.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="630" height="396" alt="image" src="https://github.com/user-attachments/assets/361b3e30-fd84-4665-97e1-dfdd45cdce8c" />



### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@ragipidavid 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
