### PR TITLE
add caching to /random

### DIFF
--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -106,6 +106,9 @@ class home(delegate.page):
         return web.template.TemplateResult(cached_homepage)
 
 
+@cache.memoize(
+    engine="memcache", key="home.random_book", expires=dateutil.HALF_HOUR_SECS
+)
 def get_random_borrowable_ebook_keys(count: int) -> list[str]:
     solr = search.get_solr()
     docs = solr.select(
@@ -121,12 +124,7 @@ class random_book(delegate.page):
     path = "/random"
 
     def GET(self):
-        # We cache 1000 books for a minute and return one randomly for each request
-        keys = cache.memcache_memoize(
-            get_random_borrowable_ebook_keys,
-            'home.random_book',
-            timeout=dateutil.MINUTE_SECS,
-        )(1000)
+        keys = get_random_borrowable_ebook_keys(1000)
         raise web.seeother(random.choice(keys))
 
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11117

Currently we call solr for every single request to /random
This PR makes it so we request 1000 books from solr and cache them for one minute and return a random on for each request. One minute caching seems low, so maybe we should bump it up.
On _local_ this cuts response times for /random from ~30ms to ~7ms.
On production the P50 of random is 1.1 seconds. This should drastically cut those times and avoid a lot of extra strain on solr without any inconvenience to users.

PS: this is just a POC. I didn't discuss this approach with staff yet.


<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

I test this with the following command:
`docker compose restart memcached web && sleep 5 && curl -s http://localhost:8080/random && hey -n 200 -c 40 -disable-redirects http://localhost:8080/random`

The command restarts the services, to clear the cache, warms the cache with a curl then makes 200 requests, 40 in parallel (not following redirects).

#### Summary

| Metric | Before | After | Diff | Diff % |
| :--- | :--- | :--- | :--- | :--- |
| **Total** | 1.2476 secs | 0.0884 secs | -1.1592 secs | -92.91% |
| **Slowest** | 0.5431 secs | 0.0235 secs | -0.5196 secs | -95.67% |
| **Fastest** | 0.0262 secs | 0.0080 secs | -0.0182 secs | -69.47% |
| **Average** | 0.2422 secs | 0.0162 secs | -0.2260 secs | -93.31% |
| **Requests/sec** | 160.3102 | 2263.3033 | +2102.9931 | +1311.83% |

Details

<details>
  <summary>Details</summary>
  
  #### Before
```
Summary:
  Total:	1.2476 secs
  Slowest:	0.5431 secs
  Fastest:	0.0262 secs
  Average:	0.2422 secs
  Requests/sec:	160.3102
  

Response time histogram:
  0.026 [1]	|■
  0.078 [0]	|
  0.130 [53]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.181 [32]	|■■■■■■■■■■■■■■■■■■■■■■■■
  0.233 [22]	|■■■■■■■■■■■■■■■■■
  0.285 [10]	|■■■■■■■■
  0.336 [31]	|■■■■■■■■■■■■■■■■■■■■■■■
  0.388 [18]	|■■■■■■■■■■■■■■
  0.440 [28]	|■■■■■■■■■■■■■■■■■■■■■
  0.491 [0]	|
  0.543 [5]	|■■■■
```

#### After
```
Summary:
  Total:	0.0884 secs
  Slowest:	0.0235 secs
  Fastest:	0.0080 secs
  Average:	0.0162 secs
  Requests/sec:	2263.3033
  

Response time histogram:
  0.008 [1]	|■
  0.010 [4]	|■■■
  0.011 [5]	|■■■■
  0.013 [11]	|■■■■■■■■■
  0.014 [19]	|■■■■■■■■■■■■■■■■
  0.016 [47]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.017 [37]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.019 [42]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.020 [21]	|■■■■■■■■■■■■■■■■■■
  0.022 [9]	|■■■■■■■■
  0.023 [4]	|■■■
```
  
</details> 




### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
