### PR TITLE
Show Trending Badge on Book Pages Using Solr Trending Data

### DIFF
--- a/openlibrary/macros/TrendingBadge.html
+++ b/openlibrary/macros/TrendingBadge.html
@@ -6,23 +6,26 @@ $ scores.reverse()
 $ scores.append(doc.get('trending_score_hourly_sum', 0))
 $ max_score = max(scores) if scores else 1
 $ max_score = max(max_score, 40)
+
+$ z = float(doc.get('trending_z_score', 0) or 0)
+
 <div class="trending-badge" title="$_('This is only visible to librarians.')">
-    $if doc.trending_z_score >= 4:
+    $if z >= 4:
         🡽
-    $elif doc.trending_z_score >= 2:
+    $elif z >= 2:
         ⇗
-    $elif doc.trending_z_score >= 0.5:
+    $elif z >= 0.5:
         ↗
-    $elif doc.trending_z_score >= -0.5:
+    $elif z >= -0.5:
         ↔
-    $elif doc.trending_z_score >= -2:
+    $elif z >= -2:
         ↘
-    $elif doc.trending_z_score >= -4:
+    $elif z >= -4:
         ⇘
     $else:
         🡾
 
-    $_('Trending: %(score).2f', score=doc.trending_z_score)
+    $_('Trending: %(score).2f', score=z)
     <span class="trending-badge__chart">
         $for score in scores:
             $ height = int((score / max_score) * 16) if max_score else 1

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -129,6 +129,10 @@ $code:
     description = get_description(page)
     putctx("description", description)
 
+    # TEST ONLY
+    edition['trending_score'] = 12.0
+    edition['trending_z_score'] = 2
+
 $def display_value(label, value, itemprop=None):
     $if value:
         <dt>$label</dt>
@@ -206,6 +210,9 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
     $:macros.EditionNavBar(reader_observations, work.edition_count, show_observations)
     <a id="overview-mobile" name="overview-mobile" class="section-anchor section-anchor--no-height"></a>
     $:render_template("type/edition/title_and_author", page, work, edition, ocaid, work_title, star_ratings_stats_mobile, for_desktop=False)
+    $ trending_threshold = 5
+    $if (edition and (edition.get('trending_score', 0) >= trending_threshold or edition.get('trending_z_score', 0) >= 2)):
+        $:macros.TrendingBadge(edition)
     <div class="editionCover">
       $:macros.databarWork(edition or work, worldcat_links, affiliate_links, editions_page=True, render_times=component_times)
     </div>
@@ -220,7 +227,10 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
       <a id="overview" name="overview" class="section-anchor section-anchor--no-height"></a>
       <!-- (desktop only) -->
       $:render_template("type/edition/title_and_author", page, work, edition, ocaid, work_title, star_ratings_stats, for_desktop=True)
-
+      
+      $ trending_threshold = 5
+      $if (edition and (edition.get('trending_score', 0) >= trending_threshold or edition.get('trending_z_score', 0) >= 2)):
+          $:macros.TrendingBadge(edition)
       $if page.type.key in ["/type/work", "/type/edition", "/type/author"]:
         $if edition and page.type.key in ["/type/work"]:
           $ edit_url = edition.url(suffix="/edit")
@@ -230,7 +240,7 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
         $ edit_url = page.key + "?m=edit"
 
       $:render_template("type/edition/compact_title", book_title, edit_url)
-
+      
       $if work and work.description or edition and edition.description:
         $if edition and edition.description:
           $ overview_desc = edition.description


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes # 11072

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
feature — Show a Trending badge on book (edition) pages when Solr trending scores indicate elevated interest. I would love some feedback if I am on the right track. Is the location of the badge ideal? Where would you like to see it?

### Technical
<!-- What should be noted about the implementation? -->
- Calls macros.TrendingBadge(edition) in openlibrary/templates/type/edition/view.html right after the title render (mobile + desktop).
- Updates openlibrary/macros/TrendingBadge.html to safely coerce missing/None values and self-gate rendering (no badge if below thresholds).
- Thresholds used: trending_score ≥ 5 (primary) or trending_z_score ≥ 2 (fallback).
- No schema changes; relies on existing Solr fields (trending_score, trending_z_score, daily/hourly buckets).

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

1. Open a local edition page (e.g., /books/OL24152177M).

2.  If your dev data lacks scores, temporarily mock in view.html’s $code: block (remove before commit):
edition['trending_score'] = 10
edition['trending_z_score'] = 2.5

3. Reload: verify badge appears above the metadata, under the title (both mobile and desktop breakpoints).

4. Lower values below thresholds; verify the badge does not render.

5. Confirm no template errors, no JS console errors, and layout remains stable.
 
6. Capture before/after screenshots for the PR.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="996" height="531" alt="image" src="https://github.com/user-attachments/assets/7bfd793b-e642-427d-8ed1-0f61b7e8459c" />


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
