### PR TITLE
Titles under a single line

### DIFF
--- a/static/css/components/list-follow.less
+++ b/static/css/components/list-follow.less
@@ -141,7 +141,7 @@
     position: relative;
     text-align: center;
     display: -webkit-box;
-    -webkit-line-clamp: 2;
+    -webkit-line-clamp: 1;
     -webkit-box-orient: vertical;
   }
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11055 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR fixes the overflowing texts in Global Lists title **by using ellipsis in a single line**.

### Technical
<!-- What should be noted about the implementation? -->
- There are up to 1 line of text
- If it overflows beyond 1 line, it is truncated with ellipsis (...)
- The full title is visible as a tooltip (hover tip) when the user hovers over it.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Click on any book of your choice.
- Navigate down to `Lists` section.
- If the length of the `title` is big, then it appears in two lines and truncated with ellipsis.
- Hover over it to view complete title.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="1901" height="720" alt="Screenshot 2025-08-09 223417" src="https://github.com/user-attachments/assets/aa51c813-e6e8-448c-abbe-bd139b63f0fe" />



### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
