### PR TITLE
Fix: Preserve list notes when resolving redirects

### DIFF
--- a/openlibrary/core/lists/model.py
+++ b/openlibrary/core/lists/model.py
@@ -324,7 +324,9 @@ class List(Thing):
                 resolved_document = web.ctx.site.get(seed.document.location)
                 if original_notes:
                     # Create AnnotatedSeed with both resolved document and original notes
-                    seed = Seed(self, {'thing': resolved_document, 'notes': original_notes})
+                    seed = Seed(
+                        self, {'thing': resolved_document, 'notes': original_notes}
+                    )
                 else:
                     seed = Seed(self, resolved_document)
                 max_checks -= 1


### PR DESCRIPTION
When list items are redirects, the notes were being lost during redirect resolution in get_seeds() method. This fix preserves the original notes by creating an AnnotatedSeed with both the resolved document and the original notes.

<!-- What issue does this PR close? -->
What issue does this PR close? - Closes #9600

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
What does this PR achieve? - fix

### Technical

<!-- What should be noted about the implementation? -->

This fixes a bug where list notes disappear when books are redirects. The original code was creating a new `Seed` without keeping the notes when resolving redirects. My fix saves the original notes first, then creates the new `Seed` with both the resolved book and the saved notes.

**Changed file:** `openlibrary/core/lists/model.py` (lines 322-330)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

I wasn't able to create redirect scenarios in the development environment, but I verified the logic preserves `original_notes` before redirect resolution and creates an AnnotatedSeed with both the resolved document and original notes.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
This is a backend fix that doesn't change UI elements directly, but prevents notes from disappearing on list items that are redirects.

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->