### PR TITLE
refactor account get method

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -627,9 +627,9 @@ def get_loan(identifier: str, user_key: str | None = None):
     account = None
     if user_key:
         if user_key.startswith('@'):
-            account = OpenLibraryAccount.get(link=user_key)
+            account = OpenLibraryAccount.get_by_link(user_key)
         else:
-            account = OpenLibraryAccount.get(key=user_key)
+            account = OpenLibraryAccount.get_by_key(user_key)
 
     d = web.ctx.site.store.get("loan-" + identifier)
     if d and (
@@ -667,7 +667,7 @@ def get_loans_of_user(user_key: str) -> list[Loan]:
         """
         delegate.fakeload()
 
-    account = OpenLibraryAccount.get(username=user_key.split('/')[-1])
+    account = OpenLibraryAccount.get_by_username(user_key.split('/')[-1])
 
     loandata = web.ctx.site.store.values(type='/type/loan', name='user', value=user_key)
     loans = [Loan(d) for d in loandata]
@@ -698,7 +698,7 @@ def get_user_waiting_loans(user_key: str) -> list[WaitingLoan]:
         delegate.fakeload()
 
     try:
-        account = OpenLibraryAccount.get(key=user_key)
+        account = OpenLibraryAccount.get_by_key(user_key)
         itemname = account.itemname if account else None
         result = WaitingLoan.query(userid=itemname)
         get_cached_user_waiting_loans.memcache_set(
@@ -956,7 +956,7 @@ class Loan(dict):
     def delete(self) -> None:
         loan = dict(self, returned_at=time.time())
         user_key = self['user']
-        account = OpenLibraryAccount.get(key=user_key)
+        account = OpenLibraryAccount.get_by_key(user_key)
         if self.get("stored_at") == 'ia':
             ia_lending_api.delete_loan(self['ocaid'], userkey2userid(user_key))
             if account and account.itemname:

--- a/openlibrary/core/waitinglist.py
+++ b/openlibrary/core/waitinglist.py
@@ -52,7 +52,7 @@ class WaitingLoan(dict):
         userid = self["userid"]
         username = ""
         if userid.startswith('@'):
-            account = OpenLibraryAccount.get_or_raise(link=userid)
+            account = OpenLibraryAccount.get_or_raise(userid, 'link')
             username = account.username
         elif userid.startswith('ol:'):
             username = userid[len("ol:") :]
@@ -119,7 +119,7 @@ class WaitingLoan(dict):
         user_key = kw['user_key']
         itemname = kw.get('itemname', '')
         if not itemname:
-            account = OpenLibraryAccount.get_or_raise(key=user_key)
+            account = OpenLibraryAccount.get_or_raise(user_key, 'key')
             itemname = account.itemname
         _wl_api.join_waitinglist(kw['identifier'], itemname)
         return cls.find(user_key, kw['identifier'], itemname=itemname)
@@ -133,7 +133,7 @@ class WaitingLoan(dict):
         Returns None if there is no such waiting loan.
         """
         if not itemname:
-            account = OpenLibraryAccount.get_or_raise(key=user_key)
+            account = OpenLibraryAccount.get_or_raise(user_key, 'key')
             itemname = account.itemname
         result = cls.query(userid=itemname, identifier=identifier)
         if result:
@@ -183,7 +183,7 @@ def get_waitinglist_size(book_key: str) -> int:
 def get_waitinglist_for_user(user_key: str) -> list[WaitingLoan]:
     """Returns the list of records for all the books that a user is waiting for."""
     waitlist = []
-    account = OpenLibraryAccount.get_or_raise(key=user_key)
+    account = OpenLibraryAccount.get_or_raise(user_key, 'key')
     if account.itemname:
         waitlist.extend(WaitingLoan.query(userid=account.itemname))
     waitlist.extend(WaitingLoan.query(userid=lending.userkey2userid(user_key)))

--- a/openlibrary/plugins/admin/tests/test_code.py
+++ b/openlibrary/plugins/admin/tests/test_code.py
@@ -19,7 +19,7 @@ def make_test_account(username: str) -> OpenLibraryAccount:
         displayname=f"{username} User",
     )
     web.ctx.site.activate_account(username)
-    return cast(OpenLibraryAccount, OpenLibraryAccount.get(username=username))
+    return cast(OpenLibraryAccount, OpenLibraryAccount.get_by_username(username))
 
 
 def make_thing(key: str, title: str = '', thing_type: str | None = None) -> dict:

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -201,9 +201,9 @@ class account_migration(delegate.page):
             )
         try:
             if i.username:
-                ol_account = OpenLibraryAccount.get(username=i.username)
+                ol_account = OpenLibraryAccount.get_by_username(i.username)
             elif i.email:
-                ol_account = OpenLibraryAccount.get(email=i.email)
+                ol_account = OpenLibraryAccount.get_by_email(i.email)
         except Exception:
             return delegate.RawText(
                 json.dumps({'error': 'bad-account'}), content_type="application/json"
@@ -527,7 +527,7 @@ class account_login(delegate.page):
             config.login_cookie_name, web.ctx.conn.get_auth_token(), expires=expires
         )
 
-        if ol_account := OpenLibraryAccount.get(email=email):
+        if ol_account := OpenLibraryAccount.get_by_email(email):
             _set_account_cookies(ol_account, expires)
 
             if web.cookies().get("pda"):
@@ -598,7 +598,7 @@ class account_validation(delegate.page):
 
     @staticmethod
     def validate_username(username):
-        ol_account = OpenLibraryAccount.get(username=username)
+        ol_account = OpenLibraryAccount.get_by_username(username)
         if ol_account:
             return _("Username unavailable")
 
@@ -608,7 +608,7 @@ class account_validation(delegate.page):
 
     @staticmethod
     def validate_email(email):
-        ol_account = OpenLibraryAccount.get(email=email)
+        ol_account = OpenLibraryAccount.get_by_email(email)
         if ol_account:
             return _('Email already registered')
 
@@ -672,7 +672,7 @@ class account_ia_email_forgot(delegate.page):
         err = ""
 
         if valid_email(i.email):
-            act = OpenLibraryAccount.get(email=i.email)
+            act = OpenLibraryAccount.get_by_email(i.email)
             if act:
                 if OpenLibraryAccount.authenticate(i.email, i.password) == "ok":
                     ia_act = act.get_linked_ia_account()
@@ -1191,7 +1191,7 @@ class account_anonymization_json(delegate.page):
         if 'error' in xauthn_response:
             raise web.HTTPError("404 Not Found", {"Content-Type": "application/json"})
 
-        ol_account = OpenLibraryAccount.get(link=xauthn_response.get('itemname', ''))
+        ol_account = OpenLibraryAccount.get_by_link(xauthn_response.get('itemname', ''))
         if not ol_account:
             raise web.HTTPError("404 Not Found", {"Content-Type": "application/json"})
 
@@ -1264,7 +1264,7 @@ def get_loan_history_data(page: int, mb: "MyBooksTemplate") -> dict[str, Any]:
     items creates pagination and navigation issues. For further discussion,
     see https://github.com/internetarchive/openlibrary/pull/8375.
     """
-    if not (account := OpenLibraryAccount.get(username=mb.username)):
+    if not (account := OpenLibraryAccount.get_by_username(mb.username)):
         raise render.notfound(
             "Account for not found for %s" % mb.username, create=False
         )

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -171,9 +171,11 @@ class internal_audit(delegate.page):
             result = {'error': 'Authentication failed for private API'}
         else:
             try:
-                result = OpenLibraryAccount.get(
-                    email=i.email, link=i.itemname, username=i.username
-                )
+                result = OpenLibraryAccount.get_by_email(i.email)
+                if result is None:
+                    result = OpenLibraryAccount.get_by_link(i.itemname)
+                if result is None:
+                    OpenLibraryAccount.get_by_username(i.username)
                 if result is None:
                     raise ValueError('Invalid Open Library account email or itemname')
                 result.enc_password = 'REDACTED'

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -171,11 +171,13 @@ class internal_audit(delegate.page):
             result = {'error': 'Authentication failed for private API'}
         else:
             try:
-                result = OpenLibraryAccount.get_by_email(i.email)
-                if result is None:
+                result = None
+                if i.itemname:
                     result = OpenLibraryAccount.get_by_link(i.itemname)
-                if result is None:
-                    OpenLibraryAccount.get_by_username(i.username)
+                elif i.email:
+                    result = OpenLibraryAccount.get_by_email(i.email)
+                elif i.username:
+                    result = OpenLibraryAccount.get_by_username(i.username)
                 if result is None:
                     raise ValueError('Invalid Open Library account email or itemname')
                 result.enc_password = 'REDACTED'

--- a/openlibrary/tests/accounts/test_models.py
+++ b/openlibrary/tests/accounts/test_models.py
@@ -67,7 +67,7 @@ def test_get(mock_web):
     key = "test/test"
     test_username = test_account.username
 
-    retrieved_account = OpenLibraryAccount.get(email=email, test=test)
+    retrieved_account = OpenLibraryAccount.get_by_email(email)
     assert retrieved_account == test_account
 
     mock_site = mock_web.ctx.site
@@ -84,18 +84,18 @@ def test_get(mock_web):
         }
     ]
 
-    retrieved_account = OpenLibraryAccount.get(link=test_username, test=test)
+    retrieved_account = OpenLibraryAccount.get_by_link(test_username)
     assert retrieved_account
     retrieved_username = get_username(retrieved_account)
     assert retrieved_username == test_username
 
     mock_site.store.values.return_value[0]["name"] = "username"
 
-    retrieved_account = OpenLibraryAccount.get(username=test_username, test=test)
+    retrieved_account = OpenLibraryAccount.get_by_username(test_username)
     assert retrieved_account
     retrieved_username = get_username(retrieved_account)
     assert retrieved_username == test_username
 
     key = f'test/{retrieved_username}'
-    retrieved_account = OpenLibraryAccount.get(key=key, test=test)
+    retrieved_account = OpenLibraryAccount.get_by_key(key)
     assert retrieved_account


### PR DESCRIPTION
<!-- What issue does this PR close? -->
This is a followup to the note we put here:
https://github.com/internetarchive/openlibrary/pull/10999/files#diff-884f3a712a7e51cce625ca19060335684272f33a967702b19e66e48dbdd1be69R495

Turns out raising by default isn't probably the ideal behavior for our codebase because we call the method fairly often and expect a None to get back.

As such, I added 

Changes:
- Replace most usages of generic `.get` method with `.get_by_*` methods which are better defined.
- Removed the `.get` method, we can use `.get_or_raise` when we want to raise.
- Refactored `.get_or_raise` to accept just a value and a literal for the type of value
- Removed the unused `test=` from the get methods
- Fixed a bug on the internal audit endpoint where we weren't checking all the ways to get a user


PS: This refactor my seem a little silly but as I'm digging into the #11133 it's been a challenge to get a user so cleaning up this code can make that a little easier.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
