### PR TITLE
make pytest run in parallel in gh actions

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -49,6 +49,7 @@ jobs:
             uv pip install --upgrade pip setuptools wheel
           }
           uv pip install -r requirements_test.txt
+          uv pip install pytest-xdist
       - run: make git
       - name: Run make i18n
         run: |

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ lint:
 	python -m ruff check .
 
 test-py:
-	pytest -n 1 . --ignore=infogami --ignore=vendor --ignore=node_modules
+	pytest -n auto . --ignore=infogami --ignore=vendor --ignore=node_modules
 
 test-i18n:
 	# Valid locale codes should be added as arguments to validate

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ lint:
 	python -m ruff check .
 
 test-py:
-	pytest -n 2 . --ignore=infogami --ignore=vendor --ignore=node_modules
+	pytest -n 1 . --ignore=infogami --ignore=vendor --ignore=node_modules
 
 test-i18n:
 	# Valid locale codes should be added as arguments to validate

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ lint:
 	python -m ruff check .
 
 test-py:
-	pytest . --ignore=infogami --ignore=vendor --ignore=node_modules
+	pytest -n 2 . --ignore=infogami --ignore=vendor --ignore=node_modules
 
 test-i18n:
 	# Valid locale codes should be added as arguments to validate

--- a/openlibrary/tests/core/test_helpers.py
+++ b/openlibrary/tests/core/test_helpers.py
@@ -100,6 +100,7 @@ def test_sprintf():
 
 
 def test_commify():
+    web.ctx.lang = "en"
     assert h.commify(123) == "123"
     assert h.commify(1234) == "1,234"
     assert h.commify(1234567) == "1,234,567"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ disallow_untyped_defs = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
+asyncio_default_fixture_loop_scope = "function"
 
 [tool.ruff]
 target-version = "py312"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ disallow_untyped_defs = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
-asyncio_default_fixture_loop_scope = "function"
 
 [tool.ruff]
 target-version = "py312"


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Wondering if the python tests GH action that usually take ~49 seconds to run in total an ~20 seconds to run the tests themselves can run in parallel to get a bit faster.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
