### PR TITLE
Allow author records with just 'death_date' to count as "dated"

### DIFF
--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -142,6 +142,9 @@ def find_author(author: dict[str, Any]) -> list["Author"]:
     Searches OL for an author by a range of queries.
     """
 
+    def has_dates(author: "dict | Author") -> bool:
+        return 'birth_date' in author or 'death_date' in author
+
     def walk_redirects(obj, seen):
         seen.add(obj['key'])
         while obj['type']['key'] == '/type/redirect':
@@ -217,10 +220,10 @@ def find_author(author: dict[str, Any]) -> list["Author"]:
         seen.add(key)
         assert a.type.key == '/type/author'
         # Both records are dateless: assume a potential match
-        if not ('birth_date' in author or 'death_date' in author) and not ('birth_date' in a or 'death_date' in a):
+        if not has_dates(author) and not has_dates(a):
             match.append(a)
         # Match if both records have at least one date, and the dates are compatible:
-        elif ('birth_date' in author or 'death_date' in author) and ('birth_date' in a or 'death_date' in a) and author_dates_match(author, a):
+        elif has_dates(author) and has_dates(a) and author_dates_match(author, a):
             match.append(a)
         # Otherwise, if one record is dated and the other dateless, don't assume a match.
     if not match:

--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -216,13 +216,13 @@ def find_author(author: dict[str, Any]) -> list["Author"]:
             continue
         seen.add(key)
         assert a.type.key == '/type/author'
-        if 'birth_date' in author and 'birth_date' not in a:
-            continue
-        if 'birth_date' not in author and 'birth_date' in a:
-            continue
-        if not author_dates_match(author, a):
-            continue
-        match.append(a)
+        # Both records are dateless: assume a potential match
+        if not ('birth_date' in author or 'death_date' in author) and not ('birth_date' in a or 'death_date' in a):
+            match.append(a)
+        # Match if both records have at least one date, and the dates are compatible:
+        elif ('birth_date' in author or 'death_date' in author) and ('birth_date' in a or 'death_date' in a) and author_dates_match(author, a):
+            match.append(a)
+        # Otherwise, if one record is dated and the other dateless, don't assume a match.
     if not match:
         return []
     if len(match) == 1:

--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -213,19 +213,18 @@ def find_author(author: dict[str, Any]) -> list["Author"]:
             break
     match = []
     seen = set()
+    # If author has dates, we only consider dated candidates,
+    # otherwise only include undated candidates.
     for a in things:
-        key = a['key']
-        if key in seen:
+        if key := a['key'] in seen:
             continue
         seen.add(key)
+        if has_dates(author) != has_dates(a):
+            continue
         assert a.type.key == '/type/author'
-        # Both records are dateless: assume a potential match
-        if not has_dates(author) and not has_dates(a):
-            match.append(a)
-        # Match if both records have at least one date, and the dates are compatible:
-        elif has_dates(author) and has_dates(a) and author_dates_match(author, a):
-            match.append(a)
-        # Otherwise, if one record is dated and the other dateless, don't assume a match.
+        if has_dates(author) and not author_dates_match(author, a):
+            continue
+        match.append(a)
     if not match:
         return []
     if len(match) == 1:

--- a/openlibrary/catalog/utils/__init__.py
+++ b/openlibrary/catalog/utils/__init__.py
@@ -58,7 +58,7 @@ def author_dates_match(a: dict, b: "dict | Author") -> bool:
     Checks if the years of two authors match. Only compares years,
     not names or keys. Works by returning False if any year specified in one record
     does not match that in the other, otherwise True. If any one author does not have
-    dates, it will return True.
+    dates, it will return True (i.e. "possible match").
 
     :param dict a: Author import dict {"name": "Some One", "birth_date": "1960"}
     :param dict b: Author import dict {"name": "Some One"}

--- a/openlibrary/catalog/utils/tests/test_catalog_utils.py
+++ b/openlibrary/catalog/utils/tests/test_catalog_utils.py
@@ -26,3 +26,8 @@ def test_author_dates_match_true(a):
 @pytest.mark.parametrize('a', NON_MATCH_CASES)
 def test_author_dates_match_false(a):
     assert not author_dates_match(a, EXISTING)
+
+def test_author_dates_match_death_only():
+    a = {'death_date': '1996'}
+    b = {'death_date': '1996'}
+    assert author_dates_match(a, b)

--- a/openlibrary/catalog/utils/tests/test_catalog_utils.py
+++ b/openlibrary/catalog/utils/tests/test_catalog_utils.py
@@ -1,6 +1,6 @@
 import pytest
-from openlibrary.catalog.utils import author_dates_match 
 
+from openlibrary.catalog.utils import author_dates_match
 
 EXISTING = {'birth_date': '1904', 'death_date': '1996'}
 
@@ -18,11 +18,11 @@ NON_MATCH_CASES = [
 ]
 
 
-@pytest.mark.parametrize('a', MATCH_CASES) 
+@pytest.mark.parametrize('a', MATCH_CASES)
 def test_author_dates_match_true(a):
     assert author_dates_match(a, EXISTING)
 
 
-@pytest.mark.parametrize('a', NON_MATCH_CASES) 
+@pytest.mark.parametrize('a', NON_MATCH_CASES)
 def test_author_dates_match_false(a):
     assert not author_dates_match(a, EXISTING)

--- a/openlibrary/catalog/utils/tests/test_catalog_utils.py
+++ b/openlibrary/catalog/utils/tests/test_catalog_utils.py
@@ -1,0 +1,28 @@
+import pytest
+from openlibrary.catalog.utils import author_dates_match 
+
+
+EXISTING = {'birth_date': '1904', 'death_date': '1996'}
+
+
+MATCH_CASES = [
+    {'birth_date': '1904', 'death_date': '1996'},
+    {'death_date': '1996'},
+    {'birth_date': '1904'},
+]
+
+
+NON_MATCH_CASES = [
+    {'birth_date': '1794', 'death_date': '1823'},
+    {'birth_date': '1904', 'death_date': '2005'},  # one date mismatch
+]
+
+
+@pytest.mark.parametrize('a', MATCH_CASES) 
+def test_author_dates_match_true(a):
+    assert author_dates_match(a, EXISTING)
+
+
+@pytest.mark.parametrize('a', NON_MATCH_CASES) 
+def test_author_dates_match_false(a):
+    assert not author_dates_match(a, EXISTING)

--- a/openlibrary/catalog/utils/tests/test_catalog_utils.py
+++ b/openlibrary/catalog/utils/tests/test_catalog_utils.py
@@ -27,6 +27,7 @@ def test_author_dates_match_true(a):
 def test_author_dates_match_false(a):
     assert not author_dates_match(a, EXISTING)
 
+
 def test_author_dates_match_death_only():
     a = {'death_date': '1996'}
     b = {'death_date': '1996'}


### PR DESCRIPTION
Allow author records with just `death_date` to count as _dated_ for the purposes of author possible match comparisons.

fixes #10736

Previously when one record had `birth_date` and the other didn't, we chose to assume they couldn't be the same.

This needs to be changed to not just look at `birth_date`, but `death_date` also, because some incoming records provide _just_ a `death_date` (example in #10736)

This is the summary of the existing intended logic when comparing a single incoming `author` record against a list of existing authors pulled out via a search query  https://github.com/internetarchive/openlibrary/blob/dee6fb024af906c0b0d9d14969c15ea15b68d103/openlibrary/catalog/add_book/load_book.py#L194-L205

* **Both records are dateless**: assume a (potential) match (based on previous comparison of name and ids etc)
* **Both records are dated**: compare dates using `author_dates_match()`, match if dates do not actively conflict
* **One record is dated, the other fully dateless**: don't assume a match



<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
I haven't testing this in a running environment with a full db of existing records.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@tfmorris 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
