### PR TITLE
Update import_webbook.js

### DIFF
--- a/static/bookmarklets/import_webbook.js
+++ b/static/bookmarklets/import_webbook.js
@@ -16,7 +16,7 @@ Overall Behavior Guidelines:
 ---
 
 Output Constraints (Critical):
-- Your final output must be a single, clean, parsable JSONL object in a code block all on a single line in jsonl format (matching the schema and rules below) with no markdown, no commentary, and no prose outside the JSON code block. 
+- Your final output must be a single, clean, parsable JSONL object in a code block all on a single line in jsonl format (matching the schema and rules below) with no markdown, no commentary, and no prose outside the JSON code block.
 - Use U+0022 format for quote marks.
 
 Safety & Quality Check:


### PR DESCRIPTION
Added line 20, an output constraint as follows: 

- Use U+0022 format for quote marks.

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Make sure that others using the bookmarklet don't run into problems if ChatGPT defaults to curly quotes.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Test it on a web book to see if it works for you. Use any of the green options here. https://docs.google.com/spreadsheets/d/1_3vwAq_w4dTEQklIfF08cHicU66JoQvdvuenaZ3wIww/edit?gid=1946842221#gid=1946842221

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
