### PR TITLE
docs(coc): grammar + comma fixes; clarify enforcement phrasing

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,14 +4,14 @@
 
 In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to make participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
+our community to be a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity and expression,
 level of experience, education, socioeconomic status, nationality, personal
 appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards
 
-Examples of behavior that contributes to creating a positive environment
+Examples of behavior that contribute to creating a positive environment
 include:
 
 * Using welcoming and inclusive language
@@ -39,8 +39,8 @@ response to any instances of unacceptable behavior.
 
 Project maintainers have the right and responsibility to remove, edit, or
 reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
+that are not aligned to this Code of Conduct, or to ban temporarily, or
+permanently exclude any contributor for other behaviors that they deem inappropriate,
 threatening, offensive, or harmful.
 
 ## Scope
@@ -56,13 +56,13 @@ further defined and clarified by project maintainers.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting the project team at openlibrary-maintainers@archive.org. All
-complaints will be reviewed and investigated and will result in a response that
+complaints will be reviewed and investigated, and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
 Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
+faith may face temporary or permanent repercussions, as determined by other
 members of the project's leadership.
 
 ## Attribution


### PR DESCRIPTION
This PR cleans up grammar in the Code of Conduct and clarifies one enforcement line. No policy or scope changes.

- “contributes” → “contribute” (subject–verb agreement)
- Add “to be” in the pledge sentence
- Clarify enforcement actions: “ban temporarily, or permanently exclude any contributor”
- Add commas for readability in enforcement paragraphs

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

### Technical
- Text-only changes to CODE_OF_CONDUCT.md
- Keeps Contributor Covenant v1.4 attribution and links intact
- Section order and headings unchanged
- Reporting email remains openlibrary-maintainers@archive.org