### PR TITLE
Improving Private button design

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -296,7 +296,7 @@ msgstr ""
 msgid "UnfollowFollow"
 msgstr ""
 
-#: Follow.html
+#: Follow.html lists/list_follow.html
 msgid "Follow"
 msgstr ""
 
@@ -6301,7 +6301,11 @@ msgid "You"
 msgstr ""
 
 #: lists/list_follow.html
-msgid "Private"
+msgid "This patron has not enabled following"
+msgstr ""
+
+#: lists/list_follow.html
+msgid "🔒︎"
 msgstr ""
 
 #: lists/list_follow.html

--- a/openlibrary/plugins/openlibrary/js/book-page-lists.js
+++ b/openlibrary/plugins/openlibrary/js/book-page-lists.js
@@ -20,7 +20,6 @@ export function initListsSection(elem) {
                 fetchPartials(ids.work, ids.edition)
                     .then((resp) => {
                         // Check response code, continue if not 4XX or 5XX
-
                         return resp.json()
                     })
                     .then((data) => {
@@ -43,6 +42,8 @@ export function initListsSection(elem) {
                                 showAllLink.classList.remove('hidden')
                             }
                         }
+                        // Initialize private buttons after content is loaded
+                        initPrivateButtonsAfterLoad(listSection)
                     })
             }
         })
@@ -53,6 +54,20 @@ export function initListsSection(elem) {
     })
 
     intersectionObserver.observe(elem)
+}
+
+/**
+ * Initialize private buttons after the lists section has been loaded
+ * @param {HTMLElement} container - The container that now has the loaded content
+ */
+function initPrivateButtonsAfterLoad(container) {
+    const privateButtons = container.querySelectorAll('.list-follow-card__private-button')
+    if (privateButtons.length > 0) {
+        import(/* webpackChunkName: "private-buttons" */ './private-button')
+            .then(module => {
+                module.initPrivateButtons(privateButtons)
+            })
+    }
 }
 
 async function fetchPartials(workId, editionId) {

--- a/openlibrary/plugins/openlibrary/js/private-button.js
+++ b/openlibrary/plugins/openlibrary/js/private-button.js
@@ -1,0 +1,12 @@
+import { FadingToast } from './Toast'
+
+export function initPrivateButtons(buttons) {
+    buttons.forEach(button => {
+        button.addEventListener('click', (event) => {
+            event.preventDefault();
+            const toast = new FadingToast('This patron has not enabled following', null, 3000);
+            toast.show();
+
+        });
+    });
+}

--- a/openlibrary/templates/lists/list_follow.html
+++ b/openlibrary/templates/lists/list_follow.html
@@ -53,9 +53,12 @@ $def list_card(list, owner, own_list):
                         $if is_public:
                             $:render_follow_button(owner_username, is_subscribed)
                         $else:
-                            <button class="list-follow-card__private-button" disabled>
-                                <span class="pvt-text">$_('Private')</span>
-                            </button>
+                            <div title="$_('This patron has not enabled following')">
+                                <button class="list-follow-card__private-button" >
+                                    <span class="pvt-icon">$_('🔒︎')</span>
+                                    <span class="pvt-text">$_('Follow')</span>
+                                </button>
+                            </div>
                 </div>
             </div>
         $else:

--- a/static/css/components/list-follow.less
+++ b/static/css/components/list-follow.less
@@ -131,7 +131,7 @@
     background-color: @grey;
     border: none;
     cursor: not-allowed;
-    pointer-events: none;
+    pointer-events: auto;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -144,6 +144,11 @@
       box-shadow: none; // Remove default shadow if present
       margin: 0;
       letter-spacing: 0.2px;
+      margin-top: 1px;
+    }
+    .pvt-icon {
+      color: @white;
+      font-size: 14px;
     }
   }
   &__title {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11139 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR aims to improve the design of `Private` button. 

Earlier Private button was not able to convey the meaning of **what was private?**.


### Technical
<!-- What should be noted about the implementation? -->
- Changed `Private` to `🔒︎ Follow` to help convey the message behind the unclickable button.
- Added hover tooltip for desktop readers with a message.
- Added toast for mobile users conveying the same message.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- One can click on any books and scroll down to `Lists`
- For patrons who have made their reading logs private, one would see a `🔒︎ Follow` button.
- On clicking this follow button one would notice a toast message saying "This patron has not enabled following".

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="1920" height="1080" alt="Screenshot (119)" src="https://github.com/user-attachments/assets/04f57b66-d82b-40dc-9a77-014c456c47b1" />
<img width="294" height="221" alt="Screenshot 2025-08-17 140720" src="https://github.com/user-attachments/assets/a042f151-e4d5-4afe-b751-fb4a55c410c8" />


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles @ragipidavid 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
