### PR TITLE
Run account anonymization actions as the patron

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -1197,7 +1197,8 @@ class account_anonymization_json(delegate.page):
         try:
             with RunAs(ol_account.username):
                 result = ol_account.anonymize(test=test)
-        except Exception:
+        except Exception as e:
+            logger.error(e)
             raise web.HTTPError(
                 "500 Internal Server Error", {"Content-Type": "application/json"}
             )

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -24,6 +24,7 @@ from openlibrary.accounts import (
     InternetArchiveAccount,
     OLAuthenticationError,
     OpenLibraryAccount,
+    RunAs,
     audit_accounts,
     clear_cookies,
     valid_email,
@@ -1194,7 +1195,8 @@ class account_anonymization_json(delegate.page):
             raise web.HTTPError("404 Not Found", {"Content-Type": "application/json"})
 
         try:
-            result = ol_account.anonymize(test=test)
+            with RunAs(ol_account.username):
+                result = ol_account.anonymize(test=test)
         except Exception:
             raise web.HTTPError(
                 "500 Internal Server Error", {"Content-Type": "application/json"}


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Valid requests to `/account/anonymize.json` have been returning `500`s, and the affected accounts are only partially anonymized: The account object is not being updated, but the account's reading log, notes, likes, etc. _are_ being updated as expected.

I suspect that actions taken within [this block](https://github.com/internetarchive/openlibrary/blob/4be092163d6fa0e995917e40c0d6def29b7591e2/openlibrary/plugins/upstream/account.py#L368-L389) require `RunAs` to complete successfully.

Exceptions thrown during patron anonymization are written to our error logs, and will be available in Sentry when they occur.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
