### PR TITLE
Feature: add prometheus logging

### DIFF
--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -164,6 +164,9 @@ services:
       - ../olsystem/etc/haproxy/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
     expose:
       - 7072
+    ports:
+      # For prometheus logging
+      - 8405:8405
     logging:
       options:
         max-size: "512m"


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11171

Related:
https://github.com/internetarchive/olsystem/pull/273 https://git.archive.org/iaux/server-config/-/merge_requests/95

This mirrors what is currently applied to production.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature. Completes support for exposing the `/metrics` endpoint for HAProxy.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Stop HAProxy with `docker compose` and bring it up again. Port 8405 outside the container should be forwarded to port 8405 inside the container.

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
