### PR TITLE
Add ebook_provider field to solr

### DIFF
--- a/conf/solr/conf/managed-schema.xml
+++ b/conf/solr/conf/managed-schema.xml
@@ -160,6 +160,7 @@
     <field name="oclc" type="text_en_splitting" multiValued="true"/>
     <field name="isbn" type="string" multiValued="true"/>
     <field name="ebook_access" type="ebookAccessLevel" multiValued="false"/>
+    <field name="ebook_provider" type="string" multiValued="true"/>
 
     <!-- Reading Levels -->
     <field name="lexile" type="pint" multiValued="true"/>

--- a/openlibrary/book_providers.py
+++ b/openlibrary/book_providers.py
@@ -1,4 +1,5 @@
 import logging
+import typing
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from typing import Literal, TypedDict, TypeVar, cast, override
@@ -157,6 +158,10 @@ class AbstractBookProvider[TProviderMetadata]:
     """
     identifier_key: str | None
 
+    @property
+    def provider_name(self) -> str:
+        return self.identifier_key or self.short_name
+
     def get_olids(self, identifier: str) -> list[str]:
         return web.ctx.site.things(
             {"type": "/type/edition", self.db_selector: identifier}
@@ -271,6 +276,11 @@ class InternetArchiveProvider(AbstractBookProvider[IALiteMetadata]):
     short_name = 'ia'
     long_name = 'Internet Archive'
     identifier_key = 'ocaid'
+
+    @property
+    @typing.override
+    def provider_name(self) -> str:
+        return 'ia'
 
     @property
     def db_selector(self) -> str:
@@ -648,8 +658,14 @@ def is_non_ia_ocaid(ocaid: str) -> bool:
     return any(provider.is_own_ocaid(ocaid) for provider in providers)
 
 
-def get_book_provider_by_name(short_name: str) -> AbstractBookProvider | None:
-    return next((p for p in PROVIDER_ORDER if p.short_name == short_name), None)
+def get_book_provider_by_name(name: str) -> AbstractBookProvider | None:
+    """
+    :param name: Either the provider's short_name (legacy) or its provider_name
+    """
+    return next(
+        (p for p in PROVIDER_ORDER if name in (p.provider_name, p.short_name)),
+        None,
+    )
 
 
 ia_provider = cast(InternetArchiveProvider, get_book_provider_by_name('ia'))

--- a/openlibrary/plugins/worksearch/schemes/works.py
+++ b/openlibrary/plugins/worksearch/schemes/works.py
@@ -51,6 +51,7 @@ class WorkSearchScheme(SearchScheme):
             "alternative_subtitle",
             "cover_i",
             "ebook_access",
+            "ebook_provider",
             "edition_count",
             "edition_key",
             "format",

--- a/openlibrary/solr/solr_types.py
+++ b/openlibrary/solr/solr_types.py
@@ -35,6 +35,7 @@ class SolrDocument(TypedDict):
     oclc: Optional[list[str]]
     isbn: Optional[list[str]]
     ebook_access: Optional[Literal['no_ebook', 'unclassified', 'printdisabled', 'borrowable', 'public']]
+    ebook_provider: Optional[list[str]]
     lexile: Optional[list[int]]
     lcc: Optional[list[str]]
     lcc_sort: Optional[str]

--- a/openlibrary/solr/updater/work.py
+++ b/openlibrary/solr/updater/work.py
@@ -475,6 +475,12 @@ class WorkSolrBuilder(AbstractSolrBuilder):
         )
 
     @property
+    def ebook_provider(self) -> list[str]:
+        return uniq(
+            provider for e in self._solr_editions for provider in e.ebook_provider
+        )
+
+    @property
     def has_fulltext(self) -> bool:
         return any(e.has_fulltext for e in self._solr_editions)
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11144
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

This will allow us to find direct book provided books with `ebook_provider:direct` (vs eg `ebook_provider:ia` or `book_provider:standard_ebooks`, etc)

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
