### PR TITLE
Fix bugs in preference migration script

### DIFF
--- a/scripts/migrations/write_prefs_to_store.py
+++ b/scripts/migrations/write_prefs_to_store.py
@@ -34,7 +34,7 @@ def copy_preferences_to_store(keys, verbose: bool = False) -> list[str]:
         try:
             if verbose:
                 print(f"Writing {key} to store...")
-            username = key.split('/')[-1]
+            username = key.split('/')[-2]
             ol_acct = OpenLibraryAccount.get_by_username(username)
             prefs = (ol_acct and ol_acct.get_user().preferences()) or {}
             if ol_acct and prefs.get('type', '') != PREFERENCE_TYPE:
@@ -112,6 +112,7 @@ def main(args):
             f"Begin writing batch of {len(affected_pref_keys)} preferences to store..."
         )
         cur_batch = affected_pref_keys[:1000]
+        affected_pref_keys = affected_pref_keys[1000:]
         retries = copy_preferences_to_store(cur_batch, verbose=args.verbose)
         affected_pref_keys.extend(retries)
         print(f"Batch completed with {len(retries)} errors\n")


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Makes the following changes to `write_prefs_to_store.py`:

- Sets `username` to the actual username in `copy_preferences_to_store()`
- Removes each batch from the list of `affected_pref_keys` 

### Technical
<!-- What should be noted about the implementation? -->
These two bugs caused the script to endlessly attempt to get the account of a nonexistent patron having username `preferences`.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
