### PR TITLE
Anonymize accounts more safely

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -333,31 +333,27 @@ class Account(web.storage):
         self._save()
 
     def anonymize(self, test=False):
-        errors_thrown = False
         if not test:
-            try:
-                patron = self.get_user()
-                email = self.email
-                username = self.username
+            patron = self.get_user()
+            email = self.email
+            username = self.username
 
-                # Remove patron from all usergroups:
-                for grp in patron.usergroups:
-                    grp.remove_user(patron.key)
+            # Remove patron from all usergroups:
+            for grp in patron.usergroups:
+                grp.remove_user(patron.key)
 
-                # Clear patron's profile page:
-                data = {'key': patron.key, 'type': '/type/delete'}
-                patron.set_data(data)
+            # Clear patron's profile page:
+            data = {'key': patron.key, 'type': '/type/delete'}
+            patron.set_data(data)
 
-                # Remove account information from store:
-                del web.ctx.site.store[f'account/{username}']
-                del web.ctx.site.store[f'account/{username}/verify']
-                del web.ctx.site.store[f'account/{username}/password']
-                del web.ctx.site.store[f'account-email/{email}']
-                del web.ctx.site.store[f'account-email/{email.lower()}']
-                # Delete preferences:
-                del web.ctx.site.store[f'/people/{username}/preferences']
-            except Exception:
-                errors_thrown = True
+            # Remove account information from store:
+            del web.ctx.site.store[f'account/{username}']
+            del web.ctx.site.store[f'account/{username}/verify']
+            del web.ctx.site.store[f'account/{username}/password']
+            del web.ctx.site.store[f'account-email/{email}']
+            del web.ctx.site.store[f'account-email/{email.lower()}']
+            # Delete preferences:
+            del web.ctx.site.store[f'/people/{username}/preferences']
 
         # Generate new unique username for patron:
         # Note: Cannot test get_activation_link() locally
@@ -368,8 +364,6 @@ class Account(web.storage):
         )
         new_username = f'anonymous-{uuid}'
         results = {'new_username': new_username}
-
-        test = test or errors_thrown
 
         # Delete all of the patron's book notes:
         results['booknotes_count'] = Booknotes.delete_all_by_username(


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Makes the following updates the the account anonymization method:
1. Prevents updates or deletes to DB tables if the account information is somehow not deleted
2. Deletes preferences from the store during the anonymization operation

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
