### PR TITLE
Switch books page lists to solr from db

### DIFF
--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -32,6 +32,8 @@ from openlibrary.core.ratings import Ratings
 from openlibrary.core.vendors import get_amazon_metadata
 from openlibrary.core.wikidata import WikidataEntity, get_wikidata_entity
 from openlibrary.plugins.upstream.utils import get_identifier_config
+from openlibrary.plugins.worksearch.code import run_solr_query
+from openlibrary.plugins.worksearch.schemes.lists import ListSearchScheme
 from openlibrary.utils import extract_numeric_id_from_olid
 from openlibrary.utils.isbn import canonical, isbn_13_to_isbn_10, to_isbn_13
 
@@ -226,6 +228,29 @@ class Thing(client.Thing):
             "h": self._get_history_preview(),
             "l": self._get_lists_cached(),
         }
+
+    def _get_lists_solr(self, limit: int = 50, offset: int = 0, sort: bool = True):
+        # Fetches and caches the lists through Solr, rather than through the DB.
+        # Caching the default case
+        if limit == 50 and offset == 0:
+            keys = self._get_lists_solr_cached()
+        else:
+            keys = self._get_lists_solr_uncached(limit=limit, offset=offset)
+
+        return keys
+
+    @cache.memoize(engine="memcache", key=lambda self: ("d" + self.key, "l"))
+    def _get_lists_solr_cached(self):
+        return self.get_lists_solr_uncached()
+
+    def _get_lists_solr_uncached(self, limit: int = 50, offset: int = 0):
+        q = {"seed": self.key}
+
+        response = run_solr_query(
+            param=q, scheme=ListSearchScheme(), fields=["key", "name"], offset=offset
+        )
+        print(response)
+        return [doc for doc in response.docs if doc.split('/')[2] == "lists"]
 
 
 class ThingReferenceDict(TypedDict):

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -32,7 +32,6 @@ from openlibrary.core.ratings import Ratings
 from openlibrary.core.vendors import get_amazon_metadata
 from openlibrary.core.wikidata import WikidataEntity, get_wikidata_entity
 from openlibrary.plugins.upstream.utils import get_identifier_config
-from openlibrary.plugins.worksearch.code import run_solr_query
 from openlibrary.plugins.worksearch.schemes.lists import ListSearchScheme
 from openlibrary.utils import extract_numeric_id_from_olid
 from openlibrary.utils.isbn import canonical, isbn_13_to_isbn_10, to_isbn_13
@@ -232,25 +231,34 @@ class Thing(client.Thing):
     def _get_lists_solr(self, limit: int = 50, offset: int = 0, sort: bool = True):
         # Fetches and caches the lists through Solr, rather than through the DB.
         # Caching the default case
-        if limit == 50 and offset == 0:
-            keys = self._get_lists_solr_cached()
-        else:
-            keys = self._get_lists_solr_uncached(limit=limit, offset=offset)
+        from openlibrary.core.lists.model import List
 
-        return keys
+        if limit == 50 and offset == 0:
+            docs = self._get_lists_solr_cached()
+        else:
+            docs = self._get_lists_solr_uncached(limit=limit, offset=offset)
+        lists = [List(key=doc["key"], site=web.ctx.site) for doc in docs]
+
+        return lists
 
     @cache.memoize(engine="memcache", key=lambda self: ("d" + self.key, "l"))
     def _get_lists_solr_cached(self):
         return self.get_lists_solr_uncached()
 
-    def _get_lists_solr_uncached(self, limit: int = 50, offset: int = 0):
-        q = {"seed": self.key}
+    def _get_lists_solr_uncached(self, limit: int = 100, offset: int = 0) -> list[str]:
+        from openlibrary.plugins.worksearch.code import run_solr_query
 
+        filter_query = "seed_count: [2 TO *]"
         response = run_solr_query(
-            param=q, scheme=ListSearchScheme(), fields=["key", "name"], offset=offset
+            param={"q": f'seed: \"{self.key}\"'},
+            scheme=ListSearchScheme(),
+            rows=limit,
+            fields=["key", "name", "seed"],
+            offset=offset,
+            extra_params=[('fq', filter_query)],
         )
-        print(response)
-        return [doc for doc in response.docs if doc.split('/')[2] == "lists"]
+        logger.warning(f'response is {response.docs}')
+        return response.docs
 
 
 class ThingReferenceDict(TypedDict):
@@ -288,6 +296,9 @@ class Edition(Thing):
 
     def get_lists(self, limit: int = 50, offset: int = 0, sort: bool = True):
         return self._get_lists(limit=limit, offset=offset, sort=sort)
+
+    def get_lists_solr(self, limit: int = 50, offset: int = 0, sort: bool = True):
+        return self._get_lists_solr(limit=limit, offset=offset, sort=sort)
 
     def get_ebook_info(self):
         """Returns the ebook info with the following fields.

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -304,8 +304,8 @@ class BookPageListsPartial(PartialDataHandler):
         edition = (edition_id and web.ctx.site.get(edition_id)) or None
 
         # Do checks and render
-        has_lists = (work and work.get_lists(limit=1)) or (
-            edition and edition.get_lists(limit=1)
+        has_lists = (work and work.get_lists_solr(limit=1)) or (
+            edition and edition.get_lists_solr(limit=1)
         )
         results["hasLists"] = bool(has_lists)
 

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -737,7 +737,9 @@ class list_search(delegate.page):
         req = ListSearchRequest.from_web_input(web.input(api='next'))
         # Can't set fields when rendering html
         req.fields = 'key'
-        resp = self.get_results(req, 'LIST_SEARCH')
+        logger.warning("SEARCH QUERY FORMAT")
+        logger.warning(req)
+        resp = self.get_results(req)
         lists = list(web.ctx.site.get_many([doc['key'] for doc in resp.docs]))
         return render_template('search/lists.html', req, resp, lists)
 

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -11,7 +11,7 @@ $if "lists" not in ctx.features:
 
 $code:
     def get_page_lists(page, seed_info):
-        return [get_list_data(list, seed_info['seed']) for list in page.get_lists(sort=False)]
+        return [get_list_data(list, seed_info['seed']) for list in page.get_lists_solr(sort=False)]
 
 $ seed_info = get_seed_info(page)
 $ user_lists = [] if async_load or not ctx.user else get_user_lists(seed_info)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11020 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR enables  Edition pages to fetch the lists that a given edition is from the Solr database in a single query, rather than having to perform multiple queries on the infogami database.  This should improve the loading times.  It also allows us to only display non-trivial lists on these pages (i.e: lists that contain more than a single entry.) 

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Step 1: Create two new lists on your local environment.  One with two books, and one with only one book. 
Step 2: Navigate to the page  of the book they share in common, and examine the Lists section. 
Step 3: If only one list is shown on that page, then the code is behaving properly. 
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="1388" height="642" alt="image" src="https://github.com/user-attachments/assets/85de0552-c8cd-4560-b7ab-9acb65e82155" />

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
