### PR TITLE
Fixed list corner radius

### DIFF
--- a/static/css/components/list-follow.less
+++ b/static/css/components/list-follow.less
@@ -63,6 +63,7 @@
     padding-top: 5px;
     gap: 0.5em;
     width: 100%;
+    border-radius: 0 0 4px 4px;
   }
   &__user {
     display: flex;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11190 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes a visual bug in List Cards where the bottom corners were overlapping with the surface and adjusted border-radius accordingly.


### Technical
<!-- What should be noted about the implementation? -->
- Just added `border-radius: 0 0 4px 4px;` to `list-follow-card__bottom`

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Go to List Cards of any book
- Zoom in the Cards
- Now sharp bottom edges would not appear

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="1117" height="361" alt="Screenshot 2025-08-26 124655" src="https://github.com/user-attachments/assets/7fe34c01-f615-4fa0-83e0-def19db28d6c" />


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@ragipidavid @mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
