### PR TITLE
set headers for wikidata get request

### DIFF
--- a/openlibrary/core/wikidata.py
+++ b/openlibrary/core/wikidata.py
@@ -202,8 +202,9 @@ def get_wikidata_entity(
 
 
 def _get_from_web(id: str) -> WikidataEntity | None:
+    headers = {'User-Agent': 'OpenLibrary.org Wikidata Integration'}
     try:
-        response = requests.get(f'{WIKIDATA_API_URL}{id}')
+        response = requests.get(f'{WIKIDATA_API_URL}{id}', headers=headers)
         response.raise_for_status()
         if response.status_code == 200:
             entity = WikidataEntity.from_dict(


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes: #11199
@mekarpeles mentioned we were getting 403 nonstop from wikidata endpoint.
I recently noticed  that we were often not loading data reliably.

Turns out it's because they have a user agent policy that is being enforced actively now [here](https://foundation.wikimedia.org/wiki/Policy:Wikimedia_Foundation_User-Agent_Policy).

To test this I run the following code locally:
```python
>>> import requests
>>> requests.get("https://www.wikidata.org/w/rest.php/wikibase/v1/entities/items/Q9152")
<Response [403]>
>>> 
>>> headers = {'User-Agent': 'OpenLibrary.org Wikidata Integration' }
>>> requests.get("https://www.wikidata.org/w/rest.php/wikibase/v1/entities/items/Q9152", headers=headers)
<Response [200]>
```

As we can see, with no headers we 403. But when you set headers it's 200.

If we were being blocked by wikidata for too many requests it would be a 429 (as I see locally when I use `hey` to make many requests)

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
