### PR TITLE
Allow independently published IA imports

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -826,6 +826,13 @@ def validate_record(rec: dict) -> None:
 
     If all the validations pass, implicitly return None.
     """
+    source_records = rec.get('source_records', [])
+    rec['source_records'] = source_records if isinstance(source_records, list) else [source_records]
+
+    for record in rec['source_records']:
+        if record.startswith('ia:'):
+            return None
+
     # Only validate publication year if a year is found.
     if publication_year := get_publication_year(rec.get('publish_date')):
         if publication_too_old_and_not_exempt(rec):

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -827,7 +827,9 @@ def validate_record(rec: dict) -> None:
     If all the validations pass, implicitly return None.
     """
     source_records = rec.get('source_records', [])
-    rec['source_records'] = source_records if isinstance(source_records, list) else [source_records]
+    rec['source_records'] = (
+        source_records if isinstance(source_records, list) else [source_records]
+    )
 
     for record in rec['source_records']:
         if record.startswith('ia:'):

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -827,13 +827,12 @@ def validate_record(rec: dict) -> None:
     If all the validations pass, implicitly return None.
     """
     source_records = rec.get('source_records', [])
-    rec['source_records'] = (
+    source_records = (
         source_records if isinstance(source_records, list) else [source_records]
     )
 
-    for record in rec['source_records']:
-        if record.startswith('ia:'):
-            return None
+    if any(rec.startswith('ia:') for rec in source_records):
+        return None
 
     # Only validate publication year if a year is found.
     if publication_year := get_publication_year(rec.get('publish_date')):

--- a/openlibrary/catalog/add_book/tests/test_add_book.py
+++ b/openlibrary/catalog/add_book/tests/test_add_book.py
@@ -1559,7 +1559,11 @@ def test_adding_list_field_items_to_edition_deduplicates_input(mock_site) -> Non
         ),
         (
             "Trying to import a book from a future year raises an error",
-            {'title': 'a book', 'source_records': ['amazon:amazon_id'], 'publish_date': '3000'},
+            {
+                'title': 'a book',
+                'source_records': ['amazon:amazon_id'],
+                'publish_date': '3000',
+            },
             PublishedInFutureYear,
         ),
         (
@@ -1601,7 +1605,12 @@ def test_adding_list_field_items_to_edition_deduplicates_input(mock_site) -> Non
         ),
         (
             "Can import an otherwise invalid record if it is from internet archive",
-            {'title': 'a book', 'source_records': ['ia:wheeee'], 'isbn_10': [], 'publishers': ['Independently Published'],},
+            {
+                'title': 'a book',
+                'source_records': ['ia:wheeee'],
+                'isbn_10': [],
+                'publishers': ['Independently Published'],
+            },
             None,
         ),
     ],

--- a/openlibrary/catalog/add_book/tests/test_add_book.py
+++ b/openlibrary/catalog/add_book/tests/test_add_book.py
@@ -1559,14 +1559,14 @@ def test_adding_list_field_items_to_edition_deduplicates_input(mock_site) -> Non
         ),
         (
             "Trying to import a book from a future year raises an error",
-            {'title': 'a book', 'source_records': ['ia:ocaid'], 'publish_date': '3000'},
+            {'title': 'a book', 'source_records': ['amazon:amazon_id'], 'publish_date': '3000'},
             PublishedInFutureYear,
         ),
         (
             "Independently published books CANNOT be imported",
             {
                 'title': 'a book',
-                'source_records': ['ia:ocaid'],
+                'source_records': ['amazon:amazon_id'],
                 'publishers': ['Independently Published'],
             },
             IndependentlyPublished,
@@ -1575,7 +1575,7 @@ def test_adding_list_field_items_to_edition_deduplicates_input(mock_site) -> Non
             "Non-independently published books can be imported",
             {
                 'title': 'a book',
-                'source_records': ['ia:ocaid'],
+                'source_records': ['other:ocaid'],
                 'publishers': ['Best Publisher'],
             },
             None,
@@ -1597,6 +1597,11 @@ def test_adding_list_field_items_to_edition_deduplicates_input(mock_site) -> Non
         (
             "Can import from sources that don't require an ISBN",
             {'title': 'a book', 'source_records': ['ia:wheeee'], 'isbn_10': []},
+            None,
+        ),
+        (
+            "Can import an otherwise invalid record if it is from internet archive",
+            {'title': 'a book', 'source_records': ['ia:wheeee'], 'isbn_10': [], 'publishers': ['Independently Published'],},
             None,
         ),
     ],


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10757 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Validates every IA record. This is more broad than what is required due to the assumption that open library should be able to import anything that is in the Internet Archive.

### Technical
<!-- What should be noted about the implementation? -->
I'm aware that some logic is duplicated. I opted for this approach to make the code more resilient. If the function order is changed down the road, this structure helps prevent breakages.
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Try to import a book such as this one: http://localhost:8080/import/preview?source=ia:seventhmanlargep0000maxb
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Before this error was fixed:

<img width="1529" height="821" alt="image" src="https://github.com/user-attachments/assets/a77c8ec1-258f-4ace-8328-82ed1068f8c6" />
 
After fix applied:

<img width="1130" height="925" alt="image" src="https://github.com/user-attachments/assets/a20229bf-4e9d-470a-a52b-a46dc24af658" />

End result:

<img width="1199" height="925" alt="image" src="https://github.com/user-attachments/assets/d87687bf-ed62-42cc-bb78-c254c70414e1" />


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini @scottbarnes 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
