### PR TITLE
Tweak solr parameters to reduce heap usage

### DIFF
--- a/conf/solr/conf/managed-schema.xml
+++ b/conf/solr/conf/managed-schema.xml
@@ -557,7 +557,7 @@
     </fieldType>
 
     <!-- A text field that applies standard title sorting conventions to its content -->
-    <fieldType name="text_title_sort" class="solr.TextField" sortMissingLast="false" omitNorms="true">
+    <fieldType name="text_title_sort" class="solr.SortableTextField" sortMissingLast="false" omitNorms="true">
       <analyzer>
         <tokenizer name="keyword" />
         <filter name="trim" />

--- a/openlibrary/plugins/worksearch/schemes/authors.py
+++ b/openlibrary/plugins/worksearch/schemes/authors.py
@@ -27,7 +27,7 @@ class AuthorSearchScheme(SearchScheme):
     sorts = MappingProxyType(
         {
             'work_count desc': 'work_count desc',
-            'name': 'name asc',
+            'name': 'name_str asc',
             # Birth Year
             'birth_date asc': 'birth_date asc',
             'birth_date desc': 'birth_date desc',


### PR DESCRIPTION
Scott noticed that the fields `title_sort` and `name` were appearing frequently in Solr's fieldCache and consuming a lot of space (~1.8G for `title`). He noted that the documentation recommends for things like sorting/faceting, docValues are recommended -- which solr.TextField doesn't support. But _does_ support them is the aptly names solr.SortableTextField!

So we switched to that for our `title_sort` field, and for the author `name` field we switched to instead sort by `name_str` which should behave the same.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
