### PR TITLE
Add `/ia/sync.json` POST handler

### DIFF
--- a/openlibrary/core/auth.py
+++ b/openlibrary/core/auth.py
@@ -42,7 +42,7 @@ class HMACToken:
             ValueError: If the secret key cannot be found in the configuration
                 (raised after digest comparison).
         """
-        current_time = datetime.datetime.now(datetime.timezone.utc)
+        current_time = datetime.datetime.now(datetime.UTC)
         expiry_str = msg.split(delimiter)[-1]
         expiry = datetime.datetime.fromisoformat(expiry_str)
 
@@ -57,9 +57,7 @@ class HMACToken:
         mac = ''
         if key:
             mac = hmac.new(
-                key.encode('utf-8'),
-                msg.encode('utf-8'),
-                hashlib.md5
+                key.encode('utf-8'), msg.encode('utf-8'), hashlib.md5
             ).hexdigest()
 
         result = hmac.compare_digest(mac, digest)

--- a/openlibrary/core/auth.py
+++ b/openlibrary/core/auth.py
@@ -1,0 +1,68 @@
+import datetime
+import hashlib
+import hmac
+
+from infogami import config
+
+
+class ExpiredTokenError(Exception):
+    pass
+
+
+class HMACToken:
+    @staticmethod
+    def verify(digest: str, msg: str, secret_key_name: str, delimiter: str = "|"):
+        """
+        Verify an HMAC digest against a message with timestamp validation.
+
+        This method validates that the provided HMAC digest matches the expected
+        digest for the given message, and that the token has not expired. The
+        message is expected to contain an ISO format timestamp as its last
+        delimiter-separated component.
+
+        To mitigate timing attacks, all cryptographic operations are performed
+        before raising any exceptions, ensuring constant-time execution regardless
+        of which validation fails first.
+
+        Args:
+            digest: The HMAC digest to verify (hexadecimal string).
+            msg: The message to verify, which must end with a delimiter-separated
+                ISO format timestamp (e.g., "data|2024-12-31T23:59:59+00:00").
+            secret_key_name: The configuration key name used to retrieve the
+                secret key for HMAC computation.
+            delimiter: The character used to separate message components.
+                Defaults to "|".
+
+        Returns:
+            bool: True if the digest is valid and the token has not expired.
+
+        Raises:
+            ExpiredTokenError: If the timestamp in the message indicates the
+                token has expired (raised after digest comparison).
+            ValueError: If the secret key cannot be found in the configuration
+                (raised after digest comparison).
+        """
+        current_time = datetime.datetime.now(datetime.timezone.utc)
+        expiry_str = msg.split(delimiter)[-1]
+        expiry = datetime.datetime.fromisoformat(expiry_str)
+
+        err: Exception | None = None
+
+        if current_time > expiry:
+            err = ExpiredTokenError()
+
+        if not (key := config.get(secret_key_name, '')):
+            err = ValueError("No key found")
+
+        mac = ''
+        if key:
+            mac = hmac.new(
+                key.encode('utf-8'),
+                msg.encode('utf-8'),
+                hashlib.md5
+            ).hexdigest()
+
+        result = hmac.compare_digest(mac, digest)
+        if err:
+            raise err
+        return result

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -294,7 +294,7 @@ class sync_ia_ol(delegate.page):
         msg = i.msg
 
         try:
-            verify_hmac(digest, msg, "ia_ol_request_shared_key")
+            verify_hmac(digest, msg, "ia_sync_secret")
         except (ValueError, ExpiredTokenError):
             raise web.HTTPError("401 Unauthorized")
 

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -9,7 +9,6 @@ import os
 import socket
 import subprocess
 import sys
-import time
 import traceback
 from collections.abc import Iterable
 

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -298,10 +298,11 @@ class unlink_ia_ol(delegate.page):
     def make_dark(self, edition):
         data = edition.dict()
         del data["ocaid"]
+        source_records = data.get("source_records", [])
+        data['source_records'] = [ rec for rec in source_records if not rec.startswith("ia:") ]
+        if not data['source_records']:
+            del data['source_records']
         web.ctx.site.save(data, 'Remove OCAID: Item no longer available to borrow.')
-
-    def update_marc(self, edition, new_marc):
-        raise NotImplementedError()
 
 
 class people:

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -50,7 +50,6 @@ from openlibrary.utils import extract_numeric_id_from_olid
 from openlibrary.utils.isbn import isbn_10_to_isbn_13, normalize_isbn
 from openlibrary.views.loanstats import get_trending_books
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -1026,17 +1025,25 @@ class unlink_ia_ol(delegate.page):
         ocaid, ts = msg.split("|")
 
         if not ts or not ocaid:
-            raise web.HTTPError("400 Bad Request", data=json.dumps({"error": "Invalid inputs"}))
+            raise web.HTTPError(
+                "400 Bad Request", data=json.dumps({"error": "Invalid inputs"})
+            )
 
         # Fetch affected editions
-        if not (edition_keys := web.ctx.site.things({"type": '/type/edition', "ocaid": ocaid})):
+        if not (
+            edition_keys := web.ctx.site.things(
+                {"type": '/type/edition', "ocaid": ocaid}
+            )
+        ):
             raise web.HTTPError("404 Not Found")
 
         editions = [web.ctx.site.get(key) for key in edition_keys]
         if len(editions) > 1:
             raise web.HTTPError(
                 "409 Conflict",
-                data=json.dumps({"error": "Multiple editions associated with given ocaid"})
+                data=json.dumps(
+                    {"error": "Multiple editions associated with given ocaid"}
+                ),
             )
 
         edition = editions[0]
@@ -1045,10 +1052,11 @@ class unlink_ia_ol(delegate.page):
         try:
             self.make_dark(edition)
         except ClientException as e:
-            logger.error(f'Failed to disassociate record with key {edition.key}', exc_info=True)
+            logger.error(
+                f'Failed to disassociate record with key {edition.key}', exc_info=True
+            )
             raise web.HTTPError(
-                "500 Internal Server Error",
-                data=json.dumps({"error": str(e)})
+                "500 Internal Server Error", data=json.dumps({"error": str(e)})
             )
 
         return delegate.RawText(json.dumps({"status": "ok"}))
@@ -1057,7 +1065,9 @@ class unlink_ia_ol(delegate.page):
         data = edition.dict()
         del data["ocaid"]
         source_records = data.get("source_records", [])
-        data['source_records'] = [rec for rec in source_records if not rec.startswith("ia:")]
+        data['source_records'] = [
+            rec for rec in source_records if not rec.startswith("ia:")
+        ]
         if not data['source_records']:
             del data['source_records']
         web.ctx.site.save(data, 'Remove OCAID: Item no longer available to borrow.')

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -12,6 +12,7 @@ import qrcode
 import web
 
 from infogami import config  # noqa: F401 side effects may be needed
+from infogami.infobase.client import ClientException
 from infogami.plugins.api.code import jsonapi
 from infogami.utils import delegate
 from infogami.utils.view import (
@@ -23,6 +24,7 @@ from openlibrary.accounts.model import (
 )
 from openlibrary.core import cache, lending, models
 from openlibrary.core import helpers as h
+from openlibrary.core.auth import ExpiredTokenError, HMACToken
 from openlibrary.core.bestbook import Bestbook
 from openlibrary.core.bookshelves_events import BookshelvesEvents
 from openlibrary.core.follows import PubSub
@@ -1000,3 +1002,57 @@ class opds_home(delegate.page):
 
         web.header('Content-Type', 'application/opds+json')
         return delegate.RawText(json.dumps(get_cached_homepage()))
+
+
+class unlink_ia_ol(delegate.page):
+    path = "/api/unlink"
+    encoding = "json"
+
+    def POST(self):
+        i = web.input(digest="", msg="")
+
+        digest = i.digest
+        msg = i.msg
+
+        try:
+            HMACToken.verify(digest, msg, "ia_sync_secret")
+        except (ValueError, ExpiredTokenError):
+            raise web.HTTPError("401 Unauthorized")
+
+        ocaid, ts = msg.split("|")
+
+        if not ts or not ocaid:
+            raise web.HTTPError("400 Bad Request", data=json.dumps({"error": "Invalid inputs"}))
+
+        # Fetch affected editions
+        if not (edition_keys := web.ctx.site.things({"type": '/type/edition', "ocaid": ocaid})):
+            raise web.HTTPError("404 Not Found")
+
+        editions = [web.ctx.site.get(key) for key in edition_keys]
+        if len(editions) > 1:
+            raise web.HTTPError(
+                "409 Conflict",
+                data=json.dumps({"error": "Multiple editions associated with given ocaid"})
+            )
+
+        edition = editions[0]
+
+        # Update records
+        try:
+            self.make_dark(edition)
+        except ClientException as e:
+            raise web.HTTPError(
+                "500 Internal Server Error",
+                data=json.dumps({"error": str(e)})
+            )
+
+        return delegate.RawText(json.dumps({"status": "ok"}))
+
+    def make_dark(self, edition):
+        data = edition.dict()
+        del data["ocaid"]
+        source_records = data.get("source_records", [])
+        data['source_records'] = [rec for rec in source_records if not rec.startswith("ia:")]
+        if not data['source_records']:
+            del data['source_records']
+        web.ctx.site.save(data, 'Remove OCAID: Item no longer available to borrow.')

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -6,6 +6,7 @@ its experience. This does not include public facing APIs with LTS
 
 import io
 import json
+import logging
 from collections import defaultdict
 
 import qrcode
@@ -48,6 +49,9 @@ from openlibrary.plugins.worksearch.subjects import (
 from openlibrary.utils import extract_numeric_id_from_olid
 from openlibrary.utils.isbn import isbn_10_to_isbn_13, normalize_isbn
 from openlibrary.views.loanstats import get_trending_books
+
+
+logger = logging.getLogger(__name__)
 
 
 class book_availability(delegate.page):
@@ -1041,6 +1045,7 @@ class unlink_ia_ol(delegate.page):
         try:
             self.make_dark(edition)
         except ClientException as e:
+            logger.error(f'Failed to disassociate record with key {edition.key}', exc_info=True)
             raise web.HTTPError(
                 "500 Internal Server Error",
                 data=json.dumps({"error": str(e)})


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Addresses #7539

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Creates new `/api/unlink.json` endpoint for the purpose of syncing data between IA and OL.  `POST` requests to this endpoint are expected to have the following query parameters:

- `msg` : A colon delimited string in the format `{ocaid}|{expiry}`
- `digest` : The hashed value of `msg`

All inputs required for the operation are expected to be sent in the `msg` string.

The `POST` handler will, in order:

1. Verify the `digest` and check the expiry
2. Validate the request inputs
3. Query for the OL edition that matches the `ocaid` given in the `msg`
4. Perform the `operation` on the selected edition

### Outstanding tasks

- [x] Create new shared key for IA <-> OL sync operations
- [x] Move `verify_hmac` to `core/auth.py`
- [x] Disassociate MARC records

### Technical
<!-- What should be noted about the implementation? -->

### Special Deployment Instructions
Ensure that new shared key entry is added to our production configurations before deploying.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
