### PR TITLE
Fix: make /import/batch/approve work

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -109,9 +109,3 @@ volumes:
   ol-build:
   ol-nodemodules:
   ol-postgres:
-
-networks:
-    default:
-        driver: bridge
-        driver_opts:
-            com.docker.network.driver.mtu: 1280


### PR DESCRIPTION
Closes #11227

This commit ensures the `batch_id` value passed into the query is the same as the value of `batch_id` as it is passed in from the endpoint.

Previously, this value was always `1`. E.g., visiting `/import/batch/approve/3` would show:
```
batch_id = '3'
0.0 (1):
            UPDATE import_item
            SET status = 'pending'
            WHERE batch_id = 1 AND status = 'needs_review';
```

### Technical
<!-- What should be noted about the implementation? -->
This change in this commit was tested for SQL injection by setting `batch_id` to '3 OR true':
```
psycopg2.errors.InvalidTextRepresentation: invalid input syntax for integer: "3 OR true"
LINE 4:             WHERE batch_id = '3 OR true' AND status = 'needs...
                                     ^
```
It is not immediately obvious to me that is a sufficient test, and I am unsure if these queries are being parameterized if created this way.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Create a new import batch as a non-privileged user. Visit `/import/batch/<batch_id>` and click on `Approve`. The batch status should change to `pending`.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles, @liz907.


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
