### PR TITLE
Make identifiers input mobile friendly

### DIFF
--- a/openlibrary/components/IdentifiersInput.vue
+++ b/openlibrary/components/IdentifiersInput.vue
@@ -74,8 +74,8 @@
 
     <template v-for="(value, name) in assignedIdentifiers">
       <div
-        v-if="value && !saveIdentifiersAsList"
-        :key="name"
+        v-for="(item, idx) in (saveIdentifiersAsList ? value : [value])"
+        :key="name + idx"
         class="assigned-identifiers-table"
         role="row"
       >
@@ -89,7 +89,7 @@
           class="identifier-value"
           role="cell"
         >
-          {{ value }}
+          {{ item }}
         </div>
         <div
           class="remove-button"
@@ -97,46 +97,14 @@
         >
           <button
             class="form-control"
-            @click="removeIdentifier(name)"
+            :disabled="!isAdmin && name === 'ocaid'"
+            :title="!isAdmin && name === 'ocaid' ? 'Only librarians can edit this identifier' : ''"
+            @click="removeIdentifier(name, idx)"
           >
             Remove
           </button>
         </div>
       </div>
-      <template v-else-if="value && saveIdentifiersAsList">
-        <div
-          v-for="(item, idx) in value"
-          :key="name + idx"
-          class="assigned-identifiers-table"
-          role="row"
-        >
-          <div
-            class="identifier-name"
-            role="rowheader"
-          >
-            {{ identifierConfigsByKey[name]?.label ?? name }}
-          </div>
-          <div
-            class="identifier-value"
-            role="cell"
-          >
-            {{ item }}
-          </div>
-          <div
-            class="remove-button"
-            role="cell"
-          >
-            <button
-              class="form-control"
-              :disabled="!isAdmin && name === 'ocaid'"
-              :title="!isAdmin && name === 'ocaid' ? 'Only librarians can edit this identifier' : ''"
-              @click="removeIdentifier(name, idx)"
-            >
-              Remove
-            </button>
-          </div>
-        </div>
-      </template>
     </template>
   </div>
 </template>

--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -134,7 +134,7 @@ $:macros.HiddenSaveButton("addWork")
                     </div>
                     <div id="hiddenWorkIdentifiers"></div>
                     <div id="identifiers-display-works">
-                        $ admin = str(ctx.user.is_admin() or ctx.user.is_super_librarian())
+                        $ admin = str(bool(ctx.user) and (ctx.user.is_admin() or ctx.user.is_super_librarian()))
                         $:render_component('IdentifiersInput', attrs=dict(assigned_ids_string=work.get_identifiers().values(), output_selector='#hiddenWorkIdentifiers', id_config_string=work_config.identifiers, input_prefix='work--identifiers', multiple='true', admin=admin))
                     </div>
                 </fieldset>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10620 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes an issue on mobile screens where the ID Numbers section's table breaks and causes a long horizontal scroll.

### Technical

- Changed from `<table>`, `<th>`, and `<tr>` elements to `<div>`s to enable more flexible styling using CSS grid. 
- Included `role` tags to make more accessible for screen readers. Testing a screen reader on Chrome confirmed that when entering the table, it is able to identify the number of rows and columns, as well as which cell the patron is currently in. 
- Added a breakpoint so the table will switch to a more vertical layout on smaller screens. 

### Testing
Select a book and press the 'Edit' button, then scroll down to the ID Numbers section. Opening up the Dev Tools in Chrome and selecting a mobile layout will show the updated table. 

### Screenshot
<img width="3701" height="2183" alt="ID Numbers Comparison" src="https://github.com/user-attachments/assets/b0e07e0c-2c81-45b6-8d86-edb4fa6c31ec" />


### Stakeholders
@cdrini 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
