### PR TITLE
Add timeout to IA availability requests to avoid localhost hanging

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -206,13 +206,13 @@ def get_groundtruth_availability(ocaid, s3_keys=None):
         response.raise_for_status()
     except httpx.TimeoutException:
         if os.getenv('LOCAL_DEV'):
-            print(
-                "Request timed out in LOCAL_DEV environment. Returning empty dictionary."
+            logger.warning(
+                "Availability request timed out in LOCAL_DEV environment. Returning empty dictionary."
             )
             return {}
         else:
-            print(
-                "Request timed out in non-LOCAL_DEV environment. Re-raising the exception."
+            logger.error(
+                "Availability request timed out in non-LOCAL_DEV environment. Re-raising the exception."
             )
             raise  # Re-raise the timeout exception if not in LOCAL_DEV
     except httpx.HTTPError:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11229

Moved to httpx, set timeout, returning empty in localhost.

According to the [docs](https://docs.python-requests.org/en/latest/user/quickstart/#timeouts):

> You can tell Requests to stop waiting for a response after a given number of seconds with the timeout parameter. Nearly all production code should use this parameter in nearly all requests. Failure to do so can cause your program to hang indefinitely:


<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
