### PR TITLE
docs: improve README grammar and clarity

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,7 @@
 
 [Open Library](https://openlibrary.org) is an open, editable library catalog, building towards a web page for every book ever published.
 
-Are you looking to get started? [This is the guide](https://github.com/internetarchive/openlibrary/blob/master/CONTRIBUTING.md) you are looking for. You may wish to learn more about [Google Summer of Code (GSoC)?](https://github.com/internetarchive/openlibrary/wiki/Google-Summer-of-Code) or [Hacktoberfest](https://github.com/internetarchive/openlibrary/wiki/Hacktoberfest).
+Looking to get started? Check out our Getting Started Guide. You may also be interested in learning more about Google Summer of Code (GSoC) or Hacktoberfest.
 
 ## Table of Contents
    - [Overview](#overview)
@@ -40,7 +40,7 @@ Here's a quick public tour of Open Library to get you familiar with the service 
 
 ## Installation
 
-Run `docker compose up` and visit http://localhost:8080
+Run docker compose up and then visit http://localhost:8080.
 
 Need more details? Checkout the [Docker instructions](https://github.com/internetarchive/openlibrary/blob/master/docker/README.md)
 or [video tutorial](https://archive.org/embed/openlibrary-developer-docs/openlibrary-docker-set-up.mp4).
@@ -78,7 +78,7 @@ If you want to dive into the source code for Infogami, see the [Infogami repo](h
 
 ## Running tests
 
-Open Library tests can be run using docker. Kindly look up on our [Testing Document](https://github.com/internetarchive/openlibrary/wiki/Testing) for more details.
+Open Library tests can be run using Docker. Please refer to our Testing Guide for more details.
 
 ```
 docker compose run --rm home make test


### PR DESCRIPTION
- Reworded "Are you looking to get started? This is the guide you are looking for." → "Looking to get started? Check out our Getting Started Guide."
- Added backticks around `docker compose up` and linked http://localhost:8080.
- Changed "Kindly look up on our Testing Document" → "Please refer to our Testing Guide."

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
