### PR TITLE
Only load the search facets when visible

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -54,7 +54,7 @@
     },
     {
       "path": "static/build/js/search.*.js",
-      "maxSize": "1.2KB"
+      "maxSize": "5KB"
     },
     {
       "path": "static/build/js/tabs.*.js",

--- a/openlibrary/plugins/openlibrary/js/search.js
+++ b/openlibrary/plugins/openlibrary/js/search.js
@@ -64,11 +64,13 @@ export function less(header, start_facet_count, facet_inc) {
  *
  * @param {HTMLElement} facetsElem Root element of the search facets sidebar component
  */
-export function initSearchFacets(facetsElem) {
+export async function initSearchFacets(facetsElem) {
     const asyncLoad = facetsElem.dataset.asyncLoad
 
     if (asyncLoad) {
         const param = JSON.parse(facetsElem.dataset.param)
+        await whenVisible(facetsElem);
+
         fetchPartials(param)
             .then((data) => {
                 if (data.activeFacets) {
@@ -154,4 +156,38 @@ function createElementFromMarkup(markup) {
     const template = document.createElement('template')
     template.innerHTML = markup
     return template.content.children[0]
+}
+
+
+/**
+ * Waits until the given element is visible in the viewport, then resolves.
+ *
+ * @param {HTMLElement} elem
+ * @param {IntersectionObserverInit} options
+ * @returns {Promise<void>}
+ */
+async function whenVisible(elem, options = {}) {
+    return new Promise((resolve) => {
+        const intersectionObserver = new IntersectionObserver(
+            (entries, observer) => {
+                entries.forEach(entry => {
+                    if (!entry.isIntersecting) {
+                        return
+                    }
+
+                    // Stop observing once the element is visible
+                    observer.unobserve(entry.target)
+                    observer.disconnect()
+                    resolve()
+                })
+            },
+            Object.assign({
+                root: null,
+                rootMargin: '200px',
+                threshold: 0
+            }, options)
+        )
+
+        intersectionObserver.observe(elem);
+    });
 }


### PR DESCRIPTION
Closes #11255 

Performance fix. Seeing a lot solr strain. Facets is our most expensive solr query, and the facets are currently not even visible on pageload on mobile. Trying making it only load the facets once the section is scrolled into view to see if that helps with load.

About ~42% of traffic to our /search page comes from mobile, so if we can get this pages not loading facets unless the user scrolls down to them, that could have a big impact.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

On testing, confirmed that
- ✅ It load on desktop without any interaction
- ✅ It does not load on mobile until the user scrolls it into view

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
