### PR TITLE
Replace failing method call in list seed `POST` handler

### DIFF
--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -594,7 +594,7 @@ class list_seeds(delegate.page):
             raise web.HTTPError(
                 "403 Forbidden",
                 {"Content-Type": "application/json"},
-                data=json.dumps({"message": "Permission denied."})
+                data=json.dumps({"message": "Permission denied."}),
             )
 
         data = formats.load(web.data(), self.encoding)


### PR DESCRIPTION
Addresses this [Sentry error](https://sentry.archive.org/organizations/ia-ux/issues/271/?project=7&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream)

There is no `list_seeds.forbidden` method, so the call to `self.forbidden()` was failing for unauthorized requests. These updates replace the `forbidden` raise with a `web.HTTPError` call.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in:

1. Make an empty-bodied `POST` request to the `/seeds.json` endpoint of somebody else's list.
2. Ensure that you receive a `403 Forbidden` response.

**Note:** POSTing an empty-bodied request to `/seeds.json` will fail in any case (authorized or not).  If such a request is authorized, a `json.decoder.JSONDecodeError` will be thrown since there is no json string to decode.  Whenever this happens, a `500 Internal Server Error` is returned.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
