### PR TITLE
Set timeAllowed solr parameter to avoid solr wasting cycles on timed-out queries

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -42,6 +42,10 @@ from openlibrary.plugins.worksearch.search import get_solr
 from openlibrary.solr.query_utils import fully_escape_query
 from openlibrary.solr.solr_types import SolrDocument
 from openlibrary.utils.isbn import normalize_isbn
+from openlibrary.utils.solr import (
+    DEFAULT_PASS_TIME_ALLOWED,
+    DEFAULT_SOLR_TIMEOUT_SECONDS,
+)
 
 logger = logging.getLogger("openlibrary.worksearch")
 
@@ -145,7 +149,8 @@ def process_facet_counts(
 def execute_solr_query(
     solr_path: str,
     params: dict | list[tuple[str, Any]],
-    _timeout: int | None = None,
+    _timeout: int | None = DEFAULT_SOLR_TIMEOUT_SECONDS,
+    _pass_time_allowed: bool = DEFAULT_PASS_TIME_ALLOWED,
 ) -> Response | None:
     url = solr_path
     if params:
@@ -158,6 +163,7 @@ def execute_solr_query(
             solr_path,
             urlencode(params),
             _timeout=_timeout,
+            _pass_time_allowed=_pass_time_allowed,
         )
     except requests.HTTPError:
         logger.exception("Failed solr query")

--- a/openlibrary/plugins/worksearch/languages.py
+++ b/openlibrary/plugins/worksearch/languages.py
@@ -80,6 +80,7 @@ def get_all_language_counts(
         # See https://openlibrary.org/query.json?type=/type/language&limit=1000
         facet_limit=1_000,
         _timeout=30,  # This query can be rather slow
+        _pass_time_allowed=False,  # Let this long-running query complete solr-side
     )
     return [
         (f'/languages/{row.value}', row.count) for row in result['facets']['language']

--- a/scripts/solr_updater/trending_updater_daily.py
+++ b/scripts/solr_updater/trending_updater_daily.py
@@ -13,7 +13,7 @@ def fetch_works_trending_scores(current_day: int):
             # /export needs a sort to work
             "sort": "key asc",
         },
-        _timeout=10_000,  # Increase timeout for large datasets
+        _timeout=None,  # No timeout for large datasets
     )
     assert resp
     data = resp.json()

--- a/scripts/solr_updater/trending_updater_hourly.py
+++ b/scripts/solr_updater/trending_updater_hourly.py
@@ -219,7 +219,7 @@ def fetch_solr_trending_data(hour_slot: int, work_keys: set[str]) -> list[dict]:
             "fl": ",".join(solr_fields),
             "sort": "key asc",
         },
-        _timeout=10_000,  # Increase timeout for large datasets
+        _timeout=None,  # No timeout for large datasets
     )
     assert resp
     data = resp.json()
@@ -235,7 +235,7 @@ def fetch_solr_trending_data(hour_slot: int, work_keys: set[str]) -> list[dict]:
                 "fl": ",".join(solr_fields),
                 "sort": "key asc",
             },
-            _timeout=10_000,  # Increase timeout for large datasets
+            _timeout=None,  # No timeout for large datasets
         )
         assert resp
         data = resp.json()


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11268

I was monitoring the solr logs, and noticed that some queries were running for 30+ seconds! Especially odd since in most places in OL we set a timeout of 10s for solr requests. Turns out solr won't abandon a query after the client closes the connection. (And this makes some sense, since it allows the query to effectively finish in the bg, so next time that query is made, caches should hopefully have been populated and it won't time out.)

But for our use cases we generally don't need that. And apparently solr has a url param for this! `timeAllowed={ms}`. This lets us forward along the timeout effectively, and solr will stop processing after ms have passed and instead return a partial result.


### Technical
<!-- What should be noted about the implementation? -->

- Caveat: The previous behaviour did have one benefit, which was that long running queries might timeout the first time, but work the second time, since the query ran solr-side and filled up some caches. Now those queries will consistently error. But we don't know what those types of queries are.
- Note this won't affect our calls to `/update` done by solr-updater ; those use httpx directly.
- Note solr does also support returning partial results... we could potentially make use of those -- that would fix big queries like `language:eng` (although note sort order might not wind up being correct). But for now just timeout.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

I patched this out, and it seems to have helped make us more resilient. I'm seeing solr perf more persistently in the sub 10ms zone (see graph). It seems like this might have increased our throughput, and is preventing large/slow queries from causing solr congestion.

<img width="1877" height="320" alt="image" src="https://github.com/user-attachments/assets/b7f87776-52dd-40ae-a392-f3f3dcb25cc2" />



### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
