### PR TITLE
Don't Search Autocomplete short generic prefixes

### DIFF
--- a/openlibrary/plugins/openlibrary/js/SearchBar.js
+++ b/openlibrary/plugins/openlibrary/js/SearchBar.js
@@ -349,8 +349,8 @@ export class SearchBar {
      * @returns {JQuery.jqXHR}
      **/
     renderAutocompletionResults() {
-        let q = this.$input.val();
-        if (q === '' || !(this.facetEndpoint in RENDER_AUTOCOMPLETE_RESULT)) {
+        let q = this.$input.val().trim();
+        if (q.length < 3 || q === 'the' || !(this.facetEndpoint in RENDER_AUTOCOMPLETE_RESULT)) {
             return;
         }
         if (this.facet.read() === 'title') {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11272 . Prevents search bar autocomplete when query < 3 characters. These queries have large result sets, and are hence slow for solr and usually just result in a timeout.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

- ✅ On testing, type slowly `a`, `b`, `c`. Only one request is made!

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

<img width="1919" height="302" alt="image" src="https://github.com/user-attachments/assets/80825084-daaa-42a2-bfce-6319c0b3a428" />


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
