### PR TITLE
Add meta-externalagent to user agent deny checks

### DIFF
--- a/docker/web_nginx.conf
+++ b/docker/web_nginx.conf
@@ -1,6 +1,7 @@
 map $http_user_agent $is_sus_user_agent {
     default 0;
     "~ByteSpider" 1;
+    "~meta-externalagent" 1;
     # Check for ancient browser user agents
     "~Firefox/([1-7]\.)" 1;
     "~Chrome/([1-9]|10)\." 1;
@@ -136,7 +137,7 @@ server {
         limit_req zone=api_limit burst=25 delay=10;
         limit_req_status 429;
 
-        if ($http_user_agent ~ (Bytespider) ) {
+        if ($http_user_agent ~ (Bytespider|meta-externalagent) ) {
             return 444;
         }
 

--- a/docker/web_nginx.conf
+++ b/docker/web_nginx.conf
@@ -137,7 +137,7 @@ server {
         limit_req zone=api_limit burst=25 delay=10;
         limit_req_status 429;
 
-        if ($http_user_agent ~ (Bytespider|meta-externalagent) ) {
+        if ($http_user_agent ~* (bytespider|meta-externalagent) ) {
             return 444;
         }
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Part of #11277
meta-externalagent does not seem to follow our crawl rates in https://openlibrary.org/robots.txt and so we're blocking them.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
