### PR TITLE
Disable automerge for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,7 @@
         "eslint-plugin-vue"
       ],
       "groupName": "eslint",
-      "automerge": true
+      "automerge": false
     },
     {
       "matchPackageNames": [
@@ -32,10 +32,10 @@
         "prettier",
         "postcss-less"
       ],
-      "automerge": true
+      "automerge": false
     },
     {
-      "automerge": true,
+      "automerge": false,
       "matchPackageNames": [
         "mypy",
         "pytest",
@@ -45,7 +45,7 @@
       ]
     },
     {
-      "automerge": true,
+      "automerge": false,
       "matchPackageNames": [
         "/^actions//"
       ]


### PR DESCRIPTION
<!-- What issue does this PR close? -->
There have been so many npm supply chain attacks this month, no longer comfortable with anything auto updating. We should also audit all our dependencies to ensure everything is fully pinned, and that we don't have anything automatically updating in any way. Eg we likely should remove `^` from our package json and block it from returning.

Eg https://news.ycombinator.com/item?id=45260741

https://news.ycombinator.com/item?id=45169657

We've been lucky so far, but I think we need to clamp down on this.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
