### PR TITLE
Add click listener to remove identifier button

### DIFF
--- a/openlibrary/components/IdentifiersInput.vue
+++ b/openlibrary/components/IdentifiersInput.vue
@@ -88,6 +88,7 @@
               class="form-control"
               :disabled="!isAdmin && name === 'ocaid'"
               :title="!isAdmin && name === 'ocaid' ? 'Only librarians can edit this identifier' : ''"
+              @click="removeIdentifier(name, idx)"
             >
               Remove
             </button>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Follows #11208

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds click listener to remove identifier buttons on edit pages.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
