### PR TITLE
Identifiers : Reinstate `isAdmin` as computed property

### DIFF
--- a/openlibrary/components/IdentifiersInput.vue
+++ b/openlibrary/components/IdentifiersInput.vue
@@ -167,8 +167,7 @@ export default {
         return {
             selectedIdentifier: '', // Which identifier is selected in dropdown
             inputValue: '', // What user put into input
-            assignedIdentifiers: {}, // IDs assigned to the entity Ex: {'viaf': '12632978'} or {'abaa': ['123456','789012']}
-            isAdmin: false,
+            assignedIdentifiers: {} // IDs assigned to the entity Ex: {'viaf': '12632978'} or {'abaa': ['123456','789012']}
         }
     },
 
@@ -194,6 +193,9 @@ export default {
         },
         hasPopularIds: function() {
             return Object.keys(this.popularIds).length !== 0;
+        },
+        isAdmin: function() {
+            return this.admin.toLowerCase() === 'true';
         }
     },
     watch: {
@@ -208,7 +210,6 @@ export default {
             },
     },
     created: function(){
-        this.isAdmin = this.admin.toLowerCase() === 'true';
         this.assignedIdentifiers = JSON.parse(decodeURIComponent(this.assigned_ids_string));
         if (this.assignedIdentifiers.length === 0) {
             this.assignedIdentifiers = {}


### PR DESCRIPTION
Follows #11283
Follows #11208

For some reason, setting `isAdmin` in the `created` lifecycle hook works as expected in my local environment, but _does not work_ on testing.  Changing `isAdmin` to a computed property appears to make things work as expected in both local dev and testing environments.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
