### PR TITLE
Totp auth

### DIFF
--- a/openlibrary/core/auth.py
+++ b/openlibrary/core/auth.py
@@ -1,0 +1,60 @@
+import hashlib
+import hmac
+import time
+from openlibrary.core import cache
+from openlibrary.core.lending import config_otp_seed as OTP_SEED
+
+class TimedOneTimePassword:
+
+    VALID_MINUTES = 10
+    
+    @staticmethod
+    def generate(email: str, ip: str, client: str, ts=None) -> str:
+        ts = ts or int(time.time() // 60)
+        payload = f"{client}:{email}:{ip}:{ts}".encode()
+        return hmac.new(OTP_SEED.encode('utf-8'), payload, hashlib.sha256).hexdigest()
+
+    @classmethod
+    def is_ratelimit(cls, ttl=60, client="", **kwargs):
+        def ratelimit_error(key, ttl):
+            return {
+                "error": "ratelimit",
+                "ratelimit": {
+                    "ttl": ttl,
+                    "key": key
+                }
+            }            
+        mc = cache.get_memcache()
+        # Limit requests to 1 / ttl per client
+        for key, value in kwargs.items():
+            cache_key = f"otp-client:{client}:{key}:{value}"
+            if not mc.add(cache_key, 1, expires=ttl):
+                return ratelimit_error(cache_key, ttl)
+
+        # Limit globally to 3 attempts per email and ip per / ttl
+        for key, value in kwargs.items():
+            cache_key = f"otp-global:{key}:{value}"
+            count = mc.incr(cache_key) if mc.get(cache_key)
+            if mc.get(cache_key):
+                count = mc.incr(cache_key)
+            else:
+                mc.set(cache_key, 1, expires=ttl)
+                count = 1
+            if count > 3:
+                return ratelimit_error(cache_key, ttl)
+
+
+    @classmethod
+    def validate(cls, otp, email, ip, client, ts):
+        expected_otp = cls.generate(email, ip, client, ts)
+        return hmac.compare_digest(otp, expected_otp)
+
+    @classmethod
+    def is_valid(cls, email, ip, client, otp):
+        now_minute = int(time.time() // 60)
+        for delta in range(cls.VALID_MINUTES):
+            ts = now_minute - delta
+            if cls.validate(otp, email, ip, client, ts):
+                return True
+        return False
+            

--- a/openlibrary/core/auth.py
+++ b/openlibrary/core/auth.py
@@ -1,21 +1,34 @@
 import hashlib
 import hmac
 import time
+import requests
+from infogami import config
 from openlibrary.core import cache
-from openlibrary.core.lending import config_otp_seed as OTP_SEED
 
 class TimedOneTimePassword:
 
     VALID_MINUTES = 10
     
     @staticmethod
-    def generate(email: str, ip: str, client: str, ts=None) -> str:
+    def generate(service_ip:str, client_email: str, client_ip: str, ts:int|None = None) -> str:
+        seed = config.get("otp_seed")
         ts = ts or int(time.time() // 60)
-        payload = f"{client}:{email}:{ip}:{ts}".encode()
-        return hmac.new(OTP_SEED.encode('utf-8'), payload, hashlib.sha256).hexdigest()
+        payload = f"{service_ip}:{client_email}:{client_ip}:{ts}".encode()
+        return hmac.new(seed.encode('utf-8'), payload, hashlib.sha256).hexdigest()
+
+    @staticmethod
+    def verify_service(service_ip: str, service_url: str) -> bool:
+        try:
+            # Is HTTPS, matches IP, valid json response
+            return service_url.startswith("https://") and \
+                (r := requests.get(service_url, timeout=5)) and \
+                r.raw._connection.sock.getpeername()[0] == service_ip and \
+                bool(r.json())
+        except Exception:
+            return False
 
     @classmethod
-    def is_ratelimit(cls, ttl=60, client="", **kwargs):
+    def is_ratelimited(cls, ttl=60, service_ip="", **kwargs):
         def ratelimit_error(key, ttl):
             return {
                 "error": "ratelimit",
@@ -23,38 +36,35 @@ class TimedOneTimePassword:
                     "ttl": ttl,
                     "key": key
                 }
-            }            
+            }
+
         mc = cache.get_memcache()
         # Limit requests to 1 / ttl per client
         for key, value in kwargs.items():
-            cache_key = f"otp-client:{client}:{key}:{value}"
+            cache_key = f"otp-client:{service_ip}:{key}:{value}"
             if not mc.add(cache_key, 1, expires=ttl):
                 return ratelimit_error(cache_key, ttl)
 
         # Limit globally to 3 attempts per email and ip per / ttl
         for key, value in kwargs.items():
             cache_key = f"otp-global:{key}:{value}"
-            count = mc.incr(cache_key) if mc.get(cache_key)
-            if mc.get(cache_key):
-                count = mc.incr(cache_key)
-            else:
-                mc.set(cache_key, 1, expires=ttl)
-                count = 1
+            count = (mc.get(cache_key) or 0) + 1
+            mc.set(cache_key, count, expires=ttl)
             if count > 3:
                 return ratelimit_error(cache_key, ttl)
 
 
     @classmethod
-    def validate(cls, otp, email, ip, client, ts):
-        expected_otp = cls.generate(email, ip, client, ts)
+    def validate(cls, otp, service_ip, client_email, client_ip, ts):
+        expected_otp = cls.generate(service_ip, client_email, client_ip, ts)
         return hmac.compare_digest(otp, expected_otp)
 
     @classmethod
-    def is_valid(cls, email, ip, client, otp):
+    def is_valid(cls, client_email, client_ip, service_ip, otp):
         now_minute = int(time.time() // 60)
         for delta in range(cls.VALID_MINUTES):
-            ts = now_minute - delta
-            if cls.validate(otp, email, ip, client, ts):
+            minute_ts = now_minute - delta
+            if cls.validate(otp, service_ip, client_email, client_ip, minute_ts):
                 return True
         return False
             

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -87,7 +87,7 @@ def setup(config):
     global config_ia_availability_api_v2_url, config_ia_ol_metadata_write_s3
     global config_ia_xauth_api_url, config_http_request_timeout, config_ia_s3_auth_url
     global config_ia_users_loan_history, config_ia_loan_api_developer_key
-    global config_ia_domain, config_fts_context
+    global config_ia_domain, config_otp_seed, config_fts_context
 
     config_bookreader_host = config.get('bookreader_host', 'archive.org')
     config_ia_domain = config.get('ia_base_url', 'https://archive.org')

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -72,6 +72,7 @@ config_ia_s3_auth_url = None
 config_ia_ol_metadata_write_s3 = None
 config_ia_users_loan_history = None
 config_ia_loan_api_developer_key = None
+config_otp_seed = None
 config_http_request_timeout = None
 config_bookreader_host = None
 config_internal_tests_api_key = None
@@ -102,6 +103,7 @@ def setup(config):
     config_ia_s3_auth_url = config.get('ia_s3_auth_url')
     config_ia_users_loan_history = config.get('ia_users_loan_history')
     config_ia_loan_api_developer_key = config.get('ia_loan_api_developer_key')
+    config_otp_seed = config.get('otp_seed')
     config_internal_tests_api_key = config.get('internal_tests_api_key')
     config_http_request_timeout = config.get('http_request_timeout')
     config_fts_context = config.get('fts_context')

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -32,7 +32,7 @@ from openlibrary.accounts import (
 )
 from openlibrary.core import helpers as h
 from openlibrary.core import lending, stats
-from openlibrary.core.auth import TimedOneTimePassword
+from openlibrary.core.auth import TimedOneTimePassword as OTP
 from openlibrary.core.booknotes import Booknotes
 from openlibrary.core.bookshelves import Bookshelves
 from openlibrary.core.follows import PubSub
@@ -452,52 +452,56 @@ class account_login_json(delegate.page):
             from infogami.plugins.api.code import login as infogami_login
 
             infogami_login().POST()
-            
-class otp_service_redeem(delegate.page):
-    path = "/account/otp/redeem"
 
-    def POST(self):
-        web.header('Content-Type', 'application/json')
-        required_keys = ("email", "ip", "client", "otp")
-        i = web.input(email="", ip="", otp="")
-        i.email.replace(" ", "+")
-        i.client = web.ctx.env.get('HTTP_X_FORWARDED_FOR')
-        if missing_fields := (k for k in required_keys if not getattr(i, k)):
-            return delegate.RawText(json.dumps({
-                "error": "missing_keys",
-                "missing_keys": missing_keys
-            }))
-        if TimedOneTimePassword.is_valid(i.email, i.ip, i.client, i.otp):
-            return delegate.RawText(json.dumps({"success": f"{i.otp}"}))
-        return delegate.RawText(json.dumps({"error": "otp_mismatch"}))
 
 class otp_service_issue(delegate.page):
     path = "/account/otp/issue"
 
     def POST(self):
         web.header('Content-Type', 'application/json')
-        i = web.input(email='', ip='', sendmail=False)
-        required_keys = ("email", "ip", "client")
+        i = web.input(email="", ip="", challenge_url="", sendmail='')
+        required_keys = ("email", "ip", "service_ip", "challenge_url")
         i.email = i.email.replace(" ", "+").lower()
-        i.client = web.ctx.env.get('HTTP_X_FORWARDED_FOR')
-        if missing_fields := (k for k in required_keys if not getattr(i, k)):
+        i.service_ip = web.ctx.env.get('HTTP_X_FORWARDED_FOR')        
+        if missing_fields := [k for k in required_keys if not getattr(i, k)]:
             return delegate.RawText(json.dumps({
                 "error": "missing_keys",
-                "missing_keys": missing_keys
+                "missing_keys": missing_fields
             }))
-                
-        if error := is_ratelimited(client=i.client, email=i.email, ip=i.ip):
+        
+        if not OTP.verify_service(i.service_ip, i.challenge_url):
+            return delegate.RawText(json.dumps({"error": "challenge_failed"}))
+        if error := OTP.is_ratelimited(service_ip=i.service_ip, email=i.email, ip=i.ip):
             return delegate.RawText(json.dumps(error))
 
-        otp = self.generate(i.email, i.ip, i.client)
-        if i.sendmail == 'true':
+        otp = OTP.generate(i.service_ip, i.email, i.ip)
+        if i.sendmail.lower() == 'true':
             web.sendmail(
                 config.from_address,
                 i.email,
                 subject="Your One Time Password",
-                message=web.safestr(f"Your one time password is: {i.otp}"),
+                message=web.safestr(f"Your one time password is: {otp}"),
             )
         return delegate.RawText(json.dumps({"success": {"otp": otp}}))
+
+class otp_service_redeem(delegate.page):
+    path = "/account/otp/redeem"
+
+    def POST(self):
+        web.header('Content-Type', 'application/json')
+        required_keys = ("email", "ip", "service_ip", "otp")
+        i = web.input(email="", ip="", otp="")
+        i.email = i.email.replace(" ", "+").lower()
+        i.service_ip = web.ctx.env.get('HTTP_X_FORWARDED_FOR')
+        if missing_fields := [k for k in required_keys if not getattr(i, k)]:
+            return delegate.RawText(json.dumps({
+                "error": "missing_keys",
+                "missing_keys": missing_fields
+            }))
+        if OTP.is_valid(i.email, i.ip, i.service_ip, i.otp):
+            return delegate.RawText(json.dumps({"success": f"{i.otp}"}))
+        raise web.HTTPError({"error": "otp_mismatch"}, {"Content-Type": "application/json"})
+
 
 class account_login(delegate.page):
     """Account login.

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -7,7 +7,7 @@ from enum import Enum
 from math import ceil
 from typing import TYPE_CHECKING, Any, Final
 from urllib.parse import urlparse
-
+        
 import requests
 import web
 
@@ -32,6 +32,7 @@ from openlibrary.accounts import (
 )
 from openlibrary.core import helpers as h
 from openlibrary.core import lending, stats
+from openlibrary.core.auth import TimedOneTimePassword
 from openlibrary.core.booknotes import Booknotes
 from openlibrary.core.bookshelves import Bookshelves
 from openlibrary.core.follows import PubSub
@@ -400,7 +401,7 @@ def _notify_on_rpd_verification(ol_account, org):
             }
         )
 
-
+        
 def _update_account_on_pd_fulfillment(ol_account: OpenLibraryAccount) -> None:
     ol_account.get_user().save_preferences({"rpd": PDRequestStatus.FULFILLED.value})
 
@@ -451,7 +452,52 @@ class account_login_json(delegate.page):
             from infogami.plugins.api.code import login as infogami_login
 
             infogami_login().POST()
+            
+class otp_service_redeem(delegate.page):
+    path = "/account/otp/redeem"
 
+    def POST(self):
+        web.header('Content-Type', 'application/json')
+        required_keys = ("email", "ip", "client", "otp")
+        i = web.input(email="", ip="", otp="")
+        i.email.replace(" ", "+")
+        i.client = web.ctx.env.get('HTTP_X_FORWARDED_FOR')
+        if missing_fields := (k for k in required_keys if not getattr(i, k)):
+            return delegate.RawText(json.dumps({
+                "error": "missing_keys",
+                "missing_keys": missing_keys
+            }))
+        if TimedOneTimePassword.is_valid(i.email, i.ip, i.client, i.otp):
+            return delegate.RawText(json.dumps({"success": f"{i.otp}"}))
+        return delegate.RawText(json.dumps({"error": "otp_mismatch"}))
+
+class otp_service_issue(delegate.page):
+    path = "/account/otp/issue"
+
+    def POST(self):
+        web.header('Content-Type', 'application/json')
+        i = web.input(email='', ip='', sendmail=False)
+        required_keys = ("email", "ip", "client")
+        i.email = i.email.replace(" ", "+").lower()
+        i.client = web.ctx.env.get('HTTP_X_FORWARDED_FOR')
+        if missing_fields := (k for k in required_keys if not getattr(i, k)):
+            return delegate.RawText(json.dumps({
+                "error": "missing_keys",
+                "missing_keys": missing_keys
+            }))
+                
+        if error := is_ratelimited(client=i.client, email=i.email, ip=i.ip):
+            return delegate.RawText(json.dumps(error))
+
+        otp = self.generate(i.email, i.ip, i.client)
+        if i.sendmail == 'true':
+            web.sendmail(
+                config.from_address,
+                i.email,
+                subject="Your One Time Password",
+                message=web.safestr(f"Your one time password is: {i.otp}"),
+            )
+        return delegate.RawText(json.dumps({"success": {"otp": otp}}))
 
 class account_login(delegate.page):
     """Account login.


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes https://github.com/ArchiveLabs/lenny/issues/95

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Prototype to implement Time bound One Time Passwords for Lenny services

Introduces an **email-based One Time Password (OTP) flow** with built-in safeguards.

## Endpoints
<!-- What should be noted about the implementation? -->

### Issue endpoint (`/account/otp/issue`)
- Generates OTPs tied to `(service_ip, email, client_ip, timestamp)`
- Enforces **rate limiting** across email, client IP, and service IP to prevent abuse
- Supports optional `sendmail=true` flag to email the OTP directly to the user

### Redeem endpoint (`/account/otp/redeem`)
- Verifies the submitted OTP against stored/derived values
- Returns success or failure in JSON

## Security & Abuse Prevention
- **Rate limiting**
  - OTPs are scoped per minute (10-second rolling loop across ~10 minutes of validity)
  - Attempts are tracked to mitigate brute-force attacks

- **Challenge check**
  - Proof of Work & Identity? Service must pass a `challenge_url` test (verifying it is a running Lenny server with https that returns json)
  - Blocks unauthorized services from abusing the API

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

From a Lenny service (must be running https)

```
curl -X POST "https://staging.openlibrary.org/account/otp/issue" -d "email=client@example.org&ip=127.0.0.1&challenge_url=https://lennyforlibraries.org/v1/api/items&sendmail=true"
```

```
curl -X POST "https://staging.openlibrary.org/account/otp/redeem" -d "email=client@example.org&ip=127.0.0.1&otp=XXX"
```



### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
