### PR TITLE
Only update `rpd` value if patron requested access via Open Library

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -553,6 +553,7 @@ class account_login(delegate.page):
             has_special_access = audit.get('special_access')
             if (
                 has_special_access
+                and ol_account.get_user().preferences().get('pda', '')
                 and ol_account.get_user().preferences().get('rpd')
                 != PDRequestStatus.FULFILLED.value
             ):


### PR DESCRIPTION
Follows #10899

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
### Background Information

Our `/admin/pd` stats tell us that ~10 patrons have had their special access requests fulfilled (meaning their `rpd` preference has a value of `2`). However, there are over 1,000 patrons who have an `rpd: 2`, but no `pda` authority in the store.

#### Why is this happening?

Whenever _any_ patron logs in, we check the `xauthn` response to see if they have special access.  If they do, we update their `rpd` status to fulfilled.  This is done even if the patron __did not__ request special access via Open Library.  Such patrons can be identified by having a fulfilled `rpd` value, but no `pda` value in their preferences (this stores the patron's chosen print disability qualifying authority).

#### How does this branch help?

This branch will prevent an `rpd` value from being saved to a patron's preference object if they do not already have a `pda` value.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
