### PR TITLE
Enhance mybooks page: add activity feed carousel and improve error ha…

### DIFF
--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -43,10 +43,10 @@ class avatar(delegate.page):
 
 class mybooks_home(delegate.page):
     path = "/people/([^/]+)/books"
-
+    
     def GET(self, username: str) -> TemplateResult:
         """Renders the template for the my books overview page
-
+        
         The other way to get to this page is /account/books which is
         defined in /plugins/account.py account_my_books. But we don't
         need to update that redirect because it already just redirects
@@ -55,11 +55,11 @@ class mybooks_home(delegate.page):
         mb = MyBooksTemplate(username, key='mybooks')
         template = self.render_template(mb)
         return mb.render(header_title=_("Books"), template=template)
-
+    
     def render_template(self, mb):
         # Marshal loans into homogeneous data that carousel can render
         want_to_read, currently_reading, already_read, loans = [], [], [], []
-
+        
         if mb.me:
             myloans = get_loans_of_user(mb.me.key)
             loans = web.Storage({"docs": [], "total_results": len(myloans)})
@@ -69,13 +69,13 @@ class mybooks_home(delegate.page):
                 if book := web.ctx.site.get(loan['book']):
                     book.loan = loan
                     loans.docs.append(book)
-
+        
         if mb.me or mb.is_public:
             params = {'sort': 'created', 'limit': 6, 'sort_order': 'desc', 'page': 1}
             want_to_read = mb.readlog.get_works(key='want-to-read', **params)
             currently_reading = mb.readlog.get_works(key='currently-reading', **params)
             already_read = mb.readlog.get_works(key='already-read', **params)
-
+            
             # Ideally, do all 3 lookups in one add_availability call
             want_to_read.docs = add_availability(
                 [d for d in want_to_read.docs if d.get('title')]
@@ -86,13 +86,15 @@ class mybooks_home(delegate.page):
             already_read.docs = add_availability(
                 [d for d in already_read.docs if d.get('title')]
             )[:5]
-
+        
         docs = {
             'loans': loans,
             'want-to-read': want_to_read,
             'currently-reading': currently_reading,
             'already-read': already_read,
+            'activity-feed': PubSub.get_feed(mb.username, limit=10),
         }
+        
         return render['account/mybooks'](
             mb.user,
             docs,
@@ -103,8 +105,6 @@ class mybooks_home(delegate.page):
             lists=mb.lists,
             component_times=mb.component_times,
         )
-
-
 class mybooks_notes(delegate.page):
     path = "/people/([^/]+)/books/notes"
 

--- a/openlibrary/templates/account/mybooks.html
+++ b/openlibrary/templates/account/mybooks.html
@@ -13,6 +13,9 @@ $def year_span(year, use_local_year=False):
   $code:
       def compact_carousel(data):
           key, title, url = data
+          # Check if the key exists to prevent errors
+          if key not in mybooks:
+              return None
           books = mybooks[key].docs
           count = mybooks[key].total_results
           return render_template("books/custom_carousel", **{
@@ -31,11 +34,12 @@ $def year_span(year, use_local_year=False):
     <div class="carousel-section-header">
       <h2 class="home-h2"><a name="$key" href="$url">$title</a></h2>
     </div>
-    <p>$_("No books are on this shelf")</p>
+    <p>$_("No items are on this shelf")</p>
 
   $# Data for carousels
   $ readlog_url = "/people/%s/books/" % username
   $ loans = ["loans", _('My Loans'), "/account/loans"]
+  $ activity_feed = ["activity-feed", _('Activity Feed'), "/people/%s/books/feed" % username]
   $ currently_reading = ["currently-reading", _('Currently Reading'), readlog_url + "currently-reading"]
   $ want_to_read = ["want-to-read", _('Want to Read'), readlog_url + "want-to-read"]
   $ already_read = ["already-read", _('Already Read'), readlog_url + "already-read"]
@@ -43,6 +47,8 @@ $def year_span(year, use_local_year=False):
   $# Render carousels
   $if owners_page:
     $:(compact_carousel(loans) or empty_carousel(loans))
+    $# Render the Activity Feed carousel
+    $:(compact_carousel(activity_feed) or empty_carousel(activity_feed))
   $if owners_page or public:
     $:(compact_carousel(currently_reading) or empty_carousel(currently_reading))
     $:(compact_carousel(want_to_read) or empty_carousel(want_to_read))
@@ -55,6 +61,9 @@ $def year_span(year, use_local_year=False):
 $code:
     def mobile_carousel(data):
         key, title, url = data
+        # Check if the key exists to prevent errors
+        if key not in mybooks:
+            return None
         books = mybooks[key].docs
         count = mybooks[key].total_results
         return render_template("books/mobile_carousel", **{
@@ -81,6 +90,10 @@ $def empty_mobile_carousel(data):
         <li>
           $# Render carousel
           $:(mobile_carousel(loans) or empty_mobile_carousel(loans))
+        </li>
+        <li>
+          $# Render carousel for Activity Feed
+          $:(mobile_carousel(activity_feed) or empty_mobile_carousel(activity_feed))
         </li>
         <li>
           $ year = current_year()
@@ -177,4 +190,3 @@ $def empty_mobile_carousel(data):
   </div>
   <p></p>
   $ component_times['Sidebar'] = time() - component_times['Sidebar']
-


### PR DESCRIPTION
Closes #10242

### [feature] Add Activity Feed Carousel to My Books Page

This PR introduces a proof-of-concept **"Activity Feed" carousel** to the "My Books" summary page (`/account/books`).

It fetches the latest book-related updates from users that the current user follows and displays them in a new carousel. This enhances the social and discovery aspects of the "My Books" page, as requested in the issue.

### Technical
-   Modified `openlibrary/accounts/mybooks.py`: The `mybooks_home` controller now fetches the first page of feed items (limited to 10) using `PubSub.get_feed()`.
-   The fetched data is added to the `docs` dictionary under the key `'activity-feed'`, which is then passed to the template.
-   Updated `openlibrary/templates/account/mybooks.html`: Added the "Activity Feed" carousel definition and rendering logic for both desktop and mobile views, reusing the existing `compact_carousel` and `mobile_carousel` patterns.

### Testing

### Screenshot

### Stakeholders
@ragipidavid @krishnaGauss 