### PR TITLE
Fix `/developers/routes` page

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -220,7 +220,6 @@ class routes(delegate.page):
 
         return '<pre>%s</pre>' % json.dumps(
             code.delegate.pages,
-            sort_keys=True,
             cls=ModulesToStr,
             indent=4,
             separators=(',', ': '),


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11258 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR fixes an error where contents of the developers/routes page failed to load. 

### Technical
<!-- What should be noted about the implementation? -->
Updated openlibrary/openlibrary/plugins/openlibrary/code.py by removing 'sort_keys=True' from the json.dumps() call

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Run openlibrary from docker. Navigate to localhost:8080/developers/routes to confirm that the page loads normally. 

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="1262" height="743" alt="Screenshot 2025-09-21 at 18 14 14" src="https://github.com/user-attachments/assets/e2047a77-ac66-4cf2-aa63-f4acc24c2aae" />

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
