### PR TITLE
Open tag creation and editing to curators

### DIFF
--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -955,6 +955,9 @@ class User(Thing):
     def is_read_only(self) -> bool:
         return self.is_usergroup_member('/usergroup/read-only')
 
+    def is_curator(self) -> bool:
+        return self.is_usergroup_member('/usergroup/curators')
+
     def get_lists(self, seed=None, limit=100, offset=0, sort=True):
         """Returns all the lists of this user.
 

--- a/openlibrary/plugins/upstream/addtag.py
+++ b/openlibrary/plugins/upstream/addtag.py
@@ -95,7 +95,7 @@ class addtag(delegate.page):
         """
         Returns True if the given user can create a new Tag
         """
-        return user and user.is_admin()
+        return user and user.is_admin() or user.is_curator()
 
     def POST(self):
         i = web.input(
@@ -212,7 +212,7 @@ class tag_edit(delegate.page):
         if not (patron := get_current_user()):
             return False
 
-        is_in_permitted_group = patron.is_admin()
+        is_in_permitted_group = patron.is_admin() or patron.is_curator()
         is_deputy = patron.key == tag.get("deputy", None)
 
         if is_in_permitted_group:

--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -2,7 +2,7 @@ $def with (page)
 
 $var title: $page.name
 
-$ can_add_tag = ctx.user and (ctx.user.is_admin())
+$ can_add_tag = ctx.user and (ctx.user.is_admin() or ctx.user.is_curator())
 $ has_tag = 'tag' in page
 $ q = query_param('q')
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11286

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Updates code such that `/usergroup/curators` members and add and edit `Tag` objects.
Adds new `is_curator()` method to the `User` model.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Business as usual tests:
- [ ] `admin` can create a new tag
- [ ] `admin` can edit an existing tag
- [ ] Edit button appears on subject pages for `admin` usergroup members

New functionality:
- [ ] `curator` can create a new tag
- [ ] `curator` can edit an existing tag
- [ ] Edit button appears on subject pages for `curators` usergroup members

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
