### PR TITLE
Add missing SOLR_MODULES environment variables to solr_builder's solr_prod service

### DIFF
--- a/scripts/solr_builder/compose.yaml
+++ b/scripts/solr_builder/compose.yaml
@@ -62,6 +62,7 @@ services:
         -Dsolr.autoSoftCommit.maxTime=60000
         -Dsolr.autoCommit.maxTime=120000
         -Dsolr.max.booleanClauses=30000
+      - SOLR_MODULES=analysis-extras
       # More memory for production
       - SOLR_JAVA_MEM=-Xms10g -Xmx10g
     volumes:


### PR DESCRIPTION
While working on the next solr reindex, noticed this environment variable was missing and preventing this from starting up.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
