### PR TITLE
Don't hit affiliate server on /isbn

### DIFF
--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -397,7 +397,10 @@ class Edition(Thing):
 
     @classmethod
     def from_isbn(
-        cls, isbn_or_asin: str, high_priority: bool = False
+        cls,
+        isbn_or_asin: str,
+        high_priority: bool = False,
+        allow_import: bool = False,
     ) -> "Edition | None":
         """
         Attempts to fetch an edition by ISBN or ASIN, or if no edition is found, then
@@ -430,23 +433,28 @@ class Edition(Thing):
                 return web.ctx.site.get(matches[0])
 
         # Attempt to fetch the book from the import_item table
-        if edition := ImportItem.import_first_staged(identifiers=book_ids):
-            return edition
+        if allow_import:
+            if edition := ImportItem.import_first_staged(identifiers=book_ids):
+                return edition
 
-        # Finally, try to fetch the book data from Amazon + import.
-        # If `high_priority=True`, then the affiliate-server, which `get_amazon_metadata()`
-        # uses, will block + wait until the Product API responds and the result, if any,
-        # is staged in `import_item`.
-        try:
-            id_ = asin or book_ids[0]
-            id_type = "asin" if asin else "isbn"
-            get_amazon_metadata(id_=id_, id_type=id_type, high_priority=high_priority)
-            return ImportItem.import_first_staged(identifiers=book_ids)
-        except requests.exceptions.ConnectionError:
-            logger.exception("Affiliate Server unreachable")
-        except requests.exceptions.HTTPError:
-            logger.exception(f"Affiliate Server: id {id_} not found")
-        return None
+            # Finally, try to fetch the book data from Amazon + import.
+            # If `high_priority=True`, then the affiliate-server, which `get_amazon_metadata()`
+            # uses, will block + wait until the Product API responds and the result, if any,
+            # is staged in `import_item`.
+            try:
+                id_ = asin or book_ids[0]
+                id_type = "asin" if asin else "isbn"
+                get_amazon_metadata(
+                    id_=id_, id_type=id_type, high_priority=high_priority
+                )
+                return ImportItem.import_first_staged(identifiers=book_ids)
+            except requests.exceptions.ConnectionError:
+                logger.exception("Affiliate Server unreachable")
+            except requests.exceptions.HTTPError:
+                logger.exception(f"Affiliate Server: id {id_} not found")
+            return None
+        else:
+            return None
 
     def is_ia_scan(self):
         metadata = self.get_ia_meta_fields()

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -687,7 +687,9 @@ class isbn_lookup(delegate.page):
             ext += '?' + web.ctx.env['QUERY_STRING']
 
         try:
-            if ed := Edition.from_isbn(isbn_or_asin=isbn, high_priority=high_priority):
+            if ed := Edition.from_isbn(
+                isbn_or_asin=isbn, high_priority=high_priority, allow_import=False
+            ):
                 return web.found(ed.key + ext)
         except Exception as e:
             logger.error(e)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11280 . This remove the auto-import of the `/isbn`. Note the greatest fix long term. We should create a separate issue to investigate how to re-enable. But this did appear to resolve our traffic issues, while still keeping the `/isbn` point up for finding books.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
