### PR TITLE
List Card Async Follow Functionality

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -292,12 +292,16 @@ msgstr ""
 msgid "Go to next section"
 msgstr ""
 
-#: Follow.html
-msgid "UnfollowFollow"
-msgstr ""
-
 #: Follow.html lists/list_follow.html
 msgid "Follow"
+msgstr ""
+
+#: Follow.html
+msgid "Unfollow"
+msgstr ""
+
+#: Follow.html
+msgid "UnfollowFollow"
 msgstr ""
 
 #: FormatExpiry.html
@@ -6301,6 +6305,14 @@ msgstr ""
 
 #: lists/home.html lists/showcase.html lists/widget.html
 msgid "See all"
+msgstr ""
+
+#: lists/list_follow.html
+msgid "Cover of book"
+msgstr ""
+
+#: lists/list_follow.html
+msgid "Avatar of the owner of the list"
 msgstr ""
 
 #: lists/list_follow.html lists/widget.html my_books/dropdown_content.html

--- a/openlibrary/macros/Follow.html
+++ b/openlibrary/macros/Follow.html
@@ -4,7 +4,6 @@ $ i18n_strings = {
 $   'follow': _('Follow'),
 $   'unfollow': _('Unfollow')
 $ }
-
 $ subscriber = ctx.user and ctx.user.key
 $ custom_request_path = request_path if request_path != '' else request.fullpath
 <div>
@@ -15,10 +14,7 @@ $ custom_request_path = request_path if request_path != '' else request.fullpath
       <input type="hidden" value="$publisher" name="publisher"/>
       <input type="hidden" value="$custom_request_path" name="redir_url"/>
       $ css_treatment = 'delete' if following else 'primary'
-      $if following: 
-        <button type="submit" class="cta-btn cta-btn--$(css_treatment)" data-i18n="$json_encode(i18n_strings)">$_("Unfollow")</button> 
-      $else:
-        <button type="submit" class="cta-btn cta-btn--$(css_treatment)" data-i18n="$json_encode(i18n_strings)" >$_("Follow")</button>
+      <button type="submit" class="cta-btn cta-btn--$(css_treatment)" data-i18n="$json_encode(i18n_strings)">$_("Unfollow" if following else "Follow")</button>
     </form>
   $else:
     <a class="cta-btn cta-btn--primary" href="/account/login?redir_url=$(ctx.path)&action=follow:$(publisher)">$_("Follow")</a>

--- a/openlibrary/macros/Follow.html
+++ b/openlibrary/macros/Follow.html
@@ -1,5 +1,10 @@
 $def with (publisher, fid='', following=False, request_path='')
 
+$ i18n_strings = {
+$   'follow': _('Follow'),
+$   'unfollow': _('Unfollow')
+$ }
+
 $ subscriber = ctx.user and ctx.user.key
 $ custom_request_path = request_path if request_path != '' else request.fullpath
 <div>
@@ -10,7 +15,10 @@ $ custom_request_path = request_path if request_path != '' else request.fullpath
       <input type="hidden" value="$publisher" name="publisher"/>
       <input type="hidden" value="$custom_request_path" name="redir_url"/>
       $ css_treatment = 'delete' if following else 'primary'
-      <button type="submit" class="cta-btn cta-btn--$(css_treatment)">$_("Unfollow" if following else "Follow")</button>
+      $if following: 
+        <button type="submit" class="cta-btn cta-btn--$(css_treatment)" data-i18n="$json_encode(i18n_strings)">$_("Unfollow")</button> 
+      $else:
+        <button type="submit" class="cta-btn cta-btn--$(css_treatment)" data-i18n="$json_encode(i18n_strings)" >$_("Follow")</button>
     </form>
   $else:
     <a class="cta-btn cta-btn--primary" href="/account/login?redir_url=$(ctx.path)&action=follow:$(publisher)">$_("Follow")</a>

--- a/openlibrary/macros/Follow.html
+++ b/openlibrary/macros/Follow.html
@@ -4,6 +4,7 @@ $ i18n_strings = {
 $   'follow': _('Follow'),
 $   'unfollow': _('Unfollow')
 $ }
+
 $ subscriber = ctx.user and ctx.user.key
 $ custom_request_path = request_path if request_path != '' else request.fullpath
 <div>

--- a/openlibrary/plugins/openlibrary/js/book-page-lists.js
+++ b/openlibrary/plugins/openlibrary/js/book-page-lists.js
@@ -91,6 +91,12 @@ async function initAsyncFollowing(elem, followForms) {
             const formData = new FormData(form);
             const publisherField = form.querySelector('input[name=publisher]');
             const publisher = publisherField.value;
+            const followButtonRefs = []
+            followForms.forEach(followForm => {
+                const followButton = followForm.querySelector('button');
+                followButton.disabled = true;
+                followButtonRefs.push(followButton)
+            });
             fetch(url, {
                 method: 'POST',
                 headers: {
@@ -107,7 +113,6 @@ async function initAsyncFollowing(elem, followForms) {
                         if (publisherField.value === publisher) {
                             const followButton = followForm.querySelector('button');
                             const i18nStrings = JSON.parse(followButton.dataset.i18n)
-                            followButton.disabled = true;
                             if (followButton.classList.contains('cta-btn--delete')) {
                                 followButton.classList.remove('cta-btn--delete');
                                 followButton.classList.add('cta-btn--primary');
@@ -127,13 +132,9 @@ async function initAsyncFollowing(elem, followForms) {
                     new PersistentToast('Failed to update followers.  Please try again in a few moments.').show();
                 })
                 .finally(() => {
-                    followForms.forEach(followForm => {
-                        const publisherField = followForm.querySelector('input[name=publisher]');
-                        if (publisherField.value === publisher) {
-                            const followButton = followForm.querySelector('button');
-                            followButton.disabled = false;
-                        }
-                    });
+                   followButtonRefs.forEach(followButtonRef => {
+                      followButtonRef.disabled = false
+                   }) 
                 });
         });
     });

--- a/openlibrary/plugins/openlibrary/js/book-page-lists.js
+++ b/openlibrary/plugins/openlibrary/js/book-page-lists.js
@@ -44,8 +44,9 @@ export function initListsSection(elem) {
                         }
                         // Initialize private buttons after content is loaded
                         initPrivateButtonsAfterLoad(listSection)
+
                         const followForms = listSection.querySelectorAll('.follow-form');
-                        initAsyncFollowing(elem, followForms)
+                        initAsyncFollowing(followForms)
                     })
             }
         })
@@ -83,7 +84,8 @@ async function fetchPartials(workId, editionId) {
 
     return fetch(buildPartialsUrl('BPListsSection', params));
 }
-async function initAsyncFollowing(elem, followForms) {
+
+async function initAsyncFollowing(followForms) {
     followForms.forEach(form => {
         form.addEventListener('submit', async e => {
             e.preventDefault();
@@ -92,11 +94,13 @@ async function initAsyncFollowing(elem, followForms) {
             const publisherField = form.querySelector('input[name=publisher]');
             const publisher = publisherField.value;
             const followButtonRefs = []
+
             followForms.forEach(followForm => {
                 const followButton = followForm.querySelector('button');
                 followButton.disabled = true;
                 followButtonRefs.push(followButton)
             });
+
             fetch(url, {
                 method: 'POST',
                 headers: {
@@ -108,11 +112,14 @@ async function initAsyncFollowing(elem, followForms) {
                     if (!resp.ok) {
                         throw new Error('Network response was not ok');
                     }
+
                     followForms.forEach(followForm => {
                         const publisherField = followForm.querySelector('input[name=publisher]');
+
                         if (publisherField.value === publisher) {
                             const followButton = followForm.querySelector('button');
                             const i18nStrings = JSON.parse(followButton.dataset.i18n)
+
                             if (followButton.classList.contains('cta-btn--delete')) {
                                 followButton.classList.remove('cta-btn--delete');
                                 followButton.classList.add('cta-btn--primary');
@@ -123,7 +130,8 @@ async function initAsyncFollowing(elem, followForms) {
                                 followButton.classList.add('cta-btn--delete');
                                 followButton.innerText = i18nStrings.unfollow 
                             }
-                            const stateInput = elem.querySelector('input[name=state]');
+
+                            const stateInput = followForm.querySelector('input[name=state]');
                             stateInput.value = 1 - stateInput.value;
                         }
                     });

--- a/openlibrary/plugins/openlibrary/js/book-page-lists.js
+++ b/openlibrary/plugins/openlibrary/js/book-page-lists.js
@@ -44,6 +44,8 @@ export function initListsSection(elem) {
                         }
                         // Initialize private buttons after content is loaded
                         initPrivateButtonsAfterLoad(listSection)
+                        const followForms = listSection.querySelectorAll('.follow-form');
+                        initAsyncFollowing(elem, followForms)
                     })
             }
         })
@@ -80,4 +82,59 @@ async function fetchPartials(workId, editionId) {
     }
 
     return fetch(buildPartialsUrl('BPListsSection', params));
+}
+async function initAsyncFollowing(elem, followForms) {
+    followForms.forEach(form => {
+        form.addEventListener('submit', async e => {
+            e.preventDefault();
+            const url = form.action;
+            const formData = new FormData(form);
+            const publisherField = form.querySelector('input[name=publisher]');
+            const publisher = publisherField.value;
+            fetch(url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                },
+                body: new URLSearchParams(formData)
+            })
+                .then(resp => {
+                    if (!resp.ok) {
+                        throw new Error('Network response was not ok');
+                    }
+                    followForms.forEach(followForm => {
+                        const publisherField = followForm.querySelector('input[name=publisher]');
+                        if (publisherField.value === publisher) {
+                            const followButton = followForm.querySelector('button');
+                            const i18nStrings = JSON.parse(followButton.dataset.i18n)
+                            followButton.disabled = true;
+                            if (followButton.classList.contains('cta-btn--delete')) {
+                                followButton.classList.remove('cta-btn--delete');
+                                followButton.classList.add('cta-btn--primary');
+                                followButton.innerText = i18nStrings.follow 
+                            }
+                            else {
+                                followButton.classList.remove('cta-btn--primary');
+                                followButton.classList.add('cta-btn--delete');
+                                followButton.innerText = i18nStrings.unfollow 
+                            }
+                            const stateInput = elem.querySelector('input[name=state]');
+                            stateInput.value = 1 - stateInput.value;
+                        }
+                    });
+                })
+                .catch((error) => {
+                    new PersistentToast('Failed to update followers.  Please try again in a few moments.').show();
+                })
+                .finally(() => {
+                    followForms.forEach(followForm => {
+                        const publisherField = followForm.querySelector('input[name=publisher]');
+                        if (publisherField.value === publisher) {
+                            const followButton = followForm.querySelector('button');
+                            followButton.disabled = false;
+                        }
+                    });
+                });
+        });
+    });
 }

--- a/openlibrary/plugins/openlibrary/js/book-page-lists.js
+++ b/openlibrary/plugins/openlibrary/js/book-page-lists.js
@@ -1,5 +1,5 @@
 import { buildPartialsUrl } from './utils'
-
+import { PersistentToast } from './Toast'
 /**
  * Initializes lazy-loading the "Lists" section of Open Library book pages.
  *
@@ -123,12 +123,12 @@ async function initAsyncFollowing(followForms) {
                             if (followButton.classList.contains('cta-btn--delete')) {
                                 followButton.classList.remove('cta-btn--delete');
                                 followButton.classList.add('cta-btn--primary');
-                                followButton.innerText = i18nStrings.follow 
+                                followButton.innerText = i18nStrings.follow
                             }
                             else {
                                 followButton.classList.remove('cta-btn--primary');
                                 followButton.classList.add('cta-btn--delete');
-                                followButton.innerText = i18nStrings.unfollow 
+                                followButton.innerText = i18nStrings.unfollow
                             }
 
                             const stateInput = followForm.querySelector('input[name=state]');

--- a/openlibrary/plugins/openlibrary/js/book-page-lists.js
+++ b/openlibrary/plugins/openlibrary/js/book-page-lists.js
@@ -136,13 +136,13 @@ async function initAsyncFollowing(followForms) {
                         }
                     });
                 })
-                .catch((error) => {
+                .catch(() => {
                     new PersistentToast('Failed to update followers.  Please try again in a few moments.').show();
                 })
                 .finally(() => {
-                   followButtonRefs.forEach(followButtonRef => {
-                      followButtonRef.disabled = false
-                   }) 
+                    followButtonRefs.forEach(followButtonRef => {
+                        followButtonRef.disabled = false
+                    })
                 });
         });
     });

--- a/openlibrary/templates/lists/list_follow.html
+++ b/openlibrary/templates/lists/list_follow.html
@@ -21,19 +21,20 @@ $def list_card(list, owner, own_list):
                    $ img_url = img_url.replace("-S.jpg", "-M.jpg")
                $else:
                    $ img_url = '/images/icons/avatar_book-sm.png'
-               <img src="$img_url" loading="lazy" width="80"/>
+               <img src="$img_url" alt="$_('Cover of book')" loading="lazy" width="80"/>
         </a>
 
         <!-- Bottom section: owner info or community label -->
         $if owner:
             <div class="list-follow-card__bottom">
                 <div class="list-follow-card__user">
+
+                            $ owner_username = owner.key.split('/')[-1]
                     <a href="$owner.key">
-                        <img src="$(owner.key)/avatar" />
+                        <img src="$(owner.key)/avatar" alt="$_('Avatar of the owner of the list')" />
                     </a>
                     <div class="list-follow-card__username">
                         $if not own_list:
-                            $ owner_username = owner.key.split('/')[-1]
                             <a class="list-follow-card__username-link" href="$owner.key" title="$owner_username">
                                 @${owner_username}
                             </a>
@@ -45,7 +46,6 @@ $def list_card(list, owner, own_list):
                 </div>
                 <div class="list-follow-card__follow-button">
                     $if not own_list:
-                        $ owner_username = owner.key.split('/')[-1]
                         $ owner_account = get_user_object(owner_username)
                         $ is_subscribed = ctx.user and ctx.user.is_subscribed_user(owner_username)
                         $ settings = owner_account.get_users_settings()


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10945

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Refactor

### Technical
<!-- What should be noted about the implementation? -->
I made several changes to improve the code that I wrote for #11093 which was a refactor of #9509. Our goal is to make the action of following new users as seamless as possible and the fixes in this PR help refactor some of the code written to implement the async following functionality so that users don't get redirected to profile page of the user that they just followed or unfollowed.

The main changes that were made in this PR:

- Added internationalization
- Disabled the follow buttons after one was clicked and enabled after the follow/unfollow request was completed
- Renamed several variables for consistency/readability
- Created a separate initAsyncFollowing method to make the initListSection more concise and the book-page-lists.js file easier to read
- Changed the ajax request to a fetch request.
- Removed a lot of the declared variables prior to making the POST request and instead used the form as the input for the POST request 
- Instead of indexing a class from a button which is easily breakable, I queried the class using contains instead. 
- Reverted the code in api.py so that we can address the issue in it in another PR

Change I did not make:
- https://github.com/internetarchive/openlibrary/pull/11093#discussion_r2255613091
- This is needed in case there are multiple lists by the same publisher and so that the follow/unfollow buttons change in other lists as well. I am open to suggestions on improving this code in case this can be rewritten. 

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Copied from #10926: 

1. Create a test account
2. Create a test list and add a book to it under the test account
3. Return to main account
4. Go to book page of the book that has been added to the test list
5. Follow user by clicking on the follow button on the list card.
6. Follow icon will negate and the page won't refresh/redirect
7. Go to the user's account in a separate tab and confirm that follow/unfollow action has been registered. 

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
https://www.loom.com/share/ecca57f343a34bd1a6185f8cd6266acb?sid=0d6b52ad-93fa-4483-bd30-58e8a1b07324

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles @jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
