### PR TITLE
Label more solr queries for monitoring + some SubjectEngine, QueryLabel refactoring

### DIFF
--- a/openlibrary/macros/RawQueryCarousel.html
+++ b/openlibrary/macros/RawQueryCarousel.html
@@ -56,7 +56,7 @@ $else:
       if has_fulltext_only:
         params['has_fulltext'] = 'true'
 
-      results = work_search(params, fields = ",".join(fields), sort=sort, limit=limit, facet=False, query_label='BOOK_CAROUSEL')
+      results = work_search(params, fields = ",".join(fields), sort=sort, limit=limit, facet=False, request_label='BOOK_CAROUSEL')
       books = [storage(b) for b in (results.get('docs', []))]
       load_more = {
         "queryType": "SEARCH",

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -238,7 +238,7 @@ class SearchFacetsPartial(PartialDataHandler):
             rows=0,
             spellcheck_count=3,
             facet=True,
-            query_label='BOOK_SEARCH_FACETS',
+            request_label='BOOK_SEARCH_FACETS',
         )
 
         sidebar = render_template(

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -528,6 +528,7 @@ class Author(models.Author):
             has_fulltext=i.mode == "ebooks",
             query=q,
             facet=True,
+            request_label='AUTHOR_BOOKS_PAGE',
         )
 
     def get_work_count(self):

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -603,7 +603,7 @@ class Work(models.Work):
         solr = get_solr()
         stats.begin("solr", get=self.key, fields=fields)
         try:
-            return solr.get(self.key, fields=fields)
+            return solr.get(self.key, fields=fields, request_label='GET_WORK_SOLR_DATA')
         except Exception:
             logging.getLogger("openlibrary").exception("Failed to get solr data")
             return None

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -45,6 +45,7 @@ from openlibrary.utils.isbn import normalize_isbn
 from openlibrary.utils.solr import (
     DEFAULT_PASS_TIME_ALLOWED,
     DEFAULT_SOLR_TIMEOUT_SECONDS,
+    SolrRequestLabel,
 )
 
 logger = logging.getLogger("openlibrary.worksearch")
@@ -193,27 +194,6 @@ def get_remembered_layout():
         return cookie_value
 
     return 'details'
-
-
-SolrRequestLabel = Literal[
-    'UNLABELLED',
-    'BOOK_SEARCH',
-    'BOOK_SEARCH_API',
-    'BOOK_SEARCH_FACETS',
-    'BOOK_CAROUSEL',
-    # Subject, publisher pages
-    'SUBJECT_ENGINE_PAGE',
-    'SUBJECT_ENGINE_API',
-    # Used for the internal request made by solr to choose the best edition
-    # during a normal book search
-    'EDITION_MATCH',
-    'LIST_SEARCH',
-    'LIST_SEARCH_API',
-    'SUBJECT_SEARCH',
-    'SUBJECT_SEARCH_API',
-    'AUTHOR_SEARCH',
-    'AUTHOR_SEARCH_API',
-]
 
 
 def run_solr_query(  # noqa: PLR0912

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -201,6 +201,9 @@ SolrRequestLabel = Literal[
     'BOOK_SEARCH_API',
     'BOOK_SEARCH_FACETS',
     'BOOK_CAROUSEL',
+    # Subject, publisher pages
+    'SUBJECT_ENGINE_PAGE',
+    'SUBJECT_ENGINE_API',
     # Used for the internal request made by solr to choose the best edition
     # during a normal book search
     'EDITION_MATCH',

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -626,6 +626,7 @@ def works_by_author(
     facet=False,
     has_fulltext=False,
     query: str | None = None,
+    request_label: SolrRequestLabel = 'UNLABELLED',
 ):
     param = {'q': query or '*:*'}
     if has_fulltext:
@@ -646,6 +647,7 @@ def works_by_author(
                 "time_facet",
             ]
         ),
+        request_label=request_label,
         fields=list(
             WorkSearchScheme.default_fetched_fields | {'editions', 'providers'}
         ),

--- a/openlibrary/plugins/worksearch/languages.py
+++ b/openlibrary/plugins/worksearch/languages.py
@@ -2,7 +2,8 @@
 
 import json
 import logging
-from typing import Literal
+from dataclasses import dataclass
+from typing import Literal, override
 
 import web
 
@@ -140,7 +141,15 @@ class language_search(delegate.page):
         return [process(p) for p in language_facets]
 
 
+@dataclass
 class LanguageEngine(subjects.SubjectEngine):
+    name: str = "language"
+    key: str = "languages"
+    prefix: str = "/languages/"
+    facet: str = "language"
+    facet_key: str = "language"
+
+    @override
     def normalize_key(self, key):
         return key
 
@@ -160,13 +169,4 @@ class LanguageEngine(subjects.SubjectEngine):
 
 
 def setup():
-    subjects.SUBJECTS.append(
-        subjects.SubjectMeta(
-            name="language",
-            key="languages",
-            prefix="/languages/",
-            facet="language",
-            facet_key="language",
-            Engine=LanguageEngine,
-        )
-    )
+    subjects.SUBJECTS.append(LanguageEngine())

--- a/openlibrary/plugins/worksearch/publishers.py
+++ b/openlibrary/plugins/worksearch/publishers.py
@@ -1,6 +1,8 @@
 """Publisher pages"""
 
 import logging
+from dataclasses import dataclass
+from typing import override
 
 import web
 
@@ -82,7 +84,15 @@ class publisher_search(delegate.page):
         ]
 
 
+@dataclass
 class PublisherEngine(subjects.SubjectEngine):
+    name: str = "publisher"
+    key: str = "publishers"
+    prefix: str = "/publishers/"
+    facet: str = "publisher_facet"
+    facet_key: str = "publisher_facet"
+
+    @override
     def normalize_key(self, key):
         return key
 
@@ -102,13 +112,4 @@ class PublisherEngine(subjects.SubjectEngine):
 
 
 def setup():
-    subjects.SUBJECTS.append(
-        subjects.SubjectMeta(
-            name="publisher",
-            key="publishers",
-            prefix="/publishers/",
-            facet="publisher_facet",
-            facet_key="publisher_facet",
-            Engine=PublisherEngine,
-        )
-    )
+    subjects.SUBJECTS.append(PublisherEngine())

--- a/openlibrary/plugins/worksearch/publishers.py
+++ b/openlibrary/plugins/worksearch/publishers.py
@@ -19,7 +19,11 @@ class publishers(subjects.subjects):
 
     def GET(self, key):
         key = key.replace("_", " ")
-        page = subjects.get_subject(key, details=True)
+        page = subjects.get_subject(
+            key,
+            details=True,
+            request_label='SUBJECT_ENGINE_PAGE',
+        )
 
         if not page or page.work_count == 0:
             web.ctx.status = "404 Not Found"

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -11,9 +11,9 @@ from infogami.utils import delegate
 from infogami.utils.view import render_template, safeint
 from openlibrary.core.lending import add_availability
 from openlibrary.core.models import Subject, Tag
-from openlibrary.plugins.worksearch.code import SolrRequestLabel
 from openlibrary.solr.query_utils import query_dict_to_str
 from openlibrary.utils import str_to_key
+from openlibrary.utils.solr import SolrRequestLabel
 
 __all__ = ["SubjectEngine", "get_subject"]
 

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -11,6 +11,7 @@ from infogami.utils import delegate
 from infogami.utils.view import render_template, safeint
 from openlibrary.core.lending import add_availability
 from openlibrary.core.models import Subject, Tag
+from openlibrary.plugins.worksearch.code import SolrRequestLabel
 from openlibrary.solr.query_utils import query_dict_to_str
 from openlibrary.utils import str_to_key
 
@@ -35,6 +36,7 @@ class subjects(delegate.page):
             details=True,
             filters={'public_scan_b': 'false', 'lending_edition_s': '*'},
             sort=web.input(sort='readinglog').sort,
+            request_label='SUBJECT_ENGINE_PAGE',
         )
 
         delegate.context.setdefault('cssfile', 'subject')
@@ -80,6 +82,7 @@ class subjects(delegate.page):
 class subjects_json(delegate.page):
     path = '(/subjects/[^/]+)'
     encoding = 'json'
+    solr_label: SolrRequestLabel = 'SUBJECT_ENGINE_API'
 
     @jsonapi
     def GET(self, key):
@@ -122,6 +125,7 @@ class subjects_json(delegate.page):
             limit=i.limit,
             sort=i.sort,
             details=i.details.lower() == 'true',
+            request_label='SUBJECT_ENGINE_API',
             **filters,
         )
         if i.has_fulltext == 'true':
@@ -162,6 +166,7 @@ def get_subject(
     offset=0,
     sort='editions',
     limit=DEFAULT_RESULTS,
+    request_label: SolrRequestLabel = 'UNLABELLED',
     **filters,
 ) -> Subject:
     """Returns data related to a subject.
@@ -230,6 +235,7 @@ def get_subject(
         offset=offset,
         sort=sort,
         limit=limit,
+        request_label=request_label,
         **filters,
     )
 
@@ -249,6 +255,7 @@ class SubjectEngine:
         offset=0,
         limit=DEFAULT_RESULTS,
         sort='new',
+        request_label: SolrRequestLabel = 'UNLABELLED',
         **filters,
     ):
         # Circular imports are everywhere -_-
@@ -272,6 +279,7 @@ class SubjectEngine:
                 ),
                 **filters,
             },
+            request_label=request_label,
             offset=offset,
             rows=limit,
             sort=sort,

--- a/openlibrary/utils/solr.py
+++ b/openlibrary/utils/solr.py
@@ -3,7 +3,7 @@
 import logging
 import re
 from collections.abc import Callable, Iterable
-from typing import TypeVar
+from typing import Literal, TypeVar
 from urllib.parse import urlencode, urlsplit
 
 import requests
@@ -16,6 +16,29 @@ T = TypeVar('T')
 
 DEFAULT_SOLR_TIMEOUT_SECONDS = 10
 DEFAULT_PASS_TIME_ALLOWED = True
+
+
+SolrRequestLabel = Literal[
+    'UNLABELLED',
+    'BOOK_SEARCH',
+    'BOOK_SEARCH_API',
+    'BOOK_SEARCH_FACETS',
+    'BOOK_CAROUSEL',
+    # /get endpoint
+    'GET_WORK_SOLR_DATA',
+    # Subject, publisher pages
+    'SUBJECT_ENGINE_PAGE',
+    'SUBJECT_ENGINE_API',
+    # Used for the internal request made by solr to choose the best edition
+    # during a normal book search
+    'EDITION_MATCH',
+    'LIST_SEARCH',
+    'LIST_SEARCH_API',
+    'SUBJECT_SEARCH',
+    'SUBJECT_SEARCH_API',
+    'AUTHOR_SEARCH',
+    'AUTHOR_SEARCH_API',
+]
 
 
 class Solr:
@@ -43,6 +66,7 @@ class Solr:
         key: str,
         fields: list[str] | None = None,
         doc_wrapper: Callable[[dict], T] = web.storage,
+        request_label: SolrRequestLabel = 'UNLABELLED',
     ) -> T | None:
         """Get a specific item from solr"""
         logger.info(f"solr /get: {key}, {fields}")
@@ -56,6 +80,7 @@ class Solr:
                     if fields
                     else {}
                 ),
+                'ol.label': request_label,
             },
         ).json()
 

--- a/openlibrary/utils/solr.py
+++ b/openlibrary/utils/solr.py
@@ -24,6 +24,7 @@ SolrRequestLabel = Literal[
     'BOOK_SEARCH_API',
     'BOOK_SEARCH_FACETS',
     'BOOK_CAROUSEL',
+    'AUTHOR_BOOKS_PAGE',
     # /get endpoint
     'GET_WORK_SOLR_DATA',
     # Subject, publisher pages

--- a/scripts/monitoring/solr_logs_monitor.py
+++ b/scripts/monitoring/solr_logs_monitor.py
@@ -42,7 +42,12 @@ class RequestLogEntry(SolrLogEntry):
     def parse_params(self) -> dict[str, str | list[str]]:
         params: dict[str, str | list[str]] = {}
         for kvp in self.params[1:-1].split('&'):
-            key, value = kvp.split('=', 1)
+            parts = kvp.split('=', 1)
+            if len(parts) != 2:
+                print(f"Warning: unexpected params format: {self.params}")
+                continue
+
+            key, value = parts
             if key in params:
                 existing_value = params[key]
                 if isinstance(existing_value, list):

--- a/scripts/monitoring/solr_logs_monitor.py
+++ b/scripts/monitoring/solr_logs_monitor.py
@@ -272,16 +272,24 @@ def main(
                     )
                 )
 
+            def get_default_for_path(path: str) -> str:
+                return {
+                    '/select': 'UNLABELLED_SELECT',
+                    '/update': 'UNLABELLED_UPDATE',
+                    '/get': 'UNLABELLED_GET',
+                }.get(path, 'UNLABELLED')
+
             # .{query_label}.count           <count>
             # .{query_label}.time.{duration} <count>
-
             count_by_query_label = Counter(
                 (
-                    entry.parse_params().get('ol.label', 'UNLABELLED'),
+                    entry.parse_params().get(
+                        'ol.label', get_default_for_path(entry.path)
+                    ),
                     standard_duration_blocks(entry.qtime),
                 )
                 for entry in minute_log_lines
-                if isinstance(entry, RequestLogEntry) and entry.path == '/select'
+                if isinstance(entry, RequestLogEntry)
             )
 
             for (query_label, duration), count in count_by_query_label.items():


### PR DESCRIPTION
We were today hit with high traffic to our subject and author pages, but were unable to see the labelled requests in our solr dashboards. The pages are now labelled with:

- `SUBJECT_ENGINE_PAGE` and `SUBJECT_ENGINE_API`. Note this also includes `/publisher` pages, which are in essence the same.
- `AUTHOR_BOOKS_PAGE` for author pages
- `GET_WORK_SOLR_DATA` has been added to label when solr data is fetched via the `Work._solr_data()` model method. This happens on a lot of pages, but is fast.

`UNLABELLED` has also been modified to suffix with the type of request made, eg `UNABELLED_SELECT`, `UNLABELLED_GET`, etc.

### Technical
- Refactors `SubjectEngine` to have a simpler class hierarchy by removing the `SubjectMeta` class. Now there is only one `SubjectEngine` class that is sub-classed for publishers and languages.
- Also renames `QueryLabel` to `SolrRequestLabel` to allow us in the future to use it to also monitor e.g. solr `/update` calls.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
✅ ol-solr1 shows the new label after deploying to testing:
<img width="1919" height="662" alt="image" src="https://github.com/user-attachments/assets/3a04700b-75d8-4ba6-b26d-9b8bedbf152b" />


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

<img width="1875" height="370" alt="image" src="https://github.com/user-attachments/assets/5af8b2ad-52a6-4a21-9ff5-b438cc936229" />


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
