### PR TITLE
Fix/tweak some solr docker parameters

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -27,6 +27,15 @@ services:
       - infobase
 
   solr:
+    environment:
+      # See compose.yaml for docs
+      # For dev, autoSoftCommit is 1s, meaning edits will show up in search after 1s
+      # Keep SOLR_OPTS in sync with other instances of solr in compose files
+      - SOLR_OPTS=
+        -Dsolr.autoSoftCommit.maxTime=1000
+        -Dsolr.autoCommit.maxTime=120000
+        -Dsolr.max.booleanClauses=30000
+        -Dsolr.environment=dev
     ports:
       - 8983:8983
 

--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -25,6 +25,13 @@ services:
     # Disabled while we're updating our version of solr, otherwise it'll pull down the new image!
     profiles: ["ol-never"]
     environment:
+      # See compose.yaml for docs
+      # Keep SOLR_OPTS in sync with other instances of solr in compose files
+      - SOLR_OPTS=
+        -Dsolr.autoSoftCommit.maxTime=60000
+        -Dsolr.autoCommit.maxTime=120000
+        -Dsolr.max.booleanClauses=30000
+        -Dsolr.environment=prod
       # More memory for production
       - SOLR_JAVA_MEM=-Xms10g -Xmx10g
       # This might overwrite the above?

--- a/compose.yaml
+++ b/compose.yaml
@@ -21,18 +21,23 @@ services:
     expose:
       - 8983
     environment:
-      # Soft commit frequently to make sure changes are visible in search
-      # Hard commit less frequently to avoid performance impact, but avoid
-      # having very large transaction log
-      # https://solr.apache.org/guide/solr/latest/configuration-guide/commits-transaction-logs.html
-      # Enlarge the max boolean clauses so that we can large intersections
-      # between books in reading logs and solr.
-      # Should be in sync with the value in openlibrary/core/bookshelves.py ,
-      # eg key:(/works/OL1W OR /works/OL2W OR ...)
+      # - autoSoftCommit.maxTime: Soft commit frequently to make sure changes are visible in search
+      # - autoCommit.maxTime: Hard commit less frequently to avoid performance impact, but avoid
+      #   having very large transaction log
+      #   https://solr.apache.org/guide/solr/latest/configuration-guide/commits-transaction-logs.html
+      # - max.booleanClauses: Enlarge the max boolean clauses so that we can large intersections
+      #   between books in reading logs and solr.
+      #   Should be in sync with the value in openlibrary/core/bookshelves.py ,
+      #   eg key:(/works/OL1W OR /works/OL2W OR ...)
+      # - environment: Setting to dev/test/prod/stage adds a tag to the admin interface.
+      #   Useful to distinguish between different solr instances.
+      #
+      # Keep SOLR_OPTS in sync with other instances of solr in compose files
       - SOLR_OPTS=
         -Dsolr.autoSoftCommit.maxTime=60000
         -Dsolr.autoCommit.maxTime=120000
         -Dsolr.max.booleanClauses=30000
+        -Dsolr.environment=dev
       - SOLR_MODULES=analysis-extras
     volumes:
       - solr-data:/var/solr

--- a/scripts/solr_builder/compose.yaml
+++ b/scripts/solr_builder/compose.yaml
@@ -34,7 +34,10 @@ services:
     environment:
       # This is optimized for bulk loading, but should be shortened for production
       # and we should set autoSoftCommit to a value that makes sense for our query usage (5-15 sec?)
-      - SOLR_OPTS=-Dsolr.autoCommit.maxTime=3600000
+      # Keep SOLR_OPTS in sync with other instances of solr in compose files
+      - SOLR_OPTS=
+        -Dsolr.autoCommit.maxTime=3600000
+        -Dsolr.environment=test
       - SOLR_MODULES=analysis-extras
       - SOLR_JAVA_MEM=-Xms3g -Xmx3g
     ports:
@@ -58,10 +61,12 @@ services:
     expose:
       - 8983
     environment:
+      # Keep in sync with compose.production.yaml
       - SOLR_OPTS=
         -Dsolr.autoSoftCommit.maxTime=60000
         -Dsolr.autoCommit.maxTime=120000
         -Dsolr.max.booleanClauses=30000
+        -Dsolr.environment=stage
       - SOLR_MODULES=analysis-extras
       # More memory for production
       - SOLR_JAVA_MEM=-Xms10g -Xmx10g


### PR DESCRIPTION
While monitoring the new staging solr's performance noticed some of its settings were out-of-sync. Sync'd them + tweaks some of the other settings.

- Makes SOLR_HEAP for the staging solr consistent with the prod solr
- Sets the `environment` flag, which adds a little coloured label to the admin dashboard, to reduce the likelihood of accidentally 
- Reduce the time for auto soft commit on the local instance; this means edits in the local instance will be reflected in solr after 1s instead of 60s like on prod. The higher time on prod is to improve performance, but not really necessary in the local environment, which is not edited as frequently.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

The label in the solr admin dashboard:
<img width="1250" height="857" alt="image" src="https://github.com/user-attachments/assets/8ea813e7-ce54-4b7a-956c-82da0ff103cb" />


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
