### PR TITLE
Fix header buttons on Create List page (#11301)

### DIFF
--- a/openlibrary/macros/databarEdit.html
+++ b/openlibrary/macros/databarEdit.html
@@ -1,11 +1,7 @@
 $def with (page)
 
-
 <div id="editTools" class="edit">
-    <div id="editHistory">
-        <a class="linkButton larger" href="$page.key?m=history" title="$_('View the editing history of this page')">$_("History")</a>
-    </div>
     <div class="editButton">
-        <a href="$page.key" title="$_('View this page (exit Edit mode)')" class="cancel">$_("Cancel")</a>
+        <a href="javascript:;" title="$_('View this page (exit Edit mode)')" class="cancel go-back-link">$_("Cancel")</a>
     </div>
 </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Fixes #11301

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
**Type:** Fix  
This PR fixes the header buttons layout on the "Create a list" page.

### Technical
- Removed the unnecessary **History** button from the header.  
- Added the `go-back-link` class to the **Cancel** button to make it functional.  
- Aligned header buttons to the right of the page title and ensured consistent spacing.

### Testing
1. Navigate to the "Create a list" page: https://openlibrary.org/people/[user_id]/lists/add  
2. Verify the **History** button is no longer present.  
3. Click the **Cancel** button and confirm it navigates back as expected.  
4. Check that the header buttons are aligned and spaced correctly.

### Screenshot
<img width="2857" height="1612" alt="image" src="https://github.com/user-attachments/assets/67ff924c-215d-4b48-9536-01413f9e91f8" />


### Stakeholders