### PR TITLE
Fix text overflow when in grid mode in /lists (#11174)

### DIFF
--- a/static/css/components/list-description.less
+++ b/static/css/components/list-description.less
@@ -4,12 +4,12 @@
  * no github design pattern library page yet
  */
 .list-books--grid .searchResultItem p {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
 }
 .list-books--grid .searchResultItem .sri__main {
-    height: auto;
+  height: auto;
 }

--- a/static/css/page-user.less
+++ b/static/css/page-user.less
@@ -255,5 +255,3 @@ textarea.toc-editor {
 @import (less) "components/sort-dropper.less";
 // Import styles for list description truncation
 @import (less) "components/list-description.less";
-
-


### PR DESCRIPTION
Closes #11174 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Type: Bug fix
This PR fixes how text overflow is handled when in list grid mode.

### Technical

- Added list-description.less file in css components folder that holds styling updates for when in list-books--grid
   - Updates specifically when paragraph tag is under .list-books--grid and .searchResultItem 
   - Updates height tag in .sri__main to limit extra whitespace after truncation
- Adds the import to page-user.less so styling is updated

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Create a list and add a minimum of 6 books
- Hit the edit button in the top right
- In the Notes (optional) text box, add a description that is long enough to be truncated (a few sentences)
- Hit save, and change view mode to grid
- Verify that the descriptions are truncated to three lines, and that overflow is now hidden.
- There should be no extra whitespace between grid items, and no text overflowing behind book covers.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="1919" height="1010" alt="image" src="https://github.com/user-attachments/assets/e01b27ea-7895-4660-b1e3-605aa960580e" />

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
