### PR TITLE
Fix button label translation for "Follow" buttons

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -305,10 +305,6 @@ msgstr ""
 msgid "Failed to update followers. Please try again in a few moments."
 msgstr ""
 
-#: Follow.html
-msgid "UnfollowFollow"
-msgstr ""
-
 #: FormatExpiry.html
 msgid "Expires"
 msgstr ""

--- a/openlibrary/macros/Follow.html
+++ b/openlibrary/macros/Follow.html
@@ -16,7 +16,7 @@ $ custom_request_path = request_path if request_path != '' else request.fullpath
       <input type="hidden" value="$publisher" name="publisher"/>
       <input type="hidden" value="$custom_request_path" name="redir_url"/>
       $ css_treatment = 'delete' if following else 'primary'
-      <button type="submit" class="cta-btn cta-btn--$(css_treatment)" data-i18n="$json_encode(i18n_strings)">$_("Unfollow" if following else "Follow")</button>
+      <button type="submit" class="cta-btn cta-btn--$(css_treatment)" data-i18n="$json_encode(i18n_strings)">$(_("Unfollow") if following else _("Follow"))</button>
     </form>
   $else:
     <a class="cta-btn cta-btn--primary" href="/account/login?redir_url=$(ctx.path)&action=follow:$(publisher)">$_("Follow")</a>


### PR DESCRIPTION
<!-- What issue does this PR close? -->

Follows #11311

Addresses bug mentioned [here](https://github.com/internetarchive/openlibrary/pull/11311/files#r2395805233)

While the original code worked, our `messages.pot` file has an entry for `UnfollowFollow` due to the way this is written.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Ensure that the "Follow" button copy is as expected (either `Follow` or `Unfollow`).
- Ensure that the `UnfollowFollow` entry is removed from `messages.pot` after the file is generated (by `pre-commit ci`)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
