### PR TITLE
Ensure default IP set in preference update script

### DIFF
--- a/scripts/migrations/update_legacy_preferences.py
+++ b/scripts/migrations/update_legacy_preferences.py
@@ -22,6 +22,7 @@ def setup(config_path):
         raise FileNotFoundError(f'No configuration file found at {config_path}')
     load_config(config_path)
     infogami._setup()
+    web.ctx.ip = web.ctx.ip or '127.0.0.1'
 
 
 def fetch_affected_keys() -> list[str]:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Follows #11310

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes failing [`web.ctx.site.save()` calls](https://github.com/internetarchive/openlibrary/blob/8d46fa4df1e49be008865cddac2a0cdb6214f8b6/scripts/migrations/update_legacy_preferences.py#L59) in legacy preference updater script by setting a default IP address.  When no IP address is set, inserts into the `transaction` table fail.

Now, when the script is being initialized, `127.0.0.1` is set by default.  A similar thing was done in `update_stale_ocaid_references.py`, [here](https://github.com/internetarchive/openlibrary/blob/8d46fa4df1e49be008865cddac2a0cdb6214f8b6/scripts/update_stale_ocaid_references.py#L138).

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
