### PR TITLE
set timeout for Image.info check to avoid site going down if covers is slow

### DIFF
--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -66,7 +66,7 @@ class Image:
         if url.startswith("//"):
             url = "http:" + url
         try:
-            d = requests.get(url).json()
+            d = requests.get(url, timeout=3).json()
             d['created'] = parse_datetime(d['created'])
             if fetch_author:
                 if d['author'] == 'None':
@@ -74,7 +74,7 @@ class Image:
                 d['author'] = d['author'] and self._site.get(d['author'])
 
             return web.storage(d)
-        except OSError:
+        except (requests.exceptions.RequestException, OSError):
             # coverstore is down
             return None
 


### PR DESCRIPTION
Follow-up from #11332 . The issue was exacerbated by the web nodes becoming saturated when covers was slow, due to this request, which did not have a timeout. 

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Tested locally by adding a sleep to coverstore:

```diff
--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import textwrap
+from time import sleep
 from typing import cast

 import requests
@@ -403,6 +404,7 @@ def parse_tarindex(file):

 class cover_details:
     def GET(self, category, key, value):
+        sleep(10)
         d = _query(category, key, value)

         if key == 'id':
```

And observed that on loading a book page, the page did not wait 10 seconds, but instead responded after ~3 , and without the `style="aspect-ratio: ..."` tag on the image.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
