### PR TITLE
Refactor error handling in `update_legacy_preferences.py`

### DIFF
--- a/scripts/migrations/update_legacy_preferences.py
+++ b/scripts/migrations/update_legacy_preferences.py
@@ -58,7 +58,7 @@ def update_preferences(keys: list[str]) -> list[str]:
             username = key.split('/')[2]
             with RunAs(username):
                 web.ctx.site.save(new_prefs, 'Updating preferences')
-        except Exception:  # noqa: BLE001
+        except (infogami.infobase.client.ClientException, KeyError, IndexError):
             retry_list.append(key)
 
     return retry_list


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Follows #11310

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
The preference updater script failed when `RunAs` was used with a deleted account.  These changes mitigate this issue by more types of errors that occur during the preference update operation in `update_preferences()`.

Additionally, failing keys are no longer retried automatically.  Instead, these keys are printed before the script shuts down, and I will manually update the affected preferences.  As we processed nearly half of the affected preferences before hitting an error, I expect the number of failures to be low. 

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
