### PR TITLE
Clamp list-follow card notes to 3 lines to prevent overflow (#11174)

### DIFF
--- a/static/css/list-follow.less
+++ b/static/css/list-follow.less
@@ -6,7 +6,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
-  -webkit-line-clamp: 3;       /* show max 3 lines */
+  -webkit-line-clamp: 3; /* show max 3 lines */
   -webkit-box-orient: vertical;
   white-space: normal;
   max-height: calc(1.2em * 3);


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11174
<!-- What does this PR achieve?-->
fix the overflow problem and solves issue 1174


### Technical
This PR adds a CSS rule in the `static/css/components/list-follow.less` file to prevent long text in list notes from overflowing outside the card container.  

It modifies the `.list-notes` class as follows:
```css
.list-notes {
    overflow-wrap: break-word; /* Allows long words to break onto the next line */
    word-break: break-word;    /* Ensures unbreakable strings (like URLs) wrap */
    white-space: pre-wrap;     /* Preserves line breaks and spaces */
}
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
