### PR TITLE
Add chapters to solr

### DIFF
--- a/conf/solr/conf/managed-schema.xml
+++ b/conf/solr/conf/managed-schema.xml
@@ -139,6 +139,7 @@
     <field name="subtitle" type="text_en_splitting"/>
     <field name="alternative_title" type="text_en_splitting" stored="false" multiValued="true"/>
     <field name="alternative_subtitle" type="text_en_splitting" stored="false" multiValued="true"/>
+    <field name="chapter" type="text_en_splitting" multiValued="true"/>
 
     <field name="edition_count" type="pint"/>
     <field name="edition_key" type="string" multiValued="true"/>

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -784,6 +784,14 @@ msgid "added to"
 msgstr ""
 
 #: SearchResultsWork.html
+msgid "Show more"
+msgstr ""
+
+#: SearchResultsWork.html
+msgid "Show less"
+msgstr ""
+
+#: SearchResultsWork.html
 #, python-format
 msgid "Cover of edition %(id)s"
 msgstr ""

--- a/openlibrary/macros/ReadMore.html
+++ b/openlibrary/macros/ReadMore.html
@@ -1,2 +1,9 @@
-<button class="read-more__toggle read-more__toggle--more">$_("Read more") &#9662</button>
-<button class="read-more__toggle read-more__toggle--less">$_("Read less") &#9650</button>
+$def with(more_text=None, less_text=None)
+
+$ more_text = more_text or _("Read more")
+$ less_text = less_text or _("Read less")
+
+$# detect-missing-i18n-skip-line
+<button class="read-more__toggle read-more__toggle--more">$more_text &#9662</button>
+$# detect-missing-i18n-skip-line
+<button class="read-more__toggle read-more__toggle--less">$less_text &#9650</button>

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -125,6 +125,43 @@ $code:
                 <a href="$subject_name_to_key(subj.replace('<em>', '').replace('</em>', ''))">$:subj</a>
             </span>
 
+          $if highlighting.get('chapter'):
+            <br />
+            $ matching_chapters = highlighting.get('chapter', [])
+
+            <div class="srw__chapters read-more">
+              <div class="read-more__content" style="max-height:80px">
+                $for chapter in matching_chapters:
+                  $if not chapter.strip():
+                    $continue
+                  $ ed_olid, rest = chapter.split(' | ', 1)
+                  $if '/books/' + ed_olid != selected_ed.get('key'):
+                    $continue
+                  $ chapter_parts = rest.split('|')
+                  $if len(chapter_parts) < 3:
+                    $ chapter_parts = ['', chapter, '']
+                  $ pagenum = None
+                  $if chapter_parts[2].strip():
+                    $ pagenum = chapter_parts[2].strip()
+                  $ is_link = pagenum and pagenum.isdigit() and selected_ed.get('ia')
+                  $ tag = 'a' if is_link else 'div'
+                  <$tag class="srw__chapter" $:('href="https://archive.org/details/%s/page/%s"' % (selected_ed.get('ia')[0], pagenum) if is_link else '')>
+                    <span>
+                      $if chapter_parts[0].strip() and not chapter_parts[0].strip().endswith('.'):
+                        $ chapter_parts[0] = chapter_parts[0].strip() + '. '
+                      $# This isn't html injection, because solr returns everything
+                      $# already html escaped except for the em of the highlight
+                      $:chapter_parts[0]
+                      $:chapter_parts[1]
+                    </span>
+                    $if pagenum:
+                      <div style="flex:1; border-bottom: 1px dotted;"></div>
+                      Page $pagenum
+                  </$tag>
+                </div>
+                $:macros.ReadMore(_('Show more'), _('Show less'))
+            </div>
+
         $if doc.get('ia') and len(doc.get('ia')) > 1:
           <br />
           $ blur_preview = "preview-covers--blur" if blur else ""

--- a/openlibrary/plugins/worksearch/schemes/works.py
+++ b/openlibrary/plugins/worksearch/schemes/works.py
@@ -50,6 +50,7 @@ class WorkSearchScheme(SearchScheme):
             "subtitle",
             "alternative_title",
             "alternative_subtitle",
+            "chapter",
             "cover_i",
             "ebook_access",
             "ebook_provider",
@@ -351,7 +352,7 @@ class WorkSearchScheme(SearchScheme):
             # qf: the fields to query un-prefixed parts of the query.
             # e.g. 'harry potter' becomes
             # 'text:(harry potter) OR alternative_title:(harry potter)^20 OR ...'
-            qf='text alternative_title^10 author_name^10',
+            qf='text alternative_title^10 author_name^10 chapter^5',
             # pf: phrase fields. This increases the score of documents that
             # match the query terms in close proximity to each other.
             pf='alternative_title^10 author_name^10',
@@ -389,6 +390,7 @@ class WorkSearchScheme(SearchScheme):
                 # Misc useful data
                 'format': 'format',
                 'language': 'language',
+                'chapter': 'chapter',
                 'publisher': 'publisher',
                 'publisher_facet': 'publisher_facet',
                 'publish_date': 'publish_date',
@@ -520,7 +522,7 @@ class WorkSearchScheme(SearchScheme):
 
             full_ed_query = '({{!edismax bq="{bq}" v={v} qf="{qf}"}})'.format(
                 # See qf in work_query
-                qf='text alternative_title^4 author_name^4',
+                qf='text alternative_title^4 author_name^4 chapter^4',
                 # Reading from the url parameter userEdQuery. This lets us avoid
                 # having to try to escape the query in order to fit inside this
                 # other query.
@@ -559,7 +561,7 @@ class WorkSearchScheme(SearchScheme):
             new_params.append(('q', full_work_query))
 
         if highlight:
-            highlight_fields = ('subject',)
+            highlight_fields = ('subject', 'chapter')
             try:
                 # This can throw the EmptyTreeError if nothing remains in the query
                 highlight_query = luqum_deepcopy(work_q_tree)
@@ -572,6 +574,8 @@ class WorkSearchScheme(SearchScheme):
                 new_params.append(('hl.fl', ','.join(highlight_fields)))
                 new_params.append(('hl.q', str(highlight_query)))
                 new_params.append(('hl.snippets', '10'))
+                # we can't trim e.g. chapter since it has a specific structure with the pipes
+                new_params.append(('hl.fragsize', '0'))
             except EmptyTreeError:
                 # nothing to highlight
                 pass

--- a/openlibrary/solr/solr_types.py
+++ b/openlibrary/solr/solr_types.py
@@ -17,6 +17,7 @@ class SolrDocument(TypedDict):
     subtitle: Optional[str]
     alternative_title: Optional[list[str]]
     alternative_subtitle: Optional[list[str]]
+    chapter: Optional[list[str]]
     edition_count: Optional[int]
     edition_key: Optional[list[str]]
     cover_edition_key: Optional[str]

--- a/openlibrary/solr/updater/edition.py
+++ b/openlibrary/solr/updater/edition.py
@@ -135,6 +135,27 @@ class EditionSolrBuilder(AbstractSolrBuilder):
         return result
 
     @property
+    def chapter(self) -> list[str]:
+        result = []
+        olid = self._edition.get('key', '').split('/', 2)[-1]
+        for chapter in self._edition.get('table_of_contents', []):
+            # Check if plain string first
+            if isinstance(chapter, str):
+                result.append(f'{olid} | {chapter}')
+                continue
+
+            title = chapter.get("title", "")
+            if chapter.get("subtitle"):
+                title += f": {chapter['subtitle']}"
+            if chapter.get("authors"):
+                title += f" ({', '.join(a['name'] for a in chapter['authors'])})"
+
+            result.append(
+                f'{olid} | {chapter.get("label", "")} | {title} | {chapter.get("pagenum", "")}'
+            )
+        return result
+
+    @property
     def cover_i(self) -> int | None:
         return next(
             (
@@ -310,6 +331,7 @@ class EditionSolrBuilder(AbstractSolrBuilder):
                 'title': self.title,
                 'subtitle': self.subtitle,
                 'alternative_title': list(self.alternative_title),
+                'chapter': self.chapter,
                 'cover_i': self.cover_i,
                 'language': self.language,
                 # Duplicate the author data from the work

--- a/openlibrary/solr/updater/work.py
+++ b/openlibrary/solr/updater/work.py
@@ -343,6 +343,10 @@ class WorkSolrBuilder(AbstractSolrBuilder):
         }
 
     @property
+    def chapter(self) -> set[str]:
+        return {chapter for ed in self._solr_editions for chapter in ed.chapter}
+
+    @property
     def edition_count(self) -> int:
         return len(self._editions)
 

--- a/static/css/components/search-result-item.less
+++ b/static/css/components/search-result-item.less
@@ -176,6 +176,40 @@
   }
 }
 
+.srw__chapters {
+  background: rgba(0, 124, 255, 0.2);
+  border-radius: 4px;
+  color: @black;
+  margin-bottom: 5px;
+  font-size: @font-size-label-medium;
+
+  .srw__chapter {
+    border-radius: inherit;
+    padding: 6px 8px;
+    display: flex;
+    gap: 4px;
+    line-height: 1.2em;
+    transition: background-color 0.2s;
+
+    em {
+      font-weight: bold;
+    }
+
+    // stylelint-disable-next-line selector-max-specificity
+    a&:hover {
+      background: rgba(0, 124, 255, 0.2);
+    }
+  }
+
+  .read-more__toggle {
+    padding: 5px 10px;
+    background: linear-gradient(
+      rgba(255, 255, 255, 0) 0,
+      rgba(249, 249, 249, 0.49) 10px
+    );
+  }
+}
+
 .searchResultItem__librarian-extras {
   font-size: 0.7em;
   border-top: 1px dashed currentColor;

--- a/static/css/page-user.less
+++ b/static/css/page-user.less
@@ -42,6 +42,7 @@
 @import (less) "components/flash-messages.less";
 @import (less) "less/z-index.less";
 @import (less) "components/provider-table.less";
+@import (less) "components/read-more.less";
 
 body {
   background-color: @beige;


### PR DESCRIPTION
Closes #8756. Experiment with adding chapters to solr. Continuation of #9898 . Depends on #11366 .


### Technical
<!-- What should be noted about the implementation? -->

The risk this carries is that it stores the table of contents both on the edition and work to allow for appropriate matching.

The work-level TOC is needed to allow it to take part in boosting work search results. The edition-level TOC is I believe needed to have the correct edition match as well. If there are performance issues we might be able to remove the edition-level TOC.

The new field has been added to our prod solr, so this should be able to be deployed without any intervention.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Locally import some books with tocs, and search for them. Requires resetting the local solr.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
