### PR TITLE
Fix: clicking label now checks associated radio button

### DIFF
--- a/openlibrary/templates/account/privacy.html
+++ b/openlibrary/templates/account/privacy.html
@@ -30,14 +30,14 @@ $ safe_mode = d.get('safe_mode', 'no')
             <div class="input radio">
                 <div class="sansserif larger">
                     <input type="radio" name="public_readlog" id="r0" value="yes" $selected(public_readlog, "yes")/>
-                    <label for="u0">$_("Yes")</label>
+                    <label for="r0">$_("Yes")</label>
                     <br/><br/>
                 </div>
             </div>
             <div class="input radio">
                 <div class="sansserif larger">
                     <input type="radio" name="public_readlog" id="r1" value="no" $selected(public_readlog, "no")/>
-                    <label for="u1">$_("No")</label>
+                    <label for="r1">$_("No")</label>
                     <br/><br/>
                 </div>
             </div>
@@ -51,14 +51,14 @@ $ safe_mode = d.get('safe_mode', 'no')
             <div class="input radio">
                 <div class="sansserif larger">
                     <input type="radio" name="safe_mode" id="r2" value="yes" $selected(safe_mode, "yes")/>
-                    <label for="u0">$_("Yes")</label>
+                    <label for="r2">$_("Yes")</label>
                     <br/><br/>
                 </div>
             </div>
             <div class="input radio">
                 <div class="sansserif larger">
                     <input type="radio" name="safe_mode" id="r3" value="no" $selected(safe_mode, "no")/>
-                    <label for="u1">$_("No")</label>
+                    <label for="r3">$_("No")</label>
                     <br/><br/>
                 </div>
             </div>


### PR DESCRIPTION
-- What issue does this PR close? 
Closes #11382

-- What does this PR achieve? [feature|hotfix|fix|refactor] 
Fix

-- What should be noted about the implementation? 

This PR updates the labels on the “Privacy & Content Moderation Settings” page so that clicking a label correctly selects its associated radio button.  
Each `<label>` tag is now linked to its corresponding `<input>` using the proper `for` and `id` attributes.  

-- Steps for reviewer to reproduce/verify what this PR does/fixes. 

1. Go to the /account/privacy (https://openlibrary.org/account/privacy)
2. Click any label next to a radio button.  
3. Observe that the associated radio button now gets checked automatically.  


https://github.com/user-attachments/assets/cba7a93c-bc62-4cbc-8412-76b0163d15f4

@jimchamp 
