### PR TITLE
Fix: corrected bad value for checked attribute on Privacy & Content M…

### DIFF
--- a/openlibrary/templates/account/privacy.html
+++ b/openlibrary/templates/account/privacy.html
@@ -13,7 +13,7 @@ $var title: $_("Your Privacy on Open Library")
 </div>
 
 $def selected(value, value2):
-    $if value == value2: checked="checked"
+    $if value == value2: checked
 
 $ public_readlog = d.get('public_readlog', 'no')
 $ safe_mode = d.get('safe_mode', 'no')


### PR DESCRIPTION
-- What issue does this PR close? 
Closes #11383 

-- What does this PR achieve? [feature|hotfix|fix|refactor] 
Fix

-- What should be noted about the implementation? 
This PR corrects the invalid value being assigned to the `checked` attribute on the “Privacy & Content Moderation Settings” page.  
The fix ensures that the correct radio button state is maintained as expected.

@jimchamp
