### PR TITLE
Fix: Hide loading indicator if carousel loading fails.

### DIFF
--- a/openlibrary/plugins/openlibrary/js/lazy-carousel.js
+++ b/openlibrary/plugins/openlibrary/js/lazy-carousel.js
@@ -82,9 +82,7 @@ function doFetchAndUpdate(target) {
             }
         })
         .catch(() => {
-            if (loadingIndicator){
-                loadingIndicator.classList.add('hidden');
-            }
+            loadingIndicator.classList.add('hidden');
             const retryElem = target.querySelector('.lazy-carousel-retry')
             retryElem.classList.remove('hidden')
         })


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes https://github.com/internetarchive/openlibrary/issues/11380

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix: This feature hides the carousel loading indicator if carousel loading fails.

### Technical
<!-- What should be noted about the implementation? -->
In [openlibrary/openlibrary/plugins/openlibrary/js/lazy-carousel.js](https://github.com/internetarchive/openlibrary/blob/a80108f50ef15f661a47ba867dc2fc54fd00fbbc/openlibrary/plugins/openlibrary/js/lazy-carousel.js#L84-L87) in catch block I added a condition to check if `loadingIndicator` is visible a then `loadingIndicator.classList.add('hidden');`
hides the loadingIndicator.
```
.catch(() => {
            if(loadingIndicator){
                loadingIndicator.classList.add('hidden');
            }
            const retryElem = target.querySelector('.lazy-carousel-retry')
            retryElem.classList.remove('hidden')
        })
```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
before:
<img width="1756" height="475" alt="image" src="https://github.com/user-attachments/assets/21400470-5c1f-41f8-93ba-ec252fda8d45" />
after:
<img width="1756" height="373" alt="unnamed" src="https://github.com/user-attachments/assets/f3ec29df-89cc-4bfa-a053-f6a419798584" />


