### PR TITLE
Add activity feed to My Books page

### DIFF
--- a/openlibrary/core/follows.py
+++ b/openlibrary/core/follows.py
@@ -178,7 +178,7 @@ class PubSub:
         return top_publishers
 
     @classmethod
-    def is_following(cls, useranme):
+    def is_following(cls, username):
         oldb = db.get_db()
         query = """
             SELECT EXISTS(
@@ -187,5 +187,5 @@ class PubSub:
                 WHERE subscriber=$subscriber
             )
         """
-        result = oldb.query(query, vars={'subscriber': useranme})
+        result = oldb.query(query, vars={'subscriber': username})
         return result and result[0].get('exists', False)

--- a/openlibrary/core/follows.py
+++ b/openlibrary/core/follows.py
@@ -176,3 +176,16 @@ class PubSub:
             vars={'limit': limit},
         )
         return top_publishers
+
+    @classmethod
+    def is_following(cls, useranme):
+        oldb = db.get_db()
+        query = """
+            SELECT EXISTS(
+                SELECT 1
+                FROM follows
+                WHERE subscriber=$subscriber
+            )
+        """
+        result = oldb.query(query, vars={'subscriber': useranme})
+        return result and result[0].get('exists', False)

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -82,7 +82,7 @@ msgid "Pending Imports"
 msgstr ""
 
 #: BookByline.html FulltextSearchSuggestionItem.html SearchResultsWork.html
-#: account/notes.html account/observations.html
+#: account/activity_feed.html account/notes.html account/observations.html
 msgid "Unknown author"
 msgstr ""
 
@@ -365,6 +365,14 @@ msgstr ""
 msgid "Loading indicator"
 msgstr ""
 
+#: LoadingIndicator.html
+msgid "Failed to fetch data."
+msgstr ""
+
+#: LoadingIndicator.html RawQueryCarousel.html
+msgid "Retry?"
+msgstr ""
+
 #: LoanReadForm.html ReadButton.html admin/inspect/memcache.html
 #: book_providers/read_button.html books/edit/edition.html books/show.html
 #: books/works-show.html trending.html type/list/embed.html widget.html
@@ -575,10 +583,6 @@ msgstr ""
 
 #: RawQueryCarousel.html
 msgid "Failed to fetch carousel."
-msgstr ""
-
-#: RawQueryCarousel.html
-msgid "Retry?"
 msgstr ""
 
 #: RawQueryCarousel.html
@@ -1496,12 +1500,13 @@ msgstr ""
 msgid "Notes"
 msgstr ""
 
-#: account/sidebar.html books/mybooks_breadcrumb_select.html
-#: openlibrary/plugins/upstream/mybooks.py
+#: account/mybooks.html account/sidebar.html
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 msgid "My Feed"
 msgstr ""
 
-#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
+#: account/activity_feed.html account/mybooks.html
+#: account/readinglog_shelf_name.html account/sidebar.html
 #: my_books/dropdown_content.html my_books/primary_action.html
 #: openlibrary/plugins/upstream/mybooks.py search/sort_options.html
 msgid "Already Read"
@@ -2295,12 +2300,14 @@ msgstr ""
 msgid "Earliest trending data is from October 2017"
 msgstr ""
 
-#: account/mybooks.html account/sidebar.html my_books/dropdown_content.html
-#: my_books/primary_action.html search/sort_options.html trending.html
+#: account/activity_feed.html account/mybooks.html account/sidebar.html
+#: my_books/dropdown_content.html my_books/primary_action.html
+#: search/sort_options.html trending.html
 msgid "Want to Read"
 msgstr ""
 
-#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
+#: account/activity_feed.html account/mybooks.html
+#: account/readinglog_shelf_name.html account/sidebar.html
 #: my_books/dropdown_content.html my_books/primary_action.html
 #: search/sort_options.html trending.html
 msgid "Currently Reading"
@@ -2471,6 +2478,30 @@ msgid ""
 " the team, then complete the <a "
 "href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">Open Library team "
 "information form</a>."
+msgstr ""
+
+#: account/activity_feed.html lists/list_follow.html
+msgid "Avatar of the owner of the list"
+msgstr ""
+
+#: account/activity_feed.html
+#, python-format
+msgid ""
+"<a class=\"activity-feed-card__user-link\" "
+"href=\"%(user_key)s/books\">@%(username)s</a> added to <a "
+"href=\"%(shelf_url)s\">shelf</a>"
+msgstr ""
+
+#: account/activity_feed.html
+msgid ""
+"Here's the latest activity around the library. Follow readers to "
+"personalize your feed."
+msgstr ""
+
+#: account/activity_feed.html
+msgid ""
+"None of the people that you follow have logged books.  When they do, "
+"you'll see it here."
 msgstr ""
 
 #: account/create.html
@@ -2747,6 +2778,10 @@ msgstr ""
 
 #: account/mybooks.html account/sidebar.html
 msgid "My Loans"
+msgstr ""
+
+#: account/mybooks.html
+msgid "Loading Activity Feed"
 msgstr ""
 
 #: account/mybooks.html type/user/view.html
@@ -6325,14 +6360,6 @@ msgstr ""
 
 #: lists/home.html lists/showcase.html lists/widget.html
 msgid "See all"
-msgstr ""
-
-#: lists/list_follow.html
-msgid "Cover of book"
-msgstr ""
-
-#: lists/list_follow.html
-msgid "Avatar of the owner of the list"
 msgstr ""
 
 #: lists/list_follow.html lists/widget.html my_books/dropdown_content.html

--- a/openlibrary/macros/Follow.html
+++ b/openlibrary/macros/Follow.html
@@ -1,4 +1,4 @@
-$def with (publisher, fid='', following=False, request_path='')
+$def with (publisher, fid='', following=0, request_path='')
 
 $ i18n_strings = {
 $   'follow': _('Follow'),

--- a/openlibrary/macros/LoadingIndicator.html
+++ b/openlibrary/macros/LoadingIndicator.html
@@ -1,4 +1,4 @@
-$def with (caption, additional_classes='', hidden=True)
+$def with (caption, additional_classes='', hidden=True, show_retry=False)
 
 $ hidden = "hidden" if hidden else ""
 
@@ -10,4 +10,7 @@ $ hidden = "hidden" if hidden else ""
       display: flex;
   ">$caption</figcaption>
   </figure>
+</div>
+<div class="retry-fetch hidden">
+    $_("Failed to fetch data.") <a href="javascript:;" class="retry-btn">$_("Retry?")</a>
 </div>

--- a/openlibrary/plugins/openlibrary/js/activity-feed/index.js
+++ b/openlibrary/plugins/openlibrary/js/activity-feed/index.js
@@ -1,3 +1,4 @@
+import { initAsyncFollowing } from "../following";
 import { buildPartialsUrl } from '../utils'
 
 /**
@@ -27,6 +28,8 @@ export async function initActivityFeedRequest(elem) {
             .then(data => {
                 const div = document.createElement('div')
                 div.innerHTML = data.partials.trim()
+                const followButtons = div.querySelectorAll('.follow-form')
+                initAsyncFollowing(followButtons)
                 loadingIndicator.classList.add('hidden')
                 for (const child of Array.from(div.children)) {
                     elem.insertAdjacentElement('beforeend', child)

--- a/openlibrary/plugins/openlibrary/js/activity-feed/index.js
+++ b/openlibrary/plugins/openlibrary/js/activity-feed/index.js
@@ -1,4 +1,4 @@
-import { initAsyncFollowing } from "../following";
+import { initAsyncFollowing } from '../following';
 import { buildPartialsUrl } from '../utils'
 
 /**

--- a/openlibrary/plugins/openlibrary/js/activity-feed/index.js
+++ b/openlibrary/plugins/openlibrary/js/activity-feed/index.js
@@ -1,0 +1,50 @@
+import { buildPartialsUrl } from '../utils'
+
+/**
+ * Fetches and displays the activity feed for a "My Books" page.
+ *
+ * @param {HTMLElement} elem - Container for the activity feed
+ * @returns {Promise<void>}
+ *
+ * @see `/openlibrary/templates/account/activity_feed.html` for activity feed template
+ */
+export async function initActivityFeedRequest(elem) {
+    const fullPath = window.location.pathname
+    const splitPath = fullPath.split('/')
+    const username = splitPath[2]  // Assumes an activity feed can only appear on the patron's "My Books" page
+
+    const loadingIndicator = elem.querySelector('.loadingIndicator')
+    const retryElem = elem.querySelector('.retry-fetch')
+
+    function fetchPartialsAndUpdatePage() {
+        return fetch(buildPartialsUrl('ActivityFeed', {username: username}))
+            .then(resp => {
+                if (!resp.ok) {
+                    throw Error('Failed to fetch partials')
+                }
+                return resp.json()
+            })
+            .then(data => {
+                const div = document.createElement('div')
+                div.innerHTML = data.partials.trim()
+                loadingIndicator.classList.add('hidden')
+                for (const child of Array.from(div.children)) {
+                    elem.insertAdjacentElement('beforeend', child)
+                }
+            })
+            .catch(() => {
+                // Show retry affordance
+                loadingIndicator.classList.add('hidden')
+                retryElem.classList.remove('hidden')
+            })
+    }
+
+    // Hydrate retry button
+    retryElem.addEventListener('click', async () => {
+        retryElem.classList.add('hidden')
+        loadingIndicator.classList.remove('hidden')
+        await fetchPartialsAndUpdatePage()
+    })
+
+    await fetchPartialsAndUpdatePage()
+}

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -582,4 +582,11 @@ jQuery(function () {
         import(/* webpackChunkName: "list-books" */ './list_books')
             .then(module => module.ListBooks.init());
     }
+
+    // Lazy-load activity feed
+    const activityFeedContainer = document.querySelector('.activity-feed-container')
+    if (activityFeedContainer) {
+        import(/* webpackChunkName: "activity-feed" */ './activity-feed')
+            .then(module => module.initActivityFeedRequest(activityFeedContainer))
+    }
 });

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -368,13 +368,16 @@ class LazyCarouselPartial(PartialDataHandler):
 
 class ActivityFeedPartial(PartialDataHandler):
     """Handler for "My Books" page activity feeds"""
+
     def __init__(self):
         self.i = web.input(username=None)
 
     def generate(self) -> dict:
         feed, follows_others = ActivityFeed.get_activity_feed(self.i.username)
         feed_url = f'/people/{self.i.username}/books/feed'
-        template_result = render_template('account/activity_feed', feed, feed_url, follows_others)
+        template_result = render_template(
+            'account/activity_feed', feed, feed_url, follows_others
+        )
         return {"partials": str(template_result)}
 
 

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -12,6 +12,7 @@ from openlibrary.core.fulltext import fulltext_search
 from openlibrary.core.lending import compose_ia_url, get_available
 from openlibrary.i18n import gettext as _
 from openlibrary.plugins.openlibrary.lists import get_user_lists
+from openlibrary.plugins.upstream.mybooks import ActivityFeed
 from openlibrary.plugins.upstream.yearly_reading_goals import get_reading_goals
 from openlibrary.plugins.worksearch.code import do_search, work_search
 from openlibrary.plugins.worksearch.subjects import (
@@ -365,6 +366,18 @@ class LazyCarouselPartial(PartialDataHandler):
         return {"partials": str(macro)}
 
 
+class ActivityFeedPartial(PartialDataHandler):
+    """Handler for "My Books" page activity feeds"""
+    def __init__(self):
+        self.i = web.input(username=None)
+
+    def generate(self) -> dict:
+        feed, follows_others = ActivityFeed.get_activity_feed(self.i.username)
+        feed_url = f'/people/{self.i.username}/books/feed'
+        template_result = render_template('account/activity_feed', feed, feed_url, follows_others)
+        return {"partials": str(template_result)}
+
+
 class PartialRequestResolver:
     # Maps `_component` values to PartialDataHandler subclasses
     component_mapping = {  # noqa: RUF012
@@ -376,6 +389,7 @@ class PartialRequestResolver:
         "LazyCarousel": LazyCarouselPartial,
         "MyBooksDropperLists": MyBooksDropperListsPartial,
         "ReadingGoalProgress": ReadingGoalProgressPartial,
+        "ActivityFeed": ActivityFeedPartial,
     }
 
     @staticmethod

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -26,6 +26,7 @@ from openlibrary.core.lending import (
 from openlibrary.core.models import LoggedBooksData, User
 from openlibrary.core.observations import Observations, convert_observation_ids
 from openlibrary.i18n import gettext as _
+from openlibrary.plugins.openlibrary.home import caching_prethread
 from openlibrary.utils import extract_numeric_id_from_olid, dateutil
 from openlibrary.utils.dateutil import current_year
 
@@ -683,7 +684,7 @@ class ActivityFeed:
     @classmethod
     def get_cached_pub_sub_feed(cls, username):
         five_minutes = 5 * dateutil.MINUTE_SECS
-        mc = memcache_memoize(cls.get_pub_sub_feed, key_prefix="my.books.pub.sub.feed", timeout=five_minutes)
+        mc = memcache_memoize(cls.get_pub_sub_feed, key_prefix="my.books.pub.sub.feed", timeout=five_minutes, prethread=caching_prethread())
         results = mc(username)
 
         for r in results:
@@ -716,7 +717,7 @@ class ActivityFeed:
     @classmethod
     def get_cached_trending_feed(cls):
         five_minutes = 5 * dateutil.MINUTE_SECS
-        mc = memcache_memoize(cls.get_trending_feed, key_prefix="my.books.trending.feed", timeout=five_minutes)
+        mc = memcache_memoize(cls.get_trending_feed, key_prefix="my.books.trending.feed", timeout=five_minutes, prethread=caching_prethread())
         results = mc()
 
         for r in results:

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -1,6 +1,5 @@
 import json
 from datetime import datetime
-from itertools import islice
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Final, Literal, cast
 
@@ -12,7 +11,7 @@ from infogami.utils import delegate
 from infogami.utils.view import public, render, safeint
 from openlibrary import accounts
 from openlibrary.accounts.model import (
-    OpenLibraryAccount,  # noqa: F401 side effects may be needed
+    OpenLibraryAccount,
 )
 from openlibrary.core.booknotes import Booknotes
 from openlibrary.core.bookshelves import Bookshelves
@@ -27,7 +26,7 @@ from openlibrary.core.models import LoggedBooksData, User
 from openlibrary.core.observations import Observations, convert_observation_ids
 from openlibrary.i18n import gettext as _
 from openlibrary.plugins.openlibrary.home import caching_prethread
-from openlibrary.utils import extract_numeric_id_from_olid, dateutil
+from openlibrary.utils import dateutil, extract_numeric_id_from_olid
 from openlibrary.utils.dateutil import current_year
 
 if TYPE_CHECKING:
@@ -114,7 +113,7 @@ class mybooks_home(delegate.page):
             owners_page=mb.is_my_page,
             counts=mb.counts,
             lists=mb.lists,
-            component_times=mb.component_times
+            component_times=mb.component_times,
         )
 
 
@@ -679,11 +678,18 @@ class ActivityFeed:
     @classmethod
     def get_cached_pub_sub_feed(cls, username):
         five_minutes = 5 * dateutil.MINUTE_SECS
-        mc = memcache_memoize(cls.get_pub_sub_feed, key_prefix="my.books.pub.sub.feed", timeout=five_minutes, prethread=caching_prethread())
+        mc = memcache_memoize(
+            cls.get_pub_sub_feed,
+            key_prefix="my.books.pub.sub.feed",
+            timeout=five_minutes,
+            prethread=caching_prethread(),
+        )
         results = mc(username)
 
         for r in results:
-            if isinstance(r['created'], str):  # `datetime` objects are stored in cache as strings
+            if isinstance(
+                r['created'], str
+            ):  # `datetime` objects are stored in cache as strings
                 # Update `created` to datetime, which is the type expected by `datestr` (called in card template)
                 r['created'] = datetime.fromisoformat(r['created'])
         return results
@@ -691,8 +697,7 @@ class ActivityFeed:
     @classmethod
     def get_trending_feed(cls):
         def has_public_reading_log(username):
-            acct = OpenLibraryAccount.get_by_username(username)
-            if acct:
+            if acct := OpenLibraryAccount.get_by_username(username):
                 user = acct.get_user()
                 return user and user.preferences().get('public_readlog', 'no') == 'yes'
             return False
@@ -712,10 +717,17 @@ class ActivityFeed:
     @classmethod
     def get_cached_trending_feed(cls):
         five_minutes = 5 * dateutil.MINUTE_SECS
-        mc = memcache_memoize(cls.get_trending_feed, key_prefix="my.books.trending.feed", timeout=five_minutes, prethread=caching_prethread())
+        mc = memcache_memoize(
+            cls.get_trending_feed,
+            key_prefix="my.books.trending.feed",
+            timeout=five_minutes,
+            prethread=caching_prethread(),
+        )
         results = mc()
 
         for r in results:
-            if isinstance(r['created'], str):  # `datetime` objects are stored in cache as strings
+            if isinstance(
+                r['created'], str
+            ):  # `datetime` objects are stored in cache as strings
                 r['created'] = datetime.fromisoformat(r['created'])
         return results

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -707,10 +707,7 @@ class ActivityFeed:
         feed = []
         for idx, item in enumerate(logged_books):
             if item['work'] and has_public_reading_log(item['username']):
-                item['work'].username = item['username']
-                item['work'].bookshelf_id = logged_books[idx]['bookshelf_id']
-                item['work'].created = logged_books[idx]['created']
-                feed.append(item['work'])
+                feed.append(item)
             if len(feed) > 2:
                 break
 

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -665,5 +665,12 @@ class ActivityFeed:
         `PubSub.get_feed` results.
         """
         following = PubSub.is_following(username)
-        feed = PubSub.get_feed(username, limit=3) if PubSub.is_following(username) else Bookshelves.get_recently_logged_books(limit=3)
+        if PubSub.is_following(username):
+            feed = PubSub.get_feed(username, limit=3)
+        else:
+            feed = Bookshelves.get_recently_logged_books(limit=3)
+            for i, doc in enumerate(feed):
+                feed[i].key = f'/works/OL{doc["work_id"]}W'
+            Bookshelves.add_solr_works(feed)
+
         return feed or [], following

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -114,9 +114,7 @@ class mybooks_home(delegate.page):
             owners_page=mb.is_my_page,
             counts=mb.counts,
             lists=mb.lists,
-            component_times=mb.component_times,
-            activity_feed=mb.activity_feed,
-            follows_others=mb.follows_others
+            component_times=mb.component_times
         )
 
 
@@ -444,11 +442,8 @@ class MyBooksTemplate:
             self.counts['followers'] = PubSub.count_followers(self.username)
             self.counts['following'] = PubSub.count_following(self.username)
 
-        self.activity_feed = []
-        self.follows_others = False
         if self.me and self.is_my_page:
             self.counts.update(PatronBooknotes.get_counts(self.username))
-            self.activity_feed, self.follows_others = ActivityFeed.get_activity_feed(self.username)
 
         self.component_times: dict = {}
 

--- a/openlibrary/templates/account/activity_feed.html
+++ b/openlibrary/templates/account/activity_feed.html
@@ -53,7 +53,7 @@ $def trending_card_footer(shelf_name, occurred_on):
 
                 $if follows_others:
                     $ username = i.get('username')
-                    $ avatar_url = "/person/%s/avatar" % username
+                    $ avatar_url = "/people/%s/avatar" % username
                     $ card_footer_html = activity_card_footer(shelf_name, occurred_on, username)
                 $else:
                     $ card_footer_html = trending_card_footer(shelf_name, occurred_on)

--- a/openlibrary/templates/account/activity_feed.html
+++ b/openlibrary/templates/account/activity_feed.html
@@ -48,9 +48,9 @@ $def trending_card_footer(shelf_name, occurred_on):
         <div class="list-showcase">
             $for i in feed:
                 $ shelf_name = shelf_id_to_name[i.get('bookshelf_id')]
-                $ bookcover_urls = ["//covers.openlibrary.org/b/id/%s-M.jpg" % i.get("work_id")]
                 $ occurred_on = datestr(i.get("created"))
-
+                $ cover = get_cover_url(i) or "/images/icons/avatar_book-sm.png"
+                $ bookcover_urls = [cover]
                 $if follows_others:
                     $ username = i.get('username')
                     $ avatar_url = "/people/%s/avatar" % username

--- a/openlibrary/templates/account/activity_feed.html
+++ b/openlibrary/templates/account/activity_feed.html
@@ -25,20 +25,22 @@ $def activity_card_header(book_title, book_key, author_name, author_key):
             <a class="activity-feed-card__header-author" href="$(author_key)">$author_name</a>
     </div>
 
-$def activity_card_footer(shelf_id, occurred_on, username):
+$def activity_card_footer(username, shelf_id, show_follow=False):
     $ user_key = "/people/%s" % username
     $ avatar_url = "%s/avatar" % user_key
-    $ shelf_name = shelf_id_to_name[shelf_id]
     $ shelf_url = "%s/books%s" % (user_key, shelf_id_to_path_segment[shelf_id])
-    $# shelf_url = user_key % '/books' % shelf_id_to_path_segment[shelf_id]
     <div class="activity-feed-card__footer">
         <div class="activity-feed-card__user">
             <a href="$user_key/books">
                 <img src="$avatar_url" alt="$_('Avatar of the owner of the list')">
             </a>
             <div class="activity-feed-card__footer-copy">
-                $:_('<a class="activity-feed-card__user-link" href="%(user_key)s/books">@%(username)s</a> added to <a href="%(shelf_url)s">%(shelf_name)s</a> %(occurred_on)s', user_key=user_key, username=username, shelf_url=shelf_url, shelf_name=shelf_name, occurred_on=occurred_on)
+                $:_('<a class="activity-feed-card__user-link" href="%(user_key)s/books">@%(username)s</a> added to <a href="%(shelf_url)s">shelf</a>', user_key=user_key, username=username, shelf_url=shelf_url)
             </div>
+            $if show_follow:
+                <div>
+                    $:macros.Follow(username, request_path="/account/books")
+                </div>
         </div>
     </div>
 
@@ -73,6 +75,6 @@ $elif not feed:
         $else:
             $ bookcover_url += "w/olid/OL%sW-M.jpg" % i.get("work_id")
         $ username = i.get('username')
-        $ card_footer_html = activity_card_footer(shelf_id, occurred_on, username)
+        $ card_footer_html = activity_card_footer(username, shelf_id, show_follow=(not follows_others))
         $:render_template("cards/multi_image_card", image_urls=[bookcover_url], header_html=card_header_html, footer_html=card_footer_html, href=book_key)
 </div>

--- a/openlibrary/templates/account/activity_feed.html
+++ b/openlibrary/templates/account/activity_feed.html
@@ -48,7 +48,7 @@ $def trending_card_footer(shelf_name, occurred_on):
         <div class="list-showcase">
             $for i in feed:
                 $ shelf_name = shelf_id_to_name[i.get('bookshelf_id')]
-                $ bookcover_urls = ["//covers.openlibrary.org/w/id/%s-M.jpg" % i.get("work_id")]
+                $ bookcover_urls = ["//covers.openlibrary.org/b/id/%s-M.jpg" % i.get("work_id")]
                 $ occurred_on = datestr(i.get("created"))
 
                 $if follows_others:

--- a/openlibrary/templates/account/activity_feed.html
+++ b/openlibrary/templates/account/activity_feed.html
@@ -12,28 +12,34 @@ $code:
         2: _('Currently Reading'),
         3: _('Already Read')
     }
+    shelf_id_to_path_segment = {
+        1: '/want-to-read',
+        2: '/currently-reading',
+        3: '/already-read'
+    }
 
-$def activity_card_footer(shelf_name, occurred_on, username):
+$def activity_card_header(book_title, book_key, author_name, author_key):
+    <div class="activity-feed-card__header">
+        <a class="activity-feed-card__header-title" href="$book_key">$book_title</a>
+        $if author_key:
+            <a class="activity-feed-card__header-author" href="$(author_key)">$author_name</a>
+    </div>
+
+$def activity_card_footer(shelf_id, occurred_on, username):
     $ user_key = "/people/%s" % username
     $ avatar_url = "%s/avatar" % user_key
+    $ shelf_name = shelf_id_to_name[shelf_id]
+    $ shelf_url = "%s/books%s" % (user_key, shelf_id_to_path_segment[shelf_id])
+    $# shelf_url = user_key % '/books' % shelf_id_to_path_segment[shelf_id]
     <div class="activity-feed-card__footer">
         <div class="activity-feed-card__user">
-            <a href="$user_key">
+            <a href="$user_key/books">
                 <img src="$avatar_url" alt="$_('Avatar of the owner of the list')">
             </a>
             <div class="activity-feed-card__footer-copy">
-                $:_('<a class="activity-feed-card__user-link" href="$user_key">@%(username)s</a> added to %(shelf_name)s %(occurred_on)s', username=username, shelf_name=shelf_name, occurred_on=occurred_on)
+                $:_('<a class="activity-feed-card__user-link" href="%(user_key)s/books">@%(username)s</a> added to <a href="%(shelf_url)s">%(shelf_name)s</a> %(occurred_on)s', user_key=user_key, username=username, shelf_url=shelf_url, shelf_name=shelf_name, occurred_on=occurred_on)
             </div>
         </div>
-        <div class="activity-feed-card__follow-button">
-            $ is_subscribed = ctx.user and ctx.user.is_subscribed_user(username)
-            $ settings = ctx.user.get_users_settings()
-        </div>
-    </div>
-
-$def trending_card_footer(shelf_name, occurred_on, username):
-    <div class="trending-feed-card__footer">
-        $_("%(someone)s marked as %(shelf_name)s %(occurred_on)s", someone=username, shelf_name=shelf_name, occurred_on=occurred_on)
     </div>
 
 <div class="carousel-section">
@@ -45,18 +51,31 @@ $def trending_card_footer(shelf_name, occurred_on, username):
             <p>$_("Here's the latest activity around the library. Follow readers to personalize your feed.")</p>
         $elif not feed:
            <p>$_("None of the people that you follow have logged books.  When they do, you'll see it here.")</p>
-        <div class="list-showcase">
+        <div class="activity-feed">
             $for i in feed:
-                $ shelf_name = shelf_id_to_name[i.get('bookshelf_id')]
-                $ occurred_on = datestr(i.get("created"))
-                $ bookcover_urls = ["//covers.openlibrary.org/w/id/%s-M.jpg" % i.get("work_id")]
-                $ username = i.get('username')
-                $if follows_others:
-                    $ avatar_url = "/people/%s/avatar" % username
-                    $ card_footer_html = activity_card_footer(shelf_name, occurred_on, username)
+                $ work = i.get('work')
+                $ book_title = work.get('title')
+                $if i.get('edition_id'):
+                    $ book_key = '/books/OL%sM' % i.get('edition_id')
                 $else:
-                    $ card_footer_html = trending_card_footer(shelf_name, occurred_on, username)
-                $:render_template("cards/multi_image_card", image_urls=bookcover_urls, footer_html=card_footer_html)
+                    $ book_key = work.get('key')
+                $if work.get('author_key', []) and work.get('author_key')[0]:
+                    $ author_key = '/authors/%s' % work.get('author_key')[0]
+                $else:
+                    $ author_key = None
+                $if work.get('author_name', []) and work.get('author_name')[0]:
+                    $ author_name = work.get('author_name')[0]
+                $else:
+                    $ author_name = _('Unknown author')
+                    $ author_key = None
+                $ card_header_html = activity_card_header(book_title, book_key, author_name, author_key)
+
+                $ shelf_id = i.get('bookshelf_id')
+                $ occurred_on = datestr(i.get("created"))
+                $ bookcover_urls = ["//covers.openlibrary.org/w/olid/OL%sW-M.jpg" % i.get("work_id")]
+                $ username = i.get('username')
+                $ card_footer_html = activity_card_footer(shelf_id, occurred_on, username)
+                $:render_template("cards/multi_image_card", image_urls=bookcover_urls, header_html=card_header_html, footer_html=card_footer_html)
         </div>
     </div>
 </div>

--- a/openlibrary/templates/account/activity_feed.html
+++ b/openlibrary/templates/account/activity_feed.html
@@ -1,0 +1,63 @@
+$def with(feed, feed_url, follows_others)
+
+$# Renders the given feed in a container filled with cards.
+$#
+$# * feed (list)              -- List of recent bookshelf events
+$# * feed_url (string)        -- `href` for the feed's source
+$# * follows_others (boolean) -- `True` if the authenticated patron follows at least one person
+
+$code:
+    shelf_id_to_name = {
+        1: _('Want to Read'),
+        2: _('Currently Reading'),
+        3: _('Already Read')
+    }
+
+$def activity_card_footer(shelf_name, occurred_on, username):
+    $ user_key = "/people/%s" % username
+    $ avatar_url = "%s/avatar" % user_key
+    <div class="activity-feed-card__footer">
+        <div class="activity-feed-card__user">
+            <a href="$user_key">
+                <img src="$avatar_url" alt="$_('Avatar of the owner of the list')">
+            </a>
+            <div class="activity-feed-card__footer-copy">
+                $:_('<a class="activity-feed-card__user-link" href="$user_key">@%(username)s</a> added to %(shelf_name)s %(occurred_on)s', username=username, shelf_name=shelf_name, occurred_on=occurred_on)
+            </div>
+        </div>
+        <div class="activity-feed-card__follow-button">
+            $ is_subscribed = ctx.user and ctx.user.is_subscribed_user(username)
+            $ settings = ctx.user.get_users_settings()
+        </div>
+    </div>
+
+$def trending_card_footer(shelf_name, occurred_on):
+    <div class="trending-feed-card__footer">
+        $_("Someone marked as %(shelf_name)s %(occurred_on)s", shelf_name=shelf_name, occurred_on=occurred_on)
+    </div>
+
+<div class="carousel-section">
+    <div class="carousel-section-header">
+        <h2 class="home-h2">
+            <a href="$feed_url">$_("My Feed")</a>
+        </h2>
+        $if not follows_others:
+            <p>$_("Here's the latest activity around the library. Follow readers to personalize your feed.")</p>
+        $elif not feed:
+           <p>$_("None of the people that you follow have logged books.  When they do, you'll see it here.")</p>
+        <div class="list-showcase">
+            $for i in feed:
+                $ shelf_name = shelf_id_to_name[i.get('bookshelf_id')]
+                $ bookcover_urls = ["//covers.openlibrary.org/w/id/%s-M.jpg" % i.get("work_id")]
+                $ occurred_on = datestr(i.get("created"))
+
+                $if follows_others:
+                    $ username = i.get('username')
+                    $ avatar_url = "/person/%s/avatar" % username
+                    $ card_footer_html = activity_card_footer(shelf_name, occurred_on, username)
+                $else:
+                    $ card_footer_html = trending_card_footer(shelf_name, occurred_on)
+                $:render_template("cards/multi_image_card", image_urls=bookcover_urls, footer_html=card_footer_html)
+        </div>
+    </div>
+</div>

--- a/openlibrary/templates/account/activity_feed.html
+++ b/openlibrary/templates/account/activity_feed.html
@@ -31,9 +31,9 @@ $def activity_card_footer(shelf_name, occurred_on, username):
         </div>
     </div>
 
-$def trending_card_footer(shelf_name, occurred_on):
+$def trending_card_footer(shelf_name, occurred_on, username):
     <div class="trending-feed-card__footer">
-        $_("Someone marked as %(shelf_name)s %(occurred_on)s", shelf_name=shelf_name, occurred_on=occurred_on)
+        $_("%(someone)s marked as %(shelf_name)s %(occurred_on)s", someone=username, shelf_name=shelf_name, occurred_on=occurred_on)
     </div>
 
 <div class="carousel-section">
@@ -49,14 +49,13 @@ $def trending_card_footer(shelf_name, occurred_on):
             $for i in feed:
                 $ shelf_name = shelf_id_to_name[i.get('bookshelf_id')]
                 $ occurred_on = datestr(i.get("created"))
-                $ cover = get_cover_url(i) or "/images/icons/avatar_book-sm.png"
-                $ bookcover_urls = [cover]
+                $ bookcover_urls = ["//covers.openlibrary.org/w/id/%s-M.jpg" % i.get("work_id")]
+                $ username = i.get('username')
                 $if follows_others:
-                    $ username = i.get('username')
                     $ avatar_url = "/people/%s/avatar" % username
                     $ card_footer_html = activity_card_footer(shelf_name, occurred_on, username)
                 $else:
-                    $ card_footer_html = trending_card_footer(shelf_name, occurred_on)
+                    $ card_footer_html = trending_card_footer(shelf_name, occurred_on, username)
                 $:render_template("cards/multi_image_card", image_urls=bookcover_urls, footer_html=card_footer_html)
         </div>
     </div>

--- a/openlibrary/templates/account/activity_feed.html
+++ b/openlibrary/templates/account/activity_feed.html
@@ -42,40 +42,33 @@ $def activity_card_footer(shelf_id, occurred_on, username):
         </div>
     </div>
 
-<div class="carousel-section">
-    <div class="carousel-section-header">
-        <h2 class="home-h2">
-            <a href="$feed_url">$_("My Feed")</a>
-        </h2>
-        $if not follows_others:
-            <p>$_("Here's the latest activity around the library. Follow readers to personalize your feed.")</p>
-        $elif not feed:
-           <p>$_("None of the people that you follow have logged books.  When they do, you'll see it here.")</p>
-        <div class="activity-feed">
-            $for i in feed:
-                $ work = i.get('work')
-                $ book_title = work.get('title')
-                $if i.get('edition_id'):
-                    $ book_key = '/books/OL%sM' % i.get('edition_id')
-                $else:
-                    $ book_key = work.get('key')
-                $if work.get('author_key', []) and work.get('author_key')[0]:
-                    $ author_key = '/authors/%s' % work.get('author_key')[0]
-                $else:
-                    $ author_key = None
-                $if work.get('author_name', []) and work.get('author_name')[0]:
-                    $ author_name = work.get('author_name')[0]
-                $else:
-                    $ author_name = _('Unknown author')
-                    $ author_key = None
-                $ card_header_html = activity_card_header(book_title, book_key, author_name, author_key)
+$if not follows_others:
+    <p>$_("Here's the latest activity around the library. Follow readers to personalize your feed.")</p>
+$elif not feed:
+   <p>$_("None of the people that you follow have logged books.  When they do, you'll see it here.")</p>
+<div class="activity-feed">
+    $for i in feed:
+        $ work = i.get('work')
+        $ book_title = work.get('title')
+        $if i.get('edition_id'):
+            $ book_key = '/books/OL%sM' % i.get('edition_id')
+        $else:
+            $ book_key = work.get('key')
+        $if work.get('author_key', []) and work.get('author_key')[0]:
+            $ author_key = '/authors/%s' % work.get('author_key')[0]
+        $else:
+            $ author_key = None
+        $if work.get('author_name', []) and work.get('author_name')[0]:
+            $ author_name = work.get('author_name')[0]
+        $else:
+            $ author_name = _('Unknown author')
+            $ author_key = None
+        $ card_header_html = activity_card_header(book_title, book_key, author_name, author_key)
 
-                $ shelf_id = i.get('bookshelf_id')
-                $ occurred_on = datestr(i.get("created"))
-                $ bookcover_urls = ["//covers.openlibrary.org/w/olid/OL%sW-M.jpg" % i.get("work_id")]
-                $ username = i.get('username')
-                $ card_footer_html = activity_card_footer(shelf_id, occurred_on, username)
-                $:render_template("cards/multi_image_card", image_urls=bookcover_urls, header_html=card_header_html, footer_html=card_footer_html)
-        </div>
-    </div>
+        $ shelf_id = i.get('bookshelf_id')
+        $ occurred_on = datestr(i.get("created"))
+        $ bookcover_urls = ["//covers.openlibrary.org/w/olid/OL%sW-M.jpg" % i.get("work_id")]
+        $ username = i.get('username')
+        $ card_footer_html = activity_card_footer(shelf_id, occurred_on, username)
+        $:render_template("cards/multi_image_card", image_urls=bookcover_urls, header_html=card_header_html, footer_html=card_footer_html, href=book_key)
 </div>

--- a/openlibrary/templates/account/activity_feed.html
+++ b/openlibrary/templates/account/activity_feed.html
@@ -67,8 +67,12 @@ $elif not feed:
 
         $ shelf_id = i.get('bookshelf_id')
         $ occurred_on = datestr(i.get("created"))
-        $ bookcover_urls = ["//covers.openlibrary.org/w/olid/OL%sW-M.jpg" % i.get("work_id")]
+        $ bookcover_url = '//covers.openlibrary.org/'
+        $if i.get("edition_id"):
+            $ bookcover_url += "b/olid/OL%sM-M.jpg" % i.get("edition_id")
+        $else:
+            $ bookcover_url += "w/olid/OL%sW-M.jpg" % i.get("work_id")
         $ username = i.get('username')
         $ card_footer_html = activity_card_footer(shelf_id, occurred_on, username)
-        $:render_template("cards/multi_image_card", image_urls=bookcover_urls, header_html=card_header_html, footer_html=card_footer_html, href=book_key)
+        $:render_template("cards/multi_image_card", image_urls=[bookcover_url], header_html=card_header_html, footer_html=card_footer_html, href=book_key)
 </div>

--- a/openlibrary/templates/account/mybooks.html
+++ b/openlibrary/templates/account/mybooks.html
@@ -70,10 +70,12 @@ $code:
             "test": False
         }) if books else None
 
-$def empty_mobile_carousel(data):
+$def empty_mobile_carousel(data, show_count=True):
     $ key, title, url = data
+    $if show_count:
+        $ title += ' (0)'
     <div class="carousel-section-header">
-      <a class="li-title-desktop" name="$key" href="$url">$title (0)<img class="icon-link__image li-count" src="/static/images/icons/right-chevron.svg"></a>
+      <a class="li-title-desktop" name="$key" href="$url">$title<img class="icon-link__image li-count" src="/static/images/icons/right-chevron.svg"></a>
     </div>
 
   $ component_times['Sidebar'] = time()
@@ -104,6 +106,10 @@ $def empty_mobile_carousel(data):
                 $:render_template('reading_goals/reading_goal_progress', [current_goal])
               </span>
           </div>
+        </li>
+        <li>
+            $ carousel_data = ('activity-feed-key', 'Activity Feed', feed_url)
+            $:empty_mobile_carousel(carousel_data, show_count=False)
         </li>
     $if public or owners_page:
         <li>
@@ -179,4 +185,3 @@ $def empty_mobile_carousel(data):
   </div>
   <p></p>
   $ component_times['Sidebar'] = time() - component_times['Sidebar']
-

--- a/openlibrary/templates/account/mybooks.html
+++ b/openlibrary/templates/account/mybooks.html
@@ -1,4 +1,4 @@
-$def with (user, mybooks, key=None, owners_page=False, public=False, counts=None, lists=None, component_times={})
+$def with (user, mybooks, key=None, owners_page=False, public=False, counts=None, lists=None, component_times={}, activity_feed=[], follows_others=False)
 
 $ username = user.key.split('/')[-1]
 
@@ -42,7 +42,9 @@ $def year_span(year, use_local_year=False):
 
   $# Render carousels
   $if owners_page:
+    $ feed_url = "%s/books/feed" % user.key
     $:(compact_carousel(loans) or empty_carousel(loans))
+    $:render_template("account/activity_feed", activity_feed, feed_url, follows_others)
   $if owners_page or public:
     $:(compact_carousel(currently_reading) or empty_carousel(currently_reading))
     $:(compact_carousel(want_to_read) or empty_carousel(want_to_read))

--- a/openlibrary/templates/account/mybooks.html
+++ b/openlibrary/templates/account/mybooks.html
@@ -1,4 +1,4 @@
-$def with (user, mybooks, key=None, owners_page=False, public=False, counts=None, lists=None, component_times={}, activity_feed=[], follows_others=False)
+$def with (user, mybooks, key=None, owners_page=False, public=False, counts=None, lists=None, component_times={})
 
 $ username = user.key.split('/')[-1]
 
@@ -44,7 +44,14 @@ $def year_span(year, use_local_year=False):
   $if owners_page:
     $ feed_url = "%s/books/feed" % user.key
     $:(compact_carousel(loans) or empty_carousel(loans))
-    $:render_template("account/activity_feed", activity_feed, feed_url, follows_others)
+    <div class="carousel-section activity-feed-container">
+        <div class="carousel-section-header">
+            <h2 class="home-h2">
+                <a href="$feed_url">$_("My Feed")</a>
+            </h2>
+        </div>
+        $:macros.LoadingIndicator(_("Loading Activity Feed"), hidden=False)
+    </div>
   $if owners_page or public:
     $:(compact_carousel(currently_reading) or empty_carousel(currently_reading))
     $:(compact_carousel(want_to_read) or empty_carousel(want_to_read))

--- a/openlibrary/templates/cards/multi_image_card.html
+++ b/openlibrary/templates/cards/multi_image_card.html
@@ -1,10 +1,5 @@
 $def with(header_html="", image_urls=[], href='', footer_html="")
 
-$def anchored_header():
-    <a href="$href" class="multi-img-card__header">
-        $:header_html
-    </a>
-
 $def header():
     <div class="multi-img-card__header">
         $:header_html
@@ -25,10 +20,7 @@ $def render_images():
         <img class="multi-img-card__images-img" src="$url" loading="lazy" width="80">
 
 <div class="multi-img-card">
-    $if href:
-        $:anchored_header()
-    $else:
-        $:header()
+    $:header()
     $if href:
         $:anchored_image_container()
     $else:

--- a/openlibrary/templates/cards/multi_image_card.html
+++ b/openlibrary/templates/cards/multi_image_card.html
@@ -22,7 +22,7 @@ $def image_container():
 
 $def render_images():
     $for url in image_urls:
-        <img src="$url" loading="lazy" width="80">
+        <img class="multi-img-card__images-img" src="$url" loading="lazy" width="80">
 
 <div class="multi-img-card">
     $if href:

--- a/openlibrary/templates/cards/multi_image_card.html
+++ b/openlibrary/templates/cards/multi_image_card.html
@@ -1,0 +1,28 @@
+$def with(header_html="", image_urls=[], image_href='', footer_html="")
+
+$def anchor_image_container():
+    <a href="$image_href" class="info-card__images">
+        $:render_images()
+    </a>
+
+$def div_image_container():
+    <div class="info-card__images">
+        $:render_images()
+    </div>
+
+$def render_images():
+    $for url in image_urls:
+        <img src="$url" loading="lazy" width="80">
+
+<div class="info-card">
+    <div class="info-card__header">
+        $:header_html
+    </div>
+    $if image_href:
+        $:anchor_image_container()
+    $else:
+        $:div_image_container()
+    <div class="info-card__footer">
+        $:footer_html
+    </div>
+</div>

--- a/openlibrary/templates/cards/multi_image_card.html
+++ b/openlibrary/templates/cards/multi_image_card.html
@@ -1,11 +1,21 @@
-$def with(header_html="", image_urls=[], image_href='', footer_html="")
+$def with(header_html="", image_urls=[], href='', footer_html="")
 
-$def anchor_image_container():
-    <a href="$image_href" class="multi-img-card__images">
+$def anchored_header():
+    <a href="$href" class="multi-img-card__header">
+        $:header_html
+    </a>
+
+$def header():
+    <div class="multi-img-card__header">
+        $:header_html
+    </div>
+
+$def anchored_image_container():
+    <a href="$href" class="multi-img-card__images">
         $:render_images()
     </a>
 
-$def div_image_container():
+$def image_container():
     <div class="multi-img-card__images">
         $:render_images()
     </div>
@@ -15,13 +25,14 @@ $def render_images():
         <img src="$url" loading="lazy" width="80">
 
 <div class="multi-img-card">
-    <div class="multi-img-card__header">
-        $:header_html
-    </div>
-    $if image_href:
-        $:anchor_image_container()
+    $if href:
+        $:anchored_header()
     $else:
-        $:div_image_container()
+        $:header()
+    $if href:
+        $:anchored_image_container()
+    $else:
+        $:image_container()
     <div class="multi-img-card__footer">
         $:footer_html
     </div>

--- a/openlibrary/templates/cards/multi_image_card.html
+++ b/openlibrary/templates/cards/multi_image_card.html
@@ -1,12 +1,12 @@
 $def with(header_html="", image_urls=[], image_href='', footer_html="")
 
 $def anchor_image_container():
-    <a href="$image_href" class="info-card__images">
+    <a href="$image_href" class="multi-img-card__images">
         $:render_images()
     </a>
 
 $def div_image_container():
-    <div class="info-card__images">
+    <div class="multi-img-card__images">
         $:render_images()
     </div>
 
@@ -14,15 +14,15 @@ $def render_images():
     $for url in image_urls:
         <img src="$url" loading="lazy" width="80">
 
-<div class="info-card">
-    <div class="info-card__header">
+<div class="multi-img-card">
+    <div class="multi-img-card__header">
         $:header_html
     </div>
     $if image_href:
         $:anchor_image_container()
     $else:
         $:div_image_container()
-    <div class="info-card__footer">
+    <div class="multi-img-card__footer">
         $:footer_html
     </div>
 </div>

--- a/openlibrary/templates/lists/list_follow.html
+++ b/openlibrary/templates/lists/list_follow.html
@@ -4,79 +4,74 @@ $def render_follow_button(owner_username, is_subscribed):
   $ request = "/people/" + owner_username
   $:macros.Follow(owner_username, following=is_subscribed, request_path=request)
 
-$def list_card(list, owner, own_list):
-    $ has_owner = owner
-    $ cached_info = list.get_patron_showcase()
-    $ count = cached_info["count"]
-    <div class="list-follow-card">
-        <a class="list-follow-card__header" href="$list.get_url()">
-                <div class="list-follow-card__title" title="${cached_info['title']}">$cached_info['title']</div>
-             <div class="list-follow-card__num-books">
-                 $ungettext("%(count)d book", "%(count)d books", count, count=count)
-             </div>
-        </a>
-        <a class="list-follow-card__covers" href="$list.get_url()">
-           $for img_url in cached_info["covers"]:
-               $if img_url:
-                   $ img_url = img_url.replace("-S.jpg", "-M.jpg")
-               $else:
-                   $ img_url = '/images/icons/avatar_book-sm.png'
-               <img src="$img_url" alt="$_('Cover of book')" loading="lazy" width="80"/>
-        </a>
-
-        <!-- Bottom section: owner info or community label -->
-        $if owner:
-            <div class="list-follow-card__bottom">
-                <div class="list-follow-card__user">
-
-                            $ owner_username = owner.key.split('/')[-1]
-                    <a href="$owner.key">
-                        <img src="$(owner.key)/avatar" alt="$_('Avatar of the owner of the list')" />
-                    </a>
-                    <div class="list-follow-card__username">
-                        $if not own_list:
-                            <a class="list-follow-card__username-link" href="$owner.key" title="$owner_username">
-                                @${owner_username}
-                            </a>
-                        $else:
-                            <a class="list-follow-card__username-link" href="$owner.key">
-                                $_('You')
-                            </a>
-                    </div>
-                </div>
-                <div class="list-follow-card__follow-button">
-                    $if not own_list:
-                        $ owner_account = get_user_object(owner_username)
-                        $ is_subscribed = ctx.user and ctx.user.is_subscribed_user(owner_username)
-                        $ settings = owner_account.get_users_settings()
-                        $ is_public = settings and settings.get('public_readlog', 'no') == "yes"
-                        $if is_public:
-                            $:render_follow_button(owner_username, is_subscribed)
-                        $else:
-                            <div title="$_('This patron has not enabled following')">
-                                <button class="list-follow-card__private-button" >
-                                    <span class="pvt-icon">$_('🔒︎')</span>
-                                    <span class="pvt-text">$_('Follow')</span>
-                                </button>
-                            </div>
-                </div>
-            </div>
-        $else:
-            <div class="list-follow-card__bottom-community">
-                <div class="list-follow-card__user">
-                    <img src="/static/images/openlibrary-128x128.png" alt="$_('OpenLibrary Logo')"/>
-                    <div class="list-follow-card__community-label">
-                        <i>$_("Community List")</i>
-                    </div>
-                </div>
-            </div>
+$def render_card_header(list_name, count):
+    <div class="list-follow-card__header">
+        <div class="list-follow-card__title" title="$list_name">$list_name</div>
+        <div class="list-follow-card__num-books">
+            $ungettext("%(count)d book", "%(count)d books", count, count=count)
+        </div>
     </div>
+
+$def render_card_footer(owner, own_list):
+    $if owner:
+        <div class="list-follow-card__bottom">
+            <div class="list-follow-card__user">
+                $ owner_username = owner.key.split('/')[-1]
+                <a href="$owner.key">
+                    <img src="$(owner.key)/avatar" alt="$_('Avatar of the owner of the list')"/>
+                </a>
+                <div class="list-follow-card__username">
+                    $if not own_list:
+                        <a class="list-follow-card__username-link" href="$owner.key" title="$owner_username">
+                            @${owner_username}
+                        </a>
+                    $else:
+                        <a class="list-follow-card__username-link" href="$owner.key">
+                            $_('You')
+                        </a>
+                </div>
+            </div>
+            <div class="list-follow-card__follow-button">
+                $if not own_list:
+                    $ owner_account = get_user_object(owner_username)
+                    $ is_subscribed = ctx.user and ctx.user.is_subscribed_user(owner_username)
+                    $ settings = owner_account.get_users_settings()
+                    $ is_public = settings and settings.get('public_readlog', 'no') == "yes"
+                    $if is_public:
+                        $:render_follow_button(owner_username, is_subscribed)
+                    $else:
+                        <div title="$_('This patron has not enabled following')">
+                            <button class="list-follow-card__private-button">
+                                <span class="pvt-icon">$_('🔒︎')</span>
+                                <span class="pvt-text">$_('Follow')</span>
+                            </button>
+                        </div>
+            </div>
+        </div>
+    $else:
+        <div class="list-follow-card__user">
+            <img src="/static/images/openlibrary-128x128.png" alt="$_('OpenLibrary Logo')"/>
+            <div class="list-follow-card__community-label">
+                <i>$_("Community List")</i>
+            </div>
+        </div>
 
 $ count = 0
 $for i, list in enumerate(lists):
     $if count < limit:
-      $ own_list = list.owner and list.owner.key == user_key
-      $ converted = convert_list(list.key)
-      $:list_card(converted, list.owner, own_list)
-      $ count = count + 1
+        $ own_list = list.owner and list.owner.key == user_key
+        $ converted = convert_list(list.key)
 
+        $ cached_info = converted.get_patron_showcase()
+        $ count = cached_info["count"]
+        $ card_header = render_card_header(cached_info['title'], count)
+        $ card_footer = render_card_footer(list.owner, own_list)
+        $ image_urls = []
+        $for img_url in cached_info["covers"]:
+            $if img_url:
+                $image_urls.append(img_url.replace("-S.jpg", "-M.jpg"))
+            $else:
+                $image_urls.append("/images/icons/avatar_book-sm.png")
+
+        $:render_template("cards/multi_image_card", header_html=card_header, image_urls=image_urls, footer_html=card_footer, href=converted.get_url())
+      $ count = count + 1

--- a/openlibrary/templates/lists/list_follow.html
+++ b/openlibrary/templates/lists/list_follow.html
@@ -4,13 +4,13 @@ $def render_follow_button(owner_username, is_subscribed):
   $ request = "/people/" + owner_username
   $:macros.Follow(owner_username, following=is_subscribed, request_path=request)
 
-$def render_card_header(list_name, count):
-    <div class="list-follow-card__header">
+$def render_card_header(list_name, count, list_url):
+    <a class="list-follow-card__header" href="$list_url">
         <div class="list-follow-card__title" title="$list_name">$list_name</div>
         <div class="list-follow-card__num-books">
             $ungettext("%(count)d book", "%(count)d books", count, count=count)
         </div>
-    </div>
+    </a>
 
 $def render_card_footer(owner, own_list):
     $if owner:
@@ -64,7 +64,7 @@ $for i, list in enumerate(lists):
 
         $ cached_info = converted.get_patron_showcase()
         $ book_count = cached_info["count"]
-        $ card_header = render_card_header(cached_info['title'], book_count)
+        $ card_header = render_card_header(cached_info['title'], book_count, converted.get_url())
         $ card_footer = render_card_footer(list.owner, own_list)
         $ image_urls = []
         $for img_url in cached_info["covers"]:

--- a/openlibrary/templates/lists/list_follow.html
+++ b/openlibrary/templates/lists/list_follow.html
@@ -63,8 +63,8 @@ $for i, list in enumerate(lists):
         $ converted = convert_list(list.key)
 
         $ cached_info = converted.get_patron_showcase()
-        $ count = cached_info["count"]
-        $ card_header = render_card_header(cached_info['title'], count)
+        $ book_count = cached_info["count"]
+        $ card_header = render_card_header(cached_info['title'], book_count)
         $ card_footer = render_card_footer(list.owner, own_list)
         $ image_urls = []
         $for img_url in cached_info["covers"]:
@@ -74,4 +74,4 @@ $for i, list in enumerate(lists):
                 $image_urls.append("/images/icons/avatar_book-sm.png")
 
         $:render_template("cards/multi_image_card", header_html=card_header, image_urls=image_urls, footer_html=card_footer, href=converted.get_url())
-      $ count = count + 1
+        $ count = count + 1

--- a/openlibrary/templates/lists/showcase.html
+++ b/openlibrary/templates/lists/showcase.html
@@ -1,26 +1,12 @@
 $def with (lists, username)
 
-
-$def list_card(list):
-    $ cached_info = list.get_patron_showcase()
-    $ count = cached_info["count"]
-    <a class="list-card" href="$list.get_url()">
-        <div class="list-card__covers">
-            $for img_url in cached_info["covers"]:
-                $if img_url:
-                    $ img_url = img_url.replace("-S.jpg", "-M.jpg")
-                $else:
-                    $ img_url = '/images/icons/avatar_book-sm.png'
-                <img src="$img_url" loading="lazy" width="80">
+$def card_footer(title, book_count):
+    <div class="list-card__name-tag">
+        <div class="list-card__title">$title</div>
+        <div class="list-card__num-books">
+            $ungettext("%(count)d book", "%(count)d books", book_count, count=book_count)
         </div>
-        <div class="list-card__name-tag">
-            <div class="list-card__title">$cached_info["title"]</div>
-            <div class="list-card__num-books">
-                $ungettext("%(count)d book", "%(count)d books", count, count=count)
-            </div>
-        </div>
-    </a>
-
+    </div>
 
 <div class="carousel-section">
     <div class="carousel-section-header">
@@ -31,9 +17,19 @@ $def list_card(list):
     <div class="list-showcase">
         $if lists:
             $ displayed_lists = 5
-            $for list in lists[:displayed_lists]
-                $:list_card(list)
-
+            $for list in lists[:displayed_lists]:
+                $ cached_info = list.get_patron_showcase()
+                $ image_urls = []
+                $for img_url in cached_info["covers"]:
+                    $if img_url:
+                        $ img_url = img_url.replace("-S.jpg", "-M.jpg")
+                    $else:
+                        $ img_url = '/images/icons/avatar_book-sm.png'
+                    $image_urls.append(img_url)
+                $ footer_html = card_footer(cached_info["title"], cached_info["count"])
+                <a class="list-card" href="$list.get_url()">
+                    $:render_template("cards/multi_image_card", image_urls=image_urls, footer_html=footer_html)
+                </a>
             $if len(lists) > displayed_lists:
                 <a
                     class="list-showcase__see-all cta-btn cta-btn--vanilla"

--- a/static/css/components/activity-feed.less
+++ b/static/css/components/activity-feed.less
@@ -1,45 +1,45 @@
 .multi-img-card {
-    margin-right: 24px;
-    flex-shrink: 0;
+  margin-right: 24px;
+  flex-shrink: 0;
 
-    &__images {
-        justify-content: center;
-    }
+  &__images {
+    justify-content: center;
+  }
 }
 
 .activity-feed-card__user {
-    display: flex;
-    align-items: center;
-    font-size: @font-size-label-medium;
-    padding-left: 5px;
-    flex: 1;
-    min-width: 0;
+  display: flex;
+  align-items: center;
+  font-size: @font-size-label-medium;
+  padding-left: 5px;
+  flex: 1;
+  min-width: 0;
 
-    img {
-        border-radius: 8px;
-        width: 30px;
-        height: 30px;
-        margin-right: 5px;
-        margin-top: -10px;
-        position: relative;
-        z-index: @z-index-level-3;
-        border: 2px solid @white;
-    }
+  img {
+    border-radius: 8px;
+    width: 30px;
+    height: 30px;
+    margin-right: 5px;
+    margin-top: -10px;
+    position: relative;
+    z-index: @z-index-level-3;
+    border: 2px solid @white;
+  }
 }
 
 .activity-feed-card__footer,
 .trending-feed-card__footer {
-    background: @grey-f4f4f4;
-    display: flex;
-    justify-content: space-between;
-    padding-bottom: 5px;
-    padding-top: 5px;
-    gap: 0.5em;
-    width: 100%;
-    border-radius: 0 0 4px 4px;
-    font-size: 12px;
+  background: @grey-f4f4f4;
+  display: flex;
+  justify-content: space-between;
+  padding-bottom: 5px;
+  padding-top: 5px;
+  gap: 0.5em;
+  width: 100%;
+  border-radius: 0 0 4px 4px;
+  font-size: 12px;
 }
 
 .trending-feed-card__footer {
-    padding: 5px;
+  padding: 5px;
 }

--- a/static/css/components/activity-feed.less
+++ b/static/css/components/activity-feed.less
@@ -1,34 +1,49 @@
-.multi-img-card {
-  margin-right: 24px;
-  flex-shrink: 0;
-
-  &__images {
-    justify-content: center;
-  }
-}
-
-.activity-feed-card__user {
+.activity-feed {
   display: flex;
-  align-items: center;
-  font-size: @font-size-label-medium;
-  padding-left: 5px;
-  flex: 1;
-  min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: thin;
+  padding: 8px 0;
 
-  img {
-    border-radius: 8px;
-    width: 30px;
-    height: 30px;
-    margin-right: 5px;
-    margin-top: -10px;
-    position: relative;
-    z-index: @z-index-level-3;
-    border: 2px solid @white;
+  .multi-img-card {
+    margin-right: 24px;
+    flex-shrink: 0;
+
+    &__images {
+      justify-content: center;
+    }
+
+    .multi-img-card__images-img {
+      width: 75px;
+    }
   }
 }
 
-.activity-feed-card__footer,
-.trending-feed-card__footer {
+.activity-feed-card__header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: inherit;
+
+  .activity-feed-card__header-title,
+  .activity-feed-card__header-author {
+    width: inherit;
+    white-space: nowrap;
+    text-align: center;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-decoration: none;
+  }
+  .activity-feed-card__header-title {
+    color: #000;
+    font-weight: 700;
+  }
+  .activity-feed-card__header-author {
+    color: #545454;
+  }
+}
+
+.activity-feed-card__footer {
   background: @grey-f4f4f4;
   display: flex;
   justify-content: space-between;
@@ -40,6 +55,23 @@
   font-size: 12px;
 }
 
-.trending-feed-card__footer {
-  padding: 5px;
+.activity-feed-card__user {
+  display: flex;
+  align-items: center;
+  font-size: @font-size-label-medium;
+  padding-left: 5px;
+  flex: 1;
+  min-width: 0;
+
+  /* avatar image */
+  img {
+    border-radius: 8px;
+    width: 30px;
+    height: 30px;
+    margin-right: 5px;
+    margin-top: -10px;
+    position: relative;
+    z-index: @z-index-level-3;
+    border: 2px solid @white;
+  }
 }

--- a/static/css/components/activity-feed.less
+++ b/static/css/components/activity-feed.less
@@ -1,0 +1,45 @@
+.multi-img-card {
+    margin-right: 24px;
+    flex-shrink: 0;
+
+    &__images {
+        justify-content: center;
+    }
+}
+
+.activity-feed-card__user {
+    display: flex;
+    align-items: center;
+    font-size: @font-size-label-medium;
+    padding-left: 5px;
+    flex: 1;
+    min-width: 0;
+
+    img {
+        border-radius: 8px;
+        width: 30px;
+        height: 30px;
+        margin-right: 5px;
+        margin-top: -10px;
+        position: relative;
+        z-index: @z-index-level-3;
+        border: 2px solid @white;
+    }
+}
+
+.activity-feed-card__footer,
+.trending-feed-card__footer {
+    background: @grey-f4f4f4;
+    display: flex;
+    justify-content: space-between;
+    padding-bottom: 5px;
+    padding-top: 5px;
+    gap: 0.5em;
+    width: 100%;
+    border-radius: 0 0 4px 4px;
+    font-size: 12px;
+}
+
+.trending-feed-card__footer {
+    padding: 5px;
+}

--- a/static/css/components/activity-feed.less
+++ b/static/css/components/activity-feed.less
@@ -35,11 +35,11 @@
     text-decoration: none;
   }
   .activity-feed-card__header-title {
-    color: #000;
+    color: @black;
     font-weight: 700;
   }
   .activity-feed-card__header-author {
-    color: #545454;
+    color: @grey-555;
   }
 }
 

--- a/static/css/components/activity-feed.less
+++ b/static/css/components/activity-feed.less
@@ -47,19 +47,22 @@
   background: @grey-f4f4f4;
   display: flex;
   justify-content: space-between;
-  padding-bottom: 5px;
-  padding-top: 5px;
+  padding: 5px;
   gap: 0.5em;
   width: 100%;
   border-radius: 0 0 4px 4px;
   font-size: 12px;
+
+  &-copy {
+    flex-grow: 2;
+    margin-left: 12px;
+  }
 }
 
 .activity-feed-card__user {
   display: flex;
   align-items: center;
   font-size: @font-size-label-medium;
-  padding-left: 5px;
   flex: 1;
   min-width: 0;
 

--- a/static/css/components/list-follow.less
+++ b/static/css/components/list-follow.less
@@ -1,244 +1,140 @@
-@import (less) "../less/colors.less";
-@import (less) "../less/font-families.less";
-@import (less) "components/read-panel.less";
-@import (less) "components/book.less";
-
 .list-follow-showcase {
-  display: flex;
-  overflow-x: auto;
-  scrollbar-width: thin;
-  padding: 8px 0;
-
-  .list-follow-card {
-    margin-right: 24px;
-    flex-shrink: 0;
-  }
-
   &__see-all {
     margin-right: 24px;
     align-self: center;
     width: auto;
   }
 }
+.list-follow-card__bottom {
+  background: @grey-f4f4f4;
+  display: flex;
+  justify-content: space-between;
+  padding-bottom: 5px;
+  padding-top: 5px;
+  gap: 0.5em;
+  width: 100%;
+  border-radius: 0 0 4px 4px;
+}
+.list-follow-card__user {
+  display: flex;
+  align-items: center;
+  font-size: @font-size-label-medium;
+  padding-left: 5px;
+  flex: 1;
+  min-width: 0;
 
-// stylelint-disable-next-line no-descending-specificity
-.list-follow-card {
+  img {
+    border-radius: 8px;
+    width: 30px;
+    height: 30px;
+    margin-right: 5px;
+    margin-top: -10px;
+    position: relative;
+    z-index: @z-index-level-3;
+    border: 2px solid @white;
+  }
+}
+
+.list-follow-card__username {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-decoration: none;
+  padding-bottom: 5px;
+  flex: 1;
+  min-width: 0;
+}
+.list-follow-card__username-link {
   a& {
     text-decoration: none;
-  }
-
-  display: flex;
-  flex-direction: column;
-
-  background-color: @beige;
-
-  @card-width: 215px;
-  width: @card-width;
-  height: 150px;
-
-  border: 1px solid fade(@black, 25%);
-  border-radius: 4px;
-  box-shadow: 2px 2px 4px fade(@black, 15%);
-
-  &__header {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    padding: 7px 10px;
-    border-radius: 0 0 4px 4px;
-    width: 100%;
-    a& {
-      text-decoration: none;
-    }
-  }
-  &__name-avatar {
-    display: flex;
-  }
-  &__bottom {
-    background: @grey-f4f4f4;
-    display: flex;
-    justify-content: space-between;
+    color: @dark-grey-two;
     padding-bottom: 5px;
-    padding-top: 5px;
-    gap: 0.5em;
-    width: 100%;
-    border-radius: 0 0 4px 4px;
-  }
-  &__user {
-    display: flex;
-    align-items: center;
-    font-size: @font-size-label-medium;
-    padding-left: 5px;
-    flex: 1;
-    min-width: 0;
-
-    img {
-      border-radius: 8px;
-      width: 30px;
-      height: 30px;
-      margin-right: 5px;
-      margin-top: -10px;
-      position: relative;
-      z-index: @z-index-level-3;
-      border: 2px solid @white;
-      flex-shrink: 0;
-    }
-  }
-
-  &__username {
+    text-overflow: ellipsis;
+    overflow: hidden;
     white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    text-decoration: none;
-    padding-bottom: 5px;
-    flex: 1;
-    min-width: 0;
-  }
-  &__username-link {
-    a& {
-      text-decoration: none;
-      color: @dark-grey-two;
-      padding-bottom: 5px;
-      text-overflow: ellipsis;
-      overflow: hidden;
-      white-space: nowrap;
-      max-width: 100%;
-      display: inline-block;
-      position: relative;
-      top: 0.2rem;
-    }
-  }
-  &__text {
-    display: flex;
-    flex-direction: column;
-  }
-
-  &__follow-button {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding-right: 5px;
-    padding-bottom: 3px;
-    .cta-btn {
-      font-size: @font-size-label-medium; // Override base size
-      padding: 1px 10px; // Less padding
-      border-radius: 4px; // Custom radius
-      box-shadow: none; // Remove default shadow if present
-      margin: 0;
-    }
-  }
-  &__private-button {
-    background-color: @grey;
-    border: none;
-    cursor: not-allowed;
-    pointer-events: auto;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    padding-bottom: 1px;
-    border-radius: 4px;
-    .pvt-text {
-      color: @white;
-      font-size: 12px; // Override base size
-      padding: 2px 4px; // Less padding
-      box-shadow: none; // Remove default shadow if present
-      margin: 0;
-      letter-spacing: 0.2px;
-      margin-top: 1px;
-    }
-    .pvt-icon {
-      color: @white;
-      font-size: 14px;
-    }
-  }
-  &__title {
-    font-weight: bold;
-    font-size: @font-size-label-large;
-    color: @black;
-    width: 100%;
-    max-height: 2.8em;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    line-height: 1.4em;
-    white-space: normal;
-    word-break: break-word;
+    max-width: 100%;
+    display: inline-block;
     position: relative;
-    text-align: center;
-    display: -webkit-box;
-    -webkit-line-clamp: 1;
-    -webkit-box-orient: vertical;
+    top: 0.2rem;
   }
+}
 
-  &__bottom-community {
-    background: @grey-f4f4f4;
-    display: flex;
-    justify-content: space-between;
-    padding-bottom: 5px;
-    padding-top: 5px;
-    margin-bottom: -3px;
-    border-radius: 0 0 3px 3px;
+.list-follow-card__follow-button {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-right: 5px;
+  padding-bottom: 3px;
+  .cta-btn {
+    font-size: @font-size-label-medium; // Override base size
+    padding: 1px 10px; // Less padding
+    border-radius: 4px; // Custom radius
+    box-shadow: none; // Remove default shadow if present
+    margin: 0;
   }
-  &__community-label {
-    font-weight: normal;
-    font-size: @font-size-label-large;
-    color: @black;
-
-    white-space: nowrap;
-    overflow: hidden;
-    padding-bottom: 2px;
+}
+.list-follow-card__private-button {
+  background-color: @grey;
+  border: none;
+  cursor: not-allowed;
+  pointer-events: auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding-bottom: 1px;
+  border-radius: 4px;
+  .pvt-text {
+    color: @white;
+    font-size: 12px; // Override base size
+    padding: 2px 4px; // Less padding
+    box-shadow: none; // Remove default shadow if present
+    margin: 0;
+    letter-spacing: 0.2px;
+    margin-top: 1px;
   }
-  &__num-books {
-    color: @grey-555;
-    font-size: @font-size-label-medium;
+  .pvt-icon {
+    color: @white;
+    font-size: 14px;
   }
-  &__info {
-    flex: 1;
-    flex-direction: row;
-  }
-  &__covers {
-    @cover-width: 64px;
-    @padding: 20px;
+}
+.list-follow-card__title {
+  font-weight: bold;
+  font-size: @font-size-label-large;
+  color: @black;
+  width: 100%;
+  max-height: 2.8em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.4em;
+  white-space: normal;
+  word-break: break-word;
+  position: relative;
+  text-align: center;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+}
 
-    flex: 1;
-    min-height: 1px; // fallback
-    overflow: clip;
+.list-follow-card__num-books {
+  color: @grey-555;
+  font-size: @font-size-label-medium;
+}
 
-    display: flex;
-    align-items: center;
-    padding: 0 @padding;
+.list-follow-card__bottom-community {
+  background: @grey-f4f4f4;
+  display: flex;
+  justify-content: space-between;
+  padding-bottom: 5px;
+  padding-top: 5px;
+  margin-bottom: -3px;
+  border-radius: 0 0 3px 3px;
+}
 
-    img {
-      width: @cover-width;
-      border-radius: 4px;
-      box-shadow: 4px 4px 0 fade(@black, 25%);
-    }
+.list-follow-card__community-label {
+  font-weight: normal;
+  font-size: @font-size-label-large;
+  color: @black;
 
-    @top-cover: 3;
-    @mid-cover: 2;
-    @bottom-cover: 1;
-
-    @overlap: ((3 * @cover-width - (@card-width - 2 * @padding)) / 2);
-
-    img:nth-child(1) {
-      z-index: @top-cover;
-      transform: translate(0, @padding);
-    }
-    img:nth-child(2) {
-      z-index: @mid-cover;
-      transform: translate(-@overlap, @padding);
-    }
-    img:nth-child(3) {
-      z-index: @bottom-cover;
-      transform: translate(-2 * @overlap, @padding);
-    }
-    &:hover img {
-      scale: 1.05;
-    }
-  }
-
-  // stylelint-disable-next-line no-descending-specificity
-  img {
-    transition: scale 0.2s;
-  }
+  white-space: nowrap;
+  overflow: hidden;
+  padding-bottom: 2px;
 }

--- a/static/css/components/list-follow.less
+++ b/static/css/components/list-follow.less
@@ -1,4 +1,14 @@
 .list-follow-showcase {
+  display: flex;
+  overflow-x: auto;
+  scrollbar-width: thin;
+  padding: 8px 0;
+
+  .multi-img-card {
+    margin-right: 24px;
+    flex-shrink: 0;
+  }
+
   &__see-all {
     margin-right: 24px;
     align-self: center;

--- a/static/css/components/list-follow.less
+++ b/static/css/components/list-follow.less
@@ -106,6 +106,14 @@
     font-size: 14px;
   }
 }
+
+.multi-img-card {
+  .list-follow-card__header {
+    text-decoration: none;
+    text-align: center;
+  }
+}
+
 .list-follow-card__title {
   font-weight: bold;
   font-size: @font-size-label-large;

--- a/static/css/components/list-showcase.less
+++ b/static/css/components/list-showcase.less
@@ -46,4 +46,8 @@
     color: @grey-555;
     font-size: @font-size-label-medium;
   }
+
+  .multi-img-card__images {
+    justify-content: initial;
+  }
 }

--- a/static/css/components/list-showcase.less
+++ b/static/css/components/list-showcase.less
@@ -2,6 +2,7 @@
 @import (less) "../less/font-families.less";
 @import (less) "components/read-panel.less";
 @import (less) "components/book.less";
+@import (less) "components/multi-image-card.less";
 
 .list-showcase {
   display: flex;
@@ -27,25 +28,8 @@
     text-decoration: none;
   }
 
-  display: flex;
-  flex-direction: column;
-
-  background-color: @beige;
-
-  @card-width: 215px;
-  width: @card-width;
-  height: 150px;
-
-  border: 1px solid fade(@black, 25%);
-  border-radius: 4px;
-  box-shadow: 2px 2px 4px fade(@black, 15%);
-
   &__name-tag {
-    background: @grey-f4f4f4;
     padding: 7px 10px;
-
-    border-radius: 0 0 4px 4px;
-    box-shadow: 0 0 4px fade(@black, 25%);
   }
 
   &__title {
@@ -61,52 +45,5 @@
   &__num-books {
     color: @grey-555;
     font-size: @font-size-label-medium;
-  }
-
-  &__covers {
-    @cover-width: 64px;
-    @padding: 20px;
-
-    flex: 1;
-    min-height: 1px; // fallback
-    overflow: clip;
-
-    display: flex;
-    align-items: center;
-    padding: 0 @padding;
-
-    img {
-      width: @cover-width;
-      border-radius: 4px;
-      box-shadow: 4px 4px 0 fade(@black, 25%);
-    }
-
-    @top-cover: 3;
-    @mid-cover: 2;
-    @bottom-cover: 1;
-
-    @overlap: ((3 * @cover-width - (@card-width - 2 * @padding)) / 2);
-
-    img:nth-child(1) {
-      z-index: @top-cover;
-      transform: translate(0, @padding);
-    }
-    img:nth-child(2) {
-      z-index: @mid-cover;
-      transform: translate(-@overlap, @padding);
-    }
-    img:nth-child(3) {
-      z-index: @bottom-cover;
-      transform: translate(-2 * @overlap, @padding);
-    }
-  }
-
-  // stylelint-disable-next-line no-descending-specificity
-  img {
-    transition: scale 0.2s;
-  }
-
-  &:hover img {
-    scale: 1.05;
   }
 }

--- a/static/css/components/multi-image-card.less
+++ b/static/css/components/multi-image-card.less
@@ -4,7 +4,7 @@
 @top-cover-z-index: 3;
 @middle-cover-z-index: 2;
 @bottom-cover-z-index: 1;
-@cover-overlap: (3 * @cover-width - (@card-width - 2 * @cover-padding)) / 2;
+@cover-overlap: ((3 * @cover-width - (@card-width - 2 * @cover-padding)) / 2);
 
 .multi-img-card {
   a& {
@@ -57,17 +57,17 @@
 
   img:nth-child(1) {
     z-index: @top-cover-z-index;
-    transform: translate(0, 20px);
+    transform: translate(0, @cover-padding);
   }
 
   img:nth-child(2) {
     z-index: @middle-cover-z-index;
-    transform: translate(-8.5px, 20px);
+    transform: translate(-1 * @cover-overlap, @cover-padding);
   }
 
   img:nth-child(3) {
     z-index: @bottom-cover-z-index;
-    transform: translate(-17px, 20px);
+    transform: translate(-2 * @cover-overlap, @cover-padding);
   }
 }
 

--- a/static/css/components/multi-image-card.less
+++ b/static/css/components/multi-image-card.less
@@ -4,75 +4,75 @@
 @top-cover-z-index: 3;
 @middle-cover-z-index: 2;
 @bottom-cover-z-index: 1;
-@cover-overlap: calc((3 * @cover-width - (@card-width - 2 * @cover-padding)) / 2);
+@cover-overlap: (3 * @cover-width - (@card-width - 2 * @cover-padding)) / 2;
 
 .multi-img-card {
-    a& {
-        text-decoration: none;
-    }
-    display: flex;
-    flex-direction: column;
+  a& {
+    text-decoration: none;
+  }
+  display: flex;
+  flex-direction: column;
 
-    background-color: @beige;
-    width: @card-width;
-    height: 150px;
+  background-color: @beige;
+  width: @card-width;
+  height: 150px;
 
-    border: 1px solid fade(@black, 25%);
-    border-radius: 4px;
-    box-shadow: 2px 2px 4px fade(@black, 15%);
+  border: 1px solid fade(@black, 25%);
+  border-radius: 4px;
+  box-shadow: 2px 2px 4px fade(@black, 15%);
 }
 
 .multi-img-card__header {
-    display:flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    padding: 7px 10px;
-    border-radius: 0 0 4px 4px;
-    width: 100%;
-    a& {
-      text-decoration: none;
-    }
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 7px 10px;
+  border-radius: 0 0 4px 4px;
+  width: 100%;
+  a& {
+    text-decoration: none;
+  }
 }
 
-.multi-img-card__images{
-    flex: 1;
-    min-height: 1px;
-    overflow: clip;
-    display: flex;
-    align-items: center;
-    padding: 0 @cover-padding;
+.multi-img-card__images {
+  flex: 1;
+  min-height: 1px;
+  overflow: clip;
+  display: flex;
+  align-items: center;
+  padding: 0 @cover-padding;
 
-    img {
-        width: @cover-width;
-        border-radius: 4px;
-        box-shadow: 4px 4px 0 fade(@black, 25%);
+  img {
+    width: @cover-width;
+    border-radius: 4px;
+    box-shadow: 4px 4px 0 fade(@black, 25%);
 
-        transition: scale 0.2s;
-    }
+    transition: scale 0.2s;
+  }
 
-    &:hover img {
-        scale: 1.05;
-    }
+  &:hover img {
+    scale: 1.05;
+  }
 
-    img:nth-child(1) {
-        z-index: @top-cover-z-index;
-        transform: translate(0,20px);
-    }
+  img:nth-child(1) {
+    z-index: @top-cover-z-index;
+    transform: translate(0, 20px);
+  }
 
-    img:nth-child(2) {
-        z-index: @middle-cover-z-index;
-        transform: translate(-8.5px,20px);
-    }
+  img:nth-child(2) {
+    z-index: @middle-cover-z-index;
+    transform: translate(-8.5px, 20px);
+  }
 
-    img:nth-child(3) {
-        z-index: @bottom-cover-z-index;
-        transform: translate(-17px, 20px);
-    }
+  img:nth-child(3) {
+    z-index: @bottom-cover-z-index;
+    transform: translate(-17px, 20px);
+  }
 }
 
 .multi-img-card__footer {
-    background: @grey-f4f4f4;
-    border-radius: 0 0 4px 4px;
-    box-shadow: 0 0 4px fade(@black, 25%);
+  background: @grey-f4f4f4;
+  border-radius: 0 0 4px 4px;
+  box-shadow: 0 0 4px fade(@black, 25%);
 }

--- a/static/css/components/multi-image-card.less
+++ b/static/css/components/multi-image-card.less
@@ -6,7 +6,10 @@
 @bottom-cover-z-index: 1;
 @cover-overlap: calc((3 * @cover-width - (@card-width - 2 * @cover-padding)) / 2);
 
-.info-card {
+.multi-img-card {
+    a& {
+        text-decoration: none;
+    }
     display: flex;
     flex-direction: column;
 
@@ -19,7 +22,20 @@
     box-shadow: 2px 2px 4px fade(@black, 15%);
 }
 
-.info-card__images{
+.multi-img-card__header {
+    display:flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    padding: 7px 10px;
+    border-radius: 0 0 4px 4px;
+    width: 100%;
+    a& {
+      text-decoration: none;
+    }
+}
+
+.multi-img-card__images{
     flex: 1;
     min-height: 1px;
     overflow: clip;
@@ -55,7 +71,7 @@
     }
 }
 
-.info-card__footer {
+.multi-img-card__footer {
     background: @grey-f4f4f4;
     border-radius: 0 0 4px 4px;
     box-shadow: 0 0 4px fade(@black, 25%);

--- a/static/css/components/multi-image-card.less
+++ b/static/css/components/multi-image-card.less
@@ -1,0 +1,62 @@
+@card-width: 215px;
+@cover-width: 64px;
+@cover-padding: 20px;
+@top-cover-z-index: 3;
+@middle-cover-z-index: 2;
+@bottom-cover-z-index: 1;
+@cover-overlap: calc((3 * @cover-width - (@card-width - 2 * @cover-padding)) / 2);
+
+.info-card {
+    display: flex;
+    flex-direction: column;
+
+    background-color: @beige;
+    width: @card-width;
+    height: 150px;
+
+    border: 1px solid fade(@black, 25%);
+    border-radius: 4px;
+    box-shadow: 2px 2px 4px fade(@black, 15%);
+}
+
+.info-card__images{
+    flex: 1;
+    min-height: 1px;
+    overflow: clip;
+    display: flex;
+    align-items: center;
+    padding: 0 @cover-padding;
+
+    img {
+        width: @cover-width;
+        border-radius: 4px;
+        box-shadow: 4px 4px 0 fade(@black, 25%);
+
+        transition: scale 0.2s;
+    }
+
+    &:hover img {
+        scale: 1.05;
+    }
+
+    img:nth-child(1) {
+        z-index: @top-cover-z-index;
+        transform: translate(0,20px);
+    }
+
+    img:nth-child(2) {
+        z-index: @middle-cover-z-index;
+        transform: translate(-8.5px,20px);
+    }
+
+    img:nth-child(3) {
+        z-index: @bottom-cover-z-index;
+        transform: translate(-17px, 20px);
+    }
+}
+
+.info-card__footer {
+    background: @grey-f4f4f4;
+    border-radius: 0 0 4px 4px;
+    box-shadow: 0 0 4px fade(@black, 25%);
+}

--- a/static/css/components/mybooks.less
+++ b/static/css/components/mybooks.less
@@ -21,6 +21,7 @@
 @import (less) "components/mybooks-list.less";
 @import (less) "components/mybooks-menu.less";
 @import (less) "components/mybooks-details.less";
+@import (less) "components/activity-feed.less";
 @import (less) "components/list-showcase.less";
 
 .icon-link__image {

--- a/static/css/page-book.less
+++ b/static/css/page-book.less
@@ -33,6 +33,8 @@
 @import (less) "components/buttonBtn.less";
 @import (less) "components/modal-links.less";
 @import (less) "components/list-follow.less";
+@import (less) "components/multi-image-card.less";
+
 // Mobile
 html {
   // Take into account the header bar + tab bar


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10242

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Updates the application such that:

1. All list cards are generated using a common template (`/cards/multi_image_card.html`).
2. An activity feed containing up to three cards now appears on the My Books page.

### Technical
<!-- What should be noted about the implementation? -->
A new `PubSub` method has been created for the purpose of determining if a patron follows _any_ other person on the site.

#### The `multi_image_card` card

The new multi-image card is composed of three sections:
- An optional header
- A container for images
- A footer

Developers are expected to pass a valid HTML string for the card's header and footer, and a list of URLs for images that will be rendered in the card.

The new `multi_image_card` has been designed to either be nested in an anchor element (like the "My Lists" cards on the My Books page), or to contain multiple anchor elements within the card itself (like the cards in the "Lists" section of book pages.

If a URL is passed to the template (via the `href` parameter), the image container will be wrapped by an anchor element that links to the given URL.  If the entire card is rendered within an anchor element, `href` should not be set as this will result in nested anchor tags.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

#### Book Page:
- [ ] Ensure that the cards in the "Lists" section appear and behave as expected.

#### My Books Page -- My Lists section
- [ ] Ensure that the cards in the "My Lists" section appear and behave as expected.

#### My Books Page -- My Feed section
If not following others, expect:
- [ ] A message encouraging you to follow others
- [ ] Feed entries to be from the general `/trending` feed

If following only people that **do not** log books, expect:
- [ ] A message explaining why the feed is empty
- [ ] No cards to appear in the section

If following people who do log books, expect:
- [ ] Up to three cards to be present in the "My Feed" section

For all cases, expect:
- [ ] The "My Feed" heading link to go to the patron's "My Feed" page

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
All images captured from my local dev environment

<img width="934" height="265" alt="Screenshot 2025-11-19 162621" src="https://github.com/user-attachments/assets/ec5d5c57-0115-441d-b146-e4243a2e9c68" />

_Updated activity feed cards._


![activity_feed_retry](https://github.com/user-attachments/assets/dbe68a7d-5f7c-4179-bdd9-08133a9fe4f2)
_Failed activity feed requests can be retried._

**Note**: The `gif` was exported from an `mp4`.  I suspect that the background color changed during the export.  Refer to the still image for a more accurate representation of the color.

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
