### PR TITLE
Fix: Allow redirected authors in validation

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -106,7 +106,7 @@ class hooks(client.hook):
             )
 
         if page.key.startswith('/a/') or page.key.startswith('/authors/'):
-            if page.type.key == '/type/author' or page.type.key == '/type/redirect':
+            if page.type.key in ('/type/author', '/type/redirect'):
                 return
 
             books = web.ctx.site.things({'type': '/type/edition', 'authors': page.key})


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes https://github.com/internetarchive/openlibrary/issues/11387

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
**Fix**: Resolves validation error when editing books containing redirected author references.

### Technical
<!-- What should be noted about the implementation? -->
Here the code checks(Line 109 and Line 121) for /type/author and if not so it doesnt proceed, which restricts editing of books that have merged authors:
https://github.com/internetarchive/openlibrary/blob/c507c960202efb932066d2204f27677ccb8a0da9/openlibrary/plugins/openlibrary/code.py#L108-L124
If we allow `/type/redirect` when validating author page types. This allows edits to proceed on records that reference merged authors, while still preventing malicious type changes.
Line 109 should be
```if page.type.key in ('/type/author', '/type/redirect'):```
Line 121 should be
```elif page.type.key not in ['/type/author', '/type/redirect'] and books:```

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
**Steps to reproduce the original issue:**
1. Find or create a work with duplicate author entries where one author has been merged (is now a redirect)
2. Attempt to edit the work to remove the duplicate author
3. Observe the validation error

**Steps to verify the fix:**
1. Apply this PR
2. Edit a work/book containing a redirected author reference
3. Verify the edit succeeds without validation errors
4. Confirm that removing duplicate authors now works correctly
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A - This is a backend validation fix with no UI changes

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
