### PR TITLE
fix: Hide default carousel on subject pages with associated Tags

### DIFF
--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -55,8 +55,9 @@ $ q = query_param('q')
 <div class="contentBody">
     $if has_tag:
       $:format(sanitize(page.tag.body))
-
-    $:macros.QueryCarousel(query=page.solr_query, sort='trending,trending_score_hourly_sum', user_lang_only=True, fallback=True)
+    $else:
+      $# Only show default carousel if subject doesn't have an associated Tag
+      $:macros.QueryCarousel(query=page.solr_query, sort='trending,trending_score_hourly_sum', user_lang_only=True, fallback=True)
     $:macros.PublishingHistory(page.publishing_history)
 
     <div class="clearfix"></div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11381

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
**Fix**: Exclude default carousel from subject pages when associated with a Tag


### Technical
<!-- What should be noted about the implementation? -->
This PR modifies the subject page template to conditionally render the default QueryCarousel based on whether the subject has an associated Tag object.

**Changes:**
- Modified `/openlibrary/templates/subjects.html`
- Wrapped the `QueryCarousel` macro call in an `$else` block
- The carousel now only renders when `has_tag` is `False` (i.e., when `'tag' not in page`)
- When a subject has an associated Tag, only the Tag's curated `body` content is displayed

### Testing
1. **Subject WITHOUT Tag**: Visit `/subjects/love` - carousel should display
2. **Subject WITH Tag**: Create a Tag for any subject as admin/curator - carousel should be hidden, only Tag body content shows
3. Verify other page sections (publishing history, related subjects, authors) still appear in both cases
