### PR TITLE
Fix list_key queries in search sometimes not working

### DIFF
--- a/openlibrary/mocks/mock_infobase.py
+++ b/openlibrary/mocks/mock_infobase.py
@@ -12,6 +12,7 @@ import web
 from infogami import config
 from infogami.infobase import account, client, common
 from infogami.infobase import config as infobase_config
+from openlibrary.core.lists.model import register_models
 from openlibrary.plugins.upstream.models import Changeset
 from openlibrary.plugins.upstream.utils import safeget
 
@@ -432,6 +433,7 @@ def mock_site(request):
         from openlibrary.plugins.upstream import models
 
         models.setup()
+        register_models()
 
     site = MockSite()
 


### PR DESCRIPTION
The `list_key` "fake" solr parameter only works for carousels ; this makes it work in the normal search UI, and also expands it to work more correctly/reliably.


### Technical
<!-- What should be noted about the implementation? -->

- Multiple `list_key` can now be specified in the query, eg `list_key:/people/mekBot/lists/OL312101L AND list_key:...`
- Backwards compatibility with the old syntax which was just a prefix of the list key is maintained, although considered legacy.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

- List carousels still work: https://testing.openlibrary.org/collections/the_haunted_library
- Queries work in the search UI: `list_key:/people/mekBot/lists/OL312101L AND ebook_access:[borrowable TO *]`

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
