### PR TITLE
Temporarily disable author page facets to see perf impact

### DIFF
--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -527,7 +527,7 @@ class Author(models.Author):
             rows=i.rows,
             has_fulltext=i.mode == "ebooks",
             query=q,
-            facet=True,
+            facet=False,
             request_label='AUTHOR_BOOKS_PAGE',
         )
 

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -166,7 +166,7 @@ $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_libra
                 </div>
 
         <!-- SUBJECTS DISPLAY -->
-        $if books_count > 0:
+        $if books_count and books.facet_counts:
             $:render_subjects(_("Subjects"), books.facet_counts.get('subject_facet'), '')
             $:render_subjects(_("Places"), books.facet_counts.get('place_facet'), 'place:')
             $:render_subjects(_("People"), books.facet_counts.get('person_facet'), 'person:')


### PR DESCRIPTION
We were seeing high bot traffic to this page, resulting in solr strain across the whole site. Turning off the facets (i.e. the subjects/places/etc) in the sidebar of the authors page, and we seem to be doing much better. They're still hitting us and traffic is 1.5x normal, but we now seem to be able to weather it.

We want to turn these back on, but make them lazy load similarly to the facets on the search page.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

<img width="1917" height="434" alt="image" src="https://github.com/user-attachments/assets/9574cf4c-7638-4d70-a215-977a10cb6eae" />

* A: when the high traffic began
* B: When this PR was patch deployed

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
