### PR TITLE
fix: Privacy settings radio labels not clickable

### DIFF
--- a/openlibrary/templates/account/privacy.html
+++ b/openlibrary/templates/account/privacy.html
@@ -30,14 +30,14 @@ $ safe_mode = d.get('safe_mode', 'no')
             <div class="input radio">
                 <div class="sansserif larger">
                     <input type="radio" name="public_readlog" id="r0" value="yes" $selected(public_readlog, "yes")/>
-                    <label for="u0">$_("Yes")</label>
+                    <label for="r0">$_("Yes")</label>
                     <br/><br/>
                 </div>
             </div>
             <div class="input radio">
                 <div class="sansserif larger">
                     <input type="radio" name="public_readlog" id="r1" value="no" $selected(public_readlog, "no")/>
-                    <label for="u1">$_("No")</label>
+                    <label for="r1">$_("No")</label>
                     <br/><br/>
                 </div>
             </div>
@@ -51,14 +51,14 @@ $ safe_mode = d.get('safe_mode', 'no')
             <div class="input radio">
                 <div class="sansserif larger">
                     <input type="radio" name="safe_mode" id="r2" value="yes" $selected(safe_mode, "yes")/>
-                    <label for="u0">$_("Yes")</label>
+                    <label for="r2">$_("Yes")</label>
                     <br/><br/>
                 </div>
             </div>
             <div class="input radio">
                 <div class="sansserif larger">
                     <input type="radio" name="safe_mode" id="r3" value="no" $selected(safe_mode, "no")/>
-                    <label for="u1">$_("No")</label>
+                    <label for="r3">$_("No")</label>
                     <br/><br/>
                 </div>
             </div>


### PR DESCRIPTION
### Problem
The radio button labels on the Privacy & Content Moderation Settings page were not functional - clicking them did not select their associated radio buttons.

### Fix
Updated the label `for` attributes to match their corresponding radio input `id` values:
- Changed `for="u0"` to `for="r0"` for public readlog Yes
- Changed `for="u1"` to `for="r1"` for public readlog No
- Changed `for="u0"` to `for="r2"` for safe mode Yes
- Changed `for="u1"` to `for="r3"` for safe mode No

### Testing
- Verified all label `for` attributes match their radio input `id`s
- Confirmed no other instances of the old `u0/u1` IDs remain
- Changes are minimal and focused on the specific accessibility issue

### References
- Related to #11382