### PR TITLE
fix: replace hardcoded URL with dynamic environment-based URL

### DIFF
--- a/openlibrary/components/BulkSearch/utils/classes.js
+++ b/openlibrary/components/BulkSearch/utils/classes.js
@@ -201,7 +201,7 @@ export class BookMatch {
 }
 
 
-const BASE_LIST_URL = 'https://openlibrary.org/account/lists/add?seeds='
+const BASE_LIST_URL = '/account/lists/add?seeds='
 
 export class BulkSearchState{
     constructor(){


### PR DESCRIPTION
Closes #

Context:
On the /search/bulk page, clicking the “Add to List” button redirected users to a hardcoded production URL (https://openlibrary.org//account/lists/add?seeds=).
This caused issues during local development, as developers were redirected away from their local environment to the live Open Library site.

Fix:
Replaced the hardcoded URL with a relative path (/account/lists/add?seeds=) so the redirect correctly respects the current environment (e.g., localhost or staging).

Testing:
Verified locally by visiting /search/bulk, performing an extract-match-add flow, and clicking “Add to List” — the redirect now stays within the local instance.

Stakeholders
@cdrini 


