### PR TITLE
fix: center 'Add Cover Image' button under blank cover box (inline ce…

### DIFF
--- a/openlibrary/templates/covers/change.html
+++ b/openlibrary/templates/covers/change.html
@@ -28,7 +28,7 @@ $else:
         $ size = "smallest"
 
 <!-- The below style is inlined to avoid repaints -->
-<div class="$size sansserif manageCoversContainer" style="position: absolute; bottom: 15px">
+<div class="$size sansserif manageCoversContainer" style="position: absolute; bottom: 15px; left: 50%; transform: translateX(-50%)">
   <a aria-controls="addImage-$imagesId" class="coverPop dialog--open" href="$(manage_url if doc.get_cover() else add_url)">
     <div class="manageCovers" data-config="$dumps({'key': doc.type.key, 'url': get_coverstore_public_url(), 'selector': cover_selector, 'add_url': add_url, 'manage_url': manage_url})">$change</div>
   </a>
@@ -57,4 +57,3 @@ $else:
         </div>
     </div>
 </div>
-


### PR DESCRIPTION
…ntering)

<!-- What issue does this PR close? -->
Closes #11377

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fixed the issue of button positioning.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

Now it's under the black box before that button position is not under box.

i can't able to attach ss becuause it is not showing exact file over here .



### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->





<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
