### PR TITLE
Fix reading log carousel to check edition-level availability

### DIFF
--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -1,6 +1,6 @@
 import json
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Final, Literal, cast
+from typing import TYPE_CHECKING, Any, Final, Literal, cast
 
 import web
 from web.template import TemplateResult
@@ -18,7 +18,6 @@ from openlibrary.core.bookshelves_events import BookshelvesEvents
 from openlibrary.core.follows import PubSub
 from openlibrary.core.lending import (
     add_availability,
-    get_availability,
     get_loans_of_user,
 )
 from openlibrary.core.models import LoggedBooksData, User
@@ -57,9 +56,15 @@ class mybooks_home(delegate.page):
         template = self.render_template(mb)
         return mb.render(header_title=_("Books"), template=template)
 
-    def render_template(self, mb):
+    def render_template(self, mb: 'MyBooksTemplate') -> TemplateResult:
         # Marshal loans into homogeneous data that carousel can render
-        want_to_read, currently_reading, already_read, loans = [], [], [], []
+
+        docs: dict[str, Any] = {
+            'loans': [],
+            'want-to-read': [],
+            'currently-reading': [],
+            'already-read': [],
+        }
 
         if mb.me:
             myloans = get_loans_of_user(mb.me.key)
@@ -70,72 +75,33 @@ class mybooks_home(delegate.page):
                 if book := web.ctx.site.get(loan['book']):
                     book.loan = loan
                     loans.docs.append(book)
+            docs['loans'] = loans
 
         if mb.me or mb.is_public:
-            params = {'sort': 'created', 'limit': 6, 'sort_order': 'desc', 'page': 1}
-            want_to_read = mb.readlog.get_works(key='want-to-read', **params)
-            currently_reading = mb.readlog.get_works(key='currently-reading', **params)
-            already_read = mb.readlog.get_works(key='already-read', **params)
+            want_to_read = mb.readlog.get_works('want-to-read', limit=6)
+            currently_reading = mb.readlog.get_works('currently-reading', limit=6)
+            already_read = mb.readlog.get_works('already-read', limit=6)
+            works = want_to_read.docs + currently_reading.docs + already_read.docs
 
-            def add_edition_availability(docs):
-                """Add edition-level availability to work docs, fallback to work-level."""
-                filtered_docs = [d for d in docs if d.get('title')]
+            def get_edition(solr_doc: web.Storage | dict) -> dict | None:
+                editions_raw = cast(dict | list[dict], solr_doc.get('editions'))
+                if isinstance(editions_raw, dict):
+                    editions = editions_raw.get('docs', [])
+                else:
+                    editions = editions_raw or []
 
-                # Extract editions and get their OLIDs
-                # editions can be a list [edition] or dict {'docs': [edition]}
-                edition_olids = []
-                doc_to_edition_olid = {}
+                return editions[0] if editions else None
 
-                for doc in filtered_docs:
-                    editions = doc.get('editions')
-                    edition = None
-                    if editions:
-                        if isinstance(editions, list) and editions:
-                            edition = editions[0]
-                        elif isinstance(editions, dict) and editions.get('docs'):
-                            edition = editions['docs'][0]
+            add_availability(
+                [get_edition(doc) or doc for doc in works if doc.get('title')]
+            )
 
-                    if edition and edition.get('key'):
-                        edition_olid = edition['key'].split('/')[-1]
-                        edition_olids.append(edition_olid)
-                        doc_to_edition_olid[doc] = edition_olid
+            docs |= {
+                'want-to-read': want_to_read,
+                'currently-reading': currently_reading,
+                'already-read': already_read,
+            }
 
-                # Get edition-level availability
-                if edition_olids:
-                    edition_availabilities = get_availability(
-                        'openlibrary_edition', edition_olids
-                    )
-                    for doc in filtered_docs:
-                        if doc in doc_to_edition_olid:
-                            edition_olid = doc_to_edition_olid[doc]
-                            if edition_olid in edition_availabilities:
-                                doc['availability'] = edition_availabilities[
-                                    edition_olid
-                                ]
-
-                # Fallback to work-level availability for docs without edition availability
-                docs_without_edition_availability = [
-                    d for d in filtered_docs if not d.get('availability')
-                ]
-                if docs_without_edition_availability:
-                    add_availability(
-                        docs_without_edition_availability, mode='openlibrary_work'
-                    )
-
-                return filtered_docs
-
-            want_to_read.docs = add_edition_availability(want_to_read.docs)[:5]
-            currently_reading.docs = add_edition_availability(currently_reading.docs)[
-                :5
-            ]
-            already_read.docs = add_edition_availability(already_read.docs)[:5]
-
-        docs = {
-            'loans': loans,
-            'want-to-read': want_to_read,
-            'currently-reading': currently_reading,
-            'already-read': already_read,
-        }
         return render['account/mybooks'](
             mb.user,
             docs,
@@ -569,7 +535,7 @@ class ReadingLog:
         sort_order: str = 'desc',
         q: str = "",
         year: int | None = None,
-    ) -> LoggedBooksData:
+    ) -> 'LoggedBooksData':
         """
         Get works for want-to-read, currently-reading, and already-read as
         determined by {key}.


### PR DESCRIPTION
When a specific edition is logged in reading logs, fetch availability at the edition level instead of work level. This ensures correct borrow buttons are shown instead of 'Locate' buttons when the logged edition is available.

Fixes #11329

<!-- What issue does this PR close? -->
Closes #11329
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Fix

### Technical
When a reading log entry has a logged edition (from `link_editions_to_works`), the code now:
- Extracts the edition from the work doc's `editions` field (handles both list and dict formats)
- Fetches availability using `'openlibrary_edition'` mode instead of work-level
- Attaches the edition availability to the work doc for display
- Falls back to work-level availability when no edition is present

### Testing
1. Add a book with a specific edition to your reading log (want-to-read, currently-reading, or already-read)
2. Visit `/people/your-username/books` to see the carousel
3. Verify the borrow button shows correctly for the logged edition (not "Locate" when edition is available)
4. Check that works without logged editions still show correct availability

@cdrini