### PR TITLE
Fix yearly reading goal progress regression

### DIFF
--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -47,7 +47,7 @@ class ReadingGoalProgressPartial(PartialDataHandler):
     def generate(self) -> dict:
         year = self.i.year or datetime.now().year
         goal = get_reading_goals(year=year)
-        component = render_template('check_ins/reading_goal_progress', [goal])
+        component = render_template('reading_goals/reading_goal_progress', [goal])
 
         return {"partials": str(component)}
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Follows #10974

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
As mentioned [here](https://github.com/internetarchive/openlibrary/pull/10974/files#r2496311788), the `render_template` call for the async reading goal progress bar was not updated after the template's file path changed.  This has prevented the progress bar being displayed whenever reading goals are set.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Log in
2. Go to your "My Books" page
3. If a goal has already been set, delete the goal by submitting `0` and refresh the page
4. Set a new yearly reading goal
5. Expect the progress bar to replace the "Set your 2XXX reading goal" call to action

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
