### PR TITLE
feat: auto-sort and deduplicate author alternate_names on save

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -1035,10 +1035,9 @@ class author_edit(delegate.page):
                 name.strip() for name in alternate_names.split('\n') if name.strip()
             ]
             sorted_names = sorted(cleaned_names, key=str.lower)
-            author.alternate_names = uniq(
-                [author.name] + sorted_names,
-                key=str.lower
-            )[1:]
+            author.alternate_names = uniq([author.name] + sorted_names, key=str.lower)[
+                1:
+            ]
             author.links = author.get('links') or []
             return author
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11419

### Problem
Authors had to manually copy `alternate_names` to external editors (like vi) to sort and remove duplicates, making cleanup time-consuming and inconsistent.

### Solution
Automatically sort and deduplicate alternate names when saving author changes:
- Clean whitespace from entries
- Sort alphabetically (case-insensitive)
- Remove duplicates (case-insensitive)
- Filter out empty lines

### Changes
**File:** `addbook.py`  
**Function:** `author_edit.process_input()`
