### PR TITLE
fix: My Books page overflow

### DIFF
--- a/static/css/components/mybooks-details.less
+++ b/static/css/components/mybooks-details.less
@@ -20,11 +20,13 @@
 .breadcrumb-wrapper {
   display: flex;
   flex-wrap: wrap;
+  min-width: 0;
   white-space: nowrap;
 }
 
 .social-wrapper {
   display: flex;
+  min-width: 0;
 }
 
 .follow-row {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11422

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
It prevents My Books page to overflow on mobiles when "Share" link is rendered.

### Technical
<!-- What should be noted about the implementation? -->
Added `min-width: 0` to header flex children so they can shrink correctly:
in `mybooks-details.less` L-20 to L-30 should be 
```
breadcrumb-wrapper {
  display: flex;
  flex-wrap: wrap;
  min-width: 0;
  white-space: nowrap;
}

.social-wrapper {
  display: flex;
  min-width: 0;
}
```
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
