### PR TITLE
fixed classification section overflow in edit page

### DIFF
--- a/static/css/components/form.olform.less
+++ b/static/css/components/form.olform.less
@@ -285,7 +285,7 @@
 
     table.identifiers tr {
       display: block;
-      margin: 0 0 8px 0;
+      margin: 0 0 8px;
     }
 
     table.identifiers td {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11431 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR fixes the Classification section overflow in x-axis in edit page of any book.

### Technical
<!-- What should be noted about the implementation? -->
I have added a mobile-specific responsive block to `form.olform.less`that:
1. Forces the two-column edit layout (`.formBackLeft` / `.formBackRight`) to stack (`float: none;` `width: 100%`).
2. Makes `.identifiers` tables stack their rows and cells (rows/cells become block-level, cells full-width).
3. Forces inputs/selects/textareas to be full-width and removes right margins that could cause overflow.
4 . Lowers horizontal padding on `.formBack` to reduce gutters.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
After the fix:
<img width="1854" height="1032" alt="Screenshot from 2025-11-07 13-33-20" src="https://github.com/user-attachments/assets/9ededfe6-72c3-4c18-acc7-5272bcf369b3" />

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
