### PR TITLE
Fix: Add cover frame errors when covers list is missing

### DIFF
--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -70,7 +70,8 @@ class Edition(models.Edition):
         This methods excludes covers that are -1 or None, which are in the data
         but should not be.
         """
-        return [Image(self._site, 'b', c) for c in self.covers if c and c > 0]
+        covers_list = self.get('covers') or []
+        return [Image(self._site, 'b', c) for c in covers_list if c and c > 0]
 
     def get_cover(self):
         covers = self.get_covers()


### PR DESCRIPTION
This PR fixes issue #11375.

When a book has no covers (i.e., the `book.covers` property is missing entirely, not just empty), the `manage_covers` modal fails to render because the `get_covers()` method in `upstream/models.py` crashes.

This fix changes `get_covers()` to safely access the property using `self.get('covers') or []`, which prevents the crash and allows the modal to load correctly.

Tested locally by:
1. Deleting all covers from a book.
2. Saving and closing the modal.
3. Re-opening the "Manage covers" modal (which now loads successfully).