### PR TITLE
Add fetchpriority attribute to main book cover image

### DIFF
--- a/openlibrary/templates/covers/book_cover.html
+++ b/openlibrary/templates/covers/book_cover.html
@@ -16,7 +16,7 @@ $ src = cover_url or '/images/icons/avatar_book.png'
 $ srcset = '%s 2x' % (cover_lg or '/images/icons/avatar_book-lg.png')
 
 $if preload:
-    $add_metatag(tag="link", **{'rel': 'preload', 'as': 'image', 'href': src, 'imagesrcset': srcset})
+    $add_metatag(tag="link", **{'rel': 'preload', 'as': 'image', 'href': src, 'imagesrcset': srcset, 'fetchpriority': 'high'})
 
 <div class="coverMagic cover-animation">
     <div class="SRPCover bookCover" style="display: $cond(cover_url, 'block', 'none');">


### PR DESCRIPTION
Small perf improvement to mark the main cover on a book page as `fetchpriority="high"`, as suggested by pagespeed insights

<img width="1215" height="435" alt="image" src="https://github.com/user-attachments/assets/7ab796ef-16cf-44d8-82e0-6f7355844fed" />

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
