### PR TITLE
rename async_work_search to work_search_async

### DIFF
--- a/openlibrary/fastapi/search.py
+++ b/openlibrary/fastapi/search.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import JSONResponse
 
-from openlibrary.plugins.worksearch.code import async_work_search
+from openlibrary.plugins.worksearch.code import work_search_async
 from openlibrary.plugins.worksearch.schemes.works import WorkSearchScheme
 
 router = APIRouter()
@@ -41,7 +41,7 @@ async def search_json(
     query.update(
         kwargs
     )  # This is a hack until we define all the params we expect above.
-    response = await async_work_search(
+    response = await work_search_async(
         query,
         sort=sort,
         page=page,

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -1209,7 +1209,7 @@ def work_search(
 
 # Warning: when changing this please also change the sync version
 @public
-async def async_work_search(
+async def work_search_async(
     query: dict,
     sort: str | None = None,
     page: int = 1,


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

As I was working on other PRs I realized it makes much more sense for autocomplete and our current workflow to have `_async` at the end rather than at the begging of the function name.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
