### PR TITLE
Fix trending updater erroring

### DIFF
--- a/openlibrary/utils/solr.py
+++ b/openlibrary/utils/solr.py
@@ -86,6 +86,7 @@ class Solr:
                 ),
                 'ol.label': request_label,
             },
+            timeout=DEFAULT_SOLR_TIMEOUT_SECONDS,
         ).json()
 
         # Solr returns {doc: null} if the record isn't there
@@ -107,6 +108,7 @@ class Solr:
                 'ids': ','.join(ids),
                 **({'fl': ','.join(fields)} if fields else {}),
             },
+            timeout=DEFAULT_SOLR_TIMEOUT_SECONDS,
         ).json()
         return [doc_wrapper(doc) for doc in resp['response']['docs']]
 
@@ -114,6 +116,8 @@ class Solr:
         resp = self.session.post(
             f'{self.base_url}/update?update.partial.requireInPlace=true&commit={commit}',
             json=request,
+            # Update commands shouldn't really have timeouts
+            timeout=None,
         ).json()
         return resp
 


### PR DESCRIPTION
Noticed trending updater stopped operating after the deploy due to the default timeouts from httpx. Addendum to #11374


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
