### PR TITLE
add served by header for fastapi

### DIFF
--- a/openlibrary/asgi_app.py
+++ b/openlibrary/asgi_app.py
@@ -154,6 +154,13 @@ def create_app() -> FastAPI:
 
     setup_i18n(app)
 
+    @app.middleware("http")
+    async def add_fastapi_header(request: Request, call_next):
+        """Middleware to add a header indicating the response came from FastAPI."""
+        response = await call_next(request)
+        response.headers["X-Served-By"] = "FastAPI"
+        return response
+
     # --- Fast routes (mounted within this app) ---
     @app.get("/health")
     def health() -> dict[str, str]:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

Right now we're splitting traffic to fastapi and web.py and we can't tell from a response where it came from. Adding this header would be useful so we can be sure where a response comes from.

Mostly useful for spot checking but I'm thinking of setting up some semi automated tests and this would be helpful there too.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
