### PR TITLE
Simplify history comments

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -5553,18 +5553,6 @@ msgstr ""
 msgid "Qualifying for Print Disability Special Access"
 msgstr ""
 
-#: history/comment.html
-msgid "Imported from"
-msgstr ""
-
-#: history/comment.html
-msgid "Found a matching"
-msgstr ""
-
-#: history/comment.html
-msgid "Edited without comment."
-msgstr ""
-
 #: history/sources.html
 msgid "record"
 msgstr ""

--- a/openlibrary/templates/history/comment.html
+++ b/openlibrary/templates/history/comment.html
@@ -1,21 +1,12 @@
 $def with (v)
 
-$ get_source_html = render_template("history/sources").get_source_html
-
 $ v = process_version(v)
-$ record_id = v.get('machine_comment')
-$if record_id:
-    $if v.revision == 1:
-       $:_('Imported from')
-       $:get_source_html(record_id)
-    $else:
-       $:_('Found a matching')
-       $:get_source_html(record_id)
-$elif 'history_v2' in ctx.features:
-    $ kind = "merge" if v.kind.startswith('merge-') else v.kind
-    $ t = get_template('recentchanges/' + kind + '/comment') or get_template('recentchanges/default/comment')
-    $:t(v, v.thing)
-$elif v.comment:
-    $v.comment
+
+$if 'history_v2' in ctx.features:
+    $ kind = 'merge' if v.kind.startswith('merge-') else v.kind
+    $ page = v.thing
 $else:
-    <em>$_("Edited without comment.")</em>
+    $ kind = 'default'
+    $ page = None
+$ t = get_template('recentchanges/' + kind + '/comment') or get_template('recentchanges/default/comment')
+$:t(v, page)

--- a/openlibrary/templates/recentchanges/default/comment.html
+++ b/openlibrary/templates/recentchanges/default/comment.html
@@ -1,2 +1,5 @@
 $def with (change, page=None)
-$change.comment
+$if change.comment:
+    $change.comment
+$else:
+    $_("Edited without comment.")

--- a/openlibrary/templates/recentchanges/default/comment.html
+++ b/openlibrary/templates/recentchanges/default/comment.html
@@ -1,5 +1,2 @@
 $def with (change, page=None)
-$if change.comment:
-    $change.comment
-$else:
-    $_("Edited without comment.")
+$change.comment


### PR DESCRIPTION
closes #1381
* No longer re-writes comments based on other fields (for `kind = "default"`. Other templates potentially still replace the user supplied comment) 
* No longer makes arbitrary comment differences for logged in vs. guest viewers (again, only for `kind = "default"`, other kind templates still rewrite comments. No idea why this this helpful? The different content depending on logged is status has already hindered investigation on the original issue.)

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
