### PR TITLE
fix(data): Correct wikidata dump format to raw TSV

### DIFF
--- a/scripts/dump-wikidata.sql
+++ b/scripts/dump-wikidata.sql
@@ -1,6 +1,6 @@
 -- Script to export Wikidata table from the Open Library database
 -- When called, this will export the entire wikidata table as a TSV file
--- Usage: psql $PSQL_PARAMS -f dump-wikidata.sql | gzip -c > ol_dump_wikidata_YYYY-MM-DD.txt.gz
+-- Usage: psql $PSQL_PARAMS -f dump-wikidata.sql | sed 's/\\\\"/\\"/g' | gzip -c > ol_dump_wikidata_YYYY-MM-DD.txt.gz
 
 -- Export all rows from the wikidata table as tab-separated values
-COPY wikidata TO STDOUT WITH (FORMAT csv, DELIMITER E'\t');
+COPY wikidata (id, updated, data) TO STDOUT;

--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -139,7 +139,7 @@ then
   if [[ ! -f $(compgen -G "ol_dump_wikidata_$yyyymm*.txt.gz") ]]
   then
       log "generating wikidata table: ol_dump_wikidata_$yyyymmdd.txt.gz"
-      time psql $PSQL_PARAMS -f $SCRIPTS/dump-wikidata.sql | gzip -c > ol_dump_wikidata_$yyyymmdd.txt.gz
+      time psql $PSQL_PARAMS -f $SCRIPTS/dump-wikidata.sql | sed 's/\\\\"/\\"/g' | gzip -c > ol_dump_wikidata_$yyyymmdd.txt.gz
   else
       log "Skipping: $(compgen -G "ol_dump_wikidata_$yyyymm*.txt.gz")"
   fi


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11439

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
[fix] Corrects the format of the Wikidata data dump to make it easily parsable with standard command-line tools.

### Technical
<!-- What should be noted about the implementation? -->
The `dump-wikidata.sql` script was using `COPY ... WITH (FORMAT csv)`, which has strict quoting rules. This caused the JSON data field to be wrapped in unnecessary double quotes, breaking parsers like `jq`.

This change updates the script to use a plain `COPY ... TO STDOUT` command. This exports the data in PostgreSQL's default raw, tab-separated format, which does not add the extra quotes around the JSON field.

This fix aligns the Wikidata dump with the format of other Open Library dumps and resolves the reported parsing issue.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
I have verified this fix locally by performing the following steps:

1.  Populated the local `wikidata` table by adding a Wikidata ID (e.g., `Q42`) to an author.
2.  Ran the original command (`... WITH (FORMAT csv)`) and confirmed it produced the incorrect, double-quoted JSON output.
    *   **Evidence of bug:** [Gist showing the incorrect output](https://gist.github.com/KrishnaShuk/bfb95d13363952306446f475b8635f32)
3.  Ran the new, corrected command (`COPY wikidata TO STDOUT;`) and confirmed it produced a clean, raw TSV output without the extra quotes.
    *   **Evidence of fix:** [Gist showing the correct output](https://gist.github.com/KrishnaShuk/96aeaa780553e790b3323216aa89fff1)

The fix behaves exactly as expected.

### Follow-up Enhancements
1. Reordering the columns to place the large JSON field last.
2. Trimming the microsecond precision from the timestamp.

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini
@tfmorris


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->