### PR TITLE
feat(admin): Added quick links to memcache dashboard for common issues

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -3781,6 +3781,30 @@ msgid "Inspect Memcache"
 msgstr ""
 
 #: admin/inspect/memcache.html
+msgid "Common Cache Fixes"
+msgstr ""
+
+#: admin/inspect/memcache.html
+msgid "Click these links to clear the cache for common, frequently-updated pages."
+msgstr ""
+
+#: admin/inspect/memcache.html
+msgid "Clear Homepage Cache"
+msgstr ""
+
+#: admin/inspect/memcache.html
+msgid "for regular users"
+msgstr ""
+
+#: admin/inspect/memcache.html
+msgid "Clear Homepage Cache (Print Disabled)"
+msgstr ""
+
+#: admin/inspect/memcache.html
+msgid "for print-disabled users"
+msgstr ""
+
+#: admin/inspect/memcache.html
 msgid ""
 "Add one memcache key per line in the text area. Each key must include a "
 "'-' as the last character."

--- a/openlibrary/templates/admin/inspect/memcache.html
+++ b/openlibrary/templates/admin/inspect/memcache.html
@@ -8,6 +8,24 @@ $var title: $_("[Admin Center] Inspect Memcache")
 </div>
 
 <div id="contentBody">
+    <div class="section" style="padding: 1em; background-color: #f5f5f5; border: 1px solid #ccc; margin-bottom: 2em;">
+    <h2>$_("Common Cache Fixes")</h2>
+    <p>$_("Click these links to clear the cache for common, frequently-updated pages.")</p>
+    <ul>
+        <li>
+            <a href="/admin/inspect/memcache?keys=home.homepage.en&action=delete">
+                <strong>$_("Clear Homepage Cache")</strong>
+            </a>
+            ($_("for regular users"))
+        </li>
+        <li style="margin-top: 0.5em;">
+            <a href="/admin/inspect/memcache?keys=home.homepage.en.pd-&action=delete">
+                <strong>$_("Clear Homepage Cache (Print Disabled)")</strong>
+            </a>
+            ($_("for print-disabled users"))
+        </li>
+    </ul>
+    </div>
 
     <div>
         <form name="by_key" class="olform">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11124
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Feature
Adds "quick fix" links to the /admin/inspect/memcache page. This allows administrators to resolve common caching problems (like a blank homepage) with a single click, instead of needing to consult external documentation and manually enter cache keys.

### Technical
<!-- What should be noted about the implementation? -->
This change modifies the openlibrary/templates/admin/inspect/memcache.html template to include a new section at the top of the page.
The new section contains hardcoded links for clearing the cache of the homepage for both regular and print-disabled users. All new user-facing strings have been wrapped in the $_() function for internationalization (i18n), as required by the project's pre-commit hooks.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

1. Log in as an administrator (admin@openlibrary.org).
2. Navigate to the Memcache dashboard at /admin/inspect/memcache.
3. Verify that the new "Common Cache Fixes" section is visible at the top of the page.
4. Click the "Clear Homepage Cache" link.
5. Verify that the page reloads and a green success banner appears with the message "Deleted 1 keys from memcache".
6. Go back and click the "Clear Homepage Cache (Print Disabled)" link.
7. Verify that this link also works and shows the green success banner.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Here is a screenshot of the updated /admin/inspect/memcache page with the new links:
<img width="1855" height="1003" alt="Screenshot from 2025-11-15 16-10-34" src="https://github.com/user-attachments/assets/3a05412f-d12a-4010-958e-131eb9239322" />

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini @mekarpeles