### PR TITLE
Add bookshelf and profile

### DIFF
--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -849,6 +849,7 @@ class opds_books(delegate.page):
 
     def GET(self, edition_olid: str):
         from pyopds2 import Link
+
         provider = get_opds_data_provider()
         resp = provider.search(query=f'edition_key:{edition_olid}')
         web.header('Content-Type', 'application/opds-publication+json')
@@ -869,7 +870,7 @@ class opds_books(delegate.page):
                     rel="profile",
                     href="https://archive.org/services/loans/loan/?action=user_profile",
                     type="application/opds-profile+json",
-                )
+                ),
             ]
             return delegate.RawText(json.dumps(pub.model_dump()))
 
@@ -965,7 +966,7 @@ class opds_home(delegate.page):
                         rel="profile",
                         href="https://archive.org/services/loans/loan/?action=user_profile",
                         type="application/opds-profile+json",
-                    )
+                    ),
                 ],
             )
             return catalog.model_dump()


### PR DESCRIPTION
This PR adds the archive.org bookshelf and profile to links.

At some point Openlibrary should have their own, if they support lending and buying from many different libraries and/or  book sellers.

### Testing

I've not tested this change yet.


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
