### PR TITLE
fix: mobile dropdown cell height

### DIFF
--- a/static/css/components/form.olform.less
+++ b/static/css/components/form.olform.less
@@ -266,5 +266,3 @@
   }
   /* stylelint-enable selector-max-specificity */
 }
-
-

--- a/static/css/components/jquery.autocomplete.less
+++ b/static/css/components/jquery.autocomplete.less
@@ -39,8 +39,6 @@
     &.ac_over {
       background-color: @light-yellow;
     }
-
-
   }
 }
 

--- a/static/css/page-edit.less
+++ b/static/css/page-edit.less
@@ -77,8 +77,6 @@ textarea {
   font-family: @body-family;
   color: @dark-grey;
   padding: 5px;
-
-
 }
 table.code {
   border: 1px solid @grey-e7e7e7;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11182

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR ensures that dropdown rows (such as for languages and contributor roles) in forms and autocomplete menus have consistent height and padding across all devices, especially improving usability on touch devices like mobile and tablets. It increases the minimum height and padding on touch screens to make selection easier and more accessible.

### Technical
- Adds @media (pointer: coarse) CSS to relevant selectors in LESS files for forms and autocomplete.
- Sets consistent min-height: 44px and appropriate padding for dropdown options and autocomplete rows.
- Applies changes to form selects, .ac_language autocomplete items, and textareas (edit screen).

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@jimchamp 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
