### PR TITLE
Replace custom cached_property with functools.cached_property

### DIFF
--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -25,7 +25,6 @@ __all__ = [
     "MemcacheCache",
     "MemoryCache",
     "RequestCache",
-    "cached_property",
     "get_memcache",
     "memcache_memoize",
     "memoize",
@@ -241,28 +240,6 @@ class memcache_memoize[**P, T]:
 ####
 
 
-def cached_property(getter):
-    """Decorator like `property`, but the value is computed on first call and cached.
-
-    class Foo:
-
-        @cached_property
-        def memcache_client(self):
-            ...
-    """
-    name = getter.__name__
-
-    def g(self):
-        if name in self.__dict__:
-            return self.__dict__[name]
-
-        value = getter(self)
-        self.__dict__[name] = value
-        return value
-
-    return property(g)
-
-
 class Cache:
     """Cache interface."""
 
@@ -322,7 +299,7 @@ class MemcacheCache(Cache):
     Expects that the memcache servers are specified in web.config.memcache_servers.
     """
 
-    @cached_property
+    @functools.cached_property
     def memcache(self):
         if servers := config.get("memcache_servers", None):
             return olmemcache.Client(servers)


### PR DESCRIPTION
Work towards #11479 . This is now built-in to python and can be replaced with [functools.cached_property](https://docs.python.org/3/library/functools.html#functools.cached_property) . It was only used in one spot.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

Added in python 3.8, it has the same semantics as our version, namely that it is store for the life time of the instance:

> The cached_property decorator only runs on lookups and only when an attribute of the same name doesn’t exist. When it does run, the cached_property writes to the attribute with the same name. Subsequent attribute reads and writes take precedence over the cached_property method and it works like a normal attribute.

> 

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
