### PR TITLE
Fix fastapi search.json not handling facet parameters

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -60,6 +60,7 @@ re_olid = re.compile(r'^OL\d+([AMW])$')
 
 plurals = {f + 's': f for f in ('publisher', 'author')}
 
+default_spellcheck_count = 10
 if hasattr(config, 'plugin_worksearch'):
     solr_select_url = (
         config.plugin_worksearch.get('solr_base_url', 'localhost') + '/select'
@@ -197,7 +198,7 @@ def get_remembered_layout():
     return 'details'
 
 
-def _prepare_solr_query_params(
+def _prepare_solr_query_params(  # noqa: PLR0912
     scheme: SearchScheme,
     param: dict | None = None,
     rows=100,
@@ -269,6 +270,8 @@ def _prepare_solr_query_params(
         if field == 'author_facet':
             field = 'author_key'
         values = param[field]
+        if isinstance(values, str):
+            values = [values]
         params += [('fq', f'{field}:"{val}"') for val in values if val]
 
     # Many fields in solr use the convention of `*_facet` both

--- a/openlibrary/plugins/worksearch/tests/test_worksearch.py
+++ b/openlibrary/plugins/worksearch/tests/test_worksearch.py
@@ -1,9 +1,11 @@
 import web
 
 from openlibrary.plugins.worksearch.code import (
+    _prepare_solr_query_params,
     get_doc,
     process_facet,
 )
+from openlibrary.plugins.worksearch.schemes.works import WorkSearchScheme
 
 
 def test_process_facet():
@@ -74,3 +76,18 @@ def test_get_doc():
             'want_to_read_count': None,
         }
     )
+
+
+def test_prepare_solr_query_params_first_publish_year_string():
+    """Test to check that when we have a facet value as a string it is converted to a list properly"""
+    scheme = WorkSearchScheme()
+    param = {'first_publish_year': '1997'}
+    params, fields = _prepare_solr_query_params(scheme, param)
+
+    param2 = {'first_publish_year': ['1997']}
+    params2, fields2 = _prepare_solr_query_params(scheme, param2)
+    assert params == params2
+    assert fields == fields2
+    # Check that the fq param for first_publish_year is correctly added
+    fq_params = [p for p in params if p[0] == 'fq']
+    assert ('fq', 'first_publish_year:"1997"') in fq_params


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

As I was reviewing the next steps for the search api to clean it up I realized that web.py was turning the inputs into arrays and we weren't handling that for facets. This will make it so that the queries are the same.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
