### PR TITLE
fix requests->httpx

### DIFF
--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -74,7 +74,7 @@ def save_page_now(
             return result.get('job_id', f"ERROR_NO_JOB_ID_{r.status_code}")
         else:
             return f"ERROR_HTTP_{r.status_code}"
-    except (requests.RequestException, ValueError) as e:
+    except (httpx.RequestException, ValueError) as e:
         return f"ERROR_EXCEPTION_{str(e)[:50]}"
 
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Followup to #11090 ; fixes `requests` reference, replaced with `httpx`

This pull request makes a small update to the exception handling in the `save_page_now` function in `openlibrary/core/ia.py`. The change switches the caught exception from `requests.RequestException` to `httpx.RequestException`, likely reflecting a transition from the `requests` library to `httpx` for HTTP requests.
