### PR TITLE
Hotfix indenting in single publication opds feed

### DIFF
--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -859,20 +859,20 @@ class opds_books(delegate.page):
                 data=json.dumps({'error': 'Edition not found'}),
             )
 
-            pub = resp.records[0].to_publication()
-            pub.links += [
-                Link(
-                    rel="http://opds-spec.org/shelf",
-                    href="https://archive.org/services/loans/loan/?action=user_bookshelf",
-                    type="application/opds+json",
-                ),
-                Link(
-                    rel="profile",
-                    href="https://archive.org/services/loans/loan/?action=user_profile",
-                    type="application/opds-profile+json",
-                ),
-            ]
-            return delegate.RawText(json.dumps(pub.model_dump()))
+        pub = resp.records[0].to_publication()
+        pub.links += [
+            Link(
+                rel="http://opds-spec.org/shelf",
+                href="https://archive.org/services/loans/loan/?action=user_bookshelf",
+                type="application/opds+json",
+            ),
+            Link(
+                rel="profile",
+                href="https://archive.org/services/loans/loan/?action=user_profile",
+                type="application/opds-profile+json",
+            ),
+        ]
+        return delegate.RawText(json.dumps(pub.model_dump()))
 
 
 class opds_home(delegate.page):


### PR DESCRIPTION
The code that was supposed to run suddenly got indented during the last refactor. This PR fixes the indentation so single item opds works again.