### PR TITLE
feat: Allow non-librarians to create Community Lists (#11222)

### DIFF
--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -7,11 +7,11 @@ from typing import Literal, cast
 from urllib.parse import parse_qs
 
 import web
+
+import openlibrary.core.helpers as h
 from infogami.infobase import client, common
 from infogami.utils import delegate
 from infogami.utils.view import public, render_template, require_login
-
-import openlibrary.core.helpers as h
 from openlibrary.accounts import get_current_user
 from openlibrary.core import cache, formats
 from openlibrary.core.lists.model import (


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11222

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
feature: Enables any authenticated user to create a Community List.

### Technical
<!-- What should be noted about the implementation? -->
This solution modifies `openlibrary/openlibrary/plugins/openlibrary/lists.py` in two ways:

1.  The `@require_login` decorator is added to the `lists_add` class to ensure only authenticated users can access the creation form.
2.  The permission logic in `lists_edit.POST` has been updated. It now differentiates between creating a new list (where it now only requires a user to be logged in) and editing an existing list (where it preserves the original, stricter `can_write` permission check). This correctly resolves the bug that was blocking non-librarians.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
To verify this fix, please follow these steps:

1.  **Test Case 1: Successful List Creation (Non-Librarian)**
    *   Log in with a regular, non-librarian user account.
    *   Navigate to `/lists/add`.
    *   Fill in a name and description for the list and click "Save".
    *   **Expected Result:** The list is created successfully, and you are redirected to the new list's page (e.g., `/lists/OL...L`).

2.  **Test Case 2: Anonymous User Redirect**
    *   Log out of your account.
    *   Navigate to `/lists/add`.
    *   **Expected Result:** You should be immediately redirected to the login page.

3.  **Test Case 3: Editing Permissions Unchanged**
    *   While logged in as a non-librarian, find a Community List created by another user.
    *   Attempt to navigate to its edit page (e.g., `/lists/OL...L/edit`).
    *   **Expected Result:** You should see a "Permission denied" error, confirming that security for editing existing content remains intact.

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini