### PR TITLE
Make primary CTA of My Books Dropper "Add to List" when logged out

### DIFF
--- a/openlibrary/templates/my_books/primary_action.html
+++ b/openlibrary/templates/my_books/primary_action.html
@@ -6,8 +6,10 @@ $def reading_log_cta(work_key, edition_key, user_key, read_status):
       $ message = _("Already Read")
     $elif read_status == 2:
       $ message = _("Currently Reading")
-    $else:
+    $elif user_key:
       $ message = _("Want to Read")
+    $else:
+      $ message = _("Add to List")
 
     $ action_value = 'remove' if read_status else 'add'
     $ bookshelf_id_value = read_status or '1'


### PR DESCRIPTION
Closes #11496 

Reduce confusion for patrons who click "Want to Read" expecting to get the book (for logged out patrons)

<!-- What issue does this PR close? -->
This pull request makes a small improvement to the logic for displaying the primary action message in the `primary_action.html` template. Now, if there is no `read_status` and the user is not logged in (`user_key` is not set), the message will show as "Add to List" instead of "Want to Read". This clarifies the action for anonymous users.
