### PR TITLE
Fix search.json only offering edition description

### DIFF
--- a/openlibrary/plugins/worksearch/schemes/works.py
+++ b/openlibrary/plugins/worksearch/schemes/works.py
@@ -108,6 +108,9 @@ class WorkSearchScheme(SearchScheme):
         {
             'description',
             'providers',
+            'work.description',
+            'editions.description',
+            'editions.providers',
         }
     )
     facet_fields = frozenset(
@@ -600,36 +603,68 @@ class WorkSearchScheme(SearchScheme):
             new_params.append(('editions.fl', ','.join(edition_fields)))
         return new_params
 
-    def add_non_solr_fields(self, non_solr_fields: set[str], solr_result: dict) -> None:
-        from openlibrary.plugins.upstream.models import Edition
+    def add_non_solr_fields(
+        self,
+        non_solr_fields: set[str],
+        solr_result: dict,
+    ) -> None:
+        from openlibrary.plugins.upstream.models import Edition, Work
+
+        prefixed_fields = {
+            prefixed_field
+            for field in non_solr_fields
+            for prefixed_field in (
+                (field,) if '.' in field else (f'work.{field}', f'editions.{field}')
+            )
+        }
+        need_works = any(field.startswith('work.') for field in prefixed_fields)
+        need_editions = any(field.startswith('editions.') for field in prefixed_fields)
 
         # Augment with data from db
-        edition_keys = [
-            ed_doc['key']
-            for doc in solr_result['response']['docs']
-            for ed_doc in doc.get('editions', {}).get('docs', [])
-        ]
-        editions = cast(list[Edition], web.ctx.site.get_many(edition_keys))
-        ed_key_to_record = {ed.key: ed for ed in editions if ed.key in edition_keys}
+        keys: list[str] = []
+        if need_works:
+            keys += [doc['key'] for doc in solr_result['response']['docs']]
+
+        if need_editions:
+            keys += [
+                ed_doc['key']
+                for doc in solr_result['response']['docs']
+                for ed_doc in doc.get('editions', {}).get('docs', [])
+            ]
+
+        things = cast(list[Work | Edition], web.ctx.site.get_many(keys))
+        key_to_thing = {t.key: t for t in things if t.key in keys}
 
         from openlibrary.book_providers import get_acquisitions
 
         for doc in solr_result['response']['docs']:
-            for ed_doc in doc.get('editions', {}).get('docs', []):
-                # `ed` could be `None` if the record has been deleted and Solr not yet updated.
-                if not (ed := ed_key_to_record.get(ed_doc['key'])):
-                    continue
+            for field in prefixed_fields:
+                prefix, field_name = field.split('.', 1)
+                if prefix == 'work':
+                    pairs = [(doc, key_to_thing.get(doc['key']))]
+                else:
+                    pairs = [
+                        (ed_doc, key_to_thing.get(ed_doc['key']))
+                        for ed_doc in doc.get('editions', {}).get('docs', [])
+                    ]
 
-                for field in non_solr_fields:
-                    val = getattr(ed, field)
-                    if field == 'providers':
-                        ed_doc[field] = [
-                            acq.__dict__ for acq in get_acquisitions(ed_doc, ed)
+                for solr_doc, db_thing in pairs:
+                    # Could be `None` if the record has been deleted and Solr not yet updated.
+                    if not db_thing:
+                        continue
+
+                    val = getattr(db_thing, field_name)
+                    if field_name == 'providers':
+                        ed = cast(Edition, db_thing)
+                        solr_doc[field_name] = [
+                            acq.__dict__ for acq in get_acquisitions(solr_doc, ed)
                         ]
                     elif isinstance(val, infogami.infobase.client.Nothing):
                         continue
-                    elif field == 'description':
-                        ed_doc[field] = val if isinstance(val, str) else val.value
+                    elif field_name == 'description':
+                        solr_doc[field_name] = (
+                            val if isinstance(val, str) else val.value
+                        )
 
 
 def lcc_transform(sf: luqum.tree.SearchField):


### PR DESCRIPTION
Fix for OPDS. You can now specify `description` to fetch both work and edition descriptions, or `work.descriptions` / `edition.descriptions` to fetch the descriptions for either the work/edition.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

- Shows both descriptions: https://testing.openlibrary.org/search.json?q=edition_key:OL27786693M&fields=key,title,description,editions
- Shows work only https://testing.openlibrary.org/search.json?q=edition_key:OL27786693M&fields=key,title,work.description,editions
- Shows edition only: https://testing.openlibrary.org/search.json?q=edition_key:OL27786693M&fields=key,title,editions.description,editions
- Works with providers: https://testing.openlibrary.org/search.json?q=edition_key:OL27786693M&fields=key,title,description,editions,providers,editions.ia,editions.ebook_access,editions.key

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
