### PR TITLE
Refactor OPDS links and update catalog metadata

### DIFF
--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -882,7 +882,7 @@ class opds_subjects(delegate.page):
         web.header('Content-Type', 'application/opds+json')
         return delegate.RawText(json.dumps(catalog.model_dump()))
 
-        
+
 class opds_home(delegate.page):
     path = r"/opds"
 


### PR DESCRIPTION
Switch to `pyopds2_openlibrary.STORED_SEARCHES` https://github.com/ArchiveLabs/pyopds2_openlibrary/pull/18 which uses `pyopds2.Search` (https://github.com/ArchiveLabs/pyopds2/commit/7b4242461d0c2cebf83728fda79e60cc63d0fab9)

This PR is **not** complete.

This pull request refactors and improves the OPDS API endpoints in `openlibrary/plugins/openlibrary/api.py`. The main changes focus on making the code more modular, reducing duplication, and introducing a new subject-based OPDS endpoint. The update also streamlines how bookshelf and profile links are added, and centralizes the logic for featured subject navigation and stored searches.

Key changes:

**Refactoring and Code Simplification:**
- Replaces repeated inline bookshelf and profile `Link` objects with calls to `provider.bookshelf_link()` and `provider.profile_link`, making the code more modular and easier to maintain. [[1]](diffhunk://#diff-ff39aef27ef9ba1505e39229b43cb2bcb15e7b9a12affbcf420628abcdea8204L830-R831) [[2]](diffhunk://#diff-ff39aef27ef9ba1505e39229b43cb2bcb15e7b9a12affbcf420628abcdea8204L863-R884)

**New Features:**
- Adds a new `opds_subjects` endpoint (`/opds/subjects/<subject_key>`) that returns an OPDS catalog for a given subject using search parameters tailored for trending, borrowable books, and safe-for-work content.

**Homepage and Navigation Improvements:**
- Updates the OPDS homepage to use a more descriptive title ("Browsing the Open Library") and changes subject navigation links to point to the new subject endpoints, improving user navigation and discoverability.
- Refactors the homepage's featured subject groups to use a centralized `provider.STORED_SEARCHES` list, simplifying the logic for generating trending, classic, romance, kids, thrillers, and textbooks sections.

