### PR TITLE
Add sort parameter to GET request in api.py

### DIFF
--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -808,7 +808,7 @@ class opds_search(delegate.page):
         from pyopds2 import Catalog, Link, Metadata
 
         i = web.input(
-            query="trending_score_hourly_sum:[1 TO *]", limit=25, sort=None, page=1
+            query="trending_score_hourly_sum:[1 TO *]", limit=25, page=1, sort=None
         )
         provider = get_opds_data_provider()
         catalog = Catalog.create(


### PR DESCRIPTION
Fixes the OPDS feed for @MarcCoquand ; adds in support for `sort` query param to be passed along with query

<!-- What issue does this PR close? -->
This pull request introduces a minor update to the OPDS search API endpoint by adding support for an optional `sort` parameter. This allows clients to specify the sorting method for search results, improving the flexibility of the API.

Enhancement to OPDS search API:

* Added a `sort` parameter to the `web.input()` call in the `opds_search` class, and passed it to the data provider's `search` method to allow clients to control the sorting of search results.
