### PR TITLE
Remove border from language component

### DIFF
--- a/static/css/components/language.less
+++ b/static/css/components/language.less
@@ -52,7 +52,6 @@
 .iaBar .language-component {
   position: relative;
   display: block;
-  border: 1px solid @mid-grey;
   border-radius: 5px;
   padding: 0.2rem 0.4rem;
   // stylelint-disable selector-max-specificity, max-nesting-depth


### PR DESCRIPTION
This pull request makes a minor update to the `language.less` stylesheet by removing the border from the `.iaBar .language-component` class. No other changes are included.

- Removed the `border: 1px solid @mid-grey;` style from the `.iaBar .language-component` class in `language.less`

Followup to #11203 #11196