### PR TITLE
Let search inside work if availability is down

### DIFF
--- a/openlibrary/core/fulltext.py
+++ b/openlibrary/core/fulltext.py
@@ -8,7 +8,6 @@ import web
 from infogami import config
 from openlibrary.core.lending import get_availability
 from openlibrary.plugins.openlibrary.home import format_book_data
-from openlibrary.utils import async_utils
 from openlibrary.utils.async_utils import async_bridge, req_context
 
 logger = logging.getLogger("openlibrary.inside")


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11519 . Note it fixes it so that the page isn't empty, but the borrow buttons again say "Locate" instead of the correct availability if the availability service is erroring.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Tested on testing and confirmed it still works, but testing isn't exhibiting the bug described in the issue. Going to patch deploy to see if it fixes it there.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
