### PR TITLE
fix: prevent share button overflow on My Books / Lists page

### DIFF
--- a/static/css/components/mybooks-details.less
+++ b/static/css/components/mybooks-details.less
@@ -25,6 +25,7 @@
 
 .social-wrapper {
   display: flex;
+  align-items: baseline;
 }
 
 .follow-row {
@@ -116,6 +117,10 @@
 @media only screen and (max-width: @width-breakpoint-tablet) {
   .breadcrumb-wrapper {
     align-items: self-end;
+  }
+
+  .social-wrapper {
+    flex-direction: column;
   }
 
   .mybooks-details {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11422

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
* Added ` flex-direction: column` at the `@width-breakpoint-tablet`  in
  [static/css/components/mybooks-details.less]
  This allows the title and the social/share button to wrap onto a new line
  when the viewport width is reduced (tablet/narrow screens), preventing the
  share button from overflowing the container.

* The change is scoped to the [mybooks-details.less](cci:7://file:///home/krishna/Contribution/openlibrary/static/css/components/mybooks-details.less:0:0-0:0) component only; no other
  files were modified.

### Testing
1. **Build** – Run `docker compose exec web make css` (or `npm run watch:css`)
   to regenerate the CSS assets.
2. **Open the page** – Navigate to a My Books / Lists page, e.g.
   `https://openlibrary.org/people/<your‑username>/lists`.
3. **Resize** the browser window to a width around **768 px** (tablet size).
4. **Verify** that the header now wraps and the “Share” button stays within the
   container without overlapping the title.

### Screenshot
#### Mobile view
<img width="430" height="802" alt="image" src="https://github.com/user-attachments/assets/d7f7f56c-0c19-4fea-ab94-6a52d4d82cd8" />

#### Normal View
<img width="980" height="594" alt="image" src="https://github.com/user-attachments/assets/59b6699b-2f20-4324-981d-72a61cd13cf6" />

### Stakeholder
@cdrini 
