### PR TITLE
Potential fix for code scanning alert no. 3: Client-side cross-site scripting

### DIFF
--- a/openlibrary/components/BarcodeScanner.vue
+++ b/openlibrary/components/BarcodeScanner.vue
@@ -50,8 +50,8 @@ export default {
     components: { LazyBookCard, SettingsIcon },
     data() {
         let returnTo = new URLSearchParams(location.search).get('returnTo');
-        // Only allow absolute URLs or root-relative URLs to prevent XSS
-        if (!/^(https?:\/\/|\/)/.test(returnTo)) {
+        // Only allow root-relative URLs (starting with a single /, but not //) to prevent open redirects
+        if (!(typeof returnTo === 'string' && returnTo.startsWith('/') && !returnTo.startsWith('//'))) {
             returnTo = null;
         }
         return {
@@ -217,17 +217,7 @@ export default {
             if (this.seenISBN.has(isbn)) return;
 
             if (this.returnTo) {
-                // Check if domain is the same as the current domain to prevent
-                // open redirects.
-                if (!this.returnTo.startsWith('/')) {
-                    // Only display the destination's origin (domain), not the full URL
-                    try {
-                        const destUrl = new URL(this.returnTo.replace('$$$', encodeURIComponent(isbn)));
-                        window.alert(`Redirecting to ${destUrl.origin}`);
-                    } catch (err) {
-                        window.alert('Redirecting to external site');
-                    }
-                }
+                // Safe: Only allow root-relative paths (see validation in data()), so no open redirects.
                 location = this.returnTo.replace('$$$', encodeURIComponent(isbn));
             }
             this.isbnList.unshift({isbn: isbn, cover: tentativeCoverUrl});

--- a/openlibrary/components/BarcodeScanner.vue
+++ b/openlibrary/components/BarcodeScanner.vue
@@ -220,7 +220,13 @@ export default {
                 // Check if domain is the same as the current domain to prevent
                 // open redirects.
                 if (!this.returnTo.startsWith('/')) {
-                    window.alert(`Redirecting to ${this.returnTo.replace('$$$', isbn)}`);
+                    // Only display the destination's origin (domain), not the full URL
+                    try {
+                        const destUrl = new URL(this.returnTo.replace('$$$', encodeURIComponent(isbn)));
+                        window.alert(`Redirecting to ${destUrl.origin}`);
+                    } catch (err) {
+                        window.alert('Redirecting to external site');
+                    }
                 }
                 location = this.returnTo.replace('$$$', encodeURIComponent(isbn));
             }

--- a/openlibrary/components/BarcodeScanner.vue
+++ b/openlibrary/components/BarcodeScanner.vue
@@ -222,7 +222,7 @@ export default {
                 if (!this.returnTo.startsWith('/')) {
                     window.alert(`Redirecting to ${this.returnTo.replace('$$$', isbn)}`);
                 }
-                location = this.returnTo.replace('$$$', isbn);
+                location = this.returnTo.replace('$$$', encodeURIComponent(isbn));
             }
             this.isbnList.unshift({isbn: isbn, cover: tentativeCoverUrl});
             this.seenISBN.add(isbn);


### PR DESCRIPTION
Potential fix for [https://github.com/internetarchive/openlibrary/security/code-scanning/3](https://github.com/internetarchive/openlibrary/security/code-scanning/3)

To fix this DOM-based cross-site scripting risk, the code must ensure that the `isbn` value substituted into the return URL is strictly sanitized or safely encoded. The canonical way is to encode the ISBN for insertion into a URL (i.e., using `encodeURIComponent`). This prevents ISBNs containing malicious data from breaking out of their intended context in the URL. We will only change line 225, wrapping the ISBN in `encodeURIComponent` before interpolation.

No additional code is required outside this file and region: `encodeURIComponent` is globally available in browsers and does not require an import. This change preserves existing behavior but blocks injected values.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
