### PR TITLE
fixed borrow availability on book pages

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -371,9 +371,7 @@ def groundtruth_to_availability_status(
     is_lendable = bool(groundtruth.get('is_lendable'))
     is_printdisabled = bool(groundtruth.get('is_printdisabled'))
 
-    status: Literal[
-        "borrow_available", "borrow_unavailable", "open", "error"
-    ]
+    status: Literal["borrow_available", "borrow_unavailable", "open", "error"]
     if is_readable:
         status = "open"
     elif available_to_borrow:
@@ -493,7 +491,9 @@ def get_availability(
     if not ids_to_fetch:
         return availabilities
 
-    def fallback_with_groundtruth(ids_subset: set[str]) -> dict[str, AvailabilityStatusV2]:
+    def fallback_with_groundtruth(
+        ids_subset: set[str],
+    ) -> dict[str, AvailabilityStatusV2]:
         if id_type != 'identifier' or not ids_subset:
             return {}
         fallback_availabilities: dict[str, AvailabilityStatusV2] = {}
@@ -511,7 +511,10 @@ def get_availability(
                 )
         if fallback_availabilities:
             mc.set_multi(
-                {key_func(_id): availability for _id, availability in fallback_availabilities.items()},
+                {
+                    key_func(_id): availability
+                    for _id, availability in fallback_availabilities.items()
+                },
                 expires=5 * dateutil.MINUTE_SECS,
             )
         return fallback_availabilities


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11520 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Restores Borrow/Search Inside buttons by falling back to ground-truth lending data when the bulk availability API rejects our requests.

### Technical
<!-- What should be noted about the implementation? -->
Root Cause:
The site’s lending stack depends on the IA bulk availability endpoint `https://archive.org/services/availability` to populate `LoanStatus.html` That endpoint began returning `success=false` with
 `"error": "Current user does not have access to scope"`
Leaving every edition’s availability.status as "error". With no valid lendable flags, the template dropped straight into its fallback branch, rendering only the Locate button and breaking Search Inside, which also reads from the same availability payload.

Fix:
Plugged a fallback into `get_availability`: when the bulk `/services/availability` call returns that scope error or raises, we now fetch each requested OCAID’s ground-truth lending record via `/services/loans/loan/?action=availability`, convert that payload into the v2 availability schema, cache it, and continue. That restores the borrowability flags the templates expect without depending solely on the failing bulk endpoint.
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
