### PR TITLE
refactor: Move pagination css from legacy to new component

### DIFF
--- a/static/css/components/pagination.less
+++ b/static/css/components/pagination.less
@@ -1,0 +1,41 @@
+// openlibrary/templates/lib/pagination.html
+// openlibrary/templates/type/author/view.html
+
+.pagination {
+  font-size: 0.75em;
+  margin: 0 15px;
+  .display-flex();
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  a {
+    display: block;
+    text-decoration: none;
+    padding: 7px;
+    margin-right: 10px;
+    &:hover {
+      background: @link-blue;
+      color: @white;
+      display: block;
+      float: left;
+      text-decoration: none;
+      padding: 7px;
+      margin-right: 10px;
+    }
+  }
+  span.ellipsis {
+    display: block;
+    float: left;
+    color: @black;
+    padding: 8px;
+    margin-right: 10px;
+  }
+  span.this {
+    display: block;
+    float: left;
+    color: @black;
+    padding: 7px;
+    border: 1px solid @lighter-grey;
+    margin-right: 10px;
+    background-color: @lightest-grey;
+  }
+}

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -271,47 +271,6 @@ q {
 @import (less) "base/helpers-common.less";
 @import (less) "base/helpers-misc.less";
 
-// openlibrary/templates/lib/pagination.html
-// openlibrary/templates/type/author/view.html
-.pagination {
-  font-size: 0.75em;
-  margin: 0 15px;
-  .display-flex();
-  justify-content: flex-end;
-  flex-wrap: wrap;
-  a {
-    display: block;
-    text-decoration: none;
-    padding: 7px;
-    margin-right: 10px;
-    &:hover {
-      background: @link-blue;
-      color: @white;
-      display: block;
-      float: left;
-      text-decoration: none;
-      padding: 7px;
-      margin-right: 10px;
-    }
-  }
-  span.ellipsis {
-    display: block;
-    float: left;
-    color: @black;
-    padding: 8px;
-    margin-right: 10px;
-  }
-  span.this {
-    display: block;
-    float: left;
-    color: @black;
-    padding: 7px;
-    border: 1px solid @lighter-grey;
-    margin-right: 10px;
-    background-color: @lightest-grey;
-  }
-}
-
 // openlibrary/templates/recentchanges/header.html
 // openlibrary/templates/showia.html
 // openlibrary/templates/showmarc.html

--- a/static/css/page-user.less
+++ b/static/css/page-user.less
@@ -253,3 +253,4 @@ textarea.toc-editor {
 @import (less) "components/searchbox.less";
 // Import styles for sort options
 @import (less) "components/sort-dropper.less";
+@import (less) "components/pagination.less";


### PR DESCRIPTION

### Technical
**Moves pagination css into it's own component file and loads.** Incremental work to deprecate `legacy.css`

### Testing
Tested on search results and author pages.

### Screenshot
<img width="865" height="561" alt="image" src="https://github.com/user-attachments/assets/4da3de44-9f65-4b8b-9609-11ac3cceff7d" />


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
