### PR TITLE
refactor: Remove unused css rules related previously to editions/view

### DIFF
--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -45,26 +45,6 @@ table {
   border-collapse: collapse;
   border-spacing: 0;
 
-  // openlibrary/templates/type/edition/view.html
-  &#toc-table {
-    width: 100%;
-    font-size: 0.8125em;
-    td {
-      padding: 5px 15px 5px 0;
-    }
-  }
-  // openlibrary/templates/type/edition/view.html
-  &.navEdition {
-    margin-bottom: 5px;
-    td.nowrap {
-      white-space: nowrap;
-    }
-    td {
-      padding: 0;
-      margin: 0;
-      vertical-align: middle;
-    }
-  }
   &.meta {
     margin-top: 10px;
     td {


### PR DESCRIPTION

### Technical
Removes unused style rules from legacy.css.


### Testing
Check rendering of editions list on work page.

### Screenshot
<img width="994" height="710" alt="image" src="https://github.com/user-attachments/assets/f3e15a21-2cea-4358-aa61-75df506d0c2f" />

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
