### PR TITLE
fix: Console errors from premature colorbox resize calls

### DIFF
--- a/openlibrary/components/ObservationForm/Utils.js
+++ b/openlibrary/components/ObservationForm/Utils.js
@@ -8,6 +8,12 @@ export function decodeAndParseJSON(str) {
     return JSON.parse(decodeURIComponent(str));
 }
 
+/*
+    window.$ is a jQuery object
+    window.$.colorbox is a jQuery plugin
+*/
 export function resizeColorbox() {
-    window.$.colorbox.resize();
+    if (window.$ && window.$.colorbox && typeof window.$.colorbox.resize === 'function') {
+        window.$.colorbox.resize();
+    }
 }


### PR DESCRIPTION
**Fixes JS error that appears on books and works pages.**
To see the issue live on prod, visit a [book page](https://openlibrary.org/books/OL9088837M/Grid_Systems_in_Graphic_Design) and open the browser dev console to view.

<img width="644" height="64" alt="image" src="https://github.com/user-attachments/assets/a8d2f6f5-2606-42fa-ae92-9bc25fa2bda9" />


### Technical
- Adds checks to make sure colorbox has been attached to the jQuery object before calling the resize.

### Stakeholders
@jimchamp @mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
