### PR TITLE
Add relative links to code organization in Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -56,11 +56,11 @@ You can also find more information regarding Developer Documentation for Open Li
 
 ## Code Organization
 
-* openlibrary/core - core openlibrary functionality, imported and used by www
-* openlibrary/plugins - other models, controllers, and view helpers
-* openlibrary/views - views for rendering web pages
-* openlibrary/templates - all the templates used in the website
-* openlibrary/macros - macros are like templates, but can be called from wikitext
+* [*openlibrary/core*](/openlibrary/core) - core openlibrary functionality, imported and used by www
+* [*openlibrary/plugins*](/openlibrary/plugins) - other models, controllers, and view helpers
+* [*openlibrary/views*](/openlibrary/views) - views for rendering web pages
+* [*openlibrary/templates*](/openlibrary/templates) - all the templates used in the website
+* [*openlibrary/macros*](/openlibrary/macros) - macros are like templates, but can be called from wikitext
 
 ## Architecture
 

--- a/Readme_chinese.md
+++ b/Readme_chinese.md
@@ -53,11 +53,11 @@
 
 ## 代码组成
 
-* openlibrary/core - 公共图书馆的核心功能，由www导入和使用
-* openlibrary/plugins - 其它模型、控制器和视图帮助器
-* openlibrary/views - 网页视图的呈现
-* openlibrary/templates - 所有在网页里使用的模板
-* openlibrary/macros - macros和模板类似，但可以被wikitext调用
+* [*openlibrary/core*](/openlibrary/core) - 公共图书馆的核心功能，由www导入和使用
+* [*openlibrary/plugins*](/openlibrary/plugins) - 其它模型、控制器和视图帮助器
+* [*openlibrary/views*](/openlibrary/views) - 网页视图的呈现
+* [*openlibrary/templates*](/openlibrary/templates) - 所有在网页里使用的模板
+* [*openlibrary/macros*](/openlibrary/macros) - macros和模板类似，但可以被wikitext调用
 
 ## 结构
 

--- a/Readme_es.md
+++ b/Readme_es.md
@@ -54,11 +54,11 @@ También puedes encontrar más información sobre la Documentación para Desarro
 
 ## Organización del Código
 
-* openlibrary/core - funcionalidad central de Open Library, importada y utilizada por www
-* openlibrary/plugins - otros modelos, controladores y ayudantes de vista (view helpers)
-* openlibrary/views - vistas para renderizar páginas web
-* openlibrary/templates - todas las plantillas utilizadas en el sitio web
-* openlibrary/macros - los macros son similares a las plantillas, pero pueden ser llamados desde wikitext
+* [*openlibrary/core*](/openlibrary/core) - funcionalidad central de Open Library, importada y utilizada por www
+* [*openlibrary/plugins*](/openlibrary/plugins) - otros modelos, controladores y ayudantes de vista (view helpers)
+* [*openlibrary/views*](/openlibrary/views) - vistas para renderizar páginas web
+* [*openlibrary/templates*](/openlibrary/templates) - todas las plantillas utilizadas en el sitio web
+* [*openlibrary/macros*](/openlibrary/macros) - los macros son similares a las plantillas, pero pueden ser llamados desde wikitext
 
 ## Arquitectura
 

--- a/Readme_vn.md
+++ b/Readme_vn.md
@@ -52,11 +52,11 @@ Bạn cũng có thể tìm kiếm thêm thông tin về Tài liệu dành cho nh
 
 ## Tổ chức code
 
-* openlibrary/core - chức năng cốt lõi của openlibrary, được nhập và sử dụng bởi www
-* openlibrary/plugins - các mô hình, các bộ điều khiển và trình trợ giúp hiển thị khác.
-* openlibrary/views - các chế độ xem để hiển thị trang web
-* openlibrary/templates - tất cả những templates được dùng trên trang web.
-* openlibrary/macros -  các macro tương tự như mẫu, nhưng có thể được gọi từ wikitext.
+* [*openlibrary/core*](/openlibrary/core) - chức năng cốt lõi của openlibrary, được nhập và sử dụng bởi www
+* [*openlibrary/plugins*](/openlibrary/plugins) - các mô hình, các bộ điều khiển và trình trợ giúp hiển thị khác.
+* [*openlibrary/views*](/openlibrary/views) - các chế độ xem để hiển thị trang web
+* [*openlibrary/templates*](/openlibrary/templates) - tất cả những templates được dùng trên trang web.
+* [*openlibrary/macros*](/openlibrary/macros) -  các macro tương tự như mẫu, nhưng có thể được gọi từ wikitext.
 
 ## Kiến trúc
 


### PR DESCRIPTION
This PR makes Readme documentation slightly more helpful by adding relative links to code (so reader can go there in one click instead of multiple).

<!-- What issue does this PR close? -->
No open issue (should I create one for this?)

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
N/A
<!-- What should be noted about the implementation? -->

### Testing
N/A
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
N/A
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
None
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
