### PR TITLE
fix: minimum book thickness validation

### DIFF
--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -570,17 +570,17 @@ $ })
                             <tr>
                                 <td rowspan="3"><img src="/images/dimensions.png" alt="$_('dimensions')" width="107" height="69" align="left"/></td>
                                 <td><span class="tip"><label for="dimensions-height">$_("Height:")</label> </span></td>
-                                <td><input name="edition--physical_dimensions--height" type="number" step="any" min="0.1"
+                                <td><input name="edition--physical_dimensions--height" type="number" step="any" min="0.01"
                                            id="dimensions-height" size="6" value="$dimensions.height"/></td>
                             </tr>
                             <tr>
                                 <td><span class="tip"><label for="dimensions-width">$_("Width:")</label> </span></td>
-                                <td><input name="edition--physical_dimensions--width" type="number" step="any" min="0.1"
+                                <td><input name="edition--physical_dimensions--width" type="number" step="any" min="0.01"
                                            id="dimensions-width" size="6" value="$dimensions.width"/></td>
                             </tr>
                             <tr>
                                 <td><span class="tip"><label for="dimensions-depth">$_("Depth:")</label> </span></td>
-                                <td><input name="edition--physical_dimensions--depth" type="number" step="any" min="0.1"
+                                <td><input name="edition--physical_dimensions--depth" type="number" step="any" min="0.01"
                                            id="dimensions-depth" size="6" value="$dimensions.depth"/></td>
                             </tr>
                         </tbody>


### PR DESCRIPTION
Closes #11542

## Solution
Lowered the HTML5 minimum validation from 0.1 to 0.01 for all three dimension fields (Height, Width, Depth) in the edition edit form template.

## Changes
- Updated `openlibrary/templates/books/edit/edition.html`
  - `edition--physical_dimensions--height`: min="0.1" → min="0.01"
  - `edition--physical_dimensions--width`: min="0.1" → min="0.01"
  - `edition--physical_dimensions--depth`: min="0.1" → min="0.01"

## Testing
Verified that:
- Books with 0.0625" depth can now be saved without validation error
- No backend changes needed (backend already accepts these values)
- Dimension fields maintain reasonable lower bounds