### PR TITLE
Exclude markdown files changes from triggering the `python_tests` workflow

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -12,6 +12,7 @@ on:
       - '**.vue'
       - '**.less'
       - '**.css'
+      - '**.md'
 permissions:
   contents: read
 


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
After reviewing a PR that only changed our README files (#11544), I had to wait for our Python unit test workflow to finish before I could merge the work.  To avoid this in the future, I've updated the workflow so that `.md` changes do not trigger the workflow.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
