### PR TITLE
Update regex for `closes` keywords in PR assignment script

### DIFF
--- a/scripts/gh_scripts/new_pr_labeler.mjs
+++ b/scripts/gh_scripts/new_pr_labeler.mjs
@@ -113,6 +113,8 @@ function parseArgs() {
     }
 }
 
+const CLOSES_REGEX = /\b(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved):?\s+#(\d+)/i
+
 /**
  * Finds first "Closes" statement in the given pull request body, then
  * returns the number of the linked issue or an empty string, if none exists.
@@ -123,7 +125,6 @@ function parseArgs() {
  *                   "Closes" statement is found.
  */
 function findLinkedIssue(body) {
-    let lowerBody = body.toLowerCase()
-    const matches = lowerBody.match(/closes #(\d+)/)
+    const matches = body.match(CLOSES_REGEX)
     return matches?.length ? Number(matches[1]) : ''
 }


### PR DESCRIPTION
Updates the PR auto-assigner script to match any of GitHub's [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).  The new regex allows for an optional colon after the keyword, so `fixes: #<N>` and `fixes #<N>` will both match.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
