### PR TITLE
feat: Auto-assign PRs when Issue Lead set after submission

### DIFF
--- a/.github/workflows/issue_lead_labeler.yml
+++ b/.github/workflows/issue_lead_labeler.yml
@@ -1,0 +1,28 @@
+name: Issue Lead Labeler
+on:
+  issues:
+    types: [labeled]
+env:
+  NODE_VERSION: '20'
+jobs:
+  assign_lead_to_pr:
+    if: "${{ github.repository == github.event.repository.full_name && startsWith(github.event.label.name, 'Lead: @') }}"
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - uses: actions/cache@v4
+        id: cache-octokit
+        with:
+          path: 'node_modules'
+          key: ${{ runner.os }}-node${{ env.NODE_VERSION}}-octokit-${{ hashFiles('**/package-lock.json') }}
+      - if: steps.cache-octokit.outputs.cache-hit != 'true'
+        run: npm install @octokit/action
+      - run: node scripts/gh_scripts/issue_lead_labeler.mjs "${{ github.repository }}" "${{ github.event.issue.number }}" "${{ github.event.label.name }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/gh_scripts/issue_lead_labeler.mjs
+++ b/scripts/gh_scripts/issue_lead_labeler.mjs
@@ -1,0 +1,95 @@
+/**
+ * Script to automatically assign a "Lead" to linked Pull Requests when a "Lead: ..." label
+ * is added to an Issue.
+ *
+ * Usage:
+ * `node issue_lead_labeler.mjs REPO_NAME ISSUE_NUMBER LEAD_LABEL`
+ *
+ * Where:
+ * `REPO_NAME` is the owner and repository (e.g. "internetarchive/openlibrary")
+ * `ISSUE_NUMBER` is the number of the issue that was labeled
+ * `LEAD_LABEL` is the label name (e.g. "Lead: @username")
+ */
+import { Octokit } from "@octokit/action";
+
+console.log('Script starting....')
+const octokit = new Octokit()
+await main()
+console.log('Script terminated....')
+
+async function main() {
+    const { fullRepoName, issueNumber, leadLabel } = parseArgs()
+    const [repoOwner, repoName] = fullRepoName.split('/')
+
+    // Extract username from label "Lead: @username"
+    const leadUsername = leadLabel.split('@')[1]
+    if (!leadUsername) {
+        console.log(`Could not extract username from label: ${leadLabel}`)
+        return
+    }
+
+    console.log(`Searching for PRs linked to issue #${issueNumber} to assign to ${leadUsername}...`)
+
+    // Search for open PRs that mention this issue using "#issueNumber" pattern
+    // This matches the "Closes #123" syntax used in PR bodies to link issues.
+    const q = `repo:${fullRepoName} is:pr is:open "#${issueNumber}"`
+    const searchResult = await octokit.request('GET /search/issues', {
+        q: q
+    })
+
+    const prs = searchResult.data.items
+    console.log(`Found ${prs.length} candidate PRs.`)
+
+    for (const pr of prs) {
+        // Verify the PR body actually contains a "closes #issueNumber" (or fixes/resolves) statement
+        // to avoid false positives from PRs that just mention the issue number
+        const prBody = (pr.body || '').toLowerCase()
+        const closingPattern = new RegExp(`(closes|fixes|resolves)\\s*#${issueNumber}\\b`, 'i')
+        if (!closingPattern.test(prBody)) {
+            console.log(`PR #${pr.number} mentions #${issueNumber} but does not close it. Skipping.`)
+            continue
+        }
+
+        const isAssigned = pr.assignees.some(assignee => assignee.login === leadUsername)
+        if (isAssigned) {
+            console.log(`PR #${pr.number} is already assigned to ${leadUsername}. Skipping.`)
+            continue
+        }
+
+        // Avoid assigning if the lead is the author of the PR
+        if (pr.user.login === leadUsername) {
+             console.log(`PR #${pr.number} author is the lead (${leadUsername}). Skipping assignment.`)
+             continue
+        }
+
+        console.log(`Assigning PR #${pr.number} to ${leadUsername}...`)
+
+        try {
+            await octokit.request('POST /repos/{owner}/{repo}/issues/{issue_number}/assignees', {
+                owner: repoOwner,
+                repo: repoName,
+                issue_number: pr.number,
+                assignees: [leadUsername],
+                headers: {
+                    'X-GitHub-Api-Version': '2022-11-28'
+                }
+            })
+            console.log(`Successfully assigned PR #${pr.number}`)
+        } catch (error) {
+            console.error(`Failed to assign PR #${pr.number}:`, error)
+        }
+    }
+}
+
+function parseArgs() {
+    if (process.argv.length < 5) {
+        console.log('Unexpected number of arguments.')
+        console.log('Usage: node issue_lead_labeler.mjs REPO_NAME ISSUE_NUMBER LEAD_LABEL')
+        process.exit(1)
+    }
+    return {
+        fullRepoName: process.argv[2],
+        issueNumber: process.argv[3],
+        leadLabel: process.argv[4]
+    }
+}


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11443

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->
- Added new GitHub Action workflow [issue_lead_labeler.yml] that triggers on `issues.labeled` events.
- Added script [issue_lead_labeler.mjs] that:
  - Extracts the username from `Lead: @username` labels.
  - Searches for open PRs containing `closes/fixes/resolves #<issue_number>` syntax.
  - Assigns the lead to matching PRs (skipping if already assigned or if lead is the PR author).
- Shares the npm cache key with other workflows for efficiency.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Create a test issue in a fork
2. Create a PR that contains `Closes #<issue_number>` in the body
3. Add a `Lead: @<your-username>` label to the issue
4. Verify the GitHub Action runs and assigns the lead to the PR
5. Verify edge cases:
   - If lead is already assigned → skipped
   - If lead is the PR author → skipped
   - If PR mentions but doesn't close the issue → skipped

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A - This is a GitHub Actions workflow, no UI changes.

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles