### PR TITLE
Fix: Show covers in search results using edition fallback (Fixes #11563)

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -81,8 +81,8 @@ msgstr ""
 msgid "Pending Imports"
 msgstr ""
 
-#: BookByline.html FulltextSearchSuggestionItem.html SearchResultsWork.html
-#: account/notes.html account/observations.html
+#: BookByline.html FulltextSearchSuggestionItem.html account/notes.html
+#: account/observations.html
 msgid "Unknown author"
 msgstr ""
 
@@ -335,10 +335,10 @@ msgstr ""
 msgid "right chevron"
 msgstr ""
 
-#: FulltextSearchSuggestionItem.html IABook.html SearchResultsWork.html
-#: books/edition-sort.html jsdef/LazyWorkPreview.html lists/list_overview.html
-#: lists/preview.html lists/snippet.html lists/widget.html
-#: my_books/dropdown_content.html type/work/editions.html
+#: FulltextSearchSuggestionItem.html IABook.html books/edition-sort.html
+#: jsdef/LazyWorkPreview.html lists/list_overview.html lists/preview.html
+#: lists/snippet.html lists/widget.html my_books/dropdown_content.html
+#: type/work/editions.html
 #, python-format
 msgid "Cover of: %(title)s"
 msgstr ""
@@ -779,47 +779,6 @@ msgstr ""
 msgid "Advanced Search"
 msgstr ""
 
-#: SearchResultsWork.html
-msgid "added to"
-msgstr ""
-
-#: SearchResultsWork.html
-#, python-format
-msgid "Cover of edition %(id)s"
-msgstr ""
-
-#: SearchResultsWork.html type/work/editions.html
-#, python-format
-msgid "First published in %(year)s"
-msgstr ""
-
-#: SearchResultsWork.html books/check.html merge/authors.html
-#: publishers/view.html
-#, python-format
-msgid "%(count)s edition"
-msgid_plural "%(count)s editions"
-msgstr[0] ""
-msgstr[1] ""
-
-#: SearchResultsWork.html
-#, python-format
-msgid "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d language</a>"
-msgid_plural "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d languages</a>"
-msgstr[0] ""
-msgstr[1] ""
-
-#: SearchResultsWork.html TrendingBadge.html
-msgid "This is only visible to librarians."
-msgstr ""
-
-#: SearchResultsWork.html
-msgid "Work Title"
-msgstr ""
-
-#: SearchResultsWork.html type/edition/admin_bar.html
-msgid "Orphaned Edition"
-msgstr ""
-
 #: ShareModal.html
 #, python-format
 msgid "Share on %(share_link)s"
@@ -950,6 +909,10 @@ msgstr ""
 #: TableOfContents.html
 #, python-format
 msgid "Page %s"
+msgstr ""
+
+#: TrendingBadge.html
+msgid "This is only visible to librarians."
 msgstr ""
 
 #: TrendingBadge.html
@@ -4585,6 +4548,13 @@ msgstr ""
 msgid "Select this book"
 msgstr ""
 
+#: books/check.html merge/authors.html publishers/view.html
+#, python-format
+msgid "%(count)s edition"
+msgid_plural "%(count)s editions"
+msgstr[0] ""
+msgstr[1] ""
+
 #: books/check.html
 #, python-format
 msgid "First published in %(year)d"
@@ -7612,6 +7582,10 @@ msgstr ""
 msgid "View Book on Archive.org"
 msgstr ""
 
+#: type/edition/admin_bar.html
+msgid "Orphaned Edition"
+msgstr ""
+
 #: type/edition/modal_links.html
 msgid "Review"
 msgstr ""
@@ -8141,6 +8115,11 @@ msgstr ""
 
 #: type/usergroup/edit.html
 msgid "Members:"
+msgstr ""
+
+#: type/work/editions.html
+#, python-format
+msgid "First published in %(year)s"
 msgstr ""
 
 #: type/work/editions.html type/work/editions_datatable.html

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -1,197 +1,215 @@
-$def with (doc, decorations=None, cta=True, availability=None, extra=None, attrs=None, rating=None, highlighting=None, show_librarian_extras=False, include_dropper=False, blur=False, footer=None, seq_index=None)
+$def with (doc, decorations=None, cta=True, availability=None, extra=None, attrs=None, rating=None, highlighting=None,
+show_librarian_extras=False, include_dropper=False, blur=False, footer=None, seq_index=None)
 
 $code:
-  max_rendered_authors = 9
-  doc_type = (
-    'infogami_work' if doc.get('type', {}).get('key') == '/type/work' else
-    'infogami_edition' if doc.get('type', {}).get('key') == '/type/edition' else
-    'solr_work' if not doc.get('editions') else
-    'solr_edition'
-  )
+max_rendered_authors = 9
+doc_type = (
+'infogami_work' if doc.get('type', {}).get('key') == '/type/work' else
+'infogami_edition' if doc.get('type', {}).get('key') == '/type/edition' else
+'solr_work' if not doc.get('editions') else
+'solr_edition'
+)
 
-  # Depending on where we come from, editions is either a dict with docs,
-  # or a list of editions directly.
-  editions = doc.get('editions') or []
-  if isinstance(editions, dict):
-    editions = editions.get('docs') or []
+# Depending on where we come from, editions is either a dict with docs,
+# or a list of editions directly.
+editions = doc.get('editions') or []
+if isinstance(editions, dict):
+editions = editions.get('docs') or []
 
-  selected_ed = doc
-  if doc_type == 'solr_edition' and editions:
-    selected_ed = editions[0]
+selected_ed = doc
+if doc_type == 'solr_edition' and editions:
+selected_ed = editions[0]
 
-  selected_ed['availability'] = selected_ed.get('availability', {}) or doc.get('availability', {}) or availability or {}
-  ocaid = (selected_ed.get('ia') and selected_ed['ia'][0]) or selected_ed.get('ocaid')
+selected_ed['availability'] = selected_ed.get('availability', {}) or doc.get('availability', {}) or availability or {}
+ocaid = (selected_ed.get('ia') and selected_ed['ia'][0]) or selected_ed.get('ocaid')
 
-  if doc_type.startswith('infogami_'):
-    book_url = doc.url()
-  else:
-    book_url = doc.key + '/' + urlsafe(doc.get('title', '-'))
+if doc_type.startswith('infogami_'):
+book_url = doc.url()
+else:
+book_url = doc.key + '/' + urlsafe(doc.get('title', '-'))
 
-  if doc_type == 'solr_edition':
-    work_edition_url = book_url + '?edition=' + urlquote('key:' + selected_ed.key)
-  else:
-    book_provider = get_book_provider(doc)
-    if book_provider and doc_type.endswith('_work'):
-      work_edition_url = book_url + '?edition=' + urlquote(book_provider.get_best_identifier_slug(doc))
-    else:
-      work_edition_url = book_url
+if doc_type == 'solr_edition':
+work_edition_url = book_url + '?edition=' + urlquote('key:' + selected_ed.key)
+else:
+book_provider = get_book_provider(doc)
+if book_provider and doc_type.endswith('_work'):
+work_edition_url = book_url + '?edition=' + urlquote(book_provider.get_best_identifier_slug(doc))
+else:
+work_edition_url = book_url
 
-  work_edition_all_url = work_edition_url
-  if '?' in work_edition_url:
-    work_edition_all_url += '&mode=all'
-  else:
-    work_edition_all_url += '?mode=all'
+work_edition_all_url = work_edition_url
+if '?' in work_edition_url:
+work_edition_all_url += '&mode=all'
+else:
+work_edition_all_url += '?mode=all'
 
-  edition_work = None
-  if doc_type == 'infogami_edition' and 'works' in doc:
-    edition_work = doc['works'][0]
+edition_work = None
+if doc_type == 'infogami_edition' and 'works' in doc:
+edition_work = doc['works'][0]
 
-  full_title = selected_ed.get('title', '') + (': ' + selected_ed.subtitle if selected_ed.get('subtitle') else '')
-  if doc_type == 'infogami_edition' and edition_work:
-    full_work_title = edition_work.get('title', '') + (': ' + edition_work.subtitle if edition_work.get('subtitle') else '')
-  else:
-    full_work_title = doc.get('title', '') + (': ' + doc.subtitle if doc.get('subtitle') else '')
+full_title = selected_ed.get('title', '') + (': ' + selected_ed.subtitle if selected_ed.get('subtitle') else '')
+if doc_type == 'infogami_edition' and edition_work:
+full_work_title = edition_work.get('title', '') + (': ' + edition_work.subtitle if edition_work.get('subtitle') else '')
+else:
+full_work_title = doc.get('title', '') + (': ' + doc.subtitle if doc.get('subtitle') else '')
 
 <li class="searchResultItem sri--w-main" itemscope itemtype="https://schema.org/Book" $:attrs>
   $ blur_cover = "bookcover--blur" if blur else ""
   $if 'log' in doc:
-    <div class="feed-item">
-      <a class="feed-item--patron" href="/people/$(doc['log']['username'])">
-        <img src="/people/$(doc['log']['username'])/avatar" class="account-avatar account-avatar--sm account-avatar-fix">
-        $doc['log']['username']
-      </a> $_("added to")
-      <a href="/people/$(doc['log']['username'])/books/$(doc['log']['shelf'].replace(' ', '-'))" class="feed-item--shelf">$doc['log']['shelf']</a> $datestr(doc['log']['updated'])
-    </div>
+  <div class="feed-item">
+    <a class="feed-item--patron" href="/people/$(doc['log']['username'])">
+      <img src="/people/$(doc['log']['username'])/avatar" class="account-avatar account-avatar--sm account-avatar-fix">
+      $doc['log']['username']
+    </a> $_("added to")
+    <a href="/people/$(doc['log']['username'])/books/$(doc['log']['shelf'].replace(' ', '-'))"
+      class="feed-item--shelf">$doc['log']['shelf']</a> $datestr(doc['log']['updated'])
+  </div>
   <div class="sri__main">
     <span class="bookcover $blur_cover">
-      $ cover = get_cover_url(selected_ed) or "/images/icons/avatar_book-sm.png"
+      $ cover = get_cover_url(selected_ed)
+      $if not cover:
+      $ cover_id = (selected_ed.get('cover_i') or doc.get('cover_i'))
+      $ cover_edition_key = (selected_ed.get('cover_edition_key') or doc.get('cover_edition_key'))
+      $ edition_keys = (selected_ed.get('edition_key') or doc.get('edition_key') or [])
+      $if cover_id:
+      $ cover = "//covers.openlibrary.org/b/id/%s-M.jpg" % cover_id
+      $elif cover_edition_key:
+      $ cover = "//covers.openlibrary.org/b/olid/%s-M.jpg" % cover_edition_key
+      $elif edition_keys:
+      $ cover = "//covers.openlibrary.org/b/olid/%s-M.jpg" % edition_keys[0]
+      $else:
+      $ cover = "/images/icons/avatar_book-sm.png"
       <a href="$work_edition_url">
-        <img
-          itemprop="image"
-          src="$cover"
-          alt="$_('Cover of: %(title)s', title=full_title)"
-          title="$_('Cover of: %(title)s', title=full_title)"
-          $:cond(seq_index is not None and seq_index > 3, 'loading="lazy"')
-	  /></a>
+        <img itemprop="image" src="$cover" alt="$_('Cover of: %(title)s', title=full_title)"
+          title="$_('Cover of: %(title)s', title=full_title)" $:cond(seq_index is not None and seq_index> 3,
+        'loading="lazy"')
+        /></a>
       $if ocaid:
-        $:macros.BookPreview(ocaid, show_only=False)
+      $:macros.BookPreview(ocaid, show_only=False)
     </span>
 
     <div class="details">
-        <div class="resultTitle">
-          <h3 itemprop="name" class="booktitle">
-            <a itemprop="url" href="$work_edition_url" class="results">$full_title</a>
-          </h3>
-        </div>
-        <span itemprop="author" itemscope itemtype="https://schema.org/Organization" class="bookauthor">
-          $ authors = None
-          $if doc_type == 'infogami_work':
-            $ authors = doc.get_authors()
-          $elif doc_type == 'infogami_edition':
-            $ authors = edition_work.get_authors() if edition_work else doc.get_authors()
-          $elif doc_type.startswith('solr_'):
-            $if 'authors' in doc:
-              $ authors = doc['authors']
-            $elif 'author_key' in doc:
-              $ authors = [ { 'key': '/authors/' + key, 'name': name } for key, name in zip(doc['author_key'], doc['author_name']) ]
-          $if not authors:
-            <em>$_('Unknown author')</em>
-          $else:
-            $code:
-              author_data = [
-                {
-                  'name': a.get('name') or a.get('author', {}).get('name'),
-                  'url': (a.get('url') or a.get('key') or a.get('author', {}).get('url') or a.get('author', {}).get('key'))
-                }
-                for a in authors
-              ]
-            $:macros.BookByline(author_data, limit=max_rendered_authors, overflow_url=work_edition_url)
+      <div class="resultTitle">
+        <h3 itemprop="name" class="booktitle">
+          <a itemprop="url" href="$work_edition_url" class="results">$full_title</a>
+        </h3>
+      </div>
+      <span itemprop="author" itemscope itemtype="https://schema.org/Organization" class="bookauthor">
+        $ authors = None
+        $if doc_type == 'infogami_work':
+        $ authors = doc.get_authors()
+        $elif doc_type == 'infogami_edition':
+        $ authors = edition_work.get_authors() if edition_work else doc.get_authors()
+        $elif doc_type.startswith('solr_'):
+        $if 'authors' in doc:
+        $ authors = doc['authors']
+        $elif 'author_key' in doc:
+        $ authors = [ { 'key': '/authors/' + key, 'name': name } for key, name in zip(doc['author_key'],
+        doc['author_name']) ]
+        $if not authors:
+        <em>$_('Unknown author')</em>
+        $else:
+        $code:
+        author_data = [
+        {
+        'name': a.get('name') or a.get('author', {}).get('name'),
+        'url': (a.get('url') or a.get('key') or a.get('author', {}).get('url') or a.get('author', {}).get('key'))
+        }
+        for a in authors
+        ]
+        $:macros.BookByline(author_data, limit=max_rendered_authors, overflow_url=work_edition_url)
+      </span>
+      <span class="resultStats">
+        $ ratings_count = doc.get('ratings_count', None)
+        $ ratings_avg = doc.get('ratings_average', None)
+        $ want_to_read_count = doc.get('want_to_read_count', None)
+        $:macros.StarRatingsByline(ratings_count, ratings_avg, want_to_read_count)
+        $if show_librarian_extras and doc.get('trending_z_score') is not None:
+        $:macros.TrendingBadge(doc)
+      </span>
+
+      $if highlighting:
+      $if highlighting.get('subject'):
+      <br />
+      <span class="srw__subjects">
+        $for subj in highlighting['subject']:
+        $# detect-missing-i18n-skip-line
+        <a href="$subject_name_to_key(subj.replace('<em>', '').replace('</em>', ''))">$:subj</a>
+      </span>
+
+      $if doc.get('ia') and len(doc.get('ia')) > 1:
+      <br />
+      $ blur_preview = "preview-covers--blur" if blur else ""
+      <span class="preview-covers $blur_preview">
+        $for x, i in enumerate(doc.get('ia')[1:10]):
+        <a href="$(book_url)?edition=ia:$(urlquote(i))">
+          <img width="30" height="45" loading="lazy" src="//archive.org/services/img/$i"
+            alt="$_('Cover of edition %(id)s', id=i)">
+        </a>
+      </span>
+
+      <span class="resultDetails">
+        $if doc.get('first_publish_year'):
+        <span>
+          $_('First published in %(year)s', year=doc.first_publish_year)
+        </span>&mdash;
+        $if doc.get('edition_count'):
+        <span>
+          <a href="$work_edition_all_url#editions-list">$ungettext('%(count)s edition', '%(count)s editions',
+            doc.edition_count, count=doc.edition_count)</a>
         </span>
-        <span class="resultStats">
-          $ ratings_count = doc.get('ratings_count', None)
-          $ ratings_avg = doc.get('ratings_average', None)
-          $ want_to_read_count = doc.get('want_to_read_count', None)
-          $:macros.StarRatingsByline(ratings_count, ratings_avg, want_to_read_count)
-          $if show_librarian_extras and doc.get('trending_z_score') is not None:
-            $:macros.TrendingBadge(doc)
+        $if doc.get('languages') and doc_type in ['infogami_work', 'solr_work']:
+        <span class="languages">
+          $ langs = [get_language_name(lang.key if hasattr(lang, 'key') else '/languages' + lang) for lang in
+          doc.languages]
+          $:ungettext('in <a class="hoverlink" title="%(langs)s">%(count)d language</a>', 'in <a class="hoverlink"
+            title="%(langs)s">%(count)d languages</a>', len(doc.languages), count=len(doc.languages),
+          langs=commify_list(langs))
         </span>
+      </span>
 
-        $if highlighting:
-          $if highlighting.get('subject'):
-            <br />
-            <span class="srw__subjects">
-              $for subj in highlighting['subject']:
-                $# detect-missing-i18n-skip-line
-                <a href="$subject_name_to_key(subj.replace('<em>', '').replace('</em>', ''))">$:subj</a>
-            </span>
-
-        $if doc.get('ia') and len(doc.get('ia')) > 1:
-          <br />
-          $ blur_preview = "preview-covers--blur" if blur else ""
-          <span class="preview-covers $blur_preview">
-            $for x, i in enumerate(doc.get('ia')[1:10]):
-              <a href="$(book_url)?edition=ia:$(urlquote(i))">
-                <img width="30" height="45" loading="lazy" src="//archive.org/services/img/$i" alt="$_('Cover of edition %(id)s', id=i)">
-              </a>
-          </span>
-
-        <span class="resultDetails">
-          $if doc.get('first_publish_year'):
-            <span>
-              $_('First published in %(year)s', year=doc.first_publish_year)
-            </span>&mdash;
-          $if doc.get('edition_count'):
-            <span>
-              <a href="$work_edition_all_url#editions-list">$ungettext('%(count)s edition', '%(count)s editions', doc.edition_count, count=doc.edition_count)</a>
-            </span>
-          $if doc.get('languages') and doc_type in ['infogami_work', 'solr_work']:
-            <span class="languages">
-              $ langs = [get_language_name(lang.key if hasattr(lang, 'key') else '/languages' + lang) for lang in doc.languages]
-              $:ungettext('in <a class="hoverlink" title="%(langs)s">%(count)d language</a>', 'in <a class="hoverlink" title="%(langs)s">%(count)d languages</a>', len(doc.languages), count=len(doc.languages), langs=commify_list(langs))
-            </span>
-        </span>
-
-        $if show_librarian_extras:
-          <div class="searchResultItem__librarian-extras" title="$_('This is only visible to librarians.')">
-            $if doc_type == 'solr_edition' or (doc_type == 'infogami_edition' and edition_work):
-              <div>$_("Work Title"): <i>$full_work_title</i></div>
-            $ is_orphan = doc_type.startswith('solr_') and doc['key'].endswith('M') or doc_type == 'infogami_edition' and not edition_work
-            $if is_orphan:
-              <div>$_("Orphaned Edition")</div>
-          </div>
-        $if extra:
-          $:extra
+      $if show_librarian_extras:
+      <div class="searchResultItem__librarian-extras" title="$_('This is only visible to librarians.')">
+        $if doc_type == 'solr_edition' or (doc_type == 'infogami_edition' and edition_work):
+        <div>$_("Work Title"): <i>$full_work_title</i></div>
+        $ is_orphan = doc_type.startswith('solr_') and doc['key'].endswith('M') or doc_type == 'infogami_edition' and
+        not edition_work
+        $if is_orphan:
+        <div>$_("Orphaned Edition")</div>
+      </div>
+      $if extra:
+      $:extra
     </div>
 
     <div class="searchResultItemCTA">
-        $if decorations:
-          $# should show reading log status widget if there is one in decorations, or read, or return, or leave waitlist
-          <div class="decorations">
-            $:decorations
-          </div>
+      $if decorations:
+      $# should show reading log status widget if there is one in decorations, or read, or return, or leave waitlist
+      <div class="decorations">
+        $:decorations
+      </div>
 
-        <div class="searchResultItemCTA-lending">
-          $if cta:
-            $:macros.LoanStatus(selected_ed, work_key=doc.key)
-        </div>
+      <div class="searchResultItemCTA-lending">
+        $if cta:
+        $:macros.LoanStatus(selected_ed, work_key=doc.key)
+      </div>
 
-        $if include_dropper:
-          $ edition_key = None
-          $if doc_type == 'solr_edition':
-            $ edition_key = selected_ed.key
-          $elif doc_type == 'infogami_edition':
-            $ edition_key = doc.key
-          $elif doc_type == 'solr_work':
-            $ edition_key = doc.get('edition_key') and doc.get("edition_key")[0]
-            $ edition_key = '/books/%s' % edition_key
-          $:render_template('my_books/dropper', doc, edition_key=edition_key, async_load=True)
+      $if include_dropper:
+      $ edition_key = None
+      $if doc_type == 'solr_edition':
+      $ edition_key = selected_ed.key
+      $elif doc_type == 'infogami_edition':
+      $ edition_key = doc.key
+      $elif doc_type == 'solr_work':
+      $ edition_key = doc.get('edition_key') and doc.get("edition_key")[0]
+      $ edition_key = '/books/%s' % edition_key
+      $:render_template('my_books/dropper', doc, edition_key=edition_key, async_load=True)
 
-        $if rating:
-          $:rating
+      $if rating:
+      $:rating
     </div>
   </div>
 
   $if footer:
-    <hr />
-    $:footer
+  <hr />
+  $:footer
 </li>

--- a/static/css/components/search-result-item.less
+++ b/static/css/components/search-result-item.less
@@ -46,8 +46,10 @@
     mask-size: cover;
     background-color: @primary-blue;
   }
+
   /* stylelint-enable selector-max-specificity */
 }
+
 .searchResultItem {
   list-style-type: none;
   line-height: 1.5em;
@@ -75,6 +77,7 @@
   a[href] {
     text-decoration: none;
   }
+
   h3 {
     display: block;
     margin: 0;
@@ -85,6 +88,7 @@
     font-family: @georgia_serif-1;
     overflow: auto;
   }
+
   .details {
     overflow: auto;
     display: inline;
@@ -99,16 +103,20 @@
     font-family: @body-family;
     display: block;
   }
+
   span.resultType {
     font-size: 0.6875em;
   }
+
   .resultDetails {
     display: block;
     font-size: @font-size-body-medium;
   }
+
   .ratingsByline {
     color: @black;
   }
+
   .preview-covers {
     display: block;
     height: 45px;
@@ -116,15 +124,18 @@
     margin-top: 10px;
     margin-bottom: 5px;
   }
+
   .preview-covers img {
     border-radius: 4px;
     opacity: 0.7;
   }
+
   .preview-covers--blur {
     img {
       filter: blur(2px);
     }
   }
+
   .bookcover {
     width: 100%;
     margin: 10px 10px 0 5px;
@@ -137,15 +148,18 @@
       width: 175px;
     }
   }
+
   .bookcover--blur {
     img {
       filter: blur(4px);
     }
   }
+
   .imageLg {
     text-align: center;
     width: 100%;
     margin: 10px 10px 0 5px;
+
     img {
       max-width: 100%;
       max-height: 110px;
@@ -203,6 +217,7 @@
   line-height: 28px;
   display: flex;
   margin-bottom: 5px;
+
   a {
     span {
       margin-right: 5px;
@@ -216,6 +231,7 @@
       top: 5px;
     }
   }
+
   a:hover span {
     background-position: -21px 0;
   }
@@ -234,7 +250,7 @@
   }
 
   // stylelint-disable-next-line no-descending-specificity
-  .trending-badge__chart > span {
+  .trending-badge__chart>span {
     display: inline-block;
     width: 4px;
     background: @green;
@@ -248,18 +264,69 @@
         width: 175px;
         text-align: right;
       }
+
       .imageLg {
         width: 175px;
         text-align: center;
       }
     }
   }
+
   .list-results {
     .searchResultItem {
       .imageLg {
         width: 175px;
         text-align: right;
       }
+    }
+  }
+}
+
+/* Mobile: keep cover visible and layout side-by-side */
+@media only screen and (max-width: 767px) {
+  .searchResultItem {
+
+    /* make the main container allow cover + details side-by-side */
+    &,
+    .sri__main {
+      display: flex;
+      flex-direction: row;
+      align-items: flex-start;
+      gap: 12px;
+    }
+
+    /* force the cover box to be a fixed, visible column */
+    .bookcover {
+      display: block !important;
+      flex: 0 0 80px;
+      width: 80px !important;
+      min-width: 80px !important;
+      margin: 0 10px 0 0;
+      text-align: left;
+      box-sizing: border-box;
+
+      img {
+        width: 100% !important;
+        height: auto !important;
+        max-width: none;
+        max-height: none;
+        display: block;
+      }
+    }
+
+    /* keep details flowing beside the cover */
+    .details {
+      width: calc(100% - 92px);
+      /* leaves space for cover + gap */
+      padding: 0;
+      display: block;
+    }
+
+    /* ensure CTA doesn't push cover out of view */
+    .searchResultItemCTA {
+      width: auto;
+      min-width: 0;
+      margin-top: 8px;
     }
   }
 }

--- a/static/css/components/search-result-item.less
+++ b/static/css/components/search-result-item.less
@@ -250,7 +250,7 @@
   }
 
   // stylelint-disable-next-line no-descending-specificity
-  .trending-badge__chart>span {
+  .trending-badge__chart > span {
     display: inline-block;
     width: 4px;
     background: @green;
@@ -285,7 +285,6 @@
 /* Mobile: keep cover visible and layout side-by-side */
 @media only screen and (max-width: 767px) {
   .searchResultItem {
-
     /* make the main container allow cover + details side-by-side */
     &,
     .sri__main {

--- a/static/css/components/searchResultItemCta.less
+++ b/static/css/components/searchResultItemCta.less
@@ -19,7 +19,7 @@
 }
 
 // For compatibility with SearchResultItem
-.searchResultItem>.searchResultItemCTA {
+.searchResultItem > .searchResultItemCTA {
   // Override .searchResultItem>div rule
   padding: 0;
 }
@@ -30,7 +30,6 @@
 
 /* Mobile: ensure search result cover is visible and layout stays horizontal-ish */
 @media only screen and (max-width: 767px) {
-
   /* make sure the cover box is visible and has a fixed width so text doesn't collapse */
   .searchResultItem .bookcover,
   .list-books .searchResultItem .bookcover {

--- a/static/css/components/searchResultItemCta.less
+++ b/static/css/components/searchResultItemCta.less
@@ -19,7 +19,7 @@
 }
 
 // For compatibility with SearchResultItem
-.searchResultItem > .searchResultItemCTA {
+.searchResultItem>.searchResultItemCTA {
   // Override .searchResultItem>div rule
   padding: 0;
 }
@@ -28,12 +28,43 @@
   margin-top: 5px;
 }
 
-@media only screen and (min-width: @width-breakpoint-tablet) {
-  .searchResultItem {
-    .searchResultItemCTA {
-      width: 200px;
-      min-width: 200px;
-      padding: 0 5px;
-    }
+/* Mobile: ensure search result cover is visible and layout stays horizontal-ish */
+@media only screen and (max-width: 767px) {
+
+  /* make sure the cover box is visible and has a fixed width so text doesn't collapse */
+  .searchResultItem .bookcover,
+  .list-books .searchResultItem .bookcover {
+    display: block !important;
+    flex: 0 0 80px;
+    /* reserve space for the cover */
+    width: 80px !important;
+    min-width: 80px !important;
+    margin-right: 12px;
+    box-sizing: border-box;
+    align-self: flex-start;
+  }
+
+  /* make the main content area flow beside the cover using flex */
+  .searchResultItem .sri__main,
+  .list-books .searchResultItem .sri__main {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  /* ensure the image fits the box */
+  .searchResultItem .bookcover img,
+  .list-books .searchResultItem .bookcover img {
+    width: 100%;
+    height: auto;
+    display: block;
+  }
+
+  /* if CTA or metadata is below, allow it to wrap under the text */
+  .searchResultItem .searchResultItemCTA {
+    width: auto;
+    min-width: 0;
+    margin-top: 8px;
   }
 }


### PR DESCRIPTION
### What issue does this PR close?
Closes #11563

### What does this PR achieve?
This PR fixes an issue where some search results failed to display a cover image
even though the corresponding work/edition page showed one.

The previous logic only attempted `get_cover_url(selected_ed)`.  
However, many Solr search documents do not include `cover_i`, and therefore
`get_cover_url` returned `None`, resulting in missing covers.

This PR adds proper fallback logic so search results can display covers whenever
a book has *any* valid cover available.

### Technical
Updated `SearchResultsWork.html` to include fallback cover logic:

1. Try `get_cover_url(selected_ed)`
2. If missing, try:
   - `cover_i`
   - `cover_edition_key`
   - first `edition_key`
3. If all fail, use default placeholder icon

This mirrors other areas of OpenLibrary where fallback logic is used, ensuring
that search results behave consistently.

### Testing
To reproduce:

1. Go to  
   `/search?q=Goa+Stott&mode=everything&sort=old&first_publish_year=2011`

2. **Before this PR:**  
   The result “Goa / Stott” displays *no cover* in search results.

3. **After this PR:**  
   The cover image appears correctly by using edition fallbacks.


### Stakeholders
@internetarchive/openlibrary-developers
