### PR TITLE
Switch to /sw.js to /static/build/js/sw.js so can use caching

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -463,14 +463,6 @@ class ia_js_cdn(delegate.page):
         return web.ok(fetch_ia_js(filename))
 
 
-class serviceworker(delegate.page):
-    path = '/sw.js'
-
-    def GET(self):
-        web.header('Content-Type', 'text/javascript')
-        return web.ok(open('static/build/js/sw.js').read())
-
-
 class assetlinks(delegate.page):
     path = '/.well-known/assetlinks'
 

--- a/openlibrary/plugins/openlibrary/js/service-worker-init.js
+++ b/openlibrary/plugins/openlibrary/js/service-worker-init.js
@@ -1,7 +1,7 @@
 export default function initServiceWorker(){
     if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {
-            navigator.serviceWorker.register('/sw.js')
+            navigator.serviceWorker.register('/static/build/js/sw.js')
                 .then(() => { })
                 .catch(error => {
                     // eslint-disable-next-line no-console


### PR DESCRIPTION
Was noticing many requests to `/sw.js` in our logs -- even from a single IP! This file should be cached unless it's modified, but since we weren't calling it from the static endpoint, it wasn't getting cached at all. So removed the special endpoint.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
