### PR TITLE
Add helper for serving static files with cache headers + fewer disk reads

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -24,7 +24,11 @@ from openlibrary.core.batch_imports import (
     batch_import,
 )
 from openlibrary.i18n import gettext as _
-from openlibrary.plugins.upstream.utils import get_coverstore_public_url, setup_requests
+from openlibrary.plugins.upstream.utils import (
+    get_coverstore_public_url,
+    serve_static_file,
+    setup_requests,
+)
 
 # make sure infogami.config.features is set
 if not hasattr(infogami.config, 'features'):
@@ -467,24 +471,23 @@ class serviceworker(delegate.page):
     path = '/sw.js'
 
     def GET(self):
-        web.header('Content-Type', 'text/javascript')
-        return web.ok(open('static/build/js/sw.js').read())
+        return serve_static_file('static/build/js/sw.js', 'text/javascript')
 
 
 class assetlinks(delegate.page):
     path = '/.well-known/assetlinks'
 
     def GET(self):
-        web.header('Content-Type', 'application/json')
-        return web.ok(open('static/.well-known/assetlinks.json').read())
+        return serve_static_file(
+            'static/.well-known/assetlinks.json', 'application/json'
+        )
 
 
 class opensearchxml(delegate.page):
     path = '/opensearch.xml'
 
     def GET(self):
-        web.header('Content-Type', 'text/plain')
-        return web.ok(open('static/opensearch.xml').read())
+        return serve_static_file('static/opensearch.xml', 'text/plain')
 
 
 class health(delegate.page):

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -12,6 +12,7 @@ from collections import defaultdict
 from collections.abc import Callable, Generator, Iterable, Iterator, MutableMapping
 from html import unescape
 from html.parser import HTMLParser
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Protocol
 from urllib.parse import (
     parse_qs,
@@ -1681,6 +1682,41 @@ def subject_name_to_key(subject: str, prefix='') -> str:
     if prefix:
         prefix = prefix.rstrip(':') + ':'
     return f'/subjects/{prefix}{subject.lower().replace(' ', '_').replace(',', '').replace('/', '')}'
+
+
+@functools.lru_cache
+def read_file_contents_cached(file_path: str) -> str:
+    return open(file_path).read()
+
+
+def serve_static_file(
+    file_path: str,
+    content_type: str,
+    max_age: int = 365 * 24 * 3600,
+    cache_contents: bool = True,
+):
+    """
+    Serve a static file with appropriate caching headers.
+
+    :param file_path: Path to the file to serve
+    :param content_type: The Content-Type header value
+    :param max_age: Cache duration in seconds (default: 1 year)
+    :return: web.ok response with file contents
+    """
+    web.header("Content-Type", content_type)
+    web.header("Cache-Control", f"max-age={max_age}")
+
+    path = Path(file_path)
+    last_modified = path.stat().st_mtime
+    web.lastmodified(datetime.datetime.fromtimestamp(last_modified, tz=datetime.UTC))
+    web.expires(max_age)
+
+    if cache_contents:
+        contents = read_file_contents_cached(file_path)
+    else:
+        contents = read_file_contents_cached.__wrapped__(file_path)
+
+    return web.ok(contents)
 
 
 def setup_requests(config=config) -> None:


### PR DESCRIPTION
Small perf improvement due to noticing these appearing frequently in the logs, even from the same IP! It's a common use case, so a helper should make this easy for us to use.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
