### PR TITLE
chore: Remove shelf+profile from publications

### DIFF
--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -851,7 +851,6 @@ class opds_books(delegate.page):
     path = r"/opds/books/(OL\d+M)"
 
     def GET(self, edition_olid: str):
-        from pyopds2 import Link
 
         provider = get_opds_data_provider()
         resp = provider.search(query=f'edition_key:{edition_olid}')


### PR DESCRIPTION
fix: In OPDS, the shelf and profile should only show up in the catalog, not specific publications. Right now we're showing a profile icon and a bookshelf when going into individual items, which is contrary to many other feeds. 

This PR intends to remove the user profile and bookshelf when viewing an individual publication, but still showing it for the normal catalog. 

### Stakeholders
@mekarpeles @cdrini 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
