### PR TITLE
Disable subject page facets

### DIFF
--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -34,7 +34,7 @@ class subjects(delegate.page):
         # q=public_scan_b:true+OR+lending_edition_s:*
         subj = get_subject(
             key,
-            details=True,
+            details=False,
             filters={'public_scan_b': 'false', 'lending_edition_s': '*'},
             sort=web.input(sort='readinglog').sort,
             request_label='SUBJECT_ENGINE_PAGE',
@@ -336,6 +336,7 @@ class SubjectEngine:
             work_count=result.num_found,
             works=add_availability([self.work_wrapper(d) for d in result.docs]),
         )
+        subject.has_details = details
 
         if details:
             result.facet_counts = {

--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -58,13 +58,15 @@ $ q = query_param('q')
     $else:
       $# Only show default carousel if subject doesn't have an associated Tag
       $:macros.QueryCarousel(query=page.solr_query, sort='trending,trending_score_hourly_sum', user_lang_only=True, fallback=True)
-    $:macros.PublishingHistory(page.publishing_history)
 
-    <div class="clearfix"></div>
-    $:macros.RelatedSubjects(page)
+    $if page.has_details:
+      $:macros.PublishingHistory(page.publishing_history)
 
-    <div class="clearfix"></div>
-    $:macros.ProlificAuthors(page.authors)
+      <div class="clearfix"></div>
+      $:macros.RelatedSubjects(page)
 
-    <div class="section clearfix"></div>
+      <div class="clearfix"></div>
+      $:macros.ProlificAuthors(page.authors)
+
+      <div class="section clearfix"></div>
 </div>


### PR DESCRIPTION
Subject pages are getting slammed right now, and the facets on these pages cause performance issues for solr. Disable for now.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
