### PR TITLE
Fix: Classification dropdown overflow on mobile view

### DIFF
--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -465,7 +465,7 @@ $ })
                             <select name="name" id="select-classification">
                                 <option value="">$_("Select one of many...")</option>
                                 $for d in edition_config.classifications:
-                                    <option value="$d.name">$d.label</option>
+                                    <option value="$d.name" data-full-label="$d.label">$truncate(d.label, 45)</option>
 
                                 <!-- <option>---</option> -->
                                 <!-- <option value="__add__">$_("Add a new classification type")</option> -->
@@ -480,7 +480,7 @@ $ })
                     </tr>
                     <tbody id="classifications-display">
                         <tr id="classifications-template" style="display: none;" class="repeat-item">
-                            <td align="right"><strong>{{\$("#select-classification").find("option[value='" + name + "']").html()}}</strong></td>
+                            <td align="right"><strong>{{\$("#select-classification").find("option[value='" + name + "']").attr("data-full-label")}}</strong></td>
                             <td>{{value}}
                                 <input type="hidden" name="{{prefix}}classifications--{{index}}--name" value="{{name}}"/>
                                 <input type="hidden" name="{{prefix}}classifications--{{index}}--value" value="{{value}}"/>

--- a/static/css/page-user.less
+++ b/static/css/page-user.less
@@ -228,6 +228,32 @@ textarea.toc-editor {
   white-space: pre;
 }
 
+#select-classification {
+  max-width: 300px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+table.classifications.identifiers {
+  @media only screen and (max-width: @width-breakpoint-tablet) {
+    tr {
+      display: flex;
+      flex-wrap: wrap;
+      border-bottom: 1px solid @lightest-grey;
+      padding-bottom: 10px;
+      margin-bottom: 10px;
+    }
+
+    td:first-child {
+      width: 100%;
+      text-align: left !important;
+      font-weight: bold;
+      color: @grey-555;
+      margin-bottom: 4px;
+    }
+  }
+}
+
 @import (less) "components/ol-message.less";
 // Import styles for fulltext-search-suggestion card
 @import (less) "components/fulltext-search-suggestion.less";
@@ -253,65 +279,3 @@ textarea.toc-editor {
 // Import styles for sort options
 @import (less) "components/sort-dropper.less";
 @import (less) "components/pagination.less";
-#select-classification {
-  max-width: 300px;
-  width: 100%;
-  box-sizing: border-box;
-}
-
-table.classifications.identifiers {
-  width: 100%;
-  max-width: 100%;
-
-  td {
-    word-wrap: break-word;
-    overflow-wrap: break-word;
-    word-break: break-word;
-    white-space: normal;
-  }
-
-  @media only screen and (max-width: @width-breakpoint-tablet) {
-    display: block;
-
-    tbody {
-      display: block;
-      width: 100%;
-    }
-
-    tr {
-      display: flex;
-      flex-wrap: wrap;
-      border-bottom: 1px solid @lightest-grey;
-      padding-bottom: 10px;
-      margin-bottom: 10px;
-    }
-
-    td {
-      display: block;
-      padding: 2px 0;
-      border: none !important;
-    }
-
-    td:first-child {
-      width: 100%;
-      text-align: left !important;
-      font-weight: bold;
-      color: @grey-555;
-      margin-bottom: 4px;
-    }
-
-    td:nth-child(2) {
-      flex: 1;
-      min-width: 0;
-      padding-right: 10px;
-      input {
-        width: 100% !important;
-        max-width: 100% !important;
-      }
-    }
-
-    td:last-child {
-      width: auto;
-    }
-  }
-}

--- a/static/css/page-user.less
+++ b/static/css/page-user.less
@@ -270,7 +270,7 @@ table.classifications.identifiers {
     white-space: normal;
   }
 
-  @media only screen and (max-width: 600px) {
+  @media only screen and (max-width: @width-breakpoint-tablet) {
     display: block;
 
     tbody {

--- a/static/css/page-user.less
+++ b/static/css/page-user.less
@@ -253,3 +253,65 @@ textarea.toc-editor {
 // Import styles for sort options
 @import (less) "components/sort-dropper.less";
 @import (less) "components/pagination.less";
+#select-classification {
+  max-width: 300px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+table.classifications.identifiers {
+  width: 100%;
+  max-width: 100%;
+
+  td {
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    word-break: break-word;
+    white-space: normal;
+  }
+
+  @media only screen and (max-width: 600px) {
+    display: block;
+
+    tbody {
+      display: block;
+      width: 100%;
+    }
+
+    tr {
+      display: flex;
+      flex-wrap: wrap;
+      border-bottom: 1px solid @lightest-grey;
+      padding-bottom: 10px;
+      margin-bottom: 10px;
+    }
+
+    td {
+      display: block;
+      padding: 2px 0;
+      border: none !important;
+    }
+
+    td:first-child {
+      width: 100%;
+      text-align: left !important;
+      font-weight: bold;
+      color: @grey-555;
+      margin-bottom: 4px;
+    }
+
+    td:nth-child(2) {
+      flex: 1;
+      min-width: 0;
+      padding-right: 10px;
+      input {
+        width: 100% !important;
+        max-width: 100% !important;
+      }
+    }
+
+    td:last-child {
+      width: auto;
+    }
+  }
+}


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11431

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR fixes the classification dropdown overflow issue on the book edition edit page, particularly on mobile/smaller screen sizes.

### Technical
<!-- What should be noted about the implementation? -->

**CSS Changes ([static/css/page-user.less](cci:7://file:///home/krishna/Contribution/openlibrary/static/css/page-user.less:0:0-0:0)):**
- Constrained `#select-classification` dropdown width to `max-width: 300px`
- Added responsive table layout for `table.classifications.identifiers` on screens ≤600px
- Table rows now use flexbox with stacked labels for better mobile readability
- Long text values wrap correctly with `word-break: break-word`

**Template Changes ([openlibrary/templates/books/edit/edition.html](cci:7://file:///home/krishna/Contribution/openlibrary/openlibrary/templates/books/edit/edition.html:0:0-0:0)):**
- Truncated long classification labels in dropdown options to 45 characters using `$truncate()`
- Added `data-full-label` attribute to preserve full text
- Updated JS template to use `data-full-label` when adding classifications to the table, ensuring full labels are displayed after selection

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Navigate to any book edition edit page (e.g., `/books/OL23269118M/Alice%27s_adventures_in_Wonderland/edit`)
2. Use browser dev tools to simulate mobile view (e.g., Samsung Galaxy S8+, 360x740)
3. Scroll to the "Classifications" section
4. Verify dropdown does not overflow the screen when opened
5. Select a classification with a long name (e.g., "Library and Archives Canada Cataloguing in Publication")
6. Add a value and click "Add"
7. Verify the full classification name appears in the table without horizontal overflow

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
## Before

[Screencast from 2025-12-11 17-25-34.webm](https://github.com/user-attachments/assets/7434045e-df62-472d-9b41-2ce9da7bf8ec)

## After

[Screencast from 2025-12-11 17-34-45.webm](https://github.com/user-attachments/assets/1696b298-db09-46f8-8f46-53f3d0c3a759)




### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@jimchamp