### PR TITLE
Initial `const` before it is referenced

### DIFF
--- a/scripts/gh_scripts/new_pr_labeler.mjs
+++ b/scripts/gh_scripts/new_pr_labeler.mjs
@@ -19,6 +19,8 @@
  */
 import { Octokit } from "@octokit/action";
 
+const CLOSES_REGEX = /\b(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved):?\s+#(\d+)/i
+
 console.log('Script starting....')
 const octokit = new Octokit()
 await main()
@@ -112,8 +114,6 @@ function parseArgs() {
         prBody: prBody
     }
 }
-
-const CLOSES_REGEX = /\b(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved):?\s+#(\d+)/i
 
 /**
  * Finds first "Closes" statement in the given pull request body, then


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11580

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Initializes the `CLOSES_REGEX` declaration before the `main()` call in our PR auto-assigner script.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
