### PR TITLE
Fix: Show work title in portrait/mobile view

### DIFF
--- a/static/css/components/work-title-and-author.less
+++ b/static/css/components/work-title-and-author.less
@@ -75,7 +75,6 @@
     .work-line {
       white-space: nowrap;
       overflow: hidden;
-      font-size: 0.875em;
     }
 
     h1.work-title {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10811

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
**fix**: Shows the work title ("An edition of [Work Title]") in portrait/mobile view, which was previously hidden.

### Technical
<!-- What should be noted about the implementation? -->
- Removed `display: none` rule for `.work-line` in the mobile media query (`@media max-width: 960px`)
- Added mobile-specific styling for `.work-line`:
  - `white-space: nowrap` - keeps the text on a single line
  - `overflow: hidden` - prevents overflow
  - `font-size: 0.875em` - slightly smaller font for mobile real estate

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Navigate to a works page, e.g., https://openlibrary.org/works/OL35085305W/The_Taming_of_the_Shrew
2. Resize browser to portrait/mobile width (< 960px) or use DevTools device emulation
3. **Before**: The "An edition of [Work Title]" line was hidden
4. **After**: The work title link is now visible and stays on a single line

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

<img width="384" height="763" alt="image" src="https://github.com/user-attachments/assets/64219d0f-8de0-4fe2-a2ca-268a0b17604a" />


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@jimchamp @mekarpeles