### PR TITLE
Add `job_name` argument to cron wrapper script

### DIFF
--- a/scripts/cron_wrapper.py
+++ b/scripts/cron_wrapper.py
@@ -96,9 +96,7 @@ def _parse_args():
         default=DEFAULT_CONFIG_PATH,
         help=f"Path to cron-wrapper configuration file. Defaults to \"{DEFAULT_CONFIG_PATH}\"",
     )
-    _parser.add_argument(
-        "job_name", help="Name of the job to be monitored"
-    )
+    _parser.add_argument("job_name", help="Name of the job to be monitored")
     _parser.add_argument(
         "script", help="Path to script that will be wrapped and monitored"
     )


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Updates `cron_wrapper` script to accept a new `job_name` argument.  Removes method that derives job name from the wrapped script's path.

### Special Deployment Procedures

The new argument is required, so our cron file will need to be updated before this is deployed.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
