### PR TITLE
Pass required argument to homepage caching function

### DIFF
--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -65,11 +65,12 @@ def get_cached_homepage():
     mc = cache.memcache_memoize(
         get_homepage, key, timeout=five_minutes, prethread=caching_prethread()
     )
-    page = mc(devmode=("dev" in web.ctx.features))
+    devmode = "dev" in web.ctx.features
+    page = mc(devmode)
 
     if not page:
-        mc.memcache_delete_by_args()
-        mc()
+        mc.memcache_delete_by_args(devmode)
+        mc(devmode)
 
     return page
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Follows https://github.com/internetarchive/openlibrary/pull/11092/files#r2632215768

Required argument `devmode` is not being passed to the homepage caching function, resulting in `web.py` error page when a blank homepage is cached.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
