### PR TITLE
Use canonical URL in author search to avoid redirects

### DIFF
--- a/openlibrary/templates/search/authors.html
+++ b/openlibrary/templates/search/authors.html
@@ -57,6 +57,7 @@ $ sort = query_param('sort', None)
         <ul class="authorList list-books">
         $for doc in results.docs:
             $ n = doc['name']
+            $ url = doc['key'] + '/' + urlsafe(n)
             $ num = doc['work_count']
             $ wc = ungettext("%(count)d book", "%(count)d books", num, count=num)
             $ date = ''
@@ -65,14 +66,14 @@ $ sort = query_param('sort', None)
             $elif 'date' in doc:
                 $ date = doc['date']
             <li class="searchResultItem">
-	      <img src="$get_coverstore_public_url()/a/olid/$(doc['key'].split('/')[-1])-M.jpg" itemprop="image" class="cover author" alt="$_('Photo of %(author)s', author=n)">
-	      <div class="details">
-		<a href="$doc['key']" class="larger">$n</a>&nbsp;<span class="brown small">$date</span><br />
-		<span class="small grey"><b>$wc</b>
+              <img src="$get_coverstore_public_url()/a/olid/$(doc['key'].split('/')[-1])-M.jpg" itemprop="image" class="cover author" alt="$_('Photo of %(author)s', author=n)">
+              <div class="details">
+                <a href="$url" class="larger">$n</a>&nbsp;<span class="brown small">$date</span><br />
+                <span class="small grey"><b>$wc</b>
                 $if 'top_subjects' in doc:
                   $_('about %(subjects)s', subjects=', '.join(doc['top_subjects'])),
                 $:_('including <i>%(topwork)s</i>', topwork=doc.get('top_work', ''))</span>
-	      </div>
+              </div>
             </li>
         </ul>
 


### PR DESCRIPTION
Small perf fix. Was also hoping it might help with #11611 , in case the referer is dropped during a 301, but that appears to not be the case.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
