### PR TITLE
Check for sitemaps.log instead of sitemaps directory

### DIFF
--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -220,6 +220,7 @@ fi
 # =================
 # Generate Sitemaps
 # =================
+# So long as a sitemaps.log doesn't exist, run sitemaps
 if [[ ! -f $TMPDIR/sitemaps/sitemaps.log ]]
 then
     log "generating sitemaps"


### PR DESCRIPTION
Fixes the first part of #7581, correctly implements #11625

Fixes a bug where absence of sitemap directory is preventing sitemaps from being run after `--overwrite` deletes `sitemaps/` directory.

This pull request makes a small change to the sitemap generation logic in `scripts/oldump.sh`. The script now checks for the existence of the `sitemaps.log` file instead of the `sitemaps` directory before generating sitemaps.

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
