### PR TITLE
Add language-aware filtering to random book feature

### DIFF
--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -11,7 +11,11 @@ from infogami.utils import delegate
 from infogami.utils.view import public, render_template
 from openlibrary.core import admin, cache, ia, lending
 from openlibrary.i18n import gettext as _
-from openlibrary.plugins.upstream.utils import get_blog_feeds
+from openlibrary.plugins.upstream.utils import (
+    convert_iso_to_marc,
+    get_blog_feeds,
+    get_populated_languages,
+)
 from openlibrary.plugins.worksearch import search, subjects
 from openlibrary.utils import dateutil
 from openlibrary.utils.async_utils import set_context_from_legacy_web_py
@@ -112,12 +116,19 @@ class home(delegate.page):
 
 
 @cache.memoize(
-    engine="memcache", key="home.random_book", expires=dateutil.HALF_HOUR_SECS
+    engine="memcache",
+    key=lambda count, language=None: f"home.random_book.{language or 'all'}",
+    expires=dateutil.HALF_HOUR_SECS,
 )
-def get_random_borrowable_ebook_keys(count: int) -> list[str]:
+def get_random_borrowable_ebook_keys(
+    count: int, language: str | None = None
+) -> list[str]:
     solr = search.get_solr()
+    query = 'type:edition AND ebook_access:[borrowable TO *]'
+    if language:
+        query += f' AND language:{language}'
     docs = solr.select(
-        'type:edition AND ebook_access:[borrowable TO *]',
+        query,
         fields=['key'],
         rows=count,
         sort=f'random_{random.random()} desc',
@@ -129,7 +140,16 @@ class random_book(delegate.page):
     path = "/random"
 
     def GET(self):
-        keys = get_random_borrowable_ebook_keys(1000)
+        # Get user's language preference
+        user_lang = None
+        web_lang = web.ctx.lang or 'en'
+        marc_lang = convert_iso_to_marc(web_lang)
+
+        # Only filter by language if it's a populated language
+        if marc_lang and marc_lang in get_populated_languages():
+            user_lang = marc_lang
+
+        keys = get_random_borrowable_ebook_keys(1000, language=user_lang)
         raise web.seeother(random.choice(keys))
 
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10810

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
**Feature**: Add language-aware filtering to the random book feature (`/random` endpoint)

When users select a non-English language for the Open Library interface, the random book feature now prioritizes showing books with editions available in their selected language. This applies only to "populated languages" (those with >15k borrowable ebooks), with automatic fallback to all languages for unpopulated languages.

### Technical
<!-- What should be noted about the implementation? -->

**Implementation follows the existing [QueryCarousel.html](cci:7://file:///home/krishna/Contribution/openlibrary/openlibrary/macros/QueryCarousel.html:0:0-0:0) pattern:**
- Modified [get_random_borrowable_ebook_keys()](cci:1://file:///home/krishna/Contribution/openlibrary/openlibrary/plugins/openlibrary/home.py:117:0-135:39) to accept optional [language](cci:1://file:///home/krishna/Contribution/openlibrary/openlibrary/plugins/upstream/utils.py:725:0-729:82) parameter
- Added per-language caching with dynamic keys: `home.random_book.{lang}` (e.g., `home.random_book.fre`, `home.random_book.eng`, `home.random_book.all`)
- Updated `random_book.GET()` to:
  - Extract user language from `web.ctx.lang`
  - Convert ISO 639-1 to MARC21 format using [convert_iso_to_marc()](cci:1://file:///home/krishna/Contribution/openlibrary/openlibrary/plugins/upstream/utils.py:1197:0-1207:15)
  - Validate language is in [get_populated_languages()](cci:1://file:///home/krishna/Contribution/openlibrary/openlibrary/plugins/upstream/utils.py:1187:0-1194:81) set
  - Pass language to Solr query only for populated languages
- Solr query becomes: `type:edition AND ebook_access:[borrowable TO *] AND language:{lang}` when language is populated

**Populated languages** (10 total): eng, fre, ger, spa, chi, ita, lat, dut, rus, jpn

**Fallback behavior**: For unpopulated languages (e.g., Hindi), the feature falls back to showing books from all languages, ensuring users always get results.

(cci:7://file:///home/krishna/Contribution/openlibrary/openlibrary/plugins/openlibrary/home.py:0:0-0:0)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->

@cdrini 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->