### PR TITLE
Proposed: Making "Borrow" always "View Book" on homepage

### DIFF
--- a/openlibrary/plugins/importapi/import_validator.py
+++ b/openlibrary/plugins/importapi/import_validator.py
@@ -69,6 +69,7 @@ class CompleteBook(BaseModel):
 
         return values
 
+
 class StrongIdentifierBook(BaseModel):
     """
     The model for a book with a title, strong identifier, plus source_records.

--- a/static/css/components/search-result-item.less
+++ b/static/css/components/search-result-item.less
@@ -86,15 +86,14 @@
     overflow: auto;
   }
   .details {
-  display: block;
-  width: 100%;
-  padding: 5px;
-  margin: 0;
+    display: block;
+    width: 100%;
+    padding: 5px;
+    margin: 0;
 
-  max-height: 6em;       
-  overflow: hidden;       
-}
-
+    max-height: 6em;
+    overflow: hidden;
+  }
 
   .resultStats {
     font-size: 0.75em;


### PR DESCRIPTION
Addresses #11648

The homepage carousel displays a Borrow button even when the logged-in user
has already borrowed the book. Because the homepage is cached, it cannot
accurately reflect user-specific loan state, which is confusing.

### Solution
This PR updates the homepage carousel card to avoid rendering the
LoanStatus component. Instead, it shows a neutral “View book” CTA that
links to the book page, where the correct loan state is displayed.

### Notes
- UI-only change
- No backend or loan logic modified
- Book pages and search results remain unchanged