### PR TITLE
fix: Notes overflow in List's grid view

### DIFF
--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -229,6 +229,7 @@ $code:
   </div>
 
   $if footer:
-    <hr />
-    $:footer
+    <div class="list-books__note">
+      $:sanitize(format(footer))
+    </div>
 </li>

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -1347,7 +1347,6 @@ ul.list-books {
     .sri__main {
       display: flex;
       flex-direction: column;
-      height: 100%;
     }
 
     .bookcover {
@@ -1377,6 +1376,22 @@ ul.list-books {
       display: none;
     }
   }
+}
+
+.list-books__note {
+  overflow: hidden;
+  padding-top: 8px;
+  margin-top: 4px;
+  border-top: @border-divider;
+  line-height: @line-height-blurb;
+  display: -webkit-box;
+  -webkit-line-clamp: 6;
+  line-clamp: 6;
+  -webkit-box-orient: vertical;
+}
+
+.list-books__note p {
+  margin-top: 0;
 }
 
 div.pop {

--- a/static/css/less/line-heights.less
+++ b/static/css/less/line-heights.less
@@ -29,6 +29,7 @@ Design approach to Line Heights:
 
 @line-height-body: @line-height-normal; // paragraphs, default text
 @line-height-meta: @line-height-snug; // bylines, counts, timestamps, secondary text (search cards)
+@line-height-blurb: @line-height-snug; // short snippet, often in narrow containers (list item notes in grid)
 
 @line-height-list: @line-height-relaxed; // multi-line lists of links/subjects (subject pages)
 @line-height-table: @line-height-snug; // edition detail grids / data tables


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11174 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes text overflow.

### Technical
- Adds a wrapper `<div>` around notes content which is limited to six lines max. Clamping happens via CSS.

This PR is similar to https://github.com/internetarchive/openlibrary/pull/11522 but with two differences:
1. The CSS in this PR is more concise
2. No server side truncation of the text

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<img width="1814" height="1139" alt="Frame 1" src="https://github.com/user-attachments/assets/111c1c80-7ab4-43e8-a216-69b5b4ba39e8" />
<img width="1814" height="969" alt="Frame 2" src="https://github.com/user-attachments/assets/81a2fa76-493b-42e3-85a8-0588acbfee7c" />


### Stakeholders
@cdrini 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
