### PR TITLE
deps: Update caniuse-lite to version 1.0.30001764

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5733,9 +5733,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001727",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
-      "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
+      "version": "1.0.30001764",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001764.tgz",
+      "integrity": "sha512-9JGuzl2M+vPL+pz70gtMF9sHdMFbY9FJaQBi186cHKH3pSzDvzoUJUPV6fqiKIMyXbud9ZLg4F3Yza1vJ1+93g==",
       "dev": true,
       "funding": [
         {
@@ -5750,7 +5750,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/caseless": {
       "version": "0.12.0",


### PR DESCRIPTION
Ran the browserlist update command per recommendation:

```
Browserslist: browsers data (caniuse-lite) is 7 months old. Please run:
[lint:js]   npx update-browserslist-db@latest
[lint:js]   Why you should do it regularly: https://github.com/browserslist/update-db#readme
```


### Technical

```
Need to install the following packages:
update-browserslist-db@1.2.3
Ok to proceed? (y) y

Latest version:     1.0.30001764
Installed version:  1.0.30001727
Removing old caniuse-lite from lock file
Installing new caniuse-lite version
$ npm install caniuse-lite baseline-browser-mapping
Cleaning package.json dependencies from caniuse-lite
$ npm uninstall caniuse-lite baseline-browser-mapping
caniuse-lite has been successfully updated

No target browser changes
----------------------------------
```

### Testing

This dep upgrade's only impact will be the muting of this warning that was appearing:
```Browserslist: browsers data (caniuse-lite) is 7 months old. Please run:```

### Stakeholders
@jimchamp cc: @cdrini @mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
