### PR TITLE
Reduce timeout for coverstore URL requests

### DIFF
--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -66,7 +66,7 @@ class Image:
         if url.startswith("//"):
             url = "http:" + url
         try:
-            d = requests.get(url, timeout=3).json()
+            d = requests.get(url, timeout=1).json()
             d['created'] = parse_datetime(d['created'])
             if fetch_author:
                 if d['author'] == 'None':


### PR DESCRIPTION
Hotfix in response to some performance issues.

When coverstore experiences high traffic/saturation, this causes downstream strain/saturation on OL. Since this data isn't 100% essential and it should generally be much faster than 1s for an internal network request, dropping from 3s.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
