### PR TITLE
Make noisy solr request logs DEBUG level

### DIFF
--- a/openlibrary/utils/solr.py
+++ b/openlibrary/utils/solr.py
@@ -75,7 +75,7 @@ class Solr:
         request_label: SolrRequestLabel = 'UNLABELLED',
     ) -> T | None:
         """Get a specific item from solr"""
-        logger.info(f"solr /get: {key}, {fields}")
+        logger.debug(f"solr /get: {key}, {fields}")
         resp = self.session.get(
             f"{self.base_url}/get",
             # It's unclear how field=None is getting in here; a better fix would be at the source.
@@ -103,7 +103,7 @@ class Solr:
         ids = list(keys)
         if not ids:
             return []
-        logger.info(f"solr /get: {ids}, {fields}")
+        logger.debug(f"solr /get: {ids}, {fields}")
         resp = self.session.post(
             f"{self.base_url}/get",
             data={
@@ -228,10 +228,10 @@ class Solr:
         if len(payload) < 500:
             sep = '&' if '?' in url else '?'
             url = url + sep + payload
-            logger.info("solr request: %s", url)
+            logger.debug("solr request: %s", url)
             return await self.async_session.get(url, timeout=_timeout)
         else:
-            logger.info("solr request: %s ...", url)
+            logger.debug("solr request: %s ...", url)
             headers = {
                 "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"
             }


### PR DESCRIPTION
These logs are so frequent that they prevent us from turning on sentry's new logging features. They're not super necessary anymore since sentry gives us network request tracking, so drop them down to DEBUG level.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@scottbarnes 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
