### PR TITLE
Fix edition weight validation blocking small existing values less than 0.01

### DIFF
--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -570,7 +570,7 @@ $ })
                             <tr>
                                 <td rowspan="3"><img src="/images/dimensions.png" alt="$_('dimensions')" width="107" height="69" align="left"/></td>
                                 <td><span class="tip"><label for="dimensions-height">$_("Height:")</label> </span></td>
-                                <td><input name="edition--physical_dimensions--height" type="number" step="any" min="0.01"
+                                <td><input name="edition--physical_dimensions--height" type="number" step="any" min="0.0"
                                            id="dimensions-height" size="6" value="$dimensions.height"/></td>
                             </tr>
                             <tr>


### PR DESCRIPTION
### What this change does

This pull request fixes a case where editing an existing edition can fail silently due to client-side form validation.

Some editions already have very small weight values stored, for example `0.001`. When an editor tries to save any change on such an edition, the browser blocks the form submission because the weight input enforces a minimum value of `0.01`. Since this validation happens at the browser level and no error message is shown, the save action appears to do nothing.

### Why this happens

The edition edit form uses an HTML `min="0.01"` constraint on the weight input. This constraint does not match the existing data, which already includes values smaller than `0.01`. As a result, valid stored data becomes impossible to edit.

### What was changed

The minimum value on the edition weight input has been lowered to `0`. This aligns the client-side validation with the data that already exists in the system and ensures that edits to existing editions are not blocked by the browser.

This change is intentionally limited to the frontend validation. It does not alter backend behavior or data storage rules.

### Result

Existing editions with small weight values can now be edited and saved normally. The silent failure during form submission is eliminated.

Fixes #11699
