### PR TITLE
Fix styling inconsistency in "Admin Only" section of Book Edit page

### DIFF
--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -656,8 +656,8 @@ $if ctx.user:
 
 $if is_admin:
     <fieldset class="major adminOnly">
-        <legend>$_("Admin Only")</legend>
         <div class="formElement">
+        <legend>$_("Admin Only")</legend>
             <div class="label">
                 <label for="additional_metadata">$_("Additional Metadata")</label>
                 <span class="tip">$_('This field can accept arbitrary key:value pairs')</span>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11707

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes Styling of "Admin Only" text.
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Go to /books/OL23269118M/Alice%27s_adventures_in_Wonderland/edit endpoint for checking.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
#### Mobile View
<img width="380" height="761" alt="image" src="https://github.com/user-attachments/assets/ed60dd34-bf06-46a2-a55b-44dc3eb0dd51" />

#### Desktop View
<img width="1313" height="1004" alt="image" src="https://github.com/user-attachments/assets/eade38c8-142c-494d-9ecb-3422a8af832b" />

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
