### PR TITLE
fix allow cover import from archive.org

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -586,9 +586,11 @@ def check_cover_url_host(
     )
 
     if not host_is_allowed:
-        logger.warning(f"disallowed cover host", extra={"host": parsed_url.netloc.casefold(), "url": cover_url})
+        logger.warning(
+            "disallowed cover host",
+            extra={"host": parsed_url.netloc.casefold(), "url": cover_url},
+        )
         return False
-
 
     return True
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10758 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes issue with not importing covers from archive.org.

### Technical
Added archive.org as an allowed host to import covers.

### Testing
I did an import with this identifier " isbn_9798395421142", and moused over the picture. Instead of showing " add covers" as the issue stated, it now shows manage covers.

Additionally, I checked the json output at http://localhost:8080/books/OL11M.json and it now contains a covers key.


### Screenshot
<img width="1191" height="967" alt="image" src="https://github.com/user-attachments/assets/0bbcecd8-3d71-4a53-927c-b6f203f24a88" />



### Json output

{"type": {"key": "/type/edition"}, "title": "the richest man in babylon", "authors": [{"key": "/authors/OL11A"}], "publish_date": "1926", "isbn_13": ["9798395421142"], "languages": [{"key": "/languages/eng"}], "number_of_pages": 122, "publishers": ["superb stories"], "source_records": ["ia:isbn_9798395421142"], "ocaid": "isbn_9798395421142", "covers": [1], "works": [{"key": "/works/OL3W"}], "key": "/books/OL11M", "latest_revision": 1, "revision": 1, "created": {"type": "/type/datetime", "value": "2026-01-19T20:47:16.070003"}, "last_modified": {"type": "/type/datetime", "value": "2026-01-19T20:47:16.070003"}}


### Stakeholders
@mekarpeles @cdrini 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
