### PR TITLE
10758/fix/allow openlibrary import covers

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -587,9 +587,11 @@ def check_cover_url_host(
     )
 
     if not host_is_allowed:
-        logger.warning(f"disallowed cover host", extra={"host": parsed_url.netloc.casefold(), "url": cover_url})
+        logger.warning(
+            "disallowed cover host",
+            extra={"host": parsed_url.netloc.casefold(), "url": cover_url},
+        )
         return False
-
 
     return True
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10758 

Added covers.openlibrary.org as another allowed host.

This is an added code to the previous PR as an option. I wasn't sure if this was something we also wanted to add and so making it a separate PR in case it is not required.

### Stakeholders
@cdrini @mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->


