### PR TITLE
silence noisy pytest output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,6 @@ filterwarnings = [
     # Ignore warnings from webob, which doesn't have a fix.
     # It comes from webtest, which we will remove when fastapi is done
     'ignore::DeprecationWarning:webob',
-    # Ignore Pydantic v1 compatibility warnings triggered by FastAPI's Query()
-    'ignore:The `__fields__` attribute is deprecated:DeprecationWarning:pydantic',
     # Ignore sqlite3 default timestamp converter warnings from web.py (Python 3.12 deprecation)
     'ignore:The default timestamp converter is deprecated:DeprecationWarning:web',
 ]


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Makes pytest less noise (to stop distracting the AI and other contributors).

It silencies the python warnings from our dependencies about them using older syntax.
I don't think we ever pay attention to these warnings anyway.

Before it looked like this:
<details>
  <summary>Spoiler</summary>
  
```
pytest . --ignore=infogami --ignore=vendor --ignore=node_modules
============================= test session starts ==============================
platform linux -- Python 3.12.2, pytest-8.3.5, pluggy-1.6.0
rootdir: /openlibrary
configfile: pyproject.toml
plugins: cov-6.1.1, httpx-0.33.0, asyncio-0.26.0, anyio-4.12.1
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
pytest_configure None
collected 3359 items

openlibrary/catalog/add_book/tests/test_add_book.py .................... [  0%]
....................................................................     [  2%]
openlibrary/catalog/add_book/tests/test_load_book.py ................... [  3%]
...............                                                          [  3%]
openlibrary/catalog/add_book/tests/test_match.py ....................... [  4%]
..........                                                               [  4%]
openlibrary/catalog/marc/tests/test_get_subjects.py .................... [  5%]
.........................                                                [  5%]
openlibrary/catalog/marc/tests/test_marc.py .....                        [  6%]
openlibrary/catalog/marc/tests/test_marc_binary.py .....                 [  6%]
openlibrary/catalog/marc/tests/test_marc_html.py .                       [  6%]
openlibrary/catalog/marc/tests/test_mnemonics.py ..                      [  6%]
openlibrary/catalog/marc/tests/test_parse.py ........................... [  7%]
.......................................                                  [  8%]
openlibrary/catalog/utils/tests/test_catalog_utils.py ......             [  8%]
openlibrary/coverstore/tests/test_archive.py ...                         [  8%]
openlibrary/coverstore/tests/test_code.py ...                            [  8%]
openlibrary/coverstore/tests/test_coverstore.py .........                [  8%]
openlibrary/coverstore/tests/test_doctests.py .....                      [  9%]
openlibrary/coverstore/tests/test_webapp.py s.ssssss                     [  9%]
openlibrary/i18n/test_po_files.py ...................................... [ 10%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 16%]
........................................................................ [ 19%]
........................................................................ [ 21%]
........................................................................ [ 23%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 29%]
........................................................................ [ 31%]
........................................................................ [ 34%]
........................................................................ [ 36%]
........................................................................ [ 38%]
........................................................................ [ 40%]
........................................................................ [ 42%]
........................................................................ [ 44%]
.........................................................                [ 46%]
openlibrary/mocks/tests/test_mock_infobase.py .....                      [ 46%]
openlibrary/mocks/tests/test_mock_memcache.py ...                        [ 46%]
openlibrary/olbase/tests/test_events.py .....                            [ 46%]
openlibrary/olbase/tests/test_ol_infobase.py .                           [ 46%]
openlibrary/plugins/admin/tests/test_code.py .....                       [ 47%]
openlibrary/plugins/admin/tests/test_services.py .                       [ 47%]
openlibrary/plugins/books/tests/test_doctests.py .............           [ 47%]
openlibrary/plugins/books/tests/test_dynlinks.py .............           [ 47%]
openlibrary/plugins/books/tests/test_readlinks.py .....                  [ 47%]
openlibrary/plugins/importapi/tests/test_code.py ......                  [ 48%]
openlibrary/plugins/importapi/tests/test_code_ils.py ...                 [ 48%]
openlibrary/plugins/importapi/tests/test_import_edition_builder.py ...   [ 48%]
openlibrary/plugins/importapi/tests/test_import_validator.py ........... [ 48%]
.........................................                                [ 49%]
openlibrary/plugins/openlibrary/tests/test_bestbookapi.py ......         [ 50%]
openlibrary/plugins/openlibrary/tests/test_home.py .....                 [ 50%]
openlibrary/plugins/openlibrary/tests/test_lists.py ........             [ 50%]
openlibrary/plugins/openlibrary/tests/test_stats.py .....                [ 50%]
openlibrary/plugins/upstream/tests/test_account.py ...                   [ 50%]
openlibrary/plugins/upstream/tests/test_addbook.py ................      [ 51%]
openlibrary/plugins/upstream/tests/test_checkins.py .....                [ 51%]
openlibrary/plugins/upstream/tests/test_forms.py .                       [ 51%]
openlibrary/plugins/upstream/tests/test_merge_authors.py ............... [ 51%]
                                                                         [ 51%]
openlibrary/plugins/upstream/tests/test_models.py ....                   [ 51%]
openlibrary/plugins/upstream/tests/test_related_carousels.py .           [ 51%]
openlibrary/plugins/upstream/tests/test_table_of_contents.py ........... [ 52%]
..                                                                       [ 52%]
openlibrary/plugins/upstream/tests/test_utils.py ................        [ 52%]
openlibrary/plugins/worksearch/schemes/tests/test_works.py ............. [ 53%]
..................                                                       [ 53%]
openlibrary/plugins/worksearch/tests/test_autocomplete.py ..             [ 53%]
openlibrary/plugins/worksearch/tests/test_worksearch.py ...              [ 53%]
openlibrary/records/tests/test_functions.py .............s.x.s.          [ 54%]
openlibrary/tests/accounts/test_models.py ....                           [ 54%]
openlibrary/tests/catalog/test_get_ia.py ............................... [ 55%]
..........                                                               [ 55%]
openlibrary/tests/catalog/test_utils.py ................................ [ 56%]
...............................................................          [ 58%]
openlibrary/tests/core/lists/test_model.py .                             [ 58%]
openlibrary/tests/core/test_cache.py ................                    [ 59%]
openlibrary/tests/core/test_connections.py ..                            [ 59%]
openlibrary/tests/core/test_db.py .................                      [ 59%]
openlibrary/tests/core/test_fulltext.py ...                              [ 59%]
openlibrary/tests/core/test_helpers.py ..........                        [ 60%]
openlibrary/tests/core/test_i18n.py ..                                   [ 60%]
openlibrary/tests/core/test_ia.py ..                                     [ 60%]
openlibrary/tests/core/test_imports.py ........                          [ 60%]
openlibrary/tests/core/test_lending.py ....                              [ 60%]
openlibrary/tests/core/test_lists_engine.py .                            [ 60%]
openlibrary/tests/core/test_lists_model.py ..                            [ 60%]
openlibrary/tests/core/test_models.py .........................          [ 61%]
openlibrary/tests/core/test_observations.py .                            [ 61%]
openlibrary/tests/core/test_olmarkdown.py .                              [ 61%]
openlibrary/tests/core/test_processors.py ....                           [ 61%]
openlibrary/tests/core/test_processors_invalidation.py ......            [ 61%]
openlibrary/tests/core/test_ratings.py .                                 [ 61%]
openlibrary/tests/core/test_unmarshal.py .........                       [ 62%]
openlibrary/tests/core/test_vendors.py ................................. [ 62%]
..                                                                       [ 63%]
openlibrary/tests/core/test_waitinglist.py .xx.                          [ 63%]
openlibrary/tests/core/test_wikidata.py ............                     [ 63%]
openlibrary/tests/data/test_dump.py .....                                [ 63%]
openlibrary/tests/fastapi/test_api_contract.py .................         [ 64%]
openlibrary/tests/fastapi/test_search.py ............................... [ 65%]
.........X.                                                              [ 65%]
openlibrary/tests/solr/test_data_provider.py ..                          [ 65%]
openlibrary/tests/solr/test_query_utils.py ..........                    [ 65%]
openlibrary/tests/solr/test_types_generator.py .                         [ 65%]
openlibrary/tests/solr/test_update.py ..                                 [ 65%]
openlibrary/tests/solr/test_utils.py ......                              [ 66%]
openlibrary/tests/solr/updater/test_author.py .                          [ 66%]
openlibrary/tests/solr/updater/test_edition.py ..                        [ 66%]
openlibrary/tests/solr/updater/test_work.py ............................ [ 66%]
....................                                                     [ 67%]
openlibrary/tests/test_templates.py .................................... [ 68%]
........................................................................ [ 70%]
........................................................................ [ 72%]
........................................................................ [ 75%]
........................................................................ [ 77%]
........................................................................ [ 79%]
........................................................................ [ 81%]
........................................................................ [ 83%]
........................................................................ [ 85%]
........................................................................ [ 87%]
........................................................................ [ 90%]
...................................................                      [ 91%]
openlibrary/utils/tests/test_dateutil.py .....                           [ 91%]
openlibrary/utils/tests/test_ddc.py .................................... [ 92%]
..........................                                               [ 93%]
openlibrary/utils/tests/test_isbn.py .......................             [ 94%]
openlibrary/utils/tests/test_lcc.py .................................... [ 95%]
.............................                                            [ 96%]
openlibrary/utils/tests/test_lccn.py .............                       [ 96%]
openlibrary/utils/tests/test_processors.py ..                            [ 96%]
openlibrary/utils/tests/test_retry.py .....                              [ 96%]
openlibrary/utils/tests/test_solr.py .                                   [ 96%]
openlibrary/utils/tests/test_utils.py ..                                 [ 96%]
scripts/monitoring/tests/test_solr_logs_monitor.py ...                   [ 96%]
scripts/monitoring/tests/test_utils_py.py ..                             [ 97%]
scripts/monitoring/tests/test_utils_sh.py ...                            [ 97%]
scripts/solr_builder/tests/test_fn_to_cli.py ......                      [ 97%]
scripts/solr_updater/tests/test_trending_updater_hourly.py .             [ 97%]
scripts/solr_updater/tests/test_trending_updater_init.py ....            [ 97%]
scripts/tests/test_affiliate_server.py ..................                [ 98%]
scripts/tests/test_archive.py sssssssss                                  [ 98%]
scripts/tests/test_copydocs.py .....                                     [ 98%]
scripts/tests/test_import_open_textbook_library.py ...                   [ 98%]
scripts/tests/test_import_standard_ebooks.py .                           [ 98%]
scripts/tests/test_isbndb.py ...................                         [ 99%]
scripts/tests/test_obfi.py ........                                      [ 99%]
scripts/tests/test_obfi_sh.py ....                                       [ 99%]
scripts/tests/test_partner_batch_imports.py .........                    [ 99%]
scripts/tests/test_promise_batch_imports.py ...                          [ 99%]
scripts/tests/test_solr_updater.py ...                                   [ 99%]
tests/test_docker_compose.py ...                                         [100%]

=============================== warnings summary ===============================
../usr/local/lib/python3.12/site-packages/genshi/compat.py:141
  /usr/local/lib/python3.12/site-packages/genshi/compat.py:141: DeprecationWarning: ast.Ellipsis is deprecated and will be removed in Python 3.14; use ast.Constant instead
    _ast_Ellipsis = ast.Ellipsis

../usr/local/lib/python3.12/site-packages/genshi/compat.py:142
  /usr/local/lib/python3.12/site-packages/genshi/compat.py:142: DeprecationWarning: ast.Str is deprecated and will be removed in Python 3.14; use ast.Constant instead
    _ast_Str = ast.Str

../usr/local/lib/python3.12/site-packages/genshi/filters/html.py:357
  /usr/local/lib/python3.12/site-packages/genshi/filters/html.py:357: SyntaxWarning: invalid escape sequence '\('
    u'[Uu][Rr\u0280][Ll\u029F]%s*\(([^)]+)' % (r'\s')).finditer

../usr/local/lib/python3.12/site-packages/memcache.py:110
  /usr/local/lib/python3.12/site-packages/memcache.py:110: SyntaxWarning: invalid escape sequence '\ '
    """Object representing a pool of memcache servers.

../usr/local/lib/python3.12/site-packages/memcache.py:1303
  /usr/local/lib/python3.12/site-packages/memcache.py:1303: SyntaxWarning: "is" with 'str' literal. Did you mean "=="?
    if key is '':

../usr/local/lib/python3.12/site-packages/memcache.py:1304
  /usr/local/lib/python3.12/site-packages/memcache.py:1304: SyntaxWarning: "is" with 'int' literal. Did you mean "=="?
    if key_extra_len is 0:

../usr/local/lib/python3.12/site-packages/dateutil/tz/tz.py:37
  /usr/local/lib/python3.12/site-packages/dateutil/tz/tz.py:37: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
    EPOCH = datetime.datetime.utcfromtimestamp(0)

../usr/local/lib/python3.12/site-packages/webob/compat.py:5
  /usr/local/lib/python3.12/site-packages/webob/compat.py:5: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    from cgi import parse_header

openlibrary/tests/core/test_db.py::TestCheckIns::test_update_event_date
openlibrary/tests/core/test_db.py::TestYearlyReadingGoals::test_update_current_count
openlibrary/tests/core/test_db.py::TestYearlyReadingGoals::test_update_target
openlibrary/tests/core/test_imports.py::TestBatchItem::test_add_items_legacy
  /usr/local/lib/python3.12/site-packages/web/db.py:487: DeprecationWarning: The default timestamp converter is deprecated as of Python 3.12; see the sqlite3 documentation for suggested replacement recipes
    row = self.cursor.fetchone()

openlibrary/tests/fastapi/test_api_contract.py: 16 warnings
  /usr/local/lib/python3.12/site-packages/web/application.py:486: DeprecationWarning: migrated to fastapi
    tocall = getattr(cls(), meth)

openlibrary/tests/fastapi/test_search.py::TestOpenAPIDocumentation::test_openapi_contains_search_endpoint
openlibrary/tests/fastapi/test_search.py::TestOpenAPIDocumentation::test_openapi_contains_search_endpoint
openlibrary/tests/fastapi/test_search.py::TestOpenAPIDocumentation::test_openapi_parameters_have_descriptions
openlibrary/tests/fastapi/test_search.py::TestOpenAPIDocumentation::test_openapi_parameters_have_descriptions
openlibrary/tests/fastapi/test_search.py::TestOpenAPIDocumentation::test_debug_openapi_structure
openlibrary/tests/fastapi/test_search.py::TestOpenAPIDocumentation::test_debug_openapi_structure
  /usr/local/lib/python3.12/site-packages/pydantic/v1/main.py:304: PydanticDeprecatedSince20: The `__fields__` attribute is deprecated, use `model_fields` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.4/migration/
    return hasattr(instance, '__fields__') and super().__instancecheck__(instance)

openlibrary/tests/fastapi/test_search.py::TestOpenAPIDocumentation::test_openapi_contains_search_endpoint
openlibrary/tests/fastapi/test_search.py::TestOpenAPIDocumentation::test_openapi_contains_search_endpoint
openlibrary/tests/fastapi/test_search.py::TestOpenAPIDocumentation::test_openapi_parameters_have_descriptions
openlibrary/tests/fastapi/test_search.py::TestOpenAPIDocumentation::test_openapi_parameters_have_descriptions
openlibrary/tests/fastapi/test_search.py::TestOpenAPIDocumentation::test_debug_openapi_structure
openlibrary/tests/fastapi/test_search.py::TestOpenAPIDocumentation::test_debug_openapi_structure
  /usr/local/lib/python3.12/site-packages/pydantic/main.py:935: PydanticDeprecatedSince20: The `__fields__` attribute is deprecated, use `model_fields` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.4/migration/
    warnings.warn('The `__fields__` attribute is deprecated, use `model_fields` instead.', DeprecationWarning)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===== 3337 passed, 18 skipped, 3 xfailed, 1 xpassed, 40 warnings in 10.90s =====

```
  
</details> 


After it looks like this:
<details>
  <summary>Spoiler</summary>
  
```
pytest . --ignore=infogami --ignore=vendor --ignore=node_modules
============================= test session starts ==============================
platform linux -- Python 3.12.2, pytest-8.3.5, pluggy-1.6.0
rootdir: /openlibrary
configfile: pyproject.toml
plugins: cov-6.1.1, httpx-0.33.0, asyncio-0.26.0, anyio-4.12.1
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
pytest_configure None
collected 3359 items

openlibrary/catalog/add_book/tests/test_add_book.py .................... [  0%]
....................................................................     [  2%]
openlibrary/catalog/add_book/tests/test_load_book.py ................... [  3%]
...............                                                          [  3%]
openlibrary/catalog/add_book/tests/test_match.py ....................... [  4%]
..........                                                               [  4%]
openlibrary/catalog/marc/tests/test_get_subjects.py .................... [  5%]
.........................                                                [  5%]
openlibrary/catalog/marc/tests/test_marc.py .....                        [  6%]
openlibrary/catalog/marc/tests/test_marc_binary.py .....                 [  6%]
openlibrary/catalog/marc/tests/test_marc_html.py .                       [  6%]
openlibrary/catalog/marc/tests/test_mnemonics.py ..                      [  6%]
openlibrary/catalog/marc/tests/test_parse.py ........................... [  7%]
.......................................                                  [  8%]
openlibrary/catalog/utils/tests/test_catalog_utils.py ......             [  8%]
openlibrary/coverstore/tests/test_archive.py ...                         [  8%]
openlibrary/coverstore/tests/test_code.py ...                            [  8%]
openlibrary/coverstore/tests/test_coverstore.py .........                [  8%]
openlibrary/coverstore/tests/test_doctests.py .....                      [  9%]
openlibrary/coverstore/tests/test_webapp.py s.ssssss                     [  9%]
openlibrary/i18n/test_po_files.py ...................................... [ 10%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 16%]
........................................................................ [ 19%]
........................................................................ [ 21%]
........................................................................ [ 23%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 29%]
........................................................................ [ 31%]
........................................................................ [ 34%]
........................................................................ [ 36%]
........................................................................ [ 38%]
........................................................................ [ 40%]
........................................................................ [ 42%]
........................................................................ [ 44%]
.........................................................                [ 46%]
openlibrary/mocks/tests/test_mock_infobase.py .....                      [ 46%]
openlibrary/mocks/tests/test_mock_memcache.py ...                        [ 46%]
openlibrary/olbase/tests/test_events.py .....                            [ 46%]
openlibrary/olbase/tests/test_ol_infobase.py .                           [ 46%]
openlibrary/plugins/admin/tests/test_code.py .....                       [ 47%]
openlibrary/plugins/admin/tests/test_services.py .                       [ 47%]
openlibrary/plugins/books/tests/test_doctests.py .............           [ 47%]
openlibrary/plugins/books/tests/test_dynlinks.py .............           [ 47%]
openlibrary/plugins/books/tests/test_readlinks.py .....                  [ 47%]
openlibrary/plugins/importapi/tests/test_code.py ......                  [ 48%]
openlibrary/plugins/importapi/tests/test_code_ils.py ...                 [ 48%]
openlibrary/plugins/importapi/tests/test_import_edition_builder.py ...   [ 48%]
openlibrary/plugins/importapi/tests/test_import_validator.py ........... [ 48%]
.........................................                                [ 49%]
openlibrary/plugins/openlibrary/tests/test_bestbookapi.py ......         [ 50%]
openlibrary/plugins/openlibrary/tests/test_home.py .....                 [ 50%]
openlibrary/plugins/openlibrary/tests/test_lists.py ........             [ 50%]
openlibrary/plugins/openlibrary/tests/test_stats.py .....                [ 50%]
openlibrary/plugins/upstream/tests/test_account.py ...                   [ 50%]
openlibrary/plugins/upstream/tests/test_addbook.py ................      [ 51%]
openlibrary/plugins/upstream/tests/test_checkins.py .....                [ 51%]
openlibrary/plugins/upstream/tests/test_forms.py .                       [ 51%]
openlibrary/plugins/upstream/tests/test_merge_authors.py ............... [ 51%]
                                                                         [ 51%]
openlibrary/plugins/upstream/tests/test_models.py ....                   [ 51%]
openlibrary/plugins/upstream/tests/test_related_carousels.py .           [ 51%]
openlibrary/plugins/upstream/tests/test_table_of_contents.py ........... [ 52%]
..                                                                       [ 52%]
openlibrary/plugins/upstream/tests/test_utils.py ................        [ 52%]
openlibrary/plugins/worksearch/schemes/tests/test_works.py ............. [ 53%]
..................                                                       [ 53%]
openlibrary/plugins/worksearch/tests/test_autocomplete.py ..             [ 53%]
openlibrary/plugins/worksearch/tests/test_worksearch.py ...              [ 53%]
openlibrary/records/tests/test_functions.py .............s.x.s.          [ 54%]
openlibrary/tests/accounts/test_models.py ....                           [ 54%]
openlibrary/tests/catalog/test_get_ia.py ............................... [ 55%]
..........                                                               [ 55%]
openlibrary/tests/catalog/test_utils.py ................................ [ 56%]
...............................................................          [ 58%]
openlibrary/tests/core/lists/test_model.py .                             [ 58%]
openlibrary/tests/core/test_cache.py ................                    [ 59%]
openlibrary/tests/core/test_connections.py ..                            [ 59%]
openlibrary/tests/core/test_db.py .................                      [ 59%]
openlibrary/tests/core/test_fulltext.py ...                              [ 59%]
openlibrary/tests/core/test_helpers.py ..........                        [ 60%]
openlibrary/tests/core/test_i18n.py ..                                   [ 60%]
openlibrary/tests/core/test_ia.py ..                                     [ 60%]
openlibrary/tests/core/test_imports.py ........                          [ 60%]
openlibrary/tests/core/test_lending.py ....                              [ 60%]
openlibrary/tests/core/test_lists_engine.py .                            [ 60%]
openlibrary/tests/core/test_lists_model.py ..                            [ 60%]
openlibrary/tests/core/test_models.py .........................          [ 61%]
openlibrary/tests/core/test_observations.py .                            [ 61%]
openlibrary/tests/core/test_olmarkdown.py .                              [ 61%]
openlibrary/tests/core/test_processors.py ....                           [ 61%]
openlibrary/tests/core/test_processors_invalidation.py ......            [ 61%]
openlibrary/tests/core/test_ratings.py .                                 [ 61%]
openlibrary/tests/core/test_unmarshal.py .........                       [ 62%]
openlibrary/tests/core/test_vendors.py ................................. [ 62%]
..                                                                       [ 63%]
openlibrary/tests/core/test_waitinglist.py .xx.                          [ 63%]
openlibrary/tests/core/test_wikidata.py ............                     [ 63%]
openlibrary/tests/data/test_dump.py .....                                [ 63%]
openlibrary/tests/fastapi/test_api_contract.py .................         [ 64%]
openlibrary/tests/fastapi/test_search.py ............................... [ 65%]
.........X.                                                              [ 65%]
openlibrary/tests/solr/test_data_provider.py ..                          [ 65%]
openlibrary/tests/solr/test_query_utils.py ..........                    [ 65%]
openlibrary/tests/solr/test_types_generator.py .                         [ 65%]
openlibrary/tests/solr/test_update.py ..                                 [ 65%]
openlibrary/tests/solr/test_utils.py ......                              [ 66%]
openlibrary/tests/solr/updater/test_author.py .                          [ 66%]
openlibrary/tests/solr/updater/test_edition.py ..                        [ 66%]
openlibrary/tests/solr/updater/test_work.py ............................ [ 66%]
....................                                                     [ 67%]
openlibrary/tests/test_templates.py .................................... [ 68%]
........................................................................ [ 70%]
........................................................................ [ 72%]
........................................................................ [ 75%]
........................................................................ [ 77%]
........................................................................ [ 79%]
........................................................................ [ 81%]
........................................................................ [ 83%]
........................................................................ [ 85%]
........................................................................ [ 87%]
........................................................................ [ 90%]
...................................................                      [ 91%]
openlibrary/utils/tests/test_dateutil.py .....                           [ 91%]
openlibrary/utils/tests/test_ddc.py .................................... [ 92%]
..........................                                               [ 93%]
openlibrary/utils/tests/test_isbn.py .......................             [ 94%]
openlibrary/utils/tests/test_lcc.py .................................... [ 95%]
.............................                                            [ 96%]
openlibrary/utils/tests/test_lccn.py .............                       [ 96%]
openlibrary/utils/tests/test_processors.py ..                            [ 96%]
openlibrary/utils/tests/test_retry.py .....                              [ 96%]
openlibrary/utils/tests/test_solr.py .                                   [ 96%]
openlibrary/utils/tests/test_utils.py ..                                 [ 96%]
scripts/monitoring/tests/test_solr_logs_monitor.py ...                   [ 96%]
scripts/monitoring/tests/test_utils_py.py ..                             [ 97%]
scripts/monitoring/tests/test_utils_sh.py ...                            [ 97%]
scripts/solr_builder/tests/test_fn_to_cli.py ......                      [ 97%]
scripts/solr_updater/tests/test_trending_updater_hourly.py .             [ 97%]
scripts/solr_updater/tests/test_trending_updater_init.py ....            [ 97%]
scripts/tests/test_affiliate_server.py ..................                [ 98%]
scripts/tests/test_archive.py sssssssss                                  [ 98%]
scripts/tests/test_copydocs.py .....                                     [ 98%]
scripts/tests/test_import_open_textbook_library.py ...                   [ 98%]
scripts/tests/test_import_standard_ebooks.py .                           [ 98%]
scripts/tests/test_isbndb.py ...................                         [ 99%]
scripts/tests/test_obfi.py ........                                      [ 99%]
scripts/tests/test_obfi_sh.py ....                                       [ 99%]
scripts/tests/test_partner_batch_imports.py .........                    [ 99%]
scripts/tests/test_promise_batch_imports.py ...                          [ 99%]
scripts/tests/test_solr_updater.py ...                                   [ 99%]
tests/test_docker_compose.py ...                                         [100%]

=========== 3337 passed, 18 skipped, 3 xfailed, 1 xpassed in 11.42s ============

```
  
</details> 


<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->
`asyncio_default_fixture_loop_scope = "function"`
All this does it set the value to the default that it will be set to in an upcoming release. Hence, quieting a warning about the change.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
