### PR TITLE
adjust worker counts and request limits

### DIFF
--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -12,7 +12,7 @@ services:
     restart: unless-stopped
     hostname: "$HOSTNAME"
     environment:
-      - GUNICORN_OPTS= --workers 50 --timeout 300 --max-requests 500
+      - GUNICORN_OPTS= --workers 30 --timeout 300 --max-requests 1500
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
       # Note this won't work with uv pip, because uv makes a network request
       - BEFORE_START=pip install -e /booklending_utils
@@ -27,7 +27,7 @@ services:
     restart: unless-stopped
     hostname: "$HOSTNAME"
     environment:
-      - GUNICORN_OPTS= --workers 2 --timeout 300 --max-requests 500
+      - GUNICORN_OPTS= --workers 2 --timeout 300 --max-requests 1500
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
     volumes:
       - ../booklending_utils:/booklending_utils


### PR DESCRIPTION
This pull request updates the Gunicorn configuration for two services in the `compose.production.yaml` file, primarily to adjust worker and request handling parameters for improved performance and stability.

Gunicorn configuration changes:

* Reduced the number of workers from 50 to 30 and increased the maximum requests per worker from 500 to 1500 for one service (`compose.production.yaml`).
* Increased the maximum requests per worker from 500 to 1500 for another service, keeping the worker count unchanged (`compose.production.yaml`).

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
