### PR TITLE
restrict paywalled useragents; use dumps

### DIFF
--- a/docker/web_nginx.conf
+++ b/docker/web_nginx.conf
@@ -5,6 +5,9 @@ map $http_user_agent $is_sus_user_agent {
     # Check for ancient browser user agents
     "~Firefox/([1-7]\.)" 1;
     "~Chrome/([1-9]|10)\." 1;
+    # Restrict paywalled commercial services
+    # Such services should use data dumps
+    "~VibXchange" 1;
 }
 
 # Log likely bots caught in /authors random loop.
@@ -142,7 +145,7 @@ server {
         limit_req zone=api_limit burst=25 delay=10;
         limit_req_status 429;
 
-        if ($http_user_agent ~* (bytespider|meta-externalagent) ) {
+        if ($http_user_agent ~* (bytespider|meta-externalagent|VibXchange) ) {
             return 403;
         }
 


### PR DESCRIPTION
This pull request updates the Nginx configuration to further restrict access from specific user agents, particularly targeting paywalled commercial services and bots. The main changes involve identifying and blocking requests from the `VibXchange` user agent.

**User agent restrictions:**

* Added a rule to flag requests from the `VibXchange` user agent as suspicious, grouping it with ancient browsers and other restricted clients in the `map $http_user_agent $is_sus_user_agent` block.
* Updated the conditional block in the server configuration to explicitly block requests from `VibXchange`, alongside existing bot user agents like `bytespider` and `meta-externalagent`, returning a 403 Forbidden status.