### PR TITLE
fix: Tab labels misaligned on books page

### DIFF
--- a/static/css/components/nav-bar.less
+++ b/static/css/components/nav-bar.less
@@ -4,7 +4,7 @@
   margin-bottom: 20px;
   font-weight: bold;
 
-  display: block;
+  display: flex;
   overflow-x: auto;
   white-space: nowrap;
   scroll-behavior: smooth;
@@ -23,6 +23,7 @@
     color: @grey;
     padding: 0 12px;
     line-height: @line-height-control;
+    border-bottom: 2px solid transparent;
   }
 
   /* stylelint-disable selector-max-specificity */
@@ -97,6 +98,7 @@
     padding: 8px 20px 0;
     background: @white;
     z-index: @z-index-level-5;
+    gap: 4px;
     scrollbar-width: thin;
 
     /* stylelint-disable selector-max-specificity */


### PR DESCRIPTION
- **fix: vertical misalignment of label in tab button**

### Technical

Switches to flexbox for vertical alignment and then removes top and bottom padding as those become superfluous because a height is explicitly set.

Additionally, it fixes a small issue where the blue button was not entirely clickable. The anchor tag now spans the entire height.

_Note: The nav bar would be good prospect for a web component in the future. Currently the CSS is overly complex and the html structure is brittle as there is JS that target specific internal elements._

### Testing

Go to book page and do a visual check of the tabs.

### Screenshot
<img width="5567" height="2289" alt="Frame 427318914" src="https://github.com/user-attachments/assets/299da795-7ec0-422f-9fb2-aed1113dbdca" />
<img width="5567" height="2093" alt="Frame 427318915" src="https://github.com/user-attachments/assets/d02e99b9-41fa-4764-887a-08b498506e88" />
<img width="5617" height="2322" alt="Frame 427318916" src="https://github.com/user-attachments/assets/2b895dc2-778f-448e-8d89-f28163ec2fff" />




### Stakeholders

@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
