### PR TITLE
disable ruff RUF059

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ extend-exclude = [
   "vendor",
 ]
 lint.ignore = [
+  "RUF059",  # enabled again after pre-commit updates per https://github.com/internetarchive/openlibrary/issues/11745
   "B007",    # unused-loop-control-variable - not a big deal for us
   "B023",    # function-uses-loop-variable - doesn't matter for our lambdas but it's a good rule
   "B904",    # raise-without-from-inside-except - not sure but it seems fine for now


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Part of #11745

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->
This is a very small and completely non-risky change to disable one rule that comes out in ruff 13 (and is blocking our upgrade).
Once we upgrade to ruff 13 and get the rest of the small changes then we should remove this line again and fix the changes.

See  #11745


### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
