### PR TITLE
fix: Implement dictionary merging in `merge_property` to correctly combine `remote_ids` during author merges.

### DIFF
--- a/openlibrary/plugins/upstream/merge_authors.py
+++ b/openlibrary/plugins/upstream/merge_authors.py
@@ -117,8 +117,9 @@ class BasicMergeEngine:
             return uniq(a + b, key=dicthash)
         elif isinstance(a, dict) and isinstance(b, dict):
             # Merge dictionaries (e.g., remote_ids)
-            result = a.copy()
-            result.update(b)
+            # Master (a) values take preference over duplicate (b) values
+            result = b.copy()
+            result.update(a)
             return result
         elif not a:
             return b


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11698

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
I reproduced the bug locally and, with the help of AI, fixed it.

Quick summary written by AI here:
When Wikidata ID Loss **OCCURS**:

The bug happens when merging a duplicate author into a master author where:
• Master has `remote_ids` (even if empty {} or with other IDs like VIAF)
• Duplicate has `remote_ids` with a Wikidata ID

Example scenarios:

Master: remote_ids = {}
Duplicate: remote_ids = {wikidata: "Q12345"}
→ Bug: Wikidata ID LOST ❌

Master: remote_ids = {viaf: "123456"}
Duplicate: remote_ids = {wikidata: "Q789"}
→ Bug: Wikidata ID LOST ❌

Why: The old logic returned the master's value if it was truthy (non-empty dict), ignoring the duplicate's IDs.

When Wikidata ID Loss **DOES NOT OCCUR**:

The bug does NOT happen when:
• Master has NO `remote_ids` field at all (None or missing)
• Duplicate has `remote_ids` with a Wikidata ID

Example:

Master: remote_ids = None (or field doesn't exist)
Duplicate: remote_ids = {wikidata: "Q12345"}
→ Works: Wikidata ID preserved ✓

Why: The old logic had elif not a: return b, which handled the None case correctly.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
