### PR TITLE
pytest v9 subtest

### DIFF
--- a/openlibrary/tests/test_templates.py
+++ b/openlibrary/tests/test_templates.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from tokenize import TokenError
 
+import pytest
 from web.template import Template
 
 
@@ -16,17 +17,8 @@ def try_parse_template(
         return False, e
 
 
-def test_all_templates_with_subtests(subtests):
-    """Test that all template files can be parsed without syntax errors.
-
-    This uses pytest 9.0's subtests feature to test all templates in a single test.
-    Benefits over parametrize:
-    - Reports ALL syntax errors in one run (doesn't stop at first failure)
-    - Cleaner test output (not 100+ separate test cases)
-    - Easier to identify which templates have issues
-    - Faster to run
-    """
-
+def test_all_templates(subtests):
+    """Test that all template files can be parsed without syntax errors."""
     template_files = [
         *Path("openlibrary/templates").rglob("*.html"),
         *Path("openlibrary/macros").rglob("*.html"),
@@ -37,3 +29,20 @@ def test_all_templates_with_subtests(subtests):
             template_text = template_path.read_text(encoding='utf-8')
             parsed, err = try_parse_template(template_text, template_path)
             assert parsed, f"Template parsing failed: {err}"
+
+
+@pytest.mark.xfail(reason="Verification test: demonstrates template error detection")
+def test_template_error_detection_verification():
+    """Verify that template error detection works by testing with a known bad template.
+
+    This is a simple verification test to prove that error detection works.
+    """
+    template_path = Path("openlibrary/templates/login.html")
+    original_content = template_path.read_text(encoding='utf-8')
+
+    # Break it in a way that WILL fail
+    broken_content = original_content.replace("{%", "ONLY_OPEN_BRACE")
+
+    # This should fail
+    parsed, err = try_parse_template(broken_content, template_path)
+    assert not parsed, f"Template should have failed but parsed: {err}"


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


This uses pytest 9.0's subtests feature to test all templates in a single test.
Benefits over parametrize:
    - Reports ALL syntax errors in one run (doesn't stop at first failure)
    - Cleaner test output (not 100+ separate test cases)
    - Easier to identify which templates have issues
    - Faster to run (collection time is faster, no fixture overhead)



### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
