### PR TITLE
Standardize async function naming convention

### DIFF
--- a/openlibrary/fastapi/search.py
+++ b/openlibrary/fastapi/search.py
@@ -20,8 +20,8 @@ from pydantic import (
 from openlibrary.core.fulltext import fulltext_search_async
 from openlibrary.fastapi.models import Pagination, PaginationLimit20
 from openlibrary.plugins.worksearch.code import (
-    async_run_solr_query,
     default_spellcheck_count,
+    run_solr_query_async,
     validate_search_json_query,
     work_search_async,
 )
@@ -226,7 +226,7 @@ async def search_subjects_json(
     pagination: Annotated[Pagination, Depends()],
     q: str = Query("", description="The search query"),
 ):
-    response = await async_run_solr_query(
+    response = await run_solr_query_async(
         SubjectSearchScheme(),
         {'q': q},
         offset=pagination.offset,
@@ -306,7 +306,7 @@ class ListSearchRequestParams(PaginationLimit20):
 async def search_lists_json(
     params: Annotated[ListSearchRequestParams, Depends()],
 ):
-    response = await async_run_solr_query(
+    response = await run_solr_query_async(
         ListSearchScheme(),
         {'q': params.q},
         offset=params.offset,
@@ -348,7 +348,7 @@ class AuthorSearchRequestParams(Pagination):
 async def search_authors_json(
     params: Annotated[AuthorSearchRequestParams, Depends()],
 ):
-    response = await async_run_solr_query(
+    response = await run_solr_query_async(
         AuthorSearchScheme(),
         {'q': params.q},
         offset=params.offset,

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -156,7 +156,7 @@ def process_facet_counts(
         yield field, list(process_facet(field, web.group(facets, 2)))
 
 
-async def async_execute_solr_query(
+async def execute_solr_query_async(
     solr_path: str,
     params: dict | list[tuple[str, Any]],
     _timeout: int | None = DEFAULT_SOLR_TIMEOUT_SECONDS,
@@ -180,7 +180,7 @@ async def async_execute_solr_query(
     return response
 
 
-execute_solr_query = async_bridge.wrap(async_execute_solr_query)
+execute_solr_query = async_bridge.wrap(execute_solr_query_async)
 
 # Expose this publicly
 public(has_solr_editions_enabled)
@@ -381,7 +381,7 @@ def run_solr_query(
     )
 
 
-async def async_run_solr_query(
+async def run_solr_query_async(
     scheme: SearchScheme,
     param: dict | None = None,
     **kwargs,
@@ -393,7 +393,7 @@ async def async_run_solr_query(
 
     url = f'{solr_select_url}?{urlencode(params)}'
     start_time = time.time()
-    response = await async_execute_solr_query(solr_select_url, params)
+    response = await execute_solr_query_async(solr_select_url, params)
     end_time = time.time()
     duration = end_time - start_time
 
@@ -1136,7 +1136,7 @@ async def work_search_async(
 ) -> dict:
     prepared = _prepare_work_search_query(query, page, offset, limit)
     scheme = WorkSearchScheme(lang=lang)
-    resp = await async_run_solr_query(
+    resp = await run_solr_query_async(
         scheme,
         prepared.query,
         rows=prepared.limit,

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -268,7 +268,7 @@ class SubjectEngine:
         # Circular imports are everywhere -_-
         from openlibrary.plugins.worksearch.code import (
             WorkSearchScheme,
-            async_run_solr_query,
+            run_solr_query_async,
         )
 
         subject_type = self.name
@@ -279,7 +279,7 @@ class SubjectEngine:
         if 'publish_year' in filters:
             # Don't want this escaped or used in fq for perf reasons
             unescaped_filters['publish_year'] = filters.pop('publish_year')
-        result = await async_run_solr_query(
+        result = await run_solr_query_async(
             WorkSearchScheme(),
             {
                 'q': query_dict_to_str(


### PR DESCRIPTION
<!-- What issue does this PR close? -->
This is a very simple renaming for two functions.

We standardized on putting _async at the end because it's much better for auto complete.
If you start typing `run_solr_qu...` you'll see both `run_solr_query_async` and `run_solr_query` as options.

In any case, it's this is temporary because we won't need the sync version as we keep making progress.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
