### PR TITLE
refactor: make `Solr.escape` a static method and update its usage

### DIFF
--- a/openlibrary/core/lists/model.py
+++ b/openlibrary/core/lists/model.py
@@ -17,6 +17,7 @@ from openlibrary.core.models import Image, Subject, Thing, ThingKey, ThingRefere
 from openlibrary.plugins.upstream.models import Author, Changeset, Edition, User, Work
 from openlibrary.plugins.worksearch.search import get_solr
 from openlibrary.plugins.worksearch.subjects import get_subject
+from openlibrary.utils.solr import Solr
 
 logger = logging.getLogger("openlibrary.lists.model")
 
@@ -250,7 +251,6 @@ class List(Thing):
         return " OR ".join(t for t in terms if t)
 
     def _get_all_subjects(self):
-        solr = get_solr()
         q = self._get_solr_query_for_subjects()
 
         # Solr has a maxBooleanClauses constraint there too many seeds, the
@@ -262,7 +262,7 @@ class List(Thing):
 
         facet_names = ['subject_facet', 'place_facet', 'person_facet', 'time_facet']
         try:
-            result = solr.select(
+            result = get_solr().select(
                 q, fields=[], facets=facet_names, facet_limit=20, facet_mincount=1
             )
         except OSError:
@@ -513,7 +513,7 @@ class Seed:
         if self.type == 'subject':
             typ, value = self.key.split(":", 1)
             # escaping value as it can have special chars like : etc.
-            value = get_solr().escape(value)
+            value = Solr.escape(value)
             return f"{typ}_key:{value}"
         else:
             doc_basekey = self.document.key.split("/")[-1]

--- a/openlibrary/plugins/worksearch/autocomplete.py
+++ b/openlibrary/plugins/worksearch/autocomplete.py
@@ -13,6 +13,7 @@ from openlibrary.utils import (
     find_olid_in_string,
     olid_to_key,
 )
+from openlibrary.utils.solr import Solr
 
 
 def to_json(d):
@@ -50,10 +51,8 @@ class autocomplete(delegate.page):
         i = web.input(q="", limit=5)
         i.limit = safeint(i.limit, 5)
 
-        solr = get_solr()
-
         # look for ID in query string here
-        q = solr.escape(i.q).strip()
+        q = Solr.escape(i.q).strip()
         embedded_olid = None
         if self.olid_suffix:
             embedded_olid = find_olid_in_string(q, self.olid_suffix)
@@ -73,7 +72,7 @@ class autocomplete(delegate.page):
             **({'sort': self.sort} if self.sort else {}),
         }
 
-        data = solr.select(solr_q, **params)
+        data = get_solr().select(solr_q, **params)
         docs = data['docs']
 
         if embedded_olid and not docs:

--- a/openlibrary/utils/solr.py
+++ b/openlibrary/utils/solr.py
@@ -56,11 +56,11 @@ class Solr:
         self.session = httpx.Client()
         self.async_session = httpx.AsyncClient()
 
-    def escape(self, query):
+    @staticmethod
+    def escape(query):
         r"""Escape special characters in the query string
 
-        >>> solr = Solr("")
-        >>> solr.escape("a[b]c")
+        >>> Solr.escape("a[b]c")
         'a\\[b\\]c'
         """
         chars = r'+-!(){}[]^"~*?:\\'


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

Trying to cleanup and better understand our solr code as we move to async.
I noticed this one small function was leading us to instantiate solr instances when we really don't need to so I changed it to be static.
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
