### PR TITLE
Remove redundant stats query from `store_counts.py`

### DIFF
--- a/openlibrary/admin/numbers.py
+++ b/openlibrary/admin/numbers.py
@@ -126,7 +126,6 @@ def admin_range__covers(**kargs):
 
 admin_range__works = functools.partial(single_thing_skeleton, type="work")
 admin_range__editions = functools.partial(single_thing_skeleton, type="edition")
-admin_range__users = functools.partial(single_thing_skeleton, type="user")
 admin_range__authors = functools.partial(single_thing_skeleton, type="author")
 admin_range__lists = functools.partial(single_thing_skeleton, type="list")
 admin_range__members = functools.partial(single_thing_skeleton, type="user")


### PR DESCRIPTION
Supports #11714 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes `admin_range__users` function from `numbers.py`.  This makes the same query as `admin_range__members`, but is not referenced in the `/stats` page template (nor the homepage template).

### Technical
<!-- What should be noted about the implementation? -->
The removed function populates the `users` value in the stats object, which is the output of the `store_counts` script.  This value doesn't appear to be referenced in the codebase (`members` _is_ accessed -- the `admin_range__members` function populates that entry).

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Run the `store_counts` script on a dev instance of Open Library.
2. Navigate to the `/stats` page and ensure the stats are correct and the page loads.
3. Navigate to the home page, and ensure that the graphs load without error.

Ideally, you would add a new account to your local instance before performing these tests.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
