### PR TITLE
Remove unused method from `SaveBookHelper`

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -3,7 +3,6 @@
 import csv
 import datetime
 import io
-import json
 import logging
 import urllib
 from typing import Literal, NoReturn, overload


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Follow-up to #8261
In support of micro edits.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
#8261 totally removes the ability to add new contributor, identifier, and classifications to `/config/edition` via the edit book UI.  This branch removes the corresponding backend code.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- [ ] Edits to books can still be made without error

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
