### PR TITLE
feat: Add start link to Openlibrary OPDS feed

### DIFF
--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -948,6 +948,11 @@ class opds_home(delegate.page):
                         type="application/opds+json",
                     ),
                     Link(
+                        rel="start",
+                        href=provider.BASE_URL,
+                        type="application/opds+json",
+                    ),
+                    Link(
                         rel="search",
                         href=f"{provider.BASE_URL}/opds/search{{?query}}",
                         type="application/opds+json",


### PR DESCRIPTION
A start link gives OPDS clients a way to return the user back to the start of the feed. Especially useful when a user is sent a hyperlink to a specific publication, and wants to go and explore the rest of the feed.

<!-- What issue does this PR close? -->
Closes https://github.com/ArchiveLabs/pyopds2_openlibrary/issues/19

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
feature

@mekarpeles @ronibhakta1 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
