### PR TITLE
remove extra cls variable being passed

### DIFF
--- a/openlibrary/core/edits.py
+++ b/openlibrary/core/edits.py
@@ -171,14 +171,6 @@ class CommunityEditsQueue:
         return rows_changed
 
     @classmethod
-    def submit_delete_request(cls, olid, submitter, comment=None):
-        if not comment:
-            # some default note from submitter
-            pass
-        url = f"{olid}/-/edit?m=delete"
-        cls.submit_request(url, submitter=submitter, comment=comment)
-
-    @classmethod
     def submit_request(
         cls,
         url: str,


### PR DESCRIPTION
<!-- What issue does this PR close? -->
I just noticed this and it seems like it's wrong...
Why would we pass cls when it should be passed automatically.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
