### PR TITLE
get_current_user works from fastapi

### DIFF
--- a/openlibrary/accounts/__init__.py
+++ b/openlibrary/accounts/__init__.py
@@ -2,6 +2,8 @@ from typing import TYPE_CHECKING
 
 import web
 
+from openlibrary.utils.request_context import site
+
 # FIXME: several modules import things from accounts.model
 # directly through openlibrary.accounts
 from .model import *  # noqa: F403
@@ -54,7 +56,7 @@ def get_current_user() -> "User | None":
     """
     Returns the currently logged in user. None if not logged in.
     """
-    return web.ctx.site.get_user()
+    return site.get().get_user()
 
 
 def find(

--- a/openlibrary/utils/request_context.py
+++ b/openlibrary/utils/request_context.py
@@ -7,10 +7,12 @@ and parsing request data for both web.py and FastAPI frameworks.
 
 from contextvars import ContextVar
 from dataclasses import dataclass
+from urllib.parse import unquote
 
 import web
 from fastapi import Request
 
+from infogami import config
 from infogami.infobase.client import Site
 from infogami.utils.delegate import create_site
 
@@ -34,6 +36,21 @@ req_context: ContextVar[RequestContextVars] = ContextVar("req_context")
 
 # TODO: Create an async and stateless version of site so we don't have to do this
 site: ContextVar[Site] = ContextVar("site")
+
+
+def setup_site(request: Request | None = None):
+    """
+    When called from web.py, web.ctx._parsed_cookies is already set.
+    When called from FastAPI, we need to set it.
+    create_site() automatically uses the cookie to set the auth token
+    """
+    if request:
+        cookie_name = config.get("login_cookie_name", "session")
+        cookie_value = request.cookies.get(cookie_name)
+        cookie_value = unquote(cookie_value) if cookie_value else ""
+        web.ctx._parsed_cookies = {cookie_name: cookie_value}
+
+    site.set(create_site())
 
 
 def _compute_is_bot(user_agent: str | None, hhcl: str | None) -> bool:
@@ -152,7 +169,7 @@ def set_context_from_legacy_web_py() -> None:
         hhcl=web.ctx.env.get("HTTP_X_HHCL"),
     )
 
-    site.set(create_site())
+    setup_site()
     req_context.set(
         RequestContextVars(
             x_forwarded_for=web.ctx.env.get("HTTP_X_FORWARDED_FOR"),
@@ -180,7 +197,7 @@ def set_context_from_fastapi(request: Request) -> None:
         hhcl=request.headers.get("X-HHCL"),
     )
 
-    site.set(create_site())
+    setup_site(request)
     req_context.set(
         RequestContextVars(
             x_forwarded_for=request.headers.get("X-Forwarded-For"),


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Blocked by: https://github.com/internetarchive/infogami/pull/273

Before this PR, if you called `get_current_user` from fastapi it would return None because it didn't have the cookie set when site was created. Now, when we create site the cookie is set correctly and we updated `get_current_user` to use the context variable instead of web.py context.

This is a necessary refactor before we start using endpoints that expect to interact with the `User` model.

Note: when we start using this in fastapi land we will have to rework how the auth dependencies are setup to work with this.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
