### PR TITLE
Fix #11695: Replace dynamic Solr field declarations with explicit ones (cover_i, ebook_count_i, last_modified_i)

### DIFF
--- a/conf/solr/conf/managed-schema.xml
+++ b/conf/solr/conf/managed-schema.xml
@@ -269,6 +269,9 @@
    <!-- fields used by documents of type list -->
    <field name="last_modified" type="pdate" indexed="true" stored="true"/>
    <field name="seed_count" type="pint" indexed="true" stored="true"/>
+   <field name="cover_i" type="pint" indexed="true" stored="true"/>
+   <field name="ebook_count_i" type="pint" indexed="true" stored="true"/>
+   <field name="last_modified_i" type="pint" indexed="true" stored="true"/>
 
     <!-- dynamic fields -->
     <dynamicField name="id_*"  type="string"  indexed="true"  stored="true" multiValued="true"/>

--- a/openlibrary/solr/solr_types.py
+++ b/openlibrary/solr/solr_types.py
@@ -124,9 +124,11 @@ class SolrDocument(TypedDict):
     subject_type: Optional[str]
     last_modified: Optional[str]
     seed_count: Optional[int]
+    cover_i: Optional[int]
+    ebook_count_i: Optional[int]
+    last_modified_i: Optional[int]
     public_scan_b: Optional[bool]
     printdisabled_s: Optional[str]
     lending_edition_s: Optional[str]
-    ebook_count_i: Optional[int]
 
 # fmt: on


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes: #11695
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Achievement: [fix]
### Technical

- Converted `cover_i`, `ebook_count_i`, and `last_modified_i` from dynamic fields to explicit `<field>` declarations in `managed-schema.xml`.
- Regenerated `openlibrary/solr/solr_types.py` and passed `test_types_generator.py`, ensuring Python types remain in sync with the Solr schema.
- Scoped changes strictly to these three fields per lead guidance (Feb 3, 2026), retaining dynamic wildcards for fields covered by the ongoing cleanup in *Remove some legacy IA-related solr fields #11586* to avoid regressions.

### Testing

- Ran the full search test suite (`make test-solr`) in Docker; all 2,935 tests passed.
- Verified in the Solr Admin Schema Browser that the new fields are explicitly defined and visible.
- Confirmed in `openlibrary/solr/updater/work.py` that `last_modified_i` is stored as a Unix timestamp (`pint`), consistent with the schema.


### Screenshot
* **Verification Proofs**: I have verified the fix via the Solr Admin UI. The proof of the fix is in the recording below:

[Screencast from 2026-02-06 02-01-32.webm](https://github.com/user-attachments/assets/4e1aef7e-feaf-4b33-97dd-98c0fe554057)

### Stakeholders
@cdrini


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
