### PR TITLE
feat: add ebook mode to search, automatically filtering for borrowable ebooks

### DIFF
--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -821,18 +821,15 @@ class opds_search(delegate.page):
             mode="ebooks",
         )
 
-        query = i.query
-        if i.mode == "ebooks" and "ebook_access:" not in query:
-            query = f"{query} ebook_access:[borrowable TO *]"
-
         provider = get_opds_data_provider()
         catalog = Catalog.create(
             metadata=Metadata(title=_("Search Results")),
             response=provider.search(
-                query=query,
+                query=i.query,
                 limit=int(i.limit),
                 offset=(int(i.page) - 1) * int(i.limit),
                 sort=i.sort,
+                facets={'mode': i.mode},
             ),
             links=[
                 Link(
@@ -842,7 +839,7 @@ class opds_search(delegate.page):
                 ),
                 Link(
                     rel="search",
-                    href=f"{provider.BASE_URL}/opds/search{{?query}}",
+                    href=f"{provider.BASE_URL}/opds/search{{?query,mode}}",
                     type="application/opds+json",
                     templated=True,
                 ),


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes # https://github.com/ArchiveLabs/pyopds2_openlibrary/issues/23

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix: `mode=ebooks` to Open Library opds `/search` URL (by default) and this should update the query to include `ebook_access:[borrowable TO *]` if it’s not present


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@MarcCoquand @mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
