### PR TITLE
Migrate partials endpoint from querystring-based routing to path-based routing

### DIFF
--- a/openlibrary/plugins/openlibrary/js/utils.js
+++ b/openlibrary/plugins/openlibrary/js/utils.js
@@ -75,9 +75,7 @@ export function trimInputValues(param) {
 
 export function buildPartialsUrl(component, params = {}) {
     const curUrl = new URL(window.location.href);
-    const url = new URL(`${location.origin}/partials.json`);
-
-    url.searchParams.set('_component', component)
+    const url = new URL(`${location.origin}/partials/${component}.json`);
 
     if (curUrl.searchParams.has('lang')) {
         url.searchParams.set('lang', curUrl.searchParams.get('lang'));

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -383,12 +383,10 @@ class PartialRequestResolver:
 
 
 class Partials(delegate.page):
-    path = '/partials'
+    path = r'/partials/([A-Za-z]+)'
     encoding = 'json'
 
-    def GET(self):
-        i = web.input(_component=None)
-        component = i.pop("_component")
+    def GET(self, component):
         return delegate.RawText(
             json.dumps(PartialRequestResolver.resolve(component)),
             content_type='application/json',


### PR DESCRIPTION
<!-- What issue does this PR close? -->

Migrate partials endpoint from querystring-based routing to path-based routing

This PR updates the partials endpoint so requests use a path segment for the component name, e.g. `/partials/AffiliateLinks.json`, instead of the legacy querystring format `/partials.json?_component=AffiliateLinks&...`.

This is an API change, but we’re updating the only known consumer at the same time. Partials are intended for internal use (not public/external consumers), so the risk of breaking unknown clients should be low.

Why this change?
FastAPI requires routes and parameters to be defined more explicitly up front. Using a path-based component name keeps the FastAPI migration cleaner and avoids an increasingly messy set of query-parameter permutations in the current migration draft (#11773).

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
