### PR TITLE
enable ruff typechecking rule

### DIFF
--- a/openlibrary/fastapi/services/subject_service.py
+++ b/openlibrary/fastapi/services/subject_service.py
@@ -7,11 +7,10 @@ code duplication and ensure consistent behavior.
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import Field
 
-from openlibrary.core.models import Subject
 from openlibrary.fastapi.models import Pagination
 from openlibrary.plugins.worksearch.subjects import (
     DEFAULT_RESULTS,
@@ -19,6 +18,9 @@ from openlibrary.plugins.worksearch.subjects import (
     date_range_to_publish_year_filter,
     get_subject_async,
 )
+
+if TYPE_CHECKING:
+    from openlibrary.core.models import Subject
 
 
 class BaseSubjectRequestParams(Pagination):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,8 @@ lint.ignore = [
   "SLF001",  # private-member-access - unfortunately we use these quite often for infogami
   "UP031",   # printf-string-formatting - a ton of work to fix to 224 errors
   # TODO: these could be fixed one day
+  "TC003",   # Move standard library import into a type-checking block. Should enable later
+  "TC006",   # runtime-cast-value - we don't do this now but could in a future PR
   "B905",    # zip-without-explicit-strict - TODO: seems like we should fix this one
   "E402",    # module-import-not-at-top-of-file - TODO: we should probably enable this and and add exceptions
     # openlibrary/plugins/admin/code.py - maybe it can be fixed
@@ -110,6 +112,7 @@ lint.select = [
   "SLF",     # flake8-self
   "SLOT",    # flake8-slots
   "T10",     # flake8-debugger
+  "TC",      # flake8-type-checking
   "UP",      # pyupgrade
   "W",       # pycodestyle
   "YTT",     # flake8-2020
@@ -138,7 +141,6 @@ lint.select = [
   # "RET",   # flake8-return
   # "S",     # flake8-bandit
   # "T20",   # flake8-print
-  # "TCH",   # flake8-type-checking
   # "TD",    # flake8-todos
   # "TID",   # flake8-tidy-imports
   # "TRY",   # tryceratops


### PR DESCRIPTION
PR #11838 just merged, updating us to Ruff 0.1.5, so I took a look at what’s new.

While the TC (type-checking) rule ([docs here](https://docs.astral.sh/ruff/rules/#flake8-todos-td)) itself isn’t new, we already comply with most of its sub-rules. Enabling it would let us take advantage of automatic fixes.

In this PR, we enable the main TC rule and explicitly disable the two sub-rules that would require additional manual cleanup.

I hope that in the future we can enable another of the rules.

The typechecking rules are relevant as I am working on the FastAPI migration and hit circular imports somewhat often. I think enabling the sub rules would help fix that automatically.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
