### PR TITLE
Update stats gathering functions

### DIFF
--- a/openlibrary/admin/numbers.py
+++ b/openlibrary/admin/numbers.py
@@ -64,6 +64,7 @@ def single_thing_skeleton(**kargs):
 
 cached_bot_accounts = None
 
+
 def get_bot_accounts(thingdb=None) -> list[int]:
     """
     Returns a list of all `thing` table IDs that are associated with

--- a/openlibrary/admin/numbers.py
+++ b/openlibrary/admin/numbers.py
@@ -6,10 +6,6 @@ All functions prefixed with `admin_range__` will be run for each day and the
 result will be stored as the part after it. e.g. the result of
 admin_range__foo will be stored under the key `foo`.
 
-All functions prefixed with `admin_delta__` will be run for the current
-day and the result will be stored as the part after it. e.g. the
-result of `admin_delta__foo` will be stored under the key `foo`.
-
 All functions prefixed with `admin_total__` will be run for the current
 day and the result will be stored as `total_<key>`. e.g. the result of
 `admin_total__foo` will be stored under the key `total__foo`.
@@ -159,12 +155,6 @@ def admin_total__authors(**kargs):
     return _count_things(db, "/type/author")
 
 
-def admin_total__subjects(**kargs):
-    # Anand - Dec 2014 - TODO
-    # Earlier implementation that uses couchdb is gone now
-    return 0
-
-
 def admin_total__lists(**kargs):
     try:
         db = kargs['thingdb']
@@ -219,27 +209,6 @@ def _query_count(db, table, type, property, distinct=False):
     return result[0].count
 
 
-def admin_total__ebooks(**kargs):
-    # Anand - Dec 2014
-    # The following implementation is too slow. Disabling for now.
-    return 0
-
-    db = kargs['thingdb']
-    return _query_count(db, "edition_str", "/type/edition", "ocaid")
-
-
 def admin_total__members(**kargs):
     db = kargs['thingdb']
     return _count_things(db, '/type/user')
-
-
-def admin_delta__ebooks(**kargs):
-    # Anand - Dec 2014 - TODO
-    # Earlier implementation that uses couchdb is gone now
-    return 0
-
-
-def admin_delta__subjects(**kargs):
-    # Anand - Dec 2014 - TODO
-    # Earlier implementation that uses couchdb is gone now
-    return 0

--- a/openlibrary/admin/numbers.py
+++ b/openlibrary/admin/numbers.py
@@ -8,7 +8,7 @@ admin_range__foo will be stored under the key `foo`.
 
 All functions prefixed with `admin_total__` will be run for the current
 day and the result will be stored as `total_<key>`. e.g. the result of
-`admin_total__foo` will be stored under the key `total__foo`.
+`admin_total__foo` will be stored under the key `total_foo`.
 
 Functions with names other than the these will not be called from the
 main harness. They can be utility functions.
@@ -64,8 +64,8 @@ def single_thing_skeleton(**kargs):
 
 # Public functions that are used by stats.py
 def admin_range__human_edits(**kargs):
-    """Calculates the number of edits between the `start` and `end`
-    parameters done by humans. `thingdb` is the database.
+    """Calculates the number of edit actions performed by humans
+    between the given `start` and `end` dates. `thingdb` is the database.
     """
     try:
         start = kargs['start'].strftime("%Y-%m-%d")
@@ -87,8 +87,8 @@ def admin_range__human_edits(**kargs):
 
 
 def admin_range__bot_edits(**kargs):
-    """Calculates the number of edits between the `start` and `end`
-    parameters done by bots. `thingdb` is the database.
+    """Calculates the number of edit actions performed by bots between
+    the `start` and `end` dates. `thingdb` is the database.
     """
     try:
         start = kargs['start'].strftime("%Y-%m-%d")
@@ -130,9 +130,9 @@ admin_range__members = functools.partial(single_thing_skeleton, type="user")
 def admin_range__loans(**kargs):
     """Finds the number of loans on a given day.
 
-    Loan info is written to infobase write log. Grepping through the log file gives us the counts.
-
-    WARNING: This script must be run on the node that has infobase logs.
+    Loan info is written to the `stats` table.  Such entries will have
+    type `loan`.  As of writing, _only_ loan data is saved in the `stats`
+    table.
     """
     try:
         db = kargs['thingdb']

--- a/openlibrary/admin/stats.py
+++ b/openlibrary/admin/stats.py
@@ -157,17 +157,7 @@ def main(infobase_config, openlibrary_config, coverstore_config, ndays=1):
             key_prefix="total",
         )
     )
-    logger.info("Gathering data using difference between totals")
-    data.update(
-        run_gathering_functions(
-            infobase_db,
-            coverstore_db,
-            yesterday,
-            today,
-            logroot,
-            prefix="admin_delta__",
-        )
-    )
+
     store_data(data, today.strftime("%Y-%m-%d"))
     # Now gather data which can be queried based on date ranges
     # The queries will be from the beginning of today till right now


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Supports #11714

**Affects /stats page**

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Makes the following updates to our stats gathering functions:

1. Removes unimplemented functions
2. Updates comments that are stale or otherwise misleading
3. Adds new function that fetches all `thing` IDs associated with bot accounts
4. Simplifies functions that query for human and bot edit counts
5. Functions that query for bot/human edits now strictly count edit transactions (not records edited)

**Important Note:** Functions that count the number of edits on the platform continue to count _every_ transaction type as an edit.  To fix this, we'll have to filter by `action` type when querying the `transaction` table.  I'm unsure if this filtering should be included in this PR.  Some transactions are being misidentified today -- perhaps those should be fixed before filters are added to the queries.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Can be tested by running `scripts/store_counts.py` with the expected arguments.  Before running, it's best to update the following values in `admin/stats.py::store_data`:

---

https://github.com/internetarchive/openlibrary/blob/b83bdda0a182e0e8d867cf30ebd9a67845f3ed92/openlibrary/admin/stats.py#L62
Change to something like `"test-counts-%s" % date` to avoid clobbering existing data.

---

https://github.com/internetarchive/openlibrary/blob/b83bdda0a182e0e8d867cf30ebd9a67845f3ed92/openlibrary/admin/stats.py#L66
Change to something like `"test-admin-stats"` for easy clean-up after testing.  With this change in place, you can delete the entries like this:

```
test_entry_keys = web.ctx.site.store.keys(type="test-admin-stats")
for key in test_entry_keys:
    web.ctx.site.store.delete(key)
```
---

The store entry created during testing can be compared to the most recent production `store_counts` entry.  Expect the `total_*` counts to be different -- human edits may be off a fair amount, while bot edits may differ slightly.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
