### PR TITLE
fix: Block duplicate OCAIDs in edition editor

### DIFF
--- a/openlibrary/components/IdentifiersInput.vue
+++ b/openlibrary/components/IdentifiersInput.vue
@@ -249,6 +249,11 @@ export default {
             if (this.saveIdentifiersAsList) {
                 // collect id values of matching type, or empty array if none present
                 const existingIds = this.assignedIdentifiers[this.selectedIdentifier] ?? [];
+                // Only one Internet Archive ID (ocaid) is allowed per edition
+                if (this.selectedIdentifier === 'ocaid' && existingIds.length > 0) {
+                    errorDisplay('Only one Internet Archive ID is allowed per edition.', this.output_selector);
+                    return;
+                }
                 const validEditionId = validateIdentifiers(this.selectedIdentifier, this.inputValue, existingIds, this.output_selector);
                 if (validEditionId) {
                     if (!this.assignedIdentifiers[this.selectedIdentifier]) {


### PR DESCRIPTION
## Summary
Fixes #395 — Prevents adding multiple Internet Archive IDs (OCAIDs) in the edition edit UI.

## Changes
- Added validation in `IdentifiersInput.vue` to block duplicate OCAID entries
- Shows error message: "Only one Internet Archive ID is allowed per edition"

## Testing
- ✅ Verified on local instance at `/books/OL1M/edit`
- ✅ First OCAID adds successfully
- ✅ Second OCAID attempt is blocked with error message
- ✅ Only one OCAID persists in the identifier list

## Stakeholder
@RayBB 