### PR TITLE
fix: Bring back clamping code

### DIFF
--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -171,6 +171,17 @@ jQuery(function () {
             .then(module => module.initLoginForm());
     }
 
+    // conditionally load clamping components
+    const clampers = document.querySelectorAll('.clamp');
+    if (clampers.length) {
+        import(/* webpackChunkName: "readmore" */ './readmore.js')
+            .then(module => {
+                if (clampers.length) {
+                    module.initClampers(clampers);
+                }
+            });
+    }
+
     // conditionally loads Goodreads import based on class in the page
     if (document.getElementsByClassName('import-table').length) {
         import(/* webpackChunkName: "goodreads-import" */'./goodreads_import.js')

--- a/openlibrary/plugins/openlibrary/js/readmore.js
+++ b/openlibrary/plugins/openlibrary/js/readmore.js
@@ -1,0 +1,32 @@
+import $ from 'jquery';
+
+export function initClampers(clampers) {
+    for (const clamper of clampers) {
+        if (clamper.clientHeight === clamper.scrollHeight) {
+            clamper.classList.remove('clamp')
+        } else {
+            /*
+                Clamper shows used to show more/less by toggling `hidden`
+                style on parent .clamp tag
+            */
+            $(clamper).on('click', function (event) {
+                const up = $(this);
+
+                // prevent the subjects from collapsing/expanding when the <a> link is being clicked
+                if (event.target.nodeName === 'A') {
+                    return
+                }
+
+                if (up.hasClass('clamp')) {
+                    clamper.style.display = clamper.style.display === '-webkit-box' || clamper.style.display === '' ? 'unset' : '-webkit-box'
+
+                    if (up.attr('data-before') === '\u25BE ') {
+                        up.attr('data-before', '\u25B8 ')
+                    } else {
+                        up.attr('data-before', '\u25BE ')
+                    }
+                }
+            })
+        }
+    }
+}


### PR DESCRIPTION

<!-- What issue does this PR close? -->
Closes # https://github.com/internetarchive/openlibrary/issues/11866

- fix: The clamper code that lived in readmore.js and was removed in error when our jquery based readmore component was being deprecated.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
Go to a works page and click the arrow on left side of the subjects list to toggle visibility of all subjects.

### Screenshot
![clamp](https://github.com/user-attachments/assets/46d8b40f-3c7b-4fb6-b9f5-7eb51d280637)


### Stakeholders
@cdrini 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
