### PR TITLE
Add SELinux relabel option to bind mount volumes in local composer config

### DIFF
--- a/compose.infogami-local.yaml
+++ b/compose.infogami-local.yaml
@@ -6,19 +6,19 @@
 services:
   web:
     volumes:
-      - ./vendor/infogami:/openlibrary/vendor/infogami
+      - ./vendor/infogami:/openlibrary/vendor/infogami:z
   fast_web:
     volumes:
-      - ./vendor/infogami:/openlibrary/vendor/infogami
+      - ./vendor/infogami:/openlibrary/vendor/infogami:z
   covers:
     volumes:
-      - ./vendor/infogami:/openlibrary/vendor/infogami
+      - ./vendor/infogami:/openlibrary/vendor/infogami:z
   infobase:
     volumes:
-      - ./vendor/infogami:/openlibrary/vendor/infogami
+      - ./vendor/infogami:/openlibrary/vendor/infogami:z
   home:
     volumes:
-      - ./vendor/infogami:/openlibrary/vendor/infogami
+      - ./vendor/infogami:/openlibrary/vendor/infogami:z
   solr-updater:
     volumes:
-      - ./vendor/infogami:/openlibrary/vendor/infogami
+      - ./vendor/infogami:/openlibrary/vendor/infogami:z

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -19,7 +19,7 @@ services:
       - ol-nodemodules:/openlibrary/node_modules
       # The above volume mounts are required so that the local dev bind mount below
       # does not clobber the data generated inside the image / container
-      - .:/openlibrary
+      - .:/openlibrary:z
     environment:
       - LOCAL_DEV=true
     depends_on:
@@ -34,7 +34,7 @@ services:
       # Debugger
       - 127.0.0.1:3001:3000
     volumes:
-      - .:/openlibrary
+      - .:/openlibrary:z
     environment:
       - LOCAL_DEV=true
 
@@ -60,7 +60,7 @@ services:
     volumes:
       # Persistent volume mount for installed git submodules
       - ol-vendor:/openlibrary/vendor
-      - .:/openlibrary
+      - .:/openlibrary:z
 
   db:
     image: postgres:${POSTGRES_VERSION:-9.3}
@@ -71,11 +71,11 @@ services:
       # This allows postgres access for psql user w/o password required
       - POSTGRES_HOST_AUTH_METHOD=trust
     volumes:
-      - .:/openlibrary
+      - .:/openlibrary:z
       # Any files inside /docker-entrypoint-initdb.d/ will get run by postgres
       # if the db is empty (which as of now is always, since we don't store the
       # postgres data anywhere).
-      - ./docker/ol-db-init.sh:/docker-entrypoint-initdb.d/ol-db-init.sh
+      - ./docker/ol-db-init.sh:/docker-entrypoint-initdb.d/ol-db-init.sh:z
       - ol-postgres:/var/lib/postgresql/data
 
   covers:
@@ -86,7 +86,7 @@ services:
       - 7075:7075
     volumes:
       - ol-vendor:/openlibrary/vendor
-      - .:/openlibrary
+      - .:/openlibrary:z
 
   infobase:
     build:
@@ -101,7 +101,7 @@ services:
     #  - 7000:7000
     volumes:
       - ol-vendor:/openlibrary/vendor
-      - .:/openlibrary
+      - .:/openlibrary:z
     depends_on:
       - db
 
@@ -123,7 +123,7 @@ services:
       - ol-vendor:/openlibrary/vendor
       - ol-build:/openlibrary/static/build
       - ol-nodemodules:/openlibrary/node_modules
-      - .:/openlibrary
+      - .:/openlibrary:z
 
 volumes:
   ol-vendor:

--- a/compose.yaml
+++ b/compose.yaml
@@ -57,7 +57,7 @@ services:
       - SOLR_MODULES=analysis-extras
     volumes:
       - solr-data:/var/solr
-      - ./conf/solr:/opt/solr/server/solr/configsets/olconfig:ro
+      - ./conf/solr:/opt/solr/server/solr/configsets/olconfig:ro,z
     networks:
       - webnet
     logging:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Fixes #11874 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes podman-compose working with SELinux enabled and enforced. This allows the application to build successfully and run on local systems with SELinux and podman-compose.

### Technical
<!-- What should be noted about the implementation? -->
I added [SELinux label options](https://docs.docker.com/engine/storage/bind-mounts/#configure-the-selinux-label) to local volume mounts. This should be ignored by any systems running without SELinux enabled, and continue to work as expected in those userspaces with Docker Compose.

I only made this change for the composer yaml files for local development. The risk of making changes to stage and production didn't seem worth the benefit. Unblocking local development was the issue I was facing. 

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
0. with SELinux enabled and podman-compose installed
1. cd to repo root working directory
2. run `podman-compose up` 
3. confirm the absence of "permission denied" errors in the log output
4. navigate to https://localhost:8080 
5. confirm application has successfully built and is running in a healthy state

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
Unsure who to tag, as this my first time attempting to contribute something to this project.


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
