### PR TITLE
Lower min weight/dimension from 0.01 to 0.001 to fix silent edit fail…

### DIFF
--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -548,7 +548,7 @@ $ })
                 <div class="input">
                     $ weight = book.get_weight() or storage(value="", units="grams")
                     <input name="edition--weight--value" type="number" step="any"
-                           id="edition--weight--value" min="0.01" size="6" value="$weight.value"/>
+                           id="edition--weight--value" min="0.001" size="6" value="$weight.value"/>
                     <span class="tip">
                         $:radiobuttons("edition--weight--units", ["grams", "kilos", "ounces", "pounds"], weight.units)
                     </span>
@@ -570,17 +570,17 @@ $ })
                             <tr>
                                 <td rowspan="3"><img src="/images/dimensions.png" alt="$_('dimensions')" width="107" height="69" align="left"/></td>
                                 <td><span class="tip"><label for="dimensions-height">$_("Height:")</label> </span></td>
-                                <td><input name="edition--physical_dimensions--height" type="number" step="any" min="0.01"
+                                <td><input name="edition--physical_dimensions--height" type="number" step="any" min="0.001"
                                            id="dimensions-height" size="6" value="$dimensions.height"/></td>
                             </tr>
                             <tr>
                                 <td><span class="tip"><label for="dimensions-width">$_("Width:")</label> </span></td>
-                                <td><input name="edition--physical_dimensions--width" type="number" step="any" min="0.01"
+                                <td><input name="edition--physical_dimensions--width" type="number" step="any" min="0.001"
                                            id="dimensions-width" size="6" value="$dimensions.width"/></td>
                             </tr>
                             <tr>
                                 <td><span class="tip"><label for="dimensions-depth">$_("Depth:")</label> </span></td>
-                                <td><input name="edition--physical_dimensions--depth" type="number" step="any" min="0.01"
+                                <td><input name="edition--physical_dimensions--depth" type="number" step="any" min="0.001"
                                            id="dimensions-depth" size="6" value="$dimensions.depth"/></td>
                             </tr>
                         </tbody>


### PR DESCRIPTION
## Fix:  #11699

### Problem
Historical edition records have weight values like `0.001` that violate the form's `min="0.01"` HTML constraint. When such a record is opened for editing, **any** save attempt silently fails because native browser validation rejects the pre-filled value  and the field is in a collapsed section so no error is shown to the user.

### Change
Changed `min` from `"0.01"` to `"0.001"` on 4 inputs in `edition.html`:
- Weight
- Height, Width, Depth (dimensions)

### Stakeholder 
@RayBB 