### PR TITLE
Reinstate `recentchanges_view` POST handler

### DIFF
--- a/openlibrary/plugins/upstream/recentchanges.py
+++ b/openlibrary/plugins/upstream/recentchanges.py
@@ -185,11 +185,10 @@ class recentchanges_view(delegate.page):
 
     # Required for reverting changesets
     def POST(self, id):
-        allowed_usergroups = [
-            '/usergroup/admin',
-            '/usergroup/super-librarians'
-        ]
-        if not (user := get_current_user()) or not (user.is_member_of_any(allowed_usergroups)):
+        allowed_usergroups = ['/usergroup/admin', '/usergroup/super-librarians']
+        if not (user := get_current_user()) or not (
+            user.is_member_of_any(allowed_usergroups)
+        ):
             raise web.unauthorized()
         if not features.is_enabled("undo"):
             return render_template(


### PR DESCRIPTION
Closes #11894

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Restores the `recentchanges_view` POST handler, which was thought to be unused.  Authentication is now required for this endpoint.  Usage is restricted to admins and super-librarians.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
