### PR TITLE
Update compose.yaml

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -68,7 +68,7 @@ services:
     command: solr-precreate openlibrary /opt/solr/server/solr/configsets/olconfig
 
   solr-updater:
-    image: "${OLIMAGE:-oldev:latest}"
+    image: "${OLIMAGE:-oldev:solr_updater}"
     command: docker/ol-solr-updater-start.sh
     hostname: "$HOSTNAME"
     init: true
@@ -89,7 +89,7 @@ services:
       - webnet
 
   covers:
-    image: "${OLIMAGE:-oldev:latest}"
+    image: "${OLIMAGE:-oldev:covers}"
     environment:
       - COVERSTORE_CONFIG=${COVERSTORE_CONFIG:-/openlibrary/conf/coverstore.yml}
       - GUNICORN_OPTS=${GUNICORN_OPTS:- --reload --workers 1 --max-requests 250}
@@ -105,7 +105,7 @@ services:
         max-file: "4"
 
   infobase:
-    image: "${OLIMAGE:-oldev:latest}"
+    image: "${OLIMAGE:-oldev:infobase}"
     environment:
       - INFOBASE_CONFIG=${INFOBASE_CONFIG:-/openlibrary/conf/infobase.yml}
       - INFOBASE_OPTS=${INFOBASE_OPTS:-}


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR aims for a long term fix for building the app on windows operating systems by explicitly setting image names for each service in the docker-compose.yml. Previously, services shared the same default image name, which caused conflicts when building or running multiple services.

### Technical
<!-- What should be noted about the implementation? -->
Assign unique image names for each service in docker-compose.yml to prevent Docker image collisions.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Run docker-compose build to ensure all services build successfully.
2. Run docker-compose up and verify that all services start without image conflicts.
3. Confirm each service is using the correct image name (docker images | grep oldev).

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@xielun-laoshi @mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
