### PR TITLE
Fix ebooks toggle visibility on author page 

### DIFF
--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -134,11 +134,11 @@ $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_libra
                     $if books_count > 0:
                         $:render_template("search/layout_options.html", selected_layout=layout)
 
-                    $if books_count > 1:
-                        $if input(mode="everything").mode == "everything":
+                    $if input(mode="everything").mode == "everything":
+                        $if books_count > 0:
                             <span>$:_('— Show <a href="%(url)s">only ebooks</a>?', url=changequery(mode='ebooks'))</span>
-                        $else:
-                            <span>$:_('— Show <a href="%(url)s">everything</a> by this author?', url=changequery(mode='everything'))</span>
+                    $else:
+                        <span>$:_('— Show <a href="%(url)s">everything</a> by this author?', url=changequery(mode='everything'))</span>
                 </div>
 
                 $:macros.Pager(page=safeint(query_param('page'), default=1), num_found=books_count)
@@ -223,3 +223,4 @@ $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_libra
 
     $:render_template("lib/history", page)
 </div>
+


### PR DESCRIPTION
Closes #11910

### Technical
The ebook/everything toggle in `templates/type/author/view.html` was wrapped in a `$if books_count > 1:` block, causing it to disappear when search results returned 0 or 1 works.

The fix applies asymmetric visibility logic:
- "Show only ebooks" is shown when `mode=everything` and `books_count > 0` (no point filtering down to ebooks if there's nothing to filter)
- "Show everything" is always shown when `mode=ebooks`, regardless of count, so users can always escape back to the full unfiltered view

### Testing
1. Go to an author page locally, e.g. `http://localhost:8080/authors/OL18319A/Mark_Twain`
2. Search for a term that returns a single result, e.g. `?mode=everything&q=Huckleberry`
3. Confirm "— Show only ebooks?" is visible with 1 result
4. Click it — confirm you land on `mode=ebooks` view with "— Show everything by this author?" still visible
5. Search `?mode=ebooks&q=Huckleberry123` — confirm "— Show everything by this author?" remains visible even with 0 results

### Screenshot
**1 work — "Show only ebooks?" visible:**
<img width="3072" height="1728" alt="image" src="https://github.com/user-attachments/assets/2c9eaac6-fb05-45dc-9b09-66d354ef2946" />


**1 work — "Show everything?" visible:**
<img width="3072" height="1728" alt="image" src="https://github.com/user-attachments/assets/74e251c9-b066-43ec-9f38-7a3e48319ab2" />

**0 works — "Show everything by this author?" visible:**
<img width="3072" height="1728" alt="Screenshot from 2026-02-24 11-23-40" src="https://github.com/user-attachments/assets/31a17ff4-dcde-4397-a94f-3d0e72bd2db0" />

### Stakeholders
@mekarpeles @davidscotson