### PR TITLE
Use  `alternate_names` fully for existing Author matching

### DIFF
--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -115,9 +115,13 @@ class AuthorImportDict(TypedDict):
 
 def do_flip(author: AuthorImportDict) -> None:
     """
-    Given an author import dict, flip its name in place
+    Given an author import dict, flip its name
+    and any alternate_names in place
     i.e. Smith, John => John Smith
     """
+    alternate_names = [flip_name(name) for name in author.get('alternate_names', [])]
+    if alternate_names:
+        author['alternate_names'] = alternate_names
     if 'personal_name' in author and author['personal_name'] != author['name']:
         # Don't flip names if name is more complex than personal_name (legacy behaviour)
         return

--- a/openlibrary/catalog/add_book/tests/test_load_book.py
+++ b/openlibrary/catalog/add_book/tests/test_load_book.py
@@ -335,11 +335,10 @@ class TestImportAuthor:
         assert isinstance(found, Author)
         assert found.key == author_alternate_name_with_dates["key"]
 
-        # Also search for author match on incoming alternate name:
+        # Expect author match on incoming alternate name (comma flipped also):
         searched_author = {
             "name": "Фёдор Д.",
-            "alternate_names": ["Fyodor Dostoevsky"],
-            # "alternate_names": ["Dostoevsky, Fyodor"],  # for testing comma flipped name
+            "alternate_names": ["Dostoevsky, Fyodor"],
             "birth_date": "1821",
             "death_date": "1881",
         }


### PR DESCRIPTION
alternate_names is being extracted from the MARC record, it appears it might not be recognised by the
create-new-author code? **No**, `alternate_names` were **_NOT_** being imported #11927 corrects this

<!-- What issue does this PR close? -->
Closes #11877

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

* Uses incoming record's `alternate_names` in the name queries used to find existing Author records by name.
* Comma flips `alternate_names` to natural name order, as we do with other `name`s


### Technical

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
