### PR TITLE
Fix: Sort language autocomplete results alphabetically with prefix ma…

### DIFF
--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -769,13 +769,18 @@ def autocomplete_languages(prefix: str) -> Iterator[Storage]:
     for lang in get_languages().values():
         for lang_name in get_names_to_try(lang):
             if lang_name and word_prefix_match(prefix, normalize_for_search(lang_name)):
-                matches.append(Storage(
-                    key=lang.key,
-                    code=lang.code,
-                    name=lang_name,
-                ))
+                matches.append(
+                    Storage(
+                        key=lang.key,
+                        code=lang.code,
+                        name=lang_name,
+                    )
+                )
                 break
-    yield from sorted(matches, key=lambda x: (not normalize_for_search(x.name).startswith(prefix), x.name))
+    yield from sorted(
+        matches,
+        key=lambda x: (not normalize_for_search(x.name).startswith(prefix), x.name),
+    )
 
 
 def get_abbrev_from_full_lang_name(input_lang_name: str, languages=None) -> str:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10765

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
The autocomplete_languages function in utils.py was yielding results in the order they were iterated from get_languages() rather than in a meaningful order. This PR collects all matches into a list first, then sorts them so that names starting with the search prefix rank above names that merely contain it elsewhere, with alphabetical ordering within each group.

Note: locale-aware collation (for correctly sorting translated language names for non-English users) is a known limitation. Implementing it safely in a concurrent web server would require a thread-safe i18n library like babel, which is not currently a dependency. This could be addressed as a separate issue. The docstring has also been updated to reflect the new correct output order.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Navigate to http://localhost:8080/languages/_autocomplete?q=eng&limit=10
2. Confirm "English" appears before "English, Middle", "English, Old", and "Creoles and Pidgins, English-based"
3. Test with other prefixes such as `fr` and `ar` to confirm consistent behaviour.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Not applicable, no UI changes to the autocomplete dropdown itself. JSON output before and after is documented in the linked issue.

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
