### PR TITLE
Language drop down out of order #10765 Fix

### DIFF
--- a/openlibrary/plugins/openlibrary/js/autocomplete.js
+++ b/openlibrary/plugins/openlibrary/js/autocomplete.js
@@ -146,7 +146,7 @@ export function init() {
                     const t = (term || '').toString().trim().toLowerCase();
                     const nBaseA = baseA.toLowerCase();
                     const nBaseB = baseB.toLowerCase();
-                    
+
                     if (t) {
                         const aExact = nBaseA === t;
                         const bExact = nBaseB === t;
@@ -165,7 +165,7 @@ export function init() {
                     if (aHasComma !== bHasComma) return aHasComma ? 1 : -1;
 
                     return A.localeCompare(B, undefined, { sensitivity: 'base' });
-                    });
+                });
 
 
                 response(


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10765

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

### Technical
<!-- What should be noted about the implementation? -->
Added sorting logic to autocomplete.js to improve how language suggestions are ordered.

Exact matches (e.g., “English”) are prioritized and appear first.

Closely related variants (e.g., “English, Old”) appear next.

Partial matches that merely contain the query term appear afterward.

Within each group, languages are sorted alphabetically to ensure a consistent and predictable order.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Go to any book
Go to Edit page
Scroll down to language section
Type in "eng"
You should see the languages are sorted.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

<img width="480" height="334" alt="Screenshot 2026-02-25 at 9 37 27 AM" src="https://github.com/user-attachments/assets/d88637d8-ac21-4325-88c2-c89dd962dece" />

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
