### PR TITLE
Remove `thingdb` as source for patron preferences

### DIFF
--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -913,13 +913,9 @@ class User(Thing):
         def query_store(_key):
             return web.ctx.site.store.get(_key)
 
-        def query_fallback(_key):
-            results = web.ctx.site.get(_key)
-            return results and results.dict().get('notifications')
-
         key = f"{self.key}/preferences"
 
-        return query_store(key) or query_fallback(key) or self.get_default_preferences()
+        return query_store(key) or self.get_default_preferences()
 
     def save_preferences(self, new_prefs) -> None:
         key = f'{self.key}/preferences'


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Advances #11009

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Prevents patron preferences accessor from querying the `thing` tables for preference objects.

Untested.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
