### PR TITLE
ignore beads

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,6 @@
 
 # MARC binary
 *.mrc	binary -linguist-detectable
+
+# Use bd merge for beads JSONL files
+.beads/issues.jsonl merge=beads

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ android.keystore
 
 # Ignore checksum file if it’s generated during build
 manifest-checksum.txt
+.beads


### PR DESCRIPTION
This pull request updates the `.gitattributes` file to specify a custom merge driver for beads JSONL files. This ensures that files matching `.beads/issues.jsonl` will use the `beads` merge driver during merges, which can help resolve conflicts more intelligently for these files.

Configuration changes:

* [`.gitattributes`](diffhunk://#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393eR12-R14): Added a rule to use the `beads` merge driver for `.beads/issues.jsonl` files.