### PR TITLE
Fix alphabetical sorting of languages by name 

### DIFF
--- a/openlibrary/plugins/worksearch/languages.py
+++ b/openlibrary/plugins/worksearch/languages.py
@@ -17,6 +17,7 @@ from . import search, subjects
 
 logger = logging.getLogger("openlibrary.worksearch")
 
+
 def normalize_sort(text: str) -> str:
     if not text:
         return ""
@@ -45,8 +46,7 @@ async def get_top_languages(
         results.sort(key=lambda x: normalize_sort(x.name))
     else:
         results.sort(
-            key=lambda x: x[sort],
-            reverse=sort in ("count", "ebook_edition_count")
+            key=lambda x: x[sort], reverse=sort in ("count", "ebook_edition_count")
         )
     return results[:limit]
 


### PR DESCRIPTION

Fix related to #11962

### Technical

Sorting logic was updated in languages.py by introducing a normalization function:

```
def normalize_sort(text: str) -> str:
    if not text:
        return ""
    return unicodedata.normalize("NFKD", text).casefold()
```
Languages are now sorted using:
```
if sort == "name":
    results.sort(key=lambda x: normalize_sort(x.name))
```

This ensures:

- Case-insensitive ordering
- Proper Unicode normalization
- Correct alphabetical sorting of languages
- Characters with diacritics (Č, Ć, etc.) appear near their base characters


### Testing

Steps to verify:

1. Run OpenLibrary locally:

```
docker-compose up
```

2. Open: http://localhost:8080/languages?sort=name

3. Change the site language to Croatian.

4. Verify alphabetical ordering:

5. Verify that uppercase and lowercase letters do not affect sorting.


Before Fix:
- Characters with diacritics appear at the end
- Case-sensitive sorting

After Fix:
- Characters with diacritics appear correctly after base characters
- Case-insensitive alphabetical order


### Stakeholders

@cdrini
@mekarpeles


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->