### PR TITLE
 Fix: Align action buttons on search result grid view

### DIFF
--- a/static/css/legacy.css
+++ b/static/css/legacy.css
@@ -1439,8 +1439,12 @@ ul.list-books span.resultType {
   flex: 1;
   display: flex;
   flex-direction: column;
-  justify-content: flex-end;
+  justify-content: flex-start;
   margin: 0;
+  margin-bottom: 0.5em;
+  aspect-ratio: 0.7;
+  overflow: hidden;
+  border-radius: 4px;
 }
 
 .list-books--grid .searchResultItem > .details,
@@ -1459,6 +1463,10 @@ ul.list-books span.resultType {
 .list-books--grid .searchResultItem .check-in-prompt,
 .list-books--grid .searchResultItem .star-rating-form {
   display: none;
+}
+
+.list-books--grid .searchResultItem .cta-btn.cta-btn--preview {
+  visibility: hidden;
 }
 
 .list-books--grid .list-books__note {


### PR DESCRIPTION
Closes #11907

Aligns action buttons horizontally on search result page when in grid view.

### Technical
-set bookcover aspect ratio to .7 and overflow to hidden so that the buttons below bookcover will align horizontally 
-set visibility of preview link to hidden

### Testing
search for books and view the result in grid view

### Screenshot
<img width="919" height="648" alt="image" src="https://github.com/user-attachments/assets/ded6fc7f-f6c7-43bc-9b9f-444088b4faa8" />


### Stakeholders
@cdrini 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
