### PR TITLE
Add trending score badge to Book Page (if > threshold)

### DIFF
--- a/openlibrary/templates/type/edition/title_and_author.html
+++ b/openlibrary/templates/type/edition/title_and_author.html
@@ -47,6 +47,11 @@ $ view_type = 'desktop' if for_desktop else 'mobile'
       <h2 class="edition-byline">
         $ is_librarian = ctx.user and ctx.user.is_librarian()
         $:macros.BookByline([{'name': author.name, 'url': author.url(), 'birth_date': author.birth_date, 'death_date': author.death_date} for author in authors], attrs='itemprop="author"', show_years=is_librarian)
+    $# Display trending badge if trending score is above threshold
+    $if work and work.get('trending_z_score') and work.get('trending_z_score', 0) > 5:
+      <div class="trending-badge-container" style="margin-top: 10px;">
+        $:macros.TrendingBadge(work)
+      </div>
       </h2>
     $elif author_names:
       <h2 class="edition-byline">


### PR DESCRIPTION
Fixes #11072

## Summary
This PR adds the TrendingBadge macro to book pages when the book's trending_z_score is greater than 5.

## Changes
- Modified `openlibrary/templates/type/edition/title_and_author.html`
- Added conditional rendering of TrendingBadge when work.trending_z_score > 5
- Badge appears below author line, above star ratings

## Testing
- [x] Code follows project guidelines
- [x] Self-review completed
- [x] Commits are signed

## Notes
The TrendingBadge is already only visible to librarians, so this change maintains that behavior.