### PR TITLE
Add searchable date pickers for edition pages

### DIFF
--- a/openlibrary/plugins/openlibrary/js/add-book.js
+++ b/openlibrary/plugins/openlibrary/js/add-book.js
@@ -10,6 +10,7 @@ import {
     isValidOclc
 } from './idValidation.js'
 import { trimInputValues } from './utils.js';
+import { initSearchableDatePickers } from './date-picker.js';
 
 let invalidChecksum;
 let invalidIsbn10;
@@ -48,6 +49,21 @@ export function initAddBookImport () {
 
     trimInputValues('input')
 
+    // This converts date inputs (publish_date, birth_date, etc.) into edtf format
+    initSearchableDatePickers();
+    const publishDateInput = document.getElementById('publish_date');
+    if (publishDateInput) {
+        publishDateInput.removeAttribute('required'); // safe, JS will validate
+        // Watch for changes on the year/month/day dropdowns
+        const container = publishDateInput.previousElementSibling;
+        if (container && container.classList.contains('date-picker-dropdowns')) {
+            container.querySelectorAll('select').forEach(select => {
+                select.addEventListener('change', function() {
+                    validatePublishDate.call(publishDateInput);
+                });
+            });
+        }
+    }
     // Prevents submission if the publish date is > 1 year in the future
     addBookForm.on('submit', function() {
         if ($('#publish-date-errors').hasClass('hidden')) {

--- a/openlibrary/plugins/openlibrary/js/date-picker.js
+++ b/openlibrary/plugins/openlibrary/js/date-picker.js
@@ -1,0 +1,140 @@
+/**
+ * Replaces all text inputs with "date" in their name with Year/Month/Day dropdowns.
+ * Works for editions, authors, and any other pages in Open Library.
+ */
+export function initSearchableDatePickers() {
+    //console.log('DEBUG: initSearchableDatePickers running...');
+
+    const DAYS_IN_MONTH = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    const isLeapYear = (year) =>
+        year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+
+    // Automatically find all text inputs with "date" in the name
+    const dateInputs = Array.from(document.querySelectorAll('input[type="text"]'))
+        .filter(input => /date/i.test(input.name));
+
+    //console.log('DEBUG: Found date inputs:', dateInputs.map(i => i.name));
+
+    dateInputs.forEach(originalInput => {
+        //console.log(`DEBUG: Converting ${originalInput.name} to dropdowns...`);
+
+        // Hide original input
+        originalInput.type = 'hidden';
+        originalInput.classList.add('date-picker-hidden-input');
+
+        // Create container
+        const container = document.createElement('div');
+        container.className = 'date-picker-dropdowns';
+        container.style.display = 'inline-flex';
+        container.style.gap = '5px';
+
+        if (originalInput.parentNode) {
+            originalInput.parentNode.insertBefore(container, originalInput);
+        }
+
+        // Year dropdown
+        const yearSelect = document.createElement('select');
+        yearSelect.name = `${originalInput.name}_year`;
+
+        const currentYear = new Date().getFullYear();
+        const MIN_YEAR = 800; // you can change to 1000 or any year
+        let yearOptions = '<option value="">Year</option>';
+        for (let y = currentYear; y >= MIN_YEAR; y--) {
+            yearOptions += `<option value="${y}">${y}</option>`;
+        }
+        yearSelect.innerHTML = yearOptions;
+
+        // Month dropdown
+        const monthSelect = document.createElement('select');
+        monthSelect.name = `${originalInput.name}_month`;
+        monthSelect.innerHTML = '<option value="">Month</option>';
+
+        const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+        months.forEach((name,i) => {
+            monthSelect.innerHTML += `<option value="${i+1}">${name}</option>`;
+        });
+
+        // Day dropdown
+        const daySelect = document.createElement('select');
+        daySelect.name = `${originalInput.name}_day`;
+        daySelect.innerHTML = '<option value="">Day</option>';
+        for (let d = 1; d <= 31; d++) {
+            daySelect.innerHTML += `<option value="${d}">${d}</option>`;
+        }
+
+        container.appendChild(yearSelect);
+        container.appendChild(monthSelect);
+        container.appendChild(daySelect);
+
+        // Update day options based on month/year
+        const updateDayOptions = () => {
+            const year = Number(yearSelect.value);
+            const month = Number(monthSelect.value);
+            if (!month) return;
+
+            let daysInMonth = DAYS_IN_MONTH[month - 1];
+            if (month === 2 && year && isLeapYear(year)) ++daysInMonth;
+
+            const now = new Date();
+            const isCurrentYear = year === now.getFullYear();
+            const isCurrentMonth = isCurrentYear && month === now.getMonth() + 1;
+
+            for (let i = 0; i < daySelect.options.length; i++) {
+                const dayValue = Number(daySelect.options[i].value);
+                if (!dayValue) continue;
+                const isFutureDay = isCurrentMonth && dayValue > now.getDate();
+                daySelect.options[i].disabled = dayValue > daysInMonth || isFutureDay;
+                daySelect.options[i].classList.toggle('hidden', dayValue > daysInMonth);
+            }
+
+            if (Number(daySelect.value) > daysInMonth ||
+            (isCurrentMonth && Number(daySelect.value) > now.getDate())) {
+                daySelect.value = '';
+            }
+        };
+        const updateFutureMonths = () => {
+            const year = Number(yearSelect.value);
+            const now = new Date();
+            const isCurrentYear = year === now.getFullYear();
+
+            for (let i = 0; i < monthSelect.options.length; i++) {
+                const monthValue = Number(monthSelect.options[i].value);
+                if (!monthValue) continue;
+                monthSelect.options[i].disabled = isCurrentYear && monthValue > now.getMonth() + 1;
+            }
+
+            if (isCurrentYear && Number(monthSelect.value) > now.getMonth() + 1) {
+                monthSelect.value = '';
+                daySelect.value = '';
+            }
+        };
+        // Update hidden input value
+        const updateHiddenInput = () => {
+            const year = yearSelect.value;
+            const month = monthSelect.value;
+            const day = daySelect.value;
+
+            let dateStr = year || '';
+            if (year && month) {
+                dateStr += `-${String(month).padStart(2,'0')}`;
+                if (day) dateStr += `-${String(day).padStart(2,'0')}`;
+            }
+
+            originalInput.value = dateStr;
+            //console.log(`DEBUG: Date updated to: ${dateStr}`);
+        };
+
+        yearSelect.addEventListener('change', ()=>{ updateFutureMonths(); updateDayOptions(); updateHiddenInput(); });
+        monthSelect.addEventListener('change', ()=>{ updateDayOptions(); updateHiddenInput(); });
+        daySelect.addEventListener('change', updateHiddenInput);
+
+        // Pre-fill from existing value
+        if (originalInput.value) {
+            const parts = originalInput.value.split('-');
+            if (parts[0]) yearSelect.value = parts[0];
+            if (parts[1]) monthSelect.value = parseInt(parts[1],10);
+            if (parts[2]) daySelect.value = parseInt(parts[2],10);
+            updateDayOptions();
+        }
+    });
+}

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -12,6 +12,7 @@ import {
 import { init as initAutocomplete } from './autocomplete';
 import { init as initJqueryRepeat } from './jquery.repeat';
 import { trimInputValues } from './utils.js';
+import { initSearchableDatePickers } from './date-picker.js';
 
 /* global render_seed_field, render_language_field, render_lazy_work_preview, render_language_autocomplete_item, render_work_field, render_work_autocomplete_item */
 /* Globals are provided by the edit edition template */
@@ -526,6 +527,9 @@ export function initEdit() {
     var fieldname = `:input${hash.replace('/', '-')}`;
 
     trimInputValues('.olform input');
+
+    // This converts date inputs (publish_date, birth_date, etc.) into edtf format
+    initSearchableDatePickers();
 
     $(link).trigger('click');
 

--- a/openlibrary/templates/site/head.html
+++ b/openlibrary/templates/site/head.html
@@ -33,6 +33,7 @@ $def with (page)
     <link href="/static/images/openlibrary-128x128.png" rel="icon" sizes="128x128" />
     $# CSS Custom Properties (design tokens) - loaded separately for caching
     <link href="$static_url('build/css/tokens.css')" rel="stylesheet" type="text/css" />
+    <link href="$static_url('css/components/date-picker.css')" rel="stylesheet" type="text/css" />
     $ style = 'build/css/page-%s.css'%ctx.get('cssfile', 'user')
     <link href="$static_url(style)" rel="stylesheet" type="text/css" />
 

--- a/static/css/components/date-picker.css
+++ b/static/css/components/date-picker.css
@@ -1,0 +1,16 @@
+/* Styles for the date picker field */
+.date-picker-dropdowns {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.date-picker-dropdowns select {
+  padding: 4px;
+  border-radius: 4px;
+  border: 1px solid var(--lightgrey, rgb(204, 204, 204));
+}
+
+.date-picker-hidden-input {
+  display: none !important;
+}


### PR DESCRIPTION
Closes #7325 

On the Add books/ Edit Books page, it replaces plain text date inputs on Add/ Edit books pages with Year/Month/Day dropdowns for a better editing experience.

### Technical
- Added a `date-picker.js` file that auto-detects any input with "date" in the name and replaces it with dropdowns
- Added that into `edit.js` and `add-book.js` via `initSearchableDatePickers()`
- Added `date-picker.css` for basic styling and loaded it globally via `head.html`

### Testing
Go to Add Book

### Screenshot

https://github.com/user-attachments/assets/77e687e8-e26f-4d6f-b047-db6758c822d6


### Stakeholders
@lokesh 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
