### PR TITLE
refactor lists_json_post in prep for fastapi

### DIFF
--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -552,7 +552,23 @@ class lists_json(delegate.page):
         data = self.loads(web.data())
         # TODO: validate data
 
-        seeds = self.process_seeds(data.get("seeds", []))
+        try:
+            result = self.process_new_list(user, data, site)
+        except ValueError as e:
+            if str(e) == "Spam list":
+                raise self.forbidden()
+            raise
+        except client.ClientException as e:
+            headers = {"Content-Type": self.get_content_type()}
+            err_data = {"message": str(e)}
+            raise web.HTTPError(e.status, data=self.dumps(err_data), headers=headers)
+
+        web.header("Content-Type", self.get_content_type())
+        return delegate.RawText(self.dumps(result))
+
+    @staticmethod
+    def process_new_list(user, data, site):
+        seeds = lists_json.process_seeds(data.get("seeds", []))
 
         lst = user.new_list(
             name=data.get("name", ""),
@@ -562,22 +578,14 @@ class lists_json(delegate.page):
         )
 
         if spamcheck.is_spam(lst):
-            raise self.forbidden()
+            raise ValueError("Spam list")
 
-        try:
-            result = site.save(
-                lst.dict(),
-                comment="Created new list.",
-                action="lists",
-                data={"list": {"key": lst.key}, "seeds": seeds},
-            )
-        except client.ClientException as e:
-            headers = {"Content-Type": self.get_content_type()}
-            data = {"message": str(e)}
-            raise web.HTTPError(e.status, data=self.dumps(data), headers=headers)
-
-        web.header("Content-Type", self.get_content_type())
-        return delegate.RawText(self.dumps(result))
+        return site.save(
+            lst.dict(),
+            comment="Created new list.",
+            action="lists",
+            data={"list": {"key": lst.key}, "seeds": seeds},
+        )
 
     @staticmethod
     def process_seeds(


### PR DESCRIPTION
This will make it easier to migrate to FastAPI.


> PR #11991: Refactors lists_json_post in prep for fastapi
> Changes Made:
> 1. Extracts logic into new process_new_list static method
> 2. Changes self.process_seeds() → lists_json.process_seeds() (both are identical - call ListRecord.normalize_input_seed)
> 3. Spam check now raises ValueError("Spam list") caught by caller instead of directly calling self.forbidden()
> Risks: None identified
> The refactor is safe:
> - Both process_seeds implementations are identical
> - Error handling behavior is preserved
> - Uses same patterns as existing code (process_seeds_update already uses lists_json.process_seeds)
> - The new exception handling flow for spam produces the same result
> The PR is a straightforward extraction/refactor with no functional changes.