### PR TITLE
Add HMAC authentication to patron anonymization handler

### DIFF
--- a/openlibrary/core/auth.py
+++ b/openlibrary/core/auth.py
@@ -16,7 +16,13 @@ class MissingKeyError(Exception):
 
 class HMACToken:
     @staticmethod
-    def verify(digest: str, msg: str, secret_key_name: str, delimiter: str = "|", unix_time=False) -> bool:
+    def verify(
+        digest: str,
+        msg: str,
+        secret_key_name: str,
+        delimiter: str = "|",
+        unix_time=False,
+    ) -> bool:
         """
         Verify an HMAC digest against a message with timestamp validation.
 
@@ -54,10 +60,16 @@ class HMACToken:
 
         err: Exception | None = None
 
-        current_time: float | datetime.datetime = time.time() if unix_time else datetime.datetime.now(datetime.UTC)
+        current_time: float | datetime.datetime = (
+            time.time() if unix_time else datetime.datetime.now(datetime.UTC)
+        )
         expiry_str = msg.rsplit(delimiter, maxsplit=1)[-1]
         try:
-            expiry: float | datetime.datetime = float(expiry_str) if unix_time else datetime.datetime.fromisoformat(expiry_str)
+            expiry: float | datetime.datetime = (
+                float(expiry_str)
+                if unix_time
+                else datetime.datetime.fromisoformat(expiry_str)
+            )
         except ValueError:
             err = ValueError("Invalid timestamp format")
             expiry = 0

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -1260,12 +1260,18 @@ class account_anonymization_json(delegate.page):
         msg = i.msg
 
         try:
-            if not HMACToken.verify(digest, msg, "ia_sync_secret", delimiter=":", unix_time=True):
-                raise web.HTTPError("401 Unauthorized", {"Content-Type": "application/json"})
+            if not HMACToken.verify(
+                digest, msg, "ia_sync_secret", delimiter=":", unix_time=True
+            ):
+                raise web.HTTPError(
+                    "401 Unauthorized", {"Content-Type": "application/json"}
+                )
         except ValueError:
             raise web.HTTPError("400 Bad Request", {"Content-Type": "application/json"})
         except ExpiredTokenError:
-            raise web.HTTPError("401 Unauthorized", {"Content-Type": "application/json"})
+            raise web.HTTPError(
+                "401 Unauthorized", {"Content-Type": "application/json"}
+            )
         except MissingKeyError:
             raise web.HTTPError(
                 "503 Service Unavailable", {"Content-Type": "application/json"}


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Supports #10976
Follows #11053 #11111

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds HMAC authentication to the patron anonymization handler.  The HMAC message is expected to be colon-delimited.  The expiry time must be a Unix timestamp in seconds, and may include a fraction of a second.

Handler will return different error codes, depending on what went wrong:

| Issue | HTTP Response |
|---|---|
| Improperly formed message (including timestamp) | `400 Bad Request` |
| Token has expired | `401 Unauthorized` |
| HMAC digest mismatch | `401 Unauthorized` |
| Misconfigured secret | `503 Service Unavailable` |

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
