### PR TITLE
Return JSON when IA->OL unlink request fails

### DIFF
--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -993,11 +993,7 @@ class unlink_ia_ol(delegate.page):
         ocaid, ts = msg.split("|")
 
         if not ts or not ocaid:
-            raise web.HTTPError(
-                "400 Bad Request",
-                {"Content-Type": "application/json"},
-                data=json.dumps({"error": "Invalid inputs"})
-            )
+            raise web.HTTPError("400 Bad Request", {"Content-Type": "application/json"}, data=json.dumps({"error": "Invalid inputs"}))
 
         # Fetch affected editions
         if not (edition_keys := web.ctx.site.things({"type": "/type/edition", "ocaid": ocaid})):
@@ -1018,11 +1014,7 @@ class unlink_ia_ol(delegate.page):
             self.make_dark(edition)
         except ClientException as e:
             logger.error(f"Failed to disassociate record with key {edition.key}", exc_info=True)
-            raise web.HTTPError(
-                "500 Internal Server Error",
-                {"Content-Type": "application/json"},
-                data=json.dumps({"error": str(e)})
-            )
+            raise web.HTTPError("500 Internal Server Error", {"Content-Type": "application/json"}, data=json.dumps({"error": str(e)}))
 
         return delegate.RawText(json.dumps({"status": "ok"}))
 

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -988,21 +988,26 @@ class unlink_ia_ol(delegate.page):
         try:
             HMACToken.verify(digest, msg, "ia_sync_secret")
         except (ValueError, ExpiredTokenError):
-            raise web.HTTPError("401 Unauthorized")
+            raise web.HTTPError("401 Unauthorized", {"Content-Type": "application/json"})
 
         ocaid, ts = msg.split("|")
 
         if not ts or not ocaid:
-            raise web.HTTPError("400 Bad Request", data=json.dumps({"error": "Invalid inputs"}))
+            raise web.HTTPError(
+                "400 Bad Request",
+                {"Content-Type": "application/json"},
+                data=json.dumps({"error": "Invalid inputs"})
+            )
 
         # Fetch affected editions
         if not (edition_keys := web.ctx.site.things({"type": "/type/edition", "ocaid": ocaid})):
-            raise web.HTTPError("404 Not Found")
+            raise web.HTTPError("404 Not Found", {"Content-Type": "application/json"})
 
         editions = [web.ctx.site.get(key) for key in edition_keys]
         if len(editions) > 1:
             raise web.HTTPError(
                 "409 Conflict",
+                {"Content-Type": "application/json"},
                 data=json.dumps({"error": "Multiple editions associated with given ocaid"}),
             )
 
@@ -1013,7 +1018,11 @@ class unlink_ia_ol(delegate.page):
             self.make_dark(edition)
         except ClientException as e:
             logger.error(f"Failed to disassociate record with key {edition.key}", exc_info=True)
-            raise web.HTTPError("500 Internal Server Error", data=json.dumps({"error": str(e)}))
+            raise web.HTTPError(
+                "500 Internal Server Error",
+                {"Content-Type": "application/json"},
+                data=json.dumps({"error": str(e)})
+            )
 
         return delegate.RawText(json.dumps({"status": "ok"}))
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Follows #11230

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Updates record unlink handler such that it returns JSON when an error occurs.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
