### PR TITLE
fix: preserve spaces around inline HTML tags in reformat_html

### DIFF
--- a/openlibrary/plugins/upstream/tests/test_utils.py
+++ b/openlibrary/plugins/upstream/tests/test_utils.py
@@ -162,6 +162,13 @@ def test_reformat_html():
     assert f("<script>alert('hello')</script>", 34) == "alert(&#39;hello&#39;)"
     assert f("&lt;script&gt;") == "&lt;script&gt;"
 
+    assert f("<p>Hello <strong>world</strong> foo</p>") == "Hello world foo"
+    assert f("<p>This <em>is</em> a test</p>") == "This is a test"
+    assert f("<p>a <b>b</b> <i>c</i> d</p>") == "a b c d"
+    assert f("<p>end<strong>word</strong></p>") == "endword"
+    assert f("<p>Hello <strong> world </strong> foo</p>") == "Hello world foo"
+    assert f("<p>Hello <strong>world\nstill strong</strong> foo</p>") == "Hello world still strong foo"
+
 
 def test_strip_accents():
     f = utils.strip_accents

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -1563,16 +1563,20 @@ def to_datetime(time: str):
     return datetime.datetime.fromisoformat(time)
 
 
+_BLOCK_SEP = object()
+
+
 class HTMLTagRemover(HTMLParser):
     def __init__(self):
         super().__init__()
         self.data = []
 
     def handle_data(self, data):
-        self.data.append(data.strip())
+        self.data.append(re.sub(r'\s+', ' ', data))
 
     def handle_endtag(self, tag):
-        self.data.append('\n' if tag in ('p', 'li') else ' ')
+        if tag in ('p', 'li'):
+            self.data.append(_BLOCK_SEP)
 
 
 @public
@@ -1593,12 +1597,20 @@ def reformat_html(html_str: str, max_length: int | None = None) -> str:
     parser = HTMLTagRemover()
     # Must have a root node, otherwise the parser will fail
     parser.feed(f'<div>{html_str}</div>')
-    content = [web.websafe(s) for s in parser.data if s]
+    parts = []
+    for s in parser.data:
+        if s is _BLOCK_SEP:
+            parts.append('\n')
+        else:
+            parts.append(web.websafe(s))
+
+    lines = [re.sub(r' {2,}', ' ', line.strip()) for line in ''.join(parts).split('\n')]
+    result = re.sub(r'\n{2,}', '\n', '\n'.join(lines)).strip()
 
     if max_length:
-        return truncate(''.join(content), max_length).strip().replace('\n', '<br>')
+        return truncate(result, max_length).strip().replace('\n', '<br>')
     else:
-        return ''.join(content).strip().replace('\n', '<br>')
+        return result.replace('\n', '<br>')
 
 
 def get_colon_only_loc_pub(pair: str) -> tuple[str, str]:


### PR DESCRIPTION
fixes #12039

### Technical
`HTMLTagRemover.handle_data` was calling `.strip()` on every text node, which 
destroyed word-boundary spaces around inline tags like `<strong>`, `<em>`, `<b>`.

For example:
`<p>Hello <strong>world</strong> foo</p>` → `"Helloworld foo"` that's wrong

Three changes in `utils.py`:

- **`handle_data`** — replaced `.strip()` with `re.sub(r'\s+', ' ', data)` to 
  preserve word-boundary spaces while still normalizing internal whitespace and 
  collapsing source newlines inside inline tags
- **`handle_endtag`** — replaced the `'\n'`/`' '` string approach with a 
  `_BLOCK_SEP` sentinel object for block tags (`p`, `li`) only. Prevents 
  source indentation whitespace between block tags from being mistaken for 
  paragraph separators
- **`reformat_html`** — iterates sentinel-aware parts, strips per-line to remove 
  source indentation, collapses double spaces, then strips the final result

### Testing
Run the existing test suite:
```bash
pytest openlibrary/plugins/upstream/tests/test_utils.py::test_reformat_html
```

All 13 tests pass (7 pre-existing + 6 new).

New cases verified:

| Input | Expected output |
|---|---|
| `<p>Hello <strong>world</strong> foo</p>` | `Hello world foo` |
| `<p>This <em>is</em> a test</p>` | `This is a test` |
| `<p>a <b>b</b> <i>c</i> d</p>` | `a b c d` |
| `<p>end<strong>word</strong></p>` | `endword` |
| `<p>Hello <strong> world </strong> foo</p>` | `Hello world foo` |
| `<p>Hello <strong>world\nstill strong</strong> foo</p>` | `Hello world still strong foo` |

### Screenshot
N/A — no UI changes.

### Stakeholders
N/A