### PR TITLE
use @cache instead of @web.memoize for i18n

### DIFF
--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 from collections.abc import Iterator
 from datetime import datetime
+from functools import cache
 from io import BytesIO
 from pathlib import Path
 
@@ -347,7 +348,7 @@ def generate_po(args):
         print("Add failed. Missing required locale code.")
 
 
-@web.memoize
+@cache
 def load_translations(lang):
     mo_path = os.path.join(root, lang, 'messages.mo')
 
@@ -355,7 +356,7 @@ def load_translations(lang):
         return Translations(open(mo_path, 'rb'))
 
 
-@web.memoize
+@cache
 def load_locale(lang):
     try:
         return babel.Locale(lang)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes https://internetarchive.slack.com/archives/C0ETZV72L/p1772748535300209?thread_ts=1772727915.711609&cid=C0ETZV72L

Sentry error:

> TypeError: join() argument must be str, bytes, or os.PathLike object, not 'NoneType'
> /partials/*.json

<img width="1341" height="465" alt="image" src="https://github.com/user-attachments/assets/34d2f32a-2ce6-49ce-913e-30a893d4a93c" />


Per above discussion, we should switch to the standard cache and stop using this memoize implementation. It introduces thread-related behavior.

This matters now because with partials running in FastAPI, we’re seeing intermittent, hard-to-reproduce errors that strongly suggest a threading interaction.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
