### PR TITLE
remove duplicate setup call

### DIFF
--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -411,6 +411,3 @@ def setup():
     )
 
     web.template.STATEMENT_NODES["jsdef"] = jsdef.JSDefNode
-
-
-setup()


### PR DESCRIPTION
Stop-gap fix for #12032 

This pull request makes a minor update to the `openlibrary/plugins/upstream/code.py` file. The change removes an unnecessary call to the `setup()` function at the end of the file.