### PR TITLE
Issue refinement workflow bug fixes and improvements

### DIFF
--- a/.github/workflows/issue_refinement.md
+++ b/.github/workflows/issue_refinement.md
@@ -33,8 +33,8 @@ Run this workflow when:
 2. Staff adds an eyes reaction (:eyes:) to an issue.
 
 If an issue does not meet this criteria (i.e. the issue is by non-staff)...
-- If the issue is a `Type: Question`, reply, "Please consider posting questions to our [Discussions](https://github.com/internetarchive/openlibrary/discussions) board." Do not otherwise engage in the thread unless staff prompts you with :eyes:
-- If the issue is a `Feature Request`, reply, "This feature request has not yet been reviewed or approved by staff. Please wait for staff to triage and appoint a `Lead` and a `Priority`. "
+- If the issue is a `Type: Question`, reply, "Thanks for reaching out! You may also get a faster response by posting on our [Discussions](https://github.com/internetarchive/openlibrary/discussions) board." Do not otherwise engage in the thread unless staff prompts you with :eyes:
+- If the issue is a `Feature Request`, reply, "Thanks for the suggestion! A staff member will review this and follow up when they can." Do not otherwise engage in the thread unless staff prompts you with :eyes:
 
 
 Skip if:
@@ -78,24 +78,6 @@ Apply labels in this priority order:
 
 **CRITICAL**: Never add `Priority:` labels or remove `Needs: Triage`. Only staff can set priority.
 
-## File Identification Keywords
-
-Map issue keywords to likely relevant files:
-
-| Keywords                             | Likely Files                                                                        |
-| ------------------------------------ | ----------------------------------------------------------------------------------- |
-| borrow, lending, loan, borrow.py     | `openlibrary/plugins/upstream/borrow.py`, `openlibrary/plugins/upstream/mybooks.py` |
-| account, login, auth, authentication | `openlibrary/plugins/upstream/account.py`, `openlibrary/accounts/`                  |
-| search, solr                         | `openlibrary/plugins/worksearch/`, `openlibrary/solr/`                              |
-| book, edit, metadata, catalog        | `openlibrary/plugins/upstream/addbook.py`, `openlibrary/catalog/`                   |
-| author                               | `openlibrary/plugins/upstream/authors.py`,                                          |
-| isbn, identifier                     | `openlibrary/catalog/isbn/`                                                         |
-| frontend, ui, css, style             | `static/css/`, `openlibrary/components/`, `openlibrary/plugins/openlibrary/js/`     |
-| vue, component                       | `openlibrary/components/`, `openlibrary/plugins/openlibrary/js/components/`         |
-| docker, dev, setup                   | `docker/`, `docker-compose.yml`, `Makefile`                                         |
-| api, endpoint, route                 | `openlibrary/plugins/` (various code.py files)                                      |
-| test, testing                        | `openlibrary/tests/`, `tests/`                                                      |
-| solr indexing                        | `openlibrary/solr/`                                                                 |
 
 ## Stakeholder @Mentioning
 
@@ -121,57 +103,33 @@ After analysis, @mention relevant staff (and reasoning) based on:
 First, you will apply any relevant blessed labels:
 [`Type: Bug`, `Needs: Lead`, `Module: Solr`, ...]
 
-Next, generate a well-structured comment:
+Next, generate a well-structured comment. Always include the core sections; add optional sections only when relevant.
 
 ```
 ## Issue Refinement
 
 ### Summary
+Brief recap of the problem, who or what it affects, and the proposed solution (or note if a proposal is missing).
 
-Brief recap of problem, who (or what metric or system) it affects, the opportunity, reasoning/justification of importance, and proposal (or if proposal is missing/needs clarification).
+### Relevant Files
+- [`path/to/file.py#L1-L30`](link) - [why relevant]
+[Link to relevant commits if helpful, max 3]
 
-### Requirements
+### Related Issues & PRs
+[List/link max 3 related issues or PRs with their states]
 
-### Success Criteria
+### 🔔 Stakeholders
+[@mention relevant staff based on file ownership, with brief reasoning]
 
-If known, how we'd know the effort is a success or what tests help us confirm the issue is resolved.
-
-### Relevant Files, Components, & Changes
-[File path with blob link to specific lines - only if confident]
-- [`path/to/file.py#L1-L30`](link) - [why relevant, key functions/classes]
-
-[Short list (max 3) of any reference commits that implicate these files as relevant to this issue or its subsystems]
-
-### Related Issues, PRs, Dependencies
-[Find and list/link (max 3) related issues with their states]
-
-### Risks, Considerations, Uncertainties
-
-Note any gotchas, things that could cause data loss, internationalization, race conditions, confusions, tensions, or open questions that may prevent progress.
-
-### 🔔 Stakeholders Notified
-[@mention relevant staff based on file ownership]
-
-### Prescriptions
-[Technical guidance - NOT product decisions]
-- [If no lead]: This issue needs a lead to review and assign priority before work begins
-- [If unclear]: e.g. `Needs: Breakdown` (if too big, not well scoped), `Needs: Investigation` (if causes or effects unknown), `Needs: Designs` (if design approach or implementation unclear), `Needs: Detail` (if unclear; list clarifying questions)
-- [If staff-only]: e.g. `Needs: Staff / Internal`, issue requires staff access to keys, internal systems, or test/prod environment.
+<!-- Optional sections — include only when relevant -->
+### Risks & Open Questions
+[Gotchas, data loss concerns, race conditions, or blocking questions]
 
 ---
-
-_Issue Refinement Assistant — Senior Technical Consultant_
+_Issue Refinement Assistant_
 _This is NOT a sign-off. This issue needs lead review before work begins._
 ```
 
-## Technical Question Answering
-
-If the issue or its comments contain specific technical questions:
-
-- Answer helpfully with specific file paths, function names, or code references
-- Provide debugging strategies or reproduction steps if applicable
-- Link to relevant documentation or wiki pages
-- **DO NOT**: Make product decisions, suggest timelines, or approve approaches
 
 ## Spam/Bot Detection
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11982

  Bug fixes:
  - **Fix feedback loop: skip issues created by github-actions[bot] or with the agentic-workflows label
   so the workflow doesn't trigger on its own failure reports**
  - Fix broken markdown table row for "JavaScript related" / "API" labels
  - Fix duplicate @seabelis in staff list
  - Fix "documentsion" typo

Improvements:
  - Change agent tone from "salty but gracious" to "professional and helpful"
  - Soften auto-replies to non-staff contributors (questions and feature requests) to be welcoming
  rather than gatekeepy
  - Scope spam detection to non-staff issues only — don't flag staff-created issues as spam
  - Simplify response comment template: trimmed from 7 mandatory sections to 4 core sections
  (Summary, Relevant Files, Related Issues, Stakeholders) with optional Risks section
  - Remove static File Identification Keywords table that would drift out of date (the agent already
  discovers files via search and git blame)
  - Remove redundant Technical Question Answering section (already covered by the Role section)

### Stakeholders

@mekarpeles @RayBB 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
