### PR TITLE
Make pre-commit autoupdate PRs monthly instead of weekly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ default_language_version:
 
 ci:
   submodules: true
+  autoupdate_schedule: "monthly"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
Small config change. Updates to pre-commit tend to cause pre-commit to be much slower during its next run, since it needs to load the latest versions. We don't need to be bleeding edge, so monthly seems like a better setting than weekly to allow us to stay up-to-date, without the unnecessary reviews/slow pre-commit runs.

See docs here: https://pre-commit.ci/#configuration-autoupdate_schedule


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
