### PR TITLE
Rely on infogami-style setup to avoid duplicate setup calls

### DIFF
--- a/openlibrary/code.py
+++ b/openlibrary/code.py
@@ -10,14 +10,7 @@ import sys
 
 import infogami
 from infogami.utils.app import pages
-from openlibrary.plugins.admin.code import setup as admin_setup
-from openlibrary.plugins.books.code import setup as books_setup
-from openlibrary.plugins.importapi.code import setup as importapi_setup
-from openlibrary.plugins.inside.code import setup as inside_setup
 from openlibrary.plugins.openlibrary import deprecated_handler
-from openlibrary.plugins.openlibrary.code import setup as openlibrary_setup
-from openlibrary.plugins.upstream.code import setup as upstream_setup
-from openlibrary.plugins.worksearch.code import setup as worksearch_setup
 
 
 def setup():
@@ -26,15 +19,16 @@ def setup():
     logger = logging.getLogger("openlibrary")
     logger.info("Application init")
 
-    # Calling the setup function itself may not be strictly needed in all cases.
-    # However, by importing the functions, we ensure the side effects are executed.
-    openlibrary_setup()
-    worksearch_setup()
-    inside_setup()
-    books_setup()
-    admin_setup()
-    upstream_setup()
-    importapi_setup()
+    # In infogami, importing a module has the side effect of registering any endpoints
+    # defined in that module, so we just need to import all the modules that define
+    # endpoints to register them.
+    import openlibrary.plugins.openlibrary.code  # noqa: I001 registers endpoints
+    import openlibrary.plugins.worksearch.code
+    import openlibrary.plugins.inside.code
+    import openlibrary.plugins.books.code
+    import openlibrary.plugins.admin.code
+    import openlibrary.plugins.upstream.code
+    import openlibrary.plugins.importapi.code  # noqa: F401 registers endpoints
 
     # Register deprecated endpoint handlers AFTER all plugins have loaded
     # This must be done here, after all plugins are imported, to ensure our handlers


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #12034 

This isn't ideal, but this `setup` pattern is used profusely and recursively throughout the codebase; including in infogami. To close the P0 and remove the risk of double-running sensitive internals, this seems like the quickest, simplest approach.


### Technical
<!-- What should be noted about the implementation? -->

In infogami we often use a pattern like this to define an endpoint:

```py
class scan(delegate.page):
    path = "/barcodescanner"

    def GET(self):
        return render.barcodescanner()
```

Sub-classing `delegate.page` is enough to register the endpoint. But if the file is never imported, that sub-classing never happens! So the pattern that infogami/webpy use is to have a setup method in the bottom of every file that contains endpoints, like this:

```py
class scan(delegate.page):
    ...

def setup():
    # Importing calls _others'_ setup methods
    from openlibrary.plugins.worksearch import autocomplete

setup()
```

This is a problematic pattern, because it makes it incredibly easy to:

1) Forget to create this magic setup method, which would cause nothing to happen
2) Accidentally register another file's endpoints just by importing, and not include it in the setup method
3) Makes it impossible to import any methods/helpers without also registering endpoints

A better approach is to make it explicit, as #11762 does:

```py
class scan(delegate.page):
    ...

def setup():
    from openlibrary.plugins.worksearch import autocomplete import setup as autocomplete_setup

    autocomplete_setup()
```

This decouples the setup from the import, but again still has the magic endpoint definition. And the new issue introduced is that we can now call these setup methods twice, resulting in undefined behaviour.

This is possibly also complicated by the `@public` decorator, which also requires being called at the correct point in the infogami import life-cycle.


### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

No duplicate headers on testing or prod.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
