### PR TITLE
Add --no-install-recommends to apt-get install in Dockerfile.olbase

### DIFF
--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -14,7 +14,7 @@ RUN groupadd --system --gid 999 openlibrary \
   && useradd --no-log-init --system -u 999 --gid openlibrary --create-home openlibrary
 
 # Misc OL dependencies
-RUN apt-get -qq update && apt-get install -y \
+RUN apt-get -qq update && apt-get install -y --no-install-recommends \
     postgresql-client \
     build-essential \
     git \


### PR DESCRIPTION
Adds --no-install-recommends flag to the apt-get install command in  docker/Dockerfile.olbase (line 17) . This reduces the image layer size by ~100MB based on  previous testing, without breaking any functionality.  Happy to help.

