### PR TITLE
fix partials user access in fastapi

### DIFF
--- a/openlibrary/accounts/__init__.py
+++ b/openlibrary/accounts/__init__.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING
 
 import web
 
+from infogami.utils.view import public
 from openlibrary.utils.request_context import site
 
 # FIXME: several modules import things from accounts.model
@@ -52,6 +53,7 @@ class RunAs:
 
 
 # Confirmed functions (these have to be here)
+@public
 def get_current_user() -> "User | None":
     """
     Returns the currently logged in user. None if not logged in.

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -15,7 +15,8 @@ $ ocaid = doc.get('ocaid') or availability.get('identifier')
 $ work_key = work_key or (doc.get('works') and doc.works[0]['key'])
 
 $ waiting_loan_start_time = time()
-$ waiting_loan = check_loan_status and ocaid and ctx.user and ctx.user.get_user_waiting_loans(ocaid, use_cache=True)
+$ user = get_current_user()
+$ waiting_loan = check_loan_status and ocaid and user and user.get_user_waiting_loans(ocaid, use_cache=True)
 $ waiting_loan_total_time = time() - waiting_loan_start_time
 $ my_turn_to_borrow = waiting_loan and waiting_loan['status'] == 'available' and waiting_loan['position'] == 1
 

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -10,6 +10,7 @@ from typing_extensions import deprecated
 
 from infogami.utils import delegate
 from infogami.utils.view import render_template
+from openlibrary.accounts import get_current_user
 from openlibrary.core.fulltext import fulltext_search
 from openlibrary.core.lending import compose_ia_url, get_available
 from openlibrary.i18n import gettext as _
@@ -254,6 +255,10 @@ class SearchFacetsPartial(PartialDataHandler):
 
     def __init__(self, data: dict | None = None, sfw: bool = False):
         self.sfw = sfw
+        user = get_current_user()
+        self.show_merge_authors = user and (
+            user.is_librarian() or user.is_super_librarian() or user.is_admin()
+        )
         if data is None:
             i = web.input(data=None)
             self.data = json.loads(i.data) if i.data else {}
@@ -284,6 +289,7 @@ class SearchFacetsPartial(PartialDataHandler):
             async_load=False,
             path=path,
             query=parsed_qs,
+            show_merge_authors=self.show_merge_authors,
         )
 
         active_facets = render_template(

--- a/openlibrary/templates/lists/carousel.html
+++ b/openlibrary/templates/lists/carousel.html
@@ -1,6 +1,7 @@
 $def with (lists, all_url)
 
-$ user_key = ctx.user and ctx.user.key
+$ user = get_current_user()
+$ user_key = user and user.key
 <div class="carousel-section">
     <div class="list-follow-showcase">
         $:render_template('lists/list_follow', lists, 5, user_key)

--- a/openlibrary/templates/search/work_search_facets.html
+++ b/openlibrary/templates/search/work_search_facets.html
@@ -1,4 +1,4 @@
-$def with (param, facet_counts=None, async_load=True, path=None, query={})
+$def with (param, facet_counts=None, async_load=True, path=None, query={}, show_merge_authors=False)
 
 $code:
     start_facet_count = 5
@@ -30,7 +30,7 @@ $code:
 $def facet(header, label, counts):
     <div class="facet $header">
         $ magic_wand_markup = ''
-        $if header == 'author_key' and len(counts) > 1 and ctx.user and ("merge-authors" in ctx.features or ctx.user.is_admin()):
+        $if header == 'author_key' and len(counts) > 1 and show_merge_authors:
             $ keys = ','.join(k for k, display, count in counts)
             $ magic_wand_markup = ' <span class="merge"><a href="/authors/merge?records=%s" title="%s">%s</a></span>' % (keys, _('Merge duplicate authors from this search'), _("Merge duplicates"))
         <h4 class="facetHead">$(label)$:(magic_wand_markup)</h4>


### PR DESCRIPTION
Closes #12023

The **Merge authors** button was not appearing in the facet.

The root cause is that `ctx.X` values such as `ctx.user` and `ctx.features` are not available in templates rendered from the FastAPI context.

This change fixes that by moving the relevant logic out of the template and into Python before rendering. It also calls `get_current_user` in other templates that are used by partials. Ideally, FastAPI-rendered templates would have access to the same feature/context data, but we do not have a general solution for that yet. For this case, simplifying the logic ahead of time seems like the most practical approach.

Another possible improvement would be to make template rendering fail loudly when a template tries to access `ctx` in a FastAPI-rendered page, though it is not yet clear what the best way to implement that would be.

More broadly, I am working on supporting HTML page rendering through FastAPI. That is already functional in principle, but the overall approach is still unsettled because many pages currently depend on `ctx.X`. This PR addresses one instance of that problem, and the wider issue will need a more complete solution soon.



### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
