### PR TITLE
Add missing languages to languages.page

### DIFF
--- a/openlibrary/plugins/openlibrary/pages/languages.page
+++ b/openlibrary/plugins/openlibrary/pages/languages.page
@@ -2695,42 +2695,6 @@
     "key": "/languages/syc"
   },
   {
-    "code": "sga",
-    "type": "/type/language",
-    "name": "Irish, Old (to 1100)",
-    "key": "/languages/sga"
-  },
-  {
-    "code": "sgn",
-    "type": "/type/language",
-    "name": "Sign languages",
-    "key": "/languages/sgn"
-  },
-  {
-    "code": "sma",
-    "type": "/type/language",
-    "name": "Southern Sami",
-    "key": "/languages/sma"
-  },
-  {
-    "code": "smj",
-    "type": "/type/language",
-    "name": "Lule Sami",
-    "key": "/languages/smj"
-  },
-  {
-    "code": "smn",
-    "type": "/type/language",
-    "name": "Inari Sami",
-    "key": "/languages/smn"
-  },
-  {
-    "code": "sms",
-    "type": "/type/language",
-    "name": "Skolt Sami",
-    "key": "/languages/sms"
-  },
-  {
     "code": "syr",
     "type": "/type/language",
     "name": "Syriac, Modern",


### PR DESCRIPTION
Closes #11989 

Added missing ISO language entries to languages.page.

The languages were inserted in the correct alphabetical order based on the `code` field and follow the same structure and format as the existing entries in the file.