### PR TITLE
refactor: replace @web.memoize with @functools.cache

### DIFF
--- a/openlibrary/core/db.py
+++ b/openlibrary/core/db.py
@@ -1,5 +1,6 @@
 """Interface to access the database of openlibrary."""
 
+import functools
 import sqlite3
 from datetime import datetime
 from sqlite3 import IntegrityError
@@ -10,7 +11,7 @@ from psycopg2.errors import UniqueViolation
 from infogami.utils import stats
 
 
-@web.memoize
+@functools.cache
 def _get_db():
     return web.database(**web.config.db_parameters)
 

--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -1,5 +1,6 @@
 """Generic helper functions to use in the templates and the webapp."""
 
+import functools
 import json
 import re
 from collections.abc import Callable, Iterable
@@ -218,7 +219,7 @@ def urlsafe(path: str) -> str:
     return _get_safepath_re().sub('_', path).strip('_')[:100]
 
 
-@web.memoize
+@functools.cache
 def _get_safepath_re():
     """Make regular expression that matches all unsafe chars."""
     # unsafe chars according to RFC 2396

--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -1,5 +1,6 @@
 import array
 import datetime
+import functools
 import io
 import itertools
 import json
@@ -391,7 +392,7 @@ class cover:
         return _query(category, key, value)
 
 
-@web.memoize
+@functools.cache
 def get_tar_index(tarindex, size):
     path = os.path.join(config.data_root, get_tarindex_path(tarindex, size))
     if not os.path.exists(path):

--- a/openlibrary/coverstore/oldb.py
+++ b/openlibrary/coverstore/oldb.py
@@ -1,5 +1,6 @@
 """Library to talk directly to OL database to avoid expensive API calls."""
 
+import functools
 import json
 
 import web
@@ -34,7 +35,7 @@ def get_memcache():
     return _memcache
 
 
-@web.memoize
+@functools.cache
 def get_property_id(name):
     db = get_db()
     try:

--- a/openlibrary/data/db.py
+++ b/openlibrary/data/db.py
@@ -21,6 +21,7 @@ Each doc is a storage object with "id", "key", "revision" and "data".
 """
 
 import datetime
+import functools
 import json
 import sys
 import time
@@ -224,6 +225,6 @@ def debug(*a):
     print(time.asctime(), a, file=sys.stderr)
 
 
-@web.memoize
+@functools.cache
 def get_thing_id(key):
     return db.query("SELECT * FROM thing WHERE key=$key", vars=locals())[0].id

--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -1,10 +1,10 @@
+import functools
 import os
 import shutil
 import subprocess
 import sys
 from collections.abc import Iterator
 from datetime import datetime
-from functools import cache
 from io import BytesIO
 from pathlib import Path
 
@@ -348,7 +348,7 @@ def generate_po(args):
         print("Add failed. Missing required locale code.")
 
 
-@cache
+@functools.cache
 def load_translations(lang):
     mo_path = os.path.join(root, lang, 'messages.mo')
 
@@ -356,7 +356,7 @@ def load_translations(lang):
         return Translations(open(mo_path, 'rb'))
 
 
-@cache
+@functools.cache
 def load_locale(lang):
     try:
         return babel.Locale(lang)

--- a/openlibrary/olbase/events.py
+++ b/openlibrary/olbase/events.py
@@ -8,6 +8,7 @@ List of events:
     * infobase.edit: Triggered for edits. Changeset is passed as argument.
 """
 
+import functools
 import logging
 
 import eventer
@@ -126,7 +127,7 @@ class MemcacheInvalidater:
             return "/subjects/" + seed
 
 
-@web.memoize
+@functools.cache
 def get_memcache():
     """Returns memcache client created from infobase configuration."""
     cache = config.get("cache", {})

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -1,5 +1,6 @@
 """Plugin to provide admin interface."""
 
+import functools
 import json
 import logging
 import os
@@ -217,7 +218,7 @@ class reload:
                 yield "<p><pre>%s</pre></p>" % traceback.format_exc()
 
 
-@web.memoize
+@functools.cache
 def local_ip():
 
     return socket.gethostbyname(socket.gethostname())

--- a/openlibrary/plugins/ol_infobase.py
+++ b/openlibrary/plugins/ol_infobase.py
@@ -2,6 +2,7 @@
 """Open Library plugin for infobase."""
 
 import datetime
+import functools
 import json
 import logging
 import logging.config
@@ -13,7 +14,8 @@ import traceback
 import requests
 import web
 
-from infogami.infobase import cache, common, config, dbstore, server
+from infogami.infobase import cache as _ib_cache
+from infogami.infobase import common, config, dbstore, server
 from openlibrary.plugins.upstream.utils import strip_accents
 
 from ..utils.isbn import isbn_10_to_isbn_13, isbn_13_to_isbn_10, normalize_isbn
@@ -121,7 +123,7 @@ def get_db():
     return site.store.db
 
 
-@web.memoize
+@functools.cache
 def get_property_id(type, name):
     db = get_db()
     type_id = get_thing_id(type)
@@ -451,10 +453,10 @@ def MemcachedDict(servers=None):
     servers = servers or []
     """Cache implementation with OL customized memcache client."""
     client = olmemcache.Client(servers)
-    return cache.MemcachedDict(memcache_client=client)
+    return _ib_cache.MemcachedDict(memcache_client=client)
 
 
-cache.register_cache('memcache', MemcachedDict)
+_ib_cache.register_cache('memcache', MemcachedDict)
 
 
 def _process_key(key):

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -3,6 +3,7 @@ Open Library Plugin.
 """
 
 import datetime
+import functools
 import gzip
 import json
 import logging
@@ -481,7 +482,7 @@ class robotstxt(delegate.page):
         return web.ok(open(f'static/{robots_file}').read())
 
 
-@web.memoize
+@functools.cache
 def fetch_ia_js(filename: str) -> str:
     return requests.get(f'https://archive.org/includes/{filename}').text
 

--- a/openlibrary/plugins/openlibrary/connection.py
+++ b/openlibrary/plugins/openlibrary/connection.py
@@ -1,6 +1,7 @@
 """Open Library extension to provide a new kind of client connection with caching support."""
 
 import datetime
+import functools
 import json
 import logging
 
@@ -564,7 +565,7 @@ class HybridConnection(client.Connection):
             return self.writer.request(sitename, path, method, data=data)
 
 
-@web.memoize
+@functools.cache
 def _update_infobase_config():
     """Updates infobase config when this function is called for the first time.
 

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -1,6 +1,7 @@
 """Upstream customizations."""
 
 import datetime
+import functools
 import hashlib
 import json
 import os.path
@@ -158,7 +159,7 @@ class merge_work(delegate.page):
         )
 
 
-@web.memoize
+@functools.cache
 @public
 def vendor_js():
     pardir = os.path.pardir
@@ -180,7 +181,7 @@ def vendor_js():
     return '/static/upstream/js/vendor.js?v=' + digest
 
 
-@web.memoize
+@functools.cache
 @public
 def static_url(path):
     """Takes path relative to static/ and constructs url to that resource with hash."""

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -1223,7 +1223,7 @@ def get_identifier_config(identifier: Literal['work', 'edition', 'author']) -> S
     return _get_identifier_config(identifier)
 
 
-@web.memoize
+@functools.cache
 def _get_identifier_config(identifier: Literal['work', 'edition', 'author']) -> Storage:
     """
     Returns the identifier config.

--- a/scripts/manage-imports.py
+++ b/scripts/manage-imports.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python
 
 import datetime
+import functools
 import json
 import logging
 import multiprocessing
 import os
 import sys
 import time
-
-import web
 
 from openlibrary.api import OLError, OpenLibrary
 from openlibrary.config import load_config
@@ -18,7 +17,7 @@ from openlibrary.core.imports import Batch, ImportItem
 logger = logging.getLogger("openlibrary.importer")
 
 
-@web.memoize
+@functools.cache
 def get_ol(servername=None):
     if os.getenv('LOCAL_DEV'):
         ol = OpenLibrary(base_url="http://localhost:8080")


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #12017

### Technical
Replaced parameterless `@web.memoize` instances with Python's built-in `@functools.cache` across 14 files. Explicitly excluded `vendor/infogami` files and the 3 instances with `expiry`/`background` parameters., following @cdrini's guidance:

> "Anywhere that doesn't specify any parameters should be safe to switch."

**Design Decision**: `@functools.cache` I intentionally used `import functools` and the fully qualified `@functools.cache` decorator to avoid namespace collisions. Many modified files already contain `from openlibrary.core import cache`, and using `from functools import cache` would have shadowed that module, leading to runtime `TypeError: 'module' object is not callable` errors.

**Excluded — require async-friendly background caching solution (tracked in #12017):**
- `get_ol_dumps` in `openlibrary/plugins/upstream/data.py`
- `_get_recent_changes` in `openlibrary/plugins/upstream/utils.py`
- `_get_recent_changes2` in `openlibrary/plugins/upstream/utils.py`

**Excluded — vendored submodule:**
- `vendor/infogami` files require a separate PR against `internetarchive/infogami`

### Testing

1. Run Python tests:
```bash
docker compose run --rm home make test-py
```
2. Run linting:
```bash
pre-commit run --all-files
```
3. Start dev server via `docker compose up` and verify the application loads with no circular import or unhashable type errors on startup.

### Screenshot

N/A — no UI changes.

### Stakeholders

@cdrini @RayBB