### PR TITLE
use get_current_user when adding a book

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -25,6 +25,7 @@ from openlibrary.plugins.upstream.models import Author, Edition, Work
 from openlibrary.plugins.upstream.table_of_contents import TocParseError
 from openlibrary.plugins.upstream.utils import fuzzy_find, render_template
 from openlibrary.plugins.worksearch.search import get_solr
+from openlibrary.utils.request_context import site
 
 logger = logging.getLogger("openlibrary.book")
 
@@ -62,7 +63,7 @@ def make_author(key: str, name: str) -> Author:
     <Author: '/authors/OL123A'>
     """
     key = "/authors/" + key
-    return web.ctx.site.new(
+    return site.get().new(
         key, {"key": key, "type": {"key": "/type/author"}, "name": name}
     )
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #12043

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Since I cannot reproduce the issue locally or on testing, I'm not totally sure if this will work.

Looking at the code path and where we are accessing a threaded dict, it seems like changing it to use the context variable is a very likely fix. 

@cdrini what do you think?


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
