### PR TITLE
Hide sort menu for series lists

### DIFF
--- a/openlibrary/templates/type/list/view_body.html
+++ b/openlibrary/templates/type/list/view_body.html
@@ -88,7 +88,8 @@ $def seed_attrs(seed):
             <div class="clearfix"></div>
 
         <div class="search-results-stats">
-            $:render_template("search/sort_options.html", selected_sort=sort, default_sort='index', search_scheme="lists_seeds")
+            $if not list.key.startswith('/series/'):
+                $:render_template("search/sort_options.html", selected_sort=sort, default_sort='index', search_scheme="lists_seeds")
             $ layout = get_remembered_layout()
             $:render_template("search/layout_options.html", selected_layout=layout)
         </div>


### PR DESCRIPTION
Closes #12054 

**fix**: Hides the sorting dropdown menu on Series pages. 

As discussed on Slack, the sorting logic is currently designed for standard Lists and does not yet support the new Series data structure. This PR hides the UI element on Series pages to prevent user confusion during the beta rollout.

### Technical
* **File modified:** `openlibrary/templates/lists/view_body.html`
* **Implementation:** Wrapped the `search/sort_options.html` template render call in a conditional block (`$if not list.key.startswith('/series/'):`). 
* **Note:** By checking the `list.key` namespace at the parent level (`view_body`), we successfully hide the dropdown for Series without having to alter the shared `sort_options.html` widget itself. The layout toggle (Grid/List view) is intentionally left outside the condition so it remains functional.

### Testing
1. Navigate to any standard User List.
2. **Verify** that the "Sort by" dropdown is visible and functional.
3. Navigate to any Series page.
4. **Verify** that the "Sort by" dropdown is completely hidden.
5. **Verify** that the Layout dropdown (Grid/List) next to it is still visible and functional.

### Screenshot
Series example:
<img width="1470" height="734" alt="Screenshot 2026-03-09 at 9 39 59 PM" src="https://github.com/user-attachments/assets/5503489e-0d76-4c15-8e90-f54f3a467a19" />
List example:
<img width="1470" height="450" alt="Screenshot 2026-03-09 at 9 45 04 PM" src="https://github.com/user-attachments/assets/c16b40f1-2086-42af-9125-f09afdd6cd4d" />

### Stakeholders
cc @cdrini  - Thanks for pointing me toward this as a good first issue!