### PR TITLE
fix: align focus ring on search input to container border

### DIFF
--- a/static/css/components/searchbox.css
+++ b/static/css/components/searchbox.css
@@ -30,7 +30,8 @@
 }
 
 .searchbox:focus-within {
-  outline: auto;
+  outline: none;
+  box-shadow: var(--box-shadow-focus);
 }
 
 /* --width-breakpoint-tablet */


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #12067

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix: The focus ring (outline) on the Search Books page was appearing on the inner `<input>` element, causing it to look offset/misaligned from the visible container border.

### Technical
The `.searchbox` container holds the visible border and border-radius, but the browser's default focus ring was drawn on the child `<input>` — which sits inset inside the container — making the ring appear misaligned.

**Fix in [static/css/components/searchbox.css](cci:7://file:///home/akram/openlibrary/static/css/components/searchbox.css:0:0-0:0):**
- Added `outline: none` to `.searchbox__input` to suppress the misaligned default ring
- Added `outline: auto` on `.searchbox:focus-within` so the ring is drawn on the outer container, perfectly hugging its border

### Testing
1. Go to http://openlibrary.org/search?mode=everything
2. Click inside the search input field
3. Verify the focus ring now aligns with the container border

### Screenshot
**Before**
<img width="2207" height="780" alt="image" src="https://github.com/user-attachments/assets/60fd319a-69e5-4b1a-aeed-a3ef0c95643c" />

**After**
<img width="2062" height="812" alt="Screenshot 2026-03-11 114512" src="https://github.com/user-attachments/assets/6b02e1ee-edf4-4f7d-96ef-fa4788b4b478" />


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@lokesh 

