### PR TITLE
Rename OlPagination event from update:page to ol-pagination-change

### DIFF
--- a/openlibrary/components/lit/OlPagination.js
+++ b/openlibrary/components/lit/OlPagination.js
@@ -18,7 +18,7 @@ import { LitElement, html, css } from 'lit';
  *                                   (default: "Page {page}, current page")
  * @prop {String} labelPagination - Aria label for the navigation landmark (default: "Pagination")
  *
- * @fires update:page - Fired when a page is selected, detail contains the page number
+ * @fires ol-pagination-change - Fired when a page is selected. detail: { page: Number }
  *
  * @example
  * <!-- Event-based -->
@@ -239,25 +239,30 @@ export class OlPagination extends LitElement {
             return;
         }
 
-        this.dispatchEvent(new CustomEvent('update:page', {
-            detail: page,
+        const event = new CustomEvent('ol-pagination-change', {
+            detail: { page },
             bubbles: true,
-            composed: true
-        }));
+            composed: true,
+            cancelable: true,
+        });
+        this.dispatchEvent(event);
+        if (event.defaultPrevented) return;
+
+        this.currentPage = page;
     }
 
     /**
      * Handle click on anchor-based page links.
-     * Dispatches the update:page event to allow interception.
+     * Dispatches the ol-pagination-change event to allow interception.
      * @param {Event} e - Click event
      * @param {Number} page - The page number
      */
     _handlePageClick(e, page) {
-        const event = new CustomEvent('update:page', {
-            detail: page,
+        const event = new CustomEvent('ol-pagination-change', {
+            detail: { page },
             bubbles: true,
             composed: true,
-            cancelable: true
+            cancelable: true,
         });
         this.dispatchEvent(event);
     }

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -1819,8 +1819,8 @@ msgstr ""
 #: design.html
 #, python-format
 msgid ""
-"When a page is clicked, the component fires an %(update_page)s event with"
-" the page number in %(event_detail)s."
+"When a page is clicked, the component fires an %(event_name)s event with "
+"the page number in %(event_detail)s."
 msgstr ""
 
 #: design.html

--- a/openlibrary/templates/design.html
+++ b/openlibrary/templates/design.html
@@ -26,16 +26,16 @@ $ _x = ctx.setdefault('cssfile', 'design')
     <div class="design-pattern__content">
       <section class="example">
         <h3 class="example__title">$_("Event-based")</h3>
-        <p>$:_("When a page is clicked, the component fires an %(update_page)s event with the page number in %(event_detail)s.", update_page="<code>update:page</code>", event_detail="<code>event.detail</code>")</p>
+        <p>$:_("When a page is clicked, the component fires an %(event_name)s event with the page number in %(event_detail)s.", event_name="<code>ol-pagination-change</code>", event_detail="<code>event.detail.page</code>")</p>
         <code class="example__code">&lt;ol-pagination total-pages="10" current-page="1"&gt;&lt;/ol-pagination&gt;</code>
         <div class="example__output">
           <ol-pagination id="demo-pagination" total-pages="10" current-page="1"></ol-pagination>
         </div>
         <p>$_("Selected page:"): <strong id="demo-selected-page">1</strong></p>
         <script>
-          document.getElementById('demo-pagination').addEventListener('update:page', (e) => {
-            document.getElementById('demo-selected-page').textContent = e.detail;
-            e.target.setAttribute('current-page', e.detail);
+          document.getElementById('demo-pagination').addEventListener('ol-pagination-change', (e) => {
+            document.getElementById('demo-selected-page').textContent = e.detail.page;
+            e.target.setAttribute('current-page', e.detail.page);
           });
         </script>
       </section>


### PR DESCRIPTION
- Rename the custom event to follow the ol-<component>-<action> convention.  ([guidelines](https://github.com/internetarchive/openlibrary/blob/master/docs/ai/web-components.md#events))
- Change detail payload from a bare number to `{ page: Number }` object for extensibility. Add cancelable support and prevent default handling.

No code outside of our test page at https://openlibrary.org/developers/design is utilizing these features so it is low risk.

### Stakeholders
@RayBB 
