### PR TITLE
Remove deprecated http2 listen parameter in nginx configs

### DIFF
--- a/docker/covers_nginx.conf
+++ b/docker/covers_nginx.conf
@@ -1,8 +1,9 @@
 # Keep in sync with web_nginx.conf
 server {
     listen 80 default;
-    listen [::]:443 ssl http2 ipv6only=on;
-    listen 443 ssl http2;
+    listen [::]:443 ssl ipv6only=on;
+    listen 443 ssl;
+    http2 on;
     server_name localhost;
 
     ssl_certificate /etc/letsencrypt/live/covers.openlibrary.org/fullchain.pem;

--- a/docker/web_nginx.conf
+++ b/docker/web_nginx.conf
@@ -48,8 +48,9 @@ map $request_uri $probably_requires_referer {
 # Keep in sync with covers_nginx.conf
 server {
     listen 80 default;
-    listen [::]:443 ssl http2 ipv6only=on;
-    listen 443 ssl http2;
+    listen [::]:443 ssl ipv6only=on;
+    listen 443 ssl;
+    http2 on;
     server_name localhost;
 
     ssl_certificate /etc/letsencrypt/live/openlibrary.org/fullchain.pem;


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Updates the nginx configurations for the `web_nginx` and `covers_nginx` containers.  Using the `http2` parameter in `listen` directives has been deprecated.

[`listen` directive documentation](https://nginx.org/en/docs/http/ngx_http_core_module.html#listen)
[`http2` directive documentation](https://nginx.org/en/docs/http/ngx_http_v2_module.html#http2)

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
