### PR TITLE
fix: reading goal link not restored after unsetting goal

### DIFF
--- a/openlibrary/plugins/openlibrary/js/reading-goals/index.js
+++ b/openlibrary/plugins/openlibrary/js/reading-goals/index.js
@@ -136,7 +136,6 @@ function addGoalSubmissionListener(submitButton) {
                             const setGoalLink = yearlyGoalSection.querySelector('.set-reading-goal-link')
                             if (setGoalLink) {
                                 setGoalLink.classList.remove('hidden')
-                                setGoalLink.addEventListener('click', onYearlyGoalClick)
                             }
                         } else {
                             const progressComponent = modal.closest('.reading-goal-progress')


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #12068 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->
**Root Cause**
When a goal is set, hidden is added directly to .`set-reading-goal-link`. When deleted, the existing logic removes hidden from `.chip-group` but never from `.set-reading-goal-link` itself.

**Fix**
In the `isDeleted` branch, remove hidden from `.set-reading-goal-link` and re-initialize its click listener via `initYearlyGoalPrompt`.


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

https://github.com/user-attachments/assets/40832f76-14c4-42f9-9055-fa8066c48ddc

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
