### PR TITLE
Created indices for bookshelves_books, community_edits_queue

### DIFF
--- a/openlibrary/core/schema.sql
+++ b/openlibrary/core/schema.sql
@@ -97,6 +97,8 @@ CREATE TABLE community_edits_queue (
     updated timestamp without time zone default (current_timestamp at time zone 'utc')
 );
 
+CREATE INDEX community_edits_queue_updated_idx ON community_edits_queue (updated);
+
 CREATE TABLE yearly_reading_goals (
     username text not null,
     year integer not null,


### PR DESCRIPTION
Small perf fix. `created` is used for sorting and filtering in a lot of places; notably the /trending/now page, which is taking ~7+ seconds to load. The `community_edits_queue` table powers the /merges endpoint, which is 1+ seconds to load.

* Trending:
    * High TPM (approx. 9/min), high P50 (3s)
    * See https://sentry.archive.org/organizations/ia-ux/insights/backend/summary/?environment=production&isDefaultQuery=false&project=7&query=transaction.op%3Ahttp.server&referrer=insights-backend-overview&sort=-p50%28span.duration%29&statsPeriod=8d&transaction=%2Ftrending%28%2F%3F.%2A%29&width=63
* Merges: https://sentry.archive.org/organizations/ia-ux/insights/backend/summary/?environment=production&isDefaultQuery=false&project=7&query=transaction.op%3Ahttp.server&referrer=insights-backend-overview&sort=-p50%28span.duration%29&statsPeriod=8d&transaction=%2Fmerges&width=63

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
