### PR TITLE
fix proxy deprecated post

### DIFF
--- a/openlibrary/plugins/openlibrary/deprecated_handler.py
+++ b/openlibrary/plugins/openlibrary/deprecated_handler.py
@@ -51,7 +51,7 @@ def proxy_to_fastapi():
                 content=web.data(),
                 cookies=web.cookies(),
             )
-    except httpx.RequestError as e:
+    except (httpx.RequestError, httpx.HTTPStatusError) as e:
         raise web.internalerror(f"Proxy request failed: {e}")
 
     # Set response headers
@@ -60,12 +60,11 @@ def proxy_to_fastapi():
             'content-encoding',
             'transfer-encoding',
             'content-length',
-            'x-served-by',
         ):
             web.header(k, v)
 
-    # Set a custom header to indicate this was proxied
-    web.header('x-served-by', 'FastAPI-Proxy')
+    # Set a custom header to indicate this was proxied through web.py
+    web.header('x-proxied-by', 'web.py')
 
     # Set response status code
     web.ctx.status = f"{resp.status_code} {resp.reason_phrase}"


### PR DESCRIPTION
Closes #12121 

### Technical
Modified `deprecated_handler.py` to proxy POST requests to the `fast_web` 
container (`http://fast_web:8080`) instead of using a 303 redirect in the 
local dev environment. GET requests continue to use the existing redirect 
behavior. A new `proxy_to_fastapi()` function handles forwarding all headers, 
cookies, and request body, and returns the response via `delegate.RawText` 
to bypass the web.py layout processor.

### Testing
1. Start the local dev environment:
```bash
   make git && docker compose up -d
```
2. Test POST proxying:
```bash
   curl -i -X POST http://localhost:8080/reading-goal.json \
     -d '{"year":2024}' \
     -H "Content-Type: application/json"
```
   Expected: `200 OK` with `x-served-by: FastAPI` in the headers.

3. Test GET redirect still works:
```bash
   curl -i http://localhost:8080/reading-goal.json
```
   Expected: `303 See Other` with `Location: http://localhost:18080/reading-goal.json`

### Screenshot
**GET request (redirected to :18080):**
<img width="1340" height="496" alt="image" src="https://github.com/user-attachments/assets/e5af361b-551d-457d-bade-1d4784ee59c1" />
**POST request (proxied to FastAPI):**
<img width="1355" height="602" alt="image" src="https://github.com/user-attachments/assets/553d6144-2d92-433c-84ad-0c629943d132" />


### Stakeholders
@RayBB 