### PR TITLE
Fixed series autocomplete to correctly resolve OL IDs and URLs, added tests.

### DIFF
--- a/openlibrary/plugins/worksearch/autocomplete.py
+++ b/openlibrary/plugins/worksearch/autocomplete.py
@@ -155,6 +155,7 @@ class series_autocomplete(autocomplete):
         """
         return f"/series/{olid}"
 
+
 class subjects_autocomplete(autocomplete):
     # can't use /subjects/_autocomplete because the subjects endpoint = /subjects/[^/]+
     path = "/subjects_autocomplete"

--- a/openlibrary/plugins/worksearch/tests/test_autocomplete.py
+++ b/openlibrary/plugins/worksearch/tests/test_autocomplete.py
@@ -104,8 +104,10 @@ def test_works_autocomplete():
             ac.GET()
             db_fetch.assert_called_once_with("/works/OL123W")
 
+
 def test_series_autocomplete_olid():
     from openlibrary.plugins.worksearch.autocomplete import series_autocomplete
+
     ac = series_autocomplete()
     with (
         patch("web.input") as mock_web_input,
@@ -119,10 +121,11 @@ def test_series_autocomplete_olid():
         mock_solr_select.return_value = {"docs": []}
         ac.GET()
         assert mock_solr_select.call_args[0][0] == 'key:"/series/OL327669L"'
-        
+
 
 def test_series_autocomplete_url():
     from openlibrary.plugins.worksearch.autocomplete import series_autocomplete
+
     ac = series_autocomplete()
     with (
         patch("web.input") as mock_web_input,
@@ -132,9 +135,7 @@ def test_series_autocomplete_url():
         patch.object(ac, "db_fetch", return_value=None),
     ):
         mock_get_solr.return_value = Solr("http://foohost:8983/solr")
-        mock_web_input.return_value = web.storage(
-            q="https://openlibrary.org/series/OL327669L/Bright_Falls", limit=5
-        )
+        mock_web_input.return_value = web.storage(q="https://openlibrary.org/series/OL327669L/Bright_Falls", limit=5)
         mock_solr_select.return_value = {"docs": []}
         ac.GET()
         assert mock_solr_select.call_args[0][0] == 'key:"/series/OL327669L"'


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #12094

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
`olid_to_key` maps the `L` suffix to `/lists/`, but series records live under `/series/`. This fix adds an `olid_to_key` method to the base `autocomplete` class and replaces the direct `olid_to_key()` call in `direct_get` with `self.olid_to_key()` . `series_autocomplete` then overrides this method to return the correct `/series/` prefix, keeping the change minimal and the base class behaviour unchanged for all other autocomplete types.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Run the test suite: `pytest openlibrary/plugins/worksearch/tests/test_autocomplete.py -v`. All 4 tests pass, including two new tests covering bare OL ID and full URL lookup for series
2. Previously `olid_to_key` mapped the `L` suffix to `/lists/`, causing the Solr query to search `key:"/lists/OL327669L"` which returned no results

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A only backend change

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
