### PR TITLE
google signup screen issue fix with use of ResizeObserver

### DIFF
--- a/openlibrary/plugins/openlibrary/js/signup.js
+++ b/openlibrary/plugins/openlibrary/js/signup.js
@@ -1,298 +1,298 @@
-import { debounce } from "./nonjquery_utils.js";
+import { debounce } from './nonjquery_utils.js';
 
 export function initSignupForm() {
-  const signupForm = document.querySelector("form[name=signup]");
-  const submitBtn = document.querySelector("button[name=signup]");
-  const rpdCheckbox = document.querySelector("#pd-request");
-  const pdaSelectorContainer = document.querySelector("#pda-selector");
-  const pdaSelector = document.querySelector("#pd_program");
-  const i18nStrings = JSON.parse(signupForm.dataset.i18n);
-  const emailLoadingIcon = $(
-    ".ol-signup-form__input--emailAddr .ol-signup-form__icon--loading",
-  );
-  const usernameLoadingIcon = $(
-    ".ol-signup-form__input--username .ol-signup-form__icon--loading",
-  );
-  const emailSuccessIcon = $(
-    ".ol-signup-form__input--emailAddr .ol-signup-form__icon--success",
-  );
-  const usernameSuccessIcon = $(
-    ".ol-signup-form__input--username .ol-signup-form__icon--success",
-  );
+    const signupForm = document.querySelector('form[name=signup]');
+    const submitBtn = document.querySelector('button[name=signup]');
+    const rpdCheckbox = document.querySelector('#pd-request');
+    const pdaSelectorContainer = document.querySelector('#pda-selector');
+    const pdaSelector = document.querySelector('#pd_program');
+    const i18nStrings = JSON.parse(signupForm.dataset.i18n);
+    const emailLoadingIcon = $(
+        '.ol-signup-form__input--emailAddr .ol-signup-form__icon--loading',
+    );
+    const usernameLoadingIcon = $(
+        '.ol-signup-form__input--username .ol-signup-form__icon--loading',
+    );
+    const emailSuccessIcon = $(
+        '.ol-signup-form__input--emailAddr .ol-signup-form__icon--success',
+    );
+    const usernameSuccessIcon = $(
+        '.ol-signup-form__input--username .ol-signup-form__icon--success',
+    );
 
-  // Keep the same with openlibrary/plugins/upstream/forms.py
-  const VALID_EMAIL_RE = /^.*@.*\..*$/;
-  const VALID_USERNAME_RE = /^[a-z0-9-_]{3,20}$/i;
-  const PASSWORD_MINLENGTH = 3;
-  const PASSWORD_MAXLENGTH = 20;
-  const USERNAME_MINLENGTH = 3;
-  const USERNAME_MAXLENGTH = 20;
+    // Keep the same with openlibrary/plugins/upstream/forms.py
+    const VALID_EMAIL_RE = /^.*@.*\..*$/;
+    const VALID_USERNAME_RE = /^[a-z0-9-_]{3,20}$/i;
+    const PASSWORD_MINLENGTH = 3;
+    const PASSWORD_MAXLENGTH = 20;
+    const USERNAME_MINLENGTH = 3;
+    const USERNAME_MAXLENGTH = 20;
 
-  // Callback that is called when grecaptcha.execute() is successful
-  function submitCreateAccountForm() {
-    signupForm.submit();
-  }
-  window.submitCreateAccountForm = submitCreateAccountForm;
-
-  // Checks whether reportValidity exists for cross-browser compatibility
-  // Includes invalid input count to account for checks not covered by reportValidity
-  $(signupForm).on("submit", function (e) {
-    e.preventDefault();
-    validatePDSelection();
-    const numInvalidInputs = signupForm.querySelectorAll(".invalid").length;
-    const isFormattingValid =
-      !signupForm.reportValidity || signupForm.reportValidity();
-    if (numInvalidInputs === 0 && isFormattingValid && window.grecaptcha) {
-      $(submitBtn).prop("disabled", true).text(i18nStrings["loading_text"]);
-      window.grecaptcha.execute();
+    // Callback that is called when grecaptcha.execute() is successful
+    function submitCreateAccountForm() {
+        signupForm.submit();
     }
-  });
+    window.submitCreateAccountForm = submitCreateAccountForm;
 
-  $("#username").on("keyup", function () {
-    const value = $(this).val();
-    $("#userUrl").addClass("darkgreen").text(value).css("font-weight", "700");
-  });
+    // Checks whether reportValidity exists for cross-browser compatibility
+    // Includes invalid input count to account for checks not covered by reportValidity
+    $(signupForm).on('submit', function (e) {
+        e.preventDefault();
+        validatePDSelection();
+        const numInvalidInputs = signupForm.querySelectorAll('.invalid').length;
+        const isFormattingValid =
+      !signupForm.reportValidity || signupForm.reportValidity();
+        if (numInvalidInputs === 0 && isFormattingValid && window.grecaptcha) {
+            $(submitBtn).prop('disabled', true).text(i18nStrings['loading_text']);
+            window.grecaptcha.execute();
+        }
+    });
 
-  /**
+    $('#username').on('keyup', function () {
+        const value = $(this).val();
+        $('#userUrl').addClass('darkgreen').text(value).css('font-weight', '700');
+    });
+
+    /**
    * Renders an error message for a given input in a given error div.
    *
    * @param {string} inputId The ID (incl #) of the input the error relates to
    * @param {string} errorDiv The ID (incl #) of the div where the error msg will be rendered
    * @param {string} errorMsg The error message text
    */
-  function renderError(inputId, errorDiv, errorMsg) {
-    $(inputId).addClass("invalid");
-    $(`label[for=${inputId.slice(1)}]`).addClass("invalid");
-    $(errorDiv).text(errorMsg);
-  }
+    function renderError(inputId, errorDiv, errorMsg) {
+        $(inputId).addClass('invalid');
+        $(`label[for=${inputId.slice(1)}]`).addClass('invalid');
+        $(errorDiv).text(errorMsg);
+    }
 
-  /**
+    /**
    * Clears error styling and message for a given input and error div.
    *
    * @param {string} inputId The ID (incl #) of the input the error relates to
    * @param {string} errorDiv The ID (incl #) of the div where the error msg is currently rendered
    */
-  function clearError(inputId, errorDiv) {
-    $(inputId).removeClass("invalid");
-    $(`label[for=${inputId.slice(1)}]`).removeClass("invalid");
-    $(errorDiv).text("");
-  }
-
-  function validateUsername() {
-    const value_username = $("#username").val();
-
-    usernameSuccessIcon.hide();
-
-    if (value_username === "") {
-      clearError("#username", "#usernameMessage");
-      return;
+    function clearError(inputId, errorDiv) {
+        $(inputId).removeClass('invalid');
+        $(`label[for=${inputId.slice(1)}]`).removeClass('invalid');
+        $(errorDiv).text('');
     }
 
-    if (
-      value_username.length < USERNAME_MINLENGTH ||
+    function validateUsername() {
+        const value_username = $('#username').val();
+
+        usernameSuccessIcon.hide();
+
+        if (value_username === '') {
+            clearError('#username', '#usernameMessage');
+            return;
+        }
+
+        if (
+            value_username.length < USERNAME_MINLENGTH ||
       value_username.length > USERNAME_MAXLENGTH
-    ) {
-      renderError(
-        "#username",
-        "#usernameMessage",
-        i18nStrings["username_length_err"],
-      );
-      return;
-    }
-
-    if (!VALID_USERNAME_RE.test(value_username)) {
-      renderError(
-        "#username",
-        "#usernameMessage",
-        i18nStrings["username_char_err"],
-      );
-      return;
-    }
-
-    usernameLoadingIcon.show();
-
-    $.ajax({
-      url: "/account/validate",
-      data: { username: value_username },
-      type: "GET",
-      success: function (errors) {
-        usernameLoadingIcon.hide();
-
-        if (errors.username) {
-          renderError("#username", "#usernameMessage", errors.username);
-        } else {
-          clearError("#username", "#usernameMessage");
-          usernameSuccessIcon.show();
+        ) {
+            renderError(
+                '#username',
+                '#usernameMessage',
+                i18nStrings['username_length_err'],
+            );
+            return;
         }
-      },
-    });
-  }
 
-  function validateEmail() {
-    const value_email = $("#emailAddr").val();
-
-    emailSuccessIcon.hide();
-
-    if (value_email === "") {
-      clearError("#emailAddr", "#emailAddrMessage");
-      return;
-    }
-
-    if (!VALID_EMAIL_RE.test(value_email)) {
-      renderError(
-        "#emailAddr",
-        "#emailAddrMessage",
-        i18nStrings["invalid_email_format"],
-      );
-      return;
-    }
-
-    emailLoadingIcon.show();
-
-    $.ajax({
-      url: "/account/validate",
-      data: { email: value_email },
-      type: "GET",
-      success: function (errors) {
-        emailLoadingIcon.hide();
-
-        if (errors.email) {
-          renderError("#emailAddr", "#emailAddrMessage", errors.email);
-        } else {
-          clearError("#emailAddr", "#emailAddrMessage");
-          emailSuccessIcon.show();
+        if (!VALID_USERNAME_RE.test(value_username)) {
+            renderError(
+                '#username',
+                '#usernameMessage',
+                i18nStrings['username_char_err'],
+            );
+            return;
         }
-      },
-    });
-  }
 
-  function validatePassword() {
-    const value_password = $("#password").val();
+        usernameLoadingIcon.show();
 
-    if (value_password === "") {
-      clearError("#password", "#passwordMessage");
-      return;
+        $.ajax({
+            url: '/account/validate',
+            data: { username: value_username },
+            type: 'GET',
+            success: function (errors) {
+                usernameLoadingIcon.hide();
+
+                if (errors.username) {
+                    renderError('#username', '#usernameMessage', errors.username);
+                } else {
+                    clearError('#username', '#usernameMessage');
+                    usernameSuccessIcon.show();
+                }
+            },
+        });
     }
 
-    if (
-      value_password.length < PASSWORD_MINLENGTH ||
+    function validateEmail() {
+        const value_email = $('#emailAddr').val();
+
+        emailSuccessIcon.hide();
+
+        if (value_email === '') {
+            clearError('#emailAddr', '#emailAddrMessage');
+            return;
+        }
+
+        if (!VALID_EMAIL_RE.test(value_email)) {
+            renderError(
+                '#emailAddr',
+                '#emailAddrMessage',
+                i18nStrings['invalid_email_format'],
+            );
+            return;
+        }
+
+        emailLoadingIcon.show();
+
+        $.ajax({
+            url: '/account/validate',
+            data: { email: value_email },
+            type: 'GET',
+            success: function (errors) {
+                emailLoadingIcon.hide();
+
+                if (errors.email) {
+                    renderError('#emailAddr', '#emailAddrMessage', errors.email);
+                } else {
+                    clearError('#emailAddr', '#emailAddrMessage');
+                    emailSuccessIcon.show();
+                }
+            },
+        });
+    }
+
+    function validatePassword() {
+        const value_password = $('#password').val();
+
+        if (value_password === '') {
+            clearError('#password', '#passwordMessage');
+            return;
+        }
+
+        if (
+            value_password.length < PASSWORD_MINLENGTH ||
       value_password.length > PASSWORD_MAXLENGTH
-    ) {
-      renderError(
-        "#password",
-        "#passwordMessage",
-        i18nStrings["password_length_err"],
-      );
-      return;
+        ) {
+            renderError(
+                '#password',
+                '#passwordMessage',
+                i18nStrings['password_length_err'],
+            );
+            return;
+        }
+
+        clearError('#password', '#passwordMessage');
     }
 
-    clearError("#password", "#passwordMessage");
-  }
+    function validatePDSelection() {
+        if (!rpdCheckbox.checked) {
+            clearError('#pd_program', '#pd_programMessage');
+            pdaSelector.setAttribute('aria-invalid', 'false');
+            return;
+        }
+        if (pdaSelector.value === '') {
+            renderError(
+                '#pd_program',
+                '#pd_programMessage',
+                i18nStrings['missing_pda_err'],
+            );
+            pdaSelector.setAttribute('aria-invalid', 'true');
+            return;
+        }
 
-  function validatePDSelection() {
-    if (!rpdCheckbox.checked) {
-      clearError("#pd_program", "#pd_programMessage");
-      pdaSelector.setAttribute("aria-invalid", "false");
-      return;
+        clearError('#pd_program', '#pd_programMessage');
+        pdaSelector.setAttribute('aria-invalid', 'false');
     }
-    if (pdaSelector.value === "") {
-      renderError(
-        "#pd_program",
-        "#pd_programMessage",
-        i18nStrings["missing_pda_err"],
-      );
-      pdaSelector.setAttribute("aria-invalid", "true");
-      return;
+
+    // Maps input ID attribute to corresponding validation function
+    function validateInput(input) {
+        const id = $(input).attr('id');
+        if (id === 'emailAddr') {
+            validateEmail();
+        } else if (id === 'username') {
+            validateUsername();
+        } else if (id === 'password') {
+            validatePassword();
+        } else {
+            throw new Error('Input validation function not found');
+        }
     }
 
-    clearError("#pd_program", "#pd_programMessage");
-    pdaSelector.setAttribute("aria-invalid", "false");
-  }
+    const $nonCheckboxInputs = $(
+        'form[name=signup] input:not([type="checkbox"])',
+    );
 
-  // Maps input ID attribute to corresponding validation function
-  function validateInput(input) {
-    const id = $(input).attr("id");
-    if (id === "emailAddr") {
-      validateEmail();
-    } else if (id === "username") {
-      validateUsername();
-    } else if (id === "password") {
-      validatePassword();
-    } else {
-      throw new Error("Input validation function not found");
-    }
-  }
+    // Validates input fields already marked as invalid on value change
+    $nonCheckboxInputs.on(
+        'input',
+        debounce(function () {
+            if ($(this).hasClass('invalid')) {
+                validateInput(this);
+            }
+        }, 50),
+    );
 
-  const $nonCheckboxInputs = $(
-    'form[name=signup] input:not([type="checkbox"])',
-  );
-
-  // Validates input fields already marked as invalid on value change
-  $nonCheckboxInputs.on(
-    "input",
-    debounce(function () {
-      if ($(this).hasClass("invalid")) {
-        validateInput(this);
-      }
-    }, 50),
-  );
-
-  // Validates all other input fields (i.e. not already marked as invalid) on blur
-  $nonCheckboxInputs.on("blur", function () {
-    if (!$(this).hasClass("invalid")) {
-      validateInput(this);
-    }
-  });
-
-  // Validates the print-disability authority selection when the selection changes
-  $("form[name=signup] select").on("change", function () {
-    validatePDSelection();
-  });
-
-  function updateSelectorVisibility() {
-    if (rpdCheckbox.checked) {
-      pdaSelectorContainer.classList.remove("hidden");
-      rpdCheckbox.setAttribute("aria-expanded", "true");
-      pdaSelectorContainer.setAttribute("aria-hidden", "false");
-      pdaSelector.setAttribute("aria-required", "true");
-    } else {
-      pdaSelectorContainer.classList.add("hidden");
-      rpdCheckbox.setAttribute("aria-expanded", "false");
-      pdaSelectorContainer.setAttribute("aria-hidden", "true");
-      pdaSelector.setAttribute("aria-required", "false");
-    }
-  }
-
-  rpdCheckbox.addEventListener("change", updateSelectorVisibility);
-
-  // On page reload, display PD program options and validate selection
-  updateSelectorVisibility();
-  validatePDSelection();
-
-  const iframe = document.getElementById("ia-third-party-logins");
-
-  if (iframe && window.ResizeObserver) {
-    const observer = new ResizeObserver((entries) => {
-      const height = entries[0].contentRect.height;
-
-      // Welcome screen from IA expands iframe height
-      if (height > 200) {
-        document.querySelector("form[name='signup']")?.classList.add("hidden");
-        document
-          .querySelector(".ol-signup-form__big-or")
-          ?.classList.add("hidden");
-      }
+    // Validates all other input fields (i.e. not already marked as invalid) on blur
+    $nonCheckboxInputs.on('blur', function () {
+        if (!$(this).hasClass('invalid')) {
+            validateInput(this);
+        }
     });
 
-    observer.observe(iframe);
-  }
+    // Validates the print-disability authority selection when the selection changes
+    $('form[name=signup] select').on('change', function () {
+        validatePDSelection();
+    });
+
+    function updateSelectorVisibility() {
+        if (rpdCheckbox.checked) {
+            pdaSelectorContainer.classList.remove('hidden');
+            rpdCheckbox.setAttribute('aria-expanded', 'true');
+            pdaSelectorContainer.setAttribute('aria-hidden', 'false');
+            pdaSelector.setAttribute('aria-required', 'true');
+        } else {
+            pdaSelectorContainer.classList.add('hidden');
+            rpdCheckbox.setAttribute('aria-expanded', 'false');
+            pdaSelectorContainer.setAttribute('aria-hidden', 'true');
+            pdaSelector.setAttribute('aria-required', 'false');
+        }
+    }
+
+    rpdCheckbox.addEventListener('change', updateSelectorVisibility);
+
+    // On page reload, display PD program options and validate selection
+    updateSelectorVisibility();
+    validatePDSelection();
+
+    const iframe = document.getElementById('ia-third-party-logins');
+
+    if (iframe && window.ResizeObserver) {
+        const observer = new ResizeObserver((entries) => {
+            const height = entries[0].contentRect.height;
+
+            // Welcome screen from IA expands iframe height
+            if (height > 200) {
+                document.querySelector('form[name=\'signup\']')?.classList.add('hidden');
+                document
+                    .querySelector('.ol-signup-form__big-or')
+                    ?.classList.add('hidden');
+            }
+        });
+
+        observer.observe(iframe);
+    }
 }
 
 export function initLoginForm() {
-  const loginForm = $("form[name=login]");
-  const loadingText = loginForm.data("i18n")["loading_text"];
+    const loginForm = $('form[name=login]');
+    const loadingText = loginForm.data('i18n')['loading_text'];
 
-  loginForm.on("submit", () => {
-    $("button[type=submit]").prop("disabled", true).text(loadingText);
-  });
+    loginForm.on('submit', () => {
+        $('button[type=submit]').prop('disabled', true).text(loadingText);
+    });
 }

--- a/openlibrary/plugins/openlibrary/js/signup.js
+++ b/openlibrary/plugins/openlibrary/js/signup.js
@@ -1,240 +1,298 @@
-import { debounce } from './nonjquery_utils.js';
+import { debounce } from "./nonjquery_utils.js";
 
 export function initSignupForm() {
-    const signupForm = document.querySelector('form[name=signup]');
-    const submitBtn = document.querySelector('button[name=signup]');
-    const rpdCheckbox = document.querySelector('#pd-request')
-    const pdaSelectorContainer = document.querySelector('#pda-selector')
-    const pdaSelector = document.querySelector('#pd_program')
-    const i18nStrings = JSON.parse(signupForm.dataset.i18n);
-    const emailLoadingIcon = $('.ol-signup-form__input--emailAddr .ol-signup-form__icon--loading');
-    const usernameLoadingIcon = $('.ol-signup-form__input--username .ol-signup-form__icon--loading');
-    const emailSuccessIcon = $('.ol-signup-form__input--emailAddr .ol-signup-form__icon--success');
-    const usernameSuccessIcon = $('.ol-signup-form__input--username .ol-signup-form__icon--success');
+  const signupForm = document.querySelector("form[name=signup]");
+  const submitBtn = document.querySelector("button[name=signup]");
+  const rpdCheckbox = document.querySelector("#pd-request");
+  const pdaSelectorContainer = document.querySelector("#pda-selector");
+  const pdaSelector = document.querySelector("#pd_program");
+  const i18nStrings = JSON.parse(signupForm.dataset.i18n);
+  const emailLoadingIcon = $(
+    ".ol-signup-form__input--emailAddr .ol-signup-form__icon--loading",
+  );
+  const usernameLoadingIcon = $(
+    ".ol-signup-form__input--username .ol-signup-form__icon--loading",
+  );
+  const emailSuccessIcon = $(
+    ".ol-signup-form__input--emailAddr .ol-signup-form__icon--success",
+  );
+  const usernameSuccessIcon = $(
+    ".ol-signup-form__input--username .ol-signup-form__icon--success",
+  );
 
-    // Keep the same with openlibrary/plugins/upstream/forms.py
-    const VALID_EMAIL_RE = /^.*@.*\..*$/;
-    const VALID_USERNAME_RE = /^[a-z0-9-_]{3,20}$/i;
-    const PASSWORD_MINLENGTH = 3;
-    const PASSWORD_MAXLENGTH = 20;
-    const USERNAME_MINLENGTH = 3;
-    const USERNAME_MAXLENGTH = 20;
+  // Keep the same with openlibrary/plugins/upstream/forms.py
+  const VALID_EMAIL_RE = /^.*@.*\..*$/;
+  const VALID_USERNAME_RE = /^[a-z0-9-_]{3,20}$/i;
+  const PASSWORD_MINLENGTH = 3;
+  const PASSWORD_MAXLENGTH = 20;
+  const USERNAME_MINLENGTH = 3;
+  const USERNAME_MAXLENGTH = 20;
 
-    // Callback that is called when grecaptcha.execute() is successful
-    function submitCreateAccountForm() {
-        signupForm.submit();
+  // Callback that is called when grecaptcha.execute() is successful
+  function submitCreateAccountForm() {
+    signupForm.submit();
+  }
+  window.submitCreateAccountForm = submitCreateAccountForm;
+
+  // Checks whether reportValidity exists for cross-browser compatibility
+  // Includes invalid input count to account for checks not covered by reportValidity
+  $(signupForm).on("submit", function (e) {
+    e.preventDefault();
+    validatePDSelection();
+    const numInvalidInputs = signupForm.querySelectorAll(".invalid").length;
+    const isFormattingValid =
+      !signupForm.reportValidity || signupForm.reportValidity();
+    if (numInvalidInputs === 0 && isFormattingValid && window.grecaptcha) {
+      $(submitBtn).prop("disabled", true).text(i18nStrings["loading_text"]);
+      window.grecaptcha.execute();
     }
-    window.submitCreateAccountForm = submitCreateAccountForm
+  });
 
-    // Checks whether reportValidity exists for cross-browser compatibility
-    // Includes invalid input count to account for checks not covered by reportValidity
-    $(signupForm).on('submit', function(e) {
-        e.preventDefault();
-        validatePDSelection()
-        const numInvalidInputs = signupForm.querySelectorAll('.invalid').length;
-        const isFormattingValid = !signupForm.reportValidity || signupForm.reportValidity();
-        if (numInvalidInputs === 0 && isFormattingValid && window.grecaptcha) {
-            $(submitBtn).prop('disabled', true).text(i18nStrings['loading_text']);
-            window.grecaptcha.execute();
-        }
-    });
+  $("#username").on("keyup", function () {
+    const value = $(this).val();
+    $("#userUrl").addClass("darkgreen").text(value).css("font-weight", "700");
+  });
 
-    $('#username').on('keyup', function(){
-        const value = $(this).val();
-        $('#userUrl').addClass('darkgreen').text(value).css('font-weight','700');
-    });
+  /**
+   * Renders an error message for a given input in a given error div.
+   *
+   * @param {string} inputId The ID (incl #) of the input the error relates to
+   * @param {string} errorDiv The ID (incl #) of the div where the error msg will be rendered
+   * @param {string} errorMsg The error message text
+   */
+  function renderError(inputId, errorDiv, errorMsg) {
+    $(inputId).addClass("invalid");
+    $(`label[for=${inputId.slice(1)}]`).addClass("invalid");
+    $(errorDiv).text(errorMsg);
+  }
 
-    /**
-     * Renders an error message for a given input in a given error div.
-     *
-     * @param {string} inputId The ID (incl #) of the input the error relates to
-     * @param {string} errorDiv The ID (incl #) of the div where the error msg will be rendered
-     * @param {string} errorMsg The error message text
-     */
-    function renderError(inputId, errorDiv, errorMsg) {
-        $(inputId).addClass('invalid');
-        $(`label[for=${inputId.slice(1)}]`).addClass('invalid');
-        $(errorDiv).text(errorMsg);
-    }
+  /**
+   * Clears error styling and message for a given input and error div.
+   *
+   * @param {string} inputId The ID (incl #) of the input the error relates to
+   * @param {string} errorDiv The ID (incl #) of the div where the error msg is currently rendered
+   */
+  function clearError(inputId, errorDiv) {
+    $(inputId).removeClass("invalid");
+    $(`label[for=${inputId.slice(1)}]`).removeClass("invalid");
+    $(errorDiv).text("");
+  }
 
-    /**
-     * Clears error styling and message for a given input and error div.
-     *
-     * @param {string} inputId The ID (incl #) of the input the error relates to
-     * @param {string} errorDiv The ID (incl #) of the div where the error msg is currently rendered
-     */
-    function clearError(inputId, errorDiv) {
-        $(inputId).removeClass('invalid');
-        $(`label[for=${inputId.slice(1)}]`).removeClass('invalid');
-        $(errorDiv).text('');
-    }
+  function validateUsername() {
+    const value_username = $("#username").val();
 
-    function validateUsername() {
-        const value_username = $('#username').val();
+    usernameSuccessIcon.hide();
 
-        usernameSuccessIcon.hide();
-
-        if (value_username === '') {
-            clearError('#username', '#usernameMessage');
-            return;
-        }
-
-        if (value_username.length < USERNAME_MINLENGTH || value_username.length > USERNAME_MAXLENGTH) {
-            renderError('#username', '#usernameMessage', i18nStrings['username_length_err']);
-            return;
-        }
-
-        if (!(VALID_USERNAME_RE.test(value_username))) {
-            renderError('#username', '#usernameMessage', i18nStrings['username_char_err']);
-            return;
-        }
-
-        usernameLoadingIcon.show();
-
-        $.ajax({
-            url: '/account/validate',
-            data: { username: value_username },
-            type: 'GET',
-            success: function(errors) {
-                usernameLoadingIcon.hide();
-
-                if (errors.username) {
-                    renderError('#username', '#usernameMessage', errors.username);
-                } else {
-                    clearError('#username', '#usernameMessage');
-                    usernameSuccessIcon.show();
-                }
-            }
-        });
+    if (value_username === "") {
+      clearError("#username", "#usernameMessage");
+      return;
     }
 
-    function validateEmail() {
-        const value_email = $('#emailAddr').val();
-
-        emailSuccessIcon.hide();
-
-        if (value_email === '') {
-            clearError('#emailAddr', '#emailAddrMessage');
-            return;
-        }
-
-        if (!VALID_EMAIL_RE.test(value_email)) {
-            renderError('#emailAddr', '#emailAddrMessage', i18nStrings['invalid_email_format']);
-            return;
-        }
-
-        emailLoadingIcon.show();
-
-        $.ajax({
-            url: '/account/validate',
-            data: { email: value_email },
-            type: 'GET',
-            success: function(errors) {
-                emailLoadingIcon.hide();
-
-                if (errors.email) {
-                    renderError('#emailAddr', '#emailAddrMessage', errors.email);
-                } else {
-                    clearError('#emailAddr', '#emailAddrMessage');
-                    emailSuccessIcon.show();
-                }
-            }
-        });
+    if (
+      value_username.length < USERNAME_MINLENGTH ||
+      value_username.length > USERNAME_MAXLENGTH
+    ) {
+      renderError(
+        "#username",
+        "#usernameMessage",
+        i18nStrings["username_length_err"],
+      );
+      return;
     }
 
-    function validatePassword() {
-        const value_password = $('#password').val();
-
-        if (value_password === '') {
-            clearError('#password', '#passwordMessage');
-            return;
-        }
-
-        if (value_password.length < PASSWORD_MINLENGTH || value_password.length > PASSWORD_MAXLENGTH) {
-            renderError('#password', '#passwordMessage', i18nStrings['password_length_err']);
-            return;
-        }
-
-        clearError('#password', '#passwordMessage');
+    if (!VALID_USERNAME_RE.test(value_username)) {
+      renderError(
+        "#username",
+        "#usernameMessage",
+        i18nStrings["username_char_err"],
+      );
+      return;
     }
 
-    function validatePDSelection() {
-        if (!rpdCheckbox.checked) {
-            clearError('#pd_program', '#pd_programMessage')
-            pdaSelector.setAttribute('aria-invalid', 'false');
-            return
-        }
-        if (pdaSelector.value === '') {
-            renderError('#pd_program', '#pd_programMessage', i18nStrings['missing_pda_err'])
-            pdaSelector.setAttribute('aria-invalid', 'true');
-            return
-        }
+    usernameLoadingIcon.show();
 
-        clearError('#pd_program', '#pd_programMessage')
-        pdaSelector.setAttribute('aria-invalid', 'false');
-    }
+    $.ajax({
+      url: "/account/validate",
+      data: { username: value_username },
+      type: "GET",
+      success: function (errors) {
+        usernameLoadingIcon.hide();
 
-    // Maps input ID attribute to corresponding validation function
-    function validateInput(input) {
-        const id = $(input).attr('id');
-        if (id === 'emailAddr') {
-            validateEmail();
-        } else if (id === 'username') {
-            validateUsername();
-        } else if (id === 'password') {
-            validatePassword();
+        if (errors.username) {
+          renderError("#username", "#usernameMessage", errors.username);
         } else {
-            throw new Error('Input validation function not found');
+          clearError("#username", "#usernameMessage");
+          usernameSuccessIcon.show();
         }
+      },
+    });
+  }
+
+  function validateEmail() {
+    const value_email = $("#emailAddr").val();
+
+    emailSuccessIcon.hide();
+
+    if (value_email === "") {
+      clearError("#emailAddr", "#emailAddrMessage");
+      return;
     }
 
-    const $nonCheckboxInputs = $('form[name=signup] input:not([type="checkbox"])')
+    if (!VALID_EMAIL_RE.test(value_email)) {
+      renderError(
+        "#emailAddr",
+        "#emailAddrMessage",
+        i18nStrings["invalid_email_format"],
+      );
+      return;
+    }
 
-    // Validates input fields already marked as invalid on value change
-    $nonCheckboxInputs.on('input', debounce(function(){
-        if ($(this).hasClass('invalid')) {
-            validateInput(this);
-        }
-    }, 50));
+    emailLoadingIcon.show();
 
-    // Validates all other input fields (i.e. not already marked as invalid) on blur
-    $nonCheckboxInputs.on('blur', function() {
-        if (!$(this).hasClass('invalid')) {
-            validateInput(this);
+    $.ajax({
+      url: "/account/validate",
+      data: { email: value_email },
+      type: "GET",
+      success: function (errors) {
+        emailLoadingIcon.hide();
+
+        if (errors.email) {
+          renderError("#emailAddr", "#emailAddrMessage", errors.email);
+        } else {
+          clearError("#emailAddr", "#emailAddrMessage");
+          emailSuccessIcon.show();
         }
+      },
+    });
+  }
+
+  function validatePassword() {
+    const value_password = $("#password").val();
+
+    if (value_password === "") {
+      clearError("#password", "#passwordMessage");
+      return;
+    }
+
+    if (
+      value_password.length < PASSWORD_MINLENGTH ||
+      value_password.length > PASSWORD_MAXLENGTH
+    ) {
+      renderError(
+        "#password",
+        "#passwordMessage",
+        i18nStrings["password_length_err"],
+      );
+      return;
+    }
+
+    clearError("#password", "#passwordMessage");
+  }
+
+  function validatePDSelection() {
+    if (!rpdCheckbox.checked) {
+      clearError("#pd_program", "#pd_programMessage");
+      pdaSelector.setAttribute("aria-invalid", "false");
+      return;
+    }
+    if (pdaSelector.value === "") {
+      renderError(
+        "#pd_program",
+        "#pd_programMessage",
+        i18nStrings["missing_pda_err"],
+      );
+      pdaSelector.setAttribute("aria-invalid", "true");
+      return;
+    }
+
+    clearError("#pd_program", "#pd_programMessage");
+    pdaSelector.setAttribute("aria-invalid", "false");
+  }
+
+  // Maps input ID attribute to corresponding validation function
+  function validateInput(input) {
+    const id = $(input).attr("id");
+    if (id === "emailAddr") {
+      validateEmail();
+    } else if (id === "username") {
+      validateUsername();
+    } else if (id === "password") {
+      validatePassword();
+    } else {
+      throw new Error("Input validation function not found");
+    }
+  }
+
+  const $nonCheckboxInputs = $(
+    'form[name=signup] input:not([type="checkbox"])',
+  );
+
+  // Validates input fields already marked as invalid on value change
+  $nonCheckboxInputs.on(
+    "input",
+    debounce(function () {
+      if ($(this).hasClass("invalid")) {
+        validateInput(this);
+      }
+    }, 50),
+  );
+
+  // Validates all other input fields (i.e. not already marked as invalid) on blur
+  $nonCheckboxInputs.on("blur", function () {
+    if (!$(this).hasClass("invalid")) {
+      validateInput(this);
+    }
+  });
+
+  // Validates the print-disability authority selection when the selection changes
+  $("form[name=signup] select").on("change", function () {
+    validatePDSelection();
+  });
+
+  function updateSelectorVisibility() {
+    if (rpdCheckbox.checked) {
+      pdaSelectorContainer.classList.remove("hidden");
+      rpdCheckbox.setAttribute("aria-expanded", "true");
+      pdaSelectorContainer.setAttribute("aria-hidden", "false");
+      pdaSelector.setAttribute("aria-required", "true");
+    } else {
+      pdaSelectorContainer.classList.add("hidden");
+      rpdCheckbox.setAttribute("aria-expanded", "false");
+      pdaSelectorContainer.setAttribute("aria-hidden", "true");
+      pdaSelector.setAttribute("aria-required", "false");
+    }
+  }
+
+  rpdCheckbox.addEventListener("change", updateSelectorVisibility);
+
+  // On page reload, display PD program options and validate selection
+  updateSelectorVisibility();
+  validatePDSelection();
+
+  const iframe = document.getElementById("ia-third-party-logins");
+
+  if (iframe && window.ResizeObserver) {
+    const observer = new ResizeObserver((entries) => {
+      const height = entries[0].contentRect.height;
+
+      // Welcome screen from IA expands iframe height
+      if (height > 200) {
+        document.querySelector("form[name='signup']")?.classList.add("hidden");
+        document
+          .querySelector(".ol-signup-form__big-or")
+          ?.classList.add("hidden");
+      }
     });
 
-    // Validates the print-disability authority selection when the selection changes
-    $('form[name=signup] select').on('change', function() {
-        validatePDSelection()
-    })
-
-    function updateSelectorVisibility() {
-        if (rpdCheckbox.checked) {
-            pdaSelectorContainer.classList.remove('hidden')
-            rpdCheckbox.setAttribute('aria-expanded','true')
-            pdaSelectorContainer.setAttribute('aria-hidden','false')
-            pdaSelector.setAttribute('aria-required', 'true')
-        } else {
-            pdaSelectorContainer.classList.add('hidden')
-            rpdCheckbox.setAttribute('aria-expanded','false')
-            pdaSelectorContainer.setAttribute('aria-hidden','true')
-            pdaSelector.setAttribute('aria-required', 'false')
-        }
-    }
-
-    rpdCheckbox.addEventListener('change', updateSelectorVisibility)
-
-    // On page reload, display PD program options and validate selection
-    updateSelectorVisibility()
-    validatePDSelection()
+    observer.observe(iframe);
+  }
 }
 
 export function initLoginForm() {
-    const loginForm = $('form[name=login]');
-    const loadingText = loginForm.data('i18n')['loading_text'];
+  const loginForm = $("form[name=login]");
+  const loadingText = loginForm.data("i18n")["loading_text"];
 
-    loginForm.on('submit', () => {
-        $('button[type=submit]').prop('disabled', true).text(loadingText);
-    })
+  loginForm.on("submit", () => {
+    $("button[type=submit]").prop("disabled", true).text(loadingText);
+  });
 }

--- a/openlibrary/plugins/openlibrary/js/signup.js
+++ b/openlibrary/plugins/openlibrary/js/signup.js
@@ -20,25 +20,25 @@ export function initSignupForm() {
     const USERNAME_MINLENGTH = 3;
     const USERNAME_MAXLENGTH = 20;
 
-  // Callback that is called when grecaptcha.execute() is successful
-  function submitCreateAccountForm() {
-    signupForm.submit();
-  }
-  window.submitCreateAccountForm = submitCreateAccountForm
-
-  // Checks whether reportValidity exists for cross-browser compatibility
-  // Includes invalid input count to account for checks not covered by reportValidity
-  $(signupForm).on("submit", function(e) {
-    e.preventDefault();
-    validatePDSelection()
-    const numInvalidInputs = signupForm.querySelectorAll(".invalid").length;
-    const isFormattingValid = !signupForm.reportValidity || signupForm.reportValidity();
-    if (numInvalidInputs === 0 && isFormattingValid && window.grecaptcha) {
-      $(submitBtn).prop("disabled", true).text(i18nStrings["loading_text"]);
-      window.grecaptcha.execute();
+    // Callback that is called when grecaptcha.execute() is successful
+    function submitCreateAccountForm() {
+        signupForm.submit();
     }
-    window.submitCreateAccountForm = submitCreateAccountForm;
-  })
+    window.submitCreateAccountForm = submitCreateAccountForm
+
+    // Checks whether reportValidity exists for cross-browser compatibility
+    // Includes invalid input count to account for checks not covered by reportValidity
+    $(signupForm).on('submit', function(e) {
+        e.preventDefault();
+        validatePDSelection()
+        const numInvalidInputs = signupForm.querySelectorAll('.invalid').length;
+        const isFormattingValid = !signupForm.reportValidity || signupForm.reportValidity();
+        if (numInvalidInputs === 0 && isFormattingValid && window.grecaptcha) {
+            $(submitBtn).prop('disabled', true).text(i18nStrings['loading_text']);
+            window.grecaptcha.execute();
+        }
+        window.submitCreateAccountForm = submitCreateAccountForm;
+    })
 
     $('#username').on('keyup', function () {
         const value = $(this).val();
@@ -171,9 +171,9 @@ export function initSignupForm() {
             return
         }
 
-    clearError("#pd_program", "#pd_programMessage")
-    pdaSelector.setAttribute("aria-invalid", "false");
-  }
+        clearError('#pd_program', '#pd_programMessage')
+        pdaSelector.setAttribute('aria-invalid', 'false');
+    }
 
     // Maps input ID attribute to corresponding validation function
     function validateInput(input) {
@@ -253,7 +253,7 @@ export function initLoginForm() {
     const loginForm = $('form[name=login]');
     const loadingText = loginForm.data('i18n')['loading_text'];
 
-  loginForm.on("submit", () => {
-    $("button[type=submit]").prop("disabled", true).text(loadingText);
-  })
+    loginForm.on('submit', () => {
+        $('button[type=submit]').prop('disabled', true).text(loadingText);
+    })
 }

--- a/openlibrary/plugins/openlibrary/js/signup.js
+++ b/openlibrary/plugins/openlibrary/js/signup.js
@@ -20,25 +20,25 @@ export function initSignupForm() {
     const USERNAME_MINLENGTH = 3;
     const USERNAME_MAXLENGTH = 20;
 
-    // Callback that is called when grecaptcha.execute() is successful
-    function submitCreateAccountForm() {
-        signupForm.submit();
+  // Callback that is called when grecaptcha.execute() is successful
+  function submitCreateAccountForm() {
+    signupForm.submit();
+  }
+  window.submitCreateAccountForm = submitCreateAccountForm
+
+  // Checks whether reportValidity exists for cross-browser compatibility
+  // Includes invalid input count to account for checks not covered by reportValidity
+  $(signupForm).on("submit", function(e) {
+    e.preventDefault();
+    validatePDSelection()
+    const numInvalidInputs = signupForm.querySelectorAll(".invalid").length;
+    const isFormattingValid = !signupForm.reportValidity || signupForm.reportValidity();
+    if (numInvalidInputs === 0 && isFormattingValid && window.grecaptcha) {
+      $(submitBtn).prop("disabled", true).text(i18nStrings["loading_text"]);
+      window.grecaptcha.execute();
     }
     window.submitCreateAccountForm = submitCreateAccountForm;
-
-    // Checks whether reportValidity exists for cross-browser compatibility
-    // Includes invalid input count to account for checks not covered by reportValidity
-    $(signupForm).on('submit', function (e) {
-        e.preventDefault();
-        validatePDSelection();
-        const numInvalidInputs = signupForm.querySelectorAll('.invalid').length;
-        const isFormattingValid =
-      !signupForm.reportValidity || signupForm.reportValidity();
-        if (numInvalidInputs === 0 && isFormattingValid && window.grecaptcha) {
-            $(submitBtn).prop('disabled', true).text(i18nStrings['loading_text']);
-            window.grecaptcha.execute();
-        }
-    });
+  })
 
     $('#username').on('keyup', function () {
         const value = $(this).val();
@@ -171,9 +171,9 @@ export function initSignupForm() {
             return
         }
 
-        clearError('#pd_program', '#pd_programMessage');
-        pdaSelector.setAttribute('aria-invalid', 'false');
-    }
+    clearError("#pd_program", "#pd_programMessage")
+    pdaSelector.setAttribute("aria-invalid", "false");
+  }
 
     // Maps input ID attribute to corresponding validation function
     function validateInput(input) {
@@ -253,7 +253,7 @@ export function initLoginForm() {
     const loginForm = $('form[name=login]');
     const loadingText = loginForm.data('i18n')['loading_text'];
 
-    loginForm.on('submit', () => {
-        $('button[type=submit]').prop('disabled', true).text(loadingText);
-    });
+  loginForm.on("submit", () => {
+    $("button[type=submit]").prop("disabled", true).text(loadingText);
+  })
 }

--- a/openlibrary/plugins/openlibrary/js/signup.js
+++ b/openlibrary/plugins/openlibrary/js/signup.js
@@ -26,32 +26,31 @@ export function initSignupForm() {
     }
     window.submitCreateAccountForm = submitCreateAccountForm
 
-    // Checks whether reportValidity exists for cross-browser compatibility
-    // Includes invalid input count to account for checks not covered by reportValidity
-    $(signupForm).on('submit', function(e) {
-        e.preventDefault();
-        validatePDSelection()
-        const numInvalidInputs = signupForm.querySelectorAll('.invalid').length;
-        const isFormattingValid = !signupForm.reportValidity || signupForm.reportValidity();
-        if (numInvalidInputs === 0 && isFormattingValid && window.grecaptcha) {
-            $(submitBtn).prop('disabled', true).text(i18nStrings['loading_text']);
-            window.grecaptcha.execute();
-        }
-        window.submitCreateAccountForm = submitCreateAccountForm;
-    })
+  // Checks whether reportValidity exists for cross-browser compatibility
+  // Includes invalid input count to account for checks not covered by reportValidity
+  $(signupForm).on("submit", function(e) {
+    e.preventDefault();
+    validatePDSelection()
+    const numInvalidInputs = signupForm.querySelectorAll(".invalid").length;
+    const isFormattingValid = !signupForm.reportValidity || signupForm.reportValidity();
+    if (numInvalidInputs === 0 && isFormattingValid && window.grecaptcha) {
+      $(submitBtn).prop("disabled", true).text(i18nStrings["loading_text"]);
+      window.grecaptcha.execute();
+    }
+  })
 
-    $('#username').on('keyup', function () {
+    $('#username').on('keyup', function(){
         const value = $(this).val();
-        $('#userUrl').addClass('darkgreen').text(value).css('font-weight', '700');
+        $('#userUrl').addClass('darkgreen').text(value).css('font-weight','700');
     });
 
     /**
-   * Renders an error message for a given input in a given error div.
-   *
-   * @param {string} inputId The ID (incl #) of the input the error relates to
-   * @param {string} errorDiv The ID (incl #) of the div where the error msg will be rendered
-   * @param {string} errorMsg The error message text
-   */
+    * Renders an error message for a given input in a given error div.
+    *
+    * @param {string} inputId The ID (incl #) of the input the error relates to
+    * @param {string} errorDiv The ID (incl #) of the div where the error msg will be rendered
+    * @param {string} errorMsg The error message text
+    */
     function renderError(inputId, errorDiv, errorMsg) {
         $(inputId).addClass('invalid');
         $(`label[for=${inputId.slice(1)}]`).addClass('invalid');
@@ -59,11 +58,11 @@ export function initSignupForm() {
     }
 
     /**
-   * Clears error styling and message for a given input and error div.
-   *
-   * @param {string} inputId The ID (incl #) of the input the error relates to
-   * @param {string} errorDiv The ID (incl #) of the div where the error msg is currently rendered
-   */
+    * Clears error styling and message for a given input and error div.
+    *
+    * @param {string} inputId The ID (incl #) of the input the error relates to
+    * @param {string} errorDiv The ID (incl #) of the div where the error msg is currently rendered
+    */
     function clearError(inputId, errorDiv) {
         $(inputId).removeClass('invalid');
         $(`label[for=${inputId.slice(1)}]`).removeClass('invalid');

--- a/openlibrary/plugins/openlibrary/js/signup.js
+++ b/openlibrary/plugins/openlibrary/js/signup.js
@@ -20,55 +20,55 @@ export function initSignupForm() {
     const USERNAME_MINLENGTH = 3;
     const USERNAME_MAXLENGTH = 20;
 
-  // Callback that is called when grecaptcha.execute() is successful
-  function submitCreateAccountForm() {
-    signupForm.submit();
-  }
-  window.submitCreateAccountForm = submitCreateAccountForm;
-
-  // Checks whether reportValidity exists for cross-browser compatibility
-  // Includes invalid input count to account for checks not covered by reportValidity
-  $(signupForm).on("submit", function (e) {
-    e.preventDefault();
-    validatePDSelection();
-    const numInvalidInputs = signupForm.querySelectorAll(".invalid").length;
-    const isFormattingValid =
-      !signupForm.reportValidity || signupForm.reportValidity();
-    if (numInvalidInputs === 0 && isFormattingValid && window.grecaptcha) {
-      $(submitBtn).prop("disabled", true).text(i18nStrings["loading_text"]);
-      window.grecaptcha.execute();
+    // Callback that is called when grecaptcha.execute() is successful
+    function submitCreateAccountForm() {
+        signupForm.submit();
     }
-  });
+    window.submitCreateAccountForm = submitCreateAccountForm;
 
-  $("#username").on("keyup", function () {
-    const value = $(this).val();
-    $("#userUrl").addClass("darkgreen").text(value).css("font-weight", "700");
-  });
+    // Checks whether reportValidity exists for cross-browser compatibility
+    // Includes invalid input count to account for checks not covered by reportValidity
+    $(signupForm).on('submit', function (e) {
+        e.preventDefault();
+        validatePDSelection();
+        const numInvalidInputs = signupForm.querySelectorAll('.invalid').length;
+        const isFormattingValid =
+      !signupForm.reportValidity || signupForm.reportValidity();
+        if (numInvalidInputs === 0 && isFormattingValid && window.grecaptcha) {
+            $(submitBtn).prop('disabled', true).text(i18nStrings['loading_text']);
+            window.grecaptcha.execute();
+        }
+    });
 
-  /**
+    $('#username').on('keyup', function () {
+        const value = $(this).val();
+        $('#userUrl').addClass('darkgreen').text(value).css('font-weight', '700');
+    });
+
+    /**
    * Renders an error message for a given input in a given error div.
    *
    * @param {string} inputId The ID (incl #) of the input the error relates to
    * @param {string} errorDiv The ID (incl #) of the div where the error msg will be rendered
    * @param {string} errorMsg The error message text
    */
-  function renderError(inputId, errorDiv, errorMsg) {
-    $(inputId).addClass("invalid");
-    $(`label[for=${inputId.slice(1)}]`).addClass("invalid");
-    $(errorDiv).text(errorMsg);
-  }
+    function renderError(inputId, errorDiv, errorMsg) {
+        $(inputId).addClass('invalid');
+        $(`label[for=${inputId.slice(1)}]`).addClass('invalid');
+        $(errorDiv).text(errorMsg);
+    }
 
-  /**
+    /**
    * Clears error styling and message for a given input and error div.
    *
    * @param {string} inputId The ID (incl #) of the input the error relates to
    * @param {string} errorDiv The ID (incl #) of the div where the error msg is currently rendered
    */
-  function clearError(inputId, errorDiv) {
-    $(inputId).removeClass("invalid");
-    $(`label[for=${inputId.slice(1)}]`).removeClass("invalid");
-    $(errorDiv).text("");
-  }
+    function clearError(inputId, errorDiv) {
+        $(inputId).removeClass('invalid');
+        $(`label[for=${inputId.slice(1)}]`).removeClass('invalid');
+        $(errorDiv).text('');
+    }
 
     function validateUsername() {
         const value_username = $('#username').val();
@@ -171,9 +171,9 @@ export function initSignupForm() {
             return
         }
 
-    clearError("#pd_program", "#pd_programMessage");
-    pdaSelector.setAttribute("aria-invalid", "false");
-  }
+        clearError('#pd_program', '#pd_programMessage');
+        pdaSelector.setAttribute('aria-invalid', 'false');
+    }
 
     // Maps input ID attribute to corresponding validation function
     function validateInput(input) {
@@ -226,9 +226,9 @@ export function initSignupForm() {
 
     rpdCheckbox.addEventListener('change', updateSelectorVisibility)
 
-  // On page reload, display PD program options and validate selection
-  updateSelectorVisibility();
-  validatePDSelection();
+    // On page reload, display PD program options and validate selection
+    updateSelectorVisibility();
+    validatePDSelection();
 
     const iframe = document.getElementById('ia-third-party-logins');
 
@@ -253,7 +253,7 @@ export function initLoginForm() {
     const loginForm = $('form[name=login]');
     const loadingText = loginForm.data('i18n')['loading_text'];
 
-  loginForm.on("submit", () => {
-    $("button[type=submit]").prop("disabled", true).text(loadingText);
-  });
+    loginForm.on('submit', () => {
+        $('button[type=submit]').prop('disabled', true).text(loadingText);
+    });
 }

--- a/openlibrary/plugins/openlibrary/js/signup.js
+++ b/openlibrary/plugins/openlibrary/js/signup.js
@@ -26,18 +26,18 @@ export function initSignupForm() {
     }
     window.submitCreateAccountForm = submitCreateAccountForm
 
-  // Checks whether reportValidity exists for cross-browser compatibility
-  // Includes invalid input count to account for checks not covered by reportValidity
-  $(signupForm).on("submit", function(e) {
-    e.preventDefault();
-    validatePDSelection()
-    const numInvalidInputs = signupForm.querySelectorAll(".invalid").length;
-    const isFormattingValid = !signupForm.reportValidity || signupForm.reportValidity();
-    if (numInvalidInputs === 0 && isFormattingValid && window.grecaptcha) {
-      $(submitBtn).prop("disabled", true).text(i18nStrings["loading_text"]);
-      window.grecaptcha.execute();
-    }
-  })
+    // Checks whether reportValidity exists for cross-browser compatibility
+    // Includes invalid input count to account for checks not covered by reportValidity
+    $(signupForm).on('submit', function(e) {
+        e.preventDefault();
+        validatePDSelection()
+        const numInvalidInputs = signupForm.querySelectorAll('.invalid').length;
+        const isFormattingValid = !signupForm.reportValidity || signupForm.reportValidity();
+        if (numInvalidInputs === 0 && isFormattingValid && window.grecaptcha) {
+            $(submitBtn).prop('disabled', true).text(i18nStrings['loading_text']);
+            window.grecaptcha.execute();
+        }
+    })
 
     $('#username').on('keyup', function(){
         const value = $(this).val();

--- a/openlibrary/plugins/openlibrary/js/signup.js
+++ b/openlibrary/plugins/openlibrary/js/signup.js
@@ -3,22 +3,14 @@ import { debounce } from './nonjquery_utils.js';
 export function initSignupForm() {
     const signupForm = document.querySelector('form[name=signup]');
     const submitBtn = document.querySelector('button[name=signup]');
-    const rpdCheckbox = document.querySelector('#pd-request');
-    const pdaSelectorContainer = document.querySelector('#pda-selector');
-    const pdaSelector = document.querySelector('#pd_program');
+    const rpdCheckbox = document.querySelector('#pd-request')
+    const pdaSelectorContainer = document.querySelector('#pda-selector')
+    const pdaSelector = document.querySelector('#pd_program')
     const i18nStrings = JSON.parse(signupForm.dataset.i18n);
-    const emailLoadingIcon = $(
-        '.ol-signup-form__input--emailAddr .ol-signup-form__icon--loading',
-    );
-    const usernameLoadingIcon = $(
-        '.ol-signup-form__input--username .ol-signup-form__icon--loading',
-    );
-    const emailSuccessIcon = $(
-        '.ol-signup-form__input--emailAddr .ol-signup-form__icon--success',
-    );
-    const usernameSuccessIcon = $(
-        '.ol-signup-form__input--username .ol-signup-form__icon--success',
-    );
+    const emailLoadingIcon = $('.ol-signup-form__input--emailAddr .ol-signup-form__icon--loading');
+    const usernameLoadingIcon = $('.ol-signup-form__input--username .ol-signup-form__icon--loading');
+    const emailSuccessIcon = $('.ol-signup-form__input--emailAddr .ol-signup-form__icon--success');
+    const usernameSuccessIcon = $('.ol-signup-form__input--username .ol-signup-form__icon--success');
 
     // Keep the same with openlibrary/plugins/upstream/forms.py
     const VALID_EMAIL_RE = /^.*@.*\..*$/;
@@ -28,55 +20,55 @@ export function initSignupForm() {
     const USERNAME_MINLENGTH = 3;
     const USERNAME_MAXLENGTH = 20;
 
-    // Callback that is called when grecaptcha.execute() is successful
-    function submitCreateAccountForm() {
-        signupForm.submit();
-    }
-    window.submitCreateAccountForm = submitCreateAccountForm;
+  // Callback that is called when grecaptcha.execute() is successful
+  function submitCreateAccountForm() {
+    signupForm.submit();
+  }
+  window.submitCreateAccountForm = submitCreateAccountForm;
 
-    // Checks whether reportValidity exists for cross-browser compatibility
-    // Includes invalid input count to account for checks not covered by reportValidity
-    $(signupForm).on('submit', function (e) {
-        e.preventDefault();
-        validatePDSelection();
-        const numInvalidInputs = signupForm.querySelectorAll('.invalid').length;
-        const isFormattingValid =
+  // Checks whether reportValidity exists for cross-browser compatibility
+  // Includes invalid input count to account for checks not covered by reportValidity
+  $(signupForm).on("submit", function (e) {
+    e.preventDefault();
+    validatePDSelection();
+    const numInvalidInputs = signupForm.querySelectorAll(".invalid").length;
+    const isFormattingValid =
       !signupForm.reportValidity || signupForm.reportValidity();
-        if (numInvalidInputs === 0 && isFormattingValid && window.grecaptcha) {
-            $(submitBtn).prop('disabled', true).text(i18nStrings['loading_text']);
-            window.grecaptcha.execute();
-        }
-    });
+    if (numInvalidInputs === 0 && isFormattingValid && window.grecaptcha) {
+      $(submitBtn).prop("disabled", true).text(i18nStrings["loading_text"]);
+      window.grecaptcha.execute();
+    }
+  });
 
-    $('#username').on('keyup', function () {
-        const value = $(this).val();
-        $('#userUrl').addClass('darkgreen').text(value).css('font-weight', '700');
-    });
+  $("#username").on("keyup", function () {
+    const value = $(this).val();
+    $("#userUrl").addClass("darkgreen").text(value).css("font-weight", "700");
+  });
 
-    /**
+  /**
    * Renders an error message for a given input in a given error div.
    *
    * @param {string} inputId The ID (incl #) of the input the error relates to
    * @param {string} errorDiv The ID (incl #) of the div where the error msg will be rendered
    * @param {string} errorMsg The error message text
    */
-    function renderError(inputId, errorDiv, errorMsg) {
-        $(inputId).addClass('invalid');
-        $(`label[for=${inputId.slice(1)}]`).addClass('invalid');
-        $(errorDiv).text(errorMsg);
-    }
+  function renderError(inputId, errorDiv, errorMsg) {
+    $(inputId).addClass("invalid");
+    $(`label[for=${inputId.slice(1)}]`).addClass("invalid");
+    $(errorDiv).text(errorMsg);
+  }
 
-    /**
+  /**
    * Clears error styling and message for a given input and error div.
    *
    * @param {string} inputId The ID (incl #) of the input the error relates to
    * @param {string} errorDiv The ID (incl #) of the div where the error msg is currently rendered
    */
-    function clearError(inputId, errorDiv) {
-        $(inputId).removeClass('invalid');
-        $(`label[for=${inputId.slice(1)}]`).removeClass('invalid');
-        $(errorDiv).text('');
-    }
+  function clearError(inputId, errorDiv) {
+    $(inputId).removeClass("invalid");
+    $(`label[for=${inputId.slice(1)}]`).removeClass("invalid");
+    $(errorDiv).text("");
+  }
 
     function validateUsername() {
         const value_username = $('#username').val();
@@ -88,24 +80,13 @@ export function initSignupForm() {
             return;
         }
 
-        if (
-            value_username.length < USERNAME_MINLENGTH ||
-      value_username.length > USERNAME_MAXLENGTH
-        ) {
-            renderError(
-                '#username',
-                '#usernameMessage',
-                i18nStrings['username_length_err'],
-            );
+        if (value_username.length < USERNAME_MINLENGTH || value_username.length > USERNAME_MAXLENGTH) {
+            renderError('#username', '#usernameMessage', i18nStrings['username_length_err']);
             return;
         }
 
-        if (!VALID_USERNAME_RE.test(value_username)) {
-            renderError(
-                '#username',
-                '#usernameMessage',
-                i18nStrings['username_char_err'],
-            );
+        if (!(VALID_USERNAME_RE.test(value_username))) {
+            renderError('#username', '#usernameMessage', i18nStrings['username_char_err']);
             return;
         }
 
@@ -115,7 +96,7 @@ export function initSignupForm() {
             url: '/account/validate',
             data: { username: value_username },
             type: 'GET',
-            success: function (errors) {
+            success: function(errors) {
                 usernameLoadingIcon.hide();
 
                 if (errors.username) {
@@ -124,7 +105,7 @@ export function initSignupForm() {
                     clearError('#username', '#usernameMessage');
                     usernameSuccessIcon.show();
                 }
-            },
+            }
         });
     }
 
@@ -139,11 +120,7 @@ export function initSignupForm() {
         }
 
         if (!VALID_EMAIL_RE.test(value_email)) {
-            renderError(
-                '#emailAddr',
-                '#emailAddrMessage',
-                i18nStrings['invalid_email_format'],
-            );
+            renderError('#emailAddr', '#emailAddrMessage', i18nStrings['invalid_email_format']);
             return;
         }
 
@@ -153,7 +130,7 @@ export function initSignupForm() {
             url: '/account/validate',
             data: { email: value_email },
             type: 'GET',
-            success: function (errors) {
+            success: function(errors) {
                 emailLoadingIcon.hide();
 
                 if (errors.email) {
@@ -162,7 +139,7 @@ export function initSignupForm() {
                     clearError('#emailAddr', '#emailAddrMessage');
                     emailSuccessIcon.show();
                 }
-            },
+            }
         });
     }
 
@@ -174,15 +151,8 @@ export function initSignupForm() {
             return;
         }
 
-        if (
-            value_password.length < PASSWORD_MINLENGTH ||
-      value_password.length > PASSWORD_MAXLENGTH
-        ) {
-            renderError(
-                '#password',
-                '#passwordMessage',
-                i18nStrings['password_length_err'],
-            );
+        if (value_password.length < PASSWORD_MINLENGTH || value_password.length > PASSWORD_MAXLENGTH) {
+            renderError('#password', '#passwordMessage', i18nStrings['password_length_err']);
             return;
         }
 
@@ -191,23 +161,19 @@ export function initSignupForm() {
 
     function validatePDSelection() {
         if (!rpdCheckbox.checked) {
-            clearError('#pd_program', '#pd_programMessage');
+            clearError('#pd_program', '#pd_programMessage')
             pdaSelector.setAttribute('aria-invalid', 'false');
-            return;
+            return
         }
         if (pdaSelector.value === '') {
-            renderError(
-                '#pd_program',
-                '#pd_programMessage',
-                i18nStrings['missing_pda_err'],
-            );
+            renderError('#pd_program', '#pd_programMessage', i18nStrings['missing_pda_err'])
             pdaSelector.setAttribute('aria-invalid', 'true');
-            return;
+            return
         }
 
-        clearError('#pd_program', '#pd_programMessage');
-        pdaSelector.setAttribute('aria-invalid', 'false');
-    }
+    clearError("#pd_program", "#pd_programMessage");
+    pdaSelector.setAttribute("aria-invalid", "false");
+  }
 
     // Maps input ID attribute to corresponding validation function
     function validateInput(input) {
@@ -223,51 +189,46 @@ export function initSignupForm() {
         }
     }
 
-    const $nonCheckboxInputs = $(
-        'form[name=signup] input:not([type="checkbox"])',
-    );
+    const $nonCheckboxInputs = $('form[name=signup] input:not([type="checkbox"])')
 
     // Validates input fields already marked as invalid on value change
-    $nonCheckboxInputs.on(
-        'input',
-        debounce(function () {
-            if ($(this).hasClass('invalid')) {
-                validateInput(this);
-            }
-        }, 50),
-    );
+    $nonCheckboxInputs.on('input', debounce(function(){
+        if ($(this).hasClass('invalid')) {
+            validateInput(this);
+        }
+    }, 50));
 
     // Validates all other input fields (i.e. not already marked as invalid) on blur
-    $nonCheckboxInputs.on('blur', function () {
+    $nonCheckboxInputs.on('blur', function() {
         if (!$(this).hasClass('invalid')) {
             validateInput(this);
         }
     });
 
     // Validates the print-disability authority selection when the selection changes
-    $('form[name=signup] select').on('change', function () {
-        validatePDSelection();
-    });
+    $('form[name=signup] select').on('change', function() {
+        validatePDSelection()
+    })
 
     function updateSelectorVisibility() {
         if (rpdCheckbox.checked) {
-            pdaSelectorContainer.classList.remove('hidden');
-            rpdCheckbox.setAttribute('aria-expanded', 'true');
-            pdaSelectorContainer.setAttribute('aria-hidden', 'false');
-            pdaSelector.setAttribute('aria-required', 'true');
+            pdaSelectorContainer.classList.remove('hidden')
+            rpdCheckbox.setAttribute('aria-expanded','true')
+            pdaSelectorContainer.setAttribute('aria-hidden','false')
+            pdaSelector.setAttribute('aria-required', 'true')
         } else {
-            pdaSelectorContainer.classList.add('hidden');
-            rpdCheckbox.setAttribute('aria-expanded', 'false');
-            pdaSelectorContainer.setAttribute('aria-hidden', 'true');
-            pdaSelector.setAttribute('aria-required', 'false');
+            pdaSelectorContainer.classList.add('hidden')
+            rpdCheckbox.setAttribute('aria-expanded','false')
+            pdaSelectorContainer.setAttribute('aria-hidden','true')
+            pdaSelector.setAttribute('aria-required', 'false')
         }
     }
 
-    rpdCheckbox.addEventListener('change', updateSelectorVisibility);
+    rpdCheckbox.addEventListener('change', updateSelectorVisibility)
 
-    // On page reload, display PD program options and validate selection
-    updateSelectorVisibility();
-    validatePDSelection();
+  // On page reload, display PD program options and validate selection
+  updateSelectorVisibility();
+  validatePDSelection();
 
     const iframe = document.getElementById('ia-third-party-logins');
 
@@ -292,7 +253,7 @@ export function initLoginForm() {
     const loginForm = $('form[name=login]');
     const loadingText = loginForm.data('i18n')['loading_text'];
 
-    loginForm.on('submit', () => {
-        $('button[type=submit]').prop('disabled', true).text(loadingText);
-    });
+  loginForm.on("submit", () => {
+    $("button[type=submit]").prop("disabled", true).text(loadingText);
+  });
 }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #12063 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->
- Added ResizeObserver to detect iframe height changes
- Hide signup form and separator when IA login iframe expands (>200px)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Trigger IA login
2. Verify signup form hides when iframe expands

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="1900" height="1624" alt="openlibrary org_account_create" src="https://github.com/user-attachments/assets/f87c2acd-1a24-4d99-a1f8-535da3cd77c4" />

### Blocker
- Not able to test locally due to dependency on Internet Archive third-party login iframe behavior.

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles @cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
