### PR TITLE
show list title for owner done

### DIFF
--- a/openlibrary/templates/type/list/view_body.html
+++ b/openlibrary/templates/type/list/view_body.html
@@ -35,16 +35,14 @@ $ sort = query_param('sort', None)
 $jsdef render_seed_count(seed_count):
     $ungettext("%(count)d item", "%(count)d items", seed_count, count=seed_count)
 
-$if not is_owner:
-    <div id="contentHead" style="margin-bottom:0;">
-        $:macros.databarView(list, edit=not list.key.startswith('/people/'))
-        <h1>$list.name</h1>
-        <p class="collapse sansserif">
-            $ component_times['render_seed_count'] = time()
-            <span class="darkgreen" id="list-items-count"><strong>$:render_seed_count(len(list.seeds))</strong></span>
-            $ component_times['render_seed_count'] = time() - component_times['render_seed_count']
-        </p>
-    </div>
+<!-- Always show header/title (previously only shown when not is_owner) -->
+<div id="contentHead" style="margin-bottom:0;">
+    $:macros.databarView(list, edit=not list.key.startswith('/people/'))
+    <h1>$list.name</h1>
+    <p class="collapse sansserif">
+        <span class="darkgreen" id="list-items-count"><strong>$:render_seed_count(len(list.seeds))</strong></span>
+    </p>
+</div>
 
 $def remove_item_link():
     $ owner = list.get_owner()


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10606

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

### Technical
<!-- What should be noted about the implementation? -->
This PR fixes the rendering of the list header for non-owners.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Navigate to list page or create a new one while logged in
2. Confirm that:
   - The list header is visible  
   - The list title renders correctly   

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="1280" height="658" alt="Screenshot 2026-03-19 at 11 44 23 AM" src="https://github.com/user-attachments/assets/ea46c6ab-59bf-49b7-a877-3e1d1e5c50af" />

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
