### PR TITLE
Fix: disable want-to-read button until JS is loaded

### DIFF
--- a/openlibrary/plugins/openlibrary/js/my-books/MyBooksDropper/ReadingLogForms.js
+++ b/openlibrary/plugins/openlibrary/js/my-books/MyBooksDropper/ReadingLogForms.js
@@ -130,6 +130,11 @@ export class ReadingLogForms {
                     this.dropperActions.toggleDropper()
                 })
             }
+
+            // Enable the primary button now that JS handlers are initialized
+            if (this.primaryButton) {
+                this.primaryButton.disabled = false
+            }
         }
     }
 

--- a/openlibrary/templates/my_books/primary_action.html
+++ b/openlibrary/templates/my_books/primary_action.html
@@ -24,7 +24,7 @@ $def reading_log_cta(work_key, edition_key, user_key, read_status):
     $if user_key:
       <input type="hidden" name="user-key" value="$(user_key)" />
 
-    <button class="book-progress-btn primary-action $(activated_status)" type="submit">
+    <button class="book-progress-btn primary-action $(activated_status)" type="submit" disabled>
       <span class="activated-check $(checkmark_visibility)">✓</span>
       <span class="btn-text">$(message)</span>
     </button>

--- a/static/css/components/mybooks-dropper.css
+++ b/static/css/components/mybooks-dropper.css
@@ -41,6 +41,11 @@
   margin-right: 2px;
 }
 
+.book-progress-btn:disabled {
+  cursor: pointer;
+  opacity: 1;
+}
+
 /* Styling for the My Books dropper's dropdown content: */
 .generic-dropper__dropdown {
   min-width: 200px;


### PR DESCRIPTION
## Summary

Prevent the ".json dead end" issue by disabling the "Want to Read" button in HTML until JavaScript has loaded and initialized its event handlers.

## Problem

When a user clicks the "Want to Read" button before JavaScript has loaded, the form submits directly to a `.json` endpoint, displaying raw JSON (`{"bookshelves_affected": null}`) to the user instead of the expected page behavior.

## Solution

1. **HTML**: Added `disabled` attribute to the primary action button
2. **JavaScript**: Enable the button in `ReadingLogForms.initialize()` after event handlers are set up
3. **CSS**: Override disabled appearance so the button looks unchanged to users

This approach was suggested by @mekarpeles in the issue discussion - keeping it simple by preventing clicks until JS is ready.

## Testing

- Python lint: ✅ Passed
- JS/CSS lint: ✅ Passed  
- Python tests: ✅ 2883 passed
- JS tests: ✅ 302 passed

## Considerations

- The button visually appears the same but won't respond to clicks until JS loads
- Users may need to click again after the page fully loads (rare edge case)
- No changes to the API or backend logic

## Related Issues

Fixes #12042