### PR TITLE
Add delete button to Tag edit view

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -4944,7 +4944,8 @@ msgstr ""
 msgid "Editing..."
 msgstr ""
 
-#: books/edit.html type/author/edit.html type/template/edit.html
+#: books/edit.html type/author/edit.html type/tag/form.html
+#: type/template/edit.html
 msgid "Delete Record"
 msgstr ""
 

--- a/openlibrary/templates/type/tag/form.html
+++ b/openlibrary/templates/type/tag/form.html
@@ -9,6 +9,11 @@ $ heading = _("Edit tag") if is_editing else _("Add a tag to Open Library")
 <div id="contentHead">
     $if is_editing:
         $:macros.databarEdit(page)
+        $if ctx.user and (ctx.user.is_admin() or ctx.user.is_super_librarian()):
+            <span class="adminOnly right">
+                <button type="submit" value="$_('Delete Record')" name="_delete" title="$_('Delete Record')" id="delete"
+                    form="tag-form">$_("Delete Record")</button>
+            </span>
 
     <h1>$heading</h1>
     $if not is_editing:
@@ -16,7 +21,7 @@ $ heading = _("Edit tag") if is_editing else _("Add a tag to Open Library")
 </div>
 
 <div id="contentBody">
-    <form name="edit" method="post" class="olform">
+    <form id="tag-form" name="edit" method="post" class="olform">
         $if redirect:
             <input type="hidden" name="redir" value="$redirect">
         $:render_template("type/tag/tag_form_inputs", page)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Addresses #11878 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds "Delete" button to Tag edit views.  Delete button is only rendered for admins and super-librarians.

Clicking "Delete" will change the affected Tag's type to `/type/delete`.

Delete functionality was already present in the Tag edit POST handler, so no server-side code changes were needed.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
