### PR TITLE
ol-chip: use close icon, add border-radius-chip token

### DIFF
--- a/openlibrary/components/lit/OLChip.js
+++ b/openlibrary/components/lit/OLChip.js
@@ -3,7 +3,7 @@ import { LitElement, html, css, nothing } from 'lit';
 /**
  * OLChip - A pill-shaped interactive chip web component
  *
- * Supports two sizes, a selected state with a checkmark icon,
+ * Supports two sizes, a selected state with a close icon,
  * click events, and optional link behavior via href.
  *
  * @property {Boolean} selected - Whether the chip is in a selected state
@@ -53,7 +53,7 @@ export class OLChip extends LitElement {
             align-items: center;
             padding: var(--chip-padding-block) var(--chip-padding-inline);
             border: var(--border-width) solid var(--color-border-subtle);
-            border-radius: var(--border-radius-pill);
+            border-radius: var(--border-radius-chip);
             font-family: var(--font-family-button);
             font-size: var(--font-size-body-medium);
             line-height: var(--line-height-chip);
@@ -99,7 +99,7 @@ export class OLChip extends LitElement {
             font-size: var(--font-size-label-medium);
         }
 
-        /* Icon carousel — clips overflow so icons slide in/out */
+        /* Close icon for selected state */
         .icon-slot {
             position: absolute;
             inset-inline-start: var(--chip-padding-inline);
@@ -109,46 +109,9 @@ export class OLChip extends LitElement {
             height: var(--chip-icon-size);
         }
 
-        .icon-carousel {
-            display: flex;
-            flex-direction: column;
-            transition: transform 0.2s cubic-bezier(.25, .46, .45, .94);
-        }
-
-        @media (hover: hover) and (pointer: fine) {
-            .chip:hover .icon-carousel {
-                transform: translateY(-50%);
-            }
-        }
-
         .icon {
             width: var(--chip-icon-size);
             height: var(--chip-icon-size);
-            flex-shrink: 0;
-            transition: opacity 0.2s cubic-bezier(.25, .46, .45, .94),
-                        filter 0.2s cubic-bezier(.25, .46, .45, .94);
-        }
-
-        .icon-check {
-            opacity: 1;
-            filter: blur(0);
-        }
-
-        .icon-close {
-            opacity: 0;
-            filter: blur(2px);
-        }
-
-        @media (hover: hover) and (pointer: fine) {
-            .chip:hover .icon-check {
-                opacity: 0;
-                filter: blur(2px);
-            }
-
-            .chip:hover .icon-close {
-                opacity: 1;
-                filter: blur(0);
-            }
         }
 
         /* Count */
@@ -186,32 +149,18 @@ export class OLChip extends LitElement {
 
         return html`
             <span class="icon-slot">
-                <span class="icon-carousel">
-                    <svg
-                        class="icon icon-check"
-                        aria-hidden="true"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        stroke-width="3"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                    >
-                        <path d="M20 6 9 17l-5-5"/>
-                    </svg>
-                    <svg
-                        class="icon icon-close"
-                        aria-hidden="true"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        stroke-width="3"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                    >
-                        <path d="M18 6 6 18"/><path d="m6 6 12 12"/>
-                    </svg>
-                </span>
+                <svg
+                    class="icon"
+                    aria-hidden="true"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="3"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                >
+                    <path d="M18 6 6 18"/><path d="m6 6 12 12"/>
+                </svg>
             </span>
         `;
     }

--- a/static/css/tokens/border-radius.css
+++ b/static/css/tokens/border-radius.css
@@ -20,13 +20,14 @@
  * Reference these throughout the app for consistent border-radius styling
  */
 :root {
-  --border-radius-button: 4px; /* buttons, tabs */
-  --border-radius-input: 4px; /* inputs, textareas */
-  --border-radius-thumbnail: 2px; /* small images */
-  --border-radius-media: 8px; /* large images, videos */
-  --border-radius-card: 8px; /* cards */
-  --border-radius-overlay: 12px; /* dialogs, modals */
-  --border-radius-badge: 2px; /* badges, tags */
-  --border-radius-notification: 8px; /* notifications, alerts */
-  --border-radius-avatar: 50%; /* avatars, profile pictures */
+  --border-radius-button: var(--border-radius-md); /* buttons, tabs */
+  --border-radius-input: var(--border-radius-md); /* inputs, textareas */
+  --border-radius-thumbnail: var(--border-radius-sm); /* small images */
+  --border-radius-media: var(--border-radius-lg); /* large images, videos */
+  --border-radius-card: var(--border-radius-lg); /* cards */
+  --border-radius-overlay: var(--border-radius-xl); /* dialogs, modals */
+  --border-radius-chip: var(--border-radius-xl); /* chips, pills that may wrap */
+  --border-radius-badge: var(--border-radius-sm); /* badges, tags */
+  --border-radius-notification: var(--border-radius-lg); /* notifications, alerts */
+  --border-radius-avatar: var(--border-radius-circle); /* avatars, profile pictures */
 }


### PR DESCRIPTION
## Summary
- Replace checkmark with close (X) icon on selected chips and remove the icon carousel hover animation
- Add `--border-radius-chip` semantic token so multi-line chips don't get an exaggerated pill shape
- Refactor all semantic border-radius tokens to reference their primitives instead of hardcoded values

## Test plan
- [ ] Verify single-line chips render with correct border-radius
- [ ] Verify multi-line chips (long labels) render with correct border-radius
- [ ] Verify selected chips show X icon on the left

## Screenshots



<img width="866" height="321" alt="Screenshot 2026-03-20 at 3 33 21 PM" src="https://github.com/user-attachments/assets/7c55d582-f1a8-4587-839d-8878cce61e9d" />

_'X' icon on left_


<img width="939" height="533" alt="image" src="https://github.com/user-attachments/assets/cb6ceeb1-f396-4af6-9e28-83bd545d6ce5" />

_border radius for multi-line chips renders with same value as single line_

## Stakeholders

@cdrini cc: @mekarpeles 

