### PR TITLE
Experiment with pgbouncer

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -71,6 +71,20 @@ services:
       - ol-vendor:/openlibrary/vendor
       - ${OL_MOUNT_DIR:-.}:/openlibrary
 
+  pgbouncer:
+    # Sits in front of the postgres container and pools connections.
+    # coverstore and infobase both point at this instead of db directly.
+    # edoburu/pgbouncer is a well-used community image (~10M pulls); no official image exists.
+    # Pin to a specific tag rather than latest for reproducibility.
+    image: edoburu/pgbouncer:v1.25.1-p0
+    networks:
+      - dbnet
+    volumes:
+      - ./docker/pgbouncer.ini:/etc/pgbouncer/pgbouncer.ini:ro
+      - ./docker/userlist.txt:/etc/pgbouncer/userlist.txt:ro
+    depends_on:
+      - db
+
   db:
     image: postgres:${POSTGRES_VERSION:-9.3}
     networks:

--- a/conf/coverstore.yml
+++ b/conf/coverstore.yml
@@ -3,7 +3,7 @@
 db_parameters:
     dbn: "postgres"
     db: "coverstore"
-    host: db
+    host: pgbouncer
 
 data_root: "/var/lib/coverstore"
 default_image: "static/images/empty.gif"

--- a/conf/infobase.yml
+++ b/conf/infobase.yml
@@ -3,7 +3,7 @@
 db_parameters:
     engine: postgres
     database: openlibrary
-    host: db
+    host: pgbouncer
 
 account_bot: /people/AccountBot
 user_root: /people/

--- a/docker/pgbouncer.ini
+++ b/docker/pgbouncer.ini
@@ -1,0 +1,22 @@
+[databases]
+; Forward both OL databases to the upstream postgres container
+openlibrary = host=db port=5432 dbname=openlibrary
+coverstore   = host=db port=5432 dbname=coverstore
+
+[pgbouncer]
+listen_addr     = 0.0.0.0
+listen_port     = 5432
+auth_type       = trust
+auth_file       = /etc/pgbouncer/userlist.txt
+
+; session mode is the safest choice for an experiment; switch to
+; transaction mode later if we want better connection multiplexing.
+; pool_mode        = session
+pool_mode        = transaction
+max_client_conn  = 100
+default_pool_size = 20
+
+; Log enough to be useful without being noisy
+log_connections  = 1
+log_disconnections = 1
+log_pooler_errors  = 1

--- a/docker/userlist.txt
+++ b/docker/userlist.txt
@@ -1,0 +1,5 @@
+; userlist.txt for pgbouncer
+; auth_type = trust locally, so passwords are ignored — entries just need to exist
+; for pgbouncer to recognise the user names it may receive.
+"postgres" ""
+"openlibrary" ""


### PR DESCRIPTION
While investigating some of the db issues, experimenting with pg bouncer. Doesn't seem like something we need right now, since the web workers seem to have always and by design been opening a new connection for every request (for better or worse). But opening a close PR in case we decide to revisit in the future.

I didn't test fully, but basic reading/writing seemed to all work locally! Even with transaction mode. I did a pass and it seemed like we weren't using SET/PREPARE/etc types of queries that would cause transaction mode issues ; sequences might cause some issues from my researching but needs more thorough testing if we want to undertake this.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
