### PR TITLE
Fix: Checked Out button redirects to homepage instead of book page

### DIFF
--- a/openlibrary/templates/type/list/embed.html
+++ b/openlibrary/templates/type/list/embed.html
@@ -61,7 +61,7 @@ $def render_seed_count(seed_count):
                                 </a>
                             $elif 'borrow_url' in ebook:
                                 $if ebook.get('borrowed'):
-                                    <a href="$ebook['borrow_url']" title="$_('This book is checked out')">
+                                    <a href="$seed.url" title="$_('This book is checked out')">
                                         <span class="image checked-out"></span>
                                         <span class="label">$_('Checked out')</span>
                                     </a>


### PR DESCRIPTION

Fixes #12149

## Problem
Clicking the "Checked Out" button on the homepage redirects users back to the homepage instead of opening the corresponding book page.

## Solution
Updated the link for checked-out books to use the book page URL (`seed.url`) instead of `borrow_url`.

## Changes
- Replaced `ebook['borrow_url']` with `seed.url` when the book is already borrowed
- Ensures consistent behavior with clicking the book image

## Result
- Clicking "Checked Out" now correctly opens the book page
- Improves usability and user experience
