### PR TITLE
Fix #10640: Render author bio correctly in Merge Authors preview

### DIFF
--- a/openlibrary/templates/merge/authors.html
+++ b/openlibrary/templates/merge/authors.html
@@ -90,7 +90,6 @@ $if can_merge:
                         <p>$:macros.TruncateString(a.bio, 250)</p>
                     $else:
                         <p>No description.</p>
-                        <p>$:reformat_html(format(a.bio), max_length=250)</p>
                     <ul>
                     $for doc in top.docs:
                         <li><a href="$doc['key']" target="new" title="$_('Open in a new window')">$doc['title']</a> <span class="smaller">$ungettext('%(count)s edition', '%(count)s editions', doc['edition_count'], count=doc['edition_count']),


### PR DESCRIPTION
Closes #10640

### Fix
On the Merge Authors page, the author bio preview was rendered with `${ ... }`, which escapes output and can display HTML entities (e.g. `&quot;`, `&#39;`) literally.
This PR switches the bio preview to `$:macros.TruncateString(a.bio, 250)` so the truncated bio is rendered consistently.

### Testing
1. Go to https://openlibrary.org/search/authors?q=Shakesp%2A&sort=work_count+desc
2. Click “Merge authors”
3. Confirm the preview description shows quotes/apostrophes correctly (not `&quot;` / `&#39;`).