### PR TITLE
Fixed checked-out button in carousel to link to book page

### DIFF
--- a/openlibrary/templates/books/custom_carousel_card.html
+++ b/openlibrary/templates/books/custom_carousel_card.html
@@ -29,8 +29,6 @@ $if author_names:
 $else:
   $ byline = ''
 
-$ work_key = book['key'] if book['key'].startswith('/work') else book.get('work_key')
-
 <div class="book carousel__item">
   <div class="book-cover">
     <a href="$(url)" data-ol-link-track="BookCarousel|CoverClick|$key">
@@ -51,5 +49,5 @@ $ work_key = book['key'] if book['key'].startswith('/work') else book.get('work_
         </div>
     </a>
   </div>
-  $:macros.LoanStatus(book, work_key=work_key, listen=False, secondary_action=secondary_action, analytics_override="BookCarousel|CTAClick|%s" % key)
+  $:macros.LoanStatus(book, work_key=url, listen=False, secondary_action=secondary_action, analytics_override="BookCarousel|CTAClick|%s" % key)
 </div>


### PR DESCRIPTION
The 'Checked Out' CTA in book carousels now points to the same URL as the carousel cover image link, instead of using the work_key which could be null.

This ensures consistent behavior: clicking either the cover image or the 'Checked Out' button navigation to the same book page.

Fixes #12149

<!-- What issue does this PR close? -->
Closes #12149 In internetarchive/openlibrary

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix broken link for button for Checked out books

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Go to https://openlibrary.org/
Click the Checked Out button for any relevant book. 
Open book description link without borrow option, same as clicking book image

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
