### PR TITLE
Add CSS guide and expand AI docs with wiki frontend content

### DIFF
--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -160,8 +160,9 @@ A Work has many Editions. This is the central relationship in the data model.
 
 These companion docs cover specific areas in depth:
 
-- [Design](design.md) — UI design patterns: typography, layout shift prevention, animations
-- [Web Component Standards](web-components.md) — Lit component conventions, naming, accessibility, events
+- [CSS](css.md) — BEM naming, selector rules, tokens in practice, bundle sizes, CSS-to-template wiring
+- [Design](design.md) — UI design patterns: typography, layout shift prevention, design tokens, animations
+- [Web Component Standards](web-components.md) — When to build a component, Lit conventions, accessibility, events
 
 ## Key File Locations
 

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -149,6 +149,10 @@ Open Library uses a wiki-style versioned data store (Infobase) via the `vendor/i
 
 A Work has many Editions. This is the central relationship in the data model.
 
+## Pull Requests
+
+When creating PRs, use the template in `.github/pull_request_template.md` for the PR body. Before pushing code, run `npm run lint` to catch issues early.
+
 ## Code Style
 
 - **Python:** Ruff linter, Black formatter. Line length 162. Target Python 3.12.

--- a/docs/ai/css.md
+++ b/docs/ai/css.md
@@ -46,6 +46,10 @@ p { margin-bottom: 1rem; }
 .book-card .book-card__title { }
 ```
 
+## Spacing and Margins
+
+Use only bottom margins for vertical spacing, never top margins. One-directional margins keep layout predictable and avoid margin-collapse surprises.
+
 ## Design Tokens
 
 Always use semantic tokens instead of hardcoded values. Stylelint will reject raw hex colors, named colors, and hardcoded values for `font-family`, `background-color`, `z-index`, and `color`.

--- a/docs/ai/css.md
+++ b/docs/ai/css.md
@@ -1,0 +1,91 @@
+# CSS
+
+Conventions and workflow for writing CSS in Open Library. CSS source lives in `static/css/`, compiled via webpack to `static/build/css/`.
+
+## Naming: BEM
+
+Use BEM (Block Element Modifier) for class names in templates and global styles. **BEM is not required** for Lit web components or Vue components — they have built-in CSS encapsulation (Shadow DOM and `<style scoped>` respectively).
+
+```css
+/* Block */
+.book-card { }
+
+/* Element (part of the block) */
+.book-card__title { }
+.book-card__cover { }
+
+/* Modifier (variation of block or element) */
+.book-card--featured { }
+.book-card__title--large { }
+```
+
+## Selector Rules
+
+**Use explicit classes, not bare elements.** Bare element selectors affect every instance globally.
+
+```css
+/* Bad — affects every paragraph */
+p { margin-bottom: 1rem; }
+
+/* Good — scoped to context */
+.book-description__text { margin-bottom: 1em; }
+```
+
+**Avoid IDs for styling.** IDs have high specificity and are meant for JavaScript hooks or anchor links, not styling.
+
+**Keep selectors as flat as possible.** Deep nesting makes selectors hard to find and override. That said, sometimes nesting is necessary to win a specificity war with legacy CSS — that's fine, just don't nest more than you need to.
+
+```css
+/* Avoid — unnecessarily deep */
+.book-list .book-card .book-card__title { }
+
+/* Prefer — flat when possible */
+.book-card__title { }
+
+/* Acceptable — nesting to override legacy styles */
+.book-card .book-card__title { }
+```
+
+## Design Tokens
+
+Always use semantic tokens instead of hardcoded values. Stylelint will reject raw hex colors, named colors, and hardcoded values for `font-family`, `background-color`, `z-index`, and `color`.
+
+```css
+/* Good — semantic token */
+.my-card { border-radius: var(--border-radius-card); }
+
+/* Bad — primitive token */
+.my-card { border-radius: var(--border-radius-lg); }
+
+/* Bad — hardcoded */
+.my-card { border-radius: 8px; }
+```
+
+If no semantic token exists for your use case, create one in the appropriate file under `static/css/tokens/` rather than reaching for a primitive or hardcoded value. See the [Design Token Guide](design.md#design-tokens) for the two-tier system.
+
+## Connecting CSS to Templates
+
+Page-specific CSS files are named `page-*.css` (e.g., `page-home.css`, `page-book.css`). Templates declare which CSS file to load via `putctx()`:
+
+```python
+$putctx("cssfile", "page-book")
+```
+
+This passes the value up to `site.html`, which loads the corresponding stylesheet in `<head>`.
+
+## Bundle Size Limits
+
+CSS on the critical rendering path has strict size limits. If you see:
+
+```
+FAIL static/build/page-plain.css: 18.81KB > maxSize 18.8KB (gzip)
+```
+
+Your changes exceeded the CSS payload limit. Options:
+
+- Remove unused styles to make room.
+- Move styles into a JavaScript entrypoint file (e.g., `<name>--js.css`) loaded via JS, which has a higher bundlesize threshold. This takes the styles off the critical path.
+
+## Browser Support
+
+Firefox and Chromium-based browsers on desktop and mobile (iOS and Android).

--- a/docs/ai/design.md
+++ b/docs/ai/design.md
@@ -58,6 +58,51 @@ Set `scroll-margin-top` for scrollable elements to ensure proper space above ele
 }
 ```
 
+## Design Tokens
+
+Open Library uses a two-tier token system defined as CSS custom properties in `static/css/tokens/`.
+
+### Tier 1: Primitives
+
+Raw values with no semantic meaning — the base palette.
+
+```css
+--blue-500: hsl(210, 80%, 50%);
+--space-16: 16px;
+--border-radius-lg: 8px;
+```
+
+You should rarely use primitives directly in component or template styles.
+
+### Tier 2: Semantic Tokens
+
+Semantic tokens reference primitives and describe purpose, not appearance.
+
+```css
+--color-link: var(--blue-600);
+--color-surface-primary: var(--white);
+--border-radius-card: var(--border-radius-lg);
+```
+
+This indirection enables visual redesigns, dark mode, and brand refreshes by changing token values in one place.
+
+### Which tier to use
+
+Always use semantic tokens. If one doesn't exist for your use case, create it in the appropriate token file rather than using a primitive or hardcoded value.
+
+### Token files
+
+| File | Contents |
+|---|---|
+| `static/css/tokens/colors.css` | Color primitives and semantic color tokens |
+| `static/css/tokens/spacing.css` | Spacing scale |
+| `static/css/tokens/border-radius.css` | Border radius primitives and semantic tokens |
+| `static/css/tokens/typography.css` | Font families, sizes, and weights |
+
+### Tokens in Shadow DOM
+
+CSS custom properties inherit through the shadow boundary, so design tokens work directly inside Lit component `static styles` blocks without any extra wiring.
+
 ## Animations
 
 ### Practical Tips

--- a/docs/ai/web-components.md
+++ b/docs/ai/web-components.md
@@ -2,6 +2,24 @@
 
 Guidelines for building Lit web components in Open Library. Components live in `openlibrary/components/lit/` and are registered in `openlibrary/components/lit/index.js`.
 
+## When to Build a Component
+
+Not every interactive element needs a web component.
+
+**Build a Lit web component when:**
+- The UI is interactive and benefits from encapsulation (its own styles, state, events)
+- The element will be reused across multiple pages or contexts
+- The behavior is complex enough to warrant a clean API (attributes, events, slots)
+
+**Use vanilla JavaScript when:**
+- The interaction is a one-off page enhancement (e.g., toggling a section)
+- The behavior is simple DOM manipulation tied to a specific template
+
+**Use a template change when:**
+- The change is purely visual or structural with no client-side interactivity
+
+**Vue** is reserved for a few specialized, JavaScript-heavy tools (librarian merge UI, reading stats, library explorer). It is not the default for new UI.
+
 Build and watch with:
 
 ```bash
@@ -76,6 +94,34 @@ Use compound components when a component has multiple related parts that need to
 - Use `aria-expanded`, `aria-selected`, `aria-current`, etc. to reflect interactive state.
 - Support translatable labels via attribute overrides (see the `label-*` props on `OlPagination` for the pattern).
 
+```js
+// aria-live for dynamic content
+html`
+  <div aria-live="polite" aria-atomic="true">
+    ${this.results.length} results found
+  </div>
+`;
+
+// aria-expanded for toggleable sections
+html`
+  <button
+    aria-expanded=${this.isOpen}
+    aria-controls="panel"
+    @click=${() => this.isOpen = !this.isOpen}
+  >${this.heading}</button>
+  <div id="panel" ?hidden=${!this.isOpen}>${this.content}</div>
+`;
+
+// aria-busy during loading
+html`
+  <div aria-busy=${this.loading}>
+    ${this.loading
+      ? html`<span>Loading...</span>`
+      : html`<ul>${this.items.map(item => html`<li>${item}</li>`)}</ul>`}
+  </div>
+`;
+```
+
 ## Keyboard
 
 - Tab order must match visual order.
@@ -84,6 +130,34 @@ Use compound components when a component has multiple related parts that need to
 - Escape dismisses overlays and popups.
 - Visible `:focus-visible` indicators on all interactive elements.
 - Trap focus inside modals.
+
+```js
+// Escape to close — clean up listeners properly
+connectedCallback() {
+  super.connectedCallback();
+  this._handleKeydown = (e) => {
+    if (e.key === 'Escape' && this.open) {
+      this.open = false;
+    }
+  };
+  document.addEventListener('keydown', this._handleKeydown);
+}
+
+disconnectedCallback() {
+  super.disconnectedCallback();
+  document.removeEventListener('keydown', this._handleKeydown);
+}
+```
+
+```css
+/* Visible focus for keyboard users */
+button:focus-visible {
+  outline: 2px solid var(--focus-color);
+  outline-offset: 2px;
+}
+
+/* Never remove focus outline without an alternative */
+```
 
 ## Styling
 
@@ -102,6 +176,30 @@ Use compound components when a component has multiple related parts that need to
 - Event names: kebab-case, `ol-<component>-<action>` format (e.g., `ol-pagination-change`).
 - Set `bubbles: true` and `composed: true` so events cross Shadow DOM boundaries.
 - Document every emitted event in the class JSDoc with `@fires`.
+
+## Slots
+
+Named slots let consumers inject content without the component needing to know about it:
+
+```js
+render() {
+  return html`
+    <div class="card">
+      <header><slot name="header"></slot></header>
+      <div class="content"><slot></slot></div>
+      <footer><slot name="footer"></slot></footer>
+    </div>
+  `;
+}
+```
+
+```html
+<ol-card>
+  <h3 slot="header">Book Title</h3>
+  <p>Description in the default slot.</p>
+  <button slot="footer">Borrow</button>
+</ol-card>
+```
 
 ## New Component Checklist
 

--- a/docs/ai/web-components.md
+++ b/docs/ai/web-components.md
@@ -163,6 +163,7 @@ button:focus-visible {
 
 - Scope all styles via Lit's `static styles` (Shadow DOM).
 - Use OL design tokens where possible. Token files live in `static/css/tokens/`.
+- Avoid outer margins on reusable components — spacing between elements is the parent's responsibility.
 
 ## Lifecycle and Performance
 


### PR DESCRIPTION
Copying some wiki content into the codebase to accelerate development when AI assistance is used. 

### Technical
- New css.md: BEM naming, selector rules, design tokens, CSS-to-template wiring, bundle sizes
- design.md: Add two-tier design token system (primitives vs semantic)
- web-components.md: Add decision framework, a11y/keyboard code examples, slot examples
- README.md: Link new css.md in Topic Guides

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@RayBB @mekarpeles @cdrini 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
