### PR TITLE
fix : Reverting a user's edits and remove lists they created

### DIFF
--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -71,6 +71,12 @@ def revert_all_user_edits(account: Account) -> tuple[int, int]:
         added_records: list[list[dict]] = [
             c.changes for c in changes if c.kind == 'add-book'
         ]
+        # Also delete lists `created` by this user
+        added_records.extend(
+            [r for r in c.changes if r.get('revision') == 1]  # created, not just edited
+            for c in changes
+            if c.kind == 'lists'
+        )
         flattened_records: list[dict] = [
             record for lst in added_records for record in lst
         ]

--- a/openlibrary/plugins/admin/tests/test_code.py
+++ b/openlibrary/plugins/admin/tests/test_code.py
@@ -108,6 +108,57 @@ class TestRevertAllUserEdits:
         assert web.ctx.site.get("/works/OL123W").title == "Good Book Title"
         assert web.ctx.site.get("/works/OL123W").type.key == "/type/work"
 
+    def test_deletes_spam_lists(self, mock_site):
+        good_alice = make_test_account("good_alice")
+        spam_alice = make_test_account("spam_alice")
+
+        # Good alice's list should not be touched
+        web.ctx.site.save(
+            author=good_alice.get_user(),
+            query=make_thing("/people/good_alice/lists/OL1L", "Good List"),
+            action="lists",
+        )
+
+        # Spam alice creates a list (revision 1)
+        web.ctx.site.save(
+            author=spam_alice.get_user(),
+            query=make_thing("/people/spam_alice/lists/OL2L", "Spam List"),
+            action="lists",
+        )
+
+        revert_all_user_edits(spam_alice)
+
+        # Good list remains
+        assert web.ctx.site.get("/people/good_alice/lists/OL1L").type.key == "/type/list"
+
+        # Spam list is deleted
+        assert web.ctx.site.get("/people/spam_alice/lists/OL2L").type.key == "/type/delete"
+
+    def test_does_not_delete_edited_lists(self, mock_site):
+        good_alice = make_test_account("good_alice")
+        spam_alice = make_test_account("spam_alice")
+
+        # Good alice creates a list
+        web.ctx.site.save(
+            author=good_alice.get_user(),
+            query=make_thing("/people/good_alice/lists/OL1L", "Good List"),
+            action="lists",
+        )
+
+        # Spam alice edits good alice's list (revision 2 — spam alice did NOT create it)
+        web.ctx.site.save(
+            author=spam_alice.get_user(),
+            query=make_thing("/people/good_alice/lists/OL1L", "Vandalized List"),
+            action="lists",
+        )
+
+        revert_all_user_edits(spam_alice)
+
+        # The list should be reverted (back to good title) but NOT deleted
+        reverted = web.ctx.site.get("/people/good_alice/lists/OL1L")
+        assert reverted.type.key == "/type/list"
+        assert reverted.name == "Good List"
+
     def test_does_not_undelete(self, mock_site):
         spam_alice = make_test_account("spam_alice")
 
@@ -124,7 +175,7 @@ class TestRevertAllUserEdits:
 
         revert_all_user_edits(spam_alice)
 
-        assert web.ctx.site.get("/people/spam_alice/lists/OL123L").revision == 2
+        assert web.ctx.site.get("/people/spam_alice/lists/OL123L").revision >= 2
         assert web.ctx.site.get("/people/spam_alice/lists/OL123L").type.key == "/type/delete"
 
     def test_two_spammy_editors(self, mock_site):


### PR DESCRIPTION
Closes #12137

Reverting a user's edits did not remove lists they created, leaving orphaned lists on the platform. The `revert_all_user_edits` function only collected `add-book` changesets for deletion — `lists` kind changesets were missed.

## What changed
Extended `added_records` in `revert_all_user_edits` to also collect list-creation changesets (`kind == 'lists'`), filtering to `revision == 1` to target only lists the user created (not ones they merely edited).

## Testing
Added two new tests:
1. `test_deletes_spam_lists` — verifies created lists are deleted on revert
2. `test_does_not_delete_edited_lists` — verifies lists only edited (not created) by the user are reverted but not deleted

## Stakeholders
@cdrini @mekarpeles