### PR TITLE
closes #12168 nginx reverse proxy opds

### DIFF
--- a/docker/web_nginx.conf
+++ b/docker/web_nginx.conf
@@ -137,7 +137,7 @@ server {
         add_header Access-Control-Allow-Origin "*" always;
         add_header Access-Control-Allow-Methods "GET, OPTIONS" always;
         add_header Access-Control-Allow-Headers "Content-Type" always;
-        return 301 /opds/;
+        return 308 /opds/;
     }
 
     location / {


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Closes #12168

<!-- What issue does this PR close? -->
This pull request adds a new reverse proxy configuration for the `/opds` endpoint in the `docker/web_nginx.conf` file. This allows requests to `/opds` to be forwarded to an external backend service, with appropriate headers set for proper proxying.

**Reverse Proxy Configuration:**

* Added a new `location /opds` block that proxies requests to `https://ol-opds.prod.archive.org/`, sets several proxy headers and adds a custom response header `X-OPDS-Backend`, and disables proxy redirects.

Blocked on https://github.com/ArchiveLabs/opds.openlibrary.org/issues/9

The internal app https://github.com/archivelabs/opds.openlibrary.org needs an env set for BASE_URL to https://openlibrary.org/opds because otherwise it renders feed w/ https://ol-opds.prod.archive.org/ which isn't what we want.
