### PR TITLE
fix(docker): add --no-install-recommends to apt-get installs (#2656)

### DIFF
--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -14,7 +14,7 @@ RUN groupadd --system --gid 999 openlibrary \
   && useradd --no-log-init --system -u 999 --gid openlibrary --create-home openlibrary
 
 # Misc OL dependencies
-RUN apt-get -qq update && apt-get install -y \
+RUN apt-get -qq update && apt-get install -y --no-install-recommends \
     postgresql-client \
     build-essential \
     git \

--- a/scripts/install_nodejs.sh
+++ b/scripts/install_nodejs.sh
@@ -3,7 +3,7 @@
 NODE_MAJOR=24
 
 # Download and import the Nodesource GPG key
-apt-get install -y ca-certificates curl gnupg
+apt-get install -y --no-install-recommends ca-certificates curl gnupg
 mkdir -p /etc/apt/keyrings
 curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 
@@ -12,4 +12,4 @@ echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.co
 
 # Run Update and Install
 apt-get update
-apt-get install nodejs -y
+apt-get install -y --no-install-recommends nodejs

--- a/scripts/monitoring/Dockerfile
+++ b/scripts/monitoring/Dockerfile
@@ -14,7 +14,7 @@ RUN \
     # and it causes issues with some of the various prod protections we have in place.
     # apt-get update && \
     # Add Docker's official GPG key:
-    apt-get install ca-certificates curl && \
+    apt-get install -y --no-install-recommends ca-certificates curl && \
     install -m 0755 -d /etc/apt/keyrings && \
     curl -fsSL ${DOCKER_KEY_URL} -o /etc/apt/keyrings/docker.asc && \
     chmod a+r /etc/apt/keyrings/docker.asc && \
@@ -24,7 +24,7 @@ RUN \
 # Only apt-update the docker source list, to avoid checking the others which might not be accessible
 RUN apt-get update -o Dir::Etc::sourcelist="sources.list.d/docker.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" && \
     # We just need the CLI since we're running in a container with socket access
-    apt-get install -y docker-ce-cli
+    apt-get install -y --no-install-recommends docker-ce-cli
 
 
 # Install netcat
@@ -42,7 +42,7 @@ RUN if [ -n "$APT_MIRROR" ]; \
     else \
         apt-get update; \
   fi && \
-    apt-get install -y netcat-traditional
+    apt-get install -y --no-install-recommends netcat-traditional
 
 # Install requirements.txt
 COPY --chown=openlibrary:openlibrary scripts/monitoring/requirements.txt scripts/monitoring/requirements.txt

--- a/scripts/solr_restarter/Dockerfile
+++ b/scripts/solr_restarter/Dockerfile
@@ -10,7 +10,7 @@ RUN \
     # and it causes issues with some of the various prod protections we have in place.
     # apt-get update && \
     # Add Docker's official GPG key:
-    apt-get install ca-certificates curl && \
+    apt-get install -y --no-install-recommends ca-certificates curl && \
     install -m 0755 -d /etc/apt/keyrings && \
     curl -fsSL ${DOCKER_KEY_URL} -o /etc/apt/keyrings/docker.asc && \
     chmod a+r /etc/apt/keyrings/docker.asc && \
@@ -20,7 +20,7 @@ RUN \
 # Only apt-update the docker source list, to avoid checking the others which might not be accessible
 RUN apt-get update -o Dir::Etc::sourcelist="sources.list.d/docker.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" && \
     # We just need the CLI since we're running in a container with socket access
-    apt-get install -y docker-ce-cli
+    apt-get install -y --no-install-recommends docker-ce-cli
 
 
 COPY . /app


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2656

### Summary

Adds `--no-install-recommends` to `apt-get install` usage in Docker-related files ([issue #2656](https://github.com/internetarchive/openlibrary/issues/2656)). This follows Ubuntu’s guidance to avoid pulling in recommended packages, yielding smaller images and more explicit dependencies.

### Files changed

| File | Change |
|------|--------|
| `docker/Dockerfile.olbase` | `apt-get install -y` → `apt-get install -y --no-install-recommends` for the main package set |
| `scripts/install_nodejs.sh` | `--no-install-recommends` on Node-related `apt-get install` lines |
| `scripts/solr_restarter/Dockerfile` | `--no-install-recommends` for `ca-certificates`/`curl` and `docker-ce-cli` |
| `scripts/monitoring/Dockerfile` | Same for Docker CLI installs and `netcat-traditional` |

### Technical

- No application/runtime Python/JS logic changes—only Debian package installation flags.
- If anything relied on an implicit “recommended” package, CI or local builds should surface it; we can add explicit packages in a follow-up if needed.

### Testing

- [x] Local `docker compose build` completed without errors before `docker compose up`.
- [x] `docker compose build` completed successfully (see build excerpt below).
- [x] `docker compose up -d` — stack started; services healthy enough to serve traffic.
- [x] **http://localhost:8080** loads; homepage shows **development version** (screenshot in section below).

### Screenshot

<img width="1512" height="982" alt="Screenshot 2026-03-24 at 06 17 32" src="https://github.com/user-attachments/assets/a35b3ef5-b912-4dd1-997e-47f46d3a3c00" />

### Stakeholders

cc @cdrini @scottbarnes — context from [#2656](https://github.com/internetarchive/openlibrary/issues/2656).