### PR TITLE
Remove unused reduce_seeds function from engine.py

### DIFF
--- a/openlibrary/core/lists/engine.py
+++ b/openlibrary/core/lists/engine.py
@@ -3,8 +3,6 @@
 import collections
 import re
 
-
-
 RE_SUBJECT = re.compile("[, _]+")
 
 

--- a/openlibrary/core/lists/engine.py
+++ b/openlibrary/core/lists/engine.py
@@ -4,26 +4,6 @@ import collections
 import re
 
 
-def reduce_seeds(values):
-    """Function to reduce the seed values got from works db."""
-    d = {
-        "works": 0,
-        "editions": 0,
-        "ebooks": 0,
-        "last_update": "",
-    }
-    subject_processor = SubjectProcessor()
-
-    for v in values:
-        d["works"] += v[0]
-        d['editions'] += v[1]
-        d['ebooks'] += v[2]
-        d['last_update'] = max(d['last_update'], v[3])
-        subject_processor.add_subjects(v[4])
-
-    d['subjects'] = subject_processor.top_subjects()
-    return d
-
 
 RE_SUBJECT = re.compile("[, _]+")
 


### PR DESCRIPTION
Confirmed that reduce_seeds is not used anywhere in the repository.

<!-- What issue does this PR close? -->
Closes #12112

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
refactor

### Technical
<!-- What should be noted about the implementation? -->
- Removed the `reduce_seeds` function
- No other parts of the codebase were affected

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Searched the repository to confirm `reduce_seeds` is not referenced elsewhere
- Verified that no import or usage exists
- Ensured no errors occur after removal

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A (backend code cleanup)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
