### PR TITLE
Fix duplicate Series additions and unselected text validation bugs in Work Edit UI

### DIFF
--- a/openlibrary/plugins/openlibrary/js/autocomplete.js
+++ b/openlibrary/plugins/openlibrary/js/autocomplete.js
@@ -119,7 +119,7 @@ export function init() {
                         }
                         $errorDiv.text(message).show();
                         setTimeout(function() { $errorDiv.fadeOut() }, 4000);
-                        
+
                         $this.val('');
                         return false; // Prevent selection
                     }
@@ -192,13 +192,13 @@ export function init() {
                     if ($textInput.val().trim() !== '' && $keyInput.val().trim() === '') {
                         $textInput.css({ 'border-color': '#e44028', 'background-color': '#fcece9' });
                         var $errorDiv = $textInput.siblings('.ac-unselected-error');
-                        
+
                         // MUST create the div first before trying to set its text!
                         if (!$errorDiv.length) {
                             $errorDiv = $('<div class="ac-unselected-error" style="color: #e44028; font-size: 0.9em; margin-top: 4px;"></div>').insertAfter($textInput);
                         }
-                        $errorDiv.text("Please select an option from the dropdown to link it.").show();
-                        
+                        $errorDiv.text('Please select an option from the dropdown to link it.').show();
+
                         setTimeout(function() { $errorDiv.fadeOut() }, 3000);
                     } else {
                         $textInput.css({ 'border-color': '', 'background-color': '' });

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -386,7 +386,7 @@ export function initSeriesMultiInputAutocomplete() {
     $('form').on('submit.seriesValidation', function(e) {
         var invalidSeries = false;
         var $firstInvalid = null;
-        
+
         $('.multi-input-autocomplete--series .ac-input').each(function() {
             var $textInput = $(this).find('.ac-input__visible');
             var $keyInput = $(this).find('.ac-input__value');
@@ -403,9 +403,9 @@ export function initSeriesMultiInputAutocomplete() {
 
         if (invalidSeries) {
             e.preventDefault();
-            alert("Please select a Series from the dropdown list menu to link it, or clear the text box.");
+            alert('Please select a Series from the dropdown list menu to link it, or clear the text box.');
             if ($firstInvalid) {
-                setTimeout(function() { $firstInvalid.focus(); }, 10);
+                setTimeout(function() { $firstInvalid.trigger('focus'); }, 10);
             }
             return false;
         }

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -588,18 +588,28 @@ class SaveBookHelper:
 
         formdata = utils.unflatten(formdata)
 
-        if 'work' in formdata and isinstance(formdata['work'], dict) and 'series' in formdata['work']:
+        if (
+            'work' in formdata
+            and isinstance(formdata['work'], dict)
+            and 'series' in formdata['work']
+        ):
             seen_series_keys = set()
             unique_work_series = []
             unique_series_names = []
-            
+
             raw_work_series = formdata['work'].get('series', [])
             raw_series_names = formdata.get('series', [])
-            
+
             for s_idx, s_obj in enumerate(raw_work_series):
-                s_name = raw_series_names[s_idx] if s_idx < len(raw_series_names) else ""
-                
-                if isinstance(s_obj, dict) and 'series' in s_obj and isinstance(s_obj['series'], dict):
+                s_name = (
+                    raw_series_names[s_idx] if s_idx < len(raw_series_names) else ""
+                )
+
+                if (
+                    isinstance(s_obj, dict)
+                    and 'series' in s_obj
+                    and isinstance(s_obj['series'], dict)
+                ):
                     s_key = s_obj['series'].get('key', '').strip()
                     if not s_key:
                         continue
@@ -611,7 +621,7 @@ class SaveBookHelper:
                 else:
                     unique_work_series.append(s_obj)
                     unique_series_names.append(s_name)
-                    
+
             formdata['work']['series'] = unique_work_series
             formdata['series'] = unique_series_names
 


### PR DESCRIPTION
Closes #12165

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
**fix:** Resolves data-integrity and UX bugs where duplicate Work Series were allowed to persist without warning, and unlinked series text (where a user failed to click a dropdown autocomplete result) was silently dropped.

### Technical
<!-- What should be noted about the implementation? -->
* **Frontend UI**:
  * Added literal text scanning to the duplicate validation logic in [autocomplete.js](cci:7://file:///Users/harshul/Contribution/openlibrary/openlibrary/plugins/openlibrary/js/autocomplete.js:0:0-0:0). This prevents users from adding rows containing the exact same String, which previously bypassed validation filters by exploiting empty canonical keys or shared `__new__` identifiers.
  * Added a native `focusout` event listener during autocomplete instance initialization ([autocomplete.js](cci:7://file:///Users/harshul/Contribution/openlibrary/openlibrary/plugins/openlibrary/js/autocomplete.js:0:0-0:0)). When a user types text but fails to connect it to a canonical Key (by clicking on the dropdown), the component now instantly alerts them by turning the field red with an inline warning.
  * Added a strict Javascript `.submit()` handler inside [edit.js](cci:7://file:///Users/harshul/Contribution/openlibrary/openlibrary/plugins/openlibrary/js/edit.js:0:0-0:0) that intercepts the "Save Changes" action to explicitly halt submission if unlinked series text exists, throwing a browser alert rather than permitting the backend to blindly erase it.
* **Backend ([addbook.py](cci:7://file:///Users/harshul/Contribution/openlibrary/openlibrary/plugins/upstream/addbook.py:0:0-0:0))**: 
  * Enforced server-side array deduplication within `SaveBookHelper.save` prior to processing.
  * Explicitly handled `key == '__new__'` cases to prevent collisions when a user creates multiple new Series instances on the same screen.
  * Explicitly stripped `key == ''` cases to prevent `KeyError` crashes if manually malformed raw POST data slips through.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Navigate to the Work Edit page of any Book.
2. Inside the **Work Series** section, manually type identical string values into two separate rows (e.g. "Harry Potter") and click "Create New Record" for both. Verify that it immediately blocks the second entry with an inline error.
3. Type any text into a Series row and intentionally hit "Tab" or click away from the input, bypassing the dropdown options. Check that a red inline error message immediately appears asking you to select it from the dropdown. 
4. Attempt to hit "Save Changes" on the page while leaving that unlinked row in its errored state. Verify that the form submission is halted and an explicit browser alert box pops up correctly.
5. Manually create two entirely different "New" series names using the dropdown UI, and verify upon Save that the backend properly registers and isolates both individual records. 

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

https://github.com/user-attachments/assets/614fa842-f8a6-4565-8c2e-d9287436a67c

### Stakeholders
@cdrini 

Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code.
