### PR TITLE
Redesign Locate button as "Check Options" with on-site anchor navigation

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -338,7 +338,7 @@ msgid "Checked Out"
 msgstr ""
 
 #: LocateButton.html
-msgid "Locate"
+msgid "Check Options"
 msgstr ""
 
 #: ManageLoansButtons.html admin/loans_table.html

--- a/openlibrary/macros/LocateButton.html
+++ b/openlibrary/macros/LocateButton.html
@@ -1,14 +1,14 @@
 $def with(edition_key, icon=False)
 
-$ locateUrl = "/books/XXX/-/borrow?action=locate".replace('XXX', edition_key or '')
+$ locateUrl = "/books/XXX#check-options".replace('XXX', edition_key or '')
 
 $if icon:
-  <a class="cta-btn cta-btn--available cta-btn--w-icon cta-btn--external" href="$locateUrl" target="_blank" rel="noopener noreferrer"
-    data-ol-link-track="CTAClick|Locate">
+  <a class="cta-btn cta-btn--available cta-btn--w-icon" href="$locateUrl"
+    data-ol-link-track="CTAClick|CheckOptions">
 
     <span class="btn-icon map"></span>
-    <span class="btn-label">$_("Locate")</span>
+    <span class="btn-label">$_("Check Options")</span>
   </a>
 $else:
-  <a class="cta-btn cta-btn--available cta-btn--external" href="$locateUrl" target="_blank" rel="noopener noreferrer"
-    data-ol-link-track="CTAClick|Locate">$_('Locate')</a>
+  <a class="cta-btn cta-btn--available" href="$locateUrl"
+    data-ol-link-track="CTAClick|CheckOptions">$_('Check Options')</a>

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -66,7 +66,7 @@ $ viewbook = "//%s/stream/XXX?ref=ol" % bookreader_host()
       </div>
     </div>
 
-    <div class="panel desktop-vendor">
+    <div class="panel desktop-vendor" id="check-options">
       <div class="btn-notice">
         $:worldcat_links
 

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -442,6 +442,14 @@ jQuery(function() {
             .removeAttr('open');
     });
 
+    // Show loading state on Check Options button click
+    document.querySelectorAll('[data-ol-link-track="CTAClick|CheckOptions"]').forEach(btn => {
+        btn.addEventListener('click', () => {
+            btn.classList.add('cta-btn--available--load');
+            setTimeout(() => btn.classList.remove('cta-btn--available--load'), 3000);
+        });
+    });
+
     // Prevent default star rating behavior:
     const ratingForms = document.querySelectorAll('.star-rating-form');
     if (ratingForms.length) {

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -13,6 +13,7 @@ from datetime import datetime
 from typing import Literal
 
 import web
+
 from infogami import config
 from infogami.infobase.utils import parse_datetime
 from infogami.utils import delegate
@@ -20,7 +21,6 @@ from infogami.utils.view import (
     add_flash_message,
     public,
 )
-
 from openlibrary import accounts
 from openlibrary.accounts.model import OpenLibraryAccount
 from openlibrary.app import render_template

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -13,7 +13,6 @@ from datetime import datetime
 from typing import Literal
 
 import web
-
 from infogami import config
 from infogami.infobase.utils import parse_datetime
 from infogami.utils import delegate
@@ -21,6 +20,7 @@ from infogami.utils.view import (
     add_flash_message,
     public,
 )
+
 from openlibrary import accounts
 from openlibrary.accounts.model import OpenLibraryAccount
 from openlibrary.app import render_template
@@ -107,7 +107,7 @@ class borrow(delegate.page):
     def GET(self, key):
         return self.POST(key)
 
-    def POST(self, key):  # noqa: PLR0912, PLR0915
+    def POST(self, key):  # noqa: PLR0915
         """Called when the user wants to borrow the edition"""
 
         i = web.input(
@@ -124,9 +124,6 @@ class borrow(delegate.page):
             raise web.notfound()
 
         from openlibrary.book_providers import get_book_provider
-
-        if action == "locate":
-            raise web.seeother(edition.get_worldcat_url())
 
         # Direct to the first web book if at least one is available.
         if (

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -308,7 +308,7 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
       </div>
 
       <div class="Tools">
-        <div class="panel mobile-vendor">
+        <div class="panel mobile-vendor" id="check-options">
           <div class="btn-notice">
             $:worldcat_links
 

--- a/static/css/components/read-panel.css
+++ b/static/css/components/read-panel.css
@@ -285,3 +285,38 @@ ul.ebook-download-options li {
   /* stylelint-enable selector-max-specificity */
   /* stylelint-enable max-nesting-depth */
 }
+
+/* Smooth scroll for Check Options anchor navigation */
+html {
+  scroll-behavior: smooth;
+}
+
+/* Base state required for border animation to work */
+.desktop-vendor,
+.mobile-vendor {
+  border: 1px solid transparent;
+  border-radius: 5px;
+}
+
+@keyframes check-options-highlight {
+  0% {
+    border: 1px solid transparent;
+    box-shadow: 0 0 10px transparent;
+  }
+
+  50% {
+    border: 1px solid var(--link-blue);
+    box-shadow: 0 0 10px var(--link-blue);
+  }
+
+  100% {
+    border: 1px solid transparent;
+    box-shadow: 0 0 10px transparent;
+  }
+}
+
+.desktop-vendor:target,
+.mobile-vendor:target {
+  animation: check-options-highlight 3s;
+  scroll-margin-top: 100px;
+}


### PR DESCRIPTION
Closes #12105

## Summary

- Renames the "Locate" CTA button to **"Check Options"** across all render contexts (search results, carousels, edition page)
- Changes the destination from an off-site WorldCat redirect (`/books/{key}/-/borrow?action=locate`) to an on-site anchor (`/books/{key}#check-options`) that scrolls to the edition page's vendor/library section
- Adds `id="check-options"` to both `.panel.desktop-vendor` (sidebar, shown on desktop) and `.panel.mobile-vendor` (main content, shown on mobile) so the anchor works at all breakpoints
- Adds a 3s glow animation (`:target` + `@keyframes`) using `var(--primary-blue)` to visually highlight the section on arrival — same pattern as PR #7125 (star ratings)
- Removes the now-dead `action == 'locate'` → WorldCat server-side redirect in `borrow.py`

## Files Changed

| File | Change |
|---|---|
| `openlibrary/macros/LocateButton.html` | Rename label, new anchor URL, drop `target="_blank"` / `cta-btn--external`, update analytics key |
| `openlibrary/macros/databarWork.html` | Add `id="check-options"` to `.desktop-vendor` |
| `openlibrary/templates/type/edition/view.html` | Add `id="check-options"` to `.mobile-vendor` |
| `static/css/components/read-panel.css` | Glow keyframe animation + `:target` rules + smooth scroll |
| `openlibrary/plugins/upstream/borrow.py` | Remove `action=locate` WorldCat redirect |

## Test plan

- [ ] On a book page, click "Check Options" — page should smooth-scroll to the vendor/library panel, which briefly glows blue
- [ ] From search results, click "Check Options" — should navigate to the edition page and scroll/highlight the vendor panel
- [ ] Verify on mobile (< 960px) — `.mobile-vendor` is the visible target and also receives the glow
- [ ] Confirm `data-ol-link-track="CTAClick|CheckOptions"` fires on click
- [ ] Confirm the old `/books/{key}/-/borrow?action=locate` URL no longer redirects to WorldCat (404 or falls through to borrow handler)
- [ ] Editions without ISBN/OCLC: vendor panel renders gracefully (WorldcatLink absent, affiliate links absent — section still present as anchor target)

## Reference

- Closes #12105
- Pattern from PR #7125 (star ratings scroll + highlight)
- Predecessor: #9952 (introduced the original Locate → WorldCat flow)