### PR TITLE
fix-styles

### DIFF
--- a/openlibrary/templates/site/head.html
+++ b/openlibrary/templates/site/head.html
@@ -2,125 +2,111 @@ $def with (title)
 
 <!DOCTYPE html>
 <html lang="$(get_lang() or 'en')">
+
 <head>
-    <meta charset="utf-8">
-    <meta name="format-detection" content="telephone=no">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    $if request.domain != 'openlibrary.org':
-        <meta name="robots" content="noindex">
-    <meta name="theme-color" content="#e2dcc5">
+  <meta charset="utf-8">
+  <meta name="format-detection" content="telephone=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  $if request.domain != 'openlibrary.org':
+  <meta name="robots" content="noindex">
+  <meta name="theme-color" content="#e2dcc5">
 
-    <link rel="canonical" href="$request.canonical_url" />
+  <link rel="canonical" href="$request.canonical_url" />
 
-    $if not is_bot():
-        <link rel="preconnect" href="https://athena.archive.org">
-        <link rel="preconnect" href="https://apollo.archive.org">
+  $if not is_bot():
+  <link rel="preconnect" href="https://athena.archive.org">
+  <link rel="preconnect" href="https://apollo.archive.org">
 
-    <link rel="search" type="application/opensearchdescription+xml" title="Open Library" href="/static/opensearch.xml">
-    <link rel="manifest" href="/static/manifest.json">
+  <link rel="search" type="application/opensearchdescription+xml" title="Open Library" href="/static/opensearch.xml">
+  <link rel="manifest" href="/static/manifest.json">
 
-    <link href="/static/images/openlibrary-128x128.png" rel="apple-touch-icon" />
-    <link href="/static/images/openlibrary-152x152.png" rel="apple-touch-icon" sizes="152x152" />
-    <link href="/static/images/openlibrary-167x167.png" rel="apple-touch-icon" sizes="167x167" />
-    <link href="/static/images/openlibrary-180x180.png" rel="apple-touch-icon" sizes="180x180" />
-    <link href="/static/images/openlibrary-192x192.png" rel="icon" sizes="192x192" />
-    <link href="/static/images/openlibrary-128x128.png" rel="icon" sizes="128x128" />
-    $# CSS Custom Properties (design tokens) - loaded separately for caching
-    <link href="$static_url('build/css/tokens.css')" rel="stylesheet" type="text/css" />
-    $ style = 'build/css/page-%s.css'%ctx.get('cssfile', 'user')
-    <link href="$static_url(style)" rel="stylesheet" type="text/css" />
+  <link href="/static/images/openlibrary-128x128.png" rel="apple-touch-icon" />
+  <link href="/static/images/openlibrary-152x152.png" rel="apple-touch-icon" sizes="152x152" />
+  <link href="/static/images/openlibrary-167x167.png" rel="apple-touch-icon" sizes="167x167" />
+  <link href="/static/images/openlibrary-180x180.png" rel="apple-touch-icon" sizes="180x180" />
+  <link href="/static/images/openlibrary-192x192.png" rel="icon" sizes="192x192" />
+  <link href="/static/images/openlibrary-128x128.png" rel="icon" sizes="128x128" />
+  $# CSS Custom Properties (design tokens) - loaded separately for caching
+  <link href="$static_url('build/css/tokens.css')" rel="stylesheet" type="text/css" />
+  $ style = 'build/css/page-%s.css'%ctx.get('cssfile', 'user')
+  <link href="$static_url(style)" rel="stylesheet" type="text/css" />
 
-    <!-- TODO: Move these pre-hydration web component styles into a dedicated CSS file -->
+  <!-- Pre-hydration web component styles -->
+  <link href="$static_url('build/css/pre-hydration.css')" rel="stylesheet" type="text/css" />
+
+  <noscript>
     <style>
-      /* Hide ol-read-more content before component is defined to prevent flash of unstyled content. The min-height is set to match the default height of the component. */
-      ol-read-more {
-        min-height: 121px;
-        visibility: hidden;
-        overflow: hidden;
-      }
-      ol-read-more[label-size="small"] {
-        min-height: 107px;
+      /* Don't hide content with clamp if no js to show more/less */
+      .clamp {
+        -webkit-line-clamp: unset !important;
       }
 
-      /* Reserve height for ol-chip before Lit hydrates to prevent layout shift */
-      ol-chip:not(:defined) {
-        display: inline-block;
-        height: 30px;
-      }
-      ol-chip[size="small"]:not(:defined) {
-        height: 24px;
+      /* @width-breakpoint-tablet media query: */
+      @media only screen and (min-width: 768px) {
+
+        /* Sticky navbar to top of screen if compact title cannot be stickied */
+        .work-menu {
+          top: 0 !important;
+        }
       }
     </style>
-
-    <noscript>
-      <style>
-        /* Don't hide content with clamp if no js to show more/less */
-        .clamp {
-          -webkit-line-clamp: unset !important;
-        }
-
-        /* @width-breakpoint-tablet media query: */
-        @media only screen and (min-width: 768px) {
-          /* Sticky navbar to top of screen if compact title cannot be stickied */
-          .work-menu {
-            top: 0 !important;
-          }
-        }
-      </style>
-    </noscript>
- <script>
- $if not is_bot():
-   var _mtm = window._mtm = window._mtm || [];
-   _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
-   (function() {
-     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-     g.async=true; g.src='https://apollo.archive.org/js/container_7cLc1b4U.js'; s.parentNode.insertBefore(g,s);
-   })();
-
-/* @licstart  The following is the entire license notice for the
- * JavaScript code in this page served from openlibrary.org.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * @licend  The above is the entire license notice
- * for the JavaScript code in this page.
- */
+  </noscript>
+  $if not is_bot():
+  <script>
+    var _mtm = window._mtm = window._mtm || [];
+    _mtm.push({ 'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start' });
+    (function () {
+      var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
+      g.async = true; g.src = 'https://apollo.archive.org/js/container_7cLc1b4U.js'; s.parentNode.insertBefore(g, s);
+    })();
   </script>
 
-    $if "dev" in ctx.features:
-        <link href="$static_url('build/css/page-dev.css')" rel="stylesheet" type="text/css"/>
+  <script>
+    /* @licstart  The following is the entire license notice for the
+     * JavaScript code in this page served from openlibrary.org.
+     *
+     * This program is free software: you can redistribute it and/or modify
+     * it under the terms of the GNU Affero General Public License as published by
+     * the Free Software Foundation, either version 3 of the License, or
+     * (at your option) any later version.
+     *
+     * This program is distributed in the hope that it will be useful,
+     * but WITHOUT ANY WARRANTY; without even the implied warranty of
+     * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+     * GNU Affero General Public License for more details.
+     *
+     * You should have received a copy of the GNU Affero General Public License
+     * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+     *
+     * @licend  The above is the entire license notice
+     * for the JavaScript code in this page.
+     */
+  </script>
 
-    <meta name="google-site-verification" content="KrqcZD4l5BLNVyjzSi2sjZBiwgmkJ1W7n6w7ThD7A74" />
-    <meta name="google-site-verification" content="vtXGm8q3UgP-f6qXTvQBo85uh3nmIYIotVqqdJDpyz4" />
-    $# Drini's Google Search Console
-    <meta name="google-site-verification" content="XYOJ9Uj0MBr6wk7kj1IkttXrqY-bbRstFMADTfEt354" />
-    $# Drini's Bing Webmaster Tools
-    <meta name="msvalidate.01" content="8BEBECBEF537077737975A49D55B857D" />
+  $if "dev" in ctx.features:
+  <link href="$static_url('build/css/page-dev.css')" rel="stylesheet" type="text/css" />
 
-    $if ctx.get("robots"):
-        <meta name="robots" content="$ctx.robots" />
+  <meta name="google-site-verification" content="KrqcZD4l5BLNVyjzSi2sjZBiwgmkJ1W7n6w7ThD7A74" />
+  <meta name="google-site-verification" content="vtXGm8q3UgP-f6qXTvQBo85uh3nmIYIotVqqdJDpyz4" />
+  $# Drini's Google Search Console
+  <meta name="google-site-verification" content="XYOJ9Uj0MBr6wk7kj1IkttXrqY-bbRstFMADTfEt354" />
+  $# Drini's Bing Webmaster Tools
+  <meta name="msvalidate.01" content="8BEBECBEF537077737975A49D55B857D" />
 
-    $if ctx.get("description"):
-        <meta name="description" content="$ctx.description" />
-    $else:
-        <meta name="description" content="$_('Open Library is an open, editable library catalog, building towards a web page for every book ever published. Read, borrow, and discover more than 3M books for free.')" />
+  $if ctx.get("robots"):
+  <meta name="robots" content="$ctx.robots" />
 
-    <title>$:title | $_("Open Library")</title>
+  $if ctx.get("description"):
+  <meta name="description" content="$ctx.description" />
+  $else:
+  <meta name="description"
+    content="$_('Open Library is an open, editable library catalog, building towards a web page for every book ever published. Read, borrow, and discover more than 3M books for free.')" />
 
-    $for link in ctx.get("links", []):
-        $:link
+  <title>$:title | $_("Open Library")</title>
 
-    $for tag in ctx.get("metatags", []):
-        $:tag
+  $for link in ctx.get("links", []):
+  $:link
+
+  $for tag in ctx.get("metatags", []):
+  $:tag
 </head>

--- a/static/css/pre-hydration.css
+++ b/static/css/pre-hydration.css
@@ -1,0 +1,18 @@
+/* Hide ol-read-more content before component is defined to prevent flash of unstyled content. The min-height is set to match the default height of the component. */
+ol-read-more {
+  min-height: 121px;
+  visibility: hidden;
+  overflow: hidden;
+}
+ol-read-more[label-size="small"] {
+  min-height: 107px;
+}
+
+/* Reserve height for ol-chip before Lit hydrates to prevent layout shift */
+ol-chip:not(:defined) {
+  display: inline-block;
+  height: 30px;
+}
+ol-chip[size="small"]:not(:defined) {
+  height: 24px;
+}

--- a/webpack.config.css.js
+++ b/webpack.config.css.js
@@ -19,6 +19,7 @@ const cssFiles = glob.sync('./static/css/page-*.css');
 const entries = {
     // Design tokens — compiled from static/css/tokens/ into a single file
     tokens: './static/css/tokens.css',
+    'pre-hydration': './static/css/pre-hydration.css',
 };
 
 cssFiles.forEach(file => {


### PR DESCRIPTION

Closes #12202 


**Refactor:** This PR moves the inline CSS out of the main HTML file ([head.html](cci:7://file:///Users/eshantharjun/Desktop/iauxgsoc/openlibrary/openlibrary/templates/site/head.html:0:0-0:0)) and puts it into its own dedicated CSS file. This makes our code much cleaner, easier to maintain, and helps the browser cache the file for better performance. 

### Technical

- Extracted the inline `<style>` block for `ol-read-more` and `ol-chip` and moved it into [static/css/pre-hydration.css](cci:7://file:///Users/eshantharjun/Desktop/iauxgsoc/openlibrary/static/css/pre-hydration.css:0:0-0:0).
- Updated [head.html](cci:7://file:///Users/eshantharjun/Desktop/iauxgsoc/openlibrary/openlibrary/templates/site/head.html:0:0-0:0) to link to this new stylesheet.
- Added the new file to [webpack.config.css.js](cci:7://file:///Users/eshantharjun/Desktop/iauxgsoc/openlibrary/webpack.config.css.js:0:0-0:0) so it gets built properly.
- As a bonus fix, I moved a Python `$if` tag outside of the Matomo `<script>` block so that IDEs and code linters stop throwing an "Unexpected keyword or identifier" error when trying to parse the `<script>` contents as JavaScript.

### Testing

1. Run the local development server.
2. Navigate to pages that use web components like the "Read More" component or the "Chips".
3. Check that the components load smoothly without any sudden jumping or "flash of unstyled content" before the JavaScript kicks in.

### Screenshot

*No visible UI changes, this is a background code cleanup to keep things organized.*

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@Arnav-0206

