### PR TITLE
Multi-commit edits

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -74,6 +74,7 @@ features:
     support: admin
     undo: enabled
     upstream: enabled
+    multi_commit_edits: enabled
 
 upstream_to_www_migration: true
 default_template_root: /upstream

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -579,25 +579,10 @@ class SaveBookHelper:
         """
         comment = formdata.pop('_comment', '')
 
-        user = accounts.get_current_user()
-        delete = (
-            user
-            and (user.is_admin() or user.is_super_librarian())
-            and formdata.pop('_delete', '')
-        )
-
         formdata = utils.unflatten(formdata)
         work_data, edition_data = self.process_input(formdata)
 
         saveutil = DocSaveHelper()
-
-        if delete:
-            if self.edition:
-                self.delete(self.edition.key, comment=comment)
-
-            if self.work and self.work.edition_count == 0:
-                self.delete(self.work.key, comment=comment)
-            return
 
         just_editing_work = edition_data is None
         if work_data:
@@ -892,9 +877,23 @@ class book_edit(delegate.page):
         else:
             work = None
 
+        if is_delete_req := ("_delete" in i):
+            user = accounts.get_current_user()
+            permitted_groups = ["/usergroup/super-librarians", "/usergroup/admin"]
+            if not user or not user.is_member_of(permitted_groups):
+                raise web.unauthorized()
+
         try:
             helper = SaveBookHelper(work, edition)
-            helper.save(web.input())
+            if is_delete_req:
+                # delete and return
+                comment = i.pop('_comment', '')
+                if edition:
+                    SaveBookHelper.delete(edition.key, comment=comment)
+                if work and work.edition_count == 0:
+                    SaveBookHelper.delete(work.key, comment=comment)
+            else:
+                helper.save(web.input())
 
             add_flash_message("info", utils.get_message("flash_catalog_updated"))
 
@@ -954,9 +953,22 @@ class work_edit(delegate.page):
         if work is None:
             raise web.notfound()
 
+        if is_delete_req := ("_delete" in i):
+            user = accounts.get_current_user()
+            permitted_groups = ["/usergroup/super-librarians", "/usergroup/admin"]
+            if not user or not user.is_member_of(permitted_groups):
+                raise web.unauthorized()
+
         try:
             helper = SaveBookHelper(work, None)
-            helper.save(web.input())
+            if is_delete_req:
+                if work.edition_count != 0:
+                    raise web.badrequest("Cannot delete work that is associated with editions.")
+                comment = i.pop('_comment', '')
+                SaveBookHelper.delete(work.key, comment=comment)
+            else:
+                helper.save(web.input())
+
             add_flash_message("info", utils.get_message("flash_catalog_updated"))
             raise safe_seeother(work.url())
         except (ClientException, ValidationException) as e:

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -235,7 +235,7 @@ class MultiCommitSaveUtility(DocSaveUtility):
     @staticmethod
     def prepare_commits(revision: dict, original: dict, delim="|") -> list[AnnotatedCommit]:
         commits = []
-        diff_paths = diff_objects(revision, original)
+        diff_paths = diff_objects(revision, original, delim=delim)
 
         def apply_single_diff(_revision, _original, _path: str):
             result = copy.deepcopy(_original)
@@ -684,13 +684,11 @@ class SaveBookHelper:
         """
         :param Work|None work:          None if editing an orphan edition
         :param Edition|None edition:    None if just editing work
-        :param dict|None orig_work:     The original state of the work. `None` if work is new
-        :param dict|None orig_edition:  The original state of the edition.  `None` if edition is new
         """
         self.work = work
         self.edition = edition
-        self.orig_work: dict|None = copy.deepcopy(work.dict()) if work else None
-        self.orig_edition: dict|None = copy.deepcopy(edition.dict()) if edition else None
+        self.orig_work: dict|None = work.dict() if work else None
+        self.orig_edition: dict|None = edition.dict() if edition else None
 
     def save(self, formdata: web.Storage) -> None:
         """
@@ -802,7 +800,7 @@ class SaveBookHelper:
             _kwargs = {"orig_doc": self.orig_edition} if using_granular_edits else {}
             saveutil.save(self.edition, **_kwargs)
 
-        saveutil.commit(comment=comment)
+        saveutil.commit(comment=comment, action="edit-book")
 
     @staticmethod
     def new_work(edition: Edition) -> Work:

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -1,10 +1,13 @@
 """Handlers for adding and editing books."""
 
+import copy
 import csv
 import datetime
 import io
 import logging
 import urllib
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Literal, NoReturn, overload
 
 import web
@@ -13,7 +16,7 @@ from web.webapi import SeeOther
 from infogami import config
 from infogami.core.db import ValidationException
 from infogami.infobase.client import ClientException
-from infogami.utils import delegate
+from infogami.utils import delegate, features
 from infogami.utils.view import add_flash_message, safeint
 from openlibrary import accounts
 from openlibrary.core.helpers import uniq
@@ -125,23 +128,23 @@ def new_doc(type_: str, **data) -> Author | Edition | Work | List | Series:
     data['type'] = {"key": type_}
     return web.ctx.site.new(key, data)
 
+class DocSaveUtility(ABC):
 
-class DocSaveHelper:
-    """Simple utility to collect the saves and save them together at the end."""
-
-    def __init__(self):
-        self.docs = []
-
+    @abstractmethod
     def save(self, doc) -> None:
-        """Adds the doc to the list of docs to be saved."""
-        if not isinstance(doc, dict):  # thing
-            doc = doc.dict()
-        self.docs.append(doc)
+        """
+        Stages the given doc for persistence in Infobase.
 
-    def commit(self, **kw) -> None:
-        """Saves all the collected docs."""
-        if self.docs:
-            web.ctx.site.save_many(self.docs, **kw)
+        DOES NOT ACTUALLY SAVE THE DOCUMENT.
+        """
+        pass
+
+    @abstractmethod
+    def commit(self):
+        """
+        Saves the staged documents in Infobase.
+        """
+        pass
 
     def create_authors_from_form_data(
         self, authors: list[dict], author_names: list[str], _test: bool = False
@@ -180,6 +183,155 @@ class DocSaveHelper:
                     self.save(doc)
                     series_dict['series']['key'] = doc.key
         return created
+
+
+@dataclass
+class DocumentRevision:
+    """Represents the full set of changes made to a single record via an edit UI.
+
+    If a new record is being created, `original` will be `None`.
+
+    Args:
+        revised:  A representation of the record containing all the updated values.
+        original: A representation of the record's initial state, or `None` if the record being created.
+    """
+    revised: dict
+    original: dict|None
+
+
+@dataclass
+class AnnotatedCommit:
+    """Represents a record that is ready to be persisted, and its corresponding action."""
+    doc: dict
+    action: str
+
+
+class MultiCommitSaveUtility(DocSaveUtility):
+    """
+    Utility that saves record edits using one transaction per modified attribute.
+    """
+    def __init__(self):
+        self.docs: list[DocumentRevision] = []
+
+    def save(self, doc, orig_doc: dict|None=None) -> None:
+        if not isinstance(doc, dict):  # thing
+            doc = doc.dict()
+        self.docs.append(DocumentRevision(revised=doc, original=orig_doc))
+
+    def commit(self, **kw) -> None:
+        if 'action' in kw:
+            del kw['action']
+        for doc in self.docs:
+            doc_type = doc.revised['type']['key'].split('/')[-1]
+            if doc.original:
+                # Make granular commits
+                commits = self.prepare_commits(doc.revised, doc.original)
+                for commit in commits:
+                    web.ctx.site.save(commit.doc, action=f'update-{doc_type}-{commit.action}', **kw)
+            else:
+                # Commit new record in a single transaction
+                web.ctx.site.save(doc.revised, action=f"add-{doc_type}", **kw)
+
+    @staticmethod
+    def prepare_commits(revision: dict, original: dict, delim="|") -> list[AnnotatedCommit]:
+        commits = []
+        def diff_objects(obj1, obj2, path: str="") -> list[str]:
+            """
+            Recursively compare two objects and return a list of differing delimited attribute paths.
+
+            Example output: ['description', 'identifiers|foo', 'publisher']
+            """
+            diffs = []
+
+            # Both are plain objects (custom classes) — check first before dict/list
+            if hasattr(obj1, "__dict__") and hasattr(obj2, "__dict__"):
+                keys = set(vars(obj1)) | set(vars(obj2))
+                for k in keys:
+                    full = f"{path}{delim}{k}" if path else k
+                    if not hasattr(obj1, k) or not hasattr(obj2, k):
+                        diffs.append(full)
+                    else:
+                        diffs.extend(diff_objects(getattr(obj1, k), getattr(obj2, k), full))
+
+            # Both are dicts
+            elif isinstance(obj1, dict) and isinstance(obj2, dict):
+                keys = set(obj1) | set(obj2)
+                for k in keys:
+                    full = f"{path}{delim}{k}" if path else k
+                    if k not in obj1 or k not in obj2:
+                        diffs.append(full)
+                    else:
+                        diffs.extend(diff_objects(obj1[k], obj2[k], full))
+
+            # Both are lists/tuples
+            elif isinstance(obj1, (list, tuple)) and isinstance(obj2, (list, tuple)):
+                if obj1 != obj2:
+                    diffs.append(path)
+
+            # Primitives / fallback
+            else:
+                if obj1 != obj2:
+                    diffs.append(path)
+
+            return diffs
+
+        diff_paths = diff_objects(revision, original)
+
+        def apply_single_diff(_revision, _original, _path: str):
+            result = copy.deepcopy(_original)
+            segments = _path.split(delim)
+
+            def get_node(obj, segs):
+                for s in segs:
+                    if isinstance(obj, dict):
+                        obj = obj[s]
+                    else:
+                        obj = getattr(obj, s)
+                return obj
+
+            def set_node(obj, segs, value):
+                for s in segs[:-1]:
+                    if isinstance(obj, dict):
+                        obj = obj[s]
+                    else:
+                        obj = getattr(obj, s)
+                last = segs[-1]
+                if isinstance(obj, dict):
+                    obj[last] = value
+                else:
+                    setattr(obj, last, value)
+
+            src_value = copy.deepcopy(get_node(_revision, segments))
+            set_node(result, segments, src_value)
+            return result
+
+        updated_rec = original
+        for p in diff_paths:
+            updated_rec = apply_single_diff(revision, updated_rec, p)
+            commits.append(AnnotatedCommit(
+                doc=updated_rec,
+                action=p.replace(delim, '-')
+            ))
+
+        return commits
+
+
+class DocSaveHelper(DocSaveUtility):
+    """Simple utility to collect the saves and save them together at the end."""
+
+    def __init__(self):
+        self.docs = []
+
+    def save(self, doc) -> None:
+        """Adds the doc to the list of docs to be saved."""
+        if not isinstance(doc, dict):  # thing
+            doc = doc.dict()
+        self.docs.append(doc)
+
+    def commit(self, **kw) -> None:
+        """Saves all the collected docs."""
+        if self.docs:
+            web.ctx.site.save_many(self.docs, **kw)
 
 
 def encode_url_path(url: str) -> str:
@@ -266,7 +418,10 @@ class addbook(delegate.page):
                 )
 
         i = utils.unflatten(i)
-        saveutil = DocSaveHelper()
+
+        using_granular_edits = features.is_enabled('multi_commit_edits')
+        saveutil = MultiCommitSaveUtility() if using_granular_edits else DocSaveHelper()
+
         created_author = saveutil.create_authors_from_form_data(
             i.authors, i.author_names, _test=i._test == 'true'
         )
@@ -567,22 +722,27 @@ class SaveBookHelper:
 
     def __init__(self, work: Work | None, edition: Edition | None):
         """
-        :param Work|None work: None if editing an orphan edition
-        :param Edition|None edition: None if just editing work
+        :param Work|None work:          None if editing an orphan edition
+        :param Edition|None edition:    None if just editing work
+        :param dict|None orig_work:     The original state of the work. `None` if work is new
+        :param dict|None orig_edition:  The original state of the edition.  `None` if edition is new
         """
         self.work = work
         self.edition = edition
+        self.orig_work: dict|None = copy.deepcopy(work.dict()) if work else None
+        self.orig_edition: dict|None = copy.deepcopy(edition.dict()) if edition else None
 
     def save(self, formdata: web.Storage) -> None:
         """
         Update work and edition documents according to the specified formdata.
         """
+        using_granular_edits = features.is_enabled('multi_commit_edits')
         comment = formdata.pop('_comment', '')
 
         formdata = utils.unflatten(formdata)
         work_data, edition_data = self.process_input(formdata)
 
-        saveutil = DocSaveHelper()
+        saveutil = MultiCommitSaveUtility() if using_granular_edits else DocSaveHelper()
 
         just_editing_work = edition_data is None
         if work_data:
@@ -615,7 +775,9 @@ class SaveBookHelper:
                 work_identifiers = work_data.pop('identifiers', {})
                 self.work.set_identifiers(work_identifiers)
                 self.work.update(work_data)
-                saveutil.save(self.work)
+
+                _kwargs = {"orig_doc": self.orig_work} if using_granular_edits else {}
+                saveutil.save(self.work, **_kwargs)
 
         if self.edition and edition_data:
             # Create a new work if so desired
@@ -645,7 +807,8 @@ class SaveBookHelper:
                             new_work[field] = val
 
                 self.work = new_work
-                saveutil.save(self.work)
+                _kwargs = {"orig_doc": None} if using_granular_edits else {}
+                saveutil.save(self.work, **_kwargs)
 
             identifiers = edition_data.pop('identifiers', [])
             self.edition.set_identifiers(identifiers)
@@ -675,9 +838,11 @@ class SaveBookHelper:
             self.edition.set_providers(providers)
 
             self.edition.update(edition_data)
-            saveutil.save(self.edition)
 
-        saveutil.commit(comment=comment, action="edit-book")
+            _kwargs = {"orig_doc": self.orig_edition} if using_granular_edits else {}
+            saveutil.save(self.edition, **_kwargs)
+
+        saveutil.commit(comment=comment)
 
     @staticmethod
     def new_work(edition: Edition) -> Work:
@@ -689,9 +854,9 @@ class SaveBookHelper:
         )
 
     @staticmethod
-    def delete(key, comment=""):
+    def delete(key, comment="", action=""):
         doc = web.ctx.site.new(key, {"key": key, "type": {"key": "/type/delete"}})
-        doc._save(comment=comment)
+        doc._save(comment=comment, action=action)
 
     def process_input(self, i):
         if 'edition' in i:
@@ -965,7 +1130,7 @@ class work_edit(delegate.page):
                 if work.edition_count != 0:
                     raise web.badrequest("Cannot delete work that is associated with editions.")
                 comment = i.pop('_comment', '')
-                SaveBookHelper.delete(work.key, comment=comment)
+                SaveBookHelper.delete(work.key, comment=comment, action="work-delete")
             else:
                 helper.save(web.input())
 
@@ -1055,7 +1220,8 @@ class work_identifiers(delegate.view):
     def POST(self, edition):
         if not accounts.get_current_user():
             raise web.unauthorized()
-        saveutil = DocSaveHelper()
+        using_granular_edits = features.is_enabled('multi_commit_edits')
+        saveutil = MultiCommitSaveUtility() if using_granular_edits else DocSaveHelper()
         i = web.input(isbn="")
         isbn = i.get("isbn")
         # Need to do some simple validation here. Perhaps just check if it's a number?
@@ -1068,8 +1234,10 @@ class work_identifiers(delegate.view):
         else:
             add_flash_message("error", "The ISBN number you entered was not valid")
             raise web.redirect(web.ctx.path)
+        orig_edition = edition.dict()
         edition.set_identifiers(data)
-        saveutil.save(edition)
+        _kwargs = {"orig_doc": orig_edition} if using_granular_edits else {}
+        saveutil.save(edition, **_kwargs)
         saveutil.commit(comment="Added an %s identifier." % typ, action="edit-book")
         add_flash_message("info", "Thank you very much for improving that record!")
         raise web.redirect(web.ctx.path)

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -26,7 +26,7 @@ from openlibrary.plugins.recaptcha import recaptcha
 from openlibrary.plugins.upstream import spamcheck, utils
 from openlibrary.plugins.upstream.models import Author, Edition, Work
 from openlibrary.plugins.upstream.table_of_contents import TocParseError
-from openlibrary.plugins.upstream.utils import fuzzy_find, render_template
+from openlibrary.plugins.upstream.utils import diff_objects, fuzzy_find, render_template
 from openlibrary.plugins.worksearch.search import get_solr
 from openlibrary.utils.request_context import site
 
@@ -235,46 +235,6 @@ class MultiCommitSaveUtility(DocSaveUtility):
     @staticmethod
     def prepare_commits(revision: dict, original: dict, delim="|") -> list[AnnotatedCommit]:
         commits = []
-        def diff_objects(obj1, obj2, path: str="") -> list[str]:
-            """
-            Recursively compare two objects and return a list of differing delimited attribute paths.
-
-            Example output: ['description', 'identifiers|foo', 'publisher']
-            """
-            diffs = []
-
-            # Both are plain objects (custom classes) — check first before dict/list
-            if hasattr(obj1, "__dict__") and hasattr(obj2, "__dict__"):
-                keys = set(vars(obj1)) | set(vars(obj2))
-                for k in keys:
-                    full = f"{path}{delim}{k}" if path else k
-                    if not hasattr(obj1, k) or not hasattr(obj2, k):
-                        diffs.append(full)
-                    else:
-                        diffs.extend(diff_objects(getattr(obj1, k), getattr(obj2, k), full))
-
-            # Both are dicts
-            elif isinstance(obj1, dict) and isinstance(obj2, dict):
-                keys = set(obj1) | set(obj2)
-                for k in keys:
-                    full = f"{path}{delim}{k}" if path else k
-                    if k not in obj1 or k not in obj2:
-                        diffs.append(full)
-                    else:
-                        diffs.extend(diff_objects(obj1[k], obj2[k], full))
-
-            # Both are lists/tuples
-            elif isinstance(obj1, (list, tuple)) and isinstance(obj2, (list, tuple)):
-                if obj1 != obj2:
-                    diffs.append(path)
-
-            # Primitives / fallback
-            else:
-                if obj1 != obj2:
-                    diffs.append(path)
-
-            return diffs
-
         diff_paths = diff_objects(revision, original)
 
         def apply_single_diff(_revision, _original, _path: str):

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -1130,14 +1130,21 @@ class author_edit(delegate.page):
             if not formdata:
                 raise web.badrequest()
             elif "_save" in i:
+                using_granular_edits = features.is_enabled('multi_commit_edits')
+                saveutil = MultiCommitSaveUtility() if using_granular_edits else DocSaveHelper()
+
+                orig_author = author.dict()
                 author.update(formdata)
-                author._save(comment=i._comment)
+
+                _kwargs = {"orig_doc": orig_author} if using_granular_edits else {}
+                saveutil.save(author.dict(), **_kwargs)
+                saveutil.commit(comment=i._comment, action="edit-author")
                 raise safe_seeother(key)
             elif "_delete" in i:
                 author = web.ctx.site.new(
                     key, {"key": key, "type": {"key": "/type/delete"}}
                 )
-                author._save(comment=i._comment)
+                author._save(comment=i._comment, action="delete-author")
                 raise safe_seeother(key)
         except (ClientException, ValidationException) as e:
             add_flash_message('error', str(e))

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -128,6 +128,7 @@ def new_doc(type_: str, **data) -> Author | Edition | Work | List | Series:
     data['type'] = {"key": type_}
     return web.ctx.site.new(key, data)
 
+
 class DocSaveUtility(ABC):
 
     @abstractmethod
@@ -195,13 +196,15 @@ class DocumentRevision:
         revised:  A representation of the record containing all the updated values.
         original: A representation of the record's initial state, or `None` if the record being created.
     """
+
     revised: dict
-    original: dict|None
+    original: dict | None
 
 
 @dataclass
 class AnnotatedCommit:
     """Represents a record that is ready to be persisted, and its corresponding action."""
+
     doc: dict
     action: str
 
@@ -210,30 +213,34 @@ class MultiCommitSaveUtility(DocSaveUtility):
     """
     Utility that saves record edits using one transaction per modified attribute.
     """
+
     def __init__(self):
         self.docs: list[DocumentRevision] = []
 
-    def save(self, doc, orig_doc: dict|None=None) -> None:
+    def save(self, doc, orig_doc: dict | None = None) -> None:
         if not isinstance(doc, dict):  # thing
             doc = doc.dict()
         self.docs.append(DocumentRevision(revised=doc, original=orig_doc))
 
     def commit(self, **kw) -> None:
-        if 'action' in kw:
-            del kw['action']
+        kw.pop('action', None)
         for doc in self.docs:
             doc_type = doc.revised['type']['key'].split('/')[-1]
             if doc.original:
                 # Make granular commits
                 commits = self.prepare_commits(doc.revised, doc.original)
                 for commit in commits:
-                    web.ctx.site.save(commit.doc, action=f'update-{doc_type}-{commit.action}', **kw)
+                    web.ctx.site.save(
+                        commit.doc, action=f'update-{doc_type}-{commit.action}', **kw
+                    )
             else:
                 # Commit new record in a single transaction
                 web.ctx.site.save(doc.revised, action=f"add-{doc_type}", **kw)
 
     @staticmethod
-    def prepare_commits(revision: dict, original: dict, delim="|") -> list[AnnotatedCommit]:
+    def prepare_commits(
+        revision: dict, original: dict, delim="|"
+    ) -> list[AnnotatedCommit]:
         commits = []
         diff_paths = diff_objects(revision, original, delim=delim)
 
@@ -268,10 +275,9 @@ class MultiCommitSaveUtility(DocSaveUtility):
         updated_rec = original
         for p in diff_paths:
             updated_rec = apply_single_diff(revision, updated_rec, p)
-            commits.append(AnnotatedCommit(
-                doc=updated_rec,
-                action=p.replace(delim, '-')
-            ))
+            commits.append(
+                AnnotatedCommit(doc=updated_rec, action=p.replace(delim, '-'))
+            )
 
         return commits
 
@@ -687,8 +693,8 @@ class SaveBookHelper:
         """
         self.work = work
         self.edition = edition
-        self.orig_work: dict|None = work.dict() if work else None
-        self.orig_edition: dict|None = edition.dict() if edition else None
+        self.orig_work: dict | None = work.dict() if work else None
+        self.orig_edition: dict | None = edition.dict() if edition else None
 
     def save(self, formdata: web.Storage) -> None:
         """
@@ -1086,7 +1092,9 @@ class work_edit(delegate.page):
             helper = SaveBookHelper(work, None)
             if is_delete_req:
                 if work.edition_count != 0:
-                    raise web.badrequest("Cannot delete work that is associated with editions.")
+                    raise web.badrequest(
+                        "Cannot delete work that is associated with editions."
+                    )
                 comment = i.pop('_comment', '')
                 SaveBookHelper.delete(work.key, comment=comment, action="work-delete")
             else:
@@ -1129,7 +1137,11 @@ class author_edit(delegate.page):
                 raise web.badrequest()
             elif "_save" in i:
                 using_granular_edits = features.is_enabled('multi_commit_edits')
-                saveutil = MultiCommitSaveUtility() if using_granular_edits else DocSaveHelper()
+                saveutil = (
+                    MultiCommitSaveUtility()
+                    if using_granular_edits
+                    else DocSaveHelper()
+                )
 
                 orig_author = author.dict()
                 author.update(formdata)

--- a/openlibrary/plugins/upstream/tests/test_utils.py
+++ b/openlibrary/plugins/upstream/tests/test_utils.py
@@ -395,14 +395,18 @@ def diff(*args, **kwargs):
 
 # --- Identical inputs ---
 
+
 def test_identical_dicts():
     assert diff({"a": 1}, {"a": 1}) == []
+
 
 def test_identical_nested_dicts():
     assert diff({"a": {"b": 1}}, {"a": {"b": 1}}) == []
 
+
 def test_identical_lists():
     assert diff({"a": [1, 2]}, {"a": [1, 2]}) == []
+
 
 def test_empty_dicts():
     assert diff({}, {}) == []
@@ -410,14 +414,18 @@ def test_empty_dicts():
 
 # --- Flat dicts ---
 
+
 def test_missing_key_in_obj2():
     assert diff({"a": 1, "b": 2}, {"a": 1}) == ["b"]
+
 
 def test_missing_key_in_obj1():
     assert diff({"a": 1}, {"a": 1, "b": 2}) == ["b"]
 
+
 def test_different_primitive_value():
     assert diff({"a": 1}, {"a": 2}) == ["a"]
+
 
 def test_multiple_differing_keys():
     assert diff({"a": 1, "b": 2}, {"a": 9, "b": 9}) == ["a", "b"]
@@ -425,11 +433,14 @@ def test_multiple_differing_keys():
 
 # --- Type mismatches ---
 
+
 def test_str_vs_list():
     assert diff({"a": ""}, {"a": []}) == ["a"]
 
+
 def test_int_vs_str():
     assert diff({"a": 1}, {"a": "1"}) == ["a"]
+
 
 def test_none_vs_str():
     assert diff({"a": None}, {"a": ""}) == ["a"]
@@ -437,11 +448,14 @@ def test_none_vs_str():
 
 # --- Nested dicts ---
 
+
 def test_nested_diff():
     assert diff({"a": {"b": 1}}, {"a": {"b": 2}}) == ["a|b"]
 
+
 def test_nested_missing_key():
     assert diff({"a": {"b": 1, "c": 2}}, {"a": {"b": 1}}) == ["a|c"]
+
 
 def test_deeply_nested_diff():
     assert diff({"a": {"b": {"c": 1}}}, {"a": {"b": {"c": 2}}}) == ["a|b|c"]
@@ -449,11 +463,14 @@ def test_deeply_nested_diff():
 
 # --- Lists ---
 
+
 def test_list_values_differ():
     assert diff({"a": [1, 2]}, {"a": [1, 3]}) == ["a"]
 
+
 def test_list_length_differs():
     assert diff({"a": [1]}, {"a": [1, 2]}) == ["a"]
+
 
 def test_list_order_matters():
     assert diff({"a": [1, 2]}, {"a": [2, 1]}) == ["a"]
@@ -461,9 +478,11 @@ def test_list_order_matters():
 
 # --- Custom delimiter ---
 
+
 def test_custom_delim():
     result = utils.diff_objects({"a": {"b": 1}}, {"a": {"b": 2}}, delim=".")
     assert sorted(result) == ["a.b"]
+
 
 def test_custom_delim_deep():
     result = utils.diff_objects({"a": {"b": {"c": 1}}}, {"a": {"b": {"c": 2}}}, delim="/")
@@ -472,15 +491,19 @@ def test_custom_delim_deep():
 
 # --- Edge cases ---
 
+
 def test_both_empty_lists():
     assert diff({"a": []}, {"a": []}) == []
 
+
 def test_both_none():
     assert diff({"a": None}, {"a": None}) == []
+
 
 def test_multiple_nested_diffs():
     obj1 = {"a": {"x": 1, "y": 2}, "b": 3}
     obj2 = {"a": {"x": 9, "y": 2}, "b": 4}
     assert diff(obj1, obj2) == ["a|x", "b"]
+
 
 # END : diff_objects tests

--- a/openlibrary/plugins/upstream/tests/test_utils.py
+++ b/openlibrary/plugins/upstream/tests/test_utils.py
@@ -385,3 +385,102 @@ def test_get_language_name(add_languages):  # noqa: F811
     assert utils.get_language_name("/languages/ger", "en") == "German"
     # Falls back to name when translation missing for requested language
     assert utils.get_language_name("/languages/ger", "fr") == "Deutsch"
+
+
+# START : diff_objects tests
+def diff(*args, **kwargs):
+    """Sort output so assertions are order-independent."""
+    return sorted(utils.diff_objects(*args, **kwargs))
+
+
+# --- Identical inputs ---
+
+def test_identical_dicts():
+    assert diff({"a": 1}, {"a": 1}) == []
+
+def test_identical_nested_dicts():
+    assert diff({"a": {"b": 1}}, {"a": {"b": 1}}) == []
+
+def test_identical_lists():
+    assert diff({"a": [1, 2]}, {"a": [1, 2]}) == []
+
+def test_empty_dicts():
+    assert diff({}, {}) == []
+
+
+# --- Flat dicts ---
+
+def test_missing_key_in_obj2():
+    assert diff({"a": 1, "b": 2}, {"a": 1}) == ["b"]
+
+def test_missing_key_in_obj1():
+    assert diff({"a": 1}, {"a": 1, "b": 2}) == ["b"]
+
+def test_different_primitive_value():
+    assert diff({"a": 1}, {"a": 2}) == ["a"]
+
+def test_multiple_differing_keys():
+    assert diff({"a": 1, "b": 2}, {"a": 9, "b": 9}) == ["a", "b"]
+
+
+# --- Type mismatches ---
+
+def test_str_vs_list():
+    assert diff({"a": ""}, {"a": []}) == ["a"]
+
+def test_int_vs_str():
+    assert diff({"a": 1}, {"a": "1"}) == ["a"]
+
+def test_none_vs_str():
+    assert diff({"a": None}, {"a": ""}) == ["a"]
+
+
+# --- Nested dicts ---
+
+def test_nested_diff():
+    assert diff({"a": {"b": 1}}, {"a": {"b": 2}}) == ["a|b"]
+
+def test_nested_missing_key():
+    assert diff({"a": {"b": 1, "c": 2}}, {"a": {"b": 1}}) == ["a|c"]
+
+def test_deeply_nested_diff():
+    assert diff({"a": {"b": {"c": 1}}}, {"a": {"b": {"c": 2}}}) == ["a|b|c"]
+
+
+# --- Lists ---
+
+def test_list_values_differ():
+    assert diff({"a": [1, 2]}, {"a": [1, 3]}) == ["a"]
+
+def test_list_length_differs():
+    assert diff({"a": [1]}, {"a": [1, 2]}) == ["a"]
+
+def test_list_order_matters():
+    assert diff({"a": [1, 2]}, {"a": [2, 1]}) == ["a"]
+
+
+# --- Custom delimiter ---
+
+def test_custom_delim():
+    result = utils.diff_objects({"a": {"b": 1}}, {"a": {"b": 2}}, delim=".")
+    assert sorted(result) == ["a.b"]
+
+def test_custom_delim_deep():
+    result = utils.diff_objects({"a": {"b": {"c": 1}}}, {"a": {"b": {"c": 2}}}, delim="/")
+    assert sorted(result) == ["a/b/c"]
+
+
+# --- Edge cases ---
+
+def test_both_empty_lists():
+    assert diff({"a": []}, {"a": []}) == []
+
+def test_both_none():
+    assert diff({"a": None}, {"a": None}) == []
+
+def test_multiple_nested_diffs():
+    obj1 = {"a": {"x": 1, "y": 2}, "b": 3}
+    obj2 = {"a": {"x": 9, "y": 2}, "b": 4}
+    assert diff(obj1, obj2) == ["a|x", "b"]
+
+# END : diff_objects tests

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -1696,6 +1696,37 @@ def subject_name_to_key(subject: str, prefix='') -> str:
     return f'/subjects/{prefix}{subject.lower().replace(' ', '_').replace(',', '').replace('/', '')}'
 
 
+def diff_objects(obj1, obj2, path: str="", delim="|") -> list[str]:
+    """
+    Recursively compare two objects and return a list of differing delimited attribute paths.
+
+    Example output: ['description', 'identifiers|foo', 'publisher']
+    """
+    diffs = []
+
+    # Both are dicts
+    if isinstance(obj1, dict) and isinstance(obj2, dict):
+        keys = set(obj1) | set(obj2)
+        for k in keys:
+            full = f"{path}{delim}{k}" if path else k
+            if k not in obj1 or k not in obj2:
+                diffs.append(full)
+            else:
+                diffs.extend(diff_objects(obj1[k], obj2[k], path=full, delim=delim))
+
+    # Both are lists/tuples
+    elif isinstance(obj1, (list, tuple)) and isinstance(obj2, (list, tuple)):
+        if obj1 != obj2:
+            diffs.append(path)
+
+    # Primitives / fallback
+    else:
+        if obj1 != obj2:
+            diffs.append(path)
+
+    return diffs
+
+
 def setup_requests(config=config) -> None:
     logger.info("Setting up requests")
 

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -1696,7 +1696,7 @@ def subject_name_to_key(subject: str, prefix='') -> str:
     return f'/subjects/{prefix}{subject.lower().replace(' ', '_').replace(',', '').replace('/', '')}'
 
 
-def diff_objects(obj1, obj2, path: str="", delim="|") -> list[str]:
+def diff_objects(obj1, obj2, path: str = "", delim="|") -> list[str]:
     """
     Recursively compare two objects and return a list of differing delimited attribute paths.
 
@@ -1720,9 +1720,8 @@ def diff_objects(obj1, obj2, path: str="", delim="|") -> list[str]:
             diffs.append(path)
 
     # Primitives / fallback
-    else:
-        if obj1 != obj2:
-            diffs.append(path)
+    elif obj1 != obj2:
+        diffs.append(path)
 
     return diffs
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #12176

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Add functionality for multi-commit edits, and enables this feature in local instances.  When this feature is enabled, any edition, work, or author record updated via the UI will be saved using multiple transactions -- one per attribute changed.  Newly created records will be persisted with a single `web.ctx.site.save` call.

Additionally, the book and work delete authorization checks were moved from the `SaveBookHelper` to the respective edit POST handlers.  This will make adding delete requests to the merge queue a bit easier.

### Technical
<!-- What should be noted about the implementation? -->
Book records are currently created and updated via the `DocSaveHelper` utility, which stages and persists each record. To support feature-flagging this behavior, a new abstract base class — `DocSaveUtility` — was introduced. Both `DocSaveHelper` and the new `MultiCommitSaveUtility` extend it.  Whenever the `multi_commit_edits` feature is enabled, `MultiCommitSaveUtility` is used to persist the records.

On `commit` call, the `MulitCommitSaveUtility` constructs the `action` event name from the edit type, record type, and name of updated attribute (if applicable).  For backwards compatibility with `DocSaveHelper`, `MultiCommitSaveUtility.commit` accepts an `action` keyword parameter.  If `action` is included in a `MultiCommitSaveUtility.commit` call, it is discarded in favor of the derived event name.

The POST handler for author edits has been updated to use either `DocSaveUtility`.  Previously, it was persisting updates with a `Thing._save()` call in the handler itself.

A new `diff_objects` utility function was created to compare two `dict` representations of Thing objects.  This returns a list of modified attribute paths (e.g. `description` or `identifiers|foo`) that are later used to apply updates to records one-by-one.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
With the `multi_commit_edits` feature enabled:

1. Edit a book or author via the UI.  Make sure to change multiple fields.
2. Check the record's history table for a quick dose of sanity.
3. Query for recent transactions to ensure that the actions are properly set:

```sql
SELECT * FROM transaction ORDER BY id DESC LIMIT 10; -- Adjust limit if more than 10 fields were changed.
```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
