### PR TITLE
refactor: Extract pre-hydration web component styles into dedicated C…

### DIFF
--- a/openlibrary/templates/site/head.html
+++ b/openlibrary/templates/site/head.html
@@ -27,30 +27,10 @@ $def with (title)
     <link href="/static/images/openlibrary-128x128.png" rel="icon" sizes="128x128" />
     $# CSS Custom Properties (design tokens) - loaded separately for caching
     <link href="$static_url('build/css/tokens.css')" rel="stylesheet" type="text/css" />
+    $# Pre-hydration styles — prevents FOUC for web components before JS hydration
+    <link href="$static_url('build/css/pre-hydration.css')" rel="stylesheet" type="text/css" />
     $ style = 'build/css/page-%s.css'%ctx.get('cssfile', 'user')
     <link href="$static_url(style)" rel="stylesheet" type="text/css" />
-
-    <!-- TODO: Move these pre-hydration web component styles into a dedicated CSS file -->
-    <style>
-      /* Hide ol-read-more content before component is defined to prevent flash of unstyled content. The min-height is set to match the default height of the component. */
-      ol-read-more {
-        min-height: 121px;
-        visibility: hidden;
-        overflow: hidden;
-      }
-      ol-read-more[label-size="small"] {
-        min-height: 107px;
-      }
-
-      /* Reserve height for ol-chip before Lit hydrates to prevent layout shift */
-      ol-chip:not(:defined) {
-        display: inline-block;
-        height: 30px;
-      }
-      ol-chip[size="small"]:not(:defined) {
-        height: 24px;
-      }
-    </style>
 
     <noscript>
       <style>

--- a/static/css/components/pre-hydration.css
+++ b/static/css/components/pre-hydration.css
@@ -1,0 +1,28 @@
+/**
+ * Pre-hydration web component styles
+ *
+ * Prevents FOUC and layout shift for web components
+ * before JavaScript defines/hydrates them.
+ * Loaded globally in <head> via a dedicated stylesheet.
+ */
+
+/* ol-read-more */
+ol-read-more {
+  min-height: 121px;
+  visibility: hidden;
+  overflow: hidden;
+}
+
+ol-read-more[label-size="small"] {
+  min-height: 107px;
+}
+
+/* ol-chip */
+ol-chip:not(:defined) {
+  display: inline-block;
+  height: 30px;
+}
+
+ol-chip[size="small"]:not(:defined) {
+  height: 24px;
+}

--- a/webpack.config.css.js
+++ b/webpack.config.css.js
@@ -19,6 +19,8 @@ const cssFiles = glob.sync('./static/css/page-*.css');
 const entries = {
     // Design tokens — compiled from static/css/tokens/ into a single file
     tokens: './static/css/tokens.css',
+    // Pre-hydration styles for web components — loaded globally in <head>
+    'pre-hydration': './static/css/components/pre-hydration.css',
 };
 
 cssFiles.forEach(file => {


### PR DESCRIPTION
Closes #12202
This PR implements the refactor discussed in #12202.

Refactor

### Technical

This PR extracts inline pre-hydration styles from `templates/site/head.html` into a dedicated CSS file.

* Added `static/css/components/pre-hydration.css` to contain styles for `ol-read-more` and `ol-chip`
* Registered the new stylesheet in `webpack.config.css.js` as a standalone entry (consistent with `tokens.css`)
* Replaced the inline `<style>` block in `head.html` with a `<link>` to the compiled stylesheet

This ensures styles are applied early to prevent layout shift or flash of unstyled content (FOUC), while improving maintainability and enabling browser caching.

### Testing

* Ran the project locally using Docker (`localhost:8080`)
* Verified that components (`ol-read-more`, `ol-chip`) render correctly on initial load
* Confirmed no flash of unstyled content (FOUC) or layout shift
* Verified that the stylesheet is correctly loaded via page source

### Screenshot

No visible UI changes — this is a structural refactor. Components render as expected before and after hydration.

