### PR TITLE
Use sessionStorage for search facet persistence

### DIFF
--- a/openlibrary/plugins/openlibrary/js/SearchUtils.js
+++ b/openlibrary/plugins/openlibrary/js/SearchUtils.js
@@ -57,7 +57,7 @@ export class PersistentValue {
      * @return {String}
      */
     read() {
-        return localStorage.getItem(this.key);
+        return sessionStorage.getItem(this.key);
     }
 
     /**
@@ -72,9 +72,9 @@ export class PersistentValue {
         }
 
         if (toWrite === null) {
-            localStorage.removeItem(this.key);
+            sessionStorage.removeItem(this.key);
         } else {
-            localStorage.setItem(this.key, toWrite);
+            sessionStorage.setItem(this.key, toWrite);
         }
 
         if (oldValue !== toWrite) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "openlibrary",
       "version": "1.0.0",
       "license": "AGPL-3.0",
-      "dependencies": {
-        "postcss-less": "^6.0.0"
-      },
       "devDependencies": {
         "@babel/core": "^7.24.7",
         "@babel/eslint-parser": "^7.24.7",
@@ -40,9 +37,6 @@
         "jquery-colorbox": "1.6.4",
         "jquery-ui": "1.13.2",
         "jquery-ui-touch-punch": "0.2.3",
-        "less": "^4.2.0",
-        "less-loader": "^12.2.0",
-        "less-plugin-clean-css": "^1.6.0",
         "lit": "^3.2.1",
         "lodash": "4.17.21",
         "lucene-query-parser": "1.2.0",
@@ -5983,19 +5977,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/clean-css": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
-      "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "source-map": "~0.6.0"
-      },
-      "engines": {
-        "node": ">= 10.0"
-      }
-    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -6160,14 +6141,6 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
-    },
-    "node_modules/copy-anything": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-what": "^3.12.0"
-      }
     },
     "node_modules/core-js": {
       "version": "3.40.0",
@@ -7045,18 +7018,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/errno": {
-      "version": "0.1.7",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "prr": "~1.0.1"
-      },
-      "bin": {
-        "errno": "cli.js"
       }
     },
     "node_modules/error-ex": {
@@ -8731,18 +8692,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/image-size": {
-      "version": "0.5.5",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -9364,11 +9313,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/is-what": {
-      "version": "3.14.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/isarray": {
       "version": "2.0.5",
@@ -10615,76 +10559,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/less": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/less/-/less-4.2.0.tgz",
-      "integrity": "sha512-P3b3HJDBtSzsXUl0im2L7gTO5Ubg8mEN6G8qoTS77iXxXX4Hvu4Qj540PZDvQ8V6DmX6iXo98k7Md0Cm1PrLaA==",
-      "dev": true,
-      "dependencies": {
-        "copy-anything": "^2.0.1",
-        "parse-node-version": "^1.0.1",
-        "tslib": "^2.3.0"
-      },
-      "bin": {
-        "lessc": "bin/lessc"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "optionalDependencies": {
-        "errno": "^0.1.1",
-        "graceful-fs": "^4.1.2",
-        "image-size": "~0.5.0",
-        "make-dir": "^2.1.0",
-        "mime": "^1.4.1",
-        "needle": "^3.1.0",
-        "source-map": "~0.6.0"
-      }
-    },
-    "node_modules/less-loader": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/less-loader/-/less-loader-12.2.0.tgz",
-      "integrity": "sha512-MYUxjSQSBUQmowc0l5nPieOYwMzGPUaTzB6inNW/bdPEG9zOL3eAAD1Qw5ZxSPk7we5dMojHwNODYMV1hq4EVg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 18.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "@rspack/core": "0.x || 1.x",
-        "less": "^3.5.0 || ^4.0.0",
-        "webpack": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@rspack/core": {
-          "optional": true
-        },
-        "webpack": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/less-plugin-clean-css": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/less-plugin-clean-css/-/less-plugin-clean-css-1.6.0.tgz",
-      "integrity": "sha512-jwXX6WlXT57OVCXa5oBJBaJq1b4s1BOKeEEoAL2UTeEitogQWfTcBbLT/vow9pl0N0MXV8Mb4KyhTGG0YbEKyQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "clean-css": "5.3.3"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/less/node_modules/tslib": {
-      "version": "2.6.0",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/leven": {
       "version": "3.1.0",
       "dev": true,
@@ -10830,19 +10704,6 @@
         "sourcemap-codec": "^1.4.8"
       }
     },
-    "node_modules/make-dir": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "pify": "^4.0.1",
-        "semver": "^5.6.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -10917,18 +10778,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/mime": {
-      "version": "1.6.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/mime-db": {
@@ -11078,6 +10927,7 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11134,32 +10984,6 @@
       "dependencies": {
         "cwise-compiler": "^1.1.2",
         "ndarray": "^1.0.13"
-      }
-    },
-    "node_modules/needle": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "debug": "^3.2.6",
-        "iconv-lite": "^0.6.3",
-        "sax": "^1.2.4"
-      },
-      "bin": {
-        "needle": "bin/needle"
-      },
-      "engines": {
-        "node": ">= 4.4.x"
-      }
-    },
-    "node_modules/needle/node_modules/debug": {
-      "version": "3.2.7",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ms": "^2.1.1"
       }
     },
     "node_modules/neo-async": {
@@ -11443,14 +11267,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/parse-node-version": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -11551,6 +11367,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -11621,6 +11438,7 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -11779,16 +11597,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.4.32"
-      }
-    },
-    "node_modules/postcss-less": {
-      "version": "6.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "postcss": "^8.3.5"
       }
     },
     "node_modules/postcss-merge-longhand": {
@@ -12518,12 +12326,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/prr": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/psl": {
       "version": "1.8.0",
       "dev": true,
@@ -13002,15 +12804,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/semver": {
-      "version": "5.7.1",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
@@ -13290,6 +13083,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"

--- a/tests/unit/js/SearchBar.test.js
+++ b/tests/unit/js/SearchBar.test.js
@@ -19,7 +19,7 @@ describe('SearchBar', () => {
             sb = new SearchBar($(DUMMY_COMPONENT_HTML));
             sinon.stub(sb, 'getCurUrl').returns(new URL('https://openlibrary.org/search'));
         });
-        afterEach(() => localStorage.clear());
+        afterEach(() => sessionStorage.clear());
         test('Does not throw on empty params', () => {
             sb.initFromUrlParams({});
         });
@@ -49,9 +49,9 @@ describe('SearchBar', () => {
         });
 
         test('Persists value in url param', () => {
-            expect(localStorage.getItem('facet')).not.toBe('title');
+            expect(sessionStorage.getItem('facet')).not.toBe('title');
             sb.initFromUrlParams({facet: 'title'});
-            expect(localStorage.getItem('facet')).toBe('title');
+            expect(sessionStorage.getItem('facet')).toBe('title');
         });
     });
 
@@ -60,7 +60,7 @@ describe('SearchBar', () => {
         beforeEach(() => {
             sb = new SearchBar($(DUMMY_COMPONENT_HTML));
         });
-        afterEach(() => localStorage.clear());
+        afterEach(() => sessionStorage.clear());
 
         test('Queries are marshalled before submit for titles', () => {
             sb.initFromUrlParams({facet: 'title'});
@@ -88,7 +88,7 @@ describe('SearchBar', () => {
         /** @type {SearchBar?} */
         let sb;
         beforeEach(() => sb = new SearchBar($(DUMMY_COMPONENT_HTML)));
-        afterEach(() => localStorage.clear());
+        afterEach(() => sessionStorage.clear());
 
         test('Only enters collapsible mode if not already there', () => {
             sb.inCollapsibleMode = true;
@@ -125,17 +125,17 @@ describe('SearchBar', () => {
         const sandbox = sinon.createSandbox();
         afterEach(() => {
             sandbox.restore();
-            localStorage.clear();
+            sessionStorage.clear();
         });
 
         test('When localStorage empty, defaults to facet=all', () => {
-            localStorage.clear();
+            sessionStorage.clear();
             const sb = new SearchBar($(DUMMY_COMPONENT_HTML));
             expect(sb.facet.read()).toBe('all');
         });
 
         test('Facet persists between page loads', () => {
-            localStorage.setItem('facet', 'title');
+            sessionStorage.setItem('facet', 'title');
             const sb = new SearchBar($(DUMMY_COMPONENT_HTML));
             expect(sb.facet.read()).toBe('title');
             const sb2 = new SearchBar($(DUMMY_COMPONENT_HTML));

--- a/tests/unit/js/SearchUtils.test.js
+++ b/tests/unit/js/SearchUtils.test.js
@@ -3,16 +3,19 @@ import * as SearchUtils from '../../../openlibrary/plugins/openlibrary/js/Search
 
 describe('PersistentValue', () => {
     const PV = SearchUtils.PersistentValue;
-    afterEach(() => localStorage.clear());
-
-    test('Saves to localStorage', () => {
-        const pv = new PV('foo');
-        pv.write('bar');
-        expect(localStorage.getItem('foo')).toBe('bar');
+    afterEach(() => {
+        sessionStorage.clear();
+        localStorage.clear();
     });
 
-    test('Reads from localStorage', () => {
-        localStorage.setItem('foo', 'bar');
+    test('Saves to sessionStorage', () => {
+        const pv = new PV('foo');
+        pv.write('bar');
+        expect(sessionStorage.getItem('foo')).toBe('bar');
+    });
+
+    test('Reads from sessionStorage', () => {
+        sessionStorage.setItem('foo', 'bar');
         const pv = new PV('foo');
         expect(pv.read()).toBe('bar');
     });
@@ -23,13 +26,13 @@ describe('PersistentValue', () => {
     });
 
     test('Does not writes default on init if already set', () => {
-        localStorage.setItem('foo', 'green');
+        sessionStorage.setItem('foo', 'green');
         const pv = new PV('foo', { default: 'blue' });
         expect(pv.read()).toBe('green');
     });
 
     test('Writes default on invalid init', () => {
-        localStorage.setItem('foo', 'anything');
+        sessionStorage.setItem('foo', 'anything');
         const pv = new PV('foo', {
             default: 'blue',
             initValidation: () => false
@@ -38,7 +41,7 @@ describe('PersistentValue', () => {
     });
 
     test('Writes null on invalid init', () => {
-        localStorage.setItem('foo', 'anything');
+        sessionStorage.setItem('foo', 'anything');
         const pv = new PV('foo', {
             initValidation: () => false
         });
@@ -46,7 +49,7 @@ describe('PersistentValue', () => {
     });
 
     test('Does not writes default on valid init', () => {
-        localStorage.setItem('foo', 'anything');
+        sessionStorage.setItem('foo', 'anything');
         const pv = new PV('foo', {
             default: 'blue',
             initValidation: () => true
@@ -55,7 +58,7 @@ describe('PersistentValue', () => {
     });
 
     test('Writing applies transformation', () => {
-        localStorage.setItem('foo', 'blue');
+        sessionStorage.setItem('foo', 'blue');
         const pv = new PV('foo', {
             writeTransformation: (newVal, oldVal) => oldVal + newVal
         });


### PR DESCRIPTION
### What does this PR achieve?
Fix: persist SearchBar facet in `sessionStorage` (instead of `localStorage`) so it resets when the browser session ends.

### Technical
- Updated `PersistentValue` storage backend to `sessionStorage`.
- Updated SearchBar/SearchUtils unit tests to match.

### Testing
- `npm test`
