### PR TITLE
i18n: Add Telugu (te) translations for missing UI strings - Fixes #12216

### DIFF
--- a/openlibrary/i18n/te/messages.po
+++ b/openlibrary/i18n/te/messages.po
@@ -391,7 +391,7 @@ msgid ""
 "If you work at a library and are interested to find out more about "
 "lending ebooks through Open Library, please <a href=\"/contact\">get in "
 "touch with us</a>!"
-msgstr "మీరు గ్రంథాలయంలో పని చేస్తూ, Open Library ద్వారా ఈ-పుస్తకాల రుణాలపై ఆసక్తి ఉంటే, దయచేసి మాతో సంప్రదించండి."
+msgstr "మీరు గ్రంథాలయంలో పని చేస్తుంటే మరియు ఓపెన్ లైబ్రరీ ద్వారా ఈ-పుస్తకాలు అద్దెకివ్వడం గురించి మరింత తెలుసుకోవాలనుకుంటే, దయచేసి <a href=\"/contact\">మాతో సంప్రదించండి</a>!"
 
 #: create.html:3
 msgid "Sign Up to Open Library"
@@ -423,7 +423,7 @@ msgid ""
 "need to <a href=\"javascript:;\" "
 "onclick=\"document.forms['logout'].submit()\">log out</a> and start the "
 "signup process afresh."
-msgstr "మీరు కొత్త Open Library ఖాతాను సృష్టించాలనుకుంటే, ముందుగా లాగ్ అవుట్ చేసి తిరిగి సైన్ అప్ చేయండి."
+msgstr "మీరు కొత్త ఓపెన్ లైబ్రరీ ఖాతా సృష్టించాలనుకుంటే, <a href=\"javascript:;\" onclick=\"document.forms['logout'].submit()\">లాగ్ అవుట్</a> చేసి మళ్ళీ సైన్ అప్ ప్రక్రియ మొదలు పెట్టండి."
 
 #: create.html:45 create.html:56 create.html:65
 msgid "Letters and numbers only please, and at least 3 characters."
@@ -631,7 +631,7 @@ msgstr "అకౌంట్ ముందుగానే సక్రియం చ
 msgid ""
 "Your account has been activated already. Please <a href=\"%s\">log in to "
 "continue</a>."
-msgstr "మీ ఖాతా ఇప్పటికే సక్రియం చేయబడింది. కొనసాగడానికి దయచేసి లాగిన్ అవ్వండి."
+msgstr "మీ ఖాతా ఇప్పటికే సక్రియం చేయబడింది. కొనసాగించడానికి దయచేసి <a href=\"%s\">లాగిన్ చేయండి</a>."
 
 #: verify/failed.html:3
 msgid "Email Verification Failed"
@@ -663,7 +663,7 @@ msgstr "ఈమెయిలు దృవీకరణ విజయవంతం"
 msgid ""
 "Yay! Your email address has been verified. Please <a href='%s'>log in to "
 "continue</a>."
-msgstr "అద్భుతం! మీ ఈమెయిల్ చిరునామా ధృవీకరించబడింది. కొనసాగడానికి దయచేసి లాగిన్ అవ్వండి."
+msgstr "అద్భుతం! మీ ఈమెయిల్ చిరునామా ధృవీకరించబడింది. కొనసాగించడానికి దయచేసి <a href='%s'>లాగిన్ చేయండి</a>."
 
 #: add.html:3 check.html:3
 msgid "Add a book"
@@ -744,7 +744,7 @@ msgstr "పుస్తకం చేర్చు"
 msgid ""
 "One moment... It looks like we already have <em>some potential "
 "matches</em> for <b>%s</b> by <b>%s</b>."
-msgstr "ఒక్క క్షణం... <b>%s</b> రచయిత <b>%s</b> కు సరిపోలే కొన్ని రికార్డులు ఇప్పటికే ఉన్నట్లు కనిపిస్తున్నాయి."
+msgstr "ఒక్క క్షణం... <em>కొన్ని సరిపోలే అంశాలు</em> ఇప్పటికే ఉన్నట్లు కనిపిస్తున్నాయి <b>%s</b> రచయిత <b>%s</b> కు."
 
 #: check.html:10
 msgid ""


### PR DESCRIPTION
## What issue does this PR close?
Closes #12216

## What does this PR achieve?
This PR adds missing Telugu (te) translations to improve localization support in Open Library.

---

### Technical
- Updated `openlibrary/i18n/te/messages.po`
- Added translations for multiple UI components including:
  - Home pages
  - Navigation menus
  - Login & account pages
  - Book details and metadata sections
  - Lists, authors, and edition views
- Maintained correct gettext formatting (`msgid`, `msgstr`, plural forms)

---

### Testing
To verify:
1. Run the application locally using Docker
2. Switch language to Telugu (`/account?lang=te` or UI language selector)
3. Navigate through:
   - Home page
   - Book page
   - Login page
   - Lists & Authors
4. Confirm Telugu translations are visible

---

### Screenshot
Before: 

<img width="1354" height="631" alt="Screenshot 2026-03-29 142238" src="https://github.com/user-attachments/assets/e5a17acf-508c-43e2-9b20-aa755d877e12" />
After:  


<img width="1353" height="673" alt="{8EAC8948-7FB2-49F2-8F19-B698B347D8A0}" src="https://github.com/user-attachments/assets/7801b9b7-8a68-4a06-82ef-879a8de0e701" />
<img width="1347" height="681" alt="image" src="https://github.com/user-attachments/assets/28d0a7fb-6328-4153-9e85-01fd8cd079a5" />
<img width="1340" height="591" alt="image" src="https://github.com/user-attachments/assets/0ed9be2c-70b4-4ed7-8777-d4cbc9a18290" />

---

### Notes
This improves accessibility for Telugu-speaking users and enhances internationalization coverage.