### PR TITLE
Fix editionauthor display by prioritizing work authors

### DIFF
--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -55,7 +55,7 @@ class Edition(models.Edition):
     title = property(get_title)
     title_prefix = property(get_title_prefix)
 
-    def get_authors(self):
+   def get_authors(self):
     if self.works:
         return self.works[0].get_authors()
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #486

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

### Technical
<!-- What should be noted about the implementation? -->
Updated Edition.get_authors method to return work authors when available instead of combining work and edition authors. This ensures consistent author data is used for rendering cover alt-text.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Open a book edition page
2. Check the cover alt-text
3. Verify that the author name matches the work author
4. Ensure no duplicate or incorrect author names are displayed

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
