### PR TITLE
Update actions where needed

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -356,7 +356,7 @@ class Account(web.storage):
 
             # Clear patron's profile page:
             data = {'key': patron.key, 'type': '/type/delete'}
-            patron.set_data(data)
+            patron.set_data(data, "delete-profile")
 
             # Remove account information from store:
             del web.ctx.site.store[f'account/{username}']

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -746,7 +746,8 @@ def load_data(  # noqa: PLR0912, PLR0915
         comment = (
             "overwrite existing edition" if existing_edition else "import new book"
         )
-        web.ctx.site.save_many(edits, comment=comment, action='add-book')
+        action = "edit-book" if existing_edition else "add-book"
+        web.ctx.site.save_many(edits, comment=comment, action=action)
 
         # Writes back `openlibrary_edition` and `openlibrary_work` to
         # archive.org item after successful import:

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -1179,9 +1179,9 @@ class User(Thing):
         # Why nofollow?
         return f'<a rel="nofollow" href="{self.key}" {extra_attrs}>{web.net.htmlquote(self.displayname)}</a>'
 
-    def set_data(self, data):
+    def set_data(self, data, action):
         self._data = data
-        self._save()
+        self._save(action=action)
 
 
 class UserGroup(Thing):
@@ -1209,7 +1209,11 @@ class UserGroup(Thing):
         if not any(userkey == member['key'] for member in members):
             members.append({'key': userkey})
             self.members = members
-            web.ctx.site.save(self.dict(), f"Adding {userkey} to {self.key}")
+            web.ctx.site.save(
+                self.dict(),
+                f"Adding {userkey} to {self.key}",
+                action="edit-usergroup-add-member"
+            )
 
     def remove_user(self, userkey):
         if not web.ctx.site.get(userkey):
@@ -1224,7 +1228,11 @@ class UserGroup(Thing):
                 break
 
         self.members = members
-        web.ctx.site.save(self.dict(), f"Removing {userkey} from {self.key}")
+        web.ctx.site.save(
+            self.dict(),
+            f"Removing {userkey} from {self.key}",
+            action="edit-usergroup-delete-member"
+        )
 
 
 class Subject(web.storage):
@@ -1311,6 +1319,7 @@ class Tag(Thing):
             t = web.ctx.site.save(
                 tag,
                 comment=comment,
+                action="create-tag"
             )
             return t
 

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -1212,7 +1212,7 @@ class UserGroup(Thing):
             web.ctx.site.save(
                 self.dict(),
                 f"Adding {userkey} to {self.key}",
-                action="edit-usergroup-add-member"
+                action="edit-usergroup-add-member",
             )
 
     def remove_user(self, userkey):
@@ -1231,7 +1231,7 @@ class UserGroup(Thing):
         web.ctx.site.save(
             self.dict(),
             f"Removing {userkey} from {self.key}",
-            action="edit-usergroup-delete-member"
+            action="edit-usergroup-delete-member",
         )
 
 
@@ -1316,11 +1316,7 @@ class Tag(Thing):
 
         with RunAs(patron):
             web.ctx.ip = web.ctx.ip or ip
-            t = web.ctx.site.save(
-                tag,
-                comment=comment,
-                action="create-tag"
-            )
+            t = web.ctx.site.save(tag, comment=comment, action="create-tag")
             return t
 
 

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -104,11 +104,7 @@ def revert_all_user_edits(account: Account) -> tuple[int, int]:
     delete_payload = [
         {'key': key, 'type': {'key': '/type/delete'}} for key in keys_to_delete
     ]
-    web.ctx.site.save_many(
-        delete_payload,
-        'Delete spam',
-        action="bulk-revert-spam"
-    )
+    web.ctx.site.save_many(delete_payload, 'Delete spam', action="bulk-revert-spam")
     return edit_count, len(delete_payload)
 
 
@@ -752,7 +748,7 @@ class permissions:
         web.ctx.site.save_many(
             [root, works, books, authors],
             comment="Updated edit policy.",
-            action="bulk-edit-permissions"
+            action="bulk-edit-permissions",
         )
 
         add_flash_message("info", "Edit policy has been updated!")

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -104,7 +104,11 @@ def revert_all_user_edits(account: Account) -> tuple[int, int]:
     delete_payload = [
         {'key': key, 'type': {'key': '/type/delete'}} for key in keys_to_delete
     ]
-    web.ctx.site.save_many(delete_payload, 'Delete spam')
+    web.ctx.site.save_many(
+        delete_payload,
+        'Delete spam',
+        action="bulk-revert-spam"
+    )
     return edit_count, len(delete_payload)
 
 
@@ -516,7 +520,7 @@ class stats:
     def POST(self, today):
         """Update stats for today."""
         doc = self.get_stats(today)
-        doc._save()
+        doc._save(action="create-stats")
         raise web.seeother(web.ctx.path)
 
     def get_stats(self, today):
@@ -552,7 +556,7 @@ class block:
             "/admin/block", {"key": "/admin/block", "type": "/type/object"}
         )
         page.ips = [{'ip': ip} for ip in ips]
-        page._save("updated blocked IPs")
+        page._save("updated blocked IPs", action="edit-blocked-ips")
 
 
 def get_blocked_ips():
@@ -746,7 +750,9 @@ class permissions:
         books = self.set_permission("/books", i.perm_records)
         authors = self.set_permission("/authors", i.perm_records)
         web.ctx.site.save_many(
-            [root, works, books, authors], comment="Updated edit policy."
+            [root, works, books, authors],
+            comment="Updated edit policy.",
+            action="bulk-edit-permissions"
         )
 
         add_flash_message("info", "Edit policy has been updated!")

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -1031,7 +1031,7 @@ class unlink_ia_ol(delegate.page):
         data["source_records"] = [rec for rec in source_records if not rec.startswith("ia:")]
         if not data["source_records"]:
             del data["source_records"]
-        web.ctx.site.save(data, "Remove OCAID: Item no longer available to borrow.", action="edit-edition-ocaid")
+        web.ctx.site.save(data, "Disassociate OCAID", action="edit-edition-ocaid")
 
 
 class monthly_logins(delegate.page):

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -650,7 +650,7 @@ class work_delete(delegate.page):
         keys_to_delete: list = [el.get("key") for el in [*editions, work.dict()]]
         delete_payload: list[dict] = [{"key": key, "type": {"key": "/type/delete"}} for key in keys_to_delete]
 
-        web.ctx.site.save_many(delete_payload, comment)
+        web.ctx.site.save_many(delete_payload, comment, action="bulk-delete-books")
         return delegate.RawText(
             json.dumps(
                 {
@@ -1031,7 +1031,11 @@ class unlink_ia_ol(delegate.page):
         data["source_records"] = [rec for rec in source_records if not rec.startswith("ia:")]
         if not data["source_records"]:
             del data["source_records"]
-        web.ctx.site.save(data, "Remove OCAID: Item no longer available to borrow.")
+        web.ctx.site.save(
+            data,
+            "Remove OCAID: Item no longer available to borrow.",
+            action="edit-edition-ocaid"
+        )
 
 
 class monthly_logins(delegate.page):

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -1031,11 +1031,7 @@ class unlink_ia_ol(delegate.page):
         data["source_records"] = [rec for rec in source_records if not rec.startswith("ia:")]
         if not data["source_records"]:
             del data["source_records"]
-        web.ctx.site.save(
-            data,
-            "Remove OCAID: Item no longer available to borrow.",
-            action="edit-edition-ocaid"
-        )
+        web.ctx.site.save(data, "Remove OCAID: Item no longer available to borrow.", action="edit-edition-ocaid")
 
 
 class monthly_logins(delegate.page):

--- a/openlibrary/plugins/openlibrary/bulk_tag.py
+++ b/openlibrary/plugins/openlibrary/bulk_tag.py
@@ -69,7 +69,11 @@ class bulk_tag_works(delegate.page):
                 w.dict()
             )  # need to convert class to raw dict in order for save_many to work
 
-        web.ctx.site.save_many(docs_to_update, comment="Bulk tagging works")
+        web.ctx.site.save_many(
+            docs_to_update,
+            comment="Bulk tagging works",
+            action="bulk-edit-work-tags"
+        )
 
         def response(msg, status="success"):
             return delegate.RawText(

--- a/openlibrary/plugins/openlibrary/bulk_tag.py
+++ b/openlibrary/plugins/openlibrary/bulk_tag.py
@@ -70,9 +70,7 @@ class bulk_tag_works(delegate.page):
             )  # need to convert class to raw dict in order for save_many to work
 
         web.ctx.site.save_many(
-            docs_to_update,
-            comment="Bulk tagging works",
-            action="bulk-edit-work-tags"
+            docs_to_update, comment="Bulk tagging works", action="bulk-edit-work-tags"
         )
 
         def response(msg, status="success"):

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -239,7 +239,7 @@ def sampleload(filename='sampledump.txt.gz'):
     with gzip.open(filename) if filename.endswith('.gz') else open(filename) as file:
         queries = [json.loads(line) for line in file]
 
-    print(web.ctx.site.save_many(queries))
+    print(web.ctx.site.save_many(queries, action="infogami-sampleload-action"))
 
 
 class routes(delegate.page):
@@ -351,6 +351,7 @@ class addauthor(delegate.page):
         web.ctx.site.save(
             {'key': key, 'name': i.name, 'type': {'key': '/type/author'}},
             comment='New Author',
+            action="create-author"
         )
         raise web.HTTPError('200 OK', {}, key)
 
@@ -943,7 +944,7 @@ class _yaml_edit(_yaml):
             d = self.load(i.body)
             p = web.ctx.site.new(key, d)
             try:
-                p._save(i._comment)
+                p._save(i._comment, action="edit-yaml")
             except (client.ClientException, ValidationException) as e:
                 add_flash_message('error', str(e))
                 return render.edit_yaml(key, i.body)

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -351,7 +351,7 @@ class addauthor(delegate.page):
         web.ctx.site.save(
             {'key': key, 'name': i.name, 'type': {'key': '/type/author'}},
             comment='New Author',
-            action="create-author"
+            action="create-author",
         )
         raise web.HTTPError('200 OK', {}, key)
 

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -401,9 +401,10 @@ class lists_edit(delegate.page):
                 # Cast is needed since the infogami code isn't typed yet
                 records_to_save.append(cast(dict, work.dict()))
 
+        action = "create-series" if list_type_plural == "series" else "create-list"
         web.ctx.site.save_many(
             records_to_save,
-            action="lists",
+            action=action,
             comment=web.input(_comment="")._comment or None,
         )
 
@@ -486,7 +487,7 @@ class lists_delete(delegate.page):
         cache.memcache_cache.delete(cache_key)
 
         delete_doc = {"key": key, "type": {"key": "/type/delete"}}
-        web.ctx.site.save(delete_doc, action="lists", comment="Deleted list.")
+        web.ctx.site.save(delete_doc, action="delete-list", comment="Deleted list.")
 
 
 class lists_json(delegate.page):
@@ -588,7 +589,7 @@ class lists_json(delegate.page):
         return site.save(
             lst.dict(),
             comment="Created new list.",
-            action="lists",
+            action="create-list",
             data={"list": {"key": lst.key}, "seeds": seeds},
         )
 
@@ -739,7 +740,7 @@ class list_seeds(delegate.page):
             "remove": data["remove"],
         }
 
-        return lst._save(comment="Updated list.", action="lists", data=changeset_data)
+        return lst._save(comment="Updated list.", action="edit-list-seeds", data=changeset_data)
 
 
 class list_seed_yaml(list_seeds):

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -740,9 +740,10 @@ class list_seeds(delegate.page):
             "remove": data["remove"],
         }
 
-        return lst._save(comment="Updated list.", action="edit-list-seeds", data=changeset_data)
+        # Distinguish between list and series seed updates for logging/audit purposes.
+        action = "edit-series-seeds" if "/series/" in key else "edit-list-seeds"
 
-
+        return lst._save(comment="Updated list.", action=action, data=changeset_data)
 class list_seed_yaml(list_seeds):
     encoding = "yml"
     content_type = 'text/yaml; charset="utf-8"'

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -744,6 +744,8 @@ class list_seeds(delegate.page):
         action = "edit-series-seeds" if "/series/" in key else "edit-list-seeds"
 
         return lst._save(comment="Updated list.", action=action, data=changeset_data)
+
+
 class list_seed_yaml(list_seeds):
     encoding = "yml"
     content_type = 'text/yaml; charset="utf-8"'

--- a/openlibrary/plugins/upstream/addtag.py
+++ b/openlibrary/plugins/upstream/addtag.py
@@ -185,10 +185,10 @@ class tag_edit(delegate.page):
                 tag = web.ctx.site.new(
                     key, {"key": key, "type": {"key": "/type/delete"}}
                 )
-                tag._save(comment=i._comment)
+                tag._save(comment=i._comment, action="delete-tag")
                 raise safe_seeother(key)
             tag.update(formdata)
-            tag._save(comment=i._comment)
+            tag._save(comment=i._comment, action="edit-tag")
             raise safe_seeother(i.redir or key)
         except (ClientException, ValidationException) as e:
             add_flash_message('error', str(e))

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -334,7 +334,9 @@ class revert(delegate.mode):
                 if prev.type.key in ["/type/delete", "/type/redirect"]:
                     return revert(prev)
                 else:
-                    prev._save("revert to revision %d" % prev.revision, action="revert-version")
+                    prev._save(
+                        "revert to revision %d" % prev.revision, action="revert-version"
+                    )
                     return prev
             elif thing.type.key == "/type/redirect":
                 redirect = web.ctx.site.get(thing.location)

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -334,7 +334,7 @@ class revert(delegate.mode):
                 if prev.type.key in ["/type/delete", "/type/redirect"]:
                     return revert(prev)
                 else:
-                    prev._save("revert to revision %d" % prev.revision)
+                    prev._save("revert to revision %d" % prev.revision, action="revert-version")
                     return prev
             elif thing.type.key == "/type/redirect":
                 redirect = web.ctx.site.get(thing.location)
@@ -370,7 +370,7 @@ class revert(delegate.mode):
             thing[k] = process(thing[k])
 
         comment = i._comment or "reverted to revision %d" % v
-        thing._save(comment)
+        thing._save(comment, action="revert-version")
         raise web.seeother(key)
 
 

--- a/openlibrary/plugins/upstream/covers.py
+++ b/openlibrary/plugins/upstream/covers.py
@@ -182,7 +182,7 @@ class manage_covers(delegate.page):
 
     def save_images(self, book, covers):
         book.covers = covers
-        book._save('Update covers')
+        book._save('Update covers', action="update-book-covers")
 
     def POST(self, key):
         if not accounts.get_current_user():
@@ -216,4 +216,4 @@ class manage_photos(manage_covers):
 
     def save_images(self, author, photos):
         author.photos = photos
-        author._save('Update photos')
+        author._save('Update photos', action="update-author-photos")

--- a/scripts/update_stale_ocaid_references.py
+++ b/scripts/update_stale_ocaid_references.py
@@ -135,7 +135,11 @@ def disassociate_dark_ocaids(s3_keys, es_editions, test=True):
             counts["updated"] += len(updated_eds)
             with RunAs('ImportBot'):
                 web.ctx.ip = web.ctx.ip or '127.0.0.1'
-                web.ctx.site.save_many(updated_eds, comment="Redacting ocaids", action="bulk-update-edition-ocaid")
+                web.ctx.site.save_many(
+                    updated_eds,
+                    comment="Redacting ocaids",
+                    action="bulk-update-edition-ocaid",
+                )
         print(counts)
         counts["batches"] += 1
     return counts

--- a/scripts/update_stale_ocaid_references.py
+++ b/scripts/update_stale_ocaid_references.py
@@ -135,7 +135,7 @@ def disassociate_dark_ocaids(s3_keys, es_editions, test=True):
             counts["updated"] += len(updated_eds)
             with RunAs('ImportBot'):
                 web.ctx.ip = web.ctx.ip or '127.0.0.1'
-                web.ctx.site.save_many(updated_eds, comment="Redacting ocaids")
+                web.ctx.site.save_many(updated_eds, comment="Redacting ocaids", action="bulk-update-edition-ocaid")
         print(counts)
         counts["batches"] += 1
     return counts


### PR DESCRIPTION
Addresses https://github.com/internetarchive/openlibrary/issues/11955
Supplants #12058 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Updates most `save`, `save_many`, and `Thing._save` calls to include a valid and accurate `action`.  Updates to actions in `addbook.py` are included in #12210.

We may also want to update the default `save` and `save_many` values in Infogami.  [This PR](https://github.com/internetarchive/infogami/pull/275) does that.  When merged, we can check the `/recentchanges` views for the default types to determine if any transaction needs an `action`.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
