### PR TITLE
Updated browse endpoint to use parse_comma_separated_list

### DIFF
--- a/openlibrary/fastapi/internal/api.py
+++ b/openlibrary/fastapi/internal/api.py
@@ -114,7 +114,8 @@ async def browse(
     pagination: Annotated[Pagination, Depends()],
     q: Annotated[str, Query()] = "",
     subject: Annotated[str, Query()] = "",
-    sorts: Annotated[list[str] | None, BeforeValidator(parse_comma_separated_list), Query()] = None,) -> dict:
+    sorts: Annotated[list[str], BeforeValidator(parse_comma_separated_list), Query()] = [],  # noqa: B006
+) -> dict:
     """
     Dynamically fetches the next page of books and checks if they are
     available to be borrowed from the Internet Archive without having
@@ -126,7 +127,7 @@ async def browse(
         limit=pagination.limit,
         page=pagination.page,
         subject=subject,
-        sorts=sorts or [],
+        sorts=sorts,
     )
 
     works = lending.get_available(url=url) if url else []


### PR DESCRIPTION
Follow up #12006 

Changes :

- Replaced the manual string splitting logic `sorts_list = [s.strip() for s in sorts.split(",") if s.strip()]` in the /browse.json with `parse_comma_separated_list` .



### Screenshot
N/A

### Stakeholders
@RayBB 
