### PR TITLE
update docs to better align with new docs site

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,95 +1,18 @@
-# Getting Started
+# Contributing
 
-## Welcome!
-This welcome section is intended for new contributors.
-
-1. **Quick Tour:** [Quick Public Tour of Open Library (10min)](https://archive.org/embed/openlibrary-tour-2020/openlibrary.ogv)
-2. **Orientation:** [Volunteer Orientation Video (1.5h)](https://archive.org/details/openlibrary-orientation-2020?start=80)
-    * [Code of conduct](https://github.com/internetarchive/openlibrary/blob/master/CODE_OF_CONDUCT.md)
-3. **Getting Started:**
-    * [Installation README](https://github.com/internetarchive/openlibrary/tree/master/docker) + [Docker Setup Walk-through (video)](https://archive.org/embed/openlibrary-developer-docs)
-4. **Contributing:**
-    * [How we use git](https://docs.openlibrary.org/developers/tools/git.html)
-    * [Finding good first issues](https://github.com/internetarchive/openlibrary/issues?q=is%3Aissue+is%3Aopen+-linked%3Apr+label%3A%22Good+First+Issue%22+no%3Aassignee)
-    * [Testing your code](https://docs.openlibrary.org/developers/tools/testing.html)
-    * [Enabling debugging & profiling](https://docs.openlibrary.org/advanced/debugging-and-performance-profiling.html)
-5. **Learning the Code:**
-    * [Technical Tour & System Overview (1h)](https://archive.org/details/openlibrary-tour-2020/technical_overview.mp4)
-    * [Walkthrough videos](https://archive.org/details/openlibrary-tour-2020)
-    * [Code Architecture](https://github.com/internetarchive/openlibrary#architecture)
-    * [Front-end Guide](https://docs.openlibrary.org/developers/frontend/frontend-guide.html)
-    * [Open Library Public APIs](https://openlibrary.org/developers/api)
-6. **Common Tasks**
-    * [Importing Production Book Data Locally](https://docs.openlibrary.org/developers/misc/loading-production-book-data.html)  
-7. **Questions?**
-    * [Docs](https://docs.openlibrary.org/)
-    * [Request a slack invite](https://openlibrary.org/volunteer)
-    * [Weekly Community calls](https://docs.openlibrary.org/everyone/community-call.html)
-    * [Open Library FAQs](https://openlibrary.org/help/faq)
-
-## Quick Tour
-
-A quick public tour of Open Library to get you familiar with the service and its offerings (10min)
-
-[![archive org_embed_openlibrary-tour-2020_openlibrary ogv (1)](https://user-images.githubusercontent.com/978325/91348906-55940d00-e799-11ea-83b9-17cd4d99642b.png)](https://archive.org/embed/openlibrary-tour-2020/openlibrary.ogv)
-
-## Onboarding
-
-A comprehensive volunteer orientation video to learn what it means to work on Open Library (1.5h).
-If you're looking for a good first issue, check out [Good First Issues](https://github.com/internetarchive/openlibrary/issues?q=is%3Aissue+is%3Aopen+-linked%3Apr+label%3A%22Good+First+Issue%22+no%3Aassignee).
-
-[![archive org_details_openlibrary-orientation-2020_start=80](https://user-images.githubusercontent.com/978325/91350387-78272580-e79b-11ea-9e26-85cfd1d38fe1.png)](https://archive.org/details/openlibrary-orientation-2020?start=80)
-
-## Technical Walkthrough
-
-A deep dive into the technical details, architecture, and code structure behind OpenLibrary.org
-
-[![archive org_details_openlibrary-tour-2020_technical_overview mp4](https://user-images.githubusercontent.com/978325/91350097-11097100-e79b-11ea-87bd-ca9724d5e43c.png)](https://archive.org/details/openlibrary-tour-2020/technical_overview.mp4)
-
-### Code of Conduct
-
-Before continuing, please familiarize yourself with our [code of conduct](https://github.com/internetarchive/openlibrary/blob/master/CODE_OF_CONDUCT.md).
-We are a non-profit, open-source, inclusive project, and we believe everyone deserves a safe place to make the world a little better. We're committed to creating this safe place.
-
-### Join our Community
-
-* The core Open Library team communicates over an invite-only Slack channel. You may request an invitation on our [volunteers](https://openlibrary.org/volunteer) page.
-* The Open Library hosts weekly video calls. Check the [community call page](https://docs.openlibrary.org/1_Everyone/Community-Call.html) for times and details.
-
-## Installing Open Library
-For instructions on setting up a local developer's instance of Open Library, please refer to the [Installation Guide](https://github.com/internetarchive/openlibrary#installation).
-
-[![archive org_details_openlibrary-developer-docs_zoom_0 mp4_autoplay=1 start=2](https://user-images.githubusercontent.com/978325/91351305-ef10ee00-e79c-11ea-9bfb-c2733696ec58.png)](https://archive.org/details/openlibrary-developer-docs/zoom_0.mp4)
-
-Refer to the [docs](https://docs.openlibrary.org/) for more information about getting set up, understanding the codebase, contributing, and more. Check out the sidebar for links to relevant topics.
-
-[Here's a handy cheat sheet](https://docs.openlibrary.org/developers/tools/git.html) if you are new to using Git.
-
-## Common Setup Tasks
-
-### Adding Data to Open Library
-- If you are looking to add data using MARC and ONIX records, visit [Open Library Bots](https://github.com/internetarchive/openlibrary-bots).
-
-## Submitting Issues
-
-[Project Management](https://docs.openlibrary.org/developers/misc/project-management.html) and [Using Managed Labels to Track Issues](https://docs.openlibrary.org/developers/misc/project-management.html#labeling-issues) explain how GitHub issues are triaged, labeled, and prioritized.
-
-### Tagging
-- If an issue requires immediate fixing, please include a comment requesting for it to be labeled and promoted as [`Priority: 0`](https://github.com/internetarchive/openlibrary/issues?q=is%3Aopen+is%3Aissue+label%3A%22Priority%3A+0%22+).
-
-## Picking Good First Issues
-
-[Here's a list of good first issues](https://github.com/internetarchive/openlibrary/issues?q=is%3Aissue+is%3Aopen+-linked%3Apr+label%3A%22Good+First+Issue%22+no%3Aassignee) to help you get started. Please only pick issues that are not assigned to anyone, or if an issue has been assigned but has seen no response or activity for 2 weeks. Do not request to be assigned to issues that are actively being worked on. If you're interested in working on an issue without an assignee or one that has been inactive, comment on it to ask if you can be assigned. If you have questions, please ask the [Lead](https://docs.openlibrary.org/developers/misc/project-management.html#triage) designated by the `Lead: @person` label on the issue.
+This page covers the community norms, contribution standards, and project management practices for Open Library. For setup and getting started, see the [Quick Start](/developers/quick-start.md) guide.
 
 ## Contributor Etiquette
 
 We value all contributors and want to ensure a positive and collaborative environment. Please follow these guidelines:
 
 ### Respecting Other Contributors' Work
+
 - **Do not undermine others' efforts**: If someone has already asked to work on an issue and been assigned (or is actively working on it), please respect their effort. Opening a competing PR without coordination undermines their contribution and violates our community spirit.
 - **Check before starting**: Before beginning work on an issue, check if someone else is already assigned or has recently expressed interest in working on it.
 
 ### Requesting Issue Assignments
+
 - **Quality over quantity**: Please do not ask to be assigned to dozens of issues at a time. Focus on making meaningful contributions rather than accumulating assignments.
 - **Demonstrate understanding**: When requesting to be assigned to an issue, show that you understand the problem by including:
   - A summary of the challenge or bug
@@ -98,33 +21,50 @@ We value all contributors and want to ensure a positive and collaborative enviro
   - Any questions you have about the implementation
 - **Use AI tools responsibly**: While you're encouraged to use AI tools (like LLMs) to assist with research and understanding the codebase, please don't simply copy-paste AI-generated responses into your comments. Take time to understand the suggestions and present them in your own words, demonstrating genuine comprehension of the issue.
 
-### Our Roadmap(s)
-You can see this year (and previous year's) roadmap(s) [here](https://docs.google.com/document/d/1KJr3A81Gew7nfuyo9PnCLCjNBDs5c7iR4loOGm1Pafs/edit).
-
-## Development Practices
-
-### Branch Names
-Whenever working on a new feature/hotfix/refactor, make sure a corresponding issue exists.
-We use the issue number in the branch name.
-
-A branch name consists of the: issue number, whether it is a feature/hotfix/refactor, and a human readable slug, e.g:
-
-```
-123/refactor/simplifying-authentication-using-xauthn
-```
-
-### Testing
-See https://docs.openlibrary.org/developers/tools/testing.html for more information.
-
-### Submitting Pull Requests
-
-Once you've finished making your changes, submit a pull request (PR). Please take the time to check whether someone has already raised the issue you are solving. Thank you for your contributions!
-
-Follow these rules when creating a PR:
+## Submitting Pull Requests
 
 1. **Test your code before opening a PR**: Maintainers may close your PR if it has clearly not been tested.
 2. **Follow the pull request template**: It's easier for a maintainer to reject a PR than it is for them to fill it out for you.
 3. **Make PRs _self-contained_**: They should clearly describe what changes have taken place. A reviewer should (for the most part) be able to complete a review without having to look at other issues.
 4. **Resolve all code review (CR) comments**: Treat comments as a todo list. Most PRs will require some edits before getting merged, so don't get discouraged if you have to make some changes!
-5. **Reply when resolving CR comments**: When resolving a comment, reply with either "DONE" or "WON'T FIX because ...". A reviewer will unresolve a comment if they feel it's necessary.
+5. **Reply when resolving CR comments**: When resolving a comment, reply with "DONE" or "WON'T FIX because ...". A reviewer will unresolve a comment if they feel it's necessary.
 
+## Managing Issues
+
+### Picking Good First Issues
+
+[Browse Good First Issues](https://github.com/internetarchive/openlibrary/issues?q=is%3Aissue+is%3Aopen+-linked%3Apr+label%3A%22Good+First+Issue%22+no%3Aassignee)
+
+- Only pick issues that are **not assigned** to anyone
+- If an issue has been assigned but has seen no response or activity for 2 weeks, you may comment to ask if you can take it
+- Do not request to be assigned to issues that are actively being worked on
+- If you have questions, ask the Lead designated by the `Lead: @person` label on the issue
+
+### When No Good First Issues Are Available
+
+If all Good First Issues are taken, here's how to find something to work on:
+
+1. **Browse all unassigned issues** — [filter by recently updated](https://github.com/internetarchive/openlibrary/issues?q=is%3Aissue+is%3Aopen+-linked%3Apr+no%3Aassignee+sort%3Aupdated-desc) to find active discussions
+2. **Look for older issues** that haven't had much activity. Before starting, verify the issue is still relevant by checking that the code area hasn't changed significantly, and leave a comment on the issue to confirm your intent
+3. **Ask in Slack** — request an invite on our [volunteers page](https://openlibrary.org/volunteer). Maintainers can point you to what's actually useful right now
+4. **Attend a weekly community call** — a good place to hear about current priorities
+5. **Documentation improvements** are always welcome and don't require a full dev setup
+
+### Tagging
+
+- If an issue requires immediate fixing, include a comment requesting it be labeled and promoted as [`Priority: 0`](https://github.com/internetarchive/openlibrary/issues?q=is%3Aopen+is%3Aissue+label%3A%22Priority%3A+0%22).
+
+For how issues are triaged, labeled, and prioritized, see [Project Management](/developers/misc/project-management.md).
+
+## Code of Conduct
+
+Please familiarize yourself with our [Code of Conduct](https://github.com/internetarchive/openlibrary/blob/master/CODE_OF_CONDUCT.md). We are a non-profit, open-source, inclusive project, and we believe everyone deserves a safe place to make the world a little better. We're committed to creating this safe place.
+
+## Community
+
+- The core Open Library team communicates over an invite-only Slack channel. Request an invitation on our [volunteers page](https://openlibrary.org/volunteer).
+- We host weekly video calls. Check the [community call page](https://docs.openlibrary.org/everyone/community-call.html) for times and details.
+
+## Roadmap
+
+View this year's roadmap (and previous years') in the [Open Library Roadmap document](https://docs.google.com/document/d/1KJr3A81Gew7nfuyo9PnCLCjNBDs5c7iR4loOGm1Pafs/edit).

--- a/Readme.md
+++ b/Readme.md
@@ -1,101 +1,19 @@
 # Open Library
 
-![Python Build](https://github.com/internetarchive/openlibrary/actions/workflows/python_tests.yml/badge.svg)
-![JS Build](https://github.com/internetarchive/openlibrary/actions/workflows/javascript_tests.yml/badge.svg)
+![GitHub Repo stars](https://img.shields.io/github/stars/internetarchive/openlibrary)
 [![contributors](https://img.shields.io/github/contributors/internetarchive/openlibrary.svg)](https://github.com/internetarchive/openlibrary/graphs/contributors)
 
 [Open Library](https://openlibrary.org) is an open, editable library catalog, building towards a web page for every book ever published.
 
-Are you looking to get started? [This is the guide](https://github.com/internetarchive/openlibrary/blob/master/CONTRIBUTING.md) you are looking for. You may wish to learn more about [Google Summer of Code (GSoC)?](https://docs.openlibrary.org/everyone/google-summer-of-code.html) or [Hacktoberfest](https://docs.openlibrary.org/everyone/hacktoberfest.html).
+## Getting Started
 
-## Table of Contents
-   - [Overview](#overview)
-   - [Installation](#installation)
-   - [Code Organization](#code-organization)
-   - [Architecture](#architecture)
-     - [The Frontend](https://docs.openlibrary.org/developers/frontend/frontend-guide.html)
-     - [The Backend](#the-backend)
-     - [The Service Architecture](https://docs.openlibrary.org/advanced/production-service-architecture.html)
-   - [Developer's Guide](#developers-guide)
-   - [Running Tests](#running-tests)
-   - [Contributing](#contributing)
-   - [Public APIs](https://openlibrary.org/developers/api)
-   - [FAQs](https://openlibrary.org/help/faq)
+**Please read the [Contributing guide](https://docs.openlibrary.org/developers/CONTRIBUTING.html) thoroughly before contributing.** It covers community norms, contribution standards, and how to work respectfully with other contributors.
 
-## Overview
+Then follow the **[Quick Start](https://docs.openlibrary.org/developers/quick-start.html)** to set up your environment and make your first contribution.
 
-Open Library is an effort started in 2006 to create "one web page for every book ever published." It provides access to many public domain and out-of-print books, which can be read online.
+For full developer documentation, see [docs.openlibrary.org](https://docs.openlibrary.org/).
 
-Here's a quick public tour of Open Library to get you familiar with the service and its offerings (10min).
-
-[![archive org_embed_openlibrary-tour-2020 (1)](https://user-images.githubusercontent.com/978325/91348906-55940d00-e799-11ea-83b9-17cd4d99642b.png)](https://archive.org/embed/openlibrary-tour-2020/openlibrary.ogv)
-
-- [Learn more about the Open Library project](https://openlibrary.org/about)
-- [The Vision (Dream) of OpenLibrary](https://openlibrary.org/about/vision)
-- [Visit the Blog](https://blog.openlibrary.org)
-
-## Installation
-
-Run `docker compose up` and visit http://localhost:8080
-
-Need more details? Checkout the [Docker instructions](https://github.com/internetarchive/openlibrary/blob/master/docker/README.md)
-or [video tutorial](https://archive.org/embed/openlibrary-developer-docs/openlibrary-docker-set-up.mp4).
-
-
-### Developer's Guide
-
-You can also find more information regarding Developer Documentation for Open Library in the Open Library [Wiki](https://docs.openlibrary.org/developers/).
-
-## Code Organization
-
-* [*openlibrary/core*](/openlibrary/core) - core openlibrary functionality, imported and used by www
-* [*openlibrary/plugins*](/openlibrary/plugins) - other models, controllers, and view helpers
-* [*openlibrary/views*](/openlibrary/views) - views for rendering web pages
-* [*openlibrary/templates*](/openlibrary/templates) - all the templates used in the website
-* [*openlibrary/macros*](/openlibrary/macros) - macros are like templates, but can be called from wikitext
-
-## Architecture
-
-### The Backend
-
-OpenLibrary is developed on top of the Infogami wiki system, which is itself built on top of the web.py Python web framework and the Infobase database framework.
-
-- [Overview of Backend Web Technologies](https://openlibrary.org/about/tech)
-
-Once you've read the overview of OpenLibrary Backend technologies, it's highly encouraged you read the developer primer which explains how to use Infogami (and its database, Infobase).
-
-- [Infogami Developer Tutorial](https://openlibrary.org/dev/docs/infogami)
-
-If you want to dive into the source code for Infogami, see the [Infogami repo](https://github.com/internetarchive/infogami).
-
-## Running tests
-
-Open Library tests can be run using docker. Kindly look up on our [Testing Document](https://docs.openlibrary.org/developers/tools/testing.html) for more details.
-
-```
-docker compose run --rm home make test
-```
-
-## Contributing
-
-There are many ways volunteers can contribute to the Open Library project, from development and design to data management and community engagement. Here’s how you can get involved:
-
-### Developers
-- **Getting Started:** Check out our [Contributing Guide](https://github.com/internetarchive/openlibrary/blob/master/CONTRIBUTING.md) for instructions on how to set up your development environment, find issues to work on, and submit your contributions.
-- **Good First Issues:** Browse our [Good First Issues](https://github.com/internetarchive/openlibrary/issues?q=is%3Aissue+is%3Aopen+-linked%3Apr+label%3A%22Good+First+Issue%22+no%3Aassignee) to find beginner-friendly tasks.
-
-### Designers
-- **Design Contributions:** We welcome designers to help improve the user experience. You can start by looking at [design-related issues](https://github.com/internetarchive/openlibrary/labels/design).
-
-### Librarians and Data Enthusiasts
-- **Data Contributions:** Learn how to contribute to our catalog and help improve book data on Open Library. Visit our [volunteer page](https://openlibrary.org/volunteer) for more information.
-
-### Community Engagement
-- **Join our Community Calls:** Open Library hosts weekly community and design calls. Check the [community call schedule](https://docs.openlibrary.org/everyone/community-call.html) for times and details.
-- **Ask Questions:** If you have any questions, request an invitation to our Slack channel on our [volunteers page](https://openlibrary.org/volunteer).
-
-For more detailed information, refer to the [Contributing Guide](https://github.com/internetarchive/openlibrary/blob/master/CONTRIBUTING.md).
-
+To volunteer in non-development roles, visit [openlibrary.org/volunteer](https://openlibrary.org/volunteer).
 
 ## License
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,64 +1,37 @@
-# Welcome to the Installation Guide for Open Library Developers
+# Docker Guide
 
-1. [Pull code locally](#pull-code-locally)
-2. [Install Docker](#install-docker) and [Test Docker](#test-docker)
-3. [Prepare your system](#prepare-your-system)
-4. [Build the project](#build-the-project)
-5. [Run the app](#run-the-app)
-6. [Update code dependencies](#code-updates)
-7. [Teardown commands](#teardown-commands)
-8. [Full reset](#fully-resetting-your-environment)
-9. [Useful docker commands](#useful-runtime-commands)
-10. [Troubleshooting](#troubleshooting)
-11. [Developing the Dockerfile](#developing-the-dockerfile) and [Debugging and Profiling docker images](#debugging-and-profiling-the-docker-image)
-12. [Technical Notes](#technical-notes)
-
-## Pull code locally
-
-Refer to [these instructions](https://docs.openlibrary.org/developers/tools/git.html#forking-and-cloning-the-open-library-repository) to fork and clone the Open Library Repository:
-
-```sh
-git clone git@github.com:YOUR_USERNAME/openlibrary.git
-```
-
-> [!IMPORTANT]  
-> When cloning the openlibrary repository, `SSH` (i.e. `git clone git@github.com:internetarchive/openlibrary.git`) must be used and *not* `https`, otherwise git submodules (e.g. `infogami` and `acs`) may not be fetched correctly. If you accidentally cloned the repository using `git clone https://...`, follow these steps: [Modifying a repository wrongly cloned with https](https://docs.openlibrary.org/developers/tools/git.html#modifying-a-repository-that-was-incorrectly-cloned-using-https-or-is-missing-the-infogami-module).
-
-## Prepare your system
-
-> [!IMPORTANT]
-> **Windows** users should see [Fix line endings, symlinks, and git submodules](https://docs.openlibrary.org/developers/tools/git.html#fix-line-endings-symlinks-and-git-submodules-only-for-windows-users-not-using-a-linux-vm). Skipping those steps will likely prevent the containers from coming up.
-
-We recommend adjusting Docker's resource settings to use at least 4GB of RAM and 2GB of swap. The defaults of 2GB RAM and 1GB swap are likely to cause the error `Killed` when running `build-assets` to build `js` dependencies.
+This guide covers everything Docker-related for local Open Library development. For the fastest path to your first contribution, start with the [Quick Start](/developers/quick-start.md) guide.
 
 ## Install Docker
 
-**Linux** users (including those using a VM), can install `Docker Engine` or `Docker Desktop` (see the [Docker FAQ](https://docs.docker.com/desktop/faqs/linuxfaqs/) to determine which is right for you).
+**Linux** users (including those using a VM) can install `Docker Engine` or `Docker Desktop` (see the [Docker FAQ](https://docs.docker.com/desktop/faqs/linuxfaqs/) to determine which is right for you).
 
-- Docker Engine: https://docs.docker.com/engine/install/#server (tested with 19.*)
+- Docker Engine: <https://docs.docker.com/engine/install/#server>
 
-**Windows** and **macOS** users should use `Docker Desktop` as of early 2023.
+**Windows** and **macOS** users should use `Docker Desktop`.
 
-- Docker Desktop: https://docs.docker.com/get-docker/
+- Docker Desktop: <https://docs.docker.com/get-docker/>
 
 For **macs** using an `M1 Chip`, please use [Docker Desktop >= 4.3.0](https://docs.docker.com/desktop/mac/release-notes/) and make sure that Docker Desktop Preferences `General / Use Docker Compose V2` is checked, enabling Docker to run without requiring `Rosetta 2`.
 
 ### Test Docker
+
 Before continuing, ensure Docker is correctly configured by running the `hello-world` container.
 
 ```sh
 docker run hello-world
 ```
 
-The output should include a `Hello from Docker!` message that will confirm everything is working with Docker and you can continue.
+The output should include a `Hello from Docker!` message. If Docker is unable to pull the `hello-world:latest` image from Docker Hub, try disabling your VPN if one is installed.
 
-If Docker is unable to pull the `hello-world:latest` image from Docker Hub, try disabling your VPN if one is installed.
+Linux users, note the lack of `sudo` before `docker run hello-world`. See the [Linux post-installation instructions](https://docs.docker.com/engine/install/linux-postinstall/) if you see a permission denied error.
 
-Linux users, note the lack of `sudo` before `docker run hello-world`. See the [Linux post-installation instructions](https://docs.docker.com/engine/install/linux-postinstall/) if you see the following error:
-```
-docker: permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Post "http://%2Fvar%2Frun%2Fdocker.sock/v1.24/containers/create": dial unix /var/run/docker.sock: connect: permission denied.
-See 'docker run --help'.
-```
+## Prepare your system
+
+> [!IMPORTANT]
+> **Windows** users should see [Fix line endings, symlinks, and git submodules](/developers/tools/git.md#fix-line-endings-symlinks-and-git-submodules-only-for-windows-users-not-using-a-linux-vm). Skipping those steps will likely prevent the containers from coming up.
+
+We recommend adjusting Docker's resource settings to use at least 4GB of RAM and 2GB of swap. The defaults of 2GB RAM and 1GB swap are likely to cause the error `Killed` when running `build-assets` to build JS dependencies.
 
 ## Build the project
 
@@ -68,11 +41,12 @@ To build the project, `cd` into the project root directory (where `compose.yaml`
 docker compose build
 ```
 
-The build process may take more than 15 minutes on older hardware or slower networks. If it times out and fails, simply re-run the `docker compose build` command.
+The build process may take more than 15 minutes on older hardware or slower networks. If it times out and fails, simply re-run the command.
 
-If you encounter any build errors, please check the [Troubleshooting Guide](#troubleshooting) for solutions or [browse our issues tagged with docker](https://github.com/internetarchive/openlibrary/issues?q=is%3Aissue%20label%3A%22Module%3A%20Docker%22).
+If you encounter any build errors, please check the [Troubleshooting](#troubleshooting) section below or [browse our issues tagged with docker](https://github.com/internetarchive/openlibrary/issues?q=is%3Aissue%20label%3A%22Module%3A%20Docker%22).
 
 ## Run the app
+
 ```sh
 docker compose up    # Ctrl-C to stop
 docker compose up -d # or, start in detached (silent) mode
@@ -80,38 +54,47 @@ docker compose up -d # or, start in detached (silent) mode
 
 You will know the environment is done loading when the text stops furiously scrolling by and you see the following repeating every few seconds on the console:
 
-```
+```log
 infobase_1      | 172.19.0.5:45716 - - [16/Feb/2023 16:54:10] "HTTP/1.1 GET /openlibrary.org/log/2023-02-16:0" - 200 OK
 infobase_1      | 172.19.0.5:45730 - - [16/Feb/2023 16:54:15] "HTTP/1.1 GET /openlibrary.org/log/2023-02-16:0" - 200 OK
 infobase_1      | 172.19.0.5:41790 - - [16/Feb/2023 16:54:20] "HTTP/1.1 GET /openlibrary.org/log/2023-02-16:0" - 200 OK
 ```
 
-At this point, visit http://localhost:8080 and you should see the Open Library banner image with "development version" emblazoned upon it to signify that it's running from your local development server. From here you can [log in locally](http://localhost:8080/account/login).
+At this point, visit <http://localhost:8080> and you should see the Open Library banner image with "development version" emblazoned upon it to signify that it's running from your local development server.
 
-As a next step, we encourage you to proceed to the ["Getting Started" guide](https://github.com/internetarchive/openlibrary/blob/master/CONTRIBUTING.md) for tips on using git, finding a good first issue to work on, and understanding the codebase.
+This exposes the following ports:
+
+| Port | Service                |
+| ---- | ---------------------- |
+| 8080 | Open Library main site |
+| 7000 | Infobase               |
+| 8983 | Solr                   |
+| 7075 | Cover store            |
+
+For example, to access Solr admin, go to <http://localhost:8983/solr/admin/>
 
 ## Code Updates
 
 > [!TIP]
-> When the Open Library code within your local docker image falls behind the code upstream, you can typically ```git pull`` the latest changes from github without having to rebuild all your docker image(s).`
+> When the Open Library code within your local docker image falls behind the code upstream, you can typically `git pull` the latest changes from GitHub without having to rebuild all your docker image(s).
 
-These instructions are intended for contributors who have **already** `built` Open Library using docker, but the contributor may have made or pulled changes to their codebase that conflict with what's baked into the image.
+These instructions are for contributors who have **already** built Open Library using Docker, but may have made or pulled changes to their codebase that conflict with what's baked into the image.
 
 Building the Open Library project can take a while and most of its images don't change often, so we only want to rebuild them when necessary. When a docker image is created, its dependencies (`pip`, `npm`, `apt-get`) are frozen in time and will be inherited by any container based from it.
 
 Occasionally, there will be cases when changes we pull or make to our codebase will require changes to our docker environment -- for instance, the addition of a python dependency, npm package, or changes to our js/vue/css that require assets to be rebuilt. In most of these cases, because the `openlibrary` repo is volume mounted, we can use the pattern `docker compose run --rm home <command>` to spin up a temporary container with instructions that run build commands to ensure our environment has all the necessary dependencies. For instance, if changes have been made to:
 
-| Change | Fix  |
-|------|-----------|
-| **`pip` python package dependencies** (e.g. `requirements.txt`) | rebuild just the `home` image with: ```docker compose build home``` |
-| **`npm` packages** | run ```docker compose run --rm home npm install --no-audit``` (see [#2032](https://github.com/internetarchive/openlibrary/issues/2032) for why) |
-| **`js`, `vue`, `css`** and other static front-end assets | perform a complete rebuild of assets using ```docker compose run --rm home npm run build-assets```, or follow the [Frontend Guide](https://docs.openlibrary.org/developers/frontend/frontend-guide.html) to rebuild only certain asset types. |
+| Change                                                          | Fix                                                                                                                                                                                                         |
+| --------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`pip` python package dependencies** (e.g. `requirements.txt`) | rebuild just the `home` image with: `docker compose build home`                                                                                                                                             |
+| **`npm` packages**                                              | run `docker compose run --rm home npm install --no-audit` (see [#2032](https://github.com/internetarchive/openlibrary/issues/2032) for why)                                                                 |
+| **`js`, `vue`, `css`** and other static front-end assets        | perform a complete rebuild of assets using `docker compose run --rm home npm run build-assets`, or follow the [Frontend Guide](/developers/frontend/frontend-guide.md) to rebuild only certain asset types. |
 
 > [!WARNING]
 > In the off-chance you find yourself needing to edit core dependencies like `apt-get` or networking, you will most likely need to do a [full rebuild](#fully-resetting-your-environment). If you are making this sort of change, you will know exactly what you are doing. See [Developing the Dockerfile](#developing-the-dockerfile).
 
 > [!TIP]
-> In addition to using ```docker compose run --rm home <command>``` to spin up a temporary container to produce an artifact, you can also use ```docker compose exec -it home <command>``` to run the fix directly on the running container. This may also allow you to test one-off changes that might otherwise require a [full rebuild](#fully-resetting-your-environment). Use caution with this approach as you may end up breaking your container and causing a restart loop.
+> In addition to using `docker compose run --rm home <command>` to spin up a temporary container to produce an artifact, you can also use `docker compose exec -it home <command>` to run the fix directly on the running container. This may also allow you to test one-off changes that might otherwise require a [full rebuild](#fully-resetting-your-environment). Use caution with this approach as you may end up breaking your container and causing a restart loop.
 
 ## Teardown commands
 
@@ -127,17 +110,6 @@ docker compose up --no-deps -d solr
 docker compose stop
 docker compose rm -v
 ```
-
-This exposes the following ports:
-
-| Port | Service                |
-| ---- | ---------------------- |
-| 8080 | Open Library main site |
-| 7000 | Infobase               |
-| 8983 | Solr                   |
-| 7075 | Cover store            |
-
-For example, to access Solr admin, go to http://localhost:8983/solr/admin/
 
 ## Fully Resetting Your Environment
 
@@ -177,7 +149,7 @@ Note: after fixing this error, be on the lookout for another error that will app
 
 Look for errors that appear very soon after running `docker compose up` that come from the `openlibrary-db-1` container when it first starts mentioning something about the `role` of `openlibrary` not existing.
 
-In this case, try the steps in [Fully Resetting Your Environment](#fully-resetting-your-environment)
+In this case, try the steps in [Fully Resetting Your Environment](#fully-resetting-your-environment).
 
 Note: please update this README with the exact wording of the error if you run into it.
 
@@ -188,10 +160,12 @@ Note: please update this README with the exact wording of the error if you run i
 ### "No module named 'infogami'"
 
 The following should populate the target of the `infogami` symbolic link (i.e. `vendor/infogami/`):
+
 ```sh
 cd path/to/your/cloned/openlibrary
 git submodule init; git submodule sync; git submodule update
 ```
+
 Windows users may need to see [Fix line endings, symlinks, and git submodules](https://docs.openlibrary.org/developers/tools/git.html#fix-line-endings-symlinks-and-git-submodules-only-for-windows-users-not-using-a-linux-vm).
 
 ### "no configuration file provided: not found" when running `docker compose <command>`
@@ -199,8 +173,10 @@ Windows users may need to see [Fix line endings, symlinks, and git submodules](h
 Ensure you're running `docker compose` commands from within the `local-openlibrary-dev-directory`.
 
 ### ConnectionError: HTTPConnectionPool(host='solr', port=8983)
+
 The full error is something like (line breaks added):
-```
+
+```log
 /openlibrary/openlibrary/templates/home/index.html: error in processing
  template: ConnectionError: HTTPConnectionPool(host='solr', port=8983):
 Max retries exceeded with url: /solr/openlibrary/select (Caused by
@@ -208,47 +184,42 @@ NameResolutionError("<urllib3.connection.HTTPConnection object at
 0x77a95c4e7f90>: Failed to resolve 'solr' ([Errno -2] Name or service
 not known)")) (falling back to default template)
 ```
+
 The following should get everything running again:
+
 ```sh
 docker compose down
 docker container ls -a
-# If you see any openlibrary container here, remove them with `docker rm -f NAME`
+# If you see any openlibrary containers here, remove them with `docker rm -f NAME`
 docker network ls
-# If you see any open library networks here, remove them with `docker network rm NAME
+# If you see any open library networks here, remove them with `docker network rm NAME`
 docker compose up  # or docker compose up -d
 ```
-If you're curious and want to understand what happened, and why the above likely fixes it, first, verify the `solr` container is running (e.g. `docker ps | grep solr`, and then look for something like `openlibrary-solr-1` that isn't `solr-updater`.) If the `solr` container isn't running, simply start it with `docker compose up solr` (or `docker compose up -d solr`) and that should fix it. If `solr` is running, verify too that you can also connect to solr at http://localhost:8983/solr/#/. If you can't, something else is likely wrong.
+
+If you're curious and want to understand what happened, and why the above likely fixes it, first, verify the `solr` container is running (e.g. `docker ps | grep solr`, and then look for something like `openlibrary-solr-1` that isn't `solr-updater`.) If the `solr` container isn't running, simply start it with `docker compose up solr` (or `docker compose up -d solr`) and that should fix it. If `solr` is running, verify too that you can also connect to solr at <http://localhost:8983/solr/#/>. If you can't, something else is likely wrong.
 
 If the `solr` container is running and the error persists, one cause seems to be that the containers sometimes become disconnected from `openlibrary_webnet` (though this could happen with `openlibrary_dbnet` too). `openlibrary-web-1`/`web` should be connected to both `openlibrary_webnet` and `openlibrary_dbnet`, but when this problem occurs, instead only one is connected. E.g.:
+
 ```sh
 docker container inspect --format '{{.NetworkSettings.Networks}}' openlibrary-web-1
 # output: map[openlibrary_dbnet:0xc00037c1c0]
 ```
+
 Because you've read this far, you can now directly fix the problem without removing the containers and networks. Simply reconnect the container to the network:
+
 ```sh
 docker network connect openlibrary_webnet openlibrary-web-1  # or `openlibrary_dbnet` as the case may be.
 docker container inspect --format '{{.NetworkSettings.Networks}}' openlibrary-web-1
 # output: map[openlibrary_dbnet:0xc00016c460 openlibrary_webnet:0xc00016c540]
 ```
+
 No restart is required. If `webnet` no longer exists, recreating it _should_ fix things: `docker network create openlibrary_webnet`.
 
-To understand a bit more about what's going on here, there are docker networks configured in `compose.yaml`. The containers should be able to resolve one another based on the container names (e.g. `web` and `solr`), assuming `compose.yaml` has them on the same netork. For more, see [Networking in Compose](https://docs.docker.com/compose/networking/).
-
-## Technical notes
-
-re: `docker-compose` and `docker compose`
-
-As of early 2023, following the installation instructions on Docker's website will install either Docker Desktop, which includes Docker Compose v2, or `docker-ce` and `docker-compose-plugin` (Linux only), both of which obviate the need to install `docker-compose` v1 separately.
-
-Further, Compose V1 will [no longer be supported by the end of June 2023](https://docs.docker.com/compose/compose-v2/) and will be removed from Docker Desktop. These directions are written for Compose V2, hence the use of `docker compose` rather than `docker-compose`. `docker compose` is [meant to be a drop-in replacement](https://docs.docker.com/compose/compose-v2/#differences-between-compose-v1-and-compose-v2) for `docker-compose`.
-
-If for some reason one cannot use a current version of Docker that includes the Docker Compose plugin, it can [be installed separately](https://docs.docker.com/compose/install/)
-
-Finally, as of this writing (early 2023), the `docker-compose` that comes with relatively recent Linux distributions (e.g. Ubuntu 22.04) still works if it is already installed.
+To understand a bit more about what's going on here, there are docker networks configured in `compose.yaml`. The containers should be able to resolve one another based on the container names (e.g. `web` and `solr`), assuming `compose.yaml` has them on the same network. For more, see [Networking in Compose](https://docs.docker.com/compose/networking/).
 
 ## Useful Runtime Commands
 
-See Docker's docs for more: https://docs.docker.com/compose/reference/overview
+See Docker's docs for more: <https://docs.docker.com/compose/reference/overview>
 
 ```sh
 # Read a service's logs (replace `web` with service name)
@@ -292,13 +263,10 @@ If you need to make changes to the dependencies in Dockerfile.olbase, rebuild it
 docker build -t openlibrary/olbase:latest -f docker/Dockerfile.olbase . # 30+ min (Win10Home/Dec 2018)
 ```
 
-This image is automatically rebuilt on deploy by ol-home0 and is pushed to at https://hub.docker.com/r/openlibrary/olbase.
+This image is automatically rebuilt on deploy by ol-home0 and is pushed to at <https://hub.docker.com/r/openlibrary/olbase>.
 
 If you're making changes you think might affect Docker Hub, you can create a branch starting with `docker-test`, e.g. `docker-test-py2py3` (no weird chars), to trigger a build in docker hub at e.g. `openlibrary/olbase:docker-test-py2py3`.
-
 
 ## Debugging and Profiling the Docker Image
 
 See [Debugging and Performance Profiling](https://docs.openlibrary.org/advanced/debugging-and-performance-profiling.html) for more information on how to attach a debugger when running in the Docker Container.
-
-


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

I've struggled for quite a while now with how to organize the docs in our repo to align with our docs.openlibrary.org site.

For now, this is the solution. It's a somewhat minimal change that clarifies the purpose of these docs so that they're well aligned with our docs site.

Contributing is now about norms
Docker is more strictly about docker (points to other pages as needed)
readme.me (root) is a simple pointer to a few other resources.

After having several people tell me it wasn't clear that docs.openlibrary.org exists after looking at the repo this is going to fix that and get people to the latest and greatest info.

I need to merge now so these updates can be imported into the main docs site since I have other changes up there that are aligned. However, I would very much welcome feedback on this and suggestions to improve!


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
