### PR TITLE
feat(search): Add query intent preprocessing layer

### DIFF
--- a/openlibrary/fastapi/search.py
+++ b/openlibrary/fastapi/search.py
@@ -30,11 +30,11 @@ from openlibrary.plugins.worksearch.code import (
     validate_search_json_query,
     work_search_async,
 )
+from openlibrary.plugins.worksearch.intent import QueryClassifier
 from openlibrary.plugins.worksearch.schemes.authors import AuthorSearchScheme
 from openlibrary.plugins.worksearch.schemes.lists import ListSearchScheme
 from openlibrary.plugins.worksearch.schemes.subjects import SubjectSearchScheme
 from openlibrary.plugins.worksearch.schemes.works import WorkSearchScheme
-from openlibrary.plugins.worksearch.intent import QueryClassifier
 
 router = APIRouter()
 
@@ -116,19 +116,19 @@ class SearchRequestParams(PublicQueryOptions, Pagination):
     @classmethod
     def apply_intent_classification(cls, data: Any) -> Any:
         if isinstance(data, dict):
-            if "query" in data and data["query"]:
+            if data.get("query"):
                 return data
-            
+
             raw_q = data.get("q")
             if raw_q:
                 if not data.get("isbn") and not data.get("publish_year") and not data.get("first_publish_year"):
                     intent_data = QueryClassifier.parse_intent(raw_q)
-                    
+
                     if "isbn" in intent_data and not data.get("isbn"):
                         data["isbn"] = intent_data["isbn"]
                     if "publish_year" in intent_data and not data.get("first_publish_year"):
                         data["first_publish_year"] = intent_data["publish_year"]
-                    
+
                     data["q"] = intent_data["q"]
         return data
 

--- a/openlibrary/plugins/worksearch/intent.py
+++ b/openlibrary/plugins/worksearch/intent.py
@@ -1,19 +1,20 @@
 import re
 from typing import Any
 
+
 class QueryClassifier:
     """
     A lightweight intent classification layer to extract structured data
     (e.g., ISBNs, Publishing Years) from raw query strings before they
     reach the Solr parsing layer.
     """
-    
+
     # Matches ISBN-10 and ISBN-13 formats with optional hyphens/spaces.
     ISBN_REGEX = re.compile(
         r"(?:\bISBN(?:-1[03])?:? )?(?=[-0-9 ]{17}$|[-0-9X ]{13}$|[0-9X]{10}$)(?:97[89][- ]?)?[0-9]{1,5}[- ]?[0-9]+[- ]?[0-9]+[- ]?[0-9X]\b",
-        re.IGNORECASE
+        re.IGNORECASE,
     )
-    
+
     # Matches a valid publishing year in the range 1400 - 2026.
     YEAR_REGEX = re.compile(r"\b(1[4-9]\d{2}|20[0-1]\d|202[0-6])\b")
 
@@ -22,7 +23,7 @@ class QueryClassifier:
         """
         Parses a raw search query and extracts high-confidence structured
         fields, returning the remaining query text.
-        
+
         :param raw_q: The original search string provided by the user.
         :return: A dictionary containing extracted fields and the residual 'q'.
         """
@@ -33,21 +34,19 @@ class QueryClassifier:
             return {"q": residual_q}
 
         # 1. Extract ISBN
-        isbn_match = cls.ISBN_REGEX.search(residual_q)
-        if isbn_match:
+        if isbn_match := cls.ISBN_REGEX.search(residual_q):
             # Strip formatting to match the underlying Solr schema requirements
             isbn_clean = isbn_match.group(0).replace('-', '').replace(' ', '').strip()
             # Handle edge case where "ISBN:" prefix is included
             if isbn_clean.lower().startswith("isbn"):
                 isbn_clean = isbn_clean[4:].strip(':')
-            
+
             extracted['isbn'] = isbn_clean
             # Remove the detected ISBN from the residual text
             residual_q = cls.ISBN_REGEX.sub('', residual_q)
 
         # 2. Extract Publish Year
-        year_match = cls.YEAR_REGEX.search(residual_q)
-        if year_match:
+        if year_match := cls.YEAR_REGEX.search(residual_q):
             extracted['publish_year'] = year_match.group(0).strip()
             residual_q = cls.YEAR_REGEX.sub('', residual_q)
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes # (add issue number if applicable)

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
feature


### Technical
This PR introduces a lightweight query intent classification step to improve how search queries are interpreted before being processed by Solr.

Currently, all queries are handled as unstructured text and passed through the Luqum-based parser. This can lead to inefficient queries and reduced relevance for inputs that contain structured signals such as ISBNs or publication years.

This change adds a preprocessing layer that extracts high-confidence structured fields and incorporates them into the request parameters prior to query execution.

**Key changes:**
- Added `openlibrary/plugins/worksearch/intent.py`
  - Implements a `QueryClassifier` with regex-based extraction for:
    - ISBN (ISBN-10 / ISBN-13)
    - Publish year (range: 1400–2026)
  - Returns extracted fields along with a cleaned residual query string

- Updated `SearchRequestParams` in `fastapi/search.py`
  - Introduced a `@model_validator(mode="before")` hook
  - Applies intent classification only when structured fields are not already provided
  - Merges extracted values into the request payload

**Design notes:**
- Does not modify existing Solr queries or Luqum parsing logic
- Fully backward compatible (no-op if no structured patterns are detected)
- Keeps implementation minimal and contained
- Provides a foundation for future extensions (e.g., author extraction, NER, improved ranking)


### Testing
Run Open Library locally and test via `/search.json`:

1. ISBN query:
q=9780439139601

Expected:
- `publish_year=1997` is extracted
- Remaining query processed normally

3. General query:

q=science fiction books

Expected:
- No change in behavior

Verify:
- No regressions in existing search results
- Correct extraction and parameter injection


### Screenshot
N/A (no UI changes)


### Stakeholders
@openlibrary