### PR TITLE
Fix mobile header spacing and alignment issues on My Books page

### DIFF
--- a/static/css/page-user.css
+++ b/static/css/page-user.css
@@ -231,3 +231,29 @@ textarea.toc-editor {
 /* Import styles for sort options */
 @import "components/sort-dropper.css";
 @import "components/pagination.css";
+
+@media only screen and (max-width: 768px) {
+  /* Remove extra top gap above username on My Books mobile header */
+  .mybooks-details header {
+    padding-top: 0;
+    margin-top: 0;
+  }
+
+  .mybooks-details .account-breadcrumb {
+    margin-top: 0;
+    padding-top: 0;
+  }
+
+  h2.account-username {
+    margin-top: 0;
+    margin-bottom: 12px;
+  }
+
+  /* Keep mobile section headers flush-left and consistent */
+  .mybooks-menu-mobile .details-title,
+  .mybooks-menu-mobile .carousel-section-header,
+  .mybooks-menu-mobile .carousel-section-header a {
+    margin-left: 0;
+    padding-left: 0;
+  }
+}


### PR DESCRIPTION
Closes #12095

fix

### Technical
- Reduced excessive top spacing in the profile header for mobile view
- Standardized left alignment of section headers (e.g., "My Stats")
- Applied changes using mobile-specific media queries to avoid affecting desktop layout
- Updated styles in page-user.css

### Testing
1. Run Open Library locally
2. Navigate to /account/books
3. Enable mobile view using browser dev tools
4. Observe:
   - Reduced spacing above username
   - Proper left alignment of section headers
5. Switch to desktop view and confirm layout remains unchanged

### Screenshot
<img width="610" height="1264" alt="Screenshot 2026-03-31 165219" src="https://github.com/user-attachments/assets/8b1081a3-1577-4286-a8c1-277df4a7565f" />
<img width="614" height="1255" alt="Screenshot 2026-03-31 165404" src="https://github.com/user-attachments/assets/b901eac9-cc3a-431f-abd0-930c055c7c0b" />
<img width="608" height="1254" alt="Screenshot 2026-03-31 165558" src="https://github.com/user-attachments/assets/be142731-c7c8-4ddb-b791-9a9488edca41" />


Desktop (unchanged):


<img width="2844" height="1440" alt="Screenshot 2026-03-31 170858" src="https://github.com/user-attachments/assets/78dfd0d1-c817-41db-83d4-705c9b40efdb" />
<img width="2852" height="1459" alt="Screenshot 2026-03-31 170921" src="https://github.com/user-attachments/assets/57abe63d-29b1-4376-a6b4-5a35afe1c89b" />

### Stakeholder

@mekarpeles