### PR TITLE
Update local dev environment to postgres 18

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -82,8 +82,7 @@ services:
     volumes:
       - ${OL_MOUNT_DIR:-.}:/openlibrary
       # Any files inside /docker-entrypoint-initdb.d/ will get run by postgres
-      # if the db is empty (which as of now is always, since we don't store the
-      # postgres data anywhere).
+      # if the db is empty (ie during first run).
       - ./docker/ol-db-init.sh:/docker-entrypoint-initdb.d/ol-db-init.sh
       - ol-postgres:/var/lib/postgresql
 


### PR DESCRIPTION
Part of #12199 .

Note this will require everyone to run:

```sh
docker compose down
docker volume rm -f openlibrary_ol-postgres
docker compose up -d
```

To reset the local database.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Locally works!

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles @jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
