### PR TITLE
make contributing.md reflect current process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,68 +1,70 @@
 # Contributing
 
-This page covers the community norms, contribution standards, and project management practices for Open Library. For setup and getting started, see the [Quick Start](https://docs.openlibrary.org/developers/quick-start.html) guide.
+Thanks for your interest in contributing to Open Library! This guide explains how to choose work, coordinate with maintainers, and submit a pull request successfully. For setup instructions, see the [Quick Start](https://docs.openlibrary.org/developers/quick-start.html) guide.
 
-## Contributor Etiquette
+## How contributing works
 
-We value all contributors and want to ensure a positive and collaborative environment. Please follow these guidelines:
+1. Find an unassigned issue
+2. Comment to request assignment and describe your plan
+3. Wait for assignment
+4. Complete the work and test it
+5. Open a self-contained PR
+6. Respond to review comments clearly
 
-### Respecting Other Contributors' Work
+## Before you begin
 
-- **Do not undermine others' efforts**: If someone has already asked to work on an issue and been assigned (or is actively working on it), please respect their effort. Opening a competing PR without coordination undermines their contribution and violates our community spirit.
-- **Check before starting**: Before beginning work on an issue, check if someone else is already assigned or has recently expressed interest in working on it.
+Please **request assignment** to an issue before starting work. Our maintainers triage issues weekly (or immediately for high-priority items) to ensure your contribution aligns with current priorities and prevent duplicate effort.
 
-### Requesting Issue Assignments
+When requesting assignment:
 
-- **Quality over quantity**: Please do not ask to be assigned to dozens of issues at a time. Focus on making meaningful contributions rather than accumulating assignments.
-- **Demonstrate understanding**: When requesting to be assigned to an issue, show that you understand the problem by including:
-  - A summary of the challenge or bug
-  - Your proposed approach to solving it
-  - Which files or components you plan to modify
-  - Any questions you have about the implementation
-- **Use AI tools responsibly**: While you're encouraged to use AI tools (like LLMs) to assist with research and understanding the codebase, please don't simply copy-paste AI-generated responses into your comments. Take time to understand the suggestions and present them in your own words, demonstrating genuine comprehension of the issue.
+- Focus on one meaningful issue at a time rather than requesting many
+- Explain the problem and your proposed approach in your own words
+- Mention which files or components you plan to modify
 
-## Submitting Pull Requests
+**Use AI tools responsibly.** Be prepared to explain the problem and your proposed solution in your own words.
 
-1. **Test your code before opening a PR**: Maintainers may close your PR if it has clearly not been tested.
-2. **Follow the pull request template**: It's easier for a maintainer to reject a PR than it is for them to fill it out for you.
-3. **Make PRs _self-contained_**: They should clearly describe what changes have taken place. A reviewer should (for the most part) be able to complete a review without having to look at other issues.
-4. **Resolve all code review (CR) comments**: Treat comments as a todo list. Most PRs will require some edits before getting merged, so don't get discouraged if you have to make some changes!
-5. **Reply when resolving CR comments**: When resolving a comment, reply with "DONE" or "WON'T FIX because ...". A reviewer will unresolve a comment if they feel it's necessary.
+Please respect current assignments. If someone is already assigned or actively working on an issue, coordinate on the issue before starting related work.
 
-## Managing Issues
+## Choosing work
 
-### Picking Good First Issues
+### Good First Issues
 
-[Browse Good First Issues](https://github.com/internetarchive/openlibrary/issues?q=is%3Aissue+is%3Aopen+-linked%3Apr+label%3A%22Good+First+Issue%22+no%3Aassignee)
+[Browse Good First Issues](https://github.com/internetarchive/openlibrary/issues?q=is%3Aissue+is%3Aopen+-linked%3Apr+label%3A%22Good+First+Issue%22+no%3Aassignee) — ideal for first-time contributors.
 
-- Only pick issues that are **not assigned** to anyone
-- If an issue has been assigned but has seen no response or activity for 2 weeks, you may comment to ask if you can take it
-- Do not request to be assigned to issues that are actively being worked on
-- If you have questions, ask the Lead designated by the `Lead: @person` label on the issue
+- Only work on issues that are not assigned to anyone
+- Request assignment before you start
+- If an assigned issue has been inactive for 2 weeks, ask whether it can be reassigned
 
-### When No Good First Issues Are Available
+### When no Good First Issues are available
 
-If all Good First Issues are taken, here's how to find something to work on:
+- Browse [unassigned issues sorted by recently updated](https://github.com/internetarchive/openlibrary/issues?q=is%3Aissue+is%3Aopen+-linked%3Apr+no%3Aassignee+sort%3Aupdated-desc)
+- Revisit older issues and confirm they're still relevant before starting
+- Ask in Slack — request an invite on our [volunteers page](https://openlibrary.org/volunteer)
+- Attend the weekly community call to hear about current priorities
 
-1. **Browse all unassigned issues** — [filter by recently updated](https://github.com/internetarchive/openlibrary/issues?q=is%3Aissue+is%3Aopen+-linked%3Apr+no%3Aassignee+sort%3Aupdated-desc) to find active discussions
-2. **Look for older issues** that haven't had much activity. Before starting, verify the issue is still relevant by checking that the code area hasn't changed significantly, and leave a comment on the issue to confirm your intent
-3. **Ask in Slack** — request an invite on our [volunteers page](https://openlibrary.org/volunteer). Maintainers can point you to what's actually useful right now
-4. **Attend a weekly community call** — a good place to hear about current priorities
-5. **Documentation improvements** are always welcome and don't require a full dev setup
+## Opening a pull request
 
-### Tagging
+- Test your changes before opening a PR so reviewers can focus on the code rather than basic setup issues
+- Mark the PR as draft if it's still in progress
+- Complete the pull request template fully so reviewers have the context they need
+- Make PRs self-contained so reviewers can understand them without extra context
 
-- If an issue requires immediate fixing, include a comment requesting it be labeled and promoted as [`Priority: 0`](https://github.com/internetarchive/openlibrary/issues?q=is%3Aopen+is%3Aissue+label%3A%22Priority%3A+0%22).
+Review comments are a normal part of the process. Most PRs need at least one round of changes before merge.
 
-## Code of Conduct
+## Responding to review
 
-Please familiarize yourself with our [Code of Conduct](https://github.com/internetarchive/openlibrary/blob/master/CODE_OF_CONDUCT.md). We are a non-profit, open-source, inclusive project, and we believe everyone deserves a safe place to make the world a little better. We're committed to creating this safe place.
+- Reply to each review comment with the change you made or why you chose a different approach
+- Resolve all review comments before requesting another review
+- When resolving a comment, reply with "DONE" or "WON'T FIX because ..."
+- If the issue has a `Lead: @username` label, that person is usually the best reviewer to tag
 
-## Community
+If you haven't heard back within one week of requesting assignment, feel free to tag the `Lead:` on the issue.
 
-- The core Open Library team communicates over an invite-only Slack channel. Request an invitation on our [volunteers page](https://openlibrary.org/volunteer).
-- We host weekly video calls. Check the [community call page](https://docs.openlibrary.org/everyone/community-call.html) for times and details.
+## Community & getting help
 
-## Roadmap
+Please read our [Code of Conduct](https://github.com/internetarchive/openlibrary/blob/master/CODE_OF_CONDUCT.md). We're a non-profit, open-source, inclusive project committed to creating a safe place for everyone.
 
-View this year's roadmap (and previous years') in the [Open Library Roadmap document](https://docs.google.com/document/d/1KJr3A81Gew7nfuyo9PnCLCjNBDs5c7iR4loOGm1Pafs/edit).
+**Get involved:**
+- Join Slack — request an invite on our [volunteers page](https://openlibrary.org/volunteer)
+- Attend weekly community calls — check the [community call page](https://docs.openlibrary.org/everyone/community-call.html) for times
+- Review the [Open Library Roadmap](https://docs.google.com/document/d/1KJr3A81Gew7nfuyo9PnCLCjNBDs5c7iR4loOGm1Pafs/edit) to understand current priorities


### PR DESCRIPTION
<!-- What issue does this PR close? -->
With this PR I'm trying to make our process crystal clear to help make it easier to deal with the many new AI generated PRs.

In short, this clearly and closely reflects our current practices and is oriented at new contributors.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
