### PR TITLE
feat: interactive testing environment dashboard on /status (#11506)

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -1564,7 +1564,7 @@ msgstr ""
 
 #: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html
 #: openlibrary/plugins/worksearch/code.py search/advancedsearch.html
-#: search/work_search_selected_facets.html
+#: search/work_search_selected_facets.html status.html
 msgid "Author"
 msgstr ""
 
@@ -1590,7 +1590,7 @@ msgstr ""
 msgid "Settings & Privacy"
 msgstr ""
 
-#: account.html
+#: account.html status.html
 msgid "or"
 msgstr ""
 
@@ -2442,11 +2442,23 @@ msgid "Testing Environment"
 msgstr ""
 
 #: status.html
-msgid "PR number or GitHub PR URL"
+msgid "Deploy triggered!"
 msgstr ""
 
 #: status.html
-msgid "Add PR"
+msgid "View Jenkins progress"
+msgstr ""
+
+#: status.html
+msgid "GitHub status refreshed."
+msgstr ""
+
+#: status.html
+msgid "PR numbers or URLs, space/comma separated"
+msgstr ""
+
+#: status.html
+msgid "Add PR(s)"
 msgstr ""
 
 #: status.html
@@ -2457,6 +2469,10 @@ msgstr ""
 #: search/advancedsearch.html status.html type/about/edit.html
 #: type/page/edit.html type/template/edit.html
 msgid "Title"
+msgstr ""
+
+#: status.html
+msgid "Assignee"
 msgstr ""
 
 #: status.html
@@ -2472,15 +2488,36 @@ msgid "Drift"
 msgstr ""
 
 #: status.html
-msgid "Active"
+msgid "Enabled"
 msgstr ""
 
 #: status.html
-msgid "Pull to Latest"
+msgid "up to date"
 msgstr ""
 
 #: status.html
-msgid "Toggle Active"
+msgid "unknown"
+msgstr ""
+
+#: status.html
+msgid "1 commit behind"
+msgstr ""
+
+#: status.html
+#, python-format
+msgid "%(count)s commits behind"
+msgstr ""
+
+#: admin/solr.html status.html
+msgid "Update"
+msgstr ""
+
+#: status.html
+msgid "Enable"
+msgstr ""
+
+#: status.html
+msgid "Disable"
 msgstr ""
 
 #: lists/lists.html status.html type/list/edit.html type/series/edit.html
@@ -2488,7 +2525,15 @@ msgid "Remove"
 msgstr ""
 
 #: status.html
-msgid "Force Rebuild"
+msgid "Selected PRs"
+msgstr ""
+
+#: status.html
+msgid "Refresh"
+msgstr ""
+
+#: status.html
+msgid "Deploy"
 msgstr ""
 
 #: status.html
@@ -2496,7 +2541,7 @@ msgid "No PRs in testing set."
 msgstr ""
 
 #: status.html
-msgid "Staged"
+msgid "Last Build Result"
 msgstr ""
 
 #: status.html
@@ -4067,10 +4112,6 @@ msgstr ""
 
 #: admin/solr.html
 msgid "Write one entry per line"
-msgstr ""
-
-#: admin/solr.html
-msgid "Update"
 msgstr ""
 
 #: admin/spamwords.html

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -2069,7 +2069,7 @@ msgstr ""
 msgid "history"
 msgstr ""
 
-#: diff.html
+#: diff.html status.html
 msgid "Added"
 msgstr ""
 
@@ -2435,6 +2435,64 @@ msgstr ""
 
 #: status.html
 msgid "Server status"
+msgstr ""
+
+#: status.html
+msgid "Testing Environment"
+msgstr ""
+
+#: status.html
+msgid "PR number or GitHub PR URL"
+msgstr ""
+
+#: status.html
+msgid "Add PR"
+msgstr ""
+
+#: status.html
+msgid "PR"
+msgstr ""
+
+#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html
+#: search/advancedsearch.html status.html type/about/edit.html
+#: type/page/edit.html type/template/edit.html
+msgid "Title"
+msgstr ""
+
+#: status.html
+msgid "Pinned Commit"
+msgstr ""
+
+#: status.html
+msgid "Branch HEAD"
+msgstr ""
+
+#: status.html
+msgid "Drift"
+msgstr ""
+
+#: status.html
+msgid "Active"
+msgstr ""
+
+#: status.html
+msgid "Pull to Latest"
+msgstr ""
+
+#: status.html
+msgid "Toggle Active"
+msgstr ""
+
+#: lists/lists.html status.html type/list/edit.html type/series/edit.html
+msgid "Remove"
+msgstr ""
+
+#: status.html
+msgid "Force Rebuild"
+msgstr ""
+
+#: status.html
+msgid "No PRs in testing set."
 msgstr ""
 
 #: status.html
@@ -4759,12 +4817,6 @@ msgid ""
 "those fields."
 msgstr ""
 
-#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html
-#: search/advancedsearch.html type/about/edit.html type/page/edit.html
-#: type/template/edit.html
-msgid "Title"
-msgstr ""
-
 #: books/add.html books/edit.html
 msgid "Use <b><i>Title: Subtitle</i></b> to add a subtitle."
 msgstr ""
@@ -6818,10 +6870,6 @@ msgstr ""
 
 #: lists/lists.html
 msgid "Remove this seed?"
-msgstr ""
-
-#: lists/lists.html type/list/edit.html type/series/edit.html
-msgid "Remove"
 msgstr ""
 
 #: lists/lists.html

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -7,7 +7,7 @@ import socket
 import sys
 import urllib.error
 import urllib.request
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlencode
@@ -18,35 +18,51 @@ from infogami import config
 from infogami.utils import delegate
 from infogami.utils.view import public, render_template
 from openlibrary.accounts import get_current_user
-from openlibrary.core import stats
+from openlibrary.core import cache, stats
 from openlibrary.utils import get_software_version
 
 status_info: dict[str, Any] = {}
-feature_flagso: dict[str, Any] = {}
+feature_flags: dict[str, Any] = {}
 
 TESTING_STATE_FILE = Path('./_testing-prs.json')
 _GITHUB_API_BASE = "https://api.github.com/repos/internetarchive/openlibrary"
 _JENKINS_URL = "https://jenkins.openlibrary.org/job/testing-deploy/buildWithParameters"
+_JENKINS_JOB_URL = "https://jenkins.openlibrary.org/job/ol-dev1-deploy%20(internal)/"
+_DRIFT_CACHE_KEY = 'status.github_pr_drift'
+_DRIFT_CACHE_TTL = 5 * 60  # 5 minutes
 
 
 class status(delegate.page):
     def GET(self):
-        testing_prs = _load_testing_state()  # None if state file doesn't exist
+        testing_state = _load_testing_state()
         is_maintainer_user = _is_maintainer()
         drift_info = {}
-        if testing_prs:
-            # NOTE: makes 1-2 GitHub API calls per PR; acceptable for small testing sets
-            drift_info = {p.pr: _get_pr_drift(p) for p in testing_prs}
-        show_testing = testing_prs is not None or is_maintainer_user
+        if testing_state:
+            drift_info, _ = _get_drift_info(testing_state)
+        show_testing = testing_state is not None or is_maintainer_user
+        last_deploy = testing_state.last_deploy_at if testing_state else ''
+        has_pending = bool(testing_state) and any(
+            p.pull_latest_sha
+            or p.pending_active is not None
+            or drift_info.get(p.pr, {}).get('merged', False)
+            or not last_deploy
+            or p.added_at > last_deploy
+            for p in testing_state.prs
+        )
+        i = web.input(deploy_triggered=None, drift_refreshed=None)
         return render_template(
             "status",
             status_info,
             feature_flags,
             dev_merged_status=get_dev_merged_status(),
-            testing_prs=testing_prs or [],
+            testing_state=testing_state,
             drift_info=drift_info,
             is_maintainer=is_maintainer_user,
             show_testing=show_testing,
+            deploy_triggered=bool(i.deploy_triggered),
+            drift_refreshed=bool(i.drift_refreshed),
+            jenkins_job_url=_JENKINS_JOB_URL,
+            has_pending=has_pending,
         )
 
 
@@ -65,13 +81,15 @@ class status_add(delegate.page):
                     pr_numbers.append(_parse_pr_number(val))
         if not pr_numbers:
             raise web.badrequest()
-        prs = _load_testing_state() or []
-        existing = {p.pr for p in prs}
+        state = _load_testing_state() or TestingState(last_deploy_at='', prs=[])
+        existing = {p.pr for p in state.prs}
         user = get_current_user()
         for pr_number in pr_numbers:
             if pr_number not in existing:
                 info = _get_pr_info(pr_number)
-                prs.append(
+                if not info['head_sha']:
+                    continue  # GitHub API unavailable or invalid PR
+                state.prs.append(
                     TestingPR(
                         pr=pr_number,
                         commit=info['head_sha'],
@@ -79,11 +97,15 @@ class status_add(delegate.page):
                         title=info['title'],
                         added_at=datetime.datetime.now(datetime.UTC).isoformat(),
                         added_by=user.key.split('/')[-1] if user else '',
+                        author=info['author'],
+                        author_avatar=info['author_avatar'],
+                        assignee=info['assignee'],
+                        assignee_avatar=info['assignee_avatar'],
                     )
                 )
                 existing.add(pr_number)
-        _save_testing_state(prs)
-        _trigger_rebuild()
+        _save_testing_state(state)
+        _evict_drift_cache()
         raise web.seeother('/status')
 
 
@@ -95,27 +117,45 @@ class status_remove(delegate.page):
             raise web.unauthorized()
         i = web.input(prs=[])
         to_remove = {int(p) for p in i.prs}
-        _save_testing_state(
-            [p for p in (_load_testing_state() or []) if p.pr not in to_remove]
-        )
-        _trigger_rebuild()
+        if state := _load_testing_state():
+            state.prs = [p for p in state.prs if p.pr not in to_remove]
+            _save_testing_state(state)
         raise web.seeother('/status')
 
 
-class status_toggle(delegate.page):
-    path = '/status/toggle'
+class status_enable(delegate.page):
+    path = '/status/enable'
 
     def POST(self):
         if not _is_maintainer():
             raise web.unauthorized()
         i = web.input(prs=[])
-        to_toggle = {int(p) for p in i.prs}
-        prs = _load_testing_state() or []
-        for p in prs:
-            if p.pr in to_toggle:
-                p.active = not p.active
-        _save_testing_state(prs)
-        _trigger_rebuild()
+        to_enable = {int(p) for p in i.prs}
+        state = _load_testing_state()
+        if not state or not to_enable:
+            raise web.seeother('/status')
+        for p in state.prs:
+            if p.pr in to_enable:
+                p.pending_active = True
+        _save_testing_state(state)
+        raise web.seeother('/status')
+
+
+class status_disable(delegate.page):
+    path = '/status/disable'
+
+    def POST(self):
+        if not _is_maintainer():
+            raise web.unauthorized()
+        i = web.input(prs=[])
+        to_disable = {int(p) for p in i.prs}
+        state = _load_testing_state()
+        if not state or not to_disable:
+            raise web.seeother('/status')
+        for p in state.prs:
+            if p.pr in to_disable:
+                p.pending_active = False
+        _save_testing_state(state)
         raise web.seeother('/status')
 
 
@@ -127,25 +167,55 @@ class status_pull_latest(delegate.page):
             raise web.unauthorized()
         i = web.input(prs=[])
         to_update = {int(p) for p in i.prs}
-        prs = _load_testing_state() or []
-        for p in prs:
+        state = _load_testing_state()
+        if not state or not to_update:
+            raise web.seeother('/status')
+        for p in state.prs:
             if p.pr in to_update:
                 info = _get_pr_info(p.pr)
-                if info['head_sha']:
-                    p.commit = info['head_sha']
-        _save_testing_state(prs)
-        _trigger_rebuild()
+                if info['head_sha'] and info['head_sha'] != p.commit:
+                    p.pull_latest_sha = info['head_sha']
+        _save_testing_state(state)
         raise web.seeother('/status')
 
 
-class status_rebuild(delegate.page):
-    path = '/status/rebuild'
+class status_deploy(delegate.page):
+    path = '/status/deploy'
 
     def POST(self):
         if not _is_maintainer():
             raise web.unauthorized()
-        _trigger_rebuild()
-        raise web.seeother('/status')
+        state = _load_testing_state()
+        if not state:
+            raise web.seeother('/status')
+        # Apply all pending changes before deploying
+        for p in state.prs:
+            if p.pull_latest_sha:
+                p.commit = p.pull_latest_sha
+                p.pull_latest_sha = ''
+            if p.pending_active is not None:
+                p.active = p.pending_active
+                p.pending_active = None
+        # Remove PRs that have already been merged into master
+        drift_info, _ = _get_drift_info(state)
+        state.prs = [
+            p for p in state.prs if not drift_info.get(p.pr, {}).get('merged', False)
+        ]
+        state.last_deploy_at = datetime.datetime.now(datetime.UTC).isoformat()
+        _save_testing_state(state)
+        _evict_drift_cache()
+        triggered = _trigger_rebuild()
+        raise web.seeother('/status?deploy_triggered=1' if triggered else '/status')
+
+
+class status_refresh(delegate.page):
+    path = '/status/refresh'
+
+    def POST(self):
+        if not _is_maintainer():
+            raise web.unauthorized()
+        _evict_drift_cache()
+        raise web.seeother('/status?drift_refreshed=1')
 
 
 @functools.cache
@@ -227,17 +297,27 @@ class TestingPR:
     title: str
     added_at: str  # ISO timestamp
     added_by: str  # OL username
+    pull_latest_sha: str = ''  # pending SHA from "Fetch Latest"; applied on deploy
+    pending_active: bool | None = None  # pending enable/disable; applied on deploy
+    author: str = ''  # GitHub login of PR author
+    author_avatar: str = ''  # GitHub avatar URL (append &s=N for sizing)
+    assignee: str = ''  # GitHub login of assignee, empty if unassigned
+    assignee_avatar: str = ''  # GitHub avatar URL for assignee
 
     @property
     def short_commit(self) -> str:
         return self.commit[:7]
 
     @property
+    def short_pull_latest(self) -> str:
+        return self.pull_latest_sha[:7] if self.pull_latest_sha else ''
+
+    @property
     def added_date(self) -> str:
         return self.added_at[:10] if self.added_at else ''
 
     def to_dict(self) -> dict:
-        return {
+        d = {
             'pr': self.pr,
             'commit': self.commit,
             'active': self.active,
@@ -245,6 +325,19 @@ class TestingPR:
             'added_at': self.added_at,
             'added_by': self.added_by,
         }
+        if self.pull_latest_sha:
+            d['pull_latest_sha'] = self.pull_latest_sha
+        if self.pending_active is not None:
+            d['pending_active'] = self.pending_active
+        if self.author:
+            d['author'] = self.author
+        if self.author_avatar:
+            d['author_avatar'] = self.author_avatar
+        if self.assignee:
+            d['assignee'] = self.assignee
+        if self.assignee_avatar:
+            d['assignee_avatar'] = self.assignee_avatar
+        return d
 
     @classmethod
     def from_dict(cls, d: dict) -> 'TestingPR':
@@ -255,20 +348,50 @@ class TestingPR:
             title=d.get('title', f"PR #{d['pr']}"),
             added_at=d.get('added_at', ''),
             added_by=d.get('added_by', ''),
+            pull_latest_sha=d.get('pull_latest_sha', ''),
+            pending_active=d.get('pending_active'),
+            author=d.get('author', ''),
+            author_avatar=d.get('author_avatar', ''),
+            assignee=d.get('assignee', ''),
+            assignee_avatar=d.get('assignee_avatar', ''),
         )
 
 
-def _load_testing_state() -> 'list[TestingPR] | None':
-    """Returns list of TestingPRs if state file exists, None otherwise."""
+@dataclass
+class TestingState:
+    last_deploy_at: str  # ISO timestamp, empty if never deployed
+    prs: list[TestingPR] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            'last_deploy_at': self.last_deploy_at,
+            'prs': [p.to_dict() for p in self.prs],
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> 'TestingState':
+        return cls(
+            last_deploy_at=d.get('last_deploy_at', ''),
+            prs=[TestingPR.from_dict(p) for p in d.get('prs', [])],
+        )
+
+
+def _load_testing_state() -> 'TestingState | None':
+    """Returns TestingState if state file exists, None otherwise."""
     if TESTING_STATE_FILE.exists():
-        return [
-            TestingPR.from_dict(d) for d in json.loads(TESTING_STATE_FILE.read_text())
-        ]
+        data = json.loads(TESTING_STATE_FILE.read_text())
+        if isinstance(data, list):
+            # Backward compat: old format was a bare array
+            return TestingState(
+                last_deploy_at='',
+                prs=[TestingPR.from_dict(d) for d in data],
+            )
+        return TestingState.from_dict(data)
     return None
 
 
-def _save_testing_state(prs: list[TestingPR]) -> None:
-    TESTING_STATE_FILE.write_text(json.dumps([p.to_dict() for p in prs], indent=2))
+def _save_testing_state(state: TestingState) -> None:
+    TESTING_STATE_FILE.write_text(json.dumps(state.to_dict(), indent=2))
     get_dev_merged_status.cache_clear()
 
 
@@ -281,44 +404,122 @@ def _is_maintainer() -> bool:
 
 def _github_get(path: str) -> dict:
     url = f"{_GITHUB_API_BASE}/{path}"
-    req = urllib.request.Request(url, headers={'Accept': 'application/vnd.github+json'})
+    headers = {
+        'Accept': 'application/vnd.github+json',
+        'User-Agent': 'openlibrary-status',
+    }
+    if token := getattr(config, 'github_api_token', None):
+        headers['Authorization'] = f'Bearer {token}'
+    req = urllib.request.Request(url, headers=headers)
     with urllib.request.urlopen(req, timeout=5) as resp:
         return json.loads(resp.read())
 
 
+def _get_drift_info(state: TestingState) -> 'tuple[dict, bool]':
+    """Return (drift_dict, from_cache). Checks memcache first; fetches GitHub on miss.
+
+    Keys are int PR numbers. JSON round-trip via memcache stringifies keys, so we
+    re-cast on read.
+
+    On a cache miss, also refreshes title/author/assignee on each TestingPR in-place
+    and saves the state file if anything changed.
+    """
+    mc = cache.get_memcache()
+    if (cached := mc.get(_DRIFT_CACHE_KEY)) is not None:
+        return {int(k): v for k, v in cached.items()}, True
+    drift = {}
+    state_changed = False
+    for p in state.prs:
+        info = _get_pr_drift(p)
+        drift[p.pr] = {k: info[k] for k in ('head_sha', 'drift', 'merged')}
+        for attr in ('title', 'author', 'author_avatar', 'assignee', 'assignee_avatar'):
+            new_val = info.get(attr, '')
+            if new_val and getattr(p, attr) != new_val:
+                setattr(p, attr, new_val)
+                state_changed = True
+    if state_changed:
+        _save_testing_state(state)
+    mc.set(_DRIFT_CACHE_KEY, drift, expires=_DRIFT_CACHE_TTL)
+    return drift, False
+
+
+def _evict_drift_cache() -> None:
+    cache.get_memcache().delete(_DRIFT_CACHE_KEY)
+
+
 def _get_pr_info(pr_number: int) -> dict:
-    """Fetch title and current HEAD SHA for a PR from GitHub."""
+    """Fetch title, HEAD SHA, author, and assignee for a PR from GitHub."""
     try:
         pr = _github_get(f"pulls/{pr_number}")
+        user = pr.get('user') or {}
+        assignee = pr.get('assignee') or {}
         return {
             'title': pr.get('title', f'PR #{pr_number}'),
             'head_sha': pr['head']['sha'],
+            'author': user.get('login', ''),
+            'author_avatar': user.get('avatar_url', ''),
+            'assignee': assignee.get('login', ''),
+            'assignee_avatar': assignee.get('avatar_url', ''),
         }
     except (urllib.error.URLError, KeyError, ValueError, json.JSONDecodeError):
-        return {'title': f'PR #{pr_number}', 'head_sha': ''}
+        return {
+            'title': f'PR #{pr_number}',
+            'head_sha': '',
+            'author': '',
+            'author_avatar': '',
+            'assignee': '',
+            'assignee_avatar': '',
+        }
 
 
 def _get_pr_drift(pr: TestingPR) -> dict:
-    """Fetch live drift info for a PR in the testing state."""
+    """Fetch live drift info + metadata for a PR from GitHub.
+
+    Returns head_sha, drift, merged plus title/author/assignee so callers can
+    refresh state without a second API call.
+    """
     try:
         gh = _github_get(f"pulls/{pr.pr}")
         head_sha = gh['head']['sha']
-        merged = gh.get('merged') or gh.get('state') == 'closed'
-        if head_sha.startswith(pr.commit) or pr.commit.startswith(head_sha[:7]):
+        merged = bool(gh.get('merged') or gh.get('merged_at'))
+        stored = pr.commit.strip()
+        if head_sha == stored or (len(stored) < 40 and head_sha.startswith(stored)):
             drift = 0
         else:
             try:
-                cmp = _github_get(f"compare/{pr.short_commit}...{head_sha[:7]}")
+                cmp = _github_get(f"compare/{stored}...{head_sha}")
                 drift = cmp.get('ahead_by', -1)
             except (urllib.error.URLError, ValueError, json.JSONDecodeError):
                 drift = -1
-        return {'head_sha': head_sha[:7], 'drift': drift, 'merged': merged}
+        user = gh.get('user') or {}
+        assignee = gh.get('assignee') or {}
+        return {
+            'head_sha': head_sha[:7],
+            'drift': drift,
+            'merged': merged,
+            'title': gh.get('title', f'PR #{pr.pr}'),
+            'author': user.get('login', ''),
+            'author_avatar': user.get('avatar_url', ''),
+            'assignee': assignee.get('login', ''),
+            'assignee_avatar': assignee.get('avatar_url', ''),
+        }
     except (urllib.error.URLError, KeyError, ValueError, json.JSONDecodeError):
-        return {'head_sha': '', 'drift': -1, 'merged': False}
+        return {
+            'head_sha': '',
+            'drift': -1,
+            'merged': False,
+            'title': '',
+            'author': '',
+            'author_avatar': '',
+            'assignee': '',
+            'assignee_avatar': '',
+        }
 
 
 def _parse_pr_number(value: str) -> int:
     value = value.strip()
+    if '/issues/' in value:
+        raise ValueError(f"Not a PR URL (looks like an issue): {value!r}")
     if m := re.search(r'/pull/(\d+)', value):
         return int(m.group(1))
     return int(value.lstrip('#'))
@@ -329,7 +530,8 @@ def _trigger_rebuild() -> bool:
     token = getattr(config, 'jenkins_token', None)
     if not token:
         return False
-    prs = _load_testing_state() or []
+    state = _load_testing_state()
+    prs = state.prs if state else []
     lines = '\n'.join(f"origin pull/{p.pr}/head  # {p.title}" for p in prs if p.active)
     url = f"{_JENKINS_URL}?{urlencode({'token': token, 'GH_REPO_AND_BRANCH': lines})}"
     try:

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -1,31 +1,151 @@
+import contextlib
 import datetime
 import functools
+import json
 import re
 import socket
 import sys
+import urllib.error
+import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlencode
 
+import web
+
 from infogami import config
 from infogami.utils import delegate
 from infogami.utils.view import public, render_template
+from openlibrary.accounts import get_current_user
 from openlibrary.core import stats
 from openlibrary.utils import get_software_version
 
 status_info: dict[str, Any] = {}
 feature_flagso: dict[str, Any] = {}
 
+TESTING_STATE_FILE = Path('./_testing-prs.json')
+_GITHUB_API_BASE = "https://api.github.com/repos/internetarchive/openlibrary"
+_JENKINS_URL = "https://jenkins.openlibrary.org/job/testing-deploy/buildWithParameters"
+
 
 class status(delegate.page):
     def GET(self):
+        testing_prs = _load_testing_state()  # None if state file doesn't exist
+        is_maintainer_user = _is_maintainer()
+        drift_info = {}
+        if testing_prs:
+            # NOTE: makes 1-2 GitHub API calls per PR; acceptable for small testing sets
+            drift_info = {p.pr: _get_pr_drift(p) for p in testing_prs}
+        show_testing = testing_prs is not None or is_maintainer_user
         return render_template(
             "status",
             status_info,
             feature_flags,
             dev_merged_status=get_dev_merged_status(),
+            testing_prs=testing_prs or [],
+            drift_info=drift_info,
+            is_maintainer=is_maintainer_user,
+            show_testing=show_testing,
         )
+
+
+class status_add(delegate.page):
+    path = '/status/add'
+
+    def POST(self):
+        if not _is_maintainer():
+            raise web.unauthorized()
+        i = web.input(pr='')
+        raw = re.split(r'[\s,]+', i.pr.strip())
+        pr_numbers = []
+        for val in raw:
+            if val:
+                with contextlib.suppress(ValueError, AttributeError):
+                    pr_numbers.append(_parse_pr_number(val))
+        if not pr_numbers:
+            raise web.badrequest()
+        prs = _load_testing_state() or []
+        existing = {p.pr for p in prs}
+        user = get_current_user()
+        for pr_number in pr_numbers:
+            if pr_number not in existing:
+                info = _get_pr_info(pr_number)
+                prs.append(
+                    TestingPR(
+                        pr=pr_number,
+                        commit=info['head_sha'],
+                        active=True,
+                        title=info['title'],
+                        added_at=datetime.datetime.now(datetime.UTC).isoformat(),
+                        added_by=user.key.split('/')[-1] if user else '',
+                    )
+                )
+                existing.add(pr_number)
+        _save_testing_state(prs)
+        _trigger_rebuild()
+        raise web.seeother('/status')
+
+
+class status_remove(delegate.page):
+    path = '/status/remove'
+
+    def POST(self):
+        if not _is_maintainer():
+            raise web.unauthorized()
+        i = web.input(prs=[])
+        to_remove = {int(p) for p in i.prs}
+        _save_testing_state(
+            [p for p in (_load_testing_state() or []) if p.pr not in to_remove]
+        )
+        _trigger_rebuild()
+        raise web.seeother('/status')
+
+
+class status_toggle(delegate.page):
+    path = '/status/toggle'
+
+    def POST(self):
+        if not _is_maintainer():
+            raise web.unauthorized()
+        i = web.input(prs=[])
+        to_toggle = {int(p) for p in i.prs}
+        prs = _load_testing_state() or []
+        for p in prs:
+            if p.pr in to_toggle:
+                p.active = not p.active
+        _save_testing_state(prs)
+        _trigger_rebuild()
+        raise web.seeother('/status')
+
+
+class status_pull_latest(delegate.page):
+    path = '/status/pull-latest'
+
+    def POST(self):
+        if not _is_maintainer():
+            raise web.unauthorized()
+        i = web.input(prs=[])
+        to_update = {int(p) for p in i.prs}
+        prs = _load_testing_state() or []
+        for p in prs:
+            if p.pr in to_update:
+                info = _get_pr_info(p.pr)
+                if info['head_sha']:
+                    p.commit = info['head_sha']
+        _save_testing_state(prs)
+        _trigger_rebuild()
+        raise web.seeother('/status')
+
+
+class status_rebuild(delegate.page):
+    path = '/status/rebuild'
+
+    def POST(self):
+        if not _is_maintainer():
+            raise web.unauthorized()
+        _trigger_rebuild()
+        raise web.seeother('/status')
 
 
 @functools.cache
@@ -97,6 +217,126 @@ class PRStatus:
     def from_output(output: str) -> 'PRStatus':
         lines = output.strip().split('\n')
         return PRStatus(pull_line=lines[0], status=lines[-1], body='\n'.join(lines[1:]))
+
+
+@dataclass
+class TestingPR:
+    pr: int
+    commit: str  # pinned commit SHA (full)
+    active: bool
+    title: str
+    added_at: str  # ISO timestamp
+    added_by: str  # OL username
+
+    @property
+    def short_commit(self) -> str:
+        return self.commit[:7]
+
+    @property
+    def added_date(self) -> str:
+        return self.added_at[:10] if self.added_at else ''
+
+    def to_dict(self) -> dict:
+        return {
+            'pr': self.pr,
+            'commit': self.commit,
+            'active': self.active,
+            'title': self.title,
+            'added_at': self.added_at,
+            'added_by': self.added_by,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> 'TestingPR':
+        return cls(
+            pr=d['pr'],
+            commit=d['commit'],
+            active=d.get('active', True),
+            title=d.get('title', f"PR #{d['pr']}"),
+            added_at=d.get('added_at', ''),
+            added_by=d.get('added_by', ''),
+        )
+
+
+def _load_testing_state() -> 'list[TestingPR] | None':
+    """Returns list of TestingPRs if state file exists, None otherwise."""
+    if TESTING_STATE_FILE.exists():
+        return [
+            TestingPR.from_dict(d) for d in json.loads(TESTING_STATE_FILE.read_text())
+        ]
+    return None
+
+
+def _save_testing_state(prs: list[TestingPR]) -> None:
+    TESTING_STATE_FILE.write_text(json.dumps([p.to_dict() for p in prs], indent=2))
+    get_dev_merged_status.cache_clear()
+
+
+def _is_maintainer() -> bool:
+    user = get_current_user()
+    return bool(
+        user and user.is_member_of_any(['/usergroup/maintainers', '/usergroup/admin'])
+    )
+
+
+def _github_get(path: str) -> dict:
+    url = f"{_GITHUB_API_BASE}/{path}"
+    req = urllib.request.Request(url, headers={'Accept': 'application/vnd.github+json'})
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        return json.loads(resp.read())
+
+
+def _get_pr_info(pr_number: int) -> dict:
+    """Fetch title and current HEAD SHA for a PR from GitHub."""
+    try:
+        pr = _github_get(f"pulls/{pr_number}")
+        return {
+            'title': pr.get('title', f'PR #{pr_number}'),
+            'head_sha': pr['head']['sha'],
+        }
+    except (urllib.error.URLError, KeyError, ValueError, json.JSONDecodeError):
+        return {'title': f'PR #{pr_number}', 'head_sha': ''}
+
+
+def _get_pr_drift(pr: TestingPR) -> dict:
+    """Fetch live drift info for a PR in the testing state."""
+    try:
+        gh = _github_get(f"pulls/{pr.pr}")
+        head_sha = gh['head']['sha']
+        merged = gh.get('merged') or gh.get('state') == 'closed'
+        if head_sha.startswith(pr.commit) or pr.commit.startswith(head_sha[:7]):
+            drift = 0
+        else:
+            try:
+                cmp = _github_get(f"compare/{pr.short_commit}...{head_sha[:7]}")
+                drift = cmp.get('ahead_by', -1)
+            except (urllib.error.URLError, ValueError, json.JSONDecodeError):
+                drift = -1
+        return {'head_sha': head_sha[:7], 'drift': drift, 'merged': merged}
+    except (urllib.error.URLError, KeyError, ValueError, json.JSONDecodeError):
+        return {'head_sha': '', 'drift': -1, 'merged': False}
+
+
+def _parse_pr_number(value: str) -> int:
+    value = value.strip()
+    if m := re.search(r'/pull/(\d+)', value):
+        return int(m.group(1))
+    return int(value.lstrip('#'))
+
+
+def _trigger_rebuild() -> bool:
+    """Call Jenkins to trigger a rebuild. No-op if jenkins_token is not configured."""
+    token = getattr(config, 'jenkins_token', None)
+    if not token:
+        return False
+    prs = _load_testing_state() or []
+    lines = '\n'.join(f"origin pull/{p.pr}/head  # {p.title}" for p in prs if p.active)
+    url = f"{_JENKINS_URL}?{urlencode({'token': token, 'GH_REPO_AND_BRANCH': lines})}"
+    try:
+        urllib.request.urlopen(url, timeout=10)
+        return True
+    except (urllib.error.URLError, ValueError):
+        return False
 
 
 @public

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -39,7 +39,7 @@ class status(delegate.page):
         drift_info = {}
         if testing_state:
             drift_info, _ = _get_drift_info(testing_state)
-        show_testing = testing_state is not None or is_maintainer_user
+        show_testing = testing_state is not None and is_maintainer_user
         last_deploy = testing_state.last_deploy_at if testing_state else ''
         has_pending = bool(testing_state) and any(
             p.pull_latest_sha

--- a/openlibrary/templates/status.html
+++ b/openlibrary/templates/status.html
@@ -1,4 +1,4 @@
-$def with (status = {}, flags = {}, dev_merged_status=None, testing_prs=None, drift_info=None, is_maintainer=False, show_testing=False)
+$def with (status = {}, flags = {}, dev_merged_status=None, testing_state=None, drift_info=None, is_maintainer=False, show_testing=False, deploy_triggered=False, drift_refreshed=False, jenkins_job_url='', has_pending=False)
 $# Template entry point for /status page
 $var title: $_("Open Library server status")
 
@@ -26,8 +26,20 @@ $var title: $_("Open Library server status")
   .drift-high { background: #fff1f0; }
   .row-merged td { text-decoration: line-through; color: #999; }
   .row-inactive { opacity: 0.6; }
+  .row-new td { background: #e6f0ff; }
+  .row-pending-enable td { background: #f0fff4; }
+  .row-pending-disable td { background: #fff0f0; }
   .testing-actions { margin-top: 0.5em; }
   .testing-actions button { margin-right: 4px; }
+  .testing-actions button:disabled,
+  .testing-standalone button:disabled { opacity: 0.6; cursor: not-allowed; }
+  .deploy-banner {
+    background: #e6ffe6;
+    border: 1px solid #5a5;
+    padding: 8px 12px;
+    margin-bottom: 1em;
+    border-radius: 4px;
+  }
 </style>
 
 <div id="contentHead">
@@ -39,13 +51,25 @@ $var title: $_("Open Library server status")
   $if show_testing:
     <h2>$_("Testing Environment")</h2>
 
+    $if deploy_triggered:
+      <div class="deploy-banner">
+        $_("Deploy triggered!")
+        $if jenkins_job_url:
+          &mdash; <a href="$jenkins_job_url" target="_blank" rel="noopener noreferrer">$_("View Jenkins progress")</a>
+      </div>
+    $if drift_refreshed:
+      <div class="deploy-banner" style="background:#e6f0ff; border-color:#55a;">
+        $_("GitHub status refreshed.")
+      </div>
+
     $if is_maintainer:
       <form method="POST" action="/status/add" style="margin-bottom: 1em;">
         <input type="text" name="pr" placeholder="$_('PR numbers or URLs, space/comma separated')" size="50">
-        <button type="submit">$_("Add PR")</button>
+        <button type="submit">$_("Add PR(s)")</button>
       </form>
 
-    $if testing_prs:
+    $if testing_state and testing_state.prs:
+      $ last_deploy_at = testing_state.last_deploy_at
       <form method="POST" id="testing-form">
         <table class="testing-table">
           <thead>
@@ -54,37 +78,66 @@ $var title: $_("Open Library server status")
                 <th><input type="checkbox" id="select-all" onclick="document.querySelectorAll('[name=prs]').forEach(function(cb){ cb.checked = this.checked; }.bind(this))"></th>
               <th>$_("PR")</th>
               <th>$_("Title")</th>
+              <th>$_("Author")</th>
+              <th>$_("Assignee")</th>
               <th>$_("Pinned Commit")</th>
               <th>$_("Branch HEAD")</th>
               <th>$_("Drift")</th>
-              <th>$_("Active")</th>
+              <th>$_("Enabled")</th>
               <th>$_("Added")</th>
             </tr>
           </thead>
           <tbody>
-            $for pr in testing_prs:
+            $for pr in testing_state.prs:
               $ d = (drift_info or {}).get(pr.pr, {})
               $ drift = d.get('drift', -1)
               $ head_sha = d.get('head_sha', '')
               $ merged = d.get('merged', False)
-              $ row_class = ('row-merged ' if merged else '') + ('row-inactive ' if not pr.active else '') + ('drift-high' if drift > 5 else ('drift-low' if drift > 0 else ''))
+              $ is_new = bool(last_deploy_at and pr.added_at > last_deploy_at)
+              $ row_class = 'row-merged' if merged else ('row-pending-enable' if pr.pending_active is True else ('row-pending-disable' if pr.pending_active is False else ('row-new' if is_new else ('' if pr.active else 'row-inactive'))))
+              $ row_class += (' drift-high' if drift > 5 else (' drift-low' if drift > 0 else ''))
               <tr class="$row_class.strip()">
                 $if is_maintainer:
                   <td><input type="checkbox" name="prs" value="$pr.pr"></td>
                 <td><a href="https://github.com/internetarchive/openlibrary/pull/$pr.pr">#$pr.pr</a></td>
                 <td>$pr.title</td>
-                <td><a href="https://github.com/internetarchive/openlibrary/commit/$pr.commit">$pr.short_commit</a></td>
+                <td>
+                  $if pr.author_avatar:
+                    <img src="${pr.author_avatar}&s=24" width="20" height="20" style="border-radius:50%;vertical-align:middle;margin-right:4px" alt="$pr.author">
+                  $pr.author
+                </td>
+                <td>
+                  $if pr.assignee:
+                    $if pr.assignee_avatar:
+                      <img src="${pr.assignee_avatar}&s=24" width="20" height="20" style="border-radius:50%;vertical-align:middle;margin-right:4px" alt="$pr.assignee">
+                    $pr.assignee
+                  $else:
+                    &mdash;
+                </td>
+                <td>
+                  $if pr.pull_latest_sha:
+                    <a href="https://github.com/internetarchive/openlibrary/commit/$pr.commit"><s>$pr.short_commit</s></a>
+                    &rarr; <a href="https://github.com/internetarchive/openlibrary/commit/$pr.pull_latest_sha">$pr.short_pull_latest</a>
+                  $else:
+                    <a href="https://github.com/internetarchive/openlibrary/commit/$pr.commit">$pr.short_commit</a>
+                </td>
                 <td>$head_sha</td>
                 <td>
                   $if drift == 0:
-                    up to date
+                    $_("up to date")
                   $elif drift < 0:
-                    unknown
+                    $_("unknown")
+                  $elif drift == 1:
+                    $_("1 commit behind")
                   $else:
-                    $drift commit$("s" if drift != 1 else "") behind
+                    $(_("%(count)s commits behind") % {"count": drift})
                 </td>
                 <td>
-                  $if pr.active:
+                  $if pr.pending_active is True:
+                    &#x23F8; &rarr; &#x2705;
+                  $elif pr.pending_active is False:
+                    &#x2705; &rarr; &#x23F8;
+                  $elif pr.active:
                     &#x2705;
                   $else:
                     &#x23F8;
@@ -96,22 +149,42 @@ $var title: $_("Open Library server status")
 
         $if is_maintainer:
           <div class="testing-actions">
-            <button formaction="/status/pull-latest" type="submit">$_("Pull to Latest")</button>
-            <button formaction="/status/toggle" type="submit">$_("Toggle Active")</button>
+            <button formaction="/status/pull-latest" type="submit">$_("Update")</button>
+            <button formaction="/status/enable" type="submit">$_("Enable")</button>
+            <button formaction="/status/disable" type="submit">$_("Disable")</button>
             <button formaction="/status/remove" type="submit">$_("Remove")</button>
+            $_("Selected PRs") &nbsp;&nbsp; $_("or") &nbsp;
+            <button formaction="/status/refresh" type="submit">$_("Refresh")</button>
           </div>
       </form>
 
-      $if is_maintainer:
-        <form method="POST" action="/status/rebuild" style="margin-top: 0.5em;">
-          <button type="submit">$_("Force Rebuild")</button>
-        </form>
+      $if is_maintainer and has_pending:
+        <div class="testing-standalone" style="margin-top: 0.75em;">
+          <form method="POST" action="/status/deploy" style="display:inline;">
+            <button type="submit" class="cta-btn cta-btn--primary">$_("Deploy")</button>
+          </form>
+        </div>
 
     $else:
       <p>$_("No PRs in testing set.")</p>
 
+    <script>
+      (function () {
+        function disableButtons(form) {
+          form.querySelectorAll('button[type="submit"]').forEach(function (btn) {
+            btn.disabled = true;
+            btn.dataset.orig = btn.textContent;
+            btn.textContent = btn.dataset.orig + '\u2026';
+          });
+        }
+        document.querySelectorAll('#testing-form, .testing-standalone form').forEach(function (form) {
+          form.addEventListener('submit', function () { disableButtons(form); });
+        });
+      })();
+    </script>
+
   $if dev_merged_status:
-      <h2> $_("Staged") </h2>
+      <h2> $_("Last Build Result") </h2>
       <pre>$dev_merged_status.git_status</pre>
 
       <br>

--- a/openlibrary/templates/status.html
+++ b/openlibrary/templates/status.html
@@ -1,4 +1,4 @@
-$def with (status = {}, flags = {}, dev_merged_status=None)
+$def with (status = {}, flags = {}, dev_merged_status=None, testing_prs=None, drift_info=None, is_maintainer=False, show_testing=False)
 $# Template entry point for /status page
 $var title: $_("Open Library server status")
 
@@ -20,6 +20,14 @@ $var title: $_("Open Library server status")
   #show_changed:checked ~ table tr.tr-body {
     display: table-row;
   }
+
+  .testing-table td, .testing-table th { padding: 6px 8px; }
+  .drift-low { background: #fffbe6; }
+  .drift-high { background: #fff1f0; }
+  .row-merged td { text-decoration: line-through; color: #999; }
+  .row-inactive { opacity: 0.6; }
+  .testing-actions { margin-top: 0.5em; }
+  .testing-actions button { margin-right: 4px; }
 </style>
 
 <div id="contentHead">
@@ -27,6 +35,81 @@ $var title: $_("Open Library server status")
 </div>
 
 <div id="contentBody">
+
+  $if show_testing:
+    <h2>$_("Testing Environment")</h2>
+
+    $if is_maintainer:
+      <form method="POST" action="/status/add" style="margin-bottom: 1em;">
+        <input type="text" name="pr" placeholder="$_('PR numbers or URLs, space/comma separated')" size="50">
+        <button type="submit">$_("Add PR")</button>
+      </form>
+
+    $if testing_prs:
+      <form method="POST" id="testing-form">
+        <table class="testing-table">
+          <thead>
+            <tr>
+              $if is_maintainer:
+                <th><input type="checkbox" id="select-all" onclick="document.querySelectorAll('[name=prs]').forEach(function(cb){ cb.checked = this.checked; }.bind(this))"></th>
+              <th>$_("PR")</th>
+              <th>$_("Title")</th>
+              <th>$_("Pinned Commit")</th>
+              <th>$_("Branch HEAD")</th>
+              <th>$_("Drift")</th>
+              <th>$_("Active")</th>
+              <th>$_("Added")</th>
+            </tr>
+          </thead>
+          <tbody>
+            $for pr in testing_prs:
+              $ d = (drift_info or {}).get(pr.pr, {})
+              $ drift = d.get('drift', -1)
+              $ head_sha = d.get('head_sha', '')
+              $ merged = d.get('merged', False)
+              $ row_class = ('row-merged ' if merged else '') + ('row-inactive ' if not pr.active else '') + ('drift-high' if drift > 5 else ('drift-low' if drift > 0 else ''))
+              <tr class="$row_class.strip()">
+                $if is_maintainer:
+                  <td><input type="checkbox" name="prs" value="$pr.pr"></td>
+                <td><a href="https://github.com/internetarchive/openlibrary/pull/$pr.pr">#$pr.pr</a></td>
+                <td>$pr.title</td>
+                <td><a href="https://github.com/internetarchive/openlibrary/commit/$pr.commit">$pr.short_commit</a></td>
+                <td>$head_sha</td>
+                <td>
+                  $if drift == 0:
+                    up to date
+                  $elif drift < 0:
+                    unknown
+                  $else:
+                    $drift commit$("s" if drift != 1 else "") behind
+                </td>
+                <td>
+                  $if pr.active:
+                    &#x2705;
+                  $else:
+                    &#x23F8;
+                </td>
+                <td title="$pr.added_by">$pr.added_date</td>
+              </tr>
+          </tbody>
+        </table>
+
+        $if is_maintainer:
+          <div class="testing-actions">
+            <button formaction="/status/pull-latest" type="submit">$_("Pull to Latest")</button>
+            <button formaction="/status/toggle" type="submit">$_("Toggle Active")</button>
+            <button formaction="/status/remove" type="submit">$_("Remove")</button>
+          </div>
+      </form>
+
+      $if is_maintainer:
+        <form method="POST" action="/status/rebuild" style="margin-top: 0.5em;">
+          <button type="submit">$_("Force Rebuild")</button>
+        </form>
+
+    $else:
+      <p>$_("No PRs in testing set.")</p>
+
   $if dev_merged_status:
       <h2> $_("Staged") </h2>
       <pre>$dev_merged_status.git_status</pre>

--- a/scripts/make-integration-branch.sh
+++ b/scripts/make-integration-branch.sh
@@ -1,41 +1,86 @@
 #!/bin/bash
 
-# Util script to merge multiple branches as listed in a file into a new branch
-# Used for dev.openlibrary.org "deploys"
-# See make-integration-branch-sample.txt for a sample of the file format.
+# Util script to merge multiple branches into a new integration branch.
+# Used for dev.openlibrary.org "deploys".
+#
+# Usage:
+#   ./make-integration-branch.sh <new-branch-name>
+#     Build from _testing-prs.json (pinned commits).
+#
+#   ./make-integration-branch.sh <branches-file> <new-branch-name>
+#     Add/update PRs from branches-file into _testing-prs.json (pinned to
+#     their current fetched SHA), then build from the full state file.
+#     This is how the bookmarklet path works: submitted PRs are added to
+#     the list and pinned to commit, then the full list is built.
+#     If no state file exists yet, one is created from the branches-file.
 
-BRANCHES_FILE=$1
-NEW_BRANCH=$2
-ONLY_STARRED=$(grep '^\*\*' $BRANCHES_FILE | sed 's/\*\*//g' )
+TESTING_STATE_FILE="_testing-prs.json"
+NEW_BRANCH=${2:-$1}
 
-echo $ALL_BRANCHES
+# --- Phase 1: if a branches file was provided, add/update those PRs in the state ---
+if [[ -n "$2" ]]; then
+    BRANCHES_FILE=$1
+    while IFS= read -r line; do
+        # Match lines like "origin pull/123/head  # PR title"
+        if [[ $line =~ ^origin\ pull/([0-9]+)/head ]]; then
+            pr_num="${BASH_REMATCH[1]}"
+            # Extract title after "# " if present, else fall back
+            title="${line#*# }"
+            [[ "$title" == "$line" ]] && title="PR #$pr_num"
+            git fetch origin "pull/$pr_num/head"
+            sha=$(git rev-parse FETCH_HEAD)
+            python3 - "$pr_num" "$sha" "$title" <<'PYEOF'
+import json, sys, datetime
+pr_num, sha, title = int(sys.argv[1]), sys.argv[2], sys.argv[3]
+state_file = '_testing-prs.json'
+try:
+    with open(state_file) as f:
+        prs = json.load(f)
+except FileNotFoundError:
+    prs = []
+existing = next((p for p in prs if p['pr'] == pr_num), None)
+if existing:
+    existing['commit'] = sha  # bookmarklet = pull to latest
+else:
+    prs.append({
+        'pr': pr_num, 'commit': sha, 'active': True, 'title': title,
+        'added_at': datetime.datetime.utcnow().isoformat(), 'added_by': 'bookmarklet',
+    })
+with open(state_file, 'w') as f:
+    json.dump(prs, f, indent=2)
+PYEOF
+        fi
+    done < "$BRANCHES_FILE"
+fi
+
+# --- Phase 2: build ---
 git checkout master
 git pull origin master
-git branch -D $NEW_BRANCH
-git checkout -b $NEW_BRANCH
+git branch -D "$NEW_BRANCH" 2>/dev/null || true
+git checkout -b "$NEW_BRANCH"
 
-while read line; do
-    branch=${line/\*\*/}
-    branch=$(echo $branch | grep -o -E '^[^#]+')
-    if [[ -z $line || $line == "#"* ]] ; then
-        :
-    elif [[ ! -z $ONLY_STARRED && $line != "**"* ]] ; then
-        :
-    elif [[ $branch == "https://github.com/internetarchive/openlibrary/pull/"*".patch" ]] ; then
-        echo -e "---\n$line"
-        curl -L $branch | git am -3
-    elif [[ $branch == "https://"* || $branch == "origin pull/"* ]] ; then
-        echo -e "---\n$line"
-        git pull $branch
-        # If the merge didn't succeed automatically, abort it
-        [[ $(git ls-files -u) ]] && git merge --abort
-    else
-        echo -e "---\n$line"
-        git merge $branch
-        # If the merge didn't succeed automatically, abort it
-        [[ $(git ls-files -u) ]] && git merge --abort
-    fi
-done <"$BRANCHES_FILE"
+if [[ -f "$TESTING_STATE_FILE" ]]; then
+    # State file exists: merge pinned commits for all active PRs
+    while IFS=' ' read -r pr_num pinned_sha; do
+        echo -e "---\norigin pull/$pr_num/head  # pinned at $pinned_sha"
+        git fetch origin "pull/$pr_num/head"
+        git merge "$pinned_sha"
+        if [[ $(git ls-files -u) ]]; then
+            git merge --abort
+            echo "Merge conflict for PR #$pr_num (pinned $pinned_sha) — skipping"
+        fi
+    done < <(python3 -c "
+import json
+with open('$TESTING_STATE_FILE') as f:
+    prs = json.load(f)
+for p in prs:
+    if p.get('active', True):
+        print(p['pr'], p['commit'])
+")
+else
+    # No state file and no branches file: nothing to build
+    echo "Nothing to build: no state file and no branches file provided."
+fi
 
 echo "---"
 echo "Complete; dev-merged created (SHA: $(git rev-parse --short HEAD))"

--- a/scripts/make-integration-branch.sh
+++ b/scripts/make-integration-branch.sh
@@ -35,19 +35,24 @@ pr_num, sha, title = int(sys.argv[1]), sys.argv[2], sys.argv[3]
 state_file = '_testing-prs.json'
 try:
     with open(state_file) as f:
-        prs = json.load(f)
+        data = json.load(f)
 except FileNotFoundError:
-    prs = []
+    data = {'last_deploy_at': '', 'prs': []}
+# Handle old array format
+if isinstance(data, list):
+    data = {'last_deploy_at': '', 'prs': data}
+prs = data['prs']
 existing = next((p for p in prs if p['pr'] == pr_num), None)
 if existing:
     existing['commit'] = sha  # bookmarklet = pull to latest
+    existing.pop('pull_latest_sha', None)
 else:
     prs.append({
         'pr': pr_num, 'commit': sha, 'active': True, 'title': title,
-        'added_at': datetime.datetime.utcnow().isoformat(), 'added_by': 'bookmarklet',
+        'added_at': datetime.datetime.now(datetime.UTC).isoformat(), 'added_by': 'bookmarklet',
     })
 with open(state_file, 'w') as f:
-    json.dump(prs, f, indent=2)
+    json.dump(data, f, indent=2)
 PYEOF
         fi
     done < "$BRANCHES_FILE"
@@ -64,6 +69,14 @@ if [[ -f "$TESTING_STATE_FILE" ]]; then
     while IFS=' ' read -r pr_num pinned_sha; do
         echo -e "---\norigin pull/$pr_num/head  # pinned at $pinned_sha"
         git fetch origin "pull/$pr_num/head"
+        # Ensure the pinned SHA is locally available
+        if ! git cat-file -e "$pinned_sha^{commit}" 2>/dev/null; then
+            git fetch origin "$pinned_sha" 2>/dev/null || true
+        fi
+        if ! git cat-file -e "$pinned_sha^{commit}" 2>/dev/null; then
+            echo "Pinned commit $pinned_sha for PR #$pr_num unavailable — skipping"
+            continue
+        fi
         git merge "$pinned_sha"
         if [[ $(git ls-files -u) ]]; then
             git merge --abort
@@ -72,7 +85,8 @@ if [[ -f "$TESTING_STATE_FILE" ]]; then
     done < <(python3 -c "
 import json
 with open('$TESTING_STATE_FILE') as f:
-    prs = json.load(f)
+    data = json.load(f)
+prs = data['prs'] if isinstance(data, dict) else data
 for p in prs:
     if p.get('active', True):
         print(p['pr'], p['commit'])
@@ -83,4 +97,4 @@ else
 fi
 
 echo "---"
-echo "Complete; dev-merged created (SHA: $(git rev-parse --short HEAD))"
+echo "Complete; $NEW_BRANCH created (SHA: $(git rev-parse --short HEAD))"


### PR DESCRIPTION
## Summary

Closes #11506

Turns `/status` into an interactive testing environment management dashboard, available to members of `/usergroup/maintainers` (or `/usergroup/admin`). Non-maintainers and logged-out visitors see a read-only view.

- **Commit pinning**: PRs are tracked by pinned commit SHA (stored in `_testing-prs.json`), not branch HEAD. "Pull to Latest" is an explicit action.
- **Dashboard actions**: Add PR, Remove, Toggle Active, Pull to Latest, Force Rebuild — all POST endpoints gated behind maintainer usergroup membership (401 for others).
- **Live drift display**: GitHub API (no token needed — public repo) fetches current branch HEAD and commit drift on page load.
- **Jenkins integration**: `_trigger_rebuild()` calls Jenkins via `jenkins_token` config key if present; no-op locally.
- **`make-integration-branch.sh`**: New JSON mode reads active PRs from `_testing-prs.json` and merges pinned SHAs instead of branch HEADs. Legacy `BRANCHES_FILE` mode preserved as fallback.

## What's not included (follow-up)

- Wiring the rebuild button to Jenkins end-to-end (requires `jenkins_token` in olsystem config on testing server)
- Bridging / deprecating the bookmarklet
- Auto-cleanup notification of merged PRs (flagged visually; auto-remove is a follow-up)

## Test plan

- [x] Log in as a member of `/usergroup/maintainers` — Testing Environment section appears with Add PR form
- [x] Log out / log in as non-maintainer — section hidden or read-only (no action buttons)
- [x] Add a PR by number — appears in table with pinned commit SHA
- [x] Add a PR by GitHub URL — parses correctly
- [x] Toggle active on a PR — active status updates
- [x] Pull to Latest — pinned commit updates to current branch HEAD
- [x] Remove a PR — removed from table
- [x] Confirm `_testing-prs.json` written to disk after each action
- [x] Confirm unauthenticated POST requests return 401
- [x] Confirm `/status` returns 200 on production (no testing section for non-maintainers without state file)