### PR TITLE
add stale PR bot

### DIFF
--- a/.github/workflows/pm_stale_pr_messenger.yml
+++ b/.github/workflows/pm_stale_pr_messenger.yml
@@ -19,8 +19,9 @@ jobs:
           stale-pr-message: >
             Hello! This pull request has been marked as stale because it has been
             waiting for submitter input for 7 days. If you're still working on
-            this, please add a comment to keep it open. Otherwise, it will be
-            automatically closed in 7 days.
+            this, please add a comment to keep it open. Otherwise, a maintainer
+            will have to determine how to proceed including reassigning or opening
+            the issue for others to work on after communicating with you.
 
             For guidance on contributing, please see our
             [Contributing guide](https://docs.openlibrary.org/developers/CONTRIBUTING.html).

--- a/.github/workflows/pm_stale_pr_messenger.yml
+++ b/.github/workflows/pm_stale_pr_messenger.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           only-pr-labels: "Needs: Submitter Input"
           days-before-issue-stale: -1 # disable issue stale
-          days-before-pr-close: 7
+          days-before-pr-close: -1 # For now, no closing just nudging
           days-before-pr-stale: 7
           stale-pr-message: >
             Hello! This pull request has been marked as stale because it has been

--- a/.github/workflows/pm_stale_pr_messenger.yml
+++ b/.github/workflows/pm_stale_pr_messenger.yml
@@ -1,0 +1,34 @@
+name: "Stale submitter input PRs"
+on:
+  schedule:
+    - cron: "12 2 * * *"
+
+jobs:
+  stale-prs:
+    if: github.repository_owner == 'internetarchive'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v10
+        with:
+          only-pr-labels: "Needs: Submitter Input"
+          days-before-issue-stale: -1 # disable issue stale
+          days-before-pr-close: 14
+          days-before-pr-stale: 7
+          stale-pr-message: >
+            Hello! This pull request has been marked as stale because it has been
+            waiting for submitter input for 7 days. If you're still working on
+            this, please add a comment to keep it open. Otherwise, it will be
+            automatically closed in 7 days.
+
+            For guidance on contributing, please see our
+            [Contributing guide](https://docs.openlibrary.org/developers/CONTRIBUTING.html).
+          close-pr-message: >
+            This pull request has been automatically closed after being marked as
+            stale for 14 days with no response. If you'd like to revisit this
+            work, feel free to open a new pull request. Thank you!
+
+            For guidance on contributing, please see our
+            [Contributing guide](https://docs.openlibrary.org/developers/CONTRIBUTING.html).
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pm_stale_pr_messenger.yml
+++ b/.github/workflows/pm_stale_pr_messenger.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           only-pr-labels: "Needs: Submitter Input"
           days-before-issue-stale: -1 # disable issue stale
-          days-before-pr-close: 14
+          days-before-pr-close: 7
           days-before-pr-stale: 7
           stale-pr-message: >
             Hello! This pull request has been marked as stale because it has been
@@ -26,7 +26,7 @@ jobs:
             [Contributing guide](https://docs.openlibrary.org/developers/CONTRIBUTING.html).
           close-pr-message: >
             This pull request has been automatically closed after being marked as
-            stale for 14 days with no response. If you'd like to revisit this
+            stale for 7 days with no response. If you'd like to revisit this
             work, feel free to open a new pull request. Thank you!
 
             For guidance on contributing, please see our


### PR DESCRIPTION
<!-- What issue does this PR close? -->
On a call today with @lokesh @mekarpeles and @cdrini we discussed adding a bot to help nudge PRs that are waiting on submitter input.

The goal here is twofold:
1. Reduce the burden on maintainers
2. Improve the experience of contributing to Open Library's codebase

How this does this:
1. Maintainers won't have the cogitative overhead of looking through their many assigned issues and having to follow up with folks who didn't respond to feedback yet. Instead, when they label an issue as `Needs: Submitter Input` they know the process will be taken care of for them to nudge the contributor.
2. If you're a contributor this means that if staff gives you feedback and you miss it or forget it you'll have two nice automated reminders at reasonable intervals. First, a warning after one week. All you have to do is comment with your intention to work on it or push up a change. 

Another benefit of this is when PRs are automatically closed with no activity is that this should make it easier for folks to find issues to work on that have been stale.

In practice this is a rather minor and incremental change to our workflow.

At present only 4 PRs would get a message encouraging them to follow up:
- #12177 - Has feedback to be addressed as well
- #11562 - Has feedback that should be addressed 
- #10718 - which does have changes requested by the reviewer but ALSO a question by the submitter. So this case, it would hopefully encourage response from both parties to follow up
- #9415 - I already sent a reminder here earlier this year

It may seem like if it effects so few PRs then why does it matter?
1. There have been nearly [100 PRs](https://github.com/internetarchive/openlibrary/pulls?q=is%3Apr+label%3A%22Needs%3A+Submitter+Input%22+is%3Aclosed++-is%3Amerged) that have been closed (not merged) while having this label.
2. This is somewhat of a new workflow that can be expanded upon. If maintainers know this will happen it makes them more likely to use the label. In the future we could also automatically apply the submitter input label when maintainers request changes on a PR.


I want to emphasize, that this is an experiment to help us deal with many new contributors and an enormous backlog of PRs to review. It may seem a little impersonal to have this added but in the big picture it should give make more time having those important connections and conversations instead of just asking someone to please follow up. As such, we can always revert this if it turns out to be too noisy or problematic.


### Prior Art

This complements our existing [pm_stale_ticket_labeler.yml](https://github.com/internetarchive/openlibrary/blob/master/.github/workflows/pm_stale_ticket_labeler.yml) workflow, which silently labels assigned issues as `Needs: Review Assignee` after 14 days of inactivity (but never closes anything). This new workflow takes the next step by actually following up with PR authors and closing when there's no response.

Again, I'll emphasize there's a lot of possibilities here like maybe in the future we should unassign them from the issue when we close the PR. However, we can keep it as baby steps.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
