### PR TITLE
Re-enable http2

### DIFF
--- a/docker/covers_nginx.conf
+++ b/docker/covers_nginx.conf
@@ -32,6 +32,7 @@ upstream covers_backend {
 server {
       listen 80;
       listen 443;
+      http2 on;
       server_name  covers.openlibrary.org;
 
       root /openlibrary;

--- a/docker/web_nginx.conf
+++ b/docker/web_nginx.conf
@@ -71,6 +71,7 @@ server {
 server {
     listen 80;
     listen 443;
+    http2 on;
     server_name  openlibrary.org;
 
     # Set the referrer policy so browsers send referrers to our own servers


### PR DESCRIPTION
Addendum to #12076 . It seems like the http2 directive doesn't "inherit" how the listen directive did? Or something like that.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Patch deploy on www and covers, and I see HTTP/2 requests streaming through the logs again.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
