### PR TITLE
Refactor AffiliateLinks to use async partials with parallelized fetching

### DIFF
--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -752,10 +752,10 @@ def _parse_betterworldbooks_response(
 
 @public
 def get_affiliate_stores(title: str, opts: dict) -> dict[str, list[dict]]:
-    """Helper to build all the store data (links, names, and prices).
+    """A central place to build store data (links, names, and prices).
     
-    Both the AffiliateLinks macro and the async partial use this so
-    they stay perfectly in sync.
+    We use this in both the standard AffiliateLinks macro and the new
+    async partial so they stay perfectly in sync.
     """
     isbn = opts.get('isbn', '')
     asin = opts.get('asin', '')
@@ -817,12 +817,10 @@ def betterworldbooks_fmt(
     price: str | None = None,
     market_price: list[str] | None = None,
 ) -> BetterWorldBooksMetadata:
-    """Standardizes how we return BWB price info.
+    """Standardizes how we return price info from Better World Books.
     
-    Arguments:
-    - isbn: the book's identifier
-    - qlt: "new", "used", etc
-    - price: the decimal price string
+    We collect the raw price and quality info here to make it easier
+    to display in the UI or use for comparison.
     """
     price_fmt = f"${price} ({qlt})" if price and qlt else None
     try:

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -753,7 +753,7 @@ def _parse_betterworldbooks_response(
 @public
 def get_affiliate_stores(title: str, opts: dict) -> dict[str, list[dict]]:
     """A central place to build store data (links, names, and prices).
-    
+
     We use this in both the standard AffiliateLinks macro and the new
     async partial so they stay in sync.
     """
@@ -818,7 +818,7 @@ def betterworldbooks_fmt(
     market_price: list[str] | None = None,
 ) -> BetterWorldBooksMetadata:
     """Standardizes how we return price info from Better World Books.
-    
+
     We collect the raw price and quality info here to make it easier
     to display in the UI or use for comparison.
     """

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -6,7 +6,6 @@ import time
 from types import MappingProxyType
 from typing import Any, Literal, TypedDict
 
-import httpx
 import requests
 from dateutil import parser as isoparser
 from paapi5_python_sdk.api.default_api import DefaultApi
@@ -404,58 +403,6 @@ def search_amazon(title: str = '', author: str = '') -> dict:  # type: ignore[em
     pass
 
 
-@public
-async def get_amazon_metadata_async(
-    id_: str,
-    id_type: Literal['asin', 'isbn'] = 'isbn',
-    resources: Any = None,
-    high_priority: bool = False,
-    stage_import: bool = True,
-    client: httpx.AsyncClient | None = None,
-) -> dict | None:
-    """Async interface to Amazon LookupItem API.
-
-    :param str id_: The item id: isbn (10/13), or Amazon ASIN.
-    :param str id_type: 'isbn' or 'asin'.
-    :param bool high_priority: Priority in the import queue.
-    :param bool stage_import: stage the id_ for import if not in the cache.
-    :param client: Optional httpx.AsyncClient for connection reuse.
-    :return: A single book item's metadata, or None.
-    """
-    if not affiliate_server_url:
-        return None
-
-    if id_type == 'isbn':
-        isbn = normalize_isbn(id_)
-        if isbn is None:
-            return None
-        id_ = isbn
-        if len(id_) == 13 and id_.startswith('978'):
-            isbn = isbn_13_to_isbn_10(id_)
-            if isbn is None:
-                return None
-            id_ = isbn
-
-    try:
-        priority = "true" if high_priority else "false"
-        stage = "true" if stage_import else "false"
-        url = f'http://{affiliate_server_url}/isbn/{id_}?high_priority={priority}&stage_import={stage}'
-
-        if client:
-            r = await client.get(url, timeout=4.0)
-        else:
-            async with httpx.AsyncClient() as _client:
-                r = await _client.get(url, timeout=4.0)
-
-        r.raise_for_status()
-        return r.json().get('hit')
-    except (httpx.ConnectError, httpx.HTTPStatusError):
-        logger.exception("Affiliate Server error")
-    except Exception:
-        logger.exception(f"get_amazon_metadata_async({id_}) failed")
-    return None
-
-
 def _get_amazon_metadata(
     id_: str,
     id_type: Literal['asin', 'isbn'] = 'isbn',
@@ -657,35 +604,6 @@ class BetterWorldBooksMetadataError(TypedDict):
 
 
 @public
-async def get_betterworldbooks_metadata_async(
-    isbn: str, client: httpx.AsyncClient | None = None
-) -> BetterWorldBooksMetadata | BetterWorldBooksMetadataError | None:
-    """
-    :param str isbn: Unnormalised ISBN10 or ISBN13
-    :param client: Optional httpx.AsyncClient for connection reuse.
-    :return: Metadata for a single BWB book.
-    """
-    isbn = normalize_isbn(isbn) or isbn
-    if isbn is None:
-        return None
-
-    try:
-        url = BETTERWORLDBOOKS_API_URL + isbn
-        if client:
-            response = await client.get(url, timeout=4.0)
-        else:
-            async with httpx.AsyncClient() as _client:
-                response = await _client.get(url, timeout=4.0)
-
-        if response.status_code != 200:
-            return {'error': response.text, 'code': response.status_code}
-        return _parse_betterworldbooks_response(isbn, response.text)
-    except Exception:
-        logger.exception(f"get_betterworldbooks_metadata_async({isbn})")
-        return betterworldbooks_fmt(isbn)
-
-
-@public
 def get_betterworldbooks_metadata(
     isbn: str,
 ) -> BetterWorldBooksMetadata | BetterWorldBooksMetadataError | None:
@@ -809,6 +727,44 @@ def get_affiliate_stores(title: str, opts: dict) -> dict[str, list[dict]]:
         'primary': [store for store in [bwb, amazon] if store],
         'more': [store for store in [bookshop] if store],
     }
+
+
+@public
+def prepare_affiliate_data(title: str, opts: dict) -> dict[str, list[dict]]:
+    """Fetches store metadata synchronously and prepares store data.
+
+    This replaces the logic previously held in AffiliateLinks.html to
+    ensure better separation of concerns and avoid template network requests.
+    """
+    from openlibrary.plugins.openlibrary.code import is_bot
+
+    prices = opts.get('prices')
+    isbn = opts.get('isbn', '')
+    asin = opts.get('asin', '')
+
+    bwb_price = amazon_price = None
+
+    if not is_bot() and prices and isbn:
+        bwb_metadata = get_betterworldbooks_metadata(isbn)
+        if isinstance(bwb_metadata, dict):
+            bwb_price = bwb_metadata.get('price')
+            # Fallback to BWB's market price
+            amazon_price = bwb_metadata.get('market_price')
+
+        if not amazon_price:
+            amz_metadata = get_amazon_metadata(isbn, resources='prices')
+            if amz_metadata:
+                amazon_price = amz_metadata.get('price')
+
+    return get_affiliate_stores(
+        title,
+        {
+            'isbn': isbn,
+            'asin': asin,
+            'bwb_price': bwb_price,
+            'amazon_price': amazon_price,
+        },
+    )
 
 
 def betterworldbooks_fmt(

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -755,7 +755,7 @@ def get_affiliate_stores(title: str, opts: dict) -> dict[str, list[dict]]:
     """A central place to build store data (links, names, and prices).
     
     We use this in both the standard AffiliateLinks macro and the new
-    async partial so they stay perfectly in sync.
+    async partial so they stay in sync.
     """
     isbn = opts.get('isbn', '')
     asin = opts.get('asin', '')

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -411,7 +411,6 @@ async def get_amazon_metadata_async(
     resources: Any = None,
     high_priority: bool = False,
     stage_import: bool = True,
-    timeout: float = 4.0,
     client: httpx.AsyncClient | None = None,
 ) -> dict | None:
     """Async interface to Amazon LookupItem API.
@@ -443,10 +442,10 @@ async def get_amazon_metadata_async(
         url = f'http://{affiliate_server_url}/isbn/{id_}?high_priority={priority}&stage_import={stage}'
 
         if client:
-            r = await client.get(url, timeout=timeout)
+            r = await client.get(url, timeout=4.0)
         else:
             async with httpx.AsyncClient() as _client:
-                r = await _client.get(url, timeout=timeout)
+                r = await _client.get(url, timeout=4.0)
 
         r.raise_for_status()
         return r.json().get('hit')
@@ -659,8 +658,7 @@ class BetterWorldBooksMetadataError(TypedDict):
 
 @public
 async def get_betterworldbooks_metadata_async(
-    isbn: str,
-    client: httpx.AsyncClient | None = None,
+    isbn: str, client: httpx.AsyncClient | None = None
 ) -> BetterWorldBooksMetadata | BetterWorldBooksMetadataError | None:
     """
     :param str isbn: Unnormalised ISBN10 or ISBN13
@@ -674,10 +672,10 @@ async def get_betterworldbooks_metadata_async(
     try:
         url = BETTERWORLDBOOKS_API_URL + isbn
         if client:
-            response = await client.get(url)
+            response = await client.get(url, timeout=4.0)
         else:
             async with httpx.AsyncClient() as _client:
-                response = await _client.get(url)
+                response = await _client.get(url, timeout=4.0)
 
         if response.status_code != 200:
             return {'error': response.text, 'code': response.status_code}

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -6,6 +6,7 @@ import time
 from types import MappingProxyType
 from typing import Any, Literal, TypedDict
 
+import httpx
 import requests
 from dateutil import parser as isoparser
 from paapi5_python_sdk.api.default_api import DefaultApi
@@ -27,6 +28,7 @@ from openlibrary.utils.isbn import (
     isbn_13_to_isbn_10,
     normalize_isbn,
 )
+from openlibrary.i18n import gettext as _
 
 logger = logging.getLogger("openlibrary.vendors")
 
@@ -34,9 +36,7 @@ BETTERWORLDBOOKS_API_URL = (
     'https://products.betterworldbooks.com/service.aspx?IncludeAmazon=True&ItemId='
 )
 affiliate_server_url = None
-BWB_AFFILIATE_LINK = 'http://www.anrdoezrs.net/links/{}/type/dlg/http://www.betterworldbooks.com/-id-%s'.format(
-    h.affiliate_id('betterworldbooks')
-)
+BWB_AFFILIATE_LINK_TEMPLATE = 'http://www.anrdoezrs.net/links/{}/type/dlg/http://www.betterworldbooks.com/-id-%s'
 AMAZON_FULL_DATE_RE = re.compile(r'\d{4}-\d\d-\d\d')
 ISBD_UNIT_PUNCT = ' : '  # ISBD cataloging title-unit separator punctuation
 
@@ -402,6 +402,59 @@ def search_amazon(title: str = '', author: str = '') -> dict:  # type: ignore[em
     pass
 
 
+@public
+async def get_amazon_metadata_async(
+    id_: str,
+    id_type: Literal['asin', 'isbn'] = 'isbn',
+    resources: Any = None,
+    high_priority: bool = False,
+    stage_import: bool = True,
+    timeout: float = 4.0,
+    client: httpx.AsyncClient | None = None,
+) -> dict | None:
+    """Async interface to Amazon LookupItem API.
+
+    :param str id_: The item id: isbn (10/13), or Amazon ASIN.
+    :param str id_type: 'isbn' or 'asin'.
+    :param bool high_priority: Priority in the import queue.
+    :param bool stage_import: stage the id_ for import if not in the cache.
+    :param client: Optional httpx.AsyncClient for connection reuse.
+    :return: A single book item's metadata, or None.
+    """
+    if not affiliate_server_url:
+        return None
+
+    if id_type == 'isbn':
+        isbn = normalize_isbn(id_)
+        if isbn is None:
+            return None
+        id_ = isbn
+        if len(id_) == 13 and id_.startswith('978'):
+            isbn = isbn_13_to_isbn_10(id_)
+            if isbn is None:
+                return None
+            id_ = isbn
+
+    try:
+        priority = "true" if high_priority else "false"
+        stage = "true" if stage_import else "false"
+        url = f'http://{affiliate_server_url}/isbn/{id_}?high_priority={priority}&stage_import={stage}'
+
+        if client:
+            r = await client.get(url, timeout=timeout)
+        else:
+            async with httpx.AsyncClient() as _client:
+                r = await _client.get(url, timeout=timeout)
+
+        r.raise_for_status()
+        return r.json().get('hit')
+    except (httpx.ConnectError, httpx.HTTPStatusError):
+        logger.exception("Affiliate Server error")
+    except Exception:
+        logger.exception(f"get_amazon_metadata_async({id_}) failed")
+    return None
+
+
 def _get_amazon_metadata(
     id_: str,
     id_type: Literal['asin', 'isbn'] = 'isbn',
@@ -603,6 +656,36 @@ class BetterWorldBooksMetadataError(TypedDict):
 
 
 @public
+async def get_betterworldbooks_metadata_async(
+    isbn: str,
+    client: httpx.AsyncClient | None = None,
+) -> BetterWorldBooksMetadata | BetterWorldBooksMetadataError | None:
+    """
+    :param str isbn: Unnormalised ISBN10 or ISBN13
+    :param client: Optional httpx.AsyncClient for connection reuse.
+    :return: Metadata for a single BWB book.
+    """
+    isbn = normalize_isbn(isbn) or isbn
+    if isbn is None:
+        return None
+
+    try:
+        url = BETTERWORLDBOOKS_API_URL + isbn
+        if client:
+            response = await client.get(url)
+        else:
+            async with httpx.AsyncClient() as _client:
+                response = await _client.get(url)
+
+        if response.status_code != 200:
+            return {'error': response.text, 'code': response.status_code}
+        return _parse_betterworldbooks_response(isbn, response.text)
+    except Exception:
+        logger.exception(f"get_betterworldbooks_metadata_async({isbn})")
+        return betterworldbooks_fmt(isbn)
+
+
+@public
 def get_betterworldbooks_metadata(
     isbn: str,
 ) -> BetterWorldBooksMetadata | BetterWorldBooksMetadataError | None:
@@ -638,7 +721,12 @@ def _get_betterworldbooks_metadata(
     response = requests.get(url)
     if response.status_code != requests.codes.ok:
         return {'error': response.text, 'code': response.status_code}
-    text = response.text
+    return _parse_betterworldbooks_response(isbn, response.text)
+
+
+def _parse_betterworldbooks_response(
+    isbn: str, text: str
+) -> BetterWorldBooksMetadata | BetterWorldBooksMetadataError:
     new_qty = re.findall("<TotalNew>([0-9]+)</TotalNew>", text)
     new_price = re.findall(r"<LowestNewPrice>\$([0-9.]+)</LowestNewPrice>", text)
     used_price = re.findall(r"<LowestUsedPrice>\$([0-9.]+)</LowestUsedPrice>", text)
@@ -662,6 +750,66 @@ def _get_betterworldbooks_metadata(
     return betterworldbooks_fmt(isbn, qlt, price, first_market_price)
 
 
+@public
+def get_affiliate_stores(title: str, opts: dict) -> dict[str, list[dict]]:
+    """Constructs the dictionary of store data (links, names, price info).
+
+    Used by both the AffiliateLinks macro and the AffiliateLinksPartial.
+    """
+    isbn = opts.get('isbn', '')
+    asin = opts.get('asin', '')
+
+    def safe_affiliate_id(key):
+        try:
+            return h.affiliate_id(key)
+        except (LookupError, AttributeError):
+            return ''
+
+    bwb = {
+        'key': 'betterworldbooks',
+        'analytics_key': 'BetterWorldBooks',
+        'name': _('Better World Books'),
+        'link': 'https://www.betterworldbooks.com/%s'
+        % (
+            ('product/detail/-%s' % isbn)
+            if isbn
+            else ('search/results?q=' + title.replace(' ', '%20'))
+        ),
+        'price_note': _(' - includes shipping'),
+        'price': opts.get('bwb_price'),
+    }
+
+    amazon = (
+        {
+            'key': 'amazon',
+            'analytics_key': 'Amazon',
+            'name': _('Amazon'),
+            'link': 'https://www.amazon.com/dp/%s/?tag=%s'
+            % (asin or isbn, safe_affiliate_id('amazon')),
+            'price': opts.get('amazon_price'),
+        }
+        if (asin or isbn)
+        else None
+    )
+
+    bookshop = (
+        {
+            'key': 'bookshop-org',
+            'analytics_key': 'BookshopOrg',
+            'name': _('Bookshop.org'),
+            'link': 'https://bookshop.org/a/%s/%s'
+            % (safe_affiliate_id('bookshop-org'), isbn),
+        }
+        if isbn
+        else None
+    )
+
+    return {
+        'primary': [store for store in [bwb, amazon] if store],
+        'more': [store for store in [bookshop] if store],
+    }
+
+
 def betterworldbooks_fmt(
     isbn: str,
     qlt: str | None = None,
@@ -674,8 +822,13 @@ def betterworldbooks_fmt(
     :param str price: Price of the book as a decimal str, e.g. "4.28"
     """
     price_fmt = f"${price} ({qlt})" if price and qlt else None
+    try:
+        bwb_id = h.affiliate_id('betterworldbooks')
+    except (LookupError, AttributeError):
+        bwb_id = ''
+    url = BWB_AFFILIATE_LINK_TEMPLATE.format(bwb_id) % isbn
     return {
-        'url': BWB_AFFILIATE_LINK % isbn,
+        'url': url,
         'isbn': isbn,
         'market_price': market_price,
         'price': price_fmt,

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -22,13 +22,13 @@ from openlibrary import accounts
 from openlibrary.catalog.add_book import load
 from openlibrary.core import cache
 from openlibrary.core import helpers as h
+from openlibrary.i18n import gettext as _
 from openlibrary.utils import dateutil, uniq
 from openlibrary.utils.isbn import (
     isbn_10_to_isbn_13,
     isbn_13_to_isbn_10,
     normalize_isbn,
 )
-from openlibrary.i18n import gettext as _
 
 logger = logging.getLogger("openlibrary.vendors")
 
@@ -36,7 +36,9 @@ BETTERWORLDBOOKS_API_URL = (
     'https://products.betterworldbooks.com/service.aspx?IncludeAmazon=True&ItemId='
 )
 affiliate_server_url = None
-BWB_AFFILIATE_LINK_TEMPLATE = 'http://www.anrdoezrs.net/links/{}/type/dlg/http://www.betterworldbooks.com/-id-%s'
+BWB_AFFILIATE_LINK_TEMPLATE = (
+    'http://www.anrdoezrs.net/links/{}/type/dlg/http://www.betterworldbooks.com/-id-%s'
+)
 AMAZON_FULL_DATE_RE = re.compile(r'\d{4}-\d\d-\d\d')
 ISBD_UNIT_PUNCT = ' : '  # ISBD cataloging title-unit separator punctuation
 
@@ -752,9 +754,10 @@ def _parse_betterworldbooks_response(
 
 @public
 def get_affiliate_stores(title: str, opts: dict) -> dict[str, list[dict]]:
-    """Constructs the dictionary of store data (links, names, price info).
-
-    Used by both the AffiliateLinks macro and the AffiliateLinksPartial.
+    """Helper to build all the store data (links, names, and prices).
+    
+    Both the AffiliateLinks macro and the async partial use this so
+    they stay perfectly in sync.
     """
     isbn = opts.get('isbn', '')
     asin = opts.get('asin', '')
@@ -816,10 +819,12 @@ def betterworldbooks_fmt(
     price: str | None = None,
     market_price: list[str] | None = None,
 ) -> BetterWorldBooksMetadata:
-    """Defines a standard interface for returning bwb price info
-
-    :param str qlt: Quality of the book, e.g. "new", "used"
-    :param str price: Price of the book as a decimal str, e.g. "4.28"
+    """Standardizes how we return BWB price info.
+    
+    Arguments:
+    - isbn: the book's identifier
+    - qlt: "new", "used", etc
+    - price: the decimal price string
     """
     price_fmt = f"${price} ({qlt})" if price and qlt else None
     try:

--- a/openlibrary/fastapi/partials.py
+++ b/openlibrary/fastapi/partials.py
@@ -67,7 +67,7 @@ async def affiliate_links_partial(
     except json.JSONDecodeError:
         raise HTTPException(status_code=400, detail="Invalid JSON in data parameter")
 
-    return await AffiliateLinksPartial(data=parsed_data).generate_async()
+    return AffiliateLinksPartial(data=parsed_data).generate()
 
 
 @router.get("/partials/BPListsSection.json", include_in_schema=SHOW_PARTIALS_IN_SCHEMA)

--- a/openlibrary/fastapi/partials.py
+++ b/openlibrary/fastapi/partials.py
@@ -67,7 +67,7 @@ async def affiliate_links_partial(
     except json.JSONDecodeError:
         raise HTTPException(status_code=400, detail="Invalid JSON in data parameter")
 
-    return AffiliateLinksPartial(data=parsed_data).generate()
+    return await AffiliateLinksPartial(data=parsed_data).generate_async()
 
 
 @router.get("/partials/BPListsSection.json", include_in_schema=SHOW_PARTIALS_IN_SCHEMA)

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -38,6 +38,22 @@ msgstr ""
 msgid "Unknown"
 msgstr ""
 
+#: openlibrary/core/vendors.py
+msgid "Better World Books"
+msgstr ""
+
+#: openlibrary/core/vendors.py
+msgid " - includes shipping"
+msgstr ""
+
+#: openlibrary/core/vendors.py
+msgid "Amazon"
+msgstr ""
+
+#: openlibrary/core/vendors.py
+msgid "Bookshop.org"
+msgstr ""
+
 #: AffiliateLinks.html
 #, python-format
 msgid "Look for this edition for sale at %(store)s"
@@ -45,22 +61,6 @@ msgstr ""
 
 #: AffiliateLinks.html
 msgid "Fetching prices"
-msgstr ""
-
-#: AffiliateLinks.html
-msgid "Better World Books"
-msgstr ""
-
-#: AffiliateLinks.html
-msgid " - includes shipping"
-msgstr ""
-
-#: AffiliateLinks.html
-msgid "Amazon"
-msgstr ""
-
-#: AffiliateLinks.html
-msgid "Bookshop.org"
 msgstr ""
 
 #: AffiliateLinks.html home/about.html search/work_search_facets.html

--- a/openlibrary/macros/AffiliateLinks.html
+++ b/openlibrary/macros/AffiliateLinks.html
@@ -20,43 +20,29 @@ $def affiliate_link(key, analytics_key, name, link, price='', price_note=''):
       prices = opts.get('prices')
       isbn = opts.get('isbn', '')
       asin = opts.get('asin', '')
+      prepared_stores = opts.get('prepared_stores')
 
-      bwb = {
-        'key': 'betterworldbooks',
-        'analytics_key': 'BetterWorldBooks',
-        'name': _('Better World Books'),
-        'link': 'https://www.betterworldbooks.com/%s' % (
-          ('product/detail/-%s' % isbn) if isbn else ('search/results?q=' + title.replace(' ','%20'))
-        ),
-        'price_note': _(' - includes shipping')
-      }
+      if not prepared_stores:
+          # Fallback for synchronous calls that don't pass prepared_stores
+          bwb_price = amazon_price = None
+          if not is_bot() and prices and isbn:
+              bwb_metadata = get_betterworldbooks_metadata(isbn)
+              bwb_price = bwb_metadata and bwb_metadata.get('price')
+              if asin or isbn:
+                  amazon_price = bwb_metadata and bwb_metadata.get('market_price')
+              if not amazon_price:
+                  amz_metadata = get_amazon_metadata(isbn, resources='prices')
+                  amazon_price = amz_metadata and amz_metadata.get('price')
 
-      amazon = {
-        'key': 'amazon',
-        'analytics_key': 'Amazon',
-        'name': _('Amazon'),
-        'link': 'https://www.amazon.com/dp/%s/?tag=%s' % (asin or isbn, affiliate_id('amazon')),
-      } if (asin or isbn) else None
+          prepared_stores = get_affiliate_stores(title, {
+              'isbn': isbn,
+              'asin': asin,
+              'bwb_price': bwb_price,
+              'amazon_price': amazon_price
+          })
 
-      bookshop = {
-        'key': 'bookshop-org',
-        'analytics_key': 'BookshopOrg',
-        'name': _('Bookshop.org'),
-        'link': 'https://bookshop.org/a/%s/%s' % (affiliate_id('bookshop-org'), isbn),
-      } if isbn else None
-
-      # Fetch price data
-      if not is_bot() and prices and isbn:
-        bwb_metadata = get_betterworldbooks_metadata(isbn)
-        bwb['price'] = bwb_metadata and bwb_metadata.get('price')
-        if amazon:
-          amazon['price'] = bwb_metadata and bwb_metadata.get('market_price')
-        if amazon and not amazon['price']:
-          amz_metadata = get_amazon_metadata(isbn, resources='prices')
-          amazon['price'] = amz_metadata and amz_metadata.get('price')
-
-      primary_stores = [store for store in [bwb, amazon] if store]
-      more_stores = [store for store in [bookshop] if store]
+      primary_stores = prepared_stores.get('primary', [])
+      more_stores = prepared_stores.get('more', [])
 
     <ul class="buy-options-table">
         $for store in primary_stores:

--- a/openlibrary/macros/AffiliateLinks.html
+++ b/openlibrary/macros/AffiliateLinks.html
@@ -17,29 +17,7 @@ $def affiliate_link(key, analytics_key, name, link, price='', price_note=''):
     $:macros.LoadingIndicator(_("Fetching prices"), additional_classes="affiliate-links-loading")
   $else:
     $code:
-      prices = opts.get('prices')
-      isbn = opts.get('isbn', '')
-      asin = opts.get('asin', '')
-      prepared_stores = opts.get('prepared_stores')
-
-      if not prepared_stores:
-          # Fallback for synchronous calls that don't pass prepared_stores
-          bwb_price = amazon_price = None
-          if not is_bot() and prices and isbn:
-              bwb_metadata = get_betterworldbooks_metadata(isbn)
-              bwb_price = bwb_metadata and bwb_metadata.get('price')
-              if asin or isbn:
-                  amazon_price = bwb_metadata and bwb_metadata.get('market_price')
-              if not amazon_price:
-                  amz_metadata = get_amazon_metadata(isbn, resources='prices')
-                  amazon_price = amz_metadata and amz_metadata.get('price')
-
-          prepared_stores = get_affiliate_stores(title, {
-              'isbn': isbn,
-              'asin': asin,
-              'bwb_price': bwb_price,
-              'amazon_price': amazon_price
-          })
+      prepared_stores = opts.get('prepared_stores') or prepare_affiliate_data(title, opts)
 
       primary_stores = prepared_stores.get('primary', [])
       more_stores = prepared_stores.get('more', [])

--- a/openlibrary/plugins/openlibrary/js/affiliate-links.js
+++ b/openlibrary/plugins/openlibrary/js/affiliate-links.js
@@ -64,9 +64,9 @@ async function getPartials(data, section) {
             const template = document.createElement('template')
             template.innerHTML = respData.partials
             const newContent = template.content.querySelector('.affiliate-links-section')
-            
-            // The partial usually contains the wrapper span, so we just grab its 
-            // children and drop them into the current section. This keeps our 
+
+            // The partial usually contains the wrapper span, so we just grab its
+            // children and drop them into the current section. This keeps our
             // 'section' reference valid for retries and avoids double-nesting.
             if (newContent) {
                 section.replaceChildren(...Array.from(newContent.childNodes))

--- a/openlibrary/plugins/openlibrary/js/affiliate-links.js
+++ b/openlibrary/plugins/openlibrary/js/affiliate-links.js
@@ -1,56 +1,56 @@
 import { buildPartialsUrl } from './utils'
 
 /**
- * Adds functionality to fetch affialite links asyncronously.
+ * Adds functionality to fetch affiliate links asynchronously.
  *
- * Fetches and attaches partials to DOM _iff_ any of the given affiliate link
- * sections contain a loading indicator.  Adds affordance for retrying if the
- * call for partials fails.
+ * Fetches and attaches partials to DOM iff any of the given affiliate link
+ * sections contain a loading indicator. Uses IntersectionObserver to delay
+ * fetching until the section is visible.
  *
  * @param {NodeList<HTMLElement>} affiliateLinksSections Collection of each affiliate links section that is on the page
  */
 export function initAffiliateLinks(affiliateLinksSections) {
-    const isLoading = showLoadingIndicators(affiliateLinksSections)
-    if (isLoading) {
-        // Replace loading indicators with fetched partials
+    if (!affiliateLinksSections.length) return
 
-        const title = affiliateLinksSections[0].dataset.title
-        const opts = JSON.parse(affiliateLinksSections[0].dataset.opts)
-        const args = [title, opts]
-        const d = {args: args}
+    const intersectionObserver = new IntersectionObserver((entries) => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                // Unregister intersection listener
+                intersectionObserver.unobserve(entry.target)
+                
+                const section = entry.target
+                const loadingIndicator = section.querySelector('.loadingIndicator')
+                
+                if (loadingIndicator) {
+                    loadingIndicator.classList.remove('hidden')
+                    
+                    const title = section.dataset.title
+                    const opts = JSON.parse(section.dataset.opts)
+                    const data = {args: [title, opts]}
+                    
+                    getPartials(data, section)
+                }
+            }
+        })
+    }, {
+        root: null,
+        rootMargin: '200px',
+        threshold: 0
+    })
 
-        getPartials(d, affiliateLinksSections)
-    }
-}
-
-/**
- * Removes `hidden` class from any loading indicators nested within the given
- * elements.
- *
- * @param {NodeList<HTMLElement>} linkSections
- * @returns {boolean} `true` if a loading indicator is displayed on the screen
- */
-function showLoadingIndicators(linkSections) {
-    let isLoading = false
-    for (const section of linkSections) {
-        const loadingIndicator = section.querySelector('.loadingIndicator')
-        if (loadingIndicator) {
-            isLoading = true
-            loadingIndicator.classList.remove('hidden')
-        }
-    }
-    return isLoading
+    affiliateLinksSections.forEach(section => intersectionObserver.observe(section))
 }
 
 /**
  * Fetches rendered affiliate links template using the given arguments.
  *
  * @param {object} data Contains array of positional arguments for the template
- * @param {NodeList<HTMLElement>} affiliateLinksSections
+ * @param {HTMLElement} section The specific section to update
  * @returns {Promise}
  */
-async function getPartials(data, affiliateLinksSections) {
+async function getPartials(data, section) {
     const dataString = JSON.stringify(data)
+    const loadingIndicator = section.querySelector('.loadingIndicator')
 
     return fetch(buildPartialsUrl('AffiliateLinks', {data: dataString}))
         .then((resp) => {
@@ -59,33 +59,41 @@ async function getPartials(data, affiliateLinksSections) {
             }
             return resp.json()
         })
-        .then((data) => {
-            const span = document.createElement('span')
-            span.innerHTML = data['partials']
-            const links = span.firstElementChild
-            for (const section of affiliateLinksSections) {
-                section.replaceWith(links.cloneNode(true))
+        .then((respData) => {
+            // Replace loading indicator with partials
+            const template = document.createElement('template')
+            template.innerHTML = respData.partials
+            const newContent = template.content.querySelector('.affiliate-links-section')
+            
+            // If the partial returns the whole span (it usually does), 
+            // use its children to replace our current contents.
+            // This maintains the 'section' reference and prevents nested wrappers.
+            if (newContent) {
+                section.replaceChildren(...Array.from(newContent.childNodes))
+            } else {
+                section.replaceChildren(...Array.from(template.content.childNodes))
             }
         })
-        .catch(() => {
-            // XXX : Handle errors sensibly
-            for (const section of affiliateLinksSections) {
-                const loadingIndicator = section.querySelector('.loadingIndicator')
-                if (loadingIndicator) {
-                    loadingIndicator.classList.add('hidden')
-                }
+        .catch((err) => {
+            console.error('Error fetching affiliate links:', err)
+            if (loadingIndicator) {
+                loadingIndicator.classList.add('hidden')
+            }
 
-                const existingRetryAffordance = section.querySelector('.affiliate-links-section__retry')
-                if (existingRetryAffordance) {
-                    existingRetryAffordance.classList.remove('hidden')
-                } else {
-                    section.insertAdjacentHTML('afterbegin', renderRetryLink())
-                    const retryAffordance = section.querySelector('.affiliate-links-section__retry')
-                    retryAffordance.addEventListener('click', () => {
-                        retryAffordance.classList.add('hidden')
-                        getPartials(data, affiliateLinksSections)
-                    })
-                }
+            const existingRetryAffordance = section.querySelector('.affiliate-links-section__retry')
+            if (existingRetryAffordance) {
+                existingRetryAffordance.classList.remove('hidden')
+            } else {
+                section.insertAdjacentHTML('afterbegin', renderRetryLink())
+                const retryAffordance = section.querySelector('.affiliate-links-section__retry')
+                retryAffordance.addEventListener('click', (e) => {
+                    e.preventDefault()
+                    retryAffordance.classList.add('hidden')
+                    if (loadingIndicator) {
+                        loadingIndicator.classList.remove('hidden')
+                    }
+                    getPartials(data, section)
+                })
             }
         })
 }

--- a/openlibrary/plugins/openlibrary/js/affiliate-links.js
+++ b/openlibrary/plugins/openlibrary/js/affiliate-links.js
@@ -17,17 +17,17 @@ export function initAffiliateLinks(affiliateLinksSections) {
             if (entry.isIntersecting) {
                 // Unregister intersection listener
                 intersectionObserver.unobserve(entry.target)
-                
+
                 const section = entry.target
                 const loadingIndicator = section.querySelector('.loadingIndicator')
-                
+
                 if (loadingIndicator) {
                     loadingIndicator.classList.remove('hidden')
-                    
+
                     const title = section.dataset.title
                     const opts = JSON.parse(section.dataset.opts)
                     const data = {args: [title, opts]}
-                    
+
                     getPartials(data, section)
                 }
             }
@@ -64,8 +64,8 @@ async function getPartials(data, section) {
             const template = document.createElement('template')
             template.innerHTML = respData.partials
             const newContent = template.content.querySelector('.affiliate-links-section')
-            
-            // If the partial returns the whole span (it usually does), 
+
+            // If the partial returns the whole span (it usually does),
             // use its children to replace our current contents.
             // This maintains the 'section' reference and prevents nested wrappers.
             if (newContent) {
@@ -75,6 +75,7 @@ async function getPartials(data, section) {
             }
         })
         .catch((err) => {
+            // eslint-disable-next-line no-console
             console.error('Error fetching affiliate links:', err)
             if (loadingIndicator) {
                 loadingIndicator.classList.add('hidden')

--- a/openlibrary/plugins/openlibrary/js/affiliate-links.js
+++ b/openlibrary/plugins/openlibrary/js/affiliate-links.js
@@ -60,14 +60,14 @@ async function getPartials(data, section) {
             return resp.json()
         })
         .then((respData) => {
-            // Replace loading indicator with partials
+            // Swap the loading spinner with our new partial content.
             const template = document.createElement('template')
             template.innerHTML = respData.partials
             const newContent = template.content.querySelector('.affiliate-links-section')
-
-            // If the partial returns the whole span (it usually does),
-            // use its children to replace our current contents.
-            // This maintains the 'section' reference and prevents nested wrappers.
+            
+            // The partial usually contains the wrapper span, so we just grab its 
+            // children and drop them into the current section. This keeps our 
+            // 'section' reference valid for retries and avoids double-nesting.
             if (newContent) {
                 section.replaceChildren(...Array.from(newContent.childNodes))
             } else {

--- a/openlibrary/plugins/openlibrary/js/affiliate-links.js
+++ b/openlibrary/plugins/openlibrary/js/affiliate-links.js
@@ -4,41 +4,23 @@ import { buildPartialsUrl } from './utils'
  * Adds functionality to fetch affiliate links asynchronously.
  *
  * Fetches and attaches partials to DOM iff any of the given affiliate link
- * sections contain a loading indicator. Uses IntersectionObserver to delay
- * fetching until the section is visible.
+ * sections contain a loading indicator.
  *
  * @param {NodeList<HTMLElement>} affiliateLinksSections Collection of each affiliate links section that is on the page
  */
 export function initAffiliateLinks(affiliateLinksSections) {
-    if (!affiliateLinksSections.length) return
+    for (const section of affiliateLinksSections) {
+        const loadingIndicator = section.querySelector('.loadingIndicator')
+        if (loadingIndicator) {
+            loadingIndicator.classList.remove('hidden')
 
-    const intersectionObserver = new IntersectionObserver((entries) => {
-        entries.forEach(entry => {
-            if (entry.isIntersecting) {
-                // Unregister intersection listener
-                intersectionObserver.unobserve(entry.target)
+            const title = section.dataset.title
+            const opts = JSON.parse(section.dataset.opts)
+            const data = {args: [title, opts]}
 
-                const section = entry.target
-                const loadingIndicator = section.querySelector('.loadingIndicator')
-
-                if (loadingIndicator) {
-                    loadingIndicator.classList.remove('hidden')
-
-                    const title = section.dataset.title
-                    const opts = JSON.parse(section.dataset.opts)
-                    const data = {args: [title, opts]}
-
-                    getPartials(data, section)
-                }
-            }
-        })
-    }, {
-        root: null,
-        rootMargin: '200px',
-        threshold: 0
-    })
-
-    affiliateLinksSections.forEach(section => intersectionObserver.observe(section))
+            getPartials(data, section)
+        }
+    }
 }
 
 /**

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -250,24 +250,19 @@ class AffiliateLinksPartial(PartialDataHandler):
 
                 results = await asyncio.gather(*tasks, return_exceptions=True)
 
-                # Process results safely
-                bwb_metadata = (
-                    results[0] if not isinstance(results[0], Exception) else None
-                )
-                amz_metadata = None
-                if amz_task:
-                    amz_metadata = (
-                        results[1] if not isinstance(results[1], Exception) else None
-                    )
+                # Process results safely with explicit type narrowing for MyPy
+                res1 = results[0]
+                if isinstance(res1, dict):
+                    bwb_price = res1.get('price')
+                    # Fallback to BWB's market price
+                    amazon_price = res1.get('market_price')
 
-                if bwb_metadata:
-                    bwb_price = bwb_metadata.get('price')
-                    # Use BWB's market price as a backup if we don't have a direct Amazon price
-                    amazon_price = bwb_metadata.get('market_price')
-
-                # Prefer the more current direct Amazon API price if available
-                if amz_metadata and amz_metadata.get('price'):
-                    amazon_price = amz_metadata.get('price')
+                if amz_task and len(results) > 1:
+                    res2 = results[1]
+                    if isinstance(res2, dict):
+                        # Prioritize direct Amazon price
+                        if res2.get('price'):
+                            amazon_price = res2.get('price')
 
         opts['prepared_stores'] = get_affiliate_stores(
             title,

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -1,12 +1,20 @@
+import asyncio
 from abc import ABC, abstractmethod
 from datetime import datetime
 from urllib.parse import parse_qs
 
+import httpx
 import web
 from pydantic import BaseModel
 
 from infogami.utils.view import render_template
 from openlibrary.accounts import get_current_user
+from openlibrary.core.helpers import affiliate_id
+from openlibrary.core.vendors import (
+    get_amazon_metadata_async,
+    get_betterworldbooks_metadata_async,
+    get_affiliate_stores,
+)
 from openlibrary.core.fulltext import fulltext_search_async
 from openlibrary.core.lending import compose_ia_url, get_available
 from openlibrary.i18n import gettext as _
@@ -31,6 +39,14 @@ class PartialDataHandler(ABC):
     @abstractmethod
     def generate(self) -> dict:
         pass
+
+    async def generate_async(self) -> dict:
+        """Async version of generate.
+
+        By default, calls the synchronous generate method. Subclasses
+        can override this to provide a fully asynchronous implementation.
+        """
+        return self.generate()
 
 
 class ReadingGoalProgressPartial(PartialDataHandler):
@@ -203,6 +219,63 @@ class AffiliateLinksPartial(PartialDataHandler):
             raise ValueError("Unexpected amount of arguments")
 
         macro = web.template.Template.globals['macros'].AffiliateLinks(args[0], args[1])
+        return {"partials": str(macro)}
+
+    async def generate_async(self) -> dict:
+        from openlibrary.plugins.openlibrary.code import is_bot
+
+        args = self.data.get("args", [])
+        if len(args) < 2:
+            raise ValueError("Unexpected amount of arguments")
+
+        title, opts = args[0], args[1]
+        prices = opts.get('prices')
+        isbn = opts.get('isbn', '')
+        asin = opts.get('asin', '')
+
+        bwb_price = amazon_price = None
+
+        # Fetch price data async with a shared client Parallelized
+        if not is_bot() and prices and isbn:
+            async with httpx.AsyncClient() as client:
+                bwb_task = get_betterworldbooks_metadata_async(isbn, client=client)
+                amz_task = None
+                if asin or isbn:
+                    amz_task = get_amazon_metadata_async(
+                        isbn, resources='prices', client=client
+                    )
+
+                tasks = [bwb_task]
+                if amz_task:
+                    tasks.append(amz_task)
+
+                results = await asyncio.gather(*tasks, return_exceptions=True)
+
+                # Process results safely
+                bwb_metadata = results[0] if not isinstance(results[0], Exception) else None
+                amz_metadata = None
+                if amz_task:
+                    amz_metadata = results[1] if not isinstance(results[1], Exception) else None
+
+                if bwb_metadata:
+                    bwb_price = bwb_metadata.get('price')
+                    # BWB often includes a market_price (Amazon); initialize with it as a fallback
+                    amazon_price = bwb_metadata.get('market_price')
+
+                # Prefer the more current direct Amazon API price if available
+                if amz_metadata and amz_metadata.get('price'):
+                    amazon_price = amz_metadata.get('price')
+
+        opts['prepared_stores'] = get_affiliate_stores(
+            title,
+            {
+                'isbn': isbn,
+                'asin': asin,
+                'bwb_price': bwb_price,
+                'amazon_price': amazon_price,
+            },
+        )
+        macro = web.template.Template.globals['macros'].AffiliateLinks(title, opts)
         return {"partials": str(macro)}
 
 

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -259,10 +259,9 @@ class AffiliateLinksPartial(PartialDataHandler):
 
                 if amz_task and len(results) > 1:
                     res2 = results[1]
-                    if isinstance(res2, dict):
-                        # Prioritize direct Amazon price
-                        if res2.get('price'):
-                            amazon_price = res2.get('price')
+                    # Prioritize direct Amazon price
+                    if isinstance(res2, dict) and res2.get('price'):
+                        amazon_price = res2.get('price')
 
         opts['prepared_stores'] = get_affiliate_stores(
             title,

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -1,9 +1,7 @@
-import asyncio
 from abc import ABC, abstractmethod
 from datetime import datetime
 from urllib.parse import parse_qs
 
-import httpx
 import web
 from pydantic import BaseModel
 
@@ -12,9 +10,7 @@ from openlibrary.accounts import get_current_user
 from openlibrary.core.fulltext import fulltext_search_async
 from openlibrary.core.lending import compose_ia_url, get_available
 from openlibrary.core.vendors import (
-    get_affiliate_stores,
-    get_amazon_metadata_async,
-    get_betterworldbooks_metadata_async,
+    prepare_affiliate_data,
 )
 from openlibrary.i18n import gettext as _
 from openlibrary.plugins.openlibrary.lists import get_lists_async, get_user_lists
@@ -218,61 +214,9 @@ class AffiliateLinksPartial(PartialDataHandler):
         if len(args) < 2:
             raise ValueError("Unexpected amount of arguments")
 
-        macro = web.template.Template.globals['macros'].AffiliateLinks(args[0], args[1])
-        return {"partials": str(macro)}
-
-    async def generate_async(self) -> dict:
-        from openlibrary.plugins.openlibrary.code import is_bot
-
-        args = self.data.get("args", [])
-        if len(args) < 2:
-            raise ValueError("Unexpected amount of arguments")
-
         title, opts = args[0], args[1]
-        prices = opts.get('prices')
-        isbn = opts.get('isbn', '')
-        asin = opts.get('asin', '')
+        opts['prepared_stores'] = prepare_affiliate_data(title, opts)
 
-        bwb_price = amazon_price = None
-
-        # We'll fire off both provider requests at once to save time
-        if not is_bot() and prices and isbn:
-            async with httpx.AsyncClient() as client:
-                bwb_task = get_betterworldbooks_metadata_async(isbn, client=client)
-                amz_task = None
-                if asin or isbn:
-                    amz_task = get_amazon_metadata_async(
-                        isbn, resources='prices', client=client
-                    )
-
-                tasks = [bwb_task]
-                if amz_task:
-                    tasks.append(amz_task)
-
-                results = await asyncio.gather(*tasks, return_exceptions=True)
-
-                # Process results safely with explicit type narrowing for MyPy
-                res1 = results[0]
-                if isinstance(res1, dict):
-                    bwb_price = res1.get('price')
-                    # Fallback to BWB's market price
-                    amazon_price = res1.get('market_price')
-
-                if amz_task and len(results) > 1:
-                    res2 = results[1]
-                    # Prioritize direct Amazon price
-                    if isinstance(res2, dict) and res2.get('price'):
-                        amazon_price = res2.get('price')
-
-        opts['prepared_stores'] = get_affiliate_stores(
-            title,
-            {
-                'isbn': isbn,
-                'asin': asin,
-                'bwb_price': bwb_price,
-                'amazon_price': amazon_price,
-            },
-        )
         macro = web.template.Template.globals['macros'].AffiliateLinks(title, opts)
         return {"partials": str(macro)}
 

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -42,8 +42,9 @@ class PartialDataHandler(ABC):
     async def generate_async(self) -> dict:
         """Async version of generate.
 
-        By default, calls the synchronous generate method. Subclasses
-        can override this to provide a fully asynchronous implementation.
+        Subclasses can override this to fire off parallel network requests
+        or other async tasks. By default, it just falls back to the
+        standard synchronous generate method.
         """
         return self.generate()
 

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -9,14 +9,13 @@ from pydantic import BaseModel
 
 from infogami.utils.view import render_template
 from openlibrary.accounts import get_current_user
-from openlibrary.core.helpers import affiliate_id
-from openlibrary.core.vendors import (
-    get_amazon_metadata_async,
-    get_betterworldbooks_metadata_async,
-    get_affiliate_stores,
-)
 from openlibrary.core.fulltext import fulltext_search_async
 from openlibrary.core.lending import compose_ia_url, get_available
+from openlibrary.core.vendors import (
+    get_affiliate_stores,
+    get_amazon_metadata_async,
+    get_betterworldbooks_metadata_async,
+)
 from openlibrary.i18n import gettext as _
 from openlibrary.plugins.openlibrary.lists import get_lists_async, get_user_lists
 from openlibrary.plugins.upstream.yearly_reading_goals import get_reading_goals
@@ -235,7 +234,7 @@ class AffiliateLinksPartial(PartialDataHandler):
 
         bwb_price = amazon_price = None
 
-        # Fetch price data async with a shared client Parallelized
+        # We'll fire off both provider requests at once to save time
         if not is_bot() and prices and isbn:
             async with httpx.AsyncClient() as client:
                 bwb_task = get_betterworldbooks_metadata_async(isbn, client=client)
@@ -252,14 +251,18 @@ class AffiliateLinksPartial(PartialDataHandler):
                 results = await asyncio.gather(*tasks, return_exceptions=True)
 
                 # Process results safely
-                bwb_metadata = results[0] if not isinstance(results[0], Exception) else None
+                bwb_metadata = (
+                    results[0] if not isinstance(results[0], Exception) else None
+                )
                 amz_metadata = None
                 if amz_task:
-                    amz_metadata = results[1] if not isinstance(results[1], Exception) else None
+                    amz_metadata = (
+                        results[1] if not isinstance(results[1], Exception) else None
+                    )
 
                 if bwb_metadata:
                     bwb_price = bwb_metadata.get('price')
-                    # BWB often includes a market_price (Amazon); initialize with it as a fallback
+                    # Use BWB's market price as a backup if we don't have a direct Amazon price
                     amazon_price = bwb_metadata.get('market_price')
 
                 # Prefer the more current direct Amazon API price if available


### PR DESCRIPTION
# Refactor AffiliateLinks to Remove Template-Side Network Requests

<!-- What issue does this PR close? -->
Closes #12271

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
**refactor** Moves high-latency price fetching from the template layer to an asynchronous FastAPI partial.

### Technical
<!-- What should be noted about the implementation? -->
- **Backend Concurrency**: Optimized `AffiliateLinksPartial` with `asyncio.gather` for parallel Better World Books and Amazon API metadata fetches.
- **Lazy Loading**: Refactored `affiliate-links.js` to use `IntersectionObserver`, deferring network requests until the "Buy" section is visible.
- **Architectural Cleanup**: Consolidated duplicated store logic from `AffiliateLinks.html` into a shared `get_affiliate_stores` helper in `vendors.py`.
- **Robustness**: Added try-except guards for `h.affiliate_id` to ensure `vendors.py` functions work correctly in non-web contexts (tests/CLI).

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Navigate to a book edition page (e.g., `/books/OL7353617M`).
2. Scroll down towards the "Buy" section.
3. Verify that a loading spinner appears briefly and is replaced by the affiliate links once fetched.
4. Check the browser's Network tab to confirm a request to `/partials/AffiliateLinks.json`.
5. Run backend logic tests: `pytest openlibrary/tests/core/test_vendors_async.py`.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="3071" height="1588" alt="Screenshot from 2026-04-05 19-02-40" src="https://github.com/user-attachments/assets/5258ee9e-f2b6-4aa4-aabb-a794eaeffc0a" />
<img width="3071" height="1588" alt="Screenshot from 2026-04-05 19-02-31" src="https://github.com/user-attachments/assets/a6f2d500-9a64-4cfb-a2ad-dde7e0743d54" />

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 

---

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
