### PR TITLE
Fix empty keys crash in solr update

### DIFF
--- a/openlibrary/solr/update.py
+++ b/openlibrary/solr/update.py
@@ -199,6 +199,10 @@ async def main(
         level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s"
     )
 
+    if not keys:
+        logger.warning("No keys provided to update. Exiting.")
+        return
+
     if keys[0].startswith('//'):
         keys = [k[1:] for k in keys]
 


### PR DESCRIPTION
Closes #12340 

Fix make reindex solr crashing on fresh local setups when there are no /lists/ or /series/ records.

This adds an early return in openlibrary/solr/update.py so empty key input logs a warning and exits cleanly instead of raising IndexError.

### Stakeholders
@RayBB 
