### PR TITLE
feat: auto-sync docs wiki into docs/wiki/ on container start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ android.keystore
 # Ignore checksum file if it’s generated during build
 manifest-checksum.txt
 .beads
+
+# Auto-synced docs wiki (cloned by docker/ol-home-start.sh)
+docs/wiki/

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -156,8 +156,6 @@ services:
       - ${OL_MOUNT_DIR:-.}:/openlibrary
       # For OSP download persistence across restarts
       - solr-updater-data:/solr-updater-data
-      # Persist the docs wiki clone across container restarts
-      - ./docs/wiki:/openlibrary/docs/wiki
     depends_on:
       solr:
         condition: service_healthy

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -156,6 +156,8 @@ services:
       - ${OL_MOUNT_DIR:-.}:/openlibrary
       # For OSP download persistence across restarts
       - solr-updater-data:/solr-updater-data
+      # Persist the docs wiki clone across container restarts
+      - ./docs/wiki:/openlibrary/docs/wiki
     depends_on:
       solr:
         condition: service_healthy

--- a/docker/ol-home-start.sh
+++ b/docker/ol-home-start.sh
@@ -1,3 +1,14 @@
 #!/bin/bash
 
+# Clone or update docs wiki so developers and AI assistants can search
+# documentation locally without switching to the browser.
+if [ -d "/openlibrary/docs/wiki/.git" ]; then
+    echo "Updating docs wiki..."
+    cd /openlibrary/docs/wiki && git pull
+else
+    echo "Cloning docs wiki..."
+    git clone https://github.com/internetarchive/openlibrary.wiki.git /openlibrary/docs/wiki
+fi
+cd /openlibrary
+
 make reindex-solr

--- a/docker/ol-home-start.sh
+++ b/docker/ol-home-start.sh
@@ -5,8 +5,6 @@
 if [ -d "/openlibrary/docs/wiki/.git" ]; then
     echo "Updating docs wiki..."
     cd /openlibrary/docs/wiki && git pull --ff-only
-elif [ -d "/openlibrary/docs/wiki" ]; then
-    echo "docs/wiki exists but is not a git repo, skipping..."
 else
     echo "Cloning docs wiki..."
     git clone https://github.com/internetarchive/openlibrary.wiki.git /openlibrary/docs/wiki

--- a/docker/ol-home-start.sh
+++ b/docker/ol-home-start.sh
@@ -4,7 +4,9 @@
 # documentation locally without switching to the browser.
 if [ -d "/openlibrary/docs/wiki/.git" ]; then
     echo "Updating docs wiki..."
-    cd /openlibrary/docs/wiki && git pull
+    cd /openlibrary/docs/wiki && git pull --ff-only
+elif [ -d "/openlibrary/docs/wiki" ]; then
+    echo "docs/wiki exists but is not a git repo, skipping..."
 else
     echo "Cloning docs wiki..."
     git clone https://github.com/internetarchive/openlibrary.wiki.git /openlibrary/docs/wiki


### PR DESCRIPTION
Closes #12303

### Technical
Adds automatic docs wiki sync on container start:
- `docker/ol-home-start.sh` — clones the wiki on first start, pulls updates on subsequent restarts
- `compose.override.yaml` — adds volume mount under `home` service to persist `docs/wiki/` across restarts
- `.gitignore` — ignores `docs/wiki/` so it doesn't appear as untracked files

Wiki source: https://github.com/internetarchive/openlibrary.wiki.git
Local path: `docs/wiki/`

### Testing
1. Fresh checkout — delete `docs/wiki/` if it exists, restart container, confirm wiki is cloned
2. Existing directory — restart container again, confirm it runs `git pull` instead of cloning
3. Confirm `docs/wiki/` does not appear in `git status`

### Screenshot
N/A - no UI changes

### Stakeholders
@RayBB
