### PR TITLE
fix: stacked edition covers overlap dropdowns

### DIFF
--- a/static/css/components/search-result-item.css
+++ b/static/css/components/search-result-item.css
@@ -126,6 +126,7 @@
 .search-result-item__preview-covers {
   display: flex;
   align-items: center;
+  isolation: isolate;
 }
 
 .search-result-item__preview-covers img {


### PR DESCRIPTION

<img width="1298" height="619" alt="stacking-bug" src="https://github.com/user-attachments/assets/0fcf24fc-0b3d-4a32-8030-23af9eea5b70" />


### Technical

The fix (isolation: isolate) tells the browser: "this container is its own stacking world." The z-indexes inside still work for layering covers relative to each other, but from the outside the whole container is just a single flat layer.

### Testing
Search for a series and then open the sort dropdown on the search results page:
https://openlibrary.org/search?q=foundation&mode=everything 

### Screenshot
See above

### Stakeholders
@cdrini 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
