### PR TITLE
Tweak solr weights/boosts - switch from additive boosting to multiplactive boosting

### DIFF
--- a/openlibrary/plugins/worksearch/schemes/works.py
+++ b/openlibrary/plugins/worksearch/schemes/works.py
@@ -355,15 +355,14 @@ class WorkSearchScheme(SearchScheme):
             # qf: the fields to query un-prefixed parts of the query.
             # e.g. 'harry potter' becomes
             # 'text:(harry potter) OR alternative_title:(harry potter)^20 OR ...'
-            solr_qf='text alternative_title^10 author_name^10 chapter^5',
+            # TODO: Change solr's text field to exclude first_sentence, by_statement, title, subtitle,
+            # alternative_subtitle . Then can replace most of qf with just text.
+            solr_qf='alternative_title^40 author_name^40 series_name^5 chapter series_position author_alternative_name subject place person time series_key author_key ia oclc lccn isbn key edition_key publisher contributor',  # noqa: E501
             # pf: phrase fields. This increases the score of documents that
             # match the query terms in close proximity to each other.
-            solr_pf='alternative_title^10 author_name^10',
-            # bf (boost factor): boost results based on the value of this
-            # field. I.e. results with more editions get boosted, upto a
-            # max of 100, after which we don't see it as good signal of
-            # quality.
-            solr_bf='min(100,edition_count) min(100,def(readinglog_count,0))',
+            solr_pf='alternative_title^50 author_name^50 series_name^5',
+            solr_pf2='alternative_title^20 author_name^20 series_name^5 chapter^5',
+            solr_boost='sum(mul(20,log(sum(3,edition_count))),min(50,def(already_read_count,0)),mul(35,log(div(sum(4,def(readinglog_count,0)), 4))))',
             # v: the query to process with the edismax query parser. Note
             # we are using a solr variable here; this reads the url parameter
             # arbitrarily called userWorkQuery.


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11777


### Technical
<!-- What should be noted about the implementation? -->

- Previously, we used the `bf` parameter for our boosting, but this applied _additive_ boosting, meaning the boosting could outweight the relevance quite drastically. Switching to `boost` gives us multiplicative boosting, which is recommended. See [Additive Boosts vs Multiplicative Boosts](https://solr.apache.org/guide/solr/latest/query-guide/dismax-query-parser.html#:~:text=Additive%20Boosts%20vs%20Multiplicative%20Boosts)
- Note there is some performance concern since we are (1) using a lot of fields in our `qf`, where previously we only had a few, and (2) using more `pf` fields. If there is too much of a performance cost, we can switch back to using `text` ; there is still a big improvement from the boosting changes alone.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Improves upon all classes in our [evaluation spreadsheet](https://docs.google.com/spreadsheets/d/1BN5I7-OkTPaoTr2Es6jQ4O9ICWFmH0q9CP6kEgolCgg/edit?gid=1006480604#gid=1006480604). *C* in the following tables (Note *A* is the same as *C*, but using `text` instead of the explicit listing of fields.)

<img width="1602" height="742" alt="image" src="https://github.com/user-attachments/assets/46d64b59-b034-4d61-97da-88fd2004f7ae" />


You can also compare results before/after here: https://codepen.io/cdrini/full/wvJqzaK

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
