### PR TITLE
fix(auth): TOTP review follow-up — guard otp_seed, atomic rate-limit counter

### DIFF
--- a/openlibrary/core/auth.py
+++ b/openlibrary/core/auth.py
@@ -123,6 +123,8 @@ class TimedOneTimePassword:
         cls, service_ip: str, client_email: str, client_ip: str, ts: int | None = None
     ) -> str:
         seed = config.get("otp_seed")
+        if not seed:
+            raise ValueError("otp_seed is not configured")
         ts = ts or int(time.time() // 60)
         payload = f"{service_ip}:{client_email}:{client_ip}:{ts}".encode()
         digest = hmac.new(seed.encode('utf-8'), payload, hashlib.sha256).digest()
@@ -148,6 +150,9 @@ class TimedOneTimePassword:
             return {"error": "ratelimit", "ratelimit": {"ttl": ttl, "key": key}}
 
         mc = cache.get_memcache()
+        if mc is None:
+            return None  # fail open: no memcache → skip rate limiting
+
         # Limit requests to 1 / ttl per client
         for key, value in kwargs.items():
             cache_key = f"otp-client:{service_ip}:{key}:{value}"
@@ -157,10 +162,14 @@ class TimedOneTimePassword:
         # Limit globally to 3 attempts per email and ip per / ttl
         for key, value in kwargs.items():
             cache_key = f"otp-global:{key}:{value}"
-            count = (mc.get(cache_key) or 0) + 1
-            mc.set(cache_key, count, expires=ttl)
-            if count > 3:
-                return ratelimit_error(cache_key, ttl)
+            if not mc.add(cache_key, 1, expires=ttl):
+                count = mc.incr(cache_key, 1)
+                if count is None:
+                    count = 1  # key expired between add and incr
+                if count > 3:
+                    return ratelimit_error(cache_key, ttl)
+
+        return None
 
     @classmethod
     def validate(cls, otp, service_ip, client_email, client_ip, ts):


### PR DESCRIPTION
## Summary

Follow-up to #11288 (TOTP auth), addressing Copilot review comments that didn't land before merge:

- **`generate()`**: raise `ValueError` if `otp_seed` is not configured, instead of silently passing `None` to HMAC
- **`check_ratelimit()`**: fail-open (`return None`) when memcache is unavailable rather than crashing
- **`check_ratelimit()`**: replace racy `get`/`set` pattern with atomic `add`/`incr` for the global rate-limit counter, plus handle the edge case where the key expires between `add` and `incr`

## Test plan

- [ ] Existing TOTP tests still pass (`make test-py`)
- [ ] Verify `generate()` raises `ValueError` when `otp_seed` is missing from config
- [ ] Verify rate limiting still works end-to-end with memcache available