### PR TITLE
refactor(css): replace raw em values with tokens in headings.css

### DIFF
--- a/static/css/base/headings.css
+++ b/static/css/base/headings.css
@@ -2,7 +2,7 @@ h1 {
   font-size: var(--font-size-headline-large);
 }
 h1.title {
-  font-size: var(--font-size-title-large); 
+  font-size: var(--font-size-title-large);
 }
 h1 span.subtitle {
   font-size: var(--font-size-title-small);

--- a/static/css/base/headings.css
+++ b/static/css/base/headings.css
@@ -1,17 +1,17 @@
 h1 {
-  font-size: 1.875em;
+  font-size: var(--font-size-headline-large);
 }
 h1.title {
-  font-size: 1.25em;
+  font-size: var(--font-size-title-large); 
 }
 h1 span.subtitle {
-  font-size: 0.65em;
+  font-size: var(--font-size-title-small);
   font-weight: normal;
 }
 /* TODO: Check if this class is still used. */
 h1.publisher {
   color: var(--brown);
-  font-size: 1.375em;
+  font-size: var(--font-size-headline-medium);
   font-family: var(--font-family-serif) !important;
   font-weight: normal !important;
   margin: 0;
@@ -21,16 +21,16 @@ h1 span.count {
 }
 
 h2 {
-  font-size: var(--font-size-title-large);
+  font-size: var(--font-size-headline-small);
 }
 h2.author {
   color: var(--brown);
-  font-size: 1.125em;
+  font-size: var(--font-size-title-medium);
   font-weight: normal;
 }
 h2.authorEdition {
   color: var(--brown);
-  font-size: 1em;
+  font-size: var(--font-size-title-small);
   font-weight: normal;
   margin: 0;
   padding: 0;
@@ -43,7 +43,7 @@ h2.edition-title {
   color: var(--grey);
   font-family: var(--font-family-title);
   font-weight: normal;
-  font-size: 1.1em;
+  font-size: var(--font-size-title-medium);
 }
 h2 a {
   color: var(--link-blue);
@@ -58,19 +58,19 @@ h1.edition,
 h2.edition {
   color: var(--black);
   font-family: var(--font-family-body);
-  font-size: 1.125em;
+  font-size: var(--font-size-title-medium);
   margin: 0;
   padding: 0;
   font-weight: normal;
 }
 
 h3 {
-  font-size: var(--font-size-label-medium);
+  font-size: var(--font-size-title-large);
 }
 /* TODO: Check if this class is still used. */
 h3.Question {
   font-family: var(--font-family-serif);
-  font-size: 1.2em;
+  font-size: var(--font-size-title-large);
   font-weight: normal;
   color: var(--brown);
   margin-top: var(--spacing-stack-sm);
@@ -79,7 +79,7 @@ h3.Question {
 }
 
 h4 {
-  font-size: 0.8125em;
+  font-size: var(--font-size-title-medium);
 }
 h4.publisher,
 h4.observer-count {
@@ -88,7 +88,7 @@ h4.observer-count {
 }
 h4.facetHead {
   font-family: var(--font-family-body);
-  font-size: 0.6875em;
+  font-size: var(--font-size-label-medium);
   font-weight: 700;
   color: var(--black);
   text-transform: uppercase;
@@ -114,13 +114,13 @@ h4.facetHead span.merge {
 }
 
 h5 {
-  font-size: 0.875em;
+  font-size: var(--font-size-title-small);
   font-family: var(--font-family-serif) !important;
   font-weight: normal !important;
 }
 
 h6 {
-  font-size: 0.6875em;
+  font-size: var(--font-size-label-medium);
 }
 
 .head h2 a {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #12372 

@mekarpeles adds via @jimchamp: and possibly closes #5349

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
refactor

### Technical
Replaces all raw `em` values in `headings.css` with design tokens and 
restores correct heading hierarchy. The core bug was `h3` using `--font-size-label-medium` (12px) — smaller than body text.

## Heading Scale After This PR
| Heading | Token | Size |
|---------|-------|------|
| h1 | `--font-size-headline-large` | 32px |
| h2 | `--font-size-headline-small` | 24px |
| h3 | `--font-size-title-large` | 22px |
| h4 | `--font-size-title-medium` | 16px |
| h5 | `--font-size-title-small` | 14px |
| h6 | `--font-size-label-medium` | 12px |

## Changes
- `static/css/base/headings.css` only — no other files touched

### Testing
Run npm run lint:css — should pass with no errors
Run npm run build-assets:css — should compile successfully
Visit localhost:8080 and check

### Screenshot
**Before**
<img width="1864" height="966" alt="Screenshot 2026-04-15 015751" src="https://github.com/user-attachments/assets/77a74e45-1399-4deb-9a9c-9da77fd8d852" />
**After**
<img width="1870" height="928" alt="Screenshot 2026-04-15 022245" src="https://github.com/user-attachments/assets/86652c2f-a44f-4b11-9d03-90ffaf00968d" />


### Stakeholders
@RayBB @lokesh 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
