### PR TITLE
Exclude dev DB dump from pre-commit fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,6 @@ repos:
       - id: end-of-file-fixer
         exclude: ^.*\.(po|pot|type|svg|ini|mr|mrc|pg_dump)$
       - id: mixed-line-ending
-        exclude: ^scripts/dev-instance/dev_db\.pg_dump$
         args:
           - --fix=lf
       - id: requirements-txt-fixer

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,6 @@ repos:
           - --fix=lf
       - id: requirements-txt-fixer
       - id: trailing-whitespace
-        exclude: ^scripts/dev-instance/dev_db\.pg_dump$
         args:
           - --markdown-linebreak-ext=md
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,12 +18,14 @@ repos:
       - id: check-yaml
       - id: detect-private-key
       - id: end-of-file-fixer
-        exclude: ^.*\.(po|pot|type|svg|ini|mr|mrc)$
+        exclude: ^.*\.(po|pot|type|svg|ini|mr|mrc|pg_dump)$
       - id: mixed-line-ending
+        exclude: ^scripts/dev-instance/dev_db\.pg_dump$
         args:
           - --fix=lf
       - id: requirements-txt-fixer
       - id: trailing-whitespace
+        exclude: ^scripts/dev-instance/dev_db\.pg_dump$
         args:
           - --markdown-linebreak-ext=md
 


### PR DESCRIPTION
Closes #12361 

Exclude `scripts/dev-instance/dev_db.pg_dump` from pre-commit hooks that may modify file formatting.

### Stakeholders
@RayBB 