### PR TITLE
Add "Needs: Submitter Input" label when PR changes are requested

### DIFF
--- a/.github/workflows/pr_changes_requested_labeler.yml
+++ b/.github/workflows/pr_changes_requested_labeler.yml
@@ -1,0 +1,30 @@
+name: pr_changes_requested_labeler
+on:
+  pull_request_review:
+    types:
+      - submitted
+env:
+  NODE_VERSION: '24'
+jobs:
+  label_pr:
+    if: ${{ github.repository == github.event.repository.full_name && github.event.review.state == 'changes_requested' }}
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - uses: actions/cache@v5
+        id: cache-octokit
+        with:
+          path: 'node_modules'
+          key: ${{ runner.os }}-node${{ env.NODE_VERSION }}-octokit-${{ hashFiles('**/package-lock.json') }}
+      - if: steps.cache-octokit.outputs.cache-hit != 'true'
+        run: npm install @octokit/action
+      - run: node scripts/gh_scripts/pr_changes_requested_labeler.mjs ${{ github.repository }} ${{ github.event.pull_request.number }} ${{ github.event.review.state }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/gh_scripts/README.md
+++ b/scripts/gh_scripts/README.md
@@ -19,6 +19,18 @@ The script does a case-insensitive search for a `closes #` statement in the newl
 The first https://github.com/internetarchive/openlibrary/labels/Priority%3A%200, https://github.com/internetarchive/openlibrary/labels/Priority%3A%201, or https://github.com/internetarchive/openlibrary/labels/Priority%3A%202 label that is found on the issue is added to the PR.
 If a lead is assigned to the issue, and the lead is not also the PR's author, the lead will be assigned to the PR.  Similar to the priority labels, only one lead can be assigned to a PR.
 
+## `pr_changes_requested_labeler.mjs`
+This script updates PR labels when a review requests changes.
+
+### Usage:
+<pre><b>node pr_changes_requested_labeler.mjs</b> repository pr_number review_state</pre>
+`repository` the repository owner and name (ex. `internetarchive/openlibrary`)
+`pr_number`  the pull request's identification number
+`review_state` the submitted GitHub review state
+
+### Details:
+When the review state is `changes_requested`, the script adds the https://github.com/internetarchive/openlibrary/labels/Needs%3A%20Submitter%20Input label to the PR and removes the https://github.com/internetarchive/openlibrary/labels/Needs%3A%20Response label if it is present.
+
 ## `issue_comment_bot.py`
 
 This script fetches issues that have new comments from contributors within the past number of hours, then posts a message to the team in our Slack channel.

--- a/scripts/gh_scripts/pr_changes_requested_labeler.mjs
+++ b/scripts/gh_scripts/pr_changes_requested_labeler.mjs
@@ -1,0 +1,83 @@
+/**
+ * Script to label a pull request when a reviewer requests changes.
+ *
+ * Usage:
+ * `node pr_changes_requested_labeler.mjs REPO_NAME PR_NUMBER REVIEW_STATE`
+ *
+ * Where:
+ * `REPO_NAME`     is the owner and repository (e.g. "internetarchive/openlibrary")
+ * `PR_NUMBER`     is the pull request number
+ * `REVIEW_STATE`  is the submitted review state (e.g. "changes_requested")
+ */
+import { fileURLToPath } from 'node:url';
+
+const SUBMITTER_INPUT_LABEL = 'Needs: Submitter Input'
+const RESPONSE_LABEL = 'Needs: Response'
+
+export function parseArgs(argv = process.argv) {
+    if (argv.length !== 5) {
+        throw new Error('Unexpected number of arguments.')
+    }
+
+    return {
+        fullRepoName: argv[2],
+        prNumber: Number(argv[3]),
+        reviewState: argv[4],
+    }
+}
+
+export function shouldHandleReview(reviewState) {
+    return reviewState?.toLowerCase() === 'changes_requested'
+}
+
+export async function syncLabels(octokit, fullRepoName, prNumber) {
+    const [repoOwner, repoName] = fullRepoName.split('/')
+
+    await octokit.request('POST /repos/{owner}/{repo}/issues/{issue_number}/labels', {
+        owner: repoOwner,
+        repo: repoName,
+        issue_number: prNumber,
+        labels: [SUBMITTER_INPUT_LABEL],
+        headers: {
+            'X-GitHub-Api-Version': '2022-11-28'
+        }
+    })
+
+    try {
+        await octokit.request('DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}', {
+            owner: repoOwner,
+            repo: repoName,
+            issue_number: prNumber,
+            name: RESPONSE_LABEL,
+            headers: {
+                'X-GitHub-Api-Version': '2022-11-28'
+            }
+        })
+    } catch (error) {
+        if (error.status !== 404) {
+            throw error
+        }
+    }
+}
+
+async function main() {
+    const { fullRepoName, prNumber, reviewState } = parseArgs()
+    if (!shouldHandleReview(reviewState)) {
+        console.log(`Review state "${reviewState}" does not require label updates.`)
+        return
+    }
+
+    const { Octokit } = await import('@octokit/action')
+    const octokit = new Octokit()
+    await syncLabels(octokit, fullRepoName, prNumber)
+    console.log(`Updated labels for PR #${prNumber}.`)
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+    try {
+        await main()
+    } catch (error) {
+        console.error(error.message)
+        process.exit(1)
+    }
+}


### PR DESCRIPTION
Closes #12375

feature

### Technical
- adds a `pull_request_review` workflow that runs when a review is submitted with `changes_requested`
- adds a dedicated script to apply `Needs: Submitter Input` and remove `Needs: Response` when present
- documents the new script alongside the existing GitHub automation scripts

### Testing
- `node --check scripts/gh_scripts/pr_changes_requested_labeler.mjs`
- `node --input-type=module` import smoke test for `parseArgs` and `shouldHandleReview`
- `ruby -e "require 'yaml'; YAML.load_file(\'.github/workflows/pr_changes_requested_labeler.yml\'); puts \"yaml ok\""`

### Screenshot
N/A

### Stakeholders
@RayBB
