### PR TITLE
Experiment with adding Server-Timings headers for fastapi

### DIFF
--- a/openlibrary/asgi_app.py
+++ b/openlibrary/asgi_app.py
@@ -16,6 +16,7 @@ from sentry_sdk import set_tag
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 import infogami
+from openlibrary.fastapi.internal.timings import server_timing_middleware
 from openlibrary.utils.request_context import set_context_from_fastapi
 from openlibrary.utils.sentry import Sentry, init_sentry
 
@@ -196,6 +197,8 @@ def create_app() -> FastAPI | None:
         set_context_from_fastapi(request)
         response = await call_next(request)
         return response
+
+    app.middleware("http")(server_timing_middleware)
 
     # setup_i18n is below set_context so that it can use the request.state.lang in set_context
     # because the handlers are called in reverse order

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -21,6 +21,7 @@ from openlibrary import accounts
 from openlibrary.catalog.add_book import load
 from openlibrary.core import cache
 from openlibrary.core import helpers as h
+from openlibrary.fastapi.internal.timings import monitor_as_server_timing
 from openlibrary.utils import dateutil, uniq
 from openlibrary.utils.isbn import (
     isbn_10_to_isbn_13,
@@ -623,6 +624,7 @@ def get_betterworldbooks_metadata(
         return betterworldbooks_fmt(isbn)
 
 
+@monitor_as_server_timing('bwb_api')
 def _get_betterworldbooks_metadata(
     isbn: str,
 ) -> BetterWorldBooksMetadata | BetterWorldBooksMetadataError:

--- a/openlibrary/fastapi/internal/timings.py
+++ b/openlibrary/fastapi/internal/timings.py
@@ -1,0 +1,76 @@
+"""
+Helpers for recording and reporting timing information in FastAPI handlers. The recorded
+times are visible in your browser's dev tools. Click on the request in the Networks panel,
+and then select the "Timing" tab to see a breakdown of the different timing entries recorded by
+the server.
+
+To use, add the `@monitor_as_server_timing('name')` decorator on any function you want to
+track. The argument is the name of the timing entry that will appear in dev tools.
+"""
+
+import asyncio
+import functools
+import time
+from collections.abc import Callable
+from contextvars import ContextVar
+
+from fastapi import Request
+
+# Per-request storage for timing entries
+_timings: ContextVar[dict[str, float] | None] = ContextVar("_timings", default=None)
+
+
+def record_timing(name: str, duration_ms: float) -> None:
+    """Add a timing entry if we're inside a tracked request."""
+    if (timings := _timings.get()) is not None:
+        timings[name] = duration_ms
+
+
+def monitor_as_server_timing(name: str):
+    """Decorator that measures execution time and records it to Server-Timing."""
+
+    def decorator(func: Callable):
+        @functools.wraps(func)
+        async def async_wrapper(*args, **kwargs):
+            start = time.perf_counter()
+            try:
+                return await func(*args, **kwargs)
+            finally:
+                duration_ms = (time.perf_counter() - start) * 1000
+                record_timing(name, duration_ms)
+
+        @functools.wraps(func)
+        def sync_wrapper(*args, **kwargs):
+            start = time.perf_counter()
+            try:
+                return func(*args, **kwargs)
+            finally:
+                duration_ms = (time.perf_counter() - start) * 1000
+                record_timing(name, duration_ms)
+
+        return async_wrapper if asyncio.iscoroutinefunction(func) else sync_wrapper
+
+    return decorator
+
+
+def build_server_timing_header(timings: dict[str, float]) -> str:
+    """Format timings as a Server-Timing header value."""
+    return ", ".join(f"{name};dur={duration:.1f}" for name, duration in timings.items())
+
+
+async def server_timing_middleware(request: Request, call_next):
+    if request.query_params.get("_timings") != "true":
+        return await call_next(request)
+
+    # Initialize a fresh timing dict for this request
+    token = _timings.set({})
+    try:
+        response = await call_next(request)
+    finally:
+        timings = _timings.get()
+        _timings.reset(token)
+
+    if timings:
+        response.headers["Server-Timing"] = build_server_timing_header(timings)
+
+    return response

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -23,6 +23,7 @@ from openlibrary.core import cache
 from openlibrary.core.env import get_ol_env
 from openlibrary.core.lending import add_availability
 from openlibrary.core.models import Edition
+from openlibrary.fastapi.internal.timings import monitor_as_server_timing
 from openlibrary.fastapi.models import SolrInternalsParams
 from openlibrary.i18n import gettext as _
 from openlibrary.plugins.openlibrary.processors import urlsafe
@@ -162,6 +163,7 @@ def process_facet_counts(
         yield field, list(process_facet(field, web.group(facets, 2)))
 
 
+@monitor_as_server_timing('solr_query')
 async def execute_solr_query_async(
     solr_path: str,
     params: dict | list[tuple[str, Any]],


### PR DESCRIPTION
Specifying `&_timings=true` adds the time taken by any tagged methods as a response header for fast api that can be seen in the dev tools.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="1917" height="878" alt="image" src="https://github.com/user-attachments/assets/8e532bf0-3eba-4892-9277-16893a0f8a17" />

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
