### PR TITLE
fix: remove duplicate fieldset/legend in advanced search form

### DIFF
--- a/openlibrary/templates/search/advancedsearch.html
+++ b/openlibrary/templates/search/advancedsearch.html
@@ -8,9 +8,6 @@
     <fieldset class="home">
       <legend>$_('Advanced Search')</legend>
       <input type="hidden" name="q" id="qtop">
-    </fieldset>
-    <fieldset class="home">
-      <legend>$_('Advanced Search')</legend>
       <div class="formElement">
         <label for="qtop-title">$_('Title')</label><br>
         <input type="text" class="siteSearch--advanced-input" name="title" id="qtop-title" placeholder="" size="35">


### PR DESCRIPTION
I was browsing the Advanced Search page and noticed the search form had what looked like a double border — a thin empty box appearing above the actual form fields. Curious, I opened DevTools and saw two `<fieldset class="home">` elements back-to-back, both with the same `<legend>Advanced Search</legend>` text.

Tracing it in `advancedsearch.html`, I found that the first fieldset contained only a hidden `<input>` and then immediately closed, while a second fieldset reopened with an identical legend and held all the visible form fields. This redundancy causes the extra border in the rendered page.

The fix consolidates the two into a single fieldset: the hidden input and all form fields now live under one `fieldset`/`legend` pair, which is the correct semantic structure.

**Changes:** 3 lines removed in `openlibrary/templates/search/advancedsearch.html` — no logic changes, no functional impact on form submission.

Fixes #12381