### PR TITLE
Fix #12381: Bug: Duplicate <legend> in Advanced Search form causing...

### DIFF
--- a/openlibrary/templates/search/advancedsearch.html
+++ b/openlibrary/templates/search/advancedsearch.html
@@ -8,9 +8,6 @@
     <fieldset class="home">
       <legend>$_('Advanced Search')</legend>
       <input type="hidden" name="q" id="qtop">
-    </fieldset>
-    <fieldset class="home">
-      <legend>$_('Advanced Search')</legend>
       <div class="formElement">
         <label for="qtop-title">$_('Title')</label><br>
         <input type="text" class="siteSearch--advanced-input" name="title" id="qtop-title" placeholder="" size="35">


### PR DESCRIPTION
## Summary
The Advanced Search form (`/advancedsearch`) contained two nested `<fieldset class="home">` elements, each with its own `<legend>Advanced Search</legend>`. This duplicate landmark/legend structure causes accessibility issues for screen readers. This PR merges them into a single fieldset.

## Changes
- Removed the redundant closing `</fieldset>`, opening `<fieldset class="home">`, and duplicate `<legend>` tags, consolidating the form into a single fieldset that contains both the hidden `#qtop` input and all the search fields.

## Testing
1. Visit `/advancedsearch` and inspect the form in DevTools — confirm there is now one `<fieldset>` with one `<legend>`.
2. Verify the hidden input `#qtop` is still present inside the fieldset.
3. Submit an advanced search query and confirm results load correctly.
4. Run `pre-commit run --all-files` — all checks pass.

Closes #12381