### PR TITLE
fix: remove duplicate legend in Advanced Search form (#12381)

### DIFF
--- a/openlibrary/templates/search/advancedsearch.html
+++ b/openlibrary/templates/search/advancedsearch.html
@@ -8,9 +8,6 @@
     <fieldset class="home">
       <legend>$_('Advanced Search')</legend>
       <input type="hidden" name="q" id="qtop">
-    </fieldset>
-    <fieldset class="home">
-      <legend>$_('Advanced Search')</legend>
       <div class="formElement">
         <label for="qtop-title">$_('Title')</label><br>
         <input type="text" class="siteSearch--advanced-input" name="title" id="qtop-title" placeholder="" size="35">


### PR DESCRIPTION
### Technical
Merged the two redundant <fieldset> tags into one. This removes the duplicate <legend>Advanced Search</legend> tag which was causing accessibility issues and redundant headings for screen readers.

### Testing
Manually verified that the form structure is correct and all input fields remain intact.

Closes #12381