### PR TITLE
fix: guard raw_resp None in search.json endpoints (OL-WEB-1YX1, OL-WEB-1Z0G)

### DIFF
--- a/openlibrary/fastapi/search.py
+++ b/openlibrary/fastapi/search.py
@@ -214,6 +214,9 @@ async def search_subjects_json(
         request_label="SUBJECT_SEARCH_API",
     )
 
+    if response.raw_resp is None:
+        return {"error": "Something went wrong"}
+
     # Backward compatibility
     raw_resp = response.raw_resp["response"]
     for doc in raw_resp["docs"]:
@@ -292,12 +295,17 @@ async def search_lists_json(
         request_label="LIST_SEARCH_API",
     )
 
+    if response.raw_resp is None:
+        return {"error": "Something went wrong"}
+
+    start = response.raw_resp["response"].get("start", params.offset or 0)
+
     if params.api == "next":
         # Match search.json
         return {
-            "numFound": response.num_found,
-            "num_found": response.num_found,
-            "start": response.raw_resp["response"].get("start", params.offset or 0),
+            "numFound": response.num_found or 0,
+            "num_found": response.num_found or 0,
+            "start": start,
             "q": params.q,
             "docs": response.docs,
         }
@@ -305,7 +313,7 @@ async def search_lists_json(
         # Default to the old API shape for a while, then we'll flip
         lists = web.ctx.site.get_many([doc["key"] for doc in response.docs])
         return {
-            "start": response.raw_resp["response"].get("start", params.offset or 0),
+            "start": start,
             "docs": [lst.preview() for lst in lists],
         }
 
@@ -334,9 +342,13 @@ async def search_authors_json(
         request_label="AUTHOR_SEARCH_API",
     )
 
+    if response.raw_resp is None:
+        return {"error": "Something went wrong"}
+
     # SIGH the public API exposes the key like this :(
     raw_resp = response.raw_resp["response"]
     for doc in raw_resp["docs"]:
-        doc["key"] = doc["key"].split("/")[-1]
+        if "key" in doc:
+            doc["key"] = doc["key"].split("/")[-1]
 
     return raw_resp

--- a/openlibrary/fastapi/search.py
+++ b/openlibrary/fastapi/search.py
@@ -226,6 +226,9 @@ async def search_subjects_json(
         request_label="SUBJECT_SEARCH_API",
     )
 
+    if response.raw_resp is None:
+        return {"numFound": 0, "start": 0, "docs": []}
+
     # Backward compatibility
     raw_resp = response.raw_resp["response"]
     for doc in raw_resp["docs"]:
@@ -307,12 +310,14 @@ async def search_lists_json(
         request_label="LIST_SEARCH_API",
     )
 
+    start = response.raw_resp["response"].get("start", params.offset or 0) if response.raw_resp else (params.offset or 0)
+
     if params.api == "next":
         # Match search.json
         return {
             "numFound": response.num_found,
             "num_found": response.num_found,
-            "start": response.raw_resp["response"].get("start", params.offset or 0),
+            "start": start,
             "q": params.q,
             "docs": response.docs,
         }
@@ -320,7 +325,7 @@ async def search_lists_json(
         # Default to the old API shape for a while, then we'll flip
         lists = web.ctx.site.get_many([doc["key"] for doc in response.docs])
         return {
-            "start": response.raw_resp["response"].get("start", params.offset or 0),
+            "start": start,
             "docs": [lst.preview() for lst in lists],
         }
 
@@ -349,9 +354,13 @@ async def search_authors_json(
         request_label="AUTHOR_SEARCH_API",
     )
 
+    if response.raw_resp is None:
+        return {"numFound": 0, "start": 0, "docs": []}
+
     # SIGH the public API exposes the key like this :(
     raw_resp = response.raw_resp["response"]
     for doc in raw_resp["docs"]:
-        doc["key"] = doc["key"].split("/")[-1]
+        if "key" in doc:
+            doc["key"] = doc["key"].split("/")[-1]
 
     return raw_resp

--- a/openlibrary/fastapi/search.py
+++ b/openlibrary/fastapi/search.py
@@ -227,7 +227,7 @@ async def search_subjects_json(
     )
 
     if response.raw_resp is None:
-        return {"numFound": 0, "start": 0, "docs": []}
+        return {"numFound": 0, "numFoundExact": True, "start": pagination.offset or 0, "docs": []}
 
     # Backward compatibility
     raw_resp = response.raw_resp["response"]
@@ -319,8 +319,8 @@ async def search_lists_json(
     if params.api == "next":
         # Match search.json
         return {
-            "numFound": response.num_found,
-            "num_found": response.num_found,
+            "numFound": response.num_found or 0,
+            "num_found": response.num_found or 0,
             "start": start,
             "q": params.q,
             "docs": response.docs,
@@ -359,7 +359,7 @@ async def search_authors_json(
     )
 
     if response.raw_resp is None:
-        return {"numFound": 0, "start": 0, "docs": []}
+        return {"numFound": 0, "numFoundExact": True, "start": params.offset or 0, "docs": []}
 
     # SIGH the public API exposes the key like this :(
     raw_resp = response.raw_resp["response"]

--- a/openlibrary/fastapi/search.py
+++ b/openlibrary/fastapi/search.py
@@ -227,7 +227,12 @@ async def search_subjects_json(
     )
 
     if response.raw_resp is None:
-        return {"numFound": 0, "numFoundExact": True, "start": pagination.offset or 0, "docs": []}
+        return {
+            "numFound": 0,
+            "numFoundExact": True,
+            "start": pagination.offset or 0,
+            "docs": [],
+        }
 
     # Backward compatibility
     raw_resp = response.raw_resp["response"]
@@ -359,7 +364,12 @@ async def search_authors_json(
     )
 
     if response.raw_resp is None:
-        return {"numFound": 0, "numFoundExact": True, "start": params.offset or 0, "docs": []}
+        return {
+            "numFound": 0,
+            "numFoundExact": True,
+            "start": params.offset or 0,
+            "docs": [],
+        }
 
     # SIGH the public API exposes the key like this :(
     raw_resp = response.raw_resp["response"]

--- a/openlibrary/fastapi/search.py
+++ b/openlibrary/fastapi/search.py
@@ -310,7 +310,11 @@ async def search_lists_json(
         request_label="LIST_SEARCH_API",
     )
 
-    start = response.raw_resp["response"].get("start", params.offset or 0) if response.raw_resp else (params.offset or 0)
+    start = (
+        response.raw_resp["response"].get("start", params.offset or 0)
+        if response.raw_resp
+        else (params.offset or 0)
+    )
 
     if params.api == "next":
         # Match search.json

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -1032,6 +1032,8 @@ async def _process_solr_search_response(response: SearchResponse, fields: str) -
     Handles the post-processing of the Solr response, which is common
     to both sync and async versions.
     """
+    if response.raw_resp is None:
+        return {"error": "Something went wrong"}
     processed_response = response.raw_resp["response"]
 
     if response.highlighting is not None:

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -652,10 +652,11 @@ def get_doc(doc: SolrDocument):
                 {
                     **ed,
                     'title': ed.get('title', 'Untitled'),
-                    'url': f"{ed.get('key', '')}/{urlsafe(ed.get('title', 'Untitled'))}",
+                    'url': f"{ed['key']}/{urlsafe(ed.get('title', 'Untitled'))}",
                 }
             )
             for ed in doc.get('editions', {}).get('docs', [])
+            if 'key' in ed
         ],
         ratings_average=doc.get('ratings_average', None),
         ratings_count=doc.get('ratings_count', None),

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -1084,7 +1084,13 @@ def _process_solr_search_response(response: SearchResponse, fields: str) -> dict
     """
     if response.raw_resp is None:
         # Solr returned an error; surface an empty-but-valid response
-        return {'numFound': 0, 'num_found': 0, 'start': 0, 'numFoundExact': True, 'docs': []}
+        return {
+            'numFound': 0,
+            'num_found': 0,
+            'start': 0,
+            'numFoundExact': True,
+            'docs': [],
+        }
     processed_response = response.raw_resp['response']
 
     if response.highlighting is not None:

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -652,7 +652,7 @@ def get_doc(doc: SolrDocument):
                 {
                     **ed,
                     'title': ed.get('title', 'Untitled'),
-                    'url': f"{ed['key']}/{urlsafe(ed.get('title', 'Untitled'))}",
+                    'url': f"{ed.get('key', '')}/{urlsafe(ed.get('title', 'Untitled'))}",
                 }
             )
             for ed in doc.get('editions', {}).get('docs', [])
@@ -1082,6 +1082,9 @@ def _process_solr_search_response(response: SearchResponse, fields: str) -> dict
     Handles the post-processing of the Solr response, which is common
     to both sync and async versions.
     """
+    if response.raw_resp is None:
+        # Solr returned an error; surface an empty-but-valid response
+        return {'numFound': 0, 'num_found': 0, 'start': 0, 'numFoundExact': True, 'docs': []}
     processed_response = response.raw_resp['response']
 
     if response.highlighting is not None:

--- a/openlibrary/tests/fastapi/test_search.py
+++ b/openlibrary/tests/fastapi/test_search.py
@@ -1,12 +1,13 @@
 """Basic tests for the FastAPI search endpoint."""
 
 import json
+from unittest.mock import patch
 from urllib.parse import urlencode
 
 import pytest
 
 from openlibrary.fastapi.search import PublicQueryOptions
-from openlibrary.plugins.worksearch.code import WorkSearchScheme
+from openlibrary.plugins.worksearch.code import SearchResponse, WorkSearchScheme
 
 
 @pytest.fixture
@@ -313,6 +314,49 @@ class TestSearchEndpoint:
         assert "fields" in call_kwargs
         assert isinstance(call_kwargs["fields"], list)
         assert call_kwargs["fields"] == expected_fields
+
+
+@pytest.fixture
+def solr_error_response():
+    """A SearchResponse with raw_resp=None, simulating a Solr error."""
+    return SearchResponse(
+        facet_counts=None,
+        sort="",
+        docs=[],
+        num_found=None,
+        solr_select="mock",
+        raw_resp=None,
+        error="Solr error",
+    )
+
+
+class TestSolrErrorHandling:
+    """Tests that search endpoints return stable empty responses when Solr errors."""
+
+    def test_subjects_json_solr_error(self, client, solr_error_response):
+        with patch("openlibrary.fastapi.search.run_solr_query_async", return_value=solr_error_response):
+            response = client.get("/search/subjects.json?q=test")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["numFound"] == 0
+        assert data["docs"] == []
+
+    def test_authors_json_solr_error(self, client, solr_error_response):
+        with patch("openlibrary.fastapi.search.run_solr_query_async", return_value=solr_error_response):
+            response = client.get("/search/authors.json?q=test")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["numFound"] == 0
+        assert data["docs"] == []
+
+    def test_lists_json_solr_error_next_api(self, client, solr_error_response):
+        with patch("openlibrary.fastapi.search.run_solr_query_async", return_value=solr_error_response):
+            response = client.get("/search/lists.json?q=test&api=next")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["numFound"] == 0
+        assert data["num_found"] == 0
+        assert data["docs"] == []
 
 
 def test_public_api_params():

--- a/openlibrary/tests/fastapi/test_search.py
+++ b/openlibrary/tests/fastapi/test_search.py
@@ -1,12 +1,13 @@
 """Basic tests for the FastAPI search endpoint."""
 
 import json
+from unittest.mock import patch
 from urllib.parse import urlencode
 
 import pytest
 
 from openlibrary.fastapi.search import PublicQueryOptions
-from openlibrary.plugins.worksearch.code import WorkSearchScheme
+from openlibrary.plugins.worksearch.code import SearchResponse, WorkSearchScheme
 
 
 @pytest.fixture
@@ -313,6 +314,42 @@ class TestSearchEndpoint:
         assert "fields" in call_kwargs
         assert isinstance(call_kwargs["fields"], list)
         assert call_kwargs["fields"] == expected_fields
+
+
+@pytest.fixture
+def solr_error_response():
+    """A SearchResponse with raw_resp=None, simulating a Solr error."""
+    return SearchResponse(
+        facet_counts=None,
+        sort="",
+        docs=[],
+        num_found=None,
+        solr_select="mock",
+        raw_resp=None,
+        error="Solr error",
+    )
+
+
+class TestSolrErrorHandling:
+    """Tests that search endpoints explicitly return an error when Solr errors."""
+
+    def test_subjects_json_solr_error(self, client, solr_error_response):
+        with patch("openlibrary.fastapi.search.run_solr_query_async", return_value=solr_error_response):
+            response = client.get("/search/subjects.json?q=test")
+        assert response.status_code == 200
+        assert response.json() == {"error": "Something went wrong"}
+
+    def test_authors_json_solr_error(self, client, solr_error_response):
+        with patch("openlibrary.fastapi.search.run_solr_query_async", return_value=solr_error_response):
+            response = client.get("/search/authors.json?q=test")
+        assert response.status_code == 200
+        assert response.json() == {"error": "Something went wrong"}
+
+    def test_lists_json_solr_error_next_api(self, client, solr_error_response):
+        with patch("openlibrary.fastapi.search.run_solr_query_async", return_value=solr_error_response):
+            response = client.get("/search/lists.json?q=test&api=next")
+        assert response.status_code == 200
+        assert response.json() == {"error": "Something went wrong"}
 
 
 def test_public_api_params():


### PR DESCRIPTION
## Summary

Fixes two Sentry production errors on `/search.json` and related search endpoints.

### Root Cause

`SearchResponse.from_solr_result()` leaves `raw_resp=None` when Solr returns an error. Multiple search endpoints then crashed accessing `raw_resp['response']` without checking for None first.

### Fixes

**OL-WEB-1YX1** — `TypeError: 'NoneType' object is not subscriptable` (~2,300 events)
- `_process_solr_search_response` in `code.py`: return an empty-but-valid response dict when `raw_resp is None` instead of crashing
- `search_subjects_json`, `search_authors_json`: guard `raw_resp` before accessing `["response"]`
- `search_lists_json`: extract `start` offset safely when `raw_resp is None`

**OL-WEB-1Z0G** — `KeyError: 'key'` (~171 events)
- `get_doc()` in `code.py`: use `ed.get('key', '')` for edition sub-documents from Solr expand queries, where `key` is not guaranteed present
- `search_authors_json`: guard `doc["key"]` before calling `.split()` on it

## Test plan

- [ ] Existing worksearch and fastapi model tests pass (`27 passed`)
- [ ] `ruff check` passes on modified files
- [ ] Sentry errors OL-WEB-1YX1 and OL-WEB-1Z0G should stop after deploy