### PR TITLE
fix: add .json suffix to check-ins route

### DIFF
--- a/openlibrary/fastapi/checkins.py
+++ b/openlibrary/fastapi/checkins.py
@@ -51,7 +51,7 @@ class CheckInResponse(BaseModel):
     id: int
 
 
-@router.post("/works/OL{work_id}W/check-ins")
+@router.post("/works/OL{work_id}W/check-ins.json")
 async def create_or_update_patron_check_in(
     work_id: int,
     data: CheckInRequest,


### PR DESCRIPTION
## Summary

Frontend POSTs to `/works/OL{work_id}W/check-ins.json` but FastAPI route only defined for `/works/OL{work_id}W/check-ins` causing 404.

## Fix

Added `.json` suffix to FastAPI router decorator.

## Testing

- Check-in submission on book pages returns 200 instead of 404

Closes #12391