### PR TITLE
move get_betterworldbooks_metadata and get_amazon_metadata out of AffiliateLinks template

### DIFF
--- a/openlibrary/macros/AffiliateLinks.html
+++ b/openlibrary/macros/AffiliateLinks.html
@@ -1,4 +1,4 @@
-$def with (title, opts, async_load=False)
+$def with (title, opts, async_load=False, bwb_metadata=None)
 
 $def affiliate_link(key, analytics_key, name, link, price='', price_note=''):
   <li class="prices-$key">
@@ -47,10 +47,10 @@ $def affiliate_link(key, analytics_key, name, link, price='', price_note=''):
 
       # Fetch price data
       if not is_bot() and prices and isbn:
-        bwb['price'] = opts.get('bwb_price')
+        bwb['price'] = bwb_metadata and bwb_metadata.get('price')
         if amazon:
-          amazon['price'] = opts.get('bwb_market_price')
-        if amazon and not amazon.get('price'):
+          amazon['price'] = bwb_metadata and bwb_metadata.get('market_price')
+        if amazon and not amazon['price']:
           amz_metadata = get_amazon_metadata(isbn, resources='prices')
           amazon['price'] = amz_metadata and amz_metadata.get('price')
 

--- a/openlibrary/macros/AffiliateLinks.html
+++ b/openlibrary/macros/AffiliateLinks.html
@@ -47,11 +47,10 @@ $def affiliate_link(key, analytics_key, name, link, price='', price_note=''):
 
       # Fetch price data
       if not is_bot() and prices and isbn:
-        bwb_metadata = get_betterworldbooks_metadata(isbn)
-        bwb['price'] = bwb_metadata and bwb_metadata.get('price')
+        bwb['price'] = opts.get('bwb_price')
         if amazon:
-          amazon['price'] = bwb_metadata and bwb_metadata.get('market_price')
-        if amazon and not amazon['price']:
+          amazon['price'] = opts.get('bwb_market_price')
+        if amazon and not amazon.get('price'):
           amz_metadata = get_amazon_metadata(isbn, resources='prices')
           amazon['price'] = amz_metadata and amz_metadata.get('price')
 

--- a/openlibrary/macros/AffiliateLinks.html
+++ b/openlibrary/macros/AffiliateLinks.html
@@ -1,4 +1,4 @@
-$def with (title, opts, async_load=False, bwb_metadata=None)
+$def with (title, opts, async_load=False, bwb_metadata=None, amz_metadata=None)
 
 $def affiliate_link(key, analytics_key, name, link, price='', price_note=''):
   <li class="prices-$key">
@@ -28,7 +28,8 @@ $def affiliate_link(key, analytics_key, name, link, price='', price_note=''):
         'link': 'https://www.betterworldbooks.com/%s' % (
           ('product/detail/-%s' % isbn) if isbn else ('search/results?q=' + title.replace(' ','%20'))
         ),
-        'price_note': _(' - includes shipping')
+        'price_note': _(' - includes shipping'),
+        'price': bwb_metadata and bwb_metadata.get('price')
       }
 
       amazon = {
@@ -36,6 +37,7 @@ $def affiliate_link(key, analytics_key, name, link, price='', price_note=''):
         'analytics_key': 'Amazon',
         'name': _('Amazon'),
         'link': 'https://www.amazon.com/dp/%s/?tag=%s' % (asin or isbn, affiliate_id('amazon')),
+        'price': bwb.get('market_price') or amz_metadata and amz_metadata.get('price')
       } if (asin or isbn) else None
 
       bookshop = {
@@ -44,15 +46,6 @@ $def affiliate_link(key, analytics_key, name, link, price='', price_note=''):
         'name': _('Bookshop.org'),
         'link': 'https://bookshop.org/a/%s/%s' % (affiliate_id('bookshop-org'), isbn),
       } if isbn else None
-
-      # Fetch price data
-      if not is_bot() and prices and isbn:
-        bwb['price'] = bwb_metadata and bwb_metadata.get('price')
-        if amazon:
-          amazon['price'] = bwb_metadata and bwb_metadata.get('market_price')
-        if amazon and not amazon['price']:
-          amz_metadata = get_amazon_metadata(isbn, resources='prices')
-          amazon['price'] = amz_metadata and amz_metadata.get('price')
 
       primary_stores = [store for store in [bwb, amazon] if store]
       more_stores = [store for store in [bookshop] if store]

--- a/openlibrary/macros/AffiliateLinks.html
+++ b/openlibrary/macros/AffiliateLinks.html
@@ -37,7 +37,7 @@ $def affiliate_link(key, analytics_key, name, link, price='', price_note=''):
         'analytics_key': 'Amazon',
         'name': _('Amazon'),
         'link': 'https://www.amazon.com/dp/%s/?tag=%s' % (asin or isbn, affiliate_id('amazon')),
-        'price': bwb.get('market_price') or amz_metadata and amz_metadata.get('price')
+        'price': (bwb_metadata and bwb_metadata.get('market_price')) or (amz_metadata and amz_metadata.get('price'))
       } if (asin or isbn) else None
 
       bookshop = {

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -12,7 +12,7 @@ from openlibrary.accounts import get_current_user
 from openlibrary.core import cache
 from openlibrary.core.fulltext import fulltext_search_async
 from openlibrary.core.lending import compose_ia_url, get_available
-from openlibrary.core.vendors import get_betterworldbooks_metadata
+from openlibrary.core.vendors import get_amazon_metadata, get_betterworldbooks_metadata
 from openlibrary.i18n import gettext as _
 from openlibrary.plugins.openlibrary.code import is_bot
 from openlibrary.plugins.openlibrary.lists import get_lists_async, get_user_lists
@@ -217,11 +217,17 @@ class AffiliateLinksPartial(PartialDataHandler):
         isbn = opts.get('isbn', '')
 
         bwb_metadata = None
+        amz_metadata = None
         if not is_bot() and opts.get('prices') and isbn:
             bwb_metadata = get_betterworldbooks_metadata(isbn)
+            amz_metadata = get_amazon_metadata(isbn)
 
         macro = web.template.Template.globals['macros'].AffiliateLinks(
-            title, opts, async_load=False, bwb_metadata=bwb_metadata
+            title,
+            opts,
+            async_load=False,
+            bwb_metadata=bwb_metadata,
+            amz_metadata=amz_metadata,
         )
         return {"partials": str(macro)}
 

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -12,7 +12,9 @@ from openlibrary.accounts import get_current_user
 from openlibrary.core import cache
 from openlibrary.core.fulltext import fulltext_search_async
 from openlibrary.core.lending import compose_ia_url, get_available
+from openlibrary.core.vendors import get_betterworldbooks_metadata
 from openlibrary.i18n import gettext as _
+from openlibrary.plugins.openlibrary.code import is_bot
 from openlibrary.plugins.openlibrary.lists import get_lists_async, get_user_lists
 from openlibrary.plugins.upstream.utils import render_macro
 from openlibrary.plugins.upstream.yearly_reading_goals import get_reading_goals
@@ -211,7 +213,16 @@ class AffiliateLinksPartial(PartialDataHandler):
         if len(args) < 2:
             raise ValueError("Unexpected amount of arguments")
 
-        macro = web.template.Template.globals['macros'].AffiliateLinks(args[0], args[1])
+        title, opts = args[0], args[1]
+        isbn = opts.get('isbn', '')
+
+        if not is_bot() and opts.get('prices') and isbn:
+            bwb_metadata = get_betterworldbooks_metadata(isbn)
+            if isinstance(bwb_metadata, dict):
+                opts['bwb_price'] = bwb_metadata.get('price')
+                opts['bwb_market_price'] = bwb_metadata.get('market_price')
+
+        macro = web.template.Template.globals['macros'].AffiliateLinks(title, opts)
         return {"partials": str(macro)}
 
 

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -216,13 +216,13 @@ class AffiliateLinksPartial(PartialDataHandler):
         title, opts = args[0], args[1]
         isbn = opts.get('isbn', '')
 
+        bwb_metadata = None
         if not is_bot() and opts.get('prices') and isbn:
             bwb_metadata = get_betterworldbooks_metadata(isbn)
-            if isinstance(bwb_metadata, dict):
-                opts['bwb_price'] = bwb_metadata.get('price')
-                opts['bwb_market_price'] = bwb_metadata.get('market_price')
 
-        macro = web.template.Template.globals['macros'].AffiliateLinks(title, opts)
+        macro = web.template.Template.globals['macros'].AffiliateLinks(
+            title, opts, async_load=False, bwb_metadata=bwb_metadata
+        )
         return {"partials": str(macro)}
 
 

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -220,7 +220,8 @@ class AffiliateLinksPartial(PartialDataHandler):
         amz_metadata = None
         if not is_bot() and opts.get('prices') and isbn:
             bwb_metadata = get_betterworldbooks_metadata(isbn)
-            amz_metadata = get_amazon_metadata(isbn)
+            if not (bwb_metadata and bwb_metadata.get('market_price')):
+                amz_metadata = get_amazon_metadata(isbn)
 
         macro = web.template.Template.globals['macros'].AffiliateLinks(
             title,

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -221,7 +221,7 @@ class AffiliateLinksPartial(PartialDataHandler):
         if not is_bot() and opts.get('prices') and isbn:
             bwb_metadata = get_betterworldbooks_metadata(isbn)
             if not (bwb_metadata and bwb_metadata.get('market_price')):
-                amz_metadata = get_amazon_metadata(isbn)
+                amz_metadata = get_amazon_metadata(isbn, resources='prices')
 
         macro = web.template.Template.globals['macros'].AffiliateLinks(
             title,


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #12271 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

- Moves the `get_betterworldbooks_metadata()` network call out of `AffiliateLinks.html` into `AffiliateLinksPartial.generate()` in
`partials.py`.
Changes :
`partials.py`: Pre-fetch BWB metadata in `AffiliateLinksPartial` and inject it into `opts`.
 `AffiliateLinks.html`: Remove the `get_betterworldbooks_metadata` call and read `bwb_price` and `bwb_market_price` directly from `opts` safely using `.get()`.



### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

- I tested the /partials/AffiliateLinks.json endpoint locally to verify that the Better World Books metadata is now being successfully intercepted and injected by the Python backend before rendering the template.
- the `data-opts` attribute in the response – it now includes `bwb_price` and `bwb_market_price`.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
