### PR TITLE
Add bulk search link to advanced search

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -5845,7 +5845,7 @@ msgid ""
 "remorse."
 msgstr ""
 
-#: bulk_search/bulk_search.html
+#: bulk_search/bulk_search.html search/advancedsearch.html
 msgid "Bulk Search (beta)"
 msgstr ""
 

--- a/openlibrary/templates/search/advancedsearch.html
+++ b/openlibrary/templates/search/advancedsearch.html
@@ -44,6 +44,7 @@
     <div class="searchPlus">
       <a href="https://openlibrary.org/search/howto">$_('How to search?')</a>
       <a href="/search/inside">$_('Full Text Search?')</a>
+      <a href="/search/bulk">$_('Bulk Search (beta)')</a>
     </div>
   </form>
 </div>


### PR DESCRIPTION
Closes #9715 

## Summary
Adds a `Bulk Search (beta)` link to the advanced search page so the bulk search feature is discoverable without exposing it broadly in the main search UI.

### Screenshot
Before
<img width="1552" height="918" alt="Screenshot 2026-04-17 at 05 19 37" src="https://github.com/user-attachments/assets/694d30a4-b1fe-4d77-9144-83c922407ef1" />
After
<img width="1552" height="918" alt="Screenshot 2026-04-17 at 05 12 35" src="https://github.com/user-attachments/assets/a2ef9986-70ee-48e8-b385-0ab43ea82ccb" />


### Stakeholders
@RayBB 
