### PR TITLE
Update `wrap_jsonp` to handle lists

### DIFF
--- a/openlibrary/fastapi/models.py
+++ b/openlibrary/fastapi/models.py
@@ -58,13 +58,19 @@ class PaginationLimit20(Pagination):
     limit: int = Field(20, ge=0, description="Maximum number of results to return.")
 
 
-def wrap_jsonp(request: Request, data: dict | str) -> Response:
+def wrap_jsonp(request: Request, data: dict | list | str) -> Response:
     """Wrap data in JSONP callback if callback param is present.
 
     Always returns a Response object.
-    Accepts either a dict (which will be JSON-serialized) or a pre-serialized JSON string.
+    Accepts a dict or list (which will be JSON-serialized), or a pre-serialized JSON string.
     """
-    json_string = json.dumps(data) if isinstance(data, dict) else data
+    if isinstance(data, str):
+        json_string = data
+    elif isinstance(data, (dict, list)):
+        json_string = json.dumps(data)
+    else:
+        raise TypeError(f"Unexpected type for JSON response: {type(data)}")
+
     if callback := request.query_params.get("callback"):
         if not JS_CALLBACK_RE.match(callback):
             raise ValueError("Invalid callback parameter: must be a valid JavaScript identifier (only letters, numbers, underscore, $, and . allowed)")

--- a/openlibrary/tests/fastapi/test_models.py
+++ b/openlibrary/tests/fastapi/test_models.py
@@ -73,6 +73,26 @@ class TestWrapJsonp:
         assert response.media_type == "application/javascript"
         assert response.body == b'cb({"key": "value"});'
 
+    def test_accepts_list_json(self):
+        """Should JSON-serialize list input."""
+        mock_request = MagicMock(spec=Request)
+        type(mock_request.query_params).get = MagicMock(return_value=None)
+
+        response = wrap_jsonp(mock_request, ["a", {"key": "value"}])
+
+        assert response.media_type == "application/json"
+        assert response.body == b'["a", {"key": "value"}]'
+
+    def test_list_with_callback(self):
+        """List input should work with callback."""
+        mock_request = MagicMock(spec=Request)
+        type(mock_request.query_params).get = MagicMock(return_value="cb")
+
+        response = wrap_jsonp(mock_request, ["a", {"key": "value"}])
+
+        assert response.media_type == "application/javascript"
+        assert response.body == b'cb(["a", {"key": "value"}]);'
+
 
 class TestParseCommaSeparatedList:
     """Tests for parse_comma_separated_list utility function.


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Addresses regression identified [here](https://github.com/internetarchive/openlibrary/pull/11922/files#r3097299043)

`starlette.responses.Response.render` is throwing an `AttributeError` when `data` is a `list`.  These changes ensure that lists are also serialized.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
