### PR TITLE
build: remove tests and partials.py from ruff/black formatting denylist

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,15 +73,12 @@ repos:
             |openlibrary/plugins/openlibrary/bulk_tag\.py
             |openlibrary/plugins/openlibrary/code\.py
             |openlibrary/plugins/openlibrary/lists\.py
-            |openlibrary/plugins/openlibrary/partials\.py
             |openlibrary/plugins/openlibrary/status\.py
             |openlibrary/plugins/upstream/addbook\.py
             |openlibrary/plugins/upstream/addtag\.py
             |openlibrary/plugins/upstream/code\.py
             |openlibrary/plugins/upstream/covers\.py
             |openlibrary/plugins/upstream/jsdef\.py
-            |openlibrary/plugins/upstream/tests/test_addbook\.py
-            |openlibrary/plugins/upstream/tests/test_models\.py
             |openlibrary/plugins/upstream/utils\.py
             |openlibrary/plugins/worksearch/code\.py
             |openlibrary/plugins/worksearch/schemes/__init__\.py
@@ -89,17 +86,12 @@ repos:
             |openlibrary/plugins/worksearch/schemes/lists\.py
             |openlibrary/plugins/worksearch/schemes/subjects\.py
             |openlibrary/plugins/worksearch/schemes/works\.py
-            |openlibrary/tests/core/lists/test_model\.py
-            |openlibrary/tests/fastapi/test_partials\.py
-            |openlibrary/tests/test_templates\.py
             |openlibrary/utils/form\.py
             |openlibrary/utils/request_context\.py
             |openlibrary/utils/schema\.py
-            |scripts/conftest\.py
             |scripts/find_duplicate_author\.py
             |scripts/monitoring/fail2ban_monitor\.py
             |scripts/monitoring/monitor\.py
-            |scripts/monitoring/tests/test_fail2ban_monitor\.py
             |scripts/update_stale_ocaid_references\.py
           )$
 
@@ -122,15 +114,12 @@ repos:
             |openlibrary/plugins/openlibrary/bulk_tag\.py
             |openlibrary/plugins/openlibrary/code\.py
             |openlibrary/plugins/openlibrary/lists\.py
-            |openlibrary/plugins/openlibrary/partials\.py
             |openlibrary/plugins/openlibrary/status\.py
             |openlibrary/plugins/upstream/addbook\.py
             |openlibrary/plugins/upstream/addtag\.py
             |openlibrary/plugins/upstream/code\.py
             |openlibrary/plugins/upstream/covers\.py
             |openlibrary/plugins/upstream/jsdef\.py
-            |openlibrary/plugins/upstream/tests/test_addbook\.py
-            |openlibrary/plugins/upstream/tests/test_models\.py
             |openlibrary/plugins/upstream/utils\.py
             |openlibrary/plugins/worksearch/code\.py
             |openlibrary/plugins/worksearch/schemes/__init__\.py
@@ -138,17 +127,12 @@ repos:
             |openlibrary/plugins/worksearch/schemes/lists\.py
             |openlibrary/plugins/worksearch/schemes/subjects\.py
             |openlibrary/plugins/worksearch/schemes/works\.py
-            |openlibrary/tests/core/lists/test_model\.py
-            |openlibrary/tests/fastapi/test_partials\.py
-            |openlibrary/tests/test_templates\.py
             |openlibrary/utils/form\.py
             |openlibrary/utils/request_context\.py
             |openlibrary/utils/schema\.py
-            |scripts/conftest\.py
             |scripts/find_duplicate_author\.py
             |scripts/monitoring/fail2ban_monitor\.py
             |scripts/monitoring/monitor\.py
-            |scripts/monitoring/tests/test_fail2ban_monitor\.py
             |scripts/update_stale_ocaid_references\.py
           )$
 

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -53,7 +53,7 @@ class ReadingGoalProgressPartial(PartialDataHandler):
     def generate(self) -> dict:
         year = self.year or datetime.now().year
         goal = get_reading_goals(year=year)
-        component = render_template('reading_goals/reading_goal_progress', [goal])
+        component = render_template("reading_goals/reading_goal_progress", [goal])
 
         return {"partials": str(component)}
 
@@ -66,16 +66,16 @@ class MyBooksDropperListsPartial(PartialDataHandler):
 
         dropper = render_template("lists/dropper_lists", user_lists)
         list_data = {
-            list_data['key']: {
-                'members': list_data['list_items'],
-                'listName': list_data['name'],
+            list_data["key"]: {
+                "members": list_data["list_items"],
+                "listName": list_data["name"],
             }
             for list_data in user_lists
         }
 
         return {
-            'dropper': str(dropper),
-            'listData': list_data,
+            "dropper": str(dropper),
+            "listData": list_data,
         }
 
 
@@ -112,14 +112,14 @@ class CarouselCardPartial(PartialDataHandler):
         cards = []
         for index, work in enumerate(search_results):
             lazy = index > self.MAX_VISIBLE_CARDS
-            editions = work.get('editions', {})
+            editions = work.get("editions", {})
             if not editions:
                 book = work
             elif isinstance(editions, list):
                 book = editions[0]
             else:
-                book = editions.get('docs', [None])[0]
-            book['authors'] = work.get('authors', [])
+                book = editions.get("docs", [None])[0]
+            book["authors"] = work.get("authors", [])
 
             cards.append(
                 render_template(
@@ -147,28 +147,28 @@ class CarouselCardPartial(PartialDataHandler):
 
     def _do_search_query(self, params: CarouselLoadMoreParams) -> list:
         fields = [
-            'key',
-            'title',
-            'subtitle',
-            'author_name',
-            'cover_i',
-            'ia',
-            'availability',
-            'id_project_gutenberg',
-            'id_project_runeberg',
-            'id_librivox',
-            'id_standard_ebooks',
-            'id_openstax',
-            'editions',
+            "key",
+            "title",
+            "subtitle",
+            "author_name",
+            "cover_i",
+            "ia",
+            "availability",
+            "id_project_gutenberg",
+            "id_project_runeberg",
+            "id_librivox",
+            "id_standard_ebooks",
+            "id_openstax",
+            "editions",
         ]
         query_params: dict = {"q": params.q}
         if params.hasFulltextOnly:
-            query_params['has_fulltext'] = 'true'
+            query_params["has_fulltext"] = "true"
 
         results = work_search(
             query_params,
             sort=params.sorts or "new",
-            fields=','.join(fields),
+            fields=",".join(fields),
             limit=params.limit,
             facet=False,
             offset=params.page,
@@ -181,7 +181,7 @@ class CarouselCardPartial(PartialDataHandler):
             limit=params.limit,
             page=params.page,
             subject=params.subject,
-            sorts=params.sorts.split(',') if params.sorts else [],
+            sorts=params.sorts.split(",") if params.sorts else [],
             advanced=True,
             safe_mode=True,
         )
@@ -189,15 +189,11 @@ class CarouselCardPartial(PartialDataHandler):
         return results if "error" not in results else []
 
     def _do_trends_query(self, params: CarouselLoadMoreParams) -> list:
-        return get_trending_books(
-            minimum=3, limit=params.limit, page=params.page, sort_by_count=False
-        )
+        return get_trending_books(minimum=3, limit=params.limit, page=params.page, sort_by_count=False)
 
     def _do_subjects_query(self, params: CarouselLoadMoreParams) -> list:
         publish_year = date_range_to_publish_year_filter(params.published_in)
-        subject = get_subject(
-            params.q, offset=params.page, limit=params.limit, publish_year=publish_year
-        )
+        subject = get_subject(params.q, offset=params.page, limit=params.limit, publish_year=publish_year)
         return subject.get("works", [])
 
 
@@ -214,16 +210,16 @@ class AffiliateLinksPartial(PartialDataHandler):
             raise ValueError("Unexpected amount of arguments")
 
         title, opts = args[0], args[1]
-        isbn = opts.get('isbn', '')
+        isbn = opts.get("isbn", "")
 
         bwb_metadata = None
         amz_metadata = None
-        if not is_bot() and opts.get('prices') and isbn:
+        if not is_bot() and opts.get("prices") and isbn:
             bwb_metadata = get_betterworldbooks_metadata(isbn)
-            if not (bwb_metadata and bwb_metadata.get('market_price')):
-                amz_metadata = get_amazon_metadata(isbn, resources='prices')
+            if not (bwb_metadata and bwb_metadata.get("market_price")):
+                amz_metadata = get_amazon_metadata(isbn, resources="prices")
 
-        macro = web.template.Template.globals['macros'].AffiliateLinks(
+        macro = web.template.Template.globals["macros"].AffiliateLinks(
             title,
             opts,
             async_load=False,
@@ -240,18 +236,16 @@ class SearchFacetsPartial(PartialDataHandler):
         self.sfw = sfw
         self.data = data
         user = get_current_user()
-        self.show_merge_authors = user and (
-            user.is_librarian() or user.is_super_librarian() or user.is_admin()
-        )
+        self.show_merge_authors = user and (user.is_librarian() or user.is_super_librarian() or user.is_admin())
 
     def generate(self) -> dict:
         raise NotImplementedError("Use generate_async instead")
 
     async def generate_async(self) -> dict:
-        path = self.data.get('path')
-        query = self.data.get('query', '')
-        parsed_qs = parse_qs(query.replace('?', ''))
-        param = self.data.get('param', {})
+        path = self.data.get("path")
+        query = self.data.get("query", "")
+        parsed_qs = parse_qs(query.replace("?", ""))
+        param = self.data.get("param", {})
 
         sort = None
         search_response = await do_search_async(
@@ -260,12 +254,12 @@ class SearchFacetsPartial(PartialDataHandler):
             rows=0,
             spellcheck_count=3,
             facet=True,
-            request_label='BOOK_SEARCH_FACETS',
+            request_label="BOOK_SEARCH_FACETS",
             sfw=self.sfw,
         )
 
         sidebar = render_template(
-            'search/work_search_facets',
+            "search/work_search_facets",
             param,
             facet_counts=search_response.facet_counts,
             async_load=False,
@@ -275,10 +269,10 @@ class SearchFacetsPartial(PartialDataHandler):
         )
 
         active_facets = render_template(
-            'search/work_search_selected_facets',
+            "search/work_search_selected_facets",
             param,
             search_response,
-            param.get('q', ''),
+            param.get("q", ""),
             path=path,
             query=parsed_qs,
         )
@@ -305,13 +299,11 @@ class FullTextSuggestionsPartial(PartialDataHandler):
         data = await fulltext_search_async(query)
         # Add caching headers only if there were no errors in the search results
         self.has_error = "error" in data
-        hits = data.get('hits', [])
-        if not hits['hits']:
-            macro = '<div></div>'
+        hits = data.get("hits", [])
+        if not hits["hits"]:
+            macro = "<div></div>"
         else:
-            macro = web.template.Template.globals['macros'].FulltextSearchSuggestion(
-                query, data
-            )
+            macro = web.template.Template.globals["macros"].FulltextSearchSuggestion(query, data)
         return {"partials": str(macro)}
 
 
@@ -334,11 +326,9 @@ class BookPageListsPartial(PartialDataHandler):
         results["hasLists"] = bool(lists)
 
         if not lists:
-            results["partials"].append(_('This work does not appear on any lists.'))
+            results["partials"].append(_("This work does not appear on any lists."))
         else:
-            query = "seed_count:[2 TO *] seed:(%s)" % " OR ".join(
-                f'"{k}"' for k in keys
-            )
+            query = "seed_count:[2 TO *] seed:(%s)" % " OR ".join(f'"{k}"' for k in keys)
             all_url = "/search/lists?q=" + web.urlquote(query) + "&sort=last_modified"
             lists_template = render_template("lists/carousel", lists, all_url)
             results["partials"].append(str(lists_template))
@@ -395,25 +385,25 @@ class LazyCarouselPartial(PartialDataHandler):
             layout=self.params.layout,
             fallback=self.params.fallback,
             safe_mode=self.params.safe_mode,
-            books_data=books['docs'],
+            books_data=books["docs"],
         )
-        return {"partials": str(macro['__body__'])}
+        return {"partials": str(macro["__body__"])}
 
 
 _CAROUSEL_FIELDS = [
-    'key',
-    'title',
-    'subtitle',
-    'editions',
-    'author_name',
-    'availability',
-    'cover_i',
-    'ia',
-    'id_project_gutenberg',
-    'id_librivox',
-    'id_standard_ebooks',
-    'id_openstax',
-    'providers',
+    "key",
+    "title",
+    "subtitle",
+    "editions",
+    "author_name",
+    "availability",
+    "cover_i",
+    "ia",
+    "id_project_gutenberg",
+    "id_librivox",
+    "id_standard_ebooks",
+    "id_openstax",
+    "providers",
 ]
 
 _SAFE_MODE_FILTER = '-subject:"content_warning:cover"'
@@ -430,10 +420,7 @@ class CarouselData(TypedDict):
     engine="memcache",
     # TODO: move this into the cache decorator so it supports hashing like memcache_memoize does
     key=lambda query, sort, limit, has_fulltext_only, safe_mode: (
-        "LazyCarouselData-"
-        + md5(
-            f"{query}-{sort}-{limit}-{has_fulltext_only}-{safe_mode}".encode()
-        ).hexdigest()
+        "LazyCarouselData-" + md5(f"{query}-{sort}-{limit}-{has_fulltext_only}-{safe_mode}".encode()).hexdigest()
     ),
     expires=300,
     cacheable=lambda key, value: "error" not in value,
@@ -452,13 +439,13 @@ async def gather_lazy_carousel_data_async(
     RawQueryCarousel.html when books_data is not pre-fetched.
     """
     if safe_mode and _SAFE_MODE_FILTER not in query:
-        effective_query = f'{query} {_SAFE_MODE_FILTER}'.strip()
+        effective_query = f"{query} {_SAFE_MODE_FILTER}".strip()
     else:
         effective_query = query
 
-    search_params: dict = {'q': effective_query}
+    search_params: dict = {"q": effective_query}
     if has_fulltext_only:
-        search_params['has_fulltext'] = 'true'
+        search_params["has_fulltext"] = "true"
 
     results = await work_search_async(
         search_params,
@@ -466,14 +453,14 @@ async def gather_lazy_carousel_data_async(
         fields=",".join(_CAROUSEL_FIELDS),
         limit=limit,
         facet=False,
-        request_label='BOOK_CAROUSEL',
+        request_label="BOOK_CAROUSEL",
     )
     return_dict: CarouselData = {
-        'docs': results.get('docs', []),
+        "docs": results.get("docs", []),
     }
     # Add error to make sure we don't cache
-    if 'error' in results:
-        return_dict['error'] = results['error']
+    if "error" in results:
+        return_dict["error"] = results["error"]
     return return_dict
 
 

--- a/openlibrary/tests/test_templates.py
+++ b/openlibrary/tests/test_templates.py
@@ -16,9 +16,7 @@ def get_template_filenames():
     return map(Path, template_files)
 
 
-def try_parse_template(
-    template_text: str, filename: Path
-) -> tuple[bool, str | Exception | None]:
+def try_parse_template(template_text: str, filename: Path) -> tuple[bool, str | Exception | None]:
     try:
         Template(template_text, str(filename))
         return True, None
@@ -44,10 +42,9 @@ def test_noopener_noreferrer(filename: Path):
     a_tags = re.findall(r"<a\s+([^>]+)>", content, re.IGNORECASE)
     for attrs in a_tags:
         if 'target="_blank"' in attrs or "target='_blank'" in attrs:
-            assert (
-                'rel="noopener noreferrer"' in attrs
-                or "rel='noopener noreferrer'" in attrs
-            ), f"Missing rel='noopener noreferrer' on external link in {filename}"
+            assert 'rel="noopener noreferrer"' in attrs or "rel='noopener noreferrer'" in attrs, (
+                f"Missing rel='noopener noreferrer' on external link in {filename}"
+            )
 
 
 def test_login_template_does_not_bind_password_value():

--- a/scripts/conftest.py
+++ b/scripts/conftest.py
@@ -88,16 +88,12 @@ def pytest_ignore_collect(collection_path, config):
 
     # If this is in the scripts directory but not in the tests subdirectory,
     # we need to decide whether to skip it
-    if collection_path.is_relative_to(
-        scripts_dir
-    ) and not collection_path.is_relative_to(tests_dir):
+    if collection_path.is_relative_to(scripts_dir) and not collection_path.is_relative_to(tests_dir):
         # Allow test files even if they're not in tests/ subdirectory
         if "test_" in collection_path.name or "_test.py" in collection_path.name:
             return None
         # Ignore __pycache__ and hidden directories/files
-        if "__pycache__" in collection_path.name or collection_path.name.startswith(
-            "."
-        ):
+        if "__pycache__" in collection_path.name or collection_path.name.startswith("."):
             return True
         # For Python files, skip them unless they're test files
         if collection_path.suffix == ".py" and collection_path.parent != tests_dir:

--- a/scripts/monitoring/tests/test_fail2ban_monitor.py
+++ b/scripts/monitoring/tests/test_fail2ban_monitor.py
@@ -19,9 +19,7 @@ def test_get_fail2ban_counts():
     mock_result = MagicMock()
     mock_result.stdout = FAKE_FAIL2BAN_OUTPUT
 
-    with patch(
-        "scripts.monitoring.fail2ban_monitor.bash_run", return_value=mock_result
-    ):
+    with patch("scripts.monitoring.fail2ban_monitor.bash_run", return_value=mock_result):
         failed, banned = get_fail2ban_counts("nginx-429")
 
     assert failed == 193


### PR DESCRIPTION
These files were previously protected from ruff-format because they were touched by active open PRs. Those PRs have since been merged, so the files should now be formatted by ruff by default.

Removed from both ruff-format exclude and black files lists:
- openlibrary/plugins/openlibrary/partials.py
- openlibrary/plugins/upstream/tests/test_addbook.py
- openlibrary/plugins/upstream/tests/test_models.py
- openlibrary/tests/core/lists/test_model.py
- openlibrary/tests/fastapi/test_partials.py
- openlibrary/tests/test_templates.py
- scripts/conftest.py
- scripts/monitoring/tests/test_fail2ban_monitor.py

pre-commit.ci will auto-format these files as needed.

<!-- What issue does this PR close? -->
Closes #12260 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
