### PR TITLE
Fix multiple Connection instances in webpy breaking RunAs

### DIFF
--- a/openlibrary/utils/request_context.py
+++ b/openlibrary/utils/request_context.py
@@ -213,9 +213,6 @@ def set_context_from_fastapi(request: Request) -> None:
         hhcl=request.headers.get("X-HHCL"),
     )
 
-    # When called from web.py, web.ctx._parsed_cookies is already set.
-    # When called from FastAPI, we need to set it.
-    # create_site() automatically uses the cookie to set the auth token
     s = create_site()
     cookie_name = config.get("login_cookie_name", "session")
     if cookie_value := request.cookies.get(cookie_name):

--- a/openlibrary/utils/request_context.py
+++ b/openlibrary/utils/request_context.py
@@ -40,21 +40,6 @@ req_context: ContextVar[RequestContextVars] = ContextVar("req_context")
 site: ContextVar[Site] = ContextVar("site")
 
 
-def setup_site(request: Request | None = None):
-    """
-    When called from web.py, web.ctx._parsed_cookies is already set.
-    When called from FastAPI, we need to set it.
-    create_site() automatically uses the cookie to set the auth token
-    """
-    s = create_site()
-    if request:
-        cookie_name = config.get("login_cookie_name", "session")
-        if cookie_value := request.cookies.get(cookie_name):
-            s._conn.set_auth_token(unquote(cookie_value))
-
-    site.set(s)
-
-
 # Keep in sync with scripts/obfi.sh (obfi_grep_bots) and docker/web_nginx.conf ($is_sus_user_agent).
 # cdrini to DRY obfi.sh side.
 USER_AGENT_BOTS = [
@@ -198,7 +183,7 @@ def set_context_from_legacy_web_py() -> None:
         hhcl=web.ctx.env.get("HTTP_X_HHCL"),
     )
 
-    setup_site()
+    site.set(web.ctx.site)
     req_context.set(
         RequestContextVars(
             x_forwarded_for=web.ctx.env.get("HTTP_X_FORWARDED_FOR"),
@@ -228,7 +213,15 @@ def set_context_from_fastapi(request: Request) -> None:
         hhcl=request.headers.get("X-HHCL"),
     )
 
-    setup_site(request)
+    # When called from web.py, web.ctx._parsed_cookies is already set.
+    # When called from FastAPI, we need to set it.
+    # create_site() automatically uses the cookie to set the auth token
+    s = create_site()
+    cookie_name = config.get("login_cookie_name", "session")
+    if cookie_value := request.cookies.get(cookie_name):
+        s._conn.set_auth_token(unquote(cookie_value))
+
+    site.set(s)
     req_context.set(
         RequestContextVars(
             x_forwarded_for=request.headers.get("X-Forwarded-For"),


### PR DESCRIPTION
Part of #11918 . Fixes specifically RunAs not working correctly sometimes when triggered from webpy endpoints.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Tested locally:
- ✅ Login works
- ✅ Logout works
- ✅ "Log in as user" works
- ✅ Tested @jimchamp 's [case here](https://github.com/internetarchive/openlibrary/pull/12085#issuecomment-4272182293) and it now correctly displays the user in the transaction: 
<img width="1297" height="66" alt="image" src="https://github.com/user-attachments/assets/1d282a48-3416-4507-898f-ea593a49aef1" />
- [ ] Needs thorough testing on testing.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB @jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
