### PR TITLE
fix: remove unused  parameter from welcome.html

### DIFF
--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -16,7 +16,7 @@ $add_metatag(property="og:site_name", content="Open Library")
 
   $:macros.BookPreview('')
 
-  $:render_template("home/welcome", test=test)
+  $:render_template("home/welcome")
 
   $if not test:
     $:macros.QueryCarousel(query='trending_score_hourly_sum:[1 TO *] readinglog_count:[4 TO *]', title=_('Trending Books'), key="trending", sort='trending', has_fulltext_only=False, user_lang_only=True)

--- a/openlibrary/templates/home/welcome.html
+++ b/openlibrary/templates/home/welcome.html
@@ -1,5 +1,3 @@
-$def with (test=False)
-
 <div class="carousel-section">
   <div class="carousel-section-header">
     <h2 class="home-h2">$_("Welcome to Open Library")</h2>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #12320

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes the unused `test` parameter from `welcome.html` and the one place it was passed in `index.html`.


### Technical
<!-- What should be noted about the implementation? -->
- Removed `$def with (test=False)` from `templates/home/welcome.html`
- Removed `test=test` argument from `render_template("home/welcome")` in `templates/home/index.html`

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Run `docker compose up`
2. Visit http://localhost:8080
3. Confirm the homepage loads correctly with all carousels visible

### Screenshot
Before:
<img width="1512" height="859" alt="Screenshot 2026-04-18 at 11 03 30 PM" src="https://github.com/user-attachments/assets/866326f9-1074-45cd-b37b-85f5b0f3a354" />

After:
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="1512" height="859" alt="Screenshot 2026-04-18 at 10 59 26 PM" src="https://github.com/user-attachments/assets/c4b78755-5b7a-4f85-aaa8-4310db91b1db" />
The test parameter was unused, so removing it changes nothing visually. Both before and after screenshots will look identical.

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
