### PR TITLE
Don't show trap links to recognized bots

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1234,6 +1234,7 @@ def is_bot():
     return req_context.get().is_bot
 
 
+@public
 def is_recognized_bot():
     # Reads from the request-scoped ContextVar set by set_context_from_legacy_web_py()
     # (web.py) or set_context_from_fastapi() — the web.py equivalent of web.ctx.

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -59,13 +59,14 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_super_li
           alt="$_('Open Library logo')"/>
       </div>
     </a>
-    $# detect-missing-i18n-skip-line
-    <a
-      href="$changequery(dict(show_page_status=1))"
-      style="color:transparent;position:absolute;pointer-events:none;"
-      tabindex="-1"
-      aria-hidden="true"
-    >Page Status</a>
+    $if not is_recognized_bot():
+      $# detect-missing-i18n-skip-line
+      <a
+        href="$changequery(dict(show_page_status=1))"
+        style="color:transparent;position:absolute;pointer-events:none;"
+        tabindex="-1"
+        aria-hidden="true"
+      >Page Status</a>
   </div>
 
   $ browseProps = {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->
Note: Pre-existing bug! We need to update our caching prethread to copy over both `is_bot` and `is_recognized_bot`. Currently we have cache leak.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Confirmed locally trap link still shows. Put on prod, saw a drop in identifying bots hitting trap links:

`sudo tac /1/var/log/nginx/access.log | obfi_grep_bots -v | grep 'show_page_status=1' | obfi_count_minute`

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
