### PR TITLE
Replace caching prethread with simpler request context copy-over

### DIFF
--- a/openlibrary/core/admin.py
+++ b/openlibrary/core/admin.py
@@ -186,15 +186,11 @@ def get_unique_logins_since(since_days=30):
 
 
 def get_cached_unique_logins_since(since_days=30):
-    from openlibrary.plugins.openlibrary.home import caching_prethread
-
-    twelve_hours = 60 * 60 * 12
-    key_prefix = "logins_since"
     mc = cache.memcache_memoize(
         get_unique_logins_since,
-        key_prefix=key_prefix,
-        timeout=twelve_hours,
-        prethread=caching_prethread(),
+        "logins_since",
+        timeout=60 * 60 * 12,  # 12 hours
+        cache_request_context=True,
     )
     return mc(since_days=since_days)
 

--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -16,10 +16,11 @@ import web
 
 from infogami import config
 from infogami.infobase.client import Nothing
-from infogami.utils import stats
+from infogami.utils import delegate, stats
 from openlibrary.core.helpers import NothingEncoder
 from openlibrary.utils import olmemcache
 from openlibrary.utils.dateutil import MINUTE_SECS
+from openlibrary.utils.request_context import RequestContextVars, req_context, set_context_from_legacy_web_py
 
 __all__ = [
     "Cache",
@@ -49,9 +50,10 @@ class memcache_memoize[**P, T]:
 
     :param f: function to be memozied
     :param key_prefix: key prefix used in memcache to store memoized results. A random value will be used if not specified.
-    :param servers: list of  memcached servers, each specified as "ip:port"
     :param timeout: timeout in seconds after which the return value must be updated
-    :param prethread: Function to call on the new thread to set it up
+    :param cache_request_context: Whether to cache the request context along with the value. This is useful
+        when the value depends on things like the user language, bot status, etc. Note not all variables in the
+        request context are forwarded to the background thread: see `RequestContextVars.copy_for_cache_thread`.
     """
 
     def __init__(
@@ -59,19 +61,19 @@ class memcache_memoize[**P, T]:
         f: Callable[P, T],
         key_prefix: str | None = None,
         timeout: int = MINUTE_SECS,
-        prethread: Callable[[], None] | None = None,
-        hash_args: bool = False,
+        hash_args: bool = True,
+        cache_request_context: bool = False,
     ):
         """Creates a new memoized function for ``f``."""
         self.f: Callable[P, T] = f
         self.key_prefix = key_prefix or self._generate_key_prefix()
         self.timeout = timeout
+        self.cache_request_context = cache_request_context
 
         self._memcache: memcache.Client | None = None
 
         self.stats = web.storage(calls=0, hits=0, updates=0, async_updates=0)
         self.active_threads: dict[str, threading.Thread] = {}
-        self.prethread = prethread
         self.hash_args = hash_args
 
     @property
@@ -106,10 +108,9 @@ class memcache_memoize[**P, T]:
         Returns the cached value when available. Computes and adds the result
         to memcache when not available. Updates asynchronously after timeout.
         """
-
         self.stats.calls += 1
 
-        value_time = self.memcache_get(args, kw)
+        value_time = self.memcache_get(*args, **kw)
 
         if value_time is None:
             self.stats.updates += 1
@@ -120,26 +121,37 @@ class memcache_memoize[**P, T]:
             value, t = value_time
             if t + self.timeout < time.time():
                 self.stats.async_updates += 1
-                self.update_async(*args, **kw)
+                background_req_context = None
+                if self.cache_request_context:
+                    background_req_context = req_context.get().copy_for_cache_thread()
+                self.update_async(background_req_context, *args, **kw)
 
         return value
 
-    def update_async(self, *args: P.args, **kw: P.kwargs) -> None:
+    def update_async(self, background_req_context: RequestContextVars | None, /, *args: P.args, **kw: P.kwargs) -> None:
         """Starts the update process asynchronously."""
-        t = threading.Thread(target=self._update_async_worker, args=args, kwargs=kw)
+        t = threading.Thread(target=self._update_async_worker, args=(background_req_context, *args), kwargs=kw)
         self.active_threads[t.name] = t
         t.start()
 
-    def _update_async_worker(self, *args: P.args, **kw: P.kwargs) -> None:
-        key = self.compute_key(args, kw) + "/flag"
+    def _update_async_worker(
+        self,
+        background_req_context: RequestContextVars | None,
+        /,
+        *args: P.args,
+        **kw: P.kwargs,
+    ) -> None:
+        key = self.compute_key(*args, **kw) + "/flag"
 
         if not self.memcache.add(key, "true"):
             # already somebody else is computing this value.
             return
 
         try:
-            if self.prethread:
-                self.prethread()
+            if background_req_context:
+                delegate.fakeload()
+                set_context_from_legacy_web_py(background_req_context)
+
             self.update(*args, **kw)
         finally:
             # Remove current thread from active threads
@@ -153,10 +165,10 @@ class memcache_memoize[**P, T]:
 
         Returns the computed value.
         """
+        key = self.compute_key(*args, **kw)
         value = self.f(*args, **kw)
         t = time.time()
-
-        self.memcache_set(args, kw, value, t)
+        self.memcache_set(key, value, t)
         return value, t
 
     def join_threads(self) -> None:
@@ -180,9 +192,12 @@ class memcache_memoize[**P, T]:
             return f"{hashlib.md5(a.encode('utf-8')).hexdigest()}"
         return a
 
-    def compute_key(self, args: tuple, kw: dict) -> str:
+    def compute_key(self, *args: P.args, **kw: P.kwargs) -> str:
         """Computes memcache key for storing result of function call with given arguments."""
-        key = self.key_prefix + "$" + self.encode_args(args, kw)
+        key = f"{self.key_prefix}"
+        if self.cache_request_context:
+            key += f"${self.json_encode(req_context.get().copy_for_cache_thread().__dict__)}"
+        key += f"${self.encode_args(args, kw)}"
         return key.replace(" ", "_")  # XXX: temporary fix to handle spaces in the arguments
 
     def json_encode(self, value: Any) -> str:
@@ -196,31 +211,30 @@ class memcache_memoize[**P, T]:
             cls=NothingEncoder,
         )
 
-    def memcache_set(self, args: tuple, kw: dict, value: T, time: float) -> None:
+    def memcache_set(self, key: str, value: T, time: float) -> None:
         """Adds value and time to memcache. Key is computed from the arguments."""
-        key = self.compute_key(args, kw)
         json_data = self.json_encode([value, time])
 
         stats.begin("memcache.set", key=key)
         self.memcache.set(key, json_data)
         stats.end()
 
-    def memcache_delete(self, args: tuple, kw: dict) -> None:
-        key = self.compute_key(args, kw)
+    def memcache_delete(self, key: str) -> None:
         stats.begin("memcache.delete", key=key)
         self.memcache.delete(key)
         stats.end()
 
-    def memcache_delete_by_args(self, *args, **kw):
+    def memcache_delete_by_args(self, *args: P.args, **kw: P.kwargs):
         """A helper method to let you pass in arguments normally instead of as a tuple and dict"""
-        self.memcache_delete(args, kw)
+        key = self.compute_key(*args, **kw)
+        self.memcache_delete(key)
 
-    def memcache_get(self, args: tuple, kw: dict) -> tuple[T, float] | None:
+    def memcache_get(self, *args: P.args, **kw: P.kwargs) -> tuple[T, float] | None:
         """Reads the value from memcache. Key is computed from the arguments.
 
         Returns (value, time) when the value is available, None otherwise.
         """
-        key = self.compute_key(args, kw)
+        key = self.compute_key(*args, **kw)
         stats.begin("memcache.get", key=key)
         json_str = cast(str, self.memcache.get(key))
         stats.end(hit=bool(json_str))

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -658,7 +658,8 @@ def get_loans_of_user(user_key: str) -> list[Loan]:
     if account and account.itemname:
         loans += _get_ia_loans_of_user(account.itemname)
     # Set patron's loans in cache w/ now timestamp
-    get_cached_loans_of_user.memcache_set((user_key,), {}, loans or [], time.time())  # rehydrate cache
+    cache_key = get_cached_loans_of_user.compute_key(user_key)
+    get_cached_loans_of_user.memcache_set(cache_key, loans or [], time.time())  # rehydrate cache
     return loans
 
 
@@ -682,9 +683,13 @@ def get_user_waiting_loans(user_key: str) -> list[WaitingLoan]:
     try:
         account = OpenLibraryAccount.get_by_key(user_key)
         itemname = account.itemname if account else None
-        result = WaitingLoan.query(userid=itemname)
-        get_cached_user_waiting_loans.memcache_set((user_key,), {}, result or [], time.time())  # rehydrate cache
-        return result or []
+        result = WaitingLoan.query(userid=itemname) or []
+
+        # rehydrate cache
+        cache_key = get_cached_user_waiting_loans.compute_key(user_key)
+        get_cached_user_waiting_loans.memcache_set(cache_key, result, time.time())
+
+        return result
     except JSONDecodeError:
         return []
 

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -1003,23 +1003,13 @@ class opds_home(delegate.page):
             return catalog.model_dump()
 
         def get_cached_homepage():
-            from openlibrary.plugins.openlibrary.code import is_bot
-            from openlibrary.plugins.openlibrary.home import caching_prethread
             from openlibrary.utils import dateutil
 
-            five_minutes = 5 * dateutil.MINUTE_SECS
-            lang = web.ctx.lang
-            key = f"home.homepage-opds.{lang}"
-            cookies = web.cookies()
-            if cookies.get("pd", False):
-                key += ".pd"
-            if cookies.get("sfw", ""):
-                key += ".sfw"
-            if is_bot():
-                key += ".bot"
-
             mc = cache.memcache_memoize(
-                build_homepage, key, timeout=five_minutes, prethread=caching_prethread()
+                build_homepage,
+                "home.homepage-opds",
+                timeout=5 * dateutil.MINUTE_SECS,
+                cache_request_context=True,
             )
             page = mc()
 

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -18,10 +18,6 @@ from openlibrary.plugins.upstream.utils import (
 )
 from openlibrary.plugins.worksearch import search, subjects
 from openlibrary.utils import dateutil
-from openlibrary.utils.request_context import (
-    req_context,
-    set_context_from_legacy_web_py,
-)
 
 logger = logging.getLogger("openlibrary.home")
 
@@ -38,7 +34,7 @@ CAROUSELS_PRESETS = {
 }
 
 
-def get_homepage(devmode):
+def get_homepage(devmode: bool):
     try:
         stats = admin.get_stats(use_mock_data=devmode)
     except Exception:
@@ -55,20 +51,13 @@ def get_homepage(devmode):
 
 
 def get_cached_homepage():
-    from openlibrary.plugins.openlibrary.code import is_bot
+    mc = cache.memcache_memoize(
+        get_homepage,
+        "home.homepage",
+        timeout=5 * dateutil.MINUTE_SECS,
+        cache_request_context=True,
+    )
 
-    five_minutes = 5 * dateutil.MINUTE_SECS
-    lang = web.ctx.lang
-    key = f"home.homepage.{lang}"
-    cookies = web.cookies()
-    if cookies.get("pd", False):
-        key += ".pd"
-    if cookies.get("sfw", ""):
-        key += ".sfw"
-    if is_bot():
-        key += ".bot"
-
-    mc = cache.memcache_memoize(get_homepage, key, timeout=five_minutes, prethread=caching_prethread())
     devmode = "dev" in web.ctx.features
     page = mc(devmode)
 
@@ -77,32 +66,6 @@ def get_cached_homepage():
         mc(devmode)
 
     return page
-
-
-# Because of caching, memcache will call `get_homepage` on another thread! So we
-# need a way to carry some information to that computation on the other thread.
-# We do that by using a python closure. The outer function is executed on the main
-# thread, so all the web.* stuff is correct. The inner function is executed on the
-# other thread, so all the web.* stuff will be dummy.
-def caching_prethread():
-    from openlibrary.plugins.openlibrary.code import is_bot
-
-    # web.ctx.lang is undefined on the new thread, so need to transfer it over
-    lang = req_context.get().lang
-    host = web.ctx.host
-    _is_bot = is_bot()
-
-    def main():
-        # Leaving this in since this is a bit strange, but you can see it clearly
-        # in action with this debug line:
-        # web.debug(f'XXXXXXXXXXX web.ctx.lang={web.ctx.get("lang")}; {lang=}')
-        delegate.fakeload()
-        web.ctx.lang = lang
-        web.ctx.is_bot = _is_bot
-        web.ctx.host = host
-        set_context_from_legacy_web_py()
-
-    return main
 
 
 class home(delegate.page):
@@ -264,9 +227,9 @@ def get_featured_subjects():
 def get_cached_featured_subjects():
     return cache.memcache_memoize(
         get_featured_subjects,
-        f"home.featured_subjects.{web.ctx.lang}",
+        "home.featured_subjects",
         timeout=dateutil.HOUR_SECS,
-        prethread=caching_prethread(),
+        cache_request_context=True,
     )()
 
 
@@ -279,12 +242,11 @@ def generic_carousel(
     timeout=None,
     safe_mode=True,
 ):
-    memcache_key = "home.ia_carousel_books"
     cached_ia_carousel_books = cache.memcache_memoize(
         get_ia_carousel_books,
-        memcache_key,
+        "home.ia_carousel_books",
         timeout=timeout or cache.DEFAULT_CACHE_LIFETIME,
-        prethread=caching_prethread(),
+        cache_request_context=True,
     )
     books = cached_ia_carousel_books(
         query=query,

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -176,7 +176,7 @@ class borrow(delegate.page):
             account = OpenLibraryAccount.get_by_email(user.email)
             ia_itemname = account.itemname if account else None
             s3_keys = web.ctx.site.store.get(account._key).get("s3_keys")
-            lending.get_cached_loans_of_user.memcache_delete(user.key, {})  # invalidate cache for user loans
+            lending.get_cached_loans_of_user.memcache_delete_by_args(user.key)  # invalidate cache for user loans
         if not user or not ia_itemname or not s3_keys:
             web.setcookie(config.login_cookie_name, "", expires=-1)
             return_path = f"{edition_redirect}/borrow?action={action}"
@@ -203,12 +203,12 @@ class borrow(delegate.page):
                 add_flash_message("success", _("%s has been returned.") % title)
             raise web.seeother(edition_redirect)
         elif action == "join-waitinglist":
-            lending.get_cached_user_waiting_loans.memcache_delete(user.key, {})  # invalidate cache for user waiting loans
+            lending.get_cached_user_waiting_loans.memcache_delete_by_args(user.key)  # invalidate cache for user waiting loans
             lending.s3_loan_api(s3_keys, ocaid=edition.ocaid, action="join_waitlist")
             stats.increment("ol.loans.joinWaitlist")
             raise web.redirect(edition_redirect)
         elif action == "leave-waitinglist":
-            lending.get_cached_user_waiting_loans.memcache_delete(user.key, {})  # invalidate cache for user waiting loans
+            lending.get_cached_user_waiting_loans.memcache_delete_by_args(user.key)  # invalidate cache for user waiting loans
             lending.s3_loan_api(s3_keys, ocaid=edition.ocaid, action="leave_waitlist")
             stats.increment("ol.loans.leaveWaitlist")
             raise web.redirect(edition_redirect)

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -26,7 +26,6 @@ from openlibrary.core.lending import (
 from openlibrary.core.models import LoggedBooksData, User
 from openlibrary.core.observations import Observations, convert_observation_ids
 from openlibrary.i18n import gettext as _
-from openlibrary.plugins.openlibrary.home import caching_prethread
 from openlibrary.plugins.worksearch.schemes.works import get_fulltext_min
 from openlibrary.utils import dateutil, extract_numeric_id_from_olid
 from openlibrary.utils.dateutil import current_year
@@ -647,12 +646,11 @@ class ActivityFeed:
 
     @classmethod
     def get_cached_pub_sub_feed(cls, username):
-        five_minutes = 5 * dateutil.MINUTE_SECS
         mc = memcache_memoize(
             cls.get_pub_sub_feed,
             key_prefix="mybooks.pubsub.feed",
-            timeout=five_minutes,
-            prethread=caching_prethread(),
+            timeout=5 * dateutil.MINUTE_SECS,
+            cache_request_context=True,
         )
         results = mc(username)
 
@@ -684,12 +682,11 @@ class ActivityFeed:
 
     @classmethod
     def get_cached_trending_feed(cls, username):
-        five_minutes = 5 * dateutil.MINUTE_SECS
         mc = memcache_memoize(
             cls.get_trending_feed,
             key_prefix="mybooks.trending.feed",
-            timeout=five_minutes,
-            prethread=caching_prethread(),
+            timeout=5 * dateutil.MINUTE_SECS,
+            cache_request_context=True,
         )
         results = mc(username)
 

--- a/openlibrary/plugins/upstream/tests/test_utils.py
+++ b/openlibrary/plugins/upstream/tests/test_utils.py
@@ -365,10 +365,6 @@ def test_render_cached_macro_evicts_cache_on_error(monkeypatch):
             "openlibrary.plugins.openlibrary.code.is_bot",
             return_value=False,
         ),
-        patch(
-            "openlibrary.plugins.openlibrary.home.caching_prethread",
-            return_value=None,
-        ),
     ):
         utils.render_cached_macro("RawQueryCarousel", ("subject:fantasy",))
 

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -238,27 +238,11 @@ def render_macro(name, args, **kwargs):
 
 @public
 def render_cached_macro(name: str, args: tuple, **kwargs):
-    from openlibrary.plugins.openlibrary.home import caching_prethread
-
-    def get_key_prefix():
-        req_context = request_context.req_context.get()
-        lang = req_context.lang
-        key_prefix = f'{name}.{lang}'
-        if req_context.print_disabled:
-            key_prefix += '.pd'
-        if req_context.sfw:
-            key_prefix += '.sfw'
-        if req_context.is_bot:
-            key_prefix += '.bot'
-        return key_prefix
-
-    five_minutes = 5 * 60
-    key_prefix = get_key_prefix()
     mc = cache.memcache_memoize(
         render_macro,
-        key_prefix=key_prefix,
-        timeout=five_minutes,
-        prethread=caching_prethread(),
+        f'cached_macro.{name}',
+        timeout=5 * 60,
+        cache_request_context=True,
         hash_args=True,  # this avoids cache key length overflow
     )
 

--- a/openlibrary/tests/core/test_cache.py
+++ b/openlibrary/tests/core/test_cache.py
@@ -9,14 +9,14 @@ from openlibrary.mocks import mock_memcache
 
 class Test_memcache_memoize:
     def test_encode_args(self):
-        m = cache.memcache_memoize(None, key_prefix="foo")
+        m = cache.memcache_memoize(lambda: None, key_prefix="foo", hash_args=False)
 
-        assert m.encode_args([]) == ""
-        assert m.encode_args(["a"]) == '"a"'
-        assert m.encode_args([1]) == "1"
-        assert m.encode_args(["a", 1]) == '"a",1'
-        assert m.encode_args([{"a": 1}]) == '{"a":1}'
-        assert m.encode_args([["a", 1]]) == '["a",1]'
+        assert m.encode_args(()) == ""
+        assert m.encode_args(("a",)) == '"a"'
+        assert m.encode_args((1,)) == "1"
+        assert m.encode_args(("a", 1)) == '"a",1'
+        assert m.encode_args(({"a": 1},)) == '{"a":1}'
+        assert m.encode_args((["a", 1],)) == '["a",1]'
 
     def test_generate_key_prefix(self):
         def foo():
@@ -26,7 +26,7 @@ class Test_memcache_memoize:
         assert m.key_prefix[:4] == "foo_"
 
     def test_random_string(self):
-        m = cache.memcache_memoize(None, "foo")
+        m = cache.memcache_memoize(lambda: None, "foo")
         assert m._random_string(0) == ""
 
         s1 = m._random_string(1)
@@ -38,7 +38,7 @@ class Test_memcache_memoize:
         assert len(s10) == 10
 
     def square_memoize(self):
-        def square(x):
+        def square(x: int):
             return x * x
 
         m = cache.memcache_memoize(square, key_prefix="square")
@@ -58,10 +58,12 @@ class Test_memcache_memoize:
     def test_update_async(self):
         m = self.square_memoize()
 
-        m.update_async(20)
+        m.update_async(None, 20)
         m.join_threads()
 
-        assert m.memcache_get([20], {})[0] == 400
+        result = m.memcache_get(20)
+        assert result is not None
+        assert result[0] == 400
 
     def test_timeout(self, monkeytime):
         m = self.square_memoize()
@@ -104,7 +106,7 @@ class Test_memoize:
         cache.memory_cache.set(key, value)
 
     def test_signatures(self):
-        def square(x):
+        def square(x: int):
             """Returns square x."""
             return x * x
 
@@ -114,7 +116,7 @@ class Test_memoize:
 
     def test_cache(self):
         @cache.memoize(engine="memory", key="square")
-        def square(x):
+        def square(x: int):
             return x * x
 
         assert square(2) == 4
@@ -126,11 +128,11 @@ class Test_memoize:
 
     def test_cache_with_tuple_keys(self):
         @cache.memoize(engine="memory", key=lambda x: (str(x), "square"))
-        def square(x):
+        def square(x: int):
             return x * x
 
         @cache.memoize(engine="memory", key=lambda x: (str(x), "double"))
-        def double(x):
+        def double(x: int):
             return x + x
 
         assert self.get("3") is None
@@ -145,7 +147,7 @@ class Test_memoize:
     async def test_async_signatures(self):
         """Ensure metadata is preserved for async functions."""
 
-        async def asquare(x):
+        async def asquare(x: int):
             """Returns async square x."""
             return x * x
 
@@ -191,7 +193,7 @@ class Test_memoize:
         """Ensure async works with complex tuple keys."""
 
         @cache.memoize(engine="memory", key=lambda x: (str(x), "async_val"))
-        async def get_val(x):
+        async def get_val(x: int):
             return x + 1
 
         await get_val(5)
@@ -210,11 +212,11 @@ class Test_memoize:
         """
 
         @cache.memoize(engine="memory", key="parity_check")
-        def sync_f(x):
+        def sync_f(x: int):
             return x + 1
 
         @cache.memoize(engine="memory", key="parity_check")
-        async def async_f(x):
+        async def async_f(x: int):
             return x + 1
 
         # 1. Run Sync, populate cache

--- a/openlibrary/utils/request_context.py
+++ b/openlibrary/utils/request_context.py
@@ -5,6 +5,7 @@ This module provides utilities for managing request-scoped context variables
 and parsing request data for both web.py and FastAPI frameworks.
 """
 
+import dataclasses
 from contextvars import ContextVar
 from dataclasses import dataclass
 from urllib.parse import unquote
@@ -32,6 +33,16 @@ class RequestContextVars:
     sfw: bool = False
     is_recognized_bot: bool = False
     is_bot: bool = False
+
+    def copy_for_cache_thread(self):
+        """Create a copy of the context vars for use in a new thread."""
+        # Everything the same, except x_forwarded_for and user_agent are see
+        # to None since they are only relevant for the original request thread.
+        return dataclasses.replace(
+            self,
+            x_forwarded_for=None,
+            user_agent=None,
+        )
 
 
 req_context: ContextVar[RequestContextVars] = ContextVar("req_context")
@@ -181,10 +192,16 @@ def _parse_solr_editions_from_fastapi(request) -> bool:
     return True
 
 
-def set_context_from_legacy_web_py() -> None:
+def set_context_from_legacy_web_py(
+    req_context_override: RequestContextVars | None = None,
+) -> None:
     """
     Extracts context from the global web.ctx and populates ContextVars.
     """
+    if req_context_override is not None:
+        req_context.set(req_context_override)
+        return
+
     solr_editions = _parse_solr_editions_from_web()
     print_disabled = bool(web.cookies().get('pd', False))
     sfw = bool(web.cookies().get('sfw', ''))


### PR DESCRIPTION
- avoids the complicated closure capture
- avoids cache leaking when new request context variables are introduced
- fixes cache leak with is_bot and is_recognized_bot
- fixes various other cache leaks where the caching prethread method was used without the corresponding variables being added to the cache key.

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
