### PR TITLE
12030/fix/title search requires phrase match of all words

### DIFF
--- a/openlibrary/plugins/openlibrary/js/SearchBar.js
+++ b/openlibrary/plugins/openlibrary/js/SearchBar.js
@@ -186,10 +186,11 @@ export class SearchBar {
         if (urlParams.q && this.getCurUrl().pathname.match(/^\/search/)) {
             let q = urlParams.q.replace(/\+/g, ' ');
             if (this.facet.read() === 'title' && q.indexOf('title:') !== -1) {
-                const parts = q.split('"');
-                if (parts.length === 3) {
-                    q = parts[1];
+                 q = q.replace('title:', '').trim();
+                if (q.startsWith('(') && q.endsWith(')')){
+                    q = q.substring(1, q.length -1);
                 }
+
             }
             this.$input.val(q);
         }
@@ -312,7 +313,7 @@ export class SearchBar {
      */
     static marshalBookSearchQuery(q) {
         if (q && q.indexOf(':') === -1 && q.indexOf('"') === -1) {
-            q = `title: "${q}"`;
+            q = `title:(${q})`;
         }
         return q;
     }

--- a/openlibrary/plugins/openlibrary/js/SearchBar.js
+++ b/openlibrary/plugins/openlibrary/js/SearchBar.js
@@ -186,7 +186,7 @@ export class SearchBar {
         if (urlParams.q && this.getCurUrl().pathname.match(/^\/search/)) {
             let q = urlParams.q.replace(/\+/g, ' ');
             if (this.facet.read() === 'title' && q.indexOf('title:') !== -1) {
-                 q = q.replace('title:', '').trim();
+                q = q.replace('title:', '').trim();
                 if (q.startsWith('(') && q.endsWith(')')){
                     q = q.substring(1, q.length -1);
                 }

--- a/tests/unit/js/SearchBar.test.js
+++ b/tests/unit/js/SearchBar.test.js
@@ -42,9 +42,9 @@ describe('SearchBar', () => {
         });
 
         test('Remove title prefix from q param', () => {
-            sb.initFromUrlParams({q: 'title:"Harry Potter"', facet: 'title'});
+            sb.initFromUrlParams({q: 'title:(Harry Potter)', facet: 'title'});
             expect(sb.$input.val()).toBe('Harry Potter');
-            sb.initFromUrlParams({q: 'title: "Harry"', facet: 'title'});
+            sb.initFromUrlParams({q: 'title: (Harry)', facet: 'title'});
             expect(sb.$input.val()).toBe('Harry');
         });
 
@@ -112,7 +112,7 @@ describe('SearchBar', () => {
         });
 
         test('Adds title prefix to plain strings', () => {
-            expect(fn('Harry Potter')).toBe('title: "Harry Potter"');
+            expect(fn('Harry Potter')).toBe('title:(Harry Potter)');
         });
 
         test('Does not add title prefix to lucene-style queries', () => {


### PR DESCRIPTION

Closes #12030

fix: search requires phrase match of all words
### Technical

The error is related to how Solr search handles phrase queries. Currently, using `title:"query"` matches the exact phrase, requiring terms to appear in that specific order.

To allow the title to contain terms regardless of their order (e.g., "harry" AND "potter"), I updated the logic to use grouped terms: title:(term1 term2).

Changes:

    Modified marshalBookSearchQuery to use the title:(...) format for Solr.

    Updated initFromUrlParams to properly handle the removal of the title: prefix and parentheses when parsing the URL.

### Testing

    In the right corner search bar, choose Title.

    Search for "responsive design".

        Original behavior: Returns "No books directly matched your search" (looking for exact phrase).

        After fix: Returns the book Responsive Web Design.

### Screenshot
Local test Screenshot:

old
<img width="2879" height="1371" alt="imagem" src="https://github.com/user-attachments/assets/cd6202fd-4765-4c5a-89df-8c25e5738983" />

after
<img width="2879" height="1372" alt="imagem" src="https://github.com/user-attachments/assets/897bae53-3424-4842-9484-6c48095a9369" />
Production

old:
<img width="2877" height="1371" alt="imagem" src="https://github.com/user-attachments/assets/68421678-f98a-4477-90cb-5d3abe2b3c05" />

expected:
<img width="2853" height="1111" alt="imagem" src="https://github.com/user-attachments/assets/9b3d21cb-452c-4d18-9796-1e39be414e9e" />
### Stakeholders

@cdrini

---
<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->

Please let me know if i went to right direction to address the issue or if there are any improvements I should make.