### PR TITLE
feat: add sentry headers to lending ia client requests

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Literal, TypedDict, cast
 import eventer
 import httpx
 import requests
+import sentry_sdk
 import web
 from simplejson.errors import JSONDecodeError
 
@@ -296,6 +297,8 @@ def get_available(
             "x-client-id": client_ip,
             "x-preferred-client-id": client_ip,
             "x-application-id": "openlibrary",
+            "sentry-trace": sentry_sdk.get_traceparent(),
+            "baggage": sentry_sdk.get_baggage(),
         }
         response = ia.session.get(url, headers=headers, timeout=config_http_request_timeout)
         items = response.json().get("response", {}).get("docs", [])
@@ -427,6 +430,8 @@ def get_availability(
             "x-preferred-client-useragent": req_context.get().user_agent or "",
             "x-application-id": "openlibrary",
             "user-agent": "Open Library Site",
+            "sentry-trace": sentry_sdk.get_traceparent(),
+            "baggage": sentry_sdk.get_baggage(),
         }
         if config_ia_ol_metadata_write_s3:
             headers["authorization"] = "LOW {s3_key}:{s3_secret}".format(**config_ia_ol_metadata_write_s3)
@@ -591,7 +596,10 @@ def is_loaned_out_on_ia(identifier: str) -> bool | None:
     """Returns True if the item is checked out on Internet Archive."""
     url = f"https://archive.org/services/borrow/{identifier}?action=status"
     try:
-        response = ia.session.get(url, timeout=config_http_request_timeout).json()
+        sentry_trace = sentry_sdk.get_traceparent()
+        baggage = sentry_sdk.get_baggage()
+        headers = {"sentry-trace": sentry_trace, "baggage": baggage} if (sentry_trace and baggage) else {}
+        response = ia.session.get(url, headers=headers, timeout=config_http_request_timeout).json()
         return response and response.get("checkedout")
     except Exception:  # TODO: Narrow exception scope
         logger.exception(f"is_loaned_out_on_ia({identifier})")


### PR DESCRIPTION
Adds Sentry headers (baggage and sentry-trace) to lending.py requests made with the IA Python client, as Sentry doesn't auto instrument these.

The hope is to get tracing out of other APIs (e.g. the Availability API), on the theory the traces will get picked up by existing petabox code. This may or may not be the case.

<!-- What issue does this PR close? -->
Closes #12421

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
I think this could be tested on testing.openlibrary.org and checking a work at `/works` on testing.openlibrary.org.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
