### PR TITLE
update bwb api url to avoid 301

### DIFF
--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -35,7 +35,7 @@ session = requests.Session()
 async_session = httpx.AsyncClient()
 
 BETTERWORLDBOOKS_API_URL = (
-    'https://products.betterworldbooks.com/service.aspx?IncludeAmazon=True&ItemId='
+    'https://products.bwbcontent.com/service.aspx?IncludeAmazon=True&ItemId='
 )
 affiliate_server_url = None
 BWB_AFFILIATE_LINK = 'http://www.anrdoezrs.net/links/{}/type/dlg/http://www.betterworldbooks.com/-id-%s'.format(


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #
BWB is redirecting
https://products.betterworldbooks.com/service.aspx?IncludeAmazon=True&ItemId=9780765319852
To
https://products.bwbcontent.com/service.aspx?IncludeAmazon=True&ItemId=

The new async client doesn't follow redirects by default.

We could update it to follow redirects but probably better to just set the updated url for now to avoid the extra hop.
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
