### PR TITLE
Add handler to associate IA `ocaid`s with OL edition records

### DIFF
--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -1158,6 +1158,7 @@ class link_ia_ol(delegate.page):
         data = edition.dict()
         data["ocaid"] = ocaid
         with accounts.RunAs("ImportBot"):
+            web.ctx.ip = web.ctx.ip or '127.0.0.1'
             web.ctx.site.save(
                 data, "Associate OCAID with record", action="edit-edition-ocaid"
             )

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -1107,6 +1107,60 @@ class unlink_ia_ol(delegate.page):
         web.ctx.site.save(data, "Disassociate OCAID", action="edit-edition-ocaid")
 
 
+class link_ia_ol(delegate.page):
+    path = "/api/link"
+    encoding = "json"
+
+    def POST(self):
+        i = web.input(digest="", msg="")
+        digest = i.digest
+        msg = i.msg
+
+        try:
+            HMACToken.verify(digest, msg, "ia_sync_secret", unix_time=True)
+        except (ValueError, ExpiredTokenError):
+            raise web.HTTPError(
+                "401 Unauthorized", {"Content-Type": "application/json"}
+            )
+
+        ocaid, olid, ts = msg.split("|")
+        if not all([ocaid, olid, ts]):
+            raise web.HTTPError(
+                "400 Bad Request",
+                {"Content-Type": "application/json"},
+                data=json.dumps({"error": "Invalid inputs"}),
+            )
+
+        # Fetch affected edition
+        edition = web.ctx.site.get(f'/books/{ocaid}')
+        if not edition:
+            raise web.HTTPError("404 Not Found", {"Content-Type": "application/json"})
+
+        # Update record
+        try:
+            self.link(edition, ocaid)
+        except ClientException as e:
+            logger.error(
+                f"Failed to associate {ocaid} with {olid}", exc_info=True
+            )
+            raise web.HTTPError(
+                "500 Internal Server Error",
+                {"Content-Type": "application/json"},
+                data=json.dumps({"error": str(e)}),
+            )
+
+        return delegate.RawText(json.dumps({"status": "ok"}))
+
+    @staticmethod
+    def link(edition, ocaid):
+        data = edition.dict()
+        data["ocaid"] = ocaid
+        if not data["source_records"]:
+            data["source_records"] = []
+        data["source_records"].append(f"ia:{ocaid}")
+        web.ctx.site.save(data, "Associate OCAID with record", action="edit-edition-ocaid")
+
+
 class monthly_logins(delegate.page):
     path = "/api/monthly_logins"
     encoding = "json"

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -1159,7 +1159,8 @@ class link_ia_ol(delegate.page):
     def link(edition, ocaid):
         data = edition.dict()
         data["ocaid"] = ocaid
-        web.ctx.site.save(data, "Associate OCAID with record", action="edit-edition-ocaid")
+        with accounts.RunAs("ImportBot"):
+            web.ctx.site.save(data, "Associate OCAID with record", action="edit-edition-ocaid")
 
 
 class monthly_logins(delegate.page):

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -1117,7 +1117,10 @@ class link_ia_ol(delegate.page):
         msg = i.msg
 
         try:
-            HMACToken.verify(digest, msg, "ia_sync_secret", unix_time=True)
+            if not HMACToken.verify(digest, msg, "ia_sync_secret", unix_time=True):
+                raise web.HTTPError(
+                    "401 Unauthorized", {"Content-Type": "application/json"}
+                )
         except (ValueError, ExpiredTokenError):
             raise web.HTTPError(
                 "401 Unauthorized", {"Content-Type": "application/json"}

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -1155,9 +1155,6 @@ class link_ia_ol(delegate.page):
     def link(edition, ocaid):
         data = edition.dict()
         data["ocaid"] = ocaid
-        if not data["source_records"]:
-            data["source_records"] = []
-        data["source_records"].append(f"ia:{ocaid}")
         web.ctx.site.save(data, "Associate OCAID with record", action="edit-edition-ocaid")
 
 

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -1133,7 +1133,7 @@ class link_ia_ol(delegate.page):
                 {"Content-Type": "application/json"},
                 data=json.dumps({"error": "Invalid inputs"}),
             )
-        ocaid, olid, ts = parts
+        ocaid, olid, _ts = parts
 
         # Fetch affected edition
         edition = web.ctx.site.get(f'/books/{olid}')

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -1126,13 +1126,14 @@ class link_ia_ol(delegate.page):
                 "401 Unauthorized", {"Content-Type": "application/json"}
             )
 
-        ocaid, olid, ts = msg.split("|")
-        if not all([ocaid, olid, ts]):
+        parts = msg.split("|", maxsplit=2)
+        if len(parts) != 3 or not all(parts):
             raise web.HTTPError(
                 "400 Bad Request",
                 {"Content-Type": "application/json"},
                 data=json.dumps({"error": "Invalid inputs"}),
             )
+        ocaid, olid, ts = parts
 
         # Fetch affected edition
         edition = web.ctx.site.get(f'/books/{ocaid}')

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -1136,7 +1136,7 @@ class link_ia_ol(delegate.page):
         ocaid, olid, ts = parts
 
         # Fetch affected edition
-        edition = web.ctx.site.get(f'/books/{ocaid}')
+        edition = web.ctx.site.get(f'/books/{olid}')
         if not edition:
             raise web.HTTPError("404 Not Found", {"Content-Type": "application/json"})
 

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -1144,9 +1144,7 @@ class link_ia_ol(delegate.page):
         try:
             self.link(edition, ocaid)
         except ClientException as e:
-            logger.error(
-                f"Failed to associate {ocaid} with {olid}", exc_info=True
-            )
+            logger.error(f"Failed to associate {ocaid} with {olid}", exc_info=True)
             raise web.HTTPError(
                 "500 Internal Server Error",
                 {"Content-Type": "application/json"},
@@ -1160,7 +1158,9 @@ class link_ia_ol(delegate.page):
         data = edition.dict()
         data["ocaid"] = ocaid
         with accounts.RunAs("ImportBot"):
-            web.ctx.site.save(data, "Associate OCAID with record", action="edit-edition-ocaid")
+            web.ctx.site.save(
+                data, "Associate OCAID with record", action="edit-edition-ocaid"
+            )
 
 
 class monthly_logins(delegate.page):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11490

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Creates new `/api/link.json` handler for the purpose of syncing data between IA and OL.  `POST` requests to this endpoint are expected to have the following query parameters:

- `msg` : A colon delimited string in the format `{ocaid}|{openlibrary_edition_id}|{expiry}`
- `digest` : The sha256 hashed value of `msg`

All inputs required for the operation are expected to be sent in the `msg` string.

The `POST` handler will, in order:

1. Verify the `digest` and check the expiry
2. Validate the request inputs
3. Query for the OL edition that matches the Open Library edition ID given in the `msg`
4. Adds given `ocaid` to the OL edition

Possible responses:

| Status | Condition                                    | Response Body                                                 |
|--------|----------------------------------------------|--------------------------------------------------------------|
| 200    | Success                                      | {"status": "ok"}                                             |
| 400    | Missing/malformed ocaid or ts in msg         | {"error": "Invalid inputs"}                                  |
| 401    | Invalid or expired HMAC digest               | (empty)                                                      |
| 404    | No edition found with given ocaid            | (empty)                                                      |
| 500    | DB/save failure                              | {"error": "`exception_message`"}                             |

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
