### PR TITLE
Fix history page pagination off-by-one

### DIFF
--- a/openlibrary/plugins/upstream/recentchanges.py
+++ b/openlibrary/plugins/upstream/recentchanges.py
@@ -200,8 +200,9 @@ class history(delegate.mode):
         page = web.ctx.site.get(path)
         if not page:
             raise web.seeother(path)
-        i = web.input(page=0)
-        offset = 20 * safeint(i.page)
+        i = web.input(page=1)
         limit = 20
-        history = get_changes({"key": path, "limit": limit, "offset": offset})
-        return render.history(page, history)
+        offset = limit * max(0, safeint(i.page) - 1)
+        history = get_changes({"key": path, "limit": limit + 1, "offset": offset})
+        has_next = len(history) > limit
+        return render.history(page, history[:limit], has_next)

--- a/openlibrary/plugins/upstream/recentchanges.py
+++ b/openlibrary/plugins/upstream/recentchanges.py
@@ -202,7 +202,9 @@ class history(delegate.mode):
             raise web.seeother(path)
         i = web.input(page=1)
         limit = 20
+        # Clamp so legacy ?page=0 links resolve to the first page instead of a negative offset.
         offset = limit * max(0, safeint(i.page) - 1)
+        # Fetch one extra item so has_next can be computed without a separate count query.
         history = get_changes({"key": path, "limit": limit + 1, "offset": offset})
         has_next = len(history) > limit
         return render.history(page, history[:limit], has_next)

--- a/openlibrary/templates/history.html
+++ b/openlibrary/templates/history.html
@@ -75,6 +75,7 @@ $ rev = page.latest_revision or page.revision
 
         </form>
 
+        $# Clamp so legacy ?page=0 URLs render as page 1 and match the component's 1-indexed scheme.
         $ page_num = max(1, safeint(query_param("page", "1")))
         $:macros.OlPaginationArrows(page_num, has_next)
 

--- a/openlibrary/templates/history.html
+++ b/openlibrary/templates/history.html
@@ -1,4 +1,4 @@
-$def with (page, h)
+$def with (page, h, has_next=False)
 
 $putctx("robots", "noindex,nofollow")
 
@@ -75,7 +75,7 @@ $ rev = page.latest_revision or page.revision
 
         </form>
 
-        $ page_num = safeint(query_param("page", "0"))
-        $:macros.OlPaginationArrows(page_num + 1, len(h) == 20)
+        $ page_num = max(1, safeint(query_param("page", "1")))
+        $:macros.OlPaginationArrows(page_num, has_next)
 
 </div>


### PR DESCRIPTION
This fixes:
  - #12398: Previous arrow on page 2 links back to page 2
  - #12420: History pages double-skip, making most revisions unreachable


### Technical
PR #12169 migrated pagination to the ol-pagination web component, which uses 1-indexed URLs (page 1 = no ?page param, page 2 = ?page=2).

The history handler was left on the old 0-indexed scheme (?page=0 = page 1, offset = 20 * page), and the template bridged them with a `+1` - but applied it when passing the page to the component rather than when interpreting the URL. So each click drifted further out of sync.

**How the bug plays out:**
1 ) Initial load at ?m=history (no ?page)                              
  - Backend reads page=0 → offset=0 → shows revisions 1–20 ✓ (correct)              
  - Template reads URL's page=0 → passes 0+1=1 to component                         
  - Component thinks it's on page 1 → "Next" link generated as ?page=2 ✓ (looks
  right)                                                                            
                                                                                    
2) User clicks "Next", URL becomes ?page=2                                  
  - Backend reads page=2 → offset=40 → shows revisions 41–60 ✗ (skipped 21–40!)     
  - Template reads URL's page=2 → passes 2+1=3 to component                         
  - Component thinks it's on page 3:                                                
    - "Next" → ?page=4                                                              
    - "Prev" → ?page=2 ← same URL → issue #12398 (the "prev arrow goes nowhere" bug)
                                                         
**The fix:**
Align the handler, the URL, and the template on 1-indexed pages to match every other paginated page on the site (admin/people/edits, loan_history, admin/memory). 

Also replaces the brittle `len(h) == 20` has-next check with a `limit + 1` fetch so the Next arrow no longer appears on exact-20-item last pages.

### Testing
Visit a history page with more than 20 revisions and navigate forward and backwards with pagination.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@cdrini 

