### PR TITLE
Note memcache.other calls in olspy

### DIFF
--- a/scripts/monitoring/olspy.sh
+++ b/scripts/monitoring/olspy.sh
@@ -117,6 +117,7 @@ classify_workers_cur_fn() {
         else if ($0 ~ / run \(asyncio\/runners\.py/) print "uvicorn.run";
         else if ($0 ~ / readline \(memcache\.py/) print "memcache.readline";
         else if ($0 ~ / _recv_value \(memcache\.py/) print "memcache._recv_value";
+        else if ($2 ~ /\(memcache\.py/) print "memcache.other";
         else if ($0 ~ /info \(openlibrary\/core\/models\.py/) print "covers.info";
         else if ($0 ~ /GET \(openlibrary\/plugins\/worksearch\/code\.py/) print "ol.worksearch_GET";
         else if ($0 ~ /GET \(openlibrary\/views\/showmarc\.py/) print "ol.showmarc_GET";


### PR DESCRIPTION
Was seeing memcache occasionally when manually inspecting the "other" category ; add a memcache catchall for any other memcache-related things.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
