### PR TITLE
build: apply ruff-format and black to more python files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,35 +64,16 @@ repos:
           (?x)^(
             openlibrary/accounts/model\.py
             |openlibrary/catalog/add_book/__init__\.py
-            |openlibrary/core/lists/model\.py
             |openlibrary/core/models\.py
             |openlibrary/core/vendors\.py
             |openlibrary/fastapi/search\.py
             |openlibrary/plugins/admin/code\.py
             |openlibrary/plugins/openlibrary/api\.py
-            |openlibrary/plugins/openlibrary/bulk_tag\.py
             |openlibrary/plugins/openlibrary/code\.py
             |openlibrary/plugins/openlibrary/lists\.py
-            |openlibrary/plugins/openlibrary/status\.py
-            |openlibrary/plugins/upstream/addbook\.py
-            |openlibrary/plugins/upstream/addtag\.py
-            |openlibrary/plugins/upstream/code\.py
-            |openlibrary/plugins/upstream/covers\.py
-            |openlibrary/plugins/upstream/jsdef\.py
             |openlibrary/plugins/upstream/utils\.py
             |openlibrary/plugins/worksearch/code\.py
-            |openlibrary/plugins/worksearch/schemes/__init__\.py
-            |openlibrary/plugins/worksearch/schemes/authors\.py
-            |openlibrary/plugins/worksearch/schemes/lists\.py
-            |openlibrary/plugins/worksearch/schemes/subjects\.py
             |openlibrary/plugins/worksearch/schemes/works\.py
-            |openlibrary/utils/form\.py
-            |openlibrary/utils/request_context\.py
-            |openlibrary/utils/schema\.py
-            |scripts/find_duplicate_author\.py
-            |scripts/monitoring/fail2ban_monitor\.py
-            |scripts/monitoring/monitor\.py
-            |scripts/update_stale_ocaid_references\.py
           )$
 
   - repo: https://github.com/psf/black-pre-commit-mirror
@@ -105,35 +86,16 @@ repos:
           (?x)^(
             openlibrary/accounts/model\.py
             |openlibrary/catalog/add_book/__init__\.py
-            |openlibrary/core/lists/model\.py
             |openlibrary/core/models\.py
             |openlibrary/core/vendors\.py
             |openlibrary/fastapi/search\.py
             |openlibrary/plugins/admin/code\.py
             |openlibrary/plugins/openlibrary/api\.py
-            |openlibrary/plugins/openlibrary/bulk_tag\.py
             |openlibrary/plugins/openlibrary/code\.py
             |openlibrary/plugins/openlibrary/lists\.py
-            |openlibrary/plugins/openlibrary/status\.py
-            |openlibrary/plugins/upstream/addbook\.py
-            |openlibrary/plugins/upstream/addtag\.py
-            |openlibrary/plugins/upstream/code\.py
-            |openlibrary/plugins/upstream/covers\.py
-            |openlibrary/plugins/upstream/jsdef\.py
             |openlibrary/plugins/upstream/utils\.py
             |openlibrary/plugins/worksearch/code\.py
-            |openlibrary/plugins/worksearch/schemes/__init__\.py
-            |openlibrary/plugins/worksearch/schemes/authors\.py
-            |openlibrary/plugins/worksearch/schemes/lists\.py
-            |openlibrary/plugins/worksearch/schemes/subjects\.py
             |openlibrary/plugins/worksearch/schemes/works\.py
-            |openlibrary/utils/form\.py
-            |openlibrary/utils/request_context\.py
-            |openlibrary/utils/schema\.py
-            |scripts/find_duplicate_author\.py
-            |scripts/monitoring/fail2ban_monitor\.py
-            |scripts/monitoring/monitor\.py
-            |scripts/update_stale_ocaid_references\.py
           )$
 
   - repo: https://github.com/codespell-project/codespell

--- a/openlibrary/core/lists/model.py
+++ b/openlibrary/core/lists/model.py
@@ -116,9 +116,7 @@ class List(Thing):
         """
         return [web.storage(name=t, url=self.key + "/tags/" + t) for t in self.tags]
 
-    def add_seed(
-        self, seed: ThingReferenceDict | AnnotatedSeedDict | SeedSubjectString
-    ):
+    def add_seed(self, seed: ThingReferenceDict | AnnotatedSeedDict | SeedSubjectString):
         """Adds a new seed to this list."""
         seed_object = Seed.from_json(self, seed)
 
@@ -129,9 +127,7 @@ class List(Thing):
             self.seeds.append(seed_object.to_db())
             return True
 
-    def remove_seed(
-        self, seed: ThingReferenceDict | AnnotatedSeedDict | SeedSubjectString
-    ):
+    def remove_seed(self, seed: ThingReferenceDict | AnnotatedSeedDict | SeedSubjectString):
         """Removes a seed for the list."""
         seed_key = Seed.from_json(self, seed).key
         if (index := self._index_of_seed(seed_key)) >= 0:
@@ -183,19 +179,12 @@ class List(Thing):
         Gets the keys of the works in this list, or of the works of the editions in
         this list. May return duplicates.
         """
-        return (
-            (seed.document.works[0].key if seed.document.works else seed.key)
-            for seed in self.get_seeds()
-            if seed.key.startswith(('/books/', '/works/'))
-        )
+        return ((seed.document.works[0].key if seed.document.works else seed.key) for seed in self.get_seeds() if seed.key.startswith(("/books/", "/works/")))
 
     def get_editions(self) -> Iterable[Edition]:
         """Returns the editions objects belonging to this list."""
         for seed in self.get_seeds():
-            if (
-                isinstance(seed.document, Thing)
-                and seed.document.type.key == "/type/edition"
-            ):
+            if isinstance(seed.document, Thing) and seed.document.type.key == "/type/edition":
                 yield cast(Edition, seed.document)
 
     def get_export_list(self) -> dict[str, list[dict]]:
@@ -211,16 +200,12 @@ class List(Thing):
         # as you access their attributes.
         things = cast(
             list[Thing],
-            web.ctx.site.get_many(
-                [seed.key for seed in self.get_seeds() if seed._type != "subject"]
-            ),
+            web.ctx.site.get_many([seed.key for seed in self.get_seeds() if seed._type != "subject"]),
         )
 
         # Create the return dictionary
         return {
-            "editions": [
-                thing.dict() for thing in things if isinstance(thing, Edition)
-            ],
+            "editions": [thing.dict() for thing in things if isinstance(thing, Edition)],
             "works": [thing.dict() for thing in things if isinstance(thing, Work)],
             "authors": [thing.dict() for thing in things if isinstance(thing, Author)],
         }
@@ -230,13 +215,11 @@ class List(Thing):
         return self._site.get_many(keys)
 
     def preload_works(self, editions):
-        return self._preload(w.key for e in editions for w in e.get('works', []))
+        return self._preload(w.key for e in editions for w in e.get("works", []))
 
     def preload_authors(self, editions):
         works = self.preload_works(editions)
-        return self._preload(
-            a.author.key for w in works for a in w.get("authors", []) if "author" in a
-        )
+        return self._preload(a.author.key for w in works for a in w.get("authors", []) if "author" in a)
 
     def load_changesets(self, editions):
         """Adds "recent_changeset" to each edition.
@@ -256,9 +239,7 @@ class List(Thing):
         for e in editions:
             if "recent_changeset" not in e:
                 with contextlib.suppress(IndexError):
-                    e['recent_changeset'] = self._site.recentchanges(
-                        {"key": e.key, "limit": 1}
-                    )[0]
+                    e["recent_changeset"] = self._site.recentchanges({"key": e.key, "limit": 1})[0]
 
     def _get_solr_query_for_subjects(self):
         terms = [seed.get_solr_query_term() for seed in self.get_seeds()]
@@ -269,26 +250,20 @@ class List(Thing):
 
         # Solr has a maxBooleanClauses constraint there too many seeds, the
         if len(self.seeds) > 500:
-            logger.warning(
-                "More than 500 seeds. skipping solr query for finding subjects."
-            )
+            logger.warning("More than 500 seeds. skipping solr query for finding subjects.")
             return []
 
-        facet_names = ['subject_facet', 'place_facet', 'person_facet', 'time_facet']
+        facet_names = ["subject_facet", "place_facet", "person_facet", "time_facet"]
         try:
-            result = get_solr().select(
-                q, fields=[], facets=facet_names, facet_limit=20, facet_mincount=1
-            )
+            result = get_solr().select(q, fields=[], facets=facet_names, facet_limit=20, facet_mincount=1)
         except OSError:
-            logger.error(
-                "Error in finding subjects of list %s", self.key, exc_info=True
-            )
+            logger.error("Error in finding subjects of list %s", self.key, exc_info=True)
             return []
 
         def get_subject_prefix(facet_name):
             name = facet_name.replace("_facet", "")
-            if name == 'subject':
-                return ''
+            if name == "subject":
+                return ""
             else:
                 return name + ":"
 
@@ -296,12 +271,10 @@ class List(Thing):
             prefix = get_subject_prefix(facet_name)
             key = prefix + title.lower().replace(" ", "_")
             url = "/subjects/" + key
-            return web.storage(
-                {"title": title, "name": title, "count": count, "key": key, "url": url}
-            )
+            return web.storage({"title": title, "name": title, "count": count, "key": key, "url": url})
 
         def process_all():
-            facets = result['facets']
+            facets = result["facets"]
             for k in facet_names:
                 for f in facets.get(k, []):
                     yield process_subject(f.name, f.value, f.count)
@@ -327,12 +300,12 @@ class List(Thing):
                 d[kind].append(s)
         return d
 
-    def get_seeds(self, sort=False, resolve_redirects=False) -> list['Seed']:
+    def get_seeds(self, sort=False, resolve_redirects=False) -> list["Seed"]:
         seeds: list[Seed] = []
         for s in self.seeds:
             seed = Seed.from_db(self, s)
             max_checks = 10
-            while resolve_redirects and seed.type == 'redirect' and max_checks:
+            while resolve_redirects and seed.type == "redirect" and max_checks:
                 resolved_document = web.ctx.site.get(seed.document.location)
                 seed = seed.copy_with(thing=resolved_document)
                 max_checks -= 1
@@ -345,13 +318,11 @@ class List(Thing):
 
     def has_seed(self, seed: ThingReferenceDict | SeedSubjectString) -> bool:
         if isinstance(seed, dict):
-            seed = seed['key']
+            seed = seed["key"]
         return seed in self._get_seed_strings()
 
     # cache the default_cover_id for 60 seconds
-    @cache.memoize(
-        "memcache", key=lambda self: ("d" + self.key, "default-cover-id"), expires=60
-    )
+    @cache.memoize("memcache", key=lambda self: ("d" + self.key, "default-cover-id"), expires=60)
     def _get_default_cover_id(self):
         for s in self.get_seeds():
             cover = s.get_cover()
@@ -362,13 +333,13 @@ class List(Thing):
         from openlibrary.core.models import Image
 
         cover_id = self._get_default_cover_id()
-        return Image(self._site, 'b', cover_id)
+        return Image(self._site, "b", cover_id)
 
         # These functions cache and retrieve the 'my lists' section for mybooks.
 
     @cache.memoize(
         "memcache",
-        key=lambda self: 'core.patron_lists.%s' % web.safestr(self.key),
+        key=lambda self: "core.patron_lists.%s" % web.safestr(self.key),
         expires=60 * 10,
     )
     def get_patron_showcase(self, limit=3):
@@ -386,14 +357,10 @@ class List(Thing):
 
         last_modified = self.last_update
         return {
-            'title': title,
-            'count': self.seed_count,
-            'covers': n_covers,
-            'last_mod': (
-                last_modified.isoformat(sep=' ', timespec="minutes")
-                if self.seed_count != 0
-                else ""
-            ),
+            "title": title,
+            "count": self.seed_count,
+            "covers": n_covers,
+            "last_mod": (last_modified.isoformat(sep=" ", timespec="minutes") if self.seed_count != 0 else ""),
         }
 
 
@@ -435,16 +402,16 @@ class Seed:
             self._type = "subject"
         elif isinstance(value, dict):
             # AnnotatedSeed
-            self.key = value['thing'].key
-            self.value = value['thing']
-            self.notes = value.get('notes')
-            self.position = value.get('position')
+            self.key = value["thing"].key
+            self.value = value["thing"]
+            self.notes = value.get("notes")
+            self.position = value.get("position")
         else:
             self.key = value.key
             self.value = value
 
     @staticmethod
-    def from_db(list: List, seed: Thing | SeedSubjectString) -> 'Seed':
+    def from_db(list: List, seed: Thing | SeedSubjectString) -> "Seed":
         if isinstance(seed, str):
             return Seed(list, seed)
         # If there is a cache miss, `seed` is a client.Thing.
@@ -463,27 +430,27 @@ class Seed:
         seed_json: SeedSubjectString | ThingReferenceDict | AnnotatedSeedDict,
     ):
         if isinstance(seed_json, dict):
-            if 'thing' in seed_json:
+            if "thing" in seed_json:
                 seed_dict = cast(AnnotatedSeedDict, seed_json)  # Appease mypy
 
                 # Validate that the key is not empty
-                key = seed_dict['thing']['key']
+                key = seed_dict["thing"]["key"]
                 if not key or not key.strip():
                     raise ValueError("Seed key cannot be empty")
 
                 annotated_seed = cast(
                     AnnotatedSeed,
                     {
-                        'thing': Thing(list._site, key),
+                        "thing": Thing(list._site, key),
                     },
                 )
                 update_list_seed_metadata(annotated_seed, seed_dict)
                 return Seed(list, annotated_seed)
-            elif 'key' in seed_json:
+            elif "key" in seed_json:
                 thing_ref = cast(ThingReferenceDict, seed_json)  # Appease mypy
 
                 # Validate that the key is not empty
-                key = thing_ref['key']
+                key = thing_ref["key"]
                 if not key or not key.strip():
                     raise ValueError("Seed key cannot be empty")
 
@@ -507,28 +474,28 @@ class Seed:
         elif self.has_metadata():
             return self.to_annotated_seed_dict()
         else:
-            return {'key': self.key}
+            return {"key": self.key}
 
-    def copy_with(self, thing: Thing | SeedSubjectString) -> 'Seed':
-        new_seed = cast(AnnotatedSeed, self.to_annotated_seed() | {'thing': thing})
+    def copy_with(self, thing: Thing | SeedSubjectString) -> "Seed":
+        new_seed = cast(AnnotatedSeed, self.to_annotated_seed() | {"thing": thing})
         return Seed(self._list, new_seed)
 
     def to_annotated_seed(self) -> AnnotatedSeed:
-        d = cast(AnnotatedSeed, {'thing': self.value})
+        d = cast(AnnotatedSeed, {"thing": self.value})
         update_list_seed_metadata(d, self.to_list_seed_metadata())
         return d
 
     def to_annotated_seed_dict(self) -> AnnotatedSeedDict:
-        d: AnnotatedSeedDict = {'thing': {'key': self.key}}
+        d: AnnotatedSeedDict = {"thing": {"key": self.key}}
         update_list_seed_metadata(d, self.to_list_seed_metadata())
         return d
 
     def to_list_seed_metadata(self) -> ListSeedMetadata:
         d: ListSeedMetadata = {}
         if self.notes:
-            d['notes'] = self.notes
+            d["notes"] = self.notes
         if self.position:
-            d['position'] = self.position
+            d["position"] = self.position
         return d
 
     def has_metadata(self) -> bool:
@@ -542,23 +509,23 @@ class Seed:
             return self.value
 
     def get_solr_query_term(self):
-        if self.type == 'subject':
+        if self.type == "subject":
             typ, value = self.key.split(":", 1)
             # escaping value as it can have special chars like : etc.
             value = Solr.escape(value)
             return f"{typ}_key:{value}"
         else:
             doc_basekey = self.document.key.split("/")[-1]
-            if self.type == 'edition':
+            if self.type == "edition":
                 return f"edition_key:{doc_basekey}"
-            elif self.type == 'work':
-                return f'key:/works/{doc_basekey}'
-            elif self.type == 'author':
+            elif self.type == "work":
+                return f"key:/works/{doc_basekey}"
+            elif self.type == "author":
                 return f"author_key:{doc_basekey}"
             else:
                 logger.warning(
                     f"Cannot get solr query term for seed type {self.type}",
-                    extra={'list': self._list.key, 'seed': self.key},
+                    extra={"list": self._list.key, "seed": self.key},
                 )
                 return None
 
@@ -598,13 +565,13 @@ class Seed:
             return "/subjects/" + subject
 
     def get_cover(self):
-        if self.type in ['work', 'edition']:
+        if self.type in ["work", "edition"]:
             doc = cast(Work | Edition, self.document)
             return doc.get_cover()
-        elif self.type == 'author':
+        elif self.type == "author":
             doc = cast(Author, self.document)
             return doc.get_photo()
-        elif self.type == 'subject':
+        elif self.type == "subject":
             doc = cast(Subject, self.document)
             return doc.get_default_cover()
         else:
@@ -612,7 +579,7 @@ class Seed:
 
     @cached_property
     def last_update(self):
-        return self.document.get('last_modified')
+        return self.document.get("last_modified")
 
     def dict(self):
         if self.type == "subject":
@@ -630,7 +597,7 @@ class Seed:
             "last_update": (self.last_update and self.last_update.isoformat()) or None,
         }
         if cover := self.get_cover():
-            d['picture'] = {"url": cover.url("S")}
+            d["picture"] = {"url": cover.url("S")}
         return d
 
     def __repr__(self):
@@ -656,7 +623,7 @@ class ListChangeset(Changeset):
     def get_seed(self, seed):
         """Returns the seed object."""
         if isinstance(seed, dict):
-            seed = self._site.get(seed['key'])
+            seed = self._site.get(seed["key"])
         return Seed.from_db(self.get_list(), seed)
 
 
@@ -668,13 +635,13 @@ def get_work_sort_key(
     tpl: tuple[Work, WorkSeriesEdgeDB],
 ) -> tuple[str, int, float, str]:
     work, edge = tpl
-    position = edge.get('position')
+    position = edge.get("position")
     pos_str = str(position or "").strip()
 
     with contextlib.suppress(ValueError):
         return ("A: Numeric", 1, float(pos_str), work.key)
 
-    if match := re.fullmatch(r'(\d+)\s*-\s*(\d+)', pos_str):
+    if match := re.fullmatch(r"(\d+)\s*-\s*(\d+)", pos_str):
         lower = int(match.group(1))
         upper = int(match.group(2))
         return ("C: Range", upper - lower, float(lower), work.key)
@@ -693,39 +660,37 @@ class Series(List):
         return [seed.to_db() for seed in self.get_seeds()]
 
     @typing.override
-    def get_seeds(self, sort=False, resolve_redirects=False) -> list['Seed']:
+    def get_seeds(self, sort=False, resolve_redirects=False) -> list["Seed"]:
         # Need to query for a series' seeds
         work_keys = web.ctx.site.things(
             {
-                'type': '/type/work',
-                'series': {'series': {'key': self.key}},
-                'limit': self.SEED_LIMIT,
+                "type": "/type/work",
+                "series": {"series": {"key": self.key}},
+                "limit": self.SEED_LIMIT,
             },
         )
         works = cast(list[Work], web.ctx.site.get_many(work_keys))
-        series_edges = [
-            (work, edge) for work in works if (edge := work.find_series_edge(self.key))
-        ]
+        series_edges = [(work, edge) for work in works if (edge := work.find_series_edge(self.key))]
 
         sorted_edges = sorted(series_edges, key=get_work_sort_key)
 
         seeds: list[Seed] = []
         for work, edge in sorted_edges:
-            seed_json = cast(AnnotatedSeedDict, {'thing': {'key': work.key}})
+            seed_json = cast(AnnotatedSeedDict, {"thing": {"key": work.key}})
             update_list_seed_metadata(seed_json, edge)
             seeds.append(Seed.from_json(self, seed_json))
         return seeds
 
 
 def register_models():
-    client.register_thing_class('/type/list', List)
-    client.register_thing_class('/type/series', Series)
-    client.register_changeset_class('lists', ListChangeset)
-    client.register_changeset_class('series', ListChangeset)
+    client.register_thing_class("/type/list", List)
+    client.register_thing_class("/type/series", Series)
+    client.register_changeset_class("lists", ListChangeset)
+    client.register_changeset_class("series", ListChangeset)
 
 
 def register_types():
     from infogami.utils import types
 
-    types.register_type(r'^(/people/[^/]+)?/lists/OL\d+L$', '/type/list')
-    types.register_type(r'^/series/OL\d+L$', '/type/series')
+    types.register_type(r"^(/people/[^/]+)?/lists/OL\d+L$", "/type/list")
+    types.register_type(r"^/series/OL\d+L$", "/type/series")

--- a/openlibrary/plugins/openlibrary/bulk_tag.py
+++ b/openlibrary/plugins/openlibrary/bulk_tag.py
@@ -23,13 +23,11 @@ class bulk_tag_works(delegate.page):
         if not user or not user.is_member_of_any(ALLOWED_USERGROUPS):
             raise web.unauthorized()
 
-        i = web.input(
-            work_ids='', tags_to_add='', tags_to_remove='', book_page_edit=False
-        )
+        i = web.input(work_ids="", tags_to_add="", tags_to_remove="", book_page_edit=False)
 
-        works = i.work_ids.split(',')
-        tags_to_add = json.loads(i.tags_to_add or '{}')
-        tags_to_remove = json.loads(i.tags_to_remove or '{}')
+        works = i.work_ids.split(",")
+        tags_to_add = json.loads(i.tags_to_add or "{}")
+        tags_to_remove = json.loads(i.tags_to_remove or "{}")
 
         docs_to_update = []
         # Number of tags added per work:
@@ -42,10 +40,10 @@ class bulk_tag_works(delegate.page):
 
             current_subjects = {
                 # XXX : Should an empty list be the default for these?
-                'subjects': uniq(w.get('subjects', '')),
-                'subject_people': uniq(w.get('subject_people', '')),
-                'subject_places': uniq(w.get('subject_places', '')),
-                'subject_times': uniq(w.get('subject_times', '')),
+                "subjects": uniq(w.get("subjects", "")),
+                "subject_people": uniq(w.get("subject_people", "")),
+                "subject_places": uniq(w.get("subject_places", "")),
+                "subject_times": uniq(w.get("subject_times", "")),
             }
             for subject_type, add_list in tags_to_add.items():
                 if add_list:
@@ -59,37 +57,27 @@ class bulk_tag_works(delegate.page):
             for subject_type, remove_list in tags_to_remove.items():
                 if remove_list:
                     orig_len = len(current_subjects[subject_type])
-                    current_subjects[subject_type] = [
-                        item
-                        for item in current_subjects[subject_type]
-                        if item not in remove_list
-                    ]
+                    current_subjects[subject_type] = [item for item in current_subjects[subject_type] if item not in remove_list]
                     docs_removing += orig_len - len(current_subjects[subject_type])
                     w[subject_type] = current_subjects[subject_type]
 
-            docs_to_update.append(
-                w.dict()
-            )  # need to convert class to raw dict in order for save_many to work
+            docs_to_update.append(w.dict())  # need to convert class to raw dict in order for save_many to work
 
-        web.ctx.site.save_many(
-            docs_to_update, comment="Bulk tagging works", action="bulk-edit-work-tags"
-        )
+        web.ctx.site.save_many(docs_to_update, comment="Bulk tagging works", action="bulk-edit-work-tags")
 
         def response(msg, status="success"):
-            return delegate.RawText(
-                json.dumps({status: msg}), content_type="application/json"
-            )
+            return delegate.RawText(json.dumps({status: msg}), content_type="application/json")
 
         # Number of times the handler was hit:
-        stats.increment('ol.tags.bulk_update')
+        stats.increment("ol.tags.bulk_update")
         if i.book_page_edit:
-            stats.increment('ol.tags.bulk_update.book_page.add', n=docs_adding)
-            stats.increment('ol.tags.bulk_update.book_page.remove', n=docs_removing)
+            stats.increment("ol.tags.bulk_update.book_page.add", n=docs_adding)
+            stats.increment("ol.tags.bulk_update.book_page.remove", n=docs_removing)
         else:
-            stats.increment('ol.tags.bulk_update.add', n=docs_adding)
-            stats.increment('ol.tags.bulk_update.remove', n=docs_removing)
+            stats.increment("ol.tags.bulk_update.add", n=docs_adding)
+            stats.increment("ol.tags.bulk_update.remove", n=docs_removing)
 
-        return response('Tagged works successfully')
+        return response("Tagged works successfully")
 
 
 def setup():

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -24,11 +24,11 @@ from openlibrary.utils import get_software_version
 status_info: dict[str, Any] = {}
 feature_flags: dict[str, Any] = {}
 
-TESTING_STATE_FILE = Path('./_testing-prs.json')
+TESTING_STATE_FILE = Path("./_testing-prs.json")
 _GITHUB_API_BASE = "https://api.github.com/repos/internetarchive/openlibrary"
 _JENKINS_URL = "https://jenkins.openlibrary.org/job/testing-deploy/buildWithParameters"
 _JENKINS_JOB_URL = "https://jenkins.openlibrary.org/job/ol-dev1-deploy%20(internal)/"
-_DRIFT_CACHE_KEY = 'status.github_pr_drift'
+_DRIFT_CACHE_KEY = "status.github_pr_drift"
 _DRIFT_CACHE_TTL = 5 * 60  # 5 minutes
 
 
@@ -40,13 +40,9 @@ class status(delegate.page):
         if testing_state:
             drift_info, _ = _get_drift_info(testing_state)
         show_testing = testing_state is not None and is_maintainer_user
-        last_deploy = testing_state.last_deploy_at if testing_state else ''
+        last_deploy = testing_state.last_deploy_at if testing_state else ""
         has_pending = bool(testing_state) and any(
-            p.pull_latest_sha
-            or p.pending_active is not None
-            or drift_info.get(p.pr, {}).get('merged', False)
-            or not last_deploy
-            or p.added_at > last_deploy
+            p.pull_latest_sha or p.pending_active is not None or drift_info.get(p.pr, {}).get("merged", False) or not last_deploy or p.added_at > last_deploy
             for p in testing_state.prs
         )
         i = web.input(deploy_triggered=None, drift_refreshed=None)
@@ -67,13 +63,13 @@ class status(delegate.page):
 
 
 class status_add(delegate.page):
-    path = '/status/add'
+    path = "/status/add"
 
     def POST(self):
         if not _is_maintainer():
             raise web.unauthorized()
-        i = web.input(pr='')
-        raw = re.split(r'[\s,]+', i.pr.strip())
+        i = web.input(pr="")
+        raw = re.split(r"[\s,]+", i.pr.strip())
         pr_numbers = []
         for val in raw:
             if val:
@@ -81,36 +77,36 @@ class status_add(delegate.page):
                     pr_numbers.append(_parse_pr_number(val))
         if not pr_numbers:
             raise web.badrequest()
-        state = _load_testing_state() or TestingState(last_deploy_at='', prs=[])
+        state = _load_testing_state() or TestingState(last_deploy_at="", prs=[])
         existing = {p.pr for p in state.prs}
         user = get_current_user()
         for pr_number in pr_numbers:
             if pr_number not in existing:
                 info = _get_pr_info(pr_number)
-                if not info['head_sha']:
+                if not info["head_sha"]:
                     continue  # GitHub API unavailable or invalid PR
                 state.prs.append(
                     TestingPR(
                         pr=pr_number,
-                        commit=info['head_sha'],
+                        commit=info["head_sha"],
                         active=True,
-                        title=info['title'],
+                        title=info["title"],
                         added_at=datetime.datetime.now(datetime.UTC).isoformat(),
-                        added_by=user.key.split('/')[-1] if user else '',
-                        author=info['author'],
-                        author_avatar=info['author_avatar'],
-                        assignee=info['assignee'],
-                        assignee_avatar=info['assignee_avatar'],
+                        added_by=user.key.split("/")[-1] if user else "",
+                        author=info["author"],
+                        author_avatar=info["author_avatar"],
+                        assignee=info["assignee"],
+                        assignee_avatar=info["assignee_avatar"],
                     )
                 )
                 existing.add(pr_number)
         _save_testing_state(state)
         _evict_drift_cache()
-        raise web.seeother('/status')
+        raise web.seeother("/status")
 
 
 class status_remove(delegate.page):
-    path = '/status/remove'
+    path = "/status/remove"
 
     def POST(self):
         if not _is_maintainer():
@@ -120,11 +116,11 @@ class status_remove(delegate.page):
         if state := _load_testing_state():
             state.prs = [p for p in state.prs if p.pr not in to_remove]
             _save_testing_state(state)
-        raise web.seeother('/status')
+        raise web.seeother("/status")
 
 
 class status_enable(delegate.page):
-    path = '/status/enable'
+    path = "/status/enable"
 
     def POST(self):
         if not _is_maintainer():
@@ -133,16 +129,16 @@ class status_enable(delegate.page):
         to_enable = {int(p) for p in i.prs}
         state = _load_testing_state()
         if not state or not to_enable:
-            raise web.seeother('/status')
+            raise web.seeother("/status")
         for p in state.prs:
             if p.pr in to_enable:
                 p.pending_active = True
         _save_testing_state(state)
-        raise web.seeother('/status')
+        raise web.seeother("/status")
 
 
 class status_disable(delegate.page):
-    path = '/status/disable'
+    path = "/status/disable"
 
     def POST(self):
         if not _is_maintainer():
@@ -151,16 +147,16 @@ class status_disable(delegate.page):
         to_disable = {int(p) for p in i.prs}
         state = _load_testing_state()
         if not state or not to_disable:
-            raise web.seeother('/status')
+            raise web.seeother("/status")
         for p in state.prs:
             if p.pr in to_disable:
                 p.pending_active = False
         _save_testing_state(state)
-        raise web.seeother('/status')
+        raise web.seeother("/status")
 
 
 class status_pull_latest(delegate.page):
-    path = '/status/pull-latest'
+    path = "/status/pull-latest"
 
     def POST(self):
         if not _is_maintainer():
@@ -169,53 +165,51 @@ class status_pull_latest(delegate.page):
         to_update = {int(p) for p in i.prs}
         state = _load_testing_state()
         if not state or not to_update:
-            raise web.seeother('/status')
+            raise web.seeother("/status")
         for p in state.prs:
             if p.pr in to_update:
                 info = _get_pr_info(p.pr)
-                if info['head_sha'] and info['head_sha'] != p.commit:
-                    p.pull_latest_sha = info['head_sha']
+                if info["head_sha"] and info["head_sha"] != p.commit:
+                    p.pull_latest_sha = info["head_sha"]
         _save_testing_state(state)
-        raise web.seeother('/status')
+        raise web.seeother("/status")
 
 
 class status_deploy(delegate.page):
-    path = '/status/deploy'
+    path = "/status/deploy"
 
     def POST(self):
         if not _is_maintainer():
             raise web.unauthorized()
         state = _load_testing_state()
         if not state:
-            raise web.seeother('/status')
+            raise web.seeother("/status")
         # Apply all pending changes before deploying
         for p in state.prs:
             if p.pull_latest_sha:
                 p.commit = p.pull_latest_sha
-                p.pull_latest_sha = ''
+                p.pull_latest_sha = ""
             if p.pending_active is not None:
                 p.active = p.pending_active
                 p.pending_active = None
         # Remove PRs that have already been merged into master
         drift_info, _ = _get_drift_info(state)
-        state.prs = [
-            p for p in state.prs if not drift_info.get(p.pr, {}).get('merged', False)
-        ]
+        state.prs = [p for p in state.prs if not drift_info.get(p.pr, {}).get("merged", False)]
         state.last_deploy_at = datetime.datetime.now(datetime.UTC).isoformat()
         _save_testing_state(state)
         _evict_drift_cache()
         triggered = _trigger_rebuild()
-        raise web.seeother('/status?deploy_triggered=1' if triggered else '/status')
+        raise web.seeother("/status?deploy_triggered=1" if triggered else "/status")
 
 
 class status_refresh(delegate.page):
-    path = '/status/refresh'
+    path = "/status/refresh"
 
     def POST(self):
         if not _is_maintainer():
             raise web.unauthorized()
         _evict_drift_cache()
-        raise web.seeother('/status?drift_refreshed=1')
+        raise web.seeother("/status?drift_refreshed=1")
 
 
 @functools.cache
@@ -226,12 +220,12 @@ def get_dev_merged_status():
 @dataclass
 class DevMergedStatus:
     git_status: str
-    pr_statuses: 'list[PRStatus]'
+    pr_statuses: "list[PRStatus]"
     footer: str
 
     @staticmethod
-    def from_output(output: str) -> 'DevMergedStatus':
-        dev_merged_pieces = output.split('\n---\n')
+    def from_output(output: str) -> "DevMergedStatus":
+        dev_merged_pieces = output.split("\n---\n")
         return DevMergedStatus(
             git_status=dev_merged_pieces[0],
             pr_statuses=list(map(PRStatus.from_output, dev_merged_pieces[1:-1])),
@@ -239,9 +233,9 @@ class DevMergedStatus:
         )
 
     @staticmethod
-    def from_file() -> 'DevMergedStatus | None':
+    def from_file() -> "DevMergedStatus | None":
         """If we're on testing and the file exists, return staged PRs"""
-        fp = Path('./_dev-merged_status.txt')
+        fp = Path("./_dev-merged_status.txt")
         if fp.exists() and (contents := fp.read_text()):
             return DevMergedStatus.from_output(contents)
         return None
@@ -251,9 +245,7 @@ class DevMergedStatus:
 
         pull_ids = [pr.pull_id for pr in self.pr_statuses if pr.pull_id]
 
-        return f"https://github.com/internetarchive/openlibrary/pulls?{urlencode({
-            "q": "is:pr is:open " + " ".join([f"#{num}" for num in pull_ids])
-        })}"
+        return f"https://github.com/internetarchive/openlibrary/pulls?{urlencode({'q': 'is:pr is:open ' + ' '.join([f'#{num}' for num in pull_ids])})}"
 
 
 @dataclass
@@ -264,14 +256,14 @@ class PRStatus:
 
     @property
     def name(self) -> str | None:
-        if '#' in self.pull_line:
-            return self.pull_line.split(' # ')[1]
+        if "#" in self.pull_line:
+            return self.pull_line.split(" # ")[1]
         else:
             return self.pull_line
 
     @property
     def pull_id(self) -> int | None:
-        if m := re.match(r'^origin pull/(\d+)', self.pull_line):
+        if m := re.match(r"^origin pull/(\d+)", self.pull_line):
             return int(m.group(1))
         else:
             return None
@@ -279,14 +271,14 @@ class PRStatus:
     @property
     def link(self) -> str | None:
         if self.pull_id is not None:
-            return f'https://github.com/internetarchive/openlibrary/pull/{self.pull_id}'
+            return f"https://github.com/internetarchive/openlibrary/pull/{self.pull_id}"
         else:
             return None
 
     @staticmethod
-    def from_output(output: str) -> 'PRStatus':
-        lines = output.strip().split('\n')
-        return PRStatus(pull_line=lines[0], status=lines[-1], body='\n'.join(lines[1:]))
+    def from_output(output: str) -> "PRStatus":
+        lines = output.strip().split("\n")
+        return PRStatus(pull_line=lines[0], status=lines[-1], body="\n".join(lines[1:]))
 
 
 @dataclass
@@ -297,12 +289,12 @@ class TestingPR:
     title: str
     added_at: str  # ISO timestamp
     added_by: str  # OL username
-    pull_latest_sha: str = ''  # pending SHA from "Fetch Latest"; applied on deploy
+    pull_latest_sha: str = ""  # pending SHA from "Fetch Latest"; applied on deploy
     pending_active: bool | None = None  # pending enable/disable; applied on deploy
-    author: str = ''  # GitHub login of PR author
-    author_avatar: str = ''  # GitHub avatar URL (append &s=N for sizing)
-    assignee: str = ''  # GitHub login of assignee, empty if unassigned
-    assignee_avatar: str = ''  # GitHub avatar URL for assignee
+    author: str = ""  # GitHub login of PR author
+    author_avatar: str = ""  # GitHub avatar URL (append &s=N for sizing)
+    assignee: str = ""  # GitHub login of assignee, empty if unassigned
+    assignee_avatar: str = ""  # GitHub avatar URL for assignee
 
     @property
     def short_commit(self) -> str:
@@ -310,50 +302,50 @@ class TestingPR:
 
     @property
     def short_pull_latest(self) -> str:
-        return self.pull_latest_sha[:7] if self.pull_latest_sha else ''
+        return self.pull_latest_sha[:7] if self.pull_latest_sha else ""
 
     @property
     def added_date(self) -> str:
-        return self.added_at[:10] if self.added_at else ''
+        return self.added_at[:10] if self.added_at else ""
 
     def to_dict(self) -> dict:
         d = {
-            'pr': self.pr,
-            'commit': self.commit,
-            'active': self.active,
-            'title': self.title,
-            'added_at': self.added_at,
-            'added_by': self.added_by,
+            "pr": self.pr,
+            "commit": self.commit,
+            "active": self.active,
+            "title": self.title,
+            "added_at": self.added_at,
+            "added_by": self.added_by,
         }
         if self.pull_latest_sha:
-            d['pull_latest_sha'] = self.pull_latest_sha
+            d["pull_latest_sha"] = self.pull_latest_sha
         if self.pending_active is not None:
-            d['pending_active'] = self.pending_active
+            d["pending_active"] = self.pending_active
         if self.author:
-            d['author'] = self.author
+            d["author"] = self.author
         if self.author_avatar:
-            d['author_avatar'] = self.author_avatar
+            d["author_avatar"] = self.author_avatar
         if self.assignee:
-            d['assignee'] = self.assignee
+            d["assignee"] = self.assignee
         if self.assignee_avatar:
-            d['assignee_avatar'] = self.assignee_avatar
+            d["assignee_avatar"] = self.assignee_avatar
         return d
 
     @classmethod
-    def from_dict(cls, d: dict) -> 'TestingPR':
+    def from_dict(cls, d: dict) -> "TestingPR":
         return cls(
-            pr=d['pr'],
-            commit=d['commit'],
-            active=d.get('active', True),
-            title=d.get('title', f"PR #{d['pr']}"),
-            added_at=d.get('added_at', ''),
-            added_by=d.get('added_by', ''),
-            pull_latest_sha=d.get('pull_latest_sha', ''),
-            pending_active=d.get('pending_active'),
-            author=d.get('author', ''),
-            author_avatar=d.get('author_avatar', ''),
-            assignee=d.get('assignee', ''),
-            assignee_avatar=d.get('assignee_avatar', ''),
+            pr=d["pr"],
+            commit=d["commit"],
+            active=d.get("active", True),
+            title=d.get("title", f"PR #{d['pr']}"),
+            added_at=d.get("added_at", ""),
+            added_by=d.get("added_by", ""),
+            pull_latest_sha=d.get("pull_latest_sha", ""),
+            pending_active=d.get("pending_active"),
+            author=d.get("author", ""),
+            author_avatar=d.get("author_avatar", ""),
+            assignee=d.get("assignee", ""),
+            assignee_avatar=d.get("assignee_avatar", ""),
         )
 
 
@@ -364,26 +356,26 @@ class TestingState:
 
     def to_dict(self) -> dict:
         return {
-            'last_deploy_at': self.last_deploy_at,
-            'prs': [p.to_dict() for p in self.prs],
+            "last_deploy_at": self.last_deploy_at,
+            "prs": [p.to_dict() for p in self.prs],
         }
 
     @classmethod
-    def from_dict(cls, d: dict) -> 'TestingState':
+    def from_dict(cls, d: dict) -> "TestingState":
         return cls(
-            last_deploy_at=d.get('last_deploy_at', ''),
-            prs=[TestingPR.from_dict(p) for p in d.get('prs', [])],
+            last_deploy_at=d.get("last_deploy_at", ""),
+            prs=[TestingPR.from_dict(p) for p in d.get("prs", [])],
         )
 
 
-def _load_testing_state() -> 'TestingState | None':
+def _load_testing_state() -> "TestingState | None":
     """Returns TestingState if state file exists, None otherwise."""
     if TESTING_STATE_FILE.exists():
         data = json.loads(TESTING_STATE_FILE.read_text())
         if isinstance(data, list):
             # Backward compat: old format was a bare array
             return TestingState(
-                last_deploy_at='',
+                last_deploy_at="",
                 prs=[TestingPR.from_dict(d) for d in data],
             )
         return TestingState.from_dict(data)
@@ -397,25 +389,23 @@ def _save_testing_state(state: TestingState) -> None:
 
 def _is_maintainer() -> bool:
     user = get_current_user()
-    return bool(
-        user and user.is_member_of_any(['/usergroup/maintainers', '/usergroup/admin'])
-    )
+    return bool(user and user.is_member_of_any(["/usergroup/maintainers", "/usergroup/admin"]))
 
 
 def _github_get(path: str) -> dict:
     url = f"{_GITHUB_API_BASE}/{path}"
     headers = {
-        'Accept': 'application/vnd.github+json',
-        'User-Agent': 'openlibrary-status',
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "openlibrary-status",
     }
-    if token := getattr(config, 'github_api_token', None):
-        headers['Authorization'] = f'Bearer {token}'
+    if token := getattr(config, "github_api_token", None):
+        headers["Authorization"] = f"Bearer {token}"
     req = urllib.request.Request(url, headers=headers)
     with urllib.request.urlopen(req, timeout=5) as resp:
         return json.loads(resp.read())
 
 
-def _get_drift_info(state: TestingState) -> 'tuple[dict, bool]':
+def _get_drift_info(state: TestingState) -> "tuple[dict, bool]":
     """Return (drift_dict, from_cache). Checks memcache first; fetches GitHub on miss.
 
     Keys are int PR numbers. JSON round-trip via memcache stringifies keys, so we
@@ -431,9 +421,9 @@ def _get_drift_info(state: TestingState) -> 'tuple[dict, bool]':
     state_changed = False
     for p in state.prs:
         info = _get_pr_drift(p)
-        drift[p.pr] = {k: info[k] for k in ('head_sha', 'drift', 'merged')}
-        for attr in ('title', 'author', 'author_avatar', 'assignee', 'assignee_avatar'):
-            new_val = info.get(attr, '')
+        drift[p.pr] = {k: info[k] for k in ("head_sha", "drift", "merged")}
+        for attr in ("title", "author", "author_avatar", "assignee", "assignee_avatar"):
+            new_val = info.get(attr, "")
             if new_val and getattr(p, attr) != new_val:
                 setattr(p, attr, new_val)
                 state_changed = True
@@ -451,24 +441,24 @@ def _get_pr_info(pr_number: int) -> dict:
     """Fetch title, HEAD SHA, author, and assignee for a PR from GitHub."""
     try:
         pr = _github_get(f"pulls/{pr_number}")
-        user = pr.get('user') or {}
-        assignee = pr.get('assignee') or {}
+        user = pr.get("user") or {}
+        assignee = pr.get("assignee") or {}
         return {
-            'title': pr.get('title', f'PR #{pr_number}'),
-            'head_sha': pr['head']['sha'],
-            'author': user.get('login', ''),
-            'author_avatar': user.get('avatar_url', ''),
-            'assignee': assignee.get('login', ''),
-            'assignee_avatar': assignee.get('avatar_url', ''),
+            "title": pr.get("title", f"PR #{pr_number}"),
+            "head_sha": pr["head"]["sha"],
+            "author": user.get("login", ""),
+            "author_avatar": user.get("avatar_url", ""),
+            "assignee": assignee.get("login", ""),
+            "assignee_avatar": assignee.get("avatar_url", ""),
         }
     except (urllib.error.URLError, KeyError, ValueError, json.JSONDecodeError):
         return {
-            'title': f'PR #{pr_number}',
-            'head_sha': '',
-            'author': '',
-            'author_avatar': '',
-            'assignee': '',
-            'assignee_avatar': '',
+            "title": f"PR #{pr_number}",
+            "head_sha": "",
+            "author": "",
+            "author_avatar": "",
+            "assignee": "",
+            "assignee_avatar": "",
         }
 
 
@@ -480,59 +470,59 @@ def _get_pr_drift(pr: TestingPR) -> dict:
     """
     try:
         gh = _github_get(f"pulls/{pr.pr}")
-        head_sha = gh['head']['sha']
-        merged = bool(gh.get('merged') or gh.get('merged_at'))
+        head_sha = gh["head"]["sha"]
+        merged = bool(gh.get("merged") or gh.get("merged_at"))
         stored = pr.commit.strip()
         if head_sha == stored or (len(stored) < 40 and head_sha.startswith(stored)):
             drift = 0
         else:
             try:
                 cmp = _github_get(f"compare/{stored}...{head_sha}")
-                drift = cmp.get('ahead_by', -1)
+                drift = cmp.get("ahead_by", -1)
             except (urllib.error.URLError, ValueError, json.JSONDecodeError):
                 drift = -1
-        user = gh.get('user') or {}
-        assignee = gh.get('assignee') or {}
+        user = gh.get("user") or {}
+        assignee = gh.get("assignee") or {}
         return {
-            'head_sha': head_sha[:7],
-            'drift': drift,
-            'merged': merged,
-            'title': gh.get('title', f'PR #{pr.pr}'),
-            'author': user.get('login', ''),
-            'author_avatar': user.get('avatar_url', ''),
-            'assignee': assignee.get('login', ''),
-            'assignee_avatar': assignee.get('avatar_url', ''),
+            "head_sha": head_sha[:7],
+            "drift": drift,
+            "merged": merged,
+            "title": gh.get("title", f"PR #{pr.pr}"),
+            "author": user.get("login", ""),
+            "author_avatar": user.get("avatar_url", ""),
+            "assignee": assignee.get("login", ""),
+            "assignee_avatar": assignee.get("avatar_url", ""),
         }
     except (urllib.error.URLError, KeyError, ValueError, json.JSONDecodeError):
         return {
-            'head_sha': '',
-            'drift': -1,
-            'merged': False,
-            'title': '',
-            'author': '',
-            'author_avatar': '',
-            'assignee': '',
-            'assignee_avatar': '',
+            "head_sha": "",
+            "drift": -1,
+            "merged": False,
+            "title": "",
+            "author": "",
+            "author_avatar": "",
+            "assignee": "",
+            "assignee_avatar": "",
         }
 
 
 def _parse_pr_number(value: str) -> int:
     value = value.strip()
-    if '/issues/' in value:
+    if "/issues/" in value:
         raise ValueError(f"Not a PR URL (looks like an issue): {value!r}")
-    if m := re.search(r'/pull/(\d+)', value):
+    if m := re.search(r"/pull/(\d+)", value):
         return int(m.group(1))
-    return int(value.lstrip('#'))
+    return int(value.lstrip("#"))
 
 
 def _trigger_rebuild() -> bool:
     """Call Jenkins to trigger a rebuild. No-op if jenkins_token is not configured."""
-    token = getattr(config, 'jenkins_token', None)
+    token = getattr(config, "jenkins_token", None)
     if not token:
         return False
     state = _load_testing_state()
     prs = state.prs if state else []
-    lines = '\n'.join(f"origin pull/{p.pr}/head  # {p.title}" for p in prs if p.active)
+    lines = "\n".join(f"origin pull/{p.pr}/head  # {p.title}" for p in prs if p.active)
     url = f"{_JENKINS_URL}?{urlencode({'token': token, 'GH_REPO_AND_BRANCH': lines})}"
     try:
         urllib.request.urlopen(url, timeout=10)
@@ -543,11 +533,7 @@ def _trigger_rebuild() -> bool:
 
 @public
 def get_git_revision_short_hash():
-    return (
-        status_info.get('Software version')
-        if status_info and isinstance(status_info, dict)
-        else None
-    )
+    return status_info.get("Software version") if status_info and isinstance(status_info, dict) else None
 
 
 def get_features_enabled():
@@ -567,5 +553,5 @@ def setup():
     feature_flags = get_features_enabled()
 
     # Host is e.g. ol-web4.blah.archive.org ; we just want the first subdomain
-    first_subdomain = host.split('.')[0] or 'unknown'
-    stats.increment('ol.servers.%s.started' % first_subdomain)
+    first_subdomain = host.split(".")[0] or "unknown"
+    stats.increment("ol.servers.%s.started" % first_subdomain)

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -63,9 +63,7 @@ def make_author(key: str, name: str) -> Author:
     <Author: '/authors/OL123A'>
     """
     key = "/authors/" + key
-    return site.get().new(
-        key, {"key": key, "type": {"key": "/type/author"}, "name": name}
-    )
+    return site.get().new(key, {"key": key, "type": {"key": "/type/author"}, "name": name})
 
 
 def make_work(doc: dict[str, str | list]) -> web.Storage:
@@ -77,14 +75,11 @@ def make_work(doc: dict[str, str | list]) -> web.Storage:
 
     w = web.storage(doc)
 
-    w.authors = [
-        make_author(key, name)
-        for key, name in zip(doc.get('author_key', []), doc.get('author_name', []))
-    ]
+    w.authors = [make_author(key, name) for key, name in zip(doc.get("author_key", []), doc.get("author_name", []))]
 
     w.cover_url = "/static/images/icons/avatar_book-sm.png"
-    w.setdefault('ia', [])
-    w.setdefault('first_publish_year', None)
+    w.setdefault("ia", [])
+    w.setdefault("first_publish_year", None)
     return w
 
 
@@ -121,8 +116,8 @@ def new_doc(type_: str, **data) -> Author | Edition | Work | List | Series:
         key = f"/{type_.rsplit('/', maxsplit=1)[-1]}/OL{next_value}L"
     else:
         key = web.ctx.site.new_key(type_)
-    data['key'] = key
-    data['type'] = {"key": type_}
+    data["key"] = key
+    data["type"] = {"key": type_}
     return web.ctx.site.new(key, data)
 
 
@@ -143,9 +138,7 @@ class DocSaveHelper:
         if self.docs:
             web.ctx.site.save_many(self.docs, **kw)
 
-    def create_authors_from_form_data(
-        self, authors: list[dict], author_names: list[str], _test: bool = False
-    ) -> bool:
+    def create_authors_from_form_data(self, authors: list[dict], author_names: list[str], _test: bool = False) -> bool:
         """
         Create any __new__ authors in the provided array. Updates the authors
         dicts _in place_ with the new key.
@@ -154,17 +147,15 @@ class DocSaveHelper:
         """
         created = False
         for author_dict, author_name in zip(authors, author_names):
-            if author_dict['author']['key'] == '__new__':
+            if author_dict["author"]["key"] == "__new__":
                 created = True
                 if not _test:
-                    doc = new_doc('/type/author', name=author_name)
+                    doc = new_doc("/type/author", name=author_name)
                     self.save(doc)
-                    author_dict['author']['key'] = doc.key
+                    author_dict["author"]["key"] = doc.key
         return created
 
-    def create_series_from_form_data(
-        self, series: list[dict], series_names: list[str], _test: bool = False
-    ) -> bool:
+    def create_series_from_form_data(self, series: list[dict], series_names: list[str], _test: bool = False) -> bool:
         """
         Create any __new__ series in the provided array. Updates the series
         dicts _in place_ with the new key.
@@ -173,12 +164,12 @@ class DocSaveHelper:
         """
         created = False
         for series_dict, series_name in zip(series, series_names):
-            if series_dict['series']['key'] == '__new__':
+            if series_dict["series"]["key"] == "__new__":
                 created = True
                 if not _test:
-                    doc = new_doc('/type/series', name=series_name)
+                    doc = new_doc("/type/series", name=series_name)
                     self.save(doc)
-                    series_dict['series']['key'] = doc.key
+                    series_dict["series"]["key"] = doc.key
         return created
 
 
@@ -228,9 +219,7 @@ class addbook(delegate.page):
         if author and author not in authors:
             authors.append(author)
 
-        return render_template(
-            'books/add', work=work, authors=authors, recaptcha=get_recaptcha()
-        )
+        return render_template("books/add", work=work, authors=authors, recaptcha=get_recaptcha())
 
     def has_permission(self) -> bool:
         """
@@ -252,43 +241,39 @@ class addbook(delegate.page):
         i.title = i.book_title
 
         if spamcheck.is_spam(i, allow_privileged_edits=True):
-            return render_template(
-                "message.html", "Oops", 'Something went wrong. Please try again later.'
-            )
+            return render_template("message.html", "Oops", "Something went wrong. Please try again later.")
 
         if not accounts.get_current_user():
             recap = get_recaptcha()
             if recap and not recap.validate():
                 return render_template(
-                    'message.html',
-                    'Recaptcha solution was incorrect',
+                    "message.html",
+                    "Recaptcha solution was incorrect",
                     'Please <a href="javascript:history.back()">go back</a> and try again.',
                 )
 
         i = utils.unflatten(i)
         saveutil = DocSaveHelper()
-        created_author = saveutil.create_authors_from_form_data(
-            i.authors, i.author_names, _test=i._test == 'true'
-        )
+        created_author = saveutil.create_authors_from_form_data(i.authors, i.author_names, _test=i._test == "true")
         match = None if created_author else self.find_matches(i)
 
-        if i._test == 'true' and not isinstance(match, list):
+        if i._test == "true" and not isinstance(match, list):
             if match:
                 return f'Matched <a href="{match.key}">{match.key}</a>'
             else:
-                return 'No match found'
+                return "No match found"
 
         if isinstance(match, list):
             # multiple matches
-            return render_template('books/check', i, match)
+            return render_template("books/check", i, match)
 
-        elif match and match.key.startswith('/books'):
+        elif match and match.key.startswith("/books"):
             # work match and edition match, match is an Edition
             if i.web_book_url:
                 match.provider = [{"url": i.web_book_url, "format": "web"}]
             return self.work_edition_match(match)
 
-        elif match and match.key.startswith('/works'):
+        elif match and match.key.startswith("/works"):
             # work match but not edition
             work = match
             return self.work_match(saveutil, work, i)
@@ -296,9 +281,7 @@ class addbook(delegate.page):
             # no match
             return self.no_match(saveutil, i)
 
-    def find_matches(
-        self, i: web.utils.Storage
-    ) -> None | Work | Edition | list[web.utils.Storage]:
+    def find_matches(self, i: web.utils.Storage) -> None | Work | Edition | list[web.utils.Storage]:
         """
         Tries to find an edition, or work, or multiple work candidates that match the
         given input data.
@@ -317,10 +300,10 @@ class addbook(delegate.page):
         author_key = i.authors and i.authors[0].author.key
 
         # work is set from the templates/books/check.html page.
-        work_key = i.get('work')
+        work_key = i.get("work")
 
         # work_key is set to none-of-these when user selects none-of-these link.
-        if work_key == 'none-of-these':
+        if work_key == "none-of-these":
             return None  # Case 1, from check page
 
         work = work_key and web.ctx.site.get(work_key)
@@ -349,7 +332,7 @@ class addbook(delegate.page):
         solr = get_solr()
         # Less exact solr search than try_edition_match(), search by supplied title and author only.
         result = solr.select(
-            {'title': i.title, 'author_key': author_key.split("/")[-1]},
+            {"title": i.title, "author_key": author_key.split("/")[-1]},
             doc_wrapper=make_work,
             q_op="AND",
         )
@@ -394,23 +377,23 @@ class addbook(delegate.page):
             return None
 
         q: dict = {}
-        work and q.setdefault('key', work.key.split("/")[-1])
-        title and q.setdefault('title', title)
-        author_key and q.setdefault('author_key', author_key.split('/')[-1])
-        publisher and q.setdefault('publisher', publisher)
+        work and q.setdefault("key", work.key.split("/")[-1])
+        title and q.setdefault("title", title)
+        author_key and q.setdefault("author_key", author_key.split("/")[-1])
+        publisher and q.setdefault("publisher", publisher)
         # There are some errors indexing of publish_year. Use publish_date until it is fixed
-        publish_year and q.setdefault('publish_date', publish_year)
+        publish_year and q.setdefault("publish_date", publish_year)
 
         mapping = {
-            'isbn_10': 'isbn',
-            'isbn_13': 'isbn',
-            'lccn': 'lccn',
-            'oclc_numbers': 'oclc',
-            'ocaid': 'ia',
+            "isbn_10": "isbn",
+            "isbn_13": "isbn",
+            "lccn": "lccn",
+            "oclc_numbers": "oclc",
+            "ocaid": "ia",
         }
         if id_value and id_name in mapping:
-            if id_name.startswith('isbn'):
-                id_value = id_value.replace('-', '')
+            if id_name.startswith("isbn"):
+                id_value = id_value.replace("-", "")
             q[mapping[id_name]] = id_value
 
         solr = get_solr()
@@ -422,20 +405,13 @@ class addbook(delegate.page):
         elif len(result.docs) == 1:
             # found one work match
             work = result.docs[0]
-            publisher = publisher and fuzzy_find(
-                publisher, work.publisher, stopwords=("publisher", "publishers", "and")
-            )
+            publisher = publisher and fuzzy_find(publisher, work.publisher, stopwords=("publisher", "publishers", "and"))
 
-            editions = web.ctx.site.get_many(
-                ["/books/" + key for key in work.edition_key]
-            )
+            editions = web.ctx.site.get_many(["/books/" + key for key in work.edition_key])
             for e in editions:
                 if publisher and (not e.publishers or e.publishers[0] != publisher):
                     continue
-                if publish_year and (
-                    not e.publish_date
-                    or publish_year != self.extract_year(e.publish_date)
-                ):
+                if publish_year and (not e.publish_date or publish_year != self.extract_year(e.publish_date)):
                     continue
                 if id_value and id_name in mapping:  # noqa: SIM102
                     if id_name not in e or id_value not in e[id_name]:
@@ -445,9 +421,7 @@ class addbook(delegate.page):
 
         return None
 
-    def work_match(
-        self, saveutil: DocSaveHelper, work: Work, i: web.utils.Storage
-    ) -> NoReturn:
+    def work_match(self, saveutil: DocSaveHelper, work: Work, i: web.utils.Storage) -> NoReturn:
         """
         Action for when a work, but not edition, is matched.
         Saves a new edition of work, created form the formdata i.
@@ -504,7 +478,7 @@ class addbook(delegate.page):
             publishers=[i.publisher],
             publish_date=i.publish_date,
         )
-        if i.get('web_book_url'):
+        if i.get("web_book_url"):
             edition.set_provider_data({"url": i.web_book_url, "format": "web"})
         if i.get("id_name") and i.get("id_value"):
             edition.set_identifiers([{"name": i.id_name, "value": i.id_value}])
@@ -512,8 +486,8 @@ class addbook(delegate.page):
 
 
 # remove existing definitions of addbook and addauthor
-delegate.pages.pop('/addbook', None)
-delegate.pages.pop('/addauthor', None)
+delegate.pages.pop("/addbook", None)
+delegate.pages.pop("/addauthor", None)
 
 
 class addbook(delegate.page):  # type: ignore[no-redef] # noqa: F811
@@ -546,9 +520,7 @@ def trim_value(value):
         value = [v2 for v in value for v2 in [trim_value(v)] if v2 is not None]
         return value or None
     elif isinstance(value, dict):
-        value = {
-            k: v2 for k, v in value.items() for v2 in [trim_value(v)] if v2 is not None
-        }
+        value = {k: v2 for k, v in value.items() for v2 in [trim_value(v)] if v2 is not None}
         return value or None
     else:
         return value
@@ -577,14 +549,10 @@ class SaveBookHelper:
         """
         Update work and edition documents according to the specified formdata.
         """
-        comment = formdata.pop('_comment', '')
+        comment = formdata.pop("_comment", "")
 
         user = accounts.get_current_user()
-        delete = (
-            user
-            and (user.is_admin() or user.is_super_librarian())
-            and formdata.pop('_delete', '')
-        )
+        delete = user and (user.is_admin() or user.is_super_librarian()) and formdata.pop("_delete", "")
 
         formdata = utils.unflatten(formdata)
         work_data, edition_data = self.process_input(formdata)
@@ -602,59 +570,53 @@ class SaveBookHelper:
         just_editing_work = edition_data is None
         if work_data:
             # Create any new authors that were added
-            saveutil.create_authors_from_form_data(
-                work_data.get("authors") or [], formdata.get('authors') or []
-            )
+            saveutil.create_authors_from_form_data(work_data.get("authors") or [], formdata.get("authors") or [])
 
             # Ditto for series
-            saveutil.create_series_from_form_data(
-                work_data.get("series") or [], formdata.get('series') or []
-            )
+            saveutil.create_series_from_form_data(work_data.get("series") or [], formdata.get("series") or [])
 
             if not just_editing_work:
                 # Mypy misses that "not just_editing_work" means there is edition data.
                 assert self.edition
                 # Handle orphaned editions
-                new_work_key = (edition_data.get('works') or [{'key': None}])[0]['key']
-                if self.work is None and (
-                    new_work_key is None or new_work_key == '__new__'
-                ):
+                new_work_key = (edition_data.get("works") or [{"key": None}])[0]["key"]
+                if self.work is None and (new_work_key is None or new_work_key == "__new__"):
                     # i.e. not moving to another work, create empty work
                     self.work = self.new_work(self.edition)
-                    edition_data.works = [{'key': self.work.key}]
+                    edition_data.works = [{"key": self.work.key}]
                     work_data.key = self.work.key
                 elif self.work is not None and new_work_key is None:
                     # we're trying to create an orphan; let's not do that
-                    edition_data.works = [{'key': self.work.key}]
+                    edition_data.works = [{"key": self.work.key}]
             if self.work is not None:
-                work_identifiers = work_data.pop('identifiers', {})
+                work_identifiers = work_data.pop("identifiers", {})
                 self.work.set_identifiers(work_identifiers)
                 self.work.update(work_data)
                 saveutil.save(self.work)
 
         if self.edition and edition_data:
             # Create a new work if so desired
-            new_work_key = (edition_data.get('works') or [{'key': None}])[0]['key']
+            new_work_key = (edition_data.get("works") or [{"key": None}])[0]["key"]
             if new_work_key == "__new__" and self.work is not None:
                 new_work = self.new_work(self.edition)
-                edition_data.works = [{'key': new_work.key}]
+                edition_data.works = [{"key": new_work.key}]
 
                 new_work_options = formdata.get(
-                    'new_work_options',
+                    "new_work_options",
                     {
-                        'copy_authors': 'no',
-                        'copy_subjects': 'no',
+                        "copy_authors": "no",
+                        "copy_subjects": "no",
                     },
                 )
 
-                if new_work_options.get('copy_authors') == 'yes' and self.work.authors:
+                if new_work_options.get("copy_authors") == "yes" and self.work.authors:
                     new_work.authors = self.work.authors
-                if new_work_options.get('copy_subjects') == 'yes':
+                if new_work_options.get("copy_subjects") == "yes":
                     for field in (
-                        'subjects',
-                        'subject_places',
-                        'subject_times',
-                        'subject_people',
+                        "subjects",
+                        "subject_places",
+                        "subject_times",
+                        "subject_people",
                     ):
                         if val := getattr(self.work, field, None):
                             new_work[field] = val
@@ -662,31 +624,27 @@ class SaveBookHelper:
                 self.work = new_work
                 saveutil.save(self.work)
 
-            identifiers = edition_data.pop('identifiers', [])
+            identifiers = edition_data.pop("identifiers", [])
             self.edition.set_identifiers(identifiers)
 
-            classifications = edition_data.pop('classifications', [])
+            classifications = edition_data.pop("classifications", [])
             self.edition.set_classifications(classifications)
 
-            self.edition.set_physical_dimensions(
-                edition_data.pop('physical_dimensions', None)
-            )
-            self.edition.set_weight(edition_data.pop('weight', None))
+            self.edition.set_physical_dimensions(edition_data.pop("physical_dimensions", None))
+            self.edition.set_weight(edition_data.pop("weight", None))
             try:
-                self.edition.set_toc_text(edition_data.pop('table_of_contents', None))
+                self.edition.set_toc_text(edition_data.pop("table_of_contents", None))
             except TocParseError as e:
-                raise ClientException(
-                    "400 Bad Request", f"Table of contents parse error: {e}"
-                )
+                raise ClientException("400 Bad Request", f"Table of contents parse error: {e}")
 
-            if edition_data.pop('translation', None) != 'yes':
+            if edition_data.pop("translation", None) != "yes":
                 edition_data.translation_of = None
                 edition_data.translated_from = None
 
-            if 'contributors' not in edition_data:
+            if "contributors" not in edition_data:
                 self.edition.contributors = []
 
-            providers = edition_data.pop('providers', [])
+            providers = edition_data.pop("providers", [])
             self.edition.set_providers(providers)
 
             self.edition.update(edition_data)
@@ -697,10 +655,10 @@ class SaveBookHelper:
     @staticmethod
     def new_work(edition: Edition) -> Work:
         return new_doc(
-            '/type/work',
-            title=edition.get('title'),
-            subtitle=edition.get('subtitle'),
-            covers=edition.get('covers', []),
+            "/type/work",
+            title=edition.get("title"),
+            subtitle=edition.get("subtitle"),
+            covers=edition.get("covers", []),
         )
 
     @staticmethod
@@ -709,12 +667,12 @@ class SaveBookHelper:
         doc._save(comment=comment)
 
     def process_input(self, i):
-        if 'edition' in i:
+        if "edition" in i:
             edition = self.process_edition(i.edition)
         else:
             edition = None
 
-        if 'work' in i and self.use_work_edits(i):
+        if "work" in i and self.use_work_edits(i):
             work = self.process_work(i.work)
         else:
             work = None
@@ -723,18 +681,18 @@ class SaveBookHelper:
 
     def process_edition(self, edition):
         """Process input data for edition."""
-        edition.publishers = edition.get('publishers', '').split(';')
-        edition.publish_places = edition.get('publish_places', '').split(';')
+        edition.publishers = edition.get("publishers", "").split(";")
+        edition.publish_places = edition.get("publish_places", "").split(";")
 
         edition = trim_doc(edition)
 
-        if list(edition.get('physical_dimensions', [])) == ['units']:
+        if list(edition.get("physical_dimensions", [])) == ["units"]:
             edition.physical_dimensions = None
 
-        if list(edition.get('weight', [])) == ['units']:
+        if list(edition.get("weight", [])) == ["units"]:
             edition.weight = None
 
-        for k in ['roles', 'identifiers', 'classifications']:
+        for k in ["roles", "identifiers", "classifications"]:
             edition[k] = edition.get(k) or []
 
         self._prevent_ocaid_deletion(edition)
@@ -759,31 +717,27 @@ class SaveBookHelper:
             """
             if not subjects:
                 return
-            f = io.StringIO(subjects.replace('\r\n', ''))
+            f = io.StringIO(subjects.replace("\r\n", ""))
             dedup = set()
-            for s in next(csv.reader(f, dialect='excel', skipinitialspace=True)):
+            for s in next(csv.reader(f, dialect="excel", skipinitialspace=True)):
                 if s.casefold() not in dedup:
                     yield s
                     dedup.add(s.casefold())
 
-        work.subjects = list(read_subject(work.get('subjects', '')))
-        work.subject_places = list(read_subject(work.get('subject_places', '')))
-        work.subject_times = list(read_subject(work.get('subject_times', '')))
-        work.subject_people = list(read_subject(work.get('subject_people', '')))
-        if ': ' in work.get('title', ''):
-            work.title, work.subtitle = work.title.split(': ', 1)
+        work.subjects = list(read_subject(work.get("subjects", "")))
+        work.subject_places = list(read_subject(work.get("subject_places", "")))
+        work.subject_times = list(read_subject(work.get("subject_times", "")))
+        work.subject_people = list(read_subject(work.get("subject_people", "")))
+        if ": " in work.get("title", ""):
+            work.title, work.subtitle = work.title.split(": ", 1)
         else:
             work.subtitle = None
 
-        for k in ['excerpts', 'links', 'identifiers']:
+        for k in ["excerpts", "links", "identifiers"]:
             work[k] = work.get(k, {})
 
         # ignore empty authors
-        work.authors = [
-            a
-            for a in work.get('authors', [])
-            if a.get('author', {}).get('key', '').strip()
-        ]
+        work.authors = [a for a in work.get("authors", []) if a.get("author", {}).get("key", "").strip()]
 
         return trim_doc(work)
 
@@ -795,24 +749,16 @@ class SaveBookHelper:
 
         # read ocaid from form data
         ocaid = next(
-            (
-                id_['value']
-                for id_ in edition.get('identifiers', [])
-                if id_['name'] == 'ocaid'
-            ),
+            (id_["value"] for id_ in edition.get("identifiers", []) if id_["name"] == "ocaid"),
             None,
         )
 
         # 'self.edition' is the edition doc from the db and 'edition' is the doc from formdata
-        if (
-            self.edition
-            and self.edition.get('ocaid')
-            and self.edition.get('ocaid') != ocaid
-        ):
+        if self.edition and self.edition.get("ocaid") and self.edition.get("ocaid") != ocaid:
             logger.warning(
                 "Attempt to change ocaid of %s from %r to %r.",
                 self.edition.key,
-                self.edition.get('ocaid'),
+                self.edition.get("ocaid"),
                 ocaid,
             )
             raise ValidationException("Changing Internet Archive ID is not allowed.")
@@ -824,15 +770,11 @@ class SaveBookHelper:
         If they don't, then we ignore the work edits.
         :param web.storage formdata: form data (parsed into a nested dict)
         """
-        if 'edition' not in formdata:
+        if "edition" not in formdata:
             # No edition data -> just editing work, so work data matters
             return True
 
-        has_edition_work = (
-            'works' in formdata.edition
-            and formdata.edition.works
-            and formdata.edition.works[0].key
-        )
+        has_edition_work = "works" in formdata.edition and formdata.edition.works and formdata.edition.works[0].key
 
         if has_edition_work:
             old_work_key = formdata.work.key
@@ -861,25 +803,21 @@ class book_edit(delegate.page):
         if edition is None:
             raise web.notfound()
 
-        work = (
-            edition.works and edition.works[0]
-        ) or edition.make_work_from_orphaned_edition()
+        work = (edition.works and edition.works[0]) or edition.make_work_from_orphaned_edition()
 
-        return render_template('books/edit', work, edition, recaptcha=get_recaptcha())
+        return render_template("books/edit", work, edition, recaptcha=get_recaptcha())
 
     def POST(self, key):
         i = web.input(v=None, work_key=None, _method="GET")
 
         if spamcheck.is_spam(allow_privileged_edits=True):
-            return render_template(
-                "message.html", "Oops", 'Something went wrong. Please try again later.'
-            )
+            return render_template("message.html", "Oops", "Something went wrong. Please try again later.")
 
         recap = get_recaptcha()
         if recap and not recap.validate():
             return render_template(
                 "message.html",
-                'Recaptcha solution was incorrect',
+                "Recaptcha solution was incorrect",
                 'Please <a href="javascript:history.back()">go back</a> and try again.',
             )
         v = i.v and safeint(i.v, None)
@@ -898,17 +836,17 @@ class book_edit(delegate.page):
 
             add_flash_message("info", utils.get_message("flash_catalog_updated"))
 
-            if i.work_key and i.work_key.startswith('/works/'):
+            if i.work_key and i.work_key.startswith("/works/"):
                 url = i.work_key
             else:
                 url = edition.url()
 
             raise safe_seeother(url)
         except ClientException as e:
-            add_flash_message('error', e.args[-1] or e.json)
+            add_flash_message("error", e.args[-1] or e.json)
             return self.GET(key)
         except ValidationException as e:
-            add_flash_message('error', str(e))
+            add_flash_message("error", str(e))
             return self.GET(key)
 
 
@@ -930,22 +868,20 @@ class work_edit(delegate.page):
         if work is None:
             raise web.notfound()
 
-        return render_template('books/edit', work, recaptcha=get_recaptcha())
+        return render_template("books/edit", work, recaptcha=get_recaptcha())
 
     def POST(self, key):
         i = web.input(v=None, _method="GET")
 
         if spamcheck.is_spam(allow_privileged_edits=True):
-            return render_template(
-                "message.html", "Oops", 'Something went wrong. Please try again later.'
-            )
+            return render_template("message.html", "Oops", "Something went wrong. Please try again later.")
 
         recap = get_recaptcha()
 
         if recap and not recap.validate():
             return render_template(
                 "message.html",
-                'Recaptcha solution was incorrect',
+                "Recaptcha solution was incorrect",
                 'Please <a href="javascript:history.back()">go back</a> and try again.',
             )
 
@@ -960,7 +896,7 @@ class work_edit(delegate.page):
             add_flash_message("info", utils.get_message("flash_catalog_updated"))
             raise safe_seeother(work.url())
         except (ClientException, ValidationException) as e:
-            add_flash_message('error', str(e))
+            add_flash_message("error", str(e))
             return self.GET(key)
 
 
@@ -997,29 +933,24 @@ class author_edit(delegate.page):
                 author._save(comment=i._comment)
                 raise safe_seeother(key)
             elif "_delete" in i:
-                author = web.ctx.site.new(
-                    key, {"key": key, "type": {"key": "/type/delete"}}
-                )
+                author = web.ctx.site.new(key, {"key": key, "type": {"key": "/type/delete"}})
                 author._save(comment=i._comment)
                 raise safe_seeother(key)
         except (ClientException, ValidationException) as e:
-            add_flash_message('error', str(e))
+            add_flash_message("error", str(e))
             author.update(formdata)
-            author['comment_'] = i._comment
+            author["comment_"] = i._comment
             return render_template("type/author/edit", author)
 
     def process_input(self, i):
         i = utils.unflatten(i)
-        if 'author' in i:
+        if "author" in i:
             author = trim_doc(i.author)
-            alternate_names = author.get('alternate_names', None) or ''
+            alternate_names = author.get("alternate_names", None) or ""
             author.alternate_names = uniq(
-                [author.name]
-                + [
-                    name.strip() for name in alternate_names.split('\n') if name.strip()
-                ],
+                [author.name] + [name.strip() for name in alternate_names.split("\n") if name.strip()],
             )[1:]
-            author.links = author.get('links') or []
+            author.links = author.get("links") or []
             return author
 
 
@@ -1049,10 +980,10 @@ class work_identifiers(delegate.view):
         # Need to do some simple validation here. Perhaps just check if it's a number?
         if len(isbn) == 10:
             typ = "ISBN 10"
-            data = [{'name': 'isbn_10', 'value': isbn}]
+            data = [{"name": "isbn_10", "value": isbn}]
         elif len(isbn) == 13:
             typ = "ISBN 13"
-            data = [{'name': 'isbn_13', 'value': isbn}]
+            data = [{"name": "isbn_13", "value": isbn}]
         else:
             add_flash_message("error", "The ISBN number you entered was not valid")
             raise web.redirect(web.ctx.path)

--- a/openlibrary/plugins/upstream/addtag.py
+++ b/openlibrary/plugins/upstream/addtag.py
@@ -28,16 +28,11 @@ TAG_TYPES = SUBJECT_SUB_TYPES + ["collection"]
 
 
 def validate_tag(tag):
-    return (
-        tag.get('name', '')
-        and tag.get('tag_description', '')
-        and tag.get('tag_type', '') in get_tag_types()
-        and tag.get('body')
-    )
+    return tag.get("name", "") and tag.get("tag_description", "") and tag.get("tag_type", "") in get_tag_types() and tag.get("body")
 
 
 def validate_subject_tag(tag):
-    return validate_tag(tag) and tag.get('tag_type', '') in get_subject_tag_types()
+    return validate_tag(tag) and tag.get("tag_type", "") in get_subject_tag_types()
 
 
 def create_tag(tag: dict):
@@ -72,24 +67,24 @@ def find_match(name: str, tag_type: str) -> str:
     Returns the key of the matching tag, or an empty string if no such tag exists.
     """
     matches = Tag.find(name, tag_type=tag_type)
-    return matches[0] if matches else ''
+    return matches[0] if matches else ""
 
 
 class addtag(delegate.page):
-    path = '/tag/add'
+    path = "/tag/add"
 
     def GET(self):
         """Main user interface for adding a tag to Open Library."""
         if not (patron := get_current_user()):
             # NOTE : will lose any query params on login redirect
-            raise web.seeother(f'/account/login?redirect={self.path}')
+            raise web.seeother(f"/account/login?redirect={self.path}")
 
         if not self.has_permission(patron):
-            raise web.unauthorized(message='Permission denied to add tags')
+            raise web.unauthorized(message="Permission denied to add tags")
 
         i = web.input(name=None, type=None, sub_type=None)
 
-        return render_template('type/tag/form', i)
+        return render_template("type/tag/form", i)
 
     def has_permission(self, user) -> bool:
         """
@@ -106,15 +101,13 @@ class addtag(delegate.page):
         )
 
         if spamcheck.is_spam(i, allow_privileged_edits=True):
-            return render_template(
-                "message.html", "Oops", 'Something went wrong. Please try again later.'
-            )
+            return render_template("message.html", "Oops", "Something went wrong. Please try again later.")
 
         if not (patron := get_current_user()):
-            raise web.seeother(f'/account/login?redirect={self.path}')
+            raise web.seeother(f"/account/login?redirect={self.path}")
 
         if not self.has_permission(patron):
-            raise web.unauthorized(message='Permission denied to add tags')
+            raise web.unauthorized(message="Permission denied to add tags")
 
         if not self.validate_input(i):
             raise web.badrequest()
@@ -122,10 +115,10 @@ class addtag(delegate.page):
         if match := find_match(i.name, i.tag_type):
             # A tag with the same name and type already exists
             add_flash_message(
-                'error',
+                "error",
                 f'A matching tag with the same name and type already exists: <a href="{match}">{match}</a>',
             )
-            return render_template('type/tag/form', i)
+            return render_template("type/tag/form", i)
 
         tag = create_tag(i)
         raise safe_seeother(tag.key)
@@ -175,23 +168,21 @@ class tag_edit(delegate.page):
             if match:
                 # A tag with the same name and type already exists
                 add_flash_message(
-                    'error',
+                    "error",
                     f'A matching tag with the same name and type already exists: <a href="{match}">{match}</a>',
                 )
                 return render_template("type/tag/form", formdata, redirect=i.redir)
 
         try:
             if "_delete" in i:
-                tag = web.ctx.site.new(
-                    key, {"key": key, "type": {"key": "/type/delete"}}
-                )
+                tag = web.ctx.site.new(key, {"key": key, "type": {"key": "/type/delete"}})
                 tag._save(comment=i._comment, action="delete-tag")
                 raise safe_seeother(key)
             tag.update(formdata)
             tag._save(comment=i._comment, action="edit-tag")
             raise safe_seeother(i.redir or key)
         except (ClientException, ValidationException) as e:
-            add_flash_message('error', str(e))
+            add_flash_message("error", str(e))
             return render_template("type/tag/form", tag, redirect=i.redir)
 
     def validate(self, data, tag_type):

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -39,12 +39,12 @@ from openlibrary.plugins.upstream import (
 )  # TODO: unused imports?
 from openlibrary.plugins.upstream.utils import render_component
 
-if not config.get('coverstore_url'):
+if not config.get("coverstore_url"):
     config.coverstore_url = "https://covers.openlibrary.org"  # type: ignore[attr-defined]
 
 import logging
 
-logger = logging.getLogger('openlibrary.plugins.upstream.code')
+logger = logging.getLogger("openlibrary.plugins.upstream.code")
 
 
 class history(delegate.mode):
@@ -54,13 +54,11 @@ class history(delegate.mode):
 
     @jsonapi
     def GET(self, path):
-        query = make_query(web.input(), required_keys=['author', 'offset', 'limit'])
-        query['key'] = path
-        query['sort'] = '-created'
+        query = make_query(web.input(), required_keys=["author", "offset", "limit"])
+        query["key"] = path
+        query["sort"] = "-created"
         # Possibly use infogami.plugins.upstream.utils get_changes to avoid json load/dump?
-        history = json.loads(
-            infogami_request('/versions', data={'query': json.dumps(query)})
-        )
+        history = json.loads(infogami_request("/versions", data={"query": json.dumps(query)}))
         for _, row in enumerate(history):
             row.pop("ip")
         return json.dumps(history)
@@ -71,9 +69,7 @@ class edit(core.edit):
 
     def GET(self, key):
         page = web.ctx.site.get(key)
-        editable_keys_re = web.re_compile(
-            r"/(authors|books|works|tags|lists|series|people/[^/]+/lists)/OL.*"
-        )
+        editable_keys_re = web.re_compile(r"/(authors|books|works|tags|lists|series|people/[^/]+/lists)/OL.*")
         if editable_keys_re.match(key):
             if page is None:
                 return web.seeother(key)
@@ -83,10 +79,8 @@ class edit(core.edit):
             return core.edit.GET(self, key)
 
     def POST(self, key):
-        if web.re_compile('/(people/[^/]+)').match(key) and spamcheck.is_spam():
-            return render_template(
-                'message.html', 'Oops', 'Something went wrong. Please try again later.'
-            )
+        if web.re_compile("/(people/[^/]+)").match(key) and spamcheck.is_spam():
+            return render_template("message.html", "Oops", "Something went wrong. Please try again later.")
         return core.edit.POST(self, key)
 
 
@@ -98,7 +92,7 @@ class change_cover(delegate.mode):
 
     def GET(self, key):
         page = web.ctx.site.get(key)
-        if page is None or page.type.key not in ['/type/edition', '/type/author']:
+        if page is None or page.type.key not in ["/type/edition", "/type/author"]:
             raise web.seeother(key)
         return render.change_cover(page)
 
@@ -107,47 +101,41 @@ class change_photo(change_cover):
     path = r"(/authors/OL\d+A)/photo"
 
 
-del delegate.modes[
-    'change_cover'
-]  # delete change_cover mode added by openlibrary plugin
+del delegate.modes["change_cover"]  # delete change_cover mode added by openlibrary plugin
 
 
 class components_test(delegate.page):
     path = "/_dev/components/HelloWorld"
 
     def GET(self):
-        return render_component('HelloWorld') + render_component('HelloWorld')
+        return render_component("HelloWorld") + render_component("HelloWorld")
 
 
 class library_explorer(delegate.page):
     path = "/explore"
 
     def GET(self):
-        return render_template('library_explorer')
+        return render_template("library_explorer")
 
 
 class merge_work(delegate.page):
     path = "/works/merge"
 
     def GET(self):
-        i = web.input(records='', mrid=None, primary=None)
+        i = web.input(records="", mrid=None, primary=None)
         user = web.ctx.site.get_user()
 
         if user is None:
             raise web.unauthorized()
-        has_access = user and (
-            (user.is_admin() or user.is_librarian()) or user.is_super_librarian()
-        )
+        has_access = user and ((user.is_admin() or user.is_librarian()) or user.is_super_librarian())
         if not has_access:
             raise web.forbidden()
 
         optional_kwargs = {}
         if not (user.is_admin() or user.is_super_librarian()):
-            optional_kwargs['can_merge'] = 'false'
+            optional_kwargs["can_merge"] = "false"
 
-        return render_template(
-            'merge/works', mrid=i.mrid, primary=i.primary, **optional_kwargs
-        )
+        return render_template("merge/works", mrid=i.mrid, primary=i.primary, **optional_kwargs)
 
 
 @functools.cache
@@ -161,15 +149,15 @@ def vendor_js():
             pardir,
             pardir,
             pardir,
-            'static',
-            'upstream',
-            'js',
-            'vendor.js',
+            "static",
+            "upstream",
+            "js",
+            "vendor.js",
         )
     )
-    with open(path, 'rb') as in_file:
+    with open(path, "rb") as in_file:
         digest = hashlib.md5(in_file.read()).hexdigest()
-    return '/static/upstream/js/vendor.js?v=' + digest
+    return "/static/upstream/js/vendor.js?v=" + digest
 
 
 @functools.cache
@@ -177,10 +165,8 @@ def vendor_js():
 def static_url(path):
     """Takes path relative to static/ and constructs url to that resource with hash."""
     pardir = os.path.pardir
-    fullpath = os.path.abspath(
-        os.path.join(__file__, pardir, pardir, pardir, pardir, "static", path)
-    )
-    with open(fullpath, 'rb') as in_file:
+    fullpath = os.path.abspath(os.path.join(__file__, pardir, pardir, pardir, pardir, "static", path))
+    with open(fullpath, "rb") as in_file:
         digest = hashlib.md5(in_file.read()).hexdigest()
     return f"/static/{path}?v={digest}"
 
@@ -191,17 +177,17 @@ class DynamicDocument:
     """
 
     def __init__(self, root):
-        self.root = web.rstrips(root, '/')
+        self.root = web.rstrips(root, "/")
         self.docs = None
         self._text = None
         self.last_modified = None
 
     def update(self):
-        keys = web.ctx.site.things({'type': '/type/rawtext', 'key~': self.root + '/*'})
+        keys = web.ctx.site.things({"type": "/type/rawtext", "key~": self.root + "/*"})
         docs = sorted(web.ctx.site.get_many(keys), key=lambda doc: doc.key)
         if docs:
             self.last_modified = min(doc.last_modified for doc in docs)
-            self._text = "\n\n".join(doc.get('body', '') for doc in docs)
+            self._text = "\n\n".join(doc.get("body", "") for doc in docs)
         else:
             self.last_modified = datetime.datetime.utcnow()
             self._text = ""
@@ -214,14 +200,14 @@ class DynamicDocument:
 
     def md5(self):
         """Returns md5 checksum of the combined documents"""
-        return hashlib.md5(self.get_text().encode('utf-8')).hexdigest()
+        return hashlib.md5(self.get_text().encode("utf-8")).hexdigest()
 
 
 def create_dynamic_document(url, prefix):
     """Creates a handler for `url` for servering combined js/css for `prefix/*` pages"""
     doc = DynamicDocument(prefix)
 
-    if url.endswith('.js'):
+    if url.endswith(".js"):
         content_type = "text/javascript"
     elif url.endswith(".css"):
         content_type = "text/css"
@@ -267,10 +253,10 @@ def create_dynamic_document(url, prefix):
 
 
 all_js = create_dynamic_document("/js/all.js", config.get("js_root", "/js"))
-web.template.Template.globals['all_js'] = all_js()
+web.template.Template.globals["all_js"] = all_js()
 
 all_css = create_dynamic_document("/css/all.css", config.get("css_root", "/css"))
-web.template.Template.globals['all_css'] = all_css()
+web.template.Template.globals["all_css"] = all_css()
 
 
 def reload():
@@ -310,9 +296,7 @@ class revert(delegate.mode):
             raise web.seeother(web.changequery({}))
 
         if not web.ctx.site.can_write(key) or not user_can_revert_records():
-            return render.permission_denied(
-                web.ctx.fullpath, "Permission denied to edit " + key + "."
-            )
+            return render.permission_denied(web.ctx.fullpath, "Permission denied to edit " + key + ".")
 
         thing = web.ctx.site.get(key, i.v)
 
@@ -325,9 +309,7 @@ class revert(delegate.mode):
                 if prev.type.key in ["/type/delete", "/type/redirect"]:
                     return revert(prev)
                 else:
-                    prev._save(
-                        "revert to revision %d" % prev.revision, action="revert-version"
-                    )
+                    prev._save("revert to revision %d" % prev.revision, action="revert-version")
                     return prev
             elif thing.type.key == "/type/redirect":
                 redirect = web.ctx.site.get(thing.location)
@@ -348,7 +330,7 @@ class revert(delegate.mode):
                 return [process(v) for v in value]
             elif isinstance(value, client.Thing):
                 if value.key:
-                    if value.type.key in ['/type/delete', '/type/revert']:
+                    if value.type.key in ["/type/delete", "/type/revert"]:
                         return revert(value)
                     else:
                         return value

--- a/openlibrary/plugins/upstream/covers.py
+++ b/openlibrary/plugins/upstream/covers.py
@@ -28,7 +28,7 @@ def setup():
 class image_validator:
     def __init__(self):
         self.max_file_size = 10 * 1024 * 1024  # 10 MB
-        self.allowed_extensions = {'.jpg', '.jpeg', '.gif', '.png', '.webp'}
+        self.allowed_extensions = {".jpg", ".jpeg", ".gif", ".png", ".webp"}
 
     def validate_size(self, file_data):
         file_size = len(file_data.read())
@@ -56,7 +56,7 @@ class add_cover(delegate.page):
 
     def GET(self, key):
         book = web.ctx.site.get(key)
-        return render_template('covers/add', book)
+        return render_template("covers/add", book)
 
     def POST(self, key):
         book = web.ctx.site.get(key)
@@ -74,20 +74,20 @@ class add_cover(delegate.page):
 
         data = self.upload(key, i)
 
-        if coverid := data.get('id'):
+        if coverid := data.get("id"):
             if isinstance(i.url, bytes):
                 i.url = i.url.decode("utf-8")
             self.save(book, coverid, url=i.url)
             cover = Image(web.ctx.site, "b", coverid)
             return render_template("covers/saved", cover)
         else:
-            return render_template("covers/add", book, {'url': i.url}, data)
+            return render_template("covers/add", book, {"url": i.url}, data)
 
     def upload(self, key, i):
         """Uploads a cover to coverstore and returns the response."""
         olid = key.split("/")[-1]
 
-        if i.file is not None and hasattr(i.file, 'file'):
+        if i.file is not None and hasattr(i.file, "file"):
             file_data = i.file.file
             filename = i.file.filename
 
@@ -97,7 +97,7 @@ class add_cover(delegate.page):
                 validator.validate_size(file_data)
                 validator.validate_image(file_data)
             except ValueError as e:
-                return web.storage({'error': str(e)})
+                return web.storage({"error": str(e)})
 
             data = file_data
         else:
@@ -114,23 +114,23 @@ class add_cover(delegate.page):
             "ip": web.ctx.ip,
         }
 
-        upload_url = f'{get_coverstore_url()}/{self.cover_category}/upload2'
+        upload_url = f"{get_coverstore_url()}/{self.cover_category}/upload2"
 
         if upload_url.startswith("//"):
             upload_url = "http:" + upload_url
 
         try:
-            files = {'data': data}
+            files = {"data": data}
             response = requests.post(upload_url, data=params, files=files)
             return web.storage(response.json())
         except requests.HTTPError as e:
             logger.exception("Covers upload failed")
-            return web.storage({'error': str(e)})
+            return web.storage({"error": str(e)})
 
     def save(self, book, coverid, url=None):
         book.covers = [coverid] + [cover.id for cover in book.get_covers()]
         book._save(
-            f'{get_coverstore_public_url()}/b/id/{coverid}-S.jpg',
+            f"{get_coverstore_public_url()}/b/id/{coverid}-S.jpg",
             action="add-cover",
             data={"url": url},
         )
@@ -153,12 +153,8 @@ class add_photo(add_cover):
 
     def GET(self, key):
         author = web.ctx.site.get(key)
-        wikidata_images = (
-            author.wikidata().get_image_urls() if author and author.wikidata() else []
-        )
-        return render_template(
-            'covers/add', author, {'wikidata_images': wikidata_images}
-        )
+        wikidata_images = author.wikidata().get_image_urls() if author and author.wikidata() else []
+        return render_template("covers/add", author, {"wikidata_images": wikidata_images})
 
     def save(self, author, photoid, url=None):
         author.photos = [photoid] + [photo.id for photo in author.get_photos()]
@@ -182,7 +178,7 @@ class manage_covers(delegate.page):
 
     def save_images(self, book, covers):
         book.covers = covers
-        book._save('Update covers', action="update-book-covers")
+        book._save("Update covers", action="update-book-covers")
 
     def POST(self, key):
         if not accounts.get_current_user():
@@ -192,8 +188,8 @@ class manage_covers(delegate.page):
             raise web.notfound()
 
         images = web.input(image=[]).image
-        if '-' in images:
-            images = [int(id) for id in images[: images.index('-')]]
+        if "-" in images:
+            images = [int(id) for id in images[: images.index("-")]]
             self.save_images(book, images)
             return render_template("covers/saved", self.get_image(book), showinfo=False)
         else:
@@ -216,4 +212,4 @@ class manage_photos(manage_covers):
 
     def save_images(self, author, photos):
         author.photos = photos
-        author._save('Update photos', action="update-author-photos")
+        author._save("Update photos", action="update-author-photos")

--- a/openlibrary/plugins/upstream/jsdef.py
+++ b/openlibrary/plugins/upstream/jsdef.py
@@ -81,7 +81,7 @@ def extension(parser):
     <BLANKLINE>
 
     """
-    parser.statement_nodes['jsdef'] = JSDefNode
+    parser.statement_nodes["jsdef"] = JSDefNode
     return parser
 
 
@@ -104,7 +104,7 @@ class JSNode:
         if web.__version__ < "0.34":
             return indent[4:] + 'yield "", %s\n' % repr(self.jsemit(self.node, ""))
         else:
-            return indent[4:] + 'self.extend(%s)\n' % repr(self.jsemit(self.node, ""))
+            return indent[4:] + "self.extend(%s)\n" % repr(self.jsemit(self.node, ""))
 
     def jsemit(self, node, indent):
         r"""Emit Javascript for given node.::
@@ -170,7 +170,7 @@ class JSNode:
 
     def jsemit_ForNode(self, node, indent):
         tok = PythonTokenizer(node.stmt)
-        tok.consume_till('in')
+        tok.consume_till("in")
         a = node.stmt[: tok.index].strip()  # for i in
         a = a[len("for") : -len("in")].strip()  # strip `for` and `in`
 
@@ -188,7 +188,7 @@ class JSNode:
         text += '<script type="text/javascript"><!--\n'
 
         text += node.stmt.replace("def ", "function ").strip(": ") + "{\n"
-        text += '    var self = [], loop;\n'
+        text += "    var self = [], loop;\n"
         text += self.jsemit(node.suite, indent + INDENT)
         text += '    return self.join("");\n'
         text += "}\n"
@@ -210,7 +210,7 @@ def tokenize(code):
             x = next(tok)
             begin = x.begin[1]
             if begin > end:
-                yield ' ' * (begin - end)
+                yield " " * (begin - end)
             if x.value:
                 yield x.value
             end = x.end[1]

--- a/openlibrary/plugins/worksearch/schemes/__init__.py
+++ b/openlibrary/plugins/worksearch/schemes/__init__.py
@@ -42,7 +42,7 @@ class SearchScheme:
 
     def __init__(self, lang: str | None = None):
         # Fall back to web.ctx.lang until we move away from it
-        self.lang = lang or getattr(web.ctx, 'lang', None) or 'en'
+        self.lang = lang or getattr(web.ctx, "lang", None) or "en"
 
     def is_search_field(self, field: str):
         return field in self.all_fields or field in self.field_name_map
@@ -68,29 +68,27 @@ class SearchScheme:
         """
 
         def process_individual_sort(sort: str) -> str:
-            if sort.startswith(('random_', 'random.hourly_', 'random.daily_')):
+            if sort.startswith(("random_", "random.hourly_", "random.daily_")):
                 # Allow custom randoms; so anything random_* is allowed
                 # Also Allow custom time randoms to allow carousels with overlapping
                 # books to have a fresh ordering when on the same collection
                 sort_order: str | None = None
-                if ' ' in sort:
-                    sort, sort_order = sort.split(' ', 1)
-                random_type, random_seed = sort.split('_', 1)
+                if " " in sort:
+                    sort, sort_order = sort.split(" ", 1)
+                random_type, random_seed = sort.split("_", 1)
                 solr_sort = self.sorts[random_type]
                 solr_sort_str = solr_sort() if callable(solr_sort) else solr_sort
-                solr_sort_field, solr_sort_order = solr_sort_str.split(' ', 1)
+                solr_sort_field, solr_sort_order = solr_sort_str.split(" ", 1)
                 sort_order = sort_order or solr_sort_order
-                return f'{solr_sort_field}_{random_seed} {sort_order}'
+                return f"{solr_sort_field}_{random_seed} {sort_order}"
             else:
                 solr_sort = self.sorts[sort]
                 return solr_sort() if callable(solr_sort) else solr_sort
 
-        return ','.join(
-            process_individual_sort(s.strip()) for s in user_sort.split(',')
-        )
+        return ",".join(process_individual_sort(s.strip()) for s in user_sort.split(","))
 
     def process_user_query(self, q_param: str) -> str:
-        if q_param == '*:*':
+        if q_param == "*:*":
             # This is a special solr syntax; don't process
             return q_param
 
@@ -101,10 +99,10 @@ class SearchScheme:
                     # let's not expose that and escape all '/'. Otherwise
                     # `key:/works/OL1W` is interpreted as a regex.
                     q_param.strip()
-                    .replace('/', '\\/')
+                    .replace("/", "\\/")
                     # Also escape unexposed lucene features
-                    .replace('?', '\\?')
-                    .replace('~', '\\~')
+                    .replace("?", "\\?")
+                    .replace("~", "\\~")
                 ),
                 self.is_search_field,
                 lower=True,
@@ -135,9 +133,9 @@ class SearchScheme:
         solr_fields: set[str],
         cur_solr_params: list[tuple[str, str]],
         highlight: bool = False,
-        solr_internals_params: 'SolrInternalsParams | None' = None,
+        solr_internals_params: "SolrInternalsParams | None" = None,
     ) -> list[tuple[str, str]]:
-        return [('q', q)]
+        return [("q", q)]
 
     def add_non_solr_fields(self, solr_fields: set[str], solr_result: dict) -> None:
         raise NotImplementedError

--- a/openlibrary/plugins/worksearch/schemes/authors.py
+++ b/openlibrary/plugins/worksearch/schemes/authors.py
@@ -12,17 +12,17 @@ logger = logging.getLogger("openlibrary.worksearch")
 
 
 class AuthorSearchScheme(SearchScheme):
-    universe = frozenset(['type:author'])
+    universe = frozenset(["type:author"])
     all_fields = frozenset(
         {
-            'key',
-            'name',
-            'alternate_names',
-            'birth_date',
-            'death_date',
-            'date',
-            'top_subjects',
-            'work_count',
+            "key",
+            "name",
+            "alternate_names",
+            "birth_date",
+            "death_date",
+            "date",
+            "top_subjects",
+            "work_count",
         }
     )
     non_solr_fields = frozenset()
@@ -30,28 +30,28 @@ class AuthorSearchScheme(SearchScheme):
     field_name_map = MappingProxyType({})
     sorts = MappingProxyType(
         {
-            'work_count desc': 'work_count desc',
-            'name': 'name_str asc',
+            "work_count desc": "work_count desc",
+            "name": "name_str asc",
             # Birth Year
-            'birth_date asc': 'birth_date asc',
-            'birth_date desc': 'birth_date desc',
+            "birth_date asc": "birth_date asc",
+            "birth_date desc": "birth_date desc",
             # Random
-            'random': 'random_1 asc',
-            'random asc': 'random_1 asc',
-            'random desc': 'random_1 desc',
-            'random.hourly': lambda: f'random_{datetime.now():%Y%m%dT%H} asc',
-            'random.daily': lambda: f'random_{datetime.now():%Y%m%d} asc',
+            "random": "random_1 asc",
+            "random asc": "random_1 asc",
+            "random desc": "random_1 desc",
+            "random.hourly": lambda: f"random_{datetime.now():%Y%m%dT%H} asc",
+            "random.daily": lambda: f"random_{datetime.now():%Y%m%d} asc",
         }
     )
     default_fetched_fields = frozenset(
         {
-            'key',
-            'name',
-            'birth_date',
-            'death_date',
-            'date',
-            'top_subjects',
-            'work_count',
+            "key",
+            "name",
+            "birth_date",
+            "death_date",
+            "date",
+            "top_subjects",
+            "work_count",
         }
     )
     facet_rewrites = MappingProxyType({})
@@ -62,13 +62,13 @@ class AuthorSearchScheme(SearchScheme):
         solr_fields: set[str],
         cur_solr_params: list[tuple[str, str]],
         highlight: bool = False,
-        solr_internals_params: 'SolrInternalsParams | None' = None,
+        solr_internals_params: "SolrInternalsParams | None" = None,
     ) -> list[tuple[str, str]]:
         return [
-            ('q', q),
-            ('q.op', 'AND'),
-            ('defType', 'edismax'),
-            ('qf', 'name alternate_names'),
-            ('pf', 'name^10 alternate_names^10'),
-            ('bf', 'min(work_count,20)'),
+            ("q", q),
+            ("q.op", "AND"),
+            ("defType", "edismax"),
+            ("qf", "name alternate_names"),
+            ("pf", "name^10 alternate_names^10"),
+            ("bf", "min(work_count,20)"),
         ]

--- a/openlibrary/plugins/worksearch/schemes/lists.py
+++ b/openlibrary/plugins/worksearch/schemes/lists.py
@@ -16,49 +16,49 @@ logger = logging.getLogger("openlibrary.worksearch")
 # define a search scheme for lists, similar to SubjectSearchScheme
 class ListSearchScheme(SearchScheme):
     # this search only applies to list type documents
-    universe = frozenset(['type:list OR list_type:*'])
+    universe = frozenset(["type:list OR list_type:*"])
     all_fields = frozenset(
         {
-            'key',  # unique identifier for the list
-            'name',  # name/title of the list
-            'list_type',  # list type: "series", "user_list", or "community_list"
-            'seed',
-            'subject',
-            'subject_key',
-            'person',
-            'person_key',
-            'place',
-            'place_key',
-            'time',
-            'time_key',
-            'last_modified',
-            'seed_count',
+            "key",  # unique identifier for the list
+            "name",  # name/title of the list
+            "list_type",  # list type: "series", "user_list", or "community_list"
+            "seed",
+            "subject",
+            "subject_key",
+            "person",
+            "person_key",
+            "place",
+            "place_key",
+            "time",
+            "time_key",
+            "last_modified",
+            "seed_count",
         }
     )
 
     # short description of the list
-    non_solr_fields = frozenset({'description'})
+    non_solr_fields = frozenset({"description"})
 
     facet_fields = frozenset()
     field_name_map = MappingProxyType({})
     sorts = MappingProxyType(
         {
-            'name asc': 'name asc',
-            'last_modified': 'last_modified desc',
-            'last_modified asc': 'last_modified asc',
-            'last_modified desc': 'last_modified desc',
-            'seed_count': 'seed_count desc',
-            'seed_count asc': 'seed_count asc',
-            'seed_count desc': 'seed_count desc',
+            "name asc": "name asc",
+            "last_modified": "last_modified desc",
+            "last_modified asc": "last_modified asc",
+            "last_modified desc": "last_modified desc",
+            "seed_count": "seed_count desc",
+            "seed_count asc": "seed_count asc",
+            "seed_count desc": "seed_count desc",
             # Random (kept from SubjectSearchScheme)
-            'random': 'random_1 asc',
-            'random asc': 'random_1 asc',
-            'random desc': 'random_1 desc',
-            'random.hourly': lambda: f'random_{datetime.now():%Y%m%dT%H} asc',
-            'random.daily': lambda: f'random_{datetime.now():%Y%m%d} asc',
+            "random": "random_1 asc",
+            "random asc": "random_1 asc",
+            "random desc": "random_1 desc",
+            "random.hourly": lambda: f"random_{datetime.now():%Y%m%dT%H} asc",
+            "random.daily": lambda: f"random_{datetime.now():%Y%m%d} asc",
         }
     )
-    default_fetched_fields = frozenset({'key', 'name'})
+    default_fetched_fields = frozenset({"key", "name"})
 
     facet_rewrites = MappingProxyType({})
 
@@ -69,21 +69,21 @@ class ListSearchScheme(SearchScheme):
         solr_fields: set[str],
         cur_solr_params: list[tuple[str, str]],
         highlight: bool = False,
-        solr_internals_params: 'SolrInternalsParams | None' = None,
+        solr_internals_params: "SolrInternalsParams | None" = None,
     ) -> list[tuple[str, str]]:
         params = [
-            ('q', q),  # actual query string
-            ('q.op', 'AND'),  # use 'AND' for matching multiple words in search queries
-            ('defType', 'edismax'),  # use edismax parser for better full-text search
+            ("q", q),  # actual query string
+            ("q.op", "AND"),  # use 'AND' for matching multiple words in search queries
+            ("defType", "edismax"),  # use edismax parser for better full-text search
             # qf specifies which fields to search and their boost weights.
             # Searching 'text' allows matching on subjects aggregated from the list's
             # books, while boosting 'name' ensures title matches rank highest.
-            ('qf', 'text name^10'),
+            ("qf", "text name^10"),
         ]
         # Default: exclude low-seed lists (issue #11905).
         # Lists with fewer than 2 seeds are likely spam. Series are exempt
         # since new series may legitimately have only one book.
         # This filter is skipped if the user explicitly queries by seed_count.
-        if 'seed_count' not in q:
-            params.append(('fq', 'seed_count:[2 TO *] OR list_type:series'))
+        if "seed_count" not in q:
+            params.append(("fq", "seed_count:[2 TO *] OR list_type:series"))
         return params

--- a/openlibrary/plugins/worksearch/schemes/subjects.py
+++ b/openlibrary/plugins/worksearch/schemes/subjects.py
@@ -12,13 +12,13 @@ logger = logging.getLogger("openlibrary.worksearch")
 
 
 class SubjectSearchScheme(SearchScheme):
-    universe = frozenset(['type:subject'])
+    universe = frozenset(["type:subject"])
     all_fields = frozenset(
         {
-            'key',
-            'name',
-            'subject_type',
-            'work_count',
+            "key",
+            "name",
+            "subject_type",
+            "work_count",
         }
     )
     non_solr_fields = frozenset()
@@ -26,21 +26,21 @@ class SubjectSearchScheme(SearchScheme):
     field_name_map = MappingProxyType({})
     sorts = MappingProxyType(
         {
-            'work_count desc': 'work_count desc',
+            "work_count desc": "work_count desc",
             # Random
-            'random': 'random_1 asc',
-            'random asc': 'random_1 asc',
-            'random desc': 'random_1 desc',
-            'random.hourly': lambda: f'random_{datetime.now():%Y%m%dT%H} asc',
-            'random.daily': lambda: f'random_{datetime.now():%Y%m%d} asc',
+            "random": "random_1 asc",
+            "random asc": "random_1 asc",
+            "random desc": "random_1 desc",
+            "random.hourly": lambda: f"random_{datetime.now():%Y%m%dT%H} asc",
+            "random.daily": lambda: f"random_{datetime.now():%Y%m%d} asc",
         }
     )
     default_fetched_fields = frozenset(
         {
-            'key',
-            'name',
-            'subject_type',
-            'work_count',
+            "key",
+            "name",
+            "subject_type",
+            "work_count",
         }
     )
     facet_rewrites = MappingProxyType({})
@@ -51,10 +51,10 @@ class SubjectSearchScheme(SearchScheme):
         solr_fields: set[str],
         cur_solr_params: list[tuple[str, str]],
         highlight: bool = False,
-        solr_internals_params: 'SolrInternalsParams | None' = None,
+        solr_internals_params: "SolrInternalsParams | None" = None,
     ) -> list[tuple[str, str]]:
         return [
-            ('q', q),
-            ('q.op', 'AND'),
-            ('defType', 'edismax'),
+            ("q", q),
+            ("q.op", "AND"),
+            ("defType", "edismax"),
         ]

--- a/openlibrary/utils/form.py
+++ b/openlibrary/utils/form.py
@@ -26,7 +26,7 @@ class AttributeList(dict):
         return " ".join(f'{k}="{web.websafe(v)}"' for k, v in self.items())
 
     def __repr__(self):
-        return '<attrs: %s>' % repr(str(self))
+        return "<attrs: %s>" % repr(str(self))
 
 
 class Input:
@@ -34,16 +34,16 @@ class Input:
         self.name = name
         self.description = description or ""
         self.value = value
-        self.validators = kw.pop('validators', [])
+        self.validators = kw.pop("validators", [])
 
-        self.help = kw.pop('help', None)
-        self.note = kw.pop('note', None)
+        self.help = kw.pop("help", None)
+        self.note = kw.pop("note", None)
 
-        self.id = kw.pop('id', name)
+        self.id = kw.pop("id", name)
         self.__dict__.update(kw)
 
-        if 'klass' in kw:
-            kw['class'] = kw.pop('klass')
+        if "klass" in kw:
+            kw["class"] = kw.pop("klass")
 
         self.attrs = AttributeList(kw)
 
@@ -55,12 +55,12 @@ class Input:
 
     def render(self):
         attrs = self.attrs.copy()
-        attrs['id'] = self.id
-        attrs['type'] = self.get_type()
-        attrs['name'] = self.name
-        attrs['value'] = self.value or ''
+        attrs["id"] = self.id
+        attrs["type"] = self.get_type()
+        attrs["name"] = self.name
+        attrs["value"] = self.value or ""
 
-        return '<input ' + str(attrs) + ' />'
+        return "<input " + str(attrs) + " />"
 
     def validate(self, value):
         self.value = value
@@ -122,7 +122,7 @@ class Hidden(Input):
 class Form:
     def __init__(self, *inputs, **kw):
         self.inputs = inputs
-        self.validators = kw.pop('validators', [])
+        self.validators = kw.pop("validators", [])
         self.note = None
 
     def __call__(self):
@@ -139,7 +139,7 @@ class Form:
 
     def __getattr__(self, name):
         # don't interfere with deepcopy
-        inputs = self.__dict__.get('inputs') or []
+        inputs = self.__dict__.get("inputs") or []
         for x in inputs:
             if x.name == name:
                 return x

--- a/openlibrary/utils/request_context.py
+++ b/openlibrary/utils/request_context.py
@@ -43,62 +43,62 @@ site: ContextVar[Site] = ContextVar("site")
 # Keep in sync with scripts/obfi.sh (obfi_grep_bots) and docker/web_nginx.conf ($is_sus_user_agent).
 # cdrini to DRY obfi.sh side.
 USER_AGENT_BOTS = [
-    '360spider',
-    'ahrefsbot',
-    'amazonbot',
-    'applebot',
-    'baiduspider',
-    'behloolbot',
-    'bingbot',
-    'brightbot',
-    'bytespider',
-    'buzzbot',
-    'claudebot',
-    'coccocbot',
-    'dataforseobot',
-    'discordbot',
-    'donkeybot',
-    'dotbot',
-    'dubbotbot',
-    'equellaurlbot',
-    'femtosearchbot',
-    'focuseekbot',
-    'googlebot',
-    'gptbot',
-    'iaskbot',
-    'icc-crawler',
-    'kazbtbot',
-    'laserlikebot',
-    'linkdexbot',
-    'meta-externalagent',
-    'mj12bot',
-    'mojeekbot',
-    'monsidobot',
-    'musobot',
-    'nsrbot',
-    'paperlibot',
-    'parsijoobot',
-    'perplexitybot',
-    'petalbot',
-    'pinterestbot',
-    'qwantbot',
-    'redditbot',
-    'semanticscholarbot',
-    'semrushbot',
-    'seznambot',
-    'sputnikbot',
-    'startmebot',
-    'tiktokspider',
-    'toutiaospider',
-    'ttspider',
-    'uptimerobot',
-    'yandex.com/bots',
-    'yandexaccessibilitybot',
-    'yandexbot',
-    'yandexmobilebot',
-    'yandexrenderresourcesbot',
-    'yoozbot',
-    'yoozbotadsbot',
+    "360spider",
+    "ahrefsbot",
+    "amazonbot",
+    "applebot",
+    "baiduspider",
+    "behloolbot",
+    "bingbot",
+    "brightbot",
+    "bytespider",
+    "buzzbot",
+    "claudebot",
+    "coccocbot",
+    "dataforseobot",
+    "discordbot",
+    "donkeybot",
+    "dotbot",
+    "dubbotbot",
+    "equellaurlbot",
+    "femtosearchbot",
+    "focuseekbot",
+    "googlebot",
+    "gptbot",
+    "iaskbot",
+    "icc-crawler",
+    "kazbtbot",
+    "laserlikebot",
+    "linkdexbot",
+    "meta-externalagent",
+    "mj12bot",
+    "mojeekbot",
+    "monsidobot",
+    "musobot",
+    "nsrbot",
+    "paperlibot",
+    "parsijoobot",
+    "perplexitybot",
+    "petalbot",
+    "pinterestbot",
+    "qwantbot",
+    "redditbot",
+    "semanticscholarbot",
+    "semrushbot",
+    "seznambot",
+    "sputnikbot",
+    "startmebot",
+    "tiktokspider",
+    "toutiaospider",
+    "ttspider",
+    "uptimerobot",
+    "yandex.com/bots",
+    "yandexaccessibilitybot",
+    "yandexbot",
+    "yandexmobilebot",
+    "yandexrenderresourcesbot",
+    "yoozbot",
+    "yoozbotadsbot",
 ]
 
 
@@ -126,7 +126,7 @@ def _compute_is_bot(user_agent: str | None, hhcl: str | None) -> bool:
     """
 
     # Check hhcl header first (set by nginx)
-    if hhcl == '1':
+    if hhcl == "1":
         return True
 
     # Check user agent
@@ -140,28 +140,28 @@ def _parse_solr_editions_from_web() -> bool:
     """Parse solr_editions from web.py context."""
 
     def read_query_string():
-        return web.input(editions=None).get('editions')
+        return web.input(editions=None).get("editions")
 
     def read_cookie():
         if "SOLR_EDITIONS" in web.ctx.env.get("HTTP_COOKIE", ""):
-            return web.cookies().get('SOLR_EDITIONS')
+            return web.cookies().get("SOLR_EDITIONS")
 
     if (qs_value := read_query_string()) is not None:
-        return qs_value == 'true'
+        return qs_value == "true"
 
     if (cookie_value := read_cookie()) is not None:
-        return cookie_value == 'true'
+        return cookie_value == "true"
 
     return True
 
 
 def _parse_solr_editions_from_fastapi(request) -> bool:
     """Parse solr_editions preference from query string or cookie."""
-    if editions_param := request.query_params.get('editions'):
-        return editions_param.lower() == 'true'
+    if editions_param := request.query_params.get("editions"):
+        return editions_param.lower() == "true"
 
-    if cookie_value := request.cookies.get('SOLR_EDITIONS'):
-        return cookie_value.lower() == 'true'
+    if cookie_value := request.cookies.get("SOLR_EDITIONS"):
+        return cookie_value.lower() == "true"
 
     return True
 
@@ -171,13 +171,11 @@ def set_context_from_legacy_web_py() -> None:
     Extracts context from the global web.ctx and populates ContextVars.
     """
     solr_editions = _parse_solr_editions_from_web()
-    print_disabled = bool(web.cookies().get('pd', False))
-    sfw = bool(web.cookies().get('sfw', ''))
+    print_disabled = bool(web.cookies().get("pd", False))
+    sfw = bool(web.cookies().get("sfw", ""))
 
     # Compute is_bot once during request setup
-    is_recognized_bot = _compute_is_recognized_bot(
-        user_agent=web.ctx.env.get("HTTP_USER_AGENT", "")
-    )
+    is_recognized_bot = _compute_is_recognized_bot(user_agent=web.ctx.env.get("HTTP_USER_AGENT", ""))
     is_bot = _compute_is_bot(
         user_agent=web.ctx.env.get("HTTP_USER_AGENT"),
         hhcl=web.ctx.env.get("HTTP_X_HHCL"),
@@ -188,7 +186,7 @@ def set_context_from_legacy_web_py() -> None:
         RequestContextVars(
             x_forwarded_for=web.ctx.env.get("HTTP_X_FORWARDED_FOR"),
             user_agent=web.ctx.env.get("HTTP_USER_AGENT"),
-            lang=web.ctx.get('lang') or 'en',
+            lang=web.ctx.get("lang") or "en",
             solr_editions=solr_editions,
             print_disabled=print_disabled,
             sfw=sfw,
@@ -223,10 +221,10 @@ def set_context_from_fastapi(request: Request) -> None:
         RequestContextVars(
             x_forwarded_for=request.headers.get("X-Forwarded-For"),
             user_agent=request.headers.get("User-Agent"),
-            lang=request.state.lang or 'en',
+            lang=request.state.lang or "en",
             solr_editions=solr_editions,
-            print_disabled=bool(request.cookies.get('pd', False)),
-            sfw=bool(request.cookies.get('sfw', '')),
+            print_disabled=bool(request.cookies.get("pd", False)),
+            sfw=bool(request.cookies.get("sfw", "")),
             is_bot=is_bot,
         )
     )

--- a/openlibrary/utils/schema.py
+++ b/openlibrary/utils/schema.py
@@ -49,7 +49,7 @@ class AbstractAdapter:
     def type_to_sql(self, type, limit=None):
         sql = self.get_native_type(type)
         if limit:
-            sql += '(%s)' % limit
+            sql += "(%s)" % limit
         return sql
 
     def get_native_type(self, type):
@@ -68,19 +68,19 @@ class AbstractAdapter:
         option: Literal["primary_key", "unique", "default", "null", "references"],
         value,
     ) -> str | None:
-        if option == 'primary_key' and value is True:
-            return 'primary key'
-        elif option == 'unique' and value is True:
-            return 'unique'
-        elif option == 'default':
-            if hasattr(value, 'sql'):
+        if option == "primary_key" and value is True:
+            return "primary key"
+        elif option == "unique" and value is True:
+            return "unique"
+        elif option == "default":
+            if hasattr(value, "sql"):
                 value = value.sql(self)
             else:
                 value = sqlrepr(value)
             return "default %s" % (value)
-        elif option == 'null':
-            return {True: 'null', False: 'not null'}[value]
-        elif option == 'references':
+        elif option == "null":
+            return {True: "null", False: "not null"}[value]
+        elif option == "references":
             return self.references_to_sql(column, value)
         return None
 
@@ -96,7 +96,7 @@ class MockAdapter(AbstractAdapter):
         return type
 
     def references_to_sql(self, column_name, value):
-        return 'references ' + value
+        return "references " + value
 
     def quote(self, value):
         return repr(value)
@@ -105,97 +105,97 @@ class MockAdapter(AbstractAdapter):
 class MySQLAdapter(AbstractAdapter):
     native_types = MappingProxyType(
         {
-            'serial': 'int auto_increment not null',
-            'integer': 'int',
-            'float': 'float',
-            'string': 'varchar',
-            'text': 'text',
-            'datetime': 'datetime',
-            'timestamp': 'datetime',
-            'time': 'time',
-            'date': 'date',
-            'binary': 'blob',
-            'boolean': 'boolean',
+            "serial": "int auto_increment not null",
+            "integer": "int",
+            "float": "float",
+            "string": "varchar",
+            "text": "text",
+            "datetime": "datetime",
+            "timestamp": "datetime",
+            "time": "time",
+            "date": "date",
+            "binary": "blob",
+            "boolean": "boolean",
         }
     )
     constants = MappingProxyType(
         {
-            'CURRENT_TIMESTAMP': 'CURRENT_TIMESTAMP',
-            'CURRENT_DATE': 'CURRENT_DATE',
-            'CURRENT_TIME': 'CURRENT_TIME',
-            'CURRENT_UTC_TIMESTAMP': 'UTC_TIMESTAMP',
-            'CURRENT_UTC_DATE': 'UTC_DATE',
-            'CURRENT_UTC_TIME': 'UTC_TIME',
+            "CURRENT_TIMESTAMP": "CURRENT_TIMESTAMP",
+            "CURRENT_DATE": "CURRENT_DATE",
+            "CURRENT_TIME": "CURRENT_TIME",
+            "CURRENT_UTC_TIMESTAMP": "UTC_TIMESTAMP",
+            "CURRENT_UTC_DATE": "UTC_DATE",
+            "CURRENT_UTC_TIME": "UTC_TIME",
         }
     )
 
     def references_to_sql(self, column_name, value):
-        return {'constraint': f'foreign key ({column_name}) references {value}'}
+        return {"constraint": f"foreign key ({column_name}) references {value}"}
 
 
 class PostgresAdapter(AbstractAdapter):
     native_types = MappingProxyType(
         {
-            'serial': 'serial',
-            'integer': 'int',
-            'float': 'float',
-            'string': 'character varying',
-            'text': 'text',
-            'datetime': 'timestamp',
-            'timestamp': 'timestamp',
-            'time': 'time',
-            'date': 'date',
-            'binary': 'bytea',
-            'boolean': 'boolean',
+            "serial": "serial",
+            "integer": "int",
+            "float": "float",
+            "string": "character varying",
+            "text": "text",
+            "datetime": "timestamp",
+            "timestamp": "timestamp",
+            "time": "time",
+            "date": "date",
+            "binary": "bytea",
+            "boolean": "boolean",
         }
     )
     constants = MappingProxyType(
         {
-            'CURRENT_TIMESTAMP': 'current_timestamp',
-            'CURRENT_DATE': 'current_date',
-            'CURRENT_TIME': 'current_time',
-            'CURRENT_UTC_TIMESTAMP': "(current_timestamp at time zone 'utc')",
-            'CURRENT_UTC_DATE': "(date (current_timestamp at timezone 'utc'))",
-            'CURRENT_UTC_TIME': "(current_time at time zone 'utc')",
+            "CURRENT_TIMESTAMP": "current_timestamp",
+            "CURRENT_DATE": "current_date",
+            "CURRENT_TIME": "current_time",
+            "CURRENT_UTC_TIMESTAMP": "(current_timestamp at time zone 'utc')",
+            "CURRENT_UTC_DATE": "(date (current_timestamp at timezone 'utc'))",
+            "CURRENT_UTC_TIME": "(current_time at time zone 'utc')",
         }
     )
 
     def references_to_sql(self, column_name, value):
-        return 'references ' + value
+        return "references " + value
 
 
 class SQLiteAdapter(AbstractAdapter):
     native_types = MappingProxyType(
         {
-            'serial': 'integer autoincrement',
-            'integer': 'integer',
-            'float': 'float',
-            'string': 'varchar',
-            'text': 'text',
-            'datetime': 'datetime',
-            'timestamp': 'datetime',
-            'time': 'datetime',
-            'date': 'date',
-            'binary': 'blob',
-            'boolean': 'boolean',
+            "serial": "integer autoincrement",
+            "integer": "integer",
+            "float": "float",
+            "string": "varchar",
+            "text": "text",
+            "datetime": "datetime",
+            "timestamp": "datetime",
+            "time": "datetime",
+            "date": "date",
+            "binary": "blob",
+            "boolean": "boolean",
         }
     )
     constants = MappingProxyType(
         {
-            'CURRENT_TIMESTAMP': "CURRENT_TIMESTAMP",
-            'CURRENT_DATE': "CURRENT_DATE",
-            'CURRENT_TIME': "CURRENT_TIME",
-            'CURRENT_UTC_TIMESTAMP': "CURRENT_TIMESTAMP",
-            'CURRENT_UTC_DATE': "CURRENT_DATE",
-            'CURRENT_UTC_TIME': "CURRENT_TIME",
+            "CURRENT_TIMESTAMP": "CURRENT_TIMESTAMP",
+            "CURRENT_DATE": "CURRENT_DATE",
+            "CURRENT_TIME": "CURRENT_TIME",
+            "CURRENT_UTC_TIMESTAMP": "CURRENT_TIMESTAMP",
+            "CURRENT_UTC_DATE": "CURRENT_DATE",
+            "CURRENT_UTC_TIME": "CURRENT_TIME",
         }
     )
 
 
-register_adapter('mysql', MySQLAdapter)
-register_adapter('postgres', PostgresAdapter)
-register_adapter('sqlite', SQLiteAdapter)
-register_adapter('mock', MockAdapter)
+register_adapter("mysql", MySQLAdapter)
+register_adapter("postgres", PostgresAdapter)
+register_adapter("sqlite", SQLiteAdapter)
+register_adapter("mock", MockAdapter)
 
 
 def sqlrepr(s):
@@ -222,12 +222,12 @@ class Constant:
 
 
 for c in [
-    'CURRENT_TIMESTAMP',
-    'CURRENT_DATE',
-    'CURRENT_TIME',
-    'CURRENT_UTC_TIMESTAMP',
-    'CURRENT_UTC_DATE',
-    'CURRENT_UTC_TIME',
+    "CURRENT_TIMESTAMP",
+    "CURRENT_DATE",
+    "CURRENT_TIME",
+    "CURRENT_UTC_TIMESTAMP",
+    "CURRENT_UTC_DATE",
+    "CURRENT_UTC_TIME",
 ]:
     register_constant(c, Constant(c))
 
@@ -274,9 +274,7 @@ class Table:
         for c in self.columns:
             for constraint in c.constraints:
                 columns.append(constraint)
-        return "create table {} (\n    {}\n);".format(
-            self.name, ",\n    ".join(columns)
-        )
+        return "create table {} (\n    {}\n);".format(self.name, ",\n    ".join(columns))
 
 
 class Column:
@@ -296,15 +294,15 @@ class Column:
         self.name = name
         self.type = type
         self.options = options
-        self.limit = self.options.pop('limit', None)
+        self.limit = self.options.pop("limit", None)
         self.constraints = []
 
-        self.primary_key = self.options.get('primary_key')
-        self.unique = self.options.get('unique')
-        self.references = self.options.get('references')
+        self.primary_key = self.options.get("primary_key")
+        self.unique = self.options.get("unique")
+        self.references = self.options.get("references")
 
         # string type is of variable length. set default length as 255.
-        if type == 'string':
+        if type == "string":
             self.limit = self.limit or 255
 
     def sql(self, engine):
@@ -315,10 +313,8 @@ class Column:
             result = adapter.column_option_to_sql(self.name, k, v)
             if result is None:
                 continue
-            elif isinstance(
-                result, dict
-            ):  # a way for column options to add constraints
-                self.constraints.append(result['constraint'])
+            elif isinstance(result, dict):  # a way for column options to add constraints
+                self.constraints.append(result["constraint"])
             else:
                 tokens.append(result)
 
@@ -343,19 +339,19 @@ class Index:
         else:
             self.columns = columns
 
-        self.unique = options.get('unique')
-        self.name = options.get('name')
+        self.unique = options.get("unique")
+        self.name = options.get("name")
 
     def sql(self, engine):
         adapter = get_adapter(engine)
 
         if self.unique:
-            s = 'create unique index '
+            s = "create unique index "
         else:
-            s = 'create index '
+            s = "create index "
 
         s += adapter.index_name(self.table, self.columns)
-        s += ' on {}({});'.format(self.table, ", ".join(self.columns))
+        s += " on {}({});".format(self.table, ", ".join(self.columns))
         return s
 
 

--- a/scripts/monitoring/monitor.py
+++ b/scripts/monitoring/monitor.py
@@ -30,7 +30,7 @@ scheduler = OlAsyncIOScheduler("OL-MONITOR")
 
 
 @limit_server(["ol-web*", "ol-covers0"], scheduler)
-@scheduler.scheduled_job('interval', seconds=60)
+@scheduler.scheduled_job("interval", seconds=60)
 def log_workers_cur_fn():
     """Logs the state of the gunicorn workers."""
     bash_run(
@@ -44,7 +44,7 @@ def log_workers_cur_fn():
 
 
 @limit_server(["ol-www0", "ol-covers0"], scheduler)
-@scheduler.scheduled_job('interval', seconds=60)
+@scheduler.scheduled_job("interval", seconds=60)
 def monitor_nginx_logs():
     """Logs recent bot traffic, HTTP statuses, and top IP counts."""
     match SERVER:
@@ -70,47 +70,45 @@ def monitor_nginx_logs():
 
 
 @limit_server(["ol-solr0", "ol-solr1"], scheduler)
-@scheduler.scheduled_job('interval', seconds=60)
+@scheduler.scheduled_job("interval", seconds=60)
 async def monitor_solr():
     # Note this is a long-running job that does its own scheduling.
     # But by having it on a 60s interval, we ensure it restarts if it fails.
     from scripts.monitoring.solr_logs_monitor import main
 
     main(
-        solr_container=(
-            'solr_builder-solr_prod-1' if SERVER == 'ol-solr1' else 'openlibrary-solr-1'
-        ),
-        graphite_prefix=f'stats.ol.{SERVER}',
+        solr_container=("solr_builder-solr_prod-1" if SERVER == "ol-solr1" else "openlibrary-solr-1"),
+        graphite_prefix=f"stats.ol.{SERVER}",
         graphite_address=GRAPHITE_URL,
     )
 
 
 @limit_server(["ol-www0"], scheduler)
-@scheduler.scheduled_job('interval', seconds=60)
+@scheduler.scheduled_job("interval", seconds=60)
 async def monitor_partner_useragents():
 
     def graphite_safe(s: str) -> str:
         """Normalize a string for safe use as a Graphite metric name."""
         # Replace dots and spaces with underscores
-        s = s.replace('.', '_').replace(' ', '_')
+        s = s.replace(".", "_").replace(" ", "_")
         # Remove or replace unsafe characters
-        s = re.sub(r'[^A-Za-z0-9_-]+', '_', s)
+        s = re.sub(r"[^A-Za-z0-9_-]+", "_", s)
         # Collapse multiple underscores
-        s = re.sub(r'_+', '_', s)
+        s = re.sub(r"_+", "_", s)
         # Strip leading/trailing underscores or dots
-        return s.strip('._')
+        return s.strip("._")
 
     def extract_agent_counts(ua_counts, allowed_names=None):
         agent_counts = {}
         for ua in ua_counts.strip().split("\n"):
             count, agent, *_ = ua.strip().split(" ")
             count = int(count)
-            agent_name = graphite_safe(agent.split('/')[0])
+            agent_name = graphite_safe(agent.split("/")[0])
             if not allowed_names or agent_name in allowed_names:
                 agent_counts[agent_name] = count
             else:
-                agent_counts.setdefault('other', 0)
-                agent_counts['other'] += count
+                agent_counts.setdefault("other", 0)
+                agent_counts["other"] += count
         return agent_counts
 
     known_names = extract_agent_counts("""
@@ -178,20 +176,16 @@ async def monitor_partner_useragents():
     events = []
     ts = int(time.time())
     for agent, count in agent_counts.items():
-        events.append(
-            GraphiteEvent(
-                path=f'stats.ol.partners.{agent}', value=float(count), timestamp=ts
-            )
-        )
+        events.append(GraphiteEvent(path=f"stats.ol.partners.{agent}", value=float(count), timestamp=ts))
     GraphiteEvent.submit_many(events, GRAPHITE_URL)
 
 
 @limit_server(["ol-www0"], scheduler)
-@scheduler.scheduled_job('interval', seconds=60)
+@scheduler.scheduled_job("interval", seconds=60)
 async def monitor_empty_homepage():
     async with httpx.AsyncClient() as client:
         ts = int(time.time())
-        response = await client.get('https://openlibrary.org')
+        response = await client.get("https://openlibrary.org")
         book_count = response.text.count('<div class="book ')
         GraphiteEvent(
             path="stats.ol.homepage_book_count",
@@ -201,7 +195,7 @@ async def monitor_empty_homepage():
 
 
 @limit_server(["ol-www0"], scheduler)
-@scheduler.scheduled_job('interval', seconds=60)
+@scheduler.scheduled_job("interval", seconds=60)
 def monitor_fail2ban():
     """Logs fail2ban nginx-429 jail stats (currently failed and banned counts)."""
     failed, banned = get_fail2ban_counts("nginx-429")
@@ -224,7 +218,7 @@ def monitor_fail2ban():
 
 
 @limit_server(["ol-home0"], scheduler)
-@scheduler.scheduled_job('interval', seconds=60)
+@scheduler.scheduled_job("interval", seconds=60)
 async def monitor_solr_updater_lag():
     (await get_solr_updater_lag_event(solr_next=False)).submit(GRAPHITE_URL)
     (await get_solr_updater_lag_event(solr_next=True)).submit(GRAPHITE_URL)

--- a/scripts/update_stale_ocaid_references.py
+++ b/scripts/update_stale_ocaid_references.py
@@ -25,9 +25,7 @@ from openlibrary.config import load_config
 from scripts.solr_builder.solr_builder.fn_to_cli import FnToCLI
 
 # Configure logging
-logging.basicConfig(
-    level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s'
-)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
 
 def create_session_with_retries(
@@ -62,7 +60,7 @@ def get_dark_ol_editions(s3_keys, rows=10_000, since=None, until=None, statefile
     fields = ["identifier", "curatenote", "curatedate", "openlibrary_edition"]
     q = "openlibrary_edition:*"
     if since or until:
-        q = ' AND '.join((q, f"curatedate:[{since or '*'} TO {until or '*'}]"))
+        q = " AND ".join((q, f"curatedate:[{since or '*'} TO {until or '*'}]"))
 
     query_params = {
         "q": q,
@@ -80,27 +78,23 @@ def get_dark_ol_editions(s3_keys, rows=10_000, since=None, until=None, statefile
     editions = {}
     while cursor is not None:
         if cursor:
-            query_params['cursor'] = cursor
+            query_params["cursor"] = cursor
 
-        response = session.get(
-            scrape_api_url, headers=headers, params=query_params, timeout=60
-        )
+        response = session.get(scrape_api_url, headers=headers, params=query_params, timeout=60)
         response.raise_for_status()
         data = response.json()
         cursor = data.get("cursor")
         editions.update(
             {
                 # Edition key `/books/OL123M` mapped to its ES dark item metadata
-                f'/books/{doc["openlibrary_edition"]}': doc
+                f"/books/{doc['openlibrary_edition']}": doc
                 for doc in data.get("items", [])
             }
         )
-        print(
-            f"Fetching batch {batch}; adding {len(data.get("items", []))} items -> {len(editions)}"
-        )
+        print(f"Fetching batch {batch}; adding {len(data.get('items', []))} items -> {len(editions)}")
         batch += 1
     if statefile:
-        with open(statefile, 'w') as fout:
+        with open(statefile, "w") as fout:
             json.dump(editions, fout)
     return editions
 
@@ -124,17 +118,17 @@ def disassociate_dark_ocaids(s3_keys, es_editions, test=True):
         updated_eds = []
         for ed in ol_editions:
             counts["processed"] += 1
-            es_id = es_editions[ed.key]['identifier']
+            es_id = es_editions[ed.key]["identifier"]
             ed_dict = ed.dict()
-            if ed_dict.get('ocaid') == es_id:
+            if ed_dict.get("ocaid") == es_id:
                 counts["dirty"] += 1
-                del ed_dict['ocaid']
+                del ed_dict["ocaid"]
                 updated_eds.append(ed_dict)
 
         if updated_eds and not test:
             counts["updated"] += len(updated_eds)
-            with RunAs('ImportBot'):
-                web.ctx.ip = web.ctx.ip or '127.0.0.1'
+            with RunAs("ImportBot"):
+                web.ctx.ip = web.ctx.ip or "127.0.0.1"
                 web.ctx.site.save_many(
                     updated_eds,
                     comment="Redacting ocaids",
@@ -154,17 +148,15 @@ def main(
 ):
     load_config(ol_config)
     infogami._setup()
-    s3_keys = config.get('ia_ol_metadata_write_s3')  # XXX needs dark scope
+    s3_keys = config.get("ia_ol_metadata_write_s3")  # XXX needs dark scope
     if statefile and os.path.exists(statefile):
         with open(statefile) as fin:
             es_editions = json.load(fin)
     else:
-        es_editions = get_dark_ol_editions(
-            s3_keys, since=since, until=until, statefile=statefile
-        )
+        es_editions = get_dark_ol_editions(s3_keys, since=since, until=until, statefile=statefile)
     counts = disassociate_dark_ocaids(s3_keys, es_editions, test=test)
     print(counts)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     FnToCLI(main).run()


### PR DESCRIPTION
Closes #12450

Reduces the `ruff-format` `exclude:` list and `black` `files:` list from 31 files to 12 files by removing entries no longer touched by open (non-draft) PRs. Both lists are kept in sync as required.

The 19 files removed from the exclusion list:
- `openlibrary/core/lists/model.py`
- `openlibrary/plugins/openlibrary/bulk_tag.py`
- `openlibrary/plugins/openlibrary/status.py`
- `openlibrary/plugins/upstream/addbook.py`
- `openlibrary/plugins/upstream/addtag.py`
- `openlibrary/plugins/upstream/code.py`
- `openlibrary/plugins/upstream/covers.py`
- `openlibrary/plugins/upstream/jsdef.py`
- `openlibrary/plugins/worksearch/schemes/__init__.py`
- `openlibrary/plugins/worksearch/schemes/authors.py`
- `openlibrary/plugins/worksearch/schemes/lists.py`
- `openlibrary/plugins/worksearch/schemes/subjects.py`
- `openlibrary/utils/form.py`
- `openlibrary/utils/request_context.py`
- `openlibrary/utils/schema.py`
- `scripts/find_duplicate_author.py`
- `scripts/monitoring/fail2ban_monitor.py`
- `scripts/monitoring/monitor.py`
- `scripts/update_stale_ocaid_references.py`

### Technical
Single commit updating only `.pre-commit-config.yaml`. CI will auto-format the 19 newly unexcluded Python files.

### Testing
CI will run `ruff-format` and `black` on the newly included files and auto-format them, confirming the formatting changes are automatic with no extra manual edits.

### Screenshot
N/A — no UI changes.

### Stakeholders
@RayBB