### PR TITLE
i18n: Add missing Arabic translation for 'Preview Only' in ar/message…

### DIFF
--- a/openlibrary/i18n/ar/messages.po
+++ b/openlibrary/i18n/ar/messages.po
@@ -6231,6 +6231,7 @@ msgstr "فقط"
 msgid "Preview Book"
 msgstr "معاينة الكتاب"
 
+#: BookPreview.html
 msgid "Preview Only"
 msgstr "معاينة فقط"
 

--- a/openlibrary/i18n/ar/messages.po
+++ b/openlibrary/i18n/ar/messages.po
@@ -6232,11 +6232,9 @@ msgid "Preview Book"
 msgstr "معاينة الكتاب"
 
 #: BookPreview.html
+#: BookPreview.html
 msgid "Preview Only"
 msgstr "معاينة فقط"
-
-
-
 #: DonateModal.html
 msgid ""
 "Donate this book to the <a href=\"https://archive.org\">Internet "

--- a/openlibrary/i18n/ar/messages.po
+++ b/openlibrary/i18n/ar/messages.po
@@ -6231,6 +6231,11 @@ msgstr "فقط"
 msgid "Preview Book"
 msgstr "معاينة الكتاب"
 
+msgid "Preview Only"
+msgstr "معاينة فقط"
+
+
+
 #: DonateModal.html
 msgid ""
 "Donate this book to the <a href=\"https://archive.org\">Internet "

--- a/openlibrary/i18n/ar/messages.po
+++ b/openlibrary/i18n/ar/messages.po
@@ -6232,7 +6232,6 @@ msgid "Preview Book"
 msgstr "معاينة الكتاب"
 
 #: BookPreview.html
-#: BookPreview.html
 msgid "Preview Only"
 msgstr "معاينة فقط"
 #: DonateModal.html


### PR DESCRIPTION
Fixes #12456

## What this PR does
Adds the missing Arabic translation for the "Preview Only" button string 
in `openlibrary/i18n/ar/messages.po`.

## Changes
- Added `msgid "Preview Only"` / `msgstr "معاينة فقط"` to the Arabic locale file

## Testing
- Verified the entry follows the same format as other translated strings in the file
- Translation is consistent with the existing Arabic translation for "Preview" (معاينة)