### PR TITLE
Fix /merges endpoint sql injection risk

### DIFF
--- a/openlibrary/core/edits.py
+++ b/openlibrary/core/edits.py
@@ -26,6 +26,9 @@ def get_status_for_view(status_code: int) -> str:
     return _("Unknown")
 
 
+ApiMode = Literal["all", "open", "closed"]
+
+
 class CommunityEditsQueue:
     """Schema
     id: Primary identifier
@@ -55,7 +58,7 @@ class CommunityEditsQueue:
         }
     )
 
-    MODES: MappingProxyType[str, list[int]] = MappingProxyType(
+    MODES: MappingProxyType[ApiMode, list[int]] = MappingProxyType(
         {
             "all": [STATUS["DECLINED"], STATUS["PENDING"], STATUS["MERGED"]],
             "open": [STATUS["PENDING"]],
@@ -68,7 +71,7 @@ class CommunityEditsQueue:
         cls,
         limit: int = 50,
         page: int = 1,
-        mode: str = "all",
+        mode: ApiMode = "all",
         order_by_updated: Literal["asc", "desc"] | None = None,
         **kwargs,
     ):
@@ -83,15 +86,11 @@ class CommunityEditsQueue:
         query_kwargs["where"] = cls.where_clause(mode, **kwargs)
 
         if order_by_updated:
-            # Verify the type to prevent sql injection
-            if order_by_updated not in ("asc", "desc"):
-                raise ValueError(f'Invalid order_by_updated value: "{order_by_updated}". Must be "asc" or "desc".')
-
             query_kwargs["order"] = f"updated {order_by_updated}"
         return oldb.select(cls.TABLENAME, **query_kwargs)
 
     @classmethod
-    def get_counts_by_mode(cls, mode="all", **kwargs):
+    def get_counts_by_mode(cls, mode: ApiMode = "all", **kwargs):
         oldb = db.get_db()
 
         query = f"SELECT count(*) from {cls.TABLENAME}"
@@ -113,7 +112,7 @@ class CommunityEditsQueue:
         return list(oldb.query(query))
 
     @classmethod
-    def where_clause(cls, mode, **kwargs):
+    def where_clause(cls, mode: ApiMode, **kwargs):
         wheres = []
 
         if kwargs.get("reviewer") is not None:
@@ -320,7 +319,7 @@ class CommunityEditsQueue:
 
 
 @public
-def cached_get_counts_by_mode(mode="all", reviewer="", **kwargs):
+def cached_get_counts_by_mode(mode: ApiMode = "all", reviewer="", **kwargs):
     return cache.memcache_memoize(
         CommunityEditsQueue.get_counts_by_mode,
         f"librarian_queue_counts_{mode}",

--- a/openlibrary/core/edits.py
+++ b/openlibrary/core/edits.py
@@ -2,6 +2,7 @@ import datetime
 import json
 from sqlite3 import IntegrityError
 from types import MappingProxyType
+from typing import Literal
 
 from psycopg2.errors import UniqueViolation
 
@@ -68,7 +69,7 @@ class CommunityEditsQueue:
         limit: int = 50,
         page: int = 1,
         mode: str = "all",
-        order: str | None = None,
+        order_by_updated: Literal["asc", "desc"] | None = None,
         **kwargs,
     ):
         oldb = db.get_db()
@@ -81,8 +82,12 @@ class CommunityEditsQueue:
 
         query_kwargs["where"] = cls.where_clause(mode, **kwargs)
 
-        if order:
-            query_kwargs["order"] = order
+        if order_by_updated:
+            # Verify the type to prevent sql injection
+            if order_by_updated not in ("asc", "desc"):
+                raise ValueError(f'Invalid order_by_updated value: "{order_by_updated}". Must be "asc" or "desc".')
+
+            query_kwargs["order"] = f"updated {order_by_updated}"
         return oldb.select(cls.TABLENAME, **query_kwargs)
 
     @classmethod

--- a/openlibrary/plugins/upstream/edits.py
+++ b/openlibrary/plugins/upstream/edits.py
@@ -1,6 +1,7 @@
 """Librarian Edits"""
 
 import json
+from typing import Literal
 
 import web
 
@@ -47,13 +48,20 @@ class community_edits_queue(delegate.page):
             order="desc",
             status=None,
         )
+
+        order: Literal["asc", "desc"] = "desc"
+        if i.order and i.order.lower() in ("asc", "desc"):
+            order = i.order.lower()
+        else:
+            return web.badrequest(f'Invalid order parameter: "{i.order}". Must be "asc" or "desc".')
+
         merge_requests = CommunityEditsQueue.get_requests(
             page=int(i.page),
             limit=int(i.limit),
             mode=i.mode,
             submitter=i.submitter,
             reviewer=i.reviewer,
-            order=f"updated {i.order}",
+            order_by_updated=order,
             status=i.status,
         ).list()
 

--- a/openlibrary/plugins/upstream/edits.py
+++ b/openlibrary/plugins/upstream/edits.py
@@ -8,7 +8,7 @@ import web
 from infogami.utils import delegate
 from infogami.utils.view import render_template
 from openlibrary import accounts
-from openlibrary.core.edits import CommunityEditsQueue, get_status_for_view
+from openlibrary.core.edits import ApiMode, CommunityEditsQueue, get_status_for_view
 
 # Usergroups that may use create or update merge requests
 ALLOWED_USERGROUPS: list[str] = [
@@ -38,7 +38,7 @@ def process_merge_request(rtype, data):
 class community_edits_queue(delegate.page):
     path = "/merges"
 
-    def GET(self):
+    def GET(self) -> str | web.HTTPError:
         i = web.input(
             page=1,
             limit=25,
@@ -55,10 +55,16 @@ class community_edits_queue(delegate.page):
         else:
             return web.badrequest(f'Invalid order parameter: "{i.order}". Must be "asc" or "desc".')
 
+        mode: ApiMode = "open"
+        if i.mode and i.mode.lower() in CommunityEditsQueue.MODES:
+            mode = i.mode.lower()
+        else:
+            return web.badrequest(f'Invalid mode parameter: "{i.mode}". Must be one of {list(CommunityEditsQueue.MODES.keys())}.')
+
         merge_requests = CommunityEditsQueue.get_requests(
             page=int(i.page),
             limit=int(i.limit),
-            mode=i.mode,
+            mode=mode,
             submitter=i.submitter,
             reviewer=i.reviewer,
             order_by_updated=order,


### PR DESCRIPTION
Can allow for non-valid sql to be input in the ORDER BY clause. Note this has been blocked on production, so is not usable there.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Confirm https://testing.openlibrary.org/merges.json?order=foo errors.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
