### PR TITLE
Prevent expensive query.json queries

### DIFF
--- a/docker/web_nginx.conf
+++ b/docker/web_nginx.conf
@@ -188,6 +188,16 @@ server {
             return 403;
         }
 
+        # Prevent like query on title/subtitle
+        if ($request_uri ~* "^/query\.json\?.*(title|subtitle)~=") {
+            return 422;
+        }
+
+        # Prevent like query on title/subtitle in json
+        if ($request_uri ~* "^/query\.json\?.*%22(title|subtitle)~%22") {
+            return 422;
+        }
+
         # Haproxy to better handle load/traffic
         proxy_pass http://web_haproxy:7072;
         proxy_set_header Host $http_host;


### PR DESCRIPTION
We've been seeing some LIKE query traffic to our /query.json endpoints, and these fields aren't meant to support that, so block it off.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
