### PR TITLE
Replace caret (visual whitespace) with whitespace in MARC LCCN subfields

### DIFF
--- a/openlibrary/catalog/marc/parse.py
+++ b/openlibrary/catalog/marc/parse.py
@@ -147,7 +147,7 @@ def read_lccn(rec: MarcBase) -> list[str]:
         for lccn in f.get_subfield_values("a"):
             if re_question.match(lccn):
                 continue
-            lccn = lccn.replace(" ", "").replace("^", "")
+            lccn = lccn.replace("^", " ")  # replace visual whitespace
             m = re_lccn.search(lccn)
             if not m:
                 continue

--- a/openlibrary/catalog/marc/parse.py
+++ b/openlibrary/catalog/marc/parse.py
@@ -147,6 +147,7 @@ def read_lccn(rec: MarcBase) -> list[str]:
         for lccn in f.get_subfield_values("a"):
             if re_question.match(lccn):
                 continue
+            lccn = lccn.replace(" ", "").replace("^", "")
             m = re_lccn.search(lccn)
             if not m:
                 continue


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Replace caret (visual whitespace) with whitespace in MARC LCCN subfields

Example import MARC:
https://openlibrary.org/show-records/harvard_bibliographic_metadata/20220215_038.bib.mrc:21930613:2077

This is non-standard and hopefully rare, but seems to occur occasionally.


<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
