### PR TITLE
Reorder pre-commit hooks for faster feedback

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,21 +32,19 @@ repos:
     hooks:
       - id: auto-walrus
 
-  - repo: https://github.com/sqlfluff/sqlfluff
-    rev: 4.1.0
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.2
     hooks:
-      - id: sqlfluff-lint
-        args: [--dialect, postgres]
-        files: \.sql$
-        # Rule exclusions and their rationale are documented in pyproject.toml
-        # under [tool.sqlfluff.core].
-        # patron_data.sql contains raw PostgreSQL COPY data rows with tab-separated
-        # values and \N nulls which sqlfluff cannot parse.
-        # import-partial.sql uses a psql variable placeholder (:source) in a COPY
-        # command which sqlfluff cannot parse.
-        # See: https://github.com/internetarchive/openlibrary/issues/12245
-        exclude: ^(scripts/dev-instance/patron_data\.sql|scripts/solr_builder/sql/import-partial\.sql)$
+      - id: codespell  # See pyproject.toml for args
+        additional_dependencies:
+          - tomli
+        args: ["--skip", "*.mjs"]
+        exclude: ^(openlibrary/plugins/upstream/utils\.py|openlibrary/catalog/marc/parse\.py|openlibrary/catalog/add_book/match\.py)$
 
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.25
+    hooks:
+      - id: validate-pyproject
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.9
@@ -98,15 +96,6 @@ repos:
             |openlibrary/plugins/worksearch/schemes/works\.py
           )$
 
-  - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.2
-    hooks:
-      - id: codespell  # See pyproject.toml for args
-        additional_dependencies:
-          - tomli
-        args: ["--skip", "*.mjs"]
-        exclude: ^(openlibrary/plugins/upstream/utils\.py|openlibrary/catalog/marc/parse\.py|openlibrary/catalog/add_book/match\.py)$
-
   - repo: https://github.com/MarcoGorelli/cython-lint
     rev: v0.19.0
     hooks:
@@ -124,10 +113,16 @@ repos:
           - types-simplejson
           - fastapi
 
-  - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.25
+  - repo: https://github.com/awebdeveloper/pre-commit-stylelint
+    rev: 0.0.2
     hooks:
-      - id: validate-pyproject
+    - id: stylelint
+      files: \.css$
+      additional_dependencies:
+        - stylelint@16.22.0
+        - stylelint-declaration-strict-value@1.11.1
+        - stylelint-prettier@5.0.3
+      args: [--fix]
 
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v9.9.1
@@ -146,16 +141,20 @@ repos:
           - "@babel/preset-env@7.24.7"
         args: [--fix]
 
-  - repo: https://github.com/awebdeveloper/pre-commit-stylelint
-    rev: 0.0.2
+  - repo: https://github.com/sqlfluff/sqlfluff
+    rev: 4.1.0
     hooks:
-    - id: stylelint
-      files: \.css$
-      additional_dependencies:
-        - stylelint@16.22.0
-        - stylelint-declaration-strict-value@1.11.1
-        - stylelint-prettier@5.0.3
-      args: [--fix]
+      - id: sqlfluff-lint
+        args: [--dialect, postgres]
+        files: \.sql$
+        # Rule exclusions and their rationale are documented in pyproject.toml
+        # under [tool.sqlfluff.core].
+        # patron_data.sql contains raw PostgreSQL COPY data rows with tab-separated
+        # values and \N nulls which sqlfluff cannot parse.
+        # import-partial.sql uses a psql variable placeholder (:source) in a COPY
+        # command which sqlfluff cannot parse.
+        # See: https://github.com/internetarchive/openlibrary/issues/12245
+        exclude: ^(scripts/dev-instance/patron_data\.sql|scripts/solr_builder/sql/import-partial\.sql)$
 
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,13 +116,13 @@ repos:
   - repo: https://github.com/awebdeveloper/pre-commit-stylelint
     rev: 0.0.2
     hooks:
-    - id: stylelint
-      files: \.css$
-      additional_dependencies:
-        - stylelint@16.22.0
-        - stylelint-declaration-strict-value@1.11.1
-        - stylelint-prettier@5.0.3
-      args: [--fix]
+      - id: stylelint
+        files: \.css$
+        additional_dependencies:
+          - stylelint@16.22.0
+          - stylelint-declaration-strict-value@1.11.1
+          - stylelint-prettier@5.0.3
+        args: [--fix]
 
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v9.9.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -141,21 +141,6 @@ repos:
           - "@babel/preset-env@7.24.7"
         args: [--fix]
 
-  - repo: https://github.com/sqlfluff/sqlfluff
-    rev: 4.1.0
-    hooks:
-      - id: sqlfluff-lint
-        args: [--dialect, postgres]
-        files: \.sql$
-        # Rule exclusions and their rationale are documented in pyproject.toml
-        # under [tool.sqlfluff.core].
-        # patron_data.sql contains raw PostgreSQL COPY data rows with tab-separated
-        # values and \N nulls which sqlfluff cannot parse.
-        # import-partial.sql uses a psql variable placeholder (:source) in a COPY
-        # command which sqlfluff cannot parse.
-        # See: https://github.com/internetarchive/openlibrary/issues/12245
-        exclude: ^(scripts/dev-instance/patron_data\.sql|scripts/solr_builder/sql/import-partial\.sql)$
-
   - repo: local
     hooks:
     - id: generate-pot
@@ -184,3 +169,18 @@ repos:
       language: python
       verbose: true
       require_serial: true
+
+  - repo: https://github.com/sqlfluff/sqlfluff
+    rev: 4.1.0
+    hooks:
+      - id: sqlfluff-lint
+        args: [--dialect, postgres]
+        files: \.sql$
+        # Rule exclusions and their rationale are documented in pyproject.toml
+        # under [tool.sqlfluff.core].
+        # patron_data.sql contains raw PostgreSQL COPY data rows with tab-separated
+        # values and \N nulls which sqlfluff cannot parse.
+        # import-partial.sql uses a psql variable placeholder (:source) in a COPY
+        # command which sqlfluff cannot parse.
+        # See: https://github.com/internetarchive/openlibrary/issues/12245
+        exclude: ^(scripts/dev-instance/patron_data\.sql|scripts/solr_builder/sql/import-partial\.sql)$


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #12471

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
refactor

### Technical
<!-- What should be noted about the implementation? -->
Reordered hooks in `.pre-commit-config.yaml` to surface faster feedback earlier and move slower hooks later.

Changes:
- Moved `codespell` and `validate-pyproject` below `auto-walrus`
- Placed `stylelint` before `eslint`
- Moved `sqlfluff-lint` toward the end of external hooks
- Kept local hooks at the end to preserve existing project conventions

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Ran: `pre-commit run --all-files`

Most hooks passed locally. `mypy` and `generate-pot` failed because my local environment is missing the project dependency `infogami`.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
