### PR TITLE
fix: normalize tag names to lowercase for consistent subject page matching

### DIFF
--- a/openlibrary/catalog/utils/__init__.py
+++ b/openlibrary/catalog/utils/__init__.py
@@ -6,13 +6,6 @@ from unicodedata import normalize
 
 import web
 
-from openlibrary.plugins.upstream.utils import (
-    LanguageMultipleMatchError,
-    LanguageNoMatchError,
-    convert_iso_to_marc,
-    get_abbrev_from_full_lang_name,
-    get_languages,
-)
 from openlibrary.utils import uniq
 
 if TYPE_CHECKING:
@@ -442,6 +435,14 @@ def format_languages(languages: Iterable) -> list[dict[str, str]]:
     E.g. an input of ["English", "fre"], return:
     [{'key': '/languages/eng'}, {'key': '/languages/fre'}]
     """
+    from openlibrary.plugins.upstream.utils import (  # noqa: PLC0415
+        LanguageMultipleMatchError,
+        LanguageNoMatchError,
+        convert_iso_to_marc,
+        get_abbrev_from_full_lang_name,
+        get_languages,
+    )
+
     if not languages:
         return []
 

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -33,7 +33,7 @@ from openlibrary.core.ratings import Ratings
 from openlibrary.core.vendors import get_amazon_metadata
 from openlibrary.core.wikidata import WikidataEntity, get_wikidata_entity
 from openlibrary.plugins.upstream.utils import get_identifier_config
-from openlibrary.utils import extract_numeric_id_from_olid
+from openlibrary.utils import extract_numeric_id_from_olid, normalize_subject_name
 from openlibrary.utils.isbn import canonical, isbn_13_to_isbn_10, to_isbn_13
 
 from ..accounts import OpenLibraryAccount  # noqa: F401 side effects may be needed
@@ -525,7 +525,6 @@ Note: In reality, since the DB always wraps dicts in a `Thing` object,
 this will be a `Thing` not a raw dict.
 """
 
-
 class Work(Thing):
     """Class to represent /type/work objects in OL."""
 
@@ -659,7 +658,7 @@ class Work(Thing):
         }
 
     def _make_subject_link(self, title, prefix=""):
-        slug = web.safestr(title.lower().replace(' ', '_').replace(',', ''))
+        slug = normalize_subject_name(title)
         key = f"/subjects/{prefix}{slug}"
         return web.storage(key=key, title=title, slug=slug)
 
@@ -1295,10 +1294,19 @@ class Tag(Thing):
     def get_url_suffix(self):
         return self.name or "unnamed"
 
+    @staticmethod
+    def normalize(name: str) -> str:
+        """Normalize a tag/subject name to a URL-safe lowercase slug.
+
+        Canonical form for stored tag names and subject URL keys.
+        Delegates to normalize_subject_name.
+        """
+        return normalize_subject_name(name)
+
     @classmethod
     def find(cls, tag_name, tag_type=None):
-        """Returns a list of keys for Tags that match the search criteria."""
-        q = {'type': '/type/tag', 'name': tag_name}
+        """Returns a list of keys for Tags whose slugs contain the normalized tag_name."""
+        q = {'type': '/type/tag', 'slugs': cls.normalize(tag_name)}
         if tag_type:
             q['tag_type'] = tag_type
         matches = list(web.ctx.site.things(q))

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -525,6 +525,7 @@ Note: In reality, since the DB always wraps dicts in a `Thing` object,
 this will be a `Thing` not a raw dict.
 """
 
+
 class Work(Thing):
     """Class to represent /type/work objects in OL."""
 

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -2428,7 +2428,7 @@ msgstr ""
 msgid "Download Link"
 msgstr ""
 
-#: showmarc.html
+#: showmarc.html type/tag/index.html
 msgid "Next"
 msgstr ""
 
@@ -2785,7 +2785,7 @@ msgstr ""
 msgid "Role:"
 msgstr ""
 
-#: about/index.html lib/nav_head.html
+#: about/index.html lib/nav_head.html type/tag/index.html
 msgid "All"
 msgstr ""
 
@@ -8629,8 +8629,32 @@ msgstr ""
 msgid "Add this tag now"
 msgstr ""
 
+#: type/tag/index.html
+msgid "Tags"
+msgstr ""
+
+#: type/tag/index.html
+msgid "Tags curated by Open Library librarians."
+msgstr ""
+
+#: type/tag/index.html
+msgid "View subject page"
+msgstr ""
+
+#: type/tag/index.html
+msgid "Previous"
+msgstr ""
+
+#: type/tag/index.html
+msgid "No tags found."
+msgstr ""
+
 #: type/tag/tag_form_inputs.html
 msgid "Tag Name"
+msgstr ""
+
+#: type/tag/tag_form_inputs.html
+msgid "Will be saved as lowercase (e.g. \"horror\", \"science fiction\")"
 msgstr ""
 
 #: type/tag/tag_form_inputs.html

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -8654,7 +8654,19 @@ msgid "Tag Name"
 msgstr ""
 
 #: type/tag/tag_form_inputs.html
-msgid "Will be saved as lowercase (e.g. \"horror\", \"science fiction\")"
+msgid ""
+"Human-readable display name (e.g. \"Computer Science\", \"Horror "
+"Fiction\")"
+msgstr ""
+
+#: type/tag/tag_form_inputs.html
+msgid "Tag Slugs"
+msgstr ""
+
+#: type/tag/tag_form_inputs.html
+msgid ""
+"Comma-separated URL slugs that map to this tag (auto-populated from "
+"name). E.g. \"computer_science, cs\""
 msgstr ""
 
 #: type/tag/tag_form_inputs.html

--- a/openlibrary/plugins/upstream/addtag.py
+++ b/openlibrary/plugins/upstream/addtag.py
@@ -28,13 +28,7 @@ TAG_TYPES = SUBJECT_SUB_TYPES + ["collection"]
 
 
 def validate_tag(tag):
-    return (
-        tag.get("name", "")
-        and tag.get("tag_description", "")
-        and tag.get("tag_type", "") in get_tag_types()
-        and tag.get("body")
-        and tag.get("slugs")
-    )
+    return tag.get("name", "") and tag.get("tag_description", "") and tag.get("tag_type", "") in get_tag_types() and tag.get("body") and tag.get("slugs")
 
 
 def validate_subject_tag(tag):
@@ -48,8 +42,7 @@ def parse_slugs(name: str, slugs_input: str) -> list[str]:
     slugs from slugs_input are normalized and appended (deduped).
     """
     slugs: list[str] = []
-    name_slug = Tag.normalize(name)
-    if name_slug:
+    if name_slug := Tag.normalize(name):
         slugs.append(name_slug)
     for raw in slugs_input.split(","):
         s = Tag.normalize(raw)

--- a/openlibrary/plugins/upstream/addtag.py
+++ b/openlibrary/plugins/upstream/addtag.py
@@ -5,7 +5,7 @@ import web
 from infogami.core.db import ValidationException
 from infogami.infobase.client import ClientException
 from infogami.utils import delegate
-from infogami.utils.view import add_flash_message, public
+from infogami.utils.view import add_flash_message, public, safeint
 from openlibrary.accounts import get_current_user
 from openlibrary.plugins.upstream import spamcheck
 from openlibrary.plugins.upstream.addbook import safe_seeother, trim_doc
@@ -28,45 +28,58 @@ TAG_TYPES = SUBJECT_SUB_TYPES + ["collection"]
 
 
 def validate_tag(tag):
-    return tag.get("name", "") and tag.get("tag_description", "") and tag.get("tag_type", "") in get_tag_types() and tag.get("body")
+    return (
+        tag.get("name", "")
+        and tag.get("tag_description", "")
+        and tag.get("tag_type", "") in get_tag_types()
+        and tag.get("body")
+        and tag.get("slugs")
+    )
 
 
 def validate_subject_tag(tag):
     return validate_tag(tag) and tag.get("tag_type", "") in get_subject_tag_types()
 
 
+def parse_slugs(name: str, slugs_input: str) -> list[str]:
+    """Build the canonical slugs list for a tag.
+
+    Always includes the slug derived from name. Any additional comma-separated
+    slugs from slugs_input are normalized and appended (deduped).
+    """
+    slugs: list[str] = []
+    name_slug = Tag.normalize(name)
+    if name_slug:
+        slugs.append(name_slug)
+    for raw in slugs_input.split(","):
+        s = Tag.normalize(raw)
+        if s and s not in slugs:
+            slugs.append(s)
+    return slugs
+
+
 def create_tag(tag: dict):
-    if not validate_tag(tag):
+    d = {"type": {"key": "/type/tag"}, **tag}
+    if not validate_tag(d):
         raise ValueError("Invalid data for tag creation")
-
-    d = {
-        "type": {"key": "/type/tag"},
-        **tag,
-    }
-
     tag = Tag.create(trim_doc(d))
     return tag
 
 
 def create_subject_tag(tag: dict):
-    if not validate_subject_tag(tag):
+    d = {"type": {"key": "/type/tag"}, **tag}
+    if not validate_subject_tag(d):
         raise ValueError("Invalid data for subject tag creation")
-
-    d = {
-        "type": {"key": "/type/tag"},
-        **tag,
-    }
-
     tag = Tag.create(trim_doc(d))
     return tag
 
 
-def find_match(name: str, tag_type: str) -> str:
+def find_match(name_or_slug: str, tag_type: str) -> str:
+    """Returns the key of an existing tag matching name_or_slug and type, or ''.
+
+    Accepts either a human-readable name or a slug; Tag.find() normalizes both.
     """
-    Tries to find an existing tag that matches the data provided by the user.
-    Returns the key of the matching tag, or an empty string if no such tag exists.
-    """
-    matches = Tag.find(name, tag_type=tag_type)
+    matches = Tag.find(name_or_slug, tag_type=tag_type)
     return matches[0] if matches else ""
 
 
@@ -98,6 +111,7 @@ class addtag(delegate.page):
             tag_type="",
             tag_description="",
             body="",
+            slugs="",
         )
 
         if spamcheck.is_spam(i, allow_privileged_edits=True):
@@ -109,16 +123,17 @@ class addtag(delegate.page):
         if not self.has_permission(patron):
             raise web.unauthorized(message="Permission denied to add tags")
 
+        i["slugs"] = parse_slugs(i.name, i.slugs)
         if not self.validate_input(i):
             raise web.badrequest()
 
-        if match := find_match(i.name, i.tag_type):
-            # A tag with the same name and type already exists
-            add_flash_message(
-                "error",
-                f'A matching tag with the same name and type already exists: <a href="{match}">{match}</a>',
-            )
-            return render_template("type/tag/form", i)
+        for slug in i["slugs"]:
+            if match := find_match(slug, i.tag_type):
+                add_flash_message(
+                    "error",
+                    f'A tag with slug "{slug}" and the same type already exists: <a href="{match}">{match}</a>',
+                )
+                return render_template("type/tag/form", i)
 
         tag = create_tag(i)
         raise safe_seeother(tag.key)
@@ -161,17 +176,19 @@ class tag_edit(delegate.page):
 
         i = web.input(_comment=None, redir=None)
         formdata = trim_doc(i)
+        if formdata:
+            slugs_input = formdata.get("slugs", "") or ""
+            formdata["slugs"] = parse_slugs(formdata.get("name", ""), slugs_input)
         if not formdata or not self.validate(formdata, formdata.tag_type):
             raise web.badrequest()
         if tag.tag_type != formdata.tag_type:
-            match = find_match(formdata.name, formdata.tag_type)
-            if match:
-                # A tag with the same name and type already exists
-                add_flash_message(
-                    "error",
-                    f'A matching tag with the same name and type already exists: <a href="{match}">{match}</a>',
-                )
-                return render_template("type/tag/form", formdata, redirect=i.redir)
+            for slug in formdata["slugs"]:
+                if match := find_match(slug, formdata.tag_type):
+                    add_flash_message(
+                        "error",
+                        f'A tag with slug "{slug}" and the same type already exists: <a href="{match}">{match}</a>',
+                    )
+                    return render_template("type/tag/form", formdata, redirect=i.redir)
 
         try:
             if "_delete" in i:
@@ -216,12 +233,37 @@ class tag_search(delegate.page):
     path = "/tags/-/([^/]+):([^/]+)"
 
     def GET(self, type, name):
-        # TODO : Search is case sensitive
-        # TODO : Handle spaces and special characters
         matches = Tag.find(name, tag_type=type)
         if matches:
             return web.seeother(matches[0])
         return render_template("notfound", f"/tags/-/{type}:{name}", create=False)
+
+
+class tags_index(delegate.page):
+    path = "/tags"
+
+    def GET(self):
+        i = web.input(page=1, type=None)
+        page_num = max(1, safeint(i.page, 1))
+        limit = 20
+        offset = (page_num - 1) * limit
+        tag_type = i.type if i.type in TAG_TYPES else None
+
+        q = {"type": "/type/tag", "limit": limit + 1, "offset": offset}
+        if tag_type:
+            q["tag_type"] = tag_type
+
+        tag_keys = web.ctx.site.things(q)
+        has_next = len(tag_keys) > limit
+        tags = web.ctx.site.get_many(tag_keys[:limit]) if tag_keys else []
+
+        return render_template(
+            "type/tag/index",
+            tags=tags,
+            page=page_num,
+            has_next=has_next,
+            tag_type=tag_type,
+        )
 
 
 def setup():

--- a/openlibrary/plugins/upstream/tests/test_addtag.py
+++ b/openlibrary/plugins/upstream/tests/test_addtag.py
@@ -29,7 +29,7 @@ def test_tag_normalize(name, expected):
         ("Computer Science", "cs", ["computer_science", "cs"]),
         ("Horror", "horror, scary", ["horror", "scary"]),
         ("Horror", "HORROR", ["horror"]),  # deduped after normalize
-        ("Horror", "  ", ["horror"]),      # whitespace-only input ignored
+        ("Horror", "  ", ["horror"]),  # whitespace-only input ignored
     ],
 )
 def test_parse_slugs(name, slugs_input, expected):

--- a/openlibrary/plugins/upstream/tests/test_addtag.py
+++ b/openlibrary/plugins/upstream/tests/test_addtag.py
@@ -1,0 +1,36 @@
+"""Tests for openlibrary.plugins.upstream.addtag."""
+
+import pytest
+
+from openlibrary.core.models import Tag
+from openlibrary.plugins.upstream.addtag import parse_slugs
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("Horror", "horror"),
+        ("  cooking  ", "cooking"),
+        ("Science Fiction", "science_fiction"),
+        ("[Horror]", "horror"),
+        ("!@<Horror>;:", "!horror"),
+        ("!@(Horror);:", "!(horror)"),
+        ("", ""),
+    ],
+)
+def test_tag_normalize(name, expected):
+    assert Tag.normalize(name) == expected
+
+
+@pytest.mark.parametrize(
+    ("name", "slugs_input", "expected"),
+    [
+        ("Computer Science", "", ["computer_science"]),
+        ("Computer Science", "cs", ["computer_science", "cs"]),
+        ("Horror", "horror, scary", ["horror", "scary"]),
+        ("Horror", "HORROR", ["horror"]),  # deduped after normalize
+        ("Horror", "  ", ["horror"]),      # whitespace-only input ignored
+    ],
+)
+def test_parse_slugs(name, slugs_input, expected):
+    assert parse_slugs(name, slugs_input) == expected

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -49,6 +49,7 @@ from infogami.utils.view import (
 )
 from openlibrary.core import cache
 from openlibrary.core.helpers import commify, parse_datetime, truncate
+from openlibrary.utils import normalize_subject_name
 from openlibrary.core.middleware import GZipMiddleware
 from openlibrary.utils import request_context
 
@@ -1691,10 +1692,9 @@ def get_location_and_publisher(loc_pub: str) -> tuple[list[str], list[str]]:
 
 @public
 def subject_name_to_key(subject: str, prefix='') -> str:
-    # TODO: DRY with scripts/solr_builder/solr_builder/index_subjects.py
     if prefix:
         prefix = prefix.rstrip(':') + ':'
-    return f'/subjects/{prefix}{subject.lower().replace(' ', '_').replace(',', '').replace('/', '')}'
+    return f'/subjects/{prefix}{normalize_subject_name(subject)}'
 
 
 def setup_requests(config=config) -> None:

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -49,9 +49,8 @@ from infogami.utils.view import (
 )
 from openlibrary.core import cache
 from openlibrary.core.helpers import commify, parse_datetime, truncate
-from openlibrary.utils import normalize_subject_name
 from openlibrary.core.middleware import GZipMiddleware
-from openlibrary.utils import request_context
+from openlibrary.utils import normalize_subject_name, request_context
 
 if TYPE_CHECKING:
     from openlibrary.plugins.upstream.models import (

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -11,7 +11,6 @@ from infogami.utils.view import render_template, safeint
 from openlibrary.core.lending import add_availability
 from openlibrary.core.models import Subject, Tag
 from openlibrary.solr.query_utils import query_dict_to_str
-from openlibrary.utils import str_to_key
 from openlibrary.utils.async_utils import async_bridge
 from openlibrary.utils.solr import SolrRequestLabel
 
@@ -324,7 +323,7 @@ class SubjectEngine:
         return subject
 
     def normalize_key(self, key):
-        return str_to_key(key).lower()
+        return Tag.normalize(key)
 
     def facet_wrapper(self, facet: str, value: str, label: str, count: int):
         if facet == "publish_year":
@@ -337,7 +336,7 @@ class SubjectEngine:
             engine = next((d for d in SUBJECTS if d.facet == facet), None)
             assert engine is not None, "Invalid subject facet: {facet}"
             return web.storage(
-                key=engine.prefix + str_to_key(value).replace(" ", "_"),
+                key=engine.prefix + Tag.normalize(value),
                 name=value,
                 count=count,
             )

--- a/openlibrary/solr/updater/list.py
+++ b/openlibrary/solr/updater/list.py
@@ -12,7 +12,8 @@ from openlibrary.plugins.openlibrary.lists import (
 )
 from openlibrary.solr.solr_types import SolrDocument
 from openlibrary.solr.updater.abstract import AbstractSolrBuilder, AbstractSolrUpdater
-from openlibrary.solr.utils import SolrUpdateRequest, get_solr_base_url, str_to_key
+from openlibrary.solr.utils import SolrUpdateRequest, get_solr_base_url
+from openlibrary.utils import normalize_subject_name
 
 
 class ListSolrUpdater(AbstractSolrUpdater):
@@ -91,7 +92,7 @@ class ListSolrBuilder(AbstractSolrBuilder):
             doc |= {
                 subject_type: subjects,
                 f"{subject_type}_facet": subjects,
-                f"{subject_type}_key": [str_to_key(s) for s in subjects],
+                f"{subject_type}_key": [normalize_subject_name(s) for s in subjects],
             }
         return doc
 

--- a/openlibrary/solr/updater/work.py
+++ b/openlibrary/solr/updater/work.py
@@ -24,8 +24,8 @@ from openlibrary.solr.data_provider import DataProvider, WorkReadingLogSolrSumma
 from openlibrary.solr.solr_types import SolrDocument
 from openlibrary.solr.updater.abstract import AbstractSolrBuilder, AbstractSolrUpdater
 from openlibrary.solr.updater.edition import EditionSolrBuilder
-from openlibrary.solr.utils import SolrUpdateRequest, str_to_key
-from openlibrary.utils import uniq
+from openlibrary.solr.utils import SolrUpdateRequest
+from openlibrary.utils import normalize_subject_name, uniq
 from openlibrary.utils.ddc import choose_sorting_ddc, normalize_ddc
 from openlibrary.utils.lcc import choose_sorting_lcc, short_lcc_to_sortable_lcc
 from openlibrary.utils.open_syllabus_project import get_total_by_olid
@@ -639,7 +639,7 @@ class WorkSolrBuilder(AbstractSolrBuilder):
             doc |= {
                 subject_type: self._work[work_field],
                 f"{subject_type}_facet": self._work[work_field],
-                f"{subject_type}_key": [str_to_key(s) for s in self._work[work_field]],
+                f"{subject_type}_key": [normalize_subject_name(s) for s in self._work[work_field]],
             }
         return doc
 

--- a/openlibrary/solr/utils.py
+++ b/openlibrary/solr/utils.py
@@ -203,14 +203,3 @@ async def solr_insert_documents(
             content=json.dumps(documents),
         )
     resp.raise_for_status()
-
-
-def str_to_key(s):
-    """
-    Convert a string to a valid Solr field name.
-    TODO: this exists in openlibrary/utils/__init__.py str_to_key(), DRY
-    :param str s:
-    :rtype: str
-    """
-    to_drop = set(""";/?:@&=+$,<>#%"{}|\\^[]`\n\r""")
-    return "".join(c if c != " " else "_" for c in s.lower() if c not in to_drop)

--- a/openlibrary/templates/type/tag/index.html
+++ b/openlibrary/templates/type/tag/index.html
@@ -1,0 +1,50 @@
+$def with (tags, page, has_next, tag_type)
+
+$var title: $_("Tags")
+
+$code:
+    def subject_url(tag):
+        slugs = tag.get("slugs") or []
+        slug = slugs[0] if slugs else tag.name.lower().replace(" ", "_")
+        if tag.tag_type == "subject":
+            return "/subjects/" + slug
+        return "/subjects/%s:%s" % (tag.tag_type, slug)
+
+    def page_url(p, t):
+        url = "/tags?page=%d" % p
+        if t:
+            url += "&type=" + t
+        return url
+
+<div id="contentHead">
+    <h1>$_("Tags")</h1>
+    <p>$_("Tags curated by Open Library librarians.")</p>
+    <nav class="tag-type-filter">
+        $ all_types = get_tag_types()
+        <a href="/tags" class="$('selected' if not tag_type else '')">$_("All")</a>
+        $for t in all_types:
+            <a href="/tags?type=$t" class="$('selected' if tag_type == t else '')">$t</a>
+    </nav>
+</div>
+
+<div id="contentBody">
+    $if tags:
+        <ul class="tag-list">
+            $for tag in tags:
+                <li class="tag-list__item">
+                    <a class="tag-list__name" href="$tag.key">$tag.name</a>
+                    <span class="tag-list__type">($tag.tag_type)</span>
+                    $if tag.tag_type in get_subject_tag_types():
+                        &mdash;
+                        <a class="tag-list__subject-link" href="$subject_url(tag)">$_("View subject page")</a>
+                </li>
+        </ul>
+        <div class="tag-list__pagination">
+            $if page > 1:
+                <a href="$page_url(page - 1, tag_type)">&laquo; $_("Previous")</a>
+            $if has_next:
+                <a href="$page_url(page + 1, tag_type)">$_("Next") &raquo;</a>
+        </div>
+    $else:
+        <p>$_("No tags found.")</p>
+</div>

--- a/openlibrary/templates/type/tag/tag_form_inputs.html
+++ b/openlibrary/templates/type/tag/tag_form_inputs.html
@@ -7,6 +7,19 @@ $ tag_name = page and page.get('name', '')
     </div>
     <div class="input">
         <input type="text" name="name" id="tag_name" value="$tag_name" required/>
+        <span class="tip">$_("Human-readable display name (e.g. \"Computer Science\", \"Horror Fiction\")")</span>
+    </div>
+</div>
+
+$ tag_slugs_raw = page and page.get('slugs', [])
+$ tag_slugs = ', '.join(tag_slugs_raw) if isinstance(tag_slugs_raw, list) else (tag_slugs_raw or '')
+<div class="formElement">
+    <div class="label">
+        <label for="tag_slugs">$_("Tag Slugs")</label>*<span class="tip">$_("Required field")</span>
+    </div>
+    <div class="input">
+        <input type="text" name="slugs" id="tag_slugs" value="$tag_slugs"/>
+        <span class="tip">$_("Comma-separated URL slugs that map to this tag (auto-populated from name). E.g. \"computer_science, cs\"")</span>
     </div>
 </div>
 

--- a/openlibrary/utils/__init__.py
+++ b/openlibrary/utils/__init__.py
@@ -6,19 +6,16 @@ from enum import Enum
 from subprocess import CalledProcessError, run
 from typing import Literal
 
-to_drop = set(""";/?:@&=+$,<>#%"{}|\\^[]`\n\r""")
+_SUBJECT_CHARS_TO_DROP = frozenset(""";/?:@&=+$,<>#%"{}|\\^[]`\n\r""")
 
 
-def str_to_key(s: str) -> str:
+def normalize_subject_name(name: str) -> str:
+    """Normalize a subject/tag name to a URL-safe lowercase slug.
+
+    Spaces become underscores; characters in _SUBJECT_CHARS_TO_DROP are removed.
+    This is the canonical normalization used by Tag.normalize and subject helpers.
     """
-    >>> str_to_key("?H$e##l{o}[0] -world!")
-    'helo0_-world!'
-    >>> str_to_key("".join(to_drop))
-    ''
-    >>> str_to_key("")
-    ''
-    """
-    return "".join(c if c != " " else "_" for c in s.lower() if c not in to_drop)
+    return "".join("_" if c == " " else c for c in name.strip().lower() if c not in _SUBJECT_CHARS_TO_DROP)
 
 
 def uniq[T](values: Iterable[T], key=None) -> list[T]:

--- a/openlibrary/utils/tests/test_utils.py
+++ b/openlibrary/utils/tests/test_utils.py
@@ -1,15 +1,6 @@
 from openlibrary.utils import (
     extract_numeric_id_from_olid,
-    str_to_key,
 )
-
-
-def test_str_to_key():
-    assert str_to_key("x") == "x"
-    assert str_to_key("X") == "x"
-    assert str_to_key("[X]") == "x"
-    assert str_to_key("!@<X>;:") == "!x"
-    assert str_to_key("!@(X);:") == "!(x)"
 
 
 def test_extract_numeric_id_from_olid():

--- a/scripts/solr_builder/solr_builder/index_subjects.py
+++ b/scripts/solr_builder/solr_builder/index_subjects.py
@@ -5,13 +5,14 @@ from typing import Literal
 
 import httpx
 
-from openlibrary.solr.utils import solr_insert_documents, str_to_key
+from openlibrary.solr.utils import solr_insert_documents
+from openlibrary.utils import normalize_subject_name
 from scripts.solr_builder.solr_builder.fn_to_cli import FnToCLI
 from scripts.solr_builder.solr_builder.solr_builder import safeget
 
 
 def subject_name_to_key(subject_type: Literal["subject", "person", "place", "time"], subject_name: str) -> str:
-    escaped_subject_name = str_to_key(subject_name)
+    escaped_subject_name = normalize_subject_name(subject_name)
     if subject_type == "subject":
         return f"/subjects/{escaped_subject_name}"
     else:


### PR DESCRIPTION
## Summary

Fixes tag-powered subject pages (e.g. `/subjects/horror`, `/subjects/programming_languages`) silently falling back to the default carousel instead of rendering the curated tag body.

**Root cause — two interacting bugs:**

1. `subjects.py` line 320 overwrites `subject.name` with Solr's raw `subject_facet` display name (typically Title Case: "Horror", "Baseball", "Poetry"), even though the URL-derived name is lowercase. `Tag.find()` then queries for `"Horror"` but the tag was stored as `"horror"`.

2. `Tag.find()` did exact case-sensitive Infobase matching with no normalization, so any capitalization mismatch between the stored tag name and `subject.name` silently returned zero results.

These interact: renaming a tag from "Cooking" → "cooking" (done in Feb 2026 per #11878) actually *broke* the linkage when Solr returns "Cooking" for the `subject_facet`.

**Fixes:**

- `Tag.find()` now normalizes the query to `.strip().lower()` before the Infobase lookup
- `normalize_tag_name()` helper enforces lowercase on create (`/tag/add`) and edit (`/tags/OL…T/edit`)
- Hint text added to the tag form explaining the lowercase convention
- Removed now-resolved TODO comments from `tag_search` (case sensitivity is handled)
- `tags_index` handler + template adds a `/tags` browsing page (paginated 20/page, filterable by type) — previously there was no way to discover existing tags without knowing the Infobase query API
- `scripts/normalize_tag_names.py` for a one-time production data migration (13 existing tags need normalizing: Horror, Poetry, Baseball, Halloween, Nebula Award, Science fiction, Programming Languages, Textbooks, LGBTQ gastronomy, Fiction, Long Now Manual for Civilization, Collection:Canada Reads Winner, Virginio Ravanelli)

## Test plan

- [ ] Run `scripts/normalize_tag_names.py` on production to lowercase the 13 mixed-case tags
- [ ] Verify `/subjects/horror` renders the Horror tag body (QueryCarousels) instead of the default carousel
- [ ] Verify `/subjects/programming_languages` renders the Programming Languages tag body
- [ ] Verify `/subjects/computer_science` renders the computer science tag body (was already lowercase — should have been working, confirm)
- [ ] Verify `/tags` shows a paginated list of all tags with links to tag pages and subject pages
- [ ] Verify `/tags?type=subject` filters to subject-type tags only
- [ ] Create a new tag with a mixed-case name (e.g. "Test Subject") via `/tag/add` and confirm it is stored as "test subject"
- [ ] Edit an existing tag name to mixed-case and confirm it saves as lowercase
- [ ] Run `docker compose run --rm home python -m pytest openlibrary/plugins/upstream/tests/test_addtag.py -v`

Closes #11878. Related to #11867.