### PR TITLE
Remove verbose output from i18n pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -167,7 +167,6 @@ repos:
       entry: python ./scripts/detect_missing_i18n.py
       types: [html]
       language: python
-      verbose: true
       require_serial: true
 
   - repo: https://github.com/sqlfluff/sqlfluff


### PR DESCRIPTION
Closes #12476

Removes `verbose: true` from the `detect-missing-i18n` pre-commit hook so contributors get the concise hook output described in the issue without changing what the hook checks.

### Technical
Only changes `.pre-commit-config.yaml`; `require_serial: true`, the hook entry point, and file type filtering remain unchanged.

### Testing
- `git diff --check`

### Screenshot
N/A — pre-commit configuration only.

### Stakeholders
@RayBB

AI assistance disclosure: OpenAI Codex GPT-5.5 helped inspect the issue, make the one-line config change, and run validation; I reviewed the resulting diff.
