### PR TITLE
Remove WMD reference from olmarkdown.py docstring

### DIFF
--- a/openlibrary/core/olmarkdown.py
+++ b/openlibrary/core/olmarkdown.py
@@ -7,8 +7,6 @@ Differences from traditional Markdown:
 * URLs are autolinked
 * generated HTML is sanitized
 
-The custom changes done here to markdown are also reptead in WMD editor,
-the javascript markdown editor used in OL.
 """
 
 import re


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #12479 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR removes the stale WMD editor reference from the `openlibrary/core/olmarkdown.py` module docstring.


### Technical
<!-- What should be noted about the implementation? -->
The WMD editor was removed in #12182. This removes the two remaining stale lines from the `openlibrary/core/olmarkdown.py` module docstring that still referenced it.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Ran `grep -ri wmd openlibrary/ static/ vendor/`

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
