### PR TITLE
make _do_search_query async for CarouselLoadMore in fastapi

### DIFF
--- a/openlibrary/fastapi/partials.py
+++ b/openlibrary/fastapi/partials.py
@@ -152,4 +152,4 @@ async def carousel_load_more_partial(
     queryType (SEARCH | BROWSE | TRENDING | SUBJECTS), q, limit, page,
     sorts, subject, hasFulltextOnly, key, layout, published_in.
     """
-    return CarouselCardPartial(params=params).generate()
+    return await CarouselCardPartial(params=params).generate_async()

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -23,7 +23,6 @@ from openlibrary.plugins.upstream.utils import render_macro
 from openlibrary.plugins.upstream.yearly_reading_goals import get_reading_goals
 from openlibrary.plugins.worksearch.code import (
     do_search_async,
-    work_search,
     work_search_async,
 )
 from openlibrary.plugins.worksearch.subjects import (
@@ -106,10 +105,13 @@ class CarouselCardPartial(PartialDataHandler):
         self.params = params
 
     def generate(self) -> dict:
+        raise NotImplementedError("Use generate_async instead")
+
+    async def generate_async(self) -> dict:
         p = self.params
 
         # Do search
-        search_results = self._make_book_query(p.queryType, p)
+        search_results = await self._make_book_query(p.queryType, p)
 
         # Render cards
         cards = []
@@ -136,9 +138,9 @@ class CarouselCardPartial(PartialDataHandler):
 
         return {"partials": [str(template) for template in cards]}
 
-    def _make_book_query(self, query_type: str, params: CarouselLoadMoreParams) -> list:
+    async def _make_book_query(self, query_type: str, params: CarouselLoadMoreParams) -> list:
         if query_type == "SEARCH":
-            return self._do_search_query(params)
+            return await self._do_search_query(params)
         if query_type == "BROWSE":
             return self._do_browse_query(params)
         if query_type == "TRENDING":
@@ -148,7 +150,7 @@ class CarouselCardPartial(PartialDataHandler):
 
         raise ValueError("Unknown query type")
 
-    def _do_search_query(self, params: CarouselLoadMoreParams) -> list:
+    async def _do_search_query(self, params: CarouselLoadMoreParams) -> list:
         fields = [
             "key",
             "title",
@@ -168,7 +170,7 @@ class CarouselCardPartial(PartialDataHandler):
         if params.hasFulltextOnly:
             query_params["has_fulltext"] = "true"
 
-        results = work_search(
+        results = await work_search_async(
             query_params,
             sort=params.sorts or "new",
             fields=",".join(fields),

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
 from hashlib import md5
-from typing import NotRequired, TypedDict
+from typing import Literal, NotRequired, TypedDict
 from urllib.parse import parse_qs
 
 import web
@@ -84,7 +84,7 @@ class MyBooksDropperListsPartial(PartialDataHandler):
 class CarouselLoadMoreParams(BaseModel):
     """Parameters for the carousel load-more partial."""
 
-    queryType: str = ""
+    queryType: Literal["SEARCH", "BROWSE", "TRENDING", "SUBJECTS"]
     q: str = ""
     limit: int = 18
     page: int = 1
@@ -111,7 +111,7 @@ class CarouselCardPartial(PartialDataHandler):
         p = self.params
 
         # Do search
-        search_results = await self._make_book_query(p.queryType, p)
+        search_results = await self._make_book_query(p)
 
         # Render cards
         cards = []
@@ -138,14 +138,14 @@ class CarouselCardPartial(PartialDataHandler):
 
         return {"partials": [str(template) for template in cards]}
 
-    async def _make_book_query(self, query_type: str, params: CarouselLoadMoreParams) -> list:
-        if query_type == "SEARCH":
+    async def _make_book_query(self, params: CarouselLoadMoreParams) -> list:
+        if params.queryType == "SEARCH":
             return await self._do_search_query(params)
-        if query_type == "BROWSE":
+        if params.queryType == "BROWSE":
             return self._do_browse_query(params)
-        if query_type == "TRENDING":
+        if params.queryType == "TRENDING":
             return self._do_trends_query(params)
-        if query_type == "SUBJECTS":
+        if params.queryType == "SUBJECTS":
             return self._do_subjects_query(params)
 
         raise ValueError("Unknown query type")

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -1127,41 +1127,6 @@ def _prepare_work_search_query(
     )
 
 
-# Note: these could share an "implementation" to keep a common interface but it creates a lot more complexity
-# Warning: when changing this please also change the async version
-@public
-def work_search(
-    query: dict,
-    sort: str | None = None,
-    page: int = 1,
-    offset: int = 0,
-    limit: int = 100,
-    fields: str = '*',
-    facet: bool = True,
-    highlight: bool = False,
-    spellcheck_count: int | None = None,
-    request_label: SolrRequestLabel = 'UNLABELLED',
-) -> dict:
-    prepared = _prepare_work_search_query(query, page, offset, limit)
-
-    resp = run_solr_query(
-        WorkSearchScheme(),
-        prepared.query,
-        rows=prepared.limit,
-        page=prepared.page,
-        sort=sort,
-        offset=prepared.offset,
-        fields=fields,
-        facet=facet,
-        highlight=highlight,
-        spellcheck_count=spellcheck_count,
-        request_label=request_label,
-    )
-
-    return _process_solr_search_response(resp, fields)
-
-
-# Warning: when changing this please also change the sync version
 @public
 async def work_search_async(
     query: dict,


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Part of https://github.com/internetarchive/openlibrary/issues/12254
Also, trying to take a simpler approach than https://github.com/internetarchive/openlibrary/pull/12252/

Basically we are just making one query type async. You can test it by going to


<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->
After this one then next parts of this endpoint will be much simpler.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
http://localhost:8080/partials/CarouselLoadMore.json?queryType=SEARCH&q=mark&limit=20
http://testing.openlibrary.org/partials/CarouselLoadMore.json?queryType=SEARCH&q=mark&limit=20
http://openlibrary.org/partials/CarouselLoadMore.json?queryType=SEARCH&q=mark&limit=20

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
