### PR TITLE
Avoid web.cookies() for pd and sfw checks

### DIFF
--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -48,7 +48,7 @@ from openlibrary.plugins.openlibrary.code import can_write
 from openlibrary.plugins.openlibrary.home import get_cached_featured_subjects
 from openlibrary.utils import extract_numeric_id_from_olid
 from openlibrary.utils.isbn import normalize_isbn
-from openlibrary.utils.request_context import site
+from openlibrary.utils.request_context import req_context, site
 
 logger = logging.getLogger(__name__)
 
@@ -818,10 +818,10 @@ class opds_home(delegate.page):
             five_minutes = 5 * dateutil.MINUTE_SECS
             lang = web.ctx.lang
             key = f"home.homepage-opds.{lang}"
-            cookies = web.cookies()
-            if cookies.get("pd", False):
+            ctx = req_context.get()
+            if ctx.print_disabled:
                 key += ".pd"
-            if cookies.get("sfw", ""):
+            if ctx.sfw:
                 key += ".sfw"
             if is_bot():
                 key += ".bot"

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -60,10 +60,10 @@ def get_cached_homepage():
     five_minutes = 5 * dateutil.MINUTE_SECS
     lang = web.ctx.lang
     key = f"home.homepage.{lang}"
-    cookies = web.cookies()
-    if cookies.get("pd", False):
+    ctx = req_context.get()
+    if ctx.print_disabled:
         key += ".pd"
-    if cookies.get("sfw", ""):
+    if ctx.sfw:
         key += ".sfw"
     if is_bot():
         key += ".bot"

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -32,6 +32,7 @@ from openlibrary.core import (
 )
 from openlibrary.i18n import gettext as _
 from openlibrary.utils import dateutil
+from openlibrary.utils.request_context import req_context
 
 logger = logging.getLogger("openlibrary.borrow")
 
@@ -497,7 +498,7 @@ def user_can_borrow_edition(user, edition) -> Literal["borrow", "browse", False]
     user_is_below_loan_limit = user.get_loan_count() < user_max_loans
 
     if book_is_lendable:
-        if web.cookies().get("pd", False):
+        if req_context.get().print_disabled:
             return "borrow"
         elif user_is_below_loan_limit:
             if lending_st.get("available_to_browse"):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #12491

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
**refactor**: Replaces direct `web.cookies()` lookups for the `pd` and `sfw` flags with values read from `req_context`, which is already populated once per request by `set_context_from_legacy_web_py()`. This follows the same pattern already used in `openlibrary/plugins/upstream/utils.py` (`render_cached_macro`).

### Technical
<!-- What should be noted about the implementation? -->
- `openlibrary/plugins/openlibrary/home.py` — `get_cached_homepage()` now reads `req_context.get().print_disabled` / `.sfw` instead of `web.cookies()`. No new import (already imported).
- `openlibrary/plugins/openlibrary/api.py` — `opds_home.get_cached_homepage()` updated identically; added `req_context` to the existing `openlibrary.utils.request_context` import.
- `openlibrary/plugins/upstream/borrow.py` — `user_can_borrow_edition()` now uses `req_context.get().print_disabled`; added the `req_context` import.
- `RequestContextVars.print_disabled` and `.sfw` are already populated from the same cookies during request setup, so behavior is unchanged.
- No changes to cache key strings (`.pd` / `.sfw` suffixes preserved).

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. `make test-py` — existing tests should still pass.
2. Manual: load the homepage with no cookies → cache key has no `.pd` / `.sfw` suffix.
3. Manual: set cookie `pd=1` → homepage cache key includes `.pd`; OPDS homepage (`/index.json` / OPDS endpoint) cache key includes `.pd`; `user_can_borrow_edition` returns `"borrow"` for a lendable book regardless of loan limit.
4. Manual: set cookie `sfw=yes` → homepage and OPDS homepage cache keys include `.sfw`.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A — backend-only refactor, no UI changes.

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB @cdrini @mekarpeles
