### PR TITLE
Fixed missing whitespace around <em> highlights in ol-chip

### DIFF
--- a/openlibrary/components/lit/OLChip.js
+++ b/openlibrary/components/lit/OLChip.js
@@ -114,16 +114,6 @@ export class OLChip extends LitElement {
             height: var(--chip-icon-size);
         }
 
-        /* Label wrapper keeps slotted content (which may include <em>
-           highlights and surrounding text nodes) in a single inline
-           layout context. Without this wrapper, each slotted node
-           becomes its own flex item and the inter-item whitespace is
-           collapsed, causing missing spaces around bolded highlights. */
-        .label {
-            display: inline;
-            white-space: normal;
-        }
-
         /* Count */
         .count {
             margin-inline-start: 4px;
@@ -182,6 +172,16 @@ export class OLChip extends LitElement {
     }
 
     render() {
+        // The <span class="label"> wrapping <slot> fixes issue #12488:
+        // .chip is display: inline-flex, so without a wrapper each
+        // slotted node (e.g. a text node followed by an <em> highlight)
+        // becomes its own flex item, and per the Flexbox spec
+        // leading/trailing whitespace inside a flex item is collapsed.
+        // The wrapper makes slotted content a single flex item that
+        // lays out as normal inline text, preserving spaces around
+        // <em>. No styling on .label is needed (and adding it could
+        // block useful inheritance such as white-space: nowrap from
+        // callers).
         const content = html`
             ${this._renderIcons()}
             <span class="label"><slot></slot></span>

--- a/openlibrary/components/lit/OLChip.js
+++ b/openlibrary/components/lit/OLChip.js
@@ -114,6 +114,16 @@ export class OLChip extends LitElement {
             height: var(--chip-icon-size);
         }
 
+        /* Label wrapper keeps slotted content (which may include <em>
+           highlights and surrounding text nodes) in a single inline
+           layout context. Without this wrapper, each slotted node
+           becomes its own flex item and the inter-item whitespace is
+           collapsed, causing missing spaces around bolded highlights. */
+        .label {
+            display: inline;
+            white-space: normal;
+        }
+
         /* Count */
         .count {
             margin-inline-start: 4px;
@@ -174,7 +184,7 @@ export class OLChip extends LitElement {
     render() {
         const content = html`
             ${this._renderIcons()}
-            <slot></slot>
+            <span class="label"><slot></slot></span>
             ${this._renderCount()}
         `;
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #12488

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix: restore whitespace around bolded `<em>` highlights inside `ol-chip` (subject pills in search results).

### Technical

`OLChip`'s `.chip` element uses `display: inline-flex`. When Solr highlight HTML such as `Adventure <em>stories</em>` is slotted into the chip, the slot's assigned nodes — a text node and an `<em>` element — become **separate flex items**. Per the CSS Flexbox spec, leading/trailing whitespace inside a flex item is collapsed, so the trailing space in `"Adventure "` is dropped and the chip renders as `Adventurestories` (visually `Adventure**stories**`).

The fix wraps `<slot>` in a single inline `<span class="label">` so all slotted content forms one flex item, which in turn lays out its own children in a normal inline formatting context. Whitespace between the text and `<em>` is preserved. The `.icon-slot` and `.count` remain separate flex items, so `:host([selected])` padding/icon positioning is unaffected.

The `.label` wrapper deliberately has **no associated CSS rule**:

- `display: inline` would be a no-op — `<span>` is already inline, and flex items are blockified by the flex container regardless.
- `white-space: normal` would block useful inheritance: a caller writing `ol-chip { white-space: nowrap; }` to force a single-line chip would have that value swallowed inside the shadow tree.

A code comment in `render()` explains the rationale so future readers know why the wrapper exists and why no styling is attached to it.

Why not other approaches:

- `white-space: pre` on `.chip` would preserve the whitespace but also keep newlines/indentation from the source and disable wrapping — undesirable for chip labels.
- `::slotted(*)` styling can't add a layout wrapper around the assigned nodes; it can only style each one individually, so it can't collapse them into one flex item.

### Testing

**1. Reproduce the bug in production search results (recommended):**

1. `docker compose up`
2. Open http://localhost:8080/search?q=adventure&mode=everything
3. Subject pills with bolded matches must show a visible space between the regular and bolded portions, e.g. `Adventure **stories**` rather than `Adventure**stories**`.

**2. Quick isolated DOM test (no full stack required):**

Save the file below as `openlibrary/components/lit/OLChip.test.html`, then serve the `lit/` folder and open the page:

```bash
cd openlibrary/components/lit
python3 -m http.server 8765
# open http://localhost:8765/OLChip.test.html
```

All five chips must render with visible whitespace where applicable. To confirm the fix actually does something, temporarily revert this PR's change (replace `<span class="label"><slot></slot></span>` with bare `<slot></slot>`) and reload — cases 1, 2, 4, 5 will collapse to `Adventurestories`-style output. Restore the change and the spaces return.

<details>
<summary><code>OLChip.test.html</code> (paste this content)</summary>

```html
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="UTF-8" />
  <title>OLChip whitespace test (issue #12488)</title>
  <!-- Map bare "lit" specifier to a CDN build so we can import OLChip.js
       directly without running webpack/vite. -->
  <script type="importmap">
  {
    "imports": {
      "lit": "https://esm.sh/lit@3"
    }
  }
  </script>
  <style>
    body {
      font-family: system-ui, sans-serif;
      padding: 24px;
      max-width: 720px;
    }
    h1 { font-size: 18px; }
    section { margin-bottom: 20px; }
    section p { margin: 0 0 6px; color: #555; font-size: 13px; }
    .row { display: flex; flex-wrap: wrap; gap: 8px; }
    code { background: #f3f3f3; padding: 1px 4px; border-radius: 3px; }

    /* Mirror the prod CSS rule from search-result-item.css so <em>
       inside the slotted highlight is bold (not italic). */
    ol-chip em { font-weight: bold; font-style: normal; }
  </style>
</head>
<body>
  <h1>OLChip whitespace test &mdash; issue #12488</h1>
  <p>
    Each chip below must show a visible space between the regular text and the
    <strong>bolded</strong> highlight. Before the fix, cases 1, 2 and 4 rendered
    as e.g. <code>Adventurestories</code>.
  </p>

  <section>
    <p>1. Trailing highlight: <code>Adventure &lt;em&gt;stories&lt;/em&gt;</code></p>
    <div class="row">
      <ol-chip size="small">Adventure <em>stories</em></ol-chip>
    </div>
  </section>

  <section>
    <p>2. Leading highlight: <code>&lt;em&gt;Adventure&lt;/em&gt; stories</code></p>
    <div class="row">
      <ol-chip size="small"><em>Adventure</em> stories</ol-chip>
    </div>
  </section>

  <section>
    <p>3. No highlight (control): <code>Fiction</code></p>
    <div class="row">
      <ol-chip size="small">Fiction</ol-chip>
    </div>
  </section>

  <section>
    <p>4. Highlights on both sides: <code>&lt;em&gt;Adventure&lt;/em&gt; and &lt;em&gt;stories&lt;/em&gt;</code></p>
    <div class="row">
      <ol-chip size="small"><em>Adventure</em> and <em>stories</em></ol-chip>
    </div>
  </section>

  <section>
    <p>5. As a link (matches search-results usage):</p>
    <div class="row">
      <ol-chip size="small" href="#"><em>Adventure</em> stories</ol-chip>
    </div>
  </section>

  <script type="module" src="./OLChip.js"></script>
</body>
</html>
```

</details>

**Cases verified:**

| # | Slotted content                              | Before fix          | After fix              |
| - | -------------------------------------------- | ------------------- | ---------------------- |
| 1 | `Adventure <em>stories</em>`                 | `Adventurestories`  | `Adventure stories`    |
| 2 | `<em>Adventure</em> stories`                 | `Adventurestories`  | `Adventure stories`    |
| 3 | `Fiction` (control, no `<em>`)               | `Fiction`           | `Fiction` (unchanged)  |
| 4 | `<em>Adventure</em> and <em>stories</em>`    | `Adventureandstories` | `Adventure and stories` |
| 5 | `<ol-chip href="#"><em>Adventure</em> stories</ol-chip>` (link variant used by search) | `Adventurestories`  | `Adventure stories`    |

Selected-state chips (with the close icon) and chips with `count` were also visually checked to ensure the icon position and count spacing did not regress. As an extra sanity check, applying `ol-chip { white-space: nowrap; }` from outside the component now correctly forces the chip onto a single line — confirming the wrapper does not block useful style inheritance.

### Screenshot

<!-- Will add before/after screenshots once the dev environment finishes building. -->
_Before / after screenshots from `/search?q=adventure&mode=everything` to be attached._

### Stakeholders

@lokesh (Lead: front-end / LIT components) — per the issue's `Lead: @lokesh` label.
@cdrini — author of #12261 which adopted `ol-chip` for subject pills, and of the original report.
