### PR TITLE
Fix WorldCat/OCLC identifiers misidentified as LCCN on /books/add

### DIFF
--- a/openlibrary/plugins/openlibrary/js/add-book.js
+++ b/openlibrary/plugins/openlibrary/js/add-book.js
@@ -176,6 +176,10 @@ function autoCompleteIdName(){
         document.getElementById('id_name').value = 'isbn_13';
     }
 
+    else if (isValidOclc(parseOclc(idValue))){
+        document.getElementById('id_name').value = 'oclc_numbers';
+    }
+
     else if ((isValidLccn(parseLccn(idValue)))){
         document.getElementById('id_name').value = 'lccn';
     }

--- a/openlibrary/plugins/openlibrary/js/idValidation.js
+++ b/openlibrary/plugins/openlibrary/js/idValidation.js
@@ -106,6 +106,9 @@ export function isValidLccn(lccn) {
 
 /**
  * Parses and cleans up OCLC/WorldCat identifier input.
+ * Strips standard MARC prefixes (ocm, ocn, on, (OCoLC)) that may appear in
+ * exported records. See:
+ * https://help.oclc.org/Metadata_Services/OCLC_MARC_records/Summary_of_processing_changes/History_of_the_OCLC_number
  * @param {String} oclc  OCLC string for parsing
  * @returns {String}  parsed OCLC string
  */
@@ -114,6 +117,9 @@ export function parseOclc(oclc) {
     return oclc
         // remove any whitespace
         .replace(/\s/g, '')
+        // remove standard MARC prefixes, case-insensitively
+        .replace(/^\(OCoLC\)/i, '')
+        .replace(/^(ocm|ocn|on)/i, '')
         // remove leading/padding zeroes
         .replace(/^0+/, '');
 }
@@ -121,7 +127,9 @@ export function parseOclc(oclc) {
 /**
  * Verify OCLC Control Number syntax. OCLC Numbers are “unique, sequentially
  * assigned number[s] associated with a record in WorldCat.”
- * They only contains digits and aren’t normally 0-padded.
+ * They only contain digits and aren’t normally 0-padded. As of writing,
+ * assigned numbers fit comfortably in 10 digits; we cap at 15 to leave
+ * generous headroom while excluding obviously-too-long numeric inputs.
  * See https://help.oclc.org/Metadata_Services/OCLC_MARC_records/Summary_of_processing_changes/History_of_the_OCLC_number
  * and https://help.oclc.org/Library_Management/WorldShare_Reports/Report_objects/Report_objects_A_to_Z/Report_objects_M-P#O
  * @param {String} oclc  OCLC string to test for valid syntax
@@ -129,7 +137,7 @@ export function parseOclc(oclc) {
  */
 export function isValidOclc(oclc) {
     // matching parsed entry to regex representing valid oclc
-    const regex = /^[1-9][0-9]*$/;
+    const regex = /^[1-9][0-9]{0,14}$/;
     return regex.test(oclc);
 }
 

--- a/tests/unit/js/idValidation.test.js
+++ b/tests/unit/js/idValidation.test.js
@@ -1,11 +1,13 @@
 import {
     parseIsbn,
     parseLccn,
+    parseOclc,
     isChecksumValidIsbn10,
     isChecksumValidIsbn13,
     isFormatValidIsbn10,
     isFormatValidIsbn13,
-    isValidLccn
+    isValidLccn,
+    isValidOclc
 } from '../../../openlibrary/plugins/openlibrary/js/idValidation.js';
 
 describe('parseIsbn', () => {
@@ -153,5 +155,50 @@ describe('isValidLccn', () => {
     });
     it('returns false for LCCN of length 13', () => {
         expect(isValidLccn('1250000000003')).toBe(false);
+    });
+});
+
+describe('parseOclc', () => {
+    it('strips whitespace', () => {
+        expect(parseOclc(' 33294504 ')).toBe('33294504');
+    });
+    it('strips leading zeroes', () => {
+        expect(parseOclc('0000033294504')).toBe('33294504');
+    });
+    it('strips the (OCoLC) MARC prefix', () => {
+        expect(parseOclc('(OCoLC)33294504')).toBe('33294504');
+    });
+    it('strips the ocm MARC prefix', () => {
+        expect(parseOclc('ocm33294504')).toBe('33294504');
+    });
+    it('strips the ocn MARC prefix', () => {
+        expect(parseOclc('ocn1297036639')).toBe('1297036639');
+    });
+    it('strips the on MARC prefix', () => {
+        expect(parseOclc('on1297036639')).toBe('1297036639');
+    });
+});
+
+describe('isValidOclc', () => {
+    it('returns true for a typical OCLC number', () => {
+        expect(isValidOclc('33294504')).toBe(true);
+    });
+    it('returns true for a single-digit OCLC number', () => {
+        expect(isValidOclc('1')).toBe(true);
+    });
+    it('returns true for a 15-digit OCLC number', () => {
+        expect(isValidOclc('123456789012345')).toBe(true);
+    });
+    it('returns false for an empty string', () => {
+        expect(isValidOclc('')).toBe(false);
+    });
+    it('returns false for non-numeric input', () => {
+        expect(isValidOclc('abc12345')).toBe(false);
+    });
+    it('returns false for input with a leading zero', () => {
+        expect(isValidOclc('0123')).toBe(false);
+    });
+    it('returns false for an OCLC longer than 15 digits', () => {
+        expect(isValidOclc('1234567890123456')).toBe(false);
     });
 });


### PR DESCRIPTION
Closes #12409

WorldCat/OCLC identifiers (e.g. `33294504`, `1297036639`) entered on `/books/add` were being auto-classified as LCCN because `autoCompleteIdName()` had no OCLC branch and the LCCN regex’s prefix is optional, so any 8+ digit number matches. This PR tightens OCLC validation and adds OCLC auto-detection. [fix]

### Technical
- `openlibrary/plugins/openlibrary/js/idValidation.js`
  - `parseOclc()` now strips standard MARC prefixes (`(OCoLC)`, `ocm`, `ocn`, `on`) in addition to whitespace and leading zeros.
  - `isValidOclc()` regex constrained to 1–15 digits (`^[1-9][0-9]{0,14}$`) to leave headroom over current OCLC numbers (~10 digits) while excluding arbitrarily long numeric strings.
- `openlibrary/plugins/openlibrary/js/add-book.js`
  - `autoCompleteIdName()` now checks `isValidOclc(parseOclc(idValue))` and sets `id_name` to `oclc_numbers` **before** the LCCN check, so plain-numeric WorldCat IDs are classified correctly.

Trade-off (per discussion in the issue): with OCLC checked before LCCN, pure-numeric LCCNs like `2001000002` will auto-detect as `oclc_numbers`. This matches the staff-suggested approach in the issue thread (Sadashii) and users can still manually correct the dropdown.

### Testing
1. `npm run test:js -- tests/unit/js/idValidation.test.js` — passes (52 tests, including new `parseOclc` and `isValidOclc` cases).
2. Manual reproduction on `/books/add`:
   - Paste `33294504` → identifier type now auto-selects **OCLC/WorldCat** (was LCCN).
   - Paste `1297036639` → auto-selects **OCLC/WorldCat**.
   - Paste `(OCoLC)33294504`, `ocm33294504`, `ocn1297036639`, `on1297036639` → parsed and auto-selects **OCLC/WorldCat**.
   - Paste `n78890351` (valid LCCN with prefix) → still auto-selects **LCCN**.
   - Paste valid ISBN-10/ISBN-13 → still auto-selects ISBN.

### Screenshot
N/A — behavior change in the auto-detected dropdown value; no visual UI change.

### Stakeholders
@cdrini @Sadashii
