### PR TITLE
make _do_subjects_query async

### DIFF
--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -34,6 +34,28 @@ from openlibrary.utils.async_utils import async_bridge
 from openlibrary.views.loanstats import get_trending_books
 
 
+def _solr_query_to_subject_key(query: str) -> str:
+    """Convert Solr query format to subject key format."""
+    # Handle Solr field format and seed format
+    prefixes = [
+        ("subject_key:", "/subjects/"),
+        ("person_key:", "/subjects/person:"),
+        ("place_key:", "/subjects/place:"),
+        ("time_key:", "/subjects/time:"),
+        ("subject:", "/subjects/"),
+    ]
+
+    for prefix, replacement in prefixes:
+        if query.startswith(prefix):
+            return f"{replacement}{query.removeprefix(prefix)}"
+
+    # Already in correct format
+    if query.startswith("/subjects/"):
+        return query
+
+    raise ValueError(f"Unable to convert query to subject key: {query}")
+
+
 class ReadingGoalProgressPartial:
     """Handler for reading goal progress."""
 
@@ -183,11 +205,15 @@ class CarouselCardPartial:
 
     async def _do_subjects_query(self, params: CarouselLoadMoreParams) -> list:
         publish_year = date_range_to_publish_year_filter(params.published_in)
+        subject_key = _solr_query_to_subject_key(params.q)
+        # Convert page (1-indexed) to offset (0-indexed), ensure non-negative
+        offset = max(0, params.page - 1) if params.page else 0
         subject = await get_subject_async(
-            params.q,
-            offset=params.page,
+            subject_key,
+            offset=offset,
             limit=params.limit,
-            publish_year=publish_year,
+            publish_year=publish_year or None,
+            request_label="BOOK_CAROUSEL",
         )
         return subject.get("works", [])
 

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -28,7 +28,7 @@ from openlibrary.plugins.worksearch.code import (
 from openlibrary.plugins.worksearch.schemes.works import WorkSearchScheme
 from openlibrary.plugins.worksearch.subjects import (
     date_range_to_publish_year_filter,
-    get_subject,
+    get_subject_async,
 )
 from openlibrary.utils.async_utils import async_bridge
 from openlibrary.views.loanstats import get_trending_books
@@ -131,7 +131,7 @@ class CarouselCardPartial:
         if params.queryType == "TRENDING":
             return self._do_trends_query(params)
         if params.queryType == "SUBJECTS":
-            return self._do_subjects_query(params)
+            return await self._do_subjects_query(params)
 
         raise ValueError("Unknown query type")
 
@@ -181,9 +181,9 @@ class CarouselCardPartial:
     def _do_trends_query(self, params: CarouselLoadMoreParams) -> list:
         return get_trending_books(minimum=3, limit=params.limit, page=params.page, sort_by_count=False)
 
-    def _do_subjects_query(self, params: CarouselLoadMoreParams) -> list:
+    async def _do_subjects_query(self, params: CarouselLoadMoreParams) -> list:
         publish_year = date_range_to_publish_year_filter(params.published_in)
-        subject = get_subject(params.q, offset=params.page, limit=params.limit, publish_year=publish_year)
+        subject = await get_subject_async(params.q, offset=params.page, limit=params.limit,     publish_year=publish_year)
         return subject.get("works", [])
 
 

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -183,7 +183,7 @@ class CarouselCardPartial:
 
     async def _do_subjects_query(self, params: CarouselLoadMoreParams) -> list:
         publish_year = date_range_to_publish_year_filter(params.published_in)
-        subject = await get_subject_async(params.q, offset=params.page, limit=params.limit,     publish_year=publish_year)
+        subject = await get_subject_async(params.q, offset=params.page, limit=params.limit, publish_year=publish_year)
         return subject.get("works", [])
 
 

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -183,7 +183,12 @@ class CarouselCardPartial:
 
     async def _do_subjects_query(self, params: CarouselLoadMoreParams) -> list:
         publish_year = date_range_to_publish_year_filter(params.published_in)
-        subject = await get_subject_async(params.q, offset=params.page, limit=params.limit, publish_year=publish_year)
+        subject = await get_subject_async(
+            params.q,
+            offset=params.page,
+            limit=params.limit,
+            publish_year=publish_year,
+        )
         return subject.get("works", [])
 
 

--- a/openlibrary/plugins/openlibrary/tests/test_partials.py
+++ b/openlibrary/plugins/openlibrary/tests/test_partials.py
@@ -1,0 +1,38 @@
+"""Tests for partials.py functionality."""
+
+import pytest
+
+from openlibrary.plugins.openlibrary.partials import _solr_query_to_subject_key
+
+
+class TestSolrQueryToSubjectKey:
+    """Tests for _solr_query_to_subject_key conversion."""
+
+    def test_subject_key_format(self):
+        """Test subject_key: format conversion."""
+        assert _solr_query_to_subject_key("subject_key:science") == "/subjects/science"
+
+    def test_person_key_format(self):
+        """Test person_key: format conversion."""
+        assert _solr_query_to_subject_key("person_key:harry_potter") == "/subjects/person:harry_potter"
+
+    def test_place_key_format(self):
+        """Test place_key: format conversion."""
+        assert _solr_query_to_subject_key("place_key:france") == "/subjects/place:france"
+
+    def test_time_key_format(self):
+        """Test time_key: format conversion."""
+        assert _solr_query_to_subject_key("time_key:19th_century") == "/subjects/time:19th_century"
+
+    def test_subject_seed_format(self):
+        """Test subject: format conversion."""
+        assert _solr_query_to_subject_key("subject:science") == "/subjects/science"
+
+    def test_already_in_correct_format(self):
+        """Test /subjects/ format passes through."""
+        assert _solr_query_to_subject_key("/subjects/science") == "/subjects/science"
+
+    def test_invalid_format_raises_error(self):
+        """Test invalid format raises ValueError."""
+        with pytest.raises(ValueError, match="Unable to convert query to subject key"):
+            _solr_query_to_subject_key("invalid:format")


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Part of #12254 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->



### Technical
<!-- What should be noted about the implementation? -->
Makes _do_subjects_query async by making the underlying fetch to get_subject_async.


### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Tested locally to ensure the endpoint successfully hits the async execution path for `queryType=SUBJECTS`.

When testing, the endpoint locally via `curl "http://localhost:8080/partials/CarouselLoadMore.json?queryType=SUBJECTS&q=subject:science&limit=20"`, it throws a `NotImplementedError: No SubjectEngine `for key deeper in subjects.py.
I verified that the master branch and the production environment throws error.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
