### PR TITLE
fix(#9773): event-driven comment labeling + simplified digest

### DIFF
--- a/.github/workflows/issue_comment_labeler.yml
+++ b/.github/workflows/issue_comment_labeler.yml
@@ -1,0 +1,60 @@
+name: issue_comment_labeler
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  label_if_needs_response:
+    if: ${{ github.repository == 'internetarchive/openlibrary' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/github-script@v7
+        env:
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+          SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ABC_TEAM_PLUS }}
+        with:
+          script: |
+            const fs = require('fs');
+            const config = JSON.parse(fs.readFileSync('.github/workflows/config/new_comment_digest.json', 'utf8'));
+            const leads = config.leads.map(l => l.githubUsername);
+
+            const commenter = context.payload.comment.user.login;
+            const issue = context.payload.issue;
+
+            if (leads.includes(commenter)) return;
+
+            if (issue.state === 'open') {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ['Needs: Response'],
+              });
+              console.log(`Labeled #${issue.number} as "Needs: Response"`);
+            } else {
+              // Closed issue — notify Slack directly instead of labeling
+              const slackToken = process.env.SLACK_TOKEN;
+              const slackChannel = process.env.SLACK_CHANNEL;
+              if (!slackToken || !slackChannel) return;
+
+              const lead = config.leads.find(l =>
+                issue.labels?.some(label => label.name === `Lead: @${l.githubUsername}`)
+              );
+              const mention = lead?.slackId ?? 'Unknown lead';
+              const text = `💬 New comment on *closed* issue <${context.payload.comment.html_url}|#${issue.number}: ${issue.title}> by *${commenter}*\nLead: ${mention}`;
+
+              await fetch('https://slack.com/api/chat.postMessage', {
+                method: 'POST',
+                headers: {
+                  'Authorization': `Bearer ${slackToken}`,
+                  'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ channel: slackChannel, text }),
+              });
+              console.log(`Pinged Slack for comment on closed issue #${issue.number}`);
+            }

--- a/.github/workflows/new_comment_digest.yml
+++ b/.github/workflows/new_comment_digest.yml
@@ -34,6 +34,7 @@ env:
   CHANNEL_ARG: '-s "#team-abc-plus"'
   VERBOSE_FLAG: ''
   NO_LABELS_FLAG: ''
+  USE_LABEL_FLAG: '--use-label'
 
 jobs:
   new_comment_digest:
@@ -79,7 +80,7 @@ jobs:
       - id: run_bot
         run: |
           trap 'echo "exit_code=$?" >> "$GITHUB_OUTPUT"' EXIT
-          scripts/gh_scripts/issue_comment_bot.py ${{ env.HOURS }} -c .github/workflows/config/new_comment_digest.json ${{ env.CHANNEL_ARG }} ${{ env.VERBOSE_FLAG }} ${{ env.NO_LABELS_FLAG }}
+          scripts/gh_scripts/issue_comment_bot.py ${{ env.HOURS }} -c .github/workflows/config/new_comment_digest.json ${{ env.CHANNEL_ARG }} ${{ env.VERBOSE_FLAG }} ${{ env.NO_LABELS_FLAG }} ${{ env.USE_LABEL_FLAG }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}

--- a/scripts/gh_scripts/issue_comment_bot.py
+++ b/scripts/gh_scripts/issue_comment_bot.py
@@ -44,40 +44,40 @@ def fetch_issues_by_label() -> list:
     Used by the digest when real-time labeling via the issue_comment_labeler workflow
     is in place, replacing the expensive poll-and-filter approach.
     """
-    p = {'labels': 'Needs: Response', 'state': 'all', 'per_page': 100}
+    p = {"labels": "Needs: Response", "state": "all", "per_page": 100}
     response = requests.get(
-        'https://api.github.com/repos/internetarchive/openlibrary/issues',
+        "https://api.github.com/repos/internetarchive/openlibrary/issues",
         params=p,
         headers=github_headers,
     )
     d = response.json()
     if response.status_code != 200:
-        print('Request for labeled issues has failed.')
-        print(f'Message: {d.get("message", "")}')
-        print(f'Documentation URL: {d.get("documentation_url", "")}')
+        print("Request for labeled issues has failed.")
+        print(f"Message: {d.get('message', '')}")
+        print(f"Documentation URL: {d.get('documentation_url', '')}")
         response.raise_for_status()
 
     results = d
     links = response.links
-    next_url = links.get('next', {}).get('url', '')
+    next_url = links.get("next", {}).get("url", "")
     while next_url:
         time.sleep(1)
         resp = requests.get(next_url, headers=github_headers)
         d = resp.json()
         if resp.status_code != 200:
-            print('Request for next page of labeled issues has failed.')
-            print(f'Message: {d.get("message", "")}')
+            print("Request for next page of labeled issues has failed.")
+            print(f"Message: {d.get('message', '')}")
             response.raise_for_status()
         results = results + d
-        next_url = resp.links.get('next', {}).get('url', '')
+        next_url = resp.links.get("next", {}).get("url", "")
 
     return [
         {
-            'number': i['number'],
-            'comment_url': i['html_url'],
-            'commenter': '',
-            'issue_title': i['title'],
-            'lead_label': find_lead_label(i.get('labels', [])),
+            "number": i["number"],
+            "comment_url": i["html_url"],
+            "commenter": "",
+            "issue_title": i["title"],
+            "lead_label": find_lead_label(i.get("labels", [])),
         }
         for i in results
     ]
@@ -496,9 +496,9 @@ def _get_parser() -> argparse.ArgumentParser:
         action="store_true",
     )
     parser.add_argument(
-        '--use-label',
+        "--use-label",
         help='Fetch issues by "Needs: Response" label instead of polling all issues for recent comments. Use when the issue_comment_labeler workflow handles real-time labeling.',
-        action='store_true',
+        action="store_true",
     )
 
     return parser

--- a/scripts/gh_scripts/issue_comment_bot.py
+++ b/scripts/gh_scripts/issue_comment_bot.py
@@ -37,6 +37,52 @@ class ConfigurationError(Exception):
     pass
 
 
+def fetch_issues_by_label() -> list:
+    """
+    Fetches all issues (open and closed) labeled "Needs: Response".
+
+    Used by the digest when real-time labeling via the issue_comment_labeler workflow
+    is in place, replacing the expensive poll-and-filter approach.
+    """
+    p = {'labels': 'Needs: Response', 'state': 'all', 'per_page': 100}
+    response = requests.get(
+        'https://api.github.com/repos/internetarchive/openlibrary/issues',
+        params=p,
+        headers=github_headers,
+    )
+    d = response.json()
+    if response.status_code != 200:
+        print('Request for labeled issues has failed.')
+        print(f'Message: {d.get("message", "")}')
+        print(f'Documentation URL: {d.get("documentation_url", "")}')
+        response.raise_for_status()
+
+    results = d
+    links = response.links
+    next_url = links.get('next', {}).get('url', '')
+    while next_url:
+        time.sleep(1)
+        resp = requests.get(next_url, headers=github_headers)
+        d = resp.json()
+        if resp.status_code != 200:
+            print('Request for next page of labeled issues has failed.')
+            print(f'Message: {d.get("message", "")}')
+            response.raise_for_status()
+        results = results + d
+        next_url = resp.links.get('next', {}).get('url', '')
+
+    return [
+        {
+            'number': i['number'],
+            'comment_url': i['html_url'],
+            'commenter': '',
+            'issue_title': i['title'],
+            'lead_label': find_lead_label(i.get('labels', [])),
+        }
+        for i in results
+    ]
+
+
 def fetch_issues():
     """
     Fetches and returns all open issues and pull requests from the `internetarchive/openlibrary` repository.
@@ -279,7 +325,8 @@ def publish_digest(
         else:
             message += "Unknown lead\n"
 
-        message += f"Commenter: *{commenter}*"
+        if commenter:
+            message += f"Commenter: *{commenter}*"
         r = post_message(
             {
                 "channel": slack_channel,
@@ -343,7 +390,8 @@ def verbose_output(issues):
         print(f"Issue #{issue['number']}:")
         print(f"\tTitle: {issue['issue_title']}")
         print(f"\t{issue['lead_label']}")
-        print(f"\tCommenter: {issue['commenter']}")
+        if issue["commenter"]:
+            print(f"\tCommenter: {issue['commenter']}")
         print(f"\tComment URL: {issue['comment_url']}")
 
 
@@ -387,13 +435,18 @@ def start_job():
     except (OSError, json.JSONDecodeError):
         raise ConfigurationError("An error occurred while parsing the configuration file.")
 
-    print("Fetching issues from GitHub...")
-    issues = fetch_issues()
-    print(f"{len(issues)} found")
+    if args.use_label:
+        print('Fetching issues labeled "Needs: Response" from GitHub...')
+        filtered_issues = fetch_issues_by_label()
+        print(f"{len(filtered_issues)} found")
+    else:
+        print("Fetching issues from GitHub...")
+        issues = fetch_issues()
+        print(f"{len(issues)} found")
 
-    print("Filtering issues...")
-    filtered_issues = filter_issues(issues, args.hours, leads)
-    print(f"{len(filtered_issues)} remain after filtering.")
+        print("Filtering issues...")
+        filtered_issues = filter_issues(issues, args.hours, leads)
+        print(f"{len(filtered_issues)} remain after filtering.")
 
     all_issues_labeled = True
     if not args.no_labels:
@@ -441,6 +494,11 @@ def _get_parser() -> argparse.ArgumentParser:
         "--verbose",
         help="Print detailed information about the issues that were found",
         action="store_true",
+    )
+    parser.add_argument(
+        '--use-label',
+        help='Fetch issues by "Needs: Response" label instead of polling all issues for recent comments. Use when the issue_comment_labeler workflow handles real-time labeling.',
+        action='store_true',
     )
 
     return parser


### PR DESCRIPTION
Fixes #9773

## Summary

- **Add `issue_comment_labeler.yml`**: new workflow triggered on every `issue_comment: created` event. Labels open issues `Needs: Response` immediately if the commenter is not a lead. For closed issues, skips the label and pings Slack directly instead.
- **Add `fetch_issues_by_label()`** to `issue_comment_bot.py`: replaces the O(n) poll-and-filter loop with a single API call fetching only issues already labeled `Needs: Response`.
- **Add `--use-label` flag** to `issue_comment_bot.py` to switch the digest to label-based fetching.
- **Update `new_comment_digest.yml`** to pass `--use-label` by default.

## Why

The current bot polls all open issues daily and makes one API call per issue to inspect comments — expensive and slow. It also misses closed issues entirely. This uses GitHub's `issue_comment` webhook to label in real-time, so the digest only needs to read the label queue rather than scanning everything.

## Test plan

- [ ] Leave a comment on an open issue as a non-lead — verify `Needs: Response` label is applied
- [ ] Leave a comment on a closed issue as a non-lead — verify Slack ping is sent, no label applied
- [ ] Leave a comment as a lead — verify nothing happens
- [ ] Trigger `new_comment_digest` manually — verify it fetches by label and posts digest correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)