### PR TITLE
fix(#6489): save translation=yes even without origin language/work

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -637,9 +637,11 @@ class SaveBookHelper:
             except TocParseError as e:
                 raise ClientException("400 Bad Request", f"Table of contents parse error: {e}")
 
-            if edition_data.pop("translation", None) != "yes":
+            is_translation = edition_data.pop("translation", None) == "yes"
+            if not is_translation:
                 edition_data.translation_of = None
                 edition_data.translated_from = None
+            edition_data.translation = is_translation or None
 
             if "contributors" not in edition_data:
                 self.edition.contributors = []

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -276,7 +276,7 @@ $jsdef render_work_autocomplete_item(item):
                     <label for="is-translation">$_("Is it a translation of another book?")</label>
                     <span class="tip"></span>
                 </div>
-                $ translation = book.translation_of or book.translated_from
+                $ translation = book.get('translation') or book.translation_of or book.translated_from
                 $ checked_yes = cond(translation, 'checked="checked"', '')
                 $ checked_no = cond(not translation, 'checked="checked"', '')
                 $if translation:


### PR DESCRIPTION
Fixes #6489

## Root cause

`addbook.py` pops the `translation` radio value and uses it as a condition but never saves it. The template then infers the "Yes" state from `book.translation_of or book.translated_from` — both of which are empty when the librarian selects "Yes" without filling in details. So `"" or []` evaluates to falsy and "No" ends up checked on next load.

## Changes

- **`openlibrary/plugins/upstream/addbook.py`**: persist `edition.translation = True` when the radio is `"yes"`, `None` otherwise
- **`openlibrary/templates/books/edit/edition.html`**: check `book.get('translation')` first, then fall back to `translation_of or translated_from` for backward compatibility with existing records

## Test plan

- [ ] Edit an edition, select "Yes, it's a translation", leave origin language and work blank, save — verify "Yes" is still checked on next load
- [ ] Edit an edition, select "Yes" and fill in origin language/work, save — verify everything still works as before
- [ ] Edit an edition, select "No", save — verify translation fields are cleared
- [ ] View an existing edition that has `translation_of` set but no `translation` boolean — verify "Yes" is still checked (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)