### PR TITLE
fix: paginate reading log query when no shelf is selected

### DIFF
--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -513,10 +513,16 @@ class Bookshelves(db.CommonExtras):
                 )
 
             if not bookshelf_id:
-                query = "SELECT * from bookshelves_books WHERE username=$username"
-                # XXX Removing limit, offset, etc from data looks like a bug
-                # unrelated / not fixing in this PR.
-                query_params = {"username": username}
+                query = (
+                    "SELECT * from bookshelves_books WHERE username=$username "
+                    f"ORDER BY created {'DESC' if sort == 'created desc' else 'ASC'} "
+                    "LIMIT $limit OFFSET $offset"
+                )
+                query_params = {
+                    "username": username,
+                    "limit": query_params["limit"],
+                    "offset": query_params["offset"],
+                }
             reading_log_books: list[web.storage] = list(oldb.query(query, vars=query_params))
 
             reading_log_keys = [
@@ -533,7 +539,7 @@ class Bookshelves(db.CommonExtras):
             if len(solr_docs) < len(reading_log_keys):
                 cls.add_storage_items_for_deletes(reading_log_keys, solr_docs)
 
-            total_results = shelf_totals.get(bookshelf_id, 0)
+            total_results = shelf_totals.get(bookshelf_id) or sum(shelf_totals.values())
             solr_docs = add_reading_log_data(reading_log_books, solr_docs)
             solr_docs = cls.link_editions_to_works(solr_docs)
 


### PR DESCRIPTION
## Problem

When a user views their reading log without selecting a specific shelf (the "All" view), `get_sorted_reading_log_books()` in `bookshelves.py` overwrites the query with one that has no `LIMIT` or `OFFSET`:

```python
if not bookshelf_id:
    query = "SELECT * from bookshelves_books WHERE username=$username"
    # XXX Removing limit, offset, etc from data looks like a bug
    # unrelated / not fixing in this PR.
    query_params = {"username": username}
```

This fetches every book the user has ever logged into memory at once, then passes all those keys to a Solr `get_many` call. For power users with thousands of books this causes significant memory pressure and slow/failed page loads — and gets worse as their library grows.

The `total_results` calculation also had a related bug: `shelf_totals.get(bookshelf_id, 0)` returns `0` when `bookshelf_id` is falsy, so pagination controls showed incorrect totals.

## Fix

- Add `LIMIT $limit OFFSET $offset` to the unbounded query, preserving the existing `limit`/`offset` from `query_params`
- Fix `total_results` to sum across all shelves when no specific shelf is selected

## Test plan

- [ ] View reading log "All" tab as a user with many books — verify only one page loads
- [ ] Paginate through the reading log — verify correct pages are returned
- [ ] View a specific shelf — verify existing behavior unchanged
- [ ] Verify total book count shown in pagination is correct for the "All" view

🤖 Generated with [Claude Code](https://claude.com/claude-code)