### PR TITLE
Different rate limits for logged in users

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -60,9 +60,11 @@ http {
     include /olsystem/etc/nginx/is_blessed_ua.conf;  # Provides $is_blessed_ua
     include /olsystem/etc/nginx/is_sus_ip.conf;  # Provides $is_sus_ip
 
-    map "$is_blessed_ip:$is_blessed_ua" $rate_limit_key {
-      "0:0" $binary_remote_addr;  # Rate-limit by IP
-      default '';  # Don't rate-limit
+    map "$is_blessed_ip:$is_blessed_ua:$cookie_session" $rate_limit_key {
+        # Session cookie is further validated by the python app
+        # See https://github.com/internetarchive/openlibrary/blob/27d63e7faee5d3b41aa6e3f45246c655025f7b83/openlibrary/plugins/openlibrary/processors.py#L145-L149
+        "0:0:" $binary_remote_addr;  # Rate-limit by IP only when session cookie is missing
+        default '';  # Don't rate-limit
     }
 
     # check if user-agent provides a means of identification


### PR DESCRIPTION
Some librarians reporting that after hitting some 429s on the merge works page, they were then getting blocked for up to half an hour. This change uses different rate limits for logged in users.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
