### PR TITLE
Switch Wikidata dump to TSV format. Fixes #11439

### DIFF
--- a/scripts/dump-wikidata.sql
+++ b/scripts/dump-wikidata.sql
@@ -1,6 +1,6 @@
 -- Script to export Wikidata table from the Open Library database
 -- When called, this will export the entire wikidata table as a TSV file
--- Usage: psql $PSQL_PARAMS -f dump-wikidata.sql | gzip -c > ol_dump_wikidata_YYYY-MM-DD.txt.gz
+-- Usage: psql $PSQL_PARAMS -f dump-wikidata.sql | sed 's/\\\\"/\\"/g' | gzip -c > ol_dump_wikidata_YYYY-MM-DD.txt.gz
 
 -- Export all rows from the wikidata table as tab-separated values
-COPY wikidata TO STDOUT WITH (FORMAT csv, DELIMITER E'\t');
+COPY wikidata (id, updated, data) TO STDOUT;

--- a/scripts/dump-wikidata.sql
+++ b/scripts/dump-wikidata.sql
@@ -1,6 +1,0 @@
--- Script to export Wikidata table from the Open Library database
--- When called, this will export the entire wikidata table as a TSV file
--- Usage: psql $PSQL_PARAMS -f dump-wikidata.sql | sed 's/\\\\"/\\"/g' | gzip -c > ol_dump_wikidata_YYYY-MM-DD.txt.gz
-
--- Export all rows from the wikidata table as tab-separated values
-COPY wikidata (id, updated, data) TO STDOUT;

--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -139,7 +139,7 @@ then
   if [[ ! -f $(compgen -G "ol_dump_wikidata_$yyyymm*.txt.gz") ]]
   then
       log "generating wikidata table: ol_dump_wikidata_$yyyymmdd.txt.gz"
-      time psql $PSQL_PARAMS -f $SCRIPTS/dump-wikidata.sql | gzip -c > ol_dump_wikidata_$yyyymmdd.txt.gz
+      time psql $PSQL_PARAMS -f $SCRIPTS/dump-wikidata.sql | sed 's/\\\\"/\\"/g' | gzip -c > ol_dump_wikidata_$yyyymmdd.txt.gz
   else
       log "Skipping: $(compgen -G "ol_dump_wikidata_$yyyymm*.txt.gz")"
   fi

--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -139,7 +139,7 @@ then
   if [[ ! -f $(compgen -G "ol_dump_wikidata_$yyyymm*.txt.gz") ]]
   then
       log "generating wikidata table: ol_dump_wikidata_$yyyymmdd.txt.gz"
-      time psql $PSQL_PARAMS -f $SCRIPTS/dump-wikidata.sql | sed 's/\\\\"/\\"/g' | gzip -c > ol_dump_wikidata_$yyyymmdd.txt.gz
+      time psql $PSQL_PARAMS -c "copy wikidata to stdout" | gzip -c > ol_dump_wikidata_$yyyymmdd.txt.gz
   else
       log "Skipping: $(compgen -G "ol_dump_wikidata_$yyyymm*.txt.gz")"
   fi


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #11439

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix

### Technical
This builds on #11470 by @KrishnaShuk but simplifies the solution by in-lining a 1-line script. It also reverts to the default column ordering so that it matches the schema, even though this is less convenient for downstream consumers. Fixing that in a consistent manner would require altering the table schema which is probably not worth the trouble.

### Testing

~It is impossible to test this on the dev instance because the wikidata table is empty (#12505), so it should be tested on the production instance, but the fix is pretty straightforward, so I don't expect issues.~

Tested successfully per comment [below](https://github.com/internetarchive/openlibrary/pull/12506#issuecomment-4356955719).

### Stakeholders

@KrishnaShuk - author of original PR
@RayBB - reviewer of original PR
@cdrini - specifier of original format in #10383
