### PR TITLE
Replace deprecated web strip helpers

### DIFF
--- a/openlibrary/core/lists/model.py
+++ b/openlibrary/core/lists/model.py
@@ -554,13 +554,13 @@ class Seed:
         if self.document:
             return self.document.url()
         elif self.key.startswith("subject:"):
-            return "/subjects/" + web.lstrips(self.key, "subject:")
+            return "/subjects/" + self.key.removeprefix("subject:")
         else:
             return "/subjects/" + self.key
 
     def get_subject_url(self, subject: SeedSubjectString) -> str:
         if subject.startswith("subject:"):
-            return "/subjects/" + web.lstrips(subject, "subject:")
+            return "/subjects/" + subject.removeprefix("subject:")
         else:
             return "/subjects/" + subject
 

--- a/openlibrary/core/processors/readableurls.py
+++ b/openlibrary/core/processors/readableurls.py
@@ -133,7 +133,7 @@ def get_readable_path(site, path, patterns, encoding=None):
             m = web.re_compile("^" + pat).match(path)
             if m:
                 prefix = m.group()
-                extra = web.lstrips(path, prefix)
+                extra = path.removeprefix(prefix)
                 tokens = extra.split("/", 2)
 
                 # `extra` starts with "/". So first token is always empty.

--- a/openlibrary/coverstore/utils.py
+++ b/openlibrary/coverstore/utils.py
@@ -13,7 +13,6 @@ from urllib.parse import parse_qsl, unquote, unquote_plus, urlsplit, urlunsplit 
 from urllib.parse import urlencode as real_urlencode
 
 import requests
-import web
 
 from openlibrary.coverstore import config, oldb
 

--- a/openlibrary/coverstore/utils.py
+++ b/openlibrary/coverstore/utils.py
@@ -35,7 +35,7 @@ def safeint(value, default=None):
 
 
 def get_ol_url():
-    return web.rstrips(config.ol_url, "/")
+    return config.ol_url.removesuffix("/")
 
 
 def ol_things(key: str, value: str) -> list[str]:

--- a/openlibrary/mocks/mock_infobase.py
+++ b/openlibrary/mocks/mock_infobase.py
@@ -211,7 +211,7 @@ class MockSite:
                 # this corrects any nested keys that have been included
                 # in values.
                 flat = common.flatten_dict(v)[0]
-                k = web.rstrips(k + "." + flat[0], ".key")
+                k = (k + "." + flat[0]).removesuffix(".key")
                 v = flat[1]
             keys = {k for k in self.filter_index(self.index, k, v) if k in keys}
 
@@ -266,10 +266,10 @@ class MockSite:
         for k, v in index:
             # for handling last_modified.value
             if k.endswith(".value"):
-                k = web.rstrips(k, ".value")
+                k = k.removesuffix(".value")
 
             if k.endswith(".key"):
-                yield web.storage(key=key, datatype="ref", name=web.rstrips(k, ".key"), value=v)
+                yield web.storage(key=key, datatype="ref", name=k.removesuffix(".key"), value=v)
             elif isinstance(v, str):
                 yield web.storage(key=key, datatype="str", name=k, value=v)
             elif isinstance(v, int):

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -215,7 +215,7 @@ class reload:
 
     def reload(self, servers):
         for s in servers:
-            s = web.rstrips(s, "/") + "/_reload"
+            s = s.removesuffix("/") + "/_reload"
             yield "<h3>" + s + "</h3>"
             try:
                 response = requests.get(s).text

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -856,7 +856,7 @@ class _yaml_edit(_yaml):
 
 def _get_user_root():
     user_root = infogami.config.get('infobase', {}).get('user_root', '/user')
-    return web.rstrips(user_root, '/')
+    return user_root.removesuffix('/')
 
 
 def _get_bots():

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -880,7 +880,7 @@ class list_subjects_json(delegate.page):
     def _process_subject(s):
         key = s["key"]
         if key.startswith("subject:"):
-            key = "/subjects/" + web.lstrips(key, "subject:")
+            key = "/subjects/" + key.removeprefix("subject:")
         else:
             key = "/subjects/" + key
         return {"name": s["name"], "count": s["count"], "url": key}

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -177,7 +177,7 @@ class DynamicDocument:
     """
 
     def __init__(self, root):
-        self.root = web.rstrips(root, "/")
+        self.root = root.removesuffix("/")
         self.docs = None
         self._text = None
         self.last_modified = None

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -201,7 +201,7 @@ class SubjectEngine:
         )
 
         subject_type = self.name
-        path = web.lstrips(key, self.prefix)
+        path = key.removeprefix(self.prefix)
         name = path.replace("_", " ")
 
         unescaped_filters = {}

--- a/openlibrary/solr/update.py
+++ b/openlibrary/solr/update.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Literal, cast
 
 import aiofiles
-import web
 
 from openlibrary.catalog.utils.query import set_query_host
 from openlibrary.solr.data_provider import (

--- a/openlibrary/solr/update.py
+++ b/openlibrary/solr/update.py
@@ -148,7 +148,7 @@ def load_configs(
     c_config: str,
     c_data_provider: (DataProvider | Literal["default", "legacy", "external"]) = "default",
 ) -> DataProvider:
-    host = web.lstrips(c_host, "http://").strip("/")
+    host = c_host.removeprefix("http://").strip("/")
     set_query_host(host)
 
     load_config(c_config)

--- a/scripts/copydocs.py
+++ b/scripts/copydocs.py
@@ -353,7 +353,7 @@ def main(
     dest_ol: Disk | OpenLibrary = OpenLibrary(dest) if dest.startswith("http://") else Disk(dest)
 
     if isinstance(dest_ol, OpenLibrary):
-        section = "[%s]" % web.lstrips(dest, "http://").strip("/")
+        section = "[%s]" % dest.removeprefix("http://").strip("/")
         if section in read_lines(os.path.expanduser("~/.olrc")):
             dest_ol.autologin()
         else:

--- a/scripts/generate-api-docs.py
+++ b/scripts/generate-api-docs.py
@@ -89,7 +89,7 @@ def generate_docs(dir):
     for path in paths:
         dirname = os.path.dirname(path)
         if path.endswith("__init__.py"):
-            submodules = [web.lstrips(docpath(s), docpath(dirname) + "/") for s in submodule_dict[dirname]]
+            submodules = [docpath(s).removeprefix(docpath(dirname) + "/") for s in submodule_dict[dirname]]
         else:
             submodules = []
         submodules.sort()

--- a/scripts/pull-templates.py
+++ b/scripts/pull-templates.py
@@ -5,7 +5,6 @@ import os
 from optparse import OptionParser
 
 import _init_path  # noqa: F401 Imported for its side effect of setting PYTHONPATH
-import web
 
 from openlibrary.api import OpenLibrary, marshal
 

--- a/scripts/pull-templates.py
+++ b/scripts/pull-templates.py
@@ -64,7 +64,7 @@ def make_path(doc):
         return "openlibrary/plugins/openlibrary/js/" + doc["key"].split("/")[-1]
     else:
         key = doc["key"].rsplit(".")[0]
-        key = web.lstrips(key, options.template_root)
+        key = key.removeprefix(options.template_root)
 
         plugin = doc.get("plugin", options.default_plugin)
         return f"openlibrary/plugins/{plugin}{key}.html"

--- a/scripts/solr_updater/solr_updater.py
+++ b/scripts/solr_updater/solr_updater.py
@@ -273,7 +273,7 @@ async def main(
 
     # set OL URL when running on a dev-instance
     if ol_url:
-        host = web.lstrips(ol_url, "http://").strip("/")
+        host = ol_url.removeprefix("http://").strip("/")
         update.set_query_host(host)
 
     set_osp_dump_location(osp_dump)


### PR DESCRIPTION
Closes #12503

## Summary

- Replace non-vendored `web.lstrips(...)` calls with `str.removeprefix(...)`.
- Replace non-vendored `web.rstrips(...)` calls with `str.removesuffix(...)`.
- Covers the affected `openlibrary/` and `scripts/` files listed in the issue while preserving behavior.

## Testing

- `git grep -n web\\.lstrips\\|web\\.rstrips -- . :(exclude)vendor` returned no matches.
- `python -m compileall -q openlibrary/core/lists/model.py openlibrary/core/processors/readableurls.py openlibrary/coverstore/utils.py openlibrary/mocks/mock_infobase.py openlibrary/plugins/admin/code.py openlibrary/plugins/openlibrary/code.py openlibrary/plugins/openlibrary/lists.py openlibrary/plugins/upstream/code.py openlibrary/plugins/worksearch/subjects.py openlibrary/solr/update.py scripts/copydocs.py scripts/generate-api-docs.py scripts/pull-templates.py scripts/solr_updater/solr_updater.py`

Note: I did not run the full test suite locally because the local environment does not have the repo test dependencies installed and this checkout expects Python `>=3.12.2,<3.12.3`.