### PR TITLE
asyncify code for trending and availability fastapi

### DIFF
--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -11,6 +11,7 @@ from infogami.infobase.utils import flatten
 from openlibrary.i18n import gettext as _
 from openlibrary.plugins.worksearch.schemes.works import WorkSearchScheme
 from openlibrary.plugins.worksearch.search import get_solr
+from openlibrary.utils.async_utils import async_bridge
 from openlibrary.utils.dateutil import DATE_ONE_MONTH_AGO, DATE_ONE_WEEK_AGO
 
 from . import db
@@ -154,25 +155,25 @@ class Bookshelves(db.CommonExtras):
 
         return list(oldb.query(query, vars=data))
 
-    @classmethod
-    def add_solr_works(cls, readinglog_items, fields: Iterable[str] | None = None) -> None:
+    @staticmethod
+    async def add_solr_works_async(readinglog_items, fields: Iterable[str] | None = None) -> None:
         """Given a list of readinglog_items, such as those returned by
         Bookshelves.most_logged_books, fetch the corresponding Open Library
         book records from solr with availability. This will add a 'work' key
         to each item in readinglog_items.
         """
-        from openlibrary.core.lending import add_availability
-        from openlibrary.plugins.worksearch.code import get_solr_works
+        from openlibrary.core.lending import add_availability_async
+        from openlibrary.plugins.worksearch.code import get_solr_works_async
 
         # This gives us a dict of all the works representing
         # the logged_books, keyed by work_id
-        work_index = get_solr_works(
+        work_index = await get_solr_works_async(
             {f"/works/OL{i['work_id']}W" for i in readinglog_items},
             fields,
             editions=True,
         )
 
-        add_availability([((w.get("editions") or {}).get("docs") or [None])[0] or w for w in work_index.values()])
+        await add_availability_async([((w.get("editions") or {}).get("docs") or [None])[0] or w for w in work_index.values()])
 
         # Attach items from the work_index in the order
         # they are represented by the trending logged books
@@ -180,6 +181,8 @@ class Bookshelves(db.CommonExtras):
             key = f"/works/OL{item['work_id']}W"
             if key in work_index:
                 readinglog_items[i]["work"] = work_index[key]
+
+    add_solr_works = async_bridge.wrap(add_solr_works_async)
 
     @classmethod
     def count_total_books_logged_by_user(cls, username: str, bookshelf_ids: list[str] | None = None) -> int:

--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -182,7 +182,7 @@ class Bookshelves(db.CommonExtras):
             if key in work_index:
                 readinglog_items[i]["work"] = work_index[key]
 
-    add_solr_works = async_bridge.wrap(add_solr_works_async)
+    add_solr_works = staticmethod(async_bridge.wrap(add_solr_works_async))
 
     @classmethod
     def count_total_books_logged_by_user(cls, username: str, bookshelf_ids: list[str] | None = None) -> int:

--- a/openlibrary/core/fulltext.py
+++ b/openlibrary/core/fulltext.py
@@ -5,7 +5,7 @@ from urllib.parse import urlencode
 import httpx
 
 from infogami import config
-from openlibrary.core.lending import get_availability
+from openlibrary.core.lending import get_availability_async
 from openlibrary.plugins.openlibrary.home import format_book_data
 from openlibrary.utils.async_utils import async_bridge
 from openlibrary.utils.request_context import req_context, site
@@ -59,7 +59,7 @@ async def fulltext_search_async(q, page=1, offset=None, limit=100, js=False, fac
     if "error" not in ia_results and ia_results["hits"]:
         hits = ia_results["hits"].get("hits", [])
         ocaids = [hit["fields"].get("identifier", [""])[0] for hit in hits]
-        availability = get_availability("identifier", ocaids)
+        availability = await get_availability_async("identifier", ocaids)
         if "error" in availability:
             availability = {}
 

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -306,7 +306,7 @@ async def get_available_async(
             if item.get("openlibrary_work"):
                 results[item["openlibrary_work"]] = item["openlibrary_edition"]
         books = web.ctx.site.get_many([f"/books/{olid}" for olid in results.values()])
-        books = add_availability(books)
+        books = await add_availability_async(books)
         return books
     except Exception:  # TODO: Narrow exception scope
         logger.exception(f"get_available({url})")
@@ -407,7 +407,7 @@ def update_availability_schema_to_v2(
     return v2_resp
 
 
-def get_availability(
+async def get_availability_async(
     id_type: Literal["identifier", "openlibrary_work", "openlibrary_edition"],
     ids: list[str],
 ) -> dict[str, AvailabilityStatusV2]:
@@ -436,7 +436,7 @@ def get_availability(
         }
         if config_ia_ol_metadata_write_s3:
             headers["authorization"] = "LOW {s3_key}:{s3_secret}".format(**config_ia_ol_metadata_write_s3)
-        resp = ia.session.get(
+        resp = await ia.async_session.get(
             config_ia_availability_api_v2_url,
             params={
                 id_type: ",".join(ids_to_fetch),
@@ -486,6 +486,9 @@ def get_availability(
         }  # type: ignore
 
 
+get_availability = async_bridge.wrap(get_availability_async)
+
+
 def get_ocaid(item: dict) -> str | None:
     # Circular import otherwise
     from ..book_providers import is_non_ia_ocaid
@@ -533,8 +536,7 @@ def get_availabilities(items: list) -> dict:
     return result
 
 
-@public
-def add_availability(
+async def add_availability_async(
     items: list,
     mode: Literal["identifier", "openlibrary_work"] = "identifier",
 ) -> list:
@@ -553,19 +555,23 @@ def add_availability(
                     item["availability"] = get_ebook_access_availability(ocaid, EbookAccess.from_solr_str(item["ebook_access"]))
         else:
             ocaids = [ocaid for ocaid in map(get_ocaid, items) if ocaid]
-            availabilities = get_availability("identifier", ocaids)
+            availabilities = await get_availability_async("identifier", ocaids)
             for item in items:
                 ocaid = get_ocaid(item)
                 if ocaid:
                     item["availability"] = availabilities.get(ocaid)
     elif mode == "openlibrary_work":
         _ids = [item["key"].split("/")[-1] for item in items]
-        availabilities = get_availability("openlibrary_work", _ids)
+        availabilities = await get_availability_async("openlibrary_work", _ids)
         for item in items:
             olid = item["key"].split("/")[-1]
             if olid:
                 item["availability"] = availabilities.get(olid)
     return items
+
+
+add_availability = async_bridge.wrap(add_availability_async)
+public(add_availability)
 
 
 def get_items_and_add_availability(ocaids: list[str]) -> dict[str, Edition]:

--- a/openlibrary/fastapi/internal/api.py
+++ b/openlibrary/fastapi/internal/api.py
@@ -84,7 +84,7 @@ class AvailabilityRequest(BaseModel):
     response_model=dict[str, AvailabilityStatusV2],
     description="Returns availability status for one or more books",
 )
-def get_book_availability(
+async def get_book_availability(
     id_type: Annotated[AvailabilityIDType, Query(alias="type", description="Type of the identifiers")],
     ids: Annotated[
         list[str],
@@ -92,7 +92,7 @@ def get_book_availability(
         Query(min_length=1, description="Comma-separated list of IDs (e.g. OL123W, ISBN, ocaid)"),
     ],
 ) -> dict:
-    return lending.get_availability(id_type, ids)
+    return await lending.get_availability_async(id_type, ids)
 
 
 @router.post(
@@ -100,11 +100,11 @@ def get_book_availability(
     response_model=dict[str, AvailabilityStatusV2],
     description="Returns availability status for one or more books",
 )
-def post_book_availability(
+async def post_book_availability(
     id_type: Annotated[AvailabilityIDType, Query(alias="type")],
     request: AvailabilityRequest,
 ) -> dict:
-    return lending.get_availability(id_type, request.ids)
+    return await lending.get_availability_async(id_type, request.ids)
 
 
 class TrendingRequestParams(Pagination):
@@ -140,7 +140,7 @@ class TrendingResponse(BaseModel):
     response_model_exclude_none=True,
     description="Returns works sorted by recent activity (reads, loans, etc.)",
 )
-def trending_books_api(
+async def trending_books_api(
     period: Annotated[TrendingPeriod, Path(description="The time period for trending books")],
     params: Annotated[TrendingRequestParams, Query()],
 ) -> TrendingResponse:
@@ -148,7 +148,7 @@ def trending_books_api(
     # ``period`` is always a key in SINCE_DAYS — guaranteed by the Literal type above.
     since_days: int | None = SINCE_DAYS.get(period, params.days)
 
-    works = get_trending_books(
+    works = await get_trending_books(
         since_days=since_days,
         since_hours=params.hours,
         limit=params.limit,

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -151,7 +151,7 @@ class CarouselCardPartial:
         if params.queryType == "BROWSE":
             return await self._do_browse_query(params)
         if params.queryType == "TRENDING":
-            return self._do_trends_query(params)
+            return await self._do_trends_query(params)
         if params.queryType == "SUBJECTS":
             return await self._do_subjects_query(params)
 
@@ -200,8 +200,8 @@ class CarouselCardPartial:
         results = await get_available_async(url=url)
         return results if "error" not in results else []
 
-    def _do_trends_query(self, params: CarouselLoadMoreParams) -> list:
-        return get_trending_books(minimum=3, limit=params.limit, page=params.page, sort_by_count=False)
+    async def _do_trends_query(self, params: CarouselLoadMoreParams) -> list:
+        return await get_trending_books(minimum=3, limit=params.limit, page=params.page, sort_by_count=False)
 
     async def _do_subjects_query(self, params: CarouselLoadMoreParams) -> list:
         publish_year = date_range_to_publish_year_filter(params.published_in)

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -21,7 +21,7 @@ from infogami.utils import delegate
 from infogami.utils.view import public, render, render_template, safeint
 from openlibrary.core import cache
 from openlibrary.core.env import get_ol_env
-from openlibrary.core.lending import add_availability
+from openlibrary.core.lending import add_availability, add_availability_async
 from openlibrary.core.models import Edition
 from openlibrary.fastapi.models import SolrInternalsParams
 from openlibrary.i18n import gettext as _
@@ -119,8 +119,7 @@ def get_facet_map() -> tuple[tuple[str, str]]:
     )
 
 
-@public
-def get_solr_works(
+async def get_solr_works_async(
     work_keys: set[str], fields: Iterable[str] | None = None, editions=False
 ) -> dict[str, web.storage]:
     from openlibrary.plugins.worksearch.search import get_solr
@@ -134,7 +133,7 @@ def get_solr_works(
 
     if editions:
         # To get the top matching edition, need to do a proper query
-        resp = run_solr_query(
+        resp = await run_solr_query_async(
             WorkSearchScheme(),
             {'q': 'key:(%s)' % ' OR '.join(work_keys)},
             rows=len(work_keys),
@@ -147,7 +146,15 @@ def get_solr_works(
             for doc in resp.docs
         }
     else:
-        return {doc['key']: doc for doc in get_solr().get_many(work_keys, fields)}
+        return {
+            doc['key']: doc
+            for doc in await get_solr().get_many_async(work_keys, fields)
+        }
+
+
+# Create a sync wrapper for backward compatibility
+get_solr_works = async_bridge.wrap(get_solr_works_async)
+public(get_solr_works)
 
 
 def read_author_facet(author_facet: str) -> tuple[str, str]:
@@ -1060,7 +1067,7 @@ class PreparedQuery:
     limit: int
 
 
-def _process_solr_search_response(response: SearchResponse, fields: str) -> dict:
+async def _process_solr_search_response(response: SearchResponse, fields: str) -> dict:
     """
     Handles the post-processing of the Solr response, which is common
     to both sync and async versions.
@@ -1082,7 +1089,7 @@ def _process_solr_search_response(response: SearchResponse, fields: str) -> dict
             )
             for work in processed_response.get('docs', [])
         ]
-        add_availability(docs_for_availability)
+        await add_availability_async(docs_for_availability)
 
     return processed_response
 
@@ -1142,7 +1149,7 @@ async def work_search_async(
         solr_internals_params=solr_internals_params,
     )
 
-    return _process_solr_search_response(resp, fields)
+    return await _process_solr_search_response(resp, fields)
 
 
 def validate_search_json_query(q: str | None) -> str | None:

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -8,7 +8,7 @@ import web
 
 from infogami.utils import delegate
 from infogami.utils.view import render_template, safeint
-from openlibrary.core.lending import add_availability
+from openlibrary.core.lending import add_availability_async
 from openlibrary.core.models import Subject, Tag
 from openlibrary.solr.query_utils import query_dict_to_str
 from openlibrary.utils.async_utils import async_bridge
@@ -272,7 +272,7 @@ class SubjectEngine:
                 phrase=True,
             ),
             work_count=result.num_found,
-            works=add_availability([self.work_wrapper(d) for d in result.docs]),
+            works=await add_availability_async([self.work_wrapper(d) for d in result.docs]),
         )
 
         if details:

--- a/openlibrary/tests/core/test_lending.py
+++ b/openlibrary/tests/core/test_lending.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -9,10 +9,10 @@ from openlibrary.utils.request_context import RequestContextVars, req_context
 @pytest.mark.usefixtures("request_context_fixture")
 class TestAddAvailability:
     def test_reads_ocaids(self, monkeypatch):
-        def mock_get_availability(id_type, ocaids):
+        async def mock_get_availability_async(id_type, ocaids):
             return {"foo": {"status": "available"}}
 
-        monkeypatch.setattr(lending, "get_availability", mock_get_availability)
+        monkeypatch.setattr(lending, "get_availability_async", mock_get_availability_async)
 
         f = lending.add_availability
         assert f([{"ocaid": "foo"}]) == [{"ocaid": "foo", "availability": {"status": "available"}}]
@@ -25,10 +25,10 @@ class TestAddAvailability:
         assert f([{}]) == [{}]
 
     def test_handles_availability_none(self, monkeypatch):
-        def mock_get_availability(id_type, ocaids):
+        async def mock_get_availability_async(id_type, ocaids):
             return {"foo": {"status": "error"}}
 
-        monkeypatch.setattr(lending, "get_availability", mock_get_availability)
+        monkeypatch.setattr(lending, "get_availability_async", mock_get_availability_async)
 
         f = lending.add_availability
         r = f([{"ocaid": "foo"}])
@@ -55,12 +55,16 @@ class TestGetAvailability:
         req_context.reset(token)
 
     def test_cache(self):
-        with patch("openlibrary.core.ia.session.get") as mock_get:
-            mock_get.return_value = Mock()
-            mock_get.return_value.json.return_value = {
-                "success": True,
-                "responses": {"foo": {"status": "open"}},
-            }
+        with patch("openlibrary.core.ia.async_session.get") as mock_get:
+            mock_response = AsyncMock()
+            mock_response.json = Mock(
+                return_value={
+                    "success": True,
+                    "responses": {"foo": {"status": "open"}},
+                }
+            )
+            mock_response.raise_for_status = Mock()
+            mock_get.return_value = mock_response
 
             foo_expected = {
                 "status": "open",
@@ -87,10 +91,12 @@ class TestGetAvailability:
             assert r2 == {"foo": foo_expected}
 
             # Now should make a call for just the new identifier
-            mock_get.return_value.json.return_value = {
-                "success": True,
-                "responses": {"bar": {"status": "error"}},
-            }
+            mock_response.json = Mock(
+                return_value={
+                    "success": True,
+                    "responses": {"bar": {"status": "error"}},
+                }
+            )
             r3 = lending.get_availability("identifier", ["foo", "bar"])
             assert mock_get.call_count == 2
             assert mock_get.call_args[1]["params"]["identifier"] == "bar"

--- a/openlibrary/tests/fastapi/test_book_availability.py
+++ b/openlibrary/tests/fastapi/test_book_availability.py
@@ -9,7 +9,7 @@ MOCK_RETURN = {"OL1W": {"status": "open", "is_previewable": True}}
 
 @pytest.fixture
 def mock_get_availability():
-    with patch("openlibrary.fastapi.internal.api.lending.get_availability") as mock:
+    with patch("openlibrary.fastapi.internal.api.lending.get_availability_async") as mock:
         mock.return_value = MOCK_RETURN
         yield mock
 

--- a/openlibrary/views/loanstats.py
+++ b/openlibrary/views/loanstats.py
@@ -5,7 +5,6 @@ from collections.abc import Iterable
 import web
 
 from infogami.utils import delegate
-from infogami.utils.view import public
 
 from .. import app
 from ..core import cache
@@ -48,8 +47,7 @@ def reading_log_summary():
     return stats
 
 
-@public
-def get_trending_books(
+async def get_trending_books(
     since_days=1,
     since_hours=0,
     limit=18,
@@ -69,7 +67,7 @@ def get_trending_books(
             minimum=minimum,
         )
     )
-    Bookshelves.add_solr_works(logged_books, fields=fields)
+    await Bookshelves.add_solr_works_async(logged_books, fields=fields)
 
     return [book["work"] for book in logged_books if book.get("work")]
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #12254

This started with trying to make `_do_trends_query` async and that quickly required making many other functions async and spidered out a bit to impact a few other endpoints and code paths but there's no logic changes just making code async.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
It's on testing, since April 30 at like 2:30pm PST. So maybe check logs but it seems to work.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
