### PR TITLE
Replaced web.urlquote with urllib.parse.quote

### DIFF
--- a/openlibrary/catalog/utils/query.py
+++ b/openlibrary/catalog/utils/query.py
@@ -4,7 +4,6 @@ import urllib
 from time import sleep
 
 import requests
-import web
 
 query_host = "openlibrary.org"
 
@@ -62,7 +61,7 @@ def get_all_ia():
     q["offset"] = 0
 
     while True:
-        url = base_url() + "/api/things?query=" + web.urlquote(json.dumps(q))
+        url = base_url() + "/api/things?query=" + urllib.parse.quote(json.dumps(q))
         ret = jsonload(url)["result"]
         yield from ret
         if not ret:

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -13,7 +13,7 @@ import random
 import socket
 import sys
 from time import time
-from urllib.parse import parse_qs, urlencode
+from urllib.parse import parse_qs, quote, urlencode
 
 import requests
 import web
@@ -1179,7 +1179,7 @@ def setup_template_globals():
             'zip': zip,
             'tuple': tuple,
             'hash': hash,
-            'urlquote': web.urlquote,
+            'urlquote': quote,
             'isbn_13_to_isbn_10': isbn_13_to_isbn_10,
             'isbn_10_to_isbn_13': isbn_10_to_isbn_13,
             'NEWLINE': '\n',

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from hashlib import md5
 from typing import Literal, NotRequired, TypedDict
-from urllib.parse import parse_qs
+from urllib.parse import parse_qs, quote
 
 import web
 from pydantic import BaseModel
@@ -344,7 +344,7 @@ class BookPageListsPartial:
             results["partials"].append(_("This work does not appear on any lists."))
         else:
             query = "seed_count:[2 TO *] seed:(%s)" % " OR ".join(f'"{k}"' for k in keys)
-            all_url = "/search/lists?q=" + web.urlquote(query) + "&sort=last_modified"
+            all_url = "/search/lists?q=" + quote(query) + "&sort=last_modified"
             lists_template = render_template("lists/carousel", lists, all_url)
             results["partials"].append(str(lists_template))
 

--- a/openlibrary/plugins/openlibrary/processors.py
+++ b/openlibrary/plugins/openlibrary/processors.py
@@ -7,6 +7,7 @@ import web
 
 from infogami import config
 from openlibrary.accounts import get_current_user
+from urllib.parse import quote
 from openlibrary.core import helpers as h
 from openlibrary.core.processors import (
     ReadableUrlProcessor,  # noqa: F401 side effects may be needed
@@ -150,7 +151,7 @@ class CookieValidationProcessor:
 
             if web.ctx.env.get("HTTP_X_OL_VERIFY_HUMAN") == "1":
                 next_url = web.ctx.env.get("REQUEST_URI") or web.ctx.env.get("HTTP_X_REQUEST_URI") or web.ctx.path
-                raise web.seeother("/verify_human?next=" + web.urlquote(next_url))
+                raise web.seeother("/verify_human?next=" + quote(next_url))
 
         return handler()
 

--- a/openlibrary/plugins/openlibrary/processors.py
+++ b/openlibrary/plugins/openlibrary/processors.py
@@ -2,12 +2,12 @@
 
 import re
 from typing import ClassVar, cast
+from urllib.parse import quote
 
 import web
 
 from infogami import config
 from openlibrary.accounts import get_current_user
-from urllib.parse import quote
 from openlibrary.core import helpers as h
 from openlibrary.core.processors import (
     ReadableUrlProcessor,  # noqa: F401 side effects may be needed

--- a/scripts/mail_bad_author_query.py
+++ b/scripts/mail_bad_author_query.py
@@ -3,6 +3,7 @@ import os
 import smtplib
 import sys
 from email.mime.text import MIMEText
+from urllib.parse import quote
 
 import web
 
@@ -28,7 +29,7 @@ for row in db_error.query("select t, query, result from errors where t between '
     seen.add(author)
     bad_count += 1
     body += "-" * 60 + "\nAuthor name: " + author + "\n"
-    body += "http://openlibrary.org/query.json?type=/type/author&name=%s" % web.urlquote(author) + "\n\n"
+    body += "http://openlibrary.org/query.json?type=/type/author&name=%s" % quote(author) + "\n\n"
     body += row.result + "\n"
 
 if bad_count == 0:


### PR DESCRIPTION
Closes #12515

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
Replaces all 5 usages of `web.urlquote(...)` with Python's built-in `urllib.parse.quote(...)`. `web.urlquote` is just an alias for `urllib.parse.quote` in modern Python, so this is a behaviour-preserving refactor.

### Testing
Run make test-py to verify no regressions
Run pre-commit run --all-files to verify code quality

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
