### PR TITLE
Lending: remove legacy OL store loan query, reduce redundant IA API calls

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -1065,7 +1065,7 @@ class IA_Lending_API:
             logger.info("POST response: %s", jsontext)
             return jsontext
         except JSONDecodeError:
-            logger.exception("POST failed to openlibrary.php, no json")
+            logger.exception("POST failed to %s, no json", config_ia_loan_api_url)
             return {}
         except Exception:  # TODO: Narrow exception scope
             logger.exception("POST failed")

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -684,7 +684,7 @@ def get_loans_of_user(user_key: str) -> list[Loan]:
 get_cached_loans_of_user = cache.memcache_memoize(
     get_loans_of_user,
     key_prefix="lending.cached_loans",
-    timeout=5 * dateutil.MINUTE_SECS,  # time to live for cached loans = 5 minutes
+    timeout=10 * dateutil.MINUTE_SECS,
 )
 
 

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -1006,7 +1006,44 @@ def update_loan_status(identifier):
 
 
 class IA_Lending_API:
-    """Archive.org waiting list API."""
+    """Server-side client for Archive.org's internal loan/waitinglist RPC API.
+
+    This class POSTs to config_ia_loan_api_url using OL's shared server key.
+    The goal (issue #11232) is to replace all calls here with s3_loan_api(),
+    which uses the patron's own S3 credentials against the official public
+    endpoint (S3_LOAN_URL = https://<host>/services/loans/loan/).
+
+    Migration status per method
+    ---------------------------
+    find_loans(userid=…)
+        → s3_loan_api(s3_keys, action="user_bookshelf")
+        Blocked on: plumbing patron s3_keys into get_loans_of_user().
+        Tracked in: issue #11232.
+
+    create_loan(identifier, userid, format, ol_key)
+        Already replaced in the user-facing borrow flow by
+        s3_loan_api(s3_keys, action="borrow_book") in borrow.py.
+        lending.create_loan() itself has no remaining callers and can be
+        removed once the method below is confirmed dead.
+
+    delete_loan(identifier, userid)
+        Used server-side in Loan.delete() for expired/forced returns.
+        → s3_loan_api(s3_keys, action="return_loan") requires patron keys.
+        Needs investigation: does IA accept a server-keyed return, or must
+        it always be patron-signed?
+
+    get_loan(identifier, userid)
+        Used in _get_ia_loan() / sync_loan() to check whether a specific
+        identifier is on loan.  No direct s3_loan_api equivalent today.
+        Needs investigation: does user_bookshelf or another action cover it?
+
+    Waitinglist methods (join/leave/update/query)
+        join_waitinglist / leave_waitinglist already have patron-signed
+        equivalents in borrow.py (s3_loan_api join_waitlist/leave_waitlist).
+        update_waitinglist and query are used internally by waitinglist.py
+        for background processing (e.g. notifying next patron in queue).
+        These need a confirmed s3 equivalent before migrating.
+    """
 
     def get_loan(self, identifier: str, userid: str | None = None):
         params = {"method": "loan.query", "identifier": identifier}

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -655,22 +655,29 @@ def _get_ia_loan(identifier: str, userid: str | None = None):
 
 
 def get_loans_of_user(user_key: str) -> list[Loan]:
-    """TODO: Remove inclusion of local data; should only come from IA"""
+    """Returns all active loans for the given user from Archive.org.
+
+    Loan records are authoritative at IA; the local OL store previously held a
+    mirror of them but that mirror is no longer maintained.
+
+    Next step (issue #11232): replace the ia_lending_api.find_loans() call below
+    with s3_loan_api(s3_keys, action="user_bookshelf"), which uses the patron's
+    own S3 credentials against the official /services/loans/loan/ endpoint.
+    That change requires plumbing s3_keys into this function and is deferred
+    because the privilege API cannot be exercised in a local dev environment.
+    """
     if "env" not in web.ctx:
-        """For the get_cached_user_loans to call the API if no cache is present,
-        we have to fakeload the web.ctx
-        """
+        # fakeload is required so that the memcache wrapper can call this
+        # function from a background context with no live web request.
         delegate.fakeload()
         set_context_from_legacy_web_py()
 
     account = OpenLibraryAccount.get_by_username(user_key.rsplit("/", maxsplit=1)[-1])
 
-    loandata = web.ctx.site.store.values(type="/type/loan", name="user", value=user_key)
-    loans = [Loan(d) for d in loandata]
-    if account and account.itemname:
-        loans += _get_ia_loans_of_user(account.itemname)
-    # Set patron's loans in cache w/ now timestamp
-    get_cached_loans_of_user.memcache_set((user_key,), {}, loans or [], time.time())  # rehydrate cache
+    loans = _get_ia_loans_of_user(account.itemname) if account and account.itemname else []
+    # Rehydrate the memcache entry so callers that use get_cached_loans_of_user
+    # immediately after this call get a fresh result without an extra round-trip.
+    get_cached_loans_of_user.memcache_set((user_key,), {}, loans, time.time())
     return loans
 
 

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -1155,13 +1155,13 @@ class account_loans(delegate.page):
 
     @require_login
     def GET(self):
-        from openlibrary.core.lending import get_loans_of_user
+        from openlibrary.core.lending import get_cached_loans_of_user
 
         user = accounts.get_current_user()
         user.update_loan_status()
         username = user["key"].split("/")[-1]
         mb = MyBooksTemplate(username, "loans")
-        docs = get_loans_of_user(user.key)
+        docs = get_cached_loans_of_user(user.key)
         template = render["account/loans"](user, docs)
         return mb.render(header_title=_("Loans"), template=template)
 

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -404,7 +404,10 @@ def get_all_loans() -> list:
 
 
 def get_loans(user):
-    return lending.get_loans_of_user(user.key)
+    # Use the cached version: get_loans_of_user always rehydrates the cache on
+    # a fresh fetch, so callers that follow an update_loan_status() call get a
+    # cache hit here instead of a redundant round-trip to the IA loan API.
+    return lending.get_cached_loans_of_user(user.key)
 
 
 def get_edition_loans(edition):

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -846,8 +846,7 @@ class User(models.User):
 
     def update_loan_status(self):
         """Sync OL ebook records for all of this user's active loans."""
-        for loan in lending.get_loans_of_user(self.key):
-            lending.sync_loan(loan["ocaid"])
+        self.get_loans()
 
     def get_safe_mode(self):
         return (self.get_users_settings() or {}).get("safe_mode", "").lower()

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -839,13 +839,14 @@ class User(models.User):
         return len(borrow.get_loans(self))
 
     def get_loans(self):
-        self.update_loan_status()
-        return lending.get_loans_of_user(self.key)
-
-    def update_loan_status(self):
-        """Update the status of this user's loans."""
         loans = lending.get_loans_of_user(self.key)
         for loan in loans:
+            lending.sync_loan(loan["ocaid"])
+        return loans
+
+    def update_loan_status(self):
+        """Sync OL ebook records for all of this user's active loans."""
+        for loan in lending.get_loans_of_user(self.key):
             lending.sync_loan(loan["ocaid"])
 
     def get_safe_mode(self):

--- a/openlibrary/tests/core/test_lending.py
+++ b/openlibrary/tests/core/test_lending.py
@@ -1,8 +1,10 @@
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
+import web
 
 from openlibrary.core import lending
+from openlibrary.utils import dateutil
 from openlibrary.utils.request_context import RequestContextVars, req_context
 
 
@@ -101,3 +103,69 @@ class TestGetAvailability:
             assert mock_get.call_count == 2
             assert mock_get.call_args[1]["params"]["identifier"] == "bar"
             assert r3 == {"foo": foo_expected, "bar": bar_expected}
+
+
+class TestGetLoansOfUser:
+    """Tests for get_loans_of_user and get_cached_loans_of_user."""
+
+    @pytest.fixture(autouse=True)
+    def _web_ctx(self, monkeypatch):
+        """Provide a minimal web.ctx so fakeload() is skipped."""
+        ctx = MagicMock()
+        ctx.__contains__ = lambda self_, key: key == "env"
+        monkeypatch.setattr(web, "ctx", ctx)
+
+    def test_returns_ia_loans(self, monkeypatch):
+        ia_loan = lending.Loan(
+            {
+                "_key": "loan-test-item",
+                "type": "/type/loan",
+                "user": "/people/testuser",
+                "book": "/books/OL1M",
+                "ocaid": "test-item",
+                "resource_type": "bookreader",
+                "stored_at": "ia",
+            }
+        )
+        mock_account = Mock()
+        mock_account.itemname = "@testuser"
+        monkeypatch.setattr(lending.OpenLibraryAccount, "get_by_username", lambda u: mock_account)
+        monkeypatch.setattr(lending, "_get_ia_loans_of_user", lambda userid: [ia_loan])
+        monkeypatch.setattr(lending.get_cached_loans_of_user, "memcache_set", lambda *a, **kw: None)
+
+        result = lending.get_loans_of_user("/people/testuser")
+
+        assert result == [ia_loan]
+
+    def test_returns_empty_list_when_no_account(self, monkeypatch):
+        monkeypatch.setattr(lending.OpenLibraryAccount, "get_by_username", lambda u: None)
+        monkeypatch.setattr(lending.get_cached_loans_of_user, "memcache_set", lambda *a, **kw: None)
+
+        result = lending.get_loans_of_user("/people/unknown")
+
+        assert result == []
+
+    def test_returns_empty_list_when_no_itemname(self, monkeypatch):
+        mock_account = Mock()
+        mock_account.itemname = None
+        monkeypatch.setattr(lending.OpenLibraryAccount, "get_by_username", lambda u: mock_account)
+        monkeypatch.setattr(lending.get_cached_loans_of_user, "memcache_set", lambda *a, **kw: None)
+
+        result = lending.get_loans_of_user("/people/testuser")
+
+        assert result == []
+
+    def test_does_not_query_local_store(self, monkeypatch):
+        """Local OL store must not be consulted — loans are authoritative at IA."""
+        mock_account = Mock()
+        mock_account.itemname = "@testuser"
+        monkeypatch.setattr(lending.OpenLibraryAccount, "get_by_username", lambda u: mock_account)
+        monkeypatch.setattr(lending, "_get_ia_loans_of_user", lambda userid: [])
+        monkeypatch.setattr(lending.get_cached_loans_of_user, "memcache_set", lambda *a, **kw: None)
+
+        lending.get_loans_of_user("/people/testuser")
+
+        web.ctx.site.store.values.assert_not_called()
+
+    def test_cache_ttl_is_ten_minutes(self):
+        assert lending.get_cached_loans_of_user.timeout == 10 * dateutil.MINUTE_SECS

--- a/openlibrary/tests/core/test_lending.py
+++ b/openlibrary/tests/core/test_lending.py
@@ -110,9 +110,14 @@ class TestGetLoansOfUser:
 
     @pytest.fixture(autouse=True)
     def _web_ctx(self, monkeypatch):
-        """Provide a minimal web.ctx so fakeload() is skipped."""
-        ctx = MagicMock()
-        ctx.__contains__ = lambda self_, key: key == "env"
+        """Provide a minimal web.ctx so fakeload() is skipped.
+
+        web.storage is a dict subclass, so `"env" in ctx` works correctly via
+        the standard __contains__ lookup — unlike MagicMock where setting
+        __contains__ on the instance is ignored by the `in` operator (Python
+        resolves special methods on the type, not the instance).
+        """
+        ctx = web.storage(env={}, site=web.storage(store=MagicMock()))
         monkeypatch.setattr(web, "ctx", ctx)
 
     def test_returns_ia_loans(self, monkeypatch):


### PR DESCRIPTION
## Summary

First step toward resolving #11232 (refactor loan retrieval to use the official IA /loans API) and #7726 (borrow performance bloat). This PR is intentionally scoped — the full `s3_loan_api` migration is documented but deferred (see below).

**Do not close #11232 or #7726** — this PR is the first step; remaining work is tracked in the `IA_Lending_API` docstring added here.

### Changes

- **Fix misleading error log** (`lending.py`): `IA_Lending_API._post()` logged `"POST failed to openlibrary.php"` even though the actual URL has been configurable for years. Now logs the real `config_ia_loan_api_url`.

- **Remove legacy OL local-store loan query** (`lending.py`): `get_loans_of_user` was querying OL's infogami store for `type="/type/loan"` records and merging them with the IA response. Those records haven't been written since the IA migration. The existing TODO comment said to remove them. Done.

- **Extend cache TTL 5 → 10 min** (`lending.py`): As specified in #11232. The cache is already explicitly invalidated on every borrow/return action, so a longer TTL is safe and reduces IA API pressure.

- **Fix double `get_loans_of_user` call in `User.get_loans()`** (`upstream/models.py`): `get_loans()` called `update_loan_status()` (which internally called `get_loans_of_user`) then called `get_loans_of_user` again — two IA round-trips where one suffices.

- **Use `get_cached_loans_of_user` in `borrow.get_loans()` and `account_loans.GET()`** (`borrow.py`, `account.py`): `get_loans_of_user` always rehydrates the memcache entry after a fresh fetch. Any caller that ran `update_loan_status()` first was then bypassing that fresh cache. Switching to `get_cached_loans_of_user` hits the cache instead.

- **Document remaining `IA_Lending_API` migration** (`lending.py`): Added a detailed docstring to `IA_Lending_API` mapping each method to its `s3_loan_api` equivalent and what blocks each migration step, so the next contributor doesn't have to re-research.

### What's NOT in this PR (and why)

The main ask of #11232 — replacing `ia_lending_api.find_loans()` with `s3_loan_api(s3_keys, action="user_bookshelf")` — requires plumbing patron S3 credentials into `get_loans_of_user`. This is deferred because:
1. The privilege API cannot be exercised in a local dev environment (noted in #11232 itself).
2. Each remaining `IA_Lending_API` method needs individual investigation (see the class docstring for details).

## Test plan

- [x] New `TestGetLoansOfUser` class in `test_lending.py` covers: IA loans returned, empty list on missing account/itemname, local store NOT queried (regression guard), cache TTL is 10 min
- [x] All existing core + waitinglist + account tests pass (`211 passed, 1 xfailed` — the 4 `test_fulltext` failures are pre-existing and unrelated)
- [ ] Manual verification: borrow, return, and `/account/loans` page work end-to-end (requires IA staging environment)