### PR TITLE
perf(readlinks): replace N ia.get_metadata() calls with single Solr query

### DIFF
--- a/openlibrary/plugins/books/readlinks.py
+++ b/openlibrary/plugins/books/readlinks.py
@@ -11,8 +11,10 @@ import web
 
 from infogami.utils import stats
 from infogami.utils.delegate import register_exception
-from openlibrary.core import helpers, ia
+from openlibrary.core import helpers
 from openlibrary.plugins.books import dynlinks
+from openlibrary.plugins.worksearch.search import get_solr
+from openlibrary.utils.solr import Solr
 
 
 def key_to_olid(key):
@@ -34,11 +36,13 @@ class ReadProcessor:
     def __init__(self, options):
         self.options = options
 
-    def get_item_status(self, ekey, iaid, collections) -> str:
-        if "inlibrary" in collections:
+    def get_item_status(self, ekey, iaid, ebook_access: str | None) -> str:
+        if ebook_access == "borrowable":
             status = "lendable"
+        elif ebook_access == "printdisabled":
+            status = "restricted"
         else:
-            status = "restricted" if "printdisabled" in collections else "full access"
+            status = "full access"
 
         if status == "lendable":
             loanstatus = web.ctx.site.store.get(f"ebooks/{iaid}", {"borrowed": "false"})
@@ -48,8 +52,7 @@ class ReadProcessor:
         return status
 
     def get_readitem(self, iaid, orig_iaid, orig_ekey, wkey, status, publish_date):
-        meta = self.iaid_to_meta.get(iaid)
-        if meta is None:
+        if iaid not in self.iaid_to_ebook_access:
             return None
 
         if status == "missing":
@@ -130,19 +133,13 @@ class ReadProcessor:
         # Sort iaids.  Is there a more concise way?
 
         def getstatus(self, iaid):
-            meta = self.iaid_to_meta.get(iaid)
-            if not meta:
-                status = "missing"
-                edition = None
-            else:
-                collections = meta.get("collection", [])
-                edition = self.iaid_to_ed.get(iaid)
+            if iaid not in self.iaid_to_ebook_access:
+                return "missing"
+            edition = self.iaid_to_ed.get(iaid)
             if not edition:
-                status = "missing"
-            else:
-                ekey = edition.get("key", "")
-                status = self.get_item_status(ekey, iaid, collections)
-            return status
+                return "missing"
+            ekey = edition.get("key", "")
+            return self.get_item_status(ekey, iaid, self.iaid_to_ebook_access[iaid])
 
         def getdate(self, iaid):
             if edition := self.iaid_to_ed.get(iaid):
@@ -226,8 +223,14 @@ class ReadProcessor:
         # in no 'exact' item match, even if one exists
         # Note that it's available thru above works/docs
         self.wkey_to_iaids = await get_solr_fields_for_works("ia", self.works, 500)
-        iaids = [value for sublist in self.wkey_to_iaids.values() for value in sublist]
-        self.iaid_to_meta = {iaid: ia.get_metadata(iaid) for iaid in iaids}
+        # Deduplicate while preserving order; the same ocaid can appear across multiple works.
+        iaids = list(dict.fromkeys(v for sublist in self.wkey_to_iaids.values() for v in sublist))
+        if iaids:
+            ia_query = "type:edition AND ia:(" + " OR ".join(Solr.escape(iaid) for iaid in iaids) + ")"
+            solr_result = await get_solr().select_async(ia_query, fields=["ia", "ebook_access"], rows=len(iaids))
+            self.iaid_to_ebook_access = {iaid: doc.get("ebook_access") for doc in solr_result.docs for iaid in (doc.get("ia") or [])}
+        else:
+            self.iaid_to_ebook_access = {}
 
         def lookup_iaids(iaids):
             step = 10

--- a/openlibrary/plugins/books/tests/test_readlinks.py
+++ b/openlibrary/plugins/books/tests/test_readlinks.py
@@ -5,16 +5,18 @@ from openlibrary.plugins.books import readlinks
 
 
 @pytest.mark.parametrize(
-    ("collections", "options", "expected"),
+    ("ebook_access", "options", "expected"),
     [
-        (["inlibrary"], {}, "lendable"),
-        (["printdisabled"], {}, "restricted"),
-        (["some other collection"], {}, "full access"),
+        ("borrowable", {}, "lendable"),
+        ("printdisabled", {}, "restricted"),
+        ("public", {}, "full access"),
+        ("no_ebook", {}, "full access"),
+        (None, {}, "full access"),
     ],
 )
-def test_get_item_status(collections, options, expected, mock_site):
+def test_get_item_status(ebook_access, options, expected, mock_site):
     read_processor = readlinks.ReadProcessor(options=options)
-    status = read_processor.get_item_status("ekey", "iaid", collections)
+    status = read_processor.get_item_status("ekey", "iaid", ebook_access)
     assert status == expected
 
 
@@ -28,6 +30,22 @@ def test_get_item_status(collections, options, expected, mock_site):
 def test_get_item_status_monkeypatched(borrowed, expected, monkeypatch, mock_site):
     read_processor = readlinks.ReadProcessor(options={})
     monkeypatch.setattr(web.ctx.site.store, "get", lambda _, __: {"borrowed": borrowed})
-    collections = ["inlibrary"]
-    status = read_processor.get_item_status("ekey", "iaid", collections)
+    status = read_processor.get_item_status("ekey", "iaid", "borrowable")
     assert status == expected
+
+
+def test_get_readitem_missing_when_not_in_solr(mock_site):
+    rp = readlinks.ReadProcessor(options={})
+    rp.iaid_to_ebook_access = {}
+    rp.iaid_to_ed = {}
+    result = rp.get_readitem("some_iaid", "some_iaid", "/books/OL1M", "/works/OL1W", "missing", "2000")
+    assert result is None
+
+
+def test_get_readitem_present_when_in_solr(mock_site):
+    rp = readlinks.ReadProcessor(options={"show_all_items": True})
+    rp.iaid_to_ebook_access = {"myiaid": "public"}
+    rp.iaid_to_ed = {"myiaid": {"key": "/books/OL1M", "covers": []}}
+    result = rp.get_readitem("myiaid", "myiaid", "/books/OL1M", "/works/OL1W", "full access", "2000")
+    assert result is not None
+    assert result["status"] == "full access"


### PR DESCRIPTION
## Summary

Fixes part of #12431.

The Books Read API (`readlinks.py`) was firing one `ia.get_metadata()` HTTP round-trip per IA identifier on a work (up to 500 per request). Downstream code used only `collection` to check `"inlibrary"` and `"printdisabled"`.

- Replace all N calls with a single batched Solr `select` query against the edition index (`type:edition AND ia:(iaid1 OR iaid2 OR ...)`), fetching `ebook_access` per edition
- `get_item_status()` now accepts `ebook_access: str | None` instead of a `collections` list — `"borrowable"` → `"lendable"`, `"printdisabled"` → `"restricted"`, anything else → `"full access"`
- Per-edition Solr is used (not work-level) to preserve accuracy for works with mixed-access editions
- `ia` import dropped — no remaining callers

## Files changed

- `openlibrary/plugins/books/readlinks.py`
- `openlibrary/plugins/books/tests/test_readlinks.py`

## Test plan

- [ ] All 9 `test_readlinks` tests pass (updated for new `ebook_access` signature + 2 new tests for Solr-backed existence check)
- [ ] No regressions in `openlibrary/plugins/books/` or `openlibrary/core/` test suites (35 passed)
- [ ] Manual verification: Books Read API (`/api/books?...&jscmd=data`) returns correct `status` for borrowable, printdisabled, and public items