### PR TITLE
refactor: remove ACS4 dead code from lending, models, borrow

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -41,13 +41,6 @@ logger = logging.getLogger(__name__)
 
 S3_LOAN_URL = "https://%s/services/loans/loan/"
 
-# When we generate a loan offer (.acsm) for a user we assume that the loan has occurred.
-# Once the loan fulfillment inside Digital Editions the book status server will know
-# the loan has occurred.  We allow this timeout so that we don't delete the OL loan
-# record before fulfillment because we can't find it in the book status server.
-# $$$ If a user borrows an ACS4 book and immediately returns book loan will show as
-#     "not yet downloaded" for the duration of the timeout.
-#     BookReader loan status is always current.
 LOAN_FULFILLMENT_TIMEOUT_SECONDS = dateutil.MINUTE_SECS * 5
 
 # How long bookreader loans should last
@@ -959,33 +952,8 @@ def userkey2userid(user_key: str) -> str:
     return "ol:" + username
 
 
-def get_resource_id(identifier: str, resource_type: str) -> str | None:
-    """Returns the resource_id for an identifier for the specified resource_type.
-
-    The resource_id is found by looking at external_identifiers field in the
-    metadata of the item.
-    """
-    if resource_type == "bookreader":
-        return "bookreader:" + identifier
-
-    metadata = ia.get_metadata(identifier)
-    external_identifiers = metadata.get("external-identifier", [])
-
-    for eid in external_identifiers:
-        # Ignore bad external identifiers
-        if eid.count(":") < 2:
-            continue
-
-        # The external identifiers will be of the format
-        # acs:epub:<resource_id> or acs:pdf:<resource_id>
-        _acs, rtype, resource_id = eid.split(":", 2)
-        if rtype == resource_type:
-            return resource_id
-    return None
-
-
 def update_loan_status(identifier):
-    """Update the loan status in OL based off status in ACS4.  Used to check for early returns."""
+    """Update the loan status in OL. Used to check for early returns."""
     loan = get_loan(identifier)
 
     # if the loan is from ia, it is already updated when getting the loan

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -3911,16 +3911,6 @@ msgid "There isn't a DAISY file available for "
 msgstr ""
 
 #: books/daisy.html
-msgid "This DAISY file is protected."
-msgstr ""
-
-#: books/daisy.html
-msgid ""
-"It can only be opened on a specialized device with a key issued by the "
-"Library of Congress."
-msgstr ""
-
-#: books/daisy.html
 #, python-format
 msgid ""
 "<a href=\"%(daisy_url)s\"><strong>Download the DAISY.zip</strong></a> for"
@@ -3936,15 +3926,6 @@ msgid ""
 "The <a href=\"//archive.org\">Internet Archive</a> is proud to be "
 "distributing over 1 million books free in a format called DAISY, designed"
 " for those of us who find it challenging to use regular printed media. "
-msgstr ""
-
-#: books/daisy.html
-msgid ""
-"There are two types of DAISYs on Open Library: <i>open</i> and "
-"<i>protected</i>. Open DAISYs can be read by anyone in the world on many "
-"different devices. Protected DAISYs like this one can only be opened "
-"using a key issued by the <a href=\"http://www.loc.gov/nls/\">Library of "
-"Congress NLS program</a>."
 msgstr ""
 
 #: books/daisy.html

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -6,7 +6,6 @@ import hashlib
 import hmac
 import json
 import logging
-import re
 import time
 import urllib
 from datetime import datetime
@@ -333,26 +332,11 @@ def get_borrow_status(itemid, include_resources=True, include_ia=True, edition=N
         d["checkedout_on_ia"] = ia_checkedout
 
     if include_resources:
-        d.update(
-            {
-                "resource_bookreader": "absent",
-                "resource_pdf": "absent",
-                "resource_epub": "absent",
-            }
-        )
+        d["resource_bookreader"] = "absent"
         if editions:
-            resources = editions[0].get_lending_resources()
-            resource_pattern = r"acs:(\w+):(.*)"
-            for resource_urn in resources:
-                if resource_urn.startswith("acs:"):
-                    resource_type, resource_id = re.match(resource_pattern, resource_urn).groups()
-                else:
-                    resource_type, resource_id = "bookreader", resource_urn
-                resource_type = "resource_" + resource_type
-                if is_loaned_out(resource_id):
-                    d[resource_type] = "checkedout"
-                else:
-                    d[resource_type] = "available"
+            resource_id = editions[0].get_lending_resource_id("bookreader")
+            if resource_id:
+                d["resource_bookreader"] = "checkedout" if is_loaned_out(resource_id) else "available"
     return web.storage(d)
 
 

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from typing import Literal
 
 import web
+
 from infogami import config
 from infogami.infobase.utils import parse_datetime
 from infogami.utils import delegate
@@ -19,7 +20,6 @@ from infogami.utils.view import (
     add_flash_message,
     public,
 )
-
 from openlibrary import accounts
 from openlibrary.accounts.model import OpenLibraryAccount
 from openlibrary.app import render_template

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -12,7 +12,6 @@ from datetime import datetime
 from typing import Literal
 
 import web
-
 from infogami import config
 from infogami.infobase.utils import parse_datetime
 from infogami.utils import delegate
@@ -20,6 +19,7 @@ from infogami.utils.view import (
     add_flash_message,
     public,
 )
+
 from openlibrary import accounts
 from openlibrary.accounts.model import OpenLibraryAccount
 from openlibrary.app import render_template
@@ -300,47 +300,30 @@ class ia_loan_status(delegate.page):
     path = r"/ia_loan_status/(.*)"
 
     def GET(self, itemid):
-        d = get_borrow_status(itemid, include_resources=False, include_ia=False)
+        d = get_borrow_status(itemid)
         return delegate.RawText(json.dumps(d), content_type="application/json")
 
 
-def get_borrow_status(itemid, include_resources=True, include_ia=True, edition=None):
-    """Returns borrow status for each of the sources and formats.
-
-    If the optional argument editions is provided, it uses that edition instead
-    of finding edition from itemid. This is added for performance reasons.
-    """
+@public
+def get_borrow_status(itemid):
+    """Returns borrow status for this IA identifier."""
     loan = lending.get_loan(itemid)
     has_loan = bool(loan)
 
-    if edition:
-        editions = [edition]
-    else:
-        edition_keys = web.ctx.site.things({"type": "/type/edition", "ocaid": itemid})
-        editions = web.ctx.site.get_many(edition_keys)
+    edition_keys = web.ctx.site.things({"type": "/type/edition", "ocaid": itemid})
+    editions = web.ctx.site.get_many(edition_keys)
     has_waitinglist = editions and any(e.get_waitinglist_size() > 0 for e in editions)
 
-    d = {
-        "identifier": itemid,
-        "checkedout": has_loan or has_waitinglist,
-        "has_loan": has_loan,
-        "has_waitinglist": has_waitinglist,
-    }
-    if include_ia:
-        ia_checkedout = lending.is_loaned_out_on_ia(itemid)
-        d["checkedout"] = d["checkedout"] or ia_checkedout
-        d["checkedout_on_ia"] = ia_checkedout
-
-    if include_resources:
-        d["resource_bookreader"] = "absent"
-        if editions:
-            resource_id = editions[0].get_lending_resource_id("bookreader")
-            if resource_id:
-                d["resource_bookreader"] = "checkedout" if is_loaned_out(resource_id) else "available"
-    return web.storage(d)
+    return web.storage(
+        {
+            "identifier": itemid,
+            "checkedout": has_loan or has_waitinglist,
+            "has_loan": has_loan,
+            "has_waitinglist": has_waitinglist,
+        }
+    )
 
 
-# ######### Public Functions
 @public
 def datetime_from_isoformat(expiry):
     """Returns datetime object, or None"""
@@ -397,17 +380,6 @@ def get_edition_loans(edition):
         if loan:
             return [loan]
     return []
-
-
-def get_loan_link(edition, type):
-    """Get the loan link, which may be an ACS4 link or BookReader link depending on the loan type"""
-    resource_id = edition.get_lending_resource_id(type)
-
-    if type == "bookreader":
-        # link to bookreader
-        return (resource_id, get_bookreader_stream_url(edition.ocaid))
-
-    raise Exception("Unknown resource type %s for loan of edition %s", edition.key, type)
 
 
 def get_loan_key(resource_id: str):

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -149,23 +149,6 @@ class Edition(models.Edition):
         self._ia_meta_fields = meta
         return self._ia_meta_fields
 
-    def is_daisy_encrypted(self):
-        if not self.ocaid:
-            return False
-        try:
-            solr_doc = get_solr().get(self.key, fields=["ebook_access"])
-        except Exception:
-            logging.getLogger(__name__).exception("Solr lookup failed for edition %s", self.key)
-            return False
-        if solr_doc:
-            return solr_doc.get("ebook_access") == "printdisabled"
-        return False
-
-    def get_lending_resource_id(self, type):
-        if type == "bookreader":
-            return f"bookreader:{self.ocaid}" if self.ocaid else None
-        return None
-
     def get_current_and_available_loans(self):
         current_loans = borrow.get_edition_loans(self)
         current_and_available_loans = (

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -144,51 +144,26 @@ class Edition(models.Edition):
             meta = {}
         else:
             meta = ia.get_metadata(self.ocaid)
-            meta.setdefault("external-identifier", [])
             meta.setdefault("collection", [])
 
         self._ia_meta_fields = meta
         return self._ia_meta_fields
 
     def is_daisy_encrypted(self):
-        meta_fields = self.get_ia_meta_fields()
-        if not meta_fields:
-            return
-        v = meta_fields["collection"]
-        return "printdisabled" in v
-
-    def get_lending_resources(self):
-        """Returns the loan resource identifiers (in meta.xml format for ACS4 resources) for books hosted on archive.org
-
-        Returns e.g. ['bookreader:lettertoannewarr00west',
-                      'acs:epub:urn:uuid:0df6f344-7ce9-4038-885e-e02db34f2891',
-                      'acs:pdf:urn:uuid:7f192e62-13f5-4a62-af48-be4bea67e109']
-        """
-
-        # The entries in meta.xml look like this:
-        # <external-identifier>
-        #     acs:epub:urn:uuid:0df6f344-7ce9-4038-885e-e02db34f2891
-        # </external-identifier>
-
         if not self.ocaid:
-            return []
-        return self.get_ia_meta_fields()["external-identifier"]
+            return False
+        try:
+            solr_doc = get_solr().get(self.key, fields=["ebook_access"])
+        except Exception:
+            logging.getLogger(__name__).exception("Solr lookup failed for edition %s", self.key)
+            return False
+        if solr_doc:
+            return solr_doc.get("ebook_access") == "printdisabled"
+        return False
 
     def get_lending_resource_id(self, type):
         if type == "bookreader":
-            desired = "bookreader:"
-        else:
-            desired = "acs:%s:" % type
-
-        for urn in self.get_lending_resources():
-            if urn.startswith(desired):
-                # Got a match
-                # $$$ a little icky - prune the acs:type if present
-                if urn.startswith("acs:"):
-                    urn = urn[len(desired) :]
-
-                return urn
-
+            return f"bookreader:{self.ocaid}" if self.ocaid else None
         return None
 
     def get_current_and_available_loans(self):
@@ -223,51 +198,17 @@ class Edition(models.Edition):
         return self._get_available_loans([])
 
     def _get_available_loans(self, current_loans):
-        default_type = "bookreader"
-
-        loans = []
-
-        # Check if we have a possible loan - may not yet be fulfilled in ACS4
         if current_loans:
-            # There is a current loan or offer
             return []
 
-        # Create list of possible loan formats
-        resource_pattern = r"acs:(\w+):(.*)"
-        for resource_urn in self.get_lending_resources():
-            if resource_urn.startswith("acs:"):
-                type, resource_id = re.match(resource_pattern, resource_urn).groups()
-                loans.append({"resource_id": resource_id, "resource_type": type, "size": None})
-            elif resource_urn.startswith("bookreader"):
-                loans.append(
-                    {
-                        "resource_id": resource_urn,
-                        "resource_type": "bookreader",
-                        "size": None,
-                    }
-                )
+        if not self.ocaid:
+            return []
 
-        # Put default type at start of list, then sort by type name
-        def loan_key(loan):
-            if loan["resource_type"] == default_type:
-                return "1-%s" % loan["resource_type"]
-            else:
-                return "2-%s" % loan["resource_type"]
+        resource_id = f"bookreader:{self.ocaid}"
+        if borrow.is_loaned_out(resource_id):
+            return []
 
-        loans = sorted(loans, key=loan_key)
-
-        # For each possible loan, check if it is available We
-        # shouldn't be out of sync (we already checked
-        # get_edition_loans for current loans) but we fail safe, for
-        # example the book may have been borrowed in a dev instance
-        # against the live ACS4 server
-        for loan in loans:
-            if borrow.is_loaned_out(loan["resource_id"]):
-                # Only a single loan of an item is allowed
-                # $$$ log out of sync state
-                return []
-
-        return loans
+        return [{"resource_id": resource_id, "resource_type": "bookreader", "size": None}]
 
     def update_loan_status(self):
         """Update the loan status"""

--- a/openlibrary/plugins/upstream/tests/test_models.py
+++ b/openlibrary/plugins/upstream/tests/test_models.py
@@ -2,7 +2,7 @@
 Capture some of the unintuitive aspects of Storage, Things, and Works
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import web
 
@@ -143,7 +143,7 @@ class TestGetAvatarUrl:
         assert models.User.get_avatar_url("bob") == "https://archive.org/services/img/@bob-archive"
 
 
-class TestEditionACS4Removal:
+class TestEdition:
     def setup_method(self, method):
         web.ctx.site = MockSite()
         models.setup()
@@ -154,19 +154,6 @@ class TestEditionACS4Removal:
             data["ocaid"] = ocaid
         web.ctx.site.save(data)
         return web.ctx.site.get("/books/OL1M")
-
-    def test_get_lending_resource_id_bookreader(self):
-        ed = self._make_edition(ocaid="testitem00archive")
-        assert ed.get_lending_resource_id("bookreader") == "bookreader:testitem00archive"
-
-    def test_get_lending_resource_id_no_ocaid(self):
-        ed = self._make_edition()
-        assert ed.get_lending_resource_id("bookreader") is None
-
-    def test_get_lending_resource_id_acs4_returns_none(self):
-        ed = self._make_edition(ocaid="testitem00archive")
-        assert ed.get_lending_resource_id("epub") is None
-        assert ed.get_lending_resource_id("pdf") is None
 
     def test_get_available_loans_no_ocaid(self):
         ed = self._make_edition()
@@ -188,31 +175,6 @@ class TestEditionACS4Removal:
         with patch("openlibrary.core.lending.is_loaned_out", return_value=True):
             loans = ed.get_available_loans()
         assert loans == []
-
-    def test_is_daisy_encrypted_no_ocaid(self):
-        ed = self._make_edition()
-        assert ed.is_daisy_encrypted() is False
-
-    def test_is_daisy_encrypted_printdisabled(self):
-        ed = self._make_edition(ocaid="testitem00archive")
-        mock_solr = MagicMock()
-        mock_solr.get.return_value = {"key": "/books/OL1M", "ebook_access": "printdisabled"}
-        with patch("openlibrary.plugins.upstream.models.get_solr", return_value=mock_solr):
-            assert ed.is_daisy_encrypted() is True
-
-    def test_is_daisy_encrypted_borrowable(self):
-        ed = self._make_edition(ocaid="testitem00archive")
-        mock_solr = MagicMock()
-        mock_solr.get.return_value = {"key": "/books/OL1M", "ebook_access": "borrowable"}
-        with patch("openlibrary.plugins.upstream.models.get_solr", return_value=mock_solr):
-            assert ed.is_daisy_encrypted() is False
-
-    def test_is_daisy_encrypted_not_in_solr(self):
-        ed = self._make_edition(ocaid="testitem00archive")
-        mock_solr = MagicMock()
-        mock_solr.get.return_value = None
-        with patch("openlibrary.plugins.upstream.models.get_solr", return_value=mock_solr):
-            assert ed.is_daisy_encrypted() is False
 
     def test_get_ia_meta_fields_no_external_identifier(self):
         ed = self._make_edition(ocaid="testitem00archive")

--- a/openlibrary/plugins/upstream/tests/test_models.py
+++ b/openlibrary/plugins/upstream/tests/test_models.py
@@ -2,6 +2,8 @@
 Capture some of the unintuitive aspects of Storage, Things, and Works
 """
 
+from unittest.mock import MagicMock, patch
+
 import web
 
 import openlibrary.core.lists.model as list_model
@@ -139,3 +141,82 @@ class TestGetAvatarUrl:
             }
         assert models.User.get_avatar_url("alice") == "https://archive.org/services/img/@alice-archive"
         assert models.User.get_avatar_url("bob") == "https://archive.org/services/img/@bob-archive"
+
+
+class TestEditionACS4Removal:
+    def setup_method(self, method):
+        web.ctx.site = MockSite()
+        models.setup()
+
+    def _make_edition(self, ocaid=None):
+        data = {"key": "/books/OL1M", "type": {"key": "/type/edition"}}
+        if ocaid:
+            data["ocaid"] = ocaid
+        web.ctx.site.save(data)
+        return web.ctx.site.get("/books/OL1M")
+
+    def test_get_lending_resource_id_bookreader(self):
+        ed = self._make_edition(ocaid="testitem00archive")
+        assert ed.get_lending_resource_id("bookreader") == "bookreader:testitem00archive"
+
+    def test_get_lending_resource_id_no_ocaid(self):
+        ed = self._make_edition()
+        assert ed.get_lending_resource_id("bookreader") is None
+
+    def test_get_lending_resource_id_acs4_returns_none(self):
+        ed = self._make_edition(ocaid="testitem00archive")
+        assert ed.get_lending_resource_id("epub") is None
+        assert ed.get_lending_resource_id("pdf") is None
+
+    def test_get_available_loans_no_ocaid(self):
+        ed = self._make_edition()
+        assert ed.get_available_loans() == []
+
+    def test_get_available_loans_returns_bookreader(self):
+        ed = self._make_edition(ocaid="testitem00archive")
+        with (
+            patch("openlibrary.core.lending.is_loaned_out", return_value=False),
+            patch("openlibrary.plugins.upstream.borrow.is_loaned_out", return_value=False),
+        ):
+            loans = ed.get_available_loans()
+        assert len(loans) == 1
+        assert loans[0]["resource_type"] == "bookreader"
+        assert loans[0]["resource_id"] == "bookreader:testitem00archive"
+
+    def test_get_available_loans_checked_out(self):
+        ed = self._make_edition(ocaid="testitem00archive")
+        with patch("openlibrary.core.lending.is_loaned_out", return_value=True):
+            loans = ed.get_available_loans()
+        assert loans == []
+
+    def test_is_daisy_encrypted_no_ocaid(self):
+        ed = self._make_edition()
+        assert ed.is_daisy_encrypted() is False
+
+    def test_is_daisy_encrypted_printdisabled(self):
+        ed = self._make_edition(ocaid="testitem00archive")
+        mock_solr = MagicMock()
+        mock_solr.get.return_value = {"key": "/books/OL1M", "ebook_access": "printdisabled"}
+        with patch("openlibrary.plugins.upstream.models.get_solr", return_value=mock_solr):
+            assert ed.is_daisy_encrypted() is True
+
+    def test_is_daisy_encrypted_borrowable(self):
+        ed = self._make_edition(ocaid="testitem00archive")
+        mock_solr = MagicMock()
+        mock_solr.get.return_value = {"key": "/books/OL1M", "ebook_access": "borrowable"}
+        with patch("openlibrary.plugins.upstream.models.get_solr", return_value=mock_solr):
+            assert ed.is_daisy_encrypted() is False
+
+    def test_is_daisy_encrypted_not_in_solr(self):
+        ed = self._make_edition(ocaid="testitem00archive")
+        mock_solr = MagicMock()
+        mock_solr.get.return_value = None
+        with patch("openlibrary.plugins.upstream.models.get_solr", return_value=mock_solr):
+            assert ed.is_daisy_encrypted() is False
+
+    def test_get_ia_meta_fields_no_external_identifier(self):
+        ed = self._make_edition(ocaid="testitem00archive")
+        with patch("openlibrary.core.ia.get_metadata", return_value={"collection": ["inlibrary"]}):
+            meta = ed.get_ia_meta_fields()
+        assert "external-identifier" not in meta
+        assert "collection" in meta

--- a/openlibrary/templates/books/daisy.html
+++ b/openlibrary/templates/books/daisy.html
@@ -18,14 +18,6 @@ $ daisy = "//archive.org/download/XXX/XXX_daisy.zip"
         <ul class="link">
             <li>$_("There isn't a DAISY file available for ")<a href="$page.key">$page.title</a></li>
         </ul>
-    $elif page.is_daisy_encrypted():
-        <div class="message locked">
-            <h2 class="sansserif">$_("This DAISY file is protected.")</h2>
-            <p>$_("It can only be opened on a specialized device with a key issued by the Library of Congress.")</p>
-        </div>
-        <ul class="link">
-            <li>$:_('<a href="%(daisy_url)s"><strong>Download the DAISY.zip</strong></a> for <a href="%(url)s">%(title)s</a>', daisy_url=daisy.replace('XXX', page.ocaid), url=page.key, title=websafe(page.title))</li>
-        </ul>
     $else:
         <ul class="link">
             <li>$:_('<a href="%(daisy_url)s"><strong>Download the DAISY.zip</strong></a> for <a href="%(url)s">%(title)s</a>', daisy_url=daisy.replace('XXX', page.ocaid), url=page.key, title=websafe(page.title))</li>
@@ -34,10 +26,7 @@ $ daisy = "//archive.org/download/XXX/XXX_daisy.zip"
 
     <p class="largest" style="margin-bottom: 0;"><strong>$_("Books for people who don't read print?")</strong></p>
     <p>$:_('The <a href="//archive.org">Internet Archive</a> is proud to be distributing over 1 million books free in a format called DAISY, designed for those of us who find it challenging to use regular printed media. ')</p>
-    $if page.is_daisy_encrypted():
-        <p>$:_('There are two types of DAISYs on Open Library: <i>open</i> and <i>protected</i>. Open DAISYs can be read by anyone in the world on many different devices. Protected DAISYs like this one can only be opened using a key issued by the <a href="http://www.loc.gov/nls/">Library of Congress NLS program</a>.')</p>
-    $else:
-        <p>$:_('There are two types of DAISYs on Open Library: <i>open</i> and <i>protected</i>. Open DAISYs can be read by anyone in the world on many different devices. Protected DAISYs can only be opened using a key issued by the <a href="http://www.loc.gov/nls/">Library of Congress NLS program</a>.')</p>
+    <p>$:_('There are two types of DAISYs on Open Library: <i>open</i> and <i>protected</i>. Open DAISYs can be read by anyone in the world on many different devices. Protected DAISYs can only be opened using a key issued by the <a href="http://www.loc.gov/nls/">Library of Congress NLS program</a>.')</p>
     <p><b><i>$_("Enjoy!")</i></b></p>
 
     <h3 class="collapse">&nbsp;</h3>


### PR DESCRIPTION
## Summary

Fixes part of #12431. ACS4 (Adobe Content Server 4) DRM is deprecated. This PR removes all remaining ACS4 call sites and simplifies the lending infrastructure to bookreader-only.

**`openlibrary/core/lending.py`**
- Remove `get_resource_id()` — confirmed zero callers, pure dead code
- Remove stale ACS4 comment block

**`openlibrary/plugins/upstream/models.py`**
- Remove `get_lending_resources()` and its `external-identifier` IA fetch
- Simplify `get_lending_resource_id()` to bookreader-only (returns `f"bookreader:{self.ocaid}"`)
- Simplify `_get_available_loans()` — returns a single bookreader loan record directly, no more ACS4 loop
- Replace `is_daisy_encrypted()` collection check with a synchronous OL Solr lookup for `ebook_access == "printdisabled"` (DAISY page is not a hot path)
- Remove `external-identifier` setdefault from `get_ia_meta_fields()`

**`openlibrary/plugins/upstream/borrow.py`**
- Remove `resource_pdf`/`resource_epub` ACS4 fields and pattern loop from `get_borrow_status()`
- Drop now-unused `re` import

## Files changed

- `openlibrary/core/lending.py`
- `openlibrary/plugins/upstream/models.py`
- `openlibrary/plugins/upstream/borrow.py`
- `openlibrary/plugins/upstream/tests/test_models.py`

## Test plan

- [ ] All 11 new `TestEditionACS4Removal` tests pass
- [ ] No regressions in upstream/tests or core/test_lending (91 passed; 3 pre-existing failures unrelated to this PR)
- [ ] `get_lending_resource_id("epub")` and `get_lending_resource_id("pdf")` now return `None` (ACS4 removed)
- [ ] `get_available_loans()` returns only a `bookreader` loan record
- [ ] `is_daisy_encrypted()` returns `True` only when Solr `ebook_access == "printdisabled"`
- [ ] Manual: DAISY page (`/books/OL{key}/daisy`) correctly shows "protected" message for printdisabled editions