### PR TITLE
fix: restore TSV format for ratings, reading-log, and covers data dumps

### DIFF
--- a/scripts/dump-covers-metadata.sql
+++ b/scripts/dump-covers-metadata.sql
@@ -12,4 +12,4 @@ COPY (
   -- By default in postgres, "2010-05-17T10:20:30" <= "2010-05-17" ->> FALSE
   -- We need to go up a day to get <= behaviour
   WHERE cover.created <= (:'upto'::date + '1 day'::interval)
-) TO stdout WITH (format csv, delimiter E'\t')
+) TO stdout 

--- a/scripts/dump-covers-metadata.sql
+++ b/scripts/dump-covers-metadata.sql
@@ -12,4 +12,4 @@ COPY (
   -- By default in postgres, "2010-05-17T10:20:30" <= "2010-05-17" ->> FALSE
   -- We need to go up a day to get <= behaviour
   WHERE cover.created <= (:'upto'::date + '1 day'::interval)
-) TO stdout 
+) TO stdout

--- a/scripts/dump-ratings.sql
+++ b/scripts/dump-ratings.sql
@@ -15,4 +15,4 @@ COPY (
   -- By default in postgres, "2010-05-17T10:20:30" <= "2010-05-17" ->> FALSE
   -- We need to go up a day to get <= behaviour
   WHERE ratings.created <= (:'upto'::date + '1 day'::interval)
-) TO stdout WITH (format csv, delimiter E'\t')
+) TO stdout 

--- a/scripts/dump-ratings.sql
+++ b/scripts/dump-ratings.sql
@@ -15,4 +15,4 @@ COPY (
   -- By default in postgres, "2010-05-17T10:20:30" <= "2010-05-17" ->> FALSE
   -- We need to go up a day to get <= behaviour
   WHERE ratings.created <= (:'upto'::date + '1 day'::interval)
-) TO stdout 
+) TO stdout

--- a/scripts/dump-reading-log.sql
+++ b/scripts/dump-reading-log.sql
@@ -17,4 +17,4 @@ COPY (
   -- By default in postgres, "2010-05-17T10:20:30" <= "2010-05-17" ->> FALSE
   -- We need to go up a day to get <= behaviour
   WHERE bookshelves_books.created <= (:'upto'::date + '1 day'::interval)
-) TO stdout 
+) TO stdout

--- a/scripts/dump-reading-log.sql
+++ b/scripts/dump-reading-log.sql
@@ -17,4 +17,4 @@ COPY (
   -- By default in postgres, "2010-05-17T10:20:30" <= "2010-05-17" ->> FALSE
   -- We need to go up a day to get <= behaviour
   WHERE bookshelves_books.created <= (:'upto'::date + '1 day'::interval)
-) TO stdout WITH (format csv, delimiter E'\t')
+) TO stdout 


### PR DESCRIPTION
## What does this PR achieve? fix

Closes #12504

### Technical
PostgreSQL's COPY ... TO stdout defaults to format text (true TSV)  tab-separated with backslash escaping for special characters.
The three dump scripts introduced after 2021 were using WITH (format csv, delimiter E'\t') instead, which is CSV mode with a tab delimiter. These two formats differ in how they handle fields containing special characters (tabs, newlines, quotes): CSV mode wraps them in double-quotes, while true TSV backslash-escapes them. This breaks downstream consumers that parse the dumps as standard TSV.

### Changes made:
Removed the WITH (format csv, delimiter E'\t') clause from:

- scripts/dump-ratings.sql
- scripts/dump-reading-log.sql
- scripts/dump-covers-metadata.sql

No Python changes, no schema changes, no migration needed. The Wikidata dump is excluded it has a separate fix in progress (#11439)
