### PR TITLE
fix: correct typo 'riased' → 'raised' in work.py comment

### DIFF
--- a/openlibrary/solr/updater/work.py
+++ b/openlibrary/solr/updater/work.py
@@ -182,7 +182,7 @@ def get_ia_collection_and_box_id(ia: str, data_provider: DataProvider) -> Option
     metadata = data_provider.get_metadata(ia)
     if metadata is None:
         # It's none when the IA id is not found/invalid.
-        # TODO: It would be better if get_metadata riased an error.
+        # TODO: It would be better if get_metadata raised an error.
         return None
     return {
         "boxid": set(get_list(metadata, "boxid")),


### PR DESCRIPTION
## Summary
- Fixes a typo in a code comment in `openlibrary/solr/updater/work.py` (line 185)
- `riased` → `raised`

## Changes
Single-line comment correction in `get_ia_collection_and_box_id`:

```python
# Before:
# TODO: It would be better if get_metadata riased an error.

# After:
# TODO: It would be better if get_metadata raised an error.
```

## Test plan
- [ ] No functional change — comment only

🤖 Generated with [Claude Code](https://claude.com/claude-code)