### PR TITLE
refactored subject_search and author_search to remove template-side network requests

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -944,10 +944,17 @@ class subject_search(delegate.page):
     path = '/search/subjects'
 
     def GET(self):
-        get_results = functools.partial(
-            self.get_results, request_label='SUBJECT_SEARCH'
+        i = web.input(q='', page=None)
+        q = i.q.strip()
+        results_per_page = 100
+        page = safeint(i.page, 1) if i.page else 1
+        offset = (page - 1) * results_per_page
+        response = (
+            self.get_results(q, offset=offset, limit=results_per_page, request_label='SUBJECT_SEARCH')
+            if q
+            else None
         )
-        return render_template('search/subjects', get_results)
+        return render_template('search/subjects', q, page, offset, results_per_page, response)
 
     def get_results(
         self,
@@ -972,8 +979,14 @@ class author_search(delegate.page):
     path = '/search/authors'
 
     def GET(self):
-        get_results = functools.partial(self.get_results, request_label='AUTHOR_SEARCH')
-        return render_template('search/authors', get_results)
+        i = web.input(q='', page=None, sort=None)
+        q = i.q.strip()
+        results_per_page = 100
+        page = safeint(i.page, 1) if i.page else 1
+        offset = (page - 1) * results_per_page
+        sort = i.sort or ''
+        results = self.get_results(q, offset=offset, limit=results_per_page, sort=sort, request_label='AUTHOR_SEARCH')
+        return render_template('search/authors', q, page, offset, results_per_page, sort, results)
 
     def get_results(
         self,

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -950,11 +950,15 @@ class subject_search(delegate.page):
         page = safeint(i.page, 1) if i.page else 1
         offset = (page - 1) * results_per_page
         response = (
-            self.get_results(q, offset=offset, limit=results_per_page, request_label='SUBJECT_SEARCH')
+            self.get_results(
+                q, offset=offset, limit=results_per_page, request_label='SUBJECT_SEARCH'
+            )
             if q
             else None
         )
-        return render_template('search/subjects', q, page, offset, results_per_page, response)
+        return render_template(
+            'search/subjects', q, page, offset, results_per_page, response
+        )
 
     def get_results(
         self,
@@ -985,8 +989,16 @@ class author_search(delegate.page):
         page = safeint(i.page, 1) if i.page else 1
         offset = (page - 1) * results_per_page
         sort = i.sort or ''
-        results = self.get_results(q, offset=offset, limit=results_per_page, sort=sort, request_label='AUTHOR_SEARCH')
-        return render_template('search/authors', q, page, offset, results_per_page, sort, results)
+        results = self.get_results(
+            q,
+            offset=offset,
+            limit=results_per_page,
+            sort=sort,
+            request_label='AUTHOR_SEARCH',
+        )
+        return render_template(
+            'search/authors', q, page, offset, results_per_page, sort, results
+        )
 
     def get_results(
         self,

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -956,9 +956,7 @@ class subject_search(delegate.page):
             if q
             else None
         )
-        return render_template(
-            'search/subjects', q, page, offset, results_per_page, response
-        )
+        return render_template('search/subjects', q, page, results_per_page, response)
 
     def get_results(
         self,
@@ -989,15 +987,19 @@ class author_search(delegate.page):
         page = safeint(i.page, 1) if i.page else 1
         offset = (page - 1) * results_per_page
         sort = i.sort or ''
-        results = self.get_results(
-            q,
-            offset=offset,
-            limit=results_per_page,
-            sort=sort,
-            request_label='AUTHOR_SEARCH',
+        results = (
+            self.get_results(
+                q,
+                offset=offset,
+                limit=results_per_page,
+                sort=sort,
+                request_label='AUTHOR_SEARCH',
+            )
+            if q
+            else None
         )
         return render_template(
-            'search/authors', q, page, offset, results_per_page, sort, results
+            'search/authors', q, page, results_per_page, sort, results
         )
 
     def get_results(

--- a/openlibrary/templates/search/authors.html
+++ b/openlibrary/templates/search/authors.html
@@ -1,4 +1,4 @@
-$def with (q, page, offset, results_per_page, sort, results)
+$def with (q, page, results_per_page, sort, results)
 
 $var title: $_('Search Open Library for "%(query)s"', query=q)
 
@@ -15,7 +15,7 @@ $var title: $_('Search Open Library for "%(query)s"', query=q)
     </form>
   </div>
 
-    $if q and results.error:
+    $if q and results and results.error:
         <strong>
             $for line in results.error.splitlines():
                 $line

--- a/openlibrary/templates/search/authors.html
+++ b/openlibrary/templates/search/authors.html
@@ -23,7 +23,7 @@ $var title: $_('Search Open Library for "%(query)s"', query=q)
                     <br>
         </strong>
 
-    $if q and not results.error:
+    $if q and results and not results.error:
         $if results.num_found:
             <div class="search-results-stats">$ungettext('%(count)s hit', '%(count)s hits', results.num_found, count=commify(results.num_found))
               $if results.num_found > 1:

--- a/openlibrary/templates/search/authors.html
+++ b/openlibrary/templates/search/authors.html
@@ -41,7 +41,7 @@ $var title: $_('Search Open Library for "%(query)s"', query=q)
               <div id="fulltext-search-suggestion" data-query="$q">
                   $:macros.LoadingIndicator(_("Checking Search Inside matches"))
               </div>
-       $if results.num_found:
+      $if results and results.num_found:
         <ul class="authorList list-books">
         $for doc in results.docs:
             $ n = doc['name']

--- a/openlibrary/templates/search/authors.html
+++ b/openlibrary/templates/search/authors.html
@@ -1,16 +1,6 @@
-$def with (get_results)
-
-$ q = query_param('q', '').strip()
-$ results_per_page = 100
-$ page = query_param('page')
-$if page:
-    $ page = int(page)
-$else:
-    $ page = 1
-$ offset = (page - 1) * results_per_page
+$def with (q, page, offset, results_per_page, sort, results)
 
 $var title: $_('Search Open Library for "%(query)s"', query=q)
-$ sort = query_param('sort', None)
 
 <div id="contentHead">
     <h1>$_("Search Authors")</h1>
@@ -24,8 +14,6 @@ $ sort = query_param('sort', None)
         $:render_template("search/searchbox", q=q)
     </form>
   </div>
-
-    $ results = get_results(q, offset=offset, limit=results_per_page, sort=sort)
 
     $if q and results.error:
         <strong>

--- a/openlibrary/templates/search/subjects.html
+++ b/openlibrary/templates/search/subjects.html
@@ -1,13 +1,5 @@
-$def with (get_results)
+$def with (q, page, offset, results_per_page, response)
 
-$ q = query_param('q', '').strip()
-$ results_per_page = 100
-$ page = query_param('page')
-$if page:
-    $ page = int(page)
-$else:
-    $ page = 1
-$ offset = (page - 1) * results_per_page
 $ url_map = { 'person': 'person:', 'place': 'place:', 'time': 'time:' }
 
 <div id="contentHead">
@@ -25,8 +17,7 @@ $ url_map = { 'person': 'person:', 'place': 'place:', 'time': 'time:' }
     </div>
 
 $if q:
-    $ response = get_results(q, offset=offset, limit=results_per_page)
-    $if not response.error:
+    $if response and not response.error:
         $if response.num_found:
             <p class="search-results-stats">$ungettext('%(count)s hit', '%(count)s hits', response.num_found, count=commify(response.num_found))</p>
         $else:

--- a/openlibrary/templates/search/subjects.html
+++ b/openlibrary/templates/search/subjects.html
@@ -1,4 +1,4 @@
-$def with (q, page, offset, results_per_page, response)
+$def with (q, page, results_per_page, response)
 
 $ url_map = { 'person': 'person:', 'place': 'place:', 'time': 'time:' }
 

--- a/openlibrary/templates/search/subjects.html
+++ b/openlibrary/templates/search/subjects.html
@@ -29,7 +29,7 @@ $if q:
                 $:macros.LoadingIndicator(_("Checking Search Inside matches"))
             </div>
 
-$if q and response.error:
+$if q and response and response.error:
     <strong>
         $for line in response.error.splitlines():
             $line
@@ -37,7 +37,7 @@ $if q and response.error:
                 <br>
     </strong>
 
-$if q and not response.error and response.num_found:
+$if q and response and not response.error and response.num_found:
     <ul class="subjectList">
     $for doc in response.docs:
         $ n = doc['name']


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #12527

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Follows the same pattern established by `list_search`. Previously, `subject_search.GET()` and `author_search.GET()` passed a `get_results` callable into the template, leaving the template responsible for calling it. This PR moves the `get_results` call into the Python GET() method and passes the result object directly to the template.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

- Visit /search/subjects?q=fiction (the results should render correctly)
- Visit /search/authors?q=rowling (the results should render correctly)
- Visit /search/subjects and /search/authors with no query (pages load without errors on the page or console)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="1225" height="588" alt="image" src="https://github.com/user-attachments/assets/bce95f05-36be-4e4c-95a6-1a91a7c1b591" />

<img width="1236" height="518" alt="image" src="https://github.com/user-attachments/assets/3a897547-c369-44fc-a443-3553f9daf2c6" />

For http://localhost:8080/search/authors 
<img width="1091" height="356" alt="image" src="https://github.com/user-attachments/assets/91711859-080d-4f8d-a4ea-49a4134441c8" />

For http://localhost:8080/search/authors
<img width="1080" height="345" alt="image" src="https://github.com/user-attachments/assets/6cee4d75-6623-4f50-a399-8d7562ef7e2d" />

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
