### PR TITLE
refactor: remove unused @public functions

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1009,29 +1009,6 @@ def get_recent_changes(*a, **kw):
         return _get_recentchanges(*a, **kw)
 
 
-@public
-def most_recent_change():
-    if 'cache_most_recent' in infogami.config.features:
-        v = web.ctx.site._request('/most_recent')
-        v.thing = web.ctx.site.get(v.key)
-        v.author = v.author and web.ctx.site.get(v.author)
-        v.created = client.parse_datetime(v.created)
-        return v
-    else:
-        return get_recent_changes(limit=1)[0]
-
-
-@public
-def get_cover_id(key):
-    try:
-        _, cat, oln = key.split('/')
-        return requests.get(
-            f"https://covers.openlibrary.org/{cat}/query?olid={oln}&limit=1"
-        ).json()[0]
-    except (IndexError, json.decoder.JSONDecodeError, TypeError, ValueError):
-        return None
-
-
 local_ip = None
 
 

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -359,16 +359,6 @@ def get_borrow_status(itemid, include_resources=True, include_ia=True, edition=N
 
 # ######### Public Functions
 @public
-def is_loan_available(edition, type) -> bool:
-    resource_id = edition.get_lending_resource_id(type)
-
-    if not resource_id:
-        return False
-
-    return not is_loaned_out(resource_id)
-
-
-@public
 def datetime_from_isoformat(expiry):
     """Returns datetime object, or None"""
     return None if expiry is None else parse_datetime(expiry)
@@ -380,19 +370,8 @@ def datetime_from_utc_timestamp(seconds):
 
 
 @public
-def can_return_resource_type(resource_type: str) -> bool:
-    """Returns true if this resource can be returned from the OL site."""
-    return resource_type.startswith("bookreader")
-
-
-@public
 def get_bookreader_stream_url(itemid: str) -> str:
     return bookreader_stream_base + "/" + itemid
-
-
-@public
-def get_bookreader_host() -> str:
-    return bookreader_host
 
 
 # ######### Helper Functions

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -140,28 +140,6 @@ class merge_work(delegate.page):
 
 @functools.cache
 @public
-def vendor_js():
-    pardir = os.path.pardir
-    path = os.path.abspath(
-        os.path.join(
-            __file__,
-            pardir,
-            pardir,
-            pardir,
-            pardir,
-            "static",
-            "upstream",
-            "js",
-            "vendor.js",
-        )
-    )
-    with open(path, "rb") as in_file:
-        digest = hashlib.md5(in_file.read()).hexdigest()
-    return "/static/upstream/js/vendor.js?v=" + digest
-
-
-@functools.cache
-@public
 def static_url(path):
     """Takes path relative to static/ and constructs url to that resource with hash."""
     pardir = os.path.pardir

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -691,5 +691,3 @@ class ActivityFeed:
             if isinstance(r["created"], str):  # `datetime` objects are stored in cache as strings
                 r["created"] = datetime.fromisoformat(r["created"])
         return results
-
-

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -554,12 +554,6 @@ class ReadingLog:
 
 
 @public
-def get_read_status(work_key, username):
-    work_id = extract_numeric_id_from_olid(work_key.split("/")[-1])
-    return Bookshelves.get_users_read_status_of_work(username, work_id)
-
-
-@public
 def add_read_statuses(username, works):
     work_ids = [extract_numeric_id_from_olid(work.key.split("/")[-1]) for work in works]
     results = Bookshelves.get_users_read_status_of_works(username, work_ids)
@@ -699,6 +693,3 @@ class ActivityFeed:
         return results
 
 
-@public
-def get_activity_feed(username):
-    return ActivityFeed.get_activity_feed(username)

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -272,12 +272,6 @@ def render_cached_macro(name: str, args: tuple, **kwargs):
 
 
 @public
-def get_error(name, *args):
-    """Return error with the given name from errors.tmpl template."""
-    return get_message_from_template("errors", name, args)
-
-
-@public
 def get_message(name: str, *args) -> str:
     """Return message with given name from messages.tmpl template"""
     return get_message_from_template("messages", name, args)
@@ -293,25 +287,6 @@ def get_message_from_template(
         return msg % args
     else:
         return msg
-
-
-@public
-def list_recent_pages(path, limit=100, offset=0):
-    """Lists all pages with name path/* in the order of last_modified."""
-    q = {}
-
-    q['key~'] = path + '/*'
-    # don't show /type/delete and /type/redirect
-    q['a:type!='] = '/type/delete'
-    q['b:type!='] = '/type/redirect'
-
-    q['sort'] = 'key'
-    q['limit'] = limit
-    q['offset'] = offset
-    q['sort'] = '-last_modified'
-    # queries are very slow with != conditions
-    # q['type'] != '/type/delete'
-    return web.ctx.site.get_many(web.ctx.site.things(q))
 
 
 @public
@@ -1556,11 +1531,6 @@ def render_once(key: str) -> bool:
 @public
 def today():
     return datetime.datetime.today()
-
-
-@public
-def to_datetime(time: str):
-    return datetime.datetime.fromisoformat(time)
 
 
 class HTMLTagRemover(HTMLParser):


### PR DESCRIPTION
## Summary

Closes #12535

Removes 11 unused \`@public\`-decorated functions confirmed to have no callers across \`.py\`, \`.html\`, and \`.js\` files after a full-text search:

- \`most_recent_change\`, \`get_cover_id\` — \`openlibrary/plugins/openlibrary/code.py\`
- \`is_loan_available\`, \`can_return_resource_type\`, \`get_bookreader_host\` — \`openlibrary/plugins/upstream/borrow.py\`
- \`vendor_js\` — \`openlibrary/plugins/upstream/code.py\`
- \`get_read_status\`, \`get_activity_feed\` public wrapper only — \`openlibrary/plugins/upstream/mybooks.py\`
- \`get_error\`, \`list_recent_pages\`, \`to_datetime\` — \`openlibrary/plugins/upstream/utils.py\`

**Notes:**
- The \`ActivityFeed.get_activity_feed\` class method is preserved — only the \`@public\` standalone wrapper delegating to it was removed.
- The \`get_cover_id\` in \`openlibrary/coverstore/code.py\` is a separate function and was not touched.
- \`databarView.html\` calls \`page.get_most_recent_change()\` which is a model method, not the removed standalone function.

## Test plan

- [ ] Verify CI passes (mypy, pre-commit hooks)
- [ ] Confirm no template or Python file references the removed function names

🤖 Generated with [Claude Code](https://claude.com/claude-code)