### PR TITLE
12487/feat/migrate list editions json to fastapi

### DIFF
--- a/openlibrary/fastapi/lists.py
+++ b/openlibrary/fastapi/lists.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Literal
 
-from fastapi import APIRouter, Path
+from fastapi import APIRouter, Path, Query, Response, HTTPException
 from fastapi.responses import Response
+from openlibrary.utils.request_context import site
+from openlibrary.core import formats
 
 router = APIRouter()
 
@@ -24,8 +26,101 @@ async def list_seeds():
     pass
 
 
-async def list_editions_json():
-    pass
+def fastapi_make_collection(request: Request, size: int, entries: list, limit: int, offset: int, key: str | None = None) -> dict:
+    d = {
+        "size": size,
+        "start": offset,
+        "end": offset + limit,
+        "entries": entries,
+        "links": {
+            "self": f"{request.url.path}{f"?{request.url.query}" if request.url.query else ""}",
+        },
+    }
+
+    if offset + len(entries) < size:
+        d["links"]["next"] = str(request.url.include_query_params(limit=limit, offset=offset + limit))
+
+    if offset > 0:
+        d["links"]["prev"] = str(request.url.include_query_params(limit=limit, offset=max(0, offset - limit)))
+
+    if key:
+        d["links"]["list"] = key
+
+    return d
+
+
+def _get_editions_response(request: Request, key: str, ext: str, limit: int, offset: int) -> Response:
+    lst = site.get().get(key)
+    if not lst:
+        raise HTTPException(status_code=404, detail="Editions not found")
+
+    all_editions = list(lst.get_editions())
+    editions = all_editions[offset : offset + limit]
+
+    response_data = fastapi_make_collection(
+        request=request,
+        size=len(all_editions),
+        entries=[e.dict() for e in editions],
+        limit=limit,
+        offset=offset,
+        key=key,
+    )
+
+    encoding = "yml" if ext in ("yml", "yaml") else "json"
+    content_type = 'text/yaml; charset="utf-8"' if encoding == "yml" else "application/json"
+
+    content = formats.dump(response_data, encoding)
+    return Response(content=content, media_type=content_type)
+
+
+@router.get("/lists/{olid}/editions.{ext}")
+def read_list_editions(
+    request: Request,
+    olid: str = Path(..., pattern=r"^OL\d+L$"),
+    ext: Literal["json", "yml", "yaml"] = Path(...),
+    limit: int = Query(50, ge=1, description="Number of editions to return"),
+    offset: int = Query(0, ge=0, description="Pagination offset"),
+):
+    key = f"/lists/{olid}"
+    return _get_editions_response(request, key, ext, limit, offset)
+
+
+@router.get("/people/{username}/lists/{olid}/editions.{ext}")
+def read_people_list_editions(
+    request: Request,
+    username: str = Path(...),
+    olid: str = Path(..., pattern=r"^OL\d+L$"),
+    ext: Literal["json", "yml", "yaml"] = Path(...),
+    limit: int = Query(50, ge=1),
+    offset: int = Query(0, ge=0),
+):
+    key = f"/people/{username}/lists/{olid}"
+    return _get_editions_response(request, key, ext, limit, offset)
+
+
+@router.get("/series/{olid}/editions.{ext}")
+def read_series_editions(
+    request: Request,
+    olid: str = Path(..., pattern=r"^OL\d+L$"),
+    ext: Literal["json", "yml", "yaml"] = Path(...),
+    limit: int = Query(50, ge=1),
+    offset: int = Query(0, ge=0),
+):
+    key = f"/series/{olid}"
+    return _get_editions_response(request, key, ext, limit, offset)
+
+
+@router.get("/people/{username}/series/{olid}/editions.{ext}")
+def read_people_series_editions(
+    request: Request,
+    username: str = Path(...),
+    olid: str = Path(..., pattern=r"^OL\d+L$"),
+    ext: Literal["json", "yml", "yaml"] = Path(...),
+    limit: int = Query(50, ge=1),
+    offset: int = Query(0, ge=0),
+):
+    key = f"/people/{username}/series/{olid}"
+    return _get_editions_response(request, key, ext, limit, offset)
 
 
 async def list_subjects_json():

--- a/openlibrary/fastapi/lists.py
+++ b/openlibrary/fastapi/lists.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from typing import Annotated, Literal
 
-from fastapi import APIRouter, Path, Query, Response, HTTPException
+from fastapi import APIRouter, HTTPException, Path, Query, Response
 from fastapi.responses import Response
-from openlibrary.utils.request_context import site
+
 from openlibrary.core import formats
+from openlibrary.utils.request_context import site
 
 router = APIRouter()
 
@@ -33,7 +34,7 @@ def fastapi_make_collection(request: Request, size: int, entries: list, limit: i
         "end": offset + limit,
         "entries": entries,
         "links": {
-            "self": f"{request.url.path}{f"?{request.url.query}" if request.url.query else ""}",
+            "self": f"{request.url.path}{f'?{request.url.query}' if request.url.query else ''}",
         },
     }
 

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -8,6 +8,7 @@ from typing import Literal, cast
 from urllib.parse import parse_qs
 
 import web
+from typing_extensions import deprecated
 
 import openlibrary.core.helpers as h
 from infogami.infobase import client, common
@@ -802,6 +803,7 @@ def get_list_editions(key, offset=0, limit=50, api=False):
         return editions
 
 
+@deprecated("migrated to fastapi")
 class list_editions_json(delegate.page):
     path = r"((?:/people/[^/]+)?/(?:lists|series)/OL\d+L)/editions"
     encoding = "json"
@@ -820,6 +822,7 @@ class list_editions_json(delegate.page):
         )
 
 
+@deprecated("migrated to fastapi")
 class list_editions_yaml(list_editions_json):
     encoding = "yml"
     content_type = 'text/yaml; charset="utf-8"'


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Part of epic #12487 (migrating lists endpoints). **Note: This is a subtask and does NOT close the epic.**

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
**Refactor** 
Migrates the `list_editions_json` and `list_editions_yaml` endpoints from `web.py` to FastAPI.

### Technical
<!-- What should be noted about the implementation? -->
- **Routing**: Unrolled the catch-all `web.py` regex into four explicit FastAPI routes.
- **Extensions**: Handled both `.json` and `.yaml` formats via a dynamic path parameter instead of relying on separate classes.
- **Pagination URLs**: Built a new `fastapi_make_collection` helper that uses FastAPI's `Request` object to generate relative `next`/`prev` links. This entirely bypasses the `web.ctx.env` dependency that causes crashes.
- **Legacy Code Isolation**: Left the original `get_list_editions` and `make_collection` functions completely untouched in `lists.py`. This ensures the old `localhost:8080` server stays alive for the required A/B comparison testing.
- **DB Fetch**: Swapped `web.ctx.site` for the modern `site.get()` ContextVar inside the FastAPI helper.
- Added the `@deprecated("migrated to fastapi")` decorator to the old `web.py` classes.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
**Manual Testing Instructions**

1. Spin up the local environment (`docker compose up`).
2. **Prerequisite:** Make sure you have at least one list in your local account. Log into `localhost:8080` and create a list with a few editions if you haven't already. 
3. Note your local username (e.g., `openlibrary`) and the ID of the list you just created (e.g., `OL1L`). 
4. Check the old `web.py` endpoint (replace `openlibrary` and `OL1L` with your details):
   ```bash
   curl -s "http://localhost:8080/people/openlibrary/lists/OL1L/editions.json?limit=2" | jq
   ```
5. Check the new FastAPI endpoint and verify the JSON shape and relative links match exactly:
   ```bash
   curl -s "http://localhost:18080/people/openlibrary/lists/OL1L/editions.json?limit=2" | jq
   ```
6. Verify 404 on bad OLIDs:
   ```bash
   curl -s -I "http://localhost:18080/people/openlibrary/lists/OL99999999999L/editions.json"
   ```
7. Verify 422 on invalid pagination parameters:
   ```bash
   curl -s "http://localhost:18080/people/openlibrary/lists/OL1L/editions.json?limit=-5"
   ```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A - Backend API migration only.

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->