### PR TITLE
Fix solr-updater and book page errors when invalid identifier

### DIFF
--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -290,6 +290,9 @@ class Edition(models.Edition):
 
                 id = id_map.get(name) or web.storage(name=name, label=name, url_format=None)
                 for v in value:
+                    if v is None:
+                        continue
+
                     d[id.name] = web.storage(
                         name=id.name,
                         label=id.label,

--- a/openlibrary/solr/updater/edition.py
+++ b/openlibrary/solr/updater/edition.py
@@ -279,7 +279,9 @@ class EditionSolrBuilder(AbstractSolrBuilder):
                 logger.warning(f'Bad identifier on {self.key}: "{key}"')
                 continue
 
-            identifiers[f"id_{solr_key}"] = uniq(v.strip() for v in id_list)
+            # Sometimes v can be None? So filter that out
+            if values := uniq(v.strip() for v in id_list if v):
+                identifiers[f"id_{solr_key}"] = values
         return identifiers
 
     @cached_property

--- a/openlibrary/tests/solr/updater/test_edition.py
+++ b/openlibrary/tests/solr/updater/test_edition.py
@@ -1,7 +1,7 @@
 import pytest
 
-from openlibrary.solr.updater.edition import EditionSolrUpdater
-from openlibrary.tests.solr.test_update import FakeDataProvider
+from openlibrary.solr.updater.edition import EditionSolrBuilder, EditionSolrUpdater
+from openlibrary.tests.solr.test_update import FakeDataProvider, make_edition
 
 
 class TestEditionSolrUpdater:
@@ -26,3 +26,17 @@ class TestEditionSolrUpdater:
         assert req.deletes == []
         assert req.adds == []
         assert new_keys == ["/works/OL1M"]
+
+
+class TestEditionSolrBuilder:
+    def test_identifiers(self):
+        edition = make_edition(
+            identifiers={
+                "Some.Weird.Key##": ["  id-1  ", None, "id-1", "id-2  "],
+                "foo": [None],
+            }
+        )
+
+        assert EditionSolrBuilder(edition).identifiers == {
+            "id_some_weird_key": ["id-1", "id-2"],
+        }


### PR DESCRIPTION
Part of #12546 . Handles making solr-updater and the book page resilient to `None` identifiers.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Now renders correctly on testing: https://testing.openlibrary.org/works/OL45259313W/Yely%27s_Holiday_Traditions
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
