### PR TITLE
fix(i18n): auto-update POT-Creation-Date only when message set changes

### DIFF
--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -202,10 +202,13 @@ def extract_messages(sources: list[str], verbose: bool, skip_untracked: bool):
     # which was the original source of merge conflicts (see #12463).
     creation_date = datetime.now(UTC)
     if os.path.exists(path):
-        with open(path, "rb") as f:
-            existing = read_po(f)
-        if {msg.id for msg in existing if msg.id} == {msg.id for msg in catalog if msg.id}:
-            creation_date = existing.creation_date
+        try:
+            with open(path, "rb") as f:
+                existing = read_po(f)
+            if {msg.id for msg in existing if msg.id} == {msg.id for msg in catalog if msg.id}:
+                creation_date = existing.creation_date
+        except Exception:
+            pass  # malformed POT (e.g. conflict markers) — regenerate with current timestamp
     catalog.creation_date = creation_date
 
     with open(path, "wb") as f:

--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -4,7 +4,7 @@ import shutil
 import subprocess
 import sys
 from collections.abc import Iterator
-from datetime import datetime
+from datetime import UTC, datetime
 from io import BytesIO
 from pathlib import Path
 
@@ -150,13 +150,9 @@ def extract_templetor(fileobj, keywords, comment_tags, options):
 
 
 def extract_messages(sources: list[str], verbose: bool, skip_untracked: bool):
-    # The creation date is hard-coded to prevent merge conflicts from i18n auto-updates.
-    # Occasional manual bumps are fine to make it more up-to-date
-    fixed_creation_date = datetime.fromisoformat("2026-04-28 18:58-0400")
     catalog = Catalog(
         project="Open Library",
         copyright_holder="Internet Archive",
-        creation_date=fixed_creation_date,
     )
     METHODS = [("**.py", "python"), ("**.html", "openlibrary.i18n:extract_templetor")]
     COMMENT_TAGS = ["NOTE:"]
@@ -200,6 +196,18 @@ def extract_messages(sources: list[str], verbose: bool, skip_untracked: bool):
                 print(f"{count}\t{file_path}", file=sys.stderr)
 
     path = os.path.join(root, "messages.pot")
+
+    # Preserve the existing creation_date if the message set hasn't changed.
+    # This prevents spurious date bumps from CI runs that don't add/remove strings,
+    # which was the original source of merge conflicts (see #12463).
+    creation_date = datetime.now(UTC)
+    if os.path.exists(path):
+        with open(path, "rb") as f:
+            existing = read_po(f)
+        if {msg.id for msg in existing if msg.id} == {msg.id for msg in catalog if msg.id}:
+            creation_date = existing.creation_date
+    catalog.creation_date = creation_date
+
     with open(path, "wb") as f:
         write_po(f, catalog, include_lineno=False)
 

--- a/openlibrary/i18n/test_extract_messages.py
+++ b/openlibrary/i18n/test_extract_messages.py
@@ -1,0 +1,82 @@
+from datetime import UTC, datetime
+
+import pytest
+from babel.messages.pofile import read_po, write_po
+
+from openlibrary import i18n
+
+
+@pytest.fixture
+def extract_env(monkeypatch, tmp_path):
+    """Isolated directory for extract_messages tests.
+
+    Creates empty openlibrary/templates/ and openlibrary/macros/ under tmp_path
+    and chdirs there so the pinned paths in extract_messages resolve to those
+    empty dirs instead of the real source tree.
+    """
+    (tmp_path / "openlibrary" / "templates").mkdir(parents=True)
+    (tmp_path / "openlibrary" / "macros").mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(i18n, "root", str(tmp_path))
+    return tmp_path
+
+
+def _stamp_old_date(pot_path):
+    """Overwrite creation_date in an existing POT file with a known old date."""
+    known_old = datetime(2020, 1, 1, tzinfo=UTC)
+    with open(pot_path, "rb") as f:
+        cat = read_po(f)
+    cat.creation_date = known_old
+    with open(pot_path, "wb") as f:
+        write_po(f, cat, include_lineno=False)
+    return known_old
+
+
+def test_extract_messages_preserves_creation_date_when_unchanged(extract_env):
+    tmp = extract_env
+    src = tmp / "src"
+    src.mkdir()
+    (src / "views.py").write_text('_("test_unique_i18n_12463")\n')
+
+    i18n.extract_messages([str(src)], verbose=False, skip_untracked=False)
+    known_old = _stamp_old_date(tmp / "messages.pot")
+
+    # Second run with identical source — date must be preserved
+    i18n.extract_messages([str(src)], verbose=False, skip_untracked=False)
+
+    with open(tmp / "messages.pot", "rb") as f:
+        assert read_po(f).creation_date == known_old
+
+
+def test_extract_messages_updates_creation_date_on_new_string(extract_env):
+    tmp = extract_env
+    src = tmp / "src"
+    src.mkdir()
+    src_file = src / "views.py"
+    src_file.write_text('_("test_unique_i18n_12463")\n')
+
+    i18n.extract_messages([str(src)], verbose=False, skip_untracked=False)
+    known_old = _stamp_old_date(tmp / "messages.pot")
+
+    # Add a new string — message set changes, so date must update
+    src_file.write_text('_("test_unique_i18n_12463")\n_("test_unique_i18n_12463_new")\n')
+    i18n.extract_messages([str(src)], verbose=False, skip_untracked=False)
+
+    with open(tmp / "messages.pot", "rb") as f:
+        assert read_po(f).creation_date != known_old
+
+
+def test_extract_messages_handles_malformed_pot(extract_env):
+    tmp = extract_env
+    src = tmp / "src"
+    src.mkdir()
+    (src / "views.py").write_text('_("test_unique_i18n_12463")\n')
+
+    # Write a corrupt POT file (e.g. git conflict markers)
+    (tmp / "messages.pot").write_bytes(b"<<<<<<< HEAD\nmalformed content\n=======\n>>>>>>> branch\n")
+
+    # Must not raise — falls back to regenerating with current timestamp
+    i18n.extract_messages([str(src)], verbose=False, skip_untracked=False)
+
+    with open(tmp / "messages.pot", "rb") as f:
+        assert read_po(f).creation_date is not None


### PR DESCRIPTION
## Summary

Fixes #12463. The `POT-Creation-Date` in `messages.pot` was hardcoded to a fixed timestamp to avoid merge conflicts from CI auto-regeneration, but this meant the date grew stale and translators couldn't tell how out of date a given `.po` file was.

- Instead of hardcoding a date, `extract_messages` now reads the existing `messages.pot` and compares message IDs between the current extraction and the existing file.
- If the message set is **unchanged**, the old `creation_date` is preserved — no diff, no merge conflict.
- If messages are **added or removed**, `creation_date` updates to the current UTC time, accurately reflecting when the template last changed.

This replaces the "occasional manual bump" workflow with a fully automatic mechanism. No more stale dates, no more merge conflicts.

## Test plan

- [ ] Run `scripts/i18n-messages extract` locally (inside Docker) with no template changes — confirm `messages.pot` header date is unchanged
- [ ] Add a new translatable string (e.g. a `_("test string")` in any template), re-run extract — confirm `POT-Creation-Date` updates to today's date
- [ ] Confirm CI `generate-pot` hook passes