### PR TITLE
chore(deps): consolidate Python security dependency upgrades

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiofiles==23.1.0
 amightygirl.paapi5-python-sdk==1.0.0
 APScheduler==3.11.0
 Babel==2.12.1
-beautifulsoup4==4.12.2
+beautifulsoup4==4.14.3
 eventer==0.1.1
 fastapi==0.119.0
 feedparser==6.0.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ python-multipart==0.0.26
 PyYAML==6.0.1
 qrcode==7.4.2
 requests==2.33.0
-sentry-sdk[fastapi]==2.49.0
+sentry-sdk[fastapi]==2.58.0
 simplejson==3.19.1
 statsd==4.0.1
 uvicorn[standard]==0.30.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ internetarchive==5.7.1
 isbnlib==3.10.14
 luqum==0.11.0
 lxml==4.9.4
-multipart==0.2.4
+multipart==1.2.2
 Pillow==10.4.0
 prometheus-fastapi-instrumentator==7.1.0
 psycopg2==2.9.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Babel==2.12.1
 beautifulsoup4==4.14.3
 eventer==0.1.1
 fastapi==0.119.0
-feedparser==6.0.11
+feedparser==6.0.12
 flup-py3==1.0.3
 Genshi==0.7.10
 git+https://github.com/ArchiveLabs/pyopds2.git@3d5b3b0f9d993b5385be013de105f98bb7d3b203

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ ijson==3.2.3
 internetarchive==5.7.1
 isbnlib==3.10.14
 luqum==0.11.0
-lxml==4.9.4
+lxml==6.1.0
 multipart==1.2.2
 Pillow==12.2.0
 prometheus-fastapi-instrumentator==7.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ pymarc==5.1.0
 python-amazon-paapi==6.2.0
 python-dateutil==2.8.2
 python-memcached==1.62
-python-multipart==0.0.21
+python-multipart==0.0.26
 PyYAML==6.0.1
 qrcode==7.4.2
 requests==2.33.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ isbnlib==3.10.14
 luqum==0.11.0
 lxml==4.9.4
 multipart==1.2.2
-Pillow==10.4.0
+Pillow==12.2.0
 prometheus-fastapi-instrumentator==7.1.0
 psycopg2==2.9.12
 pydantic==2.12.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ lxml==4.9.4
 multipart==0.2.4
 Pillow==10.4.0
 prometheus-fastapi-instrumentator==7.1.0
-psycopg2==2.9.6
+psycopg2==2.9.12
 pydantic==2.12.5
 pymarc==5.1.0
 python-amazon-paapi==6.2.0

--- a/scripts/monitoring/requirements.txt
+++ b/scripts/monitoring/requirements.txt
@@ -1,2 +1,2 @@
 APScheduler==3.11.0
-py-spy==0.4.0
+py-spy==0.4.2


### PR DESCRIPTION
## Summary

Consolidates 8 open Renovate PRs into a single tested and verified upgrade. All packages were installed and tested in Docker before opening this PR.

## Packages upgraded

| Package | Before | After | Severity | Closes |
|---------|--------|-------|----------|--------|
| psycopg2 | 2.9.6 | 2.9.12 | — | #10892 |
| beautifulsoup4 | 4.12.2 | 4.14.3 | — | #10807 |
| feedparser | 6.0.11 | 6.0.12 | — | #12564 |
| python-multipart | 0.0.21 | 0.0.26 | 🔴 High (CVE-2026-24486), 🟡 Medium (CVE-2026-40347) | #11741 |
| multipart | 0.2.4 | 1.2.2 | 🔴 Security | #12084 |
| Pillow | 10.4.0 | 12.2.0 | 🔴 High (CVE-2026-25990, CVSS 8.6) | #11848 |
| lxml | 4.9.4 | 6.1.0 | 🔴 High (CVE-2026-41066, CVSS 7.5) | #12424 |
| sentry-sdk | 2.49.0 | 2.58.0 | — | #11839 |

## 🔴 Security upgrades

**python-multipart 0.0.21 → 0.0.26** — Fixes CVE-2026-24486 (arbitrary file write via path traversal, CVSS 8.6) and CVE-2026-40347 (DoS via large multipart preamble/epilogue, CVSS 5.3). v0.0.23 removed `trust_x_headers` and `X-File-Name` fallback, but OL does not set those. Risk: low.

**multipart 0.2.4 → 1.2.2** — Major version, but no direct imports in the codebase; consumed indirectly via FastAPI middleware. Risk: medium. _What could go wrong_: file upload endpoints (batch import `/api/import`, cover uploads) could be affected if v1 changed how multipart data is exposed to FastAPI route handlers.

**Pillow 10.4.0 → 12.2.0** — Fixes CVE-2026-25990 (out-of-bounds write loading PSD images, CVSS 8.6). APIs used by OL — `Image.open`, `Image.LANCZOS`, `ImageOps.exif_transpose(in_place=True)`, `ImageDraw`, `ImageFont.truetype` — are stable and unchanged in 12.x. Risk: medium.

**lxml 4.9.4 → 6.1.0** — Fixes CVE-2026-41066 (XXE via `iterparse`/`ETCompatXMLParser`, CVSS 7.5). lxml 6.x changes `iterparse()` default from `resolve_entities=True` to `resolve_entities='internal'`. Impact analysis:
- `marc_xml.py` is the only caller using `iterparse()` without an explicit `resolve_entities` argument. It parses LoC MARC21 slim XML, which has no external entities — the stricter default is a security improvement with no functional change.
- All other callers (`importapi/code.py`, `catalog/get_ia.py`, `scripts/lc_marc_update.py`, tests) already pass `resolve_entities=False` explicitly.

## 🔧 Maintenance upgrades

**psycopg2 2.9.6 → 2.9.12** — Patch-only bump, bugfixes only. Risk: negligible.

**beautifulsoup4 4.12.2 → 4.14.3** — Minor version; stable public API, no removals. Risk: low.

**feedparser 6.0.11 → 6.0.12** — Patch bump; no API changes. Risk: negligible.

**sentry-sdk 2.49.0 → 2.58.0** — Minor version bump. OL uses internal APIs (`tracing_utils.add_query_source`, `record_sql_queries`, `utils.capture_internal_exceptions`) — all verified present and importable at 2.58.0. Risk: low.

## Testing

All packages installed cleanly in the running Docker container with no conflicts. Import verification passed for all packages including internal sentry APIs.

HTTP check: static assets return 200; no 500 errors in container logs.

Test results (run inside Docker):
- `openlibrary/catalog/marc/tests/` — **124 passed** (lxml `iterparse`)
- `openlibrary/coverstore/tests/` — **21 passed, 7 skipped** (Pillow)
- `openlibrary/plugins/importapi/` — **61 passed** (lxml `XMLParser`)
- Full remaining suite — **3318 passed, 1 xfailed**

**Total: 3524 tests, 0 failures.**

## Checklist

- [x] All packages install cleanly (no dependency conflicts)
- [x] All imports verified at new versions
- [x] App serves HTTP 200 (static assets confirmed)
- [x] 3524 tests passing, 0 failures
- [x] API compatibility verified per package
- [ ] CI passing

## References

Closes #10807, #10892, #11741, #11848, #12084, #12424, #11839, #12564