### PR TITLE
feat: index /type/page docs in Solr, add /search/pages endpoint

### DIFF
--- a/conf/solr/conf/managed-schema.xml
+++ b/conf/solr/conf/managed-schema.xml
@@ -134,6 +134,7 @@
     <field name="redirects" type="string" multiValued="true"/>
     <field name="has_fulltext" type="boolean"/>
     <field name="title" type="text_en_splitting"/>
+    <field name="body" type="text_en_splitting"/>
     <field name="title_suggest" type="text_general" multiValued="false"/>
     <field name="title_sort" type="text_title_sort" multiValued="false"/>
     <field name="subtitle" type="text_en_splitting"/>

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -1067,7 +1067,7 @@ msgstr ""
 msgid "Download Link"
 msgstr ""
 
-#: showmarc.html type/tag/index.html
+#: search/pages.html showmarc.html type/tag/index.html
 msgid "Next"
 msgstr ""
 
@@ -3414,7 +3414,8 @@ msgstr ""
 
 #: authors/index.html lib/nav_head.html lists/home.html publishers/index.html
 #: publishers/notfound.html publishers/view.html search/advancedsearch.html
-#: search/publishers.html search/searchbox.html type/local_id/view.html
+#: search/pages.html search/publishers.html search/searchbox.html
+#: type/local_id/view.html
 msgid "Search"
 msgstr ""
 
@@ -6687,6 +6688,29 @@ msgstr ""
 msgid "No <strong>lists</strong> directly matched your search"
 msgstr ""
 
+#: search/pages.html
+msgid "Page search results"
+msgstr ""
+
+#: search/pages.html
+msgid "Search is temporarily unavailable. Please try again shortly."
+msgstr ""
+
+#: search/pages.html
+#, python-format
+msgid "%(count)s result"
+msgid_plural "%(count)s results"
+msgstr[0] ""
+msgstr[1] ""
+
+#: search/pages.html type/tag/index.html
+msgid "Previous"
+msgstr ""
+
+#: search/pages.html
+msgid "No <strong>page</strong> results found for your search"
+msgstr ""
+
 #: search/publishers.html
 msgid "Publishers Search"
 msgstr ""
@@ -7678,10 +7702,6 @@ msgstr ""
 
 #: type/tag/index.html
 msgid "View subject page"
-msgstr ""
-
-#: type/tag/index.html
-msgid "Previous"
 msgstr ""
 
 #: type/tag/index.html

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -934,7 +934,9 @@ class page_search(delegate.page):
             rows=limit,
             request_label='PAGE_SEARCH',
         )
-        return render_template('search/pages', q=i.q, resp=resp, offset=offset, limit=limit)
+        return render_template(
+            'search/pages', q=i.q, resp=resp, offset=offset, limit=limit
+        )
 
 
 # searches for lists and returns results in html format

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -35,6 +35,7 @@ from openlibrary.plugins.worksearch.schemes import SearchScheme
 from openlibrary.plugins.worksearch.schemes.authors import AuthorSearchScheme
 from openlibrary.plugins.worksearch.schemes.editions import EditionSearchScheme
 from openlibrary.plugins.worksearch.schemes.lists import ListSearchScheme
+from openlibrary.plugins.worksearch.schemes.pages import PageSearchScheme
 from openlibrary.plugins.worksearch.schemes.subjects import SubjectSearchScheme
 from openlibrary.plugins.worksearch.schemes.works import (
     WorkSearchScheme,
@@ -918,6 +919,23 @@ class ListSearchRequest:
             api=i.get('api', ''),
         )
 
+
+
+class page_search(delegate.page):
+    path = '/search/pages'
+
+    def GET(self):
+        i = web.input(q='', offset='0', limit='10')
+        offset = min(safeint(i.offset, 0), 10_000)
+        limit = min(safeint(i.limit, 10), 100)
+        resp = run_solr_query(
+            PageSearchScheme(),
+            {'q': i.q},
+            offset=offset,
+            rows=limit,
+            request_label='PAGE_SEARCH',
+        )
+        return render_template('search/pages', q=i.q, resp=resp, offset=offset, limit=limit)
 
 # searches for lists and returns results in html format
 class list_search(delegate.page):

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -920,7 +920,6 @@ class ListSearchRequest:
         )
 
 
-
 class page_search(delegate.page):
     path = '/search/pages'
 
@@ -936,6 +935,7 @@ class page_search(delegate.page):
             request_label='PAGE_SEARCH',
         )
         return render_template('search/pages', q=i.q, resp=resp, offset=offset, limit=limit)
+
 
 # searches for lists and returns results in html format
 class list_search(delegate.page):

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -925,17 +925,22 @@ class page_search(delegate.page):
 
     def GET(self):
         i = web.input(q='', offset='0', limit='10')
+        q = i.q.strip()
         offset = min(safeint(i.offset, 0), 10_000)
         limit = min(safeint(i.limit, 10), 100)
-        resp = run_solr_query(
-            PageSearchScheme(),
-            {'q': i.q},
-            offset=offset,
-            rows=limit,
-            request_label='PAGE_SEARCH',
+        resp = (
+            run_solr_query(
+                PageSearchScheme(),
+                {'q': q},
+                offset=offset,
+                rows=limit,
+                request_label='PAGE_SEARCH',
+            )
+            if q
+            else None
         )
         return render_template(
-            'search/pages', q=i.q, resp=resp, offset=offset, limit=limit
+            'search/pages', q=q, resp=resp, offset=offset, limit=limit
         )
 
 

--- a/openlibrary/plugins/worksearch/schemes/pages.py
+++ b/openlibrary/plugins/worksearch/schemes/pages.py
@@ -1,0 +1,51 @@
+import logging
+import typing
+from types import MappingProxyType
+
+from openlibrary.plugins.worksearch.schemes import SearchScheme
+
+if typing.TYPE_CHECKING:
+    from openlibrary.fastapi.models import SolrInternalsParams
+
+logger = logging.getLogger("openlibrary.worksearch")
+
+
+class PageSearchScheme(SearchScheme):
+    universe = frozenset(['type:page'])
+    all_fields = frozenset(
+        {
+            'key',
+            'title',
+            'body',
+            'last_modified',
+        }
+    )
+    non_solr_fields = frozenset()
+    facet_fields = frozenset()
+    field_name_map = MappingProxyType({})
+    sorts = MappingProxyType({})
+    default_fetched_fields = frozenset({'key', 'title'})
+    facet_rewrites = MappingProxyType({})
+
+    def q_to_solr_params(
+        self,
+        q: str,
+        solr_fields: set[str],
+        cur_solr_params: list[tuple[str, str]],
+        highlight: bool = False,
+        solr_internals_params: 'SolrInternalsParams | None' = None,
+    ) -> list[tuple[str, str]]:
+        universe_terms = sorted(self.universe)
+        universe_filter = (
+            universe_terms[0]
+            if len(universe_terms) == 1
+            else f"({' OR '.join(universe_terms)})"
+        )
+        return [
+            ('q', q),
+            ('q.op', 'AND'),
+            ('defType', 'edismax'),
+            # Search body and title, boosting title matches
+            ('qf', 'body title^5'),
+            ('fq', universe_filter),
+        ]

--- a/openlibrary/plugins/worksearch/schemes/pages.py
+++ b/openlibrary/plugins/worksearch/schemes/pages.py
@@ -11,20 +11,20 @@ logger = logging.getLogger("openlibrary.worksearch")
 
 
 class PageSearchScheme(SearchScheme):
-    universe = frozenset(['type:page'])
+    universe = frozenset(["type:page"])
     all_fields = frozenset(
         {
-            'key',
-            'title',
-            'body',
-            'last_modified',
+            "key",
+            "title",
+            "body",
+            "last_modified",
         }
     )
     non_solr_fields = frozenset()
     facet_fields = frozenset()
     field_name_map = MappingProxyType({})
     sorts = MappingProxyType({})
-    default_fetched_fields = frozenset({'key', 'title'})
+    default_fetched_fields = frozenset({"key", "title"})
     facet_rewrites = MappingProxyType({})
 
     def q_to_solr_params(
@@ -33,19 +33,15 @@ class PageSearchScheme(SearchScheme):
         solr_fields: set[str],
         cur_solr_params: list[tuple[str, str]],
         highlight: bool = False,
-        solr_internals_params: 'SolrInternalsParams | None' = None,
+        solr_internals_params: "SolrInternalsParams | None" = None,
     ) -> list[tuple[str, str]]:
         universe_terms = sorted(self.universe)
-        universe_filter = (
-            universe_terms[0]
-            if len(universe_terms) == 1
-            else f"({' OR '.join(universe_terms)})"
-        )
+        universe_filter = universe_terms[0] if len(universe_terms) == 1 else f"({' OR '.join(universe_terms)})"
         return [
-            ('q', q),
-            ('q.op', 'AND'),
-            ('defType', 'edismax'),
+            ("q", q),
+            ("q.op", "AND"),
+            ("defType", "edismax"),
             # Search body and title, boosting title matches
-            ('qf', 'body title^5'),
-            ('fq', universe_filter),
+            ("qf", "body title^5"),
+            ("fq", universe_filter),
         ]

--- a/openlibrary/plugins/worksearch/schemes/pages.py
+++ b/openlibrary/plugins/worksearch/schemes/pages.py
@@ -23,7 +23,13 @@ class PageSearchScheme(SearchScheme):
     non_solr_fields = frozenset()
     facet_fields = frozenset()
     field_name_map = MappingProxyType({})
-    sorts = MappingProxyType({})
+    sorts = MappingProxyType(
+        {
+            "random": "random_1 asc",
+            "random asc": "random_1 asc",
+            "random desc": "random_1 desc",
+        }
+    )
     default_fetched_fields = frozenset({"key", "title"})
     facet_rewrites = MappingProxyType({})
 
@@ -35,13 +41,10 @@ class PageSearchScheme(SearchScheme):
         highlight: bool = False,
         solr_internals_params: "SolrInternalsParams | None" = None,
     ) -> list[tuple[str, str]]:
-        universe_terms = sorted(self.universe)
-        universe_filter = universe_terms[0] if len(universe_terms) == 1 else f"({' OR '.join(universe_terms)})"
         return [
             ("q", q),
             ("q.op", "AND"),
             ("defType", "edismax"),
             # Search body and title, boosting title matches
             ("qf", "body title^5"),
-            ("fq", universe_filter),
         ]

--- a/openlibrary/solr/update.py
+++ b/openlibrary/solr/update.py
@@ -17,6 +17,7 @@ from openlibrary.solr.updater.abstract import AbstractSolrUpdater
 from openlibrary.solr.updater.author import AuthorSolrUpdater
 from openlibrary.solr.updater.edition import EditionSolrUpdater
 from openlibrary.solr.updater.list import ListSolrUpdater
+from openlibrary.solr.updater.page import PageSolrUpdater
 from openlibrary.solr.updater.work import WorkSolrUpdater
 from openlibrary.solr.utils import (
     SolrUpdateRequest,
@@ -44,6 +45,7 @@ def get_solr_updaters() -> list[AbstractSolrUpdater]:
         WorkSolrUpdater(data_provider),
         AuthorSolrUpdater(data_provider),
         ListSolrUpdater(data_provider),
+        PageSolrUpdater(data_provider),
     ]
 
 

--- a/openlibrary/solr/updater/page.py
+++ b/openlibrary/solr/updater/page.py
@@ -1,4 +1,3 @@
-from openlibrary.solr.solr_types import SolrDocument
 from openlibrary.solr.updater.abstract import AbstractSolrBuilder, AbstractSolrUpdater
 from openlibrary.solr.utils import SolrUpdateRequest
 
@@ -67,8 +66,8 @@ class PageSolrBuilder(AbstractSolrBuilder):
             return last_mod if last_mod.endswith("Z") else last_mod + "Z"
         return None
 
-    def build(self) -> SolrDocument:
-        doc: SolrDocument = {
+    def build(self) -> dict:
+        doc: dict = {
             "key": self.key,
             "type": self.type,
         }

--- a/openlibrary/solr/updater/page.py
+++ b/openlibrary/solr/updater/page.py
@@ -25,9 +25,7 @@ class PageSolrUpdater(AbstractSolrUpdater):
             "/search",
             "/admin",
         )
-        return key.startswith("/") and not any(
-            key.startswith(p) for p in EXCLUDED
-        )
+        return key.startswith("/") and not any(key.startswith(p) for p in EXCLUDED)
 
     async def update_key(self, thing: dict) -> tuple[SolrUpdateRequest, list[str]]:
         if thing.get("type", {}).get("key") != "/type/page":

--- a/openlibrary/solr/updater/page.py
+++ b/openlibrary/solr/updater/page.py
@@ -1,0 +1,83 @@
+from openlibrary.solr.solr_types import SolrDocument
+from openlibrary.solr.updater.abstract import AbstractSolrBuilder, AbstractSolrUpdater
+from openlibrary.solr.utils import SolrUpdateRequest
+
+
+class PageSolrUpdater(AbstractSolrUpdater):
+    key_prefix = "/"
+    thing_type = "/type/page"
+
+    def key_test(self, key: str) -> bool:
+        # Exclude all known non-page key prefixes. The type check in
+        # update_key() is the authoritative guard; this is a fast pre-filter.
+        EXCLUDED = (
+            "/type/",
+            "/works/",
+            "/books/",
+            "/authors/",
+            "/people/",
+            "/lists/",
+            "/series/",
+            "/subjects/",
+            "/languages/",
+            "/publishers/",
+            "/collections/",
+            "/search",
+            "/admin",
+        )
+        return key.startswith("/") and not any(
+            key.startswith(p) for p in EXCLUDED
+        )
+
+    async def update_key(self, thing: dict) -> tuple[SolrUpdateRequest, list[str]]:
+        if thing.get("type", {}).get("key") != "/type/page":
+            return SolrUpdateRequest(), []
+        doc = PageSolrBuilder(thing).build()
+        return SolrUpdateRequest(adds=[doc]), []
+
+
+class PageSolrBuilder(AbstractSolrBuilder):
+    def __init__(self, page: dict):
+        self._page = page
+
+    @property
+    def key(self) -> str:
+        return self._page["key"]
+
+    @property
+    def type(self) -> str:
+        return "page"
+
+    @property
+    def title(self) -> str | None:
+        return self._page.get("title")
+
+    @property
+    def body(self) -> str | None:
+        body = self._page.get("body")
+        if isinstance(body, dict):
+            return body.get("value")
+        return body
+
+    @property
+    def last_modified(self) -> str | None:
+        last_mod = self._page.get("last_modified")
+        if isinstance(last_mod, dict):
+            value = last_mod["value"]
+            return value if value.endswith("Z") else value + "Z"
+        elif isinstance(last_mod, str):
+            return last_mod if last_mod.endswith("Z") else last_mod + "Z"
+        return None
+
+    def build(self) -> SolrDocument:
+        doc: SolrDocument = {
+            "key": self.key,
+            "type": self.type,
+        }
+        if self.title is not None:
+            doc["title"] = self.title
+        if self.body is not None:
+            doc["body"] = self.body
+        if self.last_modified is not None:
+            doc["last_modified"] = self.last_modified
+        return doc

--- a/openlibrary/solr/updater/page.py
+++ b/openlibrary/solr/updater/page.py
@@ -1,3 +1,6 @@
+from typing import cast
+
+from openlibrary.solr.solr_types import SolrDocument
 from openlibrary.solr.updater.abstract import AbstractSolrBuilder, AbstractSolrUpdater
 from openlibrary.solr.utils import SolrUpdateRequest
 
@@ -7,8 +10,6 @@ class PageSolrUpdater(AbstractSolrUpdater):
     thing_type = "/type/page"
 
     def key_test(self, key: str) -> bool:
-        # Exclude all known non-page key prefixes. The type check in
-        # update_key() is the authoritative guard; this is a fast pre-filter.
         EXCLUDED = (
             "/type/",
             "/works/",
@@ -60,21 +61,11 @@ class PageSolrBuilder(AbstractSolrBuilder):
     def last_modified(self) -> str | None:
         last_mod = self._page.get("last_modified")
         if isinstance(last_mod, dict):
-            value = last_mod["value"]
-            return value if value.endswith("Z") else value + "Z"
+            value = last_mod.get("value")
+            return (value + "Z") if value and not value.endswith("Z") else value
         elif isinstance(last_mod, str):
             return last_mod if last_mod.endswith("Z") else last_mod + "Z"
         return None
 
-    def build(self) -> dict:
-        doc: dict = {
-            "key": self.key,
-            "type": self.type,
-        }
-        if self.title is not None:
-            doc["title"] = self.title
-        if self.body is not None:
-            doc["body"] = self.body
-        if self.last_modified is not None:
-            doc["last_modified"] = self.last_modified
-        return doc
+    def build(self) -> SolrDocument:
+        return cast(SolrDocument, super().build())

--- a/openlibrary/templates/search/pages.html
+++ b/openlibrary/templates/search/pages.html
@@ -30,9 +30,9 @@ $:macros.SearchNavigation()
 
     <div class="search-results-nav">
       $if offset > 0:
-        <a href="/search/pages?q=$q&offset=$(offset - limit)&limit=$limit">&laquo; $:_('Previous')</a>
+        <a href="/search/pages?q=$urlencode(q)&offset=$(offset - limit)&limit=$limit">&laquo; $:_('Previous')</a>
       $if offset + limit < resp.num_found:
-        <a href="/search/pages?q=$q&offset=$(offset + limit)&limit=$limit">$:_('Next') &raquo;</a>
+        <a href="/search/pages?q=$urlencode(q)&offset=$(offset + limit)&limit=$limit">$:_('Next') &raquo;</a>
     </div>
 
   $elif q:

--- a/openlibrary/templates/search/pages.html
+++ b/openlibrary/templates/search/pages.html
@@ -1,0 +1,43 @@
+$def with (q, resp=None, offset=0, limit=10)
+
+$var title: $_('Page search results')
+
+$:macros.SearchNavigation()
+
+<div id="contentBody">
+
+<form class="pageSearch searchInsideForm" action="/search/pages">
+    <input type="text" class="larger" name="q" value="$q"/>
+    <input type="submit" class="generic-button" value="$_('Search')">
+</form>
+
+  $if resp and resp.error:
+    <center>
+      <div class="red">$:_('Search is temporarily unavailable. Please try again shortly.')</div>
+    </center>
+  $elif q and resp and resp.num_found:
+    <div class="search-results-stats">
+      $ungettext('%(count)s result', '%(count)s results', resp.num_found, count=commify(resp.num_found))
+    </div>
+    <div class="mybooks-list">
+      <ul id="listResults" class="list-books">
+        $for doc in resp.docs:
+          <li class="searchResultItem">
+            <a href="$doc['key']">$doc.get('title', doc['key'])</a>
+          </li>
+      </ul>
+    </div>
+
+    <div class="search-results-nav">
+      $if offset > 0:
+        <a href="/search/pages?q=$q&offset=$(offset - limit)&limit=$limit">&laquo; $:_('Previous')</a>
+      $if offset + limit < resp.num_found:
+        <a href="/search/pages?q=$q&offset=$(offset + limit)&limit=$limit">$:_('Next') &raquo;</a>
+    </div>
+
+  $elif q:
+    <center>
+      <div class="red">$:_('No <strong>page</strong> results found for your search')</div>
+    </center>
+
+</div>

--- a/openlibrary/tests/solr/updater/test_page.py
+++ b/openlibrary/tests/solr/updater/test_page.py
@@ -1,0 +1,236 @@
+import pytest
+from unittest.mock import MagicMock
+
+from openlibrary.solr.updater.page import PageSolrBuilder, PageSolrUpdater
+from openlibrary.plugins.worksearch.schemes.pages import PageSearchScheme
+
+
+# ---------------------------------------------------------------------------
+# PageSolrBuilder
+# ---------------------------------------------------------------------------
+
+
+class TestPageSolrBuilder:
+    def _make(self, data: dict) -> PageSolrBuilder:
+        return PageSolrBuilder(data)
+
+    def test_build_full_document(self):
+        page = {
+            "key": "/librarians",
+            "type": {"key": "/type/page"},
+            "title": "Librarians",
+            "body": {"value": "Welcome to the librarians page."},
+            "last_modified": {"value": "2023-01-01T00:00:00"},
+        }
+        doc = self._make(page).build()
+        assert doc["key"] == "/librarians"
+        assert doc["type"] == "page"
+        assert doc["title"] == "Librarians"
+        assert doc["body"] == "Welcome to the librarians page."
+        assert doc["last_modified"] == "2023-01-01T00:00:00Z"
+
+    def test_body_as_plain_string(self):
+        page = {"key": "/about", "type": {"key": "/type/page"}, "body": "plain text"}
+        doc = self._make(page).build()
+        assert doc["body"] == "plain text"
+
+    def test_body_missing(self):
+        page = {"key": "/about", "type": {"key": "/type/page"}}
+        doc = self._make(page).build()
+        assert "body" not in doc
+
+    def test_title_missing(self):
+        page = {"key": "/about", "type": {"key": "/type/page"}}
+        doc = self._make(page).build()
+        assert "title" not in doc
+
+    def test_last_modified_as_dict(self):
+        page = {
+            "key": "/about",
+            "type": {"key": "/type/page"},
+            "last_modified": {"value": "2023-06-01T12:00:00"},
+        }
+        doc = self._make(page).build()
+        assert doc["last_modified"] == "2023-06-01T12:00:00Z"
+
+    def test_last_modified_as_plain_string_without_z(self):
+        page = {
+            "key": "/about",
+            "type": {"key": "/type/page"},
+            "last_modified": "2023-06-01T12:00:00",
+        }
+        doc = self._make(page).build()
+        assert doc["last_modified"] == "2023-06-01T12:00:00Z"
+
+    def test_last_modified_as_plain_string_already_has_z(self):
+        page = {
+            "key": "/about",
+            "type": {"key": "/type/page"},
+            "last_modified": "2023-06-01T12:00:00Z",
+        }
+        doc = self._make(page).build()
+        assert doc["last_modified"] == "2023-06-01T12:00:00Z"
+
+    def test_last_modified_missing(self):
+        page = {"key": "/about", "type": {"key": "/type/page"}}
+        doc = self._make(page).build()
+        assert "last_modified" not in doc
+
+    def test_type_is_always_page_string(self):
+        page = {"key": "/about", "type": {"key": "/type/page"}}
+        doc = self._make(page).build()
+        assert doc["type"] == "page"
+
+    def test_key_required(self):
+        page = {"key": "/help/faq", "type": {"key": "/type/page"}}
+        doc = self._make(page).build()
+        assert doc["key"] == "/help/faq"
+
+    def test_last_modified_as_dict_already_has_z(self):
+        page = {"key": "/about",
+                "type": {"key": "/type/page"},
+                "last_modified": {"value": "2023-06-01T12:00:00Z"},
+                }
+        doc = self._make(page).build()
+        assert doc["last_modified"] == "2023-06-01T12:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# PageSolrUpdater.key_test
+# ---------------------------------------------------------------------------
+
+
+class TestPageSolrUpdaterKeyTest:
+    def setup_method(self):
+        self.updater = PageSolrUpdater(data_provider=MagicMock())
+
+    def test_accepts_simple_page_key(self):
+        assert self.updater.key_test("/librarians") is True
+
+    def test_accepts_nested_page_key(self):
+        assert self.updater.key_test("/help/faq") is True
+
+    def test_rejects_works(self):
+        assert self.updater.key_test("/works/OL123W") is False
+
+    def test_rejects_books(self):
+        assert self.updater.key_test("/books/OL123M") is False
+
+    def test_rejects_authors(self):
+        assert self.updater.key_test("/authors/OL123A") is False
+
+    def test_rejects_type_prefix(self):
+        assert self.updater.key_test("/type/page") is False
+
+    def test_rejects_people(self):
+        assert self.updater.key_test("/people/testuser") is False
+
+    def test_rejects_lists(self):
+        assert self.updater.key_test("/lists/OL123L") is False
+
+    def test_rejects_languages(self):
+        assert self.updater.key_test("/languages/eng") is False
+
+    def test_rejects_subjects(self):
+        assert self.updater.key_test("/subjects/history") is False
+
+    def test_rejects_search(self):
+        assert self.updater.key_test("/search") is False
+
+    def test_rejects_admin(self):
+        assert self.updater.key_test("/admin/anything") is False
+
+    def test_rejects_series(self):
+        assert self.updater.key_test("/series/OL123S") is False
+
+    def test_rejects_publishers(self):
+        assert self.updater.key_test("/publishers/OL123P") is False
+
+    def test_rejects_collections(self):
+        assert self.updater.key_test("/collections/OL123C") is False
+
+# ---------------------------------------------------------------------------
+# PageSolrUpdater.update_key
+# ---------------------------------------------------------------------------
+
+
+class TestPageSolrUpdaterUpdateKey:
+    def setup_method(self):
+        self.updater = PageSolrUpdater(data_provider=MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_wrong_type(self):
+        thing = {"key": "/about", "type": {"key": "/type/work"}}
+        req, keys = await self.updater.update_key(thing)
+        assert req.adds == []
+        assert keys == []
+
+    @pytest.mark.asyncio
+    async def test_returns_doc_for_page_type(self):
+        thing = {
+            "key": "/about",
+            "type": {"key": "/type/page"},
+            "title": "About",
+            "body": {"value": "About Open Library."},
+        }
+        req, keys = await self.updater.update_key(thing)
+        assert len(req.adds) == 1
+        assert req.adds[0]["key"] == "/about"
+        assert req.adds[0]["title"] == "About"
+        assert keys == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_missing_type(self):
+        thing = {"key": "/about"}
+        req, keys = await self.updater.update_key(thing)
+        assert req.adds == []
+        assert keys == []
+
+# ---------------------------------------------------------------------------
+# PageSearchScheme
+# ---------------------------------------------------------------------------
+
+
+class TestPageSearchScheme:
+    def setup_method(self):
+        self.scheme = PageSearchScheme()
+
+    def test_universe_filters_to_type_page(self):
+        assert 'type:page' in self.scheme.universe
+
+    def test_q_to_solr_params_uses_edismax(self):
+        params = self.scheme.q_to_solr_params('librarians', set(), [])
+        param_dict = dict(params)
+        assert param_dict['defType'] == 'edismax'
+
+    def test_q_to_solr_params_searches_body_and_title(self):
+        params = self.scheme.q_to_solr_params('librarians', set(), [])
+        param_dict = dict(params)
+        assert 'body' in param_dict['qf']
+        assert 'title' in param_dict['qf']
+
+    def test_q_to_solr_params_uses_and_operator(self):
+        params = self.scheme.q_to_solr_params('help faq', set(), [])
+        param_dict = dict(params)
+        assert param_dict['q.op'] == 'AND'
+
+    def test_default_fetched_fields_excludes_body(self):
+        # body can be very large; it should not be fetched by default
+        assert 'body' not in self.scheme.default_fetched_fields
+
+    def test_default_fetched_fields_includes_key_and_title(self):
+        assert 'key' in self.scheme.default_fetched_fields
+        assert 'title' in self.scheme.default_fetched_fields
+
+    def test_no_facet_fields(self):
+        assert len(self.scheme.facet_fields) == 0
+
+    def test_q_to_solr_params_boosts_title(self):
+        params = self.scheme.q_to_solr_params('librarians', set(), [])
+        param_dict = dict(params)
+        assert 'title^5' in param_dict['qf']
+
+    def test_q_to_solr_params_filters_to_page_type(self):
+        params = self.scheme.q_to_solr_params('librarians', set(), [])
+        fq_values = [v for k, v in params if k == 'fq']
+        assert 'type:page' in fq_values

--- a/openlibrary/tests/solr/updater/test_page.py
+++ b/openlibrary/tests/solr/updater/test_page.py
@@ -1,9 +1,9 @@
-import pytest
 from unittest.mock import MagicMock
 
-from openlibrary.solr.updater.page import PageSolrBuilder, PageSolrUpdater
-from openlibrary.plugins.worksearch.schemes.pages import PageSearchScheme
+import pytest
 
+from openlibrary.plugins.worksearch.schemes.pages import PageSearchScheme
+from openlibrary.solr.updater.page import PageSolrBuilder, PageSolrUpdater
 
 # ---------------------------------------------------------------------------
 # PageSolrBuilder
@@ -87,10 +87,11 @@ class TestPageSolrBuilder:
         assert doc["key"] == "/help/faq"
 
     def test_last_modified_as_dict_already_has_z(self):
-        page = {"key": "/about",
-                "type": {"key": "/type/page"},
-                "last_modified": {"value": "2023-06-01T12:00:00Z"},
-                }
+        page = {
+            "key": "/about",
+            "type": {"key": "/type/page"},
+            "last_modified": {"value": "2023-06-01T12:00:00Z"},
+        }
         doc = self._make(page).build()
         assert doc["last_modified"] == "2023-06-01T12:00:00Z"
 
@@ -149,6 +150,7 @@ class TestPageSolrUpdaterKeyTest:
     def test_rejects_collections(self):
         assert self.updater.key_test("/collections/OL123C") is False
 
+
 # ---------------------------------------------------------------------------
 # PageSolrUpdater.update_key
 # ---------------------------------------------------------------------------
@@ -186,6 +188,7 @@ class TestPageSolrUpdaterUpdateKey:
         assert req.adds == []
         assert keys == []
 
+
 # ---------------------------------------------------------------------------
 # PageSearchScheme
 # ---------------------------------------------------------------------------
@@ -196,41 +199,41 @@ class TestPageSearchScheme:
         self.scheme = PageSearchScheme()
 
     def test_universe_filters_to_type_page(self):
-        assert 'type:page' in self.scheme.universe
+        assert "type:page" in self.scheme.universe
 
     def test_q_to_solr_params_uses_edismax(self):
-        params = self.scheme.q_to_solr_params('librarians', set(), [])
+        params = self.scheme.q_to_solr_params("librarians", set(), [])
         param_dict = dict(params)
-        assert param_dict['defType'] == 'edismax'
+        assert param_dict["defType"] == "edismax"
 
     def test_q_to_solr_params_searches_body_and_title(self):
-        params = self.scheme.q_to_solr_params('librarians', set(), [])
+        params = self.scheme.q_to_solr_params("librarians", set(), [])
         param_dict = dict(params)
-        assert 'body' in param_dict['qf']
-        assert 'title' in param_dict['qf']
+        assert "body" in param_dict["qf"]
+        assert "title" in param_dict["qf"]
 
     def test_q_to_solr_params_uses_and_operator(self):
-        params = self.scheme.q_to_solr_params('help faq', set(), [])
+        params = self.scheme.q_to_solr_params("help faq", set(), [])
         param_dict = dict(params)
-        assert param_dict['q.op'] == 'AND'
+        assert param_dict["q.op"] == "AND"
 
     def test_default_fetched_fields_excludes_body(self):
         # body can be very large; it should not be fetched by default
-        assert 'body' not in self.scheme.default_fetched_fields
+        assert "body" not in self.scheme.default_fetched_fields
 
     def test_default_fetched_fields_includes_key_and_title(self):
-        assert 'key' in self.scheme.default_fetched_fields
-        assert 'title' in self.scheme.default_fetched_fields
+        assert "key" in self.scheme.default_fetched_fields
+        assert "title" in self.scheme.default_fetched_fields
 
     def test_no_facet_fields(self):
         assert len(self.scheme.facet_fields) == 0
 
     def test_q_to_solr_params_boosts_title(self):
-        params = self.scheme.q_to_solr_params('librarians', set(), [])
+        params = self.scheme.q_to_solr_params("librarians", set(), [])
         param_dict = dict(params)
-        assert 'title^5' in param_dict['qf']
+        assert "title^5" in param_dict["qf"]
 
     def test_q_to_solr_params_filters_to_page_type(self):
-        params = self.scheme.q_to_solr_params('librarians', set(), [])
-        fq_values = [v for k, v in params if k == 'fq']
-        assert 'type:page' in fq_values
+        params = self.scheme.q_to_solr_params("librarians", set(), [])
+        fq_values = [v for k, v in params if k == "fq"]
+        assert "type:page" in fq_values

--- a/openlibrary/tests/solr/updater/test_page.py
+++ b/openlibrary/tests/solr/updater/test_page.py
@@ -232,8 +232,3 @@ class TestPageSearchScheme:
         params = self.scheme.q_to_solr_params("librarians", set(), [])
         param_dict = dict(params)
         assert "title^5" in param_dict["qf"]
-
-    def test_q_to_solr_params_filters_to_page_type(self):
-        params = self.scheme.q_to_solr_params("librarians", set(), [])
-        fq_values = [v for k, v in params if k == "fq"]
-        assert "type:page" in fq_values

--- a/openlibrary/utils/solr.py
+++ b/openlibrary/utils/solr.py
@@ -42,6 +42,7 @@ SolrRequestLabel = Literal[
     "SUBJECT_SEARCH_API",
     "AUTHOR_SEARCH",
     "AUTHOR_SEARCH_API",
+    "PAGE_SEARCH",
 ]
 
 


### PR DESCRIPTION
Partially Closes #7939 

### Technical
This PR adds the ability to search Open Library's `/type/page` documents through Solr (feature).

- Added a `body` field to Solr `managed-schema.xml` so page content can be indexed
- Created `PageSolrUpdater` and `PageSolrBuilder` to handle indexing `/type/page` docs, including edge cases for `body` and `last_modified` being either a dict or plain string
- Created `PageSearchScheme` that uses edismax to search both `body` and `title` fields, with title matches boosted 5x
- Added a `/search/pages` endpoint that caps offset at 10,000 and limit at 100 to avoid expensive Solr requests
- Added `PAGE_SEARCH` to `SolrRequestLabel`
- Added a `pages.html` template with error handling, result count, and Previous/Next pagination

### Testing
1. Start the dev server
2. Go to `/search/pages?q=librarians`
3. You should see results with links to matching page docs
4. To test pagination, try adding `&limit=1` to the URL and confirm Previous/Next links work
5. To run unit tests: `pytest openlibrary/tests/solr/updater/test_page.py -v`

### Screenshot
Search for "librarians" returning 1 result on `/search/pages`:

<img width="1002" height="670" alt="Screen Shot 2026-05-01 at 8 09 19 PM" src="https://github.com/user-attachments/assets/71060dee-e4bf-438c-8f21-ce20473c0f36" />


### Stakeholders
@mekarpeles @cdrini