### PR TITLE
chore(deps): consolidate Python dependency upgrades

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
       - id: validate-pyproject
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.9
+    rev: v0.15.12
     hooks:
       - id: ruff-check
         args: [--fix]

--- a/openlibrary/asgi_app.py
+++ b/openlibrary/asgi_app.py
@@ -163,6 +163,7 @@ def create_app() -> FastAPI | None:
         version="0.0.1",
         debug=os.environ.get("LOCAL_DEV", "false").lower() == "true",
         lifespan=lifespan,
+        strict_content_type=False,  # A breaking change and not applicable to our app. See: https://fastapi.tiangolo.com/advanced/strict-content-type/
     )
 
     app.add_middleware(

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ python-amazon-paapi==6.2.0
 python-dateutil==2.8.2
 python-memcached==1.62
 python-multipart==0.0.26
-PyYAML==6.0.1
+PyYAML==6.0.3
 qrcode==7.4.2
 requests==2.33.1
 sentry-sdk[fastapi]==2.58.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ APScheduler==3.11.2
 Babel==2.12.1
 beautifulsoup4==4.14.3
 eventer==0.1.1
-fastapi==0.119.0
+fastapi==0.136.1
 feedparser==6.0.12
 flup-py3==1.0.3
 Genshi==0.7.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ pymarc==5.1.0
 python-amazon-paapi==6.2.0
 python-dateutil==2.8.2
 python-memcached==1.62
-python-multipart==0.0.26
+python-multipart==0.0.27
 PyYAML==6.0.3
 qrcode==7.4.2
 requests==2.33.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ python-memcached==1.62
 python-multipart==0.0.26
 PyYAML==6.0.1
 qrcode==7.4.2
-requests==2.33.0
+requests==2.33.1
 sentry-sdk[fastapi]==2.58.0
 simplejson==3.19.1
 statsd==4.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiofiles==23.1.0
 amightygirl.paapi5-python-sdk==1.0.0
-APScheduler==3.11.0
+APScheduler==3.11.2
 Babel==2.12.1
 beautifulsoup4==4.14.3
 eventer==0.1.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -8,6 +8,6 @@ mypy==1.19.1
 pymemcache==4.0.0
 pytest==9.0.3
 pytest-asyncio==1.3.0
-pytest-httpx==0.36.0
+pytest-httpx==0.36.2
 ruff==0.15.12
 WebTest==3.0.7

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -9,5 +9,5 @@ pymemcache==4.0.0
 pytest==9.0.3
 pytest-asyncio==1.3.0
 pytest-httpx==0.36.0
-ruff==0.15.0
+ruff==0.15.12
 WebTest==3.0.7

--- a/scripts/gh_scripts/requirements.txt
+++ b/scripts/gh_scripts/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.33.0
+requests==2.33.1

--- a/scripts/monitoring/requirements.txt
+++ b/scripts/monitoring/requirements.txt
@@ -1,2 +1,2 @@
-APScheduler==3.11.0
+APScheduler==3.11.2
 py-spy==0.4.2


### PR DESCRIPTION
## Summary

Consolidates 7 open Renovate PRs into a single tested upgrade. All packages installed and verified in Docker (full OL stack with `OL_MOUNT_DIR` mount) before opening this PR.

---

## Packages upgraded

| Package | Before | After | Severity | Closes |
|---------|--------|-------|----------|--------|
| ruff | 0.15.0 | 0.15.12 | — | #12581 |
| pytest-httpx | 0.36.0 | 0.36.2 | — | #12577 |
| requests | 2.33.0 | 2.33.1 | — | #12580 |
| PyYAML | 6.0.1 | 6.0.3 | — | #12579 |
| python-multipart | 0.0.26 | 0.0.27 | — | #12578 |
| APScheduler | 3.11.0 | 3.11.2 | — | #12576 |
| fastapi | 0.119.0 | 0.136.1 | 🔴 Breaking change mitigated | #12522 |

---

## fastapi 0.119.0 → 0.136.1

Large minor jump (17 versions). fastapi v0.136+ makes `strict_content_type=True` the default — a breaking change that causes OL to reject requests without an explicit `Content-Type` header. Added `strict_content_type=False` to `create_app()` to preserve existing behavior. See: https://fastapi.tiangolo.com/advanced/strict-content-type/

---

## Testing

All packages installed cleanly in Docker. Import verification passed for all packages.

HTTP check: App serves 200 on `/` after upgrade.

Test results:
- Targeted tests (catalog/marc, importapi, coverstore): **206 passed, 7 skipped**
- Full suite: **3757 passed, 18 skipped, 0 failures**

## Checklist

- [x] All packages install cleanly (no dependency conflicts)
- [x] App serves HTTP 200
- [x] 3757 tests passing, 0 failures
- [x] CI passing

## References

Closes #12581, #12577, #12580, #12579, #12578, #12576, #12522