### PR TITLE
modsecurity

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,5 +1,6 @@
 # Needed for IP anonymization
 load_module modules/ngx_http_js_module.so;
+load_module modules/ngx_http_modsecurity_module.so;
 
 user  www-data;
 

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,15 +1,12 @@
 # Needed for IP anonymization
 load_module modules/ngx_http_js_module.so;
-load_module modules/ngx_http_modsecurity_module.so;
+# Needed for modsecurity
+load_module /olsystem/lib/ngx_http_modsecurity_module.so;
 
 user  www-data;
 
-# XXX-Anand: Oct 2013
-# Increased the worker_processes to allow more workers to share the load of https.
-
-#worker_processes  1;
-worker_processes 4;
-
+# Note; 6 cores on ol-www0, 8 on ol-covers0
+worker_processes 6;
 
 error_log  /var/log/nginx/error.log;
 pid        /var/run/nginx.pid;

--- a/docker/web_nginx.conf
+++ b/docker/web_nginx.conf
@@ -77,6 +77,9 @@ server {
     http2 on;
     server_name  openlibrary.org;
 
+    modsecurity on;
+    modsecurity_rules_file /olsystem/etc/nginx/modsecurity_openlibrary.conf;
+
     # Set the referrer policy so browsers send referrers to our own servers
     # In July 2020, Chrome changed its default referrer policy so any cross-origin
     # requests only sent the root referrer `/`. Since openlibrary.org

--- a/scripts/install_nginx.sh
+++ b/scripts/install_nginx.sh
@@ -15,10 +15,14 @@ echo "deb [signed-by=/usr/share/keyrings/nginx-keyring.asc] http://nginx.org/pac
     > /etc/apt/sources.list.d/nginx.list
 
 apt-get update
+
 # Install nginx and the NJS module
 apt-get install -y --no-install-recommends nginx nginx-module-njs letsencrypt
+
 # Install modsecurity
-apt-get install -y libmodsecurity3 modsecurity-crs
+# Modsecurity will rely on the /olsystem/lib/ngx_http_modsecurity_module.so
+# Nginx will not start without it.
+apt-get install -y --no-install-recommends libmodsecurity3 modsecurity-crs
 
 # Consider pulling modsecurity rules from:
 #wget https://github.com/coreruleset/coreruleset/archive/refs/tags/v4.25.0.tar.gz

--- a/scripts/install_nginx.sh
+++ b/scripts/install_nginx.sh
@@ -14,6 +14,11 @@ curl -fsSL https://nginx.org/keys/nginx_signing.key | tee /usr/share/keyrings/ng
 echo "deb [signed-by=/usr/share/keyrings/nginx-keyring.asc] http://nginx.org/packages/debian $(lsb_release -cs) nginx" \
     > /etc/apt/sources.list.d/nginx.list
 
-# Install nginx and the NJS module
 apt-get update
+# Install nginx and the NJS module
 apt-get install -y --no-install-recommends nginx nginx-module-njs letsencrypt
+# Install modsecurity
+apt-get install -y libmodsecurity3 libmodsecurity-dev
+
+# Consider pulling modsecurity rules from:
+#wget https://github.com/coreruleset/coreruleset/archive/refs/tags/v4.25.0.tar.gz

--- a/scripts/install_nginx.sh
+++ b/scripts/install_nginx.sh
@@ -18,7 +18,7 @@ apt-get update
 # Install nginx and the NJS module
 apt-get install -y --no-install-recommends nginx nginx-module-njs letsencrypt
 # Install modsecurity
-apt-get install -y libmodsecurity3 libmodsecurity-dev
+apt-get install -y libmodsecurity3 modsecurity-crs
 
 # Consider pulling modsecurity rules from:
 #wget https://github.com/coreruleset/coreruleset/archive/refs/tags/v4.25.0.tar.gz


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Half of #12591

This pull request introduces ModSecurity support to our Nginx configuration, enhancing the web server's security by enabling a web application firewall. The main changes involve installing the ModSecurity library, loading its module in Nginx, and configuring it to use a custom ruleset.

**Security Enhancements:**

* Installed `libmodsecurity3` and `libmodsecurity-dev` packages in the `install_nginx.sh` script to provide ModSecurity support for Nginx.
* Loaded the `ngx_http_modsecurity_module.so` module in `nginx.conf` to enable ModSecurity functionality.

**Nginx Configuration Updates:**

* Enabled ModSecurity in the `web_nginx.conf` server block and specified the rules file at `/olsystem/etc/nginx/modsecurity_openlibrary.conf`.