### PR TITLE
chore(deps): consolidate Python dependency upgrades (round 2)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiofiles==23.1.0
+aiofiles==23.2.1
 amightygirl.paapi5-python-sdk==1.0.0
 APScheduler==3.11.2
 Babel==2.12.1

--- a/requirements_scripts.txt
+++ b/requirements_scripts.txt
@@ -4,4 +4,4 @@
 
 mwparserfromhell==0.6.6
 nameparser==1.1.3
-wikitextparser==0.56.1
+wikitextparser==0.56.4


### PR DESCRIPTION
## Summary

Consolidates 2 open Renovate PRs into a single tested upgrade. All packages installed and verified in Docker (full OL stack with \`OL_MOUNT_DIR\` mount) before opening this PR.

## Packages upgraded

| Package | Before | After | Notes | Closes |
|---------|--------|-------|-------|--------|
| wikitextparser | 0.56.1 | 0.56.4 | Patch bump, \`requirements_scripts.txt\` | #12586 |
| aiofiles | 23.1.0 | 23.2.1 | Minor bump, \`requirements.txt\` | #12594 |

## Testing

All packages installed in Docker and verified at correct versions:
- \`wikitextparser: 0.56.4\` ✓ (installed via \`pip install\`, import verified)
- \`aiofiles: 23.2.1\` ✓ (import verified)

HTTP check: \`/\` and \`/search?q=test\` both return 200 after upgrade.

Full test suite: **3760 passed, 18 skipped, 0 failures.**

## Checklist

- [x] All packages install cleanly
- [x] All packages verified at correct versions in Docker
- [x] App serves HTTP 200 (home + search)
- [x] 3760 tests passing, 0 failures
- [x] CI passing

## References

Closes #12586, #12594