### PR TITLE
chore(deps): consolidate Python dependency upgrades (round 3)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ git+https://github.com/webpy/webpy.git@d3649322b85777b291ac2b7b3699fb6fc839e382
 gunicorn==23.0.0
 httpx==0.28.1
 ijson==3.5.0
-internetarchive==5.7.1
+internetarchive==5.8.0
 isbnlib==3.10.14
 luqum==0.11.0
 lxml==6.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ git+https://github.com/ArchiveLabs/pyopds2_openlibrary.git@e18e79f9a06afeaabe59d
 git+https://github.com/webpy/webpy.git@d3649322b85777b291ac2b7b3699fb6fc839e382
 gunicorn==23.0.0
 httpx==0.28.1
-ijson==3.2.3
+ijson==3.5.0
 internetarchive==5.7.1
 isbnlib==3.10.14
 luqum==0.11.0


### PR DESCRIPTION
## Summary

Consolidates 2 open Renovate PRs into a single tested upgrade. All packages installed and tested in Docker before opening this PR.

## Packages upgraded

| Package | Before | After | Severity | Closes |
|---------|--------|-------|----------|--------|
| ijson | 3.2.3 | 3.5.0 | Minor | #12600 |
| internetarchive | 5.7.1 | 5.8.0 | Minor | #12601 |

## Testing

- Both packages installed in running Docker web container
- Core APIs verified: `ijson.items()`, `ijson.kvitems()`, `internetarchive.get_session()`
- `make test`: 3760 passed, 0 failed
- HTTP 200 on home and search

## Checklist

- [x] All packages install cleanly
- [x] App serves HTTP 200
- [x] Tests passing
- [x] CI passing