### PR TITLE
chore(deps): consolidate Python dependency upgrades (round 4)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ Pillow==12.2.0
 prometheus-fastapi-instrumentator==7.1.0
 psycopg2==2.9.12
 pydantic==2.13.3
-pymarc==5.1.0
+pymarc==5.3.1
 python-amazon-paapi==6.2.0
 python-dateutil==2.8.2
 python-memcached==1.62

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ multipart==1.3.1
 Pillow==12.2.0
 prometheus-fastapi-instrumentator==7.1.0
 psycopg2==2.9.12
-pydantic==2.12.5
+pydantic==2.13.3
 pymarc==5.1.0
 python-amazon-paapi==6.2.0
 python-dateutil==2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,5 +34,5 @@ requests==2.33.1
 sentry-sdk[fastapi]==2.59.0
 simplejson==3.20.2
 statsd==4.0.1
-uvicorn[standard]==0.30.6
+uvicorn[standard]==0.46.0
 validate_email==1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ internetarchive==5.7.1
 isbnlib==3.10.14
 luqum==0.11.0
 lxml==6.1.0
-multipart==1.2.2
+multipart==1.3.1
 Pillow==12.2.0
 prometheus-fastapi-instrumentator==7.1.0
 psycopg2==2.9.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ python-multipart==0.0.27
 PyYAML==6.0.3
 qrcode==7.4.2
 requests==2.33.1
-sentry-sdk[fastapi]==2.58.0
+sentry-sdk[fastapi]==2.59.0
 simplejson==3.19.1
 statsd==4.0.1
 uvicorn[standard]==0.30.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ PyYAML==6.0.3
 qrcode==7.4.2
 requests==2.33.1
 sentry-sdk[fastapi]==2.59.0
-simplejson==3.19.1
+simplejson==3.20.2
 statsd==4.0.1
 uvicorn[standard]==0.30.6
 validate_email==1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ psycopg2==2.9.12
 pydantic==2.13.3
 pymarc==5.3.1
 python-amazon-paapi==6.2.0
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
 python-memcached==1.62
 python-multipart==0.0.27
 PyYAML==6.0.3

--- a/requirements_scripts.txt
+++ b/requirements_scripts.txt
@@ -2,6 +2,6 @@
 # Run like this:
 # uv pip install -r requirements_scripts.txt && PYTHONPATH=. python ./path/to/script.py optional_args... && uv pip uninstall -y -r requirements_scripts.txt
 
-mwparserfromhell==0.6.6
+mwparserfromhell==0.7.2
 nameparser==1.1.3
 wikitextparser==0.56.4


### PR DESCRIPTION
## Summary

Consolidates 8 open/rate-limited Renovate updates into a single tested upgrade. All packages installed and tested in Docker.

## Packages upgraded

| Package | Before | After | Severity |
|---------|--------|-------|----------|
| multipart | 1.2.2 | 1.3.1 | Patch |
| mwparserfromhell | 0.6.6 | 0.7.2 | Minor |
| pydantic | 2.12.5 | 2.13.3 | Patch |
| pymarc | 5.1.0 | 5.3.1 | Minor |
| python-dateutil | 2.8.2 | 2.9.0.post0 | Minor |
| sentry-sdk | 2.58.0 | 2.59.0 | Patch |
| simplejson | 3.19.1 | 3.20.2 | Patch |
| uvicorn | 0.30.6 | 0.46.0 | Minor |

## Excluded packages

| Package | Reason |
|---------|--------|
| luqum | 0.11.0→0.14.0 breaks query parenthesization — CI failure in `test_luqum_parser` and `test_process_user_query[Operators]`. The upgrade changes how multi-term field values are parenthesized, which breaks OL's search query generation. Needs a dedicated PR to update query handling code alongside the version bump. |

## Testing

- All packages installed into Docker web container and imports verified at correct versions
- `make test`: 3760 passed, 0 failed
- HTTP 200 on home

## Checklist

- [x] All packages install cleanly
- [x] App serves HTTP 200
- [x] Tests passing
- [x] CI passing