### PR TITLE
Restrict access to '/api/versions' endpoint

### DIFF
--- a/docker/web_nginx.conf
+++ b/docker/web_nginx.conf
@@ -198,6 +198,11 @@ server {
             return 422;
         }
 
+        # This endpoint should not be publicly exposed; disable here for now
+        if ($uri = "/api/versions") {
+            return 404;
+        }
+
         # Haproxy to better handle load/traffic
         proxy_pass http://web_haproxy:7072;
         proxy_set_header Host $http_host;


### PR DESCRIPTION
Disable public access to the '/api/versions' endpoint by returning a 404 error. Need to figure out how this is being exposed and remove from the python-side.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
