### PR TITLE
Switch history page to numbered pagination

### DIFF
--- a/openlibrary/plugins/upstream/recentchanges.py
+++ b/openlibrary/plugins/upstream/recentchanges.py
@@ -4,6 +4,7 @@ This should go into infogami.
 """
 
 import json
+import math
 
 import web
 import yaml
@@ -203,8 +204,9 @@ class history(delegate.mode):
         i = web.input(page=1)
         limit = 20
         # Clamp so legacy ?page=0 links resolve to the first page instead of a negative offset.
-        offset = limit * max(0, safeint(i.page) - 1)
-        # Fetch one extra item so has_next can be computed without a separate count query.
-        history = get_changes({"key": path, "limit": limit + 1, "offset": offset})
-        has_next = len(history) > limit
-        return render.history(page, history[:limit], has_next)
+        page_num = max(1, safeint(i.page))
+        offset = (page_num - 1) * limit
+        history = get_changes({"key": path, "limit": limit, "offset": offset})
+        # page.revision is the total number of saved revisions (infogami bumps it on every save).
+        total_pages = math.ceil(page.revision / limit)
+        return render.history(page, history, page_num, total_pages)

--- a/openlibrary/templates/history.html
+++ b/openlibrary/templates/history.html
@@ -1,4 +1,4 @@
-$def with (page, h, has_next=False)
+$def with (page, h, page_num=1, total_pages=1)
 
 $putctx("robots", "noindex,nofollow")
 
@@ -20,6 +20,8 @@ $ rev = page.latest_revision or page.revision
     <h1><a href="$page.key">$name</a></h1>
 </div>
 <div id="contentBody">
+        $:macros.OlPagination(page_num, total_pages)
+
         <form action="">
         <table id="pageHistory">
         <thead>
@@ -75,8 +77,6 @@ $ rev = page.latest_revision or page.revision
 
         </form>
 
-        $# Clamp so legacy ?page=0 URLs render as page 1 and match the component's 1-indexed scheme.
-        $ page_num = max(1, safeint(query_param("page", "1")))
-        $:macros.OlPaginationArrows(page_num, has_next)
+        $:macros.OlPagination(page_num, total_pages)
 
 </div>


### PR DESCRIPTION
https://github.com/internetarchive/openlibrary/pull/12624

Replaces arrow-only pagination on the page-history view with the numbered `OlPagination` component, so users can jump to any page directly.

## Technical details

The full page count was already available via `page.revision`. Easy upgrade.

## Screenshots

**Before** 

<img width="1060" height="213" alt="image" src="https://github.com/user-attachments/assets/cc0b75aa-ec37-48d1-bbf8-ab2b3cc65b21" />

**After**
<img width="1003" height="262" alt="Screenshot 2026-05-05 at 10 53 15 AM" src="https://github.com/user-attachments/assets/3e53ee7b-f87d-47fa-8488-454468219db1" />

<!-- drop local screenshot here -->

## Test plan
Visit history page and confirm numbered pagination renders at top and bottom of table
