### PR TITLE
add name option when wrapping async functions

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -570,7 +570,7 @@ async def add_availability_async(
     return items
 
 
-add_availability = async_bridge.wrap(add_availability_async)
+add_availability = async_bridge.wrap(add_availability_async, "add_availability")
 public(add_availability)
 
 

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -476,7 +476,7 @@ async def gather_lazy_carousel_data_async(
     return return_dict
 
 
-gather_lazy_carousel_data = async_bridge.wrap(gather_lazy_carousel_data_async)
+gather_lazy_carousel_data = async_bridge.wrap(gather_lazy_carousel_data_async, "gather_lazy_carousel_data")
 
 # Expose this publicly for the template
 public(gather_lazy_carousel_data)

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -153,7 +153,7 @@ async def get_solr_works_async(
 
 
 # Create a sync wrapper for backward compatibility
-get_solr_works = async_bridge.wrap(get_solr_works_async)
+get_solr_works = async_bridge.wrap(get_solr_works_async, "get_solr_works")
 public(get_solr_works)
 
 

--- a/openlibrary/utils/async_utils.py
+++ b/openlibrary/utils/async_utils.py
@@ -26,12 +26,24 @@ class AsyncBridge:
     def run[T](self, coro: Coroutine[Any, Any, T]) -> T:
         return asyncio.run_coroutine_threadsafe(coro, self._loop).result()
 
-    def wrap(self, func: Callable[P, Coroutine[Any, Any, T]]) -> Callable[P, T]:
-        """Wrap an async function so it can be called from sync code, preserving type hints."""
+    def wrap(
+        self,
+        func: Callable[P, Coroutine[Any, Any, T]],
+        name: str | None = None,
+    ) -> Callable[P, T]:
+        """Wrap an async function so it can be called from sync code, preserving type hints.
+
+        Args:
+            func: The async function to wrap
+            name: Optional custom name for the wrapper. Defaults to func.__name__.
+                  Use this when registering with @public to ensure correct template globals.
+        """
 
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
             return self.run(func(*args, **kwargs))
 
+        wrapper.__name__ = name if name is not None else func.__name__
+        wrapper.__doc__ = func.__doc__
         return wrapper
 
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
@lokesh pointed out that we weren't able to access wrapped functions properly in templates.

This is because the `public` function uses `__name__` for the key in the templates and we weren't setting that correctly. I think this wasn't noticed until now because most of the wrapped functions are only used from python.

This lets us set an explicit name to be used.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
