### PR TITLE
Throw error when visiting follower page while unauthenticated

### DIFF
--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -421,7 +421,7 @@ class MyBooksTemplate:
         self.user = web.ctx.site.get("/people/%s" % self.username)
 
         if not self.user:
-            raise render.notfound("User %s" % self.username, create=False)
+            raise web.notfound("User %s" % self.username, create=False)
 
         self.is_public = self.user.preferences().get("public_readlog", "no") == "yes"
         self.user_itemname = self.user.get_account().get("internetarchive_itemname")

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -421,7 +421,7 @@ class MyBooksTemplate:
         self.user = web.ctx.site.get("/people/%s" % self.username)
 
         if not self.user:
-            raise web.notfound("User %s" % self.username, create=False)
+            raise web.notfound("User %s" % self.username)
 
         self.is_public = self.user.preferences().get("public_readlog", "no") == "yes"
         self.user_itemname = self.user.get_account().get("internetarchive_itemname")


### PR DESCRIPTION
Closes #12630

This pull request makes a minor change to error handling in the `openlibrary/plugins/upstream/mybooks.py` file. It updates the way a "not found" error is raised when a user cannot be found, switching from `render.notfound` to the more standard `web.notfound`. This helps maintain consistency with web.py conventions.