### PR TITLE
Update edition matching query in unlink handler

### DIFF
--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -871,11 +871,9 @@ class unlink_ia_ol(delegate.page):
         ocaid, _ts = parts
 
         # Fetch affected editions
-        if not (
-            edition_keys := web.ctx.site.things(
-                {"type": "/type/edition", "ocaid": ocaid}
-            )
-        ):
+        edition_keys = web.ctx.site.things({"type": "/type/edition", "ocaid": ocaid})
+        edition_keys.extend(web.ctx.site.things({"type": "/type/edition", "source_records": f"ia:{ocaid}"}))
+        if not edition_keys:
             raise web.HTTPError("404 Not Found", {"Content-Type": "application/json"})
 
         editions = [web.ctx.site.get(key) for key in edition_keys]
@@ -908,7 +906,8 @@ class unlink_ia_ol(delegate.page):
     @staticmethod
     def make_dark(edition, ocaid):
         data = edition.dict()
-        del data["ocaid"]
+        if data.get("ocaid", ""):
+            del data["ocaid"]
         source_records = data.get("source_records", [])
         data["source_records"] = [rec for rec in source_records if rec != f"ia:{ocaid}"]
         if not data["source_records"]:

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -878,20 +878,11 @@ class unlink_ia_ol(delegate.page):
             raise web.HTTPError("404 Not Found", {"Content-Type": "application/json"})
 
         editions = [web.ctx.site.get(key) for key in edition_keys]
-        if len(editions) > 1:
-            raise web.HTTPError(
-                "409 Conflict",
-                {"Content-Type": "application/json"},
-                data=json.dumps(
-                    {"error": "Multiple editions associated with given ocaid"}
-                ),
-            )
-
-        edition = editions[0]
 
         # Update records
         try:
-            self.make_dark(edition, ocaid)
+            for edition in editions:
+                self.make_dark(edition, ocaid)
         except ClientException as e:
             logger.error(
                 f"Failed to disassociate record with key {edition.key}", exc_info=True

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -873,6 +873,7 @@ class unlink_ia_ol(delegate.page):
         # Fetch affected editions
         edition_keys = web.ctx.site.things({"type": "/type/edition", "ocaid": ocaid})
         edition_keys.extend(web.ctx.site.things({"type": "/type/edition", "source_records": f"ia:{ocaid}"}))
+        edition_keys = list(set(edition_keys))
         if not edition_keys:
             raise web.HTTPError("404 Not Found", {"Content-Type": "application/json"})
 
@@ -906,7 +907,7 @@ class unlink_ia_ol(delegate.page):
     @staticmethod
     def make_dark(edition, ocaid):
         data = edition.dict()
-        if data.get("ocaid", ""):
+        if "ocaid" in data and data["ocaid"] == ocaid:
             del data["ocaid"]
         source_records = data.get("source_records", [])
         data["source_records"] = [rec for rec in source_records if rec != f"ia:{ocaid}"]

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -872,7 +872,11 @@ class unlink_ia_ol(delegate.page):
 
         # Fetch affected editions
         edition_keys = web.ctx.site.things({"type": "/type/edition", "ocaid": ocaid})
-        edition_keys.extend(web.ctx.site.things({"type": "/type/edition", "source_records": f"ia:{ocaid}"}))
+        edition_keys.extend(
+            web.ctx.site.things(
+                {"type": "/type/edition", "source_records": f"ia:{ocaid}"}
+            )
+        )
         edition_keys = list(set(edition_keys))
         if not edition_keys:
             raise web.HTTPError("404 Not Found", {"Content-Type": "application/json"})


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Follows #11230
Follows #12402

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
I was under the incorrect assumption that every edition having an `ocaid` would also have an `ia:{ocaid}` source record.  Believing that this was the case, I designed the unlink handler to fetch editions having an `ocaid` field that matches the ocaid included in the unlink request.

This PR updates the edition query to fetch records having an `ocaid` value that matches the given value, and records that have an `ia:` source record that contains the given ocaid.

The unlink code has also been updated to handle linked records that are missing ocaids without error.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
