### PR TITLE
Fix: add id and aria-labels to edit profile inputs (#12554)

### DIFF
--- a/openlibrary/macros/UserEditRow.html
+++ b/openlibrary/macros/UserEditRow.html
@@ -2,6 +2,7 @@ $def with (page, name, unique=True, right=False)
 
 $ label = i18n.get('/type/user', name)
 $ value = page[name]
+$ original_label = label
 
 <div class="formElement title" id="clone_$name">
     <div class="label">
@@ -19,7 +20,7 @@ $else:
             $if i == 0:
                 id="$name"
             $else:
-                aria-label="Website"
+                aria-label="$original_label"
             />
             <span>
                 $if i == len(value) - 1:

--- a/openlibrary/macros/UserEditRow.html
+++ b/openlibrary/macros/UserEditRow.html
@@ -15,7 +15,12 @@ $else:
     $ value = value or [""]
     $for i, v in enumerate(value):
         <div class="input">
-            <input type="text" name="$name#$i" value="$v"/>
+            <input type="text" name="$name#$i" value="$v"
+            $if i == 0:
+                id="$name"
+            $else:
+                aria-label="Website"
+            />
             <span>
                 $if i == len(value) - 1:
                     <button id="add_row_button" type="button">$_('Add another')</button>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #12554

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
[fix] Fixes an accessibility issue on the Edit Profile page where the repeating "Website" form label was disconnected from its input fields.

### Technical
<!-- What should be noted about the implementation? -->
Modified the `UserEditRow.html` macro. For repeating fields (`unique=False`), the first rendered input (`i == 0`) now receives `id="$name"` to properly connect to the visible `<label for="$name">`. Subsequent inputs receive `aria-label="Website"` so they remain accessible to screen readers without violating the HTML rule that requires IDs to be strictly unique. 

*(Note: The `description` field mentioned in the original issue was already fixed in a previous commit to `master` by the addition of the `ol-markdown-editor`, so it was left untouched).*

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Navigate to the Edit Profile page locally (e.g., `http://localhost:8080/people/testing?m=edit`).
2. Right-click and inspect the first "Website" input element. Verify it now has `id="website"`.
3. If you have multiple websites, inspect the second input. Verify it has `aria-label="Website"`.
4. Keyboard/Screen reader navigation will now correctly announce the field name.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
No visual UI changes; only underlying HTML accessibility attributes were modified. 

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB