### PR TITLE
Fix: Add descriptive alt text to footer social icons

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -5559,11 +5559,23 @@ msgid "Bluesky"
 msgstr ""
 
 #: lib/nav_foot.html
+msgid "Open Library on Bluesky"
+msgstr ""
+
+#: lib/nav_foot.html
 msgid "Twitter"
 msgstr ""
 
 #: lib/nav_foot.html
+msgid "Open Library on Twitter"
+msgstr ""
+
+#: lib/nav_foot.html
 msgid "GitHub"
+msgstr ""
+
+#: lib/nav_foot.html
+msgid "Open Library on GitHub"
 msgstr ""
 
 #: lib/nav_foot.html site/alert.html

--- a/openlibrary/templates/lib/nav_foot.html
+++ b/openlibrary/templates/lib/nav_foot.html
@@ -46,9 +46,9 @@ $def with (page)
           <li><a href="https://github.com/internetarchive/openlibrary/releases" title="$_('Release Notes')">$_("Release Notes")</a></li>
         </ul>
         <aside>
-          <a class="footer-icon" title="$_('Bluesky')" href="https://bsky.app/profile/openlibrary.org"><img src="/static/images/bsky.svg" alt="" loading="lazy"></a>
-          <a class="footer-icon" title="$_('Twitter')" href="https://twitter.com/OpenLibrary"><img src="/static/images/tweet.svg" alt="" loading="lazy"></a>
-          <a class="footer-icon" title="$_('GitHub')" href="https://github.com/internetarchive/openlibrary"><img src="/static/images/github.svg" alt="" loading="lazy"></a>
+          <a class="footer-icon" title="$_('Bluesky')" href="https://bsky.app/profile/openlibrary.org"><img src="/static/images/bsky.svg" alt="$_('Open Library on Bluesky')" loading="lazy"></a>
+          <a class="footer-icon" title="$_('Twitter')" href="https://twitter.com/OpenLibrary"><img src="/static/images/tweet.svg" alt="$_('Open Library on Twitter')" loading="lazy"></a>
+          <a class="footer-icon" title="$_('GitHub')" href="https://github.com/internetarchive/openlibrary"><img src="/static/images/github.svg" alt="$_('Open Library on GitHub')" loading="lazy"></a>
         </aside>
       </div>
       <div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #12611 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

### Technical
<!-- What should be noted about the implementation? -->
Updated the footer social media icon image alt attributes in `openlibrary/templates/lib/nav_foot.html` to include descriptive, translatable alt text for Bluesky, Twitter, and GitHub links.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Ran OpenLibrary locally, performed the WAVE accessibility scan (using the Chrome extension), and verified that the "Linked images missing alternative text" errors no longer appear.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="1903" height="961" alt="WAVE scan showing no linked image alt text errors in the footer" src="https://github.com/user-attachments/assets/26a0c21a-b54c-4383-81b2-639199668057" />


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
