### PR TITLE
Fix worldcat links have spaces

### DIFF
--- a/openlibrary/macros/WorldcatLink.html
+++ b/openlibrary/macros/WorldcatLink.html
@@ -1,14 +1,14 @@
-$def with(isbn=None, oclc_numbers=None, referer="")
+$def with(isbn=None, oclc_number=None)
 
-$if oclc_numbers or isbn:
+$if oclc_number or isbn:
   <div class="cta-section">
     <p class="cta-section-title world-cat-link">$_("Check nearby libraries")</p>
     <ul class="book-locate-options">
       <li><a
         class="worldcat-link"
         data-ol-link-track="worldcat-search"
-        $if oclc_numbers:
-          href="https://worldcat.org/oclc/$oclc_numbers"
+        $if oclc_number:
+          href="https://worldcat.org/oclc/$oclc_number"
         $else:
           href="https://worldcat.org/isbn/$isbn"
         title="$_('Check WorldCat for an edition near you')"

--- a/openlibrary/macros/WorldcatLink.html
+++ b/openlibrary/macros/WorldcatLink.html
@@ -4,6 +4,14 @@ $if oclc_numbers or isbn:
   <div class="cta-section">
     <p class="cta-section-title world-cat-link">$_("Check nearby libraries")</p>
     <ul class="book-locate-options">
-      <li><a class="worldcat-link" data-ol-link-track="worldcat-search" href="$macros.WorldcatUrl(isbn=isbn, oclc_numbers=oclc_numbers)" title="$_('Check WorldCat for an edition near you')">$_("WorldCat")</a></li>
+      <li><a
+        class="worldcat-link"
+        data-ol-link-track="worldcat-search"
+        $if oclc_numbers:
+          href="https://worldcat.org/oclc/$oclc_numbers"
+        $else:
+          href="https://worldcat.org/isbn/$isbn"
+        title="$_('Check WorldCat for an edition near you')"
+      >$_("WorldCat")</a></li>
     </ul>
   </div>

--- a/openlibrary/macros/WorldcatUrl.html
+++ b/openlibrary/macros/WorldcatUrl.html
@@ -1,6 +1,0 @@
-$def with(text="Check nearby libraries", isbn=None, oclc_numbers=None)
-
-$ worldcat = "https://worldcat.org/isbn/XXX"
-$ worldcatoclc = "https://worldcat.org/oclc/XXX"
-
-$(worldcatoclc.replace('XXX', oclc_numbers) if oclc_numbers else worldcat.replace('XXX', isbn))

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -180,7 +180,6 @@ $ component_times['get_observation_metrics'] = time() - component_times['get_obs
 $ component_times['affiliate_links component'] = time()
 $ prices = edition.key.startswith('/books/')
 
-$ oclc_numbers = (edition.oclc_numbers and edition.oclc_numbers[0]) or ""
 $ isbn_13 = edition.get_isbn13() or None
 $ isbn_10 = edition.get_isbn10() or None
 
@@ -195,7 +194,8 @@ $if isbn_10 and not asin:
 $ affiliate_links = macros.AffiliateLinks(edition.title, {'isbn': isbn_13, 'asin': asin, 'prices': prices}, async_load=True)
 $ component_times['affiliate_links component'] = time() - component_times['affiliate_links component']
 
-$ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=oclc_numbers, referer=page.url(relative=False))
+$ oclc_number = (edition.oclc_numbers and edition.oclc_numbers[0]) or ""
+$ worldcat_link = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_number=oclc_number)
 
 <div id="contentBody" role="main" itemscope itemtype="https://schema.org/Book">
   <div class="workDetails">
@@ -207,7 +207,7 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
     <a id="overview-mobile" name="overview-mobile" class="section-anchor section-anchor--no-height"></a>
     $:render_template("type/edition/title_and_author", page, work, edition, ocaid, work_title, star_ratings_stats_mobile, for_desktop=False)
     <div class="editionCover">
-      $:macros.databarWork(edition or work, worldcat_links, affiliate_links, editions_page=True, render_times=component_times)
+      $:macros.databarWork(edition or work, worldcat_link, affiliate_links, editions_page=True, render_times=component_times)
     </div>
 
     <div class="editionAbout">
@@ -310,7 +310,7 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
       <div class="Tools">
         <div class="panel mobile-vendor">
           <div class="btn-notice">
-            $:worldcat_links
+            $:worldcat_link
 
             <div class="cta-section">
               <p class="cta-section-title">$_('Buy this book')</p>


### PR DESCRIPTION
Fix. This is showing up in our modsecurity as "abusive traffic", but it's actually just the macro's whitespace being included in the URL. It appears some clients/browsers don't string the white space from the URL, and instead try to then go to a url like `openlibrary.org/   http://worldcat...`

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Confirmed worldcat links still render correctly: https://testing.openlibrary.org/works/OL11327425W/Prisoner_in_paradise?edition=key%3A/books/OL10691191M

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
