### PR TITLE
build: remove protected files from Ruff & Black configs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,15 +61,10 @@ repos:
         exclude: |
           (?x)^(
             openlibrary/accounts/model\.py
-            |openlibrary/catalog/add_book/__init__\.py
             |openlibrary/core/models\.py
-            |openlibrary/core/vendors\.py
-            |openlibrary/fastapi/search\.py
-            |openlibrary/plugins/admin/code\.py
             |openlibrary/plugins/openlibrary/api\.py
             |openlibrary/plugins/openlibrary/code\.py
             |openlibrary/plugins/openlibrary/lists\.py
-            |openlibrary/plugins/upstream/utils\.py
             |openlibrary/plugins/worksearch/code\.py
             |openlibrary/plugins/worksearch/schemes/works\.py
           )$
@@ -83,15 +78,10 @@ repos:
         files: |
           (?x)^(
             openlibrary/accounts/model\.py
-            |openlibrary/catalog/add_book/__init__\.py
             |openlibrary/core/models\.py
-            |openlibrary/core/vendors\.py
-            |openlibrary/fastapi/search\.py
-            |openlibrary/plugins/admin/code\.py
             |openlibrary/plugins/openlibrary/api\.py
             |openlibrary/plugins/openlibrary/code\.py
             |openlibrary/plugins/openlibrary/lists\.py
-            |openlibrary/plugins/upstream/utils\.py
             |openlibrary/plugins/worksearch/code\.py
             |openlibrary/plugins/worksearch/schemes/works\.py
           )$

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -68,9 +68,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("add_book")
 
-re_normalize = re.compile('[^[:alphanum:] ]', re.UNICODE)
-re_lang = re.compile('^/languages/([a-z]{3})$')
-ISBD_UNIT_PUNCT = ' : '  # ISBD cataloging title-unit separator punctuation
+re_normalize = re.compile("[^[:alphanum:] ]", re.UNICODE)
+re_lang = re.compile("^/languages/([a-z]{3})$")
+ISBD_UNIT_PUNCT = " : "  # ISBD cataloging title-unit separator punctuation
 SUSPECT_PUBLICATION_DATES: Final = [
     "1900",
     "January 1, 1900",
@@ -91,9 +91,9 @@ ALLOWED_COVER_HOSTS: Final = (
 
 
 type_map = {
-    'description': 'text',
-    'notes': 'text',
-    'number_of_pages': 'int',
+    "description": "text",
+    "notes": "text",
+    "number_of_pages": "int",
 }
 
 
@@ -145,20 +145,20 @@ class SourceNeedsISBN(Exception):
         return "this source needs an ISBN"
 
 
-subject_fields = ['subjects', 'subject_places', 'subject_times', 'subject_people']
+subject_fields = ["subjects", "subject_places", "subject_times", "subject_people"]
 
 
 def normalize(s: str) -> str:
     """Strip non-alphanums and truncate at 25 chars."""
     norm = strip_accents(s).lower()
-    norm = norm.replace(' and ', ' ')
-    if norm.startswith('the '):
+    norm = norm.replace(" and ", " ")
+    if norm.startswith("the "):
         norm = norm[4:]
-    elif norm.startswith('a '):
+    elif norm.startswith("a "):
         norm = norm[2:]
     # strip bracketed text
-    norm = re.sub(r' ?\(.*\)', '', norm)
-    return norm.replace(' ', '')[:25]
+    norm = re.sub(r" ?\(.*\)", "", norm)
+    return norm.replace(" ", "")[:25]
 
 
 def is_redirect(thing):
@@ -168,7 +168,7 @@ def is_redirect(thing):
     """
     if not thing:
         return False
-    return thing.type.key == '/type/redirect'
+    return thing.type.key == "/type/redirect"
 
 
 def split_subtitle(full_title: str):
@@ -184,10 +184,10 @@ def split_subtitle(full_title: str):
 
     # strip parenthetical blocks wherever they occur
     # can handle 1 level of nesting
-    re_parens_strip = re.compile(r'\(([^\)\(]*|[^\(]*\([^\)]*\)[^\)]*)\)')
-    clean_title = re.sub(re_parens_strip, '', full_title)
+    re_parens_strip = re.compile(r"\(([^\)\(]*|[^\(]*\([^\)]*\)[^\)]*)\)")
+    clean_title = re.sub(re_parens_strip, "", full_title)
 
-    titles = clean_title.split(':')
+    titles = clean_title.split(":")
     subtitle = titles.pop().strip() if len(titles) > 1 else None
     title = ISBD_UNIT_PUNCT.join([unit.strip() for unit in titles])
     return (title, subtitle)
@@ -205,18 +205,18 @@ def find_matching_work(e):
     :return: the matched work key "/works/OL..W" if found
     """
     seen = set()
-    for a in e['authors']:
-        q = {'type': '/type/work', 'authors': {'author': {'key': a['key']}}}
+    for a in e["authors"]:
+        q = {"type": "/type/work", "authors": {"author": {"key": a["key"]}}}
         work_keys = list(web.ctx.site.things(q))
         for wkey in work_keys:
             w = web.ctx.site.get(wkey)
             if wkey in seen:
                 continue
             seen.add(wkey)
-            if not w.get('title'):
+            if not w.get("title"):
                 continue
-            if mk_norm(w['title']) == mk_norm(e['title']):
-                assert w.type.key == '/type/work'
+            if mk_norm(w["title"]) == mk_norm(e["title"]):
+                assert w.type.key == "/type/work"
                 return wkey
 
 
@@ -234,60 +234,58 @@ def load_author_import_records(authors_in, edits, source, save: bool = True):
     authors = []
     author_reply = []
     for a in authors_in:
-        new_author = 'key' not in a
+        new_author = "key" not in a
         if new_author:
             if save:
-                a['key'] = web.ctx.site.new_key('/type/author')
+                a["key"] = web.ctx.site.new_key("/type/author")
             else:
-                a['key'] = f'/authors/__new__{uuid.uuid4()}'
-            a['source_records'] = [source]
+                a["key"] = f"/authors/__new__{uuid.uuid4()}"
+            a["source_records"] = [source]
             edits.append(a)
-        authors.append({'key': a['key']})
+        authors.append({"key": a["key"]})
         author_reply.append(
             {
-                'key': a['key'],
-                'name': a['name'],
-                'status': ('created' if new_author else 'matched'),
+                "key": a["key"],
+                "name": a["name"],
+                "status": ("created" if new_author else "matched"),
             }
         )
     return (authors, author_reply)
 
 
-def new_work(
-    edition: dict, rec: dict, cover_id: int | None = None, save: bool = True
-) -> dict:
+def new_work(edition: dict, rec: dict, cover_id: int | None = None, save: bool = True) -> dict:
     """
     :param edition: New OL Edition
     :param rec: Edition import data
     :return: a work to save
     """
     w = {
-        'type': {'key': '/type/work'},
-        'title': rec['title'],
+        "type": {"key": "/type/work"},
+        "title": rec["title"],
     }
     for s in subject_fields:
         if s in rec:
             w[s] = rec[s]
 
-    if 'authors' in edition:
-        w['authors'] = []
-        assert len(edition['authors']) == len(rec['authors']), "Author import failed!"
-        for i, akey in enumerate(edition['authors']):
-            author = {'type': {'key': '/type/author_role'}, 'author': akey}
-            if role := rec['authors'][i].get('role'):
-                author['role'] = role
-            w['authors'].append(author)
+    if "authors" in edition:
+        w["authors"] = []
+        assert len(edition["authors"]) == len(rec["authors"]), "Author import failed!"
+        for i, akey in enumerate(edition["authors"]):
+            author = {"type": {"key": "/type/author_role"}, "author": akey}
+            if role := rec["authors"][i].get("role"):
+                author["role"] = role
+            w["authors"].append(author)
 
-    if 'description' in rec:
-        w['description'] = {'type': '/type/text', 'value': rec['description']}
+    if "description" in rec:
+        w["description"] = {"type": "/type/text", "value": rec["description"]}
 
     if save:
-        w['key'] = web.ctx.site.new_key('/type/work')
+        w["key"] = web.ctx.site.new_key("/type/work")
     else:
-        w['key'] = f'/works/__new__{uuid.uuid4()}'
+        w["key"] = f"/works/__new__{uuid.uuid4()}"
 
-    if edition.get('covers'):
-        w['covers'] = edition['covers']
+    if edition.get("covers"):
+        w["covers"] = edition["covers"]
 
     return w
 
@@ -301,22 +299,22 @@ def add_cover(cover_url, ekey, account_key=None):
     :rtype: int or None
     :return: Cover id, or None if upload did not succeed
     """
-    olid = ekey.split('/')[-1]
-    coverstore_url = config.get('coverstore_url').rstrip('/')
-    upload_url = coverstore_url + '/b/upload2'
-    if upload_url.startswith('//'):
-        upload_url = '{}:{}'.format(web.ctx.get('protocol', 'http'), upload_url)
+    olid = ekey.split("/")[-1]
+    coverstore_url = config.get("coverstore_url").rstrip("/")
+    upload_url = coverstore_url + "/b/upload2"
+    if upload_url.startswith("//"):
+        upload_url = "{}:{}".format(web.ctx.get("protocol", "http"), upload_url)
     if not account_key:
         user = accounts.get_current_user()
         if not user:
             raise RuntimeError("accounts.get_current_user() failed")
-        account_key = user.get('key') or user.get('_key')
+        account_key = user.get("key") or user.get("_key")
     params = {
-        'author': account_key,
-        'data': None,
-        'source_url': cover_url,
-        'olid': olid,
-        'ip': web.ctx.ip,
+        "author": account_key,
+        "data": None,
+        "source_url": cover_url,
+        "olid": olid,
+        "ip": web.ctx.ip,
     }
     reply = None
     for _ in range(10):
@@ -328,40 +326,34 @@ def add_cover(cover_url, ekey, account_key=None):
         body = response.text
         if response.status_code == 500:
             raise CoverNotSaved(body)
-        if body not in ['', 'None']:
+        if body not in ["", "None"]:
             reply = response.json()
-            if response.status_code == 200 and 'id' in reply:
+            if response.status_code == 200 and "id" in reply:
                 break
         sleep(2)
-    if not reply or reply.get('message') == 'Invalid URL':
+    if not reply or reply.get("message") == "Invalid URL":
         return
-    cover_id = int(reply['id'])
+    cover_id = int(reply["id"])
     return cover_id
 
 
 def get_ia_item(ocaid):
     import internetarchive as ia
 
-    cfg = {'general': {'secure': False}}
+    cfg = {"general": {"secure": False}}
     item = ia.get_item(ocaid, config=cfg)
     return item
 
 
 def modify_ia_item(item, data):
-    access_key = (
-        lending.config_ia_ol_metadata_write_s3
-        and lending.config_ia_ol_metadata_write_s3['s3_key']
-    )
-    secret_key = (
-        lending.config_ia_ol_metadata_write_s3
-        and lending.config_ia_ol_metadata_write_s3['s3_secret']
-    )
+    access_key = lending.config_ia_ol_metadata_write_s3 and lending.config_ia_ol_metadata_write_s3["s3_key"]
+    secret_key = lending.config_ia_ol_metadata_write_s3 and lending.config_ia_ol_metadata_write_s3["s3_secret"]
     return item.modify_metadata(data, access_key=access_key, secret_key=secret_key)
 
 
 def create_ol_subjects_for_ocaid(ocaid, subjects):
     item = get_ia_item(ocaid)
-    openlibrary_subjects = copy(item.metadata.get('openlibrary_subject')) or []
+    openlibrary_subjects = copy(item.metadata.get("openlibrary_subject")) or []
 
     if not isinstance(openlibrary_subjects, list):
         openlibrary_subjects = [openlibrary_subjects]
@@ -370,9 +362,9 @@ def create_ol_subjects_for_ocaid(ocaid, subjects):
         if subject not in openlibrary_subjects:
             openlibrary_subjects.append(subject)
 
-    r = modify_ia_item(item, {'openlibrary_subject': openlibrary_subjects})
+    r = modify_ia_item(item, {"openlibrary_subject": openlibrary_subjects})
     if r.status_code != 200:
-        return f'{item.identifier} failed: {r.content}'
+        return f"{item.identifier} failed: {r.content}"
     else:
         return f"success for {item.identifier}"
 
@@ -387,20 +379,20 @@ def update_ia_metadata_for_ol_edition(edition_id):
     :return: error report, or modified archive.org metadata on success
     """
 
-    data = {'error': 'No qualifying edition'}
+    data = {"error": "No qualifying edition"}
     if edition_id:
-        ed = web.ctx.site.get(f'/books/{edition_id}')
+        ed = web.ctx.site.get(f"/books/{edition_id}")
         if ed.ocaid:
-            work = ed.works[0] if ed.get('works') else None
+            work = ed.works[0] if ed.get("works") else None
             if work and work.key:
                 item = get_ia_item(ed.ocaid)
-                work_id = work.key.split('/')[2]
+                work_id = work.key.split("/")[2]
                 r = modify_ia_item(
                     item,
-                    {'openlibrary_work': work_id, 'openlibrary_edition': edition_id},
+                    {"openlibrary_work": work_id, "openlibrary_edition": edition_id},
                 )
                 if r.status_code != 200:
-                    data = {'error': f'{item.identifier} failed: {r.content}'}
+                    data = {"error": f"{item.identifier} failed: {r.content}"}
                 else:
                     data = item.metadata
     return data
@@ -414,17 +406,11 @@ def normalize_record_bibids(rec: dict):
     :rtype: dict
     :return: A record with cleaned LCCNs, and ISBNs in the various possible ISBN locations.
     """
-    for field in ('isbn_13', 'isbn_10', 'isbn'):
+    for field in ("isbn_13", "isbn_10", "isbn"):
         if rec.get(field):
-            rec[field] = [
-                normalize_isbn(isbn)
-                for isbn in rec.get(field, '')
-                if normalize_isbn(isbn)
-            ]
-    if rec.get('lccn'):
-        rec['lccn'] = [
-            normalize_lccn(lccn) for lccn in rec.get('lccn', '') if normalize_lccn(lccn)
-        ]
+            rec[field] = [normalize_isbn(isbn) for isbn in rec.get(field, "") if normalize_isbn(isbn)]
+    if rec.get("lccn"):
+        rec["lccn"] = [normalize_lccn(lccn) for lccn in rec.get("lccn", "") if normalize_lccn(lccn)]
     return rec
 
 
@@ -435,17 +421,15 @@ def isbns_from_record(rec: dict) -> list[str]:
     :param dict rec: Edition import record
     :rtype: list
     """
-    isbns = rec.get('isbn', []) + rec.get('isbn_10', []) + rec.get('isbn_13', [])
+    isbns = rec.get("isbn", []) + rec.get("isbn_10", []) + rec.get("isbn_13", [])
     return isbns
 
 
 def find_wikisource_src(rec: dict) -> str | None:
-    if not rec.get('source_records'):
+    if not rec.get("source_records"):
         return None
-    ws_prefix = 'wikisource:'
-    ws_match = next(
-        (src for src in rec['source_records'] if src.startswith(ws_prefix)), None
-    )
+    ws_prefix = "wikisource:"
+    ws_match = next((src for src in rec["source_records"] if src.startswith(ws_prefix)), None)
     if ws_match:
         return ws_match[len(ws_prefix) :]
     return None
@@ -460,13 +444,13 @@ def build_pool(rec: dict) -> dict[str, list[str]]:
     :return: {<identifier: title | isbn | lccn etc>: [list of /books/OL..M keys that match rec on <identifier>]}
     """
     pool = defaultdict(set)
-    match_fields = ('title', 'oclc_numbers', 'lccn', 'ocaid')
+    match_fields = ("title", "oclc_numbers", "lccn", "ocaid")
 
     if ws_match := find_wikisource_src(rec):
         # If this is a wikisource import, ONLY consider a match if the same wikisource ID
-        ekeys = set(editions_matched(rec, 'identifiers.wikisource', ws_match))
+        ekeys = set(editions_matched(rec, "identifiers.wikisource", ws_match))
         if ekeys:
-            pool['wikisource'] = ekeys
+            pool["wikisource"] = ekeys
         return {k: list(v) for k, v in pool.items() if v}
 
     # Find records with matching fields
@@ -474,13 +458,11 @@ def build_pool(rec: dict) -> dict[str, list[str]]:
         pool[field] = set(editions_matched(rec, field))
 
     # update title pool with normalized title matches
-    pool['title'].update(
-        set(editions_matched(rec, 'normalized_title_', normalize(rec['title'])))
-    )
+    pool["title"].update(set(editions_matched(rec, "normalized_title_", normalize(rec["title"]))))
 
     # Find records with matching ISBNs
     if isbns := isbns_from_record(rec):
-        pool['isbn'] = set(editions_matched(rec, 'isbn_', isbns))
+        pool["isbn"] = set(editions_matched(rec, "isbn_", isbns))
     return {k: list(v) for k, v in pool.items() if v}
 
 
@@ -491,36 +473,34 @@ def find_quick_match(rec: dict) -> str | None:
     :param dict rec: Edition record
     :return: First key matched of format "/books/OL..M" or None if no match found.
     """
-    if 'openlibrary' in rec:
-        return '/books/' + rec['openlibrary']
+    if "openlibrary" in rec:
+        return "/books/" + rec["openlibrary"]
 
     if ws_match := find_wikisource_src(rec):
         # If this is a wikisource import, ONLY consider a match if the same wikisource ID
-        ekeys = editions_matched(rec, 'identifiers.wikisource', ws_match)
+        ekeys = editions_matched(rec, "identifiers.wikisource", ws_match)
         if ekeys:
             return ekeys[0]
         else:
             return None
 
-    ekeys = editions_matched(rec, 'ocaid')
+    ekeys = editions_matched(rec, "ocaid")
     if ekeys:
         return ekeys[0]
 
     if isbns := isbns_from_record(rec):
-        ekeys = editions_matched(rec, 'isbn_', isbns)
+        ekeys = editions_matched(rec, "isbn_", isbns)
         if ekeys:
             return ekeys[0]
 
     # Look for a matching non-ISBN ASIN identifier (e.g. from a BWB promise item).
-    if (non_isbn_asin := get_non_isbn_asin(rec)) and (
-        ekeys := editions_matched(rec, "identifiers.amazon", non_isbn_asin)
-    ):
+    if (non_isbn_asin := get_non_isbn_asin(rec)) and (ekeys := editions_matched(rec, "identifiers.amazon", non_isbn_asin)):
         return ekeys[0]
 
     # Only searches for the first value from these lists
-    for f in 'source_records', 'oclc_numbers', 'lccn':
+    for f in "source_records", "oclc_numbers", "lccn":
         if rec.get(f):
-            if f == 'source_records' and not rec[f][0].startswith('ia:'):
+            if f == "source_records" and not rec[f][0].startswith("ia:"):
                 continue
             if ekeys := editions_matched(rec, f, rec[f][0]):
                 return ekeys[0]
@@ -543,7 +523,7 @@ def editions_matched(rec: dict, key: str, value=None) -> list[str]:
     if value is None:
         value = rec[key]
 
-    q = {'type': '/type/edition', key: value}
+    q = {"type": "/type/edition", key: value}
 
     ekeys = list(web.ctx.site.things(q))
     return ekeys
@@ -568,23 +548,19 @@ def find_threshold_match(rec: dict, edition_pool: dict[str, list[str]]) -> str |
                 if thing is None:
                     break
                 if is_redirect(thing):
-                    edition_key = thing['location']
+                    edition_key = thing["location"]
             if thing and editions_match(rec, thing):
                 return edition_key
     return None
 
 
-def check_cover_url_host(
-    cover_url: str | None, allowed_cover_hosts: Iterable[str] = ALLOWED_COVER_HOSTS
-) -> bool:
+def check_cover_url_host(cover_url: str | None, allowed_cover_hosts: Iterable[str] = ALLOWED_COVER_HOSTS) -> bool:
     if not cover_url:
         return False
 
     parsed_url = urlparse(url=cover_url)
 
-    host_is_allowed = parsed_url.netloc.casefold() in (
-        host.casefold() for host in allowed_cover_hosts
-    )
+    host_is_allowed = parsed_url.netloc.casefold() in (host.casefold() for host in allowed_cover_hosts)
 
     if not host_is_allowed:
         logger.warning(
@@ -640,29 +616,27 @@ def load_data(  # noqa: PLR0912, PLR0915
             edition = existing_edition.dict() | rec_as_edition
 
             # Preserve source_records to avoid data loss.
-            edition['source_records'] = existing_edition.get(
-                'source_records', []
-            ) + rec.get('source_records', [])
+            edition["source_records"] = existing_edition.get("source_records", []) + rec.get("source_records", [])
 
             # Preserve existing authors, if any.
-            if authors := existing_edition.get('authors'):
-                edition['authors'] = authors
+            if authors := existing_edition.get("authors"):
+                edition["authors"] = authors
 
         else:
             edition = rec_as_edition
 
     except InvalidLanguage as e:
         return {
-            'success': False,
-            'error': str(e),
+            "success": False,
+            "error": str(e),
         }
 
-    edition_key = edition.get('key')
+    edition_key = edition.get("key")
     if not edition_key:
         if save:
-            edition_key = web.ctx.site.new_key('/type/edition')
+            edition_key = web.ctx.site.new_key("/type/edition")
         else:
-            edition_key = f'/books/__new__{uuid.uuid4()}'
+            edition_key = f"/books/__new__{uuid.uuid4()}"
 
     cover_url = edition.pop("cover", None)
     if not check_cover_url_host(cover_url):
@@ -678,89 +652,72 @@ def load_data(  # noqa: PLR0912, PLR0915
             cover_id = -2
 
     if cover_id:
-        edition['covers'] = [cover_id]
+        edition["covers"] = [cover_id]
 
     edits: list[dict] = []  # Things (Edition, Work, Authors) to be saved
     reply: dict = {}
     if not save:
-        reply['preview'] = True
-        reply['edits'] = edits
+        reply["preview"] = True
+        reply["edits"] = edits
 
     # edition.authors may have passed through `author_import_record_to_author` in `build_query`,
     # but not necessarily
-    author_in = [
-        (
-            author_import_record_to_author(a, eastern=east_in_by_statement(rec, a))
-            if isinstance(a, dict)
-            else a
-        )
-        for a in edition.get('authors', [])
-    ]
+    author_in = [(author_import_record_to_author(a, eastern=east_in_by_statement(rec, a)) if isinstance(a, dict) else a) for a in edition.get("authors", [])]
     # build_author_reply() adds authors to edits
-    authors, author_reply = load_author_import_records(
-        author_in, edits, rec['source_records'][0], save=save
-    )
+    authors, author_reply = load_author_import_records(author_in, edits, rec["source_records"][0], save=save)
 
     if authors:
-        edition['authors'] = authors
-        reply['authors'] = author_reply
+        edition["authors"] = authors
+        reply["authors"] = author_reply
 
-    work_key = safeget(lambda: edition['works'][0]['key'])
-    work_state = 'created'
+    work_key = safeget(lambda: edition["works"][0]["key"])
+    work_state = "created"
     # Look for an existing work
-    if not work_key and 'authors' in edition:
+    if not work_key and "authors" in edition:
         work_key = find_matching_work(edition)
     if work_key:
         work = web.ctx.site.get(work_key)
-        work_state = 'matched'
+        work_state = "matched"
         need_update = False
         for k in subject_fields:
             if k not in rec:
                 continue
             for s in rec[k]:
-                if normalize(s) not in [
-                    normalize(existing) for existing in work.get(k, [])
-                ]:
+                if normalize(s) not in [normalize(existing) for existing in work.get(k, [])]:
                     work.setdefault(k, []).append(s)
                     need_update = True
         if cover_id:
-            work.setdefault('covers', []).append(cover_id)
+            work.setdefault("covers", []).append(cover_id)
             need_update = True
         if need_update:
-            work_state = 'modified'
+            work_state = "modified"
             edits.append(work.dict())
     else:
         # Create new work
         work = new_work(edition, rec, cover_id, save=save)
-        work_state = 'created'
-        work_key = work['key']
+        work_state = "created"
+        work_key = work["key"]
         edits.append(work)
 
     assert work_key
-    if not edition.get('works'):
-        edition['works'] = [{'key': work_key}]
-    edition['key'] = edition_key
+    if not edition.get("works"):
+        edition["works"] = [{"key": work_key}]
+    edition["key"] = edition_key
     edits.append(edition)
 
     if save:
-        comment = (
-            "overwrite existing edition" if existing_edition else "import new book"
-        )
+        comment = "overwrite existing edition" if existing_edition else "import new book"
         action = "edit-book" if existing_edition else "add-book"
         web.ctx.site.save_many(edits, comment=comment, action=action)
 
         # Writes back `openlibrary_edition` and `openlibrary_work` to
         # archive.org item after successful import:
-        if 'ocaid' in rec:
-            update_ia_metadata_for_ol_edition(edition_key.split('/')[-1])
+        if "ocaid" in rec:
+            update_ia_metadata_for_ol_edition(edition_key.split("/")[-1])
 
-    reply['success'] = True
-    reply['edition'] = (
-        {'key': edition_key, 'status': 'modified'}
-        if existing_edition
-        else {'key': edition_key, 'status': 'created'}
-    )
-    reply['work'] = {'key': work_key, 'status': work_state}
+    reply["success"] = True
+    reply["edition"] = {"key": edition_key, "status": "modified"} if existing_edition else {"key": edition_key, "status": "created"}
+    reply["work"] = {"key": work_key, "status": work_state}
     return reply
 
 
@@ -778,46 +735,45 @@ def normalize_import_record(rec: dict) -> None:
         NOTE: This function modifies the passed-in rec in place.
     """
     required_fields = {
-        'title',
-        'source_records',
+        "title",
+        "source_records",
     }  # ['authors', 'publishers', 'publish_date']
     if missing_required_fields := required_fields - rec.keys():
         raise RequiredFields(missing_required_fields)
 
     # Ensure source_records is a list.
-    if not isinstance(rec['source_records'], list):
-        rec['source_records'] = [rec['source_records']]
+    if not isinstance(rec["source_records"], list):
+        rec["source_records"] = [rec["source_records"]]
 
-    publication_year = get_publication_year(rec.get('publish_date'))
+    publication_year = get_publication_year(rec.get("publish_date"))
     if publication_year and published_in_future_year(publication_year):
-        del rec['publish_date']
+        del rec["publish_date"]
 
     # Split subtitle if required and not already present
-    if ':' in rec.get('title', '') and not rec.get('subtitle'):
-        title, subtitle = split_subtitle(rec.get('title', ''))
+    if ":" in rec.get("title", "") and not rec.get("subtitle"):
+        title, subtitle = split_subtitle(rec.get("title", ""))
         if subtitle:
-            rec['title'] = title
-            rec['subtitle'] = subtitle
+            rec["title"] = title
+            rec["subtitle"] = subtitle
 
     rec = normalize_record_bibids(rec)
 
     # deduplicate authors
-    rec['authors'] = uniq(rec.get('authors', []), dicthash)
+    rec["authors"] = uniq(rec.get("authors", []), dicthash)
 
     # Validation by parse_data(), prior to calling load(), requires facially
     # valid publishers. If data are unavailable, we provide throw-away data
     # which validates. We use ["????"] as an override, but this must be
     # removed prior to import.
-    if rec.get('publishers') == ["????"]:
-        rec.pop('publishers')
+    if rec.get("publishers") == ["????"]:
+        rec.pop("publishers")
 
     # Remove suspect publication dates from certain sources (e.g. 1900 from Amazon).
     if any(
-        source_record.split(":")[0] in SOURCE_RECORDS_REQUIRING_DATE_SCRUTINY
-        and rec.get('publish_date') in SUSPECT_PUBLICATION_DATES
-        for source_record in rec['source_records']
+        source_record.split(":")[0] in SOURCE_RECORDS_REQUIRING_DATE_SCRUTINY and rec.get("publish_date") in SUSPECT_PUBLICATION_DATES
+        for source_record in rec["source_records"]
     ):
-        rec.pop('publish_date')
+        rec.pop("publish_date")
 
 
 def validate_record(rec: dict) -> None:
@@ -832,22 +788,20 @@ def validate_record(rec: dict) -> None:
 
     If all the validations pass, implicitly return None.
     """
-    source_records = rec.get('source_records', [])
-    source_records = (
-        source_records if isinstance(source_records, list) else [source_records]
-    )
+    source_records = rec.get("source_records", [])
+    source_records = source_records if isinstance(source_records, list) else [source_records]
 
-    if any(rec.startswith('ia:') for rec in source_records):
+    if any(rec.startswith("ia:") for rec in source_records):
         return None
 
     # Only validate publication year if a year is found.
-    if publication_year := get_publication_year(rec.get('publish_date')):
+    if publication_year := get_publication_year(rec.get("publish_date")):
         if publication_too_old_and_not_exempt(rec):
             raise PublicationYearTooOld(publication_year)
         elif published_in_future_year(publication_year):
             raise PublishedInFutureYear(publication_year)
 
-    if is_independently_published(rec.get('publishers', [])):
+    if is_independently_published(rec.get("publishers", [])):
         raise IndependentlyPublished
 
     if needs_isbn_and_lacks_one(rec):
@@ -859,9 +813,7 @@ def find_match(rec: dict, edition_pool: dict) -> str | None:
     return find_quick_match(rec) or find_threshold_match(rec, edition_pool)
 
 
-def update_edition_with_rec_data(
-    rec: dict, account_key: str | None, edition: "Edition", save: bool
-) -> bool:
+def update_edition_with_rec_data(rec: dict, account_key: str | None, edition: "Edition", save: bool) -> bool:
     """
     Enrich the Edition by adding certain fields present in rec but absent
     in edition.
@@ -870,8 +822,8 @@ def update_edition_with_rec_data(
     """
     need_edition_save = False
     # Add cover to edition
-    if 'cover' in rec and not edition.get_covers():
-        cover_url = rec['cover']
+    if "cover" in rec and not edition.get_covers():
+        cover_url = rec["cover"]
         if save:
             cover_id = add_cover(cover_url, edition.key, account_key=account_key)
         else:
@@ -880,22 +832,22 @@ def update_edition_with_rec_data(
             cover_id = -2
 
         if cover_id:
-            edition['covers'] = [cover_id]
+            edition["covers"] = [cover_id]
             need_edition_save = True
 
     # Add ocaid to edition (str), if needed
-    if 'ocaid' in rec and not edition.ocaid:
-        edition['ocaid'] = rec['ocaid']
+    if "ocaid" in rec and not edition.ocaid:
+        edition["ocaid"] = rec["ocaid"]
         need_edition_save = True
 
     # Fields which have their VALUES added if absent.
     edition_list_fields = [
-        'local_id',
-        'lccn',
-        'lc_classifications',
-        'oclc_numbers',
-        'source_records',
-        'languages',
+        "local_id",
+        "lccn",
+        "lc_classifications",
+        "oclc_numbers",
+        "source_records",
+        "languages",
     ]
     edition_dict: dict = edition.dict()
     for field in edition_list_fields:
@@ -906,16 +858,12 @@ def update_edition_with_rec_data(
         rec_values = rec.get(field, [])
 
         # Languages in `rec` are ['eng'], etc., but import requires dict-style.
-        if field == 'languages':
+        if field == "languages":
             formatted_languages = format_languages(languages=rec_values)
-            supplemented_values = existing_values + [
-                lang for lang in formatted_languages if lang not in existing_values
-            ]
+            supplemented_values = existing_values + [lang for lang in formatted_languages if lang not in existing_values]
         else:
             case_folded_values = [v.casefold() for v in existing_values]
-            supplemented_values = existing_values + [
-                v for v in rec_values if v.casefold() not in case_folded_values
-            ]
+            supplemented_values = existing_values + [v for v in rec_values if v.casefold() not in case_folded_values]
 
         if existing_values != supplemented_values:
             edition[field] = supplemented_values
@@ -923,10 +871,10 @@ def update_edition_with_rec_data(
 
     # Fields that are added as a whole if absent. (Individual values are not added.)
     other_edition_fields = [
-        'description',
-        'number_of_pages',
-        'publishers',
-        'publish_date',
+        "description",
+        "number_of_pages",
+        "publishers",
+        "publish_date",
     ]
     for f in other_edition_fields:
         if f not in rec or not rec[f]:
@@ -936,21 +884,19 @@ def update_edition_with_rec_data(
             need_edition_save = True
 
     # Add new identifiers (dict values, so different treatment from lists above.)
-    if 'identifiers' in rec:
-        identifiers = defaultdict(list, edition.dict().get('identifiers', {}))
-        for k, vals in rec['identifiers'].items():
+    if "identifiers" in rec:
+        identifiers = defaultdict(list, edition.dict().get("identifiers", {}))
+        for k, vals in rec["identifiers"].items():
             identifiers[k].extend(vals)
             identifiers[k] = list(set(identifiers[k]))
-        if edition.dict().get('identifiers') != identifiers:
-            edition['identifiers'] = identifiers
+        if edition.dict().get("identifiers") != identifiers:
+            edition["identifiers"] = identifiers
             need_edition_save = True
 
     return need_edition_save
 
 
-def update_work_with_rec_data(
-    rec: dict, edition: "Edition", work: dict[str, Any], need_work_save: bool
-) -> bool:
+def update_work_with_rec_data(rec: dict, edition: "Edition", work: dict[str, Any], need_work_save: bool) -> bool:
     """
     Enrich the Work by adding certain fields present in rec but absent
     in work.
@@ -958,44 +904,36 @@ def update_work_with_rec_data(
     NOTE: This modifies the passed-in Work in place.
     """
     # Add subjects to work, if not already present
-    if 'subjects' in rec:
-        work_subjects: list[str] = list(work.get('subjects', []))
-        rec_subjects: list[str] = rec.get('subjects', [])
-        deduped_subjects = uniq(
-            itertools.chain(work_subjects, rec_subjects), lambda item: item.casefold()
-        )
+    if "subjects" in rec:
+        work_subjects: list[str] = list(work.get("subjects", []))
+        rec_subjects: list[str] = rec.get("subjects", [])
+        deduped_subjects = uniq(itertools.chain(work_subjects, rec_subjects), lambda item: item.casefold())
 
         if work_subjects != deduped_subjects:
-            work['subjects'] = deduped_subjects
+            work["subjects"] = deduped_subjects
             need_work_save = True
 
     # Add cover to work, if needed
-    if not work.get('covers') and edition.get_covers():
-        work['covers'] = [edition['covers'][0]]
+    if not work.get("covers") and edition.get_covers():
+        work["covers"] = [edition["covers"][0]]
         need_work_save = True
 
     # Add description to work, if needed
-    if not work.get('description') and edition.get('description'):
-        work['description'] = edition['description']
+    if not work.get("description") and edition.get("description"):
+        work["description"] = edition["description"]
         need_work_save = True
 
     # Add authors to work, if needed
-    if not work.get('authors'):
-        authors = [author_import_record_to_author(a) for a in rec.get('authors', [])]
-        work['authors'] = [
-            {'type': {'key': '/type/author_role'}, 'author': a.get('key')}
-            for a in authors
-            if a.get('key')
-        ]
-        if work.get('authors'):
+    if not work.get("authors"):
+        authors = [author_import_record_to_author(a) for a in rec.get("authors", [])]
+        work["authors"] = [{"type": {"key": "/type/author_role"}, "author": a.get("key")} for a in authors if a.get("key")]
+        if work.get("authors"):
             need_work_save = True
 
     return need_work_save
 
 
-def should_overwrite_promise_item(
-    edition: "Edition", from_marc_record: bool = False
-) -> bool:
+def should_overwrite_promise_item(edition: "Edition", from_marc_record: bool = False) -> bool:
     """
     Returns True for revision 1 promise items with MARC data available.
 
@@ -1003,11 +941,11 @@ def should_overwrite_promise_item(
     quality. Overwriting revision 1 promise items with MARC data ensures
     higher quality records and eliminates the risk of obliterating human edits.
     """
-    if edition.get('revision') != 1 or not from_marc_record:
+    if edition.get("revision") != 1 or not from_marc_record:
         return False
 
     # Promise items are always index 0 in source_records.
-    return bool(safeget(lambda: edition['source_records'][0], '').startswith("promise"))
+    return bool(safeget(lambda: edition["source_records"][0], "").startswith("promise"))
 
 
 def load(
@@ -1059,20 +997,18 @@ def load(
             if not is_redirect(a):
                 existing_edition.authors.append(a)
 
-    if existing_edition.get('works'):
+    if existing_edition.get("works"):
         work = existing_edition.works[0].dict()
         work_created = False
     else:
         # Found an edition without a work
         work_created = need_work_save = need_edition_save = True
         work = new_work(existing_edition.dict(), rec)
-        existing_edition.works = [{'key': work['key']}]
+        existing_edition.works = [{"key": work["key"]}]
 
     # Send revision 1 promise item editions to the same pipeline as new editions
     # because we want to overwrite most of their data.
-    if should_overwrite_promise_item(
-        edition=existing_edition, from_marc_record=from_marc_record
-    ):
+    if should_overwrite_promise_item(edition=existing_edition, from_marc_record=from_marc_record):
         return load_data(
             rec,
             account_key=account_key,
@@ -1080,38 +1016,32 @@ def load(
             save=save,
         )
 
-    need_edition_save = update_edition_with_rec_data(
-        rec=rec, account_key=account_key, edition=existing_edition, save=save
-    )
-    need_work_save = update_work_with_rec_data(
-        rec=rec, edition=existing_edition, work=work, need_work_save=need_work_save
-    )
+    need_edition_save = update_edition_with_rec_data(rec=rec, account_key=account_key, edition=existing_edition, save=save)
+    need_work_save = update_work_with_rec_data(rec=rec, edition=existing_edition, work=work, need_work_save=need_work_save)
 
     edits: list[dict] = []
     reply: dict = {
-        'success': True,
-        'edition': {'key': match, 'status': 'matched'},
-        'work': {'key': work['key'], 'status': 'matched'},
+        "success": True,
+        "edition": {"key": match, "status": "matched"},
+        "work": {"key": work["key"], "status": "matched"},
     }
 
     if not save:
-        reply['preview'] = True
-        reply['edits'] = edits
+        reply["preview"] = True
+        reply["edits"] = edits
 
     if need_edition_save:
-        reply['edition']['status'] = 'modified'  # type: ignore[index]
+        reply["edition"]["status"] = "modified"  # type: ignore[index]
         edits.append(existing_edition.dict())
     if need_work_save:
-        reply['work']['status'] = 'created' if work_created else 'modified'  # type: ignore[index]
+        reply["work"]["status"] = "created" if work_created else "modified"  # type: ignore[index]
         edits.append(work)
 
     if save:
         if edits:
-            web.ctx.site.save_many(
-                edits, comment='import existing book', action='edit-book'
-            )
-        if 'ocaid' in rec:
-            update_ia_metadata_for_ol_edition(match.split('/')[-1])
+            web.ctx.site.save_many(edits, comment="import existing book", action="edit-book")
+        if "ocaid" in rec:
+            update_ia_metadata_for_ol_edition(match.split("/")[-1])
 
     return reply
 

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -32,26 +32,22 @@ logger = logging.getLogger("openlibrary.vendors")
 session = requests.Session()
 async_session = httpx.AsyncClient()
 
-BETTERWORLDBOOKS_API_URL = (
-    'https://products.bwbcontent.com/service.aspx?IncludeAmazon=True&ItemId='
-)
+BETTERWORLDBOOKS_API_URL = "https://products.bwbcontent.com/service.aspx?IncludeAmazon=True&ItemId="
 affiliate_server_url = None
-BWB_AFFILIATE_LINK = 'http://www.anrdoezrs.net/links/{}/type/dlg/http://www.betterworldbooks.com/-id-%s'.format(
-    h.affiliate_id('betterworldbooks')
-)
-AMAZON_FULL_DATE_RE = re.compile(r'\d{4}-\d\d-\d\d')
-ISBD_UNIT_PUNCT = ' : '  # ISBD cataloging title-unit separator punctuation
+BWB_AFFILIATE_LINK = "http://www.anrdoezrs.net/links/{}/type/dlg/http://www.betterworldbooks.com/-id-%s".format(h.affiliate_id("betterworldbooks"))
+AMAZON_FULL_DATE_RE = re.compile(r"\d{4}-\d\d-\d\d")
+ISBD_UNIT_PUNCT = " : "  # ISBD cataloging title-unit separator punctuation
 
 
 def setup(config):
     global affiliate_server_url
-    affiliate_server_url = config.get('affiliate_server')
+    affiliate_server_url = config.get("affiliate_server")
 
 
 def get_lexile(isbn):
     try:
-        url = 'https://atlas-fab.lexile.com/free/books/' + str(isbn)
-        headers = {'accept': 'application/json; version=1.0'}
+        url = "https://atlas-fab.lexile.com/free/books/" + str(isbn)
+        headers = {"accept": "application/json; version=1.0"}
         lexile = session.get(url, headers=headers)
         lexile.raise_for_status()  # this will raise an error for us if the http status returned is not 200 OK
         data = lexile.json()
@@ -70,12 +66,10 @@ class AmazonAPI:
 
     RESOURCES = MappingProxyType(
         {
-            'all': [  # Hack: pulls all resource consts from GetItemsResource
-                getattr(GetItemsResource, v)
-                for v in vars(GetItemsResource)
-                if v.isupper()
+            "all": [  # Hack: pulls all resource consts from GetItemsResource
+                getattr(GetItemsResource, v) for v in vars(GetItemsResource) if v.isupper()
             ],
-            'import': [
+            "import": [
                 GetItemsResource.IMAGES_PRIMARY_LARGE,
                 GetItemsResource.ITEMINFO_BYLINEINFO,
                 GetItemsResource.ITEMINFO_CONTENTINFO,
@@ -85,7 +79,7 @@ class AmazonAPI:
                 GetItemsResource.ITEMINFO_CLASSIFICATIONS,
                 GetItemsResource.OFFERS_LISTINGS_PRICE,
             ],
-            'prices': [GetItemsResource.OFFERS_LISTINGS_PRICE],
+            "prices": [GetItemsResource.OFFERS_LISTINGS_PRICE],
         }
     )
 
@@ -94,8 +88,8 @@ class AmazonAPI:
         key: str,
         secret: str,
         tag: str,
-        host: str = 'webservices.amazon.com',
-        region: str = 'us-east-1',
+        host: str = "webservices.amazon.com",
+        region: str = "us-east-1",
         throttling: float = 0.9,
         proxy_url: str = "",
     ) -> None:
@@ -115,9 +109,7 @@ class AmazonAPI:
         self.throttling = throttling
         self.last_query_time = time.time()
 
-        self.api = DefaultApi(
-            access_key=key, secret_key=secret, host=host, region=region
-        )
+        self.api = DefaultApi(access_key=key, secret_key=secret, host=host, region=region)
 
         # Replace the api object with one that supports the HTTP proxy. See #10310.
         if proxy_url:
@@ -144,7 +136,7 @@ class AmazonAPI:
         self,
         asins: list | str,
         serialize: bool = False,
-        marketplace: str = 'www.amazon.com',
+        marketplace: str = "www.amazon.com",
         resources: Any | None = None,
         **kwargs,
     ) -> list | None:
@@ -159,7 +151,7 @@ class AmazonAPI:
         self.last_query_time = time.time()
 
         item_ids = asins if isinstance(asins, list) else [asins]
-        _resources = self.RESOURCES[resources or 'import']
+        _resources = self.RESOURCES[resources or "import"]
         try:
             request = GetItemsRequest(
                 partner_tag=self.tag,
@@ -170,16 +162,10 @@ class AmazonAPI:
                 **kwargs,
             )
         except ApiException:
-            logger.error(
-                f"Amazon fetch failed for: {', '.join(item_ids)}", exc_info=True
-            )
+            logger.error(f"Amazon fetch failed for: {', '.join(item_ids)}", exc_info=True)
             return None
         response = self.api.get_items(request)
-        products = (
-            [p for p in response.items_result.items if p]
-            if response.items_result
-            else []
-        )
+        products = [p for p in response.items_result.items if p] if response.items_result else []
         return products if not serialize else [self.serialize(p) for p in products]
 
     @staticmethod
@@ -217,37 +203,29 @@ class AmazonAPI:
         if not product:
             return {}  # no match?
 
-        item_info = getattr(product, 'item_info')
-        images = getattr(product, 'images')
-        edition_info = item_info and getattr(item_info, 'content_info')
-        attribution = item_info and getattr(item_info, 'by_line_info')
-        price = (
-            getattr(product, 'offers')
-            and product.offers.listings
-            and product.offers.listings[0].price
-        )
-        brand = (
-            attribution
-            and getattr(attribution, 'brand')
-            and getattr(attribution.brand, 'display_value')
-        )
+        item_info = getattr(product, "item_info")
+        images = getattr(product, "images")
+        edition_info = item_info and getattr(item_info, "content_info")
+        attribution = item_info and getattr(item_info, "by_line_info")
+        price = getattr(product, "offers") and product.offers.listings and product.offers.listings[0].price
+        brand = attribution and getattr(attribution, "brand") and getattr(attribution.brand, "display_value")
         manufacturer = (
             item_info
-            and getattr(item_info, 'by_line_info')
-            and getattr(item_info.by_line_info, 'manufacturer')
+            and getattr(item_info, "by_line_info")
+            and getattr(item_info.by_line_info, "manufacturer")
             and item_info.by_line_info.manufacturer.display_value
         )
         product_group = (
             item_info
             and getattr(
                 item_info,
-                'classifications',
+                "classifications",
             )
-            and getattr(item_info.classifications, 'product_group')
+            and getattr(item_info.classifications, "product_group")
             and item_info.classifications.product_group.display_value
         )
         languages = []
-        if edition_info and getattr(edition_info, 'languages'):
+        if edition_info and getattr(edition_info, "languages"):
             # E.g.
             # 'languages': {
             #     'display_values': [
@@ -260,19 +238,9 @@ class AmazonAPI:
             # },
             # Note: We don't need to convert from e.g. "French" to "fre"; the
             # import endpoint does that.
-            languages = uniq(
-                lang.display_value
-                for lang in getattr(edition_info.languages, 'display_values', [])
-                if lang.type != 'Original Language'
-            )
+            languages = uniq(lang.display_value for lang in getattr(edition_info.languages, "display_values", []) if lang.type != "Original Language")
         try:
-            publish_date = (
-                edition_info
-                and edition_info.publication_date
-                and isoparser.parse(
-                    edition_info.publication_date.display_value
-                ).strftime('%b %d, %Y')
-            )
+            publish_date = edition_info and edition_info.publication_date and isoparser.parse(edition_info.publication_date.display_value).strftime("%b %d, %Y")
         except Exception:
             logger.exception(f"serialize({product})")
             publish_date = None
@@ -281,43 +249,24 @@ class AmazonAPI:
         isbn_13 = isbn_10_to_isbn_13(product.asin) if asin_is_isbn10 else None
 
         book = {
-            'url': "https://www.amazon.com/dp/{}/?tag={}".format(
-                product.asin, h.affiliate_id('amazon')
-            ),
-            'source_records': [f'amazon:{product.asin}'],
-            'isbn_10': [product.asin] if asin_is_isbn10 else [],
-            'isbn_13': [isbn_13] if isbn_13 else [],
-            'price': price and price.display_amount,
-            'price_amt': price and price.amount and int(100 * price.amount),
-            'title': (
-                item_info
-                and item_info.title
-                and getattr(item_info.title, 'display_value')
-            ),
-            'cover': (
+            "url": "https://www.amazon.com/dp/{}/?tag={}".format(product.asin, h.affiliate_id("amazon")),
+            "source_records": [f"amazon:{product.asin}"],
+            "isbn_10": [product.asin] if asin_is_isbn10 else [],
+            "isbn_13": [isbn_13] if isbn_13 else [],
+            "price": price and price.display_amount,
+            "price_amt": price and price.amount and int(100 * price.amount),
+            "title": (item_info and item_info.title and getattr(item_info.title, "display_value")),
+            "cover": (
                 images.primary.large.url
-                if images
-                and images.primary
-                and images.primary.large
-                and images.primary.large.url
-                and '/01RmK+J4pJL.' not in images.primary.large.url
+                if images and images.primary and images.primary.large and images.primary.large.url and "/01RmK+J4pJL." not in images.primary.large.url
                 else None
             ),
-            'authors': attribution
-            and [
-                {'name': contrib.name}
-                for contrib in attribution.contributors or []
-                if contrib.role == 'Author'
-            ],
-            'contributors': attribution
-            and [
-                {'name': contrib.name, 'role': 'Translator'}
-                for contrib in attribution.contributors or []
-                if contrib.role == 'Translator'
-            ],
-            'publishers': list({p for p in (brand, manufacturer) if p}),
+            "authors": attribution and [{"name": contrib.name} for contrib in attribution.contributors or [] if contrib.role == "Author"],
+            "contributors": attribution
+            and [{"name": contrib.name, "role": "Translator"} for contrib in attribution.contributors or [] if contrib.role == "Translator"],
+            "publishers": list({p for p in (brand, manufacturer) if p}),
             **(
-                {'number_of_pages': edition_info.pages_count.display_value}
+                {"number_of_pages": edition_info.pages_count.display_value}
                 if (
                     edition_info
                     and edition_info.pages_count
@@ -326,21 +275,11 @@ class AmazonAPI:
                 )
                 else {}
             ),
-            'edition_num': (
-                edition_info
-                and edition_info.edition
-                and edition_info.edition.display_value
-            ),
-            'publish_date': publish_date,
-            'product_group': product_group,
-            'physical_format': (
-                item_info
-                and item_info.classifications
-                and getattr(
-                    item_info.classifications.binding, 'display_value', ''
-                ).lower()
-            ),
-            **({'languages': languages} if languages else {}),
+            "edition_num": (edition_info and edition_info.edition and edition_info.edition.display_value),
+            "publish_date": publish_date,
+            "product_group": product_group,
+            "physical_format": (item_info and item_info.classifications and getattr(item_info.classifications.binding, "display_value", "").lower()),
+            **({"languages": languages} if languages else {}),
         }
 
         if is_dvd(book):
@@ -352,8 +291,8 @@ def is_dvd(book) -> bool:
     """
     If product_group or physical_format is a dvd, it will return True.
     """
-    product_group = book['product_group']
-    physical_format = book['physical_format']
+    product_group = book["product_group"]
+    physical_format = book["physical_format"]
 
     try:
         product_group = product_group.lower()
@@ -365,7 +304,7 @@ def is_dvd(book) -> bool:
     except AttributeError:
         physical_format = None
 
-    return 'dvd' in [product_group, physical_format]
+    return "dvd" in [product_group, physical_format]
 
 
 class AmazonCreatorsAPI:
@@ -382,11 +321,11 @@ class AmazonCreatorsAPI:
     """
 
     # Browse-node filtering constants — compiled once at class definition time.
-    _GENERIC_NODES: frozenset[str] = frozenset({'Books', 'Subjects', 'Departments'})
-    _UUID_RE: re.Pattern = re.compile(r'^[0-9a-f]{8}-[0-9a-f]{4}-', re.IGNORECASE)
+    _GENERIC_NODES: frozenset[str] = frozenset({"Books", "Subjects", "Departments"})
+    _UUID_RE: re.Pattern = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-", re.IGNORECASE)
     _INTERNAL_TERMS: re.Pattern = re.compile(
-        r'ASIN|^Test node|^Sponsored|^Textbook Rental|^Special Offer'
-        r'|Challenge Faves|Goodreads',
+        r"ASIN|^Test node|^Sponsored|^Textbook Rental|^Special Offer"
+        r"|Challenge Faves|Goodreads",
         re.IGNORECASE,
     )
 
@@ -396,7 +335,7 @@ class AmazonCreatorsAPI:
         credential_secret: str,
         tag: str,
         version: str = "3.1",
-        country: str = 'US',
+        country: str = "US",
         throttling: float = 0.9,
         proxy_url: str = "",
         proxy_creds: str = "",
@@ -457,8 +396,7 @@ class AmazonCreatorsAPI:
                 self.api._api_client.rest_client = rest_client
             except (ImportError, AttributeError):
                 logger.warning(
-                    "AmazonCreatorsAPI: could not inject proxy — "
-                    "falling back to environment-level proxy (HTTPS_PROXY)",
+                    "AmazonCreatorsAPI: could not inject proxy — falling back to environment-level proxy (HTTPS_PROXY)",
                     exc_info=True,
                 )
 
@@ -514,51 +452,37 @@ class AmazonCreatorsAPI:
         if not product:
             return {}
 
-        item_info = getattr(product, 'item_info', None)
-        images = getattr(product, 'images', None)
-        edition_info = item_info and getattr(item_info, 'content_info', None)
-        attribution = item_info and getattr(item_info, 'by_line_info', None)
+        item_info = getattr(product, "item_info", None)
+        images = getattr(product, "images", None)
+        edition_info = item_info and getattr(item_info, "content_info", None)
+        attribution = item_info and getattr(item_info, "by_line_info", None)
 
         # Creators API: offers_v2 replaces offers
-        offers_v2 = getattr(product, 'offers_v2', None)
-        listings = getattr(offers_v2, 'listings', None) if offers_v2 else None
+        offers_v2 = getattr(product, "offers_v2", None)
+        listings = getattr(offers_v2, "listings", None) if offers_v2 else None
         listing = listings[0] if listings else None
         price = listing and listing.price
 
-        brand = (
-            attribution
-            and getattr(attribution, 'brand', None)
-            and getattr(attribution.brand, 'display_value', None)
-        )
+        brand = attribution and getattr(attribution, "brand", None) and getattr(attribution.brand, "display_value", None)
         manufacturer = (
             item_info
-            and getattr(item_info, 'by_line_info', None)
-            and getattr(item_info.by_line_info, 'manufacturer', None)
+            and getattr(item_info, "by_line_info", None)
+            and getattr(item_info.by_line_info, "manufacturer", None)
             and item_info.by_line_info.manufacturer.display_value
         )
         product_group = (
             item_info
-            and getattr(item_info, 'classifications', None)
-            and getattr(item_info.classifications, 'product_group', None)
+            and getattr(item_info, "classifications", None)
+            and getattr(item_info.classifications, "product_group", None)
             and item_info.classifications.product_group.display_value
         )
 
         languages = []
-        if edition_info and getattr(edition_info, 'languages', None):
-            languages = uniq(
-                lang.display_value
-                for lang in getattr(edition_info.languages, 'display_values', [])
-                if lang.type != 'Original Language'
-            )
+        if edition_info and getattr(edition_info, "languages", None):
+            languages = uniq(lang.display_value for lang in getattr(edition_info.languages, "display_values", []) if lang.type != "Original Language")
 
         try:
-            publish_date = (
-                edition_info
-                and edition_info.publication_date
-                and isoparser.parse(
-                    edition_info.publication_date.display_value
-                ).strftime('%b %d, %Y')
-            )
+            publish_date = edition_info and edition_info.publication_date and isoparser.parse(edition_info.publication_date.display_value).strftime("%b %d, %Y")
         except Exception:
             logger.exception(
                 "AmazonCreatorsAPI.serialize: failed to parse publish_date for asin=%s",
@@ -570,12 +494,8 @@ class AmazonCreatorsAPI:
 
         # Prefer ISBN-13 from external_ids.eans (authoritative); fall back to
         # computing it from the ISBN-10 as we did with PA-API.
-        external_ids = item_info and getattr(item_info, 'external_ids', None)
-        eans = (
-            external_ids
-            and getattr(external_ids, 'eans', None)
-            and getattr(external_ids.eans, 'display_values', None)
-        )
+        external_ids = item_info and getattr(item_info, "external_ids", None)
+        eans = external_ids and getattr(external_ids, "eans", None) and getattr(external_ids.eans, "display_values", None)
         if eans:
             isbn_13_list = [e for e in eans if len(e) == 13]
         elif asin_is_isbn10:
@@ -587,20 +507,13 @@ class AmazonCreatorsAPI:
         # Browse node categories: unique context_free_name from all nodes +
         # their immediate ancestors, excluding generic roots and Amazon-internal
         # nodes (UUIDs, test nodes, internal campaign labels).
-        browse_node_info = getattr(product, 'browse_node_info', None)
-        browse_nodes = (
-            browse_node_info and getattr(browse_node_info, 'browse_nodes', None)
-        ) or []
+        browse_node_info = getattr(product, "browse_node_info", None)
+        browse_nodes = (browse_node_info and getattr(browse_node_info, "browse_nodes", None)) or []
         categories = uniq(
             name
             for node in browse_nodes
             for name in (
-                [getattr(node, 'context_free_name', None)]
-                + (
-                    [getattr(node.ancestor, 'context_free_name', None)]
-                    if getattr(node, 'ancestor', None)
-                    else []
-                )
+                [getattr(node, "context_free_name", None)] + ([getattr(node.ancestor, "context_free_name", None)] if getattr(node, "ancestor", None) else [])
             )
             if name
             and name not in AmazonCreatorsAPI._GENERIC_NODES
@@ -609,101 +522,53 @@ class AmazonCreatorsAPI:
         )
 
         # Availability from the buy-box listing
-        availability = (
-            listing
-            and getattr(listing, 'availability', None)
-            and getattr(listing.availability, 'type', None)
-        )
+        availability = listing and getattr(listing, "availability", None) and getattr(listing.availability, "type", None)
 
         # Savings: percentage off and original list price
-        savings = price and getattr(price, 'savings', None)
-        price_savings_pct = savings and getattr(savings, 'percentage', None)
-        saving_basis = price and getattr(price, 'saving_basis', None)
-        saving_basis_money = saving_basis and getattr(saving_basis, 'money', None)
-        list_price = saving_basis_money and getattr(
-            saving_basis_money, 'display_amount', None
-        )
+        savings = price and getattr(price, "savings", None)
+        price_savings_pct = savings and getattr(savings, "percentage", None)
+        saving_basis = price and getattr(price, "saving_basis", None)
+        saving_basis_money = saving_basis and getattr(saving_basis, "money", None)
+        list_price = saving_basis_money and getattr(saving_basis_money, "display_amount", None)
 
         # Variant images (alternate covers: back, spine, etc.)
-        variants = (images and getattr(images, 'variants', None)) or []
-        image_variants = [
-            v.large.url
-            for v in variants
-            if getattr(v, 'large', None) and getattr(v.large, 'url', None)
-        ]
+        variants = (images and getattr(images, "variants", None)) or []
+        image_variants = [v.large.url for v in variants if getattr(v, "large", None) and getattr(v.large, "url", None)]
 
         book = {
-            'url': "https://www.amazon.com/dp/{}/?tag={}".format(
-                product.asin, h.affiliate_id('amazon')
-            ),
-            'source_records': [f'amazon:{product.asin}'],
-            'isbn_10': [product.asin] if asin_is_isbn10 else [],
-            'isbn_13': isbn_13_list,
+            "url": "https://www.amazon.com/dp/{}/?tag={}".format(product.asin, h.affiliate_id("amazon")),
+            "source_records": [f"amazon:{product.asin}"],
+            "isbn_10": [product.asin] if asin_is_isbn10 else [],
+            "isbn_13": isbn_13_list,
             # Creators API: price is OfferPriceV2 → price.money.display_amount
-            'price': price and price.money and price.money.display_amount,
-            'price_amt': (
-                price
-                and price.money
-                and price.money.amount
-                and int(100 * price.money.amount)
-            ),
-            'title': (
-                item_info
-                and item_info.title
-                and getattr(item_info.title, 'display_value', None)
-            ),
-            'cover': (
+            "price": price and price.money and price.money.display_amount,
+            "price_amt": (price and price.money and price.money.amount and int(100 * price.money.amount)),
+            "title": (item_info and item_info.title and getattr(item_info.title, "display_value", None)),
+            "cover": (
                 images.primary.large.url
-                if images
-                and images.primary
-                and images.primary.large
-                and images.primary.large.url
-                and '/01RmK+J4pJL.' not in images.primary.large.url
+                if images and images.primary and images.primary.large and images.primary.large.url and "/01RmK+J4pJL." not in images.primary.large.url
                 else None
             ),
-            'authors': attribution
-            and [
-                {'name': contrib.name}
-                for contrib in (getattr(attribution, 'contributors', None) or [])
-                if contrib.role == 'Author'
-            ],
-            'contributors': attribution
-            and [
-                {'name': contrib.name, 'role': 'Translator'}
-                for contrib in (getattr(attribution, 'contributors', None) or [])
-                if contrib.role == 'Translator'
-            ],
-            'publishers': list({p for p in (brand, manufacturer) if p}),
+            "authors": attribution and [{"name": contrib.name} for contrib in (getattr(attribution, "contributors", None) or []) if contrib.role == "Author"],
+            "contributors": attribution
+            and [{"name": contrib.name, "role": "Translator"} for contrib in (getattr(attribution, "contributors", None) or []) if contrib.role == "Translator"],
+            "publishers": list({p for p in (brand, manufacturer) if p}),
             **(
-                {'number_of_pages': edition_info.pages_count.display_value}
-                if (
-                    edition_info
-                    and edition_info.pages_count
-                    and edition_info.pages_count.display_value
-                )
+                {"number_of_pages": edition_info.pages_count.display_value}
+                if (edition_info and edition_info.pages_count and edition_info.pages_count.display_value)
                 else {}
             ),
-            'edition_num': (
-                edition_info
-                and edition_info.edition
-                and edition_info.edition.display_value
-            ),
-            'publish_date': publish_date,
-            'product_group': product_group,
-            'physical_format': (
-                item_info
-                and item_info.classifications
-                and getattr(
-                    item_info.classifications.binding, 'display_value', ''
-                ).lower()
-            ),
-            **({'languages': languages} if languages else {}),
+            "edition_num": (edition_info and edition_info.edition and edition_info.edition.display_value),
+            "publish_date": publish_date,
+            "product_group": product_group,
+            "physical_format": (item_info and item_info.classifications and getattr(item_info.classifications.binding, "display_value", "").lower()),
+            **({"languages": languages} if languages else {}),
             # --- Creators API additions ---
-            **({'categories': categories} if categories else {}),
-            **({'availability': availability} if availability else {}),
-            **({'price_savings_pct': price_savings_pct} if price_savings_pct else {}),
-            **({'list_price': list_price} if list_price else {}),
-            **({'image_variants': image_variants} if image_variants else {}),
+            **({"categories": categories} if categories else {}),
+            **({"availability": availability} if availability else {}),
+            **({"price_savings_pct": price_savings_pct} if price_savings_pct else {}),
+            **({"list_price": list_price} if list_price else {}),
+            **({"image_variants": image_variants} if image_variants else {}),
         }
 
         if is_dvd(book):
@@ -713,7 +578,7 @@ class AmazonCreatorsAPI:
 
 def get_amazon_metadata(
     id_: str,
-    id_type: Literal['asin', 'isbn'] = 'isbn',
+    id_type: Literal["asin", "isbn"] = "isbn",
     resources: Any = None,
     high_priority: bool = False,
     stage_import: bool = True,
@@ -736,7 +601,7 @@ def get_amazon_metadata(
     )
 
 
-def search_amazon(title: str = '', author: str = '') -> dict:  # type: ignore[empty-body]
+def search_amazon(title: str = "", author: str = "") -> dict:  # type: ignore[empty-body]
     """Uses the Amazon Product Advertising API ItemSearch operation to search for
     books by author and/or title.
     https://docs.aws.amazon.com/AWSECommerceService/latest/DG/ItemSearch.html
@@ -748,7 +613,7 @@ def search_amazon(title: str = '', author: str = '') -> dict:  # type: ignore[em
 
 def _get_amazon_metadata(
     id_: str,
-    id_type: Literal['asin', 'isbn'] = 'isbn',
+    id_type: Literal["asin", "isbn"] = "isbn",
     resources: Any = None,
     high_priority: bool = False,
     stage_import: bool = True,
@@ -770,12 +635,12 @@ def _get_amazon_metadata(
     if not affiliate_server_url:
         return None
 
-    if id_type == 'isbn':
+    if id_type == "isbn":
         isbn = normalize_isbn(id_)
         if isbn is None:
             return None
         id_ = isbn
-        if len(id_) == 13 and id_.startswith('978'):
+        if len(id_) == 13 and id_.startswith("978"):
             isbn = isbn_13_to_isbn_10(id_)
             if isbn is None:
                 return None
@@ -785,11 +650,11 @@ def _get_amazon_metadata(
         priority = "true" if high_priority else "false"
         stage = "true" if stage_import else "false"
         r = session.get(
-            f'http://{affiliate_server_url}/isbn/{id_}?high_priority={priority}&stage_import={stage}',
+            f"http://{affiliate_server_url}/isbn/{id_}?high_priority={priority}&stage_import={stage}",
             timeout=timeout,
         )
         r.raise_for_status()
-        if data := r.json().get('hit'):
+        if data := r.json().get("hit"):
             return data
         else:
             return None
@@ -809,11 +674,9 @@ def stage_bookworm_metadata(identifier: str | None) -> dict | None:
     if not identifier:
         return None
     try:
-        r = session.get(
-            f"http://{affiliate_server_url}/isbn/{identifier}?high_priority=true&stage_import=true"
-        )
+        r = session.get(f"http://{affiliate_server_url}/isbn/{identifier}?high_priority=true&stage_import=true")
         r.raise_for_status()
-        if data := r.json().get('hit'):
+        if data := r.json().get("hit"):
             return data
         else:
             return None
@@ -832,10 +695,10 @@ def split_amazon_title(full_title: str) -> tuple[str, str | None]:
 
     # strip parenthetical blocks wherever they occur
     # can handle 1 level of nesting
-    re_parens_strip = re.compile(r'\(([^\)\(]*|[^\(]*\([^\)]*\)[^\)]*)\)')
-    full_title = re.sub(re_parens_strip, '', full_title)
+    re_parens_strip = re.compile(r"\(([^\)\(]*|[^\(]*\([^\)]*\)[^\)]*)\)")
+    full_title = re.sub(re_parens_strip, "", full_title)
 
-    titles = full_title.split(':')
+    titles = full_title.split(":")
     subtitle = titles.pop().strip() if len(titles) > 1 else None
     title = ISBD_UNIT_PUNCT.join([unit.strip() for unit in titles])
     return (title, subtitle)
@@ -850,44 +713,42 @@ def clean_amazon_metadata_for_load(metadata: dict) -> dict:
     """
 
     conforming_fields = [
-        'title',
-        'authors',
-        'contributors',
-        'publish_date',
-        'source_records',
-        'number_of_pages',
-        'languages',
-        'publishers',
-        'cover',
-        'isbn_10',
-        'isbn_13',
-        'physical_format',
+        "title",
+        "authors",
+        "contributors",
+        "publish_date",
+        "source_records",
+        "number_of_pages",
+        "languages",
+        "publishers",
+        "cover",
+        "isbn_10",
+        "isbn_13",
+        "physical_format",
     ]
     conforming_metadata = {}
     for k in conforming_fields:
         # if valid key and value not None
         if metadata.get(k) is not None:
             conforming_metadata[k] = metadata[k]
-    if source_records := metadata.get('source_records'):
-        asin = source_records[0].replace('amazon:', '')
+    if source_records := metadata.get("source_records"):
+        asin = source_records[0].replace("amazon:", "")
         if asin[0].isalpha():
             # Only store asin if it provides more information than ISBN
-            conforming_metadata['identifiers'] = {'amazon': [asin]}
-    title, subtitle = split_amazon_title(metadata['title'])
-    conforming_metadata['title'] = title
+            conforming_metadata["identifiers"] = {"amazon": [asin]}
+    title, subtitle = split_amazon_title(metadata["title"])
+    conforming_metadata["title"] = title
     if subtitle:
-        conforming_metadata['full_title'] = f'{title}{ISBD_UNIT_PUNCT}{subtitle}'
-        conforming_metadata['subtitle'] = subtitle
+        conforming_metadata["full_title"] = f"{title}{ISBD_UNIT_PUNCT}{subtitle}"
+        conforming_metadata["subtitle"] = subtitle
     # Record original title if some content has been removed (i.e. parentheses)
-    if metadata['title'] != conforming_metadata.get('full_title', title):
-        conforming_metadata['notes'] = "Source title: %s" % metadata['title']
+    if metadata["title"] != conforming_metadata.get("full_title", title):
+        conforming_metadata["notes"] = "Source title: %s" % metadata["title"]
 
     return conforming_metadata
 
 
-def create_edition_from_amazon_metadata(
-    id_: str, id_type: Literal['asin', 'isbn'] = 'isbn'
-) -> str | None:
+def create_edition_from_amazon_metadata(id_: str, id_type: Literal["asin", "isbn"] = "isbn") -> str | None:
     """Fetches Amazon metadata by id from Amazon Product Advertising API, attempts to
     create OL edition from metadata, and returns the resulting edition key `/key/OL..M`
     if successful or None otherwise.
@@ -899,13 +760,11 @@ def create_edition_from_amazon_metadata(
 
     md = get_amazon_metadata(id_, id_type=id_type)
 
-    if md and md.get('product_group') == 'Book':
-        with accounts.RunAs('ImportBot'):
-            reply = load(
-                clean_amazon_metadata_for_load(md), account_key='account/ImportBot'
-            )
-            if reply and reply.get('success'):
-                return reply['edition'].get('key')
+    if md and md.get("product_group") == "Book":
+        with accounts.RunAs("ImportBot"):
+            reply = load(clean_amazon_metadata_for_load(md), account_key="account/ImportBot")
+            if reply and reply.get("success"):
+                return reply["edition"].get("key")
     return None
 
 
@@ -986,28 +845,26 @@ async def _get_betterworldbooks_metadata(
     url = BETTERWORLDBOOKS_API_URL + isbn
     response = await async_session.get(url, timeout=3)
     if response.status_code != requests.codes.ok:
-        return {'error': response.text, 'code': response.status_code}
+        return {"error": response.text, "code": response.status_code}
     text = response.text
     new_qty = re.findall("<TotalNew>([0-9]+)</TotalNew>", text)
     new_price = re.findall(r"<LowestNewPrice>\$([0-9.]+)</LowestNewPrice>", text)
     used_price = re.findall(r"<LowestUsedPrice>\$([0-9.]+)</LowestUsedPrice>", text)
     used_qty = re.findall("<TotalUsed>([0-9]+)</TotalUsed>", text)
-    market_price = re.findall(
-        r"<LowestMarketPrice>\$([0-9.]+)</LowestMarketPrice>", text
-    )
+    market_price = re.findall(r"<LowestMarketPrice>\$([0-9.]+)</LowestMarketPrice>", text)
     price = qlt = None
 
-    if used_qty and used_qty[0] and used_qty[0] != '0':
-        price = used_price[0] if used_price else ''
-        qlt = 'used'
+    if used_qty and used_qty[0] and used_qty[0] != "0":
+        price = used_price[0] if used_price else ""
+        qlt = "used"
 
-    if new_qty and new_qty[0] and new_qty[0] != '0':
+    if new_qty and new_qty[0] and new_qty[0] != "0":
         _price = new_price[0] if new_price else None
         if _price and (not price or float(_price) < float(price)):
             price = _price
-            qlt = 'new'
+            qlt = "new"
 
-    first_market_price = ('$' + market_price[0]) if market_price else None
+    first_market_price = ("$" + market_price[0]) if market_price else None
     return betterworldbooks_fmt(isbn, qlt, price, first_market_price)
 
 
@@ -1024,10 +881,10 @@ def betterworldbooks_fmt(
     """
     price_fmt = f"${price} ({qlt})" if price and qlt else None
     return {
-        'url': BWB_AFFILIATE_LINK % isbn,
-        'isbn': isbn,
-        'market_price': market_price,
-        'price': price_fmt,
-        'price_amt': price,
-        'qlt': qlt,
+        "url": BWB_AFFILIATE_LINK % isbn,
+        "isbn": isbn,
+        "market_price": market_price,
+        "price": price_fmt,
+        "price_amt": price,
+        "qlt": qlt,
     }

--- a/openlibrary/fastapi/search.py
+++ b/openlibrary/fastapi/search.py
@@ -60,31 +60,21 @@ class PublicQueryOptions(BaseModel):
     public_scan_b: list[Literal["true", "false"]] = []
 
     # List fields (facets)
-    author_key: list[str] = Field(
-        [], description="Filter by author key.", examples=["OL1394244A"]
-    )
-    subject_facet: list[str] = Field(
-        [], description="Filter by subject.", examples=["Fiction", "City planning"]
-    )
+    author_key: list[str] = Field([], description="Filter by author key.", examples=["OL1394244A"])
+    subject_facet: list[str] = Field([], description="Filter by subject.", examples=["Fiction", "City planning"])
     person_facet: list[str] = Field(
         [],
         description="Filter by person. Not the author but the person who is the subject of the work.",
         examples=["Jane Jacobs (1916-2006)", "Cory Doctorow"],
     )
-    place_facet: list[str] = Field(
-        [], description="Filter by place.", examples=["New York", "Xiamen Shi"]
-    )
+    place_facet: list[str] = Field([], description="Filter by place.", examples=["New York", "Xiamen Shi"])
     time_facet: list[str] = Field(
         [],
         description="Filter by time. It can be formatted many ways.",
         examples=["20th century", "To 70 A.D."],
     )
-    first_publish_year: list[str] = Field(
-        [], description="Filter by first publish year.", examples=["2020"]
-    )
-    publisher_facet: list[str] = Field(
-        [], description="Filter by publisher.", examples=["Urban Land Institute"]
-    )
+    first_publish_year: list[str] = Field([], description="Filter by first publish year.", examples=["2020"])
+    publisher_facet: list[str] = Field([], description="Filter by publisher.", examples=["Urban Land Institute"])
     language: list[str] = Field(
         [],
         description="Filter by language using three-letter language codes.",
@@ -166,9 +156,7 @@ class SearchResponse(BaseModel):
 async def search_json(
     request: Request,
     params: Annotated[SearchRequestParams, Query()],
-    solr_internals_params: Annotated[
-        SolrInternalsParams | None, Depends(SolrInternalsParams.from_request)
-    ],
+    solr_internals_params: Annotated[SolrInternalsParams | None, Depends(SolrInternalsParams.from_request)],
 ) -> Any:
     """
     Performs a search for documents based on the provided query.
@@ -261,8 +249,7 @@ def create_sort_option_type(sorts_map: Mapping):
         WithJsonSchema(
             {
                 "type": "string",
-                "enum": list(sorts_map.keys())
-                + [""],  # Include empty string for default
+                "enum": list(sorts_map.keys()) + [""],  # Include empty string for default
             }
         ),
     ]
@@ -275,9 +262,7 @@ class ListSearchRequestParams(PaginationLimit20):
     q: str = Field("", description="The search query")
     fields: str = Field("", description="Fields to return")
     sort: ListSortOption = Field("", description="Sort order")  # type: ignore[valid-type]
-    api: Literal["next", ""] = Field(
-        "", description="API version: 'next' for new format, empty for old format"
-    )
+    api: Literal["next", ""] = Field("", description="API version: 'next' for new format, empty for old format")
 
     @model_validator(mode="after")
     def handle_legacy_logic(self) -> Self:

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -53,9 +53,7 @@ admin_tasks: list[web.storage] = []
 
 def register_admin_page(path, cls, label=None, visible=True, librarians=False):
     label = label or cls.__name__
-    t = web.storage(
-        path=path, cls=cls, label=label, visible=visible, librarians=librarians
-    )
+    t = web.storage(path=path, cls=cls, label=label, visible=visible, librarians=librarians)
     admin_tasks.append(t)
 
 
@@ -69,38 +67,26 @@ def revert_all_user_edits(account: Account) -> tuple[int, int]:
     keys_to_delete = set()
     while not stop:
         changes = account.get_recentchanges(limit=100, offset=100 * i)
-        added_records: list[list[dict]] = [
-            c.changes for c in changes if c.kind == 'add-book'
-        ]
+        added_records: list[list[dict]] = [c.changes for c in changes if c.kind == "add-book"]
         # Also delete lists `created` by this user
         added_records.extend(
-            [r for r in c.changes if r.get('revision') == 1]  # created, not just edited
+            [r for r in c.changes if r.get("revision") == 1]  # created, not just edited
             for c in changes
-            if c.kind == 'lists'
+            if c.kind == "lists"
         )
-        flattened_records: list[dict] = [
-            record for lst in added_records for record in lst
-        ]
-        keys_to_delete |= {r['key'] for r in flattened_records}
+        flattened_records: list[dict] = [record for lst in added_records for record in lst]
+        keys_to_delete |= {r["key"] for r in flattened_records}
 
-        keys_to_revert: dict[str, list[int]] = {
-            item.key: [] for change in changes for item in change.changes
-        }
+        keys_to_revert: dict[str, list[int]] = {item.key: [] for change in changes for item in change.changes}
         for change in changes:
             for item in change.changes:
                 keys_to_revert[item.key].append(change.id)
 
-        deleted_keys = web.ctx.site.things(
-            {'key': list(keys_to_revert), 'type': {'key': '/type/delete'}}
-        )
+        deleted_keys = web.ctx.site.things({"key": list(keys_to_revert), "type": {"key": "/type/delete"}})
 
-        changesets_with_deleted_works = {
-            change_id for key in deleted_keys for change_id in keys_to_revert[key]
-        }
+        changesets_with_deleted_works = {change_id for key in deleted_keys for change_id in keys_to_revert[key]}
 
-        changeset_ids = [
-            c.id for c in changes if c.id not in changesets_with_deleted_works
-        ]
+        changeset_ids = [c.id for c in changes if c.id not in changesets_with_deleted_works]
 
         _, len_docs = revert_changesets(changeset_ids, "Reverted Spam")
         edit_count += len_docs
@@ -108,10 +94,8 @@ def revert_all_user_edits(account: Account) -> tuple[int, int]:
         if len(changes) < 100:
             stop = True
 
-    delete_payload = [
-        {'key': key, 'type': {'key': '/type/delete'}} for key in keys_to_delete
-    ]
-    web.ctx.site.save_many(delete_payload, 'Delete spam', action="bulk-revert-spam")
+    delete_payload = [{"key": key, "type": {"key": "/type/delete"}} for key in keys_to_delete]
+    web.ctx.site.save_many(delete_payload, "Delete spam", action="bulk-revert-spam")
     return edit_count, len(delete_payload)
 
 
@@ -130,12 +114,8 @@ def revert_changesets(changeset_ids: Iterable[int], comment: str):
             return web.ctx.site.get(key, revision).dict()
 
     site = web.ctx.site
-    docs = [
-        get_doc(c['key'], c['revision'] - 1)
-        for cid in changeset_ids
-        for c in site.get_change(cid).changes
-    ]
-    docs = [doc for doc in docs if doc.get('type', {}).get('key') != '/type/delete']
+    docs = [get_doc(c["key"], c["revision"] - 1) for cid in changeset_ids for c in site.get_change(cid).changes]
+    docs = [doc for doc in docs if doc.get("type", {}).get("key") != "/type/delete"]
     data = {"reverted_changesets": [str(cid) for cid in changeset_ids]}
     manifest = web.ctx.site.save_many(docs, action="revert", data=data, comment=comment)
     return manifest, len(docs)
@@ -149,7 +129,7 @@ class admin(delegate.page):
             return self.handle(admin_index)
 
         for t in admin_tasks:
-            m = re.compile('^' + t.path + '$').match(web.ctx.path)
+            m = re.compile("^" + t.path + "$").match(web.ctx.path)
             if m:
                 return self.handle(t.cls, m.groups(), librarians=t.librarians)
         raise web.notfound()
@@ -162,15 +142,9 @@ class admin(delegate.page):
         if not m:
             raise web.nomethod(cls=cls)
         else:
-            if (
-                context.user
-                and context.user.is_librarian()
-                and web.ctx.path == '/admin/solr'
-            ):
+            if context.user and context.user.is_librarian() and web.ctx.path == "/admin/solr":
                 return m(*args)
-            if self.is_admin() or (
-                librarians and context.user and context.user.is_super_librarian()
-            ):
+            if self.is_admin() or (librarians and context.user and context.user.is_super_librarian()):
                 return m(*args)
             else:
                 return render.permission_denied(web.ctx.path, "Permission denied.")
@@ -179,14 +153,12 @@ class admin(delegate.page):
 
     def is_admin(self):
         """Returns True if the current user is in admin usergroup."""
-        return context.user and context.user.key in [
-            m.key for m in web.ctx.site.get('/usergroup/admin').members
-        ]
+        return context.user and context.user.key in [m.key for m in web.ctx.site.get("/usergroup/admin").members]
 
 
 class admin_index:
     def GET(self):
-        return web.seeother('/stats')
+        return web.seeother("/stats")
 
 
 class gitpull:
@@ -195,14 +167,14 @@ class gitpull:
         root = os.path.normpath(root)
 
         p = subprocess.Popen(
-            'cd %s && git pull' % root,
+            "cd %s && git pull" % root,
             shell=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
         )
         out = p.stdout.read()
         p.wait()
-        return '<pre>' + web.websafe(out) + '</pre>'
+        return "<pre>" + web.websafe(out) + "</pre>"
 
 
 class reload:
@@ -234,13 +206,8 @@ def local_ip():
 class _reload(delegate.page):
     def GET(self):
         # make sure the request is coming from the LAN.
-        if (
-            web.ctx.ip not in ['127.0.0.1', '0.0.0.0']
-            and web.ctx.ip.rsplit(".", 1)[0] != local_ip().rsplit(".", 1)[0]
-        ):
-            return render.permission_denied(
-                web.ctx.fullpath, "Permission denied to reload templates/macros."
-            )
+        if web.ctx.ip not in ["127.0.0.1", "0.0.0.0"] and web.ctx.ip.rsplit(".", 1)[0] != local_ip().rsplit(".", 1)[0]:
+            return render.permission_denied(web.ctx.fullpath, "Permission denied to reload templates/macros.")
 
         from infogami.plugins.wikitemplates import code as wikitemplates
 
@@ -276,24 +243,20 @@ class add_work_to_staff_picks:
         return render_template("admin/sync")
 
     def POST(self):
-        i = web.input(action="add", work_id='', subjects='openlibrary_staff_picks')
+        i = web.input(action="add", work_id="", subjects="openlibrary_staff_picks")
         results = {}
-        work_ids = i.work_id.split(',')
-        subjects = i.subjects.split(',')
+        work_ids = i.work_id.split(",")
+        subjects = i.subjects.split(",")
         for work_id in work_ids:
-            work = web.ctx.site.get('/works/%s' % work_id)
+            work = web.ctx.site.get("/works/%s" % work_id)
             editions = work.editions
             ocaids = [edition.ocaid for edition in editions if edition.ocaid]
             results[work_id] = {}
             for ocaid in ocaids:
                 try:
-                    results[work_id][ocaid] = create_ol_subjects_for_ocaid(
-                        ocaid, subjects=subjects
-                    )
+                    results[work_id][ocaid] = create_ol_subjects_for_ocaid(ocaid, subjects=subjects)
                 except ItemLocateError as err:
-                    results[work_id][
-                        ocaid
-                    ] = f'Failed to add to staff picks. Error message: {err}'
+                    results[work_id][ocaid] = f"Failed to add to staff picks. Error message: {err}"
 
         return delegate.RawText(json.dumps(results), content_type="application/json")
 
@@ -306,10 +269,10 @@ class resolve_redirects:
         return self.main(test=False)
 
     def main(self, test=False):
-        params = web.input(key='', test='')
+        params = web.input(key="", test="")
 
         # Provide an escape hatch to let GET requests resolve
-        if test is True and params.test == 'false':
+        if test is True and params.test == "false":
             test = False
 
         # Provide an escape hatch to let POST requests preview
@@ -327,7 +290,7 @@ class sync_ol_ia:
         latest openlibrary_work and openlibrary_edition to the
         Archive.org item's metadata.
         """
-        i = web.input(edition_id='')
+        i = web.input(edition_id="")
         data = update_ia_metadata_for_ol_edition(i.edition_id)
         return delegate.RawText(json.dumps(data), content_type="application/json")
 
@@ -339,7 +302,7 @@ class people_view:
             if "@" in key:
                 raise web.seeother("/admin/people/" + account.username)
             else:
-                return render_template('admin/people/view', account)
+                return render_template("admin/people/view", account)
         else:
             raise web.notfound()
 
@@ -409,9 +372,7 @@ class people_view:
     def POST_update_email(self, account, i):
         user = account.get_user()
         if not forms.vemail.valid(i.email):
-            return render_template(
-                "admin/people/view", user, i, {"email": forms.vemail.msg}
-            )
+            return render_template("admin/people/view", user, i, {"email": forms.vemail.msg})
 
         if not forms.email_not_already_used.valid(i.email):
             return render_template(
@@ -429,9 +390,7 @@ class people_view:
     def POST_update_password(self, account, i):
         user = account.get_user()
         if not forms.vpass.valid(i.password):
-            return render_template(
-                "admin/people/view", user, i, {"password": forms.vpass.msg}
-            )
+            return render_template("admin/people/view", user, i, {"password": forms.vpass.msg})
 
         account.update_password(i.password)
 
@@ -491,12 +450,12 @@ class people_edits:
 
 class ipaddress:
     def GET(self):
-        return render_template('admin/ip/index')
+        return render_template("admin/ip/index")
 
 
 class ipaddress_view:
     def GET(self, ip):
-        return render_template('admin/ip/view', ip)
+        return render_template("admin/ip/view", ip)
 
     def POST(self, ip):
         i = web.input(changesets=[], comment="Revert", action="revert")
@@ -515,9 +474,7 @@ class ipaddress_view:
 
 class stats:
     def GET(self, today):
-        json = web.ctx.site._conn.request(
-            web.ctx.site.name, '/get', 'GET', {'key': '/admin/stats/' + today}
-        )
+        json = web.ctx.site._conn.request(web.ctx.site.name, "/get", "GET", {"key": "/admin/stats/" + today})
         return delegate.RawText(json)
 
     def POST(self, today):
@@ -529,12 +486,12 @@ class stats:
     def get_stats(self, today):
         stats = web.ctx.site._request("/stats/" + today)
 
-        key = '/admin/stats/' + today
-        doc = web.ctx.site.new(key, {'key': key, 'type': {'key': '/type/object'}})
+        key = "/admin/stats/" + today
+        doc = web.ctx.site.new(key, {"key": key, "type": {"key": "/type/object"}})
         doc.edits = {
-            'human': stats.edits - stats.edits_by_bots,
-            'bot': stats.edits_by_bots,
-            'total': stats.edits,
+            "human": stats.edits - stats.edits_by_bots,
+            "bot": stats.edits_by_bots,
+            "total": stats.edits,
         }
         doc.members = stats.new_accounts
         return doc
@@ -542,9 +499,7 @@ class stats:
 
 class block:
     def GET(self):
-        page = web.ctx.site.get("/admin/block") or web.storage(
-            ips=[web.storage(ip="127.0.0.1", duration="1 week", since="1 day")]
-        )
+        page = web.ctx.site.get("/admin/block") or web.storage(ips=[web.storage(ip="127.0.0.1", duration="1 week", since="1 day")])
         return render_template("admin/block", page)
 
     def POST(self):
@@ -555,10 +510,8 @@ class block:
         raise web.seeother("/admin/block")
 
     def block_ips(self, ips):
-        page = web.ctx.get("/admin/block") or web.ctx.site.new(
-            "/admin/block", {"key": "/admin/block", "type": "/type/object"}
-        )
-        page.ips = [{'ip': ip} for ip in ips]
+        page = web.ctx.get("/admin/block") or web.ctx.site.new("/admin/block", {"key": "/admin/block", "type": "/type/object"})
+        page.ips = [{"ip": ip} for ip in ips]
         page._save("updated blocked IPs", action="edit-blocked-ips")
 
 
@@ -570,14 +523,8 @@ def get_blocked_ips():
 
 
 def block_ip_processor(handler):
-    if (
-        not web.ctx.path.startswith("/admin")
-        and (web.ctx.method == "POST" or web.ctx.path.endswith("/edit"))
-        and web.ctx.ip in get_blocked_ips()
-    ):
-        return render_template(
-            "permission_denied", web.ctx.path, "Your IP address is blocked."
-        )
+    if not web.ctx.path.startswith("/admin") and (web.ctx.method == "POST" or web.ctx.path.endswith("/edit")) and web.ctx.ip in get_blocked_ips():
+        return render_template("permission_denied", web.ctx.path, "Your IP address is blocked.")
     else:
         return handler()
 
@@ -609,16 +556,16 @@ def get_admin_stats():
         return g(docs)
 
     def has_doc(date):
-        return bool(web.ctx.site.get('/admin/stats/' + date.isoformat()))
+        return bool(web.ctx.site.get("/admin/stats/" + date.isoformat()))
 
     def g(docs):
         return {
-            'edits': {
-                'human': sum(doc['edits']['human'] for doc in docs),
-                'bot': sum(doc['edits']['bot'] for doc in docs),
-                'total': sum(doc['edits']['total'] for doc in docs),
+            "edits": {
+                "human": sum(doc["edits"]["human"] for doc in docs),
+                "bot": sum(doc["edits"]["bot"] for doc in docs),
+                "total": sum(doc["edits"]["total"] for doc in docs),
             },
-            'members': sum(doc['members'] for doc in docs),
+            "members": sum(doc["members"] for doc in docs),
         }
 
     current_date = date.today()
@@ -632,17 +579,17 @@ def get_admin_stats():
     thismonth = f(daterange(current_date, 0, -30, -1))
 
     xstats = {
-        'edits': {
-            'today': today['edits'],
-            'yesterday': yesterday['edits'],
-            'thisweek': thisweek['edits'],
-            'thismonth': thismonth['edits'],
+        "edits": {
+            "today": today["edits"],
+            "yesterday": yesterday["edits"],
+            "thisweek": thisweek["edits"],
+            "thismonth": thismonth["edits"],
         },
-        'members': {
-            'today': today['members'],
-            'yesterday': yesterday['members'],
-            'thisweek': thisweek['members'],
-            'thismonth': thismonth['members'],
+        "members": {
+            "today": today["members"],
+            "yesterday": yesterday["members"],
+            "thisweek": thisweek["members"],
+            "thismonth": thismonth["members"],
         },
     }
     return storify(xstats)
@@ -772,7 +719,7 @@ class attach_debugger:
 
         # Allow other computers to attach to ptvsd at this IP address and port.
         web.debug("Enabling debugger attachment")
-        debugpy.listen(('0.0.0.0', 3000))  # noqa: T100
+        debugpy.listen(("0.0.0.0", 3000))  # noqa: T100
         web.debug("Waiting for debugger to attach...")
         debugpy.wait_for_client()  # noqa: T100
         web.debug("Debugger attached to port 3000")
@@ -787,8 +734,8 @@ class solr:
 
     def POST(self):
         i = web.input(keys="")
-        keys = i['keys'].strip().split()
-        web.ctx.site.store['solr-force-update'] = {
+        keys = i["keys"].strip().split()
+        web.ctx.site.store["solr-force-update"] = {
             "type": "solr-force-update",
             "keys": keys,
             "_rev": None,
@@ -815,9 +762,7 @@ class imports_add:
 
     def POST(self):
         i = web.input("identifiers")
-        identifiers = [
-            line.strip() for line in i.identifiers.splitlines() if line.strip()
-        ]
+        identifiers = [line.strip() for line in i.identifiers.splitlines() if line.strip()]
         batch_name = "admin"
         batch = imports.Batch.find(batch_name, create=True)
         batch.add_items(identifiers)
@@ -832,9 +777,9 @@ class imports_by_date:
 
 class show_log:
     def GET(self):
-        i = web.input(name='')
+        i = web.input(name="")
         logname = i.name
-        filepath = config.get('errorlog', 'errors') + '/' + logname + '.html'
+        filepath = config.get("errorlog", "errors") + "/" + logname + ".html"
         if os.path.exists(filepath):
             with open(filepath) as f:
                 return f.read()
@@ -848,38 +793,30 @@ class pd_dashboard:
 
 
 def setup():
-    register_admin_page('/admin/git-pull', gitpull, label='git-pull')
-    register_admin_page('/admin/reload', reload, label='Reload Templates')
-    register_admin_page('/admin/people', people, label='People')
-    register_admin_page('/admin/people/([^/]*)', people_view, label='View People')
-    register_admin_page('/admin/people/([^/]*)/edits', people_edits, label='Edits')
-    register_admin_page('/admin/ip', ipaddress, label='IP')
-    register_admin_page('/admin/ip/(.*)', ipaddress_view, label='View IP')
-    register_admin_page(r'/admin/stats/(\d\d\d\d-\d\d-\d\d)', stats, label='Stats JSON')
-    register_admin_page('/admin/block', block, label='')
-    register_admin_page(
-        '/admin/attach_debugger', attach_debugger, label='Attach Debugger'
-    )
-    register_admin_page('/admin/inspect(?:(/.+))?', inspect, label="")
-    register_admin_page('/admin/graphs', _graphs, label="")
-    register_admin_page('/admin/logs', show_log, label="")
-    register_admin_page('/admin/permissions', permissions, label="")
-    register_admin_page('/admin/solr', solr, label="", librarians=True)
-    register_admin_page('/admin/sync', sync_ol_ia, label="", librarians=True)
-    register_admin_page(
-        '/admin/resolve_redirects', resolve_redirects, label="Resolve Redirects"
-    )
+    register_admin_page("/admin/git-pull", gitpull, label="git-pull")
+    register_admin_page("/admin/reload", reload, label="Reload Templates")
+    register_admin_page("/admin/people", people, label="People")
+    register_admin_page("/admin/people/([^/]*)", people_view, label="View People")
+    register_admin_page("/admin/people/([^/]*)/edits", people_edits, label="Edits")
+    register_admin_page("/admin/ip", ipaddress, label="IP")
+    register_admin_page("/admin/ip/(.*)", ipaddress_view, label="View IP")
+    register_admin_page(r"/admin/stats/(\d\d\d\d-\d\d-\d\d)", stats, label="Stats JSON")
+    register_admin_page("/admin/block", block, label="")
+    register_admin_page("/admin/attach_debugger", attach_debugger, label="Attach Debugger")
+    register_admin_page("/admin/inspect(?:(/.+))?", inspect, label="")
+    register_admin_page("/admin/graphs", _graphs, label="")
+    register_admin_page("/admin/logs", show_log, label="")
+    register_admin_page("/admin/permissions", permissions, label="")
+    register_admin_page("/admin/solr", solr, label="", librarians=True)
+    register_admin_page("/admin/sync", sync_ol_ia, label="", librarians=True)
+    register_admin_page("/admin/resolve_redirects", resolve_redirects, label="Resolve Redirects")
 
-    register_admin_page(
-        '/admin/staffpicks', add_work_to_staff_picks, label="", librarians=True
-    )
+    register_admin_page("/admin/staffpicks", add_work_to_staff_picks, label="", librarians=True)
 
-    register_admin_page('/admin/imports', imports_home, label="")
-    register_admin_page('/admin/imports/add', imports_add, label="")
-    register_admin_page(
-        r'/admin/imports/(\d\d\d\d-\d\d-\d\d)', imports_by_date, label=""
-    )
-    register_admin_page('/admin/spamwords', spamwords, label="")
+    register_admin_page("/admin/imports", imports_home, label="")
+    register_admin_page("/admin/imports/add", imports_add, label="")
+    register_admin_page(r"/admin/imports/(\d\d\d\d-\d\d-\d\d)", imports_by_date, label="")
+    register_admin_page("/admin/spamwords", spamwords, label="")
     register_admin_page("/admin/pd", pd_dashboard)
 
     public(get_admin_stats)

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -63,7 +63,7 @@ if TYPE_CHECKING:
 STRIP_CHARS = ",'\" "
 REPLACE_CHARS = "]["
 
-logger = logging.getLogger('openlibrary')
+logger = logging.getLogger("openlibrary")
 
 
 class LanguageMultipleMatchError(Exception):
@@ -182,10 +182,8 @@ def kebab_case(upper_camel_case: str) -> str:
     """
     # Match positions where a lowercase letter is followed by an uppercase letter,
     # or an uppercase letter is followed by another uppercase followed by a lowercase letter.
-    kebab = re.sub(
-        r'([a-z])([A-Z])', r'\1-\2', upper_camel_case
-    )  # Handle camel case boundaries
-    kebab = re.sub(r'([A-Z])([A-Z][a-z])', r'\1-\2', kebab)  # Handle acronyms
+    kebab = re.sub(r"([a-z])([A-Z])", r"\1-\2", upper_camel_case)  # Handle camel case boundaries
+    kebab = re.sub(r"([A-Z])([A-Z][a-z])", r"\1-\2", kebab)  # Handle acronyms
     return kebab.lower()
 
 
@@ -203,37 +201,37 @@ def render_component(
     from openlibrary.plugins.upstream.code import static_url
 
     attrs = attrs or {}
-    attrs_str = ''
+    attrs_str = ""
     for key, val in attrs.items():
         if (json_encode and isinstance(val, dict)) or isinstance(val, list):
             val = json.dumps(val)
             # On the Vue side use decodeURIComponent to decode
             val = urllib.parse.quote(val)
         attrs_str += f' {key}="{val}"'
-    html = ''
+    html = ""
     included = web.ctx.setdefault("included-components", [])
 
     if not included:
         # Support for legacy browsers (see vite.config.mjs)
-        polyfills_url = static_url('build/components/production/ol-polyfills-legacy.js')
+        polyfills_url = static_url("build/components/production/ol-polyfills-legacy.js")
         html += f'<script nomodule src="{polyfills_url}" defer></script>'
 
     if name not in included:
-        url = static_url('build/components/production/ol-%s.js' % name)
-        script_attrs = '' if not asyncDefer else 'async defer'
+        url = static_url("build/components/production/ol-%s.js" % name)
+        script_attrs = "" if not asyncDefer else "async defer"
         html += f'<script type="module" {script_attrs} src="{url}"></script>'
 
-        legacy_url = static_url('build/components/production/ol-%s-legacy.js' % name)
+        legacy_url = static_url("build/components/production/ol-%s-legacy.js" % name)
         html += f'<script nomodule src="{legacy_url}" defer></script>'
 
         included.append(name)
 
-    html += f'<ol-{kebab_case(name)} {attrs_str}></ol-{kebab_case(name)}>'
+    html += f"<ol-{kebab_case(name)} {attrs_str}></ol-{kebab_case(name)}>"
     return html
 
 
 def render_macro(name, args, **kwargs):
-    return dict(web.template.Template.globals['macros'][name](*args, **kwargs))
+    return dict(web.template.Template.globals["macros"][name](*args, **kwargs))
 
 
 @public
@@ -243,13 +241,13 @@ def render_cached_macro(name: str, args: tuple, **kwargs):
     def get_key_prefix():
         req_context = request_context.req_context.get()
         lang = req_context.lang
-        key_prefix = f'{name}.{lang}'
+        key_prefix = f"{name}.{lang}"
         if req_context.print_disabled:
-            key_prefix += '.pd'
+            key_prefix += ".pd"
         if req_context.sfw:
-            key_prefix += '.sfw'
+            key_prefix += ".sfw"
         if req_context.is_bot:
-            key_prefix += '.bot'
+            key_prefix += ".bot"
         return key_prefix
 
     five_minutes = 5 * 60
@@ -264,11 +262,11 @@ def render_cached_macro(name: str, args: tuple, **kwargs):
 
     try:
         page = mc(name, args, **kwargs)
-        if page.get('do_not_cache') == 'True':
+        if page.get("do_not_cache") == "True":
             mc.memcache_delete_by_args(name, args, **kwargs)
         return web.template.TemplateResult(page)
     except (ValueError, TypeError):
-        return '<span>Failed to render macro</span>'
+        return "<span>Failed to render macro</span>"
 
 
 def get_message(name: str, *args) -> str:
@@ -276,9 +274,7 @@ def get_message(name: str, *args) -> str:
     return get_message_from_template("messages", name, args)
 
 
-def get_message_from_template(
-    template_name: str, name: str, args: tuple[(Any, ...)]
-) -> str:
+def get_message_from_template(template_name: str, name: str, args: tuple[(Any, ...)]) -> str:
     d = render_template(template_name).get("messages", {})
     msg = d.get(name) or name.lower().replace("_", " ")
 
@@ -292,7 +288,7 @@ def get_message_from_template(
 def commify_list(items: Iterable[Any]) -> str:
     # Not sure why lang is sometimes ''
 
-    lang = request_context.req_context.get().lang or 'en'
+    lang = request_context.req_context.get().lang or "en"
 
     # If the list item is a template/html element, we strip it
     # so that there is no space before the comma.
@@ -333,7 +329,7 @@ def unflatten(d: dict, separator: str = "--") -> Storage | list[Any]:
             return False
 
     def setvalue(data: dict, k, v) -> None:
-        if '--' in k:
+        if "--" in k:
             k, k2 = k.split(separator, 1)
             setvalue(data.setdefault(k, {}), k2, v)
         else:
@@ -387,34 +383,30 @@ def fuzzy_find(value, options, stopwords=None):
 
 @public
 def radio_input(checked=False, **params) -> str:
-    params['type'] = 'radio'
+    params["type"] = "radio"
     if checked:
-        params['checked'] = "checked"
-    return "<input %s />" % " ".join(
-        [f'{k}="{web.websafe(v)}"' for k, v in params.items()]
-    )
+        params["checked"] = "checked"
+    return "<input %s />" % " ".join([f'{k}="{web.websafe(v)}"' for k, v in params.items()])
 
 
 def get_coverstore_url() -> str:
-    return config.get('coverstore_url', 'https://covers.openlibrary.org').rstrip('/')
+    return config.get("coverstore_url", "https://covers.openlibrary.org").rstrip("/")
 
 
 @public
 def get_coverstore_public_url() -> str:
-    if OL_COVERSTORE_PUBLIC_URL := os.environ.get('OL_COVERSTORE_PUBLIC_URL'):
-        return OL_COVERSTORE_PUBLIC_URL.rstrip('/')
+    if OL_COVERSTORE_PUBLIC_URL := os.environ.get("OL_COVERSTORE_PUBLIC_URL"):
+        return OL_COVERSTORE_PUBLIC_URL.rstrip("/")
     else:
-        return config.get('coverstore_public_url', get_coverstore_url()).rstrip('/')
+        return config.get("coverstore_public_url", get_coverstore_url()).rstrip("/")
 
 
-def _get_changes_v1_raw(
-    query: dict[str, str | int], revision: int | None = None
-) -> list[Storage]:
+def _get_changes_v1_raw(query: dict[str, str | int], revision: int | None = None) -> list[Storage]:
     """Returns the raw versions response.
 
     Revision is taken as argument to make sure a new cache entry is used when a new revision of the page is created.
     """
-    if 'env' not in web.ctx:
+    if "env" not in web.ctx:
         delegate.fakeload()
 
     versions = web.ctx.site.versions(query)
@@ -425,14 +417,12 @@ def _get_changes_v1_raw(
 
         # XXX-Anand: hack to avoid too big data to be stored in memcache.
         # v.changes is not used and it contributes to memcache bloat in a big way.
-        v.changes = '[]'
+        v.changes = "[]"
 
     return versions
 
 
-def get_changes_v1(
-    query: dict[str, str | int], revision: int | None = None
-) -> list[Storage]:
+def get_changes_v1(query: dict[str, str | int], revision: int | None = None) -> list[Storage]:
     # uses the cached function _get_changes_v1_raw to get the raw data
     # and processes to before returning.
     def process(v):
@@ -444,14 +434,12 @@ def get_changes_v1(
     return [process(v) for v in _get_changes_v1_raw(query, revision)]
 
 
-def _get_changes_v2_raw(
-    query: dict[str, str | int], revision: int | None = None
-) -> list[dict]:
+def _get_changes_v2_raw(query: dict[str, str | int], revision: int | None = None) -> list[dict]:
     """Returns the raw recentchanges response.
 
     Revision is taken as argument to make sure a new cache entry is used when a new revision of the page is created.
     """
-    if 'env' not in web.ctx:
+    if "env" not in web.ctx:
         delegate.fakeload()
 
     changes = web.ctx.site.recentchanges(query)
@@ -462,10 +450,8 @@ def _get_changes_v2_raw(
 # _get_changes_v2_raw = cache.memcache_memoize(_get_changes_v2_raw, key_prefix="upstream._get_changes_v2_raw", timeout=10*60)
 
 
-def get_changes_v2(
-    query: dict[str, str | int], revision: int | None = None
-) -> list[Changeset]:
-    page = web.ctx.site.get(query['key'])
+def get_changes_v2(query: dict[str, str | int], revision: int | None = None) -> list[Changeset]:
+    page = web.ctx.site.get(query["key"])
 
     def first(seq, default=None):
         try:
@@ -487,27 +473,21 @@ def get_changes_v2(
         return change
 
     def get_comment(change):
-        t = get_template("recentchanges/" + change.kind + "/comment") or get_template(
-            "recentchanges/default/comment"
-        )
+        t = get_template("recentchanges/" + change.kind + "/comment") or get_template("recentchanges/default/comment")
         return t(change, page)
 
-    query['key'] = page.key
+    query["key"] = page.key
     changes = _get_changes_v2_raw(query, revision=page.revision)
     return [process_change(c) for c in changes]
 
 
-def get_changes(
-    query: dict[str, str | int], revision: int | None = None
-) -> list[Changeset]:
+def get_changes(query: dict[str, str | int], revision: int | None = None) -> list[Changeset]:
     return get_changes_v2(query, revision=revision)
 
 
 @public
 def get_history(page: "Work | Author | Edition") -> Storage:
-    h = Storage(
-        revision=page.revision, lastest_revision=page.revision, created=page.created
-    )
+    h = Storage(revision=page.revision, lastest_revision=page.revision, created=page.created)
     if h.revision < 5:
         h.recent = get_changes({"key": page.key, "limit": 5}, revision=page.revision)
         h.initial = h.recent[-1:]
@@ -532,9 +512,7 @@ def get_version(key, revision):
 
 @public
 def get_recent_author(doc: "Work") -> "Thing | None":
-    versions = get_changes_v1(
-        {'key': doc.key, 'limit': 1, "offset": 0}, revision=doc.revision
-    )
+    versions = get_changes_v1({"key": doc.key, "limit": 1, "offset": 0}, revision=doc.revision)
     if versions:
         return versions[0].author
     return None
@@ -542,9 +520,7 @@ def get_recent_author(doc: "Work") -> "Thing | None":
 
 @public
 def get_recent_accounts(limit=5, offset=0):
-    versions = web.ctx.site.versions(
-        {'type': '/type/user', 'revision': 1, 'limit': limit, 'offset': offset}
-    )
+    versions = web.ctx.site.versions({"type": "/type/user", "revision": 1, "limit": limit, "offset": offset})
     return web.ctx.site.get_many([v.key for v in versions])
 
 
@@ -570,13 +546,13 @@ def process_version(v: HasGetKeyRevision) -> HasGetKeyRevision:
         "add publisher and source",
     ]
 
-    if v.key.startswith('/books/') and not v.get('machine_comment'):
-        thing = v.get('thing') or web.ctx.site.get(v.key, v.revision)
+    if v.key.startswith("/books/") and not v.get("machine_comment"):
+        thing = v.get("thing") or web.ctx.site.get(v.key, v.revision)
         if (thing.source_records and v.revision == 1) or (
             v.comment and v.comment.lower() in comments  # type: ignore [attr-defined]
         ):
             marc = thing.source_records[-1]
-            if marc.startswith('marc:'):
+            if marc.startswith("marc:"):
                 v.machine_comment = marc[len("marc:") :]  # type: ignore [attr-defined]
             else:
                 v.machine_comment = marc  # type: ignore [attr-defined]
@@ -601,23 +577,23 @@ class Metatag:
         self.attrs = attrs
 
     def __str__(self) -> str:
-        attrs = ' '.join(f'{k}="{websafe(v)}"' for k, v in self.attrs.items())
-        return f'<{self.tag} {attrs} />'
+        attrs = " ".join(f'{k}="{websafe(v)}"' for k, v in self.attrs.items())
+        return f"<{self.tag} {attrs} />"
 
     def __repr__(self) -> str:
-        return 'Metatag(%s)' % str(self)
+        return "Metatag(%s)" % str(self)
 
 
 @public
 def add_metatag(tag: str = "meta", **attrs) -> None:
-    context.setdefault('metatags', [])
+    context.setdefault("metatags", [])
     context.metatags.append(Metatag(tag, **attrs))
 
 
 @public
 def url_quote(text: str | bytes) -> str:
     if isinstance(text, str):
-        text = text.encode('utf8')
+        text = text.encode("utf8")
     return urllib.parse.quote_plus(text)
 
 
@@ -631,7 +607,7 @@ def urlencode(dict_or_list_of_tuples: dict | list[tuple[str, Any]], plus=True) -
     tuples = dict_or_list_of_tuples
     if isinstance(dict_or_list_of_tuples, dict):
         tuples = list(dict_or_list_of_tuples.items())
-    params = [(k, v.encode('utf-8') if isinstance(v, str) else v) for (k, v) in tuples]
+    params = [(k, v.encode("utf-8") if isinstance(v, str) else v) for (k, v) in tuples]
     return og_urlencode(params, quote_via=quote_plus if plus else quote)
 
 
@@ -640,9 +616,7 @@ def entity_decode(text: str) -> str:
 
 
 @public
-def set_share_links(
-    url: str = '#', title: str = '', view_context: InfogamiContext | None = None
-) -> None:
+def set_share_links(url: str = "#", title: str = "", view_context: InfogamiContext | None = None) -> None:
     """
     Constructs list share links for social platforms and assigns to view context attribute
 
@@ -655,16 +629,16 @@ def set_share_links(
     text = url_quote("Check this out: " + entity_decode(title))
     links = [
         {
-            'text': 'Facebook',
-            'url': 'https://www.facebook.com/sharer/sharer.php?u=' + encoded_url,
+            "text": "Facebook",
+            "url": "https://www.facebook.com/sharer/sharer.php?u=" + encoded_url,
         },
         {
-            'text': 'Twitter',
-            'url': f'https://twitter.com/intent/tweet?url={encoded_url}&via=openlibrary&text={text}',
+            "text": "Twitter",
+            "url": f"https://twitter.com/intent/tweet?url={encoded_url}&via=openlibrary&text={text}",
         },
         {
-            'text': 'Pinterest',
-            'url': f'https://pinterest.com/pin/create/link/?url={encoded_url}&description={text}',
+            "text": "Pinterest",
+            "url": f"https://pinterest.com/pin/create/link/?url={encoded_url}&description={text}",
         },
     ]
     if view_context is not None:
@@ -690,14 +664,10 @@ def safeget[T](func: Callable[[], T], default=None) -> T:
 def strip_accents(s: str) -> str:
     # http://stackoverflow.com/questions/517923/what-is-the-best-way-to-remove-accents-in-a-python-unicode-string
     try:
-        s.encode('ascii')
+        s.encode("ascii")
         return s
     except UnicodeEncodeError:
-        return ''.join(
-            c
-            for c in unicodedata.normalize('NFD', s)
-            if unicodedata.category(c) != 'Mn'
-        )
+        return "".join(c for c in unicodedata.normalize("NFD", s) if unicodedata.category(c) != "Mn")
 
 
 @functools.cache
@@ -727,15 +697,15 @@ def autocomplete_languages(prefix: str) -> Iterator[Storage]:
     def get_names_to_try(lang: dict) -> Generator[str | None, None, None]:
         # For each language attempt to match based on:
         # The language's name translated into the current user's chosen language (user_lang)
-        user_lang = request_context.req_context.get().lang or 'en'
-        yield safeget(lambda: lang['name_translated'][user_lang][0])
+        user_lang = request_context.req_context.get().lang or "en"
+        yield safeget(lambda: lang["name_translated"][user_lang][0])
 
         # The language's name translated into its native name (lang_iso_code)
-        lang_iso_code = safeget(lambda: lang['identifiers']['iso_639_1'][0])
-        yield safeget(lambda: lang['name_translated'][lang_iso_code][0])
+        lang_iso_code = safeget(lambda: lang["identifiers"]["iso_639_1"][0])
+        yield safeget(lambda: lang["name_translated"][lang_iso_code][0])
 
         # The language's name as it was fetched from get_languages() (None)
-        yield lang['name']
+        yield lang["name"]
 
     def normalize_for_search(s: str) -> str:
         return strip_accents(s).lower()
@@ -777,11 +747,7 @@ def get_abbrev_from_full_lang_name(input_lang_name: str, languages=None) -> str:
     for language in languages:
         language_names = itertools.chain(
             (language.name,),
-            (
-                name
-                for key in language.name_translated
-                for name in language.name_translated[key]
-            ),
+            (name for key in language.name_translated for name in language.name_translated[key]),
         )
 
         for name in language_names:
@@ -814,353 +780,351 @@ def get_marc21_language(language: str) -> str | None:
     biased towards abbreviations in ISBNdb.
     """
     language_map = {
-        'ab': 'abk',
-        'af': 'afr',
-        'afr': 'afr',
-        'afrikaans': 'afr',
-        'agq': 'agq',
-        'ak': 'aka',
-        'akk': 'akk',
-        'alb': 'alb',
-        'alg': 'alg',
-        'am': 'amh',
-        'amh': 'amh',
-        'ang': 'ang',
-        'apa': 'apa',
-        'ar': 'ara',
-        'ara': 'ara',
-        'arabic': 'ara',
-        'arc': 'arc',
-        'arm': 'arm',
-        'asa': 'asa',
-        'aus': 'aus',
-        'ave': 'ave',
-        'az': 'aze',
-        'aze': 'aze',
-        'ba': 'bak',
-        'baq': 'baq',
-        'be': 'bel',
-        'bel': 'bel',
-        'bem': 'bem',
-        'ben': 'ben',
-        'bengali': 'ben',
-        'bg': 'bul',
-        'bis': 'bis',
-        'bislama': 'bis',
-        'bm': 'bam',
-        'bn': 'ben',
-        'bos': 'bos',
-        'br': 'bre',
-        'bre': 'bre',
-        'breton': 'bre',
-        'bul': 'bul',
-        'bulgarian': 'bul',
-        'bur': 'bur',
-        'ca': 'cat',
-        'cat': 'cat',
-        'catalan': 'cat',
-        'cau': 'cau',
-        'cel': 'cel',
-        'chi': 'chi',
-        'chinese': 'chi',
-        'chu': 'chu',
-        'cop': 'cop',
-        'cor': 'cor',
-        'cos': 'cos',
-        'cpe': 'cpe',
-        'cpf': 'cpf',
-        'cre': 'cre',
-        'croatian': 'hrv',
-        'crp': 'crp',
-        'cs': 'cze',
-        'cy': 'wel',
-        'cze': 'cze',
-        'czech': 'cze',
-        'da': 'dan',
-        'dan': 'dan',
-        'danish': 'dan',
-        'de': 'ger',
-        'dut': 'dut',
-        'dutch': 'dut',
-        'dv': 'div',
-        'dz': 'dzo',
-        'ebu': 'ceb',
-        'egy': 'egy',
-        'el': 'gre',
-        'en': 'eng',
-        'en_us': 'eng',
-        'enf': 'enm',
-        'eng': 'eng',
-        'english': 'eng',
-        'enm': 'enm',
-        'eo': 'epo',
-        'epo': 'epo',
-        'es': 'spa',
-        'esk': 'esk',
-        'esp': 'und',
-        'est': 'est',
-        'et': 'est',
-        'eu': 'eus',
-        'f': 'fre',
-        'fa': 'per',
-        'ff': 'ful',
-        'fi': 'fin',
-        'fij': 'fij',
-        'filipino': 'fil',
-        'fin': 'fin',
-        'finnish': 'fin',
-        'fle': 'fre',
-        'fo': 'fao',
-        'fon': 'fon',
-        'fr': 'fre',
-        'fra': 'fre',
-        'fre': 'fre',
-        'french': 'fre',
-        'fri': 'fri',
-        'frm': 'frm',
-        'fro': 'fro',
-        'fry': 'fry',
-        'ful': 'ful',
-        'ga': 'gae',
-        'gae': 'gae',
-        'gem': 'gem',
-        'geo': 'geo',
-        'ger': 'ger',
-        'german': 'ger',
-        'gez': 'gez',
-        'gil': 'gil',
-        'gl': 'glg',
-        'gla': 'gla',
-        'gle': 'gle',
-        'glg': 'glg',
-        'gmh': 'gmh',
-        'grc': 'grc',
-        'gre': 'gre',
-        'greek': 'gre',
-        'gsw': 'gsw',
-        'guj': 'guj',
-        'hat': 'hat',
-        'hau': 'hau',
-        'haw': 'haw',
-        'heb': 'heb',
-        'hebrew': 'heb',
-        'her': 'her',
-        'hi': 'hin',
-        'hin': 'hin',
-        'hindi': 'hin',
-        'hmn': 'hmn',
-        'hr': 'hrv',
-        'hrv': 'hrv',
-        'hu': 'hun',
-        'hun': 'hun',
-        'hy': 'hye',
-        'ice': 'ice',
-        'id': 'ind',
-        'iku': 'iku',
-        'in': 'ind',
-        'ind': 'ind',
-        'indonesian': 'ind',
-        'ine': 'ine',
-        'ira': 'ira',
-        'iri': 'iri',
-        'irish': 'iri',
-        'is': 'ice',
-        'it': 'ita',
-        'ita': 'ita',
-        'italian': 'ita',
-        'iw': 'heb',
-        'ja': 'jpn',
-        'jap': 'jpn',
-        'japanese': 'jpn',
-        'jpn': 'jpn',
-        'ka': 'kat',
-        'kab': 'kab',
-        'khi': 'khi',
-        'khm': 'khm',
-        'kin': 'kin',
-        'kk': 'kaz',
-        'km': 'khm',
-        'ko': 'kor',
-        'kon': 'kon',
-        'kor': 'kor',
-        'korean': 'kor',
-        'kur': 'kur',
-        'ky': 'kir',
-        'la': 'lat',
-        'lad': 'lad',
-        'lan': 'und',
-        'lat': 'lat',
-        'latin': 'lat',
-        'lav': 'lav',
-        'lcc': 'und',
-        'lit': 'lit',
-        'lo': 'lao',
-        'lt': 'ltz',
-        'ltz': 'ltz',
-        'lv': 'lav',
-        'mac': 'mac',
-        'mal': 'mal',
-        'mao': 'mao',
-        'map': 'map',
-        'mar': 'mar',
-        'may': 'may',
-        'mfe': 'mfe',
-        'mic': 'mic',
-        'mis': 'mis',
-        'mk': 'mkh',
-        'ml': 'mal',
-        'mla': 'mla',
-        'mlg': 'mlg',
-        'mlt': 'mlt',
-        'mn': 'mon',
-        'moh': 'moh',
-        'mon': 'mon',
-        'mr': 'mar',
-        'ms': 'msa',
-        'mt': 'mlt',
-        'mul': 'mul',
-        'my': 'bur',
-        'mya': 'bur',
-        'burmese': 'bur',
-        'myn': 'myn',
-        'nai': 'nai',
-        'nav': 'nav',
-        'nde': 'nde',
-        'ndo': 'ndo',
-        'ne': 'nep',
-        'nep': 'nep',
-        'nic': 'nic',
-        'nl': 'dut',
-        'nor': 'nor',
-        'norwegian': 'nor',
-        'nso': 'sot',
-        'ny': 'nya',
-        'oc': 'oci',
-        'oci': 'oci',
-        'oji': 'oji',
-        'old norse': 'non',
-        'opy': 'und',
-        'ori': 'ori',
-        'ota': 'ota',
-        'paa': 'paa',
-        'pal': 'pal',
-        'pan': 'pan',
-        'per': 'per',
-        'persian': 'per',
-        'farsi': 'per',
-        'pl': 'pol',
-        'pli': 'pli',
-        'pol': 'pol',
-        'polish': 'pol',
-        'por': 'por',
-        'portuguese': 'por',
-        'pra': 'pra',
-        'pro': 'pro',
-        'ps': 'pus',
-        'pt': 'por',
-        'pt-br': 'por',
-        'que': 'que',
-        'ro': 'rum',
-        'roa': 'roa',
-        'roh': 'roh',
-        'romanian': 'rum',
-        'ru': 'rus',
-        'rum': 'rum',
-        'rus': 'rus',
-        'russian': 'rus',
-        'rw': 'kin',
-        'sai': 'sai',
-        'san': 'san',
-        'scc': 'srp',
-        'sco': 'sco',
-        'scottish gaelic': 'gla',
-        'scr': 'scr',
-        'sesotho': 'sot',
-        'sho': 'sna',
-        'shona': 'sna',
-        'si': 'sin',
-        'sl': 'slv',
-        'sla': 'sla',
-        'slo': 'slv',
-        'slovenian': 'slv',
-        'slv': 'slv',
-        'smo': 'smo',
-        'sna': 'sna',
-        'som': 'som',
-        'sot': 'sot',
-        'sotho': 'sot',
-        'spa': 'spa',
-        'spanish': 'spa',
-        'sq': 'alb',
-        'sr': 'srp',
-        'srp': 'srp',
-        'srr': 'srr',
-        'sso': 'sso',
-        'ssw': 'ssw',
-        'st': 'sot',
-        'sux': 'sux',
-        'sv': 'swe',
-        'sw': 'swa',
-        'swa': 'swa',
-        'swahili': 'swa',
-        'swe': 'swe',
-        'swedish': 'swe',
-        'swz': 'ssw',
-        'syc': 'syc',
-        'syr': 'syr',
-        'ta': 'tam',
-        'tag': 'tgl',
-        'tah': 'tah',
-        'tam': 'tam',
-        'tel': 'tel',
-        'tg': 'tgk',
-        'tgl': 'tgl',
-        'th': 'tha',
-        'tha': 'tha',
-        'tib': 'tib',
-        'tl': 'tgl',
-        'tr': 'tur',
-        'tsn': 'tsn',
-        'tso': 'sot',
-        'tsonga': 'tsonga',
-        'tsw': 'tsw',
-        'tswana': 'tsw',
-        'tur': 'tur',
-        'turkish': 'tur',
-        'tut': 'tut',
-        'uk': 'ukr',
-        'ukr': 'ukr',
-        'un': 'und',
-        'und': 'und',
-        'urd': 'urd',
-        'urdu': 'urd',
-        'uz': 'uzb',
-        'uzb': 'uzb',
-        'ven': 'ven',
-        'vi': 'vie',
-        'vie': 'vie',
-        'wel': 'wel',
-        'welsh': 'wel',
-        'wen': 'wen',
-        'wol': 'wol',
-        'xho': 'xho',
-        'xhosa': 'xho',
-        'yid': 'yid',
-        'yor': 'yor',
-        'yu': 'ypk',
-        'zh': 'chi',
-        'zh-cn': 'chi',
-        'zh-tw': 'chi',
-        'zul': 'zul',
-        'zulu': 'zul',
+        "ab": "abk",
+        "af": "afr",
+        "afr": "afr",
+        "afrikaans": "afr",
+        "agq": "agq",
+        "ak": "aka",
+        "akk": "akk",
+        "alb": "alb",
+        "alg": "alg",
+        "am": "amh",
+        "amh": "amh",
+        "ang": "ang",
+        "apa": "apa",
+        "ar": "ara",
+        "ara": "ara",
+        "arabic": "ara",
+        "arc": "arc",
+        "arm": "arm",
+        "asa": "asa",
+        "aus": "aus",
+        "ave": "ave",
+        "az": "aze",
+        "aze": "aze",
+        "ba": "bak",
+        "baq": "baq",
+        "be": "bel",
+        "bel": "bel",
+        "bem": "bem",
+        "ben": "ben",
+        "bengali": "ben",
+        "bg": "bul",
+        "bis": "bis",
+        "bislama": "bis",
+        "bm": "bam",
+        "bn": "ben",
+        "bos": "bos",
+        "br": "bre",
+        "bre": "bre",
+        "breton": "bre",
+        "bul": "bul",
+        "bulgarian": "bul",
+        "bur": "bur",
+        "ca": "cat",
+        "cat": "cat",
+        "catalan": "cat",
+        "cau": "cau",
+        "cel": "cel",
+        "chi": "chi",
+        "chinese": "chi",
+        "chu": "chu",
+        "cop": "cop",
+        "cor": "cor",
+        "cos": "cos",
+        "cpe": "cpe",
+        "cpf": "cpf",
+        "cre": "cre",
+        "croatian": "hrv",
+        "crp": "crp",
+        "cs": "cze",
+        "cy": "wel",
+        "cze": "cze",
+        "czech": "cze",
+        "da": "dan",
+        "dan": "dan",
+        "danish": "dan",
+        "de": "ger",
+        "dut": "dut",
+        "dutch": "dut",
+        "dv": "div",
+        "dz": "dzo",
+        "ebu": "ceb",
+        "egy": "egy",
+        "el": "gre",
+        "en": "eng",
+        "en_us": "eng",
+        "enf": "enm",
+        "eng": "eng",
+        "english": "eng",
+        "enm": "enm",
+        "eo": "epo",
+        "epo": "epo",
+        "es": "spa",
+        "esk": "esk",
+        "esp": "und",
+        "est": "est",
+        "et": "est",
+        "eu": "eus",
+        "f": "fre",
+        "fa": "per",
+        "ff": "ful",
+        "fi": "fin",
+        "fij": "fij",
+        "filipino": "fil",
+        "fin": "fin",
+        "finnish": "fin",
+        "fle": "fre",
+        "fo": "fao",
+        "fon": "fon",
+        "fr": "fre",
+        "fra": "fre",
+        "fre": "fre",
+        "french": "fre",
+        "fri": "fri",
+        "frm": "frm",
+        "fro": "fro",
+        "fry": "fry",
+        "ful": "ful",
+        "ga": "gae",
+        "gae": "gae",
+        "gem": "gem",
+        "geo": "geo",
+        "ger": "ger",
+        "german": "ger",
+        "gez": "gez",
+        "gil": "gil",
+        "gl": "glg",
+        "gla": "gla",
+        "gle": "gle",
+        "glg": "glg",
+        "gmh": "gmh",
+        "grc": "grc",
+        "gre": "gre",
+        "greek": "gre",
+        "gsw": "gsw",
+        "guj": "guj",
+        "hat": "hat",
+        "hau": "hau",
+        "haw": "haw",
+        "heb": "heb",
+        "hebrew": "heb",
+        "her": "her",
+        "hi": "hin",
+        "hin": "hin",
+        "hindi": "hin",
+        "hmn": "hmn",
+        "hr": "hrv",
+        "hrv": "hrv",
+        "hu": "hun",
+        "hun": "hun",
+        "hy": "hye",
+        "ice": "ice",
+        "id": "ind",
+        "iku": "iku",
+        "in": "ind",
+        "ind": "ind",
+        "indonesian": "ind",
+        "ine": "ine",
+        "ira": "ira",
+        "iri": "iri",
+        "irish": "iri",
+        "is": "ice",
+        "it": "ita",
+        "ita": "ita",
+        "italian": "ita",
+        "iw": "heb",
+        "ja": "jpn",
+        "jap": "jpn",
+        "japanese": "jpn",
+        "jpn": "jpn",
+        "ka": "kat",
+        "kab": "kab",
+        "khi": "khi",
+        "khm": "khm",
+        "kin": "kin",
+        "kk": "kaz",
+        "km": "khm",
+        "ko": "kor",
+        "kon": "kon",
+        "kor": "kor",
+        "korean": "kor",
+        "kur": "kur",
+        "ky": "kir",
+        "la": "lat",
+        "lad": "lad",
+        "lan": "und",
+        "lat": "lat",
+        "latin": "lat",
+        "lav": "lav",
+        "lcc": "und",
+        "lit": "lit",
+        "lo": "lao",
+        "lt": "ltz",
+        "ltz": "ltz",
+        "lv": "lav",
+        "mac": "mac",
+        "mal": "mal",
+        "mao": "mao",
+        "map": "map",
+        "mar": "mar",
+        "may": "may",
+        "mfe": "mfe",
+        "mic": "mic",
+        "mis": "mis",
+        "mk": "mkh",
+        "ml": "mal",
+        "mla": "mla",
+        "mlg": "mlg",
+        "mlt": "mlt",
+        "mn": "mon",
+        "moh": "moh",
+        "mon": "mon",
+        "mr": "mar",
+        "ms": "msa",
+        "mt": "mlt",
+        "mul": "mul",
+        "my": "bur",
+        "mya": "bur",
+        "burmese": "bur",
+        "myn": "myn",
+        "nai": "nai",
+        "nav": "nav",
+        "nde": "nde",
+        "ndo": "ndo",
+        "ne": "nep",
+        "nep": "nep",
+        "nic": "nic",
+        "nl": "dut",
+        "nor": "nor",
+        "norwegian": "nor",
+        "nso": "sot",
+        "ny": "nya",
+        "oc": "oci",
+        "oci": "oci",
+        "oji": "oji",
+        "old norse": "non",
+        "opy": "und",
+        "ori": "ori",
+        "ota": "ota",
+        "paa": "paa",
+        "pal": "pal",
+        "pan": "pan",
+        "per": "per",
+        "persian": "per",
+        "farsi": "per",
+        "pl": "pol",
+        "pli": "pli",
+        "pol": "pol",
+        "polish": "pol",
+        "por": "por",
+        "portuguese": "por",
+        "pra": "pra",
+        "pro": "pro",
+        "ps": "pus",
+        "pt": "por",
+        "pt-br": "por",
+        "que": "que",
+        "ro": "rum",
+        "roa": "roa",
+        "roh": "roh",
+        "romanian": "rum",
+        "ru": "rus",
+        "rum": "rum",
+        "rus": "rus",
+        "russian": "rus",
+        "rw": "kin",
+        "sai": "sai",
+        "san": "san",
+        "scc": "srp",
+        "sco": "sco",
+        "scottish gaelic": "gla",
+        "scr": "scr",
+        "sesotho": "sot",
+        "sho": "sna",
+        "shona": "sna",
+        "si": "sin",
+        "sl": "slv",
+        "sla": "sla",
+        "slo": "slv",
+        "slovenian": "slv",
+        "slv": "slv",
+        "smo": "smo",
+        "sna": "sna",
+        "som": "som",
+        "sot": "sot",
+        "sotho": "sot",
+        "spa": "spa",
+        "spanish": "spa",
+        "sq": "alb",
+        "sr": "srp",
+        "srp": "srp",
+        "srr": "srr",
+        "sso": "sso",
+        "ssw": "ssw",
+        "st": "sot",
+        "sux": "sux",
+        "sv": "swe",
+        "sw": "swa",
+        "swa": "swa",
+        "swahili": "swa",
+        "swe": "swe",
+        "swedish": "swe",
+        "swz": "ssw",
+        "syc": "syc",
+        "syr": "syr",
+        "ta": "tam",
+        "tag": "tgl",
+        "tah": "tah",
+        "tam": "tam",
+        "tel": "tel",
+        "tg": "tgk",
+        "tgl": "tgl",
+        "th": "tha",
+        "tha": "tha",
+        "tib": "tib",
+        "tl": "tgl",
+        "tr": "tur",
+        "tsn": "tsn",
+        "tso": "sot",
+        "tsonga": "tsonga",
+        "tsw": "tsw",
+        "tswana": "tsw",
+        "tur": "tur",
+        "turkish": "tur",
+        "tut": "tut",
+        "uk": "ukr",
+        "ukr": "ukr",
+        "un": "und",
+        "und": "und",
+        "urd": "urd",
+        "urdu": "urd",
+        "uz": "uzb",
+        "uzb": "uzb",
+        "ven": "ven",
+        "vi": "vie",
+        "vie": "vie",
+        "wel": "wel",
+        "welsh": "wel",
+        "wen": "wen",
+        "wol": "wol",
+        "xho": "xho",
+        "xhosa": "xho",
+        "yid": "yid",
+        "yor": "yor",
+        "yu": "ypk",
+        "zh": "chi",
+        "zh-cn": "chi",
+        "zh-tw": "chi",
+        "zul": "zul",
+        "zulu": "zul",
     }
     return language_map.get(language.casefold())
 
 
 @public
-def get_language_name(
-    lang_or_key: "Nothing | str | Thing", user_lang: str
-) -> Nothing | str:
+def get_language_name(lang_or_key: "Nothing | str | Thing", user_lang: str) -> Nothing | str:
     if isinstance(lang_or_key, str):
         lang = get_language(lang_or_key)
         if not lang:
@@ -1168,7 +1132,7 @@ def get_language_name(
     else:
         lang = lang_or_key
 
-    return safeget(lambda: lang['name_translated'][user_lang][0]) or lang.name  # type: ignore[index]
+    return safeget(lambda: lang["name_translated"][user_lang][0]) or lang.name  # type: ignore[index]
 
 
 @public
@@ -1178,7 +1142,7 @@ def get_populated_languages() -> set[str]:
     See https://openlibrary.org/languages
     """
     # Hard-coded for now to languages with more than 15k borrowable ebooks
-    return {'eng', 'fre', 'ger', 'spa', 'chi', 'ita', 'lat', 'dut', 'rus', 'jpn'}
+    return {"eng", "fre", "ger", "spa", "chi", "ita", "lat", "dut", "rus", "jpn"}
 
 
 @public
@@ -1188,19 +1152,19 @@ def convert_iso_to_marc(iso_639_1: str) -> str | None:
     e.g. 'en' -> 'eng'
     """
     for lang in get_languages().values():
-        code = safeget(lambda: lang['identifiers']['iso_639_1'][0])
+        code = safeget(lambda: lang["identifiers"]["iso_639_1"][0])
         if code == iso_639_1:
             return lang.code
     return None
 
 
 @public
-def get_identifier_config(identifier: Literal['work', 'edition', 'author']) -> Storage:
+def get_identifier_config(identifier: Literal["work", "edition", "author"]) -> Storage:
     return _get_identifier_config(identifier)
 
 
 @functools.cache
-def _get_identifier_config(identifier: Literal['work', 'edition', 'author']) -> Storage:
+def _get_identifier_config(identifier: Literal["work", "edition", "author"]) -> Storage:
     """
     Returns the identifier config.
 
@@ -1208,23 +1172,15 @@ def _get_identifier_config(identifier: Literal['work', 'edition', 'author']) -> 
 
     This is cached because fetching and creating the Thing object was taking about 20ms of time for each book request.
     """
-    with open(
-        f'openlibrary/plugins/openlibrary/config/{identifier}/identifiers.yml'
-    ) as in_file:
+    with open(f"openlibrary/plugins/openlibrary/config/{identifier}/identifiers.yml") as in_file:
         id_config = yaml.safe_load(in_file)
-        identifiers = [
-            Storage(id) for id in id_config.get('identifiers', []) if 'name' in id
-        ]
+        identifiers = [Storage(id) for id in id_config.get("identifiers", []) if "name" in id]
 
-    if identifier == 'edition':
-        thing = web.ctx.site.get('/config/edition')
-        classifications = [
-            Storage(t.dict()) for t in thing.classifications if 'name' in t
-        ]
+    if identifier == "edition":
+        thing = web.ctx.site.get("/config/edition")
+        classifications = [Storage(t.dict()) for t in thing.classifications if "name" in t]
         roles = thing.roles
-        return Storage(
-            classifications=classifications, identifiers=identifiers, roles=roles
-        )
+        return Storage(classifications=classifications, identifiers=identifiers, roles=roles)
 
     return Storage(identifiers=identifiers)
 
@@ -1304,14 +1260,14 @@ class UpstreamMemcacheClient:
         return {str(adapter.unconvert_key(k)): self.decompress(v) for k, v in d.items()}
 
 
-if config.get('upstream_memcache_servers'):
+if config.get("upstream_memcache_servers"):
     olmemcache.Client = UpstreamMemcacheClient  # type: ignore[assignment, misc]
     # set config.memcache_servers only after olmemcache.Client is updated
     config.memcache_servers = config.upstream_memcache_servers  # type: ignore[attr-defined]
 
 
 def _get_recent_changes():
-    site = web.ctx.get('site') or delegate.create_site()
+    site = web.ctx.get("site") or delegate.create_site()
     web.ctx.setdefault("ip", "127.0.0.1")
 
     # The recentchanges can have multiple revisions for a document if it has been
@@ -1341,7 +1297,7 @@ def _get_recent_changes():
         t = Storage()
         for k in ["key", "title", "name", "displayname"]:
             t[k] = thing[k]
-        t['type'] = Storage(key=thing.type.key)
+        t["type"] = Storage(key=thing.type.key)
         return t
 
     for r in result:
@@ -1359,7 +1315,7 @@ def _get_recent_changes2():
 
     If `$var ignore=True` is set by the message template, the change is ignored.
     """
-    if 'env' not in web.ctx:
+    if "env" not in web.ctx:
         delegate.fakeload()
 
     q = {"bot": False, "limit": 100}
@@ -1368,16 +1324,14 @@ def _get_recent_changes2():
     def is_ignored(c):
         return (
             # c.kind=='update' allow us to ignore update recent changes on people
-            c.kind == 'update'
+            c.kind == "update"
             or
             # ignore change if author has been deleted (e.g. spammer)
-            (c.author and c.author.type.key == '/type/delete')
+            (c.author and c.author.type.key == "/type/delete")
         )
 
     def render(c):
-        t = get_template("recentchanges/" + c.kind + "/message") or get_template(
-            "recentchanges/default/message"
-        )
+        t = get_template("recentchanges/" + c.kind + "/message") or get_template("recentchanges/default/message")
         return t(c)
 
     messages = [render(c) for c in changes if not is_ignored(c)]
@@ -1386,9 +1340,7 @@ def _get_recent_changes2():
 
 
 _get_recent_changes = web.memoize(_get_recent_changes, expires=5 * 60, background=True)
-_get_recent_changes2 = web.memoize(
-    _get_recent_changes2, expires=5 * 60, background=True
-)
+_get_recent_changes2 = web.memoize(_get_recent_changes2, expires=5 * 60, background=True)
 
 
 def _get_blog_feeds():
@@ -1398,17 +1350,13 @@ def _get_blog_feeds():
         tree = ET.fromstring(requests.get(url).text)
     except Exception:
         # Handle error gracefully.
-        logging.getLogger("openlibrary").error(
-            "Failed to fetch blog feeds", exc_info=True
-        )
+        logging.getLogger("openlibrary").error("Failed to fetch blog feeds", exc_info=True)
         return []
     finally:
         stats.end()
 
     def parse_item(item):
-        pubdate = datetime.datetime.strptime(
-            item.find("pubDate").text, '%a, %d %b %Y %H:%M:%S +0000'
-        ).isoformat()
+        pubdate = datetime.datetime.strptime(item.find("pubDate").text, "%a, %d %b %Y %H:%M:%S +0000").isoformat()
         return {
             "title": item.find("title").text,
             "link": item.find("link").text,
@@ -1418,9 +1366,7 @@ def _get_blog_feeds():
     return [parse_item(item) for item in tree.findall(".//item")]
 
 
-_get_blog_feeds = cache.memcache_memoize(
-    _get_blog_feeds, key_prefix="upstream.get_blog_feeds", timeout=60 * 60 * 24
-)
+_get_blog_feeds = cache.memcache_memoize(_get_blog_feeds, key_prefix="upstream.get_blog_feeds", timeout=60 * 60 * 24)
 
 
 @public
@@ -1445,9 +1391,7 @@ def create_thing(data: dict) -> Thing:
     classes. Will change the dict to be the same type as when fetched from
     the database via `web.ctx.site.get`.
     """
-    return client.create_thing(
-        web.ctx.site, data['key'], web.ctx.site._process_dict(parse_query(data))
-    )
+    return client.create_thing(web.ctx.site, data["key"], web.ctx.site._process_dict(parse_query(data)))
 
 
 @public
@@ -1455,7 +1399,7 @@ def get_ia_host(allow_dev: bool = False) -> str:
     if allow_dev:
         web_input = web.input()
         dev_host = web_input.pop("dev_host", "")  # e.g. `www-user`
-        if dev_host and re.match('^[a-zA-Z0-9-.]+$', dev_host):
+        if dev_host and re.match("^[a-zA-Z0-9-.]+$", dev_host):
             return dev_host + ".archive.org"
 
     return "archive.org"
@@ -1465,7 +1409,7 @@ def get_ia_host(allow_dev: bool = False) -> str:
 def item_image(image_path: str | None, default: str | None = None) -> str | None:
     if image_path is None:
         return default
-    if image_path.startswith('https:'):
+    if image_path.startswith("https:"):
         return image_path
     return "https:" + image_path
 
@@ -1492,31 +1436,29 @@ class Request:
         Used for adding <meta rel="canonical" ..> tag in all web pages.
         Required to make OL retain the page rank after https migration.
         """
-        readable_path = web.ctx.get('readable_path', web.ctx.path) or ''
-        query = web.ctx.query or ''
-        host = web.ctx.host or ''
+        readable_path = web.ctx.get("readable_path", web.ctx.path) or ""
+        query = web.ctx.query or ""
+        host = web.ctx.host or ""
         if url := host + readable_path + query:
             url = "https://" + url
             parsed_url = urlparse(url)
 
             parsed_query = parse_qs(parsed_url.query)
-            queries_to_exclude = ['sort', 'mode', 'v', 'type', 'debug']
+            queries_to_exclude = ["sort", "mode", "v", "type", "debug"]
 
-            canonical_query = {
-                q: v for q, v in parsed_query.items() if q not in queries_to_exclude
-            }
+            canonical_query = {q: v for q, v in parsed_query.items() if q not in queries_to_exclude}
             query = parse_urlencode(canonical_query, doseq=True)
             parsed_url = parsed_url._replace(query=query)
 
             url = urlunparse(parsed_url)
 
             return url
-        return ''
+        return ""
 
 
 @public
 def render_once(key: str) -> bool:
-    rendered = web.ctx.setdefault('render_once', {})
+    rendered = web.ctx.setdefault("render_once", {})
     if key in rendered:
         return False
     else:
@@ -1538,12 +1480,12 @@ class HTMLTagRemover(HTMLParser):
         self.data.append(data.strip())
 
     def handle_endtag(self, tag):
-        self.data.append('\n' if tag in ('p', 'li') else ' ')
+        self.data.append("\n" if tag in ("p", "li") else " ")
 
 
 @public
 def get_user_object(username):
-    user = web.ctx.site.get(f'/people/{username}')
+    user = web.ctx.site.get(f"/people/{username}")
     return user
 
 
@@ -1558,13 +1500,13 @@ def reformat_html(html_str: str, max_length: int | None = None) -> str:
     """
     parser = HTMLTagRemover()
     # Must have a root node, otherwise the parser will fail
-    parser.feed(f'<div>{html_str}</div>')
+    parser.feed(f"<div>{html_str}</div>")
     content = [web.websafe(s) for s in parser.data if s]
 
     if max_length:
-        return truncate(''.join(content), max_length).strip().replace('\n', '<br>')
+        return truncate("".join(content), max_length).strip().replace("\n", "<br>")
     else:
-        return ''.join(content).strip().replace('\n', '<br>')
+        return "".join(content).strip().replace("\n", "<br>")
 
 
 def get_colon_only_loc_pub(pair: str) -> tuple[str, str]:
@@ -1653,10 +1595,10 @@ def get_location_and_publisher(loc_pub: str) -> tuple[list[str], list[str]]:
 
 
 @public
-def subject_name_to_key(subject: str, prefix='') -> str:
+def subject_name_to_key(subject: str, prefix="") -> str:
     if prefix:
-        prefix = prefix.rstrip(':') + ':'
-    return f'/subjects/{prefix}{normalize_subject_name(subject)}'
+        prefix = prefix.rstrip(":") + ":"
+    return f"/subjects/{prefix}{normalize_subject_name(subject)}"
 
 
 def setup_requests(config=config) -> None:
@@ -1664,17 +1606,17 @@ def setup_requests(config=config) -> None:
 
     logger.info("Setting up proxy")
     if config.get("http_proxy", ""):
-        os.environ['HTTP_PROXY'] = os.environ['http_proxy'] = config.get('http_proxy')
-        os.environ['HTTPS_PROXY'] = os.environ['https_proxy'] = config.get('http_proxy')
-        logger.info('Proxy environment variables are set')
+        os.environ["HTTP_PROXY"] = os.environ["http_proxy"] = config.get("http_proxy")
+        os.environ["HTTPS_PROXY"] = os.environ["https_proxy"] = config.get("http_proxy")
+        logger.info("Proxy environment variables are set")
     else:
         logger.info("No proxy configuration found")
 
     logger.info("Setting up proxy bypass")
     if config.get("no_proxy_addresses", []):
         no_proxy = ",".join(config.get("no_proxy_addresses"))
-        os.environ['NO_PROXY'] = os.environ['no_proxy'] = no_proxy
-        logger.info('Proxy bypass environment variables are set')
+        os.environ["NO_PROXY"] = os.environ["no_proxy"] = no_proxy
+        logger.info("Proxy bypass environment variables are set")
     else:
         logger.info("No proxy bypass configuration found")
 
@@ -1688,18 +1630,18 @@ def setup() -> None:
 
     # Provide alternate implementations for websafe and commify
     web.websafe = websafe
-    web.template.Template.FILTERS['.html'] = websafe
-    web.template.Template.FILTERS['.xml'] = websafe
+    web.template.Template.FILTERS[".html"] = websafe
+    web.template.Template.FILTERS[".xml"] = websafe
 
     web.commify = commify
 
     web.template.Template.globals.update(
         {
-            'HTML': HTML,
-            'request': Request(),
-            'logger': logging.getLogger("openlibrary.template"),
-            'sum': sum,
-            'websafe': web.websafe,
+            "HTML": HTML,
+            "request": Request(),
+            "logger": logging.getLogger("openlibrary.template"),
+            "sum": sum,
+            "websafe": web.websafe,
         }
     )
 
@@ -1707,11 +1649,11 @@ def setup() -> None:
 
     web.template.Template.globals.update(h.helpers)
 
-    if config.get('use_gzip') is True:
+    if config.get("use_gzip") is True:
         config.middleware.append(GZipMiddleware)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import doctest
 
     doctest.testmod()


### PR DESCRIPTION
**Summary**

Following Ray Berger’s guidance, this PR removes several files from the
protected Black/Ruff exclude lists because they are no longer being actively
edited in open pull requests.

### Changes
- Removed the following files from both Ruff `exclude` and Black `files`:
  - `openlibrary/catalog/add_book/__init__.py`
  - `openlibrary/core/vendors.py`
  - `openlibrary/fastapi/search.py`
  - `openlibrary/plugins/admin/code.py`
  - `openlibrary/plugins/upstream/utils.py`

These files will now be formatted by Ruff (consistent with the rest of the
codebase).

<!-- What issue does this PR close? -->
Part of #12260

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
