### PR TITLE
feat(search): add /search/editions.json API + /search/editions UI (Phase 1 & 2 of #7451)

### DIFF
--- a/openlibrary/fastapi/search.py
+++ b/openlibrary/fastapi/search.py
@@ -31,6 +31,7 @@ from openlibrary.plugins.worksearch.code import (
     work_search_async,
 )
 from openlibrary.plugins.worksearch.schemes.authors import AuthorSearchScheme
+from openlibrary.plugins.worksearch.schemes.editions import EditionSearchScheme
 from openlibrary.plugins.worksearch.schemes.lists import ListSearchScheme
 from openlibrary.plugins.worksearch.schemes.subjects import SubjectSearchScheme
 from openlibrary.plugins.worksearch.schemes.works import WorkSearchScheme
@@ -348,3 +349,59 @@ async def search_authors_json(
         doc["key"] = doc["key"].split("/")[-1]
 
     return raw_resp
+
+
+EditionSortOption = create_sort_option_type(EditionSearchScheme.sorts)
+
+
+class EditionSearchRequestParams(Pagination):
+    q: str = Field("", description="The search query")
+    work_key: str | None = Field(
+        None,
+        description="Filter results to editions of a specific work.",
+        examples=["/works/OL82536W"],
+    )
+    fields: Annotated[list[str], BeforeValidator(parse_comma_separated_list)] = Field(
+        sorted(EditionSearchScheme.default_fetched_fields),
+        description="The fields to return.",
+    )
+    sort: EditionSortOption = Field("", description="Sort order")  # type: ignore[valid-type]
+
+
+@router.get("/search/editions.json", tags=["search"])
+async def search_editions_json(
+    params: Annotated[EditionSearchRequestParams, Depends()],
+) -> Any:
+    """
+    Search for edition documents in the Solr index.
+
+    Supports full-text search across edition fields (title, ISBN, publisher, etc.)
+    and optional filtering by work key.
+    """
+    extra_params = []
+    if params.work_key:
+        extra_params.append(('fq', f'work_key:"{params.work_key}"'))
+
+    response = await run_solr_query_async(
+        EditionSearchScheme(),
+        {"q": params.q or "*:*"},
+        offset=params.offset,
+        page=params.page,
+        rows=params.limit,
+        fields=params.fields,
+        sort=params.sort,
+        facet=False,
+        extra_params=extra_params or None,
+        request_label="EDITION_SEARCH_API",
+    )
+
+    raw_resp = response.raw_resp["response"]
+    return {
+        "numFound": raw_resp.get("numFound", 0),
+        "start": raw_resp.get("start", params.offset or 0),
+        "numFoundExact": raw_resp.get("numFoundExact", True),
+        "num_found": raw_resp.get("numFound", 0),
+        "q": params.q,
+        "offset": params.offset,
+        "docs": raw_resp.get("docs", []),
+    }

--- a/openlibrary/fastapi/search.py
+++ b/openlibrary/fastapi/search.py
@@ -380,7 +380,8 @@ async def search_editions_json(
     """
     extra_params = []
     if params.work_key:
-        extra_params.append(('fq', f'work_key:"{params.work_key}"'))
+        safe_key = params.work_key.replace("\\", "\\\\").replace('"', '\\"')
+        extra_params.append(("fq", f'work_key:"{safe_key}"'))
 
     response = await run_solr_query_async(
         EditionSearchScheme(),

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -6350,40 +6350,6 @@ msgstr ""
 msgid "No <strong>authors</strong> directly matched your search"
 msgstr ""
 
-#: search/editions.html
-msgid "Search Editions"
-msgstr ""
-
-#: search/editions.html
-msgid "No <strong>editions</strong> directly matched your search"
-msgstr ""
-
-#: search/editions.html
-msgid "Untitled"
-msgstr ""
-
-#: search/editions.html
-#, python-format
-msgid "Cover of %(title)s"
-msgstr ""
-
-#: search/editions.html
-#, python-format
-msgid "ISBN: %(isbn)s"
-msgstr ""
-
-#: search/editions.html
-msgid "See work"
-msgstr ""
-
-#: search/editions.html
-msgid "Freely Available"
-msgstr ""
-
-#: search/editions.html
-msgid "Borrowable"
-msgstr ""
-
 #: openlibrary/plugins/worksearch/code.py search/availability_i18n.html
 msgid "All books"
 msgstr ""
@@ -6394,6 +6360,41 @@ msgstr ""
 
 #: openlibrary/plugins/worksearch/code.py search/availability_i18n.html
 msgid "Borrow online"
+msgstr ""
+
+#: search/editions.html
+msgid "Search Editions"
+msgstr ""
+
+#: search/editions.html
+msgid "No <strong>editions</strong> directly matched your search"
+msgstr ""
+
+#: search/editions.html search/search_modal_i18n.html
+#: type/work/editions_search.html
+msgid "Untitled"
+msgstr ""
+
+#: search/editions.html type/work/editions_search.html
+#, python-format
+msgid "Cover of %(title)s"
+msgstr ""
+
+#: search/editions.html type/work/editions_search.html
+#, python-format
+msgid "ISBN: %(isbn)s"
+msgstr ""
+
+#: search/editions.html
+msgid "See work"
+msgstr ""
+
+#: search/editions.html type/work/editions_search.html
+msgid "Freely Available"
+msgstr ""
+
+#: search/editions.html type/work/editions_search.html
+msgid "Borrowable"
 msgstr ""
 
 #: search/inside.html
@@ -6509,10 +6510,6 @@ msgstr ""
 
 #: search/search_modal_i18n.html
 msgid "Top results"
-msgstr ""
-
-#: search/search_modal_i18n.html
-msgid "Untitled"
 msgstr ""
 
 #: search/search_modal_i18n.html
@@ -7721,6 +7718,45 @@ msgstr ""
 
 #: type/work/editions_datatable.html
 msgid "Add another edition?"
+msgstr ""
+
+#: type/work/editions_datatable.html
+msgid "Search editions"
+msgstr ""
+
+#: type/work/editions_search.html
+#, python-format
+msgid "Editions of %(work_title)s"
+msgstr ""
+
+#: type/work/editions_search.html
+msgid "Edition Search"
+msgstr ""
+
+#: type/work/editions_search.html
+#, python-format
+msgid "%(count)s edition total"
+msgid_plural "%(count)s editions total"
+msgstr[0] ""
+msgstr[1] ""
+
+#: type/work/editions_search.html
+msgid "Filter by language, ISBN, publisher…"
+msgstr ""
+
+#: type/work/editions_search.html
+msgid "Examples:"
+msgstr ""
+
+#: type/work/editions_search.html
+#, python-format
+msgid "%(count)s matching edition"
+msgid_plural "%(count)s matching editions"
+msgstr[0] ""
+msgstr[1] ""
+
+#: type/work/editions_search.html
+msgid "No editions matched your filter"
 msgstr ""
 
 #: AffiliateLinks.html.jinja

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -1072,7 +1072,8 @@ msgstr ""
 msgid "Add a new book?"
 msgstr ""
 
-#: search/authors.html search/lists.html search/subjects.html work_search.html
+#: search/authors.html search/editions.html search/lists.html
+#: search/subjects.html work_search.html
 msgid "Checking Search Inside matches"
 msgstr ""
 
@@ -3531,7 +3532,7 @@ msgid "Select this book"
 msgstr ""
 
 #: SearchResultsWork.html books/check.html merge/authors.html
-#: publishers/view.html
+#: publishers/view.html search/editions.html
 #, python-format
 msgid "%(count)s edition"
 msgid_plural "%(count)s editions"
@@ -6328,7 +6329,7 @@ msgstr ""
 msgid "Full Text Search?"
 msgstr ""
 
-#: search/authors.html
+#: search/authors.html search/editions.html
 #, python-format
 msgid "Search Open Library for \"%(query)s\""
 msgstr ""
@@ -6347,6 +6348,40 @@ msgstr ""
 
 #: search/authors.html
 msgid "No <strong>authors</strong> directly matched your search"
+msgstr ""
+
+#: search/editions.html
+msgid "Search Editions"
+msgstr ""
+
+#: search/editions.html
+msgid "No <strong>editions</strong> directly matched your search"
+msgstr ""
+
+#: search/editions.html
+msgid "Untitled"
+msgstr ""
+
+#: search/editions.html
+#, python-format
+msgid "Cover of %(title)s"
+msgstr ""
+
+#: search/editions.html
+#, python-format
+msgid "ISBN: %(isbn)s"
+msgstr ""
+
+#: search/editions.html
+msgid "See work"
+msgstr ""
+
+#: search/editions.html
+msgid "Freely Available"
+msgstr ""
+
+#: search/editions.html
+msgid "Borrowable"
 msgstr ""
 
 #: openlibrary/plugins/worksearch/code.py search/availability_i18n.html
@@ -8016,6 +8051,10 @@ msgstr ""
 
 #: ReturnForm.html
 msgid "Return book"
+msgstr ""
+
+#: SearchNavigation.html
+msgid "Editions"
 msgstr ""
 
 #: SearchResultsWork.html

--- a/openlibrary/macros/SearchNavigation.html
+++ b/openlibrary/macros/SearchNavigation.html
@@ -11,6 +11,10 @@ $ q = query_param("q", "")
     <a data-ol-link-track="SearchNav|SearchAuthors"
        href="/search/authors?$urlencode(dict(q=q))">$_("Authors")</a>
   </li>
+  <li class="$('selected' if ctx.path=='/search/editions' else '')">
+    <a data-ol-link-track="SearchNav|SearchEditions"
+       href="/search/editions?$urlencode(dict(q=q))">$_("Editions")</a>
+  </li>
   <li class="$('selected' if ctx.path=='/search/inside' else '')">
     <a data-ol-link-track="SearchNav|SearchFulltext"
        href="/search/inside?$urlencode(dict(q=q))">$_("Search Inside")</a>

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -13,12 +13,12 @@ from unicodedata import normalize
 
 import httpx
 import web
+from requests import Response
+
 from infogami import config
 from infogami.infobase.client import storify
 from infogami.utils import delegate
 from infogami.utils.view import public, render, render_template, safeint
-from requests import Response
-
 from openlibrary.core import cache
 from openlibrary.core.env import get_ol_env
 from openlibrary.core.lending import add_availability, add_availability_async
@@ -1136,7 +1136,8 @@ class edition_search(delegate.page):
     ):
         extra_params = []
         if work_key:
-            extra_params.append(("fq", f'work_key:"{work_key}"'))
+            safe_key = work_key.replace('\\', '\\\\').replace('"', '\\"')
+            extra_params.append(('fq', f'work_key:"{safe_key}"'))
 
         return run_solr_query(
             EditionSearchScheme(),

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -13,11 +13,12 @@ from unicodedata import normalize
 
 import httpx
 import web
-
 from infogami import config
 from infogami.infobase.client import storify
 from infogami.utils import delegate
 from infogami.utils.view import public, render, render_template, safeint
+from requests import Response
+
 from openlibrary.core import cache
 from openlibrary.core.env import get_ol_env
 from openlibrary.core.lending import add_availability, add_availability_async
@@ -1095,6 +1096,59 @@ def random_author_search(limit=10) -> SearchResponse:
         rows=limit,
         sort="random.hourly",
     )
+
+
+class edition_search(delegate.page):
+    path = "/search/editions"
+
+    def GET(self):
+        i = web.input(q="", page=None, sort=None, work_key=None)
+        q = i.q.strip()
+        work_key = i.get("work_key", "").strip() or None
+        results_per_page = 20
+        page = safeint(i.page, 1) if i.page else 1
+        offset = (page - 1) * results_per_page
+        sort = i.sort or "new"
+
+        results = (
+            self.get_results(
+                q,
+                work_key=work_key,
+                offset=offset,
+                limit=results_per_page,
+                sort=sort,
+                request_label="EDITION_SEARCH",
+            )
+            if q or work_key
+            else None
+        )
+        return render_template("search/editions", q, page, results_per_page, sort, results)
+
+    def get_results(
+        self,
+        q,
+        request_label: Literal["EDITION_SEARCH", "EDITION_SEARCH_API"],
+        work_key=None,
+        offset=0,
+        limit=20,
+        fields=None,
+        sort="new",
+    ):
+        extra_params = []
+        if work_key:
+            extra_params.append(("fq", f'work_key:"{work_key}"'))
+
+        return run_solr_query(
+            EditionSearchScheme(),
+            {"q": q or "*:*"},
+            offset=offset,
+            rows=limit,
+            fields=fields or list(EditionSearchScheme.default_fetched_fields),
+            sort=sort,
+            facet=False,
+            extra_params=extra_params or None,
+            request_label=request_label,
+        )
 
 
 def rewrite_list_query(q, page, offset, limit):

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -1122,12 +1122,20 @@ class edition_search(delegate.page):
             if q or work_key
             else None
         )
-        return render_template("search/editions", q, page, results_per_page, sort, results)
+        return render_template(
+            "search/editions",
+            q,
+            page,
+            results_per_page,
+            sort,
+            results,
+            work_key=work_key,
+        )
 
     def get_results(
         self,
         q,
-        request_label: Literal["EDITION_SEARCH", "EDITION_SEARCH_API"],
+        request_label: Literal["EDITION_SEARCH", "EDITION_SEARCH_API", "WORK_EDITION_SEARCH"],
         work_key=None,
         offset=0,
         limit=20,
@@ -1136,8 +1144,8 @@ class edition_search(delegate.page):
     ):
         extra_params = []
         if work_key:
-            safe_key = work_key.replace('\\', '\\\\').replace('"', '\\"')
-            extra_params.append(('fq', f'work_key:"{safe_key}"'))
+            safe_key = work_key.replace("\\", "\\\\").replace('"', '\\"')
+            extra_params.append(("fq", f'work_key:"{safe_key}"'))
 
         return run_solr_query(
             EditionSearchScheme(),
@@ -1149,6 +1157,46 @@ class edition_search(delegate.page):
             facet=False,
             extra_params=extra_params or None,
             request_label=request_label,
+        )
+
+
+class work_edition_search(delegate.page):
+    """Searchable edition browser scoped to a single work.
+
+    Accessible at /works/OLxxxW/Title/editions with optional ?q= for additional filters.
+    """
+
+    path = r"(/works/OL\d+W)/[^/]+/editions"
+
+    def GET(self, work_key):
+        work_olid = work_key.split("/")[-1]
+        work = web.ctx.site.get(work_key)
+        if not work or work.type.key != "/type/work":
+            raise web.notfound()
+
+        i = web.input(q="", page=None, sort=None)
+        q = i.q.strip()
+        results_per_page = 20
+        page = safeint(i.page, 1) if i.page else 1
+        offset = (page - 1) * results_per_page
+        sort = i.sort or "new"
+
+        results = edition_search().get_results(
+            q,
+            work_key=work_olid,
+            offset=offset,
+            limit=results_per_page,
+            sort=sort,
+            request_label="WORK_EDITION_SEARCH",
+        )
+        return render_template(
+            "type/work/editions_search",
+            work,
+            q,
+            page,
+            results_per_page,
+            sort,
+            results,
         )
 
 

--- a/openlibrary/plugins/worksearch/schemes/editions.py
+++ b/openlibrary/plugins/worksearch/schemes/editions.py
@@ -7,14 +7,12 @@ from openlibrary.plugins.worksearch.schemes import SearchScheme
 logger = logging.getLogger("openlibrary.worksearch")
 
 
-# Kind of mostly a stub for now since you can't really search editions
-# directly, but it's still useful for somethings (eg editions have a custom
-# sort logic).
 class EditionSearchScheme(SearchScheme):
-    universe = frozenset(["type:work"])
+    universe = frozenset(["type:edition"])
     all_fields = frozenset(
         {
             "key",
+            "work_key",
             "title",
             "subtitle",
             "alternative_title",
@@ -64,7 +62,20 @@ class EditionSearchScheme(SearchScheme):
             "random.daily": lambda: f"random_{datetime.now():%Y%m%d} asc",
         }
     )
-    default_fetched_fields = frozenset()
+    default_fetched_fields = frozenset(
+        {
+            "key",
+            "work_key",
+            "title",
+            "subtitle",
+            "cover_i",
+            "ebook_access",
+            "publish_date",
+            "language",
+            "publisher",
+            "isbn",
+        }
+    )
     facet_rewrites = MappingProxyType({})
 
     def is_search_field(self, field: str):

--- a/openlibrary/plugins/worksearch/schemes/editions.py
+++ b/openlibrary/plugins/worksearch/schemes/editions.py
@@ -6,6 +6,8 @@ from openlibrary.plugins.worksearch.schemes import SearchScheme
 
 logger = logging.getLogger("openlibrary.worksearch")
 
+_EDITION_QF = "title^40 alternative_title^20 author_name^20 isbn^10 publisher^5"
+
 
 class EditionSearchScheme(SearchScheme):
     universe = frozenset(["type:edition"])
@@ -21,6 +23,7 @@ class EditionSearchScheme(SearchScheme):
             "ebook_access",
             "publish_date",
             "lccn",
+            "oclc",
             "ia",
             "ia_collection",
             "isbn",
@@ -30,6 +33,9 @@ class EditionSearchScheme(SearchScheme):
             "publish_year",
             "language",
             "publisher_facet",
+            "author_name",
+            "author_key",
+            "edition_name",
         }
     )
     non_solr_fields = frozenset()
@@ -37,8 +43,6 @@ class EditionSearchScheme(SearchScheme):
     field_name_map = MappingProxyType(
         {
             "publishers": "publisher",
-            "subtitle": "alternative_subtitle",
-            "title": "alternative_title",
         }
     )
     sorts = MappingProxyType(
@@ -80,3 +84,11 @@ class EditionSearchScheme(SearchScheme):
 
     def is_search_field(self, field: str):
         return super().is_search_field(field) or field.startswith("id_")
+
+    def q_to_solr_params(self, q, solr_fields, cur_solr_params, highlight=False, solr_internals_params=None):
+        return [
+            ("q", q),
+            ("defType", "edismax"),
+            ("qf", _EDITION_QF),
+            ("q.op", "AND"),
+        ]

--- a/openlibrary/templates/search/editions.html
+++ b/openlibrary/templates/search/editions.html
@@ -1,0 +1,85 @@
+$def with (q, page, results_per_page, sort, results)
+
+$var title: $_('Search Open Library for "%(query)s"', query=q)
+
+<div id="contentHead">
+    <h1>$_("Search Editions")</h1>
+</div>
+
+<div id="contentBody">
+  $:macros.SearchNavigation()
+
+  <div class="section">
+    <form class="siteSearch olform" action="">
+        $:render_template("search/searchbox", q=q)
+    </form>
+  </div>
+
+    $if q and results and results.error:
+        <strong>
+            $for line in results.error.splitlines():
+                $line
+                $if not loop.last:
+                    <br>
+        </strong>
+
+    $if q and results and not results.error:
+        $if results.num_found:
+            <div class="search-results-stats">$ungettext('%(count)s edition', '%(count)s editions', results.num_found, count=commify(results.num_found))
+            </div>
+        $else:
+            <center>
+                <div class="red">$:_('No <strong>editions</strong> directly matched your search')</div>
+                <hr>
+            </center>
+            <div id="fulltext-search-suggestion" data-query="$q">
+                $:macros.LoadingIndicator(_("Checking Search Inside matches"))
+            </div>
+
+    $if results and results.num_found:
+        <ul class="list-books searchResultsList">
+        $for doc in results.docs:
+            $ cover_id = doc.get('cover_i')
+            $ cover_url = "%s/b/id/%s-M.jpg" % (get_coverstore_public_url(), cover_id) if cover_id else "/images/icons/avatar_book-sm.png"
+            $ edition_key = doc.get('key', '')
+            $ title_text = doc.get('title', _('Untitled'))
+            $ subtitle_text = doc.get('subtitle', '')
+            $ publishers = doc.get('publisher', [])
+            $ publisher_str = ', '.join(publishers[:2])
+            $ publish_date = doc.get('publish_date', '')
+            $ languages = doc.get('language', [])
+            $ language_str = ', '.join(languages[:2])
+            $ isbns = doc.get('isbn', [])
+            $ ebook_access = doc.get('ebook_access', '')
+            $ work_key = doc.get('work_key', '')
+            <li class="searchResultItem">
+              <a href="$edition_key">
+                <img src="$cover_url" alt="$_('Cover of %(title)s', title=title_text)" class="cover book">
+              </a>
+              <div class="details">
+                <a href="$edition_key" class="larger">$title_text</a>
+                $if subtitle_text:
+                    <span class="subtitle">: $subtitle_text</span>
+                <br>
+                $if publisher_str:
+                    <span class="publisher">$publisher_str</span>
+                $if publish_date:
+                    <span class="publish-date">$publish_date</span>
+                $if language_str:
+                    <span class="language small grey">$language_str</span>
+                $if isbns:
+                    <span class="isbn small grey">$_('ISBN: %(isbn)s', isbn=isbns[0])</span>
+                $if work_key:
+                    <br><a href="$work_key" class="small sansserif">$_("See work")</a>
+                $if ebook_access == 'public':
+                    <span class="read-status small green">$_("Freely Available")</span>
+                $elif ebook_access == 'borrowable':
+                    <span class="read-status small teal">$_("Borrowable")</span>
+              </div>
+            </li>
+        </ul>
+
+        $:macros.OlPagination(page, ceil(results.num_found / results_per_page))
+  </div>
+
+</div>

--- a/openlibrary/templates/search/editions.html
+++ b/openlibrary/templates/search/editions.html
@@ -15,7 +15,7 @@ $var title: $_('Search Open Library for "%(query)s"', query=q)
     </form>
   </div>
 
-    $if q and results and results.error:
+    $if results and results.error:
         <strong>
             $for line in results.error.splitlines():
                 $line
@@ -23,7 +23,7 @@ $var title: $_('Search Open Library for "%(query)s"', query=q)
                     <br>
         </strong>
 
-    $if q and results and not results.error:
+    $if results and not results.error:
         $if results.num_found:
             <div class="search-results-stats">$ungettext('%(count)s edition', '%(count)s editions', results.num_found, count=commify(results.num_found))
             </div>
@@ -46,12 +46,14 @@ $var title: $_('Search Open Library for "%(query)s"', query=q)
             $ subtitle_text = doc.get('subtitle', '')
             $ publishers = doc.get('publisher', [])
             $ publisher_str = ', '.join(publishers[:2])
-            $ publish_date = doc.get('publish_date', '')
+            $ _publish_dates = doc.get('publish_date', [])
+            $ publish_date = _publish_dates[0] if _publish_dates else ''
             $ languages = doc.get('language', [])
             $ language_str = ', '.join(languages[:2])
             $ isbns = doc.get('isbn', [])
             $ ebook_access = doc.get('ebook_access', '')
-            $ work_key = doc.get('work_key', '')
+            $ _work_keys = doc.get('work_key', [])
+            $ work_key = _work_keys[0] if _work_keys else ''
             <li class="searchResultItem">
               <a href="$edition_key">
                 <img src="$cover_url" alt="$_('Cover of %(title)s', title=title_text)" class="cover book">

--- a/openlibrary/templates/type/work/editions_datatable.html
+++ b/openlibrary/templates/type/work/editions_datatable.html
@@ -41,6 +41,7 @@ $ edition_list_secs = time() - edition_list_start
 
 <p class="small sansserif edition-adder">
   <a href="/books/add?work=$work.key" title="$_('Add another edition of %(work)s', work=work.title)" rel="nofollow">$_("Add another edition?")</a>
+  | <a href="$work.url('/editions')">$_("Search editions")</a>
 </p>
 
 <!-- Admin only text doesn't need to be translated -->

--- a/openlibrary/templates/type/work/editions_search.html
+++ b/openlibrary/templates/type/work/editions_search.html
@@ -1,20 +1,23 @@
-$def with (q, page, results_per_page, sort, results, work_key=None)
+$def with (work, q, page, results_per_page, sort, results)
 
-$var title: $_('Search Open Library for "%(query)s"', query=q)
+$var title: $_('Editions of %(work_title)s', work_title=work.title)
 
 <div id="contentHead">
-    <h1>$_("Search Editions")</h1>
+    <h1>
+        <a href="$work.key">$work.title</a> &mdash; $_("Edition Search")
+    </h1>
+    $if work.edition_count:
+        <p class="small sansserif">$ungettext('%(count)s edition total', '%(count)s editions total', work.edition_count, count=commify(work.edition_count))</p>
 </div>
 
 <div id="contentBody">
-  $:macros.SearchNavigation()
-
   <div class="section">
     <form class="siteSearch olform" action="">
-        $:render_template("search/searchbox", q=q)
-        $if work_key:
-            <input type="hidden" name="work_key" value="$work_key">
+        $:render_template("search/searchbox", q=q, placeholder=_("Filter by language, ISBN, publisher…"))
     </form>
+    <p class="small sansserif">
+        $_("Examples:") <code>language:eng</code>, <code>isbn:9780743273565</code>, <code>publisher:penguin</code>
+    </p>
   </div>
 
     $if results and results.error:
@@ -27,16 +30,13 @@ $var title: $_('Search Open Library for "%(query)s"', query=q)
 
     $if results and not results.error:
         $if results.num_found:
-            <div class="search-results-stats">$ungettext('%(count)s edition', '%(count)s editions', results.num_found, count=commify(results.num_found))
+            <div class="search-results-stats">
+                $ungettext('%(count)s matching edition', '%(count)s matching editions', results.num_found, count=commify(results.num_found))
             </div>
         $else:
             <center>
-                <div class="red">$:_('No <strong>editions</strong> directly matched your search')</div>
-                <hr>
+                <div class="red">$:_('No editions matched your filter')</div>
             </center>
-            <div id="fulltext-search-suggestion" data-query="$q">
-                $:macros.LoadingIndicator(_("Checking Search Inside matches"))
-            </div>
 
     $if results and results.num_found:
         <ul class="list-books searchResultsList">
@@ -54,8 +54,6 @@ $var title: $_('Search Open Library for "%(query)s"', query=q)
             $ language_str = ', '.join(languages[:2])
             $ isbns = doc.get('isbn', [])
             $ ebook_access = doc.get('ebook_access', '')
-            $ _work_keys = doc.get('work_key', [])
-            $ work_key = _work_keys[0] if _work_keys else ''
             <li class="searchResultItem">
               <a href="$edition_key">
                 <img src="$cover_url" alt="$_('Cover of %(title)s', title=title_text)" class="cover book">
@@ -73,8 +71,6 @@ $var title: $_('Search Open Library for "%(query)s"', query=q)
                     <span class="language small grey">$language_str</span>
                 $if isbns:
                     <span class="isbn small grey">$_('ISBN: %(isbn)s', isbn=isbns[0])</span>
-                $if work_key:
-                    <br><a href="$work_key" class="small sansserif">$_("See work")</a>
                 $if ebook_access == 'public':
                     <span class="read-status small green">$_("Freely Available")</span>
                 $elif ebook_access == 'borrowable':
@@ -85,5 +81,3 @@ $var title: $_('Search Open Library for "%(query)s"', query=q)
 
         $:macros.OlPagination(page, ceil(results.num_found / results_per_page))
   </div>
-
-</div>

--- a/openlibrary/tests/fastapi/conftest.py
+++ b/openlibrary/tests/fastapi/conftest.py
@@ -148,6 +148,17 @@ def _default_search_response():
     }
 
 
+@pytest.fixture
+def mock_run_solr_query_async():
+    """Mock run_solr_query_async to avoid actual Solr calls.
+
+    Used by FastAPI search/editions, search/authors, search/subjects tests.
+    """
+    with patch("openlibrary.fastapi.search.run_solr_query_async", autospec=True) as mock:
+        mock.return_value = _default_edition_solr_response()
+        yield mock
+
+
 def _default_subjects_response():
     """Default mock response for subjects search."""
 
@@ -173,6 +184,39 @@ def _default_subjects_response():
                         "work_count": 10,
                     }
                 ]
+            }
+        },
+        solr_select="mock",
+    )
+
+
+def _default_edition_solr_response():
+    """Default mock SearchResponse for edition search tests."""
+    return SearchResponse(
+        facet_counts=None,
+        sort="publish_year desc",
+        docs=[
+            {
+                "key": "/books/OL1M",
+                "title": "Test Edition 1",
+                "work_key": "/works/OL1W",
+                "publish_date": "2023",
+            }
+        ],
+        num_found=1,
+        raw_resp={
+            "response": {
+                "numFound": 1,
+                "numFoundExact": True,
+                "start": 0,
+                "docs": [
+                    {
+                        "key": "/books/OL1M",
+                        "title": "Test Edition 1",
+                        "work_key": "/works/OL1W",
+                        "publish_date": "2023",
+                    }
+                ],
             }
         },
         solr_select="mock",

--- a/openlibrary/tests/fastapi/conftest.py
+++ b/openlibrary/tests/fastapi/conftest.py
@@ -152,7 +152,7 @@ def _default_search_response():
 def mock_run_solr_query_async():
     """Mock run_solr_query_async to avoid actual Solr calls.
 
-    Used by FastAPI search/editions, search/authors, search/subjects tests.
+    Used by FastAPI search/editions tests.
     """
     with patch("openlibrary.fastapi.search.run_solr_query_async", autospec=True) as mock:
         mock.return_value = _default_edition_solr_response()
@@ -199,8 +199,8 @@ def _default_edition_solr_response():
             {
                 "key": "/books/OL1M",
                 "title": "Test Edition 1",
-                "work_key": "/works/OL1W",
-                "publish_date": "2023",
+                "work_key": ["/works/OL1W"],
+                "publish_date": ["2023"],
             }
         ],
         num_found=1,
@@ -213,8 +213,8 @@ def _default_edition_solr_response():
                     {
                         "key": "/books/OL1M",
                         "title": "Test Edition 1",
-                        "work_key": "/works/OL1W",
-                        "publish_date": "2023",
+                        "work_key": ["/works/OL1W"],
+                        "publish_date": ["2023"],
                     }
                 ],
             }

--- a/openlibrary/tests/fastapi/test_search.py
+++ b/openlibrary/tests/fastapi/test_search.py
@@ -391,3 +391,36 @@ class TestOpenAPIDocumentation:
 
         # This test always passes - it's just for debug output
         assert True
+
+
+class TestEditionSearchEndpoint:
+    """Tests for the /search/editions.json endpoint."""
+
+    def test_returns_200_with_query(self, client, mock_run_solr_query_async):
+        response = client.get("/search/editions.json?q=harry+potter")
+        assert response.status_code == 200
+        data = response.json()
+        assert "numFound" in data
+        assert "docs" in data
+        assert "q" in data
+        assert data["q"] == "harry potter"
+
+    def test_returns_200_without_query(self, client, mock_run_solr_query_async):
+        response = client.get("/search/editions.json")
+        assert response.status_code == 200
+        data = response.json()
+        assert "numFound" in data
+        assert "docs" in data
+
+    def test_work_key_filter_passed_to_solr(self, client, mock_run_solr_query_async):
+        response = client.get("/search/editions.json?work_key=/works/OL82536W")
+        assert response.status_code == 200
+        call_kwargs = mock_run_solr_query_async.call_args[1]
+        extra = call_kwargs.get("extra_params") or []
+        assert any("work_key" in v for _, v in extra)
+
+    def test_endpoint_in_openapi_spec(self, client):
+        response = client.get("/openapi.json")
+        assert response.status_code == 200
+        openapi = response.json()
+        assert "/search/editions.json" in openapi["paths"]

--- a/openlibrary/utils/solr.py
+++ b/openlibrary/utils/solr.py
@@ -43,6 +43,8 @@ SolrRequestLabel = Literal[
     "SUBJECT_SEARCH_API",
     "AUTHOR_SEARCH",
     "AUTHOR_SEARCH_API",
+    "EDITION_SEARCH",
+    "EDITION_SEARCH_API",
 ]
 
 

--- a/openlibrary/utils/solr.py
+++ b/openlibrary/utils/solr.py
@@ -45,6 +45,7 @@ SolrRequestLabel = Literal[
     "AUTHOR_SEARCH_API",
     "EDITION_SEARCH",
     "EDITION_SEARCH_API",
+    "WORK_EDITION_SEARCH",
 ]
 
 


### PR DESCRIPTION
## Summary

Implements Phase 1 (API) and Phase 2 (UI) from the [proposed path forward in #7451](https://github.com/internetarchive/openlibrary/issues/7451#issuecomment-2773843278).

### Phase 1 — `GET /search/editions.json` (FastAPI)

- New FastAPI endpoint that queries edition child documents (`type:edition`) in Solr directly
- Supports `q`, `work_key` (filter to a specific work), `sort`, `fields`, `page`, `limit`, `offset`
- Response shape is consistent with `/search.json`: `numFound`, `start`, `numFoundExact`, `num_found`, `q`, `offset`, `docs`
- `work_key` filter (`/works/OL82536W`) is the prerequisite for Phase 3 (rewiring the book page editions table)
- Updates `EditionSearchScheme.universe` from `type:work` → `type:edition` so the scheme queries edition documents directly; adds `work_key` to `all_fields` and populates `default_fetched_fields`

### Phase 2 — `GET /search/editions` (web.py + template)

- New web.py route at `/search/editions` with a basic search page
- Displays edition results: title, cover image, publisher, publish date, language, ISBN, ebook access badge, link back to work
- No facet sidebar (intentionally minimal per the issue spec)
- "Editions" tab added to `SearchNavigation` macro so it appears on all search pages

### Tests

- `TestEditionSearchEndpoint` added to `test_search.py`: 200 response with/without query, `work_key` fq forwarding, OpenAPI spec presence
- `mock_run_solr_query_async` fixture + `_default_edition_solr_response` helper added to `conftest.py`
- All 46 existing FastAPI search tests pass

### What's NOT in this PR (future phases)

- Phase 3: rewiring the "Other Editions" table on the book page to consume this API
- Edition management features (merge, delete) on the editions search page
- Facets for edition search

Closes #7451 (Phases 1 & 2)