### PR TITLE
Fix tag_deploy regression and add SKIP_TRANSFER for deploy reruns

### DIFF
--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -101,6 +101,12 @@ check_for_local_changes() {
         return
     fi
 
+    # Not a git repo yet (e.g. partial failure before git init) -- skip check
+    if ! ssh $SERVER "test -d $REPO_DIR/.git"; then
+        echo "✓ ($REPO_DIR exists but is not a git repo yet)"
+        return
+    fi
+
     OUTPUT=$(ssh $SERVER "cd $REPO_DIR; sudo git status --porcelain --untracked-files=all")
 
     if [ -z "$OUTPUT" ]; then
@@ -317,6 +323,7 @@ tag_deploy() {
     local REPO_DIR="${DEPLOY_DIR}/openlibrary"
     if [ ! -d "$REPO_DIR/.git" ]; then
         REPO_DIR="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+        echo "[Warning] Deploy clone not found; tagging from local repo at $REPO_DIR (HEAD: $(git -C "$REPO_DIR" rev-parse --short HEAD))"
     fi
     if ! git -C "$REPO_DIR" rev-parse "$DEPLOY_TAG" >/dev/null 2>&1; then
         echo "[Info] Tagging deploy as $DEPLOY_TAG"
@@ -335,6 +342,7 @@ tag_release() {
     local REPO_DIR="${DEPLOY_DIR}/openlibrary"
     if [ ! -d "$REPO_DIR/.git" ]; then
         REPO_DIR="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+        echo "[Warning] Deploy clone not found; reading tags from local repo at $REPO_DIR"
     fi
     LATEST_TAG_NAME=$(git -C "$REPO_DIR" describe --tags --abbrev=0)
     echo "[Now] Generate release: https://github.com/internetarchive/openlibrary/releases/new?tag=$LATEST_TAG_NAME"
@@ -420,7 +428,7 @@ deploy_openlibrary() {
     cp -r openlibrary/conf openlibrary_new
     tar -czf openlibrary_new.tar.gz openlibrary_new
 
-    if [[ -z "$SKIP_TRANSFER" ]]; then
+    if [[ "$SKIP_TRANSFER" != "1" ]]; then
         if ! copy_to_servers "$DEPLOY_DIR/openlibrary_new.tar.gz" "/opt/openlibrary" "openlibrary_new"; then
             cleanup "${DEPLOY_DIR}/openlibrary"
             exit 1

--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -323,7 +323,16 @@ tag_deploy() {
     local REPO_DIR="${DEPLOY_DIR}/openlibrary"
     if [ ! -d "$REPO_DIR/.git" ]; then
         REPO_DIR="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
-        echo "[Warning] Deploy clone not found; tagging from local repo at $REPO_DIR (HEAD: $(git -C "$REPO_DIR" rev-parse --short HEAD))"
+        local HEAD_SHA
+        HEAD_SHA="$(git -C "$REPO_DIR" rev-parse --short HEAD)"
+        echo "[Warning] Deploy clone not found; fallback to local repo at $REPO_DIR"
+        echo "          Local HEAD is $HEAD_SHA — confirm this matches what was deployed."
+        read -p "Tag production as $HEAD_SHA from the local repo? [y/N]..." confirm
+        confirm=${confirm:-N}
+        if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+            echo "[Abort] Cancelled. Verify the correct commit is checked out before re-running."
+            return 1
+        fi
     fi
     if ! git -C "$REPO_DIR" rev-parse "$DEPLOY_TAG" >/dev/null 2>&1; then
         echo "[Info] Tagging deploy as $DEPLOY_TAG"

--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -314,22 +314,29 @@ date_to_timestamp() {
 }
 
 tag_deploy() {
-    # Check if tag does NOT exist
-    if ! git -C "${DEPLOY_DIR}/openlibrary" rev-parse "$DEPLOY_TAG" >/dev/null 2>&1; then
+    local REPO_DIR="${DEPLOY_DIR}/openlibrary"
+    if [ ! -d "$REPO_DIR/.git" ]; then
+        REPO_DIR="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+    fi
+    if ! git -C "$REPO_DIR" rev-parse "$DEPLOY_TAG" >/dev/null 2>&1; then
         echo "[Info] Tagging deploy as $DEPLOY_TAG"
-        git -C "${DEPLOY_DIR}/openlibrary" tag "$DEPLOY_TAG"
-        git -C "${DEPLOY_DIR}/openlibrary" push git@github.com:internetarchive/openlibrary.git "$DEPLOY_TAG"
+        git -C "$REPO_DIR" tag "$DEPLOY_TAG"
+        git -C "$REPO_DIR" push git@github.com:internetarchive/openlibrary.git "$DEPLOY_TAG"
     else
         echo "[Info] Tag '$DEPLOY_TAG' already exists. Skipping creation."
     fi
 
     # Always update and push the 'production' tag
-    git -C "${DEPLOY_DIR}/openlibrary" tag -f production
-    git -C "${DEPLOY_DIR}/openlibrary" push -f git@github.com:internetarchive/openlibrary.git production
+    git -C "$REPO_DIR" tag -f production
+    git -C "$REPO_DIR" push -f git@github.com:internetarchive/openlibrary.git production
 }
 
 tag_release() {
-    LATEST_TAG_NAME=$(git -C "${DEPLOY_DIR}/openlibrary" describe --tags --abbrev=0)
+    local REPO_DIR="${DEPLOY_DIR}/openlibrary"
+    if [ ! -d "$REPO_DIR/.git" ]; then
+        REPO_DIR="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+    fi
+    LATEST_TAG_NAME=$(git -C "$REPO_DIR" describe --tags --abbrev=0)
     echo "[Now] Generate release: https://github.com/internetarchive/openlibrary/releases/new?tag=$LATEST_TAG_NAME"
 }
 
@@ -412,35 +419,37 @@ deploy_openlibrary() {
     cp -r openlibrary/scripts openlibrary_new
     cp -r openlibrary/conf openlibrary_new
     tar -czf openlibrary_new.tar.gz openlibrary_new
-    if ! copy_to_servers "$DEPLOY_DIR/openlibrary_new.tar.gz" "/opt/openlibrary" "openlibrary_new"; then
-        cleanup "${DEPLOY_DIR}/openlibrary"
-        exit 1
+
+    if [[ -z "$SKIP_TRANSFER" ]]; then
+        if ! copy_to_servers "$DEPLOY_DIR/openlibrary_new.tar.gz" "/opt/openlibrary" "openlibrary_new"; then
+            cleanup "${DEPLOY_DIR}/openlibrary"
+            exit 1
+        fi
+        echo ""
+        # Fix file ownership + Make into a git repo so can easily track local mods
+        for SERVER in $FQDNS; do
+            ssh $SERVER "
+                set -e
+                sudo chown -R root:staff /opt/openlibrary
+                sudo chmod -R g+rwX /opt/openlibrary
+                cd /opt/openlibrary
+                sudo git init 2>&1 > /dev/null
+                sudo git add . > /dev/null
+                sudo git commit -m 'Deployed openlibrary' > /dev/null
+            "
+        done
+
+        if ! prune_docker image; then
+            cleanup "${DEPLOY_DIR}/openlibrary"
+            exit 1
+        fi
+
+        echo ""
+        echo "Pull the latest docker images..."
+        deploy_images
     fi
-    echo ""
 
-    # Fix file ownership + Make into a git repo so can easily track local mods
-    for SERVER in $FQDNS; do
-        ssh $SERVER "
-            set -e
-            sudo chown -R root:staff /opt/openlibrary
-            sudo chmod -R g+rwX /opt/openlibrary
-            cd /opt/openlibrary
-            sudo git init 2>&1 > /dev/null
-            sudo git add . > /dev/null
-            sudo git commit -m 'Deployed openlibrary' > /dev/null
-        "
-    done
-
-    if ! prune_docker image; then
-        cleanup "${DEPLOY_DIR}/openlibrary"
-        exit 1
-    fi
-
-    echo ""
-    echo "Pull the latest docker images..."
-    deploy_images
-
-
+    tag_deploy
 
     echo "Finished production deployment at $(date)"
     echo "To reboot the servers, please run scripts/deployments/restart_all_servers.sh"
@@ -667,9 +676,6 @@ deploy_wizard() {
         fi
     fi
 
-    echo "Creating git tag for deploy... "
-    tag_deploy
-
     read -p "[Now] Restart services? [N/y]..." answer
     answer=${answer:-N}
     if [[ "$answer" =~ ^[Yy]$ ]]; then
@@ -683,7 +689,6 @@ deploy_wizard() {
         time tag_release
         read -p "Press Enter to continue..."
 
-        LATEST_TAG_NAME=$(git -C "${DEPLOY_DIR}/openlibrary" describe --tags --abbrev=0)
         echo "[Now] Deploy complete, announce in #openlibrary-g, #openlibrary, and #open-librarians-g:"
         echo ""
         echo "The Open Library weekly deploy is now complete. See changes here: https://github.com/internetarchive/openlibrary/releases/tag/$LATEST_TAG_NAME. Please respond in this thread if anything seems broken or delightful!"

--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -428,7 +428,7 @@ deploy_openlibrary() {
     cp -r openlibrary/conf openlibrary_new
     tar -czf openlibrary_new.tar.gz openlibrary_new
 
-    if [[ "$SKIP_TRANSFER" != "1" ]]; then
+    if [[ "$SKIP_OL_TRANSFER_CODE" != "1" ]]; then
         if ! copy_to_servers "$DEPLOY_DIR/openlibrary_new.tar.gz" "/opt/openlibrary" "openlibrary_new"; then
             cleanup "${DEPLOY_DIR}/openlibrary"
             exit 1
@@ -451,7 +451,9 @@ deploy_openlibrary() {
             cleanup "${DEPLOY_DIR}/openlibrary"
             exit 1
         fi
+    fi
 
+    if [[ "$SKIP_OL_TRANSFER_IMAGES" != "1" ]]; then
         echo ""
         echo "Pull the latest docker images..."
         deploy_images
@@ -668,9 +670,17 @@ deploy_wizard() {
     read -p "[Info] Skipping clone_booklending_utils, run manually if needed. Press Enter to continue..." answer
     echo ""
 
-    read -p "[Now] Run openlibrary deploy & audit now? [Y/n]..." answer
+    read -p "[Now] Run openlibrary deploy? [Y/n]..." answer
     answer=${answer:-Y}
     if [[ "$answer" =~ ^[Yy]$ ]]; then
+        read -p "[Now] Transfer codebase to servers? [Y/n]..." answer
+        answer=${answer:-Y}
+        [[ "$answer" =~ ^[Nn]$ ]] && SKIP_OL_TRANSFER_CODE=1
+
+        read -p "[Now] Transfer docker images to servers? [Y/n]..." answer
+        answer=${answer:-Y}
+        [[ "$answer" =~ ^[Nn]$ ]] && SKIP_OL_TRANSFER_IMAGES=1
+
         time deploy_openlibrary
         echo ""
         time check_servers_in_sync
@@ -734,6 +744,8 @@ elif [ "$1" == "" ]; then  # If this works to detect empty
 else
     echo "Usage: $0 [olsystem|openlibrary|review|prune|rebuild|images|check_server_storage]"
     echo "e.g: time SERVER_SUFFIX='.us.archive.org' ./scripts/deployment/deploy.sh [command]"
+    echo "Env vars: SKIP_OL_TRANSFER_CODE=1  skip SCP+git-init+prune step"
+    echo "          SKIP_OL_TRANSFER_IMAGES=1 skip docker image pull step"
     exit 1
 fi
 

--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -459,7 +459,9 @@ deploy_openlibrary() {
         deploy_images
     fi
 
-    tag_deploy
+    if [[ "$TAG_DEPLOY" == "1" ]]; then
+        tag_deploy
+    fi
 
     echo "Finished production deployment at $(date)"
     echo "To reboot the servers, please run scripts/deployments/restart_all_servers.sh"
@@ -677,9 +679,13 @@ deploy_wizard() {
         answer=${answer:-Y}
         [[ "$answer" =~ ^[Nn]$ ]] && SKIP_OL_TRANSFER_CODE=1
 
-        read -p "[Now] Transfer docker images to servers? [Y/n]..." answer
+        read -p "[Now] Deploy Docker Images? [Y/n]..." answer
         answer=${answer:-Y}
         [[ "$answer" =~ ^[Nn]$ ]] && SKIP_OL_TRANSFER_IMAGES=1
+
+        read -p "[Now] Tag deploy? [Y/n]..." answer
+        answer=${answer:-Y}
+        [[ "$answer" =~ ^[Yy]$ ]] && TAG_DEPLOY=1
 
         time deploy_openlibrary
         echo ""
@@ -746,6 +752,7 @@ else
     echo "e.g: time SERVER_SUFFIX='.us.archive.org' ./scripts/deployment/deploy.sh [command]"
     echo "Env vars: SKIP_OL_TRANSFER_CODE=1  skip SCP+git-init+prune step"
     echo "          SKIP_OL_TRANSFER_IMAGES=1 skip docker image pull step"
+    echo "          TAG_DEPLOY=1              tag this commit as the deploy (set automatically by wizard)"
     exit 1
 fi
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Fixes regression introduced in #12433

### Technical

**`tag_deploy` regression (#12433):** That PR moved `tag_deploy` out of `deploy_openlibrary()` into `deploy_wizard()` unconditionally. But `tag_deploy` requires `$DEPLOY_DIR/openlibrary` to exist — if the wizard's deploy step is skipped (user answers "n"), the directory never exists and `set -e` kills the whole wizard (as flagged by the Copilot review on that PR). Fixed by moving `tag_deploy` back inside `deploy_openlibrary()` where the fresh clone is guaranteed present.

**Standalone `./deploy.sh tag` fallback:** Both `tag_deploy` and `tag_release` now fall back to the script's own repo (`$SCRIPT_DIR`) when `$DEPLOY_DIR/openlibrary` is gone — so running `./deploy.sh tag` after cleanup (e.g. to re-push a tag after a full deploy) works without re-cloning.

**`SKIP_TRANSFER` env var:** Wraps the SCP file-copy, server git-init, docker prune, and image-pull steps in `deploy_openlibrary()`. Set `SKIP_TRANSFER=1` to skip all transfers when rerunning after a partial failure where servers already have current files. `tag_deploy` still runs.

**Bonus fixes:**
- Wizard regex `^[Yy$]` → `^[Yy]$` (`$` was inside the character class, matching a literal `$` rather than end-of-string)
- Remove dead commented-out `#tag_deploy` block in wizard
- Remove redundant `git describe` call (value already set by `tag_release`)
- Fix tab/space indentation inconsistency in `SKIP_TRANSFER` block

### Testing

- [ ] Run `./deploy.sh` wizard, answer "n" to the openlibrary deploy — wizard should continue past the tag step without aborting
- [ ] Run `./deploy.sh openlibrary` standalone — `tag_deploy` fires and pushes `deploy-*` + `production` tags
- [ ] Run `./deploy.sh tag` after a completed deploy (tmp dir already cleaned up) — falls back to local repo and pushes tags
- [ ] Run `SKIP_TRANSFER=1 ./deploy.sh openlibrary` — skips SCP/image pulls but still tags

### Screenshot
<!-- N/A — deploy script only, no UI changes -->

### Stakeholders
@mekarpeles

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->