### PR TITLE
refactor: polish OlPopover and OlSelectPopover behavior

### DIFF
--- a/openlibrary/components/lit/OlPopover.js
+++ b/openlibrary/components/lit/OlPopover.js
@@ -42,7 +42,7 @@ const FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]), selec
  * @fires ol-popover-close - Cancelable. Fired when the popover requests to
  *     close. Call `preventDefault()` to keep it open. Note: the swipe-dismiss
  *     close fires after the gesture completes and is not cancelable.
- *     detail: { reason: 'escape' | 'outside-click' | 'swipe' }
+ *     detail: { reason: 'escape' | 'outside-click' | 'swipe' | 'trigger' }
  *
  * @slot trigger - The trigger element (button, icon, etc.)
  * @slot - Default slot for popover content
@@ -623,7 +623,11 @@ export class OlPopover extends LitElement {
     // ── Trigger / outside click / keyboard ──────────────────────
 
     _onTriggerClick() {
-        this.open = !this.open;
+        if (this.open) {
+            this._requestClose('trigger');
+        } else {
+            this.open = true;
+        }
     }
 
     _onOutsideClick(e) {

--- a/openlibrary/components/lit/OlSelectPopover.js
+++ b/openlibrary/components/lit/OlSelectPopover.js
@@ -395,8 +395,8 @@ export class OlSelectPopover extends LitElement {
                 class="default-trigger"
                 aria-label=${ifDefined(count > 0 ? `${this.label}, ${count} selected` : undefined)}
             >
-                ${OlSelectPopover._chevronIcon}
                 <span>${text}</span>
+                ${OlSelectPopover._chevronIcon}
             </button>
         `;
     }
@@ -519,9 +519,10 @@ export class OlSelectPopover extends LitElement {
         if (this._pendingFocusFirst) {
             this._pendingFocusFirst = false;
             this._focusFirstItem();
-        } else {
-            // Plain open: focus the filter if present, otherwise let ol-popover's
-            // panel focus take over for keyboard list scanning.
+        } else if (!window.matchMedia('(max-width: 767px)').matches) {
+            // Desktop: focus the filter so the user can type immediately. Skipped
+            // on mobile (matches ol-popover's tray breakpoint) so the soft
+            // keyboard doesn't pop up and shrink the visible list area.
             const filter = this.shadowRoot?.querySelector('.filter-input');
             if (filter) filter.focus();
         }


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Two small refinements to the Lit popover components introduced in #12635 following a meeting w/ @cdrini @mekarpeles @RayBB @Armansiddiqui9 

### Technical
- **OlPopover** — fixes the OlSelectPopover trigger chevron not reverting to its default (down) state when the popover was closed by clicking the trigger. The chevron rotation is driven by a `data-open` attribute that OlSelectPopover toggles in response to `ol-popover-close`. The trigger-click path was setting `open = false` directly and skipping that event, so the attribute (and the chevron) got stuck in the open state. Trigger close now goes through the same `_requestClose` path as escape/outside-click so the event fires.
- **OlSelectPopover**
  - Moves the chevron icon after the label in the default trigger so the visual order is *label → indicator*.
  - Skips auto-focusing the filter input when opening on mobile (`≤767px`, matching `ol-popover`'s tray breakpoint). Previously, opening the popover on a touch device would pop up the soft keyboard and shrink the visible list area. Desktop behavior is unchanged: the filter still gets focus so the user can type immediately.

### Testing
- Click the trigger to open, click again to close → chevron rotates back to the down state on close (regression fix).
- Desktop: opening focuses the filter input so the user can type immediately.
- Mobile (or DevTools device emulation ≤767px wide): tap the trigger → popover/tray opens but the soft keyboard does **not** pop up. Tapping the filter still focuses it.
- Verify the chevron renders to the right of the label in the default trigger.

### Screenshot
<img width="510" height="701" alt="image" src="https://github.com/user-attachments/assets/fa8c8cea-4111-4e29-a3cf-b958f8cfd4fa" />

### Stakeholders
@cdrini