### PR TITLE
feat(accounts): add OTP (passwordless) login support via xauthn

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -167,6 +167,7 @@ ia_ol_xauth_s3:
 
 ia_loan_api_url: http://web:8080/internal/fake/loans
 ia_xauth_api_url: http://web:8080/internal/fake/xauth
+ia_s3_auth_url: http://web:8080/internal/fake/s3auth
 
 internal_tests_api_key: 8oPd1tx747YH374ohs48ZO5s2Nt1r9yD
 ia_availability_api_v2_url: https://archive.org/services/availability/

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -897,7 +897,7 @@ class InternetArchiveAccount(web.storage):
         return cls.xauth(
             "redeem_otp",
             email=email.strip().lower(),
-            otp=otp,
+            password=otp,
             headers=headers,
         )
 

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -14,11 +14,11 @@ from typing import TYPE_CHECKING, Literal
 
 import requests
 import web
-from validate_email import validate_email
-
 from infogami import config
 from infogami.infobase.client import ClientException
 from infogami.utils.view import public, render_template
+from validate_email import validate_email
+
 from openlibrary.core import helpers, stats
 from openlibrary.core.bestbook import Bestbook
 from openlibrary.core.booknotes import Booknotes
@@ -781,7 +781,16 @@ class InternetArchiveAccount(web.storage):
                 raise e
 
     @classmethod
-    def xauth(cls, op, test=None, s3_key=None, s3_secret=None, xauth_url=None, **data):
+    def xauth(
+        cls,
+        op,
+        test=None,
+        s3_key=None,
+        s3_secret=None,
+        xauth_url=None,
+        headers=None,
+        **data,
+    ):
         """
         See https://git.archive.org/ia/petabox/tree/master/www/sf/services/xauthn
         """
@@ -809,7 +818,7 @@ class InternetArchiveAccount(web.storage):
         if test:
             params["developer"] = test
 
-        response = requests.post(url, params=params, json=data)
+        response = requests.post(url, params=params, json=data, headers=headers or {})
         if response.status_code == 403:
             raise OLAuthenticationError("security_error")
         if response.status_code == 504 and op == "create":
@@ -871,6 +880,26 @@ class InternetArchiveAccount(web.storage):
             if reason == "account_not_verified":
                 response["values"]["reason"] = "ia_account_not_verified"
         return response
+
+    @classmethod
+    def issue_otp(cls, email, service='ol', originating_ip=None):
+        headers = {'X-Originating-IP': originating_ip} if originating_ip else None
+        return cls.xauth(
+            'issue_otp',
+            email=email.strip().lower(),
+            service=service,
+            headers=headers,
+        )
+
+    @classmethod
+    def redeem_otp(cls, email, password, originating_ip=None):
+        headers = {'X-Originating-IP': originating_ip} if originating_ip else None
+        return cls.xauth(
+            'redeem_otp',
+            email=email.strip().lower(),
+            password=password,
+            headers=headers,
+        )
 
     @classmethod
     def verify(cls, token, welcome_email=True, test=False):

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -14,11 +14,11 @@ from typing import TYPE_CHECKING, Literal
 
 import requests
 import web
+from validate_email import validate_email
+
 from infogami import config
 from infogami.infobase.client import ClientException
 from infogami.utils.view import public, render_template
-from validate_email import validate_email
-
 from openlibrary.core import helpers, stats
 from openlibrary.core.bestbook import Bestbook
 from openlibrary.core.booknotes import Booknotes
@@ -882,10 +882,10 @@ class InternetArchiveAccount(web.storage):
         return response
 
     @classmethod
-    def issue_otp(cls, email, service='ol', originating_ip=None):
-        headers = {'X-Originating-IP': originating_ip} if originating_ip else None
+    def issue_otp(cls, email, service="ol", originating_ip=None):
+        headers = {"X-Originating-IP": originating_ip} if originating_ip else None
         return cls.xauth(
-            'issue_otp',
+            "issue_otp",
             email=email.strip().lower(),
             service=service,
             headers=headers,
@@ -893,9 +893,9 @@ class InternetArchiveAccount(web.storage):
 
     @classmethod
     def redeem_otp(cls, email, password, originating_ip=None):
-        headers = {'X-Originating-IP': originating_ip} if originating_ip else None
+        headers = {"X-Originating-IP": originating_ip} if originating_ip else None
         return cls.xauth(
-            'redeem_otp',
+            "redeem_otp",
             email=email.strip().lower(),
             password=password,
             headers=headers,

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -892,12 +892,12 @@ class InternetArchiveAccount(web.storage):
         )
 
     @classmethod
-    def redeem_otp(cls, email, password, originating_ip=None):
+    def redeem_otp(cls, email, otp, originating_ip=None):
         headers = {"X-Originating-IP": originating_ip} if originating_ip else None
         return cls.xauth(
             "redeem_otp",
             email=email.strip().lower(),
-            password=password,
+            otp=otp,
             headers=headers,
         )
 

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -14,11 +14,11 @@ from typing import TYPE_CHECKING, Literal
 
 import requests
 import web
+from validate_email import validate_email
+
 from infogami import config
 from infogami.infobase.client import ClientException
 from infogami.utils.view import public, render_template
-from validate_email import validate_email
-
 from openlibrary.core import helpers, stats
 from openlibrary.core.bestbook import Bestbook
 from openlibrary.core.booknotes import Booknotes

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -14,11 +14,11 @@ from typing import TYPE_CHECKING, Literal
 
 import requests
 import web
-from validate_email import validate_email
-
 from infogami import config
 from infogami.infobase.client import ClientException
 from infogami.utils.view import public, render_template
+from validate_email import validate_email
+
 from openlibrary.core import helpers, stats
 from openlibrary.core.bestbook import Bestbook
 from openlibrary.core.booknotes import Booknotes

--- a/openlibrary/components/lit/OpenLibraryOTP.js
+++ b/openlibrary/components/lit/OpenLibraryOTP.js
@@ -9,13 +9,13 @@ import '@internetarchive/elements/ia-otp-form/ia-otp-form';
  *   1. Enter email  → POST /account/login/otp/issue
  *   2. Enter code   → POST /account/login/otp/redeem  (via ia-otp-form)
  *
- * On success the page reloads to `redirect` (defaults to /account/books).
+ * On success the page navigates to the server-sanitized redirect URL.
  *
  * Usage:
  *   <ol-otp-login></ol-otp-login>
  *   <ol-otp-login redirect="/account/books"></ol-otp-login>
  *
- * @prop {String} redirect - URL to navigate to on successful login
+ * @prop {String} redirect - Hint for post-login destination; sanitized server-side
  */
 export class OpenLibraryOTP extends LitElement {
     static properties = {
@@ -39,6 +39,7 @@ export class OpenLibraryOTP extends LitElement {
         this._issueError = '';
         this._validationStatus = 'ready';
         this._newCodeSending = false;
+        this._previousFocus = null;
     }
 
     static styles = css`
@@ -155,6 +156,16 @@ export class OpenLibraryOTP extends LitElement {
             --link-color: #4b4bdf;
             margin-top: 0.5rem;
         }
+
+        /* Visually-hidden focus sentinels used for focus-trapping */
+        .focus-sentinel {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            overflow: hidden;
+            clip: rect(0 0 0 0);
+            white-space: nowrap;
+        }
     `;
 
     render() {
@@ -166,12 +177,23 @@ export class OpenLibraryOTP extends LitElement {
             <div
                 class="overlay"
                 ?open=${this._open}
-                role="dialog"
-                aria-modal="true"
-                aria-label="Sign in with a one-time code"
                 @click=${this._handleOverlayClick}
+                @keydown=${this._handleKeydown}
             >
-                <div class="dialog">
+                <div
+                    class="dialog"
+                    role="dialog"
+                    aria-modal="true"
+                    aria-label="Sign in with a one-time code"
+                    tabindex="-1"
+                >
+                    <!-- Focus sentinel: catches Shift+Tab past the first element -->
+                    <div
+                        class="focus-sentinel"
+                        tabindex="0"
+                        @focus=${this._focusLast}
+                    ></div>
+
                     <button
                         class="close-btn"
                         @click=${this._closeModal}
@@ -182,6 +204,13 @@ export class OpenLibraryOTP extends LitElement {
                     ${this._step === 'email'
         ? this._emailTemplate
         : this._codeTemplate}
+
+                    <!-- Focus sentinel: catches Tab past the last element -->
+                    <div
+                        class="focus-sentinel"
+                        tabindex="0"
+                        @focus=${this._focusFirst}
+                    ></div>
                 </div>
             </div>
         `;
@@ -230,7 +259,24 @@ export class OpenLibraryOTP extends LitElement {
         `;
     }
 
+    updated(changedProperties) {
+        if (!changedProperties.has('_open')) return;
+        if (this._open) {
+            // Focus the first interactive element once the dialog renders
+            requestAnimationFrame(() => {
+                const first = this.shadowRoot.querySelector(
+                    '.dialog input, .dialog button:not(.close-btn)'
+                );
+                (first || this.shadowRoot.querySelector('.dialog')).focus();
+            });
+        } else if (this._previousFocus) {
+            this._previousFocus.focus();
+            this._previousFocus = null;
+        }
+    }
+
     _openModal() {
+        this._previousFocus = document.activeElement;
         this._open = true;
         this._step = 'email';
         this._issueError = '';
@@ -243,6 +289,26 @@ export class OpenLibraryOTP extends LitElement {
 
     _handleOverlayClick(e) {
         if (e.target === e.currentTarget) this._closeModal();
+    }
+
+    _handleKeydown(e) {
+        if (e.key === 'Escape') this._closeModal();
+    }
+
+    /** Redirect Tab-past-end back to the first focusable element */
+    _focusFirst() {
+        const el = this.shadowRoot.querySelector(
+            '.dialog button.close-btn, .dialog input, .dialog button:not([disabled])'
+        );
+        el?.focus();
+    }
+
+    /** Redirect Shift+Tab-past-start back to the last focusable element */
+    _focusLast() {
+        const candidates = this.shadowRoot.querySelectorAll(
+            '.dialog button:not([disabled]), .dialog input:not([disabled])'
+        );
+        candidates[candidates.length - 1]?.focus();
     }
 
     async _handleEmailSubmit(e) {
@@ -285,12 +351,14 @@ export class OpenLibraryOTP extends LitElement {
                 body: new URLSearchParams({
                     email: this._email,
                     otp: e.detail,
+                    redirect: this.redirect,
                 }),
             });
             const data = await resp.json();
             if (data.success) {
                 this._validationStatus = 'success';
-                window.location.href = this.redirect;
+                // Navigate to server-sanitized redirect (never raw this.redirect)
+                window.location.href = data.redirect;
             } else {
                 this._validationStatus = 'error';
             }

--- a/openlibrary/components/lit/OpenLibraryOTP.js
+++ b/openlibrary/components/lit/OpenLibraryOTP.js
@@ -1,0 +1,318 @@
+import { LitElement, html, css, nothing } from 'lit';
+import '@internetarchive/elements/ia-otp-form/ia-otp-form';
+
+/**
+ * OTP login flow for Open Library.
+ *
+ * Renders a trigger button that opens a modal dialog. The modal walks the
+ * patron through two steps:
+ *   1. Enter email  → POST /account/login/otp/issue
+ *   2. Enter code   → POST /account/login/otp/redeem  (via ia-otp-form)
+ *
+ * On success the page reloads to `redirect` (defaults to /account/books).
+ *
+ * Usage:
+ *   <ol-otp-login></ol-otp-login>
+ *   <ol-otp-login redirect="/account/books"></ol-otp-login>
+ *
+ * @prop {String} redirect - URL to navigate to on successful login
+ */
+export class OpenLibraryOTP extends LitElement {
+    static properties = {
+        redirect: { type: String },
+        _open: { type: Boolean, state: true },
+        _step: { type: String, state: true },
+        _email: { type: String, state: true },
+        _submitting: { type: Boolean, state: true },
+        _issueError: { type: String, state: true },
+        _validationStatus: { type: String, state: true },
+        _newCodeSending: { type: Boolean, state: true },
+    };
+
+    constructor() {
+        super();
+        this.redirect = '/account/books';
+        this._open = false;
+        this._step = 'email';
+        this._email = '';
+        this._submitting = false;
+        this._issueError = '';
+        this._validationStatus = 'ready';
+        this._newCodeSending = false;
+    }
+
+    static styles = css`
+        :host {
+            display: inline-block;
+        }
+
+        .trigger-btn {
+            background: var(--ia-button-primary-bg, #4b4bdf);
+            color: var(--ia-button-primary-color, #fff);
+            border: none;
+            border-radius: 4px;
+            padding: 8px 16px;
+            font-size: 1rem;
+            font-family: inherit;
+            cursor: pointer;
+            width: fit-content;
+        }
+        .trigger-btn:hover,
+        .trigger-btn:focus {
+            background: var(--ia-button-primary-bg-hover, #3a3abf);
+            outline: 2px solid currentColor;
+            outline-offset: 2px;
+        }
+
+        .overlay {
+            display: none;
+            position: fixed;
+            inset: 0;
+            background: rgba(0, 0, 0, 0.5);
+            z-index: 1000;
+            align-items: center;
+            justify-content: center;
+        }
+        .overlay[open] {
+            display: flex;
+        }
+
+        .dialog {
+            background: #fff;
+            border-radius: 8px;
+            padding: 2rem;
+            max-width: 400px;
+            width: 90%;
+            position: relative;
+            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+        }
+
+        .close-btn {
+            position: absolute;
+            top: 0.75rem;
+            right: 0.75rem;
+            background: none;
+            border: none;
+            font-size: 1.5rem;
+            cursor: pointer;
+            line-height: 1;
+            color: inherit;
+        }
+
+        h2 {
+            margin: 0 0 0.5rem;
+            font-size: 1.25rem;
+        }
+        p {
+            margin: 0 0 1rem;
+            font-size: 0.95rem;
+        }
+
+        .email-form {
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+        }
+        .email-form label {
+            font-size: 0.9rem;
+            font-weight: bold;
+        }
+        .email-form input[type='email'] {
+            padding: 8px;
+            font-size: 1rem;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            width: 100%;
+            box-sizing: border-box;
+        }
+        .email-form button[type='submit'] {
+            padding: 8px 16px;
+            background: var(--ia-button-primary-bg, #4b4bdf);
+            color: var(--ia-button-primary-color, #fff);
+            border: none;
+            border-radius: 4px;
+            font-size: 1rem;
+            font-family: inherit;
+            cursor: pointer;
+            align-self: flex-start;
+        }
+        .email-form button[type='submit']:disabled {
+            opacity: 0.6;
+            cursor: not-allowed;
+        }
+
+        .error {
+            color: var(--color-danger, #c00);
+            font-size: 0.9rem;
+            margin: 0;
+        }
+
+        ia-otp-form {
+            --font-size-standard: 0.95rem;
+            --font-size-lg: 1.5rem;
+            --color-success: #008000;
+            --color-danger: #c00;
+            --link-color: #4b4bdf;
+            margin-top: 0.5rem;
+        }
+    `;
+
+    render() {
+        return html`
+            <button class="trigger-btn" @click=${this._openModal}>
+                Sign in with a one-time code
+            </button>
+
+            <div
+                class="overlay"
+                ?open=${this._open}
+                role="dialog"
+                aria-modal="true"
+                aria-label="Sign in with a one-time code"
+                @click=${this._handleOverlayClick}
+            >
+                <div class="dialog">
+                    <button
+                        class="close-btn"
+                        @click=${this._closeModal}
+                        aria-label="Close"
+                    >
+                        &times;
+                    </button>
+                    ${this._step === 'email'
+        ? this._emailTemplate
+        : this._codeTemplate}
+                </div>
+            </div>
+        `;
+    }
+
+    get _emailTemplate() {
+        return html`
+            <h2>Sign in with a one-time code</h2>
+            <p>
+                Enter your Internet Archive email and we'll send you a login
+                code.
+            </p>
+            <form class="email-form" @submit=${this._handleEmailSubmit}>
+                <label for="otp-email">Email</label>
+                <input
+                    type="email"
+                    id="otp-email"
+                    .value=${this._email}
+                    @input=${(e) => (this._email = e.target.value)}
+                    autocomplete="email"
+                    required
+                />
+                ${this._issueError
+        ? html`<p class="error">${this._issueError}</p>`
+        : nothing}
+                <button type="submit" ?disabled=${this._submitting}>
+                    ${this._submitting ? 'Sending…' : 'Send me a code'}
+                </button>
+            </form>
+        `;
+    }
+
+    get _codeTemplate() {
+        return html`
+            <h2>Enter your code</h2>
+            <p>
+                We sent a 6-digit code to
+                <strong>${this._email}</strong>.
+            </p>
+            <ia-otp-form
+                .validationStatus=${this._validationStatus}
+                .newCodeSending=${this._newCodeSending}
+                @codeSubmitted=${this._handleCodeSubmitted}
+                @newCodeRequested=${this._handleResend}
+            ></ia-otp-form>
+        `;
+    }
+
+    _openModal() {
+        this._open = true;
+        this._step = 'email';
+        this._issueError = '';
+        this._validationStatus = 'ready';
+    }
+
+    _closeModal() {
+        this._open = false;
+    }
+
+    _handleOverlayClick(e) {
+        if (e.target === e.currentTarget) this._closeModal();
+    }
+
+    async _handleEmailSubmit(e) {
+        e.preventDefault();
+        this._submitting = true;
+        this._issueError = '';
+        try {
+            const resp = await fetch('/account/login/otp/issue', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                },
+                body: new URLSearchParams({ email: this._email }),
+            });
+            const data = await resp.json();
+            if (data.success) {
+                this._step = 'code';
+                this._validationStatus = 'ready';
+            } else if (resp.status === 429) {
+                this._issueError =
+                    'Too many attempts. Please wait a moment and try again.';
+            } else {
+                this._issueError = 'Unable to send code. Please try again.';
+            }
+        } catch {
+            this._issueError = 'A network error occurred. Please try again.';
+        } finally {
+            this._submitting = false;
+        }
+    }
+
+    async _handleCodeSubmitted(e) {
+        this._validationStatus = 'loading';
+        try {
+            const resp = await fetch('/account/login/otp/redeem', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                },
+                body: new URLSearchParams({
+                    email: this._email,
+                    otp: e.detail,
+                }),
+            });
+            const data = await resp.json();
+            if (data.success) {
+                this._validationStatus = 'success';
+                window.location.href = this.redirect;
+            } else {
+                this._validationStatus = 'error';
+            }
+        } catch {
+            this._validationStatus = 'error';
+        }
+    }
+
+    async _handleResend() {
+        this._newCodeSending = true;
+        try {
+            await fetch('/account/login/otp/issue', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                },
+                body: new URLSearchParams({ email: this._email }),
+            });
+        } finally {
+            this._newCodeSending = false;
+        }
+    }
+}
+
+customElements.define('ol-otp-login', OpenLibraryOTP);

--- a/openlibrary/components/lit/OpenLibraryOTP.js
+++ b/openlibrary/components/lit/OpenLibraryOTP.js
@@ -313,7 +313,7 @@ export class OpenLibraryOTP extends LitElement {
         h2.textContent = 'Sign in with a one-time code';
 
         const p = document.createElement('p');
-        p.textContent = "Enter your Internet Archive email and we'll send you a login code.";
+        p.textContent = 'Enter your Internet Archive email and we\'ll send you a login code.';
 
         const form = document.createElement('form');
         form.className = 'ol-otp-email-form';

--- a/openlibrary/components/lit/OpenLibraryOTP.js
+++ b/openlibrary/components/lit/OpenLibraryOTP.js
@@ -53,7 +53,7 @@ export class OpenLibraryOTP extends LitElement {
             border: none;
             border-radius: 4px;
             padding: 8px 16px;
-            font-size: 1rem;
+            font-size: var(--font-size-label-large, 14px);
             font-family: inherit;
             cursor: pointer;
             width: 100%;

--- a/openlibrary/components/lit/OpenLibraryOTP.js
+++ b/openlibrary/components/lit/OpenLibraryOTP.js
@@ -48,7 +48,7 @@ export class OpenLibraryOTP extends LitElement {
         }
 
         .trigger-btn {
-            background: var(--ia-button-primary-bg, #4b4bdf);
+            background: var(--primary-blue, hsl(202, 96%, 37%));
             color: var(--ia-button-primary-color, #fff);
             border: none;
             border-radius: 4px;
@@ -56,11 +56,12 @@ export class OpenLibraryOTP extends LitElement {
             font-size: 1rem;
             font-family: inherit;
             cursor: pointer;
-            width: fit-content;
+            width: 100%;
+            margin-top: 10px;
         }
         .trigger-btn:hover,
         .trigger-btn:focus {
-            background: var(--ia-button-primary-bg-hover, #3a3abf);
+            background: hsl(202, 96%, 17%);
             outline: 2px solid currentColor;
             outline-offset: 2px;
         }
@@ -288,6 +289,10 @@ export class OpenLibraryOTP extends LitElement {
     }
 
     _handleOverlayClick(e) {
+        // Keep the modal open while the user is entering their code — they are
+        // likely switching back from their email client and an accidental click
+        // should not lose their place in the flow.
+        if (this._step === 'code') return;
         if (e.target === e.currentTarget) this._closeModal();
     }
 

--- a/openlibrary/components/lit/OpenLibraryOTP.js
+++ b/openlibrary/components/lit/OpenLibraryOTP.js
@@ -1,4 +1,4 @@
-import { LitElement, html, css, nothing } from 'lit';
+import { LitElement, html, css } from 'lit';
 import '@internetarchive/elements/ia-otp-form/ia-otp-form';
 
 /**
@@ -10,6 +10,10 @@ import '@internetarchive/elements/ia-otp-form/ia-otp-form';
  *   2. Enter code   → POST /account/login/otp/redeem  (via ia-otp-form)
  *
  * On success the page navigates to the server-sanitized redirect URL.
+ *
+ * The overlay is appended directly to document.body (a "portal") and managed
+ * imperatively so that it escapes any ancestor stacking contexts. Lit's
+ * declarative render() is only used for the trigger button inside the shadow DOM.
  *
  * Usage:
  *   <ol-otp-login></ol-otp-login>
@@ -40,12 +44,186 @@ export class OpenLibraryOTP extends LitElement {
         this._validationStatus = 'ready';
         this._newCodeSending = false;
         this._previousFocus = null;
+
+        // Bound references kept for addEventListener / removeEventListener symmetry
+        this._boundHandleOverlayClick = this._handleOverlayClick.bind(this);
+        this._boundHandleKeydown = this._handleKeydown.bind(this);
+        this._boundFocusFirst = this._focusFirst.bind(this);
+        this._boundFocusLast = this._focusLast.bind(this);
+        this._boundCloseModal = this._closeModal.bind(this);
+        this._boundHandleEmailInput = (e) => { this._email = e.target.value; };
+        this._boundHandleEmailSubmit = this._handleEmailSubmit.bind(this);
+        this._boundHandleCodeSubmitted = this._handleCodeSubmitted.bind(this);
+        this._boundHandleResend = this._handleResend.bind(this);
+
+        this._buildPortal();
     }
 
+    // ---------------------------------------------------------------------------
+    // Portal construction — runs once; produces stable DOM that we mutate later
+    // ---------------------------------------------------------------------------
+
+    _buildPortal() {
+        const style = document.createElement('style');
+        style.textContent = `
+            .ol-otp-overlay {
+                display: none;
+                position: fixed;
+                inset: 0;
+                background: rgba(0, 0, 0, 0.5);
+                z-index: 1000;
+                align-items: center;
+                justify-content: center;
+            }
+            .ol-otp-overlay[open] {
+                display: flex;
+            }
+            .ol-otp-dialog {
+                background: #fff;
+                border-radius: 8px;
+                padding: 2rem;
+                max-width: 400px;
+                width: 90%;
+                position: relative;
+                box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+                font-family: inherit;
+            }
+            .ol-otp-close-btn {
+                position: absolute;
+                top: 0.75rem;
+                right: 0.75rem;
+                background: none;
+                border: none;
+                font-size: 1.5rem;
+                cursor: pointer;
+                line-height: 1;
+                color: inherit;
+            }
+            .ol-otp-dialog h2 {
+                margin: 0 0 0.5rem;
+                font-size: 1.25rem;
+            }
+            .ol-otp-dialog p {
+                margin: 0 0 1rem;
+                font-size: 0.95rem;
+            }
+            .ol-otp-email-form {
+                display: flex;
+                flex-direction: column;
+                gap: 0.75rem;
+            }
+            .ol-otp-email-form label {
+                font-size: 0.9rem;
+                font-weight: bold;
+            }
+            .ol-otp-email-form input[type='email'] {
+                padding: 8px;
+                font-size: 1rem;
+                border: 1px solid #ccc;
+                border-radius: 4px;
+                width: 100%;
+                box-sizing: border-box;
+            }
+            .ol-otp-email-form button[type='submit'] {
+                padding: 8px 16px;
+                background: var(--ia-button-primary-bg, #4b4bdf);
+                color: var(--ia-button-primary-color, #fff);
+                border: none;
+                border-radius: 4px;
+                font-size: 1rem;
+                font-family: inherit;
+                cursor: pointer;
+                align-self: flex-start;
+            }
+            .ol-otp-email-form button[type='submit']:disabled {
+                opacity: 0.6;
+                cursor: not-allowed;
+            }
+            .ol-otp-error {
+                color: var(--color-danger, #c00);
+                font-size: 0.9rem;
+                margin: 0;
+            }
+            ia-otp-form {
+                --font-size-standard: 0.95rem;
+                --font-size-lg: 1.5rem;
+                --color-success: #008000;
+                --color-danger: #c00;
+                --link-color: #4b4bdf;
+                margin-top: 0.5rem;
+            }
+            .ol-otp-focus-sentinel {
+                position: absolute;
+                width: 1px;
+                height: 1px;
+                overflow: hidden;
+                clip: rect(0 0 0 0);
+                white-space: nowrap;
+            }
+        `;
+
+        // Overlay
+        this._overlay = document.createElement('div');
+        this._overlay.className = 'ol-otp-overlay';
+
+        // Dialog
+        this._dialog = document.createElement('div');
+        this._dialog.className = 'ol-otp-dialog';
+        this._dialog.setAttribute('role', 'dialog');
+        this._dialog.setAttribute('aria-modal', 'true');
+        this._dialog.setAttribute('aria-label', 'Sign in with a one-time code');
+        this._dialog.setAttribute('tabindex', '-1');
+
+        // Focus sentinels
+        this._sentinelStart = document.createElement('div');
+        this._sentinelStart.className = 'ol-otp-focus-sentinel';
+        this._sentinelStart.setAttribute('tabindex', '0');
+
+        this._sentinelEnd = document.createElement('div');
+        this._sentinelEnd.className = 'ol-otp-focus-sentinel';
+        this._sentinelEnd.setAttribute('tabindex', '0');
+
+        // Close button
+        this._closeBtn = document.createElement('button');
+        this._closeBtn.className = 'ol-otp-close-btn';
+        this._closeBtn.setAttribute('aria-label', 'Close');
+        this._closeBtn.innerHTML = '&times;';
+
+        // Content container — swapped between email and code step
+        this._contentContainer = document.createElement('div');
+
+        this._dialog.append(
+            this._sentinelStart,
+            this._closeBtn,
+            this._contentContainer,
+            this._sentinelEnd,
+        );
+        this._overlay.appendChild(this._dialog);
+
+        // Portal container
+        this._portal = document.createElement('div');
+        this._portal.setAttribute('data-ol-otp-portal', '');
+        this._portal.append(style, this._overlay);
+
+        // Wire permanent listeners (these never need to be re-added)
+        this._overlay.addEventListener('click', this._boundHandleOverlayClick);
+        this._overlay.addEventListener('keydown', this._boundHandleKeydown);
+        this._closeBtn.addEventListener('click', this._boundCloseModal);
+        this._sentinelStart.addEventListener('focus', this._boundFocusLast);
+        this._sentinelEnd.addEventListener('focus', this._boundFocusFirst);
+    }
+
+    disconnectedCallback() {
+        super.disconnectedCallback();
+        this._portal.remove();
+    }
+
+    // ---------------------------------------------------------------------------
+    // Shadow DOM — trigger button only
+    // ---------------------------------------------------------------------------
+
     static styles = css`
-        :host {
-            display: inline-block;
-        }
+        :host { display: inline-block; }
 
         .trigger-btn {
             background: var(--primary-blue, hsl(202, 96%, 37%));
@@ -65,108 +243,6 @@ export class OpenLibraryOTP extends LitElement {
             outline: 2px solid currentColor;
             outline-offset: 2px;
         }
-
-        .overlay {
-            display: none;
-            position: fixed;
-            inset: 0;
-            background: rgba(0, 0, 0, 0.5);
-            z-index: 1000;
-            align-items: center;
-            justify-content: center;
-        }
-        .overlay[open] {
-            display: flex;
-        }
-
-        .dialog {
-            background: #fff;
-            border-radius: 8px;
-            padding: 2rem;
-            max-width: 400px;
-            width: 90%;
-            position: relative;
-            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
-        }
-
-        .close-btn {
-            position: absolute;
-            top: 0.75rem;
-            right: 0.75rem;
-            background: none;
-            border: none;
-            font-size: 1.5rem;
-            cursor: pointer;
-            line-height: 1;
-            color: inherit;
-        }
-
-        h2 {
-            margin: 0 0 0.5rem;
-            font-size: 1.25rem;
-        }
-        p {
-            margin: 0 0 1rem;
-            font-size: 0.95rem;
-        }
-
-        .email-form {
-            display: flex;
-            flex-direction: column;
-            gap: 0.75rem;
-        }
-        .email-form label {
-            font-size: 0.9rem;
-            font-weight: bold;
-        }
-        .email-form input[type='email'] {
-            padding: 8px;
-            font-size: 1rem;
-            border: 1px solid #ccc;
-            border-radius: 4px;
-            width: 100%;
-            box-sizing: border-box;
-        }
-        .email-form button[type='submit'] {
-            padding: 8px 16px;
-            background: var(--ia-button-primary-bg, #4b4bdf);
-            color: var(--ia-button-primary-color, #fff);
-            border: none;
-            border-radius: 4px;
-            font-size: 1rem;
-            font-family: inherit;
-            cursor: pointer;
-            align-self: flex-start;
-        }
-        .email-form button[type='submit']:disabled {
-            opacity: 0.6;
-            cursor: not-allowed;
-        }
-
-        .error {
-            color: var(--color-danger, #c00);
-            font-size: 0.9rem;
-            margin: 0;
-        }
-
-        ia-otp-form {
-            --font-size-standard: 0.95rem;
-            --font-size-lg: 1.5rem;
-            --color-success: #008000;
-            --color-danger: #c00;
-            --link-color: #4b4bdf;
-            margin-top: 0.5rem;
-        }
-
-        /* Visually-hidden focus sentinels used for focus-trapping */
-        .focus-sentinel {
-            position: absolute;
-            width: 1px;
-            height: 1px;
-            overflow: hidden;
-            clip: rect(0 0 0 0);
-            white-space: nowrap;
-        }
     `;
 
     render() {
@@ -174,107 +250,150 @@ export class OpenLibraryOTP extends LitElement {
             <button class="trigger-btn" @click=${this._openModal}>
                 Sign in with a one-time code
             </button>
-
-            <div
-                class="overlay"
-                ?open=${this._open}
-                @click=${this._handleOverlayClick}
-                @keydown=${this._handleKeydown}
-            >
-                <div
-                    class="dialog"
-                    role="dialog"
-                    aria-modal="true"
-                    aria-label="Sign in with a one-time code"
-                    tabindex="-1"
-                >
-                    <!-- Focus sentinel: catches Shift+Tab past the first element -->
-                    <div
-                        class="focus-sentinel"
-                        tabindex="0"
-                        @focus=${this._focusLast}
-                    ></div>
-
-                    <button
-                        class="close-btn"
-                        @click=${this._closeModal}
-                        aria-label="Close"
-                    >
-                        &times;
-                    </button>
-                    ${this._step === 'email'
-        ? this._emailTemplate
-        : this._codeTemplate}
-
-                    <!-- Focus sentinel: catches Tab past the last element -->
-                    <div
-                        class="focus-sentinel"
-                        tabindex="0"
-                        @focus=${this._focusFirst}
-                    ></div>
-                </div>
-            </div>
         `;
     }
 
-    get _emailTemplate() {
-        return html`
-            <h2>Sign in with a one-time code</h2>
-            <p>
-                Enter your Internet Archive email and we'll send you a login
-                code.
-            </p>
-            <form class="email-form" @submit=${this._handleEmailSubmit}>
-                <label for="otp-email">Email</label>
-                <input
-                    type="email"
-                    id="otp-email"
-                    .value=${this._email}
-                    @input=${(e) => (this._email = e.target.value)}
-                    autocomplete="email"
-                    required
-                />
-                ${this._issueError
-        ? html`<p class="error">${this._issueError}</p>`
-        : nothing}
-                <button type="submit" ?disabled=${this._submitting}>
-                    ${this._submitting ? 'Sending…' : 'Send me a code'}
-                </button>
-            </form>
-        `;
-    }
+    // ---------------------------------------------------------------------------
+    // Imperative portal updates — called whenever state changes
+    // ---------------------------------------------------------------------------
 
-    get _codeTemplate() {
-        return html`
-            <h2>Enter your code</h2>
-            <p>
-                We sent a 6-digit code to
-                <strong>${this._email}</strong>.
-            </p>
-            <ia-otp-form
-                .validationStatus=${this._validationStatus}
-                .newCodeSending=${this._newCodeSending}
-                @codeSubmitted=${this._handleCodeSubmitted}
-                @newCodeRequested=${this._handleResend}
-            ></ia-otp-form>
-        `;
-    }
+    updated() {
+        if (!this._portal.isConnected) {
+            document.body.appendChild(this._portal);
+        }
 
-    updated(changedProperties) {
-        if (!changedProperties.has('_open')) return;
+        // Toggle overlay visibility
+        this._overlay.toggleAttribute('open', this._open);
+
+        // Render the correct step content
         if (this._open) {
-            // Focus the first interactive element once the dialog renders
-            requestAnimationFrame(() => {
-                const first = this.shadowRoot.querySelector(
-                    '.dialog input, .dialog button:not(.close-btn)'
-                );
-                (first || this.shadowRoot.querySelector('.dialog')).focus();
-            });
-        } else if (this._previousFocus) {
-            this._previousFocus.focus();
-            this._previousFocus = null;
+            if (this._step === 'email') {
+                this._renderEmailStep();
+            } else {
+                this._renderCodeStep();
+            }
         }
     }
+
+    _renderEmailStep() {
+        // Only rebuild if we're not already showing the email step
+        if (this._contentContainer.dataset.step === 'email') {
+            // Just patch the dynamic parts in place
+            const submitBtn = this._contentContainer.querySelector('button[type="submit"]');
+            if (submitBtn) {
+                submitBtn.disabled = this._submitting;
+                submitBtn.textContent = this._submitting ? 'Sending…' : 'Send me a code';
+            }
+            const emailInput = this._contentContainer.querySelector('input[type="email"]');
+            if (emailInput && emailInput !== document.activeElement) {
+                emailInput.value = this._email;
+            }
+            // Error message
+            let errorEl = this._contentContainer.querySelector('.ol-otp-error');
+            if (this._issueError) {
+                if (!errorEl) {
+                    errorEl = document.createElement('p');
+                    errorEl.className = 'ol-otp-error';
+                    const submitBtn = this._contentContainer.querySelector('button[type="submit"]');
+                    this._contentContainer.querySelector('.ol-otp-email-form').insertBefore(errorEl, submitBtn);
+                }
+                errorEl.textContent = this._issueError;
+            } else if (errorEl) {
+                errorEl.remove();
+            }
+            return;
+        }
+
+        // Full rebuild of email step
+        this._teardownCodeStep();
+        this._contentContainer.dataset.step = 'email';
+        this._contentContainer.innerHTML = '';
+
+        const h2 = document.createElement('h2');
+        h2.textContent = 'Sign in with a one-time code';
+
+        const p = document.createElement('p');
+        p.textContent = "Enter your Internet Archive email and we'll send you a login code.";
+
+        const form = document.createElement('form');
+        form.className = 'ol-otp-email-form';
+
+        const label = document.createElement('label');
+        label.setAttribute('for', 'otp-email');
+        label.textContent = 'Email';
+
+        const input = document.createElement('input');
+        input.type = 'email';
+        input.id = 'otp-email';
+        input.value = this._email;
+        input.setAttribute('autocomplete', 'email');
+        input.required = true;
+        input.addEventListener('input', this._boundHandleEmailInput);
+
+        const submitBtn = document.createElement('button');
+        submitBtn.type = 'submit';
+        submitBtn.disabled = this._submitting;
+        submitBtn.textContent = this._submitting ? 'Sending…' : 'Send me a code';
+
+        form.append(label, input, submitBtn);
+        form.addEventListener('submit', this._boundHandleEmailSubmit);
+
+        if (this._issueError) {
+            const errorEl = document.createElement('p');
+            errorEl.className = 'ol-otp-error';
+            errorEl.textContent = this._issueError;
+            form.insertBefore(errorEl, submitBtn);
+        }
+
+        this._contentContainer.append(h2, p, form);
+    }
+
+    _renderCodeStep() {
+        if (this._contentContainer.dataset.step === 'code') {
+            // Patch ia-otp-form properties in place
+            const otpForm = this._contentContainer.querySelector('ia-otp-form');
+            if (otpForm) {
+                otpForm.validationStatus = this._validationStatus;
+                otpForm.newCodeSending = this._newCodeSending;
+            }
+            return;
+        }
+
+        this._teardownEmailStep();
+        this._contentContainer.dataset.step = 'code';
+        this._contentContainer.innerHTML = '';
+
+        const h2 = document.createElement('h2');
+        h2.textContent = 'Enter your code';
+
+        const p = document.createElement('p');
+        p.innerHTML = `We sent a 6-digit code to <strong>${this._email}</strong>.`;
+
+        const otpForm = document.createElement('ia-otp-form');
+        otpForm.validationStatus = this._validationStatus;
+        otpForm.newCodeSending = this._newCodeSending;
+        otpForm.addEventListener('codeSubmitted', this._boundHandleCodeSubmitted);
+        otpForm.addEventListener('newCodeRequested', this._boundHandleResend);
+
+        this._contentContainer.append(h2, p, otpForm);
+    }
+
+    _teardownEmailStep() {
+        const form = this._contentContainer.querySelector('.ol-otp-email-form');
+        form?.removeEventListener('submit', this._boundHandleEmailSubmit);
+        const input = this._contentContainer.querySelector('input[type="email"]');
+        input?.removeEventListener('input', this._boundHandleEmailInput);
+    }
+
+    _teardownCodeStep() {
+        const otpForm = this._contentContainer.querySelector('ia-otp-form');
+        otpForm?.removeEventListener('codeSubmitted', this._boundHandleCodeSubmitted);
+        otpForm?.removeEventListener('newCodeRequested', this._boundHandleResend);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Modal lifecycle
+    // ---------------------------------------------------------------------------
 
     _openModal() {
         this._previousFocus = document.activeElement;
@@ -282,10 +401,26 @@ export class OpenLibraryOTP extends LitElement {
         this._step = 'email';
         this._issueError = '';
         this._validationStatus = 'ready';
+
+        requestAnimationFrame(() => {
+            const first = this._contentContainer.querySelector(
+                'input, button:not(.ol-otp-close-btn)'
+            );
+            (first || this._dialog).focus();
+        });
     }
 
     _closeModal() {
         this._open = false;
+        if (this._step === 'email') this._teardownEmailStep();
+        else this._teardownCodeStep();
+        this._contentContainer.innerHTML = '';
+        delete this._contentContainer.dataset.step;
+
+        if (this._previousFocus) {
+            this._previousFocus.focus();
+            this._previousFocus = null;
+        }
     }
 
     _handleOverlayClick(e) {
@@ -302,19 +437,23 @@ export class OpenLibraryOTP extends LitElement {
 
     /** Redirect Tab-past-end back to the first focusable element */
     _focusFirst() {
-        const el = this.shadowRoot.querySelector(
-            '.dialog button.close-btn, .dialog input, .dialog button:not([disabled])'
+        const el = this._dialog.querySelector(
+            'button.ol-otp-close-btn, input, button:not([disabled])'
         );
         el?.focus();
     }
 
     /** Redirect Shift+Tab-past-start back to the last focusable element */
     _focusLast() {
-        const candidates = this.shadowRoot.querySelectorAll(
-            '.dialog button:not([disabled]), .dialog input:not([disabled])'
+        const candidates = this._dialog.querySelectorAll(
+            'button:not([disabled]), input:not([disabled])'
         );
         candidates[candidates.length - 1]?.focus();
     }
+
+    // ---------------------------------------------------------------------------
+    // Fetch handlers
+    // ---------------------------------------------------------------------------
 
     async _handleEmailSubmit(e) {
         e.preventDefault();
@@ -323,9 +462,7 @@ export class OpenLibraryOTP extends LitElement {
         try {
             const resp = await fetch('/account/login/otp/issue', {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/x-www-form-urlencoded',
-                },
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
                 body: new URLSearchParams({ email: this._email }),
             });
             const data = await resp.json();
@@ -333,8 +470,7 @@ export class OpenLibraryOTP extends LitElement {
                 this._step = 'code';
                 this._validationStatus = 'ready';
             } else if (resp.status === 429) {
-                this._issueError =
-                    'Too many attempts. Please wait a moment and try again.';
+                this._issueError = 'Too many attempts. Please wait a moment and try again.';
             } else {
                 this._issueError = 'Unable to send code. Please try again.';
             }
@@ -350,9 +486,7 @@ export class OpenLibraryOTP extends LitElement {
         try {
             const resp = await fetch('/account/login/otp/redeem', {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/x-www-form-urlencoded',
-                },
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
                 body: new URLSearchParams({
                     email: this._email,
                     otp: e.detail,
@@ -377,9 +511,7 @@ export class OpenLibraryOTP extends LitElement {
         try {
             await fetch('/account/login/otp/issue', {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/x-www-form-urlencoded',
-                },
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
                 body: new URLSearchParams({ email: this._email }),
             });
         } finally {

--- a/openlibrary/components/lit/index.js
+++ b/openlibrary/components/lit/index.js
@@ -14,3 +14,4 @@ export { OlSelectPopover } from './OlSelectPopover.js';
 export { OLChip } from './OLChip.js';
 export { OLChipGroup } from './OLChipGroup.js';
 export { OLButton } from './OLButton.js';
+export { OpenLibraryOTP } from './OpenLibraryOTP.js';

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -8,9 +8,10 @@ from math import ceil
 from typing import TYPE_CHECKING, Any, Final
 from urllib.parse import urlparse
 
-import infogami.core.code as core  # noqa: F401 side effects may be needed
 import requests
 import web
+
+import infogami.core.code as core  # noqa: F401 side effects may be needed
 from infogami import config
 from infogami.utils import delegate
 from infogami.utils.view import (
@@ -19,7 +20,6 @@ from infogami.utils.view import (
     render_template,
     require_login,
 )
-
 from openlibrary import accounts
 from openlibrary.accounts import (
     InternetArchiveAccount,
@@ -115,7 +115,12 @@ class xauth(delegate.page):
         service. This service is spoofable to return successful and
         unsuccessful login attempts depending on the provided GET parameters
         """
-        i = web.input(email="", op=None)
+        i = web.input(email="", op=None, password="")
+        # xauth() sends JSON body; web.input() only reads query params + form bodies
+        try:
+            body = json.loads(web.data() or "{}")
+        except (json.JSONDecodeError, ValueError):
+            body = {}
         result = {"error": "incorrect option specified"}
         if i.op == "authenticate":
             result = {
@@ -138,7 +143,53 @@ class xauth(delegate.page):
                 },
                 "version": 1,
             }
+        elif i.op == "issue_otp":
+            # Pretend to send an OTP email; accept any email in dev
+            result = {"success": True, "version": 1}
+        elif i.op == "redeem_otp":
+            # Accept "123456" as the dev OTP code
+            if body.get("password") == "123456":
+                result = {
+                    "success": True,
+                    "version": 1,
+                    "values": {
+                        "email": "openlibrary@example.org",
+                        "itemname": "@openlibrary",
+                        "screenname": "openlibrary",
+                        "s3": {"access": "foo", "secret": "foo"},
+                    },
+                }
+            else:
+                result = {
+                    "success": False,
+                    "version": 1,
+                    "error": "invalid_otp",
+                }
         return delegate.RawText(json.dumps(result), content_type="application/json")
+
+
+class s3auth(delegate.page):
+    path = "/internal/fake/s3auth"
+
+    def GET(self):
+        """Fake S3 auth endpoint for local dev. Accepts the dummy keys
+        issued by the fake xauth so the OTP redeem flow can complete."""
+        auth = web.ctx.env.get("HTTP_AUTHORIZATION", "")
+        # Fake keys are "foo:foo" — accept them
+        if "LOW foo:foo" in auth:
+            return delegate.RawText(
+                json.dumps(
+                    {
+                        "authorized": True,
+                        "username": "openlibrary@example.org",
+                        "itemname": "@openlibrary",
+                        "screenname": "openlibrary",
+                        "s3": {"access": "foo", "secret": "foo"},
+                    }
+                ),
+                content_type="application/json",
+            )
+        return delegate.RawText(json.dumps({"authorized": False}), content_type="application/json")
 
 
 class internal_audit(delegate.page):

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -8,10 +8,9 @@ from math import ceil
 from typing import TYPE_CHECKING, Any, Final
 from urllib.parse import urlparse
 
+import infogami.core.code as core  # noqa: F401 side effects may be needed
 import requests
 import web
-
-import infogami.core.code as core  # noqa: F401 side effects may be needed
 from infogami import config
 from infogami.utils import delegate
 from infogami.utils.view import (
@@ -20,6 +19,7 @@ from infogami.utils.view import (
     render_template,
     require_login,
 )
+
 from openlibrary import accounts
 from openlibrary.accounts import (
     InternetArchiveAccount,
@@ -406,6 +406,55 @@ class otp_service_redeem(delegate.page):
         if OTP.is_valid(i.email, i.ip, i.service_ip, i.otp):
             return delegate.RawText(json.dumps({"success": "redeemed"}))
         return delegate.RawText(json.dumps({"error": "otp_mismatch"}))
+
+
+class account_login_otp_issue(delegate.page):
+    path = "/account/login/otp/issue"
+
+    def POST(self):
+        web.header("Content-Type", "application/json")
+        i = web.input(email="")
+        if not i.email:
+            return delegate.RawText(json.dumps({"error": "missing_email"}))
+        originating_ip = web.ctx.env.get("HTTP_X_FORWARDED_FOR") or web.ctx.ip
+        result = InternetArchiveAccount.issue_otp(i.email, originating_ip=originating_ip)
+        if result.get("success"):
+            return delegate.RawText(json.dumps({"success": True}))
+        code = result.get("code", 200)
+        if code == 429:
+            web.ctx.status = "429 Too Many Requests"
+            return delegate.RawText(json.dumps({"error": "rate_limited"}))
+        return delegate.RawText(json.dumps({"error": result.get("error", "otp_issue_failed")}))
+
+
+class account_login_otp_redeem(delegate.page):
+    path = "/account/login/otp/redeem"
+
+    def POST(self):
+        web.header("Content-Type", "application/json")
+        i = web.input(email="", otp="")
+        if not i.email or not i.otp:
+            return delegate.RawText(json.dumps({"error": "missing_fields"}))
+        originating_ip = web.ctx.env.get("HTTP_X_FORWARDED_FOR") or web.ctx.ip
+        result = InternetArchiveAccount.redeem_otp(i.email, i.otp, originating_ip=originating_ip)
+        if not result.get("success"):
+            return delegate.RawText(json.dumps({"error": result.get("error", "invalid_otp")}))
+        s3 = result.get("values", {}).get("s3", {})
+        audit = audit_accounts(
+            None,
+            None,
+            require_link=True,
+            s3_access_key=s3.get("access"),
+            s3_secret_key=s3.get("secret"),
+        )
+        if error := audit.get("error"):
+            return delegate.RawText(json.dumps({"error": error}))
+        web.setcookie("pd", int(audit.get("special_access") or 0) or "")
+        web.setcookie(config.login_cookie_name, web.ctx.conn.get_auth_token())
+        email = audit.get("ia_email") or audit.get("ol_email")
+        if ol_account := OpenLibraryAccount.get_by_email(email):
+            _set_account_cookies(ol_account, expires="")
+        return delegate.RawText(json.dumps({"success": True}))
 
 
 class account_login(delegate.page):

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -459,6 +459,25 @@ class otp_service_redeem(delegate.page):
         return delegate.RawText(json.dumps({"error": "otp_mismatch"}))
 
 
+def _set_login_cookies(
+    audit: dict,
+    ol_account: OpenLibraryAccount | None,
+    remember: bool = False,
+) -> None:
+    """Set all session cookies after a successful login (password or OTP)."""
+    expires = 3600 * 24 * 365 if remember else ""
+
+    def _setcookie(name, value):
+        web.setcookie(name, value, expires=expires if value else 1)
+
+    _setcookie(config.login_cookie_name, web.ctx.conn.get_auth_token())
+    _setcookie("pd", "1" if audit.get("special_access") else "")
+    if ol_account and (ol_user := ol_account.get_user()):
+        _setcookie("sfw", "yes" if ol_user.get_safe_mode() == "yes" else "")
+        if pref_key := ol_user.preferences().get("yrg_banner_pref"):
+            web.setcookie(pref_key, "1", expires=3600 * 24 * 365)
+
+
 class account_login_otp_issue(delegate.page):
     path = "/account/login/otp/issue"
 
@@ -504,11 +523,8 @@ class account_login_otp_redeem(delegate.page):
         )
         if error := audit.get("error"):
             return delegate.RawText(json.dumps({"error": error}))
-        web.setcookie("pd", int(audit.get("special_access") or 0) or "")
-        web.setcookie(config.login_cookie_name, web.ctx.conn.get_auth_token())
         email = audit.get("ia_email") or audit.get("ol_email")
-        if ol_account := OpenLibraryAccount.get_by_email(email):
-            _set_account_cookies(ol_account, expires="")
+        _set_login_cookies(audit, OpenLibraryAccount.get_by_email(email))
         redirect = i.redirect
         # Reject non-path redirects (open redirect prevention) and login loops
         _blacklist = ["/account/login", "/account/create"]
@@ -629,17 +645,7 @@ class account_login(delegate.page):
         email = email or audit.get("ia_email") or audit.get("ol_email")
 
         if ol_account := OpenLibraryAccount.get_by_email(email):
-            ol_user = ol_account.get_user()
-            self.set_cookies(
-                remember=remember,
-                **{
-                    config.login_cookie_name: web.ctx.conn.get_auth_token(),
-                    "pd": "1" if audit.get("special_access") else "",
-                    "sfw": "yes" if ol_user.get_safe_mode() == "yes" else "",
-                },
-            )
-            if pref_key := ol_user.preferences().get("yrg_banner_pref"):
-                web.setcookie(pref_key, "1", expires=3600 * 24 * 365)
+            _set_login_cookies(audit, ol_account, remember=remember)
 
             if web.cookies().get("pda"):
                 add_flash_message(

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -8,10 +8,9 @@ from math import ceil
 from typing import TYPE_CHECKING, Any, Final
 from urllib.parse import urlparse
 
+import infogami.core.code as core  # noqa: F401 side effects may be needed
 import requests
 import web
-
-import infogami.core.code as core  # noqa: F401 side effects may be needed
 from infogami import config
 from infogami.utils import delegate
 from infogami.utils.view import (
@@ -20,6 +19,7 @@ from infogami.utils.view import (
     render_template,
     require_login,
 )
+
 from openlibrary import accounts
 from openlibrary.accounts import (
     InternetArchiveAccount,
@@ -478,12 +478,15 @@ class account_login_otp_issue(delegate.page):
         return delegate.RawText(json.dumps({"error": result.get("error", "otp_issue_failed")}))
 
 
+_OTP_REDIRECT_BLACKLIST = ["/account/login", "/account/create"]
+
+
 class account_login_otp_redeem(delegate.page):
     path = "/account/login/otp/redeem"
 
     def POST(self):
         web.header("Content-Type", "application/json")
-        i = web.input(email="", otp="")
+        i = web.input(email="", otp="", redirect="")
         if not i.email or not i.otp:
             return delegate.RawText(json.dumps({"error": "missing_fields"}))
         originating_ip = web.ctx.env.get("HTTP_X_FORWARDED_FOR") or web.ctx.ip
@@ -491,12 +494,16 @@ class account_login_otp_redeem(delegate.page):
         if not result.get("success"):
             return delegate.RawText(json.dumps({"error": result.get("error", "invalid_otp")}))
         s3 = result.get("values", {}).get("s3", {})
+        access = s3.get("access")
+        secret = s3.get("secret")
+        if not access or not secret:
+            return delegate.RawText(json.dumps({"error": "otp_redeem_incomplete"}))
         audit = audit_accounts(
             None,
             None,
             require_link=True,
-            s3_access_key=s3.get("access"),
-            s3_secret_key=s3.get("secret"),
+            s3_access_key=access,
+            s3_secret_key=secret,
         )
         if error := audit.get("error"):
             return delegate.RawText(json.dumps({"error": error}))
@@ -505,7 +512,10 @@ class account_login_otp_redeem(delegate.page):
         email = audit.get("ia_email") or audit.get("ol_email")
         if ol_account := OpenLibraryAccount.get_by_email(email):
             _set_account_cookies(ol_account, expires="")
-        return delegate.RawText(json.dumps({"success": True}))
+        redirect = i.redirect
+        if not redirect or any(path in redirect for path in _OTP_REDIRECT_BLACKLIST):
+            redirect = "/account/books"
+        return delegate.RawText(json.dumps({"success": True, "redirect": redirect}))
 
 
 class account_login(delegate.page):

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -8,9 +8,10 @@ from math import ceil
 from typing import TYPE_CHECKING, Any, Final
 from urllib.parse import urlparse
 
-import infogami.core.code as core  # noqa: F401 side effects may be needed
 import requests
 import web
+
+import infogami.core.code as core  # noqa: F401 side effects may be needed
 from infogami import config
 from infogami.utils import delegate
 from infogami.utils.view import (
@@ -19,7 +20,6 @@ from infogami.utils.view import (
     render_template,
     require_login,
 )
-
 from openlibrary import accounts
 from openlibrary.accounts import (
     InternetArchiveAccount,
@@ -478,9 +478,6 @@ class account_login_otp_issue(delegate.page):
         return delegate.RawText(json.dumps({"error": result.get("error", "otp_issue_failed")}))
 
 
-_OTP_REDIRECT_BLACKLIST = ["/account/login", "/account/create"]
-
-
 class account_login_otp_redeem(delegate.page):
     path = "/account/login/otp/redeem"
 
@@ -513,7 +510,9 @@ class account_login_otp_redeem(delegate.page):
         if ol_account := OpenLibraryAccount.get_by_email(email):
             _set_account_cookies(ol_account, expires="")
         redirect = i.redirect
-        if not redirect or any(path in redirect for path in _OTP_REDIRECT_BLACKLIST):
+        # Reject non-path redirects (open redirect prevention) and login loops
+        _blacklist = ["/account/login", "/account/create"]
+        if not redirect or not redirect.startswith("/") or redirect.startswith("//") or any(path in redirect for path in _blacklist):
             redirect = "/account/books"
         return delegate.RawText(json.dumps({"success": True, "redirect": redirect}))
 

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -148,7 +148,7 @@ class xauth(delegate.page):
             result = {"success": True, "version": 1}
         elif i.op == "redeem_otp":
             # Accept "123456" as the dev OTP code
-            if body.get("password") == "123456":
+            if body.get("otp") == "123456":
                 result = {
                     "success": True,
                     "version": 1,

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -148,7 +148,7 @@ class xauth(delegate.page):
             result = {"success": True, "version": 1}
         elif i.op == "redeem_otp":
             # Accept "123456" as the dev OTP code
-            if body.get("otp") == "123456":
+            if body.get("password") == "123456":
                 result = {
                     "success": True,
                     "version": 1,

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -119,7 +119,7 @@ class xauth(delegate.page):
         # xauth() sends JSON body; web.input() only reads query params + form bodies
         try:
             body = json.loads(web.data() or "{}")
-        except (json.JSONDecodeError, ValueError):
+        except json.JSONDecodeError, ValueError:
             body = {}
         result = {"error": "incorrect option specified"}
         if i.op == "authenticate":

--- a/openlibrary/templates/login.html
+++ b/openlibrary/templates/login.html
@@ -95,6 +95,6 @@ $if "dev" in ctx.features:
         </form>
 
         <div class="ol-signup-form__big-or">$_('OR')</div>
-        <ol-otp-login redirect="$form.redirect.value or '/account/books'"></ol-otp-login>
+        <ol-otp-login redirect="$(form.redirect.value or '/account/books')"></ol-otp-login>
     </div>
 </div>

--- a/openlibrary/templates/login.html
+++ b/openlibrary/templates/login.html
@@ -42,6 +42,8 @@ $if "dev" in ctx.features:
         <p>$:_('If you\'d like to create a new, different Open Library account, you\'ll need to <a href="javascript:;" onclick="document.forms[\'hamburger-logout\'].submit()">log out</a> and start the signup process afresh.')</p>
 
     $else:
+        <ol-otp-login redirect="$(form.redirect.value or '/account/books')"></ol-otp-login>
+        <div class="ol-signup-form__big-or">$_('OR')</div>
         <form id="register" class="login olform" name="login" method="post" data-i18n="$json_encode(i18n_strings)">
             $if form.note:
                 <div class="flash-messages">
@@ -94,7 +96,5 @@ $if "dev" in ctx.features:
             <p class="ol-signup-form__login-hint">$:_('Don\'t have an account? <a href="/account/create">Sign up now</a>.')</p>
         </form>
 
-        <div class="ol-signup-form__big-or">$_('OR')</div>
-        <ol-otp-login redirect="$(form.redirect.value or '/account/books')"></ol-otp-login>
     </div>
 </div>

--- a/openlibrary/templates/login.html
+++ b/openlibrary/templates/login.html
@@ -93,5 +93,8 @@ $if "dev" in ctx.features:
             </div>
             <p class="ol-signup-form__login-hint">$:_('Don\'t have an account? <a href="/account/create">Sign up now</a>.')</p>
         </form>
+
+        <div class="ol-signup-form__big-or">$_('OR')</div>
+        <ol-otp-login redirect="$form.redirect.value or '/account/books'"></ol-otp-login>
     </div>
 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,13 @@
       "name": "openlibrary",
       "version": "1.0.0",
       "license": "AGPL-3.0",
-      "dependencies": {
-        "@internetarchive/elements": "^0.2.5"
-      },
       "devDependencies": {
         "@babel/core": "^7.24.7",
         "@babel/eslint-parser": "^7.28.6",
         "@babel/preset-env": "^7.29.3",
         "@ericblade/quagga2": "^1.7.4",
         "@eslint/js": "^9.39.4",
+        "@internetarchive/elements": "^0.2.5",
         "@tiptap/core": "^3.20.4",
         "@tiptap/extension-image": "^3.22.1",
         "@tiptap/extension-placeholder": "^3.20.4",
@@ -3006,6 +3004,7 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/@internetarchive/elements/-/elements-0.2.5.tgz",
       "integrity": "sha512-wc6QBtUkxVQNIxbVLA53qppIn88/ZY/OwT+EU1ytNQwm6xcrCYywgA10g14bdi504IDNyB4knXqDTgVUxmu5Mg==",
+      "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/ia-clearable-text-input": "^1.1.1",
@@ -3020,12 +3019,14 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/@internetarchive/ia-clearable-text-input": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@internetarchive/ia-clearable-text-input/-/ia-clearable-text-input-1.1.1.tgz",
       "integrity": "sha512-l3Z6gKfSRURvicHlAjL3V+q/yESYSev34fswfG7ESIiWuF7UuWDKjlLOyY3gFch8eAfqS5AQ6KurRw5JWGD4RA==",
+      "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/icon-close": "^1.3.4",
@@ -3036,6 +3037,7 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
       "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.0.0"
@@ -3045,6 +3047,7 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
       "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^1.6.0",
@@ -3056,6 +3059,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
       "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.1.0",
@@ -3067,6 +3071,7 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
       "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
@@ -3076,6 +3081,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@internetarchive/ia-dropdown/-/ia-dropdown-2.1.0.tgz",
       "integrity": "sha512-FL8g78+42SiXEP21z6TjFHYGNtnG/sI6NUlPfft9GTlzOhz4QA9THRooSqa6fXeuatMPwqH4fTGhz6inwvKQ6Q==",
+      "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "lit": "^2.8.0"
@@ -3085,6 +3091,7 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
       "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.0.0"
@@ -3094,6 +3101,7 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
       "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^1.6.0",
@@ -3105,6 +3113,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
       "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.1.0",
@@ -3116,6 +3125,7 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
       "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
@@ -3125,6 +3135,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@internetarchive/icon-close/-/icon-close-1.4.1.tgz",
       "integrity": "sha512-nN1rGfScGssGFpfEew4azsrsMyUJtkDWqUDlckJi31PtyQnbZqUmZ07UO3Aw+wZIo3cU1MHxb5VxDy3Rmr8QGA==",
+      "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "lit": "^2.0.2 || ^3.0.0"
@@ -3782,12 +3793,14 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.0.tgz",
       "integrity": "sha512-HLomZXMmrCFHSRKESF5vklAKsDY7/fsT/ZhqCu3V0UoW/Qbv8wxmO4W9bx4KnCCF2Zak4yuk+AGraK/bPmI4kA==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@lit/localize": {
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/@lit/localize/-/localize-0.12.2.tgz",
       "integrity": "sha512-Qv9kvgJKDq/JVSwXOxuWvQnnOBysHA99ti9im9a4fImCmx+fto+XXcUYQbjZHqiueEEc4V20PcRDPO+1g/6seQ==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "lit": "^3.2.0"
@@ -3797,6 +3810,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
       "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.5.0"
@@ -5327,6 +5341,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -11510,6 +11525,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
       "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
@@ -11521,6 +11537,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
       "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.5.0",
@@ -11532,6 +11549,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
       "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
@@ -11624,6 +11642,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/magic-snowflakes/-/magic-snowflakes-7.0.2.tgz",
       "integrity": "sha512-hpoaXHPu2YYQT7tZK3/x4BgHmfYBoCN8+E9BbJKiDKe78nGEqYA3Sk5T2fK1SGcavKHPeBxXJgE8oaEExxeqrg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "openlibrary",
       "version": "1.0.0",
       "license": "AGPL-3.0",
+      "dependencies": {
+        "@internetarchive/elements": "^0.2.5"
+      },
       "devDependencies": {
         "@babel/core": "^7.24.7",
         "@babel/eslint-parser": "^7.28.6",
@@ -2999,6 +3002,134 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@internetarchive/elements": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@internetarchive/elements/-/elements-0.2.5.tgz",
+      "integrity": "sha512-wc6QBtUkxVQNIxbVLA53qppIn88/ZY/OwT+EU1ytNQwm6xcrCYywgA10g14bdi504IDNyB4knXqDTgVUxmu5Mg==",
+      "license": "AGPL-3.0-only",
+      "dependencies": {
+        "@internetarchive/ia-clearable-text-input": "^1.1.1",
+        "@internetarchive/ia-dropdown": "^2.1.0",
+        "@lit/localize": "^0.12.2",
+        "lit": "^2.8.0 || ^3.3.2",
+        "magic-snowflakes": "^7.0.2",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@internetarchive/elements/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@internetarchive/ia-clearable-text-input": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@internetarchive/ia-clearable-text-input/-/ia-clearable-text-input-1.1.1.tgz",
+      "integrity": "sha512-l3Z6gKfSRURvicHlAjL3V+q/yESYSev34fswfG7ESIiWuF7UuWDKjlLOyY3gFch8eAfqS5AQ6KurRw5JWGD4RA==",
+      "license": "AGPL-3.0-only",
+      "dependencies": {
+        "@internetarchive/icon-close": "^1.3.4",
+        "lit": "^2.2.7"
+      }
+    },
+    "node_modules/@internetarchive/ia-clearable-text-input/node_modules/@lit/reactive-element": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
+    },
+    "node_modules/@internetarchive/ia-clearable-text-input/node_modules/lit": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^1.6.0",
+        "lit-element": "^3.3.0",
+        "lit-html": "^2.8.0"
+      }
+    },
+    "node_modules/@internetarchive/ia-clearable-text-input/node_modules/lit-element": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.1.0",
+        "@lit/reactive-element": "^1.3.0",
+        "lit-html": "^2.8.0"
+      }
+    },
+    "node_modules/@internetarchive/ia-clearable-text-input/node_modules/lit-html": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/ia-dropdown": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@internetarchive/ia-dropdown/-/ia-dropdown-2.1.0.tgz",
+      "integrity": "sha512-FL8g78+42SiXEP21z6TjFHYGNtnG/sI6NUlPfft9GTlzOhz4QA9THRooSqa6fXeuatMPwqH4fTGhz6inwvKQ6Q==",
+      "license": "AGPL-3.0-only",
+      "dependencies": {
+        "lit": "^2.8.0"
+      }
+    },
+    "node_modules/@internetarchive/ia-dropdown/node_modules/@lit/reactive-element": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
+    },
+    "node_modules/@internetarchive/ia-dropdown/node_modules/lit": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^1.6.0",
+        "lit-element": "^3.3.0",
+        "lit-html": "^2.8.0"
+      }
+    },
+    "node_modules/@internetarchive/ia-dropdown/node_modules/lit-element": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.1.0",
+        "@lit/reactive-element": "^1.3.0",
+        "lit-html": "^2.8.0"
+      }
+    },
+    "node_modules/@internetarchive/ia-dropdown/node_modules/lit-html": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "node_modules/@internetarchive/icon-close": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@internetarchive/icon-close/-/icon-close-1.4.1.tgz",
+      "integrity": "sha512-nN1rGfScGssGFpfEew4azsrsMyUJtkDWqUDlckJi31PtyQnbZqUmZ07UO3Aw+wZIo3cU1MHxb5VxDy3Rmr8QGA==",
+      "license": "AGPL-3.0-only",
+      "dependencies": {
+        "lit": "^2.0.2 || ^3.0.0"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -3651,14 +3782,21 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.0.tgz",
       "integrity": "sha512-HLomZXMmrCFHSRKESF5vklAKsDY7/fsT/ZhqCu3V0UoW/Qbv8wxmO4W9bx4KnCCF2Zak4yuk+AGraK/bPmI4kA==",
-      "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/localize": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@lit/localize/-/localize-0.12.2.tgz",
+      "integrity": "sha512-Qv9kvgJKDq/JVSwXOxuWvQnnOBysHA99ti9im9a4fImCmx+fto+XXcUYQbjZHqiueEEc4V20PcRDPO+1g/6seQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "lit": "^3.2.0"
+      }
     },
     "node_modules/@lit/reactive-element": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
       "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.5.0"
@@ -5189,7 +5327,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -11373,7 +11510,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
       "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
@@ -11385,7 +11521,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
       "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.5.0",
@@ -11397,7 +11532,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
       "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
@@ -11485,6 +11619,15 @@
       "version": "1.2.0",
       "dev": true,
       "license": "Apache 2.0"
+    },
+    "node_modules/magic-snowflakes": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/magic-snowflakes/-/magic-snowflakes-7.0.2.tgz",
+      "integrity": "sha512-hpoaXHPu2YYQT7tZK3/x4BgHmfYBoCN8+E9BbJKiDKe78nGEqYA3Sk5T2fK1SGcavKHPeBxXJgE8oaEExxeqrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",

--- a/package.json
+++ b/package.json
@@ -130,5 +130,8 @@
     "Safari >= 11.1",
     "iOS >= 11.3",
     "Android >= 5"
-  ]
+  ],
+  "dependencies": {
+    "@internetarchive/elements": "^0.2.5"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "build-storybook": "cd stories && npm install --no-audit && npx storybook build"
   },
   "devDependencies": {
+    "@internetarchive/elements": "^0.2.5",
     "@babel/core": "^7.24.7",
     "@babel/eslint-parser": "^7.28.6",
     "@babel/preset-env": "^7.29.3",
@@ -130,8 +131,5 @@
     "Safari >= 11.1",
     "iOS >= 11.3",
     "Android >= 5"
-  ],
-  "dependencies": {
-    "@internetarchive/elements": "^0.2.5"
-  }
+  ]
 }


### PR DESCRIPTION
## Summary

Closes #12664

Users who register on archive.org via the new passwordless (OTP) flow receive a randomly-generated password and are currently unable to log into Open Library. This PR adds OTP login support to OL's login page using [`@internetarchive/elements`](https://www.npmjs.com/package/@internetarchive/elements) and the xauthn `issue_otp` / `redeem_otp` API.

## Changes

**Backend (`openlibrary/accounts/model.py`)**
- `InternetArchiveAccount.issue_otp(email, service='ol')` — calls xauthn `issue_otp`, forwards `X-Originating-IP` for rate limiting
- `InternetArchiveAccount.redeem_otp(email, password)` — calls xauthn `redeem_otp`
- `xauth()` gains an optional `headers=` kwarg

**Backend (`openlibrary/plugins/upstream/account.py`)**
- `POST /account/login/otp/issue` — issues OTP via xauthn; same endpoint handles resend (xauthn self-rate-limits at HTTP 429)
- `POST /account/login/otp/redeem` — redeems OTP; on success feeds returned S3 keys into existing `audit_accounts()` to set all OL + IA session cookies

Note: existing `/account/otp/issue` and `/account/otp/redeem` (OL-internal `TimedOneTimePassword`) are unaffected.

**Frontend (`openlibrary/components/lit/OpenLibraryOTP.js`)**
- New `<ol-otp-login>` Lit component: trigger button → modal dialog → two-step flow (email input → `<ia-otp-form>` code entry)
- Handles loading / error / success states, resend, overlay click-to-close
- `ia-otp-form` from `@internetarchive/elements` (npm `^0.2.5`) — pure UI, no hardcoded endpoints

**Template (`openlibrary/templates/login.html`)**
- Adds `<ol-otp-login>` with OR divider below the existing password form

**Dev testing**
- Fake xauth extended with `issue_otp` (always succeeds) and `redeem_otp` (accepts OTP `123456`)
- New `/internal/fake/s3auth` endpoint + `ia_s3_auth_url` in `conf/openlibrary.yml` — enables full session-cookie flow locally without hitting archive.org
- To test: issue to any email, then redeem with OTP `123456`

## Dependency

PR #11052 should land first (xauthn `activate` scaffolding). The `issue_otp`/`redeem_otp` xauthn ops used here are independent, but `audit_accounts()` IA↔OL account-linking improvements from #11052 are desirable before this ships.

## Test plan

- [ ] Login page renders with "Sign in with a one-time code" button
- [ ] Button opens modal; email step submits to `/account/login/otp/issue`
- [ ] OTP step renders `ia-otp-form`; correct code → `{"success":true}` + session cookies set
- [ ] Wrong code → error state shown in `ia-otp-form`
- [ ] "Email me another code" resend works (rate-limited by xauthn in prod)
- [ ] Overlay click and × button close the modal
- [ ] Password-based login unaffected
- [ ] `make test` passes