### PR TITLE
feat: add source toggle to OLMarkdownEditor

### DIFF
--- a/openlibrary/components/lit/OLMarkdownEditor.js
+++ b/openlibrary/components/lit/OLMarkdownEditor.js
@@ -320,6 +320,10 @@ export class OLMarkdownEditor extends LitElement {
       display: contents;
     }
 
+    .toolbar-right-slot {
+      display: contents;
+    }
+
     .toolbar-formatting {
       display: contents;
     }
@@ -637,6 +641,7 @@ export class OLMarkdownEditor extends LitElement {
           ${this.enableCode ? this._renderButton({ title: 'Inline Code', icon: ICONS.codeInline, action: this.formatInlineCode.bind(this), isActive: this._isActive('code') }) : ''}
           ${this.enableCode ? this._renderButton({ title: 'Code Block', icon: ICONS.codeBlock, action: this.formatCodeBlock.bind(this), isActive: this._isActive('codeBlock') }) : ''}
           ${this.enableHtmlBlock ? this._renderButton({ title: 'HTML Block', icon: ICONS.code, action: this.insertHtmlBlock.bind(this) }) : ''}
+          ${this.enableSource && !this.showSource ? this._renderButton({ title: 'View source', icon: ICONS.source, action: () => { this.showOverflowMenu = false; this._toggleSource(); } }) : ''}
         `;
 
         return html`
@@ -695,9 +700,11 @@ export class OLMarkdownEditor extends LitElement {
             </div>
           </div>
           ${this.enableSource ? html`
-            <div class="toolbar-spacer"></div>
-            <div class="toolbar-divider"></div>
-            ${this._renderButton({ title: this.showSource ? 'View formatted' : 'View source', icon: ICONS.source, action: this._toggleSource.bind(this), isActive: this.showSource })}
+            <span class="${this.showSource ? 'toolbar-right-slot' : 'overflow-secondary'}">
+              <div class="toolbar-spacer"></div>
+              <div class="toolbar-divider"></div>
+              ${this._renderButton({ title: this.showSource ? 'View formatted' : 'View source', icon: ICONS.source, action: this._toggleSource.bind(this), isActive: this.showSource })}
+            </span>
           ` : ''}
         </div>
 

--- a/openlibrary/components/lit/OLMarkdownEditor.js
+++ b/openlibrary/components/lit/OLMarkdownEditor.js
@@ -11,7 +11,6 @@ import { LitElement, html, css } from 'lit';
  * @prop {String} targetId - The ID of the DOM element to sync the Markdown output with.
  * @prop {String} placeholder - Text to display when the editor is empty (default: 'Write something...').
  * @prop {String} height - Minimum height of the editor area, e.g. '100px' (default: '200px'). The editor grows beyond this as content is added.
- * @prop {Boolean} enableSource - When set, adds a "View source" toolbar toggle that swaps the WYSIWYG surface for a raw markdown textarea.
  *
  * @fires ol-markdown-editor-change - Dispatched whenever the editor content changes. `e.detail.value` contains the raw markdown string.
  *
@@ -64,8 +63,7 @@ export class OLMarkdownEditor extends LitElement {
         showOverflowMenu: { state: true },
         showSource: { state: true },
         enableHtmlBlock: { type: Boolean, attribute: 'enable-html-block' },
-        enableCode: { type: Boolean, attribute: 'enable-code' },
-        enableSource: { type: Boolean, attribute: 'enable-source' }
+        enableCode: { type: Boolean, attribute: 'enable-code' }
     };
 
     static styles = css`
@@ -641,7 +639,7 @@ export class OLMarkdownEditor extends LitElement {
           ${this.enableCode ? this._renderButton({ title: 'Inline Code', icon: ICONS.codeInline, action: this.formatInlineCode.bind(this), isActive: this._isActive('code') }) : ''}
           ${this.enableCode ? this._renderButton({ title: 'Code Block', icon: ICONS.codeBlock, action: this.formatCodeBlock.bind(this), isActive: this._isActive('codeBlock') }) : ''}
           ${this.enableHtmlBlock ? this._renderButton({ title: 'HTML Block', icon: ICONS.code, action: this.insertHtmlBlock.bind(this) }) : ''}
-          ${this.enableSource && !this.showSource ? this._renderButton({ title: 'View source', icon: ICONS.source, action: () => { this.showOverflowMenu = false; this._toggleSource(); } }) : ''}
+          ${!this.showSource ? this._renderButton({ title: 'View source', icon: ICONS.source, action: () => { this.showOverflowMenu = false; this._toggleSource(); } }) : ''}
         `;
 
         return html`
@@ -699,13 +697,11 @@ export class OLMarkdownEditor extends LitElement {
               ` : ''}
             </div>
           </div>
-          ${this.enableSource ? html`
-            <span class="${this.showSource ? 'toolbar-right-slot' : 'overflow-secondary'}">
-              <div class="toolbar-spacer"></div>
-              <div class="toolbar-divider"></div>
-              ${this._renderButton({ title: this.showSource ? 'View formatted' : 'View source', icon: ICONS.source, action: this._toggleSource.bind(this), isActive: this.showSource })}
-            </span>
-          ` : ''}
+          <span class="${this.showSource ? 'toolbar-right-slot' : 'overflow-secondary'}">
+            <div class="toolbar-spacer"></div>
+            <div class="toolbar-divider"></div>
+            ${this._renderButton({ title: this.showSource ? 'View formatted' : 'View source', icon: ICONS.source, action: this._toggleSource.bind(this), isActive: this.showSource })}
+          </span>
         </div>
 
         <div id="editor-root" class="editor-input ${this.showSource ? 'is-hidden' : ''}" style="${this.height ? `min-height:${this.height}` : ''}" @click="${this._focusEditor}">

--- a/openlibrary/components/lit/OLMarkdownEditor.js
+++ b/openlibrary/components/lit/OLMarkdownEditor.js
@@ -11,6 +11,7 @@ import { LitElement, html, css } from 'lit';
  * @prop {String} targetId - The ID of the DOM element to sync the Markdown output with.
  * @prop {String} placeholder - Text to display when the editor is empty (default: 'Write something...').
  * @prop {String} height - Minimum height of the editor area, e.g. '100px' (default: '200px'). The editor grows beyond this as content is added.
+ * @prop {Boolean} enableSource - When set, adds a "View source" toolbar toggle that swaps the WYSIWYG surface for a raw markdown textarea.
  *
  * @fires ol-markdown-editor-change - Dispatched whenever the editor content changes. `e.detail.value` contains the raw markdown string.
  *
@@ -63,7 +64,8 @@ export class OLMarkdownEditor extends LitElement {
         showOverflowMenu: { state: true },
         showSource: { state: true },
         enableHtmlBlock: { type: Boolean, attribute: 'enable-html-block' },
-        enableCode: { type: Boolean, attribute: 'enable-code' }
+        enableCode: { type: Boolean, attribute: 'enable-code' },
+        enableSource: { type: Boolean, attribute: 'enable-source' }
     };
 
     static styles = css`
@@ -692,9 +694,11 @@ export class OLMarkdownEditor extends LitElement {
               ` : ''}
             </div>
           </div>
-          <div class="toolbar-spacer"></div>
-          <div class="toolbar-divider"></div>
-          ${this._renderButton({ title: this.showSource ? 'View formatted' : 'View source', icon: ICONS.source, action: this._toggleSource.bind(this), isActive: this.showSource })}
+          ${this.enableSource ? html`
+            <div class="toolbar-spacer"></div>
+            <div class="toolbar-divider"></div>
+            ${this._renderButton({ title: this.showSource ? 'View formatted' : 'View source', icon: ICONS.source, action: this._toggleSource.bind(this), isActive: this.showSource })}
+          ` : ''}
         </div>
 
         <div id="editor-root" class="editor-input ${this.showSource ? 'is-hidden' : ''}" style="${this.height ? `min-height:${this.height}` : ''}" @click="${this._focusEditor}">

--- a/openlibrary/components/lit/OLMarkdownEditor.js
+++ b/openlibrary/components/lit/OLMarkdownEditor.js
@@ -45,7 +45,8 @@ const ICONS = {
     code: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>`,
     codeInline: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3H7a2 2 0 0 0-2 2v5a2 2 0 0 1-2 2 2 2 0 0 1 2 2v5a2 2 0 0 0 2 2h1"/><path d="M16 21h1a2 2 0 0 0 2-2v-5a2 2 0 0 1 2-2 2 2 0 0 1-2-2V5a2 2 0 0 0-2-2h-1"/></svg>`,
     codeBlock: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"/><polyline points="10 10 8 12 10 14"/><polyline points="14 10 16 12 14 14"/></svg>`,
-    more: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></svg>`
+    more: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></svg>`,
+    source: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><path d="m10 13-2 2 2 2"/><path d="m14 13 2 2-2 2"/></svg>`
 };
 
 export class OLMarkdownEditor extends LitElement {
@@ -60,6 +61,7 @@ export class OLMarkdownEditor extends LitElement {
         imageUrlValue: { state: true },
         _errorMsg: { state: true },
         showOverflowMenu: { state: true },
+        showSource: { state: true },
         enableHtmlBlock: { type: Boolean, attribute: 'enable-html-block' },
         enableCode: { type: Boolean, attribute: 'enable-code' }
     };
@@ -316,6 +318,39 @@ export class OLMarkdownEditor extends LitElement {
       display: contents;
     }
 
+    .toolbar-formatting {
+      display: contents;
+    }
+
+    .toolbar-formatting[inert] .toolbar-btn {
+      opacity: 0.4;
+    }
+
+    .toolbar-spacer {
+      flex: 1 1 auto;
+    }
+
+    .source-textarea {
+      display: block;
+      width: 100%;
+      box-sizing: border-box;
+      min-height: 200px;
+      padding: var(--spacing-inset-sm);
+      border: var(--border-width-none);
+      border-radius: 0 0 var(--border-radius-card) var(--border-radius-card);
+      background: var(--white);
+      color: var(--dark-grey);
+      font-family: monospace;
+      font-size: 0.85rem;
+      line-height: 1.5;
+      resize: vertical;
+      outline: none;
+    }
+
+    .editor-input.is-hidden {
+      display: none;
+    }
+
     .overflow-menu-wrapper { position: relative; display: inline-flex; }
     .overflow-menu-wrapper.overflow-toggle { display: none; }
 
@@ -349,6 +384,7 @@ export class OLMarkdownEditor extends LitElement {
         this.imageUrlValue = '';
         this._errorMsg = null;
         this.showOverflowMenu = false;
+        this.showSource = false;
         this._handleDocumentClick = this._handleDocumentClick.bind(this);
     }
 
@@ -524,6 +560,43 @@ export class OLMarkdownEditor extends LitElement {
         return this.editor ? this.editor.isActive(type, options) : false;
     }
 
+    _toggleSource() {
+        if (!this.editor) return;
+        if (this.showSource) {
+            const textarea = this.shadowRoot.querySelector('.source-textarea');
+            if (textarea) {
+                const newValue = textarea.value;
+                if (this.targetElement) this.targetElement.value = newValue;
+                this.editor.commands.setContent(newValue, false);
+            }
+            this.showSource = false;
+            this.showLinkPopover = false;
+            this.showImagePopover = false;
+            this.showOverflowMenu = false;
+            this.updateComplete.then(() => this._focusEditor());
+        } else {
+            // Capture the editor's current height so the textarea doesn't jump.
+            const editorRoot = this.shadowRoot.getElementById('editor-root');
+            this._sourceModeHeight = editorRoot ? `${editorRoot.offsetHeight}px` : null;
+            this.showSource = true;
+            this.showLinkPopover = false;
+            this.showImagePopover = false;
+            this.showOverflowMenu = false;
+            this.updateComplete.then(() => {
+                this.shadowRoot.querySelector('.source-textarea')?.focus();
+            });
+        }
+    }
+
+    _handleSourceInput(e) {
+        if (this.targetElement) this.targetElement.value = e.target.value;
+        this.dispatchEvent(new CustomEvent('ol-markdown-editor-change', {
+            detail: { value: e.target.value },
+            bubbles: true,
+            composed: true
+        }));
+    }
+
     _renderButton({ title, icon, action, isActive = false, isDisabled = false, customColor = null }) {
         const isBtnDisabled = !this.editor || isDisabled;
 
@@ -567,61 +640,75 @@ export class OLMarkdownEditor extends LitElement {
         return html`
       <div class="editor-wrapper">
         <div class="toolbar" @mousedown="${this._handleToolbarMouseDown}">
-          ${this._renderButton({ title: 'Undo', icon: ICONS.undo, action: () => this.editor.chain().focus().undo().run(), isDisabled: !this.editor || !this.editor.can().undo() })}
-          ${this._renderButton({ title: 'Redo', icon: ICONS.redo, action: () => this.editor.chain().focus().redo().run(), isDisabled: !this.editor || !this.editor.can().redo() })}
-          <div class="toolbar-divider overflow-secondary"></div>
-          <span class="overflow-secondary">
-            ${this._renderButton({ title: 'Heading 1', icon: ICONS.h1, action: () => this.formatHeading(1), isActive: this._isActive('heading', { level: 1 }) })}
-            ${this._renderButton({ title: 'Heading 2', icon: ICONS.h2, action: () => this.formatHeading(2), isActive: this._isActive('heading', { level: 2 }) })}
-          </span>
-          <div class="toolbar-divider"></div>
-          ${this._renderButton({ title: 'Bold', icon: ICONS.bold, action: () => this.formatText('bold'), isActive: this._isActive('bold') })}
-          ${this._renderButton({ title: 'Italic', icon: ICONS.italic, action: () => this.formatText('italic'), isActive: this._isActive('italic') })}
-          <div class="link-popover-wrapper">
-            ${this._renderButton({ title: 'Link', icon: ICONS.link, action: this.toggleLinkPopover.bind(this), isActive: this._isActive('link') || this.showLinkPopover })}
-            ${this.showLinkPopover ? html`
-              <div class="link-popover" @mousedown="${(e) => e.stopPropagation()}">
-                <input type="url" class="link-input" placeholder="https://..." .value="${this.linkInputValue}" @input="${this.handleLinkInput}" @keydown="${this.handleLinkKeydown}" />
-                ${this._renderButton({ title: 'Save Link', icon: ICONS.save, action: this.applyLink.bind(this) })}
-                ${this._isActive('link') ? this._renderButton({ title: 'Remove Link', icon: ICONS.remove, action: this.removeLink.bind(this), customColor: 'var(--red)' }) : ''}
-              </div>
-            ` : ''}
-          </div>
-          <div class="link-popover-wrapper">
+          <div class="toolbar-formatting" ?inert="${this.showSource}">
+            ${this._renderButton({ title: 'Undo', icon: ICONS.undo, action: () => this.editor.chain().focus().undo().run(), isDisabled: !this.editor || !this.editor.can().undo() })}
+            ${this._renderButton({ title: 'Redo', icon: ICONS.redo, action: () => this.editor.chain().focus().redo().run(), isDisabled: !this.editor || !this.editor.can().redo() })}
+            <div class="toolbar-divider overflow-secondary"></div>
             <span class="overflow-secondary">
-              ${this._renderButton({ title: 'Image', icon: ICONS.image, action: this.toggleImagePopover.bind(this), isActive: this.showImagePopover })}
+              ${this._renderButton({ title: 'Heading 1', icon: ICONS.h1, action: () => this.formatHeading(1), isActive: this._isActive('heading', { level: 1 }) })}
+              ${this._renderButton({ title: 'Heading 2', icon: ICONS.h2, action: () => this.formatHeading(2), isActive: this._isActive('heading', { level: 2 }) })}
             </span>
-            ${this.showImagePopover ? html`
-              <div class="link-popover" @mousedown="${(e) => e.stopPropagation()}">
-                <input type="url" class="link-input image-input" placeholder="https://..." .value="${this.imageUrlValue}" @input="${this.handleImageInput}" @keydown="${this.handleImageKeydown}" />
-                ${this._renderButton({ title: 'Insert Image', icon: ICONS.save, action: this.applyImage.bind(this) })}
-              </div>
-            ` : ''}
+            <div class="toolbar-divider"></div>
+            ${this._renderButton({ title: 'Bold', icon: ICONS.bold, action: () => this.formatText('bold'), isActive: this._isActive('bold') })}
+            ${this._renderButton({ title: 'Italic', icon: ICONS.italic, action: () => this.formatText('italic'), isActive: this._isActive('italic') })}
+            <div class="link-popover-wrapper">
+              ${this._renderButton({ title: 'Link', icon: ICONS.link, action: this.toggleLinkPopover.bind(this), isActive: this._isActive('link') || this.showLinkPopover })}
+              ${this.showLinkPopover ? html`
+                <div class="link-popover" @mousedown="${(e) => e.stopPropagation()}">
+                  <input type="url" class="link-input" placeholder="https://..." .value="${this.linkInputValue}" @input="${this.handleLinkInput}" @keydown="${this.handleLinkKeydown}" />
+                  ${this._renderButton({ title: 'Save Link', icon: ICONS.save, action: this.applyLink.bind(this) })}
+                  ${this._isActive('link') ? this._renderButton({ title: 'Remove Link', icon: ICONS.remove, action: this.removeLink.bind(this), customColor: 'var(--red)' }) : ''}
+                </div>
+              ` : ''}
+            </div>
+            <div class="link-popover-wrapper">
+              <span class="overflow-secondary">
+                ${this._renderButton({ title: 'Image', icon: ICONS.image, action: this.toggleImagePopover.bind(this), isActive: this.showImagePopover })}
+              </span>
+              ${this.showImagePopover ? html`
+                <div class="link-popover" @mousedown="${(e) => e.stopPropagation()}">
+                  <input type="url" class="link-input image-input" placeholder="https://..." .value="${this.imageUrlValue}" @input="${this.handleImageInput}" @keydown="${this.handleImageKeydown}" />
+                  ${this._renderButton({ title: 'Insert Image', icon: ICONS.save, action: this.applyImage.bind(this) })}
+                </div>
+              ` : ''}
+            </div>
+            <div class="toolbar-divider"></div>
+            ${this._renderButton({ title: 'Bullet List', icon: ICONS.ul, action: () => this.formatList('bullet'), isActive: this._isActive('bulletList') })}
+            ${this._renderButton({ title: 'Numbered List', icon: ICONS.ol, action: () => this.formatList('number'), isActive: this._isActive('orderedList') })}
+            <div class="toolbar-divider"></div>
+            <span class="overflow-secondary">
+              ${this._renderButton({ title: 'Blockquote', icon: ICONS.quote, action: this.formatQuote.bind(this), isActive: this._isActive('blockquote') })}
+              ${this._renderButton({ title: 'Divider', icon: ICONS.hr, action: this.insertRule.bind(this) })}
+              ${this.enableCode ? this._renderButton({ title: 'Inline Code', icon: ICONS.codeInline, action: this.formatInlineCode.bind(this), isActive: this._isActive('code') }) : ''}
+              ${this.enableCode ? this._renderButton({ title: 'Code Block', icon: ICONS.codeBlock, action: this.formatCodeBlock.bind(this), isActive: this._isActive('codeBlock') }) : ''}
+              ${this.enableHtmlBlock ? this._renderButton({ title: 'HTML Block', icon: ICONS.code, action: this.insertHtmlBlock.bind(this) }) : ''}
+            </span>
+            <div class="overflow-menu-wrapper overflow-toggle">
+              ${this._renderButton({ title: 'More', icon: ICONS.more, action: () => { this.showOverflowMenu = !this.showOverflowMenu; if (this.showOverflowMenu) this.showLinkPopover = false; }, isActive: this.showOverflowMenu })}
+              ${this.showOverflowMenu ? html`
+                <div class="overflow-menu" @mousedown="${(e) => e.stopPropagation()}">
+                  ${secondaryButtons}
+                </div>
+              ` : ''}
+            </div>
           </div>
+          <div class="toolbar-spacer"></div>
           <div class="toolbar-divider"></div>
-          ${this._renderButton({ title: 'Bullet List', icon: ICONS.ul, action: () => this.formatList('bullet'), isActive: this._isActive('bulletList') })}
-          ${this._renderButton({ title: 'Numbered List', icon: ICONS.ol, action: () => this.formatList('number'), isActive: this._isActive('orderedList') })}
-          <div class="toolbar-divider"></div>
-          <span class="overflow-secondary">
-            ${this._renderButton({ title: 'Blockquote', icon: ICONS.quote, action: this.formatQuote.bind(this), isActive: this._isActive('blockquote') })}
-            ${this._renderButton({ title: 'Divider', icon: ICONS.hr, action: this.insertRule.bind(this) })}
-            ${this.enableCode ? this._renderButton({ title: 'Inline Code', icon: ICONS.codeInline, action: this.formatInlineCode.bind(this), isActive: this._isActive('code') }) : ''}
-            ${this.enableCode ? this._renderButton({ title: 'Code Block', icon: ICONS.codeBlock, action: this.formatCodeBlock.bind(this), isActive: this._isActive('codeBlock') }) : ''}
-            ${this.enableHtmlBlock ? this._renderButton({ title: 'HTML Block', icon: ICONS.code, action: this.insertHtmlBlock.bind(this) }) : ''}
-          </span>
-          <div class="overflow-menu-wrapper overflow-toggle">
-            ${this._renderButton({ title: 'More', icon: ICONS.more, action: () => { this.showOverflowMenu = !this.showOverflowMenu; if (this.showOverflowMenu) this.showLinkPopover = false; }, isActive: this.showOverflowMenu })}
-            ${this.showOverflowMenu ? html`
-              <div class="overflow-menu" @mousedown="${(e) => e.stopPropagation()}">
-                ${secondaryButtons}
-              </div>
-            ` : ''}
-          </div>
+          ${this._renderButton({ title: this.showSource ? 'View formatted' : 'View source', icon: ICONS.source, action: this._toggleSource.bind(this), isActive: this.showSource })}
         </div>
 
-        <div id="editor-root" class="editor-input" style="${this.height ? `min-height:${this.height}` : ''}" @click="${this._focusEditor}">
+        <div id="editor-root" class="editor-input ${this.showSource ? 'is-hidden' : ''}" style="${this.height ? `min-height:${this.height}` : ''}" @click="${this._focusEditor}">
             ${!this.editor ? html`<span class="loading-placeholder">${this.placeholder || 'Write something...'}</span>` : ''}
         </div>
+        ${this.showSource ? html`
+          <textarea
+            class="source-textarea"
+            spellcheck="false"
+            style="min-height:${this._sourceModeHeight || this.height || '200px'}"
+            .value="${this.targetElement?.value || ''}"
+            @input="${this._handleSourceInput}"
+          ></textarea>
+        ` : ''}
       </div>
     `;
     }

--- a/openlibrary/components/lit/OLMarkdownEditor.js
+++ b/openlibrary/components/lit/OLMarkdownEditor.js
@@ -345,7 +345,7 @@ export class OLMarkdownEditor extends LitElement {
       background: var(--white);
       color: var(--dark-grey);
       font-family: monospace;
-      font-size: 0.85rem;
+      font-size: 0.75rem;
       line-height: 1.5;
       resize: vertical;
       outline: none;

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -632,6 +632,18 @@ msgid ""
 msgstr ""
 
 #: design.html
+msgid "Source toggle"
+msgstr ""
+
+#: design.html
+#, python-format
+msgid ""
+"Add the %(attr)s attribute to expose a toolbar toggle that swaps the "
+"WYSIWYG surface for a raw markdown textarea. Useful for editors of pages "
+"with heavy inline HTML where WYSIWYG round-trips are awkward."
+msgstr ""
+
+#: design.html
 msgid "Change event"
 msgstr ""
 

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -593,7 +593,9 @@ msgstr ""
 #: design.html
 msgid ""
 "The ol-markdown-editor component is a WYSIWYG editor built on Tiptap that"
-" outputs Markdown. It syncs its content to a hidden target textarea."
+" outputs Markdown. It syncs its content to a hidden target textarea. A "
+"'View source' toolbar toggle is always available so editors can drop into"
+" a raw markdown textarea when WYSIWYG round-trips are awkward."
 msgstr ""
 
 #: design.html
@@ -629,18 +631,6 @@ msgid ""
 "Add the %(attr)s attribute to expose the inline code and code block "
 "buttons in the toolbar. Code support is off by default because only the "
 "wiki page renderer is guaranteed to render fenced code blocks."
-msgstr ""
-
-#: design.html
-msgid "Source toggle"
-msgstr ""
-
-#: design.html
-#, python-format
-msgid ""
-"Add the %(attr)s attribute to expose a toolbar toggle that swaps the "
-"WYSIWYG surface for a raw markdown textarea. Useful for editors of pages "
-"with heavy inline HTML where WYSIWYG round-trips are awkward."
 msgstr ""
 
 #: design.html

--- a/openlibrary/templates/design.html
+++ b/openlibrary/templates/design.html
@@ -379,7 +379,7 @@ $ _x = ctx.setdefault('cssfile', 'design')
 
       <article class="design-pattern" id="markdown-editor">
         <h2 class="design-pattern__title">$_("Markdown Editor")</h2>
-        <p class="design-pattern__description">$_("The ol-markdown-editor component is a WYSIWYG editor built on Tiptap that outputs Markdown. It syncs its content to a hidden target textarea.")</p>
+        <p class="design-pattern__description">$_("The ol-markdown-editor component is a WYSIWYG editor built on Tiptap that outputs Markdown. It syncs its content to a hidden target textarea. A 'View source' toolbar toggle is always available so editors can drop into a raw markdown textarea when WYSIWYG round-trips are awkward.")</p>
 
         <section class="example">
           <h3 class="example__title">$_("Basic usage")</h3>
@@ -448,27 +448,6 @@ print(work["title"])
 
 The response includes `title`, `authors`, and a `description` field formatted as Markdown.</textarea>
             <ol-markdown-editor target-id="demo-editor-code" enable-code></ol-markdown-editor>
-          </div>
-        </section>
-
-        <section class="example">
-          <h3 class="example__title">$_("Source toggle")</h3>
-          <p>$:_("Add the %(attr)s attribute to expose a toolbar toggle that swaps the WYSIWYG surface for a raw markdown textarea. Useful for editors of pages with heavy inline HTML where WYSIWYG round-trips are awkward.", attr="<code>enable-source</code>")</p>
-          <pre class="example__code"><code class="language-html">&lt;ol-markdown-editor
-  target-id="my-input"
-  enable-source&gt;
-&lt;/ol-markdown-editor&gt;</code></pre>
-          <div class="example__output">
-            <textarea id="demo-editor-source" style="display:none;">## Mixed content
-
-A paragraph with **bold** and *italic*.
-
-<div class="custom-callout">
-  <strong>Note:</strong> This block is raw HTML.
-</div>
-
-Another paragraph after the HTML block.</textarea>
-            <ol-markdown-editor target-id="demo-editor-source" enable-html-block enable-source></ol-markdown-editor>
           </div>
         </section>
 

--- a/openlibrary/templates/design.html
+++ b/openlibrary/templates/design.html
@@ -452,6 +452,27 @@ The response includes `title`, `authors`, and a `description` field formatted as
         </section>
 
         <section class="example">
+          <h3 class="example__title">$_("Source toggle")</h3>
+          <p>$:_("Add the %(attr)s attribute to expose a toolbar toggle that swaps the WYSIWYG surface for a raw markdown textarea. Useful for editors of pages with heavy inline HTML where WYSIWYG round-trips are awkward.", attr="<code>enable-source</code>")</p>
+          <pre class="example__code"><code class="language-html">&lt;ol-markdown-editor
+  target-id="my-input"
+  enable-source&gt;
+&lt;/ol-markdown-editor&gt;</code></pre>
+          <div class="example__output">
+            <textarea id="demo-editor-source" style="display:none;">## Mixed content
+
+A paragraph with **bold** and *italic*.
+
+<div class="custom-callout">
+  <strong>Note:</strong> This block is raw HTML.
+</div>
+
+Another paragraph after the HTML block.</textarea>
+            <ol-markdown-editor target-id="demo-editor-source" enable-html-block enable-source></ol-markdown-editor>
+          </div>
+        </section>
+
+        <section class="example">
           <h3 class="example__title">$_("Change event")</h3>
           <p>$:_("The editor fires an %(event)s event on every change. The raw Markdown string is available in %(detail)s.", event="<code>ol-markdown-editor-change</code>", detail="<code>event.detail.value</code>")</p>
           <pre class="example__code"><code class="language-html">&lt;ol-markdown-editor

--- a/openlibrary/templates/type/page/edit.html
+++ b/openlibrary/templates/type/page/edit.html
@@ -27,7 +27,7 @@ $:render_template("lib/edit_head", page)
         <div class="label"><label for="page--body">$_('Document Body:')</label></div>
         <div class="input">
             <textarea id="page--body" name="body">$page.body</textarea>
-            <ol-markdown-editor target-id="page--body" enable-html-block enable-code></ol-markdown-editor>
+            <ol-markdown-editor target-id="page--body" enable-html-block enable-code enable-source></ol-markdown-editor>
         </div>
     </div>
 

--- a/openlibrary/templates/type/page/edit.html
+++ b/openlibrary/templates/type/page/edit.html
@@ -27,7 +27,7 @@ $:render_template("lib/edit_head", page)
         <div class="label"><label for="page--body">$_('Document Body:')</label></div>
         <div class="input">
             <textarea id="page--body" name="body">$page.body</textarea>
-            <ol-markdown-editor target-id="page--body" enable-html-block enable-code enable-source></ol-markdown-editor>
+            <ol-markdown-editor target-id="page--body" enable-html-block enable-code></ol-markdown-editor>
         </div>
     </div>
 


### PR DESCRIPTION
Closes #12478

<img width="726" height="302" alt="editor-codeview" src="https://github.com/user-attachments/assets/48137a55-1d9a-452b-8148-268809c1e740" />


<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds a "View source" toggle to the markdown editor toolbar that swaps the WYSIWYG surface for a raw markdown textarea. Useful for editing help/docs pages with heavy inline HTML, copy/pasting an entire page into external tools, or any time the WYSIWYG round-trip is awkward. The toggle is built into the component and shows up on every existing `<ol-markdown-editor>` instance — no template changes needed at the call sites.

### Technical
- New `showSource` state on `OLMarkdownEditor`. Tiptap's mount point stays in the DOM (just hidden via `is-hidden`) so the editor instance is preserved across toggles.
- Source-mode edits write directly to the synced `targetElement.value` and dispatch the same `ol-markdown-editor-change` event the WYSIWYG mode emits — form submits and any external listeners behave identically in both modes.
- Toggle-off calls `editor.commands.setContent(textarea.value, false)` to push the user's source-mode edits back into Tiptap without re-firing `onUpdate` (we already wrote to the target).
- Formatting buttons are wrapped in a `display: contents` container that becomes `inert` (and visually dimmed) in source mode — no layout change, all interaction disabled in one place.
- The textarea's `min-height` is captured from the editor's rendered height at toggle time so the visible area doesn't jump.

**Toolbar placement:**
| Viewport | Mode | Where the source button lives |
|---|---|---|
| Desktop | WYSIWYG | Right-side slot (after spacer/divider) |
| Desktop | Source | Right-side slot |
| Mobile | WYSIWYG | Inside the `…` overflow menu |
| Mobile | Source | Right-side slot (forced visible — `…` menu is `inert` in source mode) |

### Testing
1. **Page edit** (`/help/faq/editing.en?m=edit` or any wiki page edit — fullest config with `enable-html-block` + `enable-code`): toggle source mode and confirm the heavy-HTML pages cdrini called out are editable as plain markdown.
2. **Author bio edit**, **edition edit** (two editors on one page), **list/user/tag edits**: confirm the toggle works on simpler instances too.

### Stakeholders
@cdrini @RayBB