### PR TITLE
refactor: split AffiliateLinks into AffiliateLinksLoadingIndicator.html for loading indicator

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -7897,10 +7897,6 @@ msgid "Look for this edition for sale at %(store)s"
 msgstr ""
 
 #: AffiliateLinks.html
-msgid "Fetching prices"
-msgstr ""
-
-#: AffiliateLinks.html
 msgid "Better World Books"
 msgstr ""
 
@@ -7920,6 +7916,10 @@ msgstr ""
 msgid ""
 "When you buy books using these links the Internet Archive may earn a <a "
 "class=\"nostyle\" href=\"/help/faq/about#selling\">small commission</a>."
+msgstr ""
+
+#: AffiliateLinksLoadingIndicator.html
+msgid "Fetching prices"
 msgstr ""
 
 #: BatchImportNavigation.html

--- a/openlibrary/macros/AffiliateLinks.html
+++ b/openlibrary/macros/AffiliateLinks.html
@@ -1,4 +1,4 @@
-$def with (title, opts, async_load=False, bwb_metadata=None, amz_metadata=None)
+$def with (title, opts, bwb_metadata=None, amz_metadata=None)
 
 $def affiliate_link(key, analytics_key, name, link, price='', price_note=''):
   <li class="prices-$key">
@@ -13,10 +13,7 @@ $def affiliate_link(key, analytics_key, name, link, price='', price_note=''):
   </li>
 
 <span class="affiliate-links-section" data-title="$title" data-opts="$json_encode(opts)">
-  $if async_load:
-    $:macros.LoadingIndicator(_("Fetching prices"), additional_classes="affiliate-links-loading")
-  $else:
-    $code:
+  $code:
       prices = opts.get('prices')
       isbn = opts.get('isbn', '')
       asin = opts.get('asin', '')
@@ -50,19 +47,19 @@ $def affiliate_link(key, analytics_key, name, link, price='', price_note=''):
       primary_stores = [store for store in [bwb, amazon] if store]
       more_stores = [store for store in [bookshop] if store]
 
-    <ul class="buy-options-table">
-        $for store in primary_stores:
-          $:affiliate_link(store['key'], store['analytics_key'], store['name'], store['link'], store.get('price', ''), store.get('price_note', ''))
-        $if more_stores:
-          <li class="more">
-            <details>
-              <summary>$_('More')</summary>
-              <ul>
-                $for store in more_stores:
-                  $:affiliate_link(store['key'], store['analytics_key'], store['name'], store['link'], store.get('price', ''), store.get('price_note', ''))
-              </ul>
-            </details>
-          </li>
-    </ul>
-    <small>$:_('When you buy books using these links the Internet Archive may earn a <a class="nostyle" href="/help/faq/about#selling">small commission</a>.')</small>
+  <ul class="buy-options-table">
+      $for store in primary_stores:
+        $:affiliate_link(store['key'], store['analytics_key'], store['name'], store['link'], store.get('price', ''), store.get('price_note', ''))
+      $if more_stores:
+        <li class="more">
+          <details>
+            <summary>$_('More')</summary>
+            <ul>
+              $for store in more_stores:
+                $:affiliate_link(store['key'], store['analytics_key'], store['name'], store['link'], store.get('price', ''), store.get('price_note', ''))
+            </ul>
+          </details>
+        </li>
+  </ul>
+  <small>$:_('When you buy books using these links the Internet Archive may earn a <a class="nostyle" href="/help/faq/about#selling">small commission</a>.')</small>
 </span>

--- a/openlibrary/macros/AffiliateLinksLoadingIndicator.html
+++ b/openlibrary/macros/AffiliateLinksLoadingIndicator.html
@@ -1,4 +1,4 @@
-$def with(title, opts)
+$def with (title, opts)
 <span class="affiliate-links-section" data-title="$title" data-opts="$json_encode(opts)">
   $:macros.LoadingIndicator(_("Fetching prices"), additional_classes="affiliate-links-loading")
 </span>

--- a/openlibrary/macros/AffiliateLinksLoadingIndicator.html
+++ b/openlibrary/macros/AffiliateLinksLoadingIndicator.html
@@ -1,0 +1,4 @@
+$def with(title, opts)
+<span class="affiliate-links-section" data-title="$title" data-opts="$json_encode(opts)">
+  $:macros.LoadingIndicator(_("Fetching prices"), additional_classes="affiliate-links-loading")
+</span>

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -240,7 +240,6 @@ class AffiliateLinksPartial:
         macro = web.template.Template.globals["macros"].AffiliateLinks(
             title,
             opts,
-            async_load=False,
             bwb_metadata=bwb_metadata,
             amz_metadata=amz_metadata,
         )

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -191,7 +191,7 @@ $if edition.get('identifiers'):
 $if isbn_10 and not asin:
     $ asin = isbn_10
 
-$ affiliate_links = macros.AffiliateLinks(edition.title, {'isbn': isbn_13, 'asin': asin, 'prices': prices}, async_load=True)
+$ affiliate_links = macros.AffiliateLinksLoadingIndicator(edition.title, {'isbn': isbn_13, 'asin': asin, 'prices': prices})
 $ component_times['affiliate_links component'] = time() - component_times['affiliate_links component']
 
 $ oclc_number = (edition.oclc_numbers and edition.oclc_numbers[0]) or ""


### PR DESCRIPTION


<!-- What issue does this PR close? -->
Part of #12678 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR is the first phase of #12678 and splits and simplifies `AffiliateLinks.html` template by moving the loading spineer to `AffiliateLinksLoadingIndicator.html `

### Technical
<!-- What should be noted about the implementation? -->

- Create AffiliateLinksLoadingIndicator.html for async spinner
- Simplify AffiliateLinks.html to render buy links only (remove async_load)
- Update view.html to use new loading indicator macro
- Remove async_load=False from partials.py call

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

- Go to any book edition page e.g. `http://localhost:8080/works/OL45310W/Robinson_Crusoe?edition=key:/books/OL24152177M`
- In the "Buy this book" section verify the "Fetching prices" loading spinner appears on page load.


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
