### PR TITLE
Fix missing f-string in facet_wrapper assert message (#12649)

### DIFF
--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -334,7 +334,7 @@ class SubjectEngine:
             return web.storage(name=label, key=f"/authors/{value}", count=count)
         elif facet in ["subject_facet", "person_facet", "place_facet", "time_facet"]:
             engine = next((d for d in SUBJECTS if d.facet == facet), None)
-            assert engine is not None, "Invalid subject facet: {facet}"
+            assert engine is not None, f"Invalid subject facet: {facet}"
             return web.storage(
                 key=engine.prefix + Tag.normalize(value),
                 name=value,

--- a/openlibrary/plugins/worksearch/tests/test_subjects.py
+++ b/openlibrary/plugins/worksearch/tests/test_subjects.py
@@ -1,5 +1,6 @@
-import pytest
 from unittest.mock import patch
+
+import pytest
 
 from openlibrary.plugins.worksearch.subjects import SubjectEngine
 
@@ -13,6 +14,5 @@ class TestFacetWrapper:
             facet="subject_facet",
             facet_key="subject_key",
         )
-        with patch("openlibrary.plugins.worksearch.subjects.SUBJECTS", []):
-            with pytest.raises(AssertionError, match="subject_facet"):
-                engine.facet_wrapper("subject_facet", "some_value", "Some Label", 5)
+        with patch("openlibrary.plugins.worksearch.subjects.SUBJECTS", []), pytest.raises(AssertionError, match="subject_facet"):
+            engine.facet_wrapper("subject_facet", "some_value", "Some Label", 5)

--- a/openlibrary/plugins/worksearch/tests/test_subjects.py
+++ b/openlibrary/plugins/worksearch/tests/test_subjects.py
@@ -1,0 +1,18 @@
+import pytest
+from unittest.mock import patch
+
+from openlibrary.plugins.worksearch.subjects import SubjectEngine
+
+
+class TestFacetWrapper:
+    def test_invalid_subject_facet_includes_value_in_error(self):
+        engine = SubjectEngine(
+            name="subject",
+            key="subjects",
+            prefix="/subjects/",
+            facet="subject_facet",
+            facet_key="subject_key",
+        )
+        with patch("openlibrary.plugins.worksearch.subjects.SUBJECTS", []):
+            with pytest.raises(AssertionError, match="subject_facet"):
+                engine.facet_wrapper("subject_facet", "some_value", "Some Label", 5)


### PR DESCRIPTION
Closes #12649

[fix]
### Technical
Adds the missing `f` prefix to the assert message string in `facet_wrapper` in `openlibrary/plugins/worksearch/subjects.py` line 337. Without the fix, the error message always printed the literal string `{facet}` instead of the actual facet value, making the assertion unhelpful for debugging.

This is my first open source contribution, working on it as part of a university course at UW Bothell. Open to any feedback or change!

### Testing
Added `openlibrary/plugins/worksearch/tests/test_subjects.py` with a test that patches `SUBJECTS` to an empty list to trigger the assert, then verifies the error message contains the actual facet value rather than the literal string `{facet}`.

To run:
`sudo docker compose run --rm home pytest openlibrary/plugins/worksearch/tests/test_subjects.py -v`

Ran `make test` locally — 3780 tests passed, 1 failed. New test file: 1 passed, 0 failed.

- `OLMarkdownEditor.test.js` fails due to a missing `@tiptap/core` dependency, pre-existing and unrelated to this change.




@mekarpeles


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
