### PR TITLE
fix(security): open redirect in BarcodeScanner + overly-broad regex in models.py

### DIFF
--- a/openlibrary/components/BarcodeScanner.vue
+++ b/openlibrary/components/BarcodeScanner.vue
@@ -51,13 +51,15 @@ export default {
     data() {
         let returnTo = new URLSearchParams(location.search).get('returnTo');
         // Only allow same-origin redirects to prevent open redirect attacks.
-        // Resolving against window.location.origin rejects javascript: URIs and
-        // off-origin https:// URLs that the old regex-only check allowed through.
-        try {
-            const url = new URL(returnTo, window.location.origin);
-            returnTo = url.origin === window.location.origin ? url.href : null;
-        } catch (_) {
-            returnTo = null;
+        // Guard for null first: new URL(null, base) coerces to the string "null"
+        // and would create a same-origin URL https://<origin>/null.
+        if (returnTo) {
+            try {
+                const url = new URL(returnTo, window.location.origin);
+                returnTo = url.origin === window.location.origin ? url.href : null;
+            } catch (_) {
+                returnTo = null;
+            }
         }
         return {
             disableISBNTextButton: false,

--- a/openlibrary/components/BarcodeScanner.vue
+++ b/openlibrary/components/BarcodeScanner.vue
@@ -50,8 +50,13 @@ export default {
     components: { LazyBookCard, SettingsIcon },
     data() {
         let returnTo = new URLSearchParams(location.search).get('returnTo');
-        // Only allow absolute URLs or root-relative URLs to prevent XSS
-        if (!/^(https?:\/\/|\/)/.test(returnTo)) {
+        // Only allow same-origin redirects to prevent open redirect attacks.
+        // Resolving against window.location.origin rejects javascript: URIs and
+        // off-origin https:// URLs that the old regex-only check allowed through.
+        try {
+            const url = new URL(returnTo, window.location.origin);
+            returnTo = url.origin === window.location.origin ? url.href : null;
+        } catch (_) {
             returnTo = null;
         }
         return {
@@ -217,12 +222,7 @@ export default {
             if (this.seenISBN.has(isbn)) return;
 
             if (this.returnTo) {
-                // Check if domain is the same as the current domain to prevent
-                // open redirects.
-                if (!this.returnTo.startsWith('/')) {
-                    window.alert(`Redirecting to ${this.returnTo.replace('$$$', isbn)}`);
-                }
-                location = this.returnTo.replace('$$$', isbn);
+                location.href = this.returnTo.replace('$$$', isbn);
             }
             this.isbnList.unshift({isbn: isbn, cover: tentativeCoverUrl});
             this.seenISBN.add(isbn);

--- a/openlibrary/fastapi/models.py
+++ b/openlibrary/fastapi/models.py
@@ -166,7 +166,7 @@ class SolrInternalsParams(BaseModel):
                 continue
 
             if value and value.startswith("$"):
-                if not re.match(r"^\$[a-zA-Z0-9.-_]+$", value):
+                if not re.match(r"^\$[a-zA-Z0-9._-]+$", value):
                     raise ValueError("Invalid solr internal variable supplied")
                 # Variables shouldn't be quoted
                 params.append(f"{solr_name}={value}")


### PR DESCRIPTION
## Summary

Fixes two medium-severity CodeQL findings.

---

### Fix 1: BarcodeScanner.vue — open redirect (CodeQL #1, `js/client-side-unvalidated-url-redirection`)

The `returnTo` query parameter was validated with a regex that allowed any `https://` URL, including off-origin domains. This made the barcode scanner an open redirect.

**Before:**
```js
if (!/^(https?:\/\/|\/)/.test(returnTo)) { returnTo = null; }
// ...then at redirect time, only warned but never blocked off-origin URLs
```

**After:**
```js
const url = new URL(returnTo, window.location.origin);
returnTo = url.origin === window.location.origin ? url.href : null;
```

The `URL` constructor rejects `javascript:` URIs, and the origin comparison rejects off-origin `https://` URLs. The now-redundant warn-but-not-block `window.alert` branch is removed.

---

### Fix 2: fastapi/models.py — overly-broad character class (CodeQL #43, `py/overly-large-range`)

`[a-zA-Z0-9.-_]` was parsed as a range from `.` (ASCII 46) to `_` (ASCII 95), matching 50+ unintended characters including `/:;<=>?@[\]^`. Intent was to allow only `.`, `-`, and `_` as punctuation.

**Before:** `r"^\$[a-zA-Z0-9.-_]+$"`
**After:** `r"^\$[a-zA-Z0-9._-]+$"` (hyphen moved to end — treated as literal)

---

### Not addressed: CDN SRI (CodeQL #51, #52)

`openlibrary/templates/swagger/swaggerui.html` loads swagger-ui-dist from `unpkg.com` without version pinning or SRI hashes. This is a genuine finding but requires either bundling swagger-ui-dist as a proper npm dep or pinning + hashing a specific CDN version. Left for a follow-up — the Swagger UI page is developer-facing only (`/swagger`).

## Testing

- [x] `pre-commit run --files` — all local hooks pass (ruff, mypy, eslint, codespell)
- [ ] Generate POT skipped — requires full Docker/infogami environment (expected)