### PR TITLE
Fix: MARC importer not updating language field

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -862,7 +862,12 @@ def update_edition_with_rec_data(rec: dict, account_key: str | None, edition: "E
             try:
                 formatted_languages = format_languages(languages=rec_values)
             except InvalidLanguage as e:
-                logger.warning("Skipping unrecognized language code during edition update: %s", e)
+                logger.warning(
+                    "Skipping unrecognized language code during edition update: %s (edition=%s, source_records=%s)",
+                    e,
+                    edition.key,
+                    rec.get("source_records"),
+                )
                 continue
             supplemented_values = existing_values + [lang for lang in formatted_languages if lang not in existing_values]
         else:

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -859,7 +859,11 @@ def update_edition_with_rec_data(rec: dict, account_key: str | None, edition: "E
 
         # Languages in `rec` are ['eng'], etc., but import requires dict-style.
         if field == "languages":
-            formatted_languages = format_languages(languages=rec_values)
+            try:
+                formatted_languages = format_languages(languages=rec_values)
+            except InvalidLanguage as e:
+                logger.warning("Skipping unrecognized language code during edition update: %s", e)
+                continue
             supplemented_values = existing_values + [lang for lang in formatted_languages if lang not in existing_values]
         else:
             case_folded_values = [v.casefold() for v in existing_values]

--- a/openlibrary/catalog/add_book/tests/test_add_book.py
+++ b/openlibrary/catalog/add_book/tests/test_add_book.py
@@ -432,6 +432,43 @@ def test_matched_edition_with_new_language_is_added_even_if_no_existing_language
     assert updated_languages == ["/languages/eng"]
 
 
+def test_marc_update_adds_language_to_edition_without_language(mock_site, add_languages, ia_writeback):
+    """
+    When a MARC record is imported (rec has language codes as strings, as
+    returned by read_edition()) and matches an existing edition that has no
+    language field, the language from the MARC 008 field should be added.
+
+    Regression test for https://github.com/internetarchive/openlibrary/issues/12698
+    """
+    # Create an existing edition without language (simulating an Amazon import)
+    existing = {
+        "title": "Test MARC Book",
+        "source_records": ["amazon:9780000000001"],
+        "isbn_13": ["9780000000001"],
+    }
+    reply = load(existing)
+    assert reply["success"] is True
+    assert reply["edition"]["status"] == "created"
+    e = mock_site.get(reply["edition"]["key"])
+    assert not e.get("languages"), "Edition should initially have no language"
+
+    # Simulate what read_edition() returns for a MARC record:
+    # languages are 3-letter MARC codes (strings), not dicts.
+    marc_rec = {
+        "title": "Test MARC Book",
+        "source_records": ["marc:marc_columbia/test.mrc:0:1000"],
+        "isbn_13": ["9780000000001"],
+        "languages": ["eng"],  # as extracted from MARC 008 by read_edition()
+    }
+    reply = load(marc_rec)
+    assert reply["success"] is True
+    assert reply["edition"]["status"] == "modified"
+
+    updated = mock_site.get(reply["edition"]["key"])
+    assert updated.languages, "Language from MARC 008 should have been added"
+    assert [lang["key"] for lang in updated.languages] == ["/languages/eng"]
+
+
 def test_matched_edition_properly_updates_non_language_fields(mock_site, add_languages, ia_writeback):
     """
     Ensure a new language is added even if the existing edition has no language

--- a/openlibrary/catalog/add_book/tests/test_add_book.py
+++ b/openlibrary/catalog/add_book/tests/test_add_book.py
@@ -432,6 +432,42 @@ def test_matched_edition_with_new_language_is_added_even_if_no_existing_language
     assert updated_languages == ["/languages/eng"]
 
 
+def test_invalid_language_in_rec_does_not_abort_other_field_updates(mock_site, add_languages, ia_writeback):
+    """
+    When rec contains an invalid language code, the InvalidLanguage exception
+    should NOT abort the rest of update_edition_with_rec_data(). Other list
+    fields (e.g. oclc_numbers) that appear in edition_list_fields after
+    'languages' must still be updated.
+
+    Regression test for https://github.com/internetarchive/openlibrary/issues/12698
+    """
+    rec = {
+        "title": "Test Invalid Lang Book",
+        "source_records": ["ia:test_invalid_lang"],
+        "isbn_13": ["9780000000002"],
+    }
+    reply = load(rec)
+    assert reply["success"] is True
+    assert reply["edition"]["status"] == "created"
+
+    update_rec = {
+        "title": "Test Invalid Lang Book",
+        "source_records": ["marc:test.mrc:0:100"],
+        "isbn_13": ["9780000000002"],
+        # "xx" is not a valid MARC or ISO language code
+        "languages": ["xx"],
+        "oclc_numbers": ["12345678"],
+    }
+    reply = load(update_rec)
+    assert reply["success"] is True
+    assert reply["edition"]["status"] == "modified"
+    updated = mock_site.get(reply["edition"]["key"])
+    # Language should be absent (bad code skipped)
+    assert not updated.get("languages"), "Invalid language code should have been skipped"
+    # But the oclc_numbers update must still have gone through
+    assert updated.oclc_numbers == ["12345678"], "oclc_numbers update should not have been aborted"
+
+
 def test_marc_update_adds_language_to_edition_without_language(mock_site, add_languages, ia_writeback):
     """
     When a MARC record is imported (rec has language codes as strings, as

--- a/openlibrary/catalog/marc/parse.py
+++ b/openlibrary/catalog/marc/parse.py
@@ -369,7 +369,9 @@ def read_languages(rec: MarcBase, lang_008: str | None = None) -> list[str]:
     found = []
     if lang_008:
         lang_008 = lang_008.lower()
-        if lang_008 not in ("   ", "###", "|||", "", "???", "zxx", "n/a"):
+        # MARC 008 language code must be exactly 3 characters; short 008 fields
+        # (< 38 chars) may produce truncated codes that are invalid.
+        if len(lang_008) == 3 and lang_008 not in ("   ", "###", "|||", "???", "zxx", "n/a"):
             found.append(lang_008)
 
     for f in rec.get_fields("041"):

--- a/openlibrary/catalog/marc/tests/test_parse.py
+++ b/openlibrary/catalog/marc/tests/test_parse.py
@@ -13,6 +13,7 @@ from openlibrary.catalog.marc.parse import (
     SeeAlsoAsTitle,
     read_author_person,
     read_edition,
+    read_languages,
 )
 
 collection_tag = "{http://www.loc.gov/MARC21/slim}collection"
@@ -184,3 +185,45 @@ class TestParse:
         assert result["death_date"] == "1865"
         assert result["entity_type"] == "person"
         assert result["remote_ids"] == {"lc_naf": "no2003007242"}
+
+    @pytest.mark.parametrize(
+        ("lang_008", "expected"),
+        [
+            # Normal valid 3-letter codes
+            ("eng", ["eng"]),
+            ("fre", ["fre"]),
+            # Filtered-out placeholder codes
+            ("   ", []),
+            ("###", []),
+            ("|||", []),
+            ("???", []),
+            ("zxx", []),
+            ("n/a", []),
+            # Short 008 — truncated slice must be rejected (not a valid 3-char code)
+            ("en", []),   # 2-char slice from a 37-char 008
+            ("e", []),    # 1-char slice from a 36-char 008
+            ("", []),     # empty slice
+        ],
+    )
+    def test_read_languages_008_code_validation(self, lang_008, expected):
+        """
+        read_languages() must only accept lang_008 values that are exactly 3
+        characters long and not a known placeholder/invalid pattern.
+
+        A truncated 008 field (< 38 chars) produces a 1- or 2-char slice at
+        [35:38]; those must be silently discarded rather than forwarded
+        downstream where they would cause InvalidLanguage errors.
+
+        Regression test for https://github.com/internetarchive/openlibrary/issues/12698
+        """
+        # Use a minimal MarcXml record with no 041 field so only lang_008 matters.
+        xml = """<record xmlns="http://www.loc.gov/MARC21/slim">
+          <leader>00000cam a2200000 a 4500</leader>
+          <controlfield tag="001">test</controlfield>
+          <datafield tag="245" ind1="1" ind2="0">
+            <subfield code="a">Test Title</subfield>
+          </datafield>
+        </record>"""
+        rec = MarcXml(etree.fromstring(xml, parser=lxml.etree.XMLParser(resolve_entities=False)))
+        result = read_languages(rec, lang_008=lang_008)
+        assert result == expected

--- a/openlibrary/catalog/marc/tests/test_parse.py
+++ b/openlibrary/catalog/marc/tests/test_parse.py
@@ -200,9 +200,9 @@ class TestParse:
             ("zxx", []),
             ("n/a", []),
             # Short 008 — truncated slice must be rejected (not a valid 3-char code)
-            ("en", []),   # 2-char slice from a 37-char 008
-            ("e", []),    # 1-char slice from a 36-char 008
-            ("", []),     # empty slice
+            ("en", []),  # 2-char slice from a 37-char 008
+            ("e", []),  # 1-char slice from a 36-char 008
+            ("", []),  # empty slice
         ],
     )
     def test_read_languages_008_code_validation(self, lang_008, expected):


### PR DESCRIPTION
Closes #12698

This PR fixes two bugs that prevented the MARC importer from updating the `languages` field on existing editions, even when the language code was present in the MARC `008` field.

### Technical

**Bug 1 — Short 008 field produces an invalid language code**
(`openlibrary/catalog/marc/parse.py` → `read_languages()`)

`read_edition()` slices `f[35:38]` from the MARC 008 control field. Some records carry short/truncated 008 fields (< 38 chars), yielding a 1- or 2-character code. The existing filter list only blocked specific 3-char patterns (`"   "`, `"###"`, etc.) and never validated the length, so short codes slipped through and caused `format_languages()` to raise `InvalidLanguage` downstream.

**Fix:** Added a `len(lang_008) == 3` guard before the filter list. Also removed the now-redundant `""` entry (the outer `if lang_008:` check already handles the empty-string case).

**Bug 2 — `InvalidLanguage` exception aborts entire edition update**
(`openlibrary/catalog/add_book/__init__.py` → `update_edition_with_rec_data()`)

When `format_languages()` raised `InvalidLanguage`, it propagated uncaught through `update_edition_with_rec_data()`, aborting the whole update — not just the language field. This could silently drop updates to LCCN, OCLC numbers, `source_records`, and other fields on the same import pass.

**Fix:** Wrapped `format_languages()` in a `try/except InvalidLanguage` block that logs a warning and `continue`s to the next field, so a bad language code is skipped without affecting other fields.

**Regression test added:**
`test_marc_update_adds_language_to_edition_without_language` — verifies that a MARC 3-letter language code (as returned by `read_edition()` from the 008 field) is correctly propagated to an existing edition that was previously imported without a language field (e.g. from Amazon).

### Testing

Run the tests with:
```bash
docker compose run --rm home python -m pytest openlibrary/catalog/add_book/tests/test_add_book.py -k "language" -v
docker compose run --rm home python -m pytest openlibrary/catalog/marc/tests/test_parse.py -v
```

All 66 MARC parse tests and all 4 language-related add_book tests pass.

To manually verify the original report, import the MARC record at `marc_columbia/Columbia-extract-20221130-029.mrc:73206659:1430` against a local OL instance against edition `OL28278453M` (which currently has no `languages` field). The 008 field at positions 35–37 is `fre`; after this fix the edition should have `[{key: "/languages/fre"}]` added.

### Screenshot
N/A — backend/data fix only.

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@tfmorris @mekarpeles @hornc