### PR TITLE
fix: strip None values from identifiers during import

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -887,10 +887,7 @@ def update_edition_with_rec_data(rec: dict, account_key: str | None, edition: "E
     if "identifiers" in rec:
         identifiers = defaultdict(
             list,
-            {
-                k: [v for v in vals if v is not None]
-                for k, vals in edition.dict().get("identifiers", {}).items()
-            },
+            {k: [v for v in vals if v is not None] for k, vals in edition.dict().get("identifiers", {}).items()},
         )
         for k, vals in rec["identifiers"].items():
             identifiers[k].extend(v for v in vals if v is not None)

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -885,9 +885,15 @@ def update_edition_with_rec_data(rec: dict, account_key: str | None, edition: "E
 
     # Add new identifiers (dict values, so different treatment from lists above.)
     if "identifiers" in rec:
-        identifiers = defaultdict(list, edition.dict().get("identifiers", {}))
+        identifiers = defaultdict(
+            list,
+            {
+                k: [v for v in vals if v is not None]
+                for k, vals in edition.dict().get("identifiers", {}).items()
+            },
+        )
         for k, vals in rec["identifiers"].items():
-            identifiers[k].extend(vals)
+            identifiers[k].extend(v for v in vals if v is not None)
             identifiers[k] = list(set(identifiers[k]))
         if edition.dict().get("identifiers") != identifiers:
             edition["identifiers"] = identifiers

--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -373,10 +373,7 @@ def import_record_to_edition(rec: dict[str, Any]) -> dict[str, Any]:
             continue
 
         if k == "identifiers":
-            book[k] = {
-                id_k: [val for val in id_vals if val is not None]
-                for id_k, id_vals in v.items()
-            }
+            book[k] = {id_k: [val for val in id_vals if val is not None] for id_k, id_vals in v.items()}
             continue
 
         if k in type_map:

--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -372,6 +372,13 @@ def import_record_to_edition(rec: dict[str, Any]) -> dict[str, Any]:
             book[k] = formatted_languages
             continue
 
+        if k == "identifiers":
+            book[k] = {
+                id_k: [val for val in id_vals if val is not None]
+                for id_k, id_vals in v.items()
+            }
+            continue
+
         if k in type_map:
             t = "/type/" + type_map[k]
             if isinstance(v, list):

--- a/openlibrary/catalog/add_book/tests/test_add_book.py
+++ b/openlibrary/catalog/add_book/tests/test_add_book.py
@@ -1451,6 +1451,86 @@ def test_add_identifiers_to_edition(mock_site) -> None:
     assert e.identifiers._data == {"goodreads": ["1234"], "librarything": ["5678"]}
 
 
+def test_null_identifiers_stripped_on_new_edition(mock_site) -> None:
+    """
+    Ensure that None values in identifiers are stripped when creating a new edition,
+    so that null identifiers are never persisted to the database.
+    """
+    rec = {
+        "source_records": ["non-marc:null-id-test"],
+        "title": "Book With Null Identifier",
+        "authors": [{"name": "Test Author"}],
+        "publishers": ["Test Publisher"],
+        "publish_date": "2020",
+        "isbn_10": ["0000000001"],
+        "identifiers": {"amazon": [None], "goodreads": ["1234", None]},
+    }
+
+    reply = load(rec)
+    assert reply["success"] is True
+    e = mock_site.get(reply["edition"]["key"])
+    assert None not in e.identifiers._data.get("amazon", [])
+    assert None not in e.identifiers._data.get("goodreads", [])
+    assert e.identifiers._data.get("goodreads") == ["1234"]
+    # amazon list should be empty (all values were None) so the key may be absent or empty
+    assert not e.identifiers._data.get("amazon")
+
+
+def test_null_identifiers_stripped_on_edition_update(mock_site) -> None:
+    """
+    Ensure that None values in identifiers are stripped when updating an existing edition,
+    so that null identifiers are never merged into the database.
+    """
+    author = {
+        "type": {"key": "/type/author"},
+        "name": "Jane Doe",
+        "key": "/authors/OL21A",
+    }
+
+    existing_work = {
+        "authors": [{"author": "/authors/OL21A", "type": {"key": "/type/author_role"}}],
+        "key": "/works/OL20W",
+        "title": "Book With Null Update",
+        "type": {"key": "/type/work"},
+    }
+
+    existing_edition = {
+        "key": "/books/OL20M",
+        "title": "Book With Null Update",
+        "publishers": ["Test Publisher"],
+        "type": {"key": "/type/edition"},
+        "source_records": ["non-marc:null-update-test"],
+        "publish_date": "2020",
+        "isbn_10": ["0000000002"],
+        "works": [{"key": "/works/OL20W"}],
+        "identifiers": {"amazon": [None], "goodreads": ["existing"]},
+    }
+
+    mock_site.save(author)
+    mock_site.save(existing_work)
+    mock_site.save(existing_edition)
+
+    rec = {
+        "source_records": "non-marc:null-update-test",
+        "title": "Book With Null Update",
+        "authors": [{"name": "Jane Doe"}],
+        "publishers": ["Test Publisher"],
+        "publish_date": "2020",
+        "isbn_10": ["0000000002"],
+        "identifiers": {"amazon": [None, "B0001"], "goodreads": [None, "newval"]},
+    }
+
+    reply = load(rec)
+    assert reply["success"] is True
+    e = mock_site.get(reply["edition"]["key"])
+    # None values must be absent; real values must be present
+    assert None not in e.identifiers._data.get("amazon", [])
+    assert "B0001" in e.identifiers._data.get("amazon", [])
+    assert None not in e.identifiers._data.get("goodreads", [])
+    assert "existing" in e.identifiers._data.get("goodreads", [])
+    assert "newval" in e.identifiers._data.get("goodreads", [])
+
+
 def test_adding_list_field_items_to_edition_deduplicates_input(mock_site) -> None:
     """
     Ensure a rec's edition_list_fields that are not present in a matched


### PR DESCRIPTION
Closes #12546

Patches the import logic to prevent saving `None` identifier values (action item 3 from the issue). Action items 1 & 2 were already addressed by #12547.

### Technical

Two touch-points in the import pipeline now filter out `None` values from identifier lists before any data is persisted:

- **`openlibrary/catalog/add_book/load_book.py` — `import_record_to_edition`**: Added a special case for the `identifiers` key that drops `None` from each identifier list before writing to the new edition dict. This prevents `None` from being saved when a brand-new edition is created from an import record.

- **`openlibrary/catalog/add_book/__init__.py` — `update_edition_with_rec_data`**: Two guards- **`openlibrary/catalog/add_book/__init__.py` — `update_edition_withtion- **`openlibrary/catalog/add_book/__ope- **`openlibrary/catalog/add_book/__init__.py` — `update_edition_with_rec_data`**: Two guards- **`openlibrary/catalog/add_book/__init__.py` — new - **`openlirea- **`openlibrary/catalog/add_book/__init__.py` — `update_edition_with_rec_data`**: Two guards- **`openlibrary/cata from the incoming record) are dropped on update, while valid values are preserved.

All 158 existing `add_book` tests continue to pass.

### Screenshot

N/A — no UI changes.

### Stakeholders
@cdrini