### PR TITLE
chore(deps): bump vite to ^8.0.5 (latest 8.0.x); unpin Python base image

### DIFF
--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -7,7 +7,7 @@ ENV MODSECURITY_TAG=${MODSECURITY_TAG}
 COPY scripts/build_modsecurity.sh /tmp/build_modsecurity.sh
 RUN bash /tmp/build_modsecurity.sh
 
-FROM python:3.12.2-slim-bookworm
+FROM python:3.12-slim-bookworm
 
 ENV LANG=en_US.UTF-8
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "svgo": "4",
         "tesseract.js": "^4.1.4",
         "tiptap-markdown": "^0.9.0",
-        "vite": "^8.0.3",
+        "vite": "^8.0.5",
         "vue": "^3.5.34",
         "vue-async-computed": "^4.0.1",
         "vue-multiselect": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "svgo": "4",
     "tesseract.js": "^4.1.4",
     "tiptap-markdown": "^0.9.0",
-    "vite": "^8.0.3",
+    "vite": "^8.0.5",
     "vue": "^3.5.34",
     "vue-async-computed": "^4.0.1",
     "vue-multiselect": "^3.5.0",


### PR DESCRIPTION
## Summary

- **vite** `^8.0.3` → `^8.0.5`: fixes three CVEs in 8.0.3–8.0.4 (path traversal in optimized deps GHSA-4w7w-66w2-5vf9, `server.fs.deny` bypass GHSA-v2wj-q39q-566r, arbitrary file read via WebSocket GHSA-p9ff-h696-f583). Risk is developer/CI machines running the Vite dev server.
- **Dockerfile.olbase** Python base image: `python:3.12.2-slim-bookworm` (March 2024) → `python:3.12-slim-bookworm` to track CPython security patches automatically (current: 3.12.11, includes CVE-2024-6232 tarfile ReDoS, CVE-2024-7592 http.cookies injection, and others).

Note: most other security dep bumps identified in a recent audit (Pillow, lodash, HAProxy, svgo, css-minimizer-webpack-plugin) were already applied in master. This PR covers the remaining two.

## Testing

- [x] `npm install` — 0 vulnerabilities after vite bump
- [x] `make js` — JS bundle builds cleanly with vite 8.0.5
- [x] Pre-commit passes on changed files

## Checklist

- [x] vite 8.0.5 installs and JS builds pass
- [x] Python base image updated to floating tag
- [x] No new errors introduced