### PR TITLE
chore(deps): consolidate Python dependency upgrades (May 2026)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiofiles==23.2.1
+aiofiles==25.1.0
 amightygirl.paapi5-python-sdk==1.0.0
 APScheduler==3.11.2
 Babel==2.18.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ multipart==1.3.1
 Pillow==12.2.0
 prometheus-fastapi-instrumentator==7.1.0
 psycopg2==2.9.12
-pydantic==2.13.3
+pydantic==2.13.4
 pymarc==5.3.1
 python-amazon-paapi==6.2.0
 python-dateutil==2.9.0.post0

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ python-memcached==1.62
 python-multipart==0.0.27
 PyYAML==6.0.3
 qrcode==7.4.2
-requests==2.33.1
+requests==2.34.0
 sentry-sdk[fastapi]==2.59.0
 simplejson==3.20.2
 statsd==4.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ pymarc==5.3.1
 python-amazon-paapi==6.2.0
 python-dateutil==2.9.0.post0
 python-memcached==1.62
-python-multipart==0.0.27
+python-multipart==0.0.28
 PyYAML==6.0.3
 qrcode==7.4.2
 requests==2.34.0

--- a/scripts/gh_scripts/requirements.txt
+++ b/scripts/gh_scripts/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.33.1
+requests==2.34.0


### PR DESCRIPTION
## Summary

Consolidates open Renovate PRs into a single tested upgrade. All packages installed and verified in Docker before opening this PR.

## Packages upgraded

| Package | Before | After | Severity | Closes |
|---------|--------|-------|----------|--------|
| pydantic | 2.13.3 | 2.13.4 | Low — patch bump | #12619 |
| aiofiles | 23.2.1 | 25.1.0 | Low — major bump (async API unchanged) | #12676 |
| requests | 2.33.1 | 2.34.0 | Low — minor bump | #12759 |
| python-multipart | 0.0.27 | 0.0.28 | Low — patch bump | #12759 |

## Excluded packages

| Package | Reason |
|---------|--------|
| luqum 0.11.0 → 0.14.0 (#12759) | **Breaking**: luqum 0.14.0 changed query parenthesization — `title:foo AND bar AND by:boo blah blah` no longer groups trailing words as `by:(boo blah blah)`. Confirmed via Docker test: `test_luqum_parser` fails. Needs separate investigation/fix. |
| Python 3.14.5 (#12643) | Python 3.14 introduces stricter string literal parsing; `openlibrary/templates/type/tag/index.html:30` fails with "unterminated string literal". Needs separate investigation. |
| chart.js 2.9.4 → 4.5.1 (#12761) | 2-major-version jump; likely breaking API changes. Needs its own PR. |
| babel-loader 9 → 10 (#12760) | Major version bump; needs separate PR. |
| @eslint/js 9 → 10 (#12675) | Major version bump; needs separate PR. |

## Testing

- ✅ All 4 packages install cleanly in Docker
- ✅ Versions verified in web container
- ✅ `make test`: 3809 passed, 0 failed
- ✅ HTTP 200 smoke test
- ✅ pre-commit clean
- ✅ luqum 0.14.0 regression confirmed and excluded (Docker test shows `test_luqum_parser` failure)