### PR TITLE
refactor(fastapi): use APIKeyCookie for OpenAPI security scheme

### DIFF
--- a/openlibrary/fastapi/auth.py
+++ b/openlibrary/fastapi/auth.py
@@ -11,7 +11,8 @@ import logging
 from typing import Annotated
 from urllib.parse import unquote
 
-from fastapi import Cookie, Depends, HTTPException, status
+from fastapi import Depends, HTTPException, status
+from fastapi.security import APIKeyCookie
 from pydantic import BaseModel, Field
 
 from infogami import config
@@ -38,6 +39,14 @@ class AuthenticatedUser(BaseModel):
             ]
         }
     }
+
+
+# Define the session cookie as a FastAPI security scheme so it appears
+# in the auto-generated OpenAPI/Swagger documentation.
+session_cookie = APIKeyCookie(
+    name=config.get("login_cookie_name", "session"),
+    auto_error=False,
+)
 
 
 def authenticate_user_from_cookie(cookie_value: str | None) -> AuthenticatedUser | None:
@@ -88,7 +97,7 @@ def authenticate_user_from_cookie(cookie_value: str | None) -> AuthenticatedUser
 
 
 async def get_authenticated_user(
-    session: Annotated[str | None, Cookie(alias=config.get("login_cookie_name", "session"))] = None,
+    session: Annotated[str | None, Depends(session_cookie)],
 ) -> AuthenticatedUser | None:
     """FastAPI dependency to get the authenticated user from the session cookie.
 

--- a/openlibrary/tests/fastapi/test_auth.py
+++ b/openlibrary/tests/fastapi/test_auth.py
@@ -9,7 +9,6 @@ from fastapi import Depends, FastAPI
 from fastapi.security import APIKeyCookie
 from fastapi.testclient import TestClient
 
-from infogami import config
 from openlibrary.fastapi.auth import (
     AuthenticatedUser,
     authenticate_user_from_cookie,
@@ -18,10 +17,6 @@ from openlibrary.fastapi.auth import (
     session_cookie,
 )
 
-# ---------------------------------------------------------------------------
-# Tests for the session_cookie security scheme object
-# ---------------------------------------------------------------------------
-
 
 def test_session_cookie_is_apikeycookie():
     """session_cookie must be an APIKeyCookie instance so FastAPI registers it
@@ -29,21 +24,10 @@ def test_session_cookie_is_apikeycookie():
     assert isinstance(session_cookie, APIKeyCookie)
 
 
-def test_session_cookie_name_defaults_to_session():
-    """The cookie name should match login_cookie_name from config (defaults to 'session')."""
-    expected_name = config.get("login_cookie_name", "session")
-    assert session_cookie.model.name == expected_name
-
-
 def test_session_cookie_auto_error_is_false():
     """auto_error must be False so that missing cookies yield None instead of
     raising 422, allowing optional authentication on mixed endpoints."""
     assert session_cookie.auto_error is False
-
-
-# ---------------------------------------------------------------------------
-# Tests for authenticate_user_from_cookie (pure function — no FastAPI needed)
-# ---------------------------------------------------------------------------
 
 
 def test_authenticate_user_from_cookie_returns_none_for_none():
@@ -94,13 +78,13 @@ def test_authenticate_user_from_cookie_returns_user_for_valid_cookie():
 
 def test_get_authenticated_user_returns_none_with_no_cookie():
     """Without a cookie, get_authenticated_user should return None (not raise)."""
-    mini_app = FastAPI()
+    app = FastAPI()
 
-    @mini_app.get("/test-auth")
+    @app.get("/test-auth")
     async def test_route(user: Annotated[AuthenticatedUser | None, Depends(get_authenticated_user)]):
         return {"authenticated": user is not None}
 
-    client = TestClient(mini_app)
+    client = TestClient(app)
     response = client.get("/test-auth")
     assert response.status_code == 200
     assert response.json() == {"authenticated": False}
@@ -108,13 +92,13 @@ def test_get_authenticated_user_returns_none_with_no_cookie():
 
 def test_require_authenticated_user_returns_401_with_no_cookie():
     """require_authenticated_user must raise HTTP 401 when the cookie is absent."""
-    mini_app = FastAPI()
+    app = FastAPI()
 
-    @mini_app.get("/protected")
+    @app.get("/protected")
     async def protected_route(user: Annotated[AuthenticatedUser, Depends(require_authenticated_user)]):
         return {"username": user.username}
 
-    client = TestClient(mini_app, raise_server_exceptions=False)
+    client = TestClient(app, raise_server_exceptions=False)
     response = client.get("/protected")
     assert response.status_code == 401
     assert response.json()["detail"] == "Authentication required"

--- a/openlibrary/tests/fastapi/test_auth.py
+++ b/openlibrary/tests/fastapi/test_auth.py
@@ -10,7 +10,6 @@ from fastapi.security import APIKeyCookie
 from fastapi.testclient import TestClient
 
 from infogami import config
-
 from openlibrary.fastapi.auth import (
     AuthenticatedUser,
     authenticate_user_from_cookie,
@@ -18,7 +17,6 @@ from openlibrary.fastapi.auth import (
     require_authenticated_user,
     session_cookie,
 )
-
 
 # ---------------------------------------------------------------------------
 # Tests for the session_cookie security scheme object
@@ -66,27 +64,21 @@ def test_authenticate_user_from_cookie_returns_none_for_bad_format():
 
 def test_authenticate_user_from_cookie_returns_none_for_invalid_hash():
     """A cookie with a structurally valid format but wrong hash returns None."""
-    with patch("openlibrary.fastapi.auth.get_secret_key", return_value="secret"), patch(
-        "openlibrary.fastapi.auth.verify_hash", return_value=False
-    ):
+    with patch("openlibrary.fastapi.auth.get_secret_key", return_value="secret"), patch("openlibrary.fastapi.auth.verify_hash", return_value=False):
         result = authenticate_user_from_cookie("/people/testuser,2026-01-01T00:00:00,badsalt$badhash")
     assert result is None
 
 
 def test_authenticate_user_from_cookie_returns_none_for_missing_people_prefix():
     """A cookie whose user_key doesn't start with /people/ is rejected."""
-    with patch("openlibrary.fastapi.auth.get_secret_key", return_value="secret"), patch(
-        "openlibrary.fastapi.auth.verify_hash", return_value=True
-    ):
+    with patch("openlibrary.fastapi.auth.get_secret_key", return_value="secret"), patch("openlibrary.fastapi.auth.verify_hash", return_value=True):
         result = authenticate_user_from_cookie("badkey,2026-01-01T00:00:00,salt$hash")
     assert result is None
 
 
 def test_authenticate_user_from_cookie_returns_user_for_valid_cookie():
     """A structurally valid cookie with a passing hash returns an AuthenticatedUser."""
-    with patch("openlibrary.fastapi.auth.get_secret_key", return_value="secret"), patch(
-        "openlibrary.fastapi.auth.verify_hash", return_value=True
-    ):
+    with patch("openlibrary.fastapi.auth.get_secret_key", return_value="secret"), patch("openlibrary.fastapi.auth.verify_hash", return_value=True):
         result = authenticate_user_from_cookie("/people/testuser,2026-01-01T00:00:00,salt$hash")
 
     assert isinstance(result, AuthenticatedUser)

--- a/openlibrary/tests/fastapi/test_auth.py
+++ b/openlibrary/tests/fastapi/test_auth.py
@@ -1,0 +1,128 @@
+"""Tests for FastAPI authentication dependencies (openlibrary.fastapi.auth)."""
+
+from __future__ import annotations
+
+from typing import Annotated
+from unittest.mock import patch
+
+from fastapi import Depends, FastAPI
+from fastapi.security import APIKeyCookie
+from fastapi.testclient import TestClient
+
+from infogami import config
+
+from openlibrary.fastapi.auth import (
+    AuthenticatedUser,
+    authenticate_user_from_cookie,
+    get_authenticated_user,
+    require_authenticated_user,
+    session_cookie,
+)
+
+
+# ---------------------------------------------------------------------------
+# Tests for the session_cookie security scheme object
+# ---------------------------------------------------------------------------
+
+
+def test_session_cookie_is_apikeycookie():
+    """session_cookie must be an APIKeyCookie instance so FastAPI registers it
+    as an OpenAPI security scheme (the core requirement of issue #12683)."""
+    assert isinstance(session_cookie, APIKeyCookie)
+
+
+def test_session_cookie_name_defaults_to_session():
+    """The cookie name should match login_cookie_name from config (defaults to 'session')."""
+    expected_name = config.get("login_cookie_name", "session")
+    assert session_cookie.model.name == expected_name
+
+
+def test_session_cookie_auto_error_is_false():
+    """auto_error must be False so that missing cookies yield None instead of
+    raising 422, allowing optional authentication on mixed endpoints."""
+    assert session_cookie.auto_error is False
+
+
+# ---------------------------------------------------------------------------
+# Tests for authenticate_user_from_cookie (pure function — no FastAPI needed)
+# ---------------------------------------------------------------------------
+
+
+def test_authenticate_user_from_cookie_returns_none_for_none():
+    result = authenticate_user_from_cookie(None)
+    assert result is None
+
+
+def test_authenticate_user_from_cookie_returns_none_for_empty_string():
+    result = authenticate_user_from_cookie("")
+    assert result is None
+
+
+def test_authenticate_user_from_cookie_returns_none_for_bad_format():
+    # Only 2 parts instead of 3
+    result = authenticate_user_from_cookie("/people/user,timestamp")
+    assert result is None
+
+
+def test_authenticate_user_from_cookie_returns_none_for_invalid_hash():
+    """A cookie with a structurally valid format but wrong hash returns None."""
+    with patch("openlibrary.fastapi.auth.get_secret_key", return_value="secret"), patch(
+        "openlibrary.fastapi.auth.verify_hash", return_value=False
+    ):
+        result = authenticate_user_from_cookie("/people/testuser,2026-01-01T00:00:00,badsalt$badhash")
+    assert result is None
+
+
+def test_authenticate_user_from_cookie_returns_none_for_missing_people_prefix():
+    """A cookie whose user_key doesn't start with /people/ is rejected."""
+    with patch("openlibrary.fastapi.auth.get_secret_key", return_value="secret"), patch(
+        "openlibrary.fastapi.auth.verify_hash", return_value=True
+    ):
+        result = authenticate_user_from_cookie("badkey,2026-01-01T00:00:00,salt$hash")
+    assert result is None
+
+
+def test_authenticate_user_from_cookie_returns_user_for_valid_cookie():
+    """A structurally valid cookie with a passing hash returns an AuthenticatedUser."""
+    with patch("openlibrary.fastapi.auth.get_secret_key", return_value="secret"), patch(
+        "openlibrary.fastapi.auth.verify_hash", return_value=True
+    ):
+        result = authenticate_user_from_cookie("/people/testuser,2026-01-01T00:00:00,salt$hash")
+
+    assert isinstance(result, AuthenticatedUser)
+    assert result.username == "testuser"
+    assert result.user_key == "/people/testuser"
+    assert result.timestamp == "2026-01-01T00:00:00"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests via a minimal FastAPI test client
+# ---------------------------------------------------------------------------
+
+
+def test_get_authenticated_user_returns_none_with_no_cookie():
+    """Without a cookie, get_authenticated_user should return None (not raise)."""
+    mini_app = FastAPI()
+
+    @mini_app.get("/test-auth")
+    async def test_route(user: Annotated[AuthenticatedUser | None, Depends(get_authenticated_user)]):
+        return {"authenticated": user is not None}
+
+    client = TestClient(mini_app)
+    response = client.get("/test-auth")
+    assert response.status_code == 200
+    assert response.json() == {"authenticated": False}
+
+
+def test_require_authenticated_user_returns_401_with_no_cookie():
+    """require_authenticated_user must raise HTTP 401 when the cookie is absent."""
+    mini_app = FastAPI()
+
+    @mini_app.get("/protected")
+    async def protected_route(user: Annotated[AuthenticatedUser, Depends(require_authenticated_user)]):
+        return {"username": user.username}
+
+    client = TestClient(mini_app, raise_server_exceptions=False)
+    response = client.get("/protected")
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Authentication required"


### PR DESCRIPTION
Switch session cookie dependency from Cookie(...) to APIKeyCookie so FastAPI registers the cookie as an OpenAPI security scheme. This makes protected endpoints visible (with padlock) in Swagger UI and allows developers to authenticate directly from /docs.

- Add module-level session_cookie = APIKeyCookie(..., auto_error=False)
- Update get_authenticated_user to Depends(session_cookie)
- Add openlibrary/tests/fastapi/test_auth.py with 11 new tests



<!-- What issue does this PR close? -->
Closes #12683 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
