### PR TITLE
fix: Follow button shows login link for authenticated users on book page lists

### DIFF
--- a/openlibrary/macros/Follow.html
+++ b/openlibrary/macros/Follow.html
@@ -21,5 +21,5 @@ $ link_track_attr = 'data-ol-link-track="%s"' % link_track.replace('"', '&quot;'
       <button type="submit" class="cta-btn cta-btn--$(css_treatment)" data-i18n="$json_encode(i18n_strings)" $link_track_attr>$(_("Unfollow") if following else _("Follow"))</button>
     </form>
   $else:
-    <a class="cta-btn cta-btn--primary" href="/account/login?redir_url=$(custom_request_path)&action=follow:$(publisher)" $link_track_attr>$_("Follow")</a>
+    <a class="cta-btn cta-btn--primary" href="/account/login?redir_url=$(urlquote(custom_request_path))&action=follow:$(publisher)" $link_track_attr>$_("Follow")</a>
 </div>

--- a/openlibrary/macros/Follow.html
+++ b/openlibrary/macros/Follow.html
@@ -6,11 +6,12 @@ $   'unfollow': _('Unfollow'),
 $   'errorMsg': _('Failed to update followers. Please try again in a few moments.')
 $ }
 
-$ subscriber = ctx.user and ctx.user.key
+$ user = get_current_user()
+$ subscriber = user and user.key
 $ custom_request_path = request_path if request_path != '' else request.fullpath
 $ link_track_attr = 'data-ol-link-track="%s"' % link_track.replace('"', '&quot;') if link_track else ''
 <div>
-  $if ctx.user:
+  $if user:
     <form class="follow-form" id="follow_$fid" method="POST" action="$(subscriber)/follows.json"
           property="follow" typeof="Follows" vocab="http://schema.org/">
       <input type="hidden" value="$following" name="state"/>
@@ -20,5 +21,5 @@ $ link_track_attr = 'data-ol-link-track="%s"' % link_track.replace('"', '&quot;'
       <button type="submit" class="cta-btn cta-btn--$(css_treatment)" data-i18n="$json_encode(i18n_strings)" $link_track_attr>$(_("Unfollow") if following else _("Follow"))</button>
     </form>
   $else:
-    <a class="cta-btn cta-btn--primary" href="/account/login?redir_url=$(ctx.path)&action=follow:$(publisher)" $link_track_attr>$_("Follow")</a>
+    <a class="cta-btn cta-btn--primary" href="/account/login?redir_url=$(custom_request_path)&action=follow:$(publisher)" $link_track_attr>$_("Follow")</a>
 </div>

--- a/openlibrary/templates/lists/list_follow.html
+++ b/openlibrary/templates/lists/list_follow.html
@@ -47,7 +47,8 @@ $def list_card(list, owner, own_list):
                 <div class="list-follow-card__follow-button">
                     $if not own_list:
                         $ owner_account = get_user_object(owner_username)
-                        $ is_subscribed = ctx.user and ctx.user.is_subscribed_user(owner_username)
+                        $ user = get_current_user()
+                        $ is_subscribed = user and user.is_subscribed_user(owner_username)
                         $ settings = owner_account.get_users_settings()
                         $ is_public = settings and settings.get('public_readlog', 'no') == "yes"
                         $if is_public:


### PR DESCRIPTION
Fixes #12692

## Root Cause

The book page "Lists" section is loaded asynchronously via a FastAPI partial endpoint (`/partials/BPListsSection.json`). When that AJAX request renders `Follow.html`, the template was checking `ctx.user` — but `ctx.user` is always `None` in FastAPI request contexts.

**Why**: `ctx` is `InfogamiContext`, a web.py `ThreadedDict` (thread-local) populated by `initialize_context()` which runs for **web.py** requests only. FastAPI uses a separate ContextVar-based `site` object for authentication. `ctx.user` is `None` in all FastAPI partial renders, regardless of whether the user is logged in.

The same root cause also produces `redir_url=/` in the login redirect link: `ctx.path` is the same thread-local and defaults to `'/'` in FastAPI context.

## Fix

Two template files, 4-line change:

**`openlibrary/macros/Follow.html`**
- `ctx.user` → `get_current_user()` (already `@public`, works in both web.py and FastAPI contexts)
- `ctx.path` → `custom_request_path` in the login redirect `<a>` tag (already correctly computed from `request_path` or `request.fullpath`)

**`openlibrary/templates/lists/list_follow.html`**
- `ctx.user.is_subscribed_user()` → `get_current_user()` so `is_subscribed` is correctly evaluated (without this fix, Follow always renders as "Follow" never "Unfollow" for the AJAX partial)

## Precedent

Commit `d6a9f2a6` ("fix partials user access in fastapi", 2026-03-09) identified and fixed this exact issue in `lists/carousel.html` (`ctx.user` → `get_current_user()`). This PR applies the same pattern to the two templates that were missed.

## Testing

- `make test`: 3779 passed, 0 failed ✓
- `pre-commit run --files openlibrary/macros/Follow.html openlibrary/templates/lists/list_follow.html`: passed (generate-pot fails locally as expected — requires Docker) ✓
- HTTP 200 on homepage ✓
- Dev Solr doesn't have list data so the BPListsSection partial returns empty — the fix can be verified on production or by manually seeding a dev list

## Regression surface

`get_current_user()` is called in the web.py rendering path too (where it wraps `web.ctx.site.get_user()`), so web.py-rendered pages (user profile Follow buttons, follows management page) are unaffected.