### PR TITLE
Fix: Add missing alt text to avatar images (#12707)

### DIFF
--- a/openlibrary/templates/account/follows.html
+++ b/openlibrary/templates/account/follows.html
@@ -7,9 +7,9 @@ $if follows:
       <li class="follow-row">
         <div class="follow-row--name">
           $if follow['publisher'] == username:
-            <a href="/people/$follow['subscriber']/books" class="username-avatar"><img src="/people/$follow['subscriber']/avatar" class="account-avatar">$follow['subscriber']</a>
+            <a href="/people/$follow['subscriber']/books" class="username-avatar"><img src="/people/$follow['subscriber']/avatar" class="account-avatar" alt="">$follow['subscriber']</a>
           $else:
-            <a href="/people/$follow['publisher']/books" class="username-avatar"><img src="/people/$follow['publisher']/avatar" class="account-avatar">$follow['publisher']</a>
+            <a href="/people/$follow['publisher']/books" class="username-avatar"><img src="/people/$follow['publisher']/avatar" class="account-avatar" alt="">$follow['publisher']</a>
         </div>
         <div>
           $if manage:

--- a/openlibrary/templates/account/view.html
+++ b/openlibrary/templates/account/view.html
@@ -20,7 +20,7 @@ $var title: $header_title
       <div class="breadcrumb-wrapper">
         $# Only show breadcrumbs when we're not on mybooks
         <div class="account-breadcrumb">
-          <a href="$mb.user.key" class="username-avatar"><img src="$(mb.user.key)/avatar" class="account-avatar"></a>
+          <a href="$mb.user.key" class="username-avatar"><img src="$(mb.user.key)/avatar" class="account-avatar" alt="$mb.username"></a>
           <h2 class="account-username"><a href="$mb.user.key">$mb.username</a> &rsaquo;</h2>
         </div>
         $if mb.key == 'list':

--- a/openlibrary/templates/account/view.html
+++ b/openlibrary/templates/account/view.html
@@ -20,7 +20,7 @@ $var title: $header_title
       <div class="breadcrumb-wrapper">
         $# Only show breadcrumbs when we're not on mybooks
         <div class="account-breadcrumb">
-          <a href="$mb.user.key" class="username-avatar"><img src="$(mb.user.key)/avatar" class="account-avatar" alt="$mb.username"></a>
+          <a href="$mb.user.key" class="username-avatar"><img src="$(mb.user.key)/avatar" class="account-avatar" alt=""></a>
           <h2 class="account-username"><a href="$mb.user.key">$mb.username</a> &rsaquo;</h2>
         </div>
         $if mb.key == 'list':

--- a/openlibrary/templates/account/view.html
+++ b/openlibrary/templates/account/view.html
@@ -20,7 +20,7 @@ $var title: $header_title
       <div class="breadcrumb-wrapper">
         $# Only show breadcrumbs when we're not on mybooks
         <div class="account-breadcrumb">
-          <a href="$mb.user.key" class="username-avatar"><img src="$(mb.user.key)/avatar" class="account-avatar" alt=""></a>
+          <a href="$mb.user.key" class="username-avatar"><img src="$(mb.user.key)/avatar" class="account-avatar" alt="$mb.username"></a>
           <h2 class="account-username"><a href="$mb.user.key">$mb.username</a> &rsaquo;</h2>
         </div>
         $if mb.key == 'list':


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #
Closes #12707
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
[fix] Adds missing alt text to avatar images on account/bookshelf pages to improve accessibility and resolve WCAG validation errors.

### Technical
<!-- What should be noted about the implementation? -->
As discussed in the issue comments, I applied two different accessibility treatments based on the HTML context:

1. **`account/view.html`**: The avatar image is the *only* content inside its `<a>` tag. To prevent an "Empty Link" / missing `alt` attribute error, I added a descriptive alt attribute (`alt="$mb.username"`).
2. **`account/follows.html`**: The avatar image is adjacent to the username text *inside the exact same link*. To prevent redundant screen reader announcements (reading the username twice), I marked the image as decorative by adding an empty alt attribute (`alt=""`). This answers Pam's question from the issue thread.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Navigate to a user's bookshelf page (e.g., `http://localhost:8080/people/openlibrary/books`).
2. Inspect the avatar image next to the username at the top of the page. Verify it has `alt="[username]"`.
3. Run the WAVE accessibility tool and confirm the missing alt text error is gone.
4. Navigate to a user's following/followers page (e.g., `http://localhost:8080/people/openlibrary/following`).
5. Inspect an avatar in the list and verify it has `alt=""`.
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
works fine and removes the violation:
<img width="1838" height="722" alt="image" src="https://github.com/user-attachments/assets/25c2b2fb-8b5f-4425-b7b7-bedfa02be08c" />

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@lokesh 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
