### PR TITLE
i18n: add translator notes to reading log and mybooks shelf strings

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -1284,13 +1284,17 @@ msgstr ""
 msgid "Earliest trending data is from October 2017"
 msgstr ""
 
-#. Label for the reading log shelf for books the user plans to read in the future (bookshelf ID 1). Used as a button label and shelf name.
+#. Label for the reading log shelf for books the user plans to read in the
+#. future (bookshelf ID 1). Used as a button label and shelf name.
 #: account/mybooks.html account/sidebar.html my_books/dropdown_content.html
 #: my_books/primary_action.html search/sort_options.html trending.html
 msgid "Want to Read"
 msgstr ""
 
-#. Label for the reading log shelf for books the user is actively reading (bookshelf ID 2). Used as a button label and shelf name.
+#. Display name for the "currently-reading" reading log shelf used in page
+#. headings and breadcrumbs.
+#. Label for the reading log shelf for books the user is actively reading
+#. (bookshelf ID 2). Used as a button label and shelf name.
 #: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
 #: my_books/dropdown_content.html my_books/primary_action.html
 #: search/sort_options.html trending.html
@@ -1303,6 +1307,8 @@ msgstr ""
 msgid "Read"
 msgstr ""
 
+#. Label for the reading log shelf for books the user stopped reading
+#. (bookshelf ID 4). Used as a button label and shelf name.
 #: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
 #: my_books/dropdown_content.html my_books/primary_action.html
 #: search/sort_options.html trending.html
@@ -1834,7 +1840,10 @@ msgstr ""
 msgid "My Loans"
 msgstr ""
 
-#. Label for the reading log shelf for books the user has finished reading (bookshelf ID 3). Used as a button label and shelf name.
+#. Display name for the "already-read" reading log shelf used in page headings
+#. and breadcrumbs.
+#. Label for the reading log shelf for books the user has finished reading
+#. (bookshelf ID 3). Used as a button label and shelf name.
 #: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
 #: my_books/dropdown_content.html my_books/primary_action.html
 #: openlibrary/plugins/upstream/mybooks.py search/sort_options.html
@@ -2148,7 +2157,8 @@ msgid ""
 "their book updates will appear here."
 msgstr ""
 
-#. Display name for the "want-to-read" reading log shelf used in page headings and breadcrumbs.
+#. Display name for the "want-to-read" reading log shelf used in page headings
+#. and breadcrumbs.
 #: account/readinglog_shelf_name.html
 msgid "Want To Read"
 msgstr ""
@@ -4141,21 +4151,24 @@ msgid "Books"
 msgstr ""
 
 #. Page title for the "Want to Read" shelf page.
-#. Example: "Want to Read (17)". %(count)d is the number of books on this shelf.
+#. Example: "Want to Read (17)". %(count)d is the number of books on this
+#. shelf.
 #: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #, python-format
 msgid "Want to Read (%(count)d)"
 msgstr ""
 
 #. Page title for the "Currently Reading" shelf page.
-#. Example: "Currently Reading (42)". %(count)d is the number of books on this shelf.
+#. Example: "Currently Reading (42)". %(count)d is the number of books on this
+#. shelf.
 #: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #, python-format
 msgid "Currently Reading (%(count)d)"
 msgstr ""
 
 #. Page title for the "Already Read" shelf page.
-#. Example: "Already Read (203)". %(count)d is the number of books on this shelf.
+#. Example: "Already Read (203)". %(count)d is the number of books on this
+#. shelf.
 #: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #, python-format
 msgid "Already Read (%(count)d)"
@@ -8363,7 +8376,10 @@ msgstr ""
 msgid "ratings"
 msgstr ""
 
-#. Shows the count of readers who added this book to their "Want to read" shelf, displayed on search result pages. %(want_to_read_count)s is a formatted integer (may include commas as thousands separators). Example: "2,389 Want to read".
+#. Shows the count of readers who added this book to their "Want to read"
+#. shelf, displayed on search result pages. %(want_to_read_count)s is a
+#. formatted integer (may include commas as thousands separators). Example:
+#. "2,389 Want to read".
 #: StarRatingsByline.html
 #, python-format
 msgid "%(want_to_read_count)s Want to read"
@@ -8374,17 +8390,22 @@ msgstr ""
 msgid "%(ratings_avg)s (%(ratings_count)s %(ratings_label)s)"
 msgstr ""
 
-#. Short label displayed next to the count of readers who want to read this book, shown in the stats bar on a book page. Example: "2,389 Want to read".
+#. Short label displayed next to the count of readers who want to read this
+#. book, shown in the stats bar on a book page. Example: "2,389 Want to read".
 #: StarRatingsStats.html
 msgid "Want to read"
 msgstr ""
 
-#. Short label displayed next to the count of readers currently reading this book, shown in the stats bar on a book page. Example: "1,247 Currently reading".
+#. Short label displayed next to the count of readers currently reading this
+#. book, shown in the stats bar on a book page. Example: "1,247 Currently
+#. reading".
 #: StarRatingsStats.html
 msgid "Currently reading"
 msgstr ""
 
-#. Short label displayed next to the count of readers who have finished this book, shown in the stats bar on a book page. Example: "15,420 Have read". This refers to the same shelf as the "Already Read" button.
+#. Short label displayed next to the count of readers who have finished this
+#. book, shown in the stats bar on a book page. Example: "15,420 Have read".
+#. This refers to the same shelf as the "Already Read" button.
 #: StarRatingsStats.html
 msgid "Have read"
 msgstr ""

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -1284,11 +1284,13 @@ msgstr ""
 msgid "Earliest trending data is from October 2017"
 msgstr ""
 
+#. Label for the reading log shelf for books the user plans to read in the future (bookshelf ID 1). Used as a button label and shelf name.
 #: account/mybooks.html account/sidebar.html my_books/dropdown_content.html
 #: my_books/primary_action.html search/sort_options.html trending.html
 msgid "Want to Read"
 msgstr ""
 
+#. Label for the reading log shelf for books the user is actively reading (bookshelf ID 2). Used as a button label and shelf name.
 #: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
 #: my_books/dropdown_content.html my_books/primary_action.html
 #: search/sort_options.html trending.html
@@ -1832,6 +1834,7 @@ msgstr ""
 msgid "My Loans"
 msgstr ""
 
+#. Label for the reading log shelf for books the user has finished reading (bookshelf ID 3). Used as a button label and shelf name.
 #: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
 #: my_books/dropdown_content.html my_books/primary_action.html
 #: openlibrary/plugins/upstream/mybooks.py search/sort_options.html
@@ -2145,6 +2148,7 @@ msgid ""
 "their book updates will appear here."
 msgstr ""
 
+#. Display name for the "want-to-read" reading log shelf used in page headings and breadcrumbs.
 #: account/readinglog_shelf_name.html
 msgid "Want To Read"
 msgstr ""
@@ -4136,16 +4140,22 @@ msgstr ""
 msgid "Books"
 msgstr ""
 
+#. Page title for the "Want to Read" shelf page.
+#. Example: "Want to Read (17)". %(count)d is the number of books on this shelf.
 #: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #, python-format
 msgid "Want to Read (%(count)d)"
 msgstr ""
 
+#. Page title for the "Currently Reading" shelf page.
+#. Example: "Currently Reading (42)". %(count)d is the number of books on this shelf.
 #: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #, python-format
 msgid "Currently Reading (%(count)d)"
 msgstr ""
 
+#. Page title for the "Already Read" shelf page.
+#. Example: "Already Read (203)". %(count)d is the number of books on this shelf.
 #: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #, python-format
 msgid "Already Read (%(count)d)"
@@ -8353,6 +8363,7 @@ msgstr ""
 msgid "ratings"
 msgstr ""
 
+#. Shows the count of readers who added this book to their "Want to read" shelf, displayed on search result pages. %(want_to_read_count)s is a formatted integer (may include commas as thousands separators). Example: "2,389 Want to read".
 #: StarRatingsByline.html
 #, python-format
 msgid "%(want_to_read_count)s Want to read"
@@ -8363,14 +8374,17 @@ msgstr ""
 msgid "%(ratings_avg)s (%(ratings_count)s %(ratings_label)s)"
 msgstr ""
 
+#. Short label displayed next to the count of readers who want to read this book, shown in the stats bar on a book page. Example: "2,389 Want to read".
 #: StarRatingsStats.html
 msgid "Want to read"
 msgstr ""
 
+#. Short label displayed next to the count of readers currently reading this book, shown in the stats bar on a book page. Example: "1,247 Currently reading".
 #: StarRatingsStats.html
 msgid "Currently reading"
 msgstr ""
 
+#. Short label displayed next to the count of readers who have finished this book, shown in the stats bar on a book page. Example: "15,420 Have read". This refers to the same shelf as the "Already Read" button.
 #: StarRatingsStats.html
 msgid "Have read"
 msgstr ""

--- a/openlibrary/macros/StarRatingsByline.html
+++ b/openlibrary/macros/StarRatingsByline.html
@@ -14,4 +14,5 @@ $ ratings_label = _('rating') if ratings_count == 1 else _('ratings')
 $if want_to_read_count and ratings_count:
   <span class="dot">·</span>
 $if want_to_read_count:
+  $code: pass  # NOTE: Shows the count of readers who added this book to their "Want to read" shelf, displayed on search result pages. %(want_to_read_count)s is a formatted integer (may include commas as thousands separators). Example: "2,389 Want to read".
   <span class="ratingsByline" itemprop="reviewCount">$_('%(want_to_read_count)s Want to read', want_to_read_count=formatted_want_to_read_count)</span>

--- a/openlibrary/macros/StarRatingsStats.html
+++ b/openlibrary/macros/StarRatingsStats.html
@@ -21,10 +21,13 @@ $ id = '--mobile' if mobile else ''
       $:macros.StarRatingsComponent(ratings_count, ratings_average, 'results_page')
   </li>
   $if want_to_read_count:
+    $code: pass  # NOTE: Short label displayed next to the count of readers who want to read this book, shown in the stats bar on a book page. Example: "2,389 Want to read".
     <li class="reading-log-stat"><span class="readers-stats__stat">$want_to_read_count</span> <span class="readers-stats__label">$_("Want to read")</span></li>
   $if currently_reading_count:
+    $code: pass  # NOTE: Short label displayed next to the count of readers currently reading this book, shown in the stats bar on a book page. Example: "1,247 Currently reading".
     <li class="reading-log-stat"><span class="readers-stats__stat">$currently_reading_count</span> <span class="readers-stats__label">$_("Currently reading")</span></li>
   $if already_read_count:
+    $code: pass  # NOTE: Short label displayed next to the count of readers who have finished this book, shown in the stats bar on a book page. Example: "15,420 Have read". This refers to the same shelf as the "Already Read" button.
     <li class="reading-log-stat"><span class="readers-stats__stat">$already_read_count</span> <span class="readers-stats__label">$_("Have read")</span></li>
   $if stopped_reading_count:
     <li class="reading-log-stat"><span class="readers-stats__stat">$stopped_reading_count</span> <span class="readers-stats__label">$_("Stopped reading")</span></li>

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -10,6 +10,9 @@ import web
 from infogami import config  # noqa: F401 side effects may be needed
 from infogami.utils import delegate
 from infogami.utils.view import public, render, safeint
+from typing_extensions import deprecated
+from web.template import TemplateResult
+
 from openlibrary import accounts
 from openlibrary.accounts.model import (
     OpenLibraryAccount,
@@ -237,12 +240,18 @@ class mybooks_readinglog(delegate.page):
     def GET(self, username, key="want-to-read"):
         mb = MyBooksTemplate(username, key)
         if mb.is_my_page or mb.is_public:
+            # NOTE: Page title for the "Currently Reading" shelf page.
+            # NOTE: Example: "Currently Reading (42)". %(count)d is the number of books on this shelf.
             KEYS_TITLES = {
                 "currently-reading": _(
                     "Currently Reading (%(count)d)",
                     count=mb.counts["currently-reading"],
                 ),
+                # NOTE: Page title for the "Want to Read" shelf page.
+                # NOTE: Example: "Want to Read (17)". %(count)d is the number of books on this shelf.
                 "want-to-read": _("Want to Read (%(count)d)", count=mb.counts["want-to-read"]),
+                # NOTE: Page title for the "Already Read" shelf page.
+                # NOTE: Example: "Already Read (203)". %(count)d is the number of books on this shelf.
                 "already-read": _("Already Read (%(count)d)", count=mb.counts["already-read"]),
                 "stopped-reading": _("Stopped Reading (%(count)d)", count=mb.counts["stopped-reading"]),
             }

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -6,13 +6,11 @@ from typing import TYPE_CHECKING, Any, Final, Literal, cast
 from warnings import deprecated
 
 import web
+from web.template import TemplateResult
 
 from infogami import config  # noqa: F401 side effects may be needed
 from infogami.utils import delegate
 from infogami.utils.view import public, render, safeint
-from typing_extensions import deprecated
-from web.template import TemplateResult
-
 from openlibrary import accounts
 from openlibrary.accounts.model import (
     OpenLibraryAccount,

--- a/openlibrary/templates/account/readinglog_shelf_name.html
+++ b/openlibrary/templates/account/readinglog_shelf_name.html
@@ -1,10 +1,13 @@
 $def with (key)
 
 $if key == 'currently-reading':
+  $code: pass  # NOTE: Display name for the "currently-reading" reading log shelf used in page headings and breadcrumbs.
   $_("Currently Reading")
 $elif key == 'want-to-read':
+  $code: pass  # NOTE: Display name for the "want-to-read" reading log shelf used in page headings and breadcrumbs.
   $_("Want To Read")
 $elif key == 'already-read':
+  $code: pass  # NOTE: Display name for the "already-read" reading log shelf used in page headings and breadcrumbs.
   $_("Already Read")
 $elif key == 'stopped-reading':
   $_("Stopped Reading")

--- a/openlibrary/templates/my_books/dropdown_content.html
+++ b/openlibrary/templates/my_books/dropdown_content.html
@@ -23,6 +23,7 @@ $def reading_log_selections(work_key, edition_key, users_work_read_status):
       <input type="hidden" name="bookshelf_id" value="1"/>
       $if edition_key:
         <input type="hidden" name="edition_id" value="$(edition_key)"/>
+      $code: pass  # NOTE: Label for the reading log shelf for books the user plans to read in the future (bookshelf ID 1). Used as a button label and shelf name.
       <button class="nostyle-btn $(btn_visibilities[1])" type="submit" data-ol-link-track="ReadingLog|WantToRead">$_('Want to Read')</button>
     </form>
 
@@ -31,6 +32,7 @@ $def reading_log_selections(work_key, edition_key, users_work_read_status):
       <input type="hidden" name="bookshelf_id" value="2"/>
       $if edition_key:
         <input type="hidden" name="edition_id" value="$(edition_key)"/>
+      $code: pass  # NOTE: Label for the reading log shelf for books the user is actively reading (bookshelf ID 2). Used as a button label and shelf name.
       <button class="nostyle-btn $(btn_visibilities[2])" type="submit" data-ol-link-track="ReadingLog|CurrentlyReading">$_('Currently Reading')</button>
     </form>
 
@@ -39,6 +41,7 @@ $def reading_log_selections(work_key, edition_key, users_work_read_status):
       <input type="hidden" name="bookshelf_id" value="3"/>
       $if edition_key:
         <input type="hidden" name="edition_id" value="$(edition_key)"/>
+      $code: pass  # NOTE: Label for the reading log shelf for books the user has finished reading (bookshelf ID 3). Used as a button label and shelf name.
       <button class="nostyle-btn $(btn_visibilities[3])" type="submit" data-ol-link-track="ReadingLog|AlreadyRead">$_('Already Read')</button>
     </form>
 

--- a/openlibrary/templates/my_books/primary_action.html
+++ b/openlibrary/templates/my_books/primary_action.html
@@ -3,15 +3,19 @@ $def with(work_key, edition_key, user_key, read_status, page_url, title="")
 $def reading_log_cta(work_key, edition_key, user_key, read_status, title):
   <form class="reading-log primary-action" method="POST" action="$(work_key)/bookshelves.json">
     $if read_status == 4:
+      $code: pass  # NOTE: Label for the reading log shelf for books the user stopped reading (bookshelf ID 4). Used as a button label and shelf name.
       $ message = _("Stopped Reading")
       $ track_value = "ReadingLog|StoppedReading"
     $elif read_status == 3:
+      $code: pass  # NOTE: Label for the reading log shelf for books the user has finished reading (bookshelf ID 3). Used as a button label and shelf name.
       $ message = _("Already Read")
       $ track_value = "ReadingLog|AlreadyRead"
     $elif read_status == 2:
+      $code: pass  # NOTE: Label for the reading log shelf for books the user is actively reading (bookshelf ID 2). Used as a button label and shelf name.
       $ message = _("Currently Reading")
       $ track_value = "ReadingLog|CurrentlyReading"
     $elif user_key:
+      $code: pass  # NOTE: Label for the reading log shelf for books the user plans to read in the future (bookshelf ID 1). Used as a button label and shelf name.
       $ message = _("Want to Read")
       $ track_value = "ReadingLog|WantToRead"
     $else:


### PR DESCRIPTION
## Summary

Closes #12562

Adds `# NOTE:` context comments to the 11 translatable strings in the reading log and mybooks features that were flagged in #12441 and tracked in #12562 as lacking translator context.

### Strings annotated

| String | Context |
|--------|---------|
| `Want to Read` | Shelf name/button, bookshelf ID 1 |
| `Currently Reading` | Shelf name/button, bookshelf ID 2 |
| `Already Read` | Shelf name/button, bookshelf ID 3 |
| `Want To Read` | Shelf display name in breadcrumbs (`readinglog_shelf_name.html`) |
| `Want to Read (%(count)d)` | Shelf page title with book count |
| `Currently Reading (%(count)d)` | Shelf page title with book count |
| `Already Read (%(count)d)` | Shelf page title with book count |
| `%(want_to_read_count)s Want to read` | Reader count on search result pages |
| `Want to read` | Stats bar label on book pages |
| `Currently reading` | Stats bar label on book pages |
| `Have read` | Stats bar label (same shelf as "Already Read" button) |

### How it works

The `# NOTE:` comment tag is already configured in `openlibrary/i18n/__init__.py` (`COMMENT_TAGS = ["NOTE:"]`, `strip_comment_tags=True`). For Templetor `.html` files the syntax is:
```html
$code: pass  # NOTE: Your note here
$_("String")
```
This generates a `pass  # NOTE: ...` line immediately before the `extend_([..._()...])` call in the compiled Python, which Babel's `extract_python` picks up and writes as a `#.` auto-comment in `messages.pot`.

For Python files, standard `# NOTE:` on the line preceding `_()` is used.

### Testing

- Verified `$code: pass  # NOTE:` extraction using a local venv with `web.py` + `babel` — notes correctly appear in extracted results for all edited templates
- All locally-runnable pre-commit hooks pass (`ruff check`, `ruff format`, `codespell`, `trim-trailing-whitespace`)
- `mypy` and `generate-pot` hooks require Docker (expected failures locally); `generate-pot` CI hook will finalise `messages.pot` from the source file annotations

## Checklist

- [x] `# NOTE:` comments added to all 11 strings
- [x] `messages.pot` manually updated to preview the `#.` entries
- [x] Extraction verified locally (Babel + web.py venv)
- [x] `ruff`, `codespell`, whitespace hooks pass
- [x] No logic or UI changes — annotation only