### PR TITLE
Fix: Make native select visible on focus for keyboard accessibility (#12708)

### DIFF
--- a/static/css/components/mybooks-details.css
+++ b/static/css/components/mybooks-details.css
@@ -52,15 +52,16 @@
   z-index: var(--z-index-level-2);
 }
 
-/* When the hidden select is focused with a keyboard, draw the official OL focus ring on the visible dropdown */
-.crumbicon:has(.disguised-select:focus-visible) .dropdown {
-  box-shadow: var(--box-shadow-focus);
-}
-
 .dropdown {
   box-shadow: 0 0 0 1px var(--lightest-grey);
   border-radius: var(--border-radius-button);
 }
+
+/* stylelint-disable selector-max-specificity */
+.crumbicon:has(.disguised-select:focus-visible) .dropdown {
+  box-shadow: var(--box-shadow-focus);
+}
+/* stylelint-enable selector-max-specificity */
 
 .down-chevron {
   margin: 6px 10px 0 3px;

--- a/static/css/components/mybooks-details.css
+++ b/static/css/components/mybooks-details.css
@@ -52,8 +52,9 @@
   z-index: var(--z-index-level-2);
 }
 
-.disguised-select:focus-visible {
-  opacity: 1;
+/* When the hidden select is focused with a keyboard, draw the official OL focus ring on the visible dropdown */
+.crumbicon:has(.disguised-select:focus-visible) .dropdown {
+  box-shadow: var(--box-shadow-focus);
 }
 
 .dropdown {

--- a/static/css/components/mybooks-details.css
+++ b/static/css/components/mybooks-details.css
@@ -52,6 +52,10 @@
   z-index: var(--z-index-level-2);
 }
 
+.disguised-select:focus-visible {
+  opacity: 1;
+}
+
 .dropdown {
   box-shadow: 0 0 0 1px var(--lightest-grey);
   border-radius: var(--border-radius-button);


### PR DESCRIPTION

<!-- What issue does this PR close? -->

Closes #12708

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
[fix] Restores visible focus to the native `<select>` elements used in reading status dropdowns for keyboard accessibility.

### Technical
<!-- What should be noted about the implementation? -->
The reading status dropdowns use a `.disguised-select` class that sets `opacity: 0.01` to hide the native `<select>` element over a custom UI button. However, this `opacity: 0.01` also hides the browser's native focus ring, causing accessibility failures for keyboard users.

The fix was to add a `:focus-visible` state to `.disguised-select` that resets the opacity to `1`. 
Because this fix targets the shared CSS class, it acts as a global fix that resolves the missing focus ring for all reading shelf dropdowns, fulfilling the issue's requirements.

* When navigating with a keyboard (`Tab`), the native select box and its focus ring become fully visible.
* When clicking with a mouse, it remains hidden, preserving the custom UI design.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Navigate to a user's bookshelf page (e.g., `http://localhost:8080/people/openlibrary/books/want-to-read`).
2. Use the `Tab` key to navigate through the interactive elements until you reach the "Want to Read" (or "Currently Reading" / "Already Read") dropdown.
3. Verify that the dropdown now clearly shows the browser's native focus indicator.
4. Click the dropdown with a mouse to verify the standard custom UI remains intact for pointer events.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Before change:
<img width="347" height="90" alt="image" src="https://github.com/user-attachments/assets/d46208ef-13e3-4106-b461-3b928e7bcfb9" />

After change:
<img width="310" height="82" alt="image" src="https://github.com/user-attachments/assets/3fd2dfa5-b101-4569-9758-b11ac2b3d738" />

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@lokesh 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
