### PR TITLE
Increase max requests for Gunicorn to 5000

### DIFF
--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -27,7 +27,7 @@ services:
     restart: unless-stopped
     hostname: "$HOSTNAME"
     environment:
-      - GUNICORN_OPTS= --workers 4 --timeout 300 --max-requests 1500
+      - GUNICORN_OPTS= --workers 4 --timeout 300 --max-requests 5000
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
     volumes:
       - ../booklending_utils:/booklending_utils

--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -27,7 +27,7 @@ services:
     restart: unless-stopped
     hostname: "$HOSTNAME"
     environment:
-      - GUNICORN_OPTS= --workers 4 --timeout 300 --max-requests 5000
+      - GUNICORN_OPTS= --workers 4 --timeout 300 --max-requests 5000 --max-requests-jitter 500
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
     volumes:
       - ../booklending_utils:/booklending_utils


### PR DESCRIPTION
At 1500 requests, If FastAPI does 50 req/sec then each worker is doing a restart every 30 seconds. @jimchamp and I were seeing particularly frequent fastapi restarts in the logs (and each restart itself takes 5-10 seconds meaning increased saturation for the remaining workers)