### PR TITLE
Fix open redirect vulnerability in login flow

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -98,9 +98,9 @@ def is_safe_redirect(url: str) -> bool:
     parsed = urlparse(url)
     if parsed.netloc or parsed.scheme:
         return False
-    if not re.match(r"^/[^/\\]", parsed.path):
+    if not re.match(r"^/[^/\\]", parsed.path):  # noqa: SIM103
         return False
-    return True
+    return True  # noqa: SIM103
 
 
 class availability(delegate.page):

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -100,7 +100,7 @@ def is_safe_redirect(url: str) -> bool:
         return False
     if not re.match(r"^/[^/\\]", parsed.path):  # noqa: SIM103
         return False
-    return True  # noqa: SIM103
+    return True
 
 
 class availability(delegate.page):

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -2,6 +2,7 @@ import csv
 import io
 import json
 import logging
+import re
 from abc import ABC, abstractmethod
 from datetime import datetime
 from enum import Enum
@@ -91,6 +92,15 @@ def get_login_error(error_key):
         "security_error": _("Login or registration attempt hit an unexpected error, please try again or contact info@archive.org"),
     }
     return LOGIN_ERRORS[error_key] if error_key in LOGIN_ERRORS else _("Request failed with error code: %(error_code)s", error_code=error_key)
+
+
+def is_safe_redirect(url: str) -> bool:
+    parsed = urlparse(url)
+    if parsed.netloc or parsed.scheme:
+        return False
+    if not re.match(r"^/[^/\\]", parsed.path):
+        return False
+    return True
 
 
 class availability(delegate.page):
@@ -572,7 +582,7 @@ class account_login(delegate.page):
         if flash_message := self.perform_post_login_action(i, ol_account):
             add_flash_message("note", _(flash_message))
 
-        if i.redirect == "" or any(path in i.redirect for path in blacklist):
+        if not is_safe_redirect(i.redirect) or any(path in i.redirect for path in blacklist):
             i.redirect = "/account/books"
         stats.increment("ol.account.xauth.login")
         raise web.seeother(i.redirect)

--- a/openlibrary/plugins/upstream/tests/test_account.py
+++ b/openlibrary/plugins/upstream/tests/test_account.py
@@ -33,6 +33,22 @@ def test_create_list_doc(wildcard):
     }
 
 
+@pytest.mark.parametrize(
+    ('redirect', 'expected'),
+    [
+        ('/account/books', True),
+        ('/account/login', True),
+        ('/books', True),
+        ('https://evil.example/path', False),
+        ('//evil.example/path', False),
+        ('/\\evil.example/path', False),
+        ('', False),
+    ],
+)
+def test_is_safe_redirect(redirect, expected):
+    assert account.is_safe_redirect(redirect) is expected
+
+
 class TestGoodReadsImport:
     def setup_method(self, method):
         with open_test_data("goodreads_library_export.csv") as reader:

--- a/openlibrary/plugins/upstream/tests/test_account.py
+++ b/openlibrary/plugins/upstream/tests/test_account.py
@@ -34,15 +34,15 @@ def test_create_list_doc(wildcard):
 
 
 @pytest.mark.parametrize(
-    ('redirect', 'expected'),
+    ("redirect", "expected"),
     [
-        ('/account/books', True),
-        ('/account/login', True),
-        ('/books', True),
-        ('https://evil.example/path', False),
-        ('//evil.example/path', False),
-        ('/\\evil.example/path', False),
-        ('', False),
+        ("/account/books", True),
+        ("/account/login", True),
+        ("/books", True),
+        ("https://evil.example/path", False),
+        ("//evil.example/path", False),
+        ("/\\evil.example/path", False),
+        ("", False),
     ],
 )
 def test_is_safe_redirect(redirect, expected):


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Implements `/account/login` security fix that was authored by @akramcodez (thanks so much!).

Code prevents off-site redirects on patron login, and was path-deployed before this PR was opened.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
