### PR TITLE
refactor: move affiliate store logic from template to Python

### DIFF
--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -794,7 +794,7 @@ def cached_get_amazon_metadata(*args, **kwargs):
 class BetterWorldBooksMetadata(TypedDict):
     url: str
     isbn: str
-    market_price: list[str] | None
+    market_price: str | None
     price: str | None
     price_amt: str | None
     qlt: str | None
@@ -872,7 +872,7 @@ def betterworldbooks_fmt(
     isbn: str,
     qlt: str | None = None,
     price: str | None = None,
-    market_price: list[str] | None = None,
+    market_price: str | None = None,
 ) -> BetterWorldBooksMetadata:
     """Defines a standard interface for returning bwb price info
 

--- a/openlibrary/fastapi/partials.py
+++ b/openlibrary/fastapi/partials.py
@@ -66,7 +66,17 @@ async def affiliate_links_partial(
     except json.JSONDecodeError:
         raise HTTPException(status_code=400, detail="Invalid JSON in data parameter")
 
-    return await AffiliateLinksPartial.generate_async(data=parsed_data)
+    args = parsed_data.get("args", [])
+    if len(args) < 2:
+        raise HTTPException(status_code=400, detail="Expected at least 2 arguments")
+
+    title, opts = args[0], args[1]
+    return await AffiliateLinksPartial.generate_async(
+        title=title,
+        isbn=opts.get("isbn", None),
+        asin=opts.get("asin", None),
+        prices=opts.get("prices", False),
+    )
 
 
 @router.get("/partials/BPListsSection.json", include_in_schema=SHOW_PARTIALS_IN_SCHEMA)

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -7899,22 +7899,6 @@ msgid "Look for this edition for sale at %(store)s"
 msgstr ""
 
 #: AffiliateLinks.html
-msgid "Better World Books"
-msgstr ""
-
-#: AffiliateLinks.html
-msgid " - includes shipping"
-msgstr ""
-
-#: AffiliateLinks.html
-msgid "Amazon"
-msgstr ""
-
-#: AffiliateLinks.html
-msgid "Bookshop.org"
-msgstr ""
-
-#: AffiliateLinks.html
 msgid ""
 "When you buy books using these links the Internet Archive may earn a <a "
 "class=\"nostyle\" href=\"/help/faq/about#selling\">small commission</a>."
@@ -8651,6 +8635,22 @@ msgstr ""
 #: openlibrary/plugins/openlibrary/lists.py
 #, python-format
 msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "Better World Books"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid " - includes shipping"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "Amazon"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "Bookshop.org"
 msgstr ""
 
 #: openlibrary/plugins/openlibrary/partials.py

--- a/openlibrary/macros/AffiliateLinks.html
+++ b/openlibrary/macros/AffiliateLinks.html
@@ -12,50 +12,18 @@ $def affiliate_link(key, analytics_key, name, link, price='', price_note=''):
         <span name="price">$price$price_note</span>
   </li>
 
+$ stores = build_affiliate_stores(title, opts, bwb_metadata, amz_metadata)
+
 <span class="affiliate-links-section" data-title="$title" data-opts="$json_encode(opts)">
-  $code:
-      prices = opts.get('prices')
-      isbn = opts.get('isbn', '')
-      asin = opts.get('asin', '')
-
-      bwb = {
-        'key': 'betterworldbooks',
-        'analytics_key': 'BetterWorldBooks',
-        'name': _('Better World Books'),
-        'link': 'https://www.betterworldbooks.com/%s' % (
-          ('product/detail/-%s' % isbn) if isbn else ('search/results?q=' + title.replace(' ','%20'))
-        ),
-        'price_note': _(' - includes shipping'),
-        'price': bwb_metadata and bwb_metadata.get('price')
-      }
-
-      amazon = {
-        'key': 'amazon',
-        'analytics_key': 'Amazon',
-        'name': _('Amazon'),
-        'link': 'https://www.amazon.com/dp/%s/?tag=%s' % (asin or isbn, affiliate_id('amazon')),
-        'price': (bwb_metadata and bwb_metadata.get('market_price')) or (amz_metadata and amz_metadata.get('price'))
-      } if (asin or isbn) else None
-
-      bookshop = {
-        'key': 'bookshop-org',
-        'analytics_key': 'BookshopOrg',
-        'name': _('Bookshop.org'),
-        'link': 'https://bookshop.org/a/%s/%s' % (affiliate_id('bookshop-org'), isbn),
-      } if isbn else None
-
-      primary_stores = [store for store in [bwb, amazon] if store]
-      more_stores = [store for store in [bookshop] if store]
-
   <ul class="buy-options-table">
-      $for store in primary_stores:
+      $for store in stores['primary_stores']:
         $:affiliate_link(store['key'], store['analytics_key'], store['name'], store['link'], store.get('price', ''), store.get('price_note', ''))
-      $if more_stores:
+      $if stores['more_stores']:
         <li class="more">
           <details>
             <summary>$_('More')</summary>
             <ul>
-              $for store in more_stores:
+              $for store in stores['more_stores']:
                 $:affiliate_link(store['key'], store['analytics_key'], store['name'], store['link'], store.get('price', ''), store.get('price_note', ''))
             </ul>
           </details>

--- a/openlibrary/macros/AffiliateLinks.html
+++ b/openlibrary/macros/AffiliateLinks.html
@@ -1,30 +1,28 @@
-$def with (title, opts, bwb_metadata=None, amz_metadata=None)
+$def with (primary_stores, more_stores)
 
-$def affiliate_link(key, analytics_key, name, link, price='', price_note=''):
-  <li class="prices-$key">
-      <a href="$link"
-         title="$_('Look for this edition for sale at %(store)s', store=name)"
-         data-ol-link-track="BuyLink|$analytics_key"
-         target="_blank" rel="noopener noreferrer">$name</a>
+$def affiliate_link(store):
+  <li class="prices-$store.key">
+      <a href="$store.link"
+         title="$_('Look for this edition for sale at %(store)s', store=store.name)"
+         data-ol-link-track="BuyLink|$store.analytics_key"
+         target="_blank" rel="noopener noreferrer">$store.name</a>
 
-      $if price:
+      $if store.price:
         <br>
-        <span name="price">$price$price_note</span>
+        <span name="price">$store.price$store.price_note</span>
   </li>
 
-$ stores = build_affiliate_stores(title, opts, bwb_metadata, amz_metadata)
-
-<span class="affiliate-links-section" data-title="$title" data-opts="$json_encode(opts)">
+<span class="affiliate-links-section">
   <ul class="buy-options-table">
-      $for store in stores['primary_stores']:
-        $:affiliate_link(store['key'], store['analytics_key'], store['name'], store['link'], store.get('price', ''), store.get('price_note', ''))
-      $if stores['more_stores']:
+      $for store in primary_stores:
+        $:affiliate_link(store)
+      $if more_stores:
         <li class="more">
           <details>
             <summary>$_('More')</summary>
             <ul>
-              $for store in stores['more_stores']:
-                $:affiliate_link(store['key'], store['analytics_key'], store['name'], store['link'], store.get('price', ''), store.get('price_note', ''))
+              $for store in more_stores:
+                $:affiliate_link(store)
             </ul>
           </details>
         </li>

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -13,6 +13,7 @@ from openlibrary.core.fulltext import fulltext_search_async
 from openlibrary.core.helpers import affiliate_id
 from openlibrary.core.lending import compose_ia_url, get_available_async
 from openlibrary.core.vendors import (
+    BetterWorldBooksMetadata,
     get_amazon_metadata,
     get_betterworldbooks_metadata,
 )
@@ -218,84 +219,102 @@ class CarouselCardPartial:
         return subject.get("works", [])
 
 
-def build_affiliate_stores(
-    title: str,
-    opts: dict,
-    bwb_metadata: dict | None = None,
-    amz_metadata: dict | None = None,
-) -> dict:
-    """Build affiliate store data for rendering in AffiliateLinks.html.
+@dataclass(frozen=True, slots=True)
+class AffiliateStoreBuildContext:
+    title: str
+    isbn: str | None
+    asin: str | None
+    bwb_metadata: BetterWorldBooksMetadata | None
+    amz_metadata: dict | None
 
-    Accepts title, opts, and optional price metadata.
-    Returns a dict with primary_stores and more_stores lists.
-    """
-    isbn = opts.get("isbn", "")
-    asin = opts.get("asin", "")
 
-    bwb: dict = {
-        "key": "betterworldbooks",
-        "analytics_key": "BetterWorldBooks",
-        "name": _("Better World Books"),
-        "link": "https://www.betterworldbooks.com/%s" % (("product/detail/-%s" % isbn) if isbn else ("search/results?q=" + quote_plus(title))),
-        "price_note": _(" - includes shipping"),
-        "price": bwb_metadata and bwb_metadata.get("price"),
-    }
+@dataclass(frozen=True, slots=True)
+class AffiliateStore:
+    key: str
+    analytics_key: str
+    name: str
+    link: str
+    price: str | None = None
+    price_note: str = ""
 
-    amazon: dict | None = (
-        {
-            "key": "amazon",
-            "analytics_key": "Amazon",
-            "name": _("Amazon"),
-            "link": "https://www.amazon.com/dp/%s/?tag=%s" % (asin or isbn, affiliate_id("amazon")),
-            "price": (bwb_metadata and bwb_metadata.get("market_price")) or (amz_metadata and amz_metadata.get("price")),
-        }
-        if (asin or isbn)
-        else None
-    )
 
-    bookshop: dict | None = (
-        {
-            "key": "bookshop-org",
-            "analytics_key": "BookshopOrg",
-            "name": _("Bookshop.org"),
-            "link": "https://bookshop.org/a/%s/%s" % (affiliate_id("bookshop-org"), isbn),
-        }
-        if isbn
-        else None
-    )
+def build_primary_stores(ctx: AffiliateStoreBuildContext) -> list[AffiliateStore]:
+    """Build affiliate store data for rendering in AffiliateLinks.html."""
 
-    return {
-        "primary_stores": [s for s in [bwb, amazon] if s],
-        "more_stores": [s for s in [bookshop] if s],
-    }
+    bwb_link = f"https://www.betterworldbooks.com/search/results?q={quote_plus(ctx.title)}"
+    if ctx.isbn:
+        bwb_link = f"https://www.betterworldbooks.com/product/detail/{ctx.isbn}"
+
+    bwb_market_price = ctx.bwb_metadata.get("market_price") if ctx.bwb_metadata else None
+    bwb_price = ctx.bwb_metadata.get("price") if ctx.bwb_metadata else None
+    amz_price = ctx.amz_metadata.get("price") if ctx.amz_metadata else None
+
+    primary_stores: list[AffiliateStore] = [
+        AffiliateStore(
+            key="betterworldbooks",
+            analytics_key="BetterWorldBooks",
+            name=_("Better World Books"),
+            link=bwb_link,
+            price=bwb_price,
+            price_note=_(" - includes shipping"),
+        )
+    ]
+
+    if ctx.asin or ctx.isbn:
+        primary_stores.append(
+            AffiliateStore(
+                key="amazon",
+                analytics_key="Amazon",
+                name=_("Amazon"),
+                link=f"https://www.amazon.com/dp/{ctx.asin or ctx.isbn}/?tag={affiliate_id('amazon')}",
+                price=bwb_market_price or amz_price,
+            )
+        )
+
+    return primary_stores
+
+
+def build_more_stores(ctx: AffiliateStoreBuildContext) -> list[AffiliateStore]:
+    """Build list of additional affiliate store data for rendering in AffiliateLinks.html."""
+    if not ctx.isbn:
+        return []
+
+    return [
+        AffiliateStore(
+            key="bookshop-org",
+            analytics_key="BookshopOrg",
+            name=_("Bookshop.org"),
+            link=f"https://bookshop.org/a/{affiliate_id('bookshop-org')}/{ctx.isbn}",
+        ),
+    ]
 
 
 class AffiliateLinksPartial:
     """Handler for affiliate links"""
 
-    @classmethod
-    async def generate_async(cls, data: dict) -> dict:
-        args = data.get("args", [])
-
-        if len(args) < 2:
-            raise ValueError("Unexpected amount of arguments")
-
-        title, opts = args[0], args[1]
-        isbn = opts.get("isbn", "")
-
+    @staticmethod
+    async def generate_async(
+        title: str,
+        isbn: str | None,
+        asin: str | None,
+        prices: bool,
+    ) -> dict:
         bwb_metadata = None
         amz_metadata = None
-        if not is_bot() and opts.get("prices") and isbn:
+        should_fetch_prices = not is_bot() and prices
+        if should_fetch_prices and isbn:
             bwb_metadata = await get_betterworldbooks_metadata(isbn)
-            if not (bwb_metadata and bwb_metadata.get("market_price")):
+            if not bwb_metadata or not bwb_metadata.get("market_price"):
                 amz_metadata = get_amazon_metadata(isbn, resources="prices")
 
-        macro = web.template.Template.globals["macros"].AffiliateLinks(
-            title,
-            opts,
-            bwb_metadata=bwb_metadata,
-            amz_metadata=amz_metadata,
-        )
+        if bwb_metadata and "error" in bwb_metadata:
+            bwb_metadata = None
+
+        ctx = AffiliateStoreBuildContext(title, isbn, asin, bwb_metadata, amz_metadata)
+
+        primary_stores = build_primary_stores(ctx)
+        more_stores = build_more_stores(ctx)
+        macro = web.template.Template.globals["macros"].AffiliateLinks(primary_stores, more_stores)
         return {"partials": str(macro)}
 
 
@@ -522,7 +541,6 @@ gather_lazy_carousel_data = async_bridge.wrap(gather_lazy_carousel_data_async, "
 
 # Expose this publicly for the template
 public(gather_lazy_carousel_data)
-public(build_affiliate_stores)
 
 
 def setup():

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -229,31 +229,25 @@ def build_affiliate_stores(
     Accepts title, opts, and optional price metadata.
     Returns a dict with primary_stores and more_stores lists.
     """
-    isbn = opts.get('isbn', '')
-    asin = opts.get('asin', '')
+    isbn = opts.get("isbn", "")
+    asin = opts.get("asin", "")
 
     bwb: dict = {
-        'key': 'betterworldbooks',
-        'analytics_key': 'BetterWorldBooks',
-        'name': _('Better World Books'),
-        'link': 'https://www.betterworldbooks.com/%s' % (
-            ('product/detail/-%s' % isbn)
-            if isbn
-            else ('search/results?q=' + title.replace(' ', '%20'))
-        ),
-        'price_note': _(' - includes shipping'),
-        'price': bwb_metadata and bwb_metadata.get('price'),
+        "key": "betterworldbooks",
+        "analytics_key": "BetterWorldBooks",
+        "name": _("Better World Books"),
+        "link": "https://www.betterworldbooks.com/%s" % (("product/detail/-%s" % isbn) if isbn else ("search/results?q=" + title.replace(" ", "%20"))),
+        "price_note": _(" - includes shipping"),
+        "price": bwb_metadata and bwb_metadata.get("price"),
     }
 
     amazon: dict | None = (
         {
-            'key': 'amazon',
-            'analytics_key': 'Amazon',
-            'name': _('Amazon'),
-            'link': 'https://www.amazon.com/dp/%s/?tag=%s'
-            % (asin or isbn, affiliate_id('amazon')),
-            'price': (bwb_metadata and bwb_metadata.get('market_price'))
-            or (amz_metadata and amz_metadata.get('price')),
+            "key": "amazon",
+            "analytics_key": "Amazon",
+            "name": _("Amazon"),
+            "link": "https://www.amazon.com/dp/%s/?tag=%s" % (asin or isbn, affiliate_id("amazon")),
+            "price": (bwb_metadata and bwb_metadata.get("market_price")) or (amz_metadata and amz_metadata.get("price")),
         }
         if (asin or isbn)
         else None
@@ -261,19 +255,18 @@ def build_affiliate_stores(
 
     bookshop: dict | None = (
         {
-            'key': 'bookshop-org',
-            'analytics_key': 'BookshopOrg',
-            'name': _('Bookshop.org'),
-            'link': 'https://bookshop.org/a/%s/%s'
-            % (affiliate_id('bookshop-org'), isbn),
+            "key": "bookshop-org",
+            "analytics_key": "BookshopOrg",
+            "name": _("Bookshop.org"),
+            "link": "https://bookshop.org/a/%s/%s" % (affiliate_id("bookshop-org"), isbn),
         }
         if isbn
         else None
     )
 
     return {
-        'primary_stores': [s for s in [bwb, amazon] if s],
-        'more_stores': [s for s in [bookshop] if s],
+        "primary_stores": [s for s in [bwb, amazon] if s],
+        "more_stores": [s for s in [bookshop] if s],
     }
 
 

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -10,6 +10,7 @@ from infogami.utils.view import public, render_template
 from openlibrary.accounts import get_current_user
 from openlibrary.core import cache
 from openlibrary.core.fulltext import fulltext_search_async
+from openlibrary.core.helpers import affiliate_id
 from openlibrary.core.lending import compose_ia_url, get_available_async
 from openlibrary.core.vendors import (
     get_amazon_metadata,
@@ -215,6 +216,65 @@ class CarouselCardPartial:
             request_label="BOOK_CAROUSEL",
         )
         return subject.get("works", [])
+
+
+def build_affiliate_stores(
+    title: str,
+    opts: dict,
+    bwb_metadata: dict | None = None,
+    amz_metadata: dict | None = None,
+) -> dict:
+    """Build affiliate store data for rendering in AffiliateLinks.html.
+
+    Accepts title, opts, and optional price metadata.
+    Returns a dict with primary_stores and more_stores lists.
+    """
+    isbn = opts.get('isbn', '')
+    asin = opts.get('asin', '')
+
+    bwb: dict = {
+        'key': 'betterworldbooks',
+        'analytics_key': 'BetterWorldBooks',
+        'name': _('Better World Books'),
+        'link': 'https://www.betterworldbooks.com/%s' % (
+            ('product/detail/-%s' % isbn)
+            if isbn
+            else ('search/results?q=' + title.replace(' ', '%20'))
+        ),
+        'price_note': _(' - includes shipping'),
+        'price': bwb_metadata and bwb_metadata.get('price'),
+    }
+
+    amazon: dict | None = (
+        {
+            'key': 'amazon',
+            'analytics_key': 'Amazon',
+            'name': _('Amazon'),
+            'link': 'https://www.amazon.com/dp/%s/?tag=%s'
+            % (asin or isbn, affiliate_id('amazon')),
+            'price': (bwb_metadata and bwb_metadata.get('market_price'))
+            or (amz_metadata and amz_metadata.get('price')),
+        }
+        if (asin or isbn)
+        else None
+    )
+
+    bookshop: dict | None = (
+        {
+            'key': 'bookshop-org',
+            'analytics_key': 'BookshopOrg',
+            'name': _('Bookshop.org'),
+            'link': 'https://bookshop.org/a/%s/%s'
+            % (affiliate_id('bookshop-org'), isbn),
+        }
+        if isbn
+        else None
+    )
+
+    return {
+        'primary_stores': [s for s in [bwb, amazon] if s],
+        'more_stores': [s for s in [bookshop] if s],
+    }
 
 
 class AffiliateLinksPartial:
@@ -469,6 +529,7 @@ gather_lazy_carousel_data = async_bridge.wrap(gather_lazy_carousel_data_async, "
 
 # Expose this publicly for the template
 public(gather_lazy_carousel_data)
+public(build_affiliate_stores)
 
 
 def setup():

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -236,8 +236,7 @@ def build_affiliate_stores(
         "key": "betterworldbooks",
         "analytics_key": "BetterWorldBooks",
         "name": _("Better World Books"),
-        "link": "https://www.betterworldbooks.com/%s"
-        % (("product/detail/-%s" % isbn) if isbn else ("search/results?q=" + quote_plus(title))),
+        "link": "https://www.betterworldbooks.com/%s" % (("product/detail/-%s" % isbn) if isbn else ("search/results?q=" + quote_plus(title))),
         "price_note": _(" - includes shipping"),
         "price": bwb_metadata and bwb_metadata.get("price"),
     }

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from hashlib import md5
 from typing import Literal, NotRequired, TypedDict
-from urllib.parse import parse_qs, quote
+from urllib.parse import parse_qs, quote, quote_plus
 
 import web
 from pydantic import BaseModel
@@ -236,7 +236,8 @@ def build_affiliate_stores(
         "key": "betterworldbooks",
         "analytics_key": "BetterWorldBooks",
         "name": _("Better World Books"),
-        "link": "https://www.betterworldbooks.com/%s" % (("product/detail/-%s" % isbn) if isbn else ("search/results?q=" + title.replace(" ", "%20"))),
+        "link": "https://www.betterworldbooks.com/%s"
+        % (("product/detail/-%s" % isbn) if isbn else ("search/results?q=" + quote_plus(title))),
         "price_note": _(" - includes shipping"),
         "price": bwb_metadata and bwb_metadata.get("price"),
     }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Part of #12678 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR is Phase 2 of #12678 and moves the affiliate store calculation logic from AffiliateLinks.html into a Python function in partials.py.


### Technical
<!-- What should be noted about the implementation? -->

- Add build_affiliate_stores() function in partials.py accepting title, opts, bwb_metadata, amz_metadata
- Expose build_affiliate_stores via public() so templates can access it
- Simplify AffiliateLinks.html to just render.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

- Go to any book edition page e.g. `http://localhost:8080/works/OL45310W/Robinson_Crusoe?edition=key:/books/OL24152177M`
- Scroll to "Buy this book" and verify store links render correctly

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
