### PR TITLE
Avoid `AttributeError` on add book action

### DIFF
--- a/openlibrary/templates/books/check.html
+++ b/openlibrary/templates/books/check.html
@@ -29,7 +29,7 @@ $var title: $_("Add a book")
                             $for a in work.authors:
                                 $a.name$cond(not loop.last, ',')
                         </span>
-                        <span class="resultPublisher">$ungettext('%(count)s edition', '%(count)s editions', work.edition_count, count=commify(work.edition_count))
+                        <span class="resultPublisher">$ungettext('%(count)s edition', '%(count)s editions', work.edition_count or 0, count=commify(work.edition_count))
                         $if work.first_publish_year:
                             <span class="smallest">&bull;</span> $_('First published in %(year)d', year=work.first_publish_year)
                         </span>

--- a/openlibrary/templates/books/check.html
+++ b/openlibrary/templates/books/check.html
@@ -29,7 +29,8 @@ $var title: $_("Add a book")
                             $for a in work.authors:
                                 $a.name$cond(not loop.last, ',')
                         </span>
-                        <span class="resultPublisher">$ungettext('%(count)s edition', '%(count)s editions', work.edition_count or 0, count=commify(work.edition_count))
+                        $ edition_count = work.get('edition_count', 0)
+                        <span class="resultPublisher">$ungettext('%(count)s edition', '%(count)s editions', edition_count, count=commify(edition_count))
                         $if work.first_publish_year:
                             <span class="smallest">&bull;</span> $_('First published in %(year)d', year=work.first_publish_year)
                         </span>


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
A librarian has reported hitting an `AttributeError` when adding a new book written by author [`/authors/OL35793A`](https://openlibrary.org/authors/OL35793A/Richard_Phillips_Feynman).  The error is thrown when a non-existent work `edition_key` is accessed while rendering the `books/check.html` template.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
