### PR TITLE
Delete unused search_amazon stub (#12732)

### DIFF
--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -601,16 +601,6 @@ def get_amazon_metadata(
     )
 
 
-def search_amazon(title: str = "", author: str = "") -> dict:  # type: ignore[empty-body]
-    """Uses the Amazon Product Advertising API ItemSearch operation to search for
-    books by author and/or title.
-    https://docs.aws.amazon.com/AWSECommerceService/latest/DG/ItemSearch.html
-    XXX! Broken while migrating from paapi 4.0 to 5.0
-    :return: dict of "results", a list of one or more found books, with metadata.
-    """
-    pass
-
-
 def _get_amazon_metadata(
     id_: str,
     id_type: Literal["asin", "isbn"] = "isbn",


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #12732

Deletes an unused empty function called `search_amazon` from `openlibrary/core/vendors.py`.

### Technical
Deletes the `search_amazon` function from `openlibrary/core/vendors.py`.

It was an empty stub. Nothing in the code uses it. 

### Testing
1. Run `git grep -n "search_amazon"` - no results.
2. The file still loads fine. No imports were removed.

### Screenshot
N/A - no UI changes.

### Stakeholders
@RayBB


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
