### PR TITLE
Don't make solr queries for list covers when unused

### DIFF
--- a/openlibrary/core/lists/model.py
+++ b/openlibrary/core/lists/model.py
@@ -565,8 +565,11 @@ class Seed:
             return "/subjects/" + subject
 
     def get_cover(self):
-        if self.type in ["work", "edition"]:
-            doc = cast(Work | Edition, self.document)
+        if self.type == "work":
+            doc = cast(Work, self.document)
+            return doc.get_cover(use_solr=False)
+        elif self.type == "edition":
+            doc = cast(Edition, self.document)
             return doc.get_cover()
         elif self.type == "author":
             doc = cast(Author, self.document)

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -1173,7 +1173,7 @@ async def get_lists_async(keys: list[str]):
     )
     lists = cast(list[List], site.get().get_many([doc["key"] for doc in response.docs]))
 
-    return [get_list_data(lst, None) for lst in lists]
+    return [get_list_data(lst, None, include_cover_url=False) for lst in lists]
 
 
 class lists_preview(delegate.page):


### PR DESCRIPTION
Seeing fastapi saturated waiting for solr requests related to getting covers for list items:
<img width="1890" height="273" alt="image" src="https://github.com/user-attachments/assets/63ffe628-b53c-465f-91f4-2dbf73f98304" />


This appears to be because if a work on a list is missing a cover, it's fetching it from solr (which falls back to an edition cover if a work is missing one). This is bad performance-wise since it makes many one-off solr requests for even a single list. Experiment with turning it off resulted in fastapi saturation dropping greatly.

```
==> PID 1693694 <==
    _solr_data (openlibrary/plugins/upstream/models.py:586)
    __get__ (functools.py:995)
    get_covers_from_solr (openlibrary/plugins/upstream/models.py:555)
    get_covers (openlibrary/plugins/upstream/models.py:549)
    get_cover (openlibrary/plugins/upstream/models.py:594)
    get_cover (openlibrary/core/lists/model.py:570)
    _get_uncached_patron_showcase (openlibrary/core/lists/model.py:353)
    get_patron_showcase (openlibrary/core/lists/model.py:346)
==> PID 1690408 <==
    _solr_data (openlibrary/plugins/upstream/models.py:586)
    __get__ (functools.py:995)
    get_covers_from_solr (openlibrary/plugins/upstream/models.py:555)
    get_covers (openlibrary/plugins/upstream/models.py:549)
    get_cover (openlibrary/plugins/upstream/models.py:594)
    get_cover (openlibrary/core/lists/model.py:570)
    _get_default_cover_id (openlibrary/core/lists/model.py:328)
    func (openlibrary/core/cache.py:499)
    get_default_cover (openlibrary/core/lists/model.py:335)
    get_list_data (openlibrary/plugins/openlibrary/lists.py:255)
    get_lists_async (openlibrary/plugins/openlibrary/lists.py:1120)
    generate_async (openlibrary/plugins/openlibrary/partials.py:332)
    book_page_lists_partial (partials.py:82)
==> PID 1688898 <==
    _solr_data (openlibrary/plugins/upstream/models.py:586)
    __get__ (functools.py:995)
    get_covers_from_solr (openlibrary/plugins/upstream/models.py:555)
    get_covers (openlibrary/plugins/upstream/models.py:549)
    get_cover (openlibrary/plugins/upstream/models.py:594)
    get_cover (openlibrary/core/lists/model.py:570)
    _get_uncached_patron_showcase (openlibrary/core/lists/model.py:353)
    get_patron_showcase (openlibrary/core/lists/model.py:346)
    func (openlibrary/core/cache.py:499)
    list_card (list_follow.html:18)
    __template__ (list_follow.html:90)
    __call__ (web/template.py:884)
    __call__ (web/template.py:991)
    saferender (infogami/utils/template.py:157)
    g (infogami/utils/template.py:139)
    <lambda> (infogami/utils/template.py:116)
    render_template (openlibrary/app.py:70)
    __template__ (carousel.html:11)
    __call__ (web/template.py:884)
    __call__ (web/template.py:991)
    saferender (infogami/utils/template.py:157)
    g (infogami/utils/template.py:139)
    <lambda> (infogami/utils/template.py:116)
    render_template (infogami/utils/template.py:218)
    generate_async (openlibrary/plugins/openlibrary/partials.py:340)
    book_page_lists_partial (partials.py:82)
```

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

- Confirmed list carousel on book page works
- Confirmed list carousel on my books page works
- Confirmed old-style list cards on /lists work

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
