### PR TITLE
Prevent FastAPI login handler from redirecting off site

### DIFF
--- a/openlibrary/fastapi/account.py
+++ b/openlibrary/fastapi/account.py
@@ -9,9 +9,9 @@ from typing import Annotated
 from urllib.parse import unquote, urlparse
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Request, Response, status
-from infogami import config
 from pydantic import BaseModel, Field
 
+from infogami import config
 from openlibrary.accounts.model import audit_accounts, generate_login_code_for_user
 from openlibrary.core import stats
 from openlibrary.fastapi.auth import (

--- a/openlibrary/fastapi/account.py
+++ b/openlibrary/fastapi/account.py
@@ -6,12 +6,12 @@ from __future__ import annotations
 
 import os
 from typing import Annotated
-from urllib.parse import unquote
+from urllib.parse import unquote, urlparse
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Request, Response, status
+from infogami import config
 from pydantic import BaseModel, Field
 
-from infogami import config
 from openlibrary.accounts.model import audit_accounts, generate_login_code_for_user
 from openlibrary.core import stats
 from openlibrary.fastapi.auth import (
@@ -24,6 +24,14 @@ from openlibrary.plugins.upstream.account import get_login_error
 router = APIRouter()
 
 SHOW_INTERNAL_IN_SCHEMA = os.getenv("LOCAL_DEV") is not None
+
+
+def _safe_redirect(url: str, default: str = "/") -> str:
+    """Return url only if it is a same-origin path; fall back to default."""
+    parsed = urlparse(url)
+    if parsed.scheme or parsed.netloc or not url.startswith("/") or url.startswith("//"):
+        return default
+    return url
 
 
 class AuthTestResponse(BaseModel):
@@ -203,7 +211,7 @@ async def login(
     # Create response with redirect
     response = Response(
         status_code=status.HTTP_303_SEE_OTHER,
-        headers={"Location": form_data.redirect},
+        headers={"Location": _safe_redirect(form_data.redirect)},
     )
 
     # Set session cookie (same as web.py)
@@ -212,7 +220,8 @@ async def login(
         login_code,
         max_age=expires,
         httponly=True,
-        secure=False,
+        secure=True,
+        samesite="lax",
     )
 
     # Set print disability flag if user has special access

--- a/openlibrary/fastapi/account.py
+++ b/openlibrary/fastapi/account.py
@@ -220,7 +220,7 @@ async def login(
         login_code,
         max_age=expires,
         httponly=True,
-        secure=True,
+        secure=request.url.scheme == "https",
         samesite="lax",
     )
 


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
The redirect form field was passed directly into the Location header with no validation, allowing open redirect to arbitrary external URLs.

_safe_redirect() now rejects any URL with a scheme, netloc, or leading // — falling back to /. Same-origin paths pass through unchanged.

Also fixes secure=False on the session cookie (authn-011) and adds SameSite=lax to match security best practices.

Addresses GHSA-22xr-xvw5-m2r9

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
