### PR TITLE
Add image template: Generalise wording to apply to authors also

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -4911,7 +4911,7 @@ msgstr ""
 
 #: covers/external_image.html
 #, python-format
-msgid "Or, use a cover from %s"
+msgid "Or, use an image from %s"
 msgstr ""
 
 #: covers/manage.html

--- a/openlibrary/templates/covers/external_image.html
+++ b/openlibrary/templates/covers/external_image.html
@@ -3,7 +3,7 @@ $def with (action, image_urls, source_name, existing_urls)
 $if set(image_urls) - existing_urls:
     <form class="ol-cover-form ol-cover-form--external" method="post" enctype="multipart/form-data" action="$action">
         <div class="label">
-            <label>$_("Or, use a cover from %s", source_name)</label>
+            <label>$_("Or, use an image from %s", source_name)</label>
         </div>
         <div class="input-container">
             $for url in image_urls:


### PR DESCRIPTION
this matches other language on the page, e.g. "paste an image from clipboard", not a "cover from clipboard"

Sometimes the correct image will be a title page (for older books), so the internal 'cover' naming isn't perfect either.

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
