### PR TITLE
migrate import_preview_json to FastAPI

### DIFF
--- a/openlibrary/asgi_app.py
+++ b/openlibrary/asgi_app.py
@@ -215,6 +215,7 @@ def create_app() -> FastAPI | None:
     from openlibrary.fastapi.books import router as books_router
     from openlibrary.fastapi.cdn import router as cdn_router
     from openlibrary.fastapi.checkins import router as checkins_router
+    from openlibrary.fastapi.importapi import router as importapi_router
     from openlibrary.fastapi.internal.api import router as internal_router
     from openlibrary.fastapi.languages import router as languages_router
     from openlibrary.fastapi.lists import router as lists_router
@@ -232,6 +233,7 @@ def create_app() -> FastAPI | None:
     app.include_router(books_router)
     app.include_router(cdn_router)
     app.include_router(checkins_router)
+    app.include_router(importapi_router)
     app.include_router(internal_router)
     app.include_router(languages_router)
     app.include_router(lists_router)

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -38,7 +38,6 @@ import requests
 import web
 
 from infogami import config
-from openlibrary.utils.request_context import site
 from openlibrary import accounts
 from openlibrary.catalog.add_book.load_book import (
     author_import_record_to_author,
@@ -63,6 +62,7 @@ from openlibrary.plugins.upstream.utils import safeget, setup_requests, strip_ac
 from openlibrary.utils import dicthash, uniq
 from openlibrary.utils.isbn import normalize_isbn
 from openlibrary.utils.lccn import normalize_lccn
+from openlibrary.utils.request_context import site
 
 if TYPE_CHECKING:
     from openlibrary.plugins.upstream.models import Edition

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -38,6 +38,7 @@ import requests
 import web
 
 from infogami import config
+from openlibrary.utils.request_context import site
 from openlibrary import accounts
 from openlibrary.catalog.add_book.load_book import (
     author_import_record_to_author,
@@ -207,9 +208,9 @@ def find_matching_work(e):
     seen = set()
     for a in e["authors"]:
         q = {"type": "/type/work", "authors": {"author": {"key": a["key"]}}}
-        work_keys = list(web.ctx.site.things(q))
+        work_keys = list(site.get().things(q))
         for wkey in work_keys:
-            w = web.ctx.site.get(wkey)
+            w = site.get().get(wkey)
             if wkey in seen:
                 continue
             seen.add(wkey)
@@ -237,7 +238,7 @@ def load_author_import_records(authors_in, edits, source, save: bool = True):
         new_author = "key" not in a
         if new_author:
             if save:
-                a["key"] = web.ctx.site.new_key("/type/author")
+                a["key"] = site.get().new_key("/type/author")
             else:
                 a["key"] = f"/authors/__new__{uuid.uuid4()}"
             a["source_records"] = [source]
@@ -280,7 +281,7 @@ def new_work(edition: dict, rec: dict, cover_id: int | None = None, save: bool =
         w["description"] = {"type": "/type/text", "value": rec["description"]}
 
     if save:
-        w["key"] = web.ctx.site.new_key("/type/work")
+        w["key"] = site.get().new_key("/type/work")
     else:
         w["key"] = f"/works/__new__{uuid.uuid4()}"
 
@@ -381,7 +382,7 @@ def update_ia_metadata_for_ol_edition(edition_id):
 
     data = {"error": "No qualifying edition"}
     if edition_id:
-        ed = web.ctx.site.get(f"/books/{edition_id}")
+        ed = site.get().get(f"/books/{edition_id}")
         if ed.ocaid:
             work = ed.works[0] if ed.get("works") else None
             if work and work.key:
@@ -525,7 +526,7 @@ def editions_matched(rec: dict, key: str, value=None) -> list[str]:
 
     q = {"type": "/type/edition", key: value}
 
-    ekeys = list(web.ctx.site.things(q))
+    ekeys = list(site.get().things(q))
     return ekeys
 
 
@@ -544,7 +545,7 @@ def find_threshold_match(rec: dict, edition_pool: dict[str, list[str]]) -> str |
             thing = None
             while not thing or is_redirect(thing):
                 seen.add(edition_key)
-                thing = web.ctx.site.get(edition_key)
+                thing = site.get().get(edition_key)
                 if thing is None:
                     break
                 if is_redirect(thing):
@@ -634,7 +635,7 @@ def load_data(  # noqa: PLR0912, PLR0915
     edition_key = edition.get("key")
     if not edition_key:
         if save:
-            edition_key = web.ctx.site.new_key("/type/edition")
+            edition_key = site.get().new_key("/type/edition")
         else:
             edition_key = f"/books/__new__{uuid.uuid4()}"
 
@@ -676,7 +677,7 @@ def load_data(  # noqa: PLR0912, PLR0915
     if not work_key and "authors" in edition:
         work_key = find_matching_work(edition)
     if work_key:
-        work = web.ctx.site.get(work_key)
+        work = site.get().get(work_key)
         work_state = "matched"
         need_update = False
         for k in subject_fields:
@@ -708,7 +709,7 @@ def load_data(  # noqa: PLR0912, PLR0915
     if save:
         comment = "overwrite existing edition" if existing_edition else "import new book"
         action = "edit-book" if existing_edition else "add-book"
-        web.ctx.site.save_many(edits, comment=comment, action=action)
+        site.get().save_many(edits, comment=comment, action=action)
 
         # Writes back `openlibrary_edition` and `openlibrary_work` to
         # archive.org item after successful import:
@@ -986,14 +987,14 @@ def load(
     # We have an edition match at this point
     need_work_save = need_edition_save = False
     work: dict[str, Any]
-    existing_edition: Edition = web.ctx.site.get(match)
+    existing_edition: Edition = site.get().get(match)
 
     # check for, and resolve, author redirects
     for a in existing_edition.authors:
         while is_redirect(a):
             if a in existing_edition.authors:
                 existing_edition.authors.remove(a)
-            a = web.ctx.site.get(a.location)
+            a = site.get().get(a.location)
             if not is_redirect(a):
                 existing_edition.authors.append(a)
 
@@ -1039,7 +1040,7 @@ def load(
 
     if save:
         if edits:
-            web.ctx.site.save_many(edits, comment="import existing book", action="edit-book")
+            site.get().save_many(edits, comment="import existing book", action="edit-book")
         if "ocaid" in rec:
             update_ia_metadata_for_ol_edition(match.split("/")[-1])
 

--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -1,10 +1,7 @@
 import logging
 from typing import TYPE_CHECKING, Any, Final, NotRequired, TypedDict, cast
 
-import web
 from pydantic import TypeAdapter, ValidationError
-
-from openlibrary.utils.request_context import site
 
 from openlibrary.catalog.utils import (
     author_dates_match,
@@ -14,6 +11,7 @@ from openlibrary.catalog.utils import (
 )
 from openlibrary.core.helpers import extract_year
 from openlibrary.utils import extract_numeric_id_from_olid, uniq
+from openlibrary.utils.request_context import site
 
 if TYPE_CHECKING:
     from openlibrary.plugins.upstream.models import Author

--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING, Any, Final, NotRequired, TypedDict, cast
 import web
 from pydantic import TypeAdapter, ValidationError
 
+from openlibrary.utils.request_context import site
+
 from openlibrary.catalog.utils import (
     author_dates_match,
     flip_name,
@@ -174,7 +176,7 @@ def find_author(author: AuthorImportDict) -> list[Author]:
         seen.add(obj["key"])
         while obj["type"]["key"] == "/type/redirect":
             assert obj["location"] != obj["key"]
-            obj = web.ctx.site.get(obj["location"])
+            obj = site.get().get(obj["location"])
             seen.add(obj["key"])
         return obj
 
@@ -187,7 +189,7 @@ def find_author(author: AuthorImportDict) -> list[Author]:
         return authors
 
     # Look for OL ID first.
-    if (key := author.get("key")) and (record := web.ctx.site.get(key)):
+    if (key := author.get("key")) and (record := site.get().get(key)):
         # Always match on OL ID, even if remote identifiers don't match.
         return get_redirected_authors([record])
 
@@ -199,8 +201,8 @@ def find_author(author: AuthorImportDict) -> list[Author]:
         for identifier, val in remote_ids.items():
             queries.append({"type": "/type/author", f"remote_ids.{identifier}": val})
         for query in queries:
-            if reply := list(web.ctx.site.things(query)):
-                matched_authors.extend(get_redirected_authors(list(web.ctx.site.get_many(reply))))
+            if reply := list(site.get().things(query)):
+                matched_authors.extend(get_redirected_authors(list(site.get().get_many(reply))))
         matched_authors = uniq(matched_authors, key=lambda thing: thing.key)
         # The match is whichever one has the most identifiers in common
         if matched_authors:
@@ -232,8 +234,8 @@ def find_author(author: AuthorImportDict) -> list[Author]:
             },  # Use `-1` to ensure an empty string from extract_year doesn't match empty dates.
         ]
         for query in queries:
-            if reply := list(web.ctx.site.things(query)):
-                things += get_redirected_authors(list(web.ctx.site.get_many(reply)))
+            if reply := list(site.get().things(query)):
+                things += get_redirected_authors(list(site.get().get_many(reply)))
                 break
     match = []
     seen = set()

--- a/openlibrary/fastapi/auth.py
+++ b/openlibrary/fastapi/auth.py
@@ -16,6 +16,7 @@ from fastapi.security import APIKeyCookie
 from pydantic import BaseModel, Field
 
 from infogami import config
+from openlibrary.accounts import get_current_user
 from openlibrary.accounts.model import get_secret_key, verify_hash
 
 logger = logging.getLogger(__name__)
@@ -136,3 +137,31 @@ async def require_authenticated_user(
         )
 
     return user
+
+
+async def require_librarian(
+    _: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],
+) -> AuthenticatedUser:
+    """FastAPI dependency that requires librarian-level access.
+
+    Checks that the authenticated user has admin, librarian, or super-librarian role.
+    Returns 403 if the user lacks sufficient permissions.
+
+    Usage:
+        @router.get("/protected")
+        async def protected_route(
+            _: Annotated[AuthenticatedUser, Depends(require_librarian)],
+        ):
+            return {"message": "You have librarian access!"}
+    """
+    user = get_current_user()
+    if not (user and (user.is_admin() or user.is_librarian() or user.is_super_librarian())):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Insufficient permissions",
+        )
+
+    return _
+
+
+LibrarianDep = Annotated[AuthenticatedUser, Depends(require_librarian)]

--- a/openlibrary/fastapi/importapi.py
+++ b/openlibrary/fastapi/importapi.py
@@ -37,12 +37,14 @@ def _build_preview_response(
 ) -> dict:
     """Shared logic for GET and POST import preview handlers."""
     try:
-        req = ImportPreviewRequest.from_input({
-            "source": source,
-            "provider": provider,
-            "identifier": identifier,
-            "save": "true" if save else "false",
-        })
+        req = ImportPreviewRequest.from_input(
+            {
+                "source": source,
+                "provider": provider,
+                "identifier": identifier,
+                "save": "true" if save else "false",
+            }
+        )
     except ValueError as e:
         return {"success": False, "error": str(e)}
 
@@ -51,15 +53,24 @@ def _build_preview_response(
 
 @router.get("/import/preview")
 def import_preview_json_get(
-    source: Annotated[str | None, Query(
-        description="Source in format 'provider:identifier' (e.g. 'amazon:ASIN')",
-    )] = None,
-    provider: Annotated[str | None, Query(
-        description="Metadata provider: amazon, ia, or marc",
-    )] = None,
-    identifier: Annotated[str | None, Query(
-        description="Identifier for the given provider",
-    )] = None,
+    source: Annotated[
+        str | None,
+        Query(
+            description="Source in format 'provider:identifier' (e.g. 'amazon:ASIN')",
+        ),
+    ] = None,
+    provider: Annotated[
+        str | None,
+        Query(
+            description="Metadata provider: amazon, ia, or marc",
+        ),
+    ] = None,
+    identifier: Annotated[
+        str | None,
+        Query(
+            description="Identifier for the given provider",
+        ),
+    ] = None,
     _: Annotated[None, Depends(check_import_permission)] = None,
 ) -> dict:
     """

--- a/openlibrary/fastapi/importapi.py
+++ b/openlibrary/fastapi/importapi.py
@@ -51,7 +51,7 @@ def _build_preview_response(
     return dict(req.metadata_provider.do_import(req.identifier, req.save))
 
 
-@router.get("/import/preview")
+@router.get("/import/preview.json")
 def import_preview_json_get(
     source: Annotated[
         str | None,
@@ -81,7 +81,7 @@ def import_preview_json_get(
     return _build_preview_response(source, provider, identifier, save=False)
 
 
-@router.post("/import/preview")
+@router.post("/import/preview.json")
 def import_preview_json_post(
     source: Annotated[str | None, Form()] = None,
     provider: Annotated[str | None, Form()] = None,

--- a/openlibrary/fastapi/importapi.py
+++ b/openlibrary/fastapi/importapi.py
@@ -6,27 +6,14 @@ from __future__ import annotations
 
 from typing import Annotated
 
-import web
-from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request, status
+from fastapi import APIRouter, Depends, Form, HTTPException, Query, status
 
 from openlibrary.accounts import get_current_user
 from openlibrary.fastapi.auth import AuthenticatedUser, require_authenticated_user
 from openlibrary.plugins.importapi.import_ui import ImportPreviewRequest
-from openlibrary.utils.request_context import site, web_ctx_ip
+from openlibrary.utils.request_context import req_context, web_ctx_ip
 
 router = APIRouter(tags=["import"])
-
-
-def _client_ip(request: Request) -> str:
-    forwarded = request.headers.get("X-Forwarded-For")
-    if forwarded:
-        return forwarded.split(",")[0].strip()
-    real_ip = request.headers.get("X-Real-IP")
-    if real_ip:
-        return real_ip.strip()
-    if request.client:
-        return request.client.host
-    return "127.0.0.1"
 
 
 def _build_preview_response(
@@ -34,10 +21,8 @@ def _build_preview_response(
     provider: str | None,
     identifier: str | None,
     save: bool,
-    request: Request,
+    client_ip: str,
 ) -> dict:
-    web.ctx.site = site.get()
-
     try:
         req = ImportPreviewRequest.from_input(
             {
@@ -50,13 +35,12 @@ def _build_preview_response(
     except ValueError as e:
         return {"success": False, "error": str(e)}
 
-    with web_ctx_ip(_client_ip(request)):
+    with web_ctx_ip(client_ip):
         return dict(req.metadata_provider.do_import(req.identifier, req.save))
 
 
 @router.get("/import/preview.json")
 def import_preview_json_get(
-    request: Request,
     _: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],
     source: Annotated[
         str | None,
@@ -88,12 +72,13 @@ def import_preview_json_get(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Insufficient permissions",
         )
-    return _build_preview_response(source, provider, identifier, save=False, request=request)
+    x_fwd = req_context.get().x_forwarded_for
+    client_ip = x_fwd.split(",")[0].strip() if x_fwd else "127.0.0.1"
+    return _build_preview_response(source, provider, identifier, save=False, client_ip=client_ip)
 
 
 @router.post("/import/preview.json")
 def import_preview_json_post(
-    request: Request,
     _: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],
     source: Annotated[str | None, Form()] = None,
     provider: Annotated[str | None, Form()] = None,
@@ -111,4 +96,6 @@ def import_preview_json_post(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Insufficient permissions",
         )
-    return _build_preview_response(source, provider, identifier, save=save, request=request)
+    x_fwd = req_context.get().x_forwarded_for
+    client_ip = x_fwd.split(",")[0].strip() if x_fwd else "127.0.0.1"
+    return _build_preview_response(source, provider, identifier, save=save, client_ip=client_ip)

--- a/openlibrary/fastapi/importapi.py
+++ b/openlibrary/fastapi/importapi.py
@@ -1,0 +1,86 @@
+"""
+FastAPI endpoints for import preview.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Form, HTTPException, Query, status
+
+from openlibrary.accounts import get_current_user
+from openlibrary.plugins.importapi.import_ui import ImportPreviewRequest
+
+router = APIRouter(tags=["import"])
+
+
+def check_import_permission() -> None:
+    """Check that the current user has admin/librarian/super-librarian role."""
+    user = get_current_user()
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication required",
+        )
+    if not (user.is_admin() or user.is_librarian() or user.is_super_librarian()):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Insufficient permissions",
+        )
+
+
+def _build_preview_response(
+    source: str | None,
+    provider: str | None,
+    identifier: str | None,
+    save: bool,
+) -> dict:
+    """Shared logic for GET and POST import preview handlers."""
+    try:
+        req = ImportPreviewRequest.from_input({
+            "source": source,
+            "provider": provider,
+            "identifier": identifier,
+            "save": "true" if save else "false",
+        })
+    except ValueError as e:
+        return {"success": False, "error": str(e)}
+
+    return dict(req.metadata_provider.do_import(req.identifier, req.save))
+
+
+@router.get("/import/preview")
+def import_preview_json_get(
+    source: Annotated[str | None, Query(
+        description="Source in format 'provider:identifier' (e.g. 'amazon:ASIN')",
+    )] = None,
+    provider: Annotated[str | None, Query(
+        description="Metadata provider: amazon, ia, or marc",
+    )] = None,
+    identifier: Annotated[str | None, Query(
+        description="Identifier for the given provider",
+    )] = None,
+    _: Annotated[None, Depends(check_import_permission)] = None,
+) -> dict:
+    """
+    Preview import metadata without saving.
+
+    Requires admin, librarian, or super-librarian role.
+    """
+    return _build_preview_response(source, provider, identifier, save=False)
+
+
+@router.post("/import/preview")
+def import_preview_json_post(
+    source: Annotated[str | None, Form()] = None,
+    provider: Annotated[str | None, Form()] = None,
+    identifier: Annotated[str | None, Form()] = None,
+    save: Annotated[bool, Form()] = False,
+    _: Annotated[None, Depends(check_import_permission)] = None,
+) -> dict:
+    """
+    Import metadata, optionally saving it.
+
+    Requires admin, librarian, or super-librarian role.
+    """
+    return _build_preview_response(source, provider, identifier, save=save)

--- a/openlibrary/fastapi/importapi.py
+++ b/openlibrary/fastapi/importapi.py
@@ -6,10 +6,9 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Form, HTTPException, Query, status
+from fastapi import APIRouter, Form, Query
 
-from openlibrary.accounts import get_current_user
-from openlibrary.fastapi.auth import AuthenticatedUser, require_authenticated_user
+from openlibrary.fastapi.auth import LibrarianDep  # noqa: TC001
 from openlibrary.plugins.importapi.import_ui import ImportPreviewRequest
 from openlibrary.utils.request_context import req_context, web_ctx_ip
 
@@ -41,7 +40,7 @@ def _build_preview_response(
 
 @router.get("/import/preview.json")
 def import_preview_json_get(
-    _: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],
+    _: LibrarianDep,
     source: Annotated[
         str | None,
         Query(
@@ -66,12 +65,6 @@ def import_preview_json_get(
 
     Requires admin, librarian, or super-librarian role.
     """
-    user = get_current_user()
-    if not (user and (user.is_admin() or user.is_librarian() or user.is_super_librarian())):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Insufficient permissions",
-        )
     x_fwd = req_context.get().x_forwarded_for
     client_ip = x_fwd.split(",")[0].strip() if x_fwd else "127.0.0.1"
     return _build_preview_response(source, provider, identifier, save=False, client_ip=client_ip)
@@ -79,7 +72,7 @@ def import_preview_json_get(
 
 @router.post("/import/preview.json")
 def import_preview_json_post(
-    _: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],
+    _: LibrarianDep,
     source: Annotated[str | None, Form()] = None,
     provider: Annotated[str | None, Form()] = None,
     identifier: Annotated[str | None, Form()] = None,
@@ -90,12 +83,6 @@ def import_preview_json_post(
 
     Requires admin, librarian, or super-librarian role.
     """
-    user = get_current_user()
-    if not (user and (user.is_admin() or user.is_librarian() or user.is_super_librarian())):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Insufficient permissions",
-        )
     x_fwd = req_context.get().x_forwarded_for
     client_ip = x_fwd.split(",")[0].strip() if x_fwd else "127.0.0.1"
     return _build_preview_response(source, provider, identifier, save=save, client_ip=client_ip)

--- a/openlibrary/fastapi/importapi.py
+++ b/openlibrary/fastapi/importapi.py
@@ -6,27 +6,27 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Form, HTTPException, Query, status
+import web
+from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request, status
 
 from openlibrary.accounts import get_current_user
+from openlibrary.fastapi.auth import AuthenticatedUser, require_authenticated_user
 from openlibrary.plugins.importapi.import_ui import ImportPreviewRequest
+from openlibrary.utils.request_context import site, web_ctx_ip
 
 router = APIRouter(tags=["import"])
 
 
-def check_import_permission() -> None:
-    """Check that the current user has admin/librarian/super-librarian role."""
-    user = get_current_user()
-    if user is None:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Authentication required",
-        )
-    if not (user.is_admin() or user.is_librarian() or user.is_super_librarian()):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Insufficient permissions",
-        )
+def _client_ip(request: Request) -> str:
+    forwarded = request.headers.get("X-Forwarded-For")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    real_ip = request.headers.get("X-Real-IP")
+    if real_ip:
+        return real_ip.strip()
+    if request.client:
+        return request.client.host
+    return "127.0.0.1"
 
 
 def _build_preview_response(
@@ -34,8 +34,10 @@ def _build_preview_response(
     provider: str | None,
     identifier: str | None,
     save: bool,
+    request: Request,
 ) -> dict:
-    """Shared logic for GET and POST import preview handlers."""
+    web.ctx.site = site.get()
+
     try:
         req = ImportPreviewRequest.from_input(
             {
@@ -48,11 +50,14 @@ def _build_preview_response(
     except ValueError as e:
         return {"success": False, "error": str(e)}
 
-    return dict(req.metadata_provider.do_import(req.identifier, req.save))
+    with web_ctx_ip(_client_ip(request)):
+        return dict(req.metadata_provider.do_import(req.identifier, req.save))
 
 
 @router.get("/import/preview.json")
 def import_preview_json_get(
+    request: Request,
+    _: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],
     source: Annotated[
         str | None,
         Query(
@@ -71,27 +76,39 @@ def import_preview_json_get(
             description="Identifier for the given provider",
         ),
     ] = None,
-    _: Annotated[None, Depends(check_import_permission)] = None,
 ) -> dict:
     """
     Preview import metadata without saving.
 
     Requires admin, librarian, or super-librarian role.
     """
-    return _build_preview_response(source, provider, identifier, save=False)
+    user = get_current_user()
+    if not (user and (user.is_admin() or user.is_librarian() or user.is_super_librarian())):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Insufficient permissions",
+        )
+    return _build_preview_response(source, provider, identifier, save=False, request=request)
 
 
 @router.post("/import/preview.json")
 def import_preview_json_post(
+    request: Request,
+    _: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],
     source: Annotated[str | None, Form()] = None,
     provider: Annotated[str | None, Form()] = None,
     identifier: Annotated[str | None, Form()] = None,
     save: Annotated[bool, Form()] = False,
-    _: Annotated[None, Depends(check_import_permission)] = None,
 ) -> dict:
     """
     Import metadata, optionally saving it.
 
     Requires admin, librarian, or super-librarian role.
     """
-    return _build_preview_response(source, provider, identifier, save=save)
+    user = get_current_user()
+    if not (user and (user.is_admin() or user.is_librarian() or user.is_super_librarian())):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Insufficient permissions",
+        )
+    return _build_preview_response(source, provider, identifier, save=save, request=request)

--- a/openlibrary/plugins/importapi/import_ui.py
+++ b/openlibrary/plugins/importapi/import_ui.py
@@ -4,6 +4,7 @@ from typing import Literal, cast, override
 
 import requests
 import web
+from typing_extensions import deprecated
 
 from infogami.plugins.api.code import jsonapi
 from infogami.utils import delegate
@@ -62,6 +63,7 @@ class import_preview(delegate.page):
             )
 
 
+@deprecated("migrated to fastapi")
 class import_preview_json(delegate.page):
     path = "/import/preview"
     encoding = "json"

--- a/openlibrary/plugins/importapi/import_ui.py
+++ b/openlibrary/plugins/importapi/import_ui.py
@@ -1,10 +1,10 @@
 import json
 from dataclasses import dataclass
 from typing import Literal, cast, override
+from warnings import deprecated
 
 import requests
 import web
-from typing_extensions import deprecated
 
 from infogami.plugins.api.code import jsonapi
 from infogami.utils import delegate

--- a/openlibrary/tests/fastapi/test_auth.py
+++ b/openlibrary/tests/fastapi/test_auth.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Annotated
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from fastapi import Depends, FastAPI
 from fastapi.security import APIKeyCookie
@@ -11,6 +11,7 @@ from fastapi.testclient import TestClient
 
 from openlibrary.fastapi.auth import (
     AuthenticatedUser,
+    LibrarianDep,
     authenticate_user_from_cookie,
     get_authenticated_user,
     require_authenticated_user,
@@ -102,3 +103,131 @@ def test_require_authenticated_user_returns_401_with_no_cookie():
     response = client.get("/protected")
     assert response.status_code == 401
     assert response.json()["detail"] == "Authentication required"
+
+
+# ---------------------------------------------------------------------------
+# require_librarian tests
+# ---------------------------------------------------------------------------
+
+
+FAKE_AUTH_USER = AuthenticatedUser(
+    username="testuser",
+    user_key="/people/testuser",
+    timestamp="2026-01-01T00:00:00",
+)
+
+
+def _build_librarian_app():
+    """Create a minimal FastAPI app with one route protected by require_librarian."""
+    app = FastAPI()
+
+    @app.get("/librarian-only")
+    async def librarian_route(_: LibrarianDep):
+        return {"message": "access granted"}
+
+    return app
+
+
+def test_require_librarian_returns_401_with_no_cookie():
+    """require_librarian must raise HTTP 401 when the user is not authenticated."""
+    app = _build_librarian_app()
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.get("/librarian-only")
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Authentication required"
+
+
+def test_require_librarian_returns_403_for_regular_user():
+    """require_librarian must raise HTTP 403 when the user lacks librarian-level roles."""
+    app = _build_librarian_app()
+    app.dependency_overrides[require_authenticated_user] = lambda: FAKE_AUTH_USER
+
+    with patch("openlibrary.fastapi.auth.get_current_user") as mock_get_user:
+        user = MagicMock()
+        user.is_admin.return_value = False
+        user.is_librarian.return_value = False
+        user.is_super_librarian.return_value = False
+        mock_get_user.return_value = user
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get("/librarian-only")
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Insufficient permissions"
+
+    app.dependency_overrides.clear()
+
+
+def test_require_librarian_allows_admin():
+    """require_librarian allows access for admin users."""
+    app = _build_librarian_app()
+    app.dependency_overrides[require_authenticated_user] = lambda: FAKE_AUTH_USER
+
+    with patch("openlibrary.fastapi.auth.get_current_user") as mock_get_user:
+        user = MagicMock()
+        user.is_admin.return_value = True
+        user.is_librarian.return_value = False
+        user.is_super_librarian.return_value = False
+        mock_get_user.return_value = user
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get("/librarian-only")
+        assert response.status_code == 200
+        assert response.json() == {"message": "access granted"}
+
+    app.dependency_overrides.clear()
+
+
+def test_require_librarian_allows_librarian():
+    """require_librarian allows access for librarian users."""
+    app = _build_librarian_app()
+    app.dependency_overrides[require_authenticated_user] = lambda: FAKE_AUTH_USER
+
+    with patch("openlibrary.fastapi.auth.get_current_user") as mock_get_user:
+        user = MagicMock()
+        user.is_admin.return_value = False
+        user.is_librarian.return_value = True
+        user.is_super_librarian.return_value = False
+        mock_get_user.return_value = user
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get("/librarian-only")
+        assert response.status_code == 200
+        assert response.json() == {"message": "access granted"}
+
+    app.dependency_overrides.clear()
+
+
+def test_require_librarian_allows_super_librarian():
+    """require_librarian allows access for super-librarian users."""
+    app = _build_librarian_app()
+    app.dependency_overrides[require_authenticated_user] = lambda: FAKE_AUTH_USER
+
+    with patch("openlibrary.fastapi.auth.get_current_user") as mock_get_user:
+        user = MagicMock()
+        user.is_admin.return_value = False
+        user.is_librarian.return_value = False
+        user.is_super_librarian.return_value = True
+        mock_get_user.return_value = user
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get("/librarian-only")
+        assert response.status_code == 200
+        assert response.json() == {"message": "access granted"}
+
+    app.dependency_overrides.clear()
+
+
+def test_require_librarian_returns_403_when_user_is_none():
+    """require_librarian returns 403 when get_current_user returns None."""
+    app = _build_librarian_app()
+    app.dependency_overrides[require_authenticated_user] = lambda: FAKE_AUTH_USER
+
+    with patch("openlibrary.fastapi.auth.get_current_user") as mock_get_user:
+        mock_get_user.return_value = None
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get("/librarian-only")
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Insufficient permissions"
+
+    app.dependency_overrides.clear()

--- a/openlibrary/tests/fastapi/test_importapi.py
+++ b/openlibrary/tests/fastapi/test_importapi.py
@@ -1,29 +1,12 @@
 """Tests for the FastAPI import preview endpoints."""
 
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock, patch
 
 import pytest
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
-
-from openlibrary.fastapi.importapi import router
 
 
 def _raise(exc: Exception) -> None:
     raise exc
-
-
-def _make_mock_user(
-    is_admin: bool = True,
-    is_librarian: bool = False,
-    is_super_librarian: bool = False,
-) -> Mock:
-    """Create a mock user with configurable role flags."""
-    user = MagicMock()
-    user.is_admin.return_value = is_admin
-    user.is_librarian.return_value = is_librarian
-    user.is_super_librarian.return_value = is_super_librarian
-    return user
 
 
 FAKE_IMPORT_RESULT = {
@@ -33,119 +16,133 @@ FAKE_IMPORT_RESULT = {
 
 
 @pytest.fixture
-def client() -> TestClient:
-    """Return a TestClient for the import preview router."""
-    app = FastAPI()
-    app.include_router(router)
-    return TestClient(app)
+def mock_site():
+    """Mock the site ContextVar to avoid real infogami connection."""
+    with patch("openlibrary.fastapi.importapi.site") as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_user_factory(mock_site, monkeypatch):
+    """Factory fixture to create and mock users with configurable roles.
+
+    Usage:
+        user = mock_user_factory(is_admin=True)
+        user = mock_user_factory(is_librarian=True)
+    """
+
+    def create_user(
+        is_admin: bool = False,
+        is_librarian: bool = False,
+        is_super_librarian: bool = False,
+    ):
+        user = MagicMock()
+        user.is_admin.return_value = is_admin
+        user.is_librarian.return_value = is_librarian
+        user.is_super_librarian.return_value = is_super_librarian
+        monkeypatch.setattr("openlibrary.fastapi.importapi.get_current_user", lambda: user)
+        return user
+
+    return create_user
+
+
+@pytest.fixture
+def mock_import_request():
+    """Return a factory that creates a mock ImportPreviewRequest."""
+
+    def _make(save: bool = False):
+        mock_req = MagicMock()
+        mock_req.metadata_provider.do_import.return_value = FAKE_IMPORT_RESULT
+        mock_req.save = save
+        return mock_req
+
+    return _make
 
 
 class TestImportPreviewAuth:
     """Authentication and authorization tests."""
 
-    def test_get_requires_authentication(self, client, monkeypatch):
-        monkeypatch.setattr(
-            "openlibrary.fastapi.importapi.get_current_user",
-            lambda: None,
-        )
-        response = client.get("/import/preview.json?source=amazon:ASIN123")
+    def test_get_requires_authentication(self, fastapi_client, mock_site):
+        response = fastapi_client.get("/import/preview.json?source=amazon:ASIN123")
         assert response.status_code == 401
 
-    def test_post_requires_authentication(self, client, monkeypatch):
-        monkeypatch.setattr(
-            "openlibrary.fastapi.importapi.get_current_user",
-            lambda: None,
+    def test_post_requires_authentication(self, fastapi_client, mock_site):
+        response = fastapi_client.post(
+            "/import/preview.json", data={"source": "amazon:ASIN123"}
         )
-        response = client.post("/import/preview.json", data={"source": "amazon:ASIN123"})
         assert response.status_code == 401
 
-    def test_get_forbidden_for_regular_user(self, client, monkeypatch):
-        monkeypatch.setattr(
-            "openlibrary.fastapi.importapi.get_current_user",
-            lambda: _make_mock_user(is_admin=False, is_librarian=False),
-        )
-        response = client.get("/import/preview.json?source=amazon:ASIN123")
+    def test_get_forbidden_for_regular_user(
+        self, fastapi_client, mock_authenticated_user, mock_user_factory
+    ):
+        mock_user_factory()
+        response = fastapi_client.get("/import/preview.json?source=amazon:ASIN123")
         assert response.status_code == 403
 
-    def test_post_forbidden_for_regular_user(self, client, monkeypatch):
-        monkeypatch.setattr(
-            "openlibrary.fastapi.importapi.get_current_user",
-            lambda: _make_mock_user(is_admin=False, is_librarian=False),
+    def test_post_forbidden_for_regular_user(
+        self, fastapi_client, mock_authenticated_user, mock_user_factory
+    ):
+        mock_user_factory()
+        response = fastapi_client.post(
+            "/import/preview.json", data={"source": "amazon:ASIN123"}
         )
-        response = client.post("/import/preview.json", data={"source": "amazon:ASIN123"})
         assert response.status_code == 403
 
-    def test_get_allows_admin(self, client, monkeypatch):
-        monkeypatch.setattr(
-            "openlibrary.fastapi.importapi.get_current_user",
-            lambda: _make_mock_user(is_admin=True),
-        )
-        mock_req = MagicMock()
-        mock_req.metadata_provider.do_import.return_value = FAKE_IMPORT_RESULT
+    def test_get_allows_admin(
+        self, fastapi_client, mock_authenticated_user, mock_user_factory, mock_import_request, monkeypatch
+    ):
+        mock_user_factory(is_admin=True)
         monkeypatch.setattr(
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
-            lambda i: mock_req,
+            lambda i: mock_import_request(),
         )
-        response = client.get("/import/preview.json?source=amazon:ASIN123")
+        response = fastapi_client.get("/import/preview.json?source=amazon:ASIN123")
         assert response.status_code == 200
 
-    def test_get_allows_librarian(self, client, monkeypatch):
-        monkeypatch.setattr(
-            "openlibrary.fastapi.importapi.get_current_user",
-            lambda: _make_mock_user(is_admin=False, is_librarian=True),
-        )
-        mock_req = MagicMock()
-        mock_req.metadata_provider.do_import.return_value = FAKE_IMPORT_RESULT
+    def test_get_allows_librarian(
+        self, fastapi_client, mock_authenticated_user, mock_user_factory, mock_import_request, monkeypatch
+    ):
+        mock_user_factory(is_librarian=True)
         monkeypatch.setattr(
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
-            lambda i: mock_req,
+            lambda i: mock_import_request(),
         )
-        response = client.get("/import/preview.json?source=amazon:ASIN123")
+        response = fastapi_client.get("/import/preview.json?source=amazon:ASIN123")
         assert response.status_code == 200
 
-    def test_get_allows_super_librarian(self, client, monkeypatch):
-        monkeypatch.setattr(
-            "openlibrary.fastapi.importapi.get_current_user",
-            lambda: _make_mock_user(is_admin=False, is_librarian=False, is_super_librarian=True),
-        )
-        mock_req = MagicMock()
-        mock_req.metadata_provider.do_import.return_value = FAKE_IMPORT_RESULT
+    def test_get_allows_super_librarian(
+        self, fastapi_client, mock_authenticated_user, mock_user_factory, mock_import_request, monkeypatch
+    ):
+        mock_user_factory(is_super_librarian=True)
         monkeypatch.setattr(
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
-            lambda i: mock_req,
+            lambda i: mock_import_request(),
         )
-        response = client.get("/import/preview.json?source=amazon:ASIN123")
+        response = fastapi_client.get("/import/preview.json?source=amazon:ASIN123")
         assert response.status_code == 200
 
 
 class TestImportPreviewGet:
     """GET /import/preview.json endpoint tests."""
 
-    def test_get_returns_import_result(self, client, monkeypatch):
-        monkeypatch.setattr(
-            "openlibrary.fastapi.importapi.get_current_user",
-            lambda: _make_mock_user(is_admin=True),
-        )
-        mock_req = MagicMock()
-        mock_req.metadata_provider.do_import.return_value = {
-            "edition": {"key": "/books/OL1M", "title": "Test Book"},
-            "success": True,
-        }
-        monkeypatch.setattr(
+    @pytest.fixture(autouse=True)
+    def _auth_setup(self, fastapi_client, mock_authenticated_user, mock_user_factory, monkeypatch):
+        self.client = fastapi_client
+        self.monkeypatch = monkeypatch
+        mock_user_factory(is_admin=True)
+
+    def test_get_returns_import_result(self, mock_import_request):
+        self.monkeypatch.setattr(
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
-            lambda i: mock_req,
+            lambda i: mock_import_request(),
         )
-        response = client.get("/import/preview.json?source=amazon:ASIN123")
+        response = self.client.get("/import/preview.json?source=amazon:ASIN123")
         assert response.status_code == 200
         data = response.json()
         assert data["success"] is True
         assert data["edition"]["key"] == "/books/OL1M"
 
-    def test_get_does_not_save(self, client, monkeypatch):
-        monkeypatch.setattr(
-            "openlibrary.fastapi.importapi.get_current_user",
-            lambda: _make_mock_user(is_admin=True),
-        )
+    def test_get_does_not_save(self):
         captured = {}
 
         def fake_from_input(i):
@@ -155,34 +152,26 @@ class TestImportPreviewGet:
             mock_req.save = False
             return mock_req
 
-        monkeypatch.setattr(
+        self.monkeypatch.setattr(
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
             fake_from_input,
         )
-        response = client.get("/import/preview.json?source=amazon:ASIN123&save=true")
+        response = self.client.get("/import/preview.json?source=amazon:ASIN123&save=true")
         assert response.status_code == 200
         assert captured["save"] == "false"
 
-    def test_get_invalid_source_returns_error(self, client, monkeypatch):
-        monkeypatch.setattr(
-            "openlibrary.fastapi.importapi.get_current_user",
-            lambda: _make_mock_user(is_admin=True),
-        )
-        monkeypatch.setattr(
+    def test_get_invalid_source_returns_error(self):
+        self.monkeypatch.setattr(
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
             lambda i: _raise(ValueError("Invalid source provided")),
         )
-        response = client.get("/import/preview.json?source=invalid")
+        response = self.client.get("/import/preview.json?source=invalid")
         assert response.status_code == 200
         data = response.json()
         assert data["success"] is False
         assert "Invalid source provided" in data["error"]
 
-    def test_get_with_provider_and_identifier(self, client, monkeypatch):
-        monkeypatch.setattr(
-            "openlibrary.fastapi.importapi.get_current_user",
-            lambda: _make_mock_user(is_admin=True),
-        )
+    def test_get_with_provider_and_identifier(self):
         captured = {}
 
         def fake_from_input(i):
@@ -192,25 +181,21 @@ class TestImportPreviewGet:
             mock_req.save = False
             return mock_req
 
-        monkeypatch.setattr(
+        self.monkeypatch.setattr(
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
             fake_from_input,
         )
-        response = client.get("/import/preview.json?provider=amazon&identifier=1234567890")
+        response = self.client.get("/import/preview.json?provider=amazon&identifier=1234567890")
         assert response.status_code == 200
         assert captured["params"]["provider"] == "amazon"
         assert captured["params"]["identifier"] == "1234567890"
 
-    def test_get_no_params_returns_error(self, client, monkeypatch):
-        monkeypatch.setattr(
-            "openlibrary.fastapi.importapi.get_current_user",
-            lambda: _make_mock_user(is_admin=True),
-        )
-        monkeypatch.setattr(
+    def test_get_no_params_returns_error(self):
+        self.monkeypatch.setattr(
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
-            lambda i: _raise(ValueError("Invalid source provided")),
+            lambda i: _raise(ValueError("No provider specified")),
         )
-        response = client.get("/import/preview.json")
+        response = self.client.get("/import/preview.json")
         assert response.status_code == 200
         data = response.json()
         assert data["success"] is False
@@ -219,25 +204,23 @@ class TestImportPreviewGet:
 class TestImportPreviewPost:
     """POST /import/preview.json endpoint tests."""
 
-    def test_post_returns_import_result(self, client, monkeypatch):
-        monkeypatch.setattr(
-            "openlibrary.fastapi.importapi.get_current_user",
-            lambda: _make_mock_user(is_admin=True),
-        )
-        mock_req = MagicMock()
-        mock_req.metadata_provider.do_import.return_value = FAKE_IMPORT_RESULT
-        monkeypatch.setattr(
+    @pytest.fixture(autouse=True)
+    def _auth_setup(self, fastapi_client, mock_authenticated_user, mock_user_factory, monkeypatch):
+        self.client = fastapi_client
+        self.monkeypatch = monkeypatch
+        mock_user_factory(is_admin=True)
+
+    def test_post_returns_import_result(self, mock_import_request):
+        self.monkeypatch.setattr(
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
-            lambda i: mock_req,
+            lambda i: mock_import_request(),
         )
-        response = client.post("/import/preview.json", data={"source": "amazon:ASIN123"})
+        response = self.client.post(
+            "/import/preview.json", data={"source": "amazon:ASIN123"}
+        )
         assert response.status_code == 200
 
-    def test_post_can_save(self, client, monkeypatch):
-        monkeypatch.setattr(
-            "openlibrary.fastapi.importapi.get_current_user",
-            lambda: _make_mock_user(is_admin=True),
-        )
+    def test_post_can_save(self):
         captured = {}
 
         def fake_from_input(i):
@@ -247,49 +230,44 @@ class TestImportPreviewPost:
             mock_req.save = captured["save"] == "true"
             return mock_req
 
-        monkeypatch.setattr(
+        self.monkeypatch.setattr(
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
             fake_from_input,
         )
-        response = client.post(
+        response = self.client.post(
             "/import/preview.json",
             data={"source": "amazon:ASIN123", "save": "true"},
         )
         assert response.status_code == 200
         assert captured["save"] == "true"
 
-    def test_post_without_save_defaults_to_false(self, client, monkeypatch):
-        monkeypatch.setattr(
-            "openlibrary.fastapi.importapi.get_current_user",
-            lambda: _make_mock_user(is_admin=True),
-        )
+    def test_post_without_save_defaults_to_false(self):
         captured = {}
 
         def fake_from_input(i):
             captured["save"] = i.get("save", "false")
             mock_req = MagicMock()
             mock_req.metadata_provider.do_import.return_value = FAKE_IMPORT_RESULT
-            mock_req.save = captured["save"] == "true"
             return mock_req
 
-        monkeypatch.setattr(
+        self.monkeypatch.setattr(
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
             fake_from_input,
         )
-        response = client.post("/import/preview.json", data={"source": "amazon:ASIN123"})
+        response = self.client.post(
+            "/import/preview.json", data={"source": "amazon:ASIN123"}
+        )
         assert response.status_code == 200
         assert captured["save"] == "false"
 
-    def test_post_invalid_source_returns_error(self, client, monkeypatch):
-        monkeypatch.setattr(
-            "openlibrary.fastapi.importapi.get_current_user",
-            lambda: _make_mock_user(is_admin=True),
-        )
-        monkeypatch.setattr(
+    def test_post_invalid_source_returns_error(self):
+        self.monkeypatch.setattr(
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
             lambda i: _raise(ValueError("Invalid source provided")),
         )
-        response = client.post("/import/preview.json", data={"source": "invalid"})
+        response = self.client.post(
+            "/import/preview.json", data={"source": "invalid"}
+        )
         assert response.status_code == 200
         data = response.json()
         assert data["success"] is False

--- a/openlibrary/tests/fastapi/test_importapi.py
+++ b/openlibrary/tests/fastapi/test_importapi.py
@@ -50,7 +50,7 @@ def mock_user_factory(monkeypatch):
         user.is_admin.return_value = is_admin
         user.is_librarian.return_value = is_librarian
         user.is_super_librarian.return_value = is_super_librarian
-        monkeypatch.setattr("openlibrary.fastapi.importapi.get_current_user", lambda: user)
+        monkeypatch.setattr("openlibrary.fastapi.auth.get_current_user", lambda: user)
         return user
 
     return create_user

--- a/openlibrary/tests/fastapi/test_importapi.py
+++ b/openlibrary/tests/fastapi/test_importapi.py
@@ -1,0 +1,305 @@
+"""Tests for the FastAPI import preview endpoints."""
+
+from unittest.mock import MagicMock, Mock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from openlibrary.fastapi.importapi import router
+
+
+def _raise(exc: Exception) -> None:
+    raise exc
+
+
+def _make_mock_user(
+    is_admin: bool = True,
+    is_librarian: bool = False,
+    is_super_librarian: bool = False,
+) -> Mock:
+    """Create a mock user with configurable role flags."""
+    user = MagicMock()
+    user.is_admin.return_value = is_admin
+    user.is_librarian.return_value = is_librarian
+    user.is_super_librarian.return_value = is_super_librarian
+    return user
+
+
+FAKE_IMPORT_RESULT = {
+    "edition": {"key": "/books/OL1M", "title": "Test Book"},
+    "success": True,
+}
+
+
+@pytest.fixture
+def client() -> TestClient:
+    """Return a TestClient for the import preview router."""
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+class TestImportPreviewAuth:
+    """Authentication and authorization tests."""
+
+    def test_get_requires_authentication(self, client, monkeypatch):
+        monkeypatch.setattr(
+            "openlibrary.fastapi.importapi.get_current_user",
+            lambda: None,
+        )
+        response = client.get("/import/preview?source=amazon:ASIN123")
+        assert response.status_code == 401
+
+    def test_post_requires_authentication(self, client, monkeypatch):
+        monkeypatch.setattr(
+            "openlibrary.fastapi.importapi.get_current_user",
+            lambda: None,
+        )
+        response = client.post("/import/preview", data={"source": "amazon:ASIN123"})
+        assert response.status_code == 401
+
+    def test_get_forbidden_for_regular_user(self, client, monkeypatch):
+        monkeypatch.setattr(
+            "openlibrary.fastapi.importapi.get_current_user",
+            lambda: _make_mock_user(is_admin=False, is_librarian=False),
+        )
+        response = client.get("/import/preview?source=amazon:ASIN123")
+        assert response.status_code == 403
+
+    def test_post_forbidden_for_regular_user(self, client, monkeypatch):
+        monkeypatch.setattr(
+            "openlibrary.fastapi.importapi.get_current_user",
+            lambda: _make_mock_user(is_admin=False, is_librarian=False),
+        )
+        response = client.post("/import/preview", data={"source": "amazon:ASIN123"})
+        assert response.status_code == 403
+
+    def test_get_allows_admin(self, client, monkeypatch):
+        monkeypatch.setattr(
+            "openlibrary.fastapi.importapi.get_current_user",
+            lambda: _make_mock_user(is_admin=True),
+        )
+        mock_req = MagicMock()
+        mock_req.metadata_provider.do_import.return_value = FAKE_IMPORT_RESULT
+        monkeypatch.setattr(
+            "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
+            lambda i: mock_req,
+        )
+        response = client.get("/import/preview?source=amazon:ASIN123")
+        assert response.status_code == 200
+
+    def test_get_allows_librarian(self, client, monkeypatch):
+        monkeypatch.setattr(
+            "openlibrary.fastapi.importapi.get_current_user",
+            lambda: _make_mock_user(is_admin=False, is_librarian=True),
+        )
+        mock_req = MagicMock()
+        mock_req.metadata_provider.do_import.return_value = FAKE_IMPORT_RESULT
+        monkeypatch.setattr(
+            "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
+            lambda i: mock_req,
+        )
+        response = client.get("/import/preview?source=amazon:ASIN123")
+        assert response.status_code == 200
+
+    def test_get_allows_super_librarian(self, client, monkeypatch):
+        monkeypatch.setattr(
+            "openlibrary.fastapi.importapi.get_current_user",
+            lambda: _make_mock_user(
+                is_admin=False, is_librarian=False, is_super_librarian=True
+            ),
+        )
+        mock_req = MagicMock()
+        mock_req.metadata_provider.do_import.return_value = FAKE_IMPORT_RESULT
+        monkeypatch.setattr(
+            "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
+            lambda i: mock_req,
+        )
+        response = client.get("/import/preview?source=amazon:ASIN123")
+        assert response.status_code == 200
+
+
+class TestImportPreviewGet:
+    """GET /import/preview endpoint tests."""
+
+    def test_get_returns_import_result(self, client, monkeypatch):
+        monkeypatch.setattr(
+            "openlibrary.fastapi.importapi.get_current_user",
+            lambda: _make_mock_user(is_admin=True),
+        )
+        mock_req = MagicMock()
+        mock_req.metadata_provider.do_import.return_value = {
+            "edition": {"key": "/books/OL1M", "title": "Test Book"},
+            "success": True,
+        }
+        monkeypatch.setattr(
+            "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
+            lambda i: mock_req,
+        )
+        response = client.get("/import/preview?source=amazon:ASIN123")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["edition"]["key"] == "/books/OL1M"
+
+    def test_get_does_not_save(self, client, monkeypatch):
+        monkeypatch.setattr(
+            "openlibrary.fastapi.importapi.get_current_user",
+            lambda: _make_mock_user(is_admin=True),
+        )
+        captured = {}
+
+        def fake_from_input(i):
+            captured["save"] = i.get("save", "false")
+            mock_req = MagicMock()
+            mock_req.metadata_provider.do_import.return_value = FAKE_IMPORT_RESULT
+            mock_req.save = False
+            return mock_req
+
+        monkeypatch.setattr(
+            "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
+            fake_from_input,
+        )
+        response = client.get("/import/preview?source=amazon:ASIN123&save=true")
+        assert response.status_code == 200
+        assert captured["save"] == "false"
+
+    def test_get_invalid_source_returns_error(self, client, monkeypatch):
+        monkeypatch.setattr(
+            "openlibrary.fastapi.importapi.get_current_user",
+            lambda: _make_mock_user(is_admin=True),
+        )
+        monkeypatch.setattr(
+            "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
+            lambda i: _raise(ValueError("Invalid source provided")),
+        )
+        response = client.get("/import/preview?source=invalid")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        assert "Invalid source provided" in data["error"]
+
+    def test_get_with_provider_and_identifier(self, client, monkeypatch):
+        monkeypatch.setattr(
+            "openlibrary.fastapi.importapi.get_current_user",
+            lambda: _make_mock_user(is_admin=True),
+        )
+        captured = {}
+
+        def fake_from_input(i):
+            captured["params"] = i
+            mock_req = MagicMock()
+            mock_req.metadata_provider.do_import.return_value = FAKE_IMPORT_RESULT
+            mock_req.save = False
+            return mock_req
+
+        monkeypatch.setattr(
+            "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
+            fake_from_input,
+        )
+        response = client.get(
+            "/import/preview?provider=amazon&identifier=1234567890"
+        )
+        assert response.status_code == 200
+        assert captured["params"]["provider"] == "amazon"
+        assert captured["params"]["identifier"] == "1234567890"
+
+    def test_get_no_params_returns_error(self, client, monkeypatch):
+        monkeypatch.setattr(
+            "openlibrary.fastapi.importapi.get_current_user",
+            lambda: _make_mock_user(is_admin=True),
+        )
+        monkeypatch.setattr(
+            "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
+            lambda i: _raise(ValueError("Invalid source provided")),
+        )
+        response = client.get("/import/preview")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+
+
+class TestImportPreviewPost:
+    """POST /import/preview endpoint tests."""
+
+    def test_post_returns_import_result(self, client, monkeypatch):
+        monkeypatch.setattr(
+            "openlibrary.fastapi.importapi.get_current_user",
+            lambda: _make_mock_user(is_admin=True),
+        )
+        mock_req = MagicMock()
+        mock_req.metadata_provider.do_import.return_value = FAKE_IMPORT_RESULT
+        monkeypatch.setattr(
+            "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
+            lambda i: mock_req,
+        )
+        response = client.post(
+            "/import/preview", data={"source": "amazon:ASIN123"}
+        )
+        assert response.status_code == 200
+
+    def test_post_can_save(self, client, monkeypatch):
+        monkeypatch.setattr(
+            "openlibrary.fastapi.importapi.get_current_user",
+            lambda: _make_mock_user(is_admin=True),
+        )
+        captured = {}
+
+        def fake_from_input(i):
+            captured["save"] = i.get("save", "false")
+            mock_req = MagicMock()
+            mock_req.metadata_provider.do_import.return_value = FAKE_IMPORT_RESULT
+            mock_req.save = captured["save"] == "true"
+            return mock_req
+
+        monkeypatch.setattr(
+            "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
+            fake_from_input,
+        )
+        response = client.post(
+            "/import/preview",
+            data={"source": "amazon:ASIN123", "save": "true"},
+        )
+        assert response.status_code == 200
+        assert captured["save"] == "true"
+
+    def test_post_without_save_defaults_to_false(self, client, monkeypatch):
+        monkeypatch.setattr(
+            "openlibrary.fastapi.importapi.get_current_user",
+            lambda: _make_mock_user(is_admin=True),
+        )
+        captured = {}
+
+        def fake_from_input(i):
+            captured["save"] = i.get("save", "false")
+            mock_req = MagicMock()
+            mock_req.metadata_provider.do_import.return_value = FAKE_IMPORT_RESULT
+            mock_req.save = captured["save"] == "true"
+            return mock_req
+
+        monkeypatch.setattr(
+            "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
+            fake_from_input,
+        )
+        response = client.post(
+            "/import/preview", data={"source": "amazon:ASIN123"}
+        )
+        assert response.status_code == 200
+        assert captured["save"] == "false"
+
+    def test_post_invalid_source_returns_error(self, client, monkeypatch):
+        monkeypatch.setattr(
+            "openlibrary.fastapi.importapi.get_current_user",
+            lambda: _make_mock_user(is_admin=True),
+        )
+        monkeypatch.setattr(
+            "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
+            lambda i: _raise(ValueError("Invalid source provided")),
+        )
+        response = client.post(
+            "/import/preview", data={"source": "invalid"}
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False

--- a/openlibrary/tests/fastapi/test_importapi.py
+++ b/openlibrary/tests/fastapi/test_importapi.py
@@ -4,6 +4,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from openlibrary.utils.request_context import RequestContextVars, req_context, site
+
 
 def _raise(exc: Exception) -> None:
     raise exc
@@ -18,8 +20,6 @@ FAKE_IMPORT_RESULT = {
 @pytest.fixture(autouse=True)
 def _setup_request_context():
     """Set ContextVars for tests that reach _build_preview_response."""
-    from openlibrary.utils.request_context import RequestContextVars, req_context, site
-
     site.set(MagicMock())
     req_context.set(
         RequestContextVars(

--- a/openlibrary/tests/fastapi/test_importapi.py
+++ b/openlibrary/tests/fastapi/test_importapi.py
@@ -1,6 +1,6 @@
 """Tests for the FastAPI import preview endpoints."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -15,15 +15,25 @@ FAKE_IMPORT_RESULT = {
 }
 
 
-@pytest.fixture
-def mock_site():
-    """Mock the site ContextVar to avoid real infogami connection."""
-    with patch("openlibrary.fastapi.importapi.site") as mock:
-        yield mock
+@pytest.fixture(autouse=True)
+def _setup_request_context():
+    """Set ContextVars for tests that reach _build_preview_response."""
+    from openlibrary.utils.request_context import RequestContextVars, req_context, site
+
+    site.set(MagicMock())
+    req_context.set(
+        RequestContextVars(
+            x_forwarded_for=None,
+            user_agent=None,
+            lang="en",
+            solr_editions=True,
+            print_disabled=False,
+        )
+    )
 
 
 @pytest.fixture
-def mock_user_factory(mock_site, monkeypatch):
+def mock_user_factory(monkeypatch):
     """Factory fixture to create and mock users with configurable roles.
 
     Usage:
@@ -62,11 +72,11 @@ def mock_import_request():
 class TestImportPreviewAuth:
     """Authentication and authorization tests."""
 
-    def test_get_requires_authentication(self, fastapi_client, mock_site):
+    def test_get_requires_authentication(self, fastapi_client):
         response = fastapi_client.get("/import/preview.json?source=amazon:ASIN123")
         assert response.status_code == 401
 
-    def test_post_requires_authentication(self, fastapi_client, mock_site):
+    def test_post_requires_authentication(self, fastapi_client):
         response = fastapi_client.post(
             "/import/preview.json", data={"source": "amazon:ASIN123"}
         )

--- a/openlibrary/tests/fastapi/test_importapi.py
+++ b/openlibrary/tests/fastapi/test_importapi.py
@@ -106,9 +106,7 @@ class TestImportPreviewAuth:
     def test_get_allows_super_librarian(self, client, monkeypatch):
         monkeypatch.setattr(
             "openlibrary.fastapi.importapi.get_current_user",
-            lambda: _make_mock_user(
-                is_admin=False, is_librarian=False, is_super_librarian=True
-            ),
+            lambda: _make_mock_user(is_admin=False, is_librarian=False, is_super_librarian=True),
         )
         mock_req = MagicMock()
         mock_req.metadata_provider.do_import.return_value = FAKE_IMPORT_RESULT
@@ -198,9 +196,7 @@ class TestImportPreviewGet:
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
             fake_from_input,
         )
-        response = client.get(
-            "/import/preview?provider=amazon&identifier=1234567890"
-        )
+        response = client.get("/import/preview?provider=amazon&identifier=1234567890")
         assert response.status_code == 200
         assert captured["params"]["provider"] == "amazon"
         assert captured["params"]["identifier"] == "1234567890"
@@ -234,9 +230,7 @@ class TestImportPreviewPost:
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
             lambda i: mock_req,
         )
-        response = client.post(
-            "/import/preview", data={"source": "amazon:ASIN123"}
-        )
+        response = client.post("/import/preview", data={"source": "amazon:ASIN123"})
         assert response.status_code == 200
 
     def test_post_can_save(self, client, monkeypatch):
@@ -282,9 +276,7 @@ class TestImportPreviewPost:
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
             fake_from_input,
         )
-        response = client.post(
-            "/import/preview", data={"source": "amazon:ASIN123"}
-        )
+        response = client.post("/import/preview", data={"source": "amazon:ASIN123"})
         assert response.status_code == 200
         assert captured["save"] == "false"
 
@@ -297,9 +289,7 @@ class TestImportPreviewPost:
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
             lambda i: _raise(ValueError("Invalid source provided")),
         )
-        response = client.post(
-            "/import/preview", data={"source": "invalid"}
-        )
+        response = client.post("/import/preview", data={"source": "invalid"})
         assert response.status_code == 200
         data = response.json()
         assert data["success"] is False

--- a/openlibrary/tests/fastapi/test_importapi.py
+++ b/openlibrary/tests/fastapi/test_importapi.py
@@ -48,7 +48,7 @@ class TestImportPreviewAuth:
             "openlibrary.fastapi.importapi.get_current_user",
             lambda: None,
         )
-        response = client.get("/import/preview?source=amazon:ASIN123")
+        response = client.get("/import/preview.json?source=amazon:ASIN123")
         assert response.status_code == 401
 
     def test_post_requires_authentication(self, client, monkeypatch):
@@ -56,7 +56,7 @@ class TestImportPreviewAuth:
             "openlibrary.fastapi.importapi.get_current_user",
             lambda: None,
         )
-        response = client.post("/import/preview", data={"source": "amazon:ASIN123"})
+        response = client.post("/import/preview.json", data={"source": "amazon:ASIN123"})
         assert response.status_code == 401
 
     def test_get_forbidden_for_regular_user(self, client, monkeypatch):
@@ -64,7 +64,7 @@ class TestImportPreviewAuth:
             "openlibrary.fastapi.importapi.get_current_user",
             lambda: _make_mock_user(is_admin=False, is_librarian=False),
         )
-        response = client.get("/import/preview?source=amazon:ASIN123")
+        response = client.get("/import/preview.json?source=amazon:ASIN123")
         assert response.status_code == 403
 
     def test_post_forbidden_for_regular_user(self, client, monkeypatch):
@@ -72,7 +72,7 @@ class TestImportPreviewAuth:
             "openlibrary.fastapi.importapi.get_current_user",
             lambda: _make_mock_user(is_admin=False, is_librarian=False),
         )
-        response = client.post("/import/preview", data={"source": "amazon:ASIN123"})
+        response = client.post("/import/preview.json", data={"source": "amazon:ASIN123"})
         assert response.status_code == 403
 
     def test_get_allows_admin(self, client, monkeypatch):
@@ -86,7 +86,7 @@ class TestImportPreviewAuth:
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
             lambda i: mock_req,
         )
-        response = client.get("/import/preview?source=amazon:ASIN123")
+        response = client.get("/import/preview.json?source=amazon:ASIN123")
         assert response.status_code == 200
 
     def test_get_allows_librarian(self, client, monkeypatch):
@@ -100,7 +100,7 @@ class TestImportPreviewAuth:
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
             lambda i: mock_req,
         )
-        response = client.get("/import/preview?source=amazon:ASIN123")
+        response = client.get("/import/preview.json?source=amazon:ASIN123")
         assert response.status_code == 200
 
     def test_get_allows_super_librarian(self, client, monkeypatch):
@@ -114,12 +114,12 @@ class TestImportPreviewAuth:
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
             lambda i: mock_req,
         )
-        response = client.get("/import/preview?source=amazon:ASIN123")
+        response = client.get("/import/preview.json?source=amazon:ASIN123")
         assert response.status_code == 200
 
 
 class TestImportPreviewGet:
-    """GET /import/preview endpoint tests."""
+    """GET /import/preview.json endpoint tests."""
 
     def test_get_returns_import_result(self, client, monkeypatch):
         monkeypatch.setattr(
@@ -135,7 +135,7 @@ class TestImportPreviewGet:
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
             lambda i: mock_req,
         )
-        response = client.get("/import/preview?source=amazon:ASIN123")
+        response = client.get("/import/preview.json?source=amazon:ASIN123")
         assert response.status_code == 200
         data = response.json()
         assert data["success"] is True
@@ -159,7 +159,7 @@ class TestImportPreviewGet:
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
             fake_from_input,
         )
-        response = client.get("/import/preview?source=amazon:ASIN123&save=true")
+        response = client.get("/import/preview.json?source=amazon:ASIN123&save=true")
         assert response.status_code == 200
         assert captured["save"] == "false"
 
@@ -172,7 +172,7 @@ class TestImportPreviewGet:
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
             lambda i: _raise(ValueError("Invalid source provided")),
         )
-        response = client.get("/import/preview?source=invalid")
+        response = client.get("/import/preview.json?source=invalid")
         assert response.status_code == 200
         data = response.json()
         assert data["success"] is False
@@ -196,7 +196,7 @@ class TestImportPreviewGet:
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
             fake_from_input,
         )
-        response = client.get("/import/preview?provider=amazon&identifier=1234567890")
+        response = client.get("/import/preview.json?provider=amazon&identifier=1234567890")
         assert response.status_code == 200
         assert captured["params"]["provider"] == "amazon"
         assert captured["params"]["identifier"] == "1234567890"
@@ -210,14 +210,14 @@ class TestImportPreviewGet:
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
             lambda i: _raise(ValueError("Invalid source provided")),
         )
-        response = client.get("/import/preview")
+        response = client.get("/import/preview.json")
         assert response.status_code == 200
         data = response.json()
         assert data["success"] is False
 
 
 class TestImportPreviewPost:
-    """POST /import/preview endpoint tests."""
+    """POST /import/preview.json endpoint tests."""
 
     def test_post_returns_import_result(self, client, monkeypatch):
         monkeypatch.setattr(
@@ -230,7 +230,7 @@ class TestImportPreviewPost:
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
             lambda i: mock_req,
         )
-        response = client.post("/import/preview", data={"source": "amazon:ASIN123"})
+        response = client.post("/import/preview.json", data={"source": "amazon:ASIN123"})
         assert response.status_code == 200
 
     def test_post_can_save(self, client, monkeypatch):
@@ -252,7 +252,7 @@ class TestImportPreviewPost:
             fake_from_input,
         )
         response = client.post(
-            "/import/preview",
+            "/import/preview.json",
             data={"source": "amazon:ASIN123", "save": "true"},
         )
         assert response.status_code == 200
@@ -276,7 +276,7 @@ class TestImportPreviewPost:
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
             fake_from_input,
         )
-        response = client.post("/import/preview", data={"source": "amazon:ASIN123"})
+        response = client.post("/import/preview.json", data={"source": "amazon:ASIN123"})
         assert response.status_code == 200
         assert captured["save"] == "false"
 
@@ -289,7 +289,7 @@ class TestImportPreviewPost:
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
             lambda i: _raise(ValueError("Invalid source provided")),
         )
-        response = client.post("/import/preview", data={"source": "invalid"})
+        response = client.post("/import/preview.json", data={"source": "invalid"})
         assert response.status_code == 200
         data = response.json()
         assert data["success"] is False

--- a/openlibrary/tests/fastapi/test_importapi.py
+++ b/openlibrary/tests/fastapi/test_importapi.py
@@ -77,30 +77,20 @@ class TestImportPreviewAuth:
         assert response.status_code == 401
 
     def test_post_requires_authentication(self, fastapi_client):
-        response = fastapi_client.post(
-            "/import/preview.json", data={"source": "amazon:ASIN123"}
-        )
+        response = fastapi_client.post("/import/preview.json", data={"source": "amazon:ASIN123"})
         assert response.status_code == 401
 
-    def test_get_forbidden_for_regular_user(
-        self, fastapi_client, mock_authenticated_user, mock_user_factory
-    ):
+    def test_get_forbidden_for_regular_user(self, fastapi_client, mock_authenticated_user, mock_user_factory):
         mock_user_factory()
         response = fastapi_client.get("/import/preview.json?source=amazon:ASIN123")
         assert response.status_code == 403
 
-    def test_post_forbidden_for_regular_user(
-        self, fastapi_client, mock_authenticated_user, mock_user_factory
-    ):
+    def test_post_forbidden_for_regular_user(self, fastapi_client, mock_authenticated_user, mock_user_factory):
         mock_user_factory()
-        response = fastapi_client.post(
-            "/import/preview.json", data={"source": "amazon:ASIN123"}
-        )
+        response = fastapi_client.post("/import/preview.json", data={"source": "amazon:ASIN123"})
         assert response.status_code == 403
 
-    def test_get_allows_admin(
-        self, fastapi_client, mock_authenticated_user, mock_user_factory, mock_import_request, monkeypatch
-    ):
+    def test_get_allows_admin(self, fastapi_client, mock_authenticated_user, mock_user_factory, mock_import_request, monkeypatch):
         mock_user_factory(is_admin=True)
         monkeypatch.setattr(
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
@@ -109,9 +99,7 @@ class TestImportPreviewAuth:
         response = fastapi_client.get("/import/preview.json?source=amazon:ASIN123")
         assert response.status_code == 200
 
-    def test_get_allows_librarian(
-        self, fastapi_client, mock_authenticated_user, mock_user_factory, mock_import_request, monkeypatch
-    ):
+    def test_get_allows_librarian(self, fastapi_client, mock_authenticated_user, mock_user_factory, mock_import_request, monkeypatch):
         mock_user_factory(is_librarian=True)
         monkeypatch.setattr(
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
@@ -120,9 +108,7 @@ class TestImportPreviewAuth:
         response = fastapi_client.get("/import/preview.json?source=amazon:ASIN123")
         assert response.status_code == 200
 
-    def test_get_allows_super_librarian(
-        self, fastapi_client, mock_authenticated_user, mock_user_factory, mock_import_request, monkeypatch
-    ):
+    def test_get_allows_super_librarian(self, fastapi_client, mock_authenticated_user, mock_user_factory, mock_import_request, monkeypatch):
         mock_user_factory(is_super_librarian=True)
         monkeypatch.setattr(
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
@@ -225,9 +211,7 @@ class TestImportPreviewPost:
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
             lambda i: mock_import_request(),
         )
-        response = self.client.post(
-            "/import/preview.json", data={"source": "amazon:ASIN123"}
-        )
+        response = self.client.post("/import/preview.json", data={"source": "amazon:ASIN123"})
         assert response.status_code == 200
 
     def test_post_can_save(self):
@@ -264,9 +248,7 @@ class TestImportPreviewPost:
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
             fake_from_input,
         )
-        response = self.client.post(
-            "/import/preview.json", data={"source": "amazon:ASIN123"}
-        )
+        response = self.client.post("/import/preview.json", data={"source": "amazon:ASIN123"})
         assert response.status_code == 200
         assert captured["save"] == "false"
 
@@ -275,9 +257,7 @@ class TestImportPreviewPost:
             "openlibrary.fastapi.importapi.ImportPreviewRequest.from_input",
             lambda i: _raise(ValueError("Invalid source provided")),
         )
-        response = self.client.post(
-            "/import/preview.json", data={"source": "invalid"}
-        )
+        response = self.client.post("/import/preview.json", data={"source": "invalid"})
         assert response.status_code == 200
         data = response.json()
         assert data["success"] is False


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR migrates `import_preview_json` from web.py to FastAPI.

### Technical
<!-- What should be noted about the implementation? -->
- Added `openlibrary/fastapi/importapi.py` with `GET /import/preview` and `POST /import/preview` endpoints
- Marked legacy `import_preview_json` class in `import_ui.py` with `@deprecated("migrated to fastapi")`
- Registered the new router in `asgi_app.py`

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
docker compose run --rm home python -m pytest openlibrary/tests/fastapi/test_importapi.py -v


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
