### PR TITLE
Fix FastAPI OpenAPI schema generation in lists router (#12746)

### DIFF
--- a/openlibrary/fastapi/lists.py
+++ b/openlibrary/fastapi/lists.py
@@ -1,7 +1,6 @@
 from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, status
-from starlette.datastructures import URL
 
 from infogami.infobase import client
 from openlibrary.accounts import get_current_user
@@ -121,7 +120,7 @@ class GetListEditionsParams:
         limit: Annotated[int, Query(ge=0, description="Number of items to return")] = 50,
         offset: Annotated[int, Query(ge=0, description="Pagination offset")] = 0,
     ):
-        self.url: URL = request.url
+        self.url = request.url
         self.limit: int = limit
         self.offset: int = offset
 

--- a/openlibrary/fastapi/lists.py
+++ b/openlibrary/fastapi/lists.py
@@ -1,8 +1,7 @@
-from __future__ import annotations
-
-from typing import TYPE_CHECKING, Annotated, Literal
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, status
+from starlette.datastructures import URL
 
 from infogami.infobase import client
 from openlibrary.accounts import get_current_user
@@ -10,9 +9,6 @@ from openlibrary.fastapi.auth import AuthenticatedUser, require_authenticated_us
 from openlibrary.plugins.openlibrary.lists import ListEditionsModel, ListSubjectsModel, get_list, get_list_editions, get_list_subjects
 from openlibrary.plugins.openlibrary.lists import lists_delete as _LegacyListsDelete
 from openlibrary.utils.request_context import site, web_ctx_ip
-
-if TYPE_CHECKING:
-    from starlette.datastructures import URL
 
 router = APIRouter(tags=["lists"])
 


### PR DESCRIPTION
Closes #12746

## Summary

`openlibrary/fastapi/lists.py` had two interacting issues that broke OpenAPI schema generation, returning 500 on `/openapi.json`, crashing `/docs`, and producing 8 errors in the FastAPI test suite (`test_search.py`, `test_list_view_json.py`):

- `from __future__ import annotations` at the top of the file deferred evaluation of every type hint into string `ForwardRef`s.
- `URL` (from `starlette.datastructures`) was imported only under `if TYPE_CHECKING:`, so Pydantic could not resolve the annotation at runtime.

The result was:

```
pydantic.errors.PydanticUserError: TypeAdapter[typing.Annotated[ForwardRef('Request'), Query(PydanticUndefined)]] is not fully defined
```

## Fix

- Remove `from __future__ import annotations` from `openlibrary/fastapi/lists.py`.
- Move `from starlette.datastructures import URL` out of the `TYPE_CHECKING` block to a normal runtime import.
- Drop the now-unused `TYPE_CHECKING` symbol from the `typing` import.

All annotations on the FastAPI route handlers and the `GetListEditionsParams` dependency class now resolve at import time, so Pydantic can build the OpenAPI schema cleanly.

## Test plan

- [ ] `docker compose up -d`
- [ ] `docker compose exec web python -m pytest openlibrary/tests/fastapi/ -v` passes
- [ ] `http://localhost:18080/openapi.json` returns 200
- [ ] `http://localhost:18080/docs` loads Swagger UI without errors

