### PR TITLE
Remove unused cache engines

### DIFF
--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -25,7 +25,6 @@ __all__ = [
     "Cache",
     "MemcacheCache",
     "MemoryCache",
-    "RequestCache",
     "get_memcache",
     "memcache_memoize",
     "memoize",
@@ -267,7 +266,11 @@ class Cache:
 
 
 class MemoryCache(Cache):
-    """Cache implementation in memory."""
+    """Cache implementation in memory.
+    
+    Note: expires is ignored. Values stay until deleted or cleared. 
+    Use MemcacheCache if you need expiration.
+"""
 
     def __init__(self):
         self.d = {}
@@ -354,32 +357,9 @@ class MemcacheCache(Cache):
         return value
 
 
-class RequestCache(Cache):
-    """Request-Local cache.
-
-    The values are cached only in the context of the current request.
-    """
-
-    @property
-    def d(self):
-        return web.ctx.setdefault("request-local-cache", {})
-
-    def get(self, key):
-        return self.d.get(key)
-
-    def set(self, key, value, expires=0):
-        self.d[key] = value
-
-    def add(self, key, value, expires=0):
-        return self.d.setdefault(key, value) is value
-
-    def delete(self, key):
-        return self.d.pop(key, None) is not None
-
 
 memory_cache = MemoryCache()
 memcache_cache = MemcacheCache()
-request_cache = RequestCache()
 
 
 def get_memcache():
@@ -390,8 +370,6 @@ def _get_cache(engine):
     d = {
         "memory": memory_cache,
         "memcache": memcache_cache,
-        "memcache+memory": memcache_cache,
-        "request": request_cache,
     }
     return d.get(engine)
 
@@ -411,7 +389,6 @@ class memoize:
         Engine to store the results. Available options are:
             * memory: stores the result in memory.
             * memcache: stores the result in memcached.
-            * request: stores the result only in the context of the current request.
 
     * key:
         key to be used in the cache. If this is a string, arguments are append
@@ -453,7 +430,7 @@ class memoize:
 
     def __init__(
         self,
-        engine: Literal["memory", "memcache", "request"],
+        engine: Literal["memory", "memcache"],
         key: str | Callable[..., str | tuple],
         expires: int = 0,
         background: bool = False,

--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -267,10 +267,10 @@ class Cache:
 
 class MemoryCache(Cache):
     """Cache implementation in memory.
-    
-    Note: expires is ignored. Values stay until deleted or cleared. 
+
+    Note: expires is ignored. Values stay until deleted or cleared.
     Use MemcacheCache if you need expiration.
-"""
+    """
 
     def __init__(self):
         self.d = {}
@@ -355,7 +355,6 @@ class MemcacheCache(Cache):
         value = self.memcache.delete(key)
         stats.end()
         return value
-
 
 
 memory_cache = MemoryCache()


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #12735 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Refactor. removes unused cache engines from `openlibrary/core/cache.py`.


### Technical
- Removed the `RequestCache` class, its singleton, and its `_all_` entry. Nothing in the codebase was using it.
- Removed the `"memcache+memory"` alias from `_get_cache()` - only the dict itself referenced it.
- Updated the `memoize._init_` type hint from `Literal["memory", "memcache", "request"]` to `Literal["memory", "memcache"]`, and dropped the matching `request` line from the docstring.
- For MemoryCache.expires: Pam flagged this as unspecified with three possible approaches. Went with documenting it as a no-op since it's the safest and doesn't change behavior. Happy to switch if preferred.

### Testing
- Ran `docker compose run --rm home pytest openlibrary/tests/core/test_cache.py -v` - all 14 tests pass.
- Grepped the repo for any leftover references to the removed pieces, nothing came up.

### Screenshot
N/A

### Stakeholders
@RayBB 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
