### PR TITLE
Read recaptcha URL from configuration file

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -172,6 +172,8 @@ internal_tests_api_key: 8oPd1tx747YH374ohs48ZO5s2Nt1r9yD
 ia_availability_api_v2_url: https://archive.org/services/availability/
 ia_base_url: https://archive.org
 
+recaptcha_url: "https://www.recaptcha.net/recaptcha/api/siteverify"
+
 sentry:
     enabled: false
     # Dummy endpoint; where sentry logs are sent to

--- a/openlibrary/plugins/recaptcha/recaptcha.py
+++ b/openlibrary/plugins/recaptcha/recaptcha.py
@@ -5,6 +5,9 @@ import logging
 import requests
 import web
 
+from infogami import config
+
+
 logger = logging.getLogger("openlibrary")
 
 INVALIDATING_ERRORS = [
@@ -34,7 +37,7 @@ class Recaptcha(web.form.Input):
             return not any(error in INVALIDATING_ERRORS for error in error_codes)
 
         i = web.input()
-        url = "https://www.recaptcha.net/recaptcha/api/siteverify"
+        url = config.get("recaptcha_url")
         params = {
             "secret": self._private_key,
             "response": i.get("g-recaptcha-response"),

--- a/openlibrary/plugins/recaptcha/recaptcha.py
+++ b/openlibrary/plugins/recaptcha/recaptcha.py
@@ -7,7 +7,6 @@ import web
 
 from infogami import config
 
-
 logger = logging.getLogger("openlibrary")
 
 INVALIDATING_ERRORS = [


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Moves recaptcha URL to Open Library's configuration file.

**Special deployment instructions:**
Must be deployed alongside https://github.com/internetarchive/olsystem/pull/354


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
