### PR TITLE
Fix #12755: Return 400 Bad Request for malformed cover image input

### DIFF
--- a/openlibrary/plugins/upstream/covers.py
+++ b/openlibrary/plugins/upstream/covers.py
@@ -5,11 +5,11 @@ from logging import getLogger
 
 import requests
 import web
-from infogami.utils import delegate
-from infogami.utils.view import safeint
 from PIL import Image as PILImage
 from PIL import UnidentifiedImageError
 
+from infogami.utils import delegate
+from infogami.utils.view import safeint
 from openlibrary import accounts
 from openlibrary.plugins.upstream.models import Image
 from openlibrary.plugins.upstream.utils import (

--- a/openlibrary/plugins/upstream/covers.py
+++ b/openlibrary/plugins/upstream/covers.py
@@ -5,11 +5,11 @@ from logging import getLogger
 
 import requests
 import web
+from infogami.utils import delegate
+from infogami.utils.view import safeint
 from PIL import Image as PILImage
 from PIL import UnidentifiedImageError
 
-from infogami.utils import delegate
-from infogami.utils.view import safeint
 from openlibrary import accounts
 from openlibrary.plugins.upstream.models import Image
 from openlibrary.plugins.upstream.utils import (
@@ -193,7 +193,8 @@ class manage_covers(delegate.page):
             self.save_images(book, images)
             return render_template("covers/saved", self.get_image(book), showinfo=False)
         else:
-            # ERROR
+            # FIX: Prevent silent failure by raising a 400 Bad Request error
+            raise web.badrequest("Invalid image format. Expected a '-' separator.")
             pass
 
 


### PR DESCRIPTION
Closes #12755

### fix
Resolves a bug where malformed cover image uploads (missing the `-` separator) would fail silently. The server now properly halts the request and alerts the client with a `400 Bad Request` error instead of quietly returning `None`.

### Technical
- **Target:** `manage_covers.POST` inside `openlibrary/plugins/upstream/covers.py`.
- **Change:** Swapped the empty `pass` placeholder in the fallback `else:` block for a `raise web.badrequest(...)` exception, aligning it with the surrounding error-handling patterns.

### Testing
Verified locally via the Docker environment using a mock script to simulate the exact bad payload reported in the issue.
1. Injected a malformed `web.input`.
2. Triggered the endpoint via the `home` container.
3. Confirmed the silent failure is gone and the server successfully throws the HTTP exception.

<img width="1061" height="808" alt="Screenshot 2026-05-19 at 2 23 37 PM" src="https://github.com/user-attachments/assets/49d8add0-b054-498f-8dfd-487d927d6dbd" />
