### PR TITLE
Build modsecurity to avoid it being outdated

### DIFF
--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -1,3 +1,12 @@
+# Temporary container to build ModSecurity
+FROM debian:bookworm-slim AS modsec-builder
+
+ARG MODSECURITY_TAG=v1.0.4
+ENV MODSECURITY_TAG=${MODSECURITY_TAG}
+
+COPY scripts/build_modsecurity.sh /tmp/build_modsecurity.sh
+RUN bash /tmp/build_modsecurity.sh
+
 FROM python:3.12.2-slim-bookworm
 
 ENV LANG=en_US.UTF-8
@@ -44,6 +53,10 @@ RUN ./install_nodejs.sh && rm ./install_nodejs.sh
 USER root
 COPY scripts/install_nginx.sh ./
 RUN ./install_nginx.sh && rm ./install_nginx.sh
+COPY --from=modsec-builder /out/ngx_http_modsecurity_module.so /usr/lib/nginx/modules/ngx_http_modsecurity_module.so
+RUN chmod 644 /usr/lib/nginx/modules/ngx_http_modsecurity_module.so \
+ && chown root:root /usr/lib/nginx/modules/ngx_http_modsecurity_module.so
+
 
 RUN mkdir -p /var/log/openlibrary /var/lib/openlibrary && chown openlibrary:openlibrary /var/log/openlibrary /var/lib/openlibrary \
  && mkdir /openlibrary && chown openlibrary:openlibrary /openlibrary \

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,7 +1,7 @@
 # Needed for IP anonymization
 load_module modules/ngx_http_js_module.so;
 # Needed for modsecurity
-load_module /olsystem/lib/ngx_http_modsecurity_module.so;
+load_module modules/ngx_http_modsecurity_module.so;
 
 user  www-data;
 

--- a/scripts/build_modsecurity.sh
+++ b/scripts/build_modsecurity.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update
+apt-get install -y --no-install-recommends \
+    automake \
+    autoconf \
+    build-essential \
+    ca-certificates \
+    curl \
+    dpkg-dev \
+    git \
+    libcurl4-openssl-dev \
+    libgeoip-dev \
+    liblmdb-dev \
+    libmodsecurity-dev \
+    libpcre2-dev \
+    libssl-dev \
+    libtool \
+    libxml2 \
+    libxml2-dev \
+    libyajl-dev \
+    lsb-release \
+    pkgconf \
+    zlib1g \
+    zlib1g-dev
+
+curl -fsSL https://nginx.org/keys/nginx_signing.key | tee /usr/share/keyrings/nginx-keyring.asc
+
+echo "deb [signed-by=/usr/share/keyrings/nginx-keyring.asc] http://nginx.org/packages/debian $(lsb_release -cs) nginx" > /etc/apt/sources.list.d/nginx.list
+echo "deb-src [signed-by=/usr/share/keyrings/nginx-keyring.asc] http://nginx.org/packages/debian $(lsb_release -cs) nginx" >> /etc/apt/sources.list.d/nginx.list
+
+cd /tmp/
+git clone --depth 1 --branch "${MODSECURITY_TAG}" https://github.com/owasp-modsecurity/ModSecurity-nginx.git
+
+apt-get update
+nginx_version="$(apt-cache policy nginx | awk '/Candidate:/ {print $2}')"
+if [ -z "${nginx_version}" ] || [ "${nginx_version}" = "(none)" ]; then
+    echo "Unable to resolve nginx candidate version from apt cache" >&2
+    exit 1
+fi
+
+mkdir -p /tmp/nginx-build
+cd /tmp/nginx-build
+apt-get source "nginx=${nginx_version}"
+nginx_source_dir="$(find /tmp/nginx-build -mindepth 1 -maxdepth 1 -type d -name 'nginx-*' | head -n 1)"
+if [ -z "${nginx_source_dir}" ]; then
+    echo "Unable to find unpacked nginx source directory" >&2
+    exit 1
+fi
+
+cd "${nginx_source_dir}"
+./configure --with-compat --add-dynamic-module=/tmp/ModSecurity-nginx
+make -j"$(nproc)" modules
+
+mkdir -p /out
+cp objs/ngx_http_modsecurity_module.so /out/ngx_http_modsecurity_module.so

--- a/scripts/install_nginx.sh
+++ b/scripts/install_nginx.sh
@@ -20,7 +20,7 @@ apt-get update
 apt-get install -y --no-install-recommends nginx nginx-module-njs letsencrypt
 
 # Install modsecurity
-# Modsecurity will rely on the /olsystem/lib/ngx_http_modsecurity_module.so
+# Modsecurity will rely on /usr/lib/nginx/modules/ngx_http_modsecurity_module.so
 # Nginx will not start without it.
 apt-get install -y --no-install-recommends libmodsecurity3 modsecurity-crs
 


### PR DESCRIPTION
Fixes issue in recent deploy.

See also olsystem PR: https://github.com/internetarchive/olsystem/pull/356

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Successfully built locally and on docker hub: https://hub.docker.com/layers/openlibrary/olbase/modsecurity-builder/images/sha256-a9d59a7e32a0068ab275b8df16ec2e7dc45329231bfb6a665bb8de9bb0e9dbdf . Tested on prod by pulling the image down and running nginx off it and it worked!

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
