### PR TITLE
build: remove black, expand ruff-format to all Python files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,39 +52,6 @@ repos:
       - id: ruff-check
         args: [--fix]
       - id: ruff-format
-        # Exclude files currently touched by open (non-draft) PRs to avoid merge conflicts.
-        # List generated with: gh pr list --state open --draft=false --json files --jq '.[].files[].path' | sort | uniq
-        # Uses YAML literal block scalar (|) + (?x) verbose regex flag so each file is on
-        # its own line. Unlike >- (folded scalar), | preserves newlines exactly. The (?x)
-        # flag tells Python's re engine to ignore all whitespace/newlines in the pattern,
-        # so the leading | on each line works correctly as an alternation operator.
-        exclude: |
-          (?x)^(
-            openlibrary/accounts/model\.py
-            |openlibrary/core/models\.py
-            |openlibrary/plugins/openlibrary/api\.py
-            |openlibrary/plugins/openlibrary/code\.py
-            |openlibrary/plugins/openlibrary/lists\.py
-            |openlibrary/plugins/worksearch/code\.py
-            |openlibrary/plugins/worksearch/schemes/works\.py
-          )$
-
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.3.1
-    hooks:
-      - id: black  # See pyproject.toml for args
-        # Complement to ruff-format above: black runs ONLY on files in active open PRs
-        # (the same set ruff-format excludes). Uses same (?x) + | literal block approach.
-        files: |
-          (?x)^(
-            openlibrary/accounts/model\.py
-            |openlibrary/core/models\.py
-            |openlibrary/plugins/openlibrary/api\.py
-            |openlibrary/plugins/openlibrary/code\.py
-            |openlibrary/plugins/openlibrary/lists\.py
-            |openlibrary/plugins/worksearch/code\.py
-            |openlibrary/plugins/worksearch/schemes/works\.py
-          )$
 
   - repo: https://github.com/MarcoGorelli/cython-lint
     rev: v0.19.0

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -42,7 +42,7 @@ class OLAuthenticationError(Exception):
 
 
 def append_random_suffix(text: str, limit: int = 9999) -> str:
-    return f'{text}{random.randint(0, limit)}'
+    return f"{text}{random.randint(0, limit)}"
 
 
 def valid_email(email: str) -> bool:
@@ -51,13 +51,8 @@ def valid_email(email: str) -> bool:
 
 def sendmail(to: str, msg, cc=None) -> None:
     cc = cc or []
-    if config.get('dummy_sendmail'):
-        message = (
-            f"To: {to}\n"
-            f"From:{config.from_address}\n"
-            f"Subject: {msg.subject}\n"
-            f"\n{web.safestr(msg)}"
-        )
+    if config.get("dummy_sendmail"):
+        message = f"To: {to}\nFrom:{config.from_address}\nSubject: {msg.subject}\n\n{web.safestr(msg)}"
 
         print("sending email", message, file=web.debug)
     else:
@@ -72,27 +67,20 @@ def sendmail(to: str, msg, cc=None) -> None:
 
 def verify_hash(secret_key, text, hash) -> bool:
     """Verifies if the hash is generated"""
-    salt = hash.split('$', 1)[0]
+    salt = hash.split("$", 1)[0]
     return generate_hash(secret_key, text, salt) == hash
 
 
 def generate_hash(secret_key, text, salt=None) -> str:
     if not isinstance(secret_key, bytes):
-        secret_key = secret_key.encode('utf-8')
-    salt = (
-        salt
-        or hmac.HMAC(
-            secret_key, str(random.random()).encode('utf-8'), hashlib.md5
-        ).hexdigest()[:5]
-    )
-    hash = hmac.HMAC(
-        secret_key, (salt + web.safestr(text)).encode('utf-8'), hashlib.md5
-    ).hexdigest()
-    return f'{salt}${hash}'
+        secret_key = secret_key.encode("utf-8")
+    salt = salt or hmac.HMAC(secret_key, str(random.random()).encode("utf-8"), hashlib.md5).hexdigest()[:5]
+    hash = hmac.HMAC(secret_key, (salt + web.safestr(text)).encode("utf-8"), hashlib.md5).hexdigest()
+    return f"{salt}${hash}"
 
 
 def get_secret_key():
-    return config.infobase['secret_key']
+    return config.infobase["secret_key"]
 
 
 def create_verification_cookie_value() -> str:
@@ -169,10 +157,10 @@ def verify_session_cookie(cookie_value: str) -> bool:
     """
     if not cookie_value:
         return False
-    if not cookie_value.startswith('/people/'):
+    if not cookie_value.startswith("/people/"):
         return True  # Unknown format — don't invalidate
     try:
-        data, signature = cookie_value.rsplit(',', 1)
+        data, signature = cookie_value.rsplit(",", 1)
     except ValueError:
         return False
     return verify_hash(get_secret_key(), data, signature)
@@ -204,10 +192,8 @@ def send_verification_email(username: str, email: str) -> None:
     doc = create_link_doc(key, username, email)
     web.ctx.site.store[key] = doc
 
-    link = web.ctx.home + "/account/verify/" + doc['code']
-    msg = render_template(
-        "email/account/verify", username=username, email=email, password=None, link=link
-    )
+    link = web.ctx.home + "/account/verify/" + doc["code"]
+    msg = render_template("email/account/verify", username=username, email=email, password=None, link=link)
     sendmail(email, msg)
 
 
@@ -234,21 +220,21 @@ def create_link_doc(key: str, username: str, email: str) -> dict:
 
 
 def clear_cookies() -> None:
-    web.setcookie('pd', "", expires=-1)
-    web.setcookie('sfw', "", expires=-1)
+    web.setcookie("pd", "", expires=-1)
+    web.setcookie("sfw", "", expires=-1)
 
 
 class Link(web.storage):
     def get_expiration_time(self) -> datetime.datetime:
-        d = self['expires_on'].split(".")[0]
+        d = self["expires_on"].split(".")[0]
         return datetime.datetime.strptime(d, "%Y-%m-%dT%H:%M:%S")
 
     def get_creation_time(self) -> datetime.datetime:
-        d = self['created_on'].split(".")[0]
+        d = self["created_on"].split(".")[0]
         return datetime.datetime.strptime(d, "%Y-%m-%dT%H:%M:%S")
 
     def delete(self) -> None:
-        del web.ctx.site.store[self['_key']]
+        del web.ctx.site.store[self["_key"]]
 
 
 class Account(web.storage):
@@ -281,7 +267,7 @@ class Account(web.storage):
             return self.username
 
     def creation_time(self) -> datetime.datetime:
-        d = self['created_on'].split(".")[0]
+        d = self["created_on"].split(".")[0]
         return datetime.datetime.strptime(d, "%Y-%m-%dT%H:%M:%S")
 
     def get_recentchanges(self, limit: int = 100, offset: int = 0):
@@ -313,7 +299,7 @@ class Account(web.storage):
 
     def is_blocked(self) -> bool:
         """Tests if this account is blocked."""
-        return getattr(self, 'status', '') == "blocked"
+        return getattr(self, "status", "") == "blocked"
 
     def login(self, password):
         """Tries to login with the given password and returns the status.
@@ -336,16 +322,13 @@ class Account(web.storage):
             code = e.get_data().get("code")
             return code
         else:
-            self['last_login'] = datetime.datetime.utcnow().isoformat()
+            self["last_login"] = datetime.datetime.utcnow().isoformat()
             self._save()
             return "ok"
 
     @classmethod
     def generate_random_password(cls, n: int = 12) -> str:
-        return ''.join(
-            random.SystemRandom().choice(string.ascii_uppercase + string.digits)
-            for _ in range(n)
-        )
+        return "".join(random.SystemRandom().choice(string.ascii_uppercase + string.digits) for _ in range(n))
 
     def generate_login_code(self) -> str:
         """Returns a string that can be set as login cookie to log in as this user."""
@@ -365,7 +348,7 @@ class Account(web.storage):
         t = self.get("last_login")
         return t and helpers.parse_datetime(t)
 
-    def get_user(self) -> 'User':
+    def get_user(self) -> "User":
         """A user is where preferences are attached to an account. An
         "Account" is outside of infogami in a separate table and is
         used to store private user information.
@@ -397,9 +380,7 @@ class Account(web.storage):
 
     def get_links(self) -> list[Link]:
         """Returns all the verification links present in the database."""
-        return web.ctx.site.store.values(
-            type="account-link", name="username", value=self.username
-        )
+        return web.ctx.site.store.values(type="account-link", name="username", value=self.username)
 
     def get_tags(self) -> list[str]:
         """Returns list of tags that this user has."""
@@ -412,14 +393,14 @@ class Account(web.storage):
         tags = self.get_tags()
         if tag not in tags:
             tags.append(tag)
-        self['tags'] = tags
+        self["tags"] = tags
         self._save()
 
     def remove_tag(self, tag) -> None:
         tags = self.get_tags()
         if tag in tags:
             tags.remove(tag)
-        self['tags'] = tags
+        self["tags"] = tags
         self._save()
 
     def set_bot_flag(self, flag) -> None:
@@ -438,49 +419,33 @@ class Account(web.storage):
                 grp.remove_user(patron.key)
 
             # Clear patron's profile page:
-            data = {'key': patron.key, 'type': '/type/delete'}
+            data = {"key": patron.key, "type": "/type/delete"}
             patron.set_data(data, "delete-profile")
 
             # Remove account information from store:
-            del web.ctx.site.store[f'account/{username}']
-            del web.ctx.site.store[f'account/{username}/verify']
-            del web.ctx.site.store[f'account/{username}/password']
-            del web.ctx.site.store[f'account-email/{email}']
-            del web.ctx.site.store[f'account-email/{email.lower()}']
+            del web.ctx.site.store[f"account/{username}"]
+            del web.ctx.site.store[f"account/{username}/verify"]
+            del web.ctx.site.store[f"account/{username}/password"]
+            del web.ctx.site.store[f"account-email/{email}"]
+            del web.ctx.site.store[f"account-email/{email.lower()}"]
             # Delete preferences:
-            del web.ctx.site.store[f'/people/{username}/preferences']
+            del web.ctx.site.store[f"/people/{username}/preferences"]
 
         # Generate new unique username for patron:
         # Note: Cannot test get_activation_link() locally
-        uuid = (
-            self.get_activation_link()['code']
-            if self.get_activation_link()
-            else generate_uuid()
-        )
-        new_username = f'anonymous-{uuid}'
-        results = {'new_username': new_username}
+        uuid = self.get_activation_link()["code"] if self.get_activation_link() else generate_uuid()
+        new_username = f"anonymous-{uuid}"
+        results = {"new_username": new_username}
 
         # Delete all of the patron's book notes:
-        results['booknotes_count'] = Booknotes.delete_all_by_username(
-            self.username, _test=test
-        )
+        results["booknotes_count"] = Booknotes.delete_all_by_username(self.username, _test=test)
 
         # Anonymize patron's username in OL DB tables:
-        results['ratings_count'] = Ratings.update_username(
-            self.username, new_username, _test=test
-        )
-        results['observations_count'] = Observations.update_username(
-            self.username, new_username, _test=test
-        )
-        results['bookshelves_count'] = Bookshelves.update_username(
-            self.username, new_username, _test=test
-        )
-        results['merge_request_count'] = CommunityEditsQueue.update_submitter_name(
-            self.username, new_username, _test=test
-        )
-        results['bestbooks_count'] = Bestbook.update_username(
-            self.username, new_username, _test=test
-        )
+        results["ratings_count"] = Ratings.update_username(self.username, new_username, _test=test)
+        results["observations_count"] = Observations.update_username(self.username, new_username, _test=test)
+        results["bookshelves_count"] = Bookshelves.update_username(self.username, new_username, _test=test)
+        results["merge_request_count"] = CommunityEditsQueue.update_submitter_name(self.username, new_username, _test=test)
+        results["bestbooks_count"] = Bestbook.update_username(self.username, new_username, _test=test)
 
         return results
 
@@ -489,13 +454,13 @@ class Account(web.storage):
         """Retrieves the Archive.org itemname which links Open Library and
         Internet Archive accounts
         """
-        return getattr(self, 'internetarchive_itemname', None)
+        return getattr(self, "internetarchive_itemname", None)
 
     def get_linked_ia_account(self):
         if self.itemname:
-            act = InternetArchiveAccount.xauth('info', itemname=self.itemname)
-            if 'values' in act and 'email' in act['values']:
-                return InternetArchiveAccount.get(email=act['values']['email'])
+            act = InternetArchiveAccount.xauth("info", itemname=self.itemname)
+            if "values" in act and "email" in act["values"]:
+                return InternetArchiveAccount.get(email=act["values"]["email"])
 
     def render_link(self) -> str:
         return f'<a href="/people/{self.username}">{web.net.htmlquote(self.displayname)}</a>'
@@ -525,9 +490,9 @@ class OpenLibraryAccount(Account):
                             an available username.
         """
         if cls.get_by_email(email):
-            raise ValueError('email_registered')
+            raise ValueError("email_registered")
 
-        username = username[1:] if username[0] == '@' else username
+        username = username[1:] if username[0] == "@" else username
         displayname = displayname or username
 
         # tests whether a user w/ this username exists
@@ -536,7 +501,7 @@ class OpenLibraryAccount(Account):
         attempt = 0
         while _user:
             if attempt >= retries:
-                ve = ValueError('username_registered')
+                ve = ValueError("username_registered")
                 ve.value = username
                 raise ve
 
@@ -546,7 +511,7 @@ class OpenLibraryAccount(Account):
         username = new_username
         if test:
             return cls(
-                itemname=f'@{username}',
+                itemname=f"@{username}",
                 email=email,
                 username=username,
                 displayname=displayname,
@@ -560,7 +525,7 @@ class OpenLibraryAccount(Account):
                 displayname=displayname,
             )
         except ClientException:
-            raise ValueError('something_went_wrong')
+            raise ValueError("something_went_wrong")
 
         if verified:
             key = f"account/{username}/verify"
@@ -574,7 +539,7 @@ class OpenLibraryAccount(Account):
         from openlibrary.accounts import RunAs
 
         with RunAs(username):
-            ol_account.get_user().save_preferences({'public_readlog': 'yes'})
+            ol_account.get_user().save_preferences({"public_readlog": "yes"})
 
         return ol_account
 
@@ -582,42 +547,38 @@ class OpenLibraryAccount(Account):
     def get_or_raise(
         cls,
         value: str,
-        field: Literal['link', 'email', 'username', 'key'],
-    ) -> 'OpenLibraryAccount':
+        field: Literal["link", "email", "username", "key"],
+    ) -> "OpenLibraryAccount":
         """Utility method retrieve an openlibrary account by its email,
         username or archive.org itemname (i.e. link)
         """
         account = None
-        if field == 'username':
+        if field == "username":
             account = cls.get_by_username(value)
-        elif field == 'email':
+        elif field == "email":
             account = cls.get_by_email(value)
-        elif field == 'link':
+        elif field == "link":
             account = cls.get_by_link(value)
-        elif field == 'key':
+        elif field == "key":
             account = cls.get_by_key(value)
         if not account:
-            raise ValueError('Unable to get Open Library account')
+            raise ValueError("Unable to get Open Library account")
         return account
 
     @classmethod
-    def get_by_key(cls, key: str) -> 'OpenLibraryAccount | None':
-        username = key.rsplit('/', maxsplit=1)[-1]
+    def get_by_key(cls, key: str) -> "OpenLibraryAccount | None":
+        username = key.rsplit("/", maxsplit=1)[-1]
         return cls.get_by_username(username)
 
     @classmethod
-    def get_by_username(cls, username: str) -> 'OpenLibraryAccount | None':
+    def get_by_username(cls, username: str) -> "OpenLibraryAccount | None":
         """Retrieves and OpenLibraryAccount by username if it exists or"""
-        match = web.ctx.site.store.values(
-            type="account", name="username", value=username, limit=1
-        )
+        match = web.ctx.site.store.values(type="account", name="username", value=username, limit=1)
 
         if len(match):
             return cls(match[0])
 
-        lower_match = web.ctx.site.store.values(
-            type="account", name="lusername", value=username, limit=1
-        )
+        lower_match = web.ctx.site.store.values(type="account", name="lusername", value=username, limit=1)
 
         if len(lower_match):
             return cls(lower_match[0])
@@ -625,17 +586,15 @@ class OpenLibraryAccount(Account):
         return None
 
     @classmethod
-    def get_by_link(cls, link: str) -> 'OpenLibraryAccount | None':
+    def get_by_link(cls, link: str) -> "OpenLibraryAccount | None":
         """
         :rtype: OpenLibraryAccount or None
         """
-        ol_accounts = web.ctx.site.store.values(
-            type="account", name="internetarchive_itemname", value=link
-        )
+        ol_accounts = web.ctx.site.store.values(type="account", name="internetarchive_itemname", value=link)
         return cls(ol_accounts[0]) if ol_accounts else None
 
     @classmethod
-    def get_by_email(cls, email: str) -> 'OpenLibraryAccount | None':
+    def get_by_email(cls, email: str) -> "OpenLibraryAccount | None":
         """the email stored in account doc is case-sensitive.
         The lowercase of email is used in the account-email document.
         querying that first and taking the username from there to make
@@ -646,54 +605,52 @@ class OpenLibraryAccount(Account):
         if that fails.
         """
         email = email.strip()
-        email_doc = web.ctx.site.store.get(
-            "account-email/" + email
-        ) or web.ctx.site.store.get("account-email/" + email.lower())
-        if email_doc and 'username' in email_doc:
-            doc = web.ctx.site.store.get("account/" + email_doc['username'])
+        email_doc = web.ctx.site.store.get("account-email/" + email) or web.ctx.site.store.get("account-email/" + email.lower())
+        if email_doc and "username" in email_doc:
+            doc = web.ctx.site.store.get("account/" + email_doc["username"])
             return cls(doc) if doc else None
         return None
 
     @property
     def verified(self) -> bool:
-        return getattr(self, 'status', '') != 'pending'
+        return getattr(self, "status", "") != "pending"
 
     @property
     def blocked(self) -> bool:
-        return getattr(self, 'status', '') == 'blocked'
+        return getattr(self, "status", "") == "blocked"
 
     def unlink(self) -> None:
         """Careful, this will save any other changes to the ol user object as
         well
         """
         _ol_account = web.ctx.site.store.get(self._key)
-        _ol_account['internetarchive_itemname'] = None
+        _ol_account["internetarchive_itemname"] = None
         web.ctx.site.store[self._key] = _ol_account
         self.internetarchive_itemname = None
-        stats.increment('ol.account.xauth.unlinked')
+        stats.increment("ol.account.xauth.unlinked")
 
     def link(self, itemname) -> None:
         """Careful, this will save any other changes to the ol user object as
         well
         """
-        itemname = itemname if itemname.startswith('@') else f'@{itemname}'
+        itemname = itemname if itemname.startswith("@") else f"@{itemname}"
 
         _ol_account = web.ctx.site.store.get(self._key)
-        _ol_account['internetarchive_itemname'] = itemname
+        _ol_account["internetarchive_itemname"] = itemname
         web.ctx.site.store[self._key] = _ol_account
         self.internetarchive_itemname = itemname
-        stats.increment('ol.account.xauth.linked')
+        stats.increment("ol.account.xauth.linked")
 
     def save_s3_keys(self, s3_keys: dict) -> None:
         _ol_account = web.ctx.site.store.get(self._key)
-        _ol_account['s3_keys'] = s3_keys
+        _ol_account["s3_keys"] = s3_keys
         web.ctx.site.store[self._key] = _ol_account
         self.s3_keys = s3_keys
 
     def update_last_login(self):
         _ol_account = web.ctx.site.store.get(self._key)
         last_login = datetime.datetime.utcnow().isoformat()
-        _ol_account['last_login'] = last_login
+        _ol_account["last_login"] = last_login
         web.ctx.site.store[self._key] = _ol_account
         self.last_login = last_login
 
@@ -745,28 +702,28 @@ class InternetArchiveAccount(web.storage):
             username.
         """
         email = email.strip().lower()
-        screenname = screenname[1:] if screenname[0] == '@' else screenname
+        screenname = screenname[1:] if screenname[0] == "@" else screenname
         notifications = notifications or []
 
         if cls.get(email=email):
-            raise OLAuthenticationError('email_registered')
+            raise OLAuthenticationError("email_registered")
 
         if not screenname:
-            raise OLAuthenticationError('missing_fields')
+            raise OLAuthenticationError("missing_fields")
 
         _screenname = screenname
         attempt = 0
         while True:
             try:
                 response = cls.xauth(
-                    'create',
+                    "create",
                     email=email,
                     password=password,
                     screenname=_screenname,
                     notifications=notifications,
                     test=test,
                     verified=verified,
-                    service='openlibrary',
+                    service="openlibrary",
                 )
             except requests.HTTPError as err:
                 status_code = err.response.status_code
@@ -774,26 +731,26 @@ class InternetArchiveAccount(web.storage):
                     raise OLAuthenticationError("request_timeout")
                 raise OLAuthenticationError("undefined_error")
 
-            if response.get('success'):
+            if response.get("success"):
                 ia_account = cls.get(email=email)
                 if test:
                     ia_account.test = True
                 return ia_account
 
             # Response has returned "failure" with reasons in "values"
-            failures = response.get('values', {})
-            if 'screenname' not in failures:
+            failures = response.get("values", {})
+            if "screenname" not in failures:
                 for field in failures:
                     # raise the first error if multiple
                     # e.g. bad_email, bad_password
-                    error = OLAuthenticationError(f'bad_{field}')
+                    error = OLAuthenticationError(f"bad_{field}")
                     error.response = response
                     raise error
             elif attempt < retries:
                 _screenname = append_random_suffix(screenname)
                 attempt += 1
             else:
-                e = OLAuthenticationError('username_registered')
+                e = OLAuthenticationError("username_registered")
                 e.value = _screenname
                 raise e
 
@@ -805,11 +762,11 @@ class InternetArchiveAccount(web.storage):
         from openlibrary.core import lending
 
         url = xauth_url or lending.config_ia_xauth_api_url
-        params = {'op': op}
+        params = {"op": op}
         data.update(
             {
-                'access': s3_key or lending.config_ia_ol_xauth_s3.get('s3_key'),
-                'secret': s3_secret or lending.config_ia_ol_xauth_s3.get('s3_secret'),
+                "access": s3_key or lending.config_ia_ol_xauth_s3.get("s3_key"),
+                "secret": s3_secret or lending.config_ia_ol_xauth_s3.get("s3_secret"),
             }
         )
 
@@ -820,11 +777,11 @@ class InternetArchiveAccount(web.storage):
         # performing an account `create` xauthn operation and the
         # `service` parameter is present, we need to rename `service`
         # as `activation-type` so it is forwarded correctly to xauth:
-        if op == 'create' and 'service' in data:
-            data['activation-type'] = data.pop('service')
+        if op == "create" and "service" in data:
+            data["activation-type"] = data.pop("service")
 
         if test:
-            params['developer'] = test
+            params["developer"] = test
 
         response = requests.post(url, params=params, json=data)
         if response.status_code == 403:
@@ -837,7 +794,7 @@ class InternetArchiveAccount(web.storage):
             # the server is down or something :P)
             return response.json()
         except ValueError:
-            return {'error': response.text, 'code': response.status_code}
+            return {"error": response.text, "code": response.status_code}
 
     @classmethod
     def s3auth(cls, access_key: str, secret_key: str):
@@ -847,29 +804,25 @@ class InternetArchiveAccount(web.storage):
         url = lending.config_ia_s3_auth_url
 
         if not isinstance(url, str):
-            raise TypeError(
-                f"Expected 'url' to be a string, got {type(url).__name__} instead"
-            )
+            raise TypeError(f"Expected 'url' to be a string, got {type(url).__name__} instead")
 
         try:
             response = requests.get(
                 url,
                 headers={
-                    'Content-Type': 'application/json',
-                    'authorization': f'LOW {access_key}:{secret_key}',
+                    "Content-Type": "application/json",
+                    "authorization": f"LOW {access_key}:{secret_key}",
                 },
             )
             response.raise_for_status()
             return response.json()
         except requests.HTTPError as e:
-            return {'error': e.response.text, 'code': e.response.status_code}
+            return {"error": e.response.text, "code": e.response.status_code}
         except JSONDecodeError as e:
-            return {'error': str(e), 'code': response.status_code}
+            return {"error": str(e), "code": response.status_code}
 
     @classmethod
-    def get(
-        cls, email, test=False, _json=False, s3_key=None, s3_secret=None, xauth_url=None
-    ):
+    def get(cls, email, test=False, _json=False, s3_key=None, s3_secret=None, xauth_url=None):
         email = email.strip().lower()
         response = cls.xauth(
             email=email,
@@ -879,18 +832,18 @@ class InternetArchiveAccount(web.storage):
             s3_secret=s3_secret,
             xauth_url=xauth_url,
         )
-        if 'success' in response:
-            values = response.get('values', {})
+        if "success" in response:
+            values = response.get("values", {})
             return values if _json else cls(**values)
 
     @classmethod
     def authenticate(cls, email, password, test=False):
         email = email.strip().lower()
-        response = cls.xauth('authenticate', test=test, email=email, password=password)
-        if not response.get('success'):
-            reason = response['values'].get('reason')
-            if reason == 'account_not_verified':
-                response['values']['reason'] = 'ia_account_not_verified'
+        response = cls.xauth("authenticate", test=test, email=email, password=password)
+        if not response.get("success"):
+            reason = response["values"].get("reason")
+            if reason == "account_not_verified":
+                response["values"]["reason"] = "ia_account_not_verified"
         return response
 
 
@@ -922,29 +875,26 @@ def audit_accounts(
 
     if s3_access_key and s3_secret_key:
         r = InternetArchiveAccount.s3auth(s3_access_key, s3_secret_key)
-        if not r.get('authorized', False):
-            return {'error': 'invalid_s3keys'}
+        if not r.get("authorized", False):
+            return {"error": "invalid_s3keys"}
         ia_login = {
-            'success': True,
-            'values': {'access': s3_access_key, 'secret': s3_secret_key},
+            "success": True,
+            "values": {"access": s3_access_key, "secret": s3_secret_key},
         }
-        email = r['username']
+        email = r["username"]
     else:
         if not valid_email(email):
-            return {'error': 'invalid_email'}
+            return {"error": "invalid_email"}
         ia_login = InternetArchiveAccount.authenticate(email, password)
 
-    if 'values' in ia_login and any(
-        ia_login['values'].get('reason') == err
-        for err in ['account_blocked', 'account_locked']
-    ):
-        return {'error': 'account_locked'}
+    if "values" in ia_login and any(ia_login["values"].get("reason") == err for err in ["account_blocked", "account_locked"]):
+        return {"error": "account_locked"}
 
-    if not ia_login.get('success'):
+    if not ia_login.get("success"):
         # Prioritize returning other errors over `account_not_found`
-        if ia_login['values'].get('reason') != "account_not_found":
-            return {'error': ia_login['values'].get('reason')}
-        return {'error': 'account_not_found'}
+        if ia_login["values"].get("reason") != "account_not_found":
+            return {"error": ia_login["values"].get("reason")}
+        return {"error": "account_not_found"}
 
     else:
         ia_account = InternetArchiveAccount.get(email=email, test=test)
@@ -973,10 +923,10 @@ def audit_accounts(
             # been linked to a different Internet Archive account.
             if ol_account and ol_account.itemname:
                 logger.error(
-                    'IA <-> OL itemname mismatch',
+                    "IA <-> OL itemname mismatch",
                     extra={
-                        'ol_itemname': ol_account.itemname,
-                        'ia_itemname': ia_account.itemname,
+                        "ol_itemname": ol_account.itemname,
+                        "ia_itemname": ia_account.itemname,
                     },
                 )
                 ol_account.unlink()
@@ -1004,10 +954,10 @@ def audit_accounts(
                     test=test,
                 )
             except ValueError:
-                return {'error': 'max_retries_exceeded'}
+                return {"error": "max_retries_exceeded"}
 
             ol_account.link(ia_account.itemname)
-            stats.increment('ol.account.xauth.ia-auto-created-ol')
+            stats.increment("ol.account.xauth.ia-auto-created-ol")
 
         # So long as there's either a linked OL account, or an unlinked OL account with
         # the same email, set them as linked (and let the finalize logic link them, if
@@ -1015,23 +965,23 @@ def audit_accounts(
         else:
             if not ol_account.itemname:
                 ol_account.link(ia_account.itemname)
-                stats.increment('ol.account.xauth.auto-linked')
+                stats.increment("ol.account.xauth.auto-linked")
             if not ol_account.verified:
                 # The IA account is activated (verifying the integrity of their email),
                 # so we make a judgement call to safely activate them.
                 ol_account.activate()
             if ol_account.blocked:
-                return {'error': 'account_blocked'}
+                return {"error": "account_blocked"}
 
     if require_link:
         ol_account = OpenLibraryAccount.get_by_link(ia_account.itemname)
         if ol_account and not ol_account.itemname:
-            return {'error': 'accounts_not_connected'}
+            return {"error": "accounts_not_connected"}
 
-    if 'values' in ia_login:
+    if "values" in ia_login:
         s3_keys = {
-            'access': ia_login['values'].pop('access'),
-            'secret': ia_login['values'].pop('secret'),
+            "access": ia_login["values"].pop("access"),
+            "secret": ia_login["values"].pop("secret"),
         }
         ol_account.save_s3_keys(s3_keys)
 
@@ -1046,18 +996,18 @@ def audit_accounts(
     web.ctx.conn.set_auth_token(ol_account.generate_login_code())
     ol_account.update_last_login()
     return {
-        'authenticated': True,
-        'special_access': getattr(ia_account, 'has_disability_access', False),
-        'ia_email': ia_account.email,
-        'ol_email': ol_account.email,
-        'ia_username': ia_account.screenname,
-        'ol_username': ol_account.username,
-        'link': ol_account.itemname,
+        "authenticated": True,
+        "special_access": getattr(ia_account, "has_disability_access", False),
+        "ia_email": ia_account.email,
+        "ol_email": ol_account.email,
+        "ia_username": ia_account.screenname,
+        "ol_username": ol_account.username,
+        "link": ol_account.itemname,
     }
 
 
 @public
 def get_internet_archive_id(key: str) -> str | None:
-    username = key.rsplit('/', maxsplit=1)[-1]
+    username = key.rsplit("/", maxsplit=1)[-1]
     ol_account = OpenLibraryAccount.get_by_username(username)
     return ol_account.itemname if ol_account else None

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -68,16 +68,16 @@ class Image:
         self.id = id
 
     def info(self, fetch_author: bool = True) -> dict[str, Any] | None:
-        url = f'{get_coverstore_url()}/{self.category}/id/{self.id}.json'
+        url = f"{get_coverstore_url()}/{self.category}/id/{self.id}.json"
         if url.startswith("//"):
             url = "http:" + url
         try:
             d = requests.get(url, timeout=1).json()
-            d['created'] = parse_datetime(d['created'])
+            d["created"] = parse_datetime(d["created"])
             if fetch_author:
-                if d['author'] == 'None':
-                    d['author'] = None
-                d['author'] = d['author'] and self._site.get(d['author'])
+                if d["author"] == "None":
+                    d["author"] = None
+                d["author"] = d["author"] and self._site.get(d["author"])
 
             return web.storage(d)
         except (requests.exceptions.RequestException, OSError):
@@ -86,7 +86,7 @@ class Image:
 
     def get_aspect_ratio(self) -> float | None:
         info = self.info(fetch_author=False)
-        if info and info.get('width') and info.get('height'):
+        if info and info.get("width") and info.get("height"):
             return info["width"] / info["height"]
         return None
 
@@ -133,12 +133,12 @@ class Thing(client.Thing):
     def _get_history_preview(self) -> dict[str, list[dict]]:
         h = {}
         if self.revision < 5:
-            h['recent'] = self._get_versions(limit=5)
-            h['initial'] = h['recent'][-1:]
-            h['recent'] = h['recent'][:-1]
+            h["recent"] = self._get_versions(limit=5)
+            h["initial"] = h["recent"][-1:]
+            h["recent"] = h["recent"][:-1]
         else:
-            h['initial'] = self._get_versions(limit=1, offset=self.revision - 1)
-            h['recent'] = self._get_versions(limit=4)
+            h["initial"] = self._get_versions(limit=1, offset=self.revision - 1)
+            h["recent"] = self._get_versions(limit=4)
         return h
 
     def _get_versions(self, limit: int, offset: int = 0) -> list[dict]:
@@ -150,7 +150,7 @@ class Thing(client.Thing):
 
             # XXX-Anand: hack to avoid too big data to be stored in memcache.
             # v.changes is not used and it contrinutes to memcache bloat in a big way.
-            v.changes = '[]'
+            v.changes = "[]"
         return versions
 
     def get_most_recent_change(self):
@@ -168,16 +168,14 @@ class Thing(client.Thing):
         # preload them
         self._site.get_many(list(authors))
 
-    def _make_url(
-        self, label: str | None, suffix: str, relative: bool = True, **params
-    ) -> str:
+    def _make_url(self, label: str | None, suffix: str, relative: bool = True, **params) -> str:
         """Make url of the form $key/$label$suffix?$params."""
         if label is not None:
             u = self.key + "/" + urlsafe(label) + suffix
         else:
             u = self.key + suffix
         if params:
-            u += '?' + urlencode(params)
+            u += "?" + urlencode(params)
         if not relative:
             u = _get_ol_base_url() + u
         return u
@@ -298,23 +296,23 @@ class Edition(Thing):
         """
         d = {}
         if self.ocaid:
-            d['has_ebook'] = True
-            d['daisy_url'] = self.url('/daisy')
-            d['daisy_only'] = True
+            d["has_ebook"] = True
+            d["daisy_url"] = self.url("/daisy")
+            d["daisy_only"] = True
 
             collections = self.get_ia_collections()
             borrowable = self.in_borrowable_collection()
 
             if borrowable:
-                d['borrow_url'] = self.url("/borrow")
+                d["borrow_url"] = self.url("/borrow")
                 key = "ebooks" + self.key
                 doc = self._site.store.get(key) or {}
                 # caution, solr borrow status may be stale!
-                d['borrowed'] = doc.get("borrowed") == "true"
-                d['daisy_only'] = False
-            elif 'printdisabled' not in collections:
-                d['read_url'] = f"https://archive.org/stream/{self.ocaid}"
-                d['daisy_only'] = False
+                d["borrowed"] = doc.get("borrowed") == "true"
+                d["daisy_only"] = False
+            elif "printdisabled" not in collections:
+                d["read_url"] = f"https://archive.org/stream/{self.ocaid}"
+                d["daisy_only"] = False
         return d
 
     def get_ia_collections(self):
@@ -322,10 +320,7 @@ class Edition(Thing):
 
     def is_access_restricted(self) -> bool:
         collections = self.get_ia_collections()
-        return bool(collections) and (
-            'printdisabled' in collections
-            or self.get_ia_meta_fields().get("access-restricted") is True
-        )
+        return bool(collections) and ("printdisabled" in collections or self.get_ia_meta_fields().get("access-restricted") is True)
 
     def is_in_private_collection(self) -> bool:
         """Private collections are lendable books that should not be
@@ -335,7 +330,7 @@ class Edition(Thing):
 
     def in_borrowable_collection(self) -> bool:
         collections = self.get_ia_collections()
-        return ('inlibrary' in collections) and not self.is_in_private_collection()
+        return ("inlibrary" in collections) and not self.is_in_private_collection()
 
     def get_waitinglist(self) -> list[WaitingLoan]:
         """Returns list of records for all users currently waiting for this book."""
@@ -343,7 +338,7 @@ class Edition(Thing):
 
     @property  # type: ignore[misc]
     def ia_metadata(self) -> dict:
-        ocaid = self.get('ocaid')
+        ocaid = self.get("ocaid")
         return get_metadata(ocaid) if ocaid else {}
 
     def get_waitinglist_size(self) -> int:
@@ -431,9 +426,9 @@ class Edition(Thing):
         # Attempt to fetch book from OL
         for book_id in book_ids:
             if book_id == asin:
-                query = {"type": "/type/edition", 'identifiers': {'amazon': asin}}
+                query = {"type": "/type/edition", "identifiers": {"amazon": asin}}
             else:
-                query = {"type": "/type/edition", f'isbn_{len(book_id)}': book_id}
+                query = {"type": "/type/edition", f"isbn_{len(book_id)}": book_id}
 
             if matches := web.ctx.site.things(query):
                 return web.ctx.site.get(matches[0])
@@ -449,10 +444,8 @@ class Edition(Thing):
             # is staged in `import_item`.
             try:
                 id_ = asin or book_ids[0]
-                id_type: Literal['asin', 'isbn'] = "asin" if asin else "isbn"
-                get_amazon_metadata(
-                    id_=id_, id_type=id_type, high_priority=high_priority
-                )
+                id_type: Literal["asin", "isbn"] = "asin" if asin else "isbn"
+                get_amazon_metadata(id_=id_, id_type=id_type, high_priority=high_priority)
                 return ImportItem.import_first_staged(identifiers=book_ids)
             except requests.exceptions.ConnectionError:
                 logger.exception("Affiliate Server unreachable")
@@ -472,17 +465,14 @@ class Edition(Thing):
         Create a dummy work from an orphaned_edition.
         """
         return web.ctx.site.new(
-            '',
+            "",
             {
-                'key': '',
-                'type': {'key': '/type/work'},
-                'title': self.title,
-                'authors': [
-                    {'type': {'key': '/type/author_role'}, 'author': {'key': a['key']}}
-                    for a in self.get('authors', [])
-                ],
-                'editions': [self],
-                'subjects': self.get('subjects', []),
+                "key": "",
+                "type": {"key": "/type/work"},
+                "title": self.title,
+                "authors": [{"type": {"key": "/type/author_role"}, "author": {"key": a["key"]}} for a in self.get("authors", [])],
+                "editions": [self],
+                "subjects": self.get("subjects", []),
             },
         )
 
@@ -497,31 +487,31 @@ class ListSeedMetadata(TypedDict):
 
 def does_seed_have_metadata(seed: ListSeedMetadata) -> bool:
     """Returns True if the seed has any metadata."""
-    return bool(seed.get('position') or seed.get('notes'))
+    return bool(seed.get("position") or seed.get("notes"))
 
 
 def update_list_seed_metadata(a: ListSeedMetadata, b: ListSeedMetadata) -> None:
     """Modifies the original ListSeedMetadata inplace."""
 
-    if p := b.get('position'):
-        a['position'] = p
+    if p := b.get("position"):
+        a["position"] = p
     else:
-        a.pop('position', None)
+        a.pop("position", None)
 
-    if n := b.get('notes'):
-        a['notes'] = n
+    if n := b.get("notes"):
+        a["notes"] = n
     else:
-        a.pop('notes', None)
+        a.pop("notes", None)
 
 
-TSeries = TypeVar('TSeries', 'Series', ThingReferenceDict, 'SeriesDict')
+TSeries = TypeVar("TSeries", "Series", ThingReferenceDict, "SeriesDict")
 
 
 class WorkSeriesEdge[TSeries](ListSeedMetadata):
     series: TSeries
 
 
-WorkSeriesEdgeDB = WorkSeriesEdge['Series']
+WorkSeriesEdgeDB = WorkSeriesEdge["Series"]
 """
 Note: In reality, since the DB always wraps dicts in a `Thing` object,
 this will be a `Thing` not a raw dict.
@@ -560,7 +550,7 @@ class Work(Thing):
         return rating
 
     def get_patrons_who_also_read(self):
-        key = self.key.split('/')[-1][2:-1]
+        key = self.key.split("/")[-1][2:-1]
         return Bookshelves.patrons_who_also_read(key)
 
     def get_users_read_status(self, username):
@@ -582,10 +572,7 @@ class Work(Thing):
             return False
         work_id = extract_numeric_id_from_olid(self.key)
         edition_id = extract_numeric_id_from_olid(edition_olid)
-        return (
-            len(Booknotes.get_patron_booknote(username, work_id, edition_id=edition_id))
-            > 0
-        )
+        return len(Booknotes.get_patron_booknote(username, work_id, edition_id=edition_id)) > 0
 
     def get_users_observations(self, username):
         if not username:
@@ -595,39 +582,31 @@ class Work(Thing):
         formatted_observations = defaultdict(list)
 
         for r in raw_observations:
-            kv_pair = Observations.get_key_value_pair(r['type'], r['value'])
+            kv_pair = Observations.get_key_value_pair(r["type"], r["value"])
             formatted_observations[kv_pair.key].append(kv_pair.value)
 
         return formatted_observations
 
     def get_num_users_by_bookshelf(self):
         if not self.key:  # a dummy work
-            return {'want-to-read': 0, 'currently-reading': 0, 'already-read': 0}
+            return {"want-to-read": 0, "currently-reading": 0, "already-read": 0}
         work_id = extract_numeric_id_from_olid(self.key)
-        num_users_by_bookshelf = Bookshelves.get_num_users_by_bookshelf_by_work_id(
-            work_id
-        )
+        num_users_by_bookshelf = Bookshelves.get_num_users_by_bookshelf_by_work_id(work_id)
         return {
-            'want-to-read': num_users_by_bookshelf.get(
-                Bookshelves.PRESET_BOOKSHELVES['Want to Read'], 0
-            ),
-            'currently-reading': num_users_by_bookshelf.get(
-                Bookshelves.PRESET_BOOKSHELVES['Currently Reading'], 0
-            ),
-            'already-read': num_users_by_bookshelf.get(
-                Bookshelves.PRESET_BOOKSHELVES['Already Read'], 0
-            ),
+            "want-to-read": num_users_by_bookshelf.get(Bookshelves.PRESET_BOOKSHELVES["Want to Read"], 0),
+            "currently-reading": num_users_by_bookshelf.get(Bookshelves.PRESET_BOOKSHELVES["Currently Reading"], 0),
+            "already-read": num_users_by_bookshelf.get(Bookshelves.PRESET_BOOKSHELVES["Already Read"], 0),
         }
 
     def get_rating_stats(self):
         if not self.key:  # a dummy work
-            return {'avg_rating': 0, 'num_ratings': 0}
+            return {"avg_rating": 0, "num_ratings": 0}
         work_id = extract_numeric_id_from_olid(self.key)
         rating_stats = Ratings.get_rating_stats(work_id)
-        if rating_stats and rating_stats['num_ratings'] > 0:
+        if rating_stats and rating_stats["num_ratings"] > 0:
             return {
-                'avg_rating': round(rating_stats['avg_rating'], 2),
-                'num_ratings': rating_stats['num_ratings'],
+                "avg_rating": round(rating_stats["avg_rating"], 2),
+                "num_ratings": rating_stats["num_ratings"],
             }
 
     def get_awards(self) -> list:
@@ -671,13 +650,13 @@ class Work(Thing):
 
         The type should be one of subject, place, person or time.
         """
-        if type == 'subject':
+        if type == "subject":
             return [self._make_subject_link(s) for s in self.get_subjects()]
-        elif type == 'place':
+        elif type == "place":
             return [self._make_subject_link(s, "place:") for s in self.subject_places]
-        elif type == 'person':
+        elif type == "person":
             return [self._make_subject_link(s, "person:") for s in self.subject_people]
-        elif type == 'time':
+        elif type == "time":
             return [self._make_subject_link(s, "time:") for s in self.subject_times]
         else:
             return []
@@ -689,13 +668,13 @@ class Work(Thing):
     def find_series_edge(self, series_key: str) -> WorkSeriesEdgeDB | None:
         series = self.series or []
         for s in series:
-            if s['series']['key'] == series_key:
+            if s["series"]["key"] == series_key:
                 return s
         return None
 
     def remove_series_edge(self, series_key: str) -> None:
         series = self.series or []
-        self.series = [s for s in series if s['series']['key'] != series_key]
+        self.series = [s for s in series if s["series"]["key"] != series_key]
 
     def get_ebook_info(self):
         """Returns the ebook info with the following fields.
@@ -720,14 +699,14 @@ class Work(Thing):
         """
         solrdata = web.storage(self._solr_data or {})
         d = {}
-        if solrdata.get('has_fulltext') and solrdata.get('public_scan_b'):
-            d['read_url'] = f"https://archive.org/stream/{solrdata.ia[0]}"
-            d['has_ebook'] = True
-        elif solrdata.get('lending_edition_s'):
-            d['borrow_url'] = f"/books/{solrdata.lending_edition_s}/x/borrow"
-            d['has_ebook'] = True
-        if solrdata.get('ia'):
-            d['ia'] = solrdata.get('ia')
+        if solrdata.get("has_fulltext") and solrdata.get("public_scan_b"):
+            d["read_url"] = f"https://archive.org/stream/{solrdata.ia[0]}"
+            d["has_ebook"] = True
+        elif solrdata.get("lending_edition_s"):
+            d["borrow_url"] = f"/books/{solrdata.lending_edition_s}/x/borrow"
+            d["has_ebook"] = True
+        if solrdata.get("ia"):
+            d["ia"] = solrdata.get("ia")
         return d
 
     @staticmethod
@@ -745,60 +724,43 @@ class Work(Thing):
         return redirect_chain
 
     @classmethod
-    def resolve_redirect_chain(
-        cls, work_key: str, test: bool = False
-    ) -> dict[str, Any]:
+    def resolve_redirect_chain(cls, work_key: str, test: bool = False) -> dict[str, Any]:
         summary: dict[str, Any] = {
-            'key': work_key,
-            'redirect_chain': [],
-            'resolved_key': None,
-            'modified': False,
+            "key": work_key,
+            "redirect_chain": [],
+            "resolved_key": None,
+            "modified": False,
         }
         redirect_chain = cls.get_redirect_chain(work_key)
-        summary['redirect_chain'] = [
-            {"key": thing.key, "occurrences": {}, "updates": {}}
-            for thing in redirect_chain
-        ]
-        summary['resolved_key'] = redirect_chain[-1].key
+        summary["redirect_chain"] = [{"key": thing.key, "occurrences": {}, "updates": {}} for thing in redirect_chain]
+        summary["resolved_key"] = redirect_chain[-1].key
 
-        for r in summary['redirect_chain']:
-            olid = r['key'].split('/')[-1][2:-1]  # 'OL1234x' --> '1234'
-            new_olid = summary['resolved_key'].split('/')[-1][2:-1]
+        for r in summary["redirect_chain"]:
+            olid = r["key"].split("/")[-1][2:-1]  # 'OL1234x' --> '1234'
+            new_olid = summary["resolved_key"].split("/")[-1][2:-1]
 
             # count reading log entries
-            r['occurrences']['readinglog'] = len(Bookshelves.get_works_shelves(olid))
-            r['occurrences']['ratings'] = len(Ratings.get_all_works_ratings(olid))
-            r['occurrences']['booknotes'] = len(Booknotes.get_booknotes_for_work(olid))
-            r['occurrences']['bestbooks'] = Bestbook.get_count(work_id=olid)
-            r['occurrences']['observations'] = len(
-                Observations.get_observations_for_work(olid)
-            )
+            r["occurrences"]["readinglog"] = len(Bookshelves.get_works_shelves(olid))
+            r["occurrences"]["ratings"] = len(Ratings.get_all_works_ratings(olid))
+            r["occurrences"]["booknotes"] = len(Booknotes.get_booknotes_for_work(olid))
+            r["occurrences"]["bestbooks"] = Bestbook.get_count(work_id=olid)
+            r["occurrences"]["observations"] = len(Observations.get_observations_for_work(olid))
 
             if new_olid != olid:
                 # track updates
-                r['updates']['readinglog'] = Bookshelves.update_work_id(
-                    olid, new_olid, _test=test
-                )
-                r['updates']['ratings'] = Ratings.update_work_id(
-                    olid, new_olid, _test=test
-                )
-                r['updates']['booknotes'] = Booknotes.update_work_id(
-                    olid, new_olid, _test=test
-                )
-                r['updates']['observations'] = Observations.update_work_id(
-                    olid, new_olid, _test=test
-                )
-                r['updates']['bestbooks'] = Bestbook.update_work_id(
-                    olid, new_olid, _test=test
-                )
-                summary['modified'] = summary['modified'] or any(
-                    any(r['updates'][group].values())
+                r["updates"]["readinglog"] = Bookshelves.update_work_id(olid, new_olid, _test=test)
+                r["updates"]["ratings"] = Ratings.update_work_id(olid, new_olid, _test=test)
+                r["updates"]["booknotes"] = Booknotes.update_work_id(olid, new_olid, _test=test)
+                r["updates"]["observations"] = Observations.update_work_id(olid, new_olid, _test=test)
+                r["updates"]["bestbooks"] = Bestbook.update_work_id(olid, new_olid, _test=test)
+                summary["modified"] = summary["modified"] or any(
+                    any(r["updates"][group].values())
                     for group in [
-                        'readinglog',
-                        'ratings',
-                        'booknotes',
-                        'observations',
-                        'bestbooks',
+                        "readinglog",
+                        "ratings",
+                        "booknotes",
+                        "observations",
+                        "bestbooks",
                     ]
                 )
 
@@ -815,14 +777,12 @@ class Work(Thing):
                 "limit": batch_size,
                 "offset": (batch * batch_size),
                 "sort": "-last_modified",
-                "last_modified>": day.strftime('%Y-%m-%d'),
-                "last_modified<": tomorrow.strftime('%Y-%m-%d'),
+                "last_modified>": day.strftime("%Y-%m-%d"),
+                "last_modified<": tomorrow.strftime("%Y-%m-%d"),
             }
         )
         more = len(work_redirect_ids) == batch_size
-        logger.info(
-            f"[update-redirects] batch: {batch}, size {batch_size}, offset {batch * batch_size}, more {more}, len {len(work_redirect_ids)}"
-        )
+        logger.info(f"[update-redirects] batch: {batch}, size {batch_size}, offset {batch * batch_size}, more {more}, len {len(work_redirect_ids)}")
         return work_redirect_ids, more
 
     @classmethod
@@ -851,24 +811,18 @@ class Work(Thing):
             batch = 0
             while has_more:
                 logger.info(
-                    f"[update-redirects] {current_date}, batch {batch+1}: #{total}",
+                    f"[update-redirects] {current_date}, batch {batch + 1}: #{total}",
                 )
-                work_redirect_ids, has_more = cls.get_redirects(
-                    current_date, batch_size=batch_size, batch=batch
-                )
+                work_redirect_ids, has_more = cls.get_redirects(current_date, batch_size=batch_size, batch=batch)
                 work_redirect_batch = web.ctx.site.get_many(work_redirect_ids)
                 for work in work_redirect_batch:
                     total += 1
                     chain = Work.resolve_redirect_chain(work.key, test=test)
-                    if chain['modified']:
+                    if chain["modified"]:
                         fixed += 1
-                        logger.info(
-                            f"[update-redirects] {current_date}, Update: #{total} fix#{fixed} batch#{batch} <{work.key}> {chain}"
-                        )
+                        logger.info(f"[update-redirects] {current_date}, Update: #{total} fix#{fixed} batch#{batch} <{work.key}> {chain}")
                     else:
-                        logger.info(
-                            f"[update-redirects] No Update Required: #{total} <{work.key}>"
-                        )
+                        logger.info(f"[update-redirects] No Update Required: #{total} <{work.key}>")
                 batch += 1
             current_date = current_date - timedelta(days=1)
 
@@ -888,13 +842,9 @@ class Author(Thing):
     def get_url_suffix(self):
         return self.name or "unnamed"
 
-    def wikidata(
-        self, bust_cache: bool = False, fetch_missing: bool = False
-    ) -> WikidataEntity | None:
+    def wikidata(self, bust_cache: bool = False, fetch_missing: bool = False) -> WikidataEntity | None:
         if wd_id := self.remote_ids.get("wikidata"):
-            return get_wikidata_entity(
-                qid=wd_id, bust_cache=bust_cache, fetch_missing=fetch_missing
-            )
+            return get_wikidata_entity(qid=wd_id, bust_cache=bust_cache, fetch_missing=fetch_missing)
         return None
 
     def __repr__(self):
@@ -907,23 +857,21 @@ class Author(Thing):
         Friend of a friend ontology Agent type. http://xmlns.com/foaf/spec/#term_Agent
         https://en.wikipedia.org/wiki/FOAF_(ontology)
         """
-        if self.get('entity_type') == 'org':
-            return 'Organization'
-        elif self.get('birth_date') or self.get('death_date'):
-            return 'Person'
-        return 'Agent'
+        if self.get("entity_type") == "org":
+            return "Organization"
+        elif self.get("birth_date") or self.get("death_date"):
+            return "Person"
+        return "Agent"
 
     def get_edition_count(self):
-        return self._site._request('/count_editions_by_author', data={'key': self.key})
+        return self._site._request("/count_editions_by_author", data={"key": self.key})
 
     edition_count = property(get_edition_count)
 
     def get_lists(self, limit=50, offset=0, sort=True):
         return self._get_lists(limit=limit, offset=offset, sort=sort)
 
-    def merge_remote_ids(
-        self, incoming_ids: dict[str, str]
-    ) -> tuple[dict[str, str], int]:
+    def merge_remote_ids(self, incoming_ids: dict[str, str]) -> tuple[dict[str, str], int]:
         """Returns the author's remote IDs merged with a given remote IDs object, as well as a count for how many IDs had conflicts.
         If incoming_ids is empty, or if there are more conflicts than matches, no merge will be attempted, and the output will be (author.remote_ids, -1).
         """
@@ -938,9 +886,7 @@ class Author(Thing):
             if identifier in output and identifier in incoming_ids:
                 if output[identifier] != incoming_ids[identifier]:
                     # For now, cause an error so we can see when/how often this happens
-                    raise AuthorRemoteIdConflictError(
-                        f"Conflicting remote IDs for author {self.key}: {output[identifier]} vs {incoming_ids[identifier]}"
-                    )
+                    raise AuthorRemoteIdConflictError(f"Conflicting remote IDs for author {self.key}: {output[identifier]} vs {incoming_ids[identifier]}")
                 else:
                     matches = matches + 1
         return output, matches
@@ -948,7 +894,7 @@ class Author(Thing):
 
 class User(Thing):
     def get_default_preferences(self) -> dict[str, str]:
-        return {'update': 'no', 'public_readlog': 'no', 'type': 'preferences'}
+        return {"update": "no", "public_readlog": "no", "type": "preferences"}
         # New users are now public by default for new patrons
         # As of 2020-05, OpenLibraryAccount.create will
         # explicitly set public_readlog: 'yes'.
@@ -956,7 +902,7 @@ class User(Thing):
         # will continue to default to 'no'
 
     def get_usergroups(self):
-        keys = self._site.things({'type': '/type/usergroup', 'members': self.key})
+        keys = self._site.things({"type": "/type/usergroup", "members": self.key})
         return self._site.get_many(keys)
 
     usergroups = property(get_usergroups)
@@ -981,16 +927,16 @@ class User(Thing):
         return query_store(key) or self.get_default_preferences()
 
     def save_preferences(self, new_prefs) -> None:
-        key = f'{self.key}/preferences'
+        key = f"{self.key}/preferences"
         prefs = self.preferences()
         prefs.update(new_prefs)
-        prefs['_rev'] = None
-        prefs['type'] = 'preferences'
+        prefs["_rev"] = None
+        prefs["type"] = "preferences"
         web.ctx.site.store[key] = prefs
 
     def is_usergroup_member(self, usergroup: str) -> bool:
-        if not usergroup.startswith('/usergroup/'):
-            usergroup = f'/usergroup/{usergroup}'
+        if not usergroup.startswith("/usergroup/"):
+            usergroup = f"/usergroup/{usergroup}"
         return usergroup in [g.key for g in self.usergroups]
 
     def is_member_of_any(self, usergroups: list[str]) -> bool:
@@ -1001,35 +947,31 @@ class User(Thing):
 
     def is_subscribed_user(self, username: str) -> int:
         my_username = self.get_username()
-        return (
-            PubSub.is_subscribed(my_username, username)
-            if my_username != username
-            else -1
-        )
+        return PubSub.is_subscribed(my_username, username) if my_username != username else -1
 
     def has_cookie(self, name):
         return web.cookies().get(name, False)
 
     def is_printdisabled(self):
-        return web.cookies().get('pd')
+        return web.cookies().get("pd")
 
     def is_admin(self) -> bool:
-        return self.is_usergroup_member('/usergroup/admin')
+        return self.is_usergroup_member("/usergroup/admin")
 
     def is_librarian(self) -> bool:
-        return self.is_usergroup_member('/usergroup/librarians')
+        return self.is_usergroup_member("/usergroup/librarians")
 
     def is_super_librarian(self) -> bool:
-        return self.is_usergroup_member('/usergroup/super-librarians')
+        return self.is_usergroup_member("/usergroup/super-librarians")
 
     def is_beta_tester(self) -> bool:
-        return self.is_usergroup_member('/usergroup/beta-testers')
+        return self.is_usergroup_member("/usergroup/beta-testers")
 
     def is_read_only(self) -> bool:
-        return self.is_usergroup_member('/usergroup/read-only')
+        return self.is_usergroup_member("/usergroup/read-only")
 
     def is_curator(self) -> bool:
-        return self.is_usergroup_member('/usergroup/curators')
+        return self.is_usergroup_member("/usergroup/curators")
 
     def get_lists(self, seed=None, limit=100, offset=0, sort=True):
         """Returns all the lists of this user.
@@ -1055,14 +997,14 @@ class User(Thing):
         engine="memcache",
         key=lambda cls, username: f"user-avatar-{username}",
         expires=24 * 3600,
-        cacheable=lambda key, value: not value.endswith('/None'),
+        cacheable=lambda key, value: not value.endswith("/None"),
     )
     def get_avatar_url(cls, username: str) -> str:
-        username = username.rsplit('/people/', maxsplit=1)[-1]
-        user = web.ctx.site.get(f'/people/{username}')
-        itemname = user.get_account().get('internetarchive_itemname')
+        username = username.rsplit("/people/", maxsplit=1)[-1]
+        user = web.ctx.site.get(f"/people/{username}")
+        itemname = user.get_account().get("internetarchive_itemname")
 
-        return f'https://archive.org/services/img/{itemname}'
+        return f"https://archive.org/services/img/{itemname}"
 
     @cache.memoize(engine="memcache", key=lambda self: ("d" + self.key, "l"))
     def _get_lists_cached(self):
@@ -1078,7 +1020,7 @@ class User(Thing):
         if seed:
             if isinstance(seed, Thing):
                 seed = {"key": seed.key}
-            q['seeds'] = seed
+            q["seeds"] = seed
 
         return self._site.things(q)
 
@@ -1131,13 +1073,9 @@ class User(Thing):
         """
         from ..plugins.upstream import borrow  # noqa: F401 side effects may be needed
 
-        loans = (
-            lending.get_cached_loans_of_user(self.key)
-            if use_cache
-            else lending.get_loans_of_user(self.key)
-        )
+        loans = lending.get_cached_loans_of_user(self.key) if use_cache else lending.get_loans_of_user(self.key)
         for loan in loans:
-            if ocaid == loan['ocaid']:
+            if ocaid == loan["ocaid"]:
                 return loan
 
     def get_waiting_loan_for(self, ocaid):
@@ -1153,18 +1091,10 @@ class User(Thing):
         :param str or None ocaid: edition ocaid
         :rtype: dict (e.g. {position: number})
         """
-        all_user_waiting_loans = (
-            lending.get_cached_user_waiting_loans
-            if use_cache
-            else lending.get_user_waiting_loans
-        )(self.key)
+        all_user_waiting_loans = (lending.get_cached_user_waiting_loans if use_cache else lending.get_user_waiting_loans)(self.key)
         if ocaid:
             return next(
-                (
-                    loan
-                    for loan in all_user_waiting_loans
-                    if loan['identifier'] == ocaid
-                ),
+                (loan for loan in all_user_waiting_loans if loan["identifier"] == ocaid),
                 None,
             )
         return all_user_waiting_loans
@@ -1180,7 +1110,7 @@ class User(Thing):
         :param str cls: HTML class to add to the link
         :rtype: str
         """
-        extra_attrs = ''
+        extra_attrs = ""
         if cls:
             extra_attrs += f'class="{cls}" '
         # Why nofollow?
@@ -1198,7 +1128,7 @@ class UserGroup(Thing):
         :param str key: e.g. /usergroup/foo
         :rtype: UserGroup | None
         """
-        if not key.startswith('/usergroup/'):
+        if not key.startswith("/usergroup/"):
             key = f"/usergroup/{key}"
         return web.ctx.site.get(key)
 
@@ -1212,9 +1142,9 @@ class UserGroup(Thing):
             raise KeyError("Invalid userkey")
 
         # Make sure userkey not already in group members:
-        members = self.get('members', [])
-        if not any(userkey == member['key'] for member in members):
-            members.append({'key': userkey})
+        members = self.get("members", [])
+        if not any(userkey == member["key"] for member in members):
+            members.append({"key": userkey})
             self.members = members
             web.ctx.site.save(
                 self.dict(),
@@ -1226,11 +1156,11 @@ class UserGroup(Thing):
         if not web.ctx.site.get(userkey):
             raise KeyError("Invalid userkey")
 
-        members = self.get('members', [])
+        members = self.get("members", [])
 
         # find index of userkey and remove user
         for i, m in enumerate(members):
-            if m.get('key', None) == userkey:
+            if m.get("key", None) == userkey:
                 members.pop(i)
                 break
 
@@ -1272,7 +1202,7 @@ class Subject(web.storage):
     def url(self, suffix="", relative=True, **params):
         u = self.key + suffix
         if params:
-            u += '?' + urlencode(params)
+            u += "?" + urlencode(params)
         if not relative:
             u = _get_ol_base_url() + u
         return u
@@ -1310,9 +1240,9 @@ class Tag(Thing):
     @classmethod
     def find(cls, tag_name, tag_type=None):
         """Returns a list of keys for Tags whose slugs contain the normalized tag_name."""
-        q = {'type': '/type/tag', 'slugs': cls.normalize(tag_name)}
+        q = {"type": "/type/tag", "slugs": cls.normalize(tag_name)}
         if tag_type:
-            q['tag_type'] = tag_type
+            q["tag_type"] = tag_type
         matches = list(web.ctx.site.things(q))
         return matches
 
@@ -1320,14 +1250,14 @@ class Tag(Thing):
     def create(
         cls,
         tag,
-        ip='127.0.0.1',
-        comment='New Tag',
+        ip="127.0.0.1",
+        comment="New Tag",
     ):
         """Creates a new Tag object."""
         current_user = web.ctx.site.get_user()
-        patron = current_user.get_username() if current_user else 'ImportBot'
-        key = web.ctx.site.new_key('/type/tag')
-        tag['key'] = key
+        patron = current_user.get_username() if current_user else "ImportBot"
+        key = web.ctx.site.new_key("/type/tag")
+        tag["key"] = key
 
         from openlibrary.accounts import RunAs
 
@@ -1379,25 +1309,25 @@ class LoggedBooksData:
 
 def register_models():
     client.register_thing_class(None, Thing)  # default
-    client.register_thing_class('/type/edition', Edition)
-    client.register_thing_class('/type/work', Work)
-    client.register_thing_class('/type/author', Author)
-    client.register_thing_class('/type/user', User)
-    client.register_thing_class('/type/usergroup', UserGroup)
-    client.register_thing_class('/type/tag', Tag)
+    client.register_thing_class("/type/edition", Edition)
+    client.register_thing_class("/type/work", Work)
+    client.register_thing_class("/type/author", Author)
+    client.register_thing_class("/type/user", User)
+    client.register_thing_class("/type/usergroup", UserGroup)
+    client.register_thing_class("/type/tag", Tag)
 
 
 def register_types():
     """Register default types for various path patterns used in OL."""
     from infogami.utils import types
 
-    types.register_type('^/authors/[^/]*$', '/type/author')
-    types.register_type('^/books/[^/]*$', '/type/edition')
-    types.register_type('^/works/[^/]*$', '/type/work')
-    types.register_type('^/languages/[^/]*$', '/type/language')
-    types.register_type('^/tags/[^/]*$', '/type/tag')
+    types.register_type("^/authors/[^/]*$", "/type/author")
+    types.register_type("^/books/[^/]*$", "/type/edition")
+    types.register_type("^/works/[^/]*$", "/type/work")
+    types.register_type("^/languages/[^/]*$", "/type/language")
+    types.register_type("^/tags/[^/]*$", "/type/tag")
 
-    types.register_type('^/usergroup/[^/]*$', '/type/usergroup')
-    types.register_type('^/permission/[^/]*$', '/type/permission')
+    types.register_type("^/usergroup/[^/]*$", "/type/usergroup")
+    types.register_type("^/permission/[^/]*$", "/type/permission")
 
-    types.register_type('^/(css|js)/[^/]*$', '/type/rawtext')
+    types.register_type("^/(css|js)/[^/]*$", "/type/rawtext")

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -54,7 +54,6 @@ logger = logging.getLogger(__name__)
 
 
 class ratings:
-
     @staticmethod
     def get_ratings_summary(work_id):
         from openlibrary.core.ratings import Ratings
@@ -111,24 +110,18 @@ class booknotes(delegate.page):
             raise web.seeother("/account/login?redirect=/works/%s" % work_id)
 
         i = web.input(notes=None, edition_id=None, redir=None)
-        edition_id = (
-            int(extract_numeric_id_from_olid(i.edition_id)) if i.edition_id else -1
-        )
+        edition_id = int(extract_numeric_id_from_olid(i.edition_id)) if i.edition_id else -1
 
         username = user.key.split("/")[2]
 
         def response(msg, status="success"):
-            return delegate.RawText(
-                json.dumps({status: msg}), content_type="application/json"
-            )
+            return delegate.RawText(json.dumps({status: msg}), content_type="application/json")
 
         if i.notes is None:
             Booknotes.remove(username, work_id, edition_id=edition_id)
             return response("removed note")
 
-        Booknotes.add(
-            username=username, work_id=work_id, notes=i.notes, edition_id=edition_id
-        )
+        Booknotes.add(username=username, work_id=work_id, notes=i.notes, edition_id=edition_id)
 
         if i.redir:
             raise web.seeother("/works/%s" % work_id)
@@ -194,12 +187,8 @@ class work_bookshelves(delegate.page):
                 content_type="application/json",
             )
 
-        if (
-            (not i.dont_remove) and bookshelf_id == current_status
-        ) or bookshelf_id == -1:
-            work_bookshelf = Bookshelves.remove(
-                username=username, work_id=work_id, bookshelf_id=current_status
-            )
+        if ((not i.dont_remove) and bookshelf_id == current_status) or bookshelf_id == -1:
+            work_bookshelf = Bookshelves.remove(username=username, work_id=work_id, bookshelf_id=current_status)
             BookshelvesEvents.delete_by_username_and_work(username, work_id)
 
         else:
@@ -226,9 +215,7 @@ class work_editions(delegate.page):
     def GET(self, key):
         doc = web.ctx.site.get(key)
         if not doc or doc.type.key != "/type/work":
-            raise web.HTTPError(
-                "404 Not Found", {"Content-Type": "application/json"}, data="{}"
-            )
+            raise web.HTTPError("404 Not Found", {"Content-Type": "application/json"}, data="{}")
         else:
             i = web.input(limit=50, offset=0)
             limit = h.safeint(i.limit) or 50
@@ -273,9 +260,7 @@ class author_works(delegate.page):
     def GET(self, key):
         doc = web.ctx.site.get(key)
         if not doc or doc.type.key != "/type/author":
-            raise web.HTTPError(
-                "404 Not Found", {"Content-Type": "application/json"}, data="{}"
-            )
+            raise web.HTTPError("404 Not Found", {"Content-Type": "application/json"}, data="{}")
         else:
             i = web.input(limit=50, offset=0)
             limit = h.safeint(i.limit, 50)
@@ -314,14 +299,14 @@ class author_works(delegate.page):
 
 
 async def get_price_data_async(isbn: str, asin: str) -> dict[str, Any]:
-    id_type_short: Literal['asin', 'isbn'] = "asin" if asin else "isbn"
+    id_type_short: Literal["asin", "isbn"] = "asin" if asin else "isbn"
     id_ = asin or (normalize_isbn(isbn) or isbn)
 
     metadata: dict = {
         "amazon": get_amazon_metadata(id_, id_type=id_type_short) or {},
         "betterworldbooks": {},
     }
-    if id_type_short == 'isbn':
+    if id_type_short == "isbn":
         metadata["betterworldbooks"] = await get_betterworldbooks_metadata(id_)
 
     # fetch book by isbn if it exists
@@ -408,9 +393,7 @@ class patrons_observations(delegate.page):
             kv_pair = Observations.get_key_value_pair(r["type"], r["value"])
             patron_observations[kv_pair.key].append(kv_pair.value)
 
-        return delegate.RawText(
-            json.dumps(patron_observations), content_type="application/json"
-        )
+        return delegate.RawText(json.dumps(patron_observations), content_type="application/json")
 
     def POST(self, work_id):
         user = accounts.get_current_user()
@@ -420,14 +403,10 @@ class patrons_observations(delegate.page):
 
         data = json.loads(web.data())
 
-        Observations.persist_observation(
-            data["username"], work_id, data["observation"], data["action"]
-        )
+        Observations.persist_observation(data["username"], work_id, data["observation"], data["action"])
 
         def response(msg, status="success"):
-            return delegate.RawText(
-                json.dumps({status: msg}), content_type="application/json"
-            )
+            return delegate.RawText(json.dumps({status: msg}), content_type="application/json")
 
         return response("Observations added")
 
@@ -441,9 +420,7 @@ class patrons_observations(delegate.page):
         Observations.remove_observations(username, work_id)
 
         def response(msg, status="success"):
-            return delegate.RawText(
-                json.dumps({status: msg}), content_type="application/json"
-            )
+            return delegate.RawText(json.dumps({status: msg}), content_type="application/json")
 
         return response("Observations removed")
 
@@ -499,9 +476,7 @@ class work_delete(delegate.page):
 
         editions: list[dict] = self.get_editions_of_work(work)
         keys_to_delete: list = [el.get("key") for el in [*editions, work.dict()]]
-        delete_payload: list[dict] = [
-            {"key": key, "type": {"key": "/type/delete"}} for key in keys_to_delete
-        ]
+        delete_payload: list[dict] = [{"key": key, "type": {"key": "/type/delete"}} for key in keys_to_delete]
 
         web.ctx.site.save_many(delete_payload, comment, action="bulk-delete-books")
         return delegate.RawText(
@@ -528,13 +503,9 @@ class hide_banner(delegate.page):
         if user and data["cookie-name"].startswith("yrg"):
             user.save_preferences({"yrg_banner_pref": data["cookie-name"]})
 
-        web.setcookie(
-            data["cookie-name"], "1", expires=(cookie_duration_days * DAY_SECONDS)
-        )
+        web.setcookie(data["cookie-name"], "1", expires=(cookie_duration_days * DAY_SECONDS))
 
-        return delegate.RawText(
-            json.dumps({"success": "Preference saved"}), content_type="application/json"
-        )
+        return delegate.RawText(json.dumps({"success": "Preference saved"}), content_type="application/json")
 
 
 class create_qrcode(delegate.page):
@@ -623,9 +594,7 @@ class bestbook_count(delegate.page):
     @jsonapi
     def GET(self):
         filt = web.input(work_id=None, username=None, topic=None)
-        result = Bestbook.get_count(
-            work_id=filt.work_id, username=filt.username, topic=filt.topic
-        )
+        result = Bestbook.get_count(work_id=filt.work_id, username=filt.username, topic=filt.topic)
         return json.dumps({"count": result})
 
 
@@ -826,9 +795,7 @@ class opds_home(delegate.page):
             if is_bot():
                 key += ".bot"
 
-            mc = cache.memcache_memoize(
-                build_homepage, key, timeout=five_minutes, prethread=caching_prethread()
-            )
+            mc = cache.memcache_memoize(build_homepage, key, timeout=five_minutes, prethread=caching_prethread())
             page = mc()
 
             if not page:
@@ -853,13 +820,9 @@ class unlink_ia_ol(delegate.page):
 
         try:
             if not HMACToken.verify(digest, msg, "ia_sync_secret", unix_time=True):
-                raise web.HTTPError(
-                    "401 Unauthorized", {"Content-Type": "application/json"}
-                )
+                raise web.HTTPError("401 Unauthorized", {"Content-Type": "application/json"})
         except (ValueError, ExpiredTokenError):
-            raise web.HTTPError(
-                "401 Unauthorized", {"Content-Type": "application/json"}
-            )
+            raise web.HTTPError("401 Unauthorized", {"Content-Type": "application/json"})
 
         parts = msg.split("|", maxsplit=1)
         if len(parts) != 2 or not all(parts):
@@ -872,11 +835,7 @@ class unlink_ia_ol(delegate.page):
 
         # Fetch affected editions
         edition_keys = web.ctx.site.things({"type": "/type/edition", "ocaid": ocaid})
-        edition_keys.extend(
-            web.ctx.site.things(
-                {"type": "/type/edition", "source_records": f"ia:{ocaid}"}
-            )
-        )
+        edition_keys.extend(web.ctx.site.things({"type": "/type/edition", "source_records": f"ia:{ocaid}"}))
         edition_keys = list(set(edition_keys))
         if not edition_keys:
             raise web.HTTPError("404 Not Found", {"Content-Type": "application/json"})
@@ -888,9 +847,7 @@ class unlink_ia_ol(delegate.page):
             for edition in editions:
                 self.make_dark(edition, ocaid)
         except ClientException as e:
-            logger.error(
-                f"Failed to disassociate record with key {edition.key}", exc_info=True
-            )
+            logger.error(f"Failed to disassociate record with key {edition.key}", exc_info=True)
             raise web.HTTPError(
                 "500 Internal Server Error",
                 {"Content-Type": "application/json"},
@@ -908,8 +865,8 @@ class unlink_ia_ol(delegate.page):
         data["source_records"] = [rec for rec in source_records if rec != f"ia:{ocaid}"]
         if not data["source_records"]:
             del data["source_records"]
-        with accounts.RunAs('ImportBot'):
-            web.ctx.ip = web.ctx.ip or '127.0.0.1'
+        with accounts.RunAs("ImportBot"):
+            web.ctx.ip = web.ctx.ip or "127.0.0.1"
             web.ctx.site.save(
                 data,
                 "Remove OCAID: Item no longer available to borrow.",
@@ -928,13 +885,9 @@ class link_ia_ol(delegate.page):
 
         try:
             if not HMACToken.verify(digest, msg, "ia_sync_secret", unix_time=True):
-                raise web.HTTPError(
-                    "401 Unauthorized", {"Content-Type": "application/json"}
-                )
+                raise web.HTTPError("401 Unauthorized", {"Content-Type": "application/json"})
         except (ValueError, ExpiredTokenError):
-            raise web.HTTPError(
-                "401 Unauthorized", {"Content-Type": "application/json"}
-            )
+            raise web.HTTPError("401 Unauthorized", {"Content-Type": "application/json"})
 
         parts = msg.split("|", maxsplit=2)
         if len(parts) != 3 or not all(parts):
@@ -946,7 +899,7 @@ class link_ia_ol(delegate.page):
         ocaid, olid, _ts = parts
 
         # Fetch affected edition
-        edition = web.ctx.site.get(f'/books/{olid}')
+        edition = web.ctx.site.get(f"/books/{olid}")
         if not edition:
             raise web.HTTPError("404 Not Found", {"Content-Type": "application/json"})
 
@@ -968,10 +921,8 @@ class link_ia_ol(delegate.page):
         data = edition.dict()
         data["ocaid"] = ocaid
         with accounts.RunAs("ImportBot"):
-            web.ctx.ip = web.ctx.ip or '127.0.0.1'
-            web.ctx.site.save(
-                data, "Associate OCAID with record", action="edit-edition-ocaid"
-            )
+            web.ctx.ip = web.ctx.ip or "127.0.0.1"
+            web.ctx.site.save(data, "Associate OCAID with record", action="edit-edition-ocaid")
 
 
 class monthly_logins(delegate.page):

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -33,7 +33,7 @@ from openlibrary.utils.request_context import (
 )
 
 # make sure infogami.config.features is set
-if not hasattr(infogami.config, 'features'):
+if not hasattr(infogami.config, "features"):
     infogami.config.features = []  # type: ignore[attr-defined]
 
 
@@ -79,8 +79,8 @@ delegate.app.add_processor(processors.ReadableUrlProcessor())
 delegate.app.add_processor(processors.ProfileProcessor())
 delegate.app.add_processor(
     processors.CORSProcessor(
-        cors_paths={'/opds'},
-        cors_prefixes={'/api/', '/opds/'},
+        cors_paths={"/opds"},
+        cors_prefixes={"/api/", "/opds/"},
     )
 )
 delegate.app.add_processor(processors.PreferenceProcessor())
@@ -96,13 +96,13 @@ except:
     api = None  # type: ignore[assignment]
 
 # http header extension for OL API
-infogami.config.http_ext_header_uri = 'http://openlibrary.org/dev/docs/api'  # type: ignore[attr-defined]
+infogami.config.http_ext_header_uri = "http://openlibrary.org/dev/docs/api"  # type: ignore[attr-defined]
 
 # setup special connection with caching support
 from openlibrary.plugins.openlibrary import connection
 
-client._connection_types['ol'] = connection.OLConnection  # type: ignore[assignment]
-infogami.config.infobase_parameters = {'type': 'ol'}
+client._connection_types["ol"] = connection.OLConnection  # type: ignore[assignment]
+infogami.config.infobase_parameters = {"type": "ol"}
 
 # set up infobase schema. required when running in standalone mode.
 from openlibrary.core import schema
@@ -120,16 +120,14 @@ list_models.register_models()
 list_models.register_types()
 
 # Remove movefiles install hook. openlibrary manages its own files.
-infogami._install_hooks = [
-    h for h in infogami._install_hooks if h.__name__ != 'movefiles'
-]
+infogami._install_hooks = [h for h in infogami._install_hooks if h.__name__ != "movefiles"]
 
 from openlibrary.plugins.openlibrary import bulk_tag, lists
 
 lists.setup()
 bulk_tag.setup()
 
-logger = logging.getLogger('openlibrary')
+logger = logging.getLogger("openlibrary")
 
 
 class hooks(client.hook):
@@ -139,27 +137,21 @@ class hooks(client.hook):
         user = get_current_user()
         account = user and user.get_account()
         if account and account.is_blocked():
-            raise ValidationException(
-                'Your account has been suspended. You are not allowed to make any edits.'
-            )
+            raise ValidationException("Your account has been suspended. You are not allowed to make any edits.")
 
-        if page.key.startswith('/a/') or page.key.startswith('/authors/'):
-            if page.type.key == '/type/author':
+        if page.key.startswith("/a/") or page.key.startswith("/authors/"):
+            if page.type.key == "/type/author":
                 return
 
-            books = s.things({'type': '/type/edition', 'authors': page.key})
-            books = books or s.things(
-                {'type': '/type/work', 'authors': {'author': {'key': page.key}}}
-            )
-            if page.type.key == '/type/delete' and books:
+            books = s.things({"type": "/type/edition", "authors": page.key})
+            books = books or s.things({"type": "/type/work", "authors": {"author": {"key": page.key}}})
+            if page.type.key == "/type/delete" and books:
                 raise ValidationException(
-                    'This Author page cannot be deleted as %d record(s) still reference this id. Please remove or reassign before trying again. Referenced by: %s'
+                    "This Author page cannot be deleted as %d record(s) still reference this id. Please remove or reassign before trying again. Referenced by: %s"
                     % (len(books), books)
                 )
-            elif page.type.key != '/type/author' and books:
-                raise ValidationException(
-                    'Changing type of author pages is not allowed.'
-                )
+            elif page.type.key != "/type/author" and books:
+                raise ValidationException("Changing type of author pages is not allowed.")
 
 
 @infogami.action
@@ -170,8 +162,8 @@ def sampledump():
         def f(k):
             if isinstance(k, dict):
                 return web.ctx.site.things(k)
-            elif k.endswith('*'):
-                return web.ctx.site.things({'key~': k})
+            elif k.endswith("*"):
+                return web.ctx.site.things({"key~": k})
             else:
                 return [k]
 
@@ -186,8 +178,8 @@ def sampledump():
             result = []
 
         if isinstance(data, dict):
-            if 'key' in data:
-                result.append(data['key'])
+            if "key" in data:
+                result.append(data["key"])
             else:
                 get_references(data.values(), result)
         elif isinstance(data, list):
@@ -199,11 +191,11 @@ def sampledump():
     visited = set()
 
     def visit(key):
-        if key in visited or key.startswith('/type/'):
+        if key in visited or key.startswith("/type/"):
             return
         elif key in visiting:
             # This is a case of circular-dependency. Add a stub object to break it.
-            print(json.dumps({'key': key, 'type': visiting[key]['type']}))
+            print(json.dumps({"key": key, "type": visiting[key]["type"]}))
             visited.add(key)
             return
 
@@ -212,9 +204,9 @@ def sampledump():
             return
 
         d = thing.dict()
-        d.pop('permission', None)
-        d.pop('child_permission', None)
-        d.pop('table_of_contents', None)
+        d.pop("permission", None)
+        d.pop("child_permission", None)
+        d.pop("table_of_contents", None)
 
         visiting[key] = d
         for ref in get_references(d.values()):
@@ -224,11 +216,11 @@ def sampledump():
         print(json.dumps(d))
 
     keys = [
-        '/scan_record',
-        '/scanning_center',
-        {'type': '/type/scan_record', 'limit': 10},
+        "/scan_record",
+        "/scanning_center",
+        {"type": "/type/scan_record", "limit": 10},
     ]
-    keys = expand_keys(keys) + ['/b/OL%dM' % i for i in range(1, 100)]
+    keys = expand_keys(keys) + ["/b/OL%dM" % i for i in range(1, 100)]
     visited = set()
 
     for k in keys:
@@ -236,197 +228,192 @@ def sampledump():
 
 
 @infogami.action
-def sampleload(filename='sampledump.txt.gz'):
+def sampleload(filename="sampledump.txt.gz"):
 
-    with gzip.open(filename) if filename.endswith('.gz') else open(filename) as file:
+    with gzip.open(filename) if filename.endswith(".gz") else open(filename) as file:
         queries = [json.loads(line) for line in file]
 
     print(web.ctx.site.save_many(queries, action="infogami-sampleload-action"))
 
 
 class routes(delegate.page):
-    path = '/developers/routes'
+    path = "/developers/routes"
 
     def GET(self):
         class ModulesToStr(json.JSONEncoder):
             def default(self, obj):
                 if isinstance(obj, metapage):
-                    return obj.__module__ + '.' + obj.__name__
+                    return obj.__module__ + "." + obj.__name__
                 return super().default(obj)
 
         from openlibrary import code
 
-        return '<pre>%s</pre>' % json.dumps(
+        return "<pre>%s</pre>" % json.dumps(
             code.delegate.pages,
             cls=ModulesToStr,
             indent=4,
-            separators=(',', ': '),
+            separators=(",", ": "),
         )
 
 
 class team(delegate.page):
-    path = '/about/team'
+    path = "/about/team"
 
     def GET(self):
         return render_template("about/index.html")
 
 
 class addbook(delegate.page):
-    path = '/addbook'
+    path = "/addbook"
 
     def GET(self):
-        d = {'type': web.ctx.site.get('/type/edition')}
+        d = {"type": web.ctx.site.get("/type/edition")}
 
         i = web.input()
-        author = i.get('author') and web.ctx.site.get(i.author)
+        author = i.get("author") and web.ctx.site.get(i.author)
         if author:
-            d['authors'] = [author]
+            d["authors"] = [author]
 
         page = web.ctx.site.new("", d)
-        return render.edit(page, self.path, 'Add Book')
+        return render.edit(page, self.path, "Add Book")
 
     def POST(self):
         from infogami.core.code import edit
 
-        key = web.ctx.site.new_key('/type/edition')
+        key = web.ctx.site.new_key("/type/edition")
         web.ctx.path = key
         return edit().POST(key)
 
 
 class widget(delegate.page):
-    path = r'(/works/OL\d+W|/books/OL\d+M)/widget'
+    path = r"(/works/OL\d+W|/books/OL\d+M)/widget"
 
     def GET(self, key: str):  # type: ignore[override]
-        olid = key.rsplit('/', maxsplit=1)[-1]
+        olid = key.rsplit("/", maxsplit=1)[-1]
         item = web.ctx.site.get(key)
-        is_work = key.startswith('/works/')
-        item['olid'] = olid
-        item['availability'] = get_availability(
-            'openlibrary_work' if is_work else 'openlibrary_edition',
+        is_work = key.startswith("/works/")
+        item["olid"] = olid
+        item["availability"] = get_availability(
+            "openlibrary_work" if is_work else "openlibrary_edition",
             [olid],
         ).get(olid)
-        item['authors'] = [
-            web.storage(key=a.key, name=a.name or None) for a in item.get_authors()
-        ]
+        item["authors"] = [web.storage(key=a.key, name=a.name or None) for a in item.get_authors()]
         return delegate.RawText(
-            render_template('widget', format_work_data(item) if is_work else item),
-            content_type='text/html',
+            render_template("widget", format_work_data(item) if is_work else item),
+            content_type="text/html",
         )
 
 
 def format_work_data(work):
     d = dict(work)
 
-    key = work.get('key', '')
+    key = work.get("key", "")
     # New solr stores the key as /works/OLxxxW
     if not key.startswith("/works/"):
         key = "/works/" + key
 
-    d['url'] = key
-    d['title'] = work.get('title', '')
+    d["url"] = key
+    d["title"] = work.get("title", "")
 
-    if 'author_key' in work and 'author_name' in work:
-        d['authors'] = [
-            {"key": key, "name": name}
-            for key, name in zip(work['author_key'], work['author_name'])
-        ]
+    if "author_key" in work and "author_name" in work:
+        d["authors"] = [{"key": key, "name": name} for key, name in zip(work["author_key"], work["author_name"])]
 
-    if 'cover_edition_key' in work:
+    if "cover_edition_key" in work:
         coverstore_url = get_coverstore_public_url()
-        d['cover_url'] = f"{coverstore_url}/b/olid/{work['cover_edition_key']}-M.jpg"
+        d["cover_url"] = f"{coverstore_url}/b/olid/{work['cover_edition_key']}-M.jpg"
 
-    d['read_url'] = "//archive.org/stream/" + work['ia'][0]
+    d["read_url"] = "//archive.org/stream/" + work["ia"][0]
     return d
 
 
 class addauthor(delegate.page):
-    path = '/addauthor'
+    path = "/addauthor"
 
     def POST(self):
         if not (get_current_user()):
             raise web.unauthorized()
-        i = web.input('name')
+        i = web.input("name")
         if len(i.name) < 2:
             return web.badrequest()
-        key = web.ctx.site.new_key('/type/author')
+        key = web.ctx.site.new_key("/type/author")
         web.ctx.path = key
         web.ctx.site.save(
-            {'key': key, 'name': i.name, 'type': {'key': '/type/author'}},
-            comment='New Author',
+            {"key": key, "name": i.name, "type": {"key": "/type/author"}},
+            comment="New Author",
             action="create-author",
         )
-        raise web.HTTPError('200 OK', {}, key)
+        raise web.HTTPError("200 OK", {}, key)
 
 
 class clonebook(delegate.page):
     def GET(self):
         from infogami.core.code import edit  # noqa: F401 side effects may be needed
 
-        i = web.input('key')
+        i = web.input("key")
         page = web.ctx.site.get(i.key)
         if page is None:
             raise web.seeother(i.key)
         else:
             d = page._getdata()
-            for k in ['isbn_10', 'isbn_13', 'lccn', 'oclc']:
+            for k in ["isbn_10", "isbn_13", "lccn", "oclc"]:
                 d.pop(k, None)
-            return render.edit(page, '/addbook', 'Clone Book')
+            return render.edit(page, "/addbook", "Clone Book")
 
 
 class robotstxt(delegate.page):
-    path = '/robots.txt'
+    path = "/robots.txt"
 
     def GET(self):
-        web.header('Content-Type', 'text/plain')
-        is_dev = 'dev' in infogami.config.features or web.ctx.host != 'openlibrary.org'
-        robots_file = 'norobots.txt' if is_dev else 'robots.txt'
-        return web.ok(open(f'static/{robots_file}').read())
+        web.header("Content-Type", "text/plain")
+        is_dev = "dev" in infogami.config.features or web.ctx.host != "openlibrary.org"
+        robots_file = "norobots.txt" if is_dev else "robots.txt"
+        return web.ok(open(f"static/{robots_file}").read())
 
 
 @functools.cache
 def fetch_ia_js(filename: str) -> str:
-    return requests.get(f'https://archive.org/includes/{filename}').text
+    return requests.get(f"https://archive.org/includes/{filename}").text
 
 
 class ia_js_cdn(delegate.page):
-    path = r'/cdn/archive.org/(donate\.js|athena\.js)'
+    path = r"/cdn/archive.org/(donate\.js|athena\.js)"
 
     def GET(self, filename):
-        web.header('Content-Type', 'text/javascript')
+        web.header("Content-Type", "text/javascript")
         web.header("Cache-Control", "max-age=%d" % (24 * 3600))
         return web.ok(fetch_ia_js(filename))
 
 
 class serviceworker(delegate.page):
-    path = '/sw.js'
+    path = "/sw.js"
 
     def GET(self):
-        web.header('Content-Type', 'text/javascript')
-        return web.ok(open('static/build/js/sw.js').read())
+        web.header("Content-Type", "text/javascript")
+        return web.ok(open("static/build/js/sw.js").read())
 
 
 class assetlinks(delegate.page):
-    path = '/.well-known/assetlinks'
+    path = "/.well-known/assetlinks"
 
     def GET(self):
-        web.header('Content-Type', 'application/json')
-        return web.ok(open('static/.well-known/assetlinks.json').read())
+        web.header("Content-Type", "application/json")
+        return web.ok(open("static/.well-known/assetlinks.json").read())
 
 
 class opensearchxml(delegate.page):
-    path = '/opensearch.xml'
+    path = "/opensearch.xml"
 
     def GET(self):
-        web.header('Content-Type', 'text/plain')
-        return web.ok(open('static/opensearch.xml').read())
+        web.header("Content-Type", "text/plain")
+        return web.ok(open("static/opensearch.xml").read())
 
 
 class health(delegate.page):
-    path = '/health'
+    path = "/health"
 
     def GET(self):
-        web.header('Content-Type', 'text/plain')
-        return web.ok('OK')
+        web.header("Content-Type", "text/plain")
+        return web.ok("OK")
 
 
 def remove_high_priority(query: str) -> str:
@@ -449,7 +436,7 @@ class batch_imports(delegate.page):
     The batch import endpoint. Expects a JSONL file POSTed with multipart/form-data.
     """
 
-    path = '/import/batch/new'
+    path = "/import/batch/new"
 
     def GET(self):
         return render_template("batch_import.html", batch_result=None)
@@ -460,72 +447,66 @@ class batch_imports(delegate.page):
         if not user_key:
             raise Forbidden("Must be logged in to create a batch import.")
 
-        import_status = (
-            "pending"
-            if user_key in _get_members_of_group("/usergroup/admin")
-            else "needs_review"
-        )
+        import_status = "pending" if user_key in _get_members_of_group("/usergroup/admin") else "needs_review"
 
         # Get the upload from web.py. See the template for the <form> used.
         batch_result = None
         form_data = web.input()
         if form_data.get("batchImportFile"):
-            batch_result = batch_import(
-                form_data['batchImportFile'], import_status=import_status
-            )
+            batch_result = batch_import(form_data["batchImportFile"], import_status=import_status)
         elif form_data.get("batchImportText"):
             batch_result = batch_import(
-                form_data['batchImportText'].encode("utf-8"),
+                form_data["batchImportText"].encode("utf-8"),
                 import_status=import_status,
             )
         else:
             add_flash_message(
-                'error',
-                'Either attach a JSONL file or copy/paste JSONL into the text area.',
+                "error",
+                "Either attach a JSONL file or copy/paste JSONL into the text area.",
             )
 
         return render_template("batch_import.html", batch_result=batch_result)
 
 
 class BatchImportView(delegate.page):
-    path = r'/import/batch/(\d+)'
+    path = r"/import/batch/(\d+)"
 
     def GET(self, batch_id):
-        i = web.input(page=1, limit=10, sort='added_time asc')
+        i = web.input(page=1, limit=10, sort="added_time asc")
         page = int(i.page)
         limit = int(i.limit)
         sort = i.sort
 
-        valid_sort_fields = ['added_time', 'import_time', 'status']
+        valid_sort_fields = ["added_time", "import_time", "status"]
         sort_field, sort_order = sort.split()
-        if sort_field not in valid_sort_fields or sort_order not in ['asc', 'desc']:
-            sort_field = 'added_time'
-            sort_order = 'asc'
+        if sort_field not in valid_sort_fields or sort_order not in ["asc", "desc"]:
+            sort_field = "added_time"
+            sort_order = "asc"
 
         offset = (page - 1) * limit
 
-        batch = db.select('import_batch', where='id=$batch_id', vars=locals())[0]
+        batch = db.select("import_batch", where="id=$batch_id", vars=locals())[0]
         total_rows = db.query(
-            'SELECT COUNT(*) AS count FROM import_item WHERE batch_id=$batch_id',
+            "SELECT COUNT(*) AS count FROM import_item WHERE batch_id=$batch_id",
             vars=locals(),
         )[0].count
 
         rows = db.select(
-            'import_item',
-            where='batch_id=$batch_id',
-            order=f'{sort_field} {sort_order}',
+            "import_item",
+            where="batch_id=$batch_id",
+            order=f"{sort_field} {sort_order}",
             limit=limit,
             offset=offset,
             vars=locals(),
         )
 
         status_counts = db.query(
-            'SELECT status, COUNT(*) AS count FROM import_item WHERE batch_id=$batch_id GROUP BY status',
+            "SELECT status, COUNT(*) AS count FROM import_item WHERE batch_id=$batch_id GROUP BY status",
             vars=locals(),
         )
 
         return render_template(
-            'batch_import_view.html',
+            "batch_import_view.html",
             batch=batch,
             rows=rows,
             total_rows=total_rows,
@@ -544,13 +525,13 @@ class BatchImportApprove(delegate.page):
     `needs_review` to `pending`.
     """
 
-    path = r'/import/batch/approve/(\d+)'
+    path = r"/import/batch/approve/(\d+)"
 
     def GET(self, batch_id):
 
         user_key = delegate.context.user and delegate.context.user.key
         if user_key not in _get_members_of_group("/usergroup/admin"):
-            raise Forbidden('Permission Denied.')
+            raise Forbidden("Permission Denied.")
 
         db.query(
             """
@@ -572,16 +553,16 @@ class BatchImportPendingView(delegate.page):
     path = r"/import/batch/pending"
 
     def GET(self):
-        i = web.input(page=1, limit=10, sort='added_time asc')
+        i = web.input(page=1, limit=10, sort="added_time asc")
         page = int(i.page)
         limit = int(i.limit)
         sort = i.sort
 
-        valid_sort_fields = ['added_time', 'import_time', 'status']
+        valid_sort_fields = ["added_time", "import_time", "status"]
         sort_field, sort_order = sort.split()
-        if sort_field not in valid_sort_fields or sort_order not in ['asc', 'desc']:
-            sort_field = 'added_time'
-            sort_order = 'asc'
+        if sort_field not in valid_sort_fields or sort_order not in ["asc", "desc"]:
+            sort_field = "added_time"
+            sort_order = "asc"
 
         offset = (page - 1) * limit
 
@@ -606,34 +587,30 @@ class BatchImportPendingView(delegate.page):
 class isbn_lookup(delegate.page):
     """The endpoint for /isbn"""
 
-    path = r'/(?:isbn|ISBN)/(.{10,})'
+    path = r"/(?:isbn|ISBN)/(.{10,})"
 
     def GET(self, isbn: str):
         input = web.input(high_priority=False)
         isbn = isbn if isbn.upper().startswith("B") else canonical(isbn)
         high_priority = input.get("high_priority") == "true"
-        if "high_priority" in web.ctx.env.get('QUERY_STRING'):
-            web.ctx.env['QUERY_STRING'] = remove_high_priority(
-                web.ctx.env.get('QUERY_STRING')
-            )
+        if "high_priority" in web.ctx.env.get("QUERY_STRING"):
+            web.ctx.env["QUERY_STRING"] = remove_high_priority(web.ctx.env.get("QUERY_STRING"))
 
         # Preserve the url type (e.g. `.json`) and query params
-        ext = ''
-        if web.ctx.encoding and web.ctx.path.endswith('.' + web.ctx.encoding):
-            ext = '.' + web.ctx.encoding
-        if web.ctx.env.get('QUERY_STRING'):
-            ext += '?' + web.ctx.env['QUERY_STRING']
+        ext = ""
+        if web.ctx.encoding and web.ctx.path.endswith("." + web.ctx.encoding):
+            ext = "." + web.ctx.encoding
+        if web.ctx.env.get("QUERY_STRING"):
+            ext += "?" + web.ctx.env["QUERY_STRING"]
 
         try:
-            if ed := Edition.from_isbn(
-                isbn_or_asin=isbn, high_priority=high_priority, allow_import=False
-            ):
+            if ed := Edition.from_isbn(isbn_or_asin=isbn, high_priority=high_priority, allow_import=False):
                 return web.found(ed.key + ext)
         except Exception as e:
             logger.error(e)
             return repr(e)
 
-        web.ctx.status = '404 Not Found'
+        web.ctx.status = "404 Not Found"
         return render.notfound(web.ctx.path, create=False)
 
 
@@ -643,38 +620,38 @@ class bookpage(delegate.page):
     otherwise, return a 404.
     """
 
-    path = r'/(oclc|lccn|ia|OCLC|LCCN|IA)/([^/]*)(/.*)?'
+    path = r"/(oclc|lccn|ia|OCLC|LCCN|IA)/([^/]*)(/.*)?"
 
-    def GET(self, key, value, suffix=''):
+    def GET(self, key, value, suffix=""):
         key = key.lower()
 
-        if key == 'oclc':
-            key = 'oclc_numbers'
-        elif key == 'ia':
-            key = 'ocaid'
+        if key == "oclc":
+            key = "oclc_numbers"
+        elif key == "ia":
+            key = "ocaid"
 
-        if key != 'ocaid':  # example: MN41558ucmf_6
-            value = value.replace('_', ' ')
+        if key != "ocaid":  # example: MN41558ucmf_6
+            value = value.replace("_", " ")
 
-        if web.ctx.encoding and web.ctx.path.endswith('.' + web.ctx.encoding):
-            ext = '.' + web.ctx.encoding
+        if web.ctx.encoding and web.ctx.path.endswith("." + web.ctx.encoding):
+            ext = "." + web.ctx.encoding
         else:
-            ext = ''
+            ext = ""
 
-        if web.ctx.env.get('QUERY_STRING'):
-            ext += '?' + web.ctx.env['QUERY_STRING']
+        if web.ctx.env.get("QUERY_STRING"):
+            ext += "?" + web.ctx.env["QUERY_STRING"]
 
-        q = {'type': '/type/edition', key: value}
+        q = {"type": "/type/edition", key: value}
 
         result = web.ctx.site.things(q)
 
         if result:
             return web.found(result[0] + ext)
-        elif key == 'ocaid':
+        elif key == "ocaid":
             # Try a range of ocaid alternatives:
             ocaid_alternatives = [
-                {'type': '/type/edition', 'source_records': 'ia:' + value},
-                {'type': '/type/volume', 'ia_id': value},
+                {"type": "/type/edition", "source_records": "ia:" + value},
+                {"type": "/type/volume", "ia_id": value},
             ]
             for q in ocaid_alternatives:
                 result = web.ctx.site.things(q)
@@ -685,114 +662,108 @@ class bookpage(delegate.page):
             from openlibrary import accounts
             from openlibrary.plugins.importapi.code import BookImportError, ia_importapi
 
-            with accounts.RunAs('ImportBot'):
+            with accounts.RunAs("ImportBot"):
                 try:
                     ia_importapi.ia_import(value, require_marc=True)
                 except BookImportError:
-                    logger.exception('Unable to import ia record')
+                    logger.exception("Unable to import ia record")
 
             # Go the the record created, or to the dummy ia-wrapper record
-            return web.found('/books/ia:' + value + ext)
+            return web.found("/books/ia:" + value + ext)
 
-        web.ctx.status = '404 Not Found'
+        web.ctx.status = "404 Not Found"
         return render.notfound(web.ctx.path, create=False)
 
 
-delegate.media_types['application/rdf+xml'] = 'rdf'
+delegate.media_types["application/rdf+xml"] = "rdf"
 
 
 class rdf(delegate.mode):
-    name = 'view'
-    encoding = 'rdf'
+    name = "view"
+    encoding = "rdf"
 
     def GET(self, key):
         page = web.ctx.site.get(key)
         if not page:
-            raise web.notfound('')
+            raise web.notfound("")
         else:
             from infogami.utils import template
 
             try:
-                result = template.typetemplate('rdf')(page)
+                result = template.typetemplate("rdf")(page)
             except:
-                raise web.notfound('')
+                raise web.notfound("")
             else:
-                return delegate.RawText(
-                    result, content_type='application/rdf+xml; charset=utf-8'
-                )
+                return delegate.RawText(result, content_type="application/rdf+xml; charset=utf-8")
 
 
-delegate.media_types[' application/atom+xml;profile=opds'] = 'opds'
+delegate.media_types[" application/atom+xml;profile=opds"] = "opds"
 
 
 class opds(delegate.mode):
-    name = 'view'
-    encoding = 'opds'
+    name = "view"
+    encoding = "opds"
 
     def GET(self, key):
         page = web.ctx.site.get(key)
         if not page:
-            raise web.notfound('')
+            raise web.notfound("")
         else:
             from openlibrary.plugins.openlibrary import opds
 
             try:
                 result = opds.OPDSEntry(page).to_string()
             except:
-                raise web.notfound('')
+                raise web.notfound("")
             else:
-                return delegate.RawText(
-                    result, content_type=' application/atom+xml;profile=opds'
-                )
+                return delegate.RawText(result, content_type=" application/atom+xml;profile=opds")
 
 
-delegate.media_types['application/marcxml+xml'] = 'marcxml'
+delegate.media_types["application/marcxml+xml"] = "marcxml"
 
 
 class marcxml(delegate.mode):
-    name = 'view'
-    encoding = 'marcxml'
+    name = "view"
+    encoding = "marcxml"
 
     def GET(self, key):
         page = web.ctx.site.get(key)
-        if page is None or page.type.key != '/type/edition':
-            raise web.notfound('')
+        if page is None or page.type.key != "/type/edition":
+            raise web.notfound("")
         else:
             from infogami.utils import template
 
             try:
-                result = template.typetemplate('marcxml')(page)
+                result = template.typetemplate("marcxml")(page)
             except:
-                raise web.notfound('')
+                raise web.notfound("")
             else:
-                return delegate.RawText(
-                    result, content_type='application/marcxml+xml; charset=utf-8'
-                )
+                return delegate.RawText(result, content_type="application/marcxml+xml; charset=utf-8")
 
 
-delegate.media_types['text/x-yaml'] = 'yml'
+delegate.media_types["text/x-yaml"] = "yml"
 
 
 class _yaml(delegate.mode):
-    name = 'view'
-    encoding = 'yml'
+    name = "view"
+    encoding = "yml"
 
     def GET(self, key):
         d = self.get_data(key)
 
-        if web.input(text='false').text.lower() == 'true':
-            web.header('Content-Type', 'text/plain; charset=utf-8')
+        if web.input(text="false").text.lower() == "true":
+            web.header("Content-Type", "text/plain; charset=utf-8")
         else:
-            web.header('Content-Type', 'text/x-yaml; charset=utf-8')
+            web.header("Content-Type", "text/x-yaml; charset=utf-8")
 
         raise web.ok(self.dump(d))
 
     def get_data(self, key):
         i = web.input(v=None)
         v = safeint(i.v, None)
-        data = {'key': key, 'revision': v}
+        data = {"key": key, "revision": v}
         try:
-            d = api.request('/get', data=data)
+            d = api.request("/get", data=data)
         except client.ClientException as e:
             if e.json:
                 msg = self.dump(json.loads(e.json))
@@ -812,8 +783,8 @@ class _yaml(delegate.mode):
 
 
 class _yaml_edit(_yaml):
-    name = 'edit'
-    encoding = 'yml'
+    name = "edit"
+    encoding = "yml"
 
     def is_admin(self):
         u = delegate.context.user
@@ -822,13 +793,13 @@ class _yaml_edit(_yaml):
     def GET(self, key):
         # only allow admin users to edit yaml
         if not self.is_admin():
-            return render.permission_denied(key, 'Permission Denied')
+            return render.permission_denied(key, "Permission Denied")
 
         try:
             d = self.get_data(key)
         except web.HTTPError:
-            if web.ctx.status.lower() == '404 not found':
-                d = {'key': key}
+            if web.ctx.status.lower() == "404 not found":
+                d = {"key": key}
             else:
                 raise
         return render.edit_yaml(key, self.dump(d))
@@ -836,42 +807,42 @@ class _yaml_edit(_yaml):
     def POST(self, key):
         # only allow admin users to edit yaml
         if not self.is_admin():
-            return render.permission_denied(key, 'Permission Denied')
+            return render.permission_denied(key, "Permission Denied")
 
-        i = web.input(body='', _comment=None)
+        i = web.input(body="", _comment=None)
 
-        if '_save' in i:
+        if "_save" in i:
             d = self.load(i.body)
             p = web.ctx.site.new(key, d)
             try:
                 p._save(i._comment, action="edit-yaml")
             except (client.ClientException, ValidationException) as e:
-                add_flash_message('error', str(e))
+                add_flash_message("error", str(e))
                 return render.edit_yaml(key, i.body)
-            raise web.seeother(key + '.yml')
-        elif '_preview' in i:
-            add_flash_message('Preview not supported')
+            raise web.seeother(key + ".yml")
+        elif "_preview" in i:
+            add_flash_message("Preview not supported")
             return render.edit_yaml(key, i.body)
         else:
-            add_flash_message('unknown action')
+            add_flash_message("unknown action")
             return render.edit_yaml(key, i.body)
 
 
 def _get_user_root():
-    user_root = infogami.config.get('infobase', {}).get('user_root', '/user')
-    return user_root.removesuffix('/')
+    user_root = infogami.config.get("infobase", {}).get("user_root", "/user")
+    return user_root.removesuffix("/")
 
 
 def _get_bots():
-    bots = web.ctx.site.store.values(type='account', name='bot', value='true')
+    bots = web.ctx.site.store.values(type="account", name="bot", value="true")
     user_root = _get_user_root()
-    return [user_root + '/' + account['username'] for account in bots]
+    return [user_root + "/" + account["username"] for account in bots]
 
 
 def _get_members_of_group(group_key):
     """Returns keys of all members of the group identifier by group_key."""
     usergroup = web.ctx.site.get(group_key) or {}
-    return [m.key for m in usergroup.get('members', [])]
+    return [m.key for m in usergroup.get("members", [])]
 
 
 def can_write():
@@ -880,11 +851,7 @@ def can_write():
     For backward-compatability, all admin users and people in api usergroup are also allowed to write.
     """
     user_key = delegate.context.user and delegate.context.user.key
-    bots = (
-        _get_members_of_group('/usergroup/api')
-        + _get_members_of_group('/usergroup/admin')
-        + _get_bots()
-    )
+    bots = _get_members_of_group("/usergroup/api") + _get_members_of_group("/usergroup/admin") + _get_bots()
     return user_key in bots
 
 
@@ -893,13 +860,13 @@ api.can_write = can_write
 
 
 class Forbidden(web.HTTPError):
-    def __init__(self, msg=''):
-        web.HTTPError.__init__(self, '403 Forbidden', {}, msg)
+    def __init__(self, msg=""):
+        web.HTTPError.__init__(self, "403 Forbidden", {}, msg)
 
 
 class BadRequest(web.HTTPError):
-    def __init__(self, msg=''):
-        web.HTTPError.__init__(self, '400 Bad Request', {}, msg)
+    def __init__(self, msg=""):
+        web.HTTPError.__init__(self, "400 Bad Request", {}, msg)
 
 
 class new:
@@ -913,43 +880,43 @@ class new:
         if isinstance(query, list):
             return [self.prepare_query(q) for q in query]
         else:
-            type = query['type']
+            type = query["type"]
             if isinstance(type, dict):
-                type = type['key']
-            query['key'] = web.ctx.site.new_key(type)
-            return query['key']
+                type = type["key"]
+            query["key"] = web.ctx.site.new_key(type)
+            return query["key"]
 
     def verify_types(self, query):
         if isinstance(query, list):
             for q in query:
                 self.verify_types(q)
         else:
-            if 'type' not in query:
-                raise BadRequest('Missing type')
-            type = query['type']
+            if "type" not in query:
+                raise BadRequest("Missing type")
+            type = query["type"]
             if isinstance(type, dict):
-                if 'key' not in type:
-                    raise BadRequest('Bad Type: ' + json.dumps(type))
-                type = type['key']
+                if "key" not in type:
+                    raise BadRequest("Bad Type: " + json.dumps(type))
+                type = type["key"]
 
             if type not in [
-                '/type/author',
-                '/type/edition',
-                '/type/work',
-                '/type/series',
-                '/type/publisher',
+                "/type/author",
+                "/type/edition",
+                "/type/work",
+                "/type/series",
+                "/type/publisher",
             ]:
-                raise BadRequest('Bad Type: ' + json.dumps(type))
+                raise BadRequest("Bad Type: " + json.dumps(type))
 
     def POST(self):
         if not can_write():
-            raise Forbidden('Permission Denied.')
+            raise Forbidden("Permission Denied.")
 
         try:
             query = json.loads(web.data())
             h = api.get_custom_headers()
-            comment = h.get('comment')
-            action = h.get('action')
+            comment = h.get("comment")
+            action = h.get("action")
         except Exception as e:
             raise BadRequest(str(e))
 
@@ -965,34 +932,31 @@ class new:
 
         # graphite/statsd tracking of bot edits
         user = delegate.context.user and delegate.context.user.key
-        if user.lower().endswith('bot'):
-            botname = user.replace('/people/', '', 1)
-            botname = botname.replace('.', '-')
-            key = 'ol.edits.bots.' + botname
+        if user.lower().endswith("bot"):
+            botname = user.replace("/people/", "", 1)
+            botname = botname.replace(".", "-")
+            key = "ol.edits.bots." + botname
             openlibrary.core.stats.increment(key)
         return json.dumps(keys)
 
 
-api and api.add_hook('new', new)
+api and api.add_hook("new", new)
 
 
 @public
 def changequery(query=None, _path=None, **kw):
     if query is None:
-        query = web.input(_method='get', _unicode=False)
+        query = web.input(_method="get", _unicode=False)
     for k, v in kw.items():
         if v is None:
             query.pop(k, None)
         else:
             query[k] = v
 
-    query = {
-        k: [web.safestr(s) for s in v] if isinstance(v, list) else web.safestr(v)
-        for k, v in query.items()
-    }
-    out = _path or web.ctx.get('readable_path', web.ctx.path)
+    query = {k: [web.safestr(s) for s in v] if isinstance(v, list) else web.safestr(v) for k, v in query.items()}
+    out = _path or web.ctx.get("readable_path", web.ctx.path)
     if query:
-        out += '?' + urllib.parse.urlencode(query, doseq=True)
+        out += "?" + urllib.parse.urlencode(query, doseq=True)
     return out
 
 
@@ -1006,7 +970,7 @@ from infogami.core.db import get_recent_changes as _get_recentchanges
 
 @public
 def get_recent_changes(*a, **kw):
-    if 'offset' in kw and kw['offset'] > 5000:
+    if "offset" in kw and kw["offset"] > 5000:
         return []
     else:
         return _get_recentchanges(*a, **kw)
@@ -1016,31 +980,28 @@ local_ip = None
 
 
 class invalidate(delegate.page):
-    path = '/system/invalidate'
+    path = "/system/invalidate"
 
     def POST(self):
         global local_ip
         if local_ip is None:
             local_ip = socket.gethostbyname(socket.gethostname())
 
-        if (
-            web.ctx.ip != '127.0.0.1'
-            and web.ctx.ip.rsplit('.', 1)[0] != local_ip.rsplit('.', 1)[0]
-        ):
-            raise Forbidden('Allowed only in the local network.')
+        if web.ctx.ip != "127.0.0.1" and web.ctx.ip.rsplit(".", 1)[0] != local_ip.rsplit(".", 1)[0]:
+            raise Forbidden("Allowed only in the local network.")
 
         data = json.loads(web.data())
         if not isinstance(data, list):
             data = [data]
         for d in data:
-            thing = client.Thing(web.ctx.site, d['key'], client.storify(d))
-            client._run_hooks('on_new_version', thing)
-        return delegate.RawText('ok')
+            thing = client.Thing(web.ctx.site, d["key"], client.storify(d))
+            client._run_hooks("on_new_version", thing)
+        return delegate.RawText("ok")
 
 
 def save_error():
     t = datetime.datetime.utcnow()
-    name = '%04d-%02d-%02d/%02d%02d%02d%06d' % (
+    name = "%04d-%02d-%02d/%02d%02d%02d%06d" % (
         t.year,
         t.month,
         t.day,
@@ -1050,16 +1011,16 @@ def save_error():
         t.microsecond,
     )
 
-    path = infogami.config.get('errorlog', 'errors') + '/' + name + '.html'
+    path = infogami.config.get("errorlog", "errors") + "/" + name + ".html"
     dir = os.path.dirname(path)
     if not os.path.exists(dir):
         os.makedirs(dir)
 
     error = web.safestr(web.djangoerror())
-    with open(path, 'w') as file:
+    with open(path, "w") as file:
         file.write(error)
 
-    print('error saved to', path, file=web.debug)
+    print("error saved to", path, file=web.debug)
     return name
 
 
@@ -1070,8 +1031,8 @@ def internalerror():
 
     # TODO: move this stats stuff to plugins\openlibrary\stats.py
     # Can't have sub-metrics, so can't add more info
-    openlibrary.core.stats.increment('ol.internal-errors')
-    increment_error_count('ol.internal-errors-segmented')
+    openlibrary.core.stats.increment("ol.internal-errors")
+    increment_error_count("ol.internal-errors-segmented")
 
     # TODO: move this to plugins\openlibrary\sentry.py
     from openlibrary.plugins.openlibrary.sentry import sentry
@@ -1080,7 +1041,7 @@ def internalerror():
     if sentry.enabled:
         sentry_event_id = sentry.capture_exception_webpy()
 
-    if features.is_enabled('debug'):
+    if features.is_enabled("debug"):
         raise web.debugerror()
     else:
         msg = render.site(
@@ -1099,7 +1060,7 @@ delegate.add_exception_hook(save_error)
 
 
 class memory(delegate.page):
-    path = '/debug/memory'
+    path = "/debug/memory"
 
     def GET(self):
         import guppy
@@ -1133,50 +1094,50 @@ def setup_template_globals():
 
     def get_supported_languages():
         return {
-            "ar": {"code": "ar", "localized": _('Arabic'), "native": "العربية"},
-            "cs": {"code": "cs", "localized": _('Czech'), "native": "Čeština"},
-            "de": {"code": "de", "localized": _('German'), "native": "Deutsch"},
-            "en": {"code": "en", "localized": _('English'), "native": "English"},
-            "es": {"code": "es", "localized": _('Spanish'), "native": "Español"},
-            "fr": {"code": "fr", "localized": _('French'), "native": "Français"},
-            "hi": {"code": "hi", "localized": _('Hindi'), "native": "हिंदी"},
-            "hr": {"code": "hr", "localized": _('Croatian'), "native": "Hrvatski"},
-            "it": {"code": "it", "localized": _('Italian'), "native": "Italiano"},
-            "pt": {"code": "pt", "localized": _('Portuguese'), "native": "Português"},
-            "ro": {"code": "ro", "localized": _('Romanian'), "native": "Română"},
-            "sc": {"code": "sc", "localized": _('Sardinian'), "native": "Sardu"},
-            "te": {"code": "te", "localized": _('Telugu'), "native": "తెలుగు"},
-            "uk": {"code": "uk", "localized": _('Ukrainian'), "native": "Українська"},
-            "zh": {"code": "zh", "localized": _('Chinese'), "native": "中文"},
-            "tl": {"code": "tl", "localized": _('Filipino'), "native": "Filipino"},
+            "ar": {"code": "ar", "localized": _("Arabic"), "native": "العربية"},
+            "cs": {"code": "cs", "localized": _("Czech"), "native": "Čeština"},
+            "de": {"code": "de", "localized": _("German"), "native": "Deutsch"},
+            "en": {"code": "en", "localized": _("English"), "native": "English"},
+            "es": {"code": "es", "localized": _("Spanish"), "native": "Español"},
+            "fr": {"code": "fr", "localized": _("French"), "native": "Français"},
+            "hi": {"code": "hi", "localized": _("Hindi"), "native": "हिंदी"},
+            "hr": {"code": "hr", "localized": _("Croatian"), "native": "Hrvatski"},
+            "it": {"code": "it", "localized": _("Italian"), "native": "Italiano"},
+            "pt": {"code": "pt", "localized": _("Portuguese"), "native": "Português"},
+            "ro": {"code": "ro", "localized": _("Romanian"), "native": "Română"},
+            "sc": {"code": "sc", "localized": _("Sardinian"), "native": "Sardu"},
+            "te": {"code": "te", "localized": _("Telugu"), "native": "తెలుగు"},
+            "uk": {"code": "uk", "localized": _("Ukrainian"), "native": "Українська"},
+            "zh": {"code": "zh", "localized": _("Chinese"), "native": "中文"},
+            "tl": {"code": "tl", "localized": _("Filipino"), "native": "Filipino"},
         }
 
     web.template.Template.globals.update(
         {
-            'cookies': web.cookies,
-            'next': next,
-            'sorted': sorted,
-            'zip': zip,
-            'tuple': tuple,
-            'hash': hash,
-            'urlquote': quote,
-            'isbn_13_to_isbn_10': isbn_13_to_isbn_10,
-            'isbn_10_to_isbn_13': isbn_10_to_isbn_13,
-            'NEWLINE': '\n',
-            'random': random.Random(),
-            'choose_random_from': random.choice,
-            'get_lang': lambda: web.ctx.lang,
-            'get_supported_languages': get_supported_languages,
-            'ceil': math.ceil,
-            'get_best_edition': get_best_edition,
-            'get_book_provider': get_book_provider,
-            'get_book_provider_by_name': get_book_provider_by_name,
-            'get_cover_url': get_cover_url,
+            "cookies": web.cookies,
+            "next": next,
+            "sorted": sorted,
+            "zip": zip,
+            "tuple": tuple,
+            "hash": hash,
+            "urlquote": quote,
+            "isbn_13_to_isbn_10": isbn_13_to_isbn_10,
+            "isbn_10_to_isbn_13": isbn_10_to_isbn_13,
+            "NEWLINE": "\n",
+            "random": random.Random(),
+            "choose_random_from": random.choice,
+            "get_lang": lambda: web.ctx.lang,
+            "get_supported_languages": get_supported_languages,
+            "ceil": math.ceil,
+            "get_best_edition": get_best_edition,
+            "get_book_provider": get_book_provider,
+            "get_book_provider_by_name": get_book_provider_by_name,
+            "get_cover_url": get_cover_url,
             # bad use of globals
-            'is_bot': is_bot,
-            'time': time,
-            'input': web.input,
-            'dumps': json.dumps,
+            "is_bot": is_bot,
+            "time": time,
+            "input": web.input,
+            "dumps": json.dumps,
         }
     )
 
@@ -1186,9 +1147,9 @@ def setup_context_defaults():
 
     context.defaults.update(
         {
-            'features': [],
-            'user': None,
-            'MAX_VISIBLE_BOOKS': 5,
+            "features": [],
+            "user": None,
+            "MAX_VISIBLE_BOOKS": 5,
         }
     )
 

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -153,19 +153,11 @@ class ListRecord:
         normalized_seeds = [
             ListRecord.normalize_input_seed(seed)
             # Seeds can be a list of seeds or a CSV string of seeds.
-            for seed_list in (
-                i["seeds"] if isinstance(i["seeds"], list) else [i["seeds"]]
-            )
+            for seed_list in (i["seeds"] if isinstance(i["seeds"], list) else [i["seeds"]])
             # Each element of seeds can be a CSV string of seeds
-            for seed in (
-                seed_list.split(",") if isinstance(seed_list, str) else [seed_list]
-            )
+            for seed in (seed_list.split(",") if isinstance(seed_list, str) else [seed_list])
         ]
-        normalized_seeds = [
-            seed
-            for seed in normalized_seeds
-            if seed and (isinstance(seed, str) or seed.get("key") or seed.get("thing"))
-        ]
+        normalized_seeds = [seed for seed in normalized_seeds if seed and (isinstance(seed, str) or seed.get("key") or seed.get("thing"))]
         return ListRecord(
             key=i["key"],
             name=i["name"],
@@ -176,13 +168,7 @@ class ListRecord:
     def to_thing_json(self):
         return {
             "key": self.key,
-            "type": {
-                "key": (
-                    "/type/series"
-                    if (self.key and "/series/" in self.key)
-                    else "/type/list"
-                )
-            },
+            "type": {"key": ("/type/series" if (self.key and "/series/" in self.key) else "/type/list")},
             "name": self.name,
             "description": self.description,
             "seeds": self.seeds,
@@ -261,9 +247,7 @@ def get_list_data(list, seed, include_cover_url=True):
     if include_cover_url:
         cover = list.get_cover() or list.get_default_cover()
 
-        d["cover_url"] = (
-            cover and cover.url("S")
-        ) or "/static/images/icons/avatar_book-sm.png"
+        d["cover_url"] = (cover and cover.url("S")) or "/static/images/icons/avatar_book-sm.png"
         if "None" in d["cover_url"]:
             d["cover_url"] = "/static/images/icons/avatar_book-sm.png"
 
@@ -280,10 +264,7 @@ def get_user_lists(seed_info):
         return []
     user_lists = user.get_lists(sort=True)
     seed = seed_info["seed"] if seed_info else None
-    return [
-        get_list_data(user_list, seed, include_cover_url=False)
-        for user_list in user_lists
-    ]
+    return [get_list_data(user_list, seed, include_cover_url=False) for user_list in user_lists]
 
 
 @public
@@ -311,9 +292,7 @@ class lists(delegate.page):
             if not mb.user:
                 raise web.notfound()
 
-            template = render_template(
-                "lists/lists.html", mb.user, mb.user.get_lists(), show_header=False
-            )
+            template = render_template("lists/lists.html", mb.user, mb.user.get_lists(), show_header=False)
             return mb.render(
                 template=template,
                 header_title=_("Lists (%(count)d)", count=len(mb.lists)),
@@ -375,9 +354,7 @@ class lists_edit(delegate.page):
 
         # Block spam lists at creation time (issue #11905)
         if spamcheck.is_spam(list_record.to_thing_json()):
-            return render_template(
-                "message.html", "Oops", "Something went wrong. Please try again later."
-            )
+            return render_template("message.html", "Oops", "Something went wrong. Please try again later.")
 
         # Creating a new list
         if not list_id:
@@ -393,24 +370,16 @@ class lists_edit(delegate.page):
             thing_json["seeds"] = []
 
             # Edit the works to add series edges
-            work_key_to_list_seed = {
-                seed["thing"]["key"]: seed for seed in list_record.get_annotated_seeds()
-            }
+            work_key_to_list_seed = {seed["thing"]["key"]: seed for seed in list_record.get_annotated_seeds()}
 
             works_to_remove: set[str] = set()
             if list_id:
                 old_series = cast(Series, web.ctx.site.get(list_key))
-                works_to_remove = {
-                    seed.key
-                    for seed in old_series.get_seeds()
-                    if seed.key not in work_key_to_list_seed
-                }
+                works_to_remove = {seed.key for seed in old_series.get_seeds() if seed.key not in work_key_to_list_seed}
 
             works = cast(
                 list[Work],
-                web.ctx.site.get_many(
-                    list(work_key_to_list_seed) + list(works_to_remove)
-                ),
+                web.ctx.site.get_many(list(work_key_to_list_seed) + list(works_to_remove)),
             )
             for work in works:
                 if work.key in works_to_remove:
@@ -425,9 +394,7 @@ class lists_edit(delegate.page):
                         # Note: The type is actually WorkSeriesEdgeDict, but internally inside infogami
                         # these behave sort of the same, since a full `Thing` object is replaced with
                         # a ThingReference (eg `{'key': '/works/OL123W'}`) when saved to the DB.
-                        work_series_edge = cast(
-                            WorkSeriesEdgeDB, {"series": {"key": list_key}}
-                        )
+                        work_series_edge = cast(WorkSeriesEdgeDB, {"series": {"key": list_key}})
 
                     # Update the edge with any metadata from the list seed
                     update_list_seed_metadata(work_series_edge, list_seed)
@@ -490,9 +457,7 @@ class lists_add(delegate.page):
                 f"Permission denied to edit {user_key}.",
             )
         list_record = ListRecord.from_input()
-        return render_template(
-            "type/list/edit", list_record, list_type=list_type, new=True
-        )
+        return render_template("type/list/edit", list_record, list_type=list_type, new=True)
 
     def POST(self, user_key: str | None, list_type_plural: Literal["lists", "series"]):  # type: ignore[override]
         return lists_edit().POST(user_key, list_type_plural, None)
@@ -785,9 +750,7 @@ class list_seeds(delegate.page):
         if not lst:
             raise web.notfound()
 
-        return delegate.RawText(
-            formats.dump(lst, self.encoding), content_type=self.content_type
-        )
+        return delegate.RawText(formats.dump(lst, self.encoding), content_type=self.content_type)
 
     def POST(self, key):
         site = web.ctx.site
@@ -907,16 +870,8 @@ def get_list_editions(
 
     links = ListEditionsLinks(
         self=_pagination_url(url),
-        next=(
-            _pagination_url(url, limit=limit, offset=end)
-            if offset + len(editions) < size
-            else None
-        ),
-        prev=(
-            _pagination_url(url, limit=limit, offset=max(0, offset - limit))
-            if offset
-            else None
-        ),
+        next=(_pagination_url(url, limit=limit, offset=end) if offset + len(editions) < size else None),
+        prev=(_pagination_url(url, limit=limit, offset=max(0, offset - limit)) if offset else None),
         list=key or None,
     )
 
@@ -948,9 +903,7 @@ class list_editions_json(delegate.page):
         )
         if not editions:
             raise web.notfound()
-        return delegate.RawText(
-            formats.dump(editions.dict(), self.encoding), content_type=self.content_type
-        )
+        return delegate.RawText(formats.dump(editions.dict(), self.encoding), content_type=self.content_type)
 
 
 class list_editions_yaml(list_editions_json):
@@ -1075,9 +1028,7 @@ class export(delegate.page):
 
         if not raw:
             if "editions" in export_data:
-                export_data["editions"] = [
-                    self.make_doc(e) for e in export_data["editions"]
-                ]
+                export_data["editions"] = [self.make_doc(e) for e in export_data["editions"]]
                 lst.preload_authors(export_data["editions"])
             else:
                 export_data["editions"] = []
@@ -1087,9 +1038,7 @@ class export(delegate.page):
             else:
                 export_data["works"] = []
             if "authors" in export_data:
-                export_data["authors"] = [
-                    self.make_doc(e) for e in export_data["authors"]
-                ]
+                export_data["authors"] = [self.make_doc(e) for e in export_data["authors"]]
                 lst.preload_authors(export_data["authors"])
             else:
                 export_data["authors"] = []

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -54,20 +54,18 @@ from openlibrary.utils.solr import (
 logger = logging.getLogger("openlibrary.worksearch")
 
 
-OLID_URLS = {'A': 'authors', 'M': 'books', 'W': 'works'}
+OLID_URLS = {"A": "authors", "M": "books", "W": "works"}
 
-re_isbn_field = re.compile(r'^\s*(?:isbn[:\s]*)?([-0-9X]{9,})\s*$', re.IGNORECASE)
-re_olid = re.compile(r'^OL\d+([AMW])$')
+re_isbn_field = re.compile(r"^\s*(?:isbn[:\s]*)?([-0-9X]{9,})\s*$", re.IGNORECASE)
+re_olid = re.compile(r"^OL\d+([AMW])$")
 
-plurals = {f + 's': f for f in ('publisher', 'author')}
+plurals = {f + "s": f for f in ("publisher", "author")}
 
 default_spellcheck_count = 10
-if hasattr(config, 'plugin_worksearch'):
-    solr_select_url = (
-        config.plugin_worksearch.get('solr_base_url', 'localhost') + '/select'
-    )
+if hasattr(config, "plugin_worksearch"):
+    solr_select_url = config.plugin_worksearch.get("solr_base_url", "localhost") + "/select"
 
-    default_spellcheck_count = config.plugin_worksearch.get('spellcheck_count', 10)
+    default_spellcheck_count = config.plugin_worksearch.get("spellcheck_count", 10)
 
 
 def compute_work_search_html_fields(sort: str | None, sfw: bool) -> list[str]:
@@ -86,19 +84,19 @@ def compute_work_search_html_fields(sort: str | None, sfw: bool) -> list[str]:
     :return: List of Solr field names to fetch
     """
     extra_fields = {
-        'editions',
-        'providers',
-        'ratings_average',
-        'ratings_count',
-        'want_to_read_count',
+        "editions",
+        "providers",
+        "ratings_average",
+        "ratings_count",
+        "want_to_read_count",
     }
-    if sort and 'trending' in sort:
-        extra_fields.add('trending_*')
+    if sort and "trending" in sort:
+        extra_fields.add("trending_*")
 
     fields = WorkSearchScheme.default_fetched_fields | extra_fields
 
     if sfw:
-        fields |= {'subject'}
+        fields |= {"subject"}
 
     return list(fields)
 
@@ -106,22 +104,20 @@ def compute_work_search_html_fields(sort: str | None, sfw: bool) -> list[str]:
 @public
 def get_facet_map() -> tuple[tuple[str, str]]:
     return (
-        ('has_fulltext', _('eBook?')),
-        ('language', _('Language')),
-        ('author_key', _('Author')),
-        ('subject_facet', _('Subjects')),
-        ('first_publish_year', _('First published')),
-        ('publisher_facet', _('Publisher')),
-        ('person_facet', _('People')),
-        ('place_facet', _('Places')),
-        ('time_facet', _('Times')),
-        ('public_scan_b', _('Classic eBooks')),
+        ("has_fulltext", _("eBook?")),
+        ("language", _("Language")),
+        ("author_key", _("Author")),
+        ("subject_facet", _("Subjects")),
+        ("first_publish_year", _("First published")),
+        ("publisher_facet", _("Publisher")),
+        ("person_facet", _("People")),
+        ("place_facet", _("Places")),
+        ("time_facet", _("Times")),
+        ("public_scan_b", _("Classic eBooks")),
     )
 
 
-async def get_solr_works_async(
-    work_keys: set[str], fields: Iterable[str] | None = None, editions=False
-) -> dict[str, web.storage]:
+async def get_solr_works_async(work_keys: set[str], fields: Iterable[str] | None = None, editions=False) -> dict[str, web.storage]:
     from openlibrary.plugins.worksearch.search import get_solr
 
     # Avoid making query if no work keys provided
@@ -129,27 +125,24 @@ async def get_solr_works_async(
         return cast(dict[str, web.storage], {})
 
     if not fields:
-        fields = WorkSearchScheme.default_fetched_fields | {'editions', 'providers'}
+        fields = WorkSearchScheme.default_fetched_fields | {"editions", "providers"}
 
     if editions:
         # To get the top matching edition, need to do a proper query
         resp = await run_solr_query_async(
             WorkSearchScheme(solr_editions=editions),
-            {'q': 'key:(%s)' % ' OR '.join(work_keys)},
+            {"q": "key:(%s)" % " OR ".join(work_keys)},
             rows=len(work_keys),
             fields=list(fields),
             facet=False,
         )
         return {
             # storify isn't typed properly, but basically recursively call web.storage
-            doc['key']: cast(web.storage, storify(doc))
+            doc["key"]: cast(web.storage, storify(doc))
             for doc in resp.docs
         }
     else:
-        return {
-            doc['key']: doc
-            for doc in await get_solr().get_many_async(work_keys, fields)
-        }
+        return {doc["key"]: doc for doc in await get_solr().get_many_async(work_keys, fields)}
 
 
 # Create a sync wrapper for backward compatibility
@@ -162,30 +155,26 @@ def read_author_facet(author_facet: str) -> tuple[str, str]:
     >>> read_author_facet("OL26783A Leo Tolstoy")
     ('OL26783A', 'Leo Tolstoy')
     """
-    key, name = author_facet.split(' ', 1)
+    key, name = author_facet.split(" ", 1)
     return key, name
 
 
-def process_facet(
-    field: str, facets: Iterable[tuple[str, int]]
-) -> tuple[str, str, int]:
-    if field == 'has_fulltext':
+def process_facet(field: str, facets: Iterable[tuple[str, int]]) -> tuple[str, str, int]:
+    if field == "has_fulltext":
         counts = dict(facets)
-        yield ('true', 'yes', counts.get('true', 0))
-        yield ('false', 'no', counts.get('false', 0))
+        yield ("true", "yes", counts.get("true", 0))
+        yield ("false", "no", counts.get("false", 0))
     else:
         for val, count in facets:
             if count == 0:
                 continue
-            if field == 'author_key':
+            if field == "author_key":
                 key, name = read_author_facet(val)
                 yield (key, name, count)
-            elif field == 'language':
+            elif field == "language":
                 yield (
                     val,
-                    get_language_name(
-                        f'/languages/{val}', req_context.get().lang or 'en'
-                    ),
+                    get_language_name(f"/languages/{val}", req_context.get().lang or "en"),
                     count,
                 )
             else:
@@ -196,8 +185,8 @@ def process_facet_counts(
     facet_counts: dict[str, list],
 ) -> dict[str, tuple[str, str, int]]:
     for field, facets in facet_counts.items():
-        if field == 'author_facet':
-            field = 'author_key'
+        if field == "author_facet":
+            field = "author_key"
         yield field, list(process_facet(field, web.group(facets, 2)))
 
 
@@ -209,7 +198,7 @@ async def execute_solr_query_async(
 ) -> httpx.Response | None:
     url = solr_path
     if params:
-        url += '&' if '?' in url else '?'
+        url += "&" if "?" in url else "?"
         url += urlencode(params)
 
     try:
@@ -231,11 +220,11 @@ execute_solr_query = async_bridge.wrap(execute_solr_query_async)
 @public
 def get_remembered_layout():
     def read_query_string():
-        return web.input(layout=None).get('layout')
+        return web.input(layout=None).get("layout")
 
     def read_cookie():
         if "LBL" in web.ctx.env.get("HTTP_COOKIE", ""):
-            return web.cookies().get('LBL')
+            return web.cookies().get("LBL")
 
     if (qs_value := read_query_string()) is not None:
         return qs_value
@@ -243,7 +232,7 @@ def get_remembered_layout():
     if (cookie_value := read_cookie()) is not None:
         return cookie_value
 
-    return 'details'
+    return "details"
 
 
 def _prepare_solr_query_params(  # noqa: PLR0912
@@ -259,7 +248,7 @@ def _prepare_solr_query_params(  # noqa: PLR0912
     highlight: bool = False,
     allowed_filter_params: set[str] | None = None,
     extra_params: list[tuple[str, Any]] | None = None,
-    request_label: SolrRequestLabel = 'UNLABELLED',
+    request_label: SolrRequestLabel = "UNLABELLED",
     solr_internals_params: SolrInternalsParams | None = None,
 ) -> tuple[list[tuple[str, Any]], list[str]]:
     """
@@ -271,57 +260,57 @@ def _prepare_solr_query_params(  # noqa: PLR0912
     if not fields:
         fields = []
     elif isinstance(fields, str):
-        fields = fields.split(',')
+        fields = fields.split(",")
 
     # use page when offset is not specified
     if offset is None:
         offset = rows * (page - 1)
 
     params = [
-        *(('fq', subquery) for subquery in scheme.universe),
-        ('start', offset),
-        ('rows', rows),
-        ('ol.label', request_label),
-        ('wt', param.get('wt', 'json')),
+        *(("fq", subquery) for subquery in scheme.universe),
+        ("start", offset),
+        ("rows", rows),
+        ("ol.label", request_label),
+        ("wt", param.get("wt", "json")),
     ] + (extra_params or [])
 
     if spellcheck_count is None:
         spellcheck_count = default_spellcheck_count
 
     if spellcheck_count:
-        params.append(('spellcheck', 'true'))
-        params.append(('spellcheck.count', spellcheck_count))
+        params.append(("spellcheck", "true"))
+        params.append(("spellcheck.count", spellcheck_count))
 
     facet_fields = scheme.facet_fields if isinstance(facet, bool) else facet
     if facet and facet_fields:
-        params.append(('facet', 'true'))
+        params.append(("facet", "true"))
         for facet in facet_fields:  # noqa: PLR1704
             if isinstance(facet, str):
-                params.append(('facet.field', facet))
+                params.append(("facet.field", facet))
             elif isinstance(facet, dict):
-                params.append(('facet.field', facet['name']))
-                if 'sort' in facet:
-                    params.append((f'f.{facet["name"]}.facet.sort', facet['sort']))
-                if 'limit' in facet:
-                    params.append((f'f.{facet["name"]}.facet.limit', facet['limit']))
+                params.append(("facet.field", facet["name"]))
+                if "sort" in facet:
+                    params.append((f"f.{facet['name']}.facet.sort", facet["sort"]))
+                if "limit" in facet:
+                    params.append((f"f.{facet['name']}.facet.limit", facet["limit"]))
             else:
                 # Should never get here
-                raise ValueError(f'Invalid facet type: {facet}')
+                raise ValueError(f"Invalid facet type: {facet}")
 
     facet_params = (allowed_filter_params or set(scheme.facet_fields)) & set(param)
     for (field, value), rewrite in scheme.facet_rewrites.items():
         if param.get(field) == value:
             if field in facet_params:
                 facet_params.remove(field)
-            params.append(('fq', rewrite() if callable(rewrite) else rewrite))
+            params.append(("fq", rewrite() if callable(rewrite) else rewrite))
 
     for field in facet_params:
-        if field == 'author_facet':
-            field = 'author_key'
+        if field == "author_facet":
+            field = "author_key"
         values = param[field]
         if isinstance(values, str):
             values = [values]
-        params += [('fq', f'{field}:"{val}"') for val in values if val]
+        params += [("fq", f'{field}:"{val}"') for val in values if val]
 
     # Many fields in solr use the convention of `*_facet` both
     # as a facet key and as the explicit search query key.
@@ -332,24 +321,20 @@ def _prepare_solr_query_params(  # noqa: PLR0912
     # This "doubling up" has no real performance implication
     # but does fix cases where the search query is different than the facet names
     q = None
-    if param.get('q'):
-        q = scheme.process_user_query(param['q'])
+    if param.get("q"):
+        q = scheme.process_user_query(param["q"])
 
     if params_q := scheme.build_q_from_params(param):
-        q = f'{q} {params_q}' if q else params_q
+        q = f"{q} {params_q}" if q else params_q
 
     if q:
-        solr_fields = (
-            set(fields or scheme.default_fetched_fields) - scheme.non_solr_fields
-        )
-        if 'editions' in solr_fields:
-            solr_fields.remove('editions')
-            solr_fields.add('editions:[subquery]')
-        if ed_sort := param.get('editions.sort'):
-            params.append(
-                ('editions.sort', EditionSearchScheme().process_user_sort(ed_sort))
-            )
-        params.append(('fl', ','.join(solr_fields)))
+        solr_fields = set(fields or scheme.default_fetched_fields) - scheme.non_solr_fields
+        if "editions" in solr_fields:
+            solr_fields.remove("editions")
+            solr_fields.add("editions:[subquery]")
+        if ed_sort := param.get("editions.sort"):
+            params.append(("editions.sort", EditionSearchScheme().process_user_sort(ed_sort)))
+        params.append(("fl", ",".join(solr_fields)))
         params += scheme.q_to_solr_params(
             q,
             solr_fields,
@@ -359,7 +344,7 @@ def _prepare_solr_query_params(  # noqa: PLR0912
         )
 
     if sort:
-        params.append(('sort', scheme.process_user_sort(sort)))
+        params.append(("sort", scheme.process_user_sort(sort)))
 
     return params, fields
 
@@ -371,13 +356,13 @@ def _process_solr_response_and_enrich(
     sort: str | None,
     url: str,
     duration: float,
-) -> 'SearchResponse':
+) -> "SearchResponse":
     """
     Processes the Solr response, enriches it, and returns a SearchResponse object.
     """
     solr_result = response.json() if response is not None else None
 
-    if safeget(lambda: solr_result['response']['docs']):
+    if safeget(lambda: solr_result["response"]["docs"]):
         non_solr_fields = set(fields) & scheme.non_solr_fields
         if non_solr_fields:
             scheme.add_non_solr_fields(non_solr_fields, solr_result)
@@ -398,9 +383,9 @@ async def run_solr_query_async(
     highlight: bool = False,
     allowed_filter_params: set[str] | None = None,
     extra_params: list[tuple[str, Any]] | None = None,
-    request_label: SolrRequestLabel = 'UNLABELLED',
+    request_label: SolrRequestLabel = "UNLABELLED",
     solr_internals_params: SolrInternalsParams | None = None,
-) -> 'SearchResponse':
+) -> "SearchResponse":
     """
     Builds and executes a synchronous Solr query.
     """
@@ -421,30 +406,26 @@ async def run_solr_query_async(
         solr_internals_params=solr_internals_params,
     )
 
-    url = f'{solr_select_url}?{urlencode(params)}'
+    url = f"{solr_select_url}?{urlencode(params)}"
     start_time = time.time()
     response = await execute_solr_query_async(solr_select_url, params)
     end_time = time.time()
     duration = end_time - start_time
 
-    return _process_solr_response_and_enrich(
-        response, scheme, fields, sort, url, duration
-    )
+    return _process_solr_response_and_enrich(response, scheme, fields, sort, url, duration)
 
 
 run_solr_query = async_bridge.wrap(run_solr_query_async)
 
 
 @functools.cache
-def load_stopwords(lang: str = 'en') -> set[str]:
+def load_stopwords(lang: str = "en") -> set[str]:
     """
     Load stop words for a given language
     """
     try:
-        with Path(f'conf/solr/conf/lang/stopwords_{lang}.txt').open() as f:
-            return {
-                line.strip() for line in f if line.strip() and not line.startswith('#')
-            }
+        with Path(f"conf/solr/conf/lang/stopwords_{lang}.txt").open() as f:
+            return {line.strip() for line in f if line.strip() and not line.startswith("#")}
     except FileNotFoundError:
         logger.warning(f"Stopwords file not found for language: {lang}")
         return set()
@@ -469,34 +450,26 @@ class SearchResponse:
         sort: str,
         solr_select: str,
         time: float,
-    ) -> 'SearchResponse':
-        if not solr_result or 'error' in solr_result:
+    ) -> "SearchResponse":
+        if not solr_result or "error" in solr_result:
             return SearchResponse(
                 facet_counts=None,
                 sort=sort,
                 docs=[],
                 num_found=None,
                 solr_select=solr_select,
-                error=(solr_result.get('error') if solr_result else None),
+                error=(solr_result.get("error") if solr_result else None),
                 time=time,
             )
         else:
-            if highlighting := solr_result.get('highlighting'):
+            if highlighting := solr_result.get("highlighting"):
                 highlighting = SearchResponse.clean_highlighting(highlighting)
             return SearchResponse(
-                facet_counts=(
-                    dict(
-                        process_facet_counts(
-                            solr_result['facet_counts']['facet_fields']
-                        )
-                    )
-                    if 'facet_counts' in solr_result
-                    else None
-                ),
+                facet_counts=(dict(process_facet_counts(solr_result["facet_counts"]["facet_fields"])) if "facet_counts" in solr_result else None),
                 sort=sort,
                 raw_resp=solr_result,
-                docs=solr_result['response']['docs'],
-                num_found=solr_result['response']['numFound'],
+                docs=solr_result["response"]["docs"],
+                num_found=solr_result["response"]["numFound"],
                 highlighting=highlighting,
                 solr_select=solr_select,
                 time=time,
@@ -534,23 +507,19 @@ class SearchResponse:
             # Note: Solr has one wrapping `<em>` per word, even if they are adjacent
             # Note: The Solr response is correctly html escaped, so there should be
             # no `<` in between the `<em>` tags since they are escaped to `&lt;`
-            return {word.lower() for word in re.findall(r'<em>([^<]+)</em>', fragment)}
+            return {word.lower() for word in re.findall(r"<em>([^<]+)</em>", fragment)}
 
         # For now just to English? In future we might support other languages, but it's unclear
         # which language to use; the book's language or the user's language?
-        stopwords = load_stopwords('en')
+        stopwords = load_stopwords("en")
         for key in list(highlighting):
             highlights = highlighting[key]
 
             for field in list(highlights):
-                highlights[field] = [
-                    term for term in highlights[field] if get_matches(term) - stopwords
-                ]
+                highlights[field] = [term for term in highlights[field] if get_matches(term) - stopwords]
 
                 # Sort by most matches
-                highlights[field].sort(
-                    key=lambda term: len(get_matches(term)), reverse=True
-                )
+                highlights[field].sort(key=lambda term: len(get_matches(term)), reverse=True)
 
                 # Remove empty
                 if not highlights[field]:
@@ -569,25 +538,25 @@ def get_doc(doc: SolrDocument):
     called from work_search template
     """
     result = web.storage(
-        key=doc['key'],
-        title=doc['title'],
+        key=doc["key"],
+        title=doc["title"],
         url=f"{doc['key']}/{urlsafe(doc['title'])}",
-        edition_count=doc['edition_count'],
-        ia=doc.get('ia', []),
-        collections=(doc.get('ia_collection') or []),
-        has_fulltext=doc.get('has_fulltext', False),
-        public_scan=doc.get('public_scan_b', bool(doc.get('ia'))),
-        lending_edition=doc.get('lending_edition_s', None),
-        lending_identifier=doc.get('lending_identifier_s', None),
+        edition_count=doc["edition_count"],
+        ia=doc.get("ia", []),
+        collections=(doc.get("ia_collection") or []),
+        has_fulltext=doc.get("has_fulltext", False),
+        public_scan=doc.get("public_scan_b", bool(doc.get("ia"))),
+        lending_edition=doc.get("lending_edition_s", None),
+        lending_identifier=doc.get("lending_identifier_s", None),
         authors=[
             web.storage(
                 key=key,
                 name=name,
                 url=f"/authors/{key}/{urlsafe(name or 'noname')}",
-                birth_date=doc.get('birth_date', None),
-                death_date=doc.get('death_date', None),
+                birth_date=doc.get("birth_date", None),
+                death_date=doc.get("death_date", None),
             )
-            for key, name in zip(doc.get('author_key', []), doc.get('author_name', []))
+            for key, name in zip(doc.get("author_key", []), doc.get("author_name", []))
         ],
         series=[
             web.storage(
@@ -598,39 +567,39 @@ def get_doc(doc: SolrDocument):
                 position=position,
             )
             for key, name, position in zip(
-                doc.get('series_key', []),
-                doc.get('series_name', []),
-                doc.get('series_position', []),
+                doc.get("series_key", []),
+                doc.get("series_name", []),
+                doc.get("series_position", []),
             )
         ],
-        first_publish_year=doc.get('first_publish_year', None),
-        first_edition=doc.get('first_edition', None),
-        subtitle=doc.get('subtitle', None),
-        cover_edition_key=doc.get('cover_edition_key', None),
-        languages=doc.get('language', []),
-        id_project_gutenberg=doc.get('id_project_gutenberg', []),
-        id_project_runeberg=doc.get('id_project_runeberg', []),
-        id_librivox=doc.get('id_librivox', []),
-        id_standard_ebooks=doc.get('id_standard_ebooks', []),
-        id_openstax=doc.get('id_openstax', []),
-        id_cita_press=doc.get('id_cita_press', []),
-        id_wikisource=doc.get('id_wikisource', []),
+        first_publish_year=doc.get("first_publish_year", None),
+        first_edition=doc.get("first_edition", None),
+        subtitle=doc.get("subtitle", None),
+        cover_edition_key=doc.get("cover_edition_key", None),
+        languages=doc.get("language", []),
+        id_project_gutenberg=doc.get("id_project_gutenberg", []),
+        id_project_runeberg=doc.get("id_project_runeberg", []),
+        id_librivox=doc.get("id_librivox", []),
+        id_standard_ebooks=doc.get("id_standard_ebooks", []),
+        id_openstax=doc.get("id_openstax", []),
+        id_cita_press=doc.get("id_cita_press", []),
+        id_wikisource=doc.get("id_wikisource", []),
         editions=[
             web.storage(
                 {
                     **ed,
-                    'title': ed.get('title', 'Untitled'),
-                    'url': f"{ed['key']}/{urlsafe(ed.get('title', 'Untitled'))}",
+                    "title": ed.get("title", "Untitled"),
+                    "url": f"{ed['key']}/{urlsafe(ed.get('title', 'Untitled'))}",
                 }
             )
-            for ed in doc.get('editions', {}).get('docs', [])
+            for ed in doc.get("editions", {}).get("docs", [])
         ],
-        ratings_average=doc.get('ratings_average', None),
-        ratings_count=doc.get('ratings_count', None),
-        want_to_read_count=doc.get('want_to_read_count', None),
+        ratings_average=doc.get("ratings_average", None),
+        ratings_count=doc.get("ratings_count", None),
+        want_to_read_count=doc.get("want_to_read_count", None),
     )
     for field in doc:
-        if field.startswith('trending_'):
+        if field.startswith("trending_"):
             result[field] = doc[field]
 
     return result
@@ -659,14 +628,14 @@ class search(delegate.page):
             if isinstance(v, list):
                 if v == []:
                     continue
-                clean = [normalize('NFC', b.strip()) for b in v]
+                clean = [normalize("NFC", b.strip()) for b in v]
                 if clean != v:
                     need_redirect = True
-                if len(clean) == 1 and clean[0] == '':
+                if len(clean) == 1 and clean[0] == "":
                     clean = None
             else:
-                clean = normalize('NFC', v.strip())
-                if clean == '':
+                clean = normalize("NFC", v.strip())
+                if clean == "":
                     need_redirect = True
                     clean = None
                 if clean != v:
@@ -686,11 +655,11 @@ class search(delegate.page):
     def GET(self):
         # Enable patrons to search for query q2 within collection q
         # q2 param gets removed and prepended to q via a redirect
-        _i = web.input(q='', q2='')
+        _i = web.input(q="", q2="")
         if _i.q.strip() and _i.q2.strip():
-            _i.q = _i.q2.strip() + ' ' + _i.q.strip()
-            _i.pop('q2')
-            raise web.seeother('/search?' + urllib.parse.urlencode(_i))
+            _i.q = _i.q2.strip() + " " + _i.q.strip()
+            _i.pop("q2")
+            raise web.seeother("/search?" + urllib.parse.urlencode(_i))
 
         i = web.input(
             author_key=[],
@@ -705,63 +674,61 @@ class search(delegate.page):
         )
 
         # Send to full-text Search Inside if checkbox checked
-        if i.get('search-fulltext'):
-            raise web.seeother(
-                '/search/inside?' + urllib.parse.urlencode({'q': i.get('q', '')})
-            )
+        if i.get("search-fulltext"):
+            raise web.seeother("/search/inside?" + urllib.parse.urlencode({"q": i.get("q", "")}))
 
-        if i.get('wisbn'):
+        if i.get("wisbn"):
             i.isbn = i.wisbn
 
         self.redirect_if_needed(i)
 
-        if 'isbn' in i:
+        if "isbn" in i:
             self.isbn_redirect(i.isbn)
 
         q_list = []
-        if q := i.get('q', '').strip():
+        if q := i.get("q", "").strip():
             m = re_olid.match(q)
             if m:
-                raise web.seeother(f'/{OLID_URLS[m.group(1)]}/{q}')
+                raise web.seeother(f"/{OLID_URLS[m.group(1)]}/{q}")
             m = re_isbn_field.match(q)
             if m:
                 self.isbn_redirect(m.group(1))
             q_list.append(q)
-        for k in ('title', 'author', 'isbn', 'subject', 'place', 'person', 'publisher'):
+        for k in ("title", "author", "isbn", "subject", "place", "person", "publisher"):
             if k in i:
-                q_list.append(f'{k}:{fully_escape_query(i[k].strip())}')
+                q_list.append(f"{k}:{fully_escape_query(i[k].strip())}")
 
         web_input = i
         param = {}
         for p in {
-            'q',
-            'title',
-            'author',
-            'page',
-            'sort',
-            'isbn',
-            'oclc',
-            'contributor',
-            'publish_place',
-            'lccn',
-            'ia',
-            'first_sentence',
-            'publisher',
-            'author_key',
-            'debug',
-            'subject',
-            'place',
-            'person',
-            'time',
-            'editions.sort',
+            "q",
+            "title",
+            "author",
+            "page",
+            "sort",
+            "isbn",
+            "oclc",
+            "contributor",
+            "publish_place",
+            "lccn",
+            "ia",
+            "first_sentence",
+            "publisher",
+            "author_key",
+            "debug",
+            "subject",
+            "place",
+            "person",
+            "time",
+            "editions.sort",
         } | WorkSearchScheme.facet_fields:
             if web_input.get(p):
                 param[p] = web_input[p]
-        if list(param) == ['has_fulltext']:
+        if list(param) == ["has_fulltext"]:
             param = {}
 
-        page = int(param.get('page', 1))
-        sort = param.get('sort')
+        page = int(param.get("page", 1))
+        sort = param.get("sort")
         rows = 20
 
         if get_ol_env().OL_EXPOSE_SOLR_INTERNALS_PARAMS:
@@ -780,16 +747,14 @@ class search(delegate.page):
                 fields=compute_work_search_html_fields(sort, req_context.get().sfw),
                 facet=False,
                 highlight=True,
-                request_label='BOOK_SEARCH',
+                request_label="BOOK_SEARCH",
                 solr_internals_params=solr_internals_params,
             )
         else:
-            search_response = SearchResponse(
-                facet_counts=None, sort='', docs=[], num_found=0, solr_select=''
-            )
+            search_response = SearchResponse(facet_counts=None, sort="", docs=[], num_found=0, solr_select="")
 
         return render.work_search(
-            ' '.join(q_list),
+            " ".join(q_list),
             search_response,
             get_doc,
             param,
@@ -801,17 +766,17 @@ class search(delegate.page):
 
 def works_by_author(
     akey: str,
-    sort='editions',
+    sort="editions",
     page=1,
     rows=100,
     facet=False,
     has_fulltext=False,
     query: str | None = None,
-    request_label: SolrRequestLabel = 'UNLABELLED',
+    request_label: SolrRequestLabel = "UNLABELLED",
 ):
-    param = {'q': query or '*:*'}
+    param = {"q": query or "*:*"}
     if has_fulltext:
-        param['has_fulltext'] = 'true'
+        param["has_fulltext"] = "true"
 
     result = run_solr_query(
         WorkSearchScheme(),
@@ -829,28 +794,24 @@ def works_by_author(
             ]
         ),
         request_label=request_label,
-        fields=list(
-            WorkSearchScheme.default_fetched_fields | {'editions', 'providers'}
-        ),
+        fields=list(WorkSearchScheme.default_fetched_fields | {"editions", "providers"}),
         extra_params=[
-            ('fq', f'author_key:{akey}'),
-            ('facet.limit', 25),
+            ("fq", f"author_key:{akey}"),
+            ("facet.limit", 25),
         ],
     )
 
     result.docs = [get_doc(doc) for doc in result.docs]
-    add_availability(
-        [(work.get('editions') or [None])[0] or work for work in result.docs]
-    )
+    add_availability([(work.get("editions") or [None])[0] or work for work in result.docs])
     return result
 
 
 def top_books_from_author(akey: str, rows=5) -> SearchResponse:
     return run_solr_query(
         WorkSearchScheme(),
-        {'q': f'author_key:{akey}'},
-        fields=['key', 'title', 'edition_count', 'first_publish_year'],
-        sort='editions',
+        {"q": f"author_key:{akey}"},
+        fields=["key", "title", "edition_count", "first_publish_year"],
+        sort="editions",
         rows=rows,
         facet=False,
     )
@@ -871,56 +832,56 @@ class ListSearchRequest:
     page: int
     fields: str
     sort: str
-    api: Literal['', 'next']
+    api: Literal["", "next"]
 
     @staticmethod
-    def from_web_input(i: web.storage) -> 'ListSearchRequest':
-        offset = safeint(i.get('offset', 0), 0)
-        limit = safeint(i.get('limit', 20), 20)
-        fields = i.get('fields', '')
-        if i.get('api') != 'next':
+    def from_web_input(i: web.storage) -> "ListSearchRequest":
+        offset = safeint(i.get("offset", 0), 0)
+        limit = safeint(i.get("limit", 20), 20)
+        fields = i.get("fields", "")
+        if i.get("api") != "next":
             limit = min(1000, limit)
-            fields = 'key'  # Just need the key since the old API fetches from DB
-            if i.get('sort'):
-                raise ValueError('sort not supported in the old API')
+            fields = "key"  # Just need the key since the old API fetches from DB
+            if i.get("sort"):
+                raise ValueError("sort not supported in the old API")
 
-        if i.get('page'):
+        if i.get("page"):
             page = safeint(i.page, 1)
             offset = limit * (page - 1)
         else:
             page = offset // limit + 1
 
         return ListSearchRequest(
-            q=i.get('q', ''),
+            q=i.get("q", ""),
             offset=offset,
             limit=limit,
             page=page,
             fields=fields,
-            sort=i.get('sort', ''),
-            api=i.get('api', ''),
+            sort=i.get("sort", ""),
+            api=i.get("api", ""),
         )
 
 
 # searches for lists and returns results in html format
 class list_search(delegate.page):
-    path = '/search/lists'
+    path = "/search/lists"
 
     def GET(self):  # referenced subject_search
-        req = ListSearchRequest.from_web_input(web.input(api='next'))
+        req = ListSearchRequest.from_web_input(web.input(api="next"))
         # Can't set fields when rendering html
-        req.fields = 'key'
-        resp = self.get_results(req, 'LIST_SEARCH')
-        lists = list(web.ctx.site.get_many([doc['key'] for doc in resp.docs]))
-        return render_template('search/lists.html', req, resp, lists)
+        req.fields = "key"
+        resp = self.get_results(req, "LIST_SEARCH")
+        lists = list(web.ctx.site.get_many([doc["key"] for doc in resp.docs]))
+        return render_template("search/lists.html", req, resp, lists)
 
     def get_results(
         self,
         req: ListSearchRequest,
-        request_label: Literal['LIST_SEARCH', 'LIST_SEARCH_API'],
+        request_label: Literal["LIST_SEARCH", "LIST_SEARCH_API"],
     ):
         return run_solr_query(
             ListSearchScheme(),
-            {'q': req.q},
+            {"q": req.q},
             offset=req.offset,
             rows=req.limit,
             fields=req.fields,
@@ -930,36 +891,30 @@ class list_search(delegate.page):
 
 
 class subject_search(delegate.page):
-    path = '/search/subjects'
+    path = "/search/subjects"
 
     def GET(self):
-        i = web.input(q='', page=None)
+        i = web.input(q="", page=None)
         q = i.q.strip()
         results_per_page = 100
         page = safeint(i.page, 1) if i.page else 1
         offset = (page - 1) * results_per_page
-        response = (
-            self.get_results(
-                q, offset=offset, limit=results_per_page, request_label='SUBJECT_SEARCH'
-            )
-            if q
-            else None
-        )
-        return render_template('search/subjects', q, page, results_per_page, response)
+        response = self.get_results(q, offset=offset, limit=results_per_page, request_label="SUBJECT_SEARCH") if q else None
+        return render_template("search/subjects", q, page, results_per_page, response)
 
     def get_results(
         self,
         q,
-        request_label: Literal['SUBJECT_SEARCH', 'SUBJECT_SEARCH_API'],
+        request_label: Literal["SUBJECT_SEARCH", "SUBJECT_SEARCH_API"],
         offset=0,
         limit=100,
     ):
         response = run_solr_query(
             SubjectSearchScheme(),
-            {'q': q},
+            {"q": q},
             offset=offset,
             rows=limit,
-            sort='work_count desc',
+            sort="work_count desc",
             request_label=request_label,
         )
 
@@ -967,42 +922,40 @@ class subject_search(delegate.page):
 
 
 class author_search(delegate.page):
-    path = '/search/authors'
+    path = "/search/authors"
 
     def GET(self):
-        i = web.input(q='', page=None, sort=None)
+        i = web.input(q="", page=None, sort=None)
         q = i.q.strip()
         results_per_page = 100
         page = safeint(i.page, 1) if i.page else 1
         offset = (page - 1) * results_per_page
-        sort = i.sort or ''
+        sort = i.sort or ""
         results = (
             self.get_results(
                 q,
                 offset=offset,
                 limit=results_per_page,
                 sort=sort,
-                request_label='AUTHOR_SEARCH',
+                request_label="AUTHOR_SEARCH",
             )
             if q
             else None
         )
-        return render_template(
-            'search/authors', q, page, results_per_page, sort, results
-        )
+        return render_template("search/authors", q, page, results_per_page, sort, results)
 
     def get_results(
         self,
         q,
-        request_label: Literal['AUTHOR_SEARCH', 'AUTHOR_SEARCH_API'],
+        request_label: Literal["AUTHOR_SEARCH", "AUTHOR_SEARCH_API"],
         offset=0,
         limit=100,
-        fields='*',
-        sort='',
+        fields="*",
+        sort="",
     ):
         resp = run_solr_query(
             AuthorSearchScheme(),
-            {'q': q},
+            {"q": q},
             offset=offset,
             rows=limit,
             fields=fields,
@@ -1017,9 +970,9 @@ class author_search(delegate.page):
 def random_author_search(limit=10) -> SearchResponse:
     return run_solr_query(
         AuthorSearchScheme(),
-        {'q': '*:*'},
+        {"q": "*:*"},
         rows=limit,
-        sort='random.hourly',
+        sort="random.hourly",
     )
 
 
@@ -1040,20 +993,18 @@ def rewrite_list_query(q, page, offset, limit):
         limit = limit or 100
 
         # make cacheable
-        if 'env' not in web.ctx:
+        if "env" not in web.ctx:
             delegate.fakeload()
         lst = cast(List, web.ctx.site.get(key))
         return list(itertools.islice(lst.get_work_keys(), offset, offset + limit))
 
-    if list_key_match := re.match(r'^(/people/[^/]+)?/lists/OL\d+L', q):
+    if list_key_match := re.match(r"^(/people/[^/]+)?/lists/OL\d+L", q):
         # we're making an assumption that q is just a list key
-        book_keys = cache.memcache_memoize(
-            cached_get_list_book_keys, "search.list_books_query", timeout=5 * 60
-        )(list_key_match.group(0), offset, limit)
+        book_keys = cache.memcache_memoize(cached_get_list_book_keys, "search.list_books_query", timeout=5 * 60)(list_key_match.group(0), offset, limit)
 
         # Compose a query for book_keys or fallback special query w/ no results
         q = re.sub(
-            r'^(/people/[^/]+)?/lists/OL\d+L',
+            r"^(/people/[^/]+)?/lists/OL\d+L",
             f"key:({' OR '.join(book_keys)})" if book_keys else "-key:*",
             q,
         )
@@ -1081,44 +1032,33 @@ async def _process_solr_search_response(response: SearchResponse, fields: str) -
     Handles the post-processing of the Solr response, which is common
     to both sync and async versions.
     """
-    processed_response = response.raw_resp['response']
+    processed_response = response.raw_resp["response"]
 
     if response.highlighting is not None:
-        processed_response['highlighting'] = response.highlighting
+        processed_response["highlighting"] = response.highlighting
 
     # For backward compatibility
-    processed_response['num_found'] = processed_response['numFound']
+    processed_response["num_found"] = processed_response["numFound"]
 
-    if fields == '*' or 'availability' in fields:
-        docs_for_availability = [
-            (
-                work['editions']['docs'][0]
-                if work.get('editions', {}).get('docs')
-                else work
-            )
-            for work in processed_response.get('docs', [])
-        ]
+    if fields == "*" or "availability" in fields:
+        docs_for_availability = [(work["editions"]["docs"][0] if work.get("editions", {}).get("docs") else work) for work in processed_response.get("docs", [])]
         await add_availability_async(docs_for_availability)
 
     return processed_response
 
 
-def _prepare_work_search_query(
-    query: dict, page: int, offset: int, limit: int
-) -> PreparedQuery:
+def _prepare_work_search_query(query: dict, page: int, offset: int, limit: int) -> PreparedQuery:
     """
     Prepares the query by making a deep copy and rewriting list queries,
     returning a structured dataclass.
     """
     # Ensure we don't mutate the `query` passed in by reference
     prepared_query_dict = copy.deepcopy(query)
-    prepared_query_dict['wt'] = 'json'
+    prepared_query_dict["wt"] = "json"
 
     # Deal with special /lists/ key queries
-    q_val, new_page, new_offset, new_limit = rewrite_list_query(
-        prepared_query_dict.get('q', ''), page, offset, limit
-    )
-    prepared_query_dict['q'] = q_val
+    q_val, new_page, new_offset, new_limit = rewrite_list_query(prepared_query_dict.get("q", ""), page, offset, limit)
+    prepared_query_dict["q"] = q_val
 
     return PreparedQuery(
         query=prepared_query_dict,
@@ -1134,12 +1074,12 @@ async def work_search_async(
     page: int | None = 1,
     offset: int | None = 0,
     limit: int = 100,
-    fields: str | list[str] = '*',
+    fields: str | list[str] = "*",
     facet: bool = True,
     spellcheck_count: int | None = None,
-    request_label: SolrRequestLabel = 'UNLABELLED',
+    request_label: SolrRequestLabel = "UNLABELLED",
     lang: str | None = None,
-    solr_internals_params: 'SolrInternalsParams | None' = None,
+    solr_internals_params: "SolrInternalsParams | None" = None,
 ) -> dict:
     prepared = _prepare_work_search_query(query, page, offset, limit)
     scheme = WorkSearchScheme(lang=lang, solr_editions=req_context.get().solr_editions)
@@ -1162,13 +1102,11 @@ async def work_search_async(
 
 def validate_search_json_query(q: str | None) -> str | None:
     if q and len(q) < 3:
-        return 'Query too short, must be at least 3 characters'
+        return "Query too short, must be at least 3 characters"
 
-    BLOCKED_QUERIES = {'the'}
+    BLOCKED_QUERIES = {"the"}
     if q and q.lower() in BLOCKED_QUERIES:
-        return (
-            f"Invalid query; the following queries are not allowed: {', '.join(sorted(BLOCKED_QUERIES))}",
-        )
+        return (f"Invalid query; the following queries are not allowed: {', '.join(sorted(BLOCKED_QUERIES))}",)
 
     return None
 

--- a/openlibrary/plugins/worksearch/schemes/works.py
+++ b/openlibrary/plugins/worksearch/schemes/works.py
@@ -37,11 +37,11 @@ from openlibrary.utils.lcc import (
 from openlibrary.utils.request_context import req_context, site
 
 logger = logging.getLogger("openlibrary.worksearch")
-re_author_key = re.compile(r'(OL\d+A)')
+re_author_key = re.compile(r"(OL\d+A)")
 
 
 class WorkSearchScheme(SearchScheme):
-    universe = frozenset(['type:work'])
+    universe = frozenset(["type:work"])
     all_fields = frozenset(
         {
             "key",
@@ -110,11 +110,11 @@ class WorkSearchScheme(SearchScheme):
     )
     non_solr_fields = frozenset(
         {
-            'description',
-            'providers',
-            'work.description',
-            'editions.description',
-            'editions.providers',
+            "description",
+            "providers",
+            "work.description",
+            "editions.description",
+            "editions.providers",
         }
     )
     facet_fields = frozenset(
@@ -133,129 +133,129 @@ class WorkSearchScheme(SearchScheme):
     )
     field_name_map = MappingProxyType(
         {
-            'author': 'author_name',
-            'authors': 'author_name',
-            'by': 'author_name',
-            'number_of_pages': 'number_of_pages_median',
-            'publishers': 'publisher',
-            'subtitle': 'alternative_subtitle',
-            'title': 'alternative_title',
-            'work_subtitle': 'subtitle',
-            'work_title': 'title',
-            'trending': 'trending_z_score',
+            "author": "author_name",
+            "authors": "author_name",
+            "by": "author_name",
+            "number_of_pages": "number_of_pages_median",
+            "publishers": "publisher",
+            "subtitle": "alternative_subtitle",
+            "title": "alternative_title",
+            "work_subtitle": "subtitle",
+            "work_title": "title",
+            "trending": "trending_z_score",
         }
     )
     sorts = MappingProxyType(
         {
-            'editions': 'edition_count desc',
-            'old': 'def(first_publish_year, 9999) asc',
-            'new': 'first_publish_year desc',
-            'trending_score_hourly_sum': 'def(trending_score_hourly_sum, 0) desc',
-            'trending_score_hourly_sum asc': 'def(trending_score_hourly_sum, 0) asc',
-            'trending_score_hourly_sum desc': 'def(trending_score_hourly_sum, 0) desc',
-            'trending': 'def(trending_z_score, 0) desc',
-            'trending asc': 'def(trending_z_score, 0) asc',
-            'trending desc': 'def(trending_z_score, 0) desc',
-            'rating': 'ratings_sortable desc',
-            'rating asc': 'ratings_sortable asc',
-            'rating desc': 'ratings_sortable desc',
-            'readinglog': 'readinglog_count desc',
-            'want_to_read': 'want_to_read_count desc',
-            'currently_reading': 'currently_reading_count desc',
-            'already_read': 'already_read_count desc',
-            'title': 'title_sort asc',
-            'scans': 'ebook_count_i desc',  # Legacy, used in some collections
+            "editions": "edition_count desc",
+            "old": "def(first_publish_year, 9999) asc",
+            "new": "first_publish_year desc",
+            "trending_score_hourly_sum": "def(trending_score_hourly_sum, 0) desc",
+            "trending_score_hourly_sum asc": "def(trending_score_hourly_sum, 0) asc",
+            "trending_score_hourly_sum desc": "def(trending_score_hourly_sum, 0) desc",
+            "trending": "def(trending_z_score, 0) desc",
+            "trending asc": "def(trending_z_score, 0) asc",
+            "trending desc": "def(trending_z_score, 0) desc",
+            "rating": "ratings_sortable desc",
+            "rating asc": "ratings_sortable asc",
+            "rating desc": "ratings_sortable desc",
+            "readinglog": "readinglog_count desc",
+            "want_to_read": "want_to_read_count desc",
+            "currently_reading": "currently_reading_count desc",
+            "already_read": "already_read_count desc",
+            "title": "title_sort asc",
+            "scans": "ebook_count_i desc",  # Legacy, used in some collections
             # Classifications
-            'lcc_sort': 'lcc_sort asc',
-            'lcc_sort asc': 'lcc_sort asc',
-            'lcc_sort desc': 'lcc_sort desc',
-            'ddc_sort': 'ddc_sort asc',
-            'ddc_sort asc': 'ddc_sort asc',
-            'ddc_sort desc': 'ddc_sort desc',
+            "lcc_sort": "lcc_sort asc",
+            "lcc_sort asc": "lcc_sort asc",
+            "lcc_sort desc": "lcc_sort desc",
+            "ddc_sort": "ddc_sort asc",
+            "ddc_sort asc": "ddc_sort asc",
+            "ddc_sort desc": "ddc_sort desc",
             # Ebook access
-            'ebook_access': 'ebook_access desc',
-            'ebook_access asc': 'ebook_access asc',
-            'ebook_access desc': 'ebook_access desc',
+            "ebook_access": "ebook_access desc",
+            "ebook_access asc": "ebook_access asc",
+            "ebook_access desc": "ebook_access desc",
             # Open Syllabus Project
-            'osp_count': 'osp_count desc',
-            'osp_count asc': 'osp_count asc',
-            'osp_count desc': 'osp_count desc',
+            "osp_count": "osp_count desc",
+            "osp_count asc": "osp_count asc",
+            "osp_count desc": "osp_count desc",
             # Key
-            'key': 'key asc',
-            'key asc': 'key asc',
-            'key desc': 'key desc',
+            "key": "key asc",
+            "key asc": "key asc",
+            "key desc": "key desc",
             # Random
-            'random': 'random_1 asc',
-            'random asc': 'random_1 asc',
-            'random desc': 'random_1 desc',
-            'random.hourly': lambda: f'random_{datetime.now():%Y%m%dT%H} asc',
-            'random.daily': lambda: f'random_{datetime.now():%Y%m%d} asc',
+            "random": "random_1 asc",
+            "random asc": "random_1 asc",
+            "random desc": "random_1 desc",
+            "random.hourly": lambda: f"random_{datetime.now():%Y%m%dT%H} asc",
+            "random.daily": lambda: f"random_{datetime.now():%Y%m%d} asc",
         }
     )
     default_fetched_fields = frozenset(
         {
-            'key',
-            'author_name',
-            'author_key',
-            'title',
-            'subtitle',
-            'series_key',
-            'series_name',
-            'series_position',
-            'edition_count',
-            'ebook_access',
-            'ia',
-            'has_fulltext',
-            'first_publish_year',
-            'cover_i',
-            'cover_edition_key',
-            'public_scan_b',
-            'lending_edition_s',
-            'lending_identifier_s',
-            'language',
-            'ia_collection',
+            "key",
+            "author_name",
+            "author_key",
+            "title",
+            "subtitle",
+            "series_key",
+            "series_name",
+            "series_position",
+            "edition_count",
+            "ebook_access",
+            "ia",
+            "has_fulltext",
+            "first_publish_year",
+            "cover_i",
+            "cover_edition_key",
+            "public_scan_b",
+            "lending_edition_s",
+            "lending_identifier_s",
+            "language",
+            "ia_collection",
             # FIXME: These should be fetched from book_providers, but can't cause circular
             # dep
-            'id_project_gutenberg',
-            'id_project_runeberg',
-            'id_librivox',
-            'id_standard_ebooks',
-            'id_openstax',
-            'id_cita_press',
-            'id_wikisource',
+            "id_project_gutenberg",
+            "id_project_runeberg",
+            "id_librivox",
+            "id_standard_ebooks",
+            "id_openstax",
+            "id_cita_press",
+            "id_wikisource",
         }
     )
     facet_rewrites = MappingProxyType(
         {
-            ('public_scan', 'true'): 'ebook_access:public',
-            ('public_scan', 'false'): '-ebook_access:public',
-            ('print_disabled', 'true'): 'ebook_access:printdisabled',
-            ('print_disabled', 'false'): '-ebook_access:printdisabled',
+            ("public_scan", "true"): "ebook_access:public",
+            ("public_scan", "false"): "-ebook_access:public",
+            ("print_disabled", "true"): "ebook_access:printdisabled",
+            ("print_disabled", "false"): "-ebook_access:printdisabled",
             (
-                'has_fulltext',
-                'true',
-            ): lambda: f'ebook_access:[{get_fulltext_min()} TO *]',
+                "has_fulltext",
+                "true",
+            ): lambda: f"ebook_access:[{get_fulltext_min()} TO *]",
             (
-                'has_fulltext',
-                'false',
-            ): lambda: f'ebook_access:[* TO {get_fulltext_min()}]',
+                "has_fulltext",
+                "false",
+            ): lambda: f"ebook_access:[* TO {get_fulltext_min()}]",
         }
     )
     # These are extra public api params on top of facets, which are also public
     public_api_params = frozenset(
         {
-            'title',
-            'publisher',
-            'oclc',
-            'lccn',
-            'contributor',
-            'subject',
-            'place',
-            'person',
-            'time',
-            'author_key',
-            'author',
-            'isbn',
+            "title",
+            "publisher",
+            "oclc",
+            "lccn",
+            "contributor",
+            "subject",
+            "place",
+            "person",
+            "time",
+            "author_key",
+            "author",
+            "isbn",
         }
     )
 
@@ -267,31 +267,29 @@ class WorkSearchScheme(SearchScheme):
 
     def is_search_field(self, field: str):
         # New variable introduced to prevent rewriting the input.
-        if field.startswith(('work.', 'edition.')):
+        if field.startswith(("work.", "edition.")):
             return self.is_search_field(field.partition(".")[2])
-        return super().is_search_field(field) or field.startswith('id_')
+        return super().is_search_field(field) or field.startswith("id_")
 
-    def transform_user_query(
-        self, user_query: str, q_tree: luqum.tree.Item
-    ) -> luqum.tree.Item:
+    def transform_user_query(self, user_query: str, q_tree: luqum.tree.Item) -> luqum.tree.Item:
         has_search_fields = False
         for node, parents in luqum_traverse(q_tree):
             if isinstance(node, luqum.tree.SearchField):
                 has_search_fields = True
                 if node.name.lower() in self.field_name_map:
                     node.name = self.field_name_map[node.name.lower()]
-                if node.name == 'isbn':
+                if node.name == "isbn":
                     isbn_transform(node)
-                if node.name in ('lcc', 'lcc_sort'):
+                if node.name in ("lcc", "lcc_sort"):
                     lcc_transform(node)
-                if node.name in ('dcc', 'dcc_sort'):
+                if node.name in ("dcc", "dcc_sort"):
                     ddc_transform(node)
 
         if not has_search_fields:
             # If there are no search fields, maybe we want just an isbn?
             isbn = normalize_isbn(user_query)
             if isbn and len(isbn) in (10, 13):
-                q_tree = luqum_parser(f'isbn:({isbn})')
+                q_tree = luqum_parser(f"isbn:({isbn})")
 
         return q_tree
 
@@ -300,23 +298,21 @@ class WorkSearchScheme(SearchScheme):
         for k in self.public_api_params & set(params):
             values = params[k] if isinstance(params[k], list) else [params[k]]
             for val in values:
-                if k == 'author':
+                if k == "author":
                     v = val.strip()
                     m = re_author_key.search(v)
                     if m:
                         q_list.append(f"author_key:({m.group(1)})")
                     else:
                         v = fully_escape_query(v)
-                        q_list.append(
-                            f"(author_name:({v}) OR author_alternative_name:({v}))"
-                        )
-                elif k == 'isbn':
+                        q_list.append(f"(author_name:({v}) OR author_alternative_name:({v}))")
+                elif k == "isbn":
                     normalized = normalize_isbn(val)
-                    q_list.append(f'isbn:({normalized or val})')
+                    q_list.append(f"isbn:({normalized or val})")
                 else:
-                    q_list.append(f'{k}:({fully_escape_query(val)})')
+                    q_list.append(f"{k}:({fully_escape_query(val)})")
 
-        return ' AND '.join(q_list)
+        return " AND ".join(q_list)
 
     def q_to_solr_params(  # noqa: PLR0915, C901
         self,
@@ -324,7 +320,7 @@ class WorkSearchScheme(SearchScheme):
         solr_fields: set[str],
         cur_solr_params: list[tuple[str, str]],
         highlight: bool = False,
-        solr_internals_params: 'SolrInternalsParams | None' = None,
+        solr_internals_params: "SolrInternalsParams | None" = None,
     ) -> list[tuple[str, str]]:
         new_params: list[tuple[str, str]] = []
 
@@ -335,18 +331,18 @@ class WorkSearchScheme(SearchScheme):
 
         # Removes the work prefix from fields; used as the callable argument for 'luqum_replace_field'
         def remove_work_prefix(field: str) -> str:
-            return field.partition('.')[2] if field.startswith('work.') else field
+            return field.partition(".")[2] if field.startswith("work.") else field
 
         # Removes the indicator prefix from queries with the 'work field' before appending them to parameters.
         final_work_query = deepcopy(work_q_tree)
         luqum_replace_field(final_work_query, remove_work_prefix)
         try:
-            luqum_remove_field(final_work_query, lambda f: f.startswith('edition.'))
+            luqum_remove_field(final_work_query, lambda f: f.startswith("edition."))
         except EmptyTreeError:
             # If the whole tree is removed, we should just search for everything
-            final_work_query = luqum_parser('*:*')
+            final_work_query = luqum_parser("*:*")
 
-        new_params.append(('userWorkQuery', str(final_work_query)))
+        new_params.append(("userWorkQuery", str(final_work_query)))
 
         # This full work query uses solr-specific syntax to add extra parameters
         # to the way the search is processed. We are using the edismax parser.
@@ -356,44 +352,42 @@ class WorkSearchScheme(SearchScheme):
         # complicated parent/child queries with defType!
 
         edismax_params = SolrInternalsParams(
-            solr_q_op='AND',
+            solr_q_op="AND",
             # qf: the fields to query un-prefixed parts of the query.
             # e.g. 'harry potter' becomes
             # 'text:(harry potter) OR alternative_title:(harry potter)^20 OR ...'
             # TODO: Change solr's text field to exclude first_sentence, by_statement, title, subtitle,
             # alternative_subtitle . Then can replace most of qf with just text.
-            solr_qf='alternative_title^40 author_name^40 series_name^5 chapter series_position author_alternative_name subject place person time series_key author_key ia oclc lccn isbn key edition_key publisher contributor',  # noqa: E501
+            solr_qf="alternative_title^40 author_name^40 series_name^5 chapter series_position author_alternative_name subject place person time series_key author_key ia oclc lccn isbn key edition_key publisher contributor",  # noqa: E501
             # pf: phrase fields. This increases the score of documents that
             # match the query terms in close proximity to each other.
-            solr_pf='alternative_title^50 author_name^50 series_name^5',
-            solr_pf2='alternative_title^20 author_name^20 series_name^5 chapter^5',
-            solr_boost='sum(mul(20,log(sum(3,edition_count))),min(50,def(already_read_count,0)),mul(35,log(div(sum(4,def(readinglog_count,0)), 4))))',
+            solr_pf="alternative_title^50 author_name^50 series_name^5",
+            solr_pf2="alternative_title^20 author_name^20 series_name^5 chapter^5",
+            solr_boost="sum(mul(20,log(sum(3,edition_count))),min(50,def(already_read_count,0)),mul(35,log(div(sum(4,def(readinglog_count,0)), 4))))",
             # v: the query to process with the edismax query parser. Note
             # we are using a solr variable here; this reads the url parameter
             # arbitrarily called userWorkQuery.
-            solr_v='$userWorkQuery',
+            solr_v="$userWorkQuery",
         )
         if solr_internals_params:
-            edismax_params = SolrInternalsParams.override(
-                edismax_params, solr_internals_params
-            )
+            edismax_params = SolrInternalsParams.override(edismax_params, solr_internals_params)
 
         full_work_query = edismax_params.to_solr_edismax_subquery()
         ed_q = None
         full_ed_query = None
         editions_fq = []
-        if self.solr_editions and 'editions:[subquery]' in solr_fields:
+        if self.solr_editions and "editions:[subquery]" in solr_fields:
             WORK_FIELD_TO_ED_FIELD: dict[str, str | Callable[[str], str]] = {
                 # Internals
-                'edition_key': 'key',
-                'text': 'text',
+                "edition_key": "key",
+                "text": "text",
                 # Display data
-                'title': 'title',
-                'title_suggest': 'title_suggest',
-                'subtitle': 'subtitle',
-                'alternative_title': 'alternative_title',
-                'alternative_subtitle': 'subtitle',
-                'cover_i': 'cover_i',
+                "title": "title",
+                "title_suggest": "title_suggest",
+                "subtitle": "subtitle",
+                "alternative_title": "alternative_title",
+                "alternative_subtitle": "subtitle",
+                "cover_i": "cover_i",
                 # Duplicate author fields
                 # Disabled until the next full reindex
                 # 'author_name': 'author_name',
@@ -401,23 +395,23 @@ class WorkSearchScheme(SearchScheme):
                 # 'author_alternative_name': 'author_alternative_name',
                 # 'author_facet': 'author_facet',
                 # Misc useful data
-                'format': 'format',
-                'language': 'language',
-                'chapter': 'chapter',
-                'publisher': 'publisher',
-                'publisher_facet': 'publisher_facet',
-                'publish_date': 'publish_date',
-                'publish_year': 'publish_year',
+                "format": "format",
+                "language": "language",
+                "chapter": "chapter",
+                "publisher": "publisher",
+                "publisher_facet": "publisher_facet",
+                "publish_date": "publish_date",
+                "publish_year": "publish_year",
                 # Identifiers
-                'isbn': 'isbn',
+                "isbn": "isbn",
                 # 'id_*': 'id_*', # Handled manually for now to match any id field
-                'ebook_access': 'ebook_access',
+                "ebook_access": "ebook_access",
                 # IA
-                'has_fulltext': 'has_fulltext',
-                'ia': 'ia',
-                'ia_collection': 'ia_collection',
-                'ia_box_id': 'ia_box_id',
-                'public_scan_b': 'public_scan_b',
+                "has_fulltext": "has_fulltext",
+                "ia": "ia",
+                "ia_collection": "ia_collection",
+                "ia_box_id": "ia_box_id",
+                "public_scan_b": "public_scan_b",
             }
 
             def convert_work_field_to_edition_field(
@@ -431,12 +425,12 @@ class WorkSearchScheme(SearchScheme):
                 """
                 if field in WORK_FIELD_TO_ED_FIELD:
                     return WORK_FIELD_TO_ED_FIELD[field]
-                elif field.startswith('id_'):
+                elif field.startswith("id_"):
                     return field
                 elif self.is_search_field(field) or field in self.facet_fields:
                     return None
                 else:
-                    raise ValueError(f'Unknown field: {field}')
+                    raise ValueError(f"Unknown field: {field}")
 
             def convert_work_query_to_edition_query(work_query: str) -> str:
                 """
@@ -445,9 +439,9 @@ class WorkSearchScheme(SearchScheme):
                 """
                 q_tree = luqum_parser(work_query)
                 for node, parents in luqum_traverse(q_tree):
-                    if isinstance(node, luqum.tree.SearchField) and node.name != '*':
-                        if node.name.startswith('edition.'):
-                            ed_field = node.name.partition('.')[2]
+                    if isinstance(node, luqum.tree.SearchField) and node.name != "*":
+                        if node.name.startswith("edition."):
+                            ed_field = node.name.partition(".")[2]
                         else:
                             ed_field = node.name
 
@@ -457,7 +451,7 @@ class WorkSearchScheme(SearchScheme):
                                 luqum_remove_child(node, parents)
                             except EmptyTreeError:
                                 # Deleted the whole tree! Nothing left
-                                return ''
+                                return ""
                         elif isinstance(new_name, str):
                             parent = parents[-1] if parents else None
                             # Prefixing with + makes the field mandatory
@@ -471,83 +465,71 @@ class WorkSearchScheme(SearchScheme):
                             ):
                                 node.name = new_name
                             else:
-                                node.name = f'+{new_name}'
-                            if new_name == 'key':
+                                node.name = f"+{new_name}"
+                            if new_name == "key":
                                 # need to convert eg 'edition_key:OL123M' to
                                 # 'key:(/books/OL123M)'. Or
                                 # key:(/books/OL123M OR /books/OL456M)
                                 for n, n_parents in luqum_traverse(node.expr):
-                                    if isinstance(
-                                        n, (luqum.tree.Word, luqum.tree.Phrase)
-                                    ):
-                                        val = (
-                                            n.value
-                                            if isinstance(n, luqum.tree.Word)
-                                            else n.value[1:-1]
-                                        )
-                                        val = val.removeprefix('/books/')
+                                    if isinstance(n, (luqum.tree.Word, luqum.tree.Phrase)):
+                                        val = n.value if isinstance(n, luqum.tree.Word) else n.value[1:-1]
+                                        val = val.removeprefix("/books/")
                                         n.value = f'"/books/{val}"'
                         elif callable(new_name):
                             # Replace this node with a new one
                             # First process the expr
-                            new_expr = convert_work_query_to_edition_query(
-                                str(node.expr)
-                            )
-                            new_node = luqum.tree.Group(
-                                luqum_parser(new_name(new_expr))
-                            )
+                            new_expr = convert_work_query_to_edition_query(str(node.expr))
+                            new_node = luqum.tree.Group(luqum_parser(new_name(new_expr)))
                             if parents:
                                 luqum_replace_child(parents[-1], node, new_node)
                             else:
-                                return convert_work_query_to_edition_query(
-                                    str(new_node)
-                                )
+                                return convert_work_query_to_edition_query(str(new_node))
                         else:
                             # Shouldn't happen
-                            raise ValueError(f'Invalid new_name: {new_name}')
+                            raise ValueError(f"Invalid new_name: {new_name}")
                 return str(q_tree)
 
             # Move over all fq parameters that can be applied to editions.
             # These are generally used to handle facets.
-            editions_fq = ['type:edition']
+            editions_fq = ["type:edition"]
             for param_name, param_value in cur_solr_params:
-                if param_name != 'fq' or param_value.startswith('type:'):
+                if param_name != "fq" or param_value.startswith("type:"):
                     continue
-                field_name, field_val = param_value.split(':', 1)
+                field_name, field_val = param_value.split(":", 1)
                 if ed_field := convert_work_field_to_edition_field(field_name):
-                    editions_fq.append(f'{ed_field}:{field_val}')
+                    editions_fq.append(f"{ed_field}:{field_val}")
             for fq in editions_fq:
-                new_params.append(('editions.fq', fq))
+                new_params.append(("editions.fq", fq))
 
-            user_lang = convert_iso_to_marc(self.lang) or 'eng'
+            user_lang = convert_iso_to_marc(self.lang) or "eng"
 
             ed_q = convert_work_query_to_edition_query(str(work_q_tree))
             # Note that if there is no edition query (because no fields in
             # the user's work query apply), we use the special value *:* to
             # match everything, but still get boosting.
-            new_params.append(('userEdQuery', ed_q or '*:*'))
+            new_params.append(("userEdQuery", ed_q or "*:*"))
             # Needs to also set this on the editions subquery; subqueries appear
             # to have their own scope for template parameters, so in order
             # for `userEdQuery` to be available to `editions.q`, we will
             # need to specify it twice.
-            new_params.append(('editions.userEdQuery', ed_q or '*:*'))
-            new_params.append(('editions.ol.label', 'EDITION_MATCH'))
+            new_params.append(("editions.userEdQuery", ed_q or "*:*"))
+            new_params.append(("editions.ol.label", "EDITION_MATCH"))
 
             full_ed_query = '({{!edismax bq="{bq}" v={v} qf="{qf}"}})'.format(
                 # See qf in work_query
-                qf='text alternative_title^4 author_name^4 chapter^4',
+                qf="text alternative_title^4 author_name^4 chapter^4",
                 # Reading from the url parameter userEdQuery. This lets us avoid
                 # having to try to escape the query in order to fit inside this
                 # other query.
-                v='$userEdQuery',
+                v="$userEdQuery",
                 # bq (boost query): Boost which edition is promoted to the top
-                bq=' '.join(
+                bq=" ".join(
                     (
-                        f'language:{user_lang}^40',
-                        'ebook_access:public^10',
-                        'ebook_access:borrowable^8',
-                        'ebook_access:printdisabled^2',
-                        'cover_i:*^2',
+                        f"language:{user_lang}^40",
+                        "ebook_access:public^10",
+                        "ebook_access:borrowable^8",
+                        "ebook_access:printdisabled^2",
+                        "cover_i:*^2",
                     )
                 ),
             )
@@ -555,26 +537,24 @@ class WorkSearchScheme(SearchScheme):
         if ed_q or len(editions_fq) > 1:
             # The elements in _this_ edition query should cause works not to
             # match _at all_ if matching editions are not found
-            new_params.append(
-                ('fullEdQuery', cast(str, full_ed_query) if ed_q else '*:*')
-            )
+            new_params.append(("fullEdQuery", cast(str, full_ed_query) if ed_q else "*:*"))
             q = (
-                f'+{full_work_query} '
+                f"+{full_work_query} "
                 # This is using the special parent query syntax to, on top of
                 # the user's `full_work_query`, also only find works which have
                 # editions matching the edition query.
                 # Also include edition-less works (i.e. edition_count:0)
-                '+('
+                "+("
                 '_query_:"{!parent which=type:work v=$fullEdQuery filters=$editions.fq}" '
-                'OR edition_count:0'
-                ')'
+                "OR edition_count:0"
+                ")"
             )
-            new_params.append(('q', q))
+            new_params.append(("q", q))
         else:
-            new_params.append(('q', full_work_query))
+            new_params.append(("q", full_work_query))
 
         if highlight:
-            highlight_fields = ('subject', 'chapter')
+            highlight_fields = ("subject", "chapter")
             try:
                 # This can throw the EmptyTreeError if nothing remains in the query
                 highlight_query = luqum_deepcopy(work_q_tree)
@@ -582,44 +562,42 @@ class WorkSearchScheme(SearchScheme):
                     highlight_query,
                     lambda f: f not in highlight_fields,
                 )
-                new_params.append(('hl', 'true'))
+                new_params.append(("hl", "true"))
                 # NOTE: This only applies to the work, really
-                new_params.append(('hl.fl', ','.join(highlight_fields)))
-                new_params.append(('hl.q', str(highlight_query)))
-                new_params.append(('hl.snippets', '10'))
+                new_params.append(("hl.fl", ",".join(highlight_fields)))
+                new_params.append(("hl.q", str(highlight_query)))
+                new_params.append(("hl.snippets", "10"))
                 # we can't trim e.g. chapter since it has a specific structure with the pipes
-                new_params.append(('hl.fragsize', '0'))
+                new_params.append(("hl.fragsize", "0"))
             except EmptyTreeError:
                 # nothing to highlight
                 pass
 
         if full_ed_query:
-            edition_fields = {
-                f.split('.', 1)[1] for f in solr_fields if f.startswith('editions.')
-            }
+            edition_fields = {f.split(".", 1)[1] for f in solr_fields if f.startswith("editions.")}
             if not edition_fields:
                 edition_fields = solr_fields - {
                     # Default to same fields as for the work...
-                    'editions:[subquery]',
+                    "editions:[subquery]",
                     # but exclude the author fields since they're primarily work data;
                     # they only exist on editions to improve search matches.
-                    'author_name',
-                    'author_key',
-                    'author_alternative_name',
-                    'author_facet',
+                    "author_name",
+                    "author_key",
+                    "author_alternative_name",
+                    "author_facet",
                 }
             # The elements in _this_ edition query will match but not affect
             # whether the work appears in search results
             new_params.append(
                 (
-                    'editions.q',
+                    "editions.q",
                     # Here we use the special terms parser to only filter the
                     # editions for a given, already matching work '_root_' node.
-                    f'({{!terms f=_root_ v=$row.key}}) AND {full_ed_query}',
+                    f"({{!terms f=_root_ v=$row.key}}) AND {full_ed_query}",
                 )
             )
-            new_params.append(('editions.rows', '1'))
-            new_params.append(('editions.fl', ','.join(edition_fields)))
+            new_params.append(("editions.rows", "1"))
+            new_params.append(("editions.fl", ",".join(edition_fields)))
         return new_params
 
     def add_non_solr_fields(
@@ -630,42 +608,31 @@ class WorkSearchScheme(SearchScheme):
         from openlibrary.plugins.upstream.models import Edition, Work
 
         prefixed_fields = {
-            prefixed_field
-            for field in non_solr_fields
-            for prefixed_field in (
-                (field,) if '.' in field else (f'work.{field}', f'editions.{field}')
-            )
+            prefixed_field for field in non_solr_fields for prefixed_field in ((field,) if "." in field else (f"work.{field}", f"editions.{field}"))
         }
-        need_works = any(field.startswith('work.') for field in prefixed_fields)
-        need_editions = any(field.startswith('editions.') for field in prefixed_fields)
+        need_works = any(field.startswith("work.") for field in prefixed_fields)
+        need_editions = any(field.startswith("editions.") for field in prefixed_fields)
 
         # Augment with data from db
         keys: list[str] = []
         if need_works:
-            keys += [doc['key'] for doc in solr_result['response']['docs']]
+            keys += [doc["key"] for doc in solr_result["response"]["docs"]]
 
         if need_editions:
-            keys += [
-                ed_doc['key']
-                for doc in solr_result['response']['docs']
-                for ed_doc in doc.get('editions', {}).get('docs', [])
-            ]
+            keys += [ed_doc["key"] for doc in solr_result["response"]["docs"] for ed_doc in doc.get("editions", {}).get("docs", [])]
 
         things = cast(list[Work | Edition], site.get().get_many(keys))
         key_to_thing = {t.key: t for t in things if t.key in keys}
 
         from openlibrary.book_providers import get_acquisitions
 
-        for doc in solr_result['response']['docs']:
+        for doc in solr_result["response"]["docs"]:
             for field in prefixed_fields:
-                prefix, field_name = field.split('.', 1)
-                if prefix == 'work':
-                    pairs = [(doc, key_to_thing.get(doc['key']))]
+                prefix, field_name = field.split(".", 1)
+                if prefix == "work":
+                    pairs = [(doc, key_to_thing.get(doc["key"]))]
                 else:
-                    pairs = [
-                        (ed_doc, key_to_thing.get(ed_doc['key']))
-                        for ed_doc in doc.get('editions', {}).get('docs', [])
-                    ]
+                    pairs = [(ed_doc, key_to_thing.get(ed_doc["key"])) for ed_doc in doc.get("editions", {}).get("docs", [])]
 
                 for solr_doc, db_thing in pairs:
                     # Could be `None` if the record has been deleted and Solr not yet updated.
@@ -673,17 +640,13 @@ class WorkSearchScheme(SearchScheme):
                         continue
 
                     val = getattr(db_thing, field_name)
-                    if field_name == 'providers':
+                    if field_name == "providers":
                         ed = cast(Edition, db_thing)
-                        solr_doc[field_name] = [
-                            acq.__dict__ for acq in get_acquisitions(solr_doc, ed)
-                        ]
+                        solr_doc[field_name] = [acq.__dict__ for acq in get_acquisitions(solr_doc, ed)]
                     elif isinstance(val, infogami.infobase.client.Nothing):
                         continue
-                    elif field_name == 'description':
-                        solr_doc[field_name] = (
-                            val if isinstance(val, str) else val.value
-                        )
+                    elif field_name == "description":
+                        solr_doc[field_name] = val if isinstance(val, str) else val.value
 
 
 def lcc_transform(sf: luqum.tree.SearchField):
@@ -695,12 +658,12 @@ def lcc_transform(sf: luqum.tree.SearchField):
         if normed_range:
             val.low.value, val.high.value = normed_range
     elif isinstance(val, luqum.tree.Word):
-        if '*' in val.value and not val.value.startswith('*'):
+        if "*" in val.value and not val.value.startswith("*"):
             # Marshals human repr into solr repr
             # lcc:A720* should become A--0720*
-            parts = val.value.split('*', 1)
+            parts = val.value.split("*", 1)
             lcc_prefix = normalize_lcc_prefix(parts[0])
-            val.value = (lcc_prefix or parts[0]) + '*' + parts[1]
+            val.value = (lcc_prefix or parts[0]) + "*" + parts[1]
         else:
             normed = short_lcc_to_sortable_lcc(val.value.strip('"'))
             if normed:
@@ -710,17 +673,15 @@ def lcc_transform(sf: luqum.tree.SearchField):
         if normed:
             val.value = f'"{normed}"'
     elif (
-        isinstance(val, luqum.tree.Group)
-        and isinstance(val.expr, luqum.tree.UnknownOperation)
-        and all(isinstance(c, luqum.tree.Word) for c in val.expr.children)
+        isinstance(val, luqum.tree.Group) and isinstance(val.expr, luqum.tree.UnknownOperation) and all(isinstance(c, luqum.tree.Word) for c in val.expr.children)
     ):
         # treat it as a string
         normed = short_lcc_to_sortable_lcc(str(val.expr))
         if normed:
-            if ' ' in normed:
+            if " " in normed:
                 sf.expr = luqum.tree.Phrase(f'"{normed}"')
             else:
-                sf.expr = luqum.tree.Word(f'{normed}*')
+                sf.expr = luqum.tree.Word(f"{normed}*")
     else:
         logger.warning(f"Unexpected lcc SearchField value type: {type(val)}")
 
@@ -731,8 +692,8 @@ def ddc_transform(sf: luqum.tree.SearchField):
         normed_range = normalize_ddc_range(val.low.value, val.high.value)
         val.low.value = normed_range[0] or val.low
         val.high.value = normed_range[1] or val.high
-    elif isinstance(val, luqum.tree.Word) and val.value.endswith('*'):
-        return normalize_ddc_prefix(val.value[:-1]) + '*'
+    elif isinstance(val, luqum.tree.Word) and val.value.endswith("*"):
+        return normalize_ddc_prefix(val.value[:-1]) + "*"
     elif isinstance(val, (luqum.tree.Word, luqum.tree.Phrase)):
         if normed := normalize_ddc(val.value.strip('"')):
             val.value = normed
@@ -742,7 +703,7 @@ def ddc_transform(sf: luqum.tree.SearchField):
 
 def isbn_transform(sf: luqum.tree.SearchField):
     field_val = sf.children[0]
-    if isinstance(field_val, luqum.tree.Word) and '*' not in field_val.value:
+    if isinstance(field_val, luqum.tree.Word) and "*" not in field_val.value:
         isbn = normalize_isbn(field_val.value)
         if isbn:
             field_val.value = isbn
@@ -752,4 +713,4 @@ def isbn_transform(sf: luqum.tree.SearchField):
 
 def get_fulltext_min():
     is_printdisabled = req_context.get().print_disabled
-    return 'printdisabled' if is_printdisabled else 'borrowable'
+    return "printdisabled" if is_printdisabled else "borrowable"


### PR DESCRIPTION
It has been over a month since ruff-format was rolled out to the majority of the codebase. All PRs that were previously in-flight have merged, so there are no longer any files that need to be excluded from formatting.

Changes:
- Remove the ruff-format 'exclude:' block (now runs on every Python file)
- Remove the black hook entirely (ruff-format is Black-compatible and is its drop-in replacement; running both was a temporary transition measure)

pre-commit.ci will automatically apply the formatting changes to the remaining files in a follow-up auto-commit.


<!-- What issue does this PR close? -->
Closes #12260

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
