### PR TITLE
docs: replace Black references with ruff-format

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,7 +23,7 @@ npm run watch               # Dev mode with hot reload
 
 ### Code Style
 
-- **Python:** Ruff + Black, line length 162
+- **Python:** Ruff for linting and `ruff format` for formatting, line length 162
 - **JS:** ESLint, single quotes, no jQuery in new code
 - **CSS:** Stylelint — no hex/named colors, use variables
 - **Branches:** `{issue-number}/{type}/{slug}`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ pre-commit run --files <file1> <file2> ...
 
 The `mypy` and `generate-pot` hooks will fail on the host (they need `infogami` which only lives in Docker) — that's expected. Everything else must pass. Common auto-fixes that pre-commit applies and you should do yourself first:
 
-- **Double quotes** — use `"string"` not `'string'` in all new Python code (black/ruff-format enforces this)
+- **Double quotes** — use `"string"` not `'string'` in all new Python code (the Ruff formatter enforces this)
 - **Import order** — imports must be sorted: stdlib → third-party (alphabetical within each group) → local (ruff isort enforces this)
 - **No trailing whitespace** on any line
 - **Single newline at EOF** — no blank lines at end of file
@@ -38,7 +38,7 @@ npm run watch               # Dev mode with hot reload
 
 ### Code Style
 
-- **Python:** Ruff + Black, line length 162, double quotes
+- **Python:** Ruff for linting and `ruff format` for formatting, line length 162, double quotes
 - **JS:** ESLint, single quotes, no jQuery in new code
 - **CSS:** Stylelint — no hex/named colors, use variables
 - **Branches:** `{issue-number}/{type}/{slug}`

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -155,7 +155,7 @@ When creating PRs, use the template in `.github/pull_request_template.md` for th
 
 ## Code Style
 
-- **Python:** Ruff linter, Black formatter. Line length 162. Target Python 3.12.
+- **Python:** Ruff for linting and `ruff format` for formatting. Line length 162. Target Python 3.12.
 - **JavaScript:** ESLint with single quotes, `prefer-template`, `eqeqeq`. No jQuery in new code.
 - **CSS:** Stylelint enforces strict value rules — no hex colors, no named colors (use variables). Strict values required for `font-family`, `background-color`, `z-index`, `color`.
 - **Branch naming:** `{issue-number}/{type}/{slug}` (e.g., `123/fix/login-redirect`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,7 @@
-# NOTE: You have to use single-quoted strings in TOML for regular expressions.
-# It's the equivalent of r-strings in Python.  Multiline strings are treated as
-# verbose regular expressions by Black.  Use [ ] to denote a significant space
-# character.
-
 [project]
 name = "openlibrary"
 version = "1.0.0"
 requires-python = ">=3.12.2,<3.12.3"
-
-[tool.black]
-skip-string-normalization = true
-target-version = ["py311"]
 
 [tool.codespell]
 ignore-words-list = "beng,curren,datas,furst,nd,nin,ot,ser,spects,te,tha,ue,upto,thirdparty"


### PR DESCRIPTION
Follow up to #12778.

Updates stale Python style guidance so docs refer to Ruff for linting and `ruff format` for formatting instead of Black. Also removes the unused `[tool.black]` config from `pyproject.toml`.

Note: root `requirements_test.txt` already has no Black dependency. The remaining `black` entry is in `vendor/infogami/requirements_test.txt`, which belongs to the Infogami submodule and needs an Infogami side PR/submodule bump.

### Stakeholders
@RayBB 