### PR TITLE
Add range validation to is_valid_date for month and day (#12754)

### DIFF
--- a/openlibrary/plugins/upstream/checkins.py
+++ b/openlibrary/plugins/upstream/checkins.py
@@ -38,7 +38,10 @@ def is_valid_date(year: int, month: int | None, day: int | None) -> bool:
     """
     if not year:
         return False
-
+    if month is not None and not 1 <= month <= 12:
+        return False
+    if day is not None and not 1 <= day <= 31:
+        return False
     return not day or bool(month)
 
 

--- a/openlibrary/plugins/upstream/checkins.py
+++ b/openlibrary/plugins/upstream/checkins.py
@@ -38,9 +38,9 @@ def is_valid_date(year: int, month: int | None, day: int | None) -> bool:
     """
     if not year:
         return False
-    if month is not None and not 1 <= month <= 12:
+    if month is not None and not 1 <= int(month) <= 12:
         return False
-    if day is not None and not 1 <= day <= 31:
+    if day is not None and not 1 <= int(day) <= 31:
         return False
     return not day or bool(month)
 

--- a/openlibrary/plugins/upstream/tests/test_checkins.py
+++ b/openlibrary/plugins/upstream/tests/test_checkins.py
@@ -41,6 +41,24 @@ class TestIsValidDate:
         # Must have a month if there is a day:
         assert is_valid_date(1999, None, 22) is False
 
+    def test_month_out_of_range(self):
+        assert is_valid_date(1999, 0, None) is False
+        assert is_valid_date(1999, 13, None) is False
+        assert is_valid_date(1999, -1, None) is False
+
+    def test_day_out_of_range(self):
+        assert is_valid_date(1999, 1, 0) is False
+        assert is_valid_date(1999, 1, 32) is False
+        assert is_valid_date(1999, 1, -1) is False
+
+    def test_boundary_values(self):
+        # Valid boundary months:
+        assert is_valid_date(1999, 1, None) is True
+        assert is_valid_date(1999, 12, None) is True
+        # Valid boundary days:
+        assert is_valid_date(1999, 1, 1) is True
+        assert is_valid_date(1999, 1, 31) is True
+
 
 class TestValidateData:
     def setup_method(self):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #12754

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
[fix]

### Technical
<!-- What should be noted about the implementation? -->
Adds range validation to `is_valid_date` in `openlibrary/plugins/upstream/checkins.py`. The function previously only checked whether `year` was truthy and whether `day` required a `month`, but performed no range checks on the values themselves. This meant `is_valid_date(2024, 13, None)` returned `True`. The fix adds two guards after the year check: `month` must be between 1 and 12 when provided, and `day` must be between 1 and 31 when provided.

Open to any feedback or change!

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Added `test_month_out_of_range`, `test_day_out_of_range`, and `test_boundary_values` to `TestIsValidDate` in `openlibrary/plugins/upstream/tests/test_checkins.py`.

To run:
`sudo docker compose run --rm home pytest openlibrary/plugins/upstream/tests/test_checkins.py::TestIsValidDate -v`

Ran `make test` locally — 3850 tests passed, 15 failed. New tests: 4 passed, 0 failed.

- The 15 failures are pre-existing Pydantic/FastAPI compatibility errors in `test_list_view_json.py`, `test_lists_json.py`, and `test_search.py`, unrelated to this change.



### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@jimchamp @mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
