### PR TITLE
build: finalize eslint formatting for remaining legacy files

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -228,22 +228,4 @@ module.exports = [
       },
     },
   },
-
-// TEMPORARY EXEMPTIONS: Turn off new formatting rules for files locked in active PRs
-  {
-    files: [
-      "openlibrary/components/lit/OLChip.js",
-      "openlibrary/plugins/openlibrary/js/SearchBar.js",
-      "openlibrary/plugins/openlibrary/js/add-book.js",
-      "openlibrary/plugins/openlibrary/js/carousel/Carousel.js",
-      "openlibrary/plugins/openlibrary/js/dialog.js",
-      "openlibrary/plugins/openlibrary/js/my-books/MyBooksDropper/ReadingLogForms.js",
-      "openlibrary/plugins/openlibrary/js/service-worker-init.js"
-    ],
-    rules: {
-      "semi": "off",
-      "space-before-function-paren": "off",
-      "comma-spacing": "off"
-    }
-  }
 ];

--- a/openlibrary/plugins/openlibrary/js/SearchBar.js
+++ b/openlibrary/plugins/openlibrary/js/SearchBar.js
@@ -2,7 +2,7 @@ import { debounce } from './nonjquery_utils.js';
 import * as SearchUtils from './SearchUtils';
 import { PersistentValue } from './SearchUtils';
 import $ from 'jquery';
-import { websafe } from './jsdef'
+import { websafe } from './jsdef';
 
 /** Mapping of search bar facets to search endpoints */
 const FACET_TO_ENDPOINT = {
@@ -63,7 +63,7 @@ const RENDER_AUTOCOMPLETE_RESULT = {
                 </a>
             </li>`;
     }
-}
+};
 
 /**
  * Manages the interactions associated with the search bar in the header
@@ -81,7 +81,7 @@ export class SearchBar {
         this.$results = this.$component.find('ul.search-results');
         this.$facetSelect = this.$component.find('.search-facet-selector select');
         this.$barcodeScanner = this.$component.find('#barcode_scanner_link');
-        this.$searchSubmit = this.$component.find('.search-bar-submit')
+        this.$searchSubmit = this.$component.find('.search-bar-submit');
 
         /** State */
         /** Whether the bar is in collapsible mode */
@@ -110,7 +110,7 @@ export class SearchBar {
             if (e.key === 'Tab' && e.shiftKey) {
                 this.clearAutocompletionResults();
             }
-        })
+        });
 
         this.$input.on('keydown', (e) => {
             if (e.key === 'ArrowUp') {
@@ -122,13 +122,13 @@ export class SearchBar {
             } else if (e.key === 'Escape') {
                 this.clearAutocompletionResults();
             }
-        })
+        });
 
         this.$barcodeScanner.on('keydown', (e) => {
             if (e.key === 'Tab') {
                 this.clearAutocompletionResults();
             }
-        })
+        });
 
         this.$results.on('keydown', (e) => {
             if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
@@ -158,7 +158,7 @@ export class SearchBar {
                 this.escapeInput = true;
                 this.clearAutocompletionResults();
             }
-        })
+        });
 
         this.$form.on('keydown', (e) => {
             if (e.key === 'Tab') {
@@ -217,7 +217,7 @@ export class SearchBar {
                 this.toggleCollapse();
                 this.$input.trigger('focus');
             }
-        }
+        };
         const expandSelectors = ['.search-component', 'a[href="/search"]'];
 
         // When clicking on the search bar or a link to /search, expand search if it isn't already.
@@ -326,7 +326,7 @@ export class SearchBar {
 
         this.$input.on('keyup', debounce(event => {
             // ignore directional keys, enter, escape, and shift for callback
-            if (![13,16,27,37,38,39,40].includes(event.keyCode)) {
+            if (![13, 16, 27, 37, 38, 39, 40].includes(event.keyCode)) {
                 this.renderAutocompletionResults();
             }
         }, 500, false));

--- a/openlibrary/plugins/openlibrary/js/add-book.js
+++ b/openlibrary/plugins/openlibrary/js/add-book.js
@@ -8,7 +8,7 @@ import {
     isFormatValidIsbn13,
     isValidLccn,
     isValidOclc
-} from './idValidation.js'
+} from './idValidation.js';
 import { trimInputValues } from './utils.js';
 
 let invalidChecksum;
@@ -21,7 +21,7 @@ let emptyId;
 const i18nStrings = JSON.parse(document.querySelector('form[name=edit]').dataset.i18n);
 const addBookForm = $('form#addbook');
 
-export function initAddBookImport () {
+export function initAddBookImport() {
     $('.list-books a').on('click', function() {
         var li = $(this).parents('li').first();
         $('input#work').val(`/works/${li.attr('id')}`);
@@ -39,21 +39,21 @@ export function initAddBookImport () {
     invalidOclc = i18nStrings.invalid_oclc;
     emptyId = i18nStrings.empty_id;
 
-    $('#id_value').on('change',autoCompleteIdName);
+    $('#id_value').on('change', autoCompleteIdName);
     $('#addbook').on('submit', parseAndValidateId);
     $('#id_value').on('input', clearErrors);
     $('#id_name').on('change', clearErrors);
 
     $('#publish_date').on('blur', validatePublishDate);
 
-    trimInputValues('input')
+    trimInputValues('input');
 
     // Prevents submission if the publish date is > 1 year in the future
     addBookForm.on('submit', function() {
         if ($('#publish-date-errors').hasClass('hidden')) {
             return true;
         } else return false;
-    })
+    });
 }
 
 // a flag to make raiseIsbnError perform differently upon subsequent calls

--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -52,7 +52,7 @@ export class Carousel {
         this.$container = $container;
 
         //This loads in i18n strings from a hidden input element, generated in the books/custom_carousel.html template.
-        const i18nInput = document.querySelector('input[name="carousel-i18n-strings"]')
+        const i18nInput = document.querySelector('input[name="carousel-i18n-strings"]');
         if (i18nInput) {
             this.i18n = JSON.parse(i18nInput.value);
         }
@@ -143,7 +143,7 @@ export class Carousel {
     }
 
     fetchPartials() {
-        const loadMore = this.loadMore
+        const loadMore = this.loadMore;
         const url = buildPartialsUrl('CarouselLoadMore', {
             queryType: loadMore.queryType,
             q: loadMore.q,
@@ -161,14 +161,14 @@ export class Carousel {
         $.ajax({url: url, type: 'GET'})
             .then((results) => {
                 this.removeLoadingSlide();
-                const cards = results.partials || []
-                cards.forEach(card => this.slick.addSlide(card))
+                const cards = results.partials || [];
+                cards.forEach(card => this.slick.addSlide(card));
 
                 if (!cards.length) {
                     loadMore.allDone = true;
                 }
                 loadMore.locked = false;
-            })
+            });
     }
 
     clearCarousel() {

--- a/openlibrary/plugins/openlibrary/js/dialog.js
+++ b/openlibrary/plugins/openlibrary/js/dialog.js
@@ -11,18 +11,18 @@ function initConfirmationDialogs() {
     const CONFIRMATION_PROMPT_DEFAULTS = { autoOpen: false, modal: true };
     $('#noMaster').dialog(CONFIRMATION_PROMPT_DEFAULTS);
 
-    const $confirmMerge = $('#confirmMerge')
+    const $confirmMerge = $('#confirmMerge');
     if ($confirmMerge.length) {
         $confirmMerge.dialog(
             $.extend({}, CONFIRMATION_PROMPT_DEFAULTS, {
                 buttons: {
                     'Yes, Merge': function() {
-                        const commentInput = document.querySelector('#author-merge-comment')
+                        const commentInput = document.querySelector('#author-merge-comment');
                         if (commentInput.value) {
-                            document.querySelector('#hidden-comment-input').value = commentInput.value
+                            document.querySelector('#hidden-comment-input').value = commentInput.value;
                         }
                         $('#mergeForm').trigger('submit');
-                        $(this).parents().find('button').attr('disabled','disabled');
+                        $(this).parents().find('button').attr('disabled', 'disabled');
                     },
                     'No, Cancel': function() {
                         $(this).dialog('close');
@@ -53,7 +53,7 @@ export function initPreviewDialogs() {
     // Delegated click handler for Book Preview buttons.
     // Uses event delegation so dynamically-added buttons (e.g. from
     // lazy-loaded carousels) work without re-initialization.
-    $(document).off('click.bookPreview').on('click.bookPreview', '[data-book-preview]', function (e) {
+    $(document).off('click.bookPreview').on('click.bookPreview', '[data-book-preview]', function(e) {
         e.preventDefault();
         const $button = $(this);
         $.colorbox({
@@ -83,7 +83,7 @@ export function initPreviewDialogs() {
  * communicates where the HTML of that dialog lives.
  */
 export function initDialogs() {
-    $('.dialog--open').on('click', function () {
+    $('.dialog--open').on('click', function() {
         const $link = $(this),
             href = `#${$link.attr('aria-controls')}`;
 
@@ -107,6 +107,6 @@ export function initDialogs() {
  */
 export function initDialogClosers(closers) {
     closers.forEach(closer => {
-        $(closer).on('click', () => $.fn.colorbox.close())
-    })
+        $(closer).on('click', () => $.fn.colorbox.close());
+    });
 }

--- a/openlibrary/plugins/openlibrary/js/my-books/MyBooksDropper/ReadingLogForms.js
+++ b/openlibrary/plugins/openlibrary/js/my-books/MyBooksDropper/ReadingLogForms.js
@@ -16,7 +16,7 @@ export const ReadingLogShelves = {
     WANT_TO_READ: '1',
     CURRENTLY_READING: '2',
     ALREADY_READ: '3'
-}
+};
 
 /**
  * Class representing a dropper's reading log forms.
@@ -52,7 +52,7 @@ export class ReadingLogForms {
          *
          * @member {Record<string, CallableFunction>}
          */
-        this.dropperActions = dropperActionCallbacks
+        this.dropperActions = dropperActionCallbacks;
 
         /**
          * Reference to each reading log submit button.  This includes the
@@ -60,7 +60,7 @@ export class ReadingLogForms {
          *
          * @member {NodeList<HTMLElement>}
          */
-        this.submitButtons = dropper.querySelectorAll('.reading-log button')
+        this.submitButtons = dropper.querySelectorAll('.reading-log button');
 
         /**
          * Reference to this dropper's primary form.
@@ -85,25 +85,25 @@ export class ReadingLogForms {
 
         for (const button of this.submitButtons) {
             if (button.classList.contains('primary-action')) {
-                this.primaryButton = button
-                this.primaryForm = button.closest('form')
+                this.primaryButton = button;
+                this.primaryForm = button.closest('form');
             }
             else if (button.classList.contains('remove-from-list')) {  // XXX : Rename class `remove-from-shelf`?
-                this.removeButton = button
+                this.removeButton = button;
             }
         }
 
         if (!this.primaryButton) {  // This dropper only contains list affordances
-            this.primaryButton = dropper.querySelector('.primary-action')
+            this.primaryButton = dropper.querySelector('.primary-action');
         }
 
         /**
          * @member {import('./CheckInComponents') | null}
          */
-        this.checkInComponents = checkInComponents
+        this.checkInComponents = checkInComponents;
 
-        this.readingLogForms = dropper.querySelectorAll('form.reading-log')
-        this.isDropperDisabled = dropper.classList.contains('generic-dropper--disabled')
+        this.readingLogForms = dropper.querySelectorAll('form.reading-log');
+        this.isDropperDisabled = dropper.classList.contains('generic-dropper--disabled');
     }
 
     /**
@@ -113,25 +113,25 @@ export class ReadingLogForms {
      */
     initialize() {
         if (this.primaryButton) {
-            this.primaryButton.removeAttribute('disabled')
+            this.primaryButton.removeAttribute('disabled');
         }
         if (!this.isDropperDisabled) {
             if (this.readingLogForms.length) {
                 for (const form of this.readingLogForms) {
-                    const submitButton = form.querySelector('button[type=submit]')
+                    const submitButton = form.querySelector('button[type=submit]');
                     submitButton.addEventListener('click', (event) => {
-                        event.preventDefault()
-                        this.updateReadingLog(form)
+                        event.preventDefault();
+                        this.updateReadingLog(form);
 
                         // Close the dropper
-                        this.dropperActions.closeDropper()
-                    })
+                        this.dropperActions.closeDropper();
+                    });
                 }
             } else {
                 // Toggle the dropper when there is no "Reading Log" primary action:
                 this.primaryButton.addEventListener('click', () => {
-                    this.dropperActions.toggleDropper()
-                })
+                    this.dropperActions.toggleDropper();
+                });
             }
         }
     }
@@ -142,20 +142,20 @@ export class ReadingLogForms {
      * @param {HTMLFormElement} form
      */
     updateReadingLog(form) {
-        let newPrimaryButtonText = this.primaryButton.querySelector('.btn-text').innerText
+        let newPrimaryButtonText = this.primaryButton.querySelector('.btn-text').innerText;
         // XXX: Use i18n strings
-        this.updatePrimaryButtonText('saving...')
+        this.updatePrimaryButtonText('saving...');
 
-        const formData = new FormData(form)
-        const url = form.getAttribute('action')
+        const formData = new FormData(form);
+        const url = form.getAttribute('action');
 
-        const hasAddedBook = formData.get('action') === 'add'
+        const hasAddedBook = formData.get('action') === 'add';
 
-        let canUpdateShelf = true
+        let canUpdateShelf = true;
 
         if (!hasAddedBook && this.checkInComponents && this.checkInComponents.hasReadDate()) {
             // XXX: Use i18n strings
-            canUpdateShelf = confirm('Removing this book from your shelves will delete your check-ins for this work.  Continue?')
+            canUpdateShelf = confirm('Removing this book from your shelves will delete your check-ins for this work.  Continue?');
         }
 
         if (canUpdateShelf) {
@@ -166,46 +166,46 @@ export class ReadingLogForms {
                 .then(response => response.json())
                 .then((data) => {
                     if (!('error' in data)) {  // XXX: Serve correct HTTP codes to avoid this
-                        this.updateActivatedStatus(hasAddedBook)
+                        this.updateActivatedStatus(hasAddedBook);
 
                         if (hasAddedBook) {
-                            const primaryButtonClicked = form.classList.contains('primary-action')
-                            const newBookshelfId = form.querySelector('input[name=bookshelf_id]').value
+                            const primaryButtonClicked = form.classList.contains('primary-action');
+                            const newBookshelfId = form.querySelector('input[name=bookshelf_id]').value;
 
                             if (!primaryButtonClicked) {
                                 // A book has been added to a shelf chosen from the dropdown.
                                 // The primary form and dropdown selections must now be updated.
-                                const clickedButton = form.querySelector('button[type=submit]')
-                                newPrimaryButtonText = clickedButton.innerText
+                                const clickedButton = form.querySelector('button[type=submit]');
+                                newPrimaryButtonText = clickedButton.innerText;
 
-                                this.updatePrimaryBookshelfId(newBookshelfId)
+                                this.updatePrimaryBookshelfId(newBookshelfId);
 
-                                this.updateDropdownButtonVisibility(clickedButton)
+                                this.updateDropdownButtonVisibility(clickedButton);
                             }
 
                             // Update check-ins:
                             if (this.checkInComponents) {
                                 if (!this.checkInComponents.hasReadDate() && newBookshelfId === ReadingLogShelves.ALREADY_READ) {
-                                    this.checkInComponents.showCheckInPrompt()
+                                    this.checkInComponents.showCheckInPrompt();
                                 } else {
-                                    this.checkInComponents.hideCheckInPrompt()
+                                    this.checkInComponents.hideCheckInPrompt();
                                 }
                             }
 
                         } else if (this.checkInComponents) {
                             // Update check-ins:
-                            this.checkInComponents.hideCheckInPrompt()
-                            this.checkInComponents.hideCheckInDisplay()
-                            this.checkInComponents.resetForm()
+                            this.checkInComponents.hideCheckInPrompt();
+                            this.checkInComponents.hideCheckInDisplay();
+                            this.checkInComponents.resetForm();
                         }
                     }
 
                     // Remove "saving..." message from button:
-                    this.updatePrimaryButtonText(newPrimaryButtonText)
-                })
+                    this.updatePrimaryButtonText(newPrimaryButtonText);
+                });
         } else {
             // Remove "saving..." message from button if shelf cannot be updated:
-            this.updatePrimaryButtonText(newPrimaryButtonText)
+            this.updatePrimaryButtonText(newPrimaryButtonText);
         }
     }
 
@@ -222,17 +222,17 @@ export class ReadingLogForms {
      */
     updateActivatedStatus(isActivated) {
         if (isActivated) {
-            this.primaryButton.querySelector('.activated-check').classList.remove('hidden')
-            this.removeButton.classList.remove('hidden')
-            this.primaryForm.querySelector('input[name=action]').value = 'remove'
+            this.primaryButton.querySelector('.activated-check').classList.remove('hidden');
+            this.removeButton.classList.remove('hidden');
+            this.primaryForm.querySelector('input[name=action]').value = 'remove';
         } else {
-            this.primaryButton.querySelector('.activated-check').classList.add('hidden')
-            this.removeButton.classList.add('hidden')
-            this.primaryForm.querySelector('input[name=action]').value = 'add'
+            this.primaryButton.querySelector('.activated-check').classList.add('hidden');
+            this.removeButton.classList.add('hidden');
+            this.primaryForm.querySelector('input[name=action]').value = 'add';
         }
 
-        this.primaryButton.classList.toggle('activated')
-        this.primaryButton.classList.toggle('unactivated')
+        this.primaryButton.classList.toggle('activated');
+        this.primaryButton.classList.toggle('unactivated');
     }
 
     /**
@@ -241,7 +241,7 @@ export class ReadingLogForms {
      * @param {string} newText
      */
     updatePrimaryButtonText(newText) {
-        this.primaryButton.querySelector('.btn-text').innerText = newText
+        this.primaryButton.querySelector('.btn-text').innerText = newText;
     }
 
     /**
@@ -250,7 +250,7 @@ export class ReadingLogForms {
      * @param {number} newId
      */
     updatePrimaryBookshelfId(newId) {
-        this.primaryForm.querySelector('input[name=bookshelf_id]').value = newId
+        this.primaryForm.querySelector('input[name=bookshelf_id]').value = newId;
     }
 
     /**
@@ -262,10 +262,10 @@ export class ReadingLogForms {
      */
     updateDropdownButtonVisibility(transitioningButton) {
         for (const button of this.submitButtons) {
-            button.classList.remove('hidden')
+            button.classList.remove('hidden');
         }
 
-        transitioningButton.classList.add('hidden')
+        transitioningButton.classList.add('hidden');
     }
 
     /**
@@ -276,13 +276,13 @@ export class ReadingLogForms {
     getDisplayString(shelfId) {
         const matchingFormElem = Array.from(this.readingLogForms).find(elem => {
             if (elem === this.primaryForm) {
-                return false
+                return false;
             }
-            const bookshelfInput = elem.querySelector('input[name=bookshelf_id]')
-            return shelfId === bookshelfInput.value
-        })
+            const bookshelfInput = elem.querySelector('input[name=bookshelf_id]');
+            return shelfId === bookshelfInput.value;
+        });
 
-        const formButton = matchingFormElem.querySelector('button')
-        return formButton.textContent
+        const formButton = matchingFormElem.querySelector('button');
+        return formButton.textContent;
     }
 }


### PR DESCRIPTION
### Description
**Part of #12260**

Follow-up to #12539. As discussed with @RayBB, it has been over a month since the ESLint formatting exemptions were narrowed down to the final 7 files locked in active PRs. It is time to pull the band-aid off. 

This PR completely removes the `TEMPORARY EXEMPTIONS` block from `eslint.config.cjs`.

### Technical
By removing these exclusions, the new ESLint formatting rules (`semi`, `space-before-function-paren`, `comma-spacing`) will now apply globally. `pre-commit.ci` will automatically format these final 7 legacy JS files in a follow-up auto-commit.

### Testing
- [x] Verified that the `eslint.config.cjs` file syntax is valid after the block removal.
- [ ] Relying on `pre-commit.ci` to successfully run `eslint --fix` on the remaining files.

### Stakeholders
@RayBB

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
