### PR TITLE
fix: star ratings hidden on Already Read page at mobile/narrow viewports

### DIFF
--- a/static/css/components/read-panel.css
+++ b/static/css/components/read-panel.css
@@ -219,7 +219,8 @@ ul.ebook-download-options li {
   }
   /* stylelint-enable no-descending-specificity */
 
-  .star-rating-form.desktop,
+  .read-options .star-rating-form.desktop,
+  .btn-notice .star-rating-form.desktop,
   .modal-links.desktop {
     display: none;
   }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #12796 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix
## Bonus
Star ratings are now also accessible on mobile devices for the first time.
Previously patrons on phones could never rate books directly from their
reading log. This fix unblocks that use case at no extra cost.

### Technical
Scope the rule to `.read-options` and `.btn-notice` — the containers
that wrap the form exclusively on book detail pages:

```css
.read-options .star-rating-form.desktop,
.btn-notice .star-rating-form.desktop,
.modal-links.desktop {
  display: none;
}
```

The reading log renders its form inside `.list-books`, which is never
matched, so ratings now stay visible at all viewport widths.

### Testing
1. Log in and go to `/account/books/already-read`
2. Open DevTools → set viewport to 800px or 960px
3. **Before:** star widgets invisible
4. **After:** star widgets visible and functional

### Screenshot
Before
<img width="1132" height="872" alt="Screenshot 2026-05-24 025955" src="https://github.com/user-attachments/assets/d4630be1-5c99-4537-9414-8a20a11c81fd" />
After
<img width="1133" height="915" alt="Screenshot 2026-05-24 030013" src="https://github.com/user-attachments/assets/3a7cfff8-84c0-4f15-a055-3b26d226fd84" />

Mobile view before 
<img width="439" height="761" alt="Screenshot 2026-05-24 030448" src="https://github.com/user-attachments/assets/a546810c-1869-4201-beb4-9006e341ca37" />
Mobile view After
<img width="415" height="814" alt="Screenshot 2026-05-24 030458" src="https://github.com/user-attachments/assets/65f3de80-e67f-4e64-9dbd-ec3e65792264" />


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini @lokesh 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
