### PR TITLE
Fix author name sort field

### DIFF
--- a/openlibrary/plugins/worksearch/schemes/tests/test_authors.py
+++ b/openlibrary/plugins/worksearch/schemes/tests/test_authors.py
@@ -1,0 +1,5 @@
+from openlibrary.plugins.worksearch.schemes.authors import AuthorSearchScheme
+
+
+def test_name_sort_uses_populated_author_sort_field():
+    assert AuthorSearchScheme().process_user_sort("name") == "name_str asc"

--- a/openlibrary/solr/updater/author.py
+++ b/openlibrary/solr/updater/author.py
@@ -76,6 +76,10 @@ class AuthorSolrBuilder(AbstractSolrBuilder):
         return self._author.get('name')
 
     @property
+    def name_str(self) -> str | None:
+        return self.name
+
+    @property
     def alternate_names(self) -> list[str]:
         return self._author.get('alternate_names', [])
 

--- a/openlibrary/tests/solr/updater/test_author.py
+++ b/openlibrary/tests/solr/updater/test_author.py
@@ -47,3 +47,5 @@ class TestAuthorUpdater:
         assert req.deletes == []
         assert len(req.adds) == 1
         assert req.adds[0]["key"] == "/authors/OL25A"
+        assert req.adds[0]["name"] == "Somebody"
+        assert req.adds[0]["name_str"] == "Somebody"


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #12794

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes author search name sorting by populating the `name_str` Solr field from the author name.

### Technical
`sort=name` for author search maps to `name_str asc`, but `AuthorSolrBuilder` was not setting `name_str`, so author documents had no value for the sort field.

This PR adds `name_str` to author Solr documents and includes regression coverage for:
- author search `sort=name` mapping to `name_str asc`
- author Solr documents including both `name` and `name_str`

This is intended as a standalone quick fix for the current broken sort behavior. It requires author docs to be reindexed after deployment.

### Testing
```bash
docker compose run --rm home pytest openlibrary/plugins/worksearch/schemes/tests/test_authors.py openlibrary/tests/solr/updater/test_author.py -q

Result:
2 passed, 1 warning

Pre-commit hooks also passed during commit.

I also reindexed local author docs and verified locally that:
/search/authors?q=*:*&mode=everything&sort=name


### Screenshots
N/A, backend/Solr document fix.



### Stakeholders
cc @cdrini @mekarpeles @tfmorris