### PR TITLE
Fix author search name sort

### DIFF
--- a/conf/solr/conf/managed-schema.xml
+++ b/conf/solr/conf/managed-schema.xml
@@ -260,7 +260,7 @@
 
    <!-- fields used by documents of type author -->
    <field name="name" type="text_international" indexed="true" stored="true" multiValued="false"/>
-   <field name="name_str" type="string" indexed="true" stored="false"/>
+   <field name="name_sort" type="text_international_sort" indexed="true" stored="false" multiValued="false"/>
    <field name="alternate_names" type="text_international" indexed="true" stored="true" multiValued="true"/>
    <field name="birth_date" type="string" indexed="true" stored="true"/>
    <field name="death_date" type="string" indexed="true" stored="true"/>
@@ -336,6 +336,8 @@
     <!-- *** copyFields for OpenLibrary fields *** -->
     <!-- TODO: Can we pare this down for performance and storage? -->
 
+    <copyField source="name" dest="name_sort"/>
+
     <copyField source="title" dest="title_suggest"/>
     <copyField source="title" dest="title_sort"/>
     <copyField source="publisher" dest="publisher_facet"/>
@@ -372,7 +374,6 @@
 
     <!-- Copy author search fields into default search field "text" -->
     <copyField source="name" dest="text"/>
-    <copyField source="name_str" dest="text"/>
     <copyField source="alternate_names" dest="text"/>
 
     <!-- *** END of OpenLibrary copyFields *** -->
@@ -564,6 +565,11 @@
         <filter name="synonymGraph" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter name="lowercase"/>
       </analyzer>
+    </fieldType>
+
+    <!-- A text field that uses the default ICU multi-locale (locale="") collating order -->
+    <fieldType name="text_international_sort" class="solr.ICUCollationField" locale="" strength="primary">
+        <!-- No analyzers allowed here, so field value must be pre-processed, if needed -->
     </fieldType>
 
     <!-- A text field that applies standard title sorting conventions to its content -->

--- a/conf/solr/conf/managed-schema.xml
+++ b/conf/solr/conf/managed-schema.xml
@@ -338,7 +338,7 @@
 
     <copyField source="name" dest="name_sort"/>
 
-    <copyField source="title" dest="title_suggest"/>
+    <copyField source="title" dest="title_suggest"/> <!-- TODO: Unused internally 3.4 GB text -->
     <copyField source="title" dest="title_sort"/>
     <copyField source="publisher" dest="publisher_facet"/>
     <copyField source="subject" dest="subject_facet"/>

--- a/conf/solr/conf/managed-schema.xml
+++ b/conf/solr/conf/managed-schema.xml
@@ -260,7 +260,7 @@
 
    <!-- fields used by documents of type author -->
    <field name="name" type="text_international" indexed="true" stored="true" multiValued="false"/>
-   <field name="name_sort" type="text_international_sort" indexed="true" stored="false" multiValued="false"/>
+   <field name="name_sort" type="text_international_sort" indexed="true" stored="false" multiValued="false" docValues="true"/>
    <field name="alternate_names" type="text_international" indexed="true" stored="true" multiValued="true"/>
    <field name="birth_date" type="string" indexed="true" stored="true"/>
    <field name="death_date" type="string" indexed="true" stored="true"/>

--- a/conf/solr/conf/managed-schema.xml
+++ b/conf/solr/conf/managed-schema.xml
@@ -260,7 +260,7 @@
 
    <!-- fields used by documents of type author -->
    <field name="name" type="text_international" indexed="true" stored="true" multiValued="false"/>
-   <field name="name_sort" type="text_international_sort" indexed="true" stored="false" multiValued="false" docValues="true"/>
+   <field name="name_sort" type="text_international_sort" indexed="true" stored="false" multiValued="false"/>
    <field name="alternate_names" type="text_international" indexed="true" stored="true" multiValued="true"/>
    <field name="birth_date" type="string" indexed="true" stored="true"/>
    <field name="death_date" type="string" indexed="true" stored="true"/>
@@ -336,8 +336,6 @@
     <!-- *** copyFields for OpenLibrary fields *** -->
     <!-- TODO: Can we pare this down for performance and storage? -->
 
-    <copyField source="name" dest="name_sort"/>
-
     <copyField source="title" dest="title_suggest"/> <!-- TODO: Unused internally 3.4 GB text -->
     <copyField source="title" dest="title_sort"/>
     <copyField source="publisher" dest="publisher_facet"/>
@@ -374,6 +372,7 @@
 
     <!-- Copy author search fields into default search field "text" -->
     <copyField source="name" dest="text"/>
+    <copyField source="name" dest="name_sort"/>
     <copyField source="alternate_names" dest="text"/>
 
     <!-- *** END of OpenLibrary copyFields *** -->

--- a/openlibrary/plugins/worksearch/schemes/authors.py
+++ b/openlibrary/plugins/worksearch/schemes/authors.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from types import MappingProxyType
 
 from openlibrary.plugins.worksearch.schemes import SearchScheme
+from openlibrary.solr.utils import get_solr_next
 
 if typing.TYPE_CHECKING:
     from openlibrary.fastapi.models import SolrInternalsParams
@@ -31,7 +32,8 @@ class AuthorSearchScheme(SearchScheme):
     sorts = MappingProxyType(
         {
             "work_count desc": "work_count desc",
-            "name": "name_sort asc",
+            # TODO: fallback can be removed after reindex is complete
+            "name": "name_sort asc" if get_solr_next() else "name_str asc",
             # Birth Year
             "birth_date asc": "birth_date asc",
             "birth_date desc": "birth_date desc",

--- a/openlibrary/plugins/worksearch/schemes/authors.py
+++ b/openlibrary/plugins/worksearch/schemes/authors.py
@@ -33,7 +33,9 @@ class AuthorSearchScheme(SearchScheme):
         {
             "work_count desc": "work_count desc",
             # TODO: fallback can be removed after reindex is complete
-            "name": "name_sort asc" if get_solr_next() else "name_str asc",
+            # NOTE: Lambda needed here, since get_solr_next reads in the openlibrary.yml
+            # at import-time, resulting in side-effects that cause unit tests to fail
+            "name": lambda: "name_sort asc" if get_solr_next() else "name_str asc",
             # Birth Year
             "birth_date asc": "birth_date asc",
             "birth_date desc": "birth_date desc",

--- a/openlibrary/plugins/worksearch/schemes/authors.py
+++ b/openlibrary/plugins/worksearch/schemes/authors.py
@@ -31,7 +31,7 @@ class AuthorSearchScheme(SearchScheme):
     sorts = MappingProxyType(
         {
             "work_count desc": "work_count desc",
-            "name": "name_str asc",
+            "name": "name_sort asc",
             # Birth Year
             "birth_date asc": "birth_date asc",
             "birth_date desc": "birth_date desc",

--- a/openlibrary/solr/solr_types.py
+++ b/openlibrary/solr/solr_types.py
@@ -118,7 +118,7 @@ class SolrDocument(TypedDict):
     text: Optional[list[str]]
     seed: Optional[list[str]]
     name: Optional[str]
-    name_str: Optional[str]
+    name_sort: Optional[str]
     alternate_names: Optional[list[str]]
     birth_date: Optional[str]
     death_date: Optional[str]

--- a/openlibrary/solr/solr_types.py
+++ b/openlibrary/solr/solr_types.py
@@ -118,9 +118,7 @@ class SolrDocument(TypedDict):
     text: Optional[list[str]]
     seed: Optional[list[str]]
     name: Optional[str]
-    # TODO: name_str can be removed when removed when reindex is complete
-    name_str: Optional[str]
-    name_sort: Optional[str]
+    name_sort: Optional[bytes]
     alternate_names: Optional[list[str]]
     birth_date: Optional[str]
     death_date: Optional[str]

--- a/openlibrary/solr/solr_types.py
+++ b/openlibrary/solr/solr_types.py
@@ -118,6 +118,8 @@ class SolrDocument(TypedDict):
     text: Optional[list[str]]
     seed: Optional[list[str]]
     name: Optional[str]
+    # TODO: name_str can be removed when removed when reindex is complete
+    name_str: Optional[str]
     name_sort: Optional[str]
     alternate_names: Optional[list[str]]
     birth_date: Optional[str]

--- a/openlibrary/solr/types_generator.py
+++ b/openlibrary/solr/types_generator.py
@@ -50,6 +50,8 @@ def generate():
                 enumsConfig = ET.parse(os.path.join(root, "../../conf/solr/conf/", enumsConfigFile))
                 enum_values = [el.text for el in enumsConfig.findall(f".//enum[@name='{field_type.get('enumName')}']/value")]
                 python_type = f"Literal[{', '.join(map(repr, enum_values))}]"
+            elif field_class == "solr.ICUCollationField":
+                python_type = "bytes"
             else:
                 raise Exception(f"Unknown field type class {field_class}")
         else:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #12794. Repairs damage from #11211

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

### Technical
Uses a `solr.ICUCollationField` for sorting instead of a string, which has the advantage of being compact, since only the collation key is stored, and broadly internationalized, to the extent that can be done in a cross language fashion. The primary strength collator will ignore both case and diacritics.

This requires the `analysis-extras` module which is configured inconsistently across the environments. I made that more consistent in 37881245e4a65a9cbea128575803376ab84450b8 in my original PR, but have omitted it here to streamline things.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<img width="749" height="680" alt="Screenshot 2026-05-25 at 19 26 03" src="https://github.com/user-attachments/assets/e609d9b6-fbbc-47fc-b32c-c1141214215c" />


### Stakeholders
@cdrini 