### PR TITLE
Set PYTHONPATH in olbase image to avoid manually specifying it for scripts

### DIFF
--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -71,6 +71,8 @@ COPY --chown=openlibrary:openlibrary requirements*.txt ./
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 # This is needed so we install packages into the system python instead of needing venv
 ENV UV_SYSTEM_PYTHON=1
+# Util to make scripts like copydocs work without needing to manually specify PYTHONPATH
+ENV PYTHONPATH=/openlibrary
 USER root
 RUN uv pip install --upgrade wheel
 RUN uv pip install -r requirements.txt


### PR DESCRIPTION
I got tired of having to specify `PYTHONPATH=.` everywhere ; we can bake this into the image and then in theory never specify it again.


### Technical
<!-- What should be noted about the implementation? -->

### Testing

To test it, I added the `ENV` line to our oldev file, and then rebuilt it and confirmed copydocs worked without having to set the environment variable.

```sh
# Before
$ docker compose exec web ./scripts/copydocs.py --help
Traceback (most recent call last):
  File "/openlibrary/./scripts/copydocs.py", line 12, in <module>
    from scripts.solr_builder.solr_builder.fn_to_cli import FnToCLI
ModuleNotFoundError: No module named 'scripts'

# After
# Add the ENV file to oldev for testing; last line is fastest
docker compose build web
docker compose up -d --no-deps web
$ docker compose exec web ./scripts/copydocs.py --help
usage: copydocs.py [-h] [--src SRC] [--dest DEST] [--comment COMMENT]
                   [--recursive | --no-recursive] [--editions | --no-editions]
                   [--lists [LISTS ...]] [--search SEARCH] [--search-limit SEARCH_LIMIT]
                   [keys ...]
...
```

Needs another pass of testing to confirm the site comes up normally with this set though.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
