### PR TITLE
Rollback slick to v1.6.0 to resolve UI bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "promise-polyfill": "8.3.0",
         "regenerator-runtime": "^0.14.1",
         "sinon": "21.1.2",
-        "slick-carousel": "^1.8.1",
+        "slick-carousel": "^1.6.0",
         "style-loader": "^4.0.0",
         "stylelint": "^16.26.1",
         "stylelint-declaration-strict-value": "^1.11.1",
@@ -14008,13 +14008,13 @@
       }
     },
     "node_modules/slick-carousel": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.8.1.tgz",
-      "integrity": "sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.6.0.tgz",
+      "integrity": "sha512-/uk00AYE+qpBJW8GVlYHGxUqp1hJoDn5I0fWdHR5yIV4jLhAqoU3BGUhX8FX/vkD0jNdjzbMX88IY7Leb+fstA==",
       "dev": true,
       "license": "MIT",
-      "peerDependencies": {
-        "jquery": ">=1.8.0"
+      "dependencies": {
+        "jquery": ">=1.7.2"
       }
     },
     "node_modules/smob": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "promise-polyfill": "8.3.0",
     "regenerator-runtime": "^0.14.1",
     "sinon": "21.1.2",
-    "slick-carousel": "^1.8.1",
+    "slick-carousel": "^1.6.0",
     "style-loader": "^4.0.0",
     "stylelint": "^16.26.1",
     "stylelint-declaration-strict-value": "^1.11.1",


### PR DESCRIPTION
Closes #12813  . Note we might need a way to prevent the new auto-updating renotave scripts to prevent this updating again.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Back to normal:
<img width="1440" height="694" alt="image" src="https://github.com/user-attachments/assets/b2855375-bb35-48fb-80c0-8ff81faac1f1" />

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
