### PR TITLE
Add timeout to requests in showmarc.py

### DIFF
--- a/openlibrary/views/showmarc.py
+++ b/openlibrary/views/showmarc.py
@@ -38,9 +38,11 @@ class show_ia(app.view):
         if error_404:  # no MARC record
             url = f"https://archive.org/download/{ia}/{ia}_meta.xml"
             try:
-                response = requests.get(url)
+                response = requests.get(url, timeout=3)
                 response.raise_for_status()
                 data = response.content
+            except requests.Timeout:
+                return "ERROR: archive.org timed out"
             except requests.HTTPError as e:
                 return "ERROR:" + str(e)
             raise web.seeother("https://archive.org/details/" + ia)

--- a/openlibrary/views/showmarc.py
+++ b/openlibrary/views/showmarc.py
@@ -24,9 +24,11 @@ class show_ia(app.view):
         error_404 = False
         url = f"https://archive.org/download/{ia}/{ia}_meta.mrc"
         try:
-            response = requests.get(url)
+            response = requests.get(url, timeout=3)
             response.raise_for_status()
             data = response.content
+        except requests.Timeout:
+            return "ERROR: archive.org timed out"
         except requests.HTTPError as e:
             if e.response.status_code == 404:
                 error_404 = True
@@ -122,9 +124,11 @@ class show_marc(app.view):
         headers = {"Range": "bytes=%d-%d" % (r0, r1)}
 
         try:
-            response = requests.get(url, headers=headers)
+            response = requests.get(url, headers=headers, timeout=3)
             response.raise_for_status()
             result = response.content[:100000]
+        except requests.Timeout:
+            return "ERROR: archive.org timed out"
         except requests.HTTPError as e:
             return "ERROR:" + str(e)
 


### PR DESCRIPTION
Closes: This PR is in response to an activate outage (for patch deploy).

Added a timeout of 3 seconds to requests to handle potential IA marc delays.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
