### PR TITLE
Use PYTHONPATH instead of pip install for booklending_utils

### DIFF
--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -14,8 +14,9 @@ services:
     environment:
       - GUNICORN_OPTS= --workers 25 --timeout 300 --max-requests 1500
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
-      # Note this won't work with uv pip, because uv makes a network request
-      - BEFORE_START=pip install -e /booklending_utils
+      # Dockerfile.olbase PYTHONPATH + booklending_utils .
+      # Keep in sync with Dockerfile.olbase + other compose files
+      - PYTHONPATH=/openlibrary:/booklending_utils
     volumes:
       - ../booklending_utils:/booklending_utils
       - ../olsystem:/olsystem

--- a/compose.staging.yaml
+++ b/compose.staging.yaml
@@ -15,8 +15,9 @@ services:
     environment:
       - GUNICORN_OPTS= --workers 4 --timeout 180
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
-      # Note this won't work with uv pip, because uv makes a network request
-      - BEFORE_START=pip install -e /booklending_utils
+      # Dockerfile.olbase PYTHONPATH + booklending_utils .
+      # Keep in sync with Dockerfile.olbase + other compose files
+      - PYTHONPATH=/openlibrary:/booklending_utils
     env_file:
       - ./.env.local
     volumes:

--- a/docker/ol-importbot-start.sh
+++ b/docker/ol-importbot-start.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 python --version
-PYTHONPATH=. scripts/manage-imports.py --config "$OL_CONFIG" import-all
+scripts/manage-imports.py --config "$OL_CONFIG" import-all

--- a/docker/ol-monitoring-start.sh
+++ b/docker/ol-monitoring-start.sh
@@ -2,4 +2,4 @@
 
 echo "Starting monitoring on $HOSTNAME"
 
-PYTHONPATH=. python scripts/monitoring/monitor.py
+python scripts/monitoring/monitor.py

--- a/docker/ol-solr-updater-start.sh
+++ b/docker/ol-solr-updater-start.sh
@@ -12,12 +12,12 @@ ls -la /solr-updater-data/
 
 # Run in background
 echo "Starting trending updater"
-PYTHONPATH=. python scripts/solr_updater/trending_updater.py \
+python scripts/solr_updater/trending_updater.py \
     "$OL_CONFIG" \
     --trending-offset-file /solr-updater-data/$TRENDING_OFFSET_FILE &
 
 echo "Starting Solr updater"
-PYTHONPATH=. python scripts/solr_updater/solr_updater.py "$OL_CONFIG" \
+python scripts/solr_updater/solr_updater.py "$OL_CONFIG" \
     --state-file /solr-updater-data/$STATE_FILE \
     --ol-url "$OL_URL" \
     --osp-dump "$OSP_DUMP_LOCATION" \

--- a/docker/ol-web-fastapi-start.sh
+++ b/docker/ol-web-fastapi-start.sh
@@ -3,11 +3,6 @@ set -euo pipefail
 
 python --version
 
-# Optional pre-start hook
-if [ -n "${BEFORE_START:-}" ] ; then
-  eval "$BEFORE_START"
-fi
-
 # Ensure default OL_CONFIG path matches compose env
 export OL_CONFIG="${OL_CONFIG:-/openlibrary/conf/openlibrary.yml}"
 

--- a/docker/ol-web-start.sh
+++ b/docker/ol-web-start.sh
@@ -2,11 +2,6 @@
 
 python --version
 
-# Provide a hook for us to specify pre-start tasks
-if [ -n "$BEFORE_START" ] ; then
-  $BEFORE_START
-fi
-
-PYTHONPATH=. exec scripts/openlibrary-server "$OL_CONFIG" \
+exec scripts/openlibrary-server "$OL_CONFIG" \
   $GUNICORN_OPTS \
   --bind :8080


### PR DESCRIPTION
Seems like the latest version of pip does a few network requests which cause the pip install to fail on our locked-down prod environment.

Also pip installing required setuptools, which no longer appears to be included.

<!-- What issue does this PR close? -->
Closes #12818

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Testing loads. Note haven't confirmed it actually imports fully though.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
