### PR TITLE
Speed up FastAPI tests 7x by session-scoping the test client fixture

### DIFF
--- a/openlibrary/tests/fastapi/conftest.py
+++ b/openlibrary/tests/fastapi/conftest.py
@@ -9,9 +9,9 @@ from openlibrary.fastapi.auth import AuthenticatedUser, require_authenticated_us
 from openlibrary.plugins.worksearch.code import SearchResponse
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def fastapi_client():
-    """Create a test client for the FastAPI app."""
+    """Create a test client for the FastAPI app (session-scoped for speed)."""
     with patch("openlibrary.asgi_app.set_context_from_fastapi", autospec=True):
         from openlibrary.asgi_app import create_app  # noqa: PLC0415
 


### PR DESCRIPTION
# Speed up FastAPI tests 7x by session-scoping the test client fixture

## Problem

The FastAPI test suite (`openlibrary/tests/fastapi/`) was significantly slower than it needed to be. Profiling revealed that the `fastapi_client` pytest fixture was **function-scoped** (the default), meaning it recreated the entire FastAPI app from scratch for every single test — including importing and registering all 13 routers, adding middlewares, mounting static files, etc.

Benchmarks showed the disparity clearly:

| Test group | Tests | Time | Per test | Relative speed |
|---|---|---|---|---|
| Non-FastAPI tests | 1,179 | **1.75s** | ~1.5ms | 1× |
| FastAPI tests (before) | 210 | **7.50s** | ~35.7ms | **~24× slower** |

The `fastapi_client` fixture alone cost **0.04–0.12s per invocation**, and ~113 tests (54%) depended on it either directly or through `mock_authenticated_user` or the `client` alias.

## Solution

Changed the fixture scope from `function` (default) to `session`:

```python
# Before
@pytest.fixture
def fastapi_client():
    ...

# After
@pytest.fixture(scope="session")
def fastapi_client():
    ...
```

The FastAPI app is stateless — it's purely route registration + middleware setup. All mutable state (`dependency_overrides` in `mock_authenticated_user`) is properly managed with setup/teardown and is safe because tests run sequentially.

## Results

| Metric | Before | After | Improvement |
|---|---|---|---|
| FastAPI test suite | **7.50s** | **1.05s** | **7.1× faster** |
| Tests passing | 210/210 | 210/210 | No regressions |

## Safety analysis

- **`dependency_overrides`**: The `mock_authenticated_user` fixture sets overrides in setup and calls `.clear()` in teardown. Since tests run sequentially, no leakage occurs between tests.
- **`patch` scope**: The `patch("openlibrary.asgi_app.set_context_from_fastapi")` now spans the entire session, but the three test files that don't use `fastapi_client` (`test_models.py`, `test_auth.py`, `test_list_view_json.py`) create their own standalone `FastAPI()` instances that never reference this function, so they're unaffected.
- **Cleanup**: `client.close()` is called at session teardown via the existing `try/finally` block.

## Testing

```bash
# FastAPI tests pass
uv run --with-requirements requirements_test.txt \
  pytest openlibrary/tests/fastapi/ -v
# → 210 passed

# Benchmark
uv run --with-requirements requirements_test.txt \
  pytest openlibrary/tests/fastapi/ -q
# → 1.05s (down from 7.50s)
```
