### PR TITLE
Add Korean translations

### DIFF
--- a/openlibrary/i18n/ko/messages.po
+++ b/openlibrary/i18n/ko/messages.po
@@ -1,0 +1,8965 @@
+# Korean translations for Open Library.
+# Copyright (C) 2026 Internet Archive
+# This file is distributed under the same license as the Open Library
+# project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Open Library VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-04-28 18:58-0400\n"
+"PO-Revision-Date: 2026-05-30 21:11+0900\n"
+"Last-Translator: Korean Translation Contributor haist0617@kaist.ac.kr\n"
+"Language: ko\n"
+"Language-Team: Synergy\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: account.html account/notifications.html account/privacy.html lib/nav_head.html
+#: type/user/view.html
+msgid "Settings"
+msgstr "설정"
+
+#: account.html
+msgid "Settings & Privacy"
+msgstr "설정 및 개인정보"
+
+#: account.html databarDiff.html
+msgid "View"
+msgstr "보기"
+
+#: account.html status.html
+msgid "or"
+msgstr "또는"
+
+#: account.html databarHistory.html databarTemplate.html databarView.html design/popover.html
+#: my_books/check_ins/check_in_prompt.html reading_goals/reading_goal_progress.html
+#: subjects.html type/edition/compact_title.html type/user/view.html
+msgid "Edit"
+msgstr "편집"
+
+#: account.html
+msgid "Your Profile Page"
+msgstr "내 프로필 페이지"
+
+#: account.html
+msgid "View or Edit your Reading Log"
+msgstr "내 독서 기록 보기 또는 편집"
+
+#: account.html
+msgid "View or Edit your Lists"
+msgstr "내 목록 보기 또는 편집"
+
+#: account.html
+msgid "Import and Export Options"
+msgstr "가져오기 및 내보내기 옵션"
+
+#: account.html
+msgid "Manage Privacy & Content Moderation Settings"
+msgstr "개인정보 및 콘텐츠 관리 설정 관리"
+
+#: account.html
+msgid "Manage Notifications Settings"
+msgstr "알림 설정 관리"
+
+#: account.html
+msgid "Manage Mailing List Subscriptions"
+msgstr "메일링 리스트 구독 관리"
+
+#: account.html
+msgid "Change Password"
+msgstr "비밀번호 변경"
+
+#: account.html
+msgid "Update Email Address"
+msgstr "이메일 주소 업데이트"
+
+#: account.html
+msgid "Deactivate Account"
+msgstr "계정 비활성화"
+
+#: account.html
+msgid "Please contact us if you need help with anything else."
+msgstr "그 밖에 도움이 필요하면 문의해 주세요."
+
+#: barcodescanner.html
+msgid "Barcode Scanner (Beta)"
+msgstr "바코드 스캐너(베타)"
+
+#: batch_import.html
+msgid "Batch Imports"
+msgstr "일괄 가져오기"
+
+#: BatchImportNavigation.html batch_import.html
+msgid "New Batch Import"
+msgstr "새 일괄 가져오기"
+
+#: batch_import.html
+msgid ""
+"Attach a JSONL formatted document with import records or copy/paste the JSONL text into"
+" the textarea."
+msgstr ""
+"Attach a JSONL formatted document with import 레코드s or copy/paste the JSONL text into "
+"the textarea."
+
+#: batch_import.html
+msgid ""
+"See the <a href=\"https://github.com/internetarchive/openlibrary-"
+"client/tree/master/olclient/schemata\">olclient import schemata</a> for more."
+msgstr ""
+"자세한 내용은 <a href=\"https://github.com/internetarchive/openlibrary-"
+"client/tree/master/olclient/schemata\">olclient 가져오기 스키마</a>를 참고하세요."
+
+#: batch_import.html
+msgid "Attach a file:"
+msgstr "파일 첨부:"
+
+#: batch_import.html
+msgid "Or copy/paste JSONL text:"
+msgstr "또는 JSONL 텍스트 복사/붙여넣기:"
+
+#: batch_import.html import_preview.html
+msgid "Import"
+msgstr "가져오기"
+
+#: batch_import.html
+msgid "Import failed."
+msgstr "가져오기에 실패했습니다."
+
+#: batch_import.html
+msgid "No import will be queued until *every* record validates successfully."
+msgstr "No import 됩니다 queued until *every* 레코드 validates 성공ly."
+
+#: batch_import.html
+msgid ""
+"Please update the JSONL file and reload this page (there should be no need to reattach "
+"the file)."
+msgstr ""
+"다음 update the JSONL file and reload this 페이지 (there should be no need to reattach the "
+"file)."
+
+#: batch_import.html
+msgid "Validation errors:"
+msgstr "검증 오류:"
+
+#: batch_import.html
+#, python-format
+msgid "Line %d:"
+msgstr "%d행:"
+
+#: batch_import.html
+msgid "Import results for batch:"
+msgstr "일괄 가져오기 결과:"
+
+#: batch_import.html
+msgid "Records submitted:"
+msgstr "제출된 레코드:"
+
+#: batch_import.html
+msgid "Total queued:"
+msgstr "대기열에 추가된 총 수:"
+
+#: batch_import.html
+msgid "Total skipped:"
+msgstr "건너뛴 총 수:"
+
+#: batch_import.html
+msgid "Not queued because they are already present in the queue:"
+msgstr "이미 대기열에 있으므로 추가되지 않음:"
+
+#: batch_import.html
+msgid "View Batch Status"
+msgstr "일괄 작업 상태 보기"
+
+#: batch_import_pending_view.html
+msgid "Pending Batch Imports"
+msgstr "대기 중인 일괄 가져오기"
+
+#: batch_import_pending_view.html
+msgid "batch_id"
+msgstr "batch_id"
+
+#: admin/imports.html admin/imports_by_date.html batch_import_pending_view.html
+#: batch_import_view.html
+msgid "Added Time"
+msgstr "추가 시간"
+
+#: account/import.html account/loans.html admin/imports.html admin/imports_by_date.html
+#: admin/loans_table.html admin/menu.html batch_import_pending_view.html
+#: batch_import_view.html librarian_dashboard/data_quality_table.html status.html
+msgid "Status"
+msgstr "상태"
+
+#: batch_import_pending_view.html batch_import_view.html
+#: merge_request_table/table_header.html
+msgid "Submitter"
+msgstr "제출자"
+
+#: RecentChangesAdmin.html batch_import_pending_view.html batch_import_view.html
+msgid "Comments"
+msgstr "댓글"
+
+#: batch_import_view.html
+msgid "Batch Import Status"
+msgstr "일괄 가져오기 상태"
+
+#: batch_import_view.html
+msgid "Batch ID:"
+msgstr "일괄 작업 ID:"
+
+#: batch_import_view.html
+msgid "Batch Name:"
+msgstr "일괄 작업 이름:"
+
+#: batch_import_view.html
+msgid "Submitter:"
+msgstr "제출자:"
+
+#: batch_import_view.html
+msgid "Submit Time:"
+msgstr "제출 시간:"
+
+#: batch_import_view.html
+msgid "Status Summary"
+msgstr "상태 요약"
+
+#: batch_import_view.html
+msgid "Approve"
+msgstr "승인"
+
+#: batch_import_view.html
+msgid "Import Items"
+msgstr "항목 가져오기"
+
+#: batch_import_view.html
+msgid "Import Time"
+msgstr "가져오기 시간"
+
+#: account/import.html admin/imports.html admin/imports_by_date.html batch_import_view.html
+#: librarian_dashboard/data_quality_table.html
+msgid "Error"
+msgstr "오류"
+
+#: batch_import_view.html
+msgid "IA ID"
+msgstr "IA ID"
+
+#: batch_import_view.html
+msgid "Data"
+msgstr "데이터"
+
+#: admin/imports.html admin/imports_by_date.html batch_import_view.html
+msgid "OL Key"
+msgstr "OL 키"
+
+#: batch_import_view.html
+msgid "Not yet imported"
+msgstr "아직 가져오지 않음"
+
+#: design.html
+msgid "Web Component Library"
+msgstr "웹 컴포넌트 라이브러리"
+
+#: OlPagination.html OlPaginationArrows.html design.html type/edition/view.html
+#: type/work/view.html
+msgid "Pagination"
+msgstr "페이지네이션"
+
+#: design.html
+msgid "Popover"
+msgstr "팝오버"
+
+#: design.html type/edition/view.html type/work/view.html
+msgid "Read More"
+msgstr "더 읽기"
+
+#: design.html
+msgid "Chip"
+msgstr "칩"
+
+#: design.html design/button.html
+msgid "Button"
+msgstr "버튼"
+
+#: design.html
+msgid "Chip Group"
+msgstr "칩 그룹"
+
+#: design.html
+msgid "Markdown Editor"
+msgstr "마크다운 편집기"
+
+#: design.html
+msgid ""
+"The ol-pagination component provides support for both event-based and URL-based "
+"navigation."
+msgstr "ol-pagination 컴포넌트는 이벤트 기반 탐색과 URL 기반 탐색을 모두 지원합니다."
+
+#: design.html
+msgid "Event-based"
+msgstr "이벤트 기반"
+
+#: design.html
+#, python-format
+msgid ""
+"When a page is clicked, the component fires an %(update_page)s event with the page "
+"number in %(event_detail)s."
+msgstr ""
+"When a 페이지 is clicked, the component fires an %(update_page)s event with the 페이지 number"
+" in %(event_detail)s."
+
+#: design.html
+msgid "Selected page:"
+msgstr "선택된 페이지:"
+
+#: design.html
+msgid "URL-based Navigation"
+msgstr "URL 기반 탐색"
+
+#: design.html
+msgid "When base-url is provided, pagination renders anchor tags for SEO-friendly links."
+msgstr "base-url이 제공되면 페이지네이션은 SEO 친화적인 링크를 위해 앵커 태그를 렌더링합니다."
+
+#: design.html
+msgid "First page (no previous arrow)"
+msgstr "첫 페이지(이전 화살표 없음)"
+
+#: design.html
+msgid "Middle page (both arrows visible)"
+msgstr "중간 페이지(양쪽 화살표 표시)"
+
+#: design.html
+msgid "Last page (no next arrow)"
+msgstr "마지막 페이지(다음 화살표 없음)"
+
+#: design.html
+msgid "3 pages"
+msgstr "3페이지"
+
+#: design.html
+msgid "5 pages (no ellipsis needed)"
+msgstr "5페이지(줄임표 필요 없음)"
+
+#: design.html
+msgid "100 pages with ellipsis:"
+msgstr "줄임표가 있는 100페이지:"
+
+#: design.html
+msgid "Arrows mode"
+msgstr "화살표 모드"
+
+#: design.html
+msgid "When total pages is unknown, use arrows mode to show only previous/next navigation."
+msgstr "When total 페이지s is 알 수 없음, use arrows mode to show only previous/next navigation."
+
+#: design.html
+msgid "Arrows mode (has next page)"
+msgstr "화살표 모드(다음 페이지 있음)"
+
+#: design.html
+msgid "Arrows mode (no next page)"
+msgstr "화살표 모드(다음 페이지 없음)"
+
+#: design.html
+msgid "Arrows mode (first page, has next)"
+msgstr "화살표 모드(첫 페이지, 다음 있음)"
+
+#: design.html
+msgid ""
+"The ol-read-more component provides expandable/collapsible content with two truncation "
+"modes: height-based and line-based."
+msgstr "ol-read-more 컴포넌트는 높이 기준과 줄 수 기준의 두 가지 줄이기 모드로 펼치고 접을 수 있는 콘텐츠를 제공합니다."
+
+#: design.html
+msgid "Height-based truncation"
+msgstr "높이 기준 줄이기"
+
+#: design.html
+#, python-format
+msgid "Use %(max_height)s to limit content by pixel height."
+msgstr "콘텐츠를 픽셀 높이로 제한하려면 %(max_height)s을(를) 사용하세요."
+
+#: design.html
+msgid "Line-based truncation"
+msgstr "줄 수 기준 줄이기"
+
+#: design.html
+#, python-format
+msgid "Use %(max_lines)s to limit content by number of lines."
+msgstr "콘텐츠를 줄 수로 제한하려면 %(max_lines)s을(를) 사용하세요."
+
+#: design.html
+msgid "Custom button text"
+msgstr "사용자 지정 버튼 텍스트"
+
+#: design.html
+#, python-format
+msgid ""
+"Use %(more_text)s and %(less_text)s to customize the toggle button labels. We'll use "
+"the i18n strings for this example."
+msgstr "토글 버튼 라벨을 사용자 지정하려면 %(more_text)s 및 %(less_text)s을(를) 사용하세요. 이 예시에서는 i18n 문자열을 사용합니다."
+
+#: SearchResultsWork.html design.html
+msgid "Show more"
+msgstr "더 보기"
+
+#: SearchResultsWork.html design.html
+msgid "Show less"
+msgstr "접기"
+
+#: design.html
+msgid "Custom background color"
+msgstr "사용자 지정 배경색"
+
+#: design.html
+#, python-format
+msgid "Use %(background_color)s to match the gradient fade to your container background."
+msgstr "그라데이션 페이드를 컨테이너 배경에 맞추려면 %(background_color)s을(를) 사용하세요."
+
+#: design.html
+msgid "Small label size"
+msgstr "작은 라벨 크기"
+
+#: design.html
+#, python-format
+msgid "Use %(label_size)s for a smaller toggle button."
+msgstr "더 작은 토글 버튼에는 %(label_size)s을(를) 사용하세요."
+
+#: design.html
+msgid "Content shorter than limit (no button)"
+msgstr "제한보다 짧은 콘텐츠(버튼 없음)"
+
+#: design.html
+msgid "When content fits within the limit, no toggle button is shown."
+msgstr "콘텐츠가 제한 안에 들어가면 토글 버튼이 표시되지 않습니다."
+
+#: design.html
+msgid "This is short content that fits within 5 lines, so no button appears."
+msgstr "이것은 short content that fits within 5 lines, so no button appears."
+
+#: design.html
+#, python-format
+msgid ""
+"The ol-chip component is a pill-shaped interactive element for filters, tags, and "
+"selections. It fires an %(event)s event on click."
+msgstr "ol-chip 컴포넌트는 필터, 태그, 선택에 쓰이는 알약 모양의 인터랙티브 요소입니다. 클릭하면 %(event)s 이벤트를 발생시킵니다."
+
+#: design.html
+msgid "Default (medium)"
+msgstr "기본값(중간)"
+
+#: design.html
+msgid "Basic chips at the default medium size."
+msgstr "기본 중간 크기의 기본 칩입니다."
+
+#: design.html
+msgid "Fiction"
+msgstr "소설"
+
+#: design.html openlibrary/plugins/openlibrary/home.py
+msgid "Science"
+msgstr "과학"
+
+#: databarDiff.html databarEdit.html databarTemplate.html databarView.html design.html
+#: lib/history.html openlibrary/plugins/openlibrary/home.py
+msgid "History"
+msgstr "역사"
+
+#: design.html
+msgid "Selected state"
+msgstr "선택된 상태"
+
+#: design.html
+msgid "A selected chip displays a checkmark icon and uses an active color scheme."
+msgstr "선택된 칩은 체크 표시 아이콘을 표시하고 활성 색상 체계를 사용합니다."
+
+#: design.html
+msgid "Small size"
+msgstr "작은 크기"
+
+#: design.html
+#, python-format
+msgid "Use %(size)s for a compact chip."
+msgstr "작은 칩에는 %(size)s을(를) 사용하세요."
+
+#: design.html
+msgid "Poetry"
+msgstr "시"
+
+#: design.html
+msgid "Drama"
+msgstr "희곡"
+
+#: design.html
+msgid "Essays"
+msgstr "에세이"
+
+#: design.html
+msgid "With count"
+msgstr "개수 포함"
+
+#: design.html
+#, python-format
+msgid "Use %(count)s to display a number alongside the label."
+msgstr "라벨 옆에 숫자를 표시하려면 %(count)s을(를) 사용하세요."
+
+#: design.html
+msgid "As a link"
+msgstr "링크로 사용"
+
+#: design.html
+#, python-format
+msgid "When %(href)s is provided, the chip renders as an anchor tag instead of a button."
+msgstr "%(href)s이(가) 제공되면 칩은 버튼 대신 앵커 태그로 렌더링됩니다."
+
+#: design.html
+msgid "Interactive toggle"
+msgstr "인터랙티브 토글"
+
+#: design.html
+#, python-format
+msgid ""
+"Clicking a chip fires an %(event)s event. Toggle the selected state by listening to the"
+" event."
+msgstr ""
+"Clicking a chip fires an %(event)s event. Toggle the selected state by 목록ening to the "
+"event."
+
+#: design.html
+msgid "Toggle me"
+msgstr "나를 토글"
+
+#: design.html
+msgid "Toggle me too"
+msgstr "나도 토글"
+
+#: design.html
+msgid ""
+"The ol-chip-group component is a flex-wrap container that provides consistent spacing "
+"for groups of chips."
+msgstr "ol-chip-group 컴포넌트는 칩 그룹에 일관된 간격을 제공하는 flex-wrap 컨테이너입니다."
+
+#: design.html
+msgid "Default (medium gap)"
+msgstr "기본값(중간 간격)"
+
+#: design.html
+msgid "Chips are spaced with an 8px gap by default."
+msgstr "칩은 기본적으로 8px 간격으로 배치됩니다."
+
+#: design.html
+msgid "Small gap"
+msgstr "작은 간격"
+
+#: design.html
+#, python-format
+msgid "Use %(gap)s for tighter spacing (4px)."
+msgstr "더 좁은 간격(4px)에는 %(gap)s을(를) 사용하세요."
+
+#: design.html
+msgid "Large gap"
+msgstr "큰 간격"
+
+#: design.html
+#, python-format
+msgid "Use %(gap)s for wider spacing (12px)."
+msgstr "더 넓은 간격(12px)에는 %(gap)s을(를) 사용하세요."
+
+#: design.html
+msgid "Wrapping behavior"
+msgstr "줄바꿈 동작"
+
+#: design.html
+msgid "Chips automatically wrap to the next line when they exceed the container width."
+msgstr "칩이 컨테이너 너비를 초과하면 자동으로 다음 줄로 넘어갑니다."
+
+#: design.html
+msgid "Biography"
+msgstr "전기"
+
+#: design.html
+msgid "With mixed chip states"
+msgstr "혼합된 칩 상태 사용"
+
+#: design.html
+msgid "Chip groups work with any combination of chip sizes, states, and link chips."
+msgstr "Chip groups 작품 with any combination of chip sizes, states, and link chips."
+
+#: design.html
+msgid ""
+"The ol-markdown-editor component is a WYSIWYG editor built on Tiptap that outputs "
+"Markdown. It syncs its content to a hidden target textarea. A 'View source' toolbar "
+"toggle is always available so editors can drop into a raw markdown textarea when "
+"WYSIWYG round-trips are awkward."
+msgstr ""
+"The ol-markdown-편집or component is a WYSIWYG 편집or built on Tiptap that outputs Markdown."
+" It syncs its content to a hidden target textarea. A 'View source' toolbar toggle is "
+"always 사용 가능 so 편집ors can drop into a raw markdown textarea when WYSIWYG round-trips "
+"are awkward."
+
+#: design.html
+msgid "Basic usage"
+msgstr "기본 사용법"
+
+#: design.html
+#, python-format
+msgid ""
+"Provide a %(target_id)s pointing to an existing textarea. The editor reads initial "
+"content from the textarea and syncs changes back to it."
+msgstr ""
+"Provide a %(target_id)s pointing to an existing textarea. The 편집or reads initial "
+"content from the textarea and syncs changes back to it."
+
+#: design.html
+msgid "Mixed Markdown and HTML"
+msgstr "마크다운과 HTML 혼합"
+
+#: design.html
+#, python-format
+msgid ""
+"Add the %(attr)s attribute to expose the HTML block button in the toolbar. HTML blocks "
+"appear with a preview and an Edit button to modify the source."
+msgstr ""
+"the %(attr)s attribute to expose the HTML block button in the toolbar. HTML blocks "
+"appear with a preview and an Edit button to modify the source. 추가"
+
+#: design.html
+msgid "Code blocks and inline code"
+msgstr "코드 블록과 인라인 코드"
+
+#: design.html
+#, python-format
+msgid ""
+"Add the %(attr)s attribute to expose the inline code and code block buttons in the "
+"toolbar. Code support is off by default because only the wiki page renderer is "
+"guaranteed to render fenced code blocks."
+msgstr ""
+"the %(attr)s attribute to expose the inline code and code block buttons in the toolbar."
+" Code support is off by default because only the wiki page renderer is guaranteed to "
+"render fenced code blocks. 추가"
+
+#: design.html
+msgid "Change event"
+msgstr "변경 이벤트"
+
+#: design.html
+#, python-format
+msgid ""
+"The editor fires an %(event)s event on every change. The raw Markdown string is "
+"available in %(detail)s."
+msgstr ""
+"The 편집or fires an %(event)s event on every change. The raw Markdown string is 사용 가능 in "
+"%(detail)s."
+
+#: diff.html
+#, python-format
+msgid "Diff on %s"
+msgstr "%s의 차이"
+
+#: diff.html
+#, python-format
+msgid "Revision %d"
+msgstr "개정 %d"
+
+#: books/check.html covers/book_cover.html diff.html jsdef/LazyWorkPreview.html
+msgid "by"
+msgstr "작성자"
+
+#: diff.html
+msgid "by Anonymous"
+msgstr "익명 작성"
+
+#: diff.html
+msgid "history"
+msgstr "기록"
+
+#: diff.html status.html
+msgid "Added"
+msgstr "추가됨"
+
+#: admin/imports_by_date.html diff.html
+msgid "Modified"
+msgstr "수정됨"
+
+#: diff.html
+msgid "Removed"
+msgstr "삭제됨"
+
+#: diff.html
+msgid "Not changed"
+msgstr "변경 없음"
+
+#: diff.html
+msgid "Differences"
+msgstr "차이"
+
+#: diff.html
+msgid "Both the revisions are identical."
+msgstr "두 개정판이 동일합니다."
+
+#: edit_yaml.html lib/edit_head.html
+msgid "You're in edit mode."
+msgstr "편집 모드입니다."
+
+#: edit_yaml.html lib/edit_head.html
+msgid "Cancel, and go back."
+msgstr "취소하고 돌아가기."
+
+#: edit_yaml.html
+msgid "YAML Representation:"
+msgstr "YAML 표현:"
+
+#: BookPreview.html book_providers/read_button.html books/edit/edition.html editpage.html
+#: import_preview.html
+msgid "Preview"
+msgstr "미리보기"
+
+#: history.html
+msgid "History of edits to"
+msgstr "편집 기록:"
+
+#: history.html
+msgid "Revision"
+msgstr "개정"
+
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html admin/ip/view.html
+#: admin/people/edits.html history.html recentchanges/render.html
+#: recentchanges/updated_records.html
+msgid "When"
+msgstr "일시"
+
+#: RecentChanges.html admin/history.html admin/ip/view.html admin/loans_table.html
+#: admin/people/edits.html history.html recentchanges/render.html
+msgid "Who"
+msgstr "작성자"
+
+#: RecentChanges.html RecentChangesUsers.html admin/history.html admin/ip/view.html
+#: admin/people/edits.html history.html recentchanges/render.html
+#: recentchanges/updated_records.html
+msgid "Comment"
+msgstr "댓글"
+
+#: history.html
+msgid "Diff"
+msgstr "차이"
+
+#: history.html
+msgid "Compare"
+msgstr "비교"
+
+#: history.html
+msgid "See Diff"
+msgstr "차이 보기"
+
+#: history.html lib/history.html
+#, python-format
+msgid "View revision %s"
+msgstr "개정 %s 보기"
+
+#: history.html
+msgid "Compare this version..."
+msgstr "이 버전을 비교..."
+
+#: history.html
+msgid "...to this version"
+msgstr "...이 버전과"
+
+#: import_preview.html
+msgid "Import Preview"
+msgstr "가져오기 미리보기"
+
+#: import_preview.html
+msgid "Preview Import"
+msgstr "가져오기 미리보기"
+
+#: import_preview.html
+msgid "Show Raw Import Data"
+msgstr "원본 가져오기 데이터 보기"
+
+#: import_preview.html
+#, python-format
+msgid "New %(thing_type)s record will be created"
+msgstr "새 %(thing_type)s 레코드가 생성됩니다"
+
+#: import_preview.html
+#, python-format
+msgid "Changes to %(key)s"
+msgstr "%(key)s의 변경 사항"
+
+#: internalerror.html
+msgid "Internal Error"
+msgstr "내부 오류"
+
+#: internalerror.html
+msgid "A Problem Occurred"
+msgstr "문제가 발생했습니다"
+
+#: internalerror.html
+msgid "We're sorry, a problem occurred while responding to your request:"
+msgstr "죄송합니다. 요청에 응답하는 중 문제가 발생했습니다:"
+
+#: internalerror.html
+#, python-format
+msgid ""
+"The reference code %s and Sentry trace ID %s have been created to track this error and "
+"we will investigate as we're able."
+msgstr ""
+"The reference code %s and Sentry trace ID %s 되었습니다 생성d to track this error and we will "
+"investigate as we're able."
+
+#: internalerror.html
+#, python-format
+msgid ""
+"The reference code %s has been created to track this error and we will investigate as "
+"we're able."
+msgstr ""
+"The reference code %s 되었습니다 생성d to track this error and we will investigate as we're "
+"able."
+
+#: internalerror.html
+msgid "Return to the <a class=\"go-back-link\" href=\"javascript:;\">previous page</a>?"
+msgstr "<a class=\"go-back-link\" href=\"javascript:;\">이전 페이지</a>로 돌아가시겠습니까?"
+
+#: interstitial.html
+msgid "You are being redirected to your book"
+msgstr "책 페이지로 이동합니다"
+
+#: interstitial.html
+#, python-format
+msgid ""
+"This book is provided by %(book_provider)s, a third-party Open Library Trusted Book "
+"Provider"
+msgstr "이 책 is provided by %(book_provider)s, a third-party Open Library Trusted Book Provider"
+
+#: interstitial.html
+#, python-format
+msgid "In %(time)s seconds, you will be automatically redirected to: %(url)s"
+msgstr "In %(time)s seconds, you 됩니다 automatically redirected to: %(url)s"
+
+#: CreateListModal.html EditButtons.html account/notifications.html
+#: account/password/reset.html account/privacy.html admin/imports-add.html
+#: admin/permissions.html books/add.html databarEdit.html design/button.html
+#: interstitial.html merge/authors.html my_books/dropdown_content.html type/list/edit.html
+#: type/series/edit.html type/tag/form.html
+msgid "Cancel"
+msgstr "취소"
+
+#: interstitial.html
+msgid "Continue without waiting"
+msgstr "기다리지 않고 계속하기"
+
+#: lib/nav_head.html library_explorer.html
+msgid "Library Explorer"
+msgstr "라이브러리 탐색기"
+
+#: account/create.html books/custom_carousel.html librarian_dashboard/data_quality_table.html
+#: login.html search/work_search_facets.html
+msgid "Loading..."
+msgstr "불러오는 중..."
+
+#: lib/header_dropdown.html lib/nav_head.html login.html
+msgid "Log In"
+msgstr "로그인"
+
+#: login.html
+msgid "This is a development instance, the default credentials are automatically filled."
+msgstr "이것은 a development instance, the default credentials are automatically filled."
+
+#: login.html
+msgid "email:"
+msgstr "이메일:"
+
+#: login.html
+msgid "password:"
+msgstr "비밀번호:"
+
+#: login.html
+msgid ""
+"Log in to use your free Open Library card to borrow digital books from the nonprofit "
+"Internet Archive"
+msgstr ""
+"Log in to use your free Open Library card 대출하려면 digital 책 from the nonprofit Internet "
+"Archive"
+
+#: account/create.html login.html
+msgid "OR"
+msgstr "또는"
+
+#: account/create.html login.html
+#, python-format
+msgid "You are already logged into Open Library as %(user)s."
+msgstr "당신은 already logged into Open Library as %(user)s."
+
+#: account/create.html login.html
+msgid ""
+"If you'd like to create a new, different Open Library account, you'll need to <a "
+"href=\"javascript:;\" onclick=\"document.forms['hamburger-logout'].submit()\">log "
+"out</a> and start the signup process afresh."
+msgstr ""
+"If you'd like to 생성 a new, different Open Library 계정, you'll need to <a "
+"href=\"javascript:;\" onclick=\"document.forms['hamburger-logout'].제출()\">log out</a> "
+"and start the signup process afresh."
+
+#: login.html
+msgid ""
+"Please enter your <a href=\"https://archive.org\">Internet Archive</a> email and "
+"password to access your Open Library account."
+msgstr ""
+"다음 enter your <a href=\"https://archive.org\">Internet Archive</a> 이메일 and 비밀번호 to "
+"access your Open Library 계정."
+
+#: login.html openlibrary/plugins/upstream/forms.py
+msgid "Email"
+msgstr "이메일"
+
+#: login.html
+msgid "Forgot your Internet Archive email?"
+msgstr "Internet Archive 이메일을 잊으셨나요?"
+
+#: account/email/forgot-ia.html login.html openlibrary/plugins/upstream/forms.py
+msgid "Password"
+msgstr "비밀번호"
+
+#: login.html
+msgid "Forgot your Password?"
+msgstr "비밀번호를 잊으셨나요?"
+
+#: account/create.html login.html
+msgid "Toggle Password Visibility"
+msgstr "비밀번호 표시 전환"
+
+#: login.html
+msgid "Remember me"
+msgstr "로그인 상태 유지"
+
+#: login.html
+msgid "Don't have an account? <a href=\"/account/create\">Sign up now</a>."
+msgstr "Don't have an 계정? <a href=\"/계정/생성\">Sign up now</a>."
+
+#: messages.html
+msgid "Created new author record."
+msgstr "새 저자 레코드를 만들었습니다."
+
+#: messages.html
+msgid "Created new edition record."
+msgstr "새 판본 레코드를 만들었습니다."
+
+#: messages.html
+msgid "Created new work record."
+msgstr "새 작품 레코드를 만들었습니다."
+
+#: messages.html
+msgid "Added new book."
+msgstr "새 책을 추가했습니다."
+
+#: messages.html
+msgid "Thank you for improving the Open Library catalog!"
+msgstr "Open Library 카탈로그 개선에 기여해 주셔서 감사합니다!"
+
+#: BookPreview.html CreateListModal.html NotesModal.html ObservationsModal.html
+#: ShareModal.html covers/author_photo.html covers/book_cover.html covers/change.html
+#: lib/exports.html my_books/check_ins/check_in_prompt.html my_books/dropdown_content.html
+#: native_dialog.html
+msgid "Close"
+msgstr "닫기"
+
+#: notfound.html
+#, python-format
+msgid "%(path)s is not found"
+msgstr "%(path)s을(를) 찾을 수 없습니다"
+
+#: languages/notfound.html notfound.html
+msgid "404 - Page Not Found"
+msgstr "404 - 페이지를 찾을 수 없음"
+
+#: notfound.html
+#, python-format
+msgid "%(path)s does not exist."
+msgstr "%(path)s이(가) 존재하지 않습니다."
+
+#: notfound.html
+msgid "Create it?"
+msgstr "만드시겠습니까?"
+
+#: notfound.html
+msgid "Looking for a template/macro?"
+msgstr "템플릿/매크로를 찾고 있나요?"
+
+#: permission.html
+#, python-format
+msgid "Permission of %(key)s"
+msgstr "%(key)s의 권한"
+
+#: permission.html
+msgid "Permission of"
+msgstr "권한:"
+
+#: permission.html
+msgid "Permission"
+msgstr "권한"
+
+#: permission.html
+msgid "Child Permission"
+msgstr "하위 권한"
+
+#: permission_denied.html
+msgid "Permission Denied"
+msgstr "권한 거부됨"
+
+#: permission_denied.html
+msgid "Permission denied."
+msgstr "권한이 거부되었습니다."
+
+#: permission_denied.html
+#, python-format
+msgid ""
+"Only logged users are allowed to add records on Open Library. Please <a href=\"%s\">log"
+" in</a> to add a book."
+msgstr ""
+"Only logged users are allowed 추가하려면 레코드s on Open Library. 다음 <a href=\"%s\">log in</a> "
+"추가하려면 a 책."
+
+#: permission_denied.html
+#, python-format
+msgid ""
+"Only logged users are allowed to modify records on Open Library. Please <a "
+"href=\"%s\">log in</a> to edit this page."
+msgstr ""
+"Only logged users are allowed to modify 레코드s on Open Library. 다음 <a href=\"%s\">log "
+"in</a> 편집하려면 this 페이지."
+
+#: permission_denied.html
+#, python-format
+msgid "You may <a href=\"%s\">log in</a> if you have the required permissions."
+msgstr "필요한 권한이 있다면 <a href=\"%s\">로그인</a>할 수 있습니다."
+
+#: recaptcha.html
+msgid ""
+"Please satisfy the reCAPTCHA below. If you have security settings or privacy blockers "
+"installed, please disable them to see the reCAPTCHA."
+msgstr ""
+"다음 satisfy the reCAPTCHA below. If you have security settings or privacy blockers "
+"installed, please disable them to see the reCAPTCHA."
+
+#: recaptcha.html
+msgid "Incorrect. Please try again."
+msgstr "올바르지 않습니다. 다시 시도해 주세요."
+
+#: showamazon.html showbwb.html showgoogle_books.html
+msgid "Record details of"
+msgstr "레코드 세부 정보:"
+
+#: showamazon.html showbwb.html showgoogle_books.html
+msgid "This record came from"
+msgstr "이 레코드의 출처"
+
+#: showia.html showmarc.html
+msgid "Record ID"
+msgstr "레코드 ID"
+
+#: showia.html showmarc.html
+msgid "Source"
+msgstr "출처"
+
+#: books/add.html covers/add.html showia.html type/edition/view.html type/work/view.html
+msgid "Internet Archive"
+msgstr "Internet Archive"
+
+#: showia.html
+msgid "Download MARC XML"
+msgstr "MARC XML 다운로드"
+
+#: showia.html
+msgid "Download MARC binary"
+msgstr "MARC 바이너리 다운로드"
+
+#: showia.html showmarc.html
+msgid "Invalid MARC record."
+msgstr "잘못된 MARC 레코드입니다."
+
+#: showia.html showmarc.html
+msgid "LEADER:"
+msgstr "LEADER:"
+
+#: showmarc.html
+msgid "Download Link"
+msgstr "다운로드 링크"
+
+#: showmarc.html type/tag/index.html
+msgid "Next"
+msgstr "다음"
+
+#: status.html
+msgid "Open Library server status"
+msgstr "Open Library 서버 상태"
+
+#: status.html
+msgid "Server status"
+msgstr "서버 상태"
+
+#: status.html
+msgid "Testing Environment"
+msgstr "테스트 환경"
+
+#: status.html
+msgid "Deploy triggered!"
+msgstr "배포가 시작되었습니다!"
+
+#: status.html
+msgid "View Jenkins progress"
+msgstr "Jenkins 진행 상황 보기"
+
+#: status.html
+msgid "GitHub status refreshed."
+msgstr "GitHub 상태가 새로고침되었습니다."
+
+#: status.html
+msgid "PR numbers or URLs, space/comma separated"
+msgstr "PR 번호 또는 URL, 공백/쉼표로 구분"
+
+#: status.html
+msgid "Add PR(s)"
+msgstr "PR 추가"
+
+#: status.html
+msgid "PR"
+msgstr "PR"
+
+#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html
+#: search/advancedsearch.html status.html type/about/edit.html type/page/edit.html
+#: type/template/edit.html
+msgid "Title"
+msgstr "제목"
+
+#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html
+#: openlibrary/plugins/worksearch/code.py search/advancedsearch.html
+#: search/work_search_selected_facets.html status.html
+msgid "Author"
+msgstr "저자"
+
+#: status.html
+msgid "Assignee"
+msgstr "담당자"
+
+#: status.html
+msgid "Pinned Commit"
+msgstr "고정된 커밋"
+
+#: status.html
+msgid "Branch HEAD"
+msgstr "브랜치 HEAD"
+
+#: status.html
+msgid "Drift"
+msgstr "차이"
+
+#: status.html
+msgid "Enabled"
+msgstr "활성화됨"
+
+#: status.html
+msgid "up to date"
+msgstr "최신 상태"
+
+#: status.html
+msgid "unknown"
+msgstr "알 수 없음"
+
+#: status.html
+msgid "1 commit behind"
+msgstr "커밋 1개 뒤처짐"
+
+#: status.html
+#, python-format
+msgid "%(count)s commits behind"
+msgstr "커밋 %(count)s개 뒤처짐"
+
+#: admin/solr.html status.html
+msgid "Update"
+msgstr "업데이트"
+
+#: status.html
+msgid "Enable"
+msgstr "활성화"
+
+#: status.html
+msgid "Disable"
+msgstr "비활성화"
+
+#: lists/lists.html status.html type/list/edit.html type/series/edit.html
+msgid "Remove"
+msgstr "제거"
+
+#: status.html
+msgid "Selected PRs"
+msgstr "선택된 PR"
+
+#: status.html
+msgid "Refresh"
+msgstr "새로고침"
+
+#: status.html
+msgid "Deploy"
+msgstr "배포"
+
+#: status.html
+msgid "No PRs in testing set."
+msgstr "테스트 세트에 PR이 없습니다."
+
+#: status.html
+msgid "Last Build Result"
+msgstr "마지막 빌드 결과"
+
+#: status.html
+msgid "View PRs on GitHub"
+msgstr "GitHub에서 PR 보기"
+
+#: status.html
+msgid "Show changed files"
+msgstr "변경된 파일 보기"
+
+#: admin/inspect/store.html admin/people/index.html status.html type/author/edit.html
+#: type/language/view.html
+msgid "Name"
+msgstr "이름"
+
+#: status.html
+msgid "System information"
+msgstr "시스템 정보"
+
+#: status.html
+msgid "Features enabled"
+msgstr "활성화된 기능"
+
+#: subjects.html
+msgid "Edit tag for this subject"
+msgstr "이 주제의 태그 편집"
+
+#: subjects.html
+msgid "Create tag for this subject"
+msgstr "이 주제의 태그 만들기"
+
+#: subjects.html
+msgid "See all works"
+msgstr "모든 작품 보기"
+
+#: merge/authors.html publishers/view.html subjects.html type/author/view.html
+#, python-format
+msgid "%(count)d work"
+msgid_plural "%(count)d works"
+msgstr[0] "%(count)d 작품"
+
+#: subjects.html
+#, python-format
+msgid "Search for books with subject %(name)s."
+msgstr "%(name)s 주제의 책 검색"
+
+#: subjects.html
+msgid "Disambiguations"
+msgstr "동명이의/구분 항목"
+
+#: trending.html
+msgid "Now"
+msgstr "지금"
+
+#: admin/graphs.html admin/index.html my_books/check_ins/check_in_form.html
+#: my_books/check_ins/check_in_prompt.html trending.html
+msgid "Today"
+msgstr "오늘"
+
+#: admin/graphs.html trending.html
+msgid "This Week"
+msgstr "이번 주"
+
+#: admin/graphs.html stats/readinglog.html trending.html
+msgid "This Month"
+msgstr "이번 달"
+
+#: trending.html
+msgid "This Year"
+msgstr "올해"
+
+#: admin/index.html books/year_breadcrumb_select.html trending.html
+msgid "All Time"
+msgstr "전체 기간"
+
+#: home/index.html openlibrary/plugins/openlibrary/api.py trending.html
+msgid "Trending Books"
+msgstr "인기 상승 중인 책"
+
+#: trending.html
+msgid "See what readers from the community are adding to their bookshelves"
+msgstr "See what readers from the community are 추가ing to their 책helves"
+
+#: trending.html
+msgid "Earliest trending data is from October 2017"
+msgstr "가장 이른 인기 추세 데이터는 2017년 10월부터입니다"
+
+#: account/mybooks.html account/sidebar.html my_books/dropdown_content.html
+#: my_books/primary_action.html search/sort_options.html trending.html
+msgid "Want to Read"
+msgstr "읽고 싶어요"
+
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
+#: my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html
+#: trending.html
+msgid "Currently Reading"
+msgstr "읽는 중"
+
+#: LoanReadForm.html ReadButton.html admin/inspect/memcache.html
+#: book_providers/read_button.html books/edit/edition.html trending.html type/list/embed.html
+#: widget.html
+msgid "Read"
+msgstr "읽음"
+
+#: trending.html
+#, python-format
+msgid "Someone marked as %(shelf)s %(k_hours_ago)s"
+msgstr "누군가 %(k_hours_ago)s 전에 %(shelf)s로 표시했습니다"
+
+#: trending.html
+#, python-format
+msgid "Logged %(count)i times %(time_unit)s"
+msgstr "%(time_unit)s 동안 %(count)i회 기록됨"
+
+#: verify_human.html
+msgid "Human Verification"
+msgstr "사람 확인"
+
+#: verify_human.html
+msgid "Please verify you are human to continue."
+msgstr "계속하려면 사람임을 확인해 주세요."
+
+#: verify_human.html
+msgid "Verify you are human"
+msgstr "사람임을 확인"
+
+#: verify_human.html
+msgid "Verification failed. Please try again."
+msgstr "확인에 실패했습니다. 다시 시도해 주세요."
+
+#: verify_human.html
+msgid "Verifying..."
+msgstr "확인 중..."
+
+#: viewpage.html
+msgid "Revert to this revision?"
+msgstr "이 개정판으로 되돌리시겠습니까?"
+
+#: viewpage.html
+msgid "Revert to this revision"
+msgstr "이 개정판으로 되돌리기"
+
+#: widget.html
+#, python-format
+msgid "Read \"%(title)s\""
+msgstr "\"%(title)s\" 읽기"
+
+#: widget.html
+#, python-format
+msgid "Borrow \"%(title)s\""
+msgstr "\"%(title)s\" 대출"
+
+#: ReadButton.html books/edit/edition.html type/list/embed.html widget.html
+msgid "Borrow"
+msgstr "대출"
+
+#: widget.html
+#, python-format
+msgid "Join waitlist for \"%(title)s\""
+msgstr "\"%(title)s\" 대기자 명단에 추가"
+
+#: LoanStatus.html widget.html
+msgid "Join Waitlist"
+msgstr "대기자 명단에 추가"
+
+#: widget.html
+#, python-format
+msgid "Learn more about \"%(title)s\" at OpenLibrary"
+msgstr "OpenLibrary에서 \"%(title)s\" 자세히 알아보기"
+
+#: reading_goals/reading_goal_form.html widget.html
+msgid "Learn More"
+msgstr "자세히 알아보기"
+
+#: widget.html
+#, python-format
+msgid ""
+"on <a target=\"_blank\" rel=\"noopener noreferrer\" "
+"href=\"%(link)s\">openlibrary.org</a>"
+msgstr "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"%(link)s\">openlibrary.org</a>에서"
+
+#: work_search.html
+msgid "Search Books"
+msgstr "책 검색"
+
+#: work_search.html
+msgid "Keywords"
+msgstr "키워드"
+
+#: RecentChanges.html recentchanges/index.html work_search.html
+msgid "Everything"
+msgstr "전체"
+
+#: work_search.html
+msgid "Ebooks"
+msgstr "전자책"
+
+#: work_search.html
+msgid "This is only visible to super librarians."
+msgstr "이 내용은 슈퍼 사서에게만 보입니다."
+
+#: work_search.html
+msgid "Solr Editions"
+msgstr "Solr 판본"
+
+#: work_search.html
+msgid "The search engine returned an error."
+msgstr "검색 엔진에서 오류가 반환되었습니다."
+
+#: work_search.html
+msgid "Solr Debugging:"
+msgstr "Solr 디버깅:"
+
+#: work_search.html
+msgid "Full URL:"
+msgstr "전체 URL:"
+
+#: work_search.html
+#, python-format
+msgid "No <strong>%(path_id)s</strong> directly matched your search."
+msgstr "검색어와 직접 일치하는 <strong>%(path_id)s</strong>이(가) 없습니다."
+
+#: work_search.html
+msgid "Add a new book?"
+msgstr "새 책을 추가하시겠습니까?"
+
+#: search/authors.html search/lists.html search/subjects.html work_search.html
+msgid "Checking Search Inside matches"
+msgstr "본문 검색 일치 항목 확인 중"
+
+#: account/reading_log.html search/authors.html search/lists.html search/subjects.html
+#: work_search.html
+#, python-format
+msgid "%(count)s hit"
+msgid_plural "%(count)s hits"
+msgstr[0] "%(count)s개 일치"
+
+#: work_search.html
+#, python-format
+msgid "Searching solr took %(count)s seconds"
+msgstr "Solr 검색에 %(count)s초가 걸렸습니다"
+
+#: about/index.html
+msgid "The Open Library Team"
+msgstr "Open Library 팀"
+
+#: about/index.html
+msgid ""
+"Open Library is made possible because of a dedicated team of staff and over 100 "
+"volunteers from around the globe."
+msgstr "Open Library는 전 세계 직원들과 100명 이상의 자원봉사자로 이루어진 헌신적인 팀 덕분에 운영됩니다."
+
+#: about/index.html
+msgid "Want to join us?"
+msgstr "함께하고 싶으신가요?"
+
+#: about/index.html
+msgid "Role:"
+msgstr "역할:"
+
+#: about/index.html lib/nav_head.html type/tag/index.html
+msgid "All"
+msgstr "전체"
+
+#: about/index.html
+msgid "Staff"
+msgstr "스태프"
+
+#: about/index.html
+msgid "Fellows"
+msgstr "펠로우"
+
+#: about/index.html
+msgid "Volunteers"
+msgstr "자원봉사자"
+
+#: about/index.html
+msgid "Department:"
+msgstr "부서:"
+
+#: about/index.html
+msgid "Communications"
+msgstr "커뮤니케이션"
+
+#: about/index.html
+msgid "Design"
+msgstr "디자인"
+
+#: about/index.html
+msgid "Engineering"
+msgstr "엔지니어링"
+
+#: about/index.html
+msgid "Librarianship"
+msgstr "사서 업무"
+
+#: about/index.html
+msgid ""
+"If you volunteer with Open Library and would like to be listed as part of the team, "
+"then complete the <a href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">Open Library team "
+"information form</a>."
+msgstr ""
+"If you volunteer with Open Library and would like to be 목록ed as part of the team, then "
+"complete the <a href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">Open Library team "
+"information form</a>."
+
+#: account/create.html openlibrary/plugins/upstream/forms.py
+msgid "Must be a valid email address"
+msgstr "유효한 이메일 주소여야 합니다"
+
+#: account/create.html openlibrary/plugins/upstream/forms.py
+msgid "Must be between 3 and 20 characters"
+msgstr "3자 이상 20자 이하여야 합니다"
+
+#: account/create.html
+msgid "Username may only contain numbers, letters, - or _"
+msgstr "사용자 이름에는 숫자, 문자, - 또는 _만 사용할 수 있습니다"
+
+#: account/create.html
+msgid "A qualifying program must be selected"
+msgstr "자격 프로그램을 선택해야 합니다"
+
+#: account/create.html
+msgid "Sign Up to Open Library"
+msgstr "Open Library 가입"
+
+#: account/create.html lib/header_dropdown.html lib/nav_head.html
+msgid "Sign Up"
+msgstr "가입"
+
+#: account/create.html
+msgid ""
+"Get your free Open Library card and borrow digital books from the nonprofit Internet "
+"Archive"
+msgstr "Get your free Open Library card and 대출 digital 책 from the nonprofit Internet Archive"
+
+#: account/create.html type/author/view.html
+msgid "Success!"
+msgstr "성공!"
+
+#: account/create.html
+msgid "Your URL"
+msgstr "내 URL"
+
+#: account/create.html
+msgid "screenname"
+msgstr "화면 이름"
+
+#: account/create.html
+msgid ""
+"I want to receive news, announcements, and resources from the <a "
+"href=\"https://archive.org/\">Internet Archive</a>, the non-profit that runs Open "
+"Library."
+msgstr ""
+"Open Library를 운영하는 비영리 단체 <a href=\"https://archive.org/\">Internet Archive</a>의 소식, "
+"공지, 자료를 받고 싶습니다."
+
+#: account/create.html
+msgid ""
+"I want to apply* for <a href=\"https://help.archive.org/help/program-overview/\" "
+"target=\"_blank\" rel=\"noopener noreferrer\">special print disability access</a> "
+"through a qualifying program."
+msgstr ""
+"자격 프로그램을 통해 <a href=\"https://help.archive.org/help/program-overview/\" "
+"target=\"_blank\" rel=\"noopener noreferrer\">인쇄물 이용 장애 특별 접근</a>을 신청*하고 싶습니다."
+
+#: account/create.html
+msgid "Select qualifying program"
+msgstr "자격 프로그램 선택"
+
+#: account/create.html
+msgid ""
+"* Please use the email address associated with this qualifying program. You will "
+"receive an email after activation with next steps."
+msgstr ""
+"* 다음 use the 이메일 추가ress associated with this qualifying program. You will receive an "
+"이메일 after activation with next steps."
+
+#: account/create.html
+msgid "Sign Up with Email"
+msgstr "이메일로 가입"
+
+#: account/create.html
+msgid ""
+"By signing up, you agree to the Internet Archive's <a class=\"ol-signup-form__link\" "
+"href=\"//archive.org/about/terms.php\" target=\"_blank\" rel=\"noopener "
+"noreferrer\">Terms of Service</a>."
+msgstr ""
+"가입하면 Internet Archive의 <a class=\"ol-signup-form__link\" "
+"href=\"//archive.org/about/terms.php\" target=\"_blank\" rel=\"noopener "
+"noreferrer\">서비스 약관</a>에 동의하게 됩니다."
+
+#: account/create.html
+msgid "Already have an account? <a href=\"/account/login\">Log in</a>"
+msgstr "Already have an 계정? <a href=\"/계정/login\">Log in</a>"
+
+#: account/delete.html
+msgid "Delete Account"
+msgstr "계정 삭제"
+
+#: account/delete.html
+msgid "Sorry, this functionality is not yet implemented."
+msgstr "죄송합니다. 이 기능은 아직 구현되지 않았습니다."
+
+#: account/follows.html
+msgid "There is nothing to see here yet."
+msgstr "아직 볼 내용이 없습니다."
+
+#: account/import.html
+msgid "Import from Goodreads"
+msgstr "Goodreads에서 가져오기"
+
+#: account/import.html
+msgid ""
+"For instructions on exporting data refer to: <a "
+"href=\"https://www.goodreads.com/review/import\">Goodreads Import/Export</a>"
+msgstr ""
+"For instructions on exporting data refer to: <a "
+"href=\"https://www.goodreads.com/리뷰/import\">Goodreads Import/Export</a>"
+
+#: account/import.html
+msgid "File size limit 10MB and .csv file type only"
+msgstr "파일 크기는 10MB 이하, .csv 파일만 가능"
+
+#: account/import.html
+msgid "Load Books"
+msgstr "책 불러오기"
+
+#: account/import.html
+msgid "Export your Reading Log"
+msgstr "독서 기록 내보내기"
+
+#: account/import.html
+msgid "Download a copy of your reading log."
+msgstr "독서 기록 사본을 다운로드합니다."
+
+#: account/import.html
+msgid "What is a reading log?"
+msgstr "독서 기록이란 무엇인가요?"
+
+#: account/import.html
+msgid "Download (.csv format)"
+msgstr "다운로드(.csv 형식)"
+
+#: account/import.html
+msgid "Export your book notes"
+msgstr "책 노트 내보내기"
+
+#: account/import.html
+msgid "Download a copy of your book notes."
+msgstr "책 노트 사본을 다운로드합니다."
+
+#: account/import.html
+msgid "What are book notes?"
+msgstr "책 노트란 무엇인가요?"
+
+#: account/import.html
+msgid "Export your reviews"
+msgstr "리뷰 내보내기"
+
+#: account/import.html
+msgid "Download a copy of your review tags."
+msgstr "리뷰 태그 사본을 다운로드합니다."
+
+#: account/import.html
+msgid "What are review tags?"
+msgstr "리뷰 태그란 무엇인가요?"
+
+#: account/import.html
+msgid "Export your list overview"
+msgstr "목록 개요 내보내기"
+
+#: account/import.html
+msgid "Download a summary of your lists and their contents."
+msgstr "목록과 그 내용의 요약을 다운로드합니다."
+
+#: account/import.html
+msgid "What are lists?"
+msgstr "목록이란 무엇인가요?"
+
+#: account/import.html
+msgid "Export your star ratings"
+msgstr "별점 내보내기"
+
+#: account/import.html
+msgid "Download a copy of your star ratings."
+msgstr "별점 사본을 다운로드합니다."
+
+#: account/import.html
+msgid "What are star ratings?"
+msgstr "별점이란 무엇인가요?"
+
+#: account/import.html
+msgid "Importing..."
+msgstr "가져오는 중..."
+
+#: account/import.html
+msgid "Reason"
+msgstr "이유"
+
+#: account/import.html
+msgid "No ISBN"
+msgstr "ISBN 없음"
+
+#: account/loan_history.html
+msgid "No loans found in your borrow history."
+msgstr "대출 기록에서 대출을 찾을 수 없습니다."
+
+#: account/loan_history.html
+msgid "<a href=\"/search\">Search for a book</a> to borrow."
+msgstr "<a href=\"/검색\">검색 for a 책</a> 대출하려면."
+
+#: account/loans.html
+msgid "You've not checked out any books at this moment."
+msgstr "현재 대출 중인 책이 없습니다."
+
+#: account/loans.html
+#, python-format
+msgid "%(count)d Current Loan"
+msgid_plural "%(count)d Current Loans"
+msgstr[0] "현재 대출 %(count)d건"
+
+#: account/loans.html admin/loans_table.html
+msgid "Loan Expires"
+msgstr "대출 만료"
+
+#: account/loans.html
+msgid "Loan actions"
+msgstr "대출 작업"
+
+#: account/loans.html
+#, python-format
+msgid "There is %(count)d person waiting for this book."
+msgid_plural "There are %(count)d people waiting for this book."
+msgstr[0] "이 책을 기다리는 사람이 %(count)d명 있습니다."
+
+#: ManageLoansButtons.html account/loans.html
+msgid "Not yet downloaded."
+msgstr "아직 다운로드하지 않음."
+
+#: ManageLoansButtons.html account/loans.html
+msgid "Download Now"
+msgstr "지금 다운로드"
+
+#: account/loans.html
+msgid "Return via<br/>Adobe Digital Editions"
+msgstr "반납 via<br/>Adobe Digital 편집ions"
+
+#: account/loans.html
+msgid "Books You're Waiting For"
+msgstr "대기 중인 책"
+
+#: account/loans.html
+msgid "You are not waiting for any books at this moment."
+msgstr "현재 대기 중인 책이 없습니다."
+
+#: account/loans.html
+msgid "Leave the Waiting List"
+msgstr "대기자 명단에서 나가기"
+
+#: account/loans.html
+msgid "Are you sure you want to leave the waiting list of<br/><strong>TITLE</strong>?"
+msgstr "정말 leave the 대기자 명단 of<br/><strong>TITLE</strong>?"
+
+#: ProlificAuthors.html account/loans.html authors/index.html lists/list_follow.html
+#: lists/showcase.html publishers/view.html search/authors.html search/publishers.html
+#: search/subjects.html
+#, python-format
+msgid "%(count)d book"
+msgid_plural "%(count)d books"
+msgstr[0] "%(count)d권"
+
+#: RecentChangesAdmin.html account/loans.html admin/loans_table.html
+msgid "Actions"
+msgstr "작업"
+
+#: account/loans.html
+#, python-format
+msgid "Waiting for 1 day"
+msgid_plural "Waiting for %(count)d days"
+msgstr[0] "%(count)d일째 대기 중"
+
+#: account/loans.html
+msgid "You are the next person to receive this book."
+msgstr "당신은 the next person to receive 이 책."
+
+#: ManageWaitlistButton.html account/loans.html
+#, python-format
+msgid "There is one person ahead of you in the waiting list."
+msgid_plural "There are %(count)d people ahead of you in the waiting list."
+msgstr[0] "대기자 명단에서 앞에 %(count)d명이 있습니다."
+
+#: ManageWaitlistButton.html account/loans.html
+msgid "You have less than an hour to borrow it."
+msgstr "당신은 less than an hour 대출하려면 it."
+
+#: account/loans.html
+#, python-format
+msgid "You have one more hour to borrow it."
+msgid_plural "You have %(hours)d more hours to borrow it."
+msgstr[0] "대출할 수 있는 시간이 %(hours)d시간 남았습니다."
+
+#: ManageWaitlistButton.html account/loans.html
+msgid "Borrow Now"
+msgstr "지금 대출"
+
+#: ManageWaitlistButton.html account/loans.html
+msgid "Leave the waiting list?"
+msgstr "대기자 명단에서 나가시겠습니까?"
+
+#: account/loans.html
+msgid ""
+"Looking for a book to borrow?  Check out our staff picks, or search for a book on a "
+"specific subject:"
+msgstr "Looking for a 책 대출하려면?  Check out our staff picks, or 검색 for a 책 on a specific 주제:"
+
+#: account/loans.html home/index.html
+msgid "Books We Love"
+msgstr "우리가 사랑하는 책"
+
+#: account/loans.html
+msgid "Or, check out our <a href=\"/collections\">special collections</a>."
+msgstr "또는 <a href=\"/collections\">특별 컬렉션</a>을 확인해 보세요."
+
+#: account/mybooks.html
+msgid "No books are on this shelf"
+msgstr "이 서가에는 책이 없습니다"
+
+#: account/mybooks.html account/sidebar.html
+msgid "My Loans"
+msgstr "내 대출"
+
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
+#: my_books/dropdown_content.html my_books/primary_action.html
+#: openlibrary/plugins/upstream/mybooks.py search/sort_options.html
+msgid "Already Read"
+msgstr "이미 읽음"
+
+#: account/mybooks.html type/user/view.html
+msgid "This reader has chosen to make their Reading Log private."
+msgstr "This reader has chosen to make their 독서 기록 비공개."
+
+#: account/mybooks.html
+#, python-format
+msgid "%(year_span)s reading goal"
+msgstr "%(year_span)s 독서 목표"
+
+#: account/mybooks.html
+msgid "View All Lists"
+msgstr "모든 목록 보기"
+
+#: account/mybooks.html
+msgid "My Stats"
+msgstr "내 통계"
+
+#: account/mybooks.html account/sidebar.html account/topmenu.html
+msgid "My Reading Stats"
+msgstr "내 독서 통계"
+
+#: account/mybooks.html account/sidebar.html books/mybooks_breadcrumb_select.html
+#: openlibrary/plugins/upstream/account.py
+msgid "Loan History"
+msgstr "대출 기록"
+
+#: account/mybooks.html account/sidebar.html
+msgid "My Notes"
+msgstr "내 노트"
+
+#: account/mybooks.html account/sidebar.html
+msgid "My Reviews"
+msgstr "내 리뷰"
+
+#: account/mybooks.html account/sidebar.html
+msgid "Import & Export Options"
+msgstr "가져오기 및 내보내기 옵션"
+
+#: account/not_verified.html account/verify/failed.html
+msgid "Oops!"
+msgstr "이런!"
+
+#: account/not_verified.html
+msgid "The email address you signed up with needs to be verified."
+msgstr "The 이메일 추가ress you signed up with needs to be verified."
+
+#: account/not_verified.html
+#, python-format
+msgid ""
+"When you created your account, we sent an email to %(email)s that contained a link for "
+"you to verify your email address. We need you to click that link, please."
+msgstr ""
+"When you 생성d your 계정, we sent an 이메일 to %(email)s that contained a link for you to "
+"verify your 이메일 추가ress. We need you to click that link, please."
+
+#: account/not_verified.html
+msgid "If you can't find the email, just hit this button to send a fresh one:"
+msgstr "If you can't find the 이메일, just hit this button to send a fresh one:"
+
+#: account/not_verified.html account/verify/failed.html
+msgid "Resend the verification email"
+msgstr "확인 이메일 다시 보내기"
+
+#: account/not_verified.html account/verify/failed.html
+msgid "Thanks!"
+msgstr "감사합니다!"
+
+#: BookByline.html FulltextSearchSuggestionItem.html SearchResultsWork.html
+#: account/notes.html account/observations.html
+msgid "Unknown author"
+msgstr "알 수 없는 저자"
+
+#: account/notes.html
+msgid "My notes for an edition of "
+msgstr "다음 판본에 대한 내 노트: "
+
+#: account/notes.html
+msgid "Title Missing"
+msgstr "제목 없음"
+
+#: account/notes.html lists/export_as_html.html type/work/editions.html
+msgid "Publish date unknown"
+msgstr "출판일 알 수 없음"
+
+#: account/notes.html books/edition-sort.html lists/export_as_html.html
+#: type/work/editions.html
+msgid "Publisher unknown"
+msgstr "출판사 알 수 없음"
+
+#: account/notes.html
+#, python-format
+msgid "in %(language)s"
+msgstr "%(language)s로"
+
+#: NotesModal.html account/notes.html
+msgid "Delete Note"
+msgstr "노트 삭제"
+
+#: NotesModal.html account/notes.html
+msgid "Save Note"
+msgstr "노트 저장"
+
+#: account/notes.html
+msgid "No notes found."
+msgstr "노트를 찾을 수 없습니다."
+
+#: account/notifications.html
+msgid "Notifications from Open Library"
+msgstr "Open Library 알림"
+
+#: account/notifications.html
+msgid "Notifications"
+msgstr "알림"
+
+#: account/notifications.html
+msgid ""
+"Notifications are connected to Lists at the moment. If one of the books on your list "
+"gets edited, or a new book comes into the catalog, we'll let you know, if you want."
+msgstr ""
+"Notifications are connected to Lists at the moment. If one of the 책 on your 목록 gets "
+"편집ed, or a new 책 comes into the catalog, we'll let you know, if you want."
+
+#: account/notifications.html
+msgid "Would you like to receive very occasional emails from Open Library?"
+msgstr "하시겠습니까 receive very occasional 이메일s from Open Library?"
+
+#: account/notifications.html
+msgid "No, thank you"
+msgstr "아니요, 괜찮습니다"
+
+#: account/notifications.html
+msgid "Yes! Please!"
+msgstr "네! 부탁합니다!"
+
+#: EditButtons.html account/notifications.html account/privacy.html admin/block.html
+#: admin/spamwords.html covers/manage.html design/button.html
+msgid "Save"
+msgstr "저장"
+
+#: EditionNavBar.html account/observations.html books/mybooks_breadcrumb_select.html
+#: openlibrary/plugins/upstream/mybooks.py
+msgid "Reviews"
+msgstr "리뷰"
+
+#: account/observations.html admin/inspect/memcache.html design/button.html
+#: design/popover.html
+msgid "Delete"
+msgstr "삭제"
+
+#: account/observations.html
+msgid "Update Reviews"
+msgstr "리뷰 업데이트"
+
+#: account/observations.html
+msgid "No observations found."
+msgstr "관찰 항목을 찾을 수 없습니다."
+
+#: account/privacy.html
+msgid "Your Privacy on Open Library"
+msgstr "Open Library에서의 개인정보"
+
+#: account/privacy.html
+msgid "Privacy & Content Moderation Settings"
+msgstr "개인정보 및 콘텐츠 관리 설정"
+
+#: account/privacy.html
+msgid "Would you like to make your <a href=\"/account/books\">Reading Log</a> public?"
+msgstr "하시겠습니까 make your <a href=\"/계정/책\">독서 기록</a> 공개?"
+
+#: account/privacy.html
+msgid ""
+"This will enable others to see what books you want to read, are reading, or have "
+"already read. Patrons with reading logs set to public may be followed."
+msgstr ""
+"This will enable others to see what 책 you want to read, are reading, or have already "
+"read. Patrons with 독서 기록s set to 공개 may be followed."
+
+#: account/privacy.html admin/people/view.html
+msgid "Yes"
+msgstr "예"
+
+#: account/privacy.html admin/people/view.html books/edit/edition.html
+msgid "No"
+msgstr "아니요"
+
+#: account/privacy.html
+msgid "Enable Safe Mode?"
+msgstr "안전 모드를 활성화할까요?"
+
+#: account/privacy.html
+msgid "Safe Mode blurs book covers that have been flagged as having sensitive imagery."
+msgstr "Safe Mode blurs 책 covers that 되었습니다 flagged as having sensitive imagery."
+
+#: account/reading_log.html
+#, python-format
+msgid "Books %(username)s is reading"
+msgstr "%(username)s님이 읽고 있는 책"
+
+#: account/reading_log.html
+#, python-format
+msgid ""
+"%(username)s is reading %(total)d books. Join %(username)s on OpenLibrary.org and tell "
+"the world what you're reading."
+msgstr ""
+"%(username)s is reading %(total)d 책. Join %(username)s on OpenLibrary.org and tell the "
+"world what you're reading."
+
+#: account/reading_log.html
+#, python-format
+msgid "Books %(username)s wants to read"
+msgstr "%(username)s님이 읽고 싶어 하는 책"
+
+#: account/reading_log.html
+#, python-format
+msgid ""
+"%(username)s wants to read %(total)d books. Join %(username)s on OpenLibrary.org and "
+"share the books that you'll soon be reading!"
+msgstr ""
+"%(username)s wants to read %(total)d 책. Join %(username)s on OpenLibrary.org and share "
+"the 책 that you'll soon be reading!"
+
+#: account/reading_log.html
+#, python-format
+msgid "Books %(username)s has read in %(year)d"
+msgstr "%(username)s님이 %(year)d년에 읽은 책"
+
+#: account/reading_log.html
+#, python-format
+msgid ""
+"%(username)s has read %(total)d books in %(year)d. Join %(username)s on OpenLibrary.org"
+" and tell the world about the books that you care about."
+msgstr ""
+"%(username)s has read %(total)d 책 in %(year)d. Join %(username)s on OpenLibrary.org and"
+" tell the world about the 책 that you care about."
+
+#: account/reading_log.html
+#, python-format
+msgid "Books %(username)s has read"
+msgstr "%(username)s님이 읽은 책"
+
+#: account/reading_log.html
+#, python-format
+msgid ""
+"%(username)s has read %(total)d books. Join %(username)s on OpenLibrary.org and tell "
+"the world about the books that you care about."
+msgstr ""
+"%(username)s has read %(total)d 책. Join %(username)s on OpenLibrary.org and tell the "
+"world about the 책 that you care about."
+
+#: account/reading_log.html
+#, python-format
+msgid "Books in %(username)s feed"
+msgstr "%(username)s님의 피드에 있는 책"
+
+#: account/reading_log.html
+#, python-format
+msgid "Books added by people %(username)s follows"
+msgstr "Books 추가ed by people %(username)s follows"
+
+#: account/reading_log.html
+msgid "Search your reading log"
+msgstr "your reading log 검색"
+
+#: account/reading_log.html type/author/view.html
+#, python-format
+msgid "— Show <a href=\"%(url)s\">only ebooks</a>?"
+msgstr "— Show <a href=\"%(url)s\">only e책</a>?"
+
+#: account/reading_log.html
+#, python-format
+msgid "— Show <a href=\"%(url)s\">everything</a> in this shelf?"
+msgstr "— 이 서가의 <a href=\"%(url)s\">모든 항목</a>을 표시할까요?"
+
+#: account/reading_log.html
+msgid "No results found in this shelf"
+msgstr "이 서가에서 결과를 찾을 수 없습니다"
+
+#: account/reading_log.html
+#, python-format
+msgid "Search all of Open Library for \"%s\"?"
+msgstr "all of Open Library for \"%s\"? 검색"
+
+#: account/reading_log.html
+msgid "You haven't marked any books as read for this year."
+msgstr "당신은n't marked any 책 as read for this year."
+
+#: account/reading_log.html
+msgid "You haven't added any books to this shelf yet."
+msgstr "당신은n't 추가ed any 책 to this shelf yet."
+
+#: account/reading_log.html
+msgid ""
+"<a href=\"/search\">Search for a book</a> to add to your reading log. <a "
+"href=\"/help/faq/reading-log\">Learn more</a> about the reading log."
+msgstr ""
+"<a href=\"/검색\">검색 for a 책</a> 추가하려면 to your 독서 기록. <a href=\"/help/faq/reading-"
+"log\">Learn more</a> about the 독서 기록."
+
+#: account/reading_log.html
+msgid ""
+"There are no recent books in your feed. When you follow public accounts, their book "
+"updates will appear here."
+msgstr ""
+"다음이 있습니다: no recent 책 in your feed. When you follow 공개 계정s, their 책 updates will appear"
+" here."
+
+#: account/readinglog_shelf_name.html
+msgid "Want To Read"
+msgstr "읽고 싶어요"
+
+#: account/readinglog_stats.html
+#, python-format
+msgid "My %(shelf_name)s Stats"
+msgstr "내 %(shelf_name)s 통계"
+
+#: account/readinglog_stats.html home/loans.html lib/nav_head.html
+msgid "My Books"
+msgstr "내 책"
+
+#: account/readinglog_stats.html
+#, python-format
+msgid ""
+"Displaying stats about <strong>%(works_count)d</strong> books. Note all charts show "
+"only the top 20 bars. Note reading log stats are private."
+msgstr ""
+"Displaying stats about <strong>%(works_count)d</strong> 책. Note all charts show only "
+"the top 20 bars. Note 독서 기록 stats are 비공개."
+
+#: account/readinglog_stats.html
+msgid "Author Stats"
+msgstr "저자 통계"
+
+#: account/readinglog_stats.html
+msgid "Most Read Authors"
+msgstr "가장 많이 읽은 저자"
+
+#: account/readinglog_stats.html
+msgid "Works by Author Sex"
+msgstr "저자 성별별 작품"
+
+#: account/readinglog_stats.html
+msgid "Works by Author Country of Citizenship"
+msgstr "저자 시민권 국가별 작품"
+
+#: account/readinglog_stats.html
+msgid "Works by Author Country of Birth"
+msgstr "저자 출생 국가별 작품"
+
+#: account/readinglog_stats.html
+msgid ""
+"Demographic statistics powered by <a href=\"https://www.wikidata.org/\">Wikidata</a>. "
+"Here's a <a id=\"wd-query-sample\" href=\"\">sample</a> of the query used. <br "
+"/>Improve these stats by adding the Wikidata author identifier following <a "
+"href=\"https://openlibrary.org/help/faq/editing.en#author-identifiers-purpose\">these "
+"instructions</a>."
+msgstr ""
+"Demographic statistics powered by <a href=\"https://www.wikidata.org/\">Wikidata</a>. "
+"Here's a <a id=\"wd-query-sample\" href=\"\">sample</a> of the query used. <br "
+"/>Improve these stats by 추가ing the Wikidata 저자 identifier following <a "
+"href=\"https://openlibrary.org/help/faq/편집ing.en#저자-identifiers-purpose\">these "
+"instructions</a>."
+
+#: account/readinglog_stats.html
+msgid "Work Stats"
+msgstr "작품 통계"
+
+#: account/readinglog_stats.html
+msgid "Works by Subject"
+msgstr "주제별 작품"
+
+#: account/readinglog_stats.html
+msgid "Works by People"
+msgstr "인물별 작품"
+
+#: account/readinglog_stats.html
+msgid "Works by Places"
+msgstr "장소별 작품"
+
+#: account/readinglog_stats.html
+msgid "Works by Time Period"
+msgstr "시대별 작품"
+
+#: account/readinglog_stats.html
+msgid "Matching works"
+msgstr "일치하는 작품"
+
+#: account/readinglog_stats.html
+msgid "Click on a bar to see matching works"
+msgstr "Click on a bar to see matching 작품"
+
+#: account/sidebar.html books/mybooks_breadcrumb_select.html
+#: openlibrary/plugins/upstream/mybooks.py
+msgid "My Feed"
+msgstr "내 피드"
+
+#: account/sidebar.html
+#, python-format
+msgid "%(year)d Reading Goal"
+msgstr "%(year)d년 독서 목표"
+
+#: account/sidebar.html
+#, python-format
+msgid "Set %(year_span)s reading goal"
+msgstr "%(year_span)s 독서 목표 설정"
+
+#: account/sidebar.html search/sort_options.html type/user/view.html
+msgid "Reading Log"
+msgstr "독서 기록"
+
+#: account/sidebar.html
+msgid "My lists"
+msgstr "내 목록"
+
+#: EditionNavBar.html SearchNavigation.html account/sidebar.html lib/nav_head.html
+#: lists/home.html recentchanges/index.html type/edition/view.html type/list/embed.html
+#: type/user/view.html type/work/view.html
+msgid "Lists"
+msgstr "목록"
+
+#: account/sidebar.html type/user/view.html
+msgid "See All"
+msgstr "모두 보기"
+
+#: account/sidebar.html type/list/edit.html type/series/edit.html
+msgid "Create a list"
+msgstr "목록 만들기"
+
+#: account/sidebar.html
+msgid "Untitled list"
+msgstr "제목 없는 목록"
+
+#: account/topmenu.html
+msgid "Import & Export"
+msgstr "가져오기 및 내보내기"
+
+#: account/topmenu.html
+#, python-format
+msgid "Privacy settings: %(public)s"
+msgstr "개인정보 설정: %(public)s"
+
+#: account/verify.html
+msgid "Verification email sent"
+msgstr "확인 이메일을 보냈습니다"
+
+#: account/password/reset_success.html account/verify.html account/verify/activated.html
+#: account/verify/success.html
+#, python-format
+msgid "Hi, %(user)s"
+msgstr "안녕하세요, %(user)s님"
+
+#: account/verify.html
+#, python-format
+msgid ""
+"We’ve sent an email to %(email)s containing a link to verify your account. Click/tap on"
+" the link to finish creating your Internet Archive account."
+msgstr ""
+"We’ve sent an 이메일 to %(email)s containing a link to verify your 계정. Click/tap on the "
+"link to finish creating your Internet Archive 계정."
+
+#: account/verify.html
+msgid "Then, come back to Open Library and find some great books!"
+msgstr "그런 다음 Open Library로 돌아와 좋은 책을 찾아보세요!"
+
+#: account/view.html
+msgid "Yearly Reading Goal"
+msgstr "연간 독서 목표"
+
+#: account/view.html books/mybooks_breadcrumb_select.html
+msgid "Following"
+msgstr "팔로잉"
+
+#: account/view.html books/mybooks_breadcrumb_select.html
+msgid "Followers"
+msgstr "팔로워"
+
+#: account/view.html design/popover.html type/edition/modal_links.html
+#: type/edition/title_and_author.html
+msgid "Share"
+msgstr "공유"
+
+#: account/view.html
+msgid "Your book notes are private and cannot be viewed by other patrons."
+msgstr "Your 책 노트 are 비공개 and 할 수 없습니다 viewed by other patrons."
+
+#: account/view.html
+msgid "Your book reviews will be shared anonymously with other patrons."
+msgstr "Your 책 리뷰 됩니다 shared anonymously with other patrons."
+
+#: account/yrg_banner.html
+#, python-format
+msgid "Set your %(year)s Yearly Reading Goal:"
+msgstr "Set your %(year)s 연간 독서 목표:"
+
+#: account/yrg_banner.html
+msgid "Set my goal"
+msgstr "내 목표 설정"
+
+#: account/email/forgot-ia.html
+msgid "Forgot Your Internet Archive Email?"
+msgstr "Internet Archive 이메일을 잊으셨나요?"
+
+#: account/email/forgot-ia.html
+msgid ""
+"Please enter your Open Library email and password, and we’ll retrieve your Archive.org "
+"email."
+msgstr "다음 enter your Open Library 이메일 and 비밀번호, and we’ll retrieve your Archive.org 이메일."
+
+#: account/email/forgot-ia.html
+msgid "Your email is:"
+msgstr "내 이메일:"
+
+#: account/email/forgot-ia.html
+msgid "Return to Log In?"
+msgstr "로그인으로 돌아가시겠습니까?"
+
+#: account/email/forgot-ia.html
+msgid "Open Library Email"
+msgstr "Open Library 이메일"
+
+#: account/email/forgot-ia.html
+msgid "Retrieve Archive.org Email"
+msgstr "Archive.org 이메일 찾기"
+
+#: account/email/forgot-ia.html account/password/forgot.html
+msgid "Forgot your Archive.org Password?"
+msgstr "Archive.org 비밀번호를 잊으셨나요?"
+
+#: account/password/forgot.html account/password/sent.html
+msgid "Username/Password Reminder"
+msgstr "사용자 이름/비밀번호 알림"
+
+#: account/password/forgot.html
+msgid "Click here."
+msgstr "여기를 클릭하세요."
+
+#: account/password/forgot.html
+msgid "Send It"
+msgstr "보내기"
+
+#: account/password/reset.html admin/people/view.html
+msgid "Reset Password"
+msgstr "비밀번호 재설정"
+
+#: account/password/reset.html
+msgid "Please enter a new password for your Open Library account."
+msgstr "다음 enter a new 비밀번호 for your Open Library 계정."
+
+#: account/password/reset.html design/button.html
+msgid "Reset"
+msgstr "재설정"
+
+#: account/password/reset_success.html
+msgid "Password Reset Successful"
+msgstr "비밀번호 재설정 성공"
+
+#: account/password/reset_success.html
+msgid ""
+"Your password has been updated. Please <a href='/account/login?redirect=/'>log in to "
+"continue</a>."
+msgstr "Your 비밀번호 되었습니다 updated. 다음 <a href='/계정/login?redirect=/'>log in 계속하려면</a>."
+
+#: account/password/sent.html
+msgid "Done."
+msgstr "완료."
+
+#: account/password/sent.html
+#, python-format
+msgid ""
+"We've sent an email to %(email)s with a reminder of your username and instructions to "
+"help you reset your Open Library password. Please check your inbox for a note from us."
+msgstr ""
+"We've sent an 이메일 to %(email)s with a reminder of your username and instructions to "
+"help you reset your Open Library 비밀번호. 다음 check your inbox for a note from us."
+
+#: account/security/check_email.html
+msgid "Account Security Check — 2026-04-28T18Z"
+msgstr "Account Security Check — 2026-04-28T18Z"
+
+#: account/security/check_email.html
+msgid "Account Security Check"
+msgstr "계정 보안 확인"
+
+#: account/security/check_email.html
+msgid "Incident date: 2026-04-28T18Z"
+msgstr "사건 날짜: 2026-04-28T18Z"
+
+#: account/security/check_email.html
+msgid "Check whether your Open Library account was in a set of accounts requiring attention."
+msgstr "Check whether your Open Library 계정 was in a set of 계정s requiring attention."
+
+#: account/security/check_email.html
+msgid ""
+"Please <a href=\"/account/login?redirect=/account/security/2026-04-28T18\">log in</a> "
+"to check whether your account was affected."
+msgstr ""
+"다음 <a href=\"/계정/login?redirect=/계정/security/2026-04-28T18\">log in</a> to check "
+"whether your 계정 was affected."
+
+#: account/security/check_email.html
+msgid "Your account is in the affected set."
+msgstr "Your 계정 is in the affected set."
+
+#: account/security/check_email.html
+msgid ""
+"Your account was found in our affected accounts list. Please review any recent "
+"communications from Open Library and consider updating your password."
+msgstr ""
+"Your 계정 was found in our affected 계정s 목록. 다음 리뷰 any recent communications from Open "
+"Library and consider updating your 비밀번호."
+
+#: account/security/check_email.html
+msgid "Your account is <em>not</em> in the affected set."
+msgstr "Your 계정 is <em>not</em> in the affected set."
+
+#: account/security/check_email.html
+msgid ""
+"Your account was <em>not</em> found in the affected accounts list. No action is "
+"required."
+msgstr "Your 계정 was <em>not</em> found in the affected 계정s 목록. No action is required."
+
+#: account/verify/activated.html
+msgid "Account already activated"
+msgstr "이미 활성화된 계정"
+
+#: account/verify/activated.html
+#, python-format
+msgid "Your account has been activated already. Please <a href=\"%s\">log in to continue</a>."
+msgstr "Your 계정 되었습니다 activated already. 다음 <a href=\"%s\">log in 계속하려면</a>."
+
+#: account/verify/failed.html
+msgid "Email Verification Failed"
+msgstr "이메일 확인 실패"
+
+#: account/verify/failed.html
+msgid ""
+"Your email address couldn't be verified. Your verification link seems invalid or "
+"expired."
+msgstr "Your 이메일 추가ress 확인할 수 없습니다. Your verification link seems invalid or expired."
+
+#: account/verify/failed.html
+msgid "Fill your email and hit this button to resend a fresh verification email:"
+msgstr "Fill your 이메일 and hit this button to resend a fresh verification 이메일:"
+
+#: account/verify/failed.html
+msgid "Enter your email address here"
+msgstr "여기에 이메일 주소 입력"
+
+#: account/verify/failed.html
+msgid "No user registered with this email address."
+msgstr "이 이메일 주소로 등록된 사용자가 없습니다."
+
+#: account/verify/success.html
+msgid "Email Verification Successful"
+msgstr "이메일 확인 성공"
+
+#: account/verify/success.html
+#, python-format
+msgid "Yay! Your email address has been verified. Please <a href='%s'>log in to continue</a>."
+msgstr "Yay! Your 이메일 추가ress 되었습니다 verified. 다음 <a href='%s'>log in 계속하려면</a>."
+
+#: admin/attach_debugger.html
+msgid "Attach Debugger"
+msgstr "디버거 연결"
+
+#: admin/attach_debugger.html
+#, python-format
+msgid "Attach Debugger on Python %(version_number)s"
+msgstr "Python %(version_number)s에 디버거 연결"
+
+#: admin/attach_debugger.html
+msgid "Start a debugger on port 3000."
+msgstr "3000번 포트에서 디버거를 시작합니다."
+
+#: admin/attach_debugger.html
+msgid "Waiting for debugger to attach..."
+msgstr "디버거 연결 대기 중..."
+
+#: admin/attach_debugger.html
+msgid "Start"
+msgstr "시작"
+
+#: admin/block.html
+msgid "Block IP address"
+msgstr "IP 주소 차단"
+
+#: admin/block.html
+#, python-format
+msgid ""
+"IP address %(address)s has been added to the textarea. Please click Save to block that "
+"IP."
+msgstr "IP 추가ress %(address)s 되었습니다 추가ed to the textarea. 다음 click 저장 to block that IP."
+
+#: admin/block.html
+msgid "Blocked IP Addresses"
+msgstr "차단된 IP 주소"
+
+#: admin/graphs.html
+msgid "Performance Graphs"
+msgstr "성능 그래프"
+
+#: admin/graphs.html
+msgid "Number of Hits"
+msgstr "조회 수"
+
+#: admin/graphs.html
+msgid "Page Load Times"
+msgstr "페이지 로드 시간"
+
+#: admin/graphs.html
+msgid "Page Load Times Split"
+msgstr "페이지 로드 시간 분할"
+
+#: admin/graphs.html
+msgid "Infobase Mean"
+msgstr "Infobase 평균"
+
+#: admin/history.html admin/imports.html authors/infobox.html type/author/edit.html
+msgid "Date"
+msgstr "날짜"
+
+#: admin/history.html
+msgid "Page"
+msgstr "페이지"
+
+#: admin/imports-add.html admin/imports.html admin/imports_by_date.html admin/menu.html
+msgid "Imports"
+msgstr "가져오기"
+
+#: admin/imports-add.html books/add.html books/edit/edition.html books/edit/excerpts.html
+#: covers/change.html type/tag/form.html
+msgid "Add"
+msgstr "추가"
+
+#: admin/imports-add.html admin/imports.html
+msgid "Add new books to import queue"
+msgstr "new books to import queue 추가"
+
+#: admin/imports-add.html
+msgid "Please add IA identifiers to be imported, one per line."
+msgstr "다음 추가 IA identifiers to be imported, one per line."
+
+#: admin/imports-add.html admin/inspect/store.html admin/ip/view.html admin/people/edits.html
+#: admin/permissions.html design/button.html my_books/check_ins/check_in_form.html
+#: reading_goals/reading_goal_form.html
+msgid "Submit"
+msgstr "제출"
+
+#: admin/imports.html
+msgid "New Books Imported Per Day"
+msgstr "일별 새로 가져온 책"
+
+#: PublishingHistory.html admin/imports.html publishers/view.html
+msgid "You need to have JavaScript turned on to see the nifty chart!"
+msgstr "멋진 차트를 보려면 JavaScript를 켜야 합니다!"
+
+#: admin/imports.html admin/imports_by_date.html admin/pd_dashboard.html site/stats.html
+msgid "Summary"
+msgstr "요약"
+
+#: admin/imports.html
+msgid "Pending Items:"
+msgstr "대기 중인 항목:"
+
+#: admin/imports.html
+#, python-format
+msgid "<strong>Current Import Rate:</strong> %(num)d imports/hour."
+msgstr "<strong>현재 가져오기 속도:</strong> 시간당 %(num)d건."
+
+#: admin/imports.html
+msgid "ETA:"
+msgstr "예상 완료 시간:"
+
+#: admin/imports.html
+msgid "Summary By Date"
+msgstr "날짜별 요약"
+
+#: admin/imports.html
+msgid "total"
+msgstr "합계"
+
+#: admin/imports.html
+msgid "#books created"
+msgstr "생성된 책 수"
+
+#: admin/imports.html
+msgid "#books already found"
+msgstr "이미 찾은 책 수"
+
+#: admin/imports.html
+msgid "#books failed to import"
+msgstr "가져오기에 실패한 책 수"
+
+#: admin/imports.html
+msgid "#books pending"
+msgstr "대기 중인 책 수"
+
+#: admin/imports.html
+msgid "Recent Imports"
+msgstr "최근 가져오기"
+
+#: admin/imports.html admin/imports_by_date.html
+msgid "Identifier"
+msgstr "식별자"
+
+#: admin/imports.html admin/imports_by_date.html
+msgid "Imported Time"
+msgstr "가져온 시간"
+
+#: admin/imports_by_date.html admin/index.html admin/pd_dashboard.html
+msgid "Total"
+msgstr "합계"
+
+#: admin/imports_by_date.html
+msgid "Created"
+msgstr "생성됨"
+
+#: admin/imports_by_date.html
+msgid "Found"
+msgstr "찾음"
+
+#: admin/imports_by_date.html
+msgid "Failed"
+msgstr "실패"
+
+#: admin/imports_by_date.html openlibrary/core/edits.py
+msgid "Pending"
+msgstr "대기 중"
+
+#: admin/imports_by_date.html
+msgid "Items"
+msgstr "항목"
+
+#: admin/index.html
+msgid ""
+"<span class=\"login-counts\">0</span> patrons have logged in at least once over the "
+"past 30 days."
+msgstr "지난 30일 동안 <span class=\"login-counts\">0</span>명의 이용자가 한 번 이상 로그인했습니다."
+
+#: admin/index.html
+msgid "Stats"
+msgstr "통계"
+
+#: admin/index.html
+msgid "Edits Per Day"
+msgstr "일별 편집 수"
+
+#: admin/index.html admin/people/index.html
+msgid "Edits"
+msgstr "편집"
+
+#: admin/index.html
+msgid "Yesterday"
+msgstr "어제"
+
+#: admin/index.html
+msgid "Last 7 days"
+msgstr "지난 7일"
+
+#: admin/index.html
+msgid "Last 28 days"
+msgstr "지난 28일"
+
+#: admin/index.html
+msgid "Human"
+msgstr "사람"
+
+#: admin/index.html admin/people/view.html
+msgid "Bot"
+msgstr "봇"
+
+#: admin/index.html
+msgid "New Accounts Per Day"
+msgstr "일별 새 계정 수"
+
+#: admin/index.html
+msgid "Members"
+msgstr "회원"
+
+#: admin/index.html
+msgid "Items Added"
+msgstr "추가된 항목"
+
+#: admin/index.html
+msgid "Trend"
+msgstr "추세"
+
+#: admin/index.html
+msgid "Works Added"
+msgstr "추가된 작품"
+
+#: admin/index.html
+msgid "Editions Added"
+msgstr "추가된 판본"
+
+#: admin/index.html
+msgid "Authors Added"
+msgstr "추가된 저자"
+
+#: admin/index.html recentchanges/index.html
+msgid "Covers Added"
+msgstr "추가된 표지"
+
+#: admin/index.html home/stats.html
+msgid "New Members"
+msgstr "새 회원"
+
+#: admin/index.html
+msgid "Lists Added"
+msgstr "추가된 목록"
+
+#: admin/index.html
+msgid "Books Logged"
+msgstr "기록된 책"
+
+#: admin/index.html
+msgid "Users Logging"
+msgstr "기록 중인 사용자"
+
+#: admin/index.html
+msgid "Yearly Reading Goals"
+msgstr "연간 독서 목표"
+
+#: admin/index.html
+msgid "Books Review Tags"
+msgstr "책 리뷰 태그"
+
+#: admin/index.html
+msgid "Books Reviewed"
+msgstr "리뷰된 책"
+
+#: admin/index.html
+msgid "Users Reviewing"
+msgstr "리뷰 중인 사용자"
+
+#: admin/index.html
+msgid "Patrons Following"
+msgstr "팔로우 중인 이용자"
+
+#: admin/index.html
+msgid "Notes Created"
+msgstr "생성된 노트"
+
+#: admin/index.html
+msgid "Patrons Creating Notes"
+msgstr "노트를 만드는 이용자"
+
+#: admin/index.html
+msgid "Books Starred"
+msgstr "별점이 매겨진 책"
+
+#: admin/index.html
+msgid "Star Rating Patrons"
+msgstr "별점을 매긴 이용자"
+
+#: admin/index.html home/stats.html
+msgid "Unique Visitors"
+msgstr "고유 방문자"
+
+#: admin/index.html
+msgid "Unique visitors IPs per day graph"
+msgstr "일별 고유 방문자 IP 그래프"
+
+#: admin/index.html
+msgid "Borrows"
+msgstr "대출"
+
+#: admin/index.html
+msgid "Borrows, last 3 months graph"
+msgstr "대출s, last 3 months graph"
+
+#: admin/index.html
+msgid "Borrows, last 2 years graph"
+msgstr "대출s, last 2 years graph"
+
+#: admin/index.html
+msgid "Unique Logins"
+msgstr "고유 로그인"
+
+#: admin/index.html
+msgid "Gathering login statistics..."
+msgstr "로그인 통계를 수집하는 중..."
+
+#: admin/loans_table.html
+msgid "BookReader"
+msgstr "BookReader"
+
+#: admin/loans_table.html book_providers/cita_press_download_options.html
+#: book_providers/ia_download_options.html book_providers/openstax_download_options.html
+#: book_providers/wikisource_download_options.html books/edit/edition.html
+msgid "PDF"
+msgstr "PDF"
+
+#: admin/loans_table.html book_providers/gutenberg_download_options.html
+#: book_providers/ia_download_options.html
+#: book_providers/standard_ebooks_download_options.html books/edit/edition.html
+msgid "ePub"
+msgstr "ePub"
+
+#: admin/loans_table.html
+msgid "No current loans."
+msgstr "현재 대출이 없습니다."
+
+#: admin/loans_table.html
+#, python-format
+msgid "%d Current Loan"
+msgid_plural "%d Current Loans"
+msgstr[0] "현재 대출 %d건"
+
+#: RecentChanges.html RecentChangesUsers.html admin/ip/view.html admin/loans_table.html
+#: admin/people/edits.html recentchanges/render.html recentchanges/updated_records.html
+msgid "What"
+msgstr "무엇"
+
+#: admin/loans_table.html
+#, python-format
+msgid "Waiting since %(date)s"
+msgstr "%(date)s부터 대기 중"
+
+#: admin/loans_table.html
+#, python-format
+msgid "#%(num_position)d among %(num_waitlist)d people waiting for this book"
+msgstr "#%(num_position)d among %(num_waitlist)d people waiting for 이 책"
+
+#: ManageLoansButtons.html admin/loans_table.html
+#, python-format
+msgid "Borrowed %(date)s"
+msgstr "%(date)s에 대출"
+
+#: admin/menu.html
+msgid "Admin Center"
+msgstr "관리자 센터"
+
+#: RelatedSubjects.html SubjectTags.html admin/menu.html admin/people/index.html
+#: admin/people/view.html openlibrary/plugins/worksearch/code.py type/author/view.html
+#: type/list/view_body.html
+msgid "People"
+msgstr "사람"
+
+#: admin/menu.html
+msgid "PD Access Requests"
+msgstr "PD 접근 요청"
+
+#: admin/menu.html
+msgid "Block IPs"
+msgstr "IP 차단"
+
+#: admin/menu.html admin/spamwords.html
+msgid "Spam Words"
+msgstr "스팸 단어"
+
+#: admin/menu.html
+msgid "Solr"
+msgstr "Solr"
+
+#: admin/menu.html
+msgid "Graphs"
+msgstr "그래프"
+
+#: admin/menu.html
+msgid "Inspect store"
+msgstr "저장소 검사"
+
+#: admin/menu.html
+msgid "Inspect memcache"
+msgstr "memcache 검사"
+
+#: admin/pd_dashboard.html
+msgid "Print Disability Access Requests"
+msgstr "인쇄물 이용 장애 접근 요청"
+
+#: admin/pd_dashboard.html
+msgid "Breakdown by Qualifying Authority"
+msgstr "자격 인증 기관별 분석"
+
+#: admin/pd_dashboard.html
+msgid "PDA"
+msgstr "PDA"
+
+#: admin/pd_dashboard.html
+msgid "Emailed"
+msgstr "이메일 보냄"
+
+#: admin/pd_dashboard.html
+msgid "Fulfilled"
+msgstr "처리 완료"
+
+#: admin/pd_dashboard.html
+msgid "Totals"
+msgstr "합계"
+
+#: admin/permissions.html
+msgid "[Admin Center] Site Permissions"
+msgstr "[관리자 센터] 사이트 권한"
+
+#: admin/permissions.html
+msgid "Site Permissions"
+msgstr "사이트 권한"
+
+#: admin/permissions.html
+msgid "Change the policy of who can edit the site."
+msgstr "Change the policy of who can 편집 the site."
+
+#: admin/permissions.html
+msgid "Who can edit Open Library records?"
+msgstr "누가 Open Library 레코드를 편집할 수 있나요?"
+
+#: admin/permissions.html
+msgid "This applies to /authors/*, /books/* and /works/* records."
+msgstr "This applies to /저자/*, /책/* and /작품/* 레코드s."
+
+#: admin/permissions.html
+msgid "Who can edit Open Library pages?"
+msgstr "누가 Open Library 페이지를 편집할 수 있나요?"
+
+#: admin/permissions.html
+msgid "This applies to /about/*, /help/*, /dev/*, /docs/* etc."
+msgstr "이는 /about/*, /help/*, /dev/*, /docs/* 등에 적용됩니다."
+
+#: admin/permissions.html
+msgid "Update permissions"
+msgstr "권한 업데이트"
+
+#: admin/permissions.html
+msgid ""
+"This updates \"permission\" and \"child_permission\" fields of /, /works, /books and "
+"/authors records in the database."
+msgstr ""
+"This updates \"permission\" and \"child_permission\" fields of /, /작품, /책 and /저자 레코드s "
+"in the database."
+
+#: admin/solr.html
+msgid "Solr Admin"
+msgstr "Solr 관리자"
+
+#: admin/solr.html
+msgid "Enter the keys of pages to be updated in OL search engine."
+msgstr "Enter the keys of 페이지s to be updated in OL 검색 engine."
+
+#: admin/solr.html
+msgid "Example:"
+msgstr "예:"
+
+#: admin/solr.html
+msgid ""
+"On update, these keys will be added to solr update queue and it'll take about 15 "
+"minutes for them to get reindexed in Solr."
+msgstr ""
+"On update, these keys 됩니다 추가ed to solr update queue and it'll take about 15 minutes for"
+" them to get reindexed in Solr."
+
+#: admin/solr.html
+msgid "Enter the keys to reindex in Solr"
+msgstr "Solr에서 다시 색인할 키 입력"
+
+#: admin/solr.html
+msgid "Write one entry per line"
+msgstr "한 줄에 하나씩 입력"
+
+#: admin/spamwords.html
+msgid "[Admin Center] Spam Words"
+msgstr "[관리자 센터] 스팸 단어"
+
+#: admin/spamwords.html
+msgid "Please enter the SPAM regular expressions in the textarea below, one per line."
+msgstr "다음 enter the SPAM regular expressions in the textarea below, one per line."
+
+#: admin/spamwords.html
+msgid "Be sure to escape any meta characters that are meant to be character literals."
+msgstr "문자 그대로 사용하려는 메타 문자는 반드시 이스케이프하세요."
+
+#: admin/spamwords.html
+msgid "If you are adding a domain, prepend the following to the domain:"
+msgstr "If you are 추가ing a domain, prepend the following to the domain:"
+
+#: admin/spamwords.html
+msgid ""
+"For example, if you want to prevent edits containing the domain <code>t.co</code>, add "
+"<code>(|https://|http://)t\\.co</code> to the spamwords list."
+msgstr ""
+"For example, if you want to prevent 편집s containing the domain <code>t.co</code>, 추가 "
+"<code>(|https://|http://)t\\.co</code> to the spamwords 목록."
+
+#: admin/spamwords.html
+msgid "Spam Domains"
+msgstr "스팸 도메인"
+
+#: admin/spamwords.html
+msgid "Please enter domains to blacklist in the textarea below, one per line."
+msgstr "다음 enter domains to black목록 in the textarea below, one per line."
+
+#: admin/sync.html
+msgid "Sync"
+msgstr "동기화"
+
+#: admin/sync.html
+msgid ""
+"Sync the metadata of various types of Open Library items (e.g. lists, subjects, works) "
+"with Archive.org."
+msgstr ""
+"Sync the metadata of various types of Open Library items (e.g. 목록, 주제, 작품) with "
+"Archive.org."
+
+#: admin/sync.html
+msgid "Add Works to Staff Picks"
+msgstr "Works to Staff Picks 추가"
+
+#: admin/sync.html
+msgid ""
+"This utility will add your work to an Open Library list called `Staff Picks` under the "
+"`openlibrary` user. It will then take the added work and explode it into a list of all "
+"its readable editions. For each Open Library edition, a metadata field called "
+"`openlibrary_subject` will be injected into the archive.org metadata of the edition's "
+"corresponding archive.org item."
+msgstr ""
+"This utility will 추가 your 작품 to an Open Library 목록 called `Staff Picks` under the "
+"`openlibrary` user. It will then take the 추가ed 작품 and explode it into a 목록 of all its "
+"readable 판본. For each Open Library 판본, a metadata field called `openlibrary_주제` 됩니다 "
+"injected into the archive.org metadata of the 판본's corresponding archive.org item."
+
+#: admin/sync.html
+msgid "add"
+msgstr "추가"
+
+#: admin/sync.html
+msgid "remove"
+msgstr "제거"
+
+#: admin/sync.html
+msgid "Update edition"
+msgstr "판본 업데이트"
+
+#: admin/sync.html
+msgid ""
+"Updates an edition on archive.org by writing in its latest  openlibrary_edition and "
+"openlibrary_work identifier values"
+msgstr ""
+"Updates an 판본 on archive.org by writing in its latest  openlibrary_판본 and "
+"openlibrary_작품 identifier values"
+
+#: admin/sync.html
+msgid "TODO"
+msgstr "TODO"
+
+#: admin/inspect/memcache.html
+msgid "[Admin Center] Inspect Memcache"
+msgstr "[관리자 센터] Memcache 검사"
+
+#: admin/inspect/memcache.html
+msgid "Inspect Memcache"
+msgstr "Memcache 검사"
+
+#: admin/inspect/memcache.html
+msgid ""
+"Add one memcache key per line in the text area. Each key must include a '-' as the last"
+" character."
+msgstr ""
+"one memcache key per line in the text area. Each key must include a '-' as the last "
+"character. 추가"
+
+#: admin/inspect/memcache.html
+msgid ""
+"For example, <code>observations-</code> should be entered in the text area if the key "
+"is <code>observations</code>."
+msgstr "예를 들어 키가 <code>observations</code>이면 텍스트 영역에는 <code>observations-</code>를 입력해야 합니다."
+
+#: admin/inspect/memcache.html
+msgid "Keys:"
+msgstr "키:"
+
+#: admin/inspect/memcache.html
+msgid "Result"
+msgstr "결과"
+
+#: admin/inspect/memcache.html
+msgid "No keys selected."
+msgstr "선택된 키가 없습니다."
+
+#: admin/inspect/memcache.html
+msgid "Not found."
+msgstr "찾을 수 없습니다."
+
+#: admin/inspect/store.html
+msgid "Admin Center / Inspect"
+msgstr "관리자 센터 / 검사"
+
+#: admin/inspect/store.html
+msgid "Inspect Store"
+msgstr "저장소 검사"
+
+#: admin/inspect/store.html
+msgid "Get"
+msgstr "가져오기"
+
+#: admin/inspect/store.html
+msgid "Key"
+msgstr "키"
+
+#: admin/inspect/store.html
+msgid "Query"
+msgstr "쿼리"
+
+#: admin/inspect/store.html
+msgid "Type"
+msgstr "유형"
+
+#: admin/inspect/store.html
+msgid "Value"
+msgstr "값"
+
+#: admin/inspect/store.html
+msgid "Documents"
+msgstr "문서"
+
+#: admin/inspect/store.html
+msgid "Json"
+msgstr "JSON"
+
+#: admin/inspect/store.html
+msgid "No results found."
+msgstr "결과를 찾을 수 없습니다."
+
+#: admin/ip/index.html
+msgid "[Admin Center] IP Addresses"
+msgstr "[관리자 센터] IP 주소"
+
+#: admin/ip/index.html
+msgid "IP Addresses"
+msgstr "IP 주소"
+
+#: admin/ip/index.html
+msgid "List of Banned IPs"
+msgstr "차단된 IP 목록"
+
+#: admin/ip/index.html admin/people/index.html
+msgid "Date/Time"
+msgstr "날짜/시간"
+
+#: admin/ip/index.html
+msgid "IP address"
+msgstr "IP 주소"
+
+#: admin/ip/index.html
+msgid "Admin Comment"
+msgstr "관리자 댓글"
+
+#: admin/ip/index.html
+msgid "# of edits"
+msgstr "편집 수"
+
+#: admin/ip/index.html
+msgid "x minutes ago"
+msgstr "x분 전"
+
+#: admin/ip/index.html admin/ip/view.html
+msgid "IP"
+msgstr "IP"
+
+#: admin/ip/index.html
+msgid "comment"
+msgstr "댓글"
+
+#: admin/ip/view.html admin/people/view.html
+msgid "[Admin Center]"
+msgstr "[관리자 센터]"
+
+#: admin/ip/view.html
+#, python-format
+msgid "IP %(ip)s is <a href=\"/admin/block\">blocked</a>."
+msgstr "IP %(ip)s은(는) <a href=\"/admin/block\">차단됨</a> 상태입니다."
+
+#: admin/ip/view.html
+#, python-format
+msgid "Block %(ip)s"
+msgstr "%(ip)s 차단"
+
+#: admin/ip/view.html admin/people/edits.html
+msgid "Please select the changesets to revert."
+msgstr "다음 select the changesets to revert."
+
+#: RecentChanges.html admin/ip/view.html admin/people/edits.html recentchanges/render.html
+msgid "When you see numbers here, that's the IP address of the anonymous editor"
+msgstr "When you see numbers here, that's the IP 추가ress of the anonymous 편집or"
+
+#: admin/ip/view.html admin/people/edits.html
+#, python-format
+msgid "Reverted by %(revert_author)s"
+msgstr "%(revert_author)s님이 되돌림"
+
+#: EditButtons.html admin/ip/view.html admin/people/edits.html
+msgid ""
+"Please, leave a short note about what you changed: <span class=\"small "
+"gray\">(Optional, but very useful!)</span>"
+msgstr ""
+"다음, leave a short note about what you changed: <span class=\"small gray\">(Optional, "
+"but very useful!)</span>"
+
+#: admin/ip/view.html admin/people/edits.html
+msgid "Reverted spam"
+msgstr "스팸 되돌림"
+
+#: admin/people/edits.html
+#, python-format
+msgid "[Admin Center] Edits of %(user)s"
+msgstr "[Admin Center] 편집s of %(user)s"
+
+#: admin/people/edits.html
+msgid "people"
+msgstr "사람"
+
+#: admin/people/edits.html
+msgid "edits"
+msgstr "편집"
+
+#: admin/people/index.html
+msgid "[Admin Center] People"
+msgstr "[관리자 센터] 사람"
+
+#: admin/people/index.html
+msgid "Find Account"
+msgstr "계정 찾기"
+
+#: admin/people/index.html admin/people/view.html
+msgid "Email Address:"
+msgstr "이메일 주소:"
+
+#: admin/people/index.html
+msgid "Find"
+msgstr "찾기"
+
+#: admin/people/index.html
+msgid "No account found with this email."
+msgstr "이 이메일로 된 계정을 찾을 수 없습니다."
+
+#: admin/people/index.html
+msgid "IA ID:"
+msgstr "IA ID:"
+
+#: admin/people/index.html
+msgid "e.g. @foobar"
+msgstr "예: @foobar"
+
+#: admin/people/index.html
+msgid "No account found with this ID."
+msgstr "이 ID로 된 계정을 찾을 수 없습니다."
+
+#: admin/people/index.html
+msgid "Recent Accounts"
+msgstr "최근 계정"
+
+#: admin/people/index.html
+msgid "email"
+msgstr "이메일"
+
+#: admin/people/index.html
+msgid "profile"
+msgstr "프로필"
+
+#: admin/people/index.html admin/people/view.html
+msgid "Edit History"
+msgstr "편집 기록"
+
+#: admin/people/view.html
+msgid "block and revert all edits"
+msgstr "차단하고 모든 편집 되돌리기"
+
+#: admin/people/view.html
+msgid "block this account"
+msgstr "이 계정 차단"
+
+#: admin/people/view.html
+#, python-format
+msgid "Registered on <span class=\"time\">%(date)s</span>."
+msgstr "<span class=\"time\">%(date)s</span>에 등록됨."
+
+#: admin/people/view.html
+msgid "login as this user"
+msgstr "이 사용자로 로그인"
+
+#: admin/people/view.html
+#, python-format
+msgid ""
+"Activated on <span class=\"time\">%(date)s</span> from <a "
+"href=\"/admin/ip/%(ip)s\">%(ip)s</a>."
+msgstr "<a href=\"/admin/ip/%(ip)s\">%(ip)s</a>에서 <span class=\"time\">%(date)s</span>에 활성화됨."
+
+#: admin/people/view.html
+msgid "unblock this account"
+msgstr "이 계정 차단 해제"
+
+#: admin/people/view.html
+msgid "activate account"
+msgstr "계정 활성화"
+
+#: admin/people/view.html
+#, python-format
+msgid "Activation link expiring on <span class=\"time\">%(date)s.</span>"
+msgstr "활성화 링크 만료 예정: <span class=\"time\">%(date)s.</span>"
+
+#: admin/people/view.html
+msgid "Activation link expired"
+msgstr "활성화 링크 만료"
+
+#: admin/people/view.html
+msgid "Resend activation link"
+msgstr "활성화 링크 다시 보내기"
+
+#: CreateListModal.html admin/people/view.html my_books/dropdown_content.html
+msgid "Name:"
+msgstr "이름:"
+
+#: admin/people/view.html
+msgid "view profile"
+msgstr "프로필 보기"
+
+#: admin/people/view.html
+msgid "Change"
+msgstr "변경"
+
+#: admin/people/view.html
+msgid "Admin"
+msgstr "관리자"
+
+#: admin/people/view.html
+msgid "Make Human"
+msgstr "사람으로 표시"
+
+#: admin/people/view.html
+msgid "Make Bot"
+msgstr "봇으로 표시"
+
+#: admin/people/view.html
+msgid "Not available"
+msgstr "사용할 수 없음"
+
+#: admin/people/view.html
+msgid "# Edits"
+msgstr "편집 수"
+
+#: admin/people/view.html
+msgid "Member Since:"
+msgstr "가입일:"
+
+#: admin/people/view.html
+msgid "Last Login:"
+msgstr "마지막 로그인:"
+
+#: admin/people/view.html
+msgid "Tags:"
+msgstr "태그:"
+
+#: admin/people/view.html
+msgid "Anonymize Account:"
+msgstr "계정 익명화:"
+
+#: admin/people/view.html
+msgid "Dry Run"
+msgstr "시험 실행"
+
+#: admin/people/view.html
+msgid "Anonymize Account"
+msgstr "계정 익명화"
+
+#: admin/people/view.html books/mybooks_breadcrumb_select.html
+#: openlibrary/plugins/upstream/account.py type/user/view.html
+msgid "Loans"
+msgstr "대출"
+
+#: admin/people/view.html
+msgid "Account not activated yet."
+msgstr "계정이 아직 활성화되지 않았습니다."
+
+#: admin/people/view.html
+msgid "Waiting Loans"
+msgstr "대기 중인 대출"
+
+#: admin/people/view.html
+#, python-format
+msgid "%(num)d edits"
+msgstr "편집 %(num)d회"
+
+#: admin/people/view.html
+msgid "Debug Info"
+msgstr "디버그 정보"
+
+#: admin/people/view.html
+msgid "Account Information"
+msgstr "계정 정보"
+
+#: admin/people/view.html
+msgid "Verifications Links"
+msgstr "확인 링크"
+
+#: admin/people/view.html
+msgid "None found"
+msgstr "찾을 수 없음"
+
+#: SearchNavigation.html authors/index.html lib/nav_foot.html merge/authors.html
+#: publishers/view.html
+msgid "Authors"
+msgstr "저자"
+
+#: authors/index.html
+msgid "Search for an Author"
+msgstr "저자 검색"
+
+#: authors/index.html lib/nav_head.html lists/home.html publishers/index.html
+#: publishers/notfound.html publishers/view.html search/advancedsearch.html
+#: search/publishers.html search/searchbox.html type/local_id/view.html
+msgid "Search"
+msgstr "검색"
+
+#: authors/index.html search/authors.html
+#, python-format
+msgid "about %(subjects)s"
+msgstr "%(subjects)s에 관하여"
+
+#: authors/index.html search/authors.html
+#, python-format
+msgid "including <i>%(topwork)s</i>"
+msgstr "<i>%(topwork)s</i> 포함"
+
+#: authors/infobox.html
+#, python-format
+msgid "View on %(site)s"
+msgstr "%(site)s에서 보기"
+
+#: authors/infobox.html
+msgid "Born"
+msgstr "출생"
+
+#: authors/infobox.html
+msgid "Died"
+msgstr "사망"
+
+#: book_providers/cita_press_download_options.html
+#: book_providers/gutenberg_download_options.html book_providers/ia_download_options.html
+#: book_providers/librivox_download_options.html
+#: book_providers/openstax_download_options.html
+#: book_providers/runeberg_download_options.html
+#: book_providers/standard_ebooks_download_options.html
+#: book_providers/wikisource_download_options.html
+msgid "Download Options"
+msgstr "다운로드 옵션"
+
+#: book_providers/cita_press_download_options.html
+msgid "Download PDF from Cita Press"
+msgstr "Cita Press에서 PDF 다운로드"
+
+#: book_providers/cita_press_download_options.html
+msgid "More at Cita Press"
+msgstr "Cita Press에서 더 보기"
+
+#: book_providers/gutenberg_download_options.html
+msgid "Download an HTML from Project Gutenberg"
+msgstr "Project Gutenberg에서 HTML 다운로드"
+
+#: book_providers/gutenberg_download_options.html
+#: book_providers/runeberg_download_options.html
+#: book_providers/standard_ebooks_download_options.html type/list/exports.html
+msgid "HTML"
+msgstr "HTML"
+
+#: book_providers/gutenberg_download_options.html
+msgid "Download a text version from Project Gutenberg"
+msgstr "Project Gutenberg에서 텍스트 버전 다운로드"
+
+#: book_providers/gutenberg_download_options.html book_providers/ia_download_options.html
+msgid "Plain text"
+msgstr "일반 텍스트"
+
+#: book_providers/gutenberg_download_options.html
+msgid "Download an ePub from Project Gutenberg"
+msgstr "Project Gutenberg에서 ePub 다운로드"
+
+#: book_providers/gutenberg_download_options.html
+msgid "Download a Kindle file from Project Gutenberg"
+msgstr "Project Gutenberg에서 Kindle 파일 다운로드"
+
+#: book_providers/gutenberg_download_options.html
+msgid "Kindle"
+msgstr "Kindle"
+
+#: book_providers/gutenberg_download_options.html
+msgid "More at Project Gutenberg"
+msgstr "Project Gutenberg에서 더 보기"
+
+#: book_providers/ia_download_options.html
+msgid "Download a PDF from Internet Archive"
+msgstr "Internet Archive에서 PDF 다운로드"
+
+#: book_providers/ia_download_options.html
+msgid "Download a text version from Internet Archive"
+msgstr "Internet Archive에서 텍스트 버전 다운로드"
+
+#: book_providers/ia_download_options.html
+msgid "Download an ePub from Internet Archive"
+msgstr "Internet Archive에서 ePub 다운로드"
+
+#: book_providers/ia_download_options.html
+msgid "Download a MOBI file from Internet Archive"
+msgstr "Internet Archive에서 MOBI 파일 다운로드"
+
+#: book_providers/ia_download_options.html
+msgid "MOBI"
+msgstr "MOBI"
+
+#: book_providers/ia_download_options.html
+msgid "Download open DAISY from Internet Archive (print-disabled format)"
+msgstr "Internet Archive에서 공개 DAISY 다운로드(인쇄물 이용 장애 형식)"
+
+#: book_providers/ia_download_options.html type/list/embed.html
+msgid "DAISY"
+msgstr "DAISY"
+
+#: book_providers/librivox_download_options.html
+msgid "Download a ZIP file of the whole book from Internet Archive"
+msgstr "Internet Archive에서 전체 책의 ZIP 파일 다운로드"
+
+#: book_providers/librivox_download_options.html
+msgid "Whole Book MP3"
+msgstr "전체 책 MP3"
+
+#: book_providers/librivox_download_options.html
+msgid "Get the RSS Feed from LibriVox"
+msgstr "LibriVox에서 RSS 피드 받기"
+
+#: book_providers/librivox_download_options.html
+msgid "RSS Feed"
+msgstr "RSS 피드"
+
+#: book_providers/librivox_download_options.html
+msgid "More at LibriVox"
+msgstr "LibriVox에서 더 보기"
+
+#: book_providers/openstax_download_options.html
+msgid "Download PDF from OpenStax"
+msgstr "OpenStax에서 PDF 다운로드"
+
+#: book_providers/openstax_download_options.html
+msgid "More at OpenStax"
+msgstr "OpenStax에서 더 보기"
+
+#: book_providers/read_button.html
+#, python-format
+msgid "Listen to a reading from %s"
+msgstr "%s의 낭독 듣기"
+
+#: book_providers/read_button.html
+msgid "Audiobook"
+msgstr "오디오북"
+
+#: book_providers/read_button.html
+#, python-format
+msgid "Read free online from %s"
+msgstr "%s에서 무료로 온라인 읽기"
+
+#: book_providers/runeberg_download_options.html
+msgid "Download all scanned images from Project Runeberg"
+msgstr "Project Runeberg에서 all scanned images 다운로드"
+
+#: book_providers/runeberg_download_options.html
+msgid "Scanned images"
+msgstr "스캔 이미지"
+
+#: book_providers/runeberg_download_options.html
+msgid "Download all color images from Project Runeberg"
+msgstr "Project Runeberg에서 all color images 다운로드"
+
+#: book_providers/runeberg_download_options.html
+msgid "Color images"
+msgstr "컬러 이미지"
+
+#: book_providers/runeberg_download_options.html
+msgid "Download all HTML files from Project Runeberg"
+msgstr "Project Runeberg에서 all HTML files 다운로드"
+
+#: book_providers/runeberg_download_options.html
+msgid "Download all text and index files from Project Runeberg"
+msgstr "Project Runeberg에서 all text and index files 다운로드"
+
+#: book_providers/runeberg_download_options.html
+msgid "Text and index files"
+msgstr "텍스트 및 색인 파일"
+
+#: book_providers/runeberg_download_options.html
+msgid "Download all OCR text from Project Runeberg"
+msgstr "Project Runeberg에서 all OCR text 다운로드"
+
+#: book_providers/runeberg_download_options.html
+msgid "OCR text"
+msgstr "OCR 텍스트"
+
+#: book_providers/runeberg_download_options.html
+msgid "More at Project Runeberg"
+msgstr "Project Runeberg에서 더 보기"
+
+#: book_providers/standard_ebooks_download_options.html
+msgid "Download an HTML from Standard Ebooks"
+msgstr "Standard Ebooks에서 HTML 다운로드"
+
+#: book_providers/standard_ebooks_download_options.html
+msgid "Download an ePub from Standard Ebook."
+msgstr "Standard Ebook.에서 an ePub 다운로드"
+
+#: book_providers/standard_ebooks_download_options.html
+msgid "Download a Kindle file from Standard Ebooks"
+msgstr "Standard Ebooks에서 a Kindle file 다운로드"
+
+#: book_providers/standard_ebooks_download_options.html
+msgid "Kindle (azw3)"
+msgstr "Kindle(azw3)"
+
+#: book_providers/standard_ebooks_download_options.html
+msgid "Download a Kobo file from Standard Ebooks"
+msgstr "Standard Ebooks에서 a Kobo file 다운로드"
+
+#: book_providers/standard_ebooks_download_options.html
+msgid "Kobo (kepub)"
+msgstr "Kobo(kepub)"
+
+#: book_providers/standard_ebooks_download_options.html
+msgid "View the source code for this Standard Ebook at GitHub"
+msgstr "the source code for this Standard Ebook at GitHub 보기"
+
+#: Subnavigation.html book_providers/standard_ebooks_download_options.html
+msgid "Source Code"
+msgstr "소스 코드"
+
+#: book_providers/standard_ebooks_download_options.html
+msgid "More at Standard Ebooks"
+msgstr "Standard Ebooks에서 더 보기"
+
+#: book_providers/wikisource_download_options.html
+msgid "Download PDF from Wikisource"
+msgstr "Wikisource에서 PDF 다운로드"
+
+#: book_providers/wikisource_download_options.html
+msgid "Download MOBI from Wikisource"
+msgstr "Wikisource에서 MOBI 다운로드"
+
+#: book_providers/wikisource_download_options.html
+msgid "MOBI (for Kindle)"
+msgstr "MOBI(Kindle용)"
+
+#: book_providers/wikisource_download_options.html
+msgid "Download EPUB from Wikisource"
+msgstr "Wikisource에서 EPUB 다운로드"
+
+#: book_providers/wikisource_download_options.html
+msgid "EPUB (for most other e-readers)"
+msgstr "EPUB(대부분의 다른 전자책 리더용)"
+
+#: book_providers/wikisource_download_options.html
+msgid "Read at Wikisource"
+msgstr "Wikisource에서 읽기"
+
+#: books/RelatedWorksCarousel.html
+msgid "You might also like"
+msgstr "이것도 좋아하실 수 있습니다"
+
+#: books/RelatedWorksCarousel.html
+msgid "More by this author"
+msgid_plural "More by these authors"
+msgstr[0] "이 저자의 더 많은 책"
+
+#: books/add.html books/check.html
+msgid "Add a book"
+msgstr "a book 추가"
+
+#: books/add.html
+msgid "Invalid ISBN checksum digit"
+msgstr "잘못된 ISBN 체크섬 숫자"
+
+#: books/add.html
+msgid "ID must be exactly 10 characters [0-9 or X]. For example 0-19-853453-1 or 0198534531"
+msgstr "ID는 정확히 10자여야 합니다[0-9 또는 X]. 예: 0-19-853453-1 또는 0198534531"
+
+#: books/add.html
+msgid "ID must be exactly 13 characters [0-9]. For example 978-3-16-148410-0 or 9783161484100"
+msgstr "ID는 정확히 13자여야 합니다[0-9]. 예: 978-3-16-148410-0 또는 9783161484100"
+
+#: books/add.html
+msgid "Invalid LC Control Number format"
+msgstr "잘못된 LC 관리 번호 형식"
+
+#: books/add.html
+msgid "Invalid OCLC/WorldCat Control Number format"
+msgstr "잘못된 OCLC/WorldCat 관리 번호 형식"
+
+#: books/add.html
+msgid "Please enter a value for the selected identifier"
+msgstr "다음 enter a value for the selected identifier"
+
+#: books/add.html
+msgid "Are you sure that's the published date?"
+msgstr "그 날짜가 출판일이 맞나요?"
+
+#: books/add.html
+msgid "Add a book to Open Library"
+msgstr "a book to Open Library 추가"
+
+#: books/add.html
+msgid "We require a minimum set of fields to create a new record. These are those fields."
+msgstr "We require a minimum set of fields to 생성 a new 레코드. These are those fields."
+
+#: books/add.html books/edit.html
+msgid "Use <b><i>Title: Subtitle</i></b> to add a subtitle."
+msgstr "Use <b><i>Title: Subtitle</i></b> 추가하려면 a subtitle."
+
+#: books/add.html books/edit.html type/author/edit.html type/tag/tag_form_inputs.html
+msgid "Required field"
+msgstr "필수 항목"
+
+#: books/add.html
+msgid ""
+"Like, \"Agatha Christie\" or \"Jean-Paul Sartre.\" We'll also do a live check to see if"
+" we already know the author."
+msgstr ""
+"Like, \"Agatha Christie\" or \"Jean-Paul Sartre.\" We'll also do a live check to see if"
+" we already know the 저자."
+
+#: books/add.html books/edit/edition.html
+msgid "Who is the publisher?"
+msgstr "Who is the 출판사?"
+
+#: books/add.html books/edit/edition.html
+msgid "For example:"
+msgstr "예:"
+
+#: books/add.html
+msgid "Oxford University Press; Penguin; W.W. Norton"
+msgstr "Oxford University Press; Penguin; W.W. Norton"
+
+#: books/add.html books/edit/edition.html
+msgid "When was it published?"
+msgstr "언제 출판되었나요?"
+
+#: books/add.html books/edit/edition.html
+msgid "You should be able to find this in the first few pages of the book."
+msgstr "You should be able to find this in the first few 페이지s of the 책."
+
+#: books/add.html
+msgid "And optionally, an ID number &#151; like an ISBN &#151; would be helpful..."
+msgstr "선택 사항으로 ISBN 같은 ID 번호가 있으면 도움이 됩니다..."
+
+#: books/add.html
+msgid "ID Type"
+msgstr "ID 유형"
+
+#: books/add.html
+msgid "ISBN may be invalid. Click \"Add\" again to submit."
+msgstr "ISBN may be invalid. Click \"추가\" again to 제출."
+
+#: books/add.html type/tag/tag_form_inputs.html
+msgid "Select"
+msgstr "선택"
+
+#: books/add.html
+msgid "ISBN 10"
+msgstr "ISBN 10"
+
+#: books/add.html
+msgid "ISBN 13"
+msgstr "ISBN 13"
+
+#: books/add.html
+msgid "LCCN"
+msgstr "LCCN"
+
+#: books/add.html
+msgid "LibriVox"
+msgstr "LibriVox"
+
+#: books/add.html
+msgid "OCLC/WorldCat"
+msgstr "OCLC/WorldCat"
+
+#: books/add.html
+msgid "Project Gutenberg"
+msgstr "Project Gutenberg"
+
+#: books/add.html books/edit/edition.html
+msgid "Book URL"
+msgstr "책 URL"
+
+#: books/add.html
+msgid "Only fill this out if this is a web book"
+msgstr "Only fill this out if this is a web 책"
+
+#: books/add.html
+#, python-format
+msgid ""
+"By saving a change to this wiki, you agree that your contribution is given freely to "
+"the world under <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" "
+"target=\"_blank\" rel=\"noopener noreferrer\" title=\"%(cc_link_title)s\">CC0</a>."
+msgstr ""
+"By saving a change to this wiki, you agree that your contribution is given freely to "
+"the world under <a href=\"https://creativecommons.org/공개domain/zero/1.0/\" "
+"target=\"_blank\" rel=\"noopener noreferrer\" title=\"%(cc_link_title)s\">CC0</a>."
+
+#: books/add.html
+msgid "This link to Creative Commons will open in a new window"
+msgstr "Creative Commons 링크가 새 창에서 열립니다"
+
+#: books/add.html
+msgid "Add this book now"
+msgstr "this book now 추가"
+
+#: books/author-autocomplete.html
+msgid "Add a new author"
+msgstr "새 저자 추가"
+
+#: books/author-autocomplete.html books/series-autocomplete.html
+msgid "Create a new record for"
+msgstr "새 record for 만들기"
+
+#: books/author-autocomplete.html
+msgid "Remove this author"
+msgstr "this author 제거"
+
+#: books/author-autocomplete.html
+msgid "Add another author?"
+msgstr "another author? 추가"
+
+#: books/check.html lib/nav_foot.html lib/nav_head.html
+msgid "Add a Book"
+msgstr "a Book 추가"
+
+#: books/check.html
+#, python-format
+msgid ""
+"One moment... It looks like we already have <em>some potential matches</em> for "
+"<b>%(title)s</b> by <b>%(author)s</b>."
+msgstr "잠시만요... 이미 <b>%(author)s</b>의 <b>%(title)s</b>와 <em>비슷한 후보</em>가 있는 것 같습니다."
+
+#: books/check.html
+msgid ""
+"Rather than creating a duplicate record, please click through the result you think best"
+" matches your book."
+msgstr ""
+"Rather than creating a duplicate 레코드, please click through the result you think best "
+"matches your 책."
+
+#: books/check.html
+msgid "Select this book"
+msgstr "이 책 선택"
+
+#: SearchResultsWork.html books/check.html merge/authors.html publishers/view.html
+#, python-format
+msgid "%(count)s edition"
+msgid_plural "%(count)s editions"
+msgstr[0] "판본 %(count)s개"
+
+#: books/check.html
+#, python-format
+msgid "First published in %(year)d"
+msgstr "%(year)d에 초판 출간"
+
+#: books/check.html
+msgid "None of these match the book I want to add."
+msgstr "None of these match the 책 I want 추가하려면."
+
+#: books/check.html design/button.html
+msgid "Continue"
+msgstr "계속"
+
+#: books/custom_carousel_card.html type/author/view.html
+msgid "name missing"
+msgstr "name 없음"
+
+#: books/custom_carousel_card.html books/mobile_carousel.html
+#, python-format
+msgid " by %(name)s"
+msgstr " %(name)s 지음"
+
+#: books/daisy.html
+msgid "Back"
+msgstr "뒤로"
+
+#: books/daisy.html
+msgid "Open Library Home"
+msgstr "Open Library 홈"
+
+#: books/daisy.html
+msgid "There isn't a DAISY file available for "
+msgstr "다음이 있습니다:n't a DAISY file 사용 가능 for "
+
+#: books/daisy.html
+#, python-format
+msgid ""
+"<a href=\"%(daisy_url)s\"><strong>Download the DAISY.zip</strong></a> for <a "
+"href=\"%(url)s\">%(title)s</a>"
+msgstr ""
+"<a href=\"%(daisy_url)s\"><strong>다운로드 the DAISY.zip</strong></a> for <a "
+"href=\"%(url)s\">%(title)s</a>"
+
+#: books/daisy.html
+msgid "Books for people who don't read print?"
+msgstr "인쇄물을 읽기 어려운 사람들을 위한 책인가요?"
+
+#: books/daisy.html
+msgid ""
+"The <a href=\"//archive.org\">Internet Archive</a> is proud to be distributing over 1 "
+"million books free in a format called DAISY, designed for those of us who find it "
+"challenging to use regular printed media. "
+msgstr ""
+"The <a href=\"//archive.org\">Internet Archive</a> is proud to be distributing over 1 "
+"million 책 free in a format called DAISY, designed for those of us who find it "
+"challenging to use regular printed media. "
+
+#: books/daisy.html
+msgid ""
+"There are two types of DAISYs on Open Library: <i>open</i> and <i>protected</i>. Open "
+"DAISYs can be read by anyone in the world on many different devices. Protected DAISYs "
+"can only be opened using a key issued by the <a "
+"href=\"http://www.loc.gov/nls/\">Library of Congress NLS program</a>."
+msgstr ""
+"다음이 있습니다: two types of DAISYs on Open Library: <i>open</i> and <i>protected</i>. Open "
+"DAISYs 할 수 있습니다 read by anyone in the world on many different devices. Protected DAISYs"
+" can only be opened using a key issued by the <a "
+"href=\"http://www.loc.gov/nls/\">Library of Congress NLS program</a>."
+
+#: books/daisy.html lists/home.html
+msgid "Enjoy!"
+msgstr "즐기세요!"
+
+#: books/daisy.html
+msgid "What is the DAISY format?"
+msgstr "DAISY 형식이란 무엇인가요?"
+
+#: books/daisy.html
+msgid ""
+"The DAISY digital format helps people who have challenges using regular printed media. "
+"DAISY digital <span class=\"highlight\">talking books</span> offer the benefits of "
+"regular audiobooks, with navigation within the book, to chapters or specific pages."
+msgstr ""
+"The DAISY digital format helps people who have challenges using regular printed media. "
+"DAISY digital <span class=\"highlight\">talking 책</span> offer the benefits of regular "
+"audio책, with navigation within the 책, to chapters or specific 페이지s."
+
+#: books/daisy.html
+msgid "More information at daisy.org"
+msgstr "자세한 정보는 daisy.org에서 확인하세요"
+
+#: books/daisy.html
+msgid "What is the NLS?"
+msgstr "NLS란 무엇인가요?"
+
+#: books/daisy.html
+msgid ""
+"The Library of Congress <a href=\"http://www.loc.gov/nls/\">National Library Service "
+"for the Blind and Physically Handicapped (NLS)</a> administers a free library program "
+"of braille and audio materials circulated to eligible borrowers in the United States "
+"through a national network of cooperating libraries."
+msgstr ""
+"The Library of Congress <a href=\"http://www.loc.gov/nls/\">National Library Service "
+"for the Blind and Physically Handicapped (NLS)</a> administers a free library program "
+"of braille and audio materials circulated to eligible 대출ers in the United States "
+"through a national net작품 of cooperating libraries."
+
+#: books/daisy.html
+msgid "Are you eligible to register?"
+msgstr "등록 자격이 있나요?"
+
+#: books/daisy.html
+msgid "How do I find DAISYs on Open Library?"
+msgstr "Open Library에서 DAISY를 어떻게 찾나요?"
+
+#: books/daisy.html
+msgid ""
+"In addition to<a href=\"/subjects/accessible_book\" title=\"Subject: Accessible book\">"
+" loads of open DAISYs</a>, the Open Library lists a smaller selection of<a "
+"href=\"/subjects/protected_DAISY\" title=\"Subject: Protected DAISY\"> protected DAISY "
+"titles</a> accessible to those with a Library of Congress NLS key. These titles are "
+"brought to you by the<a href=\"//archive.org/\"> Internet Archive</a>."
+msgstr ""
+"In 추가ition to<a href=\"/주제/accessible_책\" title=\"Subject: Accessible 책\"> loads of "
+"open DAISYs</a>, the Open Library 목록 a smaller selection of<a "
+"href=\"/주제/protected_DAISY\" title=\"Subject: Protected DAISY\"> protected DAISY "
+"titles</a> accessible to those with a Library of Congress NLS key. These titles are "
+"brought to you by the<a href=\"//archive.org/\"> Internet Archive</a>."
+
+#: books/daisy.html
+msgid ""
+"Looking for a specific title? The best way to find it is to<a href=\"/search\"> search "
+"for it</a>."
+msgstr ""
+"Looking for a specific title? The best way to find it is to<a href=\"/검색\"> 검색 for "
+"it</a>."
+
+#: books/daisy.html lib/exports.html
+msgid "Need help?"
+msgstr "도움이 필요하신가요?"
+
+#: books/daisy.html
+msgid " Please read our <a href=\"/help/faq\">FAQ on accessing books through Open Library</a>."
+msgstr " 다음 read our <a href=\"/help/faq\">FAQ on accessing 책 through Open Library</a>."
+
+#: books/edit.html
+msgid "Add a little more?"
+msgstr "a little more? 추가"
+
+#: books/edit.html
+msgid ""
+"Thank you for adding that book! Any more information you could provide would be "
+"wonderful!"
+msgstr "Thank you for 추가ing that 책! Any more information you could provide would be wonderful!"
+
+#: books/edit.html
+#, python-format
+msgid ""
+"We already know about <b>%(work_title)s</b>, but not the <b>%(year)s %(publisher)s "
+"edition</b>. Thanks! Do you know any more about this edition?"
+msgstr ""
+"We already know about <b>%(work_title)s</b>, but not the <b>%(year)s %(publisher)s "
+"판본</b>. Thanks! 알고 있나요 any more about this 판본?"
+
+#: books/edit.html
+#, python-format
+msgid ""
+"We already know about the <b>%(year)s %(publisher)s edition</b> of "
+"<b>%(work_title)s</b>, but please, tell us more!"
+msgstr ""
+"We already know about the <b>%(year)s %(publisher)s 판본</b> of <b>%(work_title)s</b>, "
+"but please, tell us more!"
+
+#: books/edit.html
+msgid "Editing..."
+msgstr "편집 중..."
+
+#: books/edit.html type/author/edit.html type/tag/form.html type/template/edit.html
+msgid "Delete Record"
+msgstr "레코드 삭제"
+
+#: books/edit.html
+msgid "Work Details"
+msgstr "작품 세부 정보"
+
+#: books/edit.html
+msgid "Unknown publisher edition"
+msgstr "알 수 없는 publisher edition"
+
+#: books/edit.html
+msgid "This Work"
+msgstr "이 작품"
+
+#: books/edit.html
+msgid ""
+"You can search by author name (like <em>j k rowling</em>) or by Open Library ID (like "
+"<a href=\"/authors/OL23919A\" target=\"_blank\" rel=\"noopener "
+"noreferrer\"><em>OL23919A</em></a>)."
+msgstr ""
+"You can 검색 by 저자 name (like <em>j k rowling</em>) or by Open Library ID (like <a "
+"href=\"/저자/OL23919A\" target=\"_blank\" rel=\"noopener "
+"noreferrer\"><em>OL23919A</em></a>)."
+
+#: books/edit.html
+msgid "Author editing requires javascript"
+msgstr "저자 편집에는 JavaScript가 필요합니다"
+
+#: books/edit.html
+msgid "Add Excerpts"
+msgstr "Excerpts 추가"
+
+#: books/edit.html type/about/edit.html type/author/edit.html
+msgid "Links"
+msgstr "링크"
+
+#: books/edit.html
+msgid "Work Series"
+msgstr "작품 시리즈"
+
+#: books/edit.html
+msgid ""
+"Series are currently in beta, and this section is only visible to super librarians and "
+"admins, like you! Any series you set will be visible by everyone, however. Please "
+"report any issues you have on Slack or GitHub."
+msgstr ""
+"Series are currently in beta, and this section is only visible to super librarians and "
+"admins, like you! Any series you set 됩니다 visible by everyone, however. 다음 report any "
+"issues you have on Slack or GitHub."
+
+#: books/edit.html
+msgid "Is this work part of a larger series?"
+msgstr "Is this 작품 part of a larger series?"
+
+#: books/edit.html
+msgid "E.g. Harry Potter, The Sword of Truth"
+msgstr "예: Harry Potter, The Sword of Truth"
+
+#: books/edit.html type/edition/view.html type/work/view.html
+msgid "Work Identifiers"
+msgstr "작품 식별자"
+
+#: books/edit.html
+msgid "Do you know any identifiers for this work?"
+msgstr "알고 있나요 any identifiers 이 작품에 대해?"
+
+#: books/edit.html
+msgid ""
+"These identifiers apply to all editions of this work, for example Wikidata work "
+"identifiers. For edition-specific identifiers, like ISBN or LCCN, go to the edition "
+"tab."
+msgstr ""
+"These identifiers apply to all 판본 of this 작품, for example Wikidata 작품 identifiers. For "
+"판본-specific identifiers, like ISBN or LCCN, go to the 판본 tab."
+
+#: FulltextSearchSuggestionItem.html IABook.html SearchResultsWork.html
+#: books/edition-sort.html jsdef/LazyWorkPreview.html lists/list_overview.html
+#: lists/preview.html lists/snippet.html lists/widget.html my_books/dropdown_content.html
+#: type/work/editions.html
+#, python-format
+msgid "Cover of: %(title)s"
+msgstr "%(title)s의 표지"
+
+#: books/edition-sort.html
+#, python-format
+msgid "%(title)s: %(subtitle)s"
+msgstr "%(title)s: %(subtitle)s"
+
+#: books/edition-sort.html
+#, python-format
+msgid "Publish date unknown, %(publisher)s"
+msgstr "Publish date 알 수 없음, %(publisher)s"
+
+#: books/edition-sort.html type/work/editions.html
+#, python-format
+msgid "in %(languagelist)s"
+msgstr "%(languagelist)s로"
+
+#: SearchNavigation.html books/mybooks_breadcrumb_select.html lib/nav_foot.html
+#: openlibrary/plugins/upstream/mybooks.py
+msgid "Books"
+msgstr "책"
+
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#, python-format
+msgid "Want to Read (%(count)d)"
+msgstr "읽고 싶어요 (%(count)d)"
+
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#, python-format
+msgid "Currently Reading (%(count)d)"
+msgstr "읽는 중 (%(count)d)"
+
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#, python-format
+msgid "Already Read (%(count)d)"
+msgstr "이미 읽음 (%(count)d)"
+
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/openlibrary/lists.py
+#, python-format
+msgid "Lists (%(count)d)"
+msgstr "목록 (%(count)d)"
+
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#: type/edition/modal_links.html
+msgid "Notes"
+msgstr "노트"
+
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
+msgid "Imports and Exports"
+msgstr "가져오기 및 내보내기"
+
+#: books/series-autocomplete.html
+msgid "Add a new series"
+msgstr "새 series 추가"
+
+#: books/series-autocomplete.html
+msgid "Series name"
+msgstr "시리즈 이름"
+
+#: books/series-autocomplete.html
+msgid "Series position"
+msgstr "시리즈 위치"
+
+#: books/series-autocomplete.html
+msgid "Remove this series"
+msgstr "this series 제거"
+
+#: books/series-autocomplete.html
+msgid "Add another series?"
+msgstr "another series? 추가"
+
+#: books/edit/about.html
+msgid "Select this subject"
+msgstr "이 주제 선택"
+
+#: books/edit/about.html
+msgid "How would you describe this book?"
+msgstr "How would you describe 이 책?"
+
+#: books/edit/about.html
+msgid "There's no wrong answer here."
+msgstr "여기에 틀린 답은 없습니다."
+
+#: books/edit/about.html
+msgid "Subject keywords?"
+msgstr "주제 키워드?"
+
+#: books/edit/about.html
+msgid "Please separate with commas."
+msgstr "쉼표로 구분해 주세요."
+
+#: books/edit/about.html
+msgid ""
+"For example: <i><a href=\"/subjects/cheese\">cheese</a>, <a "
+"href=\"/subjects/roman_empire\">Roman Empire</a>, <a "
+"href=\"/subjects/psychology\">psychology</a></i>"
+msgstr ""
+"For example: <i><a href=\"/주제/cheese\">cheese</a>, <a href=\"/주제/roman_empire\">Roman "
+"Empire</a>, <a href=\"/주제/psychology\">psychology</a></i>"
+
+#: books/edit/about.html
+msgid "A person? Or, people?"
+msgstr "인물인가요? 여러 사람인가요?"
+
+#: books/edit/about.html
+msgid ""
+"For example: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore Roosevelt</a>,"
+" <a href=\"/subjects/person:Julian_of_Norwich\">Julian of Norwich</a>, <a "
+"href=\"/subjects/person:Tintin\">Tintin</a></i>"
+msgstr ""
+"For example: <i><a href=\"/주제/person:Theodore_Roosevelt\">Theodore Roosevelt</a>, <a "
+"href=\"/주제/person:Julian_of_Norwich\">Julian of Norwich</a>, <a "
+"href=\"/주제/person:Tintin\">Tintin</a></i>"
+
+#: books/edit/about.html
+msgid "Note any places mentioned?"
+msgstr "언급된 장소가 있나요?"
+
+#: books/edit/about.html
+msgid ""
+"For example: <i><a href=\"/subjects/place:London\">London</a>, <a "
+"href=\"/subjects/place:Atlantis\">Atlantis</a>, <a "
+"href=\"/subjects/place:Omaha\">Omaha</a></i>"
+msgstr ""
+"For example: <i><a href=\"/주제/place:London\">London</a>, <a "
+"href=\"/주제/place:Atlantis\">Atlantis</a>, <a href=\"/주제/place:Omaha\">Omaha</a></i>"
+
+#: books/edit/about.html
+msgid "When is it set or about?"
+msgstr "배경이나 주제가 되는 시기는 언제인가요?"
+
+#: books/edit/about.html
+msgid ""
+"For example: <i><a href=\"/subjects/time:1984\">1984</a>, <a "
+"href=\"/subjects/time:the_middle_ages\">The Middle Ages</a>, <a "
+"href=\"/subjects/time:1810-1890\">1810-1890</a></i>"
+msgstr ""
+"For example: <i><a href=\"/주제/time:1984\">1984</a>, <a "
+"href=\"/주제/time:the_middle_ages\">The Middle Ages</a>, <a "
+"href=\"/주제/time:1810-1890\">1810-1890</a></i>"
+
+#: books/edit/edition.html
+msgid "Select this language"
+msgstr "이 언어 선택"
+
+#: books/edit/edition.html
+msgid "Remove this language"
+msgstr "this language 제거"
+
+#: books/edit/edition.html
+msgid "Remove this work"
+msgstr "this work 제거"
+
+#: books/edit/edition.html
+msgid "-- Move to a new work"
+msgstr "-- 새 작품으로 이동"
+
+#: books/edit/edition.html
+msgid "This Edition"
+msgstr "이 판본"
+
+#: books/edit/edition.html
+msgid "Enter the title of this specific edition."
+msgstr "Enter the title of this specific 판본."
+
+#: books/edit/edition.html
+msgid "Subtitle"
+msgstr "부제"
+
+#: books/edit/edition.html
+msgid "Usually distinguished by different or smaller type."
+msgstr "보통 다른 글꼴이나 더 작은 글꼴로 구분됩니다."
+
+#: books/edit/edition.html
+msgid "For example: <i>envisioning the next 50 years</i>"
+msgstr "예: <i>envisioning the next 50 years</i>"
+
+#: books/edit/edition.html
+msgid "Publishing Info"
+msgstr "출판 정보"
+
+#: books/edit/edition.html
+msgid "For example <em>Oxford University Press; Penguin; W.W. Norton</em>"
+msgstr "예: <em>Oxford University Press; Penguin; W.W. Norton</em>"
+
+#: books/edit/edition.html
+msgid "Where was the book published?"
+msgstr "Where was the 책 published?"
+
+#: books/edit/edition.html
+msgid "City, Country please."
+msgstr "도시, 국가를 입력해 주세요."
+
+#: books/edit/edition.html
+msgid "For example: <i>New York, USA; Sydney, Australia</i>"
+msgstr "예: <i>New York, USA; Sydney, Australia</i>"
+
+#: books/edit/edition.html
+msgid "What is the copyright date?"
+msgstr "저작권 날짜는 언제인가요?"
+
+#: books/edit/edition.html
+msgid "The year following the copyright statement."
+msgstr "저작권 표시 뒤에 나오는 연도입니다."
+
+#: books/edit/edition.html
+msgid "Edition Name (if applicable):"
+msgstr "편집ion Name (if applicable):"
+
+#: books/edit/edition.html
+msgid "For example: <i>Centennial edition</i>; <i>First edition</i>"
+msgstr "For example: <i>Centennial 판본</i>; <i>First 판본</i>"
+
+#: books/edit/edition.html
+msgid "Series Name (if applicable)"
+msgstr "시리즈 이름(해당하는 경우)"
+
+#: books/edit/edition.html
+msgid "The name of the publisher's series."
+msgstr "The name of the 출판사's series."
+
+#: books/edit/edition.html
+msgid "For example: <i>The Story of Civilization, Part III</i>"
+msgstr "예: <i>The Story of Civilization, Part III</i>"
+
+#: books/edit/edition.html type/edition/view.html type/work/view.html
+msgid "Contributors"
+msgstr "기여자"
+
+#: books/edit/edition.html
+msgid "Please select a role."
+msgstr "역할을 선택해 주세요."
+
+#: books/edit/edition.html
+msgid "You need to give this ROLE a name."
+msgstr "이 역할에 이름을 지정해야 합니다."
+
+#: books/edit/edition.html
+msgid "List the people involved"
+msgstr "관련된 사람들을 나열하세요"
+
+#: books/edit/edition.html
+msgid "Select role"
+msgstr "역할 선택"
+
+#: books/edit/edition.html
+msgid "Add a new role"
+msgstr "새 role 추가"
+
+#: books/edit/edition.html
+msgid "Remove this contributor"
+msgstr "this contributor 제거"
+
+#: books/edit/edition.html
+msgid "By Statement:"
+msgstr "저자/기여 표시:"
+
+#: books/edit/edition.html
+msgid "For example: <em>edited by David Anderson</em>"
+msgstr "For example: <em>편집ed by David Anderson</em>"
+
+#: books/edit/edition.html languages/index.html
+msgid "Languages"
+msgstr "언어"
+
+#: books/edit/edition.html
+msgid "What language is this edition written in?"
+msgstr "What language is this 판본 written in?"
+
+#: books/edit/edition.html
+msgid "Add another language?"
+msgstr "another language? 추가"
+
+#: books/edit/edition.html
+msgid "Is it a translation of another book?"
+msgstr "Is it a translation of another 책?"
+
+#: books/edit/edition.html
+msgid "Yes, it's a translation"
+msgstr "예, 번역본입니다"
+
+#: books/edit/edition.html
+msgid "What's the original book?"
+msgstr "What's the original 책?"
+
+#: books/edit/edition.html
+msgid "What language was the original written in?"
+msgstr "원본은 어떤 언어로 쓰였나요?"
+
+#: books/edit/edition.html
+msgid "Description of this edition"
+msgstr "이 판본의 설명"
+
+#: books/edit/edition.html
+msgid "Only if it's different from the work's description"
+msgstr "Only if it's different from the 작품's description"
+
+#: books/edit/edition.html type/edition/view.html type/work/view.html
+msgid "Table of Contents"
+msgstr "목차"
+
+#: books/edit/edition.html
+msgid ""
+"Use a \"*\" for an indent, a \"|\" to add a column, and line breaks for new lines. Like"
+" this:"
+msgstr ""
+"Use a \"*\" for an indent, a \"|\" 추가하려면 a column, and line breaks for new lines. Like "
+"this:"
+
+#: books/edit/edition.html
+msgid ""
+"This table of contents contains extra information like authors or descriptions. We "
+"don't have a great user interface for this yet, so editing this data could be "
+"difficult. Watch out!"
+msgstr ""
+"This table of contents contains extra information like 저자 or descriptions. We don't "
+"have a great user interface for this yet, so 편집ing this data could be difficult. Watch "
+"out!"
+
+#: books/edit/edition.html
+msgid "Any notes about this specific edition?"
+msgstr "Any notes about this specific 판본?"
+
+#: books/edit/edition.html
+msgid "Anything about the book that may be of interest."
+msgstr "Anything about the 책 that may be of interest."
+
+#: books/edit/edition.html
+msgid "A Plume Book"
+msgstr "A Plume Book"
+
+#: books/edit/edition.html
+msgid "Is it known by any other titles?"
+msgstr "다른 제목으로도 알려져 있나요?"
+
+#: books/edit/edition.html
+msgid ""
+"Use this field if the title is different on the cover or spine. If the edition is a "
+"collection or anthology, you may also add the individual titles of each work here."
+msgstr ""
+"Use this field if the title is different on the cover or spine. If the 판본 is a "
+"collection or anthology, you may also 추가 the individual titles of each 작품 here."
+
+#: books/edit/edition.html
+msgid ""
+"For example: <i>Eaters of the Dead</i> is an alternate title for <i><a "
+"href=\"/books/OL24923038M\">The 13th Warrior</a></i>."
+msgstr ""
+"For example: <i>Eaters of the Dead</i> is an alternate title for <i><a "
+"href=\"/책/OL24923038M\">The 13th Warrior</a></i>."
+
+#: books/edit/edition.html
+msgid "What work is this an edition of?"
+msgstr "What 작품 is this an 판본 of?"
+
+#: books/edit/edition.html
+msgid "Sometimes editions can be associated with the wrong work. You can correct that here."
+msgstr "Sometimes 판본 할 수 있습니다 associated with the wrong 작품. You can correct that here."
+
+#: books/edit/edition.html
+msgid ""
+"You can search by title or by Open Library ID (like <a href=\"/works/OL262757W\" "
+"target=\"_blank\" rel=\"noopener noreferrer\"><em>OL262757W</em></a>)."
+msgstr ""
+"You can 검색 by title or by Open Library ID (like <a href=\"/작품/OL262757W\" "
+"target=\"_blank\" rel=\"noopener noreferrer\"><em>OL262757W</em></a>)."
+
+#: books/edit/edition.html
+msgid "WARNING: Any edits made to the work from this page will be ignored."
+msgstr "WARNING: Any 편집s made to the 작품 from this 페이지 됩니다 ignored."
+
+#: books/edit/edition.html
+msgid "Copy authors to new work"
+msgstr "저자를 새 작품으로 복사"
+
+#: books/edit/edition.html
+msgid "Copy subjects to new work"
+msgstr "주제를 새 작품으로 복사"
+
+#: books/edit/edition.html
+msgid "Please select an identifier."
+msgstr "식별자를 선택해 주세요."
+
+#: books/edit/edition.html
+msgid "You need to give a value to ID."
+msgstr "ID 값을 입력해야 합니다."
+
+#: books/edit/edition.html
+msgid "ID ids cannot contain whitespace."
+msgstr "ID에는 공백을 포함할 수 없습니다."
+
+#: books/edit/edition.html
+msgid "ID must be exactly 10 characters [0-9] or X."
+msgstr "ID는 정확히 10자[0-9] 또는 X여야 합니다."
+
+#: books/edit/edition.html
+msgid "That ID already exists for this edition."
+msgstr "That ID already exists 이 판본에 대해."
+
+#: books/edit/edition.html
+msgid "ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4"
+msgstr "ID는 정확히 13자리 숫자[0-9]여야 합니다. 예: 978-1-56619-909-4"
+
+#: books/edit/edition.html
+msgid "Invalid ID format"
+msgstr "잘못된 ID 형식"
+
+#: books/edit/edition.html type/author/view.html
+msgid "ID Numbers"
+msgstr "ID 번호"
+
+#: books/edit/edition.html
+msgid "Do you know any identifiers for this edition?"
+msgstr "알고 있나요 any identifiers 이 판본에 대해?"
+
+#: books/edit/edition.html
+msgid "Like, ISBN?"
+msgstr "예: ISBN?"
+
+#: books/edit/edition.html
+msgid "Please select a classification."
+msgstr "분류를 선택해 주세요."
+
+#: books/edit/edition.html
+msgid "You need to give a value to CLASS."
+msgstr "CLASS 값을 입력해야 합니다."
+
+#: books/edit/edition.html type/edition/view.html type/work/view.html
+msgid "Classifications"
+msgstr "분류"
+
+#: books/edit/edition.html
+msgid "Do you know any classifications of this edition?"
+msgstr "알고 있나요 any classifications of this 판본?"
+
+#: books/edit/edition.html
+msgid "Like, Dewey Decimal?"
+msgstr "예: 듀이 십진분류?"
+
+#: books/edit/edition.html
+msgid "Select one of many..."
+msgstr "여러 항목 중 하나 선택..."
+
+#: books/edit/edition.html
+msgid "Add a new classification type"
+msgstr "새 classification type 추가"
+
+#: books/edit/edition.html
+msgid "Remove this classification"
+msgstr "this classification 제거"
+
+#: books/edit/edition.html type/edition/view.html type/work/view.html
+msgid "The Physical Object"
+msgstr "물리적 객체"
+
+#: books/edit/edition.html
+msgid "What sort of book is it?"
+msgstr "What sort of 책 is it?"
+
+#: books/edit/edition.html
+msgid "Paperback; Hardcover, etc."
+msgstr "페이퍼백, 하드커버 등"
+
+#: books/edit/edition.html
+msgid "How many pages?"
+msgstr "How many 페이지s?"
+
+#: books/edit/edition.html
+msgid "Pagination?"
+msgstr "페이지 매김?"
+
+#: books/edit/edition.html
+msgid "Note the highest number in each pagination pattern."
+msgstr "각 페이지 매김 패턴에서 가장 높은 번호를 적어 주세요."
+
+#: books/edit/edition.html lib/nav_foot.html
+msgid "Help"
+msgstr "도움말"
+
+#: books/edit/edition.html
+msgid "For example: <em>xii, 346p.</em>"
+msgstr "예: <em>xii, 346p.</em>"
+
+#: books/edit/edition.html
+msgid "How much does the book weigh?"
+msgstr "How much does the 책 weigh?"
+
+#: books/edit/edition.html type/edition/view.html type/work/view.html
+msgid "Dimensions"
+msgstr "크기"
+
+#: books/edit/edition.html
+msgid "dimensions"
+msgstr "크기"
+
+#: books/edit/edition.html
+msgid "Height:"
+msgstr "높이:"
+
+#: books/edit/edition.html
+msgid "Width:"
+msgstr "너비:"
+
+#: books/edit/edition.html
+msgid "Depth:"
+msgstr "두께:"
+
+#: books/edit/edition.html
+msgid "Web Book Providers"
+msgstr "웹 책 제공자"
+
+#: books/edit/edition.html
+msgid "Access Type"
+msgstr "접근 유형"
+
+#: books/edit/edition.html
+msgid "File Format"
+msgstr "파일 형식"
+
+#: books/edit/edition.html
+msgid "Provider Name"
+msgstr "제공자 이름"
+
+#: books/edit/edition.html
+msgid "Buy"
+msgstr "구매"
+
+#: books/edit/edition.html
+msgid "Web"
+msgstr "웹"
+
+#: books/edit/edition.html
+msgid "Add a provider"
+msgstr "a provider 추가"
+
+#: books/edit/edition.html
+msgid "First sentence"
+msgstr "첫 문장"
+
+#: books/edit/edition.html
+msgid "The opening line that starts the lead paragraph"
+msgstr "첫 단락을 시작하는 첫 문장입니다"
+
+#: books/edit/edition.html
+msgid "Admin Only"
+msgstr "관리자 전용"
+
+#: books/edit/edition.html
+msgid "Additional Metadata"
+msgstr "추가 메타데이터"
+
+#: books/edit/edition.html
+msgid "This field can accept arbitrary key:value pairs"
+msgstr "이 필드는 임의의 key:value 쌍을 받을 수 있습니다"
+
+#: books/edit/excerpts.html
+msgid "Please provide an excerpt."
+msgstr "발췌문을 입력해 주세요."
+
+#: books/edit/excerpts.html
+msgid "That excerpt is too long."
+msgstr "발췌문이 너무 깁니다."
+
+#: books/edit/excerpts.html
+msgid ""
+"If there are particular (short) passages you feel represent the book well, please feel "
+"free to transcribe them here."
+msgstr ""
+"If there are particular (short) passages you feel represent the 책 well, please feel "
+"free to transcribe them here."
+
+#: books/edit/excerpts.html
+msgid "Page number?"
+msgstr "페이지 번호?"
+
+#: books/edit/excerpts.html
+msgid "For example: <i>23, xi or 433-434</i>"
+msgstr "For example: <i>23, xi or 433-434</i>"
+
+#: books/edit/excerpts.html
+msgid "This excerpt is the first sentence of the book."
+msgstr "This excerpt is the first sentence of the 책."
+
+#: books/edit/excerpts.html
+msgid "Transcribe the excerpt"
+msgstr "발췌문 옮겨 적기"
+
+#: books/edit/excerpts.html
+msgid "Maximum length is 2000 characters. No HTML allowed."
+msgstr "최대 길이는 2000자입니다. HTML은 허용되지 않습니다."
+
+#: books/edit/excerpts.html
+msgid "Why did you choose this excerpt?"
+msgstr "왜 이 발췌문을 선택했나요?"
+
+#: books/edit/excerpts.html
+msgid "Add an optional note."
+msgstr "an optional note. 추가"
+
+#: books/edit/excerpts.html
+msgid "Excerpts so far..."
+msgstr "지금까지의 발췌문..."
+
+#: books/edit/excerpts.html
+msgid "noted:"
+msgstr "메모:"
+
+#: books/edit/excerpts.html
+msgid "An anonymous note:"
+msgstr "익명 메모:"
+
+#: books/edit/excerpts.html
+msgid "From page"
+msgstr "페이지:"
+
+#: books/edit/web.html
+msgid "Please provide a label."
+msgstr "라벨을 입력해 주세요."
+
+#: books/edit/web.html
+msgid "Please provide a URL."
+msgstr "URL을 입력해 주세요."
+
+#: books/edit/web.html
+msgid "Please enter a valid URL."
+msgstr "유효한 URL을 입력해 주세요."
+
+#: books/edit/web.html
+msgid ""
+"Please connect Open Library records to <u>good</u><span class=\"orange\">*</span> "
+"online resources."
+msgstr ""
+"다음 connect Open Library 레코드s to <u>good</u><span class=\"orange\">*</span> online "
+"resources."
+
+#: books/edit/web.html
+msgid "Give your link a label"
+msgstr "링크에 라벨 지정"
+
+#: books/edit/web.html
+msgid "For example: <em>New York Times review</em>"
+msgstr "For example: <em>New York Times 리뷰</em>"
+
+#: books/edit/web.html
+msgid "URL"
+msgstr "URL"
+
+#: books/edit/web.html
+msgid "Add Link"
+msgstr "Link 추가"
+
+#: books/edit/web.html
+msgid "Remove this link"
+msgstr "this link 제거"
+
+#: books/edit/web.html
+msgid ""
+"\"Good\" means no spammy links, please. Keep them relevant to the book. Irrelevant "
+"sites may be removed. Blatant spam will be deleted without remorse."
+msgstr ""
+"\"Good\" means no spammy links, please. Keep them relevant to the 책. Irrelevant sites "
+"may be 제거d. Blatant spam 됩니다 삭제d without remorse."
+
+#: bulk_search/bulk_search.html search/advancedsearch.html
+msgid "Bulk Search (beta)"
+msgstr "Bulk 검색 (beta)"
+
+#: covers/add.html
+msgid "There are two ways to put an author's image on Open Library."
+msgstr "다음이 있습니다: two ways to put an 저자's image on Open Library."
+
+#: covers/add.html
+msgid "Image Guidelines"
+msgstr "이미지 가이드라인"
+
+#: covers/add.html
+msgid "There are a few ways to put a cover image on Open Library."
+msgstr "다음이 있습니다: a few ways to put a cover image on Open Library."
+
+#: covers/add.html
+msgid "Cover Guidelines"
+msgstr "표지 가이드라인"
+
+#: covers/add.html
+msgid "Please provide a valid image."
+msgstr "유효한 이미지를 제공해 주세요."
+
+#: covers/add.html
+msgid "Please provide an image URL."
+msgstr "이미지 URL을 입력해 주세요."
+
+#: covers/add.html
+#, python-format
+msgid ""
+"Learn more by reading our <a href=\"/help/faq/editing#picture\" "
+"target=\"blank\">%(guidelines)s</a>."
+msgstr ""
+"Learn more by reading our <a href=\"/help/faq/편집ing#picture\" "
+"target=\"blank\">%(guidelines)s</a>."
+
+#: covers/add.html
+msgid "<strong>Pick one</strong> from the existing covers"
+msgstr "기존 표지 중에서 <strong>하나를 선택</strong>하세요"
+
+#: covers/add.html
+msgid "Use this image"
+msgstr "이 이미지 사용"
+
+#: covers/add.html
+msgid "Choose a JPG, GIF, PNG or WebP on your computer"
+msgstr "컴퓨터에서 JPG, GIF, PNG 또는 WebP를 선택하세요"
+
+#: covers/add.html
+msgid "Upload"
+msgstr "Upload"
+
+#: covers/add.html
+msgid "Or, paste an image from your clipboard"
+msgstr "또는 클립보드에서 이미지를 붙여넣으세요"
+
+#: covers/add.html
+msgid "Paste image from clipboard"
+msgstr "클립보드에서 이미지 붙여넣기"
+
+#: covers/add.html
+msgid "Paste Image"
+msgstr "이미지 붙여넣기"
+
+#: covers/add.html
+msgid "Upload image"
+msgstr "이미지 업로드"
+
+#: covers/add.html covers/external_image.html
+msgid "Upload Image"
+msgstr "이미지 업로드"
+
+#: covers/add.html
+msgid "Uploading..."
+msgstr "업로드 중..."
+
+#: covers/add.html
+msgid "Wikidata"
+msgstr "Wikidata"
+
+#: covers/author_photo.html
+msgid "Pull up a larger author photo"
+msgstr "더 큰 저자 사진 보기"
+
+#: covers/author_photo.html search/authors.html
+#, python-format
+msgid "Photo of %(author)s"
+msgstr "%(author)s의 사진"
+
+#: covers/author_photo.html
+msgid "Click to close"
+msgstr "클릭하여 닫기"
+
+#: covers/author_photo.html
+#, python-format
+msgid "We need a photo of %(author)s"
+msgstr "%(author)s의 사진이 필요합니다"
+
+#: covers/book_cover.html
+msgid "Pull up a bigger book cover"
+msgstr "더 큰 책 표지 보기"
+
+#: covers/book_cover.html covers/book_cover_small.html
+#, python-format
+msgid "Cover of: %(title)s by %(authors)s"
+msgstr "%(authors)s의 %(title)s 표지"
+
+#: covers/book_cover_small.html
+#, python-format
+msgid "Go to the main page for %(title)s"
+msgstr "the main page for %(title)s로 이동"
+
+#: covers/book_cover_small.html
+#, python-format
+msgid "We need a book cover for: %(title)s"
+msgstr "%(title)s의 책 표지가 필요합니다"
+
+#: covers/change.html
+msgid "Author Photos"
+msgstr "저자 사진"
+
+#: covers/change.html
+msgid "Manage Author Photos"
+msgstr "Author Photos 관리"
+
+#: covers/change.html
+msgid "Add Author Photo"
+msgstr "Author Photo 추가"
+
+#: covers/change.html
+msgid "Book Covers"
+msgstr "책 표지"
+
+#: covers/change.html
+msgid "Manage Covers"
+msgstr "Covers 관리"
+
+#: covers/change.html
+msgid "Add Cover Image"
+msgstr "Cover Image 추가"
+
+#: covers/change.html
+msgid "Manage"
+msgstr "관리"
+
+#: covers/external_image.html
+#, python-format
+msgid "Or, use an image from %s"
+msgstr "또는 %s의 이미지를 사용하세요"
+
+#: covers/manage.html
+msgid "You can drag and drop thumbnails to reorder, or into the trash to delete them."
+msgstr "You can drag and drop thumbnails to reorder, or into the trash to 삭제 them."
+
+#: covers/saved.html
+msgid "New book cover"
+msgstr "새 책 표지"
+
+#: covers/saved.html
+msgid "Saved!"
+msgstr "저장d!"
+
+#: covers/saved.html
+msgid "Notes:"
+msgstr "노트:"
+
+#: covers/saved.html
+msgid "Add another image"
+msgstr "another image 추가"
+
+#: covers/saved.html
+msgid "Finished"
+msgstr "완료"
+
+#: design/button.html merge/authors.html recentchanges/merge/view.html
+msgid "Primary"
+msgstr "기본"
+
+#: design/popover.html
+msgid "Popover component"
+msgstr "팝오버 컴포넌트"
+
+#: design/popover.html
+msgid ""
+"The ol-popover component provides a reusable animated popover panel anchored to a "
+"trigger element. It animates from the trigger using transform-origin, closes on Escape "
+"or outside click, and respects prefers-reduced-motion."
+msgstr ""
+"The ol-popover component provides a reusable animated popover panel anchored to a "
+"trigger element. It animates from the trigger using transform-origin, closes on Escape "
+"or outside click, and respects prefers-reduced-motion."
+
+#: design/popover.html
+msgid "Menu popover"
+msgstr "메뉴 팝오버"
+
+#: design/popover.html
+msgid ""
+"Popovers animate from the trigger using transform-origin. Click the button to see the "
+"scale + fade entrance."
+msgstr ""
+"Popovers animate from the trigger using transform-origin. Click the button to see the "
+"scale + fade entrance."
+
+#: design/popover.html
+msgid "Options"
+msgstr "옵션"
+
+#: design/popover.html
+msgid "Duplicate"
+msgstr "복제"
+
+#: design/popover.html
+msgid "Archive"
+msgstr "아카이브"
+
+#: design/popover.html
+msgid "Move"
+msgstr "이동"
+
+#: design/popover.html
+msgid "Placement options"
+msgstr "배치 옵션"
+
+#: design/popover.html
+#, python-format
+msgid ""
+"Use %(placement)s to control where the popover appears. The %(transform_origin)s "
+"automatically matches so the animation always expands from the trigger."
+msgstr ""
+"Use %(placement)s to control where the popover appears. The %(transform_origin)s "
+"automatically matches so the animation always expands from the trigger."
+
+#: design/popover.html
+msgid "bottom-start"
+msgstr "bottom-start"
+
+#: design/popover.html
+msgid "top-center"
+msgstr "top-center"
+
+#: email/case_created.html
+msgid "Sent!"
+msgstr "전송됨!"
+
+#: email/case_created.html
+msgid "Thank you for your note. We'll get back to you as soon as possible."
+msgstr "메모를 보내주셔서 감사합니다. 가능한 한 빨리 답변드리겠습니다."
+
+#: email/case_created.html
+msgid ""
+"It might take us a little while to read it because we receive lots of messages, but "
+"rest assured we will, and we'll get back to you if required."
+msgstr "메시지가 많아 읽는 데 시간이 조금 걸릴 수 있지만, 반드시 확인하겠습니다. 필요한 경우 답변드리겠습니다."
+
+#: email/account/pd_request.html
+msgid "Qualifying for Print Disability Special Access"
+msgstr "인쇄물 이용 장애 특별 접근 자격"
+
+#: history/sources.html
+msgid "record"
+msgstr "레코드"
+
+#: home/about.html
+msgid "About the Project"
+msgstr "프로젝트 소개"
+
+#: home/about.html
+msgid ""
+"Open Library is an open, editable library catalog, building towards a web page for "
+"every book ever published."
+msgstr ""
+"Open Library is an open, 편집able library catalog, building towards a web 페이지 for every 책"
+" ever published."
+
+#: AffiliateLinks.html home/about.html search/work_search_facets.html
+msgid "More"
+msgstr "더 보기"
+
+#: home/about.html
+msgid ""
+"Just like Wikipedia, you can contribute new information or corrections to the catalog. "
+"You can browse by <a href=\"/subjects\">subjects</a>, <a href=\"/authors\">authors</a> "
+"or <a href=\"/lists\">lists</a> members have created. If you love books, why not help "
+"build a library?"
+msgstr ""
+"Just like Wikipedia, you can contribute new information or corrections to the catalog. "
+"You can browse by <a href=\"/주제\">주제</a>, <a href=\"/저자\">저자</a> or <a "
+"href=\"/목록\">목록</a> members have 생성d. If you love 책, why not help build a library?"
+
+#: home/about.html
+msgid "Latest Blog Posts"
+msgstr "최신 블로그 글"
+
+#: home/categories.html
+msgid "Browse by Subject"
+msgstr "주제별 둘러보기"
+
+#: home/categories.html
+#, python-format
+msgid "%(count)s Book"
+msgid_plural "%(count)s Books"
+msgstr[0] "%(count)s권의 책"
+
+#: home/index.html home/welcome.html
+msgid "Welcome to Open Library"
+msgstr "Open Library에 오신 것을 환영합니다"
+
+#: home/index.html openlibrary/plugins/openlibrary/api.py
+msgid "Classic Books"
+msgstr "고전 도서"
+
+#: home/index.html
+msgid "Recently Returned"
+msgstr "최근 반납된 책"
+
+#: home/index.html openlibrary/plugins/openlibrary/api.py
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Romance"
+msgstr "로맨스"
+
+#: home/index.html openlibrary/plugins/openlibrary/api.py
+msgid "Kids"
+msgstr "어린이"
+
+#: home/index.html openlibrary/plugins/openlibrary/api.py
+msgid "Thrillers"
+msgstr "스릴러"
+
+#: home/index.html openlibrary/plugins/openlibrary/api.py
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Textbooks"
+msgstr "교과서"
+
+#: home/index.html
+msgid "Authors Alliance & MIT Press"
+msgstr "Authors Alliance & MIT Press"
+
+#: home/index.html
+msgid "Books in Local Environment"
+msgstr "로컬 환경의 책"
+
+#: home/loans.html
+#, python-format
+msgid ""
+"You can still <a href=\"/subjects/in_library#ebooks=true\">borrow</a> one more book "
+"until you've hit the limit!"
+msgid_plural ""
+"You can still <a href=\"/subjects/in_library#ebooks=true\">borrow</a> %(count)d more "
+"books until you've hit the limit!"
+msgstr[0] ""
+"한도에 도달하기 전까지 책을 %(count)d권 더 <a href=\"/subjects/in_library#ebooks=true\">대출</a>할 수 "
+"있습니다!"
+
+#: home/loans.html
+msgid "You have reached the borrowing limit. Please return a book to checkout something new."
+msgstr "당신은 reached the 대출ing limit. 다음 반납 a 책 to checkout something new."
+
+#: home/stats.html
+msgid "Around the Library"
+msgstr "도서관 둘러보기"
+
+#: home/stats.html
+msgid ""
+"Here's what's happened over the last 28 days. More <a href=\"/recentchanges\">recent "
+"changes</a>"
+msgstr "지난 28일 동안 있었던 일입니다. 더 많은 <a href=\"/recentchanges\">최근 변경 사항</a>"
+
+#: home/stats.html
+msgid "See all visitors to OpenLibrary.org"
+msgstr "OpenLibrary.org의 모든 방문자 보기"
+
+#: home/stats.html
+msgid "Area graph of recent unique visitors"
+msgstr "최근 고유 방문자 영역 그래프"
+
+#: home/stats.html
+msgid "How many new Open Library members have we welcomed?"
+msgstr "새 Open Library 회원은 몇 명이나 늘었나요?"
+
+#: home/stats.html
+msgid "Area graph of new members"
+msgstr "새 회원 영역 그래프"
+
+#: home/stats.html
+msgid "People are constantly updating the catalog"
+msgstr "사람들이 계속해서 카탈로그를 업데이트하고 있습니다"
+
+#: home/stats.html
+msgid "Area graph of recent catalog edits"
+msgstr "최근 카탈로그 편집 영역 그래프"
+
+#: home/stats.html
+msgid "Catalog Edits"
+msgstr "카탈로그 편집"
+
+#: home/stats.html
+msgid "Members can create Lists"
+msgstr "회원은 목록을 만들 수 있습니다"
+
+#: home/stats.html
+msgid "Area graph of lists created recently"
+msgstr "Area graph of 목록 생성d recently"
+
+#: home/stats.html
+msgid "Lists Created"
+msgstr "생성된 목록"
+
+#: home/stats.html
+msgid "We're a library, so we lend books, too"
+msgstr "We're a library, so we lend 책, too"
+
+#: home/stats.html
+msgid "Area graph of ebooks borrowed recently"
+msgstr "Area graph of e책 대출ed recently"
+
+#: home/stats.html
+msgid "eBooks Borrowed"
+msgstr "대출된 전자책"
+
+#: home/welcome.html
+msgid "Read Free Library Books Online"
+msgstr "무료 도서관 책을 온라인으로 읽기"
+
+#: home/welcome.html
+msgid "Millions of books available through Controlled Digital Lending"
+msgstr "Millions of 책 사용 가능 through Controlled Digital Lending"
+
+#: home/welcome.html
+msgid "Set a Yearly Reading Goal"
+msgstr "연간 독서 목표 설정"
+
+#: home/welcome.html
+msgid "Learn how to set a yearly reading goal and track what you read"
+msgstr "Learn how to set a yearly 독서 목표 and track what you read"
+
+#: home/welcome.html
+msgid "Keep Track of your Favorite Books"
+msgstr "좋아하는 책 기록하기"
+
+#: home/welcome.html
+msgid "Organize your Books using Lists & the Reading Log"
+msgstr "Organize your Books using Lists & the 독서 기록"
+
+#: home/welcome.html
+msgid "Try the virtual Library Explorer"
+msgstr "가상 라이브러리 탐색기 사용해 보기"
+
+#: home/welcome.html
+msgid "Digital shelves organized like a physical library"
+msgstr "실제 도서관처럼 정리된 디지털 서가"
+
+#: home/welcome.html
+msgid "Try Fulltext Search"
+msgstr "전문 검색 사용해 보기"
+
+#: home/welcome.html
+msgid "Find matching results within the text of millions of books"
+msgstr "Find matching results within the text of millions of 책"
+
+#: home/welcome.html
+msgid "Be an Open Librarian"
+msgstr "Open Librarian 되기"
+
+#: home/welcome.html
+msgid "Dozens of ways you can help improve the library"
+msgstr "도서관 개선을 도울 수 있는 수십 가지 방법"
+
+#: home/welcome.html
+msgid "Volunteer at Open Library"
+msgstr "Open Library에서 자원봉사하기"
+
+#: home/welcome.html
+msgid "Discover opportunities to improve the library"
+msgstr "도서관을 개선할 기회 찾아보기"
+
+#: home/welcome.html
+msgid "Send us feedback"
+msgstr "피드백 보내기"
+
+#: home/welcome.html
+msgid "Your feedback will help us improve these cards"
+msgstr "여러분의 피드백은 이 카드를 개선하는 데 도움이 됩니다"
+
+#: jsdef/LazyWorkPreview.html
+msgid "Select this work"
+msgstr "이 작품 선택"
+
+#: jsdef/LazyWorkPreview.html
+msgid "1 edition"
+msgstr "판본 1개"
+
+#: jsdef/LazyWorkPreview.html
+msgid "editions"
+msgstr "판본"
+
+#: languages/index.html
+#, python-format
+msgid "%s work"
+msgid_plural "%s works"
+msgstr[0] "%s 작품"
+
+#: languages/index.html
+#, python-format
+msgid "%s ebook edition"
+msgid_plural "%s ebook editions"
+msgstr[0] "%s 전자책 판본"
+
+#: languages/notfound.html
+#, python-format
+msgid "%s is not found"
+msgstr "%s을(를) 찾을 수 없습니다"
+
+#: languages/notfound.html
+#, python-format
+msgid "%s does not exist."
+msgstr "%s이(가) 존재하지 않습니다."
+
+#: lib/edit_head.html lib/view_head.html
+msgid "This doc was last edited by"
+msgstr "이 문서의 마지막 편집자:"
+
+#: lib/edit_head.html lib/view_head.html
+msgid "This doc was last edited anonymously"
+msgstr "This doc was last 편집ed anonymously"
+
+#: lib/exports.html
+msgid "Download catalog record:"
+msgstr "카탈로그 레코드 다운로드:"
+
+#: lib/exports.html
+msgid "RDF"
+msgstr "RDF"
+
+#: lib/exports.html type/list/exports.html
+msgid "JSON"
+msgstr "JSON"
+
+#: lib/exports.html
+msgid "OPDS"
+msgstr "OPDS"
+
+#: lib/exports.html
+msgid "Cite this on Wikipedia"
+msgstr "위키백과에서 이것을 인용"
+
+#: lib/exports.html
+msgid "Wikipedia citation"
+msgstr "위키백과 인용"
+
+#: lib/exports.html
+msgid "Copy and paste this code into your Wikipedia page."
+msgstr "Copy and paste this code into your Wikipedia 페이지."
+
+#: lib/exports.html
+msgid "Get instructions at Wikipedia in a new window"
+msgstr "새 창에서 위키백과 안내 보기"
+
+#: lib/header_dropdown.html
+msgid "My account"
+msgstr "내 계정"
+
+#: lib/header_dropdown.html type/user/view.html
+#, python-format
+msgid "Joined %(date)s"
+msgstr "가입일: %(date)s"
+
+#: lib/header_dropdown.html
+msgid "Menu"
+msgstr "메뉴"
+
+#: lib/header_dropdown.html
+msgid "New!"
+msgstr "새 항목!"
+
+#: lib/history.html
+#, python-format
+msgid "Created %(date)s"
+msgstr "생성일: %(date)s"
+
+#: lib/history.html
+#, python-format
+msgid "%(count)d revision"
+msgid_plural "%(count)d revisions"
+msgstr[0] "개정 %(count)d개"
+
+#: lib/history.html
+msgid "an anonymous user"
+msgstr "익명 사용자"
+
+#: lib/history.html
+#, python-format
+msgid "Created by %(user)s"
+msgstr "생성일: by %(user)s"
+
+#: lib/history.html
+#, python-format
+msgid "Edited by %(user)s"
+msgstr "%(user)s님이 편집함"
+
+#: lib/message_addbook.html
+msgid "Super!"
+msgstr "좋습니다!"
+
+#: lib/message_addbook.html
+msgid " Your new record is in the library. Thank you!"
+msgstr " Your new 레코드 is in the library. Thank you!"
+
+#: lib/message_addbook.html
+msgid ""
+"There are a few other simple things you can add while you're here to improve your new "
+"record quickly, and make it much easier for other people to find later."
+msgstr ""
+"다음이 있습니다: a few other simple things you can 추가 while you're here to improve your new "
+"레코드 quickly, and make it much easier for other people to find later."
+
+#: lib/message_addbook.html
+msgid "Upload a cover image"
+msgstr "표지 이미지 업로드"
+
+#: lib/message_addbook.html
+msgid "Snap a quick photo of the cover to share?"
+msgstr "공유할 표지 사진을 빠르게 찍어볼까요?"
+
+#: lib/message_addbook.html
+msgid "Add an ISBN"
+msgstr "an ISBN 추가"
+
+#: lib/message_addbook.html
+msgid "Help the library connect with other systems, like Amazon."
+msgstr "도서관이 Amazon 같은 다른 시스템과 연결되도록 도와주세요."
+
+#: lib/message_addbook.html
+msgid "Add some subjects"
+msgstr "some subjects 추가"
+
+#: lib/message_addbook.html
+msgid "They're just like tags."
+msgstr "태그와 같습니다."
+
+#: lib/message_addbook.html
+msgid "Describe what the book's about"
+msgstr "Describe what the 책's about"
+
+#: lib/message_addbook.html
+msgid "Just a sentence or two is good."
+msgstr "한두 문장이면 충분합니다."
+
+#: lib/nav_foot.html openlibrary/plugins/openlibrary/api.py site/head.html
+msgid "Open Library"
+msgstr "Open Library"
+
+#: lib/nav_foot.html
+msgid "Vision"
+msgstr "비전"
+
+#: lib/nav_foot.html
+msgid "Volunteer"
+msgstr "자원봉사"
+
+#: lib/nav_foot.html
+msgid "Partner With Us"
+msgstr "파트너가 되기"
+
+#: lib/nav_foot.html
+msgid "Jobs"
+msgstr "채용"
+
+#: lib/nav_foot.html
+msgid "Careers"
+msgstr "커리어"
+
+#: lib/nav_foot.html
+msgid "Blog"
+msgstr "블로그"
+
+#: lib/nav_foot.html
+msgid "Terms of Service"
+msgstr "서비스 약관"
+
+#: lib/nav_foot.html site/alert.html
+msgid "Donate"
+msgstr "기부"
+
+#: lib/nav_foot.html
+msgid "Discover"
+msgstr "발견"
+
+#: lib/nav_foot.html
+msgid "Go home"
+msgstr "홈으로 이동"
+
+#: lib/nav_foot.html
+msgid "Home"
+msgstr "홈"
+
+#: lib/nav_foot.html
+msgid "Explore Books"
+msgstr "Books 탐색"
+
+#: lib/nav_foot.html
+msgid "Explore authors"
+msgstr "authors 탐색"
+
+#: lib/nav_foot.html
+msgid "Explore subjects"
+msgstr "subjects 탐색"
+
+#: RelatedSubjects.html SearchNavigation.html SubjectTags.html lib/nav_foot.html
+#: lib/nav_head.html openlibrary/plugins/worksearch/code.py subjects/notfound.html
+#: type/author/view.html type/list/view_body.html
+msgid "Subjects"
+msgstr "주제"
+
+#: lib/nav_foot.html
+msgid "Explore collections"
+msgstr "collections 탐색"
+
+#: lib/nav_foot.html lib/nav_head.html
+msgid "Collections"
+msgstr "컬렉션"
+
+#: SearchNavigation.html lib/nav_foot.html lib/nav_head.html search/advancedsearch.html
+msgid "Advanced Search"
+msgstr "고급 검색"
+
+#: lib/nav_foot.html
+msgid "Navigate to top of this page"
+msgstr "이 페이지 맨 위로 이동"
+
+#: lib/nav_foot.html
+msgid "Return to Top"
+msgstr "맨 위로 돌아가기"
+
+#: lib/nav_foot.html
+msgid "Develop"
+msgstr "개발"
+
+#: lib/nav_foot.html
+msgid "Explore Open Library Developer Center"
+msgstr "Open Library Developer Center 탐색"
+
+#: lib/nav_foot.html lib/nav_head.html
+msgid "Developer Center"
+msgstr "개발자 센터"
+
+#: lib/nav_foot.html
+msgid "Explore Open Library APIs"
+msgstr "Open Library APIs 탐색"
+
+#: lib/nav_foot.html
+msgid "API Documentation"
+msgstr "API 문서"
+
+#: lib/nav_foot.html
+msgid "Bulk Open Library data"
+msgstr "Open Library 대량 데이터"
+
+#: lib/nav_foot.html
+msgid "Bulk Data Dumps"
+msgstr "대량 데이터 덤프"
+
+#: lib/nav_foot.html
+msgid "Write a bot"
+msgstr "봇 작성"
+
+#: lib/nav_foot.html
+msgid "Writing Bots"
+msgstr "봇 작성하기"
+
+#: lib/nav_foot.html
+msgid "Help Center"
+msgstr "도움말 센터"
+
+#: lib/nav_foot.html
+msgid "Contact"
+msgstr "문의"
+
+#: lib/nav_foot.html
+msgid "Contact Us"
+msgstr "문의하기"
+
+#: lib/nav_foot.html
+msgid "Suggest Edits"
+msgstr "편집 제안"
+
+#: lib/nav_foot.html
+msgid "Suggesting Edits"
+msgstr "편집 제안하기"
+
+#: lib/nav_foot.html
+msgid "Add a new book to Open Library"
+msgstr "새 book to Open Library 추가"
+
+#: lib/nav_foot.html
+msgid "Release Notes"
+msgstr "릴리스 노트"
+
+#: lib/nav_foot.html
+msgid "Bluesky"
+msgstr "Bluesky"
+
+#: lib/nav_foot.html
+msgid "Open Library on Bluesky"
+msgstr "Bluesky의 Open Library"
+
+#: lib/nav_foot.html
+msgid "Twitter"
+msgstr "Twitter"
+
+#: lib/nav_foot.html
+msgid "Open Library on Twitter"
+msgstr "Twitter의 Open Library"
+
+#: lib/nav_foot.html
+msgid "GitHub"
+msgstr "GitHub"
+
+#: lib/nav_foot.html
+msgid "Open Library on GitHub"
+msgstr "GitHub의 Open Library"
+
+#: lib/nav_foot.html site/alert.html
+msgid "Change Website Language"
+msgstr "웹사이트 언어 변경"
+
+#: lib/nav_foot.html lib/nav_head.html type/list/embed.html
+msgid "Open Library logo"
+msgstr "Open Library 로고"
+
+#: lib/nav_foot.html
+msgid ""
+"Open Library is an initiative of the <a href=\"//archive.org/\">Internet Archive</a>, a"
+" 501(c)(3) non-profit, building a digital library of Internet sites and other cultural "
+"artifacts in  digital form. Other <a href=\"//archive.org/projects/\">projects</a> "
+"include the <a href=\"//archive.org/web/\">Wayback Machine</a>, <a "
+"href=\"//archive.org/\">archive.org</a> and <a href=\"//archive-it.org\">archive-"
+"it.org</a>"
+msgstr ""
+"Open Library is an initiative of the <a href=\"//archive.org/\">Internet Archive</a>, a"
+" 501(c)(3) non-profit, building a digital library of Internet sites and other cultural "
+"artifacts in  digital form. Other <a href=\"//archive.org/projects/\">projects</a> "
+"include the <a href=\"//archive.org/web/\">Wayback Machine</a>, <a "
+"href=\"//archive.org/\">archive.org</a> and <a href=\"//archive-it.org\">archive-"
+"it.org</a>"
+
+#: lib/nav_foot.html
+#, python-format
+msgid "version <a href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</a>"
+msgstr "버전 <a href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</a>"
+
+#: lib/nav_head.html
+msgid "Loans, Reading Log, Lists, Stats"
+msgstr "Loans, 독서 기록, Lists, Stats"
+
+#: lib/nav_head.html
+msgid "My Profile"
+msgstr "내 프로필"
+
+#: lib/nav_head.html
+msgid "Log out"
+msgstr "로그아웃"
+
+#: lib/nav_head.html
+msgid "Pending Merge Requests"
+msgstr "대기 중인 병합 요청"
+
+#: lib/nav_head.html search/sort_options.html
+msgid "Trending"
+msgstr "인기 상승"
+
+#: lib/nav_head.html
+msgid "K-12 Student Library"
+msgstr "K-12 학생 도서관"
+
+#: lib/nav_head.html
+msgid "Book Talks"
+msgstr "북 토크"
+
+#: lib/nav_head.html
+msgid "Random Book"
+msgstr "무작위 책"
+
+#: lib/nav_head.html
+msgid "Recent Community Edits"
+msgstr "최근 커뮤니티 편집"
+
+#: lib/nav_head.html
+msgid "Help & Support"
+msgstr "도움말 및 지원"
+
+#: lib/nav_head.html
+msgid "Librarians Portal"
+msgstr "사서 포털"
+
+#: lib/nav_head.html
+msgid "My Open Library"
+msgstr "내 Open Library"
+
+#: databarWork.html lib/nav_head.html
+msgid "Browse"
+msgstr "둘러보기"
+
+#: lib/nav_head.html
+msgid "Contribute"
+msgstr "기여"
+
+#: lib/nav_head.html
+msgid "Resources"
+msgstr "자료"
+
+#: lib/nav_head.html
+msgid "The Internet Archive's Open Library: One page for every book"
+msgstr "The Internet Archive's Open Library: One 페이지 for every 책"
+
+#: lib/nav_head.html
+msgid "Text"
+msgstr "텍스트"
+
+#: lib/nav_head.html search/advancedsearch.html
+msgid "Subject"
+msgstr "주제"
+
+#: lib/nav_head.html
+msgid "Advanced"
+msgstr "고급"
+
+#: lib/nav_head.html
+msgid "Search by barcode"
+msgstr "by barcode 검색"
+
+#: lib/not_logged.html
+msgid ""
+"<strong>You are not <a href=\"/account/login\" title=\"Log in now\">logged "
+"in</a>.</strong> Open Library will record your IP address and include it in this page's"
+" publicly accessible edit history. If you <a href=\"/account/create\" title=\"Create an"
+" Open Library account\">create an account</a>, your IP address is concealed and you can"
+" more easily keep track of all your edits and additions."
+msgstr ""
+"<strong>당신은 not <a href=\"/계정/login\" title=\"Log in now\">logged in</a>.</strong> Open"
+" Library will 레코드 your IP 추가ress and include it in this 페이지's 공개ly accessible 편집 "
+"history. If you <a href=\"/계정/생성\" title=\"생성 an Open Library 계정\">생성 an 계정</a>, your "
+"IP 추가ress is concealed and you can more easily keep track of all your 편집s and 추가itions."
+
+#: librarian_dashboard/data_quality_table.html
+msgid "Reload"
+msgstr "다시 불러오기"
+
+#: librarian_dashboard/data_quality_table.html
+msgid "failing"
+msgstr "실패 중"
+
+#: librarian_dashboard/data_quality_table.html
+msgid "Data quality table"
+msgstr "데이터 품질 표"
+
+#: librarian_dashboard/data_quality_table.html
+msgid "Quality Criteria"
+msgstr "품질 기준"
+
+#: lists/carousel.html lists/home.html lists/showcase.html
+msgid "See all"
+msgstr "모두 보기"
+
+#: lists/export_as_html.html
+#, python-format
+msgid "%(list)s - Editions"
+msgstr "%(list)s - 판본"
+
+#: lists/export_as_html.html type/list/embed.html type/list/view_body.html
+msgid "Unknown authors"
+msgstr "알 수 없는 저자"
+
+#: lists/export_as_html.html
+msgid "Title unknown"
+msgstr "Title 알 수 없음"
+
+#: lists/export_as_html.html
+msgid "First publish date unknown"
+msgstr "First publish date 알 수 없음"
+
+#: lists/export_as_html.html
+msgid "Name unknown"
+msgstr "Name 알 수 없음"
+
+#: lists/header.html
+#, python-format
+msgid "<a href=\"%(href)s\">%(name)s</a> / Lists"
+msgstr "<a href=\"%(href)s\">%(name)s</a> / 목록"
+
+#: lists/header.html
+#, python-format
+msgid "This author is on <strong>1 list</strong>."
+msgid_plural "This author is on <strong>%(count)s lists</strong>."
+msgstr[0] "이 저자는 <strong>%(count)s개 목록</strong>에 있습니다."
+
+#: lists/header.html
+#, python-format
+msgid "This is edition is on <strong>1 list</strong>."
+msgid_plural "This edition is on <strong>%(count)s lists</strong>."
+msgstr[0] "이 판본은 <strong>%(count)s개 목록</strong>에 있습니다."
+
+#: lists/header.html
+#, python-format
+msgid "This work is on <strong>1 list</strong>."
+msgid_plural "This work is on <strong>%(count)s lists</strong>."
+msgstr[0] "이 작품은 <strong>%(count)s개 목록</strong>에 있습니다."
+
+#: lists/header.html
+#, python-format
+msgid "%(name)s has 1 list."
+msgid_plural "%(name)s has %(count)s lists."
+msgstr[0] "%(name)s님에게는 목록이 %(count)s개 있습니다."
+
+#: lists/header.html
+#, python-format
+msgid "This subject is on <strong>1 list</strong>."
+msgid_plural "This subject is on <strong>%(count)s lists</strong>."
+msgstr[0] "이 주제는 <strong>%(count)s개 목록</strong>에 있습니다."
+
+#: lists/header.html
+msgid "Hm. Can't find it."
+msgstr "음. 찾을 수 없습니다."
+
+#: lists/home.html
+msgid "Create a list of any Subjects, Authors, Works or specific Editions."
+msgstr "생성 a 목록 of any Subjects, Authors, Works or specific 편집ions."
+
+#: lists/home.html
+msgid ""
+"Once you've made a list, you can <strong>watch for updates</strong> or "
+"<strong>export</strong> all the editions in a list as HTML, BibTeX or JSON. See all "
+"your lists and any activity using the \"Lists\" link on your Account page."
+msgstr ""
+"Once you've made a 목록, you can <strong>watch for updates</strong> or "
+"<strong>export</strong> all the 판본 in a 목록 as HTML, BibTeX or JSON. See all your 목록 and"
+" any activity using the \"Lists\" link on your Account 페이지."
+
+#: lists/home.html
+#, python-format
+msgid ""
+"For the top 2000+ most requested eBooks in California for the print disabled <a "
+"href=\"%(url)s\">click here</a>."
+msgstr "캘리포니아에서 인쇄물 이용 장애인을 위해 가장 많이 요청된 전자책 2000권 이상을 보려면 <a href=\"%(url)s\">여기를 클릭하세요</a>."
+
+#: lists/home.html
+msgid "Find a list by name"
+msgstr "이름으로 목록 찾기"
+
+#: lists/home.html
+msgid "Active Lists"
+msgstr "활성 목록"
+
+#: lists/home.html
+#, python-format
+msgid "from <a href=\"%(key)s\">%(owner)s</a>"
+msgstr "<a href=\"%(key)s\">%(owner)s</a>에서"
+
+#: lists/home.html lists/preview.html lists/snippet.html type/list/embed.html
+#: type/list/view_body.html
+#, python-format
+msgid "%(count)d item"
+msgid_plural "%(count)d items"
+msgstr[0] "%(count)d개 항목"
+
+#: lists/home.html lists/preview.html lists/snippet.html
+#, python-format
+msgid "Last modified %(date)s"
+msgstr "마지막 수정: %(date)s"
+
+#: lists/home.html lists/snippet.html
+msgid "No description."
+msgstr "설명 없음."
+
+#: RecentChangesUsers.html lists/home.html lists/lists.html type/user/view.html
+msgid "Recent Activity"
+msgstr "최근 활동"
+
+#: lists/list_follow.html
+msgid "Cover of book"
+msgstr "책 표지"
+
+#: lists/list_follow.html
+msgid "Avatar of the owner of the list"
+msgstr "목록 소유자의 아바타"
+
+#: lists/list_follow.html lists/widget.html my_books/dropdown_content.html
+msgid "You"
+msgstr "나"
+
+#: lists/list_follow.html
+msgid "This patron has not enabled following"
+msgstr "이 이용자는 팔로우 기능을 활성화하지 않았습니다"
+
+#: lists/list_follow.html
+msgid "🔒︎"
+msgstr "🔒︎"
+
+#: Follow.html lists/list_follow.html
+msgid "Follow"
+msgstr "팔로우"
+
+#: lists/list_follow.html
+msgid "OpenLibrary Logo"
+msgstr "OpenLibrary 로고"
+
+#: lists/list_follow.html
+msgid "Community List"
+msgstr "커뮤니티 목록"
+
+#: lists/list_overview.html lists/widget.html my_books/dropdown_content.html
+msgid "See this list"
+msgstr "이 목록 보기"
+
+#: lists/list_overview.html lists/widget.html my_books/dropdown_content.html
+msgid "Remove from your list?"
+msgstr "from your list? 제거"
+
+#: lists/list_overview.html
+#, python-format
+msgid "from <a href=\"%(link)s\">You</a>"
+msgstr "<a href=\"%(link)s\">나</a>에게서"
+
+#: lists/list_overview.html
+#, python-format
+msgid "from <a href=\"%(link)s\">%(name)s</a>"
+msgstr "<a href=\"%(link)s\">%(name)s</a>에게서"
+
+#: lists/lists.html
+#, python-format
+msgid "%(owner)s / Lists"
+msgstr "%(owner)s / 목록"
+
+#: lists/lists.html type/list/view_body.html
+msgid "Yes, I'm sure"
+msgstr "네, 확실합니다"
+
+#: lists/lists.html type/list/view_body.html
+msgid "No, cancel"
+msgstr "No, 취소"
+
+#: lists/lists.html
+msgid "Delete this list"
+msgstr "this list 삭제"
+
+#: lists/lists.html
+msgid "Delete list"
+msgstr "목록 삭제"
+
+#: lists/lists.html
+msgid "Are you sure you want to delete this list?"
+msgstr "정말 삭제 this 목록?"
+
+#: lists/lists.html
+msgid "Remove this seed?"
+msgstr "this seed? 제거"
+
+#: lists/lists.html
+#, python-format
+msgid "Are you sure you want to remove <strong>%(title)s</strong> from this list?"
+msgstr "정말 제거 <strong>%(title)s</strong> from this 목록?"
+
+#: lists/lists.html
+msgid "This reader hasn't created any lists yet."
+msgstr "This reader hasn't 생성d any 목록 yet."
+
+#: lists/lists.html
+msgid "You haven't created any lists yet."
+msgstr "당신은n't 생성d any 목록 yet."
+
+#: lists/lists.html
+msgid "Learn how to create your first list."
+msgstr "Learn how to 생성 your first 목록."
+
+#: lists/preview.html
+#, python-format
+msgid "by <a href=\"%s\">You</a>"
+msgstr "<a href=\"%s\">나</a> 작성"
+
+#: lists/showcase.html
+#, python-format
+msgid "My Lists (%(count)d)"
+msgstr "내 목록 (%(count)d)"
+
+#: lists/showcase.html
+msgid "You have no lists."
+msgstr "목록이 없습니다."
+
+#: lists/widget.html my_books/dropdown_content.html type/type/view.html
+msgid "from"
+msgstr "출처"
+
+#: lists/widget.html
+msgid "Loading<span class=\"loading-ellipsis\">...</span>"
+msgstr "불러오는 중<span class=\"loading-ellipsis\">...</span>"
+
+#: merge/authors.html
+msgid "Merge Authors"
+msgstr "저자 병합"
+
+#: merge/authors.html
+msgid "No authors selected."
+msgstr "선택된 저자가 없습니다."
+
+#: merge/authors.html
+msgid "Please select a primary author record."
+msgstr "다음 select a primary 저자 레코드."
+
+#: merge/authors.html
+msgid "Please select some authors to merge."
+msgstr "다음 select some 저자 to merge."
+
+#: merge/authors.html
+msgid "Select the oldest profile as primary -"
+msgstr "가장 오래된 프로필을 기본으로 선택 -"
+
+#: merge/authors.html
+msgid "Select author records which should be merged with the primary"
+msgstr "Select 저자 레코드s which should be merged with the primary"
+
+#: merge/authors.html
+msgid "Press MERGE AUTHORS."
+msgstr "MERGE AUTHORS를 누르세요."
+
+#: merge/authors.html
+msgid "No primary record"
+msgstr "기본 레코드 없음"
+
+#: merge/authors.html
+msgid "You must select a primary record to point the duplicates toward."
+msgstr "You must select a primary 레코드 to point the duplicates toward."
+
+#: merge/authors.html
+msgid "Please Be Careful..."
+msgstr "주의해 주세요..."
+
+#: merge/authors.html
+msgid "<b>Are you sure</b> you want to merge these records?"
+msgstr "<b>Are you sure</b> you want to merge these 레코드s?"
+
+#: merge/authors.html
+msgid "Merge"
+msgstr "병합"
+
+#: merge/authors.html
+msgid "birth/death date"
+msgstr "출생/사망일"
+
+#: merge/authors.html
+msgid "Open in a new window"
+msgstr "새 창에서 열기"
+
+#: merge/authors.html search/work_search_selected_facets.html
+msgid "First published in"
+msgstr "초판 출간:"
+
+#: merge/authors.html
+msgid "Visit this author's page in a new window"
+msgstr "Visit this 저자's 페이지 in a new window"
+
+#: merge/authors.html
+msgid "Comment:"
+msgstr "댓글:"
+
+#: merge/authors.html
+msgid "Comment..."
+msgstr "댓글..."
+
+#: merge/authors.html
+msgid "Request Merge"
+msgstr "병합 요청"
+
+#: merge/authors.html
+msgid "Reject Merge"
+msgstr "병합 거부"
+
+#: merge/works.html
+msgid "Merge Works"
+msgstr "작품 병합"
+
+#: merge_request_table/merge_request_table.html
+msgid "Failed to submit comment. Please try again in a few moments."
+msgstr "실패했습니다 to 제출 comment. 다시 시도해 주세요 in a few moments."
+
+#: merge_request_table/merge_request_table.html
+msgid "(Optional) Why are you closing this request?"
+msgstr "(선택 사항) 이 요청을 닫는 이유는 무엇인가요?"
+
+#: merge_request_table/merge_request_table.html
+#, python-format
+msgid "Showing %(username)s's requests only."
+msgstr "%(username)s님의 요청만 표시 중."
+
+#: merge_request_table/merge_request_table.html
+msgid "Show all requests"
+msgstr "모든 요청 표시"
+
+#: merge_request_table/merge_request_table.html
+msgid "Showing all requests."
+msgstr "모든 요청 표시 중."
+
+#: merge_request_table/merge_request_table.html
+msgid "Show my requests"
+msgstr "내 요청 표시"
+
+#: merge_request_table/merge_request_table.html
+msgid "Community Edit Requests"
+msgstr "커뮤니티 편집 요청"
+
+#: merge_request_table/merge_request_table.html
+msgid "No entries here!"
+msgstr "여기에 항목이 없습니다!"
+
+#: merge_request_table/table_header.html
+msgid "Open"
+msgstr "열림"
+
+#: merge_request_table/table_header.html
+msgid "Closed"
+msgstr "닫힘"
+
+#: merge_request_table/table_header.html
+msgid "Status ▾"
+msgstr "상태 ▾"
+
+#: merge_request_table/table_header.html
+msgid "Request Status"
+msgstr "요청 상태"
+
+#: merge_request_table/table_header.html openlibrary/core/edits.py
+msgid "Merged"
+msgstr "병합됨"
+
+#: merge_request_table/table_header.html openlibrary/core/edits.py
+msgid "Declined"
+msgstr "거절됨"
+
+#: merge_request_table/table_header.html
+msgid "Submitter ▾"
+msgstr "제출ter ▾"
+
+#: merge_request_table/table_header.html
+msgid "Filter submitters"
+msgstr "제출자 필터"
+
+#: merge_request_table/table_header.html
+msgid "Submitted by me"
+msgstr "내가 제출함"
+
+#: merge_request_table/table_header.html
+msgid "Reviewer ▾"
+msgstr "검토자 ▾"
+
+#: merge_request_table/table_header.html
+msgid "Reviewer"
+msgstr "검토자"
+
+#: merge_request_table/table_header.html
+msgid "Filter reviewers"
+msgstr "검토자 필터"
+
+#: merge_request_table/table_header.html
+msgid "Assigned to nobody"
+msgstr "아무에게도 배정되지 않음"
+
+#: merge_request_table/table_header.html
+msgid "Sort ▾"
+msgstr "정렬 ▾"
+
+#: merge_request_table/table_header.html
+msgid "Sort"
+msgstr "정렬"
+
+#: merge_request_table/table_header.html
+msgid "Newest"
+msgstr "최신순"
+
+#: merge_request_table/table_header.html
+msgid "Oldest"
+msgstr "오래된순"
+
+#: merge_request_table/table_row.html
+msgid "An untitled work"
+msgstr "제목 없는 작품"
+
+#: merge_request_table/table_row.html
+msgid "An unnamed author"
+msgstr "이름 없는 저자"
+
+#: merge_request_table/table_row.html
+msgid "Open request"
+msgstr "열린 요청"
+
+#: merge_request_table/table_row.html
+msgid "Closed request"
+msgstr "닫힌 요청"
+
+#: merge_request_table/table_row.html
+msgid "No comments yet."
+msgstr "아직 댓글이 없습니다."
+
+#: merge_request_table/table_row.html
+msgid "Add a comment..."
+msgstr "a comment... 추가"
+
+#: merge_request_table/table_row.html
+msgid "Reply"
+msgstr "답글"
+
+#: merge_request_table/table_row.html
+#, python-format
+msgid ""
+"MR #%(id)s opened %(date)s by <a href=\"/people/%(submitter)s\" "
+"class=\"commenter\">@%(submitter)s</a>"
+msgstr ""
+"MR #%(id)s: <a href=\"/people/%(submitter)s\" class=\"commenter\">@%(submitter)s</a>님이 "
+"%(date)s에 열었습니다"
+
+#: merge_request_table/table_row.html
+msgid "Click to close this Merge Request"
+msgstr "이 병합 요청을 닫으려면 클릭하세요"
+
+#: merge_request_table/table_row.html
+msgid "Review <!-- (merge request) -->"
+msgstr "검토 <!-- (merge request) -->"
+
+#: merge_request_table/table_row.html
+msgid "comments"
+msgstr "댓글"
+
+#: my_books/dropdown_content.html
+msgid "Remove From Shelf"
+msgstr "From Shelf 제거"
+
+#: my_books/dropdown_content.html
+msgid "My Reading Lists:"
+msgstr "내 독서 목록:"
+
+#: my_books/dropdown_content.html
+msgid "Loading"
+msgstr "불러오는 중"
+
+#: my_books/dropdown_content.html
+msgid "Use this Work"
+msgstr "이 작품 사용"
+
+#: CreateListModal.html my_books/dropdown_content.html
+msgid "Create a new list"
+msgstr "새 목록 만들기"
+
+#: CreateListModal.html my_books/dropdown_content.html type/permission/edit.html
+#: type/usergroup/edit.html
+msgid "Description:"
+msgstr "설명:"
+
+#: CreateListModal.html my_books/dropdown_content.html type/list/edit.html
+#: type/series/edit.html
+msgid "Create new list"
+msgstr "새 목록 만들기"
+
+#: my_books/dropdown_content.html
+msgid "saving..."
+msgstr "저장 중..."
+
+#: my_books/dropdown_content.html
+msgid ""
+"Removing this book from your shelves will delete your check-ins for this work.  "
+"Continue?"
+msgstr "Removing 이 책 from your shelves will 삭제 your check-ins 이 작품에 대해.  Continue?"
+
+#: my_books/primary_action.html
+msgid "Add to List"
+msgstr "목록에 추가"
+
+#: my_books/check_ins/check_in_form.html
+msgid "January"
+msgstr "1월"
+
+#: my_books/check_ins/check_in_form.html
+msgid "February"
+msgstr "2월"
+
+#: my_books/check_ins/check_in_form.html
+msgid "March"
+msgstr "3월"
+
+#: my_books/check_ins/check_in_form.html
+msgid "April"
+msgstr "4월"
+
+#: my_books/check_ins/check_in_form.html
+msgid "May"
+msgstr "5월"
+
+#: my_books/check_ins/check_in_form.html
+msgid "June"
+msgstr "6월"
+
+#: my_books/check_ins/check_in_form.html
+msgid "July"
+msgstr "7월"
+
+#: my_books/check_ins/check_in_form.html
+msgid "August"
+msgstr "8월"
+
+#: my_books/check_ins/check_in_form.html
+msgid "September"
+msgstr "9월"
+
+#: my_books/check_ins/check_in_form.html
+msgid "October"
+msgstr "10월"
+
+#: my_books/check_ins/check_in_form.html
+msgid "November"
+msgstr "11월"
+
+#: my_books/check_ins/check_in_form.html
+msgid "December"
+msgstr "12월"
+
+#: my_books/check_ins/check_in_form.html
+msgid "Add an optional check-in date. Check-in dates are used to track yearly reading goals."
+msgstr "an optional check-in date. Check-in dates are used to track yearly reading goals. 추가"
+
+#: my_books/check_ins/check_in_form.html
+msgid "End Date:"
+msgstr "종료일:"
+
+#: my_books/check_ins/check_in_form.html
+msgid "Year:"
+msgstr "연도:"
+
+#: my_books/check_ins/check_in_form.html
+msgid "Year"
+msgstr "연도"
+
+#: my_books/check_ins/check_in_form.html
+msgid "Month:"
+msgstr "월:"
+
+#: my_books/check_ins/check_in_form.html
+msgid "Month"
+msgstr "월"
+
+#: my_books/check_ins/check_in_form.html
+msgid "Day:"
+msgstr "일:"
+
+#: my_books/check_ins/check_in_form.html
+msgid "Day"
+msgstr "일"
+
+#: my_books/check_ins/check_in_form.html
+msgid "Delete Event"
+msgstr "Event 삭제"
+
+#: my_books/check_ins/check_in_prompt.html
+msgid "Failed to delete check-in. Please try again in a few moments."
+msgstr "실패했습니다 to 삭제 check-in. 다시 시도해 주세요 in a few moments."
+
+#: my_books/check_ins/check_in_prompt.html
+msgid "Failed to submit check-in. Please try again in a few moments."
+msgstr "실패했습니다 to 제출 check-in. 다시 시도해 주세요 in a few moments."
+
+#: my_books/check_ins/check_in_prompt.html
+#, python-format
+msgid "Read <time class=\"check-in-date\">%(date)s</time>"
+msgstr "<time class=\"check-in-date\">%(date)s</time>에 읽음"
+
+#: my_books/check_ins/check_in_prompt.html
+msgid "When did you finish this book?"
+msgstr "When did you finish 이 책?"
+
+#: my_books/check_ins/check_in_prompt.html
+msgid "Other"
+msgstr "기타"
+
+#: my_books/check_ins/check_in_prompt.html
+msgid "Check-In"
+msgstr "체크인"
+
+#: observations/review_component.html
+msgid "Community Reviews"
+msgstr "커뮤니티 리뷰"
+
+#: observations/review_component.html
+msgid "No community reviews have been submitted for this work."
+msgstr "No community 리뷰 되었습니다 제출ted 이 작품에 대해."
+
+#: observations/review_component.html
+msgid "+ Add your community review"
+msgstr "+ 커뮤니티 리뷰 추가"
+
+#: observations/review_component.html
+msgid "+ Log in to add your community review"
+msgstr "+ Log in 추가하려면 your community 리뷰"
+
+#: publishers/index.html publishers/notfound.html
+msgid "Publishers"
+msgstr "출판사"
+
+#: publishers/index.html publishers/view.html
+msgid "Publisher Search"
+msgstr "출판사 검색"
+
+#: publishers/index.html publishers/view.html
+msgid "Try a keyword."
+msgstr "키워드를 입력해 보세요."
+
+#: publishers/notfound.html
+#, python-format
+msgid "We couldn't find any books published by %(publisher)s."
+msgstr "찾을 수 없습니다 any 책 published by %(publisher)s."
+
+#: publishers/notfound.html subjects/notfound.html
+msgid "Try something else?"
+msgstr "다른 것을 시도해 볼까요?"
+
+#: publishers/view.html
+#, python-format
+msgid "Publisher: %(name)s"
+msgstr "출판사: %(name)s"
+
+#: openlibrary/plugins/worksearch/code.py publishers/view.html search/advancedsearch.html
+#: type/edition/view.html type/work/view.html
+msgid "Publisher"
+msgstr "출판사"
+
+#: SearchResultsWork.html publishers/view.html
+#, python-format
+msgid "%(count)s ebook"
+msgid_plural "%(count)s ebooks"
+msgstr[0] "전자책 %(count)s권"
+
+#: publishers/view.html
+msgid "0 ebooks"
+msgstr "전자책 0권"
+
+#: PublishingHistory.html publishers/view.html
+msgid "Publishing History"
+msgstr "출판 이력"
+
+#: publishers/view.html
+msgid ""
+"This is a chart to show the when this publisher published books. Along the X axis is "
+"time, and on the y axis is the count of editions published. <a "
+"href=\"#subjectRelated\">Click here to skip the chart</a>."
+msgstr ""
+"이것은 a chart to show the when this 출판사 published 책. Along the X axis is time, and on the"
+" y axis is the count of 판본 published. <a href=\"#주제Related\">Click here to skip the "
+"chart</a>."
+
+#: PublishingHistory.html publishers/view.html
+msgid "Reset chart"
+msgstr "차트 초기화"
+
+#: PublishingHistory.html publishers/view.html
+msgid "or continue zooming in."
+msgstr "또는 계속 확대하세요."
+
+#: publishers/view.html
+msgid ""
+"This graph charts editions from this publisher over time. Click to view a single year, "
+"or drag across a range."
+msgstr ""
+"This graph charts 판본 from this 출판사 over time. Click to view a single year, or drag "
+"across a range."
+
+#: PublishingHistory.html publishers/view.html
+msgid "Editions Published"
+msgstr "출판된 판본"
+
+#: PublishingHistory.html publishers/view.html
+msgid "Year of Publication"
+msgstr "출판 연도"
+
+#: publishers/view.html
+msgid "Common Subjects"
+msgstr "공통 주제"
+
+#: publishers/view.html
+#, python-format
+msgid "Search for books published by %(publisher)s"
+msgstr "for books published by %(publisher)s 검색"
+
+#: RelatedSubjects.html publishers/view.html
+msgid "None found."
+msgstr "찾을 수 없습니다."
+
+#: ProlificAuthors.html publishers/view.html
+msgid "See more books by, and learn about, this author"
+msgstr "See more 책 by, and learn about, this 저자"
+
+#: publishers/view.html
+msgid "published most by this publisher"
+msgstr "이 출판사가 가장 많이 출판함"
+
+#: publishers/view.html
+msgid "Get more information about this publisher"
+msgstr "Get more information about this 출판사"
+
+#: reading_goals/reading_goal_form.html
+msgid "How many books would you like to read this year?"
+msgstr "How many 책 would you like to read this year?"
+
+#: reading_goals/reading_goal_form.html
+msgid "Enter \"0\" to unset your reading goal. Your check-ins will be preserved."
+msgstr "Enter \"0\" to unset your 독서 목표. Your check-ins 됩니다 preserved."
+
+#: reading_goals/reading_goal_progress.html
+#, python-format
+msgid ""
+"<span class=\"reading-goal-progress__books-read\">%(books_read)d</span>/<span class"
+"=\"reading-goal-progress__goal\">%(goal)d</span> Books"
+msgstr ""
+"<span class=\"reading-goal-progress__책-read\">%(books_read)d</span>/<span class"
+"=\"reading-goal-progress__goal\">%(goal)d</span> Books"
+
+#: reading_goals/reading_goal_progress.html
+#, python-format
+msgid "Edit %(year)d Reading Goal"
+msgstr "%(year)d Reading Goal 편집"
+
+#: recentchanges/header.html
+msgid "By"
+msgstr "작성자"
+
+#: recentchanges/header.html
+msgid "Undo All"
+msgstr "모두 실행 취소"
+
+#: recentchanges/header.html recentchanges/index.html
+msgid "Recent Changes"
+msgstr "최근 변경"
+
+#: recentchanges/index.html
+msgid "Books Edited"
+msgstr "편집된 책"
+
+#: recentchanges/index.html
+msgid "Author Merges"
+msgstr "저자 병합"
+
+#: recentchanges/index.html
+msgid "Work Merges"
+msgstr "작품 병합"
+
+#: recentchanges/index.html
+msgid "Books Added"
+msgstr "추가된 책"
+
+#: RecentChanges.html recentchanges/index.html
+msgid "By Humans"
+msgstr "사람별"
+
+#: RecentChanges.html recentchanges/index.html
+msgid "By Bots"
+msgstr "봇별"
+
+#: recentchanges/render.html
+msgid "Admin view"
+msgstr "관리자 보기"
+
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
+#: recentchanges/render.html
+msgid "Older"
+msgstr "이전"
+
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
+#: recentchanges/render.html
+msgid "Newer"
+msgstr "다음"
+
+#: recentchanges/updated_records.html
+msgid "Review what's changed in from the previous revision"
+msgstr "이전 개정판에서 변경된 사항 검토"
+
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
+#: recentchanges/default/path.html recentchanges/updated_records.html
+msgid "diff"
+msgstr "차이"
+
+#: recentchanges/add-book/path.html recentchanges/default/path.html
+#: recentchanges/edit-book/path.html recentchanges/merge/path.html
+msgid "expand"
+msgstr "펼치기"
+
+#: recentchanges/default/message.html recentchanges/edit-book/message.html
+msgid "opened a new Open Library account!"
+msgstr "opened a new Open Library 계정!"
+
+#: RecentChanges.html RecentChangesUsers.html recentchanges/default/path.html
+msgid "Review what's changed from the previous revision"
+msgstr "이전 개정판에서 변경된 사항 검토"
+
+#: recentchanges/default/view.html recentchanges/merge/view.html recentchanges/undo/view.html
+msgid "Updated Records"
+msgstr "업데이트된 레코드"
+
+#: recentchanges/merge/comment.html
+#, python-format
+msgid "Merged duplicate %(record_type)s records."
+msgstr "중복된 %(record_type)s 레코드를 병합했습니다."
+
+#: recentchanges/merge/comment.html
+#, python-format
+msgid "See <a href=\"%s\">details</a>."
+msgstr "<a href=\"%s\">세부 정보</a> 보기."
+
+#: recentchanges/merge/comment.html
+#, python-format
+msgid "Merged %(count)d duplicate %(type)s record into this primary."
+msgid_plural "Merged %(count)d duplicate %(type)s records into this primary."
+msgstr[0] "중복된 %(type)s 레코드 %(count)d개를 이 기본 레코드로 병합했습니다."
+
+#: recentchanges/merge/comment.html
+msgid "Marked as duplicate."
+msgstr "중복으로 표시됨."
+
+#: recentchanges/merge/comment.html
+#, python-format
+msgid "Merged %(page_type)s into primary %(record_type)s record."
+msgstr "Merged %(page_type)s into primary %(record_type)s 레코드."
+
+#: recentchanges/merge/message.html
+#, python-format
+msgid "%(who)s merged one duplicate of %(master)s"
+msgid_plural "%(who)s merged %(count)d duplicates of %(master)s"
+msgstr[0] "%(who)s님이 %(master)s의 중복 항목 %(count)d개를 병합했습니다"
+
+#: recentchanges/merge/message.html
+#, python-format
+msgid "one duplicate of %(master)s was merged anonymously"
+msgid_plural "%(count)d duplicates of %(master)s were merged anonymously"
+msgstr[0] "%(master)s의 중복 항목 %(count)d개가 익명으로 병합되었습니다"
+
+#: recentchanges/merge/view.html
+msgid "This merge has been undone."
+msgstr "이 병합은 취소되었습니다."
+
+#: recentchanges/merge/view.html
+msgid "Details here"
+msgstr "세부 정보는 여기"
+
+#: recentchanges/merge/view.html type/author/view.html
+msgid "Duplicates"
+msgstr "중복"
+
+#: recentchanges/merge/view.html
+#, python-format
+msgid "%(count)d record modified."
+msgid_plural "%(count)d records modified."
+msgstr[0] "%(count)d개 레코드가 수정되었습니다."
+
+#: recentchanges/undo/view.html
+#, python-format
+msgid "Undo of <a href=\"$parent.url()\">%(kind)s</a>."
+msgstr "<a href=\"$parent.url()\">%(kind)s</a> 실행 취소."
+
+#: recentchanges/undo/view.html
+#, python-format
+msgid "%(count)d records modified."
+msgstr "%(count)d개 레코드가 수정되었습니다."
+
+#: search/advancedsearch.html
+msgid "ISBN"
+msgstr "ISBN"
+
+#: search/advancedsearch.html
+msgid "Place"
+msgstr "장소"
+
+#: search/advancedsearch.html
+msgid "Person"
+msgstr "사람"
+
+#: search/advancedsearch.html
+msgid "How to search?"
+msgstr "How to 검색?"
+
+#: search/advancedsearch.html
+msgid "Full Text Search?"
+msgstr "Full Text 검색?"
+
+#: search/authors.html
+#, python-format
+msgid "Search Open Library for \"%(query)s\""
+msgstr "Open Library for \"%(query)s\" 검색"
+
+#: search/authors.html
+msgid "Search Authors"
+msgstr "저자 검색"
+
+#: search/authors.html
+msgid "Is the same author listed twice?"
+msgstr "Is the same 저자 목록ed twice?"
+
+#: search/authors.html
+msgid "Merge authors"
+msgstr "저자 병합"
+
+#: search/authors.html
+msgid "No <strong>authors</strong> directly matched your search"
+msgstr "검색어와 직접 일치하는 <strong>저자</strong>이(가) 없습니다."
+
+#: search/inside.html
+#, python-format
+msgid "Search Open Library for %s"
+msgstr "Open Library for %s 검색"
+
+#: BookSearchInside.html FulltextSearchSuggestion.html SearchNavigation.html
+#: search/inside.html search/snippets.html
+msgid "Search Inside"
+msgstr "Inside 검색"
+
+#: search/inside.html
+msgid "No <strong>Search Inside</strong> text matched your search"
+msgstr "No <strong>검색 Inside</strong> text matched your 검색"
+
+#: search/inside.html
+#, python-format
+msgid "About %(count)s result found"
+msgid_plural "About %(count)s results found"
+msgstr[0] "약 %(count)s개의 결과를 찾았습니다"
+
+#: search/inside.html
+#, python-format
+msgid "in %(seconds)s second"
+msgid_plural "in %(seconds)s seconds"
+msgstr[0] "%(seconds)s초 만에"
+
+#: EditionNavBar.html search/layout_options.html site/stats.html
+msgid "Details"
+msgstr "세부 정보"
+
+#: search/layout_options.html
+msgid "Grid"
+msgstr "격자"
+
+#: search/layout_options.html
+msgid "View as: "
+msgstr "as: 보기"
+
+#: search/lists.html
+msgid "Search results for Lists"
+msgstr "results for Lists 검색"
+
+#: search/lists.html
+msgid "Search Lists"
+msgstr "목록 검색"
+
+#: search/lists.html
+msgid "No <strong>lists</strong> directly matched your search"
+msgstr "검색어와 직접 일치하는 <strong>목록</strong>이(가) 없습니다."
+
+#: search/publishers.html
+msgid "Publishers Search"
+msgstr "출판사 검색"
+
+#: search/snippets.html
+#, python-format
+msgid "On leaf number %(page_num)d:"
+msgstr "리프 번호 %(page_num)d에서:"
+
+#: search/sort_options.html
+msgid "Relevance"
+msgstr "관련도"
+
+#: search/sort_options.html
+msgid "Work Count"
+msgstr "작품 수"
+
+#: search/sort_options.html
+msgid "Random"
+msgstr "무작위"
+
+#: search/sort_options.html
+msgid "Name (beta: Librarian only)"
+msgstr "이름(베타: 사서 전용)"
+
+#: search/sort_options.html
+msgid "Birth Date (oldest) (beta: Librarian only)"
+msgstr "생년월일(오래된순)(베타: 사서 전용)"
+
+#: search/sort_options.html
+msgid "Birth Date (youngest) (beta: Librarian only)"
+msgstr "생년월일(최근순)(베타: 사서 전용)"
+
+#: search/sort_options.html
+msgid "List Order"
+msgstr "목록 순서"
+
+#: search/sort_options.html
+msgid "Last Modified"
+msgstr "마지막 수정"
+
+#: search/sort_options.html
+msgid "Language Name"
+msgstr "언어 이름"
+
+#: search/sort_options.html
+msgid "Ebook Edition Count"
+msgstr "전자책 판본 수"
+
+#: search/sort_options.html
+msgid "Date Added (newest)"
+msgstr "Date 추가ed (newest)"
+
+#: search/sort_options.html
+msgid "Date Added (oldest)"
+msgstr "Date 추가ed (oldest)"
+
+#: search/sort_options.html
+msgid "Most Editions"
+msgstr "판본 많은순"
+
+#: search/sort_options.html
+msgid "First Published"
+msgstr "초판 출간순"
+
+#: search/sort_options.html
+msgid "Most Recent"
+msgstr "최신순"
+
+#: search/sort_options.html
+msgid "Top Rated"
+msgstr "평점 높은순"
+
+#: search/sort_options.html
+msgid "Any"
+msgstr "전체"
+
+#: search/sort_options.html
+msgid "Work Title (beta: Librarian only)"
+msgstr "작품 제목(베타: 사서 전용)"
+
+#: search/sort_options.html
+msgid "Sorting by"
+msgstr "정렬 기준"
+
+#: search/sort_options.html
+msgid "Shuffle"
+msgstr "섞기"
+
+#: search/subjects.html
+msgid "Search Subjects"
+msgstr "주제 검색"
+
+#: search/subjects.html
+msgid "No <strong>subjects</strong> directly matched your search"
+msgstr "검색어와 직접 일치하는 <strong>주제</strong>이(가) 없습니다."
+
+#: search/subjects.html
+msgid "time"
+msgstr "시간"
+
+#: search/subjects.html
+msgid "subject"
+msgstr "주제"
+
+#: search/subjects.html
+msgid "place"
+msgstr "장소"
+
+#: search/subjects.html
+msgid "org"
+msgstr "조직"
+
+#: search/subjects.html
+msgid "event"
+msgstr "이벤트"
+
+#: search/subjects.html
+msgid "person"
+msgstr "사람"
+
+#: search/subjects.html
+msgid "work"
+msgstr "작품"
+
+#: search/work_search_facets.html
+msgid "Merge duplicate authors from this search"
+msgstr "Merge duplicate 저자 from this 검색"
+
+#: search/work_search_facets.html type/work/editions.html
+msgid "Merge duplicates"
+msgstr "중복 병합"
+
+#: search/work_search_facets.html
+msgid "Less"
+msgstr "접기"
+
+#: search/work_search_facets.html
+#, python-format
+msgid "Filter results for %(facet)s"
+msgstr "%(facet)s에 대한 결과 필터링"
+
+#: search/work_search_facets.html
+msgid "Filter results for ebook availability"
+msgstr "Filter results for e책 availability"
+
+#: search/work_search_facets.html
+msgid "yes"
+msgstr "예"
+
+#: search/work_search_facets.html
+msgid "no"
+msgstr "아니요"
+
+#: search/work_search_facets.html
+msgid "Zoom In"
+msgstr "확대"
+
+#: search/work_search_facets.html
+msgid "Focus your results using these <a href=\"/search/howto\">filters</a>"
+msgstr "Focus your results using these <a href=\"/검색/howto\">filters</a>"
+
+#: search/work_search_selected_facets.html
+msgid "Written in"
+msgstr "작성 언어"
+
+#: search/work_search_selected_facets.html
+msgid "Published by"
+msgstr "출판사"
+
+#: search/work_search_selected_facets.html
+msgid "eBook"
+msgstr "전자책"
+
+#: search/work_search_selected_facets.html
+msgid "Classic eBook"
+msgstr "클래식 전자책"
+
+#: search/work_search_selected_facets.html
+msgid "Only Classic eBooks"
+msgstr "클래식 전자책만"
+
+#: search/work_search_selected_facets.html
+msgid "Classic eBooks hidden"
+msgstr "클래식 전자책 숨김"
+
+#: search/work_search_selected_facets.html
+#, python-format
+msgid "%(title)s - search"
+msgstr "%(title)s - 검색"
+
+#: site/alert.html
+msgid "Internet Archive logo"
+msgstr "Internet Archive 로고"
+
+#: site/body.html
+msgid "It looks like you're offline."
+msgstr "오프라인 상태인 것 같습니다."
+
+#: site/head.html
+msgid ""
+"Open Library is an open, editable library catalog, building towards a web page for "
+"every book ever published. Read, borrow, and discover more than 3M books for free."
+msgstr ""
+"Open Library is an open, 편집able library catalog, building towards a web 페이지 for every 책"
+" ever published. Read, 대출, and discover more than 3M 책 for free."
+
+#: site/stats.html
+msgid "Debug Stats"
+msgstr "디버그 통계"
+
+#: stats/readinglog.html
+msgid "Reading Log Stats"
+msgstr "독서 기록 통계"
+
+#: stats/readinglog.html
+msgid "# Books Logged"
+msgstr "기록된 책 수"
+
+#: stats/readinglog.html
+msgid "The total number of books logged using the Reading Log feature"
+msgstr "The total number of 책 logged using the 독서 기록 feature"
+
+#: stats/readinglog.html
+msgid "All time"
+msgstr "전체 기간"
+
+#: stats/readinglog.html
+msgid "# Unique Users Logging Books"
+msgstr "책을 기록한 고유 사용자 수"
+
+#: stats/readinglog.html
+msgid ""
+"The total number of unique users who have logged at least one book using the Reading "
+"Log feature"
+msgstr "The total number of unique users who have logged at least one 책 using the 독서 기록 feature"
+
+#: stats/readinglog.html
+msgid "# Books Starred"
+msgstr "별점이 매겨진 책 수"
+
+#: stats/readinglog.html
+msgid "The total number of books which have been starred"
+msgstr "The total number of 책 which 되었습니다 starred"
+
+#: stats/readinglog.html
+msgid "Total # Unique Raters (all time)"
+msgstr "총 고유 평점 사용자 수(전체 기간)"
+
+#: stats/readinglog.html
+msgid "Most Wanted Books (This Month)"
+msgstr "가장 많이 원하는 책(이번 달)"
+
+#: stats/readinglog.html
+#, python-format
+msgid "Added %(count)d time"
+msgid_plural "Added %(count)d times"
+msgstr[0] "%(count)d회 추가됨"
+
+#: stats/readinglog.html
+msgid "Most Wanted Books (All Time)"
+msgstr "가장 많이 원하는 책(전체 기간)"
+
+#: stats/readinglog.html
+msgid "Most Logged Books"
+msgstr "가장 많이 기록된 책"
+
+#: stats/readinglog.html
+msgid "Most Read Books (All Time)"
+msgstr "가장 많이 읽은 책(전체 기간)"
+
+#: stats/readinglog.html
+msgid "Most Rated Books"
+msgstr "가장 많이 평가된 책"
+
+#: stats/readinglog.html
+msgid "Most Rated Books (All Time)"
+msgstr "가장 많이 평가된 책(전체 기간)"
+
+#: subjects/notfound.html
+msgid "We couldn't find any books about"
+msgstr "찾을 수 없습니다 any 책 about"
+
+#: swagger/swaggerui.html
+msgid "OpenAPI"
+msgstr "OpenAPI"
+
+#: type/about/edit.html type/page/edit.html type/permission/edit.html type/template/edit.html
+#: type/usergroup/edit.html
+#, python-format
+msgid "Edit %(title)s"
+msgstr "%(title)s 편집"
+
+#: type/about/edit.html
+msgid "This only appears in the document head, and gets attached to bookmark labels"
+msgstr "This only appears in the document head, and gets attached to 책mark labels"
+
+#: type/about/edit.html
+msgid "Intro"
+msgstr "소개"
+
+#: type/about/edit.html
+msgid "This appears in first column."
+msgstr "첫 번째 열에 표시됩니다."
+
+#: type/about/edit.html
+msgid "This appears in the second column, at top."
+msgstr "두 번째 열 상단에 표시됩니다."
+
+#: type/about/edit.html
+msgid "Mailing List"
+msgstr "메일링 리스트"
+
+#: type/about/edit.html
+msgid "This appears below the links list."
+msgstr "링크 목록 아래에 표시됩니다."
+
+#: type/about/view.html
+msgid "For more information"
+msgstr "자세한 정보"
+
+#: type/author/edit.html
+msgid "Edit Author"
+msgstr "저자 편집"
+
+#: type/author/edit.html
+msgid ""
+"Please use natural order. For example: <strong>Leo Tolstoy</strong> not "
+"<strong>Tolstoy, Leo</strong>."
+msgstr ""
+"다음 use natural order. For example: <strong>Leo Tolstoy</strong> not <strong>Tolstoy, "
+"Leo</strong>."
+
+#: type/author/edit.html
+msgid "A short bio?"
+msgstr "짧은 소개?"
+
+#: type/author/edit.html
+msgid "If you \"borrow\" information from somewhere, please make sure to cite the source."
+msgstr "If you \"대출\" information from somewhere, please make sure to cite the source."
+
+#: type/author/edit.html
+msgid "Date of birth"
+msgstr "생년월일"
+
+#: type/author/edit.html
+msgid "Date of death"
+msgstr "사망일"
+
+#: type/author/edit.html
+msgid "We're not storing structured dates (yet) so a date like \"21 May 2000\" is recommended."
+msgstr "아직 구조화된 날짜를 저장하지 않으므로 \"21 May 2000\" 같은 형식을 권장합니다."
+
+#: type/author/edit.html
+msgid ""
+"This is a deprecated field. You can help improve this record by removing this date and "
+"populating the \"Date of birth\" and \"Date of death\" fields. Thanks!"
+msgstr ""
+"이것은 a deprecated field. You can help improve this 레코드 by removing this date and "
+"populating the \"Date of birth\" and \"Date of death\" fields. Thanks!"
+
+#: type/author/edit.html
+msgid "Does this author go by any other names?"
+msgstr "Does this 저자 go by any other names?"
+
+#: type/author/edit.html
+msgid ""
+"For example: Lev Nikolayevich Tolstoy was also known as Leo Tolstoy. Please list one "
+"name per line."
+msgstr ""
+"For example: Lev Nikolayevich Tolstoy was also known as Leo Tolstoy. 다음 목록 one name per"
+" line."
+
+#: type/author/edit.html
+msgid "Identifiers"
+msgstr "식별자"
+
+#: type/author/edit.html
+msgid "Author Identifiers Purpose"
+msgstr "저자 식별자의 목적"
+
+#: type/author/view.html type/edition/view.html type/work/view.html
+#, python-format
+msgid "%(page_title)s | Open Library"
+msgstr "%(page_title)s | Open Library"
+
+#: type/author/view.html
+#, python-format
+msgid "Author of %(book_titles)s"
+msgstr "%(book_titles)s의 저자"
+
+#: type/author/view.html
+msgid "Merging Authors..."
+msgstr "저자 병합 중..."
+
+#: type/author/view.html
+msgid "In progress..."
+msgstr "진행 중..."
+
+#: type/author/view.html
+msgid "Refresh the page?"
+msgstr "Refresh the 페이지?"
+
+#: type/author/view.html
+msgid ""
+"OK. The merge is in motion. <i>It will take <u>a few minutes to finish</u> the "
+"update.</i>"
+msgstr "좋습니다. 병합이 진행 중입니다. <i>업데이트를 완료하는 데 <u>몇 분 정도</u> 걸립니다.</i>"
+
+#: type/author/view.html
+msgid "Argh!"
+msgstr "아이고!"
+
+#: type/author/view.html
+msgid "That merge didn't work. It's our fault, and we've made a note of it."
+msgstr "That merge didn't 작품. It's our fault, and we've made a note of it."
+
+#: type/author/view.html
+msgid "Add another?"
+msgstr "another? 추가"
+
+#: type/author/view.html
+#, python-format
+msgid "Search %(author)s books"
+msgstr "%(author)s books 검색"
+
+#: type/author/view.html
+#, python-format
+msgid "— Show <a href=\"%(url)s\">everything</a> by this author?"
+msgstr "— Show <a href=\"%(url)s\">everything</a> by this 저자?"
+
+#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py
+#: type/author/view.html type/list/view_body.html
+msgid "Places"
+msgstr "장소"
+
+#: Profile.html type/author/view.html
+msgid "Time"
+msgstr "시간"
+
+#: type/author/view.html
+msgid "OLID"
+msgstr "OLID"
+
+#: type/author/view.html
+msgid "Inventaire.io:"
+msgstr "Inventaire.io:"
+
+#: type/author/view.html type/edition/view.html type/work/view.html
+msgid "Links <span class=\"gray small sansserif\">outside Open Library</span>"
+msgstr "<span class=\"gray small sansserif\">Open Library 외부</span> 링크"
+
+#: type/author/view.html
+msgid "No links yet."
+msgstr "아직 링크가 없습니다."
+
+#: type/author/view.html
+msgid "Add one"
+msgstr "one 추가"
+
+#: type/author/view.html
+msgid "Alternative names"
+msgstr "다른 이름"
+
+#: type/delete/view.html
+msgid "This page has been deleted"
+msgstr "이 페이지는 삭제되었습니다"
+
+#: type/delete/view.html
+msgid "What would you like to do?"
+msgstr "무엇을 하시겠습니까?"
+
+#: type/delete/view.html
+msgid "Go back where I came from"
+msgstr "이전 위치로 돌아가기"
+
+#: type/delete/view.html
+msgid "View the previous version"
+msgstr "the previous version 보기"
+
+#: type/delete/view.html
+msgid "See the page's history"
+msgstr "See the 페이지's history"
+
+#: type/delete/view.html
+msgid "Recreate it"
+msgstr "다시 만들기"
+
+#: type/edition/admin_bar.html
+msgid "Add IA Book to Staff Picks"
+msgstr "IA Book to Staff Picks 추가"
+
+#: type/edition/admin_bar.html
+msgid "Sync Archive.org ID"
+msgstr "Archive.org ID 동기화"
+
+#: type/edition/admin_bar.html
+msgid "View Book on Archive.org"
+msgstr "Book on Archive.org 보기"
+
+#: SearchResultsWork.html type/edition/admin_bar.html
+msgid "Orphaned Edition"
+msgstr "고아 판본"
+
+#: databarHistory.html databarView.html type/edition/compact_title.html
+msgid "Edit this page"
+msgstr "this page 편집"
+
+#: type/edition/modal_links.html
+msgid "Review"
+msgstr "리뷰"
+
+#: type/edition/title_and_author.html
+msgid "An edition of"
+msgstr "다음의 판본:"
+
+#: type/edition/title_and_author.html
+#, python-format
+msgid "First published in %s"
+msgstr "%s에 초판 출간"
+
+#: type/edition/title_and_author.html
+#, python-format
+msgid "Book %s"
+msgstr "책 %s"
+
+#: type/edition/view.html type/work/view.html
+msgid "Read Less"
+msgstr "접기"
+
+#: type/edition/view.html type/work/view.html
+#, python-format
+msgid "This work doesn't have a description yet. Can you <b><a href='%(url)s'>add one</a></b>?"
+msgstr "이 작품 doesn't have a description yet. Can you <b><a href='%(url)s'>추가 one</a></b>?"
+
+#: type/edition/view.html type/work/view.html
+#, python-format
+msgid ""
+"This edition doesn't have a description yet. Can you <b><a href='%(url)s'>add "
+"one</a></b>?"
+msgstr "이 판본 doesn't have a description yet. Can you <b><a href='%(url)s'>추가 one</a></b>?"
+
+#: type/edition/view.html type/work/view.html
+msgid "Publish Date"
+msgstr "출판일"
+
+#: type/edition/view.html type/work/view.html
+#, python-format
+msgid "Show other books from %(publisher)s"
+msgstr "%(publisher)s의 다른 책 보기"
+
+#: type/edition/view.html type/work/view.html
+#, python-format
+msgid "Search for other books from %(publisher)s"
+msgstr "for other books from %(publisher)s 검색"
+
+#: openlibrary/plugins/worksearch/code.py type/edition/view.html type/work/view.html
+msgid "Language"
+msgstr "언어"
+
+#: type/edition/view.html type/work/view.html
+msgid "Pages"
+msgstr "페이지"
+
+#: type/edition/view.html type/work/view.html
+msgid "ISBNs"
+msgstr "ISBN"
+
+#: databarWork.html type/edition/view.html type/work/view.html
+msgid "Buy this book"
+msgstr "이 책 구매"
+
+#: type/edition/view.html type/work/view.html
+msgid "Book Details"
+msgstr "책 세부 정보"
+
+#: type/edition/view.html type/work/view.html
+msgid "First Sentence"
+msgstr "첫 문장"
+
+#: type/edition/view.html type/work/view.html
+msgid "Edition Notes"
+msgstr "판본 노트"
+
+#: type/edition/view.html type/work/view.html
+msgid "Published in"
+msgstr "출판 장소"
+
+#: type/edition/view.html type/work/view.html
+msgid "Series"
+msgstr "시리즈"
+
+#: type/edition/view.html type/work/view.html
+msgid "Volume"
+msgstr "권"
+
+#: type/edition/view.html type/work/view.html
+msgid "Genre"
+msgstr "장르"
+
+#: type/edition/view.html type/work/view.html
+msgid "Other Titles"
+msgstr "다른 제목"
+
+#: type/edition/view.html type/work/view.html
+msgid "Copyright Date"
+msgstr "저작권 날짜"
+
+#: type/edition/view.html type/work/view.html
+msgid "Translation Of"
+msgstr "번역 원서"
+
+#: type/edition/view.html type/work/view.html
+msgid "Translated From"
+msgstr "원어"
+
+#: type/edition/view.html type/work/view.html
+msgid "External Links"
+msgstr "외부 링크"
+
+#: type/edition/view.html type/work/view.html
+msgid "Format"
+msgstr "형식"
+
+#: type/edition/view.html type/work/view.html
+msgid "Number of pages"
+msgstr "페이지 수"
+
+#: type/edition/view.html type/work/view.html
+msgid "Weight"
+msgstr "무게"
+
+#: type/edition/view.html type/work/view.html
+msgid "Edition Identifiers"
+msgstr "판본 식별자"
+
+#: type/edition/view.html type/work/view.html
+msgid "Source records"
+msgstr "출처 레코드"
+
+#: type/edition/view.html type/work/view.html
+msgid "Work Description"
+msgstr "작품 설명"
+
+#: type/edition/view.html type/work/view.html
+msgid "Original languages"
+msgstr "원어"
+
+#: type/edition/view.html type/work/view.html
+msgid "Excerpts"
+msgstr "발췌"
+
+#: type/edition/view.html type/work/view.html
+#, python-format
+msgid "Page %(page)s"
+msgstr "%(page)s페이지"
+
+#: type/edition/view.html type/work/view.html
+#, python-format
+msgid "added by %(authorlink)s."
+msgstr "%(authorlink)s님이 추가했습니다."
+
+#: type/edition/view.html type/work/view.html
+msgid "added anonymously."
+msgstr "익명으로 추가되었습니다."
+
+#: type/edition/view.html type/work/view.html
+msgid "Wikipedia"
+msgstr "위키백과"
+
+#: type/edition/view.html type/work/view.html
+msgid "Loading Lists"
+msgstr "목록 불러오는 중"
+
+#: type/language/view.html
+#, python-format
+msgid "%(language)s [deprecated]"
+msgstr "%(language)s [지원 중단]"
+
+#: type/language/view.html
+msgid "languages"
+msgstr "언어"
+
+#: type/language/view.html
+msgid "Code"
+msgstr "코드"
+
+#: type/language/view.html
+msgid "Current"
+msgstr "현재"
+
+#: type/language/view.html
+#, python-format
+msgid "Try a <a href=\"%(href)s\">search for readable books in %(language)s</a>?"
+msgstr "Try a <a href=\"%(href)s\">검색 for readable 책 in %(language)s</a>?"
+
+#: type/list/edit.html type/series/edit.html
+msgid "Create a series"
+msgstr "시리즈 만들기"
+
+#: type/list/edit.html type/series/edit.html
+#, python-format
+msgid "Editing series: %(list_name)s"
+msgstr "시리즈 편집 중: %(list_name)s"
+
+#: type/list/edit.html type/series/edit.html
+#, python-format
+msgid "Editing list: %(list_name)s"
+msgstr "목록 편집 중: %(list_name)s"
+
+#: type/list/edit.html type/series/edit.html
+msgid "Edit Series"
+msgstr "시리즈 편집"
+
+#: type/list/edit.html type/series/edit.html
+msgid "Edit List"
+msgstr "목록 편집"
+
+#: type/list/edit.html type/series/edit.html
+msgid "Move..."
+msgstr "이동..."
+
+#: type/list/edit.html type/series/edit.html
+msgid "Search for a book"
+msgstr "책 검색"
+
+#: type/list/edit.html type/series/edit.html
+msgid "Position (optional), e.g. 1, 2, 1-7"
+msgstr "위치(선택 사항), 예: 1, 2, 1-7"
+
+#: type/list/edit.html type/series/edit.html
+msgid "Notes (optional)"
+msgstr "노트(선택 사항)"
+
+#: type/list/edit.html type/series/edit.html
+msgid "List Name"
+msgstr "목록 이름"
+
+#: type/list/edit.html type/series/edit.html
+msgid "Series Name"
+msgstr "시리즈 이름"
+
+#: type/list/edit.html type/series/edit.html
+msgid "Description (optional)"
+msgstr "설명(선택 사항)"
+
+#: type/list/edit.html type/series/edit.html
+msgid "Add another book"
+msgstr "다른 책 추가"
+
+#: type/list/edit.html type/series/edit.html
+msgid "Create new series"
+msgstr "새 시리즈 만들기"
+
+#: type/list/embed.html
+msgid "Visit Open Library"
+msgstr "Open Library 방문"
+
+#: type/list/embed.html
+msgid ""
+"Open in online Book Reader. Downloads available in ePub, DAISY, PDF, TXT formats from "
+"main book page"
+msgstr "Open in online Book Reader. 다운로드s 사용 가능 in ePub, DAISY, PDF, TXT formats from main 책 페이지"
+
+#: type/list/embed.html
+msgid "This book is checked out"
+msgstr "이 책은 대출 중입니다"
+
+#: type/list/embed.html
+msgid "Checked out"
+msgstr "대출 중"
+
+#: type/list/embed.html
+msgid "Borrow book"
+msgstr "책 대출"
+
+#: type/list/embed.html
+msgid "Protected DAISY"
+msgstr "보호된 DAISY"
+
+#: BookByline.html type/list/embed.html
+#, python-format
+msgid "by %(name)s"
+msgstr "%(name)s 지음"
+
+#: type/list/exports.html
+msgid "BibTex"
+msgstr "BibTeX"
+
+#: type/list/exports.html
+msgid "Export"
+msgstr "내보내기"
+
+#: type/list/exports.html
+#, python-format
+msgid "as %(json_link)s, %(html_link)s, or %(bibtex_link)s"
+msgstr "%(json_link)s, %(html_link)s 또는 %(bibtex_link)s로"
+
+#: type/list/exports.html
+msgid "Subscribe"
+msgstr "구독"
+
+#: type/list/exports.html
+#, python-format
+msgid "Watch activity via <a rel=\"nofollow\" href=\"%s\">Atom feed</a>"
+msgstr "<a rel=\"nofollow\" href=\"%s\">Atom 피드</a>로 활동 보기"
+
+#: type/list/exports.html
+msgid "Export Not Available"
+msgstr "내보낼 수 없음"
+
+#: type/list/exports.html
+#, python-format
+msgid "Only lists with up to %(max)s editions can be exported. This one has %(count)s."
+msgstr "Only 목록 with up to %(max)s 판본 할 수 있습니다 exported. This one has %(count)s."
+
+#: type/list/exports.html
+#, python-format
+msgid ""
+"Try removing some seeds for more focus, or look at <a href=\"%s\">bulk download</a> of "
+"the catalog."
+msgstr ""
+"Try removing some seeds for more focus, or look at <a href=\"%s\">bulk 다운로드</a> of the "
+"catalog."
+
+#: type/list/view_body.html
+#, python-format
+msgid "%(name)s | Lists | Open Library"
+msgstr "%(name)s | 목록 | Open Library"
+
+#: type/list/view_body.html
+#, python-format
+msgid "%(title)s: %(description)s"
+msgstr "%(title)s: %(description)s"
+
+#: type/list/view_body.html
+msgid "View the list on Open Library."
+msgstr "Open Library에서 목록 보기."
+
+#: type/list/view_body.html
+msgid "Remove this item?"
+msgstr "이 항목을 제거하시겠습니까?"
+
+#: type/list/view_body.html
+#, python-format
+msgid "Last modified <span>%(date)s</span>"
+msgstr "마지막 수정: <span>%(date)s</span>"
+
+#: type/list/view_body.html
+msgid "Remove seed"
+msgstr "시드 제거"
+
+#: type/list/view_body.html
+msgid "Are you sure you want to remove this item from the list?"
+msgstr "이 항목을 목록에서 제거하시겠습니까?"
+
+#: type/list/view_body.html
+msgid "Remove Seed"
+msgstr "시드 제거"
+
+#: type/list/view_body.html
+msgid ""
+"You are about to remove the last item in the list. That will delete the whole list. Are"
+" you sure you want to continue?"
+msgstr "당신은 about to 제거 the last item in the 목록. That will 삭제 the whole 목록. 정말 continue?"
+
+#: type/list/view_body.html
+#, python-format
+msgid ""
+"This series contains %(limit)d or more works. Currently, only the first %(limit)d works"
+" are displayed."
+msgstr ""
+"This series contains %(limit)d or more 작품. Currently, only the first %(limit)d 작품 are "
+"displayed."
+
+#: type/list/view_body.html
+msgid "There are no items on this list."
+msgstr "이 목록에는 항목이 없습니다."
+
+#: type/list/view_body.html
+msgid ""
+"<a href=\"/search\" target=\"_blank\" rel=\"noopener noreferrer\">Search for book, "
+"subjects, or authors</a> to add to your list."
+msgstr ""
+"<a href=\"/검색\" target=\"_blank\" rel=\"noopener noreferrer\">검색 for 책, 주제, or 저자</a> "
+"추가하려면 to your 목록."
+
+#: type/list/view_body.html
+msgid "Learn more."
+msgstr "자세히 알아보기."
+
+#: type/list/view_body.html
+msgid "List Metadata"
+msgstr "목록 메타데이터"
+
+#: type/list/view_body.html
+msgid "Derived from seed metadata"
+msgstr "시드 메타데이터에서 파생됨"
+
+#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py
+#: type/list/view_body.html
+msgid "Times"
+msgstr "시간"
+
+#: type/local_id/view.html
+msgid "Local IDs"
+msgstr "로컬 ID"
+
+#: type/local_id/view.html
+msgid "Source Item"
+msgstr "원본 항목"
+
+#: type/local_id/view.html
+msgid "ID location"
+msgstr "ID 위치"
+
+#: type/local_id/view.html
+msgid "Barcode regex"
+msgstr "바코드 정규식"
+
+#: type/local_id/view.html
+msgid "URN prefix"
+msgstr "URN 접두사"
+
+#: type/local_id/view.html
+msgid "Example"
+msgstr "예"
+
+#: type/page/edit.html
+msgid "Document Body:"
+msgstr "문서 본문:"
+
+#: type/page/view.html
+msgid "Community"
+msgstr "커뮤니티"
+
+#: type/permission/edit.html
+msgid "Readers:"
+msgstr "독자:"
+
+#: type/permission/edit.html
+msgid "Writers:"
+msgstr "작성자:"
+
+#: type/permission/view.html
+msgid "Readers"
+msgstr "독자"
+
+#: type/permission/view.html
+msgid "Writers"
+msgstr "작성자"
+
+#: type/tag/form.html
+msgid "Edit tag"
+msgstr "태그 편집"
+
+#: type/tag/form.html
+msgid "Add a tag"
+msgstr "태그 추가"
+
+#: type/tag/form.html
+msgid "Add a tag to Open Library"
+msgstr "Open Library에 태그 추가"
+
+#: type/tag/form.html
+msgid "We require a minimum set of fields to create a new collection tag."
+msgstr "We require a minimum set of fields to 생성 a new collection tag."
+
+#: EditButtons.html type/tag/form.html
+msgid ""
+"By saving a change to this wiki, you agree that your contribution is given freely to "
+"the world under <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" "
+"target=\"_blank\" rel=\"noopener noreferrer\" title=\"This link to Creative Commons "
+"will open in a new window\">CC0</a>. Yippee!"
+msgstr ""
+"By saving a change to this wiki, you agree that your contribution is given freely to "
+"the world under <a href=\"https://creativecommons.org/공개domain/zero/1.0/\" "
+"target=\"_blank\" rel=\"noopener noreferrer\" title=\"This link to Creative Commons "
+"will open in a new window\">CC0</a>. Yippee!"
+
+#: type/tag/form.html
+msgid "Add this tag now"
+msgstr "이 태그 지금 추가"
+
+#: type/tag/index.html
+msgid "Tags"
+msgstr "태그"
+
+#: type/tag/index.html
+msgid "Tags curated by Open Library librarians."
+msgstr "Open Library 사서가 선별한 태그입니다."
+
+#: type/tag/index.html
+msgid "View subject page"
+msgstr "주제 페이지 보기"
+
+#: type/tag/index.html
+msgid "Previous"
+msgstr "이전"
+
+#: type/tag/index.html
+msgid "No tags found."
+msgstr "태그를 찾을 수 없습니다."
+
+#: type/tag/tag_form_inputs.html
+msgid "Tag Name"
+msgstr "태그 이름"
+
+#: type/tag/tag_form_inputs.html
+msgid "Human-readable display name (e.g. \"Computer Science\", \"Horror Fiction\")"
+msgstr "사람이 읽을 수 있는 표시 이름(예: \"Computer Science\", \"Horror Fiction\")"
+
+#: type/tag/tag_form_inputs.html
+msgid "Tag Slugs"
+msgstr "태그 슬러그"
+
+#: type/tag/tag_form_inputs.html
+msgid ""
+"Comma-separated URL slugs that map to this tag (auto-populated from name). E.g. "
+"\"computer_science, cs\""
+msgstr "이 태그에 매핑되는 쉼표로 구분된 URL 슬러그입니다(이름에서 자동 생성). 예: \"computer_science, cs\""
+
+#: type/tag/tag_form_inputs.html
+msgid "Tag Description"
+msgstr "태그 설명"
+
+#: type/tag/tag_form_inputs.html
+msgid "Page Body"
+msgstr "페이지 본문"
+
+#: type/tag/tag_form_inputs.html
+msgid "Tag type"
+msgstr "태그 유형"
+
+#: type/tag/tag_form_inputs.html
+msgid "Tag Deputy"
+msgstr "태그 담당자"
+
+#: type/tag/view.html
+#, python-format
+msgid "<strong>Type:</strong> %(tag_type)s"
+msgstr "<strong>유형:</strong> %(tag_type)s"
+
+#: type/tag/view.html type/user/edit.html
+msgid "Description"
+msgstr "설명"
+
+#: type/tag/view.html
+msgid "Tag Body"
+msgstr "태그 본문"
+
+#: type/tag/view.html
+msgid "URL Slugs"
+msgstr "URL 슬러그"
+
+#: type/tag/view.html
+#, python-format
+msgid "View subject page for %(name)s."
+msgstr "subject page for %(name)s. 보기"
+
+#: type/template/edit.html
+msgid "Plugin"
+msgstr "플러그인"
+
+#: type/template/edit.html
+msgid "Document Body"
+msgstr "문서 본문"
+
+#: type/template/edit.html
+msgid "Delete this template?"
+msgstr "이 템플릿을 삭제하시겠습니까?"
+
+#: type/template/view.html
+msgid "plugin"
+msgstr "플러그인"
+
+#: type/type/view.html
+msgid "Kind"
+msgstr "종류"
+
+#: type/type/view.html
+msgid "Properties"
+msgstr "속성"
+
+#: type/type/view.html
+msgid "of type"
+msgstr "유형:"
+
+#: type/type/view.html
+msgid "Backreferences"
+msgstr "역참조"
+
+#: type/user/edit.html
+#, python-format
+msgid "Editing %(name)s"
+msgstr "%(name)s 편집 중"
+
+#: type/user/edit.html
+msgid "Currently Editing:"
+msgstr "현재 편집 중:"
+
+#: type/user/edit.html
+msgid "Display Name"
+msgstr "표시 이름"
+
+#: type/user/view.html
+msgid "admin page"
+msgstr "관리자 페이지"
+
+#: type/user/view.html
+#, python-format
+msgid ""
+"You are publicly sharing the books you are <a href=\"%(username)s/books/currently-"
+"reading\">currently reading</a>, <a href=\"%(username)s/books/already-read\">have "
+"already read</a>, and <a href=\"%(username)s/books/want-to-read\">want to read</a>."
+msgstr ""
+"당신은 공개ly sharing the 책 you are <a href=\"%(username)s/책/currently-reading\">currently "
+"reading</a>, <a href=\"%(username)s/책/already-read\">have already read</a>, and <a "
+"href=\"%(username)s/책/want-to-read\">want to read</a>."
+
+#: type/user/view.html
+msgid "You have chosen to make your"
+msgstr "다음을"
+
+#: type/user/view.html
+msgid "private"
+msgstr "비공개"
+
+#: type/user/view.html
+msgid "Manage your privacy settings"
+msgstr "개인정보 설정 관리"
+
+#: type/user/view.html
+#, python-format
+msgid ""
+"Here are the books %(user)s is <a href=\"%(username)s/books/currently-"
+"reading\">currently reading</a>, <a href=\"%(username)s/books/already-read\">have "
+"already read</a>, and <a href=\"%(username)s/books/want-to-read\">want to read</a>!"
+msgstr ""
+"Here are the 책 %(user)s is <a href=\"%(username)s/책/currently-reading\">currently "
+"reading</a>, <a href=\"%(username)s/책/already-read\">have already read</a>, and <a "
+"href=\"%(username)s/책/want-to-read\">want to read</a>!"
+
+#: type/user/view.html
+msgid "My Lists"
+msgstr "내 목록"
+
+#: RecentChangesUsers.html type/user/view.html
+msgid "No edits. Yet."
+msgstr "아직 편집이 없습니다."
+
+#: type/usergroup/edit.html
+msgid "Members:"
+msgstr "회원:"
+
+#: SearchResultsWork.html type/work/editions.html
+#, python-format
+msgid "First published in %(year)s"
+msgstr "%(year)s년 초판 출간"
+
+#: type/work/editions.html type/work/editions_datatable.html
+#, python-format
+msgid "Add another edition of %(work)s"
+msgstr "%(work)s의 다른 판본 추가"
+
+#: UserEditRow.html type/work/editions.html
+msgid "Add another"
+msgstr "다른 항목 추가"
+
+#: type/work/editions.html
+msgid "Title missing"
+msgstr "제목 없음"
+
+#: type/work/editions_datatable.html
+#, python-format
+msgid "Showing %(count)d featured edition."
+msgid_plural "Showing %(count)d featured editions."
+msgstr[0] "추천 판본 %(count)d개 표시 중."
+
+#: type/work/editions_datatable.html
+#, python-format
+msgid "View all %(count)d editions?"
+msgstr "판본 %(count)d개 모두 보기?"
+
+#: type/work/editions_datatable.html
+msgid "Edition"
+msgstr "판본"
+
+#: type/work/editions_datatable.html
+msgid "Availability"
+msgstr "이용 가능 여부"
+
+#: type/work/editions_datatable.html
+msgid "No editions available"
+msgstr "이용 가능한 판본 없음"
+
+#: type/work/editions_datatable.html
+msgid "Add another edition?"
+msgstr "다른 판본을 추가하시겠습니까?"
+
+#: AffiliateLinks.html
+#, python-format
+msgid "Look for this edition for sale at %(store)s"
+msgstr "Look 이 판본에 대해 for sale at %(store)s"
+
+#: AffiliateLinks.html
+msgid ""
+"When you buy books using these links the Internet Archive may earn a <a "
+"class=\"nostyle\" href=\"/help/faq/about#selling\">small commission</a>."
+msgstr ""
+"When you buy 책 using these links the Internet Archive may earn a <a class=\"nostyle\" "
+"href=\"/help/faq/about#selling\">small commission</a>."
+
+#: AffiliateLinksLoadingIndicator.html
+msgid "Fetching prices"
+msgstr "가격 불러오는 중"
+
+#: BatchImportNavigation.html
+msgid "Pending Imports"
+msgstr "대기 중인 가져오기"
+
+#: BookByline.html
+#, python-format
+msgid "%(n)s other"
+msgid_plural "%(n)s others"
+msgstr[0] "기타 %(n)s개"
+
+#: BookByline.html
+msgid "by an <em>unknown author</em>"
+msgstr "by an <em>알 수 없음 저자</em>"
+
+#: BookPreview.html
+msgid "Preview Only"
+msgstr "미리보기만 가능"
+
+#: BookPreview.html
+msgid "Preview Book"
+msgstr "책 미리보기"
+
+#: DisplayCode.html
+msgid ""
+"Templates in the website are disabled now. Editing them will not have any effect on the"
+" live website."
+msgstr ""
+"Templates in the website are disabled now. 편집ing them will not have any effect on the "
+"live website."
+
+#: EditionNavBar.html
+msgid "Go to previous section"
+msgstr "이전 섹션으로 이동"
+
+#: EditionNavBar.html
+msgid "Overview"
+msgstr "개요"
+
+#: EditionNavBar.html
+#, python-format
+msgid "View %(count)s Edition"
+msgid_plural "View %(count)s Editions"
+msgstr[0] "판본 %(count)s개 보기"
+
+#: EditionNavBar.html
+#, python-format
+msgid "%(reviews)s Review"
+msgid_plural "%(reviews)s Reviews"
+msgstr[0] "리뷰 %(reviews)s개"
+
+#: EditionNavBar.html
+msgid "Related Books"
+msgstr "관련 도서"
+
+#: EditionNavBar.html
+msgid "Go to next section"
+msgstr "다음 섹션으로 이동"
+
+#: Follow.html
+msgid "Unfollow"
+msgstr "팔로우 취소"
+
+#: Follow.html
+msgid "Failed to update followers. Please try again in a few moments."
+msgstr "실패했습니다 to update followers. 다시 시도해 주세요 in a few moments."
+
+#: FormatExpiry.html
+msgid "Expires"
+msgstr "만료"
+
+#: FulltextSearchSuggestion.html
+msgid "Checking for Search Inside matches"
+msgstr "본문 검색 일치 항목 확인 중"
+
+#: FulltextSearchSuggestion.html
+msgid "Search Inside Icon"
+msgstr "본문 검색 아이콘"
+
+#: FulltextSearchSuggestion.html
+msgid "search inside icon"
+msgstr "본문 검색 아이콘"
+
+#: FulltextSearchSuggestion.html
+#, python-format
+msgid "%(book_count)s books found with matching passages"
+msgstr "%(book_count)s 책 found with matching passages"
+
+#: FulltextSearchSuggestion.html
+#, python-format
+msgid "See all %(results_count)s Search Inside Matches"
+msgstr "See all %(results_count)s 검색 Inside Matches"
+
+#: FulltextSearchSuggestion.html
+msgid "right chevron"
+msgstr "오른쪽 꺾쇠"
+
+#: FulltextSnippet.html FulltextSuggestionSnippet.html
+msgid "❝"
+msgstr "❝"
+
+#: FulltextSnippet.html FulltextSuggestionSnippet.html
+msgid "❞"
+msgstr "❞"
+
+#: FulltextSuggestionSnippet.html
+#, python-format
+msgid "Page: %(page)s"
+msgstr "페이지: %(page)s"
+
+#: IABook.html
+#, python-format
+msgid "Borrowed from Internet Archive: %(title)s"
+msgstr "대출ed from Internet Archive: %(title)s"
+
+#: LoadingIndicator.html
+msgid "Loading indicator"
+msgstr "로딩 표시기"
+
+#: LoanStatus.html
+msgid "You are <strong>next</strong> on the waiting list"
+msgstr "당신은 <strong>next</strong> on the 대기자 명단"
+
+#: LoanStatus.html
+#, python-format
+msgid "You are <strong>#%(spot)d</strong> of %(wlsize)d on the waiting list."
+msgstr "당신은 <strong>#%(spot)d</strong> of %(wlsize)d on the 대기자 명단."
+
+#: LoanStatus.html
+msgid "Leave waiting list"
+msgstr "대기자 명단 나가기"
+
+#: LoanStatus.html
+#, python-format
+msgid "Readers in line: %(count)s"
+msgstr "대기 중인 독자: %(count)s명"
+
+#: LoanStatus.html
+msgid "You'll be next in line."
+msgstr "다음 차례입니다."
+
+#: LoanStatus.html
+msgid "This book is currently checked out, please check back later."
+msgstr "이 책 is currently checked out, please check back later."
+
+#: LoanStatus.html
+msgid "Checked Out"
+msgstr "대출 중"
+
+#: LocateButton.html
+msgid "Locate"
+msgstr "찾기"
+
+#: ManageLoansButtons.html
+#, python-format
+msgid "There is one person waiting for this book."
+msgid_plural "There are %(n)s people waiting for this book."
+msgstr[0] "이 책을 기다리는 사람이 %(n)s명 있습니다."
+
+#: ManageWaitlistButton.html
+#, python-format
+msgid "Waiting for %d day"
+msgid_plural "Waiting for %d days"
+msgstr[0] "%d일째 대기 중"
+
+#: ManageWaitlistButton.html
+#, python-format
+msgid "You have %(count)d more hour to borrow it."
+msgid_plural "You have %(count)d more hours to borrow it."
+msgstr[0] "대출할 수 있는 시간이 %(count)d시간 남았습니다."
+
+#: NotInLibrary.html
+msgid "Not in Library"
+msgstr "라이브러리에 없음"
+
+#: NotesModal.html
+msgid "My Book Notes"
+msgstr "내 책 노트"
+
+#: NotesModal.html
+msgid "My private notes about this edition:"
+msgstr "이 판본에 대한 내 비공개 노트:"
+
+#: OLID.html
+#, python-format
+msgid "by  %(authors)s"
+msgstr "%(authors)s 지음"
+
+#: ObservationsModal.html
+msgid "My Book Review"
+msgstr "내 책 리뷰"
+
+#: OlPagination.html OlPaginationArrows.html
+msgid "Go to previous page"
+msgstr "이전 페이지로 이동"
+
+#: OlPagination.html OlPaginationArrows.html
+msgid "Go to next page"
+msgstr "다음 페이지로 이동"
+
+#: OlPagination.html
+#, python-brace-format
+msgid "Go to page {page}"
+msgstr "{page}페이지로 이동"
+
+#: OlPagination.html
+#, python-brace-format
+msgid "Page {page}, current page"
+msgstr "{page}페이지, 현재 페이지"
+
+#: Profile.html
+msgid "Component"
+msgstr "컴포넌트"
+
+#: ProlificAuthors.html
+msgid "Prolific Authors"
+msgstr "다작 저자"
+
+#: ProlificAuthors.html
+msgid "who have written the most books on this subject"
+msgstr "who have written the most 책 on this 주제"
+
+#: PublishingHistory.html
+msgid ""
+"This is a chart to show the publishing history of editions of works about this subject."
+" Along the X axis is time, and on the y axis is the count of editions published. <a "
+"href=\"#subjectRelated\">Click here to skip the chart</a>."
+msgstr ""
+"이것은 a chart to show the publishing history of 판본 of 작품 about this 주제. Along the X axis "
+"is time, and on the y axis is the count of 판본 published. <a href=\"#주제Related\">Click "
+"here to skip the chart</a>."
+
+#: PublishingHistory.html
+msgid "This graph charts editions published on this subject."
+msgstr "This graph charts 판본 published on this 주제."
+
+#: RawQueryCarousel.html
+msgid "Loading carousel"
+msgstr "캐러셀 불러오는 중"
+
+#: RawQueryCarousel.html
+msgid "Failed to fetch carousel."
+msgstr "캐러셀을 가져오지 못했습니다."
+
+#: RawQueryCarousel.html
+msgid "Retry?"
+msgstr "다시 시도할까요?"
+
+#: RawQueryCarousel.html
+msgid "No books match the current filters."
+msgstr "현재 필터와 일치하는 책이 없습니다."
+
+#: RawQueryCarousel.html
+msgid "Retry without filters?"
+msgstr "필터 없이 다시 시도할까요?"
+
+#: RawQueryCarousel.html
+msgid "Search collection"
+msgstr "컬렉션 검색"
+
+#: ReadButton.html
+msgid "Special Access"
+msgstr "특별 접근"
+
+#: ReadButton.html
+msgid ""
+"Special ebook access from the Internet Archive for patrons with qualifying print "
+"disabilities"
+msgstr ""
+"Special e책 access from the Internet Archive for patrons with qualifying print "
+"disabilities"
+
+#: ReadButton.html
+msgid "Borrow ebook from Internet Archive"
+msgstr "Internet Archive에서 전자책 대출"
+
+#: ReadButton.html
+msgid "Read ebook from Internet Archive"
+msgstr "Internet Archive에서 전자책 읽기"
+
+#: ReadButton.html
+msgid "Listen"
+msgstr "듣기"
+
+#: RecentChanges.html
+msgid "View MARC"
+msgstr "MARC 보기"
+
+#: RecentChangesAdmin.html
+msgid "Path"
+msgstr "경로"
+
+#: RecentChangesAdmin.html
+msgid "view"
+msgstr "보기"
+
+#: RecentChangesAdmin.html
+msgid "edit"
+msgstr "편집"
+
+#: RecentChangesAdmin.html RecentChangesUsers.html
+msgid "No edit history available."
+msgstr "사용 가능한 편집 기록이 없습니다."
+
+#: RelatedSubjects.html
+msgid "Related..."
+msgstr "관련..."
+
+#: ReturnForm.html
+msgid "Really return this book?"
+msgstr "정말 이 책을 반납하시겠습니까?"
+
+#: ReturnForm.html
+msgid "Return book"
+msgstr "책 반납"
+
+#: SearchResultsWork.html
+msgid "added to"
+msgstr "추가됨:"
+
+#: SearchResultsWork.html
+#, python-format
+msgid "Book %(position)s"
+msgstr "책 %(position)s"
+
+#: SearchResultsWork.html
+#, python-format
+msgid "Cover of edition %(id)s"
+msgstr "판본 %(id)s의 표지"
+
+#: SearchResultsWork.html
+#, python-format
+msgid "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d language</a>"
+msgid_plural "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d languages</a>"
+msgstr[0] "<a class=\"hoverlink\" title=\"%(langs)s\">%(count)d개 언어</a>로"
+
+#: SearchResultsWork.html TrendingBadge.html
+msgid "This is only visible to librarians."
+msgstr "이 내용은 사서에게만 보입니다."
+
+#: SearchResultsWork.html
+msgid "Work Title"
+msgstr "작품 제목"
+
+#: ShareModal.html
+#, python-format
+msgid "Share on %(share_link)s"
+msgstr "%(share_link)s에서 공유"
+
+#: ShareModal.html
+msgid "Embed this book in your website"
+msgstr "내 웹사이트에 이 책 삽입"
+
+#: ShareModal.html
+msgid "Embed icon"
+msgstr "삽입 아이콘"
+
+#: ShareModal.html
+msgid "Embed"
+msgstr "삽입"
+
+#: ShareModal.html
+msgid "Copy url to clipboard"
+msgstr "URL을 클립보드에 복사"
+
+#: ShareModal.html
+msgid "Copy URL icon"
+msgstr "URL 복사 아이콘"
+
+#: ShareModal.html
+msgid "Copy URL"
+msgstr "URL 복사"
+
+#: ShareModal.html
+msgid "Open QR code"
+msgstr "QR 코드 열기"
+
+#: ShareModal.html
+msgid "QR code icon"
+msgstr "QR 코드 아이콘"
+
+#: ShareModal.html
+msgid "QR Code"
+msgstr "QR 코드"
+
+#: StarRatings.html
+msgid "Clear my rating"
+msgstr "내 평점 지우기"
+
+#: StarRatingsByline.html StarRatingsComponent.html
+msgid "rating"
+msgstr "평점"
+
+#: StarRatingsByline.html StarRatingsComponent.html
+msgid "ratings"
+msgstr "평점"
+
+#: StarRatingsByline.html
+#, python-format
+msgid "%(want_to_read_count)s Want to read"
+msgstr "%(want_to_read_count)s명이 읽고 싶어 함"
+
+#: StarRatingsComponent.html
+#, python-format
+msgid "%(ratings_avg)s (%(ratings_count)s %(ratings_label)s)"
+msgstr "%(ratings_avg)s (%(ratings_count)s %(ratings_label)s)"
+
+#: StarRatingsStats.html
+msgid "Want to read"
+msgstr "읽고 싶어요"
+
+#: StarRatingsStats.html
+msgid "Currently reading"
+msgstr "읽는 중"
+
+#: StarRatingsStats.html
+msgid "Have read"
+msgstr "읽었어요"
+
+#: SubjectTags.html
+msgid "Manage Subjects"
+msgstr "주제 관리"
+
+#: Subnavigation.html
+msgid "Developer Center (Home)"
+msgstr "개발자 센터(홈)"
+
+#: Subnavigation.html
+msgid "Web API"
+msgstr "웹 API"
+
+#: Subnavigation.html
+msgid "Client Library"
+msgstr "클라이언트 라이브러리"
+
+#: Subnavigation.html
+msgid "Data Dumps"
+msgstr "데이터 덤프"
+
+#: Subnavigation.html
+msgid "Report an Issue"
+msgstr "문제 신고"
+
+#: Subnavigation.html
+msgid "Licensing"
+msgstr "라이선스"
+
+#: Subnavigation.html
+msgid "Welcome"
+msgstr "환영합니다"
+
+#: Subnavigation.html
+msgid "Searching Open Library"
+msgstr "Open Library 검색"
+
+#: Subnavigation.html
+msgid "Reading Books"
+msgstr "책 읽기"
+
+#: Subnavigation.html
+msgid "Adding & Editing Books"
+msgstr "책 추가 및 편집"
+
+#: Subnavigation.html
+msgid "Using Subjects"
+msgstr "주제 사용"
+
+#: Subnavigation.html
+msgid "Open Library F.A.Q."
+msgstr "Open Library 자주 묻는 질문"
+
+#: TableOfContents.html
+#, python-format
+msgid "Page %s"
+msgstr "%s페이지"
+
+#: TrendingBadge.html
+#, python-format
+msgid "Trending: %(score).2f"
+msgstr "인기 점수: %(score).2f"
+
+#: TypeChanger.html
+msgid "Page Type"
+msgstr "페이지 유형"
+
+#: TypeChanger.html
+msgid "Huh?"
+msgstr "네?"
+
+#: TypeChanger.html
+msgid ""
+"Every piece of Open Library is defined by the type of content it displays, usually by "
+"content definition (e.g. Authors, Editions, Works) but sometimes by content use (e.g. "
+"macro, template, rawtext). Changing this for an existing page will alter its "
+"presentation and the data fields available for editing its content."
+msgstr ""
+"Every piece of Open Library is defined by the type of content it displays, usually by "
+"content definition (e.g. Authors, 편집ions, Works) but sometimes by content use (e.g. "
+"macro, template, rawtext). Changing this for an existing 페이지 will alter its "
+"presentation and the data fields 사용 가능 for 편집ing its content."
+
+#: TypeChanger.html
+msgid "Please use caution changing Page Type!"
+msgstr "페이지 유형을 변경할 때 주의해 주세요!"
+
+#: TypeChanger.html
+msgid "(Simplest solution: If you aren't sure whether this should be changed, don't change it.)"
+msgstr "(가장 간단한 해결책: 변경해야 하는지 확실하지 않다면 변경하지 마세요.)"
+
+#: WorkInfo.html
+msgid "No link to Wikipedia in your language"
+msgstr "내 언어의 위키백과 링크 없음"
+
+#: WorldcatLink.html
+msgid "Check nearby libraries"
+msgstr "근처 도서관 확인"
+
+#: WorldcatLink.html
+msgid "Check WorldCat for an edition near you"
+msgstr "Check WorldCat for an 판본 near you"
+
+#: WorldcatLink.html
+msgid "WorldCat"
+msgstr "WorldCat"
+
+#: databarDiff.html databarEdit.html
+msgid "View the editing history of this page"
+msgstr "이 페이지의 편집 기록 보기"
+
+#: databarDiff.html
+msgid "View this page (exit Comparison view)"
+msgstr "이 페이지 보기(비교 보기 종료)"
+
+#: databarEdit.html
+msgid "View this page (exit Edit mode)"
+msgstr "이 페이지 보기(편집 모드 종료)"
+
+#: databarHistory.html databarView.html
+#, python-format
+msgid "Last edited by %(author_link)s"
+msgstr "마지막 편집자: %(author_link)s"
+
+#: databarHistory.html databarView.html
+msgid "Last edited anonymously"
+msgstr "마지막 익명 편집"
+
+#: databarTemplate.html databarView.html
+msgid "View this template's edit history"
+msgstr "이 템플릿의 편집 기록 보기"
+
+#: databarTemplate.html
+msgid "Edit this template"
+msgstr "이 템플릿 편집"
+
+#: databarWork.html
+#, python-format
+msgid "View Volume %(num)d"
+msgstr "%(num)d권 보기"
+
+#: openlibrary/core/bookshelves.py
+msgid "[Record deleted]"
+msgstr "[레코드 삭제됨]"
+
+#: openlibrary/core/edits.py
+msgid "Unknown"
+msgstr "알 수 없음"
+
+#: openlibrary/plugins/openlibrary/api.py
+msgid "Search Results"
+msgstr "검색 결과"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Arabic"
+msgstr "아랍어"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Czech"
+msgstr "체코어"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "German"
+msgstr "독일어"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "English"
+msgstr "영어"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Spanish"
+msgstr "스페인어"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "French"
+msgstr "프랑스어"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Hindi"
+msgstr "힌디어"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Croatian"
+msgstr "크로아티아어"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Italian"
+msgstr "이탈리아어"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Portuguese"
+msgstr "포르투갈어"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Romanian"
+msgstr "루마니아어"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Sardinian"
+msgstr "사르데냐어"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Telugu"
+msgstr "텔루구어"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Ukrainian"
+msgstr "우크라이나어"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Chinese"
+msgstr "중국어"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Filipino"
+msgstr "필리핀어"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Art"
+msgstr "예술"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Science Fiction"
+msgstr "공상과학"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Fantasy"
+msgstr "판타지"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Biographies"
+msgstr "전기"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Recipes"
+msgstr "레시피"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Children"
+msgstr "아동"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Medicine"
+msgstr "의학"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Religion"
+msgstr "종교"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Mystery and Detective Stories"
+msgstr "미스터리와 탐정 이야기"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Plays"
+msgstr "희곡"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Music"
+msgstr "음악"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "At least 1 subject"
+msgstr "주제 1개 이상"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "At least 1 author"
+msgstr "저자 1명 이상"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "At least 1 edition"
+msgstr "판본 1개 이상"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has work (orphaned)"
+msgstr "작품 있음(고아 항목)"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has publication year"
+msgstr "출판 연도 있음"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has cover"
+msgstr "표지 있음"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has language"
+msgstr "언어 있음"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has publisher"
+msgstr "출판사 있음"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "At least 2 editions"
+msgstr "판본 2개 이상"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has dewey decimal"
+msgstr "듀이 십진분류 있음"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has LoC classification"
+msgstr "미국의회도서관 분류 있음"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has number of pages"
+msgstr "페이지 수 있음"
+
+#: openlibrary/plugins/openlibrary/lists.py
+#, python-format
+msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
+msgstr "정말 제거 <strong>%(title)s</strong> from your 목록?"
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "Better World Books"
+msgstr "Better World Books"
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid " - includes shipping"
+msgstr " - 배송비 포함"
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "Amazon"
+msgstr "Amazon"
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "Bookshop.org"
+msgstr "Bookshop.org"
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "This work does not appear on any lists."
+msgstr "이 작품은 어떤 목록에도 없습니다."
+
+#: openlibrary/plugins/openlibrary/pd.py
+msgid "I don't have one yet"
+msgstr "아직 없습니다"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "The email address you entered is invalid"
+msgstr "입력한 이메일 주소가 유효하지 않습니다"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "This account has been blocked"
+msgstr "이 계정은 차단되었습니다"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "This account has been locked"
+msgstr "이 계정은 잠겼습니다"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "No account was found with this email. Please try again"
+msgstr "이 이메일로 된 계정을 찾을 수 없습니다. 다시 시도해 주세요"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "The password you entered is incorrect. Please try again"
+msgstr "입력한 비밀번호가 올바르지 않습니다. 다시 시도해 주세요"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Wrong password. Please try again"
+msgstr "비밀번호가 올바르지 않습니다. 다시 시도해 주세요"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Please verify your Open Library account before logging in"
+msgstr "로그인하기 전에 Open Library 계정을 확인해 주세요"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Please verify your Internet Archive account before logging in"
+msgstr "로그인하기 전에 Internet Archive 계정을 확인해 주세요"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Please fill out all fields and try again"
+msgstr "모든 필드를 입력한 뒤 다시 시도해 주세요"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "This email is already registered"
+msgstr "이 이메일은 이미 등록되어 있습니다"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "This username is already registered"
+msgstr "이 사용자 이름은 이미 등록되어 있습니다"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "A problem occurred and we were unable to log you in."
+msgstr "문제가 발생하여 로그인할 수 없습니다."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Login attempted with invalid Internet Archive s3 credentials."
+msgstr "잘못된 Internet Archive s3 자격 증명으로 로그인을 시도했습니다."
+
+#: openlibrary/plugins/upstream/account.py
+msgid ""
+"Servers are experiencing unusually high traffic, please try again later or email "
+"openlibrary@archive.org for help."
+msgstr ""
+"Servers are experiencing unusually high traffic, please try again later or 이메일 "
+"openlibrary@archive.org for help."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Email provider not recognized."
+msgstr "이메일 제공업체를 인식할 수 없습니다."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Password requirements not met."
+msgstr "비밀번호 요구 사항을 충족하지 않습니다."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "A problem occurred and we were unable to log you in"
+msgstr "문제가 발생하여 로그인할 수 없습니다"
+
+#: openlibrary/plugins/upstream/account.py
+msgid ""
+"Login or registration attempt hit an unexpected error, please try again or contact "
+"info@archive.org"
+msgstr "로그인 또는 등록 시도 중 예상치 못한 오류가 발생했습니다. 다시 시도하거나 info@archive.org로 문의해 주세요"
+
+#: openlibrary/plugins/upstream/account.py
+#, python-format
+msgid "Request failed with error code: %(error_code)s"
+msgstr "요청이 오류 코드 %(error_code)s로 실패했습니다"
+
+#: openlibrary/plugins/upstream/account.py
+msgid ""
+"Thank you for registering an Open Library account and requesting special print "
+"disability access. You should receive an email detailing next steps in the process."
+msgstr ""
+"Thank you for registering an Open Library 계정 and requesting special print disability "
+"access. You should receive an 이메일 detailing next steps in the process."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Username unavailable"
+msgstr "사용자 이름을 사용할 수 없습니다"
+
+#: openlibrary/plugins/upstream/account.py openlibrary/plugins/upstream/forms.py
+msgid "Email already registered"
+msgstr "이미 등록된 이메일입니다"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "An Internet Archive account already exists with this email"
+msgstr "이 이메일로 된 Internet Archive 계정이 이미 있습니다"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Email address is already used."
+msgstr "이메일 주소가 이미 사용 중입니다."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Your email address couldn't be updated. The specified email address is already used."
+msgstr "Your 이메일 추가ress couldn't be updated. The specified 이메일 추가ress is already used."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Email verification successful."
+msgstr "이메일 확인 성공."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Your email address has been successfully verified and updated in your account."
+msgstr "이메일 주소가 성공적으로 확인되어 계정에 업데이트되었습니다."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Email address couldn't be verified."
+msgstr "이메일 주소를 확인할 수 없습니다."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Your email address couldn't be verified. The verification link seems invalid."
+msgstr "Your 이메일 추가ress 확인할 수 없습니다. The verification link seems invalid."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Notification preferences have been updated successfully."
+msgstr "알림 설정이 성공적으로 업데이트되었습니다."
+
+#: openlibrary/plugins/upstream/borrow.py
+msgid "this book"
+msgstr "이 책"
+
+#: openlibrary/plugins/upstream/borrow.py
+#, python-format
+msgid "Unable to return %s. Please try again later or contact info@archive.org."
+msgstr "Unable to 반납 %s. 다시 시도해 주세요 later or contact info@archive.org."
+
+#: openlibrary/plugins/upstream/borrow.py
+#, python-format
+msgid "%s has been returned."
+msgstr "%s이(가) 반납되었습니다."
+
+#: openlibrary/plugins/upstream/borrow.py
+msgid ""
+"Your account has hit a lending limit. Please try again later or contact "
+"info@archive.org."
+msgstr "Your 계정 has hit a lending limit. 다시 시도해 주세요 later or contact info@archive.org."
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Username"
+msgstr "사용자 이름"
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "No user registered with this email address"
+msgstr "이 이메일 주소로 등록된 사용자가 없습니다"
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Disposable email not permitted"
+msgstr "일회용 이메일은 허용되지 않습니다"
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Your email provider is not recognized."
+msgstr "이메일 제공업체를 인식할 수 없습니다."
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Username already used"
+msgstr "이미 사용 중인 사용자 이름입니다"
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Must be between 3 and 20 letters and numbers"
+msgstr "3자 이상 20자 이하의 영문자와 숫자여야 합니다"
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Screen Name"
+msgstr "화면 이름"
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Public and cannot be changed later."
+msgstr "공개되며 나중에 변경할 수 없습니다."
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Invalid password"
+msgstr "잘못된 비밀번호"
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Your email address"
+msgstr "내 이메일 주소"
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Choose a password"
+msgstr "비밀번호 선택"
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "eBook?"
+msgstr "전자책?"
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "First published"
+msgstr "초판 출간"
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "Classic eBooks"
+msgstr "클래식 전자책"
+

--- a/openlibrary/i18n/ko/messages_ko.po
+++ b/openlibrary/i18n/ko/messages_ko.po
@@ -1,0 +1,8965 @@
+# Korean translations for Open Library.
+# Copyright (C) 2026 Internet Archive
+# This file is distributed under the same license as the Open Library
+# project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Open Library VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-04-28 18:58-0400\n"
+"PO-Revision-Date: 2026-05-30 21:11+0900\n"
+"Last-Translator: Korean Translation Contributor <EMAIL@ADDRESS>\n"
+"Language: ko\n"
+"Language-Team: Korean\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: account.html account/notifications.html account/privacy.html lib/nav_head.html
+#: type/user/view.html
+msgid "Settings"
+msgstr "설정"
+
+#: account.html
+msgid "Settings & Privacy"
+msgstr "설정 및 개인정보"
+
+#: account.html databarDiff.html
+msgid "View"
+msgstr "보기"
+
+#: account.html status.html
+msgid "or"
+msgstr "또는"
+
+#: account.html databarHistory.html databarTemplate.html databarView.html design/popover.html
+#: my_books/check_ins/check_in_prompt.html reading_goals/reading_goal_progress.html
+#: subjects.html type/edition/compact_title.html type/user/view.html
+msgid "Edit"
+msgstr "편집"
+
+#: account.html
+msgid "Your Profile Page"
+msgstr "내 프로필 페이지"
+
+#: account.html
+msgid "View or Edit your Reading Log"
+msgstr "내 독서 기록 보기 또는 편집"
+
+#: account.html
+msgid "View or Edit your Lists"
+msgstr "내 목록 보기 또는 편집"
+
+#: account.html
+msgid "Import and Export Options"
+msgstr "가져오기 및 내보내기 옵션"
+
+#: account.html
+msgid "Manage Privacy & Content Moderation Settings"
+msgstr "개인정보 및 콘텐츠 관리 설정 관리"
+
+#: account.html
+msgid "Manage Notifications Settings"
+msgstr "알림 설정 관리"
+
+#: account.html
+msgid "Manage Mailing List Subscriptions"
+msgstr "메일링 리스트 구독 관리"
+
+#: account.html
+msgid "Change Password"
+msgstr "비밀번호 변경"
+
+#: account.html
+msgid "Update Email Address"
+msgstr "이메일 주소 업데이트"
+
+#: account.html
+msgid "Deactivate Account"
+msgstr "계정 비활성화"
+
+#: account.html
+msgid "Please contact us if you need help with anything else."
+msgstr "그 밖에 도움이 필요하면 문의해 주세요."
+
+#: barcodescanner.html
+msgid "Barcode Scanner (Beta)"
+msgstr "바코드 스캐너(베타)"
+
+#: batch_import.html
+msgid "Batch Imports"
+msgstr "일괄 가져오기"
+
+#: BatchImportNavigation.html batch_import.html
+msgid "New Batch Import"
+msgstr "새 일괄 가져오기"
+
+#: batch_import.html
+msgid ""
+"Attach a JSONL formatted document with import records or copy/paste the JSONL text into"
+" the textarea."
+msgstr ""
+"Attach a JSONL formatted document with import 레코드s or copy/paste the JSONL text into "
+"the textarea."
+
+#: batch_import.html
+msgid ""
+"See the <a href=\"https://github.com/internetarchive/openlibrary-"
+"client/tree/master/olclient/schemata\">olclient import schemata</a> for more."
+msgstr ""
+"자세한 내용은 <a href=\"https://github.com/internetarchive/openlibrary-"
+"client/tree/master/olclient/schemata\">olclient 가져오기 스키마</a>를 참고하세요."
+
+#: batch_import.html
+msgid "Attach a file:"
+msgstr "파일 첨부:"
+
+#: batch_import.html
+msgid "Or copy/paste JSONL text:"
+msgstr "또는 JSONL 텍스트 복사/붙여넣기:"
+
+#: batch_import.html import_preview.html
+msgid "Import"
+msgstr "가져오기"
+
+#: batch_import.html
+msgid "Import failed."
+msgstr "가져오기에 실패했습니다."
+
+#: batch_import.html
+msgid "No import will be queued until *every* record validates successfully."
+msgstr "No import 됩니다 queued until *every* 레코드 validates 성공ly."
+
+#: batch_import.html
+msgid ""
+"Please update the JSONL file and reload this page (there should be no need to reattach "
+"the file)."
+msgstr ""
+"다음 update the JSONL file and reload this 페이지 (there should be no need to reattach the "
+"file)."
+
+#: batch_import.html
+msgid "Validation errors:"
+msgstr "검증 오류:"
+
+#: batch_import.html
+#, python-format
+msgid "Line %d:"
+msgstr "%d행:"
+
+#: batch_import.html
+msgid "Import results for batch:"
+msgstr "일괄 가져오기 결과:"
+
+#: batch_import.html
+msgid "Records submitted:"
+msgstr "제출된 레코드:"
+
+#: batch_import.html
+msgid "Total queued:"
+msgstr "대기열에 추가된 총 수:"
+
+#: batch_import.html
+msgid "Total skipped:"
+msgstr "건너뛴 총 수:"
+
+#: batch_import.html
+msgid "Not queued because they are already present in the queue:"
+msgstr "이미 대기열에 있으므로 추가되지 않음:"
+
+#: batch_import.html
+msgid "View Batch Status"
+msgstr "일괄 작업 상태 보기"
+
+#: batch_import_pending_view.html
+msgid "Pending Batch Imports"
+msgstr "대기 중인 일괄 가져오기"
+
+#: batch_import_pending_view.html
+msgid "batch_id"
+msgstr "batch_id"
+
+#: admin/imports.html admin/imports_by_date.html batch_import_pending_view.html
+#: batch_import_view.html
+msgid "Added Time"
+msgstr "추가 시간"
+
+#: account/import.html account/loans.html admin/imports.html admin/imports_by_date.html
+#: admin/loans_table.html admin/menu.html batch_import_pending_view.html
+#: batch_import_view.html librarian_dashboard/data_quality_table.html status.html
+msgid "Status"
+msgstr "상태"
+
+#: batch_import_pending_view.html batch_import_view.html
+#: merge_request_table/table_header.html
+msgid "Submitter"
+msgstr "제출자"
+
+#: RecentChangesAdmin.html batch_import_pending_view.html batch_import_view.html
+msgid "Comments"
+msgstr "댓글"
+
+#: batch_import_view.html
+msgid "Batch Import Status"
+msgstr "일괄 가져오기 상태"
+
+#: batch_import_view.html
+msgid "Batch ID:"
+msgstr "일괄 작업 ID:"
+
+#: batch_import_view.html
+msgid "Batch Name:"
+msgstr "일괄 작업 이름:"
+
+#: batch_import_view.html
+msgid "Submitter:"
+msgstr "제출자:"
+
+#: batch_import_view.html
+msgid "Submit Time:"
+msgstr "제출 시간:"
+
+#: batch_import_view.html
+msgid "Status Summary"
+msgstr "상태 요약"
+
+#: batch_import_view.html
+msgid "Approve"
+msgstr "승인"
+
+#: batch_import_view.html
+msgid "Import Items"
+msgstr "항목 가져오기"
+
+#: batch_import_view.html
+msgid "Import Time"
+msgstr "가져오기 시간"
+
+#: account/import.html admin/imports.html admin/imports_by_date.html batch_import_view.html
+#: librarian_dashboard/data_quality_table.html
+msgid "Error"
+msgstr "오류"
+
+#: batch_import_view.html
+msgid "IA ID"
+msgstr "IA ID"
+
+#: batch_import_view.html
+msgid "Data"
+msgstr "데이터"
+
+#: admin/imports.html admin/imports_by_date.html batch_import_view.html
+msgid "OL Key"
+msgstr "OL 키"
+
+#: batch_import_view.html
+msgid "Not yet imported"
+msgstr "아직 가져오지 않음"
+
+#: design.html
+msgid "Web Component Library"
+msgstr "웹 컴포넌트 라이브러리"
+
+#: OlPagination.html OlPaginationArrows.html design.html type/edition/view.html
+#: type/work/view.html
+msgid "Pagination"
+msgstr "페이지네이션"
+
+#: design.html
+msgid "Popover"
+msgstr "팝오버"
+
+#: design.html type/edition/view.html type/work/view.html
+msgid "Read More"
+msgstr "더 읽기"
+
+#: design.html
+msgid "Chip"
+msgstr "칩"
+
+#: design.html design/button.html
+msgid "Button"
+msgstr "버튼"
+
+#: design.html
+msgid "Chip Group"
+msgstr "칩 그룹"
+
+#: design.html
+msgid "Markdown Editor"
+msgstr "마크다운 편집기"
+
+#: design.html
+msgid ""
+"The ol-pagination component provides support for both event-based and URL-based "
+"navigation."
+msgstr "ol-pagination 컴포넌트는 이벤트 기반 탐색과 URL 기반 탐색을 모두 지원합니다."
+
+#: design.html
+msgid "Event-based"
+msgstr "이벤트 기반"
+
+#: design.html
+#, python-format
+msgid ""
+"When a page is clicked, the component fires an %(update_page)s event with the page "
+"number in %(event_detail)s."
+msgstr ""
+"When a 페이지 is clicked, the component fires an %(update_page)s event with the 페이지 number"
+" in %(event_detail)s."
+
+#: design.html
+msgid "Selected page:"
+msgstr "선택된 페이지:"
+
+#: design.html
+msgid "URL-based Navigation"
+msgstr "URL 기반 탐색"
+
+#: design.html
+msgid "When base-url is provided, pagination renders anchor tags for SEO-friendly links."
+msgstr "base-url이 제공되면 페이지네이션은 SEO 친화적인 링크를 위해 앵커 태그를 렌더링합니다."
+
+#: design.html
+msgid "First page (no previous arrow)"
+msgstr "첫 페이지(이전 화살표 없음)"
+
+#: design.html
+msgid "Middle page (both arrows visible)"
+msgstr "중간 페이지(양쪽 화살표 표시)"
+
+#: design.html
+msgid "Last page (no next arrow)"
+msgstr "마지막 페이지(다음 화살표 없음)"
+
+#: design.html
+msgid "3 pages"
+msgstr "3페이지"
+
+#: design.html
+msgid "5 pages (no ellipsis needed)"
+msgstr "5페이지(줄임표 필요 없음)"
+
+#: design.html
+msgid "100 pages with ellipsis:"
+msgstr "줄임표가 있는 100페이지:"
+
+#: design.html
+msgid "Arrows mode"
+msgstr "화살표 모드"
+
+#: design.html
+msgid "When total pages is unknown, use arrows mode to show only previous/next navigation."
+msgstr "When total 페이지s is 알 수 없음, use arrows mode to show only previous/next navigation."
+
+#: design.html
+msgid "Arrows mode (has next page)"
+msgstr "화살표 모드(다음 페이지 있음)"
+
+#: design.html
+msgid "Arrows mode (no next page)"
+msgstr "화살표 모드(다음 페이지 없음)"
+
+#: design.html
+msgid "Arrows mode (first page, has next)"
+msgstr "화살표 모드(첫 페이지, 다음 있음)"
+
+#: design.html
+msgid ""
+"The ol-read-more component provides expandable/collapsible content with two truncation "
+"modes: height-based and line-based."
+msgstr "ol-read-more 컴포넌트는 높이 기준과 줄 수 기준의 두 가지 줄이기 모드로 펼치고 접을 수 있는 콘텐츠를 제공합니다."
+
+#: design.html
+msgid "Height-based truncation"
+msgstr "높이 기준 줄이기"
+
+#: design.html
+#, python-format
+msgid "Use %(max_height)s to limit content by pixel height."
+msgstr "콘텐츠를 픽셀 높이로 제한하려면 %(max_height)s을(를) 사용하세요."
+
+#: design.html
+msgid "Line-based truncation"
+msgstr "줄 수 기준 줄이기"
+
+#: design.html
+#, python-format
+msgid "Use %(max_lines)s to limit content by number of lines."
+msgstr "콘텐츠를 줄 수로 제한하려면 %(max_lines)s을(를) 사용하세요."
+
+#: design.html
+msgid "Custom button text"
+msgstr "사용자 지정 버튼 텍스트"
+
+#: design.html
+#, python-format
+msgid ""
+"Use %(more_text)s and %(less_text)s to customize the toggle button labels. We'll use "
+"the i18n strings for this example."
+msgstr "토글 버튼 라벨을 사용자 지정하려면 %(more_text)s 및 %(less_text)s을(를) 사용하세요. 이 예시에서는 i18n 문자열을 사용합니다."
+
+#: SearchResultsWork.html design.html
+msgid "Show more"
+msgstr "더 보기"
+
+#: SearchResultsWork.html design.html
+msgid "Show less"
+msgstr "접기"
+
+#: design.html
+msgid "Custom background color"
+msgstr "사용자 지정 배경색"
+
+#: design.html
+#, python-format
+msgid "Use %(background_color)s to match the gradient fade to your container background."
+msgstr "그라데이션 페이드를 컨테이너 배경에 맞추려면 %(background_color)s을(를) 사용하세요."
+
+#: design.html
+msgid "Small label size"
+msgstr "작은 라벨 크기"
+
+#: design.html
+#, python-format
+msgid "Use %(label_size)s for a smaller toggle button."
+msgstr "더 작은 토글 버튼에는 %(label_size)s을(를) 사용하세요."
+
+#: design.html
+msgid "Content shorter than limit (no button)"
+msgstr "제한보다 짧은 콘텐츠(버튼 없음)"
+
+#: design.html
+msgid "When content fits within the limit, no toggle button is shown."
+msgstr "콘텐츠가 제한 안에 들어가면 토글 버튼이 표시되지 않습니다."
+
+#: design.html
+msgid "This is short content that fits within 5 lines, so no button appears."
+msgstr "이것은 short content that fits within 5 lines, so no button appears."
+
+#: design.html
+#, python-format
+msgid ""
+"The ol-chip component is a pill-shaped interactive element for filters, tags, and "
+"selections. It fires an %(event)s event on click."
+msgstr "ol-chip 컴포넌트는 필터, 태그, 선택에 쓰이는 알약 모양의 인터랙티브 요소입니다. 클릭하면 %(event)s 이벤트를 발생시킵니다."
+
+#: design.html
+msgid "Default (medium)"
+msgstr "기본값(중간)"
+
+#: design.html
+msgid "Basic chips at the default medium size."
+msgstr "기본 중간 크기의 기본 칩입니다."
+
+#: design.html
+msgid "Fiction"
+msgstr "소설"
+
+#: design.html openlibrary/plugins/openlibrary/home.py
+msgid "Science"
+msgstr "과학"
+
+#: databarDiff.html databarEdit.html databarTemplate.html databarView.html design.html
+#: lib/history.html openlibrary/plugins/openlibrary/home.py
+msgid "History"
+msgstr "역사"
+
+#: design.html
+msgid "Selected state"
+msgstr "선택된 상태"
+
+#: design.html
+msgid "A selected chip displays a checkmark icon and uses an active color scheme."
+msgstr "선택된 칩은 체크 표시 아이콘을 표시하고 활성 색상 체계를 사용합니다."
+
+#: design.html
+msgid "Small size"
+msgstr "작은 크기"
+
+#: design.html
+#, python-format
+msgid "Use %(size)s for a compact chip."
+msgstr "작은 칩에는 %(size)s을(를) 사용하세요."
+
+#: design.html
+msgid "Poetry"
+msgstr "시"
+
+#: design.html
+msgid "Drama"
+msgstr "희곡"
+
+#: design.html
+msgid "Essays"
+msgstr "에세이"
+
+#: design.html
+msgid "With count"
+msgstr "개수 포함"
+
+#: design.html
+#, python-format
+msgid "Use %(count)s to display a number alongside the label."
+msgstr "라벨 옆에 숫자를 표시하려면 %(count)s을(를) 사용하세요."
+
+#: design.html
+msgid "As a link"
+msgstr "링크로 사용"
+
+#: design.html
+#, python-format
+msgid "When %(href)s is provided, the chip renders as an anchor tag instead of a button."
+msgstr "%(href)s이(가) 제공되면 칩은 버튼 대신 앵커 태그로 렌더링됩니다."
+
+#: design.html
+msgid "Interactive toggle"
+msgstr "인터랙티브 토글"
+
+#: design.html
+#, python-format
+msgid ""
+"Clicking a chip fires an %(event)s event. Toggle the selected state by listening to the"
+" event."
+msgstr ""
+"Clicking a chip fires an %(event)s event. Toggle the selected state by 목록ening to the "
+"event."
+
+#: design.html
+msgid "Toggle me"
+msgstr "나를 토글"
+
+#: design.html
+msgid "Toggle me too"
+msgstr "나도 토글"
+
+#: design.html
+msgid ""
+"The ol-chip-group component is a flex-wrap container that provides consistent spacing "
+"for groups of chips."
+msgstr "ol-chip-group 컴포넌트는 칩 그룹에 일관된 간격을 제공하는 flex-wrap 컨테이너입니다."
+
+#: design.html
+msgid "Default (medium gap)"
+msgstr "기본값(중간 간격)"
+
+#: design.html
+msgid "Chips are spaced with an 8px gap by default."
+msgstr "칩은 기본적으로 8px 간격으로 배치됩니다."
+
+#: design.html
+msgid "Small gap"
+msgstr "작은 간격"
+
+#: design.html
+#, python-format
+msgid "Use %(gap)s for tighter spacing (4px)."
+msgstr "더 좁은 간격(4px)에는 %(gap)s을(를) 사용하세요."
+
+#: design.html
+msgid "Large gap"
+msgstr "큰 간격"
+
+#: design.html
+#, python-format
+msgid "Use %(gap)s for wider spacing (12px)."
+msgstr "더 넓은 간격(12px)에는 %(gap)s을(를) 사용하세요."
+
+#: design.html
+msgid "Wrapping behavior"
+msgstr "줄바꿈 동작"
+
+#: design.html
+msgid "Chips automatically wrap to the next line when they exceed the container width."
+msgstr "칩이 컨테이너 너비를 초과하면 자동으로 다음 줄로 넘어갑니다."
+
+#: design.html
+msgid "Biography"
+msgstr "전기"
+
+#: design.html
+msgid "With mixed chip states"
+msgstr "혼합된 칩 상태 사용"
+
+#: design.html
+msgid "Chip groups work with any combination of chip sizes, states, and link chips."
+msgstr "Chip groups 작품 with any combination of chip sizes, states, and link chips."
+
+#: design.html
+msgid ""
+"The ol-markdown-editor component is a WYSIWYG editor built on Tiptap that outputs "
+"Markdown. It syncs its content to a hidden target textarea. A 'View source' toolbar "
+"toggle is always available so editors can drop into a raw markdown textarea when "
+"WYSIWYG round-trips are awkward."
+msgstr ""
+"The ol-markdown-편집or component is a WYSIWYG 편집or built on Tiptap that outputs Markdown."
+" It syncs its content to a hidden target textarea. A 'View source' toolbar toggle is "
+"always 사용 가능 so 편집ors can drop into a raw markdown textarea when WYSIWYG round-trips "
+"are awkward."
+
+#: design.html
+msgid "Basic usage"
+msgstr "기본 사용법"
+
+#: design.html
+#, python-format
+msgid ""
+"Provide a %(target_id)s pointing to an existing textarea. The editor reads initial "
+"content from the textarea and syncs changes back to it."
+msgstr ""
+"Provide a %(target_id)s pointing to an existing textarea. The 편집or reads initial "
+"content from the textarea and syncs changes back to it."
+
+#: design.html
+msgid "Mixed Markdown and HTML"
+msgstr "마크다운과 HTML 혼합"
+
+#: design.html
+#, python-format
+msgid ""
+"Add the %(attr)s attribute to expose the HTML block button in the toolbar. HTML blocks "
+"appear with a preview and an Edit button to modify the source."
+msgstr ""
+"the %(attr)s attribute to expose the HTML block button in the toolbar. HTML blocks "
+"appear with a preview and an Edit button to modify the source. 추가"
+
+#: design.html
+msgid "Code blocks and inline code"
+msgstr "코드 블록과 인라인 코드"
+
+#: design.html
+#, python-format
+msgid ""
+"Add the %(attr)s attribute to expose the inline code and code block buttons in the "
+"toolbar. Code support is off by default because only the wiki page renderer is "
+"guaranteed to render fenced code blocks."
+msgstr ""
+"the %(attr)s attribute to expose the inline code and code block buttons in the toolbar."
+" Code support is off by default because only the wiki page renderer is guaranteed to "
+"render fenced code blocks. 추가"
+
+#: design.html
+msgid "Change event"
+msgstr "변경 이벤트"
+
+#: design.html
+#, python-format
+msgid ""
+"The editor fires an %(event)s event on every change. The raw Markdown string is "
+"available in %(detail)s."
+msgstr ""
+"The 편집or fires an %(event)s event on every change. The raw Markdown string is 사용 가능 in "
+"%(detail)s."
+
+#: diff.html
+#, python-format
+msgid "Diff on %s"
+msgstr "%s의 차이"
+
+#: diff.html
+#, python-format
+msgid "Revision %d"
+msgstr "개정 %d"
+
+#: books/check.html covers/book_cover.html diff.html jsdef/LazyWorkPreview.html
+msgid "by"
+msgstr "작성자"
+
+#: diff.html
+msgid "by Anonymous"
+msgstr "익명 작성"
+
+#: diff.html
+msgid "history"
+msgstr "기록"
+
+#: diff.html status.html
+msgid "Added"
+msgstr "추가됨"
+
+#: admin/imports_by_date.html diff.html
+msgid "Modified"
+msgstr "수정됨"
+
+#: diff.html
+msgid "Removed"
+msgstr "삭제됨"
+
+#: diff.html
+msgid "Not changed"
+msgstr "변경 없음"
+
+#: diff.html
+msgid "Differences"
+msgstr "차이"
+
+#: diff.html
+msgid "Both the revisions are identical."
+msgstr "두 개정판이 동일합니다."
+
+#: edit_yaml.html lib/edit_head.html
+msgid "You're in edit mode."
+msgstr "편집 모드입니다."
+
+#: edit_yaml.html lib/edit_head.html
+msgid "Cancel, and go back."
+msgstr "취소하고 돌아가기."
+
+#: edit_yaml.html
+msgid "YAML Representation:"
+msgstr "YAML 표현:"
+
+#: BookPreview.html book_providers/read_button.html books/edit/edition.html editpage.html
+#: import_preview.html
+msgid "Preview"
+msgstr "미리보기"
+
+#: history.html
+msgid "History of edits to"
+msgstr "편집 기록:"
+
+#: history.html
+msgid "Revision"
+msgstr "개정"
+
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html admin/ip/view.html
+#: admin/people/edits.html history.html recentchanges/render.html
+#: recentchanges/updated_records.html
+msgid "When"
+msgstr "일시"
+
+#: RecentChanges.html admin/history.html admin/ip/view.html admin/loans_table.html
+#: admin/people/edits.html history.html recentchanges/render.html
+msgid "Who"
+msgstr "작성자"
+
+#: RecentChanges.html RecentChangesUsers.html admin/history.html admin/ip/view.html
+#: admin/people/edits.html history.html recentchanges/render.html
+#: recentchanges/updated_records.html
+msgid "Comment"
+msgstr "댓글"
+
+#: history.html
+msgid "Diff"
+msgstr "차이"
+
+#: history.html
+msgid "Compare"
+msgstr "비교"
+
+#: history.html
+msgid "See Diff"
+msgstr "차이 보기"
+
+#: history.html lib/history.html
+#, python-format
+msgid "View revision %s"
+msgstr "개정 %s 보기"
+
+#: history.html
+msgid "Compare this version..."
+msgstr "이 버전을 비교..."
+
+#: history.html
+msgid "...to this version"
+msgstr "...이 버전과"
+
+#: import_preview.html
+msgid "Import Preview"
+msgstr "가져오기 미리보기"
+
+#: import_preview.html
+msgid "Preview Import"
+msgstr "가져오기 미리보기"
+
+#: import_preview.html
+msgid "Show Raw Import Data"
+msgstr "원본 가져오기 데이터 보기"
+
+#: import_preview.html
+#, python-format
+msgid "New %(thing_type)s record will be created"
+msgstr "새 %(thing_type)s 레코드가 생성됩니다"
+
+#: import_preview.html
+#, python-format
+msgid "Changes to %(key)s"
+msgstr "%(key)s의 변경 사항"
+
+#: internalerror.html
+msgid "Internal Error"
+msgstr "내부 오류"
+
+#: internalerror.html
+msgid "A Problem Occurred"
+msgstr "문제가 발생했습니다"
+
+#: internalerror.html
+msgid "We're sorry, a problem occurred while responding to your request:"
+msgstr "죄송합니다. 요청에 응답하는 중 문제가 발생했습니다:"
+
+#: internalerror.html
+#, python-format
+msgid ""
+"The reference code %s and Sentry trace ID %s have been created to track this error and "
+"we will investigate as we're able."
+msgstr ""
+"The reference code %s and Sentry trace ID %s 되었습니다 생성d to track this error and we will "
+"investigate as we're able."
+
+#: internalerror.html
+#, python-format
+msgid ""
+"The reference code %s has been created to track this error and we will investigate as "
+"we're able."
+msgstr ""
+"The reference code %s 되었습니다 생성d to track this error and we will investigate as we're "
+"able."
+
+#: internalerror.html
+msgid "Return to the <a class=\"go-back-link\" href=\"javascript:;\">previous page</a>?"
+msgstr "<a class=\"go-back-link\" href=\"javascript:;\">이전 페이지</a>로 돌아가시겠습니까?"
+
+#: interstitial.html
+msgid "You are being redirected to your book"
+msgstr "책 페이지로 이동합니다"
+
+#: interstitial.html
+#, python-format
+msgid ""
+"This book is provided by %(book_provider)s, a third-party Open Library Trusted Book "
+"Provider"
+msgstr "이 책 is provided by %(book_provider)s, a third-party Open Library Trusted Book Provider"
+
+#: interstitial.html
+#, python-format
+msgid "In %(time)s seconds, you will be automatically redirected to: %(url)s"
+msgstr "In %(time)s seconds, you 됩니다 automatically redirected to: %(url)s"
+
+#: CreateListModal.html EditButtons.html account/notifications.html
+#: account/password/reset.html account/privacy.html admin/imports-add.html
+#: admin/permissions.html books/add.html databarEdit.html design/button.html
+#: interstitial.html merge/authors.html my_books/dropdown_content.html type/list/edit.html
+#: type/series/edit.html type/tag/form.html
+msgid "Cancel"
+msgstr "취소"
+
+#: interstitial.html
+msgid "Continue without waiting"
+msgstr "기다리지 않고 계속하기"
+
+#: lib/nav_head.html library_explorer.html
+msgid "Library Explorer"
+msgstr "라이브러리 탐색기"
+
+#: account/create.html books/custom_carousel.html librarian_dashboard/data_quality_table.html
+#: login.html search/work_search_facets.html
+msgid "Loading..."
+msgstr "불러오는 중..."
+
+#: lib/header_dropdown.html lib/nav_head.html login.html
+msgid "Log In"
+msgstr "로그인"
+
+#: login.html
+msgid "This is a development instance, the default credentials are automatically filled."
+msgstr "이것은 a development instance, the default credentials are automatically filled."
+
+#: login.html
+msgid "email:"
+msgstr "이메일:"
+
+#: login.html
+msgid "password:"
+msgstr "비밀번호:"
+
+#: login.html
+msgid ""
+"Log in to use your free Open Library card to borrow digital books from the nonprofit "
+"Internet Archive"
+msgstr ""
+"Log in to use your free Open Library card 대출하려면 digital 책 from the nonprofit Internet "
+"Archive"
+
+#: account/create.html login.html
+msgid "OR"
+msgstr "또는"
+
+#: account/create.html login.html
+#, python-format
+msgid "You are already logged into Open Library as %(user)s."
+msgstr "당신은 already logged into Open Library as %(user)s."
+
+#: account/create.html login.html
+msgid ""
+"If you'd like to create a new, different Open Library account, you'll need to <a "
+"href=\"javascript:;\" onclick=\"document.forms['hamburger-logout'].submit()\">log "
+"out</a> and start the signup process afresh."
+msgstr ""
+"If you'd like to 생성 a new, different Open Library 계정, you'll need to <a "
+"href=\"javascript:;\" onclick=\"document.forms['hamburger-logout'].제출()\">log out</a> "
+"and start the signup process afresh."
+
+#: login.html
+msgid ""
+"Please enter your <a href=\"https://archive.org\">Internet Archive</a> email and "
+"password to access your Open Library account."
+msgstr ""
+"다음 enter your <a href=\"https://archive.org\">Internet Archive</a> 이메일 and 비밀번호 to "
+"access your Open Library 계정."
+
+#: login.html openlibrary/plugins/upstream/forms.py
+msgid "Email"
+msgstr "이메일"
+
+#: login.html
+msgid "Forgot your Internet Archive email?"
+msgstr "Internet Archive 이메일을 잊으셨나요?"
+
+#: account/email/forgot-ia.html login.html openlibrary/plugins/upstream/forms.py
+msgid "Password"
+msgstr "비밀번호"
+
+#: login.html
+msgid "Forgot your Password?"
+msgstr "비밀번호를 잊으셨나요?"
+
+#: account/create.html login.html
+msgid "Toggle Password Visibility"
+msgstr "비밀번호 표시 전환"
+
+#: login.html
+msgid "Remember me"
+msgstr "로그인 상태 유지"
+
+#: login.html
+msgid "Don't have an account? <a href=\"/account/create\">Sign up now</a>."
+msgstr "Don't have an 계정? <a href=\"/계정/생성\">Sign up now</a>."
+
+#: messages.html
+msgid "Created new author record."
+msgstr "새 저자 레코드를 만들었습니다."
+
+#: messages.html
+msgid "Created new edition record."
+msgstr "새 판본 레코드를 만들었습니다."
+
+#: messages.html
+msgid "Created new work record."
+msgstr "새 작품 레코드를 만들었습니다."
+
+#: messages.html
+msgid "Added new book."
+msgstr "새 책을 추가했습니다."
+
+#: messages.html
+msgid "Thank you for improving the Open Library catalog!"
+msgstr "Open Library 카탈로그 개선에 기여해 주셔서 감사합니다!"
+
+#: BookPreview.html CreateListModal.html NotesModal.html ObservationsModal.html
+#: ShareModal.html covers/author_photo.html covers/book_cover.html covers/change.html
+#: lib/exports.html my_books/check_ins/check_in_prompt.html my_books/dropdown_content.html
+#: native_dialog.html
+msgid "Close"
+msgstr "닫기"
+
+#: notfound.html
+#, python-format
+msgid "%(path)s is not found"
+msgstr "%(path)s을(를) 찾을 수 없습니다"
+
+#: languages/notfound.html notfound.html
+msgid "404 - Page Not Found"
+msgstr "404 - 페이지를 찾을 수 없음"
+
+#: notfound.html
+#, python-format
+msgid "%(path)s does not exist."
+msgstr "%(path)s이(가) 존재하지 않습니다."
+
+#: notfound.html
+msgid "Create it?"
+msgstr "만드시겠습니까?"
+
+#: notfound.html
+msgid "Looking for a template/macro?"
+msgstr "템플릿/매크로를 찾고 있나요?"
+
+#: permission.html
+#, python-format
+msgid "Permission of %(key)s"
+msgstr "%(key)s의 권한"
+
+#: permission.html
+msgid "Permission of"
+msgstr "권한:"
+
+#: permission.html
+msgid "Permission"
+msgstr "권한"
+
+#: permission.html
+msgid "Child Permission"
+msgstr "하위 권한"
+
+#: permission_denied.html
+msgid "Permission Denied"
+msgstr "권한 거부됨"
+
+#: permission_denied.html
+msgid "Permission denied."
+msgstr "권한이 거부되었습니다."
+
+#: permission_denied.html
+#, python-format
+msgid ""
+"Only logged users are allowed to add records on Open Library. Please <a href=\"%s\">log"
+" in</a> to add a book."
+msgstr ""
+"Only logged users are allowed 추가하려면 레코드s on Open Library. 다음 <a href=\"%s\">log in</a> "
+"추가하려면 a 책."
+
+#: permission_denied.html
+#, python-format
+msgid ""
+"Only logged users are allowed to modify records on Open Library. Please <a "
+"href=\"%s\">log in</a> to edit this page."
+msgstr ""
+"Only logged users are allowed to modify 레코드s on Open Library. 다음 <a href=\"%s\">log "
+"in</a> 편집하려면 this 페이지."
+
+#: permission_denied.html
+#, python-format
+msgid "You may <a href=\"%s\">log in</a> if you have the required permissions."
+msgstr "필요한 권한이 있다면 <a href=\"%s\">로그인</a>할 수 있습니다."
+
+#: recaptcha.html
+msgid ""
+"Please satisfy the reCAPTCHA below. If you have security settings or privacy blockers "
+"installed, please disable them to see the reCAPTCHA."
+msgstr ""
+"다음 satisfy the reCAPTCHA below. If you have security settings or privacy blockers "
+"installed, please disable them to see the reCAPTCHA."
+
+#: recaptcha.html
+msgid "Incorrect. Please try again."
+msgstr "올바르지 않습니다. 다시 시도해 주세요."
+
+#: showamazon.html showbwb.html showgoogle_books.html
+msgid "Record details of"
+msgstr "레코드 세부 정보:"
+
+#: showamazon.html showbwb.html showgoogle_books.html
+msgid "This record came from"
+msgstr "이 레코드의 출처"
+
+#: showia.html showmarc.html
+msgid "Record ID"
+msgstr "레코드 ID"
+
+#: showia.html showmarc.html
+msgid "Source"
+msgstr "출처"
+
+#: books/add.html covers/add.html showia.html type/edition/view.html type/work/view.html
+msgid "Internet Archive"
+msgstr "Internet Archive"
+
+#: showia.html
+msgid "Download MARC XML"
+msgstr "MARC XML 다운로드"
+
+#: showia.html
+msgid "Download MARC binary"
+msgstr "MARC 바이너리 다운로드"
+
+#: showia.html showmarc.html
+msgid "Invalid MARC record."
+msgstr "잘못된 MARC 레코드입니다."
+
+#: showia.html showmarc.html
+msgid "LEADER:"
+msgstr "LEADER:"
+
+#: showmarc.html
+msgid "Download Link"
+msgstr "다운로드 링크"
+
+#: showmarc.html type/tag/index.html
+msgid "Next"
+msgstr "다음"
+
+#: status.html
+msgid "Open Library server status"
+msgstr "Open Library 서버 상태"
+
+#: status.html
+msgid "Server status"
+msgstr "서버 상태"
+
+#: status.html
+msgid "Testing Environment"
+msgstr "테스트 환경"
+
+#: status.html
+msgid "Deploy triggered!"
+msgstr "배포가 시작되었습니다!"
+
+#: status.html
+msgid "View Jenkins progress"
+msgstr "Jenkins 진행 상황 보기"
+
+#: status.html
+msgid "GitHub status refreshed."
+msgstr "GitHub 상태가 새로고침되었습니다."
+
+#: status.html
+msgid "PR numbers or URLs, space/comma separated"
+msgstr "PR 번호 또는 URL, 공백/쉼표로 구분"
+
+#: status.html
+msgid "Add PR(s)"
+msgstr "PR 추가"
+
+#: status.html
+msgid "PR"
+msgstr "PR"
+
+#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html
+#: search/advancedsearch.html status.html type/about/edit.html type/page/edit.html
+#: type/template/edit.html
+msgid "Title"
+msgstr "제목"
+
+#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html
+#: openlibrary/plugins/worksearch/code.py search/advancedsearch.html
+#: search/work_search_selected_facets.html status.html
+msgid "Author"
+msgstr "저자"
+
+#: status.html
+msgid "Assignee"
+msgstr "담당자"
+
+#: status.html
+msgid "Pinned Commit"
+msgstr "고정된 커밋"
+
+#: status.html
+msgid "Branch HEAD"
+msgstr "브랜치 HEAD"
+
+#: status.html
+msgid "Drift"
+msgstr "차이"
+
+#: status.html
+msgid "Enabled"
+msgstr "활성화됨"
+
+#: status.html
+msgid "up to date"
+msgstr "최신 상태"
+
+#: status.html
+msgid "unknown"
+msgstr "알 수 없음"
+
+#: status.html
+msgid "1 commit behind"
+msgstr "커밋 1개 뒤처짐"
+
+#: status.html
+#, python-format
+msgid "%(count)s commits behind"
+msgstr "커밋 %(count)s개 뒤처짐"
+
+#: admin/solr.html status.html
+msgid "Update"
+msgstr "업데이트"
+
+#: status.html
+msgid "Enable"
+msgstr "활성화"
+
+#: status.html
+msgid "Disable"
+msgstr "비활성화"
+
+#: lists/lists.html status.html type/list/edit.html type/series/edit.html
+msgid "Remove"
+msgstr "제거"
+
+#: status.html
+msgid "Selected PRs"
+msgstr "선택된 PR"
+
+#: status.html
+msgid "Refresh"
+msgstr "새로고침"
+
+#: status.html
+msgid "Deploy"
+msgstr "배포"
+
+#: status.html
+msgid "No PRs in testing set."
+msgstr "테스트 세트에 PR이 없습니다."
+
+#: status.html
+msgid "Last Build Result"
+msgstr "마지막 빌드 결과"
+
+#: status.html
+msgid "View PRs on GitHub"
+msgstr "GitHub에서 PR 보기"
+
+#: status.html
+msgid "Show changed files"
+msgstr "변경된 파일 보기"
+
+#: admin/inspect/store.html admin/people/index.html status.html type/author/edit.html
+#: type/language/view.html
+msgid "Name"
+msgstr "이름"
+
+#: status.html
+msgid "System information"
+msgstr "시스템 정보"
+
+#: status.html
+msgid "Features enabled"
+msgstr "활성화된 기능"
+
+#: subjects.html
+msgid "Edit tag for this subject"
+msgstr "이 주제의 태그 편집"
+
+#: subjects.html
+msgid "Create tag for this subject"
+msgstr "이 주제의 태그 만들기"
+
+#: subjects.html
+msgid "See all works"
+msgstr "모든 작품 보기"
+
+#: merge/authors.html publishers/view.html subjects.html type/author/view.html
+#, python-format
+msgid "%(count)d work"
+msgid_plural "%(count)d works"
+msgstr[0] "%(count)d 작품"
+
+#: subjects.html
+#, python-format
+msgid "Search for books with subject %(name)s."
+msgstr "%(name)s 주제의 책 검색"
+
+#: subjects.html
+msgid "Disambiguations"
+msgstr "동명이의/구분 항목"
+
+#: trending.html
+msgid "Now"
+msgstr "지금"
+
+#: admin/graphs.html admin/index.html my_books/check_ins/check_in_form.html
+#: my_books/check_ins/check_in_prompt.html trending.html
+msgid "Today"
+msgstr "오늘"
+
+#: admin/graphs.html trending.html
+msgid "This Week"
+msgstr "이번 주"
+
+#: admin/graphs.html stats/readinglog.html trending.html
+msgid "This Month"
+msgstr "이번 달"
+
+#: trending.html
+msgid "This Year"
+msgstr "올해"
+
+#: admin/index.html books/year_breadcrumb_select.html trending.html
+msgid "All Time"
+msgstr "전체 기간"
+
+#: home/index.html openlibrary/plugins/openlibrary/api.py trending.html
+msgid "Trending Books"
+msgstr "인기 상승 중인 책"
+
+#: trending.html
+msgid "See what readers from the community are adding to their bookshelves"
+msgstr "See what readers from the community are 추가ing to their 책helves"
+
+#: trending.html
+msgid "Earliest trending data is from October 2017"
+msgstr "가장 이른 인기 추세 데이터는 2017년 10월부터입니다"
+
+#: account/mybooks.html account/sidebar.html my_books/dropdown_content.html
+#: my_books/primary_action.html search/sort_options.html trending.html
+msgid "Want to Read"
+msgstr "읽고 싶어요"
+
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
+#: my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html
+#: trending.html
+msgid "Currently Reading"
+msgstr "읽는 중"
+
+#: LoanReadForm.html ReadButton.html admin/inspect/memcache.html
+#: book_providers/read_button.html books/edit/edition.html trending.html type/list/embed.html
+#: widget.html
+msgid "Read"
+msgstr "읽음"
+
+#: trending.html
+#, python-format
+msgid "Someone marked as %(shelf)s %(k_hours_ago)s"
+msgstr "누군가 %(k_hours_ago)s 전에 %(shelf)s로 표시했습니다"
+
+#: trending.html
+#, python-format
+msgid "Logged %(count)i times %(time_unit)s"
+msgstr "%(time_unit)s 동안 %(count)i회 기록됨"
+
+#: verify_human.html
+msgid "Human Verification"
+msgstr "사람 확인"
+
+#: verify_human.html
+msgid "Please verify you are human to continue."
+msgstr "계속하려면 사람임을 확인해 주세요."
+
+#: verify_human.html
+msgid "Verify you are human"
+msgstr "사람임을 확인"
+
+#: verify_human.html
+msgid "Verification failed. Please try again."
+msgstr "확인에 실패했습니다. 다시 시도해 주세요."
+
+#: verify_human.html
+msgid "Verifying..."
+msgstr "확인 중..."
+
+#: viewpage.html
+msgid "Revert to this revision?"
+msgstr "이 개정판으로 되돌리시겠습니까?"
+
+#: viewpage.html
+msgid "Revert to this revision"
+msgstr "이 개정판으로 되돌리기"
+
+#: widget.html
+#, python-format
+msgid "Read \"%(title)s\""
+msgstr "\"%(title)s\" 읽기"
+
+#: widget.html
+#, python-format
+msgid "Borrow \"%(title)s\""
+msgstr "\"%(title)s\" 대출"
+
+#: ReadButton.html books/edit/edition.html type/list/embed.html widget.html
+msgid "Borrow"
+msgstr "대출"
+
+#: widget.html
+#, python-format
+msgid "Join waitlist for \"%(title)s\""
+msgstr "\"%(title)s\" 대기자 명단에 추가"
+
+#: LoanStatus.html widget.html
+msgid "Join Waitlist"
+msgstr "대기자 명단에 추가"
+
+#: widget.html
+#, python-format
+msgid "Learn more about \"%(title)s\" at OpenLibrary"
+msgstr "OpenLibrary에서 \"%(title)s\" 자세히 알아보기"
+
+#: reading_goals/reading_goal_form.html widget.html
+msgid "Learn More"
+msgstr "자세히 알아보기"
+
+#: widget.html
+#, python-format
+msgid ""
+"on <a target=\"_blank\" rel=\"noopener noreferrer\" "
+"href=\"%(link)s\">openlibrary.org</a>"
+msgstr "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"%(link)s\">openlibrary.org</a>에서"
+
+#: work_search.html
+msgid "Search Books"
+msgstr "책 검색"
+
+#: work_search.html
+msgid "Keywords"
+msgstr "키워드"
+
+#: RecentChanges.html recentchanges/index.html work_search.html
+msgid "Everything"
+msgstr "전체"
+
+#: work_search.html
+msgid "Ebooks"
+msgstr "전자책"
+
+#: work_search.html
+msgid "This is only visible to super librarians."
+msgstr "이 내용은 슈퍼 사서에게만 보입니다."
+
+#: work_search.html
+msgid "Solr Editions"
+msgstr "Solr 판본"
+
+#: work_search.html
+msgid "The search engine returned an error."
+msgstr "검색 엔진에서 오류가 반환되었습니다."
+
+#: work_search.html
+msgid "Solr Debugging:"
+msgstr "Solr 디버깅:"
+
+#: work_search.html
+msgid "Full URL:"
+msgstr "전체 URL:"
+
+#: work_search.html
+#, python-format
+msgid "No <strong>%(path_id)s</strong> directly matched your search."
+msgstr "검색어와 직접 일치하는 <strong>%(path_id)s</strong>이(가) 없습니다."
+
+#: work_search.html
+msgid "Add a new book?"
+msgstr "새 책을 추가하시겠습니까?"
+
+#: search/authors.html search/lists.html search/subjects.html work_search.html
+msgid "Checking Search Inside matches"
+msgstr "본문 검색 일치 항목 확인 중"
+
+#: account/reading_log.html search/authors.html search/lists.html search/subjects.html
+#: work_search.html
+#, python-format
+msgid "%(count)s hit"
+msgid_plural "%(count)s hits"
+msgstr[0] "%(count)s개 일치"
+
+#: work_search.html
+#, python-format
+msgid "Searching solr took %(count)s seconds"
+msgstr "Solr 검색에 %(count)s초가 걸렸습니다"
+
+#: about/index.html
+msgid "The Open Library Team"
+msgstr "Open Library 팀"
+
+#: about/index.html
+msgid ""
+"Open Library is made possible because of a dedicated team of staff and over 100 "
+"volunteers from around the globe."
+msgstr "Open Library는 전 세계 직원들과 100명 이상의 자원봉사자로 이루어진 헌신적인 팀 덕분에 운영됩니다."
+
+#: about/index.html
+msgid "Want to join us?"
+msgstr "함께하고 싶으신가요?"
+
+#: about/index.html
+msgid "Role:"
+msgstr "역할:"
+
+#: about/index.html lib/nav_head.html type/tag/index.html
+msgid "All"
+msgstr "전체"
+
+#: about/index.html
+msgid "Staff"
+msgstr "스태프"
+
+#: about/index.html
+msgid "Fellows"
+msgstr "펠로우"
+
+#: about/index.html
+msgid "Volunteers"
+msgstr "자원봉사자"
+
+#: about/index.html
+msgid "Department:"
+msgstr "부서:"
+
+#: about/index.html
+msgid "Communications"
+msgstr "커뮤니케이션"
+
+#: about/index.html
+msgid "Design"
+msgstr "디자인"
+
+#: about/index.html
+msgid "Engineering"
+msgstr "엔지니어링"
+
+#: about/index.html
+msgid "Librarianship"
+msgstr "사서 업무"
+
+#: about/index.html
+msgid ""
+"If you volunteer with Open Library and would like to be listed as part of the team, "
+"then complete the <a href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">Open Library team "
+"information form</a>."
+msgstr ""
+"If you volunteer with Open Library and would like to be 목록ed as part of the team, then "
+"complete the <a href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">Open Library team "
+"information form</a>."
+
+#: account/create.html openlibrary/plugins/upstream/forms.py
+msgid "Must be a valid email address"
+msgstr "유효한 이메일 주소여야 합니다"
+
+#: account/create.html openlibrary/plugins/upstream/forms.py
+msgid "Must be between 3 and 20 characters"
+msgstr "3자 이상 20자 이하여야 합니다"
+
+#: account/create.html
+msgid "Username may only contain numbers, letters, - or _"
+msgstr "사용자 이름에는 숫자, 문자, - 또는 _만 사용할 수 있습니다"
+
+#: account/create.html
+msgid "A qualifying program must be selected"
+msgstr "자격 프로그램을 선택해야 합니다"
+
+#: account/create.html
+msgid "Sign Up to Open Library"
+msgstr "Open Library 가입"
+
+#: account/create.html lib/header_dropdown.html lib/nav_head.html
+msgid "Sign Up"
+msgstr "가입"
+
+#: account/create.html
+msgid ""
+"Get your free Open Library card and borrow digital books from the nonprofit Internet "
+"Archive"
+msgstr "Get your free Open Library card and 대출 digital 책 from the nonprofit Internet Archive"
+
+#: account/create.html type/author/view.html
+msgid "Success!"
+msgstr "성공!"
+
+#: account/create.html
+msgid "Your URL"
+msgstr "내 URL"
+
+#: account/create.html
+msgid "screenname"
+msgstr "화면 이름"
+
+#: account/create.html
+msgid ""
+"I want to receive news, announcements, and resources from the <a "
+"href=\"https://archive.org/\">Internet Archive</a>, the non-profit that runs Open "
+"Library."
+msgstr ""
+"Open Library를 운영하는 비영리 단체 <a href=\"https://archive.org/\">Internet Archive</a>의 소식, "
+"공지, 자료를 받고 싶습니다."
+
+#: account/create.html
+msgid ""
+"I want to apply* for <a href=\"https://help.archive.org/help/program-overview/\" "
+"target=\"_blank\" rel=\"noopener noreferrer\">special print disability access</a> "
+"through a qualifying program."
+msgstr ""
+"자격 프로그램을 통해 <a href=\"https://help.archive.org/help/program-overview/\" "
+"target=\"_blank\" rel=\"noopener noreferrer\">인쇄물 이용 장애 특별 접근</a>을 신청*하고 싶습니다."
+
+#: account/create.html
+msgid "Select qualifying program"
+msgstr "자격 프로그램 선택"
+
+#: account/create.html
+msgid ""
+"* Please use the email address associated with this qualifying program. You will "
+"receive an email after activation with next steps."
+msgstr ""
+"* 다음 use the 이메일 추가ress associated with this qualifying program. You will receive an "
+"이메일 after activation with next steps."
+
+#: account/create.html
+msgid "Sign Up with Email"
+msgstr "이메일로 가입"
+
+#: account/create.html
+msgid ""
+"By signing up, you agree to the Internet Archive's <a class=\"ol-signup-form__link\" "
+"href=\"//archive.org/about/terms.php\" target=\"_blank\" rel=\"noopener "
+"noreferrer\">Terms of Service</a>."
+msgstr ""
+"가입하면 Internet Archive의 <a class=\"ol-signup-form__link\" "
+"href=\"//archive.org/about/terms.php\" target=\"_blank\" rel=\"noopener "
+"noreferrer\">서비스 약관</a>에 동의하게 됩니다."
+
+#: account/create.html
+msgid "Already have an account? <a href=\"/account/login\">Log in</a>"
+msgstr "Already have an 계정? <a href=\"/계정/login\">Log in</a>"
+
+#: account/delete.html
+msgid "Delete Account"
+msgstr "계정 삭제"
+
+#: account/delete.html
+msgid "Sorry, this functionality is not yet implemented."
+msgstr "죄송합니다. 이 기능은 아직 구현되지 않았습니다."
+
+#: account/follows.html
+msgid "There is nothing to see here yet."
+msgstr "아직 볼 내용이 없습니다."
+
+#: account/import.html
+msgid "Import from Goodreads"
+msgstr "Goodreads에서 가져오기"
+
+#: account/import.html
+msgid ""
+"For instructions on exporting data refer to: <a "
+"href=\"https://www.goodreads.com/review/import\">Goodreads Import/Export</a>"
+msgstr ""
+"For instructions on exporting data refer to: <a "
+"href=\"https://www.goodreads.com/리뷰/import\">Goodreads Import/Export</a>"
+
+#: account/import.html
+msgid "File size limit 10MB and .csv file type only"
+msgstr "파일 크기는 10MB 이하, .csv 파일만 가능"
+
+#: account/import.html
+msgid "Load Books"
+msgstr "책 불러오기"
+
+#: account/import.html
+msgid "Export your Reading Log"
+msgstr "독서 기록 내보내기"
+
+#: account/import.html
+msgid "Download a copy of your reading log."
+msgstr "독서 기록 사본을 다운로드합니다."
+
+#: account/import.html
+msgid "What is a reading log?"
+msgstr "독서 기록이란 무엇인가요?"
+
+#: account/import.html
+msgid "Download (.csv format)"
+msgstr "다운로드(.csv 형식)"
+
+#: account/import.html
+msgid "Export your book notes"
+msgstr "책 노트 내보내기"
+
+#: account/import.html
+msgid "Download a copy of your book notes."
+msgstr "책 노트 사본을 다운로드합니다."
+
+#: account/import.html
+msgid "What are book notes?"
+msgstr "책 노트란 무엇인가요?"
+
+#: account/import.html
+msgid "Export your reviews"
+msgstr "리뷰 내보내기"
+
+#: account/import.html
+msgid "Download a copy of your review tags."
+msgstr "리뷰 태그 사본을 다운로드합니다."
+
+#: account/import.html
+msgid "What are review tags?"
+msgstr "리뷰 태그란 무엇인가요?"
+
+#: account/import.html
+msgid "Export your list overview"
+msgstr "목록 개요 내보내기"
+
+#: account/import.html
+msgid "Download a summary of your lists and their contents."
+msgstr "목록과 그 내용의 요약을 다운로드합니다."
+
+#: account/import.html
+msgid "What are lists?"
+msgstr "목록이란 무엇인가요?"
+
+#: account/import.html
+msgid "Export your star ratings"
+msgstr "별점 내보내기"
+
+#: account/import.html
+msgid "Download a copy of your star ratings."
+msgstr "별점 사본을 다운로드합니다."
+
+#: account/import.html
+msgid "What are star ratings?"
+msgstr "별점이란 무엇인가요?"
+
+#: account/import.html
+msgid "Importing..."
+msgstr "가져오는 중..."
+
+#: account/import.html
+msgid "Reason"
+msgstr "이유"
+
+#: account/import.html
+msgid "No ISBN"
+msgstr "ISBN 없음"
+
+#: account/loan_history.html
+msgid "No loans found in your borrow history."
+msgstr "대출 기록에서 대출을 찾을 수 없습니다."
+
+#: account/loan_history.html
+msgid "<a href=\"/search\">Search for a book</a> to borrow."
+msgstr "<a href=\"/검색\">검색 for a 책</a> 대출하려면."
+
+#: account/loans.html
+msgid "You've not checked out any books at this moment."
+msgstr "현재 대출 중인 책이 없습니다."
+
+#: account/loans.html
+#, python-format
+msgid "%(count)d Current Loan"
+msgid_plural "%(count)d Current Loans"
+msgstr[0] "현재 대출 %(count)d건"
+
+#: account/loans.html admin/loans_table.html
+msgid "Loan Expires"
+msgstr "대출 만료"
+
+#: account/loans.html
+msgid "Loan actions"
+msgstr "대출 작업"
+
+#: account/loans.html
+#, python-format
+msgid "There is %(count)d person waiting for this book."
+msgid_plural "There are %(count)d people waiting for this book."
+msgstr[0] "이 책을 기다리는 사람이 %(count)d명 있습니다."
+
+#: ManageLoansButtons.html account/loans.html
+msgid "Not yet downloaded."
+msgstr "아직 다운로드하지 않음."
+
+#: ManageLoansButtons.html account/loans.html
+msgid "Download Now"
+msgstr "지금 다운로드"
+
+#: account/loans.html
+msgid "Return via<br/>Adobe Digital Editions"
+msgstr "반납 via<br/>Adobe Digital 편집ions"
+
+#: account/loans.html
+msgid "Books You're Waiting For"
+msgstr "대기 중인 책"
+
+#: account/loans.html
+msgid "You are not waiting for any books at this moment."
+msgstr "현재 대기 중인 책이 없습니다."
+
+#: account/loans.html
+msgid "Leave the Waiting List"
+msgstr "대기자 명단에서 나가기"
+
+#: account/loans.html
+msgid "Are you sure you want to leave the waiting list of<br/><strong>TITLE</strong>?"
+msgstr "정말 leave the 대기자 명단 of<br/><strong>TITLE</strong>?"
+
+#: ProlificAuthors.html account/loans.html authors/index.html lists/list_follow.html
+#: lists/showcase.html publishers/view.html search/authors.html search/publishers.html
+#: search/subjects.html
+#, python-format
+msgid "%(count)d book"
+msgid_plural "%(count)d books"
+msgstr[0] "%(count)d권"
+
+#: RecentChangesAdmin.html account/loans.html admin/loans_table.html
+msgid "Actions"
+msgstr "작업"
+
+#: account/loans.html
+#, python-format
+msgid "Waiting for 1 day"
+msgid_plural "Waiting for %(count)d days"
+msgstr[0] "%(count)d일째 대기 중"
+
+#: account/loans.html
+msgid "You are the next person to receive this book."
+msgstr "당신은 the next person to receive 이 책."
+
+#: ManageWaitlistButton.html account/loans.html
+#, python-format
+msgid "There is one person ahead of you in the waiting list."
+msgid_plural "There are %(count)d people ahead of you in the waiting list."
+msgstr[0] "대기자 명단에서 앞에 %(count)d명이 있습니다."
+
+#: ManageWaitlistButton.html account/loans.html
+msgid "You have less than an hour to borrow it."
+msgstr "당신은 less than an hour 대출하려면 it."
+
+#: account/loans.html
+#, python-format
+msgid "You have one more hour to borrow it."
+msgid_plural "You have %(hours)d more hours to borrow it."
+msgstr[0] "대출할 수 있는 시간이 %(hours)d시간 남았습니다."
+
+#: ManageWaitlistButton.html account/loans.html
+msgid "Borrow Now"
+msgstr "지금 대출"
+
+#: ManageWaitlistButton.html account/loans.html
+msgid "Leave the waiting list?"
+msgstr "대기자 명단에서 나가시겠습니까?"
+
+#: account/loans.html
+msgid ""
+"Looking for a book to borrow?  Check out our staff picks, or search for a book on a "
+"specific subject:"
+msgstr "Looking for a 책 대출하려면?  Check out our staff picks, or 검색 for a 책 on a specific 주제:"
+
+#: account/loans.html home/index.html
+msgid "Books We Love"
+msgstr "우리가 사랑하는 책"
+
+#: account/loans.html
+msgid "Or, check out our <a href=\"/collections\">special collections</a>."
+msgstr "또는 <a href=\"/collections\">특별 컬렉션</a>을 확인해 보세요."
+
+#: account/mybooks.html
+msgid "No books are on this shelf"
+msgstr "이 서가에는 책이 없습니다"
+
+#: account/mybooks.html account/sidebar.html
+msgid "My Loans"
+msgstr "내 대출"
+
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
+#: my_books/dropdown_content.html my_books/primary_action.html
+#: openlibrary/plugins/upstream/mybooks.py search/sort_options.html
+msgid "Already Read"
+msgstr "이미 읽음"
+
+#: account/mybooks.html type/user/view.html
+msgid "This reader has chosen to make their Reading Log private."
+msgstr "This reader has chosen to make their 독서 기록 비공개."
+
+#: account/mybooks.html
+#, python-format
+msgid "%(year_span)s reading goal"
+msgstr "%(year_span)s 독서 목표"
+
+#: account/mybooks.html
+msgid "View All Lists"
+msgstr "모든 목록 보기"
+
+#: account/mybooks.html
+msgid "My Stats"
+msgstr "내 통계"
+
+#: account/mybooks.html account/sidebar.html account/topmenu.html
+msgid "My Reading Stats"
+msgstr "내 독서 통계"
+
+#: account/mybooks.html account/sidebar.html books/mybooks_breadcrumb_select.html
+#: openlibrary/plugins/upstream/account.py
+msgid "Loan History"
+msgstr "대출 기록"
+
+#: account/mybooks.html account/sidebar.html
+msgid "My Notes"
+msgstr "내 노트"
+
+#: account/mybooks.html account/sidebar.html
+msgid "My Reviews"
+msgstr "내 리뷰"
+
+#: account/mybooks.html account/sidebar.html
+msgid "Import & Export Options"
+msgstr "가져오기 및 내보내기 옵션"
+
+#: account/not_verified.html account/verify/failed.html
+msgid "Oops!"
+msgstr "이런!"
+
+#: account/not_verified.html
+msgid "The email address you signed up with needs to be verified."
+msgstr "The 이메일 추가ress you signed up with needs to be verified."
+
+#: account/not_verified.html
+#, python-format
+msgid ""
+"When you created your account, we sent an email to %(email)s that contained a link for "
+"you to verify your email address. We need you to click that link, please."
+msgstr ""
+"When you 생성d your 계정, we sent an 이메일 to %(email)s that contained a link for you to "
+"verify your 이메일 추가ress. We need you to click that link, please."
+
+#: account/not_verified.html
+msgid "If you can't find the email, just hit this button to send a fresh one:"
+msgstr "If you can't find the 이메일, just hit this button to send a fresh one:"
+
+#: account/not_verified.html account/verify/failed.html
+msgid "Resend the verification email"
+msgstr "확인 이메일 다시 보내기"
+
+#: account/not_verified.html account/verify/failed.html
+msgid "Thanks!"
+msgstr "감사합니다!"
+
+#: BookByline.html FulltextSearchSuggestionItem.html SearchResultsWork.html
+#: account/notes.html account/observations.html
+msgid "Unknown author"
+msgstr "알 수 없는 저자"
+
+#: account/notes.html
+msgid "My notes for an edition of "
+msgstr "다음 판본에 대한 내 노트: "
+
+#: account/notes.html
+msgid "Title Missing"
+msgstr "제목 없음"
+
+#: account/notes.html lists/export_as_html.html type/work/editions.html
+msgid "Publish date unknown"
+msgstr "출판일 알 수 없음"
+
+#: account/notes.html books/edition-sort.html lists/export_as_html.html
+#: type/work/editions.html
+msgid "Publisher unknown"
+msgstr "출판사 알 수 없음"
+
+#: account/notes.html
+#, python-format
+msgid "in %(language)s"
+msgstr "%(language)s로"
+
+#: NotesModal.html account/notes.html
+msgid "Delete Note"
+msgstr "노트 삭제"
+
+#: NotesModal.html account/notes.html
+msgid "Save Note"
+msgstr "노트 저장"
+
+#: account/notes.html
+msgid "No notes found."
+msgstr "노트를 찾을 수 없습니다."
+
+#: account/notifications.html
+msgid "Notifications from Open Library"
+msgstr "Open Library 알림"
+
+#: account/notifications.html
+msgid "Notifications"
+msgstr "알림"
+
+#: account/notifications.html
+msgid ""
+"Notifications are connected to Lists at the moment. If one of the books on your list "
+"gets edited, or a new book comes into the catalog, we'll let you know, if you want."
+msgstr ""
+"Notifications are connected to Lists at the moment. If one of the 책 on your 목록 gets "
+"편집ed, or a new 책 comes into the catalog, we'll let you know, if you want."
+
+#: account/notifications.html
+msgid "Would you like to receive very occasional emails from Open Library?"
+msgstr "하시겠습니까 receive very occasional 이메일s from Open Library?"
+
+#: account/notifications.html
+msgid "No, thank you"
+msgstr "아니요, 괜찮습니다"
+
+#: account/notifications.html
+msgid "Yes! Please!"
+msgstr "네! 부탁합니다!"
+
+#: EditButtons.html account/notifications.html account/privacy.html admin/block.html
+#: admin/spamwords.html covers/manage.html design/button.html
+msgid "Save"
+msgstr "저장"
+
+#: EditionNavBar.html account/observations.html books/mybooks_breadcrumb_select.html
+#: openlibrary/plugins/upstream/mybooks.py
+msgid "Reviews"
+msgstr "리뷰"
+
+#: account/observations.html admin/inspect/memcache.html design/button.html
+#: design/popover.html
+msgid "Delete"
+msgstr "삭제"
+
+#: account/observations.html
+msgid "Update Reviews"
+msgstr "리뷰 업데이트"
+
+#: account/observations.html
+msgid "No observations found."
+msgstr "관찰 항목을 찾을 수 없습니다."
+
+#: account/privacy.html
+msgid "Your Privacy on Open Library"
+msgstr "Open Library에서의 개인정보"
+
+#: account/privacy.html
+msgid "Privacy & Content Moderation Settings"
+msgstr "개인정보 및 콘텐츠 관리 설정"
+
+#: account/privacy.html
+msgid "Would you like to make your <a href=\"/account/books\">Reading Log</a> public?"
+msgstr "하시겠습니까 make your <a href=\"/계정/책\">독서 기록</a> 공개?"
+
+#: account/privacy.html
+msgid ""
+"This will enable others to see what books you want to read, are reading, or have "
+"already read. Patrons with reading logs set to public may be followed."
+msgstr ""
+"This will enable others to see what 책 you want to read, are reading, or have already "
+"read. Patrons with 독서 기록s set to 공개 may be followed."
+
+#: account/privacy.html admin/people/view.html
+msgid "Yes"
+msgstr "예"
+
+#: account/privacy.html admin/people/view.html books/edit/edition.html
+msgid "No"
+msgstr "아니요"
+
+#: account/privacy.html
+msgid "Enable Safe Mode?"
+msgstr "안전 모드를 활성화할까요?"
+
+#: account/privacy.html
+msgid "Safe Mode blurs book covers that have been flagged as having sensitive imagery."
+msgstr "Safe Mode blurs 책 covers that 되었습니다 flagged as having sensitive imagery."
+
+#: account/reading_log.html
+#, python-format
+msgid "Books %(username)s is reading"
+msgstr "%(username)s님이 읽고 있는 책"
+
+#: account/reading_log.html
+#, python-format
+msgid ""
+"%(username)s is reading %(total)d books. Join %(username)s on OpenLibrary.org and tell "
+"the world what you're reading."
+msgstr ""
+"%(username)s is reading %(total)d 책. Join %(username)s on OpenLibrary.org and tell the "
+"world what you're reading."
+
+#: account/reading_log.html
+#, python-format
+msgid "Books %(username)s wants to read"
+msgstr "%(username)s님이 읽고 싶어 하는 책"
+
+#: account/reading_log.html
+#, python-format
+msgid ""
+"%(username)s wants to read %(total)d books. Join %(username)s on OpenLibrary.org and "
+"share the books that you'll soon be reading!"
+msgstr ""
+"%(username)s wants to read %(total)d 책. Join %(username)s on OpenLibrary.org and share "
+"the 책 that you'll soon be reading!"
+
+#: account/reading_log.html
+#, python-format
+msgid "Books %(username)s has read in %(year)d"
+msgstr "%(username)s님이 %(year)d년에 읽은 책"
+
+#: account/reading_log.html
+#, python-format
+msgid ""
+"%(username)s has read %(total)d books in %(year)d. Join %(username)s on OpenLibrary.org"
+" and tell the world about the books that you care about."
+msgstr ""
+"%(username)s has read %(total)d 책 in %(year)d. Join %(username)s on OpenLibrary.org and"
+" tell the world about the 책 that you care about."
+
+#: account/reading_log.html
+#, python-format
+msgid "Books %(username)s has read"
+msgstr "%(username)s님이 읽은 책"
+
+#: account/reading_log.html
+#, python-format
+msgid ""
+"%(username)s has read %(total)d books. Join %(username)s on OpenLibrary.org and tell "
+"the world about the books that you care about."
+msgstr ""
+"%(username)s has read %(total)d 책. Join %(username)s on OpenLibrary.org and tell the "
+"world about the 책 that you care about."
+
+#: account/reading_log.html
+#, python-format
+msgid "Books in %(username)s feed"
+msgstr "%(username)s님의 피드에 있는 책"
+
+#: account/reading_log.html
+#, python-format
+msgid "Books added by people %(username)s follows"
+msgstr "Books 추가ed by people %(username)s follows"
+
+#: account/reading_log.html
+msgid "Search your reading log"
+msgstr "your reading log 검색"
+
+#: account/reading_log.html type/author/view.html
+#, python-format
+msgid "— Show <a href=\"%(url)s\">only ebooks</a>?"
+msgstr "— Show <a href=\"%(url)s\">only e책</a>?"
+
+#: account/reading_log.html
+#, python-format
+msgid "— Show <a href=\"%(url)s\">everything</a> in this shelf?"
+msgstr "— 이 서가의 <a href=\"%(url)s\">모든 항목</a>을 표시할까요?"
+
+#: account/reading_log.html
+msgid "No results found in this shelf"
+msgstr "이 서가에서 결과를 찾을 수 없습니다"
+
+#: account/reading_log.html
+#, python-format
+msgid "Search all of Open Library for \"%s\"?"
+msgstr "all of Open Library for \"%s\"? 검색"
+
+#: account/reading_log.html
+msgid "You haven't marked any books as read for this year."
+msgstr "당신은n't marked any 책 as read for this year."
+
+#: account/reading_log.html
+msgid "You haven't added any books to this shelf yet."
+msgstr "당신은n't 추가ed any 책 to this shelf yet."
+
+#: account/reading_log.html
+msgid ""
+"<a href=\"/search\">Search for a book</a> to add to your reading log. <a "
+"href=\"/help/faq/reading-log\">Learn more</a> about the reading log."
+msgstr ""
+"<a href=\"/검색\">검색 for a 책</a> 추가하려면 to your 독서 기록. <a href=\"/help/faq/reading-"
+"log\">Learn more</a> about the 독서 기록."
+
+#: account/reading_log.html
+msgid ""
+"There are no recent books in your feed. When you follow public accounts, their book "
+"updates will appear here."
+msgstr ""
+"다음이 있습니다: no recent 책 in your feed. When you follow 공개 계정s, their 책 updates will appear"
+" here."
+
+#: account/readinglog_shelf_name.html
+msgid "Want To Read"
+msgstr "읽고 싶어요"
+
+#: account/readinglog_stats.html
+#, python-format
+msgid "My %(shelf_name)s Stats"
+msgstr "내 %(shelf_name)s 통계"
+
+#: account/readinglog_stats.html home/loans.html lib/nav_head.html
+msgid "My Books"
+msgstr "내 책"
+
+#: account/readinglog_stats.html
+#, python-format
+msgid ""
+"Displaying stats about <strong>%(works_count)d</strong> books. Note all charts show "
+"only the top 20 bars. Note reading log stats are private."
+msgstr ""
+"Displaying stats about <strong>%(works_count)d</strong> 책. Note all charts show only "
+"the top 20 bars. Note 독서 기록 stats are 비공개."
+
+#: account/readinglog_stats.html
+msgid "Author Stats"
+msgstr "저자 통계"
+
+#: account/readinglog_stats.html
+msgid "Most Read Authors"
+msgstr "가장 많이 읽은 저자"
+
+#: account/readinglog_stats.html
+msgid "Works by Author Sex"
+msgstr "저자 성별별 작품"
+
+#: account/readinglog_stats.html
+msgid "Works by Author Country of Citizenship"
+msgstr "저자 시민권 국가별 작품"
+
+#: account/readinglog_stats.html
+msgid "Works by Author Country of Birth"
+msgstr "저자 출생 국가별 작품"
+
+#: account/readinglog_stats.html
+msgid ""
+"Demographic statistics powered by <a href=\"https://www.wikidata.org/\">Wikidata</a>. "
+"Here's a <a id=\"wd-query-sample\" href=\"\">sample</a> of the query used. <br "
+"/>Improve these stats by adding the Wikidata author identifier following <a "
+"href=\"https://openlibrary.org/help/faq/editing.en#author-identifiers-purpose\">these "
+"instructions</a>."
+msgstr ""
+"Demographic statistics powered by <a href=\"https://www.wikidata.org/\">Wikidata</a>. "
+"Here's a <a id=\"wd-query-sample\" href=\"\">sample</a> of the query used. <br "
+"/>Improve these stats by 추가ing the Wikidata 저자 identifier following <a "
+"href=\"https://openlibrary.org/help/faq/편집ing.en#저자-identifiers-purpose\">these "
+"instructions</a>."
+
+#: account/readinglog_stats.html
+msgid "Work Stats"
+msgstr "작품 통계"
+
+#: account/readinglog_stats.html
+msgid "Works by Subject"
+msgstr "주제별 작품"
+
+#: account/readinglog_stats.html
+msgid "Works by People"
+msgstr "인물별 작품"
+
+#: account/readinglog_stats.html
+msgid "Works by Places"
+msgstr "장소별 작품"
+
+#: account/readinglog_stats.html
+msgid "Works by Time Period"
+msgstr "시대별 작품"
+
+#: account/readinglog_stats.html
+msgid "Matching works"
+msgstr "일치하는 작품"
+
+#: account/readinglog_stats.html
+msgid "Click on a bar to see matching works"
+msgstr "Click on a bar to see matching 작품"
+
+#: account/sidebar.html books/mybooks_breadcrumb_select.html
+#: openlibrary/plugins/upstream/mybooks.py
+msgid "My Feed"
+msgstr "내 피드"
+
+#: account/sidebar.html
+#, python-format
+msgid "%(year)d Reading Goal"
+msgstr "%(year)d년 독서 목표"
+
+#: account/sidebar.html
+#, python-format
+msgid "Set %(year_span)s reading goal"
+msgstr "%(year_span)s 독서 목표 설정"
+
+#: account/sidebar.html search/sort_options.html type/user/view.html
+msgid "Reading Log"
+msgstr "독서 기록"
+
+#: account/sidebar.html
+msgid "My lists"
+msgstr "내 목록"
+
+#: EditionNavBar.html SearchNavigation.html account/sidebar.html lib/nav_head.html
+#: lists/home.html recentchanges/index.html type/edition/view.html type/list/embed.html
+#: type/user/view.html type/work/view.html
+msgid "Lists"
+msgstr "목록"
+
+#: account/sidebar.html type/user/view.html
+msgid "See All"
+msgstr "모두 보기"
+
+#: account/sidebar.html type/list/edit.html type/series/edit.html
+msgid "Create a list"
+msgstr "목록 만들기"
+
+#: account/sidebar.html
+msgid "Untitled list"
+msgstr "제목 없는 목록"
+
+#: account/topmenu.html
+msgid "Import & Export"
+msgstr "가져오기 및 내보내기"
+
+#: account/topmenu.html
+#, python-format
+msgid "Privacy settings: %(public)s"
+msgstr "개인정보 설정: %(public)s"
+
+#: account/verify.html
+msgid "Verification email sent"
+msgstr "확인 이메일을 보냈습니다"
+
+#: account/password/reset_success.html account/verify.html account/verify/activated.html
+#: account/verify/success.html
+#, python-format
+msgid "Hi, %(user)s"
+msgstr "안녕하세요, %(user)s님"
+
+#: account/verify.html
+#, python-format
+msgid ""
+"We’ve sent an email to %(email)s containing a link to verify your account. Click/tap on"
+" the link to finish creating your Internet Archive account."
+msgstr ""
+"We’ve sent an 이메일 to %(email)s containing a link to verify your 계정. Click/tap on the "
+"link to finish creating your Internet Archive 계정."
+
+#: account/verify.html
+msgid "Then, come back to Open Library and find some great books!"
+msgstr "그런 다음 Open Library로 돌아와 좋은 책을 찾아보세요!"
+
+#: account/view.html
+msgid "Yearly Reading Goal"
+msgstr "연간 독서 목표"
+
+#: account/view.html books/mybooks_breadcrumb_select.html
+msgid "Following"
+msgstr "팔로잉"
+
+#: account/view.html books/mybooks_breadcrumb_select.html
+msgid "Followers"
+msgstr "팔로워"
+
+#: account/view.html design/popover.html type/edition/modal_links.html
+#: type/edition/title_and_author.html
+msgid "Share"
+msgstr "공유"
+
+#: account/view.html
+msgid "Your book notes are private and cannot be viewed by other patrons."
+msgstr "Your 책 노트 are 비공개 and 할 수 없습니다 viewed by other patrons."
+
+#: account/view.html
+msgid "Your book reviews will be shared anonymously with other patrons."
+msgstr "Your 책 리뷰 됩니다 shared anonymously with other patrons."
+
+#: account/yrg_banner.html
+#, python-format
+msgid "Set your %(year)s Yearly Reading Goal:"
+msgstr "Set your %(year)s 연간 독서 목표:"
+
+#: account/yrg_banner.html
+msgid "Set my goal"
+msgstr "내 목표 설정"
+
+#: account/email/forgot-ia.html
+msgid "Forgot Your Internet Archive Email?"
+msgstr "Internet Archive 이메일을 잊으셨나요?"
+
+#: account/email/forgot-ia.html
+msgid ""
+"Please enter your Open Library email and password, and we’ll retrieve your Archive.org "
+"email."
+msgstr "다음 enter your Open Library 이메일 and 비밀번호, and we’ll retrieve your Archive.org 이메일."
+
+#: account/email/forgot-ia.html
+msgid "Your email is:"
+msgstr "내 이메일:"
+
+#: account/email/forgot-ia.html
+msgid "Return to Log In?"
+msgstr "로그인으로 돌아가시겠습니까?"
+
+#: account/email/forgot-ia.html
+msgid "Open Library Email"
+msgstr "Open Library 이메일"
+
+#: account/email/forgot-ia.html
+msgid "Retrieve Archive.org Email"
+msgstr "Archive.org 이메일 찾기"
+
+#: account/email/forgot-ia.html account/password/forgot.html
+msgid "Forgot your Archive.org Password?"
+msgstr "Archive.org 비밀번호를 잊으셨나요?"
+
+#: account/password/forgot.html account/password/sent.html
+msgid "Username/Password Reminder"
+msgstr "사용자 이름/비밀번호 알림"
+
+#: account/password/forgot.html
+msgid "Click here."
+msgstr "여기를 클릭하세요."
+
+#: account/password/forgot.html
+msgid "Send It"
+msgstr "보내기"
+
+#: account/password/reset.html admin/people/view.html
+msgid "Reset Password"
+msgstr "비밀번호 재설정"
+
+#: account/password/reset.html
+msgid "Please enter a new password for your Open Library account."
+msgstr "다음 enter a new 비밀번호 for your Open Library 계정."
+
+#: account/password/reset.html design/button.html
+msgid "Reset"
+msgstr "재설정"
+
+#: account/password/reset_success.html
+msgid "Password Reset Successful"
+msgstr "비밀번호 재설정 성공"
+
+#: account/password/reset_success.html
+msgid ""
+"Your password has been updated. Please <a href='/account/login?redirect=/'>log in to "
+"continue</a>."
+msgstr "Your 비밀번호 되었습니다 updated. 다음 <a href='/계정/login?redirect=/'>log in 계속하려면</a>."
+
+#: account/password/sent.html
+msgid "Done."
+msgstr "완료."
+
+#: account/password/sent.html
+#, python-format
+msgid ""
+"We've sent an email to %(email)s with a reminder of your username and instructions to "
+"help you reset your Open Library password. Please check your inbox for a note from us."
+msgstr ""
+"We've sent an 이메일 to %(email)s with a reminder of your username and instructions to "
+"help you reset your Open Library 비밀번호. 다음 check your inbox for a note from us."
+
+#: account/security/check_email.html
+msgid "Account Security Check — 2026-04-28T18Z"
+msgstr "Account Security Check — 2026-04-28T18Z"
+
+#: account/security/check_email.html
+msgid "Account Security Check"
+msgstr "계정 보안 확인"
+
+#: account/security/check_email.html
+msgid "Incident date: 2026-04-28T18Z"
+msgstr "사건 날짜: 2026-04-28T18Z"
+
+#: account/security/check_email.html
+msgid "Check whether your Open Library account was in a set of accounts requiring attention."
+msgstr "Check whether your Open Library 계정 was in a set of 계정s requiring attention."
+
+#: account/security/check_email.html
+msgid ""
+"Please <a href=\"/account/login?redirect=/account/security/2026-04-28T18\">log in</a> "
+"to check whether your account was affected."
+msgstr ""
+"다음 <a href=\"/계정/login?redirect=/계정/security/2026-04-28T18\">log in</a> to check "
+"whether your 계정 was affected."
+
+#: account/security/check_email.html
+msgid "Your account is in the affected set."
+msgstr "Your 계정 is in the affected set."
+
+#: account/security/check_email.html
+msgid ""
+"Your account was found in our affected accounts list. Please review any recent "
+"communications from Open Library and consider updating your password."
+msgstr ""
+"Your 계정 was found in our affected 계정s 목록. 다음 리뷰 any recent communications from Open "
+"Library and consider updating your 비밀번호."
+
+#: account/security/check_email.html
+msgid "Your account is <em>not</em> in the affected set."
+msgstr "Your 계정 is <em>not</em> in the affected set."
+
+#: account/security/check_email.html
+msgid ""
+"Your account was <em>not</em> found in the affected accounts list. No action is "
+"required."
+msgstr "Your 계정 was <em>not</em> found in the affected 계정s 목록. No action is required."
+
+#: account/verify/activated.html
+msgid "Account already activated"
+msgstr "이미 활성화된 계정"
+
+#: account/verify/activated.html
+#, python-format
+msgid "Your account has been activated already. Please <a href=\"%s\">log in to continue</a>."
+msgstr "Your 계정 되었습니다 activated already. 다음 <a href=\"%s\">log in 계속하려면</a>."
+
+#: account/verify/failed.html
+msgid "Email Verification Failed"
+msgstr "이메일 확인 실패"
+
+#: account/verify/failed.html
+msgid ""
+"Your email address couldn't be verified. Your verification link seems invalid or "
+"expired."
+msgstr "Your 이메일 추가ress 확인할 수 없습니다. Your verification link seems invalid or expired."
+
+#: account/verify/failed.html
+msgid "Fill your email and hit this button to resend a fresh verification email:"
+msgstr "Fill your 이메일 and hit this button to resend a fresh verification 이메일:"
+
+#: account/verify/failed.html
+msgid "Enter your email address here"
+msgstr "여기에 이메일 주소 입력"
+
+#: account/verify/failed.html
+msgid "No user registered with this email address."
+msgstr "이 이메일 주소로 등록된 사용자가 없습니다."
+
+#: account/verify/success.html
+msgid "Email Verification Successful"
+msgstr "이메일 확인 성공"
+
+#: account/verify/success.html
+#, python-format
+msgid "Yay! Your email address has been verified. Please <a href='%s'>log in to continue</a>."
+msgstr "Yay! Your 이메일 추가ress 되었습니다 verified. 다음 <a href='%s'>log in 계속하려면</a>."
+
+#: admin/attach_debugger.html
+msgid "Attach Debugger"
+msgstr "디버거 연결"
+
+#: admin/attach_debugger.html
+#, python-format
+msgid "Attach Debugger on Python %(version_number)s"
+msgstr "Python %(version_number)s에 디버거 연결"
+
+#: admin/attach_debugger.html
+msgid "Start a debugger on port 3000."
+msgstr "3000번 포트에서 디버거를 시작합니다."
+
+#: admin/attach_debugger.html
+msgid "Waiting for debugger to attach..."
+msgstr "디버거 연결 대기 중..."
+
+#: admin/attach_debugger.html
+msgid "Start"
+msgstr "시작"
+
+#: admin/block.html
+msgid "Block IP address"
+msgstr "IP 주소 차단"
+
+#: admin/block.html
+#, python-format
+msgid ""
+"IP address %(address)s has been added to the textarea. Please click Save to block that "
+"IP."
+msgstr "IP 추가ress %(address)s 되었습니다 추가ed to the textarea. 다음 click 저장 to block that IP."
+
+#: admin/block.html
+msgid "Blocked IP Addresses"
+msgstr "차단된 IP 주소"
+
+#: admin/graphs.html
+msgid "Performance Graphs"
+msgstr "성능 그래프"
+
+#: admin/graphs.html
+msgid "Number of Hits"
+msgstr "조회 수"
+
+#: admin/graphs.html
+msgid "Page Load Times"
+msgstr "페이지 로드 시간"
+
+#: admin/graphs.html
+msgid "Page Load Times Split"
+msgstr "페이지 로드 시간 분할"
+
+#: admin/graphs.html
+msgid "Infobase Mean"
+msgstr "Infobase 평균"
+
+#: admin/history.html admin/imports.html authors/infobox.html type/author/edit.html
+msgid "Date"
+msgstr "날짜"
+
+#: admin/history.html
+msgid "Page"
+msgstr "페이지"
+
+#: admin/imports-add.html admin/imports.html admin/imports_by_date.html admin/menu.html
+msgid "Imports"
+msgstr "가져오기"
+
+#: admin/imports-add.html books/add.html books/edit/edition.html books/edit/excerpts.html
+#: covers/change.html type/tag/form.html
+msgid "Add"
+msgstr "추가"
+
+#: admin/imports-add.html admin/imports.html
+msgid "Add new books to import queue"
+msgstr "new books to import queue 추가"
+
+#: admin/imports-add.html
+msgid "Please add IA identifiers to be imported, one per line."
+msgstr "다음 추가 IA identifiers to be imported, one per line."
+
+#: admin/imports-add.html admin/inspect/store.html admin/ip/view.html admin/people/edits.html
+#: admin/permissions.html design/button.html my_books/check_ins/check_in_form.html
+#: reading_goals/reading_goal_form.html
+msgid "Submit"
+msgstr "제출"
+
+#: admin/imports.html
+msgid "New Books Imported Per Day"
+msgstr "일별 새로 가져온 책"
+
+#: PublishingHistory.html admin/imports.html publishers/view.html
+msgid "You need to have JavaScript turned on to see the nifty chart!"
+msgstr "멋진 차트를 보려면 JavaScript를 켜야 합니다!"
+
+#: admin/imports.html admin/imports_by_date.html admin/pd_dashboard.html site/stats.html
+msgid "Summary"
+msgstr "요약"
+
+#: admin/imports.html
+msgid "Pending Items:"
+msgstr "대기 중인 항목:"
+
+#: admin/imports.html
+#, python-format
+msgid "<strong>Current Import Rate:</strong> %(num)d imports/hour."
+msgstr "<strong>현재 가져오기 속도:</strong> 시간당 %(num)d건."
+
+#: admin/imports.html
+msgid "ETA:"
+msgstr "예상 완료 시간:"
+
+#: admin/imports.html
+msgid "Summary By Date"
+msgstr "날짜별 요약"
+
+#: admin/imports.html
+msgid "total"
+msgstr "합계"
+
+#: admin/imports.html
+msgid "#books created"
+msgstr "생성된 책 수"
+
+#: admin/imports.html
+msgid "#books already found"
+msgstr "이미 찾은 책 수"
+
+#: admin/imports.html
+msgid "#books failed to import"
+msgstr "가져오기에 실패한 책 수"
+
+#: admin/imports.html
+msgid "#books pending"
+msgstr "대기 중인 책 수"
+
+#: admin/imports.html
+msgid "Recent Imports"
+msgstr "최근 가져오기"
+
+#: admin/imports.html admin/imports_by_date.html
+msgid "Identifier"
+msgstr "식별자"
+
+#: admin/imports.html admin/imports_by_date.html
+msgid "Imported Time"
+msgstr "가져온 시간"
+
+#: admin/imports_by_date.html admin/index.html admin/pd_dashboard.html
+msgid "Total"
+msgstr "합계"
+
+#: admin/imports_by_date.html
+msgid "Created"
+msgstr "생성됨"
+
+#: admin/imports_by_date.html
+msgid "Found"
+msgstr "찾음"
+
+#: admin/imports_by_date.html
+msgid "Failed"
+msgstr "실패"
+
+#: admin/imports_by_date.html openlibrary/core/edits.py
+msgid "Pending"
+msgstr "대기 중"
+
+#: admin/imports_by_date.html
+msgid "Items"
+msgstr "항목"
+
+#: admin/index.html
+msgid ""
+"<span class=\"login-counts\">0</span> patrons have logged in at least once over the "
+"past 30 days."
+msgstr "지난 30일 동안 <span class=\"login-counts\">0</span>명의 이용자가 한 번 이상 로그인했습니다."
+
+#: admin/index.html
+msgid "Stats"
+msgstr "통계"
+
+#: admin/index.html
+msgid "Edits Per Day"
+msgstr "일별 편집 수"
+
+#: admin/index.html admin/people/index.html
+msgid "Edits"
+msgstr "편집"
+
+#: admin/index.html
+msgid "Yesterday"
+msgstr "어제"
+
+#: admin/index.html
+msgid "Last 7 days"
+msgstr "지난 7일"
+
+#: admin/index.html
+msgid "Last 28 days"
+msgstr "지난 28일"
+
+#: admin/index.html
+msgid "Human"
+msgstr "사람"
+
+#: admin/index.html admin/people/view.html
+msgid "Bot"
+msgstr "봇"
+
+#: admin/index.html
+msgid "New Accounts Per Day"
+msgstr "일별 새 계정 수"
+
+#: admin/index.html
+msgid "Members"
+msgstr "회원"
+
+#: admin/index.html
+msgid "Items Added"
+msgstr "추가된 항목"
+
+#: admin/index.html
+msgid "Trend"
+msgstr "추세"
+
+#: admin/index.html
+msgid "Works Added"
+msgstr "추가된 작품"
+
+#: admin/index.html
+msgid "Editions Added"
+msgstr "추가된 판본"
+
+#: admin/index.html
+msgid "Authors Added"
+msgstr "추가된 저자"
+
+#: admin/index.html recentchanges/index.html
+msgid "Covers Added"
+msgstr "추가된 표지"
+
+#: admin/index.html home/stats.html
+msgid "New Members"
+msgstr "새 회원"
+
+#: admin/index.html
+msgid "Lists Added"
+msgstr "추가된 목록"
+
+#: admin/index.html
+msgid "Books Logged"
+msgstr "기록된 책"
+
+#: admin/index.html
+msgid "Users Logging"
+msgstr "기록 중인 사용자"
+
+#: admin/index.html
+msgid "Yearly Reading Goals"
+msgstr "연간 독서 목표"
+
+#: admin/index.html
+msgid "Books Review Tags"
+msgstr "책 리뷰 태그"
+
+#: admin/index.html
+msgid "Books Reviewed"
+msgstr "리뷰된 책"
+
+#: admin/index.html
+msgid "Users Reviewing"
+msgstr "리뷰 중인 사용자"
+
+#: admin/index.html
+msgid "Patrons Following"
+msgstr "팔로우 중인 이용자"
+
+#: admin/index.html
+msgid "Notes Created"
+msgstr "생성된 노트"
+
+#: admin/index.html
+msgid "Patrons Creating Notes"
+msgstr "노트를 만드는 이용자"
+
+#: admin/index.html
+msgid "Books Starred"
+msgstr "별점이 매겨진 책"
+
+#: admin/index.html
+msgid "Star Rating Patrons"
+msgstr "별점을 매긴 이용자"
+
+#: admin/index.html home/stats.html
+msgid "Unique Visitors"
+msgstr "고유 방문자"
+
+#: admin/index.html
+msgid "Unique visitors IPs per day graph"
+msgstr "일별 고유 방문자 IP 그래프"
+
+#: admin/index.html
+msgid "Borrows"
+msgstr "대출"
+
+#: admin/index.html
+msgid "Borrows, last 3 months graph"
+msgstr "대출s, last 3 months graph"
+
+#: admin/index.html
+msgid "Borrows, last 2 years graph"
+msgstr "대출s, last 2 years graph"
+
+#: admin/index.html
+msgid "Unique Logins"
+msgstr "고유 로그인"
+
+#: admin/index.html
+msgid "Gathering login statistics..."
+msgstr "로그인 통계를 수집하는 중..."
+
+#: admin/loans_table.html
+msgid "BookReader"
+msgstr "BookReader"
+
+#: admin/loans_table.html book_providers/cita_press_download_options.html
+#: book_providers/ia_download_options.html book_providers/openstax_download_options.html
+#: book_providers/wikisource_download_options.html books/edit/edition.html
+msgid "PDF"
+msgstr "PDF"
+
+#: admin/loans_table.html book_providers/gutenberg_download_options.html
+#: book_providers/ia_download_options.html
+#: book_providers/standard_ebooks_download_options.html books/edit/edition.html
+msgid "ePub"
+msgstr "ePub"
+
+#: admin/loans_table.html
+msgid "No current loans."
+msgstr "현재 대출이 없습니다."
+
+#: admin/loans_table.html
+#, python-format
+msgid "%d Current Loan"
+msgid_plural "%d Current Loans"
+msgstr[0] "현재 대출 %d건"
+
+#: RecentChanges.html RecentChangesUsers.html admin/ip/view.html admin/loans_table.html
+#: admin/people/edits.html recentchanges/render.html recentchanges/updated_records.html
+msgid "What"
+msgstr "무엇"
+
+#: admin/loans_table.html
+#, python-format
+msgid "Waiting since %(date)s"
+msgstr "%(date)s부터 대기 중"
+
+#: admin/loans_table.html
+#, python-format
+msgid "#%(num_position)d among %(num_waitlist)d people waiting for this book"
+msgstr "#%(num_position)d among %(num_waitlist)d people waiting for 이 책"
+
+#: ManageLoansButtons.html admin/loans_table.html
+#, python-format
+msgid "Borrowed %(date)s"
+msgstr "%(date)s에 대출"
+
+#: admin/menu.html
+msgid "Admin Center"
+msgstr "관리자 센터"
+
+#: RelatedSubjects.html SubjectTags.html admin/menu.html admin/people/index.html
+#: admin/people/view.html openlibrary/plugins/worksearch/code.py type/author/view.html
+#: type/list/view_body.html
+msgid "People"
+msgstr "사람"
+
+#: admin/menu.html
+msgid "PD Access Requests"
+msgstr "PD 접근 요청"
+
+#: admin/menu.html
+msgid "Block IPs"
+msgstr "IP 차단"
+
+#: admin/menu.html admin/spamwords.html
+msgid "Spam Words"
+msgstr "스팸 단어"
+
+#: admin/menu.html
+msgid "Solr"
+msgstr "Solr"
+
+#: admin/menu.html
+msgid "Graphs"
+msgstr "그래프"
+
+#: admin/menu.html
+msgid "Inspect store"
+msgstr "저장소 검사"
+
+#: admin/menu.html
+msgid "Inspect memcache"
+msgstr "memcache 검사"
+
+#: admin/pd_dashboard.html
+msgid "Print Disability Access Requests"
+msgstr "인쇄물 이용 장애 접근 요청"
+
+#: admin/pd_dashboard.html
+msgid "Breakdown by Qualifying Authority"
+msgstr "자격 인증 기관별 분석"
+
+#: admin/pd_dashboard.html
+msgid "PDA"
+msgstr "PDA"
+
+#: admin/pd_dashboard.html
+msgid "Emailed"
+msgstr "이메일 보냄"
+
+#: admin/pd_dashboard.html
+msgid "Fulfilled"
+msgstr "처리 완료"
+
+#: admin/pd_dashboard.html
+msgid "Totals"
+msgstr "합계"
+
+#: admin/permissions.html
+msgid "[Admin Center] Site Permissions"
+msgstr "[관리자 센터] 사이트 권한"
+
+#: admin/permissions.html
+msgid "Site Permissions"
+msgstr "사이트 권한"
+
+#: admin/permissions.html
+msgid "Change the policy of who can edit the site."
+msgstr "Change the policy of who can 편집 the site."
+
+#: admin/permissions.html
+msgid "Who can edit Open Library records?"
+msgstr "누가 Open Library 레코드를 편집할 수 있나요?"
+
+#: admin/permissions.html
+msgid "This applies to /authors/*, /books/* and /works/* records."
+msgstr "This applies to /저자/*, /책/* and /작품/* 레코드s."
+
+#: admin/permissions.html
+msgid "Who can edit Open Library pages?"
+msgstr "누가 Open Library 페이지를 편집할 수 있나요?"
+
+#: admin/permissions.html
+msgid "This applies to /about/*, /help/*, /dev/*, /docs/* etc."
+msgstr "이는 /about/*, /help/*, /dev/*, /docs/* 등에 적용됩니다."
+
+#: admin/permissions.html
+msgid "Update permissions"
+msgstr "권한 업데이트"
+
+#: admin/permissions.html
+msgid ""
+"This updates \"permission\" and \"child_permission\" fields of /, /works, /books and "
+"/authors records in the database."
+msgstr ""
+"This updates \"permission\" and \"child_permission\" fields of /, /작품, /책 and /저자 레코드s "
+"in the database."
+
+#: admin/solr.html
+msgid "Solr Admin"
+msgstr "Solr 관리자"
+
+#: admin/solr.html
+msgid "Enter the keys of pages to be updated in OL search engine."
+msgstr "Enter the keys of 페이지s to be updated in OL 검색 engine."
+
+#: admin/solr.html
+msgid "Example:"
+msgstr "예:"
+
+#: admin/solr.html
+msgid ""
+"On update, these keys will be added to solr update queue and it'll take about 15 "
+"minutes for them to get reindexed in Solr."
+msgstr ""
+"On update, these keys 됩니다 추가ed to solr update queue and it'll take about 15 minutes for"
+" them to get reindexed in Solr."
+
+#: admin/solr.html
+msgid "Enter the keys to reindex in Solr"
+msgstr "Solr에서 다시 색인할 키 입력"
+
+#: admin/solr.html
+msgid "Write one entry per line"
+msgstr "한 줄에 하나씩 입력"
+
+#: admin/spamwords.html
+msgid "[Admin Center] Spam Words"
+msgstr "[관리자 센터] 스팸 단어"
+
+#: admin/spamwords.html
+msgid "Please enter the SPAM regular expressions in the textarea below, one per line."
+msgstr "다음 enter the SPAM regular expressions in the textarea below, one per line."
+
+#: admin/spamwords.html
+msgid "Be sure to escape any meta characters that are meant to be character literals."
+msgstr "문자 그대로 사용하려는 메타 문자는 반드시 이스케이프하세요."
+
+#: admin/spamwords.html
+msgid "If you are adding a domain, prepend the following to the domain:"
+msgstr "If you are 추가ing a domain, prepend the following to the domain:"
+
+#: admin/spamwords.html
+msgid ""
+"For example, if you want to prevent edits containing the domain <code>t.co</code>, add "
+"<code>(|https://|http://)t\\.co</code> to the spamwords list."
+msgstr ""
+"For example, if you want to prevent 편집s containing the domain <code>t.co</code>, 추가 "
+"<code>(|https://|http://)t\\.co</code> to the spamwords 목록."
+
+#: admin/spamwords.html
+msgid "Spam Domains"
+msgstr "스팸 도메인"
+
+#: admin/spamwords.html
+msgid "Please enter domains to blacklist in the textarea below, one per line."
+msgstr "다음 enter domains to black목록 in the textarea below, one per line."
+
+#: admin/sync.html
+msgid "Sync"
+msgstr "동기화"
+
+#: admin/sync.html
+msgid ""
+"Sync the metadata of various types of Open Library items (e.g. lists, subjects, works) "
+"with Archive.org."
+msgstr ""
+"Sync the metadata of various types of Open Library items (e.g. 목록, 주제, 작품) with "
+"Archive.org."
+
+#: admin/sync.html
+msgid "Add Works to Staff Picks"
+msgstr "Works to Staff Picks 추가"
+
+#: admin/sync.html
+msgid ""
+"This utility will add your work to an Open Library list called `Staff Picks` under the "
+"`openlibrary` user. It will then take the added work and explode it into a list of all "
+"its readable editions. For each Open Library edition, a metadata field called "
+"`openlibrary_subject` will be injected into the archive.org metadata of the edition's "
+"corresponding archive.org item."
+msgstr ""
+"This utility will 추가 your 작품 to an Open Library 목록 called `Staff Picks` under the "
+"`openlibrary` user. It will then take the 추가ed 작품 and explode it into a 목록 of all its "
+"readable 판본. For each Open Library 판본, a metadata field called `openlibrary_주제` 됩니다 "
+"injected into the archive.org metadata of the 판본's corresponding archive.org item."
+
+#: admin/sync.html
+msgid "add"
+msgstr "추가"
+
+#: admin/sync.html
+msgid "remove"
+msgstr "제거"
+
+#: admin/sync.html
+msgid "Update edition"
+msgstr "판본 업데이트"
+
+#: admin/sync.html
+msgid ""
+"Updates an edition on archive.org by writing in its latest  openlibrary_edition and "
+"openlibrary_work identifier values"
+msgstr ""
+"Updates an 판본 on archive.org by writing in its latest  openlibrary_판본 and "
+"openlibrary_작품 identifier values"
+
+#: admin/sync.html
+msgid "TODO"
+msgstr "TODO"
+
+#: admin/inspect/memcache.html
+msgid "[Admin Center] Inspect Memcache"
+msgstr "[관리자 센터] Memcache 검사"
+
+#: admin/inspect/memcache.html
+msgid "Inspect Memcache"
+msgstr "Memcache 검사"
+
+#: admin/inspect/memcache.html
+msgid ""
+"Add one memcache key per line in the text area. Each key must include a '-' as the last"
+" character."
+msgstr ""
+"one memcache key per line in the text area. Each key must include a '-' as the last "
+"character. 추가"
+
+#: admin/inspect/memcache.html
+msgid ""
+"For example, <code>observations-</code> should be entered in the text area if the key "
+"is <code>observations</code>."
+msgstr "예를 들어 키가 <code>observations</code>이면 텍스트 영역에는 <code>observations-</code>를 입력해야 합니다."
+
+#: admin/inspect/memcache.html
+msgid "Keys:"
+msgstr "키:"
+
+#: admin/inspect/memcache.html
+msgid "Result"
+msgstr "결과"
+
+#: admin/inspect/memcache.html
+msgid "No keys selected."
+msgstr "선택된 키가 없습니다."
+
+#: admin/inspect/memcache.html
+msgid "Not found."
+msgstr "찾을 수 없습니다."
+
+#: admin/inspect/store.html
+msgid "Admin Center / Inspect"
+msgstr "관리자 센터 / 검사"
+
+#: admin/inspect/store.html
+msgid "Inspect Store"
+msgstr "저장소 검사"
+
+#: admin/inspect/store.html
+msgid "Get"
+msgstr "가져오기"
+
+#: admin/inspect/store.html
+msgid "Key"
+msgstr "키"
+
+#: admin/inspect/store.html
+msgid "Query"
+msgstr "쿼리"
+
+#: admin/inspect/store.html
+msgid "Type"
+msgstr "유형"
+
+#: admin/inspect/store.html
+msgid "Value"
+msgstr "값"
+
+#: admin/inspect/store.html
+msgid "Documents"
+msgstr "문서"
+
+#: admin/inspect/store.html
+msgid "Json"
+msgstr "JSON"
+
+#: admin/inspect/store.html
+msgid "No results found."
+msgstr "결과를 찾을 수 없습니다."
+
+#: admin/ip/index.html
+msgid "[Admin Center] IP Addresses"
+msgstr "[관리자 센터] IP 주소"
+
+#: admin/ip/index.html
+msgid "IP Addresses"
+msgstr "IP 주소"
+
+#: admin/ip/index.html
+msgid "List of Banned IPs"
+msgstr "차단된 IP 목록"
+
+#: admin/ip/index.html admin/people/index.html
+msgid "Date/Time"
+msgstr "날짜/시간"
+
+#: admin/ip/index.html
+msgid "IP address"
+msgstr "IP 주소"
+
+#: admin/ip/index.html
+msgid "Admin Comment"
+msgstr "관리자 댓글"
+
+#: admin/ip/index.html
+msgid "# of edits"
+msgstr "편집 수"
+
+#: admin/ip/index.html
+msgid "x minutes ago"
+msgstr "x분 전"
+
+#: admin/ip/index.html admin/ip/view.html
+msgid "IP"
+msgstr "IP"
+
+#: admin/ip/index.html
+msgid "comment"
+msgstr "댓글"
+
+#: admin/ip/view.html admin/people/view.html
+msgid "[Admin Center]"
+msgstr "[관리자 센터]"
+
+#: admin/ip/view.html
+#, python-format
+msgid "IP %(ip)s is <a href=\"/admin/block\">blocked</a>."
+msgstr "IP %(ip)s은(는) <a href=\"/admin/block\">차단됨</a> 상태입니다."
+
+#: admin/ip/view.html
+#, python-format
+msgid "Block %(ip)s"
+msgstr "%(ip)s 차단"
+
+#: admin/ip/view.html admin/people/edits.html
+msgid "Please select the changesets to revert."
+msgstr "다음 select the changesets to revert."
+
+#: RecentChanges.html admin/ip/view.html admin/people/edits.html recentchanges/render.html
+msgid "When you see numbers here, that's the IP address of the anonymous editor"
+msgstr "When you see numbers here, that's the IP 추가ress of the anonymous 편집or"
+
+#: admin/ip/view.html admin/people/edits.html
+#, python-format
+msgid "Reverted by %(revert_author)s"
+msgstr "%(revert_author)s님이 되돌림"
+
+#: EditButtons.html admin/ip/view.html admin/people/edits.html
+msgid ""
+"Please, leave a short note about what you changed: <span class=\"small "
+"gray\">(Optional, but very useful!)</span>"
+msgstr ""
+"다음, leave a short note about what you changed: <span class=\"small gray\">(Optional, "
+"but very useful!)</span>"
+
+#: admin/ip/view.html admin/people/edits.html
+msgid "Reverted spam"
+msgstr "스팸 되돌림"
+
+#: admin/people/edits.html
+#, python-format
+msgid "[Admin Center] Edits of %(user)s"
+msgstr "[Admin Center] 편집s of %(user)s"
+
+#: admin/people/edits.html
+msgid "people"
+msgstr "사람"
+
+#: admin/people/edits.html
+msgid "edits"
+msgstr "편집"
+
+#: admin/people/index.html
+msgid "[Admin Center] People"
+msgstr "[관리자 센터] 사람"
+
+#: admin/people/index.html
+msgid "Find Account"
+msgstr "계정 찾기"
+
+#: admin/people/index.html admin/people/view.html
+msgid "Email Address:"
+msgstr "이메일 주소:"
+
+#: admin/people/index.html
+msgid "Find"
+msgstr "찾기"
+
+#: admin/people/index.html
+msgid "No account found with this email."
+msgstr "이 이메일로 된 계정을 찾을 수 없습니다."
+
+#: admin/people/index.html
+msgid "IA ID:"
+msgstr "IA ID:"
+
+#: admin/people/index.html
+msgid "e.g. @foobar"
+msgstr "예: @foobar"
+
+#: admin/people/index.html
+msgid "No account found with this ID."
+msgstr "이 ID로 된 계정을 찾을 수 없습니다."
+
+#: admin/people/index.html
+msgid "Recent Accounts"
+msgstr "최근 계정"
+
+#: admin/people/index.html
+msgid "email"
+msgstr "이메일"
+
+#: admin/people/index.html
+msgid "profile"
+msgstr "프로필"
+
+#: admin/people/index.html admin/people/view.html
+msgid "Edit History"
+msgstr "편집 기록"
+
+#: admin/people/view.html
+msgid "block and revert all edits"
+msgstr "차단하고 모든 편집 되돌리기"
+
+#: admin/people/view.html
+msgid "block this account"
+msgstr "이 계정 차단"
+
+#: admin/people/view.html
+#, python-format
+msgid "Registered on <span class=\"time\">%(date)s</span>."
+msgstr "<span class=\"time\">%(date)s</span>에 등록됨."
+
+#: admin/people/view.html
+msgid "login as this user"
+msgstr "이 사용자로 로그인"
+
+#: admin/people/view.html
+#, python-format
+msgid ""
+"Activated on <span class=\"time\">%(date)s</span> from <a "
+"href=\"/admin/ip/%(ip)s\">%(ip)s</a>."
+msgstr "<a href=\"/admin/ip/%(ip)s\">%(ip)s</a>에서 <span class=\"time\">%(date)s</span>에 활성화됨."
+
+#: admin/people/view.html
+msgid "unblock this account"
+msgstr "이 계정 차단 해제"
+
+#: admin/people/view.html
+msgid "activate account"
+msgstr "계정 활성화"
+
+#: admin/people/view.html
+#, python-format
+msgid "Activation link expiring on <span class=\"time\">%(date)s.</span>"
+msgstr "활성화 링크 만료 예정: <span class=\"time\">%(date)s.</span>"
+
+#: admin/people/view.html
+msgid "Activation link expired"
+msgstr "활성화 링크 만료"
+
+#: admin/people/view.html
+msgid "Resend activation link"
+msgstr "활성화 링크 다시 보내기"
+
+#: CreateListModal.html admin/people/view.html my_books/dropdown_content.html
+msgid "Name:"
+msgstr "이름:"
+
+#: admin/people/view.html
+msgid "view profile"
+msgstr "프로필 보기"
+
+#: admin/people/view.html
+msgid "Change"
+msgstr "변경"
+
+#: admin/people/view.html
+msgid "Admin"
+msgstr "관리자"
+
+#: admin/people/view.html
+msgid "Make Human"
+msgstr "사람으로 표시"
+
+#: admin/people/view.html
+msgid "Make Bot"
+msgstr "봇으로 표시"
+
+#: admin/people/view.html
+msgid "Not available"
+msgstr "사용할 수 없음"
+
+#: admin/people/view.html
+msgid "# Edits"
+msgstr "편집 수"
+
+#: admin/people/view.html
+msgid "Member Since:"
+msgstr "가입일:"
+
+#: admin/people/view.html
+msgid "Last Login:"
+msgstr "마지막 로그인:"
+
+#: admin/people/view.html
+msgid "Tags:"
+msgstr "태그:"
+
+#: admin/people/view.html
+msgid "Anonymize Account:"
+msgstr "계정 익명화:"
+
+#: admin/people/view.html
+msgid "Dry Run"
+msgstr "시험 실행"
+
+#: admin/people/view.html
+msgid "Anonymize Account"
+msgstr "계정 익명화"
+
+#: admin/people/view.html books/mybooks_breadcrumb_select.html
+#: openlibrary/plugins/upstream/account.py type/user/view.html
+msgid "Loans"
+msgstr "대출"
+
+#: admin/people/view.html
+msgid "Account not activated yet."
+msgstr "계정이 아직 활성화되지 않았습니다."
+
+#: admin/people/view.html
+msgid "Waiting Loans"
+msgstr "대기 중인 대출"
+
+#: admin/people/view.html
+#, python-format
+msgid "%(num)d edits"
+msgstr "편집 %(num)d회"
+
+#: admin/people/view.html
+msgid "Debug Info"
+msgstr "디버그 정보"
+
+#: admin/people/view.html
+msgid "Account Information"
+msgstr "계정 정보"
+
+#: admin/people/view.html
+msgid "Verifications Links"
+msgstr "확인 링크"
+
+#: admin/people/view.html
+msgid "None found"
+msgstr "찾을 수 없음"
+
+#: SearchNavigation.html authors/index.html lib/nav_foot.html merge/authors.html
+#: publishers/view.html
+msgid "Authors"
+msgstr "저자"
+
+#: authors/index.html
+msgid "Search for an Author"
+msgstr "저자 검색"
+
+#: authors/index.html lib/nav_head.html lists/home.html publishers/index.html
+#: publishers/notfound.html publishers/view.html search/advancedsearch.html
+#: search/publishers.html search/searchbox.html type/local_id/view.html
+msgid "Search"
+msgstr "검색"
+
+#: authors/index.html search/authors.html
+#, python-format
+msgid "about %(subjects)s"
+msgstr "%(subjects)s에 관하여"
+
+#: authors/index.html search/authors.html
+#, python-format
+msgid "including <i>%(topwork)s</i>"
+msgstr "<i>%(topwork)s</i> 포함"
+
+#: authors/infobox.html
+#, python-format
+msgid "View on %(site)s"
+msgstr "%(site)s에서 보기"
+
+#: authors/infobox.html
+msgid "Born"
+msgstr "출생"
+
+#: authors/infobox.html
+msgid "Died"
+msgstr "사망"
+
+#: book_providers/cita_press_download_options.html
+#: book_providers/gutenberg_download_options.html book_providers/ia_download_options.html
+#: book_providers/librivox_download_options.html
+#: book_providers/openstax_download_options.html
+#: book_providers/runeberg_download_options.html
+#: book_providers/standard_ebooks_download_options.html
+#: book_providers/wikisource_download_options.html
+msgid "Download Options"
+msgstr "다운로드 옵션"
+
+#: book_providers/cita_press_download_options.html
+msgid "Download PDF from Cita Press"
+msgstr "Cita Press에서 PDF 다운로드"
+
+#: book_providers/cita_press_download_options.html
+msgid "More at Cita Press"
+msgstr "Cita Press에서 더 보기"
+
+#: book_providers/gutenberg_download_options.html
+msgid "Download an HTML from Project Gutenberg"
+msgstr "Project Gutenberg에서 HTML 다운로드"
+
+#: book_providers/gutenberg_download_options.html
+#: book_providers/runeberg_download_options.html
+#: book_providers/standard_ebooks_download_options.html type/list/exports.html
+msgid "HTML"
+msgstr "HTML"
+
+#: book_providers/gutenberg_download_options.html
+msgid "Download a text version from Project Gutenberg"
+msgstr "Project Gutenberg에서 텍스트 버전 다운로드"
+
+#: book_providers/gutenberg_download_options.html book_providers/ia_download_options.html
+msgid "Plain text"
+msgstr "일반 텍스트"
+
+#: book_providers/gutenberg_download_options.html
+msgid "Download an ePub from Project Gutenberg"
+msgstr "Project Gutenberg에서 ePub 다운로드"
+
+#: book_providers/gutenberg_download_options.html
+msgid "Download a Kindle file from Project Gutenberg"
+msgstr "Project Gutenberg에서 Kindle 파일 다운로드"
+
+#: book_providers/gutenberg_download_options.html
+msgid "Kindle"
+msgstr "Kindle"
+
+#: book_providers/gutenberg_download_options.html
+msgid "More at Project Gutenberg"
+msgstr "Project Gutenberg에서 더 보기"
+
+#: book_providers/ia_download_options.html
+msgid "Download a PDF from Internet Archive"
+msgstr "Internet Archive에서 PDF 다운로드"
+
+#: book_providers/ia_download_options.html
+msgid "Download a text version from Internet Archive"
+msgstr "Internet Archive에서 텍스트 버전 다운로드"
+
+#: book_providers/ia_download_options.html
+msgid "Download an ePub from Internet Archive"
+msgstr "Internet Archive에서 ePub 다운로드"
+
+#: book_providers/ia_download_options.html
+msgid "Download a MOBI file from Internet Archive"
+msgstr "Internet Archive에서 MOBI 파일 다운로드"
+
+#: book_providers/ia_download_options.html
+msgid "MOBI"
+msgstr "MOBI"
+
+#: book_providers/ia_download_options.html
+msgid "Download open DAISY from Internet Archive (print-disabled format)"
+msgstr "Internet Archive에서 공개 DAISY 다운로드(인쇄물 이용 장애 형식)"
+
+#: book_providers/ia_download_options.html type/list/embed.html
+msgid "DAISY"
+msgstr "DAISY"
+
+#: book_providers/librivox_download_options.html
+msgid "Download a ZIP file of the whole book from Internet Archive"
+msgstr "Internet Archive에서 전체 책의 ZIP 파일 다운로드"
+
+#: book_providers/librivox_download_options.html
+msgid "Whole Book MP3"
+msgstr "전체 책 MP3"
+
+#: book_providers/librivox_download_options.html
+msgid "Get the RSS Feed from LibriVox"
+msgstr "LibriVox에서 RSS 피드 받기"
+
+#: book_providers/librivox_download_options.html
+msgid "RSS Feed"
+msgstr "RSS 피드"
+
+#: book_providers/librivox_download_options.html
+msgid "More at LibriVox"
+msgstr "LibriVox에서 더 보기"
+
+#: book_providers/openstax_download_options.html
+msgid "Download PDF from OpenStax"
+msgstr "OpenStax에서 PDF 다운로드"
+
+#: book_providers/openstax_download_options.html
+msgid "More at OpenStax"
+msgstr "OpenStax에서 더 보기"
+
+#: book_providers/read_button.html
+#, python-format
+msgid "Listen to a reading from %s"
+msgstr "%s의 낭독 듣기"
+
+#: book_providers/read_button.html
+msgid "Audiobook"
+msgstr "오디오북"
+
+#: book_providers/read_button.html
+#, python-format
+msgid "Read free online from %s"
+msgstr "%s에서 무료로 온라인 읽기"
+
+#: book_providers/runeberg_download_options.html
+msgid "Download all scanned images from Project Runeberg"
+msgstr "Project Runeberg에서 all scanned images 다운로드"
+
+#: book_providers/runeberg_download_options.html
+msgid "Scanned images"
+msgstr "스캔 이미지"
+
+#: book_providers/runeberg_download_options.html
+msgid "Download all color images from Project Runeberg"
+msgstr "Project Runeberg에서 all color images 다운로드"
+
+#: book_providers/runeberg_download_options.html
+msgid "Color images"
+msgstr "컬러 이미지"
+
+#: book_providers/runeberg_download_options.html
+msgid "Download all HTML files from Project Runeberg"
+msgstr "Project Runeberg에서 all HTML files 다운로드"
+
+#: book_providers/runeberg_download_options.html
+msgid "Download all text and index files from Project Runeberg"
+msgstr "Project Runeberg에서 all text and index files 다운로드"
+
+#: book_providers/runeberg_download_options.html
+msgid "Text and index files"
+msgstr "텍스트 및 색인 파일"
+
+#: book_providers/runeberg_download_options.html
+msgid "Download all OCR text from Project Runeberg"
+msgstr "Project Runeberg에서 all OCR text 다운로드"
+
+#: book_providers/runeberg_download_options.html
+msgid "OCR text"
+msgstr "OCR 텍스트"
+
+#: book_providers/runeberg_download_options.html
+msgid "More at Project Runeberg"
+msgstr "Project Runeberg에서 더 보기"
+
+#: book_providers/standard_ebooks_download_options.html
+msgid "Download an HTML from Standard Ebooks"
+msgstr "Standard Ebooks에서 HTML 다운로드"
+
+#: book_providers/standard_ebooks_download_options.html
+msgid "Download an ePub from Standard Ebook."
+msgstr "Standard Ebook.에서 an ePub 다운로드"
+
+#: book_providers/standard_ebooks_download_options.html
+msgid "Download a Kindle file from Standard Ebooks"
+msgstr "Standard Ebooks에서 a Kindle file 다운로드"
+
+#: book_providers/standard_ebooks_download_options.html
+msgid "Kindle (azw3)"
+msgstr "Kindle(azw3)"
+
+#: book_providers/standard_ebooks_download_options.html
+msgid "Download a Kobo file from Standard Ebooks"
+msgstr "Standard Ebooks에서 a Kobo file 다운로드"
+
+#: book_providers/standard_ebooks_download_options.html
+msgid "Kobo (kepub)"
+msgstr "Kobo(kepub)"
+
+#: book_providers/standard_ebooks_download_options.html
+msgid "View the source code for this Standard Ebook at GitHub"
+msgstr "the source code for this Standard Ebook at GitHub 보기"
+
+#: Subnavigation.html book_providers/standard_ebooks_download_options.html
+msgid "Source Code"
+msgstr "소스 코드"
+
+#: book_providers/standard_ebooks_download_options.html
+msgid "More at Standard Ebooks"
+msgstr "Standard Ebooks에서 더 보기"
+
+#: book_providers/wikisource_download_options.html
+msgid "Download PDF from Wikisource"
+msgstr "Wikisource에서 PDF 다운로드"
+
+#: book_providers/wikisource_download_options.html
+msgid "Download MOBI from Wikisource"
+msgstr "Wikisource에서 MOBI 다운로드"
+
+#: book_providers/wikisource_download_options.html
+msgid "MOBI (for Kindle)"
+msgstr "MOBI(Kindle용)"
+
+#: book_providers/wikisource_download_options.html
+msgid "Download EPUB from Wikisource"
+msgstr "Wikisource에서 EPUB 다운로드"
+
+#: book_providers/wikisource_download_options.html
+msgid "EPUB (for most other e-readers)"
+msgstr "EPUB(대부분의 다른 전자책 리더용)"
+
+#: book_providers/wikisource_download_options.html
+msgid "Read at Wikisource"
+msgstr "Wikisource에서 읽기"
+
+#: books/RelatedWorksCarousel.html
+msgid "You might also like"
+msgstr "이것도 좋아하실 수 있습니다"
+
+#: books/RelatedWorksCarousel.html
+msgid "More by this author"
+msgid_plural "More by these authors"
+msgstr[0] "이 저자의 더 많은 책"
+
+#: books/add.html books/check.html
+msgid "Add a book"
+msgstr "a book 추가"
+
+#: books/add.html
+msgid "Invalid ISBN checksum digit"
+msgstr "잘못된 ISBN 체크섬 숫자"
+
+#: books/add.html
+msgid "ID must be exactly 10 characters [0-9 or X]. For example 0-19-853453-1 or 0198534531"
+msgstr "ID는 정확히 10자여야 합니다[0-9 또는 X]. 예: 0-19-853453-1 또는 0198534531"
+
+#: books/add.html
+msgid "ID must be exactly 13 characters [0-9]. For example 978-3-16-148410-0 or 9783161484100"
+msgstr "ID는 정확히 13자여야 합니다[0-9]. 예: 978-3-16-148410-0 또는 9783161484100"
+
+#: books/add.html
+msgid "Invalid LC Control Number format"
+msgstr "잘못된 LC 관리 번호 형식"
+
+#: books/add.html
+msgid "Invalid OCLC/WorldCat Control Number format"
+msgstr "잘못된 OCLC/WorldCat 관리 번호 형식"
+
+#: books/add.html
+msgid "Please enter a value for the selected identifier"
+msgstr "다음 enter a value for the selected identifier"
+
+#: books/add.html
+msgid "Are you sure that's the published date?"
+msgstr "그 날짜가 출판일이 맞나요?"
+
+#: books/add.html
+msgid "Add a book to Open Library"
+msgstr "a book to Open Library 추가"
+
+#: books/add.html
+msgid "We require a minimum set of fields to create a new record. These are those fields."
+msgstr "We require a minimum set of fields to 생성 a new 레코드. These are those fields."
+
+#: books/add.html books/edit.html
+msgid "Use <b><i>Title: Subtitle</i></b> to add a subtitle."
+msgstr "Use <b><i>Title: Subtitle</i></b> 추가하려면 a subtitle."
+
+#: books/add.html books/edit.html type/author/edit.html type/tag/tag_form_inputs.html
+msgid "Required field"
+msgstr "필수 항목"
+
+#: books/add.html
+msgid ""
+"Like, \"Agatha Christie\" or \"Jean-Paul Sartre.\" We'll also do a live check to see if"
+" we already know the author."
+msgstr ""
+"Like, \"Agatha Christie\" or \"Jean-Paul Sartre.\" We'll also do a live check to see if"
+" we already know the 저자."
+
+#: books/add.html books/edit/edition.html
+msgid "Who is the publisher?"
+msgstr "Who is the 출판사?"
+
+#: books/add.html books/edit/edition.html
+msgid "For example:"
+msgstr "예:"
+
+#: books/add.html
+msgid "Oxford University Press; Penguin; W.W. Norton"
+msgstr "Oxford University Press; Penguin; W.W. Norton"
+
+#: books/add.html books/edit/edition.html
+msgid "When was it published?"
+msgstr "언제 출판되었나요?"
+
+#: books/add.html books/edit/edition.html
+msgid "You should be able to find this in the first few pages of the book."
+msgstr "You should be able to find this in the first few 페이지s of the 책."
+
+#: books/add.html
+msgid "And optionally, an ID number &#151; like an ISBN &#151; would be helpful..."
+msgstr "선택 사항으로 ISBN 같은 ID 번호가 있으면 도움이 됩니다..."
+
+#: books/add.html
+msgid "ID Type"
+msgstr "ID 유형"
+
+#: books/add.html
+msgid "ISBN may be invalid. Click \"Add\" again to submit."
+msgstr "ISBN may be invalid. Click \"추가\" again to 제출."
+
+#: books/add.html type/tag/tag_form_inputs.html
+msgid "Select"
+msgstr "선택"
+
+#: books/add.html
+msgid "ISBN 10"
+msgstr "ISBN 10"
+
+#: books/add.html
+msgid "ISBN 13"
+msgstr "ISBN 13"
+
+#: books/add.html
+msgid "LCCN"
+msgstr "LCCN"
+
+#: books/add.html
+msgid "LibriVox"
+msgstr "LibriVox"
+
+#: books/add.html
+msgid "OCLC/WorldCat"
+msgstr "OCLC/WorldCat"
+
+#: books/add.html
+msgid "Project Gutenberg"
+msgstr "Project Gutenberg"
+
+#: books/add.html books/edit/edition.html
+msgid "Book URL"
+msgstr "책 URL"
+
+#: books/add.html
+msgid "Only fill this out if this is a web book"
+msgstr "Only fill this out if this is a web 책"
+
+#: books/add.html
+#, python-format
+msgid ""
+"By saving a change to this wiki, you agree that your contribution is given freely to "
+"the world under <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" "
+"target=\"_blank\" rel=\"noopener noreferrer\" title=\"%(cc_link_title)s\">CC0</a>."
+msgstr ""
+"By saving a change to this wiki, you agree that your contribution is given freely to "
+"the world under <a href=\"https://creativecommons.org/공개domain/zero/1.0/\" "
+"target=\"_blank\" rel=\"noopener noreferrer\" title=\"%(cc_link_title)s\">CC0</a>."
+
+#: books/add.html
+msgid "This link to Creative Commons will open in a new window"
+msgstr "Creative Commons 링크가 새 창에서 열립니다"
+
+#: books/add.html
+msgid "Add this book now"
+msgstr "this book now 추가"
+
+#: books/author-autocomplete.html
+msgid "Add a new author"
+msgstr "새 저자 추가"
+
+#: books/author-autocomplete.html books/series-autocomplete.html
+msgid "Create a new record for"
+msgstr "새 record for 만들기"
+
+#: books/author-autocomplete.html
+msgid "Remove this author"
+msgstr "this author 제거"
+
+#: books/author-autocomplete.html
+msgid "Add another author?"
+msgstr "another author? 추가"
+
+#: books/check.html lib/nav_foot.html lib/nav_head.html
+msgid "Add a Book"
+msgstr "a Book 추가"
+
+#: books/check.html
+#, python-format
+msgid ""
+"One moment... It looks like we already have <em>some potential matches</em> for "
+"<b>%(title)s</b> by <b>%(author)s</b>."
+msgstr "잠시만요... 이미 <b>%(author)s</b>의 <b>%(title)s</b>와 <em>비슷한 후보</em>가 있는 것 같습니다."
+
+#: books/check.html
+msgid ""
+"Rather than creating a duplicate record, please click through the result you think best"
+" matches your book."
+msgstr ""
+"Rather than creating a duplicate 레코드, please click through the result you think best "
+"matches your 책."
+
+#: books/check.html
+msgid "Select this book"
+msgstr "이 책 선택"
+
+#: SearchResultsWork.html books/check.html merge/authors.html publishers/view.html
+#, python-format
+msgid "%(count)s edition"
+msgid_plural "%(count)s editions"
+msgstr[0] "판본 %(count)s개"
+
+#: books/check.html
+#, python-format
+msgid "First published in %(year)d"
+msgstr "%(year)d에 초판 출간"
+
+#: books/check.html
+msgid "None of these match the book I want to add."
+msgstr "None of these match the 책 I want 추가하려면."
+
+#: books/check.html design/button.html
+msgid "Continue"
+msgstr "계속"
+
+#: books/custom_carousel_card.html type/author/view.html
+msgid "name missing"
+msgstr "name 없음"
+
+#: books/custom_carousel_card.html books/mobile_carousel.html
+#, python-format
+msgid " by %(name)s"
+msgstr " %(name)s 지음"
+
+#: books/daisy.html
+msgid "Back"
+msgstr "뒤로"
+
+#: books/daisy.html
+msgid "Open Library Home"
+msgstr "Open Library 홈"
+
+#: books/daisy.html
+msgid "There isn't a DAISY file available for "
+msgstr "다음이 있습니다:n't a DAISY file 사용 가능 for "
+
+#: books/daisy.html
+#, python-format
+msgid ""
+"<a href=\"%(daisy_url)s\"><strong>Download the DAISY.zip</strong></a> for <a "
+"href=\"%(url)s\">%(title)s</a>"
+msgstr ""
+"<a href=\"%(daisy_url)s\"><strong>다운로드 the DAISY.zip</strong></a> for <a "
+"href=\"%(url)s\">%(title)s</a>"
+
+#: books/daisy.html
+msgid "Books for people who don't read print?"
+msgstr "인쇄물을 읽기 어려운 사람들을 위한 책인가요?"
+
+#: books/daisy.html
+msgid ""
+"The <a href=\"//archive.org\">Internet Archive</a> is proud to be distributing over 1 "
+"million books free in a format called DAISY, designed for those of us who find it "
+"challenging to use regular printed media. "
+msgstr ""
+"The <a href=\"//archive.org\">Internet Archive</a> is proud to be distributing over 1 "
+"million 책 free in a format called DAISY, designed for those of us who find it "
+"challenging to use regular printed media. "
+
+#: books/daisy.html
+msgid ""
+"There are two types of DAISYs on Open Library: <i>open</i> and <i>protected</i>. Open "
+"DAISYs can be read by anyone in the world on many different devices. Protected DAISYs "
+"can only be opened using a key issued by the <a "
+"href=\"http://www.loc.gov/nls/\">Library of Congress NLS program</a>."
+msgstr ""
+"다음이 있습니다: two types of DAISYs on Open Library: <i>open</i> and <i>protected</i>. Open "
+"DAISYs 할 수 있습니다 read by anyone in the world on many different devices. Protected DAISYs"
+" can only be opened using a key issued by the <a "
+"href=\"http://www.loc.gov/nls/\">Library of Congress NLS program</a>."
+
+#: books/daisy.html lists/home.html
+msgid "Enjoy!"
+msgstr "즐기세요!"
+
+#: books/daisy.html
+msgid "What is the DAISY format?"
+msgstr "DAISY 형식이란 무엇인가요?"
+
+#: books/daisy.html
+msgid ""
+"The DAISY digital format helps people who have challenges using regular printed media. "
+"DAISY digital <span class=\"highlight\">talking books</span> offer the benefits of "
+"regular audiobooks, with navigation within the book, to chapters or specific pages."
+msgstr ""
+"The DAISY digital format helps people who have challenges using regular printed media. "
+"DAISY digital <span class=\"highlight\">talking 책</span> offer the benefits of regular "
+"audio책, with navigation within the 책, to chapters or specific 페이지s."
+
+#: books/daisy.html
+msgid "More information at daisy.org"
+msgstr "자세한 정보는 daisy.org에서 확인하세요"
+
+#: books/daisy.html
+msgid "What is the NLS?"
+msgstr "NLS란 무엇인가요?"
+
+#: books/daisy.html
+msgid ""
+"The Library of Congress <a href=\"http://www.loc.gov/nls/\">National Library Service "
+"for the Blind and Physically Handicapped (NLS)</a> administers a free library program "
+"of braille and audio materials circulated to eligible borrowers in the United States "
+"through a national network of cooperating libraries."
+msgstr ""
+"The Library of Congress <a href=\"http://www.loc.gov/nls/\">National Library Service "
+"for the Blind and Physically Handicapped (NLS)</a> administers a free library program "
+"of braille and audio materials circulated to eligible 대출ers in the United States "
+"through a national net작품 of cooperating libraries."
+
+#: books/daisy.html
+msgid "Are you eligible to register?"
+msgstr "등록 자격이 있나요?"
+
+#: books/daisy.html
+msgid "How do I find DAISYs on Open Library?"
+msgstr "Open Library에서 DAISY를 어떻게 찾나요?"
+
+#: books/daisy.html
+msgid ""
+"In addition to<a href=\"/subjects/accessible_book\" title=\"Subject: Accessible book\">"
+" loads of open DAISYs</a>, the Open Library lists a smaller selection of<a "
+"href=\"/subjects/protected_DAISY\" title=\"Subject: Protected DAISY\"> protected DAISY "
+"titles</a> accessible to those with a Library of Congress NLS key. These titles are "
+"brought to you by the<a href=\"//archive.org/\"> Internet Archive</a>."
+msgstr ""
+"In 추가ition to<a href=\"/주제/accessible_책\" title=\"Subject: Accessible 책\"> loads of "
+"open DAISYs</a>, the Open Library 목록 a smaller selection of<a "
+"href=\"/주제/protected_DAISY\" title=\"Subject: Protected DAISY\"> protected DAISY "
+"titles</a> accessible to those with a Library of Congress NLS key. These titles are "
+"brought to you by the<a href=\"//archive.org/\"> Internet Archive</a>."
+
+#: books/daisy.html
+msgid ""
+"Looking for a specific title? The best way to find it is to<a href=\"/search\"> search "
+"for it</a>."
+msgstr ""
+"Looking for a specific title? The best way to find it is to<a href=\"/검색\"> 검색 for "
+"it</a>."
+
+#: books/daisy.html lib/exports.html
+msgid "Need help?"
+msgstr "도움이 필요하신가요?"
+
+#: books/daisy.html
+msgid " Please read our <a href=\"/help/faq\">FAQ on accessing books through Open Library</a>."
+msgstr " 다음 read our <a href=\"/help/faq\">FAQ on accessing 책 through Open Library</a>."
+
+#: books/edit.html
+msgid "Add a little more?"
+msgstr "a little more? 추가"
+
+#: books/edit.html
+msgid ""
+"Thank you for adding that book! Any more information you could provide would be "
+"wonderful!"
+msgstr "Thank you for 추가ing that 책! Any more information you could provide would be wonderful!"
+
+#: books/edit.html
+#, python-format
+msgid ""
+"We already know about <b>%(work_title)s</b>, but not the <b>%(year)s %(publisher)s "
+"edition</b>. Thanks! Do you know any more about this edition?"
+msgstr ""
+"We already know about <b>%(work_title)s</b>, but not the <b>%(year)s %(publisher)s "
+"판본</b>. Thanks! 알고 있나요 any more about this 판본?"
+
+#: books/edit.html
+#, python-format
+msgid ""
+"We already know about the <b>%(year)s %(publisher)s edition</b> of "
+"<b>%(work_title)s</b>, but please, tell us more!"
+msgstr ""
+"We already know about the <b>%(year)s %(publisher)s 판본</b> of <b>%(work_title)s</b>, "
+"but please, tell us more!"
+
+#: books/edit.html
+msgid "Editing..."
+msgstr "편집 중..."
+
+#: books/edit.html type/author/edit.html type/tag/form.html type/template/edit.html
+msgid "Delete Record"
+msgstr "레코드 삭제"
+
+#: books/edit.html
+msgid "Work Details"
+msgstr "작품 세부 정보"
+
+#: books/edit.html
+msgid "Unknown publisher edition"
+msgstr "알 수 없는 publisher edition"
+
+#: books/edit.html
+msgid "This Work"
+msgstr "이 작품"
+
+#: books/edit.html
+msgid ""
+"You can search by author name (like <em>j k rowling</em>) or by Open Library ID (like "
+"<a href=\"/authors/OL23919A\" target=\"_blank\" rel=\"noopener "
+"noreferrer\"><em>OL23919A</em></a>)."
+msgstr ""
+"You can 검색 by 저자 name (like <em>j k rowling</em>) or by Open Library ID (like <a "
+"href=\"/저자/OL23919A\" target=\"_blank\" rel=\"noopener "
+"noreferrer\"><em>OL23919A</em></a>)."
+
+#: books/edit.html
+msgid "Author editing requires javascript"
+msgstr "저자 편집에는 JavaScript가 필요합니다"
+
+#: books/edit.html
+msgid "Add Excerpts"
+msgstr "Excerpts 추가"
+
+#: books/edit.html type/about/edit.html type/author/edit.html
+msgid "Links"
+msgstr "링크"
+
+#: books/edit.html
+msgid "Work Series"
+msgstr "작품 시리즈"
+
+#: books/edit.html
+msgid ""
+"Series are currently in beta, and this section is only visible to super librarians and "
+"admins, like you! Any series you set will be visible by everyone, however. Please "
+"report any issues you have on Slack or GitHub."
+msgstr ""
+"Series are currently in beta, and this section is only visible to super librarians and "
+"admins, like you! Any series you set 됩니다 visible by everyone, however. 다음 report any "
+"issues you have on Slack or GitHub."
+
+#: books/edit.html
+msgid "Is this work part of a larger series?"
+msgstr "Is this 작품 part of a larger series?"
+
+#: books/edit.html
+msgid "E.g. Harry Potter, The Sword of Truth"
+msgstr "예: Harry Potter, The Sword of Truth"
+
+#: books/edit.html type/edition/view.html type/work/view.html
+msgid "Work Identifiers"
+msgstr "작품 식별자"
+
+#: books/edit.html
+msgid "Do you know any identifiers for this work?"
+msgstr "알고 있나요 any identifiers 이 작품에 대해?"
+
+#: books/edit.html
+msgid ""
+"These identifiers apply to all editions of this work, for example Wikidata work "
+"identifiers. For edition-specific identifiers, like ISBN or LCCN, go to the edition "
+"tab."
+msgstr ""
+"These identifiers apply to all 판본 of this 작품, for example Wikidata 작품 identifiers. For "
+"판본-specific identifiers, like ISBN or LCCN, go to the 판본 tab."
+
+#: FulltextSearchSuggestionItem.html IABook.html SearchResultsWork.html
+#: books/edition-sort.html jsdef/LazyWorkPreview.html lists/list_overview.html
+#: lists/preview.html lists/snippet.html lists/widget.html my_books/dropdown_content.html
+#: type/work/editions.html
+#, python-format
+msgid "Cover of: %(title)s"
+msgstr "%(title)s의 표지"
+
+#: books/edition-sort.html
+#, python-format
+msgid "%(title)s: %(subtitle)s"
+msgstr "%(title)s: %(subtitle)s"
+
+#: books/edition-sort.html
+#, python-format
+msgid "Publish date unknown, %(publisher)s"
+msgstr "Publish date 알 수 없음, %(publisher)s"
+
+#: books/edition-sort.html type/work/editions.html
+#, python-format
+msgid "in %(languagelist)s"
+msgstr "%(languagelist)s로"
+
+#: SearchNavigation.html books/mybooks_breadcrumb_select.html lib/nav_foot.html
+#: openlibrary/plugins/upstream/mybooks.py
+msgid "Books"
+msgstr "책"
+
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#, python-format
+msgid "Want to Read (%(count)d)"
+msgstr "읽고 싶어요 (%(count)d)"
+
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#, python-format
+msgid "Currently Reading (%(count)d)"
+msgstr "읽는 중 (%(count)d)"
+
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#, python-format
+msgid "Already Read (%(count)d)"
+msgstr "이미 읽음 (%(count)d)"
+
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/openlibrary/lists.py
+#, python-format
+msgid "Lists (%(count)d)"
+msgstr "목록 (%(count)d)"
+
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#: type/edition/modal_links.html
+msgid "Notes"
+msgstr "노트"
+
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
+msgid "Imports and Exports"
+msgstr "가져오기 및 내보내기"
+
+#: books/series-autocomplete.html
+msgid "Add a new series"
+msgstr "새 series 추가"
+
+#: books/series-autocomplete.html
+msgid "Series name"
+msgstr "시리즈 이름"
+
+#: books/series-autocomplete.html
+msgid "Series position"
+msgstr "시리즈 위치"
+
+#: books/series-autocomplete.html
+msgid "Remove this series"
+msgstr "this series 제거"
+
+#: books/series-autocomplete.html
+msgid "Add another series?"
+msgstr "another series? 추가"
+
+#: books/edit/about.html
+msgid "Select this subject"
+msgstr "이 주제 선택"
+
+#: books/edit/about.html
+msgid "How would you describe this book?"
+msgstr "How would you describe 이 책?"
+
+#: books/edit/about.html
+msgid "There's no wrong answer here."
+msgstr "여기에 틀린 답은 없습니다."
+
+#: books/edit/about.html
+msgid "Subject keywords?"
+msgstr "주제 키워드?"
+
+#: books/edit/about.html
+msgid "Please separate with commas."
+msgstr "쉼표로 구분해 주세요."
+
+#: books/edit/about.html
+msgid ""
+"For example: <i><a href=\"/subjects/cheese\">cheese</a>, <a "
+"href=\"/subjects/roman_empire\">Roman Empire</a>, <a "
+"href=\"/subjects/psychology\">psychology</a></i>"
+msgstr ""
+"For example: <i><a href=\"/주제/cheese\">cheese</a>, <a href=\"/주제/roman_empire\">Roman "
+"Empire</a>, <a href=\"/주제/psychology\">psychology</a></i>"
+
+#: books/edit/about.html
+msgid "A person? Or, people?"
+msgstr "인물인가요? 여러 사람인가요?"
+
+#: books/edit/about.html
+msgid ""
+"For example: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore Roosevelt</a>,"
+" <a href=\"/subjects/person:Julian_of_Norwich\">Julian of Norwich</a>, <a "
+"href=\"/subjects/person:Tintin\">Tintin</a></i>"
+msgstr ""
+"For example: <i><a href=\"/주제/person:Theodore_Roosevelt\">Theodore Roosevelt</a>, <a "
+"href=\"/주제/person:Julian_of_Norwich\">Julian of Norwich</a>, <a "
+"href=\"/주제/person:Tintin\">Tintin</a></i>"
+
+#: books/edit/about.html
+msgid "Note any places mentioned?"
+msgstr "언급된 장소가 있나요?"
+
+#: books/edit/about.html
+msgid ""
+"For example: <i><a href=\"/subjects/place:London\">London</a>, <a "
+"href=\"/subjects/place:Atlantis\">Atlantis</a>, <a "
+"href=\"/subjects/place:Omaha\">Omaha</a></i>"
+msgstr ""
+"For example: <i><a href=\"/주제/place:London\">London</a>, <a "
+"href=\"/주제/place:Atlantis\">Atlantis</a>, <a href=\"/주제/place:Omaha\">Omaha</a></i>"
+
+#: books/edit/about.html
+msgid "When is it set or about?"
+msgstr "배경이나 주제가 되는 시기는 언제인가요?"
+
+#: books/edit/about.html
+msgid ""
+"For example: <i><a href=\"/subjects/time:1984\">1984</a>, <a "
+"href=\"/subjects/time:the_middle_ages\">The Middle Ages</a>, <a "
+"href=\"/subjects/time:1810-1890\">1810-1890</a></i>"
+msgstr ""
+"For example: <i><a href=\"/주제/time:1984\">1984</a>, <a "
+"href=\"/주제/time:the_middle_ages\">The Middle Ages</a>, <a "
+"href=\"/주제/time:1810-1890\">1810-1890</a></i>"
+
+#: books/edit/edition.html
+msgid "Select this language"
+msgstr "이 언어 선택"
+
+#: books/edit/edition.html
+msgid "Remove this language"
+msgstr "this language 제거"
+
+#: books/edit/edition.html
+msgid "Remove this work"
+msgstr "this work 제거"
+
+#: books/edit/edition.html
+msgid "-- Move to a new work"
+msgstr "-- 새 작품으로 이동"
+
+#: books/edit/edition.html
+msgid "This Edition"
+msgstr "이 판본"
+
+#: books/edit/edition.html
+msgid "Enter the title of this specific edition."
+msgstr "Enter the title of this specific 판본."
+
+#: books/edit/edition.html
+msgid "Subtitle"
+msgstr "부제"
+
+#: books/edit/edition.html
+msgid "Usually distinguished by different or smaller type."
+msgstr "보통 다른 글꼴이나 더 작은 글꼴로 구분됩니다."
+
+#: books/edit/edition.html
+msgid "For example: <i>envisioning the next 50 years</i>"
+msgstr "예: <i>envisioning the next 50 years</i>"
+
+#: books/edit/edition.html
+msgid "Publishing Info"
+msgstr "출판 정보"
+
+#: books/edit/edition.html
+msgid "For example <em>Oxford University Press; Penguin; W.W. Norton</em>"
+msgstr "예: <em>Oxford University Press; Penguin; W.W. Norton</em>"
+
+#: books/edit/edition.html
+msgid "Where was the book published?"
+msgstr "Where was the 책 published?"
+
+#: books/edit/edition.html
+msgid "City, Country please."
+msgstr "도시, 국가를 입력해 주세요."
+
+#: books/edit/edition.html
+msgid "For example: <i>New York, USA; Sydney, Australia</i>"
+msgstr "예: <i>New York, USA; Sydney, Australia</i>"
+
+#: books/edit/edition.html
+msgid "What is the copyright date?"
+msgstr "저작권 날짜는 언제인가요?"
+
+#: books/edit/edition.html
+msgid "The year following the copyright statement."
+msgstr "저작권 표시 뒤에 나오는 연도입니다."
+
+#: books/edit/edition.html
+msgid "Edition Name (if applicable):"
+msgstr "편집ion Name (if applicable):"
+
+#: books/edit/edition.html
+msgid "For example: <i>Centennial edition</i>; <i>First edition</i>"
+msgstr "For example: <i>Centennial 판본</i>; <i>First 판본</i>"
+
+#: books/edit/edition.html
+msgid "Series Name (if applicable)"
+msgstr "시리즈 이름(해당하는 경우)"
+
+#: books/edit/edition.html
+msgid "The name of the publisher's series."
+msgstr "The name of the 출판사's series."
+
+#: books/edit/edition.html
+msgid "For example: <i>The Story of Civilization, Part III</i>"
+msgstr "예: <i>The Story of Civilization, Part III</i>"
+
+#: books/edit/edition.html type/edition/view.html type/work/view.html
+msgid "Contributors"
+msgstr "기여자"
+
+#: books/edit/edition.html
+msgid "Please select a role."
+msgstr "역할을 선택해 주세요."
+
+#: books/edit/edition.html
+msgid "You need to give this ROLE a name."
+msgstr "이 역할에 이름을 지정해야 합니다."
+
+#: books/edit/edition.html
+msgid "List the people involved"
+msgstr "관련된 사람들을 나열하세요"
+
+#: books/edit/edition.html
+msgid "Select role"
+msgstr "역할 선택"
+
+#: books/edit/edition.html
+msgid "Add a new role"
+msgstr "새 role 추가"
+
+#: books/edit/edition.html
+msgid "Remove this contributor"
+msgstr "this contributor 제거"
+
+#: books/edit/edition.html
+msgid "By Statement:"
+msgstr "저자/기여 표시:"
+
+#: books/edit/edition.html
+msgid "For example: <em>edited by David Anderson</em>"
+msgstr "For example: <em>편집ed by David Anderson</em>"
+
+#: books/edit/edition.html languages/index.html
+msgid "Languages"
+msgstr "언어"
+
+#: books/edit/edition.html
+msgid "What language is this edition written in?"
+msgstr "What language is this 판본 written in?"
+
+#: books/edit/edition.html
+msgid "Add another language?"
+msgstr "another language? 추가"
+
+#: books/edit/edition.html
+msgid "Is it a translation of another book?"
+msgstr "Is it a translation of another 책?"
+
+#: books/edit/edition.html
+msgid "Yes, it's a translation"
+msgstr "예, 번역본입니다"
+
+#: books/edit/edition.html
+msgid "What's the original book?"
+msgstr "What's the original 책?"
+
+#: books/edit/edition.html
+msgid "What language was the original written in?"
+msgstr "원본은 어떤 언어로 쓰였나요?"
+
+#: books/edit/edition.html
+msgid "Description of this edition"
+msgstr "이 판본의 설명"
+
+#: books/edit/edition.html
+msgid "Only if it's different from the work's description"
+msgstr "Only if it's different from the 작품's description"
+
+#: books/edit/edition.html type/edition/view.html type/work/view.html
+msgid "Table of Contents"
+msgstr "목차"
+
+#: books/edit/edition.html
+msgid ""
+"Use a \"*\" for an indent, a \"|\" to add a column, and line breaks for new lines. Like"
+" this:"
+msgstr ""
+"Use a \"*\" for an indent, a \"|\" 추가하려면 a column, and line breaks for new lines. Like "
+"this:"
+
+#: books/edit/edition.html
+msgid ""
+"This table of contents contains extra information like authors or descriptions. We "
+"don't have a great user interface for this yet, so editing this data could be "
+"difficult. Watch out!"
+msgstr ""
+"This table of contents contains extra information like 저자 or descriptions. We don't "
+"have a great user interface for this yet, so 편집ing this data could be difficult. Watch "
+"out!"
+
+#: books/edit/edition.html
+msgid "Any notes about this specific edition?"
+msgstr "Any notes about this specific 판본?"
+
+#: books/edit/edition.html
+msgid "Anything about the book that may be of interest."
+msgstr "Anything about the 책 that may be of interest."
+
+#: books/edit/edition.html
+msgid "A Plume Book"
+msgstr "A Plume Book"
+
+#: books/edit/edition.html
+msgid "Is it known by any other titles?"
+msgstr "다른 제목으로도 알려져 있나요?"
+
+#: books/edit/edition.html
+msgid ""
+"Use this field if the title is different on the cover or spine. If the edition is a "
+"collection or anthology, you may also add the individual titles of each work here."
+msgstr ""
+"Use this field if the title is different on the cover or spine. If the 판본 is a "
+"collection or anthology, you may also 추가 the individual titles of each 작품 here."
+
+#: books/edit/edition.html
+msgid ""
+"For example: <i>Eaters of the Dead</i> is an alternate title for <i><a "
+"href=\"/books/OL24923038M\">The 13th Warrior</a></i>."
+msgstr ""
+"For example: <i>Eaters of the Dead</i> is an alternate title for <i><a "
+"href=\"/책/OL24923038M\">The 13th Warrior</a></i>."
+
+#: books/edit/edition.html
+msgid "What work is this an edition of?"
+msgstr "What 작품 is this an 판본 of?"
+
+#: books/edit/edition.html
+msgid "Sometimes editions can be associated with the wrong work. You can correct that here."
+msgstr "Sometimes 판본 할 수 있습니다 associated with the wrong 작품. You can correct that here."
+
+#: books/edit/edition.html
+msgid ""
+"You can search by title or by Open Library ID (like <a href=\"/works/OL262757W\" "
+"target=\"_blank\" rel=\"noopener noreferrer\"><em>OL262757W</em></a>)."
+msgstr ""
+"You can 검색 by title or by Open Library ID (like <a href=\"/작품/OL262757W\" "
+"target=\"_blank\" rel=\"noopener noreferrer\"><em>OL262757W</em></a>)."
+
+#: books/edit/edition.html
+msgid "WARNING: Any edits made to the work from this page will be ignored."
+msgstr "WARNING: Any 편집s made to the 작품 from this 페이지 됩니다 ignored."
+
+#: books/edit/edition.html
+msgid "Copy authors to new work"
+msgstr "저자를 새 작품으로 복사"
+
+#: books/edit/edition.html
+msgid "Copy subjects to new work"
+msgstr "주제를 새 작품으로 복사"
+
+#: books/edit/edition.html
+msgid "Please select an identifier."
+msgstr "식별자를 선택해 주세요."
+
+#: books/edit/edition.html
+msgid "You need to give a value to ID."
+msgstr "ID 값을 입력해야 합니다."
+
+#: books/edit/edition.html
+msgid "ID ids cannot contain whitespace."
+msgstr "ID에는 공백을 포함할 수 없습니다."
+
+#: books/edit/edition.html
+msgid "ID must be exactly 10 characters [0-9] or X."
+msgstr "ID는 정확히 10자[0-9] 또는 X여야 합니다."
+
+#: books/edit/edition.html
+msgid "That ID already exists for this edition."
+msgstr "That ID already exists 이 판본에 대해."
+
+#: books/edit/edition.html
+msgid "ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4"
+msgstr "ID는 정확히 13자리 숫자[0-9]여야 합니다. 예: 978-1-56619-909-4"
+
+#: books/edit/edition.html
+msgid "Invalid ID format"
+msgstr "잘못된 ID 형식"
+
+#: books/edit/edition.html type/author/view.html
+msgid "ID Numbers"
+msgstr "ID 번호"
+
+#: books/edit/edition.html
+msgid "Do you know any identifiers for this edition?"
+msgstr "알고 있나요 any identifiers 이 판본에 대해?"
+
+#: books/edit/edition.html
+msgid "Like, ISBN?"
+msgstr "예: ISBN?"
+
+#: books/edit/edition.html
+msgid "Please select a classification."
+msgstr "분류를 선택해 주세요."
+
+#: books/edit/edition.html
+msgid "You need to give a value to CLASS."
+msgstr "CLASS 값을 입력해야 합니다."
+
+#: books/edit/edition.html type/edition/view.html type/work/view.html
+msgid "Classifications"
+msgstr "분류"
+
+#: books/edit/edition.html
+msgid "Do you know any classifications of this edition?"
+msgstr "알고 있나요 any classifications of this 판본?"
+
+#: books/edit/edition.html
+msgid "Like, Dewey Decimal?"
+msgstr "예: 듀이 십진분류?"
+
+#: books/edit/edition.html
+msgid "Select one of many..."
+msgstr "여러 항목 중 하나 선택..."
+
+#: books/edit/edition.html
+msgid "Add a new classification type"
+msgstr "새 classification type 추가"
+
+#: books/edit/edition.html
+msgid "Remove this classification"
+msgstr "this classification 제거"
+
+#: books/edit/edition.html type/edition/view.html type/work/view.html
+msgid "The Physical Object"
+msgstr "물리적 객체"
+
+#: books/edit/edition.html
+msgid "What sort of book is it?"
+msgstr "What sort of 책 is it?"
+
+#: books/edit/edition.html
+msgid "Paperback; Hardcover, etc."
+msgstr "페이퍼백, 하드커버 등"
+
+#: books/edit/edition.html
+msgid "How many pages?"
+msgstr "How many 페이지s?"
+
+#: books/edit/edition.html
+msgid "Pagination?"
+msgstr "페이지 매김?"
+
+#: books/edit/edition.html
+msgid "Note the highest number in each pagination pattern."
+msgstr "각 페이지 매김 패턴에서 가장 높은 번호를 적어 주세요."
+
+#: books/edit/edition.html lib/nav_foot.html
+msgid "Help"
+msgstr "도움말"
+
+#: books/edit/edition.html
+msgid "For example: <em>xii, 346p.</em>"
+msgstr "예: <em>xii, 346p.</em>"
+
+#: books/edit/edition.html
+msgid "How much does the book weigh?"
+msgstr "How much does the 책 weigh?"
+
+#: books/edit/edition.html type/edition/view.html type/work/view.html
+msgid "Dimensions"
+msgstr "크기"
+
+#: books/edit/edition.html
+msgid "dimensions"
+msgstr "크기"
+
+#: books/edit/edition.html
+msgid "Height:"
+msgstr "높이:"
+
+#: books/edit/edition.html
+msgid "Width:"
+msgstr "너비:"
+
+#: books/edit/edition.html
+msgid "Depth:"
+msgstr "두께:"
+
+#: books/edit/edition.html
+msgid "Web Book Providers"
+msgstr "웹 책 제공자"
+
+#: books/edit/edition.html
+msgid "Access Type"
+msgstr "접근 유형"
+
+#: books/edit/edition.html
+msgid "File Format"
+msgstr "파일 형식"
+
+#: books/edit/edition.html
+msgid "Provider Name"
+msgstr "제공자 이름"
+
+#: books/edit/edition.html
+msgid "Buy"
+msgstr "구매"
+
+#: books/edit/edition.html
+msgid "Web"
+msgstr "웹"
+
+#: books/edit/edition.html
+msgid "Add a provider"
+msgstr "a provider 추가"
+
+#: books/edit/edition.html
+msgid "First sentence"
+msgstr "첫 문장"
+
+#: books/edit/edition.html
+msgid "The opening line that starts the lead paragraph"
+msgstr "첫 단락을 시작하는 첫 문장입니다"
+
+#: books/edit/edition.html
+msgid "Admin Only"
+msgstr "관리자 전용"
+
+#: books/edit/edition.html
+msgid "Additional Metadata"
+msgstr "추가 메타데이터"
+
+#: books/edit/edition.html
+msgid "This field can accept arbitrary key:value pairs"
+msgstr "이 필드는 임의의 key:value 쌍을 받을 수 있습니다"
+
+#: books/edit/excerpts.html
+msgid "Please provide an excerpt."
+msgstr "발췌문을 입력해 주세요."
+
+#: books/edit/excerpts.html
+msgid "That excerpt is too long."
+msgstr "발췌문이 너무 깁니다."
+
+#: books/edit/excerpts.html
+msgid ""
+"If there are particular (short) passages you feel represent the book well, please feel "
+"free to transcribe them here."
+msgstr ""
+"If there are particular (short) passages you feel represent the 책 well, please feel "
+"free to transcribe them here."
+
+#: books/edit/excerpts.html
+msgid "Page number?"
+msgstr "페이지 번호?"
+
+#: books/edit/excerpts.html
+msgid "For example: <i>23, xi or 433-434</i>"
+msgstr "For example: <i>23, xi or 433-434</i>"
+
+#: books/edit/excerpts.html
+msgid "This excerpt is the first sentence of the book."
+msgstr "This excerpt is the first sentence of the 책."
+
+#: books/edit/excerpts.html
+msgid "Transcribe the excerpt"
+msgstr "발췌문 옮겨 적기"
+
+#: books/edit/excerpts.html
+msgid "Maximum length is 2000 characters. No HTML allowed."
+msgstr "최대 길이는 2000자입니다. HTML은 허용되지 않습니다."
+
+#: books/edit/excerpts.html
+msgid "Why did you choose this excerpt?"
+msgstr "왜 이 발췌문을 선택했나요?"
+
+#: books/edit/excerpts.html
+msgid "Add an optional note."
+msgstr "an optional note. 추가"
+
+#: books/edit/excerpts.html
+msgid "Excerpts so far..."
+msgstr "지금까지의 발췌문..."
+
+#: books/edit/excerpts.html
+msgid "noted:"
+msgstr "메모:"
+
+#: books/edit/excerpts.html
+msgid "An anonymous note:"
+msgstr "익명 메모:"
+
+#: books/edit/excerpts.html
+msgid "From page"
+msgstr "페이지:"
+
+#: books/edit/web.html
+msgid "Please provide a label."
+msgstr "라벨을 입력해 주세요."
+
+#: books/edit/web.html
+msgid "Please provide a URL."
+msgstr "URL을 입력해 주세요."
+
+#: books/edit/web.html
+msgid "Please enter a valid URL."
+msgstr "유효한 URL을 입력해 주세요."
+
+#: books/edit/web.html
+msgid ""
+"Please connect Open Library records to <u>good</u><span class=\"orange\">*</span> "
+"online resources."
+msgstr ""
+"다음 connect Open Library 레코드s to <u>good</u><span class=\"orange\">*</span> online "
+"resources."
+
+#: books/edit/web.html
+msgid "Give your link a label"
+msgstr "링크에 라벨 지정"
+
+#: books/edit/web.html
+msgid "For example: <em>New York Times review</em>"
+msgstr "For example: <em>New York Times 리뷰</em>"
+
+#: books/edit/web.html
+msgid "URL"
+msgstr "URL"
+
+#: books/edit/web.html
+msgid "Add Link"
+msgstr "Link 추가"
+
+#: books/edit/web.html
+msgid "Remove this link"
+msgstr "this link 제거"
+
+#: books/edit/web.html
+msgid ""
+"\"Good\" means no spammy links, please. Keep them relevant to the book. Irrelevant "
+"sites may be removed. Blatant spam will be deleted without remorse."
+msgstr ""
+"\"Good\" means no spammy links, please. Keep them relevant to the 책. Irrelevant sites "
+"may be 제거d. Blatant spam 됩니다 삭제d without remorse."
+
+#: bulk_search/bulk_search.html search/advancedsearch.html
+msgid "Bulk Search (beta)"
+msgstr "Bulk 검색 (beta)"
+
+#: covers/add.html
+msgid "There are two ways to put an author's image on Open Library."
+msgstr "다음이 있습니다: two ways to put an 저자's image on Open Library."
+
+#: covers/add.html
+msgid "Image Guidelines"
+msgstr "이미지 가이드라인"
+
+#: covers/add.html
+msgid "There are a few ways to put a cover image on Open Library."
+msgstr "다음이 있습니다: a few ways to put a cover image on Open Library."
+
+#: covers/add.html
+msgid "Cover Guidelines"
+msgstr "표지 가이드라인"
+
+#: covers/add.html
+msgid "Please provide a valid image."
+msgstr "유효한 이미지를 제공해 주세요."
+
+#: covers/add.html
+msgid "Please provide an image URL."
+msgstr "이미지 URL을 입력해 주세요."
+
+#: covers/add.html
+#, python-format
+msgid ""
+"Learn more by reading our <a href=\"/help/faq/editing#picture\" "
+"target=\"blank\">%(guidelines)s</a>."
+msgstr ""
+"Learn more by reading our <a href=\"/help/faq/편집ing#picture\" "
+"target=\"blank\">%(guidelines)s</a>."
+
+#: covers/add.html
+msgid "<strong>Pick one</strong> from the existing covers"
+msgstr "기존 표지 중에서 <strong>하나를 선택</strong>하세요"
+
+#: covers/add.html
+msgid "Use this image"
+msgstr "이 이미지 사용"
+
+#: covers/add.html
+msgid "Choose a JPG, GIF, PNG or WebP on your computer"
+msgstr "컴퓨터에서 JPG, GIF, PNG 또는 WebP를 선택하세요"
+
+#: covers/add.html
+msgid "Upload"
+msgstr "Upload"
+
+#: covers/add.html
+msgid "Or, paste an image from your clipboard"
+msgstr "또는 클립보드에서 이미지를 붙여넣으세요"
+
+#: covers/add.html
+msgid "Paste image from clipboard"
+msgstr "클립보드에서 이미지 붙여넣기"
+
+#: covers/add.html
+msgid "Paste Image"
+msgstr "이미지 붙여넣기"
+
+#: covers/add.html
+msgid "Upload image"
+msgstr "이미지 업로드"
+
+#: covers/add.html covers/external_image.html
+msgid "Upload Image"
+msgstr "이미지 업로드"
+
+#: covers/add.html
+msgid "Uploading..."
+msgstr "업로드 중..."
+
+#: covers/add.html
+msgid "Wikidata"
+msgstr "Wikidata"
+
+#: covers/author_photo.html
+msgid "Pull up a larger author photo"
+msgstr "더 큰 저자 사진 보기"
+
+#: covers/author_photo.html search/authors.html
+#, python-format
+msgid "Photo of %(author)s"
+msgstr "%(author)s의 사진"
+
+#: covers/author_photo.html
+msgid "Click to close"
+msgstr "클릭하여 닫기"
+
+#: covers/author_photo.html
+#, python-format
+msgid "We need a photo of %(author)s"
+msgstr "%(author)s의 사진이 필요합니다"
+
+#: covers/book_cover.html
+msgid "Pull up a bigger book cover"
+msgstr "더 큰 책 표지 보기"
+
+#: covers/book_cover.html covers/book_cover_small.html
+#, python-format
+msgid "Cover of: %(title)s by %(authors)s"
+msgstr "%(authors)s의 %(title)s 표지"
+
+#: covers/book_cover_small.html
+#, python-format
+msgid "Go to the main page for %(title)s"
+msgstr "the main page for %(title)s로 이동"
+
+#: covers/book_cover_small.html
+#, python-format
+msgid "We need a book cover for: %(title)s"
+msgstr "%(title)s의 책 표지가 필요합니다"
+
+#: covers/change.html
+msgid "Author Photos"
+msgstr "저자 사진"
+
+#: covers/change.html
+msgid "Manage Author Photos"
+msgstr "Author Photos 관리"
+
+#: covers/change.html
+msgid "Add Author Photo"
+msgstr "Author Photo 추가"
+
+#: covers/change.html
+msgid "Book Covers"
+msgstr "책 표지"
+
+#: covers/change.html
+msgid "Manage Covers"
+msgstr "Covers 관리"
+
+#: covers/change.html
+msgid "Add Cover Image"
+msgstr "Cover Image 추가"
+
+#: covers/change.html
+msgid "Manage"
+msgstr "관리"
+
+#: covers/external_image.html
+#, python-format
+msgid "Or, use an image from %s"
+msgstr "또는 %s의 이미지를 사용하세요"
+
+#: covers/manage.html
+msgid "You can drag and drop thumbnails to reorder, or into the trash to delete them."
+msgstr "You can drag and drop thumbnails to reorder, or into the trash to 삭제 them."
+
+#: covers/saved.html
+msgid "New book cover"
+msgstr "새 책 표지"
+
+#: covers/saved.html
+msgid "Saved!"
+msgstr "저장d!"
+
+#: covers/saved.html
+msgid "Notes:"
+msgstr "노트:"
+
+#: covers/saved.html
+msgid "Add another image"
+msgstr "another image 추가"
+
+#: covers/saved.html
+msgid "Finished"
+msgstr "완료"
+
+#: design/button.html merge/authors.html recentchanges/merge/view.html
+msgid "Primary"
+msgstr "기본"
+
+#: design/popover.html
+msgid "Popover component"
+msgstr "팝오버 컴포넌트"
+
+#: design/popover.html
+msgid ""
+"The ol-popover component provides a reusable animated popover panel anchored to a "
+"trigger element. It animates from the trigger using transform-origin, closes on Escape "
+"or outside click, and respects prefers-reduced-motion."
+msgstr ""
+"The ol-popover component provides a reusable animated popover panel anchored to a "
+"trigger element. It animates from the trigger using transform-origin, closes on Escape "
+"or outside click, and respects prefers-reduced-motion."
+
+#: design/popover.html
+msgid "Menu popover"
+msgstr "메뉴 팝오버"
+
+#: design/popover.html
+msgid ""
+"Popovers animate from the trigger using transform-origin. Click the button to see the "
+"scale + fade entrance."
+msgstr ""
+"Popovers animate from the trigger using transform-origin. Click the button to see the "
+"scale + fade entrance."
+
+#: design/popover.html
+msgid "Options"
+msgstr "옵션"
+
+#: design/popover.html
+msgid "Duplicate"
+msgstr "복제"
+
+#: design/popover.html
+msgid "Archive"
+msgstr "아카이브"
+
+#: design/popover.html
+msgid "Move"
+msgstr "이동"
+
+#: design/popover.html
+msgid "Placement options"
+msgstr "배치 옵션"
+
+#: design/popover.html
+#, python-format
+msgid ""
+"Use %(placement)s to control where the popover appears. The %(transform_origin)s "
+"automatically matches so the animation always expands from the trigger."
+msgstr ""
+"Use %(placement)s to control where the popover appears. The %(transform_origin)s "
+"automatically matches so the animation always expands from the trigger."
+
+#: design/popover.html
+msgid "bottom-start"
+msgstr "bottom-start"
+
+#: design/popover.html
+msgid "top-center"
+msgstr "top-center"
+
+#: email/case_created.html
+msgid "Sent!"
+msgstr "전송됨!"
+
+#: email/case_created.html
+msgid "Thank you for your note. We'll get back to you as soon as possible."
+msgstr "메모를 보내주셔서 감사합니다. 가능한 한 빨리 답변드리겠습니다."
+
+#: email/case_created.html
+msgid ""
+"It might take us a little while to read it because we receive lots of messages, but "
+"rest assured we will, and we'll get back to you if required."
+msgstr "메시지가 많아 읽는 데 시간이 조금 걸릴 수 있지만, 반드시 확인하겠습니다. 필요한 경우 답변드리겠습니다."
+
+#: email/account/pd_request.html
+msgid "Qualifying for Print Disability Special Access"
+msgstr "인쇄물 이용 장애 특별 접근 자격"
+
+#: history/sources.html
+msgid "record"
+msgstr "레코드"
+
+#: home/about.html
+msgid "About the Project"
+msgstr "프로젝트 소개"
+
+#: home/about.html
+msgid ""
+"Open Library is an open, editable library catalog, building towards a web page for "
+"every book ever published."
+msgstr ""
+"Open Library is an open, 편집able library catalog, building towards a web 페이지 for every 책"
+" ever published."
+
+#: AffiliateLinks.html home/about.html search/work_search_facets.html
+msgid "More"
+msgstr "더 보기"
+
+#: home/about.html
+msgid ""
+"Just like Wikipedia, you can contribute new information or corrections to the catalog. "
+"You can browse by <a href=\"/subjects\">subjects</a>, <a href=\"/authors\">authors</a> "
+"or <a href=\"/lists\">lists</a> members have created. If you love books, why not help "
+"build a library?"
+msgstr ""
+"Just like Wikipedia, you can contribute new information or corrections to the catalog. "
+"You can browse by <a href=\"/주제\">주제</a>, <a href=\"/저자\">저자</a> or <a "
+"href=\"/목록\">목록</a> members have 생성d. If you love 책, why not help build a library?"
+
+#: home/about.html
+msgid "Latest Blog Posts"
+msgstr "최신 블로그 글"
+
+#: home/categories.html
+msgid "Browse by Subject"
+msgstr "주제별 둘러보기"
+
+#: home/categories.html
+#, python-format
+msgid "%(count)s Book"
+msgid_plural "%(count)s Books"
+msgstr[0] "%(count)s권의 책"
+
+#: home/index.html home/welcome.html
+msgid "Welcome to Open Library"
+msgstr "Open Library에 오신 것을 환영합니다"
+
+#: home/index.html openlibrary/plugins/openlibrary/api.py
+msgid "Classic Books"
+msgstr "고전 도서"
+
+#: home/index.html
+msgid "Recently Returned"
+msgstr "최근 반납된 책"
+
+#: home/index.html openlibrary/plugins/openlibrary/api.py
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Romance"
+msgstr "로맨스"
+
+#: home/index.html openlibrary/plugins/openlibrary/api.py
+msgid "Kids"
+msgstr "어린이"
+
+#: home/index.html openlibrary/plugins/openlibrary/api.py
+msgid "Thrillers"
+msgstr "스릴러"
+
+#: home/index.html openlibrary/plugins/openlibrary/api.py
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Textbooks"
+msgstr "교과서"
+
+#: home/index.html
+msgid "Authors Alliance & MIT Press"
+msgstr "Authors Alliance & MIT Press"
+
+#: home/index.html
+msgid "Books in Local Environment"
+msgstr "로컬 환경의 책"
+
+#: home/loans.html
+#, python-format
+msgid ""
+"You can still <a href=\"/subjects/in_library#ebooks=true\">borrow</a> one more book "
+"until you've hit the limit!"
+msgid_plural ""
+"You can still <a href=\"/subjects/in_library#ebooks=true\">borrow</a> %(count)d more "
+"books until you've hit the limit!"
+msgstr[0] ""
+"한도에 도달하기 전까지 책을 %(count)d권 더 <a href=\"/subjects/in_library#ebooks=true\">대출</a>할 수 "
+"있습니다!"
+
+#: home/loans.html
+msgid "You have reached the borrowing limit. Please return a book to checkout something new."
+msgstr "당신은 reached the 대출ing limit. 다음 반납 a 책 to checkout something new."
+
+#: home/stats.html
+msgid "Around the Library"
+msgstr "도서관 둘러보기"
+
+#: home/stats.html
+msgid ""
+"Here's what's happened over the last 28 days. More <a href=\"/recentchanges\">recent "
+"changes</a>"
+msgstr "지난 28일 동안 있었던 일입니다. 더 많은 <a href=\"/recentchanges\">최근 변경 사항</a>"
+
+#: home/stats.html
+msgid "See all visitors to OpenLibrary.org"
+msgstr "OpenLibrary.org의 모든 방문자 보기"
+
+#: home/stats.html
+msgid "Area graph of recent unique visitors"
+msgstr "최근 고유 방문자 영역 그래프"
+
+#: home/stats.html
+msgid "How many new Open Library members have we welcomed?"
+msgstr "새 Open Library 회원은 몇 명이나 늘었나요?"
+
+#: home/stats.html
+msgid "Area graph of new members"
+msgstr "새 회원 영역 그래프"
+
+#: home/stats.html
+msgid "People are constantly updating the catalog"
+msgstr "사람들이 계속해서 카탈로그를 업데이트하고 있습니다"
+
+#: home/stats.html
+msgid "Area graph of recent catalog edits"
+msgstr "최근 카탈로그 편집 영역 그래프"
+
+#: home/stats.html
+msgid "Catalog Edits"
+msgstr "카탈로그 편집"
+
+#: home/stats.html
+msgid "Members can create Lists"
+msgstr "회원은 목록을 만들 수 있습니다"
+
+#: home/stats.html
+msgid "Area graph of lists created recently"
+msgstr "Area graph of 목록 생성d recently"
+
+#: home/stats.html
+msgid "Lists Created"
+msgstr "생성된 목록"
+
+#: home/stats.html
+msgid "We're a library, so we lend books, too"
+msgstr "We're a library, so we lend 책, too"
+
+#: home/stats.html
+msgid "Area graph of ebooks borrowed recently"
+msgstr "Area graph of e책 대출ed recently"
+
+#: home/stats.html
+msgid "eBooks Borrowed"
+msgstr "대출된 전자책"
+
+#: home/welcome.html
+msgid "Read Free Library Books Online"
+msgstr "무료 도서관 책을 온라인으로 읽기"
+
+#: home/welcome.html
+msgid "Millions of books available through Controlled Digital Lending"
+msgstr "Millions of 책 사용 가능 through Controlled Digital Lending"
+
+#: home/welcome.html
+msgid "Set a Yearly Reading Goal"
+msgstr "연간 독서 목표 설정"
+
+#: home/welcome.html
+msgid "Learn how to set a yearly reading goal and track what you read"
+msgstr "Learn how to set a yearly 독서 목표 and track what you read"
+
+#: home/welcome.html
+msgid "Keep Track of your Favorite Books"
+msgstr "좋아하는 책 기록하기"
+
+#: home/welcome.html
+msgid "Organize your Books using Lists & the Reading Log"
+msgstr "Organize your Books using Lists & the 독서 기록"
+
+#: home/welcome.html
+msgid "Try the virtual Library Explorer"
+msgstr "가상 라이브러리 탐색기 사용해 보기"
+
+#: home/welcome.html
+msgid "Digital shelves organized like a physical library"
+msgstr "실제 도서관처럼 정리된 디지털 서가"
+
+#: home/welcome.html
+msgid "Try Fulltext Search"
+msgstr "전문 검색 사용해 보기"
+
+#: home/welcome.html
+msgid "Find matching results within the text of millions of books"
+msgstr "Find matching results within the text of millions of 책"
+
+#: home/welcome.html
+msgid "Be an Open Librarian"
+msgstr "Open Librarian 되기"
+
+#: home/welcome.html
+msgid "Dozens of ways you can help improve the library"
+msgstr "도서관 개선을 도울 수 있는 수십 가지 방법"
+
+#: home/welcome.html
+msgid "Volunteer at Open Library"
+msgstr "Open Library에서 자원봉사하기"
+
+#: home/welcome.html
+msgid "Discover opportunities to improve the library"
+msgstr "도서관을 개선할 기회 찾아보기"
+
+#: home/welcome.html
+msgid "Send us feedback"
+msgstr "피드백 보내기"
+
+#: home/welcome.html
+msgid "Your feedback will help us improve these cards"
+msgstr "여러분의 피드백은 이 카드를 개선하는 데 도움이 됩니다"
+
+#: jsdef/LazyWorkPreview.html
+msgid "Select this work"
+msgstr "이 작품 선택"
+
+#: jsdef/LazyWorkPreview.html
+msgid "1 edition"
+msgstr "판본 1개"
+
+#: jsdef/LazyWorkPreview.html
+msgid "editions"
+msgstr "판본"
+
+#: languages/index.html
+#, python-format
+msgid "%s work"
+msgid_plural "%s works"
+msgstr[0] "%s 작품"
+
+#: languages/index.html
+#, python-format
+msgid "%s ebook edition"
+msgid_plural "%s ebook editions"
+msgstr[0] "%s 전자책 판본"
+
+#: languages/notfound.html
+#, python-format
+msgid "%s is not found"
+msgstr "%s을(를) 찾을 수 없습니다"
+
+#: languages/notfound.html
+#, python-format
+msgid "%s does not exist."
+msgstr "%s이(가) 존재하지 않습니다."
+
+#: lib/edit_head.html lib/view_head.html
+msgid "This doc was last edited by"
+msgstr "이 문서의 마지막 편집자:"
+
+#: lib/edit_head.html lib/view_head.html
+msgid "This doc was last edited anonymously"
+msgstr "This doc was last 편집ed anonymously"
+
+#: lib/exports.html
+msgid "Download catalog record:"
+msgstr "카탈로그 레코드 다운로드:"
+
+#: lib/exports.html
+msgid "RDF"
+msgstr "RDF"
+
+#: lib/exports.html type/list/exports.html
+msgid "JSON"
+msgstr "JSON"
+
+#: lib/exports.html
+msgid "OPDS"
+msgstr "OPDS"
+
+#: lib/exports.html
+msgid "Cite this on Wikipedia"
+msgstr "위키백과에서 이것을 인용"
+
+#: lib/exports.html
+msgid "Wikipedia citation"
+msgstr "위키백과 인용"
+
+#: lib/exports.html
+msgid "Copy and paste this code into your Wikipedia page."
+msgstr "Copy and paste this code into your Wikipedia 페이지."
+
+#: lib/exports.html
+msgid "Get instructions at Wikipedia in a new window"
+msgstr "새 창에서 위키백과 안내 보기"
+
+#: lib/header_dropdown.html
+msgid "My account"
+msgstr "내 계정"
+
+#: lib/header_dropdown.html type/user/view.html
+#, python-format
+msgid "Joined %(date)s"
+msgstr "가입일: %(date)s"
+
+#: lib/header_dropdown.html
+msgid "Menu"
+msgstr "메뉴"
+
+#: lib/header_dropdown.html
+msgid "New!"
+msgstr "새 항목!"
+
+#: lib/history.html
+#, python-format
+msgid "Created %(date)s"
+msgstr "생성일: %(date)s"
+
+#: lib/history.html
+#, python-format
+msgid "%(count)d revision"
+msgid_plural "%(count)d revisions"
+msgstr[0] "개정 %(count)d개"
+
+#: lib/history.html
+msgid "an anonymous user"
+msgstr "익명 사용자"
+
+#: lib/history.html
+#, python-format
+msgid "Created by %(user)s"
+msgstr "생성일: by %(user)s"
+
+#: lib/history.html
+#, python-format
+msgid "Edited by %(user)s"
+msgstr "%(user)s님이 편집함"
+
+#: lib/message_addbook.html
+msgid "Super!"
+msgstr "좋습니다!"
+
+#: lib/message_addbook.html
+msgid " Your new record is in the library. Thank you!"
+msgstr " Your new 레코드 is in the library. Thank you!"
+
+#: lib/message_addbook.html
+msgid ""
+"There are a few other simple things you can add while you're here to improve your new "
+"record quickly, and make it much easier for other people to find later."
+msgstr ""
+"다음이 있습니다: a few other simple things you can 추가 while you're here to improve your new "
+"레코드 quickly, and make it much easier for other people to find later."
+
+#: lib/message_addbook.html
+msgid "Upload a cover image"
+msgstr "표지 이미지 업로드"
+
+#: lib/message_addbook.html
+msgid "Snap a quick photo of the cover to share?"
+msgstr "공유할 표지 사진을 빠르게 찍어볼까요?"
+
+#: lib/message_addbook.html
+msgid "Add an ISBN"
+msgstr "an ISBN 추가"
+
+#: lib/message_addbook.html
+msgid "Help the library connect with other systems, like Amazon."
+msgstr "도서관이 Amazon 같은 다른 시스템과 연결되도록 도와주세요."
+
+#: lib/message_addbook.html
+msgid "Add some subjects"
+msgstr "some subjects 추가"
+
+#: lib/message_addbook.html
+msgid "They're just like tags."
+msgstr "태그와 같습니다."
+
+#: lib/message_addbook.html
+msgid "Describe what the book's about"
+msgstr "Describe what the 책's about"
+
+#: lib/message_addbook.html
+msgid "Just a sentence or two is good."
+msgstr "한두 문장이면 충분합니다."
+
+#: lib/nav_foot.html openlibrary/plugins/openlibrary/api.py site/head.html
+msgid "Open Library"
+msgstr "Open Library"
+
+#: lib/nav_foot.html
+msgid "Vision"
+msgstr "비전"
+
+#: lib/nav_foot.html
+msgid "Volunteer"
+msgstr "자원봉사"
+
+#: lib/nav_foot.html
+msgid "Partner With Us"
+msgstr "파트너가 되기"
+
+#: lib/nav_foot.html
+msgid "Jobs"
+msgstr "채용"
+
+#: lib/nav_foot.html
+msgid "Careers"
+msgstr "커리어"
+
+#: lib/nav_foot.html
+msgid "Blog"
+msgstr "블로그"
+
+#: lib/nav_foot.html
+msgid "Terms of Service"
+msgstr "서비스 약관"
+
+#: lib/nav_foot.html site/alert.html
+msgid "Donate"
+msgstr "기부"
+
+#: lib/nav_foot.html
+msgid "Discover"
+msgstr "발견"
+
+#: lib/nav_foot.html
+msgid "Go home"
+msgstr "홈으로 이동"
+
+#: lib/nav_foot.html
+msgid "Home"
+msgstr "홈"
+
+#: lib/nav_foot.html
+msgid "Explore Books"
+msgstr "Books 탐색"
+
+#: lib/nav_foot.html
+msgid "Explore authors"
+msgstr "authors 탐색"
+
+#: lib/nav_foot.html
+msgid "Explore subjects"
+msgstr "subjects 탐색"
+
+#: RelatedSubjects.html SearchNavigation.html SubjectTags.html lib/nav_foot.html
+#: lib/nav_head.html openlibrary/plugins/worksearch/code.py subjects/notfound.html
+#: type/author/view.html type/list/view_body.html
+msgid "Subjects"
+msgstr "주제"
+
+#: lib/nav_foot.html
+msgid "Explore collections"
+msgstr "collections 탐색"
+
+#: lib/nav_foot.html lib/nav_head.html
+msgid "Collections"
+msgstr "컬렉션"
+
+#: SearchNavigation.html lib/nav_foot.html lib/nav_head.html search/advancedsearch.html
+msgid "Advanced Search"
+msgstr "고급 검색"
+
+#: lib/nav_foot.html
+msgid "Navigate to top of this page"
+msgstr "이 페이지 맨 위로 이동"
+
+#: lib/nav_foot.html
+msgid "Return to Top"
+msgstr "맨 위로 돌아가기"
+
+#: lib/nav_foot.html
+msgid "Develop"
+msgstr "개발"
+
+#: lib/nav_foot.html
+msgid "Explore Open Library Developer Center"
+msgstr "Open Library Developer Center 탐색"
+
+#: lib/nav_foot.html lib/nav_head.html
+msgid "Developer Center"
+msgstr "개발자 센터"
+
+#: lib/nav_foot.html
+msgid "Explore Open Library APIs"
+msgstr "Open Library APIs 탐색"
+
+#: lib/nav_foot.html
+msgid "API Documentation"
+msgstr "API 문서"
+
+#: lib/nav_foot.html
+msgid "Bulk Open Library data"
+msgstr "Open Library 대량 데이터"
+
+#: lib/nav_foot.html
+msgid "Bulk Data Dumps"
+msgstr "대량 데이터 덤프"
+
+#: lib/nav_foot.html
+msgid "Write a bot"
+msgstr "봇 작성"
+
+#: lib/nav_foot.html
+msgid "Writing Bots"
+msgstr "봇 작성하기"
+
+#: lib/nav_foot.html
+msgid "Help Center"
+msgstr "도움말 센터"
+
+#: lib/nav_foot.html
+msgid "Contact"
+msgstr "문의"
+
+#: lib/nav_foot.html
+msgid "Contact Us"
+msgstr "문의하기"
+
+#: lib/nav_foot.html
+msgid "Suggest Edits"
+msgstr "편집 제안"
+
+#: lib/nav_foot.html
+msgid "Suggesting Edits"
+msgstr "편집 제안하기"
+
+#: lib/nav_foot.html
+msgid "Add a new book to Open Library"
+msgstr "새 book to Open Library 추가"
+
+#: lib/nav_foot.html
+msgid "Release Notes"
+msgstr "릴리스 노트"
+
+#: lib/nav_foot.html
+msgid "Bluesky"
+msgstr "Bluesky"
+
+#: lib/nav_foot.html
+msgid "Open Library on Bluesky"
+msgstr "Bluesky의 Open Library"
+
+#: lib/nav_foot.html
+msgid "Twitter"
+msgstr "Twitter"
+
+#: lib/nav_foot.html
+msgid "Open Library on Twitter"
+msgstr "Twitter의 Open Library"
+
+#: lib/nav_foot.html
+msgid "GitHub"
+msgstr "GitHub"
+
+#: lib/nav_foot.html
+msgid "Open Library on GitHub"
+msgstr "GitHub의 Open Library"
+
+#: lib/nav_foot.html site/alert.html
+msgid "Change Website Language"
+msgstr "웹사이트 언어 변경"
+
+#: lib/nav_foot.html lib/nav_head.html type/list/embed.html
+msgid "Open Library logo"
+msgstr "Open Library 로고"
+
+#: lib/nav_foot.html
+msgid ""
+"Open Library is an initiative of the <a href=\"//archive.org/\">Internet Archive</a>, a"
+" 501(c)(3) non-profit, building a digital library of Internet sites and other cultural "
+"artifacts in  digital form. Other <a href=\"//archive.org/projects/\">projects</a> "
+"include the <a href=\"//archive.org/web/\">Wayback Machine</a>, <a "
+"href=\"//archive.org/\">archive.org</a> and <a href=\"//archive-it.org\">archive-"
+"it.org</a>"
+msgstr ""
+"Open Library is an initiative of the <a href=\"//archive.org/\">Internet Archive</a>, a"
+" 501(c)(3) non-profit, building a digital library of Internet sites and other cultural "
+"artifacts in  digital form. Other <a href=\"//archive.org/projects/\">projects</a> "
+"include the <a href=\"//archive.org/web/\">Wayback Machine</a>, <a "
+"href=\"//archive.org/\">archive.org</a> and <a href=\"//archive-it.org\">archive-"
+"it.org</a>"
+
+#: lib/nav_foot.html
+#, python-format
+msgid "version <a href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</a>"
+msgstr "버전 <a href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</a>"
+
+#: lib/nav_head.html
+msgid "Loans, Reading Log, Lists, Stats"
+msgstr "Loans, 독서 기록, Lists, Stats"
+
+#: lib/nav_head.html
+msgid "My Profile"
+msgstr "내 프로필"
+
+#: lib/nav_head.html
+msgid "Log out"
+msgstr "로그아웃"
+
+#: lib/nav_head.html
+msgid "Pending Merge Requests"
+msgstr "대기 중인 병합 요청"
+
+#: lib/nav_head.html search/sort_options.html
+msgid "Trending"
+msgstr "인기 상승"
+
+#: lib/nav_head.html
+msgid "K-12 Student Library"
+msgstr "K-12 학생 도서관"
+
+#: lib/nav_head.html
+msgid "Book Talks"
+msgstr "북 토크"
+
+#: lib/nav_head.html
+msgid "Random Book"
+msgstr "무작위 책"
+
+#: lib/nav_head.html
+msgid "Recent Community Edits"
+msgstr "최근 커뮤니티 편집"
+
+#: lib/nav_head.html
+msgid "Help & Support"
+msgstr "도움말 및 지원"
+
+#: lib/nav_head.html
+msgid "Librarians Portal"
+msgstr "사서 포털"
+
+#: lib/nav_head.html
+msgid "My Open Library"
+msgstr "내 Open Library"
+
+#: databarWork.html lib/nav_head.html
+msgid "Browse"
+msgstr "둘러보기"
+
+#: lib/nav_head.html
+msgid "Contribute"
+msgstr "기여"
+
+#: lib/nav_head.html
+msgid "Resources"
+msgstr "자료"
+
+#: lib/nav_head.html
+msgid "The Internet Archive's Open Library: One page for every book"
+msgstr "The Internet Archive's Open Library: One 페이지 for every 책"
+
+#: lib/nav_head.html
+msgid "Text"
+msgstr "텍스트"
+
+#: lib/nav_head.html search/advancedsearch.html
+msgid "Subject"
+msgstr "주제"
+
+#: lib/nav_head.html
+msgid "Advanced"
+msgstr "고급"
+
+#: lib/nav_head.html
+msgid "Search by barcode"
+msgstr "by barcode 검색"
+
+#: lib/not_logged.html
+msgid ""
+"<strong>You are not <a href=\"/account/login\" title=\"Log in now\">logged "
+"in</a>.</strong> Open Library will record your IP address and include it in this page's"
+" publicly accessible edit history. If you <a href=\"/account/create\" title=\"Create an"
+" Open Library account\">create an account</a>, your IP address is concealed and you can"
+" more easily keep track of all your edits and additions."
+msgstr ""
+"<strong>당신은 not <a href=\"/계정/login\" title=\"Log in now\">logged in</a>.</strong> Open"
+" Library will 레코드 your IP 추가ress and include it in this 페이지's 공개ly accessible 편집 "
+"history. If you <a href=\"/계정/생성\" title=\"생성 an Open Library 계정\">생성 an 계정</a>, your "
+"IP 추가ress is concealed and you can more easily keep track of all your 편집s and 추가itions."
+
+#: librarian_dashboard/data_quality_table.html
+msgid "Reload"
+msgstr "다시 불러오기"
+
+#: librarian_dashboard/data_quality_table.html
+msgid "failing"
+msgstr "실패 중"
+
+#: librarian_dashboard/data_quality_table.html
+msgid "Data quality table"
+msgstr "데이터 품질 표"
+
+#: librarian_dashboard/data_quality_table.html
+msgid "Quality Criteria"
+msgstr "품질 기준"
+
+#: lists/carousel.html lists/home.html lists/showcase.html
+msgid "See all"
+msgstr "모두 보기"
+
+#: lists/export_as_html.html
+#, python-format
+msgid "%(list)s - Editions"
+msgstr "%(list)s - 판본"
+
+#: lists/export_as_html.html type/list/embed.html type/list/view_body.html
+msgid "Unknown authors"
+msgstr "알 수 없는 저자"
+
+#: lists/export_as_html.html
+msgid "Title unknown"
+msgstr "Title 알 수 없음"
+
+#: lists/export_as_html.html
+msgid "First publish date unknown"
+msgstr "First publish date 알 수 없음"
+
+#: lists/export_as_html.html
+msgid "Name unknown"
+msgstr "Name 알 수 없음"
+
+#: lists/header.html
+#, python-format
+msgid "<a href=\"%(href)s\">%(name)s</a> / Lists"
+msgstr "<a href=\"%(href)s\">%(name)s</a> / 목록"
+
+#: lists/header.html
+#, python-format
+msgid "This author is on <strong>1 list</strong>."
+msgid_plural "This author is on <strong>%(count)s lists</strong>."
+msgstr[0] "이 저자는 <strong>%(count)s개 목록</strong>에 있습니다."
+
+#: lists/header.html
+#, python-format
+msgid "This is edition is on <strong>1 list</strong>."
+msgid_plural "This edition is on <strong>%(count)s lists</strong>."
+msgstr[0] "이 판본은 <strong>%(count)s개 목록</strong>에 있습니다."
+
+#: lists/header.html
+#, python-format
+msgid "This work is on <strong>1 list</strong>."
+msgid_plural "This work is on <strong>%(count)s lists</strong>."
+msgstr[0] "이 작품은 <strong>%(count)s개 목록</strong>에 있습니다."
+
+#: lists/header.html
+#, python-format
+msgid "%(name)s has 1 list."
+msgid_plural "%(name)s has %(count)s lists."
+msgstr[0] "%(name)s님에게는 목록이 %(count)s개 있습니다."
+
+#: lists/header.html
+#, python-format
+msgid "This subject is on <strong>1 list</strong>."
+msgid_plural "This subject is on <strong>%(count)s lists</strong>."
+msgstr[0] "이 주제는 <strong>%(count)s개 목록</strong>에 있습니다."
+
+#: lists/header.html
+msgid "Hm. Can't find it."
+msgstr "음. 찾을 수 없습니다."
+
+#: lists/home.html
+msgid "Create a list of any Subjects, Authors, Works or specific Editions."
+msgstr "생성 a 목록 of any Subjects, Authors, Works or specific 편집ions."
+
+#: lists/home.html
+msgid ""
+"Once you've made a list, you can <strong>watch for updates</strong> or "
+"<strong>export</strong> all the editions in a list as HTML, BibTeX or JSON. See all "
+"your lists and any activity using the \"Lists\" link on your Account page."
+msgstr ""
+"Once you've made a 목록, you can <strong>watch for updates</strong> or "
+"<strong>export</strong> all the 판본 in a 목록 as HTML, BibTeX or JSON. See all your 목록 and"
+" any activity using the \"Lists\" link on your Account 페이지."
+
+#: lists/home.html
+#, python-format
+msgid ""
+"For the top 2000+ most requested eBooks in California for the print disabled <a "
+"href=\"%(url)s\">click here</a>."
+msgstr "캘리포니아에서 인쇄물 이용 장애인을 위해 가장 많이 요청된 전자책 2000권 이상을 보려면 <a href=\"%(url)s\">여기를 클릭하세요</a>."
+
+#: lists/home.html
+msgid "Find a list by name"
+msgstr "이름으로 목록 찾기"
+
+#: lists/home.html
+msgid "Active Lists"
+msgstr "활성 목록"
+
+#: lists/home.html
+#, python-format
+msgid "from <a href=\"%(key)s\">%(owner)s</a>"
+msgstr "<a href=\"%(key)s\">%(owner)s</a>에서"
+
+#: lists/home.html lists/preview.html lists/snippet.html type/list/embed.html
+#: type/list/view_body.html
+#, python-format
+msgid "%(count)d item"
+msgid_plural "%(count)d items"
+msgstr[0] "%(count)d개 항목"
+
+#: lists/home.html lists/preview.html lists/snippet.html
+#, python-format
+msgid "Last modified %(date)s"
+msgstr "마지막 수정: %(date)s"
+
+#: lists/home.html lists/snippet.html
+msgid "No description."
+msgstr "설명 없음."
+
+#: RecentChangesUsers.html lists/home.html lists/lists.html type/user/view.html
+msgid "Recent Activity"
+msgstr "최근 활동"
+
+#: lists/list_follow.html
+msgid "Cover of book"
+msgstr "책 표지"
+
+#: lists/list_follow.html
+msgid "Avatar of the owner of the list"
+msgstr "목록 소유자의 아바타"
+
+#: lists/list_follow.html lists/widget.html my_books/dropdown_content.html
+msgid "You"
+msgstr "나"
+
+#: lists/list_follow.html
+msgid "This patron has not enabled following"
+msgstr "이 이용자는 팔로우 기능을 활성화하지 않았습니다"
+
+#: lists/list_follow.html
+msgid "🔒︎"
+msgstr "🔒︎"
+
+#: Follow.html lists/list_follow.html
+msgid "Follow"
+msgstr "팔로우"
+
+#: lists/list_follow.html
+msgid "OpenLibrary Logo"
+msgstr "OpenLibrary 로고"
+
+#: lists/list_follow.html
+msgid "Community List"
+msgstr "커뮤니티 목록"
+
+#: lists/list_overview.html lists/widget.html my_books/dropdown_content.html
+msgid "See this list"
+msgstr "이 목록 보기"
+
+#: lists/list_overview.html lists/widget.html my_books/dropdown_content.html
+msgid "Remove from your list?"
+msgstr "from your list? 제거"
+
+#: lists/list_overview.html
+#, python-format
+msgid "from <a href=\"%(link)s\">You</a>"
+msgstr "<a href=\"%(link)s\">나</a>에게서"
+
+#: lists/list_overview.html
+#, python-format
+msgid "from <a href=\"%(link)s\">%(name)s</a>"
+msgstr "<a href=\"%(link)s\">%(name)s</a>에게서"
+
+#: lists/lists.html
+#, python-format
+msgid "%(owner)s / Lists"
+msgstr "%(owner)s / 목록"
+
+#: lists/lists.html type/list/view_body.html
+msgid "Yes, I'm sure"
+msgstr "네, 확실합니다"
+
+#: lists/lists.html type/list/view_body.html
+msgid "No, cancel"
+msgstr "No, 취소"
+
+#: lists/lists.html
+msgid "Delete this list"
+msgstr "this list 삭제"
+
+#: lists/lists.html
+msgid "Delete list"
+msgstr "목록 삭제"
+
+#: lists/lists.html
+msgid "Are you sure you want to delete this list?"
+msgstr "정말 삭제 this 목록?"
+
+#: lists/lists.html
+msgid "Remove this seed?"
+msgstr "this seed? 제거"
+
+#: lists/lists.html
+#, python-format
+msgid "Are you sure you want to remove <strong>%(title)s</strong> from this list?"
+msgstr "정말 제거 <strong>%(title)s</strong> from this 목록?"
+
+#: lists/lists.html
+msgid "This reader hasn't created any lists yet."
+msgstr "This reader hasn't 생성d any 목록 yet."
+
+#: lists/lists.html
+msgid "You haven't created any lists yet."
+msgstr "당신은n't 생성d any 목록 yet."
+
+#: lists/lists.html
+msgid "Learn how to create your first list."
+msgstr "Learn how to 생성 your first 목록."
+
+#: lists/preview.html
+#, python-format
+msgid "by <a href=\"%s\">You</a>"
+msgstr "<a href=\"%s\">나</a> 작성"
+
+#: lists/showcase.html
+#, python-format
+msgid "My Lists (%(count)d)"
+msgstr "내 목록 (%(count)d)"
+
+#: lists/showcase.html
+msgid "You have no lists."
+msgstr "목록이 없습니다."
+
+#: lists/widget.html my_books/dropdown_content.html type/type/view.html
+msgid "from"
+msgstr "출처"
+
+#: lists/widget.html
+msgid "Loading<span class=\"loading-ellipsis\">...</span>"
+msgstr "불러오는 중<span class=\"loading-ellipsis\">...</span>"
+
+#: merge/authors.html
+msgid "Merge Authors"
+msgstr "저자 병합"
+
+#: merge/authors.html
+msgid "No authors selected."
+msgstr "선택된 저자가 없습니다."
+
+#: merge/authors.html
+msgid "Please select a primary author record."
+msgstr "다음 select a primary 저자 레코드."
+
+#: merge/authors.html
+msgid "Please select some authors to merge."
+msgstr "다음 select some 저자 to merge."
+
+#: merge/authors.html
+msgid "Select the oldest profile as primary -"
+msgstr "가장 오래된 프로필을 기본으로 선택 -"
+
+#: merge/authors.html
+msgid "Select author records which should be merged with the primary"
+msgstr "Select 저자 레코드s which should be merged with the primary"
+
+#: merge/authors.html
+msgid "Press MERGE AUTHORS."
+msgstr "MERGE AUTHORS를 누르세요."
+
+#: merge/authors.html
+msgid "No primary record"
+msgstr "기본 레코드 없음"
+
+#: merge/authors.html
+msgid "You must select a primary record to point the duplicates toward."
+msgstr "You must select a primary 레코드 to point the duplicates toward."
+
+#: merge/authors.html
+msgid "Please Be Careful..."
+msgstr "주의해 주세요..."
+
+#: merge/authors.html
+msgid "<b>Are you sure</b> you want to merge these records?"
+msgstr "<b>Are you sure</b> you want to merge these 레코드s?"
+
+#: merge/authors.html
+msgid "Merge"
+msgstr "병합"
+
+#: merge/authors.html
+msgid "birth/death date"
+msgstr "출생/사망일"
+
+#: merge/authors.html
+msgid "Open in a new window"
+msgstr "새 창에서 열기"
+
+#: merge/authors.html search/work_search_selected_facets.html
+msgid "First published in"
+msgstr "초판 출간:"
+
+#: merge/authors.html
+msgid "Visit this author's page in a new window"
+msgstr "Visit this 저자's 페이지 in a new window"
+
+#: merge/authors.html
+msgid "Comment:"
+msgstr "댓글:"
+
+#: merge/authors.html
+msgid "Comment..."
+msgstr "댓글..."
+
+#: merge/authors.html
+msgid "Request Merge"
+msgstr "병합 요청"
+
+#: merge/authors.html
+msgid "Reject Merge"
+msgstr "병합 거부"
+
+#: merge/works.html
+msgid "Merge Works"
+msgstr "작품 병합"
+
+#: merge_request_table/merge_request_table.html
+msgid "Failed to submit comment. Please try again in a few moments."
+msgstr "실패했습니다 to 제출 comment. 다시 시도해 주세요 in a few moments."
+
+#: merge_request_table/merge_request_table.html
+msgid "(Optional) Why are you closing this request?"
+msgstr "(선택 사항) 이 요청을 닫는 이유는 무엇인가요?"
+
+#: merge_request_table/merge_request_table.html
+#, python-format
+msgid "Showing %(username)s's requests only."
+msgstr "%(username)s님의 요청만 표시 중."
+
+#: merge_request_table/merge_request_table.html
+msgid "Show all requests"
+msgstr "모든 요청 표시"
+
+#: merge_request_table/merge_request_table.html
+msgid "Showing all requests."
+msgstr "모든 요청 표시 중."
+
+#: merge_request_table/merge_request_table.html
+msgid "Show my requests"
+msgstr "내 요청 표시"
+
+#: merge_request_table/merge_request_table.html
+msgid "Community Edit Requests"
+msgstr "커뮤니티 편집 요청"
+
+#: merge_request_table/merge_request_table.html
+msgid "No entries here!"
+msgstr "여기에 항목이 없습니다!"
+
+#: merge_request_table/table_header.html
+msgid "Open"
+msgstr "열림"
+
+#: merge_request_table/table_header.html
+msgid "Closed"
+msgstr "닫힘"
+
+#: merge_request_table/table_header.html
+msgid "Status ▾"
+msgstr "상태 ▾"
+
+#: merge_request_table/table_header.html
+msgid "Request Status"
+msgstr "요청 상태"
+
+#: merge_request_table/table_header.html openlibrary/core/edits.py
+msgid "Merged"
+msgstr "병합됨"
+
+#: merge_request_table/table_header.html openlibrary/core/edits.py
+msgid "Declined"
+msgstr "거절됨"
+
+#: merge_request_table/table_header.html
+msgid "Submitter ▾"
+msgstr "제출ter ▾"
+
+#: merge_request_table/table_header.html
+msgid "Filter submitters"
+msgstr "제출자 필터"
+
+#: merge_request_table/table_header.html
+msgid "Submitted by me"
+msgstr "내가 제출함"
+
+#: merge_request_table/table_header.html
+msgid "Reviewer ▾"
+msgstr "검토자 ▾"
+
+#: merge_request_table/table_header.html
+msgid "Reviewer"
+msgstr "검토자"
+
+#: merge_request_table/table_header.html
+msgid "Filter reviewers"
+msgstr "검토자 필터"
+
+#: merge_request_table/table_header.html
+msgid "Assigned to nobody"
+msgstr "아무에게도 배정되지 않음"
+
+#: merge_request_table/table_header.html
+msgid "Sort ▾"
+msgstr "정렬 ▾"
+
+#: merge_request_table/table_header.html
+msgid "Sort"
+msgstr "정렬"
+
+#: merge_request_table/table_header.html
+msgid "Newest"
+msgstr "최신순"
+
+#: merge_request_table/table_header.html
+msgid "Oldest"
+msgstr "오래된순"
+
+#: merge_request_table/table_row.html
+msgid "An untitled work"
+msgstr "제목 없는 작품"
+
+#: merge_request_table/table_row.html
+msgid "An unnamed author"
+msgstr "이름 없는 저자"
+
+#: merge_request_table/table_row.html
+msgid "Open request"
+msgstr "열린 요청"
+
+#: merge_request_table/table_row.html
+msgid "Closed request"
+msgstr "닫힌 요청"
+
+#: merge_request_table/table_row.html
+msgid "No comments yet."
+msgstr "아직 댓글이 없습니다."
+
+#: merge_request_table/table_row.html
+msgid "Add a comment..."
+msgstr "a comment... 추가"
+
+#: merge_request_table/table_row.html
+msgid "Reply"
+msgstr "답글"
+
+#: merge_request_table/table_row.html
+#, python-format
+msgid ""
+"MR #%(id)s opened %(date)s by <a href=\"/people/%(submitter)s\" "
+"class=\"commenter\">@%(submitter)s</a>"
+msgstr ""
+"MR #%(id)s: <a href=\"/people/%(submitter)s\" class=\"commenter\">@%(submitter)s</a>님이 "
+"%(date)s에 열었습니다"
+
+#: merge_request_table/table_row.html
+msgid "Click to close this Merge Request"
+msgstr "이 병합 요청을 닫으려면 클릭하세요"
+
+#: merge_request_table/table_row.html
+msgid "Review <!-- (merge request) -->"
+msgstr "검토 <!-- (merge request) -->"
+
+#: merge_request_table/table_row.html
+msgid "comments"
+msgstr "댓글"
+
+#: my_books/dropdown_content.html
+msgid "Remove From Shelf"
+msgstr "From Shelf 제거"
+
+#: my_books/dropdown_content.html
+msgid "My Reading Lists:"
+msgstr "내 독서 목록:"
+
+#: my_books/dropdown_content.html
+msgid "Loading"
+msgstr "불러오는 중"
+
+#: my_books/dropdown_content.html
+msgid "Use this Work"
+msgstr "이 작품 사용"
+
+#: CreateListModal.html my_books/dropdown_content.html
+msgid "Create a new list"
+msgstr "새 목록 만들기"
+
+#: CreateListModal.html my_books/dropdown_content.html type/permission/edit.html
+#: type/usergroup/edit.html
+msgid "Description:"
+msgstr "설명:"
+
+#: CreateListModal.html my_books/dropdown_content.html type/list/edit.html
+#: type/series/edit.html
+msgid "Create new list"
+msgstr "새 목록 만들기"
+
+#: my_books/dropdown_content.html
+msgid "saving..."
+msgstr "저장 중..."
+
+#: my_books/dropdown_content.html
+msgid ""
+"Removing this book from your shelves will delete your check-ins for this work.  "
+"Continue?"
+msgstr "Removing 이 책 from your shelves will 삭제 your check-ins 이 작품에 대해.  Continue?"
+
+#: my_books/primary_action.html
+msgid "Add to List"
+msgstr "목록에 추가"
+
+#: my_books/check_ins/check_in_form.html
+msgid "January"
+msgstr "1월"
+
+#: my_books/check_ins/check_in_form.html
+msgid "February"
+msgstr "2월"
+
+#: my_books/check_ins/check_in_form.html
+msgid "March"
+msgstr "3월"
+
+#: my_books/check_ins/check_in_form.html
+msgid "April"
+msgstr "4월"
+
+#: my_books/check_ins/check_in_form.html
+msgid "May"
+msgstr "5월"
+
+#: my_books/check_ins/check_in_form.html
+msgid "June"
+msgstr "6월"
+
+#: my_books/check_ins/check_in_form.html
+msgid "July"
+msgstr "7월"
+
+#: my_books/check_ins/check_in_form.html
+msgid "August"
+msgstr "8월"
+
+#: my_books/check_ins/check_in_form.html
+msgid "September"
+msgstr "9월"
+
+#: my_books/check_ins/check_in_form.html
+msgid "October"
+msgstr "10월"
+
+#: my_books/check_ins/check_in_form.html
+msgid "November"
+msgstr "11월"
+
+#: my_books/check_ins/check_in_form.html
+msgid "December"
+msgstr "12월"
+
+#: my_books/check_ins/check_in_form.html
+msgid "Add an optional check-in date. Check-in dates are used to track yearly reading goals."
+msgstr "an optional check-in date. Check-in dates are used to track yearly reading goals. 추가"
+
+#: my_books/check_ins/check_in_form.html
+msgid "End Date:"
+msgstr "종료일:"
+
+#: my_books/check_ins/check_in_form.html
+msgid "Year:"
+msgstr "연도:"
+
+#: my_books/check_ins/check_in_form.html
+msgid "Year"
+msgstr "연도"
+
+#: my_books/check_ins/check_in_form.html
+msgid "Month:"
+msgstr "월:"
+
+#: my_books/check_ins/check_in_form.html
+msgid "Month"
+msgstr "월"
+
+#: my_books/check_ins/check_in_form.html
+msgid "Day:"
+msgstr "일:"
+
+#: my_books/check_ins/check_in_form.html
+msgid "Day"
+msgstr "일"
+
+#: my_books/check_ins/check_in_form.html
+msgid "Delete Event"
+msgstr "Event 삭제"
+
+#: my_books/check_ins/check_in_prompt.html
+msgid "Failed to delete check-in. Please try again in a few moments."
+msgstr "실패했습니다 to 삭제 check-in. 다시 시도해 주세요 in a few moments."
+
+#: my_books/check_ins/check_in_prompt.html
+msgid "Failed to submit check-in. Please try again in a few moments."
+msgstr "실패했습니다 to 제출 check-in. 다시 시도해 주세요 in a few moments."
+
+#: my_books/check_ins/check_in_prompt.html
+#, python-format
+msgid "Read <time class=\"check-in-date\">%(date)s</time>"
+msgstr "<time class=\"check-in-date\">%(date)s</time>에 읽음"
+
+#: my_books/check_ins/check_in_prompt.html
+msgid "When did you finish this book?"
+msgstr "When did you finish 이 책?"
+
+#: my_books/check_ins/check_in_prompt.html
+msgid "Other"
+msgstr "기타"
+
+#: my_books/check_ins/check_in_prompt.html
+msgid "Check-In"
+msgstr "체크인"
+
+#: observations/review_component.html
+msgid "Community Reviews"
+msgstr "커뮤니티 리뷰"
+
+#: observations/review_component.html
+msgid "No community reviews have been submitted for this work."
+msgstr "No community 리뷰 되었습니다 제출ted 이 작품에 대해."
+
+#: observations/review_component.html
+msgid "+ Add your community review"
+msgstr "+ 커뮤니티 리뷰 추가"
+
+#: observations/review_component.html
+msgid "+ Log in to add your community review"
+msgstr "+ Log in 추가하려면 your community 리뷰"
+
+#: publishers/index.html publishers/notfound.html
+msgid "Publishers"
+msgstr "출판사"
+
+#: publishers/index.html publishers/view.html
+msgid "Publisher Search"
+msgstr "출판사 검색"
+
+#: publishers/index.html publishers/view.html
+msgid "Try a keyword."
+msgstr "키워드를 입력해 보세요."
+
+#: publishers/notfound.html
+#, python-format
+msgid "We couldn't find any books published by %(publisher)s."
+msgstr "찾을 수 없습니다 any 책 published by %(publisher)s."
+
+#: publishers/notfound.html subjects/notfound.html
+msgid "Try something else?"
+msgstr "다른 것을 시도해 볼까요?"
+
+#: publishers/view.html
+#, python-format
+msgid "Publisher: %(name)s"
+msgstr "출판사: %(name)s"
+
+#: openlibrary/plugins/worksearch/code.py publishers/view.html search/advancedsearch.html
+#: type/edition/view.html type/work/view.html
+msgid "Publisher"
+msgstr "출판사"
+
+#: SearchResultsWork.html publishers/view.html
+#, python-format
+msgid "%(count)s ebook"
+msgid_plural "%(count)s ebooks"
+msgstr[0] "전자책 %(count)s권"
+
+#: publishers/view.html
+msgid "0 ebooks"
+msgstr "전자책 0권"
+
+#: PublishingHistory.html publishers/view.html
+msgid "Publishing History"
+msgstr "출판 이력"
+
+#: publishers/view.html
+msgid ""
+"This is a chart to show the when this publisher published books. Along the X axis is "
+"time, and on the y axis is the count of editions published. <a "
+"href=\"#subjectRelated\">Click here to skip the chart</a>."
+msgstr ""
+"이것은 a chart to show the when this 출판사 published 책. Along the X axis is time, and on the"
+" y axis is the count of 판본 published. <a href=\"#주제Related\">Click here to skip the "
+"chart</a>."
+
+#: PublishingHistory.html publishers/view.html
+msgid "Reset chart"
+msgstr "차트 초기화"
+
+#: PublishingHistory.html publishers/view.html
+msgid "or continue zooming in."
+msgstr "또는 계속 확대하세요."
+
+#: publishers/view.html
+msgid ""
+"This graph charts editions from this publisher over time. Click to view a single year, "
+"or drag across a range."
+msgstr ""
+"This graph charts 판본 from this 출판사 over time. Click to view a single year, or drag "
+"across a range."
+
+#: PublishingHistory.html publishers/view.html
+msgid "Editions Published"
+msgstr "출판된 판본"
+
+#: PublishingHistory.html publishers/view.html
+msgid "Year of Publication"
+msgstr "출판 연도"
+
+#: publishers/view.html
+msgid "Common Subjects"
+msgstr "공통 주제"
+
+#: publishers/view.html
+#, python-format
+msgid "Search for books published by %(publisher)s"
+msgstr "for books published by %(publisher)s 검색"
+
+#: RelatedSubjects.html publishers/view.html
+msgid "None found."
+msgstr "찾을 수 없습니다."
+
+#: ProlificAuthors.html publishers/view.html
+msgid "See more books by, and learn about, this author"
+msgstr "See more 책 by, and learn about, this 저자"
+
+#: publishers/view.html
+msgid "published most by this publisher"
+msgstr "이 출판사가 가장 많이 출판함"
+
+#: publishers/view.html
+msgid "Get more information about this publisher"
+msgstr "Get more information about this 출판사"
+
+#: reading_goals/reading_goal_form.html
+msgid "How many books would you like to read this year?"
+msgstr "How many 책 would you like to read this year?"
+
+#: reading_goals/reading_goal_form.html
+msgid "Enter \"0\" to unset your reading goal. Your check-ins will be preserved."
+msgstr "Enter \"0\" to unset your 독서 목표. Your check-ins 됩니다 preserved."
+
+#: reading_goals/reading_goal_progress.html
+#, python-format
+msgid ""
+"<span class=\"reading-goal-progress__books-read\">%(books_read)d</span>/<span class"
+"=\"reading-goal-progress__goal\">%(goal)d</span> Books"
+msgstr ""
+"<span class=\"reading-goal-progress__책-read\">%(books_read)d</span>/<span class"
+"=\"reading-goal-progress__goal\">%(goal)d</span> Books"
+
+#: reading_goals/reading_goal_progress.html
+#, python-format
+msgid "Edit %(year)d Reading Goal"
+msgstr "%(year)d Reading Goal 편집"
+
+#: recentchanges/header.html
+msgid "By"
+msgstr "작성자"
+
+#: recentchanges/header.html
+msgid "Undo All"
+msgstr "모두 실행 취소"
+
+#: recentchanges/header.html recentchanges/index.html
+msgid "Recent Changes"
+msgstr "최근 변경"
+
+#: recentchanges/index.html
+msgid "Books Edited"
+msgstr "편집된 책"
+
+#: recentchanges/index.html
+msgid "Author Merges"
+msgstr "저자 병합"
+
+#: recentchanges/index.html
+msgid "Work Merges"
+msgstr "작품 병합"
+
+#: recentchanges/index.html
+msgid "Books Added"
+msgstr "추가된 책"
+
+#: RecentChanges.html recentchanges/index.html
+msgid "By Humans"
+msgstr "사람별"
+
+#: RecentChanges.html recentchanges/index.html
+msgid "By Bots"
+msgstr "봇별"
+
+#: recentchanges/render.html
+msgid "Admin view"
+msgstr "관리자 보기"
+
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
+#: recentchanges/render.html
+msgid "Older"
+msgstr "이전"
+
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
+#: recentchanges/render.html
+msgid "Newer"
+msgstr "다음"
+
+#: recentchanges/updated_records.html
+msgid "Review what's changed in from the previous revision"
+msgstr "이전 개정판에서 변경된 사항 검토"
+
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
+#: recentchanges/default/path.html recentchanges/updated_records.html
+msgid "diff"
+msgstr "차이"
+
+#: recentchanges/add-book/path.html recentchanges/default/path.html
+#: recentchanges/edit-book/path.html recentchanges/merge/path.html
+msgid "expand"
+msgstr "펼치기"
+
+#: recentchanges/default/message.html recentchanges/edit-book/message.html
+msgid "opened a new Open Library account!"
+msgstr "opened a new Open Library 계정!"
+
+#: RecentChanges.html RecentChangesUsers.html recentchanges/default/path.html
+msgid "Review what's changed from the previous revision"
+msgstr "이전 개정판에서 변경된 사항 검토"
+
+#: recentchanges/default/view.html recentchanges/merge/view.html recentchanges/undo/view.html
+msgid "Updated Records"
+msgstr "업데이트된 레코드"
+
+#: recentchanges/merge/comment.html
+#, python-format
+msgid "Merged duplicate %(record_type)s records."
+msgstr "중복된 %(record_type)s 레코드를 병합했습니다."
+
+#: recentchanges/merge/comment.html
+#, python-format
+msgid "See <a href=\"%s\">details</a>."
+msgstr "<a href=\"%s\">세부 정보</a> 보기."
+
+#: recentchanges/merge/comment.html
+#, python-format
+msgid "Merged %(count)d duplicate %(type)s record into this primary."
+msgid_plural "Merged %(count)d duplicate %(type)s records into this primary."
+msgstr[0] "중복된 %(type)s 레코드 %(count)d개를 이 기본 레코드로 병합했습니다."
+
+#: recentchanges/merge/comment.html
+msgid "Marked as duplicate."
+msgstr "중복으로 표시됨."
+
+#: recentchanges/merge/comment.html
+#, python-format
+msgid "Merged %(page_type)s into primary %(record_type)s record."
+msgstr "Merged %(page_type)s into primary %(record_type)s 레코드."
+
+#: recentchanges/merge/message.html
+#, python-format
+msgid "%(who)s merged one duplicate of %(master)s"
+msgid_plural "%(who)s merged %(count)d duplicates of %(master)s"
+msgstr[0] "%(who)s님이 %(master)s의 중복 항목 %(count)d개를 병합했습니다"
+
+#: recentchanges/merge/message.html
+#, python-format
+msgid "one duplicate of %(master)s was merged anonymously"
+msgid_plural "%(count)d duplicates of %(master)s were merged anonymously"
+msgstr[0] "%(master)s의 중복 항목 %(count)d개가 익명으로 병합되었습니다"
+
+#: recentchanges/merge/view.html
+msgid "This merge has been undone."
+msgstr "이 병합은 취소되었습니다."
+
+#: recentchanges/merge/view.html
+msgid "Details here"
+msgstr "세부 정보는 여기"
+
+#: recentchanges/merge/view.html type/author/view.html
+msgid "Duplicates"
+msgstr "중복"
+
+#: recentchanges/merge/view.html
+#, python-format
+msgid "%(count)d record modified."
+msgid_plural "%(count)d records modified."
+msgstr[0] "%(count)d개 레코드가 수정되었습니다."
+
+#: recentchanges/undo/view.html
+#, python-format
+msgid "Undo of <a href=\"$parent.url()\">%(kind)s</a>."
+msgstr "<a href=\"$parent.url()\">%(kind)s</a> 실행 취소."
+
+#: recentchanges/undo/view.html
+#, python-format
+msgid "%(count)d records modified."
+msgstr "%(count)d개 레코드가 수정되었습니다."
+
+#: search/advancedsearch.html
+msgid "ISBN"
+msgstr "ISBN"
+
+#: search/advancedsearch.html
+msgid "Place"
+msgstr "장소"
+
+#: search/advancedsearch.html
+msgid "Person"
+msgstr "사람"
+
+#: search/advancedsearch.html
+msgid "How to search?"
+msgstr "How to 검색?"
+
+#: search/advancedsearch.html
+msgid "Full Text Search?"
+msgstr "Full Text 검색?"
+
+#: search/authors.html
+#, python-format
+msgid "Search Open Library for \"%(query)s\""
+msgstr "Open Library for \"%(query)s\" 검색"
+
+#: search/authors.html
+msgid "Search Authors"
+msgstr "저자 검색"
+
+#: search/authors.html
+msgid "Is the same author listed twice?"
+msgstr "Is the same 저자 목록ed twice?"
+
+#: search/authors.html
+msgid "Merge authors"
+msgstr "저자 병합"
+
+#: search/authors.html
+msgid "No <strong>authors</strong> directly matched your search"
+msgstr "검색어와 직접 일치하는 <strong>저자</strong>이(가) 없습니다."
+
+#: search/inside.html
+#, python-format
+msgid "Search Open Library for %s"
+msgstr "Open Library for %s 검색"
+
+#: BookSearchInside.html FulltextSearchSuggestion.html SearchNavigation.html
+#: search/inside.html search/snippets.html
+msgid "Search Inside"
+msgstr "Inside 검색"
+
+#: search/inside.html
+msgid "No <strong>Search Inside</strong> text matched your search"
+msgstr "No <strong>검색 Inside</strong> text matched your 검색"
+
+#: search/inside.html
+#, python-format
+msgid "About %(count)s result found"
+msgid_plural "About %(count)s results found"
+msgstr[0] "약 %(count)s개의 결과를 찾았습니다"
+
+#: search/inside.html
+#, python-format
+msgid "in %(seconds)s second"
+msgid_plural "in %(seconds)s seconds"
+msgstr[0] "%(seconds)s초 만에"
+
+#: EditionNavBar.html search/layout_options.html site/stats.html
+msgid "Details"
+msgstr "세부 정보"
+
+#: search/layout_options.html
+msgid "Grid"
+msgstr "격자"
+
+#: search/layout_options.html
+msgid "View as: "
+msgstr "as: 보기"
+
+#: search/lists.html
+msgid "Search results for Lists"
+msgstr "results for Lists 검색"
+
+#: search/lists.html
+msgid "Search Lists"
+msgstr "목록 검색"
+
+#: search/lists.html
+msgid "No <strong>lists</strong> directly matched your search"
+msgstr "검색어와 직접 일치하는 <strong>목록</strong>이(가) 없습니다."
+
+#: search/publishers.html
+msgid "Publishers Search"
+msgstr "출판사 검색"
+
+#: search/snippets.html
+#, python-format
+msgid "On leaf number %(page_num)d:"
+msgstr "리프 번호 %(page_num)d에서:"
+
+#: search/sort_options.html
+msgid "Relevance"
+msgstr "관련도"
+
+#: search/sort_options.html
+msgid "Work Count"
+msgstr "작품 수"
+
+#: search/sort_options.html
+msgid "Random"
+msgstr "무작위"
+
+#: search/sort_options.html
+msgid "Name (beta: Librarian only)"
+msgstr "이름(베타: 사서 전용)"
+
+#: search/sort_options.html
+msgid "Birth Date (oldest) (beta: Librarian only)"
+msgstr "생년월일(오래된순)(베타: 사서 전용)"
+
+#: search/sort_options.html
+msgid "Birth Date (youngest) (beta: Librarian only)"
+msgstr "생년월일(최근순)(베타: 사서 전용)"
+
+#: search/sort_options.html
+msgid "List Order"
+msgstr "목록 순서"
+
+#: search/sort_options.html
+msgid "Last Modified"
+msgstr "마지막 수정"
+
+#: search/sort_options.html
+msgid "Language Name"
+msgstr "언어 이름"
+
+#: search/sort_options.html
+msgid "Ebook Edition Count"
+msgstr "전자책 판본 수"
+
+#: search/sort_options.html
+msgid "Date Added (newest)"
+msgstr "Date 추가ed (newest)"
+
+#: search/sort_options.html
+msgid "Date Added (oldest)"
+msgstr "Date 추가ed (oldest)"
+
+#: search/sort_options.html
+msgid "Most Editions"
+msgstr "판본 많은순"
+
+#: search/sort_options.html
+msgid "First Published"
+msgstr "초판 출간순"
+
+#: search/sort_options.html
+msgid "Most Recent"
+msgstr "최신순"
+
+#: search/sort_options.html
+msgid "Top Rated"
+msgstr "평점 높은순"
+
+#: search/sort_options.html
+msgid "Any"
+msgstr "전체"
+
+#: search/sort_options.html
+msgid "Work Title (beta: Librarian only)"
+msgstr "작품 제목(베타: 사서 전용)"
+
+#: search/sort_options.html
+msgid "Sorting by"
+msgstr "정렬 기준"
+
+#: search/sort_options.html
+msgid "Shuffle"
+msgstr "섞기"
+
+#: search/subjects.html
+msgid "Search Subjects"
+msgstr "주제 검색"
+
+#: search/subjects.html
+msgid "No <strong>subjects</strong> directly matched your search"
+msgstr "검색어와 직접 일치하는 <strong>주제</strong>이(가) 없습니다."
+
+#: search/subjects.html
+msgid "time"
+msgstr "시간"
+
+#: search/subjects.html
+msgid "subject"
+msgstr "주제"
+
+#: search/subjects.html
+msgid "place"
+msgstr "장소"
+
+#: search/subjects.html
+msgid "org"
+msgstr "조직"
+
+#: search/subjects.html
+msgid "event"
+msgstr "이벤트"
+
+#: search/subjects.html
+msgid "person"
+msgstr "사람"
+
+#: search/subjects.html
+msgid "work"
+msgstr "작품"
+
+#: search/work_search_facets.html
+msgid "Merge duplicate authors from this search"
+msgstr "Merge duplicate 저자 from this 검색"
+
+#: search/work_search_facets.html type/work/editions.html
+msgid "Merge duplicates"
+msgstr "중복 병합"
+
+#: search/work_search_facets.html
+msgid "Less"
+msgstr "접기"
+
+#: search/work_search_facets.html
+#, python-format
+msgid "Filter results for %(facet)s"
+msgstr "%(facet)s에 대한 결과 필터링"
+
+#: search/work_search_facets.html
+msgid "Filter results for ebook availability"
+msgstr "Filter results for e책 availability"
+
+#: search/work_search_facets.html
+msgid "yes"
+msgstr "예"
+
+#: search/work_search_facets.html
+msgid "no"
+msgstr "아니요"
+
+#: search/work_search_facets.html
+msgid "Zoom In"
+msgstr "확대"
+
+#: search/work_search_facets.html
+msgid "Focus your results using these <a href=\"/search/howto\">filters</a>"
+msgstr "Focus your results using these <a href=\"/검색/howto\">filters</a>"
+
+#: search/work_search_selected_facets.html
+msgid "Written in"
+msgstr "작성 언어"
+
+#: search/work_search_selected_facets.html
+msgid "Published by"
+msgstr "출판사"
+
+#: search/work_search_selected_facets.html
+msgid "eBook"
+msgstr "전자책"
+
+#: search/work_search_selected_facets.html
+msgid "Classic eBook"
+msgstr "클래식 전자책"
+
+#: search/work_search_selected_facets.html
+msgid "Only Classic eBooks"
+msgstr "클래식 전자책만"
+
+#: search/work_search_selected_facets.html
+msgid "Classic eBooks hidden"
+msgstr "클래식 전자책 숨김"
+
+#: search/work_search_selected_facets.html
+#, python-format
+msgid "%(title)s - search"
+msgstr "%(title)s - 검색"
+
+#: site/alert.html
+msgid "Internet Archive logo"
+msgstr "Internet Archive 로고"
+
+#: site/body.html
+msgid "It looks like you're offline."
+msgstr "오프라인 상태인 것 같습니다."
+
+#: site/head.html
+msgid ""
+"Open Library is an open, editable library catalog, building towards a web page for "
+"every book ever published. Read, borrow, and discover more than 3M books for free."
+msgstr ""
+"Open Library is an open, 편집able library catalog, building towards a web 페이지 for every 책"
+" ever published. Read, 대출, and discover more than 3M 책 for free."
+
+#: site/stats.html
+msgid "Debug Stats"
+msgstr "디버그 통계"
+
+#: stats/readinglog.html
+msgid "Reading Log Stats"
+msgstr "독서 기록 통계"
+
+#: stats/readinglog.html
+msgid "# Books Logged"
+msgstr "기록된 책 수"
+
+#: stats/readinglog.html
+msgid "The total number of books logged using the Reading Log feature"
+msgstr "The total number of 책 logged using the 독서 기록 feature"
+
+#: stats/readinglog.html
+msgid "All time"
+msgstr "전체 기간"
+
+#: stats/readinglog.html
+msgid "# Unique Users Logging Books"
+msgstr "책을 기록한 고유 사용자 수"
+
+#: stats/readinglog.html
+msgid ""
+"The total number of unique users who have logged at least one book using the Reading "
+"Log feature"
+msgstr "The total number of unique users who have logged at least one 책 using the 독서 기록 feature"
+
+#: stats/readinglog.html
+msgid "# Books Starred"
+msgstr "별점이 매겨진 책 수"
+
+#: stats/readinglog.html
+msgid "The total number of books which have been starred"
+msgstr "The total number of 책 which 되었습니다 starred"
+
+#: stats/readinglog.html
+msgid "Total # Unique Raters (all time)"
+msgstr "총 고유 평점 사용자 수(전체 기간)"
+
+#: stats/readinglog.html
+msgid "Most Wanted Books (This Month)"
+msgstr "가장 많이 원하는 책(이번 달)"
+
+#: stats/readinglog.html
+#, python-format
+msgid "Added %(count)d time"
+msgid_plural "Added %(count)d times"
+msgstr[0] "%(count)d회 추가됨"
+
+#: stats/readinglog.html
+msgid "Most Wanted Books (All Time)"
+msgstr "가장 많이 원하는 책(전체 기간)"
+
+#: stats/readinglog.html
+msgid "Most Logged Books"
+msgstr "가장 많이 기록된 책"
+
+#: stats/readinglog.html
+msgid "Most Read Books (All Time)"
+msgstr "가장 많이 읽은 책(전체 기간)"
+
+#: stats/readinglog.html
+msgid "Most Rated Books"
+msgstr "가장 많이 평가된 책"
+
+#: stats/readinglog.html
+msgid "Most Rated Books (All Time)"
+msgstr "가장 많이 평가된 책(전체 기간)"
+
+#: subjects/notfound.html
+msgid "We couldn't find any books about"
+msgstr "찾을 수 없습니다 any 책 about"
+
+#: swagger/swaggerui.html
+msgid "OpenAPI"
+msgstr "OpenAPI"
+
+#: type/about/edit.html type/page/edit.html type/permission/edit.html type/template/edit.html
+#: type/usergroup/edit.html
+#, python-format
+msgid "Edit %(title)s"
+msgstr "%(title)s 편집"
+
+#: type/about/edit.html
+msgid "This only appears in the document head, and gets attached to bookmark labels"
+msgstr "This only appears in the document head, and gets attached to 책mark labels"
+
+#: type/about/edit.html
+msgid "Intro"
+msgstr "소개"
+
+#: type/about/edit.html
+msgid "This appears in first column."
+msgstr "첫 번째 열에 표시됩니다."
+
+#: type/about/edit.html
+msgid "This appears in the second column, at top."
+msgstr "두 번째 열 상단에 표시됩니다."
+
+#: type/about/edit.html
+msgid "Mailing List"
+msgstr "메일링 리스트"
+
+#: type/about/edit.html
+msgid "This appears below the links list."
+msgstr "링크 목록 아래에 표시됩니다."
+
+#: type/about/view.html
+msgid "For more information"
+msgstr "자세한 정보"
+
+#: type/author/edit.html
+msgid "Edit Author"
+msgstr "저자 편집"
+
+#: type/author/edit.html
+msgid ""
+"Please use natural order. For example: <strong>Leo Tolstoy</strong> not "
+"<strong>Tolstoy, Leo</strong>."
+msgstr ""
+"다음 use natural order. For example: <strong>Leo Tolstoy</strong> not <strong>Tolstoy, "
+"Leo</strong>."
+
+#: type/author/edit.html
+msgid "A short bio?"
+msgstr "짧은 소개?"
+
+#: type/author/edit.html
+msgid "If you \"borrow\" information from somewhere, please make sure to cite the source."
+msgstr "If you \"대출\" information from somewhere, please make sure to cite the source."
+
+#: type/author/edit.html
+msgid "Date of birth"
+msgstr "생년월일"
+
+#: type/author/edit.html
+msgid "Date of death"
+msgstr "사망일"
+
+#: type/author/edit.html
+msgid "We're not storing structured dates (yet) so a date like \"21 May 2000\" is recommended."
+msgstr "아직 구조화된 날짜를 저장하지 않으므로 \"21 May 2000\" 같은 형식을 권장합니다."
+
+#: type/author/edit.html
+msgid ""
+"This is a deprecated field. You can help improve this record by removing this date and "
+"populating the \"Date of birth\" and \"Date of death\" fields. Thanks!"
+msgstr ""
+"이것은 a deprecated field. You can help improve this 레코드 by removing this date and "
+"populating the \"Date of birth\" and \"Date of death\" fields. Thanks!"
+
+#: type/author/edit.html
+msgid "Does this author go by any other names?"
+msgstr "Does this 저자 go by any other names?"
+
+#: type/author/edit.html
+msgid ""
+"For example: Lev Nikolayevich Tolstoy was also known as Leo Tolstoy. Please list one "
+"name per line."
+msgstr ""
+"For example: Lev Nikolayevich Tolstoy was also known as Leo Tolstoy. 다음 목록 one name per"
+" line."
+
+#: type/author/edit.html
+msgid "Identifiers"
+msgstr "식별자"
+
+#: type/author/edit.html
+msgid "Author Identifiers Purpose"
+msgstr "저자 식별자의 목적"
+
+#: type/author/view.html type/edition/view.html type/work/view.html
+#, python-format
+msgid "%(page_title)s | Open Library"
+msgstr "%(page_title)s | Open Library"
+
+#: type/author/view.html
+#, python-format
+msgid "Author of %(book_titles)s"
+msgstr "%(book_titles)s의 저자"
+
+#: type/author/view.html
+msgid "Merging Authors..."
+msgstr "저자 병합 중..."
+
+#: type/author/view.html
+msgid "In progress..."
+msgstr "진행 중..."
+
+#: type/author/view.html
+msgid "Refresh the page?"
+msgstr "Refresh the 페이지?"
+
+#: type/author/view.html
+msgid ""
+"OK. The merge is in motion. <i>It will take <u>a few minutes to finish</u> the "
+"update.</i>"
+msgstr "좋습니다. 병합이 진행 중입니다. <i>업데이트를 완료하는 데 <u>몇 분 정도</u> 걸립니다.</i>"
+
+#: type/author/view.html
+msgid "Argh!"
+msgstr "아이고!"
+
+#: type/author/view.html
+msgid "That merge didn't work. It's our fault, and we've made a note of it."
+msgstr "That merge didn't 작품. It's our fault, and we've made a note of it."
+
+#: type/author/view.html
+msgid "Add another?"
+msgstr "another? 추가"
+
+#: type/author/view.html
+#, python-format
+msgid "Search %(author)s books"
+msgstr "%(author)s books 검색"
+
+#: type/author/view.html
+#, python-format
+msgid "— Show <a href=\"%(url)s\">everything</a> by this author?"
+msgstr "— Show <a href=\"%(url)s\">everything</a> by this 저자?"
+
+#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py
+#: type/author/view.html type/list/view_body.html
+msgid "Places"
+msgstr "장소"
+
+#: Profile.html type/author/view.html
+msgid "Time"
+msgstr "시간"
+
+#: type/author/view.html
+msgid "OLID"
+msgstr "OLID"
+
+#: type/author/view.html
+msgid "Inventaire.io:"
+msgstr "Inventaire.io:"
+
+#: type/author/view.html type/edition/view.html type/work/view.html
+msgid "Links <span class=\"gray small sansserif\">outside Open Library</span>"
+msgstr "<span class=\"gray small sansserif\">Open Library 외부</span> 링크"
+
+#: type/author/view.html
+msgid "No links yet."
+msgstr "아직 링크가 없습니다."
+
+#: type/author/view.html
+msgid "Add one"
+msgstr "one 추가"
+
+#: type/author/view.html
+msgid "Alternative names"
+msgstr "다른 이름"
+
+#: type/delete/view.html
+msgid "This page has been deleted"
+msgstr "이 페이지는 삭제되었습니다"
+
+#: type/delete/view.html
+msgid "What would you like to do?"
+msgstr "무엇을 하시겠습니까?"
+
+#: type/delete/view.html
+msgid "Go back where I came from"
+msgstr "이전 위치로 돌아가기"
+
+#: type/delete/view.html
+msgid "View the previous version"
+msgstr "the previous version 보기"
+
+#: type/delete/view.html
+msgid "See the page's history"
+msgstr "See the 페이지's history"
+
+#: type/delete/view.html
+msgid "Recreate it"
+msgstr "다시 만들기"
+
+#: type/edition/admin_bar.html
+msgid "Add IA Book to Staff Picks"
+msgstr "IA Book to Staff Picks 추가"
+
+#: type/edition/admin_bar.html
+msgid "Sync Archive.org ID"
+msgstr "Archive.org ID 동기화"
+
+#: type/edition/admin_bar.html
+msgid "View Book on Archive.org"
+msgstr "Book on Archive.org 보기"
+
+#: SearchResultsWork.html type/edition/admin_bar.html
+msgid "Orphaned Edition"
+msgstr "고아 판본"
+
+#: databarHistory.html databarView.html type/edition/compact_title.html
+msgid "Edit this page"
+msgstr "this page 편집"
+
+#: type/edition/modal_links.html
+msgid "Review"
+msgstr "리뷰"
+
+#: type/edition/title_and_author.html
+msgid "An edition of"
+msgstr "다음의 판본:"
+
+#: type/edition/title_and_author.html
+#, python-format
+msgid "First published in %s"
+msgstr "%s에 초판 출간"
+
+#: type/edition/title_and_author.html
+#, python-format
+msgid "Book %s"
+msgstr "책 %s"
+
+#: type/edition/view.html type/work/view.html
+msgid "Read Less"
+msgstr "접기"
+
+#: type/edition/view.html type/work/view.html
+#, python-format
+msgid "This work doesn't have a description yet. Can you <b><a href='%(url)s'>add one</a></b>?"
+msgstr "이 작품 doesn't have a description yet. Can you <b><a href='%(url)s'>추가 one</a></b>?"
+
+#: type/edition/view.html type/work/view.html
+#, python-format
+msgid ""
+"This edition doesn't have a description yet. Can you <b><a href='%(url)s'>add "
+"one</a></b>?"
+msgstr "이 판본 doesn't have a description yet. Can you <b><a href='%(url)s'>추가 one</a></b>?"
+
+#: type/edition/view.html type/work/view.html
+msgid "Publish Date"
+msgstr "출판일"
+
+#: type/edition/view.html type/work/view.html
+#, python-format
+msgid "Show other books from %(publisher)s"
+msgstr "%(publisher)s의 다른 책 보기"
+
+#: type/edition/view.html type/work/view.html
+#, python-format
+msgid "Search for other books from %(publisher)s"
+msgstr "for other books from %(publisher)s 검색"
+
+#: openlibrary/plugins/worksearch/code.py type/edition/view.html type/work/view.html
+msgid "Language"
+msgstr "언어"
+
+#: type/edition/view.html type/work/view.html
+msgid "Pages"
+msgstr "페이지"
+
+#: type/edition/view.html type/work/view.html
+msgid "ISBNs"
+msgstr "ISBN"
+
+#: databarWork.html type/edition/view.html type/work/view.html
+msgid "Buy this book"
+msgstr "이 책 구매"
+
+#: type/edition/view.html type/work/view.html
+msgid "Book Details"
+msgstr "책 세부 정보"
+
+#: type/edition/view.html type/work/view.html
+msgid "First Sentence"
+msgstr "첫 문장"
+
+#: type/edition/view.html type/work/view.html
+msgid "Edition Notes"
+msgstr "판본 노트"
+
+#: type/edition/view.html type/work/view.html
+msgid "Published in"
+msgstr "출판 장소"
+
+#: type/edition/view.html type/work/view.html
+msgid "Series"
+msgstr "시리즈"
+
+#: type/edition/view.html type/work/view.html
+msgid "Volume"
+msgstr "권"
+
+#: type/edition/view.html type/work/view.html
+msgid "Genre"
+msgstr "장르"
+
+#: type/edition/view.html type/work/view.html
+msgid "Other Titles"
+msgstr "다른 제목"
+
+#: type/edition/view.html type/work/view.html
+msgid "Copyright Date"
+msgstr "저작권 날짜"
+
+#: type/edition/view.html type/work/view.html
+msgid "Translation Of"
+msgstr "번역 원서"
+
+#: type/edition/view.html type/work/view.html
+msgid "Translated From"
+msgstr "원어"
+
+#: type/edition/view.html type/work/view.html
+msgid "External Links"
+msgstr "외부 링크"
+
+#: type/edition/view.html type/work/view.html
+msgid "Format"
+msgstr "형식"
+
+#: type/edition/view.html type/work/view.html
+msgid "Number of pages"
+msgstr "페이지 수"
+
+#: type/edition/view.html type/work/view.html
+msgid "Weight"
+msgstr "무게"
+
+#: type/edition/view.html type/work/view.html
+msgid "Edition Identifiers"
+msgstr "판본 식별자"
+
+#: type/edition/view.html type/work/view.html
+msgid "Source records"
+msgstr "출처 레코드"
+
+#: type/edition/view.html type/work/view.html
+msgid "Work Description"
+msgstr "작품 설명"
+
+#: type/edition/view.html type/work/view.html
+msgid "Original languages"
+msgstr "원어"
+
+#: type/edition/view.html type/work/view.html
+msgid "Excerpts"
+msgstr "발췌"
+
+#: type/edition/view.html type/work/view.html
+#, python-format
+msgid "Page %(page)s"
+msgstr "%(page)s페이지"
+
+#: type/edition/view.html type/work/view.html
+#, python-format
+msgid "added by %(authorlink)s."
+msgstr "%(authorlink)s님이 추가했습니다."
+
+#: type/edition/view.html type/work/view.html
+msgid "added anonymously."
+msgstr "익명으로 추가되었습니다."
+
+#: type/edition/view.html type/work/view.html
+msgid "Wikipedia"
+msgstr "위키백과"
+
+#: type/edition/view.html type/work/view.html
+msgid "Loading Lists"
+msgstr "목록 불러오는 중"
+
+#: type/language/view.html
+#, python-format
+msgid "%(language)s [deprecated]"
+msgstr "%(language)s [지원 중단]"
+
+#: type/language/view.html
+msgid "languages"
+msgstr "언어"
+
+#: type/language/view.html
+msgid "Code"
+msgstr "코드"
+
+#: type/language/view.html
+msgid "Current"
+msgstr "현재"
+
+#: type/language/view.html
+#, python-format
+msgid "Try a <a href=\"%(href)s\">search for readable books in %(language)s</a>?"
+msgstr "Try a <a href=\"%(href)s\">검색 for readable 책 in %(language)s</a>?"
+
+#: type/list/edit.html type/series/edit.html
+msgid "Create a series"
+msgstr "시리즈 만들기"
+
+#: type/list/edit.html type/series/edit.html
+#, python-format
+msgid "Editing series: %(list_name)s"
+msgstr "시리즈 편집 중: %(list_name)s"
+
+#: type/list/edit.html type/series/edit.html
+#, python-format
+msgid "Editing list: %(list_name)s"
+msgstr "목록 편집 중: %(list_name)s"
+
+#: type/list/edit.html type/series/edit.html
+msgid "Edit Series"
+msgstr "시리즈 편집"
+
+#: type/list/edit.html type/series/edit.html
+msgid "Edit List"
+msgstr "목록 편집"
+
+#: type/list/edit.html type/series/edit.html
+msgid "Move..."
+msgstr "이동..."
+
+#: type/list/edit.html type/series/edit.html
+msgid "Search for a book"
+msgstr "책 검색"
+
+#: type/list/edit.html type/series/edit.html
+msgid "Position (optional), e.g. 1, 2, 1-7"
+msgstr "위치(선택 사항), 예: 1, 2, 1-7"
+
+#: type/list/edit.html type/series/edit.html
+msgid "Notes (optional)"
+msgstr "노트(선택 사항)"
+
+#: type/list/edit.html type/series/edit.html
+msgid "List Name"
+msgstr "목록 이름"
+
+#: type/list/edit.html type/series/edit.html
+msgid "Series Name"
+msgstr "시리즈 이름"
+
+#: type/list/edit.html type/series/edit.html
+msgid "Description (optional)"
+msgstr "설명(선택 사항)"
+
+#: type/list/edit.html type/series/edit.html
+msgid "Add another book"
+msgstr "다른 책 추가"
+
+#: type/list/edit.html type/series/edit.html
+msgid "Create new series"
+msgstr "새 시리즈 만들기"
+
+#: type/list/embed.html
+msgid "Visit Open Library"
+msgstr "Open Library 방문"
+
+#: type/list/embed.html
+msgid ""
+"Open in online Book Reader. Downloads available in ePub, DAISY, PDF, TXT formats from "
+"main book page"
+msgstr "Open in online Book Reader. 다운로드s 사용 가능 in ePub, DAISY, PDF, TXT formats from main 책 페이지"
+
+#: type/list/embed.html
+msgid "This book is checked out"
+msgstr "이 책은 대출 중입니다"
+
+#: type/list/embed.html
+msgid "Checked out"
+msgstr "대출 중"
+
+#: type/list/embed.html
+msgid "Borrow book"
+msgstr "책 대출"
+
+#: type/list/embed.html
+msgid "Protected DAISY"
+msgstr "보호된 DAISY"
+
+#: BookByline.html type/list/embed.html
+#, python-format
+msgid "by %(name)s"
+msgstr "%(name)s 지음"
+
+#: type/list/exports.html
+msgid "BibTex"
+msgstr "BibTeX"
+
+#: type/list/exports.html
+msgid "Export"
+msgstr "내보내기"
+
+#: type/list/exports.html
+#, python-format
+msgid "as %(json_link)s, %(html_link)s, or %(bibtex_link)s"
+msgstr "%(json_link)s, %(html_link)s 또는 %(bibtex_link)s로"
+
+#: type/list/exports.html
+msgid "Subscribe"
+msgstr "구독"
+
+#: type/list/exports.html
+#, python-format
+msgid "Watch activity via <a rel=\"nofollow\" href=\"%s\">Atom feed</a>"
+msgstr "<a rel=\"nofollow\" href=\"%s\">Atom 피드</a>로 활동 보기"
+
+#: type/list/exports.html
+msgid "Export Not Available"
+msgstr "내보낼 수 없음"
+
+#: type/list/exports.html
+#, python-format
+msgid "Only lists with up to %(max)s editions can be exported. This one has %(count)s."
+msgstr "Only 목록 with up to %(max)s 판본 할 수 있습니다 exported. This one has %(count)s."
+
+#: type/list/exports.html
+#, python-format
+msgid ""
+"Try removing some seeds for more focus, or look at <a href=\"%s\">bulk download</a> of "
+"the catalog."
+msgstr ""
+"Try removing some seeds for more focus, or look at <a href=\"%s\">bulk 다운로드</a> of the "
+"catalog."
+
+#: type/list/view_body.html
+#, python-format
+msgid "%(name)s | Lists | Open Library"
+msgstr "%(name)s | 목록 | Open Library"
+
+#: type/list/view_body.html
+#, python-format
+msgid "%(title)s: %(description)s"
+msgstr "%(title)s: %(description)s"
+
+#: type/list/view_body.html
+msgid "View the list on Open Library."
+msgstr "Open Library에서 목록 보기."
+
+#: type/list/view_body.html
+msgid "Remove this item?"
+msgstr "이 항목을 제거하시겠습니까?"
+
+#: type/list/view_body.html
+#, python-format
+msgid "Last modified <span>%(date)s</span>"
+msgstr "마지막 수정: <span>%(date)s</span>"
+
+#: type/list/view_body.html
+msgid "Remove seed"
+msgstr "시드 제거"
+
+#: type/list/view_body.html
+msgid "Are you sure you want to remove this item from the list?"
+msgstr "이 항목을 목록에서 제거하시겠습니까?"
+
+#: type/list/view_body.html
+msgid "Remove Seed"
+msgstr "시드 제거"
+
+#: type/list/view_body.html
+msgid ""
+"You are about to remove the last item in the list. That will delete the whole list. Are"
+" you sure you want to continue?"
+msgstr "당신은 about to 제거 the last item in the 목록. That will 삭제 the whole 목록. 정말 continue?"
+
+#: type/list/view_body.html
+#, python-format
+msgid ""
+"This series contains %(limit)d or more works. Currently, only the first %(limit)d works"
+" are displayed."
+msgstr ""
+"This series contains %(limit)d or more 작품. Currently, only the first %(limit)d 작품 are "
+"displayed."
+
+#: type/list/view_body.html
+msgid "There are no items on this list."
+msgstr "이 목록에는 항목이 없습니다."
+
+#: type/list/view_body.html
+msgid ""
+"<a href=\"/search\" target=\"_blank\" rel=\"noopener noreferrer\">Search for book, "
+"subjects, or authors</a> to add to your list."
+msgstr ""
+"<a href=\"/검색\" target=\"_blank\" rel=\"noopener noreferrer\">검색 for 책, 주제, or 저자</a> "
+"추가하려면 to your 목록."
+
+#: type/list/view_body.html
+msgid "Learn more."
+msgstr "자세히 알아보기."
+
+#: type/list/view_body.html
+msgid "List Metadata"
+msgstr "목록 메타데이터"
+
+#: type/list/view_body.html
+msgid "Derived from seed metadata"
+msgstr "시드 메타데이터에서 파생됨"
+
+#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py
+#: type/list/view_body.html
+msgid "Times"
+msgstr "시간"
+
+#: type/local_id/view.html
+msgid "Local IDs"
+msgstr "로컬 ID"
+
+#: type/local_id/view.html
+msgid "Source Item"
+msgstr "원본 항목"
+
+#: type/local_id/view.html
+msgid "ID location"
+msgstr "ID 위치"
+
+#: type/local_id/view.html
+msgid "Barcode regex"
+msgstr "바코드 정규식"
+
+#: type/local_id/view.html
+msgid "URN prefix"
+msgstr "URN 접두사"
+
+#: type/local_id/view.html
+msgid "Example"
+msgstr "예"
+
+#: type/page/edit.html
+msgid "Document Body:"
+msgstr "문서 본문:"
+
+#: type/page/view.html
+msgid "Community"
+msgstr "커뮤니티"
+
+#: type/permission/edit.html
+msgid "Readers:"
+msgstr "독자:"
+
+#: type/permission/edit.html
+msgid "Writers:"
+msgstr "작성자:"
+
+#: type/permission/view.html
+msgid "Readers"
+msgstr "독자"
+
+#: type/permission/view.html
+msgid "Writers"
+msgstr "작성자"
+
+#: type/tag/form.html
+msgid "Edit tag"
+msgstr "태그 편집"
+
+#: type/tag/form.html
+msgid "Add a tag"
+msgstr "태그 추가"
+
+#: type/tag/form.html
+msgid "Add a tag to Open Library"
+msgstr "Open Library에 태그 추가"
+
+#: type/tag/form.html
+msgid "We require a minimum set of fields to create a new collection tag."
+msgstr "We require a minimum set of fields to 생성 a new collection tag."
+
+#: EditButtons.html type/tag/form.html
+msgid ""
+"By saving a change to this wiki, you agree that your contribution is given freely to "
+"the world under <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" "
+"target=\"_blank\" rel=\"noopener noreferrer\" title=\"This link to Creative Commons "
+"will open in a new window\">CC0</a>. Yippee!"
+msgstr ""
+"By saving a change to this wiki, you agree that your contribution is given freely to "
+"the world under <a href=\"https://creativecommons.org/공개domain/zero/1.0/\" "
+"target=\"_blank\" rel=\"noopener noreferrer\" title=\"This link to Creative Commons "
+"will open in a new window\">CC0</a>. Yippee!"
+
+#: type/tag/form.html
+msgid "Add this tag now"
+msgstr "이 태그 지금 추가"
+
+#: type/tag/index.html
+msgid "Tags"
+msgstr "태그"
+
+#: type/tag/index.html
+msgid "Tags curated by Open Library librarians."
+msgstr "Open Library 사서가 선별한 태그입니다."
+
+#: type/tag/index.html
+msgid "View subject page"
+msgstr "주제 페이지 보기"
+
+#: type/tag/index.html
+msgid "Previous"
+msgstr "이전"
+
+#: type/tag/index.html
+msgid "No tags found."
+msgstr "태그를 찾을 수 없습니다."
+
+#: type/tag/tag_form_inputs.html
+msgid "Tag Name"
+msgstr "태그 이름"
+
+#: type/tag/tag_form_inputs.html
+msgid "Human-readable display name (e.g. \"Computer Science\", \"Horror Fiction\")"
+msgstr "사람이 읽을 수 있는 표시 이름(예: \"Computer Science\", \"Horror Fiction\")"
+
+#: type/tag/tag_form_inputs.html
+msgid "Tag Slugs"
+msgstr "태그 슬러그"
+
+#: type/tag/tag_form_inputs.html
+msgid ""
+"Comma-separated URL slugs that map to this tag (auto-populated from name). E.g. "
+"\"computer_science, cs\""
+msgstr "이 태그에 매핑되는 쉼표로 구분된 URL 슬러그입니다(이름에서 자동 생성). 예: \"computer_science, cs\""
+
+#: type/tag/tag_form_inputs.html
+msgid "Tag Description"
+msgstr "태그 설명"
+
+#: type/tag/tag_form_inputs.html
+msgid "Page Body"
+msgstr "페이지 본문"
+
+#: type/tag/tag_form_inputs.html
+msgid "Tag type"
+msgstr "태그 유형"
+
+#: type/tag/tag_form_inputs.html
+msgid "Tag Deputy"
+msgstr "태그 담당자"
+
+#: type/tag/view.html
+#, python-format
+msgid "<strong>Type:</strong> %(tag_type)s"
+msgstr "<strong>유형:</strong> %(tag_type)s"
+
+#: type/tag/view.html type/user/edit.html
+msgid "Description"
+msgstr "설명"
+
+#: type/tag/view.html
+msgid "Tag Body"
+msgstr "태그 본문"
+
+#: type/tag/view.html
+msgid "URL Slugs"
+msgstr "URL 슬러그"
+
+#: type/tag/view.html
+#, python-format
+msgid "View subject page for %(name)s."
+msgstr "subject page for %(name)s. 보기"
+
+#: type/template/edit.html
+msgid "Plugin"
+msgstr "플러그인"
+
+#: type/template/edit.html
+msgid "Document Body"
+msgstr "문서 본문"
+
+#: type/template/edit.html
+msgid "Delete this template?"
+msgstr "이 템플릿을 삭제하시겠습니까?"
+
+#: type/template/view.html
+msgid "plugin"
+msgstr "플러그인"
+
+#: type/type/view.html
+msgid "Kind"
+msgstr "종류"
+
+#: type/type/view.html
+msgid "Properties"
+msgstr "속성"
+
+#: type/type/view.html
+msgid "of type"
+msgstr "유형:"
+
+#: type/type/view.html
+msgid "Backreferences"
+msgstr "역참조"
+
+#: type/user/edit.html
+#, python-format
+msgid "Editing %(name)s"
+msgstr "%(name)s 편집 중"
+
+#: type/user/edit.html
+msgid "Currently Editing:"
+msgstr "현재 편집 중:"
+
+#: type/user/edit.html
+msgid "Display Name"
+msgstr "표시 이름"
+
+#: type/user/view.html
+msgid "admin page"
+msgstr "관리자 페이지"
+
+#: type/user/view.html
+#, python-format
+msgid ""
+"You are publicly sharing the books you are <a href=\"%(username)s/books/currently-"
+"reading\">currently reading</a>, <a href=\"%(username)s/books/already-read\">have "
+"already read</a>, and <a href=\"%(username)s/books/want-to-read\">want to read</a>."
+msgstr ""
+"당신은 공개ly sharing the 책 you are <a href=\"%(username)s/책/currently-reading\">currently "
+"reading</a>, <a href=\"%(username)s/책/already-read\">have already read</a>, and <a "
+"href=\"%(username)s/책/want-to-read\">want to read</a>."
+
+#: type/user/view.html
+msgid "You have chosen to make your"
+msgstr "다음을"
+
+#: type/user/view.html
+msgid "private"
+msgstr "비공개"
+
+#: type/user/view.html
+msgid "Manage your privacy settings"
+msgstr "개인정보 설정 관리"
+
+#: type/user/view.html
+#, python-format
+msgid ""
+"Here are the books %(user)s is <a href=\"%(username)s/books/currently-"
+"reading\">currently reading</a>, <a href=\"%(username)s/books/already-read\">have "
+"already read</a>, and <a href=\"%(username)s/books/want-to-read\">want to read</a>!"
+msgstr ""
+"Here are the 책 %(user)s is <a href=\"%(username)s/책/currently-reading\">currently "
+"reading</a>, <a href=\"%(username)s/책/already-read\">have already read</a>, and <a "
+"href=\"%(username)s/책/want-to-read\">want to read</a>!"
+
+#: type/user/view.html
+msgid "My Lists"
+msgstr "내 목록"
+
+#: RecentChangesUsers.html type/user/view.html
+msgid "No edits. Yet."
+msgstr "아직 편집이 없습니다."
+
+#: type/usergroup/edit.html
+msgid "Members:"
+msgstr "회원:"
+
+#: SearchResultsWork.html type/work/editions.html
+#, python-format
+msgid "First published in %(year)s"
+msgstr "%(year)s년 초판 출간"
+
+#: type/work/editions.html type/work/editions_datatable.html
+#, python-format
+msgid "Add another edition of %(work)s"
+msgstr "%(work)s의 다른 판본 추가"
+
+#: UserEditRow.html type/work/editions.html
+msgid "Add another"
+msgstr "다른 항목 추가"
+
+#: type/work/editions.html
+msgid "Title missing"
+msgstr "제목 없음"
+
+#: type/work/editions_datatable.html
+#, python-format
+msgid "Showing %(count)d featured edition."
+msgid_plural "Showing %(count)d featured editions."
+msgstr[0] "추천 판본 %(count)d개 표시 중."
+
+#: type/work/editions_datatable.html
+#, python-format
+msgid "View all %(count)d editions?"
+msgstr "판본 %(count)d개 모두 보기?"
+
+#: type/work/editions_datatable.html
+msgid "Edition"
+msgstr "판본"
+
+#: type/work/editions_datatable.html
+msgid "Availability"
+msgstr "이용 가능 여부"
+
+#: type/work/editions_datatable.html
+msgid "No editions available"
+msgstr "이용 가능한 판본 없음"
+
+#: type/work/editions_datatable.html
+msgid "Add another edition?"
+msgstr "다른 판본을 추가하시겠습니까?"
+
+#: AffiliateLinks.html
+#, python-format
+msgid "Look for this edition for sale at %(store)s"
+msgstr "Look 이 판본에 대해 for sale at %(store)s"
+
+#: AffiliateLinks.html
+msgid ""
+"When you buy books using these links the Internet Archive may earn a <a "
+"class=\"nostyle\" href=\"/help/faq/about#selling\">small commission</a>."
+msgstr ""
+"When you buy 책 using these links the Internet Archive may earn a <a class=\"nostyle\" "
+"href=\"/help/faq/about#selling\">small commission</a>."
+
+#: AffiliateLinksLoadingIndicator.html
+msgid "Fetching prices"
+msgstr "가격 불러오는 중"
+
+#: BatchImportNavigation.html
+msgid "Pending Imports"
+msgstr "대기 중인 가져오기"
+
+#: BookByline.html
+#, python-format
+msgid "%(n)s other"
+msgid_plural "%(n)s others"
+msgstr[0] "기타 %(n)s개"
+
+#: BookByline.html
+msgid "by an <em>unknown author</em>"
+msgstr "by an <em>알 수 없음 저자</em>"
+
+#: BookPreview.html
+msgid "Preview Only"
+msgstr "미리보기만 가능"
+
+#: BookPreview.html
+msgid "Preview Book"
+msgstr "책 미리보기"
+
+#: DisplayCode.html
+msgid ""
+"Templates in the website are disabled now. Editing them will not have any effect on the"
+" live website."
+msgstr ""
+"Templates in the website are disabled now. 편집ing them will not have any effect on the "
+"live website."
+
+#: EditionNavBar.html
+msgid "Go to previous section"
+msgstr "이전 섹션으로 이동"
+
+#: EditionNavBar.html
+msgid "Overview"
+msgstr "개요"
+
+#: EditionNavBar.html
+#, python-format
+msgid "View %(count)s Edition"
+msgid_plural "View %(count)s Editions"
+msgstr[0] "판본 %(count)s개 보기"
+
+#: EditionNavBar.html
+#, python-format
+msgid "%(reviews)s Review"
+msgid_plural "%(reviews)s Reviews"
+msgstr[0] "리뷰 %(reviews)s개"
+
+#: EditionNavBar.html
+msgid "Related Books"
+msgstr "관련 도서"
+
+#: EditionNavBar.html
+msgid "Go to next section"
+msgstr "다음 섹션으로 이동"
+
+#: Follow.html
+msgid "Unfollow"
+msgstr "팔로우 취소"
+
+#: Follow.html
+msgid "Failed to update followers. Please try again in a few moments."
+msgstr "실패했습니다 to update followers. 다시 시도해 주세요 in a few moments."
+
+#: FormatExpiry.html
+msgid "Expires"
+msgstr "만료"
+
+#: FulltextSearchSuggestion.html
+msgid "Checking for Search Inside matches"
+msgstr "본문 검색 일치 항목 확인 중"
+
+#: FulltextSearchSuggestion.html
+msgid "Search Inside Icon"
+msgstr "본문 검색 아이콘"
+
+#: FulltextSearchSuggestion.html
+msgid "search inside icon"
+msgstr "본문 검색 아이콘"
+
+#: FulltextSearchSuggestion.html
+#, python-format
+msgid "%(book_count)s books found with matching passages"
+msgstr "%(book_count)s 책 found with matching passages"
+
+#: FulltextSearchSuggestion.html
+#, python-format
+msgid "See all %(results_count)s Search Inside Matches"
+msgstr "See all %(results_count)s 검색 Inside Matches"
+
+#: FulltextSearchSuggestion.html
+msgid "right chevron"
+msgstr "오른쪽 꺾쇠"
+
+#: FulltextSnippet.html FulltextSuggestionSnippet.html
+msgid "❝"
+msgstr "❝"
+
+#: FulltextSnippet.html FulltextSuggestionSnippet.html
+msgid "❞"
+msgstr "❞"
+
+#: FulltextSuggestionSnippet.html
+#, python-format
+msgid "Page: %(page)s"
+msgstr "페이지: %(page)s"
+
+#: IABook.html
+#, python-format
+msgid "Borrowed from Internet Archive: %(title)s"
+msgstr "대출ed from Internet Archive: %(title)s"
+
+#: LoadingIndicator.html
+msgid "Loading indicator"
+msgstr "로딩 표시기"
+
+#: LoanStatus.html
+msgid "You are <strong>next</strong> on the waiting list"
+msgstr "당신은 <strong>next</strong> on the 대기자 명단"
+
+#: LoanStatus.html
+#, python-format
+msgid "You are <strong>#%(spot)d</strong> of %(wlsize)d on the waiting list."
+msgstr "당신은 <strong>#%(spot)d</strong> of %(wlsize)d on the 대기자 명단."
+
+#: LoanStatus.html
+msgid "Leave waiting list"
+msgstr "대기자 명단 나가기"
+
+#: LoanStatus.html
+#, python-format
+msgid "Readers in line: %(count)s"
+msgstr "대기 중인 독자: %(count)s명"
+
+#: LoanStatus.html
+msgid "You'll be next in line."
+msgstr "다음 차례입니다."
+
+#: LoanStatus.html
+msgid "This book is currently checked out, please check back later."
+msgstr "이 책 is currently checked out, please check back later."
+
+#: LoanStatus.html
+msgid "Checked Out"
+msgstr "대출 중"
+
+#: LocateButton.html
+msgid "Locate"
+msgstr "찾기"
+
+#: ManageLoansButtons.html
+#, python-format
+msgid "There is one person waiting for this book."
+msgid_plural "There are %(n)s people waiting for this book."
+msgstr[0] "이 책을 기다리는 사람이 %(n)s명 있습니다."
+
+#: ManageWaitlistButton.html
+#, python-format
+msgid "Waiting for %d day"
+msgid_plural "Waiting for %d days"
+msgstr[0] "%d일째 대기 중"
+
+#: ManageWaitlistButton.html
+#, python-format
+msgid "You have %(count)d more hour to borrow it."
+msgid_plural "You have %(count)d more hours to borrow it."
+msgstr[0] "대출할 수 있는 시간이 %(count)d시간 남았습니다."
+
+#: NotInLibrary.html
+msgid "Not in Library"
+msgstr "라이브러리에 없음"
+
+#: NotesModal.html
+msgid "My Book Notes"
+msgstr "내 책 노트"
+
+#: NotesModal.html
+msgid "My private notes about this edition:"
+msgstr "이 판본에 대한 내 비공개 노트:"
+
+#: OLID.html
+#, python-format
+msgid "by  %(authors)s"
+msgstr "%(authors)s 지음"
+
+#: ObservationsModal.html
+msgid "My Book Review"
+msgstr "내 책 리뷰"
+
+#: OlPagination.html OlPaginationArrows.html
+msgid "Go to previous page"
+msgstr "이전 페이지로 이동"
+
+#: OlPagination.html OlPaginationArrows.html
+msgid "Go to next page"
+msgstr "다음 페이지로 이동"
+
+#: OlPagination.html
+#, python-brace-format
+msgid "Go to page {page}"
+msgstr "{page}페이지로 이동"
+
+#: OlPagination.html
+#, python-brace-format
+msgid "Page {page}, current page"
+msgstr "{page}페이지, 현재 페이지"
+
+#: Profile.html
+msgid "Component"
+msgstr "컴포넌트"
+
+#: ProlificAuthors.html
+msgid "Prolific Authors"
+msgstr "다작 저자"
+
+#: ProlificAuthors.html
+msgid "who have written the most books on this subject"
+msgstr "who have written the most 책 on this 주제"
+
+#: PublishingHistory.html
+msgid ""
+"This is a chart to show the publishing history of editions of works about this subject."
+" Along the X axis is time, and on the y axis is the count of editions published. <a "
+"href=\"#subjectRelated\">Click here to skip the chart</a>."
+msgstr ""
+"이것은 a chart to show the publishing history of 판본 of 작품 about this 주제. Along the X axis "
+"is time, and on the y axis is the count of 판본 published. <a href=\"#주제Related\">Click "
+"here to skip the chart</a>."
+
+#: PublishingHistory.html
+msgid "This graph charts editions published on this subject."
+msgstr "This graph charts 판본 published on this 주제."
+
+#: RawQueryCarousel.html
+msgid "Loading carousel"
+msgstr "캐러셀 불러오는 중"
+
+#: RawQueryCarousel.html
+msgid "Failed to fetch carousel."
+msgstr "캐러셀을 가져오지 못했습니다."
+
+#: RawQueryCarousel.html
+msgid "Retry?"
+msgstr "다시 시도할까요?"
+
+#: RawQueryCarousel.html
+msgid "No books match the current filters."
+msgstr "현재 필터와 일치하는 책이 없습니다."
+
+#: RawQueryCarousel.html
+msgid "Retry without filters?"
+msgstr "필터 없이 다시 시도할까요?"
+
+#: RawQueryCarousel.html
+msgid "Search collection"
+msgstr "컬렉션 검색"
+
+#: ReadButton.html
+msgid "Special Access"
+msgstr "특별 접근"
+
+#: ReadButton.html
+msgid ""
+"Special ebook access from the Internet Archive for patrons with qualifying print "
+"disabilities"
+msgstr ""
+"Special e책 access from the Internet Archive for patrons with qualifying print "
+"disabilities"
+
+#: ReadButton.html
+msgid "Borrow ebook from Internet Archive"
+msgstr "Internet Archive에서 전자책 대출"
+
+#: ReadButton.html
+msgid "Read ebook from Internet Archive"
+msgstr "Internet Archive에서 전자책 읽기"
+
+#: ReadButton.html
+msgid "Listen"
+msgstr "듣기"
+
+#: RecentChanges.html
+msgid "View MARC"
+msgstr "MARC 보기"
+
+#: RecentChangesAdmin.html
+msgid "Path"
+msgstr "경로"
+
+#: RecentChangesAdmin.html
+msgid "view"
+msgstr "보기"
+
+#: RecentChangesAdmin.html
+msgid "edit"
+msgstr "편집"
+
+#: RecentChangesAdmin.html RecentChangesUsers.html
+msgid "No edit history available."
+msgstr "사용 가능한 편집 기록이 없습니다."
+
+#: RelatedSubjects.html
+msgid "Related..."
+msgstr "관련..."
+
+#: ReturnForm.html
+msgid "Really return this book?"
+msgstr "정말 이 책을 반납하시겠습니까?"
+
+#: ReturnForm.html
+msgid "Return book"
+msgstr "책 반납"
+
+#: SearchResultsWork.html
+msgid "added to"
+msgstr "추가됨:"
+
+#: SearchResultsWork.html
+#, python-format
+msgid "Book %(position)s"
+msgstr "책 %(position)s"
+
+#: SearchResultsWork.html
+#, python-format
+msgid "Cover of edition %(id)s"
+msgstr "판본 %(id)s의 표지"
+
+#: SearchResultsWork.html
+#, python-format
+msgid "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d language</a>"
+msgid_plural "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d languages</a>"
+msgstr[0] "<a class=\"hoverlink\" title=\"%(langs)s\">%(count)d개 언어</a>로"
+
+#: SearchResultsWork.html TrendingBadge.html
+msgid "This is only visible to librarians."
+msgstr "이 내용은 사서에게만 보입니다."
+
+#: SearchResultsWork.html
+msgid "Work Title"
+msgstr "작품 제목"
+
+#: ShareModal.html
+#, python-format
+msgid "Share on %(share_link)s"
+msgstr "%(share_link)s에서 공유"
+
+#: ShareModal.html
+msgid "Embed this book in your website"
+msgstr "내 웹사이트에 이 책 삽입"
+
+#: ShareModal.html
+msgid "Embed icon"
+msgstr "삽입 아이콘"
+
+#: ShareModal.html
+msgid "Embed"
+msgstr "삽입"
+
+#: ShareModal.html
+msgid "Copy url to clipboard"
+msgstr "URL을 클립보드에 복사"
+
+#: ShareModal.html
+msgid "Copy URL icon"
+msgstr "URL 복사 아이콘"
+
+#: ShareModal.html
+msgid "Copy URL"
+msgstr "URL 복사"
+
+#: ShareModal.html
+msgid "Open QR code"
+msgstr "QR 코드 열기"
+
+#: ShareModal.html
+msgid "QR code icon"
+msgstr "QR 코드 아이콘"
+
+#: ShareModal.html
+msgid "QR Code"
+msgstr "QR 코드"
+
+#: StarRatings.html
+msgid "Clear my rating"
+msgstr "내 평점 지우기"
+
+#: StarRatingsByline.html StarRatingsComponent.html
+msgid "rating"
+msgstr "평점"
+
+#: StarRatingsByline.html StarRatingsComponent.html
+msgid "ratings"
+msgstr "평점"
+
+#: StarRatingsByline.html
+#, python-format
+msgid "%(want_to_read_count)s Want to read"
+msgstr "%(want_to_read_count)s명이 읽고 싶어 함"
+
+#: StarRatingsComponent.html
+#, python-format
+msgid "%(ratings_avg)s (%(ratings_count)s %(ratings_label)s)"
+msgstr "%(ratings_avg)s (%(ratings_count)s %(ratings_label)s)"
+
+#: StarRatingsStats.html
+msgid "Want to read"
+msgstr "읽고 싶어요"
+
+#: StarRatingsStats.html
+msgid "Currently reading"
+msgstr "읽는 중"
+
+#: StarRatingsStats.html
+msgid "Have read"
+msgstr "읽었어요"
+
+#: SubjectTags.html
+msgid "Manage Subjects"
+msgstr "주제 관리"
+
+#: Subnavigation.html
+msgid "Developer Center (Home)"
+msgstr "개발자 센터(홈)"
+
+#: Subnavigation.html
+msgid "Web API"
+msgstr "웹 API"
+
+#: Subnavigation.html
+msgid "Client Library"
+msgstr "클라이언트 라이브러리"
+
+#: Subnavigation.html
+msgid "Data Dumps"
+msgstr "데이터 덤프"
+
+#: Subnavigation.html
+msgid "Report an Issue"
+msgstr "문제 신고"
+
+#: Subnavigation.html
+msgid "Licensing"
+msgstr "라이선스"
+
+#: Subnavigation.html
+msgid "Welcome"
+msgstr "환영합니다"
+
+#: Subnavigation.html
+msgid "Searching Open Library"
+msgstr "Open Library 검색"
+
+#: Subnavigation.html
+msgid "Reading Books"
+msgstr "책 읽기"
+
+#: Subnavigation.html
+msgid "Adding & Editing Books"
+msgstr "책 추가 및 편집"
+
+#: Subnavigation.html
+msgid "Using Subjects"
+msgstr "주제 사용"
+
+#: Subnavigation.html
+msgid "Open Library F.A.Q."
+msgstr "Open Library 자주 묻는 질문"
+
+#: TableOfContents.html
+#, python-format
+msgid "Page %s"
+msgstr "%s페이지"
+
+#: TrendingBadge.html
+#, python-format
+msgid "Trending: %(score).2f"
+msgstr "인기 점수: %(score).2f"
+
+#: TypeChanger.html
+msgid "Page Type"
+msgstr "페이지 유형"
+
+#: TypeChanger.html
+msgid "Huh?"
+msgstr "네?"
+
+#: TypeChanger.html
+msgid ""
+"Every piece of Open Library is defined by the type of content it displays, usually by "
+"content definition (e.g. Authors, Editions, Works) but sometimes by content use (e.g. "
+"macro, template, rawtext). Changing this for an existing page will alter its "
+"presentation and the data fields available for editing its content."
+msgstr ""
+"Every piece of Open Library is defined by the type of content it displays, usually by "
+"content definition (e.g. Authors, 편집ions, Works) but sometimes by content use (e.g. "
+"macro, template, rawtext). Changing this for an existing 페이지 will alter its "
+"presentation and the data fields 사용 가능 for 편집ing its content."
+
+#: TypeChanger.html
+msgid "Please use caution changing Page Type!"
+msgstr "페이지 유형을 변경할 때 주의해 주세요!"
+
+#: TypeChanger.html
+msgid "(Simplest solution: If you aren't sure whether this should be changed, don't change it.)"
+msgstr "(가장 간단한 해결책: 변경해야 하는지 확실하지 않다면 변경하지 마세요.)"
+
+#: WorkInfo.html
+msgid "No link to Wikipedia in your language"
+msgstr "내 언어의 위키백과 링크 없음"
+
+#: WorldcatLink.html
+msgid "Check nearby libraries"
+msgstr "근처 도서관 확인"
+
+#: WorldcatLink.html
+msgid "Check WorldCat for an edition near you"
+msgstr "Check WorldCat for an 판본 near you"
+
+#: WorldcatLink.html
+msgid "WorldCat"
+msgstr "WorldCat"
+
+#: databarDiff.html databarEdit.html
+msgid "View the editing history of this page"
+msgstr "이 페이지의 편집 기록 보기"
+
+#: databarDiff.html
+msgid "View this page (exit Comparison view)"
+msgstr "이 페이지 보기(비교 보기 종료)"
+
+#: databarEdit.html
+msgid "View this page (exit Edit mode)"
+msgstr "이 페이지 보기(편집 모드 종료)"
+
+#: databarHistory.html databarView.html
+#, python-format
+msgid "Last edited by %(author_link)s"
+msgstr "마지막 편집자: %(author_link)s"
+
+#: databarHistory.html databarView.html
+msgid "Last edited anonymously"
+msgstr "마지막 익명 편집"
+
+#: databarTemplate.html databarView.html
+msgid "View this template's edit history"
+msgstr "이 템플릿의 편집 기록 보기"
+
+#: databarTemplate.html
+msgid "Edit this template"
+msgstr "이 템플릿 편집"
+
+#: databarWork.html
+#, python-format
+msgid "View Volume %(num)d"
+msgstr "%(num)d권 보기"
+
+#: openlibrary/core/bookshelves.py
+msgid "[Record deleted]"
+msgstr "[레코드 삭제됨]"
+
+#: openlibrary/core/edits.py
+msgid "Unknown"
+msgstr "알 수 없음"
+
+#: openlibrary/plugins/openlibrary/api.py
+msgid "Search Results"
+msgstr "검색 결과"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Arabic"
+msgstr "아랍어"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Czech"
+msgstr "체코어"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "German"
+msgstr "독일어"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "English"
+msgstr "영어"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Spanish"
+msgstr "스페인어"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "French"
+msgstr "프랑스어"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Hindi"
+msgstr "힌디어"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Croatian"
+msgstr "크로아티아어"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Italian"
+msgstr "이탈리아어"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Portuguese"
+msgstr "포르투갈어"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Romanian"
+msgstr "루마니아어"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Sardinian"
+msgstr "사르데냐어"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Telugu"
+msgstr "텔루구어"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Ukrainian"
+msgstr "우크라이나어"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Chinese"
+msgstr "중국어"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Filipino"
+msgstr "필리핀어"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Art"
+msgstr "예술"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Science Fiction"
+msgstr "공상과학"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Fantasy"
+msgstr "판타지"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Biographies"
+msgstr "전기"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Recipes"
+msgstr "레시피"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Children"
+msgstr "아동"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Medicine"
+msgstr "의학"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Religion"
+msgstr "종교"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Mystery and Detective Stories"
+msgstr "미스터리와 탐정 이야기"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Plays"
+msgstr "희곡"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Music"
+msgstr "음악"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "At least 1 subject"
+msgstr "주제 1개 이상"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "At least 1 author"
+msgstr "저자 1명 이상"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "At least 1 edition"
+msgstr "판본 1개 이상"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has work (orphaned)"
+msgstr "작품 있음(고아 항목)"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has publication year"
+msgstr "출판 연도 있음"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has cover"
+msgstr "표지 있음"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has language"
+msgstr "언어 있음"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has publisher"
+msgstr "출판사 있음"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "At least 2 editions"
+msgstr "판본 2개 이상"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has dewey decimal"
+msgstr "듀이 십진분류 있음"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has LoC classification"
+msgstr "미국의회도서관 분류 있음"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has number of pages"
+msgstr "페이지 수 있음"
+
+#: openlibrary/plugins/openlibrary/lists.py
+#, python-format
+msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
+msgstr "정말 제거 <strong>%(title)s</strong> from your 목록?"
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "Better World Books"
+msgstr "Better World Books"
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid " - includes shipping"
+msgstr " - 배송비 포함"
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "Amazon"
+msgstr "Amazon"
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "Bookshop.org"
+msgstr "Bookshop.org"
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "This work does not appear on any lists."
+msgstr "이 작품은 어떤 목록에도 없습니다."
+
+#: openlibrary/plugins/openlibrary/pd.py
+msgid "I don't have one yet"
+msgstr "아직 없습니다"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "The email address you entered is invalid"
+msgstr "입력한 이메일 주소가 유효하지 않습니다"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "This account has been blocked"
+msgstr "이 계정은 차단되었습니다"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "This account has been locked"
+msgstr "이 계정은 잠겼습니다"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "No account was found with this email. Please try again"
+msgstr "이 이메일로 된 계정을 찾을 수 없습니다. 다시 시도해 주세요"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "The password you entered is incorrect. Please try again"
+msgstr "입력한 비밀번호가 올바르지 않습니다. 다시 시도해 주세요"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Wrong password. Please try again"
+msgstr "비밀번호가 올바르지 않습니다. 다시 시도해 주세요"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Please verify your Open Library account before logging in"
+msgstr "로그인하기 전에 Open Library 계정을 확인해 주세요"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Please verify your Internet Archive account before logging in"
+msgstr "로그인하기 전에 Internet Archive 계정을 확인해 주세요"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Please fill out all fields and try again"
+msgstr "모든 필드를 입력한 뒤 다시 시도해 주세요"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "This email is already registered"
+msgstr "이 이메일은 이미 등록되어 있습니다"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "This username is already registered"
+msgstr "이 사용자 이름은 이미 등록되어 있습니다"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "A problem occurred and we were unable to log you in."
+msgstr "문제가 발생하여 로그인할 수 없습니다."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Login attempted with invalid Internet Archive s3 credentials."
+msgstr "잘못된 Internet Archive s3 자격 증명으로 로그인을 시도했습니다."
+
+#: openlibrary/plugins/upstream/account.py
+msgid ""
+"Servers are experiencing unusually high traffic, please try again later or email "
+"openlibrary@archive.org for help."
+msgstr ""
+"Servers are experiencing unusually high traffic, please try again later or 이메일 "
+"openlibrary@archive.org for help."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Email provider not recognized."
+msgstr "이메일 제공업체를 인식할 수 없습니다."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Password requirements not met."
+msgstr "비밀번호 요구 사항을 충족하지 않습니다."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "A problem occurred and we were unable to log you in"
+msgstr "문제가 발생하여 로그인할 수 없습니다"
+
+#: openlibrary/plugins/upstream/account.py
+msgid ""
+"Login or registration attempt hit an unexpected error, please try again or contact "
+"info@archive.org"
+msgstr "로그인 또는 등록 시도 중 예상치 못한 오류가 발생했습니다. 다시 시도하거나 info@archive.org로 문의해 주세요"
+
+#: openlibrary/plugins/upstream/account.py
+#, python-format
+msgid "Request failed with error code: %(error_code)s"
+msgstr "요청이 오류 코드 %(error_code)s로 실패했습니다"
+
+#: openlibrary/plugins/upstream/account.py
+msgid ""
+"Thank you for registering an Open Library account and requesting special print "
+"disability access. You should receive an email detailing next steps in the process."
+msgstr ""
+"Thank you for registering an Open Library 계정 and requesting special print disability "
+"access. You should receive an 이메일 detailing next steps in the process."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Username unavailable"
+msgstr "사용자 이름을 사용할 수 없습니다"
+
+#: openlibrary/plugins/upstream/account.py openlibrary/plugins/upstream/forms.py
+msgid "Email already registered"
+msgstr "이미 등록된 이메일입니다"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "An Internet Archive account already exists with this email"
+msgstr "이 이메일로 된 Internet Archive 계정이 이미 있습니다"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Email address is already used."
+msgstr "이메일 주소가 이미 사용 중입니다."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Your email address couldn't be updated. The specified email address is already used."
+msgstr "Your 이메일 추가ress couldn't be updated. The specified 이메일 추가ress is already used."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Email verification successful."
+msgstr "이메일 확인 성공."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Your email address has been successfully verified and updated in your account."
+msgstr "이메일 주소가 성공적으로 확인되어 계정에 업데이트되었습니다."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Email address couldn't be verified."
+msgstr "이메일 주소를 확인할 수 없습니다."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Your email address couldn't be verified. The verification link seems invalid."
+msgstr "Your 이메일 추가ress 확인할 수 없습니다. The verification link seems invalid."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Notification preferences have been updated successfully."
+msgstr "알림 설정이 성공적으로 업데이트되었습니다."
+
+#: openlibrary/plugins/upstream/borrow.py
+msgid "this book"
+msgstr "이 책"
+
+#: openlibrary/plugins/upstream/borrow.py
+#, python-format
+msgid "Unable to return %s. Please try again later or contact info@archive.org."
+msgstr "Unable to 반납 %s. 다시 시도해 주세요 later or contact info@archive.org."
+
+#: openlibrary/plugins/upstream/borrow.py
+#, python-format
+msgid "%s has been returned."
+msgstr "%s이(가) 반납되었습니다."
+
+#: openlibrary/plugins/upstream/borrow.py
+msgid ""
+"Your account has hit a lending limit. Please try again later or contact "
+"info@archive.org."
+msgstr "Your 계정 has hit a lending limit. 다시 시도해 주세요 later or contact info@archive.org."
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Username"
+msgstr "사용자 이름"
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "No user registered with this email address"
+msgstr "이 이메일 주소로 등록된 사용자가 없습니다"
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Disposable email not permitted"
+msgstr "일회용 이메일은 허용되지 않습니다"
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Your email provider is not recognized."
+msgstr "이메일 제공업체를 인식할 수 없습니다."
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Username already used"
+msgstr "이미 사용 중인 사용자 이름입니다"
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Must be between 3 and 20 letters and numbers"
+msgstr "3자 이상 20자 이하의 영문자와 숫자여야 합니다"
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Screen Name"
+msgstr "화면 이름"
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Public and cannot be changed later."
+msgstr "공개되며 나중에 변경할 수 없습니다."
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Invalid password"
+msgstr "잘못된 비밀번호"
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Your email address"
+msgstr "내 이메일 주소"
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Choose a password"
+msgstr "비밀번호 선택"
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "eBook?"
+msgstr "전자책?"
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "First published"
+msgstr "초판 출간"
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "Classic eBooks"
+msgstr "클래식 전자책"
+


### PR DESCRIPTION
## Summary
Adds initial Korean (`ko`) translations for Open Library.

## Changes
- Adds `openlibrary/i18n/ko/messages.po`
- Sets Korean plural form to `nplurals=1; plural=0;`
- Provides Korean translations for existing message strings

## Testing
- Ran `./scripts/i18n-messages validate ko`