### PR TITLE
Comment out broken Unique Visitors chart (#12823)

### DIFF
--- a/openlibrary/core/admin.py
+++ b/openlibrary/core/admin.py
@@ -105,22 +105,22 @@ def _get_visitor_counts_from_graphite(ndays: int = 28) -> list[list[int]]:
     :param ndays: number of days to read
     :return: list containing [count, timestamp] for ndays
     """
-    # try:
-    #     response = requests.get(
-    #         "http://graphite.us.archive.org/render/",
-    #         params={
-    #             "target": "summarize(stats.uniqueips.openlibrary, '1d')",
-    #             "from": f"-{ndays}days",
-    #             "tz": "UTC",
-    #             "format": "json",
-    #         },
-    #     )
-    #     response.raise_for_status()
-    #     visitors = response.json()[0]["datapoints"]
-    # except requests.exceptions.RequestException:
-    #     visitors = []
-    # return visitors
-    return []
+    try:
+        response = requests.get(
+            "http://graphite.us.archive.org/render/",
+            params={
+                "target": "summarize(stats.uniqueips.openlibrary, '1d')",
+                "from": f"-{ndays}days",
+                "tz": "UTC",
+                "format": "json",
+            },
+            timeout=5,
+        )
+        response.raise_for_status()
+        visitors = response.json()[0]["datapoints"]
+    except requests.exceptions.RequestException:
+        visitors = []
+    return visitors
 
 
 class VisitorStats(Stats):

--- a/openlibrary/core/admin.py
+++ b/openlibrary/core/admin.py
@@ -99,27 +99,28 @@ class LoanStats(Stats):
 
 
 @cache.memoize(engine="memcache", key="admin._get_visitor_counts_from_graphite", expires=5 * 60)
-def _get_visitor_counts_from_graphite(self, ndays: int = 28) -> list[list[int]]:
+def _get_visitor_counts_from_graphite(ndays: int = 28) -> list[list[int]]:
     """
     Read the unique visitors (IP addresses) per day for the last ndays from graphite.
     :param ndays: number of days to read
     :return: list containing [count, timestamp] for ndays
     """
-    try:
-        response = requests.get(
-            "http://graphite.us.archive.org/render/",
-            params={
-                "target": "summarize(stats.uniqueips.openlibrary, '1d')",
-                "from": f"-{ndays}days",
-                "tz": "UTC",
-                "format": "json",
-            },
-        )
-        response.raise_for_status()
-        visitors = response.json()[0]["datapoints"]
-    except requests.exceptions.RequestException:
-        visitors = []
-    return visitors
+    # try:
+    #     response = requests.get(
+    #         "http://graphite.us.archive.org/render/",
+    #         params={
+    #             "target": "summarize(stats.uniqueips.openlibrary, '1d')",
+    #             "from": f"-{ndays}days",
+    #             "tz": "UTC",
+    #             "format": "json",
+    #         },
+    #     )
+    #     response.raise_for_status()
+    #     visitors = response.json()[0]["datapoints"]
+    # except requests.exceptions.RequestException:
+    #     visitors = []
+    # return visitors
+    return []
 
 
 class VisitorStats(Stats):

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -461,12 +461,12 @@ msgstr ""
 msgid "Fiction"
 msgstr ""
 
-#: design.html
+#: design.html openlibrary/plugins/openlibrary/home.py
 msgid "Science"
 msgstr ""
 
 #: databarDiff.html databarEdit.html databarTemplate.html databarView.html
-#: design.html lib/history.html
+#: design.html lib/history.html openlibrary/plugins/openlibrary/home.py
 msgid "History"
 msgstr ""
 
@@ -900,7 +900,7 @@ msgid ""
 "email and password to access your Open Library account."
 msgstr ""
 
-#: login.html
+#: login.html openlibrary/plugins/upstream/forms.py
 msgid "Email"
 msgstr ""
 
@@ -909,6 +909,7 @@ msgid "Forgot your Internet Archive email?"
 msgstr ""
 
 #: account/email/forgot-ia.html login.html
+#: openlibrary/plugins/upstream/forms.py
 msgid "Password"
 msgstr ""
 
@@ -1119,8 +1120,8 @@ msgid "Title"
 msgstr ""
 
 #: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html
-#: search/advancedsearch.html search/work_search_selected_facets.html
-#: status.html
+#: openlibrary/plugins/worksearch/code.py search/advancedsearch.html
+#: search/work_search_selected_facets.html status.html
 msgid "Author"
 msgstr ""
 
@@ -1271,7 +1272,7 @@ msgstr ""
 msgid "All Time"
 msgstr ""
 
-#: home/index.html trending.html
+#: home/index.html openlibrary/plugins/openlibrary/api.py trending.html
 msgid "Trending Books"
 msgstr ""
 
@@ -1515,11 +1516,11 @@ msgid ""
 "information form</a>."
 msgstr ""
 
-#: account/create.html
+#: account/create.html openlibrary/plugins/upstream/forms.py
 msgid "Must be a valid email address"
 msgstr ""
 
-#: account/create.html
+#: account/create.html openlibrary/plugins/upstream/forms.py
 msgid "Must be between 3 and 20 characters"
 msgstr ""
 
@@ -1845,7 +1846,7 @@ msgstr ""
 #. (bookshelf ID 3). Used as a button label and shelf name.
 #: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
 #: my_books/dropdown_content.html my_books/primary_action.html
-#: search/sort_options.html
+#: openlibrary/plugins/upstream/mybooks.py search/sort_options.html
 msgid "Already Read"
 msgstr ""
 
@@ -1871,7 +1872,7 @@ msgid "My Reading Stats"
 msgstr ""
 
 #: account/mybooks.html account/sidebar.html
-#: books/mybooks_breadcrumb_select.html
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
 msgid "Loan History"
 msgstr ""
 
@@ -1987,7 +1988,7 @@ msgid "Save"
 msgstr ""
 
 #: EditionNavBar.html account/observations.html
-#: books/mybooks_breadcrumb_select.html
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 msgid "Reviews"
 msgstr ""
 
@@ -2237,6 +2238,7 @@ msgid "Click on a bar to see matching works"
 msgstr ""
 
 #: account/sidebar.html books/mybooks_breadcrumb_select.html
+#: openlibrary/plugins/upstream/mybooks.py
 msgid "My Feed"
 msgstr ""
 
@@ -2675,7 +2677,7 @@ msgstr ""
 msgid "Failed"
 msgstr ""
 
-#: admin/imports_by_date.html
+#: admin/imports_by_date.html openlibrary/core/edits.py
 msgid "Pending"
 msgstr ""
 
@@ -2805,7 +2807,7 @@ msgstr ""
 msgid "Star Rating Patrons"
 msgstr ""
 
-#: admin/index.html
+#: admin/index.html home/stats.html
 msgid "Unique Visitors"
 msgstr ""
 
@@ -2887,7 +2889,8 @@ msgid "Admin Center"
 msgstr ""
 
 #: RelatedSubjects.html SubjectTags.html admin/menu.html
-#: admin/people/index.html admin/people/view.html type/author/view.html
+#: admin/people/index.html admin/people/view.html
+#: openlibrary/plugins/worksearch/code.py type/author/view.html
 #: type/list/view_body.html
 msgid "People"
 msgstr ""
@@ -3393,7 +3396,7 @@ msgid "Anonymize Account"
 msgstr ""
 
 #: admin/people/view.html books/mybooks_breadcrumb_select.html
-#: type/user/view.html
+#: openlibrary/plugins/upstream/account.py type/user/view.html
 msgid "Loans"
 msgstr ""
 
@@ -4143,39 +4146,51 @@ msgid "in %(languagelist)s"
 msgstr ""
 
 #: SearchNavigation.html books/mybooks_breadcrumb_select.html lib/nav_foot.html
+#: openlibrary/plugins/upstream/mybooks.py
 msgid "Books"
 msgstr ""
 
-#: books/mybooks_breadcrumb_select.html
+#. Page title for the "Want to Read" shelf page.
+#. Example: "Want to Read (17)". %(count)d is the number of books on this
+#. shelf.
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #, python-format
 msgid "Want to Read (%(count)d)"
 msgstr ""
 
-#: books/mybooks_breadcrumb_select.html
+#. Page title for the "Currently Reading" shelf page.
+#. Example: "Currently Reading (42)". %(count)d is the number of books on this
+#. shelf.
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #, python-format
 msgid "Currently Reading (%(count)d)"
 msgstr ""
 
-#: books/mybooks_breadcrumb_select.html
+#. Page title for the "Already Read" shelf page.
+#. Example: "Already Read (203)". %(count)d is the number of books on this
+#. shelf.
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #, python-format
 msgid "Already Read (%(count)d)"
 msgstr ""
 
-#: books/mybooks_breadcrumb_select.html
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #, python-format
 msgid "Stopped Reading (%(count)d)"
 msgstr ""
 
 #: books/mybooks_breadcrumb_select.html
+#: openlibrary/plugins/openlibrary/lists.py
 #, python-format
 msgid "Lists (%(count)d)"
 msgstr ""
 
-#: books/mybooks_breadcrumb_select.html type/edition/modal_links.html
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#: type/edition/modal_links.html
 msgid "Notes"
 msgstr ""
 
-#: books/mybooks_breadcrumb_select.html
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
 msgid "Imports and Exports"
 msgstr ""
 
@@ -5070,7 +5085,7 @@ msgstr[1] ""
 msgid "Welcome to Open Library"
 msgstr ""
 
-#: home/index.html
+#: home/index.html openlibrary/plugins/openlibrary/api.py
 msgid "Classic Books"
 msgstr ""
 
@@ -5078,19 +5093,21 @@ msgstr ""
 msgid "Recently Returned"
 msgstr ""
 
-#: home/index.html
+#: home/index.html openlibrary/plugins/openlibrary/api.py
+#: openlibrary/plugins/openlibrary/home.py
 msgid "Romance"
 msgstr ""
 
-#: home/index.html
+#: home/index.html openlibrary/plugins/openlibrary/api.py
 msgid "Kids"
 msgstr ""
 
-#: home/index.html
+#: home/index.html openlibrary/plugins/openlibrary/api.py
 msgid "Thrillers"
 msgstr ""
 
-#: home/index.html
+#: home/index.html openlibrary/plugins/openlibrary/api.py
+#: openlibrary/plugins/openlibrary/home.py
 msgid "Textbooks"
 msgstr ""
 
@@ -5127,6 +5144,14 @@ msgstr ""
 msgid ""
 "Here's what's happened over the last 28 days. More <a "
 "href=\"/recentchanges\">recent changes</a>"
+msgstr ""
+
+#: home/stats.html
+msgid "See all visitors to OpenLibrary.org"
+msgstr ""
+
+#: home/stats.html
+msgid "Area graph of recent unique visitors"
 msgstr ""
 
 #: home/stats.html
@@ -5403,7 +5428,7 @@ msgstr ""
 msgid "Just a sentence or two is good."
 msgstr ""
 
-#: lib/nav_foot.html site/head.html
+#: lib/nav_foot.html openlibrary/plugins/openlibrary/api.py site/head.html
 msgid "Open Library"
 msgstr ""
 
@@ -5464,8 +5489,8 @@ msgid "Explore subjects"
 msgstr ""
 
 #: RelatedSubjects.html SearchNavigation.html SubjectTags.html
-#: lib/nav_foot.html lib/nav_head.html subjects/notfound.html
-#: type/author/view.html type/list/view_body.html
+#: lib/nav_foot.html lib/nav_head.html openlibrary/plugins/worksearch/code.py
+#: subjects/notfound.html type/author/view.html type/list/view_body.html
 msgid "Subjects"
 msgstr ""
 
@@ -6083,11 +6108,11 @@ msgstr ""
 msgid "Request Status"
 msgstr ""
 
-#: merge_request_table/table_header.html
+#: merge_request_table/table_header.html openlibrary/core/edits.py
 msgid "Merged"
 msgstr ""
 
-#: merge_request_table/table_header.html
+#: merge_request_table/table_header.html openlibrary/core/edits.py
 msgid "Declined"
 msgstr ""
 
@@ -6379,8 +6404,8 @@ msgstr ""
 msgid "Publisher: %(name)s"
 msgstr ""
 
-#: publishers/view.html search/advancedsearch.html type/edition/view.html
-#: type/work/view.html
+#: openlibrary/plugins/worksearch/code.py publishers/view.html
+#: search/advancedsearch.html type/edition/view.html type/work/view.html
 msgid "Publisher"
 msgstr ""
 
@@ -7145,8 +7170,8 @@ msgstr ""
 msgid "— Show <a href=\"%(url)s\">everything</a> by this author?"
 msgstr ""
 
-#: RelatedSubjects.html SubjectTags.html type/author/view.html
-#: type/list/view_body.html
+#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py
+#: type/author/view.html type/list/view_body.html
 msgid "Places"
 msgstr ""
 
@@ -7280,7 +7305,8 @@ msgstr ""
 msgid "Search for other books from %(publisher)s"
 msgstr ""
 
-#: type/edition/view.html type/work/view.html
+#: openlibrary/plugins/worksearch/code.py type/edition/view.html
+#: type/work/view.html
 msgid "Language"
 msgstr ""
 
@@ -7619,7 +7645,8 @@ msgstr ""
 msgid "Derived from seed metadata"
 msgstr ""
 
-#: RelatedSubjects.html SubjectTags.html type/list/view_body.html
+#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py
+#: type/list/view_body.html
 msgid "Times"
 msgstr ""
 
@@ -8524,5 +8551,401 @@ msgstr ""
 #: databarWork.html
 #, python-format
 msgid "View Volume %(num)d"
+msgstr ""
+
+#: openlibrary/core/bookshelves.py
+msgid "[Record deleted]"
+msgstr ""
+
+#: openlibrary/core/edits.py
+msgid "Unknown"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/api.py
+msgid "Search Results"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Arabic"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Czech"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "German"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "English"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Spanish"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "French"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Hindi"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Croatian"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Italian"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Portuguese"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Romanian"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Sardinian"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Telugu"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Ukrainian"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Chinese"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Filipino"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Art"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Science Fiction"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Fantasy"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Biographies"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Recipes"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Children"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Medicine"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Religion"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Mystery and Detective Stories"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Plays"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Music"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "At least 1 subject"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "At least 1 author"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "At least 1 edition"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has work (orphaned)"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has publication year"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has cover"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has language"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has publisher"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "At least 2 editions"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has dewey decimal"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has LoC classification"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has number of pages"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/lists.py
+#, python-format
+msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "Better World Books"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid " - includes shipping"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "Amazon"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "Bookshop.org"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "This work does not appear on any lists."
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/pd.py
+msgid "I don't have one yet"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "The email address you entered is invalid"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "This account has been blocked"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "This account has been locked"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "No account was found with this email. Please try again"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "The password you entered is incorrect. Please try again"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Wrong password. Please try again"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Please verify your Open Library account before logging in"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Please verify your Internet Archive account before logging in"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Please fill out all fields and try again"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "This email is already registered"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "This username is already registered"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "A problem occurred and we were unable to log you in."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Login attempted with invalid Internet Archive s3 credentials."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid ""
+"Servers are experiencing unusually high traffic, please try again later "
+"or email openlibrary@archive.org for help."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Email provider not recognized."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Password requirements not met."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "A problem occurred and we were unable to log you in"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid ""
+"Login or registration attempt hit an unexpected error, please try again "
+"or contact info@archive.org"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+#, python-format
+msgid "Request failed with error code: %(error_code)s"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid ""
+"Thank you for registering an Open Library account and requesting special "
+"print disability access. You should receive an email detailing next steps"
+" in the process."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Username unavailable"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+#: openlibrary/plugins/upstream/forms.py
+msgid "Email already registered"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "An Internet Archive account already exists with this email"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid ""
+"Verification failed. The link may be invalid or expired. Please try "
+"registering again."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Your email has been verified. You are now logged in."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Notification preferences have been updated successfully."
+msgstr ""
+
+#: openlibrary/plugins/upstream/borrow.py
+msgid "this book"
+msgstr ""
+
+#: openlibrary/plugins/upstream/borrow.py
+#, python-format
+msgid "Unable to return %s. Please try again later or contact info@archive.org."
+msgstr ""
+
+#: openlibrary/plugins/upstream/borrow.py
+#, python-format
+msgid "%s has been returned."
+msgstr ""
+
+#: openlibrary/plugins/upstream/borrow.py
+msgid ""
+"Your account has hit a lending limit. Please try again later or contact "
+"info@archive.org."
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Username"
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "No user registered with this email address"
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Disposable email not permitted"
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Your email provider is not recognized."
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Username already used"
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Must be between 3 and 20 letters and numbers"
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Screen Name"
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Public and cannot be changed later."
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Invalid password"
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Your email address"
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Choose a password"
+msgstr ""
+
+#: openlibrary/plugins/upstream/mybooks.py
+#, python-format
+msgid ""
+"Continue <a href=\"%(url)s\" class=\"pending-action-link\" data-"
+"action=\"%(raw_action)s\"><strong>%(action)s</strong> "
+"<em>%(name)s</em></a>"
+msgstr ""
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "eBook?"
+msgstr ""
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "First published"
+msgstr ""
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "Classic eBooks"
 msgstr ""
 

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -461,12 +461,12 @@ msgstr ""
 msgid "Fiction"
 msgstr ""
 
-#: design.html openlibrary/plugins/openlibrary/home.py
+#: design.html
 msgid "Science"
 msgstr ""
 
 #: databarDiff.html databarEdit.html databarTemplate.html databarView.html
-#: design.html lib/history.html openlibrary/plugins/openlibrary/home.py
+#: design.html lib/history.html
 msgid "History"
 msgstr ""
 
@@ -900,7 +900,7 @@ msgid ""
 "email and password to access your Open Library account."
 msgstr ""
 
-#: login.html openlibrary/plugins/upstream/forms.py
+#: login.html
 msgid "Email"
 msgstr ""
 
@@ -909,7 +909,6 @@ msgid "Forgot your Internet Archive email?"
 msgstr ""
 
 #: account/email/forgot-ia.html login.html
-#: openlibrary/plugins/upstream/forms.py
 msgid "Password"
 msgstr ""
 
@@ -1120,8 +1119,8 @@ msgid "Title"
 msgstr ""
 
 #: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html
-#: openlibrary/plugins/worksearch/code.py search/advancedsearch.html
-#: search/work_search_selected_facets.html status.html
+#: search/advancedsearch.html search/work_search_selected_facets.html
+#: status.html
 msgid "Author"
 msgstr ""
 
@@ -1272,7 +1271,7 @@ msgstr ""
 msgid "All Time"
 msgstr ""
 
-#: home/index.html openlibrary/plugins/openlibrary/api.py trending.html
+#: home/index.html trending.html
 msgid "Trending Books"
 msgstr ""
 
@@ -1516,11 +1515,11 @@ msgid ""
 "information form</a>."
 msgstr ""
 
-#: account/create.html openlibrary/plugins/upstream/forms.py
+#: account/create.html
 msgid "Must be a valid email address"
 msgstr ""
 
-#: account/create.html openlibrary/plugins/upstream/forms.py
+#: account/create.html
 msgid "Must be between 3 and 20 characters"
 msgstr ""
 
@@ -1846,7 +1845,7 @@ msgstr ""
 #. (bookshelf ID 3). Used as a button label and shelf name.
 #: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
 #: my_books/dropdown_content.html my_books/primary_action.html
-#: openlibrary/plugins/upstream/mybooks.py search/sort_options.html
+#: search/sort_options.html
 msgid "Already Read"
 msgstr ""
 
@@ -1872,7 +1871,7 @@ msgid "My Reading Stats"
 msgstr ""
 
 #: account/mybooks.html account/sidebar.html
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
+#: books/mybooks_breadcrumb_select.html
 msgid "Loan History"
 msgstr ""
 
@@ -1988,7 +1987,7 @@ msgid "Save"
 msgstr ""
 
 #: EditionNavBar.html account/observations.html
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#: books/mybooks_breadcrumb_select.html
 msgid "Reviews"
 msgstr ""
 
@@ -2238,7 +2237,6 @@ msgid "Click on a bar to see matching works"
 msgstr ""
 
 #: account/sidebar.html books/mybooks_breadcrumb_select.html
-#: openlibrary/plugins/upstream/mybooks.py
 msgid "My Feed"
 msgstr ""
 
@@ -2677,7 +2675,7 @@ msgstr ""
 msgid "Failed"
 msgstr ""
 
-#: admin/imports_by_date.html openlibrary/core/edits.py
+#: admin/imports_by_date.html
 msgid "Pending"
 msgstr ""
 
@@ -2807,7 +2805,7 @@ msgstr ""
 msgid "Star Rating Patrons"
 msgstr ""
 
-#: admin/index.html home/stats.html
+#: admin/index.html
 msgid "Unique Visitors"
 msgstr ""
 
@@ -2889,8 +2887,7 @@ msgid "Admin Center"
 msgstr ""
 
 #: RelatedSubjects.html SubjectTags.html admin/menu.html
-#: admin/people/index.html admin/people/view.html
-#: openlibrary/plugins/worksearch/code.py type/author/view.html
+#: admin/people/index.html admin/people/view.html type/author/view.html
 #: type/list/view_body.html
 msgid "People"
 msgstr ""
@@ -3396,7 +3393,7 @@ msgid "Anonymize Account"
 msgstr ""
 
 #: admin/people/view.html books/mybooks_breadcrumb_select.html
-#: openlibrary/plugins/upstream/account.py type/user/view.html
+#: type/user/view.html
 msgid "Loans"
 msgstr ""
 
@@ -4146,51 +4143,39 @@ msgid "in %(languagelist)s"
 msgstr ""
 
 #: SearchNavigation.html books/mybooks_breadcrumb_select.html lib/nav_foot.html
-#: openlibrary/plugins/upstream/mybooks.py
 msgid "Books"
 msgstr ""
 
-#. Page title for the "Want to Read" shelf page.
-#. Example: "Want to Read (17)". %(count)d is the number of books on this
-#. shelf.
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#: books/mybooks_breadcrumb_select.html
 #, python-format
 msgid "Want to Read (%(count)d)"
 msgstr ""
 
-#. Page title for the "Currently Reading" shelf page.
-#. Example: "Currently Reading (42)". %(count)d is the number of books on this
-#. shelf.
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#: books/mybooks_breadcrumb_select.html
 #, python-format
 msgid "Currently Reading (%(count)d)"
 msgstr ""
 
-#. Page title for the "Already Read" shelf page.
-#. Example: "Already Read (203)". %(count)d is the number of books on this
-#. shelf.
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#: books/mybooks_breadcrumb_select.html
 #, python-format
 msgid "Already Read (%(count)d)"
 msgstr ""
 
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#: books/mybooks_breadcrumb_select.html
 #, python-format
 msgid "Stopped Reading (%(count)d)"
 msgstr ""
 
 #: books/mybooks_breadcrumb_select.html
-#: openlibrary/plugins/openlibrary/lists.py
 #, python-format
 msgid "Lists (%(count)d)"
 msgstr ""
 
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
-#: type/edition/modal_links.html
+#: books/mybooks_breadcrumb_select.html type/edition/modal_links.html
 msgid "Notes"
 msgstr ""
 
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
+#: books/mybooks_breadcrumb_select.html
 msgid "Imports and Exports"
 msgstr ""
 
@@ -5085,7 +5070,7 @@ msgstr[1] ""
 msgid "Welcome to Open Library"
 msgstr ""
 
-#: home/index.html openlibrary/plugins/openlibrary/api.py
+#: home/index.html
 msgid "Classic Books"
 msgstr ""
 
@@ -5093,21 +5078,19 @@ msgstr ""
 msgid "Recently Returned"
 msgstr ""
 
-#: home/index.html openlibrary/plugins/openlibrary/api.py
-#: openlibrary/plugins/openlibrary/home.py
+#: home/index.html
 msgid "Romance"
 msgstr ""
 
-#: home/index.html openlibrary/plugins/openlibrary/api.py
+#: home/index.html
 msgid "Kids"
 msgstr ""
 
-#: home/index.html openlibrary/plugins/openlibrary/api.py
+#: home/index.html
 msgid "Thrillers"
 msgstr ""
 
-#: home/index.html openlibrary/plugins/openlibrary/api.py
-#: openlibrary/plugins/openlibrary/home.py
+#: home/index.html
 msgid "Textbooks"
 msgstr ""
 
@@ -5144,14 +5127,6 @@ msgstr ""
 msgid ""
 "Here's what's happened over the last 28 days. More <a "
 "href=\"/recentchanges\">recent changes</a>"
-msgstr ""
-
-#: home/stats.html
-msgid "See all visitors to OpenLibrary.org"
-msgstr ""
-
-#: home/stats.html
-msgid "Area graph of recent unique visitors"
 msgstr ""
 
 #: home/stats.html
@@ -5428,7 +5403,7 @@ msgstr ""
 msgid "Just a sentence or two is good."
 msgstr ""
 
-#: lib/nav_foot.html openlibrary/plugins/openlibrary/api.py site/head.html
+#: lib/nav_foot.html site/head.html
 msgid "Open Library"
 msgstr ""
 
@@ -5489,8 +5464,8 @@ msgid "Explore subjects"
 msgstr ""
 
 #: RelatedSubjects.html SearchNavigation.html SubjectTags.html
-#: lib/nav_foot.html lib/nav_head.html openlibrary/plugins/worksearch/code.py
-#: subjects/notfound.html type/author/view.html type/list/view_body.html
+#: lib/nav_foot.html lib/nav_head.html subjects/notfound.html
+#: type/author/view.html type/list/view_body.html
 msgid "Subjects"
 msgstr ""
 
@@ -6108,11 +6083,11 @@ msgstr ""
 msgid "Request Status"
 msgstr ""
 
-#: merge_request_table/table_header.html openlibrary/core/edits.py
+#: merge_request_table/table_header.html
 msgid "Merged"
 msgstr ""
 
-#: merge_request_table/table_header.html openlibrary/core/edits.py
+#: merge_request_table/table_header.html
 msgid "Declined"
 msgstr ""
 
@@ -6404,8 +6379,8 @@ msgstr ""
 msgid "Publisher: %(name)s"
 msgstr ""
 
-#: openlibrary/plugins/worksearch/code.py publishers/view.html
-#: search/advancedsearch.html type/edition/view.html type/work/view.html
+#: publishers/view.html search/advancedsearch.html type/edition/view.html
+#: type/work/view.html
 msgid "Publisher"
 msgstr ""
 
@@ -7170,8 +7145,8 @@ msgstr ""
 msgid "— Show <a href=\"%(url)s\">everything</a> by this author?"
 msgstr ""
 
-#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py
-#: type/author/view.html type/list/view_body.html
+#: RelatedSubjects.html SubjectTags.html type/author/view.html
+#: type/list/view_body.html
 msgid "Places"
 msgstr ""
 
@@ -7305,8 +7280,7 @@ msgstr ""
 msgid "Search for other books from %(publisher)s"
 msgstr ""
 
-#: openlibrary/plugins/worksearch/code.py type/edition/view.html
-#: type/work/view.html
+#: type/edition/view.html type/work/view.html
 msgid "Language"
 msgstr ""
 
@@ -7645,8 +7619,7 @@ msgstr ""
 msgid "Derived from seed metadata"
 msgstr ""
 
-#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py
-#: type/list/view_body.html
+#: RelatedSubjects.html SubjectTags.html type/list/view_body.html
 msgid "Times"
 msgstr ""
 
@@ -8551,401 +8524,5 @@ msgstr ""
 #: databarWork.html
 #, python-format
 msgid "View Volume %(num)d"
-msgstr ""
-
-#: openlibrary/core/bookshelves.py
-msgid "[Record deleted]"
-msgstr ""
-
-#: openlibrary/core/edits.py
-msgid "Unknown"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/api.py
-msgid "Search Results"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Arabic"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Czech"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "German"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "English"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Spanish"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "French"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Hindi"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Croatian"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Italian"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Portuguese"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Romanian"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Sardinian"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Telugu"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Ukrainian"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Chinese"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Filipino"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Art"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Science Fiction"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Fantasy"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Biographies"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Recipes"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Children"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Medicine"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Religion"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Mystery and Detective Stories"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Plays"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Music"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "At least 1 subject"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "At least 1 author"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "At least 1 edition"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "Has work (orphaned)"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "Has publication year"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "Has cover"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "Has language"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "Has publisher"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "At least 2 editions"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "Has dewey decimal"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "Has LoC classification"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "Has number of pages"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/lists.py
-#, python-format
-msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/partials.py
-msgid "Better World Books"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/partials.py
-msgid " - includes shipping"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/partials.py
-msgid "Amazon"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/partials.py
-msgid "Bookshop.org"
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/partials.py
-msgid "This work does not appear on any lists."
-msgstr ""
-
-#: openlibrary/plugins/openlibrary/pd.py
-msgid "I don't have one yet"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "The email address you entered is invalid"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "This account has been blocked"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "This account has been locked"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "No account was found with this email. Please try again"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "The password you entered is incorrect. Please try again"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Wrong password. Please try again"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Please verify your Open Library account before logging in"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Please verify your Internet Archive account before logging in"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Please fill out all fields and try again"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "This email is already registered"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "This username is already registered"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "A problem occurred and we were unable to log you in."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Login attempted with invalid Internet Archive s3 credentials."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid ""
-"Servers are experiencing unusually high traffic, please try again later "
-"or email openlibrary@archive.org for help."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Email provider not recognized."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Password requirements not met."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "A problem occurred and we were unable to log you in"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid ""
-"Login or registration attempt hit an unexpected error, please try again "
-"or contact info@archive.org"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-#, python-format
-msgid "Request failed with error code: %(error_code)s"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid ""
-"Thank you for registering an Open Library account and requesting special "
-"print disability access. You should receive an email detailing next steps"
-" in the process."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Username unavailable"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-#: openlibrary/plugins/upstream/forms.py
-msgid "Email already registered"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "An Internet Archive account already exists with this email"
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid ""
-"Verification failed. The link may be invalid or expired. Please try "
-"registering again."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Your email has been verified. You are now logged in."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Notification preferences have been updated successfully."
-msgstr ""
-
-#: openlibrary/plugins/upstream/borrow.py
-msgid "this book"
-msgstr ""
-
-#: openlibrary/plugins/upstream/borrow.py
-#, python-format
-msgid "Unable to return %s. Please try again later or contact info@archive.org."
-msgstr ""
-
-#: openlibrary/plugins/upstream/borrow.py
-#, python-format
-msgid "%s has been returned."
-msgstr ""
-
-#: openlibrary/plugins/upstream/borrow.py
-msgid ""
-"Your account has hit a lending limit. Please try again later or contact "
-"info@archive.org."
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Username"
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "No user registered with this email address"
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Disposable email not permitted"
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Your email provider is not recognized."
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Username already used"
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Must be between 3 and 20 letters and numbers"
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Screen Name"
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Public and cannot be changed later."
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Invalid password"
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Your email address"
-msgstr ""
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Choose a password"
-msgstr ""
-
-#: openlibrary/plugins/upstream/mybooks.py
-#, python-format
-msgid ""
-"Continue <a href=\"%(url)s\" class=\"pending-action-link\" data-"
-"action=\"%(raw_action)s\"><strong>%(action)s</strong> "
-"<em>%(name)s</em></a>"
-msgstr ""
-
-#: openlibrary/plugins/worksearch/code.py
-msgid "eBook?"
-msgstr ""
-
-#: openlibrary/plugins/worksearch/code.py
-msgid "First published"
-msgstr ""
-
-#: openlibrary/plugins/worksearch/code.py
-msgid "Classic eBooks"
 msgstr ""
 

--- a/openlibrary/plugins/openlibrary/js/graphs/plot.js
+++ b/openlibrary/plugins/openlibrary/js/graphs/plot.js
@@ -217,7 +217,8 @@ export function plot_tooltip_graph(node, data, tooltip_message, color='#748d36')
             fontSize: '11px',
             webkitBoxShadow: '1px 1px 3px #333',
             mozBoxShadow: '1px 1px 1px #000',
-            boxShadow: '1px 1px 1px #000'
+            boxShadow: '1px 1px 1px #000',
+            'z-index': 100
         }).appendTo('body').fadeIn(200);
     }
     node.bind('plothover', function(event, pos, item) {

--- a/openlibrary/templates/admin/index.html
+++ b/openlibrary/templates/admin/index.html
@@ -245,8 +245,7 @@ $ }
 
   <div class="clearfix"></div>
 
-  $# Conditional check since the graphite source is currently unreliable, hiding the stat when it returns nothing
-  $if counts.get("visitors") and counts["visitors"].get_summary(28):
+  $if counts["visitors"].get_summary(28):
     <h2>$_("Unique Visitors")</h2>
     <img alt="$_('Unique visitors IPs per day graph')" src="https://graphite.us.archive.org/render/?min=0&template=plain&lineMode=staircase&areaMode=stacked&areaAlpha=0.5&yAxisSide=right&title=openlibrary+++Unique+IPs+per+day+++(uip_openlibrary)&hideLegend=true&target=cactiStyle(alias(summarize(sumSeries(group(stats.uniqueips.openlibrary)),%221day%22),%22openlibrary+++Unique+IPs+per+day+++(uip_openlibrary)%22))&colorList=00ff00&height=200&width=900&from=-60days"/>
 

--- a/openlibrary/templates/admin/index.html
+++ b/openlibrary/templates/admin/index.html
@@ -245,8 +245,10 @@ $ }
 
   <div class="clearfix"></div>
 
-  <h2>$_("Unique Visitors")</h2>
-  <img alt="$_('Unique visitors IPs per day graph')" src="https://graphite.us.archive.org/render/?min=0&template=plain&lineMode=staircase&areaMode=stacked&areaAlpha=0.5&yAxisSide=right&title=openlibrary+++Unique+IPs+per+day+++(uip_openlibrary)&hideLegend=true&target=cactiStyle(alias(summarize(sumSeries(group(stats.uniqueips.openlibrary)),%221day%22),%22openlibrary+++Unique+IPs+per+day+++(uip_openlibrary)%22))&colorList=00ff00&height=200&width=900&from=-60days"/>
+  $# Conditional check since the graphite source is currently unreliable, hiding the stat when it returns nothing
+  $if counts.get("visitors") and counts["visitors"].get_summary(28):
+    <h2>$_("Unique Visitors")</h2>
+    <img alt="$_('Unique visitors IPs per day graph')" src="https://graphite.us.archive.org/render/?min=0&template=plain&lineMode=staircase&areaMode=stacked&areaAlpha=0.5&yAxisSide=right&title=openlibrary+++Unique+IPs+per+day+++(uip_openlibrary)&hideLegend=true&target=cactiStyle(alias(summarize(sumSeries(group(stats.uniqueips.openlibrary)),%221day%22),%22openlibrary+++Unique+IPs+per+day+++(uip_openlibrary)%22))&colorList=00ff00&height=200&width=900&from=-60days"/>
 
   <h2>$_("Borrows")</h2>
   <img alt="$_('Borrows, last 3 months graph')" src="https://graphite.us.archive.org/render?target=hitcount(stats.ol.loans.bookreader,%221d%22)&from=-3months&tz=UTC&width=900"/>

--- a/openlibrary/templates/home/stats.html
+++ b/openlibrary/templates/home/stats.html
@@ -7,43 +7,39 @@ $if stats:
       </div>
 
       <div id="home-stats-charts">
-        $# <div class="statschart">
-        $#   <div class="chartShow" onclick="window.location.href='//archive.org/stats';" title="$_('See all visitors to OpenLibrary.org')">
-        $#     <div id="visitors-graph" style="width:150px;height:60px;" title="$_('Area graph of recent unique visitors')"></div>
-        $#     <a href="//archive.org/stats" title="$_('See all visitors to OpenLibrary.org')"><span class="ticks">$:commify(stats["visitors"].get_summary(28))</span><span class="label">$_('Unique Visitors')</span></a>
-        $#   </div>
-        $# </div>
+        $# Conditional check since the graphite source is currently unreliable, hiding the stat when it returns nothing
+        $if stats["visitors"].get_summary(28):
+          <div class="statschart" onclick="window.location.href='//archive.org/stats';" title="$_('See all visitors to OpenLibrary.org')">
+            <div id="visitors-graph" style="width:150px;height:60px;" title="$_('Area graph of recent unique visitors')"></div>
+            <a href="//archive.org/stats" title="$_('See all visitors to OpenLibrary.org')"><span class="ticks">$:commify(stats["visitors"].get_summary(28))</span><span class="label">$_('Unique Visitors')</span></a>
+          </div>
 
-        <div class="statschart">
-          <div class="chartShow" onclick="window.location.href='/stats';" title="$_('How many new Open Library members have we welcomed?')">
-            <div id="members-graph" style="width:150px;height:60px;" title="$_('Area graph of new members')"></div>
-            <a href="/stats" title="$_('How many new Open Library members have we welcomed?')"><span class="ticks">$:commify(stats["members"].get_summary(28))</span><span class="label">$_('New Members')</span></a>
-          </div>
-        </div>
-        <div class="statschart">
-          <div class="chartShow" onclick="window.location.href='/recentchanges';" title="$_('People are constantly updating the catalog')">
-            <div id="edits-graph" style="width:150px;height:60px;" title="$_('Area graph of recent catalog edits')"></div>
-            <a href="/recentchanges" title="$_('People are constantly updating the catalog')"><span class="ticks">$:commify(stats["human_edits"].get_summary(28))</span><span class="label">$_('Catalog Edits')</span></a>
-          </div>
+        <div class="statschart" onclick="window.location.href='/stats';" title="$_('How many new Open Library members have we welcomed?')">
+          <div id="members-graph" style="width:150px;height:60px;" title="$_('Area graph of new members')"></div>
+          <a href="/stats" title="$_('How many new Open Library members have we welcomed?')"><span class="ticks">$:commify(stats["members"].get_summary(28))</span><span class="label">$_('New Members')</span></a>
         </div>
 
-        <div class="statschart">
-          <div class="chartShow" onclick="window.location.href='/lists';" title="$_('Members can create Lists')">
-            <div id="lists-graph" style="width:150px;height:60px;" title="$_('Area graph of lists created recently')"></div>
-            <a href="/lists" title="$_('Members can create Lists')"><span class="ticks">$:commify(stats["lists"].get_summary(28))</span><span class="label">$_('Lists Created')</span></a>
-          </div>
+        <div class="statschart" onclick="window.location.href='/recentchanges';" title="$_('People are constantly updating the catalog')">
+          <div id="edits-graph" style="width:150px;height:60px;" title="$_('Area graph of recent catalog edits')"></div>
+          <a href="/recentchanges" title="$_('People are constantly updating the catalog')"><span class="ticks">$:commify(stats["human_edits"].get_summary(28))</span><span class="label">$_('Catalog Edits')</span></a>
         </div>
 
-        <div class="statschart">
-          <div class="chartShow" onclick="window.location.href='/stats';" title="$_('We\'re a library, so we lend books, too')">
-            <div id="ebooks-graph" style="width:150px;height:60px;" title="$_('Area graph of ebooks borrowed recently')"></div>
-            <a href="/subjects/in_library#ebooks=true" title="$_('We\'re a library, so we lend books, too')"><span class="ticks">$:commify(stats["loans"].get_summary(28))</span><span class="label">$_('eBooks Borrowed')</span></a>
-          </div>
+        <div class="statschart" onclick="window.location.href='/lists';" title="$_('Members can create Lists')">
+          <div id="lists-graph" style="width:150px;height:60px;" title="$_('Area graph of lists created recently')"></div>
+          <a href="/lists" title="$_('Members can create Lists')"><span class="ticks">$:commify(stats["lists"].get_summary(28))</span><span class="label">$_('Lists Created')</span></a>
         </div>
+
+        <div class="statschart" onclick="window.location.href='/stats';" title="$_('We\'re a library, so we lend books, too')">
+          <div id="ebooks-graph" style="width:150px;height:60px;" title="$_('Area graph of ebooks borrowed recently')"></div>
+          <a href="/subjects/in_library#ebooks=true" title="$_('We\'re a library, so we lend books, too')"><span class="ticks">$:commify(stats["loans"].get_summary(28))</span><span class="label">$_('eBooks Borrowed')</span></a>
+        </div>
+        
       </div>
     </div>
 
-    $# <script type="text/json+graph" id="graph-json-visitors-graph">$:json_encode(stats["visitors"].get_counts(28, True))</script>
+    $# Conditional check since the graphite source is currently unreliable, hiding the stat when it returns nothing
+    $if stats["visitors"].get_summary(28):
+      <script type="text/json+graph" id="graph-json-visitors-graph">$:json_encode(stats["visitors"].get_counts(28, True))</script>
     <script type="text/json+graph" id="graph-json-members-graph">$:json_encode(stats["members"].get_counts(28, True))</script>
     <script type="text/json+graph" id="graph-json-edits-graph">$:json_encode(stats["human_edits"].get_counts(28, True))</script>
     <script type="text/json+graph" id="graph-json-lists-graph">$:json_encode(stats["lists"].get_counts(28, True))</script>

--- a/openlibrary/templates/home/stats.html
+++ b/openlibrary/templates/home/stats.html
@@ -7,12 +7,12 @@ $if stats:
       </div>
 
       <div id="home-stats-charts">
-        <div class="statschart">
-          <div class="chartShow" onclick="window.location.href='//archive.org/stats';" title="$_('See all visitors to OpenLibrary.org')">
-            <div id="visitors-graph" style="width:150px;height:60px;" title="$_('Area graph of recent unique visitors')"></div>
-            <a href="//archive.org/stats" title="$_('See all visitors to OpenLibrary.org')"><span class="ticks">$:commify(stats["visitors"].get_summary(28))</span><span class="label">$_('Unique Visitors')</span></a>
-          </div>
-        </div>
+        $# <div class="statschart">
+        $#   <div class="chartShow" onclick="window.location.href='//archive.org/stats';" title="$_('See all visitors to OpenLibrary.org')">
+        $#     <div id="visitors-graph" style="width:150px;height:60px;" title="$_('Area graph of recent unique visitors')"></div>
+        $#     <a href="//archive.org/stats" title="$_('See all visitors to OpenLibrary.org')"><span class="ticks">$:commify(stats["visitors"].get_summary(28))</span><span class="label">$_('Unique Visitors')</span></a>
+        $#   </div>
+        $# </div>
 
         <div class="statschart">
           <div class="chartShow" onclick="window.location.href='/stats';" title="$_('How many new Open Library members have we welcomed?')">
@@ -43,7 +43,7 @@ $if stats:
       </div>
     </div>
 
-    <script type="text/json+graph" id="graph-json-visitors-graph">$:json_encode(stats["visitors"].get_counts(28, True))</script>
+    $# <script type="text/json+graph" id="graph-json-visitors-graph">$:json_encode(stats["visitors"].get_counts(28, True))</script>
     <script type="text/json+graph" id="graph-json-members-graph">$:json_encode(stats["members"].get_counts(28, True))</script>
     <script type="text/json+graph" id="graph-json-edits-graph">$:json_encode(stats["human_edits"].get_counts(28, True))</script>
     <script type="text/json+graph" id="graph-json-lists-graph">$:json_encode(stats["lists"].get_counts(28, True))</script>

--- a/openlibrary/templates/home/stats.html
+++ b/openlibrary/templates/home/stats.html
@@ -7,7 +7,6 @@ $if stats:
       </div>
 
       <div id="home-stats-charts">
-        $# Conditional check since the graphite source is currently unreliable, hiding the stat when it returns nothing
         $if stats["visitors"].get_summary(28):
           <div class="statschart" onclick="window.location.href='//archive.org/stats';" title="$_('See all visitors to OpenLibrary.org')">
             <div id="visitors-graph" style="width:150px;height:60px;" title="$_('Area graph of recent unique visitors')"></div>
@@ -37,7 +36,6 @@ $if stats:
       </div>
     </div>
 
-    $# Conditional check since the graphite source is currently unreliable, hiding the stat when it returns nothing
     $if stats["visitors"].get_summary(28):
       <script type="text/json+graph" id="graph-json-visitors-graph">$:json_encode(stats["visitors"].get_counts(28, True))</script>
     <script type="text/json+graph" id="graph-json-members-graph">$:json_encode(stats["members"].get_counts(28, True))</script>

--- a/openlibrary/templates/home/stats.html
+++ b/openlibrary/templates/home/stats.html
@@ -33,7 +33,7 @@ $if stats:
           <div id="ebooks-graph" style="width:150px;height:60px;" title="$_('Area graph of ebooks borrowed recently')"></div>
           <a href="/subjects/in_library#ebooks=true" title="$_('We\'re a library, so we lend books, too')"><span class="ticks">$:commify(stats["loans"].get_summary(28))</span><span class="label">$_('eBooks Borrowed')</span></a>
         </div>
-        
+
       </div>
     </div>
 

--- a/openlibrary/templates/home/stats.html
+++ b/openlibrary/templates/home/stats.html
@@ -8,31 +8,39 @@ $if stats:
 
       <div id="home-stats-charts">
         $if stats["visitors"].get_summary(28):
-          <div class="statschart" onclick="window.location.href='//archive.org/stats';" title="$_('See all visitors to OpenLibrary.org')">
-            <div id="visitors-graph" style="width:150px;height:60px;" title="$_('Area graph of recent unique visitors')"></div>
-            <a href="//archive.org/stats" title="$_('See all visitors to OpenLibrary.org')"><span class="ticks">$:commify(stats["visitors"].get_summary(28))</span><span class="label">$_('Unique Visitors')</span></a>
+          <div class="statschart">
+            <div class="chartShow" onclick="window.location.href='//archive.org/stats';" title="$_('See all visitors to OpenLibrary.org')">
+              <div id="visitors-graph" class="chart-graph" title="$_('Area graph of recent unique visitors')"></div>
+              <a href="//archive.org/stats" title="$_('See all visitors to OpenLibrary.org')"><span class="ticks">$:commify(stats["visitors"].get_summary(28))</span><span class="label">$_('Unique Visitors')</span></a>
+            </div>
           </div>
 
-        <div class="statschart" onclick="window.location.href='/stats';" title="$_('How many new Open Library members have we welcomed?')">
-          <div id="members-graph" style="width:150px;height:60px;" title="$_('Area graph of new members')"></div>
-          <a href="/stats" title="$_('How many new Open Library members have we welcomed?')"><span class="ticks">$:commify(stats["members"].get_summary(28))</span><span class="label">$_('New Members')</span></a>
+        <div class="statschart">
+          <div class="chartShow" onclick="window.location.href='/stats';" title="$_('How many new Open Library members have we welcomed?')">
+            <div id="members-graph" class="chart-graph" title="$_('Area graph of new members')"></div>
+            <a href="/stats" title="$_('How many new Open Library members have we welcomed?')"><span class="ticks">$:commify(stats["members"].get_summary(28))</span><span class="label">$_('New Members')</span></a>
+          </div>
+        </div>
+        <div class="statschart">
+          <div class="chartShow" onclick="window.location.href='/recentchanges';" title="$_('People are constantly updating the catalog')">
+            <div id="edits-graph" class="chart-graph" title="$_('Area graph of recent catalog edits')"></div>
+            <a href="/recentchanges" title="$_('People are constantly updating the catalog')"><span class="ticks">$:commify(stats["human_edits"].get_summary(28))</span><span class="label">$_('Catalog Edits')</span></a>
+          </div>
         </div>
 
-        <div class="statschart" onclick="window.location.href='/recentchanges';" title="$_('People are constantly updating the catalog')">
-          <div id="edits-graph" style="width:150px;height:60px;" title="$_('Area graph of recent catalog edits')"></div>
-          <a href="/recentchanges" title="$_('People are constantly updating the catalog')"><span class="ticks">$:commify(stats["human_edits"].get_summary(28))</span><span class="label">$_('Catalog Edits')</span></a>
+        <div class="statschart">
+          <div class="chartShow" onclick="window.location.href='/lists';" title="$_('Members can create Lists')">
+            <div id="lists-graph" class="chart-graph" title="$_('Area graph of lists created recently')"></div>
+            <a href="/lists" title="$_('Members can create Lists')"><span class="ticks">$:commify(stats["lists"].get_summary(28))</span><span class="label">$_('Lists Created')</span></a>
+          </div>
         </div>
 
-        <div class="statschart" onclick="window.location.href='/lists';" title="$_('Members can create Lists')">
-          <div id="lists-graph" style="width:150px;height:60px;" title="$_('Area graph of lists created recently')"></div>
-          <a href="/lists" title="$_('Members can create Lists')"><span class="ticks">$:commify(stats["lists"].get_summary(28))</span><span class="label">$_('Lists Created')</span></a>
+        <div class="statschart">
+          <div class="chartShow" onclick="window.location.href='/stats';" title="$_('We\'re a library, so we lend books, too')">
+            <div id="ebooks-graph" class="chart-graph" title="$_('Area graph of ebooks borrowed recently')"></div>
+            <a href="/subjects/in_library#ebooks=true" title="$_('We\'re a library, so we lend books, too')"><span class="ticks">$:commify(stats["loans"].get_summary(28))</span><span class="label">$_('eBooks Borrowed')</span></a>
+          </div>
         </div>
-
-        <div class="statschart" onclick="window.location.href='/stats';" title="$_('We\'re a library, so we lend books, too')">
-          <div id="ebooks-graph" style="width:150px;height:60px;" title="$_('Area graph of ebooks borrowed recently')"></div>
-          <a href="/subjects/in_library#ebooks=true" title="$_('We\'re a library, so we lend books, too')"><span class="ticks">$:commify(stats["loans"].get_summary(28))</span><span class="label">$_('eBooks Borrowed')</span></a>
-        </div>
-
       </div>
     </div>
 

--- a/static/css/components/home.css
+++ b/static/css/components/home.css
@@ -46,8 +46,7 @@ div.tutorial__item img {
 }
 
 /* stylelint-disable selector-max-specificity */
-div.chartHome a:hover,
-#home-stats-charts .statschart:hover a {
+div.chartHome a:hover {
   color: var(--link-blue);
   text-decoration: underline;
 }
@@ -72,6 +71,11 @@ div.chartHome a:hover,
 #home-stats-charts .statschart a {
   color: var(--black);
   text-decoration: none;
+}
+
+#home-stats-charts .statschart:hover a {
+  color: var(--link-blue);
+  text-decoration: underline;
 }
 
 #home-stats-charts .statschart a span {

--- a/static/css/components/home.css
+++ b/static/css/components/home.css
@@ -46,7 +46,8 @@ div.tutorial__item img {
 }
 
 /* stylelint-disable selector-max-specificity */
-div.chartHome a:hover {
+div.chartHome a:hover,
+#home-stats-charts .statschart:hover a {
   color: var(--link-blue);
   text-decoration: underline;
 }
@@ -54,28 +55,35 @@ div.chartHome a:hover {
 #home-stats-charts {
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-between;
 }
 
 #home-stats-charts .statschart {
+  flex: 1;
   height: 110px;
   text-align: center;
+  padding: 1px;
+}
+
+/* stylelint-disable-next-line max-nesting-depth */
+#home-stats-charts .statschart .chartShow {
+  width: 145px;
+  height: 60px;
   margin: 0 var(--spacing-inline-sm);
+  border-bottom: 1px solid var(--grey);
   cursor: pointer;
 }
 
-#home-stats-charts .statschart div {
-  border-bottom: 1px solid var(--grey);
+/* stylelint-disable-next-line max-nesting-depth */
+#home-stats-charts .statschart .chartShow .chart-graph {
+  width: 150px;
+  height: 60px;
 }
 
+/* stylelint-disable no-descending-specificity */
+/* stylelint-disable max-nesting-depth */
 #home-stats-charts .statschart a {
   color: var(--black);
   text-decoration: none;
-}
-
-#home-stats-charts .statschart:hover a {
-  color: var(--link-blue);
-  text-decoration: underline;
 }
 
 #home-stats-charts .statschart a span {
@@ -95,6 +103,8 @@ div.chartHome a:hover {
   font-size: 0.625em;
   text-transform: uppercase;
 }
+/* stylelint-enable no-descending-specificity */
+/* stylelint-enable max-nesting-depth */
 
 #home-resource {
   font-size: 13px;

--- a/static/css/components/home.css
+++ b/static/css/components/home.css
@@ -55,26 +55,20 @@ div.chartHome a:hover,
 #home-stats-charts {
   display: flex;
   flex-wrap: wrap;
+  justify-content: space-between;
 }
 
 #home-stats-charts .statschart {
-  flex: 1;
   height: 110px;
   text-align: center;
-  padding: 1px;
-}
-
-/* stylelint-disable-next-line max-nesting-depth */
-#home-stats-charts .statschart .chartShow {
-  width: 145px;
-  height: 60px;
   margin: 0 var(--spacing-inline-sm);
-  border-bottom: 1px solid var(--grey);
   cursor: pointer;
 }
 
-/* stylelint-disable no-descending-specificity */
-/* stylelint-disable max-nesting-depth */
+#home-stats-charts .statschart div {
+  border-bottom: 1px solid var(--grey);
+}
+
 #home-stats-charts .statschart a {
   color: var(--black);
   text-decoration: none;
@@ -97,8 +91,6 @@ div.chartHome a:hover,
   font-size: 0.625em;
   text-transform: uppercase;
 }
-/* stylelint-enable no-descending-specificity */
-/* stylelint-enable max-nesting-depth */
 
 #home-resource {
   font-size: 13px;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #12823

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Dynamically hides the Unique Visitors stats charts on the homepage and the admin dashboard when visitor counts data is not available (such as when the upstream archive.org Graphite pipeline is down).

### Technical
<!-- What should be noted about the implementation? -->
- Wrapped the Unique Visitors chart and JSON embed script in `openlibrary/templates/home/stats.html` and on the admin stats page `openlibrary/templates/admin/index.html`  with a `$if stats["visitors"].get_summary(28):` template conditional.
- Added a clarifying comment note above the conditional blocks: `$# Conditional check since the graphite source is currently unreliable, hiding the stat when it returns nothing`.
- Added a `timeout=5` parameter to the Graphite request in `openlibrary/core/admin.py` to prevent hangs when the Graphite server is down.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Verify style checks:
```bash
pre-commit run --files openlibrary/core/admin.py openlibrary/templates/home/stats.html openlibrary/templates/admin/index.html
```

### Screenshot
With valid response,
<img width="1088" height="293" alt="image" src="https://github.com/user-attachments/assets/990996e8-353f-447d-858a-e599f51a12db" />

With missing/invalid response,
<img width="1303" height="321" alt="image" src="https://github.com/user-attachments/assets/bf5a2f01-b966-4684-9036-2782525d914b" />

---

### Follow-up (Ada, on behalf of Mek): narrowed the diff + fixed a tooltip bug

Mek's review asked for a smaller, more surgical diff than the one above — see [this thread](https://github.com/internetarchive/openlibrary/pull/12831#issuecomment-5007886173) for the full plan. Commit `06a61c702` (pushed on top of the commits above, nothing rewritten/rebased):

- **Reverted scope creep**: the original diff removed the `.chartShow` wrapper div and its CSS rule from *all five* charts (visitors/members/edits/lists/ebooks) in `openlibrary/templates/home/stats.html` / `static/css/components/home.css`, even though only the visitors chart needed conditional rendering. Restored members/edits/lists/ebooks to master's original wrapper structure — they're unconditional, unchanged in behavior.
- **Kept** the narrow `$if stats["visitors"].get_summary(28):` gate around the visitors chart's markup and its `graph-json-visitors-graph` script tag (homepage) — confirmed the admin page's equivalent gate was already scoped correctly, no change needed there.
- **Kept** `timeout=5` on the Graphite request in `openlibrary/core/admin.py` — reasonable, in scope.
- **Moved** the pre-existing inline `style="width:150px;height:60px;"` on each `#{id}-graph` div into a shared `.chart-graph` rule in `static/css/components/home.css`.
- **Fixed a tooltip stacking bug** found while in this code: the 5 homepage sparkline tooltips (`#chartLabelA`, `plot_tooltip_graph()` in `openlibrary/plugins/openlibrary/js/graphs/plot.js`) rendered *behind* the chart because they were missing `z-index`, unlike the equivalent tooltip in `loadEditionsGraph()` in the same file (which already sets `z-index: 100`). Root cause confirmed in a real browser: `<main>` has `position: relative; z-index: 1`, which establishes a stacking context that sits above any `z-index:auto` sibling appended later to `<body>`, regardless of DOM order — explains why the tooltip (appended last, no z-index) rendered underneath. Setting `z-index: 100` (mirroring `loadEditionsGraph`'s existing tooltip) fixes it.

**Diff after the follow-up commit** is now just 4 files / ~26 insertions, ~15 deletions net:
```
openlibrary/core/admin.py                          |  5 +++--
openlibrary/plugins/openlibrary/js/graphs/plot.js  |  3 ++-
openlibrary/templates/home/stats.html              | 22 ++++++++++++----------
static/css/components/home.css                     |  6 ++++++
```
(`openlibrary/templates/admin/index.html` needed no changes — already scoped correctly.)

#### How it was tested
- **Automated**: full `make test` (Python + JS unit + i18n) green; targeted `pytest openlibrary/plugins/openlibrary/tests/test_home.py openlibrary/tests/test_templates.py` green (746 passed); `mypy` clean; `ruff`/`ruff-format`/`stylelint`/`eslint`/`codespell` all clean via `pre-commit`.
- **Browser (Playwright), homepage — normal response**: all 5 charts render identically to master, hovering a chart shows its tooltip **above** the chart (`z-index: 100`, confirmed via `getComputedStyle`), console clean (aside from a pre-existing, unrelated dev-environment Solr/LazyCarousel 500 that reproduces on master too, since the local Solr index is empty).
- **Browser (Playwright), homepage — simulated empty visitors response**: intercepted the real server response and stripped exactly the markup the `$if` gate would omit (the visitors `.statschart` block + its `graph-json-visitors-graph` script tag) to exercise the real client bundle against that DOM. Result: visitors chart cleanly absent, the other 4 charts render unchanged (same 110px row height, no layout shift), their tooltips still work and still render above the chart, console clean.
- **Admin page**: confirmed `HTTP 200`, confirmed via code/diff review that `counts["visitors"].get_summary(28)` gates the same `<h2>`+`<img>` block master renders unconditionally (no JS/tooltip attached to this element, so the risk surface is much smaller than the homepage change). **Not independently verified with an authenticated in-browser check** — `/admin` requires an admin-permissioned account and this dev sandbox doesn't have one readily available. Flagging this explicitly rather than silently skipping it, per this repo's review process.
- **a11y**: ran `pa11y` against the homepage; 6 pre-existing violations found, none related to the changed elements (header login link contrast, book-preview iframe title, colorbox button names) — no new violations introduced.
- **Secrets scan**: clean.

<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
*(Note: the two screenshots above are Sadashii's original ones. I captured fresh Playwright screenshots for the follow-up commit — including the tooltip-above-chart fix and the layout with visitors hidden — but couldn't attach them here: there's no `gh`/API path for uploading images to a PR comment from the CLI, only the web UI's drag-and-drop. Happy to hand them off if there's a preferred way to get them attached.)*

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
