### PR TITLE
Parenthesize multi-type except clauses for Python 3

### DIFF
--- a/openlibrary/accounts/__init__.py
+++ b/openlibrary/accounts/__init__.py
@@ -80,7 +80,7 @@ def get_days_registered(user) -> str:
     try:
         reg_date = user.created.date()
         days = (datetime.datetime.now(datetime.UTC).date() - reg_date).days
-    except AttributeError, TypeError:
+    except (AttributeError, TypeError):
         # If the date is incorrectly encoded, assume the patron
         # registered a long time ago before we had this set up.
         return "d90+"

--- a/openlibrary/accounts/__init__.py
+++ b/openlibrary/accounts/__init__.py
@@ -80,7 +80,7 @@ def get_days_registered(user) -> str:
     try:
         reg_date = user.created.date()
         days = (datetime.datetime.now(datetime.UTC).date() - reg_date).days
-    except (AttributeError, TypeError):
+    except AttributeError, TypeError:
         # If the date is incorrectly encoded, assume the patron
         # registered a long time ago before we had this set up.
         return "d90+"

--- a/openlibrary/catalog/add_book/match.py
+++ b/openlibrary/catalog/add_book/match.py
@@ -220,7 +220,7 @@ def compare_date(e1: dict, e2: dict) -> ThresholdResult:
         e2_pub = int(e2["publish_date"])
         if within(e1_pub, e2_pub, 2):
             return ("date", "+/-2 years", -25)
-    except ValueError, TypeError:
+    except (ValueError, TypeError):
         pass
     return ("date", "mismatch", DATE_MISMATCH)
 

--- a/openlibrary/catalog/add_book/match.py
+++ b/openlibrary/catalog/add_book/match.py
@@ -220,7 +220,7 @@ def compare_date(e1: dict, e2: dict) -> ThresholdResult:
         e2_pub = int(e2["publish_date"])
         if within(e1_pub, e2_pub, 2):
             return ("date", "+/-2 years", -25)
-    except (ValueError, TypeError):
+    except ValueError, TypeError:
         pass
     return ("date", "mismatch", DATE_MISMATCH)
 

--- a/openlibrary/catalog/utils/__init__.py
+++ b/openlibrary/catalog/utils/__init__.py
@@ -462,7 +462,7 @@ def format_languages(languages: Iterable) -> list[dict[str, str]]:
                 # Note this must be last, since it raises errors
                 or get_abbrev_from_full_lang_name(language)
             )
-        except (LanguageNoMatchError, LanguageMultipleMatchError):
+        except LanguageNoMatchError, LanguageMultipleMatchError:
             # get_abbrev_from_full_lang_name raises errors
             raise InvalidLanguage(input_lang)
 

--- a/openlibrary/catalog/utils/__init__.py
+++ b/openlibrary/catalog/utils/__init__.py
@@ -462,7 +462,7 @@ def format_languages(languages: Iterable) -> list[dict[str, str]]:
                 # Note this must be last, since it raises errors
                 or get_abbrev_from_full_lang_name(language)
             )
-        except LanguageNoMatchError, LanguageMultipleMatchError:
+        except (LanguageNoMatchError, LanguageMultipleMatchError):
             # get_abbrev_from_full_lang_name raises errors
             raise InvalidLanguage(input_lang)
 

--- a/openlibrary/core/admin.py
+++ b/openlibrary/core/admin.py
@@ -29,7 +29,7 @@ class Stats:
         try:
             # Last available total count
             self.total = next(x for x in reversed(docs) if total_key in x)[total_key]
-        except KeyError, StopIteration:
+        except (KeyError, StopIteration):
             self.total = ""
 
     def get_counts(self, ndays=28, times=False):
@@ -74,7 +74,7 @@ def _get_loan_counts_from_graphite(ndays: int) -> list[list[int]] | None:
             },
         )
         return r.json()[0]["datapoints"]
-    except requests.exceptions.RequestException, ValueError, AttributeError:
+    except (requests.exceptions.RequestException, ValueError, AttributeError):
         return None
 
 

--- a/openlibrary/core/admin.py
+++ b/openlibrary/core/admin.py
@@ -29,7 +29,7 @@ class Stats:
         try:
             # Last available total count
             self.total = next(x for x in reversed(docs) if total_key in x)[total_key]
-        except (KeyError, StopIteration):
+        except KeyError, StopIteration:
             self.total = ""
 
     def get_counts(self, ndays=28, times=False):
@@ -74,7 +74,7 @@ def _get_loan_counts_from_graphite(ndays: int) -> list[list[int]] | None:
             },
         )
         return r.json()[0]["datapoints"]
-    except (requests.exceptions.RequestException, ValueError, AttributeError):
+    except requests.exceptions.RequestException, ValueError, AttributeError:
         return None
 
 

--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -90,7 +90,7 @@ class memcache_memoize[**P, T]:
     def _generate_key_prefix(self) -> str:
         try:
             prefix = self.f.__name__ + "_"
-        except AttributeError, TypeError:
+        except (AttributeError, TypeError):
             prefix = ""
 
         return prefix + self._random_string(10)

--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -90,7 +90,7 @@ class memcache_memoize[**P, T]:
     def _generate_key_prefix(self) -> str:
         try:
             prefix = self.f.__name__ + "_"
-        except (AttributeError, TypeError):
+        except AttributeError, TypeError:
             prefix = ""
 
         return prefix + self._random_string(10)

--- a/openlibrary/core/db.py
+++ b/openlibrary/core/db.py
@@ -49,7 +49,7 @@ class CommonExtras:
                 work_id=new_work_id,
                 vars={"work_id": current_work_id},
             )
-        except (UniqueViolation, IntegrityError):
+        except UniqueViolation, IntegrityError:
             (
                 rows_changed,
                 rows_deleted,
@@ -86,7 +86,7 @@ class CommonExtras:
                 oldb.query(f"UPDATE {cls.TABLENAME} set work_id={new_work_id} where {where}")
                 rows_changed += 1
                 t_update.rollback() if _test else t_update.commit()
-            except (UniqueViolation, IntegrityError):
+            except UniqueViolation, IntegrityError:
                 t_delete = oldb.transaction()
                 # otherwise, delete row with current_work_id if failed
                 oldb.query(f"DELETE FROM {cls.TABLENAME} WHERE {where}")
@@ -118,7 +118,7 @@ class CommonExtras:
                 username=new_username,
                 vars={"username": username},
             )
-        except (UniqueViolation, IntegrityError):
+        except UniqueViolation, IntegrityError:
             # if any of the records would conflict with an exiting
             # record associated with new_username
             pass  # assuming impossible for now, not a great assumption
@@ -133,7 +133,7 @@ class CommonExtras:
 
         try:
             rows_deleted = oldb.delete(cls.TABLENAME, where="username=$username", vars={"username": username})
-        except (UniqueViolation, IntegrityError):
+        except UniqueViolation, IntegrityError:
             pass
 
         t.rollback() if _test else t.commit()

--- a/openlibrary/core/db.py
+++ b/openlibrary/core/db.py
@@ -49,7 +49,7 @@ class CommonExtras:
                 work_id=new_work_id,
                 vars={"work_id": current_work_id},
             )
-        except UniqueViolation, IntegrityError:
+        except (UniqueViolation, IntegrityError):
             (
                 rows_changed,
                 rows_deleted,
@@ -86,7 +86,7 @@ class CommonExtras:
                 oldb.query(f"UPDATE {cls.TABLENAME} set work_id={new_work_id} where {where}")
                 rows_changed += 1
                 t_update.rollback() if _test else t_update.commit()
-            except UniqueViolation, IntegrityError:
+            except (UniqueViolation, IntegrityError):
                 t_delete = oldb.transaction()
                 # otherwise, delete row with current_work_id if failed
                 oldb.query(f"DELETE FROM {cls.TABLENAME} WHERE {where}")
@@ -118,7 +118,7 @@ class CommonExtras:
                 username=new_username,
                 vars={"username": username},
             )
-        except UniqueViolation, IntegrityError:
+        except (UniqueViolation, IntegrityError):
             # if any of the records would conflict with an exiting
             # record associated with new_username
             pass  # assuming impossible for now, not a great assumption
@@ -133,7 +133,7 @@ class CommonExtras:
 
         try:
             rows_deleted = oldb.delete(cls.TABLENAME, where="username=$username", vars={"username": username})
-        except UniqueViolation, IntegrityError:
+        except (UniqueViolation, IntegrityError):
             pass
 
         t.rollback() if _test else t.commit()

--- a/openlibrary/core/edits.py
+++ b/openlibrary/core/edits.py
@@ -159,7 +159,7 @@ class CommunityEditsQueue:
                 submitter=new_username,
                 vars={"submitter": submitter},
             )
-        except (UniqueViolation, IntegrityError):
+        except UniqueViolation, IntegrityError:
             rows_changed = 0
 
         t.rollback() if _test else t.commit()

--- a/openlibrary/core/edits.py
+++ b/openlibrary/core/edits.py
@@ -159,7 +159,7 @@ class CommunityEditsQueue:
                 submitter=new_username,
                 vars={"submitter": submitter},
             )
-        except UniqueViolation, IntegrityError:
+        except (UniqueViolation, IntegrityError):
             rows_changed = 0
 
         t.rollback() if _test else t.commit()

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -80,7 +80,7 @@ class Image:
                 d["author"] = d["author"] and self._site.get(d["author"])
 
             return web.storage(d)
-        except (requests.exceptions.RequestException, OSError):
+        except requests.exceptions.RequestException, OSError:
             # coverstore is down
             return None
 

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -80,7 +80,7 @@ class Image:
                 d["author"] = d["author"] and self._site.get(d["author"])
 
             return web.storage(d)
-        except requests.exceptions.RequestException, OSError:
+        except (requests.exceptions.RequestException, OSError):
             # coverstore is down
             return None
 

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -423,7 +423,7 @@ class AmazonCreatorsAPI:
                 # AmazonCreatorsApi; replace its rest_client to route all
                 # outbound HTTP through the proxy.
                 self.api._api_client.rest_client = rest_client
-            except ImportError, AttributeError:
+            except (ImportError, AttributeError):
                 logger.warning(
                     "AmazonCreatorsAPI: could not inject proxy — falling back to environment-level proxy (HTTPS_PROXY)",
                     exc_info=True,

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -423,7 +423,7 @@ class AmazonCreatorsAPI:
                 # AmazonCreatorsApi; replace its rest_client to route all
                 # outbound HTTP through the proxy.
                 self.api._api_client.rest_client = rest_client
-            except (ImportError, AttributeError):
+            except ImportError, AttributeError:
                 logger.warning(
                     "AmazonCreatorsAPI: could not inject proxy — falling back to environment-level proxy (HTTPS_PROXY)",
                     exc_info=True,

--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -308,7 +308,7 @@ class cover:
         url = f"https://archive.org/metadata/{identifier}/metadata"
         try:
             d = requests.get(url).json().get("result", {})
-        except OSError, ValueError:
+        except (OSError, ValueError):
             return
 
         # Not a text item or no images or scan is not complete yet
@@ -351,7 +351,7 @@ class cover:
         """
         try:
             return coverid < IMAGES_PER_ITEM * config.get("max_coveritem_index", 0)
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             return False
 
     def get_tar_filename(self, coverid, size):

--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -308,7 +308,7 @@ class cover:
         url = f"https://archive.org/metadata/{identifier}/metadata"
         try:
             d = requests.get(url).json().get("result", {})
-        except (OSError, ValueError):
+        except OSError, ValueError:
             return
 
         # Not a text item or no images or scan is not complete yet
@@ -351,7 +351,7 @@ class cover:
         """
         try:
             return coverid < IMAGES_PER_ITEM * config.get("max_coveritem_index", 0)
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             return False
 
     def get_tar_filename(self, coverid, size):

--- a/openlibrary/coverstore/utils.py
+++ b/openlibrary/coverstore/utils.py
@@ -29,7 +29,7 @@ def safeint(value, default=None):
     """
     try:
         return int(value)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         return default
 
 

--- a/openlibrary/coverstore/utils.py
+++ b/openlibrary/coverstore/utils.py
@@ -29,7 +29,7 @@ def safeint(value, default=None):
     """
     try:
         return int(value)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return default
 
 

--- a/openlibrary/fastapi/cdn.py
+++ b/openlibrary/fastapi/cdn.py
@@ -23,7 +23,7 @@ async def ia_js_cdn(filename: Annotated[str, Path()]) -> Response:
         async with httpx.AsyncClient(timeout=10.0) as client:
             upstream = await client.get(UPSTREAM_BASE + filename)
             upstream.raise_for_status()  # upstream 4xx/5xx → 502 (intentional: upstream problem)
-    except (httpx.HTTPStatusError, httpx.RequestError):
+    except httpx.HTTPStatusError, httpx.RequestError:
         # HTTPStatusError: upstream returned 4xx/5xx (including 404 — upstream problem, not bad path)
         # RequestError:    network failure — timeout, DNS error, connection refused
         raise HTTPException(status_code=502, detail="Upstream fetch failed")

--- a/openlibrary/fastapi/cdn.py
+++ b/openlibrary/fastapi/cdn.py
@@ -23,7 +23,7 @@ async def ia_js_cdn(filename: Annotated[str, Path()]) -> Response:
         async with httpx.AsyncClient(timeout=10.0) as client:
             upstream = await client.get(UPSTREAM_BASE + filename)
             upstream.raise_for_status()  # upstream 4xx/5xx → 502 (intentional: upstream problem)
-    except httpx.HTTPStatusError, httpx.RequestError:
+    except (httpx.HTTPStatusError, httpx.RequestError):
         # HTTPStatusError: upstream returned 4xx/5xx (including 404 — upstream problem, not bad path)
         # RequestError:    network failure — timeout, DNS error, connection refused
         raise HTTPException(status_code=502, detail="Upstream fetch failed")

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -181,7 +181,7 @@ class work_bookshelves(delegate.page):
             shelf_ids = Bookshelves.PRESET_BOOKSHELVES.values()
             if bookshelf_id != -1 and bookshelf_id not in shelf_ids:
                 raise ValueError
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             return delegate.RawText(
                 json.dumps({"error": "Invalid bookshelf"}),
                 content_type="application/json",
@@ -821,7 +821,7 @@ class unlink_ia_ol(delegate.page):
         try:
             if not HMACToken.verify(digest, msg, "ia_sync_secret", unix_time=True):
                 raise web.HTTPError("401 Unauthorized", {"Content-Type": "application/json"})
-        except (ValueError, ExpiredTokenError):
+        except ValueError, ExpiredTokenError:
             raise web.HTTPError("401 Unauthorized", {"Content-Type": "application/json"})
 
         parts = msg.split("|", maxsplit=1)
@@ -887,7 +887,7 @@ class link_ia_ol(delegate.page):
         try:
             if not HMACToken.verify(digest, msg, "ia_sync_secret", unix_time=True):
                 raise web.HTTPError("401 Unauthorized", {"Content-Type": "application/json"})
-        except (ValueError, ExpiredTokenError):
+        except ValueError, ExpiredTokenError:
             raise web.HTTPError("401 Unauthorized", {"Content-Type": "application/json"})
 
         parts = msg.split("|", maxsplit=2)

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -181,7 +181,7 @@ class work_bookshelves(delegate.page):
             shelf_ids = Bookshelves.PRESET_BOOKSHELVES.values()
             if bookshelf_id != -1 and bookshelf_id not in shelf_ids:
                 raise ValueError
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             return delegate.RawText(
                 json.dumps({"error": "Invalid bookshelf"}),
                 content_type="application/json",
@@ -821,7 +821,7 @@ class unlink_ia_ol(delegate.page):
         try:
             if not HMACToken.verify(digest, msg, "ia_sync_secret", unix_time=True):
                 raise web.HTTPError("401 Unauthorized", {"Content-Type": "application/json"})
-        except ValueError, ExpiredTokenError:
+        except (ValueError, ExpiredTokenError):
             raise web.HTTPError("401 Unauthorized", {"Content-Type": "application/json"})
 
         parts = msg.split("|", maxsplit=1)
@@ -887,7 +887,7 @@ class link_ia_ol(delegate.page):
         try:
             if not HMACToken.verify(digest, msg, "ia_sync_secret", unix_time=True):
                 raise web.HTTPError("401 Unauthorized", {"Content-Type": "application/json"})
-        except ValueError, ExpiredTokenError:
+        except (ValueError, ExpiredTokenError):
             raise web.HTTPError("401 Unauthorized", {"Content-Type": "application/json"})
 
         parts = msg.split("|", maxsplit=2)

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -451,7 +451,7 @@ def _get_pr_info(pr_number: int) -> dict:
             "assignee": assignee.get("login", ""),
             "assignee_avatar": assignee.get("avatar_url", ""),
         }
-    except (urllib.error.URLError, KeyError, ValueError, json.JSONDecodeError):
+    except urllib.error.URLError, KeyError, ValueError, json.JSONDecodeError:
         return {
             "title": f"PR #{pr_number}",
             "head_sha": "",
@@ -479,7 +479,7 @@ def _get_pr_drift(pr: TestingPR) -> dict:
             try:
                 cmp = _github_get(f"compare/{stored}...{head_sha}")
                 drift = cmp.get("ahead_by", -1)
-            except (urllib.error.URLError, ValueError, json.JSONDecodeError):
+            except urllib.error.URLError, ValueError, json.JSONDecodeError:
                 drift = -1
         user = gh.get("user") or {}
         assignee = gh.get("assignee") or {}
@@ -493,7 +493,7 @@ def _get_pr_drift(pr: TestingPR) -> dict:
             "assignee": assignee.get("login", ""),
             "assignee_avatar": assignee.get("avatar_url", ""),
         }
-    except (urllib.error.URLError, KeyError, ValueError, json.JSONDecodeError):
+    except urllib.error.URLError, KeyError, ValueError, json.JSONDecodeError:
         return {
             "head_sha": "",
             "drift": -1,
@@ -527,7 +527,7 @@ def _trigger_rebuild() -> bool:
     try:
         urllib.request.urlopen(url, timeout=10)
         return True
-    except (urllib.error.URLError, ValueError):
+    except urllib.error.URLError, ValueError:
         return False
 
 

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -451,7 +451,7 @@ def _get_pr_info(pr_number: int) -> dict:
             "assignee": assignee.get("login", ""),
             "assignee_avatar": assignee.get("avatar_url", ""),
         }
-    except urllib.error.URLError, KeyError, ValueError, json.JSONDecodeError:
+    except (urllib.error.URLError, KeyError, ValueError, json.JSONDecodeError):
         return {
             "title": f"PR #{pr_number}",
             "head_sha": "",
@@ -479,7 +479,7 @@ def _get_pr_drift(pr: TestingPR) -> dict:
             try:
                 cmp = _github_get(f"compare/{stored}...{head_sha}")
                 drift = cmp.get("ahead_by", -1)
-            except urllib.error.URLError, ValueError, json.JSONDecodeError:
+            except (urllib.error.URLError, ValueError, json.JSONDecodeError):
                 drift = -1
         user = gh.get("user") or {}
         assignee = gh.get("assignee") or {}
@@ -493,7 +493,7 @@ def _get_pr_drift(pr: TestingPR) -> dict:
             "assignee": assignee.get("login", ""),
             "assignee_avatar": assignee.get("avatar_url", ""),
         }
-    except urllib.error.URLError, KeyError, ValueError, json.JSONDecodeError:
+    except (urllib.error.URLError, KeyError, ValueError, json.JSONDecodeError):
         return {
             "head_sha": "",
             "drift": -1,
@@ -527,7 +527,7 @@ def _trigger_rebuild() -> bool:
     try:
         urllib.request.urlopen(url, timeout=10)
         return True
-    except urllib.error.URLError, ValueError:
+    except (urllib.error.URLError, ValueError):
         return False
 
 

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -583,7 +583,7 @@ class account_validation(delegate.page):
         url = "https://archive.org/metadata/@%s" % username
         try:
             return bool(requests.get(url).json())
-        except OSError, ValueError:
+        except (OSError, ValueError):
             return
 
     @staticmethod

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -583,7 +583,7 @@ class account_validation(delegate.page):
         url = "https://archive.org/metadata/@%s" % username
         try:
             return bool(requests.get(url).json())
-        except (OSError, ValueError):
+        except OSError, ValueError:
             return
 
     @staticmethod

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -265,7 +265,7 @@ def render_cached_macro(name: str, args: tuple, **kwargs):
         if page.get("do_not_cache") == "True":
             mc.memcache_delete_by_args(name, args, **kwargs)
         return web.template.TemplateResult(page)
-    except ValueError, TypeError:
+    except (ValueError, TypeError):
         return "<span>Failed to render macro</span>"
 
 
@@ -669,7 +669,7 @@ def safeget[T](func: Callable[[], T], default=None) -> T:
     """
     try:
         return func()
-    except KeyError, IndexError, TypeError:
+    except (KeyError, IndexError, TypeError):
         return default
 
 

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -265,7 +265,7 @@ def render_cached_macro(name: str, args: tuple, **kwargs):
         if page.get("do_not_cache") == "True":
             mc.memcache_delete_by_args(name, args, **kwargs)
         return web.template.TemplateResult(page)
-    except (ValueError, TypeError):
+    except ValueError, TypeError:
         return "<span>Failed to render macro</span>"
 
 
@@ -669,7 +669,7 @@ def safeget[T](func: Callable[[], T], default=None) -> T:
     """
     try:
         return func()
-    except (KeyError, IndexError, TypeError):
+    except KeyError, IndexError, TypeError:
         return default
 
 

--- a/openlibrary/solr/data_provider.py
+++ b/openlibrary/solr/data_provider.py
@@ -139,7 +139,7 @@ class DataProvider:
             return r.json()["response"]["docs"]
         except HTTPError:
             logger.warning("IA bulk query failed")
-        except ValueError, KeyError:
+        except (ValueError, KeyError):
             logger.warning(f"IA bulk query failed {r.status_code}: {r.json()['error']}")
 
         # Only here if an exception occurred

--- a/openlibrary/solr/data_provider.py
+++ b/openlibrary/solr/data_provider.py
@@ -139,7 +139,7 @@ class DataProvider:
             return r.json()["response"]["docs"]
         except HTTPError:
             logger.warning("IA bulk query failed")
-        except (ValueError, KeyError):
+        except ValueError, KeyError:
             logger.warning(f"IA bulk query failed {r.status_code}: {r.json()['error']}")
 
         # Only here if an exception occurred

--- a/openlibrary/solr/updater/edition.py
+++ b/openlibrary/solr/updater/edition.py
@@ -199,7 +199,7 @@ class EditionSolrBuilder(AbstractSolrBuilder):
         lexile_str = self._edition.get("lexile")
         try:
             return int(lexile_str) if lexile_str else None
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             return None
 
     @property
@@ -221,7 +221,7 @@ class EditionSolrBuilder(AbstractSolrBuilder):
         number_of_pages_str = self._edition.get("number_of_pages")
         try:
             return int(number_of_pages_str) if number_of_pages_str else None
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             return None
 
     @property

--- a/openlibrary/solr/updater/edition.py
+++ b/openlibrary/solr/updater/edition.py
@@ -199,7 +199,7 @@ class EditionSolrBuilder(AbstractSolrBuilder):
         lexile_str = self._edition.get("lexile")
         try:
             return int(lexile_str) if lexile_str else None
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             return None
 
     @property
@@ -221,7 +221,7 @@ class EditionSolrBuilder(AbstractSolrBuilder):
         number_of_pages_str = self._edition.get("number_of_pages")
         try:
             return int(number_of_pages_str) if number_of_pages_str else None
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             return None
 
     @property

--- a/openlibrary/solr/updater/work.py
+++ b/openlibrary/solr/updater/work.py
@@ -253,7 +253,7 @@ def datetimestr_to_int(datestr):
     if datestr:
         try:
             t = h.parse_datetime(datestr)
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             t = datetime.datetime.now()
     else:
         t = datetime.datetime.now()

--- a/openlibrary/solr/updater/work.py
+++ b/openlibrary/solr/updater/work.py
@@ -253,7 +253,7 @@ def datetimestr_to_int(datestr):
     if datestr:
         try:
             t = h.parse_datetime(datestr)
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             t = datetime.datetime.now()
     else:
         t = datetime.datetime.now()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ markers = [
 ]
 
 [tool.ruff]
-target-version = "py314"
+target-version = "py312"
 extend-exclude = [
   "./.*",
   "vendor",

--- a/scripts/gh_scripts/issue_comment_bot.py
+++ b/scripts/gh_scripts/issue_comment_bot.py
@@ -384,7 +384,7 @@ def start_job():
         print("Reading configuration file...")
         config = read_config(args.config)
         leads = config.get("leads", [])
-    except (OSError, json.JSONDecodeError):
+    except OSError, json.JSONDecodeError:
         raise ConfigurationError("An error occurred while parsing the configuration file.")
 
     print("Fetching issues from GitHub...")

--- a/scripts/gh_scripts/issue_comment_bot.py
+++ b/scripts/gh_scripts/issue_comment_bot.py
@@ -384,7 +384,7 @@ def start_job():
         print("Reading configuration file...")
         config = read_config(args.config)
         leads = config.get("leads", [])
-    except OSError, json.JSONDecodeError:
+    except (OSError, json.JSONDecodeError):
         raise ConfigurationError("An error occurred while parsing the configuration file.")
 
     print("Fetching issues from GitHub...")

--- a/scripts/migrations/update_legacy_preferences.py
+++ b/scripts/migrations/update_legacy_preferences.py
@@ -55,7 +55,7 @@ def update_preferences(keys: list[str]) -> list[str]:
             username = key.split("/")[2]
             with RunAs(username):
                 web.ctx.site.save(new_prefs, "Updating preferences")
-        except infogami.infobase.client.ClientException, KeyError, IndexError:
+        except (infogami.infobase.client.ClientException, KeyError, IndexError):
             retry_list.append(key)
 
     return retry_list

--- a/scripts/migrations/update_legacy_preferences.py
+++ b/scripts/migrations/update_legacy_preferences.py
@@ -55,7 +55,7 @@ def update_preferences(keys: list[str]) -> list[str]:
             username = key.split("/")[2]
             with RunAs(username):
                 web.ctx.site.save(new_prefs, "Updating preferences")
-        except (infogami.infobase.client.ClientException, KeyError, IndexError):
+        except infogami.infobase.client.ClientException, KeyError, IndexError:
             retry_list.append(key)
 
     return retry_list

--- a/scripts/monitoring/monitor.py
+++ b/scripts/monitoring/monitor.py
@@ -255,5 +255,5 @@ async def main():
 if __name__ == "__main__":
     try:
         asyncio.run(main())
-    except (KeyboardInterrupt, SystemExit):
+    except KeyboardInterrupt, SystemExit:
         print("[OL-MONITOR] Monitoring stopped.", flush=True)

--- a/scripts/monitoring/monitor.py
+++ b/scripts/monitoring/monitor.py
@@ -255,5 +255,5 @@ async def main():
 if __name__ == "__main__":
     try:
         asyncio.run(main())
-    except KeyboardInterrupt, SystemExit:
+    except (KeyboardInterrupt, SystemExit):
         print("[OL-MONITOR] Monitoring stopped.", flush=True)

--- a/scripts/partner_batch_imports.py
+++ b/scripts/partner_batch_imports.py
@@ -321,7 +321,7 @@ def load_state(path, logfile):
             active_fname, offset = next(fin).strip().split(",")
             unfinished_filenames = filenames[filenames.index(active_fname) :]
             return unfinished_filenames, int(offset)
-    except ValueError, OSError:
+    except (ValueError, OSError):
         return filenames, 0
 
 

--- a/scripts/partner_batch_imports.py
+++ b/scripts/partner_batch_imports.py
@@ -321,7 +321,7 @@ def load_state(path, logfile):
             active_fname, offset = next(fin).strip().split(",")
             unfinished_filenames = filenames[filenames.index(active_fname) :]
             return unfinished_filenames, int(offset)
-    except (ValueError, OSError):
+    except ValueError, OSError:
         return filenames, 0
 
 

--- a/scripts/providers/isbndb.py
+++ b/scripts/providers/isbndb.py
@@ -152,7 +152,7 @@ def load_state(path: str, logfile: str) -> tuple[list[str], int]:
             active_fname, offset = next(fin).strip().split(",")
             unfinished_filenames = filenames[filenames.index(active_fname) :]
             return unfinished_filenames, int(offset)
-    except (ValueError, OSError):
+    except ValueError, OSError:
         return filenames, 0
 
 

--- a/scripts/providers/isbndb.py
+++ b/scripts/providers/isbndb.py
@@ -152,7 +152,7 @@ def load_state(path: str, logfile: str) -> tuple[list[str], int]:
             active_fname, offset = next(fin).strip().split(",")
             unfinished_filenames = filenames[filenames.index(active_fname) :]
             return unfinished_filenames, int(offset)
-    except ValueError, OSError:
+    except (ValueError, OSError):
         return filenames, 0
 
 

--- a/scripts/solr_dump_xisbn.py
+++ b/scripts/solr_dump_xisbn.py
@@ -56,7 +56,7 @@ async def fetch_docs(
                 )
                 response.raise_for_status()
                 break
-            except httpx.RequestError, httpx.HTTPStatusError:
+            except (httpx.RequestError, httpx.HTTPStatusError):
                 if attempt == 4:
                     raise
                 await asyncio.sleep(2)
@@ -93,7 +93,7 @@ async def stream_bounds(
                     )
                     response.raise_for_status()
                     break
-                except httpx.RequestError, httpx.HTTPStatusError:
+                except (httpx.RequestError, httpx.HTTPStatusError):
                     if attempt == 4:
                         raise
                     await asyncio.sleep(2)

--- a/scripts/solr_dump_xisbn.py
+++ b/scripts/solr_dump_xisbn.py
@@ -56,7 +56,7 @@ async def fetch_docs(
                 )
                 response.raise_for_status()
                 break
-            except (httpx.RequestError, httpx.HTTPStatusError):
+            except httpx.RequestError, httpx.HTTPStatusError:
                 if attempt == 4:
                     raise
                 await asyncio.sleep(2)
@@ -93,7 +93,7 @@ async def stream_bounds(
                     )
                     response.raise_for_status()
                     break
-                except (httpx.RequestError, httpx.HTTPStatusError):
+                except httpx.RequestError, httpx.HTTPStatusError:
                     if attempt == 4:
                         raise
                     await asyncio.sleep(2)

--- a/scripts/solr_updater/trending_updater.py
+++ b/scripts/solr_updater/trending_updater.py
@@ -84,5 +84,5 @@ async def main(
 if __name__ == "__main__":
     try:
         FnToCLI(main).run()
-    except KeyboardInterrupt, SystemExit:
+    except (KeyboardInterrupt, SystemExit):
         print("Exiting trending updater script.")

--- a/scripts/solr_updater/trending_updater.py
+++ b/scripts/solr_updater/trending_updater.py
@@ -84,5 +84,5 @@ async def main(
 if __name__ == "__main__":
     try:
         FnToCLI(main).run()
-    except (KeyboardInterrupt, SystemExit):
+    except KeyboardInterrupt, SystemExit:
         print("Exiting trending updater script.")


### PR DESCRIPTION
Closes #12827

Fix a SyntaxError that prevents the app from starting, and stop the project formatter from reverting it. [fix]

### Technical
Python 3 requires multiple exception types in an `except` clause to be parenthesized: `except (A, B):` rather than `except A, B:`. The unparenthesized form is a SyntaxError on the Python 3.12 runtime and prevents the application from importing. This corrects all 39 occurrences across 26 files.

Root cause of why this was not already fixed: `pyproject.toml` sets `target-version = "py314"`, and under that target `ruff format` rewrites `except (A, B):` to the bare `except A, B:`. The Docker runtime, however, is Python 3.12, where the bare form is invalid. So `ruff format` (and therefore pre-commit) actively re-produces the broken syntax: a parenthesize-only change gets reverted by pre-commit.ci on every push. This PR sets `target-version = "py312"` to match the current interpreter, after which `ruff format` keeps the parentheses and the fix is stable.

### Testing
Before: `python -m py_compile openlibrary/core/db.py` fails with "multiple exception types must be parenthesized". After: every module under `openlibrary/` and `scripts/` compiles cleanly, and `ruff format` no longer strips the parentheses.

### Screenshot
Not applicable (no UI change).

### Stakeholders
@RayBB

Note: this is a target/runtime mismatch. This PR aligns the ruff target to the current runtime (3.12). If the intent is instead to run on 3.14, the alternative is to upgrade the Docker base image to 3.14 so the runtime matches the existing py314 target; either way the two need to agree. Separately, the syntax fix alone does not fully boot master: import then fails with annotation NameErrors (`Locale` in openlibrary/core/helpers.py, `Site` in openlibrary/utils/request_context.py) because commit 3c3247c34 moved those imports under `if TYPE_CHECKING:` without adding `from __future__ import annotations`. Out of scope here, noted for separate tracking.

### CI note
The `ruff-check` (pre-commit.ci) check fails here with TC004 ("move import out of type-checking block") and F821 ("undefined name") in unrelated modules (for example `User`, `TemplateResult`, `OpenLibraryAccount`, `EbookAccess`). These are not introduced by this PR; they are the eager-annotation side of the same py314/py312 mismatch described in the Note above (under py314 ruff assumes deferred annotations and does not flag `TYPE_CHECKING` imports used at runtime; under py312 it correctly does). Resolving them is part of the broader migration decision and is intentionally out of scope for this focused syntax fix.