### PR TITLE
Show Want to Read button on trending pages

### DIFF
--- a/openlibrary/templates/trending.html
+++ b/openlibrary/templates/trending.html
@@ -28,7 +28,7 @@ $ page = int(input(page=1).page)
           $else:
             $ extra = _('Logged %(count)i times %(time_unit)s', count=entry['cnt'], time_unit=pages[mode])
 
-          $:macros.SearchResultsWork(entry['work'], extra=extra, availability=entry['work'].get('availability'), seq_index=loop.index0)
+          $:macros.SearchResultsWork(entry['work'], extra=extra, availability=entry['work'].get('availability'), include_dropper=True, seq_index=loop.index0)
     </ul>
   </div>
   $:macros.OlPagination(page, total_pages=200 // 20)


### PR DESCRIPTION
Closes #12810

Add the Want to Read button to trending pages. [fix]

### Technical
Trending pages render each book through the `SearchResultsWork` macro but did not pass `include_dropper=True`, so the reading-log dropper (the Want to Read button) never rendered. Every other listing page (`work_search.html`, `type/author/view.html`, `type/list/view_body.html`, `macros/FulltextResults.html`) passes it. This adds `include_dropper=True` to the macro call in `trending.html`. Trending feeds Solr work documents via `Bookshelves.add_solr_works` (which include `edition_key` and `logged_edition`) and the dropper loads asynchronously, so no server-side changes are required.

### Testing
Visit /trending/now while logged in: a Want to Read dropper appears on each book, matching search results and list pages. When logged out it renders in its disabled state, consistent with other listing pages.

### Screenshot
Pending: current master does not start locally (see #12827), so a running screenshot could not be captured. The change mirrors the established use of `include_dropper` on other listing templates.

### Stakeholders
@mekarpeles