### PR TITLE
Fix null ASINs being saved during promise item import

### DIFF
--- a/scripts/promise_batch_imports.py
+++ b/scripts/promise_batch_imports.py
@@ -54,7 +54,8 @@ def map_book_to_olbook(book, promise_id):
             return None
         return val
 
-    asin_is_isbn_10 = book.get("ASIN") and book.get("ASIN")[0].isdigit()
+    asin = book.get("ASIN")
+    asin_is_isbn_10 = asin and asin[0].isdigit()
     product_json = book.get("ProductJSON", {})
     publish_date = clean_null(product_json.get("PublicationDate"))
     title = product_json.get("Title")
@@ -63,11 +64,11 @@ def map_book_to_olbook(book, promise_id):
     olbook = {
         "local_id": [f"urn:bwbsku:{sku.upper()}"],
         "identifiers": {
-            **({"amazon": [book.get("ASIN")]} if not asin_is_isbn_10 else {}),
+            **({"amazon": [asin]} if asin and not asin_is_isbn_10 else {}),
             **({"better_world_books": [isbn]} if not is_isbn_13(isbn) else {}),
         },
         **({"isbn_13": [isbn]} if is_isbn_13(isbn) else {}),
-        **({"isbn_10": [book.get("ASIN")]} if asin_is_isbn_10 else {}),
+        **({"isbn_10": [asin]} if asin_is_isbn_10 else {}),
         **({"title": title} if title else {}),
         "authors": ([{"name": clean_null(product_json.get("Author"))}] if clean_null(product_json.get("Author")) else []),
         "publishers": [clean_null(product_json.get("Publisher")) or "????"],

--- a/scripts/tests/test_promise_batch_imports.py
+++ b/scripts/tests/test_promise_batch_imports.py
@@ -1,6 +1,24 @@
 import pytest
 
-from ..promise_batch_imports import format_date
+from ..promise_batch_imports import format_date, map_book_to_olbook
+
+TEST_BOOK_NO_ASIN = {
+    "BookBarcode": "S0-FPI-987",
+    "PackedLocation": "Mishawaka",
+    "Sort": "Never Seen",
+    "BookSKUB": "S0-FPI-987",
+    "ISBN": "9780990697091",
+    "ProductJSON": {
+        "ISBN": "9780990697091",
+        "Title": "Yely's Holiday Traditions",
+        "MasterProductId": "62590913",
+        "BookId": "0",
+        "Author": "Maria Isabel Medina-Berrios",
+        "Publisher": "The Kemper Foundation",
+        "PublicationDate": "20151215",
+        "BisacCategory": "Juvenile Fiction"
+    }
+}
 
 
 @pytest.mark.parametrize(
@@ -13,3 +31,16 @@ from ..promise_batch_imports import format_date
 )
 def test_format_date(date, only_year, expected) -> None:
     assert format_date(date=date, only_year=only_year) == expected
+
+
+def test_map_book_to_olbook():
+    expected = {
+        "local_id": ["urn:bwbsku:S0-FPI-987"],
+        "isbn_13": ["9780990697091"],
+        "title": "Yely's Holiday Traditions",
+        "authors": [{"name": "Maria Isabel Medina-Berrios"}],
+        "publishers": ["The Kemper Foundation"],
+        "source_records": ["promise:bwb_daily_pallets_2026-01-09:S0-FPI-987"],
+        "publish_date": "2015-12-15",
+    }
+    assert map_book_to_olbook(TEST_BOOK_NO_ASIN, promise_id="bwb_daily_pallets_2026-01-09") == expected

--- a/scripts/tests/test_promise_batch_imports.py
+++ b/scripts/tests/test_promise_batch_imports.py
@@ -16,8 +16,8 @@ TEST_BOOK_NO_ASIN = {
         "Author": "Maria Isabel Medina-Berrios",
         "Publisher": "The Kemper Foundation",
         "PublicationDate": "20151215",
-        "BisacCategory": "Juvenile Fiction"
-    }
+        "BisacCategory": "Juvenile Fiction",
+    },
 }
 
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Part of #12546 . Check if ASIN is null before submitting to API.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Added a unit test with real-world data.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
