### PR TITLE
Fix `KeyError` in `promise_batch_imports.py` script

### DIFF
--- a/scripts/promise_batch_imports.py
+++ b/scripts/promise_batch_imports.py
@@ -61,7 +61,7 @@ def map_book_to_olbook(book, promise_id):
     isbn = book.get("ISBN") or " "
     sku = book.get("BookSKUB") or book.get("BookSKU") or book.get("BookBarcode")
     if not sku:
-        logger.info(F"No sku found for record: {product_json}")
+        logger.info(f"No sku found for record: {product_json}")
         return None
     olbook = {
         "local_id": [f"urn:bwbsku:{sku.upper()}"],
@@ -144,11 +144,7 @@ def batch_import(promise_id, batch_size=1000, dry_run=False):
     url = "https://archive.org/download/"
     date = promise_id.split("_")[-1]
     resp = requests.get(f"{url}{promise_id}/DailyPallets__{date}.json", stream=True)
-    olbooks_gen = (
-        olbook
-        for book in ijson.items(resp.raw, "item")
-        if (olbook := map_book_to_olbook(book, promise_id)) is not None
-    )
+    olbooks_gen = (olbook for book in ijson.items(resp.raw, "item") if (olbook := map_book_to_olbook(book, promise_id)) is not None)
 
     # Note: dry_run won't include BookWorm data.
     if dry_run:

--- a/scripts/promise_batch_imports.py
+++ b/scripts/promise_batch_imports.py
@@ -59,7 +59,10 @@ def map_book_to_olbook(book, promise_id):
     publish_date = clean_null(product_json.get("PublicationDate"))
     title = product_json.get("Title")
     isbn = book.get("ISBN") or " "
-    sku = book["BookSKUB"] or book["BookSKU"] or book["BookBarcode"]
+    sku = book.get("BookSKUB") or book.get("BookSKU") or book.get("BookBarcode")
+    if not sku:
+        logger.info(F"No sku found for record: {product_json}")
+        return None
     olbook = {
         "local_id": [f"urn:bwbsku:{sku.upper()}"],
         "identifiers": {
@@ -141,7 +144,11 @@ def batch_import(promise_id, batch_size=1000, dry_run=False):
     url = "https://archive.org/download/"
     date = promise_id.split("_")[-1]
     resp = requests.get(f"{url}{promise_id}/DailyPallets__{date}.json", stream=True)
-    olbooks_gen = (map_book_to_olbook(book, promise_id) for book in ijson.items(resp.raw, "item"))
+    olbooks_gen = (
+        olbook
+        for book in ijson.items(resp.raw, "item")
+        if (olbook := map_book_to_olbook(book, promise_id)) is not None
+    )
 
     # Note: dry_run won't include BookWorm data.
     if dry_run:


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
The promise item cron job is sometimes failing with a `KeyError` when attempting to access the `sku` in a promise item record.  This occurs within the `map_book_to_olbook` function.

This branch updates the code to use the `get` method to access this data.  If a `sku` is not found, the promise item's json is logged, and `None` is returned by `map_book_to_olbook`.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
