### PR TITLE
feat(accounts): require valid IA S3 keys on OTP service endpoints

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -165,6 +165,7 @@ ia_ol_xauth_s3:
 ia_loan_api_url: http://web:8080/internal/fake/loans
 ia_xauth_api_url: http://web:8080/internal/fake/xauth
 ia_s3_auth_url: http://web:8080/internal/fake/s3auth
+otp_seed: dev-otp-seed-for-e2e-testing
 
 internal_tests_api_key: 8oPd1tx747YH374ohs48ZO5s2Nt1r9yD
 ia_availability_api_v2_url: https://archive.org/services/availability/

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -420,7 +420,7 @@ class account_login_json(delegate.page):
 
 def _parse_low_auth_header():
     """Parse 'Authorization: LOW access:secret' from the current request.
-    Returns (access, secret) tuple or raises ValueError if missing/malformed."""
+    Returns (access, secret) tuple or raises ValueError if missing/malformed/empty."""
     header = web.ctx.env.get("HTTP_AUTHORIZATION", "")
     if not header.startswith("LOW "):
         raise ValueError("Missing or invalid Authorization header")
@@ -428,7 +428,23 @@ def _parse_low_auth_header():
     if ":" not in keys:
         raise ValueError("Malformed authorization keys")
     access, secret = keys.split(":", 1)
-    return access.strip(), secret.strip()
+    access, secret = access.strip(), secret.strip()
+    if not access or not secret:
+        raise ValueError("Empty access or secret key")
+    return access, secret
+
+
+def _require_s3_auth():
+    """Validate the request's IA S3 credentials. Returns None on success or a RawText error response."""
+    try:
+        s3_access, s3_secret = _parse_low_auth_header()
+    except ValueError:
+        return delegate.RawText(json.dumps({"error": "missing_or_invalid_authorization"}))
+    if "error" in (result := InternetArchiveAccount.s3auth(s3_access, s3_secret)):
+        if result.get("code", 400) >= 500:
+            return delegate.RawText(json.dumps({"error": "auth_service_unavailable"}))
+        return delegate.RawText(json.dumps({"error": "unauthorized"}))
+    return None
 
 
 class otp_service_issue(delegate.page):
@@ -436,13 +452,8 @@ class otp_service_issue(delegate.page):
 
     def POST(self):
         web.header("Content-Type", "application/json")
-        # Require valid IA S3 credentials — only Lenny instances linked to an OL account may call this.
-        try:
-            s3_access, s3_secret = _parse_low_auth_header()
-        except ValueError:
-            return delegate.RawText(json.dumps({"error": "missing_or_invalid_authorization"}))
-        if "error" in InternetArchiveAccount.s3auth(s3_access, s3_secret):
-            return delegate.RawText(json.dumps({"error": "unauthorized"}))
+        if err := _require_s3_auth():
+            return err
 
         i = web.input(email="", ip="", challenge_url="", sendmail="true")
         required_keys = ("email", "ip", "service_ip")
@@ -473,13 +484,8 @@ class otp_service_redeem(delegate.page):
 
     def POST(self):
         web.header("Content-Type", "application/json")
-        # Require valid IA S3 credentials — only Lenny instances linked to an OL account may call this.
-        try:
-            s3_access, s3_secret = _parse_low_auth_header()
-        except ValueError:
-            return delegate.RawText(json.dumps({"error": "missing_or_invalid_authorization"}))
-        if "error" in InternetArchiveAccount.s3auth(s3_access, s3_secret):
-            return delegate.RawText(json.dumps({"error": "unauthorized"}))
+        if err := _require_s3_auth():
+            return err
 
         required_keys = ("email", "ip", "service_ip", "otp")
         i = web.input(email="", ip="", otp="")

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -11,9 +11,10 @@ from typing import TYPE_CHECKING, Any, Final
 from urllib.parse import urlparse
 from warnings import deprecated
 
-import infogami.core.code as core  # noqa: F401 side effects may be needed
 import requests
 import web
+
+import infogami.core.code as core  # noqa: F401 side effects may be needed
 from infogami import config
 from infogami.utils import delegate
 from infogami.utils.view import (
@@ -22,7 +23,6 @@ from infogami.utils.view import (
     render_template,
     require_login,
 )
-
 from openlibrary import accounts
 from openlibrary.accounts import (
     InternetArchiveAccount,

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -11,10 +11,9 @@ from typing import TYPE_CHECKING, Any, Final
 from urllib.parse import urlparse
 from warnings import deprecated
 
+import infogami.core.code as core  # noqa: F401 side effects may be needed
 import requests
 import web
-
-import infogami.core.code as core  # noqa: F401 side effects may be needed
 from infogami import config
 from infogami.utils import delegate
 from infogami.utils.view import (
@@ -23,6 +22,7 @@ from infogami.utils.view import (
     render_template,
     require_login,
 )
+
 from openlibrary import accounts
 from openlibrary.accounts import (
     InternetArchiveAccount,
@@ -418,11 +418,32 @@ class account_login_json(delegate.page):
             infogami_login().POST()
 
 
+def _parse_low_auth_header():
+    """Parse 'Authorization: LOW access:secret' from the current request.
+    Returns (access, secret) tuple or raises ValueError if missing/malformed."""
+    header = web.ctx.env.get("HTTP_AUTHORIZATION", "")
+    if not header.startswith("LOW "):
+        raise ValueError("Missing or invalid Authorization header")
+    _, keys = header.split("LOW ", 1)
+    if ":" not in keys:
+        raise ValueError("Malformed authorization keys")
+    access, secret = keys.split(":", 1)
+    return access.strip(), secret.strip()
+
+
 class otp_service_issue(delegate.page):
     path = "/account/otp/issue"
 
     def POST(self):
         web.header("Content-Type", "application/json")
+        # Require valid IA S3 credentials — only Lenny instances linked to an OL account may call this.
+        try:
+            s3_access, s3_secret = _parse_low_auth_header()
+        except ValueError:
+            return delegate.RawText(json.dumps({"error": "missing_or_invalid_authorization"}))
+        if "error" in InternetArchiveAccount.s3auth(s3_access, s3_secret):
+            return delegate.RawText(json.dumps({"error": "unauthorized"}))
+
         i = web.input(email="", ip="", challenge_url="", sendmail="true")
         required_keys = ("email", "ip", "service_ip")
         i.email = i.email.replace(" ", "+").lower()
@@ -452,6 +473,14 @@ class otp_service_redeem(delegate.page):
 
     def POST(self):
         web.header("Content-Type", "application/json")
+        # Require valid IA S3 credentials — only Lenny instances linked to an OL account may call this.
+        try:
+            s3_access, s3_secret = _parse_low_auth_header()
+        except ValueError:
+            return delegate.RawText(json.dumps({"error": "missing_or_invalid_authorization"}))
+        if "error" in InternetArchiveAccount.s3auth(s3_access, s3_secret):
+            return delegate.RawText(json.dumps({"error": "unauthorized"}))
+
         required_keys = ("email", "ip", "service_ip", "otp")
         i = web.input(email="", ip="", otp="")
         i.email = i.email.replace(" ", "+").lower()

--- a/openlibrary/plugins/upstream/tests/test_account.py
+++ b/openlibrary/plugins/upstream/tests/test_account.py
@@ -431,3 +431,67 @@ class TestOtpServiceS3Auth:
         result = account.otp_service_redeem().POST()
         body = json.loads(result.rawtext)
         assert body["error"] == "unauthorized"
+
+    @mock.patch("openlibrary.plugins.upstream.account.OTP")
+    @mock.patch("openlibrary.plugins.upstream.account.InternetArchiveAccount")
+    @mock.patch("openlibrary.plugins.upstream.account.web")
+    def test_redeem_valid_keys_proceeds(self, mock_web, mock_ia, mock_otp):
+        mock_ia.s3auth.return_value = {"success": True, "itemname": "@testuser"}
+        mock_web.ctx.env = {
+            "HTTP_AUTHORIZATION": "LOW goodaccess:goodsecret",
+            "HTTP_X_FORWARDED_FOR": "1.2.3.4",
+        }
+        mock_web.input.return_value = web.storage(email="test@example.com", ip="1.2.3.4", otp="abc123")
+        mock_otp.is_valid.return_value = True
+        result = account.otp_service_redeem().POST()
+        body = json.loads(result.rawtext)
+        assert body == {"success": "redeemed"}
+
+
+class TestParseLowAuthHeader:
+    """Unit tests for the _parse_low_auth_header() module-level helper."""
+
+    @mock.patch("openlibrary.plugins.upstream.account.web")
+    def test_missing_header_raises(self, mock_web):
+        mock_web.ctx.env = {}
+        with pytest.raises(ValueError, match="Missing or invalid"):
+            account._parse_low_auth_header()
+
+    @mock.patch("openlibrary.plugins.upstream.account.web")
+    def test_bearer_prefix_rejected(self, mock_web):
+        mock_web.ctx.env = {"HTTP_AUTHORIZATION": "Bearer sometoken"}
+        with pytest.raises(ValueError, match="Missing or invalid"):
+            account._parse_low_auth_header()
+
+    @mock.patch("openlibrary.plugins.upstream.account.web")
+    def test_no_colon_raises(self, mock_web):
+        mock_web.ctx.env = {"HTTP_AUTHORIZATION": "LOW accessonly"}
+        with pytest.raises(ValueError, match="Malformed"):
+            account._parse_low_auth_header()
+
+    @mock.patch("openlibrary.plugins.upstream.account.web")
+    def test_empty_secret_raises(self, mock_web):
+        mock_web.ctx.env = {"HTTP_AUTHORIZATION": "LOW access:"}
+        with pytest.raises(ValueError, match="Empty"):
+            account._parse_low_auth_header()
+
+    @mock.patch("openlibrary.plugins.upstream.account.web")
+    def test_empty_access_raises(self, mock_web):
+        mock_web.ctx.env = {"HTTP_AUTHORIZATION": "LOW :secret"}
+        with pytest.raises(ValueError, match="Empty"):
+            account._parse_low_auth_header()
+
+    @mock.patch("openlibrary.plugins.upstream.account.web")
+    def test_valid_returns_stripped_tuple(self, mock_web):
+        mock_web.ctx.env = {"HTTP_AUTHORIZATION": "LOW  myaccess : mysecret "}
+        access, secret = account._parse_low_auth_header()
+        assert access == "myaccess"
+        assert secret == "mysecret"
+
+    @mock.patch("openlibrary.plugins.upstream.account.web")
+    def test_colon_in_secret_preserved(self, mock_web):
+        # S3 secrets can contain colons; only split on the first one
+        mock_web.ctx.env = {"HTTP_AUTHORIZATION": "LOW access:sec:ret"}
+        access, secret = account._parse_low_auth_header()
+        assert access == "access"
+        assert secret == "sec:ret"

--- a/openlibrary/plugins/upstream/tests/test_account.py
+++ b/openlibrary/plugins/upstream/tests/test_account.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 from unittest import mock
@@ -348,3 +349,85 @@ class TestAccountLoginRedirect:
         for call in mock_web.setcookie.call_args_list:
             assert call[0][0] != "pending_action"
         mock_web.seeother.assert_called_with("/account/books")
+
+
+class TestOtpServiceS3Auth:
+    """Tests for S3 key validation on /account/otp/issue and /account/otp/redeem."""
+
+    def _make_web_mock(self, auth_header=""):
+        m = mock.MagicMock()
+        m.ctx.env = {"HTTP_AUTHORIZATION": auth_header, "HTTP_X_FORWARDED_FOR": "1.2.3.4"}
+        m.input.return_value = web.storage(email="test@example.com", ip="1.2.3.4", challenge_url="", sendmail="false", otp="123456")
+        m.safestr.side_effect = lambda x: x
+        return m
+
+    @mock.patch("openlibrary.plugins.upstream.account.InternetArchiveAccount")
+    @mock.patch("openlibrary.plugins.upstream.account.web")
+    def test_issue_missing_auth_header(self, mock_web, mock_ia):
+        mock_web.ctx.env = {}
+        result = account.otp_service_issue().POST()
+        body = json.loads(result.data)
+        assert body["error"] == "missing_or_invalid_authorization"
+        mock_ia.s3auth.assert_not_called()
+
+    @mock.patch("openlibrary.plugins.upstream.account.InternetArchiveAccount")
+    @mock.patch("openlibrary.plugins.upstream.account.web")
+    def test_issue_empty_secret_rejected(self, mock_web, mock_ia):
+        mock_web.ctx.env = {"HTTP_AUTHORIZATION": "LOW access:"}
+        result = account.otp_service_issue().POST()
+        body = json.loads(result.data)
+        assert body["error"] == "missing_or_invalid_authorization"
+        mock_ia.s3auth.assert_not_called()
+
+    @mock.patch("openlibrary.plugins.upstream.account.InternetArchiveAccount")
+    @mock.patch("openlibrary.plugins.upstream.account.web")
+    def test_issue_invalid_keys_rejected(self, mock_web, mock_ia):
+        mock_ia.s3auth.return_value = {"error": "invalid_s3keys", "code": 401}
+        mock_web.ctx.env = {"HTTP_AUTHORIZATION": "LOW badaccess:badsecret"}
+        result = account.otp_service_issue().POST()
+        body = json.loads(result.data)
+        assert body["error"] == "unauthorized"
+
+    @mock.patch("openlibrary.plugins.upstream.account.InternetArchiveAccount")
+    @mock.patch("openlibrary.plugins.upstream.account.web")
+    def test_issue_auth_service_5xx_returns_specific_error(self, mock_web, mock_ia):
+        mock_ia.s3auth.return_value = {"error": "service error", "code": 503}
+        mock_web.ctx.env = {"HTTP_AUTHORIZATION": "LOW access:secret"}
+        result = account.otp_service_issue().POST()
+        body = json.loads(result.data)
+        assert body["error"] == "auth_service_unavailable"
+
+    @mock.patch("openlibrary.plugins.upstream.account.OTP")
+    @mock.patch("openlibrary.plugins.upstream.account.InternetArchiveAccount")
+    @mock.patch("openlibrary.plugins.upstream.account.web")
+    def test_issue_valid_keys_proceeds(self, mock_web, mock_ia, mock_otp):
+        mock_ia.s3auth.return_value = {"success": True, "itemname": "@testuser"}
+        mock_web.ctx.env = {
+            "HTTP_AUTHORIZATION": "LOW goodaccess:goodsecret",
+            "HTTP_X_FORWARDED_FOR": "1.2.3.4",
+        }
+        mock_web.input.return_value = web.storage(email="test@example.com", ip="1.2.3.4", challenge_url="", sendmail="false")
+        mock_otp.generate.return_value = "abc123"
+        mock_otp.is_ratelimited.return_value = None
+        mock_otp.verify_service.return_value = True
+        result = account.otp_service_issue().POST()
+        body = json.loads(result.data)
+        assert body == {"success": "issued"}
+
+    @mock.patch("openlibrary.plugins.upstream.account.InternetArchiveAccount")
+    @mock.patch("openlibrary.plugins.upstream.account.web")
+    def test_redeem_missing_auth_header(self, mock_web, mock_ia):
+        mock_web.ctx.env = {}
+        result = account.otp_service_redeem().POST()
+        body = json.loads(result.data)
+        assert body["error"] == "missing_or_invalid_authorization"
+        mock_ia.s3auth.assert_not_called()
+
+    @mock.patch("openlibrary.plugins.upstream.account.InternetArchiveAccount")
+    @mock.patch("openlibrary.plugins.upstream.account.web")
+    def test_redeem_invalid_keys_rejected(self, mock_web, mock_ia):
+        mock_ia.s3auth.return_value = {"error": "invalid_s3keys", "code": 401}
+        mock_web.ctx.env = {"HTTP_AUTHORIZATION": "LOW bad:creds"}
+        result = account.otp_service_redeem().POST()
+        body = json.loads(result.data)
+        assert body["error"] == "unauthorized"

--- a/openlibrary/plugins/upstream/tests/test_account.py
+++ b/openlibrary/plugins/upstream/tests/test_account.py
@@ -366,7 +366,7 @@ class TestOtpServiceS3Auth:
     def test_issue_missing_auth_header(self, mock_web, mock_ia):
         mock_web.ctx.env = {}
         result = account.otp_service_issue().POST()
-        body = json.loads(result.data)
+        body = json.loads(result.rawtext)
         assert body["error"] == "missing_or_invalid_authorization"
         mock_ia.s3auth.assert_not_called()
 
@@ -375,7 +375,7 @@ class TestOtpServiceS3Auth:
     def test_issue_empty_secret_rejected(self, mock_web, mock_ia):
         mock_web.ctx.env = {"HTTP_AUTHORIZATION": "LOW access:"}
         result = account.otp_service_issue().POST()
-        body = json.loads(result.data)
+        body = json.loads(result.rawtext)
         assert body["error"] == "missing_or_invalid_authorization"
         mock_ia.s3auth.assert_not_called()
 
@@ -385,7 +385,7 @@ class TestOtpServiceS3Auth:
         mock_ia.s3auth.return_value = {"error": "invalid_s3keys", "code": 401}
         mock_web.ctx.env = {"HTTP_AUTHORIZATION": "LOW badaccess:badsecret"}
         result = account.otp_service_issue().POST()
-        body = json.loads(result.data)
+        body = json.loads(result.rawtext)
         assert body["error"] == "unauthorized"
 
     @mock.patch("openlibrary.plugins.upstream.account.InternetArchiveAccount")
@@ -394,7 +394,7 @@ class TestOtpServiceS3Auth:
         mock_ia.s3auth.return_value = {"error": "service error", "code": 503}
         mock_web.ctx.env = {"HTTP_AUTHORIZATION": "LOW access:secret"}
         result = account.otp_service_issue().POST()
-        body = json.loads(result.data)
+        body = json.loads(result.rawtext)
         assert body["error"] == "auth_service_unavailable"
 
     @mock.patch("openlibrary.plugins.upstream.account.OTP")
@@ -411,7 +411,7 @@ class TestOtpServiceS3Auth:
         mock_otp.is_ratelimited.return_value = None
         mock_otp.verify_service.return_value = True
         result = account.otp_service_issue().POST()
-        body = json.loads(result.data)
+        body = json.loads(result.rawtext)
         assert body == {"success": "issued"}
 
     @mock.patch("openlibrary.plugins.upstream.account.InternetArchiveAccount")
@@ -419,7 +419,7 @@ class TestOtpServiceS3Auth:
     def test_redeem_missing_auth_header(self, mock_web, mock_ia):
         mock_web.ctx.env = {}
         result = account.otp_service_redeem().POST()
-        body = json.loads(result.data)
+        body = json.loads(result.rawtext)
         assert body["error"] == "missing_or_invalid_authorization"
         mock_ia.s3auth.assert_not_called()
 
@@ -429,5 +429,5 @@ class TestOtpServiceS3Auth:
         mock_ia.s3auth.return_value = {"error": "invalid_s3keys", "code": 401}
         mock_web.ctx.env = {"HTTP_AUTHORIZATION": "LOW bad:creds"}
         result = account.otp_service_redeem().POST()
-        body = json.loads(result.data)
+        body = json.loads(result.rawtext)
         assert body["error"] == "unauthorized"


### PR DESCRIPTION
## Summary

Closes #12840

The OTP service endpoints (`POST /account/otp/issue` and `/account/otp/redeem`) are used by [Lenny](https://github.com/archivelabs/lenny) to implement patron passwordless login. Lenny already sends `Authorization: LOW <access>:<secret>` headers on every OTP call (via [`ol_auth_headers()`](https://github.com/archivelabs/lenny/blob/main/lenny/core/openlibrary.py)), but OL was silently ignoring them.

This PR adds validation: both endpoints now require a valid IA S3 `Authorization: LOW` header before processing the request. Invalid or missing credentials return `{"error": "unauthorized"}`.

## Changes

**`openlibrary/plugins/upstream/account.py`**
- New module-level `_parse_low_auth_header()` helper — parses `Authorization: LOW access:secret` from the WSGI env (same pattern as the existing `account_anonymize._parse_auth_header()` instance method)
- `otp_service_issue.POST()` — validate S3 keys via `InternetArchiveAccount.s3auth()` before issuing OTP
- `otp_service_redeem.POST()` — same validation before redeeming OTP

## Why This Matters

Without this, any HTTP client can hit `/account/otp/issue` and cause OL to send unsolicited OTP emails to arbitrary addresses. Requiring valid IA S3 keys ties OTP access to Lenny instances that have been explicitly linked to an IA account via `make ol-login`.

## Companion PR

- [ArchiveLabs/lenny#184](https://github.com/ArchiveLabs/lenny/pull/184) — Lenny side: optional IA S3 auth plugin for patron borrow requests

## Test Plan

- [ ] Request without `Authorization` header → `{"error": "missing_or_invalid_authorization"}`
- [ ] Request with invalid S3 keys → `{"error": "unauthorized"}`
- [ ] Request with valid S3 keys → OTP issued/redeemed normally
- [ ] Local dev: fake S3 auth endpoint (`/internal/fake/s3auth`) accepts `foo:foo`, so existing local tests are unaffected
- [ ] `make test` passes