### PR TITLE
Fix solr builder for python 3.14

### DIFF
--- a/scripts/solr_builder/Dockerfile.olpython
+++ b/scripts/solr_builder/Dockerfile.olpython
@@ -16,6 +16,7 @@ RUN uv pip install \
     # For real-time profiling
     cprofilev \
     # Faster python
+    setuptools \
     Cython==3.0.6
 
 # Build cython files

--- a/scripts/solr_builder/compose.yaml
+++ b/scripts/solr_builder/compose.yaml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   db:
     profiles:


### PR DESCRIPTION
Part of #11650 .

setuptools is apparently no longer included in the 3.14 image ! This is used by solr builder.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Confirmed building the olpython image now works. Might need more PRs to fix other new downstream issues.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
