### PR TITLE
Fixed headings and associated lists being split across columns

### DIFF
--- a/static/css/page-user.css
+++ b/static/css/page-user.css
@@ -84,8 +84,13 @@ div#subjectsPage {
   }
 }
 
+div#subjectsPage h3 {
+  break-after: avoid;
+}
+
 div#subjectsPage ul {
   display: inline-block;
+  break-before: avoid;
 }
 
 div.lists {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #12815 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
[fix]

### Technical
<!-- What should be noted about the implementation? -->
This PR updates the Subjects page column rules so headings stay grouped with their corresponding lists. This is a CSS only change.

Changes were made for elements in `div#subjectsPage` in `static/css/page-user.css` 
- Added `break-after: avoid` on headings
- Added `break-before: avoid` on lists

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Ran the following tests with no failures
```
npm run lint
docker compose run --rm home make css
```

To verify the initial problem and the proposed solution
1. Open the [subjects](https://openlibrary.org/subjects) page in Chrome
2. Confirm headings and related lists can split across different columns
3. Apply code changes locally or in dev environment
4. View the webpage and resize it to different viewport sizes to verify that the new grouping continues to work
5. Compare the provided screenshots

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Original UI before changes
<img width="530" height="611" alt="Subjects Before Change" src="https://github.com/user-attachments/assets/64ee63b9-4536-4af6-a20a-85deebd626f6" />

UI after changes
<img width="385" height="552" alt="Subjects After Change" src="https://github.com/user-attachments/assets/a4bba705-6a4c-457b-98e5-0e637d4e3ae2" />


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
