### PR TITLE
Add tracking for Preserve Intent banner actions (#9409)

### DIFF
--- a/openlibrary/fastapi/account.py
+++ b/openlibrary/fastapi/account.py
@@ -208,11 +208,25 @@ async def login(
     # Generate auth token (same way web.py does it via Account.generate_login_code())
     login_code = generate_login_code_for_user(ol_username)
 
+    blacklist = [
+        "/account/login",
+        "/account/create",
+        "/account/verify",
+    ]
+    is_valid_redirect = True
+    redirect_url = _safe_redirect(form_data.redirect, default="")
+    if not redirect_url or any(path in redirect_url for path in blacklist):
+        is_valid_redirect = False
+        redirect_url = "/"
+
     # Create response with redirect
     response = Response(
         status_code=status.HTTP_303_SEE_OTHER,
-        headers={"Location": _safe_redirect(form_data.redirect)},
+        headers={"Location": redirect_url},
     )
+
+    if is_valid_redirect:
+        response.delete_cookie("pending_action")
 
     # Set session cookie (same as web.py)
     response.set_cookie(

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -554,6 +554,8 @@ class account_login(delegate.page):
 
         if not is_safe_redirect(redirect) or any(path in redirect for path in blacklist):
             redirect = "/account/books"
+        else:
+            web.setcookie("pending_action", "", expires=-1)
         stats.increment("ol.account.xauth.login")
         raise web.seeother(redirect)
 

--- a/openlibrary/plugins/upstream/tests/test_account.py
+++ b/openlibrary/plugins/upstream/tests/test_account.py
@@ -6,6 +6,7 @@ import pytest
 import web
 
 from openlibrary.accounts.model import create_link_doc
+from openlibrary.utils.request_context import RequestContextVars, req_context
 
 from .. import account
 from ..account import account_login, account_verify
@@ -262,3 +263,47 @@ class TestAccountLoginSetCookies:
         handler = account_login()
         handler.set_cookies(remember=False, session="abc123")
         mock_web.setcookie.assert_called_once_with("session", "abc123", expires="")
+
+
+class TestAccountLoginRedirect:
+    def setup_method(self):
+        self._req_context_token = req_context.set(
+            RequestContextVars(
+                x_forwarded_for=None,
+                user_agent="pytest-agent",
+                lang="en",
+                solr_editions=True,
+                print_disabled=False,
+                sfw=False,
+                is_recognized_bot=False,
+                is_bot=False,
+            )
+        )
+
+    def teardown_method(self):
+        req_context.reset(self._req_context_token)
+
+    @mock.patch("openlibrary.plugins.upstream.account.audit_accounts")
+    @mock.patch("openlibrary.plugins.upstream.account.OpenLibraryAccount")
+    @mock.patch("openlibrary.plugins.upstream.account.web")
+    @mock.patch("openlibrary.plugins.upstream.account.stats")
+    def test_login_deletes_preserve_intent_cookie_on_valid_redirect(self, mock_stats, mock_web, mock_ol_account_cls, mock_audit_accounts):
+        handler = account_login()
+        mock_audit_accounts.return_value = {"ia_email": "test@example.com"}
+        mock_ol_account_cls.get_by_email.return_value = mock.MagicMock()
+        mock_web.seeother.side_effect = Exception("seeother")
+
+        # Case 1: Valid redirect string -> deletes preserve intent cookie
+        with pytest.raises(Exception, match="seeother"):
+            handler.login(username="test", password="pwd", redirect="/books")
+        mock_web.setcookie.assert_any_call("pending_action", "", expires=-1)
+        mock_web.seeother.assert_called_with("/books")
+
+        mock_web.reset_mock()
+
+        # Case 2: Invalid redirect string -> redirects to fallback without deleting cookie
+        with pytest.raises(Exception, match="seeother"):
+            handler.login(username="test", password="pwd", redirect="http://evil.com")
+        for call in mock_web.setcookie.call_args_list:
+            assert call[0][0] != "pending_action"
+        mock_web.seeother.assert_called_with("/account/books")

--- a/openlibrary/templates/account/view.html
+++ b/openlibrary/templates/account/view.html
@@ -27,9 +27,14 @@ $var title: $header_title
               if (container) {
                   var link = container.querySelector('.pending-action-link');
                   if (link) {
+                      link.setAttribute('data-ol-link-track', 'PreserveIntent|Continue');
                       link.addEventListener('click', function() {
                           document.cookie = 'pending_action=; path=/; max-age=0; samesite=lax';
                       });
+                  }
+                  var dismiss = container.querySelector('.page-banner--dismissable-close');
+                  if (dismiss) {
+                      dismiss.setAttribute('data-ol-link-track', 'PreserveIntent|Dismiss');
                   }
               }
           });

--- a/openlibrary/tests/fastapi/test_account.py
+++ b/openlibrary/tests/fastapi/test_account.py
@@ -1,0 +1,48 @@
+"""Tests for FastAPI account endpoints."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from openlibrary.asgi_app import app
+
+
+def test_login_deletes_pending_action_cookie_on_valid_redirect():
+    client = TestClient(app)
+    with (
+        patch("openlibrary.fastapi.account.audit_accounts") as mock_audit,
+        patch("openlibrary.fastapi.account.generate_login_code_for_user") as mock_gen_code,
+    ):
+        mock_audit.return_value = {"ol_username": "testuser"}
+        mock_gen_code.return_value = "token"
+
+        # Case 1: Valid redirect -> deletes preserve intent cookie
+        response = client.post(
+            "/account/login",
+            data={"username": "testuser", "password": "password", "redirect": "/books"},
+            follow_redirects=False,
+        )
+        assert response.status_code == 303
+        assert response.headers["Location"] == "/books"
+
+        # Check if the set-cookie header deletes "pending_action"
+        set_cookies = [val for key, val in response.headers.multi_items() if key.lower() == "set-cookie"]
+        assert any("pending_action=" in header for header in set_cookies)
+
+        # Case 2: Invalid/unsafe redirect -> does not delete cookie, redirects to home /
+        response = client.post(
+            "/account/login",
+            data={
+                "username": "testuser",
+                "password": "password",
+                "redirect": "http://evil.com",
+            },
+            follow_redirects=False,
+        )
+        assert response.status_code == 303
+        assert response.headers["Location"] == "/"
+
+        set_cookies = [val for key, val in response.headers.multi_items() if key.lower() == "set-cookie"]
+        assert not any("pending_action=" in header for header in set_cookies)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9409

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds link tracking tags (`data-ol-link-track`) to the "continue" and "dismiss" options on the Preserve Intent login-redirect banner, and ensures the `pending_action` cookie is cleared upon successful login with a valid redirect target.

### Technical
<!-- What should be noted about the implementation? -->
- Dynamically applies `data-ol-link-track="PreserveIntent|Continue"` and `data-ol-link-track="PreserveIntent|Dismiss"` to the respective banner elements using JavaScript at `DOMContentLoaded` in `view.html`.
- Clears the `pending_action` cookie in the legacy login handler (`openlibrary/plugins/upstream/account.py`) and the FastAPI login handler (`openlibrary/fastapi/account.py`) when the redirect is safe and not blacklisted.
- Added comprehensive unit tests for both legacy and FastAPI login redirect/cookie clearing behaviors.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Run Python tests:
```bash
pytest openlibrary/plugins/upstream/tests/test_account.py openlibrary/tests/fastapi/test_account.py
```
Manually verified behaviour, cookie is deleted with correct redirect and the html attributes are present on web view.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
