### PR TITLE
i18n: add translator notes to stopped reading shelf strings

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -1307,6 +1307,10 @@ msgstr ""
 msgid "Read"
 msgstr ""
 
+#. Display name for the "stopped-reading" reading log shelf used in page
+#. headings and breadcrumbs.
+#. Label for the reading log shelf for books the user stopped reading before
+#. finishing (bookshelf ID 4). Used as a button label and shelf name.
 #. Label for the reading log shelf for books the user stopped reading
 #. (bookshelf ID 4). Used as a button label and shelf name.
 #: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
@@ -4174,6 +4178,9 @@ msgstr ""
 msgid "Already Read (%(count)d)"
 msgstr ""
 
+#. Page title for the "Stopped Reading" shelf page.
+#. Example: "Stopped Reading (8)". %(count)d is the number of books on this
+#. shelf.
 #: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #, python-format
 msgid "Stopped Reading (%(count)d)"
@@ -8410,6 +8417,9 @@ msgstr ""
 msgid "Have read"
 msgstr ""
 
+#. Short label displayed next to the count of readers who stopped reading this
+#. book before finishing, shown in the stats bar on a book page. Example: "348
+#. Stopped reading".
 #: StarRatingsStats.html
 msgid "Stopped reading"
 msgstr ""

--- a/openlibrary/macros/StarRatingsStats.html
+++ b/openlibrary/macros/StarRatingsStats.html
@@ -30,5 +30,6 @@ $ id = '--mobile' if mobile else ''
     $code: pass  # NOTE: Short label displayed next to the count of readers who have finished this book, shown in the stats bar on a book page. Example: "15,420 Have read". This refers to the same shelf as the "Already Read" button.
     <li class="reading-log-stat"><span class="readers-stats__stat">$already_read_count</span> <span class="readers-stats__label">$_("Have read")</span></li>
   $if stopped_reading_count:
+    $code: pass  # NOTE: Short label displayed next to the count of readers who stopped reading this book before finishing, shown in the stats bar on a book page. Example: "348 Stopped reading".
     <li class="reading-log-stat"><span class="readers-stats__stat">$stopped_reading_count</span> <span class="readers-stats__label">$_("Stopped reading")</span></li>
 </ul>

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -251,6 +251,8 @@ class mybooks_readinglog(delegate.page):
                 # NOTE: Page title for the "Already Read" shelf page.
                 # NOTE: Example: "Already Read (203)". %(count)d is the number of books on this shelf.
                 "already-read": _("Already Read (%(count)d)", count=mb.counts["already-read"]),
+                # NOTE: Page title for the "Stopped Reading" shelf page.
+                # NOTE: Example: "Stopped Reading (8)". %(count)d is the number of books on this shelf.
                 "stopped-reading": _("Stopped Reading (%(count)d)", count=mb.counts["stopped-reading"]),
             }
             template = self.render_template(mb)

--- a/openlibrary/templates/account/readinglog_shelf_name.html
+++ b/openlibrary/templates/account/readinglog_shelf_name.html
@@ -10,4 +10,5 @@ $elif key == 'already-read':
   $code: pass  # NOTE: Display name for the "already-read" reading log shelf used in page headings and breadcrumbs.
   $_("Already Read")
 $elif key == 'stopped-reading':
+  $code: pass  # NOTE: Display name for the "stopped-reading" reading log shelf used in page headings and breadcrumbs.
   $_("Stopped Reading")

--- a/openlibrary/templates/my_books/dropdown_content.html
+++ b/openlibrary/templates/my_books/dropdown_content.html
@@ -50,6 +50,7 @@ $def reading_log_selections(work_key, edition_key, users_work_read_status):
       <input type="hidden" name="bookshelf_id" value="4"/>
       $if edition_key:
         <input type="hidden" name="edition_id" value="$(edition_key)"/>
+      $code: pass  # NOTE: Label for the reading log shelf for books the user stopped reading before finishing (bookshelf ID 4). Used as a button label and shelf name.
       <button class="nostyle-btn $(btn_visibilities[4])" type="submit" data-ol-link-track="ReadingLog|StoppedReading">$_('Stopped Reading')</button>
     </form>
   </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #12562

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds translator notes (`# NOTE:`) for the remaining "Stopped Reading" shelf-related strings to align with the translator notes added for other shelves in #12725.

### Technical
<!-- What should be noted about the implementation? -->
Adds translator notes at the 4 remaining locations:
- `openlibrary/templates/my_books/dropdown_content.html`
- `openlibrary/templates/account/readinglog_shelf_name.html`
- `openlibrary/plugins/upstream/mybooks.py`
- `openlibrary/macros/StarRatingsStats.html`

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
N/A (comment annotations only)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles @Sadashii @tfmorris


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
