### PR TITLE
fix(carousel): source i18n from data-config so partial carousels show localized loading (follow-up to #12714)

### DIFF
--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -11,7 +11,7 @@ import { buildPartialsUrl } from  '../utils.js';
  * @property {String} carouselKey
  * @property {Object<string, string>} [i18n] localized UI strings (e.g. `loading`)
  * @property {Object} [loadMore] configuration for loading more items
- * @property {String} loadMore.url to use to load more items
+ * @property {String} loadMore.queryType query category used to fetch more items (e.g. 'SEARCH', 'BROWSE', 'SUBJECTS')
  * @property {Number} loadMore.limit of new items to receive
  * @property {'page' | 'offset'} loadMore.pageMode
  * -- INTERNAL --

--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -9,6 +9,7 @@ import { buildPartialsUrl } from  '../utils.js';
  *      number of books to show at: [default, >1200px, >1024px, >600px, >480px, >360px]
  * @property {String} analyticsCategory
  * @property {String} carouselKey
+ * @property {Object<string, string>} [i18n] localized UI strings (e.g. `loading`)
  * @property {Object} [loadMore] configuration for loading more items
  * @property {String} loadMore.url to use to load more items
  * @property {Number} loadMore.limit of new items to receive
@@ -51,11 +52,17 @@ export class Carousel {
         /** @type {jquery} */
         this.$container = $container;
 
-        // This loads in i18n strings from a hidden input element, generated in the books/custom_carousel.html template.
-        this.i18n = {loading: ''}; // Allow loading to continue if translated text is missing.
+        // i18n strings. Prefer the per-carousel strings embedded in `data-config`,
+        // which are always present even for carousels rendered via partials. Fall
+        // back to the shared hidden input (books/custom_carousel.html), then to an
+        // empty string so loading can continue if a translation is missing.
+        this.i18n = {loading: ''};
         const i18nInput = document.querySelector('input[name="carousel-i18n-strings"]');
         if (i18nInput) {
             this.i18n = JSON.parse(i18nInput.value);
+        }
+        if (this.config.i18n) {
+            this.i18n = this.config.i18n;
         }
     }
 

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -25,6 +25,9 @@ $if test or (books and len(books) >= min_books):
             'booksPerBreakpoint': [4, 4, 4, 3, 2, 1] if compact_mode else [6, 5, 4, 3, 2, 1],
             'analyticsCategory': 'BookCarousel',
             'carouselKey': key,
+            'i18n': {
+              'loading': _("Loading..."),
+            },
             'loadMore': {
               "queryType": load_more.get("queryType", ""),
               "q": load_more.get("q", ""),

--- a/tests/unit/js/carousel.test.js
+++ b/tests/unit/js/carousel.test.js
@@ -84,6 +84,31 @@ describe('Carousel', () => {
         expect(carousel.loadMore.allDone).toBe(false);
     });
 
+    test('uses i18n strings from data-config, even without the hidden input', async() => {
+        document.querySelector('input[name="carousel-i18n-strings"]').remove();
+        document.querySelector('.carousel').dataset.config = JSON.stringify({
+            i18n: { loading: 'Cargando...' },
+            loadMore: {
+                queryType: 'SUBJECTS',
+                q: 'subject:science',
+                pageMode: 'offset',
+                limit: 18,
+                key: 'science'
+            }
+        });
+        carousel = new Carousel($('.carousel'));
+        const request = $.Deferred();
+        $.ajax = jest.fn(() => request.promise());
+        carousel.loadMore.locked = true;
+
+        carousel.fetchPartials();
+        request.reject(new Error('Request failed'));
+        await flushPromises();
+
+        expect(slick.addSlide).toHaveBeenCalledWith('<div class="carousel__item carousel__loading-end">Cargando...</div>');
+        expect(carousel.loadMore.locked).toBe(false);
+    });
+
     test('does not remain locked when the i18n input is missing', async() => {
         document.querySelector('input[name="carousel-i18n-strings"]').remove();
         carousel = new Carousel($('.carousel'));


### PR DESCRIPTION
Follow-up to #12714 (which already fixed the freeze/crash on master). Closes #12848.

### Context

#12714 stopped the carousel from freezing: `Carousel.js` now defaults `this.i18n` so `appendLoadingSlide()` no longer throws when the shared hidden input is missing. 👍

This PR addresses the remaining root cause so partial-loaded carousels show the *localized* "Loading…" label instead of an empty one.

### Why the input goes missing

The i18n strings are emitted once per page via `render_once('books/custom_carousel.i18n-strings')`. `render_once` stores state in `web.ctx`, which web.py resets per request.

Lazy and load-more carousels now render through **FastAPI partials** (`openlibrary/fastapi/partials.py`), and `set_context_from_fastapi` never resets `web.ctx`. Since `web.ctx` is a web.py `ThreadedDict` keyed by OS thread, `render_once` returns `True` only for the *first* partial served by a worker thread and `False` thereafter — so most lazily-loaded carousels never receive the hidden input, and fall back to the empty loading label.

### Change

- Embed the i18n strings in each carousel's `data-config` (always rendered fresh per carousel, regardless of render path).
- `Carousel.js` prefers `config.i18n`, falling back to the hidden input and then the empty default — so the existing #12714 crash guard stays intact.
- Adds a unit test covering the `data-config` path with no hidden input.

### Testing

```
npx jest tests/unit/js/carousel.test.js   # 3 passed
npx eslint openlibrary/plugins/openlibrary/js/carousel/Carousel.js tests/unit/js/carousel.test.js   # clean
```

Manual: open `/subjects/roof_gardening`, page past the initial set so a load-more fires — the localized "Loading…" slide appears and the carousel keeps working.
