### PR TITLE
feat: open BookReader with search panel visible on Preview

### DIFF
--- a/openlibrary/macros/BookPreview.html
+++ b/openlibrary/macros/BookPreview.html
@@ -7,7 +7,7 @@ $if ocaid:
   <div class="cta-button-group">
     <a class="cta-btn cta-btn--preview"
       data-book-preview
-      data-iframe-src="https://archive.org/details/$ocaid?view=theater&wrapper=false&q="
+      data-iframe-src="https://archive.org/details/$ocaid?view=theater&amp;wrapper=false&amp;q="
       data-iframe-link="https://archive.org/details/$ocaid"
       $:analytics href="#bookPreview">$(_('Preview Only') if show_only else _('Preview'))</a>
   </div>

--- a/openlibrary/macros/BookPreview.html
+++ b/openlibrary/macros/BookPreview.html
@@ -7,7 +7,7 @@ $if ocaid:
   <div class="cta-button-group">
     <a class="cta-btn cta-btn--preview"
       data-book-preview
-      data-iframe-src="https://archive.org/details/$ocaid?view=theater&wrapper=false"
+      data-iframe-src="https://archive.org/details/$ocaid?view=theater&wrapper=false&q="
       data-iframe-link="https://archive.org/details/$ocaid"
       $:analytics href="#bookPreview">$(_('Preview Only') if show_only else _('Preview'))</a>
   </div>


### PR DESCRIPTION
## Summary

Appends `&q=` to the BookReader embed URL in the Preview button so that clicking "Preview" on a book opens BookReader with the search-inside panel already visible.

Currently patrons who click "Preview" get a book reader with no obvious indication that full-text search exists. With this change, the search panel opens automatically, making search-inside discoverable from the first interaction.

**Depends on:** internetarchive/bookreader#1550 (must deploy before this takes effect)

## Change

`openlibrary/macros/BookPreview.html` — 1 line  
Added `&q=` to the `data-iframe-src` URL passed to the BookReader embed. BookReader #1550 treats `?q=` (empty) as a signal to open the search panel on load without running a search.

## Testing

Once internetarchive/bookreader#1550 is deployed to archive.org:
1. Go to any search result page with a "Preview" button
2. Click Preview
3. Expected: BookReader opens with the search sidebar visible
4. Type a term in the search box — it should search inside the book normally

## References

Closes #11912