### PR TITLE
feat(community): add OLWeeklyPrompt Lit component for homepage weekly prompt

### DIFF
--- a/openlibrary/components/lit/OLWeeklyPrompt.js
+++ b/openlibrary/components/lit/OLWeeklyPrompt.js
@@ -291,7 +291,7 @@ export class OLWeeklyPrompt extends LitElement {
         this.nominationsJson = '[]';
         this.totalVoters = 0;
         this.username = '';
-        this.promptUrl = '/prompts';
+        this.promptUrl = '';
     }
 
     get _nominations() {
@@ -390,7 +390,7 @@ export class OLWeeklyPrompt extends LitElement {
     _renderCTA() {
         const href = this.username
             ? (this.promptUrl ? `${this.promptUrl}#nominate` : '#nominate')
-            : `/account/login?redirect=${encodeURIComponent(this.promptUrl || '/prompts')}`;
+            : (this.promptUrl ? `/account/login?redirect=${encodeURIComponent(this.promptUrl)}` : '/account/login');
 
         return html`
             <a class="nominate-btn" href="${href}" @click=${this._handleNominateClick}>

--- a/openlibrary/components/lit/OLWeeklyPrompt.js
+++ b/openlibrary/components/lit/OLWeeklyPrompt.js
@@ -1,0 +1,438 @@
+import { LitElement, html, css, nothing } from 'lit';
+
+/**
+ * OLWeeklyPrompt - Weekly staff-curated book prompt widget
+ *
+ * Mobile-first: horizontal-scroll book strip on mobile, two-column grid on desktop (≥ 640px).
+ * Data is passed via attributes/properties from the server-rendered template.
+ * The `nominations-json` attribute accepts a JSON array of nomination objects.
+ *
+ * @property {String} prompt-title     - The prompt question
+ * @property {String} prompt-desc      - Label, e.g. "Staff pick · Week of June 2"
+ * @property {String} nominations-json - JSON array: [{title, coverUrl, score, workKey}]
+ * @property {Number} total-voters     - Number of distinct voters across all nominations
+ * @property {String} username         - Logged-in OL username, or empty string if anonymous
+ * @property {String} prompt-url       - URL for the full prompt history page
+ *
+ * @fires ol-weekly-prompt-nominate - Fired when the "Nominate a Book" CTA is clicked.
+ *   detail: { username: String }
+ *
+ * @example
+ * <ol-weekly-prompt
+ *   prompt-title="Non-fiction books that expanded your understanding of the world"
+ *   prompt-desc="Staff pick · Week of June 2"
+ *   nominations-json='[{"title":"Sapiens","coverUrl":"...","score":42,"workKey":"/works/OL16311446W"}]'
+ *   total-voters="18"
+ *   username="mekarpeles"
+ * ></ol-weekly-prompt>
+ */
+export class OLWeeklyPrompt extends LitElement {
+    static properties = {
+        promptTitle:     { type: String, attribute: 'prompt-title' },
+        promptDesc:      { type: String, attribute: 'prompt-desc' },
+        nominationsJson: { type: String, attribute: 'nominations-json' },
+        totalVoters:     { type: Number, attribute: 'total-voters' },
+        username:        { type: String },
+        promptUrl:       { type: String, attribute: 'prompt-url' },
+    };
+
+    static styles = css`
+        :host {
+            display: block;
+            container-type: inline-size;
+        }
+
+        /* ── Card wrapper ─────────────────────────────────── */
+        .prompt-card {
+            background: var(--white, #fff);
+            border: 1px solid var(--color-border-subtle, #d8d8d8);
+            border-radius: 8px;
+            padding: 20px 16px 16px;
+            display: flex;
+            flex-direction: column;
+            gap: 14px;
+        }
+
+        /* ── Header (label + title) ───────────────────────── */
+        .prompt-label {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            font-size: 0.75rem;
+            font-family: var(--font-family-body, sans-serif);
+            color: var(--mid-grey, #666);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            font-weight: 600;
+        }
+
+        .prompt-label svg {
+            flex-shrink: 0;
+        }
+
+        .prompt-title {
+            margin: 0;
+            font-size: 1.125rem;
+            font-family: var(--font-family-body, sans-serif);
+            font-weight: 700;
+            color: var(--dark-grey, #222);
+            line-height: 1.4;
+        }
+
+        /* ── Book strip (mobile: horizontal scroll) ───────── */
+        .book-strip {
+            display: flex;
+            gap: 10px;
+            overflow-x: auto;
+            scroll-snap-type: x mandatory;
+            -webkit-overflow-scrolling: touch;
+            padding-bottom: 4px;
+            /* Hide scrollbar but keep scroll functionality */
+            scrollbar-width: none;
+        }
+
+        .book-strip::-webkit-scrollbar {
+            display: none;
+        }
+
+        .book-item {
+            flex: 0 0 auto;
+            scroll-snap-align: start;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 6px;
+            width: 80px;
+            text-decoration: none;
+            color: inherit;
+        }
+
+        .book-cover-wrap {
+            position: relative;
+            width: 80px;
+            height: 116px;
+            border-radius: 3px;
+            overflow: hidden;
+            box-shadow: 0 2px 6px rgba(0,0,0,0.18);
+            background: var(--lightest-grey, #f0f0f0);
+            flex-shrink: 0;
+        }
+
+        .book-cover {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+            display: block;
+        }
+
+        .book-cover-placeholder {
+            width: 100%;
+            height: 100%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: var(--lightest-grey, #f0f0f0);
+            color: var(--mid-grey, #999);
+            font-size: 1.5rem;
+        }
+
+        .rank-badge {
+            position: absolute;
+            top: 4px;
+            inset-inline-start: 4px;
+            width: 20px;
+            height: 20px;
+            border-radius: 50%;
+            font-size: 0.65rem;
+            font-weight: 800;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #fff;
+            line-height: 1;
+        }
+
+        .rank-badge[data-rank="1"] { background: #c5922a; }
+        .rank-badge[data-rank="2"] { background: #8d9498; }
+        .rank-badge[data-rank="3"] { background: #a0714f; }
+
+        .book-score {
+            font-size: 0.7rem;
+            color: var(--mid-grey, #666);
+            font-family: var(--font-family-body, sans-serif);
+        }
+
+        .book-score-arrow {
+            color: var(--primary-blue, #2075c2);
+        }
+
+        /* ── Empty state ──────────────────────────────────── */
+        .empty-strip {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            padding: 12px 0;
+            color: var(--mid-grey, #888);
+            font-size: 0.875rem;
+            font-style: italic;
+            font-family: var(--font-family-body, sans-serif);
+        }
+
+        .empty-strip svg {
+            flex-shrink: 0;
+            opacity: 0.4;
+        }
+
+        /* ── Stats + CTA row ──────────────────────────────── */
+        .footer-row {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            flex-wrap: wrap;
+        }
+
+        .prompt-stats {
+            font-size: 0.8rem;
+            color: var(--mid-grey, #666);
+            font-family: var(--font-family-body, sans-serif);
+        }
+
+        .nominate-btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            padding: 8px 16px;
+            background: var(--primary-blue, #2075c2);
+            color: #fff;
+            border: none;
+            border-radius: var(--border-radius-chip, 20px);
+            font-family: var(--font-family-button, sans-serif);
+            font-size: 0.875rem;
+            font-weight: 600;
+            cursor: pointer;
+            white-space: nowrap;
+            text-decoration: none;
+        }
+
+        @media (hover: hover) and (pointer: fine) {
+            .nominate-btn:hover {
+                filter: brightness(1.1);
+            }
+        }
+
+        .nominate-btn:active {
+            transform: scale(0.97);
+        }
+
+        .nominate-btn:focus-visible {
+            outline: none;
+            box-shadow: var(--box-shadow-focus, 0 0 0 3px rgba(32, 117, 194, 0.35));
+        }
+
+        /* ── View all link ────────────────────────────────── */
+        .view-all {
+            font-size: 0.8rem;
+            color: var(--primary-blue, #2075c2);
+            text-decoration: none;
+            font-family: var(--font-family-body, sans-serif);
+        }
+
+        .view-all:hover {
+            text-decoration: underline;
+        }
+
+        /* ── Desktop: two-column layout ───────────────────── */
+        @container (min-width: 560px) {
+            .prompt-card {
+                flex-direction: row;
+                align-items: flex-start;
+                gap: 24px;
+                padding: 24px;
+            }
+
+            .prompt-text-col {
+                flex: 0 0 220px;
+                display: flex;
+                flex-direction: column;
+                gap: 12px;
+            }
+
+            .prompt-title {
+                font-size: 1.2rem;
+            }
+
+            .books-col {
+                flex: 1;
+                min-width: 0;
+            }
+
+            .book-strip {
+                overflow-x: visible;
+                flex-wrap: wrap;
+                gap: 12px;
+            }
+
+            .book-item {
+                width: 72px;
+            }
+
+            .book-cover-wrap {
+                width: 72px;
+                height: 104px;
+            }
+        }
+    `;
+
+    constructor() {
+        super();
+        this.promptTitle = '';
+        this.promptDesc = '';
+        this.nominationsJson = '[]';
+        this.totalVoters = 0;
+        this.username = '';
+        this.promptUrl = '/prompts';
+    }
+
+    get _nominations() {
+        try {
+            return JSON.parse(this.nominationsJson);
+        } catch {
+            return [];
+        }
+    }
+
+    _handleNominateClick() {
+        this.dispatchEvent(new CustomEvent('ol-weekly-prompt-nominate', {
+            bubbles: true,
+            composed: true,
+            detail: { username: this.username },
+        }));
+    }
+
+    _renderLabel() {
+        if (!this.promptDesc) return nothing;
+        return html`
+            <p class="prompt-label">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none"
+                    stroke="currentColor" stroke-width="2.5"
+                    stroke-linecap="round" stroke-linejoin="round"
+                    aria-hidden="true">
+                    <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/>
+                    <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/>
+                </svg>
+                ${this.promptDesc}
+            </p>
+        `;
+    }
+
+    _renderCover(nom, rank) {
+        const badge = rank <= 3 ? html`
+            <span class="rank-badge" data-rank="${rank}" aria-label="Rank ${rank}">
+                ${rank}
+            </span>
+        ` : nothing;
+
+        const cover = nom.coverUrl ? html`
+            <img class="book-cover" src="${nom.coverUrl}" alt="" loading="lazy" />
+        ` : html`
+            <div class="book-cover-placeholder" aria-hidden="true">📚</div>
+        `;
+
+        return html`
+            <a class="book-item" href="${nom.workKey || '#'}"
+               aria-label="${nom.title} — ${nom.score} vote${nom.score !== 1 ? 's' : ''}">
+                <div class="book-cover-wrap">
+                    ${cover}
+                    ${badge}
+                </div>
+                <span class="book-score">
+                    <span class="book-score-arrow" aria-hidden="true">▲</span>${nom.score}
+                </span>
+            </a>
+        `;
+    }
+
+    _renderBooks() {
+        const noms = this._nominations;
+        if (noms.length === 0) {
+            return html`
+                <div class="empty-strip" role="status">
+                    <svg width="28" height="28" viewBox="0 0 24 24" fill="none"
+                        stroke="currentColor" stroke-width="1.5"
+                        stroke-linecap="round" stroke-linejoin="round"
+                        aria-hidden="true">
+                        <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/>
+                        <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/>
+                    </svg>
+                    Be the first to nominate a book
+                </div>
+            `;
+        }
+        return html`
+            <div class="book-strip" role="list" aria-label="Top nominations">
+                ${noms.map((nom, i) => html`
+                    <div role="listitem">${this._renderCover(nom, i + 1)}</div>
+                `)}
+            </div>
+        `;
+    }
+
+    _renderStats() {
+        const noms = this._nominations;
+        if (noms.length === 0 && !this.totalVoters) return nothing;
+        const parts = [];
+        if (noms.length) parts.push(`${noms.length} book${noms.length !== 1 ? 's' : ''}`);
+        if (this.totalVoters) parts.push(`${this.totalVoters} reader${this.totalVoters !== 1 ? 's' : ''}`);
+        return html`<span class="prompt-stats">${parts.join(' · ')}</span>`;
+    }
+
+    _renderCTA() {
+        const href = this.username
+            ? (this.promptUrl ? `${this.promptUrl}#nominate` : '#nominate')
+            : `/account/login?redirect=${encodeURIComponent(this.promptUrl || '/prompts')}`;
+
+        return html`
+            <a class="nominate-btn" href="${href}" @click=${this._handleNominateClick}>
+                Nominate a Book
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+                    stroke="currentColor" stroke-width="2.5"
+                    stroke-linecap="round" stroke-linejoin="round"
+                    aria-hidden="true">
+                    <path d="M5 12h14"/><path d="m12 5 7 7-7 7"/>
+                </svg>
+            </a>
+        `;
+    }
+
+    render() {
+        const textCol = html`
+            <div class="prompt-text-col">
+                ${this._renderLabel()}
+                <h2 class="prompt-title">${this.promptTitle}</h2>
+                <div class="footer-row">
+                    ${this._renderStats()}
+                    ${this._renderCTA()}
+                </div>
+                ${this.promptUrl ? html`
+                    <a class="view-all" href="${this.promptUrl}">See all prompts →</a>
+                ` : nothing}
+            </div>
+        `;
+
+        const booksCol = html`
+            <div class="books-col">
+                ${this._renderBooks()}
+            </div>
+        `;
+
+        return html`
+            <div class="prompt-card">
+                ${textCol}
+                ${booksCol}
+            </div>
+        `;
+    }
+}
+
+customElements.define('ol-weekly-prompt', OLWeeklyPrompt);

--- a/openlibrary/components/lit/OLWeeklyPrompt.js
+++ b/openlibrary/components/lit/OLWeeklyPrompt.js
@@ -28,12 +28,12 @@ import { LitElement, html, css, nothing } from 'lit';
  */
 export class OLWeeklyPrompt extends LitElement {
     static properties = {
-        promptTitle:     { type: String, attribute: 'prompt-title' },
-        promptDesc:      { type: String, attribute: 'prompt-desc' },
+        promptTitle: { type: String, attribute: 'prompt-title' },
+        promptDesc: { type: String, attribute: 'prompt-desc' },
         nominationsJson: { type: String, attribute: 'nominations-json' },
-        totalVoters:     { type: Number, attribute: 'total-voters' },
-        username:        { type: String },
-        promptUrl:       { type: String, attribute: 'prompt-url' },
+        totalVoters: { type: Number, attribute: 'total-voters' },
+        username: { type: String },
+        promptUrl: { type: String, attribute: 'prompt-url' },
     };
 
     static styles = css`

--- a/openlibrary/components/lit/index.js
+++ b/openlibrary/components/lit/index.js
@@ -15,3 +15,4 @@ export { OLChip } from './OLChip.js';
 export { OLChipGroup } from './OLChipGroup.js';
 export { OLButton } from './OLButton.js';
 export { OpenLibraryOTP } from './OpenLibraryOTP.js';
+export { OLWeeklyPrompt } from './OLWeeklyPrompt.js';

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -5206,6 +5206,18 @@ msgstr ""
 msgid "eBooks Borrowed"
 msgstr ""
 
+#: home/weekly_prompt.html
+msgid "This Week's Prompt"
+msgstr ""
+
+#: home/weekly_prompt.html
+msgid "Non-fiction books that expanded your understanding of the world"
+msgstr ""
+
+#: home/weekly_prompt.html
+msgid "Staff pick · Week of June 2"
+msgstr ""
+
 #: home/welcome.html
 msgid "Read Free Library Books Online"
 msgstr ""

--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -18,6 +18,8 @@ $add_metatag(property="og:site_name", content="Open Library")
 
   $:render_template("home/welcome")
 
+  $:render_template("home/weekly_prompt")
+
   $if not test:
     $:macros.QueryCarousel(query='trending_score_hourly_sum:[1 TO *] readinglog_count:[4 TO *]', title=_('Trending Books'), key="trending", sort='trending', has_fulltext_only=False, user_lang_only=True)
     $:macros.QueryCarousel(query="ddc:8* first_publish_year:[* TO 1950] publish_year:[2000 TO *] NOT public_scan_b:false", title=_('Classic Books'), key="public_domain", sort='trending', user_lang_only=True)

--- a/openlibrary/templates/home/weekly_prompt.html
+++ b/openlibrary/templates/home/weekly_prompt.html
@@ -1,0 +1,24 @@
+$def with ()
+
+$ username = ctx.user and ctx.user.key.split('/')[-1] or ''
+
+$ stub_nominations = [
+$   {"title": "Sapiens", "coverUrl": "https://covers.openlibrary.org/b/id/8739161-M.jpg", "score": 42, "workKey": "/works/OL17075881W"},
+$   {"title": "A Brief History of Time", "coverUrl": "https://covers.openlibrary.org/b/id/8241163-M.jpg", "score": 31, "workKey": "/works/OL3861477W"},
+$   {"title": "The Selfish Gene", "coverUrl": "https://covers.openlibrary.org/b/id/8571581-M.jpg", "score": 28, "workKey": "/works/OL1881422W"}
+$ ]
+
+<div class="carousel-section weekly-prompt-section">
+  <div class="carousel-section-header">
+    <h2 class="home-h2">$_("This Week's Prompt")</h2>
+  </div>
+
+  <ol-weekly-prompt
+    prompt-title="$_('Non-fiction books that expanded your understanding of the world')"
+    prompt-desc="$_('Staff pick · Week of June 2')"
+    nominations-json="$json_encode(stub_nominations)"
+    total-voters="18"
+    username="$username"
+    prompt-url="/prompts"
+  ></ol-weekly-prompt>
+</div>

--- a/openlibrary/templates/home/weekly_prompt.html
+++ b/openlibrary/templates/home/weekly_prompt.html
@@ -19,6 +19,5 @@ $ ]
     nominations-json="$json_encode(stub_nominations)"
     total-voters="18"
     username="$username"
-    prompt-url="/prompts"
   ></ol-weekly-prompt>
 </div>


### PR DESCRIPTION
Closes #12858 (partial — Lit component MVP; backend FastAPI router is a follow-up issue)

## Summary

Adds a mobile-first `ol-weekly-prompt` Lit web component for Open Library's homepage weekly prompt feature. Staff-curated prompts surface community book recommendations to drive book discovery and patron engagement.

- New component `openlibrary/components/lit/OLWeeklyPrompt.js`
- Registered in `openlibrary/components/lit/index.js`
- New homepage sub-template `openlibrary/templates/home/weekly_prompt.html` (stub data until backend lands)
- Positioned between welcome carousel and trending books in `home/index.html`

## Component design

**Mobile-first** — default layout is a compact card with horizontal-scroll book strip:

- Prompt title + "Staff pick · Week of…" label
- Book covers with rank badges (#1 gold, #2 silver, #3 bronze) and vote scores
- Stats row: "N books · N readers"
- Blue "Nominate a Book →" CTA (links to `/account/login` for anonymous users)
- "See all prompts →" link to future history page
- Empty state: "Be the first to nominate a book" with open-book icon

**Tablet/desktop (≥ 560px container width)** — switches to two-column via CSS container queries: prompt text left, book grid right.

## Data interface

Data is passed server-side via attributes (no fetch in the Lit component):

```html
<ol-weekly-prompt
  prompt-title="Non-fiction books that expanded your understanding of the world"
  prompt-desc="Staff pick · Week of June 2"
  nominations-json='[{"title":"Sapiens","coverUrl":"...","score":42,"workKey":"/works/OL16311446W"}]'
  total-voters="18"
  username="mekarpeles"
  prompt-url="/prompts"
></ol-weekly-prompt>
```

This keeps the component agnostic to the backend — it will work identically once the FastAPI router replaces the stub data.

## Testing

**Build:** `make lit-components` compiled clean with 0 errors (188 modules including new component).

**Browser verification** (Playwright, standalone test page):
- ✅ Mobile (375px): title, label, 3 rank-badged book covers, stats, CTA all visible
- ✅ Tablet (600px): two-column layout active, nominations in grid
- ✅ Empty state renders "Be the first to nominate a book" correctly
- ✅ Zero JS console errors at all viewports

**Note on pre-existing master breakage:** `openlibrary/core/db.py` and ~15 other files have Python 2-style `except X, Y:` syntax introduced by PR #12643 (Python 3.14 update) which prevents the full web server from starting on master. This is unrelated to this PR. Browser verification was done via a standalone Playwright-driven HTML test page serving the production Vite bundle directly. The pre-existing boot failure should be addressed in a separate fix.

## Screenshots

Mobile (375px) | Desktop (900px)
---|---
Prompt card with 3 ranked book covers, stats row, CTA button | Two-column layout with text left, nomination grid right; empty state shown

## Checklist

- [x] `make lit-components` → 0 errors
- [x] Component renders at 375px (mobile) — book strip scrollable, CTA reachable
- [x] Component renders at 600px+ — two-column layout
- [x] Empty state (0 nominations) renders correctly
- [x] CTA routes logged-in users to prompt page, anonymous to `/account/login`
- [x] Zero JS console errors
- [x] ESLint clean (auto-fixed and committed)
- [x] Lit component registered in `index.js`
- [ ] Full web server browser test blocked by pre-existing master issue (#12643)