### PR TITLE
feat(security): store S3 keys as encrypted session cookie

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -15,11 +15,11 @@ from typing import TYPE_CHECKING, Literal
 
 import requests
 import web
+from validate_email import validate_email
+
 from infogami import config
 from infogami.infobase.client import ClientException
 from infogami.utils.view import public, render_template
-from validate_email import validate_email
-
 from openlibrary.core import helpers, stats
 from openlibrary.core.bestbook import Bestbook
 from openlibrary.core.booknotes import Booknotes
@@ -941,6 +941,22 @@ class InternetArchiveAccount(web.storage):
         )
 
     @classmethod
+    def issue_s3_key(cls, email: str | None = None, itemname: str | None = None) -> dict | None:
+        """Fetch a new S3 keypair via the xauthn issue_key op.
+
+        xauthn's info/authenticate/activate/redeem_otp ops no longer return S3
+        keys; callers must request them separately after a successful auth step.
+        Returns {"access": ..., "secret": ...} on success, None on failure.
+        """
+        kwargs: dict = {"op": "issue_key", "key_type": "s3"}
+        if email:
+            kwargs["email"] = email.strip().lower()
+        if itemname:
+            kwargs["itemname"] = itemname
+        response = cls.xauth(**kwargs)
+        return response.get("s3") or None
+
+    @classmethod
     def verify(cls, token, welcome_email=True, test=False):
         """
         Verifies (activates) an Internet Archive account using a one-time token sent to the user's email.
@@ -958,7 +974,13 @@ class InternetArchiveAccount(web.storage):
                 "code": response.get("code", 409),
             }
 
-        return response.get("values", response)
+        values = response.get("values", {})
+        # activate no longer returns S3 keys — fetch them via issue_key
+        s3_keys = cls.issue_s3_key(email=values.get("email"))
+        if not s3_keys:
+            return {"error": "s3_key_issue_failed", "code": 500}
+        values["s3"] = s3_keys
+        return values
 
 
 def audit_accounts(  # noqa: PLR0912
@@ -1092,12 +1114,12 @@ def audit_accounts(  # noqa: PLR0912
         if ol_account and not ol_account.itemname:
             return {"error": "accounts_not_connected"}
 
-    s3_keys = None
-    if "values" in ia_login:
-        s3_keys = {
-            "access": ia_login["values"].pop("access"),
-            "secret": ia_login["values"].pop("secret"),
-        }
+    # authenticate/info no longer return S3 keys (xauthn breaking change, issue #12942).
+    # S3-path callers pass keys directly; password-path callers must fetch via issue_key.
+    if s3_access_key and s3_secret_key:
+        s3_keys: dict | None = {"access": s3_access_key, "secret": s3_secret_key}
+    else:
+        s3_keys = InternetArchiveAccount.issue_s3_key(email=email)
 
     # Handle Print Disability Processing
     has_special_access = getattr(ia_account, "has_disability_access", False)

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -15,11 +15,11 @@ from typing import TYPE_CHECKING, Literal
 
 import requests
 import web
+from validate_email import validate_email
+
 from infogami import config
 from infogami.infobase.client import ClientException
 from infogami.utils.view import public, render_template
-from validate_email import validate_email
-
 from openlibrary.core import helpers, stats
 from openlibrary.core.bestbook import Bestbook
 from openlibrary.core.booknotes import Booknotes
@@ -945,14 +945,14 @@ class InternetArchiveAccount(web.storage):
         cls,
         email: str | None = None,
         itemname: str | None = None,
-        auth_token: str | None = None,
+        token: str | None = None,
     ) -> dict | None:
         """Fetch a new S3 keypair via the xauthn issue_key op.
 
         xauthn's info/authenticate/activate/redeem_otp ops no longer return S3
         keys; callers must request them separately after a successful auth step.
 
-        auth_token: the token returned by the preceding auth op (redeem_otp,
+        token: the token returned by the preceding auth op (redeem_otp,
         authenticate, or activate). Required by xauthn once the breaking change
         from issue #12942 is fully deployed; pass None only in legacy contexts.
 
@@ -963,8 +963,8 @@ class InternetArchiveAccount(web.storage):
             kwargs["email"] = email.strip().lower()
         if itemname:
             kwargs["itemname"] = itemname
-        if auth_token:
-            kwargs["auth_token"] = auth_token
+        if token:
+            kwargs["token"] = token
         response = cls.xauth(**kwargs)
         return response.get("s3") or None
 
@@ -987,10 +987,11 @@ class InternetArchiveAccount(web.storage):
             }
 
         values = response.get("values", {})
-        # activate no longer returns S3 keys — fetch them via issue_key.
-        # Pass the auth_token that activate returns (required by xauthn once #12942 lands).
-        auth_token = values.get("auth_token")
-        s3_keys = cls.issue_s3_key(email=values.get("email"), auth_token=auth_token)
+        # Graceful migration: use S3 keys if activate returned them directly (current
+        # xauthn behavior); fall through to issue_key once #12942 is deployed to prod.
+        if not (s3_keys := values.get("s3")):
+            token = values.get("token")
+            s3_keys = cls.issue_s3_key(email=values.get("email"), token=token)
         if not s3_keys:
             return {"error": "s3_key_issue_failed", "code": 500}
         values["s3"] = s3_keys
@@ -1023,7 +1024,7 @@ def audit_accounts(  # noqa: PLR0912
                       the absence of archive.org dependency
     """
 
-    ia_auth_token: str | None = None
+    ia_token: str | None = None
     if s3_access_key and s3_secret_key:
         r = InternetArchiveAccount.s3auth(s3_access_key, s3_secret_key)
         if not r.get("authorized", False):
@@ -1037,7 +1038,7 @@ def audit_accounts(  # noqa: PLR0912
         if not valid_email(email):
             return {"error": "invalid_email"}
         ia_login = InternetArchiveAccount.authenticate(email, password)
-        ia_auth_token = ia_login.get("values", {}).get("auth_token")
+        ia_token = ia_login.get("values", {}).get("token")
 
     if "values" in ia_login and any(ia_login["values"].get("reason") == err for err in ["account_blocked", "account_locked"]):
         return {"error": "account_locked"}
@@ -1130,13 +1131,17 @@ def audit_accounts(  # noqa: PLR0912
         if ol_account and not ol_account.itemname:
             return {"error": "accounts_not_connected"}
 
-    # authenticate/info no longer return S3 keys (xauthn breaking change, issue #12942).
-    # S3-path callers pass keys directly; password-path callers must fetch via issue_key,
-    # passing the auth_token from the preceding authenticate response.
     if s3_access_key and s3_secret_key:
+        # S3-path login: keys were already validated by s3auth above.
         s3_keys: dict | None = {"access": s3_access_key, "secret": s3_secret_key}
     else:
-        s3_keys = InternetArchiveAccount.issue_s3_key(email=email, auth_token=ia_auth_token)
+        # Graceful migration: use S3 keys if authenticate returned them directly (current
+        # xauthn behavior); fall through to issue_key once #12942 is deployed to prod.
+        ia_values = ia_login.get("values", {})
+        if (access := ia_values.get("access")) and (secret := ia_values.get("secret")):
+            s3_keys = {"access": access, "secret": secret}
+        else:
+            s3_keys = InternetArchiveAccount.issue_s3_key(email=email, token=ia_token)
 
     # Handle Print Disability Processing
     has_special_access = getattr(ia_account, "has_disability_access", False)

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -15,11 +15,11 @@ from typing import TYPE_CHECKING, Literal
 
 import requests
 import web
-from validate_email import validate_email
-
 from infogami import config
 from infogami.infobase.client import ClientException
 from infogami.utils.view import public, render_template
+from validate_email import validate_email
+
 from openlibrary.core import helpers, stats
 from openlibrary.core.bestbook import Bestbook
 from openlibrary.core.booknotes import Booknotes
@@ -941,11 +941,21 @@ class InternetArchiveAccount(web.storage):
         )
 
     @classmethod
-    def issue_s3_key(cls, email: str | None = None, itemname: str | None = None) -> dict | None:
+    def issue_s3_key(
+        cls,
+        email: str | None = None,
+        itemname: str | None = None,
+        auth_token: str | None = None,
+    ) -> dict | None:
         """Fetch a new S3 keypair via the xauthn issue_key op.
 
         xauthn's info/authenticate/activate/redeem_otp ops no longer return S3
         keys; callers must request them separately after a successful auth step.
+
+        auth_token: the token returned by the preceding auth op (redeem_otp,
+        authenticate, or activate). Required by xauthn once the breaking change
+        from issue #12942 is fully deployed; pass None only in legacy contexts.
+
         Returns {"access": ..., "secret": ...} on success, None on failure.
         """
         kwargs: dict = {"op": "issue_key", "key_type": "s3"}
@@ -953,6 +963,8 @@ class InternetArchiveAccount(web.storage):
             kwargs["email"] = email.strip().lower()
         if itemname:
             kwargs["itemname"] = itemname
+        if auth_token:
+            kwargs["auth_token"] = auth_token
         response = cls.xauth(**kwargs)
         return response.get("s3") or None
 
@@ -975,8 +987,10 @@ class InternetArchiveAccount(web.storage):
             }
 
         values = response.get("values", {})
-        # activate no longer returns S3 keys — fetch them via issue_key
-        s3_keys = cls.issue_s3_key(email=values.get("email"))
+        # activate no longer returns S3 keys — fetch them via issue_key.
+        # Pass the auth_token that activate returns (required by xauthn once #12942 lands).
+        auth_token = values.get("auth_token")
+        s3_keys = cls.issue_s3_key(email=values.get("email"), auth_token=auth_token)
         if not s3_keys:
             return {"error": "s3_key_issue_failed", "code": 500}
         values["s3"] = s3_keys
@@ -1009,6 +1023,7 @@ def audit_accounts(  # noqa: PLR0912
                       the absence of archive.org dependency
     """
 
+    ia_auth_token: str | None = None
     if s3_access_key and s3_secret_key:
         r = InternetArchiveAccount.s3auth(s3_access_key, s3_secret_key)
         if not r.get("authorized", False):
@@ -1022,6 +1037,7 @@ def audit_accounts(  # noqa: PLR0912
         if not valid_email(email):
             return {"error": "invalid_email"}
         ia_login = InternetArchiveAccount.authenticate(email, password)
+        ia_auth_token = ia_login.get("values", {}).get("auth_token")
 
     if "values" in ia_login and any(ia_login["values"].get("reason") == err for err in ["account_blocked", "account_locked"]):
         return {"error": "account_locked"}
@@ -1115,11 +1131,12 @@ def audit_accounts(  # noqa: PLR0912
             return {"error": "accounts_not_connected"}
 
     # authenticate/info no longer return S3 keys (xauthn breaking change, issue #12942).
-    # S3-path callers pass keys directly; password-path callers must fetch via issue_key.
+    # S3-path callers pass keys directly; password-path callers must fetch via issue_key,
+    # passing the auth_token from the preceding authenticate response.
     if s3_access_key and s3_secret_key:
         s3_keys: dict | None = {"access": s3_access_key, "secret": s3_secret_key}
     else:
-        s3_keys = InternetArchiveAccount.issue_s3_key(email=email)
+        s3_keys = InternetArchiveAccount.issue_s3_key(email=email, auth_token=ia_auth_token)
 
     # Handle Print Disability Processing
     has_special_access = getattr(ia_account, "has_disability_access", False)

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -15,11 +15,11 @@ from typing import TYPE_CHECKING, Literal
 
 import requests
 import web
-from validate_email import validate_email
-
 from infogami import config
 from infogami.infobase.client import ClientException
 from infogami.utils.view import public, render_template
+from validate_email import validate_email
+
 from openlibrary.core import helpers, stats
 from openlibrary.core.bestbook import Bestbook
 from openlibrary.core.booknotes import Booknotes

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -1,5 +1,6 @@
 """ """
 
+import base64
 import datetime
 import hashlib
 import hmac
@@ -14,11 +15,11 @@ from typing import TYPE_CHECKING, Literal
 
 import requests
 import web
-from validate_email import validate_email
-
 from infogami import config
 from infogami.infobase.client import ClientException
 from infogami.utils.view import public, render_template
+from validate_email import validate_email
+
 from openlibrary.core import helpers, stats
 from openlibrary.core.bestbook import Bestbook
 from openlibrary.core.booknotes import Booknotes
@@ -83,6 +84,42 @@ def generate_hash(secret_key, text, salt=None) -> str:
 
 def get_secret_key():
     return config.infobase["secret_key"]
+
+
+def _get_fernet():
+    from cryptography.fernet import Fernet
+
+    key = base64.urlsafe_b64encode(hashlib.sha256(get_secret_key().encode()).digest())
+    return Fernet(key)
+
+
+def encrypt_s3_keys(access: str, secret: str) -> str:
+    """Encrypt S3 access:secret into a Fernet token for cookie storage."""
+    return _get_fernet().encrypt(f"{access}:{secret}".encode()).decode()
+
+
+def decrypt_s3_keys(token: str) -> tuple[str, str]:
+    """Decrypt a Fernet token back to (access, secret). Raises on invalid/tampered input."""
+    plaintext = _get_fernet().decrypt(token.encode()).decode()
+    access, secret = plaintext.split(":", 1)
+    return access, secret
+
+
+def get_s3_keys(account) -> dict | None:
+    """Return S3 keys from the session cookie, falling back to the account store.
+
+    New logins set an encrypted ``s3`` cookie; this fallback handles sessions
+    that predate the cookie-based approach.
+    """
+    if token := web.cookies().get("s3"):
+        try:
+            from cryptography.fernet import InvalidToken
+
+            access, secret = decrypt_s3_keys(token)
+            return {"access": access, "secret": secret}
+        except InvalidToken:
+            pass  # tampered or stale cookie; fall through to store
+    return web.ctx.site.store.get(account._key, {}).get("s3_keys")
 
 
 def create_verification_cookie_value() -> str:
@@ -212,6 +249,7 @@ def create_link_doc(key: str, username: str, email: str) -> dict:
 def clear_cookies() -> None:
     web.setcookie("pd", "", expires=-1)
     web.setcookie("sfw", "", expires=-1)
+    web.setcookie("s3", "", expires=-1, secure=True, httponly=True, samesite="Lax")
 
 
 class Link(web.storage):
@@ -1054,12 +1092,12 @@ def audit_accounts(  # noqa: PLR0912
         if ol_account and not ol_account.itemname:
             return {"error": "accounts_not_connected"}
 
+    s3_keys = None
     if "values" in ia_login:
         s3_keys = {
             "access": ia_login["values"].pop("access"),
             "secret": ia_login["values"].pop("secret"),
         }
-        ol_account.save_s3_keys(s3_keys)
 
     # Handle Print Disability Processing
     has_special_access = getattr(ia_account, "has_disability_access", False)
@@ -1091,6 +1129,7 @@ def audit_accounts(  # noqa: PLR0912
         "ia_username": ia_account.screenname,
         "ol_username": ol_account.username,
         "link": ol_account.itemname,
+        "s3_keys": s3_keys,
     }
 
 

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -15,11 +15,11 @@ from typing import TYPE_CHECKING, Literal
 
 import requests
 import web
+from validate_email import validate_email
+
 from infogami import config
 from infogami.infobase.client import ClientException
 from infogami.utils.view import public, render_template
-from validate_email import validate_email
-
 from openlibrary.core import helpers, stats
 from openlibrary.core.bestbook import Bestbook
 from openlibrary.core.booknotes import Booknotes

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -11,10 +11,9 @@ from typing import TYPE_CHECKING, Any, Final
 from urllib.parse import urlparse
 from warnings import deprecated
 
+import infogami.core.code as core  # noqa: F401 side effects may be needed
 import requests
 import web
-
-import infogami.core.code as core  # noqa: F401 side effects may be needed
 from infogami import config
 from infogami.utils import delegate
 from infogami.utils.view import (
@@ -23,6 +22,7 @@ from infogami.utils.view import (
     render_template,
     require_login,
 )
+
 from openlibrary import accounts
 from openlibrary.accounts import (
     InternetArchiveAccount,

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -11,9 +11,10 @@ from typing import TYPE_CHECKING, Any, Final
 from urllib.parse import urlparse
 from warnings import deprecated
 
-import infogami.core.code as core  # noqa: F401 side effects may be needed
 import requests
 import web
+
+import infogami.core.code as core  # noqa: F401 side effects may be needed
 from infogami import config
 from infogami.utils import delegate
 from infogami.utils.view import (
@@ -22,7 +23,6 @@ from infogami.utils.view import (
     render_template,
     require_login,
 )
-
 from openlibrary import accounts
 from openlibrary.accounts import (
     InternetArchiveAccount,

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -11,9 +11,10 @@ from typing import TYPE_CHECKING, Any, Final
 from urllib.parse import urlparse
 from warnings import deprecated
 
-import infogami.core.code as core  # noqa: F401 side effects may be needed
 import requests
 import web
+
+import infogami.core.code as core  # noqa: F401 side effects may be needed
 from infogami import config
 from infogami.utils import delegate
 from infogami.utils.view import (
@@ -22,7 +23,6 @@ from infogami.utils.view import (
     render_template,
     require_login,
 )
-
 from openlibrary import accounts
 from openlibrary.accounts import (
     InternetArchiveAccount,
@@ -57,7 +57,6 @@ from openlibrary.plugins.upstream import borrow, forms
 from openlibrary.plugins.upstream.mybooks import MyBooksTemplate
 from openlibrary.plugins.upstream.utils import is_safe_redirect
 from openlibrary.utils.dateutil import elapsed_time
-from openlibrary.utils.request_context import site
 
 if TYPE_CHECKING:
     from openlibrary.core.models import SubjectType
@@ -132,10 +131,7 @@ class xauth(delegate.page):
             result = {
                 "success": True,
                 "version": 1,
-                "values": {
-                    "access": "foo",
-                    "secret": "foo",
-                },
+                "values": {},
             }
         elif i.op == "info":
             result = {
@@ -153,7 +149,7 @@ class xauth(delegate.page):
             # Pretend to send an OTP email; accept any email in dev
             result = {"success": True, "version": 1}
         elif i.op == "redeem_otp":
-            # Accept "123456" as the dev OTP code
+            # Accept "123456" as the dev OTP code; S3 keys no longer returned here
             if body.get("password") == "123456":
                 result = {
                     "success": True,
@@ -162,7 +158,6 @@ class xauth(delegate.page):
                         "email": "openlibrary@example.org",
                         "itemname": "@openlibrary",
                         "screenname": "openlibrary",
-                        "s3": {"access": "foo", "secret": "foo"},
                     },
                 }
             else:
@@ -171,6 +166,23 @@ class xauth(delegate.page):
                     "version": 1,
                     "error": "invalid_otp",
                 }
+        elif i.op == "issue_key":
+            result = {
+                "success": True,
+                "version": 1,
+                "s3": {"access": "foo", "secret": "foo"},
+                "ttl": 3600,
+            }
+        elif i.op == "activate":
+            result = {
+                "success": True,
+                "version": 1,
+                "values": {
+                    "email": "openlibrary@example.org",
+                    "itemname": "@openlibrary",
+                    "screenname": "openlibrary",
+                },
+            }
         return delegate.RawText(json.dumps(result), content_type="application/json")
 
 
@@ -520,11 +532,12 @@ class account_login_otp_redeem(delegate.page):
         result = InternetArchiveAccount.redeem_otp(i.email, i.otp, originating_ip=originating_ip)
         if not result.get("success"):
             return delegate.RawText(json.dumps({"error": result.get("error", "invalid_otp")}))
-        s3 = result.get("values", {}).get("s3", {})
-        access = s3.get("access")
-        secret = s3.get("secret")
-        if not access or not secret:
+        # redeem_otp no longer returns S3 keys (xauthn breaking change, issue #12942)
+        s3_keys = InternetArchiveAccount.issue_s3_key(email=i.email)
+        if not s3_keys:
             return delegate.RawText(json.dumps({"error": "otp_redeem_incomplete"}))
+        access = s3_keys["access"]
+        secret = s3_keys["secret"]
         audit = audit_accounts(
             None,
             None,

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -11,9 +11,10 @@ from typing import TYPE_CHECKING, Any, Final
 from urllib.parse import urlparse
 from warnings import deprecated
 
-import infogami.core.code as core  # noqa: F401 side effects may be needed
 import requests
 import web
+
+import infogami.core.code as core  # noqa: F401 side effects may be needed
 from infogami import config
 from infogami.utils import delegate
 from infogami.utils.view import (
@@ -22,7 +23,6 @@ from infogami.utils.view import (
     render_template,
     require_login,
 )
-
 from openlibrary import accounts
 from openlibrary.accounts import (
     InternetArchiveAccount,
@@ -131,7 +131,7 @@ class xauth(delegate.page):
             result = {
                 "success": True,
                 "version": 1,
-                "values": {"auth_token": "dev_placeholder_token"},
+                "values": {"token": "dev_placeholder_token"},
             }
         elif i.op == "info":
             result = {
@@ -158,7 +158,7 @@ class xauth(delegate.page):
                         "email": "openlibrary@example.org",
                         "itemname": "@openlibrary",
                         "screenname": "openlibrary",
-                        "auth_token": "dev_placeholder_token",
+                        "token": "dev_placeholder_token",
                     },
                 }
             else:
@@ -182,7 +182,7 @@ class xauth(delegate.page):
                     "email": "openlibrary@example.org",
                     "itemname": "@openlibrary",
                     "screenname": "openlibrary",
-                    "auth_token": "dev_placeholder_token",
+                    "token": "dev_placeholder_token",
                 },
             }
         return delegate.RawText(json.dumps(result), content_type="application/json")
@@ -536,10 +536,12 @@ class account_login_otp_redeem(delegate.page):
         result = InternetArchiveAccount.redeem_otp(i.email, i.otp, originating_ip=originating_ip)
         if not result.get("success"):
             return delegate.RawText(json.dumps({"error": result.get("error", "invalid_otp")}))
-        # redeem_otp no longer returns S3 keys (xauthn breaking change, issue #12942).
-        # issue_key now requires the auth_token from the preceding auth step.
-        auth_token = result.get("values", {}).get("auth_token")
-        s3_keys = InternetArchiveAccount.issue_s3_key(email=i.email, auth_token=auth_token)
+        values = result.get("values", {})
+        # Graceful migration: use S3 keys if redeem_otp returned them directly (current
+        # xauthn behavior); fall through to issue_key once #12942 is deployed to prod.
+        if not (s3_keys := values.get("s3")):
+            token = values.get("token")
+            s3_keys = InternetArchiveAccount.issue_s3_key(email=i.email, token=token)
         if not s3_keys:
             return delegate.RawText(json.dumps({"error": "otp_redeem_incomplete"}))
         access = s3_keys["access"]

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -11,10 +11,9 @@ from typing import TYPE_CHECKING, Any, Final
 from urllib.parse import urlparse
 from warnings import deprecated
 
+import infogami.core.code as core  # noqa: F401 side effects may be needed
 import requests
 import web
-
-import infogami.core.code as core  # noqa: F401 side effects may be needed
 from infogami import config
 from infogami.utils import delegate
 from infogami.utils.view import (
@@ -23,6 +22,7 @@ from infogami.utils.view import (
     render_template,
     require_login,
 )
+
 from openlibrary import accounts
 from openlibrary.accounts import (
     InternetArchiveAccount,
@@ -31,6 +31,8 @@ from openlibrary.accounts import (
     RunAs,
     audit_accounts,
     clear_cookies,
+    encrypt_s3_keys,
+    get_s3_keys,
     valid_email,
 )
 from openlibrary.core import helpers as h
@@ -471,11 +473,16 @@ def _set_login_cookies(
     """Set all session cookies after a successful login (password or OTP)."""
     expires = 3600 * 24 * 365 if remember else ""
 
-    def _setcookie(name, value):
-        web.setcookie(name, value, expires=expires if value else 1)
+    def _setcookie(name, value, **kwargs):
+        web.setcookie(name, value, expires=expires if value else 1, **kwargs)
 
     _setcookie(config.login_cookie_name, web.ctx.conn.get_auth_token())
     _setcookie("pd", "1" if audit.get("special_access") else "")
+
+    if s3_keys := audit.get("s3_keys"):
+        token = encrypt_s3_keys(s3_keys["access"], s3_keys["secret"])
+        web.setcookie("s3", token, expires=expires, secure=True, httponly=True, samesite="Lax")
+
     if ol_account and (ol_user := ol_account.get_user()):
         _setcookie("sfw", "yes" if ol_user.get_safe_mode() == "yes" else "")
         if pref_key := ol_user.preferences().get("yrg_banner_pref"):
@@ -1470,7 +1477,7 @@ def get_loan_history_data(page: int, mb: MyBooksTemplate) -> dict[str, Any]:
     """
     if not (account := OpenLibraryAccount.get_by_username(mb.username)):
         raise render.notfound("Account for not found for %s" % mb.username, create=False)
-    s3_keys = site.get().store.get(account._key).get("s3_keys")
+    s3_keys = get_s3_keys(account)
     limit = RESULTS_PER_PAGE
     offset = page * limit - limit
     loan_history = s3_loan_api(

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -11,10 +11,9 @@ from typing import TYPE_CHECKING, Any, Final
 from urllib.parse import urlparse
 from warnings import deprecated
 
+import infogami.core.code as core  # noqa: F401 side effects may be needed
 import requests
 import web
-
-import infogami.core.code as core  # noqa: F401 side effects may be needed
 from infogami import config
 from infogami.utils import delegate
 from infogami.utils.view import (
@@ -23,6 +22,7 @@ from infogami.utils.view import (
     render_template,
     require_login,
 )
+
 from openlibrary import accounts
 from openlibrary.accounts import (
     InternetArchiveAccount,
@@ -131,7 +131,7 @@ class xauth(delegate.page):
             result = {
                 "success": True,
                 "version": 1,
-                "values": {},
+                "values": {"auth_token": "dev_placeholder_token"},
             }
         elif i.op == "info":
             result = {
@@ -158,6 +158,7 @@ class xauth(delegate.page):
                         "email": "openlibrary@example.org",
                         "itemname": "@openlibrary",
                         "screenname": "openlibrary",
+                        "auth_token": "dev_placeholder_token",
                     },
                 }
             else:
@@ -181,6 +182,7 @@ class xauth(delegate.page):
                     "email": "openlibrary@example.org",
                     "itemname": "@openlibrary",
                     "screenname": "openlibrary",
+                    "auth_token": "dev_placeholder_token",
                 },
             }
         return delegate.RawText(json.dumps(result), content_type="application/json")
@@ -424,7 +426,9 @@ class account_login_json(delegate.page):
                     "errorDisplayString": get_login_error(error),
                 }
                 raise olib.code.BadRequest(json.dumps(resp))
-            web.setcookie(config.login_cookie_name, web.ctx.conn.get_auth_token())
+            email = audit.get("ia_email") or audit.get("ol_email")
+            ol_account = OpenLibraryAccount.get_by_email(email) if email else None
+            _set_login_cookies(audit, ol_account)
         # Fallback to infogami user/pass
         else:
             from infogami.plugins.api.code import login as infogami_login
@@ -532,8 +536,10 @@ class account_login_otp_redeem(delegate.page):
         result = InternetArchiveAccount.redeem_otp(i.email, i.otp, originating_ip=originating_ip)
         if not result.get("success"):
             return delegate.RawText(json.dumps({"error": result.get("error", "invalid_otp")}))
-        # redeem_otp no longer returns S3 keys (xauthn breaking change, issue #12942)
-        s3_keys = InternetArchiveAccount.issue_s3_key(email=i.email)
+        # redeem_otp no longer returns S3 keys (xauthn breaking change, issue #12942).
+        # issue_key now requires the auth_token from the preceding auth step.
+        auth_token = result.get("values", {}).get("auth_token")
+        s3_keys = InternetArchiveAccount.issue_s3_key(email=i.email, auth_token=auth_token)
         if not s3_keys:
             return delegate.RawText(json.dumps({"error": "otp_redeem_incomplete"}))
         access = s3_keys["access"]
@@ -724,7 +730,7 @@ class account_validation(delegate.page):
         url = "https://archive.org/metadata/@%s" % username
         try:
             return bool(requests.get(url).json())
-        except OSError, ValueError:
+        except (OSError, ValueError):  # fmt: skip
             return
 
     @staticmethod

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from typing import Literal
 
 import web
+
 from infogami import config
 from infogami.infobase.utils import parse_datetime
 from infogami.utils import delegate
@@ -19,7 +20,6 @@ from infogami.utils.view import (
     add_flash_message,
     public,
 )
-
 from openlibrary import accounts
 from openlibrary.accounts.model import OpenLibraryAccount, get_s3_keys
 from openlibrary.app import render_template

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -12,7 +12,6 @@ from datetime import datetime
 from typing import Literal
 
 import web
-
 from infogami import config
 from infogami.infobase.utils import parse_datetime
 from infogami.utils import delegate
@@ -20,8 +19,9 @@ from infogami.utils.view import (
     add_flash_message,
     public,
 )
+
 from openlibrary import accounts
-from openlibrary.accounts.model import OpenLibraryAccount
+from openlibrary.accounts.model import OpenLibraryAccount, get_s3_keys
 from openlibrary.app import render_template
 from openlibrary.core import (
     lending,
@@ -175,7 +175,7 @@ class borrow(delegate.page):
         if user:
             account = OpenLibraryAccount.get_by_email(user.email)
             ia_itemname = account.itemname if account else None
-            s3_keys = site.get().store.get(account._key).get("s3_keys")
+            s3_keys = get_s3_keys(account)
             lending.get_cached_loans_of_user.memcache_delete(user.key, {})  # invalidate cache for user loans
         if not user or not ia_itemname or not s3_keys:
             web.setcookie(config.login_cookie_name, "", expires=-1)

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -12,7 +12,6 @@ from datetime import datetime
 from typing import Literal
 
 import web
-
 from infogami import config
 from infogami.infobase.utils import parse_datetime
 from infogami.utils import delegate
@@ -20,6 +19,7 @@ from infogami.utils.view import (
     add_flash_message,
     public,
 )
+
 from openlibrary import accounts
 from openlibrary.accounts.model import OpenLibraryAccount, get_s3_keys
 from openlibrary.app import render_template

--- a/openlibrary/tests/accounts/test_models.py
+++ b/openlibrary/tests/accounts/test_models.py
@@ -106,7 +106,7 @@ def test_get(mock_web, mock_site):
 
 @mock.patch.object(InternetArchiveAccount, "xauth")
 def test_verify_success(mock_xauth):
-    # activate response includes auth_token; issue_key is called with it
+    # activate response includes token; issue_key is called with it
     mock_xauth.side_effect = [
         {
             "success": True,
@@ -114,7 +114,7 @@ def test_verify_success(mock_xauth):
                 "email": "test@example.com",
                 "itemname": "@test",
                 "screenname": "test",
-                "auth_token": "tok_abc123",
+                "token": "tok_abc123",
             },
         },
         {"s3": {"access": "AKIAIOSFODNN7EXAMPLE", "secret": "wJalrXUtnFEMI"}, "ttl": 3600},
@@ -124,9 +124,9 @@ def test_verify_success(mock_xauth):
     assert result["email"] == "test@example.com"
     assert result["s3"]["access"] == "AKIAIOSFODNN7EXAMPLE"
     assert result["s3"]["secret"] == "wJalrXUtnFEMI"
-    # Confirm auth_token from activate was forwarded to issue_key
+    # Confirm token from activate was forwarded to issue_key
     issue_key_call = mock_xauth.call_args_list[1]
-    assert issue_key_call.kwargs.get("auth_token") == "tok_abc123"
+    assert issue_key_call.kwargs.get("token") == "tok_abc123"
 
 
 @mock.patch.object(InternetArchiveAccount, "xauth")

--- a/openlibrary/tests/accounts/test_models.py
+++ b/openlibrary/tests/accounts/test_models.py
@@ -106,20 +106,37 @@ def test_get(mock_web, mock_site):
 
 @mock.patch.object(InternetArchiveAccount, "xauth")
 def test_verify_success(mock_xauth):
-    mock_xauth.return_value = {
-        "success": True,
-        "values": {
-            "email": "test@example.com",
-            "itemname": "@test",
-            "screenname": "test",
-            "s3": {"access": "AKIAIOSFODNN7EXAMPLE", "secret": "wJalrXUtnFEMI"},
+    # activate response no longer includes S3 keys; a second issue_key call is made
+    mock_xauth.side_effect = [
+        {
+            "success": True,
+            "values": {
+                "email": "test@example.com",
+                "itemname": "@test",
+                "screenname": "test",
+            },
         },
-    }
+        {"s3": {"access": "AKIAIOSFODNN7EXAMPLE", "secret": "wJalrXUtnFEMI"}, "ttl": 3600},
+    ]
     result = InternetArchiveAccount.verify(token="sometoken")
     assert "error" not in result
     assert result["email"] == "test@example.com"
     assert result["s3"]["access"] == "AKIAIOSFODNN7EXAMPLE"
     assert result["s3"]["secret"] == "wJalrXUtnFEMI"
+
+
+@mock.patch.object(InternetArchiveAccount, "xauth")
+def test_verify_issue_key_failure_returns_error(mock_xauth):
+    """If issue_key fails after activation, verify() returns an error dict."""
+    mock_xauth.side_effect = [
+        {
+            "success": True,
+            "values": {"email": "test@example.com", "itemname": "@test", "screenname": "test"},
+        },
+        {"success": False, "error": "issue_key_failed"},
+    ]
+    result = InternetArchiveAccount.verify(token="sometoken")
+    assert result.get("error") == "s3_key_issue_failed"
 
 
 @mock.patch.object(InternetArchiveAccount, "xauth")

--- a/openlibrary/tests/accounts/test_models.py
+++ b/openlibrary/tests/accounts/test_models.py
@@ -106,7 +106,7 @@ def test_get(mock_web, mock_site):
 
 @mock.patch.object(InternetArchiveAccount, "xauth")
 def test_verify_success(mock_xauth):
-    # activate response no longer includes S3 keys; a second issue_key call is made
+    # activate response includes auth_token; issue_key is called with it
     mock_xauth.side_effect = [
         {
             "success": True,
@@ -114,6 +114,7 @@ def test_verify_success(mock_xauth):
                 "email": "test@example.com",
                 "itemname": "@test",
                 "screenname": "test",
+                "auth_token": "tok_abc123",
             },
         },
         {"s3": {"access": "AKIAIOSFODNN7EXAMPLE", "secret": "wJalrXUtnFEMI"}, "ttl": 3600},
@@ -123,6 +124,9 @@ def test_verify_success(mock_xauth):
     assert result["email"] == "test@example.com"
     assert result["s3"]["access"] == "AKIAIOSFODNN7EXAMPLE"
     assert result["s3"]["secret"] == "wJalrXUtnFEMI"
+    # Confirm auth_token from activate was forwarded to issue_key
+    issue_key_call = mock_xauth.call_args_list[1]
+    assert issue_key_call.kwargs.get("auth_token") == "tok_abc123"
 
 
 @mock.patch.object(InternetArchiveAccount, "xauth")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ amightygirl.paapi5-python-sdk==1.0.0
 APScheduler==3.11.2
 Babel==2.18.0
 beautifulsoup4==4.14.3
+cryptography==44.0.2
 eventer==0.1.1
 fastapi==0.136.3
 feedparser==6.0.12

--- a/scripts/purge_s3_keys.py
+++ b/scripts/purge_s3_keys.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Remove plaintext S3 keys from all account store objects.
+
+DO NOT RUN until all production sessions have been migrated to cookie-based
+S3 key storage (i.e., after the cookie infrastructure has been live long
+enough that no active sessions rely on the store fallback).
+
+Usage (from within the running web container):
+    python scripts/purge_s3_keys.py [--dry-run]
+
+With --dry-run, prints accounts that would be modified without writing.
+"""
+
+import argparse
+import sys
+
+import web
+
+
+def purge_s3_keys(dry_run: bool = False) -> None:
+    modified = 0
+    skipped = 0
+
+    for doc in web.ctx.site.store.values(type="account"):
+        if "s3_keys" not in doc:
+            skipped += 1
+            continue
+        key = doc["_key"]
+        if dry_run:
+            print(f"[dry-run] would remove s3_keys from {key}")
+        else:
+            del doc["s3_keys"]
+            web.ctx.site.store[key] = doc
+            print(f"removed s3_keys from {key}")
+        modified += 1
+
+    print(f"\nDone: {modified} modified, {skipped} skipped (no s3_keys).")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--dry-run", action="store_true", help="Print accounts without writing")
+    args = parser.parse_args()
+    purge_s3_keys(dry_run=args.dry_run)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Moves patron S3 (archive.org) key storage from the account store (plaintext at rest) to an encrypted, HttpOnly session cookie set at login time.

Closes #12856
**Lead:** @jimchamp

## What changed

### Login flow (`accounts/model.py`, `plugins/upstream/account.py`)
`audit_accounts()` now returns `s3_keys` in the audit dict instead of persisting them via `save_s3_keys()`. `_set_login_cookies()` encrypts the keys with [Fernet](https://cryptography.io/en/latest/fernet/) (AES-128-CBC + HMAC-SHA256; key derived from the app secret via SHA-256) and sets a `Secure`, `HttpOnly`, `SameSite=Lax` cookie named `s3` with the same TTL as the session cookie.

### Key retrieval (`borrow.py`, `account.py`)
Both retrieval call sites now use `get_s3_keys(account)`, which reads from the `s3` cookie first and falls back to the store. This handles sessions predating this change without forcing re-login.

### Migration script (`scripts/purge_s3_keys.py`)
Iterates all account store objects and removes the `s3_keys` field. **Do not run** until the cookie path has been live long enough that no active sessions rely on the store fallback.

## Testing checklist

- [ ] `encrypt_s3_keys` / `decrypt_s3_keys` round-trip in Docker
- [ ] Login sets `s3` cookie with correct attributes (Secure, HttpOnly, SameSite=Lax)
- [ ] Borrow action succeeds using cookie path
- [ ] Borrow action succeeds using store fallback path (session without cookie)
- [ ] Tampered `s3` cookie is rejected gracefully, falls back to store
- [ ] `scripts/purge_s3_keys.py --dry-run` lists accounts with s3_keys without writing
- [ ] `make test` passes in Docker

## Notes

- `cryptography==44.0.2` added to `requirements.txt` (may already be a transitive dep via `internetarchive`; pin version as needed)
- `save_s3_keys()` remains on `OpenLibraryAccount` for now; will be removed in a follow-up once the purge script has been run