### PR TITLE
Small solrbuilder tweaks/improvements

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+conf/solr/** @cdrini

--- a/openlibrary/conftest.py
+++ b/openlibrary/conftest.py
@@ -75,8 +75,14 @@ def monkeytime(monkeypatch):
         nonlocal cur_time
         cur_time += secs
 
+    async def async_sleep(secs, result=None):
+        nonlocal cur_time
+        cur_time += secs
+        return result
+
     monkeypatch.setattr("time.time", time)
     monkeypatch.setattr("time.sleep", sleep)
+    monkeypatch.setattr("asyncio.sleep", async_sleep)
 
 
 @pytest.fixture

--- a/openlibrary/solr/update.py
+++ b/openlibrary/solr/update.py
@@ -71,9 +71,9 @@ async def update_keys(
     """
     logger.debug("BEGIN update_keys")
 
-    def _solr_update(update_state: SolrUpdateRequest):
+    async def _solr_update(update_state: SolrUpdateRequest):
         if update == "update":
-            return solr_update(update_state, skip_id_check)
+            return await solr_update(update_state, skip_id_check)
         elif update == "pprint":
             print(update_state.to_solr_requests_json(sep="\n", indent=4))
         elif update == "print":
@@ -132,7 +132,7 @@ async def update_keys(
                     for doc in update_state.adds:
                         await f.write(f"{json.dumps(doc)}\n")
             else:
-                _solr_update(update_state)
+                await _solr_update(update_state)
         net_update += update_state
 
     logger.debug("END update_keys")

--- a/openlibrary/solr/utils.py
+++ b/openlibrary/solr/utils.py
@@ -191,6 +191,18 @@ async def solr_insert_documents(
     tolerant_chain=False,
     timeout: float | None = 30,  # noqa: ASYNC109
 ):
+    """
+    :param documents: List of documents to insert into Solr
+    :param solr_base_url: Base URL for Solr, e.g. http://localhost:8983/solr/openlibrary
+    :param skip_id_check: DANGER! If true, Solr will not check for duplicate IDs and will
+    insert documents even if they have the same ID as an existing document. This can lead
+        to data corruption and should only be used if you are sure that there are no
+        duplicate IDs in your dataset -- e.g. when inserting into an empty solr.
+    :param tolerant_chain: If true, use Solr's tolerant update chain, which will allow
+        the update to succeed even if some documents fail to index. This is useful for
+        large batches where you want to maximize the number of documents that get indexed,
+        even if there are some bad apples in the batch.
+    """
     solr_base_url = solr_base_url or get_solr_base_url()
     params = {}
     if skip_id_check:

--- a/openlibrary/solr/utils.py
+++ b/openlibrary/solr/utils.py
@@ -187,21 +187,24 @@ async def solr_insert_documents(
     documents: list[dict],
     solr_base_url: str | None = None,
     skip_id_check=False,
+    timeout: float | None = 30,
 ):
-    """
-    Note: This has only been tested with Solr 8, but might work with Solr 3 as well.
-    """
     solr_base_url = solr_base_url or get_solr_base_url()
     params = {}
     if skip_id_check:
         params["overwrite"] = "false"
     logger.debug(f"POSTing update to {solr_base_url}/update {params}")
-    async with httpx.AsyncClient() as client:
-        resp = await client.post(
-            f"{solr_base_url}/update",
-            timeout=30,  # seconds; the default timeout is silly short
-            params=params,
-            headers={"Content-Type": "application/json"},
-            content=json.dumps(documents),
-        )
-    resp.raise_for_status()
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{solr_base_url}/update",
+                timeout=timeout,
+                params=params,
+                headers={"Content-Type": "application/json"},
+                content=json.dumps(documents),
+            )
+        resp.raise_for_status()
+    except HTTPStatusError as e:
+        response_body = e.response.text if e.response is not None else None
+        logger.error(f"HTTP Status Solr POST Error: {e}; response body: {response_body}")
+        raise

--- a/openlibrary/solr/utils.py
+++ b/openlibrary/solr/utils.py
@@ -4,10 +4,10 @@ import os
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, cast
 
+import httpx
 from httpx import HTTPError, HTTPStatusError, TimeoutException
 
 from openlibrary import config
-from openlibrary.plugins.worksearch.search import get_solr
 from openlibrary.utils.retry import MaxRetriesExceeded, RetryStrategy
 
 if TYPE_CHECKING:
@@ -18,6 +18,7 @@ logger = logging.getLogger("openlibrary.solr")
 
 solr_base_url = None
 solr_next: bool | None = None
+httpx_client = httpx.AsyncClient()
 
 
 def load_config(c_config="conf/openlibrary.yml"):
@@ -134,7 +135,7 @@ async def solr_update(
     async def make_request():
         logger.debug(f"POSTing update to {solr_base_url}/update {params}")
         try:
-            resp = await get_solr().async_session.post(
+            resp = await httpx_client.post(
                 f"{solr_base_url}/update",
                 # Large batches especially can take a decent chunk of time
                 timeout=300,
@@ -195,7 +196,7 @@ async def solr_insert_documents(
         params["overwrite"] = "false"
     logger.debug(f"POSTing update to {solr_base_url}/update {params}")
     try:
-        resp = await get_solr().async_session.post(
+        resp = await httpx_client.post(
             f"{solr_base_url}/update",
             timeout=timeout,
             params=params,

--- a/openlibrary/solr/utils.py
+++ b/openlibrary/solr/utils.py
@@ -144,24 +144,21 @@ async def solr_update(
                 content=content,
             )
 
-            if resp.status_code == 400:
+            if resp.status_code in (200, 400):
                 resp_json = resp.json()
 
-                indiv_errors = resp_json.get("responseHeader", {}).get("errors", [])
-                if indiv_errors:
+                if indiv_errors := resp_json.get("responseHeader", {}).get("errors", []):
                     for e in indiv_errors:
                         logger.error(f"Individual Solr POST Error: {e}")
 
-                global_error = resp_json.get("error")
-                if global_error:
+                if global_error := resp_json.get("error"):
                     logger.error(f"Global Solr POST Error: {global_error.get('msg')}")
 
-                if not (indiv_errors or global_error):
-                    # We can handle the above errors. Any other 400 status codes
-                    # are fatal and should cause a retry
+                if not indiv_errors and not global_error:
                     resp.raise_for_status()
             else:
                 resp.raise_for_status()
+
         except HTTPStatusError as e:
             logger.error(f"HTTP Status Solr POST Error: {e}")
             raise

--- a/openlibrary/solr/utils.py
+++ b/openlibrary/solr/utils.py
@@ -188,12 +188,15 @@ async def solr_insert_documents(
     documents: list[dict],
     solr_base_url: str | None = None,
     skip_id_check=False,
+    tolerant_chain=False,
     timeout: float | None = 30,  # noqa: ASYNC109
 ):
     solr_base_url = solr_base_url or get_solr_base_url()
     params = {}
     if skip_id_check:
         params["overwrite"] = "false"
+    if tolerant_chain:
+        params["update.chain"] = "tolerant-chain"
     logger.debug(f"POSTing update to {solr_base_url}/update {params}")
     try:
         resp = await httpx_client.post(

--- a/openlibrary/solr/utils.py
+++ b/openlibrary/solr/utils.py
@@ -4,10 +4,10 @@ import os
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, cast
 
-import httpx
 from httpx import HTTPError, HTTPStatusError, TimeoutException
 
 from openlibrary import config
+from openlibrary.plugins.worksearch.search import get_solr
 from openlibrary.utils.retry import MaxRetriesExceeded, RetryStrategy
 
 if TYPE_CHECKING:
@@ -116,7 +116,7 @@ class SolrUpdateRequest:
         self.deletes.clear()
 
 
-def solr_update(
+async def solr_update(
     update_request: SolrUpdateRequest,
     skip_id_check=False,
     solr_base_url: str | None = None,
@@ -131,10 +131,10 @@ def solr_update(
     if skip_id_check:
         params["overwrite"] = "false"
 
-    def make_request():
+    async def make_request():
         logger.debug(f"POSTing update to {solr_base_url}/update {params}")
         try:
-            resp = httpx.post(
+            resp = await get_solr().async_session.post(
                 f"{solr_base_url}/update",
                 # Large batches especially can take a decent chunk of time
                 timeout=300,
@@ -178,7 +178,7 @@ def solr_update(
     )
 
     try:
-        return retry(make_request)
+        return await retry.async_call(make_request)
     except MaxRetriesExceeded as e:
         logger.error(f"Max retries exceeded for Solr POST: {e.last_exception}")
 
@@ -187,7 +187,7 @@ async def solr_insert_documents(
     documents: list[dict],
     solr_base_url: str | None = None,
     skip_id_check=False,
-    timeout: float | None = 30,
+    timeout: float | None = 30,  # noqa: ASYNC109
 ):
     solr_base_url = solr_base_url or get_solr_base_url()
     params = {}
@@ -195,14 +195,13 @@ async def solr_insert_documents(
         params["overwrite"] = "false"
     logger.debug(f"POSTing update to {solr_base_url}/update {params}")
     try:
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                f"{solr_base_url}/update",
-                timeout=timeout,
-                params=params,
-                headers={"Content-Type": "application/json"},
-                content=json.dumps(documents),
-            )
+        resp = await get_solr().async_session.post(
+            f"{solr_base_url}/update",
+            timeout=timeout,
+            params=params,
+            headers={"Content-Type": "application/json"},
+            content=json.dumps(documents),
+        )
         resp.raise_for_status()
     except HTTPStatusError as e:
         response_body = e.response.text if e.response is not None else None

--- a/openlibrary/tests/solr/test_utils.py
+++ b/openlibrary/tests/solr/test_utils.py
@@ -6,17 +6,10 @@ from httpx import ConnectError, Response
 
 from openlibrary.solr import utils
 from openlibrary.solr.utils import SolrUpdateRequest, solr_update
-from openlibrary.utils import retry as retry_module
 
 
 class TestSolrUpdate:
     pytestmark = pytest.mark.asyncio
-
-    def setup_solr_post(self, monkeypatch, response=None, side_effect=None):
-        mock_post = AsyncMock(return_value=response, side_effect=side_effect)
-        monkeypatch.setattr(utils.httpx_client, "post", mock_post)
-        monkeypatch.setattr(retry_module.asyncio, "sleep", AsyncMock())
-        return mock_post
 
     def sample_response_200(self):
         return Response(
@@ -90,7 +83,8 @@ class TestSolrUpdate:
         )
 
     async def test_successful_response(self, monkeypatch, monkeytime):
-        mock_post = self.setup_solr_post(monkeypatch, response=self.sample_response_200())
+        mock_post = AsyncMock(return_value=self.sample_response_200())
+        monkeypatch.setattr(utils.httpx_client, "post", mock_post)
 
         await solr_update(
             SolrUpdateRequest(commit=True),
@@ -100,7 +94,8 @@ class TestSolrUpdate:
         assert mock_post.call_count == 1
 
     async def test_non_json_solr_503(self, monkeypatch, monkeytime):
-        mock_post = self.setup_solr_post(monkeypatch, response=self.sample_response_503())
+        mock_post = AsyncMock(return_value=self.sample_response_503())
+        monkeypatch.setattr(utils.httpx_client, "post", mock_post)
 
         await solr_update(
             SolrUpdateRequest(commit=True),
@@ -110,7 +105,8 @@ class TestSolrUpdate:
         assert mock_post.call_count > 1
 
     async def test_solr_offline(self, monkeypatch, monkeytime):
-        mock_post = self.setup_solr_post(monkeypatch, side_effect=ConnectError("", request=MagicMock()))
+        mock_post = AsyncMock(side_effect=ConnectError("", request=MagicMock()))
+        monkeypatch.setattr(utils.httpx_client, "post", mock_post)
 
         await solr_update(
             SolrUpdateRequest(commit=True),
@@ -120,7 +116,8 @@ class TestSolrUpdate:
         assert mock_post.call_count > 1
 
     async def test_invalid_solr_request(self, monkeypatch, monkeytime):
-        mock_post = self.setup_solr_post(monkeypatch, response=self.sample_global_error())
+        mock_post = AsyncMock(return_value=self.sample_global_error())
+        monkeypatch.setattr(utils.httpx_client, "post", mock_post)
 
         await solr_update(
             SolrUpdateRequest(commit=True),
@@ -130,7 +127,8 @@ class TestSolrUpdate:
         assert mock_post.call_count == 1
 
     async def test_bad_apple_in_solr_request(self, monkeypatch, monkeytime):
-        mock_post = self.setup_solr_post(monkeypatch, response=self.sample_individual_error())
+        mock_post = AsyncMock(return_value=self.sample_individual_error())
+        monkeypatch.setattr(utils.httpx_client, "post", mock_post)
 
         await solr_update(
             SolrUpdateRequest(commit=True),
@@ -140,7 +138,8 @@ class TestSolrUpdate:
         assert mock_post.call_count == 1
 
     async def test_other_non_ok_status(self, monkeypatch, monkeytime):
-        mock_post = self.setup_solr_post(monkeypatch, response=Response(500, request=MagicMock(), content="{}"))
+        mock_post = AsyncMock(return_value=Response(500, request=MagicMock(), content="{}"))
+        monkeypatch.setattr(utils.httpx_client, "post", mock_post)
 
         await solr_update(
             SolrUpdateRequest(commit=True),

--- a/openlibrary/tests/solr/test_utils.py
+++ b/openlibrary/tests/solr/test_utils.py
@@ -55,7 +55,7 @@ class TestSolrUpdate:
 
     def sample_individual_error(self):
         return Response(
-            400,
+            200,
             request=MagicMock(),
             content=json.dumps(
                 {
@@ -63,8 +63,8 @@ class TestSolrUpdate:
                         "errors": [
                             {
                                 "type": "ADD",
-                                "id": "/books/OL1M",
-                                "message": "[doc=/books/OL1M] missing required field: type",
+                                "id": "/works/OL16086453W",
+                                "message": "ERROR: [doc=/works/OL16086453W] unknown field 'foo'",
                             }
                         ],
                         "maxErrors": -1,

--- a/openlibrary/tests/solr/test_utils.py
+++ b/openlibrary/tests/solr/test_utils.py
@@ -1,13 +1,25 @@
 import json
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
-import httpx
+import pytest
 from httpx import ConnectError, Response
 
+from openlibrary.solr import utils
 from openlibrary.solr.utils import SolrUpdateRequest, solr_update
+from openlibrary.utils import retry as retry_module
 
 
 class TestSolrUpdate:
+    pytestmark = pytest.mark.asyncio
+
+    def setup_solr_post(self, monkeypatch, response=None, side_effect=None):
+        mock_post = AsyncMock(return_value=response, side_effect=side_effect)
+        mock_solr = MagicMock()
+        mock_solr.async_session.post = mock_post
+        monkeypatch.setattr(utils, "get_solr", lambda: mock_solr)
+        monkeypatch.setattr(retry_module.asyncio, "sleep", AsyncMock())
+        return mock_post
+
     def sample_response_200(self):
         return Response(
             200,
@@ -79,66 +91,60 @@ class TestSolrUpdate:
             content=b"<html><body><h1>503 Service Unavailable</h1>",
         )
 
-    def test_successful_response(self, monkeypatch, monkeytime):
-        mock_post = MagicMock(return_value=self.sample_response_200())
-        monkeypatch.setattr(httpx, "post", mock_post)
+    async def test_successful_response(self, monkeypatch, monkeytime):
+        mock_post = self.setup_solr_post(monkeypatch, response=self.sample_response_200())
 
-        solr_update(
+        await solr_update(
             SolrUpdateRequest(commit=True),
             solr_base_url="http://localhost:8983/solr/foobar",
         )
 
         assert mock_post.call_count == 1
 
-    def test_non_json_solr_503(self, monkeypatch, monkeytime):
-        mock_post = MagicMock(return_value=self.sample_response_503())
-        monkeypatch.setattr(httpx, "post", mock_post)
+    async def test_non_json_solr_503(self, monkeypatch, monkeytime):
+        mock_post = self.setup_solr_post(monkeypatch, response=self.sample_response_503())
 
-        solr_update(
+        await solr_update(
             SolrUpdateRequest(commit=True),
             solr_base_url="http://localhost:8983/solr/foobar",
         )
 
         assert mock_post.call_count > 1
 
-    def test_solr_offline(self, monkeypatch, monkeytime):
-        mock_post = MagicMock(side_effect=ConnectError("", request=None))
-        monkeypatch.setattr(httpx, "post", mock_post)
+    async def test_solr_offline(self, monkeypatch, monkeytime):
+        mock_post = self.setup_solr_post(monkeypatch, side_effect=ConnectError("", request=MagicMock()))
 
-        solr_update(
+        await solr_update(
             SolrUpdateRequest(commit=True),
             solr_base_url="http://localhost:8983/solr/foobar",
         )
 
         assert mock_post.call_count > 1
 
-    def test_invalid_solr_request(self, monkeypatch, monkeytime):
-        mock_post = MagicMock(return_value=self.sample_global_error())
-        monkeypatch.setattr(httpx, "post", mock_post)
+    async def test_invalid_solr_request(self, monkeypatch, monkeytime):
+        mock_post = self.setup_solr_post(monkeypatch, response=self.sample_global_error())
 
-        solr_update(
+        await solr_update(
             SolrUpdateRequest(commit=True),
             solr_base_url="http://localhost:8983/solr/foobar",
         )
 
         assert mock_post.call_count == 1
 
-    def test_bad_apple_in_solr_request(self, monkeypatch, monkeytime):
-        mock_post = MagicMock(return_value=self.sample_individual_error())
-        monkeypatch.setattr(httpx, "post", mock_post)
+    async def test_bad_apple_in_solr_request(self, monkeypatch, monkeytime):
+        mock_post = self.setup_solr_post(monkeypatch, response=self.sample_individual_error())
 
-        solr_update(
+        await solr_update(
             SolrUpdateRequest(commit=True),
             solr_base_url="http://localhost:8983/solr/foobar",
         )
 
         assert mock_post.call_count == 1
 
-    def test_other_non_ok_status(self, monkeypatch, monkeytime):
-        mock_post = MagicMock(return_value=Response(500, request=MagicMock(), content="{}"))
-        monkeypatch.setattr(httpx, "post", mock_post)
+    async def test_other_non_ok_status(self, monkeypatch, monkeytime):
+        mock_post = self.setup_solr_post(monkeypatch, response=Response(500, request=MagicMock(), content="{}"))
 
-        solr_update(
+        await solr_update(
             SolrUpdateRequest(commit=True),
             solr_base_url="http://localhost:8983/solr/foobar",
         )

--- a/openlibrary/tests/solr/test_utils.py
+++ b/openlibrary/tests/solr/test_utils.py
@@ -14,9 +14,7 @@ class TestSolrUpdate:
 
     def setup_solr_post(self, monkeypatch, response=None, side_effect=None):
         mock_post = AsyncMock(return_value=response, side_effect=side_effect)
-        mock_solr = MagicMock()
-        mock_solr.async_session.post = mock_post
-        monkeypatch.setattr(utils, "get_solr", lambda: mock_solr)
+        monkeypatch.setattr(utils.httpx_client, "post", mock_post)
         monkeypatch.setattr(retry_module.asyncio, "sleep", AsyncMock())
         return mock_post
 

--- a/openlibrary/utils/retry.py
+++ b/openlibrary/utils/retry.py
@@ -1,4 +1,6 @@
+import asyncio
 import time
+from collections.abc import Awaitable, Callable
 
 
 class MaxRetriesExceeded(Exception):
@@ -17,7 +19,7 @@ class RetryStrategy:
         self.max_retries = max_retries
         self.delay = delay
 
-    def __call__(self, func):
+    def __call__[T](self, func: Callable[[], T]) -> T:
         try:
             return func()
         except Exception as e:
@@ -30,5 +32,21 @@ class RetryStrategy:
                 self.retry_count += 1
                 time.sleep(self.delay)
                 return self(func)
+            else:
+                raise MaxRetriesExceeded(self.last_exception)
+
+    async def async_call[T](self, func: Callable[[], Awaitable[T]]) -> T:
+        try:
+            return await func()
+        except Exception as e:
+            if not any(isinstance(e, exc) for exc in self.exceptions):
+                raise e
+
+            self.last_exception = e
+
+            if self.retry_count < self.max_retries:
+                self.retry_count += 1
+                await asyncio.sleep(self.delay)
+                return await self.async_call(func)
             else:
                 raise MaxRetriesExceeded(self.last_exception)

--- a/scripts/solr_builder/Dockerfile.olpython
+++ b/scripts/solr_builder/Dockerfile.olpython
@@ -17,7 +17,7 @@ RUN uv pip install \
     cprofilev \
     # Faster python
     setuptools \
-    Cython==3.0.6
+    Cython==3.2.5
 
 # Build cython files
 COPY . /openlibrary

--- a/scripts/solr_builder/Jenkinsfile
+++ b/scripts/solr_builder/Jenkinsfile
@@ -11,11 +11,8 @@ pipeline {
     }
   }
   parameters {
-    booleanParam(name: 'WIPE_OLD_POSTGRES', defaultValue: false, description: 'If true, removes the current postgres')
-    booleanParam(name: 'REUSE_POSTGRES', defaultValue: false, description: 'If true, assumes a functioning postgres is running/correct')
-
+    booleanParam(name: 'WIPE_OLD_POSTGRES', defaultValue: false, description: 'If true, removes the current postgres. Otherwise assumes a postgres is already filled and running')
     booleanParam(name: 'WIPE_OLD_SOLR', defaultValue: false, description: 'If true, removes the current solr')
-    booleanParam(name: 'INTO_SOLR_FROM_DUMP', defaultValue: true, description: 'If true, reindexes dump into solr')
     booleanParam(name: 'INDEX_WORKS', defaultValue: true, description: 'If true, reindexes works into solr')
     booleanParam(name: 'INDEX_ORPHANS', defaultValue: true, description: 'If true, reindexes orphans into solr')
     booleanParam(name: 'INDEX_SUBJECTS', defaultValue: true, description: 'If true, reindexes subjects into solr')
@@ -36,7 +33,7 @@ pipeline {
   }
   stages {
     stage('1: Create a local postgres copy of the database') {
-      when { expression { return !params.REUSE_POSTGRES } }
+      when { expression { return params.WIPE_OLD_POSTGRES } }
       environment {
         // Where to download the ol full dump from
         OL_DUMP_LINK = 'https://openlibrary.org/data/ol_dump_latest.txt.gz'
@@ -52,7 +49,6 @@ pipeline {
       }
       stages {
         stage('Wipe old postgres') {
-          when { expression { return params.WIPE_OLD_POSTGRES } }
           steps {
             dir(env.HOST_SOLR_BUILDER_DIR) {
               sh(label: 'Stop running db',
@@ -159,7 +155,7 @@ pipeline {
       stages {
         stage('Restart Postgres') {
           // Have to restart to because the previous workspace was destroyed on cleanup
-          when { expression { return params.REUSE_POSTGRES } }
+          when { expression { return !params.WIPE_OLD_POSTGRES } }
           steps {
             dir(env.HOST_SOLR_BUILDER_DIR) {
               sh(label: 'Stop the db containers',
@@ -204,7 +200,7 @@ pipeline {
         stage('Reindexing') {
           parallel {
             stage('Reindex from ol dump') {
-              when { expression { return params.INTO_SOLR_FROM_DUMP } }
+              when { expression { return params.INDEX_WORKS || params.INDEX_ORPHANS || params.INDEX_SUBJECTS || params.INDEX_AUTHORS || params.INDEX_LISTS } }
               stages {
                 stage('Insert works') {
                   when { expression { return params.INDEX_WORKS } }

--- a/scripts/solr_builder/solr_builder/index_subjects.py
+++ b/scripts/solr_builder/solr_builder/index_subjects.py
@@ -92,10 +92,10 @@ async def index_all_subjects(
     instances=2,
     solr_base_url="http://solr:8983/solr/openlibrary",
     skip_id_check=False,
+    offset=0,
 ):
     done = False
     active_workers: set[Future] = set()
-    offset = 0
     while True:
         if done:
             # Done! Wait for any previous workers that are still going

--- a/scripts/solr_builder/solr_builder/index_subjects.py
+++ b/scripts/solr_builder/solr_builder/index_subjects.py
@@ -72,6 +72,7 @@ async def index_subjects(
         docs,
         solr_base_url=solr_base_url,
         skip_id_check=skip_id_check,
+        tolerant_chain=True,
         timeout=None,  # Don't set a timeout for indexing
     )
     print(

--- a/scripts/solr_builder/solr_builder/index_subjects.py
+++ b/scripts/solr_builder/solr_builder/index_subjects.py
@@ -72,6 +72,7 @@ async def index_subjects(
         docs,
         solr_base_url=solr_base_url,
         skip_id_check=skip_id_check,
+        timeout=None,  # Don't set a timeout for indexing
     )
     print(
         json.dumps(


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Part of #11650 

- Simplify jenkins params by removing some redundant ones
- Update to latest cython version to fix warnings
- Add `--offset` cli argument to `index_subjects` for easy retry of failed chunk
- Remove solr insert timeout ; noticing a few EOL errors in solr logs during `index_subjects`
- Use shared httpx client for solr requests for perf
- Make solr update async
- Fixes errors in solr update commands being silenced, which resulted in us missing #12890 .

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

Before:
<img width="523" height="551" alt="image" src="https://github.com/user-attachments/assets/4e91e3ed-ccd5-40ec-9d9b-38b2dabdf4c0" />

After:
<img width="808" height="561" alt="image" src="https://github.com/user-attachments/assets/21daebee-4762-4a66-ad02-6b59b767df89" />

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
