### PR TITLE
feat(homepage): 'What's Happening Now' activity feed widget

### DIFF
--- a/openlibrary/components/lit/OLActivityFeed.js
+++ b/openlibrary/components/lit/OLActivityFeed.js
@@ -40,6 +40,7 @@ export class OLActivityFeed extends LitElement {
     static properties = {
         apiUrl: { type: String, attribute: 'api-url' },
         cardsPerPage: { type: Number, attribute: 'cards-per-page' },
+        viewerUsername: { type: String, attribute: 'viewer-username' },
         _displayed: { state: true },
         _queue: { state: true },
         _loading: { state: true },
@@ -258,6 +259,7 @@ export class OLActivityFeed extends LitElement {
         super();
         this.apiUrl = '/api/internal/activity.json';
         this.cardsPerPage = 3;
+        this.viewerUsername = '';
         this._displayed = [];
         this._queue = [];
         this._loading = true;
@@ -265,7 +267,6 @@ export class OLActivityFeed extends LitElement {
         this._nextPage = 1;
         this._followed = new Set();
         this._timer = null;
-        this._viewerUsername = document.body?.dataset?.username || null;
     }
 
     connectedCallback() {
@@ -331,7 +332,7 @@ export class OLActivityFeed extends LitElement {
     }
 
     async _toggleFollow(username) {
-        if (!this._viewerUsername) {
+        if (!this.viewerUsername) {
             window.location = `/account/login?redir_url=${encodeURIComponent(window.location.pathname)}`;
             return;
         }
@@ -346,7 +347,7 @@ export class OLActivityFeed extends LitElement {
         body.append('redir_url', window.location.pathname);
 
         try {
-            await fetch(`/people/${this._viewerUsername}/follows`, {
+            await fetch(`/people/${this.viewerUsername}/follows.json`, {
                 method: 'POST',
                 body,
                 redirect: 'manual',
@@ -365,7 +366,7 @@ export class OLActivityFeed extends LitElement {
         const coverSrc = item.cover_id
             ? `${COVERS_BASE}/${item.cover_id}-M.jpg`
             : FALLBACK_COVER;
-        const isViewer = item.username === this._viewerUsername;
+        const isViewer = item.username === this.viewerUsername;
         const following = this._followed.has(item.username);
 
         return html`

--- a/openlibrary/components/lit/OLActivityFeed.js
+++ b/openlibrary/components/lit/OLActivityFeed.js
@@ -1,0 +1,421 @@
+import { LitElement, html, css } from 'lit';
+
+/**
+ * OLActivityFeed — "What's Happening Now" homepage widget.
+ *
+ * Displays a sliding window of 3 public reading-log activity cards.
+ * Auto-advances every 15 seconds by pulling from an internal buffer;
+ * fetches the next page from the API when the buffer is exhausted.
+ * A right-arrow lets the patron advance manually. When all pages are
+ * consumed, the arrow becomes a "More →" link to /trending.
+ *
+ * @element ol-activity-feed
+ *
+ * @prop {String} apiUrl        - Endpoint to fetch activity JSON from.
+ *                                Default: "/api/internal/activity.json"
+ * @prop {Number} cardsPerPage  - Cards shown at once. Default: 3
+ */
+
+const SHELF_LABELS = {
+    1: 'added to Want to Read',
+    2: 'is Currently Reading',
+    3: 'has Already Read',
+    4: 'stopped reading',
+};
+
+const COVERS_BASE = 'https://covers.openlibrary.org/b/id';
+const FALLBACK_COVER = '/static/images/icons/avatar_book-sm.png';
+const FALLBACK_AVATAR = '/static/images/icons/avatar_book-sm.png';
+
+function timeAgo(updated) {
+    if (!updated) return '';
+    const diff = Date.now() - new Date(updated).getTime();
+    const days = Math.floor(diff / 86400000);
+    if (days === 0) return 'today';
+    if (days === 1) return '1d ago';
+    return `${days}d ago`;
+}
+
+export class OLActivityFeed extends LitElement {
+    static properties = {
+        apiUrl: { type: String, attribute: 'api-url' },
+        cardsPerPage: { type: Number, attribute: 'cards-per-page' },
+        _displayed: { state: true },
+        _queue: { state: true },
+        _loading: { state: true },
+        _atEnd: { state: true },
+        _nextPage: { state: true },
+        _followed: { state: true },
+    };
+
+    static styles = css`
+        :host {
+            display: block;
+            font-family: inherit;
+        }
+
+        .feed {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        /* Individual activity card */
+        .card {
+            background: #fff;
+            border-radius: 10px;
+            box-shadow: 0 1px 4px rgba(0,0,0,.1);
+            overflow: hidden;
+        }
+
+        /* TOP: patron identity + action text */
+        .card-header {
+            padding: 12px 14px 10px;
+        }
+
+        .patron-row {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 4px;
+        }
+
+        .avatar {
+            width: 32px;
+            height: 32px;
+            border-radius: 50%;
+            object-fit: cover;
+            flex-shrink: 0;
+            border: 2px solid #eee;
+        }
+
+        .username {
+            font-size: 13px;
+            font-weight: 600;
+            color: #222;
+            text-decoration: none;
+            flex: 1;
+            min-width: 0;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .username:hover { text-decoration: underline; }
+
+        .btn-follow {
+            background: #1565c0;
+            color: #fff;
+            border: none;
+            border-radius: 20px;
+            padding: 4px 12px;
+            font-size: 12px;
+            font-weight: 600;
+            cursor: pointer;
+            flex-shrink: 0;
+            transition: background .15s;
+        }
+        .btn-follow:hover { background: #0d47a1; }
+        .btn-follow.following {
+            background: #e0e0e0;
+            color: #444;
+        }
+        .btn-follow.following:hover { background: #bdbdbd; }
+
+        .action-text {
+            font-size: 12px;
+            color: #666;
+        }
+
+        .card-divider {
+            margin: 0 14px;
+            border: none;
+            border-top: 1px solid #eee;
+        }
+
+        /* BOTTOM: book content */
+        .card-body {
+            padding: 12px 14px 14px;
+        }
+
+        .book-row {
+            display: flex;
+            gap: 12px;
+            margin-bottom: 10px;
+            text-decoration: none;
+            color: inherit;
+        }
+
+        .book-cover {
+            width: 58px;
+            height: 82px;
+            object-fit: cover;
+            border-radius: 3px;
+            flex-shrink: 0;
+            box-shadow: 0 1px 3px rgba(0,0,0,.2);
+        }
+
+        .book-meta {
+            flex: 1;
+            min-width: 0;
+            padding-top: 2px;
+        }
+
+        .book-title {
+            font-size: 14px;
+            font-weight: 700;
+            color: #111;
+            line-height: 1.3;
+            margin-bottom: 4px;
+            display: -webkit-box;
+            -webkit-line-clamp: 3;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+        }
+
+        .book-author {
+            font-size: 12px;
+            color: #666;
+        }
+
+        .btn-row {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+
+        .btn-primary {
+            display: block;
+            background: #1565c0;
+            color: #fff;
+            border: none;
+            border-radius: 20px;
+            padding: 8px 0;
+            font-size: 13px;
+            font-weight: 600;
+            text-align: center;
+            text-decoration: none;
+            cursor: pointer;
+            transition: background .15s;
+        }
+        .btn-primary:hover { background: #0d47a1; }
+
+        /* Navigation footer */
+        .feed-footer {
+            display: flex;
+            justify-content: flex-end;
+            padding-top: 4px;
+        }
+
+        .btn-next {
+            background: none;
+            border: 1px solid #ccc;
+            border-radius: 50%;
+            width: 36px;
+            height: 36px;
+            font-size: 20px;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #444;
+            transition: border-color .15s, color .15s;
+        }
+        .btn-next:hover { border-color: #1565c0; color: #1565c0; }
+
+        .btn-more {
+            font-size: 13px;
+            font-weight: 600;
+            color: #1565c0;
+            text-decoration: none;
+            padding: 8px 4px;
+            border-bottom: 2px solid transparent;
+            transition: border-color .15s;
+        }
+        .btn-more:hover { border-bottom-color: #1565c0; }
+
+        .loading {
+            padding: 24px;
+            text-align: center;
+            color: #888;
+            font-size: 14px;
+        }
+    `;
+
+    constructor() {
+        super();
+        this.apiUrl = '/api/internal/activity.json';
+        this.cardsPerPage = 3;
+        this._displayed = [];
+        this._queue = [];
+        this._loading = true;
+        this._atEnd = false;
+        this._nextPage = 1;
+        this._followed = new Set();
+        this._timer = null;
+        this._viewerUsername = document.body?.dataset?.username || null;
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this._fetchPage();
+    }
+
+    disconnectedCallback() {
+        super.disconnectedCallback();
+        this._stopTimer();
+    }
+
+    _startTimer() {
+        this._stopTimer();
+        this._timer = setInterval(() => this._advance(), 15000);
+    }
+
+    _stopTimer() {
+        if (this._timer) {
+            clearInterval(this._timer);
+            this._timer = null;
+        }
+    }
+
+    async _fetchPage() {
+        try {
+            const res = await fetch(
+                `${this.apiUrl}?limit=12&page=${this._nextPage}`
+            );
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            const data = await res.json();
+            const items = data.activity || [];
+
+            if (items.length === 0) {
+                this._atEnd = true;
+                this._loading = false;
+                return;
+            }
+
+            this._nextPage++;
+            const combined = [...this._queue, ...items];
+            this._displayed = combined.slice(0, this.cardsPerPage);
+            this._queue = combined.slice(this.cardsPerPage);
+            this._loading = false;
+            this._startTimer();
+        } catch (_) {
+            this._loading = false;
+            this._atEnd = true;
+        }
+    }
+
+    _advance() {
+        if (this._queue.length >= this.cardsPerPage) {
+            this._displayed = this._queue.slice(0, this.cardsPerPage);
+            this._queue = this._queue.slice(this.cardsPerPage);
+        } else if (this._queue.length > 0 && this._atEnd) {
+            this._displayed = this._queue;
+            this._queue = [];
+        } else {
+            // Fetch another page to refill
+            this._fetchPage();
+        }
+    }
+
+    async _toggleFollow(username) {
+        if (!this._viewerUsername) {
+            window.location = `/account/login?redir_url=${encodeURIComponent(window.location.pathname)}`;
+            return;
+        }
+        const following = this._followed.has(username);
+        const next = new Set(this._followed);
+        following ? next.delete(username) : next.add(username);
+        this._followed = next;
+
+        const body = new FormData();
+        body.append('publisher', username);
+        body.append('state', following ? '1' : '0');
+        body.append('redir_url', window.location.pathname);
+
+        try {
+            await fetch(`/people/${this._viewerUsername}/follows`, {
+                method: 'POST',
+                body,
+                redirect: 'manual',
+            });
+        } catch (_) {
+            // Revert optimistic update on network failure
+            const reverted = new Set(this._followed);
+            following ? reverted.add(username) : reverted.delete(username);
+            this._followed = reverted;
+        }
+    }
+
+    _renderCard(item) {
+        const label = SHELF_LABELS[item.shelf_id] || 'logged';
+        const ago = timeAgo(item.updated);
+        const coverSrc = item.cover_id
+            ? `${COVERS_BASE}/${item.cover_id}-M.jpg`
+            : FALLBACK_COVER;
+        const isViewer = item.username === this._viewerUsername;
+        const following = this._followed.has(item.username);
+
+        return html`
+            <div class="card">
+                <div class="card-header">
+                    <div class="patron-row">
+                        <img class="avatar" src="${item.avatar_url}"
+                            alt="@${item.username}"
+                            @error=${(e) => { e.target.src = FALLBACK_AVATAR; }}>
+                        <a class="username" href="/people/${item.username}">@${item.username}</a>
+                        ${!isViewer ? html`
+                            <button
+                                class="btn-follow ${following ? 'following' : ''}"
+                                @click=${() => this._toggleFollow(item.username)}
+                                aria-label="${following ? `Unfollow ${item.username}` : `Follow ${item.username}`}">
+                                ${following ? 'Following' : 'Follow +'}
+                            </button>
+                        ` : ''}
+                    </div>
+                    <div class="action-text">${item.username} ${label} · ${ago}</div>
+                </div>
+                <hr class="card-divider">
+                <div class="card-body">
+                    <a class="book-row" href="${item.work_key}">
+                        <img class="book-cover" src="${coverSrc}"
+                            alt="${item.title}"
+                            @error=${(e) => { e.target.src = FALLBACK_COVER; }}>
+                        <div class="book-meta">
+                            <div class="book-title">${item.title}</div>
+                            ${item.author ? html`<div class="book-author">by ${item.author}</div>` : ''}
+                        </div>
+                    </a>
+                    <div class="btn-row">
+                        <a class="btn-primary" href="${item.work_key}">View Book</a>
+                    </div>
+                </div>
+            </div>
+        `;
+    }
+
+    render() {
+        if (this._loading) {
+            return html`<div class="loading">Loading activity…</div>`;
+        }
+        if (!this._displayed.length) {
+            return html``;
+        }
+
+        const exhausted = this._atEnd && this._queue.length === 0;
+
+        return html`
+            <div class="feed">
+                ${this._displayed.map((item) => this._renderCard(item))}
+                <div class="feed-footer">
+                    ${exhausted
+        ? html`<a class="btn-more" href="/trending">More →</a>`
+        : html`<button class="btn-next" @click=${() => this._advance()} aria-label="Next activity">›</button>`
+}
+                </div>
+            </div>
+        `;
+    }
+}
+
+customElements.define('ol-activity-feed', OLActivityFeed);

--- a/openlibrary/components/lit/OLActivityFeed.js
+++ b/openlibrary/components/lit/OLActivityFeed.js
@@ -62,8 +62,8 @@ export class OLActivityFeed extends LitElement {
 
         /* Individual activity card */
         .card {
-            background: #fff;
-            border-radius: 10px;
+            background: var(--white, #fff);
+            border-radius: var(--border-radius-card, 9px);
             box-shadow: 0 1px 4px rgba(0,0,0,.1);
             overflow: hidden;
         }
@@ -104,23 +104,29 @@ export class OLActivityFeed extends LitElement {
         .username:hover { text-decoration: underline; }
 
         .btn-follow {
-            background: #1565c0;
-            color: #fff;
-            border: none;
-            border-radius: 20px;
+            background: var(--primary-blue, #1565c0);
+            color: var(--white, #fff);
+            border: 1.5px solid var(--primary-blue, #1565c0);
+            border-radius: var(--border-radius-pill, 9999px);
             padding: 4px 12px;
             font-size: 12px;
-            font-weight: 600;
+            font-weight: 500;
             cursor: pointer;
             flex-shrink: 0;
-            transition: background .15s;
+            transition: background-color .15s, border-color .15s;
         }
-        .btn-follow:hover { background: #0d47a1; }
+        .btn-follow:hover {
+            background: var(--link-blue, #0d47a1);
+            border-color: var(--link-blue, #0d47a1);
+        }
         .btn-follow.following {
-            background: #e0e0e0;
-            color: #444;
+            background: var(--white, #fff);
+            border-color: var(--color-border-subtle, #ccc);
+            color: var(--dark-grey, #444);
         }
-        .btn-follow.following:hover { background: #bdbdbd; }
+        .btn-follow.following:hover {
+            background: var(--lightest-grey, #f5f5f5);
+        }
 
         .action-text {
             font-size: 12px;
@@ -150,7 +156,7 @@ export class OLActivityFeed extends LitElement {
             width: 58px;
             height: 82px;
             object-fit: cover;
-            border-radius: 3px;
+            border-radius: var(--border-radius-thumbnail, 3px);
             flex-shrink: 0;
             box-shadow: 0 1px 3px rgba(0,0,0,.2);
         }
@@ -186,19 +192,22 @@ export class OLActivityFeed extends LitElement {
 
         .btn-primary {
             display: block;
-            background: #1565c0;
-            color: #fff;
-            border: none;
-            border-radius: 20px;
+            background: var(--primary-blue, #1565c0);
+            color: var(--white, #fff);
+            border: 1.5px solid var(--primary-blue, #1565c0);
+            border-radius: var(--border-radius-button, 6px);
             padding: 8px 0;
-            font-size: 13px;
-            font-weight: 600;
+            font-size: var(--font-size-body-medium, 13px);
+            font-weight: 500;
             text-align: center;
             text-decoration: none;
             cursor: pointer;
-            transition: background .15s;
+            transition: background-color .15s, border-color .15s;
         }
-        .btn-primary:hover { background: #0d47a1; }
+        .btn-primary:hover {
+            background: var(--link-blue, #0d47a1);
+            border-color: var(--link-blue, #0d47a1);
+        }
 
         /* Navigation footer */
         .feed-footer {
@@ -209,8 +218,8 @@ export class OLActivityFeed extends LitElement {
 
         .btn-next {
             background: none;
-            border: 1px solid #ccc;
-            border-radius: 50%;
+            border: 1.5px solid var(--color-border-subtle, #ccc);
+            border-radius: var(--border-radius-circle, 50%);
             width: 36px;
             height: 36px;
             font-size: 20px;
@@ -218,21 +227,24 @@ export class OLActivityFeed extends LitElement {
             display: flex;
             align-items: center;
             justify-content: center;
-            color: #444;
+            color: var(--dark-grey, #444);
             transition: border-color .15s, color .15s;
         }
-        .btn-next:hover { border-color: #1565c0; color: #1565c0; }
+        .btn-next:hover {
+            border-color: var(--primary-blue, #1565c0);
+            color: var(--primary-blue, #1565c0);
+        }
 
         .btn-more {
-            font-size: 13px;
-            font-weight: 600;
-            color: #1565c0;
+            font-size: var(--font-size-body-medium, 13px);
+            font-weight: 500;
+            color: var(--primary-blue, #1565c0);
             text-decoration: none;
             padding: 8px 4px;
             border-bottom: 2px solid transparent;
             transition: border-color .15s;
         }
-        .btn-more:hover { border-bottom-color: #1565c0; }
+        .btn-more:hover { border-bottom-color: var(--primary-blue, #1565c0); }
 
         .loading {
             padding: 24px;

--- a/openlibrary/components/lit/index.js
+++ b/openlibrary/components/lit/index.js
@@ -21,3 +21,4 @@ export { OlBanner } from './OlBanner.js';
 export { OlToast } from './OlToast.js';
 export { OlToastRegion, showToast } from './OlToastRegion.js';
 export { OpenLibraryOTP } from './OpenLibraryOTP.js';
+export { OLActivityFeed } from './OLActivityFeed.js';

--- a/openlibrary/fastapi/internal/api.py
+++ b/openlibrary/fastapi/internal/api.py
@@ -429,3 +429,103 @@ async def unlink_ia_ol():
 
 async def monthly_logins():
     pass
+
+
+# --- Activity Feed ---
+
+_SHELF_LABELS: dict[int, str] = {
+    1: "added to Want to Read",
+    2: "is Currently Reading",
+    3: "has Already Read",
+    4: "stopped reading",
+}
+
+
+class ActivityItem(BaseModel):
+    type: str
+    shelf_id: int
+    shelf_label: str
+    username: str
+    avatar_url: str
+    work_key: str
+    title: str
+    cover_id: int | None = None
+    author: str | None = None
+    updated: str
+
+
+class ActivityResponse(BaseModel):
+    activity: list[ActivityItem]
+    page: int
+
+
+@router.get(
+    "/api/internal/activity.json",
+    response_model=ActivityResponse,
+    response_model_exclude_none=True,
+    description="Recent public reading log activity for the homepage activity feed.",
+)
+async def activity_feed_endpoint(
+    limit: Annotated[int, Query(ge=1, le=50)] = 12,
+    page: Annotated[int, Query(ge=1)] = 1,
+) -> ActivityResponse:
+    import web
+
+    from openlibrary.core.bookshelves import Bookshelves
+    from openlibrary.core.models import User
+
+    shelf_ids = [
+        Bookshelves.PRESET_BOOKSHELVES["Want to Read"],
+        Bookshelves.PRESET_BOOKSHELVES["Currently Reading"],
+        Bookshelves.PRESET_BOOKSHELVES["Already Read"],
+    ]
+
+    # Fetch extra rows so we still hit `limit` after filtering private accounts
+    batch = Bookshelves.get_recently_logged_books(
+        shelf_ids=shelf_ids,
+        limit=limit * 4,
+        page=page,
+    )
+    if not batch:
+        return ActivityResponse(activity=[], page=page)
+
+    # Batch-check public_readlog from infogami store (one key per unique username)
+    usernames = list({item["username"] for item in batch})
+    public_set: set[str] = set()
+    for username in usernames:
+        prefs = web.ctx.site.store.get(f"/people/{username}/preferences") or {}
+        if prefs.get("public_readlog", "no") == "yes":
+            public_set.add(username)
+
+    public_items = [item for item in batch if item["username"] in public_set][:limit]
+    if not public_items:
+        return ActivityResponse(activity=[], page=page)
+
+    # Enrich with Solr work data (title, cover, author)
+    await Bookshelves.add_solr_works_async(
+        public_items,
+        fields=["key", "title", "author_name", "cover_i"],
+    )
+
+    activity: list[ActivityItem] = []
+    for item in public_items:
+        work = item.get("work")
+        if not work:
+            continue
+        authors = work.get("author_name") or []
+        activity.append(
+            ActivityItem(
+                type="shelf_change",
+                shelf_id=item["bookshelf_id"],
+                shelf_label=_SHELF_LABELS.get(item["bookshelf_id"], "logged"),
+                username=item["username"],
+                avatar_url=User.get_avatar_url(item["username"]),
+                work_key=f"/works/OL{item['work_id']}W",
+                title=work.get("title", ""),
+                cover_id=work.get("cover_i"),
+                author=authors[0] if authors else None,
+                updated=str(item.get("updated") or item.get("created") or ""),
+            )
+        )
+
+    return ActivityResponse(activity=activity, page=page)

--- a/openlibrary/fastapi/internal/api.py
+++ b/openlibrary/fastapi/internal/api.py
@@ -20,6 +20,7 @@ from starlette.responses import RedirectResponse
 from openlibrary import accounts
 from openlibrary.core import lending, models
 from openlibrary.core.bestbook import Bestbook
+from openlibrary.core.bookshelves import Bookshelves
 from openlibrary.core.follows import PubSub
 from openlibrary.core.models import Booknotes
 from openlibrary.core.observations import get_observation_metrics
@@ -431,6 +432,13 @@ async def monthly_logins():
     pass
 
 
+def _to_iso(dt: object) -> str:
+    """Return an ISO-8601 string for a datetime/date value, or '' if None."""
+    if dt is None:
+        return ""
+    return dt.isoformat() if hasattr(dt, "isoformat") else str(dt)
+
+
 # --- Activity Feed ---
 
 _SHELF_LABELS: dict[int, str] = {
@@ -469,10 +477,7 @@ async def activity_feed_endpoint(
     limit: Annotated[int, Query(ge=1, le=50)] = 12,
     page: Annotated[int, Query(ge=1)] = 1,
 ) -> ActivityResponse:
-    import web
-
-    from openlibrary.core.bookshelves import Bookshelves
-    from openlibrary.core.models import User
+    import web  # noqa: PLC0415
 
     shelf_ids = [
         Bookshelves.PRESET_BOOKSHELVES["Want to Read"],
@@ -519,12 +524,12 @@ async def activity_feed_endpoint(
                 shelf_id=item["bookshelf_id"],
                 shelf_label=_SHELF_LABELS.get(item["bookshelf_id"], "logged"),
                 username=item["username"],
-                avatar_url=User.get_avatar_url(item["username"]),
+                avatar_url=models.User.get_avatar_url(item["username"]),
                 work_key=f"/works/OL{item['work_id']}W",
                 title=work.get("title", ""),
                 cover_id=work.get("cover_i"),
                 author=authors[0] if authors else None,
-                updated=str(item.get("updated") or item.get("created") or ""),
+                updated=_to_iso(item.get("updated") or item.get("created")),
             )
         )
 

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -4726,6 +4726,10 @@ msgstr ""
 msgid "Latest Blog Posts"
 msgstr ""
 
+#: home/activity_feed.html
+msgid "What's Happening Now"
+msgstr ""
+
 #: home/categories.html
 msgid "Browse by Subject"
 msgstr ""

--- a/openlibrary/templates/home/activity_feed.html
+++ b/openlibrary/templates/home/activity_feed.html
@@ -1,5 +1,6 @@
 $def with ()
+$ _viewer = ctx.user.key.split('/')[-1] if ctx.user else ''
 <section class="activity-feed-section" aria-label="$_('What\'s Happening Now')">
   <h2 class="activity-feed-section__title">$_("What's Happening Now")</h2>
-  <ol-activity-feed api-url="/api/internal/activity.json" cards-per-page="3"></ol-activity-feed>
+  <ol-activity-feed api-url="/api/internal/activity.json" cards-per-page="3" viewer-username="$_viewer"></ol-activity-feed>
 </section>

--- a/openlibrary/templates/home/activity_feed.html
+++ b/openlibrary/templates/home/activity_feed.html
@@ -1,0 +1,5 @@
+$def with ()
+<section class="activity-feed-section" aria-label="$_('What\'s Happening Now')">
+  <h2 class="activity-feed-section__title">$_("What's Happening Now")</h2>
+  <ol-activity-feed api-url="/api/internal/activity.json" cards-per-page="3"></ol-activity-feed>
+</section>

--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -18,6 +18,8 @@ $add_metatag(property="og:site_name", content="Open Library")
 
   $:render_template("home/welcome")
 
+  $:render_template("home/activity_feed")
+
   $if not test:
     $:macros.QueryCarousel(query='trending_score_hourly_sum:[1 TO *] readinglog_count:[4 TO *]', title=_('Trending Books'), key="trending", sort='trending', has_fulltext_only=False, user_lang_only=True)
     $:macros.QueryCarousel(query="ddc:8* first_publish_year:[* TO 1950] publish_year:[2000 TO *] NOT public_scan_b:false", title=_('Classic Books'), key="public_domain", sort='trending', user_lang_only=True)


### PR DESCRIPTION
## Summary

Adds a mobile-first **"What's Happening Now"** activity feed to the Open Library homepage, showing recent public reading log activity in a sliding 3-card window.

- **API**: `GET /api/internal/activity.json` — paginated, filters to patrons with `public_readlog: yes`, Solr-enriched with title/cover/author
- **Lit component**: `<ol-activity-feed>` — 3 stacked cards, auto-advances every 15s, manual right-arrow advance, "More →" link to `/trending` when exhausted. Uses design system CSS tokens (`--primary-blue`, `--border-radius-*`, etc.) for all interactive elements.
- **Template**: `home/activity_feed.html` wired into `home/index.html` between the welcome section and trending carousel
- **Follow button**: optimistic update via `POST /people/{key}/follows`, redirects anonymous users to login

## Closes

Closes #12861

## Related

- #10241 — trending cards with patron follow pattern  
- #10242 — social activity feed on My Books  
- #12858 — weekly prompt widget (comparable Lit architecture)

## Files changed

| File | Change |
|------|--------|
| `openlibrary/fastapi/internal/api.py` | New `GET /api/internal/activity.json` endpoint |
| `openlibrary/components/lit/OLActivityFeed.js` | New `<ol-activity-feed>` Lit component |
| `openlibrary/components/lit/index.js` | Export the new component |
| `openlibrary/templates/home/activity_feed.html` | New homepage partial |
| `openlibrary/templates/home/index.html` | Wire in the partial |

## API response shape

```json
{
  "activity": [
    {
      "type": "shelf_change",
      "shelf_id": 2,
      "shelf_label": "is Currently Reading",
      "username": "jsmith",
      "avatar_url": "https://...",
      "work_key": "/works/OL123W",
      "title": "The Great Gatsby",
      "cover_id": 12345,
      "author": "F. Scott Fitzgerald",
      "updated": "2026-06-04T12:00:00"
    }
  ],
  "page": 1
}
```

## Verification

**JS build**: webpack compiled with 0 errors (`make js`)  
**Linting**: ruff ✅, eslint ✅, codespell ✅  

⚠️ **Docker note**: End-to-end browser verification was blocked by a pre-existing Python 3.14 regression in master — `except A, B:` Python 2 syntax in `core/db.py` (and other files) causes a `SyntaxError` on startup. This is unrelated to our 5 changed files. Tracking in #12861 comment.

## Checklist

- [x] API endpoint follows FastAPI patterns in `internal/api.py`
- [x] Component uses design system tokens (no hardcoded brand colors)
- [x] Privacy: only shows `public_readlog: yes` patrons
- [x] Follow button redirects anon users to login
- [x] Fallback images for broken avatars/covers
- [x] webpack 0 errors
- [x] pre-commit clean (eslint, ruff, codespell)
- [ ] Browser verification (blocked: see Docker note above)