### PR TITLE
Update browserslist db (caniuse-lite)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6478,13 +6478,16 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
-      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "version": "2.10.34",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.34.tgz",
+      "integrity": "sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/bmp-js": {
@@ -6800,9 +6803,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001764",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001764.tgz",
-      "integrity": "sha512-9JGuzl2M+vPL+pz70gtMF9sHdMFbY9FJaQBi186cHKH3pSzDvzoUJUPV6fqiKIMyXbud9ZLg4F3Yza1vJ1+93g==",
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
     "build-storybook": "cd stories && npm install --no-audit && npx storybook build"
   },
   "devDependencies": {
-    "@internetarchive/elements": "^0.2.5",
     "@babel/core": "^7.24.7",
     "@babel/eslint-parser": "^7.28.6",
     "@babel/preset-env": "^7.29.3",
     "@ericblade/quagga2": "^1.7.4",
     "@eslint/js": "^9.39.4",
+    "@internetarchive/elements": "^0.2.5",
     "@tiptap/core": "^3.20.4",
     "@tiptap/extension-image": "^3.22.1",
     "@tiptap/extension-placeholder": "^3.20.4",


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes nothing — maintenance chore.

<!-- What does this PR achieve? -->
Runs `npx update-browserslist-db@latest` to refresh the caniuse-lite browser data, silencing this warning on every webpack/babel build:

```
Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
  npx update-browserslist-db@latest
```

### Technical

- `caniuse-lite`: `1.0.30001764` → `1.0.30001793`
- `baseline-browser-mapping`: `2.9.19` → `2.10.34` (transitive companion)
- The tool reported **"No target browser changes"** — the browser set resolved from our `browserslist` queries is identical, so transpilation/autoprefixer output is unaffected. This just keeps relative queries like `last 3 years` computed against current release data.
- npm also re-sorted `@internetarchive/elements` into correct alphabetical position in `devDependencies`.

### Testing

- `npx browserslist` resolves cleanly with no stale-data warning.

### Stakeholders

@cdrini