### PR TITLE
Migrate patrons_follows_json endpoint to FastAPI

### DIFF
--- a/openlibrary/fastapi/internal/api.py
+++ b/openlibrary/fastapi/internal/api.py
@@ -9,16 +9,22 @@ its experience. This does not include public facing APIs with LTS
 from __future__ import annotations
 
 import os
+from datetime import datetime
 from typing import Annotated, Any, Literal
+from urllib.parse import urlencode
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Path, Query, status
 from pydantic import BaseModel, BeforeValidator, Field
+from starlette.responses import RedirectResponse
 
+from openlibrary import accounts
 from openlibrary.core import lending, models
+from openlibrary.core.follows import PubSub
 from openlibrary.core.models import Booknotes
 from openlibrary.core.observations import get_observation_metrics
 from openlibrary.fastapi.auth import (
     AuthenticatedUser,
+    get_authenticated_user,
     require_authenticated_user,
 )
 from openlibrary.fastapi.models import (
@@ -305,8 +311,40 @@ async def price_api(
     return await get_price_data_async(isbn or "", asin or "")
 
 
-async def patrons_follows_json():
-    pass
+class FollowEntry(BaseModel):
+    subscriber: str
+    publisher: str
+    disabled: bool
+    updated: datetime | None = None
+    created: datetime | None = None
+
+
+@router.get("/people/{username}/follows.json", response_model=list[FollowEntry])
+async def get_patron_follows(
+    username: Annotated[str, Path(pattern=r"^[^/]+$")],
+    user: Annotated[AuthenticatedUser | None, Depends(get_authenticated_user)],
+    redir_url: Annotated[str, Query()] = "",
+) -> list[FollowEntry] | RedirectResponse:
+    if not user or user.username != username:
+        return RedirectResponse(url=f"/account/login?{urlencode({'redir_url': redir_url})}", status_code=303)
+    return PubSub.get_following(username)
+
+
+@router.post("/people/{username}/follows.json")
+async def post_patron_follows(
+    username: Annotated[str, Path(pattern=r"^[^/]+$")],
+    user: Annotated[AuthenticatedUser | None, Depends(get_authenticated_user)],
+    publisher: Annotated[str, Form()],
+    redir_url: Annotated[str, Form()] = "/",
+    state: Annotated[str, Form()] = "",
+) -> RedirectResponse:
+    if not user or user.username != username:
+        return RedirectResponse(url=f"/account/login?{urlencode({'redir_url': redir_url})}", status_code=303)
+    if not accounts.find(username=publisher):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    action = PubSub.subscribe if state == "0" else PubSub.unsubscribe
+    action(user.username, publisher)
+    return RedirectResponse(url=redir_url, status_code=303)
 
 
 async def patrons_observations():

--- a/openlibrary/fastapi/internal/api.py
+++ b/openlibrary/fastapi/internal/api.py
@@ -19,8 +19,8 @@ from starlette.responses import RedirectResponse
 
 from openlibrary import accounts
 from openlibrary.core import lending, models
-from openlibrary.core.follows import PubSub
 from openlibrary.core.bestbook import Bestbook
+from openlibrary.core.follows import PubSub
 from openlibrary.core.models import Booknotes
 from openlibrary.core.observations import get_observation_metrics
 from openlibrary.fastapi.auth import (

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -336,6 +336,7 @@ async def get_price_data_async(isbn: str, asin: str) -> dict[str, Any]:
     return metadata
 
 
+@deprecated("migrated to fastapi")
 class patrons_follows_json(delegate.page):
     path = r"(/people/[^/]+)/follows"
     encoding = "json"

--- a/openlibrary/tests/fastapi/conftest.py
+++ b/openlibrary/tests/fastapi/conftest.py
@@ -5,7 +5,11 @@ from unittest.mock import patch
 import pytest
 from fastapi.testclient import TestClient
 
-from openlibrary.fastapi.auth import AuthenticatedUser, require_authenticated_user
+from openlibrary.fastapi.auth import (
+    AuthenticatedUser,
+    get_authenticated_user,
+    require_authenticated_user,
+)
 from openlibrary.plugins.worksearch.code import SearchResponse
 
 
@@ -41,6 +45,25 @@ def mock_authenticated_user(fastapi_client):
     fastapi_client.app.dependency_overrides[require_authenticated_user] = lambda: fake_user
     yield fake_user
     fastapi_client.app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def mock_optional_authenticated_user(fastapi_client):
+    """Override get_authenticated_user for endpoints that use optional auth.
+
+    Use this fixture for endpoints that depend on get_authenticated_user
+    (which returns AuthenticatedUser | None) and handle the unauthenticated
+    case themselves — typically by returning a redirect to /account/login —
+    rather than raising 401. The fixture only clears the override it set.
+    """
+    fake_user = AuthenticatedUser(
+        username="testuser",
+        user_key="/people/testuser",
+        timestamp="2026-01-01T00:00:00",
+    )
+    fastapi_client.app.dependency_overrides[get_authenticated_user] = lambda: fake_user
+    yield fake_user
+    fastapi_client.app.dependency_overrides.pop(get_authenticated_user, None)
 
 
 @pytest.fixture

--- a/openlibrary/tests/fastapi/test_follows.py
+++ b/openlibrary/tests/fastapi/test_follows.py
@@ -1,0 +1,158 @@
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+
+from openlibrary.fastapi.auth import AuthenticatedUser, get_authenticated_user
+from openlibrary.fastapi.internal.api import FollowEntry
+
+FAKE_FOLLOWING = [
+    {
+        "subscriber": "testuser",
+        "publisher": "author1",
+        "disabled": False,
+        "updated": datetime(2026, 1, 1, 12, 0, 0),
+        "created": datetime(2026, 1, 1, 12, 0, 0),
+    },
+]
+
+
+@pytest.fixture
+def mock_auth_user(fastapi_client):
+    fake_user = AuthenticatedUser(
+        username="testuser",
+        user_key="/people/testuser",
+        timestamp="2026-01-01T00:00:00",
+    )
+    fastapi_client.app.dependency_overrides[get_authenticated_user] = lambda: fake_user
+    yield fake_user
+    fastapi_client.app.dependency_overrides.pop(get_authenticated_user, None)
+
+
+class TestGetPatronFollows:
+    def test_get_follows_returns_following(self, fastapi_client, mock_auth_user):
+        with patch("openlibrary.fastapi.internal.api.PubSub.get_following", return_value=FAKE_FOLLOWING):
+            response = fastapi_client.get("/people/testuser/follows.json")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) == 1
+        FollowEntry(**data[0])
+        assert data[0]["publisher"] == "author1"
+        assert data[0]["subscriber"] == "testuser"
+        assert data[0]["disabled"] is False
+        assert data[0]["updated"] == "2026-01-01T12:00:00"
+        assert data[0]["created"] == "2026-01-01T12:00:00"
+
+    def test_get_follows_requires_authentication(self, fastapi_client):
+        response = fastapi_client.get("/people/testuser/follows.json", follow_redirects=False)
+
+        assert response.status_code == 303
+
+    def test_get_follows_redirects_for_wrong_user(self, fastapi_client, mock_auth_user):
+        response = fastapi_client.get("/people/otheruser/follows.json", follow_redirects=False)
+
+        assert response.status_code == 303
+        assert response.headers["location"].startswith("/account/login")
+
+    def test_get_follows_redirects_with_redir_url(self, fastapi_client):
+        response = fastapi_client.get("/people/testuser/follows.json?redir_url=/books", follow_redirects=False)
+
+        assert response.status_code == 303
+        assert "redir_url=%2Fbooks" in response.headers["location"]
+
+    def test_get_follows_empty_list(self, fastapi_client, mock_auth_user):
+        with patch("openlibrary.fastapi.internal.api.PubSub.get_following", return_value=[]):
+            response = fastapi_client.get("/people/testuser/follows.json")
+
+        assert response.status_code == 200
+        assert response.json() == []
+
+
+class TestPostPatronFollows:
+    def test_post_follows_subscribes(self, fastapi_client, mock_auth_user):
+        with (
+            patch("openlibrary.fastapi.internal.api.accounts.find") as mock_find,
+            patch("openlibrary.fastapi.internal.api.PubSub.subscribe") as mock_subscribe,
+        ):
+            mock_find.return_value = True
+            response = fastapi_client.post(
+                "/people/testuser/follows.json",
+                data={"publisher": "author1", "state": "0"},
+                follow_redirects=False,
+            )
+
+        assert response.status_code == 303
+        mock_find.assert_called_once_with(username="author1")
+        mock_subscribe.assert_called_once_with("testuser", "author1")
+
+    def test_post_follows_unsubscribes(self, fastapi_client, mock_auth_user):
+        with (
+            patch("openlibrary.fastapi.internal.api.accounts.find") as mock_find,
+            patch("openlibrary.fastapi.internal.api.PubSub.unsubscribe") as mock_unsubscribe,
+        ):
+            mock_find.return_value = True
+            response = fastapi_client.post(
+                "/people/testuser/follows.json",
+                data={"publisher": "author1", "state": "1"},
+                follow_redirects=False,
+            )
+
+        assert response.status_code == 303
+        mock_find.assert_called_once_with(username="author1")
+        mock_unsubscribe.assert_called_once_with("testuser", "author1")
+
+    def test_post_follows_redirects_to_login_when_unauthenticated(self, fastapi_client):
+        response = fastapi_client.post(
+            "/people/testuser/follows.json",
+            data={"publisher": "author1", "redir_url": "/"},
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 303
+        assert response.headers["location"].startswith("/account/login")
+
+    def test_post_follows_wrong_user_preserves_redir_url(self, fastapi_client, mock_auth_user):
+        response = fastapi_client.post(
+            "/people/otheruser/follows.json",
+            data={"publisher": "author1", "redir_url": "/books/OL1M", "state": "0"},
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 303
+        assert "redir_url=%2Fbooks%2FOL1M" in response.headers["location"]
+
+    def test_post_follows_redirects_to_login_for_wrong_user(self, fastapi_client, mock_auth_user):
+        response = fastapi_client.post(
+            "/people/otheruser/follows.json",
+            data={"publisher": "author1", "redir_url": "/"},
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 303
+        assert response.headers["location"].startswith("/account/login")
+
+    def test_post_follows_nonexistent_publisher_returns_404(self, fastapi_client, mock_auth_user):
+        with patch("openlibrary.fastapi.internal.api.accounts.find", return_value=None):
+            response = fastapi_client.post(
+                "/people/testuser/follows.json",
+                data={"publisher": "nonexistent_user", "redir_url": "/", "state": "0"},
+            )
+
+        assert response.status_code == 404
+
+    def test_post_follows_follows_redirect_url(self, fastapi_client, mock_auth_user):
+        with (
+            patch("openlibrary.fastapi.internal.api.accounts.find") as mock_find,
+            patch("openlibrary.fastapi.internal.api.PubSub.subscribe"),
+        ):
+            mock_find.return_value = True
+            response = fastapi_client.post(
+                "/people/testuser/follows.json",
+                data={"publisher": "author1", "redir_url": "/books/OL1M", "state": "0"},
+                follow_redirects=False,
+            )
+
+        assert response.status_code == 303
+        assert response.headers["location"] == "/books/OL1M"

--- a/openlibrary/tests/fastapi/test_follows.py
+++ b/openlibrary/tests/fastapi/test_follows.py
@@ -3,9 +3,6 @@ from unittest.mock import patch
 
 import pytest
 
-from openlibrary.fastapi.auth import AuthenticatedUser, get_authenticated_user
-from openlibrary.fastapi.internal.api import FollowEntry
-
 FAKE_FOLLOWING = [
     {
         "subscriber": "testuser",
@@ -17,93 +14,78 @@ FAKE_FOLLOWING = [
 ]
 
 
-@pytest.fixture
-def mock_auth_user(fastapi_client):
-    fake_user = AuthenticatedUser(
-        username="testuser",
-        user_key="/people/testuser",
-        timestamp="2026-01-01T00:00:00",
-    )
-    fastapi_client.app.dependency_overrides[get_authenticated_user] = lambda: fake_user
-    yield fake_user
-    fastapi_client.app.dependency_overrides.pop(get_authenticated_user, None)
-
-
 class TestGetPatronFollows:
-    def test_get_follows_returns_following(self, fastapi_client, mock_auth_user):
+    def test_returns_following_list(self, fastapi_client, mock_optional_authenticated_user):
         with patch("openlibrary.fastapi.internal.api.PubSub.get_following", return_value=FAKE_FOLLOWING):
             response = fastapi_client.get("/people/testuser/follows.json")
 
         assert response.status_code == 200
-        data = response.json()
-        assert isinstance(data, list)
-        assert len(data) == 1
-        FollowEntry(**data[0])
-        assert data[0]["publisher"] == "author1"
-        assert data[0]["subscriber"] == "testuser"
-        assert data[0]["disabled"] is False
-        assert data[0]["updated"] == "2026-01-01T12:00:00"
-        assert data[0]["created"] == "2026-01-01T12:00:00"
+        assert response.json() == [
+            {
+                "subscriber": "testuser",
+                "publisher": "author1",
+                "disabled": False,
+                "updated": "2026-01-01T12:00:00",
+                "created": "2026-01-01T12:00:00",
+            }
+        ]
 
-    def test_get_follows_requires_authentication(self, fastapi_client):
-        response = fastapi_client.get("/people/testuser/follows.json", follow_redirects=False)
-
-        assert response.status_code == 303
-
-    def test_get_follows_redirects_for_wrong_user(self, fastapi_client, mock_auth_user):
-        response = fastapi_client.get("/people/otheruser/follows.json", follow_redirects=False)
-
-        assert response.status_code == 303
-        assert response.headers["location"].startswith("/account/login")
-
-    def test_get_follows_redirects_with_redir_url(self, fastapi_client):
-        response = fastapi_client.get("/people/testuser/follows.json?redir_url=/books", follow_redirects=False)
-
-        assert response.status_code == 303
-        assert "redir_url=%2Fbooks" in response.headers["location"]
-
-    def test_get_follows_empty_list(self, fastapi_client, mock_auth_user):
+    def test_empty_list(self, fastapi_client, mock_optional_authenticated_user):
         with patch("openlibrary.fastapi.internal.api.PubSub.get_following", return_value=[]):
             response = fastapi_client.get("/people/testuser/follows.json")
 
         assert response.status_code == 200
         assert response.json() == []
 
+    def test_unauthenticated_redirects_to_login(self, fastapi_client):
+        response = fastapi_client.get("/people/testuser/follows.json", follow_redirects=False)
+
+        assert response.status_code == 303
+        assert response.headers["location"].startswith("/account/login")
+
+    def test_wrong_user_redirects_to_login(self, fastapi_client, mock_optional_authenticated_user):
+        response = fastapi_client.get("/people/otheruser/follows.json", follow_redirects=False)
+
+        assert response.status_code == 303
+        assert response.headers["location"].startswith("/account/login")
+
+    def test_redirect_preserves_redir_url(self, fastapi_client):
+        response = fastapi_client.get("/people/testuser/follows.json?redir_url=/books", follow_redirects=False)
+
+        assert response.status_code == 303
+        assert "redir_url=%2Fbooks" in response.headers["location"]
+
 
 class TestPostPatronFollows:
-    def test_post_follows_subscribes(self, fastapi_client, mock_auth_user):
+    @pytest.mark.parametrize(
+        ("state", "expected_method"),
+        [
+            ("0", "subscribe"),
+            ("1", "unsubscribe"),
+            ("", "unsubscribe"),  # missing/empty state defaults to unsubscribe
+        ],
+    )
+    def test_routes_state_to_subscribe_or_unsubscribe(
+        self,
+        fastapi_client,
+        mock_optional_authenticated_user,
+        state,
+        expected_method,
+    ):
         with (
-            patch("openlibrary.fastapi.internal.api.accounts.find") as mock_find,
-            patch("openlibrary.fastapi.internal.api.PubSub.subscribe") as mock_subscribe,
+            patch("openlibrary.fastapi.internal.api.accounts.find", return_value=True),
+            patch(f"openlibrary.fastapi.internal.api.PubSub.{expected_method}") as mock_action,
         ):
-            mock_find.return_value = True
             response = fastapi_client.post(
                 "/people/testuser/follows.json",
-                data={"publisher": "author1", "state": "0"},
+                data={"publisher": "author1", "state": state},
                 follow_redirects=False,
             )
 
         assert response.status_code == 303
-        mock_find.assert_called_once_with(username="author1")
-        mock_subscribe.assert_called_once_with("testuser", "author1")
+        mock_action.assert_called_once_with("testuser", "author1")
 
-    def test_post_follows_unsubscribes(self, fastapi_client, mock_auth_user):
-        with (
-            patch("openlibrary.fastapi.internal.api.accounts.find") as mock_find,
-            patch("openlibrary.fastapi.internal.api.PubSub.unsubscribe") as mock_unsubscribe,
-        ):
-            mock_find.return_value = True
-            response = fastapi_client.post(
-                "/people/testuser/follows.json",
-                data={"publisher": "author1", "state": "1"},
-                follow_redirects=False,
-            )
-
-        assert response.status_code == 303
-        mock_find.assert_called_once_with(username="author1")
-        mock_unsubscribe.assert_called_once_with("testuser", "author1")
-
-    def test_post_follows_redirects_to_login_when_unauthenticated(self, fastapi_client):
+    def test_unauthenticated_redirects_to_login(self, fastapi_client):
         response = fastapi_client.post(
             "/people/testuser/follows.json",
             data={"publisher": "author1", "redir_url": "/"},
@@ -113,7 +95,7 @@ class TestPostPatronFollows:
         assert response.status_code == 303
         assert response.headers["location"].startswith("/account/login")
 
-    def test_post_follows_wrong_user_preserves_redir_url(self, fastapi_client, mock_auth_user):
+    def test_wrong_user_redirects_to_login_and_preserves_redir_url(self, fastapi_client, mock_optional_authenticated_user):
         response = fastapi_client.post(
             "/people/otheruser/follows.json",
             data={"publisher": "author1", "redir_url": "/books/OL1M", "state": "0"},
@@ -123,17 +105,7 @@ class TestPostPatronFollows:
         assert response.status_code == 303
         assert "redir_url=%2Fbooks%2FOL1M" in response.headers["location"]
 
-    def test_post_follows_redirects_to_login_for_wrong_user(self, fastapi_client, mock_auth_user):
-        response = fastapi_client.post(
-            "/people/otheruser/follows.json",
-            data={"publisher": "author1", "redir_url": "/"},
-            follow_redirects=False,
-        )
-
-        assert response.status_code == 303
-        assert response.headers["location"].startswith("/account/login")
-
-    def test_post_follows_nonexistent_publisher_returns_404(self, fastapi_client, mock_auth_user):
+    def test_nonexistent_publisher_returns_404(self, fastapi_client, mock_optional_authenticated_user):
         with patch("openlibrary.fastapi.internal.api.accounts.find", return_value=None):
             response = fastapi_client.post(
                 "/people/testuser/follows.json",
@@ -142,12 +114,11 @@ class TestPostPatronFollows:
 
         assert response.status_code == 404
 
-    def test_post_follows_follows_redirect_url(self, fastapi_client, mock_auth_user):
+    def test_success_redirects_to_redir_url(self, fastapi_client, mock_optional_authenticated_user):
         with (
-            patch("openlibrary.fastapi.internal.api.accounts.find") as mock_find,
+            patch("openlibrary.fastapi.internal.api.accounts.find", return_value=True),
             patch("openlibrary.fastapi.internal.api.PubSub.subscribe"),
         ):
-            mock_find.return_value = True
             response = fastapi_client.post(
                 "/people/testuser/follows.json",
                 data={"publisher": "author1", "redir_url": "/books/OL1M", "state": "0"},


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR migrates the `patrons_follows_json` web.py handler to FastAPI.

### Technical
<!-- What should be noted about the implementation? -->
- Add `GET /people/{username}/follows.json` FastAPI handler
- Add `POST /people/{username}/follows.json` FastAPI handler  
- Add `FollowEntry` Pydantic response model.
- Mark legacy web.py handler as `@deprecated("migrated to fastapi")`
- Add tests.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Test file : `docker compose run --rm home pytest openlibrary/tests/fastapi/test_follows.py -v`

- 1. Login
```
curl -s -c /tmp/cookies.txt -X POST "http://localhost:8080/account/login.json" \
  -H "Content-Type: application/json" \
  -d '{"username":"openlibrary","password":"openlibrary"}'
```
-  2. GET authenticated → 200 + data
```
curl -s -b /tmp/cookies.txt "http://localhost:18080/people/openlibrary/follows.json"
```
- 3. POST subscribe → 303
```
- curl -s -b /tmp/cookies.txt -X POST "http://localhost:18080/people/openlibrary/follows.json" \
   -d "publisher=openlibrary&state=0&redir_url=/" -w "%{http_code}"
```
- 4. POST unsubscribe → 303
 ```
curl -s -b /tmp/cookies.txt -X POST "http://localhost:18080/people/openlibrary/follows.json" \
 -d "publisher=openlibrary&state=1&redir_url=/" -w "%{http_code}"
```
- 5. GET unauthenticated → 303 to login
 ```
curl -s "http://localhost:18080/people/openlibrary/follows.json" \
  -w "HTTP %{http_code} -> %{redirect_url}"
```
- 6. POST nonexistent publisher → 404
 ```
curl -s -b /tmp/cookies.txt -X POST "http://localhost:18080/people/openlibrary/follows.json" \
  -d "publisher=fakepublisher&state=0&redir_url=/" -w "HTTP %{http_code}"
```
- 7. GET wrong user → 303 to login
```
curl -s -b /tmp/cookies.txt "http://localhost:18080/people/otheruser/follows.json" \
  -w "HTTP %{http_code} -> %{redirect_url}"
```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

N/A

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
