### PR TITLE
Fix 3,063 lists with subjects failing to index into solr

### DIFF
--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -191,6 +191,13 @@ SeedType = Literal["subject", "author", "work", "edition"]
 
 
 def seed_key_to_seed_type(key: str) -> SeedType:
+    if not key:
+        raise ValueError("Seed key cannot be empty")
+
+    if "/" not in key:
+        # E.g. "subject:foo" or "place:bar"
+        return "subject"
+
     match key.split("/")[1]:
         case "subjects":
             return "subject"

--- a/openlibrary/plugins/openlibrary/tests/test_lists.py
+++ b/openlibrary/plugins/openlibrary/tests/test_lists.py
@@ -152,6 +152,30 @@ class TestListRecord:
                 ListRecord.from_input()
 
 
+@pytest.mark.parametrize(
+    ("seed", "expected", "error_match"),
+    [
+        pytest.param("/subjects/foo", "subject", None, id="subjects-path"),
+        pytest.param("/authors/OL1A", "author", None, id="authors-path"),
+        pytest.param("/works/OL1W", "work", None, id="works-path"),
+        pytest.param("/books/OL1M", "edition", None, id="books-path"),
+        pytest.param("subject:ibm_database_2.", "subject", None, id="subject-raw-string"),
+        pytest.param("place:london", "subject", None, id="place-raw-string"),
+        pytest.param("person:jane_austen", "subject", None, id="person-raw-string"),
+        pytest.param("time:20th_century", "subject", None, id="time-raw-string"),
+        pytest.param("", None, "Seed key cannot be empty", id="empty-string"),
+        pytest.param("/people/alice", None, "Invalid seed key", id="invalid-path-prefix"),
+        pytest.param("/lists/OL1L", None, "Invalid seed key", id="invalid-list-path"),
+    ],
+)
+def test_seed_key_to_seed_type(seed, expected, error_match):
+    if error_match:
+        with pytest.raises(ValueError, match=error_match):
+            legacy_lists.seed_key_to_seed_type(seed)
+    else:
+        assert legacy_lists.seed_key_to_seed_type(seed) == expected
+
+
 class FakePreviewList:
     def __init__(self, key):
         self.key = key

--- a/openlibrary/solr/updater/list.py
+++ b/openlibrary/solr/updater/list.py
@@ -18,6 +18,7 @@ from openlibrary.utils import normalize_subject_name
 
 logger = logging.getLogger("openlibrary.solr")
 
+
 class ListSolrUpdater(AbstractSolrUpdater):
     key_prefix = "/lists/"
     thing_type = "/type/list"

--- a/openlibrary/solr/updater/list.py
+++ b/openlibrary/solr/updater/list.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from collections import defaultdict
 from functools import cached_property
@@ -15,6 +16,7 @@ from openlibrary.solr.updater.abstract import AbstractSolrBuilder, AbstractSolrU
 from openlibrary.solr.utils import SolrUpdateRequest, get_solr_base_url
 from openlibrary.utils import normalize_subject_name
 
+logger = logging.getLogger("openlibrary.solr")
 
 class ListSolrUpdater(AbstractSolrUpdater):
     key_prefix = "/lists/"
@@ -36,7 +38,12 @@ async def fetch_seeds_facets(seeds: list[str]):
 
     seeds_by_type: defaultdict[SeedType, list] = defaultdict(list)
     for seed in seeds:
-        seeds_by_type[seed_key_to_seed_type(seed)].append(seed)
+        try:
+            seeds_by_type[seed_key_to_seed_type(seed)].append(seed)
+        except ValueError:
+            # seed_key_to_seed_type throws for unrecognized seed key types
+            logger.warning(f"Unrecognized seed key type for seed {seed}")
+            continue
 
     query: list[str] = []
     for seed_type, seed_values in seeds_by_type.items():


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Part of #11650 

Was noticing errors for some lists that had subjects without the "/subjects" prefix.


### Technical
<!-- What should be noted about the implementation? -->
Was noticing errors of this nature during the reindex:

```
2026-06-07 11:50:01,966 [ERROR] Failed to update '/people/serenahm/lists/OL131113L'
Traceback (most recent call last):
  File "openlibrary/solr/update.py", line 123, in openlibrary.solr.update.update_keys
  File "/openlibrary/openlibrary/solr/updater/list.py", line 28, in update_key
    lst = ListSolrBuilder(list, await fetch_seeds_facets(seeds))
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openlibrary/openlibrary/solr/updater/list.py", line 39, in fetch_seeds_facets
    seeds_by_type[seed_key_to_seed_type(seed)].append(seed)
                  ~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/openlibrary/openlibrary/plugins/openlibrary/lists.py", line 194, in seed_key_to_seed_type
    match key.split("/")[1]:
          ~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
