### PR TITLE
Migrate bestbook endpoints to FastAPI

### DIFF
--- a/openlibrary/fastapi/internal/api.py
+++ b/openlibrary/fastapi/internal/api.py
@@ -26,8 +26,7 @@ from openlibrary.fastapi.models import (
     Pagination,
     parse_comma_separated_list,
 )
-from openlibrary.plugins.openlibrary.api import bestbook_award as legacy_bestbook_award
-from openlibrary.plugins.openlibrary.api import get_price_data_async
+from openlibrary.plugins.openlibrary.api import bestbook_award, get_price_data_async
 from openlibrary.plugins.openlibrary.api import ratings as legacy_ratings
 from openlibrary.utils import extract_numeric_id_from_olid
 from openlibrary.views.loanstats import SINCE_DAYS, get_trending_books
@@ -361,7 +360,7 @@ async def post_bestbook_award(
     form_comment: Annotated[str | None, Form(alias="comment")] = None,
 ) -> dict:
     """Store, update, or remove a bestbook award for a work."""
-    return legacy_bestbook_award.process_bestbook_award(
+    return bestbook_award.process_bestbook_award(
         work_id=work_id,
         op=form_op if form_op is not None else query_op or "add",
         edition_key=form_edition_key if form_edition_key is not None else query_edition_key,

--- a/openlibrary/fastapi/internal/api.py
+++ b/openlibrary/fastapi/internal/api.py
@@ -360,6 +360,11 @@ async def post_bestbook_award(
     form_comment: Annotated[str | None, Form(alias="comment")] = None,
 ) -> dict:
     """Store, update, or remove a bestbook award for a work."""
+    """
+    This endpoint accepts both form data and query parameters, and uses an op parameter to indicate the requested operation.
+    This is not the preferred API design; new endpoints should use standard HTTP methods instead.
+    This structure is maintained only for backward compatibility with the legacy endpoint. Do not copy this pattern for new code.
+    """
     return bestbook_award.process_bestbook_award(
         work_id=work_id,
         op=form_op if form_op is not None else query_op or "add",

--- a/openlibrary/fastapi/internal/api.py
+++ b/openlibrary/fastapi/internal/api.py
@@ -15,6 +15,7 @@ from fastapi import APIRouter, Depends, Form, HTTPException, Path, Query, status
 from pydantic import BaseModel, BeforeValidator, Field
 
 from openlibrary.core import lending, models
+from openlibrary.core.bestbook import Bestbook
 from openlibrary.core.models import Booknotes
 from openlibrary.core.observations import get_observation_metrics
 from openlibrary.fastapi.auth import (
@@ -25,6 +26,7 @@ from openlibrary.fastapi.models import (
     Pagination,
     parse_comma_separated_list,
 )
+from openlibrary.plugins.openlibrary.api import bestbook_award as legacy_bestbook_award
 from openlibrary.plugins.openlibrary.api import get_price_data_async
 from openlibrary.plugins.openlibrary.api import ratings as legacy_ratings
 from openlibrary.utils import extract_numeric_id_from_olid
@@ -327,12 +329,56 @@ async def public_observations(
     return {"observations": {w: get_observation_metrics(w) for w in olid}}
 
 
-async def bestbook_award():
-    pass
+class BestbookAwardResponse(BaseModel):
+    success: bool | None = Field(None, description="Whether the award operation succeeded")
+    award: int | None = Field(None, description="Award id returned by the award insert")
+    rows: int | None = Field(None, description="Number of rows affected by award removal")
+    errors: str | None = Field(None, description="Award operation error message")
 
 
-async def bestbook_count():
-    pass
+class BestbookCountResponse(BaseModel):
+    count: int = Field(..., description="Number of bestbook awards matching the filters")
+
+
+BestbookAwardOp = Literal["add", "remove", "update"]
+
+
+@router.post(
+    "/works/OL{work_id}W/awards.json",
+    response_model=BestbookAwardResponse,
+    response_model_exclude_none=True,
+)
+async def post_bestbook_award(
+    work_id: Annotated[int, Path(gt=0)],
+    user: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],
+    query_op: Annotated[BestbookAwardOp | None, Query(alias="op")] = None,
+    query_edition_key: Annotated[str | None, Query(alias="edition_key")] = None,
+    query_topic: Annotated[str | None, Query(alias="topic")] = None,
+    query_comment: Annotated[str | None, Query(alias="comment")] = None,
+    form_op: Annotated[BestbookAwardOp | None, Form(alias="op")] = None,
+    form_edition_key: Annotated[str | None, Form(alias="edition_key")] = None,
+    form_topic: Annotated[str | None, Form(alias="topic")] = None,
+    form_comment: Annotated[str | None, Form(alias="comment")] = None,
+) -> dict:
+    """Store, update, or remove a bestbook award for a work."""
+    return legacy_bestbook_award.process_bestbook_award(
+        work_id=work_id,
+        op=form_op if form_op is not None else query_op or "add",
+        edition_key=form_edition_key if form_edition_key is not None else query_edition_key,
+        topic=form_topic if form_topic is not None else query_topic,
+        comment=form_comment if form_comment is not None else query_comment or "",
+        username=user.username,
+    )
+
+
+@router.get("/awards/count.json", response_model=BestbookCountResponse)
+async def get_bestbook_count(
+    work_id: Annotated[str | None, Query()] = None,
+    username: Annotated[str | None, Query()] = None,
+    topic: Annotated[str | None, Query()] = None,
+) -> BestbookCountResponse:
+    """Get a count of bestbook awards matching the optional filters."""
+    return BestbookCountResponse(count=Bestbook.get_count(work_id=work_id, username=username, topic=topic))
 
 
 async def unlink_ia_ol():

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -522,6 +522,7 @@ class create_qrcode(delegate.page):
             return delegate.RawText(buf.getvalue())
 
 
+@deprecated("migrated to fastapi")
 class bestbook_award(delegate.page):
     path = r"/works/OL(\d+)W/awards"
     encoding = "json"
@@ -585,6 +586,7 @@ class bestbook_award(delegate.page):
         return {"errors": ", ".join(errors)}
 
 
+@deprecated("migrated to fastapi")
 class bestbook_count(delegate.page):
     """API for award count"""
 

--- a/openlibrary/tests/fastapi/test_bestbook.py
+++ b/openlibrary/tests/fastapi/test_bestbook.py
@@ -1,0 +1,377 @@
+"""Tests for the FastAPI bestbook endpoints."""
+
+import json
+from unittest.mock import call, patch
+
+import pytest
+import web
+
+from openlibrary.core.bestbook import Bestbook
+from openlibrary.plugins.openlibrary.api import bestbook_award as legacy_bestbook_award
+from openlibrary.plugins.openlibrary.api import bestbook_count as legacy_bestbook_count
+
+
+class FakeLegacyUser:
+    def __init__(self, username):
+        self.key = f"/people/{username}"
+
+
+def mock_web_input_func(data):
+    def _mock_web_input(*args, **kwargs):
+        return web.storage(kwargs | data)
+
+    return _mock_web_input
+
+
+def legacy_award_json(data, work_id=123):
+    with (
+        patch("web.input", side_effect=mock_web_input_func(data)),
+        patch("openlibrary.accounts.get_current_user", return_value=FakeLegacyUser("testuser")),
+        pytest.deprecated_call(match="migrated to fastapi"),
+    ):
+        return json.loads(legacy_bestbook_award().POST(str(work_id))["rawtext"])
+
+
+def legacy_count_json(params):
+    with patch("web.input", side_effect=mock_web_input_func(params)), pytest.deprecated_call(match="migrated to fastapi"):
+        return json.loads(legacy_bestbook_count().GET()["rawtext"])
+
+
+def post_fastapi_award(fastapi_client, data, *, use_query_params=False):
+    if use_query_params:
+        return fastapi_client.post("/works/OL123W/awards.json", params=data)
+    return fastapi_client.post("/works/OL123W/awards.json", data=data)
+
+
+@pytest.fixture
+def mock_bestbook_model():
+    """Prevent real DB calls for Bestbook mutation methods."""
+    with (
+        patch("openlibrary.plugins.openlibrary.api.Bestbook.add") as add_mock,
+        patch("openlibrary.plugins.openlibrary.api.Bestbook.remove") as remove_mock,
+    ):
+        yield add_mock, remove_mock
+
+
+class TestBestbookAwardEndpoint:
+    def test_post_award_adds_award(self, fastapi_client, mock_authenticated_user, mock_bestbook_model):
+        add_mock, remove_mock = mock_bestbook_model
+        add_mock.return_value = 123
+
+        response = fastapi_client.post(
+            "/works/OL123W/awards.json",
+            data={
+                "op": "add",
+                "edition_key": "/books/OL42M",
+                "topic": "Fiction",
+                "comment": "Great book!",
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"success": True, "award": 123}
+        add_mock.assert_called_once_with(
+            username="testuser",
+            work_id=123,
+            edition_id=42,
+            comment="Great book!",
+            topic="Fiction",
+        )
+        remove_mock.assert_not_called()
+
+    def test_post_award_adds_award_from_query_params(self, fastapi_client, mock_authenticated_user, mock_bestbook_model):
+        add_mock, remove_mock = mock_bestbook_model
+        add_mock.return_value = 123
+
+        response = fastapi_client.post(
+            "/works/OL123W/awards.json",
+            params={
+                "op": "add",
+                "edition_key": "/books/OL42M",
+                "topic": "Fiction",
+                "comment": "Great book!",
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"success": True, "award": 123}
+        add_mock.assert_called_once_with(
+            username="testuser",
+            work_id=123,
+            edition_id=42,
+            comment="Great book!",
+            topic="Fiction",
+        )
+        remove_mock.assert_not_called()
+
+    def test_post_award_defaults_to_add(self, fastapi_client, mock_authenticated_user, mock_bestbook_model):
+        add_mock, remove_mock = mock_bestbook_model
+        add_mock.return_value = 789
+
+        response = fastapi_client.post("/works/OL123W/awards.json", data={})
+
+        assert response.status_code == 200
+        assert response.json() == {"success": True, "award": 789}
+        add_mock.assert_called_once_with(
+            username="testuser",
+            work_id=123,
+            edition_id=None,
+            comment="",
+            topic=None,
+        )
+        remove_mock.assert_not_called()
+
+    def test_post_award_form_values_override_query_values(self, fastapi_client, mock_authenticated_user, mock_bestbook_model):
+        add_mock, remove_mock = mock_bestbook_model
+        add_mock.return_value = 321
+
+        response = fastapi_client.post(
+            "/works/OL123W/awards.json",
+            params={
+                "op": "remove",
+                "edition_key": "/books/OL1M",
+                "topic": "Query Topic",
+                "comment": "query comment",
+            },
+            data={
+                "op": "add",
+                "edition_key": "/books/OL42M",
+                "topic": "Form Topic",
+                "comment": "form comment",
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"success": True, "award": 321}
+        add_mock.assert_called_once_with(
+            username="testuser",
+            work_id=123,
+            edition_id=42,
+            comment="form comment",
+            topic="Form Topic",
+        )
+        remove_mock.assert_not_called()
+
+    def test_post_award_removes_award(self, fastapi_client, mock_authenticated_user, mock_bestbook_model):
+        add_mock, remove_mock = mock_bestbook_model
+        remove_mock.return_value = 1
+
+        response = fastapi_client.post(
+            "/works/OL123W/awards.json",
+            data={"op": "remove"},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"success": True, "rows": 1}
+        remove_mock.assert_called_once_with("testuser", work_id=123)
+        add_mock.assert_not_called()
+
+    def test_post_award_updates_award(self, fastapi_client, mock_authenticated_user, mock_bestbook_model):
+        add_mock, remove_mock = mock_bestbook_model
+        add_mock.return_value = 456
+
+        response = fastapi_client.post(
+            "/works/OL123W/awards.json",
+            data={
+                "op": "update",
+                "topic": "Science Fiction",
+                "comment": "Still the one.",
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"success": True, "award": 456}
+        assert remove_mock.call_args_list == [
+            call("testuser", topic="Science Fiction"),
+            call("testuser", work_id=123),
+        ]
+        add_mock.assert_called_once_with(
+            username="testuser",
+            work_id=123,
+            edition_id=None,
+            comment="Still the one.",
+            topic="Science Fiction",
+        )
+
+    def test_post_award_updates_award_from_query_params(self, fastapi_client, mock_authenticated_user, mock_bestbook_model):
+        add_mock, remove_mock = mock_bestbook_model
+        add_mock.return_value = 456
+
+        response = fastapi_client.post(
+            "/works/OL123W/awards.json",
+            params={
+                "op": "update",
+                "topic": "Science Fiction",
+                "comment": "Still the one.",
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"success": True, "award": 456}
+        assert remove_mock.call_args_list == [
+            call("testuser", topic="Science Fiction"),
+            call("testuser", work_id=123),
+        ]
+        add_mock.assert_called_once_with(
+            username="testuser",
+            work_id=123,
+            edition_id=None,
+            comment="Still the one.",
+            topic="Science Fiction",
+        )
+
+    def test_post_award_returns_domain_errors(self, fastapi_client, mock_authenticated_user, mock_bestbook_model):
+        add_mock, _ = mock_bestbook_model
+        add_mock.side_effect = Bestbook.AwardConditionsError("Only books which have been marked as read may be given awards")
+
+        response = fastapi_client.post(
+            "/works/OL123W/awards.json",
+            data={
+                "op": "add",
+                "topic": "Fiction",
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"errors": "Only books which have been marked as read may be given awards"}
+
+    def test_post_award_requires_authentication(self, fastapi_client):
+        response = fastapi_client.post(
+            "/works/OL123W/awards.json",
+            data={
+                "op": "add",
+                "topic": "Fiction",
+            },
+        )
+
+        assert response.status_code == 401
+
+    def test_post_award_rejects_invalid_op(self, fastapi_client, mock_authenticated_user):
+        response = fastapi_client.post(
+            "/works/OL123W/awards.json",
+            data={
+                "op": "invalid",
+                "topic": "Fiction",
+            },
+        )
+
+        assert response.status_code == 422
+
+    def test_post_award_rejects_invalid_query_op(self, fastapi_client, mock_authenticated_user):
+        response = fastapi_client.post(
+            "/works/OL123W/awards.json",
+            params={
+                "op": "invalid",
+                "topic": "Fiction",
+            },
+        )
+
+        assert response.status_code == 422
+
+    @pytest.mark.parametrize("path", ["/works/OLnot-a-numberW/awards.json", "/works/OL0W/awards.json"])
+    def test_post_award_rejects_invalid_work_id(self, fastapi_client, mock_authenticated_user, path):
+        response = fastapi_client.post(path, data={"op": "add"})
+
+        assert response.status_code == 422
+
+
+class TestBestbookCountEndpoint:
+    def test_count_forwards_filters(self, fastapi_client):
+        with patch("openlibrary.fastapi.internal.api.Bestbook.get_count", return_value=5) as get_count_mock:
+            response = fastapi_client.get(
+                "/awards/count.json",
+                params={
+                    "work_id": "OL123W",
+                    "username": "testuser",
+                    "topic": "Fiction",
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.json() == {"count": 5}
+        get_count_mock.assert_called_once_with(work_id="OL123W", username="testuser", topic="Fiction")
+
+    def test_count_works_without_filters(self, fastapi_client):
+        with patch("openlibrary.fastapi.internal.api.Bestbook.get_count", return_value=0) as get_count_mock:
+            response = fastapi_client.get("/awards/count.json")
+
+        assert response.status_code == 200
+        assert response.json() == {"count": 0}
+        get_count_mock.assert_called_once_with(work_id=None, username=None, topic=None)
+
+
+class TestBestbookLegacyParity:
+    @pytest.mark.parametrize("use_query_params", [False, True])
+    def test_award_add_response_matches_legacy(self, fastapi_client, mock_authenticated_user, mock_bestbook_model, use_query_params):
+        add_mock, _ = mock_bestbook_model
+        add_mock.return_value = 123
+        data = {
+            "op": "add",
+            "edition_key": "/books/OL42M",
+            "topic": "Fiction",
+            "comment": "Great book!",
+        }
+
+        legacy_response = legacy_award_json(data)
+        fastapi_response = post_fastapi_award(fastapi_client, data, use_query_params=use_query_params)
+
+        assert fastapi_response.status_code == 200
+        assert fastapi_response.json() == legacy_response
+
+    @pytest.mark.parametrize("use_query_params", [False, True])
+    def test_award_remove_response_matches_legacy(self, fastapi_client, mock_authenticated_user, mock_bestbook_model, use_query_params):
+        _, remove_mock = mock_bestbook_model
+        remove_mock.return_value = 1
+        data = {"op": "remove"}
+
+        legacy_response = legacy_award_json(data)
+        fastapi_response = post_fastapi_award(fastapi_client, data, use_query_params=use_query_params)
+
+        assert fastapi_response.status_code == 200
+        assert fastapi_response.json() == legacy_response
+
+    @pytest.mark.parametrize("use_query_params", [False, True])
+    def test_award_update_response_matches_legacy(self, fastapi_client, mock_authenticated_user, mock_bestbook_model, use_query_params):
+        add_mock, _ = mock_bestbook_model
+        add_mock.return_value = 456
+        data = {
+            "op": "update",
+            "topic": "Science Fiction",
+            "comment": "Still the one.",
+        }
+
+        legacy_response = legacy_award_json(data)
+        fastapi_response = post_fastapi_award(fastapi_client, data, use_query_params=use_query_params)
+
+        assert fastapi_response.status_code == 200
+        assert fastapi_response.json() == legacy_response
+
+    @pytest.mark.parametrize("use_query_params", [False, True])
+    def test_award_domain_error_response_matches_legacy(self, fastapi_client, mock_authenticated_user, mock_bestbook_model, use_query_params):
+        add_mock, _ = mock_bestbook_model
+        add_mock.side_effect = Bestbook.AwardConditionsError("Only books which have been marked as read may be given awards")
+        data = {
+            "op": "add",
+            "topic": "Fiction",
+        }
+
+        legacy_response = legacy_award_json(data)
+        fastapi_response = post_fastapi_award(fastapi_client, data, use_query_params=use_query_params)
+
+        assert fastapi_response.status_code == 200
+        assert fastapi_response.json() == legacy_response
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {"work_id": "OL123W", "username": "testuser", "topic": "Fiction"},
+            {},
+        ],
+    )
+    def test_count_response_matches_legacy(self, fastapi_client, params):
+        with patch("openlibrary.core.bestbook.Bestbook.get_count", return_value=5):
+            legacy_response = legacy_count_json(params)
+            fastapi_response = fastapi_client.get("/awards/count.json", params=params)
+
+        assert fastapi_response.status_code == 200
+        assert fastapi_response.json() == legacy_response


### PR DESCRIPTION
## Summary

Migrates the bestbook award/count endpoints from legacy web.py routing to FastAPI while preserving the existing award business logic.

Migrated endpoints:

- POST /works/OL{work_id}W/awards.json
- GET /awards/count.json

Thanks @Sanket17052006 for reviewing. The review comments have been addressed in this branch:

- Changed the award response type from `Any | None` to `int | None`.
- Switched award `op` validation to native FastAPI `Literal["add", "remove", "update"]` validation for both query and form inputs.
- Removed the custom `op` validator, extra constants, and `cast`.
- Updated the test mock to use a realistic integer award id.

### Testing

Endpoints tested:

- Legacy: `POST /works/OL{work_id}W/awards.json`
- FastAPI: `POST /works/OL{work_id}W/awards.json`
- Legacy: `GET /awards/count.json`
- FastAPI: `GET /awards/count.json`

Results:

- Award `add`, `remove`, and `update` requests returned matching JSON responses between legacy and FastAPI for valid authenticated requests.
- Both form data and query param POST request shapes were tested for award requests.
- Count requests returned the same `{ "count": ... }` response shape and forwarded the same filters: `work_id`, `username`, and `topic`.
- Domain errors from the shared bestbook helper return the same `{"errors": ...}` response.
- The only intentional differences are FastAPI validation/auth behavior:
  - unauthenticated award POST returns `401`
  - invalid `op` or malformed path values return `422`

## Stakeholders

@RayBB @Sanket17052006