### PR TITLE
fix(accounts): always set session cookie on login regardless of OL account lookup

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -8,9 +8,10 @@ from math import ceil
 from typing import TYPE_CHECKING, Any, Final
 from urllib.parse import urlparse
 
-import infogami.core.code as core  # noqa: F401 side effects may be needed
 import requests
 import web
+
+import infogami.core.code as core  # noqa: F401 side effects may be needed
 from infogami import config
 from infogami.utils import delegate
 from infogami.utils.view import (
@@ -19,7 +20,6 @@ from infogami.utils.view import (
     render_template,
     require_login,
 )
-
 from openlibrary import accounts
 from openlibrary.accounts import (
     InternetArchiveAccount,

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -8,10 +8,9 @@ from math import ceil
 from typing import TYPE_CHECKING, Any, Final
 from urllib.parse import urlparse
 
+import infogami.core.code as core  # noqa: F401 side effects may be needed
 import requests
 import web
-
-import infogami.core.code as core  # noqa: F401 side effects may be needed
 from infogami import config
 from infogami.utils import delegate
 from infogami.utils.view import (
@@ -20,6 +19,7 @@ from infogami.utils.view import (
     render_template,
     require_login,
 )
+
 from openlibrary import accounts
 from openlibrary.accounts import (
     InternetArchiveAccount,
@@ -644,19 +644,19 @@ class account_login(delegate.page):
             )
         email = email or audit.get("ia_email") or audit.get("ol_email")
 
-        if ol_account := OpenLibraryAccount.get_by_email(email):
-            _set_login_cookies(audit, ol_account, remember=remember)
+        ol_account = OpenLibraryAccount.get_by_email(email)
+        _set_login_cookies(audit, ol_account, remember=remember)
 
-            if web.cookies().get("pda"):
-                add_flash_message(
-                    "info",
-                    _(
-                        "Thank you for registering an Open Library account and "
-                        "requesting special print disability access. You should receive "
-                        "an email detailing next steps in the process."
-                    ),
-                )
-                web.setcookie("pda", "", expires=1)
+        if ol_account and web.cookies().get("pda"):
+            add_flash_message(
+                "info",
+                _(
+                    "Thank you for registering an Open Library account and "
+                    "requesting special print disability access. You should receive "
+                    "an email detailing next steps in the process."
+                ),
+            )
+            web.setcookie("pda", "", expires=1)
 
         blacklist = [
             "/account/login",


### PR DESCRIPTION
## Summary

Fixes a regression introduced by #11052 where users with an IA/OL email mismatch (or no linked OL account) would authenticate successfully but silently receive no session cookie, causing an infinite login loop with no error message.

**Root cause:** `_set_login_cookies` was moved inside an `if ol_account := OpenLibraryAccount.get_by_email(email):` guard in #11052. If that lookup returns `None`, the session cookie is never set, the browser gets no session, and the next request is treated as unauthenticated.

**Fix:** Move `_set_login_cookies` outside the guard, matching the OTP login flow (`account_login_otp_redeem`) which already calls it unconditionally with a potentially-`None` ol_account. `_set_login_cookies` already handles `ol_account=None` correctly.

**Before (broken):**
```python
if ol_account := OpenLibraryAccount.get_by_email(email):
    _set_login_cookies(audit, ol_account, remember=remember)   # never called if lookup fails
    if web.cookies().get("pda"):
        ...
```

**After (fixed):**
```python
ol_account = OpenLibraryAccount.get_by_email(email)
_set_login_cookies(audit, ol_account, remember=remember)       # always called
if ol_account and web.cookies().get("pda"):
    ...
```

## Test plan

- [ ] Log in with an account where IA and OL emails match — session cookie set, redirect to `/account/books`
- [ ] Log in with an account where OL account lookup returns None — session cookie still set, no silent loop
- [ ] `remember me` checkbox — session cookie has year-long expiry
- [ ] PDA cookie flow unaffected (pda banner still shows when `ol_account` is found)
- [ ] OTP login flow unaffected (separate code path, already correct)

Fixes #12857