### PR TITLE
fix: add timeout to all outbound requests calls (#12704)

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -818,7 +818,7 @@ class InternetArchiveAccount(web.storage):
         if test:
             params["developer"] = test
 
-        response = requests.post(url, params=params, json=data, headers=headers or {})
+        response = requests.post(url, params=params, json=data, headers=headers or {}, timeout=(10, 30))
         if response.status_code == 403:
             raise OLAuthenticationError("security_error")
         if response.status_code == 504 and op == "create":
@@ -848,6 +848,7 @@ class InternetArchiveAccount(web.storage):
                     "Content-Type": "application/json",
                     "authorization": f"LOW {access_key}:{secret_key}",
                 },
+                timeout=(10, 30),
             )
             response.raise_for_status()
             return response.json()

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -320,7 +320,7 @@ def add_cover(cover_url, ekey, account_key=None):
     reply = None
     for _ in range(10):
         try:
-            response = requests.post(upload_url, data=params)
+            response = requests.post(upload_url, data=params, timeout=(10, 30))
         except requests.HTTPError:
             sleep(2)
             continue

--- a/openlibrary/catalog/get_ia.py
+++ b/openlibrary/catalog/get_ia.py
@@ -18,7 +18,7 @@ def urlopen_keep_trying(url: str, headers=None, **kwargs):
     """Tries to request the url three times, raises HTTPError if 403, 404, or 416.  Returns a requests.Response"""
     for i in range(3):
         try:
-            resp = requests.get(url, headers=headers, **kwargs)
+            resp = requests.get(url, headers=headers, timeout=(10, 30), **kwargs)
             resp.raise_for_status()
             return resp
         except requests.HTTPError as error:

--- a/openlibrary/catalog/utils/query.py
+++ b/openlibrary/catalog/utils/query.py
@@ -13,7 +13,7 @@ def urlopen(url, data=None):
     user_agent = f"Mozilla/5.0 (openlibrary; {__name__}) Python/{version}"
     headers = {"User-Agent": user_agent}
 
-    return requests.get(url, data=data, headers=headers)
+    return requests.get(url, data=data, headers=headers, timeout=(10, 30))
 
 
 def jsonload(url):

--- a/openlibrary/core/admin.py
+++ b/openlibrary/core/admin.py
@@ -72,6 +72,7 @@ def _get_loan_counts_from_graphite(ndays: int) -> list[list[int]] | None:
                 "tz": "UTC",
                 "format": "json",
             },
+            timeout=(10, 30),
         )
         return r.json()[0]["datapoints"]
     except requests.exceptions.RequestException, ValueError, AttributeError:
@@ -114,6 +115,7 @@ def _get_visitor_counts_from_graphite(self, ndays: int = 28) -> list[list[int]]:
                 "tz": "UTC",
                 "format": "json",
             },
+            timeout=(10, 30),
         )
         response.raise_for_status()
         visitors = response.json()[0]["datapoints"]

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -233,7 +233,7 @@ def s3_loan_api(s3_keys, ocaid=None, action="browse", **kwargs):
 
     data = s3_keys | kwargs
 
-    response = requests.post(url + params, data=data)
+    response = requests.post(url + params, data=data, timeout=(10, 30))
     # We want this to be just `409` but first
     # `www/common/Lending.inc#L111-114` needs to
     # be updated on petabox

--- a/openlibrary/core/wikidata.py
+++ b/openlibrary/core/wikidata.py
@@ -196,7 +196,7 @@ def get_wikidata_entity(qid: str, bust_cache: bool = False, fetch_missing: bool 
 def _get_from_web(id: str) -> WikidataEntity | None:
     headers = {"User-Agent": "OpenLibrary.org Wikidata Integration"}
     try:
-        response = requests.get(f"{WIKIDATA_API_URL}{id}", headers=headers)
+        response = requests.get(f"{WIKIDATA_API_URL}{id}", headers=headers, timeout=(10, 30))
         response.raise_for_status()
         if response.status_code == 200:
             entity = WikidataEntity.from_dict(response=response.json(), updated=datetime.now())

--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -307,7 +307,7 @@ class cover:
     def get_ia_cover_url(self, identifier: str, size: Literal["S", "M", "L", ""] = "M"):
         url = f"https://archive.org/metadata/{identifier}/metadata"
         try:
-            d = requests.get(url).json().get("result", {})
+            d = requests.get(url, timeout=(10, 30)).json().get("result", {})
         except OSError, ValueError:
             return
 
@@ -522,7 +522,7 @@ def render_list_preview_image(lst_key: str):
     W, _H = background.size
     image = []
     for cover in five_covers:
-        response = requests.get(f"https://covers.openlibrary.org/b/id/{cover.id}-M.jpg")
+        response = requests.get(f"https://covers.openlibrary.org/b/id/{cover.id}-M.jpg", timeout=(10, 30))
         image_bytes = io.BytesIO(response.content)
 
         img = Image.open(image_bytes)

--- a/openlibrary/coverstore/utils.py
+++ b/openlibrary/coverstore/utils.py
@@ -71,7 +71,7 @@ USER_AGENT = "Mozilla/5.0 (Compatible; coverstore downloader http://covers.openl
 
 
 def download(url):
-    return requests.get(url, headers={"User-Agent": USER_AGENT}).content
+    return requests.get(url, headers={"User-Agent": USER_AGENT}, timeout=(10, 30)).content
 
 
 def urldecode(url: str) -> tuple[str, dict[str, str]]:

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -191,7 +191,7 @@ class reload:
             s = s.removesuffix("/") + "/_reload"
             yield "<h3>" + s + "</h3>"
             try:
-                response = requests.get(s).text
+                response = requests.get(s, timeout=(10, 30)).text
                 yield "<p><pre>" + response[:100] + "</pre></p>"
             except:
                 yield "<p><pre>%s</pre></p>" % traceback.format_exc()

--- a/openlibrary/plugins/admin/services.py
+++ b/openlibrary/plugins/admin/services.py
@@ -13,7 +13,7 @@ from bs4 import BeautifulSoup
 class Nagios:
     def __init__(self, url):
         try:
-            self.data = BeautifulSoup(requests.get(url).content, "lxml")
+            self.data = BeautifulSoup(requests.get(url, timeout=(10, 30)).content, "lxml")
         except Exception as m:
             print(m)
             self.data = None

--- a/openlibrary/plugins/importapi/import_ui.py
+++ b/openlibrary/plugins/importapi/import_ui.py
@@ -202,7 +202,7 @@ class RawMarcMetadataProvider(AbstractMetadataProvider):
         url, offset = identifier.rsplit(":", 1)
 
         headers = {"Range": f"bytes={offset}-"}
-        response = requests.get(url, headers=headers, stream=True)
+        response = requests.get(url, headers=headers, stream=True, timeout=(10, 30))
         if response.status_code != 206:
             raise ValueError(f"Failed to fetch MARC record from {url}: {response.status_code}")
 

--- a/openlibrary/plugins/ol_infobase.py
+++ b/openlibrary/plugins/ol_infobase.py
@@ -353,7 +353,7 @@ def http_notify(site, old, new):
 
     for url in config.http_listeners:
         try:
-            response = requests.get(url, params=json_data)
+            response = requests.get(url, params=json_data, timeout=(10, 30))
             response.raise_for_status()
             print("http_notify", repr(url), repr(key), repr(response.text), file=web.debug)
         except Exception:

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -372,7 +372,7 @@ class robotstxt(delegate.page):
 
 @functools.cache
 def fetch_ia_js(filename: str) -> str:
-    return requests.get(f"https://archive.org/includes/{filename}").text
+    return requests.get(f"https://archive.org/includes/{filename}", timeout=(10, 30)).text
 
 
 class ia_js_cdn(delegate.page):

--- a/openlibrary/plugins/openlibrary/pd.py
+++ b/openlibrary/plugins/openlibrary/pd.py
@@ -56,7 +56,7 @@ def make_pd_org_query() -> list:
     params = "q=collection:print_disability_access&fl[]=identifier,title&rows=1000&page=1&output=json"
     url = f"https://{base_url}/advancedsearch.php?{params}"
     try:
-        response = requests.get(url)
+        response = requests.get(url, timeout=(10, 30))
         response.raise_for_status()
     except requests.HTTPError:
         return []

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -697,7 +697,7 @@ class account_validation(delegate.page):
     def ia_username_exists(username):
         url = "https://archive.org/metadata/@%s" % username
         try:
-            return bool(requests.get(url).json())
+            return bool(requests.get(url, timeout=(10, 30)).json())
         except OSError, ValueError:
             return
 

--- a/openlibrary/plugins/upstream/covers.py
+++ b/openlibrary/plugins/upstream/covers.py
@@ -121,7 +121,7 @@ class add_cover(delegate.page):
 
         try:
             files = {"data": data}
-            response = requests.post(upload_url, data=params, files=files)
+            response = requests.post(upload_url, data=params, files=files, timeout=(10, 30))
             return web.storage(response.json())
         except requests.HTTPError as e:
             logger.exception("Covers upload failed")

--- a/openlibrary/plugins/upstream/data.py
+++ b/openlibrary/plugins/upstream/data.py
@@ -13,7 +13,7 @@ IA_BASE_URL = config.get("ia_base_url")
 def get_ol_dumps():
     """Get list of all archive.org items in the ol_exports collection uploaded by archive.org staff."""
     url = IA_BASE_URL + "/advancedsearch.php?q=collection:ol_exports+AND+(ol_dump+OR+ol_cdump)&fl[]=identifier&output=json&rows=1000"
-    docs = requests.get(url).json()["response"]["docs"]
+    docs = requests.get(url, timeout=(10, 30)).json()["response"]["docs"]
     return sorted(doc["identifier"] for doc in docs)
 
 

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -1370,7 +1370,7 @@ def _get_blog_feeds():
     url = "https://blog.openlibrary.org/feed/"
     try:
         stats.begin("get_blog_feeds", url=url)
-        tree = ET.fromstring(requests.get(url).text)
+        tree = ET.fromstring(requests.get(url, timeout=(10, 30)).text)
     except Exception:
         # Handle error gracefully.
         logging.getLogger("openlibrary").error("Failed to fetch blog feeds", exc_info=True)

--- a/openlibrary/solr/data_provider.py
+++ b/openlibrary/solr/data_provider.py
@@ -348,7 +348,7 @@ class ExternalDataProvider(DataProvider):
         return []
 
     def get_editions_of_work(self, work):
-        resp = requests.get(f"http://{self.ol_host}{work['key']}/editions.json", params={"limit": 500}).json()
+        resp = requests.get(f"http://{self.ol_host}{work['key']}/editions.json", params={"limit": 500}, timeout=(10, 30)).json()
         if "next" in resp["links"]:
             logger.warning(f"Too many editions for {work['key']}")
         return resp["entries"]

--- a/openlibrary/solr/updater/edition.py
+++ b/openlibrary/solr/updater/edition.py
@@ -74,6 +74,7 @@ def solr_select_work(edition_key):
             "rows": 1,
             "fl": "key",
         },
+        timeout=(10, 30),
     ).json()
     if docs := reply["response"].get("docs", []):
         return docs[0]["key"]  # /works/ prefix is in solr

--- a/openlibrary/utils/http.py
+++ b/openlibrary/utils/http.py
@@ -1,0 +1,11 @@
+"""
+HTTP utilities for Open Library.
+
+Provides a default timeout constant to prevent outbound requests from
+blocking workers indefinitely when upstream services hang or respond slowly.
+"""
+
+# Default timeout (in seconds) for all outbound HTTP requests.
+# Using a tuple (connect_timeout, read_timeout) is recommended by the
+# requests library: https://requests.readthedocs.io/en/latest/user/advanced/#timeouts
+OL_REQUEST_TIMEOUT = (10, 30)


### PR DESCRIPTION
### Problem
<!-- What problem does this address? -->
Resolves #12704

All outbound `requests` calls across the codebase were missing a `timeout=` parameter. This means if any upstream service (archive.org, Wikidata, Graphite, etc.) hangs or responds slowly, the worker process blocks indefinitely — potentially exhausting all workers and taking down the site.

### Solution
<!-- How did you fix it? -->
Added `timeout=(10, 30)` (10s connect, 30s read) to all 22 unguarded `requests.get` / `requests.post` calls. Also added `openlibrary/utils/http.py` which documents the `OL_REQUEST_TIMEOUT` constant for future use.

### Testing
<!-- What tests did you run? -->
- [x] Verified all previously unguarded call sites now have a timeout parameter
- [ ] Local dev environment starts successfully with `docker compose up -d`

### Checklist
<!-- Check off what applies -->
- [x] Code follows project conventions
- [x] PR is in draft mode pending review
- [x] Linked to issue #12704