### PR TITLE
Replace debug feature flag with query_param in work_search template

### DIFF
--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -53,7 +53,7 @@ $ layout = get_remembered_layout()
 
     $if search_response.error:
       $ add_flash_message("error", _("The search engine returned an error."))
-      $if is_feature_enabled('debug'):
+      $if query_param('debug'):
         <div class="ol-message ol-message--warning">
           <h3>$_("Solr Debugging:")</h3>
           $search_response.error['msg']


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Part of #12882 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Replaces the `debug` feature flag in work_search template with `query_param('debug')`, matching the pattern already used by 8 other templates. This removes one dependency on the legacy Infogami feature flag system.



### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

- Search page renders with 200 on `/?q=test` and `/?q=test&debug=true`
- Behavior is identical to prod since `debug: enabled` is still in config.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
