### PR TITLE
make debug message only for admins

### DIFF
--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -53,7 +53,7 @@ $ layout = get_remembered_layout()
 
     $if search_response.error:
       $ add_flash_message("error", _("The search engine returned an error."))
-      $if query_param('debug'):
+      $if ctx.user and ctx.user.is_admin() and query_param('debug'):
         <div class="ol-message ol-message--warning">
           <h3>$_("Solr Debugging:")</h3>
           $search_response.error['msg']


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Followup to https://github.com/internetarchive/openlibrary/pull/12883

@cdrini pointed out that we really don't wanna show the error message to anyone that's not an admin so we are adding the admin flag.

Long term it might be gated behind the VPN but for now this is simpler.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
