### PR TITLE
Remove unused feature flags from openlibrary.yml

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -55,25 +55,19 @@ plugin_worksearch:
 http_request_timeout: 10
 
 features:
-    cache_most_recent: enabled
     debug: enabled
     dev: enabled
     history_v2: admin
-    inlibrary: enabled
-    lending_v2: enabled
     lists: enabled
     merge-authors:
         filter: usergroup
         usergroup: /usergroup/librarians
-    merge-editions: admin
     publishers: enabled
     recentchanges_v2: enabled
     stats: enabled
     stats-header: enabled
     superfast: enabled
-    support: admin
     undo: enabled
-    upstream: enabled
 
 upstream_to_www_migration: true
 default_template_root: /upstream


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Part of #12882 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes 6 feature flags from `conf/openlibrary.yml` that have zero 
usage across the codebase

### Technical
<!-- What should be noted about the implementation? -->

Removed flags:
- `cache_most_recent`
- `inlibrary`
- `lending_v2`
- `merge-editions`
- `support`
- `upstream`

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Grepped for all 4 feature flag patterns (`is_feature_enabled`, 
`is_enabled`, `"flag" in ctx.features`, `"flag" in web.ctx.features`) 
across all `.py`, `.html`, and `.js` files — zero hits for all 6 flags.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
