### PR TITLE
Migrate account loans to FastAPI

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -26,7 +26,6 @@ from openlibrary.core.bookshelves import Bookshelves
 from openlibrary.core.edits import CommunityEditsQueue
 from openlibrary.core.observations import Observations
 from openlibrary.core.ratings import Ratings
-from openlibrary.utils.request_context import site
 
 try:
     from simplejson.errors import JSONDecodeError
@@ -224,7 +223,7 @@ class Link(web.storage):
         return datetime.datetime.strptime(d, "%Y-%m-%dT%H:%M:%S")
 
     def delete(self) -> None:
-        del site.get().store[self["_key"]]
+        del web.ctx.site.store[self["_key"]]
 
 
 class Account(web.storage):
@@ -262,27 +261,27 @@ class Account(web.storage):
 
     def get_recentchanges(self, limit: int = 100, offset: int = 0):
         q = {"author": self.get_user().key, "limit": limit, "offset": offset}
-        return site.get().recentchanges(q)
+        return web.ctx.site.recentchanges(q)
 
     def verify_password(self, password) -> bool:
         return verify_hash(get_secret_key(), password, self.enc_password)
 
     def update_password(self, new_password) -> None:
-        site.get().update_account(self.username, password=new_password)
+        web.ctx.site.update_account(self.username, password=new_password)
 
     def update_email(self, email) -> None:
-        site.get().update_account(self.username, email=email)
+        web.ctx.site.update_account(self.username, email=email)
 
     def activate(self) -> None:
-        site.get().activate_account(username=self.username)
+        web.ctx.site.activate_account(username=self.username)
 
     def block(self) -> None:
         """Blocks this account."""
-        site.get().update_account(self.username, status="blocked")
+        web.ctx.site.update_account(self.username, status="blocked")
 
     def unblock(self) -> None:
         """Unblocks this account."""
-        site.get().update_account(self.username, status="active")
+        web.ctx.site.update_account(self.username, status="active")
 
     def is_blocked(self) -> bool:
         """Tests if this account is blocked."""
@@ -304,7 +303,7 @@ class Account(web.storage):
         if self.is_blocked():
             return "account_blocked"
         try:
-            site.get().login(self.username, password)
+            web.ctx.site.login(self.username, password)
         except ClientException as e:
             code = e.get_data().get("code")
             return code
@@ -323,7 +322,7 @@ class Account(web.storage):
 
     def _save(self) -> None:
         """Saves this account in store."""
-        site.get().store[self._key] = self
+        web.ctx.site.store[self._key] = self
 
     @property
     def last_login(self) -> datetime.datetime:
@@ -344,30 +343,30 @@ class Account(web.storage):
         :returns: Not an Account obj, but a /people/xxx User
         """
         key = "/people/" + self.username
-        return site.get().get(key)
+        return web.ctx.site.get(key)
 
     def get_creation_info(self) -> dict:
         key = "/people/" + self.username
-        doc = site.get().get(key)
+        doc = web.ctx.site.get(key)
         return doc.get_creation_info()
 
     def get_activation_link(self) -> Link | bool:
         key = f"account/{self.username}/verify"
-        if doc := site.get().store.get(key):
+        if doc := web.ctx.site.store.get(key):
             return Link(doc)
         else:
             return False
 
     def get_password_reset_link(self) -> Link | bool:
         key = f"account/{self.username}/password"
-        if doc := site.get().store.get(key):
+        if doc := web.ctx.site.store.get(key):
             return Link(doc)
         else:
             return False
 
     def get_links(self) -> list[Link]:
         """Returns all the verification links present in the database."""
-        return site.get().store.values(type="account-link", name="username", value=self.username)
+        return web.ctx.site.store.values(type="account-link", name="username", value=self.username)
 
     def get_tags(self) -> list[str]:
         """Returns list of tags that this user has."""
@@ -410,13 +409,13 @@ class Account(web.storage):
             patron.set_data(data, "delete-profile")
 
             # Remove account information from store:
-            del site.get().store[f"account/{username}"]
-            del site.get().store[f"account/{username}/verify"]
-            del site.get().store[f"account/{username}/password"]
-            del site.get().store[f"account-email/{email}"]
-            del site.get().store[f"account-email/{email.lower()}"]
+            del web.ctx.site.store[f"account/{username}"]
+            del web.ctx.site.store[f"account/{username}/verify"]
+            del web.ctx.site.store[f"account/{username}/password"]
+            del web.ctx.site.store[f"account-email/{email}"]
+            del web.ctx.site.store[f"account-email/{email.lower()}"]
             # Delete preferences:
-            del site.get().store[f"/people/{username}/preferences"]
+            del web.ctx.site.store[f"/people/{username}/preferences"]
 
         # Generate new unique username for patron:
         # Note: Cannot test get_activation_link() locally
@@ -511,7 +510,7 @@ class OpenLibraryAccount(Account):
                 test=True,
             )
         try:
-            site.get().register(
+            web.ctx.site.register(
                 username=username,
                 email=email,
                 password=password,
@@ -523,8 +522,8 @@ class OpenLibraryAccount(Account):
         if verified:
             key = f"account/{username}/verify"
             doc = create_link_doc(key, username, email)
-            site.get().store[key] = doc
-            site.get().activate_account(username=username)
+            web.ctx.site.store[key] = doc
+            web.ctx.site.activate_account(username=username)
 
         ol_account = cls.get_by_email(email)
 
@@ -566,12 +565,12 @@ class OpenLibraryAccount(Account):
     @classmethod
     def get_by_username(cls, username: str) -> OpenLibraryAccount | None:
         """Retrieves and OpenLibraryAccount by username if it exists or"""
-        match = site.get().store.values(type="account", name="username", value=username, limit=1)
+        match = web.ctx.site.store.values(type="account", name="username", value=username, limit=1)
 
         if len(match):
             return cls(match[0])
 
-        lower_match = site.get().store.values(type="account", name="lusername", value=username, limit=1)
+        lower_match = web.ctx.site.store.values(type="account", name="lusername", value=username, limit=1)
 
         if len(lower_match):
             return cls(lower_match[0])
@@ -583,7 +582,7 @@ class OpenLibraryAccount(Account):
         """
         :rtype: OpenLibraryAccount or None
         """
-        ol_accounts = site.get().store.values(type="account", name="internetarchive_itemname", value=link)
+        ol_accounts = web.ctx.site.store.values(type="account", name="internetarchive_itemname", value=link)
         return cls(ol_accounts[0]) if ol_accounts else None
 
     @classmethod
@@ -598,9 +597,9 @@ class OpenLibraryAccount(Account):
         if that fails.
         """
         email = email.strip()
-        email_doc = site.get().store.get("account-email/" + email) or site.get().store.get("account-email/" + email.lower())
+        email_doc = web.ctx.site.store.get("account-email/" + email) or web.ctx.site.store.get("account-email/" + email.lower())
         if email_doc and "username" in email_doc:
-            doc = site.get().store.get("account/" + email_doc["username"])
+            doc = web.ctx.site.store.get("account/" + email_doc["username"])
             return cls(doc) if doc else None
         return None
 
@@ -616,9 +615,9 @@ class OpenLibraryAccount(Account):
         """Careful, this will save any other changes to the ol user object as
         well
         """
-        _ol_account = site.get().store.get(self._key)
+        _ol_account = web.ctx.site.store.get(self._key)
         _ol_account["internetarchive_itemname"] = None
-        site.get().store[self._key] = _ol_account
+        web.ctx.site.store[self._key] = _ol_account
         self.internetarchive_itemname = None
         stats.increment("ol.account.xauth.unlinked")
 
@@ -628,23 +627,23 @@ class OpenLibraryAccount(Account):
         """
         itemname = itemname if itemname.startswith("@") else f"@{itemname}"
 
-        _ol_account = site.get().store.get(self._key)
+        _ol_account = web.ctx.site.store.get(self._key)
         _ol_account["internetarchive_itemname"] = itemname
-        site.get().store[self._key] = _ol_account
+        web.ctx.site.store[self._key] = _ol_account
         self.internetarchive_itemname = itemname
         stats.increment("ol.account.xauth.linked")
 
     def save_s3_keys(self, s3_keys: dict) -> None:
-        _ol_account = site.get().store.get(self._key)
+        _ol_account = web.ctx.site.store.get(self._key)
         _ol_account["s3_keys"] = s3_keys
-        site.get().store[self._key] = _ol_account
+        web.ctx.site.store[self._key] = _ol_account
         self.s3_keys = s3_keys
 
     def update_last_login(self):
-        _ol_account = site.get().store.get(self._key)
+        _ol_account = web.ctx.site.store.get(self._key)
         last_login = datetime.datetime.utcnow().isoformat()
         _ol_account["last_login"] = last_login
-        site.get().store[self._key] = _ol_account
+        web.ctx.site.store[self._key] = _ol_account
         self.last_login = last_login
 
     @property
@@ -689,7 +688,7 @@ class OpenLibraryAccount(Account):
         if ol_account.is_blocked():
             return "account_blocked"
         try:
-            site.get().login(ol_account.username, password)
+            web.ctx.site.login(ol_account.username, password)
         except ClientException as e:
             code = e.get_data().get("code")
             return code
@@ -1073,13 +1072,13 @@ def audit_accounts(  # noqa: PLR0912
     elif ol_account.pd_authority and has_special_access and ol_account.pd_status != PDRequestStatus.FULFILLED:
         ol_account.update_pd(rpd=PDRequestStatus.FULFILLED.value)
 
-    # When a user logs in with OL credentials, the site.get().login() is called with
+    # When a user logs in with OL credentials, the web.ctx.site.login() is called with
     # their OL user credentials, which internally sets an auth_token enabling the
-    # user's session.  The site.get().login method requires OL credentials which are
+    # user's session.  The web.ctx.site.login method requires OL credentials which are
     # not present in the case where a user logs in with their IA credentials. As a
     # result, when users login with their valid IA credentials, the following kludge
     # allows us to fetch the OL account linked to their IA account, bypass this
-    # site.get().login method (which requires OL credentials), and directly set an
+    # web.ctx.site.login method (which requires OL credentials), and directly set an
     # auth_token to enable the user's session.
     web.ctx.conn.set_auth_token(ol_account.generate_login_code())
     ol_account.update_last_login()

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -26,6 +26,7 @@ from openlibrary.core.bookshelves import Bookshelves
 from openlibrary.core.edits import CommunityEditsQueue
 from openlibrary.core.observations import Observations
 from openlibrary.core.ratings import Ratings
+from openlibrary.utils.request_context import site
 
 try:
     from simplejson.errors import JSONDecodeError
@@ -223,7 +224,7 @@ class Link(web.storage):
         return datetime.datetime.strptime(d, "%Y-%m-%dT%H:%M:%S")
 
     def delete(self) -> None:
-        del web.ctx.site.store[self["_key"]]
+        del site.get().store[self["_key"]]
 
 
 class Account(web.storage):
@@ -261,27 +262,27 @@ class Account(web.storage):
 
     def get_recentchanges(self, limit: int = 100, offset: int = 0):
         q = {"author": self.get_user().key, "limit": limit, "offset": offset}
-        return web.ctx.site.recentchanges(q)
+        return site.get().recentchanges(q)
 
     def verify_password(self, password) -> bool:
         return verify_hash(get_secret_key(), password, self.enc_password)
 
     def update_password(self, new_password) -> None:
-        web.ctx.site.update_account(self.username, password=new_password)
+        site.get().update_account(self.username, password=new_password)
 
     def update_email(self, email) -> None:
-        web.ctx.site.update_account(self.username, email=email)
+        site.get().update_account(self.username, email=email)
 
     def activate(self) -> None:
-        web.ctx.site.activate_account(username=self.username)
+        site.get().activate_account(username=self.username)
 
     def block(self) -> None:
         """Blocks this account."""
-        web.ctx.site.update_account(self.username, status="blocked")
+        site.get().update_account(self.username, status="blocked")
 
     def unblock(self) -> None:
         """Unblocks this account."""
-        web.ctx.site.update_account(self.username, status="active")
+        site.get().update_account(self.username, status="active")
 
     def is_blocked(self) -> bool:
         """Tests if this account is blocked."""
@@ -303,7 +304,7 @@ class Account(web.storage):
         if self.is_blocked():
             return "account_blocked"
         try:
-            web.ctx.site.login(self.username, password)
+            site.get().login(self.username, password)
         except ClientException as e:
             code = e.get_data().get("code")
             return code
@@ -322,7 +323,7 @@ class Account(web.storage):
 
     def _save(self) -> None:
         """Saves this account in store."""
-        web.ctx.site.store[self._key] = self
+        site.get().store[self._key] = self
 
     @property
     def last_login(self) -> datetime.datetime:
@@ -343,30 +344,30 @@ class Account(web.storage):
         :returns: Not an Account obj, but a /people/xxx User
         """
         key = "/people/" + self.username
-        return web.ctx.site.get(key)
+        return site.get().get(key)
 
     def get_creation_info(self) -> dict:
         key = "/people/" + self.username
-        doc = web.ctx.site.get(key)
+        doc = site.get().get(key)
         return doc.get_creation_info()
 
     def get_activation_link(self) -> Link | bool:
         key = f"account/{self.username}/verify"
-        if doc := web.ctx.site.store.get(key):
+        if doc := site.get().store.get(key):
             return Link(doc)
         else:
             return False
 
     def get_password_reset_link(self) -> Link | bool:
         key = f"account/{self.username}/password"
-        if doc := web.ctx.site.store.get(key):
+        if doc := site.get().store.get(key):
             return Link(doc)
         else:
             return False
 
     def get_links(self) -> list[Link]:
         """Returns all the verification links present in the database."""
-        return web.ctx.site.store.values(type="account-link", name="username", value=self.username)
+        return site.get().store.values(type="account-link", name="username", value=self.username)
 
     def get_tags(self) -> list[str]:
         """Returns list of tags that this user has."""
@@ -409,13 +410,13 @@ class Account(web.storage):
             patron.set_data(data, "delete-profile")
 
             # Remove account information from store:
-            del web.ctx.site.store[f"account/{username}"]
-            del web.ctx.site.store[f"account/{username}/verify"]
-            del web.ctx.site.store[f"account/{username}/password"]
-            del web.ctx.site.store[f"account-email/{email}"]
-            del web.ctx.site.store[f"account-email/{email.lower()}"]
+            del site.get().store[f"account/{username}"]
+            del site.get().store[f"account/{username}/verify"]
+            del site.get().store[f"account/{username}/password"]
+            del site.get().store[f"account-email/{email}"]
+            del site.get().store[f"account-email/{email.lower()}"]
             # Delete preferences:
-            del web.ctx.site.store[f"/people/{username}/preferences"]
+            del site.get().store[f"/people/{username}/preferences"]
 
         # Generate new unique username for patron:
         # Note: Cannot test get_activation_link() locally
@@ -510,7 +511,7 @@ class OpenLibraryAccount(Account):
                 test=True,
             )
         try:
-            web.ctx.site.register(
+            site.get().register(
                 username=username,
                 email=email,
                 password=password,
@@ -522,8 +523,8 @@ class OpenLibraryAccount(Account):
         if verified:
             key = f"account/{username}/verify"
             doc = create_link_doc(key, username, email)
-            web.ctx.site.store[key] = doc
-            web.ctx.site.activate_account(username=username)
+            site.get().store[key] = doc
+            site.get().activate_account(username=username)
 
         ol_account = cls.get_by_email(email)
 
@@ -565,12 +566,12 @@ class OpenLibraryAccount(Account):
     @classmethod
     def get_by_username(cls, username: str) -> OpenLibraryAccount | None:
         """Retrieves and OpenLibraryAccount by username if it exists or"""
-        match = web.ctx.site.store.values(type="account", name="username", value=username, limit=1)
+        match = site.get().store.values(type="account", name="username", value=username, limit=1)
 
         if len(match):
             return cls(match[0])
 
-        lower_match = web.ctx.site.store.values(type="account", name="lusername", value=username, limit=1)
+        lower_match = site.get().store.values(type="account", name="lusername", value=username, limit=1)
 
         if len(lower_match):
             return cls(lower_match[0])
@@ -582,7 +583,7 @@ class OpenLibraryAccount(Account):
         """
         :rtype: OpenLibraryAccount or None
         """
-        ol_accounts = web.ctx.site.store.values(type="account", name="internetarchive_itemname", value=link)
+        ol_accounts = site.get().store.values(type="account", name="internetarchive_itemname", value=link)
         return cls(ol_accounts[0]) if ol_accounts else None
 
     @classmethod
@@ -597,9 +598,9 @@ class OpenLibraryAccount(Account):
         if that fails.
         """
         email = email.strip()
-        email_doc = web.ctx.site.store.get("account-email/" + email) or web.ctx.site.store.get("account-email/" + email.lower())
+        email_doc = site.get().store.get("account-email/" + email) or site.get().store.get("account-email/" + email.lower())
         if email_doc and "username" in email_doc:
-            doc = web.ctx.site.store.get("account/" + email_doc["username"])
+            doc = site.get().store.get("account/" + email_doc["username"])
             return cls(doc) if doc else None
         return None
 
@@ -615,9 +616,9 @@ class OpenLibraryAccount(Account):
         """Careful, this will save any other changes to the ol user object as
         well
         """
-        _ol_account = web.ctx.site.store.get(self._key)
+        _ol_account = site.get().store.get(self._key)
         _ol_account["internetarchive_itemname"] = None
-        web.ctx.site.store[self._key] = _ol_account
+        site.get().store[self._key] = _ol_account
         self.internetarchive_itemname = None
         stats.increment("ol.account.xauth.unlinked")
 
@@ -627,23 +628,23 @@ class OpenLibraryAccount(Account):
         """
         itemname = itemname if itemname.startswith("@") else f"@{itemname}"
 
-        _ol_account = web.ctx.site.store.get(self._key)
+        _ol_account = site.get().store.get(self._key)
         _ol_account["internetarchive_itemname"] = itemname
-        web.ctx.site.store[self._key] = _ol_account
+        site.get().store[self._key] = _ol_account
         self.internetarchive_itemname = itemname
         stats.increment("ol.account.xauth.linked")
 
     def save_s3_keys(self, s3_keys: dict) -> None:
-        _ol_account = web.ctx.site.store.get(self._key)
+        _ol_account = site.get().store.get(self._key)
         _ol_account["s3_keys"] = s3_keys
-        web.ctx.site.store[self._key] = _ol_account
+        site.get().store[self._key] = _ol_account
         self.s3_keys = s3_keys
 
     def update_last_login(self):
-        _ol_account = web.ctx.site.store.get(self._key)
+        _ol_account = site.get().store.get(self._key)
         last_login = datetime.datetime.utcnow().isoformat()
         _ol_account["last_login"] = last_login
-        web.ctx.site.store[self._key] = _ol_account
+        site.get().store[self._key] = _ol_account
         self.last_login = last_login
 
     @property
@@ -688,7 +689,7 @@ class OpenLibraryAccount(Account):
         if ol_account.is_blocked():
             return "account_blocked"
         try:
-            web.ctx.site.login(ol_account.username, password)
+            site.get().login(ol_account.username, password)
         except ClientException as e:
             code = e.get_data().get("code")
             return code
@@ -1072,13 +1073,13 @@ def audit_accounts(  # noqa: PLR0912
     elif ol_account.pd_authority and has_special_access and ol_account.pd_status != PDRequestStatus.FULFILLED:
         ol_account.update_pd(rpd=PDRequestStatus.FULFILLED.value)
 
-    # When a user logs in with OL credentials, the web.ctx.site.login() is called with
+    # When a user logs in with OL credentials, the site.get().login() is called with
     # their OL user credentials, which internally sets an auth_token enabling the
-    # user's session.  The web.ctx.site.login method requires OL credentials which are
+    # user's session.  The site.get().login method requires OL credentials which are
     # not present in the case where a user logs in with their IA credentials. As a
     # result, when users login with their valid IA credentials, the following kludge
     # allows us to fetch the OL account linked to their IA account, bypass this
-    # web.ctx.site.login method (which requires OL credentials), and directly set an
+    # site.get().login method (which requires OL credentials), and directly set an
     # auth_token to enable the user's session.
     web.ctx.conn.set_auth_token(ol_account.generate_login_code())
     ol_account.update_last_login()

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -25,6 +25,7 @@ from openlibrary.utils.async_utils import async_bridge
 from openlibrary.utils.request_context import (
     req_context,
     set_context_from_legacy_web_py,
+    site,
 )
 
 from . import helpers as h
@@ -298,7 +299,7 @@ async def get_available_async(
         for item in items:
             if item.get("openlibrary_work"):
                 results[item["openlibrary_work"]] = item["openlibrary_edition"]
-        books = web.ctx.site.get_many([f"/books/{olid}" for olid in results.values()])
+        books = site.get().get_many([f"/books/{olid}" for olid in results.values()])
         books = await add_availability_async(books)
         return books
     except Exception:  # TODO: Narrow exception scope
@@ -574,7 +575,7 @@ def get_items_and_add_availability(ocaids: list[str]) -> dict[str, Edition]:
     Returns a dict of the form: `{"ocaid1": edition1, "ocaid2": edition2, ...}`
     """
     ocaid_availability = get_availability("identifier", ocaids)
-    editions = web.ctx.site.get_many([f"/books/{item.get('openlibrary_edition')}" for item in ocaid_availability.values() if item.get("openlibrary_edition")])
+    editions = site.get().get_many([f"/books/{item.get('openlibrary_edition')}" for item in ocaid_availability.values() if item.get("openlibrary_edition")])
 
     # Attach availability
     for edition in editions:
@@ -623,7 +624,7 @@ def get_loan(identifier: str, user_key: str | None = None):
         else:
             account = OpenLibraryAccount.get_by_key(user_key)
 
-    d = web.ctx.site.store.get("loan-" + identifier)
+    d = site.get().store.get("loan-" + identifier)
     if d and (user_key is None or (account and d["user"] == account.username) or (account and d["user"] == account.itemname)):
         loan = Loan(d)
         if loan.is_expired():
@@ -658,7 +659,7 @@ def get_loans_of_user(user_key: str) -> list[Loan]:
 
     account = OpenLibraryAccount.get_by_username(user_key.rsplit("/", maxsplit=1)[-1])
 
-    loandata = web.ctx.site.store.values(type="/type/loan", name="user", value=user_key)
+    loandata = site.get().store.values(type="/type/loan", name="user", value=user_key)
     loans = [Loan(d) for d in loandata]
     if account and account.itemname:
         loans += _get_ia_loans_of_user(account.itemname)
@@ -787,7 +788,7 @@ class EBookRecord(dict):
     @staticmethod
     def find(identifier: str) -> EBookRecord:
         key = "ebooks/" + identifier
-        d = web.ctx.site.store.get(key) or {"_key": key, "type": "ebook", "_rev": 1}
+        d = site.get().store.get(key) or {"_key": key, "type": "ebook", "_rev": 1}
         return EBookRecord(d)
 
     def update(self, **kwargs):
@@ -799,7 +800,7 @@ class EBookRecord(dict):
             return
 
         dict.update(self, **kwargs)
-        web.ctx.site.store[self["_key"]] = self
+        site.get().store[self["_key"]] = self
 
 
 class Loan(dict):
@@ -901,7 +902,7 @@ class Loan(dict):
         if self.get("stored_at") == "ia":
             return
 
-        web.ctx.site.store[self["_key"]] = self
+        site.get().store[self["_key"]] = self
 
         # Inform listers that a loan is created/updated
         eventer.trigger("loan-created", self)
@@ -932,7 +933,7 @@ class Loan(dict):
             if account and account.itemname:
                 ia_lending_api.delete_loan(self["ocaid"], account.itemname)
         else:
-            web.ctx.site.store.delete(self["_key"])
+            site.get().store.delete(self["_key"])
 
         sync_loan(self["ocaid"])
         # Inform listers that a loan is completed
@@ -941,7 +942,7 @@ class Loan(dict):
 
 def resolve_identifier(identifier: str) -> str | None:
     """Returns the OL book key for given IA identifier."""
-    if keys := web.ctx.site.things({"type": "/type/edition", "ocaid": identifier}):
+    if keys := site.get().things({"type": "/type/edition", "ocaid": identifier}):
         return keys[0]
     else:
         return "/books/ia:" + identifier

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -25,7 +25,6 @@ from openlibrary.utils.async_utils import async_bridge
 from openlibrary.utils.request_context import (
     req_context,
     set_context_from_legacy_web_py,
-    site,
 )
 
 from . import helpers as h
@@ -299,7 +298,7 @@ async def get_available_async(
         for item in items:
             if item.get("openlibrary_work"):
                 results[item["openlibrary_work"]] = item["openlibrary_edition"]
-        books = site.get().get_many([f"/books/{olid}" for olid in results.values()])
+        books = web.ctx.site.get_many([f"/books/{olid}" for olid in results.values()])
         books = await add_availability_async(books)
         return books
     except Exception:  # TODO: Narrow exception scope
@@ -575,7 +574,7 @@ def get_items_and_add_availability(ocaids: list[str]) -> dict[str, Edition]:
     Returns a dict of the form: `{"ocaid1": edition1, "ocaid2": edition2, ...}`
     """
     ocaid_availability = get_availability("identifier", ocaids)
-    editions = site.get().get_many([f"/books/{item.get('openlibrary_edition')}" for item in ocaid_availability.values() if item.get("openlibrary_edition")])
+    editions = web.ctx.site.get_many([f"/books/{item.get('openlibrary_edition')}" for item in ocaid_availability.values() if item.get("openlibrary_edition")])
 
     # Attach availability
     for edition in editions:
@@ -624,7 +623,7 @@ def get_loan(identifier: str, user_key: str | None = None):
         else:
             account = OpenLibraryAccount.get_by_key(user_key)
 
-    d = site.get().store.get("loan-" + identifier)
+    d = web.ctx.site.store.get("loan-" + identifier)
     if d and (user_key is None or (account and d["user"] == account.username) or (account and d["user"] == account.itemname)):
         loan = Loan(d)
         if loan.is_expired():
@@ -659,7 +658,7 @@ def get_loans_of_user(user_key: str) -> list[Loan]:
 
     account = OpenLibraryAccount.get_by_username(user_key.rsplit("/", maxsplit=1)[-1])
 
-    loandata = site.get().store.values(type="/type/loan", name="user", value=user_key)
+    loandata = web.ctx.site.store.values(type="/type/loan", name="user", value=user_key)
     loans = [Loan(d) for d in loandata]
     if account and account.itemname:
         loans += _get_ia_loans_of_user(account.itemname)
@@ -788,7 +787,7 @@ class EBookRecord(dict):
     @staticmethod
     def find(identifier: str) -> EBookRecord:
         key = "ebooks/" + identifier
-        d = site.get().store.get(key) or {"_key": key, "type": "ebook", "_rev": 1}
+        d = web.ctx.site.store.get(key) or {"_key": key, "type": "ebook", "_rev": 1}
         return EBookRecord(d)
 
     def update(self, **kwargs):
@@ -800,7 +799,7 @@ class EBookRecord(dict):
             return
 
         dict.update(self, **kwargs)
-        site.get().store[self["_key"]] = self
+        web.ctx.site.store[self["_key"]] = self
 
 
 class Loan(dict):
@@ -902,7 +901,7 @@ class Loan(dict):
         if self.get("stored_at") == "ia":
             return
 
-        site.get().store[self["_key"]] = self
+        web.ctx.site.store[self["_key"]] = self
 
         # Inform listers that a loan is created/updated
         eventer.trigger("loan-created", self)
@@ -933,7 +932,7 @@ class Loan(dict):
             if account and account.itemname:
                 ia_lending_api.delete_loan(self["ocaid"], account.itemname)
         else:
-            site.get().store.delete(self["_key"])
+            web.ctx.site.store.delete(self["_key"])
 
         sync_loan(self["ocaid"])
         # Inform listers that a loan is completed
@@ -942,7 +941,7 @@ class Loan(dict):
 
 def resolve_identifier(identifier: str) -> str | None:
     """Returns the OL book key for given IA identifier."""
-    if keys := site.get().things({"type": "/type/edition", "ocaid": identifier}):
+    if keys := web.ctx.site.things({"type": "/type/edition", "ocaid": identifier}):
         return keys[0]
     else:
         return "/books/ia:" + identifier

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -54,11 +54,11 @@ logger = logging.getLogger("openlibrary.core")
 
 def _get_ol_base_url() -> str:
     # Anand Oct 2013
-    # Looks like the default value when called from script
-    if "[unknown]" in web.ctx.home:
-        return "https://openlibrary.org"
-    else:
-        return web.ctx.home
+    # Looks like the default value when called from script or from FastAPI (no web.ctx)
+    home = getattr(web.ctx, "home", None)
+    if home and "[unknown]" not in home:
+        return home
+    return "https://openlibrary.org"
 
 
 class Image:
@@ -430,8 +430,8 @@ class Edition(Thing):
             else:
                 query = {"type": "/type/edition", f"isbn_{len(book_id)}": book_id}
 
-            if matches := web.ctx.site.things(query):
-                return web.ctx.site.get(matches[0])
+            if matches := site.get().things(query):
+                return site.get().get(matches[0])
 
         # Attempt to fetch the book from the import_item table
         if allow_import:
@@ -464,7 +464,7 @@ class Edition(Thing):
         """
         Create a dummy work from an orphaned_edition.
         """
-        return web.ctx.site.new(
+        return site.get().new(
             "",
             {
                 "key": "",
@@ -721,7 +721,7 @@ class Work(Thing):
         redirect_chain = []
         key = work_key
         while not resolved_key:
-            thing = web.ctx.site.get(key)
+            thing = site.get().get(key)
             redirect_chain.append(thing)
             if thing.type.key == "/type/redirect":
                 key = thing.location
@@ -776,7 +776,7 @@ class Work(Thing):
     def get_redirects(cls, day, batch_size=1000, batch=0):
         tomorrow = day + timedelta(days=1)
 
-        work_redirect_ids = web.ctx.site.things(
+        work_redirect_ids = site.get().things(
             {
                 "type": "/type/redirect",
                 "key~": "/works/*",
@@ -820,7 +820,7 @@ class Work(Thing):
                     f"[update-redirects] {current_date}, batch {batch + 1}: #{total}",
                 )
                 work_redirect_ids, has_more = cls.get_redirects(current_date, batch_size=batch_size, batch=batch)
-                work_redirect_batch = web.ctx.site.get_many(work_redirect_ids)
+                work_redirect_batch = site.get().get_many(work_redirect_ids)
                 for work in work_redirect_batch:
                     total += 1
                     chain = Work.resolve_redirect_chain(work.key, test=test)
@@ -926,7 +926,7 @@ class User(Thing):
 
     def preferences(self):
         def query_store(_key):
-            return web.ctx.site.store.get(_key)
+            return site.get().store.get(_key)
 
         key = f"{self.key}/preferences"
 
@@ -938,7 +938,7 @@ class User(Thing):
         prefs.update(new_prefs)
         prefs["_rev"] = None
         prefs["type"] = "preferences"
-        web.ctx.site.store[key] = prefs
+        site.get().store[key] = prefs
 
     def is_usergroup_member(self, usergroup: str) -> bool:
         if not usergroup.startswith("/usergroup/"):
@@ -1007,7 +1007,7 @@ class User(Thing):
     )
     def get_avatar_url(cls, username: str) -> str:
         username = username.rsplit("/people/", maxsplit=1)[-1]
-        user = web.ctx.site.get(f"/people/{username}")
+        user = site.get().get(f"/people/{username}")
         itemname = user.get_account().get("internetarchive_itemname")
 
         return f"https://archive.org/services/img/{itemname}"
@@ -1136,7 +1136,7 @@ class UserGroup(Thing):
         """
         if not key.startswith("/usergroup/"):
             key = f"/usergroup/{key}"
-        return web.ctx.site.get(key)
+        return site.get().get(key)
 
     def add_user(self, userkey: str) -> None:
         """Administrative utility (designed to be used in conjunction with
@@ -1144,7 +1144,7 @@ class UserGroup(Thing):
 
         :param str userkey: e.g. /people/mekBot
         """
-        if not web.ctx.site.get(userkey):
+        if not site.get().get(userkey):
             raise KeyError("Invalid userkey")
 
         # Make sure userkey not already in group members:
@@ -1152,14 +1152,14 @@ class UserGroup(Thing):
         if not any(userkey == member["key"] for member in members):
             members.append({"key": userkey})
             self.members = members
-            web.ctx.site.save(
+            site.get().save(
                 self.dict(),
                 f"Adding {userkey} to {self.key}",
                 action="edit-usergroup-add-member",
             )
 
     def remove_user(self, userkey):
-        if not web.ctx.site.get(userkey):
+        if not site.get().get(userkey):
             raise KeyError("Invalid userkey")
 
         members = self.get("members", [])
@@ -1171,7 +1171,7 @@ class UserGroup(Thing):
                 break
 
         self.members = members
-        web.ctx.site.save(
+        site.get().save(
             self.dict(),
             f"Removing {userkey} from {self.key}",
             action="edit-usergroup-delete-member",
@@ -1222,7 +1222,7 @@ class Subject(web.storage):
         for w in self.works:
             cover_id = w.get("cover_id")
             if cover_id:
-                return Image(web.ctx.site, "b", cover_id)
+                return Image(site.get(), "b", cover_id)
 
 
 class Tag(Thing):
@@ -1249,7 +1249,7 @@ class Tag(Thing):
         q = {"type": "/type/tag", "slugs": cls.normalize(tag_name)}
         if tag_type:
             q["tag_type"] = tag_type
-        matches = list(web.ctx.site.things(q))
+        matches = list(site.get().things(q))
         return matches
 
     @classmethod
@@ -1260,16 +1260,16 @@ class Tag(Thing):
         comment="New Tag",
     ):
         """Creates a new Tag object."""
-        current_user = web.ctx.site.get_user()
+        current_user = site.get().get_user()
         patron = current_user.get_username() if current_user else "ImportBot"
-        key = web.ctx.site.new_key("/type/tag")
+        key = site.get().new_key("/type/tag")
         tag["key"] = key
 
         from openlibrary.accounts import RunAs
 
         with RunAs(patron):
             web.ctx.ip = web.ctx.ip or ip
-            t = web.ctx.site.save(tag, comment=comment, action="create-tag")
+            t = site.get().save(tag, comment=comment, action="create-tag")
             return t
 
 

--- a/openlibrary/fastapi/account.py
+++ b/openlibrary/fastapi/account.py
@@ -5,13 +5,16 @@ FastAPI account endpoints for authentication.
 from __future__ import annotations
 
 import os
-from typing import Annotated
-from urllib.parse import unquote, urlparse
+from typing import Annotated, Any
+from urllib.parse import quote, unquote, urlparse
 
-from fastapi import APIRouter, Depends, Form, HTTPException, Request, Response, status
+from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request, Response, status
+from fastapi.responses import HTMLResponse, RedirectResponse
 from pydantic import BaseModel, Field
 
 from infogami import config
+from infogami.utils.view import render_site
+from openlibrary import accounts
 from openlibrary.accounts.model import audit_accounts, generate_login_code_for_user
 from openlibrary.core import stats
 from openlibrary.fastapi.auth import (
@@ -19,7 +22,9 @@ from openlibrary.fastapi.auth import (
     get_authenticated_user,
     require_authenticated_user,
 )
+from openlibrary.plugins.upstream import account as legacy_account
 from openlibrary.plugins.upstream.account import get_login_error
+from openlibrary.utils.request_context import legacy_web_ctx_from_fastapi
 
 router = APIRouter()
 
@@ -32,6 +37,37 @@ def _safe_redirect(url: str, default: str = "/") -> str:
     if parsed.scheme or parsed.netloc or not url.startswith("/") or url.startswith("//"):
         return default
     return url
+
+
+def _request_path_with_query(request: Request) -> str:
+    if request.url.query:
+        return f"{request.url.path}?{request.url.query}"
+    return request.url.path
+
+
+def _redirect_to_login(request: Request) -> RedirectResponse:
+    redirect = quote(_request_path_with_query(request), safe="")
+    return RedirectResponse(f"/account/login?redirect={redirect}", status_code=status.HTTP_303_SEE_OTHER)
+
+
+def _render_legacy_template(template_result: Any, path: str) -> str:
+    if hasattr(template_result, "rawtext"):
+        return str(template_result.rawtext)
+
+    if "title" not in template_result:
+        template_result.title = path.lstrip("/") or path
+
+    return str(render_site(config.site, template_result))
+
+
+def _require_legacy_current_user():
+    if user := accounts.get_current_user():
+        return user
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Authentication required",
+        headers={"WWW-Authenticate": "Session"},
+    )
 
 
 class AuthTestResponse(BaseModel):
@@ -148,6 +184,60 @@ async def optional_auth_endpoint(
             "message": "Hello, anonymous user!",
             "is_authenticated": False,
         }
+
+
+@router.get("/account/loans", response_class=HTMLResponse, response_model=None)
+def account_loans_page(
+    request: Request,
+    user: Annotated[AuthenticatedUser | None, Depends(get_authenticated_user)],
+) -> HTMLResponse | RedirectResponse:
+    if user is None:
+        return _redirect_to_login(request)
+
+    with legacy_web_ctx_from_fastapi(request):
+        legacy_user = accounts.get_current_user()
+        if legacy_user is None:
+            return _redirect_to_login(request)
+        html = _render_legacy_template(legacy_account.get_account_loans_page(legacy_user), request.url.path)
+
+    return HTMLResponse(html)
+
+
+@router.get("/account/loans.json")
+def account_loans_json(
+    request: Request,
+    _: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],
+) -> dict[str, Any]:
+    with legacy_web_ctx_from_fastapi(request):
+        return legacy_account.get_account_loans_json(_require_legacy_current_user())
+
+
+@router.get("/account/loan-history", response_class=HTMLResponse, response_model=None)
+def account_loan_history_page(
+    request: Request,
+    user: Annotated[AuthenticatedUser | None, Depends(get_authenticated_user)],
+    page: Annotated[int, Query(ge=1)] = 1,
+) -> HTMLResponse | RedirectResponse:
+    if user is None:
+        return _redirect_to_login(request)
+
+    with legacy_web_ctx_from_fastapi(request):
+        legacy_user = accounts.get_current_user()
+        if legacy_user is None:
+            return _redirect_to_login(request)
+        html = _render_legacy_template(legacy_account.get_account_loan_history_page(legacy_user, page), request.url.path)
+
+    return HTMLResponse(html)
+
+
+@router.get("/account/loan-history.json")
+def account_loan_history_json(
+    request: Request,
+    _: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],
+    page: Annotated[int, Query(ge=1)] = 1,
+) -> dict[str, Any]:
+    with legacy_web_ctx_from_fastapi(request):
+        return legacy_account.get_account_loan_history_json(_require_legacy_current_user(), page)
 
 
 class LoginForm(BaseModel):

--- a/openlibrary/fastapi/account.py
+++ b/openlibrary/fastapi/account.py
@@ -22,6 +22,7 @@ from openlibrary.fastapi.auth import (
 )
 from openlibrary.plugins.upstream import account as legacy_account
 from openlibrary.plugins.upstream.account import get_login_error
+from openlibrary.utils.request_context import legacy_web_ctx_from_fastapi
 
 router = APIRouter()
 
@@ -154,33 +155,38 @@ async def optional_auth_endpoint(
 
 @router.get("/account/loans.json")
 def account_loans_json(
+    request: Request,
     _: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],
 ) -> dict[str, Any]:
-    try:
-        return legacy_account.get_account_loans_json(accounts.get_current_user())
-    except Exception:
-        if os.getenv("LOCAL_DEV"):
-            raise HTTPException(
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail="Loan data requires credentials for the production Internet Archive server and is not available in the local development environment.",
-            )
-        raise
+    with legacy_web_ctx_from_fastapi(request):
+        try:
+            return legacy_account.get_account_loans_json(accounts.get_current_user())
+        except Exception:
+            if os.getenv("LOCAL_DEV"):
+                raise HTTPException(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    detail="Loan data requires credentials for the production Internet Archive server and is not available in the local development environment.",
+                )
+            raise
 
 
 @router.get("/account/loan-history.json")
 def account_loan_history_json(
+    request: Request,
     _: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],
     page: Annotated[int, Query(ge=1)] = 1,
 ) -> dict[str, Any]:
-    try:
-        return legacy_account.get_account_loan_history_json(accounts.get_current_user(), page)
-    except Exception:
-        if os.getenv("LOCAL_DEV"):
-            raise HTTPException(
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail="Loan history requires credentials for the production Internet Archive server and is not available in the local development environment.",
-            )
-        raise
+    with legacy_web_ctx_from_fastapi(request):
+        try:
+            return legacy_account.get_account_loan_history_json(accounts.get_current_user(), page)
+        except Exception:
+            if os.getenv("LOCAL_DEV"):
+                raise HTTPException(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    detail="Loan history requires credentials for the production Internet Archive "
+                    "server and is not available in the local development environment.",
+                )
+            raise
 
 
 class LoginForm(BaseModel):

--- a/openlibrary/fastapi/account.py
+++ b/openlibrary/fastapi/account.py
@@ -22,7 +22,6 @@ from openlibrary.fastapi.auth import (
 )
 from openlibrary.plugins.upstream import account as legacy_account
 from openlibrary.plugins.upstream.account import get_login_error
-from openlibrary.utils.request_context import legacy_web_ctx_from_fastapi
 
 router = APIRouter()
 
@@ -155,38 +154,33 @@ async def optional_auth_endpoint(
 
 @router.get("/account/loans.json")
 def account_loans_json(
-    request: Request,
     _: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],
 ) -> dict[str, Any]:
-    with legacy_web_ctx_from_fastapi(request):
-        try:
-            return legacy_account.get_account_loans_json(accounts.get_current_user())
-        except Exception:
-            if os.getenv("LOCAL_DEV"):
-                raise HTTPException(
-                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                    detail="Loan data requires credentials for the production Internet Archive server and is not available in the local development environment.",
-                )
-            raise
+    try:
+        return legacy_account.get_account_loans_json(accounts.get_current_user())
+    except Exception:
+        if os.getenv("LOCAL_DEV"):
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Loan data requires credentials for the production Internet Archive server and is not available in the local development environment.",
+            )
+        raise
 
 
 @router.get("/account/loan-history.json")
 def account_loan_history_json(
-    request: Request,
     _: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],
     page: Annotated[int, Query(ge=1)] = 1,
 ) -> dict[str, Any]:
-    with legacy_web_ctx_from_fastapi(request):
-        try:
-            return legacy_account.get_account_loan_history_json(accounts.get_current_user(), page)
-        except Exception:
-            if os.getenv("LOCAL_DEV"):
-                raise HTTPException(
-                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                    detail="Loan history requires credentials for the production Internet Archive "
-                    "server and is not available in the local development environment.",
-                )
-            raise
+    try:
+        return legacy_account.get_account_loan_history_json(accounts.get_current_user(), page)
+    except Exception:
+        if os.getenv("LOCAL_DEV"):
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Loan history requires credentials for the production Internet Archive server and is not available in the local development environment.",
+            )
+        raise
 
 
 class LoginForm(BaseModel):

--- a/openlibrary/fastapi/account.py
+++ b/openlibrary/fastapi/account.py
@@ -174,13 +174,17 @@ def account_loan_history_json(
 ) -> dict[str, Any]:
     try:
         return legacy_account.get_account_loan_history_json(accounts.get_current_user(), page)
-    except Exception:
+    except Exception as e:  # noqa: BLE001
         if os.getenv("LOCAL_DEV"):
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail="Loan history requires credentials for the production Internet Archive server and is not available in the local development environment.",
             )
-        raise
+        return {
+            "error": f"{type(e).__name__}: {e}",
+            "error_type": type(e).__name__,
+            "detail": str(e),
+        }
 
 
 class LoginForm(BaseModel):

--- a/openlibrary/fastapi/account.py
+++ b/openlibrary/fastapi/account.py
@@ -6,14 +6,12 @@ from __future__ import annotations
 
 import os
 from typing import Annotated, Any
-from urllib.parse import quote, unquote, urlparse
+from urllib.parse import unquote, urlparse
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request, Response, status
-from fastapi.responses import HTMLResponse, RedirectResponse
 from pydantic import BaseModel, Field
 
 from infogami import config
-from infogami.utils.view import render_site
 from openlibrary import accounts
 from openlibrary.accounts.model import audit_accounts, generate_login_code_for_user
 from openlibrary.core import stats
@@ -37,27 +35,6 @@ def _safe_redirect(url: str, default: str = "/") -> str:
     if parsed.scheme or parsed.netloc or not url.startswith("/") or url.startswith("//"):
         return default
     return url
-
-
-def _request_path_with_query(request: Request) -> str:
-    if request.url.query:
-        return f"{request.url.path}?{request.url.query}"
-    return request.url.path
-
-
-def _redirect_to_login(request: Request) -> RedirectResponse:
-    redirect = quote(_request_path_with_query(request), safe="")
-    return RedirectResponse(f"/account/login?redirect={redirect}", status_code=status.HTTP_303_SEE_OTHER)
-
-
-def _render_legacy_template(template_result: Any, path: str) -> str:
-    if hasattr(template_result, "rawtext"):
-        return str(template_result.rawtext)
-
-    if "title" not in template_result:
-        template_result.title = path.lstrip("/") or path
-
-    return str(render_site(config.site, template_result))
 
 
 def _require_legacy_current_user():
@@ -186,23 +163,6 @@ async def optional_auth_endpoint(
         }
 
 
-@router.get("/account/loans", response_class=HTMLResponse, response_model=None)
-def account_loans_page(
-    request: Request,
-    user: Annotated[AuthenticatedUser | None, Depends(get_authenticated_user)],
-) -> HTMLResponse | RedirectResponse:
-    if user is None:
-        return _redirect_to_login(request)
-
-    with legacy_web_ctx_from_fastapi(request):
-        legacy_user = accounts.get_current_user()
-        if legacy_user is None:
-            return _redirect_to_login(request)
-        html = _render_legacy_template(legacy_account.get_account_loans_page(legacy_user), request.url.path)
-
-    return HTMLResponse(html)
-
-
 @router.get("/account/loans.json")
 def account_loans_json(
     request: Request,
@@ -210,24 +170,6 @@ def account_loans_json(
 ) -> dict[str, Any]:
     with legacy_web_ctx_from_fastapi(request):
         return legacy_account.get_account_loans_json(_require_legacy_current_user())
-
-
-@router.get("/account/loan-history", response_class=HTMLResponse, response_model=None)
-def account_loan_history_page(
-    request: Request,
-    user: Annotated[AuthenticatedUser | None, Depends(get_authenticated_user)],
-    page: Annotated[int, Query(ge=1)] = 1,
-) -> HTMLResponse | RedirectResponse:
-    if user is None:
-        return _redirect_to_login(request)
-
-    with legacy_web_ctx_from_fastapi(request):
-        legacy_user = accounts.get_current_user()
-        if legacy_user is None:
-            return _redirect_to_login(request)
-        html = _render_legacy_template(legacy_account.get_account_loan_history_page(legacy_user, page), request.url.path)
-
-    return HTMLResponse(html)
 
 
 @router.get("/account/loan-history.json")

--- a/openlibrary/fastapi/account.py
+++ b/openlibrary/fastapi/account.py
@@ -37,16 +37,6 @@ def _safe_redirect(url: str, default: str = "/") -> str:
     return url
 
 
-def _require_legacy_current_user():
-    if user := accounts.get_current_user():
-        return user
-    raise HTTPException(
-        status_code=status.HTTP_401_UNAUTHORIZED,
-        detail="Authentication required",
-        headers={"WWW-Authenticate": "Session"},
-    )
-
-
 class AuthTestResponse(BaseModel):
     """Response model for the auth test endpoint."""
 
@@ -169,7 +159,15 @@ def account_loans_json(
     _: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],
 ) -> dict[str, Any]:
     with legacy_web_ctx_from_fastapi(request):
-        return legacy_account.get_account_loans_json(_require_legacy_current_user())
+        try:
+            return legacy_account.get_account_loans_json(accounts.get_current_user())
+        except Exception:
+            if os.getenv("LOCAL_DEV"):
+                raise HTTPException(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    detail="Loan data requires credentials for the production Internet Archive server and is not available in the local development environment.",
+                )
+            raise
 
 
 @router.get("/account/loan-history.json")
@@ -179,7 +177,16 @@ def account_loan_history_json(
     page: Annotated[int, Query(ge=1)] = 1,
 ) -> dict[str, Any]:
     with legacy_web_ctx_from_fastapi(request):
-        return legacy_account.get_account_loan_history_json(_require_legacy_current_user(), page)
+        try:
+            return legacy_account.get_account_loan_history_json(accounts.get_current_user(), page)
+        except Exception:
+            if os.getenv("LOCAL_DEV"):
+                raise HTTPException(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    detail="Loan history requires credentials for the production Internet Archive "
+                    "server and is not available in the local development environment.",
+                )
+            raise
 
 
 class LoginForm(BaseModel):

--- a/openlibrary/fastapi/account.py
+++ b/openlibrary/fastapi/account.py
@@ -5,6 +5,7 @@ FastAPI account endpoints for authentication.
 from __future__ import annotations
 
 import os
+import traceback
 from typing import Annotated, Any
 from urllib.parse import unquote, urlparse
 
@@ -184,6 +185,7 @@ def account_loan_history_json(
             "error": f"{type(e).__name__}: {e}",
             "error_type": type(e).__name__,
             "detail": str(e),
+            "traceback": traceback.format_exc(),
         }
 
 

--- a/openlibrary/fastapi/account.py
+++ b/openlibrary/fastapi/account.py
@@ -5,7 +5,7 @@ FastAPI account endpoints for authentication.
 from __future__ import annotations
 
 import os
-from typing import Annotated, Any
+from typing import Annotated
 from urllib.parse import unquote, urlparse
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request, Response, status
@@ -34,6 +34,24 @@ def _safe_redirect(url: str, default: str = "/") -> str:
     if parsed.scheme or parsed.netloc or not url.startswith("/") or url.startswith("//"):
         return default
     return url
+
+
+class AccountLoansResponse(BaseModel):
+    """Response model for /account/loans.json."""
+
+    loans: list[dict] = Field(
+        ...,
+        description="List of the user's current loans, each containing ocaid, book, resource_type, expiry, etc.",
+    )
+
+
+class AccountLoanHistoryResponse(BaseModel):
+    """Response model for /account/loan-history.json."""
+
+    loans_history: dict = Field(
+        ...,
+        description="Loan history data containing 'docs' (list of loan records), 'show_next' (bool), 'limit' (int), and 'page' (int).",
+    )
 
 
 class AuthTestResponse(BaseModel):
@@ -152,10 +170,10 @@ async def optional_auth_endpoint(
         }
 
 
-@router.get("/account/loans.json")
+@router.get("/account/loans.json", response_model=AccountLoansResponse)
 def account_loans_json(
     _: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],
-) -> dict[str, Any]:
+) -> dict:
     try:
         return legacy_account.get_account_loans_json(accounts.get_current_user())
     except Exception:
@@ -167,11 +185,11 @@ def account_loans_json(
         raise
 
 
-@router.get("/account/loan-history.json")
+@router.get("/account/loan-history.json", response_model=AccountLoanHistoryResponse)
 def account_loan_history_json(
     _: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],
     page: Annotated[int, Query(ge=1)] = 1,
-) -> dict[str, Any]:
+) -> dict:
     try:
         return legacy_account.get_account_loan_history_json(accounts.get_current_user(), page)
     except Exception:

--- a/openlibrary/fastapi/account.py
+++ b/openlibrary/fastapi/account.py
@@ -5,7 +5,6 @@ FastAPI account endpoints for authentication.
 from __future__ import annotations
 
 import os
-import traceback
 from typing import Annotated, Any
 from urllib.parse import unquote, urlparse
 
@@ -175,18 +174,13 @@ def account_loan_history_json(
 ) -> dict[str, Any]:
     try:
         return legacy_account.get_account_loan_history_json(accounts.get_current_user(), page)
-    except Exception as e:  # noqa: BLE001
+    except Exception:
         if os.getenv("LOCAL_DEV"):
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail="Loan history requires credentials for the production Internet Archive server and is not available in the local development environment.",
             )
-        return {
-            "error": f"{type(e).__name__}: {e}",
-            "error_type": type(e).__name__,
-            "detail": str(e),
-            "traceback": traceback.format_exc(),
-        }
+        raise
 
 
 class LoginForm(BaseModel):

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import csv
 import io
 import json
@@ -53,6 +55,7 @@ from openlibrary.plugins.upstream import borrow, forms
 from openlibrary.plugins.upstream.mybooks import MyBooksTemplate
 from openlibrary.plugins.upstream.utils import is_safe_redirect
 from openlibrary.utils.dateutil import elapsed_time
+from openlibrary.utils.request_context import site
 
 if TYPE_CHECKING:
     from openlibrary.core.models import SubjectType
@@ -1228,13 +1231,13 @@ class my_follows(delegate.page):
         return mb.render(header_title=_(key.capitalize()), template=template)
 
 
-def get_account_loans_json(user) -> dict[str, Any]:
+def get_account_loans_json(user: User) -> dict[str, Any]:
     user.update_loan_status()
     loans = borrow.get_loans(user)
     return {"loans": loans}
 
 
-def get_account_loan_history_json(user, page: int) -> dict[str, Any]:
+def get_account_loan_history_json(user: User, page: int) -> dict[str, Any]:
     username = user["key"].split("/")[-1]
     mb = MyBooksTemplate(username, key="loan_history")
     loan_history_data = dict(get_loan_history_data(page=page, mb=mb))
@@ -1462,7 +1465,7 @@ def get_loan_history_data(page: int, mb: MyBooksTemplate) -> dict[str, Any]:
     """
     if not (account := OpenLibraryAccount.get_by_username(mb.username)):
         raise render.notfound("Account for not found for %s" % mb.username, create=False)
-    s3_keys = web.ctx.site.store.get(account._key).get("s3_keys")
+    s3_keys = site.get().store.get(account._key).get("s3_keys")
     limit = RESULTS_PER_PAGE
     offset = page * limit - limit
     loan_history = s3_loan_api(

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from math import ceil
 from typing import TYPE_CHECKING, Any, Final
 from urllib.parse import urlparse
+from warnings import deprecated
 
 import requests
 import web
@@ -1227,22 +1228,63 @@ class my_follows(delegate.page):
         return mb.render(header_title=_(key.capitalize()), template=template)
 
 
+def get_account_loans_page(user):
+    from openlibrary.core.lending import get_loans_of_user
+
+    user.update_loan_status()
+    username = user["key"].split("/")[-1]
+    mb = MyBooksTemplate(username, "loans")
+    docs = get_loans_of_user(user.key)
+    template = render["account/loans"](user, docs)
+    return mb.render(header_title=_("Loans"), template=template)
+
+
+def get_account_loans_json(user) -> dict[str, Any]:
+    user.update_loan_status()
+    loans = borrow.get_loans(user)
+    return {"loans": loans}
+
+
+def _get_account_loan_history_context(user, page: int):
+    username = user["key"].split("/")[-1]
+    mb = MyBooksTemplate(username, key="loan_history")
+    return mb, get_loan_history_data(page=page, mb=mb)
+
+
+def get_account_loan_history_data(user, page: int) -> dict[str, Any]:
+    _, loan_history_data = _get_account_loan_history_context(user, page)
+    return loan_history_data
+
+
+def get_account_loan_history_page(user, page: int):
+    mb, loan_history_data = _get_account_loan_history_context(user, page)
+    template = render["account/loan_history"](
+        docs=loan_history_data["docs"],
+        current_page=page,
+        show_next=loan_history_data["show_next"],
+        ia_base_url=CONFIG_IA_DOMAIN,
+    )
+    return mb.render(header_title=_("Loan History"), template=template)
+
+
+def get_account_loan_history_json(user, page: int) -> dict[str, Any]:
+    loan_history_data = dict(get_account_loan_history_data(user, page))
+    # Ensure all `docs` are `dicts`, as some are `Edition`s.
+    loan_history_data["docs"] = [loan.dict() if not isinstance(loan, dict) else loan for loan in loan_history_data["docs"]]
+    return {"loans_history": loan_history_data}
+
+
+@deprecated("migrated to fastapi")
 class account_loans(delegate.page):
     path = "/account/loans"
 
     @require_login
     def GET(self):
-        from openlibrary.core.lending import get_loans_of_user
-
         user = accounts.get_current_user()
-        user.update_loan_status()
-        username = user["key"].split("/")[-1]
-        mb = MyBooksTemplate(username, "loans")
-        docs = get_loans_of_user(user.key)
-        template = render["account/loans"](user, docs)
-        return mb.render(header_title=_("Loans"), template=template)
+        return get_account_loans_page(user)
 
 
+@deprecated("migrated to fastapi")
 class account_loans_json(delegate.page):
     encoding = "json"
     path = "/account/loans"
@@ -1250,12 +1292,11 @@ class account_loans_json(delegate.page):
     @require_login
     def GET(self):
         user = accounts.get_current_user()
-        user.update_loan_status()
-        loans = borrow.get_loans(user)
         web.header("Content-Type", "application/json")
-        return delegate.RawText(json.dumps({"loans": loans}))
+        return delegate.RawText(json.dumps(get_account_loans_json(user)))
 
 
+@deprecated("migrated to fastapi")
 class account_loan_history(delegate.page):
     path = "/account/loan-history"
 
@@ -1264,18 +1305,10 @@ class account_loan_history(delegate.page):
         i = web.input(page=1)
         page = int(i.page)
         user = accounts.get_current_user()
-        username = user["key"].split("/")[-1]
-        mb = MyBooksTemplate(username, key="loan_history")
-        loan_history_data = get_loan_history_data(page=page, mb=mb)
-        template = render["account/loan_history"](
-            docs=loan_history_data["docs"],
-            current_page=page,
-            show_next=loan_history_data["show_next"],
-            ia_base_url=CONFIG_IA_DOMAIN,
-        )
-        return mb.render(header_title=_("Loan History"), template=template)
+        return get_account_loan_history_page(user, page)
 
 
+@deprecated("migrated to fastapi")
 class account_loan_history_json(delegate.page):
     encoding = "json"
     path = "/account/loan-history"
@@ -1285,14 +1318,8 @@ class account_loan_history_json(delegate.page):
         i = web.input(page=1)
         page = int(i.page)
         user = accounts.get_current_user()
-        username = user["key"].split("/")[-1]
-        mb = MyBooksTemplate(username, key="loan_history")
-        loan_history_data = get_loan_history_data(page=page, mb=mb)
-        # Ensure all `docs` are `dicts`, as some are `Edition`s.
-        loan_history_data["docs"] = [loan.dict() if not isinstance(loan, dict) else loan for loan in loan_history_data["docs"]]
         web.header("Content-Type", "application/json")
-
-        return delegate.RawText(json.dumps({"loans_history": loan_history_data}))
+        return delegate.RawText(json.dumps(get_account_loan_history_json(user, page)))
 
 
 class account_waitlist(delegate.page):

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -1228,43 +1228,16 @@ class my_follows(delegate.page):
         return mb.render(header_title=_(key.capitalize()), template=template)
 
 
-def get_account_loans_page(user):
-    from openlibrary.core.lending import get_loans_of_user
-
-    user.update_loan_status()
-    username = user["key"].split("/")[-1]
-    mb = MyBooksTemplate(username, "loans")
-    docs = get_loans_of_user(user.key)
-    template = render["account/loans"](user, docs)
-    return mb.render(header_title=_("Loans"), template=template)
-
-
 def get_account_loans_json(user) -> dict[str, Any]:
     user.update_loan_status()
     loans = borrow.get_loans(user)
     return {"loans": loans}
 
 
-def _get_account_loan_history_context(user, page: int):
+def get_account_loan_history_data(user, page: int) -> dict[str, Any]:
     username = user["key"].split("/")[-1]
     mb = MyBooksTemplate(username, key="loan_history")
-    return mb, get_loan_history_data(page=page, mb=mb)
-
-
-def get_account_loan_history_data(user, page: int) -> dict[str, Any]:
-    _, loan_history_data = _get_account_loan_history_context(user, page)
-    return loan_history_data
-
-
-def get_account_loan_history_page(user, page: int):
-    mb, loan_history_data = _get_account_loan_history_context(user, page)
-    template = render["account/loan_history"](
-        docs=loan_history_data["docs"],
-        current_page=page,
-        show_next=loan_history_data["show_next"],
-        ia_base_url=CONFIG_IA_DOMAIN,
-    )
-    return mb.render(header_title=_("Loan History"), template=template)
+    return get_loan_history_data(page=page, mb=mb)
 
 
 def get_account_loan_history_json(user, page: int) -> dict[str, Any]:
@@ -1274,14 +1247,20 @@ def get_account_loan_history_json(user, page: int) -> dict[str, Any]:
     return {"loans_history": loan_history_data}
 
 
-@deprecated("migrated to fastapi")
 class account_loans(delegate.page):
     path = "/account/loans"
 
     @require_login
     def GET(self):
+        from openlibrary.core.lending import get_loans_of_user
+
         user = accounts.get_current_user()
-        return get_account_loans_page(user)
+        user.update_loan_status()
+        username = user["key"].split("/")[-1]
+        mb = MyBooksTemplate(username, "loans")
+        docs = get_loans_of_user(user.key)
+        template = render["account/loans"](user, docs)
+        return mb.render(header_title=_("Loans"), template=template)
 
 
 @deprecated("migrated to fastapi")
@@ -1296,7 +1275,6 @@ class account_loans_json(delegate.page):
         return delegate.RawText(json.dumps(get_account_loans_json(user)))
 
 
-@deprecated("migrated to fastapi")
 class account_loan_history(delegate.page):
     path = "/account/loan-history"
 
@@ -1305,7 +1283,16 @@ class account_loan_history(delegate.page):
         i = web.input(page=1)
         page = int(i.page)
         user = accounts.get_current_user()
-        return get_account_loan_history_page(user, page)
+        username = user["key"].split("/")[-1]
+        mb = MyBooksTemplate(username, key="loan_history")
+        loan_history_data = get_loan_history_data(page=page, mb=mb)
+        template = render["account/loan_history"](
+            docs=loan_history_data["docs"],
+            current_page=page,
+            show_next=loan_history_data["show_next"],
+            ia_base_url=CONFIG_IA_DOMAIN,
+        )
+        return mb.render(header_title=_("Loan History"), template=template)
 
 
 @deprecated("migrated to fastapi")

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -1234,14 +1234,10 @@ def get_account_loans_json(user) -> dict[str, Any]:
     return {"loans": loans}
 
 
-def get_account_loan_history_data(user, page: int) -> dict[str, Any]:
+def get_account_loan_history_json(user, page: int) -> dict[str, Any]:
     username = user["key"].split("/")[-1]
     mb = MyBooksTemplate(username, key="loan_history")
-    return get_loan_history_data(page=page, mb=mb)
-
-
-def get_account_loan_history_json(user, page: int) -> dict[str, Any]:
-    loan_history_data = dict(get_account_loan_history_data(user, page))
+    loan_history_data = dict(get_loan_history_data(page=page, mb=mb))
     # Ensure all `docs` are `dicts`, as some are `Edition`s.
     loan_history_data["docs"] = [loan.dict() if not isinstance(loan, dict) else loan for loan in loan_history_data["docs"]]
     return {"loans_history": loan_history_data}

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import csv
 import io
 import json
@@ -55,7 +53,6 @@ from openlibrary.plugins.upstream import borrow, forms
 from openlibrary.plugins.upstream.mybooks import MyBooksTemplate
 from openlibrary.plugins.upstream.utils import is_safe_redirect
 from openlibrary.utils.dateutil import elapsed_time
-from openlibrary.utils.request_context import site
 
 if TYPE_CHECKING:
     from openlibrary.core.models import SubjectType
@@ -1231,13 +1228,13 @@ class my_follows(delegate.page):
         return mb.render(header_title=_(key.capitalize()), template=template)
 
 
-def get_account_loans_json(user: User) -> dict[str, Any]:
+def get_account_loans_json(user) -> dict[str, Any]:
     user.update_loan_status()
     loans = borrow.get_loans(user)
     return {"loans": loans}
 
 
-def get_account_loan_history_json(user: User, page: int) -> dict[str, Any]:
+def get_account_loan_history_json(user, page: int) -> dict[str, Any]:
     username = user["key"].split("/")[-1]
     mb = MyBooksTemplate(username, key="loan_history")
     loan_history_data = dict(get_loan_history_data(page=page, mb=mb))
@@ -1465,7 +1462,7 @@ def get_loan_history_data(page: int, mb: MyBooksTemplate) -> dict[str, Any]:
     """
     if not (account := OpenLibraryAccount.get_by_username(mb.username)):
         raise render.notfound("Account for not found for %s" % mb.username, create=False)
-    s3_keys = site.get().store.get(account._key).get("s3_keys")
+    s3_keys = web.ctx.site.store.get(account._key).get("s3_keys")
     limit = RESULTS_PER_PAGE
     offset = page * limit - limit
     loan_history = s3_loan_api(

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -31,7 +31,7 @@ from openlibrary.core import (
 )
 from openlibrary.i18n import gettext as _
 from openlibrary.utils import dateutil
-from openlibrary.utils.request_context import req_context
+from openlibrary.utils.request_context import req_context, site
 
 logger = logging.getLogger("openlibrary.borrow")
 
@@ -81,10 +81,10 @@ class checkout_with_ocaid(delegate.page):
         """
         i = web.input()
         params = urllib.parse.urlencode(i)
-        ia_edition = web.ctx.site.get("/books/ia:%s" % ocaid)
+        ia_edition = site.get().get("/books/ia:%s" % ocaid)
         if not ia_edition:
             raise web.notfound()
-        edition = web.ctx.site.get(ia_edition.location)
+        edition = site.get().get(ia_edition.location)
         url = "%s/x/borrow" % edition.key
         raise web.seeother(url + "?" + params)
 
@@ -93,7 +93,7 @@ class checkout_with_ocaid(delegate.page):
         then forwards a borrow request to the canonical borrow
         endpoint with this OL identifier.
         """
-        ia_edition = web.ctx.site.get("/books/ia:%s" % ocaid)
+        ia_edition = site.get().get("/books/ia:%s" % ocaid)
         if not ia_edition:
             raise web.notfound()
         borrow().POST(ia_edition.location)
@@ -118,7 +118,7 @@ class borrow(delegate.page):
         )
 
         action = i.action
-        edition = web.ctx.site.get(key)
+        edition = site.get().get(key)
         if not edition:
             raise web.notfound()
 
@@ -175,7 +175,7 @@ class borrow(delegate.page):
         if user:
             account = OpenLibraryAccount.get_by_email(user.email)
             ia_itemname = account.itemname if account else None
-            s3_keys = web.ctx.site.store.get(account._key).get("s3_keys")
+            s3_keys = site.get().store.get(account._key).get("s3_keys")
             lending.get_cached_loans_of_user.memcache_delete(user.key, {})  # invalidate cache for user loans
         if not user or not ia_itemname or not s3_keys:
             web.setcookie(config.login_cookie_name, "", expires=-1)
@@ -264,7 +264,7 @@ class borrow_status(delegate.page):
 
         i = web.input(callback=None)
 
-        edition = web.ctx.site.get(key)
+        edition = site.get().get(key)
 
         if not edition:
             raise web.notfound()
@@ -310,8 +310,8 @@ def get_borrow_status(itemid):
     loan = lending.get_loan(itemid)
     has_loan = bool(loan)
 
-    edition_keys = web.ctx.site.things({"type": "/type/edition", "ocaid": itemid})
-    editions = web.ctx.site.get_many(edition_keys)
+    edition_keys = site.get().things({"type": "/type/edition", "ocaid": itemid})
+    editions = site.get().get_many(edition_keys)
     has_waitinglist = editions and any(e.get_waitinglist_size() > 0 for e in editions)
 
     return web.storage(
@@ -352,8 +352,8 @@ def get_all_store_values(**query) -> list:
     got_all = False
 
     while not got_all:
-        # new_values = web.ctx.site.store.values(**query)
-        new_items = web.ctx.site.store.items(**query)
+        # new_values = site.get().store.values(**query)
+        new_items = site.get().store.items(**query)
         for new_item in new_items:
             new_item[1].update({"store_key": new_item[0]})
             # XXX-Anand: Handling the existing loans
@@ -385,7 +385,7 @@ def get_edition_loans(edition):
 def get_loan_key(resource_id: str):
     """Get the key for the loan associated with the resource_id"""
     # Find loan in OL
-    loan_keys = web.ctx.site.store.query("/type/loan", "resource_id", resource_id)
+    loan_keys = site.get().store.query("/type/loan", "resource_id", resource_id)
     if not loan_keys:
         # No local records
         return None
@@ -410,7 +410,7 @@ def is_loaned_out(resource_id: str) -> bool | None:
         return lending.is_loaned_out_on_ia(identifier)
 
     # Find the loan and check if it has expired
-    loan = web.ctx.site.store.get(loan_key)
+    loan = site.get().store.get(loan_key)
     return bool(loan and datetime_from_isoformat(loan["expiry"]) < datetime.utcnow())
 
 
@@ -452,7 +452,7 @@ def is_users_turn_to_borrow(user, edition) -> bool:
 def is_admin() -> bool:
     """Returns True if the current user is in admin usergroup."""
     user = accounts.get_current_user()
-    return user is not None and user.key in [m.key for m in web.ctx.site.get("/usergroup/admin").members]
+    return user is not None and user.key in [m.key for m in site.get().get("/usergroup/admin").members]
 
 
 def return_resource(resource_id):
@@ -462,14 +462,14 @@ def return_resource(resource_id):
     if not loan_key:
         raise Exception("Asked to return %s but no loan recorded" % resource_id)
 
-    loan = web.ctx.site.store.get(loan_key)
+    loan = site.get().store.get(loan_key)
 
     delete_loan(loan_key, loan)
 
 
 def delete_loan(loan_key, loan=None) -> None:
     if not loan:
-        loan = web.ctx.site.store.get(loan_key)
+        loan = site.get().store.get(loan_key)
         if not loan:
             raise Exception("Could not find store record for %s", loan_key)
 

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -32,7 +32,6 @@ from openlibrary.plugins.upstream.utils import is_safe_redirect
 from openlibrary.plugins.worksearch.schemes.works import get_fulltext_min
 from openlibrary.utils import dateutil, extract_numeric_id_from_olid
 from openlibrary.utils.dateutil import current_year
-from openlibrary.utils.request_context import site
 
 if TYPE_CHECKING:
     from web.template import TemplateResult
@@ -77,7 +76,7 @@ class mybooks_home(delegate.page):
             # TODO: should do in one web.ctx.get_many fetch
             for loan in myloans:
                 # Book will be None if no OL edition exists for the book
-                if book := site.get().get(loan["book"]):
+                if book := web.ctx.site.get(loan["book"]):
                     book.loan = loan
                     loans.docs.append(book)
             docs["loans"] = loans
@@ -165,7 +164,7 @@ class readinglog_stats(delegate.page):
     path = "/people/([^/]+)/books/(want-to-read|currently-reading|already-read|stopped-reading)(/year/\\d{4})?/stats"
 
     def GET(self, username, key="want-to-read", year=None):
-        user = site.get().get("/people/%s" % username)
+        user = web.ctx.site.get("/people/%s" % username)
         if not user:
             return render.notfound("User %s" % username, create=False)
 
@@ -202,7 +201,7 @@ class readinglog_stats(delegate.page):
                 "name": a.name,
                 "birth_date": a.get("birth_date"),
             }
-            for a in site.get().get_many(list(author_keys))
+            for a in web.ctx.site.get_many(list(author_keys))
         ]
         return render["account/readinglog_stats"](
             works_json,
@@ -330,7 +329,7 @@ class public_my_books_json(delegate.page):
         page = safeint(i.page, 1)
         limit = safeint(i.limit, 100)
         # check if user's reading log is public
-        user = site.get().get("/people/%s" % username)
+        user = web.ctx.site.get("/people/%s" % username)
         if not user:
             return delegate.RawText(
                 json.dumps({"error": "User %s not found" % username}),
@@ -425,7 +424,7 @@ class MyBooksTemplate:
     def __init__(self, username: str, key: str) -> None:
         """The following is data required by every My Books sub-template (e.g. sidebar)"""
         self.username = username
-        self.user = site.get().get("/people/%s" % self.username)
+        self.user = web.ctx.site.get("/people/%s" % self.username)
 
         if not self.user:
             raise web.notfound("User %s" % self.username)
@@ -624,7 +623,7 @@ class PatronBooknotes:
             entry["work"] = self._get_work(entry["work_key"])
             entry["work_details"] = self._get_work_details(entry["work"])
             entry["notes"] = {i["edition_id"]: i["notes"] for i in entry["notes"]}
-            entry["editions"] = {k: site.get().get(f"/books/OL{k}M") for k in entry["notes"] if k != Booknotes.NULL_EDITION_VALUE}
+            entry["editions"] = {k: web.ctx.site.get(f"/books/OL{k}M") for k in entry["notes"] if k != Booknotes.NULL_EDITION_VALUE}
         return notes
 
     def get_observations(self, limit: int = RESULTS_PER_PAGE, page: int = 1) -> list:
@@ -641,7 +640,7 @@ class PatronBooknotes:
         return observations
 
     def _get_work(self, work_key: str) -> Work | None:
-        return site.get().get(work_key)
+        return web.ctx.site.get(work_key)
 
     def _get_work_details(self, work: Work) -> dict[str, list[str] | str | int | None]:
         author_keys = [a.author.key for a in work.get("authors", [])]
@@ -649,7 +648,7 @@ class PatronBooknotes:
         return {
             "cover_url": (work.get_cover_url("S") or "https://openlibrary.org/static/images/icons/avatar_book-sm.png"),
             "title": work.get("title"),
-            "authors": [a.name for a in site.get().get_many(author_keys)],
+            "authors": [a.name for a in web.ctx.site.get_many(author_keys)],
             "first_publish_year": work.first_publish_year or None,
         }
 

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -32,6 +32,7 @@ from openlibrary.plugins.upstream.utils import is_safe_redirect
 from openlibrary.plugins.worksearch.schemes.works import get_fulltext_min
 from openlibrary.utils import dateutil, extract_numeric_id_from_olid
 from openlibrary.utils.dateutil import current_year
+from openlibrary.utils.request_context import site
 
 if TYPE_CHECKING:
     from web.template import TemplateResult
@@ -76,7 +77,7 @@ class mybooks_home(delegate.page):
             # TODO: should do in one web.ctx.get_many fetch
             for loan in myloans:
                 # Book will be None if no OL edition exists for the book
-                if book := web.ctx.site.get(loan["book"]):
+                if book := site.get().get(loan["book"]):
                     book.loan = loan
                     loans.docs.append(book)
             docs["loans"] = loans
@@ -164,7 +165,7 @@ class readinglog_stats(delegate.page):
     path = "/people/([^/]+)/books/(want-to-read|currently-reading|already-read|stopped-reading)(/year/\\d{4})?/stats"
 
     def GET(self, username, key="want-to-read", year=None):
-        user = web.ctx.site.get("/people/%s" % username)
+        user = site.get().get("/people/%s" % username)
         if not user:
             return render.notfound("User %s" % username, create=False)
 
@@ -201,7 +202,7 @@ class readinglog_stats(delegate.page):
                 "name": a.name,
                 "birth_date": a.get("birth_date"),
             }
-            for a in web.ctx.site.get_many(list(author_keys))
+            for a in site.get().get_many(list(author_keys))
         ]
         return render["account/readinglog_stats"](
             works_json,
@@ -329,7 +330,7 @@ class public_my_books_json(delegate.page):
         page = safeint(i.page, 1)
         limit = safeint(i.limit, 100)
         # check if user's reading log is public
-        user = web.ctx.site.get("/people/%s" % username)
+        user = site.get().get("/people/%s" % username)
         if not user:
             return delegate.RawText(
                 json.dumps({"error": "User %s not found" % username}),
@@ -424,7 +425,7 @@ class MyBooksTemplate:
     def __init__(self, username: str, key: str) -> None:
         """The following is data required by every My Books sub-template (e.g. sidebar)"""
         self.username = username
-        self.user = web.ctx.site.get("/people/%s" % self.username)
+        self.user = site.get().get("/people/%s" % self.username)
 
         if not self.user:
             raise web.notfound("User %s" % self.username)
@@ -623,7 +624,7 @@ class PatronBooknotes:
             entry["work"] = self._get_work(entry["work_key"])
             entry["work_details"] = self._get_work_details(entry["work"])
             entry["notes"] = {i["edition_id"]: i["notes"] for i in entry["notes"]}
-            entry["editions"] = {k: web.ctx.site.get(f"/books/OL{k}M") for k in entry["notes"] if k != Booknotes.NULL_EDITION_VALUE}
+            entry["editions"] = {k: site.get().get(f"/books/OL{k}M") for k in entry["notes"] if k != Booknotes.NULL_EDITION_VALUE}
         return notes
 
     def get_observations(self, limit: int = RESULTS_PER_PAGE, page: int = 1) -> list:
@@ -640,7 +641,7 @@ class PatronBooknotes:
         return observations
 
     def _get_work(self, work_key: str) -> Work | None:
-        return web.ctx.site.get(work_key)
+        return site.get().get(work_key)
 
     def _get_work_details(self, work: Work) -> dict[str, list[str] | str | int | None]:
         author_keys = [a.author.key for a in work.get("authors", [])]
@@ -648,7 +649,7 @@ class PatronBooknotes:
         return {
             "cover_url": (work.get_cover_url("S") or "https://openlibrary.org/static/images/icons/avatar_book-sm.png"),
             "title": work.get("title"),
-            "authors": [a.name for a in web.ctx.site.get_many(author_keys)],
+            "authors": [a.name for a in site.get().get_many(author_keys)],
             "first_publish_year": work.first_publish_year or None,
         }
 

--- a/openlibrary/tests/accounts/test_models.py
+++ b/openlibrary/tests/accounts/test_models.py
@@ -36,8 +36,10 @@ def test_xauth_http_error_with_json(monkeypatch):
     assert xauth("create", s3_key="_", s3_secret="_") == {"error": "Unknown Parameter Blah"}
 
 
+@mock.patch("openlibrary.accounts.model.site")
 @mock.patch("openlibrary.accounts.model.web")
-def test_get(mock_web):
+def test_get(mock_web, mock_site):
+    mock_site.get.return_value = mock_web.ctx.site
     test = True
     email = "test@example.com"
     account = OpenLibraryAccount.get_by_email(email)

--- a/openlibrary/tests/accounts/test_models.py
+++ b/openlibrary/tests/accounts/test_models.py
@@ -36,10 +36,8 @@ def test_xauth_http_error_with_json(monkeypatch):
     assert xauth("create", s3_key="_", s3_secret="_") == {"error": "Unknown Parameter Blah"}
 
 
-@mock.patch("openlibrary.accounts.model.site")
 @mock.patch("openlibrary.accounts.model.web")
-def test_get(mock_web, mock_site):
-    mock_site.get.return_value = mock_web.ctx.site
+def test_get(mock_web):
     test = True
     email = "test@example.com"
     account = OpenLibraryAccount.get_by_email(email)

--- a/openlibrary/tests/core/test_models.py
+++ b/openlibrary/tests/core/test_models.py
@@ -3,6 +3,7 @@ import web
 
 from openlibrary.core import models
 from openlibrary.mocks import mock_infobase
+from openlibrary.utils.request_context import site as site_var
 
 
 class MockSite:
@@ -153,16 +154,20 @@ class TestWork:
         work3 = {"key": work3_key, "location": work4_key, "type": type_redir}
         work4 = {"key": work4_key, "type": type_work}
 
-        site = mock_infobase.MockSite()
-        site.save(web.storage(work1))
-        site.save(web.storage(work2))
-        site.save(web.storage(work3))
-        site.save(web.storage(work4))
-        monkeypatch.setattr(web.ctx, "site", site, raising=False)
+        mock_site = mock_infobase.MockSite()
+        mock_site.save(web.storage(work1))
+        mock_site.save(web.storage(work2))
+        mock_site.save(web.storage(work3))
+        mock_site.save(web.storage(work4))
+        monkeypatch.setattr(web.ctx, "site", mock_site, raising=False)
+        token = site_var.set(mock_site)
 
-        work_key = "/works/OL123W"
-        redirect_chain = models.Work.get_redirect_chain(work_key)
-        assert redirect_chain
-        resolved_work = redirect_chain[-1]
-        assert str(resolved_work.type) == type_work["key"], f"{resolved_work} of type {resolved_work.type} should be {type_work['key']}"
-        assert resolved_work.key == work4_key, f"Should be work4.key: {resolved_work}"
+        try:
+            work_key = "/works/OL123W"
+            redirect_chain = models.Work.get_redirect_chain(work_key)
+            assert redirect_chain
+            resolved_work = redirect_chain[-1]
+            assert str(resolved_work.type) == type_work["key"], f"{resolved_work} of type {resolved_work.type} should be {type_work['key']}"
+            assert resolved_work.key == work4_key, f"Should be work4.key: {resolved_work}"
+        finally:
+            site_var.reset(token)

--- a/openlibrary/tests/fastapi/test_account_loans.py
+++ b/openlibrary/tests/fastapi/test_account_loans.py
@@ -46,7 +46,7 @@ def _mock_legacy_context():
 class TestAccountLoansPages:
     def test_loans_page_renders_legacy_template(self, fastapi_client, mock_optional_authenticated_user):
         legacy_user = FakeLegacyUser()
-        template = web.storage(rawtext="<main>Loans page</main>")
+        template = web.storage(rawtext="<section>Loans page</section>")
 
         with (
             _mock_legacy_context(),
@@ -57,12 +57,12 @@ class TestAccountLoansPages:
 
         assert response.status_code == 200
         assert response.headers["content-type"].startswith("text/html")
-        assert response.text == "<main>Loans page</main>"
+        assert response.text == "<section>Loans page</section>"
         get_page.assert_called_once_with(legacy_user)
 
     def test_loan_history_page_forwards_page_query(self, fastapi_client, mock_optional_authenticated_user):
         legacy_user = FakeLegacyUser()
-        template = web.storage(rawtext="<main>Loan history page</main>")
+        template = web.storage(rawtext="<section>Loan history page</section>")
 
         with (
             _mock_legacy_context(),
@@ -72,7 +72,7 @@ class TestAccountLoansPages:
             response = fastapi_client.get("/account/loan-history?page=3")
 
         assert response.status_code == 200
-        assert response.text == "<main>Loan history page</main>"
+        assert response.text == "<section>Loan history page</section>"
         get_page.assert_called_once_with(legacy_user, 3)
 
     @pytest.mark.parametrize(

--- a/openlibrary/tests/fastapi/test_account_loans.py
+++ b/openlibrary/tests/fastapi/test_account_loans.py
@@ -137,6 +137,27 @@ class TestAccountLoansJson:
 
         assert response.status_code == 422
 
+    @pytest.mark.parametrize(
+        ("endpoint", "helper_path"),
+        [
+            ("/account/loans.json", "openlibrary.fastapi.account.legacy_account.get_account_loans_json"),
+            ("/account/loan-history.json", "openlibrary.fastapi.account.legacy_account.get_account_loan_history_json"),
+        ],
+    )
+    def test_local_dev_returns_503_with_helpful_message(self, fastapi_client, mock_authenticated_user, endpoint, helper_path, monkeypatch):
+        monkeypatch.setenv("LOCAL_DEV", "true")
+        legacy_user = FakeLegacyUser()
+
+        with (
+            _mock_legacy_context(),
+            patch("openlibrary.fastapi.account.accounts.get_current_user", return_value=legacy_user),
+            patch(helper_path, side_effect=ConnectionError("Unable to reach archive.org")),
+        ):
+            response = fastapi_client.get(endpoint)
+
+        assert response.status_code == 503
+        assert "production Internet Archive" in response.json()["detail"]
+
     def test_legacy_and_fastapi_loans_json_match_shared_helper_response(self, fastapi_client, mock_authenticated_user, monkeypatch):
         legacy_user = FakeLegacyUser()
         expected = {"loans": [{"book": "/books/OL1M", "ocaid": "test_ocaid"}]}

--- a/openlibrary/tests/fastapi/test_account_loans.py
+++ b/openlibrary/tests/fastapi/test_account_loans.py
@@ -1,0 +1,224 @@
+"""Tests for the FastAPI account loan endpoints."""
+
+import json
+from contextlib import nullcontext
+from unittest.mock import Mock, patch
+
+import pytest
+import web
+from starlette.requests import Request
+
+from infogami.utils.context import context as legacy_context
+from openlibrary.fastapi.auth import AuthenticatedUser, get_authenticated_user
+from openlibrary.plugins.upstream import account as legacy_account
+from openlibrary.utils import request_context
+
+
+class FakeLegacyUser(dict):
+    def __init__(self, username: str = "testuser"):
+        key = f"/people/{username}"
+        super().__init__(key=key)
+        self.key = key
+        self.update_loan_status = Mock()
+
+
+class FakeEdition:
+    def dict(self) -> dict:
+        return {"key": "/books/OL1M", "title": "Serialized Edition"}
+
+
+@pytest.fixture
+def mock_optional_authenticated_user(fastapi_client):
+    fake_user = AuthenticatedUser(
+        username="testuser",
+        user_key="/people/testuser",
+        timestamp="2026-01-01T00:00:00",
+    )
+    fastapi_client.app.dependency_overrides[get_authenticated_user] = lambda: fake_user
+    yield fake_user
+    fastapi_client.app.dependency_overrides.clear()
+
+
+def _mock_legacy_context():
+    return patch("openlibrary.fastapi.account.legacy_web_ctx_from_fastapi", return_value=nullcontext())
+
+
+class TestAccountLoansPages:
+    def test_loans_page_renders_legacy_template(self, fastapi_client, mock_optional_authenticated_user):
+        legacy_user = FakeLegacyUser()
+        template = web.storage(rawtext="<main>Loans page</main>")
+
+        with (
+            _mock_legacy_context(),
+            patch("openlibrary.fastapi.account.accounts.get_current_user", return_value=legacy_user),
+            patch("openlibrary.fastapi.account.legacy_account.get_account_loans_page", return_value=template) as get_page,
+        ):
+            response = fastapi_client.get("/account/loans")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/html")
+        assert response.text == "<main>Loans page</main>"
+        get_page.assert_called_once_with(legacy_user)
+
+    def test_loan_history_page_forwards_page_query(self, fastapi_client, mock_optional_authenticated_user):
+        legacy_user = FakeLegacyUser()
+        template = web.storage(rawtext="<main>Loan history page</main>")
+
+        with (
+            _mock_legacy_context(),
+            patch("openlibrary.fastapi.account.accounts.get_current_user", return_value=legacy_user),
+            patch("openlibrary.fastapi.account.legacy_account.get_account_loan_history_page", return_value=template) as get_page,
+        ):
+            response = fastapi_client.get("/account/loan-history?page=3")
+
+        assert response.status_code == 200
+        assert response.text == "<main>Loan history page</main>"
+        get_page.assert_called_once_with(legacy_user, 3)
+
+    @pytest.mark.parametrize(
+        ("path", "location"),
+        [
+            ("/account/loans", "/account/login?redirect=%2Faccount%2Floans"),
+            ("/account/loan-history?page=2", "/account/login?redirect=%2Faccount%2Floan-history%3Fpage%3D2"),
+        ],
+    )
+    def test_html_pages_redirect_unauthenticated_users_to_login(self, fastapi_client, path, location):
+        response = fastapi_client.get(path, follow_redirects=False)
+
+        assert response.status_code == 303
+        assert response.headers["location"] == location
+
+    def test_loan_history_page_rejects_invalid_page(self, fastapi_client, mock_optional_authenticated_user):
+        response = fastapi_client.get("/account/loan-history?page=0")
+
+        assert response.status_code == 422
+
+    def test_legacy_context_bridge_populates_infogami_template_context(self):
+        legacy_user = FakeLegacyUser()
+        legacy_site = Mock(_conn=Mock())
+        legacy_site.get_user.return_value = legacy_user
+        original_legacy_context = legacy_context.copy()
+        legacy_context.clear()
+        legacy_context.previous_value = "kept"
+        request = Request(
+            {
+                "type": "http",
+                "method": "GET",
+                "scheme": "http",
+                "path": "/account/loans",
+                "query_string": b"rescue=true",
+                "headers": [(b"host", b"testserver")],
+                "client": ("127.0.0.1", 1234),
+                "server": ("testserver", 80),
+            }
+        )
+        request.state.lang = "en"
+        site_token = request_context.site.set(legacy_site)
+
+        try:
+            with request_context.legacy_web_ctx_from_fastapi(request):
+                assert web.ctx.path == "/account/loans"
+                assert web.ctx.render_once == {}
+                assert web.ctx.site == legacy_site
+                assert legacy_context.path == "/account/loans"
+                assert legacy_context.user == legacy_user
+                assert legacy_context.rescue_mode is True
+
+            assert legacy_context.previous_value == "kept"
+            assert "path" not in legacy_context
+        finally:
+            request_context.site.reset(site_token)
+            legacy_context.clear()
+            legacy_context.update(original_legacy_context)
+
+
+class TestAccountLoansJson:
+    @pytest.mark.parametrize("path", ["/account/loans.json", "/account/loan-history.json"])
+    def test_json_endpoints_return_401_when_unauthenticated(self, fastapi_client, path):
+        response = fastapi_client.get(path)
+
+        assert response.status_code == 401
+
+    def test_loans_json_updates_loan_status_and_returns_loans(self, fastapi_client, mock_authenticated_user):
+        legacy_user = FakeLegacyUser()
+        loans = [{"book": "/books/OL1M", "ocaid": "test_ocaid"}]
+
+        with (
+            _mock_legacy_context(),
+            patch("openlibrary.fastapi.account.accounts.get_current_user", return_value=legacy_user),
+            patch("openlibrary.plugins.upstream.account.borrow.get_loans", return_value=loans) as get_loans,
+        ):
+            response = fastapi_client.get("/account/loans.json")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "application/json"
+        assert response.json() == {"loans": loans}
+        legacy_user.update_loan_status.assert_called_once_with()
+        get_loans.assert_called_once_with(legacy_user)
+
+    @pytest.mark.parametrize(
+        ("path", "page"),
+        [
+            ("/account/loan-history.json", 1),
+            ("/account/loan-history.json?page=2", 2),
+        ],
+    )
+    def test_loan_history_json_serializes_docs_and_forwards_page(self, fastapi_client, mock_authenticated_user, path, page):
+        legacy_user = FakeLegacyUser()
+        loan_history_data = {
+            "docs": [{"key": "/books/OL2M", "title": "Raw dict"}, FakeEdition()],
+            "show_next": True,
+            "limit": 25,
+            "page": page,
+        }
+
+        with (
+            _mock_legacy_context(),
+            patch("openlibrary.fastapi.account.accounts.get_current_user", return_value=legacy_user),
+            patch("openlibrary.plugins.upstream.account.get_account_loan_history_data", return_value=loan_history_data) as get_data,
+        ):
+            response = fastapi_client.get(path)
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "loans_history": {
+                "docs": [
+                    {"key": "/books/OL2M", "title": "Raw dict"},
+                    {"key": "/books/OL1M", "title": "Serialized Edition"},
+                ],
+                "show_next": True,
+                "limit": 25,
+                "page": page,
+            }
+        }
+        get_data.assert_called_once_with(legacy_user, page)
+
+    def test_loan_history_json_rejects_invalid_page(self, fastapi_client, mock_authenticated_user):
+        response = fastapi_client.get("/account/loan-history.json?page=0")
+
+        assert response.status_code == 422
+
+    def test_legacy_and_fastapi_loans_json_match_shared_helper_response(self, fastapi_client, mock_authenticated_user, monkeypatch):
+        legacy_user = FakeLegacyUser()
+        expected = {"loans": [{"book": "/books/OL1M", "ocaid": "test_ocaid"}]}
+        site = Mock()
+        site.get_user.return_value = legacy_user
+        web.ctx.headers = []
+        monkeypatch.setattr(web.ctx, "site", site, raising=False)
+
+        with (
+            patch("openlibrary.plugins.upstream.account.accounts.get_current_user", return_value=legacy_user),
+            patch("openlibrary.plugins.upstream.account.get_account_loans_json", return_value=expected),
+            pytest.deprecated_call(match="migrated to fastapi"),
+        ):
+            legacy_response = legacy_account.account_loans_json().GET()
+
+        with (
+            _mock_legacy_context(),
+            patch("openlibrary.fastapi.account.accounts.get_current_user", return_value=legacy_user),
+            patch("openlibrary.fastapi.account.legacy_account.get_account_loans_json", return_value=expected),
+        ):
+            fastapi_response = fastapi_client.get("/account/loans.json")
+
+        assert fastapi_response.status_code == 200
+        assert fastapi_response.json() == json.loads(legacy_response.rawtext)

--- a/openlibrary/tests/fastapi/test_account_loans.py
+++ b/openlibrary/tests/fastapi/test_account_loans.py
@@ -9,7 +9,6 @@ import web
 from starlette.requests import Request
 
 from infogami.utils.context import context as legacy_context
-from openlibrary.fastapi.auth import AuthenticatedUser, get_authenticated_user
 from openlibrary.plugins.upstream import account as legacy_account
 from openlibrary.utils import request_context
 
@@ -27,72 +26,11 @@ class FakeEdition:
         return {"key": "/books/OL1M", "title": "Serialized Edition"}
 
 
-@pytest.fixture
-def mock_optional_authenticated_user(fastapi_client):
-    fake_user = AuthenticatedUser(
-        username="testuser",
-        user_key="/people/testuser",
-        timestamp="2026-01-01T00:00:00",
-    )
-    fastapi_client.app.dependency_overrides[get_authenticated_user] = lambda: fake_user
-    yield fake_user
-    fastapi_client.app.dependency_overrides.clear()
-
-
 def _mock_legacy_context():
     return patch("openlibrary.fastapi.account.legacy_web_ctx_from_fastapi", return_value=nullcontext())
 
 
-class TestAccountLoansPages:
-    def test_loans_page_renders_legacy_template(self, fastapi_client, mock_optional_authenticated_user):
-        legacy_user = FakeLegacyUser()
-        template = web.storage(rawtext="<section>Loans page</section>")
-
-        with (
-            _mock_legacy_context(),
-            patch("openlibrary.fastapi.account.accounts.get_current_user", return_value=legacy_user),
-            patch("openlibrary.fastapi.account.legacy_account.get_account_loans_page", return_value=template) as get_page,
-        ):
-            response = fastapi_client.get("/account/loans")
-
-        assert response.status_code == 200
-        assert response.headers["content-type"].startswith("text/html")
-        assert response.text == "<section>Loans page</section>"
-        get_page.assert_called_once_with(legacy_user)
-
-    def test_loan_history_page_forwards_page_query(self, fastapi_client, mock_optional_authenticated_user):
-        legacy_user = FakeLegacyUser()
-        template = web.storage(rawtext="<section>Loan history page</section>")
-
-        with (
-            _mock_legacy_context(),
-            patch("openlibrary.fastapi.account.accounts.get_current_user", return_value=legacy_user),
-            patch("openlibrary.fastapi.account.legacy_account.get_account_loan_history_page", return_value=template) as get_page,
-        ):
-            response = fastapi_client.get("/account/loan-history?page=3")
-
-        assert response.status_code == 200
-        assert response.text == "<section>Loan history page</section>"
-        get_page.assert_called_once_with(legacy_user, 3)
-
-    @pytest.mark.parametrize(
-        ("path", "location"),
-        [
-            ("/account/loans", "/account/login?redirect=%2Faccount%2Floans"),
-            ("/account/loan-history?page=2", "/account/login?redirect=%2Faccount%2Floan-history%3Fpage%3D2"),
-        ],
-    )
-    def test_html_pages_redirect_unauthenticated_users_to_login(self, fastapi_client, path, location):
-        response = fastapi_client.get(path, follow_redirects=False)
-
-        assert response.status_code == 303
-        assert response.headers["location"] == location
-
-    def test_loan_history_page_rejects_invalid_page(self, fastapi_client, mock_optional_authenticated_user):
-        response = fastapi_client.get("/account/loan-history?page=0")
-
-        assert response.status_code == 422
-
+class TestLegacyContextBridge:
     def test_legacy_context_bridge_populates_infogami_template_context(self):
         legacy_user = FakeLegacyUser()
         legacy_site = Mock(_conn=Mock())
@@ -105,7 +43,7 @@ class TestAccountLoansPages:
                 "type": "http",
                 "method": "GET",
                 "scheme": "http",
-                "path": "/account/loans",
+                "path": "/account/loans.json",
                 "query_string": b"rescue=true",
                 "headers": [(b"host", b"testserver")],
                 "client": ("127.0.0.1", 1234),
@@ -117,10 +55,11 @@ class TestAccountLoansPages:
 
         try:
             with request_context.legacy_web_ctx_from_fastapi(request):
-                assert web.ctx.path == "/account/loans"
+                assert web.ctx.path == "/account/loans.json"
+                assert web.ctx.encoding == "json"
                 assert web.ctx.render_once == {}
                 assert web.ctx.site == legacy_site
-                assert legacy_context.path == "/account/loans"
+                assert legacy_context.path == "/account/loans.json"
                 assert legacy_context.user == legacy_user
                 assert legacy_context.rescue_mode is True
 

--- a/openlibrary/tests/fastapi/test_account_loans.py
+++ b/openlibrary/tests/fastapi/test_account_loans.py
@@ -2,7 +2,7 @@
 
 import json
 from contextlib import nullcontext
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 import web
@@ -114,7 +114,8 @@ class TestAccountLoansJson:
         with (
             _mock_legacy_context(),
             patch("openlibrary.fastapi.account.accounts.get_current_user", return_value=legacy_user),
-            patch("openlibrary.plugins.upstream.account.get_account_loan_history_data", return_value=loan_history_data) as get_data,
+            patch("openlibrary.plugins.upstream.account.MyBooksTemplate", return_value=MagicMock()),
+            patch("openlibrary.plugins.upstream.account.get_loan_history_data", return_value=loan_history_data) as get_data,
         ):
             response = fastapi_client.get(path)
 
@@ -130,7 +131,8 @@ class TestAccountLoansJson:
                 "page": page,
             }
         }
-        get_data.assert_called_once_with(legacy_user, page)
+        assert get_data.called
+        assert get_data.call_args.kwargs["page"] == page
 
     def test_loan_history_json_rejects_invalid_page(self, fastapi_client, mock_authenticated_user):
         response = fastapi_client.get("/account/loan-history.json?page=0")

--- a/openlibrary/tests/fastapi/test_account_loans.py
+++ b/openlibrary/tests/fastapi/test_account_loans.py
@@ -1,6 +1,7 @@
 """Tests for the FastAPI account loan endpoints."""
 
 import json
+from contextlib import nullcontext
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -23,6 +24,10 @@ class FakeLegacyUser(dict):
 class FakeEdition:
     def dict(self) -> dict:
         return {"key": "/books/OL1M", "title": "Serialized Edition"}
+
+
+def _mock_legacy_context():
+    return patch("openlibrary.fastapi.account.legacy_web_ctx_from_fastapi", return_value=nullcontext())
 
 
 class TestLegacyContextBridge:
@@ -78,6 +83,7 @@ class TestAccountLoansJson:
         loans = [{"book": "/books/OL1M", "ocaid": "test_ocaid"}]
 
         with (
+            _mock_legacy_context(),
             patch("openlibrary.fastapi.account.accounts.get_current_user", return_value=legacy_user),
             patch("openlibrary.plugins.upstream.account.borrow.get_loans", return_value=loans) as get_loans,
         ):
@@ -106,6 +112,7 @@ class TestAccountLoansJson:
         }
 
         with (
+            _mock_legacy_context(),
             patch("openlibrary.fastapi.account.accounts.get_current_user", return_value=legacy_user),
             patch("openlibrary.plugins.upstream.account.MyBooksTemplate", return_value=MagicMock()),
             patch("openlibrary.plugins.upstream.account.get_loan_history_data", return_value=loan_history_data) as get_data,
@@ -144,6 +151,7 @@ class TestAccountLoansJson:
         legacy_user = FakeLegacyUser()
 
         with (
+            _mock_legacy_context(),
             patch("openlibrary.fastapi.account.accounts.get_current_user", return_value=legacy_user),
             patch(helper_path, side_effect=ConnectionError("Unable to reach archive.org")),
         ):
@@ -168,6 +176,7 @@ class TestAccountLoansJson:
             legacy_response = legacy_account.account_loans_json().GET()
 
         with (
+            _mock_legacy_context(),
             patch("openlibrary.fastapi.account.accounts.get_current_user", return_value=legacy_user),
             patch("openlibrary.fastapi.account.legacy_account.get_account_loans_json", return_value=expected),
         ):

--- a/openlibrary/tests/fastapi/test_account_loans.py
+++ b/openlibrary/tests/fastapi/test_account_loans.py
@@ -5,11 +5,8 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 import web
-from starlette.requests import Request
 
-from infogami.utils.context import context as legacy_context
 from openlibrary.plugins.upstream import account as legacy_account
-from openlibrary.utils import request_context
 
 
 class FakeLegacyUser(dict):
@@ -23,47 +20,6 @@ class FakeLegacyUser(dict):
 class FakeEdition:
     def dict(self) -> dict:
         return {"key": "/books/OL1M", "title": "Serialized Edition"}
-
-
-class TestLegacyContextBridge:
-    def test_legacy_context_bridge_populates_infogami_template_context(self):
-        legacy_user = FakeLegacyUser()
-        legacy_site = Mock(_conn=Mock())
-        legacy_site.get_user.return_value = legacy_user
-        original_legacy_context = legacy_context.copy()
-        legacy_context.clear()
-        legacy_context.previous_value = "kept"
-        request = Request(
-            {
-                "type": "http",
-                "method": "GET",
-                "scheme": "http",
-                "path": "/account/loans.json",
-                "query_string": b"rescue=true",
-                "headers": [(b"host", b"testserver")],
-                "client": ("127.0.0.1", 1234),
-                "server": ("testserver", 80),
-            }
-        )
-        request.state.lang = "en"
-        site_token = request_context.site.set(legacy_site)
-
-        try:
-            with request_context.legacy_web_ctx_from_fastapi(request):
-                assert web.ctx.path == "/account/loans.json"
-                assert web.ctx.encoding == "json"
-                assert web.ctx.render_once == {}
-                assert web.ctx.site == legacy_site
-                assert legacy_context.path == "/account/loans.json"
-                assert legacy_context.user == legacy_user
-                assert legacy_context.rescue_mode is True
-
-            assert legacy_context.previous_value == "kept"
-            assert "path" not in legacy_context
-        finally:
-            request_context.site.reset(site_token)
-            legacy_context.clear()
-            legacy_context.update(original_legacy_context)
 
 
 class TestAccountLoansJson:

--- a/openlibrary/tests/fastapi/test_account_loans.py
+++ b/openlibrary/tests/fastapi/test_account_loans.py
@@ -1,7 +1,6 @@
 """Tests for the FastAPI account loan endpoints."""
 
 import json
-from contextlib import nullcontext
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -24,10 +23,6 @@ class FakeLegacyUser(dict):
 class FakeEdition:
     def dict(self) -> dict:
         return {"key": "/books/OL1M", "title": "Serialized Edition"}
-
-
-def _mock_legacy_context():
-    return patch("openlibrary.fastapi.account.legacy_web_ctx_from_fastapi", return_value=nullcontext())
 
 
 class TestLegacyContextBridge:
@@ -83,7 +78,6 @@ class TestAccountLoansJson:
         loans = [{"book": "/books/OL1M", "ocaid": "test_ocaid"}]
 
         with (
-            _mock_legacy_context(),
             patch("openlibrary.fastapi.account.accounts.get_current_user", return_value=legacy_user),
             patch("openlibrary.plugins.upstream.account.borrow.get_loans", return_value=loans) as get_loans,
         ):
@@ -112,7 +106,6 @@ class TestAccountLoansJson:
         }
 
         with (
-            _mock_legacy_context(),
             patch("openlibrary.fastapi.account.accounts.get_current_user", return_value=legacy_user),
             patch("openlibrary.plugins.upstream.account.MyBooksTemplate", return_value=MagicMock()),
             patch("openlibrary.plugins.upstream.account.get_loan_history_data", return_value=loan_history_data) as get_data,
@@ -151,7 +144,6 @@ class TestAccountLoansJson:
         legacy_user = FakeLegacyUser()
 
         with (
-            _mock_legacy_context(),
             patch("openlibrary.fastapi.account.accounts.get_current_user", return_value=legacy_user),
             patch(helper_path, side_effect=ConnectionError("Unable to reach archive.org")),
         ):
@@ -176,7 +168,6 @@ class TestAccountLoansJson:
             legacy_response = legacy_account.account_loans_json().GET()
 
         with (
-            _mock_legacy_context(),
             patch("openlibrary.fastapi.account.accounts.get_current_user", return_value=legacy_user),
             patch("openlibrary.fastapi.account.legacy_account.get_account_loans_json", return_value=expected),
         ):

--- a/openlibrary/utils/request_context.py
+++ b/openlibrary/utils/request_context.py
@@ -14,6 +14,8 @@ from urllib.parse import unquote
 import web
 
 from infogami import config
+from infogami.utils import features
+from infogami.utils.context import context as legacy_context
 from infogami.utils.delegate import create_site
 
 if TYPE_CHECKING:
@@ -233,6 +235,104 @@ def set_context_from_fastapi(request: Request) -> None:
             is_bot=is_bot,
         )
     )
+
+
+def _fastapi_request_env(request: Request) -> web.storage:
+    env = web.storage(
+        REQUEST_METHOD=request.method,
+        PATH_INFO=request.url.path,
+        QUERY_STRING=request.url.query,
+        HTTP_HOST=request.url.netloc,
+    )
+
+    for key, value in request.headers.items():
+        header_key = "HTTP_" + key.upper().replace("-", "_")
+        if header_key not in {"HTTP_CONTENT_TYPE", "HTTP_CONTENT_LENGTH"}:
+            env[header_key] = value
+
+    if content_type := request.headers.get("content-type"):
+        env.CONTENT_TYPE = content_type
+    if content_length := request.headers.get("content-length"):
+        env.CONTENT_LENGTH = content_length
+
+    return env
+
+
+@contextmanager
+def legacy_web_ctx_from_fastapi(request: Request):
+    """
+    Temporarily populate the legacy ``web.ctx`` values needed by Templetor and
+    older model helpers while handling a FastAPI request.
+    """
+    current_site = site.get()
+    query = f"?{request.url.query}" if request.url.query else ""
+    env = _fastapi_request_env(request)
+    original_legacy_context = legacy_context.copy()
+    original = {
+        name: getattr(web.ctx, name, None)
+        for name in (
+            "conn",
+            "encoding",
+            "env",
+            "environ",
+            "features",
+            "fullpath",
+            "headers",
+            "home",
+            "homepath",
+            "host",
+            "ip",
+            "lang",
+            "method",
+            "path",
+            "protocol",
+            "query",
+            "render_once",
+            "site",
+            "status",
+        )
+    }
+    missing = {name for name in original if name not in web.ctx}
+
+    web.ctx.conn = current_site._conn
+    web.ctx.encoding = "json" if request.url.path.endswith(".json") else None
+    web.ctx.env = env
+    web.ctx.environ = env
+    web.ctx.fullpath = request.url.path + query
+    web.ctx.headers = []
+    web.ctx.home = f"{request.url.scheme}://{request.url.netloc}"
+    web.ctx.homepath = ""
+    web.ctx.host = request.url.netloc
+    web.ctx.ip = request.client.host if request.client else None
+    web.ctx.lang = getattr(request.state, "lang", None) or "en"
+    web.ctx.method = request.method
+    web.ctx.path = request.url.path
+    web.ctx.protocol = request.url.scheme
+    web.ctx.query = query
+    web.ctx.render_once = {}
+    web.ctx.site = current_site
+    web.ctx.status = "200 OK"
+
+    legacy_context.load()
+    legacy_context.error = None
+    legacy_context.stylesheets = []
+    legacy_context.javascripts = []
+    legacy_context.user = current_site.get_user()
+    legacy_context.site = config.site
+    legacy_context.path = web.ctx.path
+    legacy_context.rescue_mode = request.query_params.get("rescue", "false").lower() == "true"
+    features.loadhook()
+
+    try:
+        yield
+    finally:
+        legacy_context.clear()
+        legacy_context.update(original_legacy_context)
+        for name, value in original.items():
+            if name in missing:
+                web.ctx.pop(name, None)
+            else:
+                setattr(web.ctx, name, value)
 
 
 def create_context_for_script() -> RequestContextVars:

--- a/openlibrary/utils/request_context.py
+++ b/openlibrary/utils/request_context.py
@@ -14,8 +14,6 @@ from urllib.parse import unquote
 import web
 
 from infogami import config
-from infogami.utils import features
-from infogami.utils.context import context as legacy_context
 from infogami.utils.delegate import create_site
 
 if TYPE_CHECKING:
@@ -235,104 +233,6 @@ def set_context_from_fastapi(request: Request) -> None:
             is_bot=is_bot,
         )
     )
-
-
-def _fastapi_request_env(request: Request) -> web.storage:
-    env = web.storage(
-        REQUEST_METHOD=request.method,
-        PATH_INFO=request.url.path,
-        QUERY_STRING=request.url.query,
-        HTTP_HOST=request.url.netloc,
-    )
-
-    for key, value in request.headers.items():
-        header_key = "HTTP_" + key.upper().replace("-", "_")
-        if header_key not in {"HTTP_CONTENT_TYPE", "HTTP_CONTENT_LENGTH"}:
-            env[header_key] = value
-
-    if content_type := request.headers.get("content-type"):
-        env.CONTENT_TYPE = content_type
-    if content_length := request.headers.get("content-length"):
-        env.CONTENT_LENGTH = content_length
-
-    return env
-
-
-@contextmanager
-def legacy_web_ctx_from_fastapi(request: Request):
-    """
-    Temporarily populate the legacy ``web.ctx`` values needed by Templetor and
-    older model helpers while handling a FastAPI request.
-    """
-    current_site = site.get()
-    query = f"?{request.url.query}" if request.url.query else ""
-    env = _fastapi_request_env(request)
-    original_legacy_context = legacy_context.copy()
-    original = {
-        name: getattr(web.ctx, name, None)
-        for name in (
-            "conn",
-            "encoding",
-            "env",
-            "environ",
-            "features",
-            "fullpath",
-            "headers",
-            "home",
-            "homepath",
-            "host",
-            "ip",
-            "lang",
-            "method",
-            "path",
-            "protocol",
-            "query",
-            "render_once",
-            "site",
-            "status",
-        )
-    }
-    missing = {name for name in original if name not in web.ctx}
-
-    web.ctx.conn = current_site._conn
-    web.ctx.encoding = "json" if request.url.path.endswith(".json") else None
-    web.ctx.env = env
-    web.ctx.environ = env
-    web.ctx.fullpath = request.url.path + query
-    web.ctx.headers = []
-    web.ctx.home = f"{request.url.scheme}://{request.url.netloc}"
-    web.ctx.homepath = ""
-    web.ctx.host = request.url.netloc
-    web.ctx.ip = request.client.host if request.client else None
-    web.ctx.lang = getattr(request.state, "lang", None) or "en"
-    web.ctx.method = request.method
-    web.ctx.path = request.url.path
-    web.ctx.protocol = request.url.scheme
-    web.ctx.query = query
-    web.ctx.render_once = {}
-    web.ctx.site = current_site
-    web.ctx.status = "200 OK"
-
-    legacy_context.load()
-    legacy_context.error = None
-    legacy_context.stylesheets = []
-    legacy_context.javascripts = []
-    legacy_context.user = current_site.get_user()
-    legacy_context.site = config.site
-    legacy_context.path = web.ctx.path
-    legacy_context.rescue_mode = request.query_params.get("rescue", "false").lower() == "true"
-    features.loadhook()
-
-    try:
-        yield
-    finally:
-        legacy_context.clear()
-        legacy_context.update(original_legacy_context)
-        for name, value in original.items():
-            if name in missing:
-                web.ctx.pop(name, None)
-            else:
-                setattr(web.ctx, name, value)
 
 
 def create_context_for_script() -> RequestContextVars:


### PR DESCRIPTION
## Summary

Migrates the account loan and loan-history routes from legacy web.py routing to FastAPI while preserving existing My Books rendering and lending helper behavior.

Migrated endpoints:

- GET /account/loans.json
- GET /account/loan-history.json

### Testing
- Side-by-side checks confirmed `/account/loans.json` matches legacy behavior.
- Loan-history routes match the same local dev archive.org `user_borrow_history` 401 behavior on both legacy and FastAPI.

### Stakeholders
@RayBB 