### PR TITLE
Add process pool initializer to manage-imports script

### DIFF
--- a/scripts/manage-imports.py
+++ b/scripts/manage-imports.py
@@ -47,12 +47,7 @@ def ol_import_request(item, retries=5, servername=None, require_marc=True):
         except OLError as e:
             logger.warning(f"Failed to contact OL server. error={e!r}")
             if e.code < 500:
-                return e.text
-
-
-def _init_worker(configfile):
-    """Initialize each pool worker with the application config (required for spawn start method)."""
-    load_config(configfile)
+                return e.tex
 
 
 def do_import(item, servername=None, require_marc=True):
@@ -161,7 +156,7 @@ def import_all(args, **kwargs):
     configfile = kwargs.get("configfile")
 
     # Use multiprocessing to call do_import on each item
-    with multiprocessing.Pool(processes=8, initializer=_init_worker, initargs=(configfile,)) as pool:
+    with multiprocessing.Pool(processes=8, initializer=load_config, initargs=(configfile,)) as pool:
         while True:
             logger.info("find_pending START")
             items = ImportItem.find_pending()

--- a/scripts/manage-imports.py
+++ b/scripts/manage-imports.py
@@ -50,6 +50,11 @@ def ol_import_request(item, retries=5, servername=None, require_marc=True):
                 return e.text
 
 
+def _init_worker(configfile):
+    """Initialize each pool worker with the application config (required for spawn start method)."""
+    load_config(configfile)
+
+
 def do_import(item, servername=None, require_marc=True):
 
     logger.info(f"do_import START (pid:{os.getpid()})")
@@ -153,9 +158,10 @@ def import_all(args, **kwargs):
 
     servername = kwargs.get("servername")
     require_marc = False
+    configfile = kwargs.get("configfile")
 
     # Use multiprocessing to call do_import on each item
-    with multiprocessing.Pool(processes=8) as pool:
+    with multiprocessing.Pool(processes=8, initializer=_init_worker, initargs=(configfile,)) as pool:
         while True:
             logger.info("find_pending START")
             items = ImportItem.find_pending()
@@ -193,7 +199,7 @@ def main():
     from infogami import config
 
     cmd = sys.argv[1]
-    args, flags = [], {"servername": config.get("servername", "https://openlibrary.org")}
+    args, flags = [], {"servername": config.get("servername", "https://openlibrary.org"), "configfile": configfile}
     for i in sys.argv[2:]:
         if i.startswith("--"):
             flags[i[2:]] = True

--- a/scripts/manage-imports.py
+++ b/scripts/manage-imports.py
@@ -47,7 +47,7 @@ def ol_import_request(item, retries=5, servername=None, require_marc=True):
         except OLError as e:
             logger.warning(f"Failed to contact OL server. error={e!r}")
             if e.code < 500:
-                return e.tex
+                return e.text
 
 
 def do_import(item, servername=None, require_marc=True):


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes bug causing the `importbot` container to restart endlessly.

Prior to Python 14, the default `multiprocessing` start method in Linux environments was `fork`.  Now, `spawn` is the default.

`spawn` creates a new Python interpreter process, which does not inherit the parent process's `web.config`.  The `web.config` in spawned processes did not contain the necessary credentials for connecting to our DB, causing an unhandled error which stopped the container.

This code creates an initializer method which calls `load_config` when a new process is spawned.  Now, new processes contain the necessary credentials, and the container no longer restarts ceaselessly.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
