### PR TITLE
Add `Content-Type` header to import requests

### DIFF
--- a/openlibrary/api.py
+++ b/openlibrary/api.py
@@ -226,7 +226,8 @@ class OpenLibrary:
         }
         return self._request("/api/import/ia", method="POST", data=data).text
 
-    def import_data(self, data, headers=None):
+def import_data(self, data, headers=None):
+        headers = {"Content-Type": "application/json", **(headers or {})}
         return self._request("/api/import", method="POST", data=data, headers=headers).text
 
 

--- a/openlibrary/api.py
+++ b/openlibrary/api.py
@@ -226,8 +226,8 @@ class OpenLibrary:
         }
         return self._request("/api/import/ia", method="POST", data=data).text
 
-    def import_data(self, data):
-        return self._request("/api/import", method="POST", data=data).text
+    def import_data(self, data, headers=None):
+        return self._request("/api/import", method="POST", data=data, headers=headers).text
 
 
 def marshal(data):

--- a/openlibrary/api.py
+++ b/openlibrary/api.py
@@ -226,9 +226,10 @@ class OpenLibrary:
         }
         return self._request("/api/import/ia", method="POST", data=data).text
 
+
 def import_data(self, data, headers=None):
-        headers = {"Content-Type": "application/json", **(headers or {})}
-        return self._request("/api/import", method="POST", data=data, headers=headers).text
+    headers = {"Content-Type": "application/json", **(headers or {})}
+    return self._request("/api/import", method="POST", data=data, headers=headers).text
 
 
 def marshal(data):

--- a/scripts/manage-imports.py
+++ b/scripts/manage-imports.py
@@ -40,7 +40,7 @@ def ol_import_request(item, retries=5, servername=None, require_marc=True):
         try:
             ol = get_ol(servername=servername)
             if item.data:
-                return ol.import_data(item.data)
+                return ol.import_data(item.data, headers={"Content-Type": "application/json"})
             return ol.import_ocaid(item.ia_id, require_marc=require_marc)
         except OSError as e:
             logger.warning(f"Failed to contact OL server. error={e!r}")


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds `Content-Type` headers to `importbot` `/api/import` requests.  Our WAF has been dropping such requests due to missing headers.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
