### PR TITLE
i18n(hr): AI translation update — sync with messages.pot (2026-06-11)

### DIFF
--- a/openlibrary/i18n/hr/messages.po
+++ b/openlibrary/i18n/hr/messages.po
@@ -12,18 +12,15 @@ msgstr ""
 "POT-Creation-Date: 2026-04-28 18:58-0400\n"
 "PO-Revision-Date: 2026-05-15 16:20+0200\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
-"Language-Team: \n"
 "Language: hr\n"
+"Language-Team: \n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 "Generated-By: Babel 2.12.1\n"
-"X-Generator: Poedit 3.9\n"
 
-#: account.html account/notifications.html account/privacy.html
-#: lib/nav_head.html type/user/view.html
+#: account.html account/notifications.html account/privacy.html lib/nav_head.html type/user/view.html
 msgid "Settings"
 msgstr "Postavke"
 
@@ -39,10 +36,7 @@ msgstr "Pogledaj"
 msgid "or"
 msgstr "ili"
 
-#: account.html databarHistory.html databarTemplate.html databarView.html
-#: design/popover.html my_books/check_ins/check_in_prompt.html
-#: reading_goals/reading_goal_progress.html subjects.html
-#: type/edition/compact_title.html type/user/view.html
+#: account.html databarHistory.html databarTemplate.html databarView.html design/popover.html my_books/check_ins/check_in_prompt.html reading_goals/reading_goal_progress.html subjects.html type/edition/compact_title.html type/user/view.html
 msgid "Edit"
 msgstr "Uredi"
 
@@ -103,20 +97,12 @@ msgid "New Batch Import"
 msgstr "Novi skupni uvoz"
 
 #: batch_import.html
-msgid ""
-"Attach a JSONL formatted document with import records or copy/paste the "
-"JSONL text into the textarea."
-msgstr ""
-"Priloži dokument u JSONL formatu sa zapisima uvoza ili kopiraj/zalijepi "
-"JSONL tekst u područje teksta."
+msgid "Attach a JSONL formatted document with import records or copy/paste the JSONL text into the textarea."
+msgstr "Priloži dokument u JSONL formatu sa zapisima uvoza ili kopiraj/zalijepi JSONL tekst u područje teksta."
 
 #: batch_import.html
-msgid ""
-"See the <a href=\"https://github.com/internetarchive/openlibrary-client/tree/"
-"master/olclient/schemata\">olclient import schemata</a> for more."
-msgstr ""
-"Saznaj više o <a href=\"https://github.com/internetarchive/openlibrary-"
-"client/tree/master/olclient/schemata\">shemema uvoza olclient biblioteke</a>."
+msgid "See the <a href=\"https://github.com/internetarchive/openlibrary-client/tree/master/olclient/schemata\">olclient import schemata</a> for more."
+msgstr "Saznaj više o <a href=\"https://github.com/internetarchive/openlibrary-client/tree/master/olclient/schemata\">shemema uvoza olclient biblioteke</a>."
 
 #: batch_import.html
 msgid "Attach a file:"
@@ -136,17 +122,11 @@ msgstr "Uvoz neuspio."
 
 #: batch_import.html
 msgid "No import will be queued until *every* record validates successfully."
-msgstr ""
-"Uvoz neće biti stavljen u red čekanja sve dok se *svaki* zapis uspješno ne "
-"potvrdi."
+msgstr "Uvoz neće biti stavljen u red čekanja sve dok se *svaki* zapis uspješno ne potvrdi."
 
 #: batch_import.html
-msgid ""
-"Please update the JSONL file and reload this page (there should be no need "
-"to reattach the file)."
-msgstr ""
-"Aktualiziraj JSONL datoteku i ponovo učitaj ovu stranicu (ne bi trebalo biti "
-"potrebno ponovo priložiti datoteku)."
+msgid "Please update the JSONL file and reload this page (there should be no need to reattach the file)."
+msgstr "Aktualiziraj JSONL datoteku i ponovo učitaj ovu stranicu (ne bi trebalo biti potrebno ponovo priložiti datoteku)."
 
 #: batch_import.html
 msgid "Validation errors:"
@@ -189,25 +169,19 @@ msgstr "Predstojeći skupni uvozi"
 msgid "batch_id"
 msgstr "batch_id"
 
-#: admin/imports.html admin/imports_by_date.html batch_import_pending_view.html
-#: batch_import_view.html
+#: admin/imports.html admin/imports_by_date.html batch_import_pending_view.html batch_import_view.html
 msgid "Added Time"
 msgstr "Vrijeme dodavanja"
 
-#: account/import.html account/loans.html admin/imports.html
-#: admin/imports_by_date.html admin/loans_table.html admin/menu.html
-#: batch_import_pending_view.html batch_import_view.html
-#: librarian_dashboard/data_quality_table.html status.html
+#: account/import.html account/loans.html admin/imports.html admin/imports_by_date.html admin/loans_table.html admin/menu.html batch_import_pending_view.html batch_import_view.html librarian_dashboard/data_quality_table.html status.html
 msgid "Status"
 msgstr "Stanje"
 
-#: batch_import_pending_view.html batch_import_view.html
-#: merge_request_table/table_header.html
+#: batch_import_pending_view.html batch_import_view.html merge_request_table/table_header.html
 msgid "Submitter"
 msgstr "Podnositelj"
 
-#: RecentChangesAdmin.html batch_import_pending_view.html
-#: batch_import_view.html
+#: RecentChangesAdmin.html batch_import_pending_view.html batch_import_view.html
 msgid "Comments"
 msgstr "Komentari"
 
@@ -247,8 +221,7 @@ msgstr "Uvoz artikala"
 msgid "Import Time"
 msgstr "Vrijeme uvoza"
 
-#: account/import.html admin/imports.html admin/imports_by_date.html
-#: batch_import_view.html librarian_dashboard/data_quality_table.html
+#: account/import.html admin/imports.html admin/imports_by_date.html batch_import_view.html librarian_dashboard/data_quality_table.html
 msgid "Error"
 msgstr "Greška"
 
@@ -272,8 +245,7 @@ msgstr "Još nije uvezeno"
 msgid "Web Component Library"
 msgstr "Biblioteka web komponenti"
 
-#: OlPagination.html OlPaginationArrows.html design.html type/edition/view.html
-#: type/work/view.html
+#: OlPagination.html OlPaginationArrows.html design.html type/edition/view.html type/work/view.html
 msgid "Pagination"
 msgstr "Paginacija"
 
@@ -289,6 +261,20 @@ msgstr "Čitaj više"
 msgid "Chip"
 msgstr "Čip"
 
+#: design.html design/button.html
+#, fuzzy
+msgid "Button"
+msgstr "Rođen/a"
+
+#: design.html design/toast.html
+#, fuzzy
+msgid "Toast"
+msgstr "Oznake"
+
+#: design.html design/banner.html
+msgid "Banner"
+msgstr "Baner"
+
 #: design.html
 msgid "Chip Group"
 msgstr "Grupa čipova"
@@ -298,12 +284,8 @@ msgid "Markdown Editor"
 msgstr "Markdown uređivač"
 
 #: design.html
-msgid ""
-"The ol-pagination component provides support for both event-based and URL-"
-"based navigation."
-msgstr ""
-"Komponenta ol-pagination pruža podršku za navigaciju temeljenu na događajima "
-"i na URL-ovima."
+msgid "The ol-pagination component provides support for both event-based and URL-based navigation."
+msgstr "Komponenta ol-pagination pruža podršku za navigaciju temeljenu na događajima i na URL-ovima."
 
 #: design.html
 msgid "Event-based"
@@ -311,12 +293,8 @@ msgstr "Temeljeno na događajima"
 
 #: design.html
 #, python-format
-msgid ""
-"When a page is clicked, the component fires an %(update_page)s event with "
-"the page number in %(event_detail)s."
-msgstr ""
-"Kada se klikne na jedntu stranicu, komponenta pokreće događaj "
-"%(update_page)s s brojem stranice u %(event_detail)s."
+msgid "When a page is clicked, the component fires an %(update_page)s event with the page number in %(event_detail)s."
+msgstr "Kada se klikne na jedntu stranicu, komponenta pokreće događaj %(update_page)s s brojem stranice u %(event_detail)s."
 
 #: design.html
 msgid "Selected page:"
@@ -327,12 +305,8 @@ msgid "URL-based Navigation"
 msgstr "Navigacija temeljena na URL-u"
 
 #: design.html
-msgid ""
-"When base-url is provided, pagination renders anchor tags for SEO-friendly "
-"links."
-msgstr ""
-"Kada je base-url zadan, paginacija prikazuje oznake sidra za SEO-"
-"prijateljske poveznice."
+msgid "When base-url is provided, pagination renders anchor tags for SEO-friendly links."
+msgstr "Kada je base-url zadan, paginacija prikazuje oznake sidra za SEO-prijateljske poveznice."
 
 #: design.html
 msgid "First page (no previous arrow)"
@@ -363,12 +337,8 @@ msgid "Arrows mode"
 msgstr "Modus strelica"
 
 #: design.html
-msgid ""
-"When total pages is unknown, use arrows mode to show only previous/next "
-"navigation."
-msgstr ""
-"Kada je ukupan broj stranica nepoznat, koristi modus strelica za "
-"prikazivanje samo za prethodnu/sljedeću stranicu unavigaciji."
+msgid "When total pages is unknown, use arrows mode to show only previous/next navigation."
+msgstr "Kada je ukupan broj stranica nepoznat, koristi modus strelica za prikazivanje samo za prethodnu/sljedeću stranicu unavigaciji."
 
 #: design.html
 msgid "Arrows mode (has next page)"
@@ -383,12 +353,8 @@ msgid "Arrows mode (first page, has next)"
 msgstr "Modus strelica (prva stranica, ima sljedeću stranicu)"
 
 #: design.html
-msgid ""
-"The ol-read-more component provides expandable/collapsible content with two "
-"truncation modes: height-based and line-based."
-msgstr ""
-"Komponenta ol-read-more omogućuje proširivi/sklopivi sadržaj s dva načina "
-"skraćivanja: prema visini i prema broju redaka."
+msgid "The ol-read-more component provides expandable/collapsible content with two truncation modes: height-based and line-based."
+msgstr "Komponenta ol-read-more omogućuje proširivi/sklopivi sadržaj s dva načina skraćivanja: prema visini i prema broju redaka."
 
 #: design.html
 msgid "Height-based truncation"
@@ -397,8 +363,7 @@ msgstr "Skraćivanje prema visini"
 #: design.html
 #, python-format
 msgid "Use %(max_height)s to limit content by pixel height."
-msgstr ""
-"Koristi %(max_height)s za ograničavanje sadržaja prema visini u pikselima."
+msgstr "Koristi %(max_height)s za ograničavanje sadržaja prema visini u pikselima."
 
 #: design.html
 msgid "Line-based truncation"
@@ -415,12 +380,8 @@ msgstr "Prilagođeni tekst gumba"
 
 #: design.html
 #, python-format
-msgid ""
-"Use %(more_text)s and %(less_text)s to customize the toggle button labels. "
-"We'll use the i18n strings for this example."
-msgstr ""
-"Koristi %(more_text)s i %(less_text)s za prilagodbu etiketa gumba za "
-"uključivanje/isljučivanje. U ovom primjeru ćemo koristiti i18n izraze."
+msgid "Use %(more_text)s and %(less_text)s to customize the toggle button labels. We'll use the i18n strings for this example."
+msgstr "Koristi %(more_text)s i %(less_text)s za prilagodbu etiketa gumba za uključivanje/isljučivanje. U ovom primjeru ćemo koristiti i18n izraze."
 
 #: SearchResultsWork.html design.html
 msgid "Show more"
@@ -436,12 +397,8 @@ msgstr "Prilagođena boja pozadine"
 
 #: design.html
 #, python-format
-msgid ""
-"Use %(background_color)s to match the gradient fade to your container "
-"background."
-msgstr ""
-"Koristi %(background_color)s za usklađivanje postupnog prijelaza gradijentna "
-"s pozadinom tvog kontejnera."
+msgid "Use %(background_color)s to match the gradient fade to your container background."
+msgstr "Koristi %(background_color)s za usklađivanje postupnog prijelaza gradijentna s pozadinom tvog kontejnera."
 
 #: design.html
 msgid "Small label size"
@@ -458,24 +415,16 @@ msgstr "Sadržaj je kraći od ograničenja (bez gumba)"
 
 #: design.html
 msgid "When content fits within the limit, no toggle button is shown."
-msgstr ""
-"Kada sadržaj stane unutar ograničenja, gumb za uključivanje/isljučivanje se "
-"ne prikazuje."
+msgstr "Kada sadržaj stane unutar ograničenja, gumb za uključivanje/isljučivanje se ne prikazuje."
 
 #: design.html
 msgid "This is short content that fits within 5 lines, so no button appears."
-msgstr ""
-"Ovo je kratak sadržaj koji stane unutar 5 redaka, stoga se nijedan gumb ne "
-"prikazuje."
+msgstr "Ovo je kratak sadržaj koji stane unutar 5 redaka, stoga se nijedan gumb ne prikazuje."
 
 #: design.html
 #, python-format
-msgid ""
-"The ol-chip component is a pill-shaped interactive element for filters, "
-"tags, and selections. It fires an %(event)s event on click."
-msgstr ""
-"Komponenta „ol-chip” je interaktivan element u obliku pilule za filtre, "
-"oznake i odabire. Klikom na takav element pokreće događaj %(event)s."
+msgid "The ol-chip component is a pill-shaped interactive element for filters, tags, and selections. It fires an %(event)s event on click."
+msgstr "Komponenta „ol-chip” je interaktivan element u obliku pilule za filtre, oznake i odabire. Klikom na takav element pokreće događaj %(event)s."
 
 #: design.html
 msgid "Default (medium)"
@@ -493,8 +442,7 @@ msgstr "Znanstvena fantastika"
 msgid "Science"
 msgstr "Znanost"
 
-#: databarDiff.html databarEdit.html databarTemplate.html databarView.html
-#: design.html lib/history.html openlibrary/plugins/openlibrary/home.py
+#: databarDiff.html databarEdit.html databarTemplate.html databarView.html design.html lib/history.html openlibrary/plugins/openlibrary/home.py
 msgid "History"
 msgstr "Povijest"
 
@@ -503,8 +451,7 @@ msgid "Selected state"
 msgstr "Odabrano stanje"
 
 #: design.html
-msgid ""
-"A selected chip displays a checkmark icon and uses an active color scheme."
+msgid "A selected chip displays a checkmark icon and uses an active color scheme."
 msgstr "Odabrani čip prikazuje ikonu kvačice i koristi aktivnu shemu boja."
 
 #: design.html
@@ -543,12 +490,8 @@ msgstr "Kao poveznica"
 
 #: design.html
 #, python-format
-msgid ""
-"When %(href)s is provided, the chip renders as an anchor tag instead of a "
-"button."
-msgstr ""
-"Kada je %(href)s dostupno, čip se prikazuje kao tzv. anchor tag, umjesto kao "
-"gumb."
+msgid "When %(href)s is provided, the chip renders as an anchor tag instead of a button."
+msgstr "Kada je %(href)s dostupno, čip se prikazuje kao tzv. anchor tag, umjesto kao gumb."
 
 #: design.html
 msgid "Interactive toggle"
@@ -556,12 +499,8 @@ msgstr "Interaktivni prekidač"
 
 #: design.html
 #, python-format
-msgid ""
-"Clicking a chip fires an %(event)s event. Toggle the selected state by "
-"listening to the event."
-msgstr ""
-"Klikom na čip se pokreće događaj %(event)s. Uklj./Isklj. odabrano stanje "
-"slušanjem događaja."
+msgid "Clicking a chip fires an %(event)s event. Toggle the selected state by listening to the event."
+msgstr "Klikom na čip se pokreće događaj %(event)s. Uklj./Isklj. odabrano stanje slušanjem događaja."
 
 #: design.html
 msgid "Toggle me"
@@ -572,12 +511,8 @@ msgid "Toggle me too"
 msgstr "Uklj./Isklj. i mene"
 
 #: design.html
-msgid ""
-"The ol-chip-group component is a flex-wrap container that provides "
-"consistent spacing for groups of chips."
-msgstr ""
-"Komponenta „ol-chip-group” je „flex-wrap” kontejner koji omogućuje dosljedan "
-"razmak za grupe čipova."
+msgid "The ol-chip-group component is a flex-wrap container that provides consistent spacing for groups of chips."
+msgstr "Komponenta „ol-chip-group” je „flex-wrap” kontejner koji omogućuje dosljedan razmak za grupe čipova."
 
 #: design.html
 msgid "Default (medium gap)"
@@ -610,12 +545,8 @@ msgid "Wrapping behavior"
 msgstr "Prijelom redaka"
 
 #: design.html
-msgid ""
-"Chips automatically wrap to the next line when they exceed the container "
-"width."
-msgstr ""
-"Čipovi se automatski prelamaju u sljedeći redak kada premaše širinu "
-"kontejnera."
+msgid "Chips automatically wrap to the next line when they exceed the container width."
+msgstr "Čipovi se automatski prelamaju u sljedeći redak kada premaše širinu kontejnera."
 
 #: design.html
 msgid "Biography"
@@ -626,24 +557,12 @@ msgid "With mixed chip states"
 msgstr "S miješanim čip stanjima"
 
 #: design.html
-msgid ""
-"Chip groups work with any combination of chip sizes, states, and link chips."
-msgstr ""
-"Grupe čipova rade s bilo kojom kombinacijom veličina čipova, stanja i čipova "
-"poveznica."
+msgid "Chip groups work with any combination of chip sizes, states, and link chips."
+msgstr "Grupe čipova rade s bilo kojom kombinacijom veličina čipova, stanja i čipova poveznica."
 
 #: design.html
-msgid ""
-"The ol-markdown-editor component is a WYSIWYG editor built on Tiptap that "
-"outputs Markdown. It syncs its content to a hidden target textarea. A 'View "
-"source' toolbar toggle is always available so editors can drop into a raw "
-"markdown textarea when WYSIWYG round-trips are awkward."
-msgstr ""
-"Komponenta ol-markdown-editor je WYSIWYG uređivač izgrađen na Tiptapu koji "
-"generira Markdown. Sinkronizira svoj sadržaj sa skrivenim ciljanim "
-"tekstualnim poljem (textarea). Opcija „Prikaži izvor” na alatnoj traci je "
-"uvijek dostupna kako bi urednici mogli prijeći na obični markdown tekstualno "
-"polje kada povratne konverzije u WYSIWYG uređivaču izgledaju čudno."
+msgid "The ol-markdown-editor component is a WYSIWYG editor built on Tiptap that outputs Markdown. It syncs its content to a hidden target textarea. A 'View source' toolbar toggle is always available so editors can drop into a raw markdown textarea when WYSIWYG round-trips are awkward."
+msgstr "Komponenta ol-markdown-editor je WYSIWYG uređivač izgrađen na Tiptapu koji generira Markdown. Sinkronizira svoj sadržaj sa skrivenim ciljanim tekstualnim poljem (textarea). Opcija „Prikaži izvor” na alatnoj traci je uvijek dostupna kako bi urednici mogli prijeći na obični markdown tekstualno polje kada povratne konverzije u WYSIWYG uređivaču izgledaju čudno."
 
 #: design.html
 msgid "Basic usage"
@@ -651,13 +570,8 @@ msgstr "Osnovna upotreba"
 
 #: design.html
 #, python-format
-msgid ""
-"Provide a %(target_id)s pointing to an existing textarea. The editor reads "
-"initial content from the textarea and syncs changes back to it."
-msgstr ""
-"Navedi %(target_id)s koji upućuje na postojeće tekstualno područje. Uređivač "
-"čita početni sadržaj iz tekstualnog polja i sinkronizira promjene natrag na "
-"njega."
+msgid "Provide a %(target_id)s pointing to an existing textarea. The editor reads initial content from the textarea and syncs changes back to it."
+msgstr "Navedi %(target_id)s koji upućuje na postojeće tekstualno područje. Uređivač čita početni sadržaj iz tekstualnog polja i sinkronizira promjene natrag na njega."
 
 #: design.html
 msgid "Mixed Markdown and HTML"
@@ -665,12 +579,8 @@ msgstr "Pomiješani Markdown i HTML"
 
 #: design.html
 #, python-format
-msgid ""
-"Add the %(attr)s attribute to expose the HTML block button in the toolbar. "
-"HTML blocks appear with a preview and an Edit button to modify the source."
-msgstr ""
-"Dodaj atribut %(attr)s za prikaz gumba za HTML blok u alatnoj traci. HTML "
-"blokovi se pojavljuju s pregledom i gumbom Uredi za mijenjanje izvornog koda."
+msgid "Add the %(attr)s attribute to expose the HTML block button in the toolbar. HTML blocks appear with a preview and an Edit button to modify the source."
+msgstr "Dodaj atribut %(attr)s za prikaz gumba za HTML blok u alatnoj traci. HTML blokovi se pojavljuju s pregledom i gumbom Uredi za mijenjanje izvornog koda."
 
 #: design.html
 msgid "Code blocks and inline code"
@@ -678,15 +588,8 @@ msgstr "Blokovi koda i ugrađeni kod"
 
 #: design.html
 #, python-format
-msgid ""
-"Add the %(attr)s attribute to expose the inline code and code block buttons "
-"in the toolbar. Code support is off by default because only the wiki page "
-"renderer is guaranteed to render fenced code blocks."
-msgstr ""
-"Dodaj atribut %(attr)s za prikaz gumbova za ugrađeni kod (inline) kod i blok "
-"koda u alatnoj traci. Podrška za kod je po standardno isključena jer je samo "
-"iscrtavač wiki stranica jamči za prikaz ispravan prikaz ograđenih blokova "
-"koda (fenced code blocks)."
+msgid "Add the %(attr)s attribute to expose the inline code and code block buttons in the toolbar. Code support is off by default because only the wiki page renderer is guaranteed to render fenced code blocks."
+msgstr "Dodaj atribut %(attr)s za prikaz gumbova za ugrađeni kod (inline) kod i blok koda u alatnoj traci. Podrška za kod je po standardno isključena jer je samo iscrtavač wiki stranica jamči za prikaz ispravan prikaz ograđenih blokova koda (fenced code blocks)."
 
 #: design.html
 msgid "Change event"
@@ -694,12 +597,8 @@ msgstr "Promjena događaja"
 
 #: design.html
 #, python-format
-msgid ""
-"The editor fires an %(event)s event on every change. The raw Markdown string "
-"is available in %(detail)s."
-msgstr ""
-"Urednik pokreće %(event)s događaj pri svakoj promjeni. Markdown izraz je "
-"dostupan u %(detail)s."
+msgid "The editor fires an %(event)s event on every change. The raw Markdown string is available in %(detail)s."
+msgstr "Urednik pokreće %(event)s događaj pri svakoj promjeni. Markdown izraz je dostupan u %(detail)s."
 
 #: diff.html
 #, python-format
@@ -759,8 +658,7 @@ msgstr "Prekini i vrati se natrag."
 msgid "YAML Representation:"
 msgstr "YAML prikaz:"
 
-#: BookPreview.html book_providers/read_button.html books/edit/edition.html
-#: editpage.html import_preview.html
+#: BookPreview.html book_providers/read_button.html books/edit/edition.html editpage.html import_preview.html
 msgid "Preview"
 msgstr "Pregled"
 
@@ -772,21 +670,15 @@ msgstr "Povijest promjena u"
 msgid "Revision"
 msgstr "Revizija"
 
-#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
-#: admin/ip/view.html admin/people/edits.html history.html
-#: recentchanges/render.html recentchanges/updated_records.html
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html admin/ip/view.html admin/people/edits.html history.html recentchanges/render.html recentchanges/updated_records.html
 msgid "When"
 msgstr "Kada"
 
-#: RecentChanges.html admin/history.html admin/ip/view.html
-#: admin/loans_table.html admin/people/edits.html history.html
-#: recentchanges/render.html
+#: RecentChanges.html admin/history.html admin/ip/view.html admin/loans_table.html admin/people/edits.html history.html recentchanges/render.html
 msgid "Who"
 msgstr "Tko"
 
-#: RecentChanges.html RecentChangesUsers.html admin/history.html
-#: admin/ip/view.html admin/people/edits.html history.html
-#: recentchanges/render.html recentchanges/updated_records.html
+#: RecentChanges.html RecentChangesUsers.html admin/history.html admin/ip/view.html admin/people/edits.html history.html recentchanges/render.html recentchanges/updated_records.html
 msgid "Comment"
 msgstr "Komentar"
 
@@ -851,29 +743,17 @@ msgstr "Žao nam je, došlo je do problema prilikom odgovaranja na tvoj zahtjev:
 
 #: internalerror.html
 #, python-format
-msgid ""
-"The reference code %s and Sentry trace ID %s have been created to track this "
-"error and we will investigate as we're able."
-msgstr ""
-"Referentni kod %s i Sentry trace ID %s su stvoreni za praćenje ove greške i "
-"istražit ćemo ih čim budemo mogli."
+msgid "The reference code %s and Sentry trace ID %s have been created to track this error and we will investigate as we're able."
+msgstr "Referentni kod %s i Sentry trace ID %s su stvoreni za praćenje ove greške i istražit ćemo ih čim budemo mogli."
 
 #: internalerror.html
 #, python-format
-msgid ""
-"The reference code %s has been created to track this error and we will "
-"investigate as we're able."
-msgstr ""
-"Referentni kod %s je stvoren za praćenje ove greške i istražit ćemo je čim "
-"budemo mogli."
+msgid "The reference code %s has been created to track this error and we will investigate as we're able."
+msgstr "Referentni kod %s je stvoren za praćenje ove greške i istražit ćemo je čim budemo mogli."
 
 #: internalerror.html
-msgid ""
-"Return to the <a class=\"go-back-link\" href=\"javascript:;\">previous page</"
-"a>?"
-msgstr ""
-"Vratiti se na <a class=\"go-back-link\" href=\"javascript:;\">prethodnu "
-"stranicu</a>?"
+msgid "Return to the <a class=\"go-back-link\" href=\"javascript:;\">previous page</a>?"
+msgstr "Vratiti se na <a class=\"go-back-link\" href=\"javascript:;\">prethodnu stranicu</a>?"
 
 #: interstitial.html
 msgid "You are being redirected to your book"
@@ -881,23 +761,15 @@ msgstr "Preusmjeravanje na tvoju knjigu"
 
 #: interstitial.html
 #, python-format
-msgid ""
-"This book is provided by %(book_provider)s, a third-party Open Library "
-"Trusted Book Provider"
-msgstr ""
-"Ovu knjigu osigurava %(book_provider)s, neovisan i pouzdan pružatelj knjiga "
-"u Open Library"
+msgid "This book is provided by %(book_provider)s, a third-party Open Library Trusted Book Provider"
+msgstr "Ovu knjigu osigurava %(book_provider)s, neovisan i pouzdan pružatelj knjiga u Open Library"
 
 #: interstitial.html
 #, python-format
 msgid "In %(time)s seconds, you will be automatically redirected to: %(url)s"
 msgstr "Za %(time)s s ćeš automatski biti preusmjeren/a na: %(url)s"
 
-#: CreateListModal.html EditButtons.html account/notifications.html
-#: account/password/reset.html account/privacy.html admin/imports-add.html
-#: admin/permissions.html books/add.html databarEdit.html interstitial.html
-#: merge/authors.html my_books/dropdown_content.html type/list/edit.html
-#: type/series/edit.html type/tag/form.html
+#: CreateListModal.html EditButtons.html account/notifications.html account/password/reset.html account/privacy.html admin/imports-add.html admin/permissions.html books/add.html databarEdit.html design/button.html interstitial.html merge/authors.html my_books/dropdown_content.html type/list/edit.html type/series/edit.html type/tag/form.html
 msgid "Cancel"
 msgstr "Prekini"
 
@@ -909,9 +781,7 @@ msgstr "Nastavi bez čekanja"
 msgid "Library Explorer"
 msgstr "Pretraživač knjižnice"
 
-#: account/create.html books/custom_carousel.html
-#: librarian_dashboard/data_quality_table.html login.html
-#: search/work_search_facets.html
+#: account/create.html books/custom_carousel.html librarian_dashboard/data_quality_table.html login.html search/work_search_facets.html
 msgid "Loading..."
 msgstr "Učitavanje …"
 
@@ -920,11 +790,8 @@ msgid "Log In"
 msgstr "Prijava"
 
 #: login.html
-msgid ""
-"This is a development instance, the default credentials are automatically "
-"filled."
-msgstr ""
-"Ovo je razvojna instanca, zadani podaci za prijavu se ispunjavaju automatski."
+msgid "This is a development instance, the default credentials are automatically filled."
+msgstr "Ovo je razvojna instanca, zadani podaci za prijavu se ispunjavaju automatski."
 
 #: login.html
 msgid "email:"
@@ -935,12 +802,8 @@ msgid "password:"
 msgstr "lozinka:"
 
 #: login.html
-msgid ""
-"Log in to use your free Open Library card to borrow digital books from the "
-"nonprofit Internet Archive"
-msgstr ""
-"Prijavi se za korištenje besplatne Open Library kartice za posuđivanje "
-"digitalnih knjiga od neprofitne organizacije Internet Archive"
+msgid "Log in to use your free Open Library card to borrow digital books from the nonprofit Internet Archive"
+msgstr "Prijavi se za korištenje besplatne Open Library kartice za posuđivanje digitalnih knjiga od neprofitne organizacije Internet Archive"
 
 #: account/create.html login.html
 msgid "OR"
@@ -952,22 +815,12 @@ msgid "You are already logged into Open Library as %(user)s."
 msgstr "Već si prijavljen/a na Open Library kao %(user)s."
 
 #: account/create.html login.html
-msgid ""
-"If you'd like to create a new, different Open Library account, you'll need "
-"to <a href=\"javascript:;\" onclick=\"document.forms['hamburger-"
-"logout'].submit()\">log out</a> and start the signup process afresh."
-msgstr ""
-"Ako želiš stvoriti jedan novi Open Library račun, moraš se <a "
-"href=\"javascript:;\" onclick=\"document.forms['hamburger-logout'].submit()"
-"\">odjaviti</a> i ponovo započeti postupak registracije."
+msgid "If you'd like to create a new, different Open Library account, you'll need to <a href=\"javascript:;\" onclick=\"document.forms['hamburger-logout'].submit()\">log out</a> and start the signup process afresh."
+msgstr "Ako želiš stvoriti jedan novi Open Library račun, moraš se <a href=\"javascript:;\" onclick=\"document.forms['hamburger-logout'].submit()\">odjaviti</a> i ponovo započeti postupak registracije."
 
 #: login.html
-msgid ""
-"Please enter your <a href=\"https://archive.org\">Internet Archive</a> email "
-"and password to access your Open Library account."
-msgstr ""
-"Za pristup tvom Open Library računu upiši svoju <a href=\"https://"
-"archive.org\">Internet Archive</a> e-mail adresu i lozinku."
+msgid "Please enter your <a href=\"https://archive.org\">Internet Archive</a> email and password to access your Open Library account."
+msgstr "Za pristup tvom Open Library računu upiši svoju <a href=\"https://archive.org\">Internet Archive</a> e-mail adresu i lozinku."
 
 #: login.html openlibrary/plugins/upstream/forms.py
 msgid "Email"
@@ -977,8 +830,7 @@ msgstr "E-mail"
 msgid "Forgot your Internet Archive email?"
 msgstr "Ne sjećaš se svoje Internet Archive e-mail adrese?"
 
-#: account/email/forgot-ia.html login.html
-#: openlibrary/plugins/upstream/forms.py
+#: account/email/forgot-ia.html login.html openlibrary/plugins/upstream/forms.py
 msgid "Password"
 msgstr "Lozinka"
 
@@ -1018,10 +870,7 @@ msgstr "Dodana je nova knjiga."
 msgid "Thank you for improving the Open Library catalog!"
 msgstr "Hvala ti ne poboljšavanju kataloga knjižnice Open Library!"
 
-#: BookPreview.html CreateListModal.html NotesModal.html ObservationsModal.html
-#: ShareModal.html covers/author_photo.html covers/book_cover.html
-#: covers/change.html lib/exports.html my_books/check_ins/check_in_prompt.html
-#: my_books/dropdown_content.html native_dialog.html
+#: BookPreview.html CreateListModal.html NotesModal.html ObservationsModal.html ShareModal.html covers/author_photo.html covers/book_cover.html covers/change.html design/banner.html design/toast.html lib/exports.html my_books/check_ins/check_in_prompt.html my_books/dropdown_content.html native_dialog.html
 msgid "Close"
 msgstr "Zatvori"
 
@@ -1074,21 +923,13 @@ msgstr "Dozvola odbijena."
 
 #: permission_denied.html
 #, python-format
-msgid ""
-"Only logged users are allowed to add records on Open Library. Please <a "
-"href=\"%s\">log in</a> to add a book."
-msgstr ""
-"Samo prijavljeni korisnici smiju dodavati zapise u Open Library. <a "
-"href=\"%s\">Prijavi se</a> ako želiš dodati knjigu."
+msgid "Only logged users are allowed to add records on Open Library. Please <a href=\"%s\">log in</a> to add a book."
+msgstr "Samo prijavljeni korisnici smiju dodavati zapise u Open Library. <a href=\"%s\">Prijavi se</a> ako želiš dodati knjigu."
 
 #: permission_denied.html
 #, python-format
-msgid ""
-"Only logged users are allowed to modify records on Open Library. Please <a "
-"href=\"%s\">log in</a> to edit this page."
-msgstr ""
-"Samo prijavljeni korisnici smiju mijenjati zapise u Open Library. <a "
-"href=\"%s\">Prijavi se</a> ako želiš dodati knjigu."
+msgid "Only logged users are allowed to modify records on Open Library. Please <a href=\"%s\">log in</a> to edit this page."
+msgstr "Samo prijavljeni korisnici smiju mijenjati zapise u Open Library. <a href=\"%s\">Prijavi se</a> ako želiš dodati knjigu."
 
 #: permission_denied.html
 #, python-format
@@ -1096,12 +937,8 @@ msgid "You may <a href=\"%s\">log in</a> if you have the required permissions."
 msgstr "Možeš se <a href=\"%s\">prijaviti</a>, ako imaš potrebne dozvole."
 
 #: recaptcha.html
-msgid ""
-"Please satisfy the reCAPTCHA below. If you have security settings or privacy "
-"blockers installed, please disable them to see the reCAPTCHA."
-msgstr ""
-"Riješi reCAPTCHA. Ako su sigurnosne postavke ili blokeri privatnosti "
-"instalirani, deaktiviraj ih za prikaz reCAPTCHA."
+msgid "Please satisfy the reCAPTCHA below. If you have security settings or privacy blockers installed, please disable them to see the reCAPTCHA."
+msgstr "Riješi reCAPTCHA. Ako su sigurnosne postavke ili blokeri privatnosti instalirani, deaktiviraj ih za prikaz reCAPTCHA."
 
 #: recaptcha.html
 msgid "Incorrect. Please try again."
@@ -1123,8 +960,7 @@ msgstr "ID zapisa"
 msgid "Source"
 msgstr "Izvor"
 
-#: books/add.html covers/add.html showia.html type/edition/view.html
-#: type/work/view.html
+#: books/add.html covers/add.html showia.html type/edition/view.html type/work/view.html
 msgid "Internet Archive"
 msgstr "Internet Archive"
 
@@ -1188,15 +1024,11 @@ msgstr "Dodaj PR-ove"
 msgid "PR"
 msgstr "PR"
 
-#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html
-#: search/advancedsearch.html status.html type/about/edit.html
-#: type/page/edit.html type/template/edit.html
+#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html search/advancedsearch.html status.html type/about/edit.html type/page/edit.html type/template/edit.html
 msgid "Title"
 msgstr "Naslov"
 
-#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html
-#: openlibrary/plugins/worksearch/code.py search/advancedsearch.html
-#: search/work_search_selected_facets.html status.html
+#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html openlibrary/plugins/worksearch/code.py search/advancedsearch.html search/work_search_selected_facets.html status.html
 msgid "Author"
 msgstr "Autor"
 
@@ -1281,8 +1113,7 @@ msgstr "Pogledaj PR-ove na GitHubu"
 msgid "Show changed files"
 msgstr "Prikaži promijenjene datoteke"
 
-#: admin/inspect/store.html admin/people/index.html status.html
-#: type/author/edit.html type/language/view.html
+#: admin/inspect/store.html admin/people/index.html status.html type/author/edit.html type/language/view.html
 msgid "Name"
 msgstr "Ime"
 
@@ -1327,8 +1158,7 @@ msgstr "Višeznačnosti"
 msgid "Now"
 msgstr "Sada"
 
-#: admin/graphs.html admin/index.html my_books/check_ins/check_in_form.html
-#: my_books/check_ins/check_in_prompt.html trending.html
+#: admin/graphs.html admin/index.html my_books/check_ins/check_in_form.html my_books/check_ins/check_in_prompt.html trending.html
 msgid "Today"
 msgstr "Danas"
 
@@ -1360,22 +1190,34 @@ msgstr "Pogledaj što čitatelji zajednice dodaju u svoje police"
 msgid "Earliest trending data is from October 2017"
 msgstr "Najraniji podaci o trendovima su od listopada 2017."
 
-#: account/mybooks.html account/sidebar.html my_books/dropdown_content.html
-#: my_books/primary_action.html search/sort_options.html trending.html
+#. Label for the reading log shelf for books the user plans to read in the
+#. future (bookshelf ID 1). Used as a button label and shelf name.
+#: account/mybooks.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html trending.html
 msgid "Want to Read"
 msgstr "Želim čitati"
 
-#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
-#: my_books/dropdown_content.html my_books/primary_action.html
-#: search/sort_options.html trending.html
+#. Display name for the "currently-reading" reading log shelf used in page
+#. headings and breadcrumbs.
+#. Label for the reading log shelf for books the user is actively reading
+#. (bookshelf ID 2). Used as a button label and shelf name.
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html trending.html
 msgid "Currently Reading"
 msgstr "Trenutačno čitam"
 
-#: LoanReadForm.html ReadButton.html admin/inspect/memcache.html
-#: book_providers/read_button.html books/edit/edition.html trending.html
-#: type/list/embed.html widget.html
+#: LoanReadForm.html ReadButton.html admin/inspect/memcache.html book_providers/read_button.html books/edit/edition.html trending.html type/list/embed.html widget.html
 msgid "Read"
 msgstr "Čitaj"
+
+#. Display name for the "stopped-reading" reading log shelf used in page
+#. headings and breadcrumbs.
+#. Label for the reading log shelf for books the user stopped reading before
+#. finishing (bookshelf ID 4). Used as a button label and shelf name.
+#. Label for the reading log shelf for books the user stopped reading
+#. (bookshelf ID 4). Used as a button label and shelf name.
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html trending.html
+#, fuzzy
+msgid "Stopped Reading"
+msgstr "U trendu"
 
 #: trending.html
 #, python-format
@@ -1449,12 +1291,8 @@ msgstr "Saznaj više"
 
 #: widget.html
 #, python-format
-msgid ""
-"on <a target=\"_blank\" rel=\"noopener noreferrer\" "
-"href=\"%(link)s\">openlibrary.org</a>"
-msgstr ""
-"na <a target=\"_blank\" rel=\"noopener noreferrer\" "
-"href=\"%(link)s\">openlibrary.org</a>"
+msgid "on <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"%(link)s\">openlibrary.org</a>"
+msgstr "na <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"%(link)s\">openlibrary.org</a>"
 
 #: work_search.html
 msgid "Search Books"
@@ -1505,8 +1343,7 @@ msgstr "Dodati novu knjigu?"
 msgid "Checking Search Inside matches"
 msgstr "Provjera poklapanja pretraživanja unutar"
 
-#: account/reading_log.html search/authors.html search/lists.html
-#: search/subjects.html work_search.html
+#: account/reading_log.html search/authors.html search/lists.html search/subjects.html work_search.html
 #, python-format
 msgid "%(count)s hit"
 msgid_plural "%(count)s hits"
@@ -1524,12 +1361,8 @@ msgid "The Open Library Team"
 msgstr "Open Library tim"
 
 #: about/index.html
-msgid ""
-"Open Library is made possible because of a dedicated team of staff and over "
-"100 volunteers from around the globe."
-msgstr ""
-"Open Library postoji zahvaljujući posvećenom timu zaposlenika i više od 100 "
-"volontera iz cijelog svijeta."
+msgid "Open Library is made possible because of a dedicated team of staff and over 100 volunteers from around the globe."
+msgstr "Open Library postoji zahvaljujući posvećenom timu zaposlenika i više od 100 volontera iz cijelog svijeta."
 
 #: about/index.html
 msgid "Want to join us?"
@@ -1576,14 +1409,8 @@ msgid "Librarianship"
 msgstr "Knjižničarstvo"
 
 #: about/index.html
-msgid ""
-"If you volunteer with Open Library and would like to be listed as part of "
-"the team, then complete the <a href=\"https://forms.gle/"
-"zPyuXGf4Bg6RzbDA7\">Open Library team information form</a>."
-msgstr ""
-"Ako volontiraš u Open Library i želiš biti naveden/a kao dio tima, ispuni <a "
-"href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">obrazac s podacima za Open "
-"Library tim</a>."
+msgid "If you volunteer with Open Library and would like to be listed as part of the team, then complete the <a href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">Open Library team information form</a>."
+msgstr "Ako volontiraš u Open Library i želiš biti naveden/a kao dio tima, ispuni <a href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">obrazac s podacima za Open Library tim</a>."
 
 #: account/create.html openlibrary/plugins/upstream/forms.py
 msgid "Must be a valid email address"
@@ -1610,12 +1437,8 @@ msgid "Sign Up"
 msgstr "Registriraj se"
 
 #: account/create.html
-msgid ""
-"Get your free Open Library card and borrow digital books from the nonprofit "
-"Internet Archive"
-msgstr ""
-"Nabavi besplatnu iskaznicu za Open Library i posuđuj digitalne knjige od "
-"neprofitne organizacije Internet Archive"
+msgid "Get your free Open Library card and borrow digital books from the nonprofit Internet Archive"
+msgstr "Nabavi besplatnu iskaznicu za Open Library i posuđuj digitalne knjige od neprofitne organizacije Internet Archive"
 
 #: account/create.html type/author/view.html
 msgid "Success!"
@@ -1630,49 +1453,28 @@ msgid "screenname"
 msgstr "ime ekrana"
 
 #: account/create.html
-msgid ""
-"I want to receive news, announcements, and resources from the <a "
-"href=\"https://archive.org/\">Internet Archive</a>, the non-profit that runs "
-"Open Library."
-msgstr ""
-"Želim primati novosti, najave i građu od <a href=\"https://archive.org/"
-"\">Internet Archive</a>, neprofitne organizacije koja pokreće Open Library."
+msgid "I want to receive news, announcements, and resources from the <a href=\"https://archive.org/\">Internet Archive</a>, the non-profit that runs Open Library."
+msgstr "Želim primati novosti, najave i građu od <a href=\"https://archive.org/\">Internet Archive</a>, neprofitne organizacije koja pokreće Open Library."
 
 #: account/create.html
-msgid ""
-"I want to apply* for <a href=\"https://help.archive.org/help/program-"
-"overview/\" target=\"_blank\" rel=\"noopener noreferrer\">special print "
-"disability access</a> through a qualifying program."
-msgstr ""
-"Želim se prijaviti* za <a href=\"https://help.archive.org/help/program-"
-"overview/\" target=\"_blank\" rel=\"noopener noreferrer\">poseban pristup za "
-"osobe s oštećenjem vida</a> putem kvalificiranog programa."
+msgid "I want to apply* for <a href=\"https://help.archive.org/help/program-overview/\" target=\"_blank\" rel=\"noopener noreferrer\">special print disability access</a> through a qualifying program."
+msgstr "Želim se prijaviti* za <a href=\"https://help.archive.org/help/program-overview/\" target=\"_blank\" rel=\"noopener noreferrer\">poseban pristup za osobe s oštećenjem vida</a> putem kvalificiranog programa."
 
 #: account/create.html
 msgid "Select qualifying program"
 msgstr "Odaberi kvalificirani program."
 
 #: account/create.html
-msgid ""
-"* Please use the email address associated with this qualifying program. You "
-"will receive an email after activation with next steps."
-msgstr ""
-"* Koristi e-mail adresu povezanu s ovim kvalificiranim programom. Nakon "
-"aktiviranja ćeš dobiti e-mail s daljnjim uputama."
+msgid "* Please use the email address associated with this qualifying program. You will receive an email after activation with next steps."
+msgstr "* Koristi e-mail adresu povezanu s ovim kvalificiranim programom. Nakon aktiviranja ćeš dobiti e-mail s daljnjim uputama."
 
 #: account/create.html
 msgid "Sign Up with Email"
 msgstr "Registriraj se putem e-mail adrese"
 
 #: account/create.html
-msgid ""
-"By signing up, you agree to the Internet Archive's <a class=\"ol-signup-"
-"form__link\" href=\"//archive.org/about/terms.php\" target=\"_blank\" "
-"rel=\"noopener noreferrer\">Terms of Service</a>."
-msgstr ""
-"S registracijom prihvaćaš <a class=\"ol-signup-form__link\" href=\"//"
-"archive.org/about/terms.php\" target=\"_blank\" rel=\"noopener "
-"noreferrer\">uvjete usluge</a> od Internet Archive."
+msgid "By signing up, you agree to the Internet Archive's <a class=\"ol-signup-form__link\" href=\"//archive.org/about/terms.php\" target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
+msgstr "S registracijom prihvaćaš <a class=\"ol-signup-form__link\" href=\"//archive.org/about/terms.php\" target=\"_blank\" rel=\"noopener noreferrer\">uvjete usluge</a> od Internet Archive."
 
 #: account/create.html
 msgid "Already have an account? <a href=\"/account/login\">Log in</a>"
@@ -1695,12 +1497,8 @@ msgid "Import from Goodreads"
 msgstr "Uvezi iz Goodreads"
 
 #: account/import.html
-msgid ""
-"For instructions on exporting data refer to: <a href=\"https://"
-"www.goodreads.com/review/import\">Goodreads Import/Export</a>"
-msgstr ""
-"Upute o izvozu podataka potraži na: <a href=\"https://www.goodreads.com/"
-"review/import\">Goodreads uvoz/izvoz</a>"
+msgid "For instructions on exporting data refer to: <a href=\"https://www.goodreads.com/review/import\">Goodreads Import/Export</a>"
+msgstr "Upute o izvozu podataka potraži na: <a href=\"https://www.goodreads.com/review/import\">Goodreads uvoz/izvoz</a>"
 
 #: account/import.html
 msgid "File size limit 10MB and .csv file type only"
@@ -1847,15 +1645,10 @@ msgid "Leave the Waiting List"
 msgstr "Izbriši se iz popisa čekanja"
 
 #: account/loans.html
-msgid ""
-"Are you sure you want to leave the waiting list of<br/><strong>TITLE</"
-"strong>?"
-msgstr ""
-"Stvarno se želiš izbrisati iz popisa čekanja za<br/><strong>TITLE</strong>?"
+msgid "Are you sure you want to leave the waiting list of<br/><strong>TITLE</strong>?"
+msgstr "Stvarno se želiš izbrisati iz popisa čekanja za<br/><strong>TITLE</strong>?"
 
-#: ProlificAuthors.html account/loans.html authors/index.html
-#: lists/list_follow.html lists/showcase.html publishers/view.html
-#: search/authors.html search/publishers.html search/subjects.html
+#: ProlificAuthors.html account/loans.html authors/index.html lists/list_follow.html lists/showcase.html publishers/view.html search/authors.html search/publishers.html search/subjects.html
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
@@ -1908,12 +1701,8 @@ msgid "Leave the waiting list?"
 msgstr "Želiš se izbrisati iz popisa čekanja?"
 
 #: account/loans.html
-msgid ""
-"Looking for a book to borrow?  Check out our staff picks, or search for a "
-"book on a specific subject:"
-msgstr ""
-"Tražiš knjigu za posudbu? Pogledaj izbor knjiga naših zaposlenika ili "
-"potraži knjigu određenog područja:"
+msgid "Looking for a book to borrow?  Check out our staff picks, or search for a book on a specific subject:"
+msgstr "Tražiš knjigu za posudbu? Pogledaj izbor knjiga naših zaposlenika ili potraži knjigu određenog područja:"
 
 #: account/loans.html home/index.html
 msgid "Books We Love"
@@ -1931,9 +1720,11 @@ msgstr "U ovoj polici nema knjiga"
 msgid "My Loans"
 msgstr "Moje posudbe"
 
-#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
-#: my_books/dropdown_content.html my_books/primary_action.html
-#: openlibrary/plugins/upstream/mybooks.py search/sort_options.html
+#. Display name for the "already-read" reading log shelf used in page headings
+#. and breadcrumbs.
+#. Label for the reading log shelf for books the user has finished reading
+#. (bookshelf ID 3). Used as a button label and shelf name.
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html openlibrary/plugins/upstream/mybooks.py search/sort_options.html
 msgid "Already Read"
 msgstr "Već pročitano"
 
@@ -1958,8 +1749,7 @@ msgstr "Moja statistika"
 msgid "My Reading Stats"
 msgstr "Statistika mojih čitanja"
 
-#: account/mybooks.html account/sidebar.html
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
+#: account/mybooks.html account/sidebar.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
 msgid "Loan History"
 msgstr "Povijest posudbe"
 
@@ -1985,13 +1775,8 @@ msgstr "E-mail adresa s kojom si se registrirao/la se mora potvrditi."
 
 #: account/not_verified.html
 #, python-format
-msgid ""
-"When you created your account, we sent an email to %(email)s that contained "
-"a link for you to verify your email address. We need you to click that link, "
-"please."
-msgstr ""
-"Nakon što stvoriš račun, šaljemo ti e-mail na %(email)s koja sadrži "
-"poveznicu za potvrđivanje tvoje e-mail adrese. Klikni tu poveznicu."
+msgid "When you created your account, we sent an email to %(email)s that contained a link for you to verify your email address. We need you to click that link, please."
+msgstr "Nakon što stvoriš račun, šaljemo ti e-mail na %(email)s koja sadrži poveznicu za potvrđivanje tvoje e-mail adrese. Klikni tu poveznicu."
 
 #: account/not_verified.html
 msgid "If you can't find the email, just hit this button to send a fresh one:"
@@ -2005,8 +1790,7 @@ msgstr "Ponovo pošalji e-mail za potvrđivanje"
 msgid "Thanks!"
 msgstr "Hvala!"
 
-#: BookByline.html FulltextSearchSuggestionItem.html SearchResultsWork.html
-#: account/notes.html account/observations.html
+#: BookByline.html FulltextSearchSuggestionItem.html SearchResultsWork.html account/notes.html account/observations.html
 msgid "Unknown author"
 msgstr "Nepoznat autor"
 
@@ -2022,8 +1806,7 @@ msgstr "Naslov nedostaje"
 msgid "Publish date unknown"
 msgstr "Datum izdavanja nepoznat"
 
-#: account/notes.html books/edition-sort.html lists/export_as_html.html
-#: type/work/editions.html
+#: account/notes.html books/edition-sort.html lists/export_as_html.html type/work/editions.html
 msgid "Publisher unknown"
 msgstr "Izdavač nepoznat"
 
@@ -2053,14 +1836,8 @@ msgid "Notifications"
 msgstr "Obavijesti"
 
 #: account/notifications.html
-msgid ""
-"Notifications are connected to Lists at the moment. If one of the books on "
-"your list gets edited, or a new book comes into the catalog, we'll let you "
-"know, if you want."
-msgstr ""
-"Obavijesti su trenutačno povezane s popisima. Ako se jedna knjiga s tvog "
-"popisa uredi ili ako se jedna nova knjiga doda u katalog, obavijestit ćemo "
-"te ako želiš."
+msgid "Notifications are connected to Lists at the moment. If one of the books on your list gets edited, or a new book comes into the catalog, we'll let you know, if you want."
+msgstr "Obavijesti su trenutačno povezane s popisima. Ako se jedna knjiga s tvog popisa uredi ili ako se jedna nova knjiga doda u katalog, obavijestit ćemo te ako želiš."
 
 #: account/notifications.html
 msgid "Would you like to receive very occasional emails from Open Library?"
@@ -2074,17 +1851,15 @@ msgstr "Ne, hvala"
 msgid "Yes! Please!"
 msgstr "Da, molim!"
 
-#: EditButtons.html account/notifications.html account/privacy.html
-#: admin/block.html admin/spamwords.html covers/manage.html
+#: EditButtons.html account/notifications.html account/privacy.html admin/block.html admin/spamwords.html covers/manage.html design/button.html
 msgid "Save"
 msgstr "Spremi"
 
-#: EditionNavBar.html account/observations.html
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#: EditionNavBar.html account/observations.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 msgid "Reviews"
 msgstr "Recenzije"
 
-#: account/observations.html admin/inspect/memcache.html design/popover.html
+#: account/observations.html admin/inspect/memcache.html design/button.html design/popover.html
 msgid "Delete"
 msgstr "Izbriši"
 
@@ -2105,21 +1880,13 @@ msgid "Privacy & Content Moderation Settings"
 msgstr "Postavke privatnosti i moderiranja sadržaja"
 
 #: account/privacy.html
-msgid ""
-"Would you like to make your <a href=\"/account/books\">Reading Log</a> "
-"public?"
-msgstr ""
-"Želiš li da se tvoj <a href=\"/account/books\">dnevnik čitanja</a> prikazuje "
-"javno?"
+msgid "Would you like to make your <a href=\"/account/books\">Reading Log</a> public?"
+msgstr "Želiš li da se tvoj <a href=\"/account/books\">dnevnik čitanja</a> prikazuje javno?"
 
 #: account/privacy.html
-msgid ""
-"This will enable others to see what books you want to read, are reading, or "
-"have already read. Patrons with reading logs set to public may be followed."
-msgstr ""
-"Ovo će omogućiti drugima da vide koje knjige želiš čitati, koje čitaš ili "
-"koje si već pročitao/la. Korisnici s dnevnicima čitanja koji su postavljeni "
-"na javne se mogu pratiti."
+#, fuzzy
+msgid "This will enable others to see what books you want to read, are reading, stopped reading, or have already read. Patrons with reading logs set to public may be followed."
+msgstr "Ovo će omogućiti drugima da vide koje knjige želiš čitati, koje čitaš ili koje si već pročitao/la. Korisnici s dnevnicima čitanja koji su postavljeni na javne se mogu pratiti."
 
 #: account/privacy.html admin/people/view.html
 msgid "Yes"
@@ -2134,12 +1901,8 @@ msgid "Enable Safe Mode?"
 msgstr "Aktivirati siguran modus?"
 
 #: account/privacy.html
-msgid ""
-"Safe Mode blurs book covers that have been flagged as having sensitive "
-"imagery."
-msgstr ""
-"Siguran modus zamagljuje naslovnice knjiga koje su označene kao neprikladne "
-"slike."
+msgid "Safe Mode blurs book covers that have been flagged as having sensitive imagery."
+msgstr "Siguran modus zamagljuje naslovnice knjiga koje su označene kao neprikladne slike."
 
 #: account/reading_log.html
 #, python-format
@@ -2148,12 +1911,8 @@ msgstr "Knjige koje %(username)s čita"
 
 #: account/reading_log.html
 #, python-format
-msgid ""
-"%(username)s is reading %(total)d books. Join %(username)s on "
-"OpenLibrary.org and tell the world what you're reading."
-msgstr ""
-"%(username)s čita %(total)d knjiga. Pridruži se korisniku %(username)s na "
-"OpenLibrary.org i javi svijetu što čitaš."
+msgid "%(username)s is reading %(total)d books. Join %(username)s on OpenLibrary.org and tell the world what you're reading."
+msgstr "%(username)s čita %(total)d knjiga. Pridruži se korisniku %(username)s na OpenLibrary.org i javi svijetu što čitaš."
 
 #: account/reading_log.html
 #, python-format
@@ -2162,12 +1921,18 @@ msgstr "Knjige koje %(username)s želi čitati"
 
 #: account/reading_log.html
 #, python-format
-msgid ""
-"%(username)s wants to read %(total)d books. Join %(username)s on "
-"OpenLibrary.org and share the books that you'll soon be reading!"
-msgstr ""
-"%(username)s želi čitati %(total)d knjiga. Pridruži se korisniku "
-"%(username)s na OpenLibrary.org i dijeli knjige koje ćeš uskoro čitati!"
+msgid "%(username)s wants to read %(total)d books. Join %(username)s on OpenLibrary.org and share the books that you'll soon be reading!"
+msgstr "%(username)s želi čitati %(total)d knjiga. Pridruži se korisniku %(username)s na OpenLibrary.org i dijeli knjige koje ćeš uskoro čitati!"
+
+#: account/reading_log.html
+#, fuzzy, python-format
+msgid "Books %(username)s stopped reading"
+msgstr "Knjige koje %(username)s čita"
+
+#: account/reading_log.html
+#, fuzzy, python-format
+msgid "%(username)s stopped reading %(total)d books. Join %(username)s on OpenLibrary.org to share your own reading updates!"
+msgstr "%(username)s želi čitati %(total)d knjiga. Pridruži se korisniku %(username)s na OpenLibrary.org i dijeli knjige koje ćeš uskoro čitati!"
 
 #: account/reading_log.html
 #, python-format
@@ -2176,13 +1941,8 @@ msgstr "Knjige koje je %(username)s čitao/la %(year)d."
 
 #: account/reading_log.html
 #, python-format
-msgid ""
-"%(username)s has read %(total)d books in %(year)d. Join %(username)s on "
-"OpenLibrary.org and tell the world about the books that you care about."
-msgstr ""
-"%(username)s je pročitao/la %(total)d knjiga %(year)d. Pridruži se korisniku "
-"%(username)s na OpenLibrary.org i obavijesti svijet o knjigama koje su ti "
-"važne."
+msgid "%(username)s has read %(total)d books in %(year)d. Join %(username)s on OpenLibrary.org and tell the world about the books that you care about."
+msgstr "%(username)s je pročitao/la %(total)d knjiga %(year)d. Pridruži se korisniku %(username)s na OpenLibrary.org i obavijesti svijet o knjigama koje su ti važne."
 
 #: account/reading_log.html
 #, python-format
@@ -2191,13 +1951,8 @@ msgstr "Knjige koje je %(username)s čitao/la"
 
 #: account/reading_log.html
 #, python-format
-msgid ""
-"%(username)s has read %(total)d books. Join %(username)s on OpenLibrary.org "
-"and tell the world about the books that you care about."
-msgstr ""
-"%(username)s je pročitao/la %(total)d knjiga. Pridruži se korisniku "
-"%(username)s na OpenLibrary.org i obavijesti svijet o knjigama koje su ti "
-"važne."
+msgid "%(username)s has read %(total)d books. Join %(username)s on OpenLibrary.org and tell the world about the books that you care about."
+msgstr "%(username)s je pročitao/la %(total)d knjiga. Pridruži se korisniku %(username)s na OpenLibrary.org i obavijesti svijet o knjigama koje su ti važne."
 
 #: account/reading_log.html
 #, python-format
@@ -2241,21 +1996,15 @@ msgid "You haven't added any books to this shelf yet."
 msgstr "Još nisi dodao/la nijednu knjigu u ovu policu."
 
 #: account/reading_log.html
-msgid ""
-"<a href=\"/search\">Search for a book</a> to add to your reading log. <a "
-"href=\"/help/faq/reading-log\">Learn more</a> about the reading log."
-msgstr ""
-"<a href=\"/search\">Traži knjigu</a> koju želiš dodati u dnevnik čitanja. <a "
-"href=\"/help/faq/reading-log\">Saznaj više</a> o dnevniku čitanja."
+msgid "<a href=\"/search\">Search for a book</a> to add to your reading log. <a href=\"/help/faq/reading-log\">Learn more</a> about the reading log."
+msgstr "<a href=\"/search\">Traži knjigu</a> koju želiš dodati u dnevnik čitanja. <a href=\"/help/faq/reading-log\">Saznaj više</a> o dnevniku čitanja."
 
 #: account/reading_log.html
-msgid ""
-"There are no recent books in your feed. When you follow public accounts, "
-"their book updates will appear here."
-msgstr ""
-"U tvom feedu nema novijih knjiga. Kada pratiš javne račune, ovdje će se "
-"pojaviti aktualiziranja njihovih knjiga."
+msgid "There are no recent books in your feed. When you follow public accounts, their book updates will appear here."
+msgstr "U tvom feedu nema novijih knjiga. Kada pratiš javne račune, ovdje će se pojaviti aktualiziranja njihovih knjiga."
 
+#. Display name for the "want-to-read" reading log shelf used in page headings
+#. and breadcrumbs.
 #: account/readinglog_shelf_name.html
 msgid "Want To Read"
 msgstr "Želim čitati"
@@ -2271,12 +2020,8 @@ msgstr "Moje knjige"
 
 #: account/readinglog_stats.html
 #, python-format
-msgid ""
-"Displaying stats about <strong>%(works_count)d</strong> books. Note all "
-"charts show only the top 20 bars. Note reading log stats are private."
-msgstr ""
-"Prikaz statistike o <strong>%(works_count)d</strong> knjiga. Dijagrami "
-"prikazuju samo prvih 20 stupaca. Statistika dnevnika čitanja je privatna."
+msgid "Displaying stats about <strong>%(works_count)d</strong> books. Note all charts show only the top 20 bars. Note reading log stats are private."
+msgstr "Prikaz statistike o <strong>%(works_count)d</strong> knjiga. Dijagrami prikazuju samo prvih 20 stupaca. Statistika dnevnika čitanja je privatna."
 
 #: account/readinglog_stats.html
 msgid "Author Stats"
@@ -2299,22 +2044,22 @@ msgid "Works by Author Country of Birth"
 msgstr "Djela po zemlji rođenja autora"
 
 #: account/readinglog_stats.html
-msgid ""
-"Demographic statistics powered by <a href=\"https://www.wikidata.org/"
-"\">Wikidata</a>. Here's a <a id=\"wd-query-sample\" href=\"\">sample</a> of "
-"the query used. <br />Improve these stats by adding the Wikidata author "
-"identifier following <a href=\"https://openlibrary.org/help/faq/"
-"editing.en#author-identifiers-purpose\">these instructions</a>."
-msgstr ""
-"Demografsku statistiku pruža <a href=\"https://www.wikidata.org/\">Wikidata</"
-"a>. Ovo je <a id=\"wd-query-sample\" href=\"\">primjer</a> korištenog upita. "
-"<br />Poboljšaj ovu statistiku dodavanjem Wikidata identifikatora autora "
-"slijedeći <a href=\"https://openlibrary.org/help/faq/editing.en#author-"
-"identifiers-purpose\">ove upute</a>."
+msgid "Demographic statistics powered by <a href=\"https://www.wikidata.org/\">Wikidata</a>. Here's a <a id=\"wd-query-sample\" href=\"\">sample</a> of the query used. <br />Improve these stats by adding the Wikidata author identifier following <a href=\"https://openlibrary.org/help/faq/editing.en#author-identifiers-purpose\">these instructions</a>."
+msgstr "Demografsku statistiku pruža <a href=\"https://www.wikidata.org/\">Wikidata</a>. Ovo je <a id=\"wd-query-sample\" href=\"\">primjer</a> korištenog upita. <br />Poboljšaj ovu statistiku dodavanjem Wikidata identifikatora autora slijedeći <a href=\"https://openlibrary.org/help/faq/editing.en#author-identifiers-purpose\">ove upute</a>."
 
 #: account/readinglog_stats.html
 msgid "Work Stats"
 msgstr "Statistika djela"
+
+#: account/readinglog_stats.html
+#, fuzzy
+msgid "Works by Decade Published"
+msgstr "Djela po razdoblju"
+
+#: account/readinglog_stats.html
+#, fuzzy
+msgid "Works by Century Published"
+msgstr "Prvi put izdano"
 
 #: account/readinglog_stats.html
 msgid "Works by Subject"
@@ -2340,8 +2085,7 @@ msgstr "Poklapajuća djela"
 msgid "Click on a bar to see matching works"
 msgstr "Pritisni traku za prikaz poklapajućih djela"
 
-#: account/sidebar.html books/mybooks_breadcrumb_select.html
-#: openlibrary/plugins/upstream/mybooks.py
+#: account/sidebar.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 msgid "My Feed"
 msgstr "Moj feed"
 
@@ -2363,10 +2107,7 @@ msgstr "Dnevnik čitanja"
 msgid "My lists"
 msgstr "Moji popisi"
 
-#: EditionNavBar.html SearchNavigation.html account/sidebar.html
-#: lib/nav_head.html lists/home.html recentchanges/index.html
-#: type/edition/view.html type/list/embed.html type/user/view.html
-#: type/work/view.html
+#: EditionNavBar.html SearchNavigation.html account/sidebar.html lib/nav_head.html lists/home.html recentchanges/index.html type/edition/view.html type/list/embed.html type/user/view.html type/work/view.html
 msgid "Lists"
 msgstr "Popisi"
 
@@ -2395,21 +2136,15 @@ msgstr "Postavke privatnosti: %(public)s"
 msgid "Verification email sent"
 msgstr "E-mail poruka za potvrđivanje je poslana"
 
-#: account/password/reset_success.html account/verify.html
-#: account/verify/activated.html account/verify/success.html
+#: account/password/reset_success.html account/verify.html account/verify/activated.html account/verify/success.html
 #, python-format
 msgid "Hi, %(user)s"
 msgstr "Zdravo %(user)s"
 
 #: account/verify.html
 #, python-format
-msgid ""
-"We’ve sent an email to %(email)s containing a link to verify your account. "
-"Click/tap on the link to finish creating your Internet Archive account."
-msgstr ""
-"Poslali smo e-mail na %(email)s koja sadrži poveznicu za potvrđivanje tvog "
-"računa. Klikni/dodirni poveznicu za dovršavanje stvaranja Internet Archive "
-"računa."
+msgid "We’ve sent an email to %(email)s containing a link to verify your account. Click/tap on the link to finish creating your Internet Archive account."
+msgstr "Poslali smo e-mail na %(email)s koja sadrži poveznicu za potvrđivanje tvog računa. Klikni/dodirni poveznicu za dovršavanje stvaranja Internet Archive računa."
 
 #: account/verify.html
 msgid "Then, come back to Open Library and find some great books!"
@@ -2427,15 +2162,13 @@ msgstr "Pratim"
 msgid "Followers"
 msgstr "Pratitelji"
 
-#: account/view.html design/popover.html type/edition/modal_links.html
-#: type/edition/title_and_author.html
+#: account/view.html design/popover.html type/edition/modal_links.html type/edition/title_and_author.html
 msgid "Share"
 msgstr "Dijeli"
 
 #: account/view.html
 msgid "Your book notes are private and cannot be viewed by other patrons."
-msgstr ""
-"Tvoje napomene uz knjigu su privatne i drugi članovi ih ne mogu pregledati."
+msgstr "Tvoje napomene uz knjigu su privatne i drugi članovi ih ne mogu pregledati."
 
 #: account/view.html
 msgid "Your book reviews will be shared anonymously with other patrons."
@@ -2455,12 +2188,8 @@ msgid "Forgot Your Internet Archive Email?"
 msgstr "Ne sjećaš se svoje e-mail adrese za Internet Archive?"
 
 #: account/email/forgot-ia.html
-msgid ""
-"Please enter your Open Library email and password, and we’ll retrieve your "
-"Archive.org email."
-msgstr ""
-"Upiši svoju e-mail adresu i lozinku za Open Library, a mi ćemo obnoviti "
-"tvoju e-mail adresu za Archive.org."
+msgid "Please enter your Open Library email and password, and we’ll retrieve your Archive.org email."
+msgstr "Upiši svoju e-mail adresu i lozinku za Open Library, a mi ćemo obnoviti tvoju e-mail adresu za Archive.org."
 
 #: account/email/forgot-ia.html
 msgid "Your email is:"
@@ -2502,7 +2231,7 @@ msgstr "Obnovi lozinku"
 msgid "Please enter a new password for your Open Library account."
 msgstr "Upiši novu lozinku za tvoj Open Library račun."
 
-#: account/password/reset.html
+#: account/password/reset.html design/button.html
 msgid "Reset"
 msgstr "Obnovi"
 
@@ -2511,12 +2240,8 @@ msgid "Password Reset Successful"
 msgstr "Lozinka je uspješno obnovljena"
 
 #: account/password/reset_success.html
-msgid ""
-"Your password has been updated. Please <a href='/account/login?"
-"redirect=/'>log in to continue</a>."
-msgstr ""
-"Tvoja je lozinka aktualizirana. <a href='/account/login?redirect=/'>Prijavi "
-"se i nastavi.</a>."
+msgid "Your password has been updated. Please <a href='/account/login?redirect=/'>log in to continue</a>."
+msgstr "Tvoja je lozinka aktualizirana. <a href='/account/login?redirect=/'>Prijavi se i nastavi.</a>."
 
 #: account/password/sent.html
 msgid "Done."
@@ -2524,14 +2249,8 @@ msgstr "Gotovo."
 
 #: account/password/sent.html
 #, python-format
-msgid ""
-"We've sent an email to %(email)s with a reminder of your username and "
-"instructions to help you reset your Open Library password. Please check your "
-"inbox for a note from us."
-msgstr ""
-"Poslali smo e-mail na %(email)s s podsjetnikom za tvoje korisničko ime i "
-"uputama, kako bismo ti pomogli obnoviti lozinku za Open Library. Potraži "
-"našu poruku u pristigloj pošti."
+msgid "We've sent an email to %(email)s with a reminder of your username and instructions to help you reset your Open Library password. Please check your inbox for a note from us."
+msgstr "Poslali smo e-mail na %(email)s s podsjetnikom za tvoje korisničko ime i uputama, kako bismo ti pomogli obnoviti lozinku za Open Library. Potraži našu poruku u pristigloj pošti."
 
 #: account/security/check_email.html
 msgid "Account Security Check — 2026-04-28T18Z"
@@ -2546,45 +2265,28 @@ msgid "Incident date: 2026-04-28T18Z"
 msgstr "Datum incidenta: 2026-04-28T18Z"
 
 #: account/security/check_email.html
-msgid ""
-"Check whether your Open Library account was in a set of accounts requiring "
-"attention."
-msgstr ""
-"Provjeri je li tvoj Open Library račun bio u skupu računa koji zahtijevaju "
-"pažnju."
+msgid "Check whether your Open Library account was in a set of accounts requiring attention."
+msgstr "Provjeri je li tvoj Open Library račun bio u skupu računa koji zahtijevaju pažnju."
 
 #: account/security/check_email.html
-msgid ""
-"Please <a href=\"/account/login?redirect=/account/security/"
-"2026-04-28T18\">log in</a> to check whether your account was affected."
-msgstr ""
-"<a href=\"/account/login?redirect=/account/security/2026-04-28T18\">Prijavi "
-"se</a> i provjeri je li tvoj račun bio pogođen."
+msgid "Please <a href=\"/account/login?redirect=/account/security/2026-04-28T18\">log in</a> to check whether your account was affected."
+msgstr "<a href=\"/account/login?redirect=/account/security/2026-04-28T18\">Prijavi se</a> i provjeri je li tvoj račun bio pogođen."
 
 #: account/security/check_email.html
 msgid "Your account is in the affected set."
 msgstr "Tvoj je račun u pogođenom skupu."
 
 #: account/security/check_email.html
-msgid ""
-"Your account was found in our affected accounts list. Please review any "
-"recent communications from Open Library and consider updating your password."
-msgstr ""
-"Tvoj je račun pronađen na našem popisu pogođenih računa. Pregledaj sve "
-"nedavne komunikacije od Open Library i razmisli o aktulaiziranju svoje "
-"lozinke."
+msgid "Your account was found in our affected accounts list. Please review any recent communications from Open Library and consider updating your password."
+msgstr "Tvoj je račun pronađen na našem popisu pogođenih računa. Pregledaj sve nedavne komunikacije od Open Library i razmisli o aktulaiziranju svoje lozinke."
 
 #: account/security/check_email.html
 msgid "Your account is <em>not</em> in the affected set."
 msgstr "Tvoj račun <em>nije</em> u skupu pogođenih."
 
 #: account/security/check_email.html
-msgid ""
-"Your account was <em>not</em> found in the affected accounts list. No action "
-"is required."
-msgstr ""
-"Tvoj račun <em>nije</em> pronađen na popisu pogođenih računa. Nije potrebna "
-"nikakva radnja."
+msgid "Your account was <em>not</em> found in the affected accounts list. No action is required."
+msgstr "Tvoj račun <em>nije</em> pronađen na popisu pogođenih računa. Nije potrebna nikakva radnja."
 
 #: account/verify/activated.html
 msgid "Account already activated"
@@ -2592,9 +2294,7 @@ msgstr "Račun je već aktiviran"
 
 #: account/verify/activated.html
 #, python-format
-msgid ""
-"Your account has been activated already. Please <a href=\"%s\">log in to "
-"continue</a>."
+msgid "Your account has been activated already. Please <a href=\"%s\">log in to continue</a>."
 msgstr "Tvoj je račun već aktiviran. <a href=\"%s\">Prijavi se i nastavi</a>."
 
 #: account/verify/failed.html
@@ -2602,19 +2302,12 @@ msgid "Email Verification Failed"
 msgstr "Potvrđivanje e-mail adrese nije uspjelo"
 
 #: account/verify/failed.html
-msgid ""
-"Your email address couldn't be verified. Your verification link seems "
-"invalid or expired."
-msgstr ""
-"Nije bilo moguće potvrditi tvoju e-mail adresu. Poveznica potvrde je "
-"neispravna ili je istekla."
+msgid "Your email address couldn't be verified. Your verification link seems invalid or expired."
+msgstr "Nije bilo moguće potvrditi tvoju e-mail adresu. Poveznica potvrde je neispravna ili je istekla."
 
 #: account/verify/failed.html
-msgid ""
-"Fill your email and hit this button to resend a fresh verification email:"
-msgstr ""
-"Upiši svoju e-mail adresu i pritisni ovaj gumb za ponovno slanje novog e-"
-"maila za potvrđivanje:"
+msgid "Fill your email and hit this button to resend a fresh verification email:"
+msgstr "Upiši svoju e-mail adresu i pritisni ovaj gumb za ponovno slanje novog e-maila za potvrđivanje:"
 
 #: account/verify/failed.html
 msgid "Enter your email address here"
@@ -2630,12 +2323,8 @@ msgstr "Potvrđivanje e-mail adrese je uspjelo"
 
 #: account/verify/success.html
 #, python-format
-msgid ""
-"Yay! Your email address has been verified. Please <a href='%s'>log in to "
-"continue</a>."
-msgstr ""
-"Super! Tvoja e-mail adresa je potvrđena. <a href='%s'>Prijavi se i nastavi</"
-"a>."
+msgid "Yay! Your email address has been verified. Please <a href='%s'>log in to continue</a>."
+msgstr "Super! Tvoja e-mail adresa je potvrđena. <a href='%s'>Prijavi se i nastavi</a>."
 
 #: admin/attach_debugger.html
 msgid "Attach Debugger"
@@ -2664,12 +2353,8 @@ msgstr "Blokiraj IP adresu"
 
 #: admin/block.html
 #, python-format
-msgid ""
-"IP address %(address)s has been added to the textarea. Please click Save to "
-"block that IP."
-msgstr ""
-"IP adresa %(address)s je dodana u tekstualno područje. Klikni „Spremi“ za "
-"blokiranje te IP adrese."
+msgid "IP address %(address)s has been added to the textarea. Please click Save to block that IP."
+msgstr "IP adresa %(address)s je dodana u tekstualno područje. Klikni „Spremi“ za blokiranje te IP adrese."
 
 #: admin/block.html
 msgid "Blocked IP Addresses"
@@ -2695,8 +2380,7 @@ msgstr "Dioba vremena za učitavanje stranica"
 msgid "Infobase Mean"
 msgstr "Srednja vrijednost od Infobase"
 
-#: admin/history.html admin/imports.html authors/infobox.html
-#: type/author/edit.html
+#: admin/history.html admin/imports.html authors/infobox.html type/author/edit.html
 msgid "Date"
 msgstr "Datum"
 
@@ -2704,13 +2388,11 @@ msgstr "Datum"
 msgid "Page"
 msgstr "Stranica"
 
-#: admin/imports-add.html admin/imports.html admin/imports_by_date.html
-#: admin/menu.html
+#: admin/imports-add.html admin/imports.html admin/imports_by_date.html admin/menu.html
 msgid "Imports"
 msgstr "Uzvozi"
 
-#: admin/imports-add.html books/add.html books/edit/edition.html
-#: books/edit/excerpts.html covers/change.html type/tag/form.html
+#: admin/imports-add.html books/add.html books/edit/edition.html books/edit/excerpts.html covers/change.html type/tag/form.html
 msgid "Add"
 msgstr "Dodaj"
 
@@ -2722,9 +2404,7 @@ msgstr "Dodaj nove knjige u red čekanja za uvoz"
 msgid "Please add IA identifiers to be imported, one per line."
 msgstr "Dodaj IA identifikatore za uvoz, jedan po retku."
 
-#: admin/imports-add.html admin/inspect/store.html admin/ip/view.html
-#: admin/people/edits.html admin/permissions.html
-#: my_books/check_ins/check_in_form.html reading_goals/reading_goal_form.html
+#: admin/imports-add.html admin/inspect/store.html admin/ip/view.html admin/people/edits.html admin/permissions.html design/button.html my_books/check_ins/check_in_form.html reading_goals/reading_goal_form.html
 msgid "Submit"
 msgstr "Pošalji"
 
@@ -2736,8 +2416,7 @@ msgstr "Dnevno uvezene nove knjige"
 msgid "You need to have JavaScript turned on to see the nifty chart!"
 msgstr "Za prikaz dijagrama JavaScript mora biti uključen!"
 
-#: admin/imports.html admin/imports_by_date.html admin/pd_dashboard.html
-#: site/stats.html
+#: admin/imports.html admin/imports_by_date.html admin/pd_dashboard.html site/stats.html
 msgid "Summary"
 msgstr "Sažetak"
 
@@ -2815,12 +2494,8 @@ msgid "Items"
 msgstr "Stavke"
 
 #: admin/index.html
-msgid ""
-"<span class=\"login-counts\">0</span> patrons have logged in at least once "
-"over the past 30 days."
-msgstr ""
-"<span class=\"login-counts\">0</span> korisnika se prijavilo barem jednom u "
-"zadnjih 30 dana."
+msgid "<span class=\"login-counts\">0</span> patrons have logged in at least once over the past 30 days."
+msgstr "<span class=\"login-counts\">0</span> korisnika se prijavilo barem jednom u zadnjih 30 dana."
 
 #: admin/index.html
 msgid "Stats"
@@ -2970,16 +2645,11 @@ msgstr "Prikupljanje statistike prijava …"
 msgid "BookReader"
 msgstr "BookReader"
 
-#: admin/loans_table.html book_providers/cita_press_download_options.html
-#: book_providers/ia_download_options.html
-#: book_providers/openstax_download_options.html
-#: book_providers/wikisource_download_options.html books/edit/edition.html
+#: admin/loans_table.html book_providers/cita_press_download_options.html book_providers/ia_download_options.html book_providers/openstax_download_options.html book_providers/wikisource_download_options.html books/edit/edition.html
 msgid "PDF"
 msgstr "PDF"
 
-#: admin/loans_table.html book_providers/gutenberg_download_options.html
-#: book_providers/ia_download_options.html
-#: book_providers/standard_ebooks_download_options.html books/edit/edition.html
+#: admin/loans_table.html book_providers/gutenberg_download_options.html book_providers/ia_download_options.html book_providers/standard_ebooks_download_options.html books/edit/edition.html
 msgid "ePub"
 msgstr "ePub"
 
@@ -2995,9 +2665,7 @@ msgstr[0] "%d aktualna posudba"
 msgstr[1] "%d aktualne posudbe"
 msgstr[2] "%d aktualnih posudbi"
 
-#: RecentChanges.html RecentChangesUsers.html admin/ip/view.html
-#: admin/loans_table.html admin/people/edits.html recentchanges/render.html
-#: recentchanges/updated_records.html
+#: RecentChanges.html RecentChangesUsers.html admin/ip/view.html admin/loans_table.html admin/people/edits.html recentchanges/render.html recentchanges/updated_records.html
 msgid "What"
 msgstr "Što"
 
@@ -3009,8 +2677,7 @@ msgstr "Čekam od %(date)s"
 #: admin/loans_table.html
 #, python-format
 msgid "#%(num_position)d among %(num_waitlist)d people waiting for this book"
-msgstr ""
-"%(num_position)d. na redu od %(num_waitlist)d ljudi koji čekaju na ovu knjigu"
+msgstr "%(num_position)d. na redu od %(num_waitlist)d ljudi koji čekaju na ovu knjigu"
 
 #: ManageLoansButtons.html admin/loans_table.html
 #, python-format
@@ -3021,10 +2688,7 @@ msgstr "Posuđeno %(date)s"
 msgid "Admin Center"
 msgstr "Centar za administratore"
 
-#: RelatedSubjects.html SubjectTags.html admin/menu.html
-#: admin/people/index.html admin/people/view.html
-#: openlibrary/plugins/worksearch/code.py type/author/view.html
-#: type/list/view_body.html
+#: RelatedSubjects.html SubjectTags.html admin/menu.html admin/people/index.html admin/people/view.html openlibrary/plugins/worksearch/code.py type/author/view.html type/list/view_body.html
 msgid "People"
 msgstr "Osobe"
 
@@ -3113,12 +2777,8 @@ msgid "Update permissions"
 msgstr "Dozvole za aktualiziranje"
 
 #: admin/permissions.html
-msgid ""
-"This updates \"permission\" and \"child_permission\" fields of /, /works, /"
-"books and /authors records in the database."
-msgstr ""
-"Ovo aktualizira polja „dozvola“ i „dozvola za djecu“ za /, /djela, /knjige "
-"i /autori u bazi podataka."
+msgid "This updates \"permission\" and \"child_permission\" fields of /, /works, /books and /authors records in the database."
+msgstr "Ovo aktualizira polja „dozvola“ i „dozvola za djecu“ za /, /djela, /knjige i /autori u bazi podataka."
 
 #: admin/solr.html
 msgid "Solr Admin"
@@ -3133,12 +2793,8 @@ msgid "Example:"
 msgstr "Primjer:"
 
 #: admin/solr.html
-msgid ""
-"On update, these keys will be added to solr update queue and it'll take "
-"about 15 minutes for them to get reindexed in Solr."
-msgstr ""
-"Nakon aktualiziranja će se ovi ključevi dodati u red aktualiziranja Solr "
-"platforme i trebat će oko 15 minuta da se ponovo indeksiraju u Solru."
+msgid "On update, these keys will be added to solr update queue and it'll take about 15 minutes for them to get reindexed in Solr."
+msgstr "Nakon aktualiziranja će se ovi ključevi dodati u red aktualiziranja Solr platforme i trebat će oko 15 minuta da se ponovo indeksiraju u Solru."
 
 #: admin/solr.html
 msgid "Enter the keys to reindex in Solr"
@@ -3153,16 +2809,11 @@ msgid "[Admin Center] Spam Words"
 msgstr "[Centar za administratore] Spam riječi"
 
 #: admin/spamwords.html
-msgid ""
-"Please enter the SPAM regular expressions in the textarea below, one per "
-"line."
-msgstr ""
-"Upiši regularne izraze za spam u donje područje teksta, jedan po retku."
+msgid "Please enter the SPAM regular expressions in the textarea below, one per line."
+msgstr "Upiši regularne izraze za spam u donje područje teksta, jedan po retku."
 
 #: admin/spamwords.html
-msgid ""
-"Be sure to escape any meta characters that are meant to be character "
-"literals."
+msgid "Be sure to escape any meta characters that are meant to be character literals."
 msgstr "Označi sve meta znakove koji se tretiraju kao doslovni znakovi."
 
 #: admin/spamwords.html
@@ -3170,12 +2821,9 @@ msgid "If you are adding a domain, prepend the following to the domain:"
 msgstr "Ako dodaješ domenu, domeni dodaj sljedeće:"
 
 #: admin/spamwords.html
-msgid ""
-"For example, if you want to prevent edits containing the domain <code>t.co</"
-"code>, add <code>(\b|https://|http://)t\\.co</code> to the spamwords list."
+#, fuzzy
+msgid "For example, if you want to prevent edits containing the domain <code>t.co</code>, add <code>(|https://|http://)t\\.co</code> to the spamwords list."
 msgstr ""
-"Na primjer, ako želiš spriječiti uređivanja koja sadrže domenu <code>t.co</"
-"code>, dodaj <code>(\b|https://|http://)t\\.co</code> u popis spam riječi."
 
 #: admin/spamwords.html
 msgid "Spam Domains"
@@ -3183,38 +2831,23 @@ msgstr "Spam domene"
 
 #: admin/spamwords.html
 msgid "Please enter domains to blacklist in the textarea below, one per line."
-msgstr ""
-"Upiši domene u popis blokiranih u donje područje teksta, jednu po retku."
+msgstr "Upiši domene u popis blokiranih u donje područje teksta, jednu po retku."
 
 #: admin/sync.html
 msgid "Sync"
 msgstr "Sinkronizraj"
 
 #: admin/sync.html
-msgid ""
-"Sync the metadata of various types of Open Library items (e.g. lists, "
-"subjects, works) with Archive.org."
-msgstr ""
-"Sinkroniziraj metapodatke različitih vrsta Open Library predmeta (npr. "
-"popisa, tema, djela) s Archive.org."
+msgid "Sync the metadata of various types of Open Library items (e.g. lists, subjects, works) with Archive.org."
+msgstr "Sinkroniziraj metapodatke različitih vrsta Open Library predmeta (npr. popisa, tema, djela) s Archive.org."
 
 #: admin/sync.html
 msgid "Add Works to Staff Picks"
 msgstr "Dodaj djela u izbor zaposlenika"
 
 #: admin/sync.html
-msgid ""
-"This utility will add your work to an Open Library list called `Staff Picks` "
-"under the `openlibrary` user. It will then take the added work and explode "
-"it into a list of all its readable editions. For each Open Library edition, "
-"a metadata field called `openlibrary_subject` will be injected into the "
-"archive.org metadata of the edition's corresponding archive.org item."
-msgstr ""
-"Ovaj alat dodaje tvoj rad na Open Library popis pod nazivom `Izbor "
-"zaposlenika` pod korisnikom `openlibrary`. Zatim će uzeti dodatni rad i "
-"pretvoriti ga u popis svih njegovih čitljivih izdanja. Za svako Open Library "
-"izdanje, polje metapodataka nazvano `openlibrary_subject` će se umetnuti u "
-"archive.org metapodatke odgovarajućeg predmeta izdanja na archive.org."
+msgid "This utility will add your work to an Open Library list called `Staff Picks` under the `openlibrary` user. It will then take the added work and explode it into a list of all its readable editions. For each Open Library edition, a metadata field called `openlibrary_subject` will be injected into the archive.org metadata of the edition's corresponding archive.org item."
+msgstr "Ovaj alat dodaje tvoj rad na Open Library popis pod nazivom `Izbor zaposlenika` pod korisnikom `openlibrary`. Zatim će uzeti dodatni rad i pretvoriti ga u popis svih njegovih čitljivih izdanja. Za svako Open Library izdanje, polje metapodataka nazvano `openlibrary_subject` će se umetnuti u archive.org metapodatke odgovarajućeg predmeta izdanja na archive.org."
 
 #: admin/sync.html
 msgid "add"
@@ -3229,12 +2862,8 @@ msgid "Update edition"
 msgstr "Aktualiziraj izdanje"
 
 #: admin/sync.html
-msgid ""
-"Updates an edition on archive.org by writing in its latest  "
-"openlibrary_edition and openlibrary_work identifier values"
-msgstr ""
-"Aktualizira izdanje na archive.org unosom najnovijih vrijednosti "
-"identifikatora „openlibrary_edition“ i „openlibrary_work“"
+msgid "Updates an edition on archive.org by writing in its latest  openlibrary_edition and openlibrary_work identifier values"
+msgstr "Aktualizira izdanje na archive.org unosom najnovijih vrijednosti identifikatora „openlibrary_edition“ i „openlibrary_work“"
 
 #: admin/sync.html
 msgid "TODO"
@@ -3249,20 +2878,12 @@ msgid "Inspect Memcache"
 msgstr "Pregledaj Memcache"
 
 #: admin/inspect/memcache.html
-msgid ""
-"Add one memcache key per line in the text area. Each key must include a '-' "
-"as the last character."
-msgstr ""
-"Dodaj jedan memcache ključ po retku u tekstualno područje. Svaka ključ mora "
-"sadržati „-“ kao zadnji znak."
+msgid "Add one memcache key per line in the text area. Each key must include a '-' as the last character."
+msgstr "Dodaj jedan memcache ključ po retku u tekstualno područje. Svaka ključ mora sadržati „-“ kao zadnji znak."
 
 #: admin/inspect/memcache.html
-msgid ""
-"For example, <code>observations-</code> should be entered in the text area "
-"if the key is <code>observations</code>."
-msgstr ""
-"Na primjer, upiši <code>observations-</code> u tekstualno područje ako je "
-"ključ <code>observations</code>."
+msgid "For example, <code>observations-</code> should be entered in the text area if the key is <code>observations</code>."
+msgstr "Na primjer, upiši <code>observations-</code> u tekstualno područje ako je ključ <code>observations</code>."
 
 #: admin/inspect/memcache.html
 msgid "Keys:"
@@ -3378,10 +2999,8 @@ msgstr "Blokiraj %(ip)s"
 msgid "Please select the changesets to revert."
 msgstr "Odaberi skupove promjena koje želiš vratiti."
 
-#: RecentChanges.html admin/ip/view.html admin/people/edits.html
-#: recentchanges/render.html
-msgid ""
-"When you see numbers here, that's the IP address of the anonymous editor"
+#: RecentChanges.html admin/ip/view.html admin/people/edits.html recentchanges/render.html
+msgid "When you see numbers here, that's the IP address of the anonymous editor"
 msgstr "Kada ovdje vidiš brojeve, to je IP adresa anonimnog urednika"
 
 #: admin/ip/view.html admin/people/edits.html
@@ -3390,12 +3009,8 @@ msgid "Reverted by %(revert_author)s"
 msgstr "Vraćeno od %(revert_author)s"
 
 #: EditButtons.html admin/ip/view.html admin/people/edits.html
-msgid ""
-"Please, leave a short note about what you changed: <span class=\"small "
-"gray\">(Optional, but very useful!)</span>"
-msgstr ""
-"Zapiši kratku napomenu o tvojim promjenama: <span class=\"small "
-"gray\">(Opcionalano, ali vrlo korisno!)</span>"
+msgid "Please, leave a short note about what you changed: <span class=\"small gray\">(Optional, but very useful!)</span>"
+msgstr "Zapiši kratku napomenu o tvojim promjenama: <span class=\"small gray\">(Opcionalano, ali vrlo korisno!)</span>"
 
 #: admin/ip/view.html admin/people/edits.html
 msgid "Reverted spam"
@@ -3481,12 +3096,8 @@ msgstr "prijavi se kao ovaj korisnik"
 
 #: admin/people/view.html
 #, python-format
-msgid ""
-"Activated on <span class=\"time\">%(date)s</span> from <a href=\"/admin/ip/"
-"%(ip)s\">%(ip)s</a>."
-msgstr ""
-"Aktiviran <span class=\"time\">%(date)s</span> od <a href=\"/admin/ip/"
-"%(ip)s\">%(ip)s</a>."
+msgid "Activated on <span class=\"time\">%(date)s</span> from <a href=\"/admin/ip/%(ip)s\">%(ip)s</a>."
+msgstr "Aktiviran <span class=\"time\">%(date)s</span> od <a href=\"/admin/ip/%(ip)s\">%(ip)s</a>."
 
 #: admin/people/view.html
 msgid "unblock this account"
@@ -3495,19 +3106,6 @@ msgstr "deblokiraj ovaj račun"
 #: admin/people/view.html
 msgid "activate account"
 msgstr "aktiviraj račun"
-
-#: admin/people/view.html
-#, python-format
-msgid "Activation link expiring on <span class=\"time\">%(date)s.</span>"
-msgstr "Poveznica za aktivaciju isteče <span class=\"time\">.%(date)s</span>"
-
-#: admin/people/view.html
-msgid "Activation link expired"
-msgstr "Poveznica za aktivaciju je istekla"
-
-#: admin/people/view.html
-msgid "Resend activation link"
-msgstr "Ponovo pošalji poveznicu za aktivaciju"
 
 #: CreateListModal.html admin/people/view.html my_books/dropdown_content.html
 msgid "Name:"
@@ -3565,8 +3163,7 @@ msgstr "Probni rad"
 msgid "Anonymize Account"
 msgstr "Anonimiziraj račun"
 
-#: admin/people/view.html books/mybooks_breadcrumb_select.html
-#: openlibrary/plugins/upstream/account.py type/user/view.html
+#: admin/people/view.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py type/user/view.html
 msgid "Loans"
 msgstr "Posudbe"
 
@@ -3599,8 +3196,7 @@ msgstr "Poveznica za potvrđivanje"
 msgid "None found"
 msgstr "Ništa nije pronađeno"
 
-#: SearchNavigation.html authors/index.html lib/nav_foot.html
-#: merge/authors.html publishers/view.html
+#: SearchNavigation.html authors/index.html lib/nav_foot.html merge/authors.html publishers/view.html
 msgid "Authors"
 msgstr "Autori"
 
@@ -3608,9 +3204,7 @@ msgstr "Autori"
 msgid "Search for an Author"
 msgstr "Traži autora"
 
-#: authors/index.html lib/nav_head.html lists/home.html publishers/index.html
-#: publishers/notfound.html publishers/view.html search/advancedsearch.html
-#: search/publishers.html search/searchbox.html type/local_id/view.html
+#: authors/index.html lib/nav_head.html lists/home.html publishers/index.html publishers/notfound.html publishers/view.html search/advancedsearch.html search/publishers.html search/searchbox.html type/local_id/view.html
 msgid "Search"
 msgstr "Traži"
 
@@ -3637,14 +3231,7 @@ msgstr "Rođen/a"
 msgid "Died"
 msgstr "Umro/la"
 
-#: book_providers/cita_press_download_options.html
-#: book_providers/gutenberg_download_options.html
-#: book_providers/ia_download_options.html
-#: book_providers/librivox_download_options.html
-#: book_providers/openstax_download_options.html
-#: book_providers/runeberg_download_options.html
-#: book_providers/standard_ebooks_download_options.html
-#: book_providers/wikisource_download_options.html
+#: book_providers/cita_press_download_options.html book_providers/gutenberg_download_options.html book_providers/ia_download_options.html book_providers/librivox_download_options.html book_providers/openstax_download_options.html book_providers/runeberg_download_options.html book_providers/standard_ebooks_download_options.html book_providers/wikisource_download_options.html
 msgid "Download Options"
 msgstr "Opcije za preuzimanje"
 
@@ -3660,9 +3247,7 @@ msgstr "Više na Cita Press"
 msgid "Download an HTML from Project Gutenberg"
 msgstr "Preuzmi HTML verziju od Project Gutenberg"
 
-#: book_providers/gutenberg_download_options.html
-#: book_providers/runeberg_download_options.html
-#: book_providers/standard_ebooks_download_options.html type/list/exports.html
+#: book_providers/gutenberg_download_options.html book_providers/runeberg_download_options.html book_providers/standard_ebooks_download_options.html type/list/exports.html
 msgid "HTML"
 msgstr "HTML"
 
@@ -3670,8 +3255,7 @@ msgstr "HTML"
 msgid "Download a text version from Project Gutenberg"
 msgstr "Preuzmi tekstualnu verziju od Project Gutenberg"
 
-#: book_providers/gutenberg_download_options.html
-#: book_providers/ia_download_options.html
+#: book_providers/gutenberg_download_options.html book_providers/ia_download_options.html
 msgid "Plain text"
 msgstr "Neformatirani tekst"
 
@@ -3713,8 +3297,7 @@ msgstr "MOBI"
 
 #: book_providers/ia_download_options.html
 msgid "Download open DAISY from Internet Archive (print-disabled format)"
-msgstr ""
-"Preuzmi DAISY datoteku od Internet Archive (format za slijepe/slabovidne)"
+msgstr "Preuzmi DAISY datoteku od Internet Archive (format za slijepe/slabovidne)"
 
 #: book_providers/ia_download_options.html type/list/embed.html
 msgid "DAISY"
@@ -3882,20 +3465,12 @@ msgid "Invalid ISBN checksum digit"
 msgstr "Neispravna znamenka ISBN-a"
 
 #: books/add.html
-msgid ""
-"ID must be exactly 10 characters [0-9 or X]. For example 0-19-853453-1 or "
-"0198534531"
-msgstr ""
-"ID-oznaka mora imati točno 10 znakova [0 – 9 ili X]. Na primjer: "
-"0-19-853453-1 ili 0198534531"
+msgid "ID must be exactly 10 characters [0-9 or X]. For example 0-19-853453-1 or 0198534531"
+msgstr "ID-oznaka mora imati točno 10 znakova [0 – 9 ili X]. Na primjer: 0-19-853453-1 ili 0198534531"
 
 #: books/add.html
-msgid ""
-"ID must be exactly 13 characters [0-9]. For example 978-3-16-148410-0 or "
-"9783161484100"
-msgstr ""
-"ID-oznaka mora imati točno 13 znakova [0 – 9]. Na primjer: 978-3-16-148410-0 "
-"ili 9783161484100"
+msgid "ID must be exactly 13 characters [0-9]. For example 978-3-16-148410-0 or 9783161484100"
+msgstr "ID-oznaka mora imati točno 13 znakova [0 – 9]. Na primjer: 978-3-16-148410-0 ili 9783161484100"
 
 #: books/add.html
 msgid "Invalid LC Control Number format"
@@ -3918,28 +3493,20 @@ msgid "Add a book to Open Library"
 msgstr "Dodaj knjigu u Open Library"
 
 #: books/add.html
-msgid ""
-"We require a minimum set of fields to create a new record. These are those "
-"fields."
-msgstr ""
-"Za stvaranje novog zapisa potreban je određen broj polja. Ovo su ta polja."
+msgid "We require a minimum set of fields to create a new record. These are those fields."
+msgstr "Za stvaranje novog zapisa potreban je određen broj polja. Ovo su ta polja."
 
 #: books/add.html books/edit.html
 msgid "Use <b><i>Title: Subtitle</i></b> to add a subtitle."
 msgstr "Za dodavanje podnaslova koristi <b><i>Naslov: Podnaslov</i></b>."
 
-#: books/add.html books/edit.html type/author/edit.html
-#: type/tag/tag_form_inputs.html
+#: books/add.html books/edit.html type/author/edit.html type/tag/tag_form_inputs.html
 msgid "Required field"
 msgstr "Obavezno polje"
 
 #: books/add.html
-msgid ""
-"Like, \"Agatha Christie\" or \"Jean-Paul Sartre.\" We'll also do a live "
-"check to see if we already know the author."
-msgstr ""
-"Na primjer „Agatha Christie” ili „Jean-Paul Sartre”. Također ćemo provjeriti "
-"je li već poznamo autora."
+msgid "Like, \"Agatha Christie\" or \"Jean-Paul Sartre.\" We'll also do a live check to see if we already know the author."
+msgstr "Na primjer „Agatha Christie” ili „Jean-Paul Sartre”. Također ćemo provjeriti je li već poznamo autora."
 
 #: books/add.html books/edit/edition.html
 msgid "Who is the publisher?"
@@ -3962,8 +3529,7 @@ msgid "You should be able to find this in the first few pages of the book."
 msgstr "Ovo bi se trebalo moći pronaći na prvim stranicama knjige."
 
 #: books/add.html
-msgid ""
-"And optionally, an ID number &#151; like an ISBN &#151; would be helpful..."
+msgid "And optionally, an ID number &#151; like an ISBN &#151; would be helpful..."
 msgstr "Opcionalno dodaj ID-oznaku poput ISBN-a …"
 
 #: books/add.html
@@ -4012,16 +3578,8 @@ msgstr "Ispuni ovo samo ako se radi o web knjizi"
 
 #: books/add.html
 #, python-format
-msgid ""
-"By saving a change to this wiki, you agree that your contribution is given "
-"freely to the world under <a href=\"https://creativecommons.org/publicdomain/"
-"zero/1.0/\" target=\"_blank\" rel=\"noopener noreferrer\" "
-"title=\"%(cc_link_title)s\">CC0</a>."
-msgstr ""
-"Spremanjem promjena na ovoj wiki-stranici prihvaćaš da je cijeli svijet "
-"slobodno koristi pod licencom <a href=\"https://creativecommons.org/"
-"publicdomain/zero/1.0/\" target=\"_blank\" rel=\"noopener noreferrer\" "
-"title=\"%(cc_link_title)s\">CC0</a>."
+msgid "By saving a change to this wiki, you agree that your contribution is given freely to the world under <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" target=\"_blank\" rel=\"noopener noreferrer\" title=\"%(cc_link_title)s\">CC0</a>."
+msgstr "Spremanjem promjena na ovoj wiki-stranici prihvaćaš da je cijeli svijet slobodno koristi pod licencom <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" target=\"_blank\" rel=\"noopener noreferrer\" title=\"%(cc_link_title)s\">CC0</a>."
 
 #: books/add.html
 msgid "This link to Creative Commons will open in a new window"
@@ -4053,27 +3611,18 @@ msgstr "Dodaj knjigu"
 
 #: books/check.html
 #, python-format
-msgid ""
-"One moment... It looks like we already have <em>some potential matches</em> "
-"for <b>%(title)s</b> by <b>%(author)s</b>."
-msgstr ""
-"Samo malo … Čini se da već imamo <em>neka moguća podudaranja</em> za "
-"<b>%(title)s</b>, autora <b>%(author)s</b>."
+msgid "One moment... It looks like we already have <em>some potential matches</em> for <b>%(title)s</b> by <b>%(author)s</b>."
+msgstr "Samo malo … Čini se da već imamo <em>neka moguća podudaranja</em> za <b>%(title)s</b>, autora <b>%(author)s</b>."
 
 #: books/check.html
-msgid ""
-"Rather than creating a duplicate record, please click through the result you "
-"think best matches your book."
-msgstr ""
-"Umjesto dupliciranja zapisa, pritisni rezultat za koji misliš da se najbolje "
-"podudara s tvojom knjigom."
+msgid "Rather than creating a duplicate record, please click through the result you think best matches your book."
+msgstr "Umjesto dupliciranja zapisa, pritisni rezultat za koji misliš da se najbolje podudara s tvojom knjigom."
 
 #: books/check.html
 msgid "Select this book"
 msgstr "Odaberi ovu knjigu"
 
-#: SearchResultsWork.html books/check.html merge/authors.html
-#: publishers/view.html
+#: SearchResultsWork.html books/check.html merge/authors.html publishers/view.html
 #, python-format
 msgid "%(count)s edition"
 msgid_plural "%(count)s editions"
@@ -4090,7 +3639,7 @@ msgstr "Prvi put izdano %(year)d."
 msgid "None of these match the book I want to add."
 msgstr "Ništa ne odgovara knjizi koju želim dodati."
 
-#: books/check.html
+#: books/check.html design/button.html
 msgid "Continue"
 msgstr "Nastavi"
 
@@ -4116,66 +3665,21 @@ msgid "There isn't a DAISY file available for "
 msgstr "Ne postoji DAISY datoteka za "
 
 #: books/daisy.html
-msgid "This DAISY file is protected."
-msgstr "Ova je DAISY datoteka zaštićena."
-
-#: books/daisy.html
-msgid ""
-"It can only be opened on a specialized device with a key issued by the "
-"Library of Congress."
-msgstr ""
-"Može se otvoriti samo na specijaliziranom uređaju s ključem koji je izdala "
-"knjižnica „Library of Congress“."
-
-#: books/daisy.html
 #, python-format
-msgid ""
-"<a href=\"%(daisy_url)s\"><strong>Download the DAISY.zip</strong></a> for <a "
-"href=\"%(url)s\">%(title)s</a>"
-msgstr ""
-"<a href=\"%(daisy_url)s\"><strong>Preuzmi DAISY.zip</strong></a> za <a "
-"href=\"%(url)s\">%(title)s</a>"
+msgid "<a href=\"%(daisy_url)s\"><strong>Download the DAISY.zip</strong></a> for <a href=\"%(url)s\">%(title)s</a>"
+msgstr "<a href=\"%(daisy_url)s\"><strong>Preuzmi DAISY.zip</strong></a> za <a href=\"%(url)s\">%(title)s</a>"
 
 #: books/daisy.html
 msgid "Books for people who don't read print?"
 msgstr "Knjige za slijepe/slabovidne osobe?"
 
 #: books/daisy.html
-msgid ""
-"The <a href=\"//archive.org\">Internet Archive</a> is proud to be "
-"distributing over 1 million books free in a format called DAISY, designed "
-"for those of us who find it challenging to use regular printed media. "
-msgstr ""
-"<a href=\"//archive.org\">Internet Archive</a> je ponosan što besplatno "
-"distribuira više od milijun knjiga u DAISY formatu, koji je namijenjen za "
-"slijepe/slabovidne osobe."
+msgid "The <a href=\"//archive.org\">Internet Archive</a> is proud to be distributing over 1 million books free in a format called DAISY, designed for those of us who find it challenging to use regular printed media. "
+msgstr "<a href=\"//archive.org\">Internet Archive</a> je ponosan što besplatno distribuira više od milijun knjiga u DAISY formatu, koji je namijenjen za slijepe/slabovidne osobe."
 
 #: books/daisy.html
-msgid ""
-"There are two types of DAISYs on Open Library: <i>open</i> and <i>protected</"
-"i>. Open DAISYs can be read by anyone in the world on many different "
-"devices. Protected DAISYs like this one can only be opened using a key "
-"issued by the <a href=\"http://www.loc.gov/nls/\">Library of Congress NLS "
-"program</a>."
-msgstr ""
-"Postoje dvije vrste DAISY-a na Open Library: <i>otvoreni</i> i <i>zaštićeni</"
-"i>. Otvorene DAISY datoteke može čitati svatko na svijetu na različitim "
-"uređajima. Zaštićene DAISY datoteke poput ove se mogu otvoriti samo pomoću "
-"ključa koji je izdao <a href=\"http://www.loc.gov/nls/\">Library of Congress "
-"NLS program</a>."
-
-#: books/daisy.html
-msgid ""
-"There are two types of DAISYs on Open Library: <i>open</i> and <i>protected</"
-"i>. Open DAISYs can be read by anyone in the world on many different "
-"devices. Protected DAISYs can only be opened using a key issued by the <a "
-"href=\"http://www.loc.gov/nls/\">Library of Congress NLS program</a>."
-msgstr ""
-"Postoje dvije vrste DAISY-a na Open Library: <i>otvoreni</i> i <i>zaštićeni</"
-"i>. Otvorene DAISY datoteke može čitati svatko na svijetu na različitim "
-"uređajima. Zaštićene DAISY datoteke se mogu otvoriti samo pomoću ključa koji "
-"je izdao <a href=\"http://www.loc.gov/nls/\">Library of Congress NLS "
-"program</a>."
+msgid "There are two types of DAISYs on Open Library: <i>open</i> and <i>protected</i>. Open DAISYs can be read by anyone in the world on many different devices. Protected DAISYs can only be opened using a key issued by the <a href=\"http://www.loc.gov/nls/\">Library of Congress NLS program</a>."
+msgstr "Postoje dvije vrste DAISY-a na Open Library: <i>otvoreni</i> i <i>zaštićeni</i>. Otvorene DAISY datoteke može čitati svatko na svijetu na različitim uređajima. Zaštićene DAISY datoteke se mogu otvoriti samo pomoću ključa koji je izdao <a href=\"http://www.loc.gov/nls/\">Library of Congress NLS program</a>."
 
 #: books/daisy.html lists/home.html
 msgid "Enjoy!"
@@ -4186,16 +3690,8 @@ msgid "What is the DAISY format?"
 msgstr "Što je DAISY format?"
 
 #: books/daisy.html
-msgid ""
-"The DAISY digital format helps people who have challenges using regular "
-"printed media. DAISY digital <span class=\"highlight\">talking books</span> "
-"offer the benefits of regular audiobooks, with navigation within the book, "
-"to chapters or specific pages."
-msgstr ""
-"Digitalni format DAISY pomaže ljudima koji imaju poteškoća s korištenjem "
-"običnih tiskanih medija. Digitalne DAISY <span class=\"highlight\">knjige "
-"koje govore</span> nude prednosti običnih audio knjiga, s navigacijom unutar "
-"knjige na poglavlja ili na određene stranice."
+msgid "The DAISY digital format helps people who have challenges using regular printed media. DAISY digital <span class=\"highlight\">talking books</span> offer the benefits of regular audiobooks, with navigation within the book, to chapters or specific pages."
+msgstr "Digitalni format DAISY pomaže ljudima koji imaju poteškoća s korištenjem običnih tiskanih medija. Digitalne DAISY <span class=\"highlight\">knjige koje govore</span> nude prednosti običnih audio knjiga, s navigacijom unutar knjige na poglavlja ili na određene stranice."
 
 #: books/daisy.html
 msgid "More information at daisy.org"
@@ -4206,18 +3702,8 @@ msgid "What is the NLS?"
 msgstr "Što je NLS?"
 
 #: books/daisy.html
-msgid ""
-"The Library of Congress <a href=\"http://www.loc.gov/nls/\">National Library "
-"Service for the Blind and Physically Handicapped (NLS)</a> administers a "
-"free library program of braille and audio materials circulated to eligible "
-"borrowers in the United States through a national network of cooperating "
-"libraries."
-msgstr ""
-"<a href=\"http://www.loc.gov/nls/\">Služba nacionalne knjižnice za slijepe i "
-"tjelesno hendikepirane (NLS)</a> knjižnice „Library of Congress“ upravlja "
-"besplatnom knjižničnom građom u brajici i audio materijalima koji se "
-"distribuiraju kvalificiranim zajmoprimcima u SAD-u putem nacionalne mreže "
-"surađujućih knjižnica."
+msgid "The Library of Congress <a href=\"http://www.loc.gov/nls/\">National Library Service for the Blind and Physically Handicapped (NLS)</a> administers a free library program of braille and audio materials circulated to eligible borrowers in the United States through a national network of cooperating libraries."
+msgstr "<a href=\"http://www.loc.gov/nls/\">Služba nacionalne knjižnice za slijepe i tjelesno hendikepirane (NLS)</a> knjižnice „Library of Congress“ upravlja besplatnom knjižničnom građom u brajici i audio materijalima koji se distribuiraju kvalificiranim zajmoprimcima u SAD-u putem nacionalne mreže surađujućih knjižnica."
 
 #: books/daisy.html
 msgid "Are you eligible to register?"
@@ -4228,76 +3714,44 @@ msgid "How do I find DAISYs on Open Library?"
 msgstr "Kako mogu pronaći DAISY datoteke na Open Library?"
 
 #: books/daisy.html
-msgid ""
-"In addition to<a href=\"/subjects/accessible_book\" title=\"Subject: "
-"Accessible book\"> loads of open DAISYs</a>, the Open Library lists a "
-"smaller selection of<a href=\"/subjects/protected_DAISY\" title=\"Subject: "
-"Protected DAISY\"> protected DAISY titles</a> accessible to those with a "
-"Library of Congress NLS key. These titles are brought to you by the<a "
-"href=\"//archive.org/\"> Internet Archive</a>."
-msgstr ""
-"Pored <a href=\"/subjects/accessible_book\" title=\"Predmet: Dostupne "
-"knjige\">mnogih otvorenih DAISY-a</a>, Open Library navodi manji izbor <a "
-"href=\"/subjects/protected_DAISY\" title=\"Predmet: Zaštićeni "
-"DAISY\">zaštićenih DAISY naslova</a> koji su dostupni osobama s Library of "
-"Congress NLS ključem. Ove naslove pruža <a href=\"//archive.org/\">Internet "
-"Archive</a>."
+msgid "In addition to<a href=\"/subjects/accessible_book\" title=\"Subject: Accessible book\"> loads of open DAISYs</a>, the Open Library lists a smaller selection of<a href=\"/subjects/protected_DAISY\" title=\"Subject: Protected DAISY\"> protected DAISY titles</a> accessible to those with a Library of Congress NLS key. These titles are brought to you by the<a href=\"//archive.org/\"> Internet Archive</a>."
+msgstr "Pored <a href=\"/subjects/accessible_book\" title=\"Predmet: Dostupne knjige\">mnogih otvorenih DAISY-a</a>, Open Library navodi manji izbor <a href=\"/subjects/protected_DAISY\" title=\"Predmet: Zaštićeni DAISY\">zaštićenih DAISY naslova</a> koji su dostupni osobama s Library of Congress NLS ključem. Ove naslove pruža <a href=\"//archive.org/\">Internet Archive</a>."
 
 #: books/daisy.html
-msgid ""
-"Looking for a specific title? The best way to find it is to<a href=\"/"
-"search\"> search for it</a>."
-msgstr ""
-"Tražiš određeni naslov? Najbolji način za pronalaženje je<a href=\"/"
-"search\"> da ga tražiš</a>."
+msgid "Looking for a specific title? The best way to find it is to<a href=\"/search\"> search for it</a>."
+msgstr "Tražiš određeni naslov? Najbolji način za pronalaženje je<a href=\"/search\"> da ga tražiš</a>."
 
 #: books/daisy.html lib/exports.html
 msgid "Need help?"
 msgstr "Trebaš pomoć?"
 
 #: books/daisy.html
-msgid ""
-" Please read our <a href=\"/help/faq\">FAQ on accessing books through Open "
-"Library</a>."
-msgstr ""
-"Pročitaj naša <a href=\"/help/faq\">često postavljena pitanja o pristupu "
-"knjigama putem Open Library</a>."
+msgid " Please read our <a href=\"/help/faq\">FAQ on accessing books through Open Library</a>."
+msgstr "Pročitaj naša <a href=\"/help/faq\">često postavljena pitanja o pristupu knjigama putem Open Library</a>."
 
 #: books/edit.html
 msgid "Add a little more?"
 msgstr "Želiš li dodati još malo više?"
 
 #: books/edit.html
-msgid ""
-"Thank you for adding that book! Any more information you could provide would "
-"be wonderful!"
+msgid "Thank you for adding that book! Any more information you could provide would be wonderful!"
 msgstr "Hvala ti na dodavanju te knjige! Svi dodatni podaci su dobrodošli!"
 
 #: books/edit.html
 #, python-format
-msgid ""
-"We already know about <b>%(work_title)s</b>, but not the <b>%(year)s "
-"%(publisher)s edition</b>. Thanks! Do you know any more about this edition?"
-msgstr ""
-"Već poznamo <b>%(work_title)s</b>, ali ne poznamo <b>izdanje izdavača "
-"%(publisher)s od %(year)s. godine</b>. Hvala! Imaš li još podataka o ovom "
-"izdanju?"
+msgid "We already know about <b>%(work_title)s</b>, but not the <b>%(year)s %(publisher)s edition</b>. Thanks! Do you know any more about this edition?"
+msgstr "Već poznamo <b>%(work_title)s</b>, ali ne poznamo <b>izdanje izdavača %(publisher)s od %(year)s. godine</b>. Hvala! Imaš li još podataka o ovom izdanju?"
 
 #: books/edit.html
 #, python-format
-msgid ""
-"We already know about the <b>%(year)s %(publisher)s edition</b> of "
-"<b>%(work_title)s</b>, but please, tell us more!"
-msgstr ""
-"Već poznamo <b>izdanje izdavača %(publisher)s od %(year)s. godine</b> za "
-"<b>%(work_title)s</b>, ali nam slobodno pošalji još podataka!"
+msgid "We already know about the <b>%(year)s %(publisher)s edition</b> of <b>%(work_title)s</b>, but please, tell us more!"
+msgstr "Već poznamo <b>izdanje izdavača %(publisher)s od %(year)s. godine</b> za <b>%(work_title)s</b>, ali nam slobodno pošalji još podataka!"
 
 #: books/edit.html
 msgid "Editing..."
 msgstr "Uređivanje …"
 
-#: books/edit.html type/author/edit.html type/tag/form.html
-#: type/template/edit.html
+#: books/edit.html type/author/edit.html type/tag/form.html type/template/edit.html
 msgid "Delete Record"
 msgstr "Izbriži zapis"
 
@@ -4314,14 +3768,8 @@ msgid "This Work"
 msgstr "Ovo djelo"
 
 #: books/edit.html
-msgid ""
-"You can search by author name (like <em>j k rowling</em>) or by Open Library "
-"ID (like <a href=\"/authors/OL23919A\" target=\"_blank\" rel=\"noopener "
-"noreferrer\"><em>OL23919A</em></a>)."
-msgstr ""
-"Možeš tražiti po imenu autora (poput <em>j k rowling</em>) ili po Open "
-"Library ID-oznaci (poput <a href=\"/authors/OL23919A\" target=\"_blank\" "
-"rel=\"noopener noreferrer\"><em>OL23919A</em></a>)."
+msgid "You can search by author name (like <em>j k rowling</em>) or by Open Library ID (like <a href=\"/authors/OL23919A\" target=\"_blank\" rel=\"noopener noreferrer\"><em>OL23919A</em></a>)."
+msgstr "Možeš tražiti po imenu autora (poput <em>j k rowling</em>) ili po Open Library ID-oznaci (poput <a href=\"/authors/OL23919A\" target=\"_blank\" rel=\"noopener noreferrer\"><em>OL23919A</em></a>)."
 
 #: books/edit.html
 msgid "Author editing requires javascript"
@@ -4340,15 +3788,8 @@ msgid "Work Series"
 msgstr "Radna serija"
 
 #: books/edit.html
-msgid ""
-"Series are currently in beta, and this section is only visible to super "
-"librarians and admins, like you! Any series you set will be visible by "
-"everyone, however. Please report any issues you have on Slack or GitHub."
-msgstr ""
-"Serije su trenutačno u beta fazi, a ovaj je odjeljak vidljiv samo super "
-"knjižničarima i administratorima, poput tebe! Međutim, svaka od tebe "
-"postavljena serija će svi vidjeti. Prijavi sve probleme koje imaš na Slacku "
-"ili GitHubu."
+msgid "Series are currently in beta, and this section is only visible to super librarians and admins, like you! Any series you set will be visible by everyone, however. Please report any issues you have on Slack or GitHub."
+msgstr "Serije su trenutačno u beta fazi, a ovaj je odjeljak vidljiv samo super knjižničarima i administratorima, poput tebe! Međutim, svaka od tebe postavljena serija će svi vidjeti. Prijavi sve probleme koje imaš na Slacku ili GitHubu."
 
 #: books/edit.html
 msgid "Is this work part of a larger series?"
@@ -4367,19 +3808,10 @@ msgid "Do you know any identifiers for this work?"
 msgstr "Poznaš li bilo koji identifikator za ovo djelo?"
 
 #: books/edit.html
-msgid ""
-"These identifiers apply to all editions of this work, for example Wikidata "
-"work identifiers. For edition-specific identifiers, like ISBN or LCCN, go to "
-"the edition tab."
-msgstr ""
-"Ovi se identifikatori primjenjuju na sva izdanja ovog djela, na primjer "
-"Wikidata identifikatore djela. Za identifikatore specifičnih izdanja, kao "
-"što su ISBN ili LCCN idi na kartici izdanja."
+msgid "These identifiers apply to all editions of this work, for example Wikidata work identifiers. For edition-specific identifiers, like ISBN or LCCN, go to the edition tab."
+msgstr "Ovi se identifikatori primjenjuju na sva izdanja ovog djela, na primjer Wikidata identifikatore djela. Za identifikatore specifičnih izdanja, kao što su ISBN ili LCCN idi na kartici izdanja."
 
-#: FulltextSearchSuggestionItem.html IABook.html SearchResultsWork.html
-#: books/edition-sort.html jsdef/LazyWorkPreview.html lists/list_overview.html
-#: lists/preview.html lists/snippet.html lists/widget.html
-#: my_books/dropdown_content.html type/work/editions.html
+#: FulltextSearchSuggestionItem.html IABook.html SearchResultsWork.html books/edition-sort.html jsdef/LazyWorkPreview.html lists/list_overview.html lists/preview.html lists/snippet.html lists/widget.html my_books/dropdown_content.html type/work/editions.html
 #, python-format
 msgid "Cover of: %(title)s"
 msgstr "Naslovnica za: %(title)s"
@@ -4399,34 +3831,48 @@ msgstr "Datum izdavanja nepoznat, %(publisher)s"
 msgid "in %(languagelist)s"
 msgstr "na %(languagelist)s"
 
-#: SearchNavigation.html books/mybooks_breadcrumb_select.html lib/nav_foot.html
-#: openlibrary/plugins/upstream/mybooks.py
+#: SearchNavigation.html books/mybooks_breadcrumb_select.html lib/nav_foot.html openlibrary/plugins/upstream/mybooks.py
 msgid "Books"
 msgstr "Knjige"
 
+#. Page title for the "Want to Read" shelf page.
+#. Example: "Want to Read (17)". %(count)d is the number of books on this
+#. shelf.
 #: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #, python-format
 msgid "Want to Read (%(count)d)"
 msgstr "Želim čitati (%(count)d)"
 
+#. Page title for the "Currently Reading" shelf page.
+#. Example: "Currently Reading (42)". %(count)d is the number of books on this
+#. shelf.
 #: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #, python-format
 msgid "Currently Reading (%(count)d)"
 msgstr "Trenutačno čitam (%(count)d)"
 
+#. Page title for the "Already Read" shelf page.
+#. Example: "Already Read (203)". %(count)d is the number of books on this
+#. shelf.
 #: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #, python-format
 msgid "Already Read (%(count)d)"
 msgstr "Već pročitano (%(count)d)"
 
-#: books/mybooks_breadcrumb_select.html
-#: openlibrary/plugins/openlibrary/lists.py
+#. Page title for the "Stopped Reading" shelf page.
+#. Example: "Stopped Reading (8)". %(count)d is the number of books on this
+#. shelf.
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#, fuzzy, python-format
+msgid "Stopped Reading (%(count)d)"
+msgstr "Trenutačno čitam (%(count)d)"
+
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/openlibrary/lists.py
 #, python-format
 msgid "Lists (%(count)d)"
 msgstr "Popisi (%(count)d)"
 
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
-#: type/edition/modal_links.html
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py type/edition/modal_links.html
 msgid "Notes"
 msgstr "Napomene"
 
@@ -4475,56 +3921,32 @@ msgid "Please separate with commas."
 msgstr "Odvoji zarezima."
 
 #: books/edit/about.html
-msgid ""
-"For example: <i><a href=\"/subjects/cheese\">cheese</a>, <a href=\"/subjects/"
-"roman_empire\">Roman Empire</a>, <a href=\"/subjects/"
-"psychology\">psychology</a></i>"
-msgstr ""
-"Na primjer: <i><a href=\"/subjects/cheese\">sir</a>, <a href=\"/subjects/"
-"roman_empire\">Rimsko carstvo</a>, <a href=\"/subjects/"
-"psychology\">psihologija</a></i>"
+msgid "For example: <i><a href=\"/subjects/cheese\">cheese</a>, <a href=\"/subjects/roman_empire\">Roman Empire</a>, <a href=\"/subjects/psychology\">psychology</a></i>"
+msgstr "Na primjer: <i><a href=\"/subjects/cheese\">sir</a>, <a href=\"/subjects/roman_empire\">Rimsko carstvo</a>, <a href=\"/subjects/psychology\">psihologija</a></i>"
 
 #: books/edit/about.html
 msgid "A person? Or, people?"
 msgstr "Osoba? Ili ljudi?"
 
 #: books/edit/about.html
-msgid ""
-"For example: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore "
-"Roosevelt</a>, <a href=\"/subjects/person:Julian_of_Norwich\">Julian of "
-"Norwich</a>, <a href=\"/subjects/person:Tintin\">Tintin</a></i>"
-msgstr ""
-"Na primjer: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore "
-"Roosevelt</a>, <a href=\"/subjects/person:Julian_of_Norwich\">Julian of "
-"Norwich</a>, <a href=\"/subjects/person:Tintin\">Tintin</a></i>"
+msgid "For example: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore Roosevelt</a>, <a href=\"/subjects/person:Julian_of_Norwich\">Julian of Norwich</a>, <a href=\"/subjects/person:Tintin\">Tintin</a></i>"
+msgstr "Na primjer: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore Roosevelt</a>, <a href=\"/subjects/person:Julian_of_Norwich\">Julian of Norwich</a>, <a href=\"/subjects/person:Tintin\">Tintin</a></i>"
 
 #: books/edit/about.html
 msgid "Note any places mentioned?"
 msgstr "Želiš li zabilježiti neka spomenuta mjesta?"
 
 #: books/edit/about.html
-msgid ""
-"For example: <i><a href=\"/subjects/place:London\">London</a>, <a href=\"/"
-"subjects/place:Atlantis\">Atlantis</a>, <a href=\"/subjects/"
-"place:Omaha\">Omaha</a></i>"
-msgstr ""
-"Na primjer: <i><a href=\"/subjects/place:London\">London</a>, <a href=\"/"
-"subjects/place:Atlantis\">Atlantis</a>, <a href=\"/subjects/"
-"place:Omaha\">Omaha</a></i>"
+msgid "For example: <i><a href=\"/subjects/place:London\">London</a>, <a href=\"/subjects/place:Atlantis\">Atlantis</a>, <a href=\"/subjects/place:Omaha\">Omaha</a></i>"
+msgstr "Na primjer: <i><a href=\"/subjects/place:London\">London</a>, <a href=\"/subjects/place:Atlantis\">Atlantis</a>, <a href=\"/subjects/place:Omaha\">Omaha</a></i>"
 
 #: books/edit/about.html
 msgid "When is it set or about?"
 msgstr "Kada se radnja odvija ili o kojem se razdoblju radi?"
 
 #: books/edit/about.html
-msgid ""
-"For example: <i><a href=\"/subjects/time:1984\">1984</a>, <a href=\"/"
-"subjects/time:the_middle_ages\">The Middle Ages</a>, <a href=\"/subjects/"
-"time:1810-1890\">1810-1890</a></i>"
-msgstr ""
-"Na primjer: <i><a href=\"/subjects/time:1984\">1984.</a>, <a href=\"/"
-"subjects/time:the_middle_ages\">Srednji vijek</a>, <a href=\"/subjects/"
-"time:1810-1890\">1810. – 1890.</a></i>"
+msgid "For example: <i><a href=\"/subjects/time:1984\">1984</a>, <a href=\"/subjects/time:the_middle_ages\">The Middle Ages</a>, <a href=\"/subjects/time:1810-1890\">1810-1890</a></i>"
+msgstr "Na primjer: <i><a href=\"/subjects/time:1984\">1984.</a>, <a href=\"/subjects/time:the_middle_ages\">Srednji vijek</a>, <a href=\"/subjects/time:1810-1890\">1810. – 1890.</a></i>"
 
 #: books/edit/edition.html
 msgid "Select this language"
@@ -4687,21 +4109,12 @@ msgid "Table of Contents"
 msgstr "Sadržaj"
 
 #: books/edit/edition.html
-msgid ""
-"Use a \"*\" for an indent, a \"|\" to add a column, and line breaks for new "
-"lines. Like this:"
-msgstr ""
-"Koristi „*” za uvlačenje, „|” za dodavnaje stupca i prelamanje redaka. Ovako:"
+msgid "Use a \"*\" for an indent, a \"|\" to add a column, and line breaks for new lines. Like this:"
+msgstr "Koristi „*” za uvlačenje, „|” za dodavnaje stupca i prelamanje redaka. Ovako:"
 
 #: books/edit/edition.html
-msgid ""
-"This table of contents contains extra information like authors or "
-"descriptions. We don't have a great user interface for this yet, so editing "
-"this data could be difficult. Watch out!"
-msgstr ""
-"Ovaj sadržaj sadrži dodatne informacije kao što su autori ili opisi. Još "
-"nemamo sjajno korisničko sučelje za to, stoga bi uređivanje ovih podataka "
-"moglo biti teško. Oprez!"
+msgid "This table of contents contains extra information like authors or descriptions. We don't have a great user interface for this yet, so editing this data could be difficult. Watch out!"
+msgstr "Ovaj sadržaj sadrži dodatne informacije kao što su autori ili opisi. Još nemamo sjajno korisničko sučelje za to, stoga bi uređivanje ovih podataka moglo biti teško. Oprez!"
 
 #: books/edit/edition.html
 msgid "Any notes about this specific edition?"
@@ -4720,43 +4133,24 @@ msgid "Is it known by any other titles?"
 msgstr "Je li poznato pod drugim naslovom?"
 
 #: books/edit/edition.html
-msgid ""
-"Use this field if the title is different on the cover or spine. If the "
-"edition is a collection or anthology, you may also add the individual titles "
-"of each work here."
-msgstr ""
-"Koristi ovo polje, ako je naslov drugačiji na naslovnici ili hrptu. Ako je "
-"izdanje zbirka ili antologija, ovdje možeš dodati i pojedinačne naslove "
-"svakog djela."
+msgid "Use this field if the title is different on the cover or spine. If the edition is a collection or anthology, you may also add the individual titles of each work here."
+msgstr "Koristi ovo polje, ako je naslov drugačiji na naslovnici ili hrptu. Ako je izdanje zbirka ili antologija, ovdje možeš dodati i pojedinačne naslove svakog djela."
 
 #: books/edit/edition.html
-msgid ""
-"For example: <i>Eaters of the Dead</i> is an alternate title for <i><a "
-"href=\"/books/OL24923038M\">The 13th Warrior</a></i>."
-msgstr ""
-"Na primjer: <i>Eaters of the Dead</i> je alternativni naslov za <i><a "
-"href=\"/books/OL24923038M\">The 13th Warrior</a></i>."
+msgid "For example: <i>Eaters of the Dead</i> is an alternate title for <i><a href=\"/books/OL24923038M\">The 13th Warrior</a></i>."
+msgstr "Na primjer: <i>Eaters of the Dead</i> je alternativni naslov za <i><a href=\"/books/OL24923038M\">The 13th Warrior</a></i>."
 
 #: books/edit/edition.html
 msgid "What work is this an edition of?"
 msgstr "Kojem djelu pripada ovo izdanje?"
 
 #: books/edit/edition.html
-msgid ""
-"Sometimes editions can be associated with the wrong work. You can correct "
-"that here."
-msgstr ""
-"Izdanja su ponekad povezana s pogrešnim djelom. To se može odvje ispraviti."
+msgid "Sometimes editions can be associated with the wrong work. You can correct that here."
+msgstr "Izdanja su ponekad povezana s pogrešnim djelom. To se može odvje ispraviti."
 
 #: books/edit/edition.html
-msgid ""
-"You can search by title or by Open Library ID (like <a href=\"/works/"
-"OL262757W\" target=\"_blank\" rel=\"noopener noreferrer\"><em>OL262757W</"
-"em></a>)."
-msgstr ""
-"Možeš tražiti po naslovu ili po Open Library ID-u (poput <a href=\"/works/"
-"OL262757W\" target=\"_blank\" rel=\"noopener noreferrer\"><em>OL262757W</"
-"em></a>)."
+msgid "You can search by title or by Open Library ID (like <a href=\"/works/OL262757W\" target=\"_blank\" rel=\"noopener noreferrer\"><em>OL262757W</em></a>)."
+msgstr "Možeš tražiti po naslovu ili po Open Library ID-u (poput <a href=\"/works/OL262757W\" target=\"_blank\" rel=\"noopener noreferrer\"><em>OL262757W</em></a>)."
 
 #: books/edit/edition.html
 msgid "WARNING: Any edits made to the work from this page will be ignored."
@@ -4792,8 +4186,7 @@ msgstr "Taj ID već postoji za ovo izdanje."
 
 #: books/edit/edition.html
 msgid "ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4"
-msgstr ""
-"ID-oznaka mora imati točno 13 znamenki [0-9]. Na primjer: 978-1-56619-909-4"
+msgstr "ID-oznaka mora imati točno 13 znamenki [0-9]. Na primjer: 978-1-56619-909-4"
 
 #: books/edit/edition.html
 msgid "Invalid ID format"
@@ -4945,8 +4338,7 @@ msgstr "Dodatni metapodaci"
 
 #: books/edit/edition.html
 msgid "This field can accept arbitrary key:value pairs"
-msgstr ""
-"Ovo polje može prihvatiti proizvoljne parove za ključ:vrijednosti (key:value)"
+msgstr "Ovo polje može prihvatiti proizvoljne parove za ključ:vrijednosti (key:value)"
 
 #: books/edit/excerpts.html
 msgid "Please provide an excerpt."
@@ -4957,12 +4349,8 @@ msgid "That excerpt is too long."
 msgstr "Izvadak je predug."
 
 #: books/edit/excerpts.html
-msgid ""
-"If there are particular (short) passages you feel represent the book well, "
-"please feel free to transcribe them here."
-msgstr ""
-"Ako postoje određeni (kratki) odlomci za koje smatraš da dobro predstavljaju "
-"knjigu, slobodno ih ovdje zapiši."
+msgid "If there are particular (short) passages you feel represent the book well, please feel free to transcribe them here."
+msgstr "Ako postoje određeni (kratki) odlomci za koje smatraš da dobro predstavljaju knjigu, slobodno ih ovdje zapiši."
 
 #: books/edit/excerpts.html
 msgid "Page number?"
@@ -5021,12 +4409,8 @@ msgid "Please enter a valid URL."
 msgstr "Navedi ispravnu URL adresu."
 
 #: books/edit/web.html
-msgid ""
-"Please connect Open Library records to <u>good</u><span class=\"orange\">*</"
-"span> online resources."
-msgstr ""
-"Poveži Open Library zapise s <u>dobrim</u><span class=\"orange\">*</span> "
-"internetskim resursima."
+msgid "Please connect Open Library records to <u>good</u><span class=\"orange\">*</span> online resources."
+msgstr "Poveži Open Library zapise s <u>dobrim</u><span class=\"orange\">*</span> internetskim resursima."
 
 #: books/edit/web.html
 msgid "Give your link a label"
@@ -5049,13 +4433,8 @@ msgid "Remove this link"
 msgstr "Ukloni ovu poveznicu"
 
 #: books/edit/web.html
-msgid ""
-"\"Good\" means no spammy links, please. Keep them relevant to the book. "
-"Irrelevant sites may be removed. Blatant spam will be deleted without "
-"remorse."
-msgstr ""
-"„Dobre” poveznice znači da su relevantne za knjigu. Irelevatne web-stranice "
-"će se možda ukloniti. Očiti spam će se izbrisati bez grižnje savjesti."
+msgid "\"Good\" means no spammy links, please. Keep them relevant to the book. Irrelevant sites may be removed. Blatant spam will be deleted without remorse."
+msgstr "„Dobre” poveznice znači da su relevantne za knjigu. Irelevatne web-stranice će se možda ukloniti. Očiti spam će se izbrisati bez grižnje savjesti."
 
 #: bulk_search/bulk_search.html search/advancedsearch.html
 msgid "Bulk Search (beta)"
@@ -5071,8 +4450,7 @@ msgstr "Smjernice za slike"
 
 #: covers/add.html
 msgid "There are a few ways to put a cover image on Open Library."
-msgstr ""
-"Postoji nekoliko načina za postavljanje slika naslovnica na Open Library."
+msgstr "Postoji nekoliko načina za postavljanje slika naslovnica na Open Library."
 
 #: covers/add.html
 msgid "Cover Guidelines"
@@ -5088,12 +4466,8 @@ msgstr "Zadaj URL adresu slike."
 
 #: covers/add.html
 #, python-format
-msgid ""
-"Learn more by reading our <a href=\"/help/faq/editing#picture\" "
-"target=\"blank\">%(guidelines)s</a>."
-msgstr ""
-"Saznaj više. Pročitaj naše <a href=\"/help/faq/editing#picture\" "
-"target=\"blank\">%(guidelines)s</a>."
+msgid "Learn more by reading our <a href=\"/help/faq/editing#picture\" target=\"blank\">%(guidelines)s</a>."
+msgstr "Saznaj više. Pročitaj naše <a href=\"/help/faq/editing#picture\" target=\"blank\">%(guidelines)s</a>."
 
 #: covers/add.html
 msgid "<strong>Pick one</strong> from the existing covers"
@@ -5205,17 +4579,13 @@ msgid "Manage"
 msgstr "Upravljaj"
 
 #: covers/external_image.html
-#, python-format
-msgid "Or, use a cover from %s"
+#, fuzzy, python-format
+msgid "Or, use an image from %s"
 msgstr "Ili koristi naslovnicu od %s"
 
 #: covers/manage.html
-msgid ""
-"You can drag and drop thumbnails to reorder, or into the trash to delete "
-"them."
-msgstr ""
-"Povuci-i-ispusti minijature za mijenjanje redoslijeda ili za premještanja u "
-"smeće."
+msgid "You can drag and drop thumbnails to reorder, or into the trash to delete them."
+msgstr "Povuci-i-ispusti minijature za mijenjanje redoslijeda ili za premještanja u smeće."
 
 #: covers/saved.html
 msgid "New book cover"
@@ -5237,32 +4607,129 @@ msgstr "Dodaj jednu drugu sliku"
 msgid "Finished"
 msgstr "Završeno"
 
+#: design/banner.html
+#, python-format
+msgid "The %(tag)s component is a callout-style announcement banner. The announcement is server-rendered into the default slot — already translated, visible to search engines — while the component owns the chrome: variant styling, icon, dismissal, and cookie persistence. There is intentionally no entrance animation; banners appear on every page view."
+msgstr "Komponenta %(tag)s je baner za obavijesti u stilu natpisa. Obavijest se prikazuje na poslužitelju u zadani utor — već prevedena, vidljiva tražilicama — dok komponenta upravlja izgledom: stiliziranjem varijante, ikonom, odbacivanjem i trajnošću kolačića. Namjerno nema animacije ulaska; baneri se prikazuju pri svakom učitavanju stranice."
+
+#: design/banner.html
+msgid "Variants"
+msgstr "Varijante"
+
+#: design/banner.html
+#, python-format
+msgid "Use %(variant)s for semantic variants. Each pairs a tinted surface with a filled icon circle — the same icon treatment as %(toast)s."
+msgstr "Koristite %(variant)s za semantičke varijante. Svaka spaja obojenu površinu s ispunjenim krugom ikone — isti tretman ikone kao i %(toast)s."
+
+#: design/banner.html
+msgid "Open Library is a non-profit project of the Internet Archive."
+msgstr "Open Library je neprofitni projekt Internet Archivea."
+
+#: design/banner.html
+msgid "Your import finished — 42 books added to your reading log."
+msgstr "Vaš uvoz je završen — 42 knjige dodane su u vaš dnevnik čitanja."
+
+#: design/banner.html
+msgid "Open Library will be briefly unavailable on June 12 for maintenance."
+msgstr "Open Library će biti kratko nedostupna 12. lipnja zbog održavanja."
+
+#: design/banner.html
+msgid "Search is currently degraded. Some results may be missing."
+msgstr "Pretraživanje je trenutačno ograničeno. Neki rezultati mogu nedostajati."
+
+#: design/banner.html
+msgid "Appearance"
+msgstr "Izgled"
+
+#: design/banner.html
+#, python-format
+msgid "Use %(appearance)s to control the frame. %(outlined)s (default) has a border and rounded corners. %(plain)s removes both — useful when the banner abuts the edges of other UI, like the top of the page or a card."
+msgstr "Koristite %(appearance)s za kontrolu okvira. %(outlined)s (zadano) ima obrub i zaobljene kutove. %(plain)s uklanja oboje — korisno kada baner dodiruje rubove drugog sučelja, poput vrha stranice ili kartice."
+
+#: design/banner.html
+msgid "Outlined (default): border and rounded corners."
+msgstr "Ocrtano (zadano): obrub i zaobljeni kutovi."
+
+#: design/banner.html
+msgid "Plain: no border, no border radius."
+msgstr "Jednostavno: bez obruba, bez zaobljenja rubova."
+
+#: design/banner.html
+#, fuzzy
+msgid "Dismissible"
+msgstr "Deaktiviraj"
+
+#: design/banner.html
+#, python-format
+msgid "Add %(dismissible)s for a close button. Without %(cookie_name)s, dismissal only lasts for the current page. Content comes from the page template, so links and emphasis work as usual."
+msgstr "Dodajte %(dismissible)s za gumb za zatvaranje. Bez %(cookie_name)s, odbacivanje traje samo za trenutnu stranicu. Sadržaj dolazi iz predloška stranice, pa veze i isticanje rade normalno."
+
+#: design/banner.html
+#, fuzzy
+msgid "Explore our new collections"
+msgstr "Istraži zbirke"
+
+#: design/banner.html
+#, fuzzy
+msgid "Custom icon"
+msgstr "Prilagođeni tekst gumba"
+
+#: design/banner.html
+#, python-format
+msgid "Slot a custom icon via %(slot)s to replace the variant's built-in glyph."
+msgstr "Umetnite prilagođenu ikonu putem %(slot)s kako biste zamijenili ugrađeni gliph varijante."
+
+#: design/banner.html
+#, fuzzy
+msgid "Set your Yearly Reading Goal"
+msgstr "Postavi godišnji cilj čitanja"
+
+#: design/banner.html
+msgid "Persisted dismissal"
+msgstr "Trajno odbacivanje"
+
+#: design/banner.html
+#, python-format
+msgid "The component owns no persistence — it only fires %(event)s with its %(dismiss_id)s. Two pieces of site plumbing make dismissals stick: the template guards rendering on the dismissal cookie (so dismissed banners are never served), and a site-level listener (%(glue)s) POSTs dismissals to %(endpoint)s, which sets that cookie. Per-banner TTL rides on the element as %(ttl)s — an OL convention, not component API. Dismiss this banner, reload, and it stays hidden until reset."
+msgstr "Komponenta ne posjeduje trajnost — samo aktivira %(event)s sa svojim %(dismiss_id)s. Dva dijela infrastrukture stranice osiguravaju trajnost odbacivanja: predložak čuva renderiranje na kolačiću za odbacivanje (tako da odbačeni baneri nikad nisu isporučeni), a slušač na razini stranice (%(glue)s) šalje POST odbacivanja na %(endpoint)s, koji postavlja taj kolačić. TTL po baneru nalazi se na elementu kao %(ttl)s — OL konvencija, nije API komponente. Odbacite ovaj baner, učitajte ponovo i ostaje skriven do ponovnog postavljanja."
+
+#: design/banner.html
+#, fuzzy
+msgid "Set your 2026 Yearly Reading Goal"
+msgstr "Postavi godišnji cilj čitanja"
+
+#: design/banner.html
+msgid "Reset dismissed demo banner"
+msgstr "Vrati odbačeni demo baner"
+
+#: design/banner.html
+msgid "Dismiss event"
+msgstr "Događaj odbacivanja"
+
+#: design/banner.html
+#, python-format
+msgid "The banner fires %(event)s once when dismissed, before it is removed from the DOM. Banners without a %(dismiss_id)s are page-only: they still fire the event, but the site listener ignores them."
+msgstr "Baner aktivira %(event)s jednom pri odbacivanju, prije nego što bude uklonjen iz DOM-a. Baneri bez %(dismiss_id)s su samo za stranicu: i dalje aktiviraju događaj, ali ga slušač stranice ignorira."
+
+#: design/button.html merge/authors.html recentchanges/merge/view.html
+msgid "Primary"
+msgstr "Primarni"
+
 #: design/popover.html
 msgid "Popover component"
 msgstr "Komponenta skočnog prozora"
 
 #: design/popover.html
-msgid ""
-"The ol-popover component provides a reusable animated popover panel anchored "
-"to a trigger element. It animates from the trigger using transform-origin, "
-"closes on Escape or outside click, and respects prefers-reduced-motion."
-msgstr ""
-"Komponenta „ol-popover” pruža ponovo koristivu animiranu skočnu ploču koja "
-"je pričvršćena na element pokrteača. Animacija se pokreče koristeći "
-"„transform-origin”, zatvara se tipkom Escape ili vanjskim klikom i poštuje "
-"„prefers-reduced-motion.”"
+msgid "The ol-popover component provides a reusable animated popover panel anchored to a trigger element. It animates from the trigger using transform-origin, closes on Escape or outside click, and respects prefers-reduced-motion."
+msgstr "Komponenta „ol-popover” pruža ponovo koristivu animiranu skočnu ploču koja je pričvršćena na element pokrteača. Animacija se pokreče koristeći „transform-origin”, zatvara se tipkom Escape ili vanjskim klikom i poštuje „prefers-reduced-motion.”"
 
 #: design/popover.html
 msgid "Menu popover"
 msgstr "Skočni prozor izbornika"
 
 #: design/popover.html
-msgid ""
-"Popovers animate from the trigger using transform-origin. Click the button "
-"to see the scale + fade entrance."
-msgstr ""
-"Skočni prozori se animiraju iz pokretača koristeći „transform-origin”. "
-"Klikni na gumb za prikaz skaliranja i postupnog prijelaza."
+msgid "Popovers animate from the trigger using transform-origin. Click the button to see the scale + fade entrance."
+msgstr "Skočni prozori se animiraju iz pokretača koristeći „transform-origin”. Klikni na gumb za prikaz skaliranja i postupnog prijelaza."
 
 #: design/popover.html
 msgid "Options"
@@ -5286,14 +4753,8 @@ msgstr "Opcije smještaja"
 
 #: design/popover.html
 #, python-format
-msgid ""
-"Use %(placement)s to control where the popover appears. The "
-"%(transform_origin)s automatically matches so the animation always expands "
-"from the trigger."
-msgstr ""
-"Koristi %(placement)s za kontroliranje mjesta pojavljivanja skočnog prozora. "
-"%(transform_origin)s se automatski podudara pa se animacija uvijek širi od "
-"pokretača."
+msgid "Use %(placement)s to control where the popover appears. The %(transform_origin)s automatically matches so the animation always expands from the trigger."
+msgstr "Koristi %(placement)s za kontroliranje mjesta pojavljivanja skočnog prozora. %(transform_origin)s se automatski podudara pa se animacija uvijek širi od pokretača."
 
 #: design/popover.html
 msgid "bottom-start"
@@ -5302,6 +4763,91 @@ msgstr "dolje-start"
 #: design/popover.html
 msgid "top-center"
 msgstr "gore-centrirano"
+
+#: design/toast.html
+#, python-format
+msgid "The %(tag)s component is a transient notification message. It announces itself to screen readers, auto-dismisses after a timeout (pausing on hover/focus), and removes itself from the DOM when closed. Message content is set via the %(message)s and %(description)s attributes, already translated; rich content can be slotted instead. The component's only owned string is the close button label, overridable via %(attr)s."
+msgstr "Komponenta %(tag)s je privremena poruka obavijesti. Objavljuje se čitačima zaslona, automatski se odbacuje nakon isteka vremena (pausira pri prelasku miša/fokusa) i uklanja se iz DOM-a pri zatvaranju. Sadržaj poruke postavlja se putem atributa %(message)s i %(description)s, već prevedenih; umjesto toga može se umetnuti bogati sadržaj. Jedini string koji posjeduje komponenta je oznaka gumba za zatvaranje, koja se može nadjačati putem %(attr)s."
+
+#: design/toast.html
+#, fuzzy
+msgid "Types"
+msgstr "Vrsta"
+
+#: design/toast.html
+#, python-format
+msgid "Use %(type)s for semantic variants. Errors are announced assertively (%(role)s)."
+msgstr "Koristite %(type)s za semantičke varijante. Pogreške se objavljuju asertivno (%(role)s)."
+
+#: design/toast.html
+#, fuzzy
+msgid "Saved to your reading log"
+msgstr "Pretraži tvoj dnevnik čitanja"
+
+#: design/toast.html
+msgid "Subjects successfully updated"
+msgstr "Teme su uspješno ažurirane"
+
+#: design/toast.html
+#, fuzzy
+msgid "Could not update list. Please try again later."
+msgstr "Neuspjelo aktualiziranje pratitelja. Pokušaj ponovo malo kasnije."
+
+#: design/toast.html
+#, fuzzy
+msgid "Description and rich content"
+msgstr "Opis ovog izdanja"
+
+#: design/toast.html
+#, python-format
+msgid "Use %(description)s for an optional secondary line. For uncommon rich content (links, custom markup), author the markup in an inert %(template)s element in the page template — where %(i18n)s extraction works — and pass that element to %(helper)s; its content is cloned into the toast. Node(s) built in JS also work. Nothing is ever parsed from a runtime string as HTML."
+msgstr "Koristite %(description)s za neobavezni drugi red. Za neuobičajeni bogati sadržaj (veze, prilagođeni markup), napišite markup u inertnom elementu %(template)s u predlošku stranice — gdje radi ekstrakcija %(i18n)s — i proslijedite taj element %(helper)s; njegov sadržaj klonira se u toast. Node(ovi) izgrađeni u JS-u također rade. Ništa se nikada ne parsira iz runtime stringa kao HTML."
+
+#: design/toast.html
+#, fuzzy
+msgid "Relaunch to update"
+msgstr "aktualno"
+
+#: design/toast.html
+msgid "Could not save."
+msgstr "Nije moguće spremiti."
+
+#: design/toast.html
+#, fuzzy
+msgid "Get help"
+msgstr "Trebaš pomoć?"
+
+#: design/toast.html
+msgid "Imperative use (fixed bottom-center stack)"
+msgstr "Imperativna upotreba (fiksirani skup na dnu centra)"
+
+#: design/toast.html
+#, python-format
+msgid "JavaScript callers use the exported %(helper)s helper, which stacks toasts in a shared fixed %(region)s anchored to the bottom-center of the viewport. New toasts slide up from below; older ones slide up to make room, forming a simple vertical list. Toasts dismiss themselves after %(timeout)s milliseconds (default 4000) unless %(persistent)s. Hover or focus the list to pause every toast's dismiss timer. The message is set as an attribute — always text, never HTML — and should already be translated."
+msgstr "Pozivatelji u JavaScriptu koriste izvezenog %(helper)s pomoćnika, koji slaže toaste u zajednički fiksirani %(region)s usidreni na dnu centra vidnog polja. Novi toasti klize gore odozdo; stariji klize gore kako bi napravili mjesta, čineći jednostavni vertikalni popis. Toasti se sami odbacuju nakon %(timeout)s milisekundi (zadano 4000) osim ako nije %(persistent)s. Prijeđite mišem ili fokusirajte popis kako biste pauzirali odbrojač svakog toasta. Poruka se postavlja kao atribut — uvijek tekst, nikad HTML — i treba već biti prevedena."
+
+#: design/toast.html
+#, fuzzy
+msgid "Add toast"
+msgstr "Dodaj u popis"
+
+#: design/toast.html
+msgid "Add persistent error toast"
+msgstr "Dodaj trajnu obavijest o pogrešci"
+
+#: design/toast.html
+msgid "Add rich content toast"
+msgstr "Dodaj obavijest s bogatim sadržajem"
+
+#: design/toast.html
+#, fuzzy
+msgid "Close event"
+msgstr "Zatvoreni zahtjev"
+
+#: design/toast.html
+#, fuzzy, python-format
+msgid "The toast fires %(event)s once when it begins closing, with the reason in %(detail)s."
+msgstr "Urednik pokreće %(event)s događaj pri svakoj promjeni. Markdown izraz je dostupan u %(detail)s."
 
 #: email/case_created.html
 msgid "Sent!"
@@ -5312,12 +4858,8 @@ msgid "Thank you for your note. We'll get back to you as soon as possible."
 msgstr "Hvala ti na napomeni. Javit ćemo ti se u najkraćem mogućem roku."
 
 #: email/case_created.html
-msgid ""
-"It might take us a little while to read it because we receive lots of "
-"messages, but rest assured we will, and we'll get back to you if required."
-msgstr ""
-"Možda će malo potrajati da je pročitamo jer primamo puno poruka. Mi ćemo je "
-"svakako pročitati te ćemo ti se javiti ako bude potrebno."
+msgid "It might take us a little while to read it because we receive lots of messages, but rest assured we will, and we'll get back to you if required."
+msgstr "Možda će malo potrajati da je pročitamo jer primamo puno poruka. Mi ćemo je svakako pročitati te ćemo ti se javiti ako bude potrebno."
 
 #: email/account/pd_request.html
 msgid "Qualifying for Print Disability Special Access"
@@ -5332,28 +4874,16 @@ msgid "About the Project"
 msgstr "Informacije o projektu"
 
 #: home/about.html
-msgid ""
-"Open Library is an open, editable library catalog, building towards a web "
-"page for every book ever published."
-msgstr ""
-"Open Library je otvoren i urediv knjižnični katalog, smišljen za izradu web-"
-"stranice za svaku ikada izdanu knjigu."
+msgid "Open Library is an open, editable library catalog, building towards a web page for every book ever published."
+msgstr "Open Library je otvoren i urediv knjižnični katalog, smišljen za izradu web-stranice za svaku ikada izdanu knjigu."
 
 #: AffiliateLinks.html home/about.html search/work_search_facets.html
 msgid "More"
 msgstr "Više"
 
 #: home/about.html
-msgid ""
-"Just like Wikipedia, you can contribute new information or corrections to "
-"the catalog. You can browse by <a href=\"/subjects\">subjects</a>, <a "
-"href=\"/authors\">authors</a> or <a href=\"/lists\">lists</a> members have "
-"created. If you love books, why not help build a library?"
-msgstr ""
-"Baš kao i kod Wikipedije, katalog možeš nadopuniti i ispravljati. Možeš "
-"pregledati po <a href=\"/subjects\">područjima</a>, <a href=\"/"
-"authors\">autorima</a> ili <a href=\"/lists\">popisima</a> koje su stvorili "
-"članovi. Ako voliš knjige, pomogni izgraditi knjižnicu!"
+msgid "Just like Wikipedia, you can contribute new information or corrections to the catalog. You can browse by <a href=\"/subjects\">subjects</a>, <a href=\"/authors\">authors</a> or <a href=\"/lists\">lists</a> members have created. If you love books, why not help build a library?"
+msgstr "Baš kao i kod Wikipedije, katalog možeš nadopuniti i ispravljati. Možeš pregledati po <a href=\"/subjects\">područjima</a>, <a href=\"/authors\">autorima</a> ili <a href=\"/lists\">popisima</a> koje su stvorili članovi. Ako voliš knjige, pomogni izgraditi knjižnicu!"
 
 #: home/about.html
 msgid "Latest Blog Posts"
@@ -5383,8 +4913,7 @@ msgstr "Klasične knjige"
 msgid "Recently Returned"
 msgstr "Nedavno vraćeno"
 
-#: home/index.html openlibrary/plugins/openlibrary/api.py
-#: openlibrary/plugins/openlibrary/home.py
+#: home/index.html openlibrary/plugins/openlibrary/api.py openlibrary/plugins/openlibrary/home.py
 msgid "Romance"
 msgstr "Romanca"
 
@@ -5396,8 +4925,7 @@ msgstr "Djeca"
 msgid "Thrillers"
 msgstr "Trileri"
 
-#: home/index.html openlibrary/plugins/openlibrary/api.py
-#: openlibrary/plugins/openlibrary/home.py
+#: home/index.html openlibrary/plugins/openlibrary/api.py openlibrary/plugins/openlibrary/home.py
 msgid "Textbooks"
 msgstr "Kompendiji"
 
@@ -5411,41 +4939,23 @@ msgstr "Knjige u lokalnom okruženju"
 
 #: home/loans.html
 #, python-format
-msgid ""
-"You can still <a href=\"/subjects/in_library#ebooks=true\">borrow</a> one "
-"more book until you've hit the limit!"
-msgid_plural ""
-"You can still <a href=\"/subjects/in_library#ebooks=true\">borrow</a> "
-"%(count)d more books until you've hit the limit!"
-msgstr[0] ""
-"Možeš <a href=\"/subjects/in_library#ebooks=true\">posuditi</a> još jednu "
-"knjigu prije nego što dosegneš ograničenje!"
-msgstr[1] ""
-"Možeš <a href=\"/subjects/in_library#ebooks=true\">posuditi</a> još "
-"%(count)d knjige prije nego što dosegneš ograničenje!"
-msgstr[2] ""
-"Možeš <a href=\"/subjects/in_library#ebooks=true\">posuditi</a> još "
-"%(count)d knjiga prije nego što dosegneš ograničenje!"
+msgid "You can still <a href=\"/subjects/in_library#ebooks=true\">borrow</a> one more book until you've hit the limit!"
+msgid_plural "You can still <a href=\"/subjects/in_library#ebooks=true\">borrow</a> %(count)d more books until you've hit the limit!"
+msgstr[0] "Možeš <a href=\"/subjects/in_library#ebooks=true\">posuditi</a> još jednu knjigu prije nego što dosegneš ograničenje!"
+msgstr[1] "Možeš <a href=\"/subjects/in_library#ebooks=true\">posuditi</a> još %(count)d knjige prije nego što dosegneš ograničenje!"
+msgstr[2] "Možeš <a href=\"/subjects/in_library#ebooks=true\">posuditi</a> još %(count)d knjiga prije nego što dosegneš ograničenje!"
 
 #: home/loans.html
-msgid ""
-"You have reached the borrowing limit. Please return a book to checkout "
-"something new."
-msgstr ""
-"Dosegnuo/la si ograničenje posudbi. Vrati jednu knjigu kako bi posudio/la "
-"nešto novo."
+msgid "You have reached the borrowing limit. Please return a book to checkout something new."
+msgstr "Dosegnuo/la si ograničenje posudbi. Vrati jednu knjigu kako bi posudio/la nešto novo."
 
 #: home/stats.html
 msgid "Around the Library"
 msgstr "O knjižnici"
 
 #: home/stats.html
-msgid ""
-"Here's what's happened over the last 28 days. More <a href=\"/"
-"recentchanges\">recent changes</a>"
-msgstr ""
-"Evo što se dogodilo u zadnjih 28 dana. Detaljni prikaz <a href=\"/"
-"recentchanges\">nedavnih promjena</a>"
+msgid "Here's what's happened over the last 28 days. More <a href=\"/recentchanges\">recent changes</a>"
+msgstr "Evo što se dogodilo u zadnjih 28 dana. Detaljni prikaz <a href=\"/recentchanges\">nedavnih promjena</a>"
 
 #: home/stats.html
 msgid "See all visitors to OpenLibrary.org"
@@ -5694,13 +5204,8 @@ msgid " Your new record is in the library. Thank you!"
 msgstr "Tvoj se novi zapis nalazi u knjižnici. Hvala!"
 
 #: lib/message_addbook.html
-msgid ""
-"There are a few other simple things you can add while you're here to improve "
-"your new record quickly, and make it much easier for other people to find "
-"later."
-msgstr ""
-"Postoji još nekoliko jednostavnih stvari koje možeš dodati i na taj način "
-"brzo poboljšati tvoj novi zapis te drugima olakšati da ga kasnije pronađu."
+msgid "There are a few other simple things you can add while you're here to improve your new record quickly, and make it much easier for other people to find later."
+msgstr "Postoji još nekoliko jednostavnih stvari koje možeš dodati i na taj način brzo poboljšati tvoj novi zapis te drugima olakšati da ga kasnije pronađu."
 
 #: lib/message_addbook.html
 msgid "Upload a cover image"
@@ -5794,9 +5299,7 @@ msgstr "Istraži autore"
 msgid "Explore subjects"
 msgstr "Istraži područja"
 
-#: RelatedSubjects.html SearchNavigation.html SubjectTags.html
-#: lib/nav_foot.html lib/nav_head.html openlibrary/plugins/worksearch/code.py
-#: subjects/notfound.html type/author/view.html type/list/view_body.html
+#: RelatedSubjects.html SearchNavigation.html SubjectTags.html lib/nav_foot.html lib/nav_head.html openlibrary/plugins/worksearch/code.py subjects/notfound.html type/author/view.html type/list/view_body.html
 msgid "Subjects"
 msgstr "Područja"
 
@@ -5808,8 +5311,7 @@ msgstr "Istraži zbirke"
 msgid "Collections"
 msgstr "Zbirke"
 
-#: SearchNavigation.html lib/nav_foot.html lib/nav_head.html
-#: search/advancedsearch.html
+#: SearchNavigation.html lib/nav_foot.html lib/nav_head.html search/advancedsearch.html
 msgid "Advanced Search"
 msgstr "Napredna pretraga"
 
@@ -5897,8 +5399,8 @@ msgstr "Open Library na Blueskyu"
 msgid "Twitter"
 msgstr "Twitter"
 
+# | msgid "Open Library Home"
 #: lib/nav_foot.html
-#| msgid "Open Library Home"
 msgid "Open Library on Twitter"
 msgstr "Open Library na Twitteru"
 
@@ -5906,8 +5408,8 @@ msgstr "Open Library na Twitteru"
 msgid "GitHub"
 msgstr "GitHub"
 
+# | msgid "Open Library Home"
 #: lib/nav_foot.html
-#| msgid "Open Library Home"
 msgid "Open Library on GitHub"
 msgstr "Open Library na GitHub-u"
 
@@ -5920,29 +5422,13 @@ msgid "Open Library logo"
 msgstr "Open Library logotip"
 
 #: lib/nav_foot.html
-msgid ""
-"Open Library is an initiative of the <a href=\"//archive.org/\">Internet "
-"Archive</a>, a 501(c)(3) non-profit, building a digital library of Internet "
-"sites and other cultural artifacts in  digital form. Other <a href=\"//"
-"archive.org/projects/\">projects</a> include the <a href=\"//archive.org/web/"
-"\">Wayback Machine</a>, <a href=\"//archive.org/\">archive.org</a> and <a "
-"href=\"//archive-it.org\">archive-it.org</a>"
-msgstr ""
-"Open Library je inicijativa neprofitne organizacije <a href=\"//archive.org/"
-"\">Internet Archive</a>, koja gradi digitalnu knjižnicu internetskih "
-"stranica i drugih kulturnih predmeta u digitalnom obliku. Ostali <a href=\"//"
-"archive.org/projects/\">projekti</a> uključuju <a href=\"//archive.org/web/"
-"\">Wayback Machine</a>, <a href=\"//archive.org/\">archive.org </a> i <a "
-"href=\"//archive-it.org\">archive-it.org</a>"
+msgid "Open Library is an initiative of the <a href=\"//archive.org/\">Internet Archive</a>, a 501(c)(3) non-profit, building a digital library of Internet sites and other cultural artifacts in  digital form. Other <a href=\"//archive.org/projects/\">projects</a> include the <a href=\"//archive.org/web/\">Wayback Machine</a>, <a href=\"//archive.org/\">archive.org</a> and <a href=\"//archive-it.org\">archive-it.org</a>"
+msgstr "Open Library je inicijativa neprofitne organizacije <a href=\"//archive.org/\">Internet Archive</a>, koja gradi digitalnu knjižnicu internetskih stranica i drugih kulturnih predmeta u digitalnom obliku. Ostali <a href=\"//archive.org/projects/\">projekti</a> uključuju <a href=\"//archive.org/web/\">Wayback Machine</a>, <a href=\"//archive.org/\">archive.org </a> i <a href=\"//archive-it.org\">archive-it.org</a>"
 
 #: lib/nav_foot.html
 #, python-format
-msgid ""
-"version <a href=\"https://github.com/internetarchive/openlibrary/commit/"
-"%s\">%s</a>"
-msgstr ""
-"verzija <a href=\"https://github.com/internetarchive/openlibrary/commit/"
-"%s\">%s</a>"
+msgid "version <a href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</a>"
+msgstr "verzija <a href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</a>"
 
 #: lib/nav_head.html
 msgid "Loans, Reading Log, Lists, Stats"
@@ -6025,19 +5511,8 @@ msgid "Search by barcode"
 msgstr "Traži pomoću barkoda"
 
 #: lib/not_logged.html
-msgid ""
-"<strong>You are not <a href=\"/account/login\" title=\"Log in now\">logged "
-"in</a>.</strong> Open Library will record your IP address and include it in "
-"this page's publicly accessible edit history. If you <a href=\"/account/"
-"create\" title=\"Create an Open Library account\">create an account</a>, "
-"your IP address is concealed and you can more easily keep track of all your "
-"edits and additions."
-msgstr ""
-"<strong>Nisi<a href=\"/account/login\" title=\"Prijavi se sada\">prijavljen/"
-"a</a>.</strong>Open Library će zabilježiti tvoju IP adresu i uključiti je u "
-"ovu javno dostupnu povijest promjena. Ako <a href=\"/account/create\" "
-"title=\"Stvori Open Library račun\">otvoriš račun</a>, tvoja se IP adresa "
-"skriva i možeš lakše pratiti sve tvoje promjene i dodavanja."
+msgid "<strong>You are not <a href=\"/account/login\" title=\"Log in now\">logged in</a>.</strong> Open Library will record your IP address and include it in this page's publicly accessible edit history. If you <a href=\"/account/create\" title=\"Create an Open Library account\">create an account</a>, your IP address is concealed and you can more easily keep track of all your edits and additions."
+msgstr "<strong>Nisi<a href=\"/account/login\" title=\"Prijavi se sada\">prijavljen/a</a>.</strong>Open Library će zabilježiti tvoju IP adresu i uključiti je u ovu javno dostupnu povijest promjena. Ako <a href=\"/account/create\" title=\"Stvori Open Library račun\">otvoriš račun</a>, tvoja se IP adresa skriva i možeš lakše pratiti sve tvoje promjene i dodavanja."
 
 #: librarian_dashboard/data_quality_table.html
 msgid "Reload"
@@ -6134,25 +5609,13 @@ msgid "Create a list of any Subjects, Authors, Works or specific Editions."
 msgstr "Stvori popis bilo kojih područja, autora, djela ili određenih izdanja."
 
 #: lists/home.html
-msgid ""
-"Once you've made a list, you can <strong>watch for updates</strong> or "
-"<strong>export</strong> all the editions in a list as HTML, BibTeX or JSON. "
-"See all your lists and any activity using the \"Lists\" link on your Account "
-"page."
-msgstr ""
-"Nakon što izradiš popis, možeš <strong>pratiti aktualiziranja</strong> ili "
-"<strong>izvesti</strong> sva izdanja s popisa u formatima HTML, BibTeX ili "
-"JSON. Sve svoje popise i sve aktivnosti mogu se pogledati pomoću poveznice "
-"„Popisi” na stranici tvog računa."
+msgid "Once you've made a list, you can <strong>watch for updates</strong> or <strong>export</strong> all the editions in a list as HTML, BibTeX or JSON. See all your lists and any activity using the \"Lists\" link on your Account page."
+msgstr "Nakon što izradiš popis, možeš <strong>pratiti aktualiziranja</strong> ili <strong>izvesti</strong> sva izdanja s popisa u formatima HTML, BibTeX ili JSON. Sve svoje popise i sve aktivnosti mogu se pogledati pomoću poveznice „Popisi” na stranici tvog računa."
 
 #: lists/home.html
 #, python-format
-msgid ""
-"For the top 2000+ most requested eBooks in California for the print disabled "
-"<a href=\"%(url)s\">click here</a>."
-msgstr ""
-"Za popis više od 2.000 najtraženijih e-knjiga za slijepe/slabovidne u "
-"Kaliforniji <a href=\"%(url)s\">pritisni ovdje</a>."
+msgid "For the top 2000+ most requested eBooks in California for the print disabled <a href=\"%(url)s\">click here</a>."
+msgstr "Za popis više od 2.000 najtraženijih e-knjiga za slijepe/slabovidne u Kaliforniji <a href=\"%(url)s\">pritisni ovdje</a>."
 
 #: lists/home.html
 msgid "Find a list by name"
@@ -6167,8 +5630,7 @@ msgstr "Popisi aktivnih"
 msgid "from <a href=\"%(key)s\">%(owner)s</a>"
 msgstr "od <a href=\"%(key)s\">%(owner)s</a>"
 
-#: lists/home.html lists/preview.html lists/snippet.html type/list/embed.html
-#: type/list/view_body.html
+#: lists/home.html lists/preview.html lists/snippet.html type/list/embed.html type/list/view_body.html
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
@@ -6270,8 +5732,7 @@ msgstr "Ukloniti ovaj element?"
 
 #: lists/lists.html
 #, python-format
-msgid ""
-"Are you sure you want to remove <strong>%(title)s</strong> from this list?"
+msgid "Are you sure you want to remove <strong>%(title)s</strong> from this list?"
 msgstr "Stvarno želiš ukloniti <strong>%(title)s</strong> s ovog popisa?"
 
 #: lists/lists.html
@@ -6351,10 +5812,6 @@ msgstr "Oprez …"
 #: merge/authors.html
 msgid "<b>Are you sure</b> you want to merge these records?"
 msgstr "<b>Stvarno</b> želiš sjediniti ove zapise?"
-
-#: merge/authors.html recentchanges/merge/view.html
-msgid "Primary"
-msgstr "Primarni"
 
 #: merge/authors.html
 msgid "Merge"
@@ -6527,12 +5984,8 @@ msgstr "Odgovori"
 
 #: merge_request_table/table_row.html
 #, python-format
-msgid ""
-"MR #%(id)s opened %(date)s by <a href=\"/people/%(submitter)s\" "
-"class=\"commenter\">@%(submitter)s</a>"
-msgstr ""
-"Zahtjev za sjedinjavanje #%(id)s otvoren %(date)s od <a href=\"/people/"
-"%(submitter)s\" class=\"commenter\">@%(submitter)s</a>"
+msgid "MR #%(id)s opened %(date)s by <a href=\"/people/%(submitter)s\" class=\"commenter\">@%(submitter)s</a>"
+msgstr "Zahtjev za sjedinjavanje #%(id)s otvoren %(date)s od <a href=\"/people/%(submitter)s\" class=\"commenter\">@%(submitter)s</a>"
 
 #: merge_request_table/table_row.html
 msgid "Click to close this Merge Request"
@@ -6566,15 +6019,22 @@ msgstr "Koristi ovo djelo"
 msgid "Create a new list"
 msgstr "Stvori nov popis"
 
-#: CreateListModal.html my_books/dropdown_content.html
-#: type/permission/edit.html type/usergroup/edit.html
+#: CreateListModal.html my_books/dropdown_content.html type/permission/edit.html type/usergroup/edit.html
 msgid "Description:"
 msgstr "Opis:"
 
-#: CreateListModal.html my_books/dropdown_content.html type/list/edit.html
-#: type/series/edit.html
+#: CreateListModal.html my_books/dropdown_content.html type/list/edit.html type/series/edit.html
 msgid "Create new list"
 msgstr "Stvori nov popis"
+
+#: my_books/dropdown_content.html
+#, fuzzy
+msgid "saving..."
+msgstr "Učitavanje …"
+
+#: my_books/dropdown_content.html
+msgid "Removing this book from your shelves will delete your check-ins for this work.  Continue?"
+msgstr "Uklanjanjem ove knjige s vaših polica izbrisat će se vaše provjere za ovo djelo. Nastaviti?"
 
 #: my_books/primary_action.html
 msgid "Add to List"
@@ -6629,12 +6089,8 @@ msgid "December"
 msgstr "Prosinac"
 
 #: my_books/check_ins/check_in_form.html
-msgid ""
-"Add an optional check-in date. Check-in dates are used to track yearly "
-"reading goals."
-msgstr ""
-"Dodaj opcionalni datum vraćanja. Datumi vraćanja se koriste za praćenje "
-"godišnjih ciljeva čitanja."
+msgid "Add an optional check-in date. Check-in dates are used to track yearly reading goals."
+msgstr "Dodaj opcionalni datum vraćanja. Datumi vraćanja se koriste za praćenje godišnjih ciljeva čitanja."
 
 #: my_books/check_ins/check_in_form.html
 msgid "End Date:"
@@ -6667,6 +6123,16 @@ msgstr "Dan"
 #: my_books/check_ins/check_in_form.html
 msgid "Delete Event"
 msgstr "Izbriši događaj"
+
+#: my_books/check_ins/check_in_prompt.html
+#, fuzzy
+msgid "Failed to delete check-in. Please try again in a few moments."
+msgstr "Neuspjelo slanje komentara. Pokušaj ponovo malo kasnije."
+
+#: my_books/check_ins/check_in_prompt.html
+#, fuzzy
+msgid "Failed to submit check-in. Please try again in a few moments."
+msgstr "Neuspjelo slanje komentara. Pokušaj ponovo malo kasnije."
 
 #: my_books/check_ins/check_in_prompt.html
 #, python-format
@@ -6727,8 +6193,7 @@ msgstr "Želiš li pokušati nešto drugo?"
 msgid "Publisher: %(name)s"
 msgstr "Izdavač: %(name)s"
 
-#: openlibrary/plugins/worksearch/code.py publishers/view.html
-#: search/advancedsearch.html type/edition/view.html type/work/view.html
+#: openlibrary/plugins/worksearch/code.py publishers/view.html search/advancedsearch.html type/edition/view.html type/work/view.html
 msgid "Publisher"
 msgstr "Izdavač"
 
@@ -6749,14 +6214,8 @@ msgid "Publishing History"
 msgstr "Povijest izdanja"
 
 #: publishers/view.html
-msgid ""
-"This is a chart to show the when this publisher published books. Along the X "
-"axis is time, and on the y axis is the count of editions published. <a "
-"href=\"#subjectRelated\">Click here to skip the chart</a>."
-msgstr ""
-"Vremenski dijagram za prikaz izdanih knjiga ovog izdavača. Os x označava "
-"vrijeme, os y broj objavljenih izdanja. <a href=\"#subjectRelated\">Za "
-"preskakanje prikaza dijagrama pritisni ovdje</a>."
+msgid "This is a chart to show the when this publisher published books. Along the X axis is time, and on the y axis is the count of editions published. <a href=\"#subjectRelated\">Click here to skip the chart</a>."
+msgstr "Vremenski dijagram za prikaz izdanih knjiga ovog izdavača. Os x označava vrijeme, os y broj objavljenih izdanja. <a href=\"#subjectRelated\">Za preskakanje prikaza dijagrama pritisni ovdje</a>."
 
 #: PublishingHistory.html publishers/view.html
 msgid "Reset chart"
@@ -6767,12 +6226,8 @@ msgid "or continue zooming in."
 msgstr "ili nastavi uvećavati prikaz."
 
 #: publishers/view.html
-msgid ""
-"This graph charts editions from this publisher over time. Click to view a "
-"single year, or drag across a range."
-msgstr ""
-"Dijagram prikazuje izdanja ovog izdavača u odnosu na vrijeme. Pritisni za "
-"prikaz određene godine ili povuci mišem preko raspona godina."
+msgid "This graph charts editions from this publisher over time. Click to view a single year, or drag across a range."
+msgstr "Dijagram prikazuje izdanja ovog izdavača u odnosu na vrijeme. Pritisni za prikaz određene godine ili povuci mišem preko raspona godina."
 
 #: PublishingHistory.html publishers/view.html
 msgid "Editions Published"
@@ -6812,20 +6267,13 @@ msgid "How many books would you like to read this year?"
 msgstr "Koliko knjiga želiš pročitati ove godine?"
 
 #: reading_goals/reading_goal_form.html
-msgid ""
-"Enter \"0\" to unset your reading goal. Your check-ins will be preserved."
-msgstr ""
-"Upiši „0” za poništavanje tvog cilja čitanja. Podaci tvojih vraćanja će se "
-"sačuvati."
+msgid "Enter \"0\" to unset your reading goal. Your check-ins will be preserved."
+msgstr "Upiši „0” za poništavanje tvog cilja čitanja. Podaci tvojih vraćanja će se sačuvati."
 
 #: reading_goals/reading_goal_progress.html
 #, python-format
-msgid ""
-"<span class=\"reading-goal-progress__books-read\">%(books_read)d</span>/"
-"<span class=\"reading-goal-progress__goal\">%(goal)d</span> Books"
-msgstr ""
-"<span class=\"reading-goal-progress__books-read\">%(books_read)d</span>/"
-"<span class=\"reading-goal-progress__goal\">%(goal)d</span> knjiga"
+msgid "<span class=\"reading-goal-progress__books-read\">%(books_read)d</span>/<span class=\"reading-goal-progress__goal\">%(goal)d</span> Books"
+msgstr "<span class=\"reading-goal-progress__books-read\">%(books_read)d</span>/<span class=\"reading-goal-progress__goal\">%(goal)d</span> knjiga"
 
 #: reading_goals/reading_goal_progress.html
 #, python-format
@@ -6872,13 +6320,11 @@ msgstr "Od botova"
 msgid "Admin view"
 msgstr "Pogled administratora"
 
-#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
-#: recentchanges/render.html
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html recentchanges/render.html
 msgid "Older"
 msgstr "Starije"
 
-#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
-#: recentchanges/render.html
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html recentchanges/render.html
 msgid "Newer"
 msgstr "Novije"
 
@@ -6886,13 +6332,11 @@ msgstr "Novije"
 msgid "Review what's changed in from the previous revision"
 msgstr "Pregledaj promjene u odnosu na prethodnu reviziju"
 
-#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
-#: recentchanges/default/path.html recentchanges/updated_records.html
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html recentchanges/default/path.html recentchanges/updated_records.html
 msgid "diff"
 msgstr "razlika"
 
-#: recentchanges/add-book/path.html recentchanges/default/path.html
-#: recentchanges/edit-book/path.html recentchanges/merge/path.html
+#: recentchanges/add-book/path.html recentchanges/default/path.html recentchanges/edit-book/path.html recentchanges/merge/path.html
 msgid "expand"
 msgstr "proširi"
 
@@ -6904,8 +6348,7 @@ msgstr "je otvorio/la novi Open Library račun!"
 msgid "Review what's changed from the previous revision"
 msgstr "Pregledaj promjene u odnosu na prethodnu reviziju"
 
-#: recentchanges/default/view.html recentchanges/merge/view.html
-#: recentchanges/undo/view.html
+#: recentchanges/default/view.html recentchanges/merge/view.html recentchanges/undo/view.html
 msgid "Updated Records"
 msgstr "Aktualizirani zapisi"
 
@@ -6923,12 +6366,9 @@ msgstr "Pogledaj <a href=\"%s\">detalje</a>."
 #, python-format
 msgid "Merged %(count)d duplicate %(type)s record into this primary."
 msgid_plural "Merged %(count)d duplicate %(type)s records into this primary."
-msgstr[0] ""
-"Sjedinjen je %(count)d dupli zapis za „%(type)s“ u ovaj primarni zapis."
-msgstr[1] ""
-"Sjedinjena su %(count)d dupla zapisa za „%(type)s“ u ovaj primarni zapis."
-msgstr[2] ""
-"Sjedinjeno je %(count)d duplih zapisa za „%(type)s“ u ovaj primarni zapis."
+msgstr[0] "Sjedinjen je %(count)d dupli zapis za „%(type)s“ u ovaj primarni zapis."
+msgstr[1] "Sjedinjena su %(count)d dupla zapisa za „%(type)s“ u ovaj primarni zapis."
+msgstr[2] "Sjedinjeno je %(count)d duplih zapisa za „%(type)s“ u ovaj primarni zapis."
 
 #: recentchanges/merge/comment.html
 msgid "Marked as duplicate."
@@ -7031,15 +6471,13 @@ msgstr "Nijedan <strong>autor</strong> se ne poklapa s tvojom pretragom"
 msgid "Search Open Library for %s"
 msgstr "Traži %s u Open Library"
 
-#: BookSearchInside.html FulltextSearchSuggestion.html SearchNavigation.html
-#: search/inside.html search/snippets.html
+#: BookSearchInside.html FulltextSearchSuggestion.html SearchNavigation.html search/inside.html search/snippets.html
 msgid "Search Inside"
 msgstr "Traži unutar"
 
 #: search/inside.html
 msgid "No <strong>Search Inside</strong> text matched your search"
-msgstr ""
-"Nijedan <strong>Traži unutar</strong> tekst se ne poklapa s tvojom pretragom"
+msgstr "Nijedan <strong>Traži unutar</strong> tekst se ne poklapa s tvojom pretragom"
 
 #: search/inside.html
 #, python-format
@@ -7281,14 +6719,8 @@ msgid "It looks like you're offline."
 msgstr "Čini se da nisi povezan/a na internet."
 
 #: site/head.html
-msgid ""
-"Open Library is an open, editable library catalog, building towards a web "
-"page for every book ever published. Read, borrow, and discover more than 3M "
-"books for free."
-msgstr ""
-"Open Library je otvoren i urediv knjižnični katalog, smišljen za izradu web-"
-"stranice za svaku ikada izdanu knjigu. Čitaj, posudi i pronađi više od 3 "
-"milijuna knjiga besplatno."
+msgid "Open Library is an open, editable library catalog, building towards a web page for every book ever published. Read, borrow, and discover more than 3M books for free."
+msgstr "Open Library je otvoren i urediv knjižnični katalog, smišljen za izradu web-stranice za svaku ikada izdanu knjigu. Čitaj, posudi i pronađi više od 3 milijuna knjiga besplatno."
 
 #: site/stats.html
 msgid "Debug Stats"
@@ -7304,9 +6736,7 @@ msgstr "Broj zabilježenih knjiga"
 
 #: stats/readinglog.html
 msgid "The total number of books logged using the Reading Log feature"
-msgstr ""
-"Ukupni broj zabilježenih pročitanih knjiga koristeći funkciju „Dnevnik "
-"čitanja”"
+msgstr "Ukupni broj zabilježenih pročitanih knjiga koristeći funkciju „Dnevnik čitanja”"
 
 #: stats/readinglog.html
 msgid "All time"
@@ -7317,12 +6747,8 @@ msgid "# Unique Users Logging Books"
 msgstr "Broj jedinstvenih korisnika koji bilježe knjige"
 
 #: stats/readinglog.html
-msgid ""
-"The total number of unique users who have logged at least one book using the "
-"Reading Log feature"
-msgstr ""
-"Ukupni broj jedinstvenih korisnika koji su zabilježili barem jednju "
-"pročitanu knjigu koristeći funkciju „Dnevnik čitanja”"
+msgid "The total number of unique users who have logged at least one book using the Reading Log feature"
+msgstr "Ukupni broj jedinstvenih korisnika koji su zabilježili barem jednju pročitanu knjigu koristeći funkciju „Dnevnik čitanja”"
 
 #: stats/readinglog.html
 msgid "# Books Starred"
@@ -7376,18 +6802,14 @@ msgstr "Nismo pronašli nijednu knjigu o"
 msgid "OpenAPI"
 msgstr "OpenAPI"
 
-#: type/about/edit.html type/page/edit.html type/permission/edit.html
-#: type/template/edit.html type/usergroup/edit.html
+#: type/about/edit.html type/page/edit.html type/permission/edit.html type/template/edit.html type/usergroup/edit.html
 #, python-format
 msgid "Edit %(title)s"
 msgstr "Uredi %(title)s"
 
 #: type/about/edit.html
-msgid ""
-"This only appears in the document head, and gets attached to bookmark labels"
-msgstr ""
-"Ovo se pojavljuje samo u zaglavlju dokumenta i pridružuje se oznakama "
-"zabilješki"
+msgid "This only appears in the document head, and gets attached to bookmark labels"
+msgstr "Ovo se pojavljuje samo u zaglavlju dokumenta i pridružuje se oznakama zabilješki"
 
 #: type/about/edit.html
 msgid "Intro"
@@ -7418,21 +6840,15 @@ msgid "Edit Author"
 msgstr "Uredi autora"
 
 #: type/author/edit.html
-msgid ""
-"Please use natural order. For example: <strong>Leo Tolstoy</strong> not "
-"<strong>Tolstoy, Leo</strong>."
-msgstr ""
-"Koristi uobičajeni oblik. Npr.: <strong>Leo Tolstoy</strong> umjesto "
-"<strong>Tolstoy, Leo</strong>."
+msgid "Please use natural order. For example: <strong>Leo Tolstoy</strong> not <strong>Tolstoy, Leo</strong>."
+msgstr "Koristi uobičajeni oblik. Npr.: <strong>Leo Tolstoy</strong> umjesto <strong>Tolstoy, Leo</strong>."
 
 #: type/author/edit.html
 msgid "A short bio?"
 msgstr "Kratka biografija?"
 
 #: type/author/edit.html
-msgid ""
-"If you \"borrow\" information from somewhere, please make sure to cite the "
-"source."
+msgid "If you \"borrow\" information from somewhere, please make sure to cite the source."
 msgstr "Ako odnekud „posudiš” podatak, navedi izvor."
 
 #: type/author/edit.html
@@ -7444,33 +6860,20 @@ msgid "Date of death"
 msgstr "Datum smrti"
 
 #: type/author/edit.html
-msgid ""
-"We're not storing structured dates (yet) so a date like \"21 May 2000\" is "
-"recommended."
-msgstr ""
-"Ne spremamo strukturirane datume (još ne), stoga preporučujemo navoditi "
-"datume u obliku „21. svibnja 2000.”."
+msgid "We're not storing structured dates (yet) so a date like \"21 May 2000\" is recommended."
+msgstr "Ne spremamo strukturirane datume (još ne), stoga preporučujemo navoditi datume u obliku „21. svibnja 2000.”."
 
 #: type/author/edit.html
-msgid ""
-"This is a deprecated field. You can help improve this record by removing "
-"this date and populating the \"Date of birth\" and \"Date of death\" fields. "
-"Thanks!"
-msgstr ""
-"Ovo je zastarjelo polje. Možeš poboljšati ovaj zapis uklanjanjem ovog datuma "
-"i popunjavanjem polja „Datum rođenja” i „Datum smrti”. Hvala!"
+msgid "This is a deprecated field. You can help improve this record by removing this date and populating the \"Date of birth\" and \"Date of death\" fields. Thanks!"
+msgstr "Ovo je zastarjelo polje. Možeš poboljšati ovaj zapis uklanjanjem ovog datuma i popunjavanjem polja „Datum rođenja” i „Datum smrti”. Hvala!"
 
 #: type/author/edit.html
 msgid "Does this author go by any other names?"
 msgstr "Je li ovaj autor poznat pod drugim imenima?"
 
 #: type/author/edit.html
-msgid ""
-"For example: Lev Nikolayevich Tolstoy was also known as Leo Tolstoy. Please "
-"list one name per line."
-msgstr ""
-"Na primjer: Lav Nikolajevič Tolstoj je bio poznat i kao Lav Tolstoj. Navedi "
-"jedno ime po retku."
+msgid "For example: Lev Nikolayevich Tolstoy was also known as Leo Tolstoy. Please list one name per line."
+msgstr "Na primjer: Lav Nikolajevič Tolstoj je bio poznat i kao Lav Tolstoj. Navedi jedno ime po retku."
 
 #: type/author/edit.html
 msgid "Identifiers"
@@ -7503,12 +6906,8 @@ msgid "Refresh the page?"
 msgstr "Aktualizirati stranicu?"
 
 #: type/author/view.html
-msgid ""
-"OK. The merge is in motion. <i>It will take <u>a few minutes to finish</u> "
-"the update.</i>"
-msgstr ""
-"U redu. Provodi se sjedinjavanje. <i>Aktualiziranje će potrajati <u>par "
-"minuta</u>.</i>"
+msgid "OK. The merge is in motion. <i>It will take <u>a few minutes to finish</u> the update.</i>"
+msgstr "U redu. Provodi se sjedinjavanje. <i>Aktualiziranje će potrajati <u>par minuta</u>.</i>"
 
 #: type/author/view.html
 msgid "Argh!"
@@ -7516,8 +6915,7 @@ msgstr "K vragu!"
 
 #: type/author/view.html
 msgid "That merge didn't work. It's our fault, and we've made a note of it."
-msgstr ""
-"Sjedinjavanje nije uspjelo. Radi se o našoj grešci te smo ju zabilježili."
+msgstr "Sjedinjavanje nije uspjelo. Radi se o našoj grešci te smo ju zabilježili."
 
 #: type/author/view.html
 msgid "Add another?"
@@ -7533,8 +6931,7 @@ msgstr "Traži knjige od %(author)s"
 msgid "— Show <a href=\"%(url)s\">everything</a> by this author?"
 msgstr "– Prikazati <a href=\"%(url)s\">sve</a> od ovog autora?"
 
-#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py
-#: type/author/view.html type/list/view_body.html
+#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py type/author/view.html type/list/view_body.html
 msgid "Places"
 msgstr "Mjesta"
 
@@ -7552,8 +6949,7 @@ msgstr "Inventaire.io:"
 
 #: type/author/view.html type/edition/view.html type/work/view.html
 msgid "Links <span class=\"gray small sansserif\">outside Open Library</span>"
-msgstr ""
-"Poveznice <span class=\"gray small sansserif\">izvan Open Library</span>"
+msgstr "Poveznice <span class=\"gray small sansserif\">izvan Open Library</span>"
 
 #: type/author/view.html
 msgid "No links yet."
@@ -7615,6 +7011,16 @@ msgstr "Uredi ovu stranicu"
 msgid "Review"
 msgstr "Pregledaj"
 
+#: type/edition/modal_links.html
+#, fuzzy
+msgid "reviewing"
+msgstr "Pregledaj"
+
+#: type/edition/modal_links.html
+#, fuzzy
+msgid "adding notes to"
+msgstr "Dodati jednog drugog autora?"
+
 #: type/edition/title_and_author.html
 msgid "An edition of"
 msgstr "Izdanje od"
@@ -7635,20 +7041,13 @@ msgstr "Čitaj manje"
 
 #: type/edition/view.html type/work/view.html
 #, python-format
-msgid ""
-"This work doesn't have a description yet. Can you <b><a href='%(url)s'>add "
-"one</a></b>?"
-msgstr ""
-"Ovo djelo još nema opisa. Možeš li <b><a href='%(url)s'>dodati opis</a></b>?"
+msgid "This work doesn't have a description yet. Can you <b><a href='%(url)s'>add one</a></b>?"
+msgstr "Ovo djelo još nema opisa. Možeš li <b><a href='%(url)s'>dodati opis</a></b>?"
 
 #: type/edition/view.html type/work/view.html
 #, python-format
-msgid ""
-"This edition doesn't have a description yet. Can you <b><a "
-"href='%(url)s'>add one</a></b>?"
-msgstr ""
-"Ovo izdanje još nema opisa. Možeš li <b><a href='%(url)s'>dodati opis</a></"
-"b>?"
+msgid "This edition doesn't have a description yet. Can you <b><a href='%(url)s'>add one</a></b>?"
+msgstr "Ovo izdanje još nema opisa. Možeš li <b><a href='%(url)s'>dodati opis</a></b>?"
 
 #: type/edition/view.html type/work/view.html
 msgid "Publish Date"
@@ -7664,8 +7063,7 @@ msgstr "Prikaži ostale knjige izdavača %(publisher)s"
 msgid "Search for other books from %(publisher)s"
 msgstr "Traži druge knjige od %(publisher)s"
 
-#: openlibrary/plugins/worksearch/code.py type/edition/view.html
-#: type/work/view.html
+#: openlibrary/plugins/worksearch/code.py type/edition/view.html type/work/view.html
 msgid "Language"
 msgstr "Jezik"
 
@@ -7802,8 +7200,7 @@ msgstr "Trenutačno"
 
 #: type/language/view.html
 #, python-format
-msgid ""
-"Try a <a href=\"%(href)s\">search for readable books in %(language)s</a>?"
+msgid "Try a <a href=\"%(href)s\">search for readable books in %(language)s</a>?"
 msgstr "Pokušati <a href=\"%(href)s\">tražiti knjige za %(language)s</a>?"
 
 #: type/list/edit.html type/series/edit.html
@@ -7869,12 +7266,8 @@ msgid "Visit Open Library"
 msgstr "Posjeti Open Library"
 
 #: type/list/embed.html
-msgid ""
-"Open in online Book Reader. Downloads available in ePub, DAISY, PDF, TXT "
-"formats from main book page"
-msgstr ""
-"Otvori u internetskom čitaču knjiga. Preuzimanja su dostupna u formatima "
-"ePub, DAISY, PDF, TXT s glavne stranice knjige"
+msgid "Open in online Book Reader. Downloads available in ePub, DAISY, PDF, TXT formats from main book page"
+msgstr "Otvori u internetskom čitaču knjiga. Preuzimanja su dostupna u formatima ePub, DAISY, PDF, TXT s glavne stranice knjige"
 
 #: type/list/embed.html
 msgid "This book is checked out"
@@ -7925,20 +7318,13 @@ msgstr "Izvoz nije dostupan"
 
 #: type/list/exports.html
 #, python-format
-msgid ""
-"Only lists with up to %(max)s editions can be exported. This one has "
-"%(count)s."
-msgstr ""
-"Izvesti se mogu samo popisi s najviše %(max)s izdanja. Ovaj sadrži %(count)s."
+msgid "Only lists with up to %(max)s editions can be exported. This one has %(count)s."
+msgstr "Izvesti se mogu samo popisi s najviše %(max)s izdanja. Ovaj sadrži %(count)s."
 
 #: type/list/exports.html
 #, python-format
-msgid ""
-"Try removing some seeds for more focus, or look at <a href=\"%s\">bulk "
-"download</a> of the catalog."
-msgstr ""
-"Pokušaj ukloniti neke elemente ili pogledaj <a href=\"%s\">skupno "
-"preuzimanje</a> kataloga."
+msgid "Try removing some seeds for more focus, or look at <a href=\"%s\">bulk download</a> of the catalog."
+msgstr "Pokušaj ukloniti neke elemente ili pogledaj <a href=\"%s\">skupno preuzimanje</a> kataloga."
 
 #: type/list/view_body.html
 #, python-format
@@ -7976,33 +7362,21 @@ msgid "Remove Seed"
 msgstr "Ukloni element"
 
 #: type/list/view_body.html
-msgid ""
-"You are about to remove the last item in the list. That will delete the "
-"whole list. Are you sure you want to continue?"
-msgstr ""
-"Uklonit ćeš zadnju stavku u popisu. Time se briše cijeli popis. Stvarno "
-"želiš nastaviti?"
+msgid "You are about to remove the last item in the list. That will delete the whole list. Are you sure you want to continue?"
+msgstr "Uklonit ćeš zadnju stavku u popisu. Time se briše cijeli popis. Stvarno želiš nastaviti?"
 
 #: type/list/view_body.html
 #, python-format
-msgid ""
-"This series contains %(limit)d or more works. Currently, only the first "
-"%(limit)d works are displayed."
-msgstr ""
-"Ova serija sadrži %(limit)d ili više djela. Trenutačno su prikazana samo "
-"prva %(limit)d djela."
+msgid "This series contains %(limit)d or more works. Currently, only the first %(limit)d works are displayed."
+msgstr "Ova serija sadrži %(limit)d ili više djela. Trenutačno su prikazana samo prva %(limit)d djela."
 
 #: type/list/view_body.html
 msgid "There are no items on this list."
 msgstr "Ovaj popis nema stavki."
 
 #: type/list/view_body.html
-msgid ""
-"<a href=\"/search\" target=\"_blank\" rel=\"noopener noreferrer\">Search for "
-"book, subjects, or authors</a> to add to your list."
-msgstr ""
-"<a href=\"/search\" target=\"_blank\" rel=\"noopener noreferrer\">Traži "
-"knjigu, predmete ili autore</a> za dodavanje u popis."
+msgid "<a href=\"/search\" target=\"_blank\" rel=\"noopener noreferrer\">Search for book, subjects, or authors</a> to add to your list."
+msgstr "<a href=\"/search\" target=\"_blank\" rel=\"noopener noreferrer\">Traži knjigu, predmete ili autore</a> za dodavanje u popis."
 
 #: type/list/view_body.html
 msgid "Learn more."
@@ -8016,8 +7390,7 @@ msgstr "Popis metapodataka"
 msgid "Derived from seed metadata"
 msgstr "Izvedeno iz metapodataka elemenata"
 
-#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py
-#: type/list/view_body.html
+#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py type/list/view_body.html
 msgid "Times"
 msgstr "Vremena"
 
@@ -8086,16 +7459,8 @@ msgid "We require a minimum set of fields to create a new collection tag."
 msgstr "Za stvaranje nove oznake za zbirke potreban je određen broj polja."
 
 #: EditButtons.html type/tag/form.html
-msgid ""
-"By saving a change to this wiki, you agree that your contribution is given "
-"freely to the world under <a href=\"https://creativecommons.org/publicdomain/"
-"zero/1.0/\" target=\"_blank\" rel=\"noopener noreferrer\" title=\"This link "
-"to Creative Commons will open in a new window\">CC0</a>. Yippee!"
-msgstr ""
-"Spremanjem promjena na ovoj wiki-stranici prihvaćaš da je cijeli svijet "
-"slobodno koristi pod licencom <a href=\"https://creativecommons.org/"
-"publicdomain/zero/1.0/\" target=\"_blank\" rel=\"noopener noreferrer\" "
-"title=\"Ova poveznica na Creative Commons otvara novi prozor\">CC0</a>."
+msgid "By saving a change to this wiki, you agree that your contribution is given freely to the world under <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" target=\"_blank\" rel=\"noopener noreferrer\" title=\"This link to Creative Commons will open in a new window\">CC0</a>. Yippee!"
+msgstr "Spremanjem promjena na ovoj wiki-stranici prihvaćaš da je cijeli svijet slobodno koristi pod licencom <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" target=\"_blank\" rel=\"noopener noreferrer\" title=\"Ova poveznica na Creative Commons otvara novi prozor\">CC0</a>."
 
 #: type/tag/form.html
 msgid "Add this tag now"
@@ -8126,8 +7491,7 @@ msgid "Tag Name"
 msgstr "Ime oznake"
 
 #: type/tag/tag_form_inputs.html
-msgid ""
-"Human-readable display name (e.g. \"Computer Science\", \"Horror Fiction\")"
+msgid "Human-readable display name (e.g. \"Computer Science\", \"Horror Fiction\")"
 msgstr "Čitljivo prikazano ime (npr. „Računalne znanosti”, „Horor fikcija”)"
 
 #: type/tag/tag_form_inputs.html
@@ -8135,12 +7499,8 @@ msgid "Tag Slugs"
 msgstr "Indikatori oznaka"
 
 #: type/tag/tag_form_inputs.html
-msgid ""
-"Comma-separated URL slugs that map to this tag (auto-populated from name). "
-"E.g. \"computer_science, cs\""
-msgstr ""
-"URL indikatori odvojeni zarezom koji se mapiraju na ovu oznaku (automatski "
-"se popunjavaju iz imena). Npr. „racunalne-znanosti, rz”"
+msgid "Comma-separated URL slugs that map to this tag (auto-populated from name). E.g. \"computer_science, cs\""
+msgstr "URL indikatori odvojeni zarezom koji se mapiraju na ovu oznaku (automatski se popunjavaju iz imena). Npr. „racunalne-znanosti, rz”"
 
 #: type/tag/tag_form_inputs.html
 msgid "Tag Description"
@@ -8170,6 +7530,11 @@ msgstr "Opis"
 #: type/tag/view.html
 msgid "Tag Body"
 msgstr "Tekst oznake"
+
+#: type/tag/view.html
+#, fuzzy
+msgid "URL Slugs"
+msgstr "Indikatori oznaka"
 
 #: type/tag/view.html
 #, python-format
@@ -8226,17 +7591,9 @@ msgid "admin page"
 msgstr "stranica za administratore"
 
 #: type/user/view.html
-#, python-format
-msgid ""
-"You are publicly sharing the books you are <a href=\"%(username)s/books/"
-"currently-reading\">currently reading</a>, <a href=\"%(username)s/books/"
-"already-read\">have already read</a>, and <a href=\"%(username)s/books/want-"
-"to-read\">want to read</a>."
+#, fuzzy, python-format
+msgid "You are publicly sharing the books you are <a href=\"%(username)s/books/currently-reading\">currently reading</a>, <a href=\"%(username)s/books/already-read\">have already read</a>, <a href=\"%(username)s/books/want-to-read\">want to read</a>, and have <a href=\"%(username)s/books/stopped-reading\">stopped reading</a>!"
 msgstr ""
-"Javno dijeliš knjige koje <a href=\"%(username)s/books/currently-"
-"reading\">trenutačno čitaš</a>, koje si <a href=\"%(username)s/books/already-"
-"read\">već pročitao/la</a> i koje <a href=\"%(username)s/books/want-to-"
-"read\">želiš čitati</a>."
 
 #: type/user/view.html
 msgid "You have chosen to make your"
@@ -8251,17 +7608,9 @@ msgid "Manage your privacy settings"
 msgstr "Upravljaj postavkama tvoje privatnosti"
 
 #: type/user/view.html
-#, python-format
-msgid ""
-"Here are the books %(user)s is <a href=\"%(username)s/books/currently-"
-"reading\">currently reading</a>, <a href=\"%(username)s/books/already-"
-"read\">have already read</a>, and <a href=\"%(username)s/books/want-to-"
-"read\">want to read</a>!"
+#, fuzzy, python-format
+msgid "Here are the books %(user)s is <a href=\"%(username)s/books/currently-reading\">currently reading</a>, <a href=\"%(username)s/books/already-read\">have already read</a>, <a href=\"%(username)s/books/want-to-read\">want to read</a>, and has <a href=\"%(username)s/books/stopped-reading\">stopped reading</a>!"
 msgstr ""
-"Ovdje su knjige koje %(user)s <a href=\"%(username)s/books/currently-"
-"reading\">trenutačno čita</a>, koje je <a href=\"%(username)s/books/already-"
-"read\">već pročitao/la</a> i koje <a href=\"%(username)s/books/want-to-"
-"read\">želi čitati</a>!"
 
 #: type/user/view.html
 msgid "My Lists"
@@ -8328,12 +7677,8 @@ msgid "Look for this edition for sale at %(store)s"
 msgstr "Traži ovo izdanje na rasprodaji na %(store)s"
 
 #: AffiliateLinks.html
-msgid ""
-"When you buy books using these links the Internet Archive may earn a <a "
-"class=\"nostyle\" href=\"/help/faq/about#selling\">small commission</a>."
-msgstr ""
-"Kada kupuješ knjige pomoću ovih poveznica, Internet Archive može zaraditi <a "
-"class=\"nostyle\" href=\"/help/faq/about#selling\">malu proviziju</a>."
+msgid "When you buy books using these links the Internet Archive may earn a <a class=\"nostyle\" href=\"/help/faq/about#selling\">small commission</a>."
+msgstr "Kada kupuješ knjige pomoću ovih poveznica, Internet Archive može zaraditi <a class=\"nostyle\" href=\"/help/faq/about#selling\">malu proviziju</a>."
 
 #: AffiliateLinksLoadingIndicator.html
 msgid "Fetching prices"
@@ -8364,12 +7709,8 @@ msgid "Preview Book"
 msgstr "Pregled knjige"
 
 #: DisplayCode.html
-msgid ""
-"Templates in the website are disabled now. Editing them will not have any "
-"effect on the live website."
-msgstr ""
-"Predlošci u web-stranici su sada deaktivirani. Njihovo uređivanje neće "
-"utjecati na web-stranicu uživo."
+msgid "Templates in the website are disabled now. Editing them will not have any effect on the live website."
+msgstr "Predlošci u web-stranici su sada deaktivirani. Njihovo uređivanje neće utjecati na web-stranicu uživo."
 
 #: EditionNavBar.html
 msgid "Go to previous section"
@@ -8551,10 +7892,12 @@ msgid "Go to next page"
 msgstr "Idi na sljedeću stranicu"
 
 #: OlPagination.html
+#, python-brace-format
 msgid "Go to page {page}"
 msgstr "Idi na stranicu {page}"
 
 #: OlPagination.html
+#, python-brace-format
 msgid "Page {page}, current page"
 msgstr "Stranica {page}, trenutačna stranica"
 
@@ -8571,15 +7914,8 @@ msgid "who have written the most books on this subject"
 msgstr "koji su napisali najviše knjiga u ovom području"
 
 #: PublishingHistory.html
-msgid ""
-"This is a chart to show the publishing history of editions of works about "
-"this subject. Along the X axis is time, and on the y axis is the count of "
-"editions published. <a href=\"#subjectRelated\">Click here to skip the "
-"chart</a>."
-msgstr ""
-"Vremenski dijagram za prikaz povijesti objavljivanja izdanja djela u ovom "
-"području. Os x označava vrijeme, os y broj izdanih izdanja. <a "
-"href=\"#subjectRelated\">Za preskakanje prikaza dijagrama pritisni ovdje</a>."
+msgid "This is a chart to show the publishing history of editions of works about this subject. Along the X axis is time, and on the y axis is the count of editions published. <a href=\"#subjectRelated\">Click here to skip the chart</a>."
+msgstr "Vremenski dijagram za prikaz povijesti objavljivanja izdanja djela u ovom području. Os x označava vrijeme, os y broj izdanih izdanja. <a href=\"#subjectRelated\">Za preskakanje prikaza dijagrama pritisni ovdje</a>."
 
 #: PublishingHistory.html
 msgid "This graph charts editions published on this subject."
@@ -8614,12 +7950,8 @@ msgid "Special Access"
 msgstr "Poseban pristup"
 
 #: ReadButton.html
-msgid ""
-"Special ebook access from the Internet Archive for patrons with qualifying "
-"print disabilities"
-msgstr ""
-"Poseban pristup e-knjigama s Internet Archive stranica za pokrovitelje s "
-"oštećenjem vida"
+msgid "Special ebook access from the Internet Archive for patrons with qualifying print disabilities"
+msgstr "Poseban pristup e-knjigama s Internet Archive stranica za pokrovitelje s oštećenjem vida"
 
 #: ReadButton.html
 msgid "Borrow ebook from Internet Archive"
@@ -8682,8 +8014,7 @@ msgstr "Naslovnica izdanja %(id)s"
 #: SearchResultsWork.html
 #, python-format
 msgid "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d language</a>"
-msgid_plural ""
-"in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d languages</a>"
+msgid_plural "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d languages</a>"
 msgstr[0] "na <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d jeziku</a>"
 msgstr[1] "na <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d jezika</a>"
 msgstr[2] "na <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d jezika</a>"
@@ -8738,6 +8069,26 @@ msgid "QR Code"
 msgstr "QR kod"
 
 #: StarRatings.html
+msgid "leaving a 1 star review for"
+msgstr "ostavljate recenziju s 1 zvjezdicom za"
+
+#: StarRatings.html
+msgid "leaving a 2 star review for"
+msgstr "ostavljate recenziju s 2 zvjezdice za"
+
+#: StarRatings.html
+msgid "leaving a 3 star review for"
+msgstr "ostavljate recenziju s 3 zvjezdice za"
+
+#: StarRatings.html
+msgid "leaving a 4 star review for"
+msgstr "ostavljate recenziju s 4 zvjezdice za"
+
+#: StarRatings.html
+msgid "leaving a 5 star review for"
+msgstr "ostavljate recenziju s 5 zvjezdica za"
+
+#: StarRatings.html
 msgid "Clear my rating"
 msgstr "Ukloni moju ocjenu"
 
@@ -8749,6 +8100,10 @@ msgstr "ocjena"
 msgid "ratings"
 msgstr "ocjene"
 
+#. Shows the count of readers who added this book to their "Want to read"
+#. shelf, displayed on search result pages. %(want_to_read_count)s is a
+#. formatted integer (may include commas as thousands separators). Example:
+#. "2,389 Want to read".
 #: StarRatingsByline.html
 #, python-format
 msgid "%(want_to_read_count)s Want to read"
@@ -8759,17 +8114,33 @@ msgstr "Žele čitati: %(want_to_read_count)s"
 msgid "%(ratings_avg)s (%(ratings_count)s %(ratings_label)s)"
 msgstr "%(ratings_avg)s (%(ratings_count)s %(ratings_label)s)"
 
+#. Short label displayed next to the count of readers who want to read this
+#. book, shown in the stats bar on a book page. Example: "2,389 Want to read".
 #: StarRatingsStats.html
 msgid "Want to read"
 msgstr "Žele čitati"
 
+#. Short label displayed next to the count of readers currently reading this
+#. book, shown in the stats bar on a book page. Example: "1,247 Currently
+#. reading".
 #: StarRatingsStats.html
 msgid "Currently reading"
 msgstr "Trenutačno čitaju"
 
+#. Short label displayed next to the count of readers who have finished this
+#. book, shown in the stats bar on a book page. Example: "15,420 Have read".
+#. This refers to the same shelf as the "Already Read" button.
 #: StarRatingsStats.html
 msgid "Have read"
 msgstr "Pročitali su"
+
+#. Short label displayed next to the count of readers who stopped reading this
+#. book before finishing, shown in the stats bar on a book page. Example: "348
+#. Stopped reading".
+#: StarRatingsStats.html
+#, fuzzy
+msgid "Stopped reading"
+msgstr "U trendu"
 
 #: SubjectTags.html
 msgid "Manage Subjects"
@@ -8842,27 +8213,15 @@ msgid "Huh?"
 msgstr "Huh?"
 
 #: TypeChanger.html
-msgid ""
-"Every piece of Open Library is defined by the type of content it displays, "
-"usually by content definition (e.g. Authors, Editions, Works) but sometimes "
-"by content use (e.g. macro, template, rawtext). Changing this for an "
-"existing page will alter its presentation and the data fields available for "
-"editing its content."
-msgstr ""
-"Svaki Open Library element definiran je vrstom sadržaja koji prikazuje, "
-"obično definicijom sadržaja (npr. autori, izdanja, djela), ali ponekad i "
-"upotrebom sadržaja (npr. makronaredba, predložak, neformatirani tekst). "
-"Mijenjanjem elemenata za postojeću stranicu, promijenit će se njen prikaz i "
-"podatkovna polja koja su dostupna za uređivanje sadržaja stranice."
+msgid "Every piece of Open Library is defined by the type of content it displays, usually by content definition (e.g. Authors, Editions, Works) but sometimes by content use (e.g. macro, template, rawtext). Changing this for an existing page will alter its presentation and the data fields available for editing its content."
+msgstr "Svaki Open Library element definiran je vrstom sadržaja koji prikazuje, obično definicijom sadržaja (npr. autori, izdanja, djela), ali ponekad i upotrebom sadržaja (npr. makronaredba, predložak, neformatirani tekst). Mijenjanjem elemenata za postojeću stranicu, promijenit će se njen prikaz i podatkovna polja koja su dostupna za uređivanje sadržaja stranice."
 
 #: TypeChanger.html
 msgid "Please use caution changing Page Type!"
 msgstr "Oprez pri mijenjanju vrste stranice!"
 
 #: TypeChanger.html
-msgid ""
-"(Simplest solution: If you aren't sure whether this should be changed, don't "
-"change it.)"
+msgid "(Simplest solution: If you aren't sure whether this should be changed, don't change it.)"
 msgstr "(Najjednostavnije rješenje: ako si u nedoumici, nemoj mijenjati.)"
 
 #: WorkInfo.html
@@ -9085,8 +8444,7 @@ msgstr "Sadrži broj stranica"
 
 #: openlibrary/plugins/openlibrary/lists.py
 #, python-format
-msgid ""
-"Are you sure you want to remove <strong>%(title)s</strong> from your list?"
+msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
 msgstr "Stvarno želiš ukloniti <strong>%(title)s</strong> s tvog popisa?"
 
 #: openlibrary/plugins/openlibrary/partials.py
@@ -9163,16 +8521,11 @@ msgstr "Pojavio se problem i nismo te mogli prijaviti."
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Login attempted with invalid Internet Archive s3 credentials."
-msgstr ""
-"Pokušaj prijave s neispravnim podacima za prijavu na Internet Archive s3."
+msgstr "Pokušaj prijave s neispravnim podacima za prijavu na Internet Archive s3."
 
 #: openlibrary/plugins/upstream/account.py
-msgid ""
-"Servers are experiencing unusually high traffic, please try again later or "
-"email openlibrary@archive.org for help."
-msgstr ""
-"Serveri imaju neuobičajeno velik promet. Pokušaj ponovo kasnije ili pošalji "
-"e-mail na openlibrary@archive.org za pomoć."
+msgid "Servers are experiencing unusually high traffic, please try again later or email openlibrary@archive.org for help."
+msgstr "Serveri imaju neuobičajeno velik promet. Pokušaj ponovo kasnije ili pošalji e-mail na openlibrary@archive.org za pomoć."
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Email provider not recognized."
@@ -9187,12 +8540,8 @@ msgid "A problem occurred and we were unable to log you in"
 msgstr "Pojavio se problem i nismo te mogli prijaviti"
 
 #: openlibrary/plugins/upstream/account.py
-msgid ""
-"Login or registration attempt hit an unexpected error, please try again or "
-"contact info@archive.org"
-msgstr ""
-"Neočekivana greška prilikom pokušaja prijave ili registracije. Pokušaj "
-"ponovo ili kontaktiraj info@archive.org"
+msgid "Login or registration attempt hit an unexpected error, please try again or contact info@archive.org"
+msgstr "Neočekivana greška prilikom pokušaja prijave ili registracije. Pokušaj ponovo ili kontaktiraj info@archive.org"
 
 #: openlibrary/plugins/upstream/account.py
 #, python-format
@@ -9200,21 +8549,14 @@ msgid "Request failed with error code: %(error_code)s"
 msgstr "Zahtjev nije uspio s kodom greške: %(error_code)s"
 
 #: openlibrary/plugins/upstream/account.py
-msgid ""
-"Thank you for registering an Open Library account and requesting special "
-"print disability access. You should receive an email detailing next steps in "
-"the process."
-msgstr ""
-"Hvala ti na otvaranju Open Library računa i traženja posebnog pristupa za "
-"osobe s oštećenjem vida. Primit ćeš e-mail s detaljima o sljedećim koracima "
-"u procesu."
+msgid "Thank you for registering an Open Library account and requesting special print disability access. You should receive an email detailing next steps in the process."
+msgstr "Hvala ti na otvaranju Open Library računa i traženja posebnog pristupa za osobe s oštećenjem vida. Primit ćeš e-mail s detaljima o sljedećim koracima u procesu."
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Username unavailable"
 msgstr "Korisničko ime je nedostupno"
 
-#: openlibrary/plugins/upstream/account.py
-#: openlibrary/plugins/upstream/forms.py
+#: openlibrary/plugins/upstream/account.py openlibrary/plugins/upstream/forms.py
 msgid "Email already registered"
 msgstr "E-mail adresa je već registrirana"
 
@@ -9223,37 +8565,13 @@ msgid "An Internet Archive account already exists with this email"
 msgstr "Internet Archive račun s ovom e-mail adresom već postoji"
 
 #: openlibrary/plugins/upstream/account.py
-msgid "Email address is already used."
-msgstr "E-mail adresa se već koristi."
+#, fuzzy
+msgid "Verification failed. The link may be invalid or expired. Please try registering again."
+msgstr "Potvrda nije uspjela. Pokušaj ponovo."
 
 #: openlibrary/plugins/upstream/account.py
-msgid ""
-"Your email address couldn't be updated. The specified email address is "
-"already used."
-msgstr ""
-"Neuspjelo aktualiziranje e-mail adrese. Navedena e-mail adresa se već "
-"koristi."
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Email verification successful."
-msgstr "Potvrđivanje e-mail adrese je uspjelo."
-
-#: openlibrary/plugins/upstream/account.py
-msgid ""
-"Your email address has been successfully verified and updated in your "
-"account."
-msgstr "E-mail adresa je provjerena i aktualizirana u tvom računu."
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Email address couldn't be verified."
-msgstr "Nije bilo moguće potvrditi e-mail adresu."
-
-#: openlibrary/plugins/upstream/account.py
-msgid ""
-"Your email address couldn't be verified. The verification link seems invalid."
-msgstr ""
-"Nije bilo moguće potvrditi tvoju e-mail adresu. Poveznica potvrde je "
-"neispravna."
+msgid "Your email has been verified. You are now logged in."
+msgstr "Vaša adresa e-pošte je potvrđena. Sada ste prijavljeni."
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Notification preferences have been updated successfully."
@@ -9265,11 +8583,8 @@ msgstr "ovu knjigu"
 
 #: openlibrary/plugins/upstream/borrow.py
 #, python-format
-msgid ""
-"Unable to return %s. Please try again later or contact info@archive.org."
-msgstr ""
-"Nije moguće vratiti %s. Pokušaj ponovo kasnije ili kontaktiraj "
-"info@archive.org."
+msgid "Unable to return %s. Please try again later or contact info@archive.org."
+msgstr "Nije moguće vratiti %s. Pokušaj ponovo kasnije ili kontaktiraj info@archive.org."
 
 #: openlibrary/plugins/upstream/borrow.py
 #, python-format
@@ -9277,12 +8592,8 @@ msgid "%s has been returned."
 msgstr "%s je vraćena."
 
 #: openlibrary/plugins/upstream/borrow.py
-msgid ""
-"Your account has hit a lending limit. Please try again later or contact "
-"info@archive.org."
-msgstr ""
-"Tvoj je račun dosegao ograničenje posudbi. Pokušaj ponovo kasnije ili "
-"kontaktiraj info@archive.org."
+msgid "Your account has hit a lending limit. Please try again later or contact info@archive.org."
+msgstr "Tvoj je račun dosegao ograničenje posudbi. Pokušaj ponovo kasnije ili kontaktiraj info@archive.org."
 
 #: openlibrary/plugins/upstream/forms.py
 msgid "Username"
@@ -9328,6 +8639,11 @@ msgstr "Tvoja e-mail adresa"
 msgid "Choose a password"
 msgstr "Odaberi lozinku"
 
+#: openlibrary/plugins/upstream/mybooks.py
+#, python-format
+msgid "Continue <a href=\"%(url)s\" class=\"pending-action-link\" data-action=\"%(raw_action)s\"><strong>%(action)s</strong> <em>%(name)s</em></a>"
+msgstr "Nastavi <a href=\"%(url)s\" class=\"pending-action-link\" data-action=\"%(raw_action)s\"><strong>%(action)s</strong> <em>%(name)s</em></a>"
+
 #: openlibrary/plugins/worksearch/code.py
 msgid "eBook?"
 msgstr "E-knjiga?"
@@ -9339,3 +8655,40 @@ msgstr "Prvi put izdano"
 #: openlibrary/plugins/worksearch/code.py
 msgid "Classic eBooks"
 msgstr "Klasične e-knjige"
+
+#~ msgid "Activation link expiring on <span class=\"time\">%(date)s.</span>"
+#~ msgstr "Poveznica za aktivaciju isteče <span class=\"time\">.%(date)s</span>"
+
+#~ msgid "Activation link expired"
+#~ msgstr "Poveznica za aktivaciju je istekla"
+
+#~ msgid "Resend activation link"
+#~ msgstr "Ponovo pošalji poveznicu za aktivaciju"
+
+#~ msgid "This DAISY file is protected."
+#~ msgstr "Ova je DAISY datoteka zaštićena."
+
+#~ msgid "It can only be opened on a specialized device with a key issued by the Library of Congress."
+#~ msgstr "Može se otvoriti samo na specijaliziranom uređaju s ključem koji je izdala knjižnica „Library of Congress“."
+
+#~ msgid "There are two types of DAISYs on Open Library: <i>open</i> and <i>protected</i>. Open DAISYs can be read by anyone in the world on many different devices. Protected DAISYs like this one can only be opened using a key issued by the <a href=\"http://www.loc.gov/nls/\">Library of Congress NLS program</a>."
+#~ msgstr "Postoje dvije vrste DAISY-a na Open Library: <i>otvoreni</i> i <i>zaštićeni</i>. Otvorene DAISY datoteke može čitati svatko na svijetu na različitim uređajima. Zaštićene DAISY datoteke poput ove se mogu otvoriti samo pomoću ključa koji je izdao <a href=\"http://www.loc.gov/nls/\">Library of Congress NLS program</a>."
+
+#~ msgid "Email address is already used."
+#~ msgstr "E-mail adresa se već koristi."
+
+#~ msgid "Your email address couldn't be updated. The specified email address is already used."
+#~ msgstr "Neuspjelo aktualiziranje e-mail adrese. Navedena e-mail adresa se već koristi."
+
+#~ msgid "Email verification successful."
+#~ msgstr "Potvrđivanje e-mail adrese je uspjelo."
+
+#~ msgid "Your email address has been successfully verified and updated in your account."
+#~ msgstr "E-mail adresa je provjerena i aktualizirana u tvom računu."
+
+#~ msgid "Email address couldn't be verified."
+#~ msgstr "Nije bilo moguće potvrditi e-mail adresu."
+
+#~ msgid "Your email address couldn't be verified. The verification link seems invalid."
+#~ msgstr "Nije bilo moguće potvrditi tvoju e-mail adresu. Poveznica potvrde je neispravna."
+


### PR DESCRIPTION
## Summary

Syncs the hr (Croatian) translation file with the current \`messages.pot\` template and fills in
previously untranslated strings.

**AI attribution:** All new translations in this PR were generated by \`claude-sonnet-4-6\`. They should
be reviewed by a native speaker before merging, particularly for tone and idiomatic accuracy.
Format strings (\`%(name)s\`, \`%(count)d\`, etc.) and HTML markup were preserved verbatim.

## Changes

- Ran \`scripts/i18n-messages update hr\` to sync with current \`messages.pot\`
- Filled 36 previously untranslated msgid entries
- Fixed 2 format-string errors in fuzzy entries (cleared msgstr for obsolete structure)
- Left fuzzy entries unchanged (marked for human review)

## Validation

- [x] \`i18n-messages validate hr\` — 0 errors ✓
- [x] \`test_po_files.py -k hr\` — 979 passed, 0 failures ✓
- [x] \`pre-commit run --files openlibrary/i18n/hr/messages.po\` — clean ✓

## Reviewer guidance

Please spot-check translations for:
1. Accuracy of meaning (does the translation convey the intent?)
2. Natural phrasing (does it sound like UI text, not literal translation?)
3. Preserved format strings and HTML

Native speakers: please edit the \`.po\` file directly on this branch.

🤖 Generated by \`claude-sonnet-4-6\`