### PR TITLE
i18n(tl): AI translation update — sync with messages.pot (2026-06-11)

### DIFF
--- a/openlibrary/i18n/tl/messages.po
+++ b/openlibrary/i18n/tl/messages.po
@@ -1,4 +1,4 @@
-# Translations template for Open Library.
+# Filipino (Philippines) translations for Open Library.
 # Copyright (C) 2026 Internet Archive
 # This file is distributed under the same license as the Open Library
 # project.
@@ -8,1604 +8,18 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Open Library VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-05-01 18:58-0400\n"
+"POT-Creation-Date: 2026-04-28 18:58-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: tl\n"
+"Language-Team: tl <LL@li.org>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.12.1\n"
 
-#: openlibrary/core/bookshelves.py
-msgid "[Record deleted]"
-msgstr "[Talaan ay tinanggal]"
-
-#: merge_request_table/table_header.html openlibrary/core/edits.py
-msgid "Declined"
-msgstr "Tinanggihan"
-
-#: admin/imports_by_date.html openlibrary/core/edits.py
-msgid "Pending"
-msgstr "Naghihintay"
-
-#: merge_request_table/table_header.html openlibrary/core/edits.py
-msgid "Merged"
-msgstr "Pinagsama"
-
-#: openlibrary/core/edits.py
-msgid "Unknown"
-msgstr "Hindi Kilala"
-
-#: AffiliateLinks.html
-#, python-format
-msgid "Look for this edition for sale at %(store)s"
-msgstr "Hanapin ang edisyong ito na ibinenta sa %(store)s"
-
-#: AffiliateLinks.html
-msgid "Fetching prices"
-msgstr "Kinukuha ang mga presyo"
-
-#: AffiliateLinks.html
-msgid "Better World Books"
-msgstr "Mas Magandang Mundo ng mga Aklat"
-
-#: AffiliateLinks.html
-msgid " - includes shipping"
-msgstr " - kasama ang pagpapadala"
-
-#: AffiliateLinks.html
-msgid "Amazon"
-msgstr "Amazon"
-
-#: AffiliateLinks.html
-msgid "Bookshop.org"
-msgstr "Bookshop.org"
-
-#: AffiliateLinks.html home/about.html
-msgid "More"
-msgstr "Higit pa"
-
-#: AffiliateLinks.html
-msgid ""
-"When you buy books using these links the Internet Archive may earn a <a "
-"class=\"nostyle\" href=\"/help/faq/about#selling\">small commission</a>."
-msgstr ""
-"Kapag bumili ka ng mga aklat gamit ang mga link na ito, maaaring kumita ang Internet Archive ng <a "
-"class=\"nostyle\" href=\"/help/faq/about#selling\">maliit na komisyon</a>."
-
-#: BatchImportNavigation.html batch_import.html
-msgid "New Batch Import"
-msgstr "Bagong Batch Import"
-
-#: BatchImportNavigation.html
-msgid "Pending Imports"
-msgstr "Naghihintay na Imports"
-
-#: BookByline.html FulltextSearchSuggestionItem.html SearchResultsWork.html
-#: account/notes.html account/observations.html
-msgid "Unknown author"
-msgstr "Hindi Kilalang may-akda"
-
-#: BookByline.html
-#, python-format
-msgid "%(n)s other"
-msgid_plural "%(n)s others"
-msgstr[0] "%(n)s iba"
-msgstr[1] "%(n)s iba"
-
-#: BookByline.html type/list/embed.html
-#, python-format
-msgid "by %(name)s"
-msgstr "ni %(name)s"
-
-#: BookByline.html
-msgid "by an <em>unknown author</em>"
-msgstr "ni isang <em>hindi kilalang may-akda</em>"
-
-#: BookPreview.html
-msgid "Preview Only"
-msgstr "Preview Lamang"
-
-#: BookPreview.html book_providers/read_button.html books/edit/edition.html
-#: editpage.html import_preview.html
-msgid "Preview"
-msgstr "Tukuyin"
-
-#: BookPreview.html
-msgid "Preview Book"
-msgstr "Tukuyin ang Aklat"
-
-#: BookPreview.html CreateListModal.html DonateModal.html NotesModal.html
-#: ObservationsModal.html ShareModal.html covers/author_photo.html
-#: covers/book_cover.html covers/change.html lib/history.html
-#: my_books/check_ins/check_in_prompt.html my_books/dropdown_content.html
-#: native_dialog.html
-msgid "Close"
-msgstr "Isara"
-
-#: BookSearchInside.html FulltextSearchSuggestion.html SearchNavigation.html
-#: search/inside.html search/snippets.html
-msgid "Search Inside"
-msgstr "Maghanap Sa Loob"
-
-#: CreateListModal.html my_books/dropdown_content.html
-msgid "Create a new list"
-msgstr "Lumikha ng bagong listahan"
-
-#: CreateListModal.html admin/people/view.html my_books/dropdown_content.html
-msgid "Name:"
-msgstr "Pangalan:"
-
-#: CreateListModal.html my_books/dropdown_content.html
-#: type/permission/edit.html type/usergroup/edit.html
-msgid "Description:"
-msgstr "Paglalarawan:"
-
-#: CreateListModal.html my_books/dropdown_content.html type/list/edit.html
-#: type/series/edit.html
-msgid "Create new list"
-msgstr "Lumikha ng bagong listahan"
-
-#: CreateListModal.html EditButtons.html account/notifications.html
-#: account/password/reset.html account/privacy.html admin/imports-add.html
-#: admin/permissions.html books/add.html databarEdit.html interstitial.html
-#: merge/authors.html my_books/dropdown_content.html type/list/edit.html
-#: type/series/edit.html type/tag/form.html
-msgid "Cancel"
-msgstr "Kanselahin"
-
-#: DisplayCode.html
-msgid ""
-"Templates in the website are disabled now. Editing them will not have any"
-" effect on the live website."
-msgstr ""
-"Ngayon ay na-disable ang mga template sa website. Ang pag-edit sa mga ito ay walang"
-" epekto sa aktibong website."
-
-#: DonateModal.html
-msgid ""
-"Donate this book to the <a href=\"https://archive.org\">Internet "
-"Archive</a> library."
-msgstr ""
-"Idonate ang aklat na ito sa <a href=\"https://archive.org\">Internet "
-"Archive</a> aklatan."
-
-#: DonateModal.html
-msgid ""
-"Hooray! You've discovered a title that's missing from our <a "
-"href=\"https://help.archive.org/hc/en-us/articles/360016554912-Borrowing-"
-"From-The-Lending-Library\">library</a>. Can you help donate a copy?"
-msgstr ""
-"Hooray! Natagpuan mo ang isang pamagat na nawawala sa aming <a "
-"href=\"https://help.archive.org/hc/en-us/articles/360016554912-Borrowing-"
-"From-The-Lending-Library\">aklatan</a>. Maaari ka bang tumulong na magdonate ng isang kopya?"
-
-#: DonateModal.html
-msgid ""
-"If you own this book, you can<a "
-"href=\"https://store.usps.com/store/product/shipping-supplies/priority-"
-"mail-express-padded-flat-rate-envelope-P_EP13PE\">mail</a> it to our "
-"address below."
-msgstr ""
-"Kung pagmamay-ari mo ang aklat na ito, maaari mo <a "
-"href=\"https://store.usps.com/store/product/shipping-supplies/priority-"
-"mail-express-padded-flat-rate-envelope-P_EP13PE\">ipadadala</a> ito sa aming "
-"address sa ibaba."
-
-#: DonateModal.html
-msgid "You can also purchase this book from a vendor and ship it to our address:"
-msgstr "Maaari mo ring bilhin ang aklat na ito mula sa isang nagbebenta at ipadala ito sa aming address:"
-
-#: DonateModal.html
-msgid "Benefits of donating"
-msgstr "Mga Benepisyo ng Pagdonate"
-
-#: DonateModal.html
-msgid ""
-"When you donate a physical book to the Internet Archive, your book will "
-"enjoy:"
-msgstr ""
-"Kapag nagdonate ka ng isang pisikal na aklat sa Internet Archive, ang iyong aklat ay "
-"magkakaroon ng:"
-
-#: DonateModal.html
-msgid "Donation info"
-msgstr "Impormasyon sa Donasyon"
-
-#: DonateModal.html
-msgid ""
-"Beautiful <a target=\"_blank\" href=\"https://archive.org/scanning"
-"\">high-fidelity digitization</a>"
-msgstr ""
-"Magandang <a target=\"_blank\" href=\"https://archive.org/scanning"
-"\">may mataas na kalidad na digitization</a>"
-
-#: DonateModal.html
-msgid ""
-"Long-term <a href=\"https://blog.archive.org/2011/06/06/why-preserve-"
-"books-the-new-physical-archive-of-the-internet-archive/\">archival "
-"preservation</a>"
-msgstr ""
-"Long-term <a href=\"https://blog.archive.org/2011/06/06/why-preserve-"
-"books-the-new-physical-archive-of-the-internet-archive/\">pagpapanatili ng "
-"arkibo</a>"
-
-#: DonateModal.html
-msgid ""
-"Free <a href=\"https://controlleddigitallending.org/\">controlled digital"
-" library access</a> by the <a "
-"href=\"https://en.wikipedia.org/wiki/Print_disability\">print-"
-"disabled</a> public"
-msgstr ""
-"Libreng <a href=\"https://controlleddigitallending.org/\">kontroladong digital"
-" na pag-access sa aklatan</a> sa mga <a "
-"href=\"https://en.wikipedia.org/wiki/Print_disability\">may kapansanan sa "
-"pag-print</a>"
-
-#: DonateModal.html
-msgid ""
-"Open Library is a project of the <a "
-"href=\"https://archive.org/about\">Internet Archive</a>, a 501(c)(3) non-"
-"profit"
-msgstr ""
-"Ang Open Library ay isang proyekto ng <a "
-"href=\"https://archive.org/about\">Internet Archive</a>, isang 501(c)(3) non-"
-"profit"
-
-#: EditButtons.html admin/ip/view.html admin/people/edits.html
-msgid ""
-"Please, leave a short note about what you changed: <span class=\"small "
-"gray\">(Optional, but very useful!)</span>"
-msgstr ""
-"Pakisuyo, mag-iwan ng maikling tala tungkol sa kung ano ang binago mo: <span class=\"small "
-"gray\">(Opsyonal, ngunit napaka-kapaki-pakinabang!)</span>"
-
-#: EditButtons.html books/add.html type/tag/form.html
-msgid ""
-"By saving a change to this wiki, you agree that your contribution is "
-"given freely to the world under <a "
-"href=\"https://creativecommons.org/publicdomain/zero/1.0/\" "
-"target=\"_blank\" title=\"This link to Creative Commons will open in a "
-"new window\">CC0</a>. Yippee!"
-msgstr ""
-"Sa pamamagitan ng pag-save ng isang pagbabago sa wiki na ito, sumasang-ayon ka na ang iyong kontribusyon ay "
-"ibinibigay nang malaya sa mundo sa ilalim ng <a "
-"href=\"https://creativecommons.org/publicdomain/zero/1.0/\" "
-"target=\"_blank\" title=\"Bubukas ang link na ito sa Creative Commons sa isang "
-"bagong bintana\">CC0</a>. Yippee!"
-
-#: EditButtons.html account/notifications.html account/privacy.html
-#: admin/block.html admin/spamwords.html covers/manage.html
-msgid "Save"
-msgstr "I-save"
-
-#: EditionNavBar.html
-msgid "Go to previous section"
-msgstr "Pumunta sa nakaraang bahagi"
-
-#: EditionNavBar.html
-msgid "Overview"
-msgstr "Pangkalahatang-ideya"
-
-#: EditionNavBar.html
-#, python-format
-msgid "View %(count)s Edition"
-msgid_plural "View %(count)s Editions"
-msgstr[0] "Tingnan ang %(count)s Edisyon"
-msgstr[1] "Tingnan ang %(count)s mga Edisyon"
-
-#: EditionNavBar.html search/layout_options.html site/stats.html
-msgid "Details"
-msgstr "Detalye"
-
-#: EditionNavBar.html
-#, python-format
-msgid "%(reviews)s Review"
-msgid_plural "%(reviews)s Reviews"
-msgstr[0] "%(reviews)s Review"
-msgstr[1] "%(reviews)s Mga Review"
-
-#: EditionNavBar.html account/observations.html
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
-msgid "Reviews"
-msgstr "Mga Review"
-
-#: EditionNavBar.html SearchNavigation.html account/sidebar.html
-#: lib/nav_head.html lists/home.html recentchanges/index.html
-#: type/edition/view.html type/list/embed.html type/user/view.html
-#: type/work/view.html
-msgid "Lists"
-msgstr "Mga Listahan"
-
-#: EditionNavBar.html
-msgid "Related Books"
-msgstr "Kaugnay na mga Aklat"
-
-#: EditionNavBar.html
-msgid "Go to next section"
-msgstr "Pumunta sa susunod na bahagi"
-
-#: Follow.html lists/list_follow.html
-msgid "Follow"
-msgstr "Sundan"
-
-#: Follow.html
-msgid "Unfollow"
-msgstr "Huwag Sundan"
-
-#: Follow.html
-msgid "Failed to update followers. Please try again in a few moments."
-msgstr "Nabigong i-update ang mga tagasunod. Mangyaring subukan muli sa ilang sandali."
-
-#: FormatExpiry.html
-msgid "Expires"
-msgstr "Mag-e-expire"
-
-#: FulltextSearchSuggestion.html
-msgid "Checking for Search Inside matches"
-msgstr "Sinasabing tingnan ang mga tugma sa Search Inside"
-
-#: FulltextSearchSuggestion.html
-msgid "Search Inside Icon"
-msgstr "Search Inside Icon"
-
-#: FulltextSearchSuggestion.html
-msgid "search inside icon"
-msgstr "search inside icon"
-
-#: FulltextSearchSuggestion.html
-#, python-format
-msgid "%(book_count)s books found with matching passages"
-msgstr "%(book_count)s mga aklat na natagpuan na may tugmang bahagi"
-
-#: FulltextSearchSuggestion.html
-#, python-format
-msgid "See all %(results_count)s Search Inside Matches"
-msgstr "Tingnan ang lahat ng %(results_count)s Search Inside Matches"
-
-#: FulltextSearchSuggestion.html
-msgid "right chevron"
-msgstr "kanang chevron"
-
-#: FulltextSearchSuggestionItem.html IABook.html SearchResultsWork.html
-#: books/edition-sort.html jsdef/LazyWorkPreview.html lists/list_overview.html
-#: lists/preview.html lists/snippet.html lists/widget.html
-#: my_books/dropdown_content.html type/work/editions.html
-#, python-format
-msgid "Cover of: %(title)s"
-msgstr "Pabalat ng: %(title)s"
-
-#: FulltextSnippet.html FulltextSuggestionSnippet.html
-msgid "❝"
-msgstr "❝"
-
-#: FulltextSnippet.html FulltextSuggestionSnippet.html
-msgid "❞"
-msgstr "❞"
-
-#: FulltextSuggestionSnippet.html
-#, python-format
-msgid "Page: %(page)s"
-msgstr "Pahina: %(page)s"
-
-#: IABook.html
-#, python-format
-msgid "Borrowed from Internet Archive: %(title)s"
-msgstr "Hiram mula sa Internet Archive: %(title)s"
-
-#: LoadingIndicator.html
-msgid "Loading indicator"
-msgstr "Tagapagpahiwatig ng Pag-load"
-
-#: LoanReadForm.html ReadButton.html admin/inspect/memcache.html
-#: book_providers/read_button.html books/edit/edition.html trending.html
-#: type/list/embed.html widget.html
-msgid "Read"
-msgstr "Basahin"
-
-#: LoanStatus.html
-msgid "You are <strong>next</strong> on the waiting list"
-msgstr "Ikaw ay <strong>susunod</strong> sa listahan ng naghihintay"
-
-#: LoanStatus.html
-#, python-format
-msgid "You are <strong>#%(spot)d</strong> of %(wlsize)d on the waiting list."
-msgstr "Ikaw ay <strong>#%(spot)d</strong> sa %(wlsize)d sa listahan ng naghihintay."
-
-#: LoanStatus.html
-msgid "Leave waiting list"
-msgstr "Umalis sa listahan ng naghihintay"
-
-#: LoanStatus.html widget.html
-msgid "Join Waitlist"
-msgstr "Sumali sa Waitlist"
-
-#: LoanStatus.html
-#, python-format
-msgid "Readers in line: %(count)s"
-msgstr "Mga mambabasa sa pila: %(count)s"
-
-#: LoanStatus.html
-msgid "You'll be next in line."
-msgstr "Ikaw ay susunod sa pila."
-
-#: LoanStatus.html
-msgid "This book is currently checked out, please check back later."
-msgstr "Ang aklat na ito ay kasalukuyang hiniram, mangyaring bumalik mamaya."
-
-#: LoanStatus.html
-msgid "Checked Out"
-msgstr "Nakahiram"
-
-#: LocateButton.html
-msgid "Locate"
-msgstr "Hanapin"
-
-#: ManageLoansButtons.html admin/loans_table.html
-#, python-format
-msgid "Borrowed %(date)s"
-msgstr "Hiniram noong %(date)s"
-
-#: ManageLoansButtons.html
-#, python-format
-msgid "There is one person waiting for this book."
-msgid_plural "There are %(n)s people waiting for this book."
-msgstr[0] "May isang tao na naghihintay para sa aklat na ito."
-msgstr[1] "May %(n)s tao na naghihintay para sa aklat na ito."
-
-#: ManageLoansButtons.html account/loans.html
-msgid "Not yet downloaded."
-msgstr "Hindi pa na-download."
-
-#: ManageLoansButtons.html account/loans.html
-msgid "Download Now"
-msgstr "I-download Ngayon"
-
-#: ManageWaitlistButton.html
-#, python-format
-msgid "Waiting for %d day"
-msgid_plural "Waiting for %d days"
-msgstr[0] "Naghihintay ng %d araw"
-msgstr[1] "Naghihintay ng %d araw"
-
-#: ManageWaitlistButton.html account/loans.html
-#, python-format
-msgid "There is one person ahead of you in the waiting list."
-msgid_plural "There are %(count)d people ahead of you in the waiting list."
-msgstr[0] "May isang tao na nauna sa iyo sa listahan ng naghihintay."
-msgstr[1] "May %(count)d tao na nauna sa iyo sa listahan ng naghihintay."
-
-#: ManageWaitlistButton.html account/loans.html
-msgid "You have less than an hour to borrow it."
-msgstr "Mayroon kang mas mababa sa isang oras upang hiramin ito."
-
-#: ManageWaitlistButton.html
-#, python-format
-msgid "You have %(count)d more hour to borrow it."
-msgid_plural "You have %(count)d more hours to borrow it."
-msgstr[0] "Mayroon kang %(count)d mas maraming oras upang hiramin ito."
-msgstr[1] "Mayroon kang %(count)d mas maraming oras upang hiramin ito."
-
-#: ManageWaitlistButton.html account/loans.html
-msgid "Borrow Now"
-msgstr "Hiramin Ngayon"
-
-#: ManageWaitlistButton.html account/loans.html
-msgid "Leave the waiting list?"
-msgstr "Umalis sa listahan ng naghihintay?"
-
-#: NotInLibrary.html
-msgid "Not in Library"
-msgstr "Wala sa Aklatan"
-
-#: NotesModal.html
-msgid "My Book Notes"
-msgstr "Aking Mga Tala sa Aklat"
-
-#: NotesModal.html
-msgid "My private notes about this edition:"
-msgstr "Aking mga pribadong tala tungkol sa edisyong ito:"
-
-#: NotesModal.html account/notes.html
-msgid "Delete Note"
-msgstr "Tanggalin ang Tala"
-
-#: NotesModal.html account/notes.html
-msgid "Save Note"
-msgstr "I-save ang Tala"
-
-#: OLID.html
-#, python-format
-msgid "by  %(authors)s"
-msgstr "ni  %(authors)s"
-
-#: ObservationsModal.html
-msgid "My Book Review"
-msgstr "Aking Pagsusuri ng Aklat"
-
-#: Pager.html Pager_loanhistory.html
-msgid "First"
-msgstr "Una"
-
-#: Pager.html Pager_loanhistory.html lib/pagination.html
-msgid "Previous"
-msgstr "Nakaraan"
-
-#: Pager.html Pager_loanhistory.html admin/memory/index.html history.html
-#: lib/pagination.html showmarc.html
-msgid "Next"
-msgstr "Susunod"
-
-#: Profile.html
-msgid "Component"
-msgstr "Komponent"
-
-#: Profile.html type/author/view.html
-msgid "Time"
-msgstr "Oras"
-
-#: ProlificAuthors.html
-msgid "Prolific Authors"
-msgstr "Masugid na Mga May-Akda"
-
-#: ProlificAuthors.html
-msgid "who have written the most books on this subject"
-msgstr "na sumulat ng pinakamaraming aklat tungkol sa paksang ito"
-
-#: ProlificAuthors.html publishers/view.html
-msgid "See more books by, and learn about, this author"
-msgstr "Tingnan ang higit pang mga aklat mula sa may-akdang ito at alamin ang tungkol sa kanya"
-
-#: ProlificAuthors.html account/loans.html authors/index.html
-#: lists/list_follow.html lists/showcase.html publishers/view.html
-#: search/authors.html search/publishers.html search/subjects.html
-#, python-format
-msgid "%(count)d book"
-msgid_plural "%(count)d books"
-msgstr[0] "%(count)d aklat"
-msgstr[1] "%(count)d mga aklat"
-
-#: PublishingHistory.html publishers/view.html
-msgid "Publishing History"
-msgstr "Kasaysayan ng Paglilimbag"
-
-#: PublishingHistory.html
-msgid ""
-"This is a chart to show the publishing history of editions of works about"
-" this subject. Along the X axis is time, and on the y axis is the count "
-"of editions published. <a href=\"#subjectRelated\">Click here to skip the"
-" chart</a>."
-msgstr ""
-"Ito ay isang tsart upang ipakita ang kasaysayan ng paglilimbag ng mga edisyon ng mga akdang "
-"tungkol sa paksa. Sa X axis ay ang oras, at sa Y axis ay ang bilang ng "
-"mga edisyon na nailimbag. <a href=\"#subjectRelated\">I-click dito upang laktawan ang"
-" tsart</a>."
-
-#: PublishingHistory.html publishers/view.html
-msgid "Reset chart"
-msgstr "I-reset ang tsart"
-
-#: PublishingHistory.html publishers/view.html
-msgid "or continue zooming in."
-msgstr "o magpatuloy sa pag-zoom in."
-
-#: PublishingHistory.html
-msgid "This graph charts editions published on this subject."
-msgstr "Itinataas ng graph na ito ang mga edisyon na nailimbag tungkol sa paksa."
-
-#: PublishingHistory.html publishers/view.html
-msgid "Editions Published"
-msgstr "Mga Nailimbag na Edisyon"
-
-#: PublishingHistory.html admin/imports.html publishers/view.html
-msgid "You need to have JavaScript turned on to see the nifty chart!"
-msgstr "Kailangan mong i-on ang JavaScript upang makita ang maganda nyang tsart!"
-
-#: PublishingHistory.html publishers/view.html
-msgid "Year of Publication"
-msgstr "Taon ng Paglilimbag"
-
-#: RawQueryCarousel.html
-msgid "Loading carousel"
-msgstr "Nagloload ng carousel"
-
-#: RawQueryCarousel.html
-msgid "Failed to fetch carousel."
-msgstr "Nabigong kunin ang carousel."
-
-#: RawQueryCarousel.html
-msgid "Retry?"
-msgstr "Subukan muli?"
-
-#: RawQueryCarousel.html
-msgid "No books match the current filters."
-msgstr "Walang aklat na tumutugma sa kasalukuyang mga filter."
-
-#: RawQueryCarousel.html
-msgid "Retry without filters?"
-msgstr "Subukan muli nang walang filters?"
-
-#: RawQueryCarousel.html
-msgid "Search collection"
-msgstr "Maghanap sa koleksyon"
-
-#: ReadButton.html
-msgid "Special Access"
-msgstr "Espesyal na Access"
-
-#: ReadButton.html
-msgid ""
-"Special ebook access from the Internet Archive for patrons with "
-"qualifying print disabilities"
-msgstr ""
-"Espesyal na access sa ebook mula sa Internet Archive para sa mga patron na may "
-"qualifying na kapansanan sa pag-imprinta"
-
-#: ReadButton.html books/edit/edition.html type/list/embed.html widget.html
-msgid "Borrow"
-msgstr "Hiramin"
-
-#: ReadButton.html
-msgid "Borrow ebook from Internet Archive"
-msgstr "Hiramin ang ebook mula sa Internet Archive"
-
-#: ReadButton.html
-msgid "Read ebook from Internet Archive"
-msgstr "Basahin ang ebook mula sa Internet Archive"
-
-#: ReadButton.html
-msgid "Listen"
-msgstr "Makinig"
-
-#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
-#: admin/ip/view.html admin/people/edits.html history.html
-#: recentchanges/render.html recentchanges/updated_records.html
-msgid "When"
-msgstr "Kailan"
-
-#: RecentChanges.html RecentChangesUsers.html admin/ip/view.html
-#: admin/loans_table.html admin/people/edits.html recentchanges/render.html
-#: recentchanges/updated_records.html
-msgid "What"
-msgstr "Ano"
-
-#: RecentChanges.html admin/history.html admin/ip/view.html
-#: admin/loans_table.html admin/people/edits.html history.html
-#: recentchanges/render.html
-msgid "Who"
-msgstr "Sino"
-
-#: RecentChanges.html RecentChangesUsers.html admin/history.html
-#: admin/ip/view.html admin/people/edits.html history.html
-#: recentchanges/render.html recentchanges/updated_records.html
-msgid "Comment"
-msgstr "Komento"
-
-#: RecentChanges.html RecentChangesUsers.html recentchanges/default/path.html
-msgid "Review what's changed from the previous revision"
-msgstr "Suriin kung ano ang nabago mula sa nakaraang bersyon"
-
-#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
-#: admin/memory/index.html recentchanges/default/path.html
-#: recentchanges/updated_records.html
-msgid "diff"
-msgstr "pagkakaiba"
-
-#: RecentChanges.html admin/ip/view.html admin/people/edits.html
-#: recentchanges/render.html
-msgid "When you see numbers here, that's the IP address of the anonymous editor"
-msgstr "Kapag nakakita ka ng mga numero dito, iyon ang IP address ng hindi kilalang editor"
-
-#: RecentChanges.html
-msgid "View MARC"
-msgstr "Tingnan ang MARC"
-
-#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
-#: admin/people/edits.html recentchanges/render.html
-msgid "Older"
-msgstr "Mas Matanda"
-
-#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
-#: admin/people/edits.html recentchanges/render.html
-msgid "Newer"
-msgstr "Mas Bago"
-
-#: RecentChanges.html recentchanges/index.html
-msgid "By Humans"
-msgstr "Ng mga Tao"
-
-#: RecentChanges.html recentchanges/index.html
-msgid "By Bots"
-msgstr "Ng mga Bot"
-
-#: RecentChanges.html recentchanges/index.html work_search.html
-msgid "Everything"
-msgstr "Lahat"
-
-#: RecentChangesAdmin.html
-msgid "Path"
-msgstr "Daan"
-
-#: RecentChangesAdmin.html batch_import_pending_view.html
-#: batch_import_view.html
-msgid "Comments"
-msgstr "Mga Komento"
-
-#: RecentChangesAdmin.html account/loans.html admin/loans_table.html
-msgid "Actions"
-msgstr "Mga Aksyon"
-
-#: RecentChangesAdmin.html
-msgid "view"
-msgstr "tingnan"
-
-#: RecentChangesAdmin.html
-msgid "edit"
-msgstr "i-edit"
-
-#: RecentChangesAdmin.html RecentChangesUsers.html
-msgid "No edit history available."
-msgstr "Walang magagamit na kasaysayan ng pag-edit."
-
-#: RecentChangesUsers.html lists/home.html lists/lists.html type/user/view.html
-msgid "Recent Activity"
-msgstr "Kam recent na Gawain"
-
-#: RecentChangesUsers.html type/user/view.html
-msgid "No edits. Yet."
-msgstr "Walang mga edit. Sa ngayon."
-
-#: RelatedSubjects.html SearchNavigation.html SubjectTags.html
-#: lib/nav_foot.html lib/nav_head.html openlibrary/plugins/worksearch/code.py
-#: subjects/notfound.html type/author/view.html type/list/view_body.html
-msgid "Subjects"
-msgstr "Mga Paksa"
-
-#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py
-#: type/author/view.html type/list/view_body.html
-msgid "Places"
-msgstr "Mga Lugar"
-
-#: RelatedSubjects.html SubjectTags.html admin/menu.html
-#: admin/people/index.html admin/people/view.html
-#: openlibrary/plugins/worksearch/code.py type/author/view.html
-#: type/list/view_body.html
-msgid "People"
-msgstr "Mga Tao"
-
-#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py
-#: type/list/view_body.html
-msgid "Times"
-msgstr "Mga Panahon"
-
-#: RelatedSubjects.html
-msgid "Related..."
-msgstr "Kaugnay..."
-
-#: RelatedSubjects.html publishers/view.html
-msgid "None found."
-msgstr "Walang natagpuan."
-
-#: ReturnForm.html
-msgid "Really return this book?"
-msgstr "Talagang ibabalik ang aklat na ito?"
-
-#: ReturnForm.html
-msgid "Return book"
-msgstr "Ibalik ang aklat"
-
-#: SearchNavigation.html books/mybooks_breadcrumb_select.html lib/nav_foot.html
-#: openlibrary/plugins/upstream/mybooks.py
-msgid "Books"
-msgstr "Mga Aklat"
-
-#: SearchNavigation.html authors/index.html lib/nav_foot.html
-#: merge/authors.html publishers/view.html
-msgid "Authors"
-msgstr "Mga May-Akda"
-
-#: SearchNavigation.html lib/nav_foot.html lib/nav_head.html
-#: search/advancedsearch.html
-msgid "Advanced Search"
-msgstr "Nabatid na Paghahanap"
-
-#: SearchResultsWork.html
-msgid "added to"
-msgstr "idinagdag sa"
-
-#: SearchResultsWork.html
-#, python-format
-msgid "Book %(position)s"
-msgstr "Aklat %(position)s"
-
-#: SearchResultsWork.html design.html
-msgid "Show more"
-msgstr "Ipakita ang higit pa"
-
-#: SearchResultsWork.html design.html
-msgid "Show less"
-msgstr "Ipakita ang mas kaunti"
-
-#: SearchResultsWork.html
-#, python-format
-msgid "Cover of edition %(id)s"
-msgstr "Pabalat ng edisyon %(id)s"
-
-#: SearchResultsWork.html type/work/editions.html
-#, python-format
-msgid "First published in %(year)s"
-msgstr "Una nailimbag noong %(year)s"
-
-#: SearchResultsWork.html books/check.html merge/authors.html
-#: publishers/view.html
-#, python-format
-msgid "%(count)s edition"
-msgid_plural "%(count)s editions"
-msgstr[0] "%(count)s edisyon"
-msgstr[1] "%(count)s mga edisyon"
-
-#: SearchResultsWork.html
-#, python-format
-msgid "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d language</a>"
-msgid_plural "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d languages</a>"
-msgstr[0] "sa <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d wika</a>"
-msgstr[1] "sa <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d mga wika</a>"
-
-#: SearchResultsWork.html TrendingBadge.html
-msgid "This is only visible to librarians."
-msgstr "Ito ay nakikita lamang ng mga librarian."
-
-#: SearchResultsWork.html
-msgid "Work Title"
-msgstr "Pamagat ng Akda"
-
-#: SearchResultsWork.html type/edition/admin_bar.html
-msgid "Orphaned Edition"
-msgstr "Orpanadong Edisyon"
-
-#: ShareModal.html
-#, python-format
-msgid "Share on %(share_link)s"
-msgstr "Ibahagi sa %(share_link)s"
-
-#: ShareModal.html
-msgid "Embed this book in your website"
-msgstr "I-embed ang aklat na ito sa iyong website"
-
-#: ShareModal.html
-msgid "Embed icon"
-msgstr "Embed icon"
-
-#: ShareModal.html
-msgid "Embed"
-msgstr "I-embed"
-
-#: ShareModal.html
-msgid "Copy url to clipboard"
-msgstr "Kopyahin ang url sa clipboard"
-
-#: ShareModal.html
-msgid "Copy URL icon"
-msgstr "Kopyahin ang URL icon"
-
-#: ShareModal.html
-msgid "Copy URL"
-msgstr "Kopyahin ang URL"
-
-#: ShareModal.html
-msgid "Open QR code"
-msgstr "Buksan ang QR code"
-
-#: ShareModal.html
-msgid "QR code icon"
-msgstr "QR code icon"
-
-#: ShareModal.html
-msgid "QR Code"
-msgstr "QR Code"
-
-#: StarRatings.html
-msgid "Clear my rating"
-msgstr "I-clear ang aking rating"
-
-#: StarRatingsByline.html StarRatingsComponent.html
-msgid "rating"
-msgstr "rating"
-
-#: StarRatingsByline.html StarRatingsComponent.html
-msgid "ratings"
-msgstr "ratings"
-
-#: StarRatingsByline.html
-#, python-format
-msgid "%(want_to_read_count)s Want to read"
-msgstr "%(want_to_read_count)s Gusto ng basahin"
-
-#: StarRatingsComponent.html
-#, python-format
-msgid "%(ratings_avg)s (%(ratings_count)s %(ratings_label)s)"
-msgstr "%(ratings_avg)s (%(ratings_count)s %(ratings_label)s)"
-
-#: StarRatingsStats.html
-msgid "Want to read"
-msgstr "Gusto ng basahin"
-
-#: StarRatingsStats.html
-msgid "Currently reading"
-msgstr "Kasalukuyang nagbabasa"
-
-#: StarRatingsStats.html
-msgid "Have read"
-msgstr "Nabasa na"
-
-#: SubjectTags.html
-msgid "Manage Subjects"
-msgstr "Pamahalaan ang mga Paksa"
-
-#: Subnavigation.html
-msgid "Developer Center (Home)"
-msgstr "Sentro ng Developer (Tahanan)"
-
-#: Subnavigation.html
-msgid "Web API"
-msgstr "Web API"
-
-#: Subnavigation.html
-msgid "Client Library"
-msgstr "Aklatan ng Kliyente"
-
-#: Subnavigation.html
-msgid "Data Dumps"
-msgstr "Data Dumps"
-
-#: Subnavigation.html book_providers/standard_ebooks_download_options.html
-msgid "Source Code"
-msgstr "Source Code"
-
-#: Subnavigation.html
-msgid "Report an Issue"
-msgstr "Iulat ang Isyu"
-
-#: Subnavigation.html
-msgid "Licensing"
-msgstr "Lisensya"
-
-#: Subnavigation.html
-msgid "Welcome"
-msgstr "Maligayang pagdating"
-
-#: Subnavigation.html
-msgid "Searching Open Library"
-msgstr "Naghahanap sa Open Library"
-
-#: Subnavigation.html
-msgid "Reading Books"
-msgstr "Nagbabasa ng Mga Aklat"
-
-#: Subnavigation.html
-msgid "Adding & Editing Books"
-msgstr "Pagdaragdag at Pagsusuri ng Mga Aklat"
-
-#: Subnavigation.html
-msgid "Using Subjects"
-msgstr "Gumagamit ng Mga Paksa"
-
-#: Subnavigation.html
-msgid "Open Library F.A.Q."
-msgstr "Mga Madalas Itanong sa Open Library"
-
-#: TableOfContents.html
-#, python-format
-msgid "Page %s"
-msgstr "Pahina %s"
-
-#: TrendingBadge.html
-#, python-format
-msgid "Trending: %(score).2f"
-msgstr "Umangat: %(score).2f"
-
-#: TypeChanger.html
-msgid "Page Type"
-msgstr "Uri ng Pahina"
-
-#: TypeChanger.html
-msgid "Huh?"
-msgstr "Ha?"
-
-#: TypeChanger.html
-msgid ""
-"Every piece of Open Library is defined by the type of content it "
-"displays, usually by content definition (e.g. Authors, Editions, Works) "
-"but sometimes by content use (e.g. macro, template, rawtext). Changing "
-"this for an existing page will alter its presentation and the data fields"
-" available for editing its content."
-msgstr ""
-"Bawat bahagi ng Open Library ay tinutukoy ng uri ng nilalaman nito "
-"binibigay, kadalasang batay sa depinisyon ng nilalaman (hal. Mga Awtor, Edisyon, Akda) "
-"ngunit kung minsan ay batay sa paggamit ng nilalaman (hal. macro, template, rawtext). Ang pagbabago "
-"na ito para sa isang umiiral na pahina ay babaguhin ang presentasyon nito at ang mga patlang ng data"
-" na magagamit para sa pag-edit ng nilalaman nito."
-
-#: TypeChanger.html
-msgid "Please use caution changing Page Type!"
-msgstr "Mangyaring maging maingat sa pagbabago ng Uri ng Pahina!"
-
-#: TypeChanger.html
-msgid ""
-"(Simplest solution: If you aren't sure whether this should be changed, "
-"don't change it.)"
-msgstr ""
-"(Pinakasimpleng solusyon: Kung hindi ka sigurado kung ito ay dapat baguhin, "
-"huwag itong baguhin.)"
-
-#: UserEditRow.html type/work/editions.html
-msgid "Add another"
-msgstr "Magdagdag ng isa pa"
-
-#: WorkInfo.html
-msgid "No link to Wikipedia in your language"
-msgstr "Walang link sa Wikipedia sa iyong wika"
-
-#: WorldcatLink.html
-msgid "Check nearby libraries"
-msgstr "Suriin ang mga kalapit na aklatan"
-
-#: WorldcatLink.html
-msgid "Check WorldCat for an edition near you"
-msgstr "Suriin ang WorldCat para sa isang edisyon na malapit sa iyo"
-
-#: WorldcatLink.html
-msgid "WorldCat"
-msgstr "WorldCat"
-
-#: databarDiff.html databarEdit.html
-msgid "View the editing history of this page"
-msgstr "Tingnan ang kasaysayan ng pag-edit ng pahinang ito"
-
-#: databarDiff.html databarEdit.html databarTemplate.html databarView.html
-#: lib/history.html openlibrary/plugins/openlibrary/home.py
-msgid "History"
-msgstr "Kasaysayan"
-
-#: databarDiff.html
-msgid "View this page (exit Comparison view)"
-msgstr "Tingnan ang pahinang ito (lumabas sa Paghahambing na view)"
-
-#: account.html databarDiff.html
-msgid "View"
-msgstr "Tingnan"
-
-#: databarEdit.html
-msgid "View this page (exit Edit mode)"
-msgstr "Tingnan ang pahinang ito (lumabas sa Edit mode)"
-
-#: databarHistory.html databarView.html
-#, python-format
-msgid "Last edited by %(author_link)s"
-msgstr "Huling inedit ni %(author_link)s"
-
-#: databarHistory.html databarView.html
-msgid "Last edited anonymously"
-msgstr "Huling inedit ng hindi kilala"
-
-#: databarHistory.html databarView.html type/edition/compact_title.html
-msgid "Edit this page"
-msgstr "I-edit ang pahinang ito"
-
-#: account.html databarHistory.html databarTemplate.html databarView.html
-#: my_books/check_ins/check_in_prompt.html
-#: reading_goals/reading_goal_progress.html subjects.html
-#: type/edition/compact_title.html type/user/view.html
-msgid "Edit"
-msgstr "I-edit"
-
-#: databarTemplate.html databarView.html
-msgid "View this template's edit history"
-msgstr "Tingnan ang kasaysayan ng pag-edit ng template na ito"
-
-#: databarTemplate.html
-msgid "Edit this template"
-msgstr "I-edit ang template na ito"
-
-#: databarWork.html lib/nav_head.html
-msgid "Browse"
-msgstr "Mag-browse"
-
-#: databarWork.html
-#, python-format
-msgid "View Volume %(num)d"
-msgstr "Tingnan ang Dami %(num)d"
-
-#: databarWork.html type/edition/view.html type/work/view.html
-msgid "Buy this book"
-msgstr "Bumili ng aklat na ito"
-
-#: openlibrary/plugins/openlibrary/api.py
-msgid "Search Results"
-msgstr "Mga Resulta ng Paghahanap"
-
-#: lib/nav_foot.html openlibrary/plugins/openlibrary/api.py site/neck.html
-msgid "Open Library"
-msgstr "Open Library"
-
-#: home/index.html openlibrary/plugins/openlibrary/api.py trending.html
-msgid "Trending Books"
-msgstr "Umangat na Mga Aklat"
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Arabic"
-msgstr "Arabo"
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Czech"
-msgstr "Seko"
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "German"
-msgstr "Alemán"
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "English"
-msgstr "Ingles"
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Spanish"
-msgstr "Espanyol"
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "French"
-msgstr "Pranses"
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Hindi"
-msgstr "Hindi"
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Croatian"
-msgstr "Croatian"
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Italian"
-msgstr "Italyano"
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Portuguese"
-msgstr "Portuges"
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Romanian"
-msgstr "Rumen"
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Sardinian"
-msgstr "Sardiniano"
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Telugu"
-msgstr "Telugu"
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Ukrainian"
-msgstr "Ukrainiano"
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Chinese"
-msgstr "Tsino"
-
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Filipino"
-msgstr "Filipino"
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Art"
-msgstr "Sining"
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Science Fiction"
-msgstr "Agham na Piksyon"
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Fantasy"
-msgstr "Pantasiya"
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Biographies"
-msgstr "Talambuhay"
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Recipes"
-msgstr "Mga Resipe"
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Children"
-msgstr "Mga Bata"
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Medicine"
-msgstr "Medisina"
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Religion"
-msgstr "Relihiyon"
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Mystery and Detective Stories"
-msgstr "Mga Kuwento ng Misteryo at Detektib"
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Plays"
-msgstr "Pagsasakatawan"
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Music"
-msgstr "Musika"
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Science"
-msgstr "Agham"
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "At least 1 subject"
-msgstr "Hindi bababa sa 1 paksa"
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "At least 1 author"
-msgstr "Hindi bababa sa 1 may-akda"
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "At least 1 edition"
-msgstr "Hindi bababa sa 1 edisyon"
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "Has work (orphaned)"
-msgstr "Mayroong gawa (ulila)"
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "Has publication year"
-msgstr "Mayroong taon ng publikasyon"
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "Has cover"
-msgstr "Mayroong takip"
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "Has language"
-msgstr "Mayroong wika"
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "Has publisher"
-msgstr "Mayroong publisher"
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "At least 2 editions"
-msgstr "Hindi bababa sa 2 edisyon"
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "Has dewey decimal"
-msgstr "Mayroong dewey decimal"
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "Has LoC classification"
-msgstr "Mayroong LoC klasipikasyon"
-
-#: openlibrary/plugins/openlibrary/librarian_dashboard.py
-msgid "Has number of pages"
-msgstr "Mayroong bilang ng mga pahina"
-
-#: openlibrary/plugins/openlibrary/lists.py
-#, python-format
-msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
-msgstr "Sigurado ka bang gusto mong alisin ang <strong>%(title)s</strong> mula sa iyong listahan?"
-
-#: books/mybooks_breadcrumb_select.html
-#: openlibrary/plugins/openlibrary/lists.py
-#, python-format
-msgid "Lists (%(count)d)"
-msgstr "Mga Listahan (%(count)d)"
-
-#: openlibrary/plugins/openlibrary/partials.py
-msgid "This work does not appear on any lists."
-msgstr "Ang gawaing ito ay hindi lumalabas sa alinmang listahan."
-
-#: openlibrary/plugins/openlibrary/pd.py
-msgid "I don't have one yet"
-msgstr "Wala pa akong isa"
-
-#: openlibrary/plugins/upstream/account.py
-msgid "The email address you entered is invalid"
-msgstr "Ang email address na iyong ipinasok ay hindi wasto"
-
-#: openlibrary/plugins/upstream/account.py
-msgid "This account has been blocked"
-msgstr "Ang account na ito ay na-block"
-
-#: openlibrary/plugins/upstream/account.py
-msgid "This account has been locked"
-msgstr "Ang account na ito ay na-lock"
-
-#: openlibrary/plugins/upstream/account.py
-msgid "No account was found with this email. Please try again"
-msgstr "Walang natagpuang account gamit ang email na ito. Mangyaring subukan muli"
-
-#: openlibrary/plugins/upstream/account.py
-msgid "The password you entered is incorrect. Please try again"
-msgstr "Ang password na iyong ipinasok ay mali. Mangyaring subukan muli"
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Wrong password. Please try again"
-msgstr "Maling password. Mangyaring subukan muli"
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Please verify your Open Library account before logging in"
-msgstr "Mangyaring i-verify ang iyong Open Library account bago mag-log in"
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Please verify your Internet Archive account before logging in"
-msgstr "Mangyaring i-verify ang iyong Internet Archive account bago mag-log in"
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Please fill out all fields and try again"
-msgstr "Mangyaring punan ang lahat ng patlang at subukan muli"
-
-#: openlibrary/plugins/upstream/account.py
-msgid "This email is already registered"
-msgstr "Ang email na ito ay naka-rehistro na"
-
-#: openlibrary/plugins/upstream/account.py
-msgid "This username is already registered"
-msgstr "Ang username na ito ay naka-rehistro na"
-
-#: openlibrary/plugins/upstream/account.py
-msgid "A problem occurred and we were unable to log you in."
-msgstr "Isang problema ang nangyari at hindi kami makapag-log in sa iyo."
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Login attempted with invalid Internet Archive s3 credentials."
-msgstr "Sinubukang mag-log in gamit ang hindi wastong Internet Archive s3 na kredensyal."
-
-#: openlibrary/plugins/upstream/account.py
-msgid ""
-"Servers are experiencing unusually high traffic, please try again later "
-"or email openlibrary@archive.org for help."
-msgstr ""
-"Ang mga server ay nakakaranas ng hindi karaniwang mataas na trapiko, mangyaring subukan muli mamaya "
-"o mag-email sa openlibrary@archive.org para sa tulong."
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Email provider not recognized."
-msgstr "Hindi nakilala ang tagapagbigay ng email."
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Password requirements not met."
-msgstr "Hindi natugunan ang mga kinakailangan sa password."
-
-#: openlibrary/plugins/upstream/account.py
-msgid "A problem occurred and we were unable to log you in"
-msgstr "Isang problema ang nangyari at hindi kami makapag-log in sa iyo."
-
-#: openlibrary/plugins/upstream/account.py
-msgid ""
-"Login or registration attempt hit an unexpected error, please try again "
-"or contact info@archive.org"
-msgstr ""
-"Ang pagtatangkang mag-log in o magrehistro ay nakatagpo ng hindi inaasahang error, mangyaring subukan muli "
-"o makipag-ugnayan sa info@archive.org"
-
-#: openlibrary/plugins/upstream/account.py
-#, python-format
-msgid "Request failed with error code: %(error_code)s"
-msgstr "Bumagsak ang kahilingan na may error code: %(error_code)s"
-
-#: openlibrary/plugins/upstream/account.py
-msgid ""
-"Thank you for registering an Open Library account and requesting special "
-"print disability access. You should receive an email detailing next steps"
-" in the process."
-msgstr ""
-"Salamat sa pagrehistro ng isang Open Library account at humiling ng espesyal "
-"na access para sa mga may kapansanan. Dapat kang makatanggap ng email na naglalarawan sa susunod na mga hakbang "
-"sa proseso."
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Username unavailable"
-msgstr "Hindi available ang username"
-
-#: openlibrary/plugins/upstream/account.py
-#: openlibrary/plugins/upstream/forms.py
-msgid "Email already registered"
-msgstr "Naka-rehistro na ang email"
-
-#: openlibrary/plugins/upstream/account.py
-msgid "An Internet Archive account already exists with this email"
-msgstr "Mayroon nang Internet Archive account gamit ang email na ito"
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Email address is already used."
-msgstr "Ginagamit na ang email address."
-
-#: openlibrary/plugins/upstream/account.py
-msgid ""
-"Your email address couldn't be updated. The specified email address is "
-"already used."
-msgstr ""
-"Ang iyong email address ay hindi ma-update. Ang tinukoy na email address ay "
-"ginagamit na."
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Email verification successful."
-msgstr "Matagumpay ang email verification."
-
-#: openlibrary/plugins/upstream/account.py
-msgid ""
-"Your email address has been successfully verified and updated in your "
-"account."
-msgstr ""
-"Ang iyong email address ay matagumpay na na-verify at na-update sa iyong "
-"account."
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Email address couldn't be verified."
-msgstr "Hindi ma-verify ang email address."
-
-#: openlibrary/plugins/upstream/account.py
-msgid ""
-"Your email address couldn't be verified. The verification link seems "
-"invalid."
-msgstr ""
-"Ang iyong email address ay hindi ma-verify. Ang verification link ay tila "
-"invalid."
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Notification preferences have been updated successfully."
-msgstr "Ang mga preference sa notification ay matagumpay na na-update."
-
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
-msgid "Imports and Exports"
-msgstr "Mga Import at Export"
-
-#: admin/people/view.html books/mybooks_breadcrumb_select.html
-#: openlibrary/plugins/upstream/account.py type/user/view.html
-msgid "Loans"
-msgstr "Mga Pautang"
-
-#: account/mybooks.html account/sidebar.html
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
-msgid "Loan History"
-msgstr "Kasaysayan ng Pautang"
-
-#: openlibrary/plugins/upstream/borrow.py
-msgid ""
-"Your account has hit a lending limit. Please try again later or contact "
-"info@archive.org."
-msgstr ""
-"Ang iyong account ay umabot na sa limitasyon ng pagpapautang. Mangyaring subukan muli mamaya o makipag-ugnayan "
-"sa info@archive.org."
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Username"
-msgstr "Username"
-
-#: account/email/forgot-ia.html login.html
-#: openlibrary/plugins/upstream/forms.py
-msgid "Password"
-msgstr "Password"
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "No user registered with this email address"
-msgstr "Walang gumagamit na naka-rehistro gamit ang email address na ito"
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Disposable email not permitted"
-msgstr "Hindi pinapayagan ang disposable email"
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Your email provider is not recognized."
-msgstr "Hindi nakilala ang iyong tagapagbigay ng email."
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Username already used"
-msgstr "Username na ginagamit na"
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Must be between 3 and 20 letters and numbers"
-msgstr "Dapat ay nasa pagitan ng 3 at 20 letra at numero"
-
-#: account/create.html openlibrary/plugins/upstream/forms.py
-msgid "Must be between 3 and 20 characters"
-msgstr "Dapat ay nasa pagitan ng 3 at 20 karakter"
-
-#: account/create.html openlibrary/plugins/upstream/forms.py
-msgid "Must be a valid email address"
-msgstr "Dapat ay isang wastong email address"
-
-#: login.html openlibrary/plugins/upstream/forms.py
-msgid "Email"
-msgstr "Email"
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Screen Name"
-msgstr "Pangalan ng Screen"
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Public and cannot be changed later."
-msgstr "Pampubliko at hindi maaaring baguhin sa kalaunan."
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Invalid password"
-msgstr "Maling password"
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Your email address"
-msgstr "Ang iyong email address"
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Choose a password"
-msgstr "Pumili ng password"
-
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
-#: type/edition/modal_links.html
-msgid "Notes"
-msgstr "Mga Tala"
-
-#: account/sidebar.html books/mybooks_breadcrumb_select.html
-#: openlibrary/plugins/upstream/mybooks.py
-msgid "My Feed"
-msgstr "Aking Feed"
-
-#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
-#: my_books/dropdown_content.html my_books/primary_action.html
-#: openlibrary/plugins/upstream/mybooks.py search/sort_options.html
-msgid "Already Read"
-msgstr "Nabasa na"
-
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
-#, python-format
-msgid "Currently Reading (%(count)d)"
-msgstr "Kasalukuyang Binabasa (%(count)d)"
-
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
-#, python-format
-msgid "Want to Read (%(count)d)"
-msgstr "Gustong Basahin (%(count)d)"
-
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
-#, python-format
-msgid "Already Read (%(count)d)"
-msgstr "Nabasa na (%(count)d)"
-
-#: openlibrary/plugins/worksearch/code.py
-msgid "eBook?"
-msgstr "eBook?"
-
-#: openlibrary/plugins/worksearch/code.py type/edition/view.html
-#: type/work/view.html
-msgid "Language"
-msgstr "Wika"
-
-#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html
-#: openlibrary/plugins/worksearch/code.py search/advancedsearch.html
-#: search/work_search_selected_facets.html
-msgid "Author"
-msgstr "May-akda"
-
-#: openlibrary/plugins/worksearch/code.py
-msgid "First published"
-msgstr "Unang nailathala"
-
-#: openlibrary/plugins/worksearch/code.py publishers/view.html
-#: search/advancedsearch.html type/edition/view.html type/work/view.html
-msgid "Publisher"
-msgstr "Publisher"
-
-#: openlibrary/plugins/worksearch/code.py
-msgid "Classic eBooks"
-msgstr "Klasikal na eBooks"
-
-#: account.html account/notifications.html account/privacy.html
-#: lib/nav_head.html type/user/view.html
+#: account.html account/notifications.html account/privacy.html lib/nav_head.html type/user/view.html
 msgid "Settings"
 msgstr "Mga Setting"
 
@@ -1613,9 +27,17 @@ msgstr "Mga Setting"
 msgid "Settings & Privacy"
 msgstr "Mga Setting at Privacy"
 
-#: account.html
+#: account.html databarDiff.html
+msgid "View"
+msgstr "Tingnan"
+
+#: account.html status.html
 msgid "or"
 msgstr "o"
+
+#: account.html databarHistory.html databarTemplate.html databarView.html design/popover.html my_books/check_ins/check_in_prompt.html reading_goals/reading_goal_progress.html subjects.html type/edition/compact_title.html type/user/view.html
+msgid "Edit"
+msgstr "I-edit"
 
 #: account.html
 msgid "Your Profile Page"
@@ -1669,23 +91,17 @@ msgstr "Barcode Scanner (Beta)"
 msgid "Batch Imports"
 msgstr "Batch Imports"
 
-#: batch_import.html
-msgid ""
-"Attach a JSONL formatted document with import records or copy/paste the "
-"JSONL text into the textarea."
-msgstr ""
-"I-attach ang isang JSONL na format na dokumento na may mga tala ng import o kopyahin/i-paste ang "
-"JSONL na teksto sa textarea."
+#: BatchImportNavigation.html batch_import.html
+msgid "New Batch Import"
+msgstr "Bagong Batch Import"
 
 #: batch_import.html
-msgid ""
-"See the <a href=\"https://github.com/internetarchive/openlibrary-"
-"client/tree/master/olclient/schemata\">olclient import schemata</a> for "
-"more."
-msgstr ""
-"Tumingin sa <a href=\"https://github.com/internetarchive/openlibrary-"
-"client/tree/master/olclient/schemata\">olclient import schemata</a> para sa "
-"karagdagang impormasyon."
+msgid "Attach a JSONL formatted document with import records or copy/paste the JSONL text into the textarea."
+msgstr "I-attach ang isang JSONL na format na dokumento na may mga tala ng import o kopyahin/i-paste ang JSONL na teksto sa textarea."
+
+#: batch_import.html
+msgid "See the <a href=\"https://github.com/internetarchive/openlibrary-client/tree/master/olclient/schemata\">olclient import schemata</a> for more."
+msgstr "Tumingin sa <a href=\"https://github.com/internetarchive/openlibrary-client/tree/master/olclient/schemata\">olclient import schemata</a> para sa karagdagang impormasyon."
 
 #: batch_import.html
 msgid "Attach a file:"
@@ -1708,12 +124,8 @@ msgid "No import will be queued until *every* record validates successfully."
 msgstr "Walang import na naka-queue hanggang *lahat* ng tala ay matagumpay na naka-validate."
 
 #: batch_import.html
-msgid ""
-"Please update the JSONL file and reload this page (there should be no "
-"need to reattach the file)."
-msgstr ""
-"Pakisuyong i-update ang JSONL file at i-reload ang pahinang ito (hindi na "
-"kailangan pang i-attach muli ang file)."
+msgid "Please update the JSONL file and reload this page (there should be no need to reattach the file)."
+msgstr "Pakisuyong i-update ang JSONL file at i-reload ang pahinang ito (hindi na kailangan pang i-attach muli ang file)."
 
 #: batch_import.html
 msgid "Validation errors:"
@@ -1756,22 +168,21 @@ msgstr "Mga Nakatakdang Batch Imports"
 msgid "batch_id"
 msgstr "batch_id"
 
-#: admin/imports.html admin/imports_by_date.html batch_import_pending_view.html
-#: batch_import_view.html
+#: admin/imports.html admin/imports_by_date.html batch_import_pending_view.html batch_import_view.html
 msgid "Added Time"
 msgstr "Oras ng Pagdaragdag"
 
-#: account/import.html account/loans.html admin/imports.html
-#: admin/imports_by_date.html admin/loans_table.html admin/menu.html
-#: batch_import_pending_view.html batch_import_view.html
-#: librarian_dashboard/data_quality_table.html status.html
+#: account/import.html account/loans.html admin/imports.html admin/imports_by_date.html admin/loans_table.html admin/menu.html batch_import_pending_view.html batch_import_view.html librarian_dashboard/data_quality_table.html status.html
 msgid "Status"
 msgstr "Katayuan"
 
-#: batch_import_pending_view.html batch_import_view.html
-#: merge_request_table/table_header.html
+#: batch_import_pending_view.html batch_import_view.html merge_request_table/table_header.html
 msgid "Submitter"
 msgstr "Tagapagsumite"
+
+#: RecentChangesAdmin.html batch_import_pending_view.html batch_import_view.html
+msgid "Comments"
+msgstr "Mga Komento"
 
 #: batch_import_view.html
 msgid "Batch Import Status"
@@ -1809,8 +220,7 @@ msgstr "Mag-import ng Mga Item"
 msgid "Import Time"
 msgstr "Oras ng Pag-import"
 
-#: account/import.html admin/imports.html admin/imports_by_date.html
-#: batch_import_view.html librarian_dashboard/data_quality_table.html
+#: account/import.html admin/imports.html admin/imports_by_date.html batch_import_view.html librarian_dashboard/data_quality_table.html
 msgid "Error"
 msgstr "Error"
 
@@ -1831,53 +241,62 @@ msgid "Not yet imported"
 msgstr "Hindi pa nai-import"
 
 #: design.html
-msgid "Design Pattern Library"
-msgstr "Aklatan ng Disenyo ng Pattern"
+#, fuzzy
+msgid "Web Component Library"
+msgstr "Maligayang pagdating sa Open Library"
+
+#: OlPagination.html OlPaginationArrows.html design.html type/edition/view.html type/work/view.html
+msgid "Pagination"
+msgstr "Pagpapalimbag"
 
 #: design.html
-msgid "Colors"
-msgstr "Mga Kulay"
+#, fuzzy
+msgid "Popover"
+msgstr "Aprubahan"
+
+#: design.html type/edition/view.html type/work/view.html
+msgid "Read More"
+msgstr "Magbasa ng Higit Pa"
 
 #: design.html
-msgid "Background"
-msgstr "Background"
+#, fuzzy
+msgid "Chip"
+msgstr "IP"
+
+#: design.html design/button.html
+#, fuzzy
+msgid "Button"
+msgstr "Ipinanganak"
+
+#: design.html design/toast.html
+#, fuzzy
+msgid "Toast"
+msgstr "Kabuuan"
+
+#: design.html design/banner.html
+msgid "Banner"
+msgstr "Banner"
 
 #: design.html
-msgid "Primary Call To Action"
-msgstr "Pangunahing Tawag sa Aksyon"
+msgid "Chip Group"
+msgstr "Chip Group"
 
 #: design.html
-msgid "Link (unclicked)"
-msgstr "Link (hindi nakiklik)"
+msgid "Markdown Editor"
+msgstr "Markdown Editor"
 
 #: design.html
-msgid "Link (clicked)"
-msgstr "Link (na-click)"
-
-#: design.html
-msgid "Pagination component"
-msgstr "Komponent ng Pagsasangguni"
-
-#: design.html
-msgid ""
-"The ol-pagination component provides support for both event-based and "
-"URL-based navigation."
-msgstr ""
-"Ang komponent na ol-pagination ay nagbibigay ng suporta para sa parehong event-based at "
-"URL-based na nabigasyon."
+msgid "The ol-pagination component provides support for both event-based and URL-based navigation."
+msgstr "Ang komponent na ol-pagination ay nagbibigay ng suporta para sa parehong event-based at URL-based na nabigasyon."
 
 #: design.html
 msgid "Event-based"
 msgstr "Batay sa Kaganapan"
 
 #: design.html
-#, python-format
-msgid ""
-"When a page is clicked, the component fires an %(event_name)s event with "
-"the page number in %(event_detail)s."
+#, fuzzy, python-format
+msgid "When a page is clicked, the component fires an %(update_page)s event with the page number in %(event_detail)s."
 msgstr ""
-"Kapag isang pahina ang na-click, ang komponent ay nagpapadala ng %(event_name)s na kaganapan na may "
-"numero ng pahina sa %(event_detail)s."
 
 #: design.html
 msgid "Selected page:"
@@ -1888,12 +307,8 @@ msgid "URL-based Navigation"
 msgstr "Nabigasyon batay sa URL"
 
 #: design.html
-msgid ""
-"When base-url is provided, pagination renders anchor tags for SEO-"
-"friendly links."
-msgstr ""
-"Kapag ibinigay ang base-url, ang pagsasangguni ay naglalabas ng anchor tag para sa SEO-"
-"friendly links."
+msgid "When base-url is provided, pagination renders anchor tags for SEO-friendly links."
+msgstr "Kapag ibinigay ang base-url, ang pagsasangguni ay naglalabas ng anchor tag para sa SEO-friendly links."
 
 #: design.html
 msgid "First page (no previous arrow)"
@@ -1920,16 +335,30 @@ msgid "100 pages with ellipsis:"
 msgstr "100 pahina na may ellipsis:"
 
 #: design.html
-msgid "Read More component"
-msgstr "Component ng Magbasa Pa"
+#, fuzzy
+msgid "Arrows mode"
+msgstr "Ipakita ang higit pa"
 
 #: design.html
-msgid ""
-"The ol-read-more component provides expandable/collapsible content with "
-"two truncation modes: height-based and line-based."
-msgstr ""
-"Ang ol-read-more component ay nagbibigay ng expandable/collapsible na nilalaman na may "
-"dalawang paraan ng truncation: batay sa taas at batay sa linya."
+msgid "When total pages is unknown, use arrows mode to show only previous/next navigation."
+msgstr "Kapag ang kabuuang bilang ng mga pahina ay hindi alam, gamitin ang arrows mode upang ipakita lamang ang nabigasyon ng nakaraang/susunod."
+
+#: design.html
+msgid "Arrows mode (has next page)"
+msgstr "Arrows mode (may susunod na pahina)"
+
+#: design.html
+#, fuzzy
+msgid "Arrows mode (no next page)"
+msgstr "Huling pahina (walang susunod na arrow)"
+
+#: design.html
+msgid "Arrows mode (first page, has next)"
+msgstr "Arrows mode (unang pahina, may susunod)"
+
+#: design.html
+msgid "The ol-read-more component provides expandable/collapsible content with two truncation modes: height-based and line-based."
+msgstr "Ang ol-read-more component ay nagbibigay ng expandable/collapsible na nilalaman na may dalawang paraan ng truncation: batay sa taas at batay sa linya."
 
 #: design.html
 msgid "Height-based truncation"
@@ -1955,12 +384,16 @@ msgstr "Pasadyang teksto ng button"
 
 #: design.html
 #, python-format
-msgid ""
-"Use %(more_text)s and %(less_text)s to customize the toggle button "
-"labels. We'll use the i18n strings for this example."
-msgstr ""
-"Gamitin ang %(more_text)s at %(less_text)s upang pasadya ang mga label ng toggle button. "
-"Gagamitin namin ang mga string ng i18n para sa halimbawang ito."
+msgid "Use %(more_text)s and %(less_text)s to customize the toggle button labels. We'll use the i18n strings for this example."
+msgstr "Gamitin ang %(more_text)s at %(less_text)s upang pasadya ang mga label ng toggle button. Gagamitin namin ang mga string ng i18n para sa halimbawang ito."
+
+#: SearchResultsWork.html design.html
+msgid "Show more"
+msgstr "Ipakita ang higit pa"
+
+#: SearchResultsWork.html design.html
+msgid "Show less"
+msgstr "Ipakita ang mas kaunti"
 
 #: design.html
 msgid "Custom background color"
@@ -1968,12 +401,8 @@ msgstr "Pasadyang kulay ng background"
 
 #: design.html
 #, python-format
-msgid ""
-"Use %(background_color)s to match the gradient fade to your container "
-"background."
-msgstr ""
-"Gamitin ang %(background_color)s upang itugma ang gradient fade sa iyong container "
-"background."
+msgid "Use %(background_color)s to match the gradient fade to your container background."
+msgstr "Gamitin ang %(background_color)s upang itugma ang gradient fade sa iyong container background."
 
 #: design.html
 msgid "Small label size"
@@ -1995,6 +424,197 @@ msgstr "Kapag ang nilalaman ay nagkasya sa loob ng limitasyon, walang toggle but
 #: design.html
 msgid "This is short content that fits within 5 lines, so no button appears."
 msgstr "Ito ay maikling nilalaman na nagkasya sa loob ng 5 linya, kaya walang button na lumalabas."
+
+#: design.html
+#, python-format
+msgid "The ol-chip component is a pill-shaped interactive element for filters, tags, and selections. It fires an %(event)s event on click."
+msgstr "Ang ol-chip na komponent ay isang interactive na elementong hugis-pill para sa mga filter, tag, at seleksyon. Nagpapalabas ito ng %(event)s na kaganapan sa pag-click."
+
+#: design.html
+msgid "Default (medium)"
+msgstr "Default (katamtaman)"
+
+#: design.html
+msgid "Basic chips at the default medium size."
+msgstr "Mga pangunahing chip sa default na katamtamang laki."
+
+#: design.html
+#, fuzzy
+msgid "Fiction"
+msgstr "Edisyon"
+
+#: design.html openlibrary/plugins/openlibrary/home.py
+msgid "Science"
+msgstr "Agham"
+
+#: databarDiff.html databarEdit.html databarTemplate.html databarView.html design.html lib/history.html openlibrary/plugins/openlibrary/home.py
+msgid "History"
+msgstr "Kasaysayan"
+
+#: design.html
+#, fuzzy
+msgid "Selected state"
+msgstr "Napiling pahina:"
+
+#: design.html
+msgid "A selected chip displays a checkmark icon and uses an active color scheme."
+msgstr "Ang napiling chip ay nagpapakita ng checkmark icon at gumagamit ng aktibong color scheme."
+
+#: design.html
+#, fuzzy
+msgid "Small size"
+msgstr "Maliit na sukat ng label"
+
+#: design.html
+#, python-format
+msgid "Use %(size)s for a compact chip."
+msgstr "Gamitin ang %(size)s para sa compact na chip."
+
+#: design.html
+#, fuzzy
+msgid "Poetry"
+msgstr "Subukan muli?"
+
+#: design.html
+#, fuzzy
+msgid "Drama"
+msgstr "Data"
+
+#: design.html
+#, fuzzy
+msgid "Essays"
+msgstr "less"
+
+#: design.html
+#, fuzzy
+msgid "With count"
+msgstr "Bilang ng Trabaho"
+
+#: design.html
+#, python-format
+msgid "Use %(count)s to display a number alongside the label."
+msgstr "Gamitin ang %(count)s upang magpakita ng numero kasabay ng label."
+
+#: design.html
+#, fuzzy
+msgid "As a link"
+msgstr "Magdagdag ng Link"
+
+#: design.html
+#, python-format
+msgid "When %(href)s is provided, the chip renders as an anchor tag instead of a button."
+msgstr "Kapag ibinigay ang %(href)s, ang chip ay nagre-render bilang anchor tag sa halip na button."
+
+#: design.html
+#, fuzzy
+msgid "Interactive toggle"
+msgstr "Logo ng Internet Archive"
+
+#: design.html
+#, python-format
+msgid "Clicking a chip fires an %(event)s event. Toggle the selected state by listening to the event."
+msgstr "Ang pag-click sa chip ay nagpapalabas ng %(event)s na kaganapan. I-toggle ang napiling estado sa pamamagitan ng pakikinig sa kaganapan."
+
+#: design.html
+msgid "Toggle me"
+msgstr "I-toggle ako"
+
+#: design.html
+msgid "Toggle me too"
+msgstr "I-toggle din ako"
+
+#: design.html
+msgid "The ol-chip-group component is a flex-wrap container that provides consistent spacing for groups of chips."
+msgstr "Ang ol-chip-group na komponent ay isang flex-wrap na lalagyan na nagbibigay ng pare-parehong espasyo para sa mga grupo ng chip."
+
+#: design.html
+msgid "Default (medium gap)"
+msgstr "Default (katamtamang agwat)"
+
+#: design.html
+msgid "Chips are spaced with an 8px gap by default."
+msgstr "Ang mga chip ay may 8px na agwat bilang default."
+
+#: design.html
+msgid "Small gap"
+msgstr "Maliit na agwat"
+
+#: design.html
+#, python-format
+msgid "Use %(gap)s for tighter spacing (4px)."
+msgstr "Gamitin ang %(gap)s para sa mas siksik na pagitan (4px)."
+
+#: design.html
+msgid "Large gap"
+msgstr "Malaking agwat"
+
+#: design.html
+#, python-format
+msgid "Use %(gap)s for wider spacing (12px)."
+msgstr "Gamitin ang %(gap)s para sa mas malawak na pagitan (12px)."
+
+#: design.html
+msgid "Wrapping behavior"
+msgstr "Pag-uugali ng pag-wrap"
+
+#: design.html
+msgid "Chips automatically wrap to the next line when they exceed the container width."
+msgstr "Ang mga chip ay awtomatikong nag-a-wrap sa susunod na linya kapag nalampasan ang lapad ng container."
+
+#: design.html
+#, fuzzy
+msgid "Biography"
+msgstr "Talambuhay"
+
+#: design.html
+msgid "With mixed chip states"
+msgstr "Na may pinaghalo-halong estado ng chip"
+
+#: design.html
+msgid "Chip groups work with any combination of chip sizes, states, and link chips."
+msgstr "Ang mga chip group ay gumagana sa anumang kombinasyon ng mga laki ng chip, estado, at link chip."
+
+#: design.html
+msgid "The ol-markdown-editor component is a WYSIWYG editor built on Tiptap that outputs Markdown. It syncs its content to a hidden target textarea. A 'View source' toolbar toggle is always available so editors can drop into a raw markdown textarea when WYSIWYG round-trips are awkward."
+msgstr "Ang ol-markdown-editor na komponent ay isang WYSIWYG editor na itinayo sa Tiptap na nagpapalabas ng Markdown. Sini-sync nito ang nilalaman nito sa isang nakatagong target textarea. Ang 'View source' toolbar toggle ay laging magagamit upang makapasok ang mga editor sa hilaw na markdown textarea kapag hindi maginhawa ang WYSIWYG round-trip."
+
+#: design.html
+#, fuzzy
+msgid "Basic usage"
+msgstr "Mayroong wika"
+
+#: design.html
+#, python-format
+msgid "Provide a %(target_id)s pointing to an existing textarea. The editor reads initial content from the textarea and syncs changes back to it."
+msgstr "Magbigay ng %(target_id)s na nagtuturo sa isang umiiral na textarea. Binabasa ng editor ang paunang nilalaman mula sa textarea at sini-sync ang mga pagbabago pabalik dito."
+
+#: design.html
+msgid "Mixed Markdown and HTML"
+msgstr "Pinaghalo-halong Markdown at HTML"
+
+#: design.html
+#, python-format
+msgid "Add the %(attr)s attribute to expose the HTML block button in the toolbar. HTML blocks appear with a preview and an Edit button to modify the source."
+msgstr "Idagdag ang %(attr)s na katangian upang ilantad ang HTML block button sa toolbar. Ang mga HTML block ay lilitaw na may preview at isang Edit button upang baguhin ang pinagkukunan."
+
+#: design.html
+msgid "Code blocks and inline code"
+msgstr "Mga code block at inline na code"
+
+#: design.html
+#, python-format
+msgid "Add the %(attr)s attribute to expose the inline code and code block buttons in the toolbar. Code support is off by default because only the wiki page renderer is guaranteed to render fenced code blocks."
+msgstr "Idagdag ang %(attr)s na katangian upang ilantad ang mga inline code at code block button sa toolbar. Ang suporta ng code ay naka-off bilang default dahil tanging ang wiki page renderer lamang ang ginagarantiyahang mag-render ng mga fenced code block."
+
+#: design.html
+#, fuzzy
+msgid "Change event"
+msgstr "Baguhin"
+
+#: design.html
+#, python-format
+msgid "The editor fires an %(event)s event on every change. The raw Markdown string is available in %(detail)s."
+msgstr "Ang editor ay nagpapalabas ng %(event)s na kaganapan sa bawat pagbabago. Ang hilaw na Markdown string ay makukuha sa %(detail)s."
 
 #: diff.html
 #, python-format
@@ -2018,7 +638,7 @@ msgstr "ni Walang Pangalan"
 msgid "history"
 msgstr "kasaysayan"
 
-#: diff.html
+#: diff.html status.html
 msgid "Added"
 msgstr "Idinagdag"
 
@@ -2054,6 +674,10 @@ msgstr "Kanselahin, at bumalik."
 msgid "YAML Representation:"
 msgstr "YAML Pagsasakatawan:"
 
+#: BookPreview.html book_providers/read_button.html books/edit/edition.html editpage.html import_preview.html
+msgid "Preview"
+msgstr "Tukuyin"
+
 #: history.html
 msgid "History of edits to"
 msgstr "Kasaysayan ng mga pag-edit sa"
@@ -2061,6 +685,18 @@ msgstr "Kasaysayan ng mga pag-edit sa"
 #: history.html
 msgid "Revision"
 msgstr "Rebisyon"
+
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html admin/ip/view.html admin/people/edits.html history.html recentchanges/render.html recentchanges/updated_records.html
+msgid "When"
+msgstr "Kailan"
+
+#: RecentChanges.html admin/history.html admin/ip/view.html admin/loans_table.html admin/people/edits.html history.html recentchanges/render.html
+msgid "Who"
+msgstr "Sino"
+
+#: RecentChanges.html RecentChangesUsers.html admin/history.html admin/ip/view.html admin/people/edits.html history.html recentchanges/render.html recentchanges/updated_records.html
+msgid "Comment"
+msgstr "Komento"
 
 #: history.html
 msgid "Diff"
@@ -2086,10 +722,6 @@ msgstr "Ihambing ang bersyon na ito..."
 #: history.html
 msgid "...to this version"
 msgstr "...sa bersyon na ito"
-
-#: books/daisy.html history.html
-msgid "Back"
-msgstr "Bumalik"
 
 #: import_preview.html
 msgid "Import Preview"
@@ -2127,29 +759,17 @@ msgstr "Ikinalulungkot namin, isang problema ang nangyari habang tumutugon sa iy
 
 #: internalerror.html
 #, python-format
-msgid ""
-"The reference code %s and Sentry trace ID %s have been created to track "
-"this error and we will investigate as we're able."
-msgstr ""
-"Ang reference code na %s at Sentry trace ID na %s ay nalikha upang subaybayan "
-"ang error na ito at aming susuriin kapag kami'y may kakayahan."
+msgid "The reference code %s and Sentry trace ID %s have been created to track this error and we will investigate as we're able."
+msgstr "Ang reference code na %s at Sentry trace ID na %s ay nalikha upang subaybayan ang error na ito at aming susuriin kapag kami'y may kakayahan."
 
 #: internalerror.html
 #, python-format
-msgid ""
-"The reference code %s has been created to track this error and we will "
-"investigate as we're able."
-msgstr ""
-"Ang reference code na %s ay nalikha upang subaybayan ang error na ito at kami'y "
-"magsasaliksik kapag kami'y may kakayahan."
+msgid "The reference code %s has been created to track this error and we will investigate as we're able."
+msgstr "Ang reference code na %s ay nalikha upang subaybayan ang error na ito at kami'y magsasaliksik kapag kami'y may kakayahan."
 
 #: internalerror.html
-msgid ""
-"Return to the <a class=\"go-back-link\" href=\"javascript:;\">previous "
-"page</a>?"
-msgstr ""
-"Bumalik sa <a class=\"go-back-link\" href=\"javascript:;\">nakaraang "
-"pahina</a>?"
+msgid "Return to the <a class=\"go-back-link\" href=\"javascript:;\">previous page</a>?"
+msgstr "Bumalik sa <a class=\"go-back-link\" href=\"javascript:;\">nakaraang pahina</a>?"
 
 #: interstitial.html
 msgid "You are being redirected to your book"
@@ -2157,17 +777,17 @@ msgstr "Ikaw ay nirere-direkta sa iyong libro"
 
 #: interstitial.html
 #, python-format
-msgid ""
-"This book is provided by %(book_provider)s, a third-party Open Library "
-"Trusted Book Provider"
-msgstr ""
-"Ang aklat na ito ay ibinibigay ng %(book_provider)s, isang third-party na "
-"Trusted Book Provider ng Open Library"
+msgid "This book is provided by %(book_provider)s, a third-party Open Library Trusted Book Provider"
+msgstr "Ang aklat na ito ay ibinibigay ng %(book_provider)s, isang third-party na Trusted Book Provider ng Open Library"
 
 #: interstitial.html
 #, python-format
 msgid "In %(time)s seconds, you will be automatically redirected to: %(url)s"
 msgstr "Sa loob ng %(time)s segundo, ikaw ay awtomatikong ididirekta sa: %(url)s"
+
+#: CreateListModal.html EditButtons.html account/notifications.html account/password/reset.html account/privacy.html admin/imports-add.html admin/permissions.html books/add.html databarEdit.html design/button.html interstitial.html merge/authors.html my_books/dropdown_content.html type/list/edit.html type/series/edit.html type/tag/form.html
+msgid "Cancel"
+msgstr "Kanselahin"
 
 #: interstitial.html
 msgid "Continue without waiting"
@@ -2177,9 +797,7 @@ msgstr "Magpatuloy nang hindi nag-aantay"
 msgid "Library Explorer"
 msgstr "Library Explorer"
 
-#: account/create.html books/custom_carousel.html
-#: librarian_dashboard/data_quality_table.html login.html
-#: search/work_search_facets.html
+#: account/create.html books/custom_carousel.html librarian_dashboard/data_quality_table.html login.html search/work_search_facets.html
 msgid "Loading..."
 msgstr "Naglo-load..."
 
@@ -2188,12 +806,8 @@ msgid "Log In"
 msgstr "Mag-log In"
 
 #: login.html
-msgid ""
-"This is a development instance, the default credentials are automatically"
-" filled."
-msgstr ""
-"Ito ay isang development instance, ang default credentials ay awtomatikong"
-" napunan."
+msgid "This is a development instance, the default credentials are automatically filled."
+msgstr "Ito ay isang development instance, ang default credentials ay awtomatikong napunan."
 
 #: login.html
 msgid "email:"
@@ -2204,12 +818,8 @@ msgid "password:"
 msgstr "password:"
 
 #: login.html
-msgid ""
-"Log in to use your free Open Library card to borrow digital books from "
-"the nonprofit Internet Archive"
-msgstr ""
-"Mag-log in upang gamitin ang iyong libreng Open Library card upang manghiram "
-"ng mga digital na libro mula sa nonprofit na Internet Archive."
+msgid "Log in to use your free Open Library card to borrow digital books from the nonprofit Internet Archive"
+msgstr "Mag-log in upang gamitin ang iyong libreng Open Library card upang manghiram ng mga digital na libro mula sa nonprofit na Internet Archive."
 
 #: account/create.html login.html
 msgid "OR"
@@ -2221,26 +831,24 @@ msgid "You are already logged into Open Library as %(user)s."
 msgstr "Ikaw ay naka-log in na sa Open Library bilang %(user)s."
 
 #: account/create.html login.html
-msgid ""
-"If you'd like to create a new, different Open Library account, you'll "
-"need to <a href=\"javascript:;\" onclick=\"document.forms['hamburger-"
-"logout'].submit()\">log out</a> and start the signup process afresh."
-msgstr ""
-"Kung nais mong lumikha ng isang bagong, ibang Open Library account, kailangan "
-"mong <a href=\"javascript:;\" onclick=\"document.forms['hamburger-"
-"logout'].submit()\">mag-log out</a> at simulan muli ang proseso ng pag-signup."
+msgid "If you'd like to create a new, different Open Library account, you'll need to <a href=\"javascript:;\" onclick=\"document.forms['hamburger-logout'].submit()\">log out</a> and start the signup process afresh."
+msgstr "Kung nais mong lumikha ng isang bagong, ibang Open Library account, kailangan mong <a href=\"javascript:;\" onclick=\"document.forms['hamburger-logout'].submit()\">mag-log out</a> at simulan muli ang proseso ng pag-signup."
 
 #: login.html
-msgid ""
-"Please enter your <a href=\"https://archive.org\">Internet Archive</a> "
-"email and password to access your Open Library account."
-msgstr ""
-"Pakisuyong ilagay ang iyong <a href=\"https://archive.org\">Internet Archive</a> "
-"email at password upang ma-access ang iyong Open Library account."
+msgid "Please enter your <a href=\"https://archive.org\">Internet Archive</a> email and password to access your Open Library account."
+msgstr "Pakisuyong ilagay ang iyong <a href=\"https://archive.org\">Internet Archive</a> email at password upang ma-access ang iyong Open Library account."
+
+#: login.html openlibrary/plugins/upstream/forms.py
+msgid "Email"
+msgstr "Email"
 
 #: login.html
 msgid "Forgot your Internet Archive email?"
 msgstr "Nakalimutan mo ang iyong Internet Archive email?"
+
+#: account/email/forgot-ia.html login.html openlibrary/plugins/upstream/forms.py
+msgid "Password"
+msgstr "Password"
 
 #: login.html
 msgid "Forgot your Password?"
@@ -2277,6 +885,10 @@ msgstr "Idinagdag ang bagong libro."
 #: messages.html
 msgid "Thank you for improving the Open Library catalog!"
 msgstr "Salamat sa pagpapabuti ng Open Library catalog!"
+
+#: BookPreview.html CreateListModal.html NotesModal.html ObservationsModal.html ShareModal.html covers/author_photo.html covers/book_cover.html covers/change.html design/banner.html design/toast.html lib/exports.html my_books/check_ins/check_in_prompt.html my_books/dropdown_content.html native_dialog.html
+msgid "Close"
+msgstr "Isara"
 
 #: notfound.html
 #, python-format
@@ -2327,21 +939,13 @@ msgstr "Pahintulot tinanggihan."
 
 #: permission_denied.html
 #, python-format
-msgid ""
-"Only logged users are allowed to add records on Open Library. Please <a "
-"href=\"%s\">log in</a> to add a book."
-msgstr ""
-"Tanging mga naka-log in lamang ang pinapayagang magdagdag ng mga tala sa Open Library. Pakisuyong <a "
-"href=\"%s\">mag-log in</a> upang magdagdag ng libro."
+msgid "Only logged users are allowed to add records on Open Library. Please <a href=\"%s\">log in</a> to add a book."
+msgstr "Tanging mga naka-log in lamang ang pinapayagang magdagdag ng mga tala sa Open Library. Pakisuyong <a href=\"%s\">mag-log in</a> upang magdagdag ng libro."
 
 #: permission_denied.html
 #, python-format
-msgid ""
-"Only logged users are allowed to modify records on Open Library. Please "
-"<a href=\"%s\">log in</a> to edit this page."
-msgstr ""
-"Tanging mga naka-log in lamang ang pinapayagang i-modify ang mga tala sa Open Library. Pakisuyong "
-"<a href=\"%s\">mag-log in</a> upang i-edit ang pahinang ito."
+msgid "Only logged users are allowed to modify records on Open Library. Please <a href=\"%s\">log in</a> to edit this page."
+msgstr "Tanging mga naka-log in lamang ang pinapayagang i-modify ang mga tala sa Open Library. Pakisuyong <a href=\"%s\">mag-log in</a> upang i-edit ang pahinang ito."
 
 #: permission_denied.html
 #, python-format
@@ -2349,12 +953,8 @@ msgid "You may <a href=\"%s\">log in</a> if you have the required permissions."
 msgstr "Maaari kang <a href=\"%s\">mag-log in</a> kung mayroon kang kinakailangang pahintulot."
 
 #: recaptcha.html
-msgid ""
-"Please satisfy the reCAPTCHA below. If you have security settings or "
-"privacy blockers installed, please disable them to see the reCAPTCHA."
-msgstr ""
-"Pakisuyong ayusin ang reCAPTCHA sa ibaba. Kung mayroon kang mga setting sa seguridad o "
-"mga privacy blockers na naka-install, pakisuyong i-disable ang mga ito upang makita ang reCAPTCHA."
+msgid "Please satisfy the reCAPTCHA below. If you have security settings or privacy blockers installed, please disable them to see the reCAPTCHA."
+msgstr "Pakisuyong ayusin ang reCAPTCHA sa ibaba. Kung mayroon kang mga setting sa seguridad o mga privacy blockers na naka-install, pakisuyong i-disable ang mga ito upang makita ang reCAPTCHA."
 
 #: recaptcha.html
 msgid "Incorrect. Please try again."
@@ -2376,8 +976,7 @@ msgstr "ID ng Rekord"
 msgid "Source"
 msgstr "Pinagmulan"
 
-#: books/add.html covers/add.html showia.html type/edition/view.html
-#: type/work/view.html
+#: books/add.html covers/add.html showia.html type/edition/view.html type/work/view.html
 msgid "Internet Archive"
 msgstr "Internet Archive"
 
@@ -2401,6 +1000,10 @@ msgstr "LEADER:"
 msgid "Download Link"
 msgstr "I-download ang Link"
 
+#: showmarc.html type/tag/index.html
+msgid "Next"
+msgstr "Susunod"
+
 #: status.html
 msgid "Open Library server status"
 msgstr "Katayuan ng server ng Open Library"
@@ -2410,8 +1013,125 @@ msgid "Server status"
 msgstr "Katayuan ng server"
 
 #: status.html
-msgid "Staged"
-msgstr "Naka-stage"
+msgid "Testing Environment"
+msgstr "Kapaligiran ng Pagsubok"
+
+#: status.html
+msgid "Deploy triggered!"
+msgstr "Na-trigger ang deploy!"
+
+#: status.html
+#, fuzzy
+msgid "View Jenkins progress"
+msgstr "Nasa proseso..."
+
+#: status.html
+msgid "GitHub status refreshed."
+msgstr "Na-refresh ang status ng GitHub."
+
+#: status.html
+msgid "PR numbers or URLs, space/comma separated"
+msgstr "Mga numero ng PR o URL, pinaghiwalay ng espasyo/kuwit"
+
+#: status.html
+msgid "Add PR(s)"
+msgstr "Idagdag ang PR(s)"
+
+#: status.html
+#, fuzzy
+msgid "PR"
+msgstr "Nakaraan"
+
+#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html search/advancedsearch.html status.html type/about/edit.html type/page/edit.html type/template/edit.html
+msgid "Title"
+msgstr "Pamagat"
+
+#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html openlibrary/plugins/worksearch/code.py search/advancedsearch.html search/work_search_selected_facets.html status.html
+msgid "Author"
+msgstr "May-akda"
+
+#: status.html
+msgid "Assignee"
+msgstr "Itinalaga"
+
+#: status.html
+#, fuzzy
+msgid "Pinned Commit"
+msgstr "Komento ng Admin"
+
+#: status.html
+#, fuzzy
+msgid "Branch HEAD"
+msgstr "Batch ID:"
+
+#: status.html
+#, fuzzy
+msgid "Drift"
+msgstr "I-edit"
+
+#: status.html
+#, fuzzy
+msgid "Enabled"
+msgstr "Naipadala sa Email"
+
+#: status.html
+#, fuzzy
+msgid "up to date"
+msgstr "I-update"
+
+#: status.html
+#, fuzzy
+msgid "unknown"
+msgstr "Hindi Kilala"
+
+#: status.html
+msgid "1 commit behind"
+msgstr "1 commit na nahuhuli"
+
+#: status.html
+#, fuzzy, python-format
+msgid "%(count)s commits behind"
+msgstr "%(count)s edisyon"
+
+#: admin/solr.html status.html
+msgid "Update"
+msgstr "I-update"
+
+#: status.html
+#, fuzzy
+msgid "Enable"
+msgstr "Halimbawa"
+
+#: status.html
+msgid "Disable"
+msgstr "I-disable"
+
+#: lists/lists.html status.html type/list/edit.html type/series/edit.html
+msgid "Remove"
+msgstr "Tanggalin"
+
+#: status.html
+#, fuzzy
+msgid "Selected PRs"
+msgstr "Napiling pahina:"
+
+#: status.html
+#, fuzzy
+msgid "Refresh"
+msgstr "Referrers"
+
+#: status.html
+#, fuzzy
+msgid "Deploy"
+msgstr "Tumugon"
+
+#: status.html
+msgid "No PRs in testing set."
+msgstr "Walang mga PR sa testing set."
+
+#: status.html
+msgid "Last Build Result"
+msgstr "Huling Resulta ng Build"
 
 #: status.html
 msgid "View PRs on GitHub"
@@ -2421,8 +1141,7 @@ msgstr "Tingnan ang PRs sa GitHub"
 msgid "Show changed files"
 msgstr "Ipakita ang mga nagbago na file"
 
-#: admin/inspect/store.html admin/people/index.html status.html
-#: type/author/edit.html type/language/view.html
+#: admin/inspect/store.html admin/people/index.html status.html type/author/edit.html type/language/view.html
 msgid "Name"
 msgstr "Pangalan"
 
@@ -2466,8 +1185,7 @@ msgstr "Paglilinaw"
 msgid "Now"
 msgstr "Ngayon"
 
-#: admin/graphs.html admin/index.html my_books/check_ins/check_in_form.html
-#: my_books/check_ins/check_in_prompt.html trending.html
+#: admin/graphs.html admin/index.html my_books/check_ins/check_in_form.html my_books/check_ins/check_in_prompt.html trending.html
 msgid "Today"
 msgstr "Ngayon"
 
@@ -2487,6 +1205,10 @@ msgstr "Taong ito"
 msgid "All Time"
 msgstr "Lahat ng Oras"
 
+#: home/index.html openlibrary/plugins/openlibrary/api.py trending.html
+msgid "Trending Books"
+msgstr "Umangat na Mga Aklat"
+
 #: trending.html
 msgid "See what readers from the community are adding to their bookshelves"
 msgstr "Tingnan kung ano ang idinadagdag ng mga mambabasa mula sa komunidad sa kanilang mga bookshelf"
@@ -2495,16 +1217,34 @@ msgstr "Tingnan kung ano ang idinadagdag ng mga mambabasa mula sa komunidad sa k
 msgid "Earliest trending data is from October 2017"
 msgstr "Ang pinakamatandang data ng trending ay mula Oktubre 2017"
 
-#: account/mybooks.html account/sidebar.html my_books/dropdown_content.html
-#: my_books/primary_action.html search/sort_options.html trending.html
+#. Label for the reading log shelf for books the user plans to read in the
+#. future (bookshelf ID 1). Used as a button label and shelf name.
+#: account/mybooks.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html trending.html
 msgid "Want to Read"
 msgstr "Gustong Basahin"
 
-#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
-#: my_books/dropdown_content.html my_books/primary_action.html
-#: search/sort_options.html trending.html
+#. Display name for the "currently-reading" reading log shelf used in page
+#. headings and breadcrumbs.
+#. Label for the reading log shelf for books the user is actively reading
+#. (bookshelf ID 2). Used as a button label and shelf name.
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html trending.html
 msgid "Currently Reading"
 msgstr "Kasalukuyan Nang Binabasa"
+
+#: LoanReadForm.html ReadButton.html admin/inspect/memcache.html book_providers/read_button.html books/edit/edition.html trending.html type/list/embed.html widget.html
+msgid "Read"
+msgstr "Basahin"
+
+#. Display name for the "stopped-reading" reading log shelf used in page
+#. headings and breadcrumbs.
+#. Label for the reading log shelf for books the user stopped reading before
+#. finishing (bookshelf ID 4). Used as a button label and shelf name.
+#. Label for the reading log shelf for books the user stopped reading
+#. (bookshelf ID 4). Used as a button label and shelf name.
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html trending.html
+#, fuzzy
+msgid "Stopped Reading"
+msgstr "Kasalukuyang Uso"
 
 #: trending.html
 #, python-format
@@ -2515,6 +1255,29 @@ msgstr "May taong nagmarka bilang %(shelf)s %(k_hours_ago)s"
 #, python-format
 msgid "Logged %(count)i times %(time_unit)s"
 msgstr "Naitala %(count)i beses %(time_unit)s"
+
+#: verify_human.html
+#, fuzzy
+msgid "Human Verification"
+msgstr "Nabigo ang Pag-verify ng Email"
+
+#: verify_human.html
+msgid "Please verify you are human to continue."
+msgstr "Mangyaring i-verify na ikaw ay tao upang magpatuloy."
+
+#: verify_human.html
+msgid "Verify you are human"
+msgstr "I-verify na ikaw ay tao"
+
+#: verify_human.html
+#, fuzzy
+msgid "Verification failed. Please try again."
+msgstr "Maling password. Mangyaring subukan muli"
+
+#: verify_human.html
+#, fuzzy
+msgid "Verifying..."
+msgstr "Nagre-edit..."
 
 #: viewpage.html
 msgid "Revert to this revision?"
@@ -2534,10 +1297,18 @@ msgstr "Basahin ang \"%(title)s\""
 msgid "Borrow \"%(title)s\""
 msgstr "Umatras ng \"%(title)s\""
 
+#: ReadButton.html books/edit/edition.html type/list/embed.html widget.html
+msgid "Borrow"
+msgstr "Hiramin"
+
 #: widget.html
 #, python-format
 msgid "Join waitlist for \"%(title)s\""
 msgstr "Sumali sa listahan ng paghihintay para sa \"%(title)s\""
+
+#: LoanStatus.html widget.html
+msgid "Join Waitlist"
+msgstr "Sumali sa Waitlist"
 
 #: widget.html
 #, python-format
@@ -2549,9 +1320,9 @@ msgid "Learn More"
 msgstr "Matuto Nang Higit Pa"
 
 #: widget.html
-#, python-format
-msgid "on <a target=\"_blank\" href=\"%(link)s\">openlibrary.org</a>"
-msgstr "sa <a target=\"_blank\" href=\"%(link)s\">openlibrary.org</a>"
+#, fuzzy, python-format
+msgid "on <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"%(link)s\">openlibrary.org</a>"
+msgstr ""
 
 #: work_search.html
 msgid "Search Books"
@@ -2560,6 +1331,10 @@ msgstr "Maghanap ng Mga Libro"
 #: work_search.html
 msgid "Keywords"
 msgstr "Mga Keyword"
+
+#: RecentChanges.html recentchanges/index.html work_search.html
+msgid "Everything"
+msgstr "Lahat"
 
 #: work_search.html
 msgid "Ebooks"
@@ -2598,8 +1373,7 @@ msgstr "Magdagdag ng bagong libro?"
 msgid "Checking Search Inside matches"
 msgstr "Tinitingnan ang mga tugma sa Search Inside"
 
-#: account/reading_log.html search/authors.html search/lists.html
-#: search/subjects.html work_search.html
+#: account/reading_log.html search/authors.html search/lists.html search/subjects.html work_search.html
 #, python-format
 msgid "%(count)s hit"
 msgid_plural "%(count)s hits"
@@ -2616,12 +1390,8 @@ msgid "The Open Library Team"
 msgstr "Ang Koponan ng Open Library"
 
 #: about/index.html
-msgid ""
-"Open Library is made possible because of a dedicated team of staff and "
-"over 100 volunteers from around the globe."
-msgstr ""
-"Ang Open Library ay naging posible dahil sa isang dedikadong koponan ng mga tauhan "
-"at mahigit 100 boluntaryo mula sa iba't ibang panig ng mundo."
+msgid "Open Library is made possible because of a dedicated team of staff and over 100 volunteers from around the globe."
+msgstr "Ang Open Library ay naging posible dahil sa isang dedikadong koponan ng mga tauhan at mahigit 100 boluntaryo mula sa iba't ibang panig ng mundo."
 
 #: about/index.html
 msgid "Want to join us?"
@@ -2631,7 +1401,7 @@ msgstr "Gustong sumali sa amin?"
 msgid "Role:"
 msgstr "Papel:"
 
-#: about/index.html lib/nav_head.html
+#: about/index.html lib/nav_head.html type/tag/index.html
 msgid "All"
 msgstr "Lahat"
 
@@ -2668,16 +1438,16 @@ msgid "Librarianship"
 msgstr "Librarian"
 
 #: about/index.html
-msgid ""
-"If you volunteer with Open Library and would like to be listed as part of"
-" the team, then complete the <a "
-"href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">Open Library team "
-"information form</a>."
-msgstr ""
-"Kung ikaw ay magboboluntaryo sa Open Library at nais maging bahagi ng"
-" koponan, kumpletuhin ang <a "
-"href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">form ng impormasyon ng
-"Open Library team</a>."
+msgid "If you volunteer with Open Library and would like to be listed as part of the team, then complete the <a href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">Open Library team information form</a>."
+msgstr "Kung ikaw ay magboboluntaryo sa Open Library at nais maging bahagi ng koponan, kumpletuhin ang <a href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">form ng impormasyon nOpen Library team</a>."
+
+#: account/create.html openlibrary/plugins/upstream/forms.py
+msgid "Must be a valid email address"
+msgstr "Dapat ay isang wastong email address"
+
+#: account/create.html openlibrary/plugins/upstream/forms.py
+msgid "Must be between 3 and 20 characters"
+msgstr "Dapat ay nasa pagitan ng 3 at 20 karakter"
 
 #: account/create.html
 msgid "Username may only contain numbers, letters, - or _"
@@ -2696,12 +1466,8 @@ msgid "Sign Up"
 msgstr "Mag-sign Up"
 
 #: account/create.html
-msgid ""
-"Get your free Open Library card and borrow digital books from the "
-"nonprofit Internet Archive"
-msgstr ""
-"Kunin ang iyong libreng Open Library card at manghiram ng digital na libro mula sa "
-"nonprofit na Internet Archive"
+msgid "Get your free Open Library card and borrow digital books from the nonprofit Internet Archive"
+msgstr "Kunin ang iyong libreng Open Library card at manghiram ng digital na libro mula sa nonprofit na Internet Archive"
 
 #: account/create.html type/author/view.html
 msgid "Success!"
@@ -2716,50 +1482,30 @@ msgid "screenname"
 msgstr "pangalan ng screen"
 
 #: account/create.html
-msgid ""
-"I want to receive news, announcements, and resources from the <a "
-"href=\"https://archive.org/\">Internet Archive</a>, the non-profit that "
-"runs Open Library."
-msgstr ""
-"Gusto kong makatanggap ng balita, anunsyo, at mga mapagkukunang mula sa <a "
-"href=\"https://archive.org/\">Internet Archive</a>, ang non-profit na "
-"namamahala sa Open Library."
+msgid "I want to receive news, announcements, and resources from the <a href=\"https://archive.org/\">Internet Archive</a>, the non-profit that runs Open Library."
+msgstr "Gusto kong makatanggap ng balita, anunsyo, at mga mapagkukunang mula sa <a href=\"https://archive.org/\">Internet Archive</a>, ang non-profit na namamahala sa Open Library."
 
 #: account/create.html
-msgid ""
-"I want to apply* for <a href=\"https://help.archive.org/help/program-"
-"overview/\" target=\"_blank\">special print disability access</a> through"
-" a qualifying program."
+#, fuzzy
+msgid "I want to apply* for <a href=\"https://help.archive.org/help/program-overview/\" target=\"_blank\" rel=\"noopener noreferrer\">special print disability access</a> through a qualifying program."
 msgstr ""
-"Gusto kong mag-aplay* para sa <a href=\"https://help.archive.org/help/program-"
-"overview/\" target=\"_blank\">espesyal na akses sa print disability</a> sa pamamagitan ng"
-" isang kwalipikadong programa."
 
 #: account/create.html
 msgid "Select qualifying program"
 msgstr "Piliin ang kwalipikadong programa"
 
 #: account/create.html
-msgid ""
-"* Please use the email address associated with this qualifying program. "
-"You will receive an email after activation with next steps."
-msgstr ""
-"* Mangyaring gamitin ang email address na nakaugnay sa kwalipikadong programang ito."
-" Makakatanggap ka ng email pagkatapos ng activation na may mga susunod na hakbang."
+msgid "* Please use the email address associated with this qualifying program. You will receive an email after activation with next steps."
+msgstr "* Mangyaring gamitin ang email address na nakaugnay sa kwalipikadong programang ito. Makakatanggap ka ng email pagkatapos ng activation na may mga susunod na hakbang."
 
 #: account/create.html
 msgid "Sign Up with Email"
 msgstr "Mag-sign Up gamit ang Email"
 
 #: account/create.html
-msgid ""
-"By signing up, you agree to the Internet Archive's <a class=\"ol-signup-"
-"form__link\" href=\"//archive.org/about/terms.php\" "
-"target=\"_blank\">Terms of Service</a>."
+#, fuzzy
+msgid "By signing up, you agree to the Internet Archive's <a class=\"ol-signup-form__link\" href=\"//archive.org/about/terms.php\" target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
 msgstr ""
-"Sa pag-sign up, sumasang-ayon ka sa <a class=\"ol-signup-"
-"form__link\" href=\"//archive.org/about/terms.php\" "
-"target=\"_blank\">Mga Tuntunin ng Serbisyo</a> ng Internet Archive."
 
 #: account/create.html
 msgid "Already have an account? <a href=\"/account/login\">Log in</a>"
@@ -2782,14 +1528,8 @@ msgid "Import from Goodreads"
 msgstr "I-import mula sa Goodreads"
 
 #: account/import.html
-msgid ""
-"For instructions on exporting data refer to: <a "
-"href=\"https://www.goodreads.com/review/import\">Goodreads "
-"Import/Export</a>"
-msgstr ""
-"Para sa mga tagubilin sa pag-export ng data, sumangguni sa: <a "
-"href=\"https://www.goodreads.com/review/import\">Goodreads "
-"Import/Export</a>"
+msgid "For instructions on exporting data refer to: <a href=\"https://www.goodreads.com/review/import\">Goodreads Import/Export</a>"
+msgstr "Para sa mga tagubilin sa pag-export ng data, sumangguni sa: <a href=\"https://www.goodreads.com/review/import\">Goodreads Import/Export</a>"
 
 #: account/import.html
 msgid "File size limit 10MB and .csv file type only"
@@ -2909,6 +1649,14 @@ msgid_plural "There are %(count)d people waiting for this book."
 msgstr[0] "May %(count)d taong naghihintay para sa librong ito."
 msgstr[1] "May %(count)d mga taong naghihintay para sa librong ito."
 
+#: ManageLoansButtons.html account/loans.html
+msgid "Not yet downloaded."
+msgstr "Hindi pa na-download."
+
+#: ManageLoansButtons.html account/loans.html
+msgid "Download Now"
+msgstr "I-download Ngayon"
+
 #: account/loans.html
 msgid "Return via<br/>Adobe Digital Editions"
 msgstr "Ibalik sa pamamagitan ng<br/>Adobe Digital Editions"
@@ -2926,12 +1674,19 @@ msgid "Leave the Waiting List"
 msgstr "Umalis sa Listahan ng Paghihintay"
 
 #: account/loans.html
-msgid ""
-"Are you sure you want to leave the waiting list "
-"of<br/><strong>TITLE</strong>?"
-msgstr ""
-"Sigurado ka bang nais mong umalis sa listahan ng paghihintay "
-"ng<br/><strong>TITLE</strong>?"
+msgid "Are you sure you want to leave the waiting list of<br/><strong>TITLE</strong>?"
+msgstr "Sigurado ka bang nais mong umalis sa listahan ng paghihintay ng<br/><strong>TITLE</strong>?"
+
+#: ProlificAuthors.html account/loans.html authors/index.html lists/list_follow.html lists/showcase.html publishers/view.html search/authors.html search/publishers.html search/subjects.html
+#, python-format
+msgid "%(count)d book"
+msgid_plural "%(count)d books"
+msgstr[0] "%(count)d aklat"
+msgstr[1] "%(count)d mga aklat"
+
+#: RecentChangesAdmin.html account/loans.html admin/loans_table.html
+msgid "Actions"
+msgstr "Mga Aksyon"
 
 #: account/loans.html
 #, python-format
@@ -2944,6 +1699,17 @@ msgstr[1] "Naghihintay ng %(count)d mga araw"
 msgid "You are the next person to receive this book."
 msgstr "Ikaw ang susunod na tao na makakatanggap ng librong ito."
 
+#: ManageWaitlistButton.html account/loans.html
+#, python-format
+msgid "There is one person ahead of you in the waiting list."
+msgid_plural "There are %(count)d people ahead of you in the waiting list."
+msgstr[0] "May isang tao na nauna sa iyo sa listahan ng naghihintay."
+msgstr[1] "May %(count)d tao na nauna sa iyo sa listahan ng naghihintay."
+
+#: ManageWaitlistButton.html account/loans.html
+msgid "You have less than an hour to borrow it."
+msgstr "Mayroon kang mas mababa sa isang oras upang hiramin ito."
+
 #: account/loans.html
 #, python-format
 msgid "You have one more hour to borrow it."
@@ -2951,12 +1717,17 @@ msgid_plural "You have %(hours)d more hours to borrow it."
 msgstr[0] "May isa ka pang oras upang manghiram nito."
 msgstr[1] "May %(hours)d pang oras upang manghiram nito."
 
+#: ManageWaitlistButton.html account/loans.html
+msgid "Borrow Now"
+msgstr "Hiramin Ngayon"
+
+#: ManageWaitlistButton.html account/loans.html
+msgid "Leave the waiting list?"
+msgstr "Umalis sa listahan ng naghihintay?"
+
 #: account/loans.html
-msgid ""
-"Looking for a book to borrow?  Check out our staff picks, or search for a"
-" book on a specific subject:"
-msgstr ""
-"Naghahanap ng libro upang manghiram? Suriin ang aming mga pinili ng tauhan, o maghanap para sa
+msgid "Looking for a book to borrow?  Check out our staff picks, or search for a book on a specific subject:"
+msgstr "Naghahanap ng libro upang manghiram? Suriin ang aming mga pinili ng tauhan, o maghanap para s"
 
 #: account/loans.html home/index.html
 msgid "Books We Love"
@@ -2973,6 +1744,14 @@ msgstr "Walang mga libro sa shelf na ito"
 #: account/mybooks.html account/sidebar.html
 msgid "My Loans"
 msgstr "Aking mga Pautang"
+
+#. Display name for the "already-read" reading log shelf used in page headings
+#. and breadcrumbs.
+#. Label for the reading log shelf for books the user has finished reading
+#. (bookshelf ID 3). Used as a button label and shelf name.
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html openlibrary/plugins/upstream/mybooks.py search/sort_options.html
+msgid "Already Read"
+msgstr "Nabasa na"
 
 #: account/mybooks.html type/user/view.html
 msgid "This reader has chosen to make their Reading Log private."
@@ -2994,6 +1773,10 @@ msgstr "Aking mga Estadistika"
 #: account/mybooks.html account/sidebar.html account/topmenu.html
 msgid "My Reading Stats"
 msgstr "Aking mga Estadistika sa Pagbasa"
+
+#: account/mybooks.html account/sidebar.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
+msgid "Loan History"
+msgstr "Kasaysayan ng Pautang"
 
 #: account/mybooks.html account/sidebar.html
 msgid "My Notes"
@@ -3017,14 +1800,8 @@ msgstr "Ang email address na ginamit mo sa pag-sign up ay kailangang ma-verify."
 
 #: account/not_verified.html
 #, python-format
-msgid ""
-"When you created your account, we sent an email to %(email)s that "
-"contained a link for you to verify your email address. We need you to "
-"click that link, please."
-msgstr ""
-"Kapag nilikha mo ang iyong account, nagpadala kami ng email sa %(email)s na "
-"naglalaman ng link para ma-verify ang iyong email address. Kailangan naming "
-"i-click mo ang link na iyon, pakiusap."
+msgid "When you created your account, we sent an email to %(email)s that contained a link for you to verify your email address. We need you to click that link, please."
+msgstr "Kapag nilikha mo ang iyong account, nagpadala kami ng email sa %(email)s na naglalaman ng link para ma-verify ang iyong email address. Kailangan naming i-click mo ang link na iyon, pakiusap."
 
 #: account/not_verified.html
 msgid "If you can't find the email, just hit this button to send a fresh one:"
@@ -3038,6 +1815,10 @@ msgstr "Ipadala muli ang verification email"
 msgid "Thanks!"
 msgstr "Salamat!"
 
+#: BookByline.html FulltextSearchSuggestionItem.html SearchResultsWork.html account/notes.html account/observations.html
+msgid "Unknown author"
+msgstr "Hindi Kilalang may-akda"
+
 #: account/notes.html
 msgid "My notes for an edition of "
 msgstr "Aking mga tala para sa isang edisyon ng "
@@ -3050,8 +1831,7 @@ msgstr "Nawawalang Pamagat"
 msgid "Publish date unknown"
 msgstr "Petsa ng paglathala ay hindi alam"
 
-#: account/notes.html books/edition-sort.html lists/export_as_html.html
-#: type/work/editions.html
+#: account/notes.html books/edition-sort.html lists/export_as_html.html type/work/editions.html
 msgid "Publisher unknown"
 msgstr "Publisher ay hindi kilala"
 
@@ -3059,6 +1839,14 @@ msgstr "Publisher ay hindi kilala"
 #, python-format
 msgid "in %(language)s"
 msgstr "sa %(language)s"
+
+#: NotesModal.html account/notes.html
+msgid "Delete Note"
+msgstr "Tanggalin ang Tala"
+
+#: NotesModal.html account/notes.html
+msgid "Save Note"
+msgstr "I-save ang Tala"
 
 #: account/notes.html
 msgid "No notes found."
@@ -3073,14 +1861,8 @@ msgid "Notifications"
 msgstr "Mga Abiso"
 
 #: account/notifications.html
-msgid ""
-"Notifications are connected to Lists at the moment. If one of the books "
-"on your list gets edited, or a new book comes into the catalog, we'll let"
-" you know, if you want."
-msgstr ""
-"Ang mga abiso ay konektado sa mga Listahan sa ngayon. Kung ang isa sa mga libro "
-"sa iyong listahan ay na-edit, o may bagong libro na pumasok sa katalogo, ipapaalam "
-"namin sa iyo, kung nais mo."
+msgid "Notifications are connected to Lists at the moment. If one of the books on your list gets edited, or a new book comes into the catalog, we'll let you know, if you want."
+msgstr "Ang mga abiso ay konektado sa mga Listahan sa ngayon. Kung ang isa sa mga libro sa iyong listahan ay na-edit, o may bagong libro na pumasok sa katalogo, ipapaalam namin sa iyo, kung nais mo."
 
 #: account/notifications.html
 msgid "Would you like to receive very occasional emails from Open Library?"
@@ -3094,7 +1876,15 @@ msgstr "Hindi, salamat"
 msgid "Yes! Please!"
 msgstr "Oo! Pakiusap!"
 
-#: account/observations.html admin/inspect/memcache.html
+#: EditButtons.html account/notifications.html account/privacy.html admin/block.html admin/spamwords.html covers/manage.html design/button.html
+msgid "Save"
+msgstr "I-save"
+
+#: EditionNavBar.html account/observations.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+msgid "Reviews"
+msgstr "Mga Review"
+
+#: account/observations.html admin/inspect/memcache.html design/button.html design/popover.html
 msgid "Delete"
 msgstr "Burahin"
 
@@ -3115,21 +1905,13 @@ msgid "Privacy & Content Moderation Settings"
 msgstr "Mga Setting ng Privacy at Moderation ng Nilalaman"
 
 #: account/privacy.html
-msgid ""
-"Would you like to make your <a href=\"/account/books\">Reading Log</a> "
-"public?"
-msgstr ""
-"Gusto mo bang gawing pampubliko ang iyong <a href=\"/account/books\">Reading Log</a>?"
+msgid "Would you like to make your <a href=\"/account/books\">Reading Log</a> public?"
+msgstr "Gusto mo bang gawing pampubliko ang iyong <a href=\"/account/books\">Reading Log</a>?"
 
 #: account/privacy.html
-msgid ""
-"This will enable others to see what books you want to read, are reading, "
-"or have already read. Patrons with reading logs set to public may be "
-"followed."
-msgstr ""
-"Ang hakbang na ito ay magpapahintulot sa ibang tao na makita kung anong mga libro "
-"ang nais mong basahin, binabasa, o nabasa na. Ang mga patron na may mga reading log "
-"na nakatakdang pampubliko ay maaaring sundan."
+#, fuzzy
+msgid "This will enable others to see what books you want to read, are reading, stopped reading, or have already read. Patrons with reading logs set to public may be followed."
+msgstr "Ang hakbang na ito ay magpapahintulot sa ibang tao na makita kung anong mga libro ang nais mong basahin, binabasa, o nabasa na. Ang mga patron na may mga reading log na nakatakdang pampubliko ay maaaring sundan."
 
 #: account/privacy.html admin/people/view.html
 msgid "Yes"
@@ -3144,12 +1926,8 @@ msgid "Enable Safe Mode?"
 msgstr "I-enable ang Safe Mode?"
 
 #: account/privacy.html
-msgid ""
-"Safe Mode blurs book covers that have been flagged as having sensitive "
-"imagery."
-msgstr ""
-"Ang Safe Mode ay lumalabo sa mga pabalat ng libro na itinaguyod bilang may sensitibong "
-"imahe."
+msgid "Safe Mode blurs book covers that have been flagged as having sensitive imagery."
+msgstr "Ang Safe Mode ay lumalabo sa mga pabalat ng libro na itinaguyod bilang may sensitibong imahe."
 
 #: account/reading_log.html
 #, python-format
@@ -3158,12 +1936,8 @@ msgstr "Mga librong binabasa ni %(username)s"
 
 #: account/reading_log.html
 #, python-format
-msgid ""
-"%(username)s is reading %(total)d books. Join %(username)s on "
-"OpenLibrary.org and tell the world what you're reading."
-msgstr ""
-"%(username)s ay nagbabasa ng %(total)d na mga libro. Sumali kay %(username)s sa "
-"OpenLibrary.org at ipaalam sa mundo kung ano ang iyong binabasa."
+msgid "%(username)s is reading %(total)d books. Join %(username)s on OpenLibrary.org and tell the world what you're reading."
+msgstr "%(username)s ay nagbabasa ng %(total)d na mga libro. Sumali kay %(username)s sa OpenLibrary.org at ipaalam sa mundo kung ano ang iyong binabasa."
 
 #: account/reading_log.html
 #, python-format
@@ -3172,12 +1946,18 @@ msgstr "Mga librong nais basahin ni %(username)s"
 
 #: account/reading_log.html
 #, python-format
-msgid ""
-"%(username)s wants to read %(total)d books. Join %(username)s on "
-"OpenLibrary.org and share the books that you'll soon be reading!"
-msgstr ""
-"%(username)s ay nais na basahin ang %(total)d na mga libro. Sumali kay %(username)s sa "
-"OpenLibrary.org at ibahagi ang mga librong malapit mo nang basahin!"
+msgid "%(username)s wants to read %(total)d books. Join %(username)s on OpenLibrary.org and share the books that you'll soon be reading!"
+msgstr "%(username)s ay nais na basahin ang %(total)d na mga libro. Sumali kay %(username)s sa OpenLibrary.org at ibahagi ang mga librong malapit mo nang basahin!"
+
+#: account/reading_log.html
+#, fuzzy, python-format
+msgid "Books %(username)s stopped reading"
+msgstr "Mga librong binabasa ni %(username)s"
+
+#: account/reading_log.html
+#, fuzzy, python-format
+msgid "%(username)s stopped reading %(total)d books. Join %(username)s on OpenLibrary.org to share your own reading updates!"
+msgstr "%(username)s ay nais na basahin ang %(total)d na mga libro. Sumali kay %(username)s sa OpenLibrary.org at ibahagi ang mga librong malapit mo nang basahin!"
 
 #: account/reading_log.html
 #, python-format
@@ -3186,12 +1966,8 @@ msgstr "Mga librong nabasa ni %(username)s noong %(year)d"
 
 #: account/reading_log.html
 #, python-format
-msgid ""
-"%(username)s has read %(total)d books in %(year)d. Join %(username)s on "
-"OpenLibrary.org and tell the world about the books that you care about."
-msgstr ""
-"%(username)s ay nakabasa ng %(total)d na mga libro noong %(year)d. Sumali kay %(username)s sa "
-"OpenLibrary.org at ipaalam sa mundo ang tungkol sa mga librong mahalaga sa iyo."
+msgid "%(username)s has read %(total)d books in %(year)d. Join %(username)s on OpenLibrary.org and tell the world about the books that you care about."
+msgstr "%(username)s ay nakabasa ng %(total)d na mga libro noong %(year)d. Sumali kay %(username)s sa OpenLibrary.org at ipaalam sa mundo ang tungkol sa mga librong mahalaga sa iyo."
 
 #: account/reading_log.html
 #, python-format
@@ -3200,12 +1976,8 @@ msgstr "Mga librong nabasa ni %(username)s"
 
 #: account/reading_log.html
 #, python-format
-msgid ""
-"%(username)s has read %(total)d books. Join %(username)s on "
-"OpenLibrary.org and tell the world about the books that you care about."
-msgstr ""
-"%(username)s ay nakabasa ng %(total)d na mga libro. Sumali kay %(username)s sa "
-"OpenLibrary.org at ipaalam sa mundo ang tungkol sa mga librong mahalaga sa iyo."
+msgid "%(username)s has read %(total)d books. Join %(username)s on OpenLibrary.org and tell the world about the books that you care about."
+msgstr "%(username)s ay nakabasa ng %(total)d na mga libro. Sumali kay %(username)s sa OpenLibrary.org at ipaalam sa mundo ang tungkol sa mga librong mahalaga sa iyo."
 
 #: account/reading_log.html
 #, python-format
@@ -3249,21 +2021,15 @@ msgid "You haven't added any books to this shelf yet."
 msgstr "Wala ka pang naidagdag na mga libro sa shelf na ito."
 
 #: account/reading_log.html
-msgid ""
-"<a href=\"/search\">Search for a book</a> to add to your reading log. <a "
-"href=\"/help/faq/reading-log\">Learn more</a> about the reading log."
-msgstr ""
-"<a href=\"/search\">Maghanap ng libro</a> upang idagdag sa iyong reading log. <a "
-"href=\"/help/faq/reading-log\">Matutunan pa</a> tungkol sa reading log."
+msgid "<a href=\"/search\">Search for a book</a> to add to your reading log. <a href=\"/help/faq/reading-log\">Learn more</a> about the reading log."
+msgstr "<a href=\"/search\">Maghanap ng libro</a> upang idagdag sa iyong reading log. <a href=\"/help/faq/reading-log\">Matutunan pa</a> tungkol sa reading log."
 
 #: account/reading_log.html
-msgid ""
-"There are no recent books in your feed. When you follow public accounts, "
-"their book updates will appear here."
-msgstr ""
-"Walang mga kamakailang libro sa iyong feed. Kapag nag-follow ka sa mga pampublikong "
-"akawnt, ang kanilang mga update sa libro ay lalabas dito."
+msgid "There are no recent books in your feed. When you follow public accounts, their book updates will appear here."
+msgstr "Walang mga kamakailang libro sa iyong feed. Kapag nag-follow ka sa mga pampublikong akawnt, ang kanilang mga update sa libro ay lalabas dito."
 
+#. Display name for the "want-to-read" reading log shelf used in page headings
+#. and breadcrumbs.
 #: account/readinglog_shelf_name.html
 msgid "Want To Read"
 msgstr "Gusto Kong Basahin"
@@ -3279,12 +2045,8 @@ msgstr "Aking mga Aklat"
 
 #: account/readinglog_stats.html
 #, python-format
-msgid ""
-"Displaying stats about <strong>%(works_count)d</strong> books. Note all "
-"charts show only the top 20 bars. Note reading log stats are private."
-msgstr ""
-"Ipinapakita ang mga estadistika tungkol sa <strong>%(works_count)d</strong> na aklat. Tandaan na ang lahat ng "
-"chart ay nagpapakita lamang ng nangungunang 20 bar. Tandaan na ang mga estadistika ng log ng pagbasa ay pribado."
+msgid "Displaying stats about <strong>%(works_count)d</strong> books. Note all charts show only the top 20 bars. Note reading log stats are private."
+msgstr "Ipinapakita ang mga estadistika tungkol sa <strong>%(works_count)d</strong> na aklat. Tandaan na ang lahat ng chart ay nagpapakita lamang ng nangungunang 20 bar. Tandaan na ang mga estadistika ng log ng pagbasa ay pribado."
 
 #: account/readinglog_stats.html
 msgid "Author Stats"
@@ -3307,24 +2069,22 @@ msgid "Works by Author Country of Birth"
 msgstr "Mga Gawa ayon sa Bansa ng Kapanganakan ng May-akda"
 
 #: account/readinglog_stats.html
-msgid ""
-"Demographic statistics powered by <a "
-"href=\"https://www.wikidata.org/\">Wikidata</a>. Here's a <a id=\"wd-"
-"query-sample\" href=\"\">sample</a> of the query used. <br />Improve "
-"these stats by adding the Wikidata author identifier following <a "
-"href=\"https://openlibrary.org/help/faq/editing.en#author-identifiers-"
-"purpose\">these instructions</a>."
-msgstr ""
-"Statistika ng demograpiko na pinapagana ng <a "
-"href=\"https://www.wikidata.org/\">Wikidata</a>. Narito ang isang <a id=\"wd-"
-"query-sample\" href=\"\">halimbawa</a> ng query na ginamit. <br />Pagbutihin "
-"ang mga estadistikang ito sa pamamagitan ng pagdagdag ng Wikidata author identifier ayon sa <a "
-"href=\"https://openlibrary.org/help/faq/editing.en#author-identifiers-"
-"purpose\">mga tagubiling ito</a>."
+msgid "Demographic statistics powered by <a href=\"https://www.wikidata.org/\">Wikidata</a>. Here's a <a id=\"wd-query-sample\" href=\"\">sample</a> of the query used. <br />Improve these stats by adding the Wikidata author identifier following <a href=\"https://openlibrary.org/help/faq/editing.en#author-identifiers-purpose\">these instructions</a>."
+msgstr "Statistika ng demograpiko na pinapagana ng <a href=\"https://www.wikidata.org/\">Wikidata</a>. Narito ang isang <a id=\"wd-query-sample\" href=\"\">halimbawa</a> ng query na ginamit. <br />Pagbutihin ang mga estadistikang ito sa pamamagitan ng pagdagdag ng Wikidata author identifier ayon sa <a href=\"https://openlibrary.org/help/faq/editing.en#author-identifiers-purpose\">mga tagubiling ito</a>."
 
 #: account/readinglog_stats.html
 msgid "Work Stats"
 msgstr "Statistika ng Gawa"
+
+#: account/readinglog_stats.html
+#, fuzzy
+msgid "Works by Decade Published"
+msgstr "Mga Gawa ayon sa Panahon"
+
+#: account/readinglog_stats.html
+#, fuzzy
+msgid "Works by Century Published"
+msgstr "Unang Nailathala"
 
 #: account/readinglog_stats.html
 msgid "Works by Subject"
@@ -3350,6 +2110,10 @@ msgstr "Umugma na mga gawa"
 msgid "Click on a bar to see matching works"
 msgstr "I-click ang isang bar upang makita ang mga umuugma na gawa"
 
+#: account/sidebar.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+msgid "My Feed"
+msgstr "Aking Feed"
+
 #: account/sidebar.html
 #, python-format
 msgid "%(year)d Reading Goal"
@@ -3367,6 +2131,10 @@ msgstr "Log ng Pagbasa"
 #: account/sidebar.html
 msgid "My lists"
 msgstr "Aking mga listahan"
+
+#: EditionNavBar.html SearchNavigation.html account/sidebar.html lib/nav_head.html lists/home.html recentchanges/index.html type/edition/view.html type/list/embed.html type/user/view.html type/work/view.html
+msgid "Lists"
+msgstr "Mga Listahan"
 
 #: account/sidebar.html type/user/view.html
 msgid "See All"
@@ -3393,22 +2161,15 @@ msgstr "Mga setting ng Pribadong Pagsasaayos: %(public)s"
 msgid "Verification email sent"
 msgstr "Nakalagay na ang email para sa Beripikasyon"
 
-#: account/password/reset_success.html account/verify.html
-#: account/verify/activated.html account/verify/success.html
+#: account/password/reset_success.html account/verify.html account/verify/activated.html account/verify/success.html
 #, python-format
 msgid "Hi, %(user)s"
 msgstr "Kamusta, %(user)s"
 
 #: account/verify.html
 #, python-format
-msgid ""
-"We’ve sent an email to %(email)s containing a link to verify your "
-"account. Click/tap on the link to finish creating your Internet Archive "
-"account."
-msgstr ""
-"Nagpadala kami ng email sa %(email)s na naglalaman ng link para beripikahin ang iyong "
-"account. I-click/tap ang link upang tapusin ang paglikha ng iyong Internet Archive "
-"account."
+msgid "We’ve sent an email to %(email)s containing a link to verify your account. Click/tap on the link to finish creating your Internet Archive account."
+msgstr "Nagpadala kami ng email sa %(email)s na naglalaman ng link para beripikahin ang iyong account. I-click/tap ang link upang tapusin ang paglikha ng iyong Internet Archive account."
 
 #: account/verify.html
 msgid "Then, come back to Open Library and find some great books!"
@@ -3426,8 +2187,7 @@ msgstr "Sinasundan"
 msgid "Followers"
 msgstr "Mga Tagasunod"
 
-#: account/view.html type/edition/modal_links.html
-#: type/edition/title_and_author.html
+#: account/view.html design/popover.html type/edition/modal_links.html type/edition/title_and_author.html
 msgid "Share"
 msgstr "Ibahagi"
 
@@ -3453,12 +2213,8 @@ msgid "Forgot Your Internet Archive Email?"
 msgstr "Nakalimutan Mo ang Iyong Internet Archive Email?"
 
 #: account/email/forgot-ia.html
-msgid ""
-"Please enter your Open Library email and password, and we’ll retrieve "
-"your Archive.org email."
-msgstr ""
-"Pakisok ang iyong Open Library email at password, at kami ay kukuha "
-"ng iyong Archive.org email."
+msgid "Please enter your Open Library email and password, and we’ll retrieve your Archive.org email."
+msgstr "Pakisok ang iyong Open Library email at password, at kami ay kukuha ng iyong Archive.org email."
 
 #: account/email/forgot-ia.html
 msgid "Your email is:"
@@ -3500,7 +2256,7 @@ msgstr "I-reset ang Password"
 msgid "Please enter a new password for your Open Library account."
 msgstr "Pakisok ang bagong password para sa iyong Open Library account."
 
-#: account/password/reset.html
+#: account/password/reset.html design/button.html
 msgid "Reset"
 msgstr "I-reset"
 
@@ -3509,12 +2265,8 @@ msgid "Password Reset Successful"
 msgstr "Matagumpay ang Pag-reset ng Password"
 
 #: account/password/reset_success.html
-msgid ""
-"Your password has been updated. Please <a "
-"href='/account/login?redirect=/'>log in to continue</a>."
-msgstr ""
-"Ang iyong password ay na-update na. Pakisilangin ang <a "
-"href='/account/login?redirect=/'>mag-log in upang magpatuloy</a>."
+msgid "Your password has been updated. Please <a href='/account/login?redirect=/'>log in to continue</a>."
+msgstr "Ang iyong password ay na-update na. Pakisilangin ang <a href='/account/login?redirect=/'>mag-log in upang magpatuloy</a>."
 
 #: account/password/sent.html
 msgid "Done."
@@ -3522,14 +2274,45 @@ msgstr "Tapos na."
 
 #: account/password/sent.html
 #, python-format
-msgid ""
-"We've sent an email to %(email)s with a reminder of your username and "
-"instructions to help you reset your Open Library password. Please check "
-"your inbox for a note from us."
-msgstr ""
-"Nagpadala kami ng email sa %(email)s na may paalala ng iyong username at "
-"mga tagubilin upang matulungan kang i-reset ang iyong Open Library password. Pakisuri "
-"ang iyong inbox para sa isang tala mula sa amin."
+msgid "We've sent an email to %(email)s with a reminder of your username and instructions to help you reset your Open Library password. Please check your inbox for a note from us."
+msgstr "Nagpadala kami ng email sa %(email)s na may paalala ng iyong username at mga tagubilin upang matulungan kang i-reset ang iyong Open Library password. Pakisuri ang iyong inbox para sa isang tala mula sa amin."
+
+#: account/security/check_email.html
+msgid "Account Security Check — 2026-04-28T18Z"
+msgstr "Pagsusuri ng Seguridad ng Account — 2026-04-28T18Z"
+
+#: account/security/check_email.html
+msgid "Account Security Check"
+msgstr "Pagsusuri ng Seguridad ng Account"
+
+#: account/security/check_email.html
+msgid "Incident date: 2026-04-28T18Z"
+msgstr "Petsa ng insidente: 2026-04-28T18Z"
+
+#: account/security/check_email.html
+msgid "Check whether your Open Library account was in a set of accounts requiring attention."
+msgstr "Suriin kung ang iyong account sa Open Library ay nasa isang grupo ng mga account na nangangailangan ng atensyon."
+
+#: account/security/check_email.html
+msgid "Please <a href=\"/account/login?redirect=/account/security/2026-04-28T18\">log in</a> to check whether your account was affected."
+msgstr "Mangyaring <a href=\"/account/login?redirect=/account/security/2026-04-28T18\">mag-login</a> upang suriin kung ang iyong account ay naapektuhan."
+
+#: account/security/check_email.html
+#, fuzzy
+msgid "Your account is in the affected set."
+msgstr "Hindi pa na-activate ang account."
+
+#: account/security/check_email.html
+msgid "Your account was found in our affected accounts list. Please review any recent communications from Open Library and consider updating your password."
+msgstr "Ang iyong account ay natagpuan sa aming listahan ng mga apektadong account. Mangyaring suriin ang anumang kamakailang komunikasyon mula sa Open Library at isaalang-alang ang pag-update ng iyong password."
+
+#: account/security/check_email.html
+msgid "Your account is <em>not</em> in the affected set."
+msgstr "Ang iyong account ay <em>hindi</em> nasa apektadong grupo."
+
+#: account/security/check_email.html
+msgid "Your account was <em>not</em> found in the affected accounts list. No action is required."
+msgstr "Ang iyong account ay <em>hindi</em> natagpuan sa listahan ng mga apektadong account. Walang kinakailangang aksyon."
 
 #: account/verify/activated.html
 msgid "Account already activated"
@@ -3537,24 +2320,16 @@ msgstr "Naka-activate na ang Account"
 
 #: account/verify/activated.html
 #, python-format
-msgid ""
-"Your account has been activated already. Please <a href=\"%s\">log in to "
-"continue</a>."
-msgstr ""
-"Ang iyong account ay naka-activate na. Pakisilangin ang <a href=\"%s\">mag-log in upang "
-"magpatuloy</a>."
+msgid "Your account has been activated already. Please <a href=\"%s\">log in to continue</a>."
+msgstr "Ang iyong account ay naka-activate na. Pakisilangin ang <a href=\"%s\">mag-log in upang magpatuloy</a>."
 
 #: account/verify/failed.html
 msgid "Email Verification Failed"
 msgstr "Nabigo ang Pag-verify ng Email"
 
 #: account/verify/failed.html
-msgid ""
-"Your email address couldn't be verified. Your verification link seems "
-"invalid or expired."
-msgstr ""
-"Ang iyong email address ay hindi ma-verify. Ang iyong verification link ay tila "
-"hindi wasto o nag-expire."
+msgid "Your email address couldn't be verified. Your verification link seems invalid or expired."
+msgstr "Ang iyong email address ay hindi ma-verify. Ang iyong verification link ay tila hindi wasto o nag-expire."
 
 #: account/verify/failed.html
 msgid "Fill your email and hit this button to resend a fresh verification email:"
@@ -3574,12 +2349,8 @@ msgstr "Matagumpay ang Pag-verify ng Email"
 
 #: account/verify/success.html
 #, python-format
-msgid ""
-"Yay! Your email address has been verified. Please <a href='%s'>log in to "
-"continue</a>."
-msgstr ""
-"Yay! Ang iyong email address ay na-verify na. Pakisilangin ang <a href='%s'>mag-log in upang "
-"magpatuloy</a>."
+msgid "Yay! Your email address has been verified. Please <a href='%s'>log in to continue</a>."
+msgstr "Yay! Ang iyong email address ay na-verify na. Pakisilangin ang <a href='%s'>mag-log in upang magpatuloy</a>."
 
 #: admin/attach_debugger.html
 msgid "Attach Debugger"
@@ -3608,12 +2379,13 @@ msgstr "I-block ang IP address"
 
 #: admin/block.html
 #, python-format
-msgid ""
-"IP address %(address)s has been added to the textarea. Please click Save "
-"to block that IP."
-msgstr ""
-"Ang IP address na %(address)s ay idinagdag sa textarea. Pakisilangin ang I-save "
-"upang i-block ang IP na iyon."
+msgid "IP address %(address)s has been added to the textarea. Please click Save to block that IP."
+msgstr "Ang IP address na %(address)s ay idinagdag sa textarea. Pakisilangin ang I-save upang i-block ang IP na iyon."
+
+#: admin/block.html
+#, fuzzy
+msgid "Blocked IP Addresses"
+msgstr "I-block ang IP address"
 
 #: admin/graphs.html
 msgid "Performance Graphs"
@@ -3635,8 +2407,7 @@ msgstr "Hating mga Oras ng Pag-load ng Pahina"
 msgid "Infobase Mean"
 msgstr "Mean ng Infobase"
 
-#: admin/history.html admin/imports.html authors/infobox.html
-#: type/author/edit.html
+#: admin/history.html admin/imports.html authors/infobox.html type/author/edit.html
 msgid "Date"
 msgstr "Petsa"
 
@@ -3644,13 +2415,11 @@ msgstr "Petsa"
 msgid "Page"
 msgstr "Pahina"
 
-#: admin/imports-add.html admin/imports.html admin/imports_by_date.html
-#: admin/menu.html
+#: admin/imports-add.html admin/imports.html admin/imports_by_date.html admin/menu.html
 msgid "Imports"
 msgstr "Mga Inangkat"
 
-#: admin/imports-add.html books/add.html books/edit/edition.html
-#: books/edit/excerpts.html covers/change.html type/tag/form.html
+#: admin/imports-add.html books/add.html books/edit/edition.html books/edit/excerpts.html covers/change.html type/tag/form.html
 msgid "Add"
 msgstr "Magdagdag"
 
@@ -3662,9 +2431,7 @@ msgstr "Magdagdag ng mga bagong aklat sa pila ng pag-import"
 msgid "Please add IA identifiers to be imported, one per line."
 msgstr "Pakidagdag ang mga IA identifier na ipapasok, isa sa bawat linya."
 
-#: admin/imports-add.html admin/inspect/store.html admin/ip/view.html
-#: admin/people/edits.html admin/permissions.html
-#: my_books/check_ins/check_in_form.html reading_goals/reading_goal_form.html
+#: admin/imports-add.html admin/inspect/store.html admin/ip/view.html admin/people/edits.html admin/permissions.html design/button.html my_books/check_ins/check_in_form.html reading_goals/reading_goal_form.html
 msgid "Submit"
 msgstr "Isumite"
 
@@ -3672,8 +2439,11 @@ msgstr "Isumite"
 msgid "New Books Imported Per Day"
 msgstr "Mga Bagong Aklat na Inangkat bawat Araw"
 
-#: admin/imports.html admin/imports_by_date.html admin/pd_dashboard.html
-#: site/stats.html
+#: PublishingHistory.html admin/imports.html publishers/view.html
+msgid "You need to have JavaScript turned on to see the nifty chart!"
+msgstr "Kailangan mong i-on ang JavaScript upang makita ang maganda nyang tsart!"
+
+#: admin/imports.html admin/imports_by_date.html admin/pd_dashboard.html site/stats.html
 msgid "Summary"
 msgstr "Buod"
 
@@ -3742,17 +2512,17 @@ msgstr "Natagpuan"
 msgid "Failed"
 msgstr "Nabigo"
 
+#: admin/imports_by_date.html openlibrary/core/edits.py
+msgid "Pending"
+msgstr "Naghihintay"
+
 #: admin/imports_by_date.html
 msgid "Items"
 msgstr "Mga Item"
 
 #: admin/index.html
-msgid ""
-"<span class=\"login-counts\">0</span> patrons have logged in at least "
-"once over the past 30 days."
-msgstr ""
-"<span class=\"login-counts\">0</span> patron ang nag-log in kahit isang "
-"beses sa nakaraang 30 araw."
+msgid "<span class=\"login-counts\">0</span> patrons have logged in at least once over the past 30 days."
+msgstr "<span class=\"login-counts\">0</span> patron ang nag-log in kahit isang beses sa nakaraang 30 araw."
 
 #: admin/index.html
 msgid "Stats"
@@ -3864,7 +2634,7 @@ msgstr "Mga Patron na Nalikha ng mga Tala"
 
 #: admin/index.html
 msgid "Books Starred"
-msgstr "Mga Aklat na Nakat
+msgstr "Mga Aklat na Naka"
 
 #: admin/index.html
 msgid "Star Rating Patrons"
@@ -3902,16 +2672,11 @@ msgstr "Nag-iipon ng mga estadistika ng pag-log in..."
 msgid "BookReader"
 msgstr "BookReader"
 
-#: admin/loans_table.html book_providers/cita_press_download_options.html
-#: book_providers/ia_download_options.html
-#: book_providers/openstax_download_options.html
-#: book_providers/wikisource_download_options.html books/edit/edition.html
+#: admin/loans_table.html book_providers/cita_press_download_options.html book_providers/ia_download_options.html book_providers/openstax_download_options.html book_providers/wikisource_download_options.html books/edit/edition.html
 msgid "PDF"
 msgstr "PDF"
 
-#: admin/loans_table.html book_providers/gutenberg_download_options.html
-#: book_providers/ia_download_options.html
-#: book_providers/standard_ebooks_download_options.html books/edit/edition.html
+#: admin/loans_table.html book_providers/gutenberg_download_options.html book_providers/ia_download_options.html book_providers/standard_ebooks_download_options.html books/edit/edition.html
 msgid "ePub"
 msgstr "ePub"
 
@@ -3926,6 +2691,10 @@ msgid_plural "%d Current Loans"
 msgstr[0] "%d Kasalukuyang Pautang"
 msgstr[1] "%d Kasalukuyang Pautang"
 
+#: RecentChanges.html RecentChangesUsers.html admin/ip/view.html admin/loans_table.html admin/people/edits.html recentchanges/render.html recentchanges/updated_records.html
+msgid "What"
+msgstr "Ano"
+
 #: admin/loans_table.html
 #, python-format
 msgid "Waiting since %(date)s"
@@ -3936,9 +2705,18 @@ msgstr "Naghihintay mula %(date)s"
 msgid "#%(num_position)d among %(num_waitlist)d people waiting for this book"
 msgstr "#%(num_position)d mula sa %(num_waitlist)d na tao na naghihintay para sa aklat na ito"
 
+#: ManageLoansButtons.html admin/loans_table.html
+#, python-format
+msgid "Borrowed %(date)s"
+msgstr "Hiniram noong %(date)s"
+
 #: admin/menu.html
 msgid "Admin Center"
 msgstr "Sentro ng Admin"
+
+#: RelatedSubjects.html SubjectTags.html admin/menu.html admin/people/index.html admin/people/view.html openlibrary/plugins/worksearch/code.py type/author/view.html type/list/view_body.html
+msgid "People"
+msgstr "Mga Tao"
 
 #: admin/menu.html
 msgid "PD Access Requests"
@@ -4025,12 +2803,8 @@ msgid "Update permissions"
 msgstr "I-update ang mga pahintulot"
 
 #: admin/permissions.html
-msgid ""
-"This updates \"permission\" and \"child_permission\" fields of /, /works,"
-" /books and /authors records in the database."
-msgstr ""
-"Ito ay nag-update ng mga field na \"permission\" at \"child_permission\" ng /, /works,"
-" /books at /authors na mga tala sa database."
+msgid "This updates \"permission\" and \"child_permission\" fields of /, /works, /books and /authors records in the database."
+msgstr "Ito ay nag-update ng mga field na \"permission\" at \"child_permission\" ng /, /works, /books at /authors na mga tala sa database."
 
 #: admin/solr.html
 msgid "Solr Admin"
@@ -4045,12 +2819,8 @@ msgid "Example:"
 msgstr "Halimbawa:"
 
 #: admin/solr.html
-msgid ""
-"On update, these keys will be added to solr update queue and it'll take "
-"about 15 minutes for them to get reindexed in Solr."
-msgstr ""
-"Sa pag-update, ang mga susi na ito ay idaragdag sa queue ng solr update at aabutin ng "
-"mga 15 minuto para sila ay ma-reindex sa Solr."
+msgid "On update, these keys will be added to solr update queue and it'll take about 15 minutes for them to get reindexed in Solr."
+msgstr "Sa pag-update, ang mga susi na ito ay idaragdag sa queue ng solr update at aabutin ng mga 15 minuto para sila ay ma-reindex sa Solr."
 
 #: admin/solr.html
 msgid "Enter the keys to reindex in Solr"
@@ -4060,43 +2830,26 @@ msgstr "Ilagay ang mga susi upang i-reindex sa Solr"
 msgid "Write one entry per line"
 msgstr "Sumulat ng isang entry bawat linya"
 
-#: admin/solr.html
-msgid "Update"
-msgstr "I-update"
-
 #: admin/spamwords.html
 msgid "[Admin Center] Spam Words"
 msgstr "[Sentro ng Admin] Mga Spam na Salita"
 
 #: admin/spamwords.html
-msgid ""
-"Please enter the SPAM regular expressions in the textarea below, one per "
-"line."
-msgstr ""
-"Pakisok ang mga SPAM na regular expression sa textarea sa ibaba, isa bawat "
-"linya."
+msgid "Please enter the SPAM regular expressions in the textarea below, one per line."
+msgstr "Pakisok ang mga SPAM na regular expression sa textarea sa ibaba, isa bawat linya."
 
 #: admin/spamwords.html
-msgid ""
-"Be sure to escape any meta characters that are meant to be character "
-"literals."
-msgstr ""
-"Tiyaking na-escape ang anumang meta characters na dapat maging character "
-"literals."
+msgid "Be sure to escape any meta characters that are meant to be character literals."
+msgstr "Tiyaking na-escape ang anumang meta characters na dapat maging character literals."
 
 #: admin/spamwords.html
 msgid "If you are adding a domain, prepend the following to the domain:"
 msgstr "Kung nagdadagdag ka ng domain, idagdag ang mga sumusunod sa domain:"
 
 #: admin/spamwords.html
-msgid ""
-"For example, if you want to prevent edits containing the domain "
-"<code>t.co</code>, add <code>(\\b|https://|http://)t\\.co</code> to the "
-"spamwords list."
+#, fuzzy
+msgid "For example, if you want to prevent edits containing the domain <code>t.co</code>, add <code>(|https://|http://)t\\.co</code> to the spamwords list."
 msgstr ""
-"Halimbawa, kung nais mong pigilan ang mga edit na naglalaman ng domain "
-"<code>t.co</code>, idagdag ang <code>(\\b|https://|http://)t\\.co</code> sa "
-"spamwords list."
 
 #: admin/spamwords.html
 msgid "Spam Domains"
@@ -4111,31 +2864,16 @@ msgid "Sync"
 msgstr "I-sync"
 
 #: admin/sync.html
-msgid ""
-"Sync the metadata of various types of Open Library items (e.g. lists, "
-"subjects, works) with Archive.org."
-msgstr ""
-"I-sync ang metadata ng iba't ibang uri ng mga item ng Open Library (hal. mga listahan, "
-"paksa, mga gawa) sa Archive.org."
+msgid "Sync the metadata of various types of Open Library items (e.g. lists, subjects, works) with Archive.org."
+msgstr "I-sync ang metadata ng iba't ibang uri ng mga item ng Open Library (hal. mga listahan, paksa, mga gawa) sa Archive.org."
 
 #: admin/sync.html
 msgid "Add Works to Staff Picks"
 msgstr "Idagdag ang mga Gawa sa mga Napili ng Staff"
 
 #: admin/sync.html
-msgid ""
-"This utility will add your work to an Open Library list called `Staff "
-"Picks` under the `openlibrary` user. It will then take the added work and"
-" explode it into a list of all its readable editions. For each Open "
-"Library edition, a metadata field called `openlibrary_subject` will be "
-"injected into the archive.org metadata of the edition's corresponding "
-"archive.org item."
-msgstr ""
-"Idadagdag ng utility na ito ang iyong gawa sa isang listahan ng Open Library na tinatawag na `Staff "
-"Picks` sa ilalim ng user na `openlibrary`. Pagkatapos ay kukunin nito ang idinagdag na gawa at"
-" ihahati ito sa isang listahan ng lahat ng mababasang edisyon nito. Para sa bawat Open "
-"Library edition, isang field ng metadata na tinatawag na `openlibrary_subject` ay ipapasok sa "
-"metadata ng archive.org ng katugmang item ng edisyon sa archive.org."
+msgid "This utility will add your work to an Open Library list called `Staff Picks` under the `openlibrary` user. It will then take the added work and explode it into a list of all its readable editions. For each Open Library edition, a metadata field called `openlibrary_subject` will be injected into the archive.org metadata of the edition's corresponding archive.org item."
+msgstr "Idadagdag ng utility na ito ang iyong gawa sa isang listahan ng Open Library na tinatawag na `Staff Picks` sa ilalim ng user na `openlibrary`. Pagkatapos ay kukunin nito ang idinagdag na gawa at ihahati ito sa isang listahan ng lahat ng mababasang edisyon nito. Para sa bawat Open Library edition, isang field ng metadata na tinatawag na `openlibrary_subject` ay ipapasok sa metadata ng archive.org ng katugmang item ng edisyon sa archive.org."
 
 #: admin/sync.html
 msgid "add"
@@ -4150,12 +2888,13 @@ msgid "Update edition"
 msgstr "I-update ang edisyon"
 
 #: admin/sync.html
-msgid ""
-"Updates an edition on archive.org by writing in its latest  "
-"openlibrary_edition and openlibrary_work identifier values"
-msgstr ""
-"Nag-uupdate ng isang edisyon sa archive.org sa pamamagitan ng pagsusulat ng pinakabago nitong  "
-"openlibrary_edition at openlibrary_work identifier values"
+msgid "Updates an edition on archive.org by writing in its latest  openlibrary_edition and openlibrary_work identifier values"
+msgstr "Nag-uupdate ng isang edisyon sa archive.org sa pamamagitan ng pagsusulat ng pinakabago nitong  openlibrary_edition at openlibrary_work identifier values"
+
+#: admin/sync.html
+#, fuzzy
+msgid "TODO"
+msgstr "Ngayon"
 
 #: admin/inspect/memcache.html
 msgid "[Admin Center] Inspect Memcache"
@@ -4166,20 +2905,12 @@ msgid "Inspect Memcache"
 msgstr "Suriin ang Memcache"
 
 #: admin/inspect/memcache.html
-msgid ""
-"Add one memcache key per line in the text area. Each key must include a "
-"'-' as the last character."
-msgstr ""
-"Magdagdag ng isang memcache key bawat linya sa text area. Bawat key ay dapat may kasamang "
-"'-' bilang huling karakter."
+msgid "Add one memcache key per line in the text area. Each key must include a '-' as the last character."
+msgstr "Magdagdag ng isang memcache key bawat linya sa text area. Bawat key ay dapat may kasamang '-' bilang huling karakter."
 
 #: admin/inspect/memcache.html
-msgid ""
-"For example, <code>observations-</code> should be entered in the text "
-"area if the key is <code>observations</code>."
-msgstr ""
-"Halimbawa, <code>observations-</code> ay dapat ilagay sa text "
-"area kung ang key ay <code>observations</code>."
+msgid "For example, <code>observations-</code> should be entered in the text area if the key is <code>observations</code>."
+msgstr "Halimbawa, <code>observations-</code> ay dapat ilagay sa text area kung ang key ay <code>observations</code>."
 
 #: admin/inspect/memcache.html
 msgid "Keys:"
@@ -4295,42 +3026,22 @@ msgstr "I-block ang %(ip)s"
 msgid "Please select the changesets to revert."
 msgstr "Pakisilangin ang mga changeset na ibalik."
 
+#: RecentChanges.html admin/ip/view.html admin/people/edits.html recentchanges/render.html
+msgid "When you see numbers here, that's the IP address of the anonymous editor"
+msgstr "Kapag nakakita ka ng mga numero dito, iyon ang IP address ng hindi kilalang editor"
+
 #: admin/ip/view.html admin/people/edits.html
 #, python-format
 msgid "Reverted by %(revert_author)s"
 msgstr "Ibinalik ng %(revert_author)s"
 
+#: EditButtons.html admin/ip/view.html admin/people/edits.html
+msgid "Please, leave a short note about what you changed: <span class=\"small gray\">(Optional, but very useful!)</span>"
+msgstr "Pakisuyo, mag-iwan ng maikling tala tungkol sa kung ano ang binago mo: <span class=\"small gray\">(Opsyonal, ngunit napaka-kapaki-pakinabang!)</span>"
+
 #: admin/ip/view.html admin/people/edits.html
 msgid "Reverted spam"
 msgstr "Nabawi ang spam"
-
-#: admin/memory/index.html
-msgid "Memory Status"
-msgstr "Katayuan ng Memorya"
-
-#: admin/memory/index.html
-msgid "type"
-msgstr "uri"
-
-#: admin/memory/index.html
-msgid "count"
-msgstr "bilang"
-
-#: admin/memory/index.html
-msgid "mark"
-msgstr "marka"
-
-#: admin/memory/index.html
-msgid "Prev"
-msgstr "Nakaraan"
-
-#: admin/memory/object.html
-msgid "Referents"
-msgstr "Referents"
-
-#: admin/memory/object.html
-msgid "Referrers"
-msgstr "Referrers"
 
 #: admin/people/edits.html
 #, python-format
@@ -4412,12 +3123,8 @@ msgstr "mag-login bilang user na ito"
 
 #: admin/people/view.html
 #, python-format
-msgid ""
-"Activated on <span class=\"time\">%(date)s</span> from <a "
-"href=\"/admin/ip/%(ip)s\">%(ip)s</a>."
-msgstr ""
-"Naka-activate noong <span class=\"time\">%(date)s</span> mula sa <a "
-"href=\"/admin/ip/%(ip)s\">%(ip)s</a>."
+msgid "Activated on <span class=\"time\">%(date)s</span> from <a href=\"/admin/ip/%(ip)s\">%(ip)s</a>."
+msgstr "Naka-activate noong <span class=\"time\">%(date)s</span> mula sa <a href=\"/admin/ip/%(ip)s\">%(ip)s</a>."
 
 #: admin/people/view.html
 msgid "unblock this account"
@@ -4427,18 +3134,9 @@ msgstr "i-unblock ang account na ito"
 msgid "activate account"
 msgstr "i-activate ang account"
 
-#: admin/people/view.html
-#, python-format
-msgid "Activation link expiring on <span class=\"time\">%(date)s.</span>"
-msgstr "Activation link na mag-eexpire sa <span class=\"time\">%(date)s.</span>"
-
-#: admin/people/view.html
-msgid "Activation link expired"
-msgstr "Expired na ang activation link"
-
-#: admin/people/view.html
-msgid "Resend activation link"
-msgstr "Muling ipadala ang activation link"
+#: CreateListModal.html admin/people/view.html my_books/dropdown_content.html
+msgid "Name:"
+msgstr "Pangalan:"
 
 #: admin/people/view.html
 msgid "view profile"
@@ -4492,6 +3190,10 @@ msgstr "Pagsubok na Patuyuin"
 msgid "Anonymize Account"
 msgstr "Gawing Anonimo ang Account"
 
+#: admin/people/view.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py type/user/view.html
+msgid "Loans"
+msgstr "Mga Pautang"
+
 #: admin/people/view.html
 msgid "Account not activated yet."
 msgstr "Hindi pa na-activate ang account."
@@ -4521,13 +3223,15 @@ msgstr "Mga Link ng Beripikasyon"
 msgid "None found"
 msgstr "Walang natagpuan"
 
+#: SearchNavigation.html authors/index.html lib/nav_foot.html merge/authors.html publishers/view.html
+msgid "Authors"
+msgstr "Mga May-Akda"
+
 #: authors/index.html
 msgid "Search for an Author"
 msgstr "Maghanap ng May-akda"
 
-#: authors/index.html lib/nav_head.html lists/home.html publishers/index.html
-#: publishers/notfound.html publishers/view.html search/advancedsearch.html
-#: search/publishers.html search/searchbox.html type/local_id/view.html
+#: authors/index.html lib/nav_head.html lists/home.html publishers/index.html publishers/notfound.html publishers/view.html search/advancedsearch.html search/publishers.html search/searchbox.html type/local_id/view.html
 msgid "Search"
 msgstr "Maghanap"
 
@@ -4554,14 +3258,7 @@ msgstr "Ipinanganak"
 msgid "Died"
 msgstr "Pumanaw"
 
-#: book_providers/cita_press_download_options.html
-#: book_providers/gutenberg_download_options.html
-#: book_providers/ia_download_options.html
-#: book_providers/librivox_download_options.html
-#: book_providers/openstax_download_options.html
-#: book_providers/runeberg_download_options.html
-#: book_providers/standard_ebooks_download_options.html
-#: book_providers/wikisource_download_options.html
+#: book_providers/cita_press_download_options.html book_providers/gutenberg_download_options.html book_providers/ia_download_options.html book_providers/librivox_download_options.html book_providers/openstax_download_options.html book_providers/runeberg_download_options.html book_providers/standard_ebooks_download_options.html book_providers/wikisource_download_options.html
 msgid "Download Options"
 msgstr "Mga Opsyon sa Pag-download"
 
@@ -4577,9 +3274,7 @@ msgstr "More sa Cita Press"
 msgid "Download an HTML from Project Gutenberg"
 msgstr "I-download ang HTML mula sa Proyekto Gutenberg"
 
-#: book_providers/gutenberg_download_options.html
-#: book_providers/runeberg_download_options.html
-#: book_providers/standard_ebooks_download_options.html type/list/exports.html
+#: book_providers/gutenberg_download_options.html book_providers/runeberg_download_options.html book_providers/standard_ebooks_download_options.html type/list/exports.html
 msgid "HTML"
 msgstr "HTML"
 
@@ -4587,8 +3282,7 @@ msgstr "HTML"
 msgid "Download a text version from Project Gutenberg"
 msgstr "I-download ang bersyon ng teksto mula sa Proyekto Gutenberg"
 
-#: book_providers/gutenberg_download_options.html
-#: book_providers/ia_download_options.html
+#: book_providers/gutenberg_download_options.html book_providers/ia_download_options.html
 msgid "Plain text"
 msgstr "Simpleng teksto"
 
@@ -4746,6 +3440,10 @@ msgstr "Kobo (kepub)"
 msgid "View the source code for this Standard Ebook at GitHub"
 msgstr "Tignan ang source code para sa Standard Ebook na ito sa GitHub"
 
+#: Subnavigation.html book_providers/standard_ebooks_download_options.html
+msgid "Source Code"
+msgstr "Source Code"
+
 #: book_providers/standard_ebooks_download_options.html
 msgid "More at Standard Ebooks"
 msgstr "More sa Standard Ebooks"
@@ -4793,20 +3491,12 @@ msgid "Invalid ISBN checksum digit"
 msgstr "Hindi wastong digit ng checksum ng ISBN"
 
 #: books/add.html
-msgid ""
-"ID must be exactly 10 characters [0-9 or X]. For example 0-19-853453-1 or"
-" 0198534531"
-msgstr ""
-"Ang ID ay dapat na eksaktong 10 karakter [0-9 o X]. Halimbawa 0-19-853453-1 o"
-" 0198534531"
+msgid "ID must be exactly 10 characters [0-9 or X]. For example 0-19-853453-1 or 0198534531"
+msgstr "Ang ID ay dapat na eksaktong 10 karakter [0-9 o X]. Halimbawa 0-19-853453-1 o 0198534531"
 
 #: books/add.html
-msgid ""
-"ID must be exactly 13 characters [0-9]. For example 978-3-16-148410-0 or "
-"9783161484100"
-msgstr ""
-"Ang ID ay dapat na eksaktong 13 karakter [0-9]. Halimbawa 978-3-16-148410-0 o "
-"9783161484100"
+msgid "ID must be exactly 13 characters [0-9]. For example 978-3-16-148410-0 or 9783161484100"
+msgstr "Ang ID ay dapat na eksaktong 13 karakter [0-9]. Halimbawa 978-3-16-148410-0 o 9783161484100"
 
 #: books/add.html
 msgid "Invalid LC Control Number format"
@@ -4829,41 +3519,26 @@ msgid "Add a book to Open Library"
 msgstr "Magdagdag ng libro sa Open Library"
 
 #: books/add.html
-msgid ""
-"We require a minimum set of fields to create a new record. These are "
-"those fields."
-msgstr ""
-"Kailangan namin ng minimum na set ng mga field upang lumikha ng bagong tala. Ito ang "
-"mga field na iyon."
-
-#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html
-#: search/advancedsearch.html type/about/edit.html type/page/edit.html
-#: type/template/edit.html
-msgid "Title"
-msgstr "Pamagat"
+msgid "We require a minimum set of fields to create a new record. These are those fields."
+msgstr "Kailangan namin ng minimum na set ng mga field upang lumikha ng bagong tala. Ito ang mga field na iyon."
 
 #: books/add.html books/edit.html
 msgid "Use <b><i>Title: Subtitle</i></b> to add a subtitle."
 msgstr "Gamitin ang <b><i>Pamagat: Subtitle</i></b> upang magdagdag ng subtitle."
 
-#: books/add.html books/edit.html type/author/edit.html
-#: type/tag/tag_form_inputs.html
+#: books/add.html books/edit.html type/author/edit.html type/tag/tag_form_inputs.html
 msgid "Required field"
 msgstr "Kinakailangang field"
 
 #: books/add.html
-msgid ""
-"Like, \"Agatha Christie\" or \"Jean-Paul Sartre.\" We'll also do a live "
-"check to see if we already know the author."
-msgstr ""
-"Tulad ng, \"Agatha Christie\" o \"Jean-Paul Sartre.\" Gagawa rin kami ng live "
-"check upang makita kung kilala na namin ang may-akda."
+msgid "Like, \"Agatha Christie\" or \"Jean-Paul Sartre.\" We'll also do a live check to see if we already know the author."
+msgstr "Tulad ng, \"Agatha Christie\" o \"Jean-Paul Sartre.\" Gagawa rin kami ng live check upang makita kung kilala na namin ang may-akda."
 
 #: books/add.html books/edit/edition.html
 msgid "Who is the publisher?"
 msgstr "Sino ang publisher?"
 
-#: books/add.html books/edit/edition.html books/edit/excerpts.html
+#: books/add.html books/edit/edition.html
 msgid "For example:"
 msgstr "Halimbawa:"
 
@@ -4880,12 +3555,8 @@ msgid "You should be able to find this in the first few pages of the book."
 msgstr "Dapat ay makikita mo ito sa unang ilang pahina ng libro."
 
 #: books/add.html
-msgid ""
-"And optionally, an ID number &#151; like an ISBN &#151; would be "
-"helpful..."
-msgstr ""
-"At opsyonal, ang isang ID number &#151; tulad ng ISBN &#151; ay "
-"makakatulong..."
+msgid "And optionally, an ID number &#151; like an ISBN &#151; would be helpful..."
+msgstr "At opsyonal, ang isang ID number &#151; tulad ng ISBN &#151; ay makakatulong..."
 
 #: books/add.html
 msgid "ID Type"
@@ -4932,6 +3603,16 @@ msgid "Only fill this out if this is a web book"
 msgstr "Punan ito kung ito ay isang web book lamang"
 
 #: books/add.html
+#, fuzzy, python-format
+msgid "By saving a change to this wiki, you agree that your contribution is given freely to the world under <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" target=\"_blank\" rel=\"noopener noreferrer\" title=\"%(cc_link_title)s\">CC0</a>."
+msgstr ""
+
+#: books/add.html
+#, fuzzy
+msgid "This link to Creative Commons will open in a new window"
+msgstr "Kumuha ng mga tagubilin sa Wikipedia sa bagong bintana"
+
+#: books/add.html
 msgid "Add this book now"
 msgstr "Idagdag ang librong ito ngayon"
 
@@ -4957,24 +3638,23 @@ msgstr "Magdagdag ng Libro"
 
 #: books/check.html
 #, python-format
-msgid ""
-"One moment... It looks like we already have <em>some potential "
-"matches</em> for <b>%(title)s</b> by <b>%(author)s</b>."
-msgstr ""
-"Sandali lang... Mukhang mayroon na tayong <em>ilang posibleng "
-"tugma</em> para sa <b>%(title)s</b> ni <b>%(author)s</b>."
+msgid "One moment... It looks like we already have <em>some potential matches</em> for <b>%(title)s</b> by <b>%(author)s</b>."
+msgstr "Sandali lang... Mukhang mayroon na tayong <em>ilang posibleng tugma</em> para sa <b>%(title)s</b> ni <b>%(author)s</b>."
 
 #: books/check.html
-msgid ""
-"Rather than creating a duplicate record, please click through the result "
-"you think best matches your book."
-msgstr ""
-"Sa halip na lumikha ng duplicate na tala, pakiclick ang resulta "
-"na sa tingin mo ay pinakamahusay na tugma sa iyong libro."
+msgid "Rather than creating a duplicate record, please click through the result you think best matches your book."
+msgstr "Sa halip na lumikha ng duplicate na tala, pakiclick ang resulta na sa tingin mo ay pinakamahusay na tugma sa iyong libro."
 
 #: books/check.html
 msgid "Select this book"
 msgstr "Pumili ng librong ito"
+
+#: SearchResultsWork.html books/check.html merge/authors.html publishers/view.html
+#, python-format
+msgid "%(count)s edition"
+msgid_plural "%(count)s editions"
+msgstr[0] "%(count)s edisyon"
+msgstr[1] "%(count)s mga edisyon"
 
 #: books/check.html
 #, python-format
@@ -4985,7 +3665,7 @@ msgstr "Unang nailathala noong %(year)d"
 msgid "None of these match the book I want to add."
 msgstr "Wala sa mga ito ang tugma sa librong gusto kong idagdag."
 
-#: books/check.html
+#: books/check.html design/button.html
 msgid "Continue"
 msgstr "Magpatuloy"
 
@@ -4999,6 +3679,10 @@ msgid " by %(name)s"
 msgstr " ni %(name)s"
 
 #: books/daisy.html
+msgid "Back"
+msgstr "Bumalik"
+
+#: books/daisy.html
 msgid "Open Library Home"
 msgstr "Bahay ng Open Library"
 
@@ -5007,76 +3691,21 @@ msgid "There isn't a DAISY file available for "
 msgstr "Walang DAISY file na magagamit para sa "
 
 #: books/daisy.html
-msgid "This DAISY file is protected."
-msgstr "Ang DAISY file na ito ay protektado."
-
-#: books/daisy.html
-msgid ""
-"It can only be opened on a specialized device with a key issued by the "
-"Library of Congress."
-msgstr ""
-"Ito ay maaari lamang buksan sa isang espesyal na device gamit ang isang susi na inilabas ng "
-"Library of Congress."
-
-#: books/daisy.html
 #, python-format
-msgid ""
-"<a href=\"%(daisy_url)s\"><strong>Download the DAISY.zip</strong></a> for"
-" <a href=\"%(url)s\">%(title)s</a>"
-msgstr ""
-"<a href=\"%(daisy_url)s\"><strong>I-download ang DAISY.zip</strong></a> para sa "
-"<a href=\"%(url)s\">%(title)s</a>"
+msgid "<a href=\"%(daisy_url)s\"><strong>Download the DAISY.zip</strong></a> for <a href=\"%(url)s\">%(title)s</a>"
+msgstr "<a href=\"%(daisy_url)s\"><strong>I-download ang DAISY.zip</strong></a> para sa <a href=\"%(url)s\">%(title)s</a>"
 
 #: books/daisy.html
 msgid "Books for people who don't read print?"
 msgstr "Mga libro para sa mga taong hindi nagbabasa ng nakalimbag?"
 
 #: books/daisy.html
-msgid ""
-"The <a href=\"//archive.org\">Internet Archive</a> is proud to be "
-"distributing over 1 million books free in a format called DAISY
-msgstr ""
-"Ang <a href=\"//archive.org\">Internet Archive</a> ay ipinagmamalaki na "
-"namamahagi ng higit sa 1 milyong mga aklat nang libre sa isang format na tinatawag na DAISY."
+msgid "The <a href=\"//archive.org\">Internet Archive</a> is proud to be distributing over 1 million books free in a format called DAISY, designed for those of us who find it challenging to use regular printed media. "
+msgstr "Ang <a href=\"//archive.org\">Internet Archive</a> ay ipinagmamalaki na namimigay ng mahigit 1 milyong aklat nang libre sa isang format na tinatawag na DAISY, na dinisenyo para sa mga tao na nahihirapan gumamit ng regular na nakaimprentang media."
 
 #: books/daisy.html
-msgid ""
-"The <a href=\"//archive.org\">Internet Archive</a> is proud to be "
-"distributing over 1 million books free in a format called DAISY, designed"
-" for those of us who find it challenging to use regular printed media. "
-msgstr ""
-"Ang <a href=\"//archive.org\">Internet Archive</a> ay ipinagmamalaki na "
-"namimigay ng mahigit 1 milyong aklat nang libre sa isang format na tinatawag "
-"na DAISY, na dinisenyo para sa mga tao na nahihirapan gumamit ng regular "
-"na nakaimprentang media."
-
-#: books/daisy.html
-msgid ""
-"There are two types of DAISYs on Open Library: <i>open</i> and "
-"<i>protected</i>. Open DAISYs can be read by anyone in the world on many "
-"different devices. Protected DAISYs like this one can only be opened "
-"using a key issued by the <a href=\"http://www.loc.gov/nls/\">Library of "
-"Congress NLS program</a>."
-msgstr ""
-"Mayroong dalawang uri ng DAISYs sa Open Library: <i>bukas</i> at "
-"<i>naka-protektado</i>. Ang mga Bukas na DAISY ay maaaring basahin ng sinuman "
-"sa mundo sa maraming iba't ibang aparato. Ang mga Naka-protektadong DAISY "
-"tulad nito ay maaari lamang buksan gamit ang isang susi na ibinigay ng "
-"<a href=\"http://www.loc.gov/nls/\">Library of Congress NLS program</a>."
-
-#: books/daisy.html
-msgid ""
-"There are two types of DAISYs on Open Library: <i>open</i> and "
-"<i>protected</i>. Open DAISYs can be read by anyone in the world on many "
-"different devices. Protected DAISYs can only be opened using a key issued"
-" by the <a href=\"http://www.loc.gov/nls/\">Library of Congress NLS "
-"program</a>."
-msgstr ""
-"Mayroong dalawang uri ng DAISYs sa Open Library: <i>bukas</i> at "
-"<i>naka-protektado</i>. Ang mga Bukas na DAISY ay maaaring basahin ng sinuman "
-"sa mundo sa maraming iba't ibang aparato. Ang mga Naka-protektadong DAISY "
-"ay maaari lamang buksan gamit ang isang susi na ibinigay ng "
-"<a href=\"http://www.loc.gov/nls/\">Library of Congress NLS program</a>."
+msgid "There are two types of DAISYs on Open Library: <i>open</i> and <i>protected</i>. Open DAISYs can be read by anyone in the world on many different devices. Protected DAISYs can only be opened using a key issued by the <a href=\"http://www.loc.gov/nls/\">Library of Congress NLS program</a>."
+msgstr "Mayroong dalawang uri ng DAISYs sa Open Library: <i>bukas</i> at <i>naka-protektado</i>. Ang mga Bukas na DAISY ay maaaring basahin ng sinuman sa mundo sa maraming iba't ibang aparato. Ang mga Naka-protektadong DAISY ay maaari lamang buksan gamit ang isang susi na ibinigay ng <a href=\"http://www.loc.gov/nls/\">Library of Congress NLS program</a>."
 
 #: books/daisy.html lists/home.html
 msgid "Enjoy!"
@@ -5087,16 +3716,8 @@ msgid "What is the DAISY format?"
 msgstr "Ano ang format na DAISY?"
 
 #: books/daisy.html
-msgid ""
-"The DAISY digital format helps people who have challenges using regular "
-"printed media. DAISY digital <span class=\"highlight\">talking "
-"books</span> offer the benefits of regular audiobooks, with navigation "
-"within the book, to chapters or specific pages."
-msgstr ""
-"Ang format na digital na DAISY ay tumutulong sa mga tao na may mga hamon sa "
-"Paggamit ng regular na nakaimprentang media. Ang DAISY digital <span class=\"highlight\">nagsasalitang "
-"mga aklat</span> ay nag-aalok ng mga benepisyo ng mga regular na audiobooks, "
-"na may pag-navigate sa loob ng aklat, sa mga kabanata o tiyak na mga pahina."
+msgid "The DAISY digital format helps people who have challenges using regular printed media. DAISY digital <span class=\"highlight\">talking books</span> offer the benefits of regular audiobooks, with navigation within the book, to chapters or specific pages."
+msgstr "Ang format na digital na DAISY ay tumutulong sa mga tao na may mga hamon sa Paggamit ng regular na nakaimprentang media. Ang DAISY digital <span class=\"highlight\">nagsasalitang mga aklat</span> ay nag-aalok ng mga benepisyo ng mga regular na audiobooks, na may pag-navigate sa loob ng aklat, sa mga kabanata o tiyak na mga pahina."
 
 #: books/daisy.html
 msgid "More information at daisy.org"
@@ -5107,18 +3728,8 @@ msgid "What is the NLS?"
 msgstr "Ano ang NLS?"
 
 #: books/daisy.html
-msgid ""
-"The Library of Congress <a href=\"http://www.loc.gov/nls/\">National "
-"Library Service for the Blind and Physically Handicapped (NLS)</a> "
-"administers a free library program of braille and audio materials "
-"circulated to eligible borrowers in the United States through a national "
-"network of cooperating libraries."
-msgstr ""
-"Ang Library of Congress <a href=\"http://www.loc.gov/nls/\">National "
-"Library Service for the Blind and Physically Handicapped (NLS)</a> "
-"ang namamahala sa isang libreng programa ng aklatan ng braille at mga materyales "
-"na audio na ipinamamahagi sa mga kwalipikadong nanghihiram sa Estados Unidos "
-"sa pamamagitan ng pambansang network ng mga kasaping aklatan."
+msgid "The Library of Congress <a href=\"http://www.loc.gov/nls/\">National Library Service for the Blind and Physically Handicapped (NLS)</a> administers a free library program of braille and audio materials circulated to eligible borrowers in the United States through a national network of cooperating libraries."
+msgstr "Ang Library of Congress <a href=\"http://www.loc.gov/nls/\">National Library Service for the Blind and Physically Handicapped (NLS)</a> ang namamahala sa isang libreng programa ng aklatan ng braille at mga materyales na audio na ipinamamahagi sa mga kwalipikadong nanghihiram sa Estados Unidos sa pamamagitan ng pambansang network ng mga kasaping aklatan."
 
 #: books/daisy.html
 msgid "Are you eligible to register?"
@@ -5129,78 +3740,44 @@ msgid "How do I find DAISYs on Open Library?"
 msgstr "Paano ko mahahanap ang mga DAISY sa Open Library?"
 
 #: books/daisy.html
-msgid ""
-"In addition to<a href=\"/subjects/accessible_book\" title=\"Subject: "
-"Accessible book\"> loads of open DAISYs</a>, the Open Library lists a "
-"smaller selection of<a href=\"/subjects/protected_DAISY\" "
-"title=\"Subject: Protected DAISY\"> protected DAISY titles</a> accessible"
-" to those with a Library of Congress NLS key. These titles are brought to"
-" you by the<a href=\"//archive.org/\"> Internet Archive</a>."
-msgstr ""
-"Bilang karagdagan sa <a href=\"/subjects/accessible_book\" title=\"Subject: "
-"Accessible book\"> marami pang bukas na DAISY</a>, ang Open Library ay naglista ng "
-"mas kaunting seleksyon ng <a href=\"/subjects/protected_DAISY\" "
-"title=\"Subject: Protected DAISY\"> mga naka-protektadong pamagat ng DAISY</a> "
-"na naa-access ng mga may isang susi mula sa Library of Congress NLS. Ang mga pamagat na "
-"ito ay hatid sa iyo ng <a href=\"//archive.org/\"> Internet Archive</a>."
+msgid "In addition to<a href=\"/subjects/accessible_book\" title=\"Subject: Accessible book\"> loads of open DAISYs</a>, the Open Library lists a smaller selection of<a href=\"/subjects/protected_DAISY\" title=\"Subject: Protected DAISY\"> protected DAISY titles</a> accessible to those with a Library of Congress NLS key. These titles are brought to you by the<a href=\"//archive.org/\"> Internet Archive</a>."
+msgstr "Bilang karagdagan sa <a href=\"/subjects/accessible_book\" title=\"Subject: Accessible book\"> marami pang bukas na DAISY</a>, ang Open Library ay naglista ng mas kaunting seleksyon ng <a href=\"/subjects/protected_DAISY\" title=\"Subject: Protected DAISY\"> mga naka-protektadong pamagat ng DAISY</a> na naa-access ng mga may isang susi mula sa Library of Congress NLS. Ang mga pamagat na ito ay hatid sa iyo ng <a href=\"//archive.org/\"> Internet Archive</a>."
 
 #: books/daisy.html
-msgid ""
-"Looking for a specific title? The best way to find it is to<a "
-"href=\"/search\"> search for it</a>."
-msgstr ""
-"Naghahanap ng tiyak na pamagat? Ang pinakamagandang paraan upang mahanap ito ay "
-"ang <a href=\"/search\"> maghanap para dito</a>."
+msgid "Looking for a specific title? The best way to find it is to<a href=\"/search\"> search for it</a>."
+msgstr "Naghahanap ng tiyak na pamagat? Ang pinakamagandang paraan upang mahanap ito ay ang <a href=\"/search\"> maghanap para dito</a>."
 
-#: books/daisy.html lib/history.html
+#: books/daisy.html lib/exports.html
 msgid "Need help?"
 msgstr "Kailangan ba ng tulong?"
 
 #: books/daisy.html
-msgid ""
-" Please read our <a href=\"/help/faq\">FAQ on accessing books through "
-"Open Library</a>."
-msgstr ""
-" Mangyaring basahin ang aming <a href=\"/help/faq\">FAQ tungkol sa pag-access sa mga aklat "
-"sa pamamagitan ng Open Library</a>."
+msgid " Please read our <a href=\"/help/faq\">FAQ on accessing books through Open Library</a>."
+msgstr " Mangyaring basahin ang aming <a href=\"/help/faq\">FAQ tungkol sa pag-access sa mga aklat sa pamamagitan ng Open Library</a>."
 
 #: books/edit.html
 msgid "Add a little more?"
 msgstr "Magdagdag pa ng kaunti?"
 
 #: books/edit.html
-msgid ""
-"Thank you for adding that book! Any more information you could provide "
-"would be wonderful!"
-msgstr ""
-"Salamat sa pagdagdag ng aklat na iyon! Anumang karagdagang impormasyon na maaari mong "
-"ibigay ay magiging kamangha-manghang!"
+msgid "Thank you for adding that book! Any more information you could provide would be wonderful!"
+msgstr "Salamat sa pagdagdag ng aklat na iyon! Anumang karagdagang impormasyon na maaari mong ibigay ay magiging kamangha-manghang!"
 
 #: books/edit.html
 #, python-format
-msgid ""
-"We already know about <b>%(work_title)s</b>, but not the <b>%(year)s "
-"%(publisher)s edition</b>. Thanks! Do you know any more about this "
-"edition?"
-msgstr ""
-"Alam na namin ang tungkol sa <b>%(work_title)s</b>, ngunit hindi ang <b>%(year)s "
-"%(publisher)s edition</b>. Salamat! Alam mo ba ang higit pang impormasyon "
-"tungkol sa edisyong ito?"
+msgid "We already know about <b>%(work_title)s</b>, but not the <b>%(year)s %(publisher)s edition</b>. Thanks! Do you know any more about this edition?"
+msgstr "Alam na namin ang tungkol sa <b>%(work_title)s</b>, ngunit hindi ang <b>%(year)s %(publisher)s edition</b>. Salamat! Alam mo ba ang higit pang impormasyon tungkol sa edisyong ito?"
 
 #: books/edit.html
 #, python-format
-msgid ""
-"We already know about the <b>%(year)s %(publisher)s edition</b> of "
-"<b>%(work_title)s</b>, but please, tell us more!"
-msgstr ""
-"Alam na namin ang tungkol sa <b>%(year)s %(publisher)s edition</b> ng "
-"<b>%(work_title)s</b>, ngunit mangyaring, sabihin sa amin ang higit pa!"
+msgid "We already know about the <b>%(year)s %(publisher)s edition</b> of <b>%(work_title)s</b>, but please, tell us more!"
+msgstr "Alam na namin ang tungkol sa <b>%(year)s %(publisher)s edition</b> ng <b>%(work_title)s</b>, ngunit mangyaring, sabihin sa amin ang higit pa!"
 
 #: books/edit.html
 msgid "Editing..."
 msgstr "Nagre-edit..."
 
-#: books/edit.html type/author/edit.html type/template/edit.html
+#: books/edit.html type/author/edit.html type/tag/form.html type/template/edit.html
 msgid "Delete Record"
 msgstr "Tanggalin ang Tala"
 
@@ -5217,14 +3794,9 @@ msgid "This Work"
 msgstr "Ang Trabahong Ito"
 
 #: books/edit.html
-msgid ""
-"You can search by author name (like <em>j k rowling</em>) or by Open "
-"Library ID (like <a href=\"/authors/OL23919A\" "
-"target=\"_blank\"><em>OL23919A</em></a>)."
+#, fuzzy
+msgid "You can search by author name (like <em>j k rowling</em>) or by Open Library ID (like <a href=\"/authors/OL23919A\" target=\"_blank\" rel=\"noopener noreferrer\"><em>OL23919A</em></a>)."
 msgstr ""
-"Maaari kang maghanap gamit ang pangalan ng may-akda (tulad ng <em>j k rowling</em>) "
-"o sa pamamagitan ng Open Library ID (tulad ng <a href=\"/authors/OL23919A\" "
-"target=\"_blank\"><em>OL23919A</em></a>)."
 
 #: books/edit.html
 msgid "Author editing requires javascript"
@@ -5243,14 +3815,8 @@ msgid "Work Series"
 msgstr "Serye ng Trabaho"
 
 #: books/edit.html
-msgid ""
-"Series are currently in beta, and this section is only visible to super "
-"librarians and admins, like you! Any series you set will be visible by "
-"everyone, however. Please report any issues you have on Slack or GitHub."
-msgstr ""
-"Ang mga serye ay kasalukuyang nasa beta, at ang seksyong ito ay makikita lamang "
-"sa mga super librarian at admin, tulad mo! Anumang serye na itatakda mo ay makikita "
-"ng lahat, gayunpaman. Mangyaring i-report ang anumang problema sa Slack o GitHub."
+msgid "Series are currently in beta, and this section is only visible to super librarians and admins, like you! Any series you set will be visible by everyone, however. Please report any issues you have on Slack or GitHub."
+msgstr "Ang mga serye ay kasalukuyang nasa beta, at ang seksyong ito ay makikita lamang sa mga super librarian at admin, tulad mo! Anumang serye na itatakda mo ay makikita ng lahat, gayunpaman. Mangyaring i-report ang anumang problema sa Slack o GitHub."
 
 #: books/edit.html
 msgid "Is this work part of a larger series?"
@@ -5269,14 +3835,13 @@ msgid "Do you know any identifiers for this work?"
 msgstr "Alam mo ba ang anumang mga identifier para sa trabahong ito?"
 
 #: books/edit.html
-msgid ""
-"These identifiers apply to all editions of this work, for example "
-"Wikidata work identifiers. For edition-specific identifiers, like ISBN or"
-" LCCN, go to the edition tab."
-msgstr ""
-"Ang mga identifier na ito ay nalalapat sa lahat ng edisyon ng trabahong ito, "
-"halimbawa ang mga identifier ng wikidata. Para sa mga espesyal na identifier "
-"para sa edisyon, tulad ng ISBN o LCCN, pumunta sa tab ng edisyon."
+msgid "These identifiers apply to all editions of this work, for example Wikidata work identifiers. For edition-specific identifiers, like ISBN or LCCN, go to the edition tab."
+msgstr "Ang mga identifier na ito ay nalalapat sa lahat ng edisyon ng trabahong ito, halimbawa ang mga identifier ng wikidata. Para sa mga espesyal na identifier para sa edisyon, tulad ng ISBN o LCCN, pumunta sa tab ng edisyon."
+
+#: FulltextSearchSuggestionItem.html IABook.html SearchResultsWork.html books/edition-sort.html jsdef/LazyWorkPreview.html lists/list_overview.html lists/preview.html lists/snippet.html lists/widget.html my_books/dropdown_content.html type/work/editions.html
+#, python-format
+msgid "Cover of: %(title)s"
+msgstr "Pabalat ng: %(title)s"
 
 #: books/edition-sort.html
 #, python-format
@@ -5292,6 +3857,55 @@ msgstr "Petsa ng paglalathala hindi alam, %(publisher)s"
 #, python-format
 msgid "in %(languagelist)s"
 msgstr "sa %(languagelist)s"
+
+#: SearchNavigation.html books/mybooks_breadcrumb_select.html lib/nav_foot.html openlibrary/plugins/upstream/mybooks.py
+msgid "Books"
+msgstr "Mga Aklat"
+
+#. Page title for the "Want to Read" shelf page.
+#. Example: "Want to Read (17)". %(count)d is the number of books on this
+#. shelf.
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#, python-format
+msgid "Want to Read (%(count)d)"
+msgstr "Gustong Basahin (%(count)d)"
+
+#. Page title for the "Currently Reading" shelf page.
+#. Example: "Currently Reading (42)". %(count)d is the number of books on this
+#. shelf.
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#, python-format
+msgid "Currently Reading (%(count)d)"
+msgstr "Kasalukuyang Binabasa (%(count)d)"
+
+#. Page title for the "Already Read" shelf page.
+#. Example: "Already Read (203)". %(count)d is the number of books on this
+#. shelf.
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#, python-format
+msgid "Already Read (%(count)d)"
+msgstr "Nabasa na (%(count)d)"
+
+#. Page title for the "Stopped Reading" shelf page.
+#. Example: "Stopped Reading (8)". %(count)d is the number of books on this
+#. shelf.
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#, fuzzy, python-format
+msgid "Stopped Reading (%(count)d)"
+msgstr "Kasalukuyang Binabasa (%(count)d)"
+
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/openlibrary/lists.py
+#, python-format
+msgid "Lists (%(count)d)"
+msgstr "Mga Listahan (%(count)d)"
+
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py type/edition/modal_links.html
+msgid "Notes"
+msgstr "Mga Tala"
+
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
+msgid "Imports and Exports"
+msgstr "Mga Import at Export"
 
 #: books/series-autocomplete.html
 msgid "Add a new series"
@@ -5334,56 +3948,32 @@ msgid "Please separate with commas."
 msgstr "Mangyaring paghiwalayin ng mga kuwit."
 
 #: books/edit/about.html
-msgid ""
-"For example: <i><a href=\"/subjects/cheese\">cheese</a>, <a "
-"href=\"/subjects/roman_empire\">Roman Empire</a>, <a "
-"href=\"/subjects/psychology\">psychology</a></i>"
-msgstr ""
-"Halimbawa: <i><a href=\"/subjects/cheese\">kesо</a>, <a "
-"href=\"/subjects/roman_empire\">Imperyo ng Roma</a>, <a "
-"href=\"/subjects/psychology\">sikolohiya</a></i>"
+msgid "For example: <i><a href=\"/subjects/cheese\">cheese</a>, <a href=\"/subjects/roman_empire\">Roman Empire</a>, <a href=\"/subjects/psychology\">psychology</a></i>"
+msgstr "Halimbawa: <i><a href=\"/subjects/cheese\">kesо</a>, <a href=\"/subjects/roman_empire\">Imperyo ng Roma</a>, <a href=\"/subjects/psychology\">sikolohiya</a></i>"
 
 #: books/edit/about.html
 msgid "A person? Or, people?"
 msgstr "Isang tao? O, mga tao?"
 
 #: books/edit/about.html
-msgid ""
-"For example: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore "
-"Roosevelt</a>, <a href=\"/subjects/person:Julian_of_Norwich\">Julian of "
-"Norwich</a>, <a href=\"/subjects/person:Tintin\">Tintin</a></i>"
-msgstr ""
-"Halimbawa: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore "
-"Roosevelt</a>, <a href=\"/subjects/person:Julian_of_Norwich\">Julian ng "
-"Norwich</a>, <a href=\"/subjects/person:Tintin\">Tintin</a></i>"
+msgid "For example: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore Roosevelt</a>, <a href=\"/subjects/person:Julian_of_Norwich\">Julian of Norwich</a>, <a href=\"/subjects/person:Tintin\">Tintin</a></i>"
+msgstr "Halimbawa: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore Roosevelt</a>, <a href=\"/subjects/person:Julian_of_Norwich\">Julian ng Norwich</a>, <a href=\"/subjects/person:Tintin\">Tintin</a></i>"
 
 #: books/edit/about.html
 msgid "Note any places mentioned?"
 msgstr "Tandaan ang anumang mga lugar na nabanggit?"
 
 #: books/edit/about.html
-msgid ""
-"For example: <i><a href=\"/subjects/place:London\">London</a>, <a "
-"href=\"/subjects/place:Atlantis\">Atlantis</a>, <a "
-"href=\"/subjects/place:Omaha\">Omaha</a></i>"
-msgstr ""
-"Halimbawa: <i><a href=\"/subjects/place:London\">London</a>, <a "
-"href=\"/subjects/place:Atlantis\">Atlantis</a>, <a "
-"href=\"/subjects/place:Omaha\">Omaha</a></i>"
+msgid "For example: <i><a href=\"/subjects/place:London\">London</a>, <a href=\"/subjects/place:Atlantis\">Atlantis</a>, <a href=\"/subjects/place:Omaha\">Omaha</a></i>"
+msgstr "Halimbawa: <i><a href=\"/subjects/place:London\">London</a>, <a href=\"/subjects/place:Atlantis\">Atlantis</a>, <a href=\"/subjects/place:Omaha\">Omaha</a></i>"
 
 #: books/edit/about.html
 msgid "When is it set or about?"
 msgstr "Kailan ito nakatakdang mangyari o tungkol saan?"
 
 #: books/edit/about.html
-msgid ""
-"For example: <i><a href=\"/subjects/time:1984\">1984</a>, <a "
-"href=\"/subjects/time:the_middle_ages\">The Middle Ages</a>, <a "
-"href=\"/subjects/time:1810-1890\">1810-1890</a></i>"
-msgstr ""
-"Halimbawa: <i><a href=\"/subjects/time:1984\">1984</a>, <a "
-"href=\"/subjects/time:the_middle_ages\">Ang Gitnang Panahon</a>, <a "
-"href=\"/subjects/time:1810-1890\">1810-1890</a></i>"
+msgid "For example: <i><a href=\"/subjects/time:1984\">1984</a>, <a href=\"/subjects/time:the_middle_ages\">The Middle Ages</a>, <a href=\"/subjects/time:1810-1890\">1810-1890</a></i>"
+msgstr "Halimbawa: <i><a href=\"/subjects/time:1984\">1984</a>, <a href=\"/subjects/time:the_middle_ages\">Ang Gitnang Panahon</a>, <a href=\"/subjects/time:1810-1890\">1810-1890</a></i>"
 
 #: books/edit/edition.html
 msgid "Select this language"
@@ -5418,6 +4008,10 @@ msgid "Usually distinguished by different or smaller type."
 msgstr "Kadalasang naiiba sa pamamagitan ng ibang o mas maliit na tipo."
 
 #: books/edit/edition.html
+msgid "For example: <i>envisioning the next 50 years</i>"
+msgstr "Halimbawa: <i>envisioning the next 50 years</i>"
+
+#: books/edit/edition.html
 msgid "Publishing Info"
 msgstr "Impormasyon sa Paglalathala"
 
@@ -5434,6 +4028,11 @@ msgid "City, Country please."
 msgstr "Lungsod, Bansa, mangyaring."
 
 #: books/edit/edition.html
+#, fuzzy
+msgid "For example: <i>New York, USA; Sydney, Australia</i>"
+msgstr ""
+
+#: books/edit/edition.html
 msgid "What is the copyright date?"
 msgstr "Ano ang petsa ng copyright?"
 
@@ -5446,12 +4045,20 @@ msgid "Edition Name (if applicable):"
 msgstr "Pangalan ng Edisyon (kung naaangkop):"
 
 #: books/edit/edition.html
+msgid "For example: <i>Centennial edition</i>; <i>First edition</i>"
+msgstr "Halimbawa: <i>Centennial edition</i>; <i>First edition</i>"
+
+#: books/edit/edition.html
 msgid "Series Name (if applicable)"
 msgstr "Pangalan ng Serye (kung naaangkop)"
 
 #: books/edit/edition.html
 msgid "The name of the publisher's series."
 msgstr "Ang pangalan ng serye ng publisher."
+
+#: books/edit/edition.html
+msgid "For example: <i>The Story of Civilization, Part III</i>"
+msgstr "Halimbawa: <i>The Story of Civilization, Part III</i>"
 
 #: books/edit/edition.html type/edition/view.html type/work/view.html
 msgid "Contributors"
@@ -5494,6 +4101,29 @@ msgid "Languages"
 msgstr "Wika"
 
 #: books/edit/edition.html
+#, fuzzy
+msgid "What language is this edition written in?"
+msgstr "Anong wika ang ginamit sa orihinal?"
+
+#: books/edit/edition.html
+#, fuzzy
+msgid "Add another language?"
+msgstr "Magdagdag ng isa pang larawan"
+
+#: books/edit/edition.html
+msgid "Is it a translation of another book?"
+msgstr "Ito ba ay isang salin ng ibang aklat?"
+
+#: books/edit/edition.html
+msgid "Yes, it's a translation"
+msgstr "Oo, ito ay isang salin"
+
+#: books/edit/edition.html
+#, fuzzy
+msgid "What's the original book?"
+msgstr "Ano ang NLS?"
+
+#: books/edit/edition.html
 msgid "What language was the original written in?"
 msgstr "Anong wika ang ginamit sa orihinal?"
 
@@ -5510,23 +4140,12 @@ msgid "Table of Contents"
 msgstr "Talaan ng Nilalaman"
 
 #: books/edit/edition.html
-msgid ""
-"Use a \"*\" for an indent, a \"|\" to add a column, and line breaks for "
-"new lines. Like this:"
-msgstr ""
-"Gumamit ng \"*\" para sa indent, isang \"|\" para magdagdag ng column, at "
-"line breaks para sa bagong linya. Tulad nito:"
+msgid "Use a \"*\" for an indent, a \"|\" to add a column, and line breaks for new lines. Like this:"
+msgstr "Gumamit ng \"*\" para sa indent, isang \"|\" para magdagdag ng column, at line breaks para sa bagong linya. Tulad nito:"
 
 #: books/edit/edition.html
-msgid ""
-"This table of contents contains extra information like authors or "
-"descriptions. We don't have a great user interface for this yet, so "
-"editing this data could be difficult. Watch out!"
-msgstr ""
-"Ang talahanayan ng nilalaman na ito ay naglalaman ng karagdagang impormasyon "
-"tulad ng mga may-akda o paglalarawan. Wala pa kaming mahusay na interface "
-"sa gumagamit para dito, kaya ang pag-edit ng data na ito ay maaaring maging "
-"mahirap. Mag-ingat!"
+msgid "This table of contents contains extra information like authors or descriptions. We don't have a great user interface for this yet, so editing this data could be difficult. Watch out!"
+msgstr "Ang talahanayan ng nilalaman na ito ay naglalaman ng karagdagang impormasyon tulad ng mga may-akda o paglalarawan. Wala pa kaming mahusay na interface sa gumagamit para dito, kaya ang pag-edit ng data na ito ay maaaring maging mahirap. Mag-ingat!"
 
 #: books/edit/edition.html
 msgid "Any notes about this specific edition?"
@@ -5537,51 +4156,38 @@ msgid "Anything about the book that may be of interest."
 msgstr "Anumang bagay tungkol sa aklat na maaaring maging kawili-wili."
 
 #: books/edit/edition.html
+#, fuzzy
+msgid "A Plume Book"
+msgstr "Galugarin ang mga Aklat"
+
+#: books/edit/edition.html
 msgid "Is it known by any other titles?"
 msgstr "Kilalá ba ito sa anumang iba pang pamagat?"
 
 #: books/edit/edition.html
-msgid ""
-"Use this field if the title is different on the cover or spine. If the "
-"edition is a collection or anthology, you may also add the individual "
-"titles of each work here."
-msgstr ""
-"Gumamit ng patlang na ito kung ang pamagat ay iba sa pabalat o spina. "
-"Kung ang edisyon ay isang koleksyon o antolohiya, maaari mo ring idagdag "
-"ang mga indibidwal na pamagat ng bawat gawain dito."
+msgid "Use this field if the title is different on the cover or spine. If the edition is a collection or anthology, you may also add the individual titles of each work here."
+msgstr "Gumamit ng patlang na ito kung ang pamagat ay iba sa pabalat o spina. Kung ang edisyon ay isang koleksyon o antolohiya, maaari mo ring idagdag ang mga indibidwal na pamagat ng bawat gawain dito."
 
 #: books/edit/edition.html
-msgid ""
-"For example: <i>Eaters of the Dead</i> is an alternate title for <i><a "
-"href=\"/books/OL24923038M\">The 13th Warrior</a></i>."
-msgstr ""
-"Halimbawa: <i>Eaters of the Dead</i> ay isang alternatibong pamagat para sa "
-"<i><a href=\"/books/OL24923038M\">The 13th Warrior</a></i>."
+msgid "For example: <i>Eaters of the Dead</i> is an alternate title for <i><a href=\"/books/OL24923038M\">The 13th Warrior</a></i>."
+msgstr "Halimbawa: <i>Eaters of the Dead</i> ay isang alternatibong pamagat para sa <i><a href=\"/books/OL24923038M\">The 13th Warrior</a></i>."
 
 #: books/edit/edition.html
 msgid "What work is this an edition of?"
 msgstr "Anong gawain ito ay isang edisyon ng?"
 
 #: books/edit/edition.html
-msgid ""
-"Sometimes editions can be associated with the wrong work. You can correct"
-" that here."
-msgstr ""
-"Kung minsan ang mga edisyon ay maaaring maiugnay sa maling gawain. "
-"Maaari mong ituwid iyan dito."
+msgid "Sometimes editions can be associated with the wrong work. You can correct that here."
+msgstr "Kung minsan ang mga edisyon ay maaaring maiugnay sa maling gawain. Maaari mong ituwid iyan dito."
 
 #: books/edit/edition.html
-msgid ""
-"You can search by title or by Open Library ID (like <a "
-"href=\"/works/OL262757W\" target=\"_blank\"><em>OL262757W</em></a>)."
+#, fuzzy
+msgid "You can search by title or by Open Library ID (like <a href=\"/works/OL262757W\" target=\"_blank\" rel=\"noopener noreferrer\"><em>OL262757W</em></a>)."
 msgstr ""
-"Maaari kang maghanap gamit ang pamagat o sa Open Library ID (tulad ng <a "
-"href=\"/works/OL262757W\" target=\"_blank\"><em>OL262757W</em></a>)."
 
 #: books/edit/edition.html
 msgid "WARNING: Any edits made to the work from this page will be ignored."
-msgstr "BABALA: Anumang mga pagbabago na ginawa sa gawain mula sa pahinang ito "
-"ay balewalain."
+msgstr "BABALA: Anumang mga pagbabago na ginawa sa gawain mula sa pahinang ito ay balewalain."
 
 #: books/edit/edition.html
 msgid "Copy authors to new work"
@@ -5776,16 +4382,17 @@ msgid "That excerpt is too long."
 msgstr "Ang siping iyon ay masyadong mahaba."
 
 #: books/edit/excerpts.html
-msgid ""
-"If there are particular (short) passages you feel represent the book "
-"well, please feel free to transcribe them here."
-msgstr ""
-"Kung mayroon kang mga partikular (maikling) bahagi na sa tingin mo ay "
-"kumakatawan nang maayos sa aklat, mangyaring ipasulat ang mga ito dito."
+msgid "If there are particular (short) passages you feel represent the book well, please feel free to transcribe them here."
+msgstr "Kung mayroon kang mga partikular (maikling) bahagi na sa tingin mo ay kumakatawan nang maayos sa aklat, mangyaring ipasulat ang mga ito dito."
 
 #: books/edit/excerpts.html
 msgid "Page number?"
 msgstr "Ilang pahina?"
+
+#: books/edit/excerpts.html
+#, fuzzy
+msgid "For example: <i>23, xi or 433-434</i>"
+msgstr ""
 
 #: books/edit/excerpts.html
 msgid "This excerpt is the first sentence of the book."
@@ -5836,12 +4443,8 @@ msgid "Please enter a valid URL."
 msgstr "Mangyaring maglagay ng wastong URL."
 
 #: books/edit/web.html
-msgid ""
-"Please connect Open Library records to <u>good</u><span "
-"class=\"orange\">*</span> online resources."
-msgstr ""
-"Mangyaring ikonekta ang mga tala ng Open Library sa <u>mabuti</u><span "
-"class=\"orange\">*</span> mga online na mapagkukunan."
+msgid "Please connect Open Library records to <u>good</u><span class=\"orange\">*</span> online resources."
+msgstr "Mangyaring ikonekta ang mga tala ng Open Library sa <u>mabuti</u><span class=\"orange\">*</span> mga online na mapagkukunan."
 
 #: books/edit/web.html
 msgid "Give your link a label"
@@ -5864,16 +4467,10 @@ msgid "Remove this link"
 msgstr "Tanggalin ang link na ito"
 
 #: books/edit/web.html
-msgid ""
-"\"Good\" means no spammy links, please. Keep them relevant to the book. "
-"Irrelevant sites may be removed. Blatant spam will be deleted without "
-"remorse."
-msgstr ""
-"\"Mabuti\" ay nangangahulugang walang mga spammy na link, pakisuyo. Panatilihin "
-"itong may kinalaman sa aklat. Ang mga hindi kaugnay na site ay maaaring "
-"alisin. Ang mga halatang spam ay aalisin nang walang awa."
+msgid "\"Good\" means no spammy links, please. Keep them relevant to the book. Irrelevant sites may be removed. Blatant spam will be deleted without remorse."
+msgstr "\"Mabuti\" ay nangangahulugang walang mga spammy na link, pakisuyo. Panatilihin itong may kinalaman sa aklat. Ang mga hindi kaugnay na site ay maaaring alisin. Ang mga halatang spam ay aalisin nang walang awa."
 
-#: bulk_search/bulk_search.html
+#: bulk_search/bulk_search.html search/advancedsearch.html
 msgid "Bulk Search (beta)"
 msgstr "Bulk Search (beta)"
 
@@ -5903,12 +4500,8 @@ msgstr "Mangyaring magbigay ng URL ng larawan."
 
 #: covers/add.html
 #, python-format
-msgid ""
-"Learn more by reading our <a href=\"/help/faq/editing#picture\" "
-"target=\"blank\">%(guidelines)s</a>."
-msgstr ""
-"Matuto nang higit pa sa pamamagitan ng pagbasa ng aming <a href=\"/help/faq/editing#picture\" "
-"target=\"blank\">%(guidelines)s</a>."
+msgid "Learn more by reading our <a href=\"/help/faq/editing#picture\" target=\"blank\">%(guidelines)s</a>."
+msgstr "Matuto nang higit pa sa pamamagitan ng pagbasa ng aming <a href=\"/help/faq/editing#picture\" target=\"blank\">%(guidelines)s</a>."
 
 #: covers/add.html
 msgid "<strong>Pick one</strong> from the existing covers"
@@ -6020,17 +4613,13 @@ msgid "Manage"
 msgstr "Pamahalaan"
 
 #: covers/external_image.html
-#, python-format
-msgid "Or, use a cover from %s"
+#, fuzzy, python-format
+msgid "Or, use an image from %s"
 msgstr "O, gumamit ng pabalat mula sa %s"
 
 #: covers/manage.html
-msgid ""
-"You can drag and drop thumbnails to reorder, or into the trash to delete "
-"them."
-msgstr ""
-"Maaari mong i-drag at i-drop ang mga thumbnail upang i-reorder, o sa basurahan "
-"upang tanggalin ang mga ito."
+msgid "You can drag and drop thumbnails to reorder, or into the trash to delete them."
+msgstr "Maaari mong i-drag at i-drop ang mga thumbnail upang i-reorder, o sa basurahan upang tanggalin ang mga ito."
 
 #: covers/saved.html
 msgid "New book cover"
@@ -6052,6 +4641,252 @@ msgstr "Magdagdag ng isa pang larawan"
 msgid "Finished"
 msgstr "Natapos"
 
+#: design/banner.html
+#, python-format
+msgid "The %(tag)s component is a callout-style announcement banner. The announcement is server-rendered into the default slot — already translated, visible to search engines — while the component owns the chrome: variant styling, icon, dismissal, and cookie persistence. There is intentionally no entrance animation; banners appear on every page view."
+msgstr "Ang %(tag)s na komponent ay isang callout-style na banner para sa mga anunsyo. Ang anunsyo ay nire-render sa server sa default slot — naisalin na, nakikita ng mga search engine — habang pinamamahalaan ng komponent ang chrome: variant styling, icon, dismissal, at cookie persistence. Wala itong entrance animation nang sadya; lilitaw ang mga banner sa bawat page view."
+
+#: design/banner.html
+msgid "Variants"
+msgstr "Mga Variant"
+
+#: design/banner.html
+#, python-format
+msgid "Use %(variant)s for semantic variants. Each pairs a tinted surface with a filled icon circle — the same icon treatment as %(toast)s."
+msgstr "Gamitin ang %(variant)s para sa mga semantic na variant. Ang bawat isa ay nagpapares ng may kulay na ibabaw at isang punong icon circle — parehong pagtrato ng icon tulad ng %(toast)s."
+
+#: design/banner.html
+msgid "Open Library is a non-profit project of the Internet Archive."
+msgstr "Ang Open Library ay isang non-profit na proyekto ng Internet Archive."
+
+#: design/banner.html
+msgid "Your import finished — 42 books added to your reading log."
+msgstr "Natapos na ang iyong pag-import — 42 na aklat ang idinagdag sa iyong reading log."
+
+#: design/banner.html
+msgid "Open Library will be briefly unavailable on June 12 for maintenance."
+msgstr "Ang Open Library ay pansamantalang hindi available noong Hunyo 12 para sa maintenance."
+
+#: design/banner.html
+msgid "Search is currently degraded. Some results may be missing."
+msgstr "Ang paghahanap ay kasalukuyang limitado. Maaaring may ilang resulta na nawawala."
+
+#: design/banner.html
+msgid "Appearance"
+msgstr "Hitsura"
+
+#: design/banner.html
+#, python-format
+msgid "Use %(appearance)s to control the frame. %(outlined)s (default) has a border and rounded corners. %(plain)s removes both — useful when the banner abuts the edges of other UI, like the top of the page or a card."
+msgstr "Gamitin ang %(appearance)s upang kontrolin ang frame. Ang %(outlined)s (default) ay may border at rounded corners. Inaalis ng %(plain)s ang dalawa — kapaki-pakinabang kapag ang banner ay katabi ng mga gilid ng iba pang UI, tulad ng tuktok ng pahina o card."
+
+#: design/banner.html
+msgid "Outlined (default): border and rounded corners."
+msgstr "Outlined (default): border at rounded corners."
+
+#: design/banner.html
+msgid "Plain: no border, no border radius."
+msgstr "Plain: walang border, walang border radius."
+
+#: design/banner.html
+msgid "Dismissible"
+msgstr "Maaaring isara"
+
+#: design/banner.html
+#, python-format
+msgid "Add %(dismissible)s for a close button. Without %(cookie_name)s, dismissal only lasts for the current page. Content comes from the page template, so links and emphasis work as usual."
+msgstr "Idagdag ang %(dismissible)s para sa close button. Kung walang %(cookie_name)s, ang dismissal ay para lamang sa kasalukuyang pahina. Ang nilalaman ay nagmumula sa page template, kaya gumagana ang mga link at pagbibigay-diin tulad ng karaniwan."
+
+#: design/banner.html
+#, fuzzy
+msgid "Explore our new collections"
+msgstr "Galugarin ang mga koleksyon"
+
+#: design/banner.html
+#, fuzzy
+msgid "Custom icon"
+msgstr "Pasadyang teksto ng button"
+
+#: design/banner.html
+#, python-format
+msgid "Slot a custom icon via %(slot)s to replace the variant's built-in glyph."
+msgstr "Mag-slot ng custom icon sa pamamagitan ng %(slot)s upang palitan ang built-in na glyph ng variant."
+
+#: design/banner.html
+#, fuzzy
+msgid "Set your Yearly Reading Goal"
+msgstr "Mag-set ng Taunang Layunin sa Pagbasa"
+
+#: design/banner.html
+msgid "Persisted dismissal"
+msgstr "Permanenteng dismissal"
+
+#: design/banner.html
+#, python-format
+msgid "The component owns no persistence — it only fires %(event)s with its %(dismiss_id)s. Two pieces of site plumbing make dismissals stick: the template guards rendering on the dismissal cookie (so dismissed banners are never served), and a site-level listener (%(glue)s) POSTs dismissals to %(endpoint)s, which sets that cookie. Per-banner TTL rides on the element as %(ttl)s — an OL convention, not component API. Dismiss this banner, reload, and it stays hidden until reset."
+msgstr "Ang komponent ay walang persistence — nagpapalabas lamang ito ng %(event)s kasama ang %(dismiss_id)s nito. Dalawang bahagi ng site infrastructure ang nagpapanatili ng mga dismissal: pinoprotektahan ng template ang rendering sa dismissal cookie (kaya hindi na ipinapadala ang mga na-dismiss na banner), at isang site-level listener (%(glue)s) ang nagpo-POST ng mga dismissal sa %(endpoint)s, na nagtatakda ng cookie na iyon. Ang bawat-banner na TTL ay nasa element bilang %(ttl)s — isang OL convention, hindi component API. I-dismiss ang banner na ito, i-reload, at mananatili itong nakatago hanggang ma-reset."
+
+#: design/banner.html
+#, fuzzy
+msgid "Set your 2026 Yearly Reading Goal"
+msgstr "Mag-set ng Taunang Layunin sa Pagbasa"
+
+#: design/banner.html
+msgid "Reset dismissed demo banner"
+msgstr "I-reset ang na-dismiss na demo banner"
+
+#: design/banner.html
+msgid "Dismiss event"
+msgstr "Kaganapan ng dismissal"
+
+#: design/banner.html
+#, python-format
+msgid "The banner fires %(event)s once when dismissed, before it is removed from the DOM. Banners without a %(dismiss_id)s are page-only: they still fire the event, but the site listener ignores them."
+msgstr "Nagpapalabas ang banner ng %(event)s nang isang beses kapag na-dismiss, bago ito alisin sa DOM. Ang mga banner na walang %(dismiss_id)s ay para sa pahina lamang: nagpapalabas pa rin sila ng kaganapan, ngunit binabalewala ng site listener."
+
+#: design/button.html merge/authors.html recentchanges/merge/view.html
+msgid "Primary"
+msgstr "Pangunahing"
+
+#: design/popover.html
+#, fuzzy
+msgid "Popover component"
+msgstr "Komponent"
+
+#: design/popover.html
+msgid "The ol-popover component provides a reusable animated popover panel anchored to a trigger element. It animates from the trigger using transform-origin, closes on Escape or outside click, and respects prefers-reduced-motion."
+msgstr "Ang ol-popover na komponent ay nagbibigay ng reusable na animated popover panel na nakaangkla sa isang trigger element. Nag-a-animate ito mula sa trigger gamit ang transform-origin, nagsasara sa Escape o panlabas na pag-click, at iginagalang ang prefers-reduced-motion."
+
+#: design/popover.html
+msgid "Menu popover"
+msgstr "Menu popover"
+
+#: design/popover.html
+msgid "Popovers animate from the trigger using transform-origin. Click the button to see the scale + fade entrance."
+msgstr "Ang mga popover ay nag-a-animate mula sa trigger gamit ang transform-origin. Mag-click sa button upang makita ang scale + fade entrance."
+
+#: design/popover.html
+#, fuzzy
+msgid "Options"
+msgstr "Mga Aksyon"
+
+#: design/popover.html
+#, fuzzy
+msgid "Duplicate"
+msgstr "Mga Duplicate"
+
+#: design/popover.html
+#, fuzzy
+msgid "Archive"
+msgstr "Marso"
+
+#: design/popover.html
+#, fuzzy
+msgid "Move"
+msgstr "Tanggalin"
+
+#: design/popover.html
+msgid "Placement options"
+msgstr "Mga opsyon sa placement"
+
+#: design/popover.html
+#, python-format
+msgid "Use %(placement)s to control where the popover appears. The %(transform_origin)s automatically matches so the animation always expands from the trigger."
+msgstr "Gamitin ang %(placement)s upang kontrolin kung saan lilitaw ang popover. Ang %(transform_origin)s ay awtomatikong tumutugma upang palaging lumalabas ang animation mula sa trigger."
+
+#: design/popover.html
+msgid "bottom-start"
+msgstr "bottom-start"
+
+#: design/popover.html
+#, fuzzy
+msgid "top-center"
+msgstr "Sentro ng Tulong"
+
+#: design/toast.html
+#, python-format
+msgid "The %(tag)s component is a transient notification message. It announces itself to screen readers, auto-dismisses after a timeout (pausing on hover/focus), and removes itself from the DOM when closed. Message content is set via the %(message)s and %(description)s attributes, already translated; rich content can be slotted instead. The component's only owned string is the close button label, overridable via %(attr)s."
+msgstr "Ang %(tag)s na komponent ay isang pansamantalang mensahe ng notipikasyon. Inihahayag nito ang sarili sa mga screen reader, awtomatikong nadi-dismiss pagkatapos ng timeout (ino-pause sa hover/focus), at inaalis ang sarili sa DOM kapag nasara. Ang nilalaman ng mensahe ay itinakda sa pamamagitan ng mga katangiang %(message)s at %(description)s, naisalin na; ang rich content ay maaaring i-slot sa halip. Ang tanging string na pag-aari ng komponent ay ang close button label, na maaaring palitan sa pamamagitan ng %(attr)s."
+
+#: design/toast.html
+#, fuzzy
+msgid "Types"
+msgstr "uri"
+
+#: design/toast.html
+#, python-format
+msgid "Use %(type)s for semantic variants. Errors are announced assertively (%(role)s)."
+msgstr "Gamitin ang %(type)s para sa mga semantic na variant. Ang mga error ay inihahayag nang assertive (%(role)s)."
+
+#: design/toast.html
+#, fuzzy
+msgid "Saved to your reading log"
+msgstr "Maghanap sa iyong reading log"
+
+#: design/toast.html
+msgid "Subjects successfully updated"
+msgstr "Matagumpay na na-update ang mga paksa"
+
+#: design/toast.html
+#, fuzzy
+msgid "Could not update list. Please try again later."
+msgstr "Nabigong i-update ang mga tagasunod. Mangyaring subukan muli sa ilang sandali."
+
+#: design/toast.html
+#, fuzzy
+msgid "Description and rich content"
+msgstr "Paglalarawan ng edisyong ito"
+
+#: design/toast.html
+#, python-format
+msgid "Use %(description)s for an optional secondary line. For uncommon rich content (links, custom markup), author the markup in an inert %(template)s element in the page template — where %(i18n)s extraction works — and pass that element to %(helper)s; its content is cloned into the toast. Node(s) built in JS also work. Nothing is ever parsed from a runtime string as HTML."
+msgstr "Gamitin ang %(description)s para sa opsyonal na pangalawang linya. Para sa hindi karaniwang rich content (mga link, custom markup), i-author ang markup sa isang inert na %(template)s element sa page template — kung saan gumagana ang %(i18n)s extraction — at ipasa ang element na iyon sa %(helper)s; ang nilalaman nito ay cloned sa toast. Gumagana rin ang Node(s) na ginawa sa JS. Walang kailanman na-parse mula sa runtime string bilang HTML."
+
+#: design/toast.html
+msgid "Relaunch to update"
+msgstr "I-relaunch upang mag-update"
+
+#: design/toast.html
+msgid "Could not save."
+msgstr "Hindi ma-save."
+
+#: design/toast.html
+#, fuzzy
+msgid "Get help"
+msgstr "Kailangan ba ng tulong?"
+
+#: design/toast.html
+msgid "Imperative use (fixed bottom-center stack)"
+msgstr "Imperative na paggamit (nakapirming stack sa ibabang gitna)"
+
+#: design/toast.html
+#, python-format
+msgid "JavaScript callers use the exported %(helper)s helper, which stacks toasts in a shared fixed %(region)s anchored to the bottom-center of the viewport. New toasts slide up from below; older ones slide up to make room, forming a simple vertical list. Toasts dismiss themselves after %(timeout)s milliseconds (default 4000) unless %(persistent)s. Hover or focus the list to pause every toast's dismiss timer. The message is set as an attribute — always text, never HTML — and should already be translated."
+msgstr "Gumagamit ang mga JavaScript caller ng naka-export na %(helper)s helper, na nagtatambak ng mga toast sa isang shared fixed %(region)s na nakaangkla sa ibabang gitna ng viewport. Ang mga bagong toast ay nagki-slide pataas mula sa ibaba; ang mga mas luma ay nagki-slide pataas upang gumawa ng lugar, na bumubuo ng simpleng vertical list. Ang mga toast ay nadi-dismiss ang sarili pagkatapos ng %(timeout)s millisecond (default 4000) maliban kung %(persistent)s. Mag-hover o i-focus ang listahan upang i-pause ang dismiss timer ng bawat toast. Ang mensahe ay itinakda bilang katangian — palaging teksto, hindi HTML — at dapat ay naisalin na."
+
+#: design/toast.html
+#, fuzzy
+msgid "Add toast"
+msgstr "Idagdag sa Listahan"
+
+#: design/toast.html
+msgid "Add persistent error toast"
+msgstr "Magdagdag ng persistent na error toast"
+
+#: design/toast.html
+msgid "Add rich content toast"
+msgstr "Magdagdag ng rich content toast"
+
+#: design/toast.html
+#, fuzzy
+msgid "Close event"
+msgstr "Nakasarang kahilingan"
+
+#: design/toast.html
+#, python-format
+msgid "The toast fires %(event)s once when it begins closing, with the reason in %(detail)s."
+msgstr "Nagpapalabas ang toast ng %(event)s nang isang beses kapag nagsimula itong magsara, na may dahilan sa %(detail)s."
+
 #: email/case_created.html
 msgid "Sent!"
 msgstr "Nai-send!"
@@ -6061,14 +4896,8 @@ msgid "Thank you for your note. We'll get back to you as soon as possible."
 msgstr "Salamat sa iyong tala. Babalik kami sa iyo sa lalong madaling panahon."
 
 #: email/case_created.html
-msgid ""
-"It might take us a little while to read it because we receive lots of "
-"messages, but rest assured we will, and we'll get back to you if "
-"required."
-msgstr ""
-"Maaaring tumagal kami ng kaunting oras upang basahin ito dahil tumatanggap kami "
-"ng maraming mensahe, ngunit asahan mong gagawin namin ito, at babalik kami "
-"sa iyo kung kinakailangan."
+msgid "It might take us a little while to read it because we receive lots of messages, but rest assured we will, and we'll get back to you if required."
+msgstr "Maaaring tumagal kami ng kaunting oras upang basahin ito dahil tumatanggap kami ng maraming mensahe, ngunit asahan mong gagawin namin ito, at babalik kami sa iyo kung kinakailangan."
 
 #: email/account/pd_request.html
 msgid "Qualifying for Print Disability Special Access"
@@ -6083,25 +4912,16 @@ msgid "About the Project"
 msgstr "Tungkol sa Proyekto"
 
 #: home/about.html
-msgid ""
-"Open Library is an open, editable library catalog, building towards a web"
-" page for every book ever published."
-msgstr ""
-"Ang Open Library ay isang bukas at maaring i-edit na katalogo ng aklatan, "
-"nais na magkaroon ng isang web page para sa bawat aklat na nailathala."
+msgid "Open Library is an open, editable library catalog, building towards a web page for every book ever published."
+msgstr "Ang Open Library ay isang bukas at maaring i-edit na katalogo ng aklatan, nais na magkaroon ng isang web page para sa bawat aklat na nailathala."
+
+#: AffiliateLinks.html home/about.html search/work_search_facets.html
+msgid "More"
+msgstr "Higit pa"
 
 #: home/about.html
-msgid ""
-"Just like Wikipedia, you can contribute new information or corrections to"
-" the catalog. You can browse by <a href=\"/subjects\">subjects</a>, <a "
-"href=\"/authors\">authors</a> or <a href=\"/lists\">lists</a> members "
-"have created. If you love books, why not help build a library?"
-msgstr ""
-"Tulad ng Wikipedia, maaari kang makapag-ambag ng bagong impormasyon o mga "
-"pagwawasto sa katalogo. Maaari kang mag-browse ayon sa <a href=\"/subjects\">mga "
-"paksa</a>, <a href=\"/authors\">mga may-akda</a> o <a href=\"/lists\">mga "
-"listahan</a> na nilikha ng mga miyembro. Kung mahilig ka sa mga aklat, "
-"Bakit hindi ka tumulong sa pagtatayo ng aklatan?"
+msgid "Just like Wikipedia, you can contribute new information or corrections to the catalog. You can browse by <a href=\"/subjects\">subjects</a>, <a href=\"/authors\">authors</a> or <a href=\"/lists\">lists</a> members have created. If you love books, why not help build a library?"
+msgstr "Tulad ng Wikipedia, maaari kang makapag-ambag ng bagong impormasyon o mga pagwawasto sa katalogo. Maaari kang mag-browse ayon sa <a href=\"/subjects\">mga paksa</a>, <a href=\"/authors\">mga may-akda</a> o <a href=\"/lists\">mga listahan</a> na nilikha ng mga miyembro. Kung mahilig ka sa mga aklat, Bakit hindi ka tumulong sa pagtatayo ng aklatan?"
 
 #: home/about.html
 msgid "Latest Blog Posts"
@@ -6122,45 +4942,61 @@ msgstr[1] "%(count)s Mga Aklat"
 msgid "Welcome to Open Library"
 msgstr "Maligayang pagdating sa Open Library"
 
+#: home/index.html openlibrary/plugins/openlibrary/api.py
+#, fuzzy
+msgid "Classic Books"
+msgstr "Klasikal na eBooks"
+
 #: home/index.html
 msgid "Recently Returned"
 msgstr "Kamakailan Lamang na Naibalik"
+
+#: home/index.html openlibrary/plugins/openlibrary/api.py openlibrary/plugins/openlibrary/home.py
+#, fuzzy
+msgid "Romance"
+msgstr "Rumen"
+
+#: home/index.html openlibrary/plugins/openlibrary/api.py
+#, fuzzy
+msgid "Kids"
+msgstr "Uri"
+
+#: home/index.html openlibrary/plugins/openlibrary/api.py
+#, fuzzy
+msgid "Thrillers"
+msgstr "Mga Manunulat"
+
+#: home/index.html openlibrary/plugins/openlibrary/api.py openlibrary/plugins/openlibrary/home.py
+#, fuzzy
+msgid "Textbooks"
+msgstr "Ebooks"
 
 #: home/index.html
 msgid "Authors Alliance & MIT Press"
 msgstr "Aliansa ng mga May-akda & MIT Press"
 
-#: home/loans.html
-#, python-format
-msgid ""
-"You can still <a href=\"/borrow\">borrow</a> one more book until you've "
-"hit the limit!"
-msgid_plural ""
-"You can still <a href=\"/borrow\">borrow</a> %(count)d more books until "
-"you've hit the limit!"
-msgstr[0] "Maaari ka pang <a href=\"/borrow\">humiram</a> ng isang aklat hanggang "
-"umabot ka sa limitasyon!"
-msgstr[1] "Maaari ka pang <a href=\"/borrow\">humiram</a> ng %(count)d higit pang "
-"mga aklat hanggang umabot ka sa limitasyon!"
+#: home/index.html
+msgid "Books in Local Environment"
+msgstr "Mga Aklat sa Local na Kapaligiran"
 
 #: home/loans.html
-msgid ""
-"You have reached the borrowing limit. Please return a book to checkout "
-"something new."
-msgstr "Naabot mo na ang limitasyon sa paghiram. Mangyaring ibalik ang isang "
-"aklat upang makapag-checkout ng bago."
+#, fuzzy, python-format
+msgid "You can still <a href=\"/subjects/in_library#ebooks=true\">borrow</a> one more book until you've hit the limit!"
+msgid_plural "You can still <a href=\"/subjects/in_library#ebooks=true\">borrow</a> %(count)d more books until you've hit the limit!"
+msgstr[0] "Maaari ka pang <a href=\"/borrow\">humiram</a> ng isang aklat hanggang umabot ka sa limitasyon!"
+msgstr[1] "Maaari ka pang <a href=\"/borrow\">humiram</a> ng %(count)d higit pang mga aklat hanggang umabot ka sa limitasyon!"
+
+#: home/loans.html
+msgid "You have reached the borrowing limit. Please return a book to checkout something new."
+msgstr "Naabot mo na ang limitasyon sa paghiram. Mangyaring ibalik ang isang aklat upang makapag-checkout ng bago."
 
 #: home/stats.html
 msgid "Around the Library"
 msgstr "Sa Paligid ng Aklatan"
 
 #: home/stats.html
-msgid ""
-"Here's what's happened over the last 28 days. More <a "
-"href=\"/recentchanges\">recent changes</a>"
-msgstr ""
-"Narito kung ano ang nangyari sa nakaraang 28 araw. Higit pang <a "
-"href=\"/recentchanges\">mga pagbabago</a>."
+msgid "Here's what's happened over the last 28 days. More <a href=\"/recentchanges\">recent changes</a>"
+msgstr "Narito kung ano ang nangyari sa nakaraang 28 araw. Higit pang <a href=\"/recentchanges\">mga pagbabago</a>."
 
 #: home/stats.html
 msgid "See all visitors to OpenLibrary.org"
@@ -6228,8 +5064,7 @@ msgstr "Mag-set ng Taunang Layunin sa Pagbasa"
 
 #: home/welcome.html
 msgid "Learn how to set a yearly reading goal and track what you read"
-msgstr "Alamin kung paano mag-set ng taunang layunin sa pagbasa at subaybayan ang "
-"iyong mga binasa"
+msgstr "Alamin kung paano mag-set ng taunang layunin sa pagbasa at subaybayan ang iyong mga binasa"
 
 #: home/welcome.html
 msgid "Keep Track of your Favorite Books"
@@ -6323,6 +5158,38 @@ msgstr "Ang dokumentong ito ay huling na-edit ni"
 msgid "This doc was last edited anonymously"
 msgstr "Ang dokumentong ito ay huling na-edit nang hindi nagpapakilala"
 
+#: lib/exports.html
+msgid "Download catalog record:"
+msgstr "I-download ang talaan ng katalogo:"
+
+#: lib/exports.html
+msgid "RDF"
+msgstr "RDF"
+
+#: lib/exports.html type/list/exports.html
+msgid "JSON"
+msgstr "JSON"
+
+#: lib/exports.html
+msgid "OPDS"
+msgstr "OPDS"
+
+#: lib/exports.html
+msgid "Cite this on Wikipedia"
+msgstr "I-cite ito sa Wikipedia"
+
+#: lib/exports.html
+msgid "Wikipedia citation"
+msgstr "Sipi ng Wikipedia"
+
+#: lib/exports.html
+msgid "Copy and paste this code into your Wikipedia page."
+msgstr "Kopyahin at i-paste ang code na ito sa iyong pahina ng Wikipedia."
+
+#: lib/exports.html
+msgid "Get instructions at Wikipedia in a new window"
+msgstr "Kumuha ng mga tagubilin sa Wikipedia sa bagong bintana"
+
 #: lib/header_dropdown.html
 msgid "My account"
 msgstr "Aking account"
@@ -6353,38 +5220,6 @@ msgstr[0] "%(count)d pagbabago"
 msgstr[1] "%(count)d mga pagbabago"
 
 #: lib/history.html
-msgid "Download catalog record:"
-msgstr "I-download ang talaan ng katalogo:"
-
-#: lib/history.html
-msgid "RDF"
-msgstr "RDF"
-
-#: lib/history.html type/list/exports.html
-msgid "JSON"
-msgstr "JSON"
-
-#: lib/history.html
-msgid "OPDS"
-msgstr "OPDS"
-
-#: lib/history.html
-msgid "Cite this on Wikipedia"
-msgstr "I-cite ito sa Wikipedia"
-
-#: lib/history.html
-msgid "Wikipedia citation"
-msgstr "Sipi ng Wikipedia"
-
-#: lib/history.html
-msgid "Copy and paste this code into your Wikipedia page."
-msgstr "Kopyahin at i-paste ang code na ito sa iyong pahina ng Wikipedia."
-
-#: lib/history.html
-msgid "Get instructions at Wikipedia in a new window"
-msgstr "Kumuha ng mga tagubilin sa Wikipedia sa bagong bintana"
-
-#: lib/history.html
 msgid "an anonymous user"
 msgstr "isang hindi nagpapakilalang gumagamit"
 
@@ -6407,14 +5242,8 @@ msgid " Your new record is in the library. Thank you!"
 msgstr " Ang iyong bagong tala ay nasa aklatan. Salamat!"
 
 #: lib/message_addbook.html
-msgid ""
-"There are a few other simple things you can add while you're here to "
-"improve your new record quickly, and make it much easier for other people"
-" to find later."
-msgstr ""
-"May ilang iba pang simpleng bagay na maaari mong idagdag habang narito ka "
-"upang mabilis na mapabuti ang iyong bagong tala, at gawing mas madali "
-"para sa ibang tao na mahanap ito sa hinaharap."
+msgid "There are a few other simple things you can add while you're here to improve your new record quickly, and make it much easier for other people to find later."
+msgstr "May ilang iba pang simpleng bagay na maaari mong idagdag habang narito ka upang mabilis na mapabuti ang iyong bagong tala, at gawing mas madali para sa ibang tao na mahanap ito sa hinaharap."
 
 #: lib/message_addbook.html
 msgid "Upload a cover image"
@@ -6447,6 +5276,10 @@ msgstr "Ilarawan kung tungkol saan ang aklat"
 #: lib/message_addbook.html
 msgid "Just a sentence or two is good."
 msgstr "Isang pangungusap o dalawa ay sapat na."
+
+#: lib/nav_foot.html openlibrary/plugins/openlibrary/api.py site/head.html
+msgid "Open Library"
+msgstr "Open Library"
 
 #: lib/nav_foot.html
 msgid "Vision"
@@ -6504,6 +5337,10 @@ msgstr "Galugarin ang mga may-akda"
 msgid "Explore subjects"
 msgstr "Galugarin ang mga paksa"
 
+#: RelatedSubjects.html SearchNavigation.html SubjectTags.html lib/nav_foot.html lib/nav_head.html openlibrary/plugins/worksearch/code.py subjects/notfound.html type/author/view.html type/list/view_body.html
+msgid "Subjects"
+msgstr "Mga Paksa"
+
 #: lib/nav_foot.html
 msgid "Explore collections"
 msgstr "Galugarin ang mga koleksyon"
@@ -6511,6 +5348,10 @@ msgstr "Galugarin ang mga koleksyon"
 #: lib/nav_foot.html lib/nav_head.html
 msgid "Collections"
 msgstr "Mga Koleksyon"
+
+#: SearchNavigation.html lib/nav_foot.html lib/nav_head.html search/advancedsearch.html
+msgid "Advanced Search"
+msgstr "Nabatid na Paghahanap"
 
 #: lib/nav_foot.html
 msgid "Navigate to top of this page"
@@ -6589,12 +5430,27 @@ msgid "Bluesky"
 msgstr "Bluesky"
 
 #: lib/nav_foot.html
+#, fuzzy
+msgid "Open Library on Bluesky"
+msgstr "Bahay ng Open Library"
+
+#: lib/nav_foot.html
 msgid "Twitter"
 msgstr "Twitter"
 
 #: lib/nav_foot.html
+#, fuzzy
+msgid "Open Library on Twitter"
+msgstr "Bahay ng Open Library"
+
+#: lib/nav_foot.html
 msgid "GitHub"
 msgstr "GitHub"
+
+#: lib/nav_foot.html
+#, fuzzy
+msgid "Open Library on GitHub"
+msgstr "Logo ng Open Library"
 
 #: lib/nav_foot.html site/alert.html
 msgid "Change Website Language"
@@ -6605,30 +5461,13 @@ msgid "Open Library logo"
 msgstr "Logo ng Open Library"
 
 #: lib/nav_foot.html
-msgid ""
-"Open Library is an initiative of the <a href=\"//archive.org/\">Internet "
-"Archive</a>, a 501(c)(3) non-profit, building a digital library of "
-"Internet sites and other cultural artifacts in  digital form. Other <a "
-"href=\"//archive.org/projects/\">projects</a> include the <a "
-"href=\"//archive.org/web/\">Wayback Machine</a>, <a "
-"href=\"//archive.org/\">archive.org</a> and <a href=\"//archive-it.org"
-"\">archive-it.org</a>"
-msgstr ""
-"Ang Open Library ay isang inisyatiba ng <a href=\"//archive.org/\">Internet "
-"Archive</a>, isang 501(c)(3) na non-profit, na nagtatayo ng digital na aklatan ng "
-"mga website ng Internet at iba pang mga kultural na artifact sa digital na anyo. "
-"Iba pang <a href=\"//archive.org/projects/\">mga proyekto</a> ay kinabibilangan ng "
-"<a href=\"//archive.org/web/\">Wayback Machine</a>, <a "
-"href=\"//archive.org/\">archive.org</a> at <a href=\"//archive-it.org\">archive-it.org</a>."
+msgid "Open Library is an initiative of the <a href=\"//archive.org/\">Internet Archive</a>, a 501(c)(3) non-profit, building a digital library of Internet sites and other cultural artifacts in  digital form. Other <a href=\"//archive.org/projects/\">projects</a> include the <a href=\"//archive.org/web/\">Wayback Machine</a>, <a href=\"//archive.org/\">archive.org</a> and <a href=\"//archive-it.org\">archive-it.org</a>"
+msgstr "Ang Open Library ay isang inisyatiba ng <a href=\"//archive.org/\">Internet Archive</a>, isang 501(c)(3) na non-profit, na nagtatayo ng digital na aklatan ng mga website ng Internet at iba pang mga kultural na artifact sa digital na anyo. Iba pang <a href=\"//archive.org/projects/\">mga proyekto</a> ay kinabibilangan ng <a href=\"//archive.org/web/\">Wayback Machine</a>, <a href=\"//archive.org/\">archive.org</a> at <a href=\"//archive-it.org\">archive-it.org</a>."
 
 #: lib/nav_foot.html
 #, python-format
-msgid ""
-"version <a "
-"href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</a>"
-msgstr ""
-"bersyon <a "
-"href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</a>"
+msgid "version <a href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</a>"
+msgstr "bersyon <a href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</a>"
 
 #: lib/nav_head.html
 msgid "Loans, Reading Log, Lists, Stats"
@@ -6678,6 +5517,10 @@ msgstr "Portal ng mga Librarian"
 msgid "My Open Library"
 msgstr "Aking Open Library"
 
+#: databarWork.html lib/nav_head.html
+msgid "Browse"
+msgstr "Mag-browse"
+
 #: lib/nav_head.html
 msgid "Contribute"
 msgstr "Mag-ambag"
@@ -6707,20 +5550,8 @@ msgid "Search by barcode"
 msgstr "Maghanap gamit ang barcode"
 
 #: lib/not_logged.html
-msgid ""
-"<strong>You are not <a href=\"/account/login\" title=\"Log in "
-"now\">logged in</a>.</strong> Open Library will record your IP address "
-"and include it in this page's publicly accessible edit history. If you <a"
-" href=\"/account/create\" title=\"Create an Open Library account\">create"
-" an account</a>, your IP address is concealed and you can more easily "
-"keep track of all your edits and additions."
-msgstr ""
-"<strong>Hindi ka <a href=\"/account/login\" title=\"Mag-login "
-"ngayon\">nakalogin</a>.</strong> Ire-record ng Open Library ang iyong IP address "
-"at isasama ito sa pampublikong kasaysayan ng pag-edit ng pahinang ito. Kung <a"
-" href=\"/account/create\" title=\"Lumikha ng isang Open Library account\">lumikha ka"
-" ng account</a>, nakatago ang iyong IP address at mas madali mong "
-"masusubaybayan ang lahat ng iyong pag-edit at mga karagdagan."
+msgid "<strong>You are not <a href=\"/account/login\" title=\"Log in now\">logged in</a>.</strong> Open Library will record your IP address and include it in this page's publicly accessible edit history. If you <a href=\"/account/create\" title=\"Create an Open Library account\">create an account</a>, your IP address is concealed and you can more easily keep track of all your edits and additions."
+msgstr "<strong>Hindi ka <a href=\"/account/login\" title=\"Mag-login ngayon\">nakalogin</a>.</strong> Ire-record ng Open Library ang iyong IP address at isasama ito sa pampublikong kasaysayan ng pag-edit ng pahinang ito. Kung <a href=\"/account/create\" title=\"Lumikha ng isang Open Library account\">lumikha ka ng account</a>, nakatago ang iyong IP address at mas madali mong masusubaybayan ang lahat ng iyong pag-edit at mga karagdagan."
 
 #: librarian_dashboard/data_quality_table.html
 msgid "Reload"
@@ -6776,8 +5607,8 @@ msgstr[0] "Nasa <strong>1 listahan</strong> ang may-akdang ito."
 msgstr[1] "Nasa <strong>%(count)s listahan</strong> ang may-akdang ito."
 
 #: lists/header.html
-#, python-format
-msgid "This edition is on <strong>1 list</strong>."
+#, fuzzy, python-format
+msgid "This is edition is on <strong>1 list</strong>."
 msgid_plural "This edition is on <strong>%(count)s lists</strong>."
 msgstr[0] "Nasa <strong>1 listahan</strong> ang edisyong ito."
 msgstr[1] "Nasa <strong>%(count)s listahan</strong> ang edisyong ito."
@@ -6812,25 +5643,13 @@ msgid "Create a list of any Subjects, Authors, Works or specific Editions."
 msgstr "Lumikha ng listahan ng anumang Mga Paksa, May-akda, Gawa o partikular na Edisyon."
 
 #: lists/home.html
-msgid ""
-"Once you've made a list, you can <strong>watch for updates</strong> or "
-"<strong>export</strong> all the editions in a list as HTML, BibTeX or "
-"JSON. See all your lists and any activity using the \"Lists\" link on "
-"your Account page."
-msgstr ""
-"Kapag nakagawa ka na ng listahan, maaari mong <strong>bantayan ang mga update</strong> o "
-"<strong>i-export</strong> ang lahat ng mga edisyon sa isang listahan bilang HTML, BibTeX o "
-"JSON. Tingnan ang lahat ng iyong mga listahan at anumang aktibidad gamit ang \"Lists\" na link sa "
-"iyong Pahina ng Account."
+msgid "Once you've made a list, you can <strong>watch for updates</strong> or <strong>export</strong> all the editions in a list as HTML, BibTeX or JSON. See all your lists and any activity using the \"Lists\" link on your Account page."
+msgstr "Kapag nakagawa ka na ng listahan, maaari mong <strong>bantayan ang mga update</strong> o <strong>i-export</strong> ang lahat ng mga edisyon sa isang listahan bilang HTML, BibTeX o JSON. Tingnan ang lahat ng iyong mga listahan at anumang aktibidad gamit ang \"Lists\" na link sa iyong Pahina ng Account."
 
 #: lists/home.html
 #, python-format
-msgid ""
-"For the top 2000+ most requested eBooks in California for the print "
-"disabled <a href=\"%(url)s\">click here</a>."
-msgstr ""
-"Para sa nangungunang 2000+ pinaka hinihinging eBooks sa California para sa mga may print "
-"disability <a href=\"%(url)s\">mag-click dito</a>."
+msgid "For the top 2000+ most requested eBooks in California for the print disabled <a href=\"%(url)s\">click here</a>."
+msgstr "Para sa nangungunang 2000+ pinaka hinihinging eBooks sa California para sa mga may print disability <a href=\"%(url)s\">mag-click dito</a>."
 
 #: lists/home.html
 msgid "Find a list by name"
@@ -6845,8 +5664,7 @@ msgstr "Aktibong Mga Listahan"
 msgid "from <a href=\"%(key)s\">%(owner)s</a>"
 msgstr "mula sa <a href=\"%(key)s\">%(owner)s</a>"
 
-#: lists/home.html lists/preview.html lists/snippet.html type/list/embed.html
-#: type/list/view_body.html
+#: lists/home.html lists/preview.html lists/snippet.html type/list/embed.html type/list/view_body.html
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
@@ -6861,6 +5679,10 @@ msgstr "Huling binago %(date)s"
 #: lists/home.html lists/snippet.html
 msgid "No description."
 msgstr "Walang paglalarawan."
+
+#: RecentChangesUsers.html lists/home.html lists/lists.html type/user/view.html
+msgid "Recent Activity"
+msgstr "Kam recent na Gawain"
 
 #: lists/list_follow.html
 msgid "Cover of book"
@@ -6881,6 +5703,10 @@ msgstr "Hindi pinagana ng patron na ito ang pag-sunod"
 #: lists/list_follow.html
 msgid "🔒︎"
 msgstr "🔒︎"
+
+#: Follow.html lists/list_follow.html
+msgid "Follow"
+msgstr "Sundan"
 
 #: lists/list_follow.html
 msgid "OpenLibrary Logo"
@@ -6936,10 +5762,6 @@ msgstr "Sigurado ka bang nais mong tanggalin ang listahang ito?"
 #: lists/lists.html
 msgid "Remove this seed?"
 msgstr "Tanggalin ang buto na ito?"
-
-#: lists/lists.html type/list/edit.html type/series/edit.html
-msgid "Remove"
-msgstr "Tanggalin"
 
 #: lists/lists.html
 #, python-format
@@ -7023,10 +5845,6 @@ msgstr "Mangyaring Mag-ingat..."
 #: merge/authors.html
 msgid "<b>Are you sure</b> you want to merge these records?"
 msgstr "<b>Sigurado ka bang</b> nais mong pagsamahin ang mga talaing ito?"
-
-#: merge/authors.html recentchanges/merge/view.html
-msgid "Primary"
-msgstr "Pangunahing"
 
 #: merge/authors.html
 msgid "Merge"
@@ -7117,6 +5935,14 @@ msgstr "Katayuan ▾"
 msgid "Request Status"
 msgstr "Katayuan ng Kahilingan"
 
+#: merge_request_table/table_header.html openlibrary/core/edits.py
+msgid "Merged"
+msgstr "Pinagsama"
+
+#: merge_request_table/table_header.html openlibrary/core/edits.py
+msgid "Declined"
+msgstr "Tinanggihan"
+
 #: merge_request_table/table_header.html
 msgid "Submitter ▾"
 msgstr "Nagsumite ▾"
@@ -7191,12 +6017,8 @@ msgstr "Tumugon"
 
 #: merge_request_table/table_row.html
 #, python-format
-msgid ""
-"MR #%(id)s opened %(date)s by <a href=\"/people/%(submitter)s\" "
-"class=\"commenter\">@%(submitter)s</a>"
-msgstr ""
-"MR #%(id)s binuksan %(date)s ni <a href=\"/people/%(submitter)s\" "
-"class=\"commenter\">@%(submitter)s</a>"
+msgid "MR #%(id)s opened %(date)s by <a href=\"/people/%(submitter)s\" class=\"commenter\">@%(submitter)s</a>"
+msgstr "MR #%(id)s binuksan %(date)s ni <a href=\"/people/%(submitter)s\" class=\"commenter\">@%(submitter)s</a>"
 
 #: merge_request_table/table_row.html
 msgid "Click to close this Merge Request"
@@ -7225,6 +6047,27 @@ msgstr "Naglo-load"
 #: my_books/dropdown_content.html
 msgid "Use this Work"
 msgstr "Gamitin ang Trabahong Ito"
+
+#: CreateListModal.html my_books/dropdown_content.html
+msgid "Create a new list"
+msgstr "Lumikha ng bagong listahan"
+
+#: CreateListModal.html my_books/dropdown_content.html type/permission/edit.html type/usergroup/edit.html
+msgid "Description:"
+msgstr "Paglalarawan:"
+
+#: CreateListModal.html my_books/dropdown_content.html type/list/edit.html type/series/edit.html
+msgid "Create new list"
+msgstr "Lumikha ng bagong listahan"
+
+#: my_books/dropdown_content.html
+#, fuzzy
+msgid "saving..."
+msgstr "Naglo-load..."
+
+#: my_books/dropdown_content.html
+msgid "Removing this book from your shelves will delete your check-ins for this work.  Continue?"
+msgstr "Ang pag-alis ng aklat na ito mula sa iyong mga istante ay magtatanggal ng iyong mga check-in para sa gawaing ito. Magpatuloy?"
 
 #: my_books/primary_action.html
 msgid "Add to List"
@@ -7279,12 +6122,8 @@ msgid "December"
 msgstr "Disyembre"
 
 #: my_books/check_ins/check_in_form.html
-msgid ""
-"Add an optional check-in date. Check-in dates are used to track yearly "
-"reading goals."
-msgstr ""
-"Magdagdag ng opsyonal na petsa ng check-in. Ang mga petsa ng check-in ay "
-"ginagamit upang subaybayan ang taunang mga layunin sa pagbabasa."
+msgid "Add an optional check-in date. Check-in dates are used to track yearly reading goals."
+msgstr "Magdagdag ng opsyonal na petsa ng check-in. Ang mga petsa ng check-in ay ginagamit upang subaybayan ang taunang mga layunin sa pagbabasa."
 
 #: my_books/check_ins/check_in_form.html
 msgid "End Date:"
@@ -7317,6 +6156,16 @@ msgstr "Araw"
 #: my_books/check_ins/check_in_form.html
 msgid "Delete Event"
 msgstr "Tanggalin ang Kaganapan"
+
+#: my_books/check_ins/check_in_prompt.html
+#, fuzzy
+msgid "Failed to delete check-in. Please try again in a few moments."
+msgstr "Nabigong isumite ang komento. Mangyaring subukan muli sa loob ng ilang sandali."
+
+#: my_books/check_ins/check_in_prompt.html
+#, fuzzy
+msgid "Failed to submit check-in. Please try again in a few moments."
+msgstr "Nabigong isumite ang komento. Mangyaring subukan muli sa loob ng ilang sandali."
 
 #: my_books/check_ins/check_in_prompt.html
 #, python-format
@@ -7377,7 +6226,11 @@ msgstr "Subukan ang iba pa?"
 msgid "Publisher: %(name)s"
 msgstr "Publisher: %(name)s"
 
-#: publishers/view.html
+#: openlibrary/plugins/worksearch/code.py publishers/view.html search/advancedsearch.html type/edition/view.html type/work/view.html
+msgid "Publisher"
+msgstr "Publisher"
+
+#: SearchResultsWork.html publishers/view.html
 #, python-format
 msgid "%(count)s ebook"
 msgid_plural "%(count)s ebooks"
@@ -7388,23 +6241,33 @@ msgstr[1] "%(count)s ebooks"
 msgid "0 ebooks"
 msgstr "0 ebooks"
 
-#: publishers/view.html
-msgid ""
-"This is a chart to show the when this publisher published books. Along "
-"the X axis is time, and on the y axis is the count of editions published."
-" <a href=\"#subjectRelated\">Click here to skip the chart</a>."
-msgstr ""
-"Ito ay isang tsart upang ipakita kung kailan naglathala ang publisher na ito ng mga aklat. "
-"Sa X axis ay ang oras, at sa Y axis ay ang bilang ng mga inilathalang edisyon. "
-"<a href=\"#subjectRelated\">I-click dito upang laktawan ang tsart</a>."
+#: PublishingHistory.html publishers/view.html
+msgid "Publishing History"
+msgstr "Kasaysayan ng Paglilimbag"
 
 #: publishers/view.html
-msgid ""
-"This graph charts editions from this publisher over time. Click to view a"
-" single year, or drag across a range."
-msgstr ""
-"Ang graph na ito ay naglalarawan ng mga edisyon mula sa publisher na ito sa paglipas ng panahon. "
-"I-click upang tingnan ang isang solong taon, o i-drag sa isang saklaw."
+msgid "This is a chart to show the when this publisher published books. Along the X axis is time, and on the y axis is the count of editions published. <a href=\"#subjectRelated\">Click here to skip the chart</a>."
+msgstr "Ito ay isang tsart upang ipakita kung kailan naglathala ang publisher na ito ng mga aklat. Sa X axis ay ang oras, at sa Y axis ay ang bilang ng mga inilathalang edisyon. <a href=\"#subjectRelated\">I-click dito upang laktawan ang tsart</a>."
+
+#: PublishingHistory.html publishers/view.html
+msgid "Reset chart"
+msgstr "I-reset ang tsart"
+
+#: PublishingHistory.html publishers/view.html
+msgid "or continue zooming in."
+msgstr "o magpatuloy sa pag-zoom in."
+
+#: publishers/view.html
+msgid "This graph charts editions from this publisher over time. Click to view a single year, or drag across a range."
+msgstr "Ang graph na ito ay naglalarawan ng mga edisyon mula sa publisher na ito sa paglipas ng panahon. I-click upang tingnan ang isang solong taon, o i-drag sa isang saklaw."
+
+#: PublishingHistory.html publishers/view.html
+msgid "Editions Published"
+msgstr "Mga Nailimbag na Edisyon"
+
+#: PublishingHistory.html publishers/view.html
+msgid "Year of Publication"
+msgstr "Taon ng Paglilimbag"
 
 #: publishers/view.html
 msgid "Common Subjects"
@@ -7414,6 +6277,14 @@ msgstr "Mga Karaniwang Paksa"
 #, python-format
 msgid "Search for books published by %(publisher)s"
 msgstr "Maghanap ng mga aklat na inilathala ng %(publisher)s"
+
+#: RelatedSubjects.html publishers/view.html
+msgid "None found."
+msgstr "Walang natagpuan."
+
+#: ProlificAuthors.html publishers/view.html
+msgid "See more books by, and learn about, this author"
+msgstr "Tingnan ang higit pang mga aklat mula sa may-akdang ito at alamin ang tungkol sa kanya"
 
 #: publishers/view.html
 msgid "published most by this publisher"
@@ -7433,14 +6304,8 @@ msgstr "Pumasok ng \"0\" upang alisin ang iyong layunin sa pagbabasa. Ang iyong 
 
 #: reading_goals/reading_goal_progress.html
 #, python-format
-msgid ""
-"<span class=\"reading-goal-progress__books-"
-"read\">%(books_read)d</span>/<span class=\"reading-goal-"
-"progress__goal\">%(goal)d</span> Books"
-msgstr ""
-"<span class=\"reading-goal-progress__books-"
-"read\">%(books_read)d</span>/<span class=\"reading-goal-"
-"progress__goal\">%(goal)d</span> Mga Aklat"
+msgid "<span class=\"reading-goal-progress__books-read\">%(books_read)d</span>/<span class=\"reading-goal-progress__goal\">%(goal)d</span> Books"
+msgstr "<span class=\"reading-goal-progress__books-read\">%(books_read)d</span>/<span class=\"reading-goal-progress__goal\">%(goal)d</span> Mga Aklat"
 
 #: reading_goals/reading_goal_progress.html
 #, python-format
@@ -7475,16 +6340,35 @@ msgstr "Pagsasama-sama ng Trabaho"
 msgid "Books Added"
 msgstr "Mga Akdang Idinagdag"
 
+#: RecentChanges.html recentchanges/index.html
+msgid "By Humans"
+msgstr "Ng mga Tao"
+
+#: RecentChanges.html recentchanges/index.html
+msgid "By Bots"
+msgstr "Ng mga Bot"
+
 #: recentchanges/render.html
 msgid "Admin view"
 msgstr "Pananaw ng Admin"
+
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html recentchanges/render.html
+msgid "Older"
+msgstr "Mas Matanda"
+
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html recentchanges/render.html
+msgid "Newer"
+msgstr "Mas Bago"
 
 #: recentchanges/updated_records.html
 msgid "Review what's changed in from the previous revision"
 msgstr "Suriin kung ano ang nagbago mula sa nakaraang bersyon"
 
-#: recentchanges/add-book/path.html recentchanges/default/path.html
-#: recentchanges/edit-book/path.html recentchanges/merge/path.html
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html recentchanges/default/path.html recentchanges/updated_records.html
+msgid "diff"
+msgstr "pagkakaiba"
+
+#: recentchanges/add-book/path.html recentchanges/default/path.html recentchanges/edit-book/path.html recentchanges/merge/path.html
 msgid "expand"
 msgstr "palawakin"
 
@@ -7492,8 +6376,11 @@ msgstr "palawakin"
 msgid "opened a new Open Library account!"
 msgstr "nagbukas ng bagong account sa Open Library!"
 
-#: recentchanges/default/view.html recentchanges/merge/view.html
-#: recentchanges/undo/view.html
+#: RecentChanges.html RecentChangesUsers.html recentchanges/default/path.html
+msgid "Review what's changed from the previous revision"
+msgstr "Suriin kung ano ang nabago mula sa nakaraang bersyon"
+
+#: recentchanges/default/view.html recentchanges/merge/view.html recentchanges/undo/view.html
 msgid "Updated Records"
 msgstr "Na-update na mga Tala"
 
@@ -7612,6 +6499,10 @@ msgstr "Walang <strong>mga may-akda</strong> na tumugma sa iyong paghahanap"
 msgid "Search Open Library for %s"
 msgstr "Maghanap sa Open Library para sa %s"
 
+#: BookSearchInside.html FulltextSearchSuggestion.html SearchNavigation.html search/inside.html search/snippets.html
+msgid "Search Inside"
+msgstr "Maghanap Sa Loob"
+
 #: search/inside.html
 msgid "No <strong>Search Inside</strong> text matched your search"
 msgstr "Walang <strong>Search Inside</strong> na teksto na tumugma sa iyong paghahanap"
@@ -7629,6 +6520,10 @@ msgid "in %(seconds)s second"
 msgid_plural "in %(seconds)s seconds"
 msgstr[0] "sa %(seconds)s segundo"
 msgstr[1] "sa %(seconds)s mga segundo"
+
+#: EditionNavBar.html search/layout_options.html site/stats.html
+msgid "Details"
+msgstr "Detalye"
 
 #: search/layout_options.html
 msgid "Grid"
@@ -7784,11 +6679,8 @@ msgid "Merge duplicates"
 msgstr "Pagsamahin ang mga duplicate"
 
 #: search/work_search_facets.html
-msgid "more"
-msgstr "more"
-
-#: search/work_search_facets.html
-msgid "less"
+#, fuzzy
+msgid "Less"
 msgstr "less"
 
 #: search/work_search_facets.html
@@ -7817,31 +6709,6 @@ msgid "Focus your results using these <a href=\"/search/howto\">filters</a>"
 msgstr "Tumuon sa iyong mga resulta gamit ang mga <a href=\"/search/howto\">filter</a> na ito"
 
 #: search/work_search_selected_facets.html
-msgid "eBook"
-msgstr "eBook"
-
-#: search/work_search_selected_facets.html
-msgid "Classic eBook"
-msgstr "Klasikong eBook"
-
-#: search/work_search_selected_facets.html
-msgid "Search facets"
-msgstr "Mga facet ng paghahanap"
-
-#: search/work_search_selected_facets.html
-msgid "Explore Classic eBooks"
-msgstr "Galugarin ang mga Klasikong eBook"
-
-#: search/work_search_selected_facets.html
-msgid "Only Classic eBooks"
-msgstr "Tanging mga Klasikong eBook"
-
-#: search/work_search_selected_facets.html
-#, python-format
-msgid "Explore books about %(subject)s"
-msgstr "Galugarin ang mga libro tungkol sa %(subject)s"
-
-#: search/work_search_selected_facets.html
 msgid "Written in"
 msgstr "Nakasulat sa"
 
@@ -7850,8 +6717,21 @@ msgid "Published by"
 msgstr "Inilathala ng"
 
 #: search/work_search_selected_facets.html
-msgid "Click to remove this facet"
-msgstr "I-click upang alisin ang facet na ito"
+msgid "eBook"
+msgstr "eBook"
+
+#: search/work_search_selected_facets.html
+msgid "Classic eBook"
+msgstr "Klasikong eBook"
+
+#: search/work_search_selected_facets.html
+msgid "Only Classic eBooks"
+msgstr "Tanging mga Klasikong eBook"
+
+#: search/work_search_selected_facets.html
+#, fuzzy
+msgid "Classic eBooks hidden"
+msgstr "Klasikal na eBooks"
 
 #: search/work_search_selected_facets.html
 #, python-format
@@ -7866,15 +6746,9 @@ msgstr "Logo ng Internet Archive"
 msgid "It looks like you're offline."
 msgstr "Mukhang ikaw ay offline."
 
-#: site/neck.html
-msgid ""
-"Open Library is an open, editable library catalog, building towards a web"
-" page for every book ever published. Read, borrow, and discover more than"
-" 3M books for free."
-msgstr ""
-"Ang Open Library ay isang bukas, na-edit na katalogo ng aklatan, bumubuo patungo sa isang web"
-" pahina para sa bawat aklat na nailathala. Magbasa, manghiram, at matuklasan ang higit sa"
-" 3M aklat nang libre."
+#: site/head.html
+msgid "Open Library is an open, editable library catalog, building towards a web page for every book ever published. Read, borrow, and discover more than 3M books for free."
+msgstr "Ang Open Library ay isang bukas, na-edit na katalogo ng aklatan, bumubuo patungo sa isang web pahina para sa bawat aklat na nailathala. Magbasa, manghiram, at matuklasan ang higit sa 3M aklat nang libre."
 
 #: site/stats.html
 msgid "Debug Stats"
@@ -7901,12 +6775,8 @@ msgid "# Unique Users Logging Books"
 msgstr "# Natatanging Mga Gumagamit na Nagtatala ng mga Aklat"
 
 #: stats/readinglog.html
-msgid ""
-"The total number of unique users who have logged at least one book using "
-"the Reading Log feature"
-msgstr ""
-"Ang kabuuang bilang ng mga natatanging gumagamit na nagtala ng hindi bababa sa isang aklat gamit ang "
-"tampok na Log ng Pagbasa"
+msgid "The total number of unique users who have logged at least one book using the Reading Log feature"
+msgstr "Ang kabuuang bilang ng mga natatanging gumagamit na nagtala ng hindi bababa sa isang aklat gamit ang tampok na Log ng Pagbasa"
 
 #: stats/readinglog.html
 msgid "# Books Starred"
@@ -7959,18 +6829,14 @@ msgstr "Hindi namin mahanap ang anumang aklat tungkol sa"
 msgid "OpenAPI"
 msgstr "OpenAPI"
 
-#: type/about/edit.html type/page/edit.html type/permission/edit.html
-#: type/template/edit.html type/usergroup/edit.html
+#: type/about/edit.html type/page/edit.html type/permission/edit.html type/template/edit.html type/usergroup/edit.html
 #, python-format
 msgid "Edit %(title)s"
 msgstr "I-edit ang %(title)s"
 
 #: type/about/edit.html
-msgid ""
-"This only appears in the document head, and gets attached to bookmark "
-"labels"
-msgstr ""
-"Ito ay lumalabas lamang sa ulo ng dokumento, at nakakabit sa mga label ng bookmark"
+msgid "This only appears in the document head, and gets attached to bookmark labels"
+msgstr "Ito ay lumalabas lamang sa ulo ng dokumento, at nakakabit sa mga label ng bookmark"
 
 #: type/about/edit.html
 msgid "Intro"
@@ -8001,24 +6867,16 @@ msgid "Edit Author"
 msgstr "I-edit ang May-akda"
 
 #: type/author/edit.html
-msgid ""
-"Please use natural order. For example: <strong>Leo Tolstoy</strong> not "
-"<strong>Tolstoy, Leo</strong>."
-msgstr ""
-"Pakisunod ang natural na ayos. Halimbawa: <strong>Leo Tolstoy</strong> hindi "
-"<strong>Tolstoy, Leo</strong>."
+msgid "Please use natural order. For example: <strong>Leo Tolstoy</strong> not <strong>Tolstoy, Leo</strong>."
+msgstr "Pakisunod ang natural na ayos. Halimbawa: <strong>Leo Tolstoy</strong> hindi <strong>Tolstoy, Leo</strong>."
 
 #: type/author/edit.html
 msgid "A short bio?"
 msgstr "Isang maikling talambuhay?"
 
 #: type/author/edit.html
-msgid ""
-"If you \"borrow\" information from somewhere, please make sure to cite "
-"the source."
-msgstr ""
-"Kung ikaw ay \"humiram\" ng impormasyon mula sa kahit saan, pakisiguradong banggitin ang "
-"pinagmulan."
+msgid "If you \"borrow\" information from somewhere, please make sure to cite the source."
+msgstr "Kung ikaw ay \"humiram\" ng impormasyon mula sa kahit saan, pakisiguradong banggitin ang pinagmulan."
 
 #: type/author/edit.html
 msgid "Date of birth"
@@ -8029,33 +6887,20 @@ msgid "Date of death"
 msgstr "Petsa ng kamatayan"
 
 #: type/author/edit.html
-msgid ""
-"We're not storing structured dates (yet) so a date like \"21 May 2000\" "
-"is recommended."
-msgstr ""
-"Hindi pa namin iniimbak ang mga nakabalangkas na petsa (sana) kaya ang isang petsa gaya ng \"21 Mayo 2000\" "
-"ay inirerekomenda."
+msgid "We're not storing structured dates (yet) so a date like \"21 May 2000\" is recommended."
+msgstr "Hindi pa namin iniimbak ang mga nakabalangkas na petsa (sana) kaya ang isang petsa gaya ng \"21 Mayo 2000\" ay inirerekomenda."
 
 #: type/author/edit.html
-msgid ""
-"This is a deprecated field. You can help improve this record by removing "
-"this date and populating the \"Date of birth\" and \"Date of death\" "
-"fields. Thanks!"
-msgstr ""
-"Ito ay isang deprecated na field. Maaari mong tulungan ang pagpapabuti ng rekord na ito sa pamamagitan ng pag-alis "
-"ng petsang ito at pagpopuno ng mga field na \"Petsa ng kapanganakan\" at \"Petsa ng kamatayan\". Salamat!"
+msgid "This is a deprecated field. You can help improve this record by removing this date and populating the \"Date of birth\" and \"Date of death\" fields. Thanks!"
+msgstr "Ito ay isang deprecated na field. Maaari mong tulungan ang pagpapabuti ng rekord na ito sa pamamagitan ng pag-alis ng petsang ito at pagpopuno ng mga field na \"Petsa ng kapanganakan\" at \"Petsa ng kamatayan\". Salamat!"
 
 #: type/author/edit.html
 msgid "Does this author go by any other names?"
 msgstr "May ibang pangalan ba ang may-akdang ito?"
 
 #: type/author/edit.html
-msgid ""
-"For example: Lev Nikolayevich Tolstoy was also known as Leo Tolstoy. "
-"Please list one name per line."
-msgstr ""
-"Halimbawa: Si Lev Nikolayevich Tolstoy ay kilala rin bilang Leo Tolstoy. "
-"Pakisulat ang isang pangalan sa bawat linya."
+msgid "For example: Lev Nikolayevich Tolstoy was also known as Leo Tolstoy. Please list one name per line."
+msgstr "Halimbawa: Si Lev Nikolayevich Tolstoy ay kilala rin bilang Leo Tolstoy. Pakisulat ang isang pangalan sa bawat linya."
 
 #: type/author/edit.html
 msgid "Identifiers"
@@ -8088,12 +6933,8 @@ msgid "Refresh the page?"
 msgstr "I-refresh ang pahina?"
 
 #: type/author/view.html
-msgid ""
-"OK. The merge is in motion. <i>It will take <u>a few minutes to "
-"finish</u> the update.</i>"
-msgstr ""
-"OK. Ang pagsasama ay nasa proseso. <i>Ito ay aabot ng <u>ilang minuto upang "
-"taposin</u> ang update.</i>"
+msgid "OK. The merge is in motion. <i>It will take <u>a few minutes to finish</u> the update.</i>"
+msgstr "OK. Ang pagsasama ay nasa proseso. <i>Ito ay aabot ng <u>ilang minuto upang taposin</u> ang update.</i>"
 
 #: type/author/view.html
 msgid "Argh!"
@@ -8116,6 +6957,14 @@ msgstr "Maghanap ng mga libro ni %(author)s"
 #, python-format
 msgid "— Show <a href=\"%(url)s\">everything</a> by this author?"
 msgstr "— Ipakita ang <a href=\"%(url)s\">lahat</a> ng gawa ng may-akdang ito?"
+
+#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py type/author/view.html type/list/view_body.html
+msgid "Places"
+msgstr "Mga Lugar"
+
+#: Profile.html type/author/view.html
+msgid "Time"
+msgstr "Oras"
 
 #: type/author/view.html
 msgid "OLID"
@@ -8177,9 +7026,27 @@ msgstr "I-sync ang Archive.org ID"
 msgid "View Book on Archive.org"
 msgstr "Tingnan ang Aklat sa Archive.org"
 
+#: SearchResultsWork.html type/edition/admin_bar.html
+msgid "Orphaned Edition"
+msgstr "Orpanadong Edisyon"
+
+#: databarHistory.html databarView.html type/edition/compact_title.html
+msgid "Edit this page"
+msgstr "I-edit ang pahinang ito"
+
 #: type/edition/modal_links.html
 msgid "Review"
 msgstr "Pagsusuri"
+
+#: type/edition/modal_links.html
+#, fuzzy
+msgid "reviewing"
+msgstr "Pagsusuri"
+
+#: type/edition/modal_links.html
+#, fuzzy
+msgid "adding notes to"
+msgstr "Magdagdag ng isa pang may-akda?"
 
 #: type/edition/title_and_author.html
 msgid "An edition of"
@@ -8196,30 +7063,18 @@ msgid "Book %s"
 msgstr "Aklat %s"
 
 #: type/edition/view.html type/work/view.html
-msgid "Read More"
-msgstr "Magbasa ng Higit Pa"
-
-#: type/edition/view.html type/work/view.html
 msgid "Read Less"
 msgstr "Magbasa ng Mas Kaunti"
 
 #: type/edition/view.html type/work/view.html
 #, python-format
-msgid ""
-"This work doesn't have a description yet. Can you <b><a "
-"href='%(url)s'>add one</a></b>?"
-msgstr ""
-"Walang deskripsyon ang gawaing ito. Maaari mo bang <b><a "
-"href='%(url)s'>magdagdag ng isa</a></b>?"
+msgid "This work doesn't have a description yet. Can you <b><a href='%(url)s'>add one</a></b>?"
+msgstr "Walang deskripsyon ang gawaing ito. Maaari mo bang <b><a href='%(url)s'>magdagdag ng isa</a></b>?"
 
 #: type/edition/view.html type/work/view.html
 #, python-format
-msgid ""
-"This edition doesn't have a description yet. Can you <b><a "
-"href='%(url)s'>add one</a></b>?"
-msgstr ""
-"Walang deskripsyon ang edisyong ito. Maaari mo bang <b><a "
-"href='%(url)s'>magdagdag ng isa</a></b>?"
+msgid "This edition doesn't have a description yet. Can you <b><a href='%(url)s'>add one</a></b>?"
+msgstr "Walang deskripsyon ang edisyong ito. Maaari mo bang <b><a href='%(url)s'>magdagdag ng isa</a></b>?"
 
 #: type/edition/view.html type/work/view.html
 msgid "Publish Date"
@@ -8235,6 +7090,10 @@ msgstr "Ipakita ang iba pang mga aklat mula kay %(publisher)s"
 msgid "Search for other books from %(publisher)s"
 msgstr "Maghanap ng iba pang mga aklat mula kay %(publisher)s"
 
+#: openlibrary/plugins/worksearch/code.py type/edition/view.html type/work/view.html
+msgid "Language"
+msgstr "Wika"
+
 #: type/edition/view.html type/work/view.html
 msgid "Pages"
 msgstr "Mga Pahina"
@@ -8242,6 +7101,10 @@ msgstr "Mga Pahina"
 #: type/edition/view.html type/work/view.html
 msgid "ISBNs"
 msgstr "ISBNs"
+
+#: databarWork.html type/edition/view.html type/work/view.html
+msgid "Buy this book"
+msgstr "Bumili ng aklat na ito"
 
 #: type/edition/view.html type/work/view.html
 msgid "Book Details"
@@ -8294,10 +7157,6 @@ msgstr "Mga Panlabas na Link"
 #: type/edition/view.html type/work/view.html
 msgid "Format"
 msgstr "Format"
-
-#: type/edition/view.html type/work/view.html
-msgid "Pagination"
-msgstr "Pagpapalimbag"
 
 #: type/edition/view.html type/work/view.html
 msgid "Number of pages"
@@ -8434,12 +7293,8 @@ msgid "Visit Open Library"
 msgstr "Bumisita sa Open Library"
 
 #: type/list/embed.html
-msgid ""
-"Open in online Book Reader. Downloads available in ePub, DAISY, PDF, TXT "
-"formats from main book page"
-msgstr ""
-"Buksan sa online Book Reader. Mga pag-download ay available sa ePub, DAISY, PDF, TXT "
-"na mga format mula sa pangunahing pahina ng aklat"
+msgid "Open in online Book Reader. Downloads available in ePub, DAISY, PDF, TXT formats from main book page"
+msgstr "Buksan sa online Book Reader. Mga pag-download ay available sa ePub, DAISY, PDF, TXT na mga format mula sa pangunahing pahina ng aklat"
 
 #: type/list/embed.html
 msgid "This book is checked out"
@@ -8456,6 +7311,11 @@ msgstr "Humiram ng aklat"
 #: type/list/embed.html
 msgid "Protected DAISY"
 msgstr "Naka-protektang DAISY"
+
+#: BookByline.html type/list/embed.html
+#, python-format
+msgid "by %(name)s"
+msgstr "ni %(name)s"
 
 #: type/list/exports.html
 msgid "BibTex"
@@ -8485,21 +7345,13 @@ msgstr "Hindi Available ang I-export"
 
 #: type/list/exports.html
 #, python-format
-msgid ""
-"Only lists with up to %(max)s editions can be exported. This one has "
-"%(count)s."
-msgstr ""
-"Tanging mga listahan na may hanggang %(max)s edisyon ang maaaring i-export. Ang isa na ito ay may "
-"%(count)s."
+msgid "Only lists with up to %(max)s editions can be exported. This one has %(count)s."
+msgstr "Tanging mga listahan na may hanggang %(max)s edisyon ang maaaring i-export. Ang isa na ito ay may %(count)s."
 
 #: type/list/exports.html
 #, python-format
-msgid ""
-"Try removing some seeds for more focus, or look at <a href=\"%s\">bulk "
-"download</a> of the catalog."
-msgstr ""
-"Subukan na alisin ang ilang mga seed para sa higit na pokus, o tingnan ang <a href=\"%s\">bulk "
-"download</a> ng katalogo."
+msgid "Try removing some seeds for more focus, or look at <a href=\"%s\">bulk download</a> of the catalog."
+msgstr "Subukan na alisin ang ilang mga seed para sa higit na pokus, o tingnan ang <a href=\"%s\">bulk download</a> ng katalogo."
 
 #: type/list/view_body.html
 #, python-format
@@ -8537,24 +7389,22 @@ msgid "Remove Seed"
 msgstr "Alisin ang Seed"
 
 #: type/list/view_body.html
-msgid ""
-"You are about to remove the last item in the list. That will delete the "
-"whole list. Are you sure you want to continue?"
-msgstr ""
-"Ikaw ay malapit nang alisin ang huling item sa listahan. Yan ay magbubura sa "
-"buong listahan. Sigurado ka bang nais mong magpatuloy?"
+msgid "You are about to remove the last item in the list. That will delete the whole list. Are you sure you want to continue?"
+msgstr "Ikaw ay malapit nang alisin ang huling item sa listahan. Yan ay magbubura sa buong listahan. Sigurado ka bang nais mong magpatuloy?"
+
+#: type/list/view_body.html
+#, python-format
+msgid "This series contains %(limit)d or more works. Currently, only the first %(limit)d works are displayed."
+msgstr "Ang seryeng ito ay naglalaman ng %(limit)d o higit pang gawa. Sa kasalukuyan, ang unang %(limit)d na gawa lamang ang ipinapakita."
 
 #: type/list/view_body.html
 msgid "There are no items on this list."
 msgstr "Walang mga item sa listahang ito."
 
 #: type/list/view_body.html
-msgid ""
-"<a href=\"/search\" target=\"_blank\">Search for book, subjects, or "
-"authors</a> to add to your list."
+#, fuzzy
+msgid "<a href=\"/search\" target=\"_blank\" rel=\"noopener noreferrer\">Search for book, subjects, or authors</a> to add to your list."
 msgstr ""
-"<a href=\"/search\" target=\"_blank\">Maghanap ng aklat, mga paksa, o "
-"mga may-akda</a> na idaragdag sa iyong listahan."
 
 #: type/list/view_body.html
 msgid "Learn more."
@@ -8567,6 +7417,10 @@ msgstr "Metadata ng Listahan"
 #: type/list/view_body.html
 msgid "Derived from seed metadata"
 msgstr "Nakuha mula sa seed metadata"
+
+#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py type/list/view_body.html
+msgid "Times"
+msgstr "Mga Panahon"
 
 #: type/local_id/view.html
 msgid "Local IDs"
@@ -8632,13 +7486,53 @@ msgstr "Magdagdag ng tag sa Open Library"
 msgid "We require a minimum set of fields to create a new collection tag."
 msgstr "Kailangan namin ng minimum na mga field upang makagawa ng bagong tag ng koleksyon."
 
+#: EditButtons.html type/tag/form.html
+#, fuzzy
+msgid "By saving a change to this wiki, you agree that your contribution is given freely to the world under <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" target=\"_blank\" rel=\"noopener noreferrer\" title=\"This link to Creative Commons will open in a new window\">CC0</a>. Yippee!"
+msgstr ""
+
 #: type/tag/form.html
 msgid "Add this tag now"
 msgstr "Idagdag ang tag na ito ngayon"
 
+#: type/tag/index.html
+#, fuzzy
+msgid "Tags"
+msgstr "Mga Tag:"
+
+#: type/tag/index.html
+msgid "Tags curated by Open Library librarians."
+msgstr "Mga tag na pinili ng mga librarian ng Open Library."
+
+#: type/tag/index.html
+#, fuzzy
+msgid "View subject page"
+msgstr ""
+
+#: type/tag/index.html
+msgid "Previous"
+msgstr "Nakaraan"
+
+#: type/tag/index.html
+#, fuzzy
+msgid "No tags found."
+msgstr "Hindi natagpuan."
+
 #: type/tag/tag_form_inputs.html
 msgid "Tag Name"
 msgstr "Pangalan ng Tag"
+
+#: type/tag/tag_form_inputs.html
+msgid "Human-readable display name (e.g. \"Computer Science\", \"Horror Fiction\")"
+msgstr "Pangalan na nababasa ng tao (hal. \"Computer Science\", \"Horror Fiction\")"
+
+#: type/tag/tag_form_inputs.html
+msgid "Tag Slugs"
+msgstr "Mga Tag Slug"
+
+#: type/tag/tag_form_inputs.html
+msgid "Comma-separated URL slugs that map to this tag (auto-populated from name). E.g. \"computer_science, cs\""
+msgstr "Mga URL slug na pinaghiwalay ng kuwit na nagmamapa sa tag na ito (awtomatikong pinopunan mula sa pangalan). Hal. \"computer_science, cs\""
 
 #: type/tag/tag_form_inputs.html
 msgid "Tag Description"
@@ -8668,6 +7562,10 @@ msgstr "Deskripsyon"
 #: type/tag/view.html
 msgid "Tag Body"
 msgstr "Katawan ng Tag"
+
+#: type/tag/view.html
+msgid "URL Slugs"
+msgstr "Mga URL Slug"
 
 #: type/tag/view.html
 #, python-format
@@ -8724,17 +7622,9 @@ msgid "admin page"
 msgstr "admin na pahina"
 
 #: type/user/view.html
-#, python-format
-msgid ""
-"You are publicly sharing the books you are <a href=\"%(username)s/books"
-"/currently-reading\">currently reading</a>, <a href=\"%(username)s/books"
-"/already-read\">have already read</a>, and <a href=\"%(username)s/books"
-"/want-to-read\">want to read</a>."
+#, fuzzy, python-format
+msgid "You are publicly sharing the books you are <a href=\"%(username)s/books/currently-reading\">currently reading</a>, <a href=\"%(username)s/books/already-read\">have already read</a>, <a href=\"%(username)s/books/want-to-read\">want to read</a>, and have <a href=\"%(username)s/books/stopped-reading\">stopped reading</a>!"
 msgstr ""
-"Ipinapamahagi mo nang publiko ang mga aklat na ikaw ay <a href=\"%(username)s/books"
-"/currently-reading\">kasalukuyang binabasa</a>, <a href=\"%(username)s/books"
-"/already-read\">na nabasa na</a>, at <a href=\"%(username)s/books"
-"/want-to-read\">nais mong basahin</a>."
 
 #: type/user/view.html
 msgid "You have chosen to make your"
@@ -8749,30 +7639,35 @@ msgid "Manage your privacy settings"
 msgstr "I-manage ang iyong mga privacy settings"
 
 #: type/user/view.html
-#, python-format
-msgid ""
-"Here are the books %(user)s is <a href=\"%(username)s/books/currently-"
-"reading\">currently reading</a>, <a href=\"%(username)s/books/already-"
-"read\">have already read</a>, and <a href=\"%(username)s/books/want-to-"
-"read\">want to read</a>!"
+#, fuzzy, python-format
+msgid "Here are the books %(user)s is <a href=\"%(username)s/books/currently-reading\">currently reading</a>, <a href=\"%(username)s/books/already-read\">have already read</a>, <a href=\"%(username)s/books/want-to-read\">want to read</a>, and has <a href=\"%(username)s/books/stopped-reading\">stopped reading</a>!"
 msgstr ""
-"Narito ang mga aklat na si %(user)s ay <a href=\"%(username)s/books/currently-"
-"reading\">kasalukuyang binabasa</a>, <a href=\"%(username)s/books/already-"
-"read\">na nabasa na</a>, at <a href=\"%(username)s/books/want-to-"
-"read\">nais mong basahin</a>!"
 
 #: type/user/view.html
 msgid "My Lists"
 msgstr "Aking Mga Listahan"
 
+#: RecentChangesUsers.html type/user/view.html
+msgid "No edits. Yet."
+msgstr "Walang mga edit. Sa ngayon."
+
 #: type/usergroup/edit.html
 msgid "Members:"
 msgstr "Mga Miyembro:"
+
+#: SearchResultsWork.html type/work/editions.html
+#, python-format
+msgid "First published in %(year)s"
+msgstr "Una nailimbag noong %(year)s"
 
 #: type/work/editions.html type/work/editions_datatable.html
 #, python-format
 msgid "Add another edition of %(work)s"
 msgstr "Magdagdag ng isa pang edisyon ng %(work)s"
+
+#: UserEditRow.html type/work/editions.html
+msgid "Add another"
+msgstr "Magdagdag ng isa pa"
 
 #: type/work/editions.html
 msgid "Title missing"
@@ -8806,5 +7701,1112 @@ msgstr "Walang available na edisyon"
 msgid "Add another edition?"
 msgstr "Magdagdag ng isa pang edisyon?"
 
+#: AffiliateLinks.html
+#, python-format
+msgid "Look for this edition for sale at %(store)s"
+msgstr "Hanapin ang edisyong ito na ibinenta sa %(store)s"
 
+#: AffiliateLinks.html
+msgid "When you buy books using these links the Internet Archive may earn a <a class=\"nostyle\" href=\"/help/faq/about#selling\">small commission</a>."
+msgstr "Kapag bumili ka ng mga aklat gamit ang mga link na ito, maaaring kumita ang Internet Archive ng <a class=\"nostyle\" href=\"/help/faq/about#selling\">maliit na komisyon</a>."
+
+#: AffiliateLinksLoadingIndicator.html
+msgid "Fetching prices"
+msgstr "Kinukuha ang mga presyo"
+
+#: BatchImportNavigation.html
+msgid "Pending Imports"
+msgstr "Naghihintay na Imports"
+
+#: BookByline.html
+#, python-format
+msgid "%(n)s other"
+msgid_plural "%(n)s others"
+msgstr[0] "%(n)s iba"
+msgstr[1] "%(n)s iba"
+
+#: BookByline.html
+msgid "by an <em>unknown author</em>"
+msgstr "ni isang <em>hindi kilalang may-akda</em>"
+
+#: BookPreview.html
+msgid "Preview Only"
+msgstr "Preview Lamang"
+
+#: BookPreview.html
+msgid "Preview Book"
+msgstr "Tukuyin ang Aklat"
+
+#: DisplayCode.html
+msgid "Templates in the website are disabled now. Editing them will not have any effect on the live website."
+msgstr "Ngayon ay na-disable ang mga template sa website. Ang pag-edit sa mga ito ay walang epekto sa aktibong website."
+
+#: EditionNavBar.html
+msgid "Go to previous section"
+msgstr "Pumunta sa nakaraang bahagi"
+
+#: EditionNavBar.html
+msgid "Overview"
+msgstr "Pangkalahatang-ideya"
+
+#: EditionNavBar.html
+#, python-format
+msgid "View %(count)s Edition"
+msgid_plural "View %(count)s Editions"
+msgstr[0] "Tingnan ang %(count)s Edisyon"
+msgstr[1] "Tingnan ang %(count)s mga Edisyon"
+
+#: EditionNavBar.html
+#, python-format
+msgid "%(reviews)s Review"
+msgid_plural "%(reviews)s Reviews"
+msgstr[0] "%(reviews)s Review"
+msgstr[1] "%(reviews)s Mga Review"
+
+#: EditionNavBar.html
+msgid "Related Books"
+msgstr "Kaugnay na mga Aklat"
+
+#: EditionNavBar.html
+msgid "Go to next section"
+msgstr "Pumunta sa susunod na bahagi"
+
+#: Follow.html
+msgid "Unfollow"
+msgstr "Huwag Sundan"
+
+#: Follow.html
+msgid "Failed to update followers. Please try again in a few moments."
+msgstr "Nabigong i-update ang mga tagasunod. Mangyaring subukan muli sa ilang sandali."
+
+#: FormatExpiry.html
+msgid "Expires"
+msgstr "Mag-e-expire"
+
+#: FulltextSearchSuggestion.html
+msgid "Checking for Search Inside matches"
+msgstr "Sinasabing tingnan ang mga tugma sa Search Inside"
+
+#: FulltextSearchSuggestion.html
+msgid "Search Inside Icon"
+msgstr "Search Inside Icon"
+
+#: FulltextSearchSuggestion.html
+msgid "search inside icon"
+msgstr "search inside icon"
+
+#: FulltextSearchSuggestion.html
+#, python-format
+msgid "%(book_count)s books found with matching passages"
+msgstr "%(book_count)s mga aklat na natagpuan na may tugmang bahagi"
+
+#: FulltextSearchSuggestion.html
+#, python-format
+msgid "See all %(results_count)s Search Inside Matches"
+msgstr "Tingnan ang lahat ng %(results_count)s Search Inside Matches"
+
+#: FulltextSearchSuggestion.html
+msgid "right chevron"
+msgstr "kanang chevron"
+
+#: FulltextSnippet.html FulltextSuggestionSnippet.html
+msgid "❝"
+msgstr "❝"
+
+#: FulltextSnippet.html FulltextSuggestionSnippet.html
+msgid "❞"
+msgstr "❞"
+
+#: FulltextSuggestionSnippet.html
+#, python-format
+msgid "Page: %(page)s"
+msgstr "Pahina: %(page)s"
+
+#: IABook.html
+#, python-format
+msgid "Borrowed from Internet Archive: %(title)s"
+msgstr "Hiram mula sa Internet Archive: %(title)s"
+
+#: LoadingIndicator.html
+msgid "Loading indicator"
+msgstr "Tagapagpahiwatig ng Pag-load"
+
+#: LoanStatus.html
+msgid "You are <strong>next</strong> on the waiting list"
+msgstr "Ikaw ay <strong>susunod</strong> sa listahan ng naghihintay"
+
+#: LoanStatus.html
+#, python-format
+msgid "You are <strong>#%(spot)d</strong> of %(wlsize)d on the waiting list."
+msgstr "Ikaw ay <strong>#%(spot)d</strong> sa %(wlsize)d sa listahan ng naghihintay."
+
+#: LoanStatus.html
+msgid "Leave waiting list"
+msgstr "Umalis sa listahan ng naghihintay"
+
+#: LoanStatus.html
+#, python-format
+msgid "Readers in line: %(count)s"
+msgstr "Mga mambabasa sa pila: %(count)s"
+
+#: LoanStatus.html
+msgid "You'll be next in line."
+msgstr "Ikaw ay susunod sa pila."
+
+#: LoanStatus.html
+msgid "This book is currently checked out, please check back later."
+msgstr "Ang aklat na ito ay kasalukuyang hiniram, mangyaring bumalik mamaya."
+
+#: LoanStatus.html
+msgid "Checked Out"
+msgstr "Nakahiram"
+
+#: LocateButton.html
+msgid "Locate"
+msgstr "Hanapin"
+
+#: ManageLoansButtons.html
+#, python-format
+msgid "There is one person waiting for this book."
+msgid_plural "There are %(n)s people waiting for this book."
+msgstr[0] "May isang tao na naghihintay para sa aklat na ito."
+msgstr[1] "May %(n)s tao na naghihintay para sa aklat na ito."
+
+#: ManageWaitlistButton.html
+#, python-format
+msgid "Waiting for %d day"
+msgid_plural "Waiting for %d days"
+msgstr[0] "Naghihintay ng %d araw"
+msgstr[1] "Naghihintay ng %d araw"
+
+#: ManageWaitlistButton.html
+#, python-format
+msgid "You have %(count)d more hour to borrow it."
+msgid_plural "You have %(count)d more hours to borrow it."
+msgstr[0] "Mayroon kang %(count)d mas maraming oras upang hiramin ito."
+msgstr[1] "Mayroon kang %(count)d mas maraming oras upang hiramin ito."
+
+#: NotInLibrary.html
+msgid "Not in Library"
+msgstr "Wala sa Aklatan"
+
+#: NotesModal.html
+msgid "My Book Notes"
+msgstr "Aking Mga Tala sa Aklat"
+
+#: NotesModal.html
+msgid "My private notes about this edition:"
+msgstr "Aking mga pribadong tala tungkol sa edisyong ito:"
+
+#: OLID.html
+#, python-format
+msgid "by  %(authors)s"
+msgstr "ni  %(authors)s"
+
+#: ObservationsModal.html
+msgid "My Book Review"
+msgstr "Aking Pagsusuri ng Aklat"
+
+#: OlPagination.html OlPaginationArrows.html
+#, fuzzy
+msgid "Go to previous page"
+msgstr "Pumunta sa nakaraang bahagi"
+
+#: OlPagination.html OlPaginationArrows.html
+#, fuzzy
+msgid "Go to next page"
+msgstr "Pumunta sa susunod na bahagi"
+
+#: OlPagination.html
+#, fuzzy, python-brace-format
+msgid "Go to page {page}"
+msgstr ""
+
+#: OlPagination.html
+#, python-brace-format
+msgid "Page {page}, current page"
+msgstr "Pahina {page}, kasalukuyang pahina"
+
+#: Profile.html
+msgid "Component"
+msgstr "Komponent"
+
+#: ProlificAuthors.html
+msgid "Prolific Authors"
+msgstr "Masugid na Mga May-Akda"
+
+#: ProlificAuthors.html
+msgid "who have written the most books on this subject"
+msgstr "na sumulat ng pinakamaraming aklat tungkol sa paksang ito"
+
+#: PublishingHistory.html
+msgid "This is a chart to show the publishing history of editions of works about this subject. Along the X axis is time, and on the y axis is the count of editions published. <a href=\"#subjectRelated\">Click here to skip the chart</a>."
+msgstr "Ito ay isang tsart upang ipakita ang kasaysayan ng paglilimbag ng mga edisyon ng mga akdang tungkol sa paksa. Sa X axis ay ang oras, at sa Y axis ay ang bilang ng mga edisyon na nailimbag. <a href=\"#subjectRelated\">I-click dito upang laktawan ang tsart</a>."
+
+#: PublishingHistory.html
+msgid "This graph charts editions published on this subject."
+msgstr "Itinataas ng graph na ito ang mga edisyon na nailimbag tungkol sa paksa."
+
+#: RawQueryCarousel.html
+msgid "Loading carousel"
+msgstr "Nagloload ng carousel"
+
+#: RawQueryCarousel.html
+msgid "Failed to fetch carousel."
+msgstr "Nabigong kunin ang carousel."
+
+#: RawQueryCarousel.html
+msgid "Retry?"
+msgstr "Subukan muli?"
+
+#: RawQueryCarousel.html
+msgid "No books match the current filters."
+msgstr "Walang aklat na tumutugma sa kasalukuyang mga filter."
+
+#: RawQueryCarousel.html
+msgid "Retry without filters?"
+msgstr "Subukan muli nang walang filters?"
+
+#: RawQueryCarousel.html
+msgid "Search collection"
+msgstr "Maghanap sa koleksyon"
+
+#: ReadButton.html
+msgid "Special Access"
+msgstr "Espesyal na Access"
+
+#: ReadButton.html
+msgid "Special ebook access from the Internet Archive for patrons with qualifying print disabilities"
+msgstr "Espesyal na access sa ebook mula sa Internet Archive para sa mga patron na may qualifying na kapansanan sa pag-imprinta"
+
+#: ReadButton.html
+msgid "Borrow ebook from Internet Archive"
+msgstr "Hiramin ang ebook mula sa Internet Archive"
+
+#: ReadButton.html
+msgid "Read ebook from Internet Archive"
+msgstr "Basahin ang ebook mula sa Internet Archive"
+
+#: ReadButton.html
+msgid "Listen"
+msgstr "Makinig"
+
+#: RecentChanges.html
+msgid "View MARC"
+msgstr "Tingnan ang MARC"
+
+#: RecentChangesAdmin.html
+msgid "Path"
+msgstr "Daan"
+
+#: RecentChangesAdmin.html
+msgid "view"
+msgstr "tingnan"
+
+#: RecentChangesAdmin.html
+msgid "edit"
+msgstr "i-edit"
+
+#: RecentChangesAdmin.html RecentChangesUsers.html
+msgid "No edit history available."
+msgstr "Walang magagamit na kasaysayan ng pag-edit."
+
+#: RelatedSubjects.html
+msgid "Related..."
+msgstr "Kaugnay..."
+
+#: ReturnForm.html
+msgid "Really return this book?"
+msgstr "Talagang ibabalik ang aklat na ito?"
+
+#: ReturnForm.html
+msgid "Return book"
+msgstr "Ibalik ang aklat"
+
+#: SearchResultsWork.html
+msgid "added to"
+msgstr "idinagdag sa"
+
+#: SearchResultsWork.html
+#, python-format
+msgid "Book %(position)s"
+msgstr "Aklat %(position)s"
+
+#: SearchResultsWork.html
+#, python-format
+msgid "Cover of edition %(id)s"
+msgstr "Pabalat ng edisyon %(id)s"
+
+#: SearchResultsWork.html
+#, python-format
+msgid "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d language</a>"
+msgid_plural "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d languages</a>"
+msgstr[0] "sa <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d wika</a>"
+msgstr[1] "sa <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d mga wika</a>"
+
+#: SearchResultsWork.html TrendingBadge.html
+msgid "This is only visible to librarians."
+msgstr "Ito ay nakikita lamang ng mga librarian."
+
+#: SearchResultsWork.html
+msgid "Work Title"
+msgstr "Pamagat ng Akda"
+
+#: ShareModal.html
+#, python-format
+msgid "Share on %(share_link)s"
+msgstr "Ibahagi sa %(share_link)s"
+
+#: ShareModal.html
+msgid "Embed this book in your website"
+msgstr "I-embed ang aklat na ito sa iyong website"
+
+#: ShareModal.html
+msgid "Embed icon"
+msgstr "Embed icon"
+
+#: ShareModal.html
+msgid "Embed"
+msgstr "I-embed"
+
+#: ShareModal.html
+msgid "Copy url to clipboard"
+msgstr "Kopyahin ang url sa clipboard"
+
+#: ShareModal.html
+msgid "Copy URL icon"
+msgstr "Kopyahin ang URL icon"
+
+#: ShareModal.html
+msgid "Copy URL"
+msgstr "Kopyahin ang URL"
+
+#: ShareModal.html
+msgid "Open QR code"
+msgstr "Buksan ang QR code"
+
+#: ShareModal.html
+msgid "QR code icon"
+msgstr "QR code icon"
+
+#: ShareModal.html
+msgid "QR Code"
+msgstr "QR Code"
+
+#: StarRatings.html
+msgid "leaving a 1 star review for"
+msgstr "nag-iiwan ng 1 bituin na review para sa"
+
+#: StarRatings.html
+msgid "leaving a 2 star review for"
+msgstr "nag-iiwan ng 2 bituin na review para sa"
+
+#: StarRatings.html
+msgid "leaving a 3 star review for"
+msgstr "nag-iiwan ng 3 bituin na review para sa"
+
+#: StarRatings.html
+msgid "leaving a 4 star review for"
+msgstr "nag-iiwan ng 4 na bituin na review para sa"
+
+#: StarRatings.html
+msgid "leaving a 5 star review for"
+msgstr "nag-iiwan ng 5 bituin na review para sa"
+
+#: StarRatings.html
+msgid "Clear my rating"
+msgstr "I-clear ang aking rating"
+
+#: StarRatingsByline.html StarRatingsComponent.html
+msgid "rating"
+msgstr "rating"
+
+#: StarRatingsByline.html StarRatingsComponent.html
+msgid "ratings"
+msgstr "ratings"
+
+#. Shows the count of readers who added this book to their "Want to read"
+#. shelf, displayed on search result pages. %(want_to_read_count)s is a
+#. formatted integer (may include commas as thousands separators). Example:
+#. "2,389 Want to read".
+#: StarRatingsByline.html
+#, python-format
+msgid "%(want_to_read_count)s Want to read"
+msgstr "%(want_to_read_count)s Gusto ng basahin"
+
+#: StarRatingsComponent.html
+#, python-format
+msgid "%(ratings_avg)s (%(ratings_count)s %(ratings_label)s)"
+msgstr "%(ratings_avg)s (%(ratings_count)s %(ratings_label)s)"
+
+#. Short label displayed next to the count of readers who want to read this
+#. book, shown in the stats bar on a book page. Example: "2,389 Want to read".
+#: StarRatingsStats.html
+msgid "Want to read"
+msgstr "Gusto ng basahin"
+
+#. Short label displayed next to the count of readers currently reading this
+#. book, shown in the stats bar on a book page. Example: "1,247 Currently
+#. reading".
+#: StarRatingsStats.html
+msgid "Currently reading"
+msgstr "Kasalukuyang nagbabasa"
+
+#. Short label displayed next to the count of readers who have finished this
+#. book, shown in the stats bar on a book page. Example: "15,420 Have read".
+#. This refers to the same shelf as the "Already Read" button.
+#: StarRatingsStats.html
+msgid "Have read"
+msgstr "Nabasa na"
+
+#. Short label displayed next to the count of readers who stopped reading this
+#. book before finishing, shown in the stats bar on a book page. Example: "348
+#. Stopped reading".
+#: StarRatingsStats.html
+#, fuzzy
+msgid "Stopped reading"
+msgstr "Kasalukuyang Uso"
+
+#: SubjectTags.html
+msgid "Manage Subjects"
+msgstr "Pamahalaan ang mga Paksa"
+
+#: Subnavigation.html
+msgid "Developer Center (Home)"
+msgstr "Sentro ng Developer (Tahanan)"
+
+#: Subnavigation.html
+msgid "Web API"
+msgstr "Web API"
+
+#: Subnavigation.html
+msgid "Client Library"
+msgstr "Aklatan ng Kliyente"
+
+#: Subnavigation.html
+msgid "Data Dumps"
+msgstr "Data Dumps"
+
+#: Subnavigation.html
+msgid "Report an Issue"
+msgstr "Iulat ang Isyu"
+
+#: Subnavigation.html
+msgid "Licensing"
+msgstr "Lisensya"
+
+#: Subnavigation.html
+msgid "Welcome"
+msgstr "Maligayang pagdating"
+
+#: Subnavigation.html
+msgid "Searching Open Library"
+msgstr "Naghahanap sa Open Library"
+
+#: Subnavigation.html
+msgid "Reading Books"
+msgstr "Nagbabasa ng Mga Aklat"
+
+#: Subnavigation.html
+msgid "Adding & Editing Books"
+msgstr "Pagdaragdag at Pagsusuri ng Mga Aklat"
+
+#: Subnavigation.html
+msgid "Using Subjects"
+msgstr "Gumagamit ng Mga Paksa"
+
+#: Subnavigation.html
+msgid "Open Library F.A.Q."
+msgstr "Mga Madalas Itanong sa Open Library"
+
+#: TableOfContents.html
+#, python-format
+msgid "Page %s"
+msgstr "Pahina %s"
+
+#: TrendingBadge.html
+#, python-format
+msgid "Trending: %(score).2f"
+msgstr "Umangat: %(score).2f"
+
+#: TypeChanger.html
+msgid "Page Type"
+msgstr "Uri ng Pahina"
+
+#: TypeChanger.html
+msgid "Huh?"
+msgstr "Ha?"
+
+#: TypeChanger.html
+msgid "Every piece of Open Library is defined by the type of content it displays, usually by content definition (e.g. Authors, Editions, Works) but sometimes by content use (e.g. macro, template, rawtext). Changing this for an existing page will alter its presentation and the data fields available for editing its content."
+msgstr "Bawat bahagi ng Open Library ay tinutukoy ng uri ng nilalaman nito binibigay, kadalasang batay sa depinisyon ng nilalaman (hal. Mga Awtor, Edisyon, Akda) ngunit kung minsan ay batay sa paggamit ng nilalaman (hal. macro, template, rawtext). Ang pagbabago na ito para sa isang umiiral na pahina ay babaguhin ang presentasyon nito at ang mga patlang ng data na magagamit para sa pag-edit ng nilalaman nito."
+
+#: TypeChanger.html
+msgid "Please use caution changing Page Type!"
+msgstr "Mangyaring maging maingat sa pagbabago ng Uri ng Pahina!"
+
+#: TypeChanger.html
+msgid "(Simplest solution: If you aren't sure whether this should be changed, don't change it.)"
+msgstr "(Pinakasimpleng solusyon: Kung hindi ka sigurado kung ito ay dapat baguhin, huwag itong baguhin.)"
+
+#: WorkInfo.html
+msgid "No link to Wikipedia in your language"
+msgstr "Walang link sa Wikipedia sa iyong wika"
+
+#: WorldcatLink.html
+msgid "Check nearby libraries"
+msgstr "Suriin ang mga kalapit na aklatan"
+
+#: WorldcatLink.html
+msgid "Check WorldCat for an edition near you"
+msgstr "Suriin ang WorldCat para sa isang edisyon na malapit sa iyo"
+
+#: WorldcatLink.html
+msgid "WorldCat"
+msgstr "WorldCat"
+
+#: databarDiff.html databarEdit.html
+msgid "View the editing history of this page"
+msgstr "Tingnan ang kasaysayan ng pag-edit ng pahinang ito"
+
+#: databarDiff.html
+msgid "View this page (exit Comparison view)"
+msgstr "Tingnan ang pahinang ito (lumabas sa Paghahambing na view)"
+
+#: databarEdit.html
+msgid "View this page (exit Edit mode)"
+msgstr "Tingnan ang pahinang ito (lumabas sa Edit mode)"
+
+#: databarHistory.html databarView.html
+#, python-format
+msgid "Last edited by %(author_link)s"
+msgstr "Huling inedit ni %(author_link)s"
+
+#: databarHistory.html databarView.html
+msgid "Last edited anonymously"
+msgstr "Huling inedit ng hindi kilala"
+
+#: databarTemplate.html databarView.html
+msgid "View this template's edit history"
+msgstr "Tingnan ang kasaysayan ng pag-edit ng template na ito"
+
+#: databarTemplate.html
+msgid "Edit this template"
+msgstr "I-edit ang template na ito"
+
+#: databarWork.html
+#, python-format
+msgid "View Volume %(num)d"
+msgstr "Tingnan ang Dami %(num)d"
+
+#: openlibrary/core/bookshelves.py
+msgid "[Record deleted]"
+msgstr "[Talaan ay tinanggal]"
+
+#: openlibrary/core/edits.py
+msgid "Unknown"
+msgstr "Hindi Kilala"
+
+#: openlibrary/plugins/openlibrary/api.py
+msgid "Search Results"
+msgstr "Mga Resulta ng Paghahanap"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Arabic"
+msgstr "Arabo"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Czech"
+msgstr "Seko"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "German"
+msgstr "Alemán"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "English"
+msgstr "Ingles"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Spanish"
+msgstr "Espanyol"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "French"
+msgstr "Pranses"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Hindi"
+msgstr "Hindi"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Croatian"
+msgstr "Croatian"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Italian"
+msgstr "Italyano"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Portuguese"
+msgstr "Portuges"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Romanian"
+msgstr "Rumen"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Sardinian"
+msgstr "Sardiniano"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Telugu"
+msgstr "Telugu"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Ukrainian"
+msgstr "Ukrainiano"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Chinese"
+msgstr "Tsino"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Filipino"
+msgstr "Filipino"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Art"
+msgstr "Sining"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Science Fiction"
+msgstr "Agham na Piksyon"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Fantasy"
+msgstr "Pantasiya"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Biographies"
+msgstr "Talambuhay"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Recipes"
+msgstr "Mga Resipe"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Children"
+msgstr "Mga Bata"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Medicine"
+msgstr "Medisina"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Religion"
+msgstr "Relihiyon"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Mystery and Detective Stories"
+msgstr "Mga Kuwento ng Misteryo at Detektib"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Plays"
+msgstr "Pagsasakatawan"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Music"
+msgstr "Musika"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "At least 1 subject"
+msgstr "Hindi bababa sa 1 paksa"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "At least 1 author"
+msgstr "Hindi bababa sa 1 may-akda"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "At least 1 edition"
+msgstr "Hindi bababa sa 1 edisyon"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has work (orphaned)"
+msgstr "Mayroong gawa (ulila)"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has publication year"
+msgstr "Mayroong taon ng publikasyon"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has cover"
+msgstr "Mayroong takip"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has language"
+msgstr "Mayroong wika"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has publisher"
+msgstr "Mayroong publisher"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "At least 2 editions"
+msgstr "Hindi bababa sa 2 edisyon"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has dewey decimal"
+msgstr "Mayroong dewey decimal"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has LoC classification"
+msgstr "Mayroong LoC klasipikasyon"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has number of pages"
+msgstr "Mayroong bilang ng mga pahina"
+
+#: openlibrary/plugins/openlibrary/lists.py
+#, python-format
+msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
+msgstr "Sigurado ka bang gusto mong alisin ang <strong>%(title)s</strong> mula sa iyong listahan?"
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "Better World Books"
+msgstr "Mas Magandang Mundo ng mga Aklat"
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid " - includes shipping"
+msgstr " - kasama ang pagpapadala"
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "Amazon"
+msgstr "Amazon"
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "Bookshop.org"
+msgstr "Bookshop.org"
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "This work does not appear on any lists."
+msgstr "Ang gawaing ito ay hindi lumalabas sa alinmang listahan."
+
+#: openlibrary/plugins/openlibrary/pd.py
+msgid "I don't have one yet"
+msgstr "Wala pa akong isa"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "The email address you entered is invalid"
+msgstr "Ang email address na iyong ipinasok ay hindi wasto"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "This account has been blocked"
+msgstr "Ang account na ito ay na-block"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "This account has been locked"
+msgstr "Ang account na ito ay na-lock"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "No account was found with this email. Please try again"
+msgstr "Walang natagpuang account gamit ang email na ito. Mangyaring subukan muli"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "The password you entered is incorrect. Please try again"
+msgstr "Ang password na iyong ipinasok ay mali. Mangyaring subukan muli"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Wrong password. Please try again"
+msgstr "Maling password. Mangyaring subukan muli"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Please verify your Open Library account before logging in"
+msgstr "Mangyaring i-verify ang iyong Open Library account bago mag-log in"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Please verify your Internet Archive account before logging in"
+msgstr "Mangyaring i-verify ang iyong Internet Archive account bago mag-log in"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Please fill out all fields and try again"
+msgstr "Mangyaring punan ang lahat ng patlang at subukan muli"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "This email is already registered"
+msgstr "Ang email na ito ay naka-rehistro na"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "This username is already registered"
+msgstr "Ang username na ito ay naka-rehistro na"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "A problem occurred and we were unable to log you in."
+msgstr "Isang problema ang nangyari at hindi kami makapag-log in sa iyo."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Login attempted with invalid Internet Archive s3 credentials."
+msgstr "Sinubukang mag-log in gamit ang hindi wastong Internet Archive s3 na kredensyal."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Servers are experiencing unusually high traffic, please try again later or email openlibrary@archive.org for help."
+msgstr "Ang mga server ay nakakaranas ng hindi karaniwang mataas na trapiko, mangyaring subukan muli mamaya o mag-email sa openlibrary@archive.org para sa tulong."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Email provider not recognized."
+msgstr "Hindi nakilala ang tagapagbigay ng email."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Password requirements not met."
+msgstr "Hindi natugunan ang mga kinakailangan sa password."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "A problem occurred and we were unable to log you in"
+msgstr "Isang problema ang nangyari at hindi kami makapag-log in sa iyo."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Login or registration attempt hit an unexpected error, please try again or contact info@archive.org"
+msgstr "Ang pagtatangkang mag-log in o magrehistro ay nakatagpo ng hindi inaasahang error, mangyaring subukan muli o makipag-ugnayan sa info@archive.org"
+
+#: openlibrary/plugins/upstream/account.py
+#, python-format
+msgid "Request failed with error code: %(error_code)s"
+msgstr "Bumagsak ang kahilingan na may error code: %(error_code)s"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Thank you for registering an Open Library account and requesting special print disability access. You should receive an email detailing next steps in the process."
+msgstr "Salamat sa pagrehistro ng isang Open Library account at humiling ng espesyal na access para sa mga may kapansanan. Dapat kang makatanggap ng email na naglalarawan sa susunod na mga hakbang sa proseso."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Username unavailable"
+msgstr "Hindi available ang username"
+
+#: openlibrary/plugins/upstream/account.py openlibrary/plugins/upstream/forms.py
+msgid "Email already registered"
+msgstr "Naka-rehistro na ang email"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "An Internet Archive account already exists with this email"
+msgstr "Mayroon nang Internet Archive account gamit ang email na ito"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Verification failed. The link may be invalid or expired. Please try registering again."
+msgstr "Nabigo ang pag-verify. Maaaring invalid o expired na ang link. Mangyaring subukang mag-register muli."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Your email has been verified. You are now logged in."
+msgstr "Na-verify na ang iyong email. Nakalog in ka na ngayon."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Notification preferences have been updated successfully."
+msgstr "Ang mga preference sa notification ay matagumpay na na-update."
+
+#: openlibrary/plugins/upstream/borrow.py
+#, fuzzy
+msgid "this book"
+msgstr "Bumili ng aklat na ito"
+
+#: openlibrary/plugins/upstream/borrow.py
+#, fuzzy, python-format
+msgid "Unable to return %s. Please try again later or contact info@archive.org."
+msgstr ""
+
+#: openlibrary/plugins/upstream/borrow.py
+#, fuzzy, python-format
+msgid "%s has been returned."
+msgstr ""
+
+#: openlibrary/plugins/upstream/borrow.py
+msgid "Your account has hit a lending limit. Please try again later or contact info@archive.org."
+msgstr "Ang iyong account ay umabot na sa limitasyon ng pagpapautang. Mangyaring subukan muli mamaya o makipag-ugnayan sa info@archive.org."
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Username"
+msgstr "Username"
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "No user registered with this email address"
+msgstr "Walang gumagamit na naka-rehistro gamit ang email address na ito"
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Disposable email not permitted"
+msgstr "Hindi pinapayagan ang disposable email"
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Your email provider is not recognized."
+msgstr "Hindi nakilala ang iyong tagapagbigay ng email."
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Username already used"
+msgstr "Username na ginagamit na"
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Must be between 3 and 20 letters and numbers"
+msgstr "Dapat ay nasa pagitan ng 3 at 20 letra at numero"
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Screen Name"
+msgstr "Pangalan ng Screen"
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Public and cannot be changed later."
+msgstr "Pampubliko at hindi maaaring baguhin sa kalaunan."
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Invalid password"
+msgstr "Maling password"
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Your email address"
+msgstr "Ang iyong email address"
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Choose a password"
+msgstr "Pumili ng password"
+
+#: openlibrary/plugins/upstream/mybooks.py
+#, python-format
+msgid "Continue <a href=\"%(url)s\" class=\"pending-action-link\" data-action=\"%(raw_action)s\"><strong>%(action)s</strong> <em>%(name)s</em></a>"
+msgstr "Magpatuloy <a href=\"%(url)s\" class=\"pending-action-link\" data-action=\"%(raw_action)s\"><strong>%(action)s</strong> <em>%(name)s</em></a>"
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "eBook?"
+msgstr "eBook?"
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "First published"
+msgstr "Unang nailathala"
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "Classic eBooks"
+msgstr "Klasikal na eBooks"
+
+#~ msgid "Donate this book to the <a href=\"https://archive.org\">Internet Archive</a> library."
+#~ msgstr "Idonate ang aklat na ito sa <a href=\"https://archive.org\">Internet Archive</a> aklatan."
+
+#~ msgid "Hooray! You've discovered a title that's missing from our <a href=\"https://help.archive.org/hc/en-us/articles/360016554912-Borrowing-From-The-Lending-Library\">library</a>. Can you help donate a copy?"
+#~ msgstr "Hooray! Natagpuan mo ang isang pamagat na nawawala sa aming <a href=\"https://help.archive.org/hc/en-us/articles/360016554912-Borrowing-From-The-Lending-Library\">aklatan</a>. Maaari ka bang tumulong na magdonate ng isang kopya?"
+
+#~ msgid "If you own this book, you can<a href=\"https://store.usps.com/store/product/shipping-supplies/priority-mail-express-padded-flat-rate-envelope-P_EP13PE\">mail</a> it to our address below."
+#~ msgstr "Kung pagmamay-ari mo ang aklat na ito, maaari mo <a href=\"https://store.usps.com/store/product/shipping-supplies/priority-mail-express-padded-flat-rate-envelope-P_EP13PE\">ipadadala</a> ito sa aming address sa ibaba."
+
+#~ msgid "You can also purchase this book from a vendor and ship it to our address:"
+#~ msgstr "Maaari mo ring bilhin ang aklat na ito mula sa isang nagbebenta at ipadala ito sa aming address:"
+
+#~ msgid "Benefits of donating"
+#~ msgstr "Mga Benepisyo ng Pagdonate"
+
+#~ msgid "When you donate a physical book to the Internet Archive, your book will enjoy:"
+#~ msgstr "Kapag nagdonate ka ng isang pisikal na aklat sa Internet Archive, ang iyong aklat ay magkakaroon ng:"
+
+#~ msgid "Donation info"
+#~ msgstr "Impormasyon sa Donasyon"
+
+#~ msgid "Beautiful <a target=\"_blank\" href=\"https://archive.org/scanning\">high-fidelity digitization</a>"
+#~ msgstr "Magandang <a target=\"_blank\" href=\"https://archive.org/scanning\">may mataas na kalidad na digitization</a>"
+
+#~ msgid "Long-term <a href=\"https://blog.archive.org/2011/06/06/why-preserve-books-the-new-physical-archive-of-the-internet-archive/\">archival preservation</a>"
+#~ msgstr "Long-term <a href=\"https://blog.archive.org/2011/06/06/why-preserve-books-the-new-physical-archive-of-the-internet-archive/\">pagpapanatili ng arkibo</a>"
+
+#~ msgid "Free <a href=\"https://controlleddigitallending.org/\">controlled digital library access</a> by the <a href=\"https://en.wikipedia.org/wiki/Print_disability\">print-disabled</a> public"
+#~ msgstr "Libreng <a href=\"https://controlleddigitallending.org/\">kontroladong digital na pag-access sa aklatan</a> sa mga <a href=\"https://en.wikipedia.org/wiki/Print_disability\">may kapansanan sa pag-print</a>"
+
+#~ msgid "Open Library is a project of the <a href=\"https://archive.org/about\">Internet Archive</a>, a 501(c)(3) non-profit"
+#~ msgstr "Ang Open Library ay isang proyekto ng <a href=\"https://archive.org/about\">Internet Archive</a>, isang 501(c)(3) non-profit"
+
+#~ msgid "First"
+#~ msgstr "Una"
+
+#~ msgid "Email address is already used."
+#~ msgstr "Ginagamit na ang email address."
+
+#~ msgid "Your email address couldn't be updated. The specified email address is already used."
+#~ msgstr "Ang iyong email address ay hindi ma-update. Ang tinukoy na email address ay ginagamit na."
+
+#~ msgid "Email verification successful."
+#~ msgstr "Matagumpay ang email verification."
+
+#~ msgid "Your email address has been successfully verified and updated in your account."
+#~ msgstr "Ang iyong email address ay matagumpay na na-verify at na-update sa iyong account."
+
+#~ msgid "Email address couldn't be verified."
+#~ msgstr "Hindi ma-verify ang email address."
+
+#~ msgid "Your email address couldn't be verified. The verification link seems invalid."
+#~ msgstr "Ang iyong email address ay hindi ma-verify. Ang verification link ay tila invalid."
+
+#~ msgid "Design Pattern Library"
+#~ msgstr "Aklatan ng Disenyo ng Pattern"
+
+#~ msgid "Colors"
+#~ msgstr "Mga Kulay"
+
+#~ msgid "Background"
+#~ msgstr "Background"
+
+#~ msgid "Primary Call To Action"
+#~ msgstr "Pangunahing Tawag sa Aksyon"
+
+#~ msgid "Link (unclicked)"
+#~ msgstr "Link (hindi nakiklik)"
+
+#~ msgid "Link (clicked)"
+#~ msgstr "Link (na-click)"
+
+#~ msgid "Pagination component"
+#~ msgstr "Komponent ng Pagsasangguni"
+
+#~ msgid "Read More component"
+#~ msgstr "Component ng Magbasa Pa"
+
+#~ msgid "Staged"
+#~ msgstr "Naka-stage"
+
+#~ msgid "Memory Status"
+#~ msgstr "Katayuan ng Memorya"
+
+#~ msgid "count"
+#~ msgstr "bilang"
+
+#~ msgid "mark"
+#~ msgstr "marka"
+
+#~ msgid "Referents"
+#~ msgstr "Referents"
+
+#~ msgid "Activation link expiring on <span class=\"time\">%(date)s.</span>"
+#~ msgstr "Activation link na mag-eexpire sa <span class=\"time\">%(date)s.</span>"
+
+#~ msgid "Activation link expired"
+#~ msgstr "Expired na ang activation link"
+
+#~ msgid "Resend activation link"
+#~ msgstr "Muling ipadala ang activation link"
+
+#~ msgid "This DAISY file is protected."
+#~ msgstr "Ang DAISY file na ito ay protektado."
+
+#~ msgid "It can only be opened on a specialized device with a key issued by the Library of Congress."
+#~ msgstr "Ito ay maaari lamang buksan sa isang espesyal na device gamit ang isang susi na inilabas ng Library of Congress."
+
+#~ msgid "The <a href=\"//archive.org\">Internet Archive</a> is proud to be distributing over 1 million books free in a format called DAIS"
+#~ msgstr "Ang <a href=\"//archive.org\">Internet Archive</a> ay ipinagmamalaki na namamahagi ng higit sa 1 milyong mga aklat nang libre sa isang format na tinatawag na DAISY."
+
+#~ msgid "There are two types of DAISYs on Open Library: <i>open</i> and <i>protected</i>. Open DAISYs can be read by anyone in the world on many different devices. Protected DAISYs like this one can only be opened using a key issued by the <a href=\"http://www.loc.gov/nls/\">Library of Congress NLS program</a>."
+#~ msgstr "Mayroong dalawang uri ng DAISYs sa Open Library: <i>bukas</i> at <i>naka-protektado</i>. Ang mga Bukas na DAISY ay maaaring basahin ng sinuman sa mundo sa maraming iba't ibang aparato. Ang mga Naka-protektadong DAISY tulad nito ay maaari lamang buksan gamit ang isang susi na ibinigay ng <a href=\"http://www.loc.gov/nls/\">Library of Congress NLS program</a>."
+
+#~ msgid "more"
+#~ msgstr "more"
+
+#~ msgid "Search facets"
+#~ msgstr "Mga facet ng paghahanap"
+
+#~ msgid "Explore Classic eBooks"
+#~ msgstr "Galugarin ang mga Klasikong eBook"
+
+#~ msgid "Explore books about %(subject)s"
+#~ msgstr "Galugarin ang mga libro tungkol sa %(subject)s"
+
+#~ msgid "Click to remove this facet"
+#~ msgstr "I-click upang alisin ang facet na ito"
 


### PR DESCRIPTION
## Summary

Syncs the tl (Tagalog/Filipino) translation file with the current \`messages.pot\` template and fills in
previously untranslated strings.

**AI attribution:** All new translations in this PR were generated by \`claude-sonnet-4-6\`. They should
be reviewed by a native speaker before merging, particularly for tone and idiomatic accuracy.
Format strings (\`%(name)s\`, \`%(count)d\`, etc.) and HTML markup were preserved verbatim.

## Changes

- Ran \`scripts/i18n-messages update tl\` to sync with current \`messages.pot\`
- Filled 112 previously untranslated msgid entries
- Fixed 8 format-string errors and 10 HTML structure errors in fuzzy entries
- Left fuzzy entries unchanged (marked for human review)

## Validation

- [x] \`i18n-messages validate tl\` — 0 errors ✓
- [x] \`test_po_files.py -k tl\` — 374 passed, 0 failures ✓
- [x] \`pre-commit run --files openlibrary/i18n/tl/messages.po\` — clean ✓

## Reviewer guidance

Please spot-check translations for:
1. Accuracy of meaning (does the translation convey the intent?)
2. Natural phrasing (does it sound like UI text, not literal translation?)
3. Preserved format strings and HTML

Native speakers: please edit the \`.po\` file directly on this branch.

🤖 Generated by \`claude-sonnet-4-6\`