### PR TITLE
i18n(sc): AI translation update — sync with messages.pot (2026-06-11)

### DIFF
--- a/openlibrary/i18n/sc/messages.po
+++ b/openlibrary/i18n/sc/messages.po
@@ -1,4 +1,4 @@
-# Translations template for Open Library.
+# Sardinian translations for Open Library.
 # Copyright (C) 2023 Internet Archive
 # This file is distributed under the same license as the Open Library
 # project.
@@ -8,20 +8,18 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Open Library VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-05-01 18:58-0400\n"
+"POT-Creation-Date: 2026-04-28 18:58-0400\n"
 "PO-Revision-Date: 2025-02-07 13:05+0100\n"
 "Last-Translator: \n"
-"Language-Team: \n"
 "Language: sc\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: \n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Generated-By: Babel 2.9.1\n"
-"X-Generator: Poedit 3.5\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.12.1\n"
 
-#: account.html account/notifications.html account/privacy.html
-#: lib/nav_head.html type/user/view.html
+#: account.html account/notifications.html account/privacy.html lib/nav_head.html type/user/view.html
 msgid "Settings"
 msgstr "Impostatziones"
 
@@ -33,14 +31,11 @@ msgstr "Impostatziones e riservadesa"
 msgid "View"
 msgstr "Pòmpia"
 
-#: account.html
+#: account.html status.html
 msgid "or"
 msgstr "o"
 
-#: account.html check_ins/check_in_prompt.html
-#: check_ins/reading_goal_progress.html databarHistory.html
-#: databarTemplate.html databarView.html subjects.html
-#: type/edition/compact_title.html type/user/view.html
+#: account.html databarHistory.html databarTemplate.html databarView.html design/popover.html my_books/check_ins/check_in_prompt.html reading_goals/reading_goal_progress.html subjects.html type/edition/compact_title.html type/user/view.html
 msgid "Edit"
 msgstr "Modìfica"
 
@@ -62,8 +57,7 @@ msgstr "Optziones de importatzione e esportatzione"
 
 #: account.html
 msgid "Manage Privacy & Content Moderation Settings"
-msgstr ""
-"Amministra sas impostatziones de riservadesa e moderatzione de cuntenutos"
+msgstr "Amministra sas impostatziones de riservadesa e moderatzione de cuntenutos"
 
 #: account.html
 msgid "Manage Notifications Settings"
@@ -102,21 +96,12 @@ msgid "New Batch Import"
 msgstr "Importatzione in lotos noa"
 
 #: batch_import.html
-msgid ""
-"Attach a JSONL formatted document with import records or copy/paste the "
-"JSONL text into the textarea."
-msgstr ""
-"Alliga unu documentu formatadu JSONL cun sos registros de importatzione o "
-"còpia/incolla su testu JSON a intro de s'àrea de testu."
+msgid "Attach a JSONL formatted document with import records or copy/paste the JSONL text into the textarea."
+msgstr "Alliga unu documentu formatadu JSONL cun sos registros de importatzione o còpia/incolla su testu JSON a intro de s'àrea de testu."
 
 #: batch_import.html
-msgid ""
-"See the <a href=\"https://github.com/internetarchive/openlibrary-client/tree/"
-"master/olclient/schemata\">olclient import schemata</a> for more."
-msgstr ""
-"Pòmpia·ti sos <a href=\"https://github.com/internetarchive/openlibrary-"
-"client/tree/master/olclient/schemata\">ischemas de importatzione de olclient "
-"</a> pro nd'ischire de prus."
+msgid "See the <a href=\"https://github.com/internetarchive/openlibrary-client/tree/master/olclient/schemata\">olclient import schemata</a> for more."
+msgstr "Pòmpia·ti sos <a href=\"https://github.com/internetarchive/openlibrary-client/tree/master/olclient/schemata\">ischemas de importatzione de olclient </a> pro nd'ischire de prus."
 
 #: batch_import.html
 msgid "Attach a file:"
@@ -126,7 +111,7 @@ msgstr "Alliga unu documentu:"
 msgid "Or copy/paste JSONL text:"
 msgstr "O còpia/incolla testu JSONL:"
 
-#: batch_import.html
+#: batch_import.html import_preview.html
 msgid "Import"
 msgstr "Importa"
 
@@ -136,17 +121,11 @@ msgstr "Importatzione fallida."
 
 #: batch_import.html
 msgid "No import will be queued until *every* record validates successfully."
-msgstr ""
-"Peruna importatzione s'at a pònnere in fila finas a cando *cada* registru no "
-"at a èssere cunvalidadu cun sutzessu."
+msgstr "Peruna importatzione s'at a pònnere in fila finas a cando *cada* registru no at a èssere cunvalidadu cun sutzessu."
 
 #: batch_import.html
-msgid ""
-"Please update the JSONL file and reload this page (there should be no need "
-"to reattach the file)."
-msgstr ""
-"Pro praghere atualiza s'archìviu JSONL e torra a carrigare custa pàgina (non "
-"bi diat dèpere èssere bisòngiu de nche torrare a alligare s'archìviu)."
+msgid "Please update the JSONL file and reload this page (there should be no need to reattach the file)."
+msgstr "Pro praghere atualiza s'archìviu JSONL e torra a carrigare custa pàgina (non bi diat dèpere èssere bisòngiu de nche torrare a alligare s'archìviu)."
 
 #: batch_import.html
 msgid "Validation errors:"
@@ -189,24 +168,19 @@ msgstr "Importatziones in lotos in isetu"
 msgid "batch_id"
 msgstr "id_lotu"
 
-#: admin/imports.html admin/imports_by_date.html batch_import_pending_view.html
-#: batch_import_view.html
+#: admin/imports.html admin/imports_by_date.html batch_import_pending_view.html batch_import_view.html
 msgid "Added Time"
 msgstr "Momentu de annanta"
 
-#: account/import.html account/loans.html admin/imports.html
-#: admin/imports_by_date.html admin/loans_table.html admin/menu.html
-#: batch_import_pending_view.html batch_import_view.html status.html
+#: account/import.html account/loans.html admin/imports.html admin/imports_by_date.html admin/loans_table.html admin/menu.html batch_import_pending_view.html batch_import_view.html librarian_dashboard/data_quality_table.html status.html
 msgid "Status"
 msgstr "Istatus"
 
-#: batch_import_pending_view.html batch_import_view.html
-#: merge_request_table/table_header.html
+#: batch_import_pending_view.html batch_import_view.html merge_request_table/table_header.html
 msgid "Submitter"
 msgstr "Imbiadore"
 
-#: RecentChangesAdmin.html batch_import_pending_view.html
-#: batch_import_view.html
+#: RecentChangesAdmin.html batch_import_pending_view.html batch_import_view.html
 msgid "Comments"
 msgstr "Cummentos"
 
@@ -246,8 +220,7 @@ msgstr "Elementos de importare"
 msgid "Import Time"
 msgstr "Tempus de importatzione"
 
-#: account/import.html admin/imports.html admin/imports_by_date.html
-#: batch_import_view.html
+#: account/import.html admin/imports.html admin/imports_by_date.html batch_import_view.html librarian_dashboard/data_quality_table.html
 msgid "Error"
 msgstr "Errore"
 
@@ -268,52 +241,384 @@ msgid "Not yet imported"
 msgstr "Galu no importadu"
 
 #: design.html
-msgid "Design Pattern Library"
-msgstr "Biblioteca de modellos de disinnu"
+#, fuzzy
+msgid "Web Component Library"
+msgstr "Bene bènnidu a s'Open Library"
+
+#: OlPagination.html OlPaginationArrows.html design.html type/edition/view.html type/work/view.html
+msgid "Pagination"
+msgstr "Impaginatzione"
 
 #: design.html
-msgid "Fonts"
-msgstr "Caràteres"
+#, fuzzy
+msgid "Popover"
+msgstr "Aprova"
+
+#: design.html type/edition/view.html type/work/view.html
+#, fuzzy
+msgid "Read More"
+msgstr "Leghe de prus"
 
 #: design.html
-msgid "Font-size"
-msgstr "Mannària de su caràtere"
+#, fuzzy
+msgid "Chip"
+msgstr "IP"
+
+#: design.html design/button.html
+#, fuzzy
+msgid "Button"
+msgstr "Nàschida"
+
+#: design.html design/toast.html
+#, fuzzy
+msgid "Toast"
+msgstr "Totale"
+
+#: design.html design/banner.html
+msgid "Banner"
+msgstr "Banner"
 
 #: design.html
-msgid "Font-family"
-msgstr "Famìlia de caràteres"
+msgid "Chip Group"
+msgstr "Chip Group"
 
 #: design.html
-msgid "Sans-serif: Verdana"
-msgstr "Sans-serif: Verdana"
+msgid "Markdown Editor"
+msgstr "Editor Markdown"
 
 #: design.html
-msgid "Serif: Georgia"
-msgstr "Serif: Georgia"
+msgid "The ol-pagination component provides support for both event-based and URL-based navigation."
+msgstr "Su cumponente ol-pagination fornit suporte pro sa navigatzione basada in eventos e in URL."
 
 #: design.html
-msgid "Colors"
-msgstr "Colores"
+#, fuzzy
+msgid "Event-based"
+msgstr "eventu"
 
 #: design.html
-msgid "Defaults"
-msgstr "Predefinidos"
+#, python-format
+msgid "When a page is clicked, the component fires an %(update_page)s event with the page number in %(event_detail)s."
+msgstr "Candu si sèlicit una pàgina, su cumponente emite un'eventu %(update_page)s cun su nùmeru de pàgina in %(event_detail)s."
 
 #: design.html
-msgid "Background"
+#, fuzzy
+msgid "Selected page:"
+msgstr "Seletziona unu ruolu"
+
+#: design.html
+msgid "URL-based Navigation"
+msgstr "Navigatzione basada in URL"
+
+#: design.html
+msgid "When base-url is provided, pagination renders anchor tags for SEO-friendly links."
+msgstr "Candu si provedint base-url, sa paginatzione renderizat tàgos àncora pro colegamentos amigàbiles a su SEO."
+
+#: design.html
+msgid "First page (no previous arrow)"
+msgstr "Prima pàgina (sena fritza precedente)"
+
+#: design.html
+msgid "Middle page (both arrows visible)"
+msgstr "Pàgina de in medas (ambas is fritzas visìbiles)"
+
+#: design.html
+msgid "Last page (no next arrow)"
+msgstr "Ùrtima pàgina (sena fritza in avantis)"
+
+#: design.html
+#, fuzzy
+msgid "3 pages"
+msgstr "Pàginas"
+
+#: design.html
+msgid "5 pages (no ellipsis needed)"
+msgstr "5 pàginas (sena puntos de suspensione)"
+
+#: design.html
+msgid "100 pages with ellipsis:"
+msgstr "100 pàginas cun puntos de suspensione:"
+
+#: design.html
+msgid "Arrows mode"
+msgstr "Modalidade fretza"
+
+#: design.html
+msgid "When total pages is unknown, use arrows mode to show only previous/next navigation."
+msgstr "Candu su nùmeru totale de pàginas est iscunotu, usa sa modalidade fretza pro amostare petzi sa navigatzione precedente/sutzessiva."
+
+#: design.html
+msgid "Arrows mode (has next page)"
+msgstr "Modalidade fretza (at pàgina sutzessiva)"
+
+#: design.html
+msgid "Arrows mode (no next page)"
+msgstr "Modalidade fretza (sena pàgina sutzessiva)"
+
+#: design.html
+msgid "Arrows mode (first page, has next)"
+msgstr "Modalidade fretza (prima pàgina, at sutzessiva)"
+
+#: design.html
+msgid "The ol-read-more component provides expandable/collapsible content with two truncation modes: height-based and line-based."
+msgstr "Su cumponente ol-read-more fornit cuntenutu espandìbile/collassàbile cun duas modalidades de truncatzione: basada in arta e basada in rìgulas."
+
+#: design.html
+msgid "Height-based truncation"
+msgstr "Truncatzione basada in arta"
+
+#: design.html
+#, python-format
+msgid "Use %(max_height)s to limit content by pixel height."
+msgstr "Usa %(max_height)s pro limitare su cuntenutu pro arta in pixels."
+
+#: design.html
+msgid "Line-based truncation"
+msgstr "Truncatzione basada in rìgulas"
+
+#: design.html
+#, python-format
+msgid "Use %(max_lines)s to limit content by number of lines."
+msgstr "Usa %(max_lines)s pro limitare su cuntenutu pro nùmeru de rìgulas."
+
+#: design.html
+msgid "Custom button text"
+msgstr "Testu de butone personalizadu"
+
+#: design.html
+#, python-format
+msgid "Use %(more_text)s and %(less_text)s to customize the toggle button labels. We'll use the i18n strings for this example."
+msgstr "Usa %(more_text)s e %(less_text)s pro personalizare is etichetas de su butone de commutare. Amus a usare is cadenas i18n pro custu esempiu."
+
+#: SearchResultsWork.html design.html
+#, fuzzy
+msgid "Show more"
+msgstr "Ammustra sas rechestas meas"
+
+#: SearchResultsWork.html design.html
+#, fuzzy
+msgid "Show less"
+msgstr "Ammustra totu sas rechestas"
+
+#: design.html
+#, fuzzy
+msgid "Custom background color"
 msgstr "Isfundu"
 
 #: design.html
-msgid "Primary Call To Action"
-msgstr "Cramada primària a s'atzione"
+#, python-format
+msgid "Use %(background_color)s to match the gradient fade to your container background."
+msgstr "Usa %(background_color)s pro fàghere currispondère su sfumadu gradiente a su fundu de su container tuo."
 
 #: design.html
-msgid "Link (unclicked)"
-msgstr "Ligàmene (no incarcadu)"
+msgid "Small label size"
+msgstr "Eticheta de tia pitzinna"
 
 #: design.html
-msgid "Link (clicked)"
-msgstr "Ligàmene (incarcadu)"
+#, python-format
+msgid "Use %(label_size)s for a smaller toggle button."
+msgstr "Usa %(label_size)s pro unu butone de commutare prus piticu."
+
+#: design.html
+msgid "Content shorter than limit (no button)"
+msgstr "Cuntenutu prus curtzu de su lìmite (sena butone)"
+
+#: design.html
+msgid "When content fits within the limit, no toggle button is shown."
+msgstr "Candu su cuntenutu si cabat intra de su lìmite, non si amostrat nissunu butone de commutare."
+
+#: design.html
+msgid "This is short content that fits within 5 lines, so no button appears."
+msgstr "Custu est unu cuntenutu curtu chi si cabit intra de 5 rìgulas, pro custu non aparit nissunu butone."
+
+#: design.html
+#, python-format
+msgid "The ol-chip component is a pill-shaped interactive element for filters, tags, and selections. It fires an %(event)s event on click."
+msgstr "Su cumponente ol-chip est unu elementu interativu a forma de pìllula pro filtros, etichetas e seletzioni. Emite un'eventu %(event)s a su click."
+
+#: design.html
+msgid "Default (medium)"
+msgstr "Predefinidu (mediu)"
+
+#: design.html
+msgid "Basic chips at the default medium size."
+msgstr "Chip bàsicos a sa tia media predefinida."
+
+#: design.html
+#, fuzzy
+msgid "Fiction"
+msgstr "Editzione"
+
+#: design.html openlibrary/plugins/openlibrary/home.py
+#, fuzzy
+msgid "Science"
+msgstr "Annulla"
+
+#: databarDiff.html databarEdit.html databarTemplate.html databarView.html design.html lib/history.html openlibrary/plugins/openlibrary/home.py
+msgid "History"
+msgstr "Cronologia"
+
+#: design.html
+#, fuzzy
+msgid "Selected state"
+msgstr "Seletziona unu ruolu"
+
+#: design.html
+msgid "A selected chip displays a checkmark icon and uses an active color scheme."
+msgstr "Unu chip seletzionadu mostat un'ìcona checkmark e usa uno schema de colores ativu."
+
+#: design.html
+#, fuzzy
+msgid "Small size"
+msgstr "Totu su tempus"
+
+#: design.html
+#, python-format
+msgid "Use %(size)s for a compact chip."
+msgstr "Usa %(size)s pro unu chip cumpattu."
+
+#: design.html
+msgid "Poetry"
+msgstr "Poesia"
+
+#: design.html
+#, fuzzy
+msgid "Drama"
+msgstr "Datos"
+
+#: design.html
+#, fuzzy
+msgid "Essays"
+msgstr "de mancu"
+
+#: design.html
+#, fuzzy
+msgid "With count"
+msgstr "Nùmeru de òperas"
+
+#: design.html
+#, python-format
+msgid "Use %(count)s to display a number alongside the label."
+msgstr "Usa %(count)s pro amostare unu nùmeru a costàgiu de s'eticheta."
+
+#: design.html
+#, fuzzy
+msgid "As a link"
+msgstr "Agiunghe unu ligàmene"
+
+#: design.html
+#, python-format
+msgid "When %(href)s is provided, the chip renders as an anchor tag instead of a button."
+msgstr "Candu si fornit %(href)s, su chip renderizat comente tàgo àncora in vetu de butone."
+
+#: design.html
+#, fuzzy
+msgid "Interactive toggle"
+msgstr "Logotipu de s'Internet Archive"
+
+#: design.html
+#, python-format
+msgid "Clicking a chip fires an %(event)s event. Toggle the selected state by listening to the event."
+msgstr "Fàgher click in unu chip emite un'eventu %(event)s. Commuta su status seletzionadu cun s'ascurtu de s'eventu."
+
+#: design.html
+msgid "Toggle me"
+msgstr "Commutami"
+
+#: design.html
+msgid "Toggle me too"
+msgstr "Commutami puru"
+
+#: design.html
+msgid "The ol-chip-group component is a flex-wrap container that provides consistent spacing for groups of chips."
+msgstr "Su cumponente ol-chip-group est unu container flex-wrap chi fornit unu spaziamientu uniorme pro grupos de chip."
+
+#: design.html
+msgid "Default (medium gap)"
+msgstr "Predefinidu (ispàtziu mediu)"
+
+#: design.html
+msgid "Chips are spaced with an 8px gap by default."
+msgstr "Is chip ant unu ispàtziu de 8px pro predefinitzione."
+
+#: design.html
+msgid "Small gap"
+msgstr "Ispàtziu piticu"
+
+#: design.html
+#, python-format
+msgid "Use %(gap)s for tighter spacing (4px)."
+msgstr "Usa %(gap)s pro unu ispàtziu prus strechu (4px)."
+
+#: design.html
+msgid "Large gap"
+msgstr "Ispàtziu mannu"
+
+#: design.html
+#, python-format
+msgid "Use %(gap)s for wider spacing (12px)."
+msgstr "Usa %(gap)s pro unu ispàtziu prus largu (12px)."
+
+#: design.html
+msgid "Wrapping behavior"
+msgstr "Cumportamentu de imbucaddu"
+
+#: design.html
+msgid "Chips automatically wrap to the next line when they exceed the container width."
+msgstr "Is chip si imbucant automàticaments a sa rìgula sutzessiva candu superant sa largaria de su container."
+
+#: design.html
+#, fuzzy
+msgid "Biography"
+msgstr "Gràficos"
+
+#: design.html
+msgid "With mixed chip states"
+msgstr "Cun istatòs de chip mesturaus"
+
+#: design.html
+msgid "Chip groups work with any combination of chip sizes, states, and link chips."
+msgstr "Is grupos de chip funtzionant cun qualunque cumbinatzione de tias de chip, istatòs e chip colegamientos."
+
+#: design.html
+msgid "The ol-markdown-editor component is a WYSIWYG editor built on Tiptap that outputs Markdown. It syncs its content to a hidden target textarea. A 'View source' toolbar toggle is always available so editors can drop into a raw markdown textarea when WYSIWYG round-trips are awkward."
+msgstr "Su cumponente ol-markdown-editor est unu editor WYSIWYG costruidu in Tiptap chi produet Markdown. Sincronizat su cuntenutu suo a una textarea objetivu abscùndida. Su toggle 'View source' de sa barra de is strumentus est semper disponìbile pro chi is editores podem intrare in una textarea markdown bruta candu is àndidas/redòrrios WYSIWYG sunt complicadas."
+
+#: design.html
+msgid "Basic usage"
+msgstr "Impreu bàsicu"
+
+#: design.html
+#, python-format
+msgid "Provide a %(target_id)s pointing to an existing textarea. The editor reads initial content from the textarea and syncs changes back to it."
+msgstr "Furnì unu %(target_id)s chi puntat a una textarea esistente. S'editor leghet su cuntenutu iniziale dae sa textarea e sincronizat is modìficas pagatoras a issa."
+
+#: design.html
+msgid "Mixed Markdown and HTML"
+msgstr "Markdown e HTML mesturaus"
+
+#: design.html
+#, python-format
+msgid "Add the %(attr)s attribute to expose the HTML block button in the toolbar. HTML blocks appear with a preview and an Edit button to modify the source."
+msgstr "Agiùnghe s'atributu %(attr)s pro esponer su butone de bloccu HTML in sa barra de is strumentus. Is blocos HTML aparint cun una anteprima e unu butone Modìfica pro cambiare sa fonte."
+
+#: design.html
+msgid "Code blocks and inline code"
+msgstr "Blocos de còdihe e còdihe in lìnia"
+
+#: design.html
+#, python-format
+msgid "Add the %(attr)s attribute to expose the inline code and code block buttons in the toolbar. Code support is off by default because only the wiki page renderer is guaranteed to render fenced code blocks."
+msgstr "Agiùnghe s'atributu %(attr)s pro esponer is butones de còdihe in lìnia e blocos de còdihe in sa barra de is strumentus. Su suporte de còdihe est ispentadu pro predefinitzione, porghi petzi su renderer de sa pàgina wiki est garantidu de renderizare is blocos de còdihe delimitados."
+
+#: design.html
+#, fuzzy
+msgid "Change event"
+msgstr "Càmbia"
+
+#: design.html
+#, python-format
+msgid "The editor fires an %(event)s event on every change. The raw Markdown string is available in %(detail)s."
+msgstr "S'editor emite un'eventu %(event)s a ònnia modìfica. Sa cadena Markdown bruta est disponìbile in %(detail)s."
 
 #: diff.html
 #, python-format
@@ -321,6 +626,23 @@ msgid "Diff on %s"
 msgstr "Diferèntzias cunfronta a %s"
 
 #: diff.html
+#, python-format
+msgid "Revision %d"
+msgstr "Revisione %d"
+
+#: books/check.html covers/book_cover.html diff.html jsdef/LazyWorkPreview.html
+msgid "by"
+msgstr "de"
+
+#: diff.html
+msgid "by Anonymous"
+msgstr "de Anònimu"
+
+#: diff.html
+msgid "history"
+msgstr "cronologia"
+
+#: diff.html status.html
 msgid "Added"
 msgstr "Annantu"
 
@@ -335,25 +657,6 @@ msgstr "Bogadu"
 #: diff.html
 msgid "Not changed"
 msgstr "Non modificadu"
-
-#: diff.html
-#, python-format
-msgid "Revision %d"
-msgstr "Revisione %d"
-
-#: books/check.html books/show.html covers/book_cover.html
-#: covers/book_cover_single_edition.html covers/book_cover_work.html diff.html
-#: jsdef/LazyWorkPreview.html lists/preview.html
-msgid "by"
-msgstr "de"
-
-#: diff.html
-msgid "by Anonymous"
-msgstr "de Anònimu"
-
-#: diff.html
-msgid "history"
-msgstr "cronologia"
 
 #: diff.html
 msgid "Differences"
@@ -375,8 +678,7 @@ msgstr "Annulla, e torra a in segus."
 msgid "YAML Representation:"
 msgstr "Rapresentatzione YAML:"
 
-#: BookPreview.html book_providers/direct_read_button.html
-#: books/edit/edition.html editpage.html
+#: BookPreview.html book_providers/read_button.html books/edit/edition.html editpage.html import_preview.html
 msgid "Preview"
 msgstr "Anteprima"
 
@@ -388,21 +690,15 @@ msgstr "Cronologia de sas modìficas a"
 msgid "Revision"
 msgstr "Revisione"
 
-#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
-#: admin/ip/view.html admin/people/edits.html history.html
-#: recentchanges/render.html recentchanges/updated_records.html
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html admin/ip/view.html admin/people/edits.html history.html recentchanges/render.html recentchanges/updated_records.html
 msgid "When"
 msgstr "Cando"
 
-#: RecentChanges.html admin/history.html admin/ip/view.html
-#: admin/loans_table.html admin/people/edits.html history.html
-#: recentchanges/render.html
+#: RecentChanges.html admin/history.html admin/ip/view.html admin/loans_table.html admin/people/edits.html history.html recentchanges/render.html
 msgid "Who"
 msgstr "Chie"
 
-#: RecentChanges.html RecentChangesUsers.html admin/history.html
-#: admin/ip/view.html admin/people/edits.html history.html
-#: recentchanges/render.html recentchanges/updated_records.html
+#: RecentChanges.html RecentChangesUsers.html admin/history.html admin/ip/view.html admin/people/edits.html history.html recentchanges/render.html recentchanges/updated_records.html
 msgid "Comment"
 msgstr "Cummentu"
 
@@ -431,42 +727,83 @@ msgstr "Cunfronta custa versione..."
 msgid "...to this version"
 msgstr "...cun custa versione"
 
-#: books/daisy.html history.html
-msgid "Back"
-msgstr "Antepostu"
+#: import_preview.html
+#, fuzzy
+msgid "Import Preview"
+msgstr "Tempus de importatzione"
 
-#: Pager.html Pager_loanhistory.html admin/memory/index.html history.html
-#: lib/pagination.html showmarc.html
-msgid "Next"
-msgstr "Imbeniente"
+#: import_preview.html
+#, fuzzy
+msgid "Preview Import"
+msgstr "Importatziones reghentes"
+
+#: import_preview.html
+msgid "Show Raw Import Data"
+msgstr "Amosta is Datos de Importatzione Brutos"
+
+#: import_preview.html
+#, python-format
+msgid "New %(thing_type)s record will be created"
+msgstr "Unu nou registru %(thing_type)s at a esser creadu"
+
+#: import_preview.html
+#, python-format
+msgid "Changes to %(key)s"
+msgstr "Modìficas a %(key)s"
 
 #: internalerror.html
 msgid "Internal Error"
 msgstr "Errore internu"
 
 #: internalerror.html
-msgid "Hmm..."
-msgstr "Hmm..."
+msgid "A Problem Occurred"
+msgstr "Est capitadu unu Problema"
 
 #: internalerror.html
-msgid "Sorry. There seems to be a problem with what you were just looking at."
-msgstr "Paret chi bi siat carchi problema cun su chi fias abbistende."
+msgid "We're sorry, a problem occurred while responding to your request:"
+msgstr "Si cundolèmus, est capitadu unu problema mentras si rispondiat a sa dumanda tua:"
 
 #: internalerror.html
 #, python-format
-msgid ""
-"We've noted the error %s and will look into it as soon as possible. Head for "
-"<a href=\"/\">home</a>?"
-msgstr ""
-"Amus notadu s'errore %s e nos nd'amus a ocupare cantu prus luego s'at a "
-"pòdere. Boles torrare a sa <a href=\"/\">pàgina printzipale</a>?"
+msgid "The reference code %s and Sentry trace ID %s have been created to track this error and we will investigate as we're able."
+msgstr "Su còdihe de referèntzia %s e s'ID de trace Sentry %s ant essidu pro monitorare custu erore e amus a investigare a pustis chi podèmus."
+
+#: internalerror.html
+#, python-format
+msgid "The reference code %s has been created to track this error and we will investigate as we're able."
+msgstr "Su còdihe de referèntzia %s est essidu pro monitorare custu erore e amus a investigare a pustis chi podèmus."
+
+#: internalerror.html
+msgid "Return to the <a class=\"go-back-link\" href=\"javascript:;\">previous page</a>?"
+msgstr "Torrare a sa <a class=\"go-back-link\" href=\"javascript:;\">pàgina precedente</a>?"
+
+#: interstitial.html
+msgid "You are being redirected to your book"
+msgstr "Ses essende rediriggidu a su libru tuo"
+
+#: interstitial.html
+#, python-format
+msgid "This book is provided by %(book_provider)s, a third-party Open Library Trusted Book Provider"
+msgstr "Custu libru est fornidu dae %(book_provider)s, un'erogatzione de libros fidada de partzis tertziarias de Open Library"
+
+#: interstitial.html
+#, python-format
+msgid "In %(time)s seconds, you will be automatically redirected to: %(url)s"
+msgstr "In %(time)s segundos, serès automàticaments rediriggidu a: %(url)s"
+
+#: CreateListModal.html EditButtons.html account/notifications.html account/password/reset.html account/privacy.html admin/imports-add.html admin/permissions.html books/add.html databarEdit.html design/button.html interstitial.html merge/authors.html my_books/dropdown_content.html type/list/edit.html type/series/edit.html type/tag/form.html
+msgid "Cancel"
+msgstr "Annulla"
+
+#: interstitial.html
+msgid "Continue without waiting"
+msgstr "Continua sena istetìre"
 
 #: lib/nav_head.html library_explorer.html
 msgid "Library Explorer"
 msgstr "Esploradore de sa biblioteca"
 
-#: account/create.html books/custom_carousel.html login.html
-#: search/work_search_facets.html
+#: account/create.html books/custom_carousel.html librarian_dashboard/data_quality_table.html login.html search/work_search_facets.html
 msgid "Loading..."
 msgstr "Carrighende..."
 
@@ -475,12 +812,8 @@ msgid "Log In"
 msgstr "Intra"
 
 #: login.html
-msgid ""
-"This is a development instance, the default credentials are automatically "
-"filled."
-msgstr ""
-"Custa est un'istàntzia de isvilupu, sas credentziales predefinidas benint "
-"insertadas in manera automàtica."
+msgid "This is a development instance, the default credentials are automatically filled."
+msgstr "Custa est un'istàntzia de isvilupu, sas credentziales predefinidas benint insertadas in manera automàtica."
 
 #: login.html
 msgid "email:"
@@ -491,13 +824,8 @@ msgid "password:"
 msgstr "crae:"
 
 #: login.html
-msgid ""
-"Log in to use your free Open Library card to borrow digital books from the "
-"nonprofit Internet Archive"
-msgstr ""
-"Intra pro impreare sa carta de badas tua de s'Open Library pro pigare in "
-"prèstidu libros digitales dae s'assòtziu chene punnas de lucru Internet "
-"Archive"
+msgid "Log in to use your free Open Library card to borrow digital books from the nonprofit Internet Archive"
+msgstr "Intra pro impreare sa carta de badas tua de s'Open Library pro pigare in prèstidu libros digitales dae s'assòtziu chene punnas de lucru Internet Archive"
 
 #: account/create.html login.html
 msgid "OR"
@@ -509,26 +837,14 @@ msgid "You are already logged into Open Library as %(user)s."
 msgstr "Ses giai intradu in s'Open Library comente %(user)s."
 
 #: account/create.html login.html
-msgid ""
-"If you'd like to create a new, different Open Library account, you'll need "
-"to <a href=\"javascript:;\" onclick=\"document.forms['hamburger-logout']."
-"submit()\">log out</a> and start the signup process afresh."
-msgstr ""
-"Si boles creare unu contu nou, diferente pro s'Open Library, depes <a "
-"href=\"javascript:;\" onclick=\"document.forms['hamburger-logout']."
-"submit()\">essire</a> e torrare a incumintzare su protzessu de "
-"registratzione dae nou."
+msgid "If you'd like to create a new, different Open Library account, you'll need to <a href=\"javascript:;\" onclick=\"document.forms['hamburger-logout'].submit()\">log out</a> and start the signup process afresh."
+msgstr "Si boles creare unu contu nou, diferente pro s'Open Library, depes <a href=\"javascript:;\" onclick=\"document.forms['hamburger-logout'].submit()\">essire</a> e torrare a incumintzare su protzessu de registratzione dae nou."
 
 #: login.html
-msgid ""
-"Please enter your <a href=\"https://archive.org\">Internet Archive</a> email "
-"and password to access your Open Library account."
-msgstr ""
-"Pro praghere inserta s'indiritzu de posta eletrònica tuo e sa crae de "
-"intrada tua de s'<a href=\"https://archive.org\">Internet Archive</a> pro "
-"intrare in su contu tuo de s'Open Library."
+msgid "Please enter your <a href=\"https://archive.org\">Internet Archive</a> email and password to access your Open Library account."
+msgstr "Pro praghere inserta s'indiritzu de posta eletrònica tuo e sa crae de intrada tua de s'<a href=\"https://archive.org\">Internet Archive</a> pro intrare in su contu tuo de s'Open Library."
 
-#: forms.py login.html
+#: login.html openlibrary/plugins/upstream/forms.py
 msgid "Email"
 msgstr "Indiritzu de posta eletrònica"
 
@@ -536,7 +852,7 @@ msgstr "Indiritzu de posta eletrònica"
 msgid "Forgot your Internet Archive email?"
 msgstr "As ismentigadu s'indiritzu de posta tuo pro s'Internet Archive?"
 
-#: account/email/forgot-ia.html forms.py login.html
+#: account/email/forgot-ia.html login.html openlibrary/plugins/upstream/forms.py
 msgid "Password"
 msgstr "Crae"
 
@@ -573,26 +889,11 @@ msgid "Added new book."
 msgstr "Libru nou annantu."
 
 #: messages.html
-msgid "Thank you very much for adding that new book!"
-msgstr "Gràtzias medas pro àere annantu cussu libru nou!"
-
-#: messages.html
-msgid "Thank you very much for improving that record!"
+#, fuzzy
+msgid "Thank you for improving the Open Library catalog!"
 msgstr "Gràtzias medas pro àere megioradu cussu registru!"
 
-#: BookPreview.html CreateListModal.html DonateModal.html NotesModal.html
-#: ObservationsModal.html ShareModal.html
-#: book_providers/cita_press_read_button.html
-#: book_providers/direct_read_button.html
-#: book_providers/gutenberg_read_button.html
-#: book_providers/librivox_read_button.html
-#: book_providers/openstax_read_button.html
-#: book_providers/runeberg_read_button.html
-#: book_providers/standard_ebooks_read_button.html
-#: book_providers/wikisource_read_button.html covers/author_photo.html
-#: covers/book_cover.html covers/book_cover_single_edition.html
-#: covers/book_cover_work.html covers/change.html lib/history.html
-#: my_books/dropdown_content.html native_dialog.html
+#: BookPreview.html CreateListModal.html NotesModal.html ObservationsModal.html ShareModal.html covers/author_photo.html covers/book_cover.html covers/change.html design/banner.html design/toast.html lib/exports.html my_books/check_ins/check_in_prompt.html my_books/dropdown_content.html native_dialog.html
 msgid "Close"
 msgstr "Serra"
 
@@ -644,22 +945,14 @@ msgid "Permission denied."
 msgstr "Permissu negadu."
 
 #: permission_denied.html
-msgid ""
-"Only logged users are allowed to add records on Open Library. Please <a "
-"href=\"/account/login?redirect=$path\">log in</a> to add a book."
+#, fuzzy, python-format
+msgid "Only logged users are allowed to add records on Open Library. Please <a href=\"%s\">log in</a> to add a book."
 msgstr ""
-"Petzi sos utentes chi ant fatu atzessu podent agiùnghere registros a s'Open "
-"Library. Pro praghere <a href=\"/account/login?redirect=$path\">intra</a> "
-"pro agiùnghere unu libru."
 
 #: permission_denied.html
-msgid ""
-"Only logged users are allowed to modify records on Open Library. Please <a "
-"href=\"/account/login?redirect=$path\">log in</a> to edit this page."
+#, fuzzy, python-format
+msgid "Only logged users are allowed to modify records on Open Library. Please <a href=\"%s\">log in</a> to edit this page."
 msgstr ""
-"Petzi sos utentes chi ant fatu atzessu podent modificare registros in s'Open "
-"Library. Pro praghere <a href=\"/account/login?redirect=$path\">intra</a> "
-"pro modificare custa pàgina."
 
 #: permission_denied.html
 #, python-format
@@ -667,12 +960,8 @@ msgid "You may <a href=\"%s\">log in</a> if you have the required permissions."
 msgstr "Podes <a href=\"%s\">intrare</a> si tenes sos permissos netzessàrios."
 
 #: recaptcha.html
-msgid ""
-"Please satisfy the reCAPTCHA below. If you have security settings or privacy "
-"blockers installed, please disable them to see the reCAPTCHA."
-msgstr ""
-"Pro praghere risolve su reCAPTCHA inoghe in suta. Si tenes impostatziones de "
-"seguresa o blocadores de riservadesa istuda·los pro bìdere su reCAPTCHA."
+msgid "Please satisfy the reCAPTCHA below. If you have security settings or privacy blockers installed, please disable them to see the reCAPTCHA."
+msgstr "Pro praghere risolve su reCAPTCHA inoghe in suta. Si tenes impostatziones de seguresa o blocadores de riservadesa istuda·los pro bìdere su reCAPTCHA."
 
 #: recaptcha.html
 msgid "Incorrect. Please try again."
@@ -694,7 +983,7 @@ msgstr "ID de registru"
 msgid "Source"
 msgstr "Orìgine"
 
-#: books/add.html showia.html type/edition/view.html type/work/view.html
+#: books/add.html covers/add.html showia.html type/edition/view.html type/work/view.html
 msgid "Internet Archive"
 msgstr "Internet Archive"
 
@@ -718,6 +1007,10 @@ msgstr "DIRETORE:"
 msgid "Download Link"
 msgstr "Ligàmene de iscarrigamentu"
 
+#: showmarc.html type/tag/index.html
+msgid "Next"
+msgstr "Imbeniente"
+
 #: status.html
 msgid "Open Library server status"
 msgstr "Istadu de su serbidore de Open Library"
@@ -727,25 +1020,147 @@ msgid "Server status"
 msgstr "Istadu de su serbidore"
 
 #: status.html
+msgid "Testing Environment"
+msgstr "Ambienti de Testing"
+
+#: status.html
+msgid "Deploy triggered!"
+msgstr "Deploy trigerradu!"
+
+#: status.html
+#, fuzzy
+msgid "View Jenkins progress"
+msgstr "In progressu..."
+
+#: status.html
+msgid "GitHub status refreshed."
+msgstr "Status GitHub agiornadu."
+
+#: status.html
+msgid "PR numbers or URLs, space/comma separated"
+msgstr "Nùmeros de PR o URLs, separados cun ispatzu/coma"
+
+#: status.html
+msgid "Add PR(s)"
+msgstr "Agiùnghe PR(s)"
+
+#: status.html
+#, fuzzy
+msgid "PR"
+msgstr "Pretzedente"
+
+#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html search/advancedsearch.html status.html type/about/edit.html type/page/edit.html type/template/edit.html
+msgid "Title"
+msgstr "Tìtulu"
+
+#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html openlibrary/plugins/worksearch/code.py search/advancedsearch.html search/work_search_selected_facets.html status.html
+msgid "Author"
+msgstr "Autore"
+
+#: status.html
+msgid "Assignee"
+msgstr "Assigantau/da"
+
+#: status.html
+#, fuzzy
+msgid "Pinned Commit"
+msgstr "Cummentu de s'amministratzione"
+
+#: status.html
+#, fuzzy
+msgid "Branch HEAD"
+msgstr "ID de su lotu:"
+
+#: status.html
+#, fuzzy
+msgid "Drift"
+msgstr "modìfica"
+
+#: status.html
+#, fuzzy
+msgid "Enabled"
+msgstr "Incorporadu"
+
+#: status.html
+#, fuzzy
+msgid "up to date"
+msgstr "Atualiza"
+
+#: status.html
+#, fuzzy
+msgid "unknown"
+msgstr "Nùmene disconnotu"
+
+#: status.html
+msgid "1 commit behind"
+msgstr "1 commit atràsu"
+
+#: status.html
+#, fuzzy, python-format
+msgid "%(count)s commits behind"
+msgstr "%(count)s editzione"
+
+#: admin/solr.html status.html
+msgid "Update"
+msgstr "Atualiza"
+
+#: status.html
+#, fuzzy
+msgid "Enable"
+msgstr "Esèmpiu"
+
+#: status.html
+#, fuzzy
+msgid "Disable"
+msgstr "Imprenta disabilitada"
+
+#: lists/lists.html status.html type/list/edit.html type/series/edit.html
+msgid "Remove"
+msgstr "Boga"
+
+#: status.html
+#, fuzzy
+msgid "Selected PRs"
+msgstr "Seletziona unu ruolu"
+
+#: status.html
+#, fuzzy
+msgid "Refresh"
+msgstr "Referentes"
+
+#: status.html
+#, fuzzy
+msgid "Deploy"
+msgstr "Risposta"
+
+#: status.html
+msgid "No PRs in testing set."
+msgstr "Sena PRs in s'inseme de testing."
+
+#: status.html
+msgid "Last Build Result"
+msgstr "Ùrtimu Risultadu de Build"
+
+#: status.html
+#, fuzzy
+msgid "View PRs on GitHub"
+msgstr "abbista su profilu"
+
+#: status.html
+msgid "Show changed files"
+msgstr "Mustra sos archìvios mudados"
+
+#: admin/inspect/store.html admin/people/index.html status.html type/author/edit.html type/language/view.html
+msgid "Name"
+msgstr "Nùmene"
+
+#: status.html
 msgid "System information"
 msgstr "Informatziones de sistema"
 
 #: status.html
 msgid "Features enabled"
 msgstr "Funtzionalidades abilitadas"
-
-#: status.html
-msgid "Staged"
-msgstr "In programma"
-
-#: status.html
-msgid "Show changed files"
-msgstr "Mustra sos archìvios mudados"
-
-#: admin/inspect/store.html admin/people/index.html status.html
-#: type/author/edit.html type/language/view.html
-msgid "Name"
-msgstr "Nùmene"
 
 #: subjects.html
 msgid "Edit tag for this subject"
@@ -775,90 +1190,11 @@ msgstr "Chirca libros cun argumentu %(name)s."
 msgid "Disambiguations"
 msgstr "Disambiguatziones"
 
-#: support.html
-msgid "How can we help?"
-msgstr "Comente podimus agiudare?"
-
-#: support.html
-msgid ""
-"Your question has been sent to our support team. We'll get back to you "
-"shortly. You can also <a href=\"https://twitter.com/openlibrary\">contact us "
-"on Twitter</a>."
-msgstr ""
-"As imbiadu sa dimanda tua a s'iscuadra de suportu nostra. T'amus a torrare "
-"risposta luego. Nos podes fintzas <a href=\"https://twitter.com/"
-"openlibrary\">chircare in Twitter</a>."
-
-#: support.html
-msgid ""
-"Please check our <a href=\"/help/\">Help Pages</a> and <a href=\"/help/"
-"faq\">Frequently Asked Questions</a> (FAQ) to see if your question is "
-"answered there. Thank you."
-msgstr ""
-"Pro praghere abbista·ti sas <a href=\"/help/\">Pàginas de agiudu</a> e sas "
-"<a href=\"/help/faq\">Preguntas fitianas</a> (PF/FAQ) nostras pro bìdere si "
-"sa dimanda tua tenet giai una risposta in cue. Gràtzias."
-
-#: support.html
-msgid "Your Name"
-msgstr "Su nùmene tuo"
-
-#: support.html
-msgid "Your Email Address"
-msgstr "S'indiritzu de posta eletrònica tuo"
-
-#: support.html
-msgid "We'll need this if you want a reply"
-msgstr "Amus a bisongiare de custu si boles una risposta"
-
-#: support.html
-msgid ""
-"If you wish to be contacted by other means, please add your contact "
-"preference and details to your question."
-msgstr ""
-"Si boles a ti cuntatare in carchi àtera manera annanghe sa preferèntzia tua "
-"e sos detàllios tuos de cuntatu a sa dimanda tua."
-
-#: lib/nav_head.html search/advancedsearch.html support.html
-msgid "Subject"
-msgstr "Argumentu"
-
-#: support.html
-msgid "Your Question"
-msgstr "Sa dimanda tua"
-
-#: support.html
-msgid "Note: our staff will likely only be able respond in English."
-msgstr ""
-"Tene in contu: s'iscuadra nostra t'at a pòdere torrare risposta petzi in "
-"inglesu."
-
-#: support.html
-msgid ""
-"If you encounter an error message, please include it. For questions about "
-"our books, please provide the title/author or Open Library ID."
-msgstr ""
-"Si atzapas unu messàgiu de errore pro praghere include·lu. Pro dimandas "
-"subra de sos libros nostros iscrie·nos su tìtulu/autore o s'ID de Open "
-"Library."
-
-#: support.html
-msgid "Send"
-msgstr "Imbia"
-
-#: CreateListModal.html EditButtons.html account/notifications.html
-#: account/password/reset.html account/privacy.html admin/imports-add.html
-#: admin/permissions.html books/add.html databarEdit.html merge/authors.html
-#: my_books/dropdown_content.html support.html type/tag/form.html
-msgid "Cancel"
-msgstr "Annulla"
-
 #: trending.html
 msgid "Now"
 msgstr "Como"
 
-#: admin/graphs.html admin/index.html check_ins/check_in_form.html
-#: check_ins/check_in_prompt.html trending.html
+#: admin/graphs.html admin/index.html my_books/check_ins/check_in_form.html my_books/check_ins/check_in_prompt.html trending.html
 msgid "Today"
 msgstr "Oe"
 
@@ -874,49 +1210,50 @@ msgstr "Custu mese"
 msgid "This Year"
 msgstr "Cust'annu"
 
-#: account/view.html admin/index.html books/year_breadcrumb_select.html
-#: trending.html
+#: admin/index.html books/year_breadcrumb_select.html trending.html
 msgid "All Time"
 msgstr "Semper"
 
-#: home/index.html trending.html
+#: home/index.html openlibrary/plugins/openlibrary/api.py trending.html
 msgid "Trending Books"
 msgstr "Libros de tendèntzia"
 
 #: trending.html
 msgid "See what readers from the community are adding to their bookshelves"
-msgstr ""
-"Abbista ite sos letores de sa comunidade sunt annanghende a sos iscafales "
-"issoro"
+msgstr "Abbista ite sos letores de sa comunidade sunt annanghende a sos iscafales issoro"
 
 #: trending.html
 msgid "Earliest trending data is from October 2017"
-msgstr ""
-"Sos primos datos subra de sas tendèntzias sunt de su santugaine de su 2017"
+msgstr "Sos primos datos subra de sas tendèntzias sunt de su santugaine de su 2017"
 
-#: account/mybooks.html account/sidebar.html my_books/dropdown_content.html
-#: my_books/primary_action.html search/sort_options.html trending.html
+#. Label for the reading log shelf for books the user plans to read in the
+#. future (bookshelf ID 1). Used as a button label and shelf name.
+#: account/mybooks.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html trending.html
 msgid "Want to Read"
 msgstr "Chèrgio lèghere"
 
-#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
-#: my_books/dropdown_content.html my_books/primary_action.html
-#: search/sort_options.html trending.html
+#. Display name for the "currently-reading" reading log shelf used in page
+#. headings and breadcrumbs.
+#. Label for the reading log shelf for books the user is actively reading
+#. (bookshelf ID 2). Used as a button label and shelf name.
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html trending.html
 msgid "Currently Reading"
 msgstr "So leghende"
 
-#: LoanReadForm.html ReadButton.html admin/inspect/memcache.html
-#: book_providers/cita_press_read_button.html
-#: book_providers/direct_read_button.html
-#: book_providers/gutenberg_read_button.html
-#: book_providers/openstax_read_button.html
-#: book_providers/runeberg_read_button.html
-#: book_providers/standard_ebooks_read_button.html
-#: book_providers/wikisource_read_button.html books/custom_carousel.html
-#: books/edit/edition.html books/show.html books/works-show.html trending.html
-#: type/list/embed.html widget.html
+#: LoanReadForm.html ReadButton.html admin/inspect/memcache.html book_providers/read_button.html books/edit/edition.html trending.html type/list/embed.html widget.html
 msgid "Read"
 msgstr "Leghe"
+
+#. Display name for the "stopped-reading" reading log shelf used in page
+#. headings and breadcrumbs.
+#. Label for the reading log shelf for books the user stopped reading before
+#. finishing (bookshelf ID 4). Used as a button label and shelf name.
+#. Label for the reading log shelf for books the user stopped reading
+#. (bookshelf ID 4). Used as a button label and shelf name.
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html trending.html
+#, fuzzy
+msgid "Stopped Reading"
+msgstr "De tendèntzia"
 
 #: trending.html
 #, python-format
@@ -927,6 +1264,29 @@ msgstr "Calicunu l'at marcadu comente %(shelf)s %(k_hours_ago)s"
 #, python-format
 msgid "Logged %(count)i times %(time_unit)s"
 msgstr "Atzessu fatu %(count)i bortas %(time_unit)s"
+
+#: verify_human.html
+#, fuzzy
+msgid "Human Verification"
+msgstr "Verìfica de s'indiritzu de posta fallida"
+
+#: verify_human.html
+msgid "Please verify you are human to continue."
+msgstr "Pro praghere, cunfirma de esser unu umanu pro continuare."
+
+#: verify_human.html
+msgid "Verify you are human"
+msgstr "Cunfirma de esser unu umanu"
+
+#: verify_human.html
+#, fuzzy
+msgid "Verification failed. Please try again."
+msgstr "Crae isballiada. Torra a proare"
+
+#: verify_human.html
+#, fuzzy
+msgid "Verifying..."
+msgstr "Modifichende..."
 
 #: viewpage.html
 msgid "Revert to this revision?"
@@ -946,8 +1306,7 @@ msgstr "Leghe \"%(title)s\""
 msgid "Borrow \"%(title)s\""
 msgstr "Piga in prèstidu \"%(title)s\""
 
-#: ReadButton.html books/custom_carousel.html books/edit/edition.html
-#: type/list/embed.html widget.html
+#: ReadButton.html books/edit/edition.html type/list/embed.html widget.html
 msgid "Borrow"
 msgstr "Piga in prèstidu"
 
@@ -956,7 +1315,7 @@ msgstr "Piga in prèstidu"
 msgid "Join waitlist for \"%(title)s\""
 msgstr "Auni·ti a sa lista de isetu pro \"%(title)s\""
 
-#: LoanStatus.html books/custom_carousel.html widget.html
+#: LoanStatus.html widget.html
 msgid "Join Waitlist"
 msgstr "Auni·ti a sa lista de isetu"
 
@@ -965,14 +1324,14 @@ msgstr "Auni·ti a sa lista de isetu"
 msgid "Learn more about \"%(title)s\" at OpenLibrary"
 msgstr "Impara de prus subra de \"%(title)s\" in s'OpenLibrary"
 
-#: check_ins/reading_goal_form.html widget.html
+#: reading_goals/reading_goal_form.html widget.html
 msgid "Learn More"
 msgstr "Impara de prus"
 
 #: widget.html
-#, python-format
-msgid "on <a target=\"_blank\" href=\"%(link)s\">openlibrary.org</a>"
-msgstr "subra de <a target=\"_blank\" href=\"%(link)s\">openlibrary.org</a>"
+#, fuzzy, python-format
+msgid "on <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"%(link)s\">openlibrary.org</a>"
+msgstr ""
 
 #: work_search.html
 msgid "Search Books"
@@ -991,10 +1350,6 @@ msgid "Ebooks"
 msgstr "Libros eletrònicos"
 
 #: work_search.html
-msgid "Print Disabled"
-msgstr "Imprenta disabilitada"
-
-#: work_search.html
 msgid "This is only visible to super librarians."
 msgstr "Visìbile petzi pro sos superbibliotecàrios."
 
@@ -1003,11 +1358,23 @@ msgid "Solr Editions"
 msgstr "Editziones Solr"
 
 #: work_search.html
+#, fuzzy
+msgid "The search engine returned an error."
+msgstr "PUH! ERRORE de su motore de chirca!"
+
+#: work_search.html
+#, fuzzy
+msgid "Solr Debugging:"
+msgstr "Amministradore Solr"
+
+#: work_search.html
+msgid "Full URL:"
+msgstr "URL cumpleta:"
+
+#: work_search.html
 #, python-format
 msgid "No <strong>%(path_id)s</strong> directly matched your search."
-msgstr ""
-"Non b'at àpidu <strong>%(path_id)s</strong> cun una currispondèntzia direta "
-"cun sa chirca tua."
+msgstr "Non b'at àpidu <strong>%(path_id)s</strong> cun una currispondèntzia direta cun sa chirca tua."
 
 #: work_search.html
 msgid "Add a new book?"
@@ -1017,17 +1384,12 @@ msgstr "Annànghere unu libru nou?"
 msgid "Checking Search Inside matches"
 msgstr "Verifichende sas currispondèntzias cun sa Chirca a intro"
 
-#: account/reading_log.html search/authors.html search/subjects.html
-#: work_search.html
+#: account/reading_log.html search/authors.html search/lists.html search/subjects.html work_search.html
 #, python-format
 msgid "%(count)s hit"
 msgid_plural "%(count)s hits"
 msgstr[0] "%(count)s resurtadu"
 msgstr[1] "%(count)s resurtados"
-
-#: work_search.html
-msgid "BARF! Search engine ERROR!"
-msgstr "PUH! ERRORE de su motore de chirca!"
 
 #: work_search.html
 #, python-format
@@ -1039,12 +1401,8 @@ msgid "The Open Library Team"
 msgstr "S'iscuadra de Open Library"
 
 #: about/index.html
-msgid ""
-"Open Library is made possible because of a dedicated team of staff and over "
-"100 volunteers from around the globe."
-msgstr ""
-"S'Open Library est possìbile gràtzias a unu grupu de personale dedicadu e a "
-"prus de 100 voluntàrios de totu su mundu."
+msgid "Open Library is made possible because of a dedicated team of staff and over 100 volunteers from around the globe."
+msgstr "S'Open Library est possìbile gràtzias a unu grupu de personale dedicadu e a prus de 100 voluntàrios de totu su mundu."
 
 #: about/index.html
 msgid "Want to join us?"
@@ -1054,7 +1412,7 @@ msgstr "Ti boles aunire a nois?"
 msgid "Role:"
 msgstr "Ruolu:"
 
-#: about/index.html lib/nav_head.html
+#: about/index.html lib/nav_head.html type/tag/index.html
 msgid "All"
 msgstr "Totu"
 
@@ -1091,27 +1449,24 @@ msgid "Librarianship"
 msgstr "Biblioteconomia"
 
 #: about/index.html
-msgid ""
-"If you volunteer with Open Library and would like to be listed as part of "
-"the team, then complete the <a href=\"https://forms.gle/"
-"zPyuXGf4Bg6RzbDA7\">Open Library team information form</a>."
-msgstr ""
-"Si faghes voluntariadu cun s'Open Library e ti dias bòlere allistadu comente "
-"parte de s'iscuàdra, cumpila su <a href=\"https://forms.gle/"
-"zPyuXGf4Bg6RzbDA7\">mòdulu de informatziones de s'iscuàdra de Open Library</"
-"a>."
+msgid "If you volunteer with Open Library and would like to be listed as part of the team, then complete the <a href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">Open Library team information form</a>."
+msgstr "Si faghes voluntariadu cun s'Open Library e ti dias bòlere allistadu comente parte de s'iscuàdra, cumpila su <a href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">mòdulu de informatziones de s'iscuàdra de Open Library</a>."
 
-#: account/create.html forms.py
+#: account/create.html openlibrary/plugins/upstream/forms.py
 msgid "Must be a valid email address"
 msgstr "Depet èssere un'indiritzu de posta eletrònica vàlidu"
 
-#: account/create.html forms.py
+#: account/create.html openlibrary/plugins/upstream/forms.py
 msgid "Must be between 3 and 20 characters"
 msgstr "Depet tènnere intre 3 e 20 caràteres"
 
 #: account/create.html
 msgid "Username may only contain numbers, letters, - or _"
 msgstr "Su nùmene utente podet cuntènnere petzi nùmeros, lìteras, - o _"
+
+#: account/create.html
+msgid "A qualifying program must be selected"
+msgstr "Devet esser seletzionadu unu programma qualificadu"
 
 #: account/create.html
 msgid "Sign Up to Open Library"
@@ -1122,12 +1477,8 @@ msgid "Sign Up"
 msgstr "Registra·ti"
 
 #: account/create.html
-msgid ""
-"Get your free Open Library card and borrow digital books from the nonprofit "
-"Internet Archive"
-msgstr ""
-"Otene sa carta tua a indonu de s'Open Library e piga in prèstidu libros "
-"digitales dae s'assòtziu chene punna de lucru Internet Archive"
+msgid "Get your free Open Library card and borrow digital books from the nonprofit Internet Archive"
+msgstr "Otene sa carta tua a indonu de s'Open Library e piga in prèstidu libros digitales dae s'assòtziu chene punna de lucru Internet Archive"
 
 #: account/create.html type/author/view.html
 msgid "Success!"
@@ -1142,18 +1493,29 @@ msgid "screenname"
 msgstr "nùmene mustradu"
 
 #: account/create.html
+msgid "I want to receive news, announcements, and resources from the <a href=\"https://archive.org/\">Internet Archive</a>, the non-profit that runs Open Library."
+msgstr "Bògio retzire novas, annùntzios, e resursas dae s'<a href=\"https://archive.org/\">Internet Archive</a>, s'assòtziu chene punna de logru chi manìgiat s'Open Library."
+
+#: account/create.html
+msgid "I want to apply* for <a href=\"https://help.archive.org/help/program-overview/\" target=\"_blank\" rel=\"noopener noreferrer\">special print disability access</a> through a qualifying program."
+msgstr "Chèrgio applichessì* pro <a href=\"https://help.archive.org/help/program-overview/\" target=\"_blank\" rel=\"noopener noreferrer\">s'atzessu ispetziale pro incapatzidade de impressione</a> a travers de unu programma qualificadu."
+
+#: account/create.html
+msgid "Select qualifying program"
+msgstr "Sèligi programma qualificadu"
+
+#: account/create.html
+msgid "* Please use the email address associated with this qualifying program. You will receive an email after activation with next steps."
+msgstr "* Pro praghere usa s'indiritzu de posta eletrònica assotziadu a custu programma qualificadu. Recibirès un'email a pustis de s'ativatzione cun is passos sutzessivos."
+
+#: account/create.html
 msgid "Sign Up with Email"
 msgstr "Registra·ti cun sa posta eletrònica"
 
 #: account/create.html
-msgid ""
-"By signing up, you agree to the Internet Archive's <a class=\"ol-signup-"
-"form__link\" href=\"//archive.org/about/terms.php\" target=\"_blank\">Terms "
-"of Service</a>."
+#, fuzzy
+msgid "By signing up, you agree to the Internet Archive's <a class=\"ol-signup-form__link\" href=\"//archive.org/about/terms.php\" target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
 msgstr ""
-"Registrende·ti, atzetas sas <a class=\"ol-signup-form__link\" href=\"//"
-"archive.org/about/terms.php\" target=\"_blank\">Cunditziones de Impreu</a> "
-"de s'Internet Archive."
 
 #: account/create.html
 msgid "Already have an account? <a href=\"/account/login\">Log in</a>"
@@ -1176,18 +1538,12 @@ msgid "Import from Goodreads"
 msgstr "Importa dae Goodreads"
 
 #: account/import.html
-msgid ""
-"For instructions on exporting data refer to: <a href=\"https://www.goodreads."
-"com/review/import\">Goodreads Import/Export</a>"
-msgstr ""
-"Pro inditos subra de esportatzione de datos pòmpia·ti: <a href=\"https://www."
-"goodreads.com/review/import\">Importatziones/Esportatziones de Goodreads</a>"
+msgid "For instructions on exporting data refer to: <a href=\"https://www.goodreads.com/review/import\">Goodreads Import/Export</a>"
+msgstr "Pro inditos subra de esportatzione de datos pòmpia·ti: <a href=\"https://www.goodreads.com/review/import\">Importatziones/Esportatziones de Goodreads</a>"
 
 #: account/import.html
 msgid "File size limit 10MB and .csv file type only"
-msgstr ""
-"Sa mannària màssima de sos documentos est de 10MB e est cunsentidu su "
-"formadu .csv ebbia"
+msgstr "Sa mannària màssima de sos documentos est de 10MB e est cunsentidu su formadu .csv ebbia"
 
 #: account/import.html
 msgid "Load Books"
@@ -1202,8 +1558,9 @@ msgid "Download a copy of your reading log."
 msgstr "Iscàrriga una còpia de su registru de letura tuo."
 
 #: account/import.html
-msgid "What is this?"
-msgstr "Ite est custu?"
+#, fuzzy
+msgid "What is a reading log?"
+msgstr "Registru de letura"
 
 #: account/import.html
 msgid "Download (.csv format)"
@@ -1328,16 +1685,10 @@ msgid "Leave the Waiting List"
 msgstr "Lassa sa lista de isetu"
 
 #: account/loans.html
-msgid ""
-"Are you sure you want to leave the waiting list of<br/><strong>TITLE</"
-"strong>?"
-msgstr ""
-"Ses seguru de bòlere lassare sa lista de isetu pro<br/><strong>TITLE</"
-"strong>?"
+msgid "Are you sure you want to leave the waiting list of<br/><strong>TITLE</strong>?"
+msgstr "Ses seguru de bòlere lassare sa lista de isetu pro<br/><strong>TITLE</strong>?"
 
-#: ProlificAuthors.html account/loans.html authors/index.html
-#: lists/showcase.html publishers/view.html search/authors.html
-#: search/publishers.html search/subjects.html
+#: ProlificAuthors.html account/loans.html authors/index.html lists/list_follow.html lists/showcase.html publishers/view.html search/authors.html search/publishers.html search/subjects.html
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
@@ -1364,8 +1715,7 @@ msgstr "As a èssere su pròssimu a retzire custu libru."
 msgid "There is one person ahead of you in the waiting list."
 msgid_plural "There are %(count)d people ahead of you in the waiting list."
 msgstr[0] "B'at petzi una persone in antis de tie in sa lista de isetu."
-msgstr[1] ""
-"Bi sunt petzi %(count)d persones in antis de tie in sa lista de isetu."
+msgstr[1] "Bi sunt petzi %(count)d persones in antis de tie in sa lista de isetu."
 
 #: ManageWaitlistButton.html account/loans.html
 msgid "You have less than an hour to borrow it."
@@ -1387,12 +1737,8 @@ msgid "Leave the waiting list?"
 msgstr "Lassare sa lista de isetu?"
 
 #: account/loans.html
-msgid ""
-"Looking for a book to borrow?  Check out our staff picks, or search for a "
-"book on a specific subject:"
-msgstr ""
-"Ses chirchende unu libru de pigare in prèstidu?  Pòmpia·ti sos issèberos de "
-"su personale nostru, o chirca unu libru subra de un'argumentu ispetzìficu:"
+msgid "Looking for a book to borrow?  Check out our staff picks, or search for a book on a specific subject:"
+msgstr "Ses chirchende unu libru de pigare in prèstidu?  Pòmpia·ti sos issèberos de su personale nostru, o chirca unu libru subra de un'argumentu ispetzìficu:"
 
 #: account/loans.html home/index.html
 msgid "Books We Love"
@@ -1400,9 +1746,7 @@ msgstr "Libros chi amamus"
 
 #: account/loans.html
 msgid "Or, check out our <a href=\"/collections\">special collections</a>."
-msgstr ""
-"O pòmpia·ti sas <a href=\"/collections\">colletziones ispetziales</a> "
-"nostras."
+msgstr "O pòmpia·ti sas <a href=\"/collections\">colletziones ispetziales</a> nostras."
 
 #: account/mybooks.html
 msgid "No books are on this shelf"
@@ -1412,20 +1756,22 @@ msgstr "Custu iscafale non tenet libros"
 msgid "My Loans"
 msgstr "Sos prèstidos meos"
 
-#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
-#: my_books/dropdown_content.html my_books/primary_action.html mybooks.py
-#: search/sort_options.html
+#. Display name for the "already-read" reading log shelf used in page headings
+#. and breadcrumbs.
+#. Label for the reading log shelf for books the user has finished reading
+#. (bookshelf ID 3). Used as a button label and shelf name.
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html openlibrary/plugins/upstream/mybooks.py search/sort_options.html
 msgid "Already Read"
 msgstr "Giai lèghidu"
 
 #: account/mybooks.html type/user/view.html
 msgid "This reader has chosen to make their Reading Log private."
-msgstr ""
-"Custu letore at isseberadu de impostare su registru de letura suo privadu."
+msgstr "Custu letore at isseberadu de impostare su registru de letura suo privadu."
 
-#: account/mybooks.html account/sidebar.html
-msgid "Untitled list"
-msgstr "Lista chene tìtulu"
+#: account/mybooks.html
+#, fuzzy, python-format
+msgid "%(year_span)s reading goal"
+msgstr "Cunfigura s' obietivu de letura pro su %(year_span)s"
 
 #: account/mybooks.html
 msgid "View All Lists"
@@ -1439,8 +1785,7 @@ msgstr "Istatìsticas meas"
 msgid "My Reading Stats"
 msgstr "Sas istatìsticas meas de letura"
 
-#: account.py account/mybooks.html account/sidebar.html
-#: books/mybooks_breadcrumb_select.html
+#: account/mybooks.html account/sidebar.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
 msgid "Loan History"
 msgstr "Cronologia de sos prèstidos"
 
@@ -1462,25 +1807,16 @@ msgstr "Oops!"
 
 #: account/not_verified.html
 msgid "The email address you signed up with needs to be verified."
-msgstr ""
-"S'indiritzu de posta chi as impreadu pro ti registrare bolet verificadu."
+msgstr "S'indiritzu de posta chi as impreadu pro ti registrare bolet verificadu."
 
 #: account/not_verified.html
 #, python-format
-msgid ""
-"When you created your account, we sent an email to %(email)s that contained "
-"a link for you to verify your email address. We need you to click that link, "
-"please."
-msgstr ""
-"Cando as creadu su contu tuo, amus imbiadu un' email a %(email)s chi "
-"cuntenet unu ligàmene pro verificare s'indiritzu de posta eletrònica tuo. "
-"Nos bisòngiat chi incarches cussu ligàmene."
+msgid "When you created your account, we sent an email to %(email)s that contained a link for you to verify your email address. We need you to click that link, please."
+msgstr "Cando as creadu su contu tuo, amus imbiadu un' email a %(email)s chi cuntenet unu ligàmene pro verificare s'indiritzu de posta eletrònica tuo. Nos bisòngiat chi incarches cussu ligàmene."
 
 #: account/not_verified.html
 msgid "If you can't find the email, just hit this button to send a fresh one:"
-msgstr ""
-"Si non resesses a atzapare cussa lìtera, incarca custu butone pro nde "
-"imbiare una noa:"
+msgstr "Si non resesses a atzapare cussa lìtera, incarca custu butone pro nde imbiare una noa:"
 
 #: account/not_verified.html account/verify/failed.html
 msgid "Resend the verification email"
@@ -1490,8 +1826,7 @@ msgstr "Torra a imbiare su messàgiu de posta de verìfica"
 msgid "Thanks!"
 msgstr "Gràtzias!"
 
-#: BookByline.html FulltextSearchSuggestionItem.html SearchResultsWork.html
-#: account/notes.html account/observations.html
+#: BookByline.html FulltextSearchSuggestionItem.html SearchResultsWork.html account/notes.html account/observations.html
 msgid "Unknown author"
 msgstr "Autore disconnotu"
 
@@ -1507,8 +1842,7 @@ msgstr "Mancat su tìtulu"
 msgid "Publish date unknown"
 msgstr "Data de publicatzione disconnota"
 
-#: account/notes.html books/edition-sort.html books/works-show.html
-#: lists/export_as_html.html type/work/editions.html
+#: account/notes.html books/edition-sort.html lists/export_as_html.html type/work/editions.html
 msgid "Publisher unknown"
 msgstr "Domo editora disconnota"
 
@@ -1538,20 +1872,12 @@ msgid "Notifications"
 msgstr "Notìficas"
 
 #: account/notifications.html
-msgid ""
-"Notifications are connected to Lists at the moment. If one of the books on "
-"your list gets edited, or a new book comes into the catalog, we'll let you "
-"know, if you want."
-msgstr ""
-"In custu momentu sas notìficas sunt ligadas a sas listas. Si unu de sos "
-"libros in sa lista tua benit modificadu o arribbat unu libru nou in su "
-"catàlogu ti l'amus a fàghere ischire, si boles."
+msgid "Notifications are connected to Lists at the moment. If one of the books on your list gets edited, or a new book comes into the catalog, we'll let you know, if you want."
+msgstr "In custu momentu sas notìficas sunt ligadas a sas listas. Si unu de sos libros in sa lista tua benit modificadu o arribbat unu libru nou in su catàlogu ti l'amus a fàghere ischire, si boles."
 
 #: account/notifications.html
 msgid "Would you like to receive very occasional emails from Open Library?"
-msgstr ""
-"Ti diat agradare a retzire messàgios de posta eletrònica ocasionales dae "
-"s'Open Library?"
+msgstr "Ti diat agradare a retzire messàgios de posta eletrònica ocasionales dae s'Open Library?"
 
 #: account/notifications.html
 msgid "No, thank you"
@@ -1561,17 +1887,15 @@ msgstr "Nono, gràtzias"
 msgid "Yes! Please!"
 msgstr "Eja, pro praghere!"
 
-#: EditButtons.html account/notifications.html account/privacy.html
-#: admin/block.html admin/spamwords.html covers/manage.html
+#: EditButtons.html account/notifications.html account/privacy.html admin/block.html admin/spamwords.html covers/manage.html design/button.html
 msgid "Save"
 msgstr "Sarva"
 
-#: EditionNavBar.html account/observations.html
-#: books/mybooks_breadcrumb_select.html mybooks.py
+#: EditionNavBar.html account/observations.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 msgid "Reviews"
 msgstr "Retzensiones"
 
-#: account/observations.html admin/inspect/memcache.html
+#: account/observations.html admin/inspect/memcache.html design/button.html design/popover.html
 msgid "Delete"
 msgstr "Iscantzella"
 
@@ -1592,21 +1916,13 @@ msgid "Privacy & Content Moderation Settings"
 msgstr "Impostatziones de riservadesa e moderatzione de cuntenutu"
 
 #: account/privacy.html
-msgid ""
-"Would you like to make your <a href=\"/account/books\">Reading Log</a> "
-"public?"
-msgstr ""
-"Boles cunfigurare comente pùblicu su <a href=\"/account/books\">Registru de "
-"letura</a> tuo?"
+msgid "Would you like to make your <a href=\"/account/books\">Reading Log</a> public?"
+msgstr "Boles cunfigurare comente pùblicu su <a href=\"/account/books\">Registru de letura</a> tuo?"
 
 #: account/privacy.html
-msgid ""
-"This will enable others to see what books you want to read, are reading, or "
-"have already read. Patrons with reading logs set to public may be followed."
-msgstr ""
-"Custu at a permìtere a àteros de bìdere sos libros chi boles lèghere, ses "
-"leghende, o as giai lèghidu. Sos metzenates cun registros de leghidura "
-"cunfigurados comente pùblicos podent èssere sighidos dae àteros."
+#, fuzzy
+msgid "This will enable others to see what books you want to read, are reading, stopped reading, or have already read. Patrons with reading logs set to public may be followed."
+msgstr "Custu at a permìtere a àteros de bìdere sos libros chi boles lèghere, ses leghende, o as giai lèghidu. Sos metzenates cun registros de leghidura cunfigurados comente pùblicos podent èssere sighidos dae àteros."
 
 #: account/privacy.html admin/people/view.html
 msgid "Yes"
@@ -1621,12 +1937,8 @@ msgid "Enable Safe Mode?"
 msgstr "Abilitare sa modalidade segura?"
 
 #: account/privacy.html
-msgid ""
-"Safe Mode blurs book covers that have been flagged as having sensitive "
-"imagery."
-msgstr ""
-"Sa modalidade segura isfocat sas coberteddas de libros chi sunt istadas "
-"marcadas comente immàgines sensìbiles."
+msgid "Safe Mode blurs book covers that have been flagged as having sensitive imagery."
+msgstr "Sa modalidade segura isfocat sas coberteddas de libros chi sunt istadas marcadas comente immàgines sensìbiles."
 
 #: account/reading_log.html
 #, python-format
@@ -1635,12 +1947,8 @@ msgstr "Sos libros chi %(username)s est leghende"
 
 #: account/reading_log.html
 #, python-format
-msgid ""
-"%(username)s is reading %(total)d books. Join %(username)s on OpenLibrary."
-"org and tell the world what you're reading."
-msgstr ""
-"%(username)s est leghende %(total)d libros. Auni·ti a %(username)s in "
-"OpenLibrary.org e nara a su mundu ite ses leghende."
+msgid "%(username)s is reading %(total)d books. Join %(username)s on OpenLibrary.org and tell the world what you're reading."
+msgstr "%(username)s est leghende %(total)d libros. Auni·ti a %(username)s in OpenLibrary.org e nara a su mundu ite ses leghende."
 
 #: account/reading_log.html
 #, python-format
@@ -1649,12 +1957,18 @@ msgstr "Libros chi %(username)s cheret lèghere"
 
 #: account/reading_log.html
 #, python-format
-msgid ""
-"%(username)s wants to read %(total)d books. Join %(username)s on OpenLibrary."
-"org and share the books that you'll soon be reading!"
-msgstr ""
-"%(username)s bolet lèghere %(total)d libros. Auni·ti a %(username)s in "
-"OpenLibrary.org e cumpartzi sos libros chi as a lèghere luego!"
+msgid "%(username)s wants to read %(total)d books. Join %(username)s on OpenLibrary.org and share the books that you'll soon be reading!"
+msgstr "%(username)s bolet lèghere %(total)d libros. Auni·ti a %(username)s in OpenLibrary.org e cumpartzi sos libros chi as a lèghere luego!"
+
+#: account/reading_log.html
+#, fuzzy, python-format
+msgid "Books %(username)s stopped reading"
+msgstr "Sos libros chi %(username)s est leghende"
+
+#: account/reading_log.html
+#, fuzzy, python-format
+msgid "%(username)s stopped reading %(total)d books. Join %(username)s on OpenLibrary.org to share your own reading updates!"
+msgstr "%(username)s bolet lèghere %(total)d libros. Auni·ti a %(username)s in OpenLibrary.org e cumpartzi sos libros chi as a lèghere luego!"
 
 #: account/reading_log.html
 #, python-format
@@ -1663,13 +1977,8 @@ msgstr "Sos libros chi %(username)s at lèghidu in su %(year)d"
 
 #: account/reading_log.html
 #, python-format
-msgid ""
-"%(username)s has read %(total)d books in %(year)d. Join %(username)s on "
-"OpenLibrary.org and tell the world about the books that you care about."
-msgstr ""
-"%(username)s at lèghidu %(total)d libros in su %(year)d. Auni·ti a "
-"%(username)s in OpenLibrary.org e conta a su mundu de sos libros chi tenes "
-"in coro."
+msgid "%(username)s has read %(total)d books in %(year)d. Join %(username)s on OpenLibrary.org and tell the world about the books that you care about."
+msgstr "%(username)s at lèghidu %(total)d libros in su %(year)d. Auni·ti a %(username)s in OpenLibrary.org e conta a su mundu de sos libros chi tenes in coro."
 
 #: account/reading_log.html
 #, python-format
@@ -1678,12 +1987,8 @@ msgstr "Libros chi %(username)s at lèghidu"
 
 #: account/reading_log.html
 #, python-format
-msgid ""
-"%(username)s has read %(total)d books. Join %(username)s on OpenLibrary.org "
-"and tell the world about the books that you care about."
-msgstr ""
-"%(username)s at lèghidu %(total)d libros. Auni·ti a %(username)s in "
-"OpenLibrary.org e conta a su mundu subra de sos libros chi t'istant a coro."
+msgid "%(username)s has read %(total)d books. Join %(username)s on OpenLibrary.org and tell the world about the books that you care about."
+msgstr "%(username)s at lèghidu %(total)d libros. Auni·ti a %(username)s in OpenLibrary.org e conta a su mundu subra de sos libros chi t'istant a coro."
 
 #: account/reading_log.html
 #, python-format
@@ -1699,17 +2004,15 @@ msgstr "Libros annantos dae gente chi %(username)s sighit"
 msgid "Search your reading log"
 msgstr "Chirca in su registru de letura tuo"
 
-#: account/reading_log.html search/sort_options.html
-msgid "Sorting by"
-msgstr "Ordinamentu pro"
+#: account/reading_log.html type/author/view.html
+#, fuzzy, python-format
+msgid "— Show <a href=\"%(url)s\">only ebooks</a>?"
+msgstr ""
 
 #: account/reading_log.html
-msgid "Date Added (newest)"
-msgstr "Data de annanta (prus noos)"
-
-#: account/reading_log.html
-msgid "Date Added (oldest)"
-msgstr "Data de annanta (prus betzos)"
+#, fuzzy, python-format
+msgid "— Show <a href=\"%(url)s\">everything</a> in this shelf?"
+msgstr "Ammustrende petzi sos libros eletrònicos. Boles bìdere <a href=\"%(url)s\">totu</a> de custu autore?"
 
 #: account/reading_log.html
 msgid "No results found in this shelf"
@@ -1729,22 +2032,15 @@ msgid "You haven't added any books to this shelf yet."
 msgstr "No as galu annantu perunu libru a custu iscafale."
 
 #: account/reading_log.html
-msgid ""
-"<a href=\"/search\">Search for a book</a> to add to your reading log. <a "
-"href=\"/help/faq/reading-log\">Learn more</a> about the reading log."
-msgstr ""
-"<a href=\"/search\">Chirca unu libru</a> de annànghere a su registru de "
-"letura tuo. <a href=\"/help/faq/reading-log\">Impara de prus</a> subra de su "
-"registru de letura."
+msgid "<a href=\"/search\">Search for a book</a> to add to your reading log. <a href=\"/help/faq/reading-log\">Learn more</a> about the reading log."
+msgstr "<a href=\"/search\">Chirca unu libru</a> de annànghere a su registru de letura tuo. <a href=\"/help/faq/reading-log\">Impara de prus</a> subra de su registru de letura."
 
 #: account/reading_log.html
-msgid ""
-"There are no recent books in your feed. When you follow public accounts, "
-"their book updates will appear here."
-msgstr ""
-"Non b'at libros reghentes in su flussu tuo. Cando sighis contos pùblicos, "
-"sas atualitzatziones de sos libros issoro s'ant a ammustrare inoghe."
+msgid "There are no recent books in your feed. When you follow public accounts, their book updates will appear here."
+msgstr "Non b'at libros reghentes in su flussu tuo. Cando sighis contos pùblicos, sas atualitzatziones de sos libros issoro s'ant a ammustrare inoghe."
 
+#. Display name for the "want-to-read" reading log shelf used in page headings
+#. and breadcrumbs.
 #: account/readinglog_shelf_name.html
 msgid "Want To Read"
 msgstr "Chèrgio lèghere"
@@ -1760,14 +2056,8 @@ msgstr "Libros meos"
 
 #: account/readinglog_stats.html
 #, python-format
-msgid ""
-"Displaying stats about <strong>%(works_count)d</strong> books. Note all "
-"charts show only the top 20 bars. Note reading log stats are private."
-msgstr ""
-"Ammustrende istatìsticas subra de <strong>%(works_count)d</strong> libros. "
-"Ammenta·ti chi totu sos gràficos mustrant petzi sas 20 istangas de importu "
-"prus mannu. Tene in contu chi sas istatìsticas de su registru de letura sunt "
-"privadas."
+msgid "Displaying stats about <strong>%(works_count)d</strong> books. Note all charts show only the top 20 bars. Note reading log stats are private."
+msgstr "Ammustrende istatìsticas subra de <strong>%(works_count)d</strong> libros. Ammenta·ti chi totu sos gràficos mustrant petzi sas 20 istangas de importu prus mannu. Tene in contu chi sas istatìsticas de su registru de letura sunt privadas."
 
 #: account/readinglog_stats.html
 msgid "Author Stats"
@@ -1790,22 +2080,22 @@ msgid "Works by Author Country of Birth"
 msgstr "Òperas pro istadu de nàschida de sos autores"
 
 #: account/readinglog_stats.html
-msgid ""
-"Demographic statistics powered by <a href=\"https://www.wikidata.org/"
-"\">Wikidata</a>. Here's a <a id=\"wd-query-sample\" href=\"\">sample</a> of "
-"the query used. <br />Improve these stats by adding the Wikidata author "
-"identifier following <a href=\"https://openlibrary.org/help/faq/editing."
-"en#author-identifiers-purpose\">these instructions</a>."
-msgstr ""
-"Istatìsticas demogràficas frunidas dae <a href=\"https://www.wikidata.org/"
-"\">Wikidata</a>. Inoghe b'at <a id=\"wd-query-sample\" href=\"\">un'esèmpiu</"
-"a> de sa rechesta impreada.<br />Megiora custas istatìsticas annanghende "
-"s'identificadore Wikidata de s'autore sighende <a href=\"https://openlibrary."
-"org/help/faq/editing.en#author-identifiers-purpose\">custos inditos</a>."
+msgid "Demographic statistics powered by <a href=\"https://www.wikidata.org/\">Wikidata</a>. Here's a <a id=\"wd-query-sample\" href=\"\">sample</a> of the query used. <br />Improve these stats by adding the Wikidata author identifier following <a href=\"https://openlibrary.org/help/faq/editing.en#author-identifiers-purpose\">these instructions</a>."
+msgstr "Istatìsticas demogràficas frunidas dae <a href=\"https://www.wikidata.org/\">Wikidata</a>. Inoghe b'at <a id=\"wd-query-sample\" href=\"\">un'esèmpiu</a> de sa rechesta impreada.<br />Megiora custas istatìsticas annanghende s'identificadore Wikidata de s'autore sighende <a href=\"https://openlibrary.org/help/faq/editing.en#author-identifiers-purpose\">custos inditos</a>."
 
 #: account/readinglog_stats.html
 msgid "Work Stats"
 msgstr "Istatìsticas de s'òpera"
+
+#: account/readinglog_stats.html
+#, fuzzy
+msgid "Works by Decade Published"
+msgstr "Òperas pro perìodu"
+
+#: account/readinglog_stats.html
+#, fuzzy
+msgid "Works by Century Published"
+msgstr "Prus betzos"
 
 #: account/readinglog_stats.html
 msgid "Works by Subject"
@@ -1831,7 +2121,7 @@ msgstr "Òperas chi currispondent"
 msgid "Click on a bar to see matching works"
 msgstr "Incarca in un'istanga pro bìdere òperas currispondentes"
 
-#: account/sidebar.html books/mybooks_breadcrumb_select.html mybooks.py
+#: account/sidebar.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 msgid "My Feed"
 msgstr "Su flussu meu"
 
@@ -1845,10 +2135,6 @@ msgstr "Obietivu de letura pro su %(year)d"
 msgid "Set %(year_span)s reading goal"
 msgstr "Cunfigura s' obietivu de letura pro su %(year_span)s"
 
-#: account/sidebar.html
-msgid "Yearly Reading Goal"
-msgstr "Obietivu de letura annuale"
-
 #: account/sidebar.html search/sort_options.html type/user/view.html
 msgid "Reading Log"
 msgstr "Registru de letura"
@@ -1857,21 +2143,21 @@ msgstr "Registru de letura"
 msgid "My lists"
 msgstr "Sas listas meas"
 
-#: EditionNavBar.html SearchNavigation.html account/sidebar.html
-#: lib/nav_head.html lists/home.html lists/widget.html recentchanges/index.html
-#: type/edition/view.html type/list/embed.html type/user/view.html
-#: type/work/view.html
+#: EditionNavBar.html SearchNavigation.html account/sidebar.html lib/nav_head.html lists/home.html recentchanges/index.html type/edition/view.html type/list/embed.html type/user/view.html type/work/view.html
 msgid "Lists"
 msgstr "Listas"
 
-#: account/sidebar.html type/edition/view.html type/user/view.html
-#: type/work/view.html
+#: account/sidebar.html type/user/view.html
 msgid "See All"
 msgstr "Abbista totu"
 
-#: account/sidebar.html type/list/edit.html
+#: account/sidebar.html type/list/edit.html type/series/edit.html
 msgid "Create a list"
 msgstr "Crea una lista"
+
+#: account/sidebar.html
+msgid "Untitled list"
+msgstr "Lista chene tìtulu"
 
 #: account/topmenu.html
 msgid "Import & Export"
@@ -1886,25 +2172,23 @@ msgstr "Impostatziones de riservadesa: %(public)s"
 msgid "Verification email sent"
 msgstr "Lìtera eletrònica de verìfica imbiada"
 
-#: account.py account/password/reset_success.html account/verify.html
-#: account/verify/activated.html account/verify/success.html
+#: account/password/reset_success.html account/verify.html account/verify/activated.html account/verify/success.html
 #, python-format
 msgid "Hi, %(user)s"
 msgstr "Salude, %(user)s"
 
 #: account/verify.html
 #, python-format
-msgid ""
-"We’ve sent an email to %(email)s containing a link to verify your account. "
-"Click/tap on the link to finish creating your Internet Archive account."
-msgstr ""
-"Amus imbiadu un'email a %(email)s chi cuntenet unu ligàmene pro verificare "
-"su contu tuo. Incarca/toca su ligàmene pro acabbare de creare su contu tuo "
-"pro s'Internet Archive."
+msgid "We’ve sent an email to %(email)s containing a link to verify your account. Click/tap on the link to finish creating your Internet Archive account."
+msgstr "Amus imbiadu un'email a %(email)s chi cuntenet unu ligàmene pro verificare su contu tuo. Incarca/toca su ligàmene pro acabbare de creare su contu tuo pro s'Internet Archive."
 
 #: account/verify.html
 msgid "Then, come back to Open Library and find some great books!"
 msgstr "A pustis, torra a s'Open Library e atzapa libros de primore!"
+
+#: account/view.html
+msgid "Yearly Reading Goal"
+msgstr "Obietivu de letura annuale"
 
 #: account/view.html books/mybooks_breadcrumb_select.html
 msgid "Following"
@@ -1914,22 +2198,17 @@ msgstr "Sighende"
 msgid "Followers"
 msgstr "Sighidores"
 
-#: account/view.html type/edition/modal_links.html
-#: type/edition/title_and_author.html
+#: account/view.html design/popover.html type/edition/modal_links.html type/edition/title_and_author.html
 msgid "Share"
 msgstr "Cumpartzi"
 
 #: account/view.html
 msgid "Your book notes are private and cannot be viewed by other patrons."
-msgstr ""
-"Sas notas de sos libros tuas sunt privadas e sos àteros metzenates non las "
-"podent bìdere."
+msgstr "Sas notas de sos libros tuas sunt privadas e sos àteros metzenates non las podent bìdere."
 
 #: account/view.html
 msgid "Your book reviews will be shared anonymously with other patrons."
-msgstr ""
-"Sas retzensiones tuas ant a èssere cumpartzidas in manera anònima cun àteros "
-"metzenates."
+msgstr "Sas retzensiones tuas ant a èssere cumpartzidas in manera anònima cun àteros metzenates."
 
 #: account/yrg_banner.html
 #, python-format
@@ -1945,12 +2224,8 @@ msgid "Forgot Your Internet Archive Email?"
 msgstr "As ismentigadu s'indiritzu de posta tuo pro s'Internet Archive?"
 
 #: account/email/forgot-ia.html
-msgid ""
-"Please enter your Open Library email and password, and we’ll retrieve your "
-"Archive.org email."
-msgstr ""
-"Inserta s'indiritzu de posta eletrònica tuo e sa crae de intrada tua pro "
-"s'Open Library, e amus a recuperare s'indiritzu de posta tuo pro Archive.org."
+msgid "Please enter your Open Library email and password, and we’ll retrieve your Archive.org email."
+msgstr "Inserta s'indiritzu de posta eletrònica tuo e sa crae de intrada tua pro s'Open Library, e amus a recuperare s'indiritzu de posta tuo pro Archive.org."
 
 #: account/email/forgot-ia.html
 msgid "Your email is:"
@@ -1992,7 +2267,7 @@ msgstr "Reseta sa crae"
 msgid "Please enter a new password for your Open Library account."
 msgstr "Inserta una crae noa pro su contu to de s'Open Library."
 
-#: account/password/reset.html
+#: account/password/reset.html design/button.html
 msgid "Reset"
 msgstr "Reseta"
 
@@ -2001,12 +2276,8 @@ msgid "Password Reset Successful"
 msgstr "Resetada de sa crae fata cun sutzessu"
 
 #: account/password/reset_success.html
-msgid ""
-"Your password has been updated. Please <a href='/account/login?"
-"redirect=/'>log in to continue</a>."
-msgstr ""
-"Sa crae tua est istada atualizada. Pro praghere <a href='/account/login?"
-"redirect=/'>intra pro sighire</a>."
+msgid "Your password has been updated. Please <a href='/account/login?redirect=/'>log in to continue</a>."
+msgstr "Sa crae tua est istada atualizada. Pro praghere <a href='/account/login?redirect=/'>intra pro sighire</a>."
 
 #: account/password/sent.html
 msgid "Done."
@@ -2014,14 +2285,45 @@ msgstr "Fatu."
 
 #: account/password/sent.html
 #, python-format
-msgid ""
-"We've sent an email to %(email)s with a reminder of your username and "
-"instructions to help you reset your Open Library password. Please check your "
-"inbox for a note from us."
-msgstr ""
-"T'amus imbiadu unu messàgiu de posta eletrònica a %(email)s cun un'avisu cun "
-"su nùmene de utente tuo e inditos pro t'agiudare a resetare sa crae tua de "
-"s'Open Library. Chirca su messàgiu nostru in sa cartella de intrada tua."
+msgid "We've sent an email to %(email)s with a reminder of your username and instructions to help you reset your Open Library password. Please check your inbox for a note from us."
+msgstr "T'amus imbiadu unu messàgiu de posta eletrònica a %(email)s cun un'avisu cun su nùmene de utente tuo e inditos pro t'agiudare a resetare sa crae tua de s'Open Library. Chirca su messàgiu nostru in sa cartella de intrada tua."
+
+#: account/security/check_email.html
+msgid "Account Security Check — 2026-04-28T18Z"
+msgstr "Cuntrollu de Seguràntzia de s'Account — 2026-04-28T18Z"
+
+#: account/security/check_email.html
+msgid "Account Security Check"
+msgstr "Cuntrollu de Seguràntzia de s'Account"
+
+#: account/security/check_email.html
+msgid "Incident date: 2026-04-28T18Z"
+msgstr "Data de s'incidente: 2026-04-28T18Z"
+
+#: account/security/check_email.html
+msgid "Check whether your Open Library account was in a set of accounts requiring attention."
+msgstr "Cuntrolla si s'account tuo de Open Library fiat in unu inseme de accounts chi rechèdiant atentzione."
+
+#: account/security/check_email.html
+msgid "Please <a href=\"/account/login?redirect=/account/security/2026-04-28T18\">log in</a> to check whether your account was affected."
+msgstr "Pro praghere <a href=\"/account/login?redirect=/account/security/2026-04-28T18\">intra</a> pro cuntrolare si s'account tuo fiat afetadu."
+
+#: account/security/check_email.html
+#, fuzzy
+msgid "Your account is in the affected set."
+msgstr "Contu galu no ativadu."
+
+#: account/security/check_email.html
+msgid "Your account was found in our affected accounts list. Please review any recent communications from Open Library and consider updating your password."
+msgstr "S'account tuo est istadu trovadu in sa lista de s'accounts afetados nostros. Pro praghere reìghile is cummuncatziònes retzentes dae Open Library e cunsidera de agiornare sa paràula de atzessu tua."
+
+#: account/security/check_email.html
+msgid "Your account is <em>not</em> in the affected set."
+msgstr "S'account tuo <em>no</em> est in s'inseme afetadu."
+
+#: account/security/check_email.html
+msgid "Your account was <em>not</em> found in the affected accounts list. No action is required."
+msgstr "S'account tuo <em>no</em> est istadu trovadu in sa lista de s'accounts afetados. Non si rechèdit nessuna atzòne."
 
 #: account/verify/activated.html
 msgid "Account already activated"
@@ -2029,30 +2331,20 @@ msgstr "Contu giai ativadu"
 
 #: account/verify/activated.html
 #, python-format
-msgid ""
-"Your account has been activated already. Please <a href=\"%s\">log in to "
-"continue</a>."
-msgstr ""
-"Su contu tuo est istadu giai ativadu. <a href=\"%s\">Intra pro sighire</a>."
+msgid "Your account has been activated already. Please <a href=\"%s\">log in to continue</a>."
+msgstr "Su contu tuo est istadu giai ativadu. <a href=\"%s\">Intra pro sighire</a>."
 
 #: account/verify/failed.html
 msgid "Email Verification Failed"
 msgstr "Verìfica de s'indiritzu de posta fallida"
 
 #: account/verify/failed.html
-msgid ""
-"Your email address couldn't be verified. Your verification link seems "
-"invalid or expired."
-msgstr ""
-"No at fatu a verificare s'indiritzu de posta eletrònica tuo. Su ligàmene de "
-"verìfica tuo paret chi non siat vàlidu o siat iscadidu."
+msgid "Your email address couldn't be verified. Your verification link seems invalid or expired."
+msgstr "No at fatu a verificare s'indiritzu de posta eletrònica tuo. Su ligàmene de verìfica tuo paret chi non siat vàlidu o siat iscadidu."
 
 #: account/verify/failed.html
-msgid ""
-"Fill your email and hit this button to resend a fresh verification email:"
-msgstr ""
-"Inserta s'indiritzu de posta eletrònica tuo e incarca in custu butone pro "
-"torrare a imbiare una lìtera de verìfica noa:"
+msgid "Fill your email and hit this button to resend a fresh verification email:"
+msgstr "Inserta s'indiritzu de posta eletrònica tuo e incarca in custu butone pro torrare a imbiare una lìtera de verìfica noa:"
 
 #: account/verify/failed.html
 msgid "Enter your email address here"
@@ -2068,12 +2360,8 @@ msgstr "Verìfica de s'indiritzu de posta fata cun sutzessu"
 
 #: account/verify/success.html
 #, python-format
-msgid ""
-"Yay! Your email address has been verified. Please <a href='%s'>log in to "
-"continue</a>."
-msgstr ""
-"Bene meda! S'indiritzu tuo est istadu verificadu. <a href='%s'>Intra pro "
-"sighire</a>."
+msgid "Yay! Your email address has been verified. Please <a href='%s'>log in to continue</a>."
+msgstr "Bene meda! S'indiritzu tuo est istadu verificadu. <a href='%s'>Intra pro sighire</a>."
 
 #: admin/attach_debugger.html
 msgid "Attach Debugger"
@@ -2102,12 +2390,13 @@ msgstr "Bloca s'indiritzu IP"
 
 #: admin/block.html
 #, python-format
-msgid ""
-"IP address %(address)s has been added to the textarea. Please click Save to "
-"block that IP."
-msgstr ""
-"S'indiritzu IP %(address)s est istadu agiuntu a s'àrea de testu. Pro "
-"praghere incarca Sarva pro blocare cussu IP."
+msgid "IP address %(address)s has been added to the textarea. Please click Save to block that IP."
+msgstr "S'indiritzu IP %(address)s est istadu agiuntu a s'àrea de testu. Pro praghere incarca Sarva pro blocare cussu IP."
+
+#: admin/block.html
+#, fuzzy
+msgid "Blocked IP Addresses"
+msgstr "Bloca s'indiritzu IP"
 
 #: admin/graphs.html
 msgid "Performance Graphs"
@@ -2129,8 +2418,7 @@ msgstr "Tempos de càrriga de sas pàginas partzidos"
 msgid "Infobase Mean"
 msgstr "Mèdia de Infobase"
 
-#: admin/history.html admin/imports.html authors/infobox.html
-#: type/author/edit.html
+#: admin/history.html admin/imports.html authors/infobox.html type/author/edit.html
 msgid "Date"
 msgstr "Data"
 
@@ -2138,13 +2426,11 @@ msgstr "Data"
 msgid "Page"
 msgstr "Pàgina"
 
-#: admin/imports-add.html admin/imports.html admin/imports_by_date.html
-#: admin/menu.html
+#: admin/imports-add.html admin/imports.html admin/imports_by_date.html admin/menu.html
 msgid "Imports"
 msgstr "Importatziones"
 
-#: admin/imports-add.html books/add.html books/edit/edition.html
-#: books/edit/excerpts.html covers/change.html type/tag/form.html
+#: admin/imports-add.html books/add.html books/edit/edition.html books/edit/excerpts.html covers/change.html type/tag/form.html
 msgid "Add"
 msgstr "Annanghe"
 
@@ -2156,9 +2442,7 @@ msgstr "Agiunghe libros noos a sa fila de importatzione"
 msgid "Please add IA identifiers to be imported, one per line."
 msgstr "Annanghe sos identificadores IA de importare, unu pro lìnia."
 
-#: admin/imports-add.html admin/inspect/store.html admin/ip/view.html
-#: admin/people/edits.html admin/permissions.html check_ins/check_in_form.html
-#: check_ins/reading_goal_form.html
+#: admin/imports-add.html admin/inspect/store.html admin/ip/view.html admin/people/edits.html admin/permissions.html design/button.html my_books/check_ins/check_in_form.html reading_goals/reading_goal_form.html
 msgid "Submit"
 msgstr "Imbia"
 
@@ -2170,7 +2454,7 @@ msgstr "Libros noos importados pro die"
 msgid "You need to have JavaScript turned on to see the nifty chart!"
 msgstr "Depes tènnere JavaScript allutu pro bìdere custu gràficu galanu!"
 
-#: admin/imports.html admin/imports_by_date.html site/stats.html
+#: admin/imports.html admin/imports_by_date.html admin/pd_dashboard.html site/stats.html
 msgid "Summary"
 msgstr "Resumu"
 
@@ -2181,8 +2465,7 @@ msgstr "Elementos in suspesu:"
 #: admin/imports.html
 #, python-format
 msgid "<strong>Current Import Rate:</strong> %(num)d imports/hour."
-msgstr ""
-"<strong>Tassu de importatzione atuale:</strong> %(num)d importatziones/ora."
+msgstr "<strong>Tassu de importatzione atuale:</strong> %(num)d importatziones/ora."
 
 #: admin/imports.html
 msgid "ETA:"
@@ -2224,7 +2507,7 @@ msgstr "Identificadore"
 msgid "Imported Time"
 msgstr "Momentu de importatzione"
 
-#: admin/imports_by_date.html admin/index.html
+#: admin/imports_by_date.html admin/index.html admin/pd_dashboard.html
 msgid "Total"
 msgstr "Totale"
 
@@ -2240,13 +2523,17 @@ msgstr "Atzapadu"
 msgid "Failed"
 msgstr "Fallidu"
 
-#: admin/imports_by_date.html
+#: admin/imports_by_date.html openlibrary/core/edits.py
 msgid "Pending"
 msgstr "In suspesu"
 
 #: admin/imports_by_date.html
 msgid "Items"
 msgstr "Elementos"
+
+#: admin/index.html
+msgid "<span class=\"login-counts\">0</span> patrons have logged in at least once over the past 30 days."
+msgstr "<span class=\"login-counts\">0</span> patrinos ant intradu a su sistema a su meu una borta in is ùrtimos 30 dies."
 
 #: admin/index.html
 msgid "Stats"
@@ -2384,20 +2671,25 @@ msgstr "Prèstidos, gràficu de sos ùrtimos 3 meses"
 msgid "Borrows, last 2 years graph"
 msgstr "Prèstidos, gràficu de sos ùrtimos 2 annos"
 
+#: admin/index.html
+#, fuzzy
+msgid "Unique Logins"
+msgstr "Bisitadores ùnicos"
+
+#: admin/index.html
+#, fuzzy
+msgid "Gathering login statistics..."
+msgstr "Istatìsticas de sa cronologia de letura"
+
 #: admin/loans_table.html
 msgid "BookReader"
 msgstr "BookReader"
 
-#: admin/loans_table.html book_providers/cita_press_download_options.html
-#: book_providers/ia_download_options.html
-#: book_providers/openstax_download_options.html
-#: book_providers/wikisource_download_options.html books/edit/edition.html
+#: admin/loans_table.html book_providers/cita_press_download_options.html book_providers/ia_download_options.html book_providers/openstax_download_options.html book_providers/wikisource_download_options.html books/edit/edition.html
 msgid "PDF"
 msgstr "PDF"
 
-#: admin/loans_table.html book_providers/gutenberg_download_options.html
-#: book_providers/ia_download_options.html
-#: book_providers/standard_ebooks_download_options.html books/edit/edition.html
+#: admin/loans_table.html book_providers/gutenberg_download_options.html book_providers/ia_download_options.html book_providers/standard_ebooks_download_options.html books/edit/edition.html
 msgid "ePub"
 msgstr "ePub"
 
@@ -2412,9 +2704,7 @@ msgid_plural "%d Current Loans"
 msgstr[0] "%d prèstidu atuale"
 msgstr[1] "%d prèstidos atuales"
 
-#: RecentChanges.html RecentChangesUsers.html admin/ip/view.html
-#: admin/loans_table.html admin/people/edits.html recentchanges/render.html
-#: recentchanges/updated_records.html
+#: RecentChanges.html RecentChangesUsers.html admin/ip/view.html admin/loans_table.html admin/people/edits.html recentchanges/render.html recentchanges/updated_records.html
 msgid "What"
 msgstr "Ite"
 
@@ -2426,8 +2716,7 @@ msgstr "Isetende dae su %(date)s"
 #: admin/loans_table.html
 #, python-format
 msgid "#%(num_position)d among %(num_waitlist)d people waiting for this book"
-msgstr ""
-"#%(num_position)d intre %(num_waitlist)d persones isetende pro custu libru"
+msgstr "#%(num_position)d intre %(num_waitlist)d persones isetende pro custu libru"
 
 #: ManageLoansButtons.html admin/loans_table.html
 #, python-format
@@ -2438,11 +2727,14 @@ msgstr "Pigadu in prèstidu su %(date)s"
 msgid "Admin Center"
 msgstr "Tzentru de amministratzione"
 
-#: RelatedSubjects.html SubjectTags.html admin/menu.html
-#: admin/people/index.html admin/people/view.html type/author/view.html
-#: type/list/view_body.html
+#: RelatedSubjects.html SubjectTags.html admin/menu.html admin/people/index.html admin/people/view.html openlibrary/plugins/worksearch/code.py type/author/view.html type/list/view_body.html
 msgid "People"
 msgstr "Persones"
+
+#: admin/menu.html
+#, fuzzy
+msgid "PD Access Requests"
+msgstr "Rechesta aberta"
 
 #: admin/menu.html
 msgid "Block IPs"
@@ -2467,6 +2759,34 @@ msgstr "Ispetziona sa butega"
 #: admin/menu.html
 msgid "Inspect memcache"
 msgstr "Ispetziona sa memòria temporànea"
+
+#: admin/pd_dashboard.html
+msgid "Print Disability Access Requests"
+msgstr "Rechestas de Atzessu pro Incapatzidade de Impressione"
+
+#: admin/pd_dashboard.html
+msgid "Breakdown by Qualifying Authority"
+msgstr "Suddivisione pro Autoridade Qualificadora"
+
+#: admin/pd_dashboard.html
+#, fuzzy
+msgid "PDA"
+msgstr "Atualiza"
+
+#: admin/pd_dashboard.html
+#, fuzzy
+msgid "Emailed"
+msgstr "posta eletrònica"
+
+#: admin/pd_dashboard.html
+#, fuzzy
+msgid "Fulfilled"
+msgstr "Fallidu"
+
+#: admin/pd_dashboard.html
+#, fuzzy
+msgid "Totals"
+msgstr "Totale"
 
 #: admin/permissions.html
 msgid "[Admin Center] Site Permissions"
@@ -2501,12 +2821,9 @@ msgid "Update permissions"
 msgstr "Autorizatzione pro sas atualizatziones"
 
 #: admin/permissions.html
-msgid ""
-"This updates  and  fields of /, /works, /books and /authors records in the "
-"database."
-msgstr ""
-"Custu annoat sos campos  e  fields de sos registros /, /works, /books e /"
-"authors in sa base de datos."
+#, fuzzy
+msgid "This updates \"permission\" and \"child_permission\" fields of /, /works, /books and /authors records in the database."
+msgstr "Custu annoat sos campos  e  fields de sos registros /, /works, /books e /authors in sa base de datos."
 
 #: admin/solr.html
 msgid "Solr Admin"
@@ -2514,21 +2831,15 @@ msgstr "Amministradore Solr"
 
 #: admin/solr.html
 msgid "Enter the keys of pages to be updated in OL search engine."
-msgstr ""
-"Inserta sas craes de sas pàginas de atualizare in su motore de chirca de OL."
+msgstr "Inserta sas craes de sas pàginas de atualizare in su motore de chirca de OL."
 
 #: admin/solr.html
 msgid "Example:"
 msgstr "Esèmpiu:"
 
 #: admin/solr.html
-msgid ""
-"On update, these keys will be added to solr update queue and it'll take "
-"about 15 minutes for them to get reindexed in Solr."
-msgstr ""
-"Durante s'atualizatzione, custas tzifras s'ant a annànghere a sa fila de "
-"agiornamentu Solr e b'ant a bàlere unos 15 minutos pro nche los torrare a "
-"inditzitzare in Solr."
+msgid "On update, these keys will be added to solr update queue and it'll take about 15 minutes for them to get reindexed in Solr."
+msgstr "Durante s'atualizatzione, custas tzifras s'ant a annànghere a sa fila de agiornamentu Solr e b'ant a bàlere unos 15 minutos pro nche los torrare a inditzitzare in Solr."
 
 #: admin/solr.html
 msgid "Enter the keys to reindex in Solr"
@@ -2538,42 +2849,26 @@ msgstr "Inserta sas craes pro torrare a inditzizare in Solr"
 msgid "Write one entry per line"
 msgstr "Iscrie una boghe pro lìnia"
 
-#: admin/solr.html
-msgid "Update"
-msgstr "Atualiza"
-
 #: admin/spamwords.html
 msgid "[Admin Center] Spam Words"
 msgstr "[Tzentru de amministratzione] Paràulas ispam"
 
 #: admin/spamwords.html
-msgid ""
-"Please enter the SPAM regular expressions in the textarea below, one per "
-"line."
-msgstr ""
-"Inserta sas espressiones regulares de SPAM in s'àrea de testu in suta, una "
-"pro lìnia."
+msgid "Please enter the SPAM regular expressions in the textarea below, one per line."
+msgstr "Inserta sas espressiones regulares de SPAM in s'àrea de testu in suta, una pro lìnia."
 
 #: admin/spamwords.html
-msgid ""
-"Be sure to escape any meta characters that are meant to be character "
-"literals."
-msgstr ""
-"Assegura·ti de estràere cada caràtere meta chi diant dèpere èssere caràteres "
-"literales."
+msgid "Be sure to escape any meta characters that are meant to be character literals."
+msgstr "Assegura·ti de estràere cada caràtere meta chi diant dèpere èssere caràteres literales."
 
 #: admin/spamwords.html
 msgid "If you are adding a domain, prepend the following to the domain:"
 msgstr "Si ses annanghende unu domìniu, in antis de su domìniu agiunghe custu:"
 
 #: admin/spamwords.html
-msgid ""
-"For example, if you want to prevent edits containing the domain <code>t.co</"
-"code>, add <code>(\b|https://|http://)t\\.co</code> to the spamwords list."
+#, fuzzy
+msgid "For example, if you want to prevent edits containing the domain <code>t.co</code>, add <code>(|https://|http://)t\\.co</code> to the spamwords list."
 msgstr ""
-"Pro esèmpiu, si cheres evitare modìficas chi cuntenent su domìniu <code>t."
-"co</code>, annnaghe <code>(\b|https://|http://)t\\.co</code> a sa lista de "
-"paràulas de ispam."
 
 #: admin/spamwords.html
 msgid "Spam Domains"
@@ -2581,9 +2876,48 @@ msgstr "Domìnios ispam"
 
 #: admin/spamwords.html
 msgid "Please enter domains to blacklist in the textarea below, one per line."
-msgstr ""
-"Inserta sos domìnios de pònnere in sa lista niedda in s'àrea de testu inoghe "
-"in suta, unu pro lìnia."
+msgstr "Inserta sos domìnios de pònnere in sa lista niedda in s'àrea de testu inoghe in suta, unu pro lìnia."
+
+#: admin/sync.html
+msgid "Sync"
+msgstr "Sincronizatzione"
+
+#: admin/sync.html
+msgid "Sync the metadata of various types of Open Library items (e.g. lists, subjects, works) with Archive.org."
+msgstr "Sincroniza is metadatos de diversos tipos de elementos de Open Library (p.e. listas, matèrias, òperas) cun Archive.org."
+
+#: admin/sync.html
+#, fuzzy
+msgid "Add Works to Staff Picks"
+msgstr "Annanghe a sos issèberos de s'iscuadra de traballu"
+
+#: admin/sync.html
+msgid "This utility will add your work to an Open Library list called `Staff Picks` under the `openlibrary` user. It will then take the added work and explode it into a list of all its readable editions. For each Open Library edition, a metadata field called `openlibrary_subject` will be injected into the archive.org metadata of the edition's corresponding archive.org item."
+msgstr "Cust'utilidade agiùnghet s'òpera tua a una lista de Open Library clamada `Staff Picks` suta de s'utente `openlibrary`. A pustis acollit s'òpera agiùntada e sa dividit in una lista de todas is editziònes lèggibiles. Pro ònnia editziones de Open Library, unu campu de metadatos clamadu `openlibrary_subject` at a esser injetadu in is metadatos de archive.org de s'artìculu de archive.org currispundente a s'editziones."
+
+#: admin/sync.html
+#, fuzzy
+msgid "add"
+msgstr "Annanghe"
+
+#: admin/sync.html
+#, fuzzy
+msgid "remove"
+msgstr "Boga"
+
+#: admin/sync.html
+#, fuzzy
+msgid "Update edition"
+msgstr "Autorizatzione pro sas atualizatziones"
+
+#: admin/sync.html
+msgid "Updates an edition on archive.org by writing in its latest  openlibrary_edition and openlibrary_work identifier values"
+msgstr "Agiorna una editziones in archive.org iscriende is valores de identificadore openlibrary_edition e openlibrary_work prus retzentes"
+
+#: admin/sync.html
+#, fuzzy
+msgid "TODO"
+msgstr "Oe"
 
 #: admin/inspect/memcache.html
 msgid "[Admin Center] Inspect Memcache"
@@ -2594,20 +2928,12 @@ msgid "Inspect Memcache"
 msgstr "Ispetziona sa memòria temporànea"
 
 #: admin/inspect/memcache.html
-msgid ""
-"Add one memcache key per line in the text area. Each key must include a '-' "
-"as the last character."
-msgstr ""
-"Annanghe una crae d memòria temporànea pro lìnia in s'àrea de testu. Cada "
-"crae depet inclùdere unu '-' comente ùrtimu caràtere."
+msgid "Add one memcache key per line in the text area. Each key must include a '-' as the last character."
+msgstr "Annanghe una crae d memòria temporànea pro lìnia in s'àrea de testu. Cada crae depet inclùdere unu '-' comente ùrtimu caràtere."
 
 #: admin/inspect/memcache.html
-msgid ""
-"For example, <code>observations-</code> should be entered in the text area "
-"if the key is <code>observations</code>."
-msgstr ""
-"Pro esèmpiu, <code>osservatziones-</code> si diat dèpere insertare in s'àrea "
-"de testu si sa crae est <code>osservatziones</code>."
+msgid "For example, <code>observations-</code> should be entered in the text area if the key is <code>observations</code>."
+msgstr "Pro esèmpiu, <code>osservatziones-</code> si diat dèpere insertare in s'àrea de testu si sa crae est <code>osservatziones</code>."
 
 #: admin/inspect/memcache.html
 msgid "Keys:"
@@ -2723,10 +3049,8 @@ msgstr "Bloca a %(ip)s"
 msgid "Please select the changesets to revert."
 msgstr "Seletziona sas modìficas de annullare."
 
-#: RecentChanges.html admin/ip/view.html admin/people/edits.html
-#: recentchanges/render.html
-msgid ""
-"When you see numbers here, that's the IP address of the anonymous editor"
+#: RecentChanges.html admin/ip/view.html admin/people/edits.html recentchanges/render.html
+msgid "When you see numbers here, that's the IP address of the anonymous editor"
 msgstr "Cando bides nùmeros inoghe, est s'indiritzu IP de s'editore anònimu"
 
 #: admin/ip/view.html admin/people/edits.html
@@ -2735,50 +3059,12 @@ msgid "Reverted by %(revert_author)s"
 msgstr "Annulladu dae %(revert_author)s"
 
 #: EditButtons.html admin/ip/view.html admin/people/edits.html
-msgid ""
-"Please, leave a short note about what you changed: <span class=\"small "
-"gray\">(Optional, but very useful!)</span>"
-msgstr ""
-"Lassa una nota curtza subra de su chi as cambiadu: <span class=\"small "
-"gray\">(Optzionale, ma utilosu meda!)</span>"
+msgid "Please, leave a short note about what you changed: <span class=\"small gray\">(Optional, but very useful!)</span>"
+msgstr "Lassa una nota curtza subra de su chi as cambiadu: <span class=\"small gray\">(Optzionale, ma utilosu meda!)</span>"
 
 #: admin/ip/view.html admin/people/edits.html
 msgid "Reverted spam"
 msgstr "Ispam annulladu"
-
-#: admin/memory/index.html
-msgid "Memory Status"
-msgstr "Istatus de sa memòria"
-
-#: admin/memory/index.html
-msgid "type"
-msgstr "casta"
-
-#: admin/memory/index.html
-msgid "count"
-msgstr "contègiu"
-
-#: admin/memory/index.html
-msgid "mark"
-msgstr "marcu"
-
-#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
-#: admin/memory/index.html recentchanges/default/path.html
-#: recentchanges/updated_records.html
-msgid "diff"
-msgstr "diferèntzias"
-
-#: admin/memory/index.html
-msgid "Prev"
-msgstr "Pretzedente"
-
-#: admin/memory/object.html
-msgid "Referents"
-msgstr "Riferimentos"
-
-#: admin/memory/object.html
-msgid "Referrers"
-msgstr "Referentes"
 
 #: admin/people/edits.html
 #, python-format
@@ -2792,16 +3078,6 @@ msgstr "persones"
 #: admin/people/edits.html
 msgid "edits"
 msgstr "modìficas"
-
-#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
-#: admin/people/edits.html recentchanges/render.html
-msgid "Older"
-msgstr "Prus betzu"
-
-#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
-#: admin/people/edits.html recentchanges/render.html
-msgid "Newer"
-msgstr "Prus nou"
 
 #: admin/people/index.html
 msgid "[Admin Center] People"
@@ -2870,12 +3146,8 @@ msgstr "intra comente custu utente"
 
 #: admin/people/view.html
 #, python-format
-msgid ""
-"Activated on <span class=\"time\">%(date)s</span> from <a href=\"/admin/ip/"
-"%(ip)s\">%(ip)s</a>."
-msgstr ""
-"Ativadu su <span class=\"time\">%(date)s</span> dae <a href=\"/admin/ip/"
-"%(ip)s\">%(ip)s</a>."
+msgid "Activated on <span class=\"time\">%(date)s</span> from <a href=\"/admin/ip/%(ip)s\">%(ip)s</a>."
+msgstr "Ativadu su <span class=\"time\">%(date)s</span> dae <a href=\"/admin/ip/%(ip)s\">%(ip)s</a>."
 
 #: admin/people/view.html
 msgid "unblock this account"
@@ -2884,20 +3156,6 @@ msgstr "isbloca custu contu"
 #: admin/people/view.html
 msgid "activate account"
 msgstr "ativa su contu"
-
-#: admin/people/view.html
-#, python-format
-msgid "Activation link expiring on <span class=\"time\">%(date)s.</span>"
-msgstr ""
-"Su ligàmene de ativatzione iscadit su <span class=\"time\">%(date)s.</span>"
-
-#: admin/people/view.html
-msgid "Activation link expired"
-msgstr "Su ligàmene de ativatzione est iscadidu"
-
-#: admin/people/view.html
-msgid "Resend activation link"
-msgstr "Torra a imbiare su ligàmene de verìfica"
 
 #: CreateListModal.html admin/people/view.html my_books/dropdown_content.html
 msgid "Name:"
@@ -2955,8 +3213,7 @@ msgstr "Esecutzione de anteprima"
 msgid "Anonymize Account"
 msgstr "Anonimiza su contu"
 
-#: account.py admin/people/view.html books/mybooks_breadcrumb_select.html
-#: type/user/view.html
+#: admin/people/view.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py type/user/view.html
 msgid "Loans"
 msgstr "Prèstidos"
 
@@ -2989,8 +3246,7 @@ msgstr "Ligàmenes de verìfica"
 msgid "None found"
 msgstr "Perunu agatadu"
 
-#: SearchNavigation.html authors/index.html lib/nav_foot.html
-#: merge/authors.html publishers/view.html
+#: SearchNavigation.html authors/index.html lib/nav_foot.html merge/authors.html publishers/view.html
 msgid "Authors"
 msgstr "Autores"
 
@@ -2998,9 +3254,7 @@ msgstr "Autores"
 msgid "Search for an Author"
 msgstr "Chirca un'autore"
 
-#: authors/index.html lib/nav_head.html lists/home.html publishers/index.html
-#: publishers/notfound.html publishers/view.html search/advancedsearch.html
-#: search/publishers.html search/searchbox.html type/local_id/view.html
+#: authors/index.html lib/nav_head.html lists/home.html publishers/index.html publishers/notfound.html publishers/view.html search/advancedsearch.html search/publishers.html search/searchbox.html type/local_id/view.html
 msgid "Search"
 msgstr "Chirca"
 
@@ -3027,14 +3281,7 @@ msgstr "Nàschida"
 msgid "Died"
 msgstr "Morte"
 
-#: book_providers/cita_press_download_options.html
-#: book_providers/gutenberg_download_options.html
-#: book_providers/ia_download_options.html
-#: book_providers/librivox_download_options.html
-#: book_providers/openstax_download_options.html
-#: book_providers/runeberg_download_options.html
-#: book_providers/standard_ebooks_download_options.html
-#: book_providers/wikisource_download_options.html
+#: book_providers/cita_press_download_options.html book_providers/gutenberg_download_options.html book_providers/ia_download_options.html book_providers/librivox_download_options.html book_providers/openstax_download_options.html book_providers/runeberg_download_options.html book_providers/standard_ebooks_download_options.html book_providers/wikisource_download_options.html
 msgid "Download Options"
 msgstr "Optziones de iscarrigamentu"
 
@@ -3046,54 +3293,11 @@ msgstr "Iscàrriga PDF dae Cita Press"
 msgid "More at Cita Press"
 msgstr "De prus in Cita Press"
 
-#: book_providers/cita_press_read_button.html
-msgid "Read eBook from Cita Press"
-msgstr "Leghe libros de Cita Press"
-
-#: book_providers/cita_press_read_button.html
-msgid ""
-"This book is available from <a href=\"https://citapress.org/\">Cita Press</"
-"a>. Cita Press is a trusted book provider of works written by women, pairing "
-"contemporary authors and designers with open access texts to make carefully "
-"designed books available for free and open source."
-msgstr ""
-"Custu libru est a disponimentu in <a href=\"https://citapress.org/\">Cita "
-"Press</a>. Cita Press est unu frunidore fidadu de òperas iscritas dae "
-"fèminas, chi ponet paris autoras e disinnadoras cuntemporàneas cun testos a "
-"atzessu lìberu pro creare libros disinnados a finu a indonu e a còdighe "
-"lìberu."
-
-#: book_providers/cita_press_read_button.html
-#: book_providers/direct_read_button.html
-#: book_providers/gutenberg_read_button.html
-#: book_providers/librivox_read_button.html
-#: book_providers/openstax_read_button.html
-#: book_providers/runeberg_read_button.html
-#: book_providers/standard_ebooks_read_button.html
-#: book_providers/wikisource_read_button.html
-msgid "Learn more"
-msgstr "Àteras informatziones"
-
-#: book_providers/direct_read_button.html
-msgid "Read free online"
-msgstr "Leghe de badas in lìnia"
-
-#: book_providers/direct_read_button.html
-#, python-format
-msgid ""
-"This book is freely available from <a href=\"%s\">%s</a>, an external third-"
-"party book provider."
-msgstr ""
-"Custu libru est a disponimentu a indonu in <a href=\"%s\">%s</a>, unu "
-"frunidore esternu de libros de tertza parte."
-
 #: book_providers/gutenberg_download_options.html
 msgid "Download an HTML from Project Gutenberg"
 msgstr "Iscàrriga unu HTML dae su Project Gutenberg"
 
-#: book_providers/gutenberg_download_options.html
-#: book_providers/runeberg_download_options.html
-#: book_providers/standard_ebooks_download_options.html type/list/exports.html
+#: book_providers/gutenberg_download_options.html book_providers/runeberg_download_options.html book_providers/standard_ebooks_download_options.html type/list/exports.html
 msgid "HTML"
 msgstr "HTML"
 
@@ -3101,8 +3305,7 @@ msgstr "HTML"
 msgid "Download a text version from Project Gutenberg"
 msgstr "Iscàrriga una versione testuale dae su Project Gutenberg"
 
-#: book_providers/gutenberg_download_options.html
-#: book_providers/ia_download_options.html
+#: book_providers/gutenberg_download_options.html book_providers/ia_download_options.html
 msgid "Plain text"
 msgstr "Testu simpre"
 
@@ -3121,23 +3324,6 @@ msgstr "Kindle"
 #: book_providers/gutenberg_download_options.html
 msgid "More at Project Gutenberg"
 msgstr "De prus in su Project Gutenberg"
-
-#: book_providers/gutenberg_read_button.html
-msgid "Read eBook from Project Gutenberg"
-msgstr "Leghe libros digitales de su Project Gutenberg"
-
-#: book_providers/gutenberg_read_button.html
-msgid ""
-"This book is available from <a href=\"https://www.gutenberg.org/\">Project "
-"Gutenberg</a>. Project Gutenberg is a trusted book provider of classic "
-"ebooks, supporting thousands of volunteers in the creation and distribution "
-"of over 60,000 free eBooks."
-msgstr ""
-"Custu libru est a disponimentu in su <a href=\"https://www.gutenberg.org/"
-"\">Project Gutenberg</a>. Project Gutenberg est unu frunidore fidadu de "
-"libros eletrònicos clàssicos, chi dat su suportu suo a mìgias de voluntàrios "
-"in sa creatzione e distributzione de prus de 60.000 libros eletrònicos "
-"lìberos."
 
 #: book_providers/ia_download_options.html
 msgid "Download a PDF from Internet Archive"
@@ -3161,9 +3347,7 @@ msgstr "MOBI"
 
 #: book_providers/ia_download_options.html
 msgid "Download open DAISY from Internet Archive (print-disabled format)"
-msgstr ""
-"Iscàrriga unu DAISY abertu dae s'Internet Archive (formadu pro chie tenet "
-"problemas de vista)"
+msgstr "Iscàrriga unu DAISY abertu dae s'Internet Archive (formadu pro chie tenet problemas de vista)"
 
 #: book_providers/ia_download_options.html type/list/embed.html
 msgid "DAISY"
@@ -3189,24 +3373,6 @@ msgstr "Flussu RSS"
 msgid "More at LibriVox"
 msgstr "De prus in Librivox"
 
-#: book_providers/librivox_read_button.html
-msgid "Listen to a reading from LibriVox"
-msgstr "Ascurta una letura dae LibriVox"
-
-#: book_providers/librivox_read_button.html
-msgid "Audiobook"
-msgstr "Libru àudio"
-
-#: book_providers/librivox_read_button.html
-msgid ""
-"This book is available from <a href=\"https://librivox.org/\">LibriVox</a>. "
-"LibriVox is a trusted book provider of public domain audiobooks, narrated by "
-"volunteers, distributed for free on the internet."
-msgstr ""
-"Custu libru est a disponimentu in <a href=\"https://librivox.org/"
-"\">LibriVox</a>. LibriVox est unu frunidore fidadu de libros de domìniu "
-"pùblicu, contados dae voluntàrios, distribuidos a indonu in ìnternet."
-
 #: book_providers/openstax_download_options.html
 msgid "Download PDF from OpenStax"
 msgstr "Iscàrriga PDF dae OpenStax"
@@ -3215,22 +3381,19 @@ msgstr "Iscàrriga PDF dae OpenStax"
 msgid "More at OpenStax"
 msgstr "De prus in OpenStax"
 
-#: book_providers/openstax_read_button.html
-msgid "Read eBook from OpenStax"
-msgstr "Leghe libros de OpenStax"
-
-#: book_providers/openstax_read_button.html
-msgid ""
-"This book is available from <a href=\"https://www.openstax.org/\">OpenStax</"
-"a>. OpenStax is a trusted book provider and a 501(c)(3) nonprofit charitable "
-"corporation dedicated to providing free high-quality, peer-reviewed, openly "
-"licensed textbooks online."
+#: book_providers/read_button.html
+#, fuzzy, python-format
+msgid "Listen to a reading from %s"
 msgstr ""
-"Custu libru est a disponimentu in <a href=\"https://www.openstax.org/"
-"\">OpenStax</a>. OpenStax est unu frunidore fidadu de libros e un'ente de "
-"benefitzèntzia chene punna de lucru chi si dèdicat a frunire de badas e in "
-"lìnia libros de testu de calidade arta, chi ant tentu una revisione "
-"paritària e cun litzèntzia aberta."
+
+#: book_providers/read_button.html
+msgid "Audiobook"
+msgstr "Libru àudio"
+
+#: book_providers/read_button.html
+#, fuzzy, python-format
+msgid "Read free online from %s"
+msgstr ""
 
 #: book_providers/runeberg_download_options.html
 msgid "Download all scanned images from Project Runeberg"
@@ -3254,9 +3417,7 @@ msgstr "Iscàrriga totu sos documentos HTML dae Project Runeberg"
 
 #: book_providers/runeberg_download_options.html
 msgid "Download all text and index files from Project Runeberg"
-msgstr ""
-"Iscàrriga totu sos testos e sos documentos de inditzizatzione dae Project "
-"Runeberg"
+msgstr "Iscàrriga totu sos testos e sos documentos de inditzizatzione dae Project Runeberg"
 
 #: book_providers/runeberg_download_options.html
 msgid "Text and index files"
@@ -3273,20 +3434,6 @@ msgstr "Testu OCR"
 #: book_providers/runeberg_download_options.html
 msgid "More at Project Runeberg"
 msgstr "De prus in Project Runeberg"
-
-#: book_providers/runeberg_read_button.html
-msgid "Read eBook from Project Runeberg"
-msgstr "Leghe libros digitales de Project Runeberg"
-
-#: book_providers/runeberg_read_button.html
-msgid ""
-"This book is available from <a href=\"https://runeberg.org/\">Project "
-"Runeberg</a>. Project Runeberg is a trusted book provider of classic Nordic "
-"(Scandinavian) literature in electronic form."
-msgstr ""
-"Custu libru est a disponimentu in <a href=\"https://runeberg.org/\">Project "
-"Runeberg</a>. Project Gutenberg est unu frunidore fidadu libros de "
-"literadura nòrdica (iscandìnava) clàssica in formadu eletrònicu."
 
 #: book_providers/standard_ebooks_download_options.html
 msgid "Download an HTML from Standard Ebooks"
@@ -3324,24 +3471,6 @@ msgstr "Còdighe de orìgine"
 msgid "More at Standard Ebooks"
 msgstr "De prus in Standard Ebooks"
 
-#: book_providers/standard_ebooks_read_button.html
-msgid "Read eBook from Standard eBooks"
-msgstr "Leghe libros de Standard eBooks"
-
-#: book_providers/standard_ebooks_read_button.html
-msgid ""
-"This book is available from <a href=\"https://standardebooks.org/\">Standard "
-"Ebooks</a>. Standard Ebooks is a trusted book provider and a volunteer-"
-"driven project that produces new editions of public domain ebooks that are "
-"lovingly formatted, open source, free of copyright restrictions, and free of "
-"cost."
-msgstr ""
-"Custu libru est a disponimentu in <a href=\"https://standardebooks.org/"
-"\">Standard Ebooks</a>. Standard Ebooks est unu frunidore fidadu de libros e "
-"unu progetu ghiadu dae voluntàrios chi produit editziones noas de libros "
-"eletrònicos chi sunt formatados cun amore, a còdighe abertu, chene lìmites "
-"de deretu de autore e a indonu."
-
 #: book_providers/wikisource_download_options.html
 msgid "Download PDF from Wikisource"
 msgstr "Iscàrriga PDF dae Wikisource"
@@ -3366,26 +3495,6 @@ msgstr "EPUB (pro su prus de sos àteros letores eletrònicos)"
 msgid "Read at Wikisource"
 msgstr "Leghe in Wikisource"
 
-#: book_providers/wikisource_read_button.html
-msgid "Read eBook on Wikisource"
-msgstr "Leghe su libru eletrònicu in Wikisource"
-
-#: book_providers/wikisource_read_button.html
-msgid ""
-"This book is available from <a href=\"https://wikisource.org/\">Wikisource</"
-"a>. Wikisource, a <a href=\"https://www.wikimedia.org/\">Wikimedia "
-"Foundation</a> project, is a trusted book provider of works available under "
-"the <a href=\"https://creativecommons.org/licenses/by-sa/4.0/\">CC-BY-SA</a> "
-"open content license, such as essays, historical documents, letters, "
-"speeches, and public domain books."
-msgstr ""
-"Custu libru est a disponimentu dae <a href=\"https://wikisource.org/"
-"\">Wikisource</a>. Wikisource, unu progetu de sa <a href=\"https://www."
-"wikimedia.org/\">Fundatzione Wikimedia</a>, est unu frunidore fidadu de "
-"òperas a disponimentu suta de sa litzèntzia de cuntenutos lìberos <a "
-"href=\"https://creativecommons.org/licenses/by-sa/4.0/\">CC-BY-SA</a>, che a "
-"sàgios, documentos istòricos, lìteras, discursos e libros de domìniu pùblicu."
-
 #: books/RelatedWorksCarousel.html
 msgid "You might also like"
 msgstr "Ti diat pòdere agradare fintzas"
@@ -3405,23 +3514,20 @@ msgid "Invalid ISBN checksum digit"
 msgstr "Tzifra de controllu de s'ISBN invàlida"
 
 #: books/add.html
-msgid ""
-"ID must be exactly 10 characters [0-9 or X]. For example 0-19-853453-1 or "
-"0198534531"
-msgstr ""
-"S'ID depet tènnere 10 caràteres esatos [0-9 o X]. A esèmpiu 0-19-853453-1 o "
-"0198534531"
+msgid "ID must be exactly 10 characters [0-9 or X]. For example 0-19-853453-1 or 0198534531"
+msgstr "S'ID depet tènnere 10 caràteres esatos [0-9 o X]. A esèmpiu 0-19-853453-1 o 0198534531"
 
 #: books/add.html
-msgid ""
-"ID must be exactly 13 characters [0-9]. For example 978-3-16-148410-0 or "
-"9783161484100"
-msgstr ""
-"S'ID depet tènnere 13 caràteres esatos [0-9]. A esèmpiu 978-3-16-148410-0 o "
-"9783161484100"
+msgid "ID must be exactly 13 characters [0-9]. For example 978-3-16-148410-0 or 9783161484100"
+msgstr "S'ID depet tènnere 13 caràteres esatos [0-9]. A esèmpiu 978-3-16-148410-0 o 9783161484100"
 
 #: books/add.html
 msgid "Invalid LC Control Number format"
+msgstr "Formadu de su nùmeru de controllu LC non vàlidu"
+
+#: books/add.html
+#, fuzzy
+msgid "Invalid OCLC/WorldCat Control Number format"
 msgstr "Formadu de su nùmeru de controllu LC non vàlidu"
 
 #: books/add.html
@@ -3437,46 +3543,26 @@ msgid "Add a book to Open Library"
 msgstr "Annanghe unu libru a s'Open Library"
 
 #: books/add.html
-msgid ""
-"We require a minimum set of fields to create a new record. These are those "
-"fields."
-msgstr ""
-"Tenimus bisòngiu de un'annantu mìnimu de campos pro creare unu registru nou. "
-"Custos sunt cussos campos."
-
-#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html
-#: search/advancedsearch.html type/about/edit.html type/page/edit.html
-#: type/template/edit.html
-msgid "Title"
-msgstr "Tìtulu"
+msgid "We require a minimum set of fields to create a new record. These are those fields."
+msgstr "Tenimus bisòngiu de un'annantu mìnimu de campos pro creare unu registru nou. Custos sunt cussos campos."
 
 #: books/add.html books/edit.html
 msgid "Use <b><i>Title: Subtitle</i></b> to add a subtitle."
 msgstr "Imprea <b><i>Tìtulu: Sutatìtulu</i></b> pro annànghere unu sutatìtulu."
 
-#: books/add.html books/edit.html type/author/edit.html
-#: type/tag/tag_form_inputs.html
+#: books/add.html books/edit.html type/author/edit.html type/tag/tag_form_inputs.html
 msgid "Required field"
 msgstr "Campu netzessàriu"
 
-#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html
-#: search/advancedsearch.html search/work_search_selected_facets.html
-msgid "Author"
-msgstr "Autore"
-
 #: books/add.html
-msgid ""
-"Like, \"Agatha Christie\" or \"Jean-Paul Sartre.\" We'll also do a live "
-"check to see if we already know the author."
-msgstr ""
-"Che a \"Agatha Christie\" o \"Jean-Paul Sartre.\" Amus a fàghere fintzas una "
-"verìfica in tempus reale pro bìdere si connoschimus giai s'autore."
+msgid "Like, \"Agatha Christie\" or \"Jean-Paul Sartre.\" We'll also do a live check to see if we already know the author."
+msgstr "Che a \"Agatha Christie\" o \"Jean-Paul Sartre.\" Amus a fàghere fintzas una verìfica in tempus reale pro bìdere si connoschimus giai s'autore."
 
 #: books/add.html books/edit/edition.html
 msgid "Who is the publisher?"
 msgstr "Chie est s'editore?"
 
-#: books/add.html books/edit/edition.html books/edit/excerpts.html
+#: books/add.html books/edit/edition.html
 msgid "For example:"
 msgstr "A esèmpiu:"
 
@@ -3493,11 +3579,8 @@ msgid "You should be able to find this in the first few pages of the book."
 msgstr "Dias dèpere pòdere atzapare custu in sas primas pàginas de su libru."
 
 #: books/add.html
-msgid ""
-"And optionally, an ID number &#151; like an ISBN &#151; would be helpful..."
-msgstr ""
-"E, optzionalmente, unu nùmeru ID &#151; che a un'ISBN &#151; diat èssere de "
-"agiudu..."
+msgid "And optionally, an ID number &#151; like an ISBN &#151; would be helpful..."
+msgstr "E, optzionalmente, unu nùmeru ID &#151; che a un'ISBN &#151; diat èssere de agiudu..."
 
 #: books/add.html
 msgid "ID Type"
@@ -3505,9 +3588,7 @@ msgstr "Casta de ID"
 
 #: books/add.html
 msgid "ISBN may be invalid. Click \"Add\" again to submit."
-msgstr ""
-"S'ISBN diat pòdere èssere invàlidu. Torra a incarcare \"Annanghe\" pro "
-"imbiare."
+msgstr "S'ISBN diat pòdere èssere invàlidu. Torra a incarcare \"Annanghe\" pro imbiare."
 
 #: books/add.html type/tag/tag_form_inputs.html
 msgid "Select"
@@ -3530,6 +3611,11 @@ msgid "LibriVox"
 msgstr "Librivox"
 
 #: books/add.html
+#, fuzzy
+msgid "OCLC/WorldCat"
+msgstr "WorldCat"
+
+#: books/add.html
 msgid "Project Gutenberg"
 msgstr "Project Gutenberg"
 
@@ -3541,17 +3627,15 @@ msgstr "URL de su libru"
 msgid "Only fill this out if this is a web book"
 msgstr "Compila custu petzi si est unu libru web"
 
-#: EditButtons.html books/add.html type/tag/form.html
-msgid ""
-"By saving a change to this wiki, you agree that your contribution is given "
-"freely to the world under <a href=\"https://creativecommons.org/publicdomain/"
-"zero/1.0/\" target=\"_blank\" title=\"This link to Creative Commons will "
-"open in a new window\">CC0</a>. Yippee!"
+#: books/add.html
+#, fuzzy, python-format
+msgid "By saving a change to this wiki, you agree that your contribution is given freely to the world under <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" target=\"_blank\" rel=\"noopener noreferrer\" title=\"%(cc_link_title)s\">CC0</a>."
 msgstr ""
-"Sarvende una modìfica a custa wiki atzetas chi sa contributzione tua la daes "
-"in manera lìbera a su mundu suta de sa <a href=\"https://creativecommons.org/"
-"publicdomain/zero/1.0/\" target=\"_blank\" title=\"This link to Creative "
-"Commons will open in a new window\">CC0</a>. Urrà!"
+
+#: books/add.html
+#, fuzzy
+msgid "This link to Creative Commons will open in a new window"
+msgstr "Retzi inditos in Wikipedia in una ventana noa"
 
 #: books/add.html
 msgid "Add this book now"
@@ -3561,7 +3645,7 @@ msgstr "Annanghe custu libru como"
 msgid "Add a new author"
 msgstr "Annanghe un'autore nou"
 
-#: books/author-autocomplete.html
+#: books/author-autocomplete.html books/series-autocomplete.html
 msgid "Create a new record for"
 msgstr "Crea unu registru nou pro"
 
@@ -3579,27 +3663,18 @@ msgstr "Annanghe unu libru"
 
 #: books/check.html
 #, python-format
-msgid ""
-"One moment... It looks like we already have <em>some potential matches</em> "
-"for <b>%(title)s</b> by <b>%(author)s</b>."
-msgstr ""
-"Unu momentu... Paret chi bi siant giai <em>unas cantas currispondèntzias</"
-"em> pro <b>%(title)s</b> de <b>%(author)s</b>."
+msgid "One moment... It looks like we already have <em>some potential matches</em> for <b>%(title)s</b> by <b>%(author)s</b>."
+msgstr "Unu momentu... Paret chi bi siant giai <em>unas cantas currispondèntzias</em> pro <b>%(title)s</b> de <b>%(author)s</b>."
 
 #: books/check.html
-msgid ""
-"Rather than creating a duplicate record, please click through the result you "
-"think best matches your book."
-msgstr ""
-"In càmbiu de creare unu registru dòpiu incarca in su resurtadu chi pensas "
-"chi currispondat mègius cun su libru tuo."
+msgid "Rather than creating a duplicate record, please click through the result you think best matches your book."
+msgstr "In càmbiu de creare unu registru dòpiu incarca in su resurtadu chi pensas chi currispondat mègius cun su libru tuo."
 
 #: books/check.html
 msgid "Select this book"
 msgstr "Seletziona custu libru"
 
-#: SearchResultsWork.html books/check.html merge/authors.html
-#: publishers/view.html
+#: SearchResultsWork.html books/check.html merge/authors.html publishers/view.html
 #, python-format
 msgid "%(count)s edition"
 msgid_plural "%(count)s editions"
@@ -3615,22 +3690,22 @@ msgstr "Publicadu a primu in su %(year)d"
 msgid "None of these match the book I want to add."
 msgstr "Perunu de custos currispondet cun su libru chi bògio annànghere."
 
-#: books/check.html
+#: books/check.html design/button.html
 msgid "Continue"
 msgstr "Sighi"
 
-#: NotInLibrary.html books/custom_carousel.html
-msgid "Not in Library"
-msgstr "No in sa biblioteca"
-
-#: books/custom_carousel.html type/author/view.html
+#: books/custom_carousel_card.html type/author/view.html
 msgid "name missing"
 msgstr "nùmene chi mancat"
 
-#: books/custom_carousel.html books/mobile_carousel.html
+#: books/custom_carousel_card.html books/mobile_carousel.html
 #, python-format
 msgid " by %(name)s"
 msgstr " de %(name)s"
+
+#: books/daisy.html
+msgid "Back"
+msgstr "Antepostu"
 
 #: books/daisy.html
 msgid "Open Library Home"
@@ -3641,67 +3716,21 @@ msgid "There isn't a DAISY file available for "
 msgstr "Non b'at unu documentu DAISY a disponimentu pro "
 
 #: books/daisy.html
-msgid "This DAISY file is protected."
-msgstr "Custu documentu DAISY est amparadu."
-
-#: books/daisy.html
-msgid ""
-"It can only be opened on a specialized device with a key issued by the "
-"Library of Congress."
-msgstr ""
-"Si podet abèrrere petzi cun unu dispositivu ispetzializadu cun una crae "
-"emìtida dae sa Biblioteca de su Cungressu."
-
-#: books/daisy.html
 #, python-format
-msgid ""
-"<a href=\"%(daisy_url)s\"><strong>Download the DAISY.zip</strong></a> for <a "
-"href=\"%(url)s\">%(title)s</a>"
-msgstr ""
-"<a href=\"%(daisy_url)s\"><strong>Iscàrriga su DAISY.zip</strong></a> pro <a "
-"href=\"%(url)s\">%(title)s</a>"
+msgid "<a href=\"%(daisy_url)s\"><strong>Download the DAISY.zip</strong></a> for <a href=\"%(url)s\">%(title)s</a>"
+msgstr "<a href=\"%(daisy_url)s\"><strong>Iscàrriga su DAISY.zip</strong></a> pro <a href=\"%(url)s\">%(title)s</a>"
 
 #: books/daisy.html
 msgid "Books for people who don't read print?"
 msgstr "Libros pro chie non podet lèghere cosa imprentada?"
 
 #: books/daisy.html
-msgid ""
-"The <a href=\"//archive.org\">Internet Archive</a> is proud to be "
-"distributing over 1 million books free in a format called DAISY, designed "
-"for those of us who find it challenging to use regular printed media. "
-msgstr ""
-"S'<a href=\"//archive.org\">Internet Archive</a> est orgogliosu de "
-"distribuire prus de 1 millione de libros a indonu in unu formadu chi si "
-"narat DAISY, progetadu pro sos de nois chi atzapant difìtzile a impreare "
-"mèdios imprentados in manera regulare. "
+msgid "The <a href=\"//archive.org\">Internet Archive</a> is proud to be distributing over 1 million books free in a format called DAISY, designed for those of us who find it challenging to use regular printed media. "
+msgstr "S'<a href=\"//archive.org\">Internet Archive</a> est orgogliosu de distribuire prus de 1 millione de libros a indonu in unu formadu chi si narat DAISY, progetadu pro sos de nois chi atzapant difìtzile a impreare mèdios imprentados in manera regulare. "
 
 #: books/daisy.html
-msgid ""
-"There are two types of DAISYs on Open Library: <i>open</i> and <i>protected</"
-"i>. Open DAISYs can be read by anyone in the world on many different "
-"devices. Protected DAISYs like this one can only be opened using a key "
-"issued by the <a href=\"http://www.loc.gov/nls/\">Library of Congress NLS "
-"program</a>."
-msgstr ""
-"Bi sunt duas castas de DAISY in s'Open Library: <i>abertos</i> e "
-"<i>amparados</i>. Sos DAISY abertos los podet lèghere chie si siat in su "
-"mundu in medas dispositivos diferentes. Sos DAISY amparados che a custu si "
-"podent abèrrere petzi impreende una crae intregada dae su <a href=\"http://"
-"www.loc.gov/nls/\">programma NLS de sa Biblioteca de su Cungressu</a>."
-
-#: books/daisy.html
-msgid ""
-"There are two types of DAISYs on Open Library: <i>open</i> and <i>protected</"
-"i>. Open DAISYs can be read by anyone in the world on many different "
-"devices. Protected DAISYs can only be opened using a key issued by the <a "
-"href=\"http://www.loc.gov/nls/\">Library of Congress NLS program</a>."
-msgstr ""
-"Bi sunt duas castas de DAISY in s'Open Library: <i>abertos</i> e "
-"<i>amparados</i>. Sos DAISY abertos los podet lèghere chie si siat in su "
-"mundu in medas dispositivos diferentes. Sos DAISY amparados si podent "
-"abèrrere petzi impreende una crae intregada dae su <a href=\"http://www.loc."
-"gov/nls/\">programma NLS de sa Biblioteca de su Cungressu</a>."
+msgid "There are two types of DAISYs on Open Library: <i>open</i> and <i>protected</i>. Open DAISYs can be read by anyone in the world on many different devices. Protected DAISYs can only be opened using a key issued by the <a href=\"http://www.loc.gov/nls/\">Library of Congress NLS program</a>."
+msgstr "Bi sunt duas castas de DAISY in s'Open Library: <i>abertos</i> e <i>amparados</i>. Sos DAISY abertos los podet lèghere chie si siat in su mundu in medas dispositivos diferentes. Sos DAISY amparados si podent abèrrere petzi impreende una crae intregada dae su <a href=\"http://www.loc.gov/nls/\">programma NLS de sa Biblioteca de su Cungressu</a>."
 
 #: books/daisy.html lists/home.html
 msgid "Enjoy!"
@@ -3712,17 +3741,8 @@ msgid "What is the DAISY format?"
 msgstr "Ite est su formadu DAISY?"
 
 #: books/daisy.html
-msgid ""
-"The DAISY digital format helps people who have challenges using regular "
-"printed media. DAISY digital <span class=\"highlight\">talking books</span> "
-"offer the benefits of regular audiobooks, with navigation within the book, "
-"to chapters or specific pages."
-msgstr ""
-"Su formadu digitale DAISY agiudat a sas persones chi tenent problemas cun "
-"s'impreu de mèdios imprentados in manera regulare. Sos <span "
-"class=\"highlight\">libros chistionadores</span> digitales DAISY oferint sos "
-"benefìtzios de sos audiolibros regulares cun sa navigatzione a intro de su "
-"libru, cara a sos capìtulos o a a pàginas ispetzìficas."
+msgid "The DAISY digital format helps people who have challenges using regular printed media. DAISY digital <span class=\"highlight\">talking books</span> offer the benefits of regular audiobooks, with navigation within the book, to chapters or specific pages."
+msgstr "Su formadu digitale DAISY agiudat a sas persones chi tenent problemas cun s'impreu de mèdios imprentados in manera regulare. Sos <span class=\"highlight\">libros chistionadores</span> digitales DAISY oferint sos benefìtzios de sos audiolibros regulares cun sa navigatzione a intro de su libru, cara a sos capìtulos o a a pàginas ispetzìficas."
 
 #: books/daisy.html
 msgid "More information at daisy.org"
@@ -3733,19 +3753,8 @@ msgid "What is the NLS?"
 msgstr "Ite est su NLS?"
 
 #: books/daisy.html
-msgid ""
-"The Library of Congress <a href=\"http://www.loc.gov/nls/\">National Library "
-"Service for the Blind and Physically Handicapped (NLS)</a> administers a "
-"free library program of braille and audio materials circulated to eligible "
-"borrowers in the United States through a national network of cooperating "
-"libraries."
-msgstr ""
-"Su <a href=\"http://www.loc.gov/nls/\">National Library Service for the "
-"Blind and Physically Handicapped (NLS)</a> (Servìtziu de biblioteca "
-"natzionale pro sos tzegos e sos disàbiles fìsicos) de sa Biblioteca de su "
-"Cungressu amministrat unu programma a indonu de materiales in braille e "
-"sonoros intregados a gente chi tenet diritu de los pigare in prèstidu in sos "
-"Istados Unidos pro mèdiu de una rete natzionale de bibliotecas chi cooperant."
+msgid "The Library of Congress <a href=\"http://www.loc.gov/nls/\">National Library Service for the Blind and Physically Handicapped (NLS)</a> administers a free library program of braille and audio materials circulated to eligible borrowers in the United States through a national network of cooperating libraries."
+msgstr "Su <a href=\"http://www.loc.gov/nls/\">National Library Service for the Blind and Physically Handicapped (NLS)</a> (Servìtziu de biblioteca natzionale pro sos tzegos e sos disàbiles fìsicos) de sa Biblioteca de su Cungressu amministrat unu programma a indonu de materiales in braille e sonoros intregados a gente chi tenet diritu de los pigare in prèstidu in sos Istados Unidos pro mèdiu de una rete natzionale de bibliotecas chi cooperant."
 
 #: books/daisy.html
 msgid "Are you eligible to register?"
@@ -3756,77 +3765,44 @@ msgid "How do I find DAISYs on Open Library?"
 msgstr "Comente potzo atzapare sos DAISY in s'Open Library?"
 
 #: books/daisy.html
-msgid ""
-"In addition to<a href=\"/subjects/accessible_book\" title=\"Subject: "
-"Accessible book\"> loads of open DAISYs</a>, the Open Library lists a "
-"smaller selection of<a href=\"/subjects/protected_DAISY\" title=\"Subject: "
-"Protected DAISY\"> protected DAISY titles</a> accessible to those with a "
-"Library of Congress NLS key. These titles are brought to you by the<a "
-"href=\"//archive.org/\"> Internet Archive</a>."
-msgstr ""
-"Paris a<a href=\"/subjects/accessible_book\" title=\"Subject: Accessible "
-"book\"> unu muntone de DAISY abertos</a>, s'Open Library tenent in lista una "
-"seletzione prus minore de<a href=\"/subjects/protected_DAISY\" "
-"title=\"Subject: Protected DAISY\"> tìtulos DAISY amparados</a>, chi bi "
-"podent atzèdere sos chi tenent una crae NLS de sa Biblioteca de su "
-"Cungressu. Custos tìtulos los frunit s'<a href=\"//archive.org/\">Internet "
-"Archive</a>."
+msgid "In addition to<a href=\"/subjects/accessible_book\" title=\"Subject: Accessible book\"> loads of open DAISYs</a>, the Open Library lists a smaller selection of<a href=\"/subjects/protected_DAISY\" title=\"Subject: Protected DAISY\"> protected DAISY titles</a> accessible to those with a Library of Congress NLS key. These titles are brought to you by the<a href=\"//archive.org/\"> Internet Archive</a>."
+msgstr "Paris a<a href=\"/subjects/accessible_book\" title=\"Subject: Accessible book\"> unu muntone de DAISY abertos</a>, s'Open Library tenent in lista una seletzione prus minore de<a href=\"/subjects/protected_DAISY\" title=\"Subject: Protected DAISY\"> tìtulos DAISY amparados</a>, chi bi podent atzèdere sos chi tenent una crae NLS de sa Biblioteca de su Cungressu. Custos tìtulos los frunit s'<a href=\"//archive.org/\">Internet Archive</a>."
 
 #: books/daisy.html
-msgid ""
-"Looking for a specific title? The best way to find it is to<a href=\"/"
-"search\"> search for it</a>."
-msgstr ""
-"Ti bisòngiat unu tìtulu ispetzìficu? Sa mègius manera de l'atzapare est a <a "
-"href=\"/search\"> lu chircare</a>."
+msgid "Looking for a specific title? The best way to find it is to<a href=\"/search\"> search for it</a>."
+msgstr "Ti bisòngiat unu tìtulu ispetzìficu? Sa mègius manera de l'atzapare est a <a href=\"/search\"> lu chircare</a>."
 
-#: books/daisy.html lib/history.html
+#: books/daisy.html lib/exports.html
 msgid "Need help?"
 msgstr "Ti bisòngiat agiudu?"
 
 #: books/daisy.html
-msgid ""
-" Please read our <a href=\"/help/faq\">FAQ on accessing books through Open "
-"Library</a>."
-msgstr ""
-" Leghe·ti sas <a href=\"/help/faq\">PF nostras subra de s'atzessu a sos "
-"libros pro mèdiu de s'Open Library</a>."
+msgid " Please read our <a href=\"/help/faq\">FAQ on accessing books through Open Library</a>."
+msgstr " Leghe·ti sas <a href=\"/help/faq\">PF nostras subra de s'atzessu a sos libros pro mèdiu de s'Open Library</a>."
 
 #: books/edit.html
 msgid "Add a little more?"
 msgstr "Annànghere carchi cosa de prus?"
 
 #: books/edit.html
-msgid ""
-"Thank you for adding that book! Any more information you could provide would "
-"be wonderful!"
-msgstr ""
-"Gràtzias pro àere annantu cussu libru! Cale si siat àtera informatzione tue "
-"potzas frunire diat èssere una cosa bona meda!"
+msgid "Thank you for adding that book! Any more information you could provide would be wonderful!"
+msgstr "Gràtzias pro àere annantu cussu libru! Cale si siat àtera informatzione tue potzas frunire diat èssere una cosa bona meda!"
 
 #: books/edit.html
 #, python-format
-msgid ""
-"We already know about <b>%(work_title)s</b>, but not the <b>%(year)s "
-"%(publisher)s edition</b>. Thanks! Do you know any more about this edition?"
-msgstr ""
-"Connoschimus giai <b>%(work_title)s</b>, ma non s'editzione <b>%(year)s de "
-"%(publisher)s</b>. Gràtzias! Ischis àtera cosa subra de custa editzione?"
+msgid "We already know about <b>%(work_title)s</b>, but not the <b>%(year)s %(publisher)s edition</b>. Thanks! Do you know any more about this edition?"
+msgstr "Connoschimus giai <b>%(work_title)s</b>, ma non s'editzione <b>%(year)s de %(publisher)s</b>. Gràtzias! Ischis àtera cosa subra de custa editzione?"
 
 #: books/edit.html
 #, python-format
-msgid ""
-"We already know about the <b>%(year)s %(publisher)s edition</b> of "
-"<b>%(work_title)s</b>, but please, tell us more!"
-msgstr ""
-"Connoschimus giai s'<b>editzione %(publisher)s de su %(year)s</b> de "
-"<b>%(work_title)s</b>, ma, pro praghere, nara·nos carchi cosa de prus!"
+msgid "We already know about the <b>%(year)s %(publisher)s edition</b> of <b>%(work_title)s</b>, but please, tell us more!"
+msgstr "Connoschimus giai s'<b>editzione %(publisher)s de su %(year)s</b> de <b>%(work_title)s</b>, ma, pro praghere, nara·nos carchi cosa de prus!"
 
 #: books/edit.html
 msgid "Editing..."
 msgstr "Modifichende..."
 
-#: books/edit.html type/author/edit.html type/template/edit.html
+#: books/edit.html type/author/edit.html type/tag/form.html type/template/edit.html
 msgid "Delete Record"
 msgstr "Iscantzella su registru"
 
@@ -3843,14 +3819,9 @@ msgid "This Work"
 msgstr "Cust'òpera"
 
 #: books/edit.html
-msgid ""
-"You can search by author name (like <em>j k rowling</em>) or by Open Library "
-"ID (like <a href=\"/authors/OL23919A\" target=\"_blank\"><em>OL23919A</em></"
-"a>)."
+#, fuzzy
+msgid "You can search by author name (like <em>j k rowling</em>) or by Open Library ID (like <a href=\"/authors/OL23919A\" target=\"_blank\" rel=\"noopener noreferrer\"><em>OL23919A</em></a>)."
 msgstr ""
-"Podes chircare impreende su nùmene de s'autore (che a <em>j k rowling</em>) "
-"o s'ID de Open Library (che a <a href=\"/authors/OL23919A\" "
-"target=\"_blank\"><em>OL23919A</em></a>)."
 
 #: books/edit.html
 msgid "Author editing requires javascript"
@@ -3864,6 +3835,23 @@ msgstr "Annanghe estratos"
 msgid "Links"
 msgstr "Ligàmenes"
 
+#: books/edit.html
+#, fuzzy
+msgid "Work Series"
+msgstr "Òperas aunidas"
+
+#: books/edit.html
+msgid "Series are currently in beta, and this section is only visible to super librarians and admins, like you! Any series you set will be visible by everyone, however. Please report any issues you have on Slack or GitHub."
+msgstr "Is series sunt atualmente in beta, e custa sètzione est visìbile petzi pro bibliotecàrios super e amministradores, comente tue! Calsissiat serie chi programmas at a esser visìbile pro totus, però. Pro praghere segnala is problemas chi as in Slack o GitHub."
+
+#: books/edit.html
+msgid "Is this work part of a larger series?"
+msgstr "Custu traballu est parte de una serie prus manna?"
+
+#: books/edit.html
+msgid "E.g. Harry Potter, The Sword of Truth"
+msgstr "P.e. Harry Potter, The Sword of Truth"
+
 #: books/edit.html type/edition/view.html type/work/view.html
 msgid "Work Identifiers"
 msgstr "Identificadores de òpera"
@@ -3873,20 +3861,10 @@ msgid "Do you know any identifiers for this work?"
 msgstr "Connosches carchi identificadore pro cust'òpera?"
 
 #: books/edit.html
-msgid ""
-"These identifiers apply to all editions of this work, for example Wikidata "
-"work identifiers. For edition-specific identifiers, like ISBN or LCCN, go to "
-"the edition tab."
-msgstr ""
-"Custos identificadores s'àplicant a totu sas editziones de custa òpera, che "
-"a esèmpiu sos identificadores de òpera de Wikidata. Pro sos identificadores "
-"ispetzìficos pro editzione, che a sos ISBN o sos LCCN, bae a s'ischeda de "
-"s'editzione."
+msgid "These identifiers apply to all editions of this work, for example Wikidata work identifiers. For edition-specific identifiers, like ISBN or LCCN, go to the edition tab."
+msgstr "Custos identificadores s'àplicant a totu sas editziones de custa òpera, che a esèmpiu sos identificadores de òpera de Wikidata. Pro sos identificadores ispetzìficos pro editzione, che a sos ISBN o sos LCCN, bae a s'ischeda de s'editzione."
 
-#: FulltextSearchSuggestionItem.html IABook.html SearchResultsWork.html
-#: books/edition-sort.html jsdef/LazyWorkPreview.html lists/list_overview.html
-#: lists/preview.html lists/snippet.html lists/widget.html
-#: my_books/dropdown_content.html type/work/editions.html
+#: FulltextSearchSuggestionItem.html IABook.html SearchResultsWork.html books/edition-sort.html jsdef/LazyWorkPreview.html lists/list_overview.html lists/preview.html lists/snippet.html lists/widget.html my_books/dropdown_content.html type/work/editions.html
 #, python-format
 msgid "Cover of: %(title)s"
 msgstr "Cobertedda de: %(title)s"
@@ -3906,39 +3884,79 @@ msgstr "Data de publicatzione disconnota, %(publisher)s"
 msgid "in %(languagelist)s"
 msgstr "in %(languagelist)s"
 
-#: SearchNavigation.html books/mybooks_breadcrumb_select.html lib/nav_foot.html
-#: mybooks.py
+#: SearchNavigation.html books/mybooks_breadcrumb_select.html lib/nav_foot.html openlibrary/plugins/upstream/mybooks.py
 msgid "Books"
 msgstr "Libros"
 
-#: books/mybooks_breadcrumb_select.html mybooks.py
+#. Page title for the "Want to Read" shelf page.
+#. Example: "Want to Read (17)". %(count)d is the number of books on this
+#. shelf.
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #, python-format
 msgid "Want to Read (%(count)d)"
 msgstr "Bògio lèghere (%(count)d)"
 
-#: books/mybooks_breadcrumb_select.html mybooks.py
+#. Page title for the "Currently Reading" shelf page.
+#. Example: "Currently Reading (42)". %(count)d is the number of books on this
+#. shelf.
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #, python-format
 msgid "Currently Reading (%(count)d)"
 msgstr "Leghende como (%(count)d)"
 
-#: books/mybooks_breadcrumb_select.html mybooks.py
+#. Page title for the "Already Read" shelf page.
+#. Example: "Already Read (203)". %(count)d is the number of books on this
+#. shelf.
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #, python-format
 msgid "Already Read (%(count)d)"
 msgstr "Giai lèghidos (%(count)d)"
 
-#: books/mybooks_breadcrumb_select.html
+#. Page title for the "Stopped Reading" shelf page.
+#. Example: "Stopped Reading (8)". %(count)d is the number of books on this
+#. shelf.
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#, fuzzy, python-format
+msgid "Stopped Reading (%(count)d)"
+msgstr "Leghende como (%(count)d)"
+
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/openlibrary/lists.py
 #, python-format
 msgid "Lists (%(count)d)"
 msgstr "Listas (%(count)d)"
 
-#: books/mybooks_breadcrumb_select.html mybooks.py
-#: type/edition/modal_links.html
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py type/edition/modal_links.html
 msgid "Notes"
 msgstr "Notas"
 
-#: account.py books/mybooks_breadcrumb_select.html
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
 msgid "Imports and Exports"
 msgstr "Importatziones e esportatziones"
+
+#: books/series-autocomplete.html
+#, fuzzy
+msgid "Add a new series"
+msgstr "Annanghe unu ruolu nou"
+
+#: books/series-autocomplete.html
+#, fuzzy
+msgid "Series name"
+msgstr "Nùmene de utente"
+
+#: books/series-autocomplete.html
+#, fuzzy
+msgid "Series position"
+msgstr "Permissu"
+
+#: books/series-autocomplete.html
+#, fuzzy
+msgid "Remove this series"
+msgstr "Bogare custu elementu?"
+
+#: books/series-autocomplete.html
+#, fuzzy
+msgid "Add another series?"
+msgstr "Annanghe un'àtera immàgine"
 
 #: books/edit/about.html
 msgid "Select this subject"
@@ -3961,56 +3979,32 @@ msgid "Please separate with commas."
 msgstr "Separa·las cun vìrgulas."
 
 #: books/edit/about.html
-msgid ""
-"For example: <i><a href=\"/subjects/cheese\">cheese</a>, <a href=\"/subjects/"
-"roman_empire\">Roman Empire</a>, <a href=\"/subjects/"
-"psychology\">psychology</a></i>"
-msgstr ""
-"Pro esèmpiu: <i><a href=\"/subjects/cheese\">casu</a>, <a href=\"/subjects/"
-"roman_empire\">Impèriu romanu</a>, <a href=\"/subjects/"
-"psychology\">psicologia</a></i>"
+msgid "For example: <i><a href=\"/subjects/cheese\">cheese</a>, <a href=\"/subjects/roman_empire\">Roman Empire</a>, <a href=\"/subjects/psychology\">psychology</a></i>"
+msgstr "Pro esèmpiu: <i><a href=\"/subjects/cheese\">casu</a>, <a href=\"/subjects/roman_empire\">Impèriu romanu</a>, <a href=\"/subjects/psychology\">psicologia</a></i>"
 
 #: books/edit/about.html
 msgid "A person? Or, people?"
 msgstr "Una persone? O grupos de persones?"
 
 #: books/edit/about.html
-msgid ""
-"For example: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore "
-"Roosevelt</a>, <a href=\"/subjects/person:Julian_of_Norwich\">Julian of "
-"Norwich</a>, <a href=\"/subjects/person:Tintin\">Tintin</a></i>"
-msgstr ""
-"Pro esèmpiu: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore "
-"Roosevelt</a>, <a href=\"/subjects/person:Julian_of_Norwich\">Julian of "
-"Norwich</a>, <a href=\"/subjects/person:Tintin\">Tintin</a></i>"
+msgid "For example: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore Roosevelt</a>, <a href=\"/subjects/person:Julian_of_Norwich\">Julian of Norwich</a>, <a href=\"/subjects/person:Tintin\">Tintin</a></i>"
+msgstr "Pro esèmpiu: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore Roosevelt</a>, <a href=\"/subjects/person:Julian_of_Norwich\">Julian of Norwich</a>, <a href=\"/subjects/person:Tintin\">Tintin</a></i>"
 
 #: books/edit/about.html
 msgid "Note any places mentioned?"
 msgstr "Notas carchi logu mentovadu?"
 
 #: books/edit/about.html
-msgid ""
-"For example: <i><a href=\"/subjects/place:London\">London</a>, <a href=\"/"
-"subjects/place:Atlantis\">Atlantis</a>, <a href=\"/subjects/place:"
-"Omaha\">Omaha</a></i>"
-msgstr ""
-"Pro esèmpiu: <i><a href=\"/subjects/place:London\">Londra</a>, <a href=\"/"
-"subjects/place:Atlantis\">Atlàntide</a>, <a href=\"/subjects/place:"
-"Omaha\">Omaha</a></i>"
+msgid "For example: <i><a href=\"/subjects/place:London\">London</a>, <a href=\"/subjects/place:Atlantis\">Atlantis</a>, <a href=\"/subjects/place:Omaha\">Omaha</a></i>"
+msgstr "Pro esèmpiu: <i><a href=\"/subjects/place:London\">Londra</a>, <a href=\"/subjects/place:Atlantis\">Atlàntide</a>, <a href=\"/subjects/place:Omaha\">Omaha</a></i>"
 
 #: books/edit/about.html
 msgid "When is it set or about?"
 msgstr "Cando est ambientadu o de cando chistionat?"
 
 #: books/edit/about.html
-msgid ""
-"For example: <i><a href=\"/subjects/time:1984\">1984</a>, <a href=\"/"
-"subjects/time:the_middle_ages\">The Middle Ages</a>, <a href=\"/subjects/"
-"time:1810-1890\">1810-1890</a></i>"
-msgstr ""
-"Pro esèmpiu: <i><a href=\"/subjects/time:1984\">1984</a>, <a href=\"/"
-"subjects/time:the_middle_ages\">The Middle Ages</a>, <a href=\"/subjects/"
-"time:1810-1890\">1810-1890</a></i>"
+msgid "For example: <i><a href=\"/subjects/time:1984\">1984</a>, <a href=\"/subjects/time:the_middle_ages\">The Middle Ages</a>, <a href=\"/subjects/time:1810-1890\">1810-1890</a></i>"
+msgstr "Pro esèmpiu: <i><a href=\"/subjects/time:1984\">1984</a>, <a href=\"/subjects/time:the_middle_ages\">The Middle Ages</a>, <a href=\"/subjects/time:1810-1890\">1810-1890</a></i>"
 
 #: books/edit/edition.html
 msgid "Select this language"
@@ -4045,6 +4039,10 @@ msgid "Usually distinguished by different or smaller type."
 msgstr "Contraddistintu, de sòlitu, dae unu caràtere diferente o prus minore."
 
 #: books/edit/edition.html
+msgid "For example: <i>envisioning the next 50 years</i>"
+msgstr "Pro esempiu: <i>envisioning the next 50 years</i>"
+
+#: books/edit/edition.html
 msgid "Publishing Info"
 msgstr "Informatziones de publicatzione"
 
@@ -4061,6 +4059,11 @@ msgid "City, Country please."
 msgstr "Tzitade, Paisu pro praghere."
 
 #: books/edit/edition.html
+#, fuzzy
+msgid "For example: <i>New York, USA; Sydney, Australia</i>"
+msgstr ""
+
+#: books/edit/edition.html
 msgid "What is the copyright date?"
 msgstr "Cal'est sa data de su deretu de autore?"
 
@@ -4073,12 +4076,20 @@ msgid "Edition Name (if applicable):"
 msgstr "Nùmene de s'editzione (si si podet aplicare):"
 
 #: books/edit/edition.html
+msgid "For example: <i>Centennial edition</i>; <i>First edition</i>"
+msgstr "Pro esempiu: <i>Centennial edition</i>; <i>First edition</i>"
+
+#: books/edit/edition.html
 msgid "Series Name (if applicable)"
 msgstr "Nùmene de sa sèrie (si si podet aplicare)"
 
 #: books/edit/edition.html
 msgid "The name of the publisher's series."
 msgstr "Nùmene de sa serie de s'editore."
+
+#: books/edit/edition.html
+msgid "For example: <i>The Story of Civilization, Part III</i>"
+msgstr "Pro esempiu: <i>The Story of Civilization, Part III</i>"
 
 #: books/edit/edition.html type/edition/view.html type/work/view.html
 msgid "Contributors"
@@ -4157,23 +4168,12 @@ msgid "Table of Contents"
 msgstr "Ìnditze"
 
 #: books/edit/edition.html
-msgid ""
-"Use a \"*\" for an indent, a \"|\" to add a column, and line breaks for new "
-"lines. Like this:"
-msgstr ""
-"Imprea unu \"*\" pro un'indentatzione, unu \"|\" pro annànghere una colonna, "
-"e unu brincu de riga pro rigas noas. A tipu gasi:"
+msgid "Use a \"*\" for an indent, a \"|\" to add a column, and line breaks for new lines. Like this:"
+msgstr "Imprea unu \"*\" pro un'indentatzione, unu \"|\" pro annànghere una colonna, e unu brincu de riga pro rigas noas. A tipu gasi:"
 
 #: books/edit/edition.html
-msgid ""
-"This table of contents contains extra information like authors or "
-"descriptions. We don't have a great user interface for this yet, so editing "
-"this data could be difficult. Watch out!"
-msgstr ""
-"Custu ìnditze cuntenet informatziones in prus che a sos autores o sas "
-"descritziones. Non tenimus galu una interfache de utente de primore pro "
-"custu, duncas a modificare custos datos diat pòdere èssere difìtzile. Dae "
-"cara!"
+msgid "This table of contents contains extra information like authors or descriptions. We don't have a great user interface for this yet, so editing this data could be difficult. Watch out!"
+msgstr "Custu ìnditze cuntenet informatziones in prus che a sos autores o sas descritziones. Non tenimus galu una interfache de utente de primore pro custu, duncas a modificare custos datos diat pòdere èssere difìtzile. Dae cara!"
 
 #: books/edit/edition.html
 msgid "Any notes about this specific edition?"
@@ -4181,56 +4181,41 @@ msgstr "Notas chi pertocant a custa editzione ispetzìfica?"
 
 #: books/edit/edition.html
 msgid "Anything about the book that may be of interest."
-msgstr ""
-"Cale si siat cosa subra de su libru chi diat pòdere èssere de interessu."
+msgstr "Cale si siat cosa subra de su libru chi diat pòdere èssere de interessu."
+
+#: books/edit/edition.html
+#, fuzzy
+msgid "A Plume Book"
+msgstr "Esplora libros"
 
 #: books/edit/edition.html
 msgid "Is it known by any other titles?"
 msgstr "Est connotu cun àteros tìtulos?"
 
 #: books/edit/edition.html
-msgid ""
-"Use this field if the title is different on the cover or spine. If the "
-"edition is a collection or anthology, you may also add the individual titles "
-"of each work here."
-msgstr ""
-"Imprea custu campu si su tìtulu est diferente in sa cobertedda o in "
-"s'ischina. Si s'editzione est una colletzione o antologia podes fintzas "
-"annànghere su tìtulu individuale de cada òpera inoghe."
+msgid "Use this field if the title is different on the cover or spine. If the edition is a collection or anthology, you may also add the individual titles of each work here."
+msgstr "Imprea custu campu si su tìtulu est diferente in sa cobertedda o in s'ischina. Si s'editzione est una colletzione o antologia podes fintzas annànghere su tìtulu individuale de cada òpera inoghe."
 
 #: books/edit/edition.html
-msgid ""
-"For example: <i>Eaters of the Dead</i> is an alternate title for <i><a "
-"href=\"/books/OL24923038M\">The 13th Warrior</a></i>."
-msgstr ""
-"Pro esèmpiu: <i>Eaters of the Dead</i> est unu tìtulu alternativu pro <i><a "
-"href=\"/books/OL24923038M\">The 13th Warrior</a></i>."
+msgid "For example: <i>Eaters of the Dead</i> is an alternate title for <i><a href=\"/books/OL24923038M\">The 13th Warrior</a></i>."
+msgstr "Pro esèmpiu: <i>Eaters of the Dead</i> est unu tìtulu alternativu pro <i><a href=\"/books/OL24923038M\">The 13th Warrior</a></i>."
 
 #: books/edit/edition.html
 msgid "What work is this an edition of?"
 msgstr "Custa est un'editzione de cale òpera?"
 
 #: books/edit/edition.html
-msgid ""
-"Sometimes editions can be associated with the wrong work. You can correct "
-"that here."
-msgstr ""
-"A bortas sas editziones podent èssere assotziadas a s'òpera isballiada. Lu "
-"podes currègere inoghe."
+msgid "Sometimes editions can be associated with the wrong work. You can correct that here."
+msgstr "A bortas sas editziones podent èssere assotziadas a s'òpera isballiada. Lu podes currègere inoghe."
 
 #: books/edit/edition.html
-msgid ""
-"You can search by title or by Open Library ID (like <a href=\"/works/"
-"OL262757W\" target=\"_blank\"><em>OL262757W</em></a>)."
+#, fuzzy
+msgid "You can search by title or by Open Library ID (like <a href=\"/works/OL262757W\" target=\"_blank\" rel=\"noopener noreferrer\"><em>OL262757W</em></a>)."
 msgstr ""
-"Podes chircare impreende su tìtulu o s'ID de Open Library (che a <a href=\"/"
-"works/OL262757W\" target=\"_blank\"><em>OL262757W</em></a>)."
 
 #: books/edit/edition.html
 msgid "WARNING: Any edits made to the work from this page will be ignored."
-msgstr ""
-"DAE CARA: Cale si siat modìfica fata a s'òpera dae custa pàgina at a èssere "
-"ignorada."
+msgstr "DAE CARA: Cale si siat modìfica fata a s'òpera dae custa pàgina at a èssere ignorada."
 
 #: books/edit/edition.html
 msgid "Copy authors to new work"
@@ -4262,8 +4247,7 @@ msgstr "Custu ID esistit giai pro custa editzione."
 
 #: books/edit/edition.html
 msgid "ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4"
-msgstr ""
-"s'ID depet èssere de 13 caràteres [0-9] esatos. A esèmpiu: 978-1-56619-909-4"
+msgstr "s'ID depet èssere de 13 caràteres [0-9] esatos. A esèmpiu: 978-1-56619-909-4"
 
 #: books/edit/edition.html
 msgid "Invalid ID format"
@@ -4426,16 +4410,17 @@ msgid "That excerpt is too long."
 msgstr "Custu estratu est tropu longu."
 
 #: books/edit/excerpts.html
-msgid ""
-"If there are particular (short) passages you feel represent the book well, "
-"please feel free to transcribe them here."
-msgstr ""
-"Si b'at passàgios (curtzos) chi pensas chi rapresentent su libru comente si "
-"tocat, pro praghere trascrie·los inoghe."
+msgid "If there are particular (short) passages you feel represent the book well, please feel free to transcribe them here."
+msgstr "Si b'at passàgios (curtzos) chi pensas chi rapresentent su libru comente si tocat, pro praghere trascrie·los inoghe."
 
 #: books/edit/excerpts.html
 msgid "Page number?"
 msgstr "Nùmeru de pàgina?"
+
+#: books/edit/excerpts.html
+#, fuzzy
+msgid "For example: <i>23, xi or 433-434</i>"
+msgstr ""
 
 #: books/edit/excerpts.html
 msgid "This excerpt is the first sentence of the book."
@@ -4486,12 +4471,8 @@ msgid "Please enter a valid URL."
 msgstr "Pro praghere fruni un'URL vàlidu."
 
 #: books/edit/web.html
-msgid ""
-"Please connect Open Library records to <u>good</u><span class=\"orange\">*</"
-"span> online resources."
-msgstr ""
-"Collega sos registros de s'Open Library a resursas in lìnia <u>bonas</"
-"u><span class=\"orange\">*</span>."
+msgid "Please connect Open Library records to <u>good</u><span class=\"orange\">*</span> online resources."
+msgstr "Collega sos registros de s'Open Library a resursas in lìnia <u>bonas</u><span class=\"orange\">*</span>."
 
 #: books/edit/web.html
 msgid "Give your link a label"
@@ -4514,153 +4495,16 @@ msgid "Remove this link"
 msgstr "Boga custu ligàmene"
 
 #: books/edit/web.html
-msgid ""
-"\"Good\" means no spammy links, please. Keep them relevant to the book. "
-"Irrelevant sites may be removed. Blatant spam will be deleted without "
-"remorse."
-msgstr ""
-"\"Bonas\" bolet nàrrere chi non siat ligàmenes de arga, pro praghere. "
-"Mantene·los rilevantes pro su libru. Sitos chene rilevàntzia diat pòdere "
-"èssere bogados. Arga ladina at a èssere iscantzellada chene impudu."
+msgid "\"Good\" means no spammy links, please. Keep them relevant to the book. Irrelevant sites may be removed. Blatant spam will be deleted without remorse."
+msgstr "\"Bonas\" bolet nàrrere chi non siat ligàmenes de arga, pro praghere. Mantene·los rilevantes pro su libru. Sitos chene rilevàntzia diat pòdere èssere bogados. Arga ladina at a èssere iscantzellada chene impudu."
 
-#: bulk_search/bulk_search.html
+#: bulk_search/bulk_search.html search/advancedsearch.html
 msgid "Bulk Search (beta)"
 msgstr "Chirca de lotos (beta)"
 
-#: check_ins/check_in_form.html
-msgid "January"
-msgstr "Ghennàrgiu"
-
-#: check_ins/check_in_form.html
-msgid "February"
-msgstr "Freàrgiu"
-
-#: check_ins/check_in_form.html
-msgid "March"
-msgstr "Martzu"
-
-#: check_ins/check_in_form.html
-msgid "April"
-msgstr "Abrile"
-
-#: check_ins/check_in_form.html
-msgid "May"
-msgstr "Maju"
-
-#: check_ins/check_in_form.html
-msgid "June"
-msgstr "Làmpadas"
-
-#: check_ins/check_in_form.html
-msgid "July"
-msgstr "Trìulas"
-
-#: check_ins/check_in_form.html
-msgid "August"
-msgstr "Austu"
-
-#: check_ins/check_in_form.html
-msgid "September"
-msgstr "Cabudanni"
-
-#: check_ins/check_in_form.html
-msgid "October"
-msgstr "Santugaine"
-
-#: check_ins/check_in_form.html
-msgid "November"
-msgstr "Santandria"
-
-#: check_ins/check_in_form.html
-msgid "December"
-msgstr "Nadale"
-
-#: check_ins/check_in_form.html
-msgid ""
-"Add an optional check-in date.  Check-in dates are used to track yearly "
-"reading goals."
-msgstr ""
-"Annanghe una data optzionale de registratzione. Sas datas de registratzione "
-"s'impreant pro arrastare sos obietivos annuales de leghidura."
-
-#: check_ins/check_in_form.html
-msgid "End Date:"
-msgstr "Data de fine:"
-
-#: check_ins/check_in_form.html
-msgid "Year:"
-msgstr "Annu:"
-
-#: check_ins/check_in_form.html
-msgid "Year"
-msgstr "Annu"
-
-#: check_ins/check_in_form.html
-msgid "Month:"
-msgstr "Mese:"
-
-#: check_ins/check_in_form.html
-msgid "Month"
-msgstr "Mese"
-
-#: check_ins/check_in_form.html
-msgid "Day:"
-msgstr "Die:"
-
-#: check_ins/check_in_form.html
-msgid "Day"
-msgstr "Die"
-
-#: check_ins/check_in_form.html
-msgid "Delete Event"
-msgstr "Iscantzella s'eventu"
-
-#: check_ins/check_in_prompt.html
-#, python-format
-msgid "Read <time class=\"check-in-date\">%(date)s</time>"
-msgstr "Lèghidu su <time class=\"check-in-date\">%(date)s</time>"
-
-#: check_ins/check_in_prompt.html
-msgid "When did you finish this book?"
-msgstr "Cando as acabadu custu libru?"
-
-#: check_ins/check_in_prompt.html
-msgid "Other"
-msgstr "Àteru"
-
-#: check_ins/check_in_prompt.html
-msgid "Check-In"
-msgstr "Registratzione"
-
-#: check_ins/reading_goal_form.html
-msgid "How many books would you like to read this year?"
-msgstr "Cantos libros dias bòlere lèghere cust'annu?"
-
-#: check_ins/reading_goal_form.html
-msgid ""
-"Enter \"0\" to unset your reading goal. Your check-ins will be preserved."
-msgstr ""
-"Inserta \"0\" pro annullare s'obietivu de letura tuo. Sas registratziones "
-"tuas s'ant a preservare."
-
-#: check_ins/reading_goal_progress.html
-#, python-format
-msgid ""
-"<span class=\"reading-goal-progress__books-read\">%(books_read)d</span>/"
-"<span class=\"reading-goal-progress__goal\">%(goal)d</span> Books"
-msgstr ""
-"<span class=\"reading-goal-progress__books-read\">%(books_read)d</span>/"
-"<span class=\"reading-goal-progress__goal\">%(goal)d</span> libros"
-
-#: check_ins/reading_goal_progress.html
-#, python-format
-msgid "Edit %(year)d Reading Goal"
-msgstr "Modìfica s'obietivu de leghidura pro su %(year)d"
-
 #: covers/add.html
 msgid "There are two ways to put an author's image on Open Library."
-msgstr ""
-"B'at duas maneras pro pònnere un'immàgine de un'autore in s'Open Library."
+msgstr "B'at duas maneras pro pònnere un'immàgine de un'autore in s'Open Library."
 
 #: covers/add.html
 msgid "Image Guidelines"
@@ -4668,8 +4512,7 @@ msgstr "Lìnias de ghia pro sas immàgines"
 
 #: covers/add.html
 msgid "There are a few ways to put a cover image on Open Library."
-msgstr ""
-"B'at duas maneras pro pònnere un'immàgine de cobertedda in s'Open Library."
+msgstr "B'at duas maneras pro pònnere un'immàgine de cobertedda in s'Open Library."
 
 #: covers/add.html
 msgid "Cover Guidelines"
@@ -4685,12 +4528,8 @@ msgstr "Pro praghere càrriga un'URL vàlidu."
 
 #: covers/add.html
 #, python-format
-msgid ""
-"Learn more by reading our <a href=\"/help/faq/editing#picture\" "
-"target=\"blank\">%(guidelines)s</a>."
-msgstr ""
-"Impara de prus leghende·ti sas <a href=\"/help/faq/editing#picture\" "
-"target=\"blank\">%(guidelines)s</a> nostras."
+msgid "Learn more by reading our <a href=\"/help/faq/editing#picture\" target=\"blank\">%(guidelines)s</a>."
+msgstr "Impara de prus leghende·ti sas <a href=\"/help/faq/editing#picture\" target=\"blank\">%(guidelines)s</a> nostras."
 
 #: covers/add.html
 msgid "<strong>Pick one</strong> from the existing covers"
@@ -4701,7 +4540,8 @@ msgid "Use this image"
 msgstr "Imprea custa immàgine"
 
 #: covers/add.html
-msgid "Choose a JPG, GIF or PNG on your computer"
+#, fuzzy
+msgid "Choose a JPG, GIF, PNG or WebP on your computer"
 msgstr "Issèbera unu JPG, GIF o PNG in s'elaboradore tuo"
 
 #: covers/add.html
@@ -4709,12 +4549,36 @@ msgid "Upload"
 msgstr "Càrriga"
 
 #: covers/add.html
-msgid "Or, use the the cover from Internet Archive"
-msgstr "O imprea sa cobertedda dae s'Internet Archive"
+msgid "Or, paste an image from your clipboard"
+msgstr "O pure, incolla un'ìmaggine dae sa clipboard tua"
+
+#: covers/add.html
+msgid "Paste image from clipboard"
+msgstr "Incolla ìmaggine dae sa clipboard"
+
+#: covers/add.html
+#, fuzzy
+msgid "Paste Image"
+msgstr "Annanghe un'àtera immàgine"
+
+#: covers/add.html
+#, fuzzy
+msgid "Upload image"
+msgstr "Càrriga un'immàgine de cobertedda"
+
+#: covers/add.html covers/external_image.html
+#, fuzzy
+msgid "Upload Image"
+msgstr "Càrriga un'immàgine de cobertedda"
 
 #: covers/add.html
 msgid "Uploading..."
 msgstr "Carrighende..."
+
+#: covers/add.html
+#, fuzzy
+msgid "Wikidata"
+msgstr "Wikipedia"
 
 #: covers/author_photo.html
 msgid "Pull up a larger author photo"
@@ -4738,26 +4602,20 @@ msgstr "Nos bisòngiat una fotografia de %(author)s"
 msgid "Pull up a bigger book cover"
 msgstr "Pone una cobertedda de libru prus manna"
 
-#: covers/book_cover.html covers/book_cover_single_edition.html
-#: covers/book_cover_small.html covers/book_cover_work.html
+#: covers/book_cover.html covers/book_cover_small.html
 #, python-format
 msgid "Cover of: %(title)s by %(authors)s"
 msgstr "Cobertedda de: %(title)s de %(authors)s"
-
-#: covers/book_cover_single_edition.html covers/book_cover_work.html
-msgid "View a larger book cover"
-msgstr "Càstia una cobertedda de libru prus manna"
-
-#: covers/book_cover_single_edition.html covers/book_cover_small.html
-#: covers/book_cover_work.html
-#, python-format
-msgid "We need a book cover for: %(title)s"
-msgstr "Tenimus una cobertedda de libru pro: %(title)s"
 
 #: covers/book_cover_small.html
 #, python-format
 msgid "Go to the main page for %(title)s"
 msgstr "Bae a sa pàgina printzipale pro %(title)s"
+
+#: covers/book_cover_small.html
+#, python-format
+msgid "We need a book cover for: %(title)s"
+msgstr "Tenimus una cobertedda de libru pro: %(title)s"
 
 #: covers/change.html
 msgid "Author Photos"
@@ -4787,13 +4645,14 @@ msgstr "Annanghe un'immàgine de cobertedda"
 msgid "Manage"
 msgstr "Manìgia"
 
+#: covers/external_image.html
+#, python-format
+msgid "Or, use an image from %s"
+msgstr "O pure, usa un'ìmaggine dae %s"
+
 #: covers/manage.html
-msgid ""
-"You can drag and drop thumbnails to reorder, or into the trash to delete "
-"them."
-msgstr ""
-"Podes trisinare e lassare miniaduras de torrare a ordinare, o in sa cartella "
-"de s'arga pro las iscantzellare."
+msgid "You can drag and drop thumbnails to reorder, or into the trash to delete them."
+msgstr "Podes trisinare e lassare miniaduras de torrare a ordinare, o in sa cartella de s'arga pro las iscantzellare."
 
 #: covers/saved.html
 msgid "New book cover"
@@ -4815,36 +4674,268 @@ msgstr "Annanghe un'àtera immàgine"
 msgid "Finished"
 msgstr "Acabadu"
 
+#: design/banner.html
+#, python-format
+msgid "The %(tag)s component is a callout-style announcement banner. The announcement is server-rendered into the default slot — already translated, visible to search engines — while the component owns the chrome: variant styling, icon, dismissal, and cookie persistence. There is intentionally no entrance animation; banners appear on every page view."
+msgstr "Su cumponente %(tag)s est unu banner de annuntziu in stile callout. S'annùntziu est renderizadu a su servidore in su slot predefinidu — già traduidu, visìbile a is motores de chirca — mentras su cumponente amministrat sa chrome: stile de variante, ìcona, dismissal e persistèntzia de cookie. No at animatzione de intrada de manera intenzionale; is banners aparint a ònnia carigamentu de pàgina."
+
+#: design/banner.html
+msgid "Variants"
+msgstr "Variantes"
+
+#: design/banner.html
+#, python-format
+msgid "Use %(variant)s for semantic variants. Each pairs a tinted surface with a filled icon circle — the same icon treatment as %(toast)s."
+msgstr "Usa %(variant)s pro is variantes semàntias. Cada una acòpiat una superfìtzie tintada cun unu tzìrculu de ìcona rinchidu — su matessi trattamentu de ìcona comente %(toast)s."
+
+#: design/banner.html
+msgid "Open Library is a non-profit project of the Internet Archive."
+msgstr "Open Library est unu prótzettu sena fines de lucru de Internet Archive."
+
+#: design/banner.html
+msgid "Your import finished — 42 books added to your reading log."
+msgstr "S'importatzione tua est terminada — 42 libros sunt istados agiùntos a su diari de lèghidu tuo."
+
+#: design/banner.html
+msgid "Open Library will be briefly unavailable on June 12 for maintenance."
+msgstr "Open Library at a esser brevemente non disponìbile su 12 de làmpadas pro mantentzione."
+
+#: design/banner.html
+msgid "Search is currently degraded. Some results may be missing."
+msgstr "Sa chirca est atualmente limitada. Depes mancabant àlguni risultados."
+
+#: design/banner.html
+msgid "Appearance"
+msgstr "Aspetu"
+
+#: design/banner.html
+#, python-format
+msgid "Use %(appearance)s to control the frame. %(outlined)s (default) has a border and rounded corners. %(plain)s removes both — useful when the banner abuts the edges of other UI, like the top of the page or a card."
+msgstr "Usa %(appearance)s pro controllare su quadru. %(outlined)s (predefinidu) at unu bordu e cantones arredondados. %(plain)s elimina ambos — ùtile candu su banner est a costàgiu de is borduros de àtera UI, comente su cima de sa pàgina o una carta."
+
+#: design/banner.html
+msgid "Outlined (default): border and rounded corners."
+msgstr "Delineadu (predefinidu): bordu e cantones arredondados."
+
+#: design/banner.html
+msgid "Plain: no border, no border radius."
+msgstr "Simpliche: sena bordu, sena ràgiu de bordu."
+
+#: design/banner.html
+msgid "Dismissible"
+msgstr "Serràbile"
+
+#: design/banner.html
+#, python-format
+msgid "Add %(dismissible)s for a close button. Without %(cookie_name)s, dismissal only lasts for the current page. Content comes from the page template, so links and emphasis work as usual."
+msgstr "Agiùnghe %(dismissible)s pro unu butone de serradùra. Sena %(cookie_name)s, sa serradùra durat petzi pro sa pàgina curente. Su cuntenutu venit dae su template de sa pàgina, de manera chi is colegamentos e is enfasis funtzionant comente de sòlitu."
+
+#: design/banner.html
+#, fuzzy
+msgid "Explore our new collections"
+msgstr "Esplora sas colletziones"
+
+#: design/banner.html
+#, fuzzy
+msgid "Custom icon"
+msgstr "Icona de su còdighe QR"
+
+#: design/banner.html
+#, python-format
+msgid "Slot a custom icon via %(slot)s to replace the variant's built-in glyph."
+msgstr "Inseris un'ìcona personalizadas via %(slot)s pro sustituire su gliph integradu de sa variante."
+
+#: design/banner.html
+#, fuzzy
+msgid "Set your Yearly Reading Goal"
+msgstr "Cunfigura un'obietivu de letura annuale"
+
+#: design/banner.html
+#, fuzzy
+msgid "Persisted dismissal"
+msgstr "Imprenta disabilitada"
+
+#: design/banner.html
+#, python-format
+msgid "The component owns no persistence — it only fires %(event)s with its %(dismiss_id)s. Two pieces of site plumbing make dismissals stick: the template guards rendering on the dismissal cookie (so dismissed banners are never served), and a site-level listener (%(glue)s) POSTs dismissals to %(endpoint)s, which sets that cookie. Per-banner TTL rides on the element as %(ttl)s — an OL convention, not component API. Dismiss this banner, reload, and it stays hidden until reset."
+msgstr "Su cumponente no at persistèntzia propia — emite petzi %(event)s cun su suo %(dismiss_id)s. Duas partes de s'infrastruttura de su situ faint durare is serradùras: su template cuida sa renderizatzione in su cookie de serradùra (a manera chi is banners serraus non sunt mai servidus), e unu listener a livellu de situ (%(glue)s) invia POST de serradùras a %(endpoint)s, chi definit cussu cookie. Su TTL pro-banner est in s'elementu comente %(ttl)s — una cumbentzione OL, no API de cumponente. Serra custu banner, ricàrriga, e restat abscùndidu finas a su reset."
+
+#: design/banner.html
+#, fuzzy
+msgid "Set your 2026 Yearly Reading Goal"
+msgstr "Cunfigura un'obietivu de letura annuale"
+
+#: design/banner.html
+msgid "Reset dismissed demo banner"
+msgstr "Reimposta su banner demo serradu"
+
+#: design/banner.html
+msgid "Dismiss event"
+msgstr "Eventu de serradùra"
+
+#: design/banner.html
+#, python-format
+msgid "The banner fires %(event)s once when dismissed, before it is removed from the DOM. Banners without a %(dismiss_id)s are page-only: they still fire the event, but the site listener ignores them."
+msgstr "Su banner emite %(event)s una borta candu est serradu, prima de esser removidu dae su DOM. Is banners sena %(dismiss_id)s sunt petzi pro sa pàgina: emitent a su matessi s'eventu, ma su listener de su situ is ignorat."
+
+#: design/button.html merge/authors.html recentchanges/merge/view.html
+msgid "Primary"
+msgstr "Primàriu"
+
+#: design/popover.html
+#, fuzzy
+msgid "Popover component"
+msgstr "Cumponente"
+
+#: design/popover.html
+msgid "The ol-popover component provides a reusable animated popover panel anchored to a trigger element. It animates from the trigger using transform-origin, closes on Escape or outside click, and respects prefers-reduced-motion."
+msgstr "Su cumponente ol-popover fornit unu panel popover animadu riutilizàbile ancorado a unu elementu trigger. S'animat dae su trigger usando transform-origin, si serrrat a Escape o clic esterno, e rispètat prefers-reduced-motion."
+
+#: design/popover.html
+msgid "Menu popover"
+msgstr "Popover de menù"
+
+#: design/popover.html
+msgid "Popovers animate from the trigger using transform-origin. Click the button to see the scale + fade entrance."
+msgstr "Is popovers s'animant dae su trigger usando transform-origin. Fai clic in su butone pro bìdere s'intrada scale + fade."
+
+#: design/popover.html
+#, fuzzy
+msgid "Options"
+msgstr "Atziones"
+
+#: design/popover.html
+#, fuzzy
+msgid "Duplicate"
+msgstr "Duplicados"
+
+#: design/popover.html
+#, fuzzy
+msgid "Archive"
+msgstr "Martzu"
+
+#: design/popover.html
+#, fuzzy
+msgid "Move"
+msgstr "Boga"
+
+#: design/popover.html
+msgid "Placement options"
+msgstr "Optziònes de posizionamentu"
+
+#: design/popover.html
+#, python-format
+msgid "Use %(placement)s to control where the popover appears. The %(transform_origin)s automatically matches so the animation always expands from the trigger."
+msgstr "Usa %(placement)s pro controllare undi aparit su popover. %(transform_origin)s si agiùstat automàticament a manera chi s'animatzione si espandat semper dae su trigger."
+
+#: design/popover.html
+msgid "bottom-start"
+msgstr "bottom-start"
+
+#: design/popover.html
+#, fuzzy
+msgid "top-center"
+msgstr "Tzentru de agiudu"
+
+#: design/toast.html
+#, python-format
+msgid "The %(tag)s component is a transient notification message. It announces itself to screen readers, auto-dismisses after a timeout (pausing on hover/focus), and removes itself from the DOM when closed. Message content is set via the %(message)s and %(description)s attributes, already translated; rich content can be slotted instead. The component's only owned string is the close button label, overridable via %(attr)s."
+msgstr "Su cumponente %(tag)s est unu messàgiu de notìfica transitòriu. S'annùntzia a is screen reader, si serrrat automàticament a pustis de unu timeout (in pausa a su hover/focus), e si removit dae su DOM candu est serradu. Su cuntenutu de su messàgiu est definidu via is atributos %(message)s e %(description)s, già traduidus; su cuntenutu riccu podet esser inseridu in vetu. Sa sola cadena de su cumponente est s'eticheta de su butone de serradùra, sobreponìbile via %(attr)s."
+
+#: design/toast.html
+#, fuzzy
+msgid "Types"
+msgstr "casta"
+
+#: design/toast.html
+#, python-format
+msgid "Use %(type)s for semantic variants. Errors are announced assertively (%(role)s)."
+msgstr "Usa %(type)s pro is variantes semàntias. Is errores sunt annuntziados in manera assertiva (%(role)s)."
+
+#: design/toast.html
+#, fuzzy
+msgid "Saved to your reading log"
+msgstr "Chirca in su registru de letura tuo"
+
+#: design/toast.html
+msgid "Subjects successfully updated"
+msgstr "Matèrias agiornadas cun ésimu"
+
+#: design/toast.html
+#, fuzzy
+msgid "Could not update list. Please try again later."
+msgstr "Isballiadu. Torra a proare."
+
+#: design/toast.html
+#, fuzzy
+msgid "Description and rich content"
+msgstr "Descritzione de custa editzione"
+
+#: design/toast.html
+#, python-format
+msgid "Use %(description)s for an optional secondary line. For uncommon rich content (links, custom markup), author the markup in an inert %(template)s element in the page template — where %(i18n)s extraction works — and pass that element to %(helper)s; its content is cloned into the toast. Node(s) built in JS also work. Nothing is ever parsed from a runtime string as HTML."
+msgstr "Usa %(description)s pro una rìgula atzidentale optzionale. Pro cuntenutu riccu non cumune (colegamentos, markup personalizadu), autora su markup in unu elementu %(template)s inerte in su template de sa pàgina — undi funtzionat s'estratzione %(i18n)s — e passai custu elementu a %(helper)s; su cuntenutu suo est clonadu in su toast. Funtzionant puru is Node(s) costruidos in JS. Non est mai parsifadu nudda dae una cadena de runtime comente HTML."
+
+#: design/toast.html
+msgid "Relaunch to update"
+msgstr "Rilàntzia pro agiornare"
+
+#: design/toast.html
+msgid "Could not save."
+msgstr "Non est possìbile sarvare."
+
+#: design/toast.html
+#, fuzzy
+msgid "Get help"
+msgstr "Ti bisòngiat agiudu?"
+
+#: design/toast.html
+msgid "Imperative use (fixed bottom-center stack)"
+msgstr "Impreu imperativu (pila fissa in su bassu-tzentru)"
+
+#: design/toast.html
+#, python-format
+msgid "JavaScript callers use the exported %(helper)s helper, which stacks toasts in a shared fixed %(region)s anchored to the bottom-center of the viewport. New toasts slide up from below; older ones slide up to make room, forming a simple vertical list. Toasts dismiss themselves after %(timeout)s milliseconds (default 4000) unless %(persistent)s. Hover or focus the list to pause every toast's dismiss timer. The message is set as an attribute — always text, never HTML — and should already be translated."
+msgstr "Is chiamantes JavaScript usant s'agiudanti %(helper)s esportadu, chi accumontat is toast in una %(region)s fissa cumparta ancurada in su bassu-tzentru de su viewport. Is toast nouvos abarrant a artu dae bassu; is prus vèchios abarrant a artu pro fàghere logus, formende una lista verticale simpliche. Is toast si serrant da solu a pustis de %(timeout)s millisegundes (predefinidu 4000) a mancus chi non siant %(persistent)s. Passa su mùrriu o concentra sa lista pro pausare su contadore de serradùra de ònnia toast. Su messàgiu est definidu comente atributu — semper testu, mai HTML — e devet esser già traduidu."
+
+#: design/toast.html
+#, fuzzy
+msgid "Add toast"
+msgstr "Annanghe a sa lista"
+
+#: design/toast.html
+msgid "Add persistent error toast"
+msgstr "Agiùnghe un toast de errore persistente"
+
+#: design/toast.html
+msgid "Add rich content toast"
+msgstr "Agiùnghe un toast de cuntenutu riccu"
+
+#: design/toast.html
+#, fuzzy
+msgid "Close event"
+msgstr "Rechesta serrada"
+
+#: design/toast.html
+#, python-format
+msgid "The toast fires %(event)s once when it begins closing, with the reason in %(detail)s."
+msgstr "Su toast emite %(event)s una borta candu cumentzat a serrarse, cun sa motivatzione in %(detail)s."
+
 #: email/case_created.html
 msgid "Sent!"
 msgstr "Imbiada!"
 
 #: email/case_created.html
 msgid "Thank you for your note. We'll get back to you as soon as possible."
-msgstr ""
-"Ti torramus gràtzias pro sa nota tua. T'amus a torrare imposta su prus in "
-"presse chi amus a pòdere."
+msgstr "Ti torramus gràtzias pro sa nota tua. T'amus a torrare imposta su prus in presse chi amus a pòdere."
 
 #: email/case_created.html
-msgid ""
-"It might take us a little while to read it because we receive lots of "
-"messages, but rest assured we will, and we'll get back to you if required."
-msgstr ""
-"Nos diat pòdere bisongiare unu pagu de tempus in antis de lu pòdere lèghere "
-"ca retzimus unu muntone de messàgios, ma ista seguru chi l'amus a fàghere, e "
-"t'amus a torrare imposta si at a serbire."
+msgid "It might take us a little while to read it because we receive lots of messages, but rest assured we will, and we'll get back to you if required."
+msgstr "Nos diat pòdere bisongiare unu pagu de tempus in antis de lu pòdere lèghere ca retzimus unu muntone de messàgios, ma ista seguru chi l'amus a fàghere, e t'amus a torrare imposta si at a serbire."
 
-#: history/comment.html
-msgid "Imported from"
-msgstr "Importadu dae"
-
-#: history/comment.html
-msgid "Found a matching"
-msgstr "Atzapada una currispondèntzia"
-
-#: history/comment.html
-msgid "Edited without comment."
-msgstr "Modificadu chene cummentu."
+#: email/account/pd_request.html
+msgid "Qualifying for Print Disability Special Access"
+msgstr "Qualificatzione pro s'Atzessu Ispetziale pro Incapatzidade de Impressione"
 
 #: history/sources.html
 msgid "record"
@@ -4855,29 +4946,16 @@ msgid "About the Project"
 msgstr "Subra su Progetu"
 
 #: home/about.html
-msgid ""
-"Open Library is an open, editable library catalog, building towards a web "
-"page for every book ever published."
-msgstr ""
-"S'Open Library est unu catàlogu abertu, chi si podet modificare e punnat a "
-"tènnere una pàgina web pro cada libru mai publicadu."
+msgid "Open Library is an open, editable library catalog, building towards a web page for every book ever published."
+msgstr "S'Open Library est unu catàlogu abertu, chi si podet modificare e punnat a tènnere una pàgina web pro cada libru mai publicadu."
 
-#: AffiliateLinks.html home/about.html
+#: AffiliateLinks.html home/about.html search/work_search_facets.html
 msgid "More"
 msgstr "De prus"
 
 #: home/about.html
-msgid ""
-"Just like Wikipedia, you can contribute new information or corrections to "
-"the catalog. You can browse by <a href=\"/subjects\">subjects</a>, <a "
-"href=\"/authors\">authors</a> or <a href=\"/lists\">lists</a> members have "
-"created. If you love books, why not help build a library?"
-msgstr ""
-"Gasi comente in Wikipedia, podes frunire informatziones noas o curretziones "
-"a su catàlogu. Podes esplorare pro <a href=\"/subjects\">argumentu</a>, <a "
-"href=\"/authors\">autores</a> o <a href=\"/lists\">listas</a> chi sos "
-"membros ant creadu. Si amas sos libros, proite no agiudas a fraigare una "
-"biblioteca?"
+msgid "Just like Wikipedia, you can contribute new information or corrections to the catalog. You can browse by <a href=\"/subjects\">subjects</a>, <a href=\"/authors\">authors</a> or <a href=\"/lists\">lists</a> members have created. If you love books, why not help build a library?"
+msgstr "Gasi comente in Wikipedia, podes frunire informatziones noas o curretziones a su catàlogu. Podes esplorare pro <a href=\"/subjects\">argumentu</a>, <a href=\"/authors\">autores</a> o <a href=\"/lists\">listas</a> chi sos membros ant creadu. Si amas sos libros, proite no agiudas a fraigare una biblioteca?"
 
 #: home/about.html
 msgid "Latest Blog Posts"
@@ -4886,11 +4964,6 @@ msgstr "Ùrtimas publicatziones de su blog"
 #: home/categories.html
 msgid "Browse by Subject"
 msgstr "Esplora pro argumentu"
-
-#: home/categories.html
-#, python-format
-msgid "browse %(subject)s books"
-msgstr "esplora libros subra de %(subject)s"
 
 #: home/categories.html
 #, python-format
@@ -4903,7 +4976,7 @@ msgstr[1] "%(count)s libros"
 msgid "Welcome to Open Library"
 msgstr "Bene bènnidu a s'Open Library"
 
-#: home/index.html
+#: home/index.html openlibrary/plugins/openlibrary/api.py
 msgid "Classic Books"
 msgstr "Libros clàssicos"
 
@@ -4911,56 +4984,48 @@ msgstr "Libros clàssicos"
 msgid "Recently Returned"
 msgstr "Torrados dae pagu"
 
-#: home/index.html
+#: home/index.html openlibrary/plugins/openlibrary/api.py openlibrary/plugins/openlibrary/home.py
 msgid "Romance"
 msgstr "Libros de amore"
 
-#: home/index.html
+#: home/index.html openlibrary/plugins/openlibrary/api.py
 msgid "Kids"
 msgstr "Pitzinnos"
 
-#: home/index.html
+#: home/index.html openlibrary/plugins/openlibrary/api.py
 msgid "Thrillers"
 msgstr "Thrillers"
 
-#: home/index.html
+#: home/index.html openlibrary/plugins/openlibrary/api.py openlibrary/plugins/openlibrary/home.py
 msgid "Textbooks"
 msgstr "Libros de testu"
 
-#: home/loans.html
-#, python-format
-msgid ""
-"You can still <a href=\"/borrow\">borrow</a> one more book until you've hit "
-"the limit!"
-msgid_plural ""
-"You can still <a href=\"/borrow\">borrow</a> %(count)d more books until "
-"you've hit the limit!"
-msgstr[0] ""
-"Podes galu <a href=\"/borrow\">pigare in prèstidu</a> un'àteru libru in "
-"antis de arribbare a su lìmite!"
-msgstr[1] ""
-"Podes galu <a href=\"/borrow\">pigare in prèstidu</a>àteros %(count)d libros "
-"in antis de arribbare a su lìmite!"
+#: home/index.html
+msgid "Authors Alliance & MIT Press"
+msgstr "Authors Alliance & MIT Press"
+
+#: home/index.html
+msgid "Books in Local Environment"
+msgstr "Libros in s'Ambienti Locale"
 
 #: home/loans.html
-msgid ""
-"You have reached the borrowing limit. Please return a book to checkout "
-"something new."
-msgstr ""
-"Ses arribbadu a su lìmite de prèstidos. Pro praghere torra unu libru pro "
-"pigare carchi cosa de nou."
+#, fuzzy, python-format
+msgid "You can still <a href=\"/subjects/in_library#ebooks=true\">borrow</a> one more book until you've hit the limit!"
+msgid_plural "You can still <a href=\"/subjects/in_library#ebooks=true\">borrow</a> %(count)d more books until you've hit the limit!"
+msgstr[0] "Podes galu <a href=\"/borrow\">pigare in prèstidu</a> un'àteru libru in antis de arribbare a su lìmite!"
+msgstr[1] "Podes galu <a href=\"/borrow\">pigare in prèstidu</a>àteros %(count)d libros in antis de arribbare a su lìmite!"
+
+#: home/loans.html
+msgid "You have reached the borrowing limit. Please return a book to checkout something new."
+msgstr "Ses arribbadu a su lìmite de prèstidos. Pro praghere torra unu libru pro pigare carchi cosa de nou."
 
 #: home/stats.html
 msgid "Around the Library"
 msgstr "A giru in sa biblioteca"
 
 #: home/stats.html
-msgid ""
-"Here's what's happened over the last 28 days. More <a href=\"/"
-"recentchanges\">recent changes</a>"
-msgstr ""
-"Custu est su chi est acontèssidu in sas ùrtimas 28 dies. Àteras <a href=\"/"
-"recentchanges\">modìficas reghentes</a>"
+msgid "Here's what's happened over the last 28 days. More <a href=\"/recentchanges\">recent changes</a>"
+msgstr "Custu est su chi est acontèssidu in sas ùrtimas 28 dies. Àteras <a href=\"/recentchanges\">modìficas reghentes</a>"
 
 #: home/stats.html
 msgid "See all visitors to OpenLibrary.org"
@@ -5020,9 +5085,7 @@ msgstr "Leghe libros de sa biblioteca de badas in lìnia"
 
 #: home/welcome.html
 msgid "Millions of books available through Controlled Digital Lending"
-msgstr ""
-"Milliones de libros a disponimentu pro mèdiu de su prèstidu digitale "
-"controlladu"
+msgstr "Milliones de libros a disponimentu pro mèdiu de su prèstidu digitale controlladu"
 
 #: home/welcome.html
 msgid "Set a Yearly Reading Goal"
@@ -5030,9 +5093,7 @@ msgstr "Cunfigura un'obietivu de letura annuale"
 
 #: home/welcome.html
 msgid "Learn how to set a yearly reading goal and track what you read"
-msgstr ""
-"Impara comente cunfigurare un'obietivu de letura annuale e arrastare su chi "
-"leghes"
+msgstr "Impara comente cunfigurare un'obietivu de letura annuale e arrastare su chi leghes"
 
 #: home/welcome.html
 msgid "Keep Track of your Favorite Books"
@@ -5056,9 +5117,7 @@ msgstr "Proa sa chirca de testu integrale"
 
 #: home/welcome.html
 msgid "Find matching results within the text of millions of books"
-msgstr ""
-"Atzapa resurtados chi currispondent a intro de sos testos de milliones de "
-"libros"
+msgstr "Atzapa resurtados chi currispondent a intro de sos testos de milliones de libros"
 
 #: home/welcome.html
 msgid "Be an Open Librarian"
@@ -5097,63 +5156,18 @@ msgid "editions"
 msgstr "editziones"
 
 #: languages/index.html
-#, python-format
-msgid "%s book"
-msgid_plural "%s books"
-msgstr[0] "%s libru"
-msgstr[1] "%s libros"
+#, fuzzy, python-format
+msgid "%s work"
+msgid_plural "%s works"
+msgstr[0] ""
+msgstr[1] ""
 
-#: languages/language_list.html
-msgid "Czech"
-msgstr "Tzecu"
-
-#: languages/language_list.html
-msgid "German"
-msgstr "Tedescu"
-
-#: languages/language_list.html
-msgid "English"
-msgstr "Inglesu"
-
-#: languages/language_list.html
-msgid "Spanish"
-msgstr "Ispagnolu"
-
-#: languages/language_list.html
-msgid "French"
-msgstr "Frantzesu"
-
-#: languages/language_list.html
-msgid "Croatian"
-msgstr "Croatu"
-
-#: languages/language_list.html
-msgid "Italian"
-msgstr "Italianu"
-
-#: languages/language_list.html
-msgid "Portuguese"
-msgstr "Portoghesu"
-
-#: languages/language_list.html
-msgid "Hindi"
-msgstr "Hindi"
-
-#: languages/language_list.html
-msgid "Sardinian"
-msgstr "Sardu"
-
-#: languages/language_list.html
-msgid "Telugu"
-msgstr "Telugu"
-
-#: languages/language_list.html
-msgid "Ukrainian"
-msgstr "Ucràinu"
-
-#: languages/language_list.html
-msgid "Chinese"
-msgstr "Tzinesu"
+#: languages/index.html
+#, fuzzy, python-format
+msgid "%s ebook edition"
+msgid_plural "%s ebook editions"
+msgstr[0] ""
+msgstr[1] ""
 
 #: languages/notfound.html
 #, python-format
@@ -5173,6 +5187,38 @@ msgstr "Custu documentu l'at modificadu a ùrtimu"
 msgid "This doc was last edited anonymously"
 msgstr "Custu documentu l'ant modificadu in anònimu"
 
+#: lib/exports.html
+msgid "Download catalog record:"
+msgstr "Iscàrriga su registru de su catàlogu:"
+
+#: lib/exports.html
+msgid "RDF"
+msgstr "RDF"
+
+#: lib/exports.html type/list/exports.html
+msgid "JSON"
+msgstr "JSON"
+
+#: lib/exports.html
+msgid "OPDS"
+msgstr "OPDS"
+
+#: lib/exports.html
+msgid "Cite this on Wikipedia"
+msgstr "Tzita custu in Wikipedia"
+
+#: lib/exports.html
+msgid "Wikipedia citation"
+msgstr "Tzita de Wikipedia"
+
+#: lib/exports.html
+msgid "Copy and paste this code into your Wikipedia page."
+msgstr "Còpia e incolla custu còdighe in sa pàgina de Wikipedia tua."
+
+#: lib/exports.html
+msgid "Get instructions at Wikipedia in a new window"
+msgstr "Retzi inditos in Wikipedia in una ventana noa"
+
 #: lib/header_dropdown.html
 msgid "My account"
 msgstr "Su contu meu"
@@ -5190,11 +5236,6 @@ msgstr "Menù"
 msgid "New!"
 msgstr "Nou!"
 
-#: databarDiff.html databarEdit.html databarTemplate.html databarView.html
-#: lib/history.html
-msgid "History"
-msgstr "Cronologia"
-
 #: lib/history.html
 #, python-format
 msgid "Created %(date)s"
@@ -5206,38 +5247,6 @@ msgid "%(count)d revision"
 msgid_plural "%(count)d revisions"
 msgstr[0] "%(count)d revisione"
 msgstr[1] "%(count)d revisiones"
-
-#: lib/history.html
-msgid "Download catalog record:"
-msgstr "Iscàrriga su registru de su catàlogu:"
-
-#: lib/history.html
-msgid "RDF"
-msgstr "RDF"
-
-#: lib/history.html type/list/exports.html
-msgid "JSON"
-msgstr "JSON"
-
-#: lib/history.html
-msgid "OPDS"
-msgstr "OPDS"
-
-#: lib/history.html
-msgid "Cite this on Wikipedia"
-msgstr "Tzita custu in Wikipedia"
-
-#: lib/history.html
-msgid "Wikipedia citation"
-msgstr "Tzita de Wikipedia"
-
-#: lib/history.html
-msgid "Copy and paste this code into your Wikipedia page."
-msgstr "Còpia e incolla custu còdighe in sa pàgina de Wikipedia tua."
-
-#: lib/history.html
-msgid "Get instructions at Wikipedia in a new window"
-msgstr "Retzi inditos in Wikipedia in una ventana noa"
 
 #: lib/history.html
 msgid "an anonymous user"
@@ -5262,14 +5271,8 @@ msgid " Your new record is in the library. Thank you!"
 msgstr " Su registru nou tuo est in sa biblioteca. Gràtzias!"
 
 #: lib/message_addbook.html
-msgid ""
-"There are a few other simple things you can add while you're here to improve "
-"your new record quickly, and make it much easier for other people to find "
-"later."
-msgstr ""
-"Bi sunt unas cantas àteras cosas chi podes annànghere sende inoghe pro "
-"megiorare in presse su registru nou tuo, e pro fàghere in manera chi a "
-"pustis siat prus fàtzile de atzapare pro àtera gente."
+msgid "There are a few other simple things you can add while you're here to improve your new record quickly, and make it much easier for other people to find later."
+msgstr "Bi sunt unas cantas àteras cosas chi podes annànghere sende inoghe pro megiorare in presse su registru nou tuo, e pro fàghere in manera chi a pustis siat prus fàtzile de atzapare pro àtera gente."
 
 #: lib/message_addbook.html
 msgid "Upload a cover image"
@@ -5303,7 +5306,7 @@ msgstr "Descrie de ite chistionat su libru"
 msgid "Just a sentence or two is good."
 msgstr "Petzi una o duas fràsias andant bene."
 
-#: lib/nav_foot.html site/neck.html
+#: lib/nav_foot.html openlibrary/plugins/openlibrary/api.py site/head.html
 msgid "Open Library"
 msgstr "Open Library"
 
@@ -5363,9 +5366,7 @@ msgstr "Esplora sos autores"
 msgid "Explore subjects"
 msgstr "Esplora sos argumentos"
 
-#: RelatedSubjects.html SearchNavigation.html SubjectTags.html
-#: lib/nav_foot.html lib/nav_head.html subjects/notfound.html
-#: type/author/view.html type/list/view_body.html
+#: RelatedSubjects.html SearchNavigation.html SubjectTags.html lib/nav_foot.html lib/nav_head.html openlibrary/plugins/worksearch/code.py subjects/notfound.html type/author/view.html type/list/view_body.html
 msgid "Subjects"
 msgstr "Argumentos"
 
@@ -5377,8 +5378,7 @@ msgstr "Esplora sas colletziones"
 msgid "Collections"
 msgstr "Colletziones"
 
-#: SearchNavigation.html lib/nav_foot.html lib/nav_head.html
-#: search/advancedsearch.html
+#: SearchNavigation.html lib/nav_foot.html lib/nav_head.html search/advancedsearch.html
 msgid "Advanced Search"
 msgstr "Chirca avantzada"
 
@@ -5455,12 +5455,32 @@ msgid "Release Notes"
 msgstr "Notas de sa versione"
 
 #: lib/nav_foot.html
+#, fuzzy
+msgid "Bluesky"
+msgstr "Còmpora"
+
+#: lib/nav_foot.html
+#, fuzzy
+msgid "Open Library on Bluesky"
+msgstr "Pàgina printzipale de Open Library"
+
+#: lib/nav_foot.html
 msgid "Twitter"
 msgstr "Twitter"
 
 #: lib/nav_foot.html
+#, fuzzy
+msgid "Open Library on Twitter"
+msgstr "Pàgina printzipale de Open Library"
+
+#: lib/nav_foot.html
 msgid "GitHub"
 msgstr "GitHub"
+
+#: lib/nav_foot.html
+#, fuzzy
+msgid "Open Library on GitHub"
+msgstr "Logotipu de s'Open Library"
 
 #: lib/nav_foot.html site/alert.html
 msgid "Change Website Language"
@@ -5471,30 +5491,13 @@ msgid "Open Library logo"
 msgstr "Logotipu de s'Open Library"
 
 #: lib/nav_foot.html
-msgid ""
-"Open Library is an initiative of the <a href=\"//archive.org/\">Internet "
-"Archive</a>, a 501(c)(3) non-profit, building a digital library of Internet "
-"sites and other cultural artifacts in  digital form. Other <a href=\"//"
-"archive.org/projects/\">projects</a> include the <a href=\"//archive.org/web/"
-"\">Wayback Machine</a>, <a href=\"//archive.org/\">archive.org</a> and <a "
-"href=\"//archive-it.org\">archive-it.org</a>"
-msgstr ""
-"S'Open Library est un'initziativa de s'<a href=\"//archive.org/\">Internet "
-"Archive</a>, un'organizatzione chene punna de lucru 501(c)(3) chi est "
-"fraighende una biblioteca digitale de sitos ìnternet e àteros artefatos in "
-"forma digitale. Àteros <a href=\"//archive.org/projects/\">progetos</a> "
-"incluint sa <a href=\"//archive.org/web/\">Wayback Machine</a>, <a href=\"//"
-"archive.org/\">archive.org</a> e <a href=\"//archive-it.org\">archive-it."
-"org</a>"
+msgid "Open Library is an initiative of the <a href=\"//archive.org/\">Internet Archive</a>, a 501(c)(3) non-profit, building a digital library of Internet sites and other cultural artifacts in  digital form. Other <a href=\"//archive.org/projects/\">projects</a> include the <a href=\"//archive.org/web/\">Wayback Machine</a>, <a href=\"//archive.org/\">archive.org</a> and <a href=\"//archive-it.org\">archive-it.org</a>"
+msgstr "S'Open Library est un'initziativa de s'<a href=\"//archive.org/\">Internet Archive</a>, un'organizatzione chene punna de lucru 501(c)(3) chi est fraighende una biblioteca digitale de sitos ìnternet e àteros artefatos in forma digitale. Àteros <a href=\"//archive.org/projects/\">progetos</a> incluint sa <a href=\"//archive.org/web/\">Wayback Machine</a>, <a href=\"//archive.org/\">archive.org</a> e <a href=\"//archive-it.org\">archive-it.org</a>"
 
 #: lib/nav_foot.html
 #, python-format
-msgid ""
-"version <a href=\"https://github.com/internetarchive/openlibrary/commit/"
-"%s\">%s</a>"
-msgstr ""
-"versione <a href=\"https://github.com/internetarchive/openlibrary/commit/"
-"%s\">%s</a>"
+msgid "version <a href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</a>"
+msgstr "versione <a href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</a>"
 
 #: lib/nav_head.html
 msgid "Loans, Reading Log, Lists, Stats"
@@ -5512,7 +5515,7 @@ msgstr "Essi"
 msgid "Pending Merge Requests"
 msgstr "Dimandas de unione in isetu"
 
-#: lib/nav_head.html
+#: lib/nav_head.html search/sort_options.html
 msgid "Trending"
 msgstr "De tendèntzia"
 
@@ -5564,6 +5567,10 @@ msgstr "S'Open Library de s'Internet Archive: Una pàgina pro cada libru"
 msgid "Text"
 msgstr "Testu"
 
+#: lib/nav_head.html search/advancedsearch.html
+msgid "Subject"
+msgstr "Argumentu"
+
 #: lib/nav_head.html
 msgid "Advanced"
 msgstr "Avantzadu"
@@ -5573,24 +5580,30 @@ msgid "Search by barcode"
 msgstr "Chirca pro còdighe a istangas"
 
 #: lib/not_logged.html
-msgid ""
-"<strong>You are not <a href=\"/account/login\" title=\"Log in now\">logged "
-"in</a>.</strong> Open Library will record your IP address and include it in "
-"this page's publicly accessible edit history. If you <a href=\"/account/"
-"create\" title=\"Create an Open Library account\">create an account</a>, "
-"your IP address is concealed and you can more easily keep track of all your "
-"edits and additions."
-msgstr ""
-"<strong>Non ses <a href=\"/account/login\" title=\"Log in now\">intradu</a>."
-"</strong> S'Open Library at a registrare s'indiritzu IP tuo e l'at a "
-"inclùdere in sa cronologia a atzessu pùblicu de sas modìficas a custa "
-"pàgina. Si <a href=\"/account/create\" title=\"Create an Open Library "
-"account\">creas unu contu</a>, s'indiritzu IP tuo est cuadu e podes sighire "
-"in manera prus fàtzile totu sas modìficas e sas agiuntas tuas."
+msgid "<strong>You are not <a href=\"/account/login\" title=\"Log in now\">logged in</a>.</strong> Open Library will record your IP address and include it in this page's publicly accessible edit history. If you <a href=\"/account/create\" title=\"Create an Open Library account\">create an account</a>, your IP address is concealed and you can more easily keep track of all your edits and additions."
+msgstr "<strong>Non ses <a href=\"/account/login\" title=\"Log in now\">intradu</a>.</strong> S'Open Library at a registrare s'indiritzu IP tuo e l'at a inclùdere in sa cronologia a atzessu pùblicu de sas modìficas a custa pàgina. Si <a href=\"/account/create\" title=\"Create an Open Library account\">creas unu contu</a>, s'indiritzu IP tuo est cuadu e podes sighire in manera prus fàtzile totu sas modìficas e sas agiuntas tuas."
 
-#: Pager.html Pager_loanhistory.html lib/pagination.html
-msgid "Previous"
-msgstr "Pretzedente"
+#: librarian_dashboard/data_quality_table.html
+#, fuzzy
+msgid "Reload"
+msgstr "Leghe"
+
+#: librarian_dashboard/data_quality_table.html
+#, fuzzy
+msgid "failing"
+msgstr "Listas de posta eletrònica"
+
+#: librarian_dashboard/data_quality_table.html
+msgid "Data quality table"
+msgstr "Tabella de calidade de datos"
+
+#: librarian_dashboard/data_quality_table.html
+msgid "Quality Criteria"
+msgstr "Critèrios de Calidade"
+
+#: lists/carousel.html lists/home.html lists/showcase.html
+msgid "See all"
+msgstr "Abbista totu"
 
 #: lists/export_as_html.html
 #, python-format
@@ -5659,29 +5672,16 @@ msgstr "Hm. Non l'atzapo."
 
 #: lists/home.html
 msgid "Create a list of any Subjects, Authors, Works or specific Editions."
-msgstr ""
-"Crea una lista de argumentos, autores, òperas o editziones ispetzìficas."
+msgstr "Crea una lista de argumentos, autores, òperas o editziones ispetzìficas."
 
 #: lists/home.html
-msgid ""
-"Once you've made a list, you can <strong>watch for updates</strong> or "
-"<strong>export</strong> all the editions in a list as HTML, BibTeX or JSON. "
-"See all your lists and any activity using the \"Lists\" link on your Account "
-"page."
-msgstr ""
-"Una borta chi as fatu una lista, podes <strong>sighire sos agiornamentos</"
-"strong> o <strong>esportare</strong> totu sas editziones in una lista "
-"comente HTML, BibTeX o JSON. Abbista totu sas listas tuas e cale si siat "
-"atividade impreende su ligàmene \"Listas\" in sa pàgina de su contu tuo."
+msgid "Once you've made a list, you can <strong>watch for updates</strong> or <strong>export</strong> all the editions in a list as HTML, BibTeX or JSON. See all your lists and any activity using the \"Lists\" link on your Account page."
+msgstr "Una borta chi as fatu una lista, podes <strong>sighire sos agiornamentos</strong> o <strong>esportare</strong> totu sas editziones in una lista comente HTML, BibTeX o JSON. Abbista totu sas listas tuas e cale si siat atividade impreende su ligàmene \"Listas\" in sa pàgina de su contu tuo."
 
 #: lists/home.html
 #, python-format
-msgid ""
-"For the top 2000+ most requested eBooks in California for the print disabled "
-"<a href=\"%(url)s\">click here</a>."
-msgstr ""
-"Pro sos 2.000+ libros eletrònicos prus pedidos in Califòrnia pro chie tenet "
-"problemas de vista <a href=\"%(url)s\">incarca inoghe</a>."
+msgid "For the top 2000+ most requested eBooks in California for the print disabled <a href=\"%(url)s\">click here</a>."
+msgstr "Pro sos 2.000+ libros eletrònicos prus pedidos in Califòrnia pro chie tenet problemas de vista <a href=\"%(url)s\">incarca inoghe</a>."
 
 #: lists/home.html
 msgid "Find a list by name"
@@ -5696,8 +5696,7 @@ msgstr "Listas ativas"
 msgid "from <a href=\"%(key)s\">%(owner)s</a>"
 msgstr "de <a href=\"%(key)s\">%(owner)s</a>"
 
-#: lists/home.html lists/preview.html lists/snippet.html type/list/embed.html
-#: type/list/view_body.html
+#: lists/home.html lists/preview.html lists/snippet.html type/list/embed.html type/list/view_body.html
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
@@ -5717,9 +5716,41 @@ msgstr "Peruna descritzione."
 msgid "Recent Activity"
 msgstr "Atividade reghente"
 
-#: lists/home.html lists/showcase.html
-msgid "See all"
-msgstr "Abbista totu"
+#: lists/list_follow.html
+#, fuzzy
+msgid "Cover of book"
+msgstr "Piga in prèstidu su libru"
+
+#: lists/list_follow.html
+msgid "Avatar of the owner of the list"
+msgstr "Avatar de su proprietàriu de sa lista"
+
+#: lists/list_follow.html lists/widget.html my_books/dropdown_content.html
+msgid "You"
+msgstr "Tue"
+
+#: lists/list_follow.html
+#, fuzzy
+msgid "This patron has not enabled following"
+msgstr "Metzenates sighende"
+
+#: lists/list_follow.html
+msgid "🔒︎"
+msgstr "🔒︎"
+
+#: Follow.html lists/list_follow.html
+msgid "Follow"
+msgstr "Sighi"
+
+#: lists/list_follow.html
+#, fuzzy
+msgid "OpenLibrary Logo"
+msgstr "Logotipu de s'Open Library"
+
+#: lists/list_follow.html
+#, fuzzy
+msgid "Community List"
+msgstr "Comunidade"
 
 #: lists/list_overview.html lists/widget.html my_books/dropdown_content.html
 msgid "See this list"
@@ -5768,16 +5799,10 @@ msgstr "Ses seguru chi boles cantzellare custa lista?"
 msgid "Remove this seed?"
 msgstr "Bogare custu elementu?"
 
-#: lists/lists.html type/list/edit.html
-msgid "Remove"
-msgstr "Boga"
-
 #: lists/lists.html
 #, python-format
-msgid ""
-"Are you sure you want to remove <strong>%(title)s</strong> from this list?"
-msgstr ""
-"Ses seguru de nche bòlere bogare <strong>%(title)s</strong> dae custa lista?"
+msgid "Are you sure you want to remove <strong>%(title)s</strong> from this list?"
+msgstr "Ses seguru de nche bòlere bogare <strong>%(title)s</strong> dae custa lista?"
 
 #: lists/lists.html
 msgid "This reader hasn't created any lists yet."
@@ -5792,8 +5817,9 @@ msgid "Learn how to create your first list."
 msgstr "Impara comente creare sa prima lista tua."
 
 #: lists/preview.html
-msgid "by <a href=\"$owner.key\">You</a>"
-msgstr "dae <a href=\"$owner.key\">tene</a>"
+#, fuzzy, python-format
+msgid "by <a href=\"%s\">You</a>"
+msgstr ""
 
 #: lists/showcase.html
 #, python-format
@@ -5804,20 +5830,9 @@ msgstr "Listas meas (%(count)d)"
 msgid "You have no lists."
 msgstr "Non tenes listas."
 
-#: lists/widget.html
-#, python-format
-msgid "%(count)d List"
-msgid_plural "%(count)d Lists"
-msgstr[0] "%(count)d lista"
-msgstr[1] "%(count)d listas"
-
 #: lists/widget.html my_books/dropdown_content.html type/type/view.html
 msgid "from"
 msgstr "dae"
-
-#: lists/widget.html my_books/dropdown_content.html
-msgid "You"
-msgstr "Tue"
 
 #: lists/widget.html
 msgid "Loading<span class=\"loading-ellipsis\">...</span>"
@@ -5857,8 +5872,7 @@ msgstr "Perunu registru primàriu"
 
 #: merge/authors.html
 msgid "You must select a primary record to point the duplicates toward."
-msgstr ""
-"Depes seletzionare unu registru primàriu pro b'inditare sos duplicados."
+msgstr "Depes seletzionare unu registru primàriu pro b'inditare sos duplicados."
 
 #: merge/authors.html
 msgid "Please Be Careful..."
@@ -5867,10 +5881,6 @@ msgstr "Dae cara, pro praghere..."
 #: merge/authors.html
 msgid "<b>Are you sure</b> you want to merge these records?"
 msgstr "<b>Ses seguru</b> de bòlere aunire custos registros?"
-
-#: merge/authors.html recentchanges/merge/view.html
-msgid "Primary"
-msgstr "Primàriu"
 
 #: merge/authors.html
 msgid "Merge"
@@ -5961,11 +5971,11 @@ msgstr "Istatus ▾"
 msgid "Request Status"
 msgstr "Istadu de sa rechesta"
 
-#: merge_request_table/table_header.html
+#: merge_request_table/table_header.html openlibrary/core/edits.py
 msgid "Merged"
 msgstr "Aunidos"
 
-#: merge_request_table/table_header.html
+#: merge_request_table/table_header.html openlibrary/core/edits.py
 msgid "Declined"
 msgstr "Negadu"
 
@@ -6043,20 +6053,17 @@ msgstr "Risposta"
 
 #: merge_request_table/table_row.html
 #, python-format
-msgid ""
-"MR #%(id)s opened %(date)s by <a href=\"/people/%(submitter)s\" "
-"class=\"commenter\">@%(submitter)s</a>"
-msgstr ""
-"RU #%(id)s aberta su %(date)s dae <a href=\"/people/%(submitter)s\" "
-"class=\"commenter\">@%(submitter)s</a>"
+msgid "MR #%(id)s opened %(date)s by <a href=\"/people/%(submitter)s\" class=\"commenter\">@%(submitter)s</a>"
+msgstr "RU #%(id)s aberta su %(date)s dae <a href=\"/people/%(submitter)s\" class=\"commenter\">@%(submitter)s</a>"
 
 #: merge_request_table/table_row.html
 msgid "Click to close this Merge Request"
 msgstr "Incarca pro serrare custa rechesta de unione"
 
-#: merge_request_table/table_row.html type/edition/modal_links.html
-msgid "Review"
-msgstr "Retzensione"
+#: merge_request_table/table_row.html
+#, fuzzy
+msgid "Review <!-- (merge request) -->"
+msgstr "Dimandas de unione in isetu"
 
 #: merge_request_table/table_row.html
 msgid "comments"
@@ -6082,18 +6089,138 @@ msgstr "Imprea custa òpera"
 msgid "Create a new list"
 msgstr "Crea una lista noa"
 
-#: CreateListModal.html my_books/dropdown_content.html
-#: type/permission/edit.html type/usergroup/edit.html
+#: CreateListModal.html my_books/dropdown_content.html type/permission/edit.html type/usergroup/edit.html
 msgid "Description:"
 msgstr "Descritzione:"
 
-#: CreateListModal.html my_books/dropdown_content.html type/list/edit.html
+#: CreateListModal.html my_books/dropdown_content.html type/list/edit.html type/series/edit.html
 msgid "Create new list"
 msgstr "Crea una lista noa"
+
+#: my_books/dropdown_content.html
+#, fuzzy
+msgid "saving..."
+msgstr "Carrighende..."
+
+#: my_books/dropdown_content.html
+msgid "Removing this book from your shelves will delete your check-ins for this work.  Continue?"
+msgstr "S'eliminatzione de custu libru dae is istantes tuos at a iscantzellare is check-in pro custu traballu. Cuntiuare?"
 
 #: my_books/primary_action.html
 msgid "Add to List"
 msgstr "Annanghe a sa lista"
+
+#: my_books/check_ins/check_in_form.html
+msgid "January"
+msgstr "Ghennàrgiu"
+
+#: my_books/check_ins/check_in_form.html
+msgid "February"
+msgstr "Freàrgiu"
+
+#: my_books/check_ins/check_in_form.html
+msgid "March"
+msgstr "Martzu"
+
+#: my_books/check_ins/check_in_form.html
+msgid "April"
+msgstr "Abrile"
+
+#: my_books/check_ins/check_in_form.html
+msgid "May"
+msgstr "Maju"
+
+#: my_books/check_ins/check_in_form.html
+msgid "June"
+msgstr "Làmpadas"
+
+#: my_books/check_ins/check_in_form.html
+msgid "July"
+msgstr "Trìulas"
+
+#: my_books/check_ins/check_in_form.html
+msgid "August"
+msgstr "Austu"
+
+#: my_books/check_ins/check_in_form.html
+msgid "September"
+msgstr "Cabudanni"
+
+#: my_books/check_ins/check_in_form.html
+msgid "October"
+msgstr "Santugaine"
+
+#: my_books/check_ins/check_in_form.html
+msgid "November"
+msgstr "Santandria"
+
+#: my_books/check_ins/check_in_form.html
+msgid "December"
+msgstr "Nadale"
+
+#: my_books/check_ins/check_in_form.html
+#, fuzzy
+msgid "Add an optional check-in date. Check-in dates are used to track yearly reading goals."
+msgstr "Annanghe una data optzionale de registratzione. Sas datas de registratzione s'impreant pro arrastare sos obietivos annuales de leghidura."
+
+#: my_books/check_ins/check_in_form.html
+msgid "End Date:"
+msgstr "Data de fine:"
+
+#: my_books/check_ins/check_in_form.html
+msgid "Year:"
+msgstr "Annu:"
+
+#: my_books/check_ins/check_in_form.html
+msgid "Year"
+msgstr "Annu"
+
+#: my_books/check_ins/check_in_form.html
+msgid "Month:"
+msgstr "Mese:"
+
+#: my_books/check_ins/check_in_form.html
+msgid "Month"
+msgstr "Mese"
+
+#: my_books/check_ins/check_in_form.html
+msgid "Day:"
+msgstr "Die:"
+
+#: my_books/check_ins/check_in_form.html
+msgid "Day"
+msgstr "Die"
+
+#: my_books/check_ins/check_in_form.html
+msgid "Delete Event"
+msgstr "Iscantzella s'eventu"
+
+#: my_books/check_ins/check_in_prompt.html
+#, fuzzy
+msgid "Failed to delete check-in. Please try again in a few moments."
+msgstr "Imbiu de su cummentu fallidu. Torra a proare unu pagu prus a tardu."
+
+#: my_books/check_ins/check_in_prompt.html
+#, fuzzy
+msgid "Failed to submit check-in. Please try again in a few moments."
+msgstr "Imbiu de su cummentu fallidu. Torra a proare unu pagu prus a tardu."
+
+#: my_books/check_ins/check_in_prompt.html
+#, python-format
+msgid "Read <time class=\"check-in-date\">%(date)s</time>"
+msgstr "Lèghidu su <time class=\"check-in-date\">%(date)s</time>"
+
+#: my_books/check_ins/check_in_prompt.html
+msgid "When did you finish this book?"
+msgstr "Cando as acabadu custu libru?"
+
+#: my_books/check_ins/check_in_prompt.html
+msgid "Other"
+msgstr "Àteru"
+
+#: my_books/check_ins/check_in_prompt.html
+msgid "Check-In"
+msgstr "Registratzione"
 
 #: observations/review_component.html
 msgid "Community Reviews"
@@ -6137,12 +6264,11 @@ msgstr "Proare carchi cosa de àteru?"
 msgid "Publisher: %(name)s"
 msgstr "Editore: %(name)s"
 
-#: publishers/view.html search/advancedsearch.html type/edition/view.html
-#: type/work/view.html
+#: openlibrary/plugins/worksearch/code.py publishers/view.html search/advancedsearch.html type/edition/view.html type/work/view.html
 msgid "Publisher"
 msgstr "Editore"
 
-#: publishers/view.html
+#: SearchResultsWork.html publishers/view.html
 #, python-format
 msgid "%(count)s ebook"
 msgid_plural "%(count)s ebooks"
@@ -6158,15 +6284,8 @@ msgid "Publishing History"
 msgstr "Cronologia de publicatzione"
 
 #: publishers/view.html
-msgid ""
-"This is a chart to show the when this publisher published books. Along the X "
-"axis is time, and on the y axis is the count of editions published. <a "
-"href=\"#subjectRelated\">Click here to skip the chart</a>."
-msgstr ""
-"Custu est unu gràficu pro ammustrare cando custu editore at publicadu "
-"libros. In s'asse X b'at su tempus, e in s'asse Y b'at su contu de sas "
-"editziones publicadas. <a href=\"#subjectRelated\">Incarca inoghe pro "
-"brincare su gràficu</a>."
+msgid "This is a chart to show the when this publisher published books. Along the X axis is time, and on the y axis is the count of editions published. <a href=\"#subjectRelated\">Click here to skip the chart</a>."
+msgstr "Custu est unu gràficu pro ammustrare cando custu editore at publicadu libros. In s'asse X b'at su tempus, e in s'asse Y b'at su contu de sas editziones publicadas. <a href=\"#subjectRelated\">Incarca inoghe pro brincare su gràficu</a>."
 
 #: PublishingHistory.html publishers/view.html
 msgid "Reset chart"
@@ -6177,12 +6296,8 @@ msgid "or continue zooming in."
 msgstr "o sighi a ismanniare."
 
 #: publishers/view.html
-msgid ""
-"This graph charts editions from this publisher over time. Click to view a "
-"single year, or drag across a range."
-msgstr ""
-"Custu gràficu mapat sas editziones de custu editore in su tempus. Incarca "
-"pro bìdere un'annu sìngulu, o trìsina in un'intervallu."
+msgid "This graph charts editions from this publisher over time. Click to view a single year, or drag across a range."
+msgstr "Custu gràficu mapat sas editziones de custu editore in su tempus. Incarca pro bìdere un'annu sìngulu, o trìsina in un'intervallu."
 
 #: PublishingHistory.html publishers/view.html
 msgid "Editions Published"
@@ -6216,6 +6331,24 @@ msgstr "publicadu mescamente dae custu editore"
 #: publishers/view.html
 msgid "Get more information about this publisher"
 msgstr "Otene prus informatziones subra de custu editore"
+
+#: reading_goals/reading_goal_form.html
+msgid "How many books would you like to read this year?"
+msgstr "Cantos libros dias bòlere lèghere cust'annu?"
+
+#: reading_goals/reading_goal_form.html
+msgid "Enter \"0\" to unset your reading goal. Your check-ins will be preserved."
+msgstr "Inserta \"0\" pro annullare s'obietivu de letura tuo. Sas registratziones tuas s'ant a preservare."
+
+#: reading_goals/reading_goal_progress.html
+#, python-format
+msgid "<span class=\"reading-goal-progress__books-read\">%(books_read)d</span>/<span class=\"reading-goal-progress__goal\">%(goal)d</span> Books"
+msgstr "<span class=\"reading-goal-progress__books-read\">%(books_read)d</span>/<span class=\"reading-goal-progress__goal\">%(goal)d</span> libros"
+
+#: reading_goals/reading_goal_progress.html
+#, python-format
+msgid "Edit %(year)d Reading Goal"
+msgstr "Modìfica s'obietivu de leghidura pro su %(year)d"
 
 #: recentchanges/header.html
 msgid "By"
@@ -6257,12 +6390,23 @@ msgstr "Dae bots"
 msgid "Admin view"
 msgstr "Vista de amministradore"
 
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html recentchanges/render.html
+msgid "Older"
+msgstr "Prus betzu"
+
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html recentchanges/render.html
+msgid "Newer"
+msgstr "Prus nou"
+
 #: recentchanges/updated_records.html
 msgid "Review what's changed in from the previous revision"
 msgstr "Abbista ite est mudadu dae sa versione pretzedente"
 
-#: recentchanges/add-book/path.html recentchanges/default/path.html
-#: recentchanges/edit-book/path.html recentchanges/merge/path.html
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html recentchanges/default/path.html recentchanges/updated_records.html
+msgid "diff"
+msgstr "diferèntzias"
+
+#: recentchanges/add-book/path.html recentchanges/default/path.html recentchanges/edit-book/path.html recentchanges/merge/path.html
 msgid "expand"
 msgstr "ismànnia"
 
@@ -6274,8 +6418,7 @@ msgstr "at abertu unu contu nou de s'Open Library!"
 msgid "Review what's changed from the previous revision"
 msgstr "Abbista ite est mudadu dae sa versione pretzedente"
 
-#: recentchanges/default/view.html recentchanges/merge/view.html
-#: recentchanges/undo/view.html
+#: recentchanges/default/view.html recentchanges/merge/view.html recentchanges/undo/view.html
 msgid "Updated Records"
 msgstr "Registros atualizados"
 
@@ -6293,10 +6436,8 @@ msgstr "Abbista sos <a href=\"%s\">detàllios</a>."
 #, python-format
 msgid "Merged %(count)d duplicate %(type)s record into this primary."
 msgid_plural "Merged %(count)d duplicate %(type)s records into this primary."
-msgstr[0] ""
-"%(count)d registru duplicadu de %(type)s aunidu a custu printzipale."
-msgstr[1] ""
-"%(count)d registros duplicados de %(type)s aunidos a custu printzipale."
+msgstr[0] "%(count)d registru duplicadu de %(type)s aunidu a custu printzipale."
+msgstr[1] "%(count)d registros duplicados de %(type)s aunidos a custu printzipale."
 
 #: recentchanges/merge/comment.html
 msgid "Marked as duplicate."
@@ -6319,8 +6460,7 @@ msgstr[1] "%(who)s at aunidu %(count)d duplicados de %(master)s"
 msgid "one duplicate of %(master)s was merged anonymously"
 msgid_plural "%(count)d duplicates of %(master)s were merged anonymously"
 msgstr[0] "unu duplicadu de %(master)s l'ant aunidu in manera anònima"
-msgstr[1] ""
-"%(count)d duplicados de %(master)s los ant aunidos in manera anònima"
+msgstr[1] "%(count)d duplicados de %(master)s los ant aunidos in manera anònima"
 
 #: recentchanges/merge/view.html
 msgid "This merge has been undone."
@@ -6390,25 +6530,20 @@ msgstr "Auni autores"
 
 #: search/authors.html
 msgid "No <strong>authors</strong> directly matched your search"
-msgstr ""
-"Perunu <strong>autore</strong> at tentu currispondèntzias diretas cun sa "
-"chirca tua"
+msgstr "Perunu <strong>autore</strong> at tentu currispondèntzias diretas cun sa chirca tua"
 
 #: search/inside.html
 #, python-format
 msgid "Search Open Library for %s"
 msgstr "Chirca %s in s'Open Library"
 
-#: BookSearchInside.html FulltextSearchSuggestion.html SearchNavigation.html
-#: search/inside.html search/snippets.html
+#: BookSearchInside.html FulltextSearchSuggestion.html SearchNavigation.html search/inside.html search/snippets.html
 msgid "Search Inside"
 msgstr "Chirca a intro"
 
 #: search/inside.html
 msgid "No <strong>Search Inside</strong> text matched your search"
-msgstr ""
-"Perunu testu de sa <strong>Chirca a intro</strong> de sas òperas at tentu "
-"currispondèntzias cun sa chirca tua"
+msgstr "Perunu testu de sa <strong>Chirca a intro</strong> de sas òperas at tentu currispondèntzias cun sa chirca tua"
 
 #: search/inside.html
 #, python-format
@@ -6424,6 +6559,19 @@ msgid_plural "in %(seconds)s seconds"
 msgstr[0] "in %(seconds)s segundu"
 msgstr[1] "in %(seconds)s segundos"
 
+#: EditionNavBar.html search/layout_options.html site/stats.html
+msgid "Details"
+msgstr "Detàllios"
+
+#: search/layout_options.html
+msgid "Grid"
+msgstr "Grella"
+
+#: search/layout_options.html
+#, fuzzy
+msgid "View as: "
+msgstr "Ammustra MARC"
+
 #: search/lists.html
 msgid "Search results for Lists"
 msgstr "Resurtados de chirca de listas"
@@ -6434,8 +6582,7 @@ msgstr "Chirca listas"
 
 #: search/lists.html
 msgid "No <strong>lists</strong> directly matched your search"
-msgstr ""
-"No b'at <strong>listas chi</strong> currispondant diretamente a sa chirca tua"
+msgstr "No b'at <strong>listas chi</strong> currispondant diretamente a sa chirca tua"
 
 #: search/publishers.html
 msgid "Publishers Search"
@@ -6451,8 +6598,27 @@ msgid "Relevance"
 msgstr "Rilevàntzia"
 
 #: search/sort_options.html
+msgid "Work Count"
+msgstr "Nùmeru de òperas"
+
+#: search/sort_options.html
 msgid "Random"
 msgstr "A casu"
+
+#: search/sort_options.html
+#, fuzzy
+msgid "Name (beta: Librarian only)"
+msgstr "Tìtulu de s'òpera (beta: bibliotecàrios ebbia)"
+
+#: search/sort_options.html
+#, fuzzy
+msgid "Birth Date (oldest) (beta: Librarian only)"
+msgstr "Tìtulu de s'òpera (beta: bibliotecàrios ebbia)"
+
+#: search/sort_options.html
+#, fuzzy
+msgid "Birth Date (youngest) (beta: Librarian only)"
+msgstr "Tìtulu de s'òpera (beta: bibliotecàrios ebbia)"
 
 #: search/sort_options.html
 msgid "List Order"
@@ -6461,6 +6627,24 @@ msgstr "Òrdine de sa lista"
 #: search/sort_options.html
 msgid "Last Modified"
 msgstr "Ùrtima modìfica"
+
+#: search/sort_options.html
+#, fuzzy
+msgid "Language Name"
+msgstr "Limba"
+
+#: search/sort_options.html
+#, fuzzy
+msgid "Ebook Edition Count"
+msgstr "bloca custu contu"
+
+#: search/sort_options.html
+msgid "Date Added (newest)"
+msgstr "Data de annanta (prus noos)"
+
+#: search/sort_options.html
+msgid "Date Added (oldest)"
+msgstr "Data de annanta (prus betzos)"
 
 #: search/sort_options.html
 msgid "Most Editions"
@@ -6479,16 +6663,16 @@ msgid "Top Rated"
 msgstr "Votos prus artos"
 
 #: search/sort_options.html
+msgid "Any"
+msgstr "Cale si siat"
+
+#: search/sort_options.html
 msgid "Work Title (beta: Librarian only)"
 msgstr "Tìtulu de s'òpera (beta: bibliotecàrios ebbia)"
 
 #: search/sort_options.html
-msgid "Work Count"
-msgstr "Nùmeru de òperas"
-
-#: search/sort_options.html
-msgid "Any"
-msgstr "Cale si siat"
+msgid "Sorting by"
+msgstr "Ordinamentu pro"
 
 #: search/sort_options.html
 msgid "Shuffle"
@@ -6500,9 +6684,7 @@ msgstr "Chirca argumentos"
 
 #: search/subjects.html
 msgid "No <strong>subjects</strong> directly matched your search"
-msgstr ""
-"Perunu <strong>argumentu</strong> at tentu una currispondèntzia direta cun "
-"sa chirca tua"
+msgstr "Perunu <strong>argumentu</strong> at tentu una currispondèntzia direta cun sa chirca tua"
 
 #: search/subjects.html
 msgid "time"
@@ -6541,11 +6723,8 @@ msgid "Merge duplicates"
 msgstr "Auni sos duplicados"
 
 #: search/work_search_facets.html
-msgid "more"
-msgstr "de prus"
-
-#: search/work_search_facets.html
-msgid "less"
+#, fuzzy
+msgid "Less"
 msgstr "de mancu"
 
 #: search/work_search_facets.html
@@ -6571,34 +6750,7 @@ msgstr "Ismànnia"
 
 #: search/work_search_facets.html
 msgid "Focus your results using these <a href=\"/search/howto\">filters</a>"
-msgstr ""
-"Afina sos resurtados tuos impreende custos <a href=\"/search/"
-"howto\">filtros</a>"
-
-#: search/work_search_selected_facets.html
-msgid "eBook"
-msgstr "Libru eletrònicu"
-
-#: search/work_search_selected_facets.html
-msgid "Classic eBook"
-msgstr "Libru eletrònicu clàssicu"
-
-#: search/work_search_selected_facets.html
-msgid "Search facets"
-msgstr "Pannellos de chirca"
-
-#: search/work_search_selected_facets.html
-msgid "Explore Classic eBooks"
-msgstr "Esplora sos libros eletrònicos clàssicos"
-
-#: search/work_search_selected_facets.html
-msgid "Only Classic eBooks"
-msgstr "Petzi libros eletrònicos clàssicos"
-
-#: search/work_search_selected_facets.html
-#, python-format
-msgid "Explore books about %(subject)s"
-msgstr "Esplora libros subra de %(subject)s"
+msgstr "Afina sos resurtados tuos impreende custos <a href=\"/search/howto\">filtros</a>"
 
 #: search/work_search_selected_facets.html
 msgid "Written in"
@@ -6609,8 +6761,21 @@ msgid "Published by"
 msgstr "Publicadu dae"
 
 #: search/work_search_selected_facets.html
-msgid "Click to remove this facet"
-msgstr "Incarca pro bogare custu pannellu"
+msgid "eBook"
+msgstr "Libru eletrònicu"
+
+#: search/work_search_selected_facets.html
+msgid "Classic eBook"
+msgstr "Libru eletrònicu clàssicu"
+
+#: search/work_search_selected_facets.html
+msgid "Only Classic eBooks"
+msgstr "Petzi libros eletrònicos clàssicos"
+
+#: search/work_search_selected_facets.html
+#, fuzzy
+msgid "Classic eBooks hidden"
+msgstr "Libru eletrònicu clàssicu"
 
 #: search/work_search_selected_facets.html
 #, python-format
@@ -6625,24 +6790,13 @@ msgstr "Logotipu de s'Internet Archive"
 msgid "It looks like you're offline."
 msgstr "Paret chi non sias in lìnia."
 
-#: site/neck.html
-msgid ""
-"Open Library is an open, editable library catalog, building towards a web "
-"page for every book ever published. Read, borrow, and discover more than 3M "
-"books for free."
-msgstr ""
-"Open Library est unu catàlogu de biblioteca abertu, editàbile, chi "
-"s'isvilupat cun sa punna de tènnere una pàgina web pro cada libru chi siat "
-"mai istadu publicadu. Leghe, piga a prèstidu e iscoberi prus de 3 milliones "
-"de libros de badas."
+#: site/head.html
+msgid "Open Library is an open, editable library catalog, building towards a web page for every book ever published. Read, borrow, and discover more than 3M books for free."
+msgstr "Open Library est unu catàlogu de biblioteca abertu, editàbile, chi s'isvilupat cun sa punna de tènnere una pàgina web pro cada libru chi siat mai istadu publicadu. Leghe, piga a prèstidu e iscoberi prus de 3 milliones de libros de badas."
 
 #: site/stats.html
 msgid "Debug Stats"
 msgstr "Istatìsticas de depuratzione de còdighe"
-
-#: EditionNavBar.html site/stats.html
-msgid "Details"
-msgstr "Detàllios"
 
 #: stats/readinglog.html
 msgid "Reading Log Stats"
@@ -6654,9 +6808,7 @@ msgstr "# Libros registrados"
 
 #: stats/readinglog.html
 msgid "The total number of books logged using the Reading Log feature"
-msgstr ""
-"Su nùmeru totale de sos libros registrados impreende sa funtzionalidade de "
-"sa cronologia de letura"
+msgstr "Su nùmeru totale de sos libros registrados impreende sa funtzionalidade de sa cronologia de letura"
 
 #: stats/readinglog.html
 msgid "All time"
@@ -6667,12 +6819,8 @@ msgid "# Unique Users Logging Books"
 msgstr "# Utentes ùnicos chi imbiant libros"
 
 #: stats/readinglog.html
-msgid ""
-"The total number of unique users who have logged at least one book using the "
-"Reading Log feature"
-msgstr ""
-"Su nùmeru totale de utentes ùnicos chi ant registradu a su mancu unu libru "
-"impreende sa funtzionalidade de sa cronologia de letura"
+msgid "The total number of unique users who have logged at least one book using the Reading Log feature"
+msgstr "Su nùmeru totale de utentes ùnicos chi ant registradu a su mancu unu libru impreende sa funtzionalidade de sa cronologia de letura"
 
 #: stats/readinglog.html
 msgid "# Books Starred"
@@ -6725,18 +6873,14 @@ msgstr "Non semus resèssidos a atzapare perunu libru subra de"
 msgid "OpenAPI"
 msgstr "OpenAPI"
 
-#: type/about/edit.html type/page/edit.html type/permission/edit.html
-#: type/template/edit.html type/usergroup/edit.html
+#: type/about/edit.html type/page/edit.html type/permission/edit.html type/template/edit.html type/usergroup/edit.html
 #, python-format
 msgid "Edit %(title)s"
 msgstr "Modìfica %(title)s"
 
 #: type/about/edit.html
-msgid ""
-"This only appears in the document head, and gets attached to bookmark labels"
-msgstr ""
-"Custu aparit petzi in s'intestatzione, e est ligadu a sas etichetas de sos "
-"sinnalibros"
+msgid "This only appears in the document head, and gets attached to bookmark labels"
+msgstr "Custu aparit petzi in s'intestatzione, e est ligadu a sas etichetas de sos sinnalibros"
 
 #: type/about/edit.html
 msgid "Intro"
@@ -6767,24 +6911,16 @@ msgid "Edit Author"
 msgstr "Modìfica s'autore"
 
 #: type/author/edit.html
-msgid ""
-"Please use natural order. For example: <strong>Leo Tolstoy</strong> not "
-"<strong>Tolstoy, Leo</strong>."
-msgstr ""
-"Imprea s'òrdine naturale. A esèmpiu: <strong>Leo Tolstoy</strong> non "
-"<strong>Tolstoy, Leo</strong>."
+msgid "Please use natural order. For example: <strong>Leo Tolstoy</strong> not <strong>Tolstoy, Leo</strong>."
+msgstr "Imprea s'òrdine naturale. A esèmpiu: <strong>Leo Tolstoy</strong> non <strong>Tolstoy, Leo</strong>."
 
 #: type/author/edit.html
 msgid "A short bio?"
 msgstr "Una biografia curtza?"
 
 #: type/author/edit.html
-msgid ""
-"If you \"borrow\" information from somewhere, please make sure to cite the "
-"source."
-msgstr ""
-"Si \"pigas in prèstidu\" informatziones dae aterue pro praghere ammenta·ti "
-"de nde tzitare s'orìgine."
+msgid "If you \"borrow\" information from somewhere, please make sure to cite the source."
+msgstr "Si \"pigas in prèstidu\" informatziones dae aterue pro praghere ammenta·ti de nde tzitare s'orìgine."
 
 #: type/author/edit.html
 msgid "Date of birth"
@@ -6795,34 +6931,20 @@ msgid "Date of death"
 msgstr "Data de morte"
 
 #: type/author/edit.html
-msgid ""
-"We're not storing structured dates (yet) so a date like \"21 May 2000\" is "
-"recommended."
-msgstr ""
-"Non semus sarvende datos istruturados (pro como) duncas a data che a \"21 "
-"May 2000\" est racumandada."
+msgid "We're not storing structured dates (yet) so a date like \"21 May 2000\" is recommended."
+msgstr "Non semus sarvende datos istruturados (pro como) duncas a data che a \"21 May 2000\" est racumandada."
 
 #: type/author/edit.html
-msgid ""
-"This is a deprecated field. You can help improve this record by removing "
-"this date and populating the \"Date of birth\" and \"Date of death\" fields. "
-"Thanks!"
-msgstr ""
-"Custu est unu campu disusadu. Podes agiudare a megiorare custu registru "
-"boghende·li custa data e compilende sos campos \"Data de nàschida\" e \"Data "
-"de morte\". Gràtzias!"
+msgid "This is a deprecated field. You can help improve this record by removing this date and populating the \"Date of birth\" and \"Date of death\" fields. Thanks!"
+msgstr "Custu est unu campu disusadu. Podes agiudare a megiorare custu registru boghende·li custa data e compilende sos campos \"Data de nàschida\" e \"Data de morte\". Gràtzias!"
 
 #: type/author/edit.html
 msgid "Does this author go by any other names?"
 msgstr "Custu autore est connotu cun àteros nùmenes?"
 
 #: type/author/edit.html
-msgid ""
-"For example: Lev Nikolayevich Tolstoy was also known as Leo Tolstoy. Please "
-"list one name per line."
-msgstr ""
-"Pro esèmpiu, Lev Nikolayevich Tolstoj fiat connotu fintzas comente Leon "
-"Tolstoj. Inserta unu nùmene pro lìnea."
+msgid "For example: Lev Nikolayevich Tolstoy was also known as Leo Tolstoy. Please list one name per line."
+msgstr "Pro esèmpiu, Lev Nikolayevich Tolstoj fiat connotu fintzas comente Leon Tolstoj. Inserta unu nùmene pro lìnea."
 
 #: type/author/edit.html
 msgid "Identifiers"
@@ -6855,12 +6977,8 @@ msgid "Refresh the page?"
 msgstr "Annoare sa pàgina?"
 
 #: type/author/view.html
-msgid ""
-"OK. The merge is in motion. <i>It will take <u>a few minutes to finish</u> "
-"the update.</i>"
-msgstr ""
-"AB. S'unione est in cursu. <i>B'ant a bòlere <u>una paja de minutos pro "
-"agabbare cun</u> s'agiornamentu.</i>"
+msgid "OK. The merge is in motion. <i>It will take <u>a few minutes to finish</u> the update.</i>"
+msgstr "AB. S'unione est in cursu. <i>B'ant a bòlere <u>una paja de minutos pro agabbare cun</u> s'agiornamentu.</i>"
 
 #: type/author/view.html
 msgid "Argh!"
@@ -6871,38 +6989,20 @@ msgid "That merge didn't work. It's our fault, and we've made a note of it."
 msgstr "S'unione no at funtzionadu. Est curpa nostra, e nos l'amus annotadu."
 
 #: type/author/view.html
-msgid "Location"
-msgstr "Logu"
-
-#: type/author/view.html
 msgid "Add another?"
 msgstr "Nde boles annànghere un'àtera?"
-
-#: type/author/view.html
-#, python-format
-msgid ""
-"Showing all works by author. Would you like to see <a href=\"%(url)s\">only "
-"ebooks</a>?"
-msgstr ""
-"Ammustrende totu sas òperas pro autore. Boles bìdere <a "
-"href=\"%(url)s\">petzi sos libros eletrònicos</a>?"
-
-#: type/author/view.html
-#, python-format
-msgid ""
-"Showing ebooks only. Would you like to see <a href=\"%(url)s\">everything</"
-"a> by this author?"
-msgstr ""
-"Ammustrende petzi sos libros eletrònicos. Boles bìdere <a "
-"href=\"%(url)s\">totu</a> de custu autore?"
 
 #: type/author/view.html
 #, python-format
 msgid "Search %(author)s books"
 msgstr "Chirca libros de %(author)s"
 
-#: RelatedSubjects.html SubjectTags.html type/author/view.html
-#: type/list/view_body.html
+#: type/author/view.html
+#, fuzzy, python-format
+msgid "— Show <a href=\"%(url)s\">everything</a> by this author?"
+msgstr "Ammustrende petzi sos libros eletrònicos. Boles bìdere <a href=\"%(url)s\">totu</a> de custu autore?"
+
+#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py type/author/view.html type/list/view_body.html
 msgid "Places"
 msgstr "Logos"
 
@@ -6920,9 +7020,7 @@ msgstr "Inventaire.io:"
 
 #: type/author/view.html type/edition/view.html type/work/view.html
 msgid "Links <span class=\"gray small sansserif\">outside Open Library</span>"
-msgstr ""
-"Ligàmene <span class=\"gray small sansserif\">a foras de s'Open Library</"
-"span>"
+msgstr "Ligàmene <span class=\"gray small sansserif\">a foras de s'Open Library</span>"
 
 #: type/author/view.html
 msgid "No links yet."
@@ -6953,15 +7051,16 @@ msgid "View the previous version"
 msgstr "Abbista sa versione pretzedente"
 
 #: type/delete/view.html
-msgid "Recreate it"
-msgstr "Torra·la a creare"
-
-#: type/delete/view.html
 msgid "See the page's history"
 msgstr "Abbista sa cronologia de sa pàgina"
 
+#: type/delete/view.html
+msgid "Recreate it"
+msgstr "Torra·la a creare"
+
 #: type/edition/admin_bar.html
-msgid "Add to Staff Picks"
+#, fuzzy
+msgid "Add IA Book to Staff Picks"
 msgstr "Annanghe a sos issèberos de s'iscuadra de traballu"
 
 #: type/edition/admin_bar.html
@@ -6980,6 +7079,20 @@ msgstr "Editzione òrfana"
 msgid "Edit this page"
 msgstr "Modìfica custa pàgina"
 
+#: type/edition/modal_links.html
+msgid "Review"
+msgstr "Retzensione"
+
+#: type/edition/modal_links.html
+#, fuzzy
+msgid "reviewing"
+msgstr "Retzensione"
+
+#: type/edition/modal_links.html
+#, fuzzy
+msgid "adding notes to"
+msgstr "Annànghere un'àteru autore?"
+
 #: type/edition/title_and_author.html
 msgid "An edition of"
 msgstr "Un'editzione de"
@@ -6989,23 +7102,25 @@ msgstr "Un'editzione de"
 msgid "First published in %s"
 msgstr "Publicadu pro sa prima borta in su %s"
 
-#: type/edition/view.html type/work/view.html
-#, python-format
-msgid ""
-"This work doesn't have a description yet. Can you <b><a href='%(url)s'>add "
-"one</a></b>?"
+#: type/edition/title_and_author.html
+#, fuzzy, python-format
+msgid "Book %s"
 msgstr ""
-"Custa òpera non tenet galu una descritzione. A nde podes <b><a "
-"href='%(url)s'>agiùnghere una</a></b> tue?"
+
+#: type/edition/view.html type/work/view.html
+#, fuzzy
+msgid "Read Less"
+msgstr "Leghe de mancu"
 
 #: type/edition/view.html type/work/view.html
 #, python-format
-msgid ""
-"This edition doesn't have a description yet. Can you <b><a "
-"href='%(url)s'>add one</a></b>?"
-msgstr ""
-"Custa editzione non tenet galu una descritzione. A nde podes <b><a "
-"href='%(url)s'>agiùnghere una</a></b> tue?"
+msgid "This work doesn't have a description yet. Can you <b><a href='%(url)s'>add one</a></b>?"
+msgstr "Custa òpera non tenet galu una descritzione. A nde podes <b><a href='%(url)s'>agiùnghere una</a></b> tue?"
+
+#: type/edition/view.html type/work/view.html
+#, python-format
+msgid "This edition doesn't have a description yet. Can you <b><a href='%(url)s'>add one</a></b>?"
+msgstr "Custa editzione non tenet galu una descritzione. A nde podes <b><a href='%(url)s'>agiùnghere una</a></b> tue?"
 
 #: type/edition/view.html type/work/view.html
 msgid "Publish Date"
@@ -7021,7 +7136,7 @@ msgstr "Ammustra àteros libros de %(publisher)s"
 msgid "Search for other books from %(publisher)s"
 msgstr "Chirca àteros libros de %(publisher)s"
 
-#: type/edition/view.html type/work/view.html
+#: openlibrary/plugins/worksearch/code.py type/edition/view.html type/work/view.html
 msgid "Language"
 msgstr "Limba"
 
@@ -7090,10 +7205,6 @@ msgid "Format"
 msgstr "Formadu"
 
 #: type/edition/view.html type/work/view.html
-msgid "Pagination"
-msgstr "Impaginatzione"
-
-#: type/edition/view.html type/work/view.html
 msgid "Number of pages"
 msgstr "Nùmeru de pàginas"
 
@@ -7140,16 +7251,14 @@ msgid "Wikipedia"
 msgstr "Wikipedia"
 
 #: type/edition/view.html type/work/view.html
-msgid "This work does not appear on any lists."
-msgstr "Cust'òpera no aparit in peruna lista."
-
-#: type/edition/view.html type/work/view.html
-msgid "Loading Related Books"
-msgstr "Carrighende libros ligados"
+#, fuzzy
+msgid "Loading Lists"
+msgstr "Sas listas meas de letura:"
 
 #: type/language/view.html
-msgid "deprecated"
-msgstr "disusadu"
+#, fuzzy, python-format
+msgid "%(language)s [deprecated]"
+msgstr "in %(language)s"
 
 #: type/language/view.html
 msgid "languages"
@@ -7165,59 +7274,79 @@ msgstr "Atuale"
 
 #: type/language/view.html
 #, python-format
-msgid ""
-"Try a <a href=\"%(href)s\">search for readable books in %(language)s</a>?"
-msgstr ""
-"Boles proare a <a href=\"%(href)s\">chircare libros consultàbiles in "
-"%(language)s</a>?"
+msgid "Try a <a href=\"%(href)s\">search for readable books in %(language)s</a>?"
+msgstr "Boles proare a <a href=\"%(href)s\">chircare libros consultàbiles in %(language)s</a>?"
 
-#: type/list/edit.html
+#: type/list/edit.html type/series/edit.html
+#, fuzzy
+msgid "Create a series"
+msgstr "Crea una lista"
+
+#: type/list/edit.html type/series/edit.html
+#, fuzzy, python-format
+msgid "Editing series: %(list_name)s"
+msgstr "Modifichende sa lista: %(list_name)s"
+
+#: type/list/edit.html type/series/edit.html
 #, python-format
 msgid "Editing list: %(list_name)s"
 msgstr "Modifichende sa lista: %(list_name)s"
 
-#: type/list/edit.html
+#: type/list/edit.html type/series/edit.html
+#, fuzzy
+msgid "Edit Series"
+msgstr "Sèrie"
+
+#: type/list/edit.html type/series/edit.html
 msgid "Edit List"
 msgstr "Modìfica sa lista"
 
-#: type/list/edit.html
-msgid ""
-"⚠️ Saving global lists is admin-only while the feature is under development."
-msgstr ""
-"⚠️ Su sarvamentu de sas listas globales est riservadu petzi a sos "
-"amministradores in su mentres chi sa funtzionalidade est in fase de isvilupu."
+#: type/list/edit.html type/series/edit.html
+#, fuzzy
+msgid "Move..."
+msgstr "Boga"
 
-#: type/list/edit.html
+#: type/list/edit.html type/series/edit.html
 msgid "Search for a book"
 msgstr "Chirca unu libru"
 
-#: type/list/edit.html
+#: type/list/edit.html type/series/edit.html
+msgid "Position (optional), e.g. 1, 2, 1-7"
+msgstr "Positzione (optzionale), p.e. 1, 2, 1-7"
+
+#: type/list/edit.html type/series/edit.html
 msgid "Notes (optional)"
 msgstr "Notas (optzionales)"
 
-#: type/list/edit.html
+#: type/list/edit.html type/series/edit.html
 msgid "List Name"
 msgstr "Nùmene de sa lista"
 
-#: type/list/edit.html
+#: type/list/edit.html type/series/edit.html
+#, fuzzy
+msgid "Series Name"
+msgstr "Nùmene de utente"
+
+#: type/list/edit.html type/series/edit.html
 msgid "Description (optional)"
 msgstr "Descritzione (optzionale)"
 
-#: type/list/edit.html
+#: type/list/edit.html type/series/edit.html
 msgid "Add another book"
 msgstr "Annanghe un'àteru libru"
+
+#: type/list/edit.html type/series/edit.html
+#, fuzzy
+msgid "Create new series"
+msgstr "Crea una lista noa"
 
 #: type/list/embed.html
 msgid "Visit Open Library"
 msgstr "Vìsita s'Open Library"
 
 #: type/list/embed.html
-msgid ""
-"Open in online Book Reader. Downloads available in ePub, DAISY, PDF, TXT "
-"formats from main book page"
-msgstr ""
-"Aberi in su letore de libros in lìnia. Iscarrigamentos a disponimentu in "
-"formados ePub, DAISY, PDF e TXT dae sa pàgina printzipale de su libru"
+msgid "Open in online Book Reader. Downloads available in ePub, DAISY, PDF, TXT formats from main book page"
+msgstr "Aberi in su letore de libros in lìnia. Iscarrigamentos a disponimentu in formados ePub, DAISY, PDF e TXT dae sa pàgina printzipale de su libru"
 
 #: type/list/embed.html
 msgid "This book is checked out"
@@ -7260,9 +7389,7 @@ msgstr "Iscrie·ti"
 #: type/list/exports.html
 #, python-format
 msgid "Watch activity via <a rel=\"nofollow\" href=\"%s\">Atom feed</a>"
-msgstr ""
-"Sighi s'atividade pro mèdiu de <a rel=\"nofollow\" href=\"%s\">su flussu "
-"Atom</a>"
+msgstr "Sighi s'atividade pro mèdiu de <a rel=\"nofollow\" href=\"%s\">su flussu Atom</a>"
 
 #: type/list/exports.html
 msgid "Export Not Available"
@@ -7270,22 +7397,13 @@ msgstr "Esportatzione no a disponimentu"
 
 #: type/list/exports.html
 #, python-format
-msgid ""
-"Only lists with up to %(max)s editions can be exported. This one has "
-"%(count)s."
-msgstr ""
-"Petzi sas listas cun finas a %(max)s editziones si podent esportare. Custa "
-"nde tenet %(count)s."
+msgid "Only lists with up to %(max)s editions can be exported. This one has %(count)s."
+msgstr "Petzi sas listas cun finas a %(max)s editziones si podent esportare. Custa nde tenet %(count)s."
 
 #: type/list/exports.html
 #, python-format
-msgid ""
-"Try removing some seeds for more focus, or look at <a href=\"%s\">bulk "
-"download</a> of the catalog."
-msgstr ""
-"Pro a nde bogare unos cantos elementos pro tènnere resurtados prus "
-"cuntzentrados, o pòmpia·ti <a href=\"%s\">s'iscarrigamentu massivu</a> de su "
-"catàlogu."
+msgid "Try removing some seeds for more focus, or look at <a href=\"%s\">bulk download</a> of the catalog."
+msgstr "Pro a nde bogare unos cantos elementos pro tènnere resurtados prus cuntzentrados, o pòmpia·ti <a href=\"%s\">s'iscarrigamentu massivu</a> de su catàlogu."
 
 #: type/list/view_body.html
 #, python-format
@@ -7323,24 +7441,22 @@ msgid "Remove Seed"
 msgstr "Boga elementu"
 
 #: type/list/view_body.html
-msgid ""
-"You are about to remove the last item in the list. That will delete the "
-"whole list. Are you sure you want to continue?"
-msgstr ""
-"Ses prontu a iscantzellare s' ùrtimu elementu de sa lista. Custu at a "
-"iscantzellare totu sa lista. Ses seguru chi boles sighire?"
+msgid "You are about to remove the last item in the list. That will delete the whole list. Are you sure you want to continue?"
+msgstr "Ses prontu a iscantzellare s' ùrtimu elementu de sa lista. Custu at a iscantzellare totu sa lista. Ses seguru chi boles sighire?"
+
+#: type/list/view_body.html
+#, python-format
+msgid "This series contains %(limit)d or more works. Currently, only the first %(limit)d works are displayed."
+msgstr "Custa serie cuntenet %(limit)d o prus traballos. Momentaneamente, petzi su primu %(limit)d traballu est amostadu."
 
 #: type/list/view_body.html
 msgid "There are no items on this list."
 msgstr "Non b'at elementos in custa lista."
 
 #: type/list/view_body.html
-msgid ""
-"<a href=\"/search\" target=\"_blank\">Search for book, subjects, or authors</"
-"a> to add to your list."
+#, fuzzy
+msgid "<a href=\"/search\" target=\"_blank\" rel=\"noopener noreferrer\">Search for book, subjects, or authors</a> to add to your list."
 msgstr ""
-"<a href=\"/search\" target=\"_blank\">Chirca libros, argumentos o autores</"
-"a> de annànghere a sa lista tua."
 
 #: type/list/view_body.html
 msgid "Learn more."
@@ -7354,7 +7470,7 @@ msgstr "Metadatos de sa lista"
 msgid "Derived from seed metadata"
 msgstr "Derivados dae sos metadatos de s'elementu"
 
-#: RelatedSubjects.html SubjectTags.html type/list/view_body.html
+#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py type/list/view_body.html
 msgid "Times"
 msgstr "Èpocas"
 
@@ -7420,17 +7536,55 @@ msgstr "Annanghe un'eticheta a s'Open Library"
 
 #: type/tag/form.html
 msgid "We require a minimum set of fields to create a new collection tag."
+msgstr "Tenimus bisòngiu de un'annantu mìnimu de campos pro creare un'eticheta de regorta noa."
+
+#: EditButtons.html type/tag/form.html
+#, fuzzy
+msgid "By saving a change to this wiki, you agree that your contribution is given freely to the world under <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" target=\"_blank\" rel=\"noopener noreferrer\" title=\"This link to Creative Commons will open in a new window\">CC0</a>. Yippee!"
 msgstr ""
-"Tenimus bisòngiu de un'annantu mìnimu de campos pro creare un'eticheta de "
-"regorta noa."
 
 #: type/tag/form.html
 msgid "Add this tag now"
 msgstr "Annanghe custa eticheta como"
 
+#: type/tag/index.html
+#, fuzzy
+msgid "Tags"
+msgstr "Etichetas:"
+
+#: type/tag/index.html
+msgid "Tags curated by Open Library librarians."
+msgstr "Etichetas curadas dae is bibliotecàrios de Open Library."
+
+#: type/tag/index.html
+#, fuzzy
+msgid "View subject page"
+msgstr ""
+
+#: type/tag/index.html
+msgid "Previous"
+msgstr "Pretzedente"
+
+#: type/tag/index.html
+#, fuzzy
+msgid "No tags found."
+msgstr "No agatadu."
+
 #: type/tag/tag_form_inputs.html
 msgid "Tag Name"
 msgstr "Nùmene de eticheta"
+
+#: type/tag/tag_form_inputs.html
+msgid "Human-readable display name (e.g. \"Computer Science\", \"Horror Fiction\")"
+msgstr "Nùmene de visualizatzione lèggibile (p.e. \"Computer Science\", \"Horror Fiction\")"
+
+#: type/tag/tag_form_inputs.html
+msgid "Tag Slugs"
+msgstr "Slug de Etichetas"
+
+#: type/tag/tag_form_inputs.html
+msgid "Comma-separated URL slugs that map to this tag (auto-populated from name). E.g. \"computer_science, cs\""
+msgstr "Slugs URL separados cun coma chi mapeant a custa eticheta (populados automàticament dae su nùmene). P.e. \"computer_science, cs\""
 
 #: type/tag/tag_form_inputs.html
 msgid "Tag Description"
@@ -7442,6 +7596,11 @@ msgstr "Corpus de sa pàgina"
 
 #: type/tag/tag_form_inputs.html
 msgid "Tag type"
+msgstr "Casta de eticheta"
+
+#: type/tag/tag_form_inputs.html
+#, fuzzy
+msgid "Tag Deputy"
 msgstr "Casta de eticheta"
 
 #: type/tag/view.html
@@ -7456,6 +7615,10 @@ msgstr "Descritzione"
 #: type/tag/view.html
 msgid "Tag Body"
 msgstr "Corpus de s'eticheta"
+
+#: type/tag/view.html
+msgid "URL Slugs"
+msgstr "Slugs URL"
 
 #: type/tag/view.html
 #, python-format
@@ -7512,17 +7675,9 @@ msgid "admin page"
 msgstr "pàgina de amministratzione"
 
 #: type/user/view.html
-#, python-format
-msgid ""
-"You are publicly sharing the books you are <a href=\"%(username)s/books/"
-"currently-reading\">currently reading</a>, <a href=\"%(username)s/books/"
-"already-read\">have already read</a>, and <a href=\"%(username)s/books/want-"
-"to-read\">want to read</a>."
+#, fuzzy, python-format
+msgid "You are publicly sharing the books you are <a href=\"%(username)s/books/currently-reading\">currently reading</a>, <a href=\"%(username)s/books/already-read\">have already read</a>, <a href=\"%(username)s/books/want-to-read\">want to read</a>, and have <a href=\"%(username)s/books/stopped-reading\">stopped reading</a>!"
 msgstr ""
-"Ses cumpartzende in manera pùblica sos libros chi ses <a href=\"%(username)s/"
-"books/currently-reading\">leghende como</a>, sos chi <a href=\"%(username)s/"
-"books/already-read\">as giai lèghidu</a>, e sos chi <a href=\"%(username)s/"
-"books/want-to-read\">boles lèghere</a>."
 
 #: type/user/view.html
 msgid "You have chosen to make your"
@@ -7537,17 +7692,9 @@ msgid "Manage your privacy settings"
 msgstr "Amministra sas impostatziones de sa riservadesa tuas"
 
 #: type/user/view.html
-#, python-format
-msgid ""
-"Here are the books %(user)s is <a href=\"%(username)s/books/currently-"
-"reading\">currently reading</a>, <a href=\"%(username)s/books/already-"
-"read\">have already read</a>, and <a href=\"%(username)s/books/want-to-"
-"read\">want to read</a>!"
+#, fuzzy, python-format
+msgid "Here are the books %(user)s is <a href=\"%(username)s/books/currently-reading\">currently reading</a>, <a href=\"%(username)s/books/already-read\">have already read</a>, <a href=\"%(username)s/books/want-to-read\">want to read</a>, and has <a href=\"%(username)s/books/stopped-reading\">stopped reading</a>!"
 msgstr ""
-"Inoghe b'at sos libros chi %(user)s est <a href=\"%(username)s/books/"
-"currently-reading\">leghende como</a>, <a href=\"%(username)s/books/already-"
-"read\">at giai lèghidu</a>, e <a href=\"%(username)s/books/want-to-"
-"read\">bolet lèghere</a>!"
 
 #: type/user/view.html
 msgid "My Lists"
@@ -7613,33 +7760,12 @@ msgid "Look for this edition for sale at %(store)s"
 msgstr "Chirca cust'editzione in bèndida in %(store)s"
 
 #: AffiliateLinks.html
+msgid "When you buy books using these links the Internet Archive may earn a <a class=\"nostyle\" href=\"/help/faq/about#selling\">small commission</a>."
+msgstr "Cando còmporas libros impreende custos ligàmenes s'Internet Archive diat pòdere balangiare una <a class=\"nostyle\" href=\"/help/faq/about#selling\">cummissione minore</a>."
+
+#: AffiliateLinksLoadingIndicator.html
 msgid "Fetching prices"
 msgstr "Recuperende sos prètzios"
-
-#: AffiliateLinks.html
-msgid "Better World Books"
-msgstr "Better World Books"
-
-#: AffiliateLinks.html
-msgid " - includes shipping"
-msgstr " - includet s'ispeditzione"
-
-#: AffiliateLinks.html
-msgid "Amazon"
-msgstr "Amazon"
-
-#: AffiliateLinks.html
-msgid "Bookshop.org"
-msgstr "Bookshop.org"
-
-#: AffiliateLinks.html
-msgid ""
-"When you buy books using these links the Internet Archive may earn a <a "
-"class=\"nostyle\" href=\"/help/faq/about#selling\">small commission</a>."
-msgstr ""
-"Cando còmporas libros impreende custos ligàmenes s'Internet Archive diat "
-"pòdere balangiare una <a class=\"nostyle\" href=\"/help/faq/"
-"about#selling\">cummissione minore</a>."
 
 #: BatchImportNavigation.html
 msgid "Pending Imports"
@@ -7665,97 +7791,13 @@ msgid "Preview Book"
 msgstr "Abbista un'anteprima de su libru"
 
 #: DisplayCode.html
-msgid ""
-"Templates in the website are disabled now. Editing them will not have any "
-"effect on the live website."
-msgstr ""
-"Sos modellos in su situ como sunt disativados. Sa modìfica issoro no at a "
-"tènnere perunu efetu in su situ web in lìnia."
+msgid "Templates in the website are disabled now. Editing them will not have any effect on the live website."
+msgstr "Sos modellos in su situ como sunt disativados. Sa modìfica issoro no at a tènnere perunu efetu in su situ web in lìnia."
 
-#: DonateModal.html
-msgid ""
-"Donate this book to the <a href=\"https://archive.org\">Internet Archive</a> "
-"library."
-msgstr ""
-"Dona custu libru a sa biblioteca de <a href=\"https://archive."
-"org\">s'Internet Archive</a>."
-
-#: DonateModal.html
-msgid ""
-"Hooray! You've discovered a title that's missing from our <a href=\"https://"
-"help.archive.org/hc/en-us/articles/360016554912-Borrowing-From-The-Lending-"
-"Library\">library</a>. Can you help donate a copy?"
-msgstr ""
-"Urrà! As iscobertu unu tìtulu chi mancat in sa <a href=\"https://help."
-"archive.org/hc/en-us/articles/360016554912-Borrowing-From-The-Lending-"
-"Library\">biblioteca</a> nostra. Podes agiudare a nde donare una còpia?"
-
-#: DonateModal.html
-msgid ""
-"If you own this book, you can<a href=\"https://store.usps.com/store/product/"
-"shipping-supplies/priority-mail-express-padded-flat-rate-envelope-"
-"P_EP13PE\">mail</a> it to our address below."
-msgstr ""
-"Si tenes custu libru, nos lu podes <a href=\"https://store.usps.com/store/"
-"product/shipping-supplies/priority-mail-express-padded-flat-rate-envelope-"
-"P_EP13PE\">ispedire</a> a s'indiritzu nostru inoghe in suta."
-
-#: DonateModal.html
-msgid ""
-"You can also purchase this book from a vendor and ship it to our address:"
-msgstr ""
-"Podes fintzas comporare custu libru dae unu bendidore e imbiare·nos·lu a "
-"s'indiritzu nostru:"
-
-#: DonateModal.html
-msgid "Benefits of donating"
-msgstr "Vantàgios de sa donatzione"
-
-#: DonateModal.html
-msgid ""
-"When you donate a physical book to the Internet Archive, your book will "
-"enjoy:"
-msgstr "Cando donas unu libru a s'Internet Archive, su libru tuo at a tènnere:"
-
-#: DonateModal.html
-msgid "Donation info"
-msgstr "Informatziones de donatzione"
-
-#: DonateModal.html
-msgid ""
-"Beautiful <a target=\"_blank\" href=\"https://archive.org/scanning\">high-"
-"fidelity digitization</a>"
-msgstr ""
-"Una <a target=\"_blank\" href=\"https://archive.org/"
-"scanning\">digitalizatzione a fidelidade arta</a> bella a beru"
-
-#: DonateModal.html
-msgid ""
-"Long-term <a href=\"https://blog.archive.org/2011/06/06/why-preserve-books-"
-"the-new-physical-archive-of-the-internet-archive/\">archival preservation</a>"
-msgstr ""
-"Unu <a href=\"https://blog.archive.org/2011/06/06/why-preserve-books-the-new-"
-"physical-archive-of-the-internet-archive/\">custoimentu in archìviu</a> a "
-"tèrmine longu"
-
-#: DonateModal.html
-msgid ""
-"Free <a href=\"https://controlleddigitallending.org/\">controlled digital "
-"library access</a> by the <a href=\"https://en.wikipedia.org/wiki/"
-"Print_disability\">print-disabled</a> public"
-msgstr ""
-"Atzessu lìberu <a href=\"https://controlleddigitallending.org/\">a sa "
-"biblioteca digitale controllada</a> pro su pùblicu cun<a href=\"https://en."
-"wikipedia.org/wiki/Print_disability\">disabilidades ligadas a sos caràteres "
-"imprentados</a>"
-
-#: DonateModal.html
-msgid ""
-"Open Library is a project of the <a href=\"https://archive.org/"
-"about\">Internet Archive</a>, a 501(c)(3) non-profit"
-msgstr ""
-"Open Library est unu progetu de s'<a href=\"https://archive.org/"
-"about\">Internet Archive</a>, un'assòtziu 501(c)(3) chene punna de logru"
+#: EditionNavBar.html
+#, fuzzy
+msgid "Go to previous section"
+msgstr "Bae a sa setzione imbeniente"
 
 #: EditionNavBar.html
 msgid "Overview"
@@ -7784,12 +7826,14 @@ msgid "Go to next section"
 msgstr "Bae a sa setzione imbeniente"
 
 #: Follow.html
-msgid "UnfollowFollow"
-msgstr "Acaba de sighire"
+#, fuzzy
+msgid "Unfollow"
+msgstr "Sighi"
 
 #: Follow.html
-msgid "Follow"
-msgstr "Sighi"
+#, fuzzy
+msgid "Failed to update followers. Please try again in a few moments."
+msgstr "Imbiu de su cummentu fallidu. Torra a proare unu pagu prus a tardu."
 
 #: FormatExpiry.html
 msgid "Expires"
@@ -7815,8 +7859,7 @@ msgstr "%(book_count)s libros atzapados cun passàgios chi currispondent"
 #: FulltextSearchSuggestion.html
 #, python-format
 msgid "See all %(results_count)s Search Inside Matches"
-msgstr ""
-"Abbista totu sas %(results_count)s currispondèntzias de sa chirca a intro"
+msgstr "Abbista totu sas %(results_count)s currispondèntzias de sa chirca a intro"
 
 #: FulltextSearchSuggestion.html
 msgid "right chevron"
@@ -7899,6 +7942,10 @@ msgid_plural "You have %(count)d more hours to borrow it."
 msgstr[0] "Tenes %(count)d àtera ora pro lu pigare in prèstidu."
 msgstr[1] "Tenes àteras %(count)d oras pro lu pigare in prèstidu."
 
+#: NotInLibrary.html
+msgid "Not in Library"
+msgstr "No in sa biblioteca"
+
 #: NotesModal.html
 msgid "My Book Notes"
 msgstr "Sas notas meas a su libru"
@@ -7907,13 +7954,33 @@ msgstr "Sas notas meas a su libru"
 msgid "My private notes about this edition:"
 msgstr "Sas notas privadas meas subra de custa editzione:"
 
+#: OLID.html
+#, fuzzy, python-format
+msgid "by  %(authors)s"
+msgstr ""
+
 #: ObservationsModal.html
 msgid "My Book Review"
 msgstr "Sa retzensione mea a su libru"
 
-#: Pager.html Pager_loanhistory.html
-msgid "First"
-msgstr "Primu"
+#: OlPagination.html OlPaginationArrows.html
+msgid "Go to previous page"
+msgstr "Anda a sa pàgina precedente"
+
+#: OlPagination.html OlPaginationArrows.html
+#, fuzzy
+msgid "Go to next page"
+msgstr "Bae a sa setzione imbeniente"
+
+#: OlPagination.html
+#, fuzzy, python-brace-format
+msgid "Go to page {page}"
+msgstr ""
+
+#: OlPagination.html
+#, python-brace-format
+msgid "Page {page}, current page"
+msgstr "Pàgina {page}, pàgina curente"
 
 #: Profile.html
 msgid "Component"
@@ -7928,21 +7995,33 @@ msgid "who have written the most books on this subject"
 msgstr "chi ant iscritu sa parte manna de sos libros subra de custu argumentu"
 
 #: PublishingHistory.html
-msgid ""
-"This is a chart to show the publishing history of editions of works about "
-"this subject. Along the X axis is time, and on the y axis is the count of "
-"editions published. <a href=\"#subjectRelated\">Click here to skip the "
-"chart</a>."
-msgstr ""
-"Custu est unu gràficu pro mustrare sa cronologia de publicatzione de "
-"editziones de traballos subra de custu argumentu. In s'asse x b'at su "
-"tempus, ee in s'asse y b'at su nùmeru de editziones publicadas. <a "
-"href=\"#subjectRelated\">Incarca inoghe pro brincare su gràficu</a>."
+msgid "This is a chart to show the publishing history of editions of works about this subject. Along the X axis is time, and on the y axis is the count of editions published. <a href=\"#subjectRelated\">Click here to skip the chart</a>."
+msgstr "Custu est unu gràficu pro mustrare sa cronologia de publicatzione de editziones de traballos subra de custu argumentu. In s'asse x b'at su tempus, ee in s'asse y b'at su nùmeru de editziones publicadas. <a href=\"#subjectRelated\">Incarca inoghe pro brincare su gràficu</a>."
 
 #: PublishingHistory.html
 msgid "This graph charts editions published on this subject."
-msgstr ""
-"Custu gràficu mapat sas editziones publicadas subra de custu argumentu."
+msgstr "Custu gràficu mapat sas editziones publicadas subra de custu argumentu."
+
+#: RawQueryCarousel.html
+#, fuzzy
+msgid "Loading carousel"
+msgstr "Indicadore de carrigamentu"
+
+#: RawQueryCarousel.html
+msgid "Failed to fetch carousel."
+msgstr "Fallidu is prenus de su carusèlliu."
+
+#: RawQueryCarousel.html
+msgid "Retry?"
+msgstr "Retenta?"
+
+#: RawQueryCarousel.html
+msgid "No books match the current filters."
+msgstr "Nessunu libru currispondet is filtros currentes."
+
+#: RawQueryCarousel.html
+msgid "Retry without filters?"
+msgstr "Retenta sena filtros?"
 
 #: RawQueryCarousel.html
 msgid "Search collection"
@@ -7953,12 +8032,8 @@ msgid "Special Access"
 msgstr "Atzessu ispetziale"
 
 #: ReadButton.html
-msgid ""
-"Special ebook access from the Internet Archive for patrons with qualifying "
-"print disabilities"
-msgstr ""
-"Atzessu ispetziale dae s'Internet Archive pro metzenates cun problemas de "
-"vista"
+msgid "Special ebook access from the Internet Archive for patrons with qualifying print disabilities"
+msgstr "Atzessu ispetziale dae s'Internet Archive pro metzenates cun problemas de vista"
 
 #: ReadButton.html
 msgid "Borrow ebook from Internet Archive"
@@ -7971,14 +8046,6 @@ msgstr "Leghe su libru eletrònicu dae s'Internet Archive"
 #: ReadButton.html
 msgid "Listen"
 msgstr "Ascurta"
-
-#: ReadMore.html
-msgid "Read more"
-msgstr "Leghe de prus"
-
-#: ReadMore.html
-msgid "Read less"
-msgstr "Leghe de mancu"
 
 #: RecentChanges.html
 msgid "View MARC"
@@ -8017,6 +8084,11 @@ msgid "added to"
 msgstr "annantu a"
 
 #: SearchResultsWork.html
+#, fuzzy, python-format
+msgid "Book %(position)s"
+msgstr ""
+
+#: SearchResultsWork.html
 #, python-format
 msgid "Cover of edition %(id)s"
 msgstr "Cobertedda de s'editzione %(id)s"
@@ -8024,12 +8096,11 @@ msgstr "Cobertedda de s'editzione %(id)s"
 #: SearchResultsWork.html
 #, python-format
 msgid "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d language</a>"
-msgid_plural ""
-"in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d languages</a>"
+msgid_plural "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d languages</a>"
 msgstr[0] "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d limba</a>"
 msgstr[1] "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d limbas</a>"
 
-#: SearchResultsWork.html
+#: SearchResultsWork.html TrendingBadge.html
 msgid "This is only visible to librarians."
 msgstr "Custu lu podent bìdere petzi sos bibliotecàrios."
 
@@ -8079,6 +8150,26 @@ msgid "QR Code"
 msgstr "Còdighe QR"
 
 #: StarRatings.html
+msgid "leaving a 1 star review for"
+msgstr "lassende una recentsione de 1 isteddu pro"
+
+#: StarRatings.html
+msgid "leaving a 2 star review for"
+msgstr "lassende una recentsione de 2 isteddos pro"
+
+#: StarRatings.html
+msgid "leaving a 3 star review for"
+msgstr "lassende una recentsione de 3 isteddos pro"
+
+#: StarRatings.html
+msgid "leaving a 4 star review for"
+msgstr "lassende una recentsione de 4 isteddos pro"
+
+#: StarRatings.html
+msgid "leaving a 5 star review for"
+msgstr "lassende una recentsione de 5 isteddos pro"
+
+#: StarRatings.html
 msgid "Clear my rating"
 msgstr "Inneta sa valutatzione mea"
 
@@ -8090,6 +8181,10 @@ msgstr "votu"
 msgid "ratings"
 msgstr "votos"
 
+#. Shows the count of readers who added this book to their "Want to read"
+#. shelf, displayed on search result pages. %(want_to_read_count)s is a
+#. formatted integer (may include commas as thousands separators). Example:
+#. "2,389 Want to read".
 #: StarRatingsByline.html
 #, python-format
 msgid "%(want_to_read_count)s Want to read"
@@ -8100,17 +8195,38 @@ msgstr "%(want_to_read_count)s Chèrgio lèghere"
 msgid "%(ratings_avg)s (%(ratings_count)s %(ratings_label)s)"
 msgstr "%(ratings_avg)s (%(ratings_count)s %(ratings_label)s)"
 
+#. Short label displayed next to the count of readers who want to read this
+#. book, shown in the stats bar on a book page. Example: "2,389 Want to read".
 #: StarRatingsStats.html
 msgid "Want to read"
 msgstr "Chèrgio lèghere"
 
+#. Short label displayed next to the count of readers currently reading this
+#. book, shown in the stats bar on a book page. Example: "1,247 Currently
+#. reading".
 #: StarRatingsStats.html
 msgid "Currently reading"
 msgstr "Leghende como"
 
+#. Short label displayed next to the count of readers who have finished this
+#. book, shown in the stats bar on a book page. Example: "15,420 Have read".
+#. This refers to the same shelf as the "Already Read" button.
 #: StarRatingsStats.html
 msgid "Have read"
 msgstr "Apo lèghidu"
+
+#. Short label displayed next to the count of readers who stopped reading this
+#. book before finishing, shown in the stats bar on a book page. Example: "348
+#. Stopped reading".
+#: StarRatingsStats.html
+#, fuzzy
+msgid "Stopped reading"
+msgstr "De tendèntzia"
+
+#: SubjectTags.html
+#, fuzzy
+msgid "Manage Subjects"
+msgstr "Impreare sos argumentos"
 
 #: Subnavigation.html
 msgid "Developer Center (Home)"
@@ -8165,6 +8281,11 @@ msgstr "P.F. de s'Open Library"
 msgid "Page %s"
 msgstr "Pàgina %s"
 
+#: TrendingBadge.html
+#, python-format
+msgid "Trending: %(score).2f"
+msgstr "In tendèntzia: %(score).2f"
+
 #: TypeChanger.html
 msgid "Page Type"
 msgstr "Casta de pàgina"
@@ -8174,31 +8295,16 @@ msgid "Huh?"
 msgstr "Ah?"
 
 #: TypeChanger.html
-msgid ""
-"Every piece of Open Library is defined by the type of content it displays, "
-"usually by content definition (e.g. Authors, Editions, Works) but sometimes "
-"by content use (e.g. macro, template, rawtext). Changing this for an "
-"existing page will alter its presentation and the data fields available for "
-"editing its content."
-msgstr ""
-"Cada parte de s'Open Library est definida dae sa casta de cuntenutu chi "
-"ammustrat, de sòlitu pro definitzione de su cuntenutu (a es. Autores, "
-"Ediziones, Òperas) ma a bortas pro s'impreu de su cuntenutu (pro es. macro, "
-"modellu, testu crudu). Si custu càmbiat pro una pàgina chi esistit, at a "
-"cambiare sa presentatzione sua e sos campos de datos a disponimentu pro "
-"modificare su cuntenutu suo."
+msgid "Every piece of Open Library is defined by the type of content it displays, usually by content definition (e.g. Authors, Editions, Works) but sometimes by content use (e.g. macro, template, rawtext). Changing this for an existing page will alter its presentation and the data fields available for editing its content."
+msgstr "Cada parte de s'Open Library est definida dae sa casta de cuntenutu chi ammustrat, de sòlitu pro definitzione de su cuntenutu (a es. Autores, Ediziones, Òperas) ma a bortas pro s'impreu de su cuntenutu (pro es. macro, modellu, testu crudu). Si custu càmbiat pro una pàgina chi esistit, at a cambiare sa presentatzione sua e sos campos de datos a disponimentu pro modificare su cuntenutu suo."
 
 #: TypeChanger.html
 msgid "Please use caution changing Page Type!"
 msgstr "Dae cara cambiende sa casta de pàgina!"
 
 #: TypeChanger.html
-msgid ""
-"(Simplest solution: If you aren't sure whether this should be changed, don't "
-"change it.)"
-msgstr ""
-"(Solutzione prus fàtzile: si non ses seguru si diat èssere su casu de la "
-"cambiare, non la càmbies.)"
+msgid "(Simplest solution: If you aren't sure whether this should be changed, don't change it.)"
+msgstr "(Solutzione prus fàtzile: si non ses seguru si diat èssere su casu de la cambiare, non la càmbies.)"
 
 #: WorkInfo.html
 msgid "No link to Wikipedia in your language"
@@ -8207,10 +8313,6 @@ msgstr "Perunu ligàmene a Wikipedia in sa limba tua"
 #: WorldcatLink.html
 msgid "Check nearby libraries"
 msgstr "Chirca in sas bibliotecas a curtzu"
-
-#: WorldcatLink.html
-msgid "Library.link"
-msgstr "Library.link"
 
 #: WorldcatLink.html
 msgid "Check WorldCat for an edition near you"
@@ -8254,214 +8356,414 @@ msgstr "Modìfica custu modellu"
 msgid "View Volume %(num)d"
 msgstr "Abbista su volume %(num)d"
 
-#: account.py
+#: openlibrary/core/bookshelves.py
+#, fuzzy
+msgid "[Record deleted]"
+msgstr "ID de registru"
+
+#: openlibrary/core/edits.py
+#, fuzzy
+msgid "Unknown"
+msgstr "Nùmene disconnotu"
+
+#: openlibrary/plugins/openlibrary/api.py
+#, fuzzy
+msgid "Search Results"
+msgstr "Chirca listas"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Arabic"
+msgstr "Àrabu"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Czech"
+msgstr "Tzecu"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "German"
+msgstr "Tedescu"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "English"
+msgstr "Inglesu"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Spanish"
+msgstr "Ispagnolu"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "French"
+msgstr "Frantzesu"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Hindi"
+msgstr "Hindi"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Croatian"
+msgstr "Croatu"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Italian"
+msgstr "Italianu"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Portuguese"
+msgstr "Portoghesu"
+
+#: openlibrary/plugins/openlibrary/code.py
+#, fuzzy
+msgid "Romanian"
+msgstr "Croatu"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Sardinian"
+msgstr "Sardu"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Telugu"
+msgstr "Telugu"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Ukrainian"
+msgstr "Ucràinu"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Chinese"
+msgstr "Tzinesu"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Filipino"
+msgstr "Filipino"
+
+#: openlibrary/plugins/openlibrary/home.py
+#, fuzzy
+msgid "Art"
+msgstr "Incumintza"
+
+#: openlibrary/plugins/openlibrary/home.py
+#, fuzzy
+msgid "Science Fiction"
+msgstr "Classificatziones"
+
+#: openlibrary/plugins/openlibrary/home.py
+#, fuzzy
+msgid "Fantasy"
+msgstr "Caràteres"
+
+#: openlibrary/plugins/openlibrary/home.py
+#, fuzzy
+msgid "Biographies"
+msgstr "Gràficos"
+
+#: openlibrary/plugins/openlibrary/home.py
+#, fuzzy
+msgid "Recipes"
+msgstr "Retzensiones"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Children"
+msgstr "Pitzinnos"
+
+#: openlibrary/plugins/openlibrary/home.py
+#, fuzzy
+msgid "Medicine"
+msgstr "Icona incorporada"
+
+#: openlibrary/plugins/openlibrary/home.py
+#, fuzzy
+msgid "Religion"
+msgstr "Revisione"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Mystery and Detective Stories"
+msgstr "Nòvelas de Misteriu e Detectives"
+
+#: openlibrary/plugins/openlibrary/home.py
+#, fuzzy
+msgid "Plays"
+msgstr "Logos"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Music"
+msgstr "Mùsica"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+#, fuzzy
+msgid "At least 1 subject"
+msgstr "Seletziona custu argumentu"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+#, fuzzy
+msgid "At least 1 author"
+msgstr "Annanghe un'autore nou"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+#, fuzzy
+msgid "At least 1 edition"
+msgstr "Custa editzione"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has work (orphaned)"
+msgstr "At traballu (orfanu)"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+#, fuzzy
+msgid "Has publication year"
+msgstr "Annu de publicatzione"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+#, fuzzy
+msgid "Has cover"
+msgstr "Iscoberi"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+#, fuzzy
+msgid "Has language"
+msgstr "Limba"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+#, fuzzy
+msgid "Has publisher"
+msgstr "Editore"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+#, fuzzy
+msgid "At least 2 editions"
+msgstr "Prus editziones"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+#, fuzzy
+msgid "Has dewey decimal"
+msgstr "Che a sa detzimale de Dewey?"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+#, fuzzy
+msgid "Has LoC classification"
+msgstr "Classificatziones"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+#, fuzzy
+msgid "Has number of pages"
+msgstr "Nùmeru de pàginas"
+
+#: openlibrary/plugins/openlibrary/lists.py
+#, fuzzy, python-format
+msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
+msgstr "Ses seguru de nche bòlere bogare <strong>%(title)s</strong> dae custa lista?"
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "Better World Books"
+msgstr "Better World Books"
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid " - includes shipping"
+msgstr " - includet s'ispeditzione"
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "Amazon"
+msgstr "Amazon"
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "Bookshop.org"
+msgstr "Bookshop.org"
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "This work does not appear on any lists."
+msgstr "Cust'òpera no aparit in peruna lista."
+
+#: openlibrary/plugins/openlibrary/pd.py
+msgid "I don't have one yet"
+msgstr "Non nde tèngio ancora unu"
+
+#: openlibrary/plugins/upstream/account.py
 msgid "The email address you entered is invalid"
 msgstr "S'indiritzu de posta chi as insertadu no est àlidu"
 
-#: account.py
+#: openlibrary/plugins/upstream/account.py
 msgid "This account has been blocked"
 msgstr "Custa contu est istadu blocadu"
 
-#: account.py
+#: openlibrary/plugins/upstream/account.py
 msgid "This account has been locked"
 msgstr "Custu contu est istadu tancadu"
 
-#: account.py
+#: openlibrary/plugins/upstream/account.py
 msgid "No account was found with this email. Please try again"
-msgstr ""
-"Perunu contu atzapadu cun custu indiritzo de posta eletrònica. Torra a proare"
+msgstr "Perunu contu atzapadu cun custu indiritzo de posta eletrònica. Torra a proare"
 
-#: account.py
+#: openlibrary/plugins/upstream/account.py
 msgid "The password you entered is incorrect. Please try again"
 msgstr "Sa crae chi as insertadu est isballiada. Torra a proare"
 
-#: account.py
+#: openlibrary/plugins/upstream/account.py
 msgid "Wrong password. Please try again"
 msgstr "Crae isballiada. Torra a proare"
 
-#: account.py
+#: openlibrary/plugins/upstream/account.py
 msgid "Please verify your Open Library account before logging in"
 msgstr "Verìfica su contu tuo de s'Open Library in antis de intrare"
 
-#: account.py
+#: openlibrary/plugins/upstream/account.py
 msgid "Please verify your Internet Archive account before logging in"
 msgstr "Verìfica su contu tuo de s'Internet Archive in antis de intrare"
 
-#: account.py
+#: openlibrary/plugins/upstream/account.py
 msgid "Please fill out all fields and try again"
 msgstr "Inserta totu sos campos e torra a proare"
 
-#: account.py
+#: openlibrary/plugins/upstream/account.py
 msgid "This email is already registered"
 msgstr "Custu indiritzu de posta est giai registradu"
 
-#: account.py
+#: openlibrary/plugins/upstream/account.py
 msgid "This username is already registered"
 msgstr "Custu nùmene de utente est giai registradu"
 
-#: account.py
+#: openlibrary/plugins/upstream/account.py
 msgid "A problem occurred and we were unable to log you in."
 msgstr "B'at àpidu unu problema e non t'amus pòdidu fàghere intrare."
 
-#: account.py
+#: openlibrary/plugins/upstream/account.py
 msgid "Login attempted with invalid Internet Archive s3 credentials."
-msgstr ""
-"Atzessu intentadu cun credentziales s3 de s'Internet Archive non vàlidas."
+msgstr "Atzessu intentadu cun credentziales s3 de s'Internet Archive non vàlidas."
 
-#: account.py
-msgid ""
-"Servers are experiencing unusually high traffic, please try again later or "
-"email openlibrary@archive.org for help."
-msgstr ""
-"Sos webidores sunt tenende unu tràficu prus artu de su sòlitu, torra a "
-"proare prus a tardu o imbia unu messàgiu de posta eletrònica a "
-"openlibrary@archive.org pro pedire agiudu."
+#: openlibrary/plugins/upstream/account.py
+msgid "Servers are experiencing unusually high traffic, please try again later or email openlibrary@archive.org for help."
+msgstr "Sos webidores sunt tenende unu tràficu prus artu de su sòlitu, torra a proare prus a tardu o imbia unu messàgiu de posta eletrònica a openlibrary@archive.org pro pedire agiudu."
 
-#: account.py
+#: openlibrary/plugins/upstream/account.py
 msgid "Email provider not recognized."
 msgstr "Su frunidore de posta eletrònica no est reconnòschidu."
 
-#: account.py
+#: openlibrary/plugins/upstream/account.py
 msgid "Password requirements not met."
 msgstr "Rechisidos de sa crae non rispetados."
 
-#: account.py
+#: openlibrary/plugins/upstream/account.py
 msgid "A problem occurred and we were unable to log you in"
 msgstr "B'at àpidu unu problema e non t'amus pòdidu fàghere intrare"
 
-#: account.py
+#: openlibrary/plugins/upstream/account.py
+#, fuzzy
+msgid "Login or registration attempt hit an unexpected error, please try again or contact info@archive.org"
+msgstr "Su contu tuo est arribbadu a unu lìmite de prèstidos. Torra a proare prus a tardu o cuntata a info@archive.org."
+
+#: openlibrary/plugins/upstream/account.py
 #, python-format
 msgid "Request failed with error code: %(error_code)s"
 msgstr "Dimanda fallida cun còdighe de errore: %(error_code)s"
 
-#: account.py
-#, python-format
-msgid ""
-"We've sent the verification email to %(email)s. You'll need to read that and "
-"click on the verification link to verify your email."
-msgstr ""
-"Amus imbiadu sa lìtera eletrònica de verìfica a %(email)s. Ti l'as a dèpere "
-"lèghere e as a dèpere incarcare in su ligàmene de verìfica pro averguare "
-"s'indiritzu de posta eletrònica tuo."
+#: openlibrary/plugins/upstream/account.py
+msgid "Thank you for registering an Open Library account and requesting special print disability access. You should receive an email detailing next steps in the process."
+msgstr "Gràtzias pro t'atzedi a unu account de Open Library e domandare s'atzessu ispetziale pro incapatzidade de impressione. Deves retzire un'email cun is detallos de is passos sutzessivos de su prètzimu."
 
-#: account.py
+#: openlibrary/plugins/upstream/account.py
 msgid "Username unavailable"
 msgstr "Nùmene utente no a disponimentu"
 
-#: account.py forms.py
+#: openlibrary/plugins/upstream/account.py openlibrary/plugins/upstream/forms.py
 msgid "Email already registered"
 msgstr "Indiritzu de posta giai registradu"
 
-#: account.py
+#: openlibrary/plugins/upstream/account.py
 msgid "An Internet Archive account already exists with this email"
-msgstr ""
-"Unu contu de s'Internet Archive cun custu indiritzu de posta eletrònica "
-"esistit giai"
+msgstr "Unu contu de s'Internet Archive cun custu indiritzu de posta eletrònica esistit giai"
 
-#: account.py
-msgid "Email address is already used."
-msgstr "S'indiritzu de posta eletrònica tuo est giai istadu impreadu."
+#: openlibrary/plugins/upstream/account.py
+msgid "Verification failed. The link may be invalid or expired. Please try registering again."
+msgstr "Sa cunfirma at fallidu. Su colegamentu podet esser invalidu o scadudu. Pro praghere, torra a registrarte."
 
-#: account.py
-msgid ""
-"Your email address couldn't be updated. The specified email address is "
-"already used."
-msgstr ""
-"S'atualizatzione de s'indiritzu de posta tuo est fallida. S'indiritzu "
-"ispetzificadu est giai impreadu."
+#: openlibrary/plugins/upstream/account.py
+msgid "Your email has been verified. You are now logged in."
+msgstr "S'email tua est istada cunfirmada. Immoi ses intradu/a a su sistema."
 
-#: account.py
-msgid "Email verification successful."
-msgstr "Verìfica de s'indiritzu de posta fata cun sutzessu."
-
-#: account.py
-msgid ""
-"Your email address has been successfully verified and updated in your "
-"account."
-msgstr ""
-"S' indiritzu de posta eletrònica tuo est istadu verificadu cun sutzessu e "
-"atualizazu in su contu tuo."
-
-#: account.py
-msgid "Email address couldn't be verified."
-msgstr "S' indiritzu de posta non si podiat averguare."
-
-#: account.py
-msgid ""
-"Your email address couldn't be verified. The verification link seems invalid."
-msgstr ""
-"Non faghiat a verificare s'indiritzu de posta eletrònica tuo. Su ligàmene de "
-"verìfica tuo paret chi siat non vàlidu."
-
-#: account.py
-msgid "Password reset failed."
-msgstr "Resetada de sa crae fallida."
-
-#: account.py
+#: openlibrary/plugins/upstream/account.py
 msgid "Notification preferences have been updated successfully."
 msgstr "Sas preferèntzias de notìfica sunt istadas atualizadas cun sutzessu."
 
-#: borrow.py
-msgid ""
-"Your account has hit a lending limit. Please try again later or contact "
-"info@archive.org."
-msgstr ""
-"Su contu tuo est arribbadu a unu lìmite de prèstidos. Torra a proare prus a "
-"tardu o cuntata a info@archive.org."
+#: openlibrary/plugins/upstream/borrow.py
+#, fuzzy
+msgid "this book"
+msgstr "Còmpora custu libru"
 
-#: forms.py
+#: openlibrary/plugins/upstream/borrow.py
+#, fuzzy, python-format
+msgid "Unable to return %s. Please try again later or contact info@archive.org."
+msgstr ""
+
+#: openlibrary/plugins/upstream/borrow.py
+#, fuzzy, python-format
+msgid "%s has been returned."
+msgstr ""
+
+#: openlibrary/plugins/upstream/borrow.py
+msgid "Your account has hit a lending limit. Please try again later or contact info@archive.org."
+msgstr "Su contu tuo est arribbadu a unu lìmite de prèstidos. Torra a proare prus a tardu o cuntata a info@archive.org."
+
+#: openlibrary/plugins/upstream/forms.py
 msgid "Username"
 msgstr "Nùmene de utente"
 
-#: forms.py
+#: openlibrary/plugins/upstream/forms.py
 msgid "No user registered with this email address"
 msgstr "Perunu utente registradu cun custu indiritzu de posta"
 
-#: forms.py
+#: openlibrary/plugins/upstream/forms.py
 msgid "Disposable email not permitted"
 msgstr "Sos indiritzos de posta temporàneos non sunt ammìtidos"
 
-#: forms.py
+#: openlibrary/plugins/upstream/forms.py
 msgid "Your email provider is not recognized."
 msgstr "Su frunidore tuo de posta eletrònica no est reconnòschidu."
 
-#: forms.py
+#: openlibrary/plugins/upstream/forms.py
 msgid "Username already used"
 msgstr "Nùmene utente giai impreadu"
 
-#: forms.py
+#: openlibrary/plugins/upstream/forms.py
 msgid "Must be between 3 and 20 letters and numbers"
 msgstr "Depet tènnere intre 3 e 20 lìteras e nùmeros"
 
-#: forms.py
+#: openlibrary/plugins/upstream/forms.py
 msgid "Screen Name"
 msgstr "Nùmene mustradu"
 
-#: forms.py
+#: openlibrary/plugins/upstream/forms.py
 msgid "Public and cannot be changed later."
 msgstr "Est pùblicu e non si podet mudare prus a tardu."
 
-#: forms.py
-msgid ""
-"I want to receive news, announcements, and resources from the <a "
-"href=\"https://archive.org/\">Internet Archive</a>, the non-profit that runs "
-"Open Library."
-msgstr ""
-"Bògio retzire novas, annùntzios, e resursas dae s'<a href=\"https://archive."
-"org/\">Internet Archive</a>, s'assòtziu chene punna de logru chi manìgiat "
-"s'Open Library."
-
-#: forms.py
+#: openlibrary/plugins/upstream/forms.py
 msgid "Invalid password"
 msgstr "Crae non vàlida"
 
-#: forms.py
+#: openlibrary/plugins/upstream/forms.py
 msgid "Your email address"
 msgstr "S'indiritzu de posta eletrònica tuo"
 
-#: forms.py
+#: openlibrary/plugins/upstream/forms.py
 msgid "Choose a password"
 msgstr "Issèbera una crae de intrada"
+
+#: openlibrary/plugins/upstream/mybooks.py
+#, python-format
+msgid "Continue <a href=\"%(url)s\" class=\"pending-action-link\" data-action=\"%(raw_action)s\"><strong>%(action)s</strong> <em>%(name)s</em></a>"
+msgstr "Continua <a href=\"%(url)s\" class=\"pending-action-link\" data-action=\"%(raw_action)s\"><strong>%(action)s</strong> <em>%(name)s</em></a>"
+
+#: openlibrary/plugins/worksearch/code.py
+#, fuzzy
+msgid "eBook?"
+msgstr "Libru eletrònicu"
+
+#: openlibrary/plugins/worksearch/code.py
+#, fuzzy
+msgid "First published"
+msgstr "Prus betzos"
+
+#: openlibrary/plugins/worksearch/code.py
+#, fuzzy
+msgid "Classic eBooks"
+msgstr "Libru eletrònicu clàssicu"
 
 #~ msgid "Edit Subject Tag"
 #~ msgstr "Modìfica s'eticheta de s'argumentu"
@@ -8490,7 +8792,6 @@ msgstr "Issèbera una crae de intrada"
 #~ msgid "Sponsorships"
 #~ msgstr "Patrotzìnios"
 
-#, python-format
 #~ msgid "Books %(userdisplayname)s is sponsoring"
 #~ msgstr "Libros chi %(userdisplayname)s est patrotzinende"
 
@@ -8503,7 +8804,6 @@ msgstr "Issèbera una crae de intrada"
 #~ msgid "Book Sponsorship"
 #~ msgstr "Patrotzìniu de libros"
 
-#, python-format
 #~ msgid "We've sponsored <strong>%(num)d</strong> books"
 #~ msgstr "Amus patrotzinadu <strong>%(num)d</strong> libros"
 
@@ -8592,9 +8892,7 @@ msgstr "Issèbera una crae de intrada"
 #~ msgstr "Comente dias descrìere cust'eticheta?"
 
 #~ msgid "Links <span class=\"gray small sansserif\">(outside Open Library)"
-#~ msgstr ""
-#~ "Ligàmenes <span class=\"gray small sansserif\">in foras de s'Open "
-#~ "Library</span>"
+#~ msgstr "Ligàmenes <span class=\"gray small sansserif\">in foras de s'Open Library</span>"
 
 #~ msgid "Label"
 #~ msgstr "Eticheta"
@@ -8602,14 +8900,12 @@ msgstr "Issèbera una crae de intrada"
 #~ msgid "See All Results"
 #~ msgstr "Abbista totu sos resurtados"
 
-#, python-format
 #~ msgid "%s previewable"
 #~ msgstr "%s si podet bìdere in anteprima"
 
 #~ msgid "Books to Sponsor"
 #~ msgstr "Libros de isponsorizare"
 
-#, python-format
 #~ msgid "This book was generously donated by %(donor)s"
 #~ msgstr "Custu libru l'at donadu cun generosidade %(donor)s"
 
@@ -8661,7 +8957,6 @@ msgstr "Issèbera una crae de intrada"
 #~ msgid "Classic eBooks"
 #~ msgstr "Libros eletrònicos clàssicos"
 
-#, python-format
 #~ msgid "Search for books containing the phrase \"%s\"?"
 #~ msgstr "Chircare libros chi cuntenent sa fràsia \"%s\"?"
 
@@ -8672,9 +8967,7 @@ msgstr "Issèbera una crae de intrada"
 #~ msgstr "filtros"
 
 #~ msgid "Complete the form below to create a new Internet Archive account."
-#~ msgstr ""
-#~ "Compila su mòdulu inoghe in suta pro creare unu contu nou pro s'Internet "
-#~ "Archive."
+#~ msgstr "Compila su mòdulu inoghe in suta pro creare unu contu nou pro s'Internet Archive."
 
 #~ msgid "Each field is required"
 #~ msgstr "Cada campu est netzessàriu"
@@ -8697,47 +8990,24 @@ msgstr "Issèbera una crae de intrada"
 #~ msgid "You can search by title or by Open Library ID (like"
 #~ msgstr "Podes chircare pro tìtulu o pro ID de OpenLibrary (che a"
 
-#, python-format
 #~ msgid "Imported from %(source)s  <a href=\"%(url)s\">%(type)s record</a>."
-#~ msgstr ""
-#~ "Importadu dae %(source)s  <a href=\"%(url)s\">%(type)s registru</a>."
+#~ msgstr "Importadu dae %(source)s  <a href=\"%(url)s\">%(type)s registru</a>."
 
-#, python-format
 #~ msgid "Found a <a href=\"%(url)s\">matching record</a> from %(source)s."
-#~ msgstr ""
-#~ "Atzapadu unu <a href=\"%(url)s\">registru currispondente</a> dae "
-#~ "%(source)s."
+#~ msgstr "Atzapadu unu <a href=\"%(url)s\">registru currispondente</a> dae %(source)s."
 
-#~ msgid ""
-#~ "We use a system called Markdown to format the text in your edits on Open "
-#~ "Library. Some HTML formatting is also accepted. Paragraphs are "
-#~ "automatically generated from any hard-break returns (blank lines) within "
-#~ "your text. You can preview your work in real time below the editing field."
-#~ msgstr ""
-#~ "Impreamus unu sistema chi si narat Markdown pro formatare su testu in sas "
-#~ "modìficas tuas in s'Open Library. Fintzas unu pagu de formatatzione HTML "
-#~ "est atzetada. Sos paràgrafos s'ingendrant in automàticu dae cale si siat "
-#~ "brincu de lìnia dòpiu (lìnias bòidas) in su testu tuo. Podes bìdere "
-#~ "s'anteprima de su traballu tuo in tempus reale in suta de su campu de "
-#~ "modìfica."
+#~ msgid "We use a system called Markdown to format the text in your edits on Open Library. Some HTML formatting is also accepted. Paragraphs are automatically generated from any hard-break returns (blank lines) within your text. You can preview your work in real time below the editing field."
+#~ msgstr "Impreamus unu sistema chi si narat Markdown pro formatare su testu in sas modìficas tuas in s'Open Library. Fintzas unu pagu de formatatzione HTML est atzetada. Sos paràgrafos s'ingendrant in automàticu dae cale si siat brincu de lìnia dòpiu (lìnias bòidas) in su testu tuo. Podes bìdere s'anteprima de su traballu tuo in tempus reale in suta de su campu de modìfica."
 
 #~ msgid "Formatting marks should envelope the effected text, for example:"
-#~ msgstr ""
-#~ "Sos marcos de modìfica diant dèpere inghiriare su testu influentzadu, a "
-#~ "esèmpiu:"
+#~ msgstr "Sos marcos de modìfica diant dèpere inghiriare su testu influentzadu, a esèmpiu:"
 
-#~ msgid ""
-#~ "To \"escape\" any Markdown tags (i.e. use an asterisk as an asterisk "
-#~ "rather than emphasizing text) place a backslash \\ prior to the character."
-#~ msgstr ""
-#~ "Pro ti nche \"fuire\" dae cale si siat eticheta de Markdown (est a "
-#~ "nàrrere, impreare un'asteriscu comente asteriscu in càmbiu de dare ènfasi "
-#~ "a su testu) pone un'istanga a s'imbesse \\ in antis de su caràtere."
+#~ msgid "To \"escape\" any Markdown tags (i.e. use an asterisk as an asterisk rather than emphasizing text) place a backslash \\ prior to the character."
+#~ msgstr "Pro ti nche \"fuire\" dae cale si siat eticheta de Markdown (est a nàrrere, impreare un'asteriscu comente asteriscu in càmbiu de dare ènfasi a su testu) pone un'istanga a s'imbesse \\ in antis de su caràtere."
 
 #~ msgid "No hits"
 #~ msgstr "Perunu resurtadu"
 
-#, python-format
 #~ msgid "No hits for: %(query)s"
 #~ msgstr "Perunu resurtadu pro: %(query)s"
 
@@ -8779,3 +9049,287 @@ msgstr "Issèbera una crae de intrada"
 
 #~ msgid "Passwords didn't match."
 #~ msgstr "Sas craes non currispondent."
+
+#~ msgid "Design Pattern Library"
+#~ msgstr "Biblioteca de modellos de disinnu"
+
+#~ msgid "Font-size"
+#~ msgstr "Mannària de su caràtere"
+
+#~ msgid "Font-family"
+#~ msgstr "Famìlia de caràteres"
+
+#~ msgid "Sans-serif: Verdana"
+#~ msgstr "Sans-serif: Verdana"
+
+#~ msgid "Serif: Georgia"
+#~ msgstr "Serif: Georgia"
+
+#~ msgid "Colors"
+#~ msgstr "Colores"
+
+#~ msgid "Defaults"
+#~ msgstr "Predefinidos"
+
+#~ msgid "Primary Call To Action"
+#~ msgstr "Cramada primària a s'atzione"
+
+#~ msgid "Link (unclicked)"
+#~ msgstr "Ligàmene (no incarcadu)"
+
+#~ msgid "Link (clicked)"
+#~ msgstr "Ligàmene (incarcadu)"
+
+#~ msgid "Hmm..."
+#~ msgstr "Hmm..."
+
+#~ msgid "Sorry. There seems to be a problem with what you were just looking at."
+#~ msgstr "Paret chi bi siat carchi problema cun su chi fias abbistende."
+
+#~ msgid "We've noted the error %s and will look into it as soon as possible. Head for <a href=\"/\">home</a>?"
+#~ msgstr "Amus notadu s'errore %s e nos nd'amus a ocupare cantu prus luego s'at a pòdere. Boles torrare a sa <a href=\"/\">pàgina printzipale</a>?"
+
+#~ msgid "Thank you very much for adding that new book!"
+#~ msgstr "Gràtzias medas pro àere annantu cussu libru nou!"
+
+#~ msgid "Staged"
+#~ msgstr "In programma"
+
+#~ msgid "How can we help?"
+#~ msgstr "Comente podimus agiudare?"
+
+#~ msgid "Your question has been sent to our support team. We'll get back to you shortly. You can also <a href=\"https://twitter.com/openlibrary\">contact us on Twitter</a>."
+#~ msgstr "As imbiadu sa dimanda tua a s'iscuadra de suportu nostra. T'amus a torrare risposta luego. Nos podes fintzas <a href=\"https://twitter.com/openlibrary\">chircare in Twitter</a>."
+
+#~ msgid "Please check our <a href=\"/help/\">Help Pages</a> and <a href=\"/help/faq\">Frequently Asked Questions</a> (FAQ) to see if your question is answered there. Thank you."
+#~ msgstr "Pro praghere abbista·ti sas <a href=\"/help/\">Pàginas de agiudu</a> e sas <a href=\"/help/faq\">Preguntas fitianas</a> (PF/FAQ) nostras pro bìdere si sa dimanda tua tenet giai una risposta in cue. Gràtzias."
+
+#~ msgid "Your Name"
+#~ msgstr "Su nùmene tuo"
+
+#~ msgid "Your Email Address"
+#~ msgstr "S'indiritzu de posta eletrònica tuo"
+
+#~ msgid "We'll need this if you want a reply"
+#~ msgstr "Amus a bisongiare de custu si boles una risposta"
+
+#~ msgid "If you wish to be contacted by other means, please add your contact preference and details to your question."
+#~ msgstr "Si boles a ti cuntatare in carchi àtera manera annanghe sa preferèntzia tua e sos detàllios tuos de cuntatu a sa dimanda tua."
+
+#~ msgid "Your Question"
+#~ msgstr "Sa dimanda tua"
+
+#~ msgid "Note: our staff will likely only be able respond in English."
+#~ msgstr "Tene in contu: s'iscuadra nostra t'at a pòdere torrare risposta petzi in inglesu."
+
+#~ msgid "If you encounter an error message, please include it. For questions about our books, please provide the title/author or Open Library ID."
+#~ msgstr "Si atzapas unu messàgiu de errore pro praghere include·lu. Pro dimandas subra de sos libros nostros iscrie·nos su tìtulu/autore o s'ID de Open Library."
+
+#~ msgid "Send"
+#~ msgstr "Imbia"
+
+#~ msgid "What is this?"
+#~ msgstr "Ite est custu?"
+
+#~ msgid "Memory Status"
+#~ msgstr "Istatus de sa memòria"
+
+#~ msgid "count"
+#~ msgstr "contègiu"
+
+#~ msgid "mark"
+#~ msgstr "marcu"
+
+#~ msgid "Referents"
+#~ msgstr "Riferimentos"
+
+#~ msgid "Activation link expiring on <span class=\"time\">%(date)s.</span>"
+#~ msgstr "Su ligàmene de ativatzione iscadit su <span class=\"time\">%(date)s.</span>"
+
+#~ msgid "Activation link expired"
+#~ msgstr "Su ligàmene de ativatzione est iscadidu"
+
+#~ msgid "Resend activation link"
+#~ msgstr "Torra a imbiare su ligàmene de verìfica"
+
+#~ msgid "Read eBook from Cita Press"
+#~ msgstr "Leghe libros de Cita Press"
+
+#~ msgid "This book is available from <a href=\"https://citapress.org/\">Cita Press</a>. Cita Press is a trusted book provider of works written by women, pairing contemporary authors and designers with open access texts to make carefully designed books available for free and open source."
+#~ msgstr "Custu libru est a disponimentu in <a href=\"https://citapress.org/\">Cita Press</a>. Cita Press est unu frunidore fidadu de òperas iscritas dae fèminas, chi ponet paris autoras e disinnadoras cuntemporàneas cun testos a atzessu lìberu pro creare libros disinnados a finu a indonu e a còdighe lìberu."
+
+#~ msgid "Learn more"
+#~ msgstr "Àteras informatziones"
+
+#~ msgid "This book is freely available from <a href=\"%s\">%s</a>, an external third-party book provider."
+#~ msgstr "Custu libru est a disponimentu a indonu in <a href=\"%s\">%s</a>, unu frunidore esternu de libros de tertza parte."
+
+#~ msgid "Read eBook from Project Gutenberg"
+#~ msgstr "Leghe libros digitales de su Project Gutenberg"
+
+#~ msgid "This book is available from <a href=\"https://www.gutenberg.org/\">Project Gutenberg</a>. Project Gutenberg is a trusted book provider of classic ebooks, supporting thousands of volunteers in the creation and distribution of over 60,000 free eBooks."
+#~ msgstr "Custu libru est a disponimentu in su <a href=\"https://www.gutenberg.org/\">Project Gutenberg</a>. Project Gutenberg est unu frunidore fidadu de libros eletrònicos clàssicos, chi dat su suportu suo a mìgias de voluntàrios in sa creatzione e distributzione de prus de 60.000 libros eletrònicos lìberos."
+
+#~ msgid "This book is available from <a href=\"https://librivox.org/\">LibriVox</a>. LibriVox is a trusted book provider of public domain audiobooks, narrated by volunteers, distributed for free on the internet."
+#~ msgstr "Custu libru est a disponimentu in <a href=\"https://librivox.org/\">LibriVox</a>. LibriVox est unu frunidore fidadu de libros de domìniu pùblicu, contados dae voluntàrios, distribuidos a indonu in ìnternet."
+
+#~ msgid "Read eBook from OpenStax"
+#~ msgstr "Leghe libros de OpenStax"
+
+#~ msgid "This book is available from <a href=\"https://www.openstax.org/\">OpenStax</a>. OpenStax is a trusted book provider and a 501(c)(3) nonprofit charitable corporation dedicated to providing free high-quality, peer-reviewed, openly licensed textbooks online."
+#~ msgstr "Custu libru est a disponimentu in <a href=\"https://www.openstax.org/\">OpenStax</a>. OpenStax est unu frunidore fidadu de libros e un'ente de benefitzèntzia chene punna de lucru chi si dèdicat a frunire de badas e in lìnia libros de testu de calidade arta, chi ant tentu una revisione paritària e cun litzèntzia aberta."
+
+#~ msgid "Read eBook from Project Runeberg"
+#~ msgstr "Leghe libros digitales de Project Runeberg"
+
+#~ msgid "This book is available from <a href=\"https://runeberg.org/\">Project Runeberg</a>. Project Runeberg is a trusted book provider of classic Nordic (Scandinavian) literature in electronic form."
+#~ msgstr "Custu libru est a disponimentu in <a href=\"https://runeberg.org/\">Project Runeberg</a>. Project Gutenberg est unu frunidore fidadu libros de literadura nòrdica (iscandìnava) clàssica in formadu eletrònicu."
+
+#~ msgid "Read eBook from Standard eBooks"
+#~ msgstr "Leghe libros de Standard eBooks"
+
+#~ msgid "This book is available from <a href=\"https://standardebooks.org/\">Standard Ebooks</a>. Standard Ebooks is a trusted book provider and a volunteer-driven project that produces new editions of public domain ebooks that are lovingly formatted, open source, free of copyright restrictions, and free of cost."
+#~ msgstr "Custu libru est a disponimentu in <a href=\"https://standardebooks.org/\">Standard Ebooks</a>. Standard Ebooks est unu frunidore fidadu de libros e unu progetu ghiadu dae voluntàrios chi produit editziones noas de libros eletrònicos chi sunt formatados cun amore, a còdighe abertu, chene lìmites de deretu de autore e a indonu."
+
+#~ msgid "Read eBook on Wikisource"
+#~ msgstr "Leghe su libru eletrònicu in Wikisource"
+
+#~ msgid "This book is available from <a href=\"https://wikisource.org/\">Wikisource</a>. Wikisource, a <a href=\"https://www.wikimedia.org/\">Wikimedia Foundation</a> project, is a trusted book provider of works available under the <a href=\"https://creativecommons.org/licenses/by-sa/4.0/\">CC-BY-SA</a> open content license, such as essays, historical documents, letters, speeches, and public domain books."
+#~ msgstr "Custu libru est a disponimentu dae <a href=\"https://wikisource.org/\">Wikisource</a>. Wikisource, unu progetu de sa <a href=\"https://www.wikimedia.org/\">Fundatzione Wikimedia</a>, est unu frunidore fidadu de òperas a disponimentu suta de sa litzèntzia de cuntenutos lìberos <a href=\"https://creativecommons.org/licenses/by-sa/4.0/\">CC-BY-SA</a>, che a sàgios, documentos istòricos, lìteras, discursos e libros de domìniu pùblicu."
+
+#~ msgid "This DAISY file is protected."
+#~ msgstr "Custu documentu DAISY est amparadu."
+
+#~ msgid "It can only be opened on a specialized device with a key issued by the Library of Congress."
+#~ msgstr "Si podet abèrrere petzi cun unu dispositivu ispetzializadu cun una crae emìtida dae sa Biblioteca de su Cungressu."
+
+#~ msgid "There are two types of DAISYs on Open Library: <i>open</i> and <i>protected</i>. Open DAISYs can be read by anyone in the world on many different devices. Protected DAISYs like this one can only be opened using a key issued by the <a href=\"http://www.loc.gov/nls/\">Library of Congress NLS program</a>."
+#~ msgstr "Bi sunt duas castas de DAISY in s'Open Library: <i>abertos</i> e <i>amparados</i>. Sos DAISY abertos los podet lèghere chie si siat in su mundu in medas dispositivos diferentes. Sos DAISY amparados che a custu si podent abèrrere petzi impreende una crae intregada dae su <a href=\"http://www.loc.gov/nls/\">programma NLS de sa Biblioteca de su Cungressu</a>."
+
+#~ msgid "Or, use the the cover from Internet Archive"
+#~ msgstr "O imprea sa cobertedda dae s'Internet Archive"
+
+#~ msgid "View a larger book cover"
+#~ msgstr "Càstia una cobertedda de libru prus manna"
+
+#~ msgid "Imported from"
+#~ msgstr "Importadu dae"
+
+#~ msgid "Found a matching"
+#~ msgstr "Atzapada una currispondèntzia"
+
+#~ msgid "Edited without comment."
+#~ msgstr "Modificadu chene cummentu."
+
+#~ msgid "browse %(subject)s books"
+#~ msgstr "esplora libros subra de %(subject)s"
+
+#~ msgid "%s book"
+#~ msgid_plural "%s books"
+#~ msgstr[0] "%s libru"
+#~ msgstr[1] "%s libros"
+
+#~ msgid "by <a href=\"$owner.key\">You</a>"
+#~ msgstr "dae <a href=\"$owner.key\">tene</a>"
+
+#~ msgid "%(count)d List"
+#~ msgid_plural "%(count)d Lists"
+#~ msgstr[0] "%(count)d lista"
+#~ msgstr[1] "%(count)d listas"
+
+#~ msgid "more"
+#~ msgstr "de prus"
+
+#~ msgid "Search facets"
+#~ msgstr "Pannellos de chirca"
+
+#~ msgid "Explore Classic eBooks"
+#~ msgstr "Esplora sos libros eletrònicos clàssicos"
+
+#~ msgid "Explore books about %(subject)s"
+#~ msgstr "Esplora libros subra de %(subject)s"
+
+#~ msgid "Click to remove this facet"
+#~ msgstr "Incarca pro bogare custu pannellu"
+
+#~ msgid "Location"
+#~ msgstr "Logu"
+
+#~ msgid "Showing all works by author. Would you like to see <a href=\"%(url)s\">only ebooks</a>?"
+#~ msgstr "Ammustrende totu sas òperas pro autore. Boles bìdere <a href=\"%(url)s\">petzi sos libros eletrònicos</a>?"
+
+#~ msgid "Loading Related Books"
+#~ msgstr "Carrighende libros ligados"
+
+#~ msgid "deprecated"
+#~ msgstr "disusadu"
+
+#~ msgid "⚠️ Saving global lists is admin-only while the feature is under development."
+#~ msgstr "⚠️ Su sarvamentu de sas listas globales est riservadu petzi a sos amministradores in su mentres chi sa funtzionalidade est in fase de isvilupu."
+
+#~ msgid "Donate this book to the <a href=\"https://archive.org\">Internet Archive</a> library."
+#~ msgstr "Dona custu libru a sa biblioteca de <a href=\"https://archive.org\">s'Internet Archive</a>."
+
+#~ msgid "Hooray! You've discovered a title that's missing from our <a href=\"https://help.archive.org/hc/en-us/articles/360016554912-Borrowing-From-The-Lending-Library\">library</a>. Can you help donate a copy?"
+#~ msgstr "Urrà! As iscobertu unu tìtulu chi mancat in sa <a href=\"https://help.archive.org/hc/en-us/articles/360016554912-Borrowing-From-The-Lending-Library\">biblioteca</a> nostra. Podes agiudare a nde donare una còpia?"
+
+#~ msgid "If you own this book, you can<a href=\"https://store.usps.com/store/product/shipping-supplies/priority-mail-express-padded-flat-rate-envelope-P_EP13PE\">mail</a> it to our address below."
+#~ msgstr "Si tenes custu libru, nos lu podes <a href=\"https://store.usps.com/store/product/shipping-supplies/priority-mail-express-padded-flat-rate-envelope-P_EP13PE\">ispedire</a> a s'indiritzu nostru inoghe in suta."
+
+#~ msgid "You can also purchase this book from a vendor and ship it to our address:"
+#~ msgstr "Podes fintzas comporare custu libru dae unu bendidore e imbiare·nos·lu a s'indiritzu nostru:"
+
+#~ msgid "Benefits of donating"
+#~ msgstr "Vantàgios de sa donatzione"
+
+#~ msgid "When you donate a physical book to the Internet Archive, your book will enjoy:"
+#~ msgstr "Cando donas unu libru a s'Internet Archive, su libru tuo at a tènnere:"
+
+#~ msgid "Donation info"
+#~ msgstr "Informatziones de donatzione"
+
+#~ msgid "Beautiful <a target=\"_blank\" href=\"https://archive.org/scanning\">high-fidelity digitization</a>"
+#~ msgstr "Una <a target=\"_blank\" href=\"https://archive.org/scanning\">digitalizatzione a fidelidade arta</a> bella a beru"
+
+#~ msgid "Long-term <a href=\"https://blog.archive.org/2011/06/06/why-preserve-books-the-new-physical-archive-of-the-internet-archive/\">archival preservation</a>"
+#~ msgstr "Unu <a href=\"https://blog.archive.org/2011/06/06/why-preserve-books-the-new-physical-archive-of-the-internet-archive/\">custoimentu in archìviu</a> a tèrmine longu"
+
+#~ msgid "Free <a href=\"https://controlleddigitallending.org/\">controlled digital library access</a> by the <a href=\"https://en.wikipedia.org/wiki/Print_disability\">print-disabled</a> public"
+#~ msgstr "Atzessu lìberu <a href=\"https://controlleddigitallending.org/\">a sa biblioteca digitale controllada</a> pro su pùblicu cun<a href=\"https://en.wikipedia.org/wiki/Print_disability\">disabilidades ligadas a sos caràteres imprentados</a>"
+
+#~ msgid "Open Library is a project of the <a href=\"https://archive.org/about\">Internet Archive</a>, a 501(c)(3) non-profit"
+#~ msgstr "Open Library est unu progetu de s'<a href=\"https://archive.org/about\">Internet Archive</a>, un'assòtziu 501(c)(3) chene punna de logru"
+
+#~ msgid "UnfollowFollow"
+#~ msgstr "Acaba de sighire"
+
+#~ msgid "First"
+#~ msgstr "Primu"
+
+#~ msgid "Library.link"
+#~ msgstr "Library.link"
+
+#~ msgid "We've sent the verification email to %(email)s. You'll need to read that and click on the verification link to verify your email."
+#~ msgstr "Amus imbiadu sa lìtera eletrònica de verìfica a %(email)s. Ti l'as a dèpere lèghere e as a dèpere incarcare in su ligàmene de verìfica pro averguare s'indiritzu de posta eletrònica tuo."
+
+#~ msgid "Email address is already used."
+#~ msgstr "S'indiritzu de posta eletrònica tuo est giai istadu impreadu."
+
+#~ msgid "Your email address couldn't be updated. The specified email address is already used."
+#~ msgstr "S'atualizatzione de s'indiritzu de posta tuo est fallida. S'indiritzu ispetzificadu est giai impreadu."
+
+#~ msgid "Email verification successful."
+#~ msgstr "Verìfica de s'indiritzu de posta fata cun sutzessu."
+
+#~ msgid "Your email address has been successfully verified and updated in your account."
+#~ msgstr "S' indiritzu de posta eletrònica tuo est istadu verificadu cun sutzessu e atualizazu in su contu tuo."
+
+#~ msgid "Email address couldn't be verified."
+#~ msgstr "S' indiritzu de posta non si podiat averguare."
+
+#~ msgid "Your email address couldn't be verified. The verification link seems invalid."
+#~ msgstr "Non faghiat a verificare s'indiritzu de posta eletrònica tuo. Su ligàmene de verìfica tuo paret chi siat non vàlidu."
+
+#~ msgid "Password reset failed."
+#~ msgstr "Resetada de sa crae fallida."
+


### PR DESCRIPTION
## Summary

Syncs the sc (Sardinian) translation file with the current \`messages.pot\` template and fills in
previously untranslated strings.

**AI attribution:** All new translations in this PR were generated by \`claude-sonnet-4-6\`. They should
be reviewed by a native speaker before merging, particularly for tone and idiomatic accuracy.
Format strings (\`%(name)s\`, \`%(count)d\`, etc.) and HTML markup were preserved verbatim.

## Changes

- Ran \`scripts/i18n-messages update sc\` to sync with current \`messages.pot\`
- Filled 186 previously untranslated msgid entries
- Fixed 17 format-string errors and 8 HTML structure errors in fuzzy entries
- Left fuzzy entries unchanged (marked for human review)

## Validation

- [x] \`i18n-messages validate sc\` — 0 errors ✓
- [x] \`test_po_files.py -k sc\` — 170 passed, 0 failures ✓
- [x] \`pre-commit run --files openlibrary/i18n/sc/messages.po\` — clean ✓

## Reviewer guidance

Please spot-check translations for:
1. Accuracy of meaning (does the translation convey the intent?)
2. Natural phrasing (does it sound like UI text, not literal translation?)
3. Preserved format strings and HTML

Native speakers: please edit the \`.po\` file directly on this branch.

🤖 Generated by \`claude-sonnet-4-6\`