### PR TITLE
i18n(ro): AI translation update — sync with messages.pot (2026-06-11)

### DIFF
--- a/openlibrary/i18n/ro/messages.po
+++ b/openlibrary/i18n/ro/messages.po
@@ -2725,97 +2725,97 @@ msgstr "email"
 
 #: admin/people/index.html
 msgid "profile"
-msgstr ""
+msgstr "profil"
 
 #: admin/people/index.html admin/people/view.html
 msgid "Edit History"
-msgstr ""
+msgstr "Istoricul modificărilor"
 
 #: admin/people/view.html
 msgid "block and revert all edits"
-msgstr ""
+msgstr "blochează și revertează toate modificările"
 
 #: admin/people/view.html
 msgid "block this account"
-msgstr ""
+msgstr "blochează acest cont"
 
 #: admin/people/view.html
 #, python-format
 msgid "Registered on <span class=\"time\">%(date)s</span>."
-msgstr ""
+msgstr "Înregistrat pe <span class=\"time\">%(date)s</span>."
 
 #: admin/people/view.html
 msgid "login as this user"
-msgstr ""
+msgstr "autentifică-te ca acest utilizator"
 
 #: admin/people/view.html
 #, python-format
 msgid "Activated on <span class=\"time\">%(date)s</span> from <a href=\"/admin/ip/%(ip)s\">%(ip)s</a>."
-msgstr ""
+msgstr "Activat pe <span class=\"time\">%(date)s</span> de la <a href=\"/admin/ip/%(ip)s\">%(ip)s</a>."
 
 #: admin/people/view.html
 msgid "unblock this account"
-msgstr ""
+msgstr "deblochează acest cont"
 
 #: admin/people/view.html
 msgid "activate account"
-msgstr ""
+msgstr "activează contul"
 
 #: CreateListModal.html admin/people/view.html my_books/dropdown_content.html
 msgid "Name:"
-msgstr ""
+msgstr "Nume:"
 
 #: admin/people/view.html
 msgid "view profile"
-msgstr ""
+msgstr "vizualizează profilul"
 
 #: admin/people/view.html
 msgid "Change"
-msgstr ""
+msgstr "Schimbă"
 
 #: admin/people/view.html
 msgid "Admin"
-msgstr ""
+msgstr "Admin"
 
 #: admin/people/view.html
 msgid "Make Human"
-msgstr ""
+msgstr "Marchează ca uman"
 
 #: admin/people/view.html
 msgid "Make Bot"
-msgstr ""
+msgstr "Marchează ca bot"
 
 #: admin/people/view.html
 msgid "Not available"
-msgstr ""
+msgstr "Indisponibil"
 
 #: admin/people/view.html
 msgid "# Edits"
-msgstr ""
+msgstr "Nr. de modificări"
 
 #: admin/people/view.html
 msgid "Member Since:"
-msgstr ""
+msgstr "Membru din:"
 
 #: admin/people/view.html
 msgid "Last Login:"
-msgstr ""
+msgstr "Ultima autentificare:"
 
 #: admin/people/view.html
 msgid "Tags:"
-msgstr ""
+msgstr "Etichete:"
 
 #: admin/people/view.html
 msgid "Anonymize Account:"
-msgstr ""
+msgstr "Anonimizare cont:"
 
 #: admin/people/view.html
 msgid "Dry Run"
-msgstr ""
+msgstr "Rulare simulată"
 
 #: admin/people/view.html
 msgid "Anonymize Account"
-msgstr ""
+msgstr "Anonimizează contul"
 
 #: admin/people/view.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py type/user/view.html
 msgid "Loans"
@@ -2823,32 +2823,32 @@ msgstr "Împrumuturi"
 
 #: admin/people/view.html
 msgid "Account not activated yet."
-msgstr ""
+msgstr "Contul nu a fost activat încă."
 
 #: admin/people/view.html
 msgid "Waiting Loans"
-msgstr ""
+msgstr "Împrumuturi în așteptare"
 
 #: admin/people/view.html
 #, python-format
 msgid "%(num)d edits"
-msgstr ""
+msgstr "%(num)d modificări"
 
 #: admin/people/view.html
 msgid "Debug Info"
-msgstr ""
+msgstr "Informații de depanare"
 
 #: admin/people/view.html
 msgid "Account Information"
-msgstr ""
+msgstr "Informații cont"
 
 #: admin/people/view.html
 msgid "Verifications Links"
-msgstr ""
+msgstr "Linkuri de verificare"
 
 #: admin/people/view.html
 msgid "None found"
-msgstr ""
+msgstr "Niciuna găsită"
 
 #: SearchNavigation.html authors/index.html lib/nav_foot.html merge/authors.html publishers/view.html
 msgid "Authors"
@@ -2856,7 +2856,7 @@ msgstr "Autori"
 
 #: authors/index.html
 msgid "Search for an Author"
-msgstr ""
+msgstr "Caută un autor"
 
 #: authors/index.html lib/nav_head.html lists/home.html publishers/index.html publishers/notfound.html publishers/view.html search/advancedsearch.html search/publishers.html search/searchbox.html type/local_id/view.html
 msgid "Search"
@@ -2865,41 +2865,41 @@ msgstr "Căutare"
 #: authors/index.html search/authors.html
 #, python-format
 msgid "about %(subjects)s"
-msgstr ""
+msgstr "despre %(subjects)s"
 
 #: authors/index.html search/authors.html
 #, python-format
 msgid "including <i>%(topwork)s</i>"
-msgstr ""
+msgstr "inclusiv <i>%(topwork)s</i>"
 
 #: authors/infobox.html
 #, python-format
 msgid "View on %(site)s"
-msgstr ""
+msgstr "Vizualizează pe %(site)s"
 
 #: authors/infobox.html
 msgid "Born"
-msgstr ""
+msgstr "Născut"
 
 #: authors/infobox.html
 msgid "Died"
-msgstr ""
+msgstr "Decedat"
 
 #: book_providers/cita_press_download_options.html book_providers/gutenberg_download_options.html book_providers/ia_download_options.html book_providers/librivox_download_options.html book_providers/openstax_download_options.html book_providers/runeberg_download_options.html book_providers/standard_ebooks_download_options.html book_providers/wikisource_download_options.html
 msgid "Download Options"
-msgstr ""
+msgstr "Opțiuni de descărcare"
 
 #: book_providers/cita_press_download_options.html
 msgid "Download PDF from Cita Press"
-msgstr ""
+msgstr "Descarcă PDF de la Cita Press"
 
 #: book_providers/cita_press_download_options.html
 msgid "More at Cita Press"
-msgstr ""
+msgstr "Mai mult la Cita Press"
 
 #: book_providers/gutenberg_download_options.html
 msgid "Download an HTML from Project Gutenberg"
-msgstr ""
+msgstr "Descarcă HTML de la Project Gutenberg"
 
 #: book_providers/gutenberg_download_options.html book_providers/runeberg_download_options.html book_providers/standard_ebooks_download_options.html type/list/exports.html
 msgid "HTML"
@@ -2907,19 +2907,19 @@ msgstr "HTML"
 
 #: book_providers/gutenberg_download_options.html
 msgid "Download a text version from Project Gutenberg"
-msgstr ""
+msgstr "Descarcă versiunea text de la Project Gutenberg"
 
 #: book_providers/gutenberg_download_options.html book_providers/ia_download_options.html
 msgid "Plain text"
-msgstr ""
+msgstr "Text simplu"
 
 #: book_providers/gutenberg_download_options.html
 msgid "Download an ePub from Project Gutenberg"
-msgstr ""
+msgstr "Descarcă ePub de la Project Gutenberg"
 
 #: book_providers/gutenberg_download_options.html
 msgid "Download a Kindle file from Project Gutenberg"
-msgstr ""
+msgstr "Descarcă fișier Kindle de la Project Gutenberg"
 
 #: book_providers/gutenberg_download_options.html
 msgid "Kindle"
@@ -2927,23 +2927,23 @@ msgstr "Kindle"
 
 #: book_providers/gutenberg_download_options.html
 msgid "More at Project Gutenberg"
-msgstr ""
+msgstr "Mai mult la Project Gutenberg"
 
 #: book_providers/ia_download_options.html
 msgid "Download a PDF from Internet Archive"
-msgstr ""
+msgstr "Descarcă PDF de la Internet Archive"
 
 #: book_providers/ia_download_options.html
 msgid "Download a text version from Internet Archive"
-msgstr ""
+msgstr "Descarcă versiunea text de la Internet Archive"
 
 #: book_providers/ia_download_options.html
 msgid "Download an ePub from Internet Archive"
-msgstr ""
+msgstr "Descarcă ePub de la Internet Archive"
 
 #: book_providers/ia_download_options.html
 msgid "Download a MOBI file from Internet Archive"
-msgstr ""
+msgstr "Descarcă fișier MOBI de la Internet Archive"
 
 #: book_providers/ia_download_options.html
 msgid "MOBI"
@@ -2951,65 +2951,65 @@ msgstr "MOBI"
 
 #: book_providers/ia_download_options.html
 msgid "Download open DAISY from Internet Archive (print-disabled format)"
-msgstr ""
+msgstr "Descarcă DAISY deschis de la Internet Archive (format pentru persoane cu dizabilități de tipărire)"
 
 #: book_providers/ia_download_options.html type/list/embed.html
 msgid "DAISY"
-msgstr ""
+msgstr "DAISY"
 
 #: book_providers/librivox_download_options.html
 msgid "Download a ZIP file of the whole book from Internet Archive"
-msgstr ""
+msgstr "Descarcă fișier ZIP al întregii cărți de la Internet Archive"
 
 #: book_providers/librivox_download_options.html
 msgid "Whole Book MP3"
-msgstr ""
+msgstr "Întreaga carte MP3"
 
 #: book_providers/librivox_download_options.html
 msgid "Get the RSS Feed from LibriVox"
-msgstr ""
+msgstr "Obține feed-ul RSS de la LibriVox"
 
 #: book_providers/librivox_download_options.html
 msgid "RSS Feed"
-msgstr ""
+msgstr "Feed RSS"
 
 #: book_providers/librivox_download_options.html
 msgid "More at LibriVox"
-msgstr ""
+msgstr "Mai mult la LibriVox"
 
 #: book_providers/openstax_download_options.html
 msgid "Download PDF from OpenStax"
-msgstr ""
+msgstr "Descarcă PDF de la OpenStax"
 
 #: book_providers/openstax_download_options.html
 msgid "More at OpenStax"
-msgstr ""
+msgstr "Mai mult la OpenStax"
 
 #: book_providers/read_button.html
 #, python-format
 msgid "Listen to a reading from %s"
-msgstr ""
+msgstr "Ascultă o lectură de la %s"
 
 #: book_providers/read_button.html
 msgid "Audiobook"
-msgstr ""
+msgstr "Carte audio"
 
 #: book_providers/read_button.html
 #, python-format
 msgid "Read free online from %s"
-msgstr ""
+msgstr "Citește gratuit online de la %s"
 
 #: book_providers/runeberg_download_options.html
 msgid "Download all scanned images from Project Runeberg"
-msgstr ""
+msgstr "Descarcă toate imaginile scanate de la Project Runeberg"
 
 #: book_providers/runeberg_download_options.html
 msgid "Scanned images"
-msgstr ""
+msgstr "Imagini scanate"
 
 #: book_providers/runeberg_download_options.html
 msgid "Download all color images from Project Runeberg"
-msgstr ""
+msgstr "Descarcă toate imaginile color de la Project Runeberg"
 
 #: book_providers/runeberg_download_options.html
 msgid "Color images"
@@ -3017,39 +3017,39 @@ msgstr "Imagini color"
 
 #: book_providers/runeberg_download_options.html
 msgid "Download all HTML files from Project Runeberg"
-msgstr ""
+msgstr "Descarcă toate fișierele HTML de la Project Runeberg"
 
 #: book_providers/runeberg_download_options.html
 msgid "Download all text and index files from Project Runeberg"
-msgstr ""
+msgstr "Descarcă toate fișierele text și index de la Project Runeberg"
 
 #: book_providers/runeberg_download_options.html
 msgid "Text and index files"
-msgstr ""
+msgstr "Fișiere text și index"
 
 #: book_providers/runeberg_download_options.html
 msgid "Download all OCR text from Project Runeberg"
-msgstr ""
+msgstr "Descarcă tot textul OCR de la Project Runeberg"
 
 #: book_providers/runeberg_download_options.html
 msgid "OCR text"
-msgstr ""
+msgstr "Text OCR"
 
 #: book_providers/runeberg_download_options.html
 msgid "More at Project Runeberg"
-msgstr ""
+msgstr "Mai mult la Project Runeberg"
 
 #: book_providers/standard_ebooks_download_options.html
 msgid "Download an HTML from Standard Ebooks"
-msgstr ""
+msgstr "Descarcă HTML de la Standard Ebooks"
 
 #: book_providers/standard_ebooks_download_options.html
 msgid "Download an ePub from Standard Ebook."
-msgstr ""
+msgstr "Descarcă ePub de la Standard Ebooks."
 
 #: book_providers/standard_ebooks_download_options.html
 msgid "Download a Kindle file from Standard Ebooks"
-msgstr ""
+msgstr "Descarcă fișier Kindle de la Standard Ebooks"
 
 #: book_providers/standard_ebooks_download_options.html
 msgid "Kindle (azw3)"
@@ -3057,7 +3057,7 @@ msgstr "Kindle (azw3)"
 
 #: book_providers/standard_ebooks_download_options.html
 msgid "Download a Kobo file from Standard Ebooks"
-msgstr ""
+msgstr "Descarcă fișier Kobo de la Standard Ebooks"
 
 #: book_providers/standard_ebooks_download_options.html
 msgid "Kobo (kepub)"
@@ -3065,7 +3065,7 @@ msgstr "Kobo (kepub)"
 
 #: book_providers/standard_ebooks_download_options.html
 msgid "View the source code for this Standard Ebook at GitHub"
-msgstr ""
+msgstr "Vizualizează codul sursă al acestei Standard Ebook pe GitHub"
 
 #: Subnavigation.html book_providers/standard_ebooks_download_options.html
 msgid "Source Code"

--- a/openlibrary/i18n/ro/messages.po
+++ b/openlibrary/i18n/ro/messages.po
@@ -6381,67 +6381,67 @@ msgstr "Inventaire.io:"
 
 #: type/author/view.html type/edition/view.html type/work/view.html
 msgid "Links <span class=\"gray small sansserif\">outside Open Library</span>"
-msgstr ""
+msgstr "Linkuri <span class=\"gray small sansserif\">din afara Open Library</span>"
 
 #: type/author/view.html
 msgid "No links yet."
-msgstr ""
+msgstr "Niciun link încă."
 
 #: type/author/view.html
 msgid "Add one"
-msgstr ""
+msgstr "Adăugați unul"
 
 #: type/author/view.html
 msgid "Alternative names"
-msgstr ""
+msgstr "Nume alternative"
 
 #: type/delete/view.html
 msgid "This page has been deleted"
-msgstr ""
+msgstr "Această pagină a fost ștearsă"
 
 #: type/delete/view.html
 msgid "What would you like to do?"
-msgstr ""
+msgstr "Ce doriți să faceți?"
 
 #: type/delete/view.html
 msgid "Go back where I came from"
-msgstr ""
+msgstr "Înapoi de unde am venit"
 
 #: type/delete/view.html
 msgid "View the previous version"
-msgstr ""
+msgstr "Vizualizați versiunea anterioară"
 
 #: type/delete/view.html
 msgid "See the page's history"
-msgstr ""
+msgstr "Vedeți istoricul paginii"
 
 #: type/delete/view.html
 msgid "Recreate it"
-msgstr ""
+msgstr "Recreați-o"
 
 #: type/edition/admin_bar.html
 msgid "Add IA Book to Staff Picks"
-msgstr ""
+msgstr "Adăugați cartea IA la Selecțiile personalului"
 
 #: type/edition/admin_bar.html
 msgid "Sync Archive.org ID"
-msgstr ""
+msgstr "Sincronizați ID-ul Archive.org"
 
 #: type/edition/admin_bar.html
 msgid "View Book on Archive.org"
-msgstr ""
+msgstr "Vizualizați cartea pe Archive.org"
 
 #: SearchResultsWork.html type/edition/admin_bar.html
 msgid "Orphaned Edition"
-msgstr ""
+msgstr "Ediție orfană"
 
 #: databarHistory.html databarView.html type/edition/compact_title.html
 msgid "Edit this page"
-msgstr ""
+msgstr "Editați această pagină"
 
 #: type/edition/modal_links.html
 msgid "Review"
-msgstr ""
+msgstr "Recenzie"
 
 #: type/edition/modal_links.html
 #, fuzzy
@@ -6455,12 +6455,12 @@ msgstr "Nicio notă găsită."
 
 #: type/edition/title_and_author.html
 msgid "An edition of"
-msgstr ""
+msgstr "O ediție a"
 
 #: type/edition/title_and_author.html
 #, python-format
 msgid "First published in %s"
-msgstr ""
+msgstr "Prima publicare în %s"
 
 #: type/edition/title_and_author.html
 #, fuzzy, python-format
@@ -6480,30 +6480,30 @@ msgstr "Citit"
 #: type/edition/view.html type/work/view.html
 #, python-format
 msgid "This work doesn't have a description yet. Can you <b><a href='%(url)s'>add one</a></b>?"
-msgstr ""
+msgstr "Această operă nu are încă o descriere. Puteți <b><a href='%(url)s'>adăuga una</a></b>?"
 
 #: type/edition/view.html type/work/view.html
 #, python-format
 msgid "This edition doesn't have a description yet. Can you <b><a href='%(url)s'>add one</a></b>?"
-msgstr ""
+msgstr "Această ediție nu are încă o descriere. Puteți <b><a href='%(url)s'>adăuga una</a></b>?"
 
 #: type/edition/view.html type/work/view.html
 msgid "Publish Date"
-msgstr ""
+msgstr "Data publicării"
 
 #: type/edition/view.html type/work/view.html
 #, python-format
 msgid "Show other books from %(publisher)s"
-msgstr ""
+msgstr "Afișați alte cărți de la %(publisher)s"
 
 #: type/edition/view.html type/work/view.html
 #, python-format
 msgid "Search for other books from %(publisher)s"
-msgstr ""
+msgstr "Căutați alte cărți de la %(publisher)s"
 
 #: openlibrary/plugins/worksearch/code.py type/edition/view.html type/work/view.html
 msgid "Language"
-msgstr ""
+msgstr "Limbă"
 
 #: type/edition/view.html type/work/view.html
 msgid "Pages"
@@ -6511,31 +6511,31 @@ msgstr "Pagini"
 
 #: type/edition/view.html type/work/view.html
 msgid "ISBNs"
-msgstr ""
+msgstr "ISBN-uri"
 
 #: databarWork.html type/edition/view.html type/work/view.html
 msgid "Buy this book"
-msgstr ""
+msgstr "Cumpărați această carte"
 
 #: type/edition/view.html type/work/view.html
 msgid "Book Details"
-msgstr ""
+msgstr "Detalii carte"
 
 #: type/edition/view.html type/work/view.html
 msgid "First Sentence"
-msgstr ""
+msgstr "Prima propoziție"
 
 #: type/edition/view.html type/work/view.html
 msgid "Edition Notes"
-msgstr ""
+msgstr "Note ediție"
 
 #: type/edition/view.html type/work/view.html
 msgid "Published in"
-msgstr ""
+msgstr "Publicată în"
 
 #: type/edition/view.html type/work/view.html
 msgid "Series"
-msgstr ""
+msgstr "Serie"
 
 #: type/edition/view.html type/work/view.html
 msgid "Volume"
@@ -6547,19 +6547,19 @@ msgstr "Gen"
 
 #: type/edition/view.html type/work/view.html
 msgid "Other Titles"
-msgstr ""
+msgstr "Alte titluri"
 
 #: type/edition/view.html type/work/view.html
 msgid "Copyright Date"
-msgstr ""
+msgstr "Data drepturilor de autor"
 
 #: type/edition/view.html type/work/view.html
 msgid "Translation Of"
-msgstr ""
+msgstr "Traducere a"
 
 #: type/edition/view.html type/work/view.html
 msgid "Translated From"
-msgstr ""
+msgstr "Tradusă din"
 
 #: type/edition/view.html type/work/view.html
 msgid "External Links"
@@ -6571,11 +6571,11 @@ msgstr "Format"
 
 #: OlPagination.html OlPaginationArrows.html type/edition/view.html type/work/view.html
 msgid "Pagination"
-msgstr ""
+msgstr "Paginare"
 
 #: type/edition/view.html type/work/view.html
 msgid "Number of pages"
-msgstr ""
+msgstr "Număr de pagini"
 
 #: type/edition/view.html type/work/view.html
 msgid "Weight"
@@ -6583,41 +6583,41 @@ msgstr "Greutate"
 
 #: type/edition/view.html type/work/view.html
 msgid "Edition Identifiers"
-msgstr ""
+msgstr "Identificatori ediție"
 
 #: type/edition/view.html type/work/view.html
 msgid "Source records"
-msgstr ""
+msgstr "Înregistrări sursă"
 
 #: type/edition/view.html type/work/view.html
 msgid "Work Description"
-msgstr ""
+msgstr "Descriere operă"
 
 #: type/edition/view.html type/work/view.html
 msgid "Original languages"
-msgstr ""
+msgstr "Limbi originale"
 
 #: type/edition/view.html type/work/view.html
 msgid "Excerpts"
-msgstr ""
+msgstr "Extrase"
 
 #: type/edition/view.html type/work/view.html
 #, python-format
 msgid "Page %(page)s"
-msgstr ""
+msgstr "Pagina %(page)s"
 
 #: type/edition/view.html type/work/view.html
 #, python-format
 msgid "added by %(authorlink)s."
-msgstr ""
+msgstr "adăugat de %(authorlink)s."
 
 #: type/edition/view.html type/work/view.html
 msgid "added anonymously."
-msgstr ""
+msgstr "adăugat anonim."
 
 #: type/edition/view.html type/work/view.html
 msgid "Wikipedia"
-msgstr ""
+msgstr "Wikipedia"
 
 #: type/edition/view.html type/work/view.html
 #, fuzzy
@@ -6627,7 +6627,7 @@ msgstr "Istoric împrumuturi"
 #: type/language/view.html
 #, python-format
 msgid "%(language)s [deprecated]"
-msgstr ""
+msgstr "%(language)s [depreciat]"
 
 #: type/language/view.html
 msgid "languages"
@@ -6635,16 +6635,16 @@ msgstr "limbi"
 
 #: type/language/view.html
 msgid "Code"
-msgstr ""
+msgstr "Cod"
 
 #: type/language/view.html
 msgid "Current"
-msgstr ""
+msgstr "Curent"
 
 #: type/language/view.html
 #, python-format
 msgid "Try a <a href=\"%(href)s\">search for readable books in %(language)s</a>?"
-msgstr ""
+msgstr "Încercați o <a href=\"%(href)s\">căutare de cărți lizibile în %(language)s</a>?"
 
 #: type/list/edit.html type/series/edit.html
 #, fuzzy
@@ -6654,12 +6654,12 @@ msgstr "Creați o listă"
 #: type/list/edit.html type/series/edit.html
 #, python-format
 msgid "Editing series: %(list_name)s"
-msgstr ""
+msgstr "Editare serie: %(list_name)s"
 
 #: type/list/edit.html type/series/edit.html
 #, python-format
 msgid "Editing list: %(list_name)s"
-msgstr ""
+msgstr "Editare listă: %(list_name)s"
 
 #: type/list/edit.html type/series/edit.html
 #, fuzzy
@@ -6672,23 +6672,23 @@ msgstr "Editează lista"
 
 #: type/list/edit.html type/series/edit.html
 msgid "Move..."
-msgstr ""
+msgstr "Mută..."
 
 #: type/list/edit.html type/series/edit.html
 msgid "Search for a book"
-msgstr ""
+msgstr "Căutați o carte"
 
 #: type/list/edit.html type/series/edit.html
 msgid "Position (optional), e.g. 1, 2, 1-7"
-msgstr ""
+msgstr "Poziție (opțional), ex. 1, 2, 1-7"
 
 #: type/list/edit.html type/series/edit.html
 msgid "Notes (optional)"
-msgstr ""
+msgstr "Note (opțional)"
 
 #: type/list/edit.html type/series/edit.html
 msgid "List Name"
-msgstr ""
+msgstr "Numele listei"
 
 #: type/list/edit.html type/series/edit.html
 #, fuzzy
@@ -6697,11 +6697,11 @@ msgstr "Nume de utilizator"
 
 #: type/list/edit.html type/series/edit.html
 msgid "Description (optional)"
-msgstr ""
+msgstr "Descriere (opțional)"
 
 #: type/list/edit.html type/series/edit.html
 msgid "Add another book"
-msgstr ""
+msgstr "Adăugați altă carte"
 
 #: type/list/edit.html type/series/edit.html
 #, fuzzy
@@ -6710,68 +6710,68 @@ msgstr "Creați o listă"
 
 #: type/list/embed.html
 msgid "Visit Open Library"
-msgstr ""
+msgstr "Vizitați Open Library"
 
 #: type/list/embed.html
 msgid "Open in online Book Reader. Downloads available in ePub, DAISY, PDF, TXT formats from main book page"
-msgstr ""
+msgstr "Deschideți în Cititorul de cărți online. Descărcările sunt disponibile în format ePub, DAISY, PDF, TXT de pe pagina principală a cărții"
 
 #: type/list/embed.html
 msgid "This book is checked out"
-msgstr ""
+msgstr "Această carte este împrumutată"
 
 #: type/list/embed.html
 msgid "Checked out"
-msgstr ""
+msgstr "Împrumutată"
 
 #: type/list/embed.html
 msgid "Borrow book"
-msgstr ""
+msgstr "Împrumutați cartea"
 
 #: type/list/embed.html
 msgid "Protected DAISY"
-msgstr ""
+msgstr "DAISY protejat"
 
 #: BookByline.html type/list/embed.html
 #, python-format
 msgid "by %(name)s"
-msgstr ""
+msgstr "de %(name)s"
 
 #: type/list/exports.html
 msgid "BibTex"
-msgstr ""
+msgstr "BibTex"
 
 #: type/list/exports.html
 msgid "Export"
-msgstr ""
+msgstr "Exportați"
 
 #: type/list/exports.html
 #, python-format
 msgid "as %(json_link)s, %(html_link)s, or %(bibtex_link)s"
-msgstr ""
+msgstr "ca %(json_link)s, %(html_link)s sau %(bibtex_link)s"
 
 #: type/list/exports.html
 msgid "Subscribe"
-msgstr ""
+msgstr "Abonați-vă"
 
 #: type/list/exports.html
 #, python-format
 msgid "Watch activity via <a rel=\"nofollow\" href=\"%s\">Atom feed</a>"
-msgstr ""
+msgstr "Urmăriți activitatea prin <a rel=\"nofollow\" href=\"%s\">flux Atom</a>"
 
 #: type/list/exports.html
 msgid "Export Not Available"
-msgstr ""
+msgstr "Exportul nu este disponibil"
 
 #: type/list/exports.html
 #, python-format
 msgid "Only lists with up to %(max)s editions can be exported. This one has %(count)s."
-msgstr ""
+msgstr "Pot fi exportate doar liste cu până la %(max)s ediții. Aceasta are %(count)s."
 
 #: type/list/exports.html
 #, python-format
 msgid "Try removing some seeds for more focus, or look at <a href=\"%s\">bulk download</a> of the catalog."
-msgstr ""
+msgstr "Încercați să eliminați câteva elemente pentru mai mult focus sau consultați <a href=\"%s\">descărcarea în bloc</a> a catalogului."
 
 #: type/list/view_body.html
 #, python-format

--- a/openlibrary/i18n/ro/messages.po
+++ b/openlibrary/i18n/ro/messages.po
@@ -7113,28 +7113,28 @@ msgstr "Disponibilitate"
 
 #: type/work/editions_datatable.html
 msgid "No editions available"
-msgstr ""
+msgstr "Nicio ediție disponibilă"
 
 #: type/work/editions_datatable.html
 msgid "Add another edition?"
-msgstr ""
+msgstr "Adăugați o altă ediție?"
 
 #: AffiliateLinks.html
 #, python-format
 msgid "Look for this edition for sale at %(store)s"
-msgstr ""
+msgstr "Căutați această ediție de vânzare la %(store)s"
 
 #: AffiliateLinks.html
 msgid "When you buy books using these links the Internet Archive may earn a <a class=\"nostyle\" href=\"/help/faq/about#selling\">small commission</a>."
-msgstr ""
+msgstr "Când cumpărați cărți folosind aceste linkuri, Internet Archive poate câștiga un <a class=\"nostyle\" href=\"/help/faq/about#selling\">mic comision</a>."
 
 #: AffiliateLinksLoadingIndicator.html
 msgid "Fetching prices"
-msgstr ""
+msgstr "Se obțin prețuri"
 
 #: BatchImportNavigation.html
 msgid "Pending Imports"
-msgstr ""
+msgstr "Importuri în așteptare"
 
 #: BookByline.html
 #, python-format
@@ -7146,27 +7146,27 @@ msgstr[2] ""
 
 #: BookByline.html
 msgid "by an <em>unknown author</em>"
-msgstr ""
+msgstr "de un <em>autor necunoscut</em>"
 
 #: BookPreview.html
 msgid "Preview Only"
-msgstr ""
+msgstr "Doar previzualizare"
 
 #: BookPreview.html
 msgid "Preview Book"
-msgstr ""
+msgstr "Previzualizare carte"
 
 #: DisplayCode.html
 msgid "Templates in the website are disabled now. Editing them will not have any effect on the live website."
-msgstr ""
+msgstr "Șabloanele din site sunt dezactivate în prezent. Editarea lor nu va avea niciun efect pe site-ul live."
 
 #: EditionNavBar.html
 msgid "Go to previous section"
-msgstr ""
+msgstr "Mergeți la secțiunea anterioară"
 
 #: EditionNavBar.html
 msgid "Overview"
-msgstr ""
+msgstr "Prezentare generală"
 
 #: EditionNavBar.html
 #, python-format
@@ -7186,11 +7186,11 @@ msgstr[2] ""
 
 #: EditionNavBar.html
 msgid "Related Books"
-msgstr ""
+msgstr "Cărți similare"
 
 #: EditionNavBar.html
 msgid "Go to next section"
-msgstr ""
+msgstr "Mergeți la secțiunea următoare"
 
 #: Follow.html
 #, fuzzy
@@ -7199,93 +7199,93 @@ msgstr "Urmăresc"
 
 #: Follow.html
 msgid "Failed to update followers. Please try again in a few moments."
-msgstr ""
+msgstr "Actualizarea urmăritorilor a eșuat. Vă rugăm să încercați din nou în câteva momente."
 
 #: FormatExpiry.html
 msgid "Expires"
-msgstr ""
+msgstr "Expiră"
 
 #: FulltextSearchSuggestion.html
 msgid "Checking for Search Inside matches"
-msgstr ""
+msgstr "Se verifică potrivirile Search Inside"
 
 #: FulltextSearchSuggestion.html
 msgid "Search Inside Icon"
-msgstr ""
+msgstr "Pictograma Search Inside"
 
 #: FulltextSearchSuggestion.html
 msgid "search inside icon"
-msgstr ""
+msgstr "pictograma căutare interioară"
 
 #: FulltextSearchSuggestion.html
 #, python-format
 msgid "%(book_count)s books found with matching passages"
-msgstr ""
+msgstr "%(book_count)s cărți găsite cu pasaje corespunzătoare"
 
 #: FulltextSearchSuggestion.html
 #, python-format
 msgid "See all %(results_count)s Search Inside Matches"
-msgstr ""
+msgstr "Vedeți toate %(results_count)s potriviri Search Inside"
 
 #: FulltextSearchSuggestion.html
 msgid "right chevron"
-msgstr ""
+msgstr "săgeată dreapta"
 
 #: FulltextSnippet.html FulltextSuggestionSnippet.html
 msgid "❝"
-msgstr ""
+msgstr "❝"
 
 #: FulltextSnippet.html FulltextSuggestionSnippet.html
 msgid "❞"
-msgstr ""
+msgstr "❞"
 
 #: FulltextSuggestionSnippet.html
 #, python-format
 msgid "Page: %(page)s"
-msgstr ""
+msgstr "Pagina: %(page)s"
 
 #: IABook.html
 #, python-format
 msgid "Borrowed from Internet Archive: %(title)s"
-msgstr ""
+msgstr "Împrumutat de la Internet Archive: %(title)s"
 
 #: LoadingIndicator.html
 msgid "Loading indicator"
-msgstr ""
+msgstr "Indicator de încărcare"
 
 #: LoanStatus.html
 msgid "You are <strong>next</strong> on the waiting list"
-msgstr ""
+msgstr "Ești <strong>următorul</strong> pe lista de așteptare"
 
 #: LoanStatus.html
 #, python-format
 msgid "You are <strong>#%(spot)d</strong> of %(wlsize)d on the waiting list."
-msgstr ""
+msgstr "Ești <strong>#%(spot)d</strong> din %(wlsize)d pe lista de așteptare."
 
 #: LoanStatus.html
 msgid "Leave waiting list"
-msgstr ""
+msgstr "Ieșiți din lista de așteptare"
 
 #: LoanStatus.html
 #, python-format
 msgid "Readers in line: %(count)s"
-msgstr ""
+msgstr "Cititori la rând: %(count)s"
 
 #: LoanStatus.html
 msgid "You'll be next in line."
-msgstr ""
+msgstr "Veți fi următorul la rând."
 
 #: LoanStatus.html
 msgid "This book is currently checked out, please check back later."
-msgstr ""
+msgstr "Această carte este în prezent împrumutată, vă rugăm să reveniți mai târziu."
 
 #: LoanStatus.html
 msgid "Checked Out"
-msgstr ""
+msgstr "Împrumutată"
 
 #: LocateButton.html
 msgid "Locate"
-msgstr ""
+msgstr "Localizați"
 
 #: ManageLoansButtons.html
 #, python-format
@@ -7313,15 +7313,15 @@ msgstr[2] ""
 
 #: NotInLibrary.html
 msgid "Not in Library"
-msgstr ""
+msgstr "Nu se află în bibliotecă"
 
 #: NotesModal.html
 msgid "My Book Notes"
-msgstr ""
+msgstr "Notele mele despre carte"
 
 #: NotesModal.html
 msgid "My private notes about this edition:"
-msgstr ""
+msgstr "Notele mele private despre această ediție:"
 
 #: OLID.html
 #, fuzzy, python-format
@@ -7330,130 +7330,130 @@ msgstr ""
 
 #: ObservationsModal.html
 msgid "My Book Review"
-msgstr ""
+msgstr "Recenzia mea despre carte"
 
 #: OlPagination.html OlPaginationArrows.html
 msgid "Go to previous page"
-msgstr ""
+msgstr "Mergeți la pagina anterioară"
 
 #: OlPagination.html OlPaginationArrows.html
 msgid "Go to next page"
-msgstr ""
+msgstr "Mergeți la pagina următoare"
 
 #: OlPagination.html
 #, python-brace-format
 msgid "Go to page {page}"
-msgstr ""
+msgstr "Mergeți la pagina {page}"
 
 #: OlPagination.html
 #, python-brace-format
 msgid "Page {page}, current page"
-msgstr ""
+msgstr "Pagina {page}, pagina curentă"
 
 #: Profile.html
 msgid "Component"
-msgstr ""
+msgstr "Componentă"
 
 #: ProlificAuthors.html
 msgid "Prolific Authors"
-msgstr ""
+msgstr "Autori prolifici"
 
 #: ProlificAuthors.html
 msgid "who have written the most books on this subject"
-msgstr ""
+msgstr "care au scris cele mai multe cărți despre acest subiect"
 
 #: PublishingHistory.html
 msgid "This is a chart to show the publishing history of editions of works about this subject. Along the X axis is time, and on the y axis is the count of editions published. <a href=\"#subjectRelated\">Click here to skip the chart</a>."
-msgstr ""
+msgstr "Acesta este un grafic care arată istoricul publicării edițiilor operelor despre acest subiect. Pe axa X este timpul, iar pe axa Y este numărul de ediții publicate. <a href=\"#subjectRelated\">Faceți clic aici pentru a omite graficul</a>."
 
 #: PublishingHistory.html
 msgid "This graph charts editions published on this subject."
-msgstr ""
+msgstr "Acest grafic ilustrează edițiile publicate despre acest subiect."
 
 #: RawQueryCarousel.html
 msgid "Loading carousel"
-msgstr ""
+msgstr "Se încarcă caruselul"
 
 #: RawQueryCarousel.html
 msgid "Failed to fetch carousel."
-msgstr ""
+msgstr "Caruselul nu a putut fi obținut."
 
 #: RawQueryCarousel.html
 msgid "Retry?"
-msgstr ""
+msgstr "Reîncercați?"
 
 #: RawQueryCarousel.html
 msgid "No books match the current filters."
-msgstr ""
+msgstr "Nicio carte nu corespunde filtrelor curente."
 
 #: RawQueryCarousel.html
 msgid "Retry without filters?"
-msgstr ""
+msgstr "Reîncercați fără filtre?"
 
 #: RawQueryCarousel.html
 msgid "Search collection"
-msgstr ""
+msgstr "Căutați în colecție"
 
 #: ReadButton.html
 msgid "Special Access"
-msgstr ""
+msgstr "Acces special"
 
 #: ReadButton.html
 msgid "Special ebook access from the Internet Archive for patrons with qualifying print disabilities"
-msgstr ""
+msgstr "Acces special la ebook de la Internet Archive pentru utilizatorii cu dizabilități de citire tipărită eligibile"
 
 #: ReadButton.html
 msgid "Borrow ebook from Internet Archive"
-msgstr ""
+msgstr "Împrumutați ebook de la Internet Archive"
 
 #: ReadButton.html
 msgid "Read ebook from Internet Archive"
-msgstr ""
+msgstr "Citiți ebook de la Internet Archive"
 
 #: ReadButton.html
 msgid "Listen"
-msgstr ""
+msgstr "Ascultați"
 
 #: RecentChanges.html
 msgid "View MARC"
-msgstr ""
+msgstr "Vizualizați MARC"
 
 #: RecentChangesAdmin.html
 msgid "Path"
-msgstr ""
+msgstr "Cale"
 
 #: RecentChangesAdmin.html
 msgid "view"
-msgstr ""
+msgstr "vizualizare"
 
 #: RecentChangesAdmin.html
 msgid "edit"
-msgstr ""
+msgstr "editare"
 
 #: RecentChangesAdmin.html RecentChangesUsers.html
 msgid "No edit history available."
-msgstr ""
+msgstr "Niciun istoric de editare disponibil."
 
 #: RelatedSubjects.html
 msgid "Related..."
-msgstr ""
+msgstr "Similare..."
 
 #: ReturnForm.html
 msgid "Really return this book?"
-msgstr ""
+msgstr "Sigur doriți să returnați această carte?"
 
 #: ReturnForm.html
 msgid "Return book"
-msgstr ""
+msgstr "Returnați cartea"
 
 #: SearchResultsWork.html
 msgid "added to"
-msgstr ""
+msgstr "adăugat la"
 
 #: SearchResultsWork.html
 #, python-format
 msgid "Book %(position)s"
-msgstr ""
+msgstr "Cartea %(position)s"
 
 #: SearchResultsWork.html
 #, fuzzy
@@ -7462,12 +7462,12 @@ msgstr "Mai mult"
 
 #: SearchResultsWork.html
 msgid "Show less"
-msgstr ""
+msgstr "Afișați mai puțin"
 
 #: SearchResultsWork.html
 #, python-format
 msgid "Cover of edition %(id)s"
-msgstr ""
+msgstr "Coperta ediției %(id)s"
 
 #: SearchResultsWork.html
 #, python-format
@@ -7479,16 +7479,16 @@ msgstr[2] ""
 
 #: SearchResultsWork.html TrendingBadge.html
 msgid "This is only visible to librarians."
-msgstr ""
+msgstr "Acesta este vizibil doar pentru bibliotecari."
 
 #: SearchResultsWork.html
 msgid "Work Title"
-msgstr ""
+msgstr "Titlul operei"
 
 #: ShareModal.html
 #, python-format
 msgid "Share on %(share_link)s"
-msgstr ""
+msgstr "Distribuiți pe %(share_link)s"
 
 #: ShareModal.html
 msgid "Embed this book in your website"

--- a/openlibrary/i18n/ro/messages.po
+++ b/openlibrary/i18n/ro/messages.po
@@ -6024,31 +6024,31 @@ msgstr "Top evaluat"
 
 #: search/sort_options.html
 msgid "Any"
-msgstr ""
+msgstr "Orice"
 
 #: search/sort_options.html
 msgid "Work Title (beta: Librarian only)"
-msgstr ""
+msgstr "Titlul operei (beta: doar bibliotecar)"
 
 #: search/sort_options.html
 msgid "Sorting by"
-msgstr ""
+msgstr "Sortare după"
 
 #: search/sort_options.html
 msgid "Shuffle"
-msgstr ""
+msgstr "Amestecat"
 
 #: search/subjects.html
 msgid "Search Subjects"
-msgstr ""
+msgstr "Căutați subiecte"
 
 #: search/subjects.html
 msgid "No <strong>subjects</strong> directly matched your search"
-msgstr ""
+msgstr "Niciun <strong>subiect</strong> nu s-a potrivit direct cu căutarea dvs."
 
 #: search/subjects.html
 msgid "time"
-msgstr ""
+msgstr "timp"
 
 #: search/subjects.html
 msgid "subject"
@@ -6076,11 +6076,11 @@ msgstr "muncă"
 
 #: search/work_search_facets.html
 msgid "Merge duplicate authors from this search"
-msgstr ""
+msgstr "Fuzionați autorii duplicați din această căutare"
 
 #: search/work_search_facets.html type/work/editions.html
 msgid "Merge duplicates"
-msgstr ""
+msgstr "Fuzionați duplicatele"
 
 #: search/work_search_facets.html
 #, fuzzy
@@ -6090,47 +6090,47 @@ msgstr "Liste"
 #: search/work_search_facets.html
 #, python-format
 msgid "Filter results for %(facet)s"
-msgstr ""
+msgstr "Filtrați rezultatele pentru %(facet)s"
 
 #: search/work_search_facets.html
 msgid "Filter results for ebook availability"
-msgstr ""
+msgstr "Filtrați rezultatele după disponibilitatea ebook"
 
 #: search/work_search_facets.html
 msgid "yes"
-msgstr ""
+msgstr "da"
 
 #: search/work_search_facets.html
 msgid "no"
-msgstr ""
+msgstr "nu"
 
 #: search/work_search_facets.html
 msgid "Zoom In"
-msgstr ""
+msgstr "Mărire"
 
 #: search/work_search_facets.html
 msgid "Focus your results using these <a href=\"/search/howto\">filters</a>"
-msgstr ""
+msgstr "Rafinați rezultatele folosind aceste <a href=\"/search/howto\">filtre</a>"
 
 #: search/work_search_selected_facets.html
 msgid "Written in"
-msgstr ""
+msgstr "Scrisă în"
 
 #: search/work_search_selected_facets.html
 msgid "Published by"
-msgstr ""
+msgstr "Publicată de"
 
 #: search/work_search_selected_facets.html
 msgid "eBook"
-msgstr ""
+msgstr "eBook"
 
 #: search/work_search_selected_facets.html
 msgid "Classic eBook"
-msgstr ""
+msgstr "eBook clasic"
 
 #: search/work_search_selected_facets.html
 msgid "Only Classic eBooks"
-msgstr ""
+msgstr "Doar eBook-uri clasice"
 
 #: search/work_search_selected_facets.html
 #, fuzzy
@@ -6140,15 +6140,15 @@ msgstr "Cărți electronice clasice"
 #: search/work_search_selected_facets.html
 #, python-format
 msgid "%(title)s - search"
-msgstr ""
+msgstr "%(title)s - căutare"
 
 #: site/alert.html
 msgid "Internet Archive logo"
-msgstr ""
+msgstr "Sigla Internet Archive"
 
 #: site/body.html
 msgid "It looks like you're offline."
-msgstr ""
+msgstr "Se pare că ești offline."
 
 #: site/head.html
 msgid "Open Library is an open, editable library catalog, building towards a web page for every book ever published. Read, borrow, and discover more than 3M books for free."
@@ -6156,47 +6156,47 @@ msgstr "Open Library este un catalog de bibliotecă deschis și editabil, care �
 
 #: site/stats.html
 msgid "Debug Stats"
-msgstr ""
+msgstr "Statistici de depanare"
 
 #: stats/readinglog.html
 msgid "Reading Log Stats"
-msgstr ""
+msgstr "Statistici jurnal lectură"
 
 #: stats/readinglog.html
 msgid "# Books Logged"
-msgstr ""
+msgstr "# Cărți înregistrate"
 
 #: stats/readinglog.html
 msgid "The total number of books logged using the Reading Log feature"
-msgstr ""
+msgstr "Numărul total de cărți înregistrate folosind funcția Jurnal lectură"
 
 #: stats/readinglog.html
 msgid "All time"
-msgstr ""
+msgstr "Toată perioada"
 
 #: stats/readinglog.html
 msgid "# Unique Users Logging Books"
-msgstr ""
+msgstr "# Utilizatori unici care înregistrează cărți"
 
 #: stats/readinglog.html
 msgid "The total number of unique users who have logged at least one book using the Reading Log feature"
-msgstr ""
+msgstr "Numărul total de utilizatori unici care au înregistrat cel puțin o carte folosind funcția Jurnal lectură"
 
 #: stats/readinglog.html
 msgid "# Books Starred"
-msgstr ""
+msgstr "# Cărți marcate cu stea"
 
 #: stats/readinglog.html
 msgid "The total number of books which have been starred"
-msgstr ""
+msgstr "Numărul total de cărți care au fost marcate cu stea"
 
 #: stats/readinglog.html
 msgid "Total # Unique Raters (all time)"
-msgstr ""
+msgstr "Total # Evaluatori unici (toată perioada)"
 
 #: stats/readinglog.html
 msgid "Most Wanted Books (This Month)"
-msgstr ""
+msgstr "Cele mai dorite cărți (luna aceasta)"
 
 #: stats/readinglog.html
 #, python-format
@@ -6208,27 +6208,27 @@ msgstr[2] ""
 
 #: stats/readinglog.html
 msgid "Most Wanted Books (All Time)"
-msgstr ""
+msgstr "Cele mai dorite cărți (toată perioada)"
 
 #: stats/readinglog.html
 msgid "Most Logged Books"
-msgstr ""
+msgstr "Cărți cel mai des înregistrate"
 
 #: stats/readinglog.html
 msgid "Most Read Books (All Time)"
-msgstr ""
+msgstr "Cărți cel mai mult citite (toată perioada)"
 
 #: stats/readinglog.html
 msgid "Most Rated Books"
-msgstr ""
+msgstr "Cărți cel mai bine evaluate"
 
 #: stats/readinglog.html
 msgid "Most Rated Books (All Time)"
-msgstr ""
+msgstr "Cărți cel mai bine evaluate (toată perioada)"
 
 #: subjects/notfound.html
 msgid "We couldn't find any books about"
-msgstr ""
+msgstr "Nu am găsit nicio carte despre"
 
 #: swagger/swaggerui.html
 msgid "OpenAPI"
@@ -6237,11 +6237,11 @@ msgstr "OpenAPI"
 #: type/about/edit.html type/page/edit.html type/permission/edit.html type/template/edit.html type/usergroup/edit.html
 #, python-format
 msgid "Edit %(title)s"
-msgstr ""
+msgstr "Editați %(title)s"
 
 #: type/about/edit.html
 msgid "This only appears in the document head, and gets attached to bookmark labels"
-msgstr ""
+msgstr "Aceasta apare doar în capul documentului și este atașată etichetelor de marcaj"
 
 #: type/about/edit.html
 msgid "Intro"
@@ -6249,135 +6249,135 @@ msgstr "Introducere"
 
 #: type/about/edit.html
 msgid "This appears in first column."
-msgstr ""
+msgstr "Aceasta apare în prima coloană."
 
 #: type/about/edit.html
 msgid "This appears in the second column, at top."
-msgstr ""
+msgstr "Aceasta apare în a doua coloană, în partea de sus."
 
 #: type/about/edit.html
 msgid "Mailing List"
-msgstr ""
+msgstr "Listă de corespondență"
 
 #: type/about/edit.html
 msgid "This appears below the links list."
-msgstr ""
+msgstr "Aceasta apare sub lista de linkuri."
 
 #: type/about/view.html
 msgid "For more information"
-msgstr ""
+msgstr "Pentru mai multe informații"
 
 #: type/author/edit.html
 msgid "Edit Author"
-msgstr ""
+msgstr "Editați autorul"
 
 #: type/author/edit.html
 msgid "Please use natural order. For example: <strong>Leo Tolstoy</strong> not <strong>Tolstoy, Leo</strong>."
-msgstr ""
+msgstr "Vă rugăm să folosiți ordinea naturală. De exemplu: <strong>Leo Tolstoy</strong> nu <strong>Tolstoy, Leo</strong>."
 
 #: type/author/edit.html
 msgid "A short bio?"
-msgstr ""
+msgstr "O scurtă biografie?"
 
 #: type/author/edit.html
 msgid "If you \"borrow\" information from somewhere, please make sure to cite the source."
-msgstr ""
+msgstr "Dacă \"împrumutați\" informații din altă parte, asigurați-vă că citați sursa."
 
 #: type/author/edit.html
 msgid "Date of birth"
-msgstr ""
+msgstr "Data nașterii"
 
 #: type/author/edit.html
 msgid "Date of death"
-msgstr ""
+msgstr "Data decesului"
 
 #: type/author/edit.html
 msgid "We're not storing structured dates (yet) so a date like \"21 May 2000\" is recommended."
-msgstr ""
+msgstr "Nu stocăm încă date structurate, deci se recomandă o dată de forma \"21 mai 2000\"."
 
 #: type/author/edit.html
 msgid "This is a deprecated field. You can help improve this record by removing this date and populating the \"Date of birth\" and \"Date of death\" fields. Thanks!"
-msgstr ""
+msgstr "Acesta este un câmp depreciat. Puteți îmbunătăți această înregistrare eliminând această dată și completând câmpurile \"Data nașterii\" și \"Data decesului\". Mulțumim!"
 
 #: type/author/edit.html
 msgid "Does this author go by any other names?"
-msgstr ""
+msgstr "Autorul este cunoscut și sub alte nume?"
 
 #: type/author/edit.html
 msgid "For example: Lev Nikolayevich Tolstoy was also known as Leo Tolstoy. Please list one name per line."
-msgstr ""
+msgstr "De exemplu: Lev Nikolayevich Tolstoy era cunoscut și ca Leo Tolstoy. Vă rugăm să listați câte un nume pe linie."
 
 #: type/author/edit.html
 msgid "Identifiers"
-msgstr ""
+msgstr "Identificatori"
 
 #: type/author/edit.html
 msgid "Author Identifiers Purpose"
-msgstr ""
+msgstr "Scopul identificatorilor autorului"
 
 #: type/author/view.html type/edition/view.html type/work/view.html
 #, python-format
 msgid "%(page_title)s | Open Library"
-msgstr ""
+msgstr "%(page_title)s | Open Library"
 
 #: type/author/view.html
 #, python-format
 msgid "Author of %(book_titles)s"
-msgstr ""
+msgstr "Autor al %(book_titles)s"
 
 #: type/author/view.html
 msgid "Merging Authors..."
-msgstr ""
+msgstr "Fuzionarea autorilor..."
 
 #: type/author/view.html
 msgid "In progress..."
-msgstr ""
+msgstr "În curs..."
 
 #: type/author/view.html
 msgid "Refresh the page?"
-msgstr ""
+msgstr "Reîncărcați pagina?"
 
 #: type/author/view.html
 msgid "OK. The merge is in motion. <i>It will take <u>a few minutes to finish</u> the update.</i>"
-msgstr ""
+msgstr "OK. Fuzionarea este în curs. <i>Va dura <u>câteva minute pentru a finaliza</u> actualizarea.</i>"
 
 #: type/author/view.html
 msgid "Argh!"
-msgstr ""
+msgstr "Argh!"
 
 #: type/author/view.html
 msgid "That merge didn't work. It's our fault, and we've made a note of it."
-msgstr ""
+msgstr "Fuzionarea nu a funcționat. Este greșeala noastră și am notat-o."
 
 #: type/author/view.html
 msgid "Add another?"
-msgstr ""
+msgstr "Adăugați altul?"
 
 #: type/author/view.html
 #, python-format
 msgid "Search %(author)s books"
-msgstr ""
+msgstr "Căutați cărțile lui %(author)s"
 
 #: type/author/view.html
 #, python-format
 msgid "— Show <a href=\"%(url)s\">everything</a> by this author?"
-msgstr ""
+msgstr "— Afișați <a href=\"%(url)s\">tot</a> de la acest autor?"
 
 #: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py type/author/view.html type/list/view_body.html
 msgid "Places"
-msgstr ""
+msgstr "Locuri"
 
 #: Profile.html type/author/view.html
 msgid "Time"
-msgstr ""
+msgstr "Timp"
 
 #: type/author/view.html
 msgid "OLID"
-msgstr ""
+msgstr "OLID"
 
 #: type/author/view.html
 msgid "Inventaire.io:"
-msgstr ""
+msgstr "Inventaire.io:"
 
 #: type/author/view.html type/edition/view.html type/work/view.html
 msgid "Links <span class=\"gray small sansserif\">outside Open Library</span>"

--- a/openlibrary/i18n/ro/messages.po
+++ b/openlibrary/i18n/ro/messages.po
@@ -1,4 +1,4 @@
-# Translations template for Open Library.
+# Romanian translations for Open Library.
 # Copyright (C) 2025 Internet Archive
 # This file is distributed under the same license as the Open Library
 # project.
@@ -9,21 +9,18 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Open Library VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-05-01 18:58-0400\n"
+"POT-Creation-Date: 2026-04-28 18:58-0400\n"
 "PO-Revision-Date: 2025-03-03 13:00+0200\n"
 "Last-Translator: \n"
-"Language-Team: Viorel-Cătălin Răpițeanu\n"
 "Language: ro\n"
+"Language-Team: Viorel-Cătălin Răpițeanu\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n==0 || (n!=1 && n%100>=1 && n%100<=19) ? 1 : 2);\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n==0 || (n!=1 && n%100>=1 && "
-"n%100<=19) ? 1 : 2);\n"
 "Generated-By: Babel 2.12.1\n"
-"X-Generator: Poedit 3.5\n"
 
-#: account.html account/notifications.html account/privacy.html lib/nav_head.html
-#: type/user/view.html
+#: account.html account/notifications.html account/privacy.html lib/nav_head.html type/user/view.html
 msgid "Settings"
 msgstr "Setări"
 
@@ -35,13 +32,11 @@ msgstr "Setări și confidențialitate"
 msgid "View"
 msgstr "Vizualizează"
 
-#: account.html
+#: account.html status.html
 msgid "or"
 msgstr "sau"
 
-#: account.html check_ins/check_in_prompt.html check_ins/reading_goal_progress.html
-#: databarHistory.html databarTemplate.html databarView.html subjects.html
-#: type/edition/compact_title.html type/user/view.html
+#: account.html databarHistory.html databarTemplate.html databarView.html my_books/check_ins/check_in_prompt.html reading_goals/reading_goal_progress.html subjects.html type/edition/compact_title.html type/user/view.html
 msgid "Edit"
 msgstr "Editează"
 
@@ -91,27 +86,23 @@ msgstr "Vă rugăm să ne contactați dacă aveți nevoie de ajutor cu altceva."
 
 #: barcodescanner.html
 msgid "Barcode Scanner (Beta)"
-msgstr ""
+msgstr "Scanner de coduri de bare (Beta)"
 
 #: batch_import.html
 msgid "Batch Imports"
-msgstr ""
+msgstr "Importuri în masă"
 
 #: BatchImportNavigation.html batch_import.html
 msgid "New Batch Import"
-msgstr ""
+msgstr "Import nou în masă"
 
 #: batch_import.html
-msgid ""
-"Attach a JSONL formatted document with import records or copy/paste the JSONL "
-"text into the textarea."
-msgstr ""
+msgid "Attach a JSONL formatted document with import records or copy/paste the JSONL text into the textarea."
+msgstr "Atașați un document în format JSONL cu înregistrări de import sau copiați/lipiți textul JSONL în câmpul de text."
 
 #: batch_import.html
-msgid ""
-"See the <a href=\"https://github.com/internetarchive/openlibrary-client/tree/"
-"master/olclient/schemata\">olclient import schemata</a> for more."
-msgstr ""
+msgid "See the <a href=\"https://github.com/internetarchive/openlibrary-client/tree/master/olclient/schemata\">olclient import schemata</a> for more."
+msgstr "Consultați <a href=\"https://github.com/internetarchive/openlibrary-client/tree/master/olclient/schemata\">schemele de import olclient</a> pentru mai multe informații."
 
 #: batch_import.html
 msgid "Attach a file:"
@@ -119,9 +110,9 @@ msgstr "Atașați un fișier:"
 
 #: batch_import.html
 msgid "Or copy/paste JSONL text:"
-msgstr ""
+msgstr "Sau copiați/lipiți textul JSONL:"
 
-#: batch_import.html
+#: batch_import.html import_preview.html
 msgid "Import"
 msgstr "Importă"
 
@@ -131,86 +122,80 @@ msgstr "Importul a eșuat."
 
 #: batch_import.html
 msgid "No import will be queued until *every* record validates successfully."
-msgstr ""
+msgstr "Nicio importare nu va fi pusă în așteptare până când *fiecare* înregistrare nu este validată cu succes."
 
 #: batch_import.html
-msgid ""
-"Please update the JSONL file and reload this page (there should be no need to "
-"reattach the file)."
-msgstr ""
+msgid "Please update the JSONL file and reload this page (there should be no need to reattach the file)."
+msgstr "Actualizați fișierul JSONL și reîncărcați această pagină (nu ar trebui să fie necesară reatașarea fișierului)."
 
 #: batch_import.html
 msgid "Validation errors:"
-msgstr ""
+msgstr "Erori de validare:"
 
 #: batch_import.html
 #, python-format
 msgid "Line %d:"
-msgstr ""
+msgstr "Linia %d:"
 
 #: batch_import.html
 msgid "Import results for batch:"
-msgstr ""
+msgstr "Rezultatele importului pentru lot:"
 
 #: batch_import.html
 msgid "Records submitted:"
-msgstr ""
+msgstr "Înregistrări trimise:"
 
 #: batch_import.html
 msgid "Total queued:"
-msgstr ""
+msgstr "Total în așteptare:"
 
 #: batch_import.html
 msgid "Total skipped:"
-msgstr ""
+msgstr "Total omise:"
 
 #: batch_import.html
 msgid "Not queued because they are already present in the queue:"
-msgstr ""
+msgstr "Nepuse în așteptare deoarece sunt deja prezente în coadă:"
 
 #: batch_import.html
 msgid "View Batch Status"
-msgstr ""
+msgstr "Vezi starea lotului"
 
 #: batch_import_pending_view.html
 msgid "Pending Batch Imports"
-msgstr ""
+msgstr "Importuri în masă în așteptare"
 
 #: batch_import_pending_view.html
 msgid "batch_id"
-msgstr ""
+msgstr "ID lot"
 
-#: admin/imports.html admin/imports_by_date.html batch_import_pending_view.html
-#: batch_import_view.html
+#: admin/imports.html admin/imports_by_date.html batch_import_pending_view.html batch_import_view.html
 msgid "Added Time"
-msgstr ""
+msgstr "Ora adăugării"
 
-#: account/import.html account/loans.html admin/imports.html
-#: admin/imports_by_date.html admin/loans_table.html admin/menu.html
-#: batch_import_pending_view.html batch_import_view.html status.html
+#: account/import.html account/loans.html admin/imports.html admin/imports_by_date.html admin/loans_table.html admin/menu.html batch_import_pending_view.html batch_import_view.html librarian_dashboard/data_quality_table.html status.html
 msgid "Status"
-msgstr ""
+msgstr "Stare"
 
-#: batch_import_pending_view.html batch_import_view.html
-#: merge_request_table/table_header.html
+#: batch_import_pending_view.html batch_import_view.html merge_request_table/table_header.html
 msgid "Submitter"
-msgstr ""
+msgstr "Expeditor"
 
 #: RecentChangesAdmin.html batch_import_pending_view.html batch_import_view.html
 msgid "Comments"
-msgstr ""
+msgstr "Comentarii"
 
 #: batch_import_view.html
 msgid "Batch Import Status"
-msgstr ""
+msgstr "Starea importului în masă"
 
 #: batch_import_view.html
 msgid "Batch ID:"
-msgstr ""
+msgstr "ID lot:"
 
 #: batch_import_view.html
 msgid "Batch Name:"
-msgstr ""
+msgstr "Nume lot:"
 
 #: batch_import_view.html
 msgid "Submitter:"
@@ -222,190 +207,133 @@ msgstr ""
 
 #: batch_import_view.html
 msgid "Status Summary"
-msgstr ""
+msgstr "Rezumat stare"
 
 #: batch_import_view.html
 msgid "Approve"
-msgstr ""
+msgstr "Aprobă"
 
 #: batch_import_view.html
 msgid "Import Items"
-msgstr ""
+msgstr "Importă elemente"
 
 #: batch_import_view.html
 msgid "Import Time"
-msgstr ""
+msgstr "Ora importului"
 
-#: account/import.html admin/imports.html admin/imports_by_date.html
-#: batch_import_view.html
+#: account/import.html admin/imports.html admin/imports_by_date.html batch_import_view.html librarian_dashboard/data_quality_table.html
 msgid "Error"
-msgstr ""
+msgstr "Eroare"
 
 #: batch_import_view.html
 msgid "IA ID"
-msgstr ""
+msgstr "ID IA"
 
 #: batch_import_view.html
 msgid "Data"
-msgstr ""
+msgstr "Date"
 
 #: admin/imports.html admin/imports_by_date.html batch_import_view.html
 msgid "OL Key"
-msgstr ""
+msgstr "Cheie OL"
 
 #: batch_import_view.html
 msgid "Not yet imported"
-msgstr ""
-
-#: design.html
-msgid "Design Pattern Library"
-msgstr ""
-
-#: design.html
-msgid "Fonts"
-msgstr "Fonturi"
-
-#: design.html
-msgid "Font-size"
-msgstr "Dimensiune font"
-
-#: design.html
-msgid "Font-family"
-msgstr "Familie de fonturi"
-
-#: design.html
-msgid "Sans-serif: Verdana"
-msgstr ""
-
-#: design.html
-msgid "Serif: Georgia"
-msgstr ""
-
-#: design.html
-msgid "Colors"
-msgstr ""
-
-#: design.html
-msgid "Defaults"
-msgstr ""
-
-#: design.html
-msgid "Background"
-msgstr ""
-
-#: design.html
-msgid "Primary Call To Action"
-msgstr ""
-
-#: design.html
-msgid "Link (unclicked)"
-msgstr ""
-
-#: design.html
-msgid "Link (clicked)"
-msgstr ""
+msgstr "Neimportat încă"
 
 #: diff.html
 #, python-format
 msgid "Diff on %s"
-msgstr ""
-
-#: diff.html
-msgid "Added"
-msgstr ""
-
-#: admin/imports_by_date.html diff.html
-msgid "Modified"
-msgstr ""
-
-#: diff.html
-msgid "Removed"
-msgstr ""
-
-#: diff.html
-msgid "Not changed"
-msgstr ""
+msgstr "Diferențe la %s"
 
 #: diff.html
 #, python-format
 msgid "Revision %d"
-msgstr ""
+msgstr "Revizia %d"
 
-#: books/check.html books/show.html covers/book_cover.html
-#: covers/book_cover_single_edition.html covers/book_cover_work.html diff.html
-#: jsdef/LazyWorkPreview.html lists/preview.html
+#: books/check.html covers/book_cover.html diff.html jsdef/LazyWorkPreview.html
 msgid "by"
-msgstr ""
+msgstr "de"
 
 #: diff.html
 msgid "by Anonymous"
-msgstr ""
+msgstr "de Anonim"
 
 #: diff.html
 msgid "history"
-msgstr ""
+msgstr "istoric"
+
+#: diff.html status.html
+msgid "Added"
+msgstr "Adăugat"
+
+#: admin/imports_by_date.html diff.html
+msgid "Modified"
+msgstr "Modificat"
+
+#: diff.html
+msgid "Removed"
+msgstr "Eliminat"
+
+#: diff.html
+msgid "Not changed"
+msgstr "Nemodificat"
 
 #: diff.html
 msgid "Differences"
-msgstr ""
+msgstr "Diferențe"
 
 #: diff.html
 msgid "Both the revisions are identical."
-msgstr ""
+msgstr "Ambele revizii sunt identice."
 
 #: edit_yaml.html lib/edit_head.html
 msgid "You're in edit mode."
-msgstr ""
+msgstr "Ești în modul de editare."
 
 #: edit_yaml.html lib/edit_head.html
 msgid "Cancel, and go back."
-msgstr ""
+msgstr "Anulează și întoarce-te."
 
 #: edit_yaml.html
 msgid "YAML Representation:"
-msgstr ""
+msgstr "Reprezentare YAML:"
 
-#: BookPreview.html book_providers/direct_read_button.html books/edit/edition.html
-#: editpage.html
+#: BookPreview.html book_providers/read_button.html books/edit/edition.html editpage.html import_preview.html
 msgid "Preview"
-msgstr ""
+msgstr "Previzualizare"
 
 #: history.html
 msgid "History of edits to"
-msgstr ""
+msgstr "Istoricul modificărilor la"
 
 #: history.html
 msgid "Revision"
-msgstr ""
+msgstr "Revizie"
 
-#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
-#: admin/ip/view.html admin/people/edits.html history.html recentchanges/render.html
-#: recentchanges/updated_records.html
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html admin/ip/view.html admin/people/edits.html history.html recentchanges/render.html recentchanges/updated_records.html
 msgid "When"
 msgstr "Când"
 
-#: RecentChanges.html admin/history.html admin/ip/view.html admin/loans_table.html
-#: admin/people/edits.html history.html recentchanges/render.html
+#: RecentChanges.html admin/history.html admin/ip/view.html admin/loans_table.html admin/people/edits.html history.html recentchanges/render.html
 msgid "Who"
 msgstr "Cine"
 
-#: RecentChanges.html RecentChangesUsers.html admin/history.html admin/ip/view.html
-#: admin/people/edits.html history.html recentchanges/render.html
-#: recentchanges/updated_records.html
+#: RecentChanges.html RecentChangesUsers.html admin/history.html admin/ip/view.html admin/people/edits.html history.html recentchanges/render.html recentchanges/updated_records.html
 msgid "Comment"
 msgstr "Comentariu"
 
 #: history.html
 msgid "Diff"
-msgstr ""
+msgstr "Diferențe"
 
 #: history.html
 msgid "Compare"
-msgstr ""
+msgstr "Compară"
 
 #: history.html
 msgid "See Diff"
-msgstr ""
+msgstr "Vezi diferențele"
 
 #: history.html lib/history.html
 #, python-format
@@ -414,51 +342,89 @@ msgstr "Vizualizează revizia %s"
 
 #: history.html
 msgid "Compare this version..."
-msgstr ""
+msgstr "Compară această versiune..."
 
 #: history.html
 msgid "...to this version"
-msgstr ""
+msgstr "...cu această versiune"
 
-#: books/daisy.html history.html
-msgid "Back"
-msgstr ""
+#: import_preview.html
+#, fuzzy
+msgid "Import Preview"
+msgstr "Recenziile mele"
 
-#: Pager.html Pager_loanhistory.html admin/memory/index.html history.html
-#: lib/pagination.html showmarc.html
-msgid "Next"
-msgstr ""
+#: import_preview.html
+#, fuzzy
+msgid "Preview Import"
+msgstr "Importă"
+
+#: import_preview.html
+msgid "Show Raw Import Data"
+msgstr "Afișează datele brute de import"
+
+#: import_preview.html
+#, python-format
+msgid "New %(thing_type)s record will be created"
+msgstr "Va fi creată o nouă înregistrare %(thing_type)s"
+
+#: import_preview.html
+#, python-format
+msgid "Changes to %(key)s"
+msgstr "Modificări la %(key)s"
 
 #: internalerror.html
 msgid "Internal Error"
-msgstr ""
+msgstr "Eroare internă"
 
 #: internalerror.html
 msgid "A Problem Occurred"
-msgstr ""
+msgstr "A apărut o problemă"
 
 #: internalerror.html
 msgid "We're sorry, a problem occurred while responding to your request:"
-msgstr ""
+msgstr "Ne pare rău, a apărut o problemă la procesarea cererii dumneavoastră:"
 
 #: internalerror.html
 #, python-format
-msgid ""
-"The reference code %s has been created to track this error and we will "
-"investigate as we're able."
-msgstr ""
+msgid "The reference code %s and Sentry trace ID %s have been created to track this error and we will investigate as we're able."
+msgstr "Codul de referință %s și ID-ul de urmărire Sentry %s au fost create pentru a urmări această eroare și vom investiga cauza."
 
 #: internalerror.html
-msgid ""
-"Return to the <a class=\"go-back-link\" href=\"javascript:;\">previous page</a>?"
-msgstr ""
+#, python-format
+msgid "The reference code %s has been created to track this error and we will investigate as we're able."
+msgstr "Codul de referință %s a fost creat pentru a urmări această eroare și vom investiga cauza."
+
+#: internalerror.html
+msgid "Return to the <a class=\"go-back-link\" href=\"javascript:;\">previous page</a>?"
+msgstr "Revenire la <a class=\"go-back-link\" href=\"javascript:;\">pagina anterioară</a>?"
+
+#: interstitial.html
+msgid "You are being redirected to your book"
+msgstr "Ești redirecționat la cartea ta"
+
+#: interstitial.html
+#, python-format
+msgid "This book is provided by %(book_provider)s, a third-party Open Library Trusted Book Provider"
+msgstr "Această carte este oferită de %(book_provider)s, un furnizor de cărți de încredere terț al Open Library."
+
+#: interstitial.html
+#, python-format
+msgid "In %(time)s seconds, you will be automatically redirected to: %(url)s"
+msgstr "În %(time)s secunde, vei fi redirecționat automat la: %(url)s"
+
+#: CreateListModal.html EditButtons.html account/notifications.html account/password/reset.html account/privacy.html admin/imports-add.html admin/permissions.html books/add.html databarEdit.html interstitial.html merge/authors.html my_books/dropdown_content.html type/list/edit.html type/series/edit.html type/tag/form.html
+msgid "Cancel"
+msgstr "Anulează"
+
+#: interstitial.html
+msgid "Continue without waiting"
+msgstr "Continuă fără să aștepți"
 
 #: lib/nav_head.html library_explorer.html
 msgid "Library Explorer"
 msgstr "Explorator de bibliotecă"
 
-#: account/create.html books/custom_carousel.html login.html
-#: search/work_search_facets.html
+#: account/create.html books/custom_carousel.html librarian_dashboard/data_quality_table.html login.html search/work_search_facets.html
 msgid "Loading..."
 msgstr "Se încarcă..."
 
@@ -467,11 +433,8 @@ msgid "Log In"
 msgstr "Autentificare"
 
 #: login.html
-msgid ""
-"This is a development instance, the default credentials are automatically filled."
-msgstr ""
-"Acesta este o instanță de dezvoltare, credențialele implicite sunt completate "
-"automat."
+msgid "This is a development instance, the default credentials are automatically filled."
+msgstr "Acesta este o instanță de dezvoltare, credențialele implicite sunt completate automat."
 
 #: login.html
 msgid "email:"
@@ -482,12 +445,8 @@ msgid "password:"
 msgstr "parolă:"
 
 #: login.html
-msgid ""
-"Log in to use your free Open Library card to borrow digital books from the "
-"nonprofit Internet Archive"
-msgstr ""
-"Conectați-vă pentru a utiliza cardul dumneavoastră gratuit Open Library și a "
-"împrumuta cărți digitale de la organizația non-profit Internet Archive"
+msgid "Log in to use your free Open Library card to borrow digital books from the nonprofit Internet Archive"
+msgstr "Conectați-vă pentru a utiliza cardul dumneavoastră gratuit Open Library și a împrumuta cărți digitale de la organizația non-profit Internet Archive"
 
 #: account/create.html login.html
 msgid "OR"
@@ -499,23 +458,12 @@ msgid "You are already logged into Open Library as %(user)s."
 msgstr "Sunteți deja conectat la Open Library sub numele de utilizator %(user)s."
 
 #: account/create.html login.html
-msgid ""
-"If you'd like to create a new, different Open Library account, you'll need to <a "
-"href=\"javascript:;\" onclick=\"document.forms['hamburger-logout'].submit()\">log "
-"out</a> and start the signup process afresh."
-msgstr ""
-"Dacă doriți să creați un cont nou și diferit de Open Library, trebuie să vă <a "
-"href=\"javascript:;\" onclick=\"document.forms['hamburger-logout']."
-"submit()\">deconectați</a> și să începeți procesul de înregistrare de la început."
+msgid "If you'd like to create a new, different Open Library account, you'll need to <a href=\"javascript:;\" onclick=\"document.forms['hamburger-logout'].submit()\">log out</a> and start the signup process afresh."
+msgstr "Dacă doriți să creați un cont nou și diferit de Open Library, trebuie să vă <a href=\"javascript:;\" onclick=\"document.forms['hamburger-logout'].submit()\">deconectați</a> și să începeți procesul de înregistrare de la început."
 
 #: login.html
-msgid ""
-"Please enter your <a href=\"https://archive.org\">Internet Archive</a> email and "
-"password to access your Open Library account."
-msgstr ""
-"Vă rugăm să introduceți adresa dumneavoastră de e-mail și parola de la <a "
-"href=\"https://archive.org\">Internet Archive</a> pentru a accesa contul "
-"dumneavoastră Open Library."
+msgid "Please enter your <a href=\"https://archive.org\">Internet Archive</a> email and password to access your Open Library account."
+msgstr "Vă rugăm să introduceți adresa dumneavoastră de e-mail și parola de la <a href=\"https://archive.org\">Internet Archive</a> pentru a accesa contul dumneavoastră Open Library."
 
 #: login.html openlibrary/plugins/upstream/forms.py
 msgid "Email"
@@ -547,38 +495,25 @@ msgstr "Nu ai un cont? <a href=\"/account/create\">Înregistrează-te acum</a>."
 
 #: messages.html
 msgid "Created new author record."
-msgstr ""
+msgstr "A fost creată o nouă înregistrare de autor."
 
 #: messages.html
 msgid "Created new edition record."
-msgstr ""
+msgstr "A fost creată o nouă înregistrare de ediție."
 
 #: messages.html
 msgid "Created new work record."
-msgstr ""
+msgstr "A fost creată o nouă înregistrare de operă."
 
 #: messages.html
 msgid "Added new book."
 msgstr ""
 
 #: messages.html
-msgid "Thank you very much for adding that new book!"
+msgid "Thank you for improving the Open Library catalog!"
 msgstr ""
 
-#: messages.html
-msgid "Thank you very much for improving that record!"
-msgstr ""
-
-#: BookPreview.html CreateListModal.html DonateModal.html NotesModal.html
-#: ObservationsModal.html ShareModal.html book_providers/cita_press_read_button.html
-#: book_providers/direct_read_button.html book_providers/gutenberg_read_button.html
-#: book_providers/librivox_read_button.html book_providers/openstax_read_button.html
-#: book_providers/runeberg_read_button.html
-#: book_providers/standard_ebooks_read_button.html
-#: book_providers/wikisource_read_button.html covers/author_photo.html
-#: covers/book_cover.html covers/book_cover_single_edition.html
-#: covers/book_cover_work.html covers/change.html lib/history.html
-#: my_books/dropdown_content.html native_dialog.html
+#: BookPreview.html CreateListModal.html NotesModal.html ObservationsModal.html ShareModal.html covers/author_photo.html covers/book_cover.html covers/change.html lib/exports.html my_books/check_ins/check_in_prompt.html my_books/dropdown_content.html native_dialog.html
 msgid "Close"
 msgstr ""
 
@@ -630,15 +565,13 @@ msgid "Permission denied."
 msgstr ""
 
 #: permission_denied.html
-msgid ""
-"Only logged users are allowed to add records on Open Library. Please <a href=\"/"
-"account/login?redirect=$path\">log in</a> to add a book."
+#, python-format
+msgid "Only logged users are allowed to add records on Open Library. Please <a href=\"%s\">log in</a> to add a book."
 msgstr ""
 
 #: permission_denied.html
-msgid ""
-"Only logged users are allowed to modify records on Open Library. Please <a "
-"href=\"/account/login?redirect=$path\">log in</a> to edit this page."
+#, python-format
+msgid "Only logged users are allowed to modify records on Open Library. Please <a href=\"%s\">log in</a> to edit this page."
 msgstr ""
 
 #: permission_denied.html
@@ -647,9 +580,7 @@ msgid "You may <a href=\"%s\">log in</a> if you have the required permissions."
 msgstr ""
 
 #: recaptcha.html
-msgid ""
-"Please satisfy the reCAPTCHA below. If you have security settings or privacy "
-"blockers installed, please disable them to see the reCAPTCHA."
+msgid "Please satisfy the reCAPTCHA below. If you have security settings or privacy blockers installed, please disable them to see the reCAPTCHA."
 msgstr ""
 
 #: recaptcha.html
@@ -672,7 +603,7 @@ msgstr ""
 msgid "Source"
 msgstr ""
 
-#: books/add.html showia.html type/edition/view.html type/work/view.html
+#: books/add.html covers/add.html showia.html type/edition/view.html type/work/view.html
 msgid "Internet Archive"
 msgstr "Internet Archive"
 
@@ -696,6 +627,10 @@ msgstr ""
 msgid "Download Link"
 msgstr ""
 
+#: showmarc.html type/tag/index.html
+msgid "Next"
+msgstr ""
+
 #: status.html
 msgid "Open Library server status"
 msgstr ""
@@ -705,24 +640,137 @@ msgid "Server status"
 msgstr ""
 
 #: status.html
-msgid "System information"
+msgid "Testing Environment"
 msgstr ""
 
 #: status.html
-msgid "Features enabled"
+msgid "Deploy triggered!"
 msgstr ""
 
 #: status.html
-msgid "Staged"
+msgid "View Jenkins progress"
+msgstr ""
+
+#: status.html
+msgid "GitHub status refreshed."
+msgstr ""
+
+#: status.html
+msgid "PR numbers or URLs, space/comma separated"
+msgstr ""
+
+#: status.html
+msgid "Add PR(s)"
+msgstr ""
+
+#: status.html
+msgid "PR"
+msgstr ""
+
+#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html search/advancedsearch.html status.html type/about/edit.html type/page/edit.html type/template/edit.html
+msgid "Title"
+msgstr "Titlu"
+
+#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html openlibrary/plugins/worksearch/code.py search/advancedsearch.html search/work_search_selected_facets.html status.html
+msgid "Author"
+msgstr "Autor"
+
+#: status.html
+msgid "Assignee"
+msgstr ""
+
+#: status.html
+msgid "Pinned Commit"
+msgstr ""
+
+#: status.html
+msgid "Branch HEAD"
+msgstr ""
+
+#: status.html
+#, fuzzy
+msgid "Drift"
+msgstr "Editează"
+
+#: status.html
+msgid "Enabled"
+msgstr ""
+
+#: status.html
+msgid "up to date"
+msgstr ""
+
+#: status.html
+#, fuzzy
+msgid "unknown"
+msgstr "Necunoscut"
+
+#: status.html
+msgid "1 commit behind"
+msgstr ""
+
+#: status.html
+#, fuzzy, python-format
+msgid "%(count)s commits behind"
+msgstr ""
+
+#: admin/solr.html status.html
+msgid "Update"
+msgstr ""
+
+#: status.html
+msgid "Enable"
+msgstr ""
+
+#: status.html
+msgid "Disable"
+msgstr ""
+
+#: lists/lists.html status.html type/list/edit.html type/series/edit.html
+msgid "Remove"
+msgstr ""
+
+#: status.html
+#, fuzzy
+msgid "Selected PRs"
+msgstr "Șterge lista"
+
+#: status.html
+#, fuzzy
+msgid "Refresh"
+msgstr "Franceză"
+
+#: status.html
+#, fuzzy
+msgid "Deploy"
+msgstr "Dezvoltare"
+
+#: status.html
+msgid "No PRs in testing set."
+msgstr ""
+
+#: status.html
+msgid "Last Build Result"
+msgstr ""
+
+#: status.html
+msgid "View PRs on GitHub"
 msgstr ""
 
 #: status.html
 msgid "Show changed files"
 msgstr ""
 
-#: admin/inspect/store.html admin/people/index.html status.html
-#: type/author/edit.html type/language/view.html
+#: admin/inspect/store.html admin/people/index.html status.html type/author/edit.html type/language/view.html
 msgid "Name"
+msgstr ""
+
+#: status.html
+msgid "System information"
+msgstr ""
+
+#: status.html
+msgid "Features enabled"
 msgstr ""
 
 #: subjects.html
@@ -754,77 +802,11 @@ msgstr ""
 msgid "Disambiguations"
 msgstr ""
 
-#: support.html
-msgid "How can we help?"
-msgstr ""
-
-#: support.html
-msgid ""
-"Your question has been sent to our support team. We'll get back to you shortly. "
-"You can also <a href=\"https://twitter.com/openlibrary\">contact us on Twitter</"
-"a>."
-msgstr ""
-
-#: support.html
-msgid ""
-"Please check our <a href=\"/help/\">Help Pages</a> and <a href=\"/help/"
-"faq\">Frequently Asked Questions</a> (FAQ) to see if your question is answered "
-"there. Thank you."
-msgstr ""
-
-#: support.html
-msgid "Your Name"
-msgstr ""
-
-#: support.html
-msgid "Your Email Address"
-msgstr ""
-
-#: support.html
-msgid "We'll need this if you want a reply"
-msgstr ""
-
-#: support.html
-msgid ""
-"If you wish to be contacted by other means, please add your contact preference "
-"and details to your question."
-msgstr ""
-
-#: lib/nav_head.html search/advancedsearch.html support.html
-msgid "Subject"
-msgstr "Subiect"
-
-#: support.html
-msgid "Your Question"
-msgstr ""
-
-#: support.html
-msgid "Note: our staff will likely only be able respond in English."
-msgstr ""
-
-#: support.html
-msgid ""
-"If you encounter an error message, please include it. For questions about our "
-"books, please provide the title/author or Open Library ID."
-msgstr ""
-
-#: support.html
-msgid "Send"
-msgstr "Trimite"
-
-#: CreateListModal.html EditButtons.html account/notifications.html
-#: account/password/reset.html account/privacy.html admin/imports-add.html
-#: admin/permissions.html books/add.html databarEdit.html merge/authors.html
-#: my_books/dropdown_content.html support.html type/tag/form.html
-msgid "Cancel"
-msgstr ""
-
 #: trending.html
 msgid "Now"
 msgstr ""
 
-#: admin/graphs.html admin/index.html check_ins/check_in_form.html
-#: check_ins/check_in_prompt.html trending.html
+#: admin/graphs.html admin/index.html my_books/check_ins/check_in_form.html my_books/check_ins/check_in_prompt.html trending.html
 msgid "Today"
 msgstr ""
 
@@ -840,12 +822,11 @@ msgstr ""
 msgid "This Year"
 msgstr ""
 
-#: account/view.html admin/index.html books/year_breadcrumb_select.html
-#: trending.html
+#: admin/index.html books/year_breadcrumb_select.html trending.html
 msgid "All Time"
 msgstr ""
 
-#: home/index.html trending.html
+#: home/index.html openlibrary/plugins/openlibrary/api.py trending.html
 msgid "Trending Books"
 msgstr ""
 
@@ -857,27 +838,34 @@ msgstr ""
 msgid "Earliest trending data is from October 2017"
 msgstr ""
 
-#: account/mybooks.html account/sidebar.html my_books/dropdown_content.html
-#: my_books/primary_action.html search/sort_options.html trending.html
+#. Label for the reading log shelf for books the user plans to read in the
+#. future (bookshelf ID 1). Used as a button label and shelf name.
+#: account/mybooks.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html trending.html
 msgid "Want to Read"
 msgstr "Doresc să citesc"
 
-#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
-#: my_books/dropdown_content.html my_books/primary_action.html
-#: search/sort_options.html trending.html
+#. Display name for the "currently-reading" reading log shelf used in page
+#. headings and breadcrumbs.
+#. Label for the reading log shelf for books the user is actively reading
+#. (bookshelf ID 2). Used as a button label and shelf name.
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html trending.html
 msgid "Currently Reading"
 msgstr "În curs de citire"
 
-#: LoanReadForm.html ReadButton.html admin/inspect/memcache.html
-#: book_providers/cita_press_read_button.html book_providers/direct_read_button.html
-#: book_providers/gutenberg_read_button.html
-#: book_providers/openstax_read_button.html book_providers/runeberg_read_button.html
-#: book_providers/standard_ebooks_read_button.html
-#: book_providers/wikisource_read_button.html books/custom_carousel.html
-#: books/edit/edition.html books/show.html books/works-show.html trending.html
-#: type/list/embed.html widget.html
+#: LoanReadForm.html ReadButton.html admin/inspect/memcache.html book_providers/read_button.html books/edit/edition.html trending.html type/list/embed.html widget.html
 msgid "Read"
 msgstr "Citit"
+
+#. Display name for the "stopped-reading" reading log shelf used in page
+#. headings and breadcrumbs.
+#. Label for the reading log shelf for books the user stopped reading before
+#. finishing (bookshelf ID 4). Used as a button label and shelf name.
+#. Label for the reading log shelf for books the user stopped reading
+#. (bookshelf ID 4). Used as a button label and shelf name.
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html trending.html
+#, fuzzy
+msgid "Stopped Reading"
+msgstr "În tendințe"
 
 #: trending.html
 #, python-format
@@ -887,6 +875,27 @@ msgstr ""
 #: trending.html
 #, python-format
 msgid "Logged %(count)i times %(time_unit)s"
+msgstr ""
+
+#: verify_human.html
+msgid "Human Verification"
+msgstr ""
+
+#: verify_human.html
+msgid "Please verify you are human to continue."
+msgstr ""
+
+#: verify_human.html
+msgid "Verify you are human"
+msgstr ""
+
+#: verify_human.html
+#, fuzzy
+msgid "Verification failed. Please try again."
+msgstr "E-mail de verificare trimis"
+
+#: verify_human.html
+msgid "Verifying..."
 msgstr ""
 
 #: viewpage.html
@@ -907,8 +916,7 @@ msgstr ""
 msgid "Borrow \"%(title)s\""
 msgstr ""
 
-#: ReadButton.html books/custom_carousel.html books/edit/edition.html
-#: type/list/embed.html widget.html
+#: ReadButton.html books/edit/edition.html type/list/embed.html widget.html
 msgid "Borrow"
 msgstr "Împrumută"
 
@@ -917,7 +925,7 @@ msgstr "Împrumută"
 msgid "Join waitlist for \"%(title)s\""
 msgstr ""
 
-#: LoanStatus.html books/custom_carousel.html widget.html
+#: LoanStatus.html widget.html
 msgid "Join Waitlist"
 msgstr ""
 
@@ -926,13 +934,13 @@ msgstr ""
 msgid "Learn more about \"%(title)s\" at OpenLibrary"
 msgstr ""
 
-#: check_ins/reading_goal_form.html widget.html
+#: reading_goals/reading_goal_form.html widget.html
 msgid "Learn More"
 msgstr "Află mai multe"
 
 #: widget.html
 #, python-format
-msgid "on <a target=\"_blank\" href=\"%(link)s\">openlibrary.org</a>"
+msgid "on <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"%(link)s\">openlibrary.org</a>"
 msgstr ""
 
 #: work_search.html
@@ -984,8 +992,7 @@ msgstr ""
 msgid "Checking Search Inside matches"
 msgstr ""
 
-#: account/reading_log.html search/authors.html search/subjects.html
-#: work_search.html
+#: account/reading_log.html search/authors.html search/lists.html search/subjects.html work_search.html
 #, python-format
 msgid "%(count)s hit"
 msgid_plural "%(count)s hits"
@@ -1003,9 +1010,7 @@ msgid "The Open Library Team"
 msgstr ""
 
 #: about/index.html
-msgid ""
-"Open Library is made possible because of a dedicated team of staff and over 100 "
-"volunteers from around the globe."
+msgid "Open Library is made possible because of a dedicated team of staff and over 100 volunteers from around the globe."
 msgstr ""
 
 #: about/index.html
@@ -1016,7 +1021,7 @@ msgstr ""
 msgid "Role:"
 msgstr "Rol:"
 
-#: about/index.html lib/nav_head.html
+#: about/index.html lib/nav_head.html type/tag/index.html
 msgid "All"
 msgstr "Toate"
 
@@ -1053,10 +1058,7 @@ msgid "Librarianship"
 msgstr ""
 
 #: about/index.html
-msgid ""
-"If you volunteer with Open Library and would like to be listed as part of the "
-"team, then complete the <a href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">Open "
-"Library team information form</a>."
+msgid "If you volunteer with Open Library and would like to be listed as part of the team, then complete the <a href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">Open Library team information form</a>."
 msgstr ""
 
 #: account/create.html openlibrary/plugins/upstream/forms.py
@@ -1072,6 +1074,10 @@ msgid "Username may only contain numbers, letters, - or _"
 msgstr ""
 
 #: account/create.html
+msgid "A qualifying program must be selected"
+msgstr ""
+
+#: account/create.html
 msgid "Sign Up to Open Library"
 msgstr ""
 
@@ -1080,9 +1086,7 @@ msgid "Sign Up"
 msgstr "Înscriere"
 
 #: account/create.html
-msgid ""
-"Get your free Open Library card and borrow digital books from the nonprofit "
-"Internet Archive"
+msgid "Get your free Open Library card and borrow digital books from the nonprofit Internet Archive"
 msgstr ""
 
 #: account/create.html type/author/view.html
@@ -1098,14 +1102,27 @@ msgid "screenname"
 msgstr ""
 
 #: account/create.html
+msgid "I want to receive news, announcements, and resources from the <a href=\"https://archive.org/\">Internet Archive</a>, the non-profit that runs Open Library."
+msgstr ""
+
+#: account/create.html
+msgid "I want to apply* for <a href=\"https://help.archive.org/help/program-overview/\" target=\"_blank\" rel=\"noopener noreferrer\">special print disability access</a> through a qualifying program."
+msgstr ""
+
+#: account/create.html
+msgid "Select qualifying program"
+msgstr ""
+
+#: account/create.html
+msgid "* Please use the email address associated with this qualifying program. You will receive an email after activation with next steps."
+msgstr ""
+
+#: account/create.html
 msgid "Sign Up with Email"
 msgstr ""
 
 #: account/create.html
-msgid ""
-"By signing up, you agree to the Internet Archive's <a class=\"ol-signup-"
-"form__link\" href=\"//archive.org/about/terms.php\" target=\"_blank\">Terms of "
-"Service</a>."
+msgid "By signing up, you agree to the Internet Archive's <a class=\"ol-signup-form__link\" href=\"//archive.org/about/terms.php\" target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
 msgstr ""
 
 #: account/create.html
@@ -1129,12 +1146,8 @@ msgid "Import from Goodreads"
 msgstr "Importă de la Goodreads"
 
 #: account/import.html
-msgid ""
-"For instructions on exporting data refer to: <a href=\"https://www.goodreads.com/"
-"review/import\">Goodreads Import/Export</a>"
-msgstr ""
-"Pentru instrucțiuni despre exportul de date, consultați: <a href=\"https://www."
-"goodreads.com/review/import\">Import/Export Goodreads</a>"
+msgid "For instructions on exporting data refer to: <a href=\"https://www.goodreads.com/review/import\">Goodreads Import/Export</a>"
+msgstr "Pentru instrucțiuni despre exportul de date, consultați: <a href=\"https://www.goodreads.com/review/import\">Import/Export Goodreads</a>"
 
 #: account/import.html
 msgid "File size limit 10MB and .csv file type only"
@@ -1153,8 +1166,9 @@ msgid "Download a copy of your reading log."
 msgstr "Descărcați o copie a jurnalului dumneavoastră de citire."
 
 #: account/import.html
-msgid "What is this?"
-msgstr "Ce este asta?"
+#, fuzzy
+msgid "What is a reading log?"
+msgstr "Jurnal de citire"
 
 #: account/import.html
 msgid "Download (.csv format)"
@@ -1281,13 +1295,10 @@ msgid "Leave the Waiting List"
 msgstr ""
 
 #: account/loans.html
-msgid ""
-"Are you sure you want to leave the waiting list of<br/><strong>TITLE</strong>?"
+msgid "Are you sure you want to leave the waiting list of<br/><strong>TITLE</strong>?"
 msgstr ""
 
-#: ProlificAuthors.html account/loans.html authors/index.html lists/showcase.html
-#: publishers/view.html search/authors.html search/publishers.html
-#: search/subjects.html
+#: ProlificAuthors.html account/loans.html authors/index.html lists/list_follow.html lists/showcase.html publishers/view.html search/authors.html search/publishers.html search/subjects.html
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
@@ -1340,12 +1351,8 @@ msgid "Leave the waiting list?"
 msgstr ""
 
 #: account/loans.html
-msgid ""
-"Looking for a book to borrow?  Check out our staff picks, or search for a book on "
-"a specific subject:"
-msgstr ""
-"Căutați să împrumutați o carte? Vizitați alegerile noastre recomandate sau "
-"căutați o carte pe un subiect specific:"
+msgid "Looking for a book to borrow?  Check out our staff picks, or search for a book on a specific subject:"
+msgstr "Căutați să împrumutați o carte? Vizitați alegerile noastre recomandate sau căutați o carte pe un subiect specific:"
 
 #: account/loans.html home/index.html
 msgid "Books We Love"
@@ -1363,9 +1370,11 @@ msgstr "Nu aveți nicio carte pe acest raft"
 msgid "My Loans"
 msgstr "Împrumuturile mele"
 
-#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
-#: my_books/dropdown_content.html my_books/primary_action.html
-#: openlibrary/plugins/upstream/mybooks.py search/sort_options.html
+#. Display name for the "already-read" reading log shelf used in page headings
+#. and breadcrumbs.
+#. Label for the reading log shelf for books the user has finished reading
+#. (bookshelf ID 3). Used as a button label and shelf name.
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html openlibrary/plugins/upstream/mybooks.py search/sort_options.html
 msgid "Already Read"
 msgstr "Deja citite"
 
@@ -1377,10 +1386,6 @@ msgstr "Acest cititor a ales să-și facă jurnalul de citire privat."
 #, python-format
 msgid "%(year_span)s reading goal"
 msgstr "Obiectiv de citire pentru %(year_span)s"
-
-#: account/mybooks.html account/sidebar.html
-msgid "Untitled list"
-msgstr "Listă fără titlu"
 
 #: account/mybooks.html
 msgid "View All Lists"
@@ -1394,8 +1399,7 @@ msgstr "Statisticile mele"
 msgid "My Reading Stats"
 msgstr "Statisticile mele de citire"
 
-#: account/mybooks.html account/sidebar.html books/mybooks_breadcrumb_select.html
-#: openlibrary/plugins/upstream/account.py
+#: account/mybooks.html account/sidebar.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
 msgid "Loan History"
 msgstr "Istoric împrumuturi"
 
@@ -1421,9 +1425,7 @@ msgstr ""
 
 #: account/not_verified.html
 #, python-format
-msgid ""
-"When you created your account, we sent an email to %(email)s that contained a "
-"link for you to verify your email address. We need you to click that link, please."
+msgid "When you created your account, we sent an email to %(email)s that contained a link for you to verify your email address. We need you to click that link, please."
 msgstr ""
 
 #: account/not_verified.html
@@ -1438,8 +1440,7 @@ msgstr ""
 msgid "Thanks!"
 msgstr "Mulțumesc!"
 
-#: BookByline.html FulltextSearchSuggestionItem.html SearchResultsWork.html
-#: account/notes.html account/observations.html
+#: BookByline.html FulltextSearchSuggestionItem.html SearchResultsWork.html account/notes.html account/observations.html
 msgid "Unknown author"
 msgstr "Autor necunoscut"
 
@@ -1455,8 +1456,7 @@ msgstr ""
 msgid "Publish date unknown"
 msgstr ""
 
-#: account/notes.html books/edition-sort.html books/works-show.html
-#: lists/export_as_html.html type/work/editions.html
+#: account/notes.html books/edition-sort.html lists/export_as_html.html type/work/editions.html
 msgid "Publisher unknown"
 msgstr ""
 
@@ -1486,10 +1486,7 @@ msgid "Notifications"
 msgstr ""
 
 #: account/notifications.html
-msgid ""
-"Notifications are connected to Lists at the moment. If one of the books on your "
-"list gets edited, or a new book comes into the catalog, we'll let you know, if "
-"you want."
+msgid "Notifications are connected to Lists at the moment. If one of the books on your list gets edited, or a new book comes into the catalog, we'll let you know, if you want."
 msgstr ""
 
 #: account/notifications.html
@@ -1504,13 +1501,11 @@ msgstr "Nu, mulțumesc"
 msgid "Yes! Please!"
 msgstr "Da! Vă rog!"
 
-#: EditButtons.html account/notifications.html account/privacy.html admin/block.html
-#: admin/spamwords.html covers/manage.html
+#: EditButtons.html account/notifications.html account/privacy.html admin/block.html admin/spamwords.html covers/manage.html
 msgid "Save"
 msgstr "Salvează"
 
-#: EditionNavBar.html account/observations.html books/mybooks_breadcrumb_select.html
-#: openlibrary/plugins/upstream/mybooks.py
+#: EditionNavBar.html account/observations.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 msgid "Reviews"
 msgstr "Recenzii"
 
@@ -1535,14 +1530,11 @@ msgid "Privacy & Content Moderation Settings"
 msgstr ""
 
 #: account/privacy.html
-msgid ""
-"Would you like to make your <a href=\"/account/books\">Reading Log</a> public?"
+msgid "Would you like to make your <a href=\"/account/books\">Reading Log</a> public?"
 msgstr ""
 
 #: account/privacy.html
-msgid ""
-"This will enable others to see what books you want to read, are reading, or have "
-"already read. Patrons with reading logs set to public may be followed."
+msgid "This will enable others to see what books you want to read, are reading, stopped reading, or have already read. Patrons with reading logs set to public may be followed."
 msgstr ""
 
 #: account/privacy.html admin/people/view.html
@@ -1558,8 +1550,7 @@ msgid "Enable Safe Mode?"
 msgstr ""
 
 #: account/privacy.html
-msgid ""
-"Safe Mode blurs book covers that have been flagged as having sensitive imagery."
+msgid "Safe Mode blurs book covers that have been flagged as having sensitive imagery."
 msgstr ""
 
 #: account/reading_log.html
@@ -1569,9 +1560,7 @@ msgstr ""
 
 #: account/reading_log.html
 #, python-format
-msgid ""
-"%(username)s is reading %(total)d books. Join %(username)s on OpenLibrary.org and "
-"tell the world what you're reading."
+msgid "%(username)s is reading %(total)d books. Join %(username)s on OpenLibrary.org and tell the world what you're reading."
 msgstr ""
 
 #: account/reading_log.html
@@ -1581,9 +1570,17 @@ msgstr ""
 
 #: account/reading_log.html
 #, python-format
-msgid ""
-"%(username)s wants to read %(total)d books. Join %(username)s on OpenLibrary.org "
-"and share the books that you'll soon be reading!"
+msgid "%(username)s wants to read %(total)d books. Join %(username)s on OpenLibrary.org and share the books that you'll soon be reading!"
+msgstr ""
+
+#: account/reading_log.html
+#, python-format
+msgid "Books %(username)s stopped reading"
+msgstr ""
+
+#: account/reading_log.html
+#, python-format
+msgid "%(username)s stopped reading %(total)d books. Join %(username)s on OpenLibrary.org to share your own reading updates!"
 msgstr ""
 
 #: account/reading_log.html
@@ -1593,9 +1590,7 @@ msgstr ""
 
 #: account/reading_log.html
 #, python-format
-msgid ""
-"%(username)s has read %(total)d books in %(year)d. Join %(username)s on "
-"OpenLibrary.org and tell the world about the books that you care about."
+msgid "%(username)s has read %(total)d books in %(year)d. Join %(username)s on OpenLibrary.org and tell the world about the books that you care about."
 msgstr ""
 
 #: account/reading_log.html
@@ -1605,9 +1600,7 @@ msgstr ""
 
 #: account/reading_log.html
 #, python-format
-msgid ""
-"%(username)s has read %(total)d books. Join %(username)s on OpenLibrary.org and "
-"tell the world about the books that you care about."
+msgid "%(username)s has read %(total)d books. Join %(username)s on OpenLibrary.org and tell the world about the books that you care about."
 msgstr ""
 
 #: account/reading_log.html
@@ -1624,16 +1617,14 @@ msgstr ""
 msgid "Search your reading log"
 msgstr ""
 
-#: account/reading_log.html search/sort_options.html
-msgid "Sorting by"
+#: account/reading_log.html type/author/view.html
+#, python-format
+msgid "— Show <a href=\"%(url)s\">only ebooks</a>?"
 msgstr ""
 
 #: account/reading_log.html
-msgid "Date Added (newest)"
-msgstr ""
-
-#: account/reading_log.html
-msgid "Date Added (oldest)"
+#, python-format
+msgid "— Show <a href=\"%(url)s\">everything</a> in this shelf?"
 msgstr ""
 
 #: account/reading_log.html
@@ -1654,22 +1645,15 @@ msgid "You haven't added any books to this shelf yet."
 msgstr "Momentan nu ați adăugat nicio carte pe acest raft."
 
 #: account/reading_log.html
-msgid ""
-"<a href=\"/search\">Search for a book</a> to add to your reading log. <a href=\"/"
-"help/faq/reading-log\">Learn more</a> about the reading log."
-msgstr ""
-"<a href=\"/search\">Căutați o carte</a> pentru a o adăuga la jurnalul "
-"dumneavoastră de citire. <a href=\"/help/faq/reading-log\">Aflați mai multe</a> "
-"despre jurnalul de citire."
+msgid "<a href=\"/search\">Search for a book</a> to add to your reading log. <a href=\"/help/faq/reading-log\">Learn more</a> about the reading log."
+msgstr "<a href=\"/search\">Căutați o carte</a> pentru a o adăuga la jurnalul dumneavoastră de citire. <a href=\"/help/faq/reading-log\">Aflați mai multe</a> despre jurnalul de citire."
 
 #: account/reading_log.html
-msgid ""
-"There are no recent books in your feed. When you follow public accounts, their "
-"book updates will appear here."
-msgstr ""
-"Nu există cărți recente în fluxul dumneavoastră. Când urmăriți conturi publice, "
-"actualizările lor de carte vor apărea aici."
+msgid "There are no recent books in your feed. When you follow public accounts, their book updates will appear here."
+msgstr "Nu există cărți recente în fluxul dumneavoastră. Când urmăriți conturi publice, actualizările lor de carte vor apărea aici."
 
+#. Display name for the "want-to-read" reading log shelf used in page headings
+#. and breadcrumbs.
 #: account/readinglog_shelf_name.html
 msgid "Want To Read"
 msgstr "Doresc să citesc"
@@ -1685,13 +1669,8 @@ msgstr "Cărțile mele"
 
 #: account/readinglog_stats.html
 #, python-format
-msgid ""
-"Displaying stats about <strong>%(works_count)d</strong> books. Note all charts "
-"show only the top 20 bars. Note reading log stats are private."
-msgstr ""
-"Afișează statistici despre <strong>%(works_count)d</strong> cărți. Notă: Toate "
-"graficele afișează doar primele 20 de bare. Notă: Statisticile jurnalului de "
-"citire sunt private."
+msgid "Displaying stats about <strong>%(works_count)d</strong> books. Note all charts show only the top 20 bars. Note reading log stats are private."
+msgstr "Afișează statistici despre <strong>%(works_count)d</strong> cărți. Notă: Toate graficele afișează doar primele 20 de bare. Notă: Statisticile jurnalului de citire sunt private."
 
 #: account/readinglog_stats.html
 msgid "Author Stats"
@@ -1714,22 +1693,22 @@ msgid "Works by Author Country of Birth"
 msgstr "Opere după țara de naștere a autorului"
 
 #: account/readinglog_stats.html
-msgid ""
-"Demographic statistics powered by <a href=\"https://www.wikidata.org/\">Wikidata</"
-"a>. Here's a <a id=\"wd-query-sample\" href=\"\">sample</a> of the query used. "
-"<br />Improve these stats by adding the Wikidata author identifier following <a "
-"href=\"https://openlibrary.org/help/faq/editing.en#author-identifiers-"
-"purpose\">these instructions</a>."
-msgstr ""
-"Statistici demografice furnizate de <a href=\"https://www.wikidata.org/"
-"\">Wikidata</a>. Iată un <a id=\"wd-query-sample\" href=\"\">exemplu</a> de "
-"interogare utilizată. <br /> Îmbunătățiți aceste statistici prin adăugarea "
-"identificatorului Wikidata al autorului, urmând <a href=\"https://openlibrary.org/"
-"help/faq/editing.en#author-identifiers-purpose\">aceste instrucțiuni</a>."
+msgid "Demographic statistics powered by <a href=\"https://www.wikidata.org/\">Wikidata</a>. Here's a <a id=\"wd-query-sample\" href=\"\">sample</a> of the query used. <br />Improve these stats by adding the Wikidata author identifier following <a href=\"https://openlibrary.org/help/faq/editing.en#author-identifiers-purpose\">these instructions</a>."
+msgstr "Statistici demografice furnizate de <a href=\"https://www.wikidata.org/\">Wikidata</a>. Iată un <a id=\"wd-query-sample\" href=\"\">exemplu</a> de interogare utilizată. <br /> Îmbunătățiți aceste statistici prin adăugarea identificatorului Wikidata al autorului, urmând <a href=\"https://openlibrary.org/help/faq/editing.en#author-identifiers-purpose\">aceste instrucțiuni</a>."
 
 #: account/readinglog_stats.html
 msgid "Work Stats"
 msgstr "Statistici despre opere"
+
+#: account/readinglog_stats.html
+#, fuzzy
+msgid "Works by Decade Published"
+msgstr "Opere după perioadă de timp"
+
+#: account/readinglog_stats.html
+#, fuzzy
+msgid "Works by Century Published"
+msgstr "Publicat pentru prima dată"
 
 #: account/readinglog_stats.html
 msgid "Works by Subject"
@@ -1755,8 +1734,7 @@ msgstr "Lucrări care se potrivesc"
 msgid "Click on a bar to see matching works"
 msgstr "Faceți clic pe o bară pentru a vedea lucrările care se potrivesc"
 
-#: account/sidebar.html books/mybooks_breadcrumb_select.html
-#: openlibrary/plugins/upstream/mybooks.py
+#: account/sidebar.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 msgid "My Feed"
 msgstr "Fluxul meu"
 
@@ -1778,20 +1756,21 @@ msgstr "Jurnal de citire"
 msgid "My lists"
 msgstr "Listele mele"
 
-#: EditionNavBar.html SearchNavigation.html account/sidebar.html lib/nav_head.html
-#: lists/home.html lists/widget.html recentchanges/index.html type/edition/view.html
-#: type/list/embed.html type/user/view.html type/work/view.html
+#: EditionNavBar.html SearchNavigation.html account/sidebar.html lib/nav_head.html lists/home.html recentchanges/index.html type/edition/view.html type/list/embed.html type/user/view.html type/work/view.html
 msgid "Lists"
 msgstr "Liste"
 
-#: account/sidebar.html type/edition/view.html type/user/view.html
-#: type/work/view.html
+#: account/sidebar.html type/user/view.html
 msgid "See All"
 msgstr "Vedețile pe toate"
 
-#: account/sidebar.html type/list/edit.html
+#: account/sidebar.html type/list/edit.html type/series/edit.html
 msgid "Create a list"
 msgstr "Creați o listă"
+
+#: account/sidebar.html
+msgid "Untitled list"
+msgstr "Listă fără titlu"
 
 #: account/topmenu.html
 msgid "Import & Export"
@@ -1806,22 +1785,15 @@ msgstr "Setări de confidențialitate: %(public)s"
 msgid "Verification email sent"
 msgstr "E-mail de verificare trimis"
 
-#: account/password/reset_success.html account/verify.html
-#: account/verify/activated.html account/verify/success.html
-#: openlibrary/plugins/upstream/account.py
+#: account/password/reset_success.html account/verify.html account/verify/activated.html account/verify/success.html
 #, python-format
 msgid "Hi, %(user)s"
 msgstr "Salut, %(user)s"
 
 #: account/verify.html
 #, python-format
-msgid ""
-"We’ve sent an email to %(email)s containing a link to verify your account. Click/"
-"tap on the link to finish creating your Internet Archive account."
-msgstr ""
-"Am trimis un e-mail la %(email)s care conține un link pentru a verifica contul "
-"dumneavoastră. Faceți clic pe el pentru a finaliza crearea contului dumneavoastră "
-"Internet Archive."
+msgid "We’ve sent an email to %(email)s containing a link to verify your account. Click/tap on the link to finish creating your Internet Archive account."
+msgstr "Am trimis un e-mail la %(email)s care conține un link pentru a verifica contul dumneavoastră. Faceți clic pe el pentru a finaliza crearea contului dumneavoastră Internet Archive."
 
 #: account/verify.html
 msgid "Then, come back to Open Library and find some great books!"
@@ -1839,22 +1811,17 @@ msgstr "Urmăresc"
 msgid "Followers"
 msgstr "Urmăritori"
 
-#: account/view.html type/edition/modal_links.html
-#: type/edition/title_and_author.html
+#: account/view.html type/edition/modal_links.html type/edition/title_and_author.html
 msgid "Share"
 msgstr "Distribuie"
 
 #: account/view.html
 msgid "Your book notes are private and cannot be viewed by other patrons."
-msgstr ""
-"Notițele dumneavoastră de carte sunt private și nu pot fi vizualizate de alți "
-"utilizatori."
+msgstr "Notițele dumneavoastră de carte sunt private și nu pot fi vizualizate de alți utilizatori."
 
 #: account/view.html
 msgid "Your book reviews will be shared anonymously with other patrons."
-msgstr ""
-"Recenziile dumneavoastră la cărți vor fi distribuite în mod anonim altor "
-"utilizatori."
+msgstr "Recenziile dumneavoastră la cărți vor fi distribuite în mod anonim altor utilizatori."
 
 #: account/yrg_banner.html
 #, python-format
@@ -1870,9 +1837,7 @@ msgid "Forgot Your Internet Archive Email?"
 msgstr ""
 
 #: account/email/forgot-ia.html
-msgid ""
-"Please enter your Open Library email and password, and we’ll retrieve your "
-"Archive.org email."
+msgid "Please enter your Open Library email and password, and we’ll retrieve your Archive.org email."
 msgstr ""
 
 #: account/email/forgot-ia.html
@@ -1924,9 +1889,7 @@ msgid "Password Reset Successful"
 msgstr ""
 
 #: account/password/reset_success.html
-msgid ""
-"Your password has been updated. Please <a href='/account/login?redirect=/'>log in "
-"to continue</a>."
+msgid "Your password has been updated. Please <a href='/account/login?redirect=/'>log in to continue</a>."
 msgstr ""
 
 #: account/password/sent.html
@@ -1935,10 +1898,43 @@ msgstr ""
 
 #: account/password/sent.html
 #, python-format
-msgid ""
-"We've sent an email to %(email)s with a reminder of your username and "
-"instructions to help you reset your Open Library password. Please check your "
-"inbox for a note from us."
+msgid "We've sent an email to %(email)s with a reminder of your username and instructions to help you reset your Open Library password. Please check your inbox for a note from us."
+msgstr ""
+
+#: account/security/check_email.html
+msgid "Account Security Check — 2026-04-28T18Z"
+msgstr ""
+
+#: account/security/check_email.html
+msgid "Account Security Check"
+msgstr ""
+
+#: account/security/check_email.html
+msgid "Incident date: 2026-04-28T18Z"
+msgstr ""
+
+#: account/security/check_email.html
+msgid "Check whether your Open Library account was in a set of accounts requiring attention."
+msgstr ""
+
+#: account/security/check_email.html
+msgid "Please <a href=\"/account/login?redirect=/account/security/2026-04-28T18\">log in</a> to check whether your account was affected."
+msgstr ""
+
+#: account/security/check_email.html
+msgid "Your account is in the affected set."
+msgstr ""
+
+#: account/security/check_email.html
+msgid "Your account was found in our affected accounts list. Please review any recent communications from Open Library and consider updating your password."
+msgstr ""
+
+#: account/security/check_email.html
+msgid "Your account is <em>not</em> in the affected set."
+msgstr ""
+
+#: account/security/check_email.html
+msgid "Your account was <em>not</em> found in the affected accounts list. No action is required."
 msgstr ""
 
 #: account/verify/activated.html
@@ -1947,9 +1943,7 @@ msgstr ""
 
 #: account/verify/activated.html
 #, python-format
-msgid ""
-"Your account has been activated already. Please <a href=\"%s\">log in to "
-"continue</a>."
+msgid "Your account has been activated already. Please <a href=\"%s\">log in to continue</a>."
 msgstr ""
 
 #: account/verify/failed.html
@@ -1957,9 +1951,7 @@ msgid "Email Verification Failed"
 msgstr ""
 
 #: account/verify/failed.html
-msgid ""
-"Your email address couldn't be verified. Your verification link seems invalid or "
-"expired."
+msgid "Your email address couldn't be verified. Your verification link seems invalid or expired."
 msgstr ""
 
 #: account/verify/failed.html
@@ -1980,9 +1972,7 @@ msgstr ""
 
 #: account/verify/success.html
 #, python-format
-msgid ""
-"Yay! Your email address has been verified. Please <a href='%s'>log in to "
-"continue</a>."
+msgid "Yay! Your email address has been verified. Please <a href='%s'>log in to continue</a>."
 msgstr ""
 
 #: admin/attach_debugger.html
@@ -2012,9 +2002,11 @@ msgstr ""
 
 #: admin/block.html
 #, python-format
-msgid ""
-"IP address %(address)s has been added to the textarea. Please click Save to block "
-"that IP."
+msgid "IP address %(address)s has been added to the textarea. Please click Save to block that IP."
+msgstr ""
+
+#: admin/block.html
+msgid "Blocked IP Addresses"
 msgstr ""
 
 #: admin/graphs.html
@@ -2045,13 +2037,11 @@ msgstr ""
 msgid "Page"
 msgstr ""
 
-#: admin/imports-add.html admin/imports.html admin/imports_by_date.html
-#: admin/menu.html
+#: admin/imports-add.html admin/imports.html admin/imports_by_date.html admin/menu.html
 msgid "Imports"
 msgstr ""
 
-#: admin/imports-add.html books/add.html books/edit/edition.html
-#: books/edit/excerpts.html covers/change.html type/tag/form.html
+#: admin/imports-add.html books/add.html books/edit/edition.html books/edit/excerpts.html covers/change.html type/tag/form.html
 msgid "Add"
 msgstr ""
 
@@ -2063,9 +2053,7 @@ msgstr ""
 msgid "Please add IA identifiers to be imported, one per line."
 msgstr ""
 
-#: admin/imports-add.html admin/inspect/store.html admin/ip/view.html
-#: admin/people/edits.html admin/permissions.html check_ins/check_in_form.html
-#: check_ins/reading_goal_form.html
+#: admin/imports-add.html admin/inspect/store.html admin/ip/view.html admin/people/edits.html admin/permissions.html my_books/check_ins/check_in_form.html reading_goals/reading_goal_form.html
 msgid "Submit"
 msgstr "Salvează"
 
@@ -2077,7 +2065,7 @@ msgstr ""
 msgid "You need to have JavaScript turned on to see the nifty chart!"
 msgstr ""
 
-#: admin/imports.html admin/imports_by_date.html site/stats.html
+#: admin/imports.html admin/imports_by_date.html admin/pd_dashboard.html site/stats.html
 msgid "Summary"
 msgstr ""
 
@@ -2130,7 +2118,7 @@ msgstr ""
 msgid "Imported Time"
 msgstr ""
 
-#: admin/imports_by_date.html admin/index.html
+#: admin/imports_by_date.html admin/index.html admin/pd_dashboard.html
 msgid "Total"
 msgstr ""
 
@@ -2152,6 +2140,10 @@ msgstr ""
 
 #: admin/imports_by_date.html
 msgid "Items"
+msgstr ""
+
+#: admin/index.html
+msgid "<span class=\"login-counts\">0</span> patrons have logged in at least once over the past 30 days."
 msgstr ""
 
 #: admin/index.html
@@ -2290,20 +2282,24 @@ msgstr "Împrumuturi, graficul ultimelor 3 luni"
 msgid "Borrows, last 2 years graph"
 msgstr "Împrumuturi, graficul ultimilor 2 ani"
 
+#: admin/index.html
+#, fuzzy
+msgid "Unique Logins"
+msgstr "Vizitatori unici"
+
+#: admin/index.html
+msgid "Gathering login statistics..."
+msgstr ""
+
 #: admin/loans_table.html
 msgid "BookReader"
 msgstr ""
 
-#: admin/loans_table.html book_providers/cita_press_download_options.html
-#: book_providers/ia_download_options.html
-#: book_providers/openstax_download_options.html
-#: book_providers/wikisource_download_options.html books/edit/edition.html
+#: admin/loans_table.html book_providers/cita_press_download_options.html book_providers/ia_download_options.html book_providers/openstax_download_options.html book_providers/wikisource_download_options.html books/edit/edition.html
 msgid "PDF"
 msgstr "PDF"
 
-#: admin/loans_table.html book_providers/gutenberg_download_options.html
-#: book_providers/ia_download_options.html
-#: book_providers/standard_ebooks_download_options.html books/edit/edition.html
+#: admin/loans_table.html book_providers/gutenberg_download_options.html book_providers/ia_download_options.html book_providers/standard_ebooks_download_options.html books/edit/edition.html
 msgid "ePub"
 msgstr ""
 
@@ -2319,9 +2315,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: RecentChanges.html RecentChangesUsers.html admin/ip/view.html
-#: admin/loans_table.html admin/people/edits.html recentchanges/render.html
-#: recentchanges/updated_records.html
+#: RecentChanges.html RecentChangesUsers.html admin/ip/view.html admin/loans_table.html admin/people/edits.html recentchanges/render.html recentchanges/updated_records.html
 msgid "What"
 msgstr "Ce"
 
@@ -2344,10 +2338,12 @@ msgstr ""
 msgid "Admin Center"
 msgstr ""
 
-#: RelatedSubjects.html SubjectTags.html admin/menu.html admin/people/index.html
-#: admin/people/view.html openlibrary/plugins/worksearch/code.py
-#: type/author/view.html type/list/view_body.html
+#: RelatedSubjects.html SubjectTags.html admin/menu.html admin/people/index.html admin/people/view.html openlibrary/plugins/worksearch/code.py type/author/view.html type/list/view_body.html
 msgid "People"
+msgstr ""
+
+#: admin/menu.html
+msgid "PD Access Requests"
 msgstr ""
 
 #: admin/menu.html
@@ -2373,6 +2369,33 @@ msgstr ""
 #: admin/menu.html
 msgid "Inspect memcache"
 msgstr ""
+
+#: admin/pd_dashboard.html
+msgid "Print Disability Access Requests"
+msgstr ""
+
+#: admin/pd_dashboard.html
+msgid "Breakdown by Qualifying Authority"
+msgstr ""
+
+#: admin/pd_dashboard.html
+#, fuzzy
+msgid "PDA"
+msgstr "PDF"
+
+#: admin/pd_dashboard.html
+#, fuzzy
+msgid "Emailed"
+msgstr "E-mail"
+
+#: admin/pd_dashboard.html
+msgid "Fulfilled"
+msgstr ""
+
+#: admin/pd_dashboard.html
+#, fuzzy
+msgid "Totals"
+msgstr "Discuții despre cărți"
 
 #: admin/permissions.html
 msgid "[Admin Center] Site Permissions"
@@ -2407,9 +2430,7 @@ msgid "Update permissions"
 msgstr ""
 
 #: admin/permissions.html
-msgid ""
-"This updates  and  fields of /, /works, /books and /authors records in the "
-"database."
+msgid "This updates \"permission\" and \"child_permission\" fields of /, /works, /books and /authors records in the database."
 msgstr ""
 
 #: admin/solr.html
@@ -2425,9 +2446,7 @@ msgid "Example:"
 msgstr ""
 
 #: admin/solr.html
-msgid ""
-"On update, these keys will be added to solr update queue and it'll take about 15 "
-"minutes for them to get reindexed in Solr."
+msgid "On update, these keys will be added to solr update queue and it'll take about 15 minutes for them to get reindexed in Solr."
 msgstr ""
 
 #: admin/solr.html
@@ -2438,22 +2457,16 @@ msgstr ""
 msgid "Write one entry per line"
 msgstr ""
 
-#: admin/solr.html
-msgid "Update"
-msgstr ""
-
 #: admin/spamwords.html
 msgid "[Admin Center] Spam Words"
 msgstr ""
 
 #: admin/spamwords.html
-msgid ""
-"Please enter the SPAM regular expressions in the textarea below, one per line."
+msgid "Please enter the SPAM regular expressions in the textarea below, one per line."
 msgstr ""
 
 #: admin/spamwords.html
-msgid ""
-"Be sure to escape any meta characters that are meant to be character literals."
+msgid "Be sure to escape any meta characters that are meant to be character literals."
 msgstr ""
 
 #: admin/spamwords.html
@@ -2461,9 +2474,7 @@ msgid "If you are adding a domain, prepend the following to the domain:"
 msgstr ""
 
 #: admin/spamwords.html
-msgid ""
-"For example, if you want to prevent edits containing the domain <code>t.co</"
-"code>, add <code>(\b|https://|http://)t\\.co</code> to the spamwords list."
+msgid "For example, if you want to prevent edits containing the domain <code>t.co</code>, add <code>(|https://|http://)t\\.co</code> to the spamwords list."
 msgstr ""
 
 #: admin/spamwords.html
@@ -2472,6 +2483,44 @@ msgstr ""
 
 #: admin/spamwords.html
 msgid "Please enter domains to blacklist in the textarea below, one per line."
+msgstr ""
+
+#: admin/sync.html
+msgid "Sync"
+msgstr ""
+
+#: admin/sync.html
+msgid "Sync the metadata of various types of Open Library items (e.g. lists, subjects, works) with Archive.org."
+msgstr ""
+
+#: admin/sync.html
+msgid "Add Works to Staff Picks"
+msgstr ""
+
+#: admin/sync.html
+msgid "This utility will add your work to an Open Library list called `Staff Picks` under the `openlibrary` user. It will then take the added work and explode it into a list of all its readable editions. For each Open Library edition, a metadata field called `openlibrary_subject` will be injected into the archive.org metadata of the edition's corresponding archive.org item."
+msgstr ""
+
+#: admin/sync.html
+msgid "add"
+msgstr ""
+
+#: admin/sync.html
+#, fuzzy
+msgid "remove"
+msgstr "Recenzii"
+
+#: admin/sync.html
+#, fuzzy
+msgid "Update edition"
+msgstr "o ediție"
+
+#: admin/sync.html
+msgid "Updates an edition on archive.org by writing in its latest  openlibrary_edition and openlibrary_work identifier values"
+msgstr ""
+
+#: admin/sync.html
+msgid "TODO"
 msgstr ""
 
 #: admin/inspect/memcache.html
@@ -2483,15 +2532,11 @@ msgid "Inspect Memcache"
 msgstr ""
 
 #: admin/inspect/memcache.html
-msgid ""
-"Add one memcache key per line in the text area. Each key must include a '-' as "
-"the last character."
+msgid "Add one memcache key per line in the text area. Each key must include a '-' as the last character."
 msgstr ""
 
 #: admin/inspect/memcache.html
-msgid ""
-"For example, <code>observations-</code> should be entered in the text area if the "
-"key is <code>observations</code>."
+msgid "For example, <code>observations-</code> should be entered in the text area if the key is <code>observations</code>."
 msgstr ""
 
 #: admin/inspect/memcache.html
@@ -2608,8 +2653,7 @@ msgstr ""
 msgid "Please select the changesets to revert."
 msgstr ""
 
-#: RecentChanges.html admin/ip/view.html admin/people/edits.html
-#: recentchanges/render.html
+#: RecentChanges.html admin/ip/view.html admin/people/edits.html recentchanges/render.html
 msgid "When you see numbers here, that's the IP address of the anonymous editor"
 msgstr ""
 
@@ -2619,47 +2663,11 @@ msgid "Reverted by %(revert_author)s"
 msgstr ""
 
 #: EditButtons.html admin/ip/view.html admin/people/edits.html
-msgid ""
-"Please, leave a short note about what you changed: <span class=\"small "
-"gray\">(Optional, but very useful!)</span>"
+msgid "Please, leave a short note about what you changed: <span class=\"small gray\">(Optional, but very useful!)</span>"
 msgstr ""
 
 #: admin/ip/view.html admin/people/edits.html
 msgid "Reverted spam"
-msgstr ""
-
-#: admin/memory/index.html
-msgid "Memory Status"
-msgstr ""
-
-#: admin/memory/index.html
-msgid "type"
-msgstr ""
-
-#: admin/memory/index.html
-msgid "count"
-msgstr ""
-
-#: admin/memory/index.html
-msgid "mark"
-msgstr ""
-
-#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
-#: admin/memory/index.html recentchanges/default/path.html
-#: recentchanges/updated_records.html
-msgid "diff"
-msgstr ""
-
-#: admin/memory/index.html
-msgid "Prev"
-msgstr ""
-
-#: admin/memory/object.html
-msgid "Referents"
-msgstr ""
-
-#: admin/memory/object.html
-msgid "Referrers"
 msgstr ""
 
 #: admin/people/edits.html
@@ -2673,16 +2681,6 @@ msgstr ""
 
 #: admin/people/edits.html
 msgid "edits"
-msgstr ""
-
-#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
-#: admin/people/edits.html recentchanges/render.html
-msgid "Older"
-msgstr ""
-
-#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
-#: admin/people/edits.html recentchanges/render.html
-msgid "Newer"
 msgstr ""
 
 #: admin/people/index.html
@@ -2752,9 +2750,7 @@ msgstr ""
 
 #: admin/people/view.html
 #, python-format
-msgid ""
-"Activated on <span class=\"time\">%(date)s</span> from <a href=\"/admin/ip/"
-"%(ip)s\">%(ip)s</a>."
+msgid "Activated on <span class=\"time\">%(date)s</span> from <a href=\"/admin/ip/%(ip)s\">%(ip)s</a>."
 msgstr ""
 
 #: admin/people/view.html
@@ -2763,19 +2759,6 @@ msgstr ""
 
 #: admin/people/view.html
 msgid "activate account"
-msgstr ""
-
-#: admin/people/view.html
-#, python-format
-msgid "Activation link expiring on <span class=\"time\">%(date)s.</span>"
-msgstr ""
-
-#: admin/people/view.html
-msgid "Activation link expired"
-msgstr ""
-
-#: admin/people/view.html
-msgid "Resend activation link"
 msgstr ""
 
 #: CreateListModal.html admin/people/view.html my_books/dropdown_content.html
@@ -2834,8 +2817,7 @@ msgstr ""
 msgid "Anonymize Account"
 msgstr ""
 
-#: admin/people/view.html books/mybooks_breadcrumb_select.html
-#: openlibrary/plugins/upstream/account.py type/user/view.html
+#: admin/people/view.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py type/user/view.html
 msgid "Loans"
 msgstr "Împrumuturi"
 
@@ -2868,8 +2850,7 @@ msgstr ""
 msgid "None found"
 msgstr ""
 
-#: SearchNavigation.html authors/index.html lib/nav_foot.html merge/authors.html
-#: publishers/view.html
+#: SearchNavigation.html authors/index.html lib/nav_foot.html merge/authors.html publishers/view.html
 msgid "Authors"
 msgstr "Autori"
 
@@ -2877,9 +2858,7 @@ msgstr "Autori"
 msgid "Search for an Author"
 msgstr ""
 
-#: authors/index.html lib/nav_head.html lists/home.html publishers/index.html
-#: publishers/notfound.html publishers/view.html search/advancedsearch.html
-#: search/publishers.html search/searchbox.html type/local_id/view.html
+#: authors/index.html lib/nav_head.html lists/home.html publishers/index.html publishers/notfound.html publishers/view.html search/advancedsearch.html search/publishers.html search/searchbox.html type/local_id/view.html
 msgid "Search"
 msgstr "Căutare"
 
@@ -2906,14 +2885,7 @@ msgstr ""
 msgid "Died"
 msgstr ""
 
-#: book_providers/cita_press_download_options.html
-#: book_providers/gutenberg_download_options.html
-#: book_providers/ia_download_options.html
-#: book_providers/librivox_download_options.html
-#: book_providers/openstax_download_options.html
-#: book_providers/runeberg_download_options.html
-#: book_providers/standard_ebooks_download_options.html
-#: book_providers/wikisource_download_options.html
+#: book_providers/cita_press_download_options.html book_providers/gutenberg_download_options.html book_providers/ia_download_options.html book_providers/librivox_download_options.html book_providers/openstax_download_options.html book_providers/runeberg_download_options.html book_providers/standard_ebooks_download_options.html book_providers/wikisource_download_options.html
 msgid "Download Options"
 msgstr ""
 
@@ -2925,45 +2897,11 @@ msgstr ""
 msgid "More at Cita Press"
 msgstr ""
 
-#: book_providers/cita_press_read_button.html
-msgid "Read eBook from Cita Press"
-msgstr ""
-
-#: book_providers/cita_press_read_button.html
-msgid ""
-"This book is available from <a href=\"https://citapress.org/\">Cita Press</a>. "
-"Cita Press is a trusted book provider of works written by women, pairing "
-"contemporary authors and designers with open access texts to make carefully "
-"designed books available for free and open source."
-msgstr ""
-
-#: book_providers/cita_press_read_button.html book_providers/direct_read_button.html
-#: book_providers/gutenberg_read_button.html
-#: book_providers/librivox_read_button.html book_providers/openstax_read_button.html
-#: book_providers/runeberg_read_button.html
-#: book_providers/standard_ebooks_read_button.html
-#: book_providers/wikisource_read_button.html
-msgid "Learn more"
-msgstr ""
-
-#: book_providers/direct_read_button.html
-msgid "Read free online"
-msgstr ""
-
-#: book_providers/direct_read_button.html
-#, python-format
-msgid ""
-"This book is freely available from <a href=\"%s\">%s</a>, an external third-party "
-"book provider."
-msgstr ""
-
 #: book_providers/gutenberg_download_options.html
 msgid "Download an HTML from Project Gutenberg"
 msgstr ""
 
-#: book_providers/gutenberg_download_options.html
-#: book_providers/runeberg_download_options.html
-#: book_providers/standard_ebooks_download_options.html type/list/exports.html
+#: book_providers/gutenberg_download_options.html book_providers/runeberg_download_options.html book_providers/standard_ebooks_download_options.html type/list/exports.html
 msgid "HTML"
 msgstr "HTML"
 
@@ -2971,8 +2909,7 @@ msgstr "HTML"
 msgid "Download a text version from Project Gutenberg"
 msgstr ""
 
-#: book_providers/gutenberg_download_options.html
-#: book_providers/ia_download_options.html
+#: book_providers/gutenberg_download_options.html book_providers/ia_download_options.html
 msgid "Plain text"
 msgstr ""
 
@@ -2990,18 +2927,6 @@ msgstr "Kindle"
 
 #: book_providers/gutenberg_download_options.html
 msgid "More at Project Gutenberg"
-msgstr ""
-
-#: book_providers/gutenberg_read_button.html
-msgid "Read eBook from Project Gutenberg"
-msgstr ""
-
-#: book_providers/gutenberg_read_button.html
-msgid ""
-"This book is available from <a href=\"https://www.gutenberg.org/\">Project "
-"Gutenberg</a>. Project Gutenberg is a trusted book provider of classic ebooks, "
-"supporting thousands of volunteers in the creation and distribution of over "
-"60,000 free eBooks."
 msgstr ""
 
 #: book_providers/ia_download_options.html
@@ -3052,21 +2977,6 @@ msgstr ""
 msgid "More at LibriVox"
 msgstr ""
 
-#: book_providers/librivox_read_button.html
-msgid "Listen to a reading from LibriVox"
-msgstr ""
-
-#: book_providers/librivox_read_button.html
-msgid "Audiobook"
-msgstr ""
-
-#: book_providers/librivox_read_button.html
-msgid ""
-"This book is available from <a href=\"https://librivox.org/\">LibriVox</a>. "
-"LibriVox is a trusted book provider of public domain audiobooks, narrated by "
-"volunteers, distributed for free on the internet."
-msgstr ""
-
 #: book_providers/openstax_download_options.html
 msgid "Download PDF from OpenStax"
 msgstr ""
@@ -3075,16 +2985,18 @@ msgstr ""
 msgid "More at OpenStax"
 msgstr ""
 
-#: book_providers/openstax_read_button.html
-msgid "Read eBook from OpenStax"
+#: book_providers/read_button.html
+#, python-format
+msgid "Listen to a reading from %s"
 msgstr ""
 
-#: book_providers/openstax_read_button.html
-msgid ""
-"This book is available from <a href=\"https://www.openstax.org/\">OpenStax</a>. "
-"OpenStax is a trusted book provider and a 501(c)(3) nonprofit charitable "
-"corporation dedicated to providing free high-quality, peer-reviewed, openly "
-"licensed textbooks online."
+#: book_providers/read_button.html
+msgid "Audiobook"
+msgstr ""
+
+#: book_providers/read_button.html
+#, python-format
+msgid "Read free online from %s"
 msgstr ""
 
 #: book_providers/runeberg_download_options.html
@@ -3127,17 +3039,6 @@ msgstr ""
 msgid "More at Project Runeberg"
 msgstr ""
 
-#: book_providers/runeberg_read_button.html
-msgid "Read eBook from Project Runeberg"
-msgstr ""
-
-#: book_providers/runeberg_read_button.html
-msgid ""
-"This book is available from <a href=\"https://runeberg.org/\">Project Runeberg</"
-"a>. Project Runeberg is a trusted book provider of classic Nordic (Scandinavian) "
-"literature in electronic form."
-msgstr ""
-
 #: book_providers/standard_ebooks_download_options.html
 msgid "Download an HTML from Standard Ebooks"
 msgstr ""
@@ -3174,18 +3075,6 @@ msgstr "Cod sursă"
 msgid "More at Standard Ebooks"
 msgstr ""
 
-#: book_providers/standard_ebooks_read_button.html
-msgid "Read eBook from Standard eBooks"
-msgstr ""
-
-#: book_providers/standard_ebooks_read_button.html
-msgid ""
-"This book is available from <a href=\"https://standardebooks.org/\">Standard "
-"Ebooks</a>. Standard Ebooks is a trusted book provider and a volunteer-driven "
-"project that produces new editions of public domain ebooks that are lovingly "
-"formatted, open source, free of copyright restrictions, and free of cost."
-msgstr ""
-
 #: book_providers/wikisource_download_options.html
 msgid "Download PDF from Wikisource"
 msgstr ""
@@ -3210,20 +3099,6 @@ msgstr ""
 msgid "Read at Wikisource"
 msgstr ""
 
-#: book_providers/wikisource_read_button.html
-msgid "Read eBook on Wikisource"
-msgstr ""
-
-#: book_providers/wikisource_read_button.html
-msgid ""
-"This book is available from <a href=\"https://wikisource.org/\">Wikisource</a>. "
-"Wikisource, a <a href=\"https://www.wikimedia.org/\">Wikimedia Foundation</a> "
-"project, is a trusted book provider of works available under the <a "
-"href=\"https://creativecommons.org/licenses/by-sa/4.0/\">CC-BY-SA</a> open "
-"content license, such as essays, historical documents, letters, speeches, and "
-"public domain books."
-msgstr ""
-
 #: books/RelatedWorksCarousel.html
 msgid "You might also like"
 msgstr ""
@@ -3244,19 +3119,19 @@ msgid "Invalid ISBN checksum digit"
 msgstr ""
 
 #: books/add.html
-msgid ""
-"ID must be exactly 10 characters [0-9 or X]. For example 0-19-853453-1 or "
-"0198534531"
+msgid "ID must be exactly 10 characters [0-9 or X]. For example 0-19-853453-1 or 0198534531"
 msgstr ""
 
 #: books/add.html
-msgid ""
-"ID must be exactly 13 characters [0-9]. For example 978-3-16-148410-0 or "
-"9783161484100"
+msgid "ID must be exactly 13 characters [0-9]. For example 978-3-16-148410-0 or 9783161484100"
 msgstr ""
 
 #: books/add.html
 msgid "Invalid LC Control Number format"
+msgstr ""
+
+#: books/add.html
+msgid "Invalid OCLC/WorldCat Control Number format"
 msgstr ""
 
 #: books/add.html
@@ -3272,42 +3147,26 @@ msgid "Add a book to Open Library"
 msgstr ""
 
 #: books/add.html
-msgid ""
-"We require a minimum set of fields to create a new record. These are those fields."
+msgid "We require a minimum set of fields to create a new record. These are those fields."
 msgstr ""
-
-#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html
-#: search/advancedsearch.html type/about/edit.html type/page/edit.html
-#: type/template/edit.html
-msgid "Title"
-msgstr "Titlu"
 
 #: books/add.html books/edit.html
 msgid "Use <b><i>Title: Subtitle</i></b> to add a subtitle."
 msgstr ""
 
-#: books/add.html books/edit.html type/author/edit.html
-#: type/tag/tag_form_inputs.html
+#: books/add.html books/edit.html type/author/edit.html type/tag/tag_form_inputs.html
 msgid "Required field"
 msgstr ""
 
-#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html
-#: openlibrary/plugins/worksearch/code.py search/advancedsearch.html
-#: search/work_search_selected_facets.html
-msgid "Author"
-msgstr "Autor"
-
 #: books/add.html
-msgid ""
-"Like, \"Agatha Christie\" or \"Jean-Paul Sartre.\" We'll also do a live check to "
-"see if we already know the author."
+msgid "Like, \"Agatha Christie\" or \"Jean-Paul Sartre.\" We'll also do a live check to see if we already know the author."
 msgstr ""
 
 #: books/add.html books/edit/edition.html
 msgid "Who is the publisher?"
 msgstr ""
 
-#: books/add.html books/edit/edition.html books/edit/excerpts.html
+#: books/add.html books/edit/edition.html
 msgid "For example:"
 msgstr ""
 
@@ -3356,6 +3215,11 @@ msgid "LibriVox"
 msgstr ""
 
 #: books/add.html
+#, fuzzy
+msgid "OCLC/WorldCat"
+msgstr "WorldCat"
+
+#: books/add.html
 msgid "Project Gutenberg"
 msgstr ""
 
@@ -3367,12 +3231,13 @@ msgstr ""
 msgid "Only fill this out if this is a web book"
 msgstr ""
 
-#: EditButtons.html books/add.html type/tag/form.html
-msgid ""
-"By saving a change to this wiki, you agree that your contribution is given freely "
-"to the world under <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" "
-"target=\"_blank\" title=\"This link to Creative Commons will open in a new "
-"window\">CC0</a>. Yippee!"
+#: books/add.html
+#, python-format
+msgid "By saving a change to this wiki, you agree that your contribution is given freely to the world under <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" target=\"_blank\" rel=\"noopener noreferrer\" title=\"%(cc_link_title)s\">CC0</a>."
+msgstr ""
+
+#: books/add.html
+msgid "This link to Creative Commons will open in a new window"
 msgstr ""
 
 #: books/add.html
@@ -3383,7 +3248,7 @@ msgstr ""
 msgid "Add a new author"
 msgstr ""
 
-#: books/author-autocomplete.html
+#: books/author-autocomplete.html books/series-autocomplete.html
 msgid "Create a new record for"
 msgstr ""
 
@@ -3401,15 +3266,11 @@ msgstr "Adaugă o carte"
 
 #: books/check.html
 #, python-format
-msgid ""
-"One moment... It looks like we already have <em>some potential matches</em> for "
-"<b>%(title)s</b> by <b>%(author)s</b>."
+msgid "One moment... It looks like we already have <em>some potential matches</em> for <b>%(title)s</b> by <b>%(author)s</b>."
 msgstr ""
 
 #: books/check.html
-msgid ""
-"Rather than creating a duplicate record, please click through the result you "
-"think best matches your book."
+msgid "Rather than creating a duplicate record, please click through the result you think best matches your book."
 msgstr ""
 
 #: books/check.html
@@ -3437,17 +3298,17 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: NotInLibrary.html books/custom_carousel.html
-msgid "Not in Library"
-msgstr ""
-
-#: books/custom_carousel.html type/author/view.html
+#: books/custom_carousel_card.html type/author/view.html
 msgid "name missing"
 msgstr ""
 
-#: books/custom_carousel.html books/mobile_carousel.html
+#: books/custom_carousel_card.html books/mobile_carousel.html
 #, python-format
 msgid " by %(name)s"
+msgstr ""
+
+#: books/daisy.html
+msgid "Back"
 msgstr ""
 
 #: books/daisy.html
@@ -3459,20 +3320,8 @@ msgid "There isn't a DAISY file available for "
 msgstr ""
 
 #: books/daisy.html
-msgid "This DAISY file is protected."
-msgstr ""
-
-#: books/daisy.html
-msgid ""
-"It can only be opened on a specialized device with a key issued by the Library of "
-"Congress."
-msgstr ""
-
-#: books/daisy.html
 #, python-format
-msgid ""
-"<a href=\"%(daisy_url)s\"><strong>Download the DAISY.zip</strong></a> for <a "
-"href=\"%(url)s\">%(title)s</a>"
+msgid "<a href=\"%(daisy_url)s\"><strong>Download the DAISY.zip</strong></a> for <a href=\"%(url)s\">%(title)s</a>"
 msgstr ""
 
 #: books/daisy.html
@@ -3480,26 +3329,11 @@ msgid "Books for people who don't read print?"
 msgstr ""
 
 #: books/daisy.html
-msgid ""
-"The <a href=\"//archive.org\">Internet Archive</a> is proud to be distributing "
-"over 1 million books free in a format called DAISY, designed for those of us who "
-"find it challenging to use regular printed media. "
+msgid "The <a href=\"//archive.org\">Internet Archive</a> is proud to be distributing over 1 million books free in a format called DAISY, designed for those of us who find it challenging to use regular printed media. "
 msgstr ""
 
 #: books/daisy.html
-msgid ""
-"There are two types of DAISYs on Open Library: <i>open</i> and <i>protected</i>. "
-"Open DAISYs can be read by anyone in the world on many different devices. "
-"Protected DAISYs like this one can only be opened using a key issued by the <a "
-"href=\"http://www.loc.gov/nls/\">Library of Congress NLS program</a>."
-msgstr ""
-
-#: books/daisy.html
-msgid ""
-"There are two types of DAISYs on Open Library: <i>open</i> and <i>protected</i>. "
-"Open DAISYs can be read by anyone in the world on many different devices. "
-"Protected DAISYs can only be opened using a key issued by the <a href=\"http://"
-"www.loc.gov/nls/\">Library of Congress NLS program</a>."
+msgid "There are two types of DAISYs on Open Library: <i>open</i> and <i>protected</i>. Open DAISYs can be read by anyone in the world on many different devices. Protected DAISYs can only be opened using a key issued by the <a href=\"http://www.loc.gov/nls/\">Library of Congress NLS program</a>."
 msgstr ""
 
 #: books/daisy.html lists/home.html
@@ -3511,11 +3345,7 @@ msgid "What is the DAISY format?"
 msgstr ""
 
 #: books/daisy.html
-msgid ""
-"The DAISY digital format helps people who have challenges using regular printed "
-"media. DAISY digital <span class=\"highlight\">talking books</span> offer the "
-"benefits of regular audiobooks, with navigation within the book, to chapters or "
-"specific pages."
+msgid "The DAISY digital format helps people who have challenges using regular printed media. DAISY digital <span class=\"highlight\">talking books</span> offer the benefits of regular audiobooks, with navigation within the book, to chapters or specific pages."
 msgstr ""
 
 #: books/daisy.html
@@ -3527,11 +3357,7 @@ msgid "What is the NLS?"
 msgstr ""
 
 #: books/daisy.html
-msgid ""
-"The Library of Congress <a href=\"http://www.loc.gov/nls/\">National Library "
-"Service for the Blind and Physically Handicapped (NLS)</a> administers a free "
-"library program of braille and audio materials circulated to eligible borrowers "
-"in the United States through a national network of cooperating libraries."
+msgid "The Library of Congress <a href=\"http://www.loc.gov/nls/\">National Library Service for the Blind and Physically Handicapped (NLS)</a> administers a free library program of braille and audio materials circulated to eligible borrowers in the United States through a national network of cooperating libraries."
 msgstr ""
 
 #: books/daisy.html
@@ -3543,28 +3369,19 @@ msgid "How do I find DAISYs on Open Library?"
 msgstr ""
 
 #: books/daisy.html
-msgid ""
-"In addition to<a href=\"/subjects/accessible_book\" title=\"Subject: Accessible "
-"book\"> loads of open DAISYs</a>, the Open Library lists a smaller selection of<a "
-"href=\"/subjects/protected_DAISY\" title=\"Subject: Protected DAISY\"> protected "
-"DAISY titles</a> accessible to those with a Library of Congress NLS key. These "
-"titles are brought to you by the<a href=\"//archive.org/\"> Internet Archive</a>."
+msgid "In addition to<a href=\"/subjects/accessible_book\" title=\"Subject: Accessible book\"> loads of open DAISYs</a>, the Open Library lists a smaller selection of<a href=\"/subjects/protected_DAISY\" title=\"Subject: Protected DAISY\"> protected DAISY titles</a> accessible to those with a Library of Congress NLS key. These titles are brought to you by the<a href=\"//archive.org/\"> Internet Archive</a>."
 msgstr ""
 
 #: books/daisy.html
-msgid ""
-"Looking for a specific title? The best way to find it is to<a href=\"/search\"> "
-"search for it</a>."
+msgid "Looking for a specific title? The best way to find it is to<a href=\"/search\"> search for it</a>."
 msgstr ""
 
-#: books/daisy.html lib/history.html
+#: books/daisy.html lib/exports.html
 msgid "Need help?"
 msgstr ""
 
 #: books/daisy.html
-msgid ""
-" Please read our <a href=\"/help/faq\">FAQ on accessing books through Open "
-"Library</a>."
+msgid " Please read our <a href=\"/help/faq\">FAQ on accessing books through Open Library</a>."
 msgstr ""
 
 #: books/edit.html
@@ -3572,30 +3389,24 @@ msgid "Add a little more?"
 msgstr ""
 
 #: books/edit.html
-msgid ""
-"Thank you for adding that book! Any more information you could provide would be "
-"wonderful!"
+msgid "Thank you for adding that book! Any more information you could provide would be wonderful!"
 msgstr ""
 
 #: books/edit.html
 #, python-format
-msgid ""
-"We already know about <b>%(work_title)s</b>, but not the <b>%(year)s "
-"%(publisher)s edition</b>. Thanks! Do you know any more about this edition?"
+msgid "We already know about <b>%(work_title)s</b>, but not the <b>%(year)s %(publisher)s edition</b>. Thanks! Do you know any more about this edition?"
 msgstr ""
 
 #: books/edit.html
 #, python-format
-msgid ""
-"We already know about the <b>%(year)s %(publisher)s edition</b> of "
-"<b>%(work_title)s</b>, but please, tell us more!"
+msgid "We already know about the <b>%(year)s %(publisher)s edition</b> of <b>%(work_title)s</b>, but please, tell us more!"
 msgstr ""
 
 #: books/edit.html
 msgid "Editing..."
 msgstr ""
 
-#: books/edit.html type/author/edit.html type/template/edit.html
+#: books/edit.html type/author/edit.html type/tag/form.html type/template/edit.html
 msgid "Delete Record"
 msgstr ""
 
@@ -3612,9 +3423,7 @@ msgid "This Work"
 msgstr ""
 
 #: books/edit.html
-msgid ""
-"You can search by author name (like <em>j k rowling</em>) or by Open Library ID "
-"(like <a href=\"/authors/OL23919A\" target=\"_blank\"><em>OL23919A</em></a>)."
+msgid "You can search by author name (like <em>j k rowling</em>) or by Open Library ID (like <a href=\"/authors/OL23919A\" target=\"_blank\" rel=\"noopener noreferrer\"><em>OL23919A</em></a>)."
 msgstr ""
 
 #: books/edit.html
@@ -3629,6 +3438,23 @@ msgstr ""
 msgid "Links"
 msgstr ""
 
+#: books/edit.html
+#, fuzzy
+msgid "Work Series"
+msgstr "Statistici despre opere"
+
+#: books/edit.html
+msgid "Series are currently in beta, and this section is only visible to super librarians and admins, like you! Any series you set will be visible by everyone, however. Please report any issues you have on Slack or GitHub."
+msgstr ""
+
+#: books/edit.html
+msgid "Is this work part of a larger series?"
+msgstr ""
+
+#: books/edit.html
+msgid "E.g. Harry Potter, The Sword of Truth"
+msgstr ""
+
 #: books/edit.html type/edition/view.html type/work/view.html
 msgid "Work Identifiers"
 msgstr ""
@@ -3638,16 +3464,10 @@ msgid "Do you know any identifiers for this work?"
 msgstr ""
 
 #: books/edit.html
-msgid ""
-"These identifiers apply to all editions of this work, for example Wikidata work "
-"identifiers. For edition-specific identifiers, like ISBN or LCCN, go to the "
-"edition tab."
+msgid "These identifiers apply to all editions of this work, for example Wikidata work identifiers. For edition-specific identifiers, like ISBN or LCCN, go to the edition tab."
 msgstr ""
 
-#: FulltextSearchSuggestionItem.html IABook.html SearchResultsWork.html
-#: books/edition-sort.html jsdef/LazyWorkPreview.html lists/list_overview.html
-#: lists/preview.html lists/snippet.html lists/widget.html
-#: my_books/dropdown_content.html type/work/editions.html
+#: FulltextSearchSuggestionItem.html IABook.html SearchResultsWork.html books/edition-sort.html jsdef/LazyWorkPreview.html lists/list_overview.html lists/preview.html lists/snippet.html lists/widget.html my_books/dropdown_content.html type/work/editions.html
 #, python-format
 msgid "Cover of: %(title)s"
 msgstr ""
@@ -3667,39 +3487,76 @@ msgstr ""
 msgid "in %(languagelist)s"
 msgstr ""
 
-#: SearchNavigation.html books/mybooks_breadcrumb_select.html lib/nav_foot.html
-#: openlibrary/plugins/upstream/mybooks.py
+#: SearchNavigation.html books/mybooks_breadcrumb_select.html lib/nav_foot.html openlibrary/plugins/upstream/mybooks.py
 msgid "Books"
 msgstr "Cărți"
 
+#. Page title for the "Want to Read" shelf page.
+#. Example: "Want to Read (17)". %(count)d is the number of books on this
+#. shelf.
 #: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #, python-format
 msgid "Want to Read (%(count)d)"
 msgstr "Doresc să citesc (%(count)d)"
 
+#. Page title for the "Currently Reading" shelf page.
+#. Example: "Currently Reading (42)". %(count)d is the number of books on this
+#. shelf.
 #: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #, python-format
 msgid "Currently Reading (%(count)d)"
 msgstr "În curs de citire (%(count)d)"
 
+#. Page title for the "Already Read" shelf page.
+#. Example: "Already Read (203)". %(count)d is the number of books on this
+#. shelf.
 #: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #, python-format
 msgid "Already Read (%(count)d)"
 msgstr "Deja citite (%(count)d)"
+
+#. Page title for the "Stopped Reading" shelf page.
+#. Example: "Stopped Reading (8)". %(count)d is the number of books on this
+#. shelf.
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#, fuzzy, python-format
+msgid "Stopped Reading (%(count)d)"
+msgstr "În curs de citire (%(count)d)"
 
 #: books/mybooks_breadcrumb_select.html openlibrary/plugins/openlibrary/lists.py
 #, python-format
 msgid "Lists (%(count)d)"
 msgstr "Liste (%(count)d)"
 
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
-#: type/edition/modal_links.html
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py type/edition/modal_links.html
 msgid "Notes"
 msgstr "Notițe"
 
 #: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
 msgid "Imports and Exports"
 msgstr "Importuri și exporturi"
+
+#: books/series-autocomplete.html
+msgid "Add a new series"
+msgstr ""
+
+#: books/series-autocomplete.html
+#, fuzzy
+msgid "Series name"
+msgstr "Nume de utilizator"
+
+#: books/series-autocomplete.html
+#, fuzzy
+msgid "Series position"
+msgstr "Științifico-fantastic"
+
+#: books/series-autocomplete.html
+msgid "Remove this series"
+msgstr ""
+
+#: books/series-autocomplete.html
+msgid "Add another series?"
+msgstr ""
 
 #: books/edit/about.html
 msgid "Select this subject"
@@ -3722,10 +3579,7 @@ msgid "Please separate with commas."
 msgstr ""
 
 #: books/edit/about.html
-msgid ""
-"For example: <i><a href=\"/subjects/cheese\">cheese</a>, <a href=\"/subjects/"
-"roman_empire\">Roman Empire</a>, <a href=\"/subjects/psychology\">psychology</a></"
-"i>"
+msgid "For example: <i><a href=\"/subjects/cheese\">cheese</a>, <a href=\"/subjects/roman_empire\">Roman Empire</a>, <a href=\"/subjects/psychology\">psychology</a></i>"
 msgstr ""
 
 #: books/edit/about.html
@@ -3733,10 +3587,7 @@ msgid "A person? Or, people?"
 msgstr ""
 
 #: books/edit/about.html
-msgid ""
-"For example: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore "
-"Roosevelt</a>, <a href=\"/subjects/person:Julian_of_Norwich\">Julian of Norwich</"
-"a>, <a href=\"/subjects/person:Tintin\">Tintin</a></i>"
+msgid "For example: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore Roosevelt</a>, <a href=\"/subjects/person:Julian_of_Norwich\">Julian of Norwich</a>, <a href=\"/subjects/person:Tintin\">Tintin</a></i>"
 msgstr ""
 
 #: books/edit/about.html
@@ -3744,10 +3595,7 @@ msgid "Note any places mentioned?"
 msgstr ""
 
 #: books/edit/about.html
-msgid ""
-"For example: <i><a href=\"/subjects/place:London\">London</a>, <a href=\"/"
-"subjects/place:Atlantis\">Atlantis</a>, <a href=\"/subjects/place:Omaha\">Omaha</"
-"a></i>"
+msgid "For example: <i><a href=\"/subjects/place:London\">London</a>, <a href=\"/subjects/place:Atlantis\">Atlantis</a>, <a href=\"/subjects/place:Omaha\">Omaha</a></i>"
 msgstr ""
 
 #: books/edit/about.html
@@ -3755,10 +3603,7 @@ msgid "When is it set or about?"
 msgstr ""
 
 #: books/edit/about.html
-msgid ""
-"For example: <i><a href=\"/subjects/time:1984\">1984</a>, <a href=\"/subjects/"
-"time:the_middle_ages\">The Middle Ages</a>, <a href=\"/subjects/"
-"time:1810-1890\">1810-1890</a></i>"
+msgid "For example: <i><a href=\"/subjects/time:1984\">1984</a>, <a href=\"/subjects/time:the_middle_ages\">The Middle Ages</a>, <a href=\"/subjects/time:1810-1890\">1810-1890</a></i>"
 msgstr ""
 
 #: books/edit/edition.html
@@ -3794,6 +3639,10 @@ msgid "Usually distinguished by different or smaller type."
 msgstr ""
 
 #: books/edit/edition.html
+msgid "For example: <i>envisioning the next 50 years</i>"
+msgstr ""
+
+#: books/edit/edition.html
 msgid "Publishing Info"
 msgstr ""
 
@@ -3810,6 +3659,10 @@ msgid "City, Country please."
 msgstr ""
 
 #: books/edit/edition.html
+msgid "For example: <i>New York, USA; Sydney, Australia</i>"
+msgstr ""
+
+#: books/edit/edition.html
 msgid "What is the copyright date?"
 msgstr ""
 
@@ -3822,11 +3675,19 @@ msgid "Edition Name (if applicable):"
 msgstr ""
 
 #: books/edit/edition.html
+msgid "For example: <i>Centennial edition</i>; <i>First edition</i>"
+msgstr ""
+
+#: books/edit/edition.html
 msgid "Series Name (if applicable)"
 msgstr ""
 
 #: books/edit/edition.html
 msgid "The name of the publisher's series."
+msgstr ""
+
+#: books/edit/edition.html
+msgid "For example: <i>The Story of Civilization, Part III</i>"
 msgstr ""
 
 #: books/edit/edition.html type/edition/view.html type/work/view.html
@@ -3906,16 +3767,11 @@ msgid "Table of Contents"
 msgstr ""
 
 #: books/edit/edition.html
-msgid ""
-"Use a \"*\" for an indent, a \"|\" to add a column, and line breaks for new "
-"lines. Like this:"
+msgid "Use a \"*\" for an indent, a \"|\" to add a column, and line breaks for new lines. Like this:"
 msgstr ""
 
 #: books/edit/edition.html
-msgid ""
-"This table of contents contains extra information like authors or descriptions. "
-"We don't have a great user interface for this yet, so editing this data could be "
-"difficult. Watch out!"
+msgid "This table of contents contains extra information like authors or descriptions. We don't have a great user interface for this yet, so editing this data could be difficult. Watch out!"
 msgstr ""
 
 #: books/edit/edition.html
@@ -3927,20 +3783,20 @@ msgid "Anything about the book that may be of interest."
 msgstr ""
 
 #: books/edit/edition.html
+#, fuzzy
+msgid "A Plume Book"
+msgstr "Descoperă cărți"
+
+#: books/edit/edition.html
 msgid "Is it known by any other titles?"
 msgstr ""
 
 #: books/edit/edition.html
-msgid ""
-"Use this field if the title is different on the cover or spine. If the edition is "
-"a collection or anthology, you may also add the individual titles of each work "
-"here."
+msgid "Use this field if the title is different on the cover or spine. If the edition is a collection or anthology, you may also add the individual titles of each work here."
 msgstr ""
 
 #: books/edit/edition.html
-msgid ""
-"For example: <i>Eaters of the Dead</i> is an alternate title for <i><a href=\"/"
-"books/OL24923038M\">The 13th Warrior</a></i>."
+msgid "For example: <i>Eaters of the Dead</i> is an alternate title for <i><a href=\"/books/OL24923038M\">The 13th Warrior</a></i>."
 msgstr ""
 
 #: books/edit/edition.html
@@ -3948,15 +3804,11 @@ msgid "What work is this an edition of?"
 msgstr ""
 
 #: books/edit/edition.html
-msgid ""
-"Sometimes editions can be associated with the wrong work. You can correct that "
-"here."
+msgid "Sometimes editions can be associated with the wrong work. You can correct that here."
 msgstr ""
 
 #: books/edit/edition.html
-msgid ""
-"You can search by title or by Open Library ID (like <a href=\"/works/OL262757W\" "
-"target=\"_blank\"><em>OL262757W</em></a>)."
+msgid "You can search by title or by Open Library ID (like <a href=\"/works/OL262757W\" target=\"_blank\" rel=\"noopener noreferrer\"><em>OL262757W</em></a>)."
 msgstr ""
 
 #: books/edit/edition.html
@@ -4156,13 +4008,15 @@ msgid "That excerpt is too long."
 msgstr ""
 
 #: books/edit/excerpts.html
-msgid ""
-"If there are particular (short) passages you feel represent the book well, please "
-"feel free to transcribe them here."
+msgid "If there are particular (short) passages you feel represent the book well, please feel free to transcribe them here."
 msgstr ""
 
 #: books/edit/excerpts.html
 msgid "Page number?"
+msgstr ""
+
+#: books/edit/excerpts.html
+msgid "For example: <i>23, xi or 433-434</i>"
 msgstr ""
 
 #: books/edit/excerpts.html
@@ -4214,9 +4068,7 @@ msgid "Please enter a valid URL."
 msgstr ""
 
 #: books/edit/web.html
-msgid ""
-"Please connect Open Library records to <u>good</u><span class=\"orange\">*</span> "
-"online resources."
+msgid "Please connect Open Library records to <u>good</u><span class=\"orange\">*</span> online resources."
 msgstr ""
 
 #: books/edit/web.html
@@ -4240,137 +4092,12 @@ msgid "Remove this link"
 msgstr ""
 
 #: books/edit/web.html
-msgid ""
-"\"Good\" means no spammy links, please. Keep them relevant to the book. "
-"Irrelevant sites may be removed. Blatant spam will be deleted without remorse."
+msgid "\"Good\" means no spammy links, please. Keep them relevant to the book. Irrelevant sites may be removed. Blatant spam will be deleted without remorse."
 msgstr ""
 
-#: bulk_search/bulk_search.html
+#: bulk_search/bulk_search.html search/advancedsearch.html
 msgid "Bulk Search (beta)"
 msgstr ""
-
-#: check_ins/check_in_form.html
-msgid "January"
-msgstr ""
-
-#: check_ins/check_in_form.html
-msgid "February"
-msgstr ""
-
-#: check_ins/check_in_form.html
-msgid "March"
-msgstr ""
-
-#: check_ins/check_in_form.html
-msgid "April"
-msgstr ""
-
-#: check_ins/check_in_form.html
-msgid "May"
-msgstr ""
-
-#: check_ins/check_in_form.html
-msgid "June"
-msgstr ""
-
-#: check_ins/check_in_form.html
-msgid "July"
-msgstr ""
-
-#: check_ins/check_in_form.html
-msgid "August"
-msgstr ""
-
-#: check_ins/check_in_form.html
-msgid "September"
-msgstr ""
-
-#: check_ins/check_in_form.html
-msgid "October"
-msgstr ""
-
-#: check_ins/check_in_form.html
-msgid "November"
-msgstr ""
-
-#: check_ins/check_in_form.html
-msgid "December"
-msgstr ""
-
-#: check_ins/check_in_form.html
-msgid ""
-"Add an optional check-in date.  Check-in dates are used to track yearly reading "
-"goals."
-msgstr ""
-
-#: check_ins/check_in_form.html
-msgid "End Date:"
-msgstr ""
-
-#: check_ins/check_in_form.html
-msgid "Year:"
-msgstr ""
-
-#: check_ins/check_in_form.html
-msgid "Year"
-msgstr ""
-
-#: check_ins/check_in_form.html
-msgid "Month:"
-msgstr ""
-
-#: check_ins/check_in_form.html
-msgid "Month"
-msgstr ""
-
-#: check_ins/check_in_form.html
-msgid "Day:"
-msgstr ""
-
-#: check_ins/check_in_form.html
-msgid "Day"
-msgstr ""
-
-#: check_ins/check_in_form.html
-msgid "Delete Event"
-msgstr ""
-
-#: check_ins/check_in_prompt.html
-#, python-format
-msgid "Read <time class=\"check-in-date\">%(date)s</time>"
-msgstr ""
-
-#: check_ins/check_in_prompt.html
-msgid "When did you finish this book?"
-msgstr ""
-
-#: check_ins/check_in_prompt.html
-msgid "Other"
-msgstr ""
-
-#: check_ins/check_in_prompt.html
-msgid "Check-In"
-msgstr ""
-
-#: check_ins/reading_goal_form.html
-msgid "How many books would you like to read this year?"
-msgstr "Câte cărți doriți să citiți anul acesta?"
-
-#: check_ins/reading_goal_form.html
-msgid "Enter \"0\" to unset your reading goal. Your check-ins will be preserved."
-msgstr ""
-
-#: check_ins/reading_goal_progress.html
-#, python-format
-msgid ""
-"<span class=\"reading-goal-progress__books-read\">%(books_read)d</span>/<span "
-"class=\"reading-goal-progress__goal\">%(goal)d</span> Books"
-msgstr ""
-
-#: check_ins/reading_goal_progress.html
-#, python-format
-msgid "Edit %(year)d Reading Goal"
-msgstr "Modifică obiectivul de citire pentru %(year)d"
 
 #: covers/add.html
 msgid "There are two ways to put an author's image on Open Library."
@@ -4398,9 +4125,7 @@ msgstr ""
 
 #: covers/add.html
 #, python-format
-msgid ""
-"Learn more by reading our <a href=\"/help/faq/editing#picture\" "
-"target=\"blank\">%(guidelines)s</a>."
+msgid "Learn more by reading our <a href=\"/help/faq/editing#picture\" target=\"blank\">%(guidelines)s</a>."
 msgstr ""
 
 #: covers/add.html
@@ -4412,7 +4137,7 @@ msgid "Use this image"
 msgstr ""
 
 #: covers/add.html
-msgid "Choose a JPG, GIF or PNG on your computer"
+msgid "Choose a JPG, GIF, PNG or WebP on your computer"
 msgstr ""
 
 #: covers/add.html
@@ -4428,14 +4153,14 @@ msgid "Paste image from clipboard"
 msgstr ""
 
 #: covers/add.html
-msgid "No Image Pasted"
+msgid "Paste Image"
 msgstr ""
 
 #: covers/add.html
 msgid "Upload image"
 msgstr ""
 
-#: covers/add.html
+#: covers/add.html covers/external_image.html
 msgid "Upload Image"
 msgstr ""
 
@@ -4444,7 +4169,7 @@ msgid "Uploading..."
 msgstr ""
 
 #: covers/add.html
-msgid "Or, use the the cover from Internet Archive"
+msgid "Wikidata"
 msgstr ""
 
 #: covers/author_photo.html
@@ -4469,25 +4194,19 @@ msgstr ""
 msgid "Pull up a bigger book cover"
 msgstr ""
 
-#: covers/book_cover.html covers/book_cover_single_edition.html
-#: covers/book_cover_small.html covers/book_cover_work.html
+#: covers/book_cover.html covers/book_cover_small.html
 #, python-format
 msgid "Cover of: %(title)s by %(authors)s"
-msgstr ""
-
-#: covers/book_cover_single_edition.html covers/book_cover_work.html
-msgid "View a larger book cover"
-msgstr ""
-
-#: covers/book_cover_single_edition.html covers/book_cover_small.html
-#: covers/book_cover_work.html
-#, python-format
-msgid "We need a book cover for: %(title)s"
 msgstr ""
 
 #: covers/book_cover_small.html
 #, python-format
 msgid "Go to the main page for %(title)s"
+msgstr ""
+
+#: covers/book_cover_small.html
+#, python-format
+msgid "We need a book cover for: %(title)s"
 msgstr ""
 
 #: covers/change.html
@@ -4518,9 +4237,13 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
+#: covers/external_image.html
+#, python-format
+msgid "Or, use an image from %s"
+msgstr ""
+
 #: covers/manage.html
-msgid ""
-"You can drag and drop thumbnails to reorder, or into the trash to delete them."
+msgid "You can drag and drop thumbnails to reorder, or into the trash to delete them."
 msgstr ""
 
 #: covers/saved.html
@@ -4552,21 +4275,11 @@ msgid "Thank you for your note. We'll get back to you as soon as possible."
 msgstr ""
 
 #: email/case_created.html
-msgid ""
-"It might take us a little while to read it because we receive lots of messages, "
-"but rest assured we will, and we'll get back to you if required."
+msgid "It might take us a little while to read it because we receive lots of messages, but rest assured we will, and we'll get back to you if required."
 msgstr ""
 
-#: history/comment.html
-msgid "Imported from"
-msgstr ""
-
-#: history/comment.html
-msgid "Found a matching"
-msgstr ""
-
-#: history/comment.html
-msgid "Edited without comment."
+#: email/account/pd_request.html
+msgid "Qualifying for Print Disability Special Access"
 msgstr ""
 
 #: history/sources.html
@@ -4578,28 +4291,16 @@ msgid "About the Project"
 msgstr "Despre proiect"
 
 #: home/about.html
-msgid ""
-"Open Library is an open, editable library catalog, building towards a web page "
-"for every book ever published."
-msgstr ""
-"Open Library este un catalog de bibliotecă deschis și editabil, care își propune "
-"să creeze o pagină web pentru fiecare carte publicată vreodată."
+msgid "Open Library is an open, editable library catalog, building towards a web page for every book ever published."
+msgstr "Open Library este un catalog de bibliotecă deschis și editabil, care își propune să creeze o pagină web pentru fiecare carte publicată vreodată."
 
-#: AffiliateLinks.html home/about.html
+#: AffiliateLinks.html home/about.html search/work_search_facets.html
 msgid "More"
 msgstr "Mai mult"
 
 #: home/about.html
-msgid ""
-"Just like Wikipedia, you can contribute new information or corrections to the "
-"catalog. You can browse by <a href=\"/subjects\">subjects</a>, <a href=\"/"
-"authors\">authors</a> or <a href=\"/lists\">lists</a> members have created. If "
-"you love books, why not help build a library?"
-msgstr ""
-"La fel ca Wikipedia, puteți contribui cu informații noi sau corecturi la catalog. "
-"Puteți naviga după <a href=\"/subjects\">subiecte</a>, <a href=\"/"
-"authors\">autori</a> sau <a href=\"/lists\">liste</a> create de membri. Dacă vă "
-"plac cărțile, de ce nu ajuți la construirea unei biblioteci?"
+msgid "Just like Wikipedia, you can contribute new information or corrections to the catalog. You can browse by <a href=\"/subjects\">subjects</a>, <a href=\"/authors\">authors</a> or <a href=\"/lists\">lists</a> members have created. If you love books, why not help build a library?"
+msgstr "La fel ca Wikipedia, puteți contribui cu informații noi sau corecturi la catalog. Puteți naviga după <a href=\"/subjects\">subiecte</a>, <a href=\"/authors\">autori</a> sau <a href=\"/lists\">liste</a> create de membri. Dacă vă plac cărțile, de ce nu ajuți la construirea unei biblioteci?"
 
 #: home/about.html
 msgid "Latest Blog Posts"
@@ -4608,11 +4309,6 @@ msgstr "Ultimele postări pe blog"
 #: home/categories.html
 msgid "Browse by Subject"
 msgstr "Navigați după subiect"
-
-#: home/categories.html
-#, python-format
-msgid "browse %(subject)s books"
-msgstr ""
 
 #: home/categories.html
 #, python-format
@@ -4626,7 +4322,7 @@ msgstr[2] "%(count)s de cărți"
 msgid "Welcome to Open Library"
 msgstr "Bun venit la Open Library"
 
-#: home/index.html
+#: home/index.html openlibrary/plugins/openlibrary/api.py
 msgid "Classic Books"
 msgstr "Cărți clasice"
 
@@ -4634,38 +4330,40 @@ msgstr "Cărți clasice"
 msgid "Recently Returned"
 msgstr "Recent returnate"
 
-#: home/index.html openlibrary/plugins/openlibrary/home.py
+#: home/index.html openlibrary/plugins/openlibrary/api.py openlibrary/plugins/openlibrary/home.py
 msgid "Romance"
 msgstr "Romantism"
 
-#: home/index.html
+#: home/index.html openlibrary/plugins/openlibrary/api.py
 msgid "Kids"
 msgstr "Copii"
 
-#: home/index.html
+#: home/index.html openlibrary/plugins/openlibrary/api.py
 msgid "Thrillers"
 msgstr "Thrillere"
 
-#: home/index.html openlibrary/plugins/openlibrary/home.py
+#: home/index.html openlibrary/plugins/openlibrary/api.py openlibrary/plugins/openlibrary/home.py
 msgid "Textbooks"
 msgstr "Manuale"
 
+#: home/index.html
+msgid "Authors Alliance & MIT Press"
+msgstr ""
+
+#: home/index.html
+msgid "Books in Local Environment"
+msgstr ""
+
 #: home/loans.html
-#, python-format
-msgid ""
-"You can still <a href=\"/borrow\">borrow</a> one more book until you've hit the "
-"limit!"
-msgid_plural ""
-"You can still <a href=\"/borrow\">borrow</a> %(count)d more books until you've "
-"hit the limit!"
+#, fuzzy, python-format
+msgid "You can still <a href=\"/subjects/in_library#ebooks=true\">borrow</a> one more book until you've hit the limit!"
+msgid_plural "You can still <a href=\"/subjects/in_library#ebooks=true\">borrow</a> %(count)d more books until you've hit the limit!"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
 #: home/loans.html
-msgid ""
-"You have reached the borrowing limit. Please return a book to checkout something "
-"new."
+msgid "You have reached the borrowing limit. Please return a book to checkout something new."
 msgstr ""
 
 #: home/stats.html
@@ -4673,12 +4371,8 @@ msgid "Around the Library"
 msgstr "În jurul bibliotecii"
 
 #: home/stats.html
-msgid ""
-"Here's what's happened over the last 28 days. More <a href=\"/"
-"recentchanges\">recent changes</a>"
-msgstr ""
-"Iată ce s-a întâmplat în ultimele 28 de zile. Mai multe <a href=\"/"
-"recentchanges\">modificări recente</a>"
+msgid "Here's what's happened over the last 28 days. More <a href=\"/recentchanges\">recent changes</a>"
+msgstr "Iată ce s-a întâmplat în ultimele 28 de zile. Mai multe <a href=\"/recentchanges\">modificări recente</a>"
 
 #: home/stats.html
 msgid "See all visitors to OpenLibrary.org"
@@ -4746,8 +4440,7 @@ msgstr "Stabiliți un obiectiv anual de lectură"
 
 #: home/welcome.html
 msgid "Learn how to set a yearly reading goal and track what you read"
-msgstr ""
-"Aflați cum să setați un obiectiv anual de lectură și să urmăriți ceea ce citiți"
+msgstr "Aflați cum să setați un obiectiv anual de lectură și să urmăriți ceea ce citiți"
 
 #: home/welcome.html
 msgid "Keep Track of your Favorite Books"
@@ -4810,9 +4503,17 @@ msgid "editions"
 msgstr "ediții"
 
 #: languages/index.html
-#, python-format
-msgid "%s book"
-msgid_plural "%s books"
+#, fuzzy, python-format
+msgid "%s work"
+msgid_plural "%s works"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: languages/index.html
+#, fuzzy, python-format
+msgid "%s ebook edition"
+msgid_plural "%s ebook editions"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
@@ -4835,6 +4536,38 @@ msgstr ""
 msgid "This doc was last edited anonymously"
 msgstr ""
 
+#: lib/exports.html
+msgid "Download catalog record:"
+msgstr ""
+
+#: lib/exports.html
+msgid "RDF"
+msgstr ""
+
+#: lib/exports.html type/list/exports.html
+msgid "JSON"
+msgstr ""
+
+#: lib/exports.html
+msgid "OPDS"
+msgstr ""
+
+#: lib/exports.html
+msgid "Cite this on Wikipedia"
+msgstr ""
+
+#: lib/exports.html
+msgid "Wikipedia citation"
+msgstr ""
+
+#: lib/exports.html
+msgid "Copy and paste this code into your Wikipedia page."
+msgstr ""
+
+#: lib/exports.html
+msgid "Get instructions at Wikipedia in a new window"
+msgstr ""
+
 #: lib/header_dropdown.html
 msgid "My account"
 msgstr ""
@@ -4852,8 +4585,7 @@ msgstr ""
 msgid "New!"
 msgstr ""
 
-#: databarDiff.html databarEdit.html databarTemplate.html databarView.html
-#: lib/history.html openlibrary/plugins/openlibrary/home.py
+#: databarDiff.html databarEdit.html databarTemplate.html databarView.html lib/history.html openlibrary/plugins/openlibrary/home.py
 msgid "History"
 msgstr "Istoric"
 
@@ -4869,38 +4601,6 @@ msgid_plural "%(count)d revisions"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
-
-#: lib/history.html
-msgid "Download catalog record:"
-msgstr ""
-
-#: lib/history.html
-msgid "RDF"
-msgstr ""
-
-#: lib/history.html type/list/exports.html
-msgid "JSON"
-msgstr ""
-
-#: lib/history.html
-msgid "OPDS"
-msgstr ""
-
-#: lib/history.html
-msgid "Cite this on Wikipedia"
-msgstr ""
-
-#: lib/history.html
-msgid "Wikipedia citation"
-msgstr ""
-
-#: lib/history.html
-msgid "Copy and paste this code into your Wikipedia page."
-msgstr ""
-
-#: lib/history.html
-msgid "Get instructions at Wikipedia in a new window"
-msgstr ""
 
 #: lib/history.html
 msgid "an anonymous user"
@@ -4925,9 +4625,7 @@ msgid " Your new record is in the library. Thank you!"
 msgstr ""
 
 #: lib/message_addbook.html
-msgid ""
-"There are a few other simple things you can add while you're here to improve your "
-"new record quickly, and make it much easier for other people to find later."
+msgid "There are a few other simple things you can add while you're here to improve your new record quickly, and make it much easier for other people to find later."
 msgstr ""
 
 #: lib/message_addbook.html
@@ -4962,7 +4660,7 @@ msgstr ""
 msgid "Just a sentence or two is good."
 msgstr ""
 
-#: lib/nav_foot.html site/neck.html
+#: lib/nav_foot.html openlibrary/plugins/openlibrary/api.py site/head.html
 msgid "Open Library"
 msgstr "Open Library"
 
@@ -5022,9 +4720,7 @@ msgstr "Descoperă autori"
 msgid "Explore subjects"
 msgstr "Descoperă subiecte"
 
-#: RelatedSubjects.html SearchNavigation.html SubjectTags.html lib/nav_foot.html
-#: lib/nav_head.html openlibrary/plugins/worksearch/code.py subjects/notfound.html
-#: type/author/view.html type/list/view_body.html
+#: RelatedSubjects.html SearchNavigation.html SubjectTags.html lib/nav_foot.html lib/nav_head.html openlibrary/plugins/worksearch/code.py subjects/notfound.html type/author/view.html type/list/view_body.html
 msgid "Subjects"
 msgstr "Subiecte"
 
@@ -5036,8 +4732,7 @@ msgstr "Descoperă colecții"
 msgid "Collections"
 msgstr "Colecții"
 
-#: SearchNavigation.html lib/nav_foot.html lib/nav_head.html
-#: search/advancedsearch.html
+#: SearchNavigation.html lib/nav_foot.html lib/nav_head.html search/advancedsearch.html
 msgid "Advanced Search"
 msgstr "Căutare avansată"
 
@@ -5114,12 +4809,31 @@ msgid "Release Notes"
 msgstr "Note de lansare"
 
 #: lib/nav_foot.html
+msgid "Bluesky"
+msgstr ""
+
+#: lib/nav_foot.html
+#, fuzzy
+msgid "Open Library on Bluesky"
+msgstr "Sigla Open Library"
+
+#: lib/nav_foot.html
 msgid "Twitter"
 msgstr "Twitter"
 
 #: lib/nav_foot.html
+#, fuzzy
+msgid "Open Library on Twitter"
+msgstr "Sigla Open Library"
+
+#: lib/nav_foot.html
 msgid "GitHub"
 msgstr "GitHub"
+
+#: lib/nav_foot.html
+#, fuzzy
+msgid "Open Library on GitHub"
+msgstr "Sigla Open Library"
 
 #: lib/nav_foot.html site/alert.html
 msgid "Change Website Language"
@@ -5130,29 +4844,13 @@ msgid "Open Library logo"
 msgstr "Sigla Open Library"
 
 #: lib/nav_foot.html
-msgid ""
-"Open Library is an initiative of the <a href=\"//archive.org/\">Internet Archive</"
-"a>, a 501(c)(3) non-profit, building a digital library of Internet sites and "
-"other cultural artifacts in  digital form. Other <a href=\"//archive.org/projects/"
-"\">projects</a> include the <a href=\"//archive.org/web/\">Wayback Machine</a>, "
-"<a href=\"//archive.org/\">archive.org</a> and <a href=\"//archive-it."
-"org\">archive-it.org</a>"
-msgstr ""
-"Open Library este o inițiativă a <a href=\"//archive.org/\">Internet Archive</a>, "
-"o organizație non-profit 501(c)(3) care construiește o bibliotecă digitală de "
-"site-uri de internet și alte artefacte culturale în formă digitală. Alte <a "
-"href=\"//archive.org/projects/\">proiecte</a> includ <a href=\"//archive.org/web/"
-"\">Wayback Machine</a>, <a href=\"//archive.org/\">archive.org</a> și <a href=\"//"
-"archive-it.org\">archive-it.org</a>"
+msgid "Open Library is an initiative of the <a href=\"//archive.org/\">Internet Archive</a>, a 501(c)(3) non-profit, building a digital library of Internet sites and other cultural artifacts in  digital form. Other <a href=\"//archive.org/projects/\">projects</a> include the <a href=\"//archive.org/web/\">Wayback Machine</a>, <a href=\"//archive.org/\">archive.org</a> and <a href=\"//archive-it.org\">archive-it.org</a>"
+msgstr "Open Library este o inițiativă a <a href=\"//archive.org/\">Internet Archive</a>, o organizație non-profit 501(c)(3) care construiește o bibliotecă digitală de site-uri de internet și alte artefacte culturale în formă digitală. Alte <a href=\"//archive.org/projects/\">proiecte</a> includ <a href=\"//archive.org/web/\">Wayback Machine</a>, <a href=\"//archive.org/\">archive.org</a> și <a href=\"//archive-it.org\">archive-it.org</a>"
 
 #: lib/nav_foot.html
 #, python-format
-msgid ""
-"version <a href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</"
-"a>"
-msgstr ""
-"versiune <a href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</"
-"a>"
+msgid "version <a href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</a>"
+msgstr "versiune <a href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</a>"
 
 #: lib/nav_head.html
 msgid "Loans, Reading Log, Lists, Stats"
@@ -5170,7 +4868,7 @@ msgstr "Deconectare"
 msgid "Pending Merge Requests"
 msgstr "Cereri de fuziune în așteptare"
 
-#: lib/nav_head.html
+#: lib/nav_head.html search/sort_options.html
 msgid "Trending"
 msgstr "În tendințe"
 
@@ -5216,13 +4914,15 @@ msgstr "Resurse"
 
 #: lib/nav_head.html
 msgid "The Internet Archive's Open Library: One page for every book"
-msgstr ""
-"Biblioteca deschisă a inițiativei „Internet Archive”: O pagină pentru fiecare "
-"carte"
+msgstr "Biblioteca deschisă a inițiativei „Internet Archive”: O pagină pentru fiecare carte"
 
 #: lib/nav_head.html
 msgid "Text"
 msgstr "Text"
+
+#: lib/nav_head.html search/advancedsearch.html
+msgid "Subject"
+msgstr "Subiect"
 
 #: lib/nav_head.html
 msgid "Advanced"
@@ -5233,16 +4933,29 @@ msgid "Search by barcode"
 msgstr "Căutați după codul de bare"
 
 #: lib/not_logged.html
-msgid ""
-"<strong>You are not <a href=\"/account/login\" title=\"Log in now\">logged in</a>."
-"</strong> Open Library will record your IP address and include it in this page's "
-"publicly accessible edit history. If you <a href=\"/account/create\" "
-"title=\"Create an Open Library account\">create an account</a>, your IP address "
-"is concealed and you can more easily keep track of all your edits and additions."
+msgid "<strong>You are not <a href=\"/account/login\" title=\"Log in now\">logged in</a>.</strong> Open Library will record your IP address and include it in this page's publicly accessible edit history. If you <a href=\"/account/create\" title=\"Create an Open Library account\">create an account</a>, your IP address is concealed and you can more easily keep track of all your edits and additions."
 msgstr ""
 
-#: Pager.html Pager_loanhistory.html lib/pagination.html
-msgid "Previous"
+#: librarian_dashboard/data_quality_table.html
+#, fuzzy
+msgid "Reload"
+msgstr "Citit"
+
+#: librarian_dashboard/data_quality_table.html
+#, fuzzy
+msgid "failing"
+msgstr "Urmăresc"
+
+#: librarian_dashboard/data_quality_table.html
+msgid "Data quality table"
+msgstr ""
+
+#: librarian_dashboard/data_quality_table.html
+msgid "Quality Criteria"
+msgstr ""
+
+#: lists/carousel.html lists/home.html lists/showcase.html
+msgid "See all"
 msgstr ""
 
 #: lists/export_as_html.html
@@ -5320,17 +5033,12 @@ msgid "Create a list of any Subjects, Authors, Works or specific Editions."
 msgstr ""
 
 #: lists/home.html
-msgid ""
-"Once you've made a list, you can <strong>watch for updates</strong> or "
-"<strong>export</strong> all the editions in a list as HTML, BibTeX or JSON. See "
-"all your lists and any activity using the \"Lists\" link on your Account page."
+msgid "Once you've made a list, you can <strong>watch for updates</strong> or <strong>export</strong> all the editions in a list as HTML, BibTeX or JSON. See all your lists and any activity using the \"Lists\" link on your Account page."
 msgstr ""
 
 #: lists/home.html
 #, python-format
-msgid ""
-"For the top 2000+ most requested eBooks in California for the print disabled <a "
-"href=\"%(url)s\">click here</a>."
+msgid "For the top 2000+ most requested eBooks in California for the print disabled <a href=\"%(url)s\">click here</a>."
 msgstr ""
 
 #: lists/home.html
@@ -5346,8 +5054,7 @@ msgstr "Liste active"
 msgid "from <a href=\"%(key)s\">%(owner)s</a>"
 msgstr ""
 
-#: lists/home.html lists/preview.html lists/snippet.html type/list/embed.html
-#: type/list/view_body.html
+#: lists/home.html lists/preview.html lists/snippet.html type/list/embed.html type/list/view_body.html
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
@@ -5368,8 +5075,38 @@ msgstr ""
 msgid "Recent Activity"
 msgstr "Activitate recentă"
 
-#: lists/home.html lists/showcase.html
-msgid "See all"
+#: lists/list_follow.html
+msgid "Cover of book"
+msgstr ""
+
+#: lists/list_follow.html
+msgid "Avatar of the owner of the list"
+msgstr ""
+
+#: lists/list_follow.html lists/widget.html my_books/dropdown_content.html
+msgid "You"
+msgstr ""
+
+#: lists/list_follow.html
+msgid "This patron has not enabled following"
+msgstr ""
+
+#: lists/list_follow.html
+msgid "🔒︎"
+msgstr ""
+
+#: Follow.html lists/list_follow.html
+msgid "Follow"
+msgstr ""
+
+#: lists/list_follow.html
+#, fuzzy
+msgid "OpenLibrary Logo"
+msgstr "Sigla Open Library"
+
+#: lists/list_follow.html
+#, fuzzy
+msgid "Community List"
 msgstr ""
 
 #: lists/list_overview.html lists/widget.html my_books/dropdown_content.html
@@ -5419,10 +5156,6 @@ msgstr ""
 msgid "Remove this seed?"
 msgstr ""
 
-#: lists/lists.html type/list/edit.html
-msgid "Remove"
-msgstr ""
-
 #: lists/lists.html
 #, python-format
 msgid "Are you sure you want to remove <strong>%(title)s</strong> from this list?"
@@ -5441,7 +5174,8 @@ msgid "Learn how to create your first list."
 msgstr "Aflați cum puteți să creați prima dumneavoastră listă."
 
 #: lists/preview.html
-msgid "by <a href=\"$owner.key\">You</a>"
+#, python-format
+msgid "by <a href=\"%s\">You</a>"
 msgstr ""
 
 #: lists/showcase.html
@@ -5453,20 +5187,8 @@ msgstr "Listele mele (%(count)d)"
 msgid "You have no lists."
 msgstr "Nu aveți nicio listă."
 
-#: lists/widget.html
-#, python-format
-msgid "%(count)d List"
-msgid_plural "%(count)d Lists"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-
 #: lists/widget.html my_books/dropdown_content.html type/type/view.html
 msgid "from"
-msgstr ""
-
-#: lists/widget.html my_books/dropdown_content.html
-msgid "You"
 msgstr ""
 
 #: lists/widget.html
@@ -5692,9 +5414,7 @@ msgstr ""
 
 #: merge_request_table/table_row.html
 #, python-format
-msgid ""
-"MR #%(id)s opened %(date)s by <a href=\"/people/%(submitter)s\" "
-"class=\"commenter\">@%(submitter)s</a>"
+msgid "MR #%(id)s opened %(date)s by <a href=\"/people/%(submitter)s\" class=\"commenter\">@%(submitter)s</a>"
 msgstr ""
 
 #: merge_request_table/table_row.html
@@ -5729,17 +5449,134 @@ msgstr ""
 msgid "Create a new list"
 msgstr ""
 
-#: CreateListModal.html my_books/dropdown_content.html type/permission/edit.html
-#: type/usergroup/edit.html
+#: CreateListModal.html my_books/dropdown_content.html type/permission/edit.html type/usergroup/edit.html
 msgid "Description:"
 msgstr ""
 
-#: CreateListModal.html my_books/dropdown_content.html type/list/edit.html
+#: CreateListModal.html my_books/dropdown_content.html type/list/edit.html type/series/edit.html
 msgid "Create new list"
+msgstr ""
+
+#: my_books/dropdown_content.html
+#, fuzzy
+msgid "saving..."
+msgstr "Se încarcă..."
+
+#: my_books/dropdown_content.html
+msgid "Removing this book from your shelves will delete your check-ins for this work.  Continue?"
 msgstr ""
 
 #: my_books/primary_action.html
 msgid "Add to List"
+msgstr ""
+
+#: my_books/check_ins/check_in_form.html
+msgid "January"
+msgstr ""
+
+#: my_books/check_ins/check_in_form.html
+msgid "February"
+msgstr ""
+
+#: my_books/check_ins/check_in_form.html
+msgid "March"
+msgstr ""
+
+#: my_books/check_ins/check_in_form.html
+msgid "April"
+msgstr ""
+
+#: my_books/check_ins/check_in_form.html
+msgid "May"
+msgstr ""
+
+#: my_books/check_ins/check_in_form.html
+msgid "June"
+msgstr ""
+
+#: my_books/check_ins/check_in_form.html
+msgid "July"
+msgstr ""
+
+#: my_books/check_ins/check_in_form.html
+msgid "August"
+msgstr ""
+
+#: my_books/check_ins/check_in_form.html
+msgid "September"
+msgstr ""
+
+#: my_books/check_ins/check_in_form.html
+msgid "October"
+msgstr ""
+
+#: my_books/check_ins/check_in_form.html
+msgid "November"
+msgstr ""
+
+#: my_books/check_ins/check_in_form.html
+msgid "December"
+msgstr ""
+
+#: my_books/check_ins/check_in_form.html
+msgid "Add an optional check-in date. Check-in dates are used to track yearly reading goals."
+msgstr ""
+
+#: my_books/check_ins/check_in_form.html
+msgid "End Date:"
+msgstr ""
+
+#: my_books/check_ins/check_in_form.html
+msgid "Year:"
+msgstr ""
+
+#: my_books/check_ins/check_in_form.html
+msgid "Year"
+msgstr ""
+
+#: my_books/check_ins/check_in_form.html
+msgid "Month:"
+msgstr ""
+
+#: my_books/check_ins/check_in_form.html
+msgid "Month"
+msgstr ""
+
+#: my_books/check_ins/check_in_form.html
+msgid "Day:"
+msgstr ""
+
+#: my_books/check_ins/check_in_form.html
+msgid "Day"
+msgstr ""
+
+#: my_books/check_ins/check_in_form.html
+msgid "Delete Event"
+msgstr ""
+
+#: my_books/check_ins/check_in_prompt.html
+msgid "Failed to delete check-in. Please try again in a few moments."
+msgstr ""
+
+#: my_books/check_ins/check_in_prompt.html
+msgid "Failed to submit check-in. Please try again in a few moments."
+msgstr ""
+
+#: my_books/check_ins/check_in_prompt.html
+#, python-format
+msgid "Read <time class=\"check-in-date\">%(date)s</time>"
+msgstr ""
+
+#: my_books/check_ins/check_in_prompt.html
+msgid "When did you finish this book?"
+msgstr ""
+
+#: my_books/check_ins/check_in_prompt.html
+msgid "Other"
+msgstr ""
+
+#: my_books/check_ins/check_in_prompt.html
+msgid "Check-In"
 msgstr ""
 
 #: observations/review_component.html
@@ -5784,12 +5621,11 @@ msgstr ""
 msgid "Publisher: %(name)s"
 msgstr ""
 
-#: openlibrary/plugins/worksearch/code.py publishers/view.html
-#: search/advancedsearch.html type/edition/view.html type/work/view.html
+#: openlibrary/plugins/worksearch/code.py publishers/view.html search/advancedsearch.html type/edition/view.html type/work/view.html
 msgid "Publisher"
 msgstr ""
 
-#: publishers/view.html
+#: SearchResultsWork.html publishers/view.html
 #, python-format
 msgid "%(count)s ebook"
 msgid_plural "%(count)s ebooks"
@@ -5806,10 +5642,7 @@ msgid "Publishing History"
 msgstr ""
 
 #: publishers/view.html
-msgid ""
-"This is a chart to show the when this publisher published books. Along the X axis "
-"is time, and on the y axis is the count of editions published. <a "
-"href=\"#subjectRelated\">Click here to skip the chart</a>."
+msgid "This is a chart to show the when this publisher published books. Along the X axis is time, and on the y axis is the count of editions published. <a href=\"#subjectRelated\">Click here to skip the chart</a>."
 msgstr ""
 
 #: PublishingHistory.html publishers/view.html
@@ -5821,9 +5654,7 @@ msgid "or continue zooming in."
 msgstr ""
 
 #: publishers/view.html
-msgid ""
-"This graph charts editions from this publisher over time. Click to view a single "
-"year, or drag across a range."
+msgid "This graph charts editions from this publisher over time. Click to view a single year, or drag across a range."
 msgstr ""
 
 #: PublishingHistory.html publishers/view.html
@@ -5858,6 +5689,24 @@ msgstr ""
 #: publishers/view.html
 msgid "Get more information about this publisher"
 msgstr ""
+
+#: reading_goals/reading_goal_form.html
+msgid "How many books would you like to read this year?"
+msgstr "Câte cărți doriți să citiți anul acesta?"
+
+#: reading_goals/reading_goal_form.html
+msgid "Enter \"0\" to unset your reading goal. Your check-ins will be preserved."
+msgstr ""
+
+#: reading_goals/reading_goal_progress.html
+#, python-format
+msgid "<span class=\"reading-goal-progress__books-read\">%(books_read)d</span>/<span class=\"reading-goal-progress__goal\">%(goal)d</span> Books"
+msgstr ""
+
+#: reading_goals/reading_goal_progress.html
+#, python-format
+msgid "Edit %(year)d Reading Goal"
+msgstr "Modifică obiectivul de citire pentru %(year)d"
 
 #: recentchanges/header.html
 msgid "By"
@@ -5899,12 +5748,23 @@ msgstr ""
 msgid "Admin view"
 msgstr ""
 
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html recentchanges/render.html
+msgid "Older"
+msgstr ""
+
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html recentchanges/render.html
+msgid "Newer"
+msgstr ""
+
 #: recentchanges/updated_records.html
 msgid "Review what's changed in from the previous revision"
 msgstr ""
 
-#: recentchanges/add-book/path.html recentchanges/default/path.html
-#: recentchanges/edit-book/path.html recentchanges/merge/path.html
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html recentchanges/default/path.html recentchanges/updated_records.html
+msgid "diff"
+msgstr ""
+
+#: recentchanges/add-book/path.html recentchanges/default/path.html recentchanges/edit-book/path.html recentchanges/merge/path.html
 msgid "expand"
 msgstr ""
 
@@ -5916,8 +5776,7 @@ msgstr ""
 msgid "Review what's changed from the previous revision"
 msgstr ""
 
-#: recentchanges/default/view.html recentchanges/merge/view.html
-#: recentchanges/undo/view.html
+#: recentchanges/default/view.html recentchanges/merge/view.html recentchanges/undo/view.html
 msgid "Updated Records"
 msgstr ""
 
@@ -6040,8 +5899,7 @@ msgstr ""
 msgid "Search Open Library for %s"
 msgstr ""
 
-#: BookSearchInside.html FulltextSearchSuggestion.html SearchNavigation.html
-#: search/inside.html search/snippets.html
+#: BookSearchInside.html FulltextSearchSuggestion.html SearchNavigation.html search/inside.html search/snippets.html
 msgid "Search Inside"
 msgstr ""
 
@@ -6064,6 +5922,19 @@ msgid_plural "in %(seconds)s seconds"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
+
+#: EditionNavBar.html search/layout_options.html site/stats.html
+msgid "Details"
+msgstr "Detalii"
+
+#: search/layout_options.html
+msgid "Grid"
+msgstr ""
+
+#: search/layout_options.html
+#, fuzzy
+msgid "View as: "
+msgstr "Vizualizează"
 
 #: search/lists.html
 msgid "Search results for Lists"
@@ -6091,7 +5962,23 @@ msgid "Relevance"
 msgstr ""
 
 #: search/sort_options.html
+msgid "Work Count"
+msgstr ""
+
+#: search/sort_options.html
 msgid "Random"
+msgstr ""
+
+#: search/sort_options.html
+msgid "Name (beta: Librarian only)"
+msgstr ""
+
+#: search/sort_options.html
+msgid "Birth Date (oldest) (beta: Librarian only)"
+msgstr ""
+
+#: search/sort_options.html
+msgid "Birth Date (youngest) (beta: Librarian only)"
 msgstr ""
 
 #: search/sort_options.html
@@ -6100,6 +5987,23 @@ msgstr ""
 
 #: search/sort_options.html
 msgid "Last Modified"
+msgstr ""
+
+#: search/sort_options.html
+#, fuzzy
+msgid "Language Name"
+msgstr "limbi"
+
+#: search/sort_options.html
+msgid "Ebook Edition Count"
+msgstr ""
+
+#: search/sort_options.html
+msgid "Date Added (newest)"
+msgstr ""
+
+#: search/sort_options.html
+msgid "Date Added (oldest)"
 msgstr ""
 
 #: search/sort_options.html
@@ -6119,15 +6023,15 @@ msgid "Top Rated"
 msgstr ""
 
 #: search/sort_options.html
+msgid "Any"
+msgstr ""
+
+#: search/sort_options.html
 msgid "Work Title (beta: Librarian only)"
 msgstr ""
 
 #: search/sort_options.html
-msgid "Work Count"
-msgstr ""
-
-#: search/sort_options.html
-msgid "Any"
+msgid "Sorting by"
 msgstr ""
 
 #: search/sort_options.html
@@ -6179,12 +6083,9 @@ msgid "Merge duplicates"
 msgstr ""
 
 #: search/work_search_facets.html
-msgid "more"
-msgstr ""
-
-#: search/work_search_facets.html
-msgid "less"
-msgstr ""
+#, fuzzy
+msgid "Less"
+msgstr "Liste"
 
 #: search/work_search_facets.html
 #, python-format
@@ -6212,31 +6113,6 @@ msgid "Focus your results using these <a href=\"/search/howto\">filters</a>"
 msgstr ""
 
 #: search/work_search_selected_facets.html
-msgid "eBook"
-msgstr ""
-
-#: search/work_search_selected_facets.html
-msgid "Classic eBook"
-msgstr ""
-
-#: search/work_search_selected_facets.html
-msgid "Search facets"
-msgstr ""
-
-#: search/work_search_selected_facets.html
-msgid "Explore Classic eBooks"
-msgstr ""
-
-#: search/work_search_selected_facets.html
-msgid "Only Classic eBooks"
-msgstr ""
-
-#: search/work_search_selected_facets.html
-#, python-format
-msgid "Explore books about %(subject)s"
-msgstr ""
-
-#: search/work_search_selected_facets.html
 msgid "Written in"
 msgstr ""
 
@@ -6245,8 +6121,21 @@ msgid "Published by"
 msgstr ""
 
 #: search/work_search_selected_facets.html
-msgid "Click to remove this facet"
+msgid "eBook"
 msgstr ""
+
+#: search/work_search_selected_facets.html
+msgid "Classic eBook"
+msgstr ""
+
+#: search/work_search_selected_facets.html
+msgid "Only Classic eBooks"
+msgstr ""
+
+#: search/work_search_selected_facets.html
+#, fuzzy
+msgid "Classic eBooks hidden"
+msgstr "Cărți electronice clasice"
 
 #: search/work_search_selected_facets.html
 #, python-format
@@ -6261,23 +6150,13 @@ msgstr ""
 msgid "It looks like you're offline."
 msgstr ""
 
-#: site/neck.html
-msgid ""
-"Open Library is an open, editable library catalog, building towards a web page "
-"for every book ever published. Read, borrow, and discover more than 3M books for "
-"free."
-msgstr ""
-"Open Library este un catalog de bibliotecă deschis și editabil, care își propune "
-"să creeze o pagină web pentru fiecare carte publicată vreodată. Citiți, "
-"împrumutați și descoperiți peste 3 milioane de cărți gratuit."
+#: site/head.html
+msgid "Open Library is an open, editable library catalog, building towards a web page for every book ever published. Read, borrow, and discover more than 3M books for free."
+msgstr "Open Library este un catalog de bibliotecă deschis și editabil, care își propune să creeze o pagină web pentru fiecare carte publicată vreodată. Citiți, împrumutați și descoperiți peste 3 milioane de cărți gratuit."
 
 #: site/stats.html
 msgid "Debug Stats"
 msgstr ""
-
-#: EditionNavBar.html site/stats.html
-msgid "Details"
-msgstr "Detalii"
 
 #: stats/readinglog.html
 msgid "Reading Log Stats"
@@ -6300,9 +6179,7 @@ msgid "# Unique Users Logging Books"
 msgstr ""
 
 #: stats/readinglog.html
-msgid ""
-"The total number of unique users who have logged at least one book using the "
-"Reading Log feature"
+msgid "The total number of unique users who have logged at least one book using the Reading Log feature"
 msgstr ""
 
 #: stats/readinglog.html
@@ -6357,8 +6234,7 @@ msgstr ""
 msgid "OpenAPI"
 msgstr "OpenAPI"
 
-#: type/about/edit.html type/page/edit.html type/permission/edit.html
-#: type/template/edit.html type/usergroup/edit.html
+#: type/about/edit.html type/page/edit.html type/permission/edit.html type/template/edit.html type/usergroup/edit.html
 #, python-format
 msgid "Edit %(title)s"
 msgstr ""
@@ -6396,9 +6272,7 @@ msgid "Edit Author"
 msgstr ""
 
 #: type/author/edit.html
-msgid ""
-"Please use natural order. For example: <strong>Leo Tolstoy</strong> not "
-"<strong>Tolstoy, Leo</strong>."
+msgid "Please use natural order. For example: <strong>Leo Tolstoy</strong> not <strong>Tolstoy, Leo</strong>."
 msgstr ""
 
 #: type/author/edit.html
@@ -6406,8 +6280,7 @@ msgid "A short bio?"
 msgstr ""
 
 #: type/author/edit.html
-msgid ""
-"If you \"borrow\" information from somewhere, please make sure to cite the source."
+msgid "If you \"borrow\" information from somewhere, please make sure to cite the source."
 msgstr ""
 
 #: type/author/edit.html
@@ -6419,15 +6292,11 @@ msgid "Date of death"
 msgstr ""
 
 #: type/author/edit.html
-msgid ""
-"We're not storing structured dates (yet) so a date like \"21 May 2000\" is "
-"recommended."
+msgid "We're not storing structured dates (yet) so a date like \"21 May 2000\" is recommended."
 msgstr ""
 
 #: type/author/edit.html
-msgid ""
-"This is a deprecated field. You can help improve this record by removing this "
-"date and populating the \"Date of birth\" and \"Date of death\" fields. Thanks!"
+msgid "This is a deprecated field. You can help improve this record by removing this date and populating the \"Date of birth\" and \"Date of death\" fields. Thanks!"
 msgstr ""
 
 #: type/author/edit.html
@@ -6435,9 +6304,7 @@ msgid "Does this author go by any other names?"
 msgstr ""
 
 #: type/author/edit.html
-msgid ""
-"For example: Lev Nikolayevich Tolstoy was also known as Leo Tolstoy. Please list "
-"one name per line."
+msgid "For example: Lev Nikolayevich Tolstoy was also known as Leo Tolstoy. Please list one name per line."
 msgstr ""
 
 #: type/author/edit.html
@@ -6471,9 +6338,7 @@ msgid "Refresh the page?"
 msgstr ""
 
 #: type/author/view.html
-msgid ""
-"OK. The merge is in motion. <i>It will take <u>a few minutes to finish</u> the "
-"update.</i>"
+msgid "OK. The merge is in motion. <i>It will take <u>a few minutes to finish</u> the update.</i>"
 msgstr ""
 
 #: type/author/view.html
@@ -6485,25 +6350,7 @@ msgid "That merge didn't work. It's our fault, and we've made a note of it."
 msgstr ""
 
 #: type/author/view.html
-msgid "Location"
-msgstr ""
-
-#: type/author/view.html
 msgid "Add another?"
-msgstr ""
-
-#: type/author/view.html
-#, python-format
-msgid ""
-"Showing all works by author. Would you like to see <a href=\"%(url)s\">only "
-"ebooks</a>?"
-msgstr ""
-
-#: type/author/view.html
-#, python-format
-msgid ""
-"Showing ebooks only. Would you like to see <a href=\"%(url)s\">everything</a> by "
-"this author?"
 msgstr ""
 
 #: type/author/view.html
@@ -6511,8 +6358,12 @@ msgstr ""
 msgid "Search %(author)s books"
 msgstr ""
 
-#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py
-#: type/author/view.html type/list/view_body.html
+#: type/author/view.html
+#, python-format
+msgid "— Show <a href=\"%(url)s\">everything</a> by this author?"
+msgstr ""
+
+#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py type/author/view.html type/list/view_body.html
 msgid "Places"
 msgstr ""
 
@@ -6561,15 +6412,15 @@ msgid "View the previous version"
 msgstr ""
 
 #: type/delete/view.html
-msgid "Recreate it"
-msgstr ""
-
-#: type/delete/view.html
 msgid "See the page's history"
 msgstr ""
 
+#: type/delete/view.html
+msgid "Recreate it"
+msgstr ""
+
 #: type/edition/admin_bar.html
-msgid "Add to Staff Picks"
+msgid "Add IA Book to Staff Picks"
 msgstr ""
 
 #: type/edition/admin_bar.html
@@ -6592,6 +6443,16 @@ msgstr ""
 msgid "Review"
 msgstr ""
 
+#: type/edition/modal_links.html
+#, fuzzy
+msgid "reviewing"
+msgstr "Recenzii"
+
+#: type/edition/modal_links.html
+#, fuzzy
+msgid "adding notes to"
+msgstr "Nicio notă găsită."
+
 #: type/edition/title_and_author.html
 msgid "An edition of"
 msgstr ""
@@ -6601,18 +6462,29 @@ msgstr ""
 msgid "First published in %s"
 msgstr ""
 
+#: type/edition/title_and_author.html
+#, fuzzy, python-format
+msgid "Book %s"
+msgstr ""
+
+#: type/edition/view.html type/work/view.html
+#, fuzzy
+msgid "Read More"
+msgstr "Află mai multe"
+
+#: type/edition/view.html type/work/view.html
+#, fuzzy
+msgid "Read Less"
+msgstr "Citit"
+
 #: type/edition/view.html type/work/view.html
 #, python-format
-msgid ""
-"This work doesn't have a description yet. Can you <b><a href='%(url)s'>add one</"
-"a></b>?"
+msgid "This work doesn't have a description yet. Can you <b><a href='%(url)s'>add one</a></b>?"
 msgstr ""
 
 #: type/edition/view.html type/work/view.html
 #, python-format
-msgid ""
-"This edition doesn't have a description yet. Can you <b><a href='%(url)s'>add "
-"one</a></b>?"
+msgid "This edition doesn't have a description yet. Can you <b><a href='%(url)s'>add one</a></b>?"
 msgstr ""
 
 #: type/edition/view.html type/work/view.html
@@ -6697,7 +6569,7 @@ msgstr "Legături externe"
 msgid "Format"
 msgstr "Format"
 
-#: type/edition/view.html type/work/view.html
+#: OlPagination.html OlPaginationArrows.html type/edition/view.html type/work/view.html
 msgid "Pagination"
 msgstr ""
 
@@ -6748,15 +6620,13 @@ msgid "Wikipedia"
 msgstr ""
 
 #: type/edition/view.html type/work/view.html
-msgid "This work does not appear on any lists."
-msgstr ""
-
-#: type/edition/view.html type/work/view.html
-msgid "Loading Related Books"
-msgstr ""
+#, fuzzy
+msgid "Loading Lists"
+msgstr "Istoric împrumuturi"
 
 #: type/language/view.html
-msgid "deprecated"
+#, python-format
+msgid "%(language)s [deprecated]"
 msgstr ""
 
 #: type/language/view.html
@@ -6776,47 +6646,74 @@ msgstr ""
 msgid "Try a <a href=\"%(href)s\">search for readable books in %(language)s</a>?"
 msgstr ""
 
-#: type/list/edit.html
+#: type/list/edit.html type/series/edit.html
+#, fuzzy
+msgid "Create a series"
+msgstr "Creați o listă"
+
+#: type/list/edit.html type/series/edit.html
+#, python-format
+msgid "Editing series: %(list_name)s"
+msgstr ""
+
+#: type/list/edit.html type/series/edit.html
 #, python-format
 msgid "Editing list: %(list_name)s"
 msgstr ""
 
-#: type/list/edit.html
+#: type/list/edit.html type/series/edit.html
+#, fuzzy
+msgid "Edit Series"
+msgstr "Editează lista"
+
+#: type/list/edit.html type/series/edit.html
 msgid "Edit List"
 msgstr "Editează lista"
 
-#: type/list/edit.html
-msgid "⚠️ Saving global lists is admin-only while the feature is under development."
+#: type/list/edit.html type/series/edit.html
+msgid "Move..."
 msgstr ""
 
-#: type/list/edit.html
+#: type/list/edit.html type/series/edit.html
 msgid "Search for a book"
 msgstr ""
 
-#: type/list/edit.html
+#: type/list/edit.html type/series/edit.html
+msgid "Position (optional), e.g. 1, 2, 1-7"
+msgstr ""
+
+#: type/list/edit.html type/series/edit.html
 msgid "Notes (optional)"
 msgstr ""
 
-#: type/list/edit.html
+#: type/list/edit.html type/series/edit.html
 msgid "List Name"
 msgstr ""
 
-#: type/list/edit.html
+#: type/list/edit.html type/series/edit.html
+#, fuzzy
+msgid "Series Name"
+msgstr "Nume de utilizator"
+
+#: type/list/edit.html type/series/edit.html
 msgid "Description (optional)"
 msgstr ""
 
-#: type/list/edit.html
+#: type/list/edit.html type/series/edit.html
 msgid "Add another book"
 msgstr ""
+
+#: type/list/edit.html type/series/edit.html
+#, fuzzy
+msgid "Create new series"
+msgstr "Creați o listă"
 
 #: type/list/embed.html
 msgid "Visit Open Library"
 msgstr ""
 
 #: type/list/embed.html
-msgid ""
-"Open in online Book Reader. Downloads available in ePub, DAISY, PDF, TXT formats "
-"from main book page"
+msgid "Open in online Book Reader. Downloads available in ePub, DAISY, PDF, TXT formats from main book page"
 msgstr ""
 
 #: type/list/embed.html
@@ -6868,15 +6765,12 @@ msgstr ""
 
 #: type/list/exports.html
 #, python-format
-msgid ""
-"Only lists with up to %(max)s editions can be exported. This one has %(count)s."
+msgid "Only lists with up to %(max)s editions can be exported. This one has %(count)s."
 msgstr ""
 
 #: type/list/exports.html
 #, python-format
-msgid ""
-"Try removing some seeds for more focus, or look at <a href=\"%s\">bulk download</"
-"a> of the catalog."
+msgid "Try removing some seeds for more focus, or look at <a href=\"%s\">bulk download</a> of the catalog."
 msgstr ""
 
 #: type/list/view_body.html
@@ -6915,9 +6809,12 @@ msgid "Remove Seed"
 msgstr ""
 
 #: type/list/view_body.html
-msgid ""
-"You are about to remove the last item in the list. That will delete the whole "
-"list. Are you sure you want to continue?"
+msgid "You are about to remove the last item in the list. That will delete the whole list. Are you sure you want to continue?"
+msgstr ""
+
+#: type/list/view_body.html
+#, python-format
+msgid "This series contains %(limit)d or more works. Currently, only the first %(limit)d works are displayed."
 msgstr ""
 
 #: type/list/view_body.html
@@ -6925,9 +6822,7 @@ msgid "There are no items on this list."
 msgstr ""
 
 #: type/list/view_body.html
-msgid ""
-"<a href=\"/search\" target=\"_blank\">Search for book, subjects, or authors</a> "
-"to add to your list."
+msgid "<a href=\"/search\" target=\"_blank\" rel=\"noopener noreferrer\">Search for book, subjects, or authors</a> to add to your list."
 msgstr ""
 
 #: type/list/view_body.html
@@ -6942,8 +6837,7 @@ msgstr ""
 msgid "Derived from seed metadata"
 msgstr ""
 
-#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py
-#: type/list/view_body.html
+#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py type/list/view_body.html
 msgid "Times"
 msgstr ""
 
@@ -7011,12 +6905,50 @@ msgstr ""
 msgid "We require a minimum set of fields to create a new collection tag."
 msgstr ""
 
+#: EditButtons.html type/tag/form.html
+msgid "By saving a change to this wiki, you agree that your contribution is given freely to the world under <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" target=\"_blank\" rel=\"noopener noreferrer\" title=\"This link to Creative Commons will open in a new window\">CC0</a>. Yippee!"
+msgstr ""
+
 #: type/tag/form.html
 msgid "Add this tag now"
 msgstr ""
 
+#: type/tag/index.html
+#, fuzzy
+msgid "Tags"
+msgstr "Pagini"
+
+#: type/tag/index.html
+msgid "Tags curated by Open Library librarians."
+msgstr ""
+
+#: type/tag/index.html
+msgid "View subject page"
+msgstr ""
+
+#: type/tag/index.html
+msgid "Previous"
+msgstr ""
+
+#: type/tag/index.html
+#, fuzzy
+msgid "No tags found."
+msgstr "Nicio notă găsită."
+
 #: type/tag/tag_form_inputs.html
 msgid "Tag Name"
+msgstr ""
+
+#: type/tag/tag_form_inputs.html
+msgid "Human-readable display name (e.g. \"Computer Science\", \"Horror Fiction\")"
+msgstr ""
+
+#: type/tag/tag_form_inputs.html
+msgid "Tag Slugs"
+msgstr ""
+
+#: type/tag/tag_form_inputs.html
+msgid "Comma-separated URL slugs that map to this tag (auto-populated from name). E.g. \"computer_science, cs\""
 msgstr ""
 
 #: type/tag/tag_form_inputs.html
@@ -7031,6 +6963,10 @@ msgstr ""
 msgid "Tag type"
 msgstr ""
 
+#: type/tag/tag_form_inputs.html
+msgid "Tag Deputy"
+msgstr ""
+
 #: type/tag/view.html
 #, python-format
 msgid "<strong>Type:</strong> %(tag_type)s"
@@ -7042,6 +6978,10 @@ msgstr ""
 
 #: type/tag/view.html
 msgid "Tag Body"
+msgstr ""
+
+#: type/tag/view.html
+msgid "URL Slugs"
 msgstr ""
 
 #: type/tag/view.html
@@ -7100,11 +7040,7 @@ msgstr ""
 
 #: type/user/view.html
 #, python-format
-msgid ""
-"You are publicly sharing the books you are <a href=\"%(username)s/books/currently-"
-"reading\">currently reading</a>, <a href=\"%(username)s/books/already-read\">have "
-"already read</a>, and <a href=\"%(username)s/books/want-to-read\">want to read</"
-"a>."
+msgid "You are publicly sharing the books you are <a href=\"%(username)s/books/currently-reading\">currently reading</a>, <a href=\"%(username)s/books/already-read\">have already read</a>, <a href=\"%(username)s/books/want-to-read\">want to read</a>, and have <a href=\"%(username)s/books/stopped-reading\">stopped reading</a>!"
 msgstr ""
 
 #: type/user/view.html
@@ -7121,11 +7057,7 @@ msgstr "Gestionați setările dumneavoastră de confidențialitate"
 
 #: type/user/view.html
 #, python-format
-msgid ""
-"Here are the books %(user)s is <a href=\"%(username)s/books/currently-"
-"reading\">currently reading</a>, <a href=\"%(username)s/books/already-read\">have "
-"already read</a>, and <a href=\"%(username)s/books/want-to-read\">want to read</"
-"a>!"
+msgid "Here are the books %(user)s is <a href=\"%(username)s/books/currently-reading\">currently reading</a>, <a href=\"%(username)s/books/already-read\">have already read</a>, <a href=\"%(username)s/books/want-to-read\">want to read</a>, and has <a href=\"%(username)s/books/stopped-reading\">stopped reading</a>!"
 msgstr ""
 
 #: type/user/view.html
@@ -7193,29 +7125,11 @@ msgid "Look for this edition for sale at %(store)s"
 msgstr ""
 
 #: AffiliateLinks.html
+msgid "When you buy books using these links the Internet Archive may earn a <a class=\"nostyle\" href=\"/help/faq/about#selling\">small commission</a>."
+msgstr ""
+
+#: AffiliateLinksLoadingIndicator.html
 msgid "Fetching prices"
-msgstr ""
-
-#: AffiliateLinks.html
-msgid "Better World Books"
-msgstr ""
-
-#: AffiliateLinks.html
-msgid " - includes shipping"
-msgstr ""
-
-#: AffiliateLinks.html
-msgid "Amazon"
-msgstr ""
-
-#: AffiliateLinks.html
-msgid "Bookshop.org"
-msgstr ""
-
-#: AffiliateLinks.html
-msgid ""
-"When you buy books using these links the Internet Archive may earn a <a "
-"class=\"nostyle\" href=\"/help/faq/about#selling\">small commission</a>."
 msgstr ""
 
 #: BatchImportNavigation.html
@@ -7243,71 +7157,7 @@ msgid "Preview Book"
 msgstr ""
 
 #: DisplayCode.html
-msgid ""
-"Templates in the website are disabled now. Editing them will not have any effect "
-"on the live website."
-msgstr ""
-
-#: DonateModal.html
-msgid ""
-"Donate this book to the <a href=\"https://archive.org\">Internet Archive</a> "
-"library."
-msgstr ""
-
-#: DonateModal.html
-msgid ""
-"Hooray! You've discovered a title that's missing from our <a href=\"https://help."
-"archive.org/hc/en-us/articles/360016554912-Borrowing-From-The-Lending-"
-"Library\">library</a>. Can you help donate a copy?"
-msgstr ""
-
-#: DonateModal.html
-msgid ""
-"If you own this book, you can<a href=\"https://store.usps.com/store/product/"
-"shipping-supplies/priority-mail-express-padded-flat-rate-envelope-"
-"P_EP13PE\">mail</a> it to our address below."
-msgstr ""
-
-#: DonateModal.html
-msgid "You can also purchase this book from a vendor and ship it to our address:"
-msgstr ""
-
-#: DonateModal.html
-msgid "Benefits of donating"
-msgstr ""
-
-#: DonateModal.html
-msgid ""
-"When you donate a physical book to the Internet Archive, your book will enjoy:"
-msgstr ""
-
-#: DonateModal.html
-msgid "Donation info"
-msgstr ""
-
-#: DonateModal.html
-msgid ""
-"Beautiful <a target=\"_blank\" href=\"https://archive.org/scanning\">high-"
-"fidelity digitization</a>"
-msgstr ""
-
-#: DonateModal.html
-msgid ""
-"Long-term <a href=\"https://blog.archive.org/2011/06/06/why-preserve-books-the-"
-"new-physical-archive-of-the-internet-archive/\">archival preservation</a>"
-msgstr ""
-
-#: DonateModal.html
-msgid ""
-"Free <a href=\"https://controlleddigitallending.org/\">controlled digital library "
-"access</a> by the <a href=\"https://en.wikipedia.org/wiki/"
-"Print_disability\">print-disabled</a> public"
-msgstr ""
-
-#: DonateModal.html
-msgid ""
-"Open Library is a project of the <a href=\"https://archive.org/about\">Internet "
-"Archive</a>, a 501(c)(3) non-profit"
+msgid "Templates in the website are disabled now. Editing them will not have any effect on the live website."
 msgstr ""
 
 #: EditionNavBar.html
@@ -7343,11 +7193,12 @@ msgid "Go to next section"
 msgstr ""
 
 #: Follow.html
-msgid "UnfollowFollow"
-msgstr ""
+#, fuzzy
+msgid "Unfollow"
+msgstr "Urmăresc"
 
 #: Follow.html
-msgid "Follow"
+msgid "Failed to update followers. Please try again in a few moments."
 msgstr ""
 
 #: FormatExpiry.html
@@ -7460,6 +7311,10 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#: NotInLibrary.html
+msgid "Not in Library"
+msgstr ""
+
 #: NotesModal.html
 msgid "My Book Notes"
 msgstr ""
@@ -7468,12 +7323,31 @@ msgstr ""
 msgid "My private notes about this edition:"
 msgstr ""
 
+#: OLID.html
+#, fuzzy, python-format
+msgid "by  %(authors)s"
+msgstr ""
+
 #: ObservationsModal.html
 msgid "My Book Review"
 msgstr ""
 
-#: Pager.html Pager_loanhistory.html
-msgid "First"
+#: OlPagination.html OlPaginationArrows.html
+msgid "Go to previous page"
+msgstr ""
+
+#: OlPagination.html OlPaginationArrows.html
+msgid "Go to next page"
+msgstr ""
+
+#: OlPagination.html
+#, python-brace-format
+msgid "Go to page {page}"
+msgstr ""
+
+#: OlPagination.html
+#, python-brace-format
+msgid "Page {page}, current page"
 msgstr ""
 
 #: Profile.html
@@ -7489,14 +7363,31 @@ msgid "who have written the most books on this subject"
 msgstr ""
 
 #: PublishingHistory.html
-msgid ""
-"This is a chart to show the publishing history of editions of works about this "
-"subject. Along the X axis is time, and on the y axis is the count of editions "
-"published. <a href=\"#subjectRelated\">Click here to skip the chart</a>."
+msgid "This is a chart to show the publishing history of editions of works about this subject. Along the X axis is time, and on the y axis is the count of editions published. <a href=\"#subjectRelated\">Click here to skip the chart</a>."
 msgstr ""
 
 #: PublishingHistory.html
 msgid "This graph charts editions published on this subject."
+msgstr ""
+
+#: RawQueryCarousel.html
+msgid "Loading carousel"
+msgstr ""
+
+#: RawQueryCarousel.html
+msgid "Failed to fetch carousel."
+msgstr ""
+
+#: RawQueryCarousel.html
+msgid "Retry?"
+msgstr ""
+
+#: RawQueryCarousel.html
+msgid "No books match the current filters."
+msgstr ""
+
+#: RawQueryCarousel.html
+msgid "Retry without filters?"
 msgstr ""
 
 #: RawQueryCarousel.html
@@ -7508,9 +7399,7 @@ msgid "Special Access"
 msgstr ""
 
 #: ReadButton.html
-msgid ""
-"Special ebook access from the Internet Archive for patrons with qualifying print "
-"disabilities"
+msgid "Special ebook access from the Internet Archive for patrons with qualifying print disabilities"
 msgstr ""
 
 #: ReadButton.html
@@ -7523,14 +7412,6 @@ msgstr ""
 
 #: ReadButton.html
 msgid "Listen"
-msgstr ""
-
-#: ReadMore.html
-msgid "Read more"
-msgstr ""
-
-#: ReadMore.html
-msgid "Read less"
 msgstr ""
 
 #: RecentChanges.html
@@ -7571,6 +7452,20 @@ msgstr ""
 
 #: SearchResultsWork.html
 #, python-format
+msgid "Book %(position)s"
+msgstr ""
+
+#: SearchResultsWork.html
+#, fuzzy
+msgid "Show more"
+msgstr "Mai mult"
+
+#: SearchResultsWork.html
+msgid "Show less"
+msgstr ""
+
+#: SearchResultsWork.html
+#, python-format
 msgid "Cover of edition %(id)s"
 msgstr ""
 
@@ -7582,7 +7477,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: SearchResultsWork.html
+#: SearchResultsWork.html TrendingBadge.html
 msgid "This is only visible to librarians."
 msgstr ""
 
@@ -7632,6 +7527,26 @@ msgid "QR Code"
 msgstr ""
 
 #: StarRatings.html
+msgid "leaving a 1 star review for"
+msgstr ""
+
+#: StarRatings.html
+msgid "leaving a 2 star review for"
+msgstr ""
+
+#: StarRatings.html
+msgid "leaving a 3 star review for"
+msgstr ""
+
+#: StarRatings.html
+msgid "leaving a 4 star review for"
+msgstr ""
+
+#: StarRatings.html
+msgid "leaving a 5 star review for"
+msgstr ""
+
+#: StarRatings.html
 msgid "Clear my rating"
 msgstr ""
 
@@ -7643,6 +7558,10 @@ msgstr ""
 msgid "ratings"
 msgstr ""
 
+#. Shows the count of readers who added this book to their "Want to read"
+#. shelf, displayed on search result pages. %(want_to_read_count)s is a
+#. formatted integer (may include commas as thousands separators). Example:
+#. "2,389 Want to read".
 #: StarRatingsByline.html
 #, python-format
 msgid "%(want_to_read_count)s Want to read"
@@ -7653,17 +7572,38 @@ msgstr "%(want_to_read_count)s doresc să citesc"
 msgid "%(ratings_avg)s (%(ratings_count)s %(ratings_label)s)"
 msgstr ""
 
+#. Short label displayed next to the count of readers who want to read this
+#. book, shown in the stats bar on a book page. Example: "2,389 Want to read".
 #: StarRatingsStats.html
 msgid "Want to read"
 msgstr "Doresc să citesc"
 
+#. Short label displayed next to the count of readers currently reading this
+#. book, shown in the stats bar on a book page. Example: "1,247 Currently
+#. reading".
 #: StarRatingsStats.html
 msgid "Currently reading"
 msgstr "În curs de citire"
 
+#. Short label displayed next to the count of readers who have finished this
+#. book, shown in the stats bar on a book page. Example: "15,420 Have read".
+#. This refers to the same shelf as the "Already Read" button.
 #: StarRatingsStats.html
 msgid "Have read"
 msgstr ""
+
+#. Short label displayed next to the count of readers who stopped reading this
+#. book before finishing, shown in the stats bar on a book page. Example: "348
+#. Stopped reading".
+#: StarRatingsStats.html
+#, fuzzy
+msgid "Stopped reading"
+msgstr "În tendințe"
+
+#: SubjectTags.html
+#, fuzzy
+msgid "Manage Subjects"
+msgstr "Subiecte"
 
 #: Subnavigation.html
 msgid "Developer Center (Home)"
@@ -7718,6 +7658,11 @@ msgstr ""
 msgid "Page %s"
 msgstr ""
 
+#: TrendingBadge.html
+#, python-format
+msgid "Trending: %(score).2f"
+msgstr ""
+
 #: TypeChanger.html
 msgid "Page Type"
 msgstr ""
@@ -7727,11 +7672,7 @@ msgid "Huh?"
 msgstr ""
 
 #: TypeChanger.html
-msgid ""
-"Every piece of Open Library is defined by the type of content it displays, "
-"usually by content definition (e.g. Authors, Editions, Works) but sometimes by "
-"content use (e.g. macro, template, rawtext). Changing this for an existing page "
-"will alter its presentation and the data fields available for editing its content."
+msgid "Every piece of Open Library is defined by the type of content it displays, usually by content definition (e.g. Authors, Editions, Works) but sometimes by content use (e.g. macro, template, rawtext). Changing this for an existing page will alter its presentation and the data fields available for editing its content."
 msgstr ""
 
 #: TypeChanger.html
@@ -7739,9 +7680,7 @@ msgid "Please use caution changing Page Type!"
 msgstr ""
 
 #: TypeChanger.html
-msgid ""
-"(Simplest solution: If you aren't sure whether this should be changed, don't "
-"change it.)"
+msgid "(Simplest solution: If you aren't sure whether this should be changed, don't change it.)"
 msgstr ""
 
 #: WorkInfo.html
@@ -7750,10 +7689,6 @@ msgstr ""
 
 #: WorldcatLink.html
 msgid "Check nearby libraries"
-msgstr ""
-
-#: WorldcatLink.html
-msgid "Library.link"
 msgstr ""
 
 #: WorldcatLink.html
@@ -7798,64 +7733,211 @@ msgstr ""
 msgid "View Volume %(num)d"
 msgstr ""
 
-#: openlibrary/plugins/upstream/forms.py
-msgid "Username"
-msgstr "Nume de utilizator"
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "No user registered with this email address"
+#: openlibrary/core/bookshelves.py
+msgid "[Record deleted]"
 msgstr ""
 
-#: openlibrary/plugins/upstream/account.py openlibrary/plugins/upstream/forms.py
-msgid "Email already registered"
+#: openlibrary/core/edits.py
+msgid "Unknown"
+msgstr "Necunoscut"
+
+#: openlibrary/plugins/openlibrary/api.py
+#, fuzzy
+msgid "Search Results"
+msgstr "Căutare"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Arabic"
 msgstr ""
 
-#: openlibrary/plugins/upstream/forms.py
-msgid "Disposable email not permitted"
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Czech"
+msgstr "Cehă"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "German"
+msgstr "Germană"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "English"
+msgstr "Engleză"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Spanish"
+msgstr "Spaniolă"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "French"
+msgstr "Franceză"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Hindi"
+msgstr "Hindusă"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Croatian"
+msgstr "Croată"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Italian"
+msgstr "Italiană"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Portuguese"
+msgstr "Portugheză"
+
+#: openlibrary/plugins/openlibrary/code.py
+#, fuzzy
+msgid "Romanian"
+msgstr "Croată"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Sardinian"
+msgstr "Sardiniană"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Telugu"
+msgstr "Telugu"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Ukrainian"
+msgstr "Ucrainiană"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Chinese"
+msgstr "Chineză"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Filipino"
 msgstr ""
 
-#: openlibrary/plugins/upstream/forms.py
-msgid "Your email provider is not recognized."
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Art"
+msgstr "Artă"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Science Fiction"
+msgstr "Științifico-fantastic"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Fantasy"
+msgstr "Fantezie"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Biographies"
+msgstr "Biografii"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Recipes"
+msgstr "Rețete"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Children"
+msgstr "Copii"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Medicine"
+msgstr "Medicină"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Religion"
+msgstr "Religie"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Mystery and Detective Stories"
+msgstr "Povestiri cu mister și detectivi"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Plays"
+msgstr "Piese de teatru"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Music"
+msgstr "Muzică"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Science"
+msgstr "Știință"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "At least 1 subject"
 msgstr ""
 
-#: openlibrary/plugins/upstream/forms.py
-msgid "Username already used"
-msgstr "Nume de utilizator deja folosit"
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Must be between 3 and 20 letters and numbers"
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "At least 1 author"
 msgstr ""
 
-#: openlibrary/plugins/upstream/forms.py
-msgid "Screen Name"
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+#, fuzzy
+msgid "At least 1 edition"
+msgstr "o ediție"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has work (orphaned)"
 msgstr ""
 
-#: openlibrary/plugins/upstream/forms.py
-msgid "Public and cannot be changed later."
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has publication year"
 msgstr ""
 
-#: openlibrary/plugins/upstream/forms.py
-msgid ""
-"I want to receive news, announcements, and resources from the <a href=\"https://"
-"archive.org/\">Internet Archive</a>, the non-profit that runs Open Library."
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+#, fuzzy
+msgid "Has cover"
+msgstr "Descoperă"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+#, fuzzy
+msgid "Has language"
+msgstr "limbi"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+#, fuzzy
+msgid "Has publisher"
+msgstr "Publicat pentru prima dată"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "At least 2 editions"
 msgstr ""
 
-#: openlibrary/plugins/upstream/forms.py
-msgid "Invalid password"
-msgstr "Parolă nevalidă"
-
-#: openlibrary/plugins/upstream/forms.py
-msgid "Your email address"
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has dewey decimal"
 msgstr ""
 
-#: openlibrary/plugins/upstream/forms.py
-msgid "Choose a password"
-msgstr "Alegeți o parolă"
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has LoC classification"
+msgstr ""
 
-#: openlibrary/plugins/upstream/borrow.py
-msgid ""
-"Your account has hit a lending limit. Please try again later or contact "
-"info@archive.org."
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has number of pages"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/lists.py
+#, python-format
+msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "Better World Books"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid " - includes shipping"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "Amazon"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "Bookshop.org"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "This work does not appear on any lists."
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/pd.py
+msgid "I don't have one yet"
 msgstr ""
 
 #: openlibrary/plugins/upstream/account.py
@@ -7911,9 +7993,7 @@ msgid "Login attempted with invalid Internet Archive s3 credentials."
 msgstr ""
 
 #: openlibrary/plugins/upstream/account.py
-msgid ""
-"Servers are experiencing unusually high traffic, please try again later or email "
-"openlibrary@archive.org for help."
+msgid "Servers are experiencing unusually high traffic, please try again later or email openlibrary@archive.org for help."
 msgstr ""
 
 #: openlibrary/plugins/upstream/account.py
@@ -7929,9 +8009,7 @@ msgid "A problem occurred and we were unable to log you in"
 msgstr ""
 
 #: openlibrary/plugins/upstream/account.py
-msgid ""
-"Login or registration attempt hit an unexpected error, please try again or "
-"contact info@archive.org"
+msgid "Login or registration attempt hit an unexpected error, please try again or contact info@archive.org"
 msgstr ""
 
 #: openlibrary/plugins/upstream/account.py
@@ -7940,14 +8018,15 @@ msgid "Request failed with error code: %(error_code)s"
 msgstr ""
 
 #: openlibrary/plugins/upstream/account.py
-#, python-format
-msgid ""
-"We've sent the verification email to %(email)s. You'll need to read that and "
-"click on the verification link to verify your email."
+msgid "Thank you for registering an Open Library account and requesting special print disability access. You should receive an email detailing next steps in the process."
 msgstr ""
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Username unavailable"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py openlibrary/plugins/upstream/forms.py
+msgid "Email already registered"
 msgstr ""
 
 #: openlibrary/plugins/upstream/account.py
@@ -7955,145 +8034,84 @@ msgid "An Internet Archive account already exists with this email"
 msgstr ""
 
 #: openlibrary/plugins/upstream/account.py
-msgid "Email address is already used."
-msgstr "Adresa de e-mail este deja folosită."
-
-#: openlibrary/plugins/upstream/account.py
-msgid ""
-"Your email address couldn't be updated. The specified email address is already "
-"used."
+msgid "Verification failed. The link may be invalid or expired. Please try registering again."
 msgstr ""
 
 #: openlibrary/plugins/upstream/account.py
-msgid "Email verification successful."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid ""
-"Your email address has been successfully verified and updated in your account."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Email address couldn't be verified."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid ""
-"Your email address couldn't be verified. The verification link seems invalid."
-msgstr ""
-
-#: openlibrary/plugins/upstream/account.py
-msgid "Password reset failed."
+msgid "Your email has been verified. You are now logged in."
 msgstr ""
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Notification preferences have been updated successfully."
 msgstr ""
 
-#: openlibrary/plugins/openlibrary/lists.py
-#, python-format
-msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
+#: openlibrary/plugins/upstream/borrow.py
+#, fuzzy
+msgid "this book"
 msgstr ""
 
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Czech"
-msgstr "Cehă"
+#: openlibrary/plugins/upstream/borrow.py
+#, python-format
+msgid "Unable to return %s. Please try again later or contact info@archive.org."
+msgstr ""
 
-#: openlibrary/plugins/openlibrary/code.py
-msgid "German"
-msgstr "Germană"
+#: openlibrary/plugins/upstream/borrow.py
+#, fuzzy, python-format
+msgid "%s has been returned."
+msgstr ""
 
-#: openlibrary/plugins/openlibrary/code.py
-msgid "English"
-msgstr "Engleză"
+#: openlibrary/plugins/upstream/borrow.py
+msgid "Your account has hit a lending limit. Please try again later or contact info@archive.org."
+msgstr ""
 
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Spanish"
-msgstr "Spaniolă"
+#: openlibrary/plugins/upstream/forms.py
+msgid "Username"
+msgstr "Nume de utilizator"
 
-#: openlibrary/plugins/openlibrary/code.py
-msgid "French"
-msgstr "Franceză"
+#: openlibrary/plugins/upstream/forms.py
+msgid "No user registered with this email address"
+msgstr ""
 
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Croatian"
-msgstr "Croată"
+#: openlibrary/plugins/upstream/forms.py
+msgid "Disposable email not permitted"
+msgstr ""
 
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Italian"
-msgstr "Italiană"
+#: openlibrary/plugins/upstream/forms.py
+msgid "Your email provider is not recognized."
+msgstr ""
 
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Portuguese"
-msgstr "Portugheză"
+#: openlibrary/plugins/upstream/forms.py
+msgid "Username already used"
+msgstr "Nume de utilizator deja folosit"
 
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Hindi"
-msgstr "Hindusă"
+#: openlibrary/plugins/upstream/forms.py
+msgid "Must be between 3 and 20 letters and numbers"
+msgstr ""
 
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Sardinian"
-msgstr "Sardiniană"
+#: openlibrary/plugins/upstream/forms.py
+msgid "Screen Name"
+msgstr ""
 
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Telugu"
-msgstr "Telugu"
+#: openlibrary/plugins/upstream/forms.py
+msgid "Public and cannot be changed later."
+msgstr ""
 
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Ukrainian"
-msgstr "Ucrainiană"
+#: openlibrary/plugins/upstream/forms.py
+msgid "Invalid password"
+msgstr "Parolă nevalidă"
 
-#: openlibrary/plugins/openlibrary/code.py
-msgid "Chinese"
-msgstr "Chineză"
+#: openlibrary/plugins/upstream/forms.py
+msgid "Your email address"
+msgstr ""
 
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Art"
-msgstr "Artă"
+#: openlibrary/plugins/upstream/forms.py
+msgid "Choose a password"
+msgstr "Alegeți o parolă"
 
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Science Fiction"
-msgstr "Științifico-fantastic"
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Fantasy"
-msgstr "Fantezie"
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Biographies"
-msgstr "Biografii"
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Recipes"
-msgstr "Rețete"
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Children"
-msgstr "Copii"
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Medicine"
-msgstr "Medicină"
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Religion"
-msgstr "Religie"
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Mystery and Detective Stories"
-msgstr "Povestiri cu mister și detectivi"
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Plays"
-msgstr "Piese de teatru"
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Music"
-msgstr "Muzică"
-
-#: openlibrary/plugins/openlibrary/home.py
-msgid "Science"
-msgstr "Știință"
+#: openlibrary/plugins/upstream/mybooks.py
+#, python-format
+msgid "Continue <a href=\"%(url)s\" class=\"pending-action-link\" data-action=\"%(raw_action)s\"><strong>%(action)s</strong> <em>%(name)s</em></a>"
+msgstr ""
 
 #: openlibrary/plugins/worksearch/code.py
 msgid "eBook?"
@@ -8107,6 +8125,354 @@ msgstr "Publicat pentru prima dată"
 msgid "Classic eBooks"
 msgstr "Cărți electronice clasice"
 
-#: openlibrary/core/edits.py
-msgid "Unknown"
-msgstr "Necunoscut"
+#~ msgid "Design Pattern Library"
+#~ msgstr ""
+
+#~ msgid "Fonts"
+#~ msgstr "Fonturi"
+
+#~ msgid "Font-size"
+#~ msgstr "Dimensiune font"
+
+#~ msgid "Font-family"
+#~ msgstr "Familie de fonturi"
+
+#~ msgid "Sans-serif: Verdana"
+#~ msgstr ""
+
+#~ msgid "Serif: Georgia"
+#~ msgstr ""
+
+#~ msgid "Colors"
+#~ msgstr ""
+
+#~ msgid "Defaults"
+#~ msgstr ""
+
+#~ msgid "Background"
+#~ msgstr ""
+
+#~ msgid "Primary Call To Action"
+#~ msgstr ""
+
+#~ msgid "Link (unclicked)"
+#~ msgstr ""
+
+#~ msgid "Link (clicked)"
+#~ msgstr ""
+
+#~ msgid "Thank you very much for adding that new book!"
+#~ msgstr ""
+
+#~ msgid "Thank you very much for improving that record!"
+#~ msgstr ""
+
+#~ msgid "Only logged users are allowed to add records on Open Library. Please <a href=\"/account/login?redirect=$path\">log in</a> to add a book."
+#~ msgstr ""
+
+#~ msgid "Only logged users are allowed to modify records on Open Library. Please <a href=\"/account/login?redirect=$path\">log in</a> to edit this page."
+#~ msgstr ""
+
+#~ msgid "Staged"
+#~ msgstr ""
+
+#~ msgid "How can we help?"
+#~ msgstr ""
+
+#~ msgid "Your question has been sent to our support team. We'll get back to you shortly. You can also <a href=\"https://twitter.com/openlibrary\">contact us on Twitter</a>."
+#~ msgstr ""
+
+#~ msgid "Please check our <a href=\"/help/\">Help Pages</a> and <a href=\"/help/faq\">Frequently Asked Questions</a> (FAQ) to see if your question is answered there. Thank you."
+#~ msgstr ""
+
+#~ msgid "Your Name"
+#~ msgstr ""
+
+#~ msgid "Your Email Address"
+#~ msgstr ""
+
+#~ msgid "We'll need this if you want a reply"
+#~ msgstr ""
+
+#~ msgid "If you wish to be contacted by other means, please add your contact preference and details to your question."
+#~ msgstr ""
+
+#~ msgid "Your Question"
+#~ msgstr ""
+
+#~ msgid "Note: our staff will likely only be able respond in English."
+#~ msgstr ""
+
+#~ msgid "If you encounter an error message, please include it. For questions about our books, please provide the title/author or Open Library ID."
+#~ msgstr ""
+
+#~ msgid "Send"
+#~ msgstr "Trimite"
+
+#~ msgid "on <a target=\"_blank\" href=\"%(link)s\">openlibrary.org</a>"
+#~ msgstr ""
+
+#~ msgid "By signing up, you agree to the Internet Archive's <a class=\"ol-signup-form__link\" href=\"//archive.org/about/terms.php\" target=\"_blank\">Terms of Service</a>."
+#~ msgstr ""
+
+#~ msgid "What is this?"
+#~ msgstr "Ce este asta?"
+
+#~ msgid "This will enable others to see what books you want to read, are reading, or have already read. Patrons with reading logs set to public may be followed."
+#~ msgstr ""
+
+#~ msgid "This updates  and  fields of /, /works, /books and /authors records in the database."
+#~ msgstr ""
+
+#~ msgid "For example, if you want to prevent edits containing the domain <code>t.co</code>, add <code>(\\b|https://|http://)t\\.co</code> to the spamwords list."
+#~ msgstr ""
+
+#~ msgid "Memory Status"
+#~ msgstr ""
+
+#~ msgid "type"
+#~ msgstr ""
+
+#~ msgid "count"
+#~ msgstr ""
+
+#~ msgid "mark"
+#~ msgstr ""
+
+#~ msgid "Prev"
+#~ msgstr ""
+
+#~ msgid "Referents"
+#~ msgstr ""
+
+#~ msgid "Referrers"
+#~ msgstr ""
+
+#~ msgid "Activation link expiring on <span class=\"time\">%(date)s.</span>"
+#~ msgstr ""
+
+#~ msgid "Activation link expired"
+#~ msgstr ""
+
+#~ msgid "Resend activation link"
+#~ msgstr ""
+
+#~ msgid "Read eBook from Cita Press"
+#~ msgstr ""
+
+#~ msgid "This book is available from <a href=\"https://citapress.org/\">Cita Press</a>. Cita Press is a trusted book provider of works written by women, pairing contemporary authors and designers with open access texts to make carefully designed books available for free and open source."
+#~ msgstr ""
+
+#~ msgid "Learn more"
+#~ msgstr ""
+
+#~ msgid "Read free online"
+#~ msgstr ""
+
+#~ msgid "This book is freely available from <a href=\"%s\">%s</a>, an external third-party book provider."
+#~ msgstr ""
+
+#~ msgid "Read eBook from Project Gutenberg"
+#~ msgstr ""
+
+#~ msgid "This book is available from <a href=\"https://www.gutenberg.org/\">Project Gutenberg</a>. Project Gutenberg is a trusted book provider of classic ebooks, supporting thousands of volunteers in the creation and distribution of over 60,000 free eBooks."
+#~ msgstr ""
+
+#~ msgid "Listen to a reading from LibriVox"
+#~ msgstr ""
+
+#~ msgid "This book is available from <a href=\"https://librivox.org/\">LibriVox</a>. LibriVox is a trusted book provider of public domain audiobooks, narrated by volunteers, distributed for free on the internet."
+#~ msgstr ""
+
+#~ msgid "Read eBook from OpenStax"
+#~ msgstr ""
+
+#~ msgid "This book is available from <a href=\"https://www.openstax.org/\">OpenStax</a>. OpenStax is a trusted book provider and a 501(c)(3) nonprofit charitable corporation dedicated to providing free high-quality, peer-reviewed, openly licensed textbooks online."
+#~ msgstr ""
+
+#~ msgid "Read eBook from Project Runeberg"
+#~ msgstr ""
+
+#~ msgid "This book is available from <a href=\"https://runeberg.org/\">Project Runeberg</a>. Project Runeberg is a trusted book provider of classic Nordic (Scandinavian) literature in electronic form."
+#~ msgstr ""
+
+#~ msgid "Read eBook from Standard eBooks"
+#~ msgstr ""
+
+#~ msgid "This book is available from <a href=\"https://standardebooks.org/\">Standard Ebooks</a>. Standard Ebooks is a trusted book provider and a volunteer-driven project that produces new editions of public domain ebooks that are lovingly formatted, open source, free of copyright restrictions, and free of cost."
+#~ msgstr ""
+
+#~ msgid "Read eBook on Wikisource"
+#~ msgstr ""
+
+#~ msgid "This book is available from <a href=\"https://wikisource.org/\">Wikisource</a>. Wikisource, a <a href=\"https://www.wikimedia.org/\">Wikimedia Foundation</a> project, is a trusted book provider of works available under the <a href=\"https://creativecommons.org/licenses/by-sa/4.0/\">CC-BY-SA</a> open content license, such as essays, historical documents, letters, speeches, and public domain books."
+#~ msgstr ""
+
+#~ msgid "By saving a change to this wiki, you agree that your contribution is given freely to the world under <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" target=\"_blank\" title=\"This link to Creative Commons will open in a new window\">CC0</a>. Yippee!"
+#~ msgstr ""
+
+#~ msgid "This DAISY file is protected."
+#~ msgstr ""
+
+#~ msgid "It can only be opened on a specialized device with a key issued by the Library of Congress."
+#~ msgstr ""
+
+#~ msgid "There are two types of DAISYs on Open Library: <i>open</i> and <i>protected</i>. Open DAISYs can be read by anyone in the world on many different devices. Protected DAISYs like this one can only be opened using a key issued by the <a href=\"http://www.loc.gov/nls/\">Library of Congress NLS program</a>."
+#~ msgstr ""
+
+#~ msgid "You can search by author name (like <em>j k rowling</em>) or by Open Library ID (like <a href=\"/authors/OL23919A\" target=\"_blank\"><em>OL23919A</em></a>)."
+#~ msgstr ""
+
+#~ msgid "You can search by title or by Open Library ID (like <a href=\"/works/OL262757W\" target=\"_blank\"><em>OL262757W</em></a>)."
+#~ msgstr ""
+
+#~ msgid "Add an optional check-in date.  Check-in dates are used to track yearly reading goals."
+#~ msgstr ""
+
+#~ msgid "Choose a JPG, GIF or PNG on your computer"
+#~ msgstr ""
+
+#~ msgid "No Image Pasted"
+#~ msgstr ""
+
+#~ msgid "Or, use the the cover from Internet Archive"
+#~ msgstr ""
+
+#~ msgid "View a larger book cover"
+#~ msgstr ""
+
+#~ msgid "Imported from"
+#~ msgstr ""
+
+#~ msgid "Found a matching"
+#~ msgstr ""
+
+#~ msgid "Edited without comment."
+#~ msgstr ""
+
+#~ msgid "browse %(subject)s books"
+#~ msgstr ""
+
+#~ msgid "by <a href=\"$owner.key\">You</a>"
+#~ msgstr ""
+
+#~ msgid "more"
+#~ msgstr ""
+
+#~ msgid "less"
+#~ msgstr ""
+
+#~ msgid "Search facets"
+#~ msgstr ""
+
+#~ msgid "Explore Classic eBooks"
+#~ msgstr ""
+
+#~ msgid "Explore books about %(subject)s"
+#~ msgstr ""
+
+#~ msgid "Click to remove this facet"
+#~ msgstr ""
+
+#~ msgid "Location"
+#~ msgstr ""
+
+#~ msgid "Showing all works by author. Would you like to see <a href=\"%(url)s\">only ebooks</a>?"
+#~ msgstr ""
+
+#~ msgid "Showing ebooks only. Would you like to see <a href=\"%(url)s\">everything</a> by this author?"
+#~ msgstr ""
+
+#~ msgid "Add to Staff Picks"
+#~ msgstr ""
+
+#~ msgid "Loading Related Books"
+#~ msgstr ""
+
+#~ msgid "deprecated"
+#~ msgstr ""
+
+#~ msgid "⚠️ Saving global lists is admin-only while the feature is under development."
+#~ msgstr ""
+
+#~ msgid "<a href=\"/search\" target=\"_blank\">Search for book, subjects, or authors</a> to add to your list."
+#~ msgstr ""
+
+#~ msgid "You are publicly sharing the books you are <a href=\"%(username)s/books/currently-reading\">currently reading</a>, <a href=\"%(username)s/books/already-read\">have already read</a>, and <a href=\"%(username)s/books/want-to-read\">want to read</a>."
+#~ msgstr ""
+
+#~ msgid "Here are the books %(user)s is <a href=\"%(username)s/books/currently-reading\">currently reading</a>, <a href=\"%(username)s/books/already-read\">have already read</a>, and <a href=\"%(username)s/books/want-to-read\">want to read</a>!"
+#~ msgstr ""
+
+#~ msgid "Donate this book to the <a href=\"https://archive.org\">Internet Archive</a> library."
+#~ msgstr ""
+
+#~ msgid "Hooray! You've discovered a title that's missing from our <a href=\"https://help.archive.org/hc/en-us/articles/360016554912-Borrowing-From-The-Lending-Library\">library</a>. Can you help donate a copy?"
+#~ msgstr ""
+
+#~ msgid "If you own this book, you can<a href=\"https://store.usps.com/store/product/shipping-supplies/priority-mail-express-padded-flat-rate-envelope-P_EP13PE\">mail</a> it to our address below."
+#~ msgstr ""
+
+#~ msgid "You can also purchase this book from a vendor and ship it to our address:"
+#~ msgstr ""
+
+#~ msgid "Benefits of donating"
+#~ msgstr ""
+
+#~ msgid "When you donate a physical book to the Internet Archive, your book will enjoy:"
+#~ msgstr ""
+
+#~ msgid "Donation info"
+#~ msgstr ""
+
+#~ msgid "Beautiful <a target=\"_blank\" href=\"https://archive.org/scanning\">high-fidelity digitization</a>"
+#~ msgstr ""
+
+#~ msgid "Long-term <a href=\"https://blog.archive.org/2011/06/06/why-preserve-books-the-new-physical-archive-of-the-internet-archive/\">archival preservation</a>"
+#~ msgstr ""
+
+#~ msgid "Free <a href=\"https://controlleddigitallending.org/\">controlled digital library access</a> by the <a href=\"https://en.wikipedia.org/wiki/Print_disability\">print-disabled</a> public"
+#~ msgstr ""
+
+#~ msgid "Open Library is a project of the <a href=\"https://archive.org/about\">Internet Archive</a>, a 501(c)(3) non-profit"
+#~ msgstr ""
+
+#~ msgid "UnfollowFollow"
+#~ msgstr ""
+
+#~ msgid "First"
+#~ msgstr ""
+
+#~ msgid "Read more"
+#~ msgstr ""
+
+#~ msgid "Read less"
+#~ msgstr ""
+
+#~ msgid "Library.link"
+#~ msgstr ""
+
+#~ msgid "We've sent the verification email to %(email)s. You'll need to read that and click on the verification link to verify your email."
+#~ msgstr ""
+
+#~ msgid "Email address is already used."
+#~ msgstr "Adresa de e-mail este deja folosită."
+
+#~ msgid "Your email address couldn't be updated. The specified email address is already used."
+#~ msgstr ""
+
+#~ msgid "Email verification successful."
+#~ msgstr ""
+
+#~ msgid "Your email address has been successfully verified and updated in your account."
+#~ msgstr ""
+
+#~ msgid "Email address couldn't be verified."
+#~ msgstr ""
+
+#~ msgid "Your email address couldn't be verified. The verification link seems invalid."
+#~ msgstr ""
+
+#~ msgid "Password reset failed."
+#~ msgstr ""
+

--- a/openlibrary/i18n/ro/messages.po
+++ b/openlibrary/i18n/ro/messages.po
@@ -4089,182 +4089,182 @@ msgstr "Adaugă link"
 
 #: books/edit/web.html
 msgid "Remove this link"
-msgstr ""
+msgstr "Elimină acest link"
 
 #: books/edit/web.html
 msgid "\"Good\" means no spammy links, please. Keep them relevant to the book. Irrelevant sites may be removed. Blatant spam will be deleted without remorse."
-msgstr ""
+msgstr "\"Bun\" înseamnă fără linkuri spam, vă rugăm. Păstrați-le relevante pentru carte. Site-urile irelevante pot fi eliminate. Spam-ul evident va fi șters fără remușcări."
 
 #: bulk_search/bulk_search.html search/advancedsearch.html
 msgid "Bulk Search (beta)"
-msgstr ""
+msgstr "Căutare în masă (beta)"
 
 #: covers/add.html
 msgid "There are two ways to put an author's image on Open Library."
-msgstr ""
+msgstr "Există două moduri de a pune fotografia unui autor pe Open Library."
 
 #: covers/add.html
 msgid "Image Guidelines"
-msgstr ""
+msgstr "Ghid pentru imagini"
 
 #: covers/add.html
 msgid "There are a few ways to put a cover image on Open Library."
-msgstr ""
+msgstr "Există câteva moduri de a pune o imagine de copertă pe Open Library."
 
 #: covers/add.html
 msgid "Cover Guidelines"
-msgstr ""
+msgstr "Ghid pentru coperte"
 
 #: covers/add.html
 msgid "Please provide a valid image."
-msgstr ""
+msgstr "Furnizați o imagine validă."
 
 #: covers/add.html
 msgid "Please provide an image URL."
-msgstr ""
+msgstr "Furnizați un URL de imagine."
 
 #: covers/add.html
 #, python-format
 msgid "Learn more by reading our <a href=\"/help/faq/editing#picture\" target=\"blank\">%(guidelines)s</a>."
-msgstr ""
+msgstr "Aflați mai multe citind <a href=\"/help/faq/editing#picture\" target=\"blank\">%(guidelines)s</a>."
 
 #: covers/add.html
 msgid "<strong>Pick one</strong> from the existing covers"
-msgstr ""
+msgstr "<strong>Alegeți una</strong> din copertele existente"
 
 #: covers/add.html
 msgid "Use this image"
-msgstr ""
+msgstr "Folosește această imagine"
 
 #: covers/add.html
 msgid "Choose a JPG, GIF, PNG or WebP on your computer"
-msgstr ""
+msgstr "Alegeți un JPG, GIF, PNG sau WebP de pe computerul dvs."
 
 #: covers/add.html
 msgid "Upload"
-msgstr ""
+msgstr "Încărcați"
 
 #: covers/add.html
 msgid "Or, paste an image from your clipboard"
-msgstr ""
+msgstr "Sau, lipiți o imagine din clipboard"
 
 #: covers/add.html
 msgid "Paste image from clipboard"
-msgstr ""
+msgstr "Lipiți imaginea din clipboard"
 
 #: covers/add.html
 msgid "Paste Image"
-msgstr ""
+msgstr "Lipire imagine"
 
 #: covers/add.html
 msgid "Upload image"
-msgstr ""
+msgstr "Încărcați imaginea"
 
 #: covers/add.html covers/external_image.html
 msgid "Upload Image"
-msgstr ""
+msgstr "Încarcă imagine"
 
 #: covers/add.html
 msgid "Uploading..."
-msgstr ""
+msgstr "Se încarcă..."
 
 #: covers/add.html
 msgid "Wikidata"
-msgstr ""
+msgstr "Wikidata"
 
 #: covers/author_photo.html
 msgid "Pull up a larger author photo"
-msgstr ""
+msgstr "Deschide o fotografie mai mare a autorului"
 
 #: covers/author_photo.html search/authors.html
 #, python-format
 msgid "Photo of %(author)s"
-msgstr ""
+msgstr "Fotografie a lui %(author)s"
 
 #: covers/author_photo.html
 msgid "Click to close"
-msgstr ""
+msgstr "Faceți clic pentru a închide"
 
 #: covers/author_photo.html
 #, python-format
 msgid "We need a photo of %(author)s"
-msgstr ""
+msgstr "Avem nevoie de o fotografie a lui %(author)s"
 
 #: covers/book_cover.html
 msgid "Pull up a bigger book cover"
-msgstr ""
+msgstr "Deschide o copertă mai mare a cărții"
 
 #: covers/book_cover.html covers/book_cover_small.html
 #, python-format
 msgid "Cover of: %(title)s by %(authors)s"
-msgstr ""
+msgstr "Copertă: %(title)s de %(authors)s"
 
 #: covers/book_cover_small.html
 #, python-format
 msgid "Go to the main page for %(title)s"
-msgstr ""
+msgstr "Mergi la pagina principală pentru %(title)s"
 
 #: covers/book_cover_small.html
 #, python-format
 msgid "We need a book cover for: %(title)s"
-msgstr ""
+msgstr "Avem nevoie de o copertă de carte pentru: %(title)s"
 
 #: covers/change.html
 msgid "Author Photos"
-msgstr ""
+msgstr "Fotografii autori"
 
 #: covers/change.html
 msgid "Manage Author Photos"
-msgstr ""
+msgstr "Gestionați fotografiile autorilor"
 
 #: covers/change.html
 msgid "Add Author Photo"
-msgstr ""
+msgstr "Adaugă fotografie autor"
 
 #: covers/change.html
 msgid "Book Covers"
-msgstr ""
+msgstr "Coperte cărți"
 
 #: covers/change.html
 msgid "Manage Covers"
-msgstr ""
+msgstr "Gestionați copertele"
 
 #: covers/change.html
 msgid "Add Cover Image"
-msgstr ""
+msgstr "Adaugă imagine de copertă"
 
 #: covers/change.html
 msgid "Manage"
-msgstr ""
+msgstr "Gestionează"
 
 #: covers/external_image.html
 #, python-format
 msgid "Or, use an image from %s"
-msgstr ""
+msgstr "Sau, folosiți o imagine de la %s"
 
 #: covers/manage.html
 msgid "You can drag and drop thumbnails to reorder, or into the trash to delete them."
-msgstr ""
+msgstr "Puteți glisa și plasa miniaturile pentru reordonare sau în coș pentru a le șterge."
 
 #: covers/saved.html
 msgid "New book cover"
-msgstr ""
+msgstr "Copertă nouă carte"
 
 #: covers/saved.html
 msgid "Saved!"
-msgstr ""
+msgstr "Salvat!"
 
 #: covers/saved.html
 msgid "Notes:"
-msgstr ""
+msgstr "Note:"
 
 #: covers/saved.html
 msgid "Add another image"
-msgstr ""
+msgstr "Adaugă altă imagine"
 
 #: covers/saved.html
 msgid "Finished"
-msgstr ""
+msgstr "Terminat"
 
 #: email/case_created.html
 msgid "Sent!"
@@ -4272,19 +4272,19 @@ msgstr "Trimis!"
 
 #: email/case_created.html
 msgid "Thank you for your note. We'll get back to you as soon as possible."
-msgstr ""
+msgstr "Mulțumim pentru nota dumneavoastră. Vă vom răspunde cât mai curând posibil."
 
 #: email/case_created.html
 msgid "It might take us a little while to read it because we receive lots of messages, but rest assured we will, and we'll get back to you if required."
-msgstr ""
+msgstr "Poate dura ceva timp să o citim deoarece primim multe mesaje, dar fiți siguri că o vom face și vă vom răspunde dacă este necesar."
 
 #: email/account/pd_request.html
 msgid "Qualifying for Print Disability Special Access"
-msgstr ""
+msgstr "Calificare pentru acces special cu dizabilități de tipărire"
 
 #: history/sources.html
 msgid "record"
-msgstr ""
+msgstr "înregistrare"
 
 #: home/about.html
 msgid "About the Project"
@@ -4348,11 +4348,11 @@ msgstr "Manuale"
 
 #: home/index.html
 msgid "Authors Alliance & MIT Press"
-msgstr ""
+msgstr "Authors Alliance & MIT Press"
 
 #: home/index.html
 msgid "Books in Local Environment"
-msgstr ""
+msgstr "Cărți în mediul local"
 
 #: home/loans.html
 #, fuzzy, python-format
@@ -4364,7 +4364,7 @@ msgstr[2] ""
 
 #: home/loans.html
 msgid "You have reached the borrowing limit. Please return a book to checkout something new."
-msgstr ""
+msgstr "Ați atins limita de împrumut. Vă rugăm să returnați o carte pentru a împrumuta ceva nou."
 
 #: home/stats.html
 msgid "Around the Library"
@@ -4492,7 +4492,7 @@ msgstr "Feedbackul dumneavoastră ne va ajuta să îmbunătățim aceste carduri
 
 #: jsdef/LazyWorkPreview.html
 msgid "Select this work"
-msgstr ""
+msgstr "Selectează această operă"
 
 #: jsdef/LazyWorkPreview.html
 msgid "1 edition"
@@ -4521,69 +4521,69 @@ msgstr[2] ""
 #: languages/notfound.html
 #, python-format
 msgid "%s is not found"
-msgstr ""
+msgstr "%s nu a fost găsit"
 
 #: languages/notfound.html
 #, python-format
 msgid "%s does not exist."
-msgstr ""
+msgstr "%s nu există."
 
 #: lib/edit_head.html lib/view_head.html
 msgid "This doc was last edited by"
-msgstr ""
+msgstr "Acest document a fost editat ultima dată de"
 
 #: lib/edit_head.html lib/view_head.html
 msgid "This doc was last edited anonymously"
-msgstr ""
+msgstr "Acest document a fost editat ultima dată anonim"
 
 #: lib/exports.html
 msgid "Download catalog record:"
-msgstr ""
+msgstr "Descarcă înregistrarea catalogului:"
 
 #: lib/exports.html
 msgid "RDF"
-msgstr ""
+msgstr "RDF"
 
 #: lib/exports.html type/list/exports.html
 msgid "JSON"
-msgstr ""
+msgstr "JSON"
 
 #: lib/exports.html
 msgid "OPDS"
-msgstr ""
+msgstr "OPDS"
 
 #: lib/exports.html
 msgid "Cite this on Wikipedia"
-msgstr ""
+msgstr "Citează pe Wikipedia"
 
 #: lib/exports.html
 msgid "Wikipedia citation"
-msgstr ""
+msgstr "Citare Wikipedia"
 
 #: lib/exports.html
 msgid "Copy and paste this code into your Wikipedia page."
-msgstr ""
+msgstr "Copiați și lipiți acest cod în pagina Wikipedia."
 
 #: lib/exports.html
 msgid "Get instructions at Wikipedia in a new window"
-msgstr ""
+msgstr "Obțineți instrucțiuni pe Wikipedia într-o fereastră nouă"
 
 #: lib/header_dropdown.html
 msgid "My account"
-msgstr ""
+msgstr "Contul meu"
 
 #: lib/header_dropdown.html type/user/view.html
 #, python-format
 msgid "Joined %(date)s"
-msgstr ""
+msgstr "Alăturat %(date)s"
 
 #: lib/header_dropdown.html
 msgid "Menu"
-msgstr ""
+msgstr "Meniu"
 
 #: lib/header_dropdown.html
 msgid "New!"
-msgstr ""
+msgstr "Nou!"
 
 #: databarDiff.html databarEdit.html databarTemplate.html databarView.html lib/history.html openlibrary/plugins/openlibrary/home.py
 msgid "History"
@@ -4592,7 +4592,7 @@ msgstr "Istoric"
 #: lib/history.html
 #, python-format
 msgid "Created %(date)s"
-msgstr ""
+msgstr "Creat %(date)s"
 
 #: lib/history.html
 #, python-format
@@ -4604,33 +4604,33 @@ msgstr[2] ""
 
 #: lib/history.html
 msgid "an anonymous user"
-msgstr ""
+msgstr "un utilizator anonim"
 
 #: lib/history.html
 #, python-format
 msgid "Created by %(user)s"
-msgstr ""
+msgstr "Creat de %(user)s"
 
 #: lib/history.html
 #, python-format
 msgid "Edited by %(user)s"
-msgstr ""
+msgstr "Editat de %(user)s"
 
 #: lib/message_addbook.html
 msgid "Super!"
-msgstr ""
+msgstr "Super!"
 
 #: lib/message_addbook.html
 msgid " Your new record is in the library. Thank you!"
-msgstr ""
+msgstr " Noua înregistrare se află în bibliotecă. Mulțumim!"
 
 #: lib/message_addbook.html
 msgid "There are a few other simple things you can add while you're here to improve your new record quickly, and make it much easier for other people to find later."
-msgstr ""
+msgstr "Mai sunt câteva lucruri simple pe care le poți adăuga acum pentru a îmbunătăți rapid noua înregistrare și a facilita găsirea ei de alții."
 
 #: lib/message_addbook.html
 msgid "Upload a cover image"
-msgstr ""
+msgstr "Încarcă o imagine de copertă"
 
 #: lib/message_addbook.html
 msgid "Snap a quick photo of the cover to share?"

--- a/openlibrary/i18n/ro/messages.po
+++ b/openlibrary/i18n/ro/messages.po
@@ -199,11 +199,11 @@ msgstr "Nume lot:"
 
 #: batch_import_view.html
 msgid "Submitter:"
-msgstr ""
+msgstr "Trimițător:"
 
 #: batch_import_view.html
 msgid "Submit Time:"
-msgstr ""
+msgstr "Ora trimiterii:"
 
 #: batch_import_view.html
 msgid "Status Summary"
@@ -5647,48 +5647,48 @@ msgstr "Acesta este un grafic care arată când a publicat cărți acest editor.
 
 #: PublishingHistory.html publishers/view.html
 msgid "Reset chart"
-msgstr ""
+msgstr "Resetați graficul"
 
 #: PublishingHistory.html publishers/view.html
 msgid "or continue zooming in."
-msgstr ""
+msgstr "sau continuați mărirea."
 
 #: publishers/view.html
 msgid "This graph charts editions from this publisher over time. Click to view a single year, or drag across a range."
-msgstr ""
+msgstr "Acest grafic ilustrează edițiile acestui editor de-a lungul timpului. Faceți clic pentru a vedea un singur an sau trageți pentru a selecta un interval."
 
 #: PublishingHistory.html publishers/view.html
 msgid "Editions Published"
-msgstr ""
+msgstr "Ediții publicate"
 
 #: PublishingHistory.html publishers/view.html
 msgid "Year of Publication"
-msgstr ""
+msgstr "Anul publicării"
 
 #: publishers/view.html
 msgid "Common Subjects"
-msgstr ""
+msgstr "Subiecte comune"
 
 #: publishers/view.html
 #, python-format
 msgid "Search for books published by %(publisher)s"
-msgstr ""
+msgstr "Căutați cărți publicate de %(publisher)s"
 
 #: RelatedSubjects.html publishers/view.html
 msgid "None found."
-msgstr ""
+msgstr "Niciun rezultat."
 
 #: ProlificAuthors.html publishers/view.html
 msgid "See more books by, and learn about, this author"
-msgstr ""
+msgstr "Vedeți mai multe cărți ale acestui autor și aflați mai multe despre el"
 
 #: publishers/view.html
 msgid "published most by this publisher"
-msgstr ""
+msgstr "publicat cel mai mult de acest editor"
 
 #: publishers/view.html
 msgid "Get more information about this publisher"
-msgstr ""
+msgstr "Obțineți mai multe informații despre acest editor"
 
 #: reading_goals/reading_goal_form.html
 msgid "How many books would you like to read this year?"
@@ -5696,12 +5696,12 @@ msgstr "Câte cărți doriți să citiți anul acesta?"
 
 #: reading_goals/reading_goal_form.html
 msgid "Enter \"0\" to unset your reading goal. Your check-ins will be preserved."
-msgstr ""
+msgstr "Introduceți \"0\" pentru a anula obiectivul de lectură. Înregistrările dvs. vor fi păstrate."
 
 #: reading_goals/reading_goal_progress.html
 #, python-format
 msgid "<span class=\"reading-goal-progress__books-read\">%(books_read)d</span>/<span class=\"reading-goal-progress__goal\">%(goal)d</span> Books"
-msgstr ""
+msgstr "<span class=\"reading-goal-progress__books-read\">%(books_read)d</span>/<span class=\"reading-goal-progress__goal\">%(goal)d</span> Cărți"
 
 #: reading_goals/reading_goal_progress.html
 #, python-format
@@ -5710,85 +5710,85 @@ msgstr "Modifică obiectivul de citire pentru %(year)d"
 
 #: recentchanges/header.html
 msgid "By"
-msgstr ""
+msgstr "De"
 
 #: recentchanges/header.html
 msgid "Undo All"
-msgstr ""
+msgstr "Anulați tot"
 
 #: recentchanges/header.html recentchanges/index.html
 msgid "Recent Changes"
-msgstr ""
+msgstr "Modificări recente"
 
 #: recentchanges/index.html
 msgid "Books Edited"
-msgstr ""
+msgstr "Cărți editate"
 
 #: recentchanges/index.html
 msgid "Author Merges"
-msgstr ""
+msgstr "Fuzionări autori"
 
 #: recentchanges/index.html
 msgid "Work Merges"
-msgstr ""
+msgstr "Fuzionări opere"
 
 #: recentchanges/index.html
 msgid "Books Added"
-msgstr ""
+msgstr "Cărți adăugate"
 
 #: RecentChanges.html recentchanges/index.html
 msgid "By Humans"
-msgstr ""
+msgstr "De oameni"
 
 #: RecentChanges.html recentchanges/index.html
 msgid "By Bots"
-msgstr ""
+msgstr "De boți"
 
 #: recentchanges/render.html
 msgid "Admin view"
-msgstr ""
+msgstr "Vizualizare admin"
 
 #: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html recentchanges/render.html
 msgid "Older"
-msgstr ""
+msgstr "Mai vechi"
 
 #: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html recentchanges/render.html
 msgid "Newer"
-msgstr ""
+msgstr "Mai noi"
 
 #: recentchanges/updated_records.html
 msgid "Review what's changed in from the previous revision"
-msgstr ""
+msgstr "Revizuiți ce s-a schimbat față de revizuirea anterioară"
 
 #: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html recentchanges/default/path.html recentchanges/updated_records.html
 msgid "diff"
-msgstr ""
+msgstr "diferențe"
 
 #: recentchanges/add-book/path.html recentchanges/default/path.html recentchanges/edit-book/path.html recentchanges/merge/path.html
 msgid "expand"
-msgstr ""
+msgstr "extinde"
 
 #: recentchanges/default/message.html recentchanges/edit-book/message.html
 msgid "opened a new Open Library account!"
-msgstr ""
+msgstr "a deschis un nou cont Open Library!"
 
 #: RecentChanges.html RecentChangesUsers.html recentchanges/default/path.html
 msgid "Review what's changed from the previous revision"
-msgstr ""
+msgstr "Revizuiți ce s-a schimbat față de revizuirea anterioară"
 
 #: recentchanges/default/view.html recentchanges/merge/view.html recentchanges/undo/view.html
 msgid "Updated Records"
-msgstr ""
+msgstr "Înregistrări actualizate"
 
 #: recentchanges/merge/comment.html
 #, python-format
 msgid "Merged duplicate %(record_type)s records."
-msgstr ""
+msgstr "Înregistrări duplicate %(record_type)s fuzionate."
 
 #: recentchanges/merge/comment.html
 #, python-format
 msgid "See <a href=\"%s\">details</a>."
-msgstr ""
+msgstr "Consultați <a href=\"%s\">detaliile</a>."
 
 #: recentchanges/merge/comment.html
 #, python-format
@@ -5800,12 +5800,12 @@ msgstr[2] ""
 
 #: recentchanges/merge/comment.html
 msgid "Marked as duplicate."
-msgstr ""
+msgstr "Marcat ca duplicat."
 
 #: recentchanges/merge/comment.html
 #, python-format
 msgid "Merged %(page_type)s into primary %(record_type)s record."
-msgstr ""
+msgstr "%(page_type)s fuzionat în înregistrarea principală %(record_type)s."
 
 #: recentchanges/merge/message.html
 #, python-format
@@ -5825,15 +5825,15 @@ msgstr[2] ""
 
 #: recentchanges/merge/view.html
 msgid "This merge has been undone."
-msgstr ""
+msgstr "Această fuzionare a fost anulată."
 
 #: recentchanges/merge/view.html
 msgid "Details here"
-msgstr ""
+msgstr "Detalii aici"
 
 #: recentchanges/merge/view.html type/author/view.html
 msgid "Duplicates"
-msgstr ""
+msgstr "Duplicate"
 
 #: recentchanges/merge/view.html
 #, python-format
@@ -5846,12 +5846,12 @@ msgstr[2] ""
 #: recentchanges/undo/view.html
 #, python-format
 msgid "Undo of <a href=\"$parent.url()\">%(kind)s</a>."
-msgstr ""
+msgstr "Anulare a <a href=\"$parent.url()\">%(kind)s</a>."
 
 #: recentchanges/undo/view.html
 #, python-format
 msgid "%(count)d records modified."
-msgstr ""
+msgstr "%(count)d înregistrări modificate."
 
 #: search/advancedsearch.html
 msgid "ISBN"
@@ -5859,7 +5859,7 @@ msgstr "ISBN"
 
 #: search/advancedsearch.html
 msgid "Place"
-msgstr ""
+msgstr "Loc"
 
 #: search/advancedsearch.html
 msgid "Person"
@@ -5867,45 +5867,45 @@ msgstr "Persoană"
 
 #: search/advancedsearch.html
 msgid "How to search?"
-msgstr ""
+msgstr "Cum să căutați?"
 
 #: search/advancedsearch.html
 msgid "Full Text Search?"
-msgstr ""
+msgstr "Căutare în text integral?"
 
 #: search/authors.html
 #, python-format
 msgid "Search Open Library for \"%(query)s\""
-msgstr ""
+msgstr "Căutați în Open Library \"%(query)s\""
 
 #: search/authors.html
 msgid "Search Authors"
-msgstr ""
+msgstr "Căutați autori"
 
 #: search/authors.html
 msgid "Is the same author listed twice?"
-msgstr ""
+msgstr "Autorul este listat de două ori?"
 
 #: search/authors.html
 msgid "Merge authors"
-msgstr ""
+msgstr "Fuzionați autori"
 
 #: search/authors.html
 msgid "No <strong>authors</strong> directly matched your search"
-msgstr ""
+msgstr "Niciun <strong>autor</strong> nu s-a potrivit direct cu căutarea dvs."
 
 #: search/inside.html
 #, python-format
 msgid "Search Open Library for %s"
-msgstr ""
+msgstr "Căutați în Open Library %s"
 
 #: BookSearchInside.html FulltextSearchSuggestion.html SearchNavigation.html search/inside.html search/snippets.html
 msgid "Search Inside"
-msgstr ""
+msgstr "Căutare în interior"
 
 #: search/inside.html
 msgid "No <strong>Search Inside</strong> text matched your search"
-msgstr ""
+msgstr "Niciun text <strong>Search Inside</strong> nu s-a potrivit cu căutarea dvs."
 
 #: search/inside.html
 #, python-format
@@ -5929,7 +5929,7 @@ msgstr "Detalii"
 
 #: search/layout_options.html
 msgid "Grid"
-msgstr ""
+msgstr "Grilă"
 
 #: search/layout_options.html
 #, fuzzy
@@ -5938,56 +5938,56 @@ msgstr "Vizualizează"
 
 #: search/lists.html
 msgid "Search results for Lists"
-msgstr ""
+msgstr "Rezultatele căutării pentru liste"
 
 #: search/lists.html
 msgid "Search Lists"
-msgstr ""
+msgstr "Căutați liste"
 
 #: search/lists.html
 msgid "No <strong>lists</strong> directly matched your search"
-msgstr ""
+msgstr "Nicio <strong>listă</strong> nu s-a potrivit direct cu căutarea dvs."
 
 #: search/publishers.html
 msgid "Publishers Search"
-msgstr ""
+msgstr "Căutare edituri"
 
 #: search/snippets.html
 #, python-format
 msgid "On leaf number %(page_num)d:"
-msgstr ""
+msgstr "Pe foaia numărul %(page_num)d:"
 
 #: search/sort_options.html
 msgid "Relevance"
-msgstr ""
+msgstr "Relevanță"
 
 #: search/sort_options.html
 msgid "Work Count"
-msgstr ""
+msgstr "Număr de opere"
 
 #: search/sort_options.html
 msgid "Random"
-msgstr ""
+msgstr "Aleatoriu"
 
 #: search/sort_options.html
 msgid "Name (beta: Librarian only)"
-msgstr ""
+msgstr "Nume (beta: doar bibliotecar)"
 
 #: search/sort_options.html
 msgid "Birth Date (oldest) (beta: Librarian only)"
-msgstr ""
+msgstr "Data nașterii (cel mai vechi) (beta: doar bibliotecar)"
 
 #: search/sort_options.html
 msgid "Birth Date (youngest) (beta: Librarian only)"
-msgstr ""
+msgstr "Data nașterii (cel mai tânăr) (beta: doar bibliotecar)"
 
 #: search/sort_options.html
 msgid "List Order"
-msgstr ""
+msgstr "Ordinea listei"
 
 #: search/sort_options.html
 msgid "Last Modified"
-msgstr ""
+msgstr "Ultima modificare"
 
 #: search/sort_options.html
 #, fuzzy
@@ -5996,31 +5996,31 @@ msgstr "limbi"
 
 #: search/sort_options.html
 msgid "Ebook Edition Count"
-msgstr ""
+msgstr "Număr ediții ebook"
 
 #: search/sort_options.html
 msgid "Date Added (newest)"
-msgstr ""
+msgstr "Data adăugării (cel mai recent)"
 
 #: search/sort_options.html
 msgid "Date Added (oldest)"
-msgstr ""
+msgstr "Data adăugării (cel mai vechi)"
 
 #: search/sort_options.html
 msgid "Most Editions"
-msgstr ""
+msgstr "Cele mai multe ediții"
 
 #: search/sort_options.html
 msgid "First Published"
-msgstr ""
+msgstr "Prima publicație"
 
 #: search/sort_options.html
 msgid "Most Recent"
-msgstr ""
+msgstr "Cel mai recent"
 
 #: search/sort_options.html
 msgid "Top Rated"
-msgstr ""
+msgstr "Top evaluat"
 
 #: search/sort_options.html
 msgid "Any"

--- a/openlibrary/i18n/ro/messages.po
+++ b/openlibrary/i18n/ro/messages.po
@@ -7492,71 +7492,71 @@ msgstr "Distribuiți pe %(share_link)s"
 
 #: ShareModal.html
 msgid "Embed this book in your website"
-msgstr ""
+msgstr "Incorporați această carte în site-ul dvs."
 
 #: ShareModal.html
 msgid "Embed icon"
-msgstr ""
+msgstr "Pictogramă incorporare"
 
 #: ShareModal.html
 msgid "Embed"
-msgstr ""
+msgstr "Incorporare"
 
 #: ShareModal.html
 msgid "Copy url to clipboard"
-msgstr ""
+msgstr "Copiați URL-ul în clipboard"
 
 #: ShareModal.html
 msgid "Copy URL icon"
-msgstr ""
+msgstr "Pictogramă copiere URL"
 
 #: ShareModal.html
 msgid "Copy URL"
-msgstr ""
+msgstr "Copiați URL-ul"
 
 #: ShareModal.html
 msgid "Open QR code"
-msgstr ""
+msgstr "Deschideți codul QR"
 
 #: ShareModal.html
 msgid "QR code icon"
-msgstr ""
+msgstr "Pictogramă cod QR"
 
 #: ShareModal.html
 msgid "QR Code"
-msgstr ""
+msgstr "Cod QR"
 
 #: StarRatings.html
 msgid "leaving a 1 star review for"
-msgstr ""
+msgstr "lăsând o recenzie de 1 stea pentru"
 
 #: StarRatings.html
 msgid "leaving a 2 star review for"
-msgstr ""
+msgstr "lăsând o recenzie de 2 stele pentru"
 
 #: StarRatings.html
 msgid "leaving a 3 star review for"
-msgstr ""
+msgstr "lăsând o recenzie de 3 stele pentru"
 
 #: StarRatings.html
 msgid "leaving a 4 star review for"
-msgstr ""
+msgstr "lăsând o recenzie de 4 stele pentru"
 
 #: StarRatings.html
 msgid "leaving a 5 star review for"
-msgstr ""
+msgstr "lăsând o recenzie de 5 stele pentru"
 
 #: StarRatings.html
 msgid "Clear my rating"
-msgstr ""
+msgstr "Ștergeți evaluarea mea"
 
 #: StarRatingsByline.html StarRatingsComponent.html
 msgid "rating"
-msgstr ""
+msgstr "evaluare"
 
 #: StarRatingsByline.html StarRatingsComponent.html
 msgid "ratings"
-msgstr ""
+msgstr "evaluări"
 
 #. Shows the count of readers who added this book to their "Want to read"
 #. shelf, displayed on search result pages. %(want_to_read_count)s is a
@@ -7570,7 +7570,7 @@ msgstr "%(want_to_read_count)s doresc să citesc"
 #: StarRatingsComponent.html
 #, python-format
 msgid "%(ratings_avg)s (%(ratings_count)s %(ratings_label)s)"
-msgstr ""
+msgstr "%(ratings_avg)s (%(ratings_count)s %(ratings_label)s)"
 
 #. Short label displayed next to the count of readers who want to read this
 #. book, shown in the stats bar on a book page. Example: "2,389 Want to read".
@@ -7590,7 +7590,7 @@ msgstr "În curs de citire"
 #. This refers to the same shelf as the "Already Read" button.
 #: StarRatingsStats.html
 msgid "Have read"
-msgstr ""
+msgstr "Am citit"
 
 #. Short label displayed next to the count of readers who stopped reading this
 #. book before finishing, shown in the stats bar on a book page. Example: "348
@@ -7607,19 +7607,19 @@ msgstr "Subiecte"
 
 #: Subnavigation.html
 msgid "Developer Center (Home)"
-msgstr ""
+msgstr "Centrul dezvoltatorilor (Acasă)"
 
 #: Subnavigation.html
 msgid "Web API"
-msgstr ""
+msgstr "Web API"
 
 #: Subnavigation.html
 msgid "Client Library"
-msgstr ""
+msgstr "Bibliotecă client"
 
 #: Subnavigation.html
 msgid "Data Dumps"
-msgstr ""
+msgstr "Exporturi date"
 
 #: Subnavigation.html
 msgid "Report an Issue"
@@ -7627,73 +7627,73 @@ msgstr "Raportați o problemă"
 
 #: Subnavigation.html
 msgid "Licensing"
-msgstr ""
+msgstr "Licențiere"
 
 #: Subnavigation.html
 msgid "Welcome"
-msgstr ""
+msgstr "Bun venit"
 
 #: Subnavigation.html
 msgid "Searching Open Library"
-msgstr ""
+msgstr "Căutarea în Open Library"
 
 #: Subnavigation.html
 msgid "Reading Books"
-msgstr ""
+msgstr "Citirea cărților"
 
 #: Subnavigation.html
 msgid "Adding & Editing Books"
-msgstr ""
+msgstr "Adăugarea și editarea cărților"
 
 #: Subnavigation.html
 msgid "Using Subjects"
-msgstr ""
+msgstr "Utilizarea subiectelor"
 
 #: Subnavigation.html
 msgid "Open Library F.A.Q."
-msgstr ""
+msgstr "Întrebări frecvente Open Library"
 
 #: TableOfContents.html
 #, python-format
 msgid "Page %s"
-msgstr ""
+msgstr "Pagina %s"
 
 #: TrendingBadge.html
 #, python-format
 msgid "Trending: %(score).2f"
-msgstr ""
+msgstr "Tendință: %(score).2f"
 
 #: TypeChanger.html
 msgid "Page Type"
-msgstr ""
+msgstr "Tipul paginii"
 
 #: TypeChanger.html
 msgid "Huh?"
-msgstr ""
+msgstr "Poftim?"
 
 #: TypeChanger.html
 msgid "Every piece of Open Library is defined by the type of content it displays, usually by content definition (e.g. Authors, Editions, Works) but sometimes by content use (e.g. macro, template, rawtext). Changing this for an existing page will alter its presentation and the data fields available for editing its content."
-msgstr ""
+msgstr "Fiecare element Open Library este definit de tipul de conținut pe care îl afișează, de obicei prin definiția conținutului (ex. Autori, Ediții, Opere), dar uneori prin utilizarea conținutului (ex. macro, șablon, text brut). Schimbarea acestuia pentru o pagină existentă va modifica prezentarea și câmpurile de date disponibile pentru editarea conținutului."
 
 #: TypeChanger.html
 msgid "Please use caution changing Page Type!"
-msgstr ""
+msgstr "Vă rugăm să fiți atent când schimbați Tipul paginii!"
 
 #: TypeChanger.html
 msgid "(Simplest solution: If you aren't sure whether this should be changed, don't change it.)"
-msgstr ""
+msgstr "(Soluție simplă: Dacă nu ești sigur că trebuie schimbat, nu-l schimba.)"
 
 #: WorkInfo.html
 msgid "No link to Wikipedia in your language"
-msgstr ""
+msgstr "Niciun link Wikipedia în limba dvs."
 
 #: WorldcatLink.html
 msgid "Check nearby libraries"
-msgstr ""
+msgstr "Verificați bibliotecile din apropiere"
 
 #: WorldcatLink.html
 msgid "Check WorldCat for an edition near you"
-msgstr ""
+msgstr "Verificați WorldCat pentru o ediție din apropierea dvs."
 
 #: WorldcatLink.html
 msgid "WorldCat"
@@ -7701,41 +7701,41 @@ msgstr "WorldCat"
 
 #: databarDiff.html databarEdit.html
 msgid "View the editing history of this page"
-msgstr ""
+msgstr "Vedeți istoricul de editare al acestei pagini"
 
 #: databarDiff.html
 msgid "View this page (exit Comparison view)"
-msgstr ""
+msgstr "Vizualizați această pagină (ieșiți din modul Comparație)"
 
 #: databarEdit.html
 msgid "View this page (exit Edit mode)"
-msgstr ""
+msgstr "Vizualizați această pagină (ieșiți din modul Editare)"
 
 #: databarHistory.html databarView.html
 #, python-format
 msgid "Last edited by %(author_link)s"
-msgstr ""
+msgstr "Ultima editare de %(author_link)s"
 
 #: databarHistory.html databarView.html
 msgid "Last edited anonymously"
-msgstr ""
+msgstr "Ultima editare anonimă"
 
 #: databarTemplate.html databarView.html
 msgid "View this template's edit history"
-msgstr ""
+msgstr "Vedeți istoricul de editare al acestui șablon"
 
 #: databarTemplate.html
 msgid "Edit this template"
-msgstr ""
+msgstr "Editați acest șablon"
 
 #: databarWork.html
 #, python-format
 msgid "View Volume %(num)d"
-msgstr ""
+msgstr "Vizualizați Volumul %(num)d"
 
 #: openlibrary/core/bookshelves.py
 msgid "[Record deleted]"
-msgstr ""
+msgstr "[Înregistrare ștearsă]"
 
 #: openlibrary/core/edits.py
 msgid "Unknown"
@@ -7748,7 +7748,7 @@ msgstr "Căutare"
 
 #: openlibrary/plugins/openlibrary/code.py
 msgid "Arabic"
-msgstr ""
+msgstr "Arabă"
 
 #: openlibrary/plugins/openlibrary/code.py
 msgid "Czech"
@@ -7809,7 +7809,7 @@ msgstr "Chineză"
 
 #: openlibrary/plugins/openlibrary/code.py
 msgid "Filipino"
-msgstr ""
+msgstr "Filipino"
 
 #: openlibrary/plugins/openlibrary/home.py
 msgid "Art"
@@ -7861,11 +7861,11 @@ msgstr "Știință"
 
 #: openlibrary/plugins/openlibrary/librarian_dashboard.py
 msgid "At least 1 subject"
-msgstr ""
+msgstr "Cel puțin 1 subiect"
 
 #: openlibrary/plugins/openlibrary/librarian_dashboard.py
 msgid "At least 1 author"
-msgstr ""
+msgstr "Cel puțin 1 autor"
 
 #: openlibrary/plugins/openlibrary/librarian_dashboard.py
 #, fuzzy
@@ -7874,11 +7874,11 @@ msgstr "o ediție"
 
 #: openlibrary/plugins/openlibrary/librarian_dashboard.py
 msgid "Has work (orphaned)"
-msgstr ""
+msgstr "Are operă (orfană)"
 
 #: openlibrary/plugins/openlibrary/librarian_dashboard.py
 msgid "Has publication year"
-msgstr ""
+msgstr "Are an de publicare"
 
 #: openlibrary/plugins/openlibrary/librarian_dashboard.py
 #, fuzzy
@@ -7897,52 +7897,52 @@ msgstr "Publicat pentru prima dată"
 
 #: openlibrary/plugins/openlibrary/librarian_dashboard.py
 msgid "At least 2 editions"
-msgstr ""
+msgstr "Cel puțin 2 ediții"
 
 #: openlibrary/plugins/openlibrary/librarian_dashboard.py
 msgid "Has dewey decimal"
-msgstr ""
+msgstr "Are clasificare Dewey"
 
 #: openlibrary/plugins/openlibrary/librarian_dashboard.py
 msgid "Has LoC classification"
-msgstr ""
+msgstr "Are clasificare LoC"
 
 #: openlibrary/plugins/openlibrary/librarian_dashboard.py
 msgid "Has number of pages"
-msgstr ""
+msgstr "Are număr de pagini"
 
 #: openlibrary/plugins/openlibrary/lists.py
 #, python-format
 msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
-msgstr ""
+msgstr "Sigur doriți să eliminați <strong>%(title)s</strong> din lista dvs.?"
 
 #: openlibrary/plugins/openlibrary/partials.py
 msgid "Better World Books"
-msgstr ""
+msgstr "Better World Books"
 
 #: openlibrary/plugins/openlibrary/partials.py
 msgid " - includes shipping"
-msgstr ""
+msgstr " - include livrarea"
 
 #: openlibrary/plugins/openlibrary/partials.py
 msgid "Amazon"
-msgstr ""
+msgstr "Amazon"
 
 #: openlibrary/plugins/openlibrary/partials.py
 msgid "Bookshop.org"
-msgstr ""
+msgstr "Bookshop.org"
 
 #: openlibrary/plugins/openlibrary/partials.py
 msgid "This work does not appear on any lists."
-msgstr ""
+msgstr "Această operă nu apare pe nicio listă."
 
 #: openlibrary/plugins/openlibrary/pd.py
 msgid "I don't have one yet"
-msgstr ""
+msgstr "Nu am încă unul"
 
 #: openlibrary/plugins/upstream/account.py
 msgid "The email address you entered is invalid"
-msgstr ""
+msgstr "Adresa de email introdusă este invalidă"
 
 #: openlibrary/plugins/upstream/account.py
 msgid "This account has been blocked"
@@ -7950,31 +7950,31 @@ msgstr "Acest cont a fost blocat"
 
 #: openlibrary/plugins/upstream/account.py
 msgid "This account has been locked"
-msgstr ""
+msgstr "Acest cont a fost blocat"
 
 #: openlibrary/plugins/upstream/account.py
 msgid "No account was found with this email. Please try again"
-msgstr ""
+msgstr "Niciun cont găsit cu acest email. Vă rugăm să încercați din nou"
 
 #: openlibrary/plugins/upstream/account.py
 msgid "The password you entered is incorrect. Please try again"
-msgstr ""
+msgstr "Parola introdusă este incorectă. Vă rugăm să încercați din nou"
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Wrong password. Please try again"
-msgstr ""
+msgstr "Parolă greșită. Vă rugăm să încercați din nou"
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Please verify your Open Library account before logging in"
-msgstr ""
+msgstr "Vă rugăm să vă verificați contul Open Library înainte de a vă conecta"
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Please verify your Internet Archive account before logging in"
-msgstr ""
+msgstr "Vă rugăm să vă verificați contul Internet Archive înainte de a vă conecta"
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Please fill out all fields and try again"
-msgstr ""
+msgstr "Vă rugăm să completați toate câmpurile și să încercați din nou"
 
 #: openlibrary/plugins/upstream/account.py
 msgid "This email is already registered"

--- a/openlibrary/i18n/ro/messages.po
+++ b/openlibrary/i18n/ro/messages.po
@@ -2031,27 +2031,27 @@ msgstr "Media Infobase"
 
 #: admin/history.html admin/imports.html authors/infobox.html type/author/edit.html
 msgid "Date"
-msgstr ""
+msgstr "Dată"
 
 #: admin/history.html
 msgid "Page"
-msgstr ""
+msgstr "Pagină"
 
 #: admin/imports-add.html admin/imports.html admin/imports_by_date.html admin/menu.html
 msgid "Imports"
-msgstr ""
+msgstr "Importuri"
 
 #: admin/imports-add.html books/add.html books/edit/edition.html books/edit/excerpts.html covers/change.html type/tag/form.html
 msgid "Add"
-msgstr ""
+msgstr "Adaugă"
 
 #: admin/imports-add.html admin/imports.html
 msgid "Add new books to import queue"
-msgstr ""
+msgstr "Adaugă cărți noi în coada de import"
 
 #: admin/imports-add.html
 msgid "Please add IA identifiers to be imported, one per line."
-msgstr ""
+msgstr "Adăugați identificatorii IA de importat, câte unul pe linie."
 
 #: admin/imports-add.html admin/inspect/store.html admin/ip/view.html admin/people/edits.html admin/permissions.html my_books/check_ins/check_in_form.html reading_goals/reading_goal_form.html
 msgid "Submit"
@@ -2059,156 +2059,156 @@ msgstr "Salvează"
 
 #: admin/imports.html
 msgid "New Books Imported Per Day"
-msgstr ""
+msgstr "Cărți noi importate pe zi"
 
 #: PublishingHistory.html admin/imports.html publishers/view.html
 msgid "You need to have JavaScript turned on to see the nifty chart!"
-msgstr ""
+msgstr "Trebuie să ai JavaScript activat pentru a vedea graficul!"
 
 #: admin/imports.html admin/imports_by_date.html admin/pd_dashboard.html site/stats.html
 msgid "Summary"
-msgstr ""
+msgstr "Rezumat"
 
 #: admin/imports.html
 msgid "Pending Items:"
-msgstr ""
+msgstr "Elemente în așteptare:"
 
 #: admin/imports.html
 #, python-format
 msgid "<strong>Current Import Rate:</strong> %(num)d imports/hour."
-msgstr ""
+msgstr "<strong>Rata curentă de import:</strong> %(num)d importuri/oră."
 
 #: admin/imports.html
 msgid "ETA:"
-msgstr ""
+msgstr "ETA:"
 
 #: admin/imports.html
 msgid "Summary By Date"
-msgstr ""
+msgstr "Rezumat pe dată"
 
 #: admin/imports.html
 msgid "total"
-msgstr ""
+msgstr "total"
 
 #: admin/imports.html
 msgid "#books created"
-msgstr ""
+msgstr "#cărți create"
 
 #: admin/imports.html
 msgid "#books already found"
-msgstr ""
+msgstr "#cărți deja găsite"
 
 #: admin/imports.html
 msgid "#books failed to import"
-msgstr ""
+msgstr "#cărți cu import eșuat"
 
 #: admin/imports.html
 msgid "#books pending"
-msgstr ""
+msgstr "#cărți în așteptare"
 
 #: admin/imports.html
 msgid "Recent Imports"
-msgstr ""
+msgstr "Importuri recente"
 
 #: admin/imports.html admin/imports_by_date.html
 msgid "Identifier"
-msgstr ""
+msgstr "Identificator"
 
 #: admin/imports.html admin/imports_by_date.html
 msgid "Imported Time"
-msgstr ""
+msgstr "Ora importului"
 
 #: admin/imports_by_date.html admin/index.html admin/pd_dashboard.html
 msgid "Total"
-msgstr ""
+msgstr "Total"
 
 #: admin/imports_by_date.html
 msgid "Created"
-msgstr ""
+msgstr "Create"
 
 #: admin/imports_by_date.html
 msgid "Found"
-msgstr ""
+msgstr "Găsite"
 
 #: admin/imports_by_date.html
 msgid "Failed"
-msgstr ""
+msgstr "Eșuate"
 
 #: admin/imports_by_date.html openlibrary/core/edits.py
 msgid "Pending"
-msgstr ""
+msgstr "În așteptare"
 
 #: admin/imports_by_date.html
 msgid "Items"
-msgstr ""
+msgstr "Elemente"
 
 #: admin/index.html
 msgid "<span class=\"login-counts\">0</span> patrons have logged in at least once over the past 30 days."
-msgstr ""
+msgstr "<span class=\"login-counts\">0</span> utilizatori s-au autentificat cel puțin o dată în ultimele 30 de zile."
 
 #: admin/index.html
 msgid "Stats"
-msgstr ""
+msgstr "Statistici"
 
 #: admin/index.html
 msgid "Edits Per Day"
-msgstr ""
+msgstr "Modificări pe zi"
 
 #: admin/index.html admin/people/index.html
 msgid "Edits"
-msgstr ""
+msgstr "Modificări"
 
 #: admin/index.html
 msgid "Yesterday"
-msgstr ""
+msgstr "Ieri"
 
 #: admin/index.html
 msgid "Last 7 days"
-msgstr ""
+msgstr "Ultimele 7 zile"
 
 #: admin/index.html
 msgid "Last 28 days"
-msgstr ""
+msgstr "Ultimele 28 de zile"
 
 #: admin/index.html
 msgid "Human"
-msgstr ""
+msgstr "Uman"
 
 #: admin/index.html admin/people/view.html
 msgid "Bot"
-msgstr ""
+msgstr "Bot"
 
 #: admin/index.html
 msgid "New Accounts Per Day"
-msgstr ""
+msgstr "Conturi noi pe zi"
 
 #: admin/index.html
 msgid "Members"
-msgstr ""
+msgstr "Membri"
 
 #: admin/index.html
 msgid "Items Added"
-msgstr ""
+msgstr "Elemente adăugate"
 
 #: admin/index.html
 msgid "Trend"
-msgstr ""
+msgstr "Tendință"
 
 #: admin/index.html
 msgid "Works Added"
-msgstr ""
+msgstr "Opere adăugate"
 
 #: admin/index.html
 msgid "Editions Added"
-msgstr ""
+msgstr "Ediții adăugate"
 
 #: admin/index.html
 msgid "Authors Added"
-msgstr ""
+msgstr "Autori adăugați"
 
 #: admin/index.html recentchanges/index.html
 msgid "Covers Added"
-msgstr ""
+msgstr "Coperte adăugate"
 
 #: admin/index.html home/stats.html
 msgid "New Members"
@@ -2220,11 +2220,11 @@ msgstr "Liste adăugate"
 
 #: admin/index.html
 msgid "Books Logged"
-msgstr ""
+msgstr "Cărți înregistrate"
 
 #: admin/index.html
 msgid "Users Logging"
-msgstr ""
+msgstr "Utilizatori care înregistrează"
 
 #: admin/index.html
 msgid "Yearly Reading Goals"
@@ -2232,35 +2232,35 @@ msgstr "Obiective anuale de citire"
 
 #: admin/index.html
 msgid "Books Review Tags"
-msgstr ""
+msgstr "Etichete de recenzii cărți"
 
 #: admin/index.html
 msgid "Books Reviewed"
-msgstr ""
+msgstr "Cărți recenzate"
 
 #: admin/index.html
 msgid "Users Reviewing"
-msgstr ""
+msgstr "Utilizatori care recenzează"
 
 #: admin/index.html
 msgid "Patrons Following"
-msgstr ""
+msgstr "Utilizatori care urmăresc"
 
 #: admin/index.html
 msgid "Notes Created"
-msgstr ""
+msgstr "Note create"
 
 #: admin/index.html
 msgid "Patrons Creating Notes"
-msgstr ""
+msgstr "Utilizatori care creează note"
 
 #: admin/index.html
 msgid "Books Starred"
-msgstr ""
+msgstr "Cărți marcate cu stea"
 
 #: admin/index.html
 msgid "Star Rating Patrons"
-msgstr ""
+msgstr "Utilizatori care acordă stele"
 
 #: admin/index.html home/stats.html
 msgid "Unique Visitors"
@@ -2289,11 +2289,11 @@ msgstr "Vizitatori unici"
 
 #: admin/index.html
 msgid "Gathering login statistics..."
-msgstr ""
+msgstr "Se colectează statistici de autentificare..."
 
 #: admin/loans_table.html
 msgid "BookReader"
-msgstr ""
+msgstr "BookReader"
 
 #: admin/loans_table.html book_providers/cita_press_download_options.html book_providers/ia_download_options.html book_providers/openstax_download_options.html book_providers/wikisource_download_options.html books/edit/edition.html
 msgid "PDF"
@@ -2301,11 +2301,11 @@ msgstr "PDF"
 
 #: admin/loans_table.html book_providers/gutenberg_download_options.html book_providers/ia_download_options.html book_providers/standard_ebooks_download_options.html books/edit/edition.html
 msgid "ePub"
-msgstr ""
+msgstr "ePub"
 
 #: admin/loans_table.html
 msgid "No current loans."
-msgstr ""
+msgstr "Niciun împrumut curent."
 
 #: admin/loans_table.html
 #, python-format
@@ -2322,37 +2322,37 @@ msgstr "Ce"
 #: admin/loans_table.html
 #, python-format
 msgid "Waiting since %(date)s"
-msgstr ""
+msgstr "Așteptare din %(date)s"
 
 #: admin/loans_table.html
 #, python-format
 msgid "#%(num_position)d among %(num_waitlist)d people waiting for this book"
-msgstr ""
+msgstr "#%(num_position)d din %(num_waitlist)d persoane care așteaptă această carte"
 
 #: ManageLoansButtons.html admin/loans_table.html
 #, python-format
 msgid "Borrowed %(date)s"
-msgstr ""
+msgstr "Împrumutat la %(date)s"
 
 #: admin/menu.html
 msgid "Admin Center"
-msgstr ""
+msgstr "Centru de administrare"
 
 #: RelatedSubjects.html SubjectTags.html admin/menu.html admin/people/index.html admin/people/view.html openlibrary/plugins/worksearch/code.py type/author/view.html type/list/view_body.html
 msgid "People"
-msgstr ""
+msgstr "Persoane"
 
 #: admin/menu.html
 msgid "PD Access Requests"
-msgstr ""
+msgstr "Cereri de acces PD"
 
 #: admin/menu.html
 msgid "Block IPs"
-msgstr ""
+msgstr "Blochează IP-uri"
 
 #: admin/menu.html admin/spamwords.html
 msgid "Spam Words"
-msgstr ""
+msgstr "Cuvinte spam"
 
 #: admin/menu.html
 msgid "Solr"
@@ -2360,23 +2360,23 @@ msgstr "Solr"
 
 #: admin/menu.html
 msgid "Graphs"
-msgstr ""
+msgstr "Grafice"
 
 #: admin/menu.html
 msgid "Inspect store"
-msgstr ""
+msgstr "Inspectează magazin"
 
 #: admin/menu.html
 msgid "Inspect memcache"
-msgstr ""
+msgstr "Inspectează memcache"
 
 #: admin/pd_dashboard.html
 msgid "Print Disability Access Requests"
-msgstr ""
+msgstr "Cereri de acces pentru dizabilități de tipărire"
 
 #: admin/pd_dashboard.html
 msgid "Breakdown by Qualifying Authority"
-msgstr ""
+msgstr "Defalcare după autoritate calificatoare"
 
 #: admin/pd_dashboard.html
 #, fuzzy
@@ -2390,7 +2390,7 @@ msgstr "E-mail"
 
 #: admin/pd_dashboard.html
 msgid "Fulfilled"
-msgstr ""
+msgstr "Îndeplinite"
 
 #: admin/pd_dashboard.html
 #, fuzzy
@@ -2399,15 +2399,15 @@ msgstr "Discuții despre cărți"
 
 #: admin/permissions.html
 msgid "[Admin Center] Site Permissions"
-msgstr ""
+msgstr "[Centru de administrare] Permisiuni site"
 
 #: admin/permissions.html
 msgid "Site Permissions"
-msgstr ""
+msgstr "Permisiuni site"
 
 #: admin/permissions.html
 msgid "Change the policy of who can edit the site."
-msgstr ""
+msgstr "Schimbă politica de editare a site-ului."
 
 #: admin/permissions.html
 msgid "Who can edit Open Library records?"

--- a/openlibrary/i18n/ro/messages.po
+++ b/openlibrary/i18n/ro/messages.po
@@ -2411,67 +2411,67 @@ msgstr "Schimbă politica de editare a site-ului."
 
 #: admin/permissions.html
 msgid "Who can edit Open Library records?"
-msgstr ""
+msgstr "Cine poate edita înregistrările Open Library?"
 
 #: admin/permissions.html
 msgid "This applies to /authors/*, /books/* and /works/* records."
-msgstr ""
+msgstr "Aceasta se aplică înregistrărilor /authors/*, /books/* și /works/*."
 
 #: admin/permissions.html
 msgid "Who can edit Open Library pages?"
-msgstr ""
+msgstr "Cine poate edita paginile Open Library?"
 
 #: admin/permissions.html
 msgid "This applies to /about/*, /help/*, /dev/*, /docs/* etc."
-msgstr ""
+msgstr "Aceasta se aplică paginilor /about/*, /help/*, /dev/*, /docs/* etc."
 
 #: admin/permissions.html
 msgid "Update permissions"
-msgstr ""
+msgstr "Actualizează permisiunile"
 
 #: admin/permissions.html
 msgid "This updates \"permission\" and \"child_permission\" fields of /, /works, /books and /authors records in the database."
-msgstr ""
+msgstr "Aceasta actualizează câmpurile \"permission\" și \"child_permission\" ale înregistrărilor /, /works, /books și /authors din baza de date."
 
 #: admin/solr.html
 msgid "Solr Admin"
-msgstr ""
+msgstr "Admin Solr"
 
 #: admin/solr.html
 msgid "Enter the keys of pages to be updated in OL search engine."
-msgstr ""
+msgstr "Introduceți cheile paginilor de actualizat în motorul de căutare OL."
 
 #: admin/solr.html
 msgid "Example:"
-msgstr ""
+msgstr "Exemplu:"
 
 #: admin/solr.html
 msgid "On update, these keys will be added to solr update queue and it'll take about 15 minutes for them to get reindexed in Solr."
-msgstr ""
+msgstr "La actualizare, aceste chei vor fi adăugate în coada de actualizare Solr și va dura aproximativ 15 minute pentru reindexare."
 
 #: admin/solr.html
 msgid "Enter the keys to reindex in Solr"
-msgstr ""
+msgstr "Introduceți cheile de reindexat în Solr"
 
 #: admin/solr.html
 msgid "Write one entry per line"
-msgstr ""
+msgstr "Scrieți câte o intrare pe linie"
 
 #: admin/spamwords.html
 msgid "[Admin Center] Spam Words"
-msgstr ""
+msgstr "[Centru de administrare] Cuvinte spam"
 
 #: admin/spamwords.html
 msgid "Please enter the SPAM regular expressions in the textarea below, one per line."
-msgstr ""
+msgstr "Introduceți expresiile regulate SPAM în câmpul de text de mai jos, câte una pe linie."
 
 #: admin/spamwords.html
 msgid "Be sure to escape any meta characters that are meant to be character literals."
-msgstr ""
+msgstr "Asigurați-vă că specificați caracterele meta care sunt literale."
 
 #: admin/spamwords.html
 msgid "If you are adding a domain, prepend the following to the domain:"
-msgstr ""
+msgstr "Dacă adăugați un domeniu, adăugați înainte următoarele la domeniu:"
 
 #: admin/spamwords.html
 msgid "For example, if you want to prevent edits containing the domain <code>t.co</code>, add <code>(|https://|http://)t\\.co</code> to the spamwords list."
@@ -2479,31 +2479,31 @@ msgstr ""
 
 #: admin/spamwords.html
 msgid "Spam Domains"
-msgstr ""
+msgstr "Domenii spam"
 
 #: admin/spamwords.html
 msgid "Please enter domains to blacklist in the textarea below, one per line."
-msgstr ""
+msgstr "Introduceți domeniile de blocat în câmpul de text de mai jos, câte unul pe linie."
 
 #: admin/sync.html
 msgid "Sync"
-msgstr ""
+msgstr "Sincronizare"
 
 #: admin/sync.html
 msgid "Sync the metadata of various types of Open Library items (e.g. lists, subjects, works) with Archive.org."
-msgstr ""
+msgstr "Sincronizați metadatele diferitelor tipuri de elemente Open Library (ex. liste, subiecte, opere) cu Archive.org."
 
 #: admin/sync.html
 msgid "Add Works to Staff Picks"
-msgstr ""
+msgstr "Adaugă opere la Selecțiile personalului"
 
 #: admin/sync.html
 msgid "This utility will add your work to an Open Library list called `Staff Picks` under the `openlibrary` user. It will then take the added work and explode it into a list of all its readable editions. For each Open Library edition, a metadata field called `openlibrary_subject` will be injected into the archive.org metadata of the edition's corresponding archive.org item."
-msgstr ""
+msgstr "Această funcție va adăuga opera ta pe o listă Open Library numită 'Staff Picks' sub utilizatorul 'openlibrary'. Va exploda opera adăugată într-o listă a tuturor edițiilor sale lizibile și va injecta câmpul de metadate 'openlibrary_subject' în metadatele archive.org ale fiecărui element corespunzător."
 
 #: admin/sync.html
 msgid "add"
-msgstr ""
+msgstr "adaugă"
 
 #: admin/sync.html
 #, fuzzy
@@ -2517,211 +2517,211 @@ msgstr "o ediție"
 
 #: admin/sync.html
 msgid "Updates an edition on archive.org by writing in its latest  openlibrary_edition and openlibrary_work identifier values"
-msgstr ""
+msgstr "Actualizează o ediție pe archive.org prin scrierea celor mai recente valori de identificator openlibrary_edition și openlibrary_work"
 
 #: admin/sync.html
 msgid "TODO"
-msgstr ""
+msgstr "DE FĂCUT"
 
 #: admin/inspect/memcache.html
 msgid "[Admin Center] Inspect Memcache"
-msgstr ""
+msgstr "[Centru de administrare] Inspectează Memcache"
 
 #: admin/inspect/memcache.html
 msgid "Inspect Memcache"
-msgstr ""
+msgstr "Inspectează Memcache"
 
 #: admin/inspect/memcache.html
 msgid "Add one memcache key per line in the text area. Each key must include a '-' as the last character."
-msgstr ""
+msgstr "Adăugați câte o cheie memcache pe linie în câmpul text. Fiecare cheie trebuie să includă un \"-\" ca ultim caracter."
 
 #: admin/inspect/memcache.html
 msgid "For example, <code>observations-</code> should be entered in the text area if the key is <code>observations</code>."
-msgstr ""
+msgstr "De exemplu, <code>observations-</code> trebuie introdus în câmpul text dacă cheia este <code>observations</code>."
 
 #: admin/inspect/memcache.html
 msgid "Keys:"
-msgstr ""
+msgstr "Chei:"
 
 #: admin/inspect/memcache.html
 msgid "Result"
-msgstr ""
+msgstr "Rezultat"
 
 #: admin/inspect/memcache.html
 msgid "No keys selected."
-msgstr ""
+msgstr "Nicio cheie selectată."
 
 #: admin/inspect/memcache.html
 msgid "Not found."
-msgstr ""
+msgstr "Negăsit."
 
 #: admin/inspect/store.html
 msgid "Admin Center / Inspect"
-msgstr ""
+msgstr "Centru de administrare / Inspectare"
 
 #: admin/inspect/store.html
 msgid "Inspect Store"
-msgstr ""
+msgstr "Inspectare magazin"
 
 #: admin/inspect/store.html
 msgid "Get"
-msgstr ""
+msgstr "Obține"
 
 #: admin/inspect/store.html
 msgid "Key"
-msgstr ""
+msgstr "Cheie"
 
 #: admin/inspect/store.html
 msgid "Query"
-msgstr ""
+msgstr "Interogare"
 
 #: admin/inspect/store.html
 msgid "Type"
-msgstr ""
+msgstr "Tip"
 
 #: admin/inspect/store.html
 msgid "Value"
-msgstr ""
+msgstr "Valoare"
 
 #: admin/inspect/store.html
 msgid "Documents"
-msgstr ""
+msgstr "Documente"
 
 #: admin/inspect/store.html
 msgid "Json"
-msgstr ""
+msgstr "Json"
 
 #: admin/inspect/store.html
 msgid "No results found."
-msgstr ""
+msgstr "Niciun rezultat găsit."
 
 #: admin/ip/index.html
 msgid "[Admin Center] IP Addresses"
-msgstr ""
+msgstr "[Centru de administrare] Adrese IP"
 
 #: admin/ip/index.html
 msgid "IP Addresses"
-msgstr ""
+msgstr "Adrese IP"
 
 #: admin/ip/index.html
 msgid "List of Banned IPs"
-msgstr ""
+msgstr "Lista IP-urilor blocate"
 
 #: admin/ip/index.html admin/people/index.html
 msgid "Date/Time"
-msgstr ""
+msgstr "Dată/Oră"
 
 #: admin/ip/index.html
 msgid "IP address"
-msgstr ""
+msgstr "Adresă IP"
 
 #: admin/ip/index.html
 msgid "Admin Comment"
-msgstr ""
+msgstr "Comentariu admin"
 
 #: admin/ip/index.html
 msgid "# of edits"
-msgstr ""
+msgstr "Nr. de modificări"
 
 #: admin/ip/index.html
 msgid "x minutes ago"
-msgstr ""
+msgstr "x minute în urmă"
 
 #: admin/ip/index.html admin/ip/view.html
 msgid "IP"
-msgstr ""
+msgstr "IP"
 
 #: admin/ip/index.html
 msgid "comment"
-msgstr ""
+msgstr "comentariu"
 
 #: admin/ip/view.html admin/people/view.html
 msgid "[Admin Center]"
-msgstr ""
+msgstr "[Centru de administrare]"
 
 #: admin/ip/view.html
 #, python-format
 msgid "IP %(ip)s is <a href=\"/admin/block\">blocked</a>."
-msgstr ""
+msgstr "IP-ul %(ip)s este <a href=\"/admin/block\">blocat</a>."
 
 #: admin/ip/view.html
 #, python-format
 msgid "Block %(ip)s"
-msgstr ""
+msgstr "Blochează %(ip)s"
 
 #: admin/ip/view.html admin/people/edits.html
 msgid "Please select the changesets to revert."
-msgstr ""
+msgstr "Selectați seturile de modificări de revertat."
 
 #: RecentChanges.html admin/ip/view.html admin/people/edits.html recentchanges/render.html
 msgid "When you see numbers here, that's the IP address of the anonymous editor"
-msgstr ""
+msgstr "Când vedeți numere aici, aceea este adresa IP a editorului anonim"
 
 #: admin/ip/view.html admin/people/edits.html
 #, python-format
 msgid "Reverted by %(revert_author)s"
-msgstr ""
+msgstr "Revertat de %(revert_author)s"
 
 #: EditButtons.html admin/ip/view.html admin/people/edits.html
 msgid "Please, leave a short note about what you changed: <span class=\"small gray\">(Optional, but very useful!)</span>"
-msgstr ""
+msgstr "Vă rugăm să lăsați o scurtă notă despre ce ați modificat: <span class=\"small gray\">(Opțional, dar foarte util!)</span>"
 
 #: admin/ip/view.html admin/people/edits.html
 msgid "Reverted spam"
-msgstr ""
+msgstr "Spam revertat"
 
 #: admin/people/edits.html
 #, python-format
 msgid "[Admin Center] Edits of %(user)s"
-msgstr ""
+msgstr "[Centru de administrare] Modificări ale %(user)s"
 
 #: admin/people/edits.html
 msgid "people"
-msgstr ""
+msgstr "persoane"
 
 #: admin/people/edits.html
 msgid "edits"
-msgstr ""
+msgstr "modificări"
 
 #: admin/people/index.html
 msgid "[Admin Center] People"
-msgstr ""
+msgstr "[Centru de administrare] Persoane"
 
 #: admin/people/index.html
 msgid "Find Account"
-msgstr ""
+msgstr "Găsește cont"
 
 #: admin/people/index.html admin/people/view.html
 msgid "Email Address:"
-msgstr ""
+msgstr "Adresă email:"
 
 #: admin/people/index.html
 msgid "Find"
-msgstr ""
+msgstr "Găsește"
 
 #: admin/people/index.html
 msgid "No account found with this email."
-msgstr ""
+msgstr "Niciun cont găsit cu acest email."
 
 #: admin/people/index.html
 msgid "IA ID:"
-msgstr ""
+msgstr "ID IA:"
 
 #: admin/people/index.html
 msgid "e.g. @foobar"
-msgstr ""
+msgstr "ex. @foobar"
 
 #: admin/people/index.html
 msgid "No account found with this ID."
-msgstr ""
+msgstr "Niciun cont găsit cu acest ID."
 
 #: admin/people/index.html
 msgid "Recent Accounts"
-msgstr ""
+msgstr "Conturi recente"
 
 #: admin/people/index.html
 msgid "email"
-msgstr ""
+msgstr "email"
 
 #: admin/people/index.html
 msgid "profile"

--- a/openlibrary/i18n/ro/messages.po
+++ b/openlibrary/i18n/ro/messages.po
@@ -7978,72 +7978,72 @@ msgstr "Vă rugăm să completați toate câmpurile și să încercați din nou"
 
 #: openlibrary/plugins/upstream/account.py
 msgid "This email is already registered"
-msgstr ""
+msgstr "Această adresă de email este deja înregistrată"
 
 #: openlibrary/plugins/upstream/account.py
 msgid "This username is already registered"
-msgstr ""
+msgstr "Acest nume de utilizator este deja înregistrat"
 
 #: openlibrary/plugins/upstream/account.py
 msgid "A problem occurred and we were unable to log you in."
-msgstr ""
+msgstr "A apărut o problemă și nu am putut să vă conectăm."
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Login attempted with invalid Internet Archive s3 credentials."
-msgstr ""
+msgstr "S-a încercat conectarea cu credențiale s3 Internet Archive invalide."
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Servers are experiencing unusually high traffic, please try again later or email openlibrary@archive.org for help."
-msgstr ""
+msgstr "Serverele experimentează trafic neobișnuit de mare, vă rugăm să încercați din nou mai târziu sau trimiteți un email la openlibrary@archive.org pentru ajutor."
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Email provider not recognized."
-msgstr ""
+msgstr "Furnizorul de email nu este recunoscut."
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Password requirements not met."
-msgstr ""
+msgstr "Cerințele pentru parolă nu sunt îndeplinite."
 
 #: openlibrary/plugins/upstream/account.py
 msgid "A problem occurred and we were unable to log you in"
-msgstr ""
+msgstr "A apărut o problemă și nu am putut să vă conectăm"
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Login or registration attempt hit an unexpected error, please try again or contact info@archive.org"
-msgstr ""
+msgstr "Încercarea de conectare sau înregistrare a întâlnit o eroare neașteptată, vă rugăm să încercați din nou sau să contactați info@archive.org"
 
 #: openlibrary/plugins/upstream/account.py
 #, python-format
 msgid "Request failed with error code: %(error_code)s"
-msgstr ""
+msgstr "Solicitarea a eșuat cu codul de eroare: %(error_code)s"
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Thank you for registering an Open Library account and requesting special print disability access. You should receive an email detailing next steps in the process."
-msgstr ""
+msgstr "Vă mulțumim pentru înregistrarea unui cont Open Library și solicitarea accesului special pentru dizabilități de lectură tipărită. Ar trebui să primiți un email cu detalii despre pașii următori în proces."
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Username unavailable"
-msgstr ""
+msgstr "Nume de utilizator indisponibil"
 
 #: openlibrary/plugins/upstream/account.py openlibrary/plugins/upstream/forms.py
 msgid "Email already registered"
-msgstr ""
+msgstr "Email deja înregistrat"
 
 #: openlibrary/plugins/upstream/account.py
 msgid "An Internet Archive account already exists with this email"
-msgstr ""
+msgstr "Un cont Internet Archive există deja cu acest email"
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Verification failed. The link may be invalid or expired. Please try registering again."
-msgstr ""
+msgstr "Verificarea a eșuat. Linkul poate fi invalid sau expirat. Vă rugăm să încercați să vă înregistrați din nou."
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Your email has been verified. You are now logged in."
-msgstr ""
+msgstr "Emailul dvs. a fost verificat. Sunteți acum conectat."
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Notification preferences have been updated successfully."
-msgstr ""
+msgstr "Preferințele de notificare au fost actualizate cu succes."
 
 #: openlibrary/plugins/upstream/borrow.py
 #, fuzzy
@@ -8053,7 +8053,7 @@ msgstr ""
 #: openlibrary/plugins/upstream/borrow.py
 #, python-format
 msgid "Unable to return %s. Please try again later or contact info@archive.org."
-msgstr ""
+msgstr "Imposibil de returnat %s. Vă rugăm să încercați din nou mai târziu sau să contactați info@archive.org."
 
 #: openlibrary/plugins/upstream/borrow.py
 #, fuzzy, python-format
@@ -8062,7 +8062,7 @@ msgstr ""
 
 #: openlibrary/plugins/upstream/borrow.py
 msgid "Your account has hit a lending limit. Please try again later or contact info@archive.org."
-msgstr ""
+msgstr "Contul dvs. a atins limita de împrumut. Vă rugăm să încercați din nou mai târziu sau să contactați info@archive.org."
 
 #: openlibrary/plugins/upstream/forms.py
 msgid "Username"
@@ -8070,15 +8070,15 @@ msgstr "Nume de utilizator"
 
 #: openlibrary/plugins/upstream/forms.py
 msgid "No user registered with this email address"
-msgstr ""
+msgstr "Niciun utilizator înregistrat cu această adresă de email"
 
 #: openlibrary/plugins/upstream/forms.py
 msgid "Disposable email not permitted"
-msgstr ""
+msgstr "Email de unică folosință nepermis"
 
 #: openlibrary/plugins/upstream/forms.py
 msgid "Your email provider is not recognized."
-msgstr ""
+msgstr "Furnizorul dvs. de email nu este recunoscut."
 
 #: openlibrary/plugins/upstream/forms.py
 msgid "Username already used"
@@ -8086,15 +8086,15 @@ msgstr "Nume de utilizator deja folosit"
 
 #: openlibrary/plugins/upstream/forms.py
 msgid "Must be between 3 and 20 letters and numbers"
-msgstr ""
+msgstr "Trebuie să aibă între 3 și 20 de litere și cifre"
 
 #: openlibrary/plugins/upstream/forms.py
 msgid "Screen Name"
-msgstr ""
+msgstr "Nume de ecran"
 
 #: openlibrary/plugins/upstream/forms.py
 msgid "Public and cannot be changed later."
-msgstr ""
+msgstr "Public și nu poate fi schimbat ulterior."
 
 #: openlibrary/plugins/upstream/forms.py
 msgid "Invalid password"
@@ -8102,7 +8102,7 @@ msgstr "Parolă nevalidă"
 
 #: openlibrary/plugins/upstream/forms.py
 msgid "Your email address"
-msgstr ""
+msgstr "Adresa dvs. de email"
 
 #: openlibrary/plugins/upstream/forms.py
 msgid "Choose a password"
@@ -8111,7 +8111,7 @@ msgstr "Alegeți o parolă"
 #: openlibrary/plugins/upstream/mybooks.py
 #, python-format
 msgid "Continue <a href=\"%(url)s\" class=\"pending-action-link\" data-action=\"%(raw_action)s\"><strong>%(action)s</strong> <em>%(name)s</em></a>"
-msgstr ""
+msgstr "Continuați <a href=\"%(url)s\" class=\"pending-action-link\" data-action=\"%(raw_action)s\"><strong>%(action)s</strong> <em>%(name)s</em></a>"
 
 #: openlibrary/plugins/worksearch/code.py
 msgid "eBook?"

--- a/openlibrary/i18n/ro/messages.po
+++ b/openlibrary/i18n/ro/messages.po
@@ -3073,15 +3073,15 @@ msgstr "Cod sursă"
 
 #: book_providers/standard_ebooks_download_options.html
 msgid "More at Standard Ebooks"
-msgstr ""
+msgstr "Mai mult la Standard Ebooks"
 
 #: book_providers/wikisource_download_options.html
 msgid "Download PDF from Wikisource"
-msgstr ""
+msgstr "Descarcă PDF de la Wikisource"
 
 #: book_providers/wikisource_download_options.html
 msgid "Download MOBI from Wikisource"
-msgstr ""
+msgstr "Descarcă MOBI de la Wikisource"
 
 #: book_providers/wikisource_download_options.html
 msgid "MOBI (for Kindle)"
@@ -3089,19 +3089,19 @@ msgstr "MOBI (pentru Kindle)"
 
 #: book_providers/wikisource_download_options.html
 msgid "Download EPUB from Wikisource"
-msgstr ""
+msgstr "Descarcă EPUB de la Wikisource"
 
 #: book_providers/wikisource_download_options.html
 msgid "EPUB (for most other e-readers)"
-msgstr ""
+msgstr "EPUB (pentru majoritatea celorlalte e-readere)"
 
 #: book_providers/wikisource_download_options.html
 msgid "Read at Wikisource"
-msgstr ""
+msgstr "Citește la Wikisource"
 
 #: books/RelatedWorksCarousel.html
 msgid "You might also like"
-msgstr ""
+msgstr "Ți-ar putea plăcea și"
 
 #: books/RelatedWorksCarousel.html
 msgid "More by this author"
@@ -3116,103 +3116,103 @@ msgstr "Adaugă o carte"
 
 #: books/add.html
 msgid "Invalid ISBN checksum digit"
-msgstr ""
+msgstr "Cifra de control ISBN invalidă"
 
 #: books/add.html
 msgid "ID must be exactly 10 characters [0-9 or X]. For example 0-19-853453-1 or 0198534531"
-msgstr ""
+msgstr "ID-ul trebuie să aibă exact 10 caractere [0-9 sau X]. De exemplu 0-19-853453-1 sau 0198534531"
 
 #: books/add.html
 msgid "ID must be exactly 13 characters [0-9]. For example 978-3-16-148410-0 or 9783161484100"
-msgstr ""
+msgstr "ID-ul trebuie să aibă exact 13 caractere [0-9]. De exemplu 978-3-16-148410-0 sau 9783161484100"
 
 #: books/add.html
 msgid "Invalid LC Control Number format"
-msgstr ""
+msgstr "Format invalid pentru numărul de control LC"
 
 #: books/add.html
 msgid "Invalid OCLC/WorldCat Control Number format"
-msgstr ""
+msgstr "Format invalid pentru numărul de control OCLC/WorldCat"
 
 #: books/add.html
 msgid "Please enter a value for the selected identifier"
-msgstr ""
+msgstr "Introduceți o valoare pentru identificatorul selectat"
 
 #: books/add.html
 msgid "Are you sure that's the published date?"
-msgstr ""
+msgstr "Ești sigur că aceasta este data publicării?"
 
 #: books/add.html
 msgid "Add a book to Open Library"
-msgstr ""
+msgstr "Adaugă o carte în Open Library"
 
 #: books/add.html
 msgid "We require a minimum set of fields to create a new record. These are those fields."
-msgstr ""
+msgstr "Avem nevoie de un set minim de câmpuri pentru a crea o înregistrare nouă. Acestea sunt acele câmpuri."
 
 #: books/add.html books/edit.html
 msgid "Use <b><i>Title: Subtitle</i></b> to add a subtitle."
-msgstr ""
+msgstr "Folosiți <b><i>Titlu: Subtitlu</i></b> pentru a adăuga un subtitlu."
 
 #: books/add.html books/edit.html type/author/edit.html type/tag/tag_form_inputs.html
 msgid "Required field"
-msgstr ""
+msgstr "Câmp obligatoriu"
 
 #: books/add.html
 msgid "Like, \"Agatha Christie\" or \"Jean-Paul Sartre.\" We'll also do a live check to see if we already know the author."
-msgstr ""
+msgstr "De exemplu, \"Agatha Christie\" sau \"Jean-Paul Sartre.\" Vom verifica și în timp real dacă cunoaștem deja autorul."
 
 #: books/add.html books/edit/edition.html
 msgid "Who is the publisher?"
-msgstr ""
+msgstr "Cine este editorul?"
 
 #: books/add.html books/edit/edition.html
 msgid "For example:"
-msgstr ""
+msgstr "De exemplu:"
 
 #: books/add.html
 msgid "Oxford University Press; Penguin; W.W. Norton"
-msgstr ""
+msgstr "Oxford University Press; Penguin; W.W. Norton"
 
 #: books/add.html books/edit/edition.html
 msgid "When was it published?"
-msgstr ""
+msgstr "Când a fost publicată?"
 
 #: books/add.html books/edit/edition.html
 msgid "You should be able to find this in the first few pages of the book."
-msgstr ""
+msgstr "Ar trebui să găsiți aceasta în primele câteva pagini ale cărții."
 
 #: books/add.html
 msgid "And optionally, an ID number &#151; like an ISBN &#151; would be helpful..."
-msgstr ""
+msgstr "Și opțional, un număr ID &#151; cum ar fi un ISBN &#151; ar fi de ajutor..."
 
 #: books/add.html
 msgid "ID Type"
-msgstr ""
+msgstr "Tip ID"
 
 #: books/add.html
 msgid "ISBN may be invalid. Click \"Add\" again to submit."
-msgstr ""
+msgstr "ISBN poate fi invalid. Faceți din nou clic pe \"Adaugă\" pentru a trimite."
 
 #: books/add.html type/tag/tag_form_inputs.html
 msgid "Select"
-msgstr ""
+msgstr "Selectează"
 
 #: books/add.html
 msgid "ISBN 10"
-msgstr ""
+msgstr "ISBN 10"
 
 #: books/add.html
 msgid "ISBN 13"
-msgstr ""
+msgstr "ISBN 13"
 
 #: books/add.html
 msgid "LCCN"
-msgstr ""
+msgstr "LCCN"
 
 #: books/add.html
 msgid "LibriVox"
-msgstr ""
+msgstr "LibriVox"
 
 #: books/add.html
 #, fuzzy
@@ -3221,44 +3221,44 @@ msgstr "WorldCat"
 
 #: books/add.html
 msgid "Project Gutenberg"
-msgstr ""
+msgstr "Project Gutenberg"
 
 #: books/add.html books/edit/edition.html
 msgid "Book URL"
-msgstr ""
+msgstr "URL carte"
 
 #: books/add.html
 msgid "Only fill this out if this is a web book"
-msgstr ""
+msgstr "Completați numai dacă aceasta este o carte web"
 
 #: books/add.html
 #, python-format
 msgid "By saving a change to this wiki, you agree that your contribution is given freely to the world under <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" target=\"_blank\" rel=\"noopener noreferrer\" title=\"%(cc_link_title)s\">CC0</a>."
-msgstr ""
+msgstr "Prin salvarea unei modificări în acest wiki, ești de acord că contribuția ta este oferită liber lumii sub <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" target=\"_blank\" rel=\"noopener noreferrer\" title=\"%(cc_link_title)s\">CC0</a>."
 
 #: books/add.html
 msgid "This link to Creative Commons will open in a new window"
-msgstr ""
+msgstr "Acest link către Creative Commons se va deschide într-o fereastră nouă"
 
 #: books/add.html
 msgid "Add this book now"
-msgstr ""
+msgstr "Adaugă această carte acum"
 
 #: books/author-autocomplete.html
 msgid "Add a new author"
-msgstr ""
+msgstr "Adaugă un autor nou"
 
 #: books/author-autocomplete.html books/series-autocomplete.html
 msgid "Create a new record for"
-msgstr ""
+msgstr "Crează o înregistrare nouă pentru"
 
 #: books/author-autocomplete.html
 msgid "Remove this author"
-msgstr ""
+msgstr "Elimină acest autor"
 
 #: books/author-autocomplete.html
 msgid "Add another author?"
-msgstr ""
+msgstr "Adaugi alt autor?"
 
 #: books/check.html lib/nav_foot.html lib/nav_head.html
 msgid "Add a Book"
@@ -3267,15 +3267,15 @@ msgstr "Adaugă o carte"
 #: books/check.html
 #, python-format
 msgid "One moment... It looks like we already have <em>some potential matches</em> for <b>%(title)s</b> by <b>%(author)s</b>."
-msgstr ""
+msgstr "Un moment... Se pare că avem deja <em>câteva potriviri posibile</em> pentru <b>%(title)s</b> de <b>%(author)s</b>."
 
 #: books/check.html
 msgid "Rather than creating a duplicate record, please click through the result you think best matches your book."
-msgstr ""
+msgstr "În loc să creezi o înregistrare duplicată, te rugăm să dai clic pe rezultatul care crezi că se potrivește cel mai bine cu cartea ta."
 
 #: books/check.html
 msgid "Select this book"
-msgstr ""
+msgstr "Selectează această carte"
 
 #: SearchResultsWork.html books/check.html merge/authors.html publishers/view.html
 #, python-format
@@ -3288,127 +3288,127 @@ msgstr[2] ""
 #: books/check.html
 #, python-format
 msgid "First published in %(year)d"
-msgstr ""
+msgstr "Publicată prima dată în %(year)d"
 
 #: books/check.html
 msgid "None of these match the book I want to add."
-msgstr ""
+msgstr "Niciuna dintre acestea nu se potrivește cu cartea pe care vreau să o adaug."
 
 #: books/check.html
 msgid "Continue"
-msgstr ""
+msgstr "Continuă"
 
 #: books/custom_carousel_card.html type/author/view.html
 msgid "name missing"
-msgstr ""
+msgstr "nume lipsă"
 
 #: books/custom_carousel_card.html books/mobile_carousel.html
 #, python-format
 msgid " by %(name)s"
-msgstr ""
+msgstr " de %(name)s"
 
 #: books/daisy.html
 msgid "Back"
-msgstr ""
+msgstr "Înapoi"
 
 #: books/daisy.html
 msgid "Open Library Home"
-msgstr ""
+msgstr "Pagina principală Open Library"
 
 #: books/daisy.html
 msgid "There isn't a DAISY file available for "
-msgstr ""
+msgstr "Nu există un fișier DAISY disponibil pentru "
 
 #: books/daisy.html
 #, python-format
 msgid "<a href=\"%(daisy_url)s\"><strong>Download the DAISY.zip</strong></a> for <a href=\"%(url)s\">%(title)s</a>"
-msgstr ""
+msgstr "<a href=\"%(daisy_url)s\"><strong>Descarcă DAISY.zip</strong></a> pentru <a href=\"%(url)s\">%(title)s</a>"
 
 #: books/daisy.html
 msgid "Books for people who don't read print?"
-msgstr ""
+msgstr "Cărți pentru persoanele care nu citesc pe hârtie?"
 
 #: books/daisy.html
 msgid "The <a href=\"//archive.org\">Internet Archive</a> is proud to be distributing over 1 million books free in a format called DAISY, designed for those of us who find it challenging to use regular printed media. "
-msgstr ""
+msgstr "<a href=\"//archive.org\">Internet Archive</a> este mândru să distribuie peste 1 milion de cărți gratuit într-un format numit DAISY, conceput pentru cei care găsesc dificil de utilizat media tipărită obișnuită."
 
 #: books/daisy.html
 msgid "There are two types of DAISYs on Open Library: <i>open</i> and <i>protected</i>. Open DAISYs can be read by anyone in the world on many different devices. Protected DAISYs can only be opened using a key issued by the <a href=\"http://www.loc.gov/nls/\">Library of Congress NLS program</a>."
-msgstr ""
+msgstr "Există două tipuri de DAISY pe Open Library: <i>deschis</i> și <i>protejat</i>. DAISY-urile deschise pot fi citite de oricine din lume pe multe dispozitive diferite. DAISY-urile protejate pot fi deschise numai folosind o cheie emisă de <a href=\"http://www.loc.gov/nls/\">Programul NLS al Bibliotecii Congresului</a>."
 
 #: books/daisy.html lists/home.html
 msgid "Enjoy!"
-msgstr ""
+msgstr "Bucurați-vă!"
 
 #: books/daisy.html
 msgid "What is the DAISY format?"
-msgstr ""
+msgstr "Ce este formatul DAISY?"
 
 #: books/daisy.html
 msgid "The DAISY digital format helps people who have challenges using regular printed media. DAISY digital <span class=\"highlight\">talking books</span> offer the benefits of regular audiobooks, with navigation within the book, to chapters or specific pages."
-msgstr ""
+msgstr "Formatul digital DAISY ajută persoanele care au dificultăți în utilizarea media tipărite obișnuite. Cărțile <span class=\"highlight\">audio digitale</span> DAISY oferă avantajele cărților audio obișnuite, cu navigare în interiorul cărții, la capitole sau pagini specifice."
 
 #: books/daisy.html
 msgid "More information at daisy.org"
-msgstr ""
+msgstr "Mai multe informații la daisy.org"
 
 #: books/daisy.html
 msgid "What is the NLS?"
-msgstr ""
+msgstr "Ce este NLS?"
 
 #: books/daisy.html
 msgid "The Library of Congress <a href=\"http://www.loc.gov/nls/\">National Library Service for the Blind and Physically Handicapped (NLS)</a> administers a free library program of braille and audio materials circulated to eligible borrowers in the United States through a national network of cooperating libraries."
-msgstr ""
+msgstr "Biblioteca Congresului <a href=\"http://www.loc.gov/nls/\">Serviciul Național de Bibliotecă pentru Orbi și Persoane cu Handicap Fizic (NLS)</a> administrează un program gratuit de materiale în braille și audio distribuite beneficiarilor eligibili din Statele Unite printr-o rețea națională de biblioteci cooperante."
 
 #: books/daisy.html
 msgid "Are you eligible to register?"
-msgstr ""
+msgstr "Ești eligibil să te înregistrezi?"
 
 #: books/daisy.html
 msgid "How do I find DAISYs on Open Library?"
-msgstr ""
+msgstr "Cum găsesc DAISY-uri pe Open Library?"
 
 #: books/daisy.html
 msgid "In addition to<a href=\"/subjects/accessible_book\" title=\"Subject: Accessible book\"> loads of open DAISYs</a>, the Open Library lists a smaller selection of<a href=\"/subjects/protected_DAISY\" title=\"Subject: Protected DAISY\"> protected DAISY titles</a> accessible to those with a Library of Congress NLS key. These titles are brought to you by the<a href=\"//archive.org/\"> Internet Archive</a>."
-msgstr ""
+msgstr "Pe lângă<a href=\"/subjects/accessible_book\" title=\"Subiect: Carte accesibilă\"> multe DAISY-uri deschise</a>, Open Library listează o selecție mai mică de<a href=\"/subjects/protected_DAISY\" title=\"Subiect: DAISY protejat\"> titluri DAISY protejate</a> accesibile celor cu cheie NLS. Aceste titluri vă sunt aduse de<a href=\"//archive.org/\"> Internet Archive</a>."
 
 #: books/daisy.html
 msgid "Looking for a specific title? The best way to find it is to<a href=\"/search\"> search for it</a>."
-msgstr ""
+msgstr "Cauți un titlu specific? Cel mai bun mod de a-l găsi este să<a href=\"/search\"> cauți</a>."
 
 #: books/daisy.html lib/exports.html
 msgid "Need help?"
-msgstr ""
+msgstr "Ai nevoie de ajutor?"
 
 #: books/daisy.html
 msgid " Please read our <a href=\"/help/faq\">FAQ on accessing books through Open Library</a>."
-msgstr ""
+msgstr " Te rugăm să citești <a href=\"/help/faq\">FAQ-ul nostru despre accesarea cărților prin Open Library</a>."
 
 #: books/edit.html
 msgid "Add a little more?"
-msgstr ""
+msgstr "Adaugi mai multe?"
 
 #: books/edit.html
 msgid "Thank you for adding that book! Any more information you could provide would be wonderful!"
-msgstr ""
+msgstr "Mulțumim pentru adăugarea cărții! Orice informații suplimentare pe care le-ai putea oferi ar fi minunate!"
 
 #: books/edit.html
 #, python-format
 msgid "We already know about <b>%(work_title)s</b>, but not the <b>%(year)s %(publisher)s edition</b>. Thanks! Do you know any more about this edition?"
-msgstr ""
+msgstr "Știm deja despre <b>%(work_title)s</b>, dar nu despre <b>ediția %(year)s %(publisher)s</b>. Mulțumim! Știi ceva mai mult despre această ediție?"
 
 #: books/edit.html
 #, python-format
 msgid "We already know about the <b>%(year)s %(publisher)s edition</b> of <b>%(work_title)s</b>, but please, tell us more!"
-msgstr ""
+msgstr "Știm deja despre <b>ediția %(year)s %(publisher)s</b> a <b>%(work_title)s</b>, dar te rugăm, spune-ne mai mult!"
 
 #: books/edit.html
 msgid "Editing..."
-msgstr ""
+msgstr "Se editează..."
 
 #: books/edit.html type/author/edit.html type/tag/form.html type/template/edit.html
 msgid "Delete Record"
-msgstr ""
+msgstr "Șterge înregistrarea"
 
 #: books/edit.html
 msgid "Work Details"

--- a/openlibrary/i18n/ro/messages.po
+++ b/openlibrary/i18n/ro/messages.po
@@ -904,17 +904,17 @@ msgstr "Revertiți la această revizie?"
 
 #: viewpage.html
 msgid "Revert to this revision"
-msgstr ""
+msgstr "Revenire la această revizie"
 
 #: widget.html
 #, python-format
 msgid "Read \"%(title)s\""
-msgstr ""
+msgstr "Citește \"%(title)s\""
 
 #: widget.html
 #, python-format
 msgid "Borrow \"%(title)s\""
-msgstr ""
+msgstr "Împrumută \"%(title)s\""
 
 #: ReadButton.html books/edit/edition.html type/list/embed.html widget.html
 msgid "Borrow"
@@ -923,16 +923,16 @@ msgstr "Împrumută"
 #: widget.html
 #, python-format
 msgid "Join waitlist for \"%(title)s\""
-msgstr ""
+msgstr "Înscrie-te pe lista de așteptare pentru \"%(title)s\""
 
 #: LoanStatus.html widget.html
 msgid "Join Waitlist"
-msgstr ""
+msgstr "Înscrie-te pe lista de așteptare"
 
 #: widget.html
 #, python-format
 msgid "Learn more about \"%(title)s\" at OpenLibrary"
-msgstr ""
+msgstr "Află mai multe despre \"%(title)s\" la OpenLibrary"
 
 #: reading_goals/reading_goal_form.html widget.html
 msgid "Learn More"
@@ -941,11 +941,11 @@ msgstr "Află mai multe"
 #: widget.html
 #, python-format
 msgid "on <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"%(link)s\">openlibrary.org</a>"
-msgstr ""
+msgstr "pe <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"%(link)s\">openlibrary.org</a>"
 
 #: work_search.html
 msgid "Search Books"
-msgstr ""
+msgstr "Caută cărți"
 
 #: work_search.html
 msgid "Keywords"
@@ -953,44 +953,44 @@ msgstr "Cuvinte cheie"
 
 #: RecentChanges.html recentchanges/index.html work_search.html
 msgid "Everything"
-msgstr ""
+msgstr "Tot"
 
 #: work_search.html
 msgid "Ebooks"
-msgstr ""
+msgstr "E-books"
 
 #: work_search.html
 msgid "This is only visible to super librarians."
-msgstr ""
+msgstr "Aceasta este vizibilă doar pentru super-bibliotecari."
 
 #: work_search.html
 msgid "Solr Editions"
-msgstr ""
+msgstr "Ediții Solr"
 
 #: work_search.html
 msgid "The search engine returned an error."
-msgstr ""
+msgstr "Motorul de căutare a returnat o eroare."
 
 #: work_search.html
 msgid "Solr Debugging:"
-msgstr ""
+msgstr "Depanare Solr:"
 
 #: work_search.html
 msgid "Full URL:"
-msgstr ""
+msgstr "URL complet:"
 
 #: work_search.html
 #, python-format
 msgid "No <strong>%(path_id)s</strong> directly matched your search."
-msgstr ""
+msgstr "Niciun <strong>%(path_id)s</strong> nu a corespuns direct căutării dvs."
 
 #: work_search.html
 msgid "Add a new book?"
-msgstr ""
+msgstr "Adaugă o carte nouă?"
 
 #: search/authors.html search/lists.html search/subjects.html work_search.html
 msgid "Checking Search Inside matches"
-msgstr ""
+msgstr "Se verifică potrivirile Search Inside"
 
 #: account/reading_log.html search/authors.html search/lists.html search/subjects.html work_search.html
 #, python-format
@@ -1003,19 +1003,19 @@ msgstr[2] ""
 #: work_search.html
 #, python-format
 msgid "Searching solr took %(count)s seconds"
-msgstr ""
+msgstr "Căutarea în Solr a durat %(count)s secunde"
 
 #: about/index.html
 msgid "The Open Library Team"
-msgstr ""
+msgstr "Echipa Open Library"
 
 #: about/index.html
 msgid "Open Library is made possible because of a dedicated team of staff and over 100 volunteers from around the globe."
-msgstr ""
+msgstr "Open Library este posibil datorită unei echipe dedicate de angajați și peste 100 de voluntari din întreaga lume."
 
 #: about/index.html
 msgid "Want to join us?"
-msgstr ""
+msgstr "Vrei să ni te alături?"
 
 #: about/index.html
 msgid "Role:"
@@ -1027,11 +1027,11 @@ msgstr "Toate"
 
 #: about/index.html
 msgid "Staff"
-msgstr ""
+msgstr "Personal"
 
 #: about/index.html
 msgid "Fellows"
-msgstr ""
+msgstr "Bursieri"
 
 #: about/index.html
 msgid "Volunteers"
@@ -1043,43 +1043,43 @@ msgstr "Departament:"
 
 #: about/index.html
 msgid "Communications"
-msgstr ""
+msgstr "Comunicare"
 
 #: about/index.html
 msgid "Design"
-msgstr ""
+msgstr "Design"
 
 #: about/index.html
 msgid "Engineering"
-msgstr ""
+msgstr "Inginerie"
 
 #: about/index.html
 msgid "Librarianship"
-msgstr ""
+msgstr "Biblioteconomie"
 
 #: about/index.html
 msgid "If you volunteer with Open Library and would like to be listed as part of the team, then complete the <a href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">Open Library team information form</a>."
-msgstr ""
+msgstr "Dacă ești voluntar la Open Library și dorești să fii listat ca parte a echipei, completează <a href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">formularul de informații al echipei Open Library</a>."
 
 #: account/create.html openlibrary/plugins/upstream/forms.py
 msgid "Must be a valid email address"
-msgstr ""
+msgstr "Trebuie să fie o adresă de email validă"
 
 #: account/create.html openlibrary/plugins/upstream/forms.py
 msgid "Must be between 3 and 20 characters"
-msgstr ""
+msgstr "Trebuie să aibă între 3 și 20 de caractere"
 
 #: account/create.html
 msgid "Username may only contain numbers, letters, - or _"
-msgstr ""
+msgstr "Numele de utilizator poate conține numai cifre, litere, - sau _"
 
 #: account/create.html
 msgid "A qualifying program must be selected"
-msgstr ""
+msgstr "Trebuie selectat un program eligibil"
 
 #: account/create.html
 msgid "Sign Up to Open Library"
-msgstr ""
+msgstr "Înregistrare la Open Library"
 
 #: account/create.html lib/header_dropdown.html lib/nav_head.html
 msgid "Sign Up"
@@ -1087,47 +1087,47 @@ msgstr "Înscriere"
 
 #: account/create.html
 msgid "Get your free Open Library card and borrow digital books from the nonprofit Internet Archive"
-msgstr ""
+msgstr "Obține-ți cardul gratuit Open Library și împrumută cărți digitale de la organizația nonprofit Internet Archive"
 
 #: account/create.html type/author/view.html
 msgid "Success!"
-msgstr ""
+msgstr "Succes!"
 
 #: account/create.html
 msgid "Your URL"
-msgstr ""
+msgstr "URL-ul tău"
 
 #: account/create.html
 msgid "screenname"
-msgstr ""
+msgstr "pseudonim"
 
 #: account/create.html
 msgid "I want to receive news, announcements, and resources from the <a href=\"https://archive.org/\">Internet Archive</a>, the non-profit that runs Open Library."
-msgstr ""
+msgstr "Doresc să primesc știri, anunțuri și resurse de la <a href=\"https://archive.org/\">Internet Archive</a>, organizația nonprofit care administrează Open Library."
 
 #: account/create.html
 msgid "I want to apply* for <a href=\"https://help.archive.org/help/program-overview/\" target=\"_blank\" rel=\"noopener noreferrer\">special print disability access</a> through a qualifying program."
-msgstr ""
+msgstr "Doresc să aplic* pentru <a href=\"https://help.archive.org/help/program-overview/\" target=\"_blank\" rel=\"noopener noreferrer\">acces special pentru persoane cu dizabilități de tipărire</a> printr-un program eligibil."
 
 #: account/create.html
 msgid "Select qualifying program"
-msgstr ""
+msgstr "Selectează programul eligibil"
 
 #: account/create.html
 msgid "* Please use the email address associated with this qualifying program. You will receive an email after activation with next steps."
-msgstr ""
+msgstr "* Vă rugăm să folosiți adresa de email asociată acestui program eligibil. Veți primi un email după activare cu pașii următori."
 
 #: account/create.html
 msgid "Sign Up with Email"
-msgstr ""
+msgstr "Înregistrare cu email"
 
 #: account/create.html
 msgid "By signing up, you agree to the Internet Archive's <a class=\"ol-signup-form__link\" href=\"//archive.org/about/terms.php\" target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
-msgstr ""
+msgstr "Prin înregistrare, ești de acord cu <a class=\"ol-signup-form__link\" href=\"//archive.org/about/terms.php\" target=\"_blank\" rel=\"noopener noreferrer\">Termenii de utilizare</a> ai Internet Archive."
 
 #: account/create.html
 msgid "Already have an account? <a href=\"/account/login\">Log in</a>"
-msgstr ""
+msgstr "Ai deja un cont? <a href=\"/account/login\">Conectează-te</a>"
 
 #: account/delete.html
 msgid "Delete Account"
@@ -1228,19 +1228,19 @@ msgstr "Se importă..."
 
 #: account/import.html
 msgid "Reason"
-msgstr ""
+msgstr "Motiv"
 
 #: account/import.html
 msgid "No ISBN"
-msgstr ""
+msgstr "Fără ISBN"
 
 #: account/loan_history.html
 msgid "No loans found in your borrow history."
-msgstr ""
+msgstr "Nu s-au găsit împrumuturi în istoricul tău."
 
 #: account/loan_history.html
 msgid "<a href=\"/search\">Search for a book</a> to borrow."
-msgstr ""
+msgstr "<a href=\"/search\">Caută o carte</a> pentru a împrumuta."
 
 #: account/loans.html
 msgid "You've not checked out any books at this moment."
@@ -1256,11 +1256,11 @@ msgstr[2] ""
 
 #: account/loans.html admin/loans_table.html
 msgid "Loan Expires"
-msgstr ""
+msgstr "Expirare împrumut"
 
 #: account/loans.html
 msgid "Loan actions"
-msgstr ""
+msgstr "Acțiuni împrumut"
 
 #: account/loans.html
 #, python-format
@@ -1272,15 +1272,15 @@ msgstr[2] ""
 
 #: ManageLoansButtons.html account/loans.html
 msgid "Not yet downloaded."
-msgstr ""
+msgstr "Nu a fost descărcat încă."
 
 #: ManageLoansButtons.html account/loans.html
 msgid "Download Now"
-msgstr ""
+msgstr "Descarcă acum"
 
 #: account/loans.html
 msgid "Return via<br/>Adobe Digital Editions"
-msgstr ""
+msgstr "Returnează prin<br/>Adobe Digital Editions"
 
 #: account/loans.html
 msgid "Books You're Waiting For"
@@ -1292,11 +1292,11 @@ msgstr "Nu așteptați nicio carte în acest moment."
 
 #: account/loans.html
 msgid "Leave the Waiting List"
-msgstr ""
+msgstr "Părăsește lista de așteptare"
 
 #: account/loans.html
 msgid "Are you sure you want to leave the waiting list of<br/><strong>TITLE</strong>?"
-msgstr ""
+msgstr "Sigur dorești să părăsești lista de așteptare pentru<br/><strong>TITLE</strong>?"
 
 #: ProlificAuthors.html account/loans.html authors/index.html lists/list_follow.html lists/showcase.html publishers/view.html search/authors.html search/publishers.html search/subjects.html
 #, python-format
@@ -1308,7 +1308,7 @@ msgstr[2] "%(count)d de cărți"
 
 #: RecentChangesAdmin.html account/loans.html admin/loans_table.html
 msgid "Actions"
-msgstr ""
+msgstr "Acțiuni"
 
 #: account/loans.html
 #, python-format
@@ -1320,7 +1320,7 @@ msgstr[2] ""
 
 #: account/loans.html
 msgid "You are the next person to receive this book."
-msgstr ""
+msgstr "Ești următoarea persoană care va primi această carte."
 
 #: ManageWaitlistButton.html account/loans.html
 #, python-format
@@ -1332,7 +1332,7 @@ msgstr[2] ""
 
 #: ManageWaitlistButton.html account/loans.html
 msgid "You have less than an hour to borrow it."
-msgstr ""
+msgstr "Ai mai puțin de o oră pentru a o împrumuta."
 
 #: account/loans.html
 #, python-format
@@ -1344,11 +1344,11 @@ msgstr[2] ""
 
 #: ManageWaitlistButton.html account/loans.html
 msgid "Borrow Now"
-msgstr ""
+msgstr "Împrumută acum"
 
 #: ManageWaitlistButton.html account/loans.html
 msgid "Leave the waiting list?"
-msgstr ""
+msgstr "Părăsești lista de așteptare?"
 
 #: account/loans.html
 msgid "Looking for a book to borrow?  Check out our staff picks, or search for a book on a specific subject:"
@@ -1421,20 +1421,20 @@ msgstr "Oups!"
 
 #: account/not_verified.html
 msgid "The email address you signed up with needs to be verified."
-msgstr ""
+msgstr "Adresa de email cu care te-ai înregistrat trebuie verificată."
 
 #: account/not_verified.html
 #, python-format
 msgid "When you created your account, we sent an email to %(email)s that contained a link for you to verify your email address. We need you to click that link, please."
-msgstr ""
+msgstr "Când ți-ai creat contul, am trimis un email la %(email)s cu un link pentru verificarea adresei tale de email. Trebuie să accesezi acel link, te rugăm."
 
 #: account/not_verified.html
 msgid "If you can't find the email, just hit this button to send a fresh one:"
-msgstr ""
+msgstr "Dacă nu găsești emailul, apasă pe acest buton pentru a trimite unul nou:"
 
 #: account/not_verified.html account/verify/failed.html
 msgid "Resend the verification email"
-msgstr ""
+msgstr "Retrimite emailul de verificare"
 
 #: account/not_verified.html account/verify/failed.html
 msgid "Thanks!"
@@ -1446,32 +1446,32 @@ msgstr "Autor necunoscut"
 
 #: account/notes.html
 msgid "My notes for an edition of "
-msgstr ""
+msgstr "Notele mele pentru o ediție din "
 
 #: account/notes.html
 msgid "Title Missing"
-msgstr ""
+msgstr "Titlu lipsă"
 
 #: account/notes.html lists/export_as_html.html type/work/editions.html
 msgid "Publish date unknown"
-msgstr ""
+msgstr "Dată de publicare necunoscută"
 
 #: account/notes.html books/edition-sort.html lists/export_as_html.html type/work/editions.html
 msgid "Publisher unknown"
-msgstr ""
+msgstr "Editor necunoscut"
 
 #: account/notes.html
 #, python-format
 msgid "in %(language)s"
-msgstr ""
+msgstr "în %(language)s"
 
 #: NotesModal.html account/notes.html
 msgid "Delete Note"
-msgstr ""
+msgstr "Șterge notă"
 
 #: NotesModal.html account/notes.html
 msgid "Save Note"
-msgstr ""
+msgstr "Salvează notă"
 
 #: account/notes.html
 msgid "No notes found."
@@ -1479,15 +1479,15 @@ msgstr "Nicio notă găsită."
 
 #: account/notifications.html
 msgid "Notifications from Open Library"
-msgstr ""
+msgstr "Notificări de la Open Library"
 
 #: account/notifications.html
 msgid "Notifications"
-msgstr ""
+msgstr "Notificări"
 
 #: account/notifications.html
 msgid "Notifications are connected to Lists at the moment. If one of the books on your list gets edited, or a new book comes into the catalog, we'll let you know, if you want."
-msgstr ""
+msgstr "Notificările sunt conectate la Liste în prezent. Dacă una dintre cărțile din lista ta este editată sau o carte nouă apare în catalog, te vom anunța, dacă dorești."
 
 #: account/notifications.html
 msgid "Would you like to receive very occasional emails from Open Library?"

--- a/openlibrary/i18n/ro/messages.po
+++ b/openlibrary/i18n/ro/messages.po
@@ -3780,7 +3780,7 @@ msgstr "Vreo notă despre această ediție specifică?"
 
 #: books/edit/edition.html
 msgid "Anything about the book that may be of interest."
-msgstr ""
+msgstr "Orice despre carte care poate fi de interes."
 
 #: books/edit/edition.html
 #, fuzzy
@@ -3789,135 +3789,135 @@ msgstr "Descoperă cărți"
 
 #: books/edit/edition.html
 msgid "Is it known by any other titles?"
-msgstr ""
+msgstr "Este cunoscut și sub alte titluri?"
 
 #: books/edit/edition.html
 msgid "Use this field if the title is different on the cover or spine. If the edition is a collection or anthology, you may also add the individual titles of each work here."
-msgstr ""
+msgstr "Folosiți acest câmp dacă titlul este diferit pe copertă sau pe cotor. Dacă ediția este o colecție sau o antologie, puteți adăuga și titlurile individuale ale fiecărei opere."
 
 #: books/edit/edition.html
 msgid "For example: <i>Eaters of the Dead</i> is an alternate title for <i><a href=\"/books/OL24923038M\">The 13th Warrior</a></i>."
-msgstr ""
+msgstr "De exemplu: <i>Eaters of the Dead</i> este un titlu alternativ pentru <i><a href=\"/books/OL24923038M\">The 13th Warrior</a></i>."
 
 #: books/edit/edition.html
 msgid "What work is this an edition of?"
-msgstr ""
+msgstr "De ce operă este o ediție aceasta?"
 
 #: books/edit/edition.html
 msgid "Sometimes editions can be associated with the wrong work. You can correct that here."
-msgstr ""
+msgstr "Uneori edițiile pot fi asociate cu opera greșită. Puteți corecta aceasta aici."
 
 #: books/edit/edition.html
 msgid "You can search by title or by Open Library ID (like <a href=\"/works/OL262757W\" target=\"_blank\" rel=\"noopener noreferrer\"><em>OL262757W</em></a>)."
-msgstr ""
+msgstr "Poți căuta după titlu sau după ID Open Library (ca <a href=\"/works/OL262757W\" target=\"_blank\" rel=\"noopener noreferrer\"><em>OL262757W</em></a>)."
 
 #: books/edit/edition.html
 msgid "WARNING: Any edits made to the work from this page will be ignored."
-msgstr ""
+msgstr "AVERTISMENT: Orice modificări aduse operei din această pagină vor fi ignorate."
 
 #: books/edit/edition.html
 msgid "Copy authors to new work"
-msgstr ""
+msgstr "Copiază autorii la opera nouă"
 
 #: books/edit/edition.html
 msgid "Copy subjects to new work"
-msgstr ""
+msgstr "Copiază subiectele la opera nouă"
 
 #: books/edit/edition.html
 msgid "Please select an identifier."
-msgstr ""
+msgstr "Selectați un identificator."
 
 #: books/edit/edition.html
 msgid "You need to give a value to ID."
-msgstr ""
+msgstr "Trebuie să dai o valoare ID-ului."
 
 #: books/edit/edition.html
 msgid "ID ids cannot contain whitespace."
-msgstr ""
+msgstr "ID-urile nu pot conține spații."
 
 #: books/edit/edition.html
 msgid "ID must be exactly 10 characters [0-9] or X."
-msgstr ""
+msgstr "ID-ul trebuie să aibă exact 10 caractere [0-9] sau X."
 
 #: books/edit/edition.html
 msgid "That ID already exists for this edition."
-msgstr ""
+msgstr "Acel ID există deja pentru această ediție."
 
 #: books/edit/edition.html
 msgid "ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4"
-msgstr ""
+msgstr "ID-ul trebuie să aibă exact 13 cifre [0-9]. De exemplu: 978-1-56619-909-4"
 
 #: books/edit/edition.html
 msgid "Invalid ID format"
-msgstr ""
+msgstr "Format ID invalid"
 
 #: books/edit/edition.html type/author/view.html
 msgid "ID Numbers"
-msgstr ""
+msgstr "Numere ID"
 
 #: books/edit/edition.html
 msgid "Do you know any identifiers for this edition?"
-msgstr ""
+msgstr "Cunoști vreun identificator pentru această ediție?"
 
 #: books/edit/edition.html
 msgid "Like, ISBN?"
-msgstr ""
+msgstr "Cum ar fi ISBN?"
 
 #: books/edit/edition.html
 msgid "Please select a classification."
-msgstr ""
+msgstr "Selectați o clasificare."
 
 #: books/edit/edition.html
 msgid "You need to give a value to CLASS."
-msgstr ""
+msgstr "Trebuie să dai o valoare la CLASĂ."
 
 #: books/edit/edition.html type/edition/view.html type/work/view.html
 msgid "Classifications"
-msgstr ""
+msgstr "Clasificări"
 
 #: books/edit/edition.html
 msgid "Do you know any classifications of this edition?"
-msgstr ""
+msgstr "Cunoști vreo clasificare a acestei ediții?"
 
 #: books/edit/edition.html
 msgid "Like, Dewey Decimal?"
-msgstr ""
+msgstr "Cum ar fi Clasificarea Zecimală Dewey?"
 
 #: books/edit/edition.html
 msgid "Select one of many..."
-msgstr ""
+msgstr "Selectați una din mai multe..."
 
 #: books/edit/edition.html
 msgid "Add a new classification type"
-msgstr ""
+msgstr "Adaugă un tip de clasificare nou"
 
 #: books/edit/edition.html
 msgid "Remove this classification"
-msgstr ""
+msgstr "Elimină această clasificare"
 
 #: books/edit/edition.html type/edition/view.html type/work/view.html
 msgid "The Physical Object"
-msgstr ""
+msgstr "Obiectul fizic"
 
 #: books/edit/edition.html
 msgid "What sort of book is it?"
-msgstr ""
+msgstr "Ce fel de carte este?"
 
 #: books/edit/edition.html
 msgid "Paperback; Hardcover, etc."
-msgstr ""
+msgstr "Broșată; Cartonată etc."
 
 #: books/edit/edition.html
 msgid "How many pages?"
-msgstr ""
+msgstr "Câte pagini are?"
 
 #: books/edit/edition.html
 msgid "Pagination?"
-msgstr ""
+msgstr "Paginație?"
 
 #: books/edit/edition.html
 msgid "Note the highest number in each pagination pattern."
-msgstr ""
+msgstr "Notați cel mai mare număr din fiecare model de paginație."
 
 #: books/edit/edition.html lib/nav_foot.html
 msgid "Help"
@@ -3925,167 +3925,167 @@ msgstr "Ajutor"
 
 #: books/edit/edition.html
 msgid "For example: <em>xii, 346p.</em>"
-msgstr ""
+msgstr "De exemplu: <em>xii, 346p.</em>"
 
 #: books/edit/edition.html
 msgid "How much does the book weigh?"
-msgstr ""
+msgstr "Cât cântărește cartea?"
 
 #: books/edit/edition.html type/edition/view.html type/work/view.html
 msgid "Dimensions"
-msgstr ""
+msgstr "Dimensiuni"
 
 #: books/edit/edition.html
 msgid "dimensions"
-msgstr ""
+msgstr "dimensiuni"
 
 #: books/edit/edition.html
 msgid "Height:"
-msgstr ""
+msgstr "Înălțime:"
 
 #: books/edit/edition.html
 msgid "Width:"
-msgstr ""
+msgstr "Lățime:"
 
 #: books/edit/edition.html
 msgid "Depth:"
-msgstr ""
+msgstr "Adâncime:"
 
 #: books/edit/edition.html
 msgid "Web Book Providers"
-msgstr ""
+msgstr "Furnizori carte web"
 
 #: books/edit/edition.html
 msgid "Access Type"
-msgstr ""
+msgstr "Tip acces"
 
 #: books/edit/edition.html
 msgid "File Format"
-msgstr ""
+msgstr "Format fișier"
 
 #: books/edit/edition.html
 msgid "Provider Name"
-msgstr ""
+msgstr "Numele furnizorului"
 
 #: books/edit/edition.html
 msgid "Buy"
-msgstr ""
+msgstr "Cumpără"
 
 #: books/edit/edition.html
 msgid "Web"
-msgstr ""
+msgstr "Web"
 
 #: books/edit/edition.html
 msgid "Add a provider"
-msgstr ""
+msgstr "Adaugă un furnizor"
 
 #: books/edit/edition.html
 msgid "First sentence"
-msgstr ""
+msgstr "Prima propoziție"
 
 #: books/edit/edition.html
 msgid "The opening line that starts the lead paragraph"
-msgstr ""
+msgstr "Propoziția de deschidere care începe paragraful principal"
 
 #: books/edit/edition.html
 msgid "Admin Only"
-msgstr ""
+msgstr "Numai pentru admin"
 
 #: books/edit/edition.html
 msgid "Additional Metadata"
-msgstr ""
+msgstr "Metadate suplimentare"
 
 #: books/edit/edition.html
 msgid "This field can accept arbitrary key:value pairs"
-msgstr ""
+msgstr "Acest câmp acceptă perechi arbitrare cheie:valoare"
 
 #: books/edit/excerpts.html
 msgid "Please provide an excerpt."
-msgstr ""
+msgstr "Introduceți un fragment."
 
 #: books/edit/excerpts.html
 msgid "That excerpt is too long."
-msgstr ""
+msgstr "Acel fragment este prea lung."
 
 #: books/edit/excerpts.html
 msgid "If there are particular (short) passages you feel represent the book well, please feel free to transcribe them here."
-msgstr ""
+msgstr "Dacă există pasaje particulare (scurte) pe care le considerați reprezentative pentru carte, vă rugăm să le transcrieți aici."
 
 #: books/edit/excerpts.html
 msgid "Page number?"
-msgstr ""
+msgstr "Numărul paginii?"
 
 #: books/edit/excerpts.html
 msgid "For example: <i>23, xi or 433-434</i>"
-msgstr ""
+msgstr "De exemplu: <i>23, xi sau 433-434</i>"
 
 #: books/edit/excerpts.html
 msgid "This excerpt is the first sentence of the book."
-msgstr ""
+msgstr "Acest fragment este prima propoziție a cărții."
 
 #: books/edit/excerpts.html
 msgid "Transcribe the excerpt"
-msgstr ""
+msgstr "Transcrieți fragmentul"
 
 #: books/edit/excerpts.html
 msgid "Maximum length is 2000 characters. No HTML allowed."
-msgstr ""
+msgstr "Lungimea maximă este 2000 de caractere. Nu este permis HTML."
 
 #: books/edit/excerpts.html
 msgid "Why did you choose this excerpt?"
-msgstr ""
+msgstr "De ce ați ales acest fragment?"
 
 #: books/edit/excerpts.html
 msgid "Add an optional note."
-msgstr ""
+msgstr "Adaugă o notă opțională."
 
 #: books/edit/excerpts.html
 msgid "Excerpts so far..."
-msgstr ""
+msgstr "Fragmente până acum..."
 
 #: books/edit/excerpts.html
 msgid "noted:"
-msgstr ""
+msgstr "notă:"
 
 #: books/edit/excerpts.html
 msgid "An anonymous note:"
-msgstr ""
+msgstr "O notă anonimă:"
 
 #: books/edit/excerpts.html
 msgid "From page"
-msgstr ""
+msgstr "De la pagina"
 
 #: books/edit/web.html
 msgid "Please provide a label."
-msgstr ""
+msgstr "Introduceți o etichetă."
 
 #: books/edit/web.html
 msgid "Please provide a URL."
-msgstr ""
+msgstr "Introduceți un URL."
 
 #: books/edit/web.html
 msgid "Please enter a valid URL."
-msgstr ""
+msgstr "Introduceți un URL valid."
 
 #: books/edit/web.html
 msgid "Please connect Open Library records to <u>good</u><span class=\"orange\">*</span> online resources."
-msgstr ""
+msgstr "Vă rugăm să conectați înregistrările Open Library la resurse online <u>bune</u><span class=\"orange\">*</span>."
 
 #: books/edit/web.html
 msgid "Give your link a label"
-msgstr ""
+msgstr "Dați un nume linkului dvs."
 
 #: books/edit/web.html
 msgid "For example: <em>New York Times review</em>"
-msgstr ""
+msgstr "De exemplu: <em>Recenzie New York Times</em>"
 
 #: books/edit/web.html
 msgid "URL"
-msgstr ""
+msgstr "URL"
 
 #: books/edit/web.html
 msgid "Add Link"
-msgstr ""
+msgstr "Adaugă link"
 
 #: books/edit/web.html
 msgid "Remove this link"

--- a/openlibrary/i18n/ro/messages.po
+++ b/openlibrary/i18n/ro/messages.po
@@ -3412,31 +3412,31 @@ msgstr "Șterge înregistrarea"
 
 #: books/edit.html
 msgid "Work Details"
-msgstr ""
+msgstr "Detalii operă"
 
 #: books/edit.html
 msgid "Unknown publisher edition"
-msgstr ""
+msgstr "Ediție cu editor necunoscut"
 
 #: books/edit.html
 msgid "This Work"
-msgstr ""
+msgstr "Această operă"
 
 #: books/edit.html
 msgid "You can search by author name (like <em>j k rowling</em>) or by Open Library ID (like <a href=\"/authors/OL23919A\" target=\"_blank\" rel=\"noopener noreferrer\"><em>OL23919A</em></a>)."
-msgstr ""
+msgstr "Poți căuta după numele autorului (ca <em>j k rowling</em>) sau după ID-ul Open Library (ca <a href=\"/authors/OL23919A\" target=\"_blank\" rel=\"noopener noreferrer\"><em>OL23919A</em></a>)."
 
 #: books/edit.html
 msgid "Author editing requires javascript"
-msgstr ""
+msgstr "Editarea autorilor necesită javascript"
 
 #: books/edit.html
 msgid "Add Excerpts"
-msgstr ""
+msgstr "Adaugă fragmente"
 
 #: books/edit.html type/about/edit.html type/author/edit.html
 msgid "Links"
-msgstr ""
+msgstr "Linkuri"
 
 #: books/edit.html
 #, fuzzy
@@ -3445,47 +3445,47 @@ msgstr "Statistici despre opere"
 
 #: books/edit.html
 msgid "Series are currently in beta, and this section is only visible to super librarians and admins, like you! Any series you set will be visible by everyone, however. Please report any issues you have on Slack or GitHub."
-msgstr ""
+msgstr "Seriile sunt în prezent în versiune beta și această secțiune este vizibilă numai pentru super-bibliotecari și administratori, ca tine! Orice serie setată va fi vizibilă pentru toată lumea. Vă rugăm să raportați orice probleme pe Slack sau GitHub."
 
 #: books/edit.html
 msgid "Is this work part of a larger series?"
-msgstr ""
+msgstr "Această operă face parte dintr-o serie mai mare?"
 
 #: books/edit.html
 msgid "E.g. Harry Potter, The Sword of Truth"
-msgstr ""
+msgstr "Ex. Harry Potter, The Sword of Truth"
 
 #: books/edit.html type/edition/view.html type/work/view.html
 msgid "Work Identifiers"
-msgstr ""
+msgstr "Identificatori operă"
 
 #: books/edit.html
 msgid "Do you know any identifiers for this work?"
-msgstr ""
+msgstr "Cunoști vreun identificator pentru această operă?"
 
 #: books/edit.html
 msgid "These identifiers apply to all editions of this work, for example Wikidata work identifiers. For edition-specific identifiers, like ISBN or LCCN, go to the edition tab."
-msgstr ""
+msgstr "Acești identificatori se aplică tuturor edițiilor acestei opere, de exemplu identificatorii Wikidata. Pentru identificatori specifici ediției, cum ar fi ISBN sau LCCN, mergi la fila ediție."
 
 #: FulltextSearchSuggestionItem.html IABook.html SearchResultsWork.html books/edition-sort.html jsdef/LazyWorkPreview.html lists/list_overview.html lists/preview.html lists/snippet.html lists/widget.html my_books/dropdown_content.html type/work/editions.html
 #, python-format
 msgid "Cover of: %(title)s"
-msgstr ""
+msgstr "Copertă pentru: %(title)s"
 
 #: books/edition-sort.html
 #, python-format
 msgid "%(title)s: %(subtitle)s"
-msgstr ""
+msgstr "%(title)s: %(subtitle)s"
 
 #: books/edition-sort.html
 #, python-format
 msgid "Publish date unknown, %(publisher)s"
-msgstr ""
+msgstr "Dată de publicare necunoscută, %(publisher)s"
 
 #: books/edition-sort.html type/work/editions.html
 #, python-format
 msgid "in %(languagelist)s"
-msgstr ""
+msgstr "în %(languagelist)s"
 
 #: SearchNavigation.html books/mybooks_breadcrumb_select.html lib/nav_foot.html openlibrary/plugins/upstream/mybooks.py
 msgid "Books"
@@ -3538,7 +3538,7 @@ msgstr "Importuri și exporturi"
 
 #: books/series-autocomplete.html
 msgid "Add a new series"
-msgstr ""
+msgstr "Adaugă o serie nouă"
 
 #: books/series-autocomplete.html
 #, fuzzy
@@ -3552,231 +3552,231 @@ msgstr "Științifico-fantastic"
 
 #: books/series-autocomplete.html
 msgid "Remove this series"
-msgstr ""
+msgstr "Elimină această serie"
 
 #: books/series-autocomplete.html
 msgid "Add another series?"
-msgstr ""
+msgstr "Adaugi altă serie?"
 
 #: books/edit/about.html
 msgid "Select this subject"
-msgstr ""
+msgstr "Selectează acest subiect"
 
 #: books/edit/about.html
 msgid "How would you describe this book?"
-msgstr ""
+msgstr "Cum ai descrie această carte?"
 
 #: books/edit/about.html
 msgid "There's no wrong answer here."
-msgstr ""
+msgstr "Nu există un răspuns greșit."
 
 #: books/edit/about.html
 msgid "Subject keywords?"
-msgstr ""
+msgstr "Cuvinte cheie pentru subiect?"
 
 #: books/edit/about.html
 msgid "Please separate with commas."
-msgstr ""
+msgstr "Separați cu virgule."
 
 #: books/edit/about.html
 msgid "For example: <i><a href=\"/subjects/cheese\">cheese</a>, <a href=\"/subjects/roman_empire\">Roman Empire</a>, <a href=\"/subjects/psychology\">psychology</a></i>"
-msgstr ""
+msgstr "De exemplu: <i><a href=\"/subjects/cheese\">brânză</a>, <a href=\"/subjects/roman_empire\">Imperiul Roman</a>, <a href=\"/subjects/psychology\">psihologie</a></i>"
 
 #: books/edit/about.html
 msgid "A person? Or, people?"
-msgstr ""
+msgstr "O persoană? Sau persoane?"
 
 #: books/edit/about.html
 msgid "For example: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore Roosevelt</a>, <a href=\"/subjects/person:Julian_of_Norwich\">Julian of Norwich</a>, <a href=\"/subjects/person:Tintin\">Tintin</a></i>"
-msgstr ""
+msgstr "De exemplu: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore Roosevelt</a>, <a href=\"/subjects/person:Julian_of_Norwich\">Julian of Norwich</a>, <a href=\"/subjects/person:Tintin\">Tintin</a></i>"
 
 #: books/edit/about.html
 msgid "Note any places mentioned?"
-msgstr ""
+msgstr "Notezi locurile menționate?"
 
 #: books/edit/about.html
 msgid "For example: <i><a href=\"/subjects/place:London\">London</a>, <a href=\"/subjects/place:Atlantis\">Atlantis</a>, <a href=\"/subjects/place:Omaha\">Omaha</a></i>"
-msgstr ""
+msgstr "De exemplu: <i><a href=\"/subjects/place:London\">Londra</a>, <a href=\"/subjects/place:Atlantis\">Atlantis</a>, <a href=\"/subjects/place:Omaha\">Omaha</a></i>"
 
 #: books/edit/about.html
 msgid "When is it set or about?"
-msgstr ""
+msgstr "Când este setată sau despre ce perioadă este?"
 
 #: books/edit/about.html
 msgid "For example: <i><a href=\"/subjects/time:1984\">1984</a>, <a href=\"/subjects/time:the_middle_ages\">The Middle Ages</a>, <a href=\"/subjects/time:1810-1890\">1810-1890</a></i>"
-msgstr ""
+msgstr "De exemplu: <i><a href=\"/subjects/time:1984\">1984</a>, <a href=\"/subjects/time:the_middle_ages\">Evul Mediu</a>, <a href=\"/subjects/time:1810-1890\">1810-1890</a></i>"
 
 #: books/edit/edition.html
 msgid "Select this language"
-msgstr ""
+msgstr "Selectează această limbă"
 
 #: books/edit/edition.html
 msgid "Remove this language"
-msgstr ""
+msgstr "Elimină această limbă"
 
 #: books/edit/edition.html
 msgid "Remove this work"
-msgstr ""
+msgstr "Elimină această operă"
 
 #: books/edit/edition.html
 msgid "-- Move to a new work"
-msgstr ""
+msgstr "-- Mută într-o operă nouă"
 
 #: books/edit/edition.html
 msgid "This Edition"
-msgstr ""
+msgstr "Această ediție"
 
 #: books/edit/edition.html
 msgid "Enter the title of this specific edition."
-msgstr ""
+msgstr "Introduceți titlul acestei ediții specifice."
 
 #: books/edit/edition.html
 msgid "Subtitle"
-msgstr ""
+msgstr "Subtitlu"
 
 #: books/edit/edition.html
 msgid "Usually distinguished by different or smaller type."
-msgstr ""
+msgstr "De obicei distins prin tip diferit sau mai mic."
 
 #: books/edit/edition.html
 msgid "For example: <i>envisioning the next 50 years</i>"
-msgstr ""
+msgstr "De exemplu: <i>imaginând următorii 50 de ani</i>"
 
 #: books/edit/edition.html
 msgid "Publishing Info"
-msgstr ""
+msgstr "Informații de publicare"
 
 #: books/edit/edition.html
 msgid "For example <em>Oxford University Press; Penguin; W.W. Norton</em>"
-msgstr ""
+msgstr "De exemplu <em>Oxford University Press; Penguin; W.W. Norton</em>"
 
 #: books/edit/edition.html
 msgid "Where was the book published?"
-msgstr ""
+msgstr "Unde a fost publicată cartea?"
 
 #: books/edit/edition.html
 msgid "City, Country please."
-msgstr ""
+msgstr "Oraș, Țară, vă rugăm."
 
 #: books/edit/edition.html
 msgid "For example: <i>New York, USA; Sydney, Australia</i>"
-msgstr ""
+msgstr "De exemplu: <i>New York, SUA; Sydney, Australia</i>"
 
 #: books/edit/edition.html
 msgid "What is the copyright date?"
-msgstr ""
+msgstr "Care este data drepturilor de autor?"
 
 #: books/edit/edition.html
 msgid "The year following the copyright statement."
-msgstr ""
+msgstr "Anul care urmează mențiunii drepturilor de autor."
 
 #: books/edit/edition.html
 msgid "Edition Name (if applicable):"
-msgstr ""
+msgstr "Numele ediției (dacă este cazul):"
 
 #: books/edit/edition.html
 msgid "For example: <i>Centennial edition</i>; <i>First edition</i>"
-msgstr ""
+msgstr "De exemplu: <i>Ediție centenară</i>; <i>Prima ediție</i>"
 
 #: books/edit/edition.html
 msgid "Series Name (if applicable)"
-msgstr ""
+msgstr "Numele seriei (dacă este cazul)"
 
 #: books/edit/edition.html
 msgid "The name of the publisher's series."
-msgstr ""
+msgstr "Numele seriei editorului."
 
 #: books/edit/edition.html
 msgid "For example: <i>The Story of Civilization, Part III</i>"
-msgstr ""
+msgstr "De exemplu: <i>The Story of Civilization, Part III</i>"
 
 #: books/edit/edition.html type/edition/view.html type/work/view.html
 msgid "Contributors"
-msgstr ""
+msgstr "Contributori"
 
 #: books/edit/edition.html
 msgid "Please select a role."
-msgstr ""
+msgstr "Selectați un rol."
 
 #: books/edit/edition.html
 msgid "You need to give this ROLE a name."
-msgstr ""
+msgstr "Trebuie să dai un nume acestui ROL."
 
 #: books/edit/edition.html
 msgid "List the people involved"
-msgstr ""
+msgstr "Listați persoanele implicate"
 
 #: books/edit/edition.html
 msgid "Select role"
-msgstr ""
+msgstr "Selectează rol"
 
 #: books/edit/edition.html
 msgid "Add a new role"
-msgstr ""
+msgstr "Adaugă un rol nou"
 
 #: books/edit/edition.html
 msgid "Remove this contributor"
-msgstr ""
+msgstr "Elimină acest contributor"
 
 #: books/edit/edition.html
 msgid "By Statement:"
-msgstr ""
+msgstr "Declarație by:"
 
 #: books/edit/edition.html
 msgid "For example: <em>edited by David Anderson</em>"
-msgstr ""
+msgstr "De exemplu: <em>editat de David Anderson</em>"
 
 #: books/edit/edition.html languages/index.html
 msgid "Languages"
-msgstr ""
+msgstr "Limbi"
 
 #: books/edit/edition.html
 msgid "What language is this edition written in?"
-msgstr ""
+msgstr "În ce limbă este scrisă această ediție?"
 
 #: books/edit/edition.html
 msgid "Add another language?"
-msgstr ""
+msgstr "Adaugi altă limbă?"
 
 #: books/edit/edition.html
 msgid "Is it a translation of another book?"
-msgstr ""
+msgstr "Este o traducere a altei cărți?"
 
 #: books/edit/edition.html
 msgid "Yes, it's a translation"
-msgstr ""
+msgstr "Da, este o traducere"
 
 #: books/edit/edition.html
 msgid "What's the original book?"
-msgstr ""
+msgstr "Care este cartea originală?"
 
 #: books/edit/edition.html
 msgid "What language was the original written in?"
-msgstr ""
+msgstr "În ce limbă a fost scris originalul?"
 
 #: books/edit/edition.html
 msgid "Description of this edition"
-msgstr ""
+msgstr "Descrierea acestei ediții"
 
 #: books/edit/edition.html
 msgid "Only if it's different from the work's description"
-msgstr ""
+msgstr "Numai dacă diferă de descrierea operei"
 
 #: books/edit/edition.html type/edition/view.html type/work/view.html
 msgid "Table of Contents"
-msgstr ""
+msgstr "Cuprins"
 
 #: books/edit/edition.html
 msgid "Use a \"*\" for an indent, a \"|\" to add a column, and line breaks for new lines. Like this:"
-msgstr ""
+msgstr "Folosiți un \"*\" pentru indentare, un \"|\" pentru a adăuga o coloană și întreruperi de linie pentru linii noi. Astfel:"
 
 #: books/edit/edition.html
 msgid "This table of contents contains extra information like authors or descriptions. We don't have a great user interface for this yet, so editing this data could be difficult. Watch out!"
-msgstr ""
+msgstr "Acest cuprins conține informații suplimentare precum autori sau descrieri. Nu avem încă o interfață bună pentru aceasta, deci editarea acestor date poate fi dificilă. Atenție!"
 
 #: books/edit/edition.html
 msgid "Any notes about this specific edition?"
-msgstr ""
+msgstr "Vreo notă despre această ediție specifică?"
 
 #: books/edit/edition.html
 msgid "Anything about the book that may be of interest."

--- a/openlibrary/i18n/ro/messages.po
+++ b/openlibrary/i18n/ro/messages.po
@@ -507,20 +507,20 @@ msgstr "A fost creată o nouă înregistrare de operă."
 
 #: messages.html
 msgid "Added new book."
-msgstr ""
+msgstr "Carte nouă adăugată."
 
 #: messages.html
 msgid "Thank you for improving the Open Library catalog!"
-msgstr ""
+msgstr "Vă mulțumim pentru îmbunătățirea catalogului Open Library!"
 
 #: BookPreview.html CreateListModal.html NotesModal.html ObservationsModal.html ShareModal.html covers/author_photo.html covers/book_cover.html covers/change.html lib/exports.html my_books/check_ins/check_in_prompt.html my_books/dropdown_content.html native_dialog.html
 msgid "Close"
-msgstr ""
+msgstr "Închide"
 
 #: notfound.html
 #, python-format
 msgid "%(path)s is not found"
-msgstr ""
+msgstr "%(path)s nu a fost găsit"
 
 #: languages/notfound.html notfound.html
 msgid "404 - Page Not Found"
@@ -529,79 +529,79 @@ msgstr "404 - Pagina nu a fost găsită"
 #: notfound.html
 #, python-format
 msgid "%(path)s does not exist."
-msgstr ""
+msgstr "%(path)s nu există."
 
 #: notfound.html
 msgid "Create it?"
-msgstr ""
+msgstr "Îl creați?"
 
 #: notfound.html
 msgid "Looking for a template/macro?"
-msgstr ""
+msgstr "Cauți un șablon/macro?"
 
 #: permission.html
 #, python-format
 msgid "Permission of %(key)s"
-msgstr ""
+msgstr "Permisiune pentru %(key)s"
 
 #: permission.html
 msgid "Permission of"
-msgstr ""
+msgstr "Permisiune pentru"
 
 #: permission.html
 msgid "Permission"
-msgstr ""
+msgstr "Permisiune"
 
 #: permission.html
 msgid "Child Permission"
-msgstr ""
+msgstr "Permisiune secundară"
 
 #: permission_denied.html
 msgid "Permission Denied"
-msgstr ""
+msgstr "Permisiune refuzată"
 
 #: permission_denied.html
 msgid "Permission denied."
-msgstr ""
+msgstr "Permisiune refuzată."
 
 #: permission_denied.html
 #, python-format
 msgid "Only logged users are allowed to add records on Open Library. Please <a href=\"%s\">log in</a> to add a book."
-msgstr ""
+msgstr "Numai utilizatorii autentificați pot adăuga înregistrări în Open Library. Vă rugăm să <a href=\"%s\">vă autentificați</a> pentru a adăuga o carte."
 
 #: permission_denied.html
 #, python-format
 msgid "Only logged users are allowed to modify records on Open Library. Please <a href=\"%s\">log in</a> to edit this page."
-msgstr ""
+msgstr "Numai utilizatorii autentificați pot modifica înregistrări în Open Library. Vă rugăm să <a href=\"%s\">vă autentificați</a> pentru a edita această pagină."
 
 #: permission_denied.html
 #, python-format
 msgid "You may <a href=\"%s\">log in</a> if you have the required permissions."
-msgstr ""
+msgstr "Puteți <a href=\"%s\">vă autentifica</a> dacă aveți permisiunile necesare."
 
 #: recaptcha.html
 msgid "Please satisfy the reCAPTCHA below. If you have security settings or privacy blockers installed, please disable them to see the reCAPTCHA."
-msgstr ""
+msgstr "Vă rugăm să completați reCAPTCHA de mai jos. Dacă aveți setări de securitate sau blocatoare de confidențialitate activate, dezactivați-le pentru a vedea reCAPTCHA."
 
 #: recaptcha.html
 msgid "Incorrect. Please try again."
-msgstr ""
+msgstr "Incorect. Vă rugăm să încercați din nou."
 
 #: showamazon.html showbwb.html showgoogle_books.html
 msgid "Record details of"
-msgstr ""
+msgstr "Detalii înregistrare pentru"
 
 #: showamazon.html showbwb.html showgoogle_books.html
 msgid "This record came from"
-msgstr ""
+msgstr "Această înregistrare provine din"
 
 #: showia.html showmarc.html
 msgid "Record ID"
-msgstr ""
+msgstr "ID înregistrare"
 
 #: showia.html showmarc.html
 msgid "Source"
-msgstr ""
+msgstr "Sursă"
 
 #: books/add.html covers/add.html showia.html type/edition/view.html type/work/view.html
 msgid "Internet Archive"
@@ -609,63 +609,63 @@ msgstr "Internet Archive"
 
 #: showia.html
 msgid "Download MARC XML"
-msgstr ""
+msgstr "Descarcă MARC XML"
 
 #: showia.html
 msgid "Download MARC binary"
-msgstr ""
+msgstr "Descarcă MARC binar"
 
 #: showia.html showmarc.html
 msgid "Invalid MARC record."
-msgstr ""
+msgstr "Înregistrare MARC nevalidă."
 
 #: showia.html showmarc.html
 msgid "LEADER:"
-msgstr ""
+msgstr "LEADER:"
 
 #: showmarc.html
 msgid "Download Link"
-msgstr ""
+msgstr "Link de descărcare"
 
 #: showmarc.html type/tag/index.html
 msgid "Next"
-msgstr ""
+msgstr "Următor"
 
 #: status.html
 msgid "Open Library server status"
-msgstr ""
+msgstr "Starea serverului Open Library"
 
 #: status.html
 msgid "Server status"
-msgstr ""
+msgstr "Starea serverului"
 
 #: status.html
 msgid "Testing Environment"
-msgstr ""
+msgstr "Mediu de testare"
 
 #: status.html
 msgid "Deploy triggered!"
-msgstr ""
+msgstr "Implementare declanșată!"
 
 #: status.html
 msgid "View Jenkins progress"
-msgstr ""
+msgstr "Vezi progresul Jenkins"
 
 #: status.html
 msgid "GitHub status refreshed."
-msgstr ""
+msgstr "Starea GitHub actualizată."
 
 #: status.html
 msgid "PR numbers or URLs, space/comma separated"
-msgstr ""
+msgstr "Numere sau URL-uri PR, separate prin spații/virgule"
 
 #: status.html
 msgid "Add PR(s)"
-msgstr ""
+msgstr "Adaugă PR-uri"
 
 #: status.html
 msgid "PR"
-msgstr ""
+msgstr "PR"
 
 #: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html search/advancedsearch.html status.html type/about/edit.html type/page/edit.html type/template/edit.html
 msgid "Title"
@@ -677,15 +677,15 @@ msgstr "Autor"
 
 #: status.html
 msgid "Assignee"
-msgstr ""
+msgstr "Responsabil"
 
 #: status.html
 msgid "Pinned Commit"
-msgstr ""
+msgstr "Commit fixat"
 
 #: status.html
 msgid "Branch HEAD"
-msgstr ""
+msgstr "HEAD ramură"
 
 #: status.html
 #, fuzzy
@@ -694,11 +694,11 @@ msgstr "Editează"
 
 #: status.html
 msgid "Enabled"
-msgstr ""
+msgstr "Activat"
 
 #: status.html
 msgid "up to date"
-msgstr ""
+msgstr "actualizat"
 
 #: status.html
 #, fuzzy
@@ -707,7 +707,7 @@ msgstr "Necunoscut"
 
 #: status.html
 msgid "1 commit behind"
-msgstr ""
+msgstr "1 commit în urmă"
 
 #: status.html
 #, fuzzy, python-format
@@ -716,19 +716,19 @@ msgstr ""
 
 #: admin/solr.html status.html
 msgid "Update"
-msgstr ""
+msgstr "Actualizează"
 
 #: status.html
 msgid "Enable"
-msgstr ""
+msgstr "Activează"
 
 #: status.html
 msgid "Disable"
-msgstr ""
+msgstr "Dezactivează"
 
 #: lists/lists.html status.html type/list/edit.html type/series/edit.html
 msgid "Remove"
-msgstr ""
+msgstr "Elimină"
 
 #: status.html
 #, fuzzy
@@ -747,43 +747,43 @@ msgstr "Dezvoltare"
 
 #: status.html
 msgid "No PRs in testing set."
-msgstr ""
+msgstr "Niciun PR în setul de testare."
 
 #: status.html
 msgid "Last Build Result"
-msgstr ""
+msgstr "Ultimul rezultat al build-ului"
 
 #: status.html
 msgid "View PRs on GitHub"
-msgstr ""
+msgstr "Vezi PR-urile pe GitHub"
 
 #: status.html
 msgid "Show changed files"
-msgstr ""
+msgstr "Arată fișierele modificate"
 
 #: admin/inspect/store.html admin/people/index.html status.html type/author/edit.html type/language/view.html
 msgid "Name"
-msgstr ""
+msgstr "Nume"
 
 #: status.html
 msgid "System information"
-msgstr ""
+msgstr "Informații sistem"
 
 #: status.html
 msgid "Features enabled"
-msgstr ""
+msgstr "Funcționalități activate"
 
 #: subjects.html
 msgid "Edit tag for this subject"
-msgstr ""
+msgstr "Editează eticheta pentru acest subiect"
 
 #: subjects.html
 msgid "Create tag for this subject"
-msgstr ""
+msgstr "Creează eticheta pentru acest subiect"
 
 #: subjects.html
 msgid "See all works"
-msgstr ""
+msgstr "Vezi toate lucrările"
 
 #: merge/authors.html publishers/view.html subjects.html type/author/view.html
 #, python-format
@@ -796,47 +796,47 @@ msgstr[2] ""
 #: subjects.html
 #, python-format
 msgid "Search for books with subject %(name)s."
-msgstr ""
+msgstr "Caută cărți cu subiectul %(name)s."
 
 #: subjects.html
 msgid "Disambiguations"
-msgstr ""
+msgstr "Dezambiguizări"
 
 #: trending.html
 msgid "Now"
-msgstr ""
+msgstr "Acum"
 
 #: admin/graphs.html admin/index.html my_books/check_ins/check_in_form.html my_books/check_ins/check_in_prompt.html trending.html
 msgid "Today"
-msgstr ""
+msgstr "Astăzi"
 
 #: admin/graphs.html trending.html
 msgid "This Week"
-msgstr ""
+msgstr "Această săptămână"
 
 #: admin/graphs.html stats/readinglog.html trending.html
 msgid "This Month"
-msgstr ""
+msgstr "Această lună"
 
 #: trending.html
 msgid "This Year"
-msgstr ""
+msgstr "Acest an"
 
 #: admin/index.html books/year_breadcrumb_select.html trending.html
 msgid "All Time"
-msgstr ""
+msgstr "Oricând"
 
 #: home/index.html openlibrary/plugins/openlibrary/api.py trending.html
 msgid "Trending Books"
-msgstr ""
+msgstr "Cărți în tendințe"
 
 #: trending.html
 msgid "See what readers from the community are adding to their bookshelves"
-msgstr ""
+msgstr "Vezi ce adaugă cititorii din comunitate pe rafturile lor"
 
 #: trending.html
 msgid "Earliest trending data is from October 2017"
-msgstr ""
+msgstr "Cele mai vechi date despre tendințe sunt din octombrie 2017"
 
 #. Label for the reading log shelf for books the user plans to read in the
 #. future (bookshelf ID 1). Used as a button label and shelf name.
@@ -870,24 +870,24 @@ msgstr "În tendințe"
 #: trending.html
 #, python-format
 msgid "Someone marked as %(shelf)s %(k_hours_ago)s"
-msgstr ""
+msgstr "Cineva a marcat ca %(shelf)s %(k_hours_ago)s"
 
 #: trending.html
 #, python-format
 msgid "Logged %(count)i times %(time_unit)s"
-msgstr ""
+msgstr "Înregistrat de %(count)i ori %(time_unit)s"
 
 #: verify_human.html
 msgid "Human Verification"
-msgstr ""
+msgstr "Verificare umană"
 
 #: verify_human.html
 msgid "Please verify you are human to continue."
-msgstr ""
+msgstr "Vă rugăm să confirmați că sunteți uman pentru a continua."
 
 #: verify_human.html
 msgid "Verify you are human"
-msgstr ""
+msgstr "Confirmați că sunteți uman"
 
 #: verify_human.html
 #, fuzzy
@@ -896,11 +896,11 @@ msgstr "E-mail de verificare trimis"
 
 #: verify_human.html
 msgid "Verifying..."
-msgstr ""
+msgstr "Se verifică..."
 
 #: viewpage.html
 msgid "Revert to this revision?"
-msgstr ""
+msgstr "Revertiți la această revizie?"
 
 #: viewpage.html
 msgid "Revert to this revision"

--- a/openlibrary/i18n/ro/messages.po
+++ b/openlibrary/i18n/ro/messages.po
@@ -6776,142 +6776,142 @@ msgstr "Încercați să eliminați câteva elemente pentru mai mult focus sau co
 #: type/list/view_body.html
 #, python-format
 msgid "%(name)s | Lists | Open Library"
-msgstr ""
+msgstr "%(name)s | Liste | Open Library"
 
 #: type/list/view_body.html
 #, python-format
 msgid "%(title)s: %(description)s"
-msgstr ""
+msgstr "%(title)s: %(description)s"
 
 #: type/list/view_body.html
 msgid "View the list on Open Library."
-msgstr ""
+msgstr "Vizualizați lista pe Open Library."
 
 #: type/list/view_body.html
 msgid "Remove this item?"
-msgstr ""
+msgstr "Eliminați acest element?"
 
 #: type/list/view_body.html
 #, python-format
 msgid "Last modified <span>%(date)s</span>"
-msgstr ""
+msgstr "Ultima modificare <span>%(date)s</span>"
 
 #: type/list/view_body.html
 msgid "Remove seed"
-msgstr ""
+msgstr "Eliminați elementul"
 
 #: type/list/view_body.html
 msgid "Are you sure you want to remove this item from the list?"
-msgstr ""
+msgstr "Sigur doriți să eliminați acest element din listă?"
 
 #: type/list/view_body.html
 msgid "Remove Seed"
-msgstr ""
+msgstr "Eliminați elementul"
 
 #: type/list/view_body.html
 msgid "You are about to remove the last item in the list. That will delete the whole list. Are you sure you want to continue?"
-msgstr ""
+msgstr "Urmează să eliminați ultimul element din listă. Aceasta va șterge întreaga listă. Sigur doriți să continuați?"
 
 #: type/list/view_body.html
 #, python-format
 msgid "This series contains %(limit)d or more works. Currently, only the first %(limit)d works are displayed."
-msgstr ""
+msgstr "Această serie conține %(limit)d sau mai multe opere. În prezent, sunt afișate doar primele %(limit)d opere."
 
 #: type/list/view_body.html
 msgid "There are no items on this list."
-msgstr ""
+msgstr "Nu există elemente în această listă."
 
 #: type/list/view_body.html
 msgid "<a href=\"/search\" target=\"_blank\" rel=\"noopener noreferrer\">Search for book, subjects, or authors</a> to add to your list."
-msgstr ""
+msgstr "<a href=\"/search\" target=\"_blank\" rel=\"noopener noreferrer\">Căutați cărți, subiecte sau autori</a> pentru a adăuga în lista dvs."
 
 #: type/list/view_body.html
 msgid "Learn more."
-msgstr ""
+msgstr "Aflați mai multe."
 
 #: type/list/view_body.html
 msgid "List Metadata"
-msgstr ""
+msgstr "Metadate listă"
 
 #: type/list/view_body.html
 msgid "Derived from seed metadata"
-msgstr ""
+msgstr "Derivat din metadatele elementelor"
 
 #: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py type/list/view_body.html
 msgid "Times"
-msgstr ""
+msgstr "Perioade"
 
 #: type/local_id/view.html
 msgid "Local IDs"
-msgstr ""
+msgstr "ID-uri locale"
 
 #: type/local_id/view.html
 msgid "Source Item"
-msgstr ""
+msgstr "Element sursă"
 
 #: type/local_id/view.html
 msgid "ID location"
-msgstr ""
+msgstr "Locația ID-ului"
 
 #: type/local_id/view.html
 msgid "Barcode regex"
-msgstr ""
+msgstr "Regex cod de bare"
 
 #: type/local_id/view.html
 msgid "URN prefix"
-msgstr ""
+msgstr "Prefix URN"
 
 #: type/local_id/view.html
 msgid "Example"
-msgstr ""
+msgstr "Exemplu"
 
 #: type/page/edit.html
 msgid "Document Body:"
-msgstr ""
+msgstr "Corpul documentului:"
 
 #: type/page/view.html
 msgid "Community"
-msgstr ""
+msgstr "Comunitate"
 
 #: type/permission/edit.html
 msgid "Readers:"
-msgstr ""
+msgstr "Cititori:"
 
 #: type/permission/edit.html
 msgid "Writers:"
-msgstr ""
+msgstr "Scriitori:"
 
 #: type/permission/view.html
 msgid "Readers"
-msgstr ""
+msgstr "Cititori"
 
 #: type/permission/view.html
 msgid "Writers"
-msgstr ""
+msgstr "Scriitori"
 
 #: type/tag/form.html
 msgid "Edit tag"
-msgstr ""
+msgstr "Editați eticheta"
 
 #: type/tag/form.html
 msgid "Add a tag"
-msgstr ""
+msgstr "Adăugați o etichetă"
 
 #: type/tag/form.html
 msgid "Add a tag to Open Library"
-msgstr ""
+msgstr "Adăugați o etichetă în Open Library"
 
 #: type/tag/form.html
 msgid "We require a minimum set of fields to create a new collection tag."
-msgstr ""
+msgstr "Avem nevoie de un set minim de câmpuri pentru a crea o nouă etichetă de colecție."
 
 #: EditButtons.html type/tag/form.html
 msgid "By saving a change to this wiki, you agree that your contribution is given freely to the world under <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" target=\"_blank\" rel=\"noopener noreferrer\" title=\"This link to Creative Commons will open in a new window\">CC0</a>. Yippee!"
-msgstr ""
+msgstr "Prin salvarea unei modificări în acest wiki, vă exprimați acordul că contribuția dvs. este oferită lumii în mod gratuit sub <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" target=\"_blank\" rel=\"noopener noreferrer\" title=\"Acest link către Creative Commons se va deschide într-o fereastră nouă\">CC0</a>. Super!"
 
 #: type/tag/form.html
 msgid "Add this tag now"
-msgstr ""
+msgstr "Adăugați această etichetă acum"
 
 #: type/tag/index.html
 #, fuzzy
@@ -6920,15 +6920,15 @@ msgstr "Pagini"
 
 #: type/tag/index.html
 msgid "Tags curated by Open Library librarians."
-msgstr ""
+msgstr "Etichete îngrijite de biblioteicarii Open Library."
 
 #: type/tag/index.html
 msgid "View subject page"
-msgstr ""
+msgstr "Vizualizați pagina subiectului"
 
 #: type/tag/index.html
 msgid "Previous"
-msgstr ""
+msgstr "Anterior"
 
 #: type/tag/index.html
 #, fuzzy
@@ -6937,111 +6937,111 @@ msgstr "Nicio notă găsită."
 
 #: type/tag/tag_form_inputs.html
 msgid "Tag Name"
-msgstr ""
+msgstr "Numele etichetei"
 
 #: type/tag/tag_form_inputs.html
 msgid "Human-readable display name (e.g. \"Computer Science\", \"Horror Fiction\")"
-msgstr ""
+msgstr "Nume afișat lizibil pentru oameni (ex. \"Informatică\", \"Ficțiune horror\")"
 
 #: type/tag/tag_form_inputs.html
 msgid "Tag Slugs"
-msgstr ""
+msgstr "Slug-uri etichetă"
 
 #: type/tag/tag_form_inputs.html
 msgid "Comma-separated URL slugs that map to this tag (auto-populated from name). E.g. \"computer_science, cs\""
-msgstr ""
+msgstr "Slug-uri URL separate prin virgulă, care corespund acestei etichete (populate automat din nume). Ex. \"computer_science, cs\""
 
 #: type/tag/tag_form_inputs.html
 msgid "Tag Description"
-msgstr ""
+msgstr "Descriere etichetă"
 
 #: type/tag/tag_form_inputs.html
 msgid "Page Body"
-msgstr ""
+msgstr "Corpul paginii"
 
 #: type/tag/tag_form_inputs.html
 msgid "Tag type"
-msgstr ""
+msgstr "Tipul etichetei"
 
 #: type/tag/tag_form_inputs.html
 msgid "Tag Deputy"
-msgstr ""
+msgstr "Etichetă surogat"
 
 #: type/tag/view.html
 #, python-format
 msgid "<strong>Type:</strong> %(tag_type)s"
-msgstr ""
+msgstr "<strong>Tip:</strong> %(tag_type)s"
 
 #: type/tag/view.html type/user/edit.html
 msgid "Description"
-msgstr ""
+msgstr "Descriere"
 
 #: type/tag/view.html
 msgid "Tag Body"
-msgstr ""
+msgstr "Corpul etichetei"
 
 #: type/tag/view.html
 msgid "URL Slugs"
-msgstr ""
+msgstr "Slug-uri URL"
 
 #: type/tag/view.html
 #, python-format
 msgid "View subject page for %(name)s."
-msgstr ""
+msgstr "Vizualizați pagina subiectului pentru %(name)s."
 
 #: type/template/edit.html
 msgid "Plugin"
-msgstr ""
+msgstr "Plugin"
 
 #: type/template/edit.html
 msgid "Document Body"
-msgstr ""
+msgstr "Corpul documentului"
 
 #: type/template/edit.html
 msgid "Delete this template?"
-msgstr ""
+msgstr "Ștergeți acest șablon?"
 
 #: type/template/view.html
 msgid "plugin"
-msgstr ""
+msgstr "plugin"
 
 #: type/type/view.html
 msgid "Kind"
-msgstr ""
+msgstr "Tip"
 
 #: type/type/view.html
 msgid "Properties"
-msgstr ""
+msgstr "Proprietăți"
 
 #: type/type/view.html
 msgid "of type"
-msgstr ""
+msgstr "de tip"
 
 #: type/type/view.html
 msgid "Backreferences"
-msgstr ""
+msgstr "Referințe inverse"
 
 #: type/user/edit.html
 #, python-format
 msgid "Editing %(name)s"
-msgstr ""
+msgstr "Editare %(name)s"
 
 #: type/user/edit.html
 msgid "Currently Editing:"
-msgstr ""
+msgstr "Se editează în prezent:"
 
 #: type/user/edit.html
 msgid "Display Name"
-msgstr ""
+msgstr "Nume afișat"
 
 #: type/user/view.html
 msgid "admin page"
-msgstr ""
+msgstr "pagina admin"
 
 #: type/user/view.html
 #, python-format
 msgid "You are publicly sharing the books you are <a href=\"%(username)s/books/currently-reading\">currently reading</a>, <a href=\"%(username)s/books/already-read\">have already read</a>, <a href=\"%(username)s/books/want-to-read\">want to read</a>, and have <a href=\"%(username)s/books/stopped-reading\">stopped reading</a>!"
-msgstr ""
+msgstr "Distribuiți public cărțile pe care <a href=\"%(username)s/books/currently-reading\">le citiți în prezent</a>, <a href=\"%(username)s/books/already-read\">le-ați citit deja</a>, <a href=\"%(username)s/books/want-to-read\">doriți să le citiți</a> și pe care <a href=\"%(username)s/books/stopped-reading\">le-ați abandonat</a>!"
 
 #: type/user/view.html
 msgid "You have chosen to make your"
@@ -7058,37 +7058,37 @@ msgstr "Gestionați setările dumneavoastră de confidențialitate"
 #: type/user/view.html
 #, python-format
 msgid "Here are the books %(user)s is <a href=\"%(username)s/books/currently-reading\">currently reading</a>, <a href=\"%(username)s/books/already-read\">have already read</a>, <a href=\"%(username)s/books/want-to-read\">want to read</a>, and has <a href=\"%(username)s/books/stopped-reading\">stopped reading</a>!"
-msgstr ""
+msgstr "Acestea sunt cărțile pe care %(user)s <a href=\"%(username)s/books/currently-reading\">le citește în prezent</a>, <a href=\"%(username)s/books/already-read\">le-a citit deja</a>, <a href=\"%(username)s/books/want-to-read\">dorește să le citească</a> și pe care <a href=\"%(username)s/books/stopped-reading\">le-a abandonat</a>!"
 
 #: type/user/view.html
 msgid "My Lists"
-msgstr ""
+msgstr "Listele mele"
 
 #: RecentChangesUsers.html type/user/view.html
 msgid "No edits. Yet."
-msgstr ""
+msgstr "Nicio editare. Deocamdată."
 
 #: type/usergroup/edit.html
 msgid "Members:"
-msgstr ""
+msgstr "Membri:"
 
 #: SearchResultsWork.html type/work/editions.html
 #, python-format
 msgid "First published in %(year)s"
-msgstr ""
+msgstr "Prima publicare în %(year)s"
 
 #: type/work/editions.html type/work/editions_datatable.html
 #, python-format
 msgid "Add another edition of %(work)s"
-msgstr ""
+msgstr "Adăugați o altă ediție a lui %(work)s"
 
 #: UserEditRow.html type/work/editions.html
 msgid "Add another"
-msgstr ""
+msgstr "Adăugați altul"
 
 #: type/work/editions.html
 msgid "Title missing"
-msgstr ""
+msgstr "Titlu lipsă"
 
 #: type/work/editions_datatable.html
 #, python-format
@@ -7101,15 +7101,15 @@ msgstr[2] ""
 #: type/work/editions_datatable.html
 #, python-format
 msgid "View all %(count)d editions?"
-msgstr ""
+msgstr "Vizualizați toate cele %(count)d ediții?"
 
 #: type/work/editions_datatable.html
 msgid "Edition"
-msgstr ""
+msgstr "Ediție"
 
 #: type/work/editions_datatable.html
 msgid "Availability"
-msgstr ""
+msgstr "Disponibilitate"
 
 #: type/work/editions_datatable.html
 msgid "No editions available"

--- a/openlibrary/i18n/ro/messages.po
+++ b/openlibrary/i18n/ro/messages.po
@@ -5326,136 +5326,136 @@ msgstr "Închis"
 
 #: merge_request_table/table_header.html
 msgid "Status ▾"
-msgstr ""
+msgstr "Stare ▾"
 
 #: merge_request_table/table_header.html
 msgid "Request Status"
-msgstr ""
+msgstr "Starea cererii"
 
 #: merge_request_table/table_header.html openlibrary/core/edits.py
 msgid "Merged"
-msgstr ""
+msgstr "Fuzionat"
 
 #: merge_request_table/table_header.html openlibrary/core/edits.py
 msgid "Declined"
-msgstr ""
+msgstr "Respins"
 
 #: merge_request_table/table_header.html
 msgid "Submitter ▾"
-msgstr ""
+msgstr "Expeditor ▾"
 
 #: merge_request_table/table_header.html
 msgid "Filter submitters"
-msgstr ""
+msgstr "Filtrează expeditorii"
 
 #: merge_request_table/table_header.html
 msgid "Submitted by me"
-msgstr ""
+msgstr "Trimise de mine"
 
 #: merge_request_table/table_header.html
 msgid "Reviewer ▾"
-msgstr ""
+msgstr "Recenzent ▾"
 
 #: merge_request_table/table_header.html
 msgid "Reviewer"
-msgstr ""
+msgstr "Recenzent"
 
 #: merge_request_table/table_header.html
 msgid "Filter reviewers"
-msgstr ""
+msgstr "Filtrează recenzenții"
 
 #: merge_request_table/table_header.html
 msgid "Assigned to nobody"
-msgstr ""
+msgstr "Neatasat nimănui"
 
 #: merge_request_table/table_header.html
 msgid "Sort ▾"
-msgstr ""
+msgstr "Sortare ▾"
 
 #: merge_request_table/table_header.html
 msgid "Sort"
-msgstr ""
+msgstr "Sortare"
 
 #: merge_request_table/table_header.html
 msgid "Newest"
-msgstr ""
+msgstr "Cele mai noi"
 
 #: merge_request_table/table_header.html
 msgid "Oldest"
-msgstr ""
+msgstr "Cele mai vechi"
 
 #: merge_request_table/table_row.html
 msgid "An untitled work"
-msgstr ""
+msgstr "O operă fără titlu"
 
 #: merge_request_table/table_row.html
 msgid "An unnamed author"
-msgstr ""
+msgstr "Un autor fără nume"
 
 #: merge_request_table/table_row.html
 msgid "Open request"
-msgstr ""
+msgstr "Cerere deschisă"
 
 #: merge_request_table/table_row.html
 msgid "Closed request"
-msgstr ""
+msgstr "Cerere închisă"
 
 #: merge_request_table/table_row.html
 msgid "No comments yet."
-msgstr ""
+msgstr "Niciun comentariu încă."
 
 #: merge_request_table/table_row.html
 msgid "Add a comment..."
-msgstr ""
+msgstr "Adaugă un comentariu..."
 
 #: merge_request_table/table_row.html
 msgid "Reply"
-msgstr ""
+msgstr "Răspunde"
 
 #: merge_request_table/table_row.html
 #, python-format
 msgid "MR #%(id)s opened %(date)s by <a href=\"/people/%(submitter)s\" class=\"commenter\">@%(submitter)s</a>"
-msgstr ""
+msgstr "MR #%(id)s deschis %(date)s de <a href=\"/people/%(submitter)s\" class=\"commenter\">@%(submitter)s</a>"
 
 #: merge_request_table/table_row.html
 msgid "Click to close this Merge Request"
-msgstr ""
+msgstr "Faceți clic pentru a închide această cerere de fuzionare"
 
 #: merge_request_table/table_row.html
 msgid "Review <!-- (merge request) -->"
-msgstr ""
+msgstr "Revizuire <!-- (cerere de fuzionare) -->"
 
 #: merge_request_table/table_row.html
 msgid "comments"
-msgstr ""
+msgstr "comentarii"
 
 #: my_books/dropdown_content.html
 msgid "Remove From Shelf"
-msgstr ""
+msgstr "Elimină de pe raft"
 
 #: my_books/dropdown_content.html
 msgid "My Reading Lists:"
-msgstr ""
+msgstr "Listele mele de lectură:"
 
 #: my_books/dropdown_content.html
 msgid "Loading"
-msgstr ""
+msgstr "Se încarcă"
 
 #: my_books/dropdown_content.html
 msgid "Use this Work"
-msgstr ""
+msgstr "Folosește această operă"
 
 #: CreateListModal.html my_books/dropdown_content.html
 msgid "Create a new list"
-msgstr ""
+msgstr "Creează o listă nouă"
 
 #: CreateListModal.html my_books/dropdown_content.html type/permission/edit.html type/usergroup/edit.html
 msgid "Description:"
-msgstr ""
+msgstr "Descriere:"
 
 #: CreateListModal.html my_books/dropdown_content.html type/list/edit.html type/series/edit.html
 msgid "Create new list"
-msgstr ""
+msgstr "Creează o listă nouă"
 
 #: my_books/dropdown_content.html
 #, fuzzy
@@ -5464,144 +5464,144 @@ msgstr "Se încarcă..."
 
 #: my_books/dropdown_content.html
 msgid "Removing this book from your shelves will delete your check-ins for this work.  Continue?"
-msgstr ""
+msgstr "Eliminarea acestei cărți de pe rafturile tale va șterge înregistrările tale de progres pentru această operă. Continuați?"
 
 #: my_books/primary_action.html
 msgid "Add to List"
-msgstr ""
+msgstr "Adaugă la listă"
 
 #: my_books/check_ins/check_in_form.html
 msgid "January"
-msgstr ""
+msgstr "Ianuarie"
 
 #: my_books/check_ins/check_in_form.html
 msgid "February"
-msgstr ""
+msgstr "Februarie"
 
 #: my_books/check_ins/check_in_form.html
 msgid "March"
-msgstr ""
+msgstr "Martie"
 
 #: my_books/check_ins/check_in_form.html
 msgid "April"
-msgstr ""
+msgstr "Aprilie"
 
 #: my_books/check_ins/check_in_form.html
 msgid "May"
-msgstr ""
+msgstr "Mai"
 
 #: my_books/check_ins/check_in_form.html
 msgid "June"
-msgstr ""
+msgstr "Iunie"
 
 #: my_books/check_ins/check_in_form.html
 msgid "July"
-msgstr ""
+msgstr "Iulie"
 
 #: my_books/check_ins/check_in_form.html
 msgid "August"
-msgstr ""
+msgstr "August"
 
 #: my_books/check_ins/check_in_form.html
 msgid "September"
-msgstr ""
+msgstr "Septembrie"
 
 #: my_books/check_ins/check_in_form.html
 msgid "October"
-msgstr ""
+msgstr "Octombrie"
 
 #: my_books/check_ins/check_in_form.html
 msgid "November"
-msgstr ""
+msgstr "Noiembrie"
 
 #: my_books/check_ins/check_in_form.html
 msgid "December"
-msgstr ""
+msgstr "Decembrie"
 
 #: my_books/check_ins/check_in_form.html
 msgid "Add an optional check-in date. Check-in dates are used to track yearly reading goals."
-msgstr ""
+msgstr "Adaugă o dată opțională de înregistrare. Datele de înregistrare sunt folosite pentru urmărirea obiectivelor anuale de lectură."
 
 #: my_books/check_ins/check_in_form.html
 msgid "End Date:"
-msgstr ""
+msgstr "Data de final:"
 
 #: my_books/check_ins/check_in_form.html
 msgid "Year:"
-msgstr ""
+msgstr "An:"
 
 #: my_books/check_ins/check_in_form.html
 msgid "Year"
-msgstr ""
+msgstr "An"
 
 #: my_books/check_ins/check_in_form.html
 msgid "Month:"
-msgstr ""
+msgstr "Lună:"
 
 #: my_books/check_ins/check_in_form.html
 msgid "Month"
-msgstr ""
+msgstr "Lună"
 
 #: my_books/check_ins/check_in_form.html
 msgid "Day:"
-msgstr ""
+msgstr "Zi:"
 
 #: my_books/check_ins/check_in_form.html
 msgid "Day"
-msgstr ""
+msgstr "Zi"
 
 #: my_books/check_ins/check_in_form.html
 msgid "Delete Event"
-msgstr ""
+msgstr "Șterge evenimentul"
 
 #: my_books/check_ins/check_in_prompt.html
 msgid "Failed to delete check-in. Please try again in a few moments."
-msgstr ""
+msgstr "Nu s-a putut șterge înregistrarea. Vă rugăm să încercați din nou în câteva momente."
 
 #: my_books/check_ins/check_in_prompt.html
 msgid "Failed to submit check-in. Please try again in a few moments."
-msgstr ""
+msgstr "Nu s-a putut trimite înregistrarea. Vă rugăm să încercați din nou în câteva momente."
 
 #: my_books/check_ins/check_in_prompt.html
 #, python-format
 msgid "Read <time class=\"check-in-date\">%(date)s</time>"
-msgstr ""
+msgstr "Citit <time class=\"check-in-date\">%(date)s</time>"
 
 #: my_books/check_ins/check_in_prompt.html
 msgid "When did you finish this book?"
-msgstr ""
+msgstr "Când ai terminat această carte?"
 
 #: my_books/check_ins/check_in_prompt.html
 msgid "Other"
-msgstr ""
+msgstr "Altele"
 
 #: my_books/check_ins/check_in_prompt.html
 msgid "Check-In"
-msgstr ""
+msgstr "Înregistrare progres"
 
 #: observations/review_component.html
 msgid "Community Reviews"
-msgstr ""
+msgstr "Recenzii comunitate"
 
 #: observations/review_component.html
 msgid "No community reviews have been submitted for this work."
-msgstr ""
+msgstr "Nicio recenzie din comunitate nu a fost trimisă pentru această operă."
 
 #: observations/review_component.html
 msgid "+ Add your community review"
-msgstr ""
+msgstr "+ Adaugă recenzia ta din comunitate"
 
 #: observations/review_component.html
 msgid "+ Log in to add your community review"
-msgstr ""
+msgstr "+ Autentifică-te pentru a adăuga recenzia ta din comunitate"
 
 #: publishers/index.html publishers/notfound.html
 msgid "Publishers"
-msgstr ""
+msgstr "Editori"
 
 #: publishers/index.html publishers/view.html
 msgid "Publisher Search"
-msgstr ""
+msgstr "Căutare editor"
 
 #: publishers/index.html publishers/view.html
 msgid "Try a keyword."
@@ -5610,20 +5610,20 @@ msgstr "Încercați un cuvânt cheie."
 #: publishers/notfound.html
 #, python-format
 msgid "We couldn't find any books published by %(publisher)s."
-msgstr ""
+msgstr "Nu am putut găsi nicio carte publicată de %(publisher)s."
 
 #: publishers/notfound.html subjects/notfound.html
 msgid "Try something else?"
-msgstr ""
+msgstr "Încercați altceva?"
 
 #: publishers/view.html
 #, python-format
 msgid "Publisher: %(name)s"
-msgstr ""
+msgstr "Editor: %(name)s"
 
 #: openlibrary/plugins/worksearch/code.py publishers/view.html search/advancedsearch.html type/edition/view.html type/work/view.html
 msgid "Publisher"
-msgstr ""
+msgstr "Editor"
 
 #: SearchResultsWork.html publishers/view.html
 #, python-format
@@ -5635,15 +5635,15 @@ msgstr[2] ""
 
 #: publishers/view.html
 msgid "0 ebooks"
-msgstr ""
+msgstr "0 e-books"
 
 #: PublishingHistory.html publishers/view.html
 msgid "Publishing History"
-msgstr ""
+msgstr "Istoricul publicării"
 
 #: publishers/view.html
 msgid "This is a chart to show the when this publisher published books. Along the X axis is time, and on the y axis is the count of editions published. <a href=\"#subjectRelated\">Click here to skip the chart</a>."
-msgstr ""
+msgstr "Acesta este un grafic care arată când a publicat cărți acest editor. Pe axa X este timpul, iar pe axa Y este numărul de ediții publicate. <a href=\"#subjectRelated\">Faceți clic aici pentru a sări graficul</a>."
 
 #: PublishingHistory.html publishers/view.html
 msgid "Reset chart"

--- a/openlibrary/i18n/ro/messages.po
+++ b/openlibrary/i18n/ro/messages.po
@@ -4634,31 +4634,31 @@ msgstr "Încarcă o imagine de copertă"
 
 #: lib/message_addbook.html
 msgid "Snap a quick photo of the cover to share?"
-msgstr ""
+msgstr "Faceți rapid o fotografie a copertei pentru a o partaja?"
 
 #: lib/message_addbook.html
 msgid "Add an ISBN"
-msgstr ""
+msgstr "Adaugă un ISBN"
 
 #: lib/message_addbook.html
 msgid "Help the library connect with other systems, like Amazon."
-msgstr ""
+msgstr "Ajutați biblioteca să se conecteze cu alte sisteme, precum Amazon."
 
 #: lib/message_addbook.html
 msgid "Add some subjects"
-msgstr ""
+msgstr "Adaugă câteva subiecte"
 
 #: lib/message_addbook.html
 msgid "They're just like tags."
-msgstr ""
+msgstr "Sunt ca niște etichete."
 
 #: lib/message_addbook.html
 msgid "Describe what the book's about"
-msgstr ""
+msgstr "Descrie despre ce este cartea"
 
 #: lib/message_addbook.html
 msgid "Just a sentence or two is good."
-msgstr ""
+msgstr "O propoziție sau două este suficient."
 
 #: lib/nav_foot.html openlibrary/plugins/openlibrary/api.py site/head.html
 msgid "Open Library"
@@ -4810,7 +4810,7 @@ msgstr "Note de lansare"
 
 #: lib/nav_foot.html
 msgid "Bluesky"
-msgstr ""
+msgstr "Bluesky"
 
 #: lib/nav_foot.html
 #, fuzzy
@@ -4934,7 +4934,7 @@ msgstr "Căutați după codul de bare"
 
 #: lib/not_logged.html
 msgid "<strong>You are not <a href=\"/account/login\" title=\"Log in now\">logged in</a>.</strong> Open Library will record your IP address and include it in this page's publicly accessible edit history. If you <a href=\"/account/create\" title=\"Create an Open Library account\">create an account</a>, your IP address is concealed and you can more easily keep track of all your edits and additions."
-msgstr ""
+msgstr "<strong>Nu ești <a href=\"/account/login\" title=\"Autentifică-te acum\">autentificat</a>.</strong> Open Library va înregistra adresa ta IP și o va include în istoricul public al acestei pagini. Dacă <a href=\"/account/create\" title=\"Creează un cont Open Library\">creezi un cont</a>, adresa ta IP este ascunsă și poți urmări mai ușor toate modificările și adăugirile tale."
 
 #: librarian_dashboard/data_quality_table.html
 #, fuzzy
@@ -4948,24 +4948,24 @@ msgstr "Urmăresc"
 
 #: librarian_dashboard/data_quality_table.html
 msgid "Data quality table"
-msgstr ""
+msgstr "Tabel calitate date"
 
 #: librarian_dashboard/data_quality_table.html
 msgid "Quality Criteria"
-msgstr ""
+msgstr "Criterii de calitate"
 
 #: lists/carousel.html lists/home.html lists/showcase.html
 msgid "See all"
-msgstr ""
+msgstr "Vezi tot"
 
 #: lists/export_as_html.html
 #, python-format
 msgid "%(list)s - Editions"
-msgstr ""
+msgstr "%(list)s - Ediții"
 
 #: lists/export_as_html.html type/list/embed.html type/list/view_body.html
 msgid "Unknown authors"
-msgstr ""
+msgstr "Autori necunoscuți"
 
 #: lists/export_as_html.html
 msgid "Title unknown"
@@ -4973,16 +4973,16 @@ msgstr "Titlu necunoscut"
 
 #: lists/export_as_html.html
 msgid "First publish date unknown"
-msgstr ""
+msgstr "Data primei publicări necunoscută"
 
 #: lists/export_as_html.html
 msgid "Name unknown"
-msgstr ""
+msgstr "Nume necunoscut"
 
 #: lists/header.html
 #, python-format
 msgid "<a href=\"%(href)s\">%(name)s</a> / Lists"
-msgstr ""
+msgstr "<a href=\"%(href)s\">%(name)s</a> / Liste"
 
 #: lists/header.html
 #, python-format
@@ -5026,24 +5026,24 @@ msgstr[2] ""
 
 #: lists/header.html
 msgid "Hm. Can't find it."
-msgstr ""
+msgstr "Hmm. Nu pot găsi."
 
 #: lists/home.html
 msgid "Create a list of any Subjects, Authors, Works or specific Editions."
-msgstr ""
+msgstr "Creați o listă cu orice Subiecte, Autori, Opere sau Ediții specifice."
 
 #: lists/home.html
 msgid "Once you've made a list, you can <strong>watch for updates</strong> or <strong>export</strong> all the editions in a list as HTML, BibTeX or JSON. See all your lists and any activity using the \"Lists\" link on your Account page."
-msgstr ""
+msgstr "Odată ce ai creat o listă, poți <strong>urmări actualizările</strong> sau <strong>exporta</strong> toate edițiile dintr-o listă ca HTML, BibTeX sau JSON. Vizualizați toate listele și activitatea dvs. folosind linkul \"Liste\" de pe pagina contului."
 
 #: lists/home.html
 #, python-format
 msgid "For the top 2000+ most requested eBooks in California for the print disabled <a href=\"%(url)s\">click here</a>."
-msgstr ""
+msgstr "Pentru primele 2000+ e-books cel mai solicitate în California pentru persoanele cu dizabilități de tipărire <a href=\"%(url)s\">faceți clic aici</a>."
 
 #: lists/home.html
 msgid "Find a list by name"
-msgstr ""
+msgstr "Găsiți o listă după nume"
 
 #: lists/home.html
 msgid "Active Lists"
@@ -5052,7 +5052,7 @@ msgstr "Liste active"
 #: lists/home.html
 #, python-format
 msgid "from <a href=\"%(key)s\">%(owner)s</a>"
-msgstr ""
+msgstr "de la <a href=\"%(key)s\">%(owner)s</a>"
 
 #: lists/home.html lists/preview.html lists/snippet.html type/list/embed.html type/list/view_body.html
 #, python-format
@@ -5065,11 +5065,11 @@ msgstr[2] ""
 #: lists/home.html lists/preview.html lists/snippet.html
 #, python-format
 msgid "Last modified %(date)s"
-msgstr ""
+msgstr "Modificat ultima dată %(date)s"
 
 #: lists/home.html lists/snippet.html
 msgid "No description."
-msgstr ""
+msgstr "Fără descriere."
 
 #: RecentChangesUsers.html lists/home.html lists/lists.html type/user/view.html
 msgid "Recent Activity"
@@ -5077,27 +5077,27 @@ msgstr "Activitate recentă"
 
 #: lists/list_follow.html
 msgid "Cover of book"
-msgstr ""
+msgstr "Copertă carte"
 
 #: lists/list_follow.html
 msgid "Avatar of the owner of the list"
-msgstr ""
+msgstr "Avatarul proprietarului listei"
 
 #: lists/list_follow.html lists/widget.html my_books/dropdown_content.html
 msgid "You"
-msgstr ""
+msgstr "Tu"
 
 #: lists/list_follow.html
 msgid "This patron has not enabled following"
-msgstr ""
+msgstr "Acest utilizator nu a activat urmărirea"
 
 #: lists/list_follow.html
 msgid "🔒︎"
-msgstr ""
+msgstr "🔒︎"
 
 #: Follow.html lists/list_follow.html
 msgid "Follow"
-msgstr ""
+msgstr "Urmărește"
 
 #: lists/list_follow.html
 #, fuzzy
@@ -5111,26 +5111,26 @@ msgstr ""
 
 #: lists/list_overview.html lists/widget.html my_books/dropdown_content.html
 msgid "See this list"
-msgstr ""
+msgstr "Vezi această listă"
 
 #: lists/list_overview.html lists/widget.html my_books/dropdown_content.html
 msgid "Remove from your list?"
-msgstr ""
+msgstr "Elimini din lista ta?"
 
 #: lists/list_overview.html
 #, python-format
 msgid "from <a href=\"%(link)s\">You</a>"
-msgstr ""
+msgstr "de la <a href=\"%(link)s\">Tine</a>"
 
 #: lists/list_overview.html
 #, python-format
 msgid "from <a href=\"%(link)s\">%(name)s</a>"
-msgstr ""
+msgstr "de la <a href=\"%(link)s\">%(name)s</a>"
 
 #: lists/lists.html
 #, python-format
 msgid "%(owner)s / Lists"
-msgstr ""
+msgstr "%(owner)s / Liste"
 
 #: lists/lists.html type/list/view_body.html
 msgid "Yes, I'm sure"
@@ -5150,20 +5150,20 @@ msgstr "Șterge lista"
 
 #: lists/lists.html
 msgid "Are you sure you want to delete this list?"
-msgstr ""
+msgstr "Ești sigur că vrei să ștergi această listă?"
 
 #: lists/lists.html
 msgid "Remove this seed?"
-msgstr ""
+msgstr "Eliminați această intrare?"
 
 #: lists/lists.html
 #, python-format
 msgid "Are you sure you want to remove <strong>%(title)s</strong> from this list?"
-msgstr ""
+msgstr "Ești sigur că vrei să elimini <strong>%(title)s</strong> din această listă?"
 
 #: lists/lists.html
 msgid "This reader hasn't created any lists yet."
-msgstr ""
+msgstr "Acest cititor nu a creat încă nicio listă."
 
 #: lists/lists.html
 msgid "You haven't created any lists yet."
@@ -5176,7 +5176,7 @@ msgstr "Aflați cum puteți să creați prima dumneavoastră listă."
 #: lists/preview.html
 #, python-format
 msgid "by <a href=\"%s\">You</a>"
-msgstr ""
+msgstr "de <a href=\"%s\">Tine</a>"
 
 #: lists/showcase.html
 #, python-format
@@ -5189,140 +5189,140 @@ msgstr "Nu aveți nicio listă."
 
 #: lists/widget.html my_books/dropdown_content.html type/type/view.html
 msgid "from"
-msgstr ""
+msgstr "de la"
 
 #: lists/widget.html
 msgid "Loading<span class=\"loading-ellipsis\">...</span>"
-msgstr ""
+msgstr "Se încarcă<span class=\"loading-ellipsis\">...</span>"
 
 #: merge/authors.html
 msgid "Merge Authors"
-msgstr ""
+msgstr "Fuzionează autori"
 
 #: merge/authors.html
 msgid "No authors selected."
-msgstr ""
+msgstr "Niciun autor selectat."
 
 #: merge/authors.html
 msgid "Please select a primary author record."
-msgstr ""
+msgstr "Selectați o înregistrare principală de autor."
 
 #: merge/authors.html
 msgid "Please select some authors to merge."
-msgstr ""
+msgstr "Selectați autorii de fuzionat."
 
 #: merge/authors.html
 msgid "Select the oldest profile as primary -"
-msgstr ""
+msgstr "Selectați cel mai vechi profil ca principal -"
 
 #: merge/authors.html
 msgid "Select author records which should be merged with the primary"
-msgstr ""
+msgstr "Selectați înregistrările de autori care trebuie fuzionate cu cel principal"
 
 #: merge/authors.html
 msgid "Press MERGE AUTHORS."
-msgstr ""
+msgstr "Apăsați FUZIONEAZĂ AUTORI."
 
 #: merge/authors.html
 msgid "No primary record"
-msgstr ""
+msgstr "Fără înregistrare principală"
 
 #: merge/authors.html
 msgid "You must select a primary record to point the duplicates toward."
-msgstr ""
+msgstr "Trebuie să selectați o înregistrare principală spre care să indice duplicatele."
 
 #: merge/authors.html
 msgid "Please Be Careful..."
-msgstr ""
+msgstr "Atenție vă rugăm..."
 
 #: merge/authors.html
 msgid "<b>Are you sure</b> you want to merge these records?"
-msgstr ""
+msgstr "<b>Ești sigur</b> că vrei să fuzionezi aceste înregistrări?"
 
 #: merge/authors.html recentchanges/merge/view.html
 msgid "Primary"
-msgstr ""
+msgstr "Principal"
 
 #: merge/authors.html
 msgid "Merge"
-msgstr ""
+msgstr "Fuzionează"
 
 #: merge/authors.html
 msgid "birth/death date"
-msgstr ""
+msgstr "dată naștere/deces"
 
 #: merge/authors.html
 msgid "Open in a new window"
-msgstr ""
+msgstr "Deschide într-o fereastră nouă"
 
 #: merge/authors.html search/work_search_selected_facets.html
 msgid "First published in"
-msgstr ""
+msgstr "Publicată prima dată în"
 
 #: merge/authors.html
 msgid "Visit this author's page in a new window"
-msgstr ""
+msgstr "Vizitați pagina acestui autor într-o fereastră nouă"
 
 #: merge/authors.html
 msgid "Comment:"
-msgstr ""
+msgstr "Comentariu:"
 
 #: merge/authors.html
 msgid "Comment..."
-msgstr ""
+msgstr "Comentariu..."
 
 #: merge/authors.html
 msgid "Request Merge"
-msgstr ""
+msgstr "Solicită fuzionare"
 
 #: merge/authors.html
 msgid "Reject Merge"
-msgstr ""
+msgstr "Respinge fuzionarea"
 
 #: merge/works.html
 msgid "Merge Works"
-msgstr ""
+msgstr "Fuzionează opere"
 
 #: merge_request_table/merge_request_table.html
 msgid "Failed to submit comment. Please try again in a few moments."
-msgstr ""
+msgstr "Nu s-a putut trimite comentariul. Vă rugăm să încercați din nou în câteva momente."
 
 #: merge_request_table/merge_request_table.html
 msgid "(Optional) Why are you closing this request?"
-msgstr ""
+msgstr "(Opțional) De ce închideți această cerere?"
 
 #: merge_request_table/merge_request_table.html
 #, python-format
 msgid "Showing %(username)s's requests only."
-msgstr ""
+msgstr "Se afișează numai cererile lui %(username)s."
 
 #: merge_request_table/merge_request_table.html
 msgid "Show all requests"
-msgstr ""
+msgstr "Afișează toate cererile"
 
 #: merge_request_table/merge_request_table.html
 msgid "Showing all requests."
-msgstr ""
+msgstr "Se afișează toate cererile."
 
 #: merge_request_table/merge_request_table.html
 msgid "Show my requests"
-msgstr ""
+msgstr "Afișează cererile mele"
 
 #: merge_request_table/merge_request_table.html
 msgid "Community Edit Requests"
-msgstr ""
+msgstr "Cereri de editare din comunitate"
 
 #: merge_request_table/merge_request_table.html
 msgid "No entries here!"
-msgstr ""
+msgstr "Nicio intrare aici!"
 
 #: merge_request_table/table_header.html
 msgid "Open"
-msgstr ""
+msgstr "Deschide"
 
 #: merge_request_table/table_header.html
 msgid "Closed"
-msgstr ""
+msgstr "Închis"
 
 #: merge_request_table/table_header.html
 msgid "Status ▾"

--- a/openlibrary/i18n/ro/messages.po
+++ b/openlibrary/i18n/ro/messages.po
@@ -1491,7 +1491,7 @@ msgstr "Notificările sunt conectate la Liste în prezent. Dacă una dintre căr
 
 #: account/notifications.html
 msgid "Would you like to receive very occasional emails from Open Library?"
-msgstr ""
+msgstr "Dorești să primești ocazional emailuri de la Open Library?"
 
 #: account/notifications.html
 msgid "No, thank you"
@@ -1515,7 +1515,7 @@ msgstr "Șterge"
 
 #: account/observations.html
 msgid "Update Reviews"
-msgstr ""
+msgstr "Actualizează recenzii"
 
 #: account/observations.html
 msgid "No observations found."
@@ -1523,19 +1523,19 @@ msgstr "Nicio observație găsită."
 
 #: account/privacy.html
 msgid "Your Privacy on Open Library"
-msgstr ""
+msgstr "Confidențialitatea ta pe Open Library"
 
 #: account/privacy.html
 msgid "Privacy & Content Moderation Settings"
-msgstr ""
+msgstr "Setări de confidențialitate și moderare a conținutului"
 
 #: account/privacy.html
 msgid "Would you like to make your <a href=\"/account/books\">Reading Log</a> public?"
-msgstr ""
+msgstr "Dorești să faci <a href=\"/account/books\">Jurnalul de lectură</a> public?"
 
 #: account/privacy.html
 msgid "This will enable others to see what books you want to read, are reading, stopped reading, or have already read. Patrons with reading logs set to public may be followed."
-msgstr ""
+msgstr "Aceasta va permite altora să vadă ce cărți vrei să citești, citești, ai oprit lectura sau ai citit deja. Utilizatorii cu jurnale de lectură publice pot fi urmăriți."
 
 #: account/privacy.html admin/people/view.html
 msgid "Yes"
@@ -1547,98 +1547,98 @@ msgstr "Nu"
 
 #: account/privacy.html
 msgid "Enable Safe Mode?"
-msgstr ""
+msgstr "Activezi Modul sigur?"
 
 #: account/privacy.html
 msgid "Safe Mode blurs book covers that have been flagged as having sensitive imagery."
-msgstr ""
+msgstr "Modul sigur estompează copertele cărților marcate ca având imagini sensibile."
 
 #: account/reading_log.html
 #, python-format
 msgid "Books %(username)s is reading"
-msgstr ""
+msgstr "Cărți pe care le citește %(username)s"
 
 #: account/reading_log.html
 #, python-format
 msgid "%(username)s is reading %(total)d books. Join %(username)s on OpenLibrary.org and tell the world what you're reading."
-msgstr ""
+msgstr "%(username)s citește %(total)d cărți. Alătură-te lui %(username)s pe OpenLibrary.org și spune lumii ce citești."
 
 #: account/reading_log.html
 #, python-format
 msgid "Books %(username)s wants to read"
-msgstr ""
+msgstr "Cărți pe care %(username)s vrea să le citească"
 
 #: account/reading_log.html
 #, python-format
 msgid "%(username)s wants to read %(total)d books. Join %(username)s on OpenLibrary.org and share the books that you'll soon be reading!"
-msgstr ""
+msgstr "%(username)s vrea să citească %(total)d cărți. Alătură-te lui %(username)s pe OpenLibrary.org și împărtășește cărțile pe care le vei citi în curând!"
 
 #: account/reading_log.html
 #, python-format
 msgid "Books %(username)s stopped reading"
-msgstr ""
+msgstr "Cărți la care %(username)s a oprit lectura"
 
 #: account/reading_log.html
 #, python-format
 msgid "%(username)s stopped reading %(total)d books. Join %(username)s on OpenLibrary.org to share your own reading updates!"
-msgstr ""
+msgstr "%(username)s a oprit lectura la %(total)d cărți. Alătură-te lui %(username)s pe OpenLibrary.org pentru a-ți împărtăși propriile actualizări de lectură!"
 
 #: account/reading_log.html
 #, python-format
 msgid "Books %(username)s has read in %(year)d"
-msgstr ""
+msgstr "Cărți citite de %(username)s în %(year)d"
 
 #: account/reading_log.html
 #, python-format
 msgid "%(username)s has read %(total)d books in %(year)d. Join %(username)s on OpenLibrary.org and tell the world about the books that you care about."
-msgstr ""
+msgstr "%(username)s a citit %(total)d cărți în %(year)d. Alătură-te lui %(username)s pe OpenLibrary.org și spune lumii despre cărțile care îți pasă."
 
 #: account/reading_log.html
 #, python-format
 msgid "Books %(username)s has read"
-msgstr ""
+msgstr "Cărți citite de %(username)s"
 
 #: account/reading_log.html
 #, python-format
 msgid "%(username)s has read %(total)d books. Join %(username)s on OpenLibrary.org and tell the world about the books that you care about."
-msgstr ""
+msgstr "%(username)s a citit %(total)d cărți. Alătură-te lui %(username)s pe OpenLibrary.org și spune lumii despre cărțile care îți pasă."
 
 #: account/reading_log.html
 #, python-format
 msgid "Books in %(username)s feed"
-msgstr ""
+msgstr "Cărți în feedul lui %(username)s"
 
 #: account/reading_log.html
 #, python-format
 msgid "Books added by people %(username)s follows"
-msgstr ""
+msgstr "Cărți adăugate de persoanele urmărite de %(username)s"
 
 #: account/reading_log.html
 msgid "Search your reading log"
-msgstr ""
+msgstr "Caută în jurnalul de lectură"
 
 #: account/reading_log.html type/author/view.html
 #, python-format
 msgid "— Show <a href=\"%(url)s\">only ebooks</a>?"
-msgstr ""
+msgstr "— Afișează <a href=\"%(url)s\">numai e-books</a>?"
 
 #: account/reading_log.html
 #, python-format
 msgid "— Show <a href=\"%(url)s\">everything</a> in this shelf?"
-msgstr ""
+msgstr "— Afișează <a href=\"%(url)s\">tot</a> din acest raft?"
 
 #: account/reading_log.html
 msgid "No results found in this shelf"
-msgstr ""
+msgstr "Niciun rezultat găsit în acest raft"
 
 #: account/reading_log.html
 #, python-format
 msgid "Search all of Open Library for \"%s\"?"
-msgstr ""
+msgstr "Caută în tot Open Library pentru \"%s\"?"
 
 #: account/reading_log.html
 msgid "You haven't marked any books as read for this year."
-msgstr ""
+msgstr "Nu ai marcat nicio carte ca citită pentru acest an."
 
 #: account/reading_log.html
 msgid "You haven't added any books to this shelf yet."
@@ -1830,204 +1830,204 @@ msgstr "Stabilește-ți obiectivul anual de citire pentru %(year)s:"
 
 #: account/yrg_banner.html
 msgid "Set my goal"
-msgstr ""
+msgstr "Stabilește-mi obiectivul"
 
 #: account/email/forgot-ia.html
 msgid "Forgot Your Internet Archive Email?"
-msgstr ""
+msgstr "Ai uitat emailul Internet Archive?"
 
 #: account/email/forgot-ia.html
 msgid "Please enter your Open Library email and password, and we’ll retrieve your Archive.org email."
-msgstr ""
+msgstr "Introduceți emailul și parola Open Library, iar noi vom recupera emailul Archive.org."
 
 #: account/email/forgot-ia.html
 msgid "Your email is:"
-msgstr ""
+msgstr "Emailul tău este:"
 
 #: account/email/forgot-ia.html
 msgid "Return to Log In?"
-msgstr ""
+msgstr "Revino la autentificare?"
 
 #: account/email/forgot-ia.html
 msgid "Open Library Email"
-msgstr ""
+msgstr "Email Open Library"
 
 #: account/email/forgot-ia.html
 msgid "Retrieve Archive.org Email"
-msgstr ""
+msgstr "Recuperează emailul Archive.org"
 
 #: account/email/forgot-ia.html account/password/forgot.html
 msgid "Forgot your Archive.org Password?"
-msgstr ""
+msgstr "Ai uitat parola Archive.org?"
 
 #: account/password/forgot.html account/password/sent.html
 msgid "Username/Password Reminder"
-msgstr ""
+msgstr "Reamintire utilizator/parolă"
 
 #: account/password/forgot.html
 msgid "Click here."
-msgstr ""
+msgstr "Apasă aici."
 
 #: account/password/forgot.html
 msgid "Send It"
-msgstr ""
+msgstr "Trimite"
 
 #: account/password/reset.html admin/people/view.html
 msgid "Reset Password"
-msgstr ""
+msgstr "Resetează parola"
 
 #: account/password/reset.html
 msgid "Please enter a new password for your Open Library account."
-msgstr ""
+msgstr "Introduceți o nouă parolă pentru contul dvs. Open Library."
 
 #: account/password/reset.html
 msgid "Reset"
-msgstr ""
+msgstr "Resetează"
 
 #: account/password/reset_success.html
 msgid "Password Reset Successful"
-msgstr ""
+msgstr "Resetare parolă reușită"
 
 #: account/password/reset_success.html
 msgid "Your password has been updated. Please <a href='/account/login?redirect=/'>log in to continue</a>."
-msgstr ""
+msgstr "Parola ta a fost actualizată. Te rugăm să <a href=\"/account/login?redirect=/\">te autentifici pentru a continua</a>."
 
 #: account/password/sent.html
 msgid "Done."
-msgstr ""
+msgstr "Gata."
 
 #: account/password/sent.html
 #, python-format
 msgid "We've sent an email to %(email)s with a reminder of your username and instructions to help you reset your Open Library password. Please check your inbox for a note from us."
-msgstr ""
+msgstr "Am trimis un email la %(email)s cu un reminder al numelui de utilizator și instrucțiuni pentru resetarea parolei Open Library. Verifică căsuța de intrare pentru un mesaj de la noi."
 
 #: account/security/check_email.html
 msgid "Account Security Check — 2026-04-28T18Z"
-msgstr ""
+msgstr "Verificare securitate cont — 2026-04-28T18Z"
 
 #: account/security/check_email.html
 msgid "Account Security Check"
-msgstr ""
+msgstr "Verificare securitate cont"
 
 #: account/security/check_email.html
 msgid "Incident date: 2026-04-28T18Z"
-msgstr ""
+msgstr "Data incidentului: 2026-04-28T18Z"
 
 #: account/security/check_email.html
 msgid "Check whether your Open Library account was in a set of accounts requiring attention."
-msgstr ""
+msgstr "Verifică dacă contul tău Open Library a fost într-un set de conturi care necesitau atenție."
 
 #: account/security/check_email.html
 msgid "Please <a href=\"/account/login?redirect=/account/security/2026-04-28T18\">log in</a> to check whether your account was affected."
-msgstr ""
+msgstr "Te rugăm să <a href=\"/account/login?redirect=/account/security/2026-04-28T18\">te autentifici</a> pentru a verifica dacă contul tău a fost afectat."
 
 #: account/security/check_email.html
 msgid "Your account is in the affected set."
-msgstr ""
+msgstr "Contul tău se află în setul afectat."
 
 #: account/security/check_email.html
 msgid "Your account was found in our affected accounts list. Please review any recent communications from Open Library and consider updating your password."
-msgstr ""
+msgstr "Contul tău a fost găsit în lista noastră de conturi afectate. Te rugăm să revizuiești orice comunicare recentă de la Open Library și să iei în considerare actualizarea parolei."
 
 #: account/security/check_email.html
 msgid "Your account is <em>not</em> in the affected set."
-msgstr ""
+msgstr "Contul tău <em>nu</em> se află în setul afectat."
 
 #: account/security/check_email.html
 msgid "Your account was <em>not</em> found in the affected accounts list. No action is required."
-msgstr ""
+msgstr "Contul tău <em>nu</em> a fost găsit în lista de conturi afectate. Nu este necesară nicio acțiune."
 
 #: account/verify/activated.html
 msgid "Account already activated"
-msgstr ""
+msgstr "Contul a fost deja activat"
 
 #: account/verify/activated.html
 #, python-format
 msgid "Your account has been activated already. Please <a href=\"%s\">log in to continue</a>."
-msgstr ""
+msgstr "Contul tău a fost deja activat. Te rugăm să <a href=\"%s\">te autentifici pentru a continua</a>."
 
 #: account/verify/failed.html
 msgid "Email Verification Failed"
-msgstr ""
+msgstr "Verificarea emailului a eșuat"
 
 #: account/verify/failed.html
 msgid "Your email address couldn't be verified. Your verification link seems invalid or expired."
-msgstr ""
+msgstr "Adresa ta de email nu a putut fi verificată. Linkul de verificare pare invalid sau expirat."
 
 #: account/verify/failed.html
 msgid "Fill your email and hit this button to resend a fresh verification email:"
-msgstr ""
+msgstr "Introduceți emailul și apăsați acest buton pentru a retrimite un email de verificare proaspăt:"
 
 #: account/verify/failed.html
 msgid "Enter your email address here"
-msgstr ""
+msgstr "Introduceți adresa de email aici"
 
 #: account/verify/failed.html
 msgid "No user registered with this email address."
-msgstr ""
+msgstr "Niciun utilizator înregistrat cu această adresă de email."
 
 #: account/verify/success.html
 msgid "Email Verification Successful"
-msgstr ""
+msgstr "Verificarea emailului a reușit"
 
 #: account/verify/success.html
 #, python-format
 msgid "Yay! Your email address has been verified. Please <a href='%s'>log in to continue</a>."
-msgstr ""
+msgstr "Felicitări! Adresa ta de email a fost verificată. Te rugăm să <a href=\"%s\">te autentifici pentru a continua</a>."
 
 #: admin/attach_debugger.html
 msgid "Attach Debugger"
-msgstr ""
+msgstr "Atașează depanator"
 
 #: admin/attach_debugger.html
 #, python-format
 msgid "Attach Debugger on Python %(version_number)s"
-msgstr ""
+msgstr "Atașează depanator pe Python %(version_number)s"
 
 #: admin/attach_debugger.html
 msgid "Start a debugger on port 3000."
-msgstr ""
+msgstr "Pornești un depanator pe portul 3000."
 
 #: admin/attach_debugger.html
 msgid "Waiting for debugger to attach..."
-msgstr ""
+msgstr "Se așteaptă atașarea depanatorului..."
 
 #: admin/attach_debugger.html
 msgid "Start"
-msgstr ""
+msgstr "Pornește"
 
 #: admin/block.html
 msgid "Block IP address"
-msgstr ""
+msgstr "Blochează adresa IP"
 
 #: admin/block.html
 #, python-format
 msgid "IP address %(address)s has been added to the textarea. Please click Save to block that IP."
-msgstr ""
+msgstr "Adresa IP %(address)s a fost adăugată în câmpul de text. Apăsați Salvează pentru a bloca acea adresă IP."
 
 #: admin/block.html
 msgid "Blocked IP Addresses"
-msgstr ""
+msgstr "Adrese IP blocate"
 
 #: admin/graphs.html
 msgid "Performance Graphs"
-msgstr ""
+msgstr "Grafice de performanță"
 
 #: admin/graphs.html
 msgid "Number of Hits"
-msgstr ""
+msgstr "Număr de accesări"
 
 #: admin/graphs.html
 msgid "Page Load Times"
-msgstr ""
+msgstr "Timpi de încărcare a paginii"
 
 #: admin/graphs.html
 msgid "Page Load Times Split"
-msgstr ""
+msgstr "Timpi de încărcare a paginii — detaliu"
 
 #: admin/graphs.html
 msgid "Infobase Mean"
-msgstr ""
+msgstr "Media Infobase"
 
 #: admin/history.html admin/imports.html authors/infobox.html type/author/edit.html
 msgid "Date"


### PR DESCRIPTION
## Summary

Syncs the Romanian (ro) translation file with the current `messages.pot` template and fills in
previously untranslated strings.

**AI attribution:** All new translations in this PR were generated by `claude-sonnet-4-6`. They should
be reviewed by a native speaker before merging, particularly for tone and idiomatic accuracy.
Format strings (`%(name)s`, `%(count)d`, etc.) and HTML markup were preserved verbatim.

## Changes

- Ran `scripts/i18n-messages update ro` to sync with current `messages.pot`
- Filling previously untranslated msgid entries (work in progress — batching ~75 at a time)
- Cleared 5 pre-existing fuzzy entries with placeholder mismatches that caused validation errors
- Left fuzzy entries unchanged (marked for human review)

## Validation

- [x] `i18n-messages validate ro` — 0 errors ✓
- [ ] `i18n-messages compile ro` — in progress
- [ ] `pre-commit run --files openlibrary/i18n/ro/messages.po` — clean

## Reviewer guidance

Please spot-check translations for:
1. Accuracy of meaning
2. Natural phrasing (UI text, not literal translation)
3. Correct plural forms for Romanian
4. Preserved format strings and HTML

🤖 Generated by `claude-sonnet-4-6`