### PR TITLE
feat(books): rename Locate button to Check WorldCat and use Check Options for search/carousels

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -7809,6 +7809,10 @@ msgstr ""
 msgid "Book preview"
 msgstr ""
 
+#: CheckWorldcat.html
+msgid "Check WorldCat"
+msgstr ""
+
 #: DisplayCode.html
 msgid ""
 "Templates in the website are disabled now. Editing them will not have any"

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -7946,8 +7946,12 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
-#: LocateButton.html
-msgid "Locate"
+#: LoanStatus.html
+msgid "Check options for this book."
+msgstr ""
+
+#: LoanStatus.html
+msgid "Check Options"
 msgstr ""
 
 #: ManageWaitlistButton.html

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -7123,8 +7123,12 @@ msgstr ""
 msgid "Only a preview is available."
 msgstr ""
 
-#: LocateButton.html
-msgid "Locate"
+#: LoanStatus.html
+msgid "Check options for this book."
+msgstr ""
+
+#: LoanStatus.html
+msgid "Check Options"
 msgstr ""
 
 #: NotInLibrary.html

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -7006,6 +7006,10 @@ msgstr ""
 msgid "See more about this book on Archive.org"
 msgstr ""
 
+#: CheckWorldcat.html
+msgid "Check WorldCat"
+msgstr ""
+
 #: DisplayCode.html
 msgid "Templates in the website are disabled now. Editing them will not have any effect on the live website."
 msgstr ""

--- a/openlibrary/macros/CheckWorldcat.html
+++ b/openlibrary/macros/CheckWorldcat.html
@@ -7,8 +7,8 @@ $if icon:
     data-ol-link-track="CTAClick|Locate">
 
     <span class="btn-icon map"></span>
-    <span class="btn-label">$_("Locate")</span>
+    <span class="btn-label">$_("Check WorldCat")</span>
   </a>
 $else:
   <a class="cta-btn cta-btn--available cta-btn--external" href="$locateUrl" target="_blank" rel="noopener noreferrer"
-    data-ol-link-track="CTAClick|Locate">$_('Locate')</a>
+    data-ol-link-track="CTAClick|Locate">$_('Check WorldCat')</a>

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -1,4 +1,4 @@
-$def with (doc, work_key=None, listen=True, allow_expensive_availability_check=False, secondary_action=False, check_loan_status=False, user_lists=None, post='', is_book_page=False, analytics_override=None, lending_state=None)
+$def with (doc, work_key=None, listen=True, allow_expensive_availability_check=False, secondary_action=False, check_loan_status=False, user_lists=None, post='', editions_page=False, analytics_override=None, lending_state=None)
 $# Takes following parameters:
 $# * doc - Can be a Work, Edition, or solr dict.
 $# * listen - whether to display listen button
@@ -153,19 +153,20 @@ $elif lending_state == 'preview_only':
   $if secondary_action:
       $:macros.BookSearchInside(ocaid)
 
-$else:
-  $# Only render LocateButton instead of NotInLibrary when not on an edition's page, for that specific edition.
-  $# secondary_action means we're on a book page and it's the button under the cover image.
-  $ edition_key = doc.key.split('/')[2]
-  $if secondary_action:
-      $:macros.LocateButton(edition_key)
-  $elif is_edition:
-      $# Wrapper if locate button is not in read panel
-      <div class="cta-button-group">
-        $:macros.LocateButton(edition_key)
-      </div>
+$elif is_edition:
+  $if editions_page:
+      $:macros.CheckWorldcat(edition_key)
   $else:
-      $:macros.NotInLibrary(None, analytics_attr)
+      <div class="cta-button-group">
+        <a
+            href="$work_key"
+            class="cta-btn cta-btn--unavailable"
+            title="$_('Check options for this book.')"
+        >$_("Check Options")</a>
+      </div>
+
+$else:
+  $:macros.NotInLibrary(None, analytics_attr)
 
 $:post
 

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -1,4 +1,4 @@
-$def with (doc, work_key=None, listen=True, allow_expensive_availability_check=False, secondary_action=False, check_loan_status=False, user_lists=None, post='', is_book_page=False, analytics_override=None, lending_state=None)
+$def with (doc, work_key=None, listen=True, allow_expensive_availability_check=False, secondary_action=False, check_loan_status=False, user_lists=None, post='', editions_page=False, analytics_override=None, lending_state=None)
 $# Takes following parameters:
 $# * doc - Can be a Work, Edition, or solr dict.
 $# * listen - whether to display listen button
@@ -163,19 +163,20 @@ $elif lending_state == 'preview_only':
   $else:
     $:macros.BookPreview(ocaid, show_only=True)
 
-$else:
-  $# Only render LocateButton instead of NotInLibrary when not on an edition's page, for that specific edition.
-  $# secondary_action means we're on a book page and it's the button under the cover image.
-  $ edition_key = doc.key.split('/')[2]
-  $if secondary_action:
-      $:macros.LocateButton(edition_key)
-  $elif is_edition:
-      $# Wrapper if locate button is not in read panel
-      <div class="cta-button-group">
-        $:macros.LocateButton(edition_key)
-      </div>
+$elif is_edition:
+  $if editions_page:
+      $:macros.CheckWorldcat(edition_key)
   $else:
-      $:macros.NotInLibrary(None, analytics_attr)
+      <div class="cta-button-group">
+        <a
+            href="$work_key"
+            class="cta-btn cta-btn--unavailable"
+            title="$_('Check options for this book.')"
+        >$_("Check Options")</a>
+      </div>
+
+$else:
+  $:macros.NotInLibrary(None, analytics_attr)
 
 $:post
 

--- a/openlibrary/macros/ReadButton.html
+++ b/openlibrary/macros/ReadButton.html
@@ -47,7 +47,7 @@ $if any(menu_items) and not is_carousel:
           </li>
         $if edition_key:
           <li>
-            $:macros.LocateButton(edition_key, icon=True)
+            $:macros.CheckWorldcat(edition_key, icon=True)
           </li>
       </ul>
     </details>

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -36,7 +36,7 @@ $ viewbook = "//%s/stream/XXX?ref=ol" % bookreader_host()
         $# if edition availability status is error
         $ render_times['databarWork: LoanStatus'] = time()
         $ expensive_check = page.get('availability', {}).get('status') in ['error']
-        $:macros.LoanStatus(page, allow_expensive_availability_check=expensive_check, secondary_action=editions_page, check_loan_status=editions_page, post=lists_widget, lending_state=lending_state)
+        $:macros.LoanStatus(page, allow_expensive_availability_check=expensive_check, secondary_action=editions_page, check_loan_status=editions_page, post=lists_widget, lending_state=lending_state, editions_page=editions_page)
         $ render_times['databarWork: LoanStatus'] = time() - render_times['databarWork: LoanStatus']
 
         <hr>

--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -90,7 +90,7 @@ $ url = book.get_cover_url("S") or "/static/images/icons/avatar_book-sm.png"
       <div class="links">
         <ul class="read">
           $# render_first is only true on the book page for an edition.
-          <li class="read-option">$:macros.LoanStatus(book, is_book_page=render_first, lending_state=lending_state)</li>
+          <li class="read-option">$:macros.LoanStatus(book, lending_state=lending_state)</li>
         </ul>
       </div>
     </td>


### PR DESCRIPTION
Closes #12105 
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR renames the "Locate" button to "Check WorldCat" on the book/edition page, and changes the label to "Check Options" (pointing back to the book/work page) in search results, carousels, and the editions table when a specific edition is unavailable.

### Technical
<!-- What should be noted about the implementation? -->
- Renamed the `LocateButton.html` macro to `CheckWorldcat.html` and changed user-facing string labels to `Check WorldCat`.
- Created conditional logic inside `LoanStatus.html`:
  - `edition_page=True` (passed from the edition/work view template) renders the `CheckWorldcat` button.
  - When `is_edition` is `True` but it is not on the book page itself (e.g., search results, carousels, editions list), it renders a `Check Options` button linking to the work page (`$work_key`).
- Retained the `CTAClick|Locate` telemetry event action for click analytics to avoid breaking historical dashboards.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Run python template tests:
   `uv run --with-requirements requirements_test.txt pytest openlibrary/tests/test_templates.py`
2. Run standard lint checks:
   `npm run lint`

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="1451" height="521" alt="image" src="https://github.com/user-attachments/assets/5ebcf840-bfee-4542-9031-14c08804359b" />
<img width="327" height="542" alt="image" src="https://github.com/user-attachments/assets/f6695de9-a042-4001-8fcc-7a79ff9df65b" />


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 