### PR TITLE
Migrate merge_authors_json to FastAPI

### DIFF
--- a/openlibrary/asgi_app.py
+++ b/openlibrary/asgi_app.py
@@ -222,6 +222,7 @@ def create_app() -> FastAPI | None:
     from openlibrary.fastapi.internal.api import router as internal_router
     from openlibrary.fastapi.languages import router as languages_router
     from openlibrary.fastapi.lists import router as lists_router
+    from openlibrary.fastapi.merge_authors import router as merge_authors_router
     from openlibrary.fastapi.partials import router as partials_router
     from openlibrary.fastapi.public_my_books import router as public_my_books_router
     from openlibrary.fastapi.publishers import router as publishers_router
@@ -240,6 +241,7 @@ def create_app() -> FastAPI | None:
     app.include_router(internal_router)
     app.include_router(languages_router)
     app.include_router(lists_router)
+    app.include_router(merge_authors_router)
     app.include_router(partials_router)
     app.include_router(public_my_books_router)
     app.include_router(publishers_router)

--- a/openlibrary/fastapi/merge_authors.py
+++ b/openlibrary/fastapi/merge_authors.py
@@ -13,13 +13,13 @@ from pydantic import BaseModel
 
 from infogami.infobase.client import ClientException
 from openlibrary.fastapi.auth import LibrarianDep  # noqa: TC001
-from openlibrary.plugins.upstream.edits import process_merge_request
+from openlibrary.plugins.upstream.edits import perform_merge_update
 from openlibrary.plugins.upstream.merge_authors import (
     AuthorMergeEngine,
     AuthorRedirectEngine,
 )
 from openlibrary.utils.request_context import req_context, web_ctx_ip
-from openlibrary.utils.retry import MaxRetriesExceeded, RetryStrategy
+from openlibrary.utils.retry import MaxRetriesExceeded
 
 router = APIRouter(tags=["merge-authors"])
 
@@ -44,23 +44,8 @@ def merge_authors_json(_: LibrarianDep, data: MergeAuthorsBody) -> Any:
                 detail=json.loads(e.json),
             )
 
-        def update_request() -> None:
-            if data.mrid:
-                rtype = "update-request"
-                update_data: dict[str, Any] = {"action": "approve", "mrid": data.mrid}
-            else:
-                rtype = "create-request"
-                update_data = {"mr_type": 2, "olids": data.olids, "action": "create-merged"}
-            if data.comment:
-                update_data["comment"] = data.comment
-            process_merge_request(rtype, update_data)
-
         try:
-            RetryStrategy(
-                [ClientException],
-                max_retries=5,
-                delay=2,
-            )(update_request)
+            perform_merge_update(mrid=data.mrid, olids=data.olids, comment=data.comment)
         except MaxRetriesExceeded as e:
             raise HTTPException(
                 status_code=400,

--- a/openlibrary/fastapi/merge_authors.py
+++ b/openlibrary/fastapi/merge_authors.py
@@ -33,17 +33,14 @@ class MergeAuthorsBody(BaseModel):
 
 @router.post("/authors/merge.json")
 def merge_authors_json(_: LibrarianDep, data: MergeAuthorsBody) -> Any:
-    def merge_records() -> Any:
-        try:
-            engine = AuthorMergeEngine(AuthorRedirectEngine())
-            return engine.merge(data.master, data.duplicates)
-        except ClientException as e:
-            raise HTTPException(
-                status_code=400,
-                detail=json.loads(e.json),
-            )
-
-    merge_result = merge_records()
+    try:
+        engine = AuthorMergeEngine(AuthorRedirectEngine())
+        merge_result = engine.merge(data.master, data.duplicates)
+    except ClientException as e:
+        raise HTTPException(
+            status_code=400,
+            detail=json.loads(e.json),
+        )
 
     def update_request() -> None:
         if data.mrid:

--- a/openlibrary/fastapi/merge_authors.py
+++ b/openlibrary/fastapi/merge_authors.py
@@ -1,0 +1,71 @@
+"""FastAPI endpoint for merging authors.
+
+Migrated from openlibrary.plugins.upstream.merge_authors.merge_authors_json.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from infogami.infobase.client import ClientException
+from openlibrary.fastapi.auth import LibrarianDep  # noqa: TC001
+from openlibrary.plugins.upstream.edits import process_merge_request
+from openlibrary.plugins.upstream.merge_authors import (
+    AuthorMergeEngine,
+    AuthorRedirectEngine,
+)
+from openlibrary.utils.retry import MaxRetriesExceeded, RetryStrategy
+
+router = APIRouter(tags=["merge-authors"])
+
+
+class MergeAuthorsBody(BaseModel):
+    master: str
+    duplicates: list[str]
+    mrid: str | None = None
+    comment: str | None = None
+    olids: str = ""
+
+
+@router.post("/authors/merge.json")
+def merge_authors_json(_: LibrarianDep, data: MergeAuthorsBody) -> Any:
+    def merge_records() -> Any:
+        try:
+            engine = AuthorMergeEngine(AuthorRedirectEngine())
+            return engine.merge(data.master, data.duplicates)
+        except ClientException as e:
+            raise HTTPException(
+                status_code=400,
+                detail=json.loads(e.json),
+            )
+
+    merge_result = merge_records()
+
+    def update_request() -> None:
+        if data.mrid:
+            rtype = "update-request"
+            update_data: dict[str, Any] = {"action": "approve", "mrid": data.mrid}
+        else:
+            rtype = "create-request"
+            update_data = {"mr_type": 2, "olids": data.olids, "action": "create-merged"}
+        if data.comment:
+            update_data["comment"] = data.comment
+        process_merge_request(rtype, update_data)
+
+    try:
+        RetryStrategy(
+            [ClientException],
+            max_retries=5,
+            delay=2,
+        )(update_request)
+    except MaxRetriesExceeded as e:
+        raise HTTPException(
+            status_code=400,
+            detail=str(e.last_exception),
+        )
+
+    return merge_result

--- a/openlibrary/fastapi/merge_authors.py
+++ b/openlibrary/fastapi/merge_authors.py
@@ -18,6 +18,7 @@ from openlibrary.plugins.upstream.merge_authors import (
     AuthorMergeEngine,
     AuthorRedirectEngine,
 )
+from openlibrary.utils.request_context import req_context, web_ctx_ip
 from openlibrary.utils.retry import MaxRetriesExceeded, RetryStrategy
 
 router = APIRouter(tags=["merge-authors"])
@@ -33,36 +34,37 @@ class MergeAuthorsBody(BaseModel):
 
 @router.post("/authors/merge.json")
 def merge_authors_json(_: LibrarianDep, data: MergeAuthorsBody) -> Any:
-    try:
-        engine = AuthorMergeEngine(AuthorRedirectEngine())
-        merge_result = engine.merge(data.master, data.duplicates)
-    except ClientException as e:
-        raise HTTPException(
-            status_code=400,
-            detail=json.loads(e.json),
-        )
+    with web_ctx_ip(req_context.get().x_forwarded_for or "127.0.0.1"):
+        try:
+            engine = AuthorMergeEngine(AuthorRedirectEngine())
+            merge_result = engine.merge(data.master, data.duplicates)
+        except ClientException as e:
+            raise HTTPException(
+                status_code=400,
+                detail=json.loads(e.json),
+            )
 
-    def update_request() -> None:
-        if data.mrid:
-            rtype = "update-request"
-            update_data: dict[str, Any] = {"action": "approve", "mrid": data.mrid}
-        else:
-            rtype = "create-request"
-            update_data = {"mr_type": 2, "olids": data.olids, "action": "create-merged"}
-        if data.comment:
-            update_data["comment"] = data.comment
-        process_merge_request(rtype, update_data)
+        def update_request() -> None:
+            if data.mrid:
+                rtype = "update-request"
+                update_data: dict[str, Any] = {"action": "approve", "mrid": data.mrid}
+            else:
+                rtype = "create-request"
+                update_data = {"mr_type": 2, "olids": data.olids, "action": "create-merged"}
+            if data.comment:
+                update_data["comment"] = data.comment
+            process_merge_request(rtype, update_data)
 
-    try:
-        RetryStrategy(
-            [ClientException],
-            max_retries=5,
-            delay=2,
-        )(update_request)
-    except MaxRetriesExceeded as e:
-        raise HTTPException(
-            status_code=400,
-            detail=str(e.last_exception),
-        )
+        try:
+            RetryStrategy(
+                [ClientException],
+                max_retries=5,
+                delay=2,
+            )(update_request)
+        except MaxRetriesExceeded as e:
+            raise HTTPException(
+                status_code=400,
+                detail=str(e.last_exception),
+            )
 
     return merge_result

--- a/openlibrary/plugins/openlibrary/js/merge.js
+++ b/openlibrary/plugins/openlibrary/js/merge.js
@@ -91,6 +91,7 @@ export function initAuthorView() {
     $.ajax({
         url: '/authors/merge.json',
         type: 'POST',
+        contentType: 'application/json',
         data: JSON.stringify(data),
         error: function() {
             $('#preMerge').fadeOut();

--- a/openlibrary/plugins/upstream/edits.py
+++ b/openlibrary/plugins/upstream/edits.py
@@ -9,6 +9,7 @@ from infogami.utils import delegate
 from infogami.utils.view import render_template
 from openlibrary import accounts
 from openlibrary.core.edits import ApiMode, CommunityEditsQueue, get_status_for_view
+from openlibrary.utils.request_context import site
 
 # Usergroups that may use create or update merge requests
 ALLOWED_USERGROUPS: list[str] = [
@@ -203,12 +204,12 @@ class community_edits_queue(delegate.page):
     def create_title(mr_type: int, olids: list[str]) -> str:
         if mr_type == CommunityEditsQueue.TYPE["WORK_MERGE"]:
             for olid in olids:
-                book = web.ctx.site.get(f"/works/{olid}")
+                book = site.get().get(f"/works/{olid}")
                 if book and book.title:
                     return book.title
         elif mr_type == CommunityEditsQueue.TYPE["AUTHOR_MERGE"]:
             for olid in olids:
-                author = web.ctx.site.get(f"/authors/{olid}")
+                author = site.get().get(f"/authors/{olid}")
                 if author and author.name:
                     return author.name
         return "Unknown record"

--- a/openlibrary/plugins/upstream/edits.py
+++ b/openlibrary/plugins/upstream/edits.py
@@ -5,11 +5,13 @@ from typing import Literal
 
 import web
 
+from infogami.infobase.client import ClientException
 from infogami.utils import delegate
 from infogami.utils.view import render_template
 from openlibrary import accounts
 from openlibrary.core.edits import ApiMode, CommunityEditsQueue, get_status_for_view
 from openlibrary.utils.request_context import site
+from openlibrary.utils.retry import RetryStrategy
 
 # Usergroups that may use create or update merge requests
 ALLOWED_USERGROUPS: list[str] = [
@@ -34,6 +36,45 @@ def process_merge_request(rtype, data):
     else:
         resp = response(status="error", error="Unknown request type")
     return resp
+
+
+def perform_merge_update(mrid: str | None, olids: str, comment: str | None) -> None:
+    """Orchestrate the merge request update with retries.
+
+    Builds the appropriate request type and data, then attempts to process
+    the merge request with retry logic.
+
+    Args:
+        mrid: Merge request ID to approve, or None to create a new request.
+        olids: Comma-separated author keys (used when creating a new request).
+        comment: Optional comment for the merge request.
+
+    Raises:
+        MaxRetriesExceeded: If all retry attempts to process the request fail.
+    """
+
+    def update_request() -> None:
+        if mrid:
+            process_merge_request(
+                "update-request",
+                {
+                    "action": "approve",
+                    "mrid": mrid,
+                    **({"comment": comment} if comment else {}),
+                },
+            )
+        else:
+            process_merge_request(
+                "create-request",
+                {
+                    "mr_type": 2,
+                    "olids": olids,
+                    "action": "create-merged",
+                    **({"comment": comment} if comment else {}),
+                },
+            )
+
+    RetryStrategy([ClientException], max_retries=5, delay=2)(update_request)
 
 
 class community_edits_queue(delegate.page):

--- a/openlibrary/plugins/upstream/merge_authors.py
+++ b/openlibrary/plugins/upstream/merge_authors.py
@@ -11,11 +11,11 @@ from infogami.infobase.client import ClientException
 from infogami.utils import delegate
 from infogami.utils.view import render_template, safeint
 from openlibrary.accounts import get_current_user
-from openlibrary.plugins.upstream.edits import process_merge_request
+from openlibrary.plugins.upstream.edits import perform_merge_update, process_merge_request
 from openlibrary.plugins.worksearch.code import top_books_from_author
 from openlibrary.utils import dicthash, uniq
 from openlibrary.utils.request_context import site
-from openlibrary.utils.retry import MaxRetriesExceeded, RetryStrategy
+from openlibrary.utils.retry import MaxRetriesExceeded
 
 
 class BasicRedirectEngine:
@@ -336,29 +336,11 @@ class merge_authors_json(delegate.page):
             except ClientException as e:
                 raise web.badrequest(json.loads(e.json))
 
-        def update_request() -> None:
-            data = {}
-            if mrid:
-                # Update the request
-                rtype = "update-request"
-                data = {"action": "approve", "mrid": mrid}
-            else:
-                # Create new request
-                rtype = "create-request"
-                data = {"mr_type": 2, "olids": olids, "action": "create-merged"}
-            if comment:
-                data["comment"] = comment
-            process_merge_request(rtype, data)
-
         # actually perform merge and save affected records to db
         merge_result = merge_records()
         # attempt to update the merge request status with retries
         try:
-            RetryStrategy(
-                [ClientException],
-                max_retries=5,
-                delay=2,
-            )(update_request)
+            perform_merge_update(mrid=mrid, olids=olids, comment=comment)
         except MaxRetriesExceeded as e:
             raise web.badrequest(str(e.last_exception))
         return delegate.RawText(json.dumps(merge_result), content_type="application/json")

--- a/openlibrary/plugins/upstream/merge_authors.py
+++ b/openlibrary/plugins/upstream/merge_authors.py
@@ -3,6 +3,7 @@
 import json
 import re
 from typing import Any
+from warnings import deprecated
 
 import web
 
@@ -13,6 +14,7 @@ from openlibrary.accounts import get_current_user
 from openlibrary.plugins.upstream.edits import process_merge_request
 from openlibrary.plugins.worksearch.code import top_books_from_author
 from openlibrary.utils import dicthash, uniq
+from openlibrary.utils.request_context import site
 from openlibrary.utils.retry import MaxRetriesExceeded, RetryStrategy
 
 
@@ -87,7 +89,7 @@ class BasicMergeEngine:
         docs_to_save.extend(self.redirect_engine.make_redirects(master, duplicates))
 
         # Merge all the duplicates into the master.
-        master_doc = web.ctx.site.get(master).dict()
+        master_doc = site.get().get(master).dict()
         dups = get_many(duplicates)
         for d in dups:
             master_doc = self.merge_docs(master_doc, d)
@@ -125,12 +127,12 @@ class BasicMergeEngine:
 class AuthorRedirectEngine(BasicRedirectEngine):
     def find_references(self, key):
         q = {"type": "/type/edition", "authors": key, "limit": 10000}
-        edition_keys = web.ctx.site.things(q)
+        edition_keys = site.get().things(q)
         editions = get_many(edition_keys)
         work_keys_1 = [w["key"] for e in editions for w in e.get("works", [])]
 
         q = {"type": "/type/work", "authors": {"author": {"key": key}}, "limit": 10000}
-        work_keys_2 = web.ctx.site.things(q)
+        work_keys_2 = site.get().things(q)
         return edition_keys + work_keys_1 + work_keys_2
 
 
@@ -146,7 +148,7 @@ class AuthorMergeEngine(BasicMergeEngine):
         return master
 
     def save(self, docs, master, duplicates):
-        return web.ctx.site.save_many(
+        return site.get().save_many(
             docs,
             comment="merge authors",
             action="merge-authors",
@@ -200,7 +202,7 @@ def get_many(keys: list[str]) -> list[dict]:
             doc["table_of_contents"] = fix_table_of_contents(doc["table_of_contents"])
         return doc
 
-    return [process(thing.dict()) for thing in web.ctx.site.get_many(list(keys))]
+    return [process(thing.dict()) for thing in site.get().get_many(list(keys))]
 
 
 def make_redirect_doc(key, redirect):
@@ -211,11 +213,11 @@ class merge_authors(delegate.page):
     path = "/authors/merge"
 
     def is_enabled(self):
-        user = web.ctx.site.get_user()
+        user = site.get().get_user()
         return "merge-authors" in web.ctx.features or (user and user.is_admin())
 
     def filter_authors(self, keys):
-        docs = web.ctx.site.get_many(["/authors/" + k for k in keys])
+        docs = site.get().get_many(["/authors/" + k for k in keys])
         d = {doc.key: doc.type.key for doc in docs}
         return [k for k in keys if d.get("/authors/" + k) == "/type/author"]
 
@@ -305,6 +307,7 @@ class merge_authors(delegate.page):
             raise web.seeother(redir_url)
 
 
+@deprecated("migrated to fastapi")
 class merge_authors_json(delegate.page):
     """JSON API for merge authors.
 
@@ -315,7 +318,7 @@ class merge_authors_json(delegate.page):
     encoding = "json"
 
     def is_enabled(self):
-        user = web.ctx.site.get_user()
+        user = site.get().get_user()
         return "merge-authors" in web.ctx.features or (user and user.is_admin())
 
     def POST(self):

--- a/openlibrary/plugins/upstream/tests/test_merge_authors.py
+++ b/openlibrary/plugins/upstream/tests/test_merge_authors.py
@@ -12,6 +12,7 @@ from openlibrary.plugins.upstream.merge_authors import (
     space_squash_and_strip,
 )
 from openlibrary.utils import dicthash
+from openlibrary.utils.request_context import site
 
 
 def setup_module(mod):
@@ -137,6 +138,7 @@ class TestBasicMergeEngine:
 
 def test_get_many():
     web.ctx.site = MockSite()
+    site.set(web.ctx.site)
     # get_many should handle bad table_of_contents in the edition.
     edition = {
         "key": "/books/OL1M",
@@ -158,6 +160,7 @@ def test_get_many():
 class TestAuthorRedirectEngine:
     def setup_method(self, method):
         web.ctx.site = MockSite()
+        site.set(web.ctx.site)
 
     def test_fix_edition(self):
         update_references = AuthorRedirectEngine().update_references
@@ -223,6 +226,7 @@ class TestAuthorMergeEngine:
     def setup_method(self, method):
         self.engine = AuthorMergeEngine(AuthorRedirectEngine())
         web.ctx.site = MockSite()
+        site.set(web.ctx.site)
 
     def test_redirection(self):
         web.ctx.site.add([TEST_AUTHORS.a, TEST_AUTHORS.b, TEST_AUTHORS.c])

--- a/openlibrary/tests/fastapi/test_merge_authors.py
+++ b/openlibrary/tests/fastapi/test_merge_authors.py
@@ -1,0 +1,281 @@
+"""Tests for POST /authors/merge.json (FastAPI merge_authors_json endpoint)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from infogami.infobase.client import ClientException
+from openlibrary.utils.request_context import RequestContextVars, req_context, site
+
+
+@pytest.fixture(autouse=True)
+def _setup_request_context():
+    """Set ContextVars so require_librarian -> get_current_user() works."""
+    site.set(MagicMock())
+    req_context.set(
+        RequestContextVars(
+            x_forwarded_for=None,
+            user_agent=None,
+            lang="en",
+            solr_editions=True,
+            print_disabled=False,
+        )
+    )
+
+
+@pytest.fixture
+def mock_user_factory(monkeypatch):
+    """Factory fixture to create and mock users with configurable roles.
+
+    Usage:
+        mock_user_factory(is_admin=True)
+    """
+
+    def create_user(
+        is_admin: bool = False,
+        is_librarian: bool = False,
+        is_super_librarian: bool = False,
+    ):
+        user = MagicMock()
+        user.is_admin.return_value = is_admin
+        user.is_librarian.return_value = is_librarian
+        user.is_super_librarian.return_value = is_super_librarian
+        monkeypatch.setattr(
+            "openlibrary.fastapi.auth.get_current_user",
+            lambda: user,
+        )
+        return user
+
+    return create_user
+
+
+@pytest.fixture
+def mock_merge_engine():
+    """Mock the AuthorMergeEngine to avoid actual DB calls."""
+    with patch(
+        "openlibrary.fastapi.merge_authors.AuthorMergeEngine",
+        autospec=True,
+    ) as mock:
+        instance = mock.return_value
+        instance.merge.return_value = [
+            {"key": "/authors/OL1A", "revision": 2},
+        ]
+        yield instance
+
+
+@pytest.fixture
+def mock_process_merge_request():
+    """Mock process_merge_request to avoid actual merge request creation."""
+    with patch(
+        "openlibrary.fastapi.merge_authors.process_merge_request",
+        autospec=True,
+    ) as mock:
+        yield mock
+
+
+class TestMergeAuthorsJson:
+    def test_merge_success(
+        self,
+        fastapi_client,
+        mock_authenticated_user,
+        mock_user_factory,
+        mock_merge_engine,
+        mock_process_merge_request,
+    ):
+        """Admin user can merge authors successfully."""
+        mock_user_factory(is_admin=True)
+
+        response = fastapi_client.post(
+            "/authors/merge.json",
+            json={
+                "master": "/authors/OL1A",
+                "duplicates": ["/authors/OL2A", "/authors/OL3A"],
+                "comment": "merging duplicates",
+            },
+        )
+        assert response.status_code == 200
+        assert response.json() == [
+            {"key": "/authors/OL1A", "revision": 2},
+        ]
+        mock_merge_engine.merge.assert_called_once_with(
+            "/authors/OL1A",
+            ["/authors/OL2A", "/authors/OL3A"],
+        )
+        mock_process_merge_request.assert_called_once()
+
+    def test_merge_success_with_mrid(
+        self,
+        fastapi_client,
+        mock_authenticated_user,
+        mock_user_factory,
+        mock_merge_engine,
+        mock_process_merge_request,
+    ):
+        """Admin user can merge authors with an existing merge request ID."""
+        mock_user_factory(is_admin=True)
+
+        response = fastapi_client.post(
+            "/authors/merge.json",
+            json={
+                "master": "/authors/OL1A",
+                "duplicates": ["/authors/OL2A"],
+                "mrid": "123",
+                "comment": "approving merge request",
+            },
+        )
+        assert response.status_code == 200
+        mock_process_merge_request.assert_called_once_with(
+            "update-request",
+            {"action": "approve", "mrid": "123", "comment": "approving merge request"},
+        )
+
+    def test_merge_success_without_mrid_creates_request(
+        self,
+        fastapi_client,
+        mock_authenticated_user,
+        mock_user_factory,
+        mock_merge_engine,
+        mock_process_merge_request,
+    ):
+        """When no mrid is provided, a new merge request record is created."""
+        mock_user_factory(is_admin=True)
+
+        response = fastapi_client.post(
+            "/authors/merge.json",
+            json={
+                "master": "/authors/OL1A",
+                "duplicates": ["/authors/OL2A"],
+                "olids": "/authors/OL1A,/authors/OL2A",
+            },
+        )
+        assert response.status_code == 200
+        mock_process_merge_request.assert_called_once_with(
+            "create-request",
+            {
+                "mr_type": 2,
+                "olids": "/authors/OL1A,/authors/OL2A",
+                "action": "create-merged",
+            },
+        )
+
+    def test_merge_unauthenticated(self, fastapi_client):
+        """Unauthenticated request returns 401 (from require_authenticated_user)."""
+        response = fastapi_client.post(
+            "/authors/merge.json",
+            json={
+                "master": "/authors/OL1A",
+                "duplicates": ["/authors/OL2A"],
+            },
+        )
+        assert response.status_code == 401
+
+    def test_merge_forbidden_non_librarian(
+        self,
+        fastapi_client,
+        mock_authenticated_user,
+        mock_user_factory,
+    ):
+        """Regular user without librarian/admin role cannot merge authors."""
+        mock_user_factory(
+            is_admin=False,
+            is_librarian=False,
+            is_super_librarian=False,
+        )
+
+        response = fastapi_client.post(
+            "/authors/merge.json",
+            json={
+                "master": "/authors/OL1A",
+                "duplicates": ["/authors/OL2A"],
+            },
+        )
+        assert response.status_code == 403
+
+    def test_merge_allowed_for_librarian(
+        self,
+        fastapi_client,
+        mock_authenticated_user,
+        mock_user_factory,
+        mock_merge_engine,
+        mock_process_merge_request,
+    ):
+        """Librarian (not admin) can merge authors."""
+        mock_user_factory(
+            is_admin=False,
+            is_librarian=True,
+            is_super_librarian=False,
+        )
+
+        response = fastapi_client.post(
+            "/authors/merge.json",
+            json={
+                "master": "/authors/OL1A",
+                "duplicates": ["/authors/OL2A"],
+            },
+        )
+        assert response.status_code == 200
+
+    def test_merge_allowed_for_super_librarian(
+        self,
+        fastapi_client,
+        mock_authenticated_user,
+        mock_user_factory,
+        mock_merge_engine,
+        mock_process_merge_request,
+    ):
+        """Super librarian can merge authors."""
+        mock_user_factory(
+            is_admin=False,
+            is_librarian=False,
+            is_super_librarian=True,
+        )
+
+        response = fastapi_client.post(
+            "/authors/merge.json",
+            json={
+                "master": "/authors/OL1A",
+                "duplicates": ["/authors/OL2A"],
+            },
+        )
+        assert response.status_code == 200
+
+    def test_merge_raises_400_on_client_exception(
+        self,
+        fastapi_client,
+        mock_authenticated_user,
+        mock_user_factory,
+        mock_merge_engine,
+        mock_process_merge_request,
+    ):
+        """ClientException from AuthorMergeEngine returns 400 with parsed error body."""
+        mock_user_factory(is_admin=True)
+        mock_merge_engine.merge.side_effect = ClientException(
+            "400 Bad Request",
+            "internal error",
+            '{"error": "not_found", "message": "internal error"}',
+        )
+        response = fastapi_client.post(
+            "/authors/merge.json",
+            json={"master": "/authors/OL1A", "duplicates": ["/authors/OL999A"]},
+        )
+        assert response.status_code == 400
+        assert response.json() == {"detail": {"error": "not_found", "message": "internal error"}}
+
+    def test_merge_raises_400_when_retries_exhausted(
+        self,
+        fastapi_client,
+        mock_authenticated_user,
+        mock_user_factory,
+        mock_merge_engine,
+        mock_process_merge_request,
+        monkeytime,
+    ):
+        """When process_merge_request keeps failing, retries are exhausted and 400 is returned."""
+        mock_user_factory(is_admin=True)
+        mock_process_merge_request.side_effect = ClientException("400 Bad Request", "retry error")
+        response = fastapi_client.post(
+            "/authors/merge.json",
+            json={"master": "/authors/OL1A", "duplicates": ["/authors/OL2A"]},
+        )
+        assert response.status_code == 400
+        assert "retry error" in response.json()["detail"]

--- a/openlibrary/tests/fastapi/test_merge_authors.py
+++ b/openlibrary/tests/fastapi/test_merge_authors.py
@@ -67,7 +67,7 @@ def mock_merge_engine():
 def mock_process_merge_request():
     """Mock process_merge_request to avoid actual merge request creation."""
     with patch(
-        "openlibrary.fastapi.merge_authors.process_merge_request",
+        "openlibrary.plugins.upstream.edits.process_merge_request",
         autospec=True,
     ) as mock:
         yield mock


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR migrates the merge_authors_json web.py handler to FastAPI.

### Technical
<!-- What should be noted about the implementation? -->
- Add`MergeAuthorsBody` Pydantic model for request validation
- Uses shared `LibrarianDep` dependency injection for auth
- Replaced `web.ctx.site` → `site.get()` ContextVar in `merge_authors.py` and `edits.py`
- Marked legacy class with `@deprecated`

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
```
docker compose run --rm home pytest openlibrary/tests/fastapi/test_merge_authors.py -v
```
Login:
```
curl -s -c /tmp/cookies.txt -X POST "http://localhost:8080/account/login.json" \
  -H "Content-Type: application/json" \
  -d '{"username":"openlibrary","password":"openlibrary"}'
```
POST merge authenticated → 200:
```
curl -s -b /tmp/cookies.txt -X POST "http://localhost:18080/authors/merge.json" \
  -H "Content-Type: application/json" \
  -d '{"master": "/authors/OL1A", "duplicates": ["/authors/OL2A"]}'
```
POST unauthenticated → 401:
```
curl -s -w "\nHTTP %{http_code}" -X POST "http://localhost:18080/authors/merge.json" \
  -H "Content-Type: application/json" \
  -d '{"master": "/authors/OL1A", "duplicates": ["/authors/OL2A"]}'
```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
