### PR TITLE
Adding primitive support for likes #12768

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -26,6 +26,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      db-schema:
+        condition: service_completed_successfully
       infobase:
         condition: service_started
       mockservices:
@@ -108,6 +110,30 @@ services:
       timeout: 1s
       retries: 24
 
+  # Idempotently (re-)applies openlibrary/core/schema.sql on every `docker
+  # compose up`, not just fresh volumes. `ol-db-init.sh` only runs once, via
+  # Postgres's own docker-entrypoint-initdb.d convention, which is skipped
+  # entirely once the data directory already exists -- so a long-running dev
+  # DB volume never picks up new tables/indexes added to schema.sql without
+  # this. Safe to re-run: every statement in schema.sql is IF-NOT-EXISTS or
+  # guarded with a WHERE NOT EXISTS check.
+  db-schema:
+    image: postgres:${POSTGRES_VERSION:-18.3}
+    networks:
+      - dbnet
+    environment:
+      - PGHOST=db
+      - PGUSER=openlibrary
+      - PGDATABASE=openlibrary
+    volumes:
+      - ${OL_MOUNT_DIR:-.}:/openlibrary
+    working_dir: /openlibrary
+    depends_on:
+      db:
+        condition: service_healthy
+    command: ["psql", "-v", "ON_ERROR_STOP=1", "-f", "openlibrary/core/schema.sql"]
+    restart: "no"
+
   covers:
     build:
       context: .
@@ -135,6 +161,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      db-schema:
+        condition: service_completed_successfully
 
   home:
     image: "${OLIMAGE:-oldev:latest}"
@@ -164,6 +192,8 @@ services:
         condition: service_healthy
       db:
         condition: service_healthy
+      db-schema:
+        condition: service_completed_successfully
 
   mockservices:
     build:

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -26,8 +26,6 @@ services:
     depends_on:
       db:
         condition: service_healthy
-      db-schema:
-        condition: service_completed_successfully
       infobase:
         condition: service_started
       mockservices:
@@ -110,30 +108,6 @@ services:
       timeout: 1s
       retries: 24
 
-  # Idempotently (re-)applies openlibrary/core/schema.sql on every `docker
-  # compose up`, not just fresh volumes. `ol-db-init.sh` only runs once, via
-  # Postgres's own docker-entrypoint-initdb.d convention, which is skipped
-  # entirely once the data directory already exists -- so a long-running dev
-  # DB volume never picks up new tables/indexes added to schema.sql without
-  # this. Safe to re-run: every statement in schema.sql is IF-NOT-EXISTS or
-  # guarded with a WHERE NOT EXISTS check.
-  db-schema:
-    image: postgres:${POSTGRES_VERSION:-18.3}
-    networks:
-      - dbnet
-    environment:
-      - PGHOST=db
-      - PGUSER=openlibrary
-      - PGDATABASE=openlibrary
-    volumes:
-      - ${OL_MOUNT_DIR:-.}:/openlibrary
-    working_dir: /openlibrary
-    depends_on:
-      db:
-        condition: service_healthy
-    command: ["psql", "-v", "ON_ERROR_STOP=1", "-f", "openlibrary/core/schema.sql"]
-    restart: "no"
-
   covers:
     build:
       context: .
@@ -161,8 +135,6 @@ services:
     depends_on:
       db:
         condition: service_healthy
-      db-schema:
-        condition: service_completed_successfully
 
   home:
     image: "${OLIMAGE:-oldev:latest}"
@@ -192,8 +164,6 @@ services:
         condition: service_healthy
       db:
         condition: service_healthy
-      db-schema:
-        condition: service_completed_successfully
 
   mockservices:
     build:

--- a/openlibrary/core/likes.py
+++ b/openlibrary/core/likes.py
@@ -1,14 +1,16 @@
-import logging  
+import logging
+
 from . import db
 
 logger = logging.getLogger(__name__)
+
 
 class Likes:
     TABLENAME = "likes"
     PRIMARY_KEY = ("username", "key")
 
-# TODO : likes on redirected/merged keys may not resolve correctly.
-# See resolve_redirects_bulk for handling this gap.
+    # TODO : likes on redirected/merged keys may not resolve correctly.
+    # See resolve_redirects_bulk for handling this gap.
 
     @classmethod
     def like(cls, username: str, key: str, value: int = 1) -> None:
@@ -29,6 +31,7 @@ class Likes:
                 vars={"username": username, "key": key},
                 value=value,
             )
+
     @classmethod
     def unlike(cls, username: str, key: str) -> None:
         oldb = db.get_db()
@@ -38,21 +41,18 @@ class Likes:
                 where="username=$username AND key=$key",
                 vars={"username": username, "key": key},
             )
-    
+
     @classmethod
     def dislike(cls, username: str, key: str) -> None:
-            cls.like(username, key, value=-1)
-            
-      
+        cls.like(username, key, value=-1)
+
     @classmethod
     def get_count(cls, key: str) -> dict[str, int]:
-       oldb = db.get_db()
-       likes_count = oldb.query(
-           "SELECT value, COUNT(*) as count FROM likes WHERE key=$key AND value=1 GROUP BY value", vars={"key": key})
-       dislike_count = oldb.query(
-           "SELECT value, COUNT(*) as count FROM likes WHERE key=$key AND value=-1 GROUP BY value", vars={"key": key})
-       return {"likes": likes_count[0]["count"] if likes_count else 0, "dislikes": dislike_count[0]["count"] if dislike_count else 0}
-    
+        oldb = db.get_db()
+        likes_count = oldb.query("SELECT value, COUNT(*) as count FROM likes WHERE key=$key AND value=1 GROUP BY value", vars={"key": key})
+        dislike_count = oldb.query("SELECT value, COUNT(*) as count FROM likes WHERE key=$key AND value=-1 GROUP BY value", vars={"key": key})
+        return {"likes": likes_count[0]["count"] if likes_count else 0, "dislikes": dislike_count[0]["count"] if dislike_count else 0}
+
     @classmethod
     def get_for_patron(cls, username: str, limit: int = 50, offset: int = 0) -> list:
         """Return all likes by a patron, paginated."""
@@ -65,7 +65,6 @@ class Likes:
             offset=offset,
         )
         return list(likes)
-        
 
     @classmethod
     def patron_liked(cls, username: str, key: str) -> bool:
@@ -76,5 +75,5 @@ class Likes:
             where="username=$username AND key=$key",
             vars={"username": username, "key": key},
             limit=1,
-       )
+        )
         return len(like) > 0

--- a/openlibrary/core/likes.py
+++ b/openlibrary/core/likes.py
@@ -1,0 +1,80 @@
+import logging  
+from . import db
+
+logger = logging.getLogger(__name__)
+
+class Likes:
+    TABLENAME = "likes"
+    PRIMARY_KEY = ("username", "key")
+
+# TODO : likes on redirected/merged keys may not resolve correctly.
+# See resolve_redirects_bulk for handling this gap.
+
+    @classmethod
+    def like(cls, username: str, key: str, value: int = 1) -> None:
+        if value not in (1, -1):
+            raise ValueError("value must be 1 (like) or -1 (dislike)")
+        oldb = db.get_db()
+        if not cls.patron_liked(username, key):
+            oldb.insert(
+                cls.TABLENAME,
+                username=username,
+                key=key,
+                value=value,
+            )
+        else:
+            oldb.update(
+                cls.TABLENAME,
+                where="username=$username AND key=$key",
+                vars={"username": username, "key": key},
+                value=value,
+            )
+    @classmethod
+    def unlike(cls, username: str, key: str) -> None:
+        oldb = db.get_db()
+        if cls.patron_liked(username, key):
+            oldb.delete(
+                cls.TABLENAME,
+                where="username=$username AND key=$key",
+                vars={"username": username, "key": key},
+            )
+    
+    @classmethod
+    def dislike(cls, username: str, key: str) -> None:
+            cls.like(username, key, value=-1)
+            
+      
+    @classmethod
+    def get_count(cls, key: str) -> dict[str, int]:
+       oldb = db.get_db()
+       likes_count = oldb.query(
+           "SELECT value, COUNT(*) as count FROM likes WHERE key=$key AND value=1 GROUP BY value", vars={"key": key})
+       dislike_count = oldb.query(
+           "SELECT value, COUNT(*) as count FROM likes WHERE key=$key AND value=-1 GROUP BY value", vars={"key": key})
+       return {"likes": likes_count[0]["count"] if likes_count else 0, "dislikes": dislike_count[0]["count"] if dislike_count else 0}
+    
+    @classmethod
+    def get_for_patron(cls, username: str, limit: int = 50, offset: int = 0) -> list:
+        """Return all likes by a patron, paginated."""
+        oldb = db.get_db()
+        likes = oldb.select(
+            cls.TABLENAME,
+            where="username=$username",
+            vars={"username": username},
+            limit=limit,
+            offset=offset,
+        )
+        return list(likes)
+        
+
+    @classmethod
+    def patron_liked(cls, username: str, key: str) -> bool:
+        """Return whether the patron has liked this key."""
+        oldb = db.get_db()
+        like = oldb.select(
+            cls.TABLENAME,
+            where="username=$username AND key=$key",
+            vars={"username": username, "key": key},
+            limit=1,
+       )
+        return len(like) > 0

--- a/openlibrary/core/likes.py
+++ b/openlibrary/core/likes.py
@@ -11,8 +11,16 @@ class Likes:
     TABLENAME = "likes"
     PRIMARY_KEY = ("username", "key")
 
-    # TODO : likes on redirected/merged keys may not resolve correctly.
-    # See resolve_redirects_bulk for handling this gap.
+    # Scope decision (2026-07-29): `key` is intentionally not restricted to any
+    # object type. For now, `likes` is intended for lists, and possibly future
+    # prompts/activity-feed events -- NOT works, editions, or authors. Those
+    # object types go through librarian merge/redirect (see
+    # Work.resolve_redirects_bulk in core/models.py), which `likes` does not
+    # hook into -- a like on a merged work/author/edition key would silently
+    # orphan. If a future change extends `likes` to cover those types, this
+    # gap needs to be closed first (either by wiring Likes into the existing
+    # work-redirect resolution, or -- for authors -- building an equivalent
+    # resolver, since none exists for any feature today).
 
     @classmethod
     def like(cls, username: str, key: str, value: int = 1) -> None:

--- a/openlibrary/core/likes.py
+++ b/openlibrary/core/likes.py
@@ -1,5 +1,7 @@
 import logging
 
+import web
+
 from . import db
 
 logger = logging.getLogger(__name__)
@@ -30,6 +32,7 @@ class Likes:
                 where="username=$username AND key=$key",
                 vars={"username": username, "key": key},
                 value=value,
+                modified=web.db.SQLLiteral("CURRENT_TIMESTAMP"),
             )
 
     @classmethod

--- a/openlibrary/core/schema.sql
+++ b/openlibrary/core/schema.sql
@@ -17,6 +17,17 @@ CREATE TABLE follows (
     created timestamp without time zone default (current_timestamp at time zone 'utc'),
     primary key (subscriber, publisher)
 );
+CREATE TABLE likes (
+    username    TEXT        NOT NULL,
+    key         TEXT        NOT NULL,   -- full infogami key, e.g. /works/OL123W
+    value       SMALLINT    NOT NULL DEFAULT 1 CHECK (value IN (1, -1)),
+    created     TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    modified    TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (username, key)
+);
+CREATE INDEX likes_key_idx      ON likes (key);
+CREATE INDEX likes_username_idx ON likes (username);
+
 CREATE INDEX subscriber_idx ON follows (subscriber);
 CREATE INDEX publisher_idx ON follows (publisher);
 

--- a/openlibrary/core/schema.sql
+++ b/openlibrary/core/schema.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS ratings (
+CREATE TABLE ratings (
     username text NOT NULL,
     work_id integer NOT NULL,
     rating integer,
@@ -7,9 +7,9 @@ CREATE TABLE IF NOT EXISTS ratings (
     created timestamp without time zone default (current_timestamp at time zone 'utc'),
     primary key (username, work_id)
 );
-CREATE INDEX IF NOT EXISTS ratings_work_id_idx ON ratings (work_id);
+CREATE INDEX ratings_work_id_idx ON ratings (work_id);
 
-CREATE TABLE IF NOT EXISTS follows (
+CREATE TABLE follows (
     subscriber text NOT NULL,
     publisher text NOT NULL,
     disabled BOOLEAN DEFAULT FALSE,
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS follows (
     created timestamp without time zone default (current_timestamp at time zone 'utc'),
     primary key (subscriber, publisher)
 );
-CREATE TABLE IF NOT EXISTS likes (
+CREATE TABLE likes (
     username    TEXT        NOT NULL,
     key         TEXT        NOT NULL,   -- full infogami key, e.g. /works/OL123W
     value       SMALLINT    NOT NULL DEFAULT 1 CHECK (value IN (1, -1)),
@@ -25,13 +25,13 @@ CREATE TABLE IF NOT EXISTS likes (
     modified    TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (username, key)
 );
-CREATE INDEX IF NOT EXISTS likes_key_idx      ON likes (key);
-CREATE INDEX IF NOT EXISTS likes_username_idx ON likes (username);
+CREATE INDEX likes_key_idx      ON likes (key);
+CREATE INDEX likes_username_idx ON likes (username);
 
-CREATE INDEX IF NOT EXISTS subscriber_idx ON follows (subscriber);
-CREATE INDEX IF NOT EXISTS publisher_idx ON follows (publisher);
+CREATE INDEX subscriber_idx ON follows (subscriber);
+CREATE INDEX publisher_idx ON follows (publisher);
 
-CREATE TABLE IF NOT EXISTS booknotes (
+CREATE TABLE booknotes (
     username text NOT NULL,
     work_id integer NOT NULL,
     edition_id integer NOT NULL default -1,
@@ -40,9 +40,9 @@ CREATE TABLE IF NOT EXISTS booknotes (
     created timestamp without time zone default (current_timestamp at time zone 'utc'),
     primary key (username, work_id, edition_id)
 );
-CREATE INDEX IF NOT EXISTS booknotes_work_id_idx ON booknotes (work_id);
+CREATE INDEX booknotes_work_id_idx ON booknotes (work_id);
 
-CREATE TABLE IF NOT EXISTS bookshelves (
+CREATE TABLE bookshelves (
     id serial not null primary key,
     name text,
     description text default null,
@@ -51,7 +51,7 @@ CREATE TABLE IF NOT EXISTS bookshelves (
     created timestamp without time zone default (current_timestamp at time zone 'utc')
 );
 
-CREATE TABLE IF NOT EXISTS bookshelves_books (
+CREATE TABLE bookshelves_books (
     username text NOT NULL,
     work_id integer NOT NULL,
     bookshelf_id INTEGER references bookshelves(id) ON DELETE CASCADE ON UPDATE CASCADE,
@@ -61,46 +61,15 @@ CREATE TABLE IF NOT EXISTS bookshelves_books (
     created timestamp without time zone default (current_timestamp at time zone 'utc'),
     primary key (username, work_id, bookshelf_id)
 );
-CREATE INDEX IF NOT EXISTS bookshelves_books_work_id_idx ON bookshelves_books (work_id);
-CREATE INDEX IF NOT EXISTS bookshelves_books_updated_idx ON bookshelves_books (updated);
-CREATE INDEX IF NOT EXISTS bookshelves_books_created_idx ON bookshelves_books (created);
--- No UNIQUE constraint exists on bookshelves.name, so these use a
--- WHERE NOT EXISTS guard (rather than ON CONFLICT) to stay idempotent when
--- schema.sql is re-applied against an already-provisioned dev database.
-INSERT INTO bookshelves (name, description)
-    SELECT
-        'Want to Read',
-        'A list of books I want to read'
-    WHERE NOT EXISTS (
-        SELECT 1 FROM bookshelves
-        WHERE name = 'Want to Read'
-    );
-INSERT INTO bookshelves (name, description)
-    SELECT
-        'Currently Reading',
-        'A list of books I am currently reading'
-    WHERE NOT EXISTS (
-        SELECT 1 FROM bookshelves
-        WHERE name = 'Currently Reading'
-    );
-INSERT INTO bookshelves (name, description)
-    SELECT
-        'Already Read',
-        'A list of books I have finished reading'
-    WHERE NOT EXISTS (
-        SELECT 1 FROM bookshelves
-        WHERE name = 'Already Read'
-    );
-INSERT INTO bookshelves (name, description)
-    SELECT
-        'Stopped Reading',
-        'A list of books I have stopped reading'
-    WHERE NOT EXISTS (
-        SELECT 1 FROM bookshelves
-        WHERE name = 'Stopped Reading'
-    );
+CREATE INDEX bookshelves_books_work_id_idx ON bookshelves_books (work_id);
+CREATE INDEX bookshelves_books_updated_idx ON bookshelves_books (updated);
+CREATE INDEX bookshelves_books_created_idx ON bookshelves_books (created);
+INSERT INTO bookshelves (name, description) VALUES ('Want to Read', 'A list of books I want to read');
+INSERT INTO bookshelves (name, description) VALUES ('Currently Reading', 'A list of books I am currently reading');
+INSERT INTO bookshelves (name, description) VALUES ('Already Read', 'A list of books I have finished reading');
+INSERT INTO bookshelves (name, description) VALUES ('Stopped Reading', 'A list of books I have stopped reading');
 
-CREATE TABLE IF NOT EXISTS bookshelves_events (
+CREATE TABLE bookshelves_events (
     id serial primary key,
     username text not null,
     work_id integer not null,
@@ -113,10 +82,10 @@ CREATE TABLE IF NOT EXISTS bookshelves_events (
 );
 
 -- Multi-index optimized to fetch a specific user's check-ins
-CREATE INDEX IF NOT EXISTS bookshelves_events_user_checkins_idx
+CREATE INDEX bookshelves_events_user_checkins_idx
     ON bookshelves_events (username, work_id, event_type DESC, event_date DESC);
 
-CREATE TABLE IF NOT EXISTS observations (
+CREATE TABLE observations (
     work_id INTEGER not null,
     edition_id INTEGER default -1,
     username text not null,
@@ -125,9 +94,9 @@ CREATE TABLE IF NOT EXISTS observations (
     created timestamp without time zone default (current_timestamp at time zone 'utc'),
     primary key (work_id, edition_id, username, observation_value, observation_type)
 );
-CREATE INDEX IF NOT EXISTS observations_username_idx ON observations (username);
+CREATE INDEX observations_username_idx ON observations (username);
 
-CREATE TABLE IF NOT EXISTS community_edits_queue (
+CREATE TABLE community_edits_queue (
     id serial not null primary key,
     title text,
     submitter text not null,
@@ -140,9 +109,9 @@ CREATE TABLE IF NOT EXISTS community_edits_queue (
     updated timestamp without time zone default (current_timestamp at time zone 'utc')
 );
 
-CREATE INDEX IF NOT EXISTS community_edits_queue_updated_idx ON community_edits_queue (updated);
+CREATE INDEX community_edits_queue_updated_idx ON community_edits_queue (updated);
 
-CREATE TABLE IF NOT EXISTS yearly_reading_goals (
+CREATE TABLE yearly_reading_goals (
     username text not null,
     year integer not null,
     target integer not null,
@@ -151,13 +120,13 @@ CREATE TABLE IF NOT EXISTS yearly_reading_goals (
     primary key (username, year)
 );
 
-CREATE TABLE IF NOT EXISTS wikidata (
+CREATE TABLE wikidata (
     id text not null primary key,
     data json,
     updated timestamp without time zone default (current_timestamp at time zone 'utc')
 );
 
-CREATE TABLE IF NOT EXISTS bestbooks (
+CREATE TABLE bestbooks (
     award_id serial not null primary key,
     username text not null,
     work_id integer not null,
@@ -170,11 +139,11 @@ CREATE TABLE IF NOT EXISTS bestbooks (
     UNIQUE (username, topic)
 );
 
-CREATE INDEX IF NOT EXISTS bestbooks_username ON bestbooks (username);
-CREATE INDEX IF NOT EXISTS bestbooks_work ON bestbooks (work_id);
-CREATE INDEX IF NOT EXISTS bestbooks_topic ON bestbooks (topic);
+CREATE INDEX bestbooks_username ON bestbooks (username);
+CREATE INDEX bestbooks_work ON bestbooks (work_id);
+CREATE INDEX bestbooks_topic ON bestbooks (topic);
 
-CREATE TABLE IF NOT EXISTS acquisitions (
+CREATE TABLE acquisitions (
     id serial primary key,
     work_id integer not null,
     edition_id integer not null,
@@ -187,6 +156,6 @@ CREATE TABLE IF NOT EXISTS acquisitions (
     UNIQUE (local_id, provider_name)
 );
 
-CREATE INDEX IF NOT EXISTS acquisitions_work_id_idx ON acquisitions (work_id);
-CREATE INDEX IF NOT EXISTS acquisitions_edition_id_idx ON acquisitions (edition_id);
-CREATE INDEX IF NOT EXISTS acquisitions_updated_idx ON acquisitions (updated);
+CREATE INDEX acquisitions_work_id_idx ON acquisitions (work_id);
+CREATE INDEX acquisitions_edition_id_idx ON acquisitions (edition_id);
+CREATE INDEX acquisitions_updated_idx ON acquisitions (updated);

--- a/openlibrary/core/schema.sql
+++ b/openlibrary/core/schema.sql
@@ -1,4 +1,4 @@
-CREATE TABLE ratings (
+CREATE TABLE IF NOT EXISTS ratings (
     username text NOT NULL,
     work_id integer NOT NULL,
     rating integer,
@@ -7,9 +7,9 @@ CREATE TABLE ratings (
     created timestamp without time zone default (current_timestamp at time zone 'utc'),
     primary key (username, work_id)
 );
-CREATE INDEX ratings_work_id_idx ON ratings (work_id);
+CREATE INDEX IF NOT EXISTS ratings_work_id_idx ON ratings (work_id);
 
-CREATE TABLE follows (
+CREATE TABLE IF NOT EXISTS follows (
     subscriber text NOT NULL,
     publisher text NOT NULL,
     disabled BOOLEAN DEFAULT FALSE,
@@ -17,7 +17,7 @@ CREATE TABLE follows (
     created timestamp without time zone default (current_timestamp at time zone 'utc'),
     primary key (subscriber, publisher)
 );
-CREATE TABLE likes (
+CREATE TABLE IF NOT EXISTS likes (
     username    TEXT        NOT NULL,
     key         TEXT        NOT NULL,   -- full infogami key, e.g. /works/OL123W
     value       SMALLINT    NOT NULL DEFAULT 1 CHECK (value IN (1, -1)),
@@ -25,13 +25,13 @@ CREATE TABLE likes (
     modified    TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (username, key)
 );
-CREATE INDEX likes_key_idx      ON likes (key);
-CREATE INDEX likes_username_idx ON likes (username);
+CREATE INDEX IF NOT EXISTS likes_key_idx      ON likes (key);
+CREATE INDEX IF NOT EXISTS likes_username_idx ON likes (username);
 
-CREATE INDEX subscriber_idx ON follows (subscriber);
-CREATE INDEX publisher_idx ON follows (publisher);
+CREATE INDEX IF NOT EXISTS subscriber_idx ON follows (subscriber);
+CREATE INDEX IF NOT EXISTS publisher_idx ON follows (publisher);
 
-CREATE TABLE booknotes (
+CREATE TABLE IF NOT EXISTS booknotes (
     username text NOT NULL,
     work_id integer NOT NULL,
     edition_id integer NOT NULL default -1,
@@ -40,9 +40,9 @@ CREATE TABLE booknotes (
     created timestamp without time zone default (current_timestamp at time zone 'utc'),
     primary key (username, work_id, edition_id)
 );
-CREATE INDEX booknotes_work_id_idx ON booknotes (work_id);
+CREATE INDEX IF NOT EXISTS booknotes_work_id_idx ON booknotes (work_id);
 
-CREATE TABLE bookshelves (
+CREATE TABLE IF NOT EXISTS bookshelves (
     id serial not null primary key,
     name text,
     description text default null,
@@ -51,7 +51,7 @@ CREATE TABLE bookshelves (
     created timestamp without time zone default (current_timestamp at time zone 'utc')
 );
 
-CREATE TABLE bookshelves_books (
+CREATE TABLE IF NOT EXISTS bookshelves_books (
     username text NOT NULL,
     work_id integer NOT NULL,
     bookshelf_id INTEGER references bookshelves(id) ON DELETE CASCADE ON UPDATE CASCADE,
@@ -61,15 +61,46 @@ CREATE TABLE bookshelves_books (
     created timestamp without time zone default (current_timestamp at time zone 'utc'),
     primary key (username, work_id, bookshelf_id)
 );
-CREATE INDEX bookshelves_books_work_id_idx ON bookshelves_books (work_id);
-CREATE INDEX bookshelves_books_updated_idx ON bookshelves_books (updated);
-CREATE INDEX bookshelves_books_created_idx ON bookshelves_books (created);
-INSERT INTO bookshelves (name, description) VALUES ('Want to Read', 'A list of books I want to read');
-INSERT INTO bookshelves (name, description) VALUES ('Currently Reading', 'A list of books I am currently reading');
-INSERT INTO bookshelves (name, description) VALUES ('Already Read', 'A list of books I have finished reading');
-INSERT INTO bookshelves (name, description) VALUES ('Stopped Reading', 'A list of books I have stopped reading');
+CREATE INDEX IF NOT EXISTS bookshelves_books_work_id_idx ON bookshelves_books (work_id);
+CREATE INDEX IF NOT EXISTS bookshelves_books_updated_idx ON bookshelves_books (updated);
+CREATE INDEX IF NOT EXISTS bookshelves_books_created_idx ON bookshelves_books (created);
+-- No UNIQUE constraint exists on bookshelves.name, so these use a
+-- WHERE NOT EXISTS guard (rather than ON CONFLICT) to stay idempotent when
+-- schema.sql is re-applied against an already-provisioned dev database.
+INSERT INTO bookshelves (name, description)
+    SELECT
+        'Want to Read',
+        'A list of books I want to read'
+    WHERE NOT EXISTS (
+        SELECT 1 FROM bookshelves
+        WHERE name = 'Want to Read'
+    );
+INSERT INTO bookshelves (name, description)
+    SELECT
+        'Currently Reading',
+        'A list of books I am currently reading'
+    WHERE NOT EXISTS (
+        SELECT 1 FROM bookshelves
+        WHERE name = 'Currently Reading'
+    );
+INSERT INTO bookshelves (name, description)
+    SELECT
+        'Already Read',
+        'A list of books I have finished reading'
+    WHERE NOT EXISTS (
+        SELECT 1 FROM bookshelves
+        WHERE name = 'Already Read'
+    );
+INSERT INTO bookshelves (name, description)
+    SELECT
+        'Stopped Reading',
+        'A list of books I have stopped reading'
+    WHERE NOT EXISTS (
+        SELECT 1 FROM bookshelves
+        WHERE name = 'Stopped Reading'
+    );
 
-CREATE TABLE bookshelves_events (
+CREATE TABLE IF NOT EXISTS bookshelves_events (
     id serial primary key,
     username text not null,
     work_id integer not null,
@@ -82,10 +113,10 @@ CREATE TABLE bookshelves_events (
 );
 
 -- Multi-index optimized to fetch a specific user's check-ins
-CREATE INDEX bookshelves_events_user_checkins_idx
+CREATE INDEX IF NOT EXISTS bookshelves_events_user_checkins_idx
     ON bookshelves_events (username, work_id, event_type DESC, event_date DESC);
 
-CREATE TABLE observations (
+CREATE TABLE IF NOT EXISTS observations (
     work_id INTEGER not null,
     edition_id INTEGER default -1,
     username text not null,
@@ -94,9 +125,9 @@ CREATE TABLE observations (
     created timestamp without time zone default (current_timestamp at time zone 'utc'),
     primary key (work_id, edition_id, username, observation_value, observation_type)
 );
-CREATE INDEX observations_username_idx ON observations (username);
+CREATE INDEX IF NOT EXISTS observations_username_idx ON observations (username);
 
-CREATE TABLE community_edits_queue (
+CREATE TABLE IF NOT EXISTS community_edits_queue (
     id serial not null primary key,
     title text,
     submitter text not null,
@@ -109,9 +140,9 @@ CREATE TABLE community_edits_queue (
     updated timestamp without time zone default (current_timestamp at time zone 'utc')
 );
 
-CREATE INDEX community_edits_queue_updated_idx ON community_edits_queue (updated);
+CREATE INDEX IF NOT EXISTS community_edits_queue_updated_idx ON community_edits_queue (updated);
 
-CREATE TABLE yearly_reading_goals (
+CREATE TABLE IF NOT EXISTS yearly_reading_goals (
     username text not null,
     year integer not null,
     target integer not null,
@@ -120,13 +151,13 @@ CREATE TABLE yearly_reading_goals (
     primary key (username, year)
 );
 
-CREATE TABLE wikidata (
+CREATE TABLE IF NOT EXISTS wikidata (
     id text not null primary key,
     data json,
     updated timestamp without time zone default (current_timestamp at time zone 'utc')
 );
 
-CREATE TABLE bestbooks (
+CREATE TABLE IF NOT EXISTS bestbooks (
     award_id serial not null primary key,
     username text not null,
     work_id integer not null,
@@ -139,11 +170,11 @@ CREATE TABLE bestbooks (
     UNIQUE (username, topic)
 );
 
-CREATE INDEX bestbooks_username ON bestbooks (username);
-CREATE INDEX bestbooks_work ON bestbooks (work_id);
-CREATE INDEX bestbooks_topic ON bestbooks (topic);
+CREATE INDEX IF NOT EXISTS bestbooks_username ON bestbooks (username);
+CREATE INDEX IF NOT EXISTS bestbooks_work ON bestbooks (work_id);
+CREATE INDEX IF NOT EXISTS bestbooks_topic ON bestbooks (topic);
 
-CREATE TABLE acquisitions (
+CREATE TABLE IF NOT EXISTS acquisitions (
     id serial primary key,
     work_id integer not null,
     edition_id integer not null,
@@ -156,6 +187,6 @@ CREATE TABLE acquisitions (
     UNIQUE (local_id, provider_name)
 );
 
-CREATE INDEX acquisitions_work_id_idx ON acquisitions (work_id);
-CREATE INDEX acquisitions_edition_id_idx ON acquisitions (edition_id);
-CREATE INDEX acquisitions_updated_idx ON acquisitions (updated);
+CREATE INDEX IF NOT EXISTS acquisitions_work_id_idx ON acquisitions (work_id);
+CREATE INDEX IF NOT EXISTS acquisitions_edition_id_idx ON acquisitions (edition_id);
+CREATE INDEX IF NOT EXISTS acquisitions_updated_idx ON acquisitions (updated);

--- a/openlibrary/plugins/openlibrary/tests/test_likes.py
+++ b/openlibrary/plugins/openlibrary/tests/test_likes.py
@@ -4,6 +4,7 @@ from openlibrary.plugins.openlibrary.tests.test_followsapi import FakeUser
 from openlibrary.plugins.upstream.likes import likes_control
 import pytest
 import web
+import re
 
 from openlibrary.core.likes import Likes
 
@@ -44,7 +45,7 @@ def test_double_like():
         assert oldb.update.call_count == 1
 
 def test_like_invalid_value():
-    with pytest.raises(ValueError, match = "value must be 1 (like) or -1 (dislike)"):
+    with pytest.raises(ValueError, match = re.escape("value must be 1 (like) or -1 (dislike)")):
         Likes.like("user1", "/works/OL1W", 99)
 
 def test_like_unauthenticated():

--- a/openlibrary/plugins/openlibrary/tests/test_likes.py
+++ b/openlibrary/plugins/openlibrary/tests/test_likes.py
@@ -1,22 +1,24 @@
+import re
 from unittest.mock import MagicMock, patch
 
-from openlibrary.plugins.openlibrary.tests.test_followsapi import FakeUser
-from openlibrary.plugins.upstream.likes import likes_control
 import pytest
 import web
-import re
 
 from openlibrary.core.likes import Likes
+from openlibrary.plugins.openlibrary.tests.test_followsapi import FakeUser
+from openlibrary.plugins.upstream.likes import likes_control
+
 
 def test_like():
-    with(
-        patch("web.data",return_value =b'{"key": "/works/OL1W", "value": 1}'),
+    with (
+        patch("web.data", return_value=b'{"key": "/works/OL1W", "value": 1}'),
         patch("web.ctx") as mock_ctx,
-        patch("openlibrary.core.likes.Likes.like") as mock_likes
+        patch("openlibrary.core.likes.Likes.like") as mock_likes,
     ):
         mock_ctx.site.get_user.return_value = FakeUser("test_user")
         likes_control().POST()
         mock_likes.assert_called_once_with("test_user", "/works/OL1W", 1)
+
 
 def test_unlike():
     with (
@@ -29,6 +31,7 @@ def test_unlike():
         likes_control().DELETE()
 
         mock_unlike.assert_called_once_with("test_user", "/works/OL1W")
+
 
 def test_double_like():
     with (
@@ -44,15 +47,14 @@ def test_double_like():
         assert oldb.insert.call_count == 1
         assert oldb.update.call_count == 1
 
+
 def test_like_invalid_value():
-    with pytest.raises(ValueError, match = re.escape("value must be 1 (like) or -1 (dislike)")):
+    with pytest.raises(ValueError, match=re.escape("value must be 1 (like) or -1 (dislike)")):
         Likes.like("user1", "/works/OL1W", 99)
 
+
 def test_like_unauthenticated():
-    with (
-        patch("web.data", return_value=b'{"key": "/works/OL1W", "value": 1}'),
-        patch.object(web.ctx,"site") as mock_site
-    ):
+    with patch("web.data", return_value=b'{"key": "/works/OL1W", "value": 1}'), patch.object(web.ctx, "site") as mock_site:
         mock_site.get_user.return_value = None
         web.ctx.headers = []
         with pytest.raises(web.HTTPError):

--- a/openlibrary/plugins/openlibrary/tests/test_likes.py
+++ b/openlibrary/plugins/openlibrary/tests/test_likes.py
@@ -1,0 +1,58 @@
+from unittest.mock import MagicMock, patch
+
+from openlibrary.plugins.openlibrary.tests.test_followsapi import FakeUser
+from openlibrary.plugins.upstream.likes import likes_control
+import pytest
+import web
+
+from openlibrary.core.likes import Likes
+
+def test_like():
+    with(
+        patch("web.data",return_value =b'{"key": "/works/OL1W", "value": 1}'),
+        patch("web.ctx") as mock_ctx,
+        patch("openlibrary.core.likes.Likes.like") as mock_likes
+    ):
+        mock_ctx.site.get_user.return_value = FakeUser("test_user")
+        likes_control().POST()
+        mock_likes.assert_called_once_with("test_user", "/works/OL1W", 1)
+
+def test_unlike():
+    with (
+        patch("web.data", return_value=b'{"key": "/works/OL1W"}'),
+        patch("web.ctx") as mock_ctx,
+        patch("openlibrary.core.likes.Likes.unlike") as mock_unlike,
+    ):
+        mock_ctx.site.get_user.return_value = FakeUser("test_user")
+
+        likes_control().DELETE()
+
+        mock_unlike.assert_called_once_with("test_user", "/works/OL1W")
+
+def test_double_like():
+    with (
+        patch("openlibrary.core.likes.db.get_db") as mock_get_db,
+        patch.object(Likes, "patron_liked", side_effect=[False, True]),
+    ):
+        oldb = MagicMock()
+        mock_get_db.return_value = oldb
+
+        Likes.like("user1", "/works/OL1W", 1)
+        Likes.like("user1", "/works/OL1W", 1)
+
+        assert oldb.insert.call_count == 1
+        assert oldb.update.call_count == 1
+
+def test_like_invalid_value():
+    with pytest.raises(ValueError):
+        Likes.like("user1", "/works/OL1W", 99)
+
+def test_like_unauthenticated():
+    with (
+        patch("web.data", return_value=b'{"key": "/works/OL1W", "value": 1}'),
+        patch("web.ctx") as mock_ctx,
+    ):
+        mock_ctx.site.get_user.return_value = None
+
+        with pytest.raises(web.HTTPError):
+            likes_control().POST()

--- a/openlibrary/plugins/openlibrary/tests/test_likes.py
+++ b/openlibrary/plugins/openlibrary/tests/test_likes.py
@@ -44,15 +44,15 @@ def test_double_like():
         assert oldb.update.call_count == 1
 
 def test_like_invalid_value():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match = "value must be 1 (like) or -1 (dislike)"):
         Likes.like("user1", "/works/OL1W", 99)
 
 def test_like_unauthenticated():
     with (
         patch("web.data", return_value=b'{"key": "/works/OL1W", "value": 1}'),
-        patch("web.ctx") as mock_ctx,
+        patch.object(web.ctx,"site") as mock_site
     ):
-        mock_ctx.site.get_user.return_value = None
-
+        mock_site.get_user.return_value = None
+        web.ctx.headers = []
         with pytest.raises(web.HTTPError):
             likes_control().POST()

--- a/openlibrary/plugins/openlibrary/tests/test_likes.py
+++ b/openlibrary/plugins/openlibrary/tests/test_likes.py
@@ -1,3 +1,4 @@
+import json
 import re
 from unittest.mock import MagicMock, patch
 
@@ -6,7 +7,7 @@ import web
 
 from openlibrary.core.likes import Likes
 from openlibrary.plugins.openlibrary.tests.test_followsapi import FakeUser
-from openlibrary.plugins.upstream.likes import get_patron_likes, likes_control
+from openlibrary.plugins.upstream.likes import get_likes_record, get_patron_likes, likes_control
 
 
 def test_like():
@@ -54,11 +55,62 @@ def test_like_invalid_value():
 
 
 def test_like_unauthenticated():
-    with patch("web.data", return_value=b'{"key": "/works/OL1W", "value": 1}'), patch.object(web.ctx, "site") as mock_site:
+    # `create=True` -- see test_patron_likes_unauthenticated below for why.
+    with patch("web.data", return_value=b'{"key": "/works/OL1W", "value": 1}'), patch.object(web.ctx, "site", create=True) as mock_site:
         mock_site.get_user.return_value = None
         web.ctx.headers = []
         with pytest.raises(web.HTTPError):
             likes_control().POST()
+
+
+def test_unlike_unauthenticated():
+    with patch("web.data", return_value=b'{"key": "/works/OL1W"}'), patch.object(web.ctx, "site", create=True) as mock_site:
+        mock_site.get_user.return_value = None
+        web.ctx.headers = []
+        with pytest.raises(web.HTTPError):
+            likes_control().DELETE()
+
+
+def test_like_missing_key():
+    with patch("web.data", return_value=b'{"value": 1}'), patch("web.ctx") as mock_ctx:
+        mock_ctx.site.get_user.return_value = FakeUser("test_user")
+        with pytest.raises(web.HTTPError):
+            likes_control().POST()
+
+
+def test_unlike_missing_key():
+    with patch("web.data", return_value=b"{}"), patch("web.ctx") as mock_ctx:
+        mock_ctx.site.get_user.return_value = FakeUser("test_user")
+        with pytest.raises(web.HTTPError):
+            likes_control().DELETE()
+
+
+def test_get_likes_record_missing_key():
+    with patch("web.input", return_value=web.storage(key="")), pytest.raises(web.HTTPError):
+        get_likes_record().GET()
+
+
+def test_get_likes_record_anonymous():
+    with (
+        patch("web.input", return_value=web.storage(key="/works/OL1W")),
+        patch("web.ctx") as mock_ctx,
+        patch("openlibrary.core.likes.Likes.get_count", return_value={"likes": 3, "dislikes": 1}),
+    ):
+        mock_ctx.site.get_user.return_value = None
+        result = get_likes_record().GET()
+        assert json.loads(result.rawtext) == {"likes": 3, "dislikes": 1, "patron_liked": False}
+
+
+def test_get_likes_record_authenticated():
+    with (
+        patch("web.input", return_value=web.storage(key="/works/OL1W")),
+        patch("web.ctx") as mock_ctx,
+        patch("openlibrary.core.likes.Likes.get_count", return_value={"likes": 3, "dislikes": 1}),
+        patch("openlibrary.core.likes.Likes.patron_liked", return_value=True),
+    ):
+        mock_ctx.site.get_user.return_value = FakeUser("test_user")
+        result = get_likes_record().GET()
+        assert json.loads(result.rawtext) == {"likes": 3, "dislikes": 1, "patron_liked": True}
 
 
 def test_patron_likes_unauthenticated():
@@ -87,3 +139,57 @@ def test_patron_likes_ignores_username_param_and_uses_caller_identity():
         get_patron_likes().GET()
 
         mock_get_for_patron.assert_called_once_with("test_user", 50, 0)
+
+
+def test_patron_likes_invalid_limit():
+    with (
+        patch("web.input", return_value=web.storage(limit="not-a-number", offset=0)),
+        patch("web.ctx") as mock_ctx,
+    ):
+        mock_ctx.site.get_user.return_value = FakeUser("test_user")
+        with pytest.raises(web.HTTPError):
+            get_patron_likes().GET()
+
+
+def test_patron_likes_negative_offset():
+    with (
+        patch("web.input", return_value=web.storage(limit=50, offset=-1)),
+        patch("web.ctx") as mock_ctx,
+    ):
+        mock_ctx.site.get_user.return_value = FakeUser("test_user")
+        with pytest.raises(web.HTTPError):
+            get_patron_likes().GET()
+
+
+def test_patron_likes_limit_is_capped():
+    with (
+        patch("web.input", return_value=web.storage(limit=100_000, offset=0)),
+        patch("web.ctx") as mock_ctx,
+        patch("openlibrary.core.likes.Likes.get_for_patron", return_value=[]) as mock_get_for_patron,
+    ):
+        mock_ctx.site.get_user.return_value = FakeUser("test_user")
+
+        get_patron_likes().GET()
+
+        mock_get_for_patron.assert_called_once_with("test_user", get_patron_likes.MAX_LIMIT, 0)
+
+
+def test_get_count():
+    with patch("openlibrary.core.likes.db.get_db") as mock_get_db:
+        oldb = MagicMock()
+        oldb.query.side_effect = [
+            [{"value": 1, "count": 3}],
+            [{"value": -1, "count": 1}],
+        ]
+        mock_get_db.return_value = oldb
+
+        assert Likes.get_count("/works/OL1W") == {"likes": 3, "dislikes": 1}
+
+
+def test_get_count_no_likes():
+    with patch("openlibrary.core.likes.db.get_db") as mock_get_db:
+        oldb = MagicMock()
+        oldb.query.return_value = []
+        mock_get_db.return_value = oldb
+
+        assert Likes.get_count("/works/OL1W") == {"likes": 0, "dislikes": 0}

--- a/openlibrary/plugins/openlibrary/tests/test_likes.py
+++ b/openlibrary/plugins/openlibrary/tests/test_likes.py
@@ -6,7 +6,7 @@ import web
 
 from openlibrary.core.likes import Likes
 from openlibrary.plugins.openlibrary.tests.test_followsapi import FakeUser
-from openlibrary.plugins.upstream.likes import likes_control
+from openlibrary.plugins.upstream.likes import get_patron_likes, likes_control
 
 
 def test_like():
@@ -59,3 +59,31 @@ def test_like_unauthenticated():
         web.ctx.headers = []
         with pytest.raises(web.HTTPError):
             likes_control().POST()
+
+
+def test_patron_likes_unauthenticated():
+    # `create=True` avoids a test-isolation gap in this file's other tests:
+    # `web.ctx` may not have a `site` attribute yet until something in the
+    # broader suite sets it as a side effect, which makes plain
+    # `patch.object(web.ctx, "site")` (no `create=True`) fail before this test
+    # even runs, depending on execution order.
+    with patch.object(web.ctx, "site", create=True) as mock_site:
+        mock_site.get_user.return_value = None
+        web.ctx.headers = []
+        with pytest.raises(web.HTTPError):
+            get_patron_likes().GET()
+
+
+def test_patron_likes_ignores_username_param_and_uses_caller_identity():
+    # A patron must only ever be able to fetch their own likes -- the endpoint
+    # must not accept an arbitrary `username` to look up another patron's likes.
+    with (
+        patch("web.input", return_value=web.storage(username="someone_else", limit=50, offset=0)),
+        patch("web.ctx") as mock_ctx,
+        patch("openlibrary.core.likes.Likes.get_for_patron", return_value=[]) as mock_get_for_patron,
+    ):
+        mock_ctx.site.get_user.return_value = FakeUser("test_user")
+
+        get_patron_likes().GET()
+
+        mock_get_for_patron.assert_called_once_with("test_user", 50, 0)

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -31,6 +31,7 @@ from openlibrary.plugins.upstream import (
     checkins,
     covers,
     edits,
+    likes,
     merge_authors,
     models,
     recentchanges,  # noqa: F401 side effects may be needed
@@ -342,7 +343,7 @@ def setup():
     yearly_reading_goals.setup()
 
     from openlibrary.plugins.upstream import data, jsdef
-
+    
     data.setup()
 
     # setup template globals

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -31,6 +31,7 @@ from openlibrary.plugins.upstream import (
     checkins,
     covers,
     edits,
+    likes,  # noqa: F401 side effects may be needed
     merge_authors,
     models,
     recentchanges,  # noqa: F401 side effects may be needed
@@ -128,7 +129,7 @@ class merge_work(delegate.page):
 
         if user is None:
             raise web.unauthorized()
-        has_access = user and user.is_librarian_or_higher()
+        has_access = user and ((user.is_admin() or user.is_librarian()) or user.is_super_librarian())
         if not has_access:
             raise web.forbidden()
 

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -31,7 +31,6 @@ from openlibrary.plugins.upstream import (
     checkins,
     covers,
     edits,
-    likes,
     merge_authors,
     models,
     recentchanges,  # noqa: F401 side effects may be needed
@@ -343,7 +342,7 @@ def setup():
     yearly_reading_goals.setup()
 
     from openlibrary.plugins.upstream import data, jsdef
-    
+
     data.setup()
 
     # setup template globals

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -129,7 +129,7 @@ class merge_work(delegate.page):
 
         if user is None:
             raise web.unauthorized()
-        has_access = user and ((user.is_admin() or user.is_librarian()) or user.is_super_librarian())
+        has_access = user and user.is_librarian_or_higher()
         if not has_access:
             raise web.forbidden()
 

--- a/openlibrary/plugins/upstream/likes.py
+++ b/openlibrary/plugins/upstream/likes.py
@@ -1,12 +1,14 @@
 import json
+
 import web
+
 from infogami.utils import delegate
 from openlibrary.core.likes import Likes
-from openlibrary import accounts
+
 
 class likes_control(delegate.page):
     path = "/api/like"
-    
+
     def POST(self):
         user = web.ctx.site.get_user()
         data = json.loads(web.data())
@@ -19,7 +21,7 @@ class likes_control(delegate.page):
             Likes.like(username, key, value)
         except ValueError as e:
             raise web.badrequest(str(e))
-        
+
         return delegate.RawText(json.dumps({"key": key, "value": value}))
 
     def DELETE(self):
@@ -30,20 +32,27 @@ class likes_control(delegate.page):
             raise web.unauthorized()
         username = user.key.split("/")[-1]
         Likes.unlike(username, key)
-        return delegate.RawText(json.dumps({"key": key,}))
+        return delegate.RawText(
+            json.dumps(
+                {
+                    "key": key,
+                }
+            )
+        )
+
 
 class get_likes_record(delegate.page):
-     path = "/api/likes"
-     def GET(self):
+    path = "/api/likes"
+
+    def GET(self):
         i = web.input(key="")
         key = i.key
         if not key:
             raise web.badrequest()
         count = Likes.get_count(key)
-        user = web.ctx.site.get_user()
-        if user:
+        if user := web.ctx.site.get_user():
             username = user.key.split("/")[-1]
-            patron_liked=Likes.patron_liked(username, key)
+            patron_liked = Likes.patron_liked(username, key)
             result = {
                 "likes": count["likes"],
                 "dislikes": count["dislikes"],
@@ -57,10 +66,11 @@ class get_likes_record(delegate.page):
                 "patron_liked": patron_liked,
             }
         return delegate.RawText(json.dumps(result))
-     
+
 
 class get_patron_likes(delegate.page):
     path = "/api/patron/likes"
+
     def GET(self):
         i = web.input(username="", limit=50, offset=0)
         likes = Likes.get_for_patron(i.username, int(i.limit), int(i.offset))

--- a/openlibrary/plugins/upstream/likes.py
+++ b/openlibrary/plugins/upstream/likes.py
@@ -15,7 +15,11 @@ class likes_control(delegate.page):
             raise web.unauthorized()
         value = data.get("value", 1)
         username = user.key.split("/")[-1]
-        Likes.like(username, key, value)
+        try:
+            Likes.like(username, key, value)
+        except ValueError as e:
+            raise web.badrequest(str(e))
+        
         return delegate.RawText(json.dumps({"key": key, "value": value}))
 
     def DELETE(self):
@@ -40,6 +44,11 @@ class get_likes_record(delegate.page):
         if user:
             username = user.key.split("/")[-1]
             patron_liked=Likes.patron_liked(username, key)
+            result = {
+                "likes": count["likes"],
+                "dislikes": count["dislikes"],
+                "patron_liked": patron_liked,
+            }
         else:
             patron_liked = False
             result = {
@@ -55,4 +64,4 @@ class get_patron_likes(delegate.page):
     def GET(self):
         i = web.input(username="", limit=50, offset=0)
         likes = Likes.get_for_patron(i.username, int(i.limit), int(i.offset))
-        return delegate.RawText(json.dumps(list(likes)))
+        return delegate.RawText(json.dumps(list(likes), default=str))

--- a/openlibrary/plugins/upstream/likes.py
+++ b/openlibrary/plugins/upstream/likes.py
@@ -1,0 +1,58 @@
+import json
+import web
+from infogami.utils import delegate
+from openlibrary.core.likes import Likes
+from openlibrary import accounts
+
+class likes_control(delegate.page):
+    path = "/api/like"
+    
+    def POST(self):
+        user = web.ctx.site.get_user()
+        data = json.loads(web.data())
+        key = data.get("key")
+        if not user:
+            raise web.unauthorized()
+        value = data.get("value", 1)
+        username = user.key.split("/")[-1]
+        Likes.like(username, key, value)
+        return delegate.RawText(json.dumps({"key": key, "value": value}))
+
+    def DELETE(self):
+        user = web.ctx.site.get_user()
+        data = json.loads(web.data())
+        key = data.get("key")
+        if not user:
+            raise web.unauthorized()
+        username = user.key.split("/")[-1]
+        Likes.unlike(username, key)
+        return delegate.RawText(json.dumps({"key": key,}))
+
+class get_likes_record(delegate.page):
+     path = "/api/likes"
+     def GET(self):
+        i = web.input(key="")
+        key = i.key
+        if not key:
+            raise web.badrequest()
+        count = Likes.get_count(key)
+        user = web.ctx.site.get_user()
+        if user:
+            username = user.key.split("/")[-1]
+            patron_liked=Likes.patron_liked(username, key)
+        else:
+            patron_liked = False
+            result = {
+                "likes": count["likes"],
+                "dislikes": count["dislikes"],
+                "patron_liked": patron_liked,
+            }
+        return delegate.RawText(json.dumps(result))
+     
+
+class get_patron_likes(delegate.page):
+    path = "/api/patron/likes"
+    def GET(self):
+        i = web.input(username="", limit=50, offset=0)
+        likes = Likes.get_for_patron(i.username, int(i.limit), int(i.offset))
+        return delegate.RawText(json.dumps(list(likes)))

--- a/openlibrary/plugins/upstream/likes.py
+++ b/openlibrary/plugins/upstream/likes.py
@@ -72,6 +72,10 @@ class get_patron_likes(delegate.page):
     path = "/api/patron/likes"
 
     def GET(self):
-        i = web.input(username="", limit=50, offset=0)
-        likes = Likes.get_for_patron(i.username, int(i.limit), int(i.offset))
+        user = web.ctx.site.get_user()
+        if not user:
+            raise web.unauthorized()
+        username = user.key.split("/")[-1]
+        i = web.input(limit=50, offset=0)
+        likes = Likes.get_for_patron(username, int(i.limit), int(i.offset))
         return delegate.RawText(json.dumps(list(likes), default=str))

--- a/openlibrary/plugins/upstream/likes.py
+++ b/openlibrary/plugins/upstream/likes.py
@@ -11,10 +11,12 @@ class likes_control(delegate.page):
 
     def POST(self):
         user = web.ctx.site.get_user()
-        data = json.loads(web.data())
-        key = data.get("key")
         if not user:
             raise web.unauthorized()
+        data = json.loads(web.data())
+        key = data.get("key")
+        if not key:
+            raise web.badrequest("key is required")
         value = data.get("value", 1)
         username = user.key.split("/")[-1]
         try:
@@ -26,10 +28,12 @@ class likes_control(delegate.page):
 
     def DELETE(self):
         user = web.ctx.site.get_user()
-        data = json.loads(web.data())
-        key = data.get("key")
         if not user:
             raise web.unauthorized()
+        data = json.loads(web.data())
+        key = data.get("key")
+        if not key:
+            raise web.badrequest("key is required")
         username = user.key.split("/")[-1]
         Likes.unlike(username, key)
         return delegate.RawText(
@@ -53,23 +57,20 @@ class get_likes_record(delegate.page):
         if user := web.ctx.site.get_user():
             username = user.key.split("/")[-1]
             patron_liked = Likes.patron_liked(username, key)
-            result = {
-                "likes": count["likes"],
-                "dislikes": count["dislikes"],
-                "patron_liked": patron_liked,
-            }
         else:
             patron_liked = False
-            result = {
-                "likes": count["likes"],
-                "dislikes": count["dislikes"],
-                "patron_liked": patron_liked,
-            }
+        result = {
+            "likes": count["likes"],
+            "dislikes": count["dislikes"],
+            "patron_liked": patron_liked,
+        }
         return delegate.RawText(json.dumps(result))
 
 
 class get_patron_likes(delegate.page):
     path = "/api/patron/likes"
+
+    MAX_LIMIT = 200
 
     def GET(self):
         user = web.ctx.site.get_user()
@@ -77,5 +78,13 @@ class get_patron_likes(delegate.page):
             raise web.unauthorized()
         username = user.key.split("/")[-1]
         i = web.input(limit=50, offset=0)
-        likes = Likes.get_for_patron(username, int(i.limit), int(i.offset))
+        try:
+            limit = int(i.limit)
+            offset = int(i.offset)
+        except ValueError:
+            raise web.badrequest("limit and offset must be integers")
+        if limit < 0 or offset < 0:
+            raise web.badrequest("limit and offset must not be negative")
+        limit = min(limit, self.MAX_LIMIT)
+        likes = Likes.get_for_patron(username, limit, offset)
         return delegate.RawText(json.dumps(list(likes), default=str))


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #12768 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Added a likes table to the Open Library database, a openlibrary/core/likes.py model, and a small set of backend API endpoints.


### Technical
<!-- What should be noted about the implementation? -->
- Added `likes` table DDL to `scripts/db_setup.py`
- Added `openlibrary/core/likes.py` with `Likes` class (`like`, `unlike`, `dislike`, `get_count`, `get_for_patron`, `patron_liked`)
- Registered API endpoints in `openlibrary/plugins/upstream/code.py`:
  - `POST /api/like` — like or dislike a record (auth required)
  - `DELETE /api/like` — remove a like (auth required)
  - `GET /api/likes` — get like/dislike count + `patron_liked` flag
  - `GET /api/patron/likes` — get all likes by a patron (paginated)
- Auth enforcement: unauthenticated requests return 401
- Added unit tests covering: like, unlike, double-like idempotency, value constraint, unauthenticated rejection
- Added `# TODO` comment in `likes.py` documenting the redirect/merge gap and pointing to `resolve_redirects_bulk`

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
No UI changes — backend only. Run unit tests with:
`docker compose run --rm home pytest openlibrary/plugins/openlibrary/tests/test_likes.py`

Note: test suite currently blocked by upstream `NameError: name 'Locale' is not defined` in `conftest.py` (unrelated to this PR).

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
