### PR TITLE
Pin slick-carousel to 1.6.0 to fix broken carousel layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "promise-polyfill": "8.3.0",
         "regenerator-runtime": "^0.14.1",
         "sinon": "21.1.2",
-        "slick-carousel": "^1.6.0",
+        "slick-carousel": "1.6.0",
         "style-loader": "^4.0.0",
         "stylelint": "^16.26.1",
         "stylelint-declaration-strict-value": "^1.11.1",
@@ -14827,13 +14827,13 @@
       }
     },
     "node_modules/slick-carousel": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.8.1.tgz",
-      "integrity": "sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.6.0.tgz",
+      "integrity": "sha512-/uk00AYE+qpBJW8GVlYHGxUqp1hJoDn5I0fWdHR5yIV4jLhAqoU3BGUhX8FX/vkD0jNdjzbMX88IY7Leb+fstA==",
       "dev": true,
       "license": "MIT",
-      "peerDependencies": {
-        "jquery": ">=1.8.0"
+      "dependencies": {
+        "jquery": ">=1.7.2"
       }
     },
     "node_modules/smob": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "promise-polyfill": "8.3.0",
     "regenerator-runtime": "^0.14.1",
     "sinon": "21.1.2",
-    "slick-carousel": "^1.6.0",
+    "slick-carousel": "1.6.0",
     "style-loader": "^4.0.0",
     "stylelint": "^16.26.1",
     "stylelint-declaration-strict-value": "^1.11.1",


### PR DESCRIPTION
## Problem

Book carousels (Trending, Classic Books, etc.) render with covers **stacked vertically** instead of in a horizontal row. The nav arrows still work, which made this look like a single CSS bug.

## Cause

`package.json` declared `"slick-carousel": "^1.6.0"`, but the caret let `package-lock.json` resolve to **1.8.1**.

Slick 1.8.x changed the default `rows` option from `0` to `1`. With `rows: 1`, slick **wraps every slide in a generated `<div class="slick-slide">`** rather than adding the `slick-slide` class to the existing `.carousel__item`. Our vendored `static/css/lib/slick.css` has no `float` on `.slick-slide` (the `float: left` only lives on `.carousel__item`), so the wrapper divs render `display: block; float: none` and the covers stack vertically. The arrows keep working because they're built by slick's JS.

Confirmed on testing: the live `.slick-slide` is a generated wrapper around `.carousel__item`, and injecting `float: left` onto it restores the horizontal layout.

## Fix

Pin `slick-carousel` to exactly `1.6.0` and regenerate the lockfile. The carousel implementation is written for 1.6.0 (see the comment in `Carousel.js`), so this stops the lockfile drifting to an incompatible major.

Diff is minimal — `^1.6.0` → `1.6.0` plus the corresponding lockfile entries.

## Testing

- [ ] Carousels on the home page render horizontally with working prev/next arrows.