### PR TITLE
i18n(pl): AI translation update — sync with messages.pot (2026-06-16)

### DIFF
--- a/openlibrary/i18n/pl/messages.po
+++ b/openlibrary/i18n/pl/messages.po
@@ -53,7 +53,7 @@ msgstr "Wyświetl lub edytuj Twoje Listy"
 
 #: account.html
 msgid "Import and Export Options"
-msgstr ""
+msgstr "Opcje importu i eksportu"
 
 #: account.html
 #, fuzzy
@@ -67,7 +67,7 @@ msgstr "Zarządzaj swoimi ustawieniami prywatności"
 
 #: account.html
 msgid "Manage Mailing List Subscriptions"
-msgstr ""
+msgstr "Zarządzaj subskrypcjami listy mailingowej"
 
 #: account.html
 msgid "Change Password"
@@ -88,7 +88,7 @@ msgstr "Skontaktuj się z nami, jeśli potrzebujesz pomocy w innej sprawie."
 
 #: barcodescanner.html
 msgid "Barcode Scanner (Beta)"
-msgstr ""
+msgstr "Skaner kodów kreskowych (Beta)"
 
 #: batch_import.html
 #, fuzzy
@@ -97,23 +97,23 @@ msgstr "Autorzy"
 
 #: BatchImportNavigation.html batch_import.html
 msgid "New Batch Import"
-msgstr ""
+msgstr "Nowy import zbiorczy"
 
 #: batch_import.html
 msgid "Attach a JSONL formatted document with import records or copy/paste the JSONL text into the textarea."
-msgstr ""
+msgstr "Załącz dokument w formacie JSONL z rekordami importu lub wklej tekst JSONL do pola tekstowego."
 
 #: batch_import.html
 msgid "See the <a href=\"https://github.com/internetarchive/openlibrary-client/tree/master/olclient/schemata\">olclient import schemata</a> for more."
-msgstr ""
+msgstr "Zobacz <a href=\"https://github.com/internetarchive/openlibrary-client/tree/master/olclient/schemata\">schematy importu olclient</a>, aby dowiedzieć się więcej."
 
 #: batch_import.html
 msgid "Attach a file:"
-msgstr ""
+msgstr "Załącz plik:"
 
 #: batch_import.html
 msgid "Or copy/paste JSONL text:"
-msgstr ""
+msgstr "Lub wklej tekst JSONL:"
 
 #: batch_import.html import_preview.html
 #, fuzzy
@@ -127,52 +127,52 @@ msgstr "Nie udało się ustawić nowego hasła."
 
 #: batch_import.html
 msgid "No import will be queued until *every* record validates successfully."
-msgstr ""
+msgstr "Żaden import nie zostanie dodany do kolejki, dopóki *każdy* rekord nie przejdzie walidacji pomyślnie."
 
 #: batch_import.html
 msgid "Please update the JSONL file and reload this page (there should be no need to reattach the file)."
-msgstr ""
+msgstr "Zaktualizuj plik JSONL i odśwież tę stronę (nie powinno być potrzeby ponownego załączania pliku)."
 
 #: batch_import.html
 msgid "Validation errors:"
-msgstr ""
+msgstr "Błędy walidacji:"
 
 #: batch_import.html
 #, python-format
 msgid "Line %d:"
-msgstr ""
+msgstr "Linia %d:"
 
 #: batch_import.html
 msgid "Import results for batch:"
-msgstr ""
+msgstr "Wyniki importu dla partii:"
 
 #: batch_import.html
 msgid "Records submitted:"
-msgstr ""
+msgstr "Rekordy przesłane:"
 
 #: batch_import.html
 msgid "Total queued:"
-msgstr ""
+msgstr "Łącznie w kolejce:"
 
 #: batch_import.html
 msgid "Total skipped:"
-msgstr ""
+msgstr "Łącznie pominięte:"
 
 #: batch_import.html
 msgid "Not queued because they are already present in the queue:"
-msgstr ""
+msgstr "Nie dodano do kolejki, ponieważ są już w kolejce:"
 
 #: batch_import.html
 msgid "View Batch Status"
-msgstr ""
+msgstr "Zobacz status partii"
 
 #: batch_import_pending_view.html
 msgid "Pending Batch Imports"
-msgstr ""
+msgstr "Oczekujące importy zbiorcze"
 
 #: batch_import_pending_view.html
 msgid "batch_id"
-msgstr ""
+msgstr "identyfikator_partii"
 
 #: admin/imports.html admin/imports_by_date.html batch_import_pending_view.html batch_import_view.html
 #, fuzzy
@@ -195,11 +195,11 @@ msgstr "Komentarz"
 
 #: batch_import_view.html
 msgid "Batch Import Status"
-msgstr ""
+msgstr "Status importu zbiorczego"
 
 #: batch_import_view.html
 msgid "Batch ID:"
-msgstr ""
+msgstr "ID partii:"
 
 #: batch_import_view.html
 #, fuzzy
@@ -228,19 +228,19 @@ msgstr "Usuń"
 
 #: batch_import_view.html
 msgid "Import Items"
-msgstr ""
+msgstr "Importuj elementy"
 
 #: batch_import_view.html
 msgid "Import Time"
-msgstr ""
+msgstr "Czas importu"
 
 #: account/import.html admin/imports.html admin/imports_by_date.html batch_import_view.html librarian_dashboard/data_quality_table.html
 msgid "Error"
-msgstr ""
+msgstr "Błąd"
 
 #: batch_import_view.html
 msgid "IA ID"
-msgstr ""
+msgstr "ID IA"
 
 #: batch_import_view.html
 #, fuzzy
@@ -249,7 +249,7 @@ msgstr "Dorzuć się"
 
 #: admin/imports.html admin/imports_by_date.html batch_import_view.html
 msgid "OL Key"
-msgstr ""
+msgstr "Klucz OL"
 
 #: batch_import_view.html
 #, fuzzy
@@ -313,11 +313,11 @@ msgstr "Anuluj i wróć."
 
 #: edit_yaml.html
 msgid "YAML Representation:"
-msgstr ""
+msgstr "Reprezentacja YAML:"
 
 #: BookPreview.html book_providers/read_button.html books/edit/edition.html editpage.html import_preview.html
 msgid "Preview"
-msgstr ""
+msgstr "Podgląd"
 
 #: history.html
 msgid "History of edits to"
@@ -358,7 +358,7 @@ msgstr "Zobacz korekty %s"
 
 #: history.html
 msgid "Compare this version..."
-msgstr ""
+msgstr "Porównaj tę wersję..."
 
 #: history.html
 #, fuzzy
@@ -367,7 +367,7 @@ msgstr "Te wydanie"
 
 #: import_preview.html
 msgid "Import Preview"
-msgstr ""
+msgstr "Podgląd importu"
 
 #: import_preview.html
 #, fuzzy
@@ -376,57 +376,57 @@ msgstr "Wypożycz teraz"
 
 #: import_preview.html
 msgid "Show Raw Import Data"
-msgstr ""
+msgstr "Pokaż surowe dane importu"
 
 #: import_preview.html
 #, python-format
 msgid "New %(thing_type)s record will be created"
-msgstr ""
+msgstr "Zostanie utworzony nowy rekord %(thing_type)s"
 
 #: import_preview.html
 #, python-format
 msgid "Changes to %(key)s"
-msgstr ""
+msgstr "Zmiany w %(key)s"
 
 #: internalerror.html
 msgid "Internal Error"
-msgstr ""
+msgstr "Błąd wewnętrzny"
 
 #: internalerror.html
 msgid "A Problem Occurred"
-msgstr ""
+msgstr "Wystąpił problem"
 
 #: internalerror.html
 msgid "We're sorry, a problem occurred while responding to your request:"
-msgstr ""
+msgstr "Przepraszamy, wystąpił problem podczas przetwarzania Twojego żądania:"
 
 #: internalerror.html
 #, python-format
 msgid "The reference code %s and Sentry trace ID %s have been created to track this error and we will investigate as we're able."
-msgstr ""
+msgstr "Kod referencyjny %s i identyfikator śladu Sentry %s zostały utworzone, aby śledzić ten błąd – zbadamy go w miarę możliwości."
 
 #: internalerror.html
 #, python-format
 msgid "The reference code %s has been created to track this error and we will investigate as we're able."
-msgstr ""
+msgstr "Kod referencyjny %s został utworzony, aby śledzić ten błąd – zbadamy go w miarę możliwości."
 
 #: internalerror.html
 msgid "Return to the <a class=\"go-back-link\" href=\"javascript:;\">previous page</a>?"
-msgstr ""
+msgstr "Wróć do <a class=\"go-back-link\" href=\"javascript:;\">poprzedniej strony</a>?"
 
 #: interstitial.html
 msgid "You are being redirected to your book"
-msgstr ""
+msgstr "Za chwilę zostaniesz przekierowany do swojej książki"
 
 #: interstitial.html
 #, python-format
 msgid "This book is provided by %(book_provider)s, a third-party Open Library Trusted Book Provider"
-msgstr ""
+msgstr "Ta książka jest udostępniana przez %(book_provider)s, zaufanego zewnętrznego dostawcę książek Open Library"
 
 #: interstitial.html
 #, python-format
 msgid "In %(time)s seconds, you will be automatically redirected to: %(url)s"
-msgstr ""
+msgstr "Za %(time)s sekund zostaniesz automatycznie przekierowany do: %(url)s"
 
 #: CreateListModal.html EditButtons.html account/notifications.html account/password/reset.html account/privacy.html admin/imports-add.html admin/permissions.html books/add.html databarEdit.html interstitial.html merge/authors.html my_books/dropdown_content.html type/list/edit.html type/series/edit.html type/tag/form.html
 msgid "Cancel"
@@ -434,7 +434,7 @@ msgstr "Anuluj"
 
 #: interstitial.html
 msgid "Continue without waiting"
-msgstr ""
+msgstr "Kontynuuj bez czekania"
 
 #: lib/nav_head.html library_explorer.html
 #, fuzzy
@@ -452,7 +452,7 @@ msgstr "Zaloguj się"
 
 #: login.html
 msgid "This is a development instance, the default credentials are automatically filled."
-msgstr ""
+msgstr "To jest instancja deweloperska – domyślne dane logowania są wypełniane automatycznie."
 
 #: login.html
 #, fuzzy
@@ -466,7 +466,7 @@ msgstr "Hasło"
 
 #: login.html
 msgid "Log in to use your free Open Library card to borrow digital books from the nonprofit Internet Archive"
-msgstr ""
+msgstr "Zaloguj się, aby używać bezpłatnej karty Open Library do wypożyczania cyfrowych książek od organizacji non-profit Internet Archive"
 
 #: account/create.html login.html
 #, fuzzy
@@ -505,7 +505,7 @@ msgstr "Nie pamiętasz swojego hasła?"
 
 #: account/create.html login.html
 msgid "Toggle Password Visibility"
-msgstr ""
+msgstr "Przełącz widoczność hasła"
 
 #: login.html
 msgid "Remember me"
@@ -538,7 +538,7 @@ msgstr "Dodaj książkę"
 
 #: messages.html
 msgid "Thank you for improving the Open Library catalog!"
-msgstr ""
+msgstr "Dziękujemy za ulepszanie katalogu Open Library!"
 
 #: BookPreview.html CreateListModal.html NotesModal.html ObservationsModal.html ShareModal.html covers/author_photo.html covers/book_cover.html covers/change.html lib/exports.html my_books/check_ins/check_in_prompt.html my_books/dropdown_content.html native_dialog.html
 msgid "Close"
@@ -547,7 +547,7 @@ msgstr "Zamknij"
 #: notfound.html
 #, python-format
 msgid "%(path)s is not found"
-msgstr ""
+msgstr "%(path)s nie został znaleziony"
 
 #: languages/notfound.html notfound.html
 msgid "404 - Page Not Found"
@@ -556,7 +556,7 @@ msgstr "404 - Strona nie istnieje"
 #: notfound.html
 #, python-format
 msgid "%(path)s does not exist."
-msgstr ""
+msgstr "%(path)s nie istnieje."
 
 #: notfound.html
 msgid "Create it?"
@@ -564,12 +564,12 @@ msgstr "Utworzyć?"
 
 #: notfound.html
 msgid "Looking for a template/macro?"
-msgstr ""
+msgstr "Szukasz szablonu/makra?"
 
 #: permission.html
 #, python-format
 msgid "Permission of %(key)s"
-msgstr ""
+msgstr "Uprawnienia dla %(key)s"
 
 #: permission.html
 #, fuzzy
@@ -598,12 +598,12 @@ msgstr "Odmowa zezwolenia."
 #: permission_denied.html
 #, python-format
 msgid "Only logged users are allowed to add records on Open Library. Please <a href=\"%s\">log in</a> to add a book."
-msgstr ""
+msgstr "Tylko zalogowani użytkownicy mogą dodawać rekordy w Open Library. Proszę <a href=\"%s\">zaloguj się</a>, aby dodać książkę."
 
 #: permission_denied.html
 #, python-format
 msgid "Only logged users are allowed to modify records on Open Library. Please <a href=\"%s\">log in</a> to edit this page."
-msgstr ""
+msgstr "Tylko zalogowani użytkownicy mogą modyfikować rekordy w Open Library. Proszę <a href=\"%s\">zaloguj się</a>, aby edytować tę stronę."
 
 #: permission_denied.html
 #, python-format
@@ -617,15 +617,15 @@ msgstr "Jeśli nie widzisz reCAPTCHA, wyłącz chwilowo ustawienia zabezpieczeń
 
 #: recaptcha.html
 msgid "Incorrect. Please try again."
-msgstr ""
+msgstr "Nieprawidłowo. Proszę spróbuj ponownie."
 
 #: showamazon.html showbwb.html showgoogle_books.html
 msgid "Record details of"
-msgstr ""
+msgstr "Szczegóły rekordu"
 
 #: showamazon.html showbwb.html showgoogle_books.html
 msgid "This record came from"
-msgstr ""
+msgstr "Ten rekord pochodzi z"
 
 #: showia.html showmarc.html
 #, fuzzy
@@ -682,31 +682,31 @@ msgstr "Status"
 
 #: status.html
 msgid "Testing Environment"
-msgstr ""
+msgstr "Środowisko testowe"
 
 #: status.html
 msgid "Deploy triggered!"
-msgstr ""
+msgstr "Wdrożenie uruchomione!"
 
 #: status.html
 msgid "View Jenkins progress"
-msgstr ""
+msgstr "Zobacz postęp Jenkins"
 
 #: status.html
 msgid "GitHub status refreshed."
-msgstr ""
+msgstr "Status GitHub odświeżony."
 
 #: status.html
 msgid "PR numbers or URLs, space/comma separated"
-msgstr ""
+msgstr "Numery PR lub adresy URL, oddzielone spacją/przecinkiem"
 
 #: status.html
 msgid "Add PR(s)"
-msgstr ""
+msgstr "Dodaj PR(y)"
 
 #: status.html
 msgid "PR"
-msgstr ""
+msgstr "PR"
 
 #: books/add.html books/edit.html books/edit/edition.html search/advancedsearch.html status.html type/about/edit.html type/page/edit.html type/template/edit.html
 msgid "Title"
@@ -718,15 +718,15 @@ msgstr "Autor"
 
 #: status.html
 msgid "Assignee"
-msgstr ""
+msgstr "Przypisany"
 
 #: status.html
 msgid "Pinned Commit"
-msgstr ""
+msgstr "Przypięty commit"
 
 #: status.html
 msgid "Branch HEAD"
-msgstr ""
+msgstr "HEAD gałęzi"
 
 #: status.html
 #, fuzzy
@@ -740,7 +740,7 @@ msgstr "Umieść"
 
 #: status.html
 msgid "up to date"
-msgstr ""
+msgstr "aktualne"
 
 #: status.html
 #, fuzzy
@@ -749,12 +749,12 @@ msgstr "Nieznany autor"
 
 #: status.html
 msgid "1 commit behind"
-msgstr ""
+msgstr "1 commit za"
 
 #: status.html
 #, python-format
 msgid "%(count)s commits behind"
-msgstr ""
+msgstr "%(count)s commitów za"
 
 #: admin/solr.html status.html
 #, fuzzy
@@ -792,15 +792,15 @@ msgstr "Rozwijaj"
 
 #: status.html
 msgid "No PRs in testing set."
-msgstr ""
+msgstr "Brak PR-ów w zestawie testowym."
 
 #: status.html
 msgid "Last Build Result"
-msgstr ""
+msgstr "Ostatni wynik budowania"
 
 #: status.html
 msgid "View PRs on GitHub"
-msgstr ""
+msgstr "Zobacz PR-y na GitHub"
 
 #: status.html
 #, fuzzy
@@ -813,11 +813,11 @@ msgstr "Imię i nazwisko"
 
 #: status.html
 msgid "System information"
-msgstr ""
+msgstr "Informacje o systemie"
 
 #: status.html
 msgid "Features enabled"
-msgstr ""
+msgstr "Włączone funkcje"
 
 #: subjects.html
 msgid "Edit tag for this subject"

--- a/openlibrary/i18n/pl/messages.po
+++ b/openlibrary/i18n/pl/messages.po
@@ -1616,7 +1616,7 @@ msgstr "Usuń listę"
 
 #: account/observations.html
 msgid "Update Reviews"
-msgstr ""
+msgstr "Zaktualizuj recenzje"
 
 #: account/observations.html
 #, fuzzy
@@ -1634,11 +1634,11 @@ msgstr "Ustawienia prywatności"
 
 #: account/privacy.html
 msgid "Would you like to make your <a href=\"/account/books\">Reading Log</a> public?"
-msgstr ""
+msgstr "Czy chcesz upublicznić swój <a href=\"/account/books\">Dziennik Lektury</a>?"
 
 #: account/privacy.html
 msgid "This will enable others to see what books you want to read, are reading, stopped reading, or have already read. Patrons with reading logs set to public may be followed."
-msgstr ""
+msgstr "Umożliwi to innym zobaczenie, jakie książki chcesz przeczytać, czytasz, przestałeś czytać lub już przeczytałeś. Użytkownicy z publicznymi dziennikami lektury mogą być obserwowani."
 
 #: account/privacy.html admin/people/view.html
 msgid "Yes"
@@ -1650,11 +1650,11 @@ msgstr "Nie"
 
 #: account/privacy.html
 msgid "Enable Safe Mode?"
-msgstr ""
+msgstr "Włączyć tryb bezpieczny?"
 
 #: account/privacy.html
 msgid "Safe Mode blurs book covers that have been flagged as having sensitive imagery."
-msgstr ""
+msgstr "Tryb bezpieczny rozmywa okładki książek oznaczone jako zawierające wrażliwe treści graficzne."
 
 #: account/reading_log.html
 #, python-format
@@ -1689,12 +1689,12 @@ msgstr "%(username)s chce przeczytać %(total)d książek. Dołącz do %(usernam
 #: account/reading_log.html
 #, python-format
 msgid "Books %(username)s has read in %(year)d"
-msgstr ""
+msgstr "Książki przeczytane przez %(username)s w %(year)d"
 
 #: account/reading_log.html
 #, python-format
 msgid "%(username)s has read %(total)d books in %(year)d. Join %(username)s on OpenLibrary.org and tell the world about the books that you care about."
-msgstr ""
+msgstr "%(username)s przeczytał(a) %(total)d książek w %(year)d. Dołącz do %(username)s na OpenLibrary.org i opowiedz światu o książkach, które są dla Ciebie ważne."
 
 #: account/reading_log.html
 #, python-format
@@ -1714,7 +1714,7 @@ msgstr "Książki przeczytane przez %(username)s"
 #: account/reading_log.html
 #, python-format
 msgid "Books added by people %(username)s follows"
-msgstr ""
+msgstr "Książki dodane przez osoby obserwowane przez %(username)s"
 
 #: account/reading_log.html
 #, fuzzy
@@ -1724,7 +1724,7 @@ msgstr "Wyświetl lub edytuj Dziennik Lektur"
 #: account/reading_log.html type/author/view.html
 #, python-format
 msgid "— Show <a href=\"%(url)s\">only ebooks</a>?"
-msgstr ""
+msgstr "— Pokaż <a href=\"%(url)s\">tylko e-booki</a>?"
 
 #: account/reading_log.html
 #, fuzzy, python-format
@@ -1739,7 +1739,7 @@ msgstr "Brak wyników."
 #: account/reading_log.html
 #, python-format
 msgid "Search all of Open Library for \"%s\"?"
-msgstr ""
+msgstr "Wyszukać \"%s\" w całym Open Library?"
 
 #: account/reading_log.html
 #, fuzzy
@@ -1753,11 +1753,11 @@ msgstr "Obecnie nie masz zaznaczonych żadnych książek."
 
 #: account/reading_log.html
 msgid "<a href=\"/search\">Search for a book</a> to add to your reading log. <a href=\"/help/faq/reading-log\">Learn more</a> about the reading log."
-msgstr ""
+msgstr "<a href=\"/search\">Wyszukaj książkę</a>, aby dodać ją do dziennika lektury. <a href=\"/help/faq/reading-log\">Dowiedz się więcej</a> o dzienniku lektury."
 
 #: account/reading_log.html
 msgid "There are no recent books in your feed. When you follow public accounts, their book updates will appear here."
-msgstr ""
+msgstr "W Twoim kanale nie ma ostatnich książek. Gdy zaczniesz obserwować publiczne konta, ich aktualizacje książek będą się tutaj pojawiać."
 
 #. Display name for the "want-to-read" reading log shelf used in page headings
 #. and breadcrumbs.
@@ -1769,7 +1769,7 @@ msgstr "Chcę przeczytać"
 #: account/readinglog_stats.html
 #, python-format
 msgid "My %(shelf_name)s Stats"
-msgstr ""
+msgstr "Moje statystyki %(shelf_name)s"
 
 #: account/readinglog_stats.html home/loans.html lib/nav_head.html
 msgid "My Books"
@@ -1778,7 +1778,7 @@ msgstr "Moje książki"
 #: account/readinglog_stats.html
 #, python-format
 msgid "Displaying stats about <strong>%(works_count)d</strong> books. Note all charts show only the top 20 bars. Note reading log stats are private."
-msgstr ""
+msgstr "Wyświetlanie statystyk dla <strong>%(works_count)d</strong> książek. Uwaga: wszystkie wykresy pokazują tylko 20 najważniejszych pozycji. Statystyki dziennika lektury są prywatne."
 
 #: account/readinglog_stats.html
 #, fuzzy
@@ -1792,19 +1792,19 @@ msgstr "Zobacz autorów"
 
 #: account/readinglog_stats.html
 msgid "Works by Author Sex"
-msgstr ""
+msgstr "Dzieła według płci autora"
 
 #: account/readinglog_stats.html
 msgid "Works by Author Country of Citizenship"
-msgstr ""
+msgstr "Dzieła według kraju obywatelstwa autora"
 
 #: account/readinglog_stats.html
 msgid "Works by Author Country of Birth"
-msgstr ""
+msgstr "Dzieła według kraju urodzenia autora"
 
 #: account/readinglog_stats.html
 msgid "Demographic statistics powered by <a href=\"https://www.wikidata.org/\">Wikidata</a>. Here's a <a id=\"wd-query-sample\" href=\"\">sample</a> of the query used. <br />Improve these stats by adding the Wikidata author identifier following <a href=\"https://openlibrary.org/help/faq/editing.en#author-identifiers-purpose\">these instructions</a>."
-msgstr ""
+msgstr "Statystyki demograficzne dostarczane przez <a href=\"https://www.wikidata.org/\">Wikidata</a>. Oto <a id=\"wd-query-sample\" href=\"\">przykład</a> użytego zapytania. <br />Popraw te statystyki, dodając identyfikator autora Wikidata zgodnie z <a href=\"https://openlibrary.org/help/faq/editing.en#author-identifiers-purpose\">tymi instrukcjami</a>."
 
 #: account/readinglog_stats.html
 #, fuzzy
@@ -1828,15 +1828,15 @@ msgstr "Przeglądaj według tematów"
 
 #: account/readinglog_stats.html
 msgid "Works by People"
-msgstr ""
+msgstr "Dzieła według osób"
 
 #: account/readinglog_stats.html
 msgid "Works by Places"
-msgstr ""
+msgstr "Dzieła według miejsc"
 
 #: account/readinglog_stats.html
 msgid "Works by Time Period"
-msgstr ""
+msgstr "Dzieła według okresu"
 
 #: account/readinglog_stats.html
 #, fuzzy
@@ -1845,7 +1845,7 @@ msgstr "Usuń tę pozycję"
 
 #: account/readinglog_stats.html
 msgid "Click on a bar to see matching works"
-msgstr ""
+msgstr "Kliknij na słupek, aby zobaczyć pasujące dzieła"
 
 #: account/sidebar.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #, fuzzy
@@ -1855,12 +1855,12 @@ msgstr "1 plik inicujuący"
 #: account/sidebar.html
 #, python-format
 msgid "%(year)d Reading Goal"
-msgstr ""
+msgstr "Cel czytelniczy %(year)d"
 
 #: account/sidebar.html
 #, python-format
 msgid "Set %(year_span)s reading goal"
-msgstr ""
+msgstr "Ustaw cel czytelniczy %(year_span)s"
 
 #: account/sidebar.html search/sort_options.html type/user/view.html
 msgid "Reading Log"
@@ -1887,16 +1887,16 @@ msgstr "Stwórz nową listę"
 
 #: account/sidebar.html
 msgid "Untitled list"
-msgstr ""
+msgstr "Lista bez tytułu"
 
 #: account/topmenu.html
 msgid "Import & Export"
-msgstr ""
+msgstr "Import i eksport"
 
 #: account/topmenu.html
 #, python-format
 msgid "Privacy settings: %(public)s"
-msgstr ""
+msgstr "Ustawienia prywatności: %(public)s"
 
 #: account/verify.html
 msgid "Verification email sent"
@@ -1914,7 +1914,7 @@ msgstr ""
 
 #: account/verify.html
 msgid "Then, come back to Open Library and find some great books!"
-msgstr ""
+msgstr "Następnie wróć do Open Library i znajdź świetne książki!"
 
 #: account/view.html
 #, fuzzy
@@ -1923,7 +1923,7 @@ msgstr "Mój Dziennik Lektur"
 
 #: account/view.html books/mybooks_breadcrumb_select.html
 msgid "Following"
-msgstr ""
+msgstr "Obserwowani"
 
 #: account/view.html books/mybooks_breadcrumb_select.html
 #, fuzzy
@@ -1937,20 +1937,20 @@ msgstr "Zachowaj"
 
 #: account/view.html
 msgid "Your book notes are private and cannot be viewed by other patrons."
-msgstr ""
+msgstr "Twoje notatki do książek są prywatne i nie mogą być przeglądane przez innych użytkowników."
 
 #: account/view.html
 msgid "Your book reviews will be shared anonymously with other patrons."
-msgstr ""
+msgstr "Twoje recenzje książek będą udostępniane anonimowo innym użytkownikom."
 
 #: account/yrg_banner.html
 #, python-format
 msgid "Set your %(year)s Yearly Reading Goal:"
-msgstr ""
+msgstr "Ustaw swój roczny cel czytelniczy %(year)s:"
 
 #: account/yrg_banner.html
 msgid "Set my goal"
-msgstr ""
+msgstr "Ustaw mój cel"
 
 #: account/email/forgot-ia.html
 msgid "Forgot Your Internet Archive Email?"
@@ -1977,7 +1977,7 @@ msgstr "Open Library"
 
 #: account/email/forgot-ia.html
 msgid "Retrieve Archive.org Email"
-msgstr ""
+msgstr "Pobierz adres e-mail Archive.org"
 
 #: account/email/forgot-ia.html account/password/forgot.html
 msgid "Forgot your Archive.org Password?"
@@ -1989,7 +1989,7 @@ msgstr "Nazwa użytkownika/Przypomnij hasło"
 
 #: account/password/forgot.html
 msgid "Click here."
-msgstr ""
+msgstr "Kliknij tutaj."
 
 #: account/password/forgot.html
 msgid "Send It"
@@ -2026,39 +2026,39 @@ msgstr "Wysłaliśmy e-mail na\" %(email)s z przypomnieniem o Twojej nazwie uży
 
 #: account/security/check_email.html
 msgid "Account Security Check — 2026-04-28T18Z"
-msgstr ""
+msgstr "Sprawdzenie bezpieczeństwa konta — 2026-04-28T18Z"
 
 #: account/security/check_email.html
 msgid "Account Security Check"
-msgstr ""
+msgstr "Sprawdzenie bezpieczeństwa konta"
 
 #: account/security/check_email.html
 msgid "Incident date: 2026-04-28T18Z"
-msgstr ""
+msgstr "Data zdarzenia: 2026-04-28T18Z"
 
 #: account/security/check_email.html
 msgid "Check whether your Open Library account was in a set of accounts requiring attention."
-msgstr ""
+msgstr "Sprawdź, czy Twoje konto Open Library znalazło się w grupie kont wymagających uwagi."
 
 #: account/security/check_email.html
 msgid "Please <a href=\"/account/login?redirect=/account/security/2026-04-28T18\">log in</a> to check whether your account was affected."
-msgstr ""
+msgstr "Proszę <a href=\"/account/login?redirect=/account/security/2026-04-28T18\">zaloguj się</a>, aby sprawdzić, czy Twoje konto zostało naruszone."
 
 #: account/security/check_email.html
 msgid "Your account is in the affected set."
-msgstr ""
+msgstr "Twoje konto znajduje się w grupie dotkniętych."
 
 #: account/security/check_email.html
 msgid "Your account was found in our affected accounts list. Please review any recent communications from Open Library and consider updating your password."
-msgstr ""
+msgstr "Twoje konto zostało znalezione na liście dotkniętych kont. Prosimy zapoznać się z ostatnimi komunikatami od Open Library i rozważyć zmianę hasła."
 
 #: account/security/check_email.html
 msgid "Your account is <em>not</em> in the affected set."
-msgstr ""
+msgstr "Twoje konto <em>nie</em> znajduje się w grupie dotkniętych."
 
 #: account/security/check_email.html
 msgid "Your account was <em>not</em> found in the affected accounts list. No action is required."
-msgstr ""
+msgstr "Twoje konto <em>nie</em> zostało znalezione na liście dotkniętych kont. Nie jest wymagane żadne działanie."
 
 #: account/verify/activated.html
 msgid "Account already activated"
@@ -2079,7 +2079,7 @@ msgstr "Twój adres e-mail nie został zweryfikowany. Twój link weryfikacyjnyst
 
 #: account/verify/failed.html
 msgid "Fill your email and hit this button to resend a fresh verification email:"
-msgstr ""
+msgstr "Wprowadź swój adres e-mail i kliknij ten przycisk, aby ponownie wysłać e-mail weryfikacyjny:"
 
 #: account/verify/failed.html
 msgid "Enter your email address here"
@@ -2100,20 +2100,20 @@ msgstr "Super! Twój e-mail został zweryfikowany.<a href='%s'>Zaloguj się, aby
 
 #: admin/attach_debugger.html
 msgid "Attach Debugger"
-msgstr ""
+msgstr "Dołącz debugger"
 
 #: admin/attach_debugger.html
 #, python-format
 msgid "Attach Debugger on Python %(version_number)s"
-msgstr ""
+msgstr "Dołącz debugger do Python %(version_number)s"
 
 #: admin/attach_debugger.html
 msgid "Start a debugger on port 3000."
-msgstr ""
+msgstr "Uruchom debugger na porcie 3000."
 
 #: admin/attach_debugger.html
 msgid "Waiting for debugger to attach..."
-msgstr ""
+msgstr "Oczekiwanie na dołączenie debuggera..."
 
 #: admin/attach_debugger.html
 #, fuzzy
@@ -2128,15 +2128,15 @@ msgstr "Twój adres e-mail"
 #: admin/block.html
 #, python-format
 msgid "IP address %(address)s has been added to the textarea. Please click Save to block that IP."
-msgstr ""
+msgstr "Adres IP %(address)s został dodany do pola tekstowego. Kliknij Zapisz, aby zablokować ten adres IP."
 
 #: admin/block.html
 msgid "Blocked IP Addresses"
-msgstr ""
+msgstr "Zablokowane adresy IP"
 
 #: admin/graphs.html
 msgid "Performance Graphs"
-msgstr ""
+msgstr "Wykresy wydajności"
 
 #: admin/graphs.html
 #, fuzzy
@@ -2145,15 +2145,15 @@ msgstr "Liczba stron"
 
 #: admin/graphs.html
 msgid "Page Load Times"
-msgstr ""
+msgstr "Czasy ładowania stron"
 
 #: admin/graphs.html
 msgid "Page Load Times Split"
-msgstr ""
+msgstr "Podział czasów ładowania stron"
 
 #: admin/graphs.html
 msgid "Infobase Mean"
-msgstr ""
+msgstr "Średnia Infobase"
 
 #: admin/history.html admin/imports.html authors/infobox.html type/author/edit.html
 #, fuzzy
@@ -2181,7 +2181,7 @@ msgstr "Dodaj nową książkę do Open Library"
 
 #: admin/imports-add.html
 msgid "Please add IA identifiers to be imported, one per line."
-msgstr ""
+msgstr "Proszę dodać identyfikatory IA do zaimportowania, jeden w wierszu."
 
 #: admin/imports-add.html admin/inspect/store.html admin/ip/view.html admin/people/edits.html admin/permissions.html my_books/check_ins/check_in_form.html reading_goals/reading_goal_form.html
 msgid "Submit"
@@ -2189,7 +2189,7 @@ msgstr "Zatwierdź"
 
 #: admin/imports.html
 msgid "New Books Imported Per Day"
-msgstr ""
+msgstr "Nowe książki zaimportowane dziennie"
 
 #: PublishingHistory.html admin/imports.html publishers/view.html
 msgid "You need to have JavaScript turned on to see the nifty chart!"
@@ -2197,7 +2197,7 @@ msgstr "Musisz mieć włączony JavaScript, aby zobaczyć fajny wykres!"
 
 #: admin/imports.html admin/imports_by_date.html admin/pd_dashboard.html site/stats.html
 msgid "Summary"
-msgstr ""
+msgstr "Podsumowanie"
 
 #: admin/imports.html
 #, fuzzy
@@ -2207,7 +2207,7 @@ msgstr "Moje listy lektur:"
 #: admin/imports.html
 #, python-format
 msgid "<strong>Current Import Rate:</strong> %(num)d imports/hour."
-msgstr ""
+msgstr "<strong>Bieżące tempo importu:</strong> %(num)d importów/godzinę."
 
 #: admin/imports.html
 #, fuzzy
@@ -2216,7 +2216,7 @@ msgstr "Grubość"
 
 #: admin/imports.html
 msgid "Summary By Date"
-msgstr ""
+msgstr "Podsumowanie według daty"
 
 #: admin/imports.html
 #, fuzzy
@@ -2230,27 +2230,27 @@ msgstr "Utworzone Listy"
 
 #: admin/imports.html
 msgid "#books already found"
-msgstr ""
+msgstr "#książki już znalezione"
 
 #: admin/imports.html
 msgid "#books failed to import"
-msgstr ""
+msgstr "#książki, których import się nie powiódł"
 
 #: admin/imports.html
 msgid "#books pending"
-msgstr ""
+msgstr "#książki oczekujące"
 
 #: admin/imports.html
 msgid "Recent Imports"
-msgstr ""
+msgstr "Ostatnie importy"
 
 #: admin/imports.html admin/imports_by_date.html
 msgid "Identifier"
-msgstr ""
+msgstr "Identyfikator"
 
 #: admin/imports.html admin/imports_by_date.html
 msgid "Imported Time"
-msgstr ""
+msgstr "Czas importu"
 
 #: admin/imports_by_date.html admin/index.html admin/pd_dashboard.html
 #, fuzzy
@@ -2274,7 +2274,7 @@ msgstr "filtrów"
 
 #: admin/imports_by_date.html openlibrary/core/edits.py
 msgid "Pending"
-msgstr ""
+msgstr "Oczekujące"
 
 #: admin/imports_by_date.html
 #, fuzzy
@@ -2283,7 +2283,7 @@ msgstr "Motywy:"
 
 #: admin/index.html
 msgid "<span class=\"login-counts\">0</span> patrons have logged in at least once over the past 30 days."
-msgstr ""
+msgstr "<span class=\"login-counts\">0</span> użytkowników zalogowało się co najmniej raz w ciągu ostatnich 30 dni."
 
 #: admin/index.html
 #, fuzzy
@@ -2292,7 +2292,7 @@ msgstr "Status"
 
 #: admin/index.html
 msgid "Edits Per Day"
-msgstr ""
+msgstr "Edycje dziennie"
 
 #: admin/index.html admin/people/index.html
 #, fuzzy
@@ -2301,19 +2301,19 @@ msgstr "Edytuj"
 
 #: admin/index.html
 msgid "Yesterday"
-msgstr ""
+msgstr "Wczoraj"
 
 #: admin/index.html
 msgid "Last 7 days"
-msgstr ""
+msgstr "Ostatnie 7 dni"
 
 #: admin/index.html
 msgid "Last 28 days"
-msgstr ""
+msgstr "Ostatnie 28 dni"
 
 #: admin/index.html
 msgid "Human"
-msgstr ""
+msgstr "Człowiek"
 
 #: admin/index.html admin/people/view.html
 #, fuzzy

--- a/openlibrary/i18n/pl/messages.po
+++ b/openlibrary/i18n/pl/messages.po
@@ -8074,18 +8074,18 @@ msgstr "mniej"
 #: SearchResultsWork.html
 #, python-format
 msgid "Cover of edition %(id)s"
-msgstr ""
+msgstr "Okładka wydania %(id)s"
 
 #: SearchResultsWork.html
 #, python-format
 msgid "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d language</a>"
 msgid_plural "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d languages</a>"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "w <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d języku</a>"
+msgstr[1] "w <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d językach</a>"
 
 #: SearchResultsWork.html TrendingBadge.html
 msgid "This is only visible to librarians."
-msgstr ""
+msgstr "To jest widoczne tylko dla bibliotekarzy."
 
 #: SearchResultsWork.html
 #, fuzzy
@@ -8095,7 +8095,7 @@ msgstr "Podobe tytuły"
 #: ShareModal.html
 #, python-format
 msgid "Share on %(share_link)s"
-msgstr ""
+msgstr "Udostępnij w %(share_link)s"
 
 #: ShareModal.html
 msgid "Embed this book in your website"
@@ -8112,51 +8112,51 @@ msgstr "Umieść"
 
 #: ShareModal.html
 msgid "Copy url to clipboard"
-msgstr ""
+msgstr "Skopiuj adres URL do schowka"
 
 #: ShareModal.html
 msgid "Copy URL icon"
-msgstr ""
+msgstr "Ikona kopiowania URL"
 
 #: ShareModal.html
 msgid "Copy URL"
-msgstr ""
+msgstr "Kopiuj URL"
 
 #: ShareModal.html
 msgid "Open QR code"
-msgstr ""
+msgstr "Otwórz kod QR"
 
 #: ShareModal.html
 msgid "QR code icon"
-msgstr ""
+msgstr "Ikona kodu QR"
 
 #: ShareModal.html
 msgid "QR Code"
-msgstr ""
+msgstr "Kod QR"
 
 #: StarRatings.html
 msgid "leaving a 1 star review for"
-msgstr ""
+msgstr "wystawianie recenzji 1 gwiazdkowej dla"
 
 #: StarRatings.html
 msgid "leaving a 2 star review for"
-msgstr ""
+msgstr "wystawianie recenzji 2 gwiazdkowej dla"
 
 #: StarRatings.html
 msgid "leaving a 3 star review for"
-msgstr ""
+msgstr "wystawianie recenzji 3 gwiazdkowej dla"
 
 #: StarRatings.html
 msgid "leaving a 4 star review for"
-msgstr ""
+msgstr "wystawianie recenzji 4 gwiazdkowej dla"
 
 #: StarRatings.html
 msgid "leaving a 5 star review for"
-msgstr ""
+msgstr "wystawianie recenzji 5 gwiazdkowej dla"
 
 #: StarRatings.html
 msgid "Clear my rating"
-msgstr ""
+msgstr "Usuń moją ocenę"
 
 #: StarRatingsByline.html StarRatingsComponent.html
 #, fuzzy
@@ -8175,12 +8175,12 @@ msgstr "Akcje"
 #: StarRatingsByline.html
 #, python-format
 msgid "%(want_to_read_count)s Want to read"
-msgstr ""
+msgstr "%(want_to_read_count)s Chce przeczytać"
 
 #: StarRatingsComponent.html
 #, python-format
 msgid "%(ratings_avg)s (%(ratings_count)s %(ratings_label)s)"
-msgstr ""
+msgstr "%(ratings_avg)s (%(ratings_count)s %(ratings_label)s)"
 
 #. Short label displayed next to the count of readers who want to read this
 #. book, shown in the stats bar on a book page. Example: "2,389 Want to read".
@@ -8210,7 +8210,7 @@ msgstr "Przeczytane"
 #. Stopped reading".
 #: StarRatingsStats.html
 msgid "Stopped reading"
-msgstr ""
+msgstr "Przerwano czytanie"
 
 #: SubjectTags.html
 #, fuzzy
@@ -8224,7 +8224,7 @@ msgstr "Centrum programistów"
 
 #: Subnavigation.html
 msgid "Web API"
-msgstr ""
+msgstr "Web API"
 
 #: Subnavigation.html
 #, fuzzy
@@ -8248,7 +8248,7 @@ msgstr "Wymiary"
 
 #: Subnavigation.html
 msgid "Welcome"
-msgstr ""
+msgstr "Witamy"
 
 #: Subnavigation.html
 #, fuzzy
@@ -8262,7 +8262,7 @@ msgstr "Dziennik Lektur"
 
 #: Subnavigation.html
 msgid "Adding & Editing Books"
-msgstr ""
+msgstr "Dodawanie i edytowanie książek"
 
 #: Subnavigation.html
 #, fuzzy
@@ -8277,12 +8277,12 @@ msgstr "Open Library"
 #: TableOfContents.html
 #, python-format
 msgid "Page %s"
-msgstr ""
+msgstr "Strona %s"
 
 #: TrendingBadge.html
 #, python-format
 msgid "Trending: %(score).2f"
-msgstr ""
+msgstr "Trendy: %(score).2f"
 
 #: TypeChanger.html
 msgid "Page Type"
@@ -8306,7 +8306,7 @@ msgstr "(Najprostsze rozwiązanie: jeśli nie masz pewności, czy należy to zmi
 
 #: WorkInfo.html
 msgid "No link to Wikipedia in your language"
-msgstr ""
+msgstr "Brak linku do Wikipedii w Twoim języku"
 
 #: WorldcatLink.html
 msgid "Check nearby libraries"
@@ -8318,7 +8318,7 @@ msgstr "Przejdź na WorldCat, by znaleźć najbliższa bibliotekę z tym wydanie
 
 #: WorldcatLink.html
 msgid "WorldCat"
-msgstr ""
+msgstr "WorldCat"
 
 #: databarDiff.html databarEdit.html
 #, fuzzy
@@ -8327,16 +8327,16 @@ msgstr "Wróć na górę tej strony"
 
 #: databarDiff.html
 msgid "View this page (exit Comparison view)"
-msgstr ""
+msgstr "Wyświetl tę stronę (wyjdź z widoku porównania)"
 
 #: databarEdit.html
 msgid "View this page (exit Edit mode)"
-msgstr ""
+msgstr "Wyświetl tę stronę (wyjdź z trybu edycji)"
 
 #: databarHistory.html databarView.html
 #, python-format
 msgid "Last edited by %(author_link)s"
-msgstr ""
+msgstr "Ostatnio edytowane przez %(author_link)s"
 
 #: databarHistory.html databarView.html
 msgid "Last edited anonymously"
@@ -8344,7 +8344,7 @@ msgstr "Ostatnio edydowano anonimowo"
 
 #: databarTemplate.html databarView.html
 msgid "View this template's edit history"
-msgstr ""
+msgstr "Wyświetl historię edycji tego szablonu"
 
 #: databarTemplate.html
 msgid "Edit this template"
@@ -8353,11 +8353,11 @@ msgstr "Edytuj ten szablon"
 #: databarWork.html
 #, python-format
 msgid "View Volume %(num)d"
-msgstr ""
+msgstr "Wyświetl Tom %(num)d"
 
 #: openlibrary/core/bookshelves.py
 msgid "[Record deleted]"
-msgstr ""
+msgstr "[Rekord usunięty]"
 
 #: openlibrary/core/edits.py
 #, fuzzy
@@ -8375,7 +8375,7 @@ msgstr "Arabski"
 
 #: openlibrary/plugins/openlibrary/code.py
 msgid "Czech"
-msgstr ""
+msgstr "Czeski"
 
 #: openlibrary/plugins/openlibrary/code.py
 msgid "German"
@@ -8395,7 +8395,7 @@ msgstr "Francuski"
 
 #: openlibrary/plugins/openlibrary/code.py
 msgid "Hindi"
-msgstr ""
+msgstr "Hindi"
 
 #: openlibrary/plugins/openlibrary/code.py
 #, fuzzy
@@ -8417,15 +8417,15 @@ msgstr "Romanse"
 
 #: openlibrary/plugins/openlibrary/code.py
 msgid "Sardinian"
-msgstr ""
+msgstr "Sardyński"
 
 #: openlibrary/plugins/openlibrary/code.py
 msgid "Telugu"
-msgstr ""
+msgstr "Telugu"
 
 #: openlibrary/plugins/openlibrary/code.py
 msgid "Ukrainian"
-msgstr ""
+msgstr "Ukraiński"
 
 #: openlibrary/plugins/openlibrary/code.py
 msgid "Chinese"
@@ -8433,11 +8433,11 @@ msgstr "Chiński"
 
 #: openlibrary/plugins/openlibrary/code.py
 msgid "Filipino"
-msgstr ""
+msgstr "Filipiński"
 
 #: openlibrary/plugins/openlibrary/home.py
 msgid "Art"
-msgstr ""
+msgstr "Sztuka"
 
 #: openlibrary/plugins/openlibrary/home.py
 #, fuzzy
@@ -8451,7 +8451,7 @@ msgstr "dowolny"
 
 #: openlibrary/plugins/openlibrary/home.py
 msgid "Biographies"
-msgstr ""
+msgstr "Biografie"
 
 #: openlibrary/plugins/openlibrary/home.py
 #, fuzzy
@@ -8460,7 +8460,7 @@ msgstr "Seria"
 
 #: openlibrary/plugins/openlibrary/home.py
 msgid "Children"
-msgstr ""
+msgstr "Dla dzieci"
 
 #: openlibrary/plugins/openlibrary/home.py
 #, fuzzy
@@ -8474,7 +8474,7 @@ msgstr "Korekta"
 
 #: openlibrary/plugins/openlibrary/home.py
 msgid "Mystery and Detective Stories"
-msgstr ""
+msgstr "Kryminały i opowiadania detektywistyczne"
 
 #: openlibrary/plugins/openlibrary/home.py
 #, fuzzy
@@ -8483,7 +8483,7 @@ msgstr "Miejsca"
 
 #: openlibrary/plugins/openlibrary/home.py
 msgid "Music"
-msgstr ""
+msgstr "Muzyka"
 
 #: openlibrary/plugins/openlibrary/home.py
 #, fuzzy
@@ -8492,7 +8492,7 @@ msgstr "Anuluj"
 
 #: openlibrary/plugins/openlibrary/librarian_dashboard.py
 msgid "At least 1 subject"
-msgstr ""
+msgstr "Co najmniej 1 temat"
 
 #: openlibrary/plugins/openlibrary/librarian_dashboard.py
 #, fuzzy
@@ -8506,7 +8506,7 @@ msgstr "1 wydanie"
 
 #: openlibrary/plugins/openlibrary/librarian_dashboard.py
 msgid "Has work (orphaned)"
-msgstr ""
+msgstr "Ma dzieło (osierocone)"
 
 #: openlibrary/plugins/openlibrary/librarian_dashboard.py
 #, fuzzy
@@ -8555,51 +8555,51 @@ msgstr "Na pewno chcesz usunąć <strong>%(title)s</strong> z Twoich list?"
 
 #: openlibrary/plugins/openlibrary/partials.py
 msgid "Better World Books"
-msgstr ""
+msgstr "Better World Books"
 
 #: openlibrary/plugins/openlibrary/partials.py
 msgid " - includes shipping"
-msgstr ""
+msgstr " - wliczono koszt wysyłki"
 
 #: openlibrary/plugins/openlibrary/partials.py
 msgid "Amazon"
-msgstr ""
+msgstr "Amazon"
 
 #: openlibrary/plugins/openlibrary/partials.py
 msgid "Bookshop.org"
-msgstr ""
+msgstr "Bookshop.org"
 
 #: openlibrary/plugins/openlibrary/partials.py
 msgid "This work does not appear on any lists."
-msgstr ""
+msgstr "To dzieło nie pojawia się na żadnych listach."
 
 #: openlibrary/plugins/openlibrary/pd.py
 msgid "I don't have one yet"
-msgstr ""
+msgstr "Nie mam jeszcze żadnego"
 
 #: openlibrary/plugins/upstream/account.py
 msgid "The email address you entered is invalid"
-msgstr ""
+msgstr "Podany adres e-mail jest nieprawidłowy"
 
 #: openlibrary/plugins/upstream/account.py
 msgid "This account has been blocked"
-msgstr ""
+msgstr "To konto zostało zablokowane"
 
 #: openlibrary/plugins/upstream/account.py
 msgid "This account has been locked"
-msgstr ""
+msgstr "To konto zostało zablokowane"
 
 #: openlibrary/plugins/upstream/account.py
 msgid "No account was found with this email. Please try again"
-msgstr ""
+msgstr "Nie znaleziono konta z tym adresem e-mail. Spróbuj ponownie"
 
 #: openlibrary/plugins/upstream/account.py
 msgid "The password you entered is incorrect. Please try again"
-msgstr ""
+msgstr "Podane hasło jest nieprawidłowe. Spróbuj ponownie"
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Wrong password. Please try again"
-msgstr ""
+msgstr "Błędne hasło. Spróbuj ponownie"
 
 #: openlibrary/plugins/upstream/account.py
 #, fuzzy
@@ -8608,11 +8608,11 @@ msgstr "Wpisz nowe hasło do Twojego konta na Open Library"
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Please verify your Internet Archive account before logging in"
-msgstr ""
+msgstr "Zweryfikuj swoje konto Internet Archive przed zalogowaniem się"
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Please fill out all fields and try again"
-msgstr ""
+msgstr "Wypełnij wszystkie pola i spróbuj ponownie"
 
 #: openlibrary/plugins/upstream/account.py
 #, fuzzy
@@ -8626,15 +8626,15 @@ msgstr "Podany e-mail jest już zarejestrowany"
 
 #: openlibrary/plugins/upstream/account.py
 msgid "A problem occurred and we were unable to log you in."
-msgstr ""
+msgstr "Wystąpił problem i nie mogliśmy Cię zalogować."
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Login attempted with invalid Internet Archive s3 credentials."
-msgstr ""
+msgstr "Próba logowania z nieprawidłowymi poświadczeniami s3 Internet Archive."
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Servers are experiencing unusually high traffic, please try again later or email openlibrary@archive.org for help."
-msgstr ""
+msgstr "Serwery doświadczają niezwykle wysokiego ruchu, spróbuj ponownie później lub napisz na openlibrary@archive.org po pomoc."
 
 #: openlibrary/plugins/upstream/account.py
 #, fuzzy
@@ -8648,24 +8648,24 @@ msgstr "Hasła nie są identyczne."
 
 #: openlibrary/plugins/upstream/account.py
 msgid "A problem occurred and we were unable to log you in"
-msgstr ""
+msgstr "Wystąpił problem i nie mogliśmy Cię zalogować"
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Login or registration attempt hit an unexpected error, please try again or contact info@archive.org"
-msgstr ""
+msgstr "Próba logowania lub rejestracji napotkała nieoczekiwany błąd, spróbuj ponownie lub skontaktuj się z info@archive.org"
 
 #: openlibrary/plugins/upstream/account.py
 #, python-format
 msgid "Request failed with error code: %(error_code)s"
-msgstr ""
+msgstr "Żądanie nie powiodło się z kodem błędu: %(error_code)s"
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Thank you for registering an Open Library account and requesting special print disability access. You should receive an email detailing next steps in the process."
-msgstr ""
+msgstr "Dziękujemy za rejestrację konta Open Library i ubieganie się o specjalny dostęp dla osób z niepełnosprawnością druku. Powinieneś/aś otrzymać wiadomość e-mail z informacjami o następnych krokach."
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Username unavailable"
-msgstr ""
+msgstr "Nazwa użytkownika niedostępna"
 
 #: openlibrary/plugins/upstream/account.py openlibrary/plugins/upstream/forms.py
 msgid "Email already registered"
@@ -8673,15 +8673,15 @@ msgstr "Podany e-mail jest już zarejestrowany"
 
 #: openlibrary/plugins/upstream/account.py
 msgid "An Internet Archive account already exists with this email"
-msgstr ""
+msgstr "Konto Internet Archive z tym adresem e-mail już istnieje"
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Verification failed. The link may be invalid or expired. Please try registering again."
-msgstr ""
+msgstr "Weryfikacja nie powiodła się. Link może być nieprawidłowy lub wygasł. Spróbuj zarejestrować się ponownie."
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Your email has been verified. You are now logged in."
-msgstr ""
+msgstr "Twój adres e-mail został zweryfikowany. Jesteś teraz zalogowany/a."
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Notification preferences have been updated successfully."
@@ -8695,7 +8695,7 @@ msgstr "Kup tą książkę"
 #: openlibrary/plugins/upstream/borrow.py
 #, python-format
 msgid "Unable to return %s. Please try again later or contact info@archive.org."
-msgstr ""
+msgstr "Nie można zwrócić %s. Spróbuj ponownie później lub skontaktuj się z info@archive.org."
 
 #: openlibrary/plugins/upstream/borrow.py
 #, python-format

--- a/openlibrary/i18n/pl/messages.po
+++ b/openlibrary/i18n/pl/messages.po
@@ -18,7 +18,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.12.1\n"
 
-#: account.html account/notifications.html account/privacy.html lib/nav_head.html type/user/view.html
+#: account.html account/notifications.html account/privacy.html
+#: lib/nav_head.html type/user/view.html
 msgid "Settings"
 msgstr "Ustawienia"
 
@@ -35,7 +36,10 @@ msgstr "Wyświetl"
 msgid "or"
 msgstr "lub"
 
-#: account.html databarHistory.html databarTemplate.html databarView.html my_books/check_ins/check_in_prompt.html reading_goals/reading_goal_progress.html subjects.html type/edition/compact_title.html type/user/view.html
+#: account.html databarHistory.html databarTemplate.html databarView.html
+#: my_books/check_ins/check_in_prompt.html
+#: reading_goals/reading_goal_progress.html subjects.html
+#: type/edition/compact_title.html type/user/view.html
 msgid "Edit"
 msgstr "Edytuj"
 
@@ -100,12 +104,22 @@ msgid "New Batch Import"
 msgstr "Nowy import zbiorczy"
 
 #: batch_import.html
-msgid "Attach a JSONL formatted document with import records or copy/paste the JSONL text into the textarea."
-msgstr "Załącz dokument w formacie JSONL z rekordami importu lub wklej tekst JSONL do pola tekstowego."
+msgid ""
+"Attach a JSONL formatted document with import records or copy/paste the "
+"JSONL text into the textarea."
+msgstr ""
+"Załącz dokument w formacie JSONL z rekordami importu lub wklej tekst "
+"JSONL do pola tekstowego."
 
 #: batch_import.html
-msgid "See the <a href=\"https://github.com/internetarchive/openlibrary-client/tree/master/olclient/schemata\">olclient import schemata</a> for more."
-msgstr "Zobacz <a href=\"https://github.com/internetarchive/openlibrary-client/tree/master/olclient/schemata\">schematy importu olclient</a>, aby dowiedzieć się więcej."
+msgid ""
+"See the <a href=\"https://github.com/internetarchive/openlibrary-"
+"client/tree/master/olclient/schemata\">olclient import schemata</a> for "
+"more."
+msgstr ""
+"Zobacz <a href=\"https://github.com/internetarchive/openlibrary-"
+"client/tree/master/olclient/schemata\">schematy importu olclient</a>, aby"
+" dowiedzieć się więcej."
 
 #: batch_import.html
 msgid "Attach a file:"
@@ -127,11 +141,17 @@ msgstr "Nie udało się ustawić nowego hasła."
 
 #: batch_import.html
 msgid "No import will be queued until *every* record validates successfully."
-msgstr "Żaden import nie zostanie dodany do kolejki, dopóki *każdy* rekord nie przejdzie walidacji pomyślnie."
+msgstr ""
+"Żaden import nie zostanie dodany do kolejki, dopóki *każdy* rekord nie "
+"przejdzie walidacji pomyślnie."
 
 #: batch_import.html
-msgid "Please update the JSONL file and reload this page (there should be no need to reattach the file)."
-msgstr "Zaktualizuj plik JSONL i odśwież tę stronę (nie powinno być potrzeby ponownego załączania pliku)."
+msgid ""
+"Please update the JSONL file and reload this page (there should be no "
+"need to reattach the file)."
+msgstr ""
+"Zaktualizuj plik JSONL i odśwież tę stronę (nie powinno być potrzeby "
+"ponownego załączania pliku)."
 
 #: batch_import.html
 msgid "Validation errors:"
@@ -174,21 +194,27 @@ msgstr "Oczekujące importy zbiorcze"
 msgid "batch_id"
 msgstr "identyfikator_partii"
 
-#: admin/imports.html admin/imports_by_date.html batch_import_pending_view.html batch_import_view.html
+#: admin/imports.html admin/imports_by_date.html batch_import_pending_view.html
+#: batch_import_view.html
 #, fuzzy
 msgid "Added Time"
 msgstr "Dodano"
 
-#: account/import.html account/loans.html admin/imports.html admin/imports_by_date.html admin/loans_table.html admin/menu.html batch_import_pending_view.html batch_import_view.html librarian_dashboard/data_quality_table.html status.html
+#: account/import.html account/loans.html admin/imports.html
+#: admin/imports_by_date.html admin/loans_table.html admin/menu.html
+#: batch_import_pending_view.html batch_import_view.html
+#: librarian_dashboard/data_quality_table.html status.html
 msgid "Status"
 msgstr "Status"
 
-#: batch_import_pending_view.html batch_import_view.html merge_request_table/table_header.html
+#: batch_import_pending_view.html batch_import_view.html
+#: merge_request_table/table_header.html
 #, fuzzy
 msgid "Submitter"
 msgstr "Zatwierdź"
 
-#: RecentChangesAdmin.html batch_import_pending_view.html batch_import_view.html
+#: RecentChangesAdmin.html batch_import_pending_view.html
+#: batch_import_view.html
 #, fuzzy
 msgid "Comments"
 msgstr "Komentarz"
@@ -234,7 +260,8 @@ msgstr "Importuj elementy"
 msgid "Import Time"
 msgstr "Czas importu"
 
-#: account/import.html admin/imports.html admin/imports_by_date.html batch_import_view.html librarian_dashboard/data_quality_table.html
+#: account/import.html admin/imports.html admin/imports_by_date.html
+#: batch_import_view.html librarian_dashboard/data_quality_table.html
 msgid "Error"
 msgstr "Błąd"
 
@@ -315,7 +342,8 @@ msgstr "Anuluj i wróć."
 msgid "YAML Representation:"
 msgstr "Reprezentacja YAML:"
 
-#: BookPreview.html book_providers/read_button.html books/edit/edition.html editpage.html import_preview.html
+#: BookPreview.html book_providers/read_button.html books/edit/edition.html
+#: editpage.html import_preview.html
 msgid "Preview"
 msgstr "Podgląd"
 
@@ -327,15 +355,21 @@ msgstr "Historia zmian"
 msgid "Revision"
 msgstr "Korekta"
 
-#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html admin/ip/view.html admin/people/edits.html history.html recentchanges/render.html recentchanges/updated_records.html
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
+#: admin/ip/view.html admin/people/edits.html history.html
+#: recentchanges/render.html recentchanges/updated_records.html
 msgid "When"
 msgstr "Kiedy"
 
-#: RecentChanges.html admin/history.html admin/ip/view.html admin/loans_table.html admin/people/edits.html history.html recentchanges/render.html
+#: RecentChanges.html admin/history.html admin/ip/view.html
+#: admin/loans_table.html admin/people/edits.html history.html
+#: recentchanges/render.html
 msgid "Who"
 msgstr "Kto"
 
-#: RecentChanges.html RecentChangesUsers.html admin/history.html admin/ip/view.html admin/people/edits.html history.html recentchanges/render.html recentchanges/updated_records.html
+#: RecentChanges.html RecentChangesUsers.html admin/history.html
+#: admin/ip/view.html admin/people/edits.html history.html
+#: recentchanges/render.html recentchanges/updated_records.html
 msgid "Comment"
 msgstr "Komentarz"
 
@@ -402,17 +436,29 @@ msgstr "Przepraszamy, wystąpił problem podczas przetwarzania Twojego żądania
 
 #: internalerror.html
 #, python-format
-msgid "The reference code %s and Sentry trace ID %s have been created to track this error and we will investigate as we're able."
-msgstr "Kod referencyjny %s i identyfikator śladu Sentry %s zostały utworzone, aby śledzić ten błąd – zbadamy go w miarę możliwości."
+msgid ""
+"The reference code %s and Sentry trace ID %s have been created to track "
+"this error and we will investigate as we're able."
+msgstr ""
+"Kod referencyjny %s i identyfikator śladu Sentry %s zostały utworzone, "
+"aby śledzić ten błąd – zbadamy go w miarę możliwości."
 
 #: internalerror.html
 #, python-format
-msgid "The reference code %s has been created to track this error and we will investigate as we're able."
-msgstr "Kod referencyjny %s został utworzony, aby śledzić ten błąd – zbadamy go w miarę możliwości."
+msgid ""
+"The reference code %s has been created to track this error and we will "
+"investigate as we're able."
+msgstr ""
+"Kod referencyjny %s został utworzony, aby śledzić ten błąd – zbadamy go w"
+" miarę możliwości."
 
 #: internalerror.html
-msgid "Return to the <a class=\"go-back-link\" href=\"javascript:;\">previous page</a>?"
-msgstr "Wróć do <a class=\"go-back-link\" href=\"javascript:;\">poprzedniej strony</a>?"
+msgid ""
+"Return to the <a class=\"go-back-link\" href=\"javascript:;\">previous "
+"page</a>?"
+msgstr ""
+"Wróć do <a class=\"go-back-link\" href=\"javascript:;\">poprzedniej "
+"strony</a>?"
 
 #: interstitial.html
 msgid "You are being redirected to your book"
@@ -420,15 +466,23 @@ msgstr "Za chwilę zostaniesz przekierowany do swojej książki"
 
 #: interstitial.html
 #, python-format
-msgid "This book is provided by %(book_provider)s, a third-party Open Library Trusted Book Provider"
-msgstr "Ta książka jest udostępniana przez %(book_provider)s, zaufanego zewnętrznego dostawcę książek Open Library"
+msgid ""
+"This book is provided by %(book_provider)s, a third-party Open Library "
+"Trusted Book Provider"
+msgstr ""
+"Ta książka jest udostępniana przez %(book_provider)s, zaufanego "
+"zewnętrznego dostawcę książek Open Library"
 
 #: interstitial.html
 #, python-format
 msgid "In %(time)s seconds, you will be automatically redirected to: %(url)s"
 msgstr "Za %(time)s sekund zostaniesz automatycznie przekierowany do: %(url)s"
 
-#: CreateListModal.html EditButtons.html account/notifications.html account/password/reset.html account/privacy.html admin/imports-add.html admin/permissions.html books/add.html databarEdit.html interstitial.html merge/authors.html my_books/dropdown_content.html type/list/edit.html type/series/edit.html type/tag/form.html
+#: CreateListModal.html EditButtons.html account/notifications.html
+#: account/password/reset.html account/privacy.html admin/imports-add.html
+#: admin/permissions.html books/add.html databarEdit.html interstitial.html
+#: merge/authors.html my_books/dropdown_content.html type/list/edit.html
+#: type/series/edit.html type/tag/form.html
 msgid "Cancel"
 msgstr "Anuluj"
 
@@ -441,7 +495,9 @@ msgstr "Kontynuuj bez czekania"
 msgid "Library Explorer"
 msgstr "Biblioteka Kongresu"
 
-#: account/create.html books/custom_carousel.html librarian_dashboard/data_quality_table.html login.html search/work_search_facets.html
+#: account/create.html books/custom_carousel.html
+#: librarian_dashboard/data_quality_table.html login.html
+#: search/work_search_facets.html
 #, fuzzy
 msgid "Loading..."
 msgstr "zapisywanie..."
@@ -451,8 +507,12 @@ msgid "Log In"
 msgstr "Zaloguj się"
 
 #: login.html
-msgid "This is a development instance, the default credentials are automatically filled."
-msgstr "To jest instancja deweloperska – domyślne dane logowania są wypełniane automatycznie."
+msgid ""
+"This is a development instance, the default credentials are automatically"
+" filled."
+msgstr ""
+"To jest instancja deweloperska – domyślne dane logowania są wypełniane "
+"automatycznie."
 
 #: login.html
 #, fuzzy
@@ -465,8 +525,12 @@ msgid "password:"
 msgstr "Hasło"
 
 #: login.html
-msgid "Log in to use your free Open Library card to borrow digital books from the nonprofit Internet Archive"
-msgstr "Zaloguj się, aby używać bezpłatnej karty Open Library do wypożyczania cyfrowych książek od organizacji non-profit Internet Archive"
+msgid ""
+"Log in to use your free Open Library card to borrow digital books from "
+"the nonprofit Internet Archive"
+msgstr ""
+"Zaloguj się, aby używać bezpłatnej karty Open Library do wypożyczania "
+"cyfrowych książek od organizacji non-profit Internet Archive"
 
 #: account/create.html login.html
 #, fuzzy
@@ -480,12 +544,22 @@ msgstr "Jeśteś już zarejestrowany w Open Library jako %(user)s."
 
 #: account/create.html login.html
 #, fuzzy
-msgid "If you'd like to create a new, different Open Library account, you'll need to <a href=\"javascript:;\" onclick=\"document.forms['hamburger-logout'].submit()\">log out</a> and start the signup process afresh."
-msgstr "Jeśli chcesz utworzyć nowe konto na Open Library <a href=\"javascript:;\" onclick=\"document.forms['logout'].submit()\">Wyloguj się</a> i utwórz nowe konto."
+msgid ""
+"If you'd like to create a new, different Open Library account, you'll "
+"need to <a href=\"javascript:;\" onclick=\"document.forms['hamburger-"
+"logout'].submit()\">log out</a> and start the signup process afresh."
+msgstr ""
+"Jeśli chcesz utworzyć nowe konto na Open Library <a href=\"javascript:;\""
+" onclick=\"document.forms['logout'].submit()\">Wyloguj się</a> i utwórz "
+"nowe konto."
 
 #: login.html
-msgid "Please enter your <a href=\"https://archive.org\">Internet Archive</a> email and password to access your Open Library account."
-msgstr "Wprowadź swój <a href=\"https://archive.org\">Internet Archive</a> e-mail i hasło umożliwiające dostęp do konta Open Library."
+msgid ""
+"Please enter your <a href=\"https://archive.org\">Internet Archive</a> "
+"email and password to access your Open Library account."
+msgstr ""
+"Wprowadź swój <a href=\"https://archive.org\">Internet Archive</a> e-mail"
+" i hasło umożliwiające dostęp do konta Open Library."
 
 #: login.html openlibrary/plugins/upstream/forms.py
 msgid "Email"
@@ -495,7 +569,8 @@ msgstr "E-mail"
 msgid "Forgot your Internet Archive email?"
 msgstr "Nie pamiętasz e-maila z Internet Archive?"
 
-#: account/email/forgot-ia.html login.html openlibrary/plugins/upstream/forms.py
+#: account/email/forgot-ia.html login.html
+#: openlibrary/plugins/upstream/forms.py
 msgid "Password"
 msgstr "Hasło"
 
@@ -514,7 +589,9 @@ msgstr "\"Zapamniętaj mnie"
 #: login.html
 #, fuzzy
 msgid "Don't have an account? <a href=\"/account/create\">Sign up now</a>."
-msgstr "Nie masz jeszcze konta na Open Library? <a href=\"/account/create\">Utwórz konto</a>."
+msgstr ""
+"Nie masz jeszcze konta na Open Library? <a "
+"href=\"/account/create\">Utwórz konto</a>."
 
 #: messages.html
 #, fuzzy
@@ -540,7 +617,10 @@ msgstr "Dodaj książkę"
 msgid "Thank you for improving the Open Library catalog!"
 msgstr "Dziękujemy za ulepszanie katalogu Open Library!"
 
-#: BookPreview.html CreateListModal.html NotesModal.html ObservationsModal.html ShareModal.html covers/author_photo.html covers/book_cover.html covers/change.html lib/exports.html my_books/check_ins/check_in_prompt.html my_books/dropdown_content.html native_dialog.html
+#: BookPreview.html CreateListModal.html NotesModal.html ObservationsModal.html
+#: ShareModal.html covers/author_photo.html covers/book_cover.html
+#: covers/change.html lib/exports.html my_books/check_ins/check_in_prompt.html
+#: my_books/dropdown_content.html native_dialog.html
 msgid "Close"
 msgstr "Zamknij"
 
@@ -597,13 +677,21 @@ msgstr "Odmowa zezwolenia."
 
 #: permission_denied.html
 #, python-format
-msgid "Only logged users are allowed to add records on Open Library. Please <a href=\"%s\">log in</a> to add a book."
-msgstr "Tylko zalogowani użytkownicy mogą dodawać rekordy w Open Library. Proszę <a href=\"%s\">zaloguj się</a>, aby dodać książkę."
+msgid ""
+"Only logged users are allowed to add records on Open Library. Please <a "
+"href=\"%s\">log in</a> to add a book."
+msgstr ""
+"Tylko zalogowani użytkownicy mogą dodawać rekordy w Open Library. Proszę "
+"<a href=\"%s\">zaloguj się</a>, aby dodać książkę."
 
 #: permission_denied.html
 #, python-format
-msgid "Only logged users are allowed to modify records on Open Library. Please <a href=\"%s\">log in</a> to edit this page."
-msgstr "Tylko zalogowani użytkownicy mogą modyfikować rekordy w Open Library. Proszę <a href=\"%s\">zaloguj się</a>, aby edytować tę stronę."
+msgid ""
+"Only logged users are allowed to modify records on Open Library. Please "
+"<a href=\"%s\">log in</a> to edit this page."
+msgstr ""
+"Tylko zalogowani użytkownicy mogą modyfikować rekordy w Open Library. "
+"Proszę <a href=\"%s\">zaloguj się</a>, aby edytować tę stronę."
 
 #: permission_denied.html
 #, python-format
@@ -612,8 +700,12 @@ msgstr "Możesz się <a href=\"%s\">zalogować</a> jeśli masz wymagane uprawnie
 
 #: recaptcha.html
 #, fuzzy
-msgid "Please satisfy the reCAPTCHA below. If you have security settings or privacy blockers installed, please disable them to see the reCAPTCHA."
-msgstr "Jeśli nie widzisz reCAPTCHA, wyłącz chwilowo ustawienia zabezpieczeń lub inne programy blokujące prywatność."
+msgid ""
+"Please satisfy the reCAPTCHA below. If you have security settings or "
+"privacy blockers installed, please disable them to see the reCAPTCHA."
+msgstr ""
+"Jeśli nie widzisz reCAPTCHA, wyłącz chwilowo ustawienia zabezpieczeń lub "
+"inne programy blokujące prywatność."
 
 #: recaptcha.html
 msgid "Incorrect. Please try again."
@@ -637,7 +729,8 @@ msgstr "Pole wymagane"
 msgid "Source"
 msgstr "więcej"
 
-#: books/add.html covers/add.html showia.html type/edition/view.html type/work/view.html
+#: books/add.html covers/add.html showia.html type/edition/view.html
+#: type/work/view.html
 msgid "Internet Archive"
 msgstr "Internet Archive"
 
@@ -708,11 +801,16 @@ msgstr "Dodaj PR(y)"
 msgid "PR"
 msgstr "PR"
 
-#: books/add.html books/edit.html books/edit/edition.html search/advancedsearch.html status.html type/about/edit.html type/page/edit.html type/template/edit.html
+#: books/add.html books/edit.html books/edit/edition.html
+#: search/advancedsearch.html status.html type/about/edit.html
+#: type/page/edit.html type/template/edit.html
 msgid "Title"
 msgstr "Tytuł"
 
-#: books/add.html books/edit.html books/edit/edition.html openlibrary/plugins/worksearch/code.py search/advancedsearch.html search/search_modal_i18n.html search/work_search_selected_facets.html status.html
+#: books/add.html books/edit.html books/edit/edition.html
+#: openlibrary/plugins/worksearch/code.py search/advancedsearch.html
+#: search/search_modal_i18n.html search/work_search_selected_facets.html
+#: status.html
 msgid "Author"
 msgstr "Autor"
 
@@ -807,7 +905,8 @@ msgstr "Zobacz PR-y na GitHub"
 msgid "Show changed files"
 msgstr "Nie zmnieniono"
 
-#: admin/inspect/store.html admin/people/index.html status.html type/author/edit.html type/language/view.html
+#: admin/inspect/store.html admin/people/index.html status.html
+#: type/author/edit.html type/language/view.html
 msgid "Name"
 msgstr "Imię i nazwisko"
 
@@ -853,7 +952,8 @@ msgstr "Ujednoznacznienia"
 msgid "Now"
 msgstr "Nie"
 
-#: admin/graphs.html admin/index.html my_books/check_ins/check_in_form.html my_books/check_ins/check_in_prompt.html trending.html
+#: admin/graphs.html admin/index.html my_books/check_ins/check_in_form.html
+#: my_books/check_ins/check_in_prompt.html trending.html
 msgid "Today"
 msgstr "Dziś"
 
@@ -890,7 +990,8 @@ msgstr "Najwcześniejsze dane o trendach pochodzą z października 2017"
 
 #. Label for the reading log shelf for books the user plans to read in the
 #. future (bookshelf ID 1). Used as a button label and shelf name.
-#: account/mybooks.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html trending.html
+#: account/mybooks.html account/sidebar.html my_books/dropdown_content.html
+#: my_books/primary_action.html search/sort_options.html trending.html
 msgid "Want to Read"
 msgstr "Chcę przeczytać"
 
@@ -898,11 +999,15 @@ msgstr "Chcę przeczytać"
 #. headings and breadcrumbs.
 #. Label for the reading log shelf for books the user is actively reading
 #. (bookshelf ID 2). Used as a button label and shelf name.
-#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html trending.html
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
+#: my_books/dropdown_content.html my_books/primary_action.html
+#: search/sort_options.html trending.html
 msgid "Currently Reading"
 msgstr "W trakcie czytania"
 
-#: LoanReadForm.html ReadButton.html admin/inspect/memcache.html book_providers/read_button.html books/edit/edition.html trending.html type/list/embed.html widget.html
+#: LoanReadForm.html ReadButton.html admin/inspect/memcache.html
+#: book_providers/read_button.html books/edit/edition.html trending.html
+#: type/list/embed.html widget.html
 msgid "Read"
 msgstr "Przeczytaj"
 
@@ -912,7 +1017,9 @@ msgstr "Przeczytaj"
 #. finishing (bookshelf ID 4). Used as a button label and shelf name.
 #. Label for the reading log shelf for books the user stopped reading
 #. (bookshelf ID 4). Used as a button label and shelf name.
-#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html trending.html
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
+#: my_books/dropdown_content.html my_books/primary_action.html
+#: search/sort_options.html trending.html
 msgid "Stopped Reading"
 msgstr "Przestał czytać"
 
@@ -993,8 +1100,12 @@ msgstr "Dowiedz się więcej"
 
 #: widget.html
 #, python-format
-msgid "on <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"%(link)s\">openlibrary.org</a>"
-msgstr "na <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"%(link)s\">openlibrary.org</a>"
+msgid ""
+"on <a target=\"_blank\" rel=\"noopener noreferrer\" "
+"href=\"%(link)s\">openlibrary.org</a>"
+msgstr ""
+"na <a target=\"_blank\" rel=\"noopener noreferrer\" "
+"href=\"%(link)s\">openlibrary.org</a>"
 
 #: work_search.html
 #, fuzzy
@@ -1015,7 +1126,8 @@ msgstr "To jest widoczne tylko dla super bibliotekarzy."
 msgid "Solr Editions"
 msgstr "Większość wydań"
 
-#: design/toggle.html openlibrary/plugins/worksearch/code.py search/availability_i18n.html work_search.html
+#: design/toggle.html openlibrary/plugins/worksearch/code.py
+#: search/availability_i18n.html work_search.html
 #, fuzzy
 msgid "Readable Only"
 msgstr "Tylko administratorzy"
@@ -1024,7 +1136,8 @@ msgstr "Tylko administratorzy"
 msgid "Filter by availability"
 msgstr "Filtruj według dostępności"
 
-#: openlibrary/plugins/worksearch/code.py search/search_modal_i18n.html type/edition/view.html type/work/view.html work_search.html
+#: openlibrary/plugins/worksearch/code.py search/search_modal_i18n.html
+#: type/edition/view.html type/work/view.html work_search.html
 msgid "Language"
 msgstr "Język"
 
@@ -1033,7 +1146,8 @@ msgstr "Język"
 msgid "Search languages…"
 msgstr "Wybierz ten język"
 
-#: books/edit/edition.html languages/index.html search/search_modal_i18n.html work_search.html
+#: books/edit/edition.html languages/index.html search/search_modal_i18n.html
+#: work_search.html
 #, fuzzy
 msgid "Languages"
 msgstr "Język"
@@ -1057,7 +1171,9 @@ msgstr "Pełny URL:"
 #: work_search.html
 #, python-format
 msgid "No <strong>%(path_id)s</strong> directly matched your search."
-msgstr "Żaden <strong>%(path_id)s</strong> nie pasuje bezpośrednio do Twojego wyszukiwania."
+msgstr ""
+"Żaden <strong>%(path_id)s</strong> nie pasuje bezpośrednio do Twojego "
+"wyszukiwania."
 
 #: work_search.html
 #, fuzzy
@@ -1069,7 +1185,8 @@ msgstr "Dodaj książkę"
 msgid "Checking Search Inside matches"
 msgstr "Szukaj w"
 
-#: account/reading_log.html search/authors.html search/lists.html search/subjects.html work_search.html
+#: account/reading_log.html search/authors.html search/lists.html
+#: search/subjects.html work_search.html
 #, python-format
 msgid "%(count)s hit"
 msgid_plural "%(count)s hits"
@@ -1087,8 +1204,12 @@ msgid "The Open Library Team"
 msgstr "Open Library"
 
 #: about/index.html
-msgid "Open Library is made possible because of a dedicated team of staff and over 100 volunteers from around the globe."
-msgstr "Open Library jest możliwe dzięki zaangażowanemu zespołowi pracowników i ponad 100 wolontariuszy z całego świata."
+msgid ""
+"Open Library is made possible because of a dedicated team of staff and "
+"over 100 volunteers from around the globe."
+msgstr ""
+"Open Library jest możliwe dzięki zaangażowanemu zespołowi pracowników i "
+"ponad 100 wolontariuszy z całego świata."
 
 #: about/index.html
 msgid "Want to join us?"
@@ -1139,8 +1260,16 @@ msgid "Librarianship"
 msgstr "Bibliotekarstwo"
 
 #: about/index.html
-msgid "If you volunteer with Open Library and would like to be listed as part of the team, then complete the <a href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">Open Library team information form</a>."
-msgstr "Jeśli wolontariacko pracujesz z Open Library i chcesz być wymieniony jako część zespołu, wypełnij <a href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">formularz informacyjny zespołu Open Library</a>."
+msgid ""
+"If you volunteer with Open Library and would like to be listed as part of"
+" the team, then complete the <a "
+"href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">Open Library team "
+"information form</a>."
+msgstr ""
+"Jeśli wolontariacko pracujesz z Open Library i chcesz być wymieniony jako"
+" część zespołu, wypełnij <a "
+"href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">formularz informacyjny "
+"zespołu Open Library</a>."
 
 #: account/create.html openlibrary/plugins/upstream/forms.py
 msgid "Must be a valid email address"
@@ -1167,8 +1296,12 @@ msgid "Sign Up"
 msgstr "Załóż konto"
 
 #: account/create.html
-msgid "Get your free Open Library card and borrow digital books from the nonprofit Internet Archive"
-msgstr "Zdobądź bezpłatną kartę Open Library i wypożyczaj cyfrowe książki od organizacji non-profit Internet Archive"
+msgid ""
+"Get your free Open Library card and borrow digital books from the "
+"nonprofit Internet Archive"
+msgstr ""
+"Zdobądź bezpłatną kartę Open Library i wypożyczaj cyfrowe książki od "
+"organizacji non-profit Internet Archive"
 
 #: account/create.html type/author/view.html
 msgid "Success!"
@@ -1185,28 +1318,51 @@ msgid "screenname"
 msgstr "Nazwa użytkownika"
 
 #: account/create.html
-msgid "I want to receive news, announcements, and resources from the <a href=\"https://archive.org/\">Internet Archive</a>, the non-profit that runs Open Library."
-msgstr "Chcę otrzymywać wiadomości, ogłoszenia i zasoby od <a href=\"https://archive.org/\">Internet Archive</a>, organizacji non-profit prowadzącej Open Library."
+msgid ""
+"I want to receive news, announcements, and resources from the <a "
+"href=\"https://archive.org/\">Internet Archive</a>, the non-profit that "
+"runs Open Library."
+msgstr ""
+"Chcę otrzymywać wiadomości, ogłoszenia i zasoby od <a "
+"href=\"https://archive.org/\">Internet Archive</a>, organizacji non-"
+"profit prowadzącej Open Library."
 
 #: account/create.html
-msgid "I want to apply* for <a href=\"https://help.archive.org/help/program-overview/\" target=\"_blank\" rel=\"noopener noreferrer\">special print disability access</a> through a qualifying program."
-msgstr "Chcę ubiegać się* o <a href=\"https://help.archive.org/help/program-overview/\" target=\"_blank\" rel=\"noopener noreferrer\">specjalny dostęp dla osób z niepełnosprawnością druku</a> przez kwalifikujący program."
+msgid ""
+"I want to apply* for <a href=\"https://help.archive.org/help/program-"
+"overview/\" target=\"_blank\" rel=\"noopener noreferrer\">special print "
+"disability access</a> through a qualifying program."
+msgstr ""
+"Chcę ubiegać się* o <a href=\"https://help.archive.org/help/program-"
+"overview/\" target=\"_blank\" rel=\"noopener noreferrer\">specjalny "
+"dostęp dla osób z niepełnosprawnością druku</a> przez kwalifikujący "
+"program."
 
 #: account/create.html
 msgid "Select qualifying program"
 msgstr "Wybierz kwalifikujący program"
 
 #: account/create.html
-msgid "* Please use the email address associated with this qualifying program. You will receive an email after activation with next steps."
-msgstr "* Proszę użyć adresu e-mail powiązanego z tym kwalifikującym programem. Po aktywacji otrzymasz e-mail z kolejnymi krokami."
+msgid ""
+"* Please use the email address associated with this qualifying program. "
+"You will receive an email after activation with next steps."
+msgstr ""
+"* Proszę użyć adresu e-mail powiązanego z tym kwalifikującym programem. "
+"Po aktywacji otrzymasz e-mail z kolejnymi krokami."
 
 #: account/create.html
 msgid "Sign Up with Email"
 msgstr "Zarejestruj się przez e-mail"
 
 #: account/create.html
-msgid "By signing up, you agree to the Internet Archive's <a class=\"ol-signup-form__link\" href=\"//archive.org/about/terms.php\" target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
-msgstr "Rejestrując się, zgadzasz się z <a class=\"ol-signup-form__link\" href=\"//archive.org/about/terms.php\" target=\"_blank\" rel=\"noopener noreferrer\">Warunkami usługi</a> Internet Archive."
+msgid ""
+"By signing up, you agree to the Internet Archive's <a class=\"ol-signup-"
+"form__link\" href=\"//archive.org/about/terms.php\" target=\"_blank\" "
+"rel=\"noopener noreferrer\">Terms of Service</a>."
+msgstr ""
+"Rejestrując się, zgadzasz się z <a class=\"ol-signup-form__link\" "
+"href=\"//archive.org/about/terms.php\" target=\"_blank\" rel=\"noopener "
+"noreferrer\">Warunkami usługi</a> Internet Archive."
 
 #: account/create.html
 msgid "Already have an account? <a href=\"/account/login\">Log in</a>"
@@ -1230,8 +1386,14 @@ msgid "Import from Goodreads"
 msgstr "Importuj z Goodreads"
 
 #: account/import.html
-msgid "For instructions on exporting data refer to: <a href=\"https://www.goodreads.com/review/import\">Goodreads Import/Export</a>"
-msgstr "Instrukcje dotyczące eksportu danych znajdziesz tutaj: <a href=\"https://www.goodreads.com/review/import\">Goodreads Import/Export</a>"
+msgid ""
+"For instructions on exporting data refer to: <a "
+"href=\"https://www.goodreads.com/review/import\">Goodreads "
+"Import/Export</a>"
+msgstr ""
+"Instrukcje dotyczące eksportu danych znajdziesz tutaj: <a "
+"href=\"https://www.goodreads.com/review/import\">Goodreads "
+"Import/Export</a>"
 
 #: account/import.html
 msgid "File size limit 10MB and .csv file type only"
@@ -1386,10 +1548,16 @@ msgid "Leave the Waiting List"
 msgstr "Opuść Listę Oczekujących"
 
 #: account/loans.html
-msgid "Are you sure you want to leave the waiting list of<br/><strong>TITLE</strong>?"
-msgstr "Czy na pewno chcesz opuścić listę oczekujących na<br/><strong>TITLE</strong>?"
+msgid ""
+"Are you sure you want to leave the waiting list "
+"of<br/><strong>TITLE</strong>?"
+msgstr ""
+"Czy na pewno chcesz opuścić listę oczekujących "
+"na<br/><strong>TITLE</strong>?"
 
-#: ProlificAuthors.html account/loans.html authors/index.html lists/list_follow.html lists/showcase.html publishers/view.html search/authors.html search/publishers.html search/subjects.html
+#: ProlificAuthors.html account/loans.html authors/index.html
+#: lists/list_follow.html lists/showcase.html publishers/view.html
+#: search/authors.html search/publishers.html search/subjects.html
 #, fuzzy, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
@@ -1438,8 +1606,12 @@ msgid "Leave the waiting list?"
 msgstr "Opuścić listę oczekujących?"
 
 #: account/loans.html
-msgid "Looking for a book to borrow?  Check out our staff picks, or search for a book on a specific subject:"
-msgstr "Szukasz książki do wypożyczenia? Sprawdź nasze polecenia lub wyszukaj książkę na określony temat:"
+msgid ""
+"Looking for a book to borrow?  Check out our staff picks, or search for a"
+" book on a specific subject:"
+msgstr ""
+"Szukasz książki do wypożyczenia? Sprawdź nasze polecenia lub wyszukaj "
+"książkę na określony temat:"
 
 #: account/loans.html home/index.html
 msgid "Books We Love"
@@ -1461,7 +1633,9 @@ msgstr "Wypożyczone przeze mnie"
 #. and breadcrumbs.
 #. Label for the reading log shelf for books the user has finished reading
 #. (bookshelf ID 3). Used as a button label and shelf name.
-#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html openlibrary/plugins/upstream/mybooks.py search/sort_options.html
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
+#: my_books/dropdown_content.html my_books/primary_action.html
+#: openlibrary/plugins/upstream/mybooks.py search/sort_options.html
 msgid "Already Read"
 msgstr "Przeczytane"
 
@@ -1489,7 +1663,8 @@ msgstr "Moje listy"
 msgid "My Reading Stats"
 msgstr "Moje listy lektur:"
 
-#: account/mybooks.html account/sidebar.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
+#: account/mybooks.html account/sidebar.html
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
 #, fuzzy
 msgid "Loan History"
 msgstr "Historia"
@@ -1519,8 +1694,14 @@ msgstr "E-mail nie mógł zostać zweryfikowany."
 
 #: account/not_verified.html
 #, python-format
-msgid "When you created your account, we sent an email to %(email)s that contained a link for you to verify your email address. We need you to click that link, please."
-msgstr "Kiedy tworzyłeś swoje konto, wysłaliśmy e-mail na adres %(email)s zawierający link do weryfikacji Twojego adresu e-mail. Prosimy kliknąć ten link."
+msgid ""
+"When you created your account, we sent an email to %(email)s that "
+"contained a link for you to verify your email address. We need you to "
+"click that link, please."
+msgstr ""
+"Kiedy tworzyłeś swoje konto, wysłaliśmy e-mail na adres %(email)s "
+"zawierający link do weryfikacji Twojego adresu e-mail. Prosimy kliknąć "
+"ten link."
 
 #: account/not_verified.html
 msgid "If you can't find the email, just hit this button to send a fresh one:"
@@ -1534,7 +1715,8 @@ msgstr "Wyślij e-mail weryfikacyjny ponownie"
 msgid "Thanks!"
 msgstr "Dziękujemy!"
 
-#: BookByline.html FulltextSearchSuggestionItem.html SearchResultsWork.html account/notes.html account/observations.html
+#: BookByline.html FulltextSearchSuggestionItem.html SearchResultsWork.html
+#: account/notes.html account/observations.html
 msgid "Unknown author"
 msgstr "Nieznany autor"
 
@@ -1552,7 +1734,8 @@ msgstr "brakuje imienia"
 msgid "Publish date unknown"
 msgstr "Data wydania nieznana"
 
-#: account/notes.html books/edition-sort.html lists/export_as_html.html type/work/editions.html
+#: account/notes.html books/edition-sort.html lists/export_as_html.html
+#: type/work/editions.html
 msgid "Publisher unknown"
 msgstr "Wydawnictwo nieznane"
 
@@ -1585,8 +1768,14 @@ msgid "Notifications"
 msgstr "Powiadomienia"
 
 #: account/notifications.html
-msgid "Notifications are connected to Lists at the moment. If one of the books on your list gets edited, or a new book comes into the catalog, we'll let you know, if you want."
-msgstr "Powiadomienia są teraz związane z Listami. kiedy książka na Twojej liście będzie edytowana, lub nowa książka jest dodana do katalogu,  dostaniesz o tym powiadomienie, jeśli chcesz."
+msgid ""
+"Notifications are connected to Lists at the moment. If one of the books "
+"on your list gets edited, or a new book comes into the catalog, we'll let"
+" you know, if you want."
+msgstr ""
+"Powiadomienia są teraz związane z Listami. kiedy książka na Twojej liście"
+" będzie edytowana, lub nowa książka jest dodana do katalogu,  dostaniesz "
+"o tym powiadomienie, jeśli chcesz."
 
 #: account/notifications.html
 msgid "Would you like to receive very occasional emails from Open Library?"
@@ -1600,11 +1789,13 @@ msgstr "Nie, dziękuję"
 msgid "Yes! Please!"
 msgstr "Tak, poproszę!"
 
-#: EditButtons.html account/notifications.html account/privacy.html admin/block.html admin/spamwords.html covers/manage.html
+#: EditButtons.html account/notifications.html account/privacy.html
+#: admin/block.html admin/spamwords.html covers/manage.html
 msgid "Save"
 msgstr "Zachowaj"
 
-#: EditionNavBar.html account/observations.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#: EditionNavBar.html account/observations.html
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #, fuzzy
 msgid "Reviews"
 msgstr "Wyświetl"
@@ -1633,12 +1824,22 @@ msgid "Privacy & Content Moderation Settings"
 msgstr "Ustawienia prywatności"
 
 #: account/privacy.html
-msgid "Would you like to make your <a href=\"/account/books\">Reading Log</a> public?"
-msgstr "Czy chcesz upublicznić swój <a href=\"/account/books\">Dziennik Lektury</a>?"
+msgid ""
+"Would you like to make your <a href=\"/account/books\">Reading Log</a> "
+"public?"
+msgstr ""
+"Czy chcesz upublicznić swój <a href=\"/account/books\">Dziennik "
+"Lektury</a>?"
 
 #: account/privacy.html
-msgid "This will enable others to see what books you want to read, are reading, stopped reading, or have already read. Patrons with reading logs set to public may be followed."
-msgstr "Umożliwi to innym zobaczenie, jakie książki chcesz przeczytać, czytasz, przestałeś czytać lub już przeczytałeś. Użytkownicy z publicznymi dziennikami lektury mogą być obserwowani."
+msgid ""
+"This will enable others to see what books you want to read, are reading, "
+"stopped reading, or have already read. Patrons with reading logs set to "
+"public may be followed."
+msgstr ""
+"Umożliwi to innym zobaczenie, jakie książki chcesz przeczytać, czytasz, "
+"przestałeś czytać lub już przeczytałeś. Użytkownicy z publicznymi "
+"dziennikami lektury mogą być obserwowani."
 
 #: account/privacy.html admin/people/view.html
 msgid "Yes"
@@ -1653,8 +1854,12 @@ msgid "Enable Safe Mode?"
 msgstr "Włączyć tryb bezpieczny?"
 
 #: account/privacy.html
-msgid "Safe Mode blurs book covers that have been flagged as having sensitive imagery."
-msgstr "Tryb bezpieczny rozmywa okładki książek oznaczone jako zawierające wrażliwe treści graficzne."
+msgid ""
+"Safe Mode blurs book covers that have been flagged as having sensitive "
+"imagery."
+msgstr ""
+"Tryb bezpieczny rozmywa okładki książek oznaczone jako zawierające "
+"wrażliwe treści graficzne."
 
 #: account/reading_log.html
 #, python-format
@@ -1663,8 +1868,12 @@ msgstr "Książki, które obecnie czyta %(username)s"
 
 #: account/reading_log.html
 #, python-format
-msgid "%(username)s is reading %(total)d books. Join %(username)s on OpenLibrary.org and tell the world what you're reading."
-msgstr "%(username)s czyta %(total)d książek. Dołącz do %(username)s na OpenLibrary.org i powiedz światu, co czytasz."
+msgid ""
+"%(username)s is reading %(total)d books. Join %(username)s on "
+"OpenLibrary.org and tell the world what you're reading."
+msgstr ""
+"%(username)s czyta %(total)d książek. Dołącz do %(username)s na "
+"OpenLibrary.org i powiedz światu, co czytasz."
 
 #: account/reading_log.html
 #, python-format
@@ -1673,8 +1882,12 @@ msgstr "Książki, które %(username)s chce przeczytać"
 
 #: account/reading_log.html
 #, python-format
-msgid "%(username)s wants to read %(total)d books. Join %(username)s on OpenLibrary.org and share the books that you'll soon be reading!"
-msgstr "%(username)s chce przeczytać %(total)d książek. Dołącz do %(username)s na OpenLibrary.org i pokaż światu, co będziesz wkrótce czytać!"
+msgid ""
+"%(username)s wants to read %(total)d books. Join %(username)s on "
+"OpenLibrary.org and share the books that you'll soon be reading!"
+msgstr ""
+"%(username)s chce przeczytać %(total)d książek. Dołącz do %(username)s na"
+" OpenLibrary.org i pokaż światu, co będziesz wkrótce czytać!"
 
 #: account/reading_log.html
 #, fuzzy, python-format
@@ -1683,8 +1896,12 @@ msgstr "Książki, które obecnie czyta %(username)s"
 
 #: account/reading_log.html
 #, fuzzy, python-format
-msgid "%(username)s stopped reading %(total)d books. Join %(username)s on OpenLibrary.org to share your own reading updates!"
-msgstr "%(username)s chce przeczytać %(total)d książek. Dołącz do %(username)s na OpenLibrary.org i pokaż światu, co będziesz wkrótce czytać!"
+msgid ""
+"%(username)s stopped reading %(total)d books. Join %(username)s on "
+"OpenLibrary.org to share your own reading updates!"
+msgstr ""
+"%(username)s chce przeczytać %(total)d książek. Dołącz do %(username)s na"
+" OpenLibrary.org i pokaż światu, co będziesz wkrótce czytać!"
 
 #: account/reading_log.html
 #, python-format
@@ -1693,8 +1910,13 @@ msgstr "Książki przeczytane przez %(username)s w %(year)d"
 
 #: account/reading_log.html
 #, python-format
-msgid "%(username)s has read %(total)d books in %(year)d. Join %(username)s on OpenLibrary.org and tell the world about the books that you care about."
-msgstr "%(username)s przeczytał(a) %(total)d książek w %(year)d. Dołącz do %(username)s na OpenLibrary.org i opowiedz światu o książkach, które są dla Ciebie ważne."
+msgid ""
+"%(username)s has read %(total)d books in %(year)d. Join %(username)s on "
+"OpenLibrary.org and tell the world about the books that you care about."
+msgstr ""
+"%(username)s przeczytał(a) %(total)d książek w %(year)d. Dołącz do "
+"%(username)s na OpenLibrary.org i opowiedz światu o książkach, które są "
+"dla Ciebie ważne."
 
 #: account/reading_log.html
 #, python-format
@@ -1703,8 +1925,13 @@ msgstr "Książki przeczytane przez %(username)s"
 
 #: account/reading_log.html
 #, python-format
-msgid "%(username)s has read %(total)d books. Join %(username)s on OpenLibrary.org and tell the world about the books that you care about."
-msgstr "%(username)s przeczytał\\(a\\) %(total)d książek. Dołącz do %(username)s na OpenLibrary.org i powiedz światu o książkach, które są dla Ciebie ważne."
+msgid ""
+"%(username)s has read %(total)d books. Join %(username)s on "
+"OpenLibrary.org and tell the world about the books that you care about."
+msgstr ""
+"%(username)s przeczytał\\(a\\) %(total)d książek. Dołącz do %(username)s "
+"na OpenLibrary.org i powiedz światu o książkach, które są dla Ciebie "
+"ważne."
 
 #: account/reading_log.html
 #, fuzzy, python-format
@@ -1752,12 +1979,21 @@ msgid "You haven't added any books to this shelf yet."
 msgstr "Obecnie nie masz zaznaczonych żadnych książek."
 
 #: account/reading_log.html
-msgid "<a href=\"/search\">Search for a book</a> to add to your reading log. <a href=\"/help/faq/reading-log\">Learn more</a> about the reading log."
-msgstr "<a href=\"/search\">Wyszukaj książkę</a>, aby dodać ją do dziennika lektury. <a href=\"/help/faq/reading-log\">Dowiedz się więcej</a> o dzienniku lektury."
+msgid ""
+"<a href=\"/search\">Search for a book</a> to add to your reading log. <a "
+"href=\"/help/faq/reading-log\">Learn more</a> about the reading log."
+msgstr ""
+"<a href=\"/search\">Wyszukaj książkę</a>, aby dodać ją do dziennika "
+"lektury. <a href=\"/help/faq/reading-log\">Dowiedz się więcej</a> o "
+"dzienniku lektury."
 
 #: account/reading_log.html
-msgid "There are no recent books in your feed. When you follow public accounts, their book updates will appear here."
-msgstr "W Twoim kanale nie ma ostatnich książek. Gdy zaczniesz obserwować publiczne konta, ich aktualizacje książek będą się tutaj pojawiać."
+msgid ""
+"There are no recent books in your feed. When you follow public accounts, "
+"their book updates will appear here."
+msgstr ""
+"W Twoim kanale nie ma ostatnich książek. Gdy zaczniesz obserwować "
+"publiczne konta, ich aktualizacje książek będą się tutaj pojawiać."
 
 #. Display name for the "want-to-read" reading log shelf used in page headings
 #. and breadcrumbs.
@@ -1777,8 +2013,13 @@ msgstr "Moje książki"
 
 #: account/readinglog_stats.html
 #, python-format
-msgid "Displaying stats about <strong>%(works_count)d</strong> books. Note all charts show only the top 20 bars. Note reading log stats are private."
-msgstr "Wyświetlanie statystyk dla <strong>%(works_count)d</strong> książek. Uwaga: wszystkie wykresy pokazują tylko 20 najważniejszych pozycji. Statystyki dziennika lektury są prywatne."
+msgid ""
+"Displaying stats about <strong>%(works_count)d</strong> books. Note all "
+"charts show only the top 20 bars. Note reading log stats are private."
+msgstr ""
+"Wyświetlanie statystyk dla <strong>%(works_count)d</strong> książek. "
+"Uwaga: wszystkie wykresy pokazują tylko 20 najważniejszych pozycji. "
+"Statystyki dziennika lektury są prywatne."
 
 #: account/readinglog_stats.html
 #, fuzzy
@@ -1803,8 +2044,20 @@ msgid "Works by Author Country of Birth"
 msgstr "Dzieła według kraju urodzenia autora"
 
 #: account/readinglog_stats.html
-msgid "Demographic statistics powered by <a href=\"https://www.wikidata.org/\">Wikidata</a>. Here's a <a id=\"wd-query-sample\" href=\"\">sample</a> of the query used. <br />Improve these stats by adding the Wikidata author identifier following <a href=\"https://openlibrary.org/help/faq/editing.en#author-identifiers-purpose\">these instructions</a>."
-msgstr "Statystyki demograficzne dostarczane przez <a href=\"https://www.wikidata.org/\">Wikidata</a>. Oto <a id=\"wd-query-sample\" href=\"\">przykład</a> użytego zapytania. <br />Popraw te statystyki, dodając identyfikator autora Wikidata zgodnie z <a href=\"https://openlibrary.org/help/faq/editing.en#author-identifiers-purpose\">tymi instrukcjami</a>."
+msgid ""
+"Demographic statistics powered by <a "
+"href=\"https://www.wikidata.org/\">Wikidata</a>. Here's a <a id=\"wd-"
+"query-sample\" href=\"\">sample</a> of the query used. <br />Improve "
+"these stats by adding the Wikidata author identifier following <a "
+"href=\"https://openlibrary.org/help/faq/editing.en#author-identifiers-"
+"purpose\">these instructions</a>."
+msgstr ""
+"Statystyki demograficzne dostarczane przez <a "
+"href=\"https://www.wikidata.org/\">Wikidata</a>. Oto <a id=\"wd-query-"
+"sample\" href=\"\">przykład</a> użytego zapytania. <br />Popraw te "
+"statystyki, dodając identyfikator autora Wikidata zgodnie z <a "
+"href=\"https://openlibrary.org/help/faq/editing.en#author-identifiers-"
+"purpose\">tymi instrukcjami</a>."
 
 #: account/readinglog_stats.html
 #, fuzzy
@@ -1847,7 +2100,8 @@ msgstr "Usuń tę pozycję"
 msgid "Click on a bar to see matching works"
 msgstr "Kliknij na słupek, aby zobaczyć pasujące dzieła"
 
-#: account/sidebar.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#: account/sidebar.html books/mybooks_breadcrumb_select.html
+#: openlibrary/plugins/upstream/mybooks.py
 #, fuzzy
 msgid "My Feed"
 msgstr "1 plik inicujuący"
@@ -1871,7 +2125,10 @@ msgstr "Dziennik Lektur"
 msgid "My lists"
 msgstr "Moje listy"
 
-#: EditionNavBar.html SearchNavigation.html account/sidebar.html lib/nav_head.html lists/home.html recentchanges/index.html type/edition/view.html type/list/embed.html type/user/view.html type/work/view.html
+#: EditionNavBar.html SearchNavigation.html account/sidebar.html
+#: lib/nav_head.html lists/home.html recentchanges/index.html
+#: type/edition/view.html type/list/embed.html type/user/view.html
+#: type/work/view.html
 msgid "Lists"
 msgstr "Listy"
 
@@ -1902,15 +2159,21 @@ msgstr "Ustawienia prywatności: %(public)s"
 msgid "Verification email sent"
 msgstr "E-mail weryfikacyjny został wysłany."
 
-#: account/password/reset_success.html account/verify.html account/verify/activated.html account/verify/success.html
+#: account/password/reset_success.html account/verify.html
+#: account/verify/activated.html account/verify/success.html
 #, python-format
 msgid "Hi, %(user)s"
 msgstr "Cześć, %(user)s"
 
 #: account/verify.html
 #, python-format
-msgid "We’ve sent an email to %(email)s containing a link to verify your account. Click/tap on the link to finish creating your Internet Archive account."
+msgid ""
+"We’ve sent an email to %(email)s containing a link to verify your "
+"account. Click/tap on the link to finish creating your Internet Archive "
+"account."
 msgstr ""
+"Wysłaliśmy wiadomość e-mail na adres %(email)s zawierającą link do "
+"weryfikacji konta. Kliknij/naciśnij link, aby aktywować swoje konto."
 
 #: account/verify.html
 msgid "Then, come back to Open Library and find some great books!"
@@ -1930,14 +2193,17 @@ msgstr "Obserwowani"
 msgid "Followers"
 msgstr "filtrów"
 
-#: account/view.html type/edition/modal_links.html type/edition/title_and_author.html
+#: account/view.html type/edition/modal_links.html
+#: type/edition/title_and_author.html
 #, fuzzy
 msgid "Share"
 msgstr "Zachowaj"
 
 #: account/view.html
 msgid "Your book notes are private and cannot be viewed by other patrons."
-msgstr "Twoje notatki do książek są prywatne i nie mogą być przeglądane przez innych użytkowników."
+msgstr ""
+"Twoje notatki do książek są prywatne i nie mogą być przeglądane przez "
+"innych użytkowników."
 
 #: account/view.html
 msgid "Your book reviews will be shared anonymously with other patrons."
@@ -1957,8 +2223,12 @@ msgid "Forgot Your Internet Archive Email?"
 msgstr "Nie pamiętasz swojego adresu e-mail na Internet Archive?"
 
 #: account/email/forgot-ia.html
-msgid "Please enter your Open Library email and password, and we’ll retrieve your Archive.org email."
-msgstr "Wprowadź swój adres e-mail i hasło Open Library, a my pobierzemy Twój adres e-mail Archive.org."
+msgid ""
+"Please enter your Open Library email and password, and we’ll retrieve "
+"your Archive.org email."
+msgstr ""
+"Wprowadź swój adres e-mail i hasło Open Library, a my pobierzemy Twój "
+"adres e-mail Archive.org."
 
 #: account/email/forgot-ia.html
 #, fuzzy
@@ -2012,8 +2282,12 @@ msgid "Password Reset Successful"
 msgstr "Hasło zostało zresetowane"
 
 #: account/password/reset_success.html
-msgid "Your password has been updated. Please <a href='/account/login?redirect=/'>log in to continue</a>."
-msgstr "Twoje hasło zostało uaktualnione, aby kontynuować <a href='/account/login?redirect=/'>Zaloguj się</a>."
+msgid ""
+"Your password has been updated. Please <a "
+"href='/account/login?redirect=/'>log in to continue</a>."
+msgstr ""
+"Twoje hasło zostało uaktualnione, aby kontynuować <a "
+"href='/account/login?redirect=/'>Zaloguj się</a>."
 
 #: account/password/sent.html
 msgid "Done."
@@ -2021,8 +2295,14 @@ msgstr "Gotowe."
 
 #: account/password/sent.html
 #, python-format
-msgid "We've sent an email to %(email)s with a reminder of your username and instructions to help you reset your Open Library password. Please check your inbox for a note from us."
-msgstr "Wysłaliśmy e-mail na\" %(email)s z przypomnieniem o Twojej nazwie użytkownika oraz instrukcjami jak zresetować hasło do Open Library. Sprawdź swoją skrzynkę odbiorczą."
+msgid ""
+"We've sent an email to %(email)s with a reminder of your username and "
+"instructions to help you reset your Open Library password. Please check "
+"your inbox for a note from us."
+msgstr ""
+"Wysłaliśmy e-mail na\" %(email)s z przypomnieniem o Twojej nazwie "
+"użytkownika oraz instrukcjami jak zresetować hasło do Open Library. "
+"Sprawdź swoją skrzynkę odbiorczą."
 
 #: account/security/check_email.html
 msgid "Account Security Check — 2026-04-28T18Z"
@@ -2037,28 +2317,48 @@ msgid "Incident date: 2026-04-28T18Z"
 msgstr "Data zdarzenia: 2026-04-28T18Z"
 
 #: account/security/check_email.html
-msgid "Check whether your Open Library account was in a set of accounts requiring attention."
-msgstr "Sprawdź, czy Twoje konto Open Library znalazło się w grupie kont wymagających uwagi."
+msgid ""
+"Check whether your Open Library account was in a set of accounts "
+"requiring attention."
+msgstr ""
+"Sprawdź, czy Twoje konto Open Library znalazło się w grupie kont "
+"wymagających uwagi."
 
 #: account/security/check_email.html
-msgid "Please <a href=\"/account/login?redirect=/account/security/2026-04-28T18\">log in</a> to check whether your account was affected."
-msgstr "Proszę <a href=\"/account/login?redirect=/account/security/2026-04-28T18\">zaloguj się</a>, aby sprawdzić, czy Twoje konto zostało naruszone."
+msgid ""
+"Please <a "
+"href=\"/account/login?redirect=/account/security/2026-04-28T18\">log "
+"in</a> to check whether your account was affected."
+msgstr ""
+"Proszę <a "
+"href=\"/account/login?redirect=/account/security/2026-04-28T18\">zaloguj "
+"się</a>, aby sprawdzić, czy Twoje konto zostało naruszone."
 
 #: account/security/check_email.html
 msgid "Your account is in the affected set."
 msgstr "Twoje konto znajduje się w grupie dotkniętych."
 
 #: account/security/check_email.html
-msgid "Your account was found in our affected accounts list. Please review any recent communications from Open Library and consider updating your password."
-msgstr "Twoje konto zostało znalezione na liście dotkniętych kont. Prosimy zapoznać się z ostatnimi komunikatami od Open Library i rozważyć zmianę hasła."
+msgid ""
+"Your account was found in our affected accounts list. Please review any "
+"recent communications from Open Library and consider updating your "
+"password."
+msgstr ""
+"Twoje konto zostało znalezione na liście dotkniętych kont. Prosimy "
+"zapoznać się z ostatnimi komunikatami od Open Library i rozważyć zmianę "
+"hasła."
 
 #: account/security/check_email.html
 msgid "Your account is <em>not</em> in the affected set."
 msgstr "Twoje konto <em>nie</em> znajduje się w grupie dotkniętych."
 
 #: account/security/check_email.html
-msgid "Your account was <em>not</em> found in the affected accounts list. No action is required."
-msgstr "Twoje konto <em>nie</em> zostało znalezione na liście dotkniętych kont. Nie jest wymagane żadne działanie."
+msgid ""
+"Your account was <em>not</em> found in the affected accounts list. No "
+"action is required."
+msgstr ""
+"Twoje konto <em>nie</em> zostało znalezione na liście dotkniętych kont. "
+"Nie jest wymagane żadne działanie."
 
 #: account/verify/activated.html
 msgid "Account already activated"
@@ -2066,20 +2366,30 @@ msgstr "Konto jest już aktywne"
 
 #: account/verify/activated.html
 #, python-format
-msgid "Your account has been activated already. Please <a href=\"%s\">log in to continue</a>."
-msgstr "Twoje konto jest już aktywne. <a href=\"%s\">Zaloguj się, by kontynuować</a>."
+msgid ""
+"Your account has been activated already. Please <a href=\"%s\">log in to "
+"continue</a>."
+msgstr ""
+"Twoje konto jest już aktywne. <a href=\"%s\">Zaloguj się, by "
+"kontynuować</a>."
 
 #: account/verify/failed.html
 msgid "Email Verification Failed"
 msgstr "Weryfikacja adresu e-mail nie powiodła się"
 
 #: account/verify/failed.html
-msgid "Your email address couldn't be verified. Your verification link seems invalid or expired."
-msgstr "Twój adres e-mail nie został zweryfikowany. Twój link weryfikacyjnystracił ważność."
+msgid ""
+"Your email address couldn't be verified. Your verification link seems "
+"invalid or expired."
+msgstr ""
+"Twój adres e-mail nie został zweryfikowany. Twój link "
+"weryfikacyjnystracił ważność."
 
 #: account/verify/failed.html
 msgid "Fill your email and hit this button to resend a fresh verification email:"
-msgstr "Wprowadź swój adres e-mail i kliknij ten przycisk, aby ponownie wysłać e-mail weryfikacyjny:"
+msgstr ""
+"Wprowadź swój adres e-mail i kliknij ten przycisk, aby ponownie wysłać "
+"e-mail weryfikacyjny:"
 
 #: account/verify/failed.html
 msgid "Enter your email address here"
@@ -2095,8 +2405,12 @@ msgstr "Twój e-mail został zweryfikowany."
 
 #: account/verify/success.html
 #, python-format
-msgid "Yay! Your email address has been verified. Please <a href='%s'>log in to continue</a>."
-msgstr "Super! Twój e-mail został zweryfikowany.<a href='%s'>Zaloguj się, aby kontynuować</a>."
+msgid ""
+"Yay! Your email address has been verified. Please <a href='%s'>log in to "
+"continue</a>."
+msgstr ""
+"Super! Twój e-mail został zweryfikowany.<a href='%s'>Zaloguj się, aby "
+"kontynuować</a>."
 
 #: admin/attach_debugger.html
 msgid "Attach Debugger"
@@ -2127,8 +2441,12 @@ msgstr "Twój adres e-mail"
 
 #: admin/block.html
 #, python-format
-msgid "IP address %(address)s has been added to the textarea. Please click Save to block that IP."
-msgstr "Adres IP %(address)s został dodany do pola tekstowego. Kliknij Zapisz, aby zablokować ten adres IP."
+msgid ""
+"IP address %(address)s has been added to the textarea. Please click Save "
+"to block that IP."
+msgstr ""
+"Adres IP %(address)s został dodany do pola tekstowego. Kliknij Zapisz, "
+"aby zablokować ten adres IP."
 
 #: admin/block.html
 msgid "Blocked IP Addresses"
@@ -2155,7 +2473,8 @@ msgstr "Podział czasów ładowania stron"
 msgid "Infobase Mean"
 msgstr "Średnia Infobase"
 
-#: admin/history.html admin/imports.html authors/infobox.html type/author/edit.html
+#: admin/history.html admin/imports.html authors/infobox.html
+#: type/author/edit.html
 #, fuzzy
 msgid "Date"
 msgstr "Dorzuć się"
@@ -2165,12 +2484,14 @@ msgstr "Dorzuć się"
 msgid "Page"
 msgstr "miejsce"
 
-#: admin/imports-add.html admin/imports.html admin/imports_by_date.html admin/menu.html
+#: admin/imports-add.html admin/imports.html admin/imports_by_date.html
+#: admin/menu.html
 #, fuzzy
 msgid "Imports"
 msgstr "Tekst"
 
-#: admin/imports-add.html books/add.html books/edit/edition.html books/edit/excerpts.html covers/change.html type/tag/form.html
+#: admin/imports-add.html books/add.html books/edit/edition.html
+#: books/edit/excerpts.html covers/change.html type/tag/form.html
 msgid "Add"
 msgstr "Dodaj"
 
@@ -2183,7 +2504,9 @@ msgstr "Dodaj nową książkę do Open Library"
 msgid "Please add IA identifiers to be imported, one per line."
 msgstr "Proszę dodać identyfikatory IA do zaimportowania, jeden w wierszu."
 
-#: admin/imports-add.html admin/inspect/store.html admin/ip/view.html admin/people/edits.html admin/permissions.html my_books/check_ins/check_in_form.html reading_goals/reading_goal_form.html
+#: admin/imports-add.html admin/inspect/store.html admin/ip/view.html
+#: admin/people/edits.html admin/permissions.html
+#: my_books/check_ins/check_in_form.html reading_goals/reading_goal_form.html
 msgid "Submit"
 msgstr "Zatwierdź"
 
@@ -2195,7 +2518,8 @@ msgstr "Nowe książki zaimportowane dziennie"
 msgid "You need to have JavaScript turned on to see the nifty chart!"
 msgstr "Musisz mieć włączony JavaScript, aby zobaczyć fajny wykres!"
 
-#: admin/imports.html admin/imports_by_date.html admin/pd_dashboard.html site/stats.html
+#: admin/imports.html admin/imports_by_date.html admin/pd_dashboard.html
+#: site/stats.html
 msgid "Summary"
 msgstr "Podsumowanie"
 
@@ -2282,8 +2606,12 @@ msgid "Items"
 msgstr "Motywy:"
 
 #: admin/index.html
-msgid "<span class=\"login-counts\">0</span> patrons have logged in at least once over the past 30 days."
-msgstr "<span class=\"login-counts\">0</span> użytkowników zalogowało się co najmniej raz w ciągu ostatnich 30 dni."
+msgid ""
+"<span class=\"login-counts\">0</span> patrons have logged in at least "
+"once over the past 30 days."
+msgstr ""
+"<span class=\"login-counts\">0</span> użytkowników zalogowało się co "
+"najmniej raz w ciągu ostatnich 30 dni."
 
 #: admin/index.html
 #, fuzzy
@@ -2451,11 +2779,16 @@ msgstr "Zbieranie statystyk logowania..."
 msgid "BookReader"
 msgstr "BookReader"
 
-#: admin/loans_table.html book_providers/cita_press_download_options.html book_providers/ia_download_options.html book_providers/openstax_download_options.html book_providers/wikisource_download_options.html books/edit/edition.html
+#: admin/loans_table.html book_providers/cita_press_download_options.html
+#: book_providers/ia_download_options.html
+#: book_providers/openstax_download_options.html
+#: book_providers/wikisource_download_options.html books/edit/edition.html
 msgid "PDF"
 msgstr "PDF"
 
-#: admin/loans_table.html book_providers/gutenberg_download_options.html book_providers/ia_download_options.html book_providers/standard_ebooks_download_options.html books/edit/edition.html
+#: admin/loans_table.html book_providers/gutenberg_download_options.html
+#: book_providers/ia_download_options.html
+#: book_providers/standard_ebooks_download_options.html books/edit/edition.html
 msgid "ePub"
 msgstr "ePub"
 
@@ -2471,7 +2804,9 @@ msgid_plural "%d Current Loans"
 msgstr[0] "%d aktualne wypożyczenie"
 msgstr[1] "%d aktualne wypożyczenia"
 
-#: RecentChanges.html RecentChangesUsers.html admin/ip/view.html admin/loans_table.html admin/people/edits.html recentchanges/render.html recentchanges/updated_records.html
+#: RecentChanges.html RecentChangesUsers.html admin/ip/view.html
+#: admin/loans_table.html admin/people/edits.html recentchanges/render.html
+#: recentchanges/updated_records.html
 msgid "What"
 msgstr "Co"
 
@@ -2495,7 +2830,10 @@ msgstr "Dołączył\\(a\\) %(date)s"
 msgid "Admin Center"
 msgstr "Centrum Rozwoju"
 
-#: RelatedSubjects.html SubjectTags.html admin/menu.html admin/people/index.html admin/people/view.html openlibrary/plugins/worksearch/code.py type/author/view.html type/list/view_body.html
+#: RelatedSubjects.html SubjectTags.html admin/menu.html
+#: admin/people/index.html admin/people/view.html
+#: openlibrary/plugins/worksearch/code.py type/author/view.html
+#: type/list/view_body.html
 msgid "People"
 msgstr "Ludzie"
 
@@ -2592,8 +2930,12 @@ msgid "Update permissions"
 msgstr "Zaktualizuj adres e-mail"
 
 #: admin/permissions.html
-msgid "This updates \"permission\" and \"child_permission\" fields of /, /works, /books and /authors records in the database."
-msgstr "Aktualizuje to pola \"permission\" i \"child_permission\" rekordów /, /works, /books i /authors w bazie danych."
+msgid ""
+"This updates \"permission\" and \"child_permission\" fields of /, /works,"
+" /books and /authors records in the database."
+msgstr ""
+"Aktualizuje to pola \"permission\" i \"child_permission\" rekordów /, "
+"/works, /books i /authors w bazie danych."
 
 #: admin/solr.html
 msgid "Solr Admin"
@@ -2609,8 +2951,12 @@ msgid "Example:"
 msgstr "Na przykład:"
 
 #: admin/solr.html
-msgid "On update, these keys will be added to solr update queue and it'll take about 15 minutes for them to get reindexed in Solr."
-msgstr "Po aktualizacji te klucze zostaną dodane do kolejki aktualizacji solr i ponowne indeksowanie w Solr zajmie około 15 minut."
+msgid ""
+"On update, these keys will be added to solr update queue and it'll take "
+"about 15 minutes for them to get reindexed in Solr."
+msgstr ""
+"Po aktualizacji te klucze zostaną dodane do kolejki aktualizacji solr i "
+"ponowne indeksowanie w Solr zajmie około 15 minut."
 
 #: admin/solr.html
 msgid "Enter the keys to reindex in Solr"
@@ -2625,19 +2971,30 @@ msgid "[Admin Center] Spam Words"
 msgstr "[Centrum administracyjne] Słowa spam"
 
 #: admin/spamwords.html
-msgid "Please enter the SPAM regular expressions in the textarea below, one per line."
-msgstr "Proszę wprowadzić wyrażenia regularne SPAM w polu tekstowym poniżej, jedno w wierszu."
+msgid ""
+"Please enter the SPAM regular expressions in the textarea below, one per "
+"line."
+msgstr ""
+"Proszę wprowadzić wyrażenia regularne SPAM w polu tekstowym poniżej, "
+"jedno w wierszu."
 
 #: admin/spamwords.html
-msgid "Be sure to escape any meta characters that are meant to be character literals."
-msgstr "Pamiętaj, aby eskejpować wszystkie metaznaki, które mają być literałami znakowymi."
+msgid ""
+"Be sure to escape any meta characters that are meant to be character "
+"literals."
+msgstr ""
+"Pamiętaj, aby eskejpować wszystkie metaznaki, które mają być literałami "
+"znakowymi."
 
 #: admin/spamwords.html
 msgid "If you are adding a domain, prepend the following to the domain:"
 msgstr "Jeśli dodajesz domenę, poprzedź ją następującym ciągiem:"
 
 #: admin/spamwords.html
-msgid "For example, if you want to prevent edits containing the domain <code>t.co</code>, add <code>(|https://|http://)t\\.co</code> to the spamwords list."
+msgid ""
+"For example, if you want to prevent edits containing the domain "
+"<code>t.co</code>, add <code>(|https://|http://)t\\.co</code> to the "
+"spamwords list."
 msgstr ""
 
 #: admin/spamwords.html
@@ -2647,15 +3004,21 @@ msgstr "Wypożyczone przeze mnie"
 
 #: admin/spamwords.html
 msgid "Please enter domains to blacklist in the textarea below, one per line."
-msgstr "Proszę wprowadzić domeny do zablokowania w polu tekstowym poniżej, jedna w wierszu."
+msgstr ""
+"Proszę wprowadzić domeny do zablokowania w polu tekstowym poniżej, jedna "
+"w wierszu."
 
 #: admin/sync.html
 msgid "Sync"
 msgstr "Synchronizuj"
 
 #: admin/sync.html
-msgid "Sync the metadata of various types of Open Library items (e.g. lists, subjects, works) with Archive.org."
-msgstr "Synchronizuj metadane różnych typów elementów Open Library (np. listy, tematy, dzieła) z Archive.org."
+msgid ""
+"Sync the metadata of various types of Open Library items (e.g. lists, "
+"subjects, works) with Archive.org."
+msgstr ""
+"Synchronizuj metadane różnych typów elementów Open Library (np. listy, "
+"tematy, dzieła) z Archive.org."
 
 #: admin/sync.html
 #, fuzzy
@@ -2663,8 +3026,20 @@ msgid "Add Works to Staff Picks"
 msgstr "Dodaj do Wyboranych przez nas"
 
 #: admin/sync.html
-msgid "This utility will add your work to an Open Library list called `Staff Picks` under the `openlibrary` user. It will then take the added work and explode it into a list of all its readable editions. For each Open Library edition, a metadata field called `openlibrary_subject` will be injected into the archive.org metadata of the edition's corresponding archive.org item."
-msgstr "To narzędzie doda Twoje dzieło do listy Open Library o nazwie `Staff Picks` pod użytkownikiem `openlibrary`. Następnie weźmie dodane dzieło i rozwinie je na listę wszystkich czytelnych wydań. Dla każdego wydania Open Library pole metadanych o nazwie `openlibrary_subject` zostanie wstrzyknięte do metadanych archive.org odpowiadającego elementu archive.org."
+msgid ""
+"This utility will add your work to an Open Library list called `Staff "
+"Picks` under the `openlibrary` user. It will then take the added work and"
+" explode it into a list of all its readable editions. For each Open "
+"Library edition, a metadata field called `openlibrary_subject` will be "
+"injected into the archive.org metadata of the edition's corresponding "
+"archive.org item."
+msgstr ""
+"To narzędzie doda Twoje dzieło do listy Open Library o nazwie `Staff "
+"Picks` pod użytkownikiem `openlibrary`. Następnie weźmie dodane dzieło i "
+"rozwinie je na listę wszystkich czytelnych wydań. Dla każdego wydania "
+"Open Library pole metadanych o nazwie `openlibrary_subject` zostanie "
+"wstrzyknięte do metadanych archive.org odpowiadającego elementu "
+"archive.org."
 
 #: admin/sync.html
 #, fuzzy
@@ -2682,8 +3057,12 @@ msgid "Update edition"
 msgstr "O tym wydaniu"
 
 #: admin/sync.html
-msgid "Updates an edition on archive.org by writing in its latest  openlibrary_edition and openlibrary_work identifier values"
-msgstr "Aktualizuje wydanie na archive.org, zapisując najnowsze wartości identyfikatorów openlibrary_edition i openlibrary_work"
+msgid ""
+"Updates an edition on archive.org by writing in its latest  "
+"openlibrary_edition and openlibrary_work identifier values"
+msgstr ""
+"Aktualizuje wydanie na archive.org, zapisując najnowsze wartości "
+"identyfikatorów openlibrary_edition i openlibrary_work"
 
 #: admin/sync.html
 msgid "TODO"
@@ -2699,12 +3078,20 @@ msgid "Inspect Memcache"
 msgstr "Wyszukiwanie tematu"
 
 #: admin/inspect/memcache.html
-msgid "Add one memcache key per line in the text area. Each key must include a '-' as the last character."
-msgstr "Dodaj jeden klucz memcache w wierszu w polu tekstowym. Każdy klucz musi zawierać '-' jako ostatni znak."
+msgid ""
+"Add one memcache key per line in the text area. Each key must include a "
+"'-' as the last character."
+msgstr ""
+"Dodaj jeden klucz memcache w wierszu w polu tekstowym. Każdy klucz musi "
+"zawierać '-' jako ostatni znak."
 
 #: admin/inspect/memcache.html
-msgid "For example, <code>observations-</code> should be entered in the text area if the key is <code>observations</code>."
-msgstr "Na przykład, <code>observations-</code> należy wprowadzić w polu tekstowym, jeśli klucz to <code>observations</code>."
+msgid ""
+"For example, <code>observations-</code> should be entered in the text "
+"area if the key is <code>observations</code>."
+msgstr ""
+"Na przykład, <code>observations-</code> należy wprowadzić w polu "
+"tekstowym, jeśli klucz to <code>observations</code>."
 
 #: admin/inspect/memcache.html
 #, fuzzy
@@ -2837,7 +3224,8 @@ msgstr "Zablokuj %(ip)s"
 msgid "Please select the changesets to revert."
 msgstr "Wybierz autorów do połączenia."
 
-#: RecentChanges.html admin/ip/view.html admin/people/edits.html recentchanges/render.html
+#: RecentChanges.html admin/ip/view.html admin/people/edits.html
+#: recentchanges/render.html
 msgid "When you see numbers here, that's the IP address of the anonymous editor"
 msgstr "Gdy widzisz tu liczby, jest to adres IP anonimowego edytora"
 
@@ -2847,8 +3235,12 @@ msgid "Reverted by %(revert_author)s"
 msgstr "Przywrócone przez %(revert_author)s"
 
 #: EditButtons.html admin/ip/view.html admin/people/edits.html
-msgid "Please, leave a short note about what you changed: <span class=\"small gray\">(Optional, but very useful!)</span>"
-msgstr "Proszę, zostaw krótką notatkę o tym, co zmieniłeś: <span class=\"small gray\">(Opcjonalnie, ale bardzo przydatne!)</span>"
+msgid ""
+"Please, leave a short note about what you changed: <span class=\"small "
+"gray\">(Optional, but very useful!)</span>"
+msgstr ""
+"Proszę, zostaw krótką notatkę o tym, co zmieniłeś: <span class=\"small "
+"gray\">(Opcjonalnie, ale bardzo przydatne!)</span>"
 
 #: admin/ip/view.html admin/people/edits.html
 msgid "Reverted spam"
@@ -2945,8 +3337,12 @@ msgstr "zaloguj się jako ten użytkownik"
 
 #: admin/people/view.html
 #, python-format
-msgid "Activated on <span class=\"time\">%(date)s</span> from <a href=\"/admin/ip/%(ip)s\">%(ip)s</a>."
-msgstr "Aktywowany <span class=\"time\">%(date)s</span> z <a href=\"/admin/ip/%(ip)s\">%(ip)s</a>."
+msgid ""
+"Activated on <span class=\"time\">%(date)s</span> from <a "
+"href=\"/admin/ip/%(ip)s\">%(ip)s</a>."
+msgstr ""
+"Aktywowany <span class=\"time\">%(date)s</span> z <a "
+"href=\"/admin/ip/%(ip)s\">%(ip)s</a>."
 
 #: admin/people/view.html
 msgid "unblock this account"
@@ -3021,7 +3417,8 @@ msgstr "Próba sucha"
 msgid "Anonymize Account"
 msgstr "Moje konto"
 
-#: admin/people/view.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py type/user/view.html
+#: admin/people/view.html books/mybooks_breadcrumb_select.html
+#: openlibrary/plugins/upstream/account.py type/user/view.html
 msgid "Loans"
 msgstr "Wypożyczone"
 
@@ -3058,7 +3455,8 @@ msgstr "E-mail weryfikacyjny został wysłany."
 msgid "None found"
 msgstr "Nie znaleziono."
 
-#: SearchNavigation.html authors/index.html lib/nav_foot.html merge/authors.html publishers/view.html
+#: SearchNavigation.html authors/index.html lib/nav_foot.html
+#: merge/authors.html publishers/view.html
 msgid "Authors"
 msgstr "Autorzy"
 
@@ -3066,7 +3464,10 @@ msgstr "Autorzy"
 msgid "Search for an Author"
 msgstr "Wyszukaj autora"
 
-#: authors/index.html lib/nav_head.html lists/home.html publishers/index.html publishers/notfound.html publishers/view.html search/advancedsearch.html search/publishers.html search/search_modal_i18n.html search/searchbox.html type/local_id/view.html
+#: authors/index.html lib/nav_head.html lists/home.html publishers/index.html
+#: publishers/notfound.html publishers/view.html search/advancedsearch.html
+#: search/publishers.html search/search_modal_i18n.html search/searchbox.html
+#: type/local_id/view.html
 msgid "Search"
 msgstr "Szukaj"
 
@@ -3095,7 +3496,14 @@ msgstr "lub"
 msgid "Died"
 msgstr "Zmieniono"
 
-#: book_providers/cita_press_download_options.html book_providers/gutenberg_download_options.html book_providers/ia_download_options.html book_providers/librivox_download_options.html book_providers/openstax_download_options.html book_providers/runeberg_download_options.html book_providers/standard_ebooks_download_options.html book_providers/wikisource_download_options.html
+#: book_providers/cita_press_download_options.html
+#: book_providers/gutenberg_download_options.html
+#: book_providers/ia_download_options.html
+#: book_providers/librivox_download_options.html
+#: book_providers/openstax_download_options.html
+#: book_providers/runeberg_download_options.html
+#: book_providers/standard_ebooks_download_options.html
+#: book_providers/wikisource_download_options.html
 #, fuzzy
 msgid "Download Options"
 msgstr "Pobierz"
@@ -3113,7 +3521,9 @@ msgstr "Więcej na Cita Press"
 msgid "Download an HTML from Project Gutenberg"
 msgstr "Pobierz HTML z Project Gutenberg"
 
-#: book_providers/gutenberg_download_options.html book_providers/runeberg_download_options.html book_providers/standard_ebooks_download_options.html type/list/exports.html
+#: book_providers/gutenberg_download_options.html
+#: book_providers/runeberg_download_options.html
+#: book_providers/standard_ebooks_download_options.html type/list/exports.html
 msgid "HTML"
 msgstr "HTML"
 
@@ -3122,7 +3532,8 @@ msgstr "HTML"
 msgid "Download a text version from Project Gutenberg"
 msgstr "Przeczytaj e-book z Internet Archive"
 
-#: book_providers/gutenberg_download_options.html book_providers/ia_download_options.html
+#: book_providers/gutenberg_download_options.html
+#: book_providers/ia_download_options.html
 msgid "Plain text"
 msgstr "Zwykły tekst"
 
@@ -3170,7 +3581,9 @@ msgstr "MOBI"
 
 #: book_providers/ia_download_options.html
 msgid "Download open DAISY from Internet Archive (print-disabled format)"
-msgstr "Pobierz otwarty DAISY z Internet Archive (format dla osób z niepełnosprawnością druku)"
+msgstr ""
+"Pobierz otwarty DAISY z Internet Archive (format dla osób z "
+"niepełnosprawnością druku)"
 
 #: book_providers/ia_download_options.html type/list/embed.html
 msgid "DAISY"
@@ -3348,12 +3761,16 @@ msgstr "Nieprawidłowa cyfra kontrolna ISBN"
 
 #: books/add.html
 #, fuzzy
-msgid "ID must be exactly 10 characters [0-9 or X]. For example 0-19-853453-1 or 0198534531"
+msgid ""
+"ID must be exactly 10 characters [0-9 or X]. For example 0-19-853453-1 or"
+" 0198534531"
 msgstr "ID musi zawierać dokładnie 10 znaków [0-9] lub X."
 
 #: books/add.html
 #, fuzzy
-msgid "ID must be exactly 13 characters [0-9]. For example 978-3-16-148410-0 or 9783161484100"
+msgid ""
+"ID must be exactly 13 characters [0-9]. For example 978-3-16-148410-0 or "
+"9783161484100"
 msgstr "ID musi zawierać dokładnie 10 znaków [0-9] lub X."
 
 #: books/add.html
@@ -3378,20 +3795,27 @@ msgid "Add a book to Open Library"
 msgstr "Dodaj książkę do Open Library"
 
 #: books/add.html
-msgid "We require a minimum set of fields to create a new record. These are those fields."
+msgid ""
+"We require a minimum set of fields to create a new record. These are "
+"those fields."
 msgstr "Aby utworzyć nowy wpis wymagane jest uzupełnienie nastepujących pól."
 
 #: books/add.html books/edit.html
 msgid "Use <b><i>Title: Subtitle</i></b> to add a subtitle."
 msgstr "Użyj <b><i>Tytuł: Podtytuł</i></b> aby dodać podtytuł."
 
-#: books/add.html books/edit.html type/author/edit.html type/tag/tag_form_inputs.html
+#: books/add.html books/edit.html type/author/edit.html
+#: type/tag/tag_form_inputs.html
 msgid "Required field"
 msgstr "Pole wymagane"
 
 #: books/add.html
-msgid "Like, \"Agatha Christie\" or \"Jean-Paul Sartre.\" We'll also do a live check to see if we already know the author."
-msgstr "Na przykład, \"Agatha Christie\" lub \"Jean-Paul Sartre.\" Jeśli autor znajduje się na liście - kliknij na jego nazwisko by wybrać."
+msgid ""
+"Like, \"Agatha Christie\" or \"Jean-Paul Sartre.\" We'll also do a live "
+"check to see if we already know the author."
+msgstr ""
+"Na przykład, \"Agatha Christie\" lub \"Jean-Paul Sartre.\" Jeśli autor "
+"znajduje się na liście - kliknij na jego nazwisko by wybrać."
 
 #: books/add.html books/edit/edition.html
 msgid "Who is the publisher?"
@@ -3414,7 +3838,9 @@ msgid "You should be able to find this in the first few pages of the book."
 msgstr "Możesz znaleźć te informacje na pierwszych stronach książki."
 
 #: books/add.html
-msgid "And optionally, an ID number &#151; like an ISBN &#151; would be helpful..."
+msgid ""
+"And optionally, an ID number &#151; like an ISBN &#151; would be "
+"helpful..."
 msgstr "Opjonalnie możesz dodać numer identyfikacyjny &#151; np. ISBN &#151"
 
 #: books/add.html
@@ -3466,8 +3892,18 @@ msgstr "Wypełnij to tylko jeśli jest to e-book internetowy"
 
 #: books/add.html
 #, python-format
-msgid "By saving a change to this wiki, you agree that your contribution is given freely to the world under <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" target=\"_blank\" rel=\"noopener noreferrer\" title=\"%(cc_link_title)s\">CC0</a>."
-msgstr "Zapisując zmianę w tym wiki, zgadzasz się, że Twój wkład jest przekazany światu bezpłatnie na zasadzie <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" target=\"_blank\" rel=\"noopener noreferrer\" title=\"%(cc_link_title)s\">CC0</a>."
+msgid ""
+"By saving a change to this wiki, you agree that your contribution is "
+"given freely to the world under <a "
+"href=\"https://creativecommons.org/publicdomain/zero/1.0/\" "
+"target=\"_blank\" rel=\"noopener noreferrer\" "
+"title=\"%(cc_link_title)s\">CC0</a>."
+msgstr ""
+"Zapisując zmianę w tym wiki, zgadzasz się, że Twój wkład jest przekazany "
+"światu bezpłatnie na zasadzie <a "
+"href=\"https://creativecommons.org/publicdomain/zero/1.0/\" "
+"target=\"_blank\" rel=\"noopener noreferrer\" "
+"title=\"%(cc_link_title)s\">CC0</a>."
 
 #: books/add.html
 msgid "This link to Creative Commons will open in a new window"
@@ -3500,18 +3936,27 @@ msgstr "Dodaj książkę"
 
 #: books/check.html
 #, python-format
-msgid "One moment... It looks like we already have <em>some potential matches</em> for <b>%(title)s</b> by <b>%(author)s</b>."
-msgstr "Chwileczkę... Wydaje się, że mamy już <em>podobną książkę</em> <b>%(title)s</b> autorstwa <b>%(author)s</b>."
+msgid ""
+"One moment... It looks like we already have <em>some potential "
+"matches</em> for <b>%(title)s</b> by <b>%(author)s</b>."
+msgstr ""
+"Chwileczkę... Wydaje się, że mamy już <em>podobną książkę</em> "
+"<b>%(title)s</b> autorstwa <b>%(author)s</b>."
 
 #: books/check.html
-msgid "Rather than creating a duplicate record, please click through the result you think best matches your book."
-msgstr "Nie twórz duplikatu tej książki. Wybierz odpowiedni tytuł z poniższej listy."
+msgid ""
+"Rather than creating a duplicate record, please click through the result "
+"you think best matches your book."
+msgstr ""
+"Nie twórz duplikatu tej książki. Wybierz odpowiedni tytuł z poniższej "
+"listy."
 
 #: books/check.html
 msgid "Select this book"
 msgstr "Wybierz tę książkę"
 
-#: SearchResultsWork.html books/check.html merge/authors.html publishers/view.html
+#: SearchResultsWork.html books/check.html merge/authors.html
+#: publishers/view.html
 #, python-format
 msgid "%(count)s edition"
 msgid_plural "%(count)s editions"
@@ -3556,20 +4001,40 @@ msgstr "Nie ma dostępnego pliku DAISY dla "
 
 #: books/daisy.html
 #, python-format
-msgid "<a href=\"%(daisy_url)s\"><strong>Download the DAISY.zip</strong></a> for <a href=\"%(url)s\">%(title)s</a>"
-msgstr "<a href=\"%(daisy_url)s\"><strong>Pobierz DAISY.zip</strong></a> dla <a href=\"%(url)s\">%(title)s</a>"
+msgid ""
+"<a href=\"%(daisy_url)s\"><strong>Download the DAISY.zip</strong></a> for"
+" <a href=\"%(url)s\">%(title)s</a>"
+msgstr ""
+"<a href=\"%(daisy_url)s\"><strong>Pobierz DAISY.zip</strong></a> dla <a "
+"href=\"%(url)s\">%(title)s</a>"
 
 #: books/daisy.html
 msgid "Books for people who don't read print?"
 msgstr "Książki dla osób nieczytelnych w druku?"
 
 #: books/daisy.html
-msgid "The <a href=\"//archive.org\">Internet Archive</a> is proud to be distributing over 1 million books free in a format called DAISY, designed for those of us who find it challenging to use regular printed media. "
-msgstr "<a href=\"//archive.org\">Internet Archive</a> z dumą dystrybuuje ponad 1 milion książek bezpłatnie w formacie DAISY, zaprojektowanym dla tych, którym trudno korzystać z tradycyjnych materiałów drukowanych. "
+msgid ""
+"The <a href=\"//archive.org\">Internet Archive</a> is proud to be "
+"distributing over 1 million books free in a format called DAISY, designed"
+" for those of us who find it challenging to use regular printed media. "
+msgstr ""
+"<a href=\"//archive.org\">Internet Archive</a> z dumą dystrybuuje ponad 1"
+" milion książek bezpłatnie w formacie DAISY, zaprojektowanym dla tych, "
+"którym trudno korzystać z tradycyjnych materiałów drukowanych. "
 
 #: books/daisy.html
-msgid "There are two types of DAISYs on Open Library: <i>open</i> and <i>protected</i>. Open DAISYs can be read by anyone in the world on many different devices. Protected DAISYs can only be opened using a key issued by the <a href=\"http://www.loc.gov/nls/\">Library of Congress NLS program</a>."
-msgstr "W Open Library dostępne są dwa typy DAISY: <i>otwarte</i> i <i>chronione</i>. Otwarte DAISY mogą być czytane przez każdego na świecie na wielu urządzeniach. Chronione DAISY można otwierać tylko przy użyciu klucza wydanego przez <a href=\"http://www.loc.gov/nls/\">program NLS Biblioteki Kongresu</a>."
+msgid ""
+"There are two types of DAISYs on Open Library: <i>open</i> and "
+"<i>protected</i>. Open DAISYs can be read by anyone in the world on many "
+"different devices. Protected DAISYs can only be opened using a key issued"
+" by the <a href=\"http://www.loc.gov/nls/\">Library of Congress NLS "
+"program</a>."
+msgstr ""
+"W Open Library dostępne są dwa typy DAISY: <i>otwarte</i> i "
+"<i>chronione</i>. Otwarte DAISY mogą być czytane przez każdego na świecie"
+" na wielu urządzeniach. Chronione DAISY można otwierać tylko przy użyciu "
+"klucza wydanego przez <a href=\"http://www.loc.gov/nls/\">program NLS "
+"Biblioteki Kongresu</a>."
 
 #: books/daisy.html lists/home.html
 msgid "Enjoy!"
@@ -3581,8 +4046,16 @@ msgid "What is the DAISY format?"
 msgstr "Wydawnictwo"
 
 #: books/daisy.html
-msgid "The DAISY digital format helps people who have challenges using regular printed media. DAISY digital <span class=\"highlight\">talking books</span> offer the benefits of regular audiobooks, with navigation within the book, to chapters or specific pages."
-msgstr "Format cyfrowy DAISY pomaga osobom mającym trudności z korzystaniem z tradycyjnych materiałów drukowanych. Cyfrowe <span class=\"highlight\">audiobooki</span> DAISY oferują zalety zwykłych audiobooków, z nawigacją po książce, do rozdziałów lub konkretnych stron."
+msgid ""
+"The DAISY digital format helps people who have challenges using regular "
+"printed media. DAISY digital <span class=\"highlight\">talking "
+"books</span> offer the benefits of regular audiobooks, with navigation "
+"within the book, to chapters or specific pages."
+msgstr ""
+"Format cyfrowy DAISY pomaga osobom mającym trudności z korzystaniem z "
+"tradycyjnych materiałów drukowanych. Cyfrowe <span "
+"class=\"highlight\">audiobooki</span> DAISY oferują zalety zwykłych "
+"audiobooków, z nawigacją po książce, do rozdziałów lub konkretnych stron."
 
 #: books/daisy.html
 #, fuzzy
@@ -3595,8 +4068,18 @@ msgid "What is the NLS?"
 msgstr "Wydawnictwo"
 
 #: books/daisy.html
-msgid "The Library of Congress <a href=\"http://www.loc.gov/nls/\">National Library Service for the Blind and Physically Handicapped (NLS)</a> administers a free library program of braille and audio materials circulated to eligible borrowers in the United States through a national network of cooperating libraries."
-msgstr "Biblioteka Kongresu <a href=\"http://www.loc.gov/nls/\">National Library Service for the Blind and Physically Handicapped (NLS)</a> administruje bezpłatny program biblioteczny materiałów brajlowskich i audio udostępnianych uprawnionym wypożyczającym w Stanach Zjednoczonych za pośrednictwem krajowej sieci bibliotek współpracujących."
+msgid ""
+"The Library of Congress <a href=\"http://www.loc.gov/nls/\">National "
+"Library Service for the Blind and Physically Handicapped (NLS)</a> "
+"administers a free library program of braille and audio materials "
+"circulated to eligible borrowers in the United States through a national "
+"network of cooperating libraries."
+msgstr ""
+"Biblioteka Kongresu <a href=\"http://www.loc.gov/nls/\">National Library "
+"Service for the Blind and Physically Handicapped (NLS)</a> administruje "
+"bezpłatny program biblioteczny materiałów brajlowskich i audio "
+"udostępnianych uprawnionym wypożyczającym w Stanach Zjednoczonych za "
+"pośrednictwem krajowej sieci bibliotek współpracujących."
 
 #: books/daisy.html
 msgid "Are you eligible to register?"
@@ -3608,20 +4091,40 @@ msgid "How do I find DAISYs on Open Library?"
 msgstr "Zobacz wszystkich odwiedzających OpenLibrary.org"
 
 #: books/daisy.html
-msgid "In addition to<a href=\"/subjects/accessible_book\" title=\"Subject: Accessible book\"> loads of open DAISYs</a>, the Open Library lists a smaller selection of<a href=\"/subjects/protected_DAISY\" title=\"Subject: Protected DAISY\"> protected DAISY titles</a> accessible to those with a Library of Congress NLS key. These titles are brought to you by the<a href=\"//archive.org/\"> Internet Archive</a>."
-msgstr "Oprócz<a href=\"/subjects/accessible_book\" title=\"Subject: Accessible book\"> wielu otwartych DAISY</a>, Open Library zawiera mniejszy wybór<a href=\"/subjects/protected_DAISY\" title=\"Subject: Protected DAISY\"> chronionych tytułów DAISY</a> dostępnych dla posiadaczy klucza NLS Biblioteki Kongresu. Te tytuły są dostarczane przez<a href=\"//archive.org/\"> Internet Archive</a>."
+msgid ""
+"In addition to<a href=\"/subjects/accessible_book\" title=\"Subject: "
+"Accessible book\"> loads of open DAISYs</a>, the Open Library lists a "
+"smaller selection of<a href=\"/subjects/protected_DAISY\" "
+"title=\"Subject: Protected DAISY\"> protected DAISY titles</a> accessible"
+" to those with a Library of Congress NLS key. These titles are brought to"
+" you by the<a href=\"//archive.org/\"> Internet Archive</a>."
+msgstr ""
+"Oprócz<a href=\"/subjects/accessible_book\" title=\"Subject: Accessible "
+"book\"> wielu otwartych DAISY</a>, Open Library zawiera mniejszy wybór<a "
+"href=\"/subjects/protected_DAISY\" title=\"Subject: Protected DAISY\"> "
+"chronionych tytułów DAISY</a> dostępnych dla posiadaczy klucza NLS "
+"Biblioteki Kongresu. Te tytuły są dostarczane przez<a "
+"href=\"//archive.org/\"> Internet Archive</a>."
 
 #: books/daisy.html
-msgid "Looking for a specific title? The best way to find it is to<a href=\"/search\"> search for it</a>."
-msgstr "Szukasz konkretnego tytułu? Najlepszym sposobem jest<a href=\"/search\"> wyszukanie go</a>."
+msgid ""
+"Looking for a specific title? The best way to find it is to<a "
+"href=\"/search\"> search for it</a>."
+msgstr ""
+"Szukasz konkretnego tytułu? Najlepszym sposobem jest<a href=\"/search\"> "
+"wyszukanie go</a>."
 
 #: books/daisy.html lib/exports.html
 msgid "Need help?"
 msgstr "Potrzebujesz pomocy?"
 
 #: books/daisy.html
-msgid " Please read our <a href=\"/help/faq\">FAQ on accessing books through Open Library</a>."
-msgstr " Proszę przeczytaj nasze <a href=\"/help/faq\">FAQ dotyczące dostępu do książek przez Open Library</a>."
+msgid ""
+" Please read our <a href=\"/help/faq\">FAQ on accessing books through "
+"Open Library</a>."
+msgstr ""
+" Proszę przeczytaj nasze <a href=\"/help/faq\">FAQ dotyczące dostępu do "
+"książek przez Open Library</a>."
 
 #: books/edit.html
 msgid "Add a little more?"
@@ -3629,24 +4132,38 @@ msgstr "Dodaj nieco więcej?"
 
 #: books/edit.html
 #, fuzzy
-msgid "Thank you for adding that book! Any more information you could provide would be wonderful!"
-msgstr "<p class=\"alert thanks\">Dziękujemy za dodanie tej książki! Jeśli możesz udostępnić dodatkowe informacje, będziemy bardzo wdzięczni!</p>"
+msgid ""
+"Thank you for adding that book! Any more information you could provide "
+"would be wonderful!"
+msgstr ""
+"<p class=\"alert thanks\">Dziękujemy za dodanie tej książki! Jeśli możesz"
+" udostępnić dodatkowe informacje, będziemy bardzo wdzięczni!</p>"
 
 #: books/edit.html
 #, python-format
-msgid "We already know about <b>%(work_title)s</b>, but not the <b>%(year)s %(publisher)s edition</b>. Thanks! Do you know any more about this edition?"
-msgstr "Wiemy już o <b>%(work_title)s</b>, ale nie o wydaniu <b>%(year)s %(publisher)s</b>. Dziękujemy! Czy wiesz coś więcej o tym wydaniu?"
+msgid ""
+"We already know about <b>%(work_title)s</b>, but not the <b>%(year)s "
+"%(publisher)s edition</b>. Thanks! Do you know any more about this "
+"edition?"
+msgstr ""
+"Wiemy już o <b>%(work_title)s</b>, ale nie o wydaniu <b>%(year)s "
+"%(publisher)s</b>. Dziękujemy! Czy wiesz coś więcej o tym wydaniu?"
 
 #: books/edit.html
 #, fuzzy, python-format
-msgid "We already know about the <b>%(year)s %(publisher)s edition</b> of <b>%(work_title)s</b>, but please, tell us more!"
-msgstr "Już znamy wydanie tej <b>%(year)s %(publisher)s edition</b> książki <b>%(work_title)s</b>, ale prosimy o podanie więcej informacji!"
+msgid ""
+"We already know about the <b>%(year)s %(publisher)s edition</b> of "
+"<b>%(work_title)s</b>, but please, tell us more!"
+msgstr ""
+"Już znamy wydanie tej <b>%(year)s %(publisher)s edition</b> książki "
+"<b>%(work_title)s</b>, ale prosimy o podanie więcej informacji!"
 
 #: books/edit.html
 msgid "Editing..."
 msgstr "Edytowanie..."
 
-#: books/edit.html type/author/edit.html type/tag/form.html type/template/edit.html
+#: books/edit.html type/author/edit.html type/tag/form.html
+#: type/template/edit.html
 msgid "Delete Record"
 msgstr "Usuń wpis"
 
@@ -3664,8 +4181,14 @@ msgid "This Work"
 msgstr "Usuń tę pozycję"
 
 #: books/edit.html
-msgid "You can search by author name (like <em>j k rowling</em>) or by Open Library ID (like <a href=\"/authors/OL23919A\" target=\"_blank\" rel=\"noopener noreferrer\"><em>OL23919A</em></a>)."
-msgstr "Możesz wyszukiwać według imienia autora (jak <em>j k rowling</em>) lub według identyfikatora Open Library (jak <a href=\"/authors/OL23919A\" target=\"_blank\" rel=\"noopener noreferrer\"><em>OL23919A</em></a>)."
+msgid ""
+"You can search by author name (like <em>j k rowling</em>) or by Open "
+"Library ID (like <a href=\"/authors/OL23919A\" target=\"_blank\" "
+"rel=\"noopener noreferrer\"><em>OL23919A</em></a>)."
+msgstr ""
+"Możesz wyszukiwać według imienia autora (jak <em>j k rowling</em>) lub "
+"według identyfikatora Open Library (jak <a href=\"/authors/OL23919A\" "
+"target=\"_blank\" rel=\"noopener noreferrer\"><em>OL23919A</em></a>)."
 
 #: books/edit.html
 msgid "Author editing requires javascript"
@@ -3685,8 +4208,15 @@ msgid "Work Series"
 msgstr "Seria"
 
 #: books/edit.html
-msgid "Series are currently in beta, and this section is only visible to super librarians and admins, like you! Any series you set will be visible by everyone, however. Please report any issues you have on Slack or GitHub."
-msgstr "Serie są obecnie w fazie beta i ta sekcja jest widoczna tylko dla super bibliotekarzy i administratorów, takich jak Ty! Jednak wszystkie ustawione serie będą widoczne dla wszystkich. Zgłaszaj wszelkie problemy na Slacku lub GitHub."
+msgid ""
+"Series are currently in beta, and this section is only visible to super "
+"librarians and admins, like you! Any series you set will be visible by "
+"everyone, however. Please report any issues you have on Slack or GitHub."
+msgstr ""
+"Serie są obecnie w fazie beta i ta sekcja jest widoczna tylko dla super "
+"bibliotekarzy i administratorów, takich jak Ty! Jednak wszystkie "
+"ustawione serie będą widoczne dla wszystkich. Zgłaszaj wszelkie problemy "
+"na Slacku lub GitHub."
 
 #: books/edit.html
 #, fuzzy
@@ -3707,10 +4237,19 @@ msgid "Do you know any identifiers for this work?"
 msgstr "Czy znasz oznaczenia tego wydania?"
 
 #: books/edit.html
-msgid "These identifiers apply to all editions of this work, for example Wikidata work identifiers. For edition-specific identifiers, like ISBN or LCCN, go to the edition tab."
-msgstr "Te identyfikatory dotyczą wszystkich wydań tego dzieła, na przykład identyfikatory dzieła Wikidata. W przypadku identyfikatorów specyficznych dla wydania, takich jak ISBN lub LCCN, przejdź na kartę wydania."
+msgid ""
+"These identifiers apply to all editions of this work, for example "
+"Wikidata work identifiers. For edition-specific identifiers, like ISBN or"
+" LCCN, go to the edition tab."
+msgstr ""
+"Te identyfikatory dotyczą wszystkich wydań tego dzieła, na przykład "
+"identyfikatory dzieła Wikidata. W przypadku identyfikatorów specyficznych"
+" dla wydania, takich jak ISBN lub LCCN, przejdź na kartę wydania."
 
-#: FulltextSearchSuggestionItem.html IABook.html SearchResultsWork.html books/edition-sort.html jsdef/LazyWorkPreview.html lists/list_overview.html lists/preview.html lists/snippet.html lists/widget.html my_books/dropdown_content.html type/work/editions.html
+#: FulltextSearchSuggestionItem.html IABook.html SearchResultsWork.html
+#: books/edition-sort.html jsdef/LazyWorkPreview.html lists/list_overview.html
+#: lists/preview.html lists/snippet.html lists/widget.html
+#: my_books/dropdown_content.html type/work/editions.html
 #, python-format
 msgid "Cover of: %(title)s"
 msgstr "Okładka: %(title)s"
@@ -3730,7 +4269,8 @@ msgstr "Data wydania nieznana, %(publisher)s"
 msgid "in %(languagelist)s"
 msgstr "opublikowane w językach %(languagelist)s"
 
-#: SearchNavigation.html books/mybooks_breadcrumb_select.html lib/nav_foot.html openlibrary/plugins/upstream/mybooks.py
+#: SearchNavigation.html books/mybooks_breadcrumb_select.html lib/nav_foot.html
+#: openlibrary/plugins/upstream/mybooks.py
 msgid "Books"
 msgstr "Książki"
 
@@ -3766,12 +4306,14 @@ msgstr "Przeczytał\\(a\\) (%(count)d)"
 msgid "Stopped Reading (%(count)d)"
 msgstr "Obcenie czyta (%(count)d)"
 
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/openlibrary/lists.py
+#: books/mybooks_breadcrumb_select.html
+#: openlibrary/plugins/openlibrary/lists.py
 #, fuzzy, python-format
 msgid "Lists (%(count)d)"
 msgstr "Chce przeczytać (%(count)d)"
 
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py type/edition/modal_links.html
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#: type/edition/modal_links.html
 #, fuzzy
 msgid "Notes"
 msgstr "Notatki:"
@@ -3827,32 +4369,56 @@ msgid "Please separate with commas."
 msgstr "Wpisuj słowa kluczowe po przecinku."
 
 #: books/edit/about.html
-msgid "For example: <i><a href=\"/subjects/cheese\">cheese</a>, <a href=\"/subjects/roman_empire\">Roman Empire</a>, <a href=\"/subjects/psychology\">psychology</a></i>"
-msgstr "Na przykład: <i><a href=\"/subjects/cheese\">ser</a>, <a href=\"/subjects/roman_empire\">Cesarstwo Rzymskie</a>, <a href=\"/subjects/psychology\">psychologia</a></i>"
+msgid ""
+"For example: <i><a href=\"/subjects/cheese\">cheese</a>, <a "
+"href=\"/subjects/roman_empire\">Roman Empire</a>, <a "
+"href=\"/subjects/psychology\">psychology</a></i>"
+msgstr ""
+"Na przykład: <i><a href=\"/subjects/cheese\">ser</a>, <a "
+"href=\"/subjects/roman_empire\">Cesarstwo Rzymskie</a>, <a "
+"href=\"/subjects/psychology\">psychologia</a></i>"
 
 #: books/edit/about.html
 msgid "A person? Or, people?"
 msgstr "jedna czy więcej osób?"
 
 #: books/edit/about.html
-msgid "For example: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore Roosevelt</a>, <a href=\"/subjects/person:Julian_of_Norwich\">Julian of Norwich</a>, <a href=\"/subjects/person:Tintin\">Tintin</a></i>"
-msgstr "Na przykład: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore Roosevelt</a>, <a href=\"/subjects/person:Julian_of_Norwich\">Julian of Norwich</a>, <a href=\"/subjects/person:Tintin\">Tintin</a></i>"
+msgid ""
+"For example: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore "
+"Roosevelt</a>, <a href=\"/subjects/person:Julian_of_Norwich\">Julian of "
+"Norwich</a>, <a href=\"/subjects/person:Tintin\">Tintin</a></i>"
+msgstr ""
+"Na przykład: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore "
+"Roosevelt</a>, <a href=\"/subjects/person:Julian_of_Norwich\">Julian of "
+"Norwich</a>, <a href=\"/subjects/person:Tintin\">Tintin</a></i>"
 
 #: books/edit/about.html
 msgid "Note any places mentioned?"
 msgstr "Czy zostały wspomniane jakieś miejsca?"
 
 #: books/edit/about.html
-msgid "For example: <i><a href=\"/subjects/place:London\">London</a>, <a href=\"/subjects/place:Atlantis\">Atlantis</a>, <a href=\"/subjects/place:Omaha\">Omaha</a></i>"
-msgstr "Na przykład: <i><a href=\"/subjects/place:London\">Londyn</a>, <a href=\"/subjects/place:Atlantis\">Atlantyda</a>, <a href=\"/subjects/place:Omaha\">Omaha</a></i>"
+msgid ""
+"For example: <i><a href=\"/subjects/place:London\">London</a>, <a "
+"href=\"/subjects/place:Atlantis\">Atlantis</a>, <a "
+"href=\"/subjects/place:Omaha\">Omaha</a></i>"
+msgstr ""
+"Na przykład: <i><a href=\"/subjects/place:London\">Londyn</a>, <a "
+"href=\"/subjects/place:Atlantis\">Atlantyda</a>, <a "
+"href=\"/subjects/place:Omaha\">Omaha</a></i>"
 
 #: books/edit/about.html
 msgid "When is it set or about?"
 msgstr "Kiedy odbywa się akcja książki, o czym jest?"
 
 #: books/edit/about.html
-msgid "For example: <i><a href=\"/subjects/time:1984\">1984</a>, <a href=\"/subjects/time:the_middle_ages\">The Middle Ages</a>, <a href=\"/subjects/time:1810-1890\">1810-1890</a></i>"
-msgstr "Na przykład: <i><a href=\"/subjects/time:1984\">1984</a>, <a href=\"/subjects/time:the_middle_ages\">Średniowiecze</a>, <a href=\"/subjects/time:1810-1890\">1810-1890</a></i>"
+msgid ""
+"For example: <i><a href=\"/subjects/time:1984\">1984</a>, <a "
+"href=\"/subjects/time:the_middle_ages\">The Middle Ages</a>, <a "
+"href=\"/subjects/time:1810-1890\">1810-1890</a></i>"
+msgstr ""
+"Na przykład: <i><a href=\"/subjects/time:1984\">1984</a>, <a "
+"href=\"/subjects/time:the_middle_ages\">Średniowiecze</a>, <a "
+"href=\"/subjects/time:1810-1890\">1810-1890</a></i>"
 
 #: books/edit/edition.html
 msgid "Select this language"
@@ -4014,12 +4580,22 @@ msgid "Table of Contents"
 msgstr "Spis treści"
 
 #: books/edit/edition.html
-msgid "Use a \"*\" for an indent, a \"|\" to add a column, and line breaks for new lines. Like this:"
-msgstr "Użyj \"*\" by zrobić wcięcie, \"|\" by dodać kolumnę oraz zakończenie i rozpoczęcie nowej linii. W taki sposób:"
+msgid ""
+"Use a \"*\" for an indent, a \"|\" to add a column, and line breaks for "
+"new lines. Like this:"
+msgstr ""
+"Użyj \"*\" by zrobić wcięcie, \"|\" by dodać kolumnę oraz zakończenie i "
+"rozpoczęcie nowej linii. W taki sposób:"
 
 #: books/edit/edition.html
-msgid "This table of contents contains extra information like authors or descriptions. We don't have a great user interface for this yet, so editing this data could be difficult. Watch out!"
-msgstr "Ten spis treści zawiera dodatkowe informacje, takie jak autorzy lub opisy. Nie mamy jeszcze dobrego interfejsu użytkownika do tego, więc edycja tych danych może być trudna. Uważaj!"
+msgid ""
+"This table of contents contains extra information like authors or "
+"descriptions. We don't have a great user interface for this yet, so "
+"editing this data could be difficult. Watch out!"
+msgstr ""
+"Ten spis treści zawiera dodatkowe informacje, takie jak autorzy lub "
+"opisy. Nie mamy jeszcze dobrego interfejsu użytkownika do tego, więc "
+"edycja tych danych może być trudna. Uważaj!"
 
 #: books/edit/edition.html
 msgid "Any notes about this specific edition?"
@@ -4039,24 +4615,44 @@ msgid "Is it known by any other titles?"
 msgstr "Czy ta pozycja jest znana pod innymi tytułami?"
 
 #: books/edit/edition.html
-msgid "Use this field if the title is different on the cover or spine. If the edition is a collection or anthology, you may also add the individual titles of each work here."
-msgstr "Wypełnij te pole jeśli tytuł jest inny na okładce lub grzbiecie książki. Jeśli te wydanie jest kolekcją lub antologią, możesz tutaj także dodać poszczególne tytuły."
+msgid ""
+"Use this field if the title is different on the cover or spine. If the "
+"edition is a collection or anthology, you may also add the individual "
+"titles of each work here."
+msgstr ""
+"Wypełnij te pole jeśli tytuł jest inny na okładce lub grzbiecie książki. "
+"Jeśli te wydanie jest kolekcją lub antologią, możesz tutaj także dodać "
+"poszczególne tytuły."
 
 #: books/edit/edition.html
-msgid "For example: <i>Eaters of the Dead</i> is an alternate title for <i><a href=\"/books/OL24923038M\">The 13th Warrior</a></i>."
-msgstr "Na przykład: <i>Eaters of the Dead</i> to alternatywny tytuł dla <i><a href=\"/books/OL24923038M\">The 13th Warrior</a></i>."
+msgid ""
+"For example: <i>Eaters of the Dead</i> is an alternate title for <i><a "
+"href=\"/books/OL24923038M\">The 13th Warrior</a></i>."
+msgstr ""
+"Na przykład: <i>Eaters of the Dead</i> to alternatywny tytuł dla <i><a "
+"href=\"/books/OL24923038M\">The 13th Warrior</a></i>."
 
 #: books/edit/edition.html
 msgid "What work is this an edition of?"
 msgstr "Jest to wydanie książki... "
 
 #: books/edit/edition.html
-msgid "Sometimes editions can be associated with the wrong work. You can correct that here."
-msgstr "Zdarza się, że wydania są skojarzone z niepoprawnymi książkami. Możesz to poprawić tutaj."
+msgid ""
+"Sometimes editions can be associated with the wrong work. You can correct"
+" that here."
+msgstr ""
+"Zdarza się, że wydania są skojarzone z niepoprawnymi książkami. Możesz to"
+" poprawić tutaj."
 
 #: books/edit/edition.html
-msgid "You can search by title or by Open Library ID (like <a href=\"/works/OL262757W\" target=\"_blank\" rel=\"noopener noreferrer\"><em>OL262757W</em></a>)."
-msgstr "Możesz wyszukiwać według tytułu lub identyfikatora Open Library (jak <a href=\"/works/OL262757W\" target=\"_blank\" rel=\"noopener noreferrer\"><em>OL262757W</em></a>)."
+msgid ""
+"You can search by title or by Open Library ID (like <a "
+"href=\"/works/OL262757W\" target=\"_blank\" rel=\"noopener "
+"noreferrer\"><em>OL262757W</em></a>)."
+msgstr ""
+"Możesz wyszukiwać według tytułu lub identyfikatora Open Library (jak <a "
+"href=\"/works/OL262757W\" target=\"_blank\" rel=\"noopener "
+"noreferrer\"><em>OL262757W</em></a>)."
 
 #: books/edit/edition.html
 msgid "WARNING: Any edits made to the work from this page will be ignored."
@@ -4265,8 +4861,12 @@ msgid "That excerpt is too long."
 msgstr "Ten fragment jest za długi."
 
 #: books/edit/excerpts.html
-msgid "If there are particular (short) passages you feel represent the book well, please feel free to transcribe them here."
-msgstr "Jeśli Twoim zdaniem pewne (krótkie) fragmenty dobrze reprezentują całą książkę, proszę zacytować je tutaj."
+msgid ""
+"If there are particular (short) passages you feel represent the book "
+"well, please feel free to transcribe them here."
+msgstr ""
+"Jeśli Twoim zdaniem pewne (krótkie) fragmenty dobrze reprezentują całą "
+"książkę, proszę zacytować je tutaj."
 
 #: books/edit/excerpts.html
 msgid "Page number?"
@@ -4326,8 +4926,12 @@ msgid "Please enter a valid URL."
 msgstr "Proszę podać URL."
 
 #: books/edit/web.html
-msgid "Please connect Open Library records to <u>good</u><span class=\"orange\">*</span> online resources."
-msgstr "Proszę połączyć kroniki Open Library <u>poprawnych</u><span class=\"orange\">*</span> z zasobami online."
+msgid ""
+"Please connect Open Library records to <u>good</u><span "
+"class=\"orange\">*</span> online resources."
+msgstr ""
+"Proszę połączyć kroniki Open Library <u>poprawnych</u><span "
+"class=\"orange\">*</span> z zasobami online."
 
 #: books/edit/web.html
 msgid "Give your link a label"
@@ -4351,8 +4955,14 @@ msgid "Remove this link"
 msgstr "Usuń ten link"
 
 #: books/edit/web.html
-msgid "\"Good\" means no spammy links, please. Keep them relevant to the book. Irrelevant sites may be removed. Blatant spam will be deleted without remorse."
-msgstr "\"Poprwany\" oznacza link bez spamu. Linki muszą być powiązane z tą książką. Nieistotne strony mogą zostać usunięte. Rażący spam zostanie usunięty natychmiastowo."
+msgid ""
+"\"Good\" means no spammy links, please. Keep them relevant to the book. "
+"Irrelevant sites may be removed. Blatant spam will be deleted without "
+"remorse."
+msgstr ""
+"\"Poprwany\" oznacza link bez spamu. Linki muszą być powiązane z tą "
+"książką. Nieistotne strony mogą zostać usunięte. Rażący spam zostanie "
+"usunięty natychmiastowo."
 
 #: bulk_search/bulk_search.html search/advancedsearch.html
 msgid "Bulk Search (beta)"
@@ -4387,8 +4997,12 @@ msgstr "Podaj ULR tego obrazu."
 
 #: covers/add.html
 #, python-format
-msgid "Learn more by reading our <a href=\"/help/faq/editing#picture\" target=\"blank\">%(guidelines)s</a>."
-msgstr "Dowiedz się więcej, czytając nasze <a href=\"/help/faq/editing#picture\" target=\"blank\">%(guidelines)s</a>."
+msgid ""
+"Learn more by reading our <a href=\"/help/faq/editing#picture\" "
+"target=\"blank\">%(guidelines)s</a>."
+msgstr ""
+"Dowiedz się więcej, czytając nasze <a href=\"/help/faq/editing#picture\" "
+"target=\"blank\">%(guidelines)s</a>."
 
 #: covers/add.html
 #, fuzzy
@@ -4517,8 +5131,12 @@ msgid "Or, use an image from %s"
 msgstr "Lub użyj obrazu z %s"
 
 #: covers/manage.html
-msgid "You can drag and drop thumbnails to reorder, or into the trash to delete them."
-msgstr "Możesz przeciągać i upuszczać miniatury w celu zmiany kolejności, lub przeciągać je do kosza w celu usunięcia"
+msgid ""
+"You can drag and drop thumbnails to reorder, or into the trash to delete "
+"them."
+msgstr ""
+"Możesz przeciągać i upuszczać miniatury w celu zmiany kolejności, lub "
+"przeciągać je do kosza w celu usunięcia"
 
 #: covers/saved.html
 msgid "New book cover"
@@ -4546,8 +5164,16 @@ msgstr "Przełącz"
 
 #: design/toggle.html
 #, python-format
-msgid "The %(tag)s component is a switch with a bold label and an optional greyed sublabel. The whole control is one %(role)s button, so the entire surface is clickable and Enter/Space activate it. It owns its on/off state: clicking flips %(checked)s and fires %(event)s."
-msgstr "Komponent %(tag)s to przełącznik z pogrubioną etykietą i opcjonalną szarą podetyketą. Cała kontrolka to jeden przycisk %(role)s, więc cała powierzchnia jest klikalna, a Enter/Spacja ją aktywuje. Zarządza swoim stanem włącz/wyłącz: kliknięcie zmienia %(checked)s i wywołuje %(event)s."
+msgid ""
+"The %(tag)s component is a switch with a bold label and an optional "
+"greyed sublabel. The whole control is one %(role)s button, so the entire "
+"surface is clickable and Enter/Space activate it. It owns its on/off "
+"state: clicking flips %(checked)s and fires %(event)s."
+msgstr ""
+"Komponent %(tag)s to przełącznik z pogrubioną etykietą i opcjonalną szarą"
+" podetyketą. Cała kontrolka to jeden przycisk %(role)s, więc cała "
+"powierzchnia jest klikalna, a Enter/Spacja ją aktywuje. Zarządza swoim "
+"stanem włącz/wyłącz: kliknięcie zmienia %(checked)s i wywołuje %(event)s."
 
 #: design/toggle.html
 msgid "Default"
@@ -4555,8 +5181,12 @@ msgstr "Domyślny"
 
 #: design/toggle.html
 #, python-format
-msgid "A plain toggle: just the switch, a bold %(label)s, and an optional greyed %(sublabel)s."
-msgstr "Prosty przełącznik: tylko przełącznik, pogrubiona %(label)s i opcjonalna szara %(sublabel)s."
+msgid ""
+"A plain toggle: just the switch, a bold %(label)s, and an optional greyed"
+" %(sublabel)s."
+msgstr ""
+"Prosty przełącznik: tylko przełącznik, pogrubiona %(label)s i opcjonalna "
+"szara %(sublabel)s."
 
 #: design/toggle.html
 msgid "Card variant"
@@ -4564,8 +5194,14 @@ msgstr "Wariant kart"
 
 #: design/toggle.html
 #, python-format
-msgid "Use %(variant)s for a bordered container. When checked, it fills with a solid primary-blue background and white text — the same treatment as a selected %(chip)s."
-msgstr "Użyj %(variant)s dla kontenera z obramowaniem. Po zaznaczeniu wypełnia się jednolitym niebieskim tłem i białym tekstem — takie samo traktowanie jak wybrany %(chip)s."
+msgid ""
+"Use %(variant)s for a bordered container. When checked, it fills with a "
+"solid primary-blue background and white text — the same treatment as a "
+"selected %(chip)s."
+msgstr ""
+"Użyj %(variant)s dla kontenera z obramowaniem. Po zaznaczeniu wypełnia "
+"się jednolitym niebieskim tłem i białym tekstem — takie samo traktowanie "
+"jak wybrany %(chip)s."
 
 #: design/toggle.html
 #, fuzzy
@@ -4574,8 +5210,14 @@ msgstr "Spis treści"
 
 #: design/toggle.html
 #, python-format
-msgid "Put content in the default slot to customize the label instead of using %(label)s / %(sublabel)s. Supply %(accessible_label)s so the switch still has an accessible name."
-msgstr "Umieść zawartość w domyślnym slocie, aby dostosować etykietę zamiast używać %(label)s / %(sublabel)s. Podaj %(accessible_label)s, aby przełącznik nadal miał dostępną nazwę."
+msgid ""
+"Put content in the default slot to customize the label instead of using "
+"%(label)s / %(sublabel)s. Supply %(accessible_label)s so the switch still"
+" has an accessible name."
+msgstr ""
+"Umieść zawartość w domyślnym slocie, aby dostosować etykietę zamiast "
+"używać %(label)s / %(sublabel)s. Podaj %(accessible_label)s, aby "
+"przełącznik nadal miał dostępną nazwę."
 
 #: design/toggle.html
 msgid "Dark mode"
@@ -4618,12 +5260,19 @@ msgid "Thank you for your note. We'll get back to you as soon as possible."
 msgstr "Dziękujemy za wiadomość. Odpowiemy tak szybko, jak to możliwe."
 
 #: email/case_created.html
-msgid "It might take us a little while to read it because we receive lots of messages, but rest assured we will, and we'll get back to you if required."
+msgid ""
+"It might take us a little while to read it because we receive lots of "
+"messages, but rest assured we will, and we'll get back to you if "
+"required."
 msgstr ""
+"Przeczytanie wiadomości może nam zająć chwilę, ponieważ otrzymujemy wiele"
+" wiadomości, ale możesz być pewien, że odezwiemy się do Ciebie."
 
 #: email/account/pd_request.html
 msgid "Qualifying for Print Disability Special Access"
-msgstr "Kwalifikowanie się do specjalnego dostępu dla osób z niepełnosprawnością druku"
+msgstr ""
+"Kwalifikowanie się do specjalnego dostępu dla osób z niepełnosprawnością "
+"druku"
 
 #: history/sources.html
 #, fuzzy
@@ -4635,16 +5284,30 @@ msgid "About the Project"
 msgstr "O projekcie"
 
 #: home/about.html
-msgid "Open Library is an open, editable library catalog, building towards a web page for every book ever published."
-msgstr "Open Library to otwarty, edytowalny katalog biblioteczny, dążący do stworzenia strony internetowej dla każdej kiedykolwiek opublikowanej książki."
+msgid ""
+"Open Library is an open, editable library catalog, building towards a web"
+" page for every book ever published."
+msgstr ""
+"Open Library to otwarty, edytowalny katalog biblioteczny, dążący do "
+"stworzenia strony internetowej dla każdej kiedykolwiek opublikowanej "
+"książki."
 
 #: AffiliateLinks.html home/about.html search/work_search_facets.html
 msgid "More"
 msgstr "Więcej"
 
 #: home/about.html
-msgid "Just like Wikipedia, you can contribute new information or corrections to the catalog. You can browse by <a href=\"/subjects\">subjects</a>, <a href=\"/authors\">authors</a> or <a href=\"/lists\">lists</a> members have created. If you love books, why not help build a library?"
-msgstr "Tak jak na Wikipedii, możesz dodać nowe informacje lub poprawki do katalogu. Możesz przeglądać według <a href=\"/subjects\">tematyki</a>, <a href=\"/authors\">autorów</a> lub <a href=\"/lists\">list</a> stworzonych przez użytkowników. Jeśli kochasz książki - czemu nie pomóc w budowie biblioteki?"
+msgid ""
+"Just like Wikipedia, you can contribute new information or corrections to"
+" the catalog. You can browse by <a href=\"/subjects\">subjects</a>, <a "
+"href=\"/authors\">authors</a> or <a href=\"/lists\">lists</a> members "
+"have created. If you love books, why not help build a library?"
+msgstr ""
+"Tak jak na Wikipedii, możesz dodać nowe informacje lub poprawki do "
+"katalogu. Możesz przeglądać według <a href=\"/subjects\">tematyki</a>, <a"
+" href=\"/authors\">autorów</a> lub <a href=\"/lists\">list</a> "
+"stworzonych przez użytkowników. Jeśli kochasz książki - czemu nie pomóc w"
+" budowie biblioteki?"
 
 #: home/about.html
 msgid "Latest Blog Posts"
@@ -4673,7 +5336,8 @@ msgstr "Literatura klasyczna"
 msgid "Recently Returned"
 msgstr "Ostatnio zwrócone"
 
-#: home/index.html openlibrary/plugins/openlibrary/api.py openlibrary/plugins/openlibrary/home.py
+#: home/index.html openlibrary/plugins/openlibrary/api.py
+#: openlibrary/plugins/openlibrary/home.py
 msgid "Romance"
 msgstr "Romanse"
 
@@ -4685,7 +5349,8 @@ msgstr "Książki dla dzieci"
 msgid "Thrillers"
 msgstr "Dreszczwce"
 
-#: home/index.html openlibrary/plugins/openlibrary/api.py openlibrary/plugins/openlibrary/home.py
+#: home/index.html openlibrary/plugins/openlibrary/api.py
+#: openlibrary/plugins/openlibrary/home.py
 msgid "Textbooks"
 msgstr "Podręczniki"
 
@@ -4699,22 +5364,40 @@ msgstr "Książki w środowisku lokalnym"
 
 #: home/loans.html
 #, python-format
-msgid "You can still <a href=\"/subjects/in_library#ebooks=true\">borrow</a> one more book until you've hit the limit!"
-msgid_plural "You can still <a href=\"/subjects/in_library#ebooks=true\">borrow</a> %(count)d more books until you've hit the limit!"
-msgstr[0] "Możesz jeszcze <a href=\"/subjects/in_library#ebooks=true\">wypożyczyć</a> jedną książkę, zanim osiągniesz limit!"
-msgstr[1] "Możesz jeszcze <a href=\"/subjects/in_library#ebooks=true\">wypożyczyć</a> %(count)d książki, zanim osiągniesz limit!"
+msgid ""
+"You can still <a href=\"/subjects/in_library#ebooks=true\">borrow</a> one"
+" more book until you've hit the limit!"
+msgid_plural ""
+"You can still <a href=\"/subjects/in_library#ebooks=true\">borrow</a> "
+"%(count)d more books until you've hit the limit!"
+msgstr[0] ""
+"Możesz jeszcze <a "
+"href=\"/subjects/in_library#ebooks=true\">wypożyczyć</a> jedną książkę, "
+"zanim osiągniesz limit!"
+msgstr[1] ""
+"Możesz jeszcze <a "
+"href=\"/subjects/in_library#ebooks=true\">wypożyczyć</a> %(count)d "
+"książki, zanim osiągniesz limit!"
 
 #: home/loans.html
-msgid "You have reached the borrowing limit. Please return a book to checkout something new."
-msgstr "Osiągnąłeś/aś limit wypożyczeń. Proszę zwrócić książkę, aby wypożyczyć coś nowego."
+msgid ""
+"You have reached the borrowing limit. Please return a book to checkout "
+"something new."
+msgstr ""
+"Osiągnąłeś/aś limit wypożyczeń. Proszę zwrócić książkę, aby wypożyczyć "
+"coś nowego."
 
 #: home/stats.html
 msgid "Around the Library"
 msgstr "O Open Library"
 
 #: home/stats.html
-msgid "Here's what's happened over the last 28 days. More <a href=\"/recentchanges\">recent changes</a>"
-msgstr "Oto co wydarzyło się w ciągu ostatnich 28 dni. Więcej <a href=\"/recentchanges\">ostatnich zmian</a>"
+msgid ""
+"Here's what's happened over the last 28 days. More <a "
+"href=\"/recentchanges\">recent changes</a>"
+msgstr ""
+"Oto co wydarzyło się w ciągu ostatnich 28 dni. Więcej <a "
+"href=\"/recentchanges\">ostatnich zmian</a>"
 
 #: home/stats.html
 msgid "See all visitors to OpenLibrary.org"
@@ -4783,7 +5466,9 @@ msgstr "Ustaw roczny cel czytelniczy"
 
 #: home/welcome.html
 msgid "Learn how to set a yearly reading goal and track what you read"
-msgstr "Dowiedz się, jak ustawić roczny cel czytelniczy i śledzić przeczytane książki"
+msgstr ""
+"Dowiedz się, jak ustawić roczny cel czytelniczy i śledzić przeczytane "
+"książki"
 
 #: home/welcome.html
 msgid "Keep Track of your Favorite Books"
@@ -4937,7 +5622,8 @@ msgstr "Menu"
 msgid "New!"
 msgstr "Nowsze"
 
-#: databarDiff.html databarEdit.html databarTemplate.html databarView.html lib/history.html openlibrary/plugins/openlibrary/home.py
+#: databarDiff.html databarEdit.html databarTemplate.html databarView.html
+#: lib/history.html openlibrary/plugins/openlibrary/home.py
 msgid "History"
 msgstr "Historia"
 
@@ -4976,8 +5662,13 @@ msgid " Your new record is in the library. Thank you!"
 msgstr " Twój nowy rekord jest w bibliotece. Dziękujemy!"
 
 #: lib/message_addbook.html
-msgid "There are a few other simple things you can add while you're here to improve your new record quickly, and make it much easier for other people to find later."
+msgid ""
+"There are a few other simple things you can add while you're here to "
+"improve your new record quickly, and make it much easier for other people"
+" to find later."
 msgstr ""
+"Jest kilka innych prostych rzeczy, które możesz dodać podczas wizyty, aby"
+" szybko ulepszyć swój nowy rekord."
 
 #: lib/message_addbook.html
 #, fuzzy
@@ -5074,7 +5765,9 @@ msgstr "Zobacz autorów"
 msgid "Explore subjects"
 msgstr "Zobacz książki"
 
-#: RelatedSubjects.html SearchNavigation.html SubjectTags.html lib/nav_foot.html lib/nav_head.html openlibrary/plugins/worksearch/code.py subjects/notfound.html type/author/view.html type/list/view_body.html
+#: RelatedSubjects.html SearchNavigation.html SubjectTags.html
+#: lib/nav_foot.html lib/nav_head.html openlibrary/plugins/worksearch/code.py
+#: subjects/notfound.html type/author/view.html type/list/view_body.html
 msgid "Subjects"
 msgstr "Tematyka"
 
@@ -5088,7 +5781,8 @@ msgstr "Zobacz książki"
 msgid "Collections"
 msgstr "Akcje"
 
-#: SearchNavigation.html lib/nav_foot.html lib/nav_head.html search/advancedsearch.html
+#: SearchNavigation.html lib/nav_foot.html lib/nav_head.html
+#: search/advancedsearch.html
 msgid "Advanced Search"
 msgstr "Wyszukiwanie zaawansowane"
 
@@ -5206,13 +5900,31 @@ msgid "Open Library logo"
 msgstr "Open Library"
 
 #: lib/nav_foot.html
-msgid "Open Library is an initiative of the <a href=\"//archive.org/\">Internet Archive</a>, a 501(c)(3) non-profit, building a digital library of Internet sites and other cultural artifacts in  digital form. Other <a href=\"//archive.org/projects/\">projects</a> include the <a href=\"//archive.org/web/\">Wayback Machine</a>, <a href=\"//archive.org/\">archive.org</a> and <a href=\"//archive-it.org\">archive-it.org</a>"
-msgstr "Open Library to inicjatywa <a href=\"//archive.org/\">Internet Archive</a>, 501(c)(3) organizacji non-profit, tworzącej cyfrową bibliotekę stron internetowych i innych artefaktów kulturowych w formie cyfrowej. Inne <a href=\"//archive.org/projects/\">projekty</a> obejmują <a href=\"//archive.org/web/\">Wayback Machine</a>, <a href=\"//archive.org/\">archive.org</a> oraz <a href=\"//archive-it.org\">archive-it.org</a>"
+msgid ""
+"Open Library is an initiative of the <a href=\"//archive.org/\">Internet "
+"Archive</a>, a 501(c)(3) non-profit, building a digital library of "
+"Internet sites and other cultural artifacts in  digital form. Other <a "
+"href=\"//archive.org/projects/\">projects</a> include the <a "
+"href=\"//archive.org/web/\">Wayback Machine</a>, <a "
+"href=\"//archive.org/\">archive.org</a> and <a href=\"//archive-it.org"
+"\">archive-it.org</a>"
+msgstr ""
+"Open Library to inicjatywa <a href=\"//archive.org/\">Internet "
+"Archive</a>, 501(c)(3) organizacji non-profit, tworzącej cyfrową "
+"bibliotekę stron internetowych i innych artefaktów kulturowych w formie "
+"cyfrowej. Inne <a href=\"//archive.org/projects/\">projekty</a> obejmują "
+"<a href=\"//archive.org/web/\">Wayback Machine</a>, <a "
+"href=\"//archive.org/\">archive.org</a> oraz <a href=\"//archive-it.org"
+"\">archive-it.org</a>"
 
 #: lib/nav_foot.html
 #, python-format
-msgid "version <a href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</a>"
-msgstr "wersja <a href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</a>"
+msgid ""
+"version <a "
+"href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</a>"
+msgstr ""
+"wersja <a "
+"href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</a>"
 
 #: lib/nav_head.html
 msgid "Loans, Reading Log, Lists, Stats"
@@ -5289,8 +6001,20 @@ msgid "Search by barcode"
 msgstr "Szukaj w"
 
 #: lib/not_logged.html
-msgid "<strong>You are not <a href=\"/account/login\" title=\"Log in now\">logged in</a>.</strong> Open Library will record your IP address and include it in this page's publicly accessible edit history. If you <a href=\"/account/create\" title=\"Create an Open Library account\">create an account</a>, your IP address is concealed and you can more easily keep track of all your edits and additions."
+msgid ""
+"<strong>You are not <a href=\"/account/login\" title=\"Log in "
+"now\">logged in</a>.</strong> Open Library will record your IP address "
+"and include it in this page's publicly accessible edit history. If you <a"
+" href=\"/account/create\" title=\"Create an Open Library account\">create"
+" an account</a>, your IP address is concealed and you can more easily "
+"keep track of all your edits and additions."
 msgstr ""
+"<strong>Nie jesteś <a href=\"/account/login\" title=\"Zaloguj się "
+"teraz\">zalogowany/a</a>.</strong> Open Library zapisze Twój adres IP i "
+"uwzględni go w publicznie dostępnej historii edycji tej strony. Jeśli <a "
+"href=\"/account/create\" title=\"Utwórz konto w Open Library\">utworzysz "
+"konto</a>, Twój adres IP zostanie ukryty i będziesz mógł/mogła łatwiej "
+"śledzić wszystkie swoje edycje i dodania."
 
 #: librarian_dashboard/data_quality_table.html
 #, fuzzy
@@ -5385,13 +6109,26 @@ msgid "Create a list of any Subjects, Authors, Works or specific Editions."
 msgstr "Stwórz listę dowolnych tematów, autorów, książek lub wydań."
 
 #: lists/home.html
-msgid "Once you've made a list, you can <strong>watch for updates</strong> or <strong>export</strong> all the editions in a list as HTML, BibTeX or JSON. See all your lists and any activity using the \"Lists\" link on your Account page."
-msgstr "Po utworzeniu listy możesz <strong>obserwować aktualizacje</strong> lub <strong>eksportować</strong> wszystkie wydania z listy jako HTML, BibTeX lub JSON. Zobacz wszystkie swoje listy i wszelkie działania za pomocą linku \"Lists\" na stronie Twojego konta."
+msgid ""
+"Once you've made a list, you can <strong>watch for updates</strong> or "
+"<strong>export</strong> all the editions in a list as HTML, BibTeX or "
+"JSON. See all your lists and any activity using the \"Lists\" link on "
+"your Account page."
+msgstr ""
+"Po utworzeniu listy możesz <strong>obserwować aktualizacje</strong> lub "
+"<strong>eksportować</strong> wszystkie wydania z listy jako HTML, BibTeX "
+"lub JSON. Zobacz wszystkie swoje listy i wszelkie działania za pomocą "
+"linku \"Lists\" na stronie Twojego konta."
 
 #: lists/home.html
 #, python-format
-msgid "For the top 2000+ most requested eBooks in California for the print disabled <a href=\"%(url)s\">click here</a>."
-msgstr "Aby zapoznać się z ponad 2000 najczęściej żądanych e-booków w Kalifornii dla osób z niepełnosprawnością druku, <a href=\"%(url)s\">kliknij tutaj</a>."
+msgid ""
+"For the top 2000+ most requested eBooks in California for the print "
+"disabled <a href=\"%(url)s\">click here</a>."
+msgstr ""
+"Aby zapoznać się z ponad 2000 najczęściej żądanych e-booków w Kalifornii "
+"dla osób z niepełnosprawnością druku, <a href=\"%(url)s\">kliknij "
+"tutaj</a>."
 
 #: lists/home.html
 msgid "Find a list by name"
@@ -5406,7 +6143,8 @@ msgstr "Aktywne Listy"
 msgid "from <a href=\"%(key)s\">%(owner)s</a>"
 msgstr "<a href=\"%(key)s\">%(owner)s</a>"
 
-#: lists/home.html lists/preview.html lists/snippet.html type/list/embed.html type/list/view_body.html
+#: lists/home.html lists/preview.html lists/snippet.html type/list/embed.html
+#: type/list/view_body.html
 #, fuzzy, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
@@ -5568,12 +6306,14 @@ msgstr "Wybierz autorów do połączenia."
 
 #: merge/authors.html
 msgid "Select the oldest profile as primary -"
-msgstr ""
+msgstr "Wybierz najstarszy profil jako główny -"
 
 #: merge/authors.html
 #, fuzzy
 msgid "Select author records which should be merged with the primary"
-msgstr "Wybierz dokumenty autora, które powinny zostać połączone z głównym dokumentem"
+msgstr ""
+"Wybierz dokumenty autora, które powinny zostać połączone z głównym "
+"dokumentem"
 
 #: merge/authors.html
 msgid "Press MERGE AUTHORS."
@@ -5599,7 +6339,7 @@ msgstr "<b>Czy na pewno</b> chcesz połączyć te dokumenty?"
 
 #: merge/authors.html recentchanges/merge/view.html
 msgid "Primary"
-msgstr ""
+msgstr "Główny"
 
 #: merge/authors.html
 msgid "Merge"
@@ -5607,7 +6347,7 @@ msgstr "Połącz"
 
 #: merge/authors.html
 msgid "birth/death date"
-msgstr ""
+msgstr "data urodzenia/śmierci"
 
 #: merge/authors.html
 msgid "Open in a new window"
@@ -5648,28 +6388,28 @@ msgstr "Połącz autorów"
 
 #: merge_request_table/merge_request_table.html
 msgid "Failed to submit comment. Please try again in a few moments."
-msgstr ""
+msgstr "Nie udało się przesłać komentarza. Spróbuj ponownie za chwilę."
 
 #: merge_request_table/merge_request_table.html
 msgid "(Optional) Why are you closing this request?"
-msgstr ""
+msgstr "(Opcjonalnie) Dlaczego zamykasz tę prośbę?"
 
 #: merge_request_table/merge_request_table.html
 #, python-format
 msgid "Showing %(username)s's requests only."
-msgstr ""
+msgstr "Wyświetlanie tylko próśb %(username)s."
 
 #: merge_request_table/merge_request_table.html
 msgid "Show all requests"
-msgstr ""
+msgstr "Pokaż wszystkie prośby"
 
 #: merge_request_table/merge_request_table.html
 msgid "Showing all requests."
-msgstr ""
+msgstr "Wyświetlanie wszystkich próśb."
 
 #: merge_request_table/merge_request_table.html
 msgid "Show my requests"
-msgstr ""
+msgstr "Pokaż moje prośby"
 
 #: merge_request_table/merge_request_table.html
 #, fuzzy
@@ -5678,7 +6418,7 @@ msgstr "Najnowsze zmiany wprowadzone przez społeczność"
 
 #: merge_request_table/merge_request_table.html
 msgid "No entries here!"
-msgstr ""
+msgstr "Brak wpisów!"
 
 #: merge_request_table/table_header.html
 #, fuzzy
@@ -5707,7 +6447,7 @@ msgstr "Połącz"
 
 #: merge_request_table/table_header.html openlibrary/core/edits.py
 msgid "Declined"
-msgstr ""
+msgstr "Odrzucono"
 
 #: merge_request_table/table_header.html
 #, fuzzy
@@ -5716,11 +6456,11 @@ msgstr "Zatwierdź"
 
 #: merge_request_table/table_header.html
 msgid "Filter submitters"
-msgstr ""
+msgstr "Filtruj nadawców"
 
 #: merge_request_table/table_header.html
 msgid "Submitted by me"
-msgstr ""
+msgstr "Przesłane przeze mnie"
 
 #: merge_request_table/table_header.html
 #, fuzzy
@@ -5739,7 +6479,7 @@ msgstr "filtrów"
 
 #: merge_request_table/table_header.html
 msgid "Assigned to nobody"
-msgstr ""
+msgstr "Nieprzypisane"
 
 #: merge_request_table/table_header.html
 #, fuzzy
@@ -5763,7 +6503,7 @@ msgstr "Starsze"
 
 #: merge_request_table/table_row.html
 msgid "An untitled work"
-msgstr ""
+msgstr "Dzieło bez tytułu"
 
 #: merge_request_table/table_row.html
 #, fuzzy
@@ -5772,11 +6512,11 @@ msgstr "Nieznany autor"
 
 #: merge_request_table/table_row.html
 msgid "Open request"
-msgstr ""
+msgstr "Otwarta prośba"
 
 #: merge_request_table/table_row.html
 msgid "Closed request"
-msgstr ""
+msgstr "Zamknięta prośba"
 
 #: merge_request_table/table_row.html
 #, fuzzy
@@ -5790,12 +6530,16 @@ msgstr "Edytowano bez dodania komentarza."
 
 #: merge_request_table/table_row.html
 msgid "Reply"
-msgstr ""
+msgstr "Odpowiedz"
 
 #: merge_request_table/table_row.html
 #, python-format
-msgid "MR #%(id)s opened %(date)s by <a href=\"/people/%(submitter)s\" class=\"commenter\">@%(submitter)s</a>"
+msgid ""
+"MR #%(id)s opened %(date)s by <a href=\"/people/%(submitter)s\" "
+"class=\"commenter\">@%(submitter)s</a>"
 msgstr ""
+"MR #%(id)s otwarto %(date)s przez <a href=\"/people/%(submitter)s\" "
+"class=\"commenter\">@%(submitter)s</a>"
 
 #: merge_request_table/table_row.html
 #, fuzzy
@@ -5804,7 +6548,7 @@ msgstr "Kliknij, aby usunąć ten aspekt"
 
 #: merge_request_table/table_row.html
 msgid "Review <!-- (merge request) -->"
-msgstr ""
+msgstr "Recenzja <!-- (merge request) -->"
 
 #: merge_request_table/table_row.html
 #, fuzzy
@@ -5834,11 +6578,13 @@ msgstr "Usuń tę pozycję"
 msgid "Create a new list"
 msgstr "Stwórz nową listę"
 
-#: CreateListModal.html my_books/dropdown_content.html type/permission/edit.html type/usergroup/edit.html
+#: CreateListModal.html my_books/dropdown_content.html
+#: type/permission/edit.html type/usergroup/edit.html
 msgid "Description:"
 msgstr "Opis"
 
-#: CreateListModal.html my_books/dropdown_content.html type/list/edit.html type/series/edit.html
+#: CreateListModal.html my_books/dropdown_content.html type/list/edit.html
+#: type/series/edit.html
 msgid "Create new list"
 msgstr "Utwórz nową listę"
 
@@ -5847,8 +6593,12 @@ msgid "saving..."
 msgstr "zapisywanie..."
 
 #: my_books/dropdown_content.html
-msgid "Removing this book from your shelves will delete your check-ins for this work.  Continue?"
+msgid ""
+"Removing this book from your shelves will delete your check-ins for this "
+"work.  Continue?"
 msgstr ""
+"Usunięcie tej książki z półek spowoduje usunięcie Twoich zameldowań dla "
+"tego dzieła. Kontynuować?"
 
 #: my_books/primary_action.html
 msgid "Add to List"
@@ -5881,15 +6631,15 @@ msgstr "dowolny"
 
 #: my_books/check_ins/check_in_form.html
 msgid "June"
-msgstr ""
+msgstr "Czerwiec"
 
 #: my_books/check_ins/check_in_form.html
 msgid "July"
-msgstr ""
+msgstr "Lipiec"
 
 #: my_books/check_ins/check_in_form.html
 msgid "August"
-msgstr ""
+msgstr "Sierpień"
 
 #: my_books/check_ins/check_in_form.html
 #, fuzzy
@@ -5912,8 +6662,12 @@ msgid "December"
 msgstr "\"Zapamniętaj mnie"
 
 #: my_books/check_ins/check_in_form.html
-msgid "Add an optional check-in date. Check-in dates are used to track yearly reading goals."
+msgid ""
+"Add an optional check-in date. Check-in dates are used to track yearly "
+"reading goals."
 msgstr ""
+"Dodaj opcjonalną datę zameldowania. Daty zameldowań są używane do "
+"śledzenia rocznych celów czytelniczych."
 
 #: my_books/check_ins/check_in_form.html
 #, fuzzy
@@ -5922,7 +6676,7 @@ msgstr "Wyślij"
 
 #: my_books/check_ins/check_in_form.html
 msgid "Year:"
-msgstr ""
+msgstr "Rok:"
 
 #: my_books/check_ins/check_in_form.html
 #, fuzzy
@@ -5931,15 +6685,15 @@ msgstr "Szukaj"
 
 #: my_books/check_ins/check_in_form.html
 msgid "Month:"
-msgstr ""
+msgstr "Miesiąc:"
 
 #: my_books/check_ins/check_in_form.html
 msgid "Month"
-msgstr ""
+msgstr "Miesiąc"
 
 #: my_books/check_ins/check_in_form.html
 msgid "Day:"
-msgstr ""
+msgstr "Dzień:"
 
 #: my_books/check_ins/check_in_form.html
 #, fuzzy
@@ -5953,16 +6707,16 @@ msgstr "Usuń listę"
 
 #: my_books/check_ins/check_in_prompt.html
 msgid "Failed to delete check-in. Please try again in a few moments."
-msgstr ""
+msgstr "Nie udało się usunąć zameldowania. Spróbuj ponownie za chwilę."
 
 #: my_books/check_ins/check_in_prompt.html
 msgid "Failed to submit check-in. Please try again in a few moments."
-msgstr ""
+msgstr "Nie udało się przesłać zameldowania. Spróbuj ponownie za chwilę."
 
 #: my_books/check_ins/check_in_prompt.html
 #, python-format
 msgid "Read <time class=\"check-in-date\">%(date)s</time>"
-msgstr ""
+msgstr "Przeczytano <time class=\"check-in-date\">%(date)s</time>"
 
 #: my_books/check_ins/check_in_prompt.html
 #, fuzzy
@@ -5976,7 +6730,7 @@ msgstr "Dodaj kolejną"
 
 #: my_books/check_ins/check_in_prompt.html
 msgid "Check-In"
-msgstr ""
+msgstr "Zameldowanie"
 
 #: observations/review_component.html
 #, fuzzy
@@ -5985,15 +6739,15 @@ msgstr "Najnowsze zmiany wprowadzone przez społeczność"
 
 #: observations/review_component.html
 msgid "No community reviews have been submitted for this work."
-msgstr ""
+msgstr "Nie przesłano żadnych recenzji społeczności dla tego dzieła."
 
 #: observations/review_component.html
 msgid "+ Add your community review"
-msgstr ""
+msgstr "+ Dodaj swoją recenzję społeczności"
 
 #: observations/review_component.html
 msgid "+ Log in to add your community review"
-msgstr ""
+msgstr "+ Zaloguj się, aby dodać swoją recenzję społeczności"
 
 #: publishers/index.html publishers/notfound.html
 msgid "Publishers"
@@ -6012,7 +6766,7 @@ msgstr "Słowa kluczowe"
 #: publishers/notfound.html
 #, python-format
 msgid "We couldn't find any books published by %(publisher)s."
-msgstr ""
+msgstr "Nie znaleźliśmy żadnych książek wydanych przez %(publisher)s."
 
 #: publishers/notfound.html subjects/notfound.html
 msgid "Try something else?"
@@ -6021,9 +6775,10 @@ msgstr "Wyszukać inne?"
 #: publishers/view.html
 #, python-format
 msgid "Publisher: %(name)s"
-msgstr ""
+msgstr "Wydawca: %(name)s"
 
-#: openlibrary/plugins/worksearch/code.py publishers/view.html search/advancedsearch.html type/edition/view.html type/work/view.html
+#: openlibrary/plugins/worksearch/code.py publishers/view.html
+#: search/advancedsearch.html type/edition/view.html type/work/view.html
 msgid "Publisher"
 msgstr "Wydawca"
 
@@ -6031,8 +6786,8 @@ msgstr "Wydawca"
 #, python-format
 msgid "%(count)s ebook"
 msgid_plural "%(count)s ebooks"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%(count)s e-book"
+msgstr[1] "%(count)s e-booki"
 
 #: publishers/view.html
 #, fuzzy
@@ -6044,8 +6799,14 @@ msgid "Publishing History"
 msgstr "Historia publikacji"
 
 #: publishers/view.html
-msgid "This is a chart to show the when this publisher published books. Along the X axis is time, and on the y axis is the count of editions published. <a href=\"#subjectRelated\">Click here to skip the chart</a>."
-msgstr "To wykres pokazujący, kiedy ten wydawca opublikował książki. Oś X wskazuje na czas, oś Y wskazuje liczbę opublikowanych wydań. <a href=\"#subjectRelated\"> Kliknij tutaj, aby pominąć wykres</a>."
+msgid ""
+"This is a chart to show the when this publisher published books. Along "
+"the X axis is time, and on the y axis is the count of editions published."
+" <a href=\"#subjectRelated\">Click here to skip the chart</a>."
+msgstr ""
+"To wykres pokazujący, kiedy ten wydawca opublikował książki. Oś X "
+"wskazuje na czas, oś Y wskazuje liczbę opublikowanych wydań. <a "
+"href=\"#subjectRelated\"> Kliknij tutaj, aby pominąć wykres</a>."
 
 #: PublishingHistory.html publishers/view.html
 msgid "Reset chart"
@@ -6056,8 +6817,13 @@ msgid "or continue zooming in."
 msgstr "lub kontynuuj powiększanie."
 
 #: publishers/view.html
-msgid "This graph charts editions from this publisher over time. Click to view a single year, or drag across a range."
-msgstr "Ten diagram przedstawia wykresy publikacji tego wydawcy w miarę upływu czasu. Kliknij, aby wyświetlić pojedynczy rok lub przeciągnij przez cały zakres."
+msgid ""
+"This graph charts editions from this publisher over time. Click to view a"
+" single year, or drag across a range."
+msgstr ""
+"Ten diagram przedstawia wykresy publikacji tego wydawcy w miarę upływu "
+"czasu. Kliknij, aby wyświetlić pojedynczy rok lub przeciągnij przez cały "
+"zakres."
 
 #: PublishingHistory.html publishers/view.html
 msgid "Editions Published"
@@ -6074,7 +6840,7 @@ msgstr "Wspólne tematy"
 #: publishers/view.html
 #, python-format
 msgid "Search for books published by %(publisher)s"
-msgstr ""
+msgstr "Szukaj książek wydanych przez %(publisher)s"
 
 #: RelatedSubjects.html publishers/view.html
 msgid "None found."
@@ -6094,21 +6860,29 @@ msgstr "Uzyskaj więcej informacji o tym wydawcy"
 
 #: reading_goals/reading_goal_form.html
 msgid "How many books would you like to read this year?"
-msgstr ""
+msgstr "Ile książek chcesz przeczytać w tym roku?"
 
 #: reading_goals/reading_goal_form.html
 msgid "Enter \"0\" to unset your reading goal. Your check-ins will be preserved."
 msgstr ""
+"Wpisz „0\", aby usunąć cel czytelniczy. Twoje zameldowania zostaną "
+"zachowane."
 
 #: reading_goals/reading_goal_progress.html
 #, python-format
-msgid "<span class=\"reading-goal-progress__books-read\">%(books_read)d</span>/<span class=\"reading-goal-progress__goal\">%(goal)d</span> Books"
+msgid ""
+"<span class=\"reading-goal-progress__books-"
+"read\">%(books_read)d</span>/<span class=\"reading-goal-"
+"progress__goal\">%(goal)d</span> Books"
 msgstr ""
+"<span class=\"reading-goal-progress__books-"
+"read\">%(books_read)d</span>/<span class=\"reading-goal-"
+"progress__goal\">%(goal)d</span> książek"
 
 #: reading_goals/reading_goal_progress.html
 #, python-format
 msgid "Edit %(year)d Reading Goal"
-msgstr ""
+msgstr "Edytuj cel czytelniczy na %(year)d rok"
 
 #: recentchanges/header.html
 #, fuzzy
@@ -6117,7 +6891,7 @@ msgstr "autorstwa"
 
 #: recentchanges/header.html
 msgid "Undo All"
-msgstr ""
+msgstr "Cofnij wszystko"
 
 #: recentchanges/header.html recentchanges/index.html
 msgid "Recent Changes"
@@ -6140,15 +6914,15 @@ msgstr "Wyszukiwanie autora"
 
 #: recentchanges/index.html
 msgid "Books Added"
-msgstr ""
+msgstr "Dodane książki"
 
 #: RecentChanges.html recentchanges/index.html
 msgid "By Humans"
-msgstr ""
+msgstr "Przez ludzi"
 
 #: RecentChanges.html recentchanges/index.html
 msgid "By Bots"
-msgstr ""
+msgstr "Przez boty"
 
 #: RecentChanges.html recentchanges/index.html
 msgid "Everything"
@@ -6159,24 +6933,28 @@ msgstr "Wszystko"
 msgid "Admin view"
 msgstr "strona administratora"
 
-#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html recentchanges/render.html
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
+#: recentchanges/render.html
 msgid "Older"
 msgstr "Starsze"
 
-#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html recentchanges/render.html
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
+#: recentchanges/render.html
 msgid "Newer"
 msgstr "Nowsze"
 
 #: recentchanges/updated_records.html
 msgid "Review what's changed in from the previous revision"
-msgstr ""
+msgstr "Sprawdź, co zmieniło się w stosunku do poprzedniej wersji"
 
-#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html recentchanges/default/path.html recentchanges/updated_records.html
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
+#: recentchanges/default/path.html recentchanges/updated_records.html
 #, fuzzy
 msgid "diff"
 msgstr "Różnica"
 
-#: recentchanges/add-book/path.html recentchanges/default/path.html recentchanges/edit-book/path.html recentchanges/merge/path.html
+#: recentchanges/add-book/path.html recentchanges/default/path.html
+#: recentchanges/edit-book/path.html recentchanges/merge/path.html
 #, fuzzy
 msgid "expand"
 msgstr "Przeczytaj"
@@ -6187,9 +6965,10 @@ msgstr "utwórz nowe konto na Open Library"
 
 #: RecentChanges.html RecentChangesUsers.html recentchanges/default/path.html
 msgid "Review what's changed from the previous revision"
-msgstr ""
+msgstr "Sprawdź, co zmieniło się od poprzedniej wersji"
 
-#: recentchanges/default/view.html recentchanges/merge/view.html recentchanges/undo/view.html
+#: recentchanges/default/view.html recentchanges/merge/view.html
+#: recentchanges/undo/view.html
 #, fuzzy
 msgid "Updated Records"
 msgstr "Usuń wpis"
@@ -6197,19 +6976,19 @@ msgstr "Usuń wpis"
 #: recentchanges/merge/comment.html
 #, python-format
 msgid "Merged duplicate %(record_type)s records."
-msgstr ""
+msgstr "Scalono zduplikowane rekordy %(record_type)s."
 
 #: recentchanges/merge/comment.html
 #, python-format
 msgid "See <a href=\"%s\">details</a>."
-msgstr ""
+msgstr "Zobacz <a href=\"%s\">szczegóły</a>."
 
 #: recentchanges/merge/comment.html
 #, python-format
 msgid "Merged %(count)d duplicate %(type)s record into this primary."
 msgid_plural "Merged %(count)d duplicate %(type)s records into this primary."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Scalono %(count)d zduplikowany rekord %(type)s z tym głównym."
+msgstr[1] "Scalono %(count)d zduplikowane rekordy %(type)s z tym głównym."
 
 #: recentchanges/merge/comment.html
 #, fuzzy
@@ -6219,7 +6998,7 @@ msgstr "Duplikaty"
 #: recentchanges/merge/comment.html
 #, python-format
 msgid "Merged %(page_type)s into primary %(record_type)s record."
-msgstr ""
+msgstr "Scalono %(page_type)s z głównym rekordem %(record_type)s."
 
 #: recentchanges/merge/message.html
 #, python-format
@@ -6237,11 +7016,11 @@ msgstr[1] "%(count)d duplikatów %(master)s zostało połączone anonimowo"
 
 #: recentchanges/merge/view.html
 msgid "This merge has been undone."
-msgstr ""
+msgstr "To scalenie zostało cofnięte."
 
 #: recentchanges/merge/view.html
 msgid "Details here"
-msgstr ""
+msgstr "Szczegóły tutaj"
 
 #: recentchanges/merge/view.html type/author/view.html
 msgid "Duplicates"
@@ -6251,18 +7030,18 @@ msgstr "Duplikaty"
 #, python-format
 msgid "%(count)d record modified."
 msgid_plural "%(count)d records modified."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%(count)d rekord zmodyfikowany."
+msgstr[1] "%(count)d rekordy zmodyfikowane."
 
 #: recentchanges/undo/view.html
 #, python-format
 msgid "Undo of <a href=\"$parent.url()\">%(kind)s</a>."
-msgstr ""
+msgstr "Cofnięcie <a href=\"$parent.url()\">%(kind)s</a>."
 
 #: recentchanges/undo/view.html
 #, python-format
 msgid "%(count)d records modified."
-msgstr ""
+msgstr "%(count)d rekordów zmodyfikowanych."
 
 #: search/advancedsearch.html
 msgid "ISBN"
@@ -6293,7 +7072,7 @@ msgstr "Wyszukiwanie pełnotekstowe"
 #: search/authors.html
 #, python-format
 msgid "Search Open Library for \"%(query)s\""
-msgstr ""
+msgstr "Szukaj w Open Library dla \"%(query)s\""
 
 #: search/authors.html
 #, fuzzy
@@ -6311,6 +7090,8 @@ msgstr "Połącz autorów"
 #: search/authors.html
 msgid "No <strong>authors</strong> directly matched your search"
 msgstr ""
+"Żaden <strong>autor</strong> nie pasuje bezpośrednio do Twojego "
+"wyszukiwania"
 
 #: openlibrary/plugins/worksearch/code.py search/availability_i18n.html
 #, fuzzy
@@ -6319,7 +7100,7 @@ msgstr "Książki"
 
 #: openlibrary/plugins/worksearch/code.py search/availability_i18n.html
 msgid "Free to read now"
-msgstr ""
+msgstr "Czytaj bezpłatnie teraz"
 
 #: openlibrary/plugins/worksearch/code.py search/availability_i18n.html
 #, fuzzy
@@ -6329,29 +7110,32 @@ msgstr "Wypożycz teraz"
 #: search/inside.html
 #, python-format
 msgid "Search Open Library for %s"
-msgstr ""
+msgstr "Szukaj w Open Library dla %s"
 
-#: BookSearchInside.html FulltextSearchSuggestion.html SearchNavigation.html search/inside.html search/snippets.html
+#: BookSearchInside.html FulltextSearchSuggestion.html SearchNavigation.html
+#: search/inside.html search/snippets.html
 msgid "Search Inside"
 msgstr "Szukaj w"
 
 #: search/inside.html
 msgid "No <strong>Search Inside</strong> text matched your search"
 msgstr ""
+"Żaden tekst <strong>Szukaj w środku</strong> nie pasuje do Twojego "
+"wyszukiwania"
 
 #: search/inside.html
 #, python-format
 msgid "About %(count)s result found"
 msgid_plural "About %(count)s results found"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Znaleziono około %(count)s wynik"
+msgstr[1] "Znaleziono około %(count)s wyniki"
 
 #: search/inside.html
 #, python-format
 msgid "in %(seconds)s second"
 msgid_plural "in %(seconds)s seconds"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "w %(seconds)s sekundzie"
+msgstr[1] "w %(seconds)s sekundy"
 
 #: EditionNavBar.html search/layout_options.html site/stats.html
 #, fuzzy
@@ -6360,7 +7144,7 @@ msgstr "E-mail"
 
 #: search/layout_options.html
 msgid "Grid"
-msgstr ""
+msgstr "Siatka"
 
 #: search/layout_options.html
 #, fuzzy
@@ -6369,7 +7153,7 @@ msgstr "Wyświetl"
 
 #: search/lists.html
 msgid "Search results for Lists"
-msgstr ""
+msgstr "Wyniki wyszukiwania dla list"
 
 #: search/lists.html
 #, fuzzy
@@ -6678,8 +7462,14 @@ msgstr ""
 
 #: site/head.html
 #, fuzzy
-msgid "Open Library is an open, editable library catalog, building towards a web page for every book ever published. Read, borrow, and discover more than 3M books for free."
-msgstr "Open Library to otwarty, edytowalny katalog biblioteczny, dążący do stworzenia strony internetowej dla każdej kiedykolwiek opublikowanej książki."
+msgid ""
+"Open Library is an open, editable library catalog, building towards a web"
+" page for every book ever published. Read, borrow, and discover more than"
+" 3M books for free."
+msgstr ""
+"Open Library to otwarty, edytowalny katalog biblioteczny, dążący do "
+"stworzenia strony internetowej dla każdej kiedykolwiek opublikowanej "
+"książki."
 
 #: site/stats.html
 msgid "Debug Stats"
@@ -6709,7 +7499,9 @@ msgid "# Unique Users Logging Books"
 msgstr ""
 
 #: stats/readinglog.html
-msgid "The total number of unique users who have logged at least one book using the Reading Log feature"
+msgid ""
+"The total number of unique users who have logged at least one book using "
+"the Reading Log feature"
 msgstr ""
 
 #: stats/readinglog.html
@@ -6766,13 +7558,16 @@ msgstr ""
 msgid "OpenAPI"
 msgstr ""
 
-#: type/about/edit.html type/page/edit.html type/permission/edit.html type/template/edit.html type/usergroup/edit.html
+#: type/about/edit.html type/page/edit.html type/permission/edit.html
+#: type/template/edit.html type/usergroup/edit.html
 #, python-format
 msgid "Edit %(title)s"
 msgstr "Edytuj %(title)s"
 
 #: type/about/edit.html
-msgid "This only appears in the document head, and gets attached to bookmark labels"
+msgid ""
+"This only appears in the document head, and gets attached to bookmark "
+"labels"
 msgstr ""
 
 #: type/about/edit.html
@@ -6805,16 +7600,24 @@ msgid "Edit Author"
 msgstr "Edytuj autora"
 
 #: type/author/edit.html
-msgid "Please use natural order. For example: <strong>Leo Tolstoy</strong> not <strong>Tolstoy, Leo</strong>."
-msgstr "Prosimy o podanie imienia i nazwiska. Na przykład: <strong>Lew Tołstoj</strong> nie <strong>Tołstoj, Lew</strong>. "
+msgid ""
+"Please use natural order. For example: <strong>Leo Tolstoy</strong> not "
+"<strong>Tolstoy, Leo</strong>."
+msgstr ""
+"Prosimy o podanie imienia i nazwiska. Na przykład: <strong>Lew "
+"Tołstoj</strong> nie <strong>Tołstoj, Lew</strong>. "
 
 #: type/author/edit.html
 msgid "A short bio?"
 msgstr "Krótka biografia?"
 
 #: type/author/edit.html
-msgid "If you \"borrow\" information from somewhere, please make sure to cite the source."
-msgstr "Jeśli \"pożyczasz\" pewne informacje z innych źródeł, prosimy o ich podanie."
+msgid ""
+"If you \"borrow\" information from somewhere, please make sure to cite "
+"the source."
+msgstr ""
+"Jeśli \"pożyczasz\" pewne informacje z innych źródeł, prosimy o ich "
+"podanie."
 
 #: type/author/edit.html
 msgid "Date of birth"
@@ -6825,11 +7628,18 @@ msgid "Date of death"
 msgstr "Data śmierci"
 
 #: type/author/edit.html
-msgid "We're not storing structured dates (yet) so a date like \"21 May 2000\" is recommended."
-msgstr "Nie przechowujemy (jeszcze) ustrukturyzowanych dat, prosimy o podanie daty w formacie \"21 maj 2000\"."
+msgid ""
+"We're not storing structured dates (yet) so a date like \"21 May 2000\" "
+"is recommended."
+msgstr ""
+"Nie przechowujemy (jeszcze) ustrukturyzowanych dat, prosimy o podanie "
+"daty w formacie \"21 maj 2000\"."
 
 #: type/author/edit.html
-msgid "This is a deprecated field. You can help improve this record by removing this date and populating the \"Date of birth\" and \"Date of death\" fields. Thanks!"
+msgid ""
+"This is a deprecated field. You can help improve this record by removing "
+"this date and populating the \"Date of birth\" and \"Date of death\" "
+"fields. Thanks!"
 msgstr ""
 
 #: type/author/edit.html
@@ -6837,7 +7647,9 @@ msgid "Does this author go by any other names?"
 msgstr "Czy autor posługiwał się innymi nazwiskami lub pseudonimami?"
 
 #: type/author/edit.html
-msgid "For example: Lev Nikolayevich Tolstoy was also known as Leo Tolstoy. Please list one name per line."
+msgid ""
+"For example: Lev Nikolayevich Tolstoy was also known as Leo Tolstoy. "
+"Please list one name per line."
 msgstr ""
 
 #: type/author/edit.html
@@ -6871,8 +7683,12 @@ msgid "Refresh the page?"
 msgstr "Odświeżyć stronę?"
 
 #: type/author/view.html
-msgid "OK. The merge is in motion. <i>It will take <u>a few minutes to finish</u> the update.</i>"
-msgstr "OK. Łączenie zostało rozpoczęte. <i>Aktualizacja zakończy się <u>w ciągu kilku minut</u>.</i>"
+msgid ""
+"OK. The merge is in motion. <i>It will take <u>a few minutes to "
+"finish</u> the update.</i>"
+msgstr ""
+"OK. Łączenie zostało rozpoczęte. <i>Aktualizacja zakończy się <u>w ciągu "
+"kilku minut</u>.</i>"
 
 #: type/author/view.html
 msgid "Argh!"
@@ -6880,7 +7696,9 @@ msgstr "Ups!"
 
 #: type/author/view.html
 msgid "That merge didn't work. It's our fault, and we've made a note of it."
-msgstr "Te połączenie się nie powiodło. To nasza wina, zarejesterowaliśmy ten błąd."
+msgstr ""
+"Te połączenie się nie powiodło. To nasza wina, zarejesterowaliśmy ten "
+"błąd."
 
 #: type/author/view.html
 msgid "Add another?"
@@ -6894,9 +7712,12 @@ msgstr ""
 #: type/author/view.html
 #, fuzzy, python-format
 msgid "— Show <a href=\"%(url)s\">everything</a> by this author?"
-msgstr "Wczytywanie tylko e-booków. Czy chesz zobaczyć <a href=\"%(url)s\">wszystkie</a> prace tego autora?"
+msgstr ""
+"Wczytywanie tylko e-booków. Czy chesz zobaczyć <a "
+"href=\"%(url)s\">wszystkie</a> prace tego autora?"
 
-#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py type/author/view.html type/list/view_body.html
+#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py
+#: type/author/view.html type/list/view_body.html
 msgid "Places"
 msgstr "Miejsca"
 
@@ -7022,12 +7843,16 @@ msgstr ""
 
 #: type/edition/view.html type/work/view.html
 #, python-format
-msgid "This work doesn't have a description yet. Can you <b><a href='%(url)s'>add one</a></b>?"
+msgid ""
+"This work doesn't have a description yet. Can you <b><a "
+"href='%(url)s'>add one</a></b>?"
 msgstr ""
 
 #: type/edition/view.html type/work/view.html
 #, python-format
-msgid "This edition doesn't have a description yet. Can you <b><a href='%(url)s'>add one</a></b>?"
+msgid ""
+"This edition doesn't have a description yet. Can you <b><a "
+"href='%(url)s'>add one</a></b>?"
 msgstr ""
 
 #: type/edition/view.html type/work/view.html
@@ -7112,7 +7937,8 @@ msgstr "Linki zewnętrzne"
 msgid "Format"
 msgstr "Format"
 
-#: OlPagination.html OlPaginationArrows.html type/edition/view.html type/work/view.html
+#: OlPagination.html OlPaginationArrows.html type/edition/view.html
+#: type/work/view.html
 msgid "Pagination"
 msgstr "Paginacja"
 
@@ -7270,7 +8096,9 @@ msgid "Visit Open Library"
 msgstr "Open Library"
 
 #: type/list/embed.html
-msgid "Open in online Book Reader. Downloads available in ePub, DAISY, PDF, TXT formats from main book page"
+msgid ""
+"Open in online Book Reader. Downloads available in ePub, DAISY, PDF, TXT "
+"formats from main book page"
 msgstr ""
 
 #: type/list/embed.html
@@ -7325,12 +8153,16 @@ msgstr ""
 
 #: type/list/exports.html
 #, python-format
-msgid "Only lists with up to %(max)s editions can be exported. This one has %(count)s."
+msgid ""
+"Only lists with up to %(max)s editions can be exported. This one has "
+"%(count)s."
 msgstr ""
 
 #: type/list/exports.html
 #, python-format
-msgid "Try removing some seeds for more focus, or look at <a href=\"%s\">bulk download</a> of the catalog."
+msgid ""
+"Try removing some seeds for more focus, or look at <a href=\"%s\">bulk "
+"download</a> of the catalog."
 msgstr ""
 
 #: type/list/view_body.html
@@ -7374,12 +8206,16 @@ msgid "Remove Seed"
 msgstr "Usunąć ten plik inicujuący?"
 
 #: type/list/view_body.html
-msgid "You are about to remove the last item in the list. That will delete the whole list. Are you sure you want to continue?"
+msgid ""
+"You are about to remove the last item in the list. That will delete the "
+"whole list. Are you sure you want to continue?"
 msgstr ""
 
 #: type/list/view_body.html
 #, python-format
-msgid "This series contains %(limit)d or more works. Currently, only the first %(limit)d works are displayed."
+msgid ""
+"This series contains %(limit)d or more works. Currently, only the first "
+"%(limit)d works are displayed."
 msgstr ""
 
 #: type/list/view_body.html
@@ -7387,7 +8223,9 @@ msgid "There are no items on this list."
 msgstr ""
 
 #: type/list/view_body.html
-msgid "<a href=\"/search\" target=\"_blank\" rel=\"noopener noreferrer\">Search for book, subjects, or authors</a> to add to your list."
+msgid ""
+"<a href=\"/search\" target=\"_blank\" rel=\"noopener noreferrer\">Search "
+"for book, subjects, or authors</a> to add to your list."
 msgstr ""
 
 #: type/list/view_body.html
@@ -7403,7 +8241,8 @@ msgstr "Dodatkowe metadane"
 msgid "Derived from seed metadata"
 msgstr ""
 
-#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py type/list/view_body.html
+#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py
+#: type/list/view_body.html
 msgid "Times"
 msgstr "Okres"
 
@@ -7484,7 +8323,12 @@ msgid "We require a minimum set of fields to create a new collection tag."
 msgstr "Aby utworzyć nowy wpis wymagane jest uzupełnienie nastepujących pól."
 
 #: EditButtons.html type/tag/form.html
-msgid "By saving a change to this wiki, you agree that your contribution is given freely to the world under <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" target=\"_blank\" rel=\"noopener noreferrer\" title=\"This link to Creative Commons will open in a new window\">CC0</a>. Yippee!"
+msgid ""
+"By saving a change to this wiki, you agree that your contribution is "
+"given freely to the world under <a "
+"href=\"https://creativecommons.org/publicdomain/zero/1.0/\" "
+"target=\"_blank\" rel=\"noopener noreferrer\" title=\"This link to "
+"Creative Commons will open in a new window\">CC0</a>. Yippee!"
 msgstr ""
 
 #: type/tag/form.html
@@ -7521,7 +8365,9 @@ msgid "Tag Name"
 msgstr "Imię i nazwisko"
 
 #: type/tag/tag_form_inputs.html
-msgid "Human-readable display name (e.g. \"Computer Science\", \"Horror Fiction\")"
+msgid ""
+"Human-readable display name (e.g. \"Computer Science\", \"Horror "
+"Fiction\")"
 msgstr ""
 
 #: type/tag/tag_form_inputs.html
@@ -7529,7 +8375,9 @@ msgid "Tag Slugs"
 msgstr ""
 
 #: type/tag/tag_form_inputs.html
-msgid "Comma-separated URL slugs that map to this tag (auto-populated from name). E.g. \"computer_science, cs\""
+msgid ""
+"Comma-separated URL slugs that map to this tag (auto-populated from "
+"name). E.g. \"computer_science, cs\""
 msgstr ""
 
 #: type/tag/tag_form_inputs.html
@@ -7632,7 +8480,12 @@ msgstr "strona administratora"
 
 #: type/user/view.html
 #, python-format
-msgid "You are publicly sharing the books you are <a href=\"%(username)s/books/currently-reading\">currently reading</a>, <a href=\"%(username)s/books/already-read\">have already read</a>, <a href=\"%(username)s/books/want-to-read\">want to read</a>, and have <a href=\"%(username)s/books/stopped-reading\">stopped reading</a>!"
+msgid ""
+"You are publicly sharing the books you are <a href=\"%(username)s/books"
+"/currently-reading\">currently reading</a>, <a href=\"%(username)s/books"
+"/already-read\">have already read</a>, <a href=\"%(username)s/books/want-"
+"to-read\">want to read</a>, and have <a href=\"%(username)s/books"
+"/stopped-reading\">stopped reading</a>!"
 msgstr ""
 
 #: type/user/view.html
@@ -7649,7 +8502,12 @@ msgstr "Zarządzaj swoimi ustawieniami prywatności"
 
 #: type/user/view.html
 #, python-format
-msgid "Here are the books %(user)s is <a href=\"%(username)s/books/currently-reading\">currently reading</a>, <a href=\"%(username)s/books/already-read\">have already read</a>, <a href=\"%(username)s/books/want-to-read\">want to read</a>, and has <a href=\"%(username)s/books/stopped-reading\">stopped reading</a>!"
+msgid ""
+"Here are the books %(user)s is <a href=\"%(username)s/books/currently-"
+"reading\">currently reading</a>, <a href=\"%(username)s/books/already-"
+"read\">have already read</a>, <a href=\"%(username)s/books/want-to-"
+"read\">want to read</a>, and has <a href=\"%(username)s/books/stopped-"
+"reading\">stopped reading</a>!"
 msgstr ""
 
 #: type/user/view.html
@@ -7716,7 +8574,9 @@ msgid "Look for this edition for sale at %(store)s"
 msgstr ""
 
 #: AffiliateLinks.html
-msgid "When you buy books using these links the Internet Archive may earn a <a class=\"nostyle\" href=\"/help/faq/about#selling\">small commission</a>."
+msgid ""
+"When you buy books using these links the Internet Archive may earn a <a "
+"class=\"nostyle\" href=\"/help/faq/about#selling\">small commission</a>."
 msgstr ""
 
 #: AffiliateLinksLoadingIndicator.html
@@ -7750,7 +8610,9 @@ msgid "Preview Book"
 msgstr "Wypożycz teraz"
 
 #: DisplayCode.html
-msgid "Templates in the website are disabled now. Editing them will not have any effect on the live website."
+msgid ""
+"Templates in the website are disabled now. Editing them will not have any"
+" effect on the live website."
 msgstr ""
 
 #: EditionNavBar.html
@@ -7961,8 +8823,15 @@ msgid "who have written the most books on this subject"
 msgstr "którzy napisali najwięcej książek na ten temat"
 
 #: PublishingHistory.html
-msgid "This is a chart to show the publishing history of editions of works about this subject. Along the X axis is time, and on the y axis is the count of editions published. <a href=\"#subjectRelated\">Click here to skip the chart</a>."
-msgstr "To wykres pokazujący historię publikacji dzieł na ten temat. Oś X wskazuje na czas, oś Y wskazuje liczbę publikacji. <a href=\"#subjectRelated\"> Kliknij tutaj, aby pominąć wykres</a>."
+msgid ""
+"This is a chart to show the publishing history of editions of works about"
+" this subject. Along the X axis is time, and on the y axis is the count "
+"of editions published. <a href=\"#subjectRelated\">Click here to skip the"
+" chart</a>."
+msgstr ""
+"To wykres pokazujący historię publikacji dzieł na ten temat. Oś X "
+"wskazuje na czas, oś Y wskazuje liczbę publikacji. <a "
+"href=\"#subjectRelated\"> Kliknij tutaj, aby pominąć wykres</a>."
 
 #: PublishingHistory.html
 msgid "This graph charts editions published on this subject."
@@ -7999,7 +8868,9 @@ msgid "Special Access"
 msgstr "Miejsca"
 
 #: ReadButton.html
-msgid "Special ebook access from the Internet Archive for patrons with qualifying print disabilities"
+msgid ""
+"Special ebook access from the Internet Archive for patrons with "
+"qualifying print disabilities"
 msgstr ""
 
 #: ReadButton.html
@@ -8293,16 +9164,30 @@ msgid "Huh?"
 msgstr "Wpisz ponownie"
 
 #: TypeChanger.html
-msgid "Every piece of Open Library is defined by the type of content it displays, usually by content definition (e.g. Authors, Editions, Works) but sometimes by content use (e.g. macro, template, rawtext). Changing this for an existing page will alter its presentation and the data fields available for editing its content."
-msgstr "Każdy element Open Library jest określony przez rodzaj informacji które wyświetla, zwykle według definicji treści (np. autorzy, wydania, prace), a czasem według zawartości (np. makro, szablon, tekst). Zmiany na istniejącej stronie zmienią jej prezentację i pola danychdostępnych do edycji jej zawartości."
+msgid ""
+"Every piece of Open Library is defined by the type of content it "
+"displays, usually by content definition (e.g. Authors, Editions, Works) "
+"but sometimes by content use (e.g. macro, template, rawtext). Changing "
+"this for an existing page will alter its presentation and the data fields"
+" available for editing its content."
+msgstr ""
+"Każdy element Open Library jest określony przez rodzaj informacji które "
+"wyświetla, zwykle według definicji treści (np. autorzy, wydania, prace), "
+"a czasem według zawartości (np. makro, szablon, tekst). Zmiany na "
+"istniejącej stronie zmienią jej prezentację i pola danychdostępnych do "
+"edycji jej zawartości."
 
 #: TypeChanger.html
 msgid "Please use caution changing Page Type!"
 msgstr "Zachowaj ostrożność, zmieniając Typ Strony!"
 
 #: TypeChanger.html
-msgid "(Simplest solution: If you aren't sure whether this should be changed, don't change it.)"
-msgstr "(Najprostsze rozwiązanie: jeśli nie masz pewności, czy należy to zmienić, nie zmieniaj tego.)"
+msgid ""
+"(Simplest solution: If you aren't sure whether this should be changed, "
+"don't change it.)"
+msgstr ""
+"(Najprostsze rozwiązanie: jeśli nie masz pewności, czy należy to zmienić,"
+" nie zmieniaj tego.)"
 
 #: WorkInfo.html
 msgid "No link to Wikipedia in your language"
@@ -8633,7 +9518,9 @@ msgid "Login attempted with invalid Internet Archive s3 credentials."
 msgstr ""
 
 #: openlibrary/plugins/upstream/account.py
-msgid "Servers are experiencing unusually high traffic, please try again later or email openlibrary@archive.org for help."
+msgid ""
+"Servers are experiencing unusually high traffic, please try again later "
+"or email openlibrary@archive.org for help."
 msgstr ""
 
 #: openlibrary/plugins/upstream/account.py
@@ -8651,7 +9538,9 @@ msgid "A problem occurred and we were unable to log you in"
 msgstr ""
 
 #: openlibrary/plugins/upstream/account.py
-msgid "Login or registration attempt hit an unexpected error, please try again or contact info@archive.org"
+msgid ""
+"Login or registration attempt hit an unexpected error, please try again "
+"or contact info@archive.org"
 msgstr ""
 
 #: openlibrary/plugins/upstream/account.py
@@ -8660,14 +9549,18 @@ msgid "Request failed with error code: %(error_code)s"
 msgstr ""
 
 #: openlibrary/plugins/upstream/account.py
-msgid "Thank you for registering an Open Library account and requesting special print disability access. You should receive an email detailing next steps in the process."
+msgid ""
+"Thank you for registering an Open Library account and requesting special "
+"print disability access. You should receive an email detailing next steps"
+" in the process."
 msgstr ""
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Username unavailable"
 msgstr ""
 
-#: openlibrary/plugins/upstream/account.py openlibrary/plugins/upstream/forms.py
+#: openlibrary/plugins/upstream/account.py
+#: openlibrary/plugins/upstream/forms.py
 msgid "Email already registered"
 msgstr "Podany e-mail jest już zarejestrowany"
 
@@ -8676,7 +9569,9 @@ msgid "An Internet Archive account already exists with this email"
 msgstr ""
 
 #: openlibrary/plugins/upstream/account.py
-msgid "Verification failed. The link may be invalid or expired. Please try registering again."
+msgid ""
+"Verification failed. The link may be invalid or expired. Please try "
+"registering again."
 msgstr ""
 
 #: openlibrary/plugins/upstream/account.py
@@ -8703,7 +9598,9 @@ msgid "%s has been returned."
 msgstr ""
 
 #: openlibrary/plugins/upstream/borrow.py
-msgid "Your account has hit a lending limit. Please try again later or contact info@archive.org."
+msgid ""
+"Your account has hit a lending limit. Please try again later or contact "
+"info@archive.org."
 msgstr ""
 
 #: openlibrary/plugins/upstream/forms.py
@@ -8753,7 +9650,10 @@ msgstr "Wybierz hasło"
 
 #: openlibrary/plugins/upstream/mybooks.py
 #, python-format
-msgid "Continue <a href=\"%(url)s\" class=\"pending-action-link\" data-action=\"%(raw_action)s\"><strong>%(action)s</strong> <em>%(name)s</em></a>"
+msgid ""
+"Continue <a href=\"%(url)s\" class=\"pending-action-link\" data-"
+"action=\"%(raw_action)s\"><strong>%(action)s</strong> "
+"<em>%(name)s</em></a>"
 msgstr ""
 
 #: openlibrary/plugins/worksearch/code.py
@@ -8777,16 +9677,28 @@ msgstr "Kasyczne e-booki"
 #~ msgid "Reading Lists"
 #~ msgstr "Listy lektur"
 
-#~ msgid "Last edited by <a href=\"$author.key\" rel=\"nofollow\">%(authorname)s</a>"
-#~ msgstr "Ostatnio edytowane przez <a href=\"$author.key\" rel=\"nofollow\">%(authorname)s</a>"
+#~ msgid ""
+#~ "Last edited by <a href=\"$author.key\" "
+#~ "rel=\"nofollow\">%(authorname)s</a>"
+#~ msgstr ""
+#~ "Ostatnio edytowane przez <a "
+#~ "href=\"$author.key\" rel=\"nofollow\">%(authorname)s</a>"
 
 #~ msgid "Add another edition of"
 #~ msgstr "Dodaj kolejne wydanie"
 
-#~ msgid "There's no description for this book yet. Can you <b><a href='%s'>add one</a></b>?"
-#~ msgstr "Ta książka nie ma jeszcze opisu. Czy możesz <b><a href='%s'>dodać opis</a></b>?"
+#~ msgid ""
+#~ "There's no description for this book "
+#~ "yet. Can you <b><a href='%s'>add "
+#~ "one</a></b>?"
+#~ msgstr ""
+#~ "Ta książka nie ma jeszcze opisu. "
+#~ "Czy możesz <b><a href='%s'>dodać opis</a></b>?"
 
-#~ msgid "Only lists with up to %(max)s editions can be exported. This one has %s(count)."
+#~ msgid ""
+#~ "Only lists with up to %(max)s "
+#~ "editions can be exported. This one "
+#~ "has %s(count)."
 #~ msgstr ""
 
 #~ msgid "First published in %s"
@@ -8830,23 +9742,41 @@ msgstr "Kasyczne e-booki"
 #~ msgstr[0] "%s wydanie"
 #~ msgstr[1] "%s wydań"
 
-#~ msgid "We've sent the verification email to %(email)s. You'll need to read that and click on the verification link to verify your email."
-#~ msgstr "Wysłaliśmy potwierdzenie na adres %(email)s. Przeczytaj je i kliknij zamieszczony link, by potwierdzić swój e-mail."
+#~ msgid ""
+#~ "We've sent the verification email to "
+#~ "%(email)s. You'll need to read that "
+#~ "and click on the verification link "
+#~ "to verify your email."
+#~ msgstr ""
+#~ "Wysłaliśmy potwierdzenie na adres %(email)s."
+#~ " Przeczytaj je i kliknij zamieszczony "
+#~ "link, by potwierdzić swój e-mail."
 
 #~ msgid "Email address is already used."
 #~ msgstr "Ten e-mail jest już w użyciu."
 
-#~ msgid "Your email address couldn't be updated. The specified email address is already used."
+#~ msgid ""
+#~ "Your email address couldn't be updated."
+#~ " The specified email address is "
+#~ "already used."
 #~ msgstr "Twój e-mail nie został zaktualizowany. Podany e-mail jest już w użyciu."
 
 #~ msgid "Email verification successful."
 #~ msgstr "Twój e-mail został zweryfikowany."
 
-#~ msgid "Your email address has been successfully verified and updated in your account."
+#~ msgid ""
+#~ "Your email address has been successfully"
+#~ " verified and updated in your "
+#~ "account."
 #~ msgstr "Twój e-mail został zweryfikowany i zaktualizowany na Twoimkoncie."
 
-#~ msgid "Your email address couldn't be verified. The verification link seems invalid."
-#~ msgstr "Twój e-mail nie mógł zostać zweryfikowany. Link weryfikacyjny jest nieważny."
+#~ msgid ""
+#~ "Your email address couldn't be verified."
+#~ " The verification link seems invalid."
+#~ msgstr ""
+#~ "Twój e-mail nie mógł zostać "
+#~ "zweryfikowany. Link weryfikacyjny jest "
+#~ "nieważny."
 
 #~ msgid "Choose a screen name"
 #~ msgstr "Wybierz nick"
@@ -8857,7 +9787,11 @@ msgstr "Kasyczne e-booki"
 #~ msgid "Confirm password"
 #~ msgstr "Potwierdź hasło"
 
-#~ msgid "Send me a monthly newsletter from the <a href=\"https://archive.org/\">Internet Archive</a>, the non-profit that runs Open Library"
+#~ msgid ""
+#~ "Send me a monthly newsletter from "
+#~ "the <a href=\"https://archive.org/\">Internet "
+#~ "Archive</a>, the non-profit that runs"
+#~ " Open Library"
 #~ msgstr ""
 
 #~ msgid "Websites"
@@ -8866,13 +9800,33 @@ msgstr "Kasyczne e-booki"
 #~ msgid "Deprecated"
 #~ msgstr "Przestarzałe"
 
-#~ msgid "Showing all works by author. Would you like to see <a href=\"%(url)s\">only ebooks</a>?"
-#~ msgstr "Wczytywanie wszystkich prac autora. Czy chesz zobaczyć <a href=\"%(url)s\">tylko e-booki</a>?"
+#~ msgid ""
+#~ "Showing all works by author. Would "
+#~ "you like to see <a href=\"%(url)s\">only"
+#~ " ebooks</a>?"
+#~ msgstr ""
+#~ "Wczytywanie wszystkich prac autora. Czy "
+#~ "chesz zobaczyć <a href=\"%(url)s\">tylko "
+#~ "e-booki</a>?"
 
-#~ msgid "<a href=\"%(url)s\"><strong>1 edition</strong></a> of <strong class=\"booktitle\">%(title)s</strong> found in the catalog."
-#~ msgid_plural "<a href=\"%(url)s\"><strong>%(count)d editions</strong></a> of <strong class=\"booktitle\">%(title)s</strong> found in the catalog."
-#~ msgstr[0] "<a href=\"%(url)s\"><strong>1 wydanie</strong></a><strong class=\"booktitle\">%(title)s</strong> w tym katalogu."
-#~ msgstr[1] "<a href=\"%(url)s\"><strong>%(count)d wydania</strong></a><strong class=\"booktitle\">%(title)s</strong> w tym katalogu."
+#~ msgid ""
+#~ "<a href=\"%(url)s\"><strong>1 edition</strong></a> "
+#~ "of <strong class=\"booktitle\">%(title)s</strong> "
+#~ "found in the catalog."
+#~ msgid_plural ""
+#~ "<a href=\"%(url)s\"><strong>%(count)d "
+#~ "editions</strong></a> of <strong "
+#~ "class=\"booktitle\">%(title)s</strong> found in the"
+#~ " catalog."
+#~ msgstr[0] ""
+#~ "<a href=\"%(url)s\"><strong>1 wydanie</strong></a><strong"
+#~ " class=\"booktitle\">%(title)s</strong> w tym "
+#~ "katalogu."
+#~ msgstr[1] ""
+#~ "<a href=\"%(url)s\"><strong>%(count)d "
+#~ "wydania</strong></a><strong "
+#~ "class=\"booktitle\">%(title)s</strong> w tym "
+#~ "katalogu."
 
 #~ msgid "Search for subjects about %(place)s"
 #~ msgstr "Szukaj tematów związanych z"
@@ -8894,7 +9848,11 @@ msgstr "Kasyczne e-booki"
 #~ msgstr[0] "1 praca"
 #~ msgstr[1] "%(count)d prace"
 
-#~ msgid "You are about the remove the last item in the list. That will delete the whole list. Are you sure you want to continue?"
+#~ msgid ""
+#~ "You are about the remove the last"
+#~ " item in the list. That will "
+#~ "delete the whole list. Are you "
+#~ "sure you want to continue?"
 #~ msgstr ""
 
 #~ msgid "Download DAISY eBook for print disabled"
@@ -8933,8 +9891,16 @@ msgstr "Kasyczne e-booki"
 #~ msgid "Your reading log is currently set to private"
 #~ msgstr "Twój dziennik lektur jest obecnie niewidoczny dla innych"
 
-#~ msgid "You have 5 ebooks out at the moment. That's the limit! You can free up slots by returning books early."
-#~ msgstr "Obecnie masz 5 ebooków. To maksymalna dozwolona ilość! Możesz wypożyczyć więcej e-booków kiedy zwrócisz obecnie wypożyczone."
+#~ msgid ""
+#~ "You have 5 ebooks out at the "
+#~ "moment. That's the limit! You can "
+#~ "free up slots by returning books "
+#~ "early."
+#~ msgstr ""
+#~ "Obecnie masz 5 ebooków. To maksymalna"
+#~ " dozwolona ilość! Możesz wypożyczyć więcej"
+#~ " e-booków kiedy zwrócisz obecnie "
+#~ "wypożyczone."
 
 #~ msgid "How To Return eBooks through Adobe Digital Editions"
 #~ msgstr ""
@@ -8966,34 +9932,83 @@ msgstr "Kasyczne e-booki"
 #~ msgstr[1] "%(count)s książek"
 
 #~ msgid "There are 2 different sources for borrowing books through Open Library:"
-#~ msgstr "Istnieją 2 źródła, z których możesz wypożyczyć książki przez Opne Library"
+#~ msgstr ""
+#~ "Istnieją 2 źródła, z których możesz "
+#~ "wypożyczyć książki przez Opne Library"
 
-#~ msgid "The <a href=\"//archive.org/\">Internet Archive</a> and several partner libraries are offering thousands of eBooks for loan to anyone with an Open Library account, anywhere in the world."
-#~ msgstr "<a href=\"//archive.org/\">Internet Archive</a> oraz inne partnerskie biblioteki oferują tysiące e-booków użytkownikom na całym świecie, którzy posiadają konto na Open Library."
+#~ msgid ""
+#~ "The <a href=\"//archive.org/\">Internet Archive</a>"
+#~ " and several partner libraries are "
+#~ "offering thousands of eBooks for loan"
+#~ " to anyone with an Open Library "
+#~ "account, anywhere in the world."
+#~ msgstr ""
+#~ "<a href=\"//archive.org/\">Internet Archive</a> oraz"
+#~ " inne partnerskie biblioteki oferują "
+#~ "tysiące e-booków użytkownikom na całym "
+#~ "świecie, którzy posiadają konto na Open"
+#~ " Library."
 
 #~ msgid "physical books from your local library"
 #~ msgstr "Papierowe wydania książek z Twojej lokalnej biblioteki"
 
-#~ msgid "We connect our records to WorldCat wherever possible. You can tell WorldCat your postcode/zip code, and it will tell you the closest library with a copy of the book."
-#~ msgstr "Na bieżąco udostępiniamy nasze kroniki dla WorldCat. Na WorldCatmożesz podać swój kod pocztowy i wyszukać najbliższą bibliotekę, z kopią wybranej książki."
+#~ msgid ""
+#~ "We connect our records to WorldCat "
+#~ "wherever possible. You can tell WorldCat"
+#~ " your postcode/zip code, and it will"
+#~ " tell you the closest library with"
+#~ " a copy of the book."
+#~ msgstr ""
+#~ "Na bieżąco udostępiniamy nasze kroniki "
+#~ "dla WorldCat. Na WorldCatmożesz podać "
+#~ "swój kod pocztowy i wyszukać najbliższą"
+#~ " bibliotekę, z kopią wybranej książki."
 
 #~ msgid "Getting Started"
 #~ msgstr "Zaczynamy"
 
-#~ msgid "All you need to borrow a book scanned at the Internet Archive is an Open Library account and Adobe Digital Editions."
-#~ msgstr "Aby wypożyczyć zeskanowaną książkę z Internet Archive potrzebujesz jedynie konta na Open Library oraz Adobe Digital Editions."
+#~ msgid ""
+#~ "All you need to borrow a book "
+#~ "scanned at the Internet Archive is "
+#~ "an Open Library account and Adobe "
+#~ "Digital Editions."
+#~ msgstr ""
+#~ "Aby wypożyczyć zeskanowaną książkę z "
+#~ "Internet Archive potrzebujesz jedynie konta"
+#~ " na Open Library oraz Adobe Digital"
+#~ " Editions."
 
-#~ msgid "Loans through WorldCat are managed through your local libraries, not through Open Library."
-#~ msgstr "Wypożyczenia dokonane za pomocą WorldCat są zarządzane przez lokalne biblioteki, nie przez Open Library."
+#~ msgid ""
+#~ "Loans through WorldCat are managed "
+#~ "through your local libraries, not "
+#~ "through Open Library."
+#~ msgstr ""
+#~ "Wypożyczenia dokonane za pomocą WorldCat "
+#~ "są zarządzane przez lokalne biblioteki, "
+#~ "nie przez Open Library."
 
-#~ msgid "Check out the <a href=\"/help/faq#section-borrowing\"><strong>Lending FAQ</strong></a> for more information."
-#~ msgstr "Więcej informacji znajdziesz na <a href=\"/help/faq#section-borrowing\"><strong>Wypożyczanie FAQ</strong></a>."
+#~ msgid ""
+#~ "Check out the <a href=\"/help/faq#section-"
+#~ "borrowing\"><strong>Lending FAQ</strong></a> for "
+#~ "more information."
+#~ msgstr ""
+#~ "Więcej informacji znajdziesz na <a "
+#~ "href=\"/help/faq#section-borrowing\"><strong>Wypożyczanie "
+#~ "FAQ</strong></a>."
 
 #~ msgid "Which books are available?"
 #~ msgstr "Które książki są dostępne?"
 
-#~ msgid "Browse all the available books through the <a href=\"/subjects/lending_library\">\"Lending Library\"</a> subject, or try a <a href=\"/search?subject_facet=Lending%20library\">search</a>."
-#~ msgstr "Przeszukaj wszystkie dostępne książki z<a href=\"/subjects/lending_library\">\"Wypożyczalni\"</a> o danej tematyce, lub wypróbuj <a href=\"/search?subject_facet=Lending%20library\">wyszukiwarkę</a>."
+#~ msgid ""
+#~ "Browse all the available books through"
+#~ " the <a href=\"/subjects/lending_library\">\"Lending"
+#~ " Library\"</a> subject, or try a <a"
+#~ " href=\"/search?subject_facet=Lending%20library\">search</a>."
+#~ msgstr ""
+#~ "Przeszukaj wszystkie dostępne książki z<a "
+#~ "href=\"/subjects/lending_library\">\"Wypożyczalni\"</a> o "
+#~ "danej tematyce, lub wypróbuj <a "
+#~ "href=\"/search?subject_facet=Lending%20library\">wyszukiwarkę</a>."
 
 #~ msgid "Help/Downloads"
 #~ msgstr "Pomoc/Pobrane"
@@ -9001,11 +10016,26 @@ msgstr "Kasyczne e-booki"
 #~ msgid "Download Adobe Digital Editions"
 #~ msgstr "Pobierz Adobe Digital Editions"
 
-#~ msgid "<a href=\"http://www.adobe.com/products/digitaleditions/help/\">Help</a> on adobe.com"
-#~ msgstr "<a href=\"http://www.adobe.com/products/digitaleditions/help/\">Pomoc</a> na adobe.com"
+#~ msgid ""
+#~ "<a "
+#~ "href=\"http://www.adobe.com/products/digitaleditions/help/\">Help</a>"
+#~ " on adobe.com"
+#~ msgstr ""
+#~ "<a "
+#~ "href=\"http://www.adobe.com/products/digitaleditions/help/\">Pomoc</a>"
+#~ " na adobe.com"
 
-#~ msgid "If you work at a library and are interested to find out more about lending ebooks through Open Library, please <a href=\"/contact\">get in touch with us</a>!"
-#~ msgstr "Jeśli jesteś pracownikiem biblioteki i chcesz wiedzieć więcej o wypożyczaniu książek przez Open Library, <a href=\"/contact\">skontaktuj się z nami</a>!"
+#~ msgid ""
+#~ "If you work at a library and "
+#~ "are interested to find out more "
+#~ "about lending ebooks through Open "
+#~ "Library, please <a href=\"/contact\">get in"
+#~ " touch with us</a>!"
+#~ msgstr ""
+#~ "Jeśli jesteś pracownikiem biblioteki i "
+#~ "chcesz wiedzieć więcej o wypożyczaniu "
+#~ "książek przez Open Library, <a "
+#~ "href=\"/contact\">skontaktuj się z nami</a>!"
 
 #~ msgid "Complete the form below to create a new Internet Archive account."
 #~ msgstr "Wypełnij poniższy formularz, aby utworzyć konto na Internet Archive."
@@ -9026,7 +10056,9 @@ msgstr "Kasyczne e-booki"
 #~ msgstr "Wystarczy podanie roku publikacji tego wydania."
 
 #~ msgid "Since you are not logged in, please satisfy the reCAPTCHA below."
-#~ msgstr "Poniważ nie jesteś zalogowana, prosimy o uzupełnienie reCAPTCHA poniżej."
+#~ msgstr ""
+#~ "Poniważ nie jesteś zalogowana, prosimy o"
+#~ " uzupełnienie reCAPTCHA poniżej."
 
 #~ msgid "Sponsor"
 #~ msgstr "Zasponsoruj"
@@ -9061,8 +10093,13 @@ msgstr "Kasyczne e-booki"
 #~ msgid "Please leave a note: Why is this classification useful?"
 #~ msgstr "Prosimy o uwagi: Dlaczego ten rodzaj kasyfikacji jest przydatny?"
 
-#~ msgid "Can you direct us to more information about this classification system online?"
-#~ msgstr "Prosimy o podanie elektronicznego źródła informacji o tym systemie klasyfikacji."
+#~ msgid ""
+#~ "Can you direct us to more "
+#~ "information about this classification system"
+#~ " online?"
+#~ msgstr ""
+#~ "Prosimy o podanie elektronicznego źródła "
+#~ "informacji o tym systemie klasyfikacji."
 
 #~ msgid "You can search by title or by Open Library ID (like"
 #~ msgstr "Możesz wyszukać przez tytuł lub przez ID z Open Library (like"
@@ -9098,14 +10135,40 @@ msgstr "Kasyczne e-booki"
 #~ msgstr[0] "1 korekta"
 #~ msgstr[1] "%(count)d korekty"
 
-#~ msgid "We use a system called Markdown to format the text in your edits on Open Library. Some HTML formatting is also accepted. Paragraphs are automatically generated from any hard-break returns (blank lines) within your text. You can preview your work in real time below the editing field."
-#~ msgstr "Używamy systemu Markdown do formatowania tekstu w Twoich edycjach w Open Library. Niektóre formatowanie HTML jest również akceptowane. Akapity są automatycznie generowane na podstawie zwrotów typu hard-break (puste linie) w Twoim tekscie. Możesz wyświetlić podgląd swojej pracy w czasie rzeczywistym poniżej pola edycji."
+#~ msgid ""
+#~ "We use a system called Markdown to"
+#~ " format the text in your edits "
+#~ "on Open Library. Some HTML formatting"
+#~ " is also accepted. Paragraphs are "
+#~ "automatically generated from any hard-"
+#~ "break returns (blank lines) within your"
+#~ " text. You can preview your work "
+#~ "in real time below the editing "
+#~ "field."
+#~ msgstr ""
+#~ "Używamy systemu Markdown do formatowania "
+#~ "tekstu w Twoich edycjach w Open "
+#~ "Library. Niektóre formatowanie HTML jest "
+#~ "również akceptowane. Akapity są automatycznie"
+#~ " generowane na podstawie zwrotów typu "
+#~ "hard-break (puste linie) w Twoim "
+#~ "tekscie. Możesz wyświetlić podgląd swojej "
+#~ "pracy w czasie rzeczywistym poniżej pola"
+#~ " edycji."
 
 #~ msgid "Formatting marks should envelope the effected text, for example:"
 #~ msgstr "Znaki formatujące powinny otaczać utworzony tekst, na przykład:"
 
-#~ msgid "To \"escape\" any Markdown tags (i.e. use an asterisk as an asterisk rather than emphasizing text) place a backslash \\ prior to the character."
-#~ msgstr "Aby \"uciec\" tagom Markdown (tj. użyć gwiazdki jako gwiazdki zamiast podkreślenia tekstu) umieść ukośnik \\ przed tym znakiem."
+#~ msgid ""
+#~ "To \"escape\" any Markdown tags (i.e."
+#~ " use an asterisk as an asterisk "
+#~ "rather than emphasizing text) place a"
+#~ " backslash \\ prior to the character."
+#~ msgstr ""
+#~ "Aby \"uciec\" tagom Markdown (tj. użyć"
+#~ " gwiazdki jako gwiazdki zamiast "
+#~ "podkreślenia tekstu) umieść ukośnik \\ "
+#~ "przed tym znakiem."
 
 #~ msgid "Log in"
 #~ msgstr "Zaloguj się"
@@ -9182,8 +10245,14 @@ msgstr "Kasyczne e-booki"
 #~ msgid "Sorry. There seems to be a problem with what you were just looking at."
 #~ msgstr "Przepraszamy. Wygląda na to, że jest problem z wyświetleniem treści."
 
-#~ msgid "We've noted the error %s and will look into it as soon as possible. Head for <a href=\"/\">home</a>?"
-#~ msgstr "Zauważyliśmy błąd %s i sprawdzimy go jak najszybciej. Przejść do <a href=\"/\">home</a>?"
+#~ msgid ""
+#~ "We've noted the error %s and will"
+#~ " look into it as soon as "
+#~ "possible. Head for <a href=\"/\">home</a>?"
+#~ msgstr ""
+#~ "Zauważyliśmy błąd %s i sprawdzimy go "
+#~ "jak najszybciej. Przejść do <a "
+#~ "href=\"/\">home</a>?"
 
 #~ msgid "Join waitlist for &quot;%(title)s&quot;"
 #~ msgstr ""
@@ -9229,8 +10298,16 @@ msgstr "Kasyczne e-booki"
 #~ msgid "(Optional, but very useful!)"
 #~ msgstr "(Opcjonalne, ale bardzo pomocne!)"
 
-#~ msgid "<em>Please Note:</em> Only Admins can delete things. <a href=\"/contact\" class=\"blue\">Let us know</a> if there's a problem."
-#~ msgstr "<em>Uwaga:</em> Tylko administratorzy mogą usuwać elementy. <a href=\"/contact\" class=\"blue\">Daj nam znać</a> jeśli wystąpił problem."
+#~ msgid ""
+#~ "<em>Please Note:</em> Only Admins can "
+#~ "delete things. <a href=\"/contact\" "
+#~ "class=\"blue\">Let us know</a> if there's "
+#~ "a problem."
+#~ msgstr ""
+#~ "<em>Uwaga:</em> Tylko administratorzy mogą "
+#~ "usuwać elementy. <a href=\"/contact\" "
+#~ "class=\"blue\">Daj nam znać</a> jeśli wystąpił"
+#~ " problem."
 
 #~ msgid "Readers waiting for this title: %(count)d"
 #~ msgstr ""
@@ -9238,7 +10315,11 @@ msgstr "Kasyczne e-booki"
 #~ msgid "Sponsor eBook"
 #~ msgstr "%s e-book"
 
-#~ msgid "We don’t have this book yet. You can add it to our Lending Library with a %(price)s tax deductible donation."
+#~ msgid ""
+#~ "We don’t have this book yet. You"
+#~ " can add it to our Lending "
+#~ "Library with a %(price)s tax deductible"
+#~ " donation."
 #~ msgstr ""
 
 #~ msgid "First"

--- a/openlibrary/i18n/pl/messages.po
+++ b/openlibrary/i18n/pl/messages.po
@@ -1958,7 +1958,7 @@ msgstr "Nie pamiętasz swojego adresu e-mail na Internet Archive?"
 
 #: account/email/forgot-ia.html
 msgid "Please enter your Open Library email and password, and we’ll retrieve your Archive.org email."
-msgstr ""
+msgstr "Wprowadź swój adres e-mail i hasło Open Library, a my pobierzemy Twój adres e-mail Archive.org."
 
 #: account/email/forgot-ia.html
 #, fuzzy
@@ -3617,11 +3617,11 @@ msgstr "Szukasz konkretnego tytułu? Najlepszym sposobem jest<a href=\"/search\"
 
 #: books/daisy.html lib/exports.html
 msgid "Need help?"
-msgstr ""
+msgstr "Potrzebujesz pomocy?"
 
 #: books/daisy.html
 msgid " Please read our <a href=\"/help/faq\">FAQ on accessing books through Open Library</a>."
-msgstr ""
+msgstr " Proszę przeczytaj nasze <a href=\"/help/faq\">FAQ dotyczące dostępu do książek przez Open Library</a>."
 
 #: books/edit.html
 msgid "Add a little more?"
@@ -3635,7 +3635,7 @@ msgstr "<p class=\"alert thanks\">Dziękujemy za dodanie tej książki! Jeśli m
 #: books/edit.html
 #, python-format
 msgid "We already know about <b>%(work_title)s</b>, but not the <b>%(year)s %(publisher)s edition</b>. Thanks! Do you know any more about this edition?"
-msgstr ""
+msgstr "Wiemy już o <b>%(work_title)s</b>, ale nie o wydaniu <b>%(year)s %(publisher)s</b>. Dziękujemy! Czy wiesz coś więcej o tym wydaniu?"
 
 #: books/edit.html
 #, fuzzy, python-format
@@ -3652,11 +3652,11 @@ msgstr "Usuń wpis"
 
 #: books/edit.html
 msgid "Work Details"
-msgstr ""
+msgstr "Szczegóły dzieła"
 
 #: books/edit.html
 msgid "Unknown publisher edition"
-msgstr ""
+msgstr "Wydanie nieznanego wydawcy"
 
 #: books/edit.html
 #, fuzzy
@@ -3665,11 +3665,11 @@ msgstr "Usuń tę pozycję"
 
 #: books/edit.html
 msgid "You can search by author name (like <em>j k rowling</em>) or by Open Library ID (like <a href=\"/authors/OL23919A\" target=\"_blank\" rel=\"noopener noreferrer\"><em>OL23919A</em></a>)."
-msgstr ""
+msgstr "Możesz wyszukiwać według imienia autora (jak <em>j k rowling</em>) lub według identyfikatora Open Library (jak <a href=\"/authors/OL23919A\" target=\"_blank\" rel=\"noopener noreferrer\"><em>OL23919A</em></a>)."
 
 #: books/edit.html
 msgid "Author editing requires javascript"
-msgstr ""
+msgstr "Edycja autora wymaga javascript"
 
 #: books/edit.html
 msgid "Add Excerpts"
@@ -3686,7 +3686,7 @@ msgstr "Seria"
 
 #: books/edit.html
 msgid "Series are currently in beta, and this section is only visible to super librarians and admins, like you! Any series you set will be visible by everyone, however. Please report any issues you have on Slack or GitHub."
-msgstr ""
+msgstr "Serie są obecnie w fazie beta i ta sekcja jest widoczna tylko dla super bibliotekarzy i administratorów, takich jak Ty! Jednak wszystkie ustawione serie będą widoczne dla wszystkich. Zgłaszaj wszelkie problemy na Slacku lub GitHub."
 
 #: books/edit.html
 #, fuzzy
@@ -3695,11 +3695,11 @@ msgstr "Czy ta książka jest częścią serii?"
 
 #: books/edit.html
 msgid "E.g. Harry Potter, The Sword of Truth"
-msgstr ""
+msgstr "Np. Harry Potter, Miecz Prawdy"
 
 #: books/edit.html type/edition/view.html type/work/view.html
 msgid "Work Identifiers"
-msgstr ""
+msgstr "Identyfikatory dzieła"
 
 #: books/edit.html
 #, fuzzy
@@ -3708,12 +3708,12 @@ msgstr "Czy znasz oznaczenia tego wydania?"
 
 #: books/edit.html
 msgid "These identifiers apply to all editions of this work, for example Wikidata work identifiers. For edition-specific identifiers, like ISBN or LCCN, go to the edition tab."
-msgstr ""
+msgstr "Te identyfikatory dotyczą wszystkich wydań tego dzieła, na przykład identyfikatory dzieła Wikidata. W przypadku identyfikatorów specyficznych dla wydania, takich jak ISBN lub LCCN, przejdź na kartę wydania."
 
 #: FulltextSearchSuggestionItem.html IABook.html SearchResultsWork.html books/edition-sort.html jsdef/LazyWorkPreview.html lists/list_overview.html lists/preview.html lists/snippet.html lists/widget.html my_books/dropdown_content.html type/work/editions.html
 #, python-format
 msgid "Cover of: %(title)s"
-msgstr ""
+msgstr "Okładka: %(title)s"
 
 #: books/edition-sort.html
 #, python-format
@@ -3723,7 +3723,7 @@ msgstr "%(title)s: %(subtitle)s"
 #: books/edition-sort.html
 #, python-format
 msgid "Publish date unknown, %(publisher)s"
-msgstr ""
+msgstr "Data wydania nieznana, %(publisher)s"
 
 #: books/edition-sort.html type/work/editions.html
 #, python-format
@@ -3778,7 +3778,7 @@ msgstr "Notatki:"
 
 #: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
 msgid "Imports and Exports"
-msgstr ""
+msgstr "Importy i eksporty"
 
 #: books/series-autocomplete.html
 #, fuzzy
@@ -3828,7 +3828,7 @@ msgstr "Wpisuj słowa kluczowe po przecinku."
 
 #: books/edit/about.html
 msgid "For example: <i><a href=\"/subjects/cheese\">cheese</a>, <a href=\"/subjects/roman_empire\">Roman Empire</a>, <a href=\"/subjects/psychology\">psychology</a></i>"
-msgstr ""
+msgstr "Na przykład: <i><a href=\"/subjects/cheese\">ser</a>, <a href=\"/subjects/roman_empire\">Cesarstwo Rzymskie</a>, <a href=\"/subjects/psychology\">psychologia</a></i>"
 
 #: books/edit/about.html
 msgid "A person? Or, people?"
@@ -3836,7 +3836,7 @@ msgstr "jedna czy więcej osób?"
 
 #: books/edit/about.html
 msgid "For example: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore Roosevelt</a>, <a href=\"/subjects/person:Julian_of_Norwich\">Julian of Norwich</a>, <a href=\"/subjects/person:Tintin\">Tintin</a></i>"
-msgstr ""
+msgstr "Na przykład: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore Roosevelt</a>, <a href=\"/subjects/person:Julian_of_Norwich\">Julian of Norwich</a>, <a href=\"/subjects/person:Tintin\">Tintin</a></i>"
 
 #: books/edit/about.html
 msgid "Note any places mentioned?"
@@ -3844,7 +3844,7 @@ msgstr "Czy zostały wspomniane jakieś miejsca?"
 
 #: books/edit/about.html
 msgid "For example: <i><a href=\"/subjects/place:London\">London</a>, <a href=\"/subjects/place:Atlantis\">Atlantis</a>, <a href=\"/subjects/place:Omaha\">Omaha</a></i>"
-msgstr ""
+msgstr "Na przykład: <i><a href=\"/subjects/place:London\">Londyn</a>, <a href=\"/subjects/place:Atlantis\">Atlantyda</a>, <a href=\"/subjects/place:Omaha\">Omaha</a></i>"
 
 #: books/edit/about.html
 msgid "When is it set or about?"
@@ -3852,7 +3852,7 @@ msgstr "Kiedy odbywa się akcja książki, o czym jest?"
 
 #: books/edit/about.html
 msgid "For example: <i><a href=\"/subjects/time:1984\">1984</a>, <a href=\"/subjects/time:the_middle_ages\">The Middle Ages</a>, <a href=\"/subjects/time:1810-1890\">1810-1890</a></i>"
-msgstr ""
+msgstr "Na przykład: <i><a href=\"/subjects/time:1984\">1984</a>, <a href=\"/subjects/time:the_middle_ages\">Średniowiecze</a>, <a href=\"/subjects/time:1810-1890\">1810-1890</a></i>"
 
 #: books/edit/edition.html
 msgid "Select this language"
@@ -3888,7 +3888,7 @@ msgstr "Zwykle wydrukowany mniejszą lub inną czcionką."
 
 #: books/edit/edition.html
 msgid "For example: <i>envisioning the next 50 years</i>"
-msgstr ""
+msgstr "Na przykład: <i>wyobrażając sobie następne 50 lat</i>"
 
 #: books/edit/edition.html
 msgid "Publishing Info"
@@ -3896,7 +3896,7 @@ msgstr "Informacje wydawnicze"
 
 #: books/edit/edition.html
 msgid "For example <em>Oxford University Press; Penguin; W.W. Norton</em>"
-msgstr ""
+msgstr "Na przykład <em>Oxford University Press; Penguin; W.W. Norton</em>"
 
 #: books/edit/edition.html
 msgid "Where was the book published?"
@@ -3908,7 +3908,7 @@ msgstr "Prosimy o podanie państwa i miasta publikacji."
 
 #: books/edit/edition.html
 msgid "For example: <i>New York, USA; Sydney, Australia</i>"
-msgstr ""
+msgstr "Na przykład: <i>Nowy Jork, USA; Sydney, Australia</i>"
 
 #: books/edit/edition.html
 #, fuzzy
@@ -3921,15 +3921,15 @@ msgstr "Rok podany po informacji o prawach autorskich."
 
 #: books/edit/edition.html
 msgid "Edition Name (if applicable):"
-msgstr ""
+msgstr "Nazwa wydania (jeśli dotyczy):"
 
 #: books/edit/edition.html
 msgid "For example: <i>Centennial edition</i>; <i>First edition</i>"
-msgstr ""
+msgstr "Na przykład: <i>Wydanie jubileuszowe</i>; <i>Pierwsze wydanie</i>"
 
 #: books/edit/edition.html
 msgid "Series Name (if applicable)"
-msgstr ""
+msgstr "Nazwa serii (jeśli dotyczy)"
 
 #: books/edit/edition.html
 msgid "The name of the publisher's series."
@@ -3937,7 +3937,7 @@ msgstr "Nazwa serii wydawnictwa"
 
 #: books/edit/edition.html
 msgid "For example: <i>The Story of Civilization, Part III</i>"
-msgstr ""
+msgstr "Na przykład: <i>Historia cywilizacji, część III</i>"
 
 #: books/edit/edition.html type/edition/view.html type/work/view.html
 msgid "Contributors"
@@ -3974,7 +3974,7 @@ msgstr "Czy podany jest autor?"
 
 #: books/edit/edition.html
 msgid "For example: <em>edited by David Anderson</em>"
-msgstr ""
+msgstr "Na przykład: <em>pod redakcją Davida Andersona</em>"
 
 #: books/edit/edition.html
 msgid "What language is this edition written in?"
@@ -4019,7 +4019,7 @@ msgstr "Użyj \"*\" by zrobić wcięcie, \"|\" by dodać kolumnę oraz zakończe
 
 #: books/edit/edition.html
 msgid "This table of contents contains extra information like authors or descriptions. We don't have a great user interface for this yet, so editing this data could be difficult. Watch out!"
-msgstr ""
+msgstr "Ten spis treści zawiera dodatkowe informacje, takie jak autorzy lub opisy. Nie mamy jeszcze dobrego interfejsu użytkownika do tego, więc edycja tych danych może być trudna. Uważaj!"
 
 #: books/edit/edition.html
 msgid "Any notes about this specific edition?"
@@ -4044,7 +4044,7 @@ msgstr "Wypełnij te pole jeśli tytuł jest inny na okładce lub grzbiecie ksi�
 
 #: books/edit/edition.html
 msgid "For example: <i>Eaters of the Dead</i> is an alternate title for <i><a href=\"/books/OL24923038M\">The 13th Warrior</a></i>."
-msgstr ""
+msgstr "Na przykład: <i>Eaters of the Dead</i> to alternatywny tytuł dla <i><a href=\"/books/OL24923038M\">The 13th Warrior</a></i>."
 
 #: books/edit/edition.html
 msgid "What work is this an edition of?"
@@ -4056,7 +4056,7 @@ msgstr "Zdarza się, że wydania są skojarzone z niepoprawnymi książkami. Mo�
 
 #: books/edit/edition.html
 msgid "You can search by title or by Open Library ID (like <a href=\"/works/OL262757W\" target=\"_blank\" rel=\"noopener noreferrer\"><em>OL262757W</em></a>)."
-msgstr ""
+msgstr "Możesz wyszukiwać według tytułu lub identyfikatora Open Library (jak <a href=\"/works/OL262757W\" target=\"_blank\" rel=\"noopener noreferrer\"><em>OL262757W</em></a>)."
 
 #: books/edit/edition.html
 msgid "WARNING: Any edits made to the work from this page will be ignored."
@@ -4090,7 +4090,7 @@ msgstr "ID musi zawierać dokładnie 10 znaków [0-9] lub X."
 
 #: books/edit/edition.html
 msgid "That ID already exists for this edition."
-msgstr ""
+msgstr "Ten identyfikator już istnieje dla tego wydania."
 
 #: books/edit/edition.html
 #, fuzzy
@@ -4176,7 +4176,7 @@ msgstr "Pomoc"
 
 #: books/edit/edition.html
 msgid "For example: <em>xii, 346p.</em>"
-msgstr ""
+msgstr "Na przykład: <em>xii, 346 s.</em>"
 
 #: books/edit/edition.html
 msgid "How much does the book weigh?"
@@ -4205,7 +4205,7 @@ msgstr "Grubość"
 
 #: books/edit/edition.html
 msgid "Web Book Providers"
-msgstr ""
+msgstr "Dostawcy e-booków internetowych"
 
 #: books/edit/edition.html
 #, fuzzy
@@ -4219,7 +4219,7 @@ msgstr "Format"
 
 #: books/edit/edition.html
 msgid "Provider Name"
-msgstr ""
+msgstr "Nazwa dostawcy"
 
 #: books/edit/edition.html
 #, fuzzy
@@ -4242,7 +4242,7 @@ msgstr "Pierwsze zdanie"
 
 #: books/edit/edition.html
 msgid "The opening line that starts the lead paragraph"
-msgstr ""
+msgstr "Pierwsze zdanie rozpoczynające wiodący akapit"
 
 #: books/edit/edition.html
 msgid "Admin Only"
@@ -4254,7 +4254,7 @@ msgstr "Dodatkowe metadane"
 
 #: books/edit/edition.html
 msgid "This field can accept arbitrary key:value pairs"
-msgstr ""
+msgstr "To pole może przyjmować dowolne pary klucz:wartość"
 
 #: books/edit/excerpts.html
 msgid "Please provide an excerpt."
@@ -4274,11 +4274,11 @@ msgstr "Jaki jest numer strony?"
 
 #: books/edit/excerpts.html
 msgid "For example: <i>23, xi or 433-434</i>"
-msgstr ""
+msgstr "Na przykład: <i>23, xi lub 433-434</i>"
 
 #: books/edit/excerpts.html
 msgid "This excerpt is the first sentence of the book."
-msgstr ""
+msgstr "Ten fragment to pierwsze zdanie książki."
 
 #: books/edit/excerpts.html
 msgid "Transcribe the excerpt"
@@ -4335,11 +4335,11 @@ msgstr "Nadaj etykietę swojemu linkowi."
 
 #: books/edit/web.html
 msgid "For example: <em>New York Times review</em>"
-msgstr ""
+msgstr "Na przykład: <em>recenzja New York Times</em>"
 
 #: books/edit/web.html
 msgid "URL"
-msgstr ""
+msgstr "URL"
 
 #: books/edit/web.html
 #, fuzzy
@@ -4356,7 +4356,7 @@ msgstr "\"Poprwany\" oznacza link bez spamu. Linki muszą być powiązane z tą 
 
 #: bulk_search/bulk_search.html search/advancedsearch.html
 msgid "Bulk Search (beta)"
-msgstr ""
+msgstr "Wyszukiwanie zbiorcze (beta)"
 
 #: covers/add.html
 #, fuzzy
@@ -4388,7 +4388,7 @@ msgstr "Podaj ULR tego obrazu."
 #: covers/add.html
 #, python-format
 msgid "Learn more by reading our <a href=\"/help/faq/editing#picture\" target=\"blank\">%(guidelines)s</a>."
-msgstr ""
+msgstr "Dowiedz się więcej, czytając nasze <a href=\"/help/faq/editing#picture\" target=\"blank\">%(guidelines)s</a>."
 
 #: covers/add.html
 #, fuzzy
@@ -4407,15 +4407,15 @@ msgstr "Wybierz plik JPG, GIF lub PNG z Twojego komputera."
 
 #: covers/add.html
 msgid "Upload"
-msgstr ""
+msgstr "Prześlij"
 
 #: covers/add.html
 msgid "Or, paste an image from your clipboard"
-msgstr ""
+msgstr "Lub wklej obraz ze schowka"
 
 #: covers/add.html
 msgid "Paste image from clipboard"
-msgstr ""
+msgstr "Wklej obraz ze schowka"
 
 #: covers/add.html
 #, fuzzy
@@ -4424,11 +4424,11 @@ msgstr "Dodaj kolejny obraz"
 
 #: covers/add.html
 msgid "Upload image"
-msgstr ""
+msgstr "Prześlij obraz"
 
 #: covers/add.html covers/external_image.html
 msgid "Upload Image"
-msgstr ""
+msgstr "Prześlij obraz"
 
 #: covers/add.html
 #, fuzzy
@@ -4442,40 +4442,40 @@ msgstr "Wikipedia"
 
 #: covers/author_photo.html
 msgid "Pull up a larger author photo"
-msgstr ""
+msgstr "Powiększ zdjęcie autora"
 
 #: covers/author_photo.html search/authors.html
 #, python-format
 msgid "Photo of %(author)s"
-msgstr ""
+msgstr "Zdjęcie %(author)s"
 
 #: covers/author_photo.html
 msgid "Click to close"
-msgstr ""
+msgstr "Kliknij, aby zamknąć"
 
 #: covers/author_photo.html
 #, python-format
 msgid "We need a photo of %(author)s"
-msgstr ""
+msgstr "Potrzebujemy zdjęcia %(author)s"
 
 #: covers/book_cover.html
 msgid "Pull up a bigger book cover"
-msgstr ""
+msgstr "Powiększ okładkę książki"
 
 #: covers/book_cover.html covers/book_cover_small.html
 #, python-format
 msgid "Cover of: %(title)s by %(authors)s"
-msgstr ""
+msgstr "Okładka: %(title)s autorstwa %(authors)s"
 
 #: covers/book_cover_small.html
 #, python-format
 msgid "Go to the main page for %(title)s"
-msgstr ""
+msgstr "Przejdź do głównej strony %(title)s"
 
 #: covers/book_cover_small.html
 #, python-format
 msgid "We need a book cover for: %(title)s"
-msgstr ""
+msgstr "Potrzebujemy okładki dla: %(title)s"
 
 #: covers/change.html
 #, fuzzy
@@ -4499,7 +4499,7 @@ msgstr "Książki, które kochamy"
 
 #: covers/change.html
 msgid "Manage Covers"
-msgstr ""
+msgstr "Zarządzaj okładkami"
 
 #: covers/change.html
 #, fuzzy
@@ -4514,7 +4514,7 @@ msgstr "Język"
 #: covers/external_image.html
 #, python-format
 msgid "Or, use an image from %s"
-msgstr ""
+msgstr "Lub użyj obrazu z %s"
 
 #: covers/manage.html
 msgid "You can drag and drop thumbnails to reorder, or into the trash to delete them."
@@ -4522,7 +4522,7 @@ msgstr "Możesz przeciągać i upuszczać miniatury w celu zmiany kolejności, l
 
 #: covers/saved.html
 msgid "New book cover"
-msgstr ""
+msgstr "Nowa okładka książki"
 
 #: covers/saved.html
 msgid "Saved!"
@@ -4542,30 +4542,30 @@ msgstr "Zakończono"
 
 #: design/toggle.html
 msgid "Toggle"
-msgstr ""
+msgstr "Przełącz"
 
 #: design/toggle.html
 #, python-format
 msgid "The %(tag)s component is a switch with a bold label and an optional greyed sublabel. The whole control is one %(role)s button, so the entire surface is clickable and Enter/Space activate it. It owns its on/off state: clicking flips %(checked)s and fires %(event)s."
-msgstr ""
+msgstr "Komponent %(tag)s to przełącznik z pogrubioną etykietą i opcjonalną szarą podetyketą. Cała kontrolka to jeden przycisk %(role)s, więc cała powierzchnia jest klikalna, a Enter/Spacja ją aktywuje. Zarządza swoim stanem włącz/wyłącz: kliknięcie zmienia %(checked)s i wywołuje %(event)s."
 
 #: design/toggle.html
 msgid "Default"
-msgstr ""
+msgstr "Domyślny"
 
 #: design/toggle.html
 #, python-format
 msgid "A plain toggle: just the switch, a bold %(label)s, and an optional greyed %(sublabel)s."
-msgstr ""
+msgstr "Prosty przełącznik: tylko przełącznik, pogrubiona %(label)s i opcjonalna szara %(sublabel)s."
 
 #: design/toggle.html
 msgid "Card variant"
-msgstr ""
+msgstr "Wariant kart"
 
 #: design/toggle.html
 #, python-format
 msgid "Use %(variant)s for a bordered container. When checked, it fills with a solid primary-blue background and white text — the same treatment as a selected %(chip)s."
-msgstr ""
+msgstr "Użyj %(variant)s dla kontenera z obramowaniem. Po zaznaczeniu wypełnia się jednolitym niebieskim tłem i białym tekstem — takie samo traktowanie jak wybrany %(chip)s."
 
 #: design/toggle.html
 #, fuzzy
@@ -4575,15 +4575,15 @@ msgstr "Spis treści"
 #: design/toggle.html
 #, python-format
 msgid "Put content in the default slot to customize the label instead of using %(label)s / %(sublabel)s. Supply %(accessible_label)s so the switch still has an accessible name."
-msgstr ""
+msgstr "Umieść zawartość w domyślnym slocie, aby dostosować etykietę zamiast używać %(label)s / %(sublabel)s. Podaj %(accessible_label)s, aby przełącznik nadal miał dostępną nazwę."
 
 #: design/toggle.html
 msgid "Dark mode"
-msgstr ""
+msgstr "Tryb ciemny"
 
 #: design/toggle.html
 msgid "easier on the eyes"
-msgstr ""
+msgstr "łagodniejszy dla oczu"
 
 #: design/toggle.html
 #, fuzzy
@@ -4593,20 +4593,20 @@ msgstr "Dla osób z trudnościami w czytaniu druku"
 #: design/toggle.html
 #, python-format
 msgid "Add %(disabled)s to block interaction."
-msgstr ""
+msgstr "Dodaj %(disabled)s, aby zablokować interakcję."
 
 #: design/toggle.html
 msgid "Change event"
-msgstr ""
+msgstr "Zdarzenie zmiany"
 
 #: design/toggle.html
 #, python-format
 msgid "Toggling fires %(event)s with the new state in %(detail)s."
-msgstr ""
+msgstr "Przełączanie wyzwala %(event)s z nowym stanem w %(detail)s."
 
 #: design/toggle.html
 msgid "Checked:"
-msgstr ""
+msgstr "Zaznaczone:"
 
 #: email/case_created.html
 #, fuzzy
@@ -4615,7 +4615,7 @@ msgstr "Wyślij"
 
 #: email/case_created.html
 msgid "Thank you for your note. We'll get back to you as soon as possible."
-msgstr ""
+msgstr "Dziękujemy za wiadomość. Odpowiemy tak szybko, jak to możliwe."
 
 #: email/case_created.html
 msgid "It might take us a little while to read it because we receive lots of messages, but rest assured we will, and we'll get back to you if required."
@@ -4623,7 +4623,7 @@ msgstr ""
 
 #: email/account/pd_request.html
 msgid "Qualifying for Print Disability Special Access"
-msgstr ""
+msgstr "Kwalifikowanie się do specjalnego dostępu dla osób z niepełnosprawnością druku"
 
 #: history/sources.html
 #, fuzzy
@@ -4658,8 +4658,8 @@ msgstr "Przeglądaj według tematów"
 #, python-format
 msgid "%(count)s Book"
 msgid_plural "%(count)s Books"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%(count)s książka"
+msgstr[1] "%(count)s książki"
 
 #: home/index.html home/welcome.html
 msgid "Welcome to Open Library"
@@ -4691,22 +4691,22 @@ msgstr "Podręczniki"
 
 #: home/index.html
 msgid "Authors Alliance & MIT Press"
-msgstr ""
+msgstr "Authors Alliance & MIT Press"
 
 #: home/index.html
 msgid "Books in Local Environment"
-msgstr ""
+msgstr "Książki w środowisku lokalnym"
 
 #: home/loans.html
 #, python-format
 msgid "You can still <a href=\"/subjects/in_library#ebooks=true\">borrow</a> one more book until you've hit the limit!"
 msgid_plural "You can still <a href=\"/subjects/in_library#ebooks=true\">borrow</a> %(count)d more books until you've hit the limit!"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Możesz jeszcze <a href=\"/subjects/in_library#ebooks=true\">wypożyczyć</a> jedną książkę, zanim osiągniesz limit!"
+msgstr[1] "Możesz jeszcze <a href=\"/subjects/in_library#ebooks=true\">wypożyczyć</a> %(count)d książki, zanim osiągniesz limit!"
 
 #: home/loans.html
 msgid "You have reached the borrowing limit. Please return a book to checkout something new."
-msgstr ""
+msgstr "Osiągnąłeś/aś limit wypożyczeń. Proszę zwrócić książkę, aby wypożyczyć coś nowego."
 
 #: home/stats.html
 msgid "Around the Library"
@@ -4722,7 +4722,7 @@ msgstr "Zobacz wszystkich odwiedzających OpenLibrary.org"
 
 #: home/stats.html
 msgid "Area graph of recent unique visitors"
-msgstr ""
+msgstr "Wykres obszarowy ostatnich unikalnych odwiedzających"
 
 #: home/stats.html
 msgid "How many new Open Library members have we welcomed?"
@@ -4739,7 +4739,7 @@ msgstr "Użytkownicy na bierząco aktualizujący katalog"
 
 #: home/stats.html
 msgid "Area graph of recent catalog edits"
-msgstr ""
+msgstr "Wykres obszarowy ostatnich edycji katalogu"
 
 #: home/stats.html
 msgid "Catalog Edits"
@@ -4751,7 +4751,7 @@ msgstr "Użytkownicy mogą tworzyć Listy"
 
 #: home/stats.html
 msgid "Area graph of lists created recently"
-msgstr ""
+msgstr "Wykres obszarowy ostatnio utworzonych list"
 
 #: home/stats.html
 msgid "Lists Created"
@@ -4763,7 +4763,7 @@ msgstr "Jesteśmy biblioteką, więc równierz wypożyczamy książki"
 
 #: home/stats.html
 msgid "Area graph of ebooks borrowed recently"
-msgstr ""
+msgstr "Wykres obszarowy ostatnio wypożyczonych e-booków"
 
 #: home/stats.html
 msgid "eBooks Borrowed"
@@ -4771,35 +4771,35 @@ msgstr "Wypożyczone e-booki"
 
 #: home/welcome.html
 msgid "Read Free Library Books Online"
-msgstr ""
+msgstr "Czytaj bezpłatne książki biblioteczne online"
 
 #: home/welcome.html
 msgid "Millions of books available through Controlled Digital Lending"
-msgstr ""
+msgstr "Miliony książek dostępnych poprzez kontrolowane cyfrowe wypożyczanie"
 
 #: home/welcome.html
 msgid "Set a Yearly Reading Goal"
-msgstr ""
+msgstr "Ustaw roczny cel czytelniczy"
 
 #: home/welcome.html
 msgid "Learn how to set a yearly reading goal and track what you read"
-msgstr ""
+msgstr "Dowiedz się, jak ustawić roczny cel czytelniczy i śledzić przeczytane książki"
 
 #: home/welcome.html
 msgid "Keep Track of your Favorite Books"
-msgstr ""
+msgstr "Śledź swoje ulubione książki"
 
 #: home/welcome.html
 msgid "Organize your Books using Lists & the Reading Log"
-msgstr ""
+msgstr "Organizuj swoje książki za pomocą list i dziennika czytelniczego"
 
 #: home/welcome.html
 msgid "Try the virtual Library Explorer"
-msgstr ""
+msgstr "Wypróbuj wirtualnego Eksploratora Biblioteki"
 
 #: home/welcome.html
 msgid "Digital shelves organized like a physical library"
-msgstr ""
+msgstr "Cyfrowe półki zorganizowane jak fizyczna biblioteka"
 
 #: home/welcome.html
 #, fuzzy
@@ -4808,7 +4808,7 @@ msgstr "Wyszukiwanie pełnotekstowe"
 
 #: home/welcome.html
 msgid "Find matching results within the text of millions of books"
-msgstr ""
+msgstr "Znajdź pasujące wyniki w tekście milionów książek"
 
 #: home/welcome.html
 #, fuzzy
@@ -4817,7 +4817,7 @@ msgstr "Open Library"
 
 #: home/welcome.html
 msgid "Dozens of ways you can help improve the library"
-msgstr ""
+msgstr "Dziesiątki sposobów, w jakie możesz pomóc ulepszyć bibliotekę"
 
 #: home/welcome.html
 #, fuzzy
@@ -4826,15 +4826,15 @@ msgstr "Witamy w Open Library"
 
 #: home/welcome.html
 msgid "Discover opportunities to improve the library"
-msgstr ""
+msgstr "Odkryj możliwości ulepszenia biblioteki"
 
 #: home/welcome.html
 msgid "Send us feedback"
-msgstr ""
+msgstr "Wyślij nam opinię"
 
 #: home/welcome.html
 msgid "Your feedback will help us improve these cards"
-msgstr ""
+msgstr "Twoja opinia pomoże nam ulepszyć te karty"
 
 #: jsdef/LazyWorkPreview.html
 #, fuzzy
@@ -4855,15 +4855,15 @@ msgstr "Wydawnictwo"
 #, python-format
 msgid "%s work"
 msgid_plural "%s works"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%s dzieło"
+msgstr[1] "%s dzieła"
 
 #: languages/index.html
 #, python-format
 msgid "%s ebook edition"
 msgid_plural "%s ebook editions"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%s wydanie e-book"
+msgstr[1] "%s wydania e-book"
 
 #: languages/notfound.html
 #, fuzzy, python-format
@@ -4889,7 +4889,7 @@ msgstr "Pobierz wpis w katalogu:"
 
 #: lib/exports.html
 msgid "RDF"
-msgstr ""
+msgstr "RDF"
 
 #: lib/exports.html type/list/exports.html
 #, fuzzy
@@ -4930,7 +4930,7 @@ msgstr "Dołączył\\(a\\) %(date)s"
 
 #: lib/header_dropdown.html
 msgid "Menu"
-msgstr ""
+msgstr "Menu"
 
 #: lib/header_dropdown.html
 #, fuzzy
@@ -4965,15 +4965,15 @@ msgstr ""
 #: lib/history.html
 #, python-format
 msgid "Edited by %(user)s"
-msgstr ""
+msgstr "Edytowane przez %(user)s"
 
 #: lib/message_addbook.html
 msgid "Super!"
-msgstr ""
+msgstr "Super!"
 
 #: lib/message_addbook.html
 msgid " Your new record is in the library. Thank you!"
-msgstr ""
+msgstr " Twój nowy rekord jest w bibliotece. Dziękujemy!"
 
 #: lib/message_addbook.html
 msgid "There are a few other simple things you can add while you're here to improve your new record quickly, and make it much easier for other people to find later."
@@ -4986,7 +4986,7 @@ msgstr "Dodaj kolejny obraz"
 
 #: lib/message_addbook.html
 msgid "Snap a quick photo of the cover to share?"
-msgstr ""
+msgstr "Zrób szybkie zdjęcie okładki, aby się podzielić?"
 
 #: lib/message_addbook.html
 #, fuzzy
@@ -4995,7 +4995,7 @@ msgstr "Dodaj książkę"
 
 #: lib/message_addbook.html
 msgid "Help the library connect with other systems, like Amazon."
-msgstr ""
+msgstr "Pomóż bibliotece połączyć się z innymi systemami, takimi jak Amazon."
 
 #: lib/message_addbook.html
 #, fuzzy
@@ -5004,15 +5004,15 @@ msgstr "Wspólne tematy"
 
 #: lib/message_addbook.html
 msgid "They're just like tags."
-msgstr ""
+msgstr "Są jak tagi."
 
 #: lib/message_addbook.html
 msgid "Describe what the book's about"
-msgstr ""
+msgstr "Opisz, o czym jest ta książka"
 
 #: lib/message_addbook.html
 msgid "Just a sentence or two is good."
-msgstr ""
+msgstr "Wystarczy jedno lub dwa zdania."
 
 #: lib/nav_foot.html openlibrary/plugins/openlibrary/api.py site/head.html
 msgid "Open Library"
@@ -5024,11 +5024,11 @@ msgstr "Wizja"
 
 #: lib/nav_foot.html
 msgid "Volunteer"
-msgstr ""
+msgstr "Wolontariusz"
 
 #: lib/nav_foot.html
 msgid "Partner With Us"
-msgstr ""
+msgstr "Zostań naszym partnerem"
 
 #: lib/nav_foot.html
 msgid "Jobs"
@@ -5170,7 +5170,7 @@ msgstr "Związek z tematem"
 
 #: lib/nav_foot.html
 msgid "Bluesky"
-msgstr ""
+msgstr "Bluesky"
 
 #: lib/nav_foot.html
 #, fuzzy
@@ -5189,7 +5189,7 @@ msgstr "Open Library"
 
 #: lib/nav_foot.html
 msgid "GitHub"
-msgstr ""
+msgstr "GitHub"
 
 #: lib/nav_foot.html
 #, fuzzy
@@ -5198,7 +5198,7 @@ msgstr "Open Library"
 
 #: lib/nav_foot.html site/alert.html
 msgid "Change Website Language"
-msgstr ""
+msgstr "Zmień język strony"
 
 #: lib/nav_foot.html lib/nav_head.html type/list/embed.html
 #, fuzzy
@@ -5216,7 +5216,7 @@ msgstr "wersja <a href=\"https://github.com/internetarchive/openlibrary/commit/%
 
 #: lib/nav_head.html
 msgid "Loans, Reading Log, Lists, Stats"
-msgstr ""
+msgstr "Wypożyczenia, dziennik czytelniczy, listy, statystyki"
 
 #: lib/nav_head.html
 msgid "My Profile"
@@ -5228,7 +5228,7 @@ msgstr "Wyloguj się"
 
 #: lib/nav_head.html
 msgid "Pending Merge Requests"
-msgstr ""
+msgstr "Oczekujące prośby o scalenie"
 
 #: lib/nav_head.html search/sort_options.html
 #, fuzzy
@@ -5259,7 +5259,7 @@ msgstr "Pomoc i wsparcie"
 
 #: lib/nav_head.html
 msgid "Librarians Portal"
-msgstr ""
+msgstr "Portal bibliotekarzy"
 
 #: lib/nav_head.html
 #, fuzzy
@@ -5277,11 +5277,11 @@ msgstr "Współtwórcy"
 
 #: lib/nav_head.html
 msgid "Resources"
-msgstr ""
+msgstr "Zasoby"
 
 #: lib/nav_head.html
 msgid "The Internet Archive's Open Library: One page for every book"
-msgstr ""
+msgstr "Open Library Internet Archive: Jedna strona dla każdej książki"
 
 #: lib/nav_head.html
 #, fuzzy
@@ -5299,15 +5299,15 @@ msgstr "Przeczytaj"
 
 #: librarian_dashboard/data_quality_table.html
 msgid "failing"
-msgstr ""
+msgstr "niepowodzenie"
 
 #: librarian_dashboard/data_quality_table.html
 msgid "Data quality table"
-msgstr ""
+msgstr "Tabela jakości danych"
 
 #: librarian_dashboard/data_quality_table.html
 msgid "Quality Criteria"
-msgstr ""
+msgstr "Kryteria jakości"
 
 #: lists/carousel.html lists/home.html lists/showcase.html
 msgid "See all"
@@ -5316,7 +5316,7 @@ msgstr "Zobacz wszystkie"
 #: lists/export_as_html.html
 #, python-format
 msgid "%(list)s - Editions"
-msgstr ""
+msgstr "%(list)s - Wydania"
 
 #: lists/export_as_html.html type/list/embed.html type/list/view_body.html
 #, fuzzy
@@ -5330,16 +5330,16 @@ msgstr "Wydawnictwo nieznane"
 
 #: lists/export_as_html.html
 msgid "First publish date unknown"
-msgstr ""
+msgstr "Data pierwszej publikacji nieznana"
 
 #: lists/export_as_html.html
 msgid "Name unknown"
-msgstr ""
+msgstr "Imię nieznane"
 
 #: lists/header.html
 #, python-format
 msgid "<a href=\"%(href)s\">%(name)s</a> / Lists"
-msgstr ""
+msgstr "<a href=\"%(href)s\">%(name)s</a> / Listy"
 
 #: lists/header.html
 #, python-format
@@ -5366,8 +5366,8 @@ msgstr[1] "Ta książka znajduje się na <strong> %(count)s listach</strong>."
 #, python-format
 msgid "%(name)s has 1 list."
 msgid_plural "%(name)s has %(count)s lists."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%(name)s ma 1 listę."
+msgstr[1] "%(name)s ma %(count)s listy."
 
 #: lists/header.html
 #, python-format
@@ -5391,7 +5391,7 @@ msgstr "Po utworzeniu listy możesz <strong>obserwować aktualizacje</strong> lu
 #: lists/home.html
 #, python-format
 msgid "For the top 2000+ most requested eBooks in California for the print disabled <a href=\"%(url)s\">click here</a>."
-msgstr ""
+msgstr "Aby zapoznać się z ponad 2000 najczęściej żądanych e-booków w Kalifornii dla osób z niepełnosprawnością druku, <a href=\"%(url)s\">kliknij tutaj</a>."
 
 #: lists/home.html
 msgid "Find a list by name"
@@ -5433,7 +5433,7 @@ msgstr "Wypożycz teraz"
 
 #: lists/list_follow.html
 msgid "Avatar of the owner of the list"
-msgstr ""
+msgstr "Awatar właściciela listy"
 
 #: lists/list_follow.html lists/widget.html my_books/dropdown_content.html
 msgid "You"
@@ -5441,15 +5441,15 @@ msgstr "Ty"
 
 #: lists/list_follow.html
 msgid "This patron has not enabled following"
-msgstr ""
+msgstr "Ten użytkownik nie włączył obserwowania"
 
 #: lists/list_follow.html
 msgid "🔒︎"
-msgstr ""
+msgstr "🔒︎"
 
 #: Follow.html lists/list_follow.html
 msgid "Follow"
-msgstr ""
+msgstr "Obserwuj"
 
 #: lists/list_follow.html
 #, fuzzy
@@ -5458,7 +5458,7 @@ msgstr "Open Library"
 
 #: lists/list_follow.html
 msgid "Community List"
-msgstr ""
+msgstr "Lista społeczności"
 
 #: lists/list_overview.html lists/widget.html my_books/dropdown_content.html
 msgid "See this list"
@@ -5471,12 +5471,12 @@ msgstr "Usnunąć z listy?"
 #: lists/list_overview.html
 #, python-format
 msgid "from <a href=\"%(link)s\">You</a>"
-msgstr ""
+msgstr "od <a href=\"%(link)s\">Ciebie</a>"
 
 #: lists/list_overview.html
 #, python-format
 msgid "from <a href=\"%(link)s\">%(name)s</a>"
-msgstr ""
+msgstr "od <a href=\"%(link)s\">%(name)s</a>"
 
 #: lists/lists.html
 #, python-format
@@ -5485,7 +5485,7 @@ msgstr "%(owner)s / Listy"
 
 #: lists/lists.html type/list/view_body.html
 msgid "Yes, I'm sure"
-msgstr ""
+msgstr "Tak, jestem pewien/pewna"
 
 #: lists/lists.html type/list/view_body.html
 #, fuzzy
@@ -5515,20 +5515,20 @@ msgstr "Czy na pewno chcesz usunąć<strong>%(title)s</strong> z tej listy?"
 
 #: lists/lists.html
 msgid "This reader hasn't created any lists yet."
-msgstr ""
+msgstr "Ten czytelnik nie utworzył jeszcze żadnych list."
 
 #: lists/lists.html
 msgid "You haven't created any lists yet."
-msgstr ""
+msgstr "Nie utworzyłeś/aś jeszcze żadnych list."
 
 #: lists/lists.html
 msgid "Learn how to create your first list."
-msgstr ""
+msgstr "Dowiedz się, jak utworzyć swoją pierwszą listę."
 
 #: lists/preview.html
 #, python-format
 msgid "by <a href=\"%s\">You</a>"
-msgstr ""
+msgstr "przez <a href=\"%s\">Ciebie</a>"
 
 #: lists/showcase.html
 #, fuzzy, python-format
@@ -5547,7 +5547,7 @@ msgstr "Ze strony"
 
 #: lists/widget.html
 msgid "Loading<span class=\"loading-ellipsis\">...</span>"
-msgstr ""
+msgstr "Ładowanie<span class=\"loading-ellipsis\">...</span>"
 
 #: merge/authors.html
 msgid "Merge Authors"

--- a/openlibrary/i18n/pl/messages.po
+++ b/openlibrary/i18n/pl/messages.po
@@ -9,4079 +9,8764 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Open Library VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-03-24 14:26-0400\n"
+"POT-Creation-Date: 2026-04-28 18:58-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.12.1\n"
 
-#: account.py:354 account.py:389 password/reset_success.html:10 verify.html:9
-#: verify/activated.html:10 verify/success.html:10
-#, python-format
-msgid "Hi, %(user)s"
-msgstr "Cześć, %(user)s"
-
-#: account.py:355 account.py:390
-#, python-format
-msgid ""
-"We've sent the verification email to %(email)s. You'll need to read that "
-"and click on the verification link to verify your email."
-msgstr ""
-"Wysłaliśmy potwierdzenie na adres %(email)s. Przeczytaj je i kliknij "
-"zamieszczony link, by potwierdzić swój e-mail."
-
-#: account.py:420
-msgid "Email address is already used."
-msgstr "Ten e-mail jest już w użyciu."
-
-#: account.py:421
-msgid ""
-"Your email address couldn't be updated. The specified email address is "
-"already used."
-msgstr "Twój e-mail nie został zaktualizowany. Podany e-mail jest już w użyciu."
-
-#: account.py:425
-msgid "Email verification successful."
-msgstr "Twój e-mail został zweryfikowany."
-
-#: account.py:426
-msgid ""
-"Your email address has been successfully verified and updated in your "
-"account."
-msgstr "Twój e-mail został zweryfikowany i zaktualizowany na Twoimkoncie."
-
-#: account.py:430
-msgid "Email address couldn't be verified."
-msgstr "E-mail nie mógł zostać zweryfikowany."
-
-#: account.py:431
-msgid ""
-"Your email address couldn't be verified. The verification link seems "
-"invalid."
-msgstr ""
-"Twój e-mail nie mógł zostać zweryfikowany. Link weryfikacyjny jest "
-"nieważny."
-
-#: account.py:527 account.py:537
-msgid "Password reset failed."
-msgstr "Nie udało się ustawić nowego hasła."
-
-#: account.py:583 account.py:599
-msgid "Notification preferences have been updated successfully."
-msgstr "Preferencje dotyczące powiadomień zostały zaktualizowane."
-
-#: forms.py:19
-msgid "Username"
-msgstr "Nazwa użytkownika"
-
-#: forms.py:20 openlibrary/templates/login.html:41
-msgid "Password"
-msgstr "Hasło"
-
-#: forms.py:25
-msgid "No user registered with this email address"
-msgstr "Nie istnieje konto z podanym adresem e-mail"
-
-#: forms.py:26
-msgid "Email already registered"
-msgstr "Podany e-mail jest już zarejestrowany"
-
-#: forms.py:27
-msgid "Disposable email not permitted"
-msgstr "Jednorazowy e-mail jest niedozwolony."
-
-#: forms.py:28
-msgid "Your email provider is not recognized."
-msgstr "Twój dostawca poczty e-mail jest nieznany."
-
-#: forms.py:29
-msgid "Username already used"
-msgstr "Konto z podaną nazwą użytkownika już istnieje."
-
-#: forms.py:31
-msgid "Must be between 3 and 20 letters and numbers"
-msgstr "Musi składać się z min. 3 i max. 20 liter i liczb."
-
-#: forms.py:32
-msgid "Must be between 3 and 20 characters"
-msgstr "Musi składać się z min. 3 i max. 20 znaków."
-
-#: forms.py:33
-msgid "Must be a valid email address"
-msgstr "Wymagane jest podnanie adresu e-mail."
-
-#: forms.py:47 forms.py:94
-msgid "Your email address"
-msgstr "Twój adres e-mail"
-
-#: forms.py:51
-msgid "Choose a screen name"
-msgstr "Wybierz nick"
-
-#: forms.py:53
-msgid "Letters and numbers only please, and at least 3 characters."
-msgstr "Proszę używać tylko liter i liczb, minimum 3 znaki."
-
-#: forms.py:56 forms.py:98
-msgid "Choose a password"
-msgstr "Wybierz hasło"
-
-#: forms.py:59
-msgid "Confirm password"
-msgstr "Potwierdź hasło"
-
-#: forms.py:61
-msgid "Passwords didn't match."
-msgstr "Hasła nie są identyczne."
-
-#: forms.py:62
-msgid ""
-"Send me a monthly newsletter from the <a "
-"href=\"https://archive.org/\">Internet Archive</a>, the non-profit that "
-"runs Open Library"
-msgstr ""
-
-#: forms.py:91
-msgid "Invalid password"
-msgstr "Błędne hasło"
-
-#: edit.html:13
-msgid "Edit Author"
-msgstr "Edytuj autora"
-
-#: edit.html:26
-msgid "Name"
-msgstr "Imię i nazwisko"
-
-#: edit.html:28
-msgid ""
-"Please use natural order. For example: <strong>Leo Tolstoy</strong> not "
-"<strong>Tolstoy, Leo</strong>."
-msgstr ""
-"Prosimy o podanie imienia i nazwiska. Na przykład: <strong>Lew "
-"Tołstoj</strong> nie <strong>Tołstoj, Lew</strong>. "
-
-#: edit.html:29 edit.html:92 edit/addfield.html:100 edit/addfield.html:145
-msgid "Required field"
-msgstr "Pole wymagane"
-
-#: edit.html:43
-msgid "About"
-msgstr "Opis"
-
-#: edit.html:44 edit.html:110
-msgid "Links"
-msgstr "Linki"
-
-#: edit.html:53
-msgid "A short bio?"
-msgstr "Krótka biografia?"
-
-#: edit.html:54
-msgid ""
-"If you \"borrow\" information from somewhere, please make sure to cite "
-"the source."
-msgstr ""
-"Jeśli \"pożyczasz\" pewne informacje z innych źródeł, prosimy o ich "
-"podanie."
-
-#: edit.html:64
-msgid "Date of birth"
-msgstr "Data urodzenia"
-
-#: edit.html:73
-msgid "Date of death"
-msgstr "Data śmierci"
-
-#: edit.html:82
-msgid ""
-"We're not storing structured dates (yet) so a date like \"21 May 2000\" "
-"is recommended."
-msgstr ""
-"Nie przechowujemy (jeszcze) ustrukturyzowanych dat, prosimy o podanie "
-"daty w formacie \"21 maj 2000\"."
-
-#: edit.html:90
-msgid "Does this author go by any other names?"
-msgstr "Czy autor posługiwał się innymi nazwiskami lub pseudonimami?"
-
-#: edit.html:91 edit/about.html:21 edit/about.html:35 edit/about.html:49
-#: edit/about.html:63 edit/addfield.html:77 edit/addfield.html:104
-#: edit/addfield.html:113 edit/addfield.html:149 edit/edition.html:151
-#: edit/edition.html:172 edit/edition.html:220 edit/edition.html:252
-#: edit/edition.html:263 edit/edition.html:283 edit/edition.html:358
-#: edit/edition.html:609 edit/excerpts.html:19 edit/web.html:23
-msgid "For example:"
-msgstr "Na przykład:"
-
-#: edit.html:102
-msgid "Websites"
-msgstr "Strony internetowe"
-
-#: edit.html:103
-msgid "Deprecated"
-msgstr "Przestarzałe"
-
-#: edit.html:132 edit.html:149 openlibrary/macros/EditButtons.html:25
-msgid "Delete Record"
-msgstr "Usuń wpis"
-
-#: view.html:46
-msgid "name missing"
-msgstr "brakuje imienia"
-
-#: view.html:11 view.html:14 view.html:47
-#, python-format
-msgid "%(page_title)s | Open Library"
-msgstr "%(page_title)s | Open Library"
-
-#: view.html:60
-#, python-format
-msgid "Author of %(book_titles)s"
-msgstr "Autor %(book_titles)s"
-
-#: view.html:90
-msgid "Merging Authors..."
-msgstr "Łączenie autorów..."
-
-#: view.html:91
-msgid "In progress..."
-msgstr ""
-
-#: editions2.html:31 view.html:92
-msgid "Duplicates"
-msgstr "Duplikaty"
-
-#: view.html:104
-msgid "Refresh the page?"
-msgstr "Odświeżyć stronę?"
-
-#: view.html:105
-msgid "Success!"
-msgstr "Udało się!"
-
-#: view.html:106
-msgid ""
-"OK. The merge is in motion. <i>It will take <u>a few minutes to "
-"finish</u> the update.</i>"
-msgstr ""
-"OK. Łączenie zostało rozpoczęte. <i>Aktualizacja zakończy się <u>w ciągu "
-"kilku minut</u>.</i>"
-
-#: view.html:110
-msgid "Argh!"
-msgstr "Ups!"
-
-#: view.html:111
-msgid "That merge didn't work. It's our fault, and we've made a note of it."
-msgstr ""
-"Te połączenie się nie powiodło. To nasza wina, zarejesterowaliśmy ten "
-"błąd."
-
-#: view.html:121
-msgid "Website"
-msgstr "Strona internetowa"
-
-#: view.html:127
-msgid "Location"
-msgstr "Lokalizaja"
-
-#: authors.html:117 openlibrary/templates/subjects.html:19 view.html:17
-#: view.html:134
-#, python-format
-msgid "1 work"
-msgid_plural "%(count)d works"
-msgstr[0] "1 praca"
-msgstr[1] "%(count)d prace"
-
-#: view.html:135
-msgid "Add another?"
-msgstr "Dodać kolejną?"
-
-#: openlibrary/templates/work_search.html:106 view.html:139
-msgid "Sorting by"
-msgstr "Sortuj"
-
-#: openlibrary/templates/work_search.html:108
-#: openlibrary/templates/work_search.html:110
-#: openlibrary/templates/work_search.html:112
-#: openlibrary/templates/work_search.html:114 view.html:141 view.html:143
-#: view.html:145 view.html:147
-msgid "Most Editions"
-msgstr "Większość wydań"
-
-#: openlibrary/templates/work_search.html:108
-#: openlibrary/templates/work_search.html:110
-#: openlibrary/templates/work_search.html:112
-#: openlibrary/templates/work_search.html:114 view.html:141 view.html:143
-#: view.html:145 view.html:147
-msgid "First Published"
-msgstr "Data pierwszej publikacji"
-
-#: openlibrary/templates/work_search.html:108
-#: openlibrary/templates/work_search.html:110
-#: openlibrary/templates/work_search.html:112
-#: openlibrary/templates/work_search.html:114 view.html:141 view.html:143
-#: view.html:145 view.html:147
-msgid "Most Recent"
-msgstr "Najnowsze"
-
-#: add.html:24 advancedsearch.html:17 edit.html:20 edit.html:92
-#: nav_head.html:44 search_foot.html:8 search_head.html:8 view.html:147
-msgid "Title"
-msgstr "Tytuł"
-
-#: view.html:152
-#, fuzzy, python-format
-msgid ""
-"Showing all works by author. Would you like to see <a "
-"href=\"%(url)s\">only ebooks</a>?"
-msgstr ""
-"Wczytywanie wszystkich prac autora. Czy chesz zobaczyć <a "
-"href=\"%(url)s\">tylko e-booki</a>?"
-
-#: view.html:154
-#, fuzzy, python-format
-msgid ""
-"Showing ebooks only. Would you like to see <a "
-"href=\"%(url)s\">everything</a> by this author?"
-msgstr ""
-"Wczytywanie tylko e-booków. Czy chesz zobaczyć <a "
-"href=\"%(url)s\">wszystkie</a> prace tego autora?"
-
-#: nav_foot.html:27 nav_head.html:72 openlibrary/templates/subjects.html:9
-#: openlibrary/templates/work_search.html:123 view.html:136 view.html:190
-#: view.html:278 view.html:279
-msgid "Subjects"
-msgstr "Tematyka"
-
-#: openlibrary/templates/subjects.html:9
-#: openlibrary/templates/work_search.html:125 view.html:138 view.html:191
-#: view.html:280 view.html:281
-msgid "Places"
-msgstr "Miejsca"
-
-#: openlibrary/templates/subjects.html:9
-#: openlibrary/templates/work_search.html:124 view.html:137 view.html:192
-#: view.html:279 view.html:280
-msgid "People"
-msgstr "Ludzie"
-
-#: view.html:193
-msgid "Time"
-msgstr "Okres"
-
-#: view.html:202
-msgid "Links <span class=\"gray small sansserif\">(outside Open Library)</span>"
-msgstr "Linki <span class=\"gray small sansserif\">(spoza Open Library)</span>"
-
-#: view.html:221
-msgid "No links yet."
-msgstr "Nie ma jeszcze linków."
-
-#: view.html:221
-msgid "Add one"
-msgstr "Dodaj"
-
-#: view.html:228
-msgid "Alternative names"
-msgstr "Alternatywne nazwiska"
-
-#: edit.html:31 edit.html:33
-msgid "Document Body:"
-msgstr "Treść dokumentu:"
-
-#: view.html:160
-#, python-format
-msgid ""
-"<a href=\"%(url)s\"><strong>1 edition</strong></a> of <strong "
-"class=\"booktitle\">%(title)s</strong> found in the catalog."
-msgid_plural ""
-"<a href=\"%(url)s\"><strong>%(count)d editions</strong></a> of <strong "
-"class=\"booktitle\">%(title)s</strong> found in the catalog."
-msgstr[0] ""
-"<a href=\"%(url)s\"><strong>1 wydanie</strong></a><strong "
-"class=\"booktitle\">%(title)s</strong> w tym katalogu."
-msgstr[1] ""
-"<a href=\"%(url)s\"><strong>%(count)d wydania</strong></a><strong "
-"class=\"booktitle\">%(title)s</strong> w tym katalogu."
-
-#: editions.html:14 editions_datatable.html:13 view.html:162
-#, fuzzy, python-format
-msgid "Add another edition of %(work)s"
-msgstr "Dodaj kolejne wydanie %(worktitle)s"
-
-#: view.html:162
-#, fuzzy
-msgid "Add another edition?"
-msgstr "Dodaj kolejne wydanie"
-
-#: edit/edition.html:293 view.html:196
-msgid "Contributors"
-msgstr "Współtwórcy"
-
-#: book_cover.html:41 book_cover_single_edition.html:18
-#: book_cover_single_edition.html:36 book_cover_small.html:18
-#: book_cover_work.html:18 book_cover_work.html:32 check.html:32
-#: openlibrary/macros/SearchResultsWork.html:33
-#: openlibrary/templates/diff.html:42 show.html:16 view.html:216 view.html:245
-msgid "by"
-msgstr "autorstwa"
-
-#: view.html:241
-msgid "Published"
-msgstr "Opublikowana"
-
-#: view.html:248
-#, fuzzy, python-format
-msgid "Show other books from %(publisher)s"
-msgstr "Pokaż inne książki z %s"
-
-#: view.html:250
-#, fuzzy, python-format
-msgid "Search for other books from %(publisher)s"
-msgstr "Szukaj innych książek"
-
-#: view.html:253
-msgid "in"
-msgstr "w"
-
-#: view.html:255
-#, fuzzy, python-format
-msgid "Search for subjects about %(place)s"
-msgstr "Szukaj tematów związanych z"
-
-#: view.html:263
-#, fuzzy, python-format
-msgid "Written in %(language)s"
-msgstr "Napisanych w %(lang)s"
-
-#: openlibrary/templates/subjects.html:9
-#: openlibrary/templates/work_search.html:126 view.html:139 view.html:281
-#: view.html:282
-msgid "Times"
-msgstr "Okres"
-
-#: view.html:288
-msgid "About the Edition"
-msgstr "O tym wydaniu"
-
-#: view.html:115 view.html:291
-msgid "About the Book"
-msgstr "O tej książce"
-
-#: view.html:107 view.html:295
-#, python-format
-msgid ""
-"There's no description for this book yet. Can you <b><a "
-"href='%(url)s'>add one</a></b>?"
-msgstr ""
-"Ta książka nie ma jeszcze opisu. Czy możesz <b><a href='%s'>dodać "
-"opis</a></b>?"
-
-#: view.html:112 view.html:298
-msgid "First Sentence"
-msgstr "Pierwsze zdanie"
-
-#: view.html:304
-msgid "Table of Contents"
-msgstr "Spis treści"
-
-#: view.html:322
-msgid "Edition Notes"
-msgstr "Uwagi do wydania"
-
-#: view.html:327
-msgid "Series"
-msgstr "Seria"
-
-#: view.html:328
-msgid "Volume"
-msgstr "Tom"
-
-#: view.html:329
-msgid "Genre"
-msgstr "Gatunek literacki"
-
-#: view.html:330
-msgid "Other Titles"
-msgstr "Podobe tytuły"
-
-#: view.html:331
-msgid "Copyright Date"
-msgstr "Data nadania praw autorskich"
-
-#: view.html:332
-msgid "Translation Of"
-msgstr "Tłumacznie"
-
-#: view.html:333
-msgid "Translated From"
-msgstr "Przetłumaczono z"
-
-#: edit/edition.html:522 view.html:182 view.html:340
-msgid "Classifications"
-msgstr "Klasyfikacje"
-
-#: edit/edition.html:579 view.html:350
-msgid "The Physical Object"
-msgstr "Obiekt fizyczny"
-
-#: view.html:351
-msgid "Format"
-msgstr "Format"
-
-#: view.html:352
-msgid "Pagination"
-msgstr "Paginacja"
-
-#: view.html:353
-msgid "Number of pages"
-msgstr "Liczba stron"
-
-#: edit/edition.html:630 view.html:354
-msgid "Dimensions"
-msgstr "Wymiary"
-
-#: view.html:355
-msgid "Weight"
-msgstr "Waga"
-
-#: edit/edition.html:448 view.html:361
-msgid "ID Numbers"
-msgstr "Numery indentyfikacyjne"
-
-#: view.html:385
-#, python-format
-msgid "This book was generously donated by %(donor)s"
-msgstr ""
-
-#: view.html:387
-#, fuzzy
-msgid "This book was generously donated anonymously"
-msgstr "Ten dokument był ostatnio edytowany anonimowo"
-
-#: view.html:392
-msgid "Learn more about Book Sponsorship"
-msgstr ""
-
-#: edit.html:14
-#, fuzzy
-msgid "Edit List"
-msgstr "Usuń listę"
-
-#: edit.html:25
-#, fuzzy
-msgid "Label"
-msgstr "miejsce"
-
-#: edit.html:34 edit.html:54
-msgid "Description"
-msgstr "Opis"
-
-#: embed.html:17 home.html:48 preview.html:23 snippet.html:18 view.html:32
-#, python-format
-msgid "1 seed"
-msgid_plural "%(count)d seeds"
-msgstr[0] "1 plik inicujuący"
-msgstr[1] "%(count)d pliki inicujuące"
-
-#: embed.html:22
-#, fuzzy
-msgid "Visit Open Library"
-msgstr "Open Library"
-
-#: embed.html:22
-#, fuzzy
-msgid "Open Library logo"
-msgstr "Open Library"
-
-#: books.html:89 embed.html:27 home.html:7 home.html:10 index.html:40
-#: lists.html:10 nav_head.html:48 nav_head.html:73 search_head.html:70
-#: view.html:31 view.html:42 view.html:60 widget.html:234
-msgid "Lists"
-msgstr "Listy"
-
-#: embed.html:41 view.html:165
-#, fuzzy
-msgid "Unknown authors"
-msgstr "Nieznany autor"
-
-#: embed.html:67
-msgid ""
-"Open in online Book Reader. Downloads available in ePub, DAISY, PDF, TXT "
-"formats from main book page"
-msgstr ""
-
-#: custom_carousel.html:47 custom_carousel.html:52 editions_datatable.html:23
-#: embed.html:69 openlibrary/macros/ReadButton.html:13
-#: openlibrary/templates/widget.html:33 show.html:34
-msgid "Read"
-msgstr "Przeczytaj"
-
-#: embed.html:73
-msgid "This book is checked out"
-msgstr ""
-
-#: embed.html:75
-msgid "Checked out"
-msgstr ""
-
-#: embed.html:78
-#, fuzzy
-msgid "Borrow book"
-msgstr "Wypożycz teraz"
-
-#: custom_carousel.html:44 custom_carousel.html:50 embed.html:80
-#: openlibrary/macros/ReadButton.html:9 openlibrary/templates/widget.html:38
-msgid "Borrow"
-msgstr "Wypożycz"
-
-#: embed.html:83 view.html:228 view.html:242
-msgid "Protected DAISY"
-msgstr ""
-
-#: embed.html:85 openlibrary/macros/DownloadOptions.html:27
-msgid "DAISY"
-msgstr ""
-
-#: embed.html:100 view.html:215
-#, fuzzy, python-format
-msgid "by %(name)s"
-msgstr " autorstwa %(name)s"
-
-#: embed.html:113 view.html:222
-#, fuzzy, python-format
-msgid "- 1 edition"
-msgid_plural "- %(count)s editions"
-msgstr[0] "1 wydanie"
-msgstr[1] "(count)s wydań"
-
-#: embed.html:115 view.html:224
-#, fuzzy, python-format
-msgid "- 1 work"
-msgid_plural "- %(count)s works"
-msgstr[0] "1 praca"
-msgstr[1] "%(count)d prace"
-
-#: exports.html:30
-#, fuzzy
-msgid "Export"
-msgstr "Tekst"
-
-#: exports.html:31
-#, python-format
-msgid "as %(json_link)s, %(html_link)s, or %(bibtex_link)s"
-msgstr ""
-
-#: exports.html:35 exports.html:55
-msgid "Subscribe"
-msgstr ""
-
-#: exports.html:36 exports.html:56
-#, python-format
-msgid "Watch activity via <a rel=\"nofollow\" href=\"%s\">Atom feed</a>"
-msgstr ""
-
-#: exports.html:43
-msgid "Export Not Available"
-msgstr ""
-
-#: exports.html:48
-#, python-format
-msgid ""
-"Only lists with up to %(max)s editions can be exported. This one has "
-"%(count)s."
-msgstr ""
-
-#: exports.html:50
-#, python-format
-msgid ""
-"Try removing some seeds for more focus, or look at <a href=\"%s\">bulk "
-"download</a> of the catalog."
-msgstr ""
-
-#: view.html:8
-#, fuzzy, python-format
-msgid "%(name)s | Lists | Open Library"
-msgstr "%(page_title)s | Open Library"
-
-#: view.html:14
-#, fuzzy, python-format
-msgid "%(title)s: %(description)s"
-msgstr "%(title)s: %(subtitle)s"
-
-#: view.html:21
-#, fuzzy
-msgid "View the list on Open Library."
-msgstr "Zobacz wszystkich odwiedzających OpenLibrary.org"
-
-#: view.html:105 view.html:136
-msgid "Yes, I'm sure"
-msgstr ""
-
-#: view.html:123 view.html:145
-#, fuzzy
-msgid "No, cancel"
-msgstr "Anuluj"
-
-#: view.html:156
-#, fuzzy
-msgid "Remove seed"
-msgstr "Usunąć ten plik inicujuący?"
-
-#: view.html:156
-#, fuzzy
-msgid "Are you sure you want to remove this item from the list?"
-msgstr "Czy na pewno chcesz usunąć tę listę?"
-
-#: view.html:157
-#, fuzzy
-msgid "Remove Seed"
-msgstr "Usunąć ten plik inicujuący?"
-
-#: view.html:158
-msgid ""
-"You are about the remove the last item in the list. That will delete the "
-"whole list. Are you sure you want to continue?"
-msgstr ""
-
-#: view.html:220
-#, python-format
-msgid "- <a href=\"%(url)s\">1 edition</a> in catalog"
-msgid_plural "- <a href=\"%(url)s\">%(count)s editions</a> in catalog"
-msgstr[0] ""
-msgstr[1] ""
-
-#: view.html:228
-msgid "Download DAISY eBook for print disabled"
-msgstr ""
-
-#: view.html:232
-#, python-format
-msgid "Last updated <span>%(date)s</span>"
-msgstr ""
-
-#: view.html:239
-#, fuzzy
-msgid "Remove this item?"
-msgstr "Usunąć ten plik inicujuący?"
-
-#: openlibrary/macros/SearchResultsWork.html:60 view.html:246
-msgid "Download DAISY"
-msgstr "Pobierz DAISY"
-
-#: view.html:259
-#, fuzzy
-msgid "List Metadata"
-msgstr "Dodatkowe metadane"
-
-#: view.html:260
-msgid "Derived from seed metadata"
-msgstr ""
-
-#: edit.html:9
-#, python-format
-msgid "Edit %(title)s"
-msgstr "Edytuj %(title)s"
-
-#: edit.html:28
-msgid "Currently Editing:"
-msgstr "Obecnie edytujesz: "
-
-#: edit.html:40
-msgid "Display Name"
-msgstr "Wyświetl nazwę"
-
-#: view.html:20
-#, python-format
-msgid "Joined %(date)s"
-msgstr "Dołączył\\(a\\) %(date)s"
-
-#: nav_head.html:123 notifications.html:13 openlibrary/templates/account.html:7
-#: openlibrary/templates/account.html:12 privacy.html:13 search_head.html:71
-#: view.html:23
+#: account.html account/notifications.html account/privacy.html lib/nav_head.html type/user/view.html
 msgid "Settings"
 msgstr "Ustawienia"
 
-#: search_head.html:69 view.html:25
-msgid "Loans"
-msgstr "Wypożyczone"
-
-#: view.html:28
-msgid "admin page"
-msgstr "strona administratora"
-
-#: books.html:53 books.html:76 view.html:46
-msgid "Reading Log"
-msgstr "Dziennik Lektur"
-
-#: view.html:48
-#, fuzzy, python-format
-msgid ""
-"This user has chosen to publicly share the books they are <a "
-"href=\"%(username)s/books/currently-reading\">currently reading</a>, <a "
-"href=\"%(username)s/books/already-read\">have already read</a>, and <a "
-"href=\"%(username)s/books/want-to-read\">want to read</a>!"
-msgstr ""
-"Ten użytkownik postanowił publicznie udostępnić książki, które <a "
-"href=\"$(page.key)/books/currently-reading\">obecnie czyta</a>, <a "
-"href=\"$(page.key)/books/already-read\">przeczytał\\(a\\)</a> oraz<a "
-"href=\"$(page.key)/books/want-to-read\">chce przeczytać</a>!"
-
-#: view.html:50
-msgid "This user has chosen to keep their Reading Log private"
-msgstr "Ten użytkownik postanowił nie udostępniać swojego Dziennika Lektur"
-
-#: home.html:63 view.html:61
-msgid "See all"
-msgstr "Zobacz wszystkie"
-
-#: home.html:62 lists.html:113 view.html:75
-msgid "Recent Activity"
-msgstr "Ostatnia aktywność"
-
-#: view.html:78
-msgid "No edits. Yet."
-msgstr "Brak zmian. Jak na razie."
-
-#: editions.html:11 editions_datatable.html:10
-#, python-format
-msgid "First published in %(year)s"
-msgstr "Po raz pierwszy opublikowana w %(year)s"
-
-#: editions.html:14 editions_datatable.html:13
-#: openlibrary/macros/UserEditRow.html:25
-msgid "Add another"
-msgstr "Dodaj kolejną"
-
-#: editions.html:17 openlibrary/templates/work_search.html:271
+#: account.html
 #, fuzzy
-msgid "Merge duplicates"
-msgstr "Duplikaty"
+msgid "Settings & Privacy"
+msgstr "Ustawienia"
 
-#: editions.html:27
-#, fuzzy, python-format
-msgid "Cover of: %(title)s"
-msgstr "Okładka : %(listname)s"
+#: account.html databarDiff.html
+msgid "View"
+msgstr "Wyświetl"
 
-#: editions.html:36
-#, fuzzy, python-format
-msgid "Publish date unknown"
-msgstr "Data publikacji nieznana, %s"
+#: account.html status.html
+msgid "or"
+msgstr "lub"
 
-#: edition-sort.html:58 editions.html:38 works-show.html:30
-msgid "Publisher unknown"
-msgstr "Wydawnictwo nieznane"
+#: account.html databarHistory.html databarTemplate.html databarView.html my_books/check_ins/check_in_prompt.html reading_goals/reading_goal_progress.html subjects.html type/edition/compact_title.html type/user/view.html
+msgid "Edit"
+msgstr "Edytuj"
 
-#: editions.html:43
-#, fuzzy
-msgid "Title missing"
-msgstr "brakuje imienia"
+#: account.html
+msgid "Your Profile Page"
+msgstr "Twój profil"
 
-#: editions.html:47
-#, fuzzy, python-format
-msgid "in %(language)s"
-msgstr "opublikowane w językach %(languagelist)s"
+#: account.html
+msgid "View or Edit your Reading Log"
+msgstr "Wyświetl lub edytuj Dziennik Lektur"
 
-#: authors.html:110 check.html:36 editions_datatable.html:8
-#: openlibrary/macros/SearchResultsWork.html:42
-#: openlibrary/templates/subjects.html:128 preview.html:24 view.html:27
-#: view.html:70 view.html:161
-#, python-format
-msgid "1 edition"
-msgid_plural "%(count)s editions"
-msgstr[0] "1 wydanie"
-msgstr[1] "(count)s wydań"
+#: account.html
+msgid "View or Edit your Lists"
+msgstr "Wyświetl lub edytuj Twoje Listy"
 
-#: editions_datatable.html:22
-msgid "Edition"
-msgstr "Wydawnictwo"
-
-#: editions_datatable.html:24
-msgid "Locate"
-msgstr "Zlokalizuj"
-
-#: editions_datatable.html:45
-msgid "Merge editions"
-msgstr "Połącz wydania"
-
-#: edition-sort.html:44 view.html:21
-#, python-format
-msgid "%(title)s: %(subtitle)s"
-msgstr "%(title)s: %(subtitle)s"
-
-#: view.html:23
-#, fuzzy, python-format
-msgid "%(title)s by %(author)s"
-msgstr "%(title)s autorstwa %(authorlist)s"
-
-#: check.html:38 view.html:30
-#, python-format
-msgid "First published in %(year)d"
-msgstr "Pierwsze wydanie w %(year)d"
-
-#: view.html:34
-#, python-format
-msgid "Subjects: %(subjectlist)s"
-msgstr "Tematyka: %(subjectlist)s"
-
-#: view.html:36
-#, python-format
-msgid "Places: %(placelist)s"
-msgstr "Miejsca: %(placelist)s"
-
-#: view.html:38
-#, python-format
-msgid "People: %(peoplelist)s"
-msgstr "Ludzie: %(peoplelist)s"
-
-#: view.html:40
-#, python-format
-msgid "Times: %(timelist)s"
-msgstr "Okres: %(timelist)s"
-
-#: view.html:57
-msgid "Add to Staff Picks"
-msgstr "Dodaj do Wyboranych przez nas"
-
-#: view.html:76
-#, fuzzy, python-format
-msgid "By %(author)s"
-msgstr " autorstwa %(name)s"
-
-#: view.html:78
-msgid "By <em>unknown author</em>"
-msgstr "<em>autor nieznany</em>"
-
-#: view.html:82
-#, fuzzy
-msgid "Go to the editions section to read or download ebooks."
-msgstr "Przejdź do sekcji wydań by przeczytać lub pobrać e-booki"
-
-#: view.html:119
-msgid "Original languages"
-msgstr "Języki oryginału"
-
-#: view.html:143
-msgid "Excerpts"
-msgstr "Fragmenty"
-
-#: view.html:152
-#, python-format
-msgid "Page %(page)s"
+#: account.html
+msgid "Import and Export Options"
 msgstr ""
 
-#: view.html:159
-#, fuzzy, python-format
-msgid "added by %(authorlink)s."
-msgstr "%(title)s autorstwa %(authorlist)s"
-
-#: view.html:161
+#: account.html
 #, fuzzy
-msgid "added anonymously."
-msgstr "dodana anonimowo"
-
-#: view.html:173
-msgid "Wikipedia"
-msgstr "Wikipedia"
-
-#: view.html:185
-msgid "Library of Congress"
-msgstr "Biblioteka Kongresu"
-
-#: view.html:188
-msgid "Dewey"
-msgstr "Dewey"
-
-#: books.html:15 nav_head.html:78 nav_head.html:79
-msgid "My Books"
-msgstr "Moje książki"
-
-#: books.html:27 widget.html:110
-msgid "Currently Reading"
-msgstr "W trakcie czytania"
-
-#: books.html:28
-#, python-format
-msgid "Books %(username)s is reading"
-msgstr "Książki, które obecnie czyta %(username)s"
-
-#: books.html:29
-#, python-format
-msgid ""
-"%(username)s is reading %(total)d books. Join %(username)s on "
-"OpenLibrary.org and tell the world what you're reading."
-msgstr ""
-"%(username)s czyta %(total)d książek. Dołącz do %(username)s na "
-"OpenLibrary.org i powiedz światu, co czytasz."
-
-#: books.html:31
-#, fuzzy
-msgid "Want To Read"
-msgstr "Chcę przeczytać"
-
-#: books.html:32
-#, python-format
-msgid "Books %(username)s wants to read"
-msgstr "Książki, które %(username)s chce przeczytać"
-
-#: books.html:33
-#, python-format
-msgid ""
-"%(username)s wants to read %(total)d books. Join %(username)s on "
-"OpenLibrary.org and share the books that you'll soon be reading!"
-msgstr ""
-"%(username)s chce przeczytać %(total)d książek. Dołącz do %(username)s na"
-" OpenLibrary.org i pokaż światu, co będziesz wkrótce czytać!"
-
-#: books.html:35 widget.html:108 widget.html:171
-msgid "Already Read"
-msgstr "Przeczytane"
-
-#: books.html:36
-#, python-format
-msgid "Books %(username)s has read"
-msgstr "Książki przeczytane przez %(username)s"
-
-#: books.html:37
-#, python-format
-msgid ""
-"%(username)s has read %(total)d books. Join %(username)s on "
-"OpenLibrary.org and tell the world about the books that you care about."
-msgstr ""
-"%(username)s przeczytał\\(a\\) %(total)d książek. Dołącz do %(username)s "
-"na OpenLibrary.org i powiedz światu o książkach, które są dla Ciebie "
-"ważne."
-
-#: books.html:39 books.html:84
-msgid "Sponsorships"
-msgstr "Sponsoring"
-
-#: books.html:40
-#, python-format
-msgid "Books %(userdisplayname)s is sponsoring"
-msgstr "Książki sponsorowane przez %(userdisplayname)s"
-
-#: books.html:65
-msgid "Your reading log is currently set to public"
-msgstr "Twój dziennik lektur jest obecnie udostępiniony publicznie"
-
-#: books.html:68
-msgid "Your reading log is currently set to private"
-msgstr "Twój dziennik lektur jest obecnie niewidoczny dla innych"
-
-#: books.html:70
-msgid "Manage your privacy settings"
+msgid "Manage Privacy & Content Moderation Settings"
 msgstr "Zarządzaj swoimi ustawieniami prywatności"
 
-#: books.html:77
-#, python-format
-msgid "Currently Reading (%(count)d)"
-msgstr "Obcenie czyta (%(count)d)"
-
-#: books.html:78
-#, python-format
-msgid "Want to Read (%(count)d)"
-msgstr "Chce przeczytać (%(count)d)"
-
-#: books.html:79
-#, python-format
-msgid "Already Read (%(count)d)"
-msgstr "Przeczytał\\(a\\) (%(count)d)"
-
-#: books.html:116
-msgid "No books are on this shelf"
-msgstr "Ta półka jest pusta"
-
-#: borrow.html:7 borrow.html:72
-msgid "Books You've Checked Out"
-msgstr "Książki, które zaznaczyłeś"
-
-#: borrow.html:52
-msgid ""
-"You have 5 ebooks out at the moment. That's the limit! You can free up "
-"slots by returning books early."
-msgstr ""
-"Obecnie masz 5 ebooków. To maksymalna dozwolona ilość! Możesz wypożyczyć "
-"więcej e-booków kiedy zwrócisz obecnie wypożyczone."
-
-#: borrow.html:74
-msgid "You've not checked out any books at this moment."
-msgstr "Obecnie nie masz zaznaczonych żadnych książek."
-
-#: borrow.html:83
-msgid "1 Current Loan"
-msgstr "1 obecnie wypożyczona"
-
-#: borrow.html:85
-#, fuzzy, python-format
-msgid "%(count)d Current Loans"
-msgstr "Obecnie wypożyczone"
-
-#: borrow.html:87
-msgid "Loan Expires"
-msgstr "Termin zwrotu"
-
-#: borrow.html:88
-msgid "Loan actions"
-msgstr "Wypożycz..."
-
-#: borrow.html:115
-#, python-format
-msgid "There is one person waiting for this book."
-msgid_plural "There are %(n)d people waiting for this book."
-msgstr[0] "Jedna osoba oczekuje na wypożyczenie tej książki."
-msgstr[1] "%(n)d osób oczekuje na wypożyczenie tej książki."
-
-#: borrow.html:121
-msgid "Not yet downloaded."
-msgstr "Jeszcze nie pobrana."
-
-#: borrow.html:122
-msgid "Download Now"
-msgstr "Pobierz"
-
-#: borrow.html:131
-msgid "Return via<br/>Adobe Digital Editions"
-msgstr "Zwróć przez<br/>Adobe Digital Editions"
-
-#: borrow.html:140
-msgid "How To Return eBooks through Adobe Digital Editions"
-msgstr ""
-
-#: borrow.html:142
+#: account.html
 #, fuzzy
-msgid "Open Adobe Digital Editions"
-msgstr "Pobierz Adobe Digital Editions"
+msgid "Manage Notifications Settings"
+msgstr "Zarządzaj swoimi ustawieniami prywatności"
 
-#: borrow.html:143
-msgid "Click the Library icon at the upper left corner"
+#: account.html
+msgid "Manage Mailing List Subscriptions"
 msgstr ""
 
-#: borrow.html:144
-msgid "Move your mouse over the cover of the eBook you wish to return"
-msgstr ""
+#: account.html
+msgid "Change Password"
+msgstr "Zmień hasło"
 
-#: borrow.html:145
-msgid "Find the arrow at the upper left of the cover and open the eBook menu"
-msgstr ""
+#: account.html
+msgid "Update Email Address"
+msgstr "Zaktualizuj adres e-mail"
 
-#: borrow.html:146
-msgid "Click \"Return Borrowed Item\""
-msgstr ""
-
-#: borrow.html:147
-msgid "Click \"Return\" to confirm"
-msgstr ""
-
-#: borrow.html:148
+#: account.html
 #, fuzzy
-msgid "Done!"
-msgstr "Dodaj"
+msgid "Deactivate Account"
+msgstr "Usuń konto"
 
-#: borrow.html:153
-msgid "Books You're Waiting For"
-msgstr "Książki, na które czekasz"
+#: account.html
+msgid "Please contact us if you need help with anything else."
+msgstr "Skontaktuj się z nami, jeśli potrzebujesz pomocy w innej sprawie."
 
-#: borrow.html:156
-msgid "You are not waiting for any books at this moment."
-msgstr "Obecnie nie czekasz na żadne książki"
-
-#: borrow.html:159
-msgid "Leave the Waiting List"
-msgstr "Opuść Listę Oczekujących"
-
-#: borrow.html:159
-msgid ""
-"Are you sure you want to leave the waiting list "
-"of<br/><strong>TITLE</strong>?"
+#: barcodescanner.html
+msgid "Barcode Scanner (Beta)"
 msgstr ""
-"Na pewno chcesz opuścić listę oczekujących "
-"na<br/><strong>%(title)s</strong>?"
 
-#: authors.html:66 borrow.html:176 openlibrary/templates/subjects.html:95
-#: subjects.html:89 view.html:131
+#: batch_import.html
+#, fuzzy
+msgid "Batch Imports"
+msgstr "Autorzy"
+
+#: BatchImportNavigation.html batch_import.html
+msgid "New Batch Import"
+msgstr ""
+
+#: batch_import.html
+msgid "Attach a JSONL formatted document with import records or copy/paste the JSONL text into the textarea."
+msgstr ""
+
+#: batch_import.html
+msgid "See the <a href=\"https://github.com/internetarchive/openlibrary-client/tree/master/olclient/schemata\">olclient import schemata</a> for more."
+msgstr ""
+
+#: batch_import.html
+msgid "Attach a file:"
+msgstr ""
+
+#: batch_import.html
+msgid "Or copy/paste JSONL text:"
+msgstr ""
+
+#: batch_import.html import_preview.html
+#, fuzzy
+msgid "Import"
+msgstr "Tekst"
+
+#: batch_import.html
+#, fuzzy
+msgid "Import failed."
+msgstr "Nie udało się ustawić nowego hasła."
+
+#: batch_import.html
+msgid "No import will be queued until *every* record validates successfully."
+msgstr ""
+
+#: batch_import.html
+msgid "Please update the JSONL file and reload this page (there should be no need to reattach the file)."
+msgstr ""
+
+#: batch_import.html
+msgid "Validation errors:"
+msgstr ""
+
+#: batch_import.html
 #, python-format
-msgid "1 book"
-msgid_plural "%(count)d books"
-msgstr[0] "1 książka"
-msgstr[1] "%(count)s książek"
+msgid "Line %d:"
+msgstr ""
 
-#: borrow.html:178
+#: batch_import.html
+msgid "Import results for batch:"
+msgstr ""
+
+#: batch_import.html
+msgid "Records submitted:"
+msgstr ""
+
+#: batch_import.html
+msgid "Total queued:"
+msgstr ""
+
+#: batch_import.html
+msgid "Total skipped:"
+msgstr ""
+
+#: batch_import.html
+msgid "Not queued because they are already present in the queue:"
+msgstr ""
+
+#: batch_import.html
+msgid "View Batch Status"
+msgstr ""
+
+#: batch_import_pending_view.html
+msgid "Pending Batch Imports"
+msgstr ""
+
+#: batch_import_pending_view.html
+msgid "batch_id"
+msgstr ""
+
+#: admin/imports.html admin/imports_by_date.html batch_import_pending_view.html batch_import_view.html
+#, fuzzy
+msgid "Added Time"
+msgstr "Dodano"
+
+#: account/import.html account/loans.html admin/imports.html admin/imports_by_date.html admin/loans_table.html admin/menu.html batch_import_pending_view.html batch_import_view.html librarian_dashboard/data_quality_table.html status.html
 msgid "Status"
 msgstr "Status"
 
-#: borrow.html:179
+#: batch_import_pending_view.html batch_import_view.html merge_request_table/table_header.html
+#, fuzzy
+msgid "Submitter"
+msgstr "Zatwierdź"
+
+#: RecentChangesAdmin.html batch_import_pending_view.html batch_import_view.html
+#, fuzzy
+msgid "Comments"
+msgstr "Komentarz"
+
+#: batch_import_view.html
+msgid "Batch Import Status"
+msgstr ""
+
+#: batch_import_view.html
+msgid "Batch ID:"
+msgstr ""
+
+#: batch_import_view.html
+#, fuzzy
+msgid "Batch Name:"
+msgstr "Nazwa:"
+
+#: batch_import_view.html
+#, fuzzy
+msgid "Submitter:"
+msgstr "Zatwierdź"
+
+#: batch_import_view.html
+#, fuzzy
+msgid "Submit Time:"
+msgstr "Zatwierdź"
+
+#: batch_import_view.html
+#, fuzzy
+msgid "Status Summary"
+msgstr "Status"
+
+#: batch_import_view.html
+#, fuzzy
+msgid "Approve"
+msgstr "Usuń"
+
+#: batch_import_view.html
+msgid "Import Items"
+msgstr ""
+
+#: batch_import_view.html
+msgid "Import Time"
+msgstr ""
+
+#: account/import.html admin/imports.html admin/imports_by_date.html batch_import_view.html librarian_dashboard/data_quality_table.html
+msgid "Error"
+msgstr ""
+
+#: batch_import_view.html
+msgid "IA ID"
+msgstr ""
+
+#: batch_import_view.html
+#, fuzzy
+msgid "Data"
+msgstr "Dorzuć się"
+
+#: admin/imports.html admin/imports_by_date.html batch_import_view.html
+msgid "OL Key"
+msgstr ""
+
+#: batch_import_view.html
+#, fuzzy
+msgid "Not yet imported"
+msgstr "Jeszcze nie pobrana."
+
+#: diff.html
+#, python-format
+msgid "Diff on %s"
+msgstr "Różnica na %s"
+
+#: diff.html
+#, python-format
+msgid "Revision %d"
+msgstr "Korekta %d"
+
+#: books/check.html covers/book_cover.html diff.html jsdef/LazyWorkPreview.html
+msgid "by"
+msgstr "autorstwa"
+
+#: diff.html
+msgid "by Anonymous"
+msgstr "Anoninowo"
+
+#: diff.html
+#, fuzzy
+msgid "history"
+msgstr "Historia"
+
+#: diff.html status.html
+msgid "Added"
+msgstr "Dodano"
+
+#: admin/imports_by_date.html diff.html
+msgid "Modified"
+msgstr "Zmieniono"
+
+#: diff.html
+msgid "Removed"
+msgstr "Usunięto"
+
+#: diff.html
+msgid "Not changed"
+msgstr "Nie zmnieniono"
+
+#: diff.html
+msgid "Differences"
+msgstr "Różnice"
+
+#: diff.html
+msgid "Both the revisions are identical."
+msgstr "Obydwie korekty są identyczne."
+
+#: edit_yaml.html lib/edit_head.html
+msgid "You're in edit mode."
+msgstr "Jesteś w trybie edycji."
+
+#: edit_yaml.html lib/edit_head.html
+msgid "Cancel, and go back."
+msgstr "Anuluj i wróć."
+
+#: edit_yaml.html
+msgid "YAML Representation:"
+msgstr ""
+
+#: BookPreview.html book_providers/read_button.html books/edit/edition.html editpage.html import_preview.html
+msgid "Preview"
+msgstr ""
+
+#: history.html
+msgid "History of edits to"
+msgstr "Historia zmian"
+
+#: history.html
+msgid "Revision"
+msgstr "Korekta"
+
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html admin/ip/view.html admin/people/edits.html history.html recentchanges/render.html recentchanges/updated_records.html
+msgid "When"
+msgstr "Kiedy"
+
+#: RecentChanges.html admin/history.html admin/ip/view.html admin/loans_table.html admin/people/edits.html history.html recentchanges/render.html
+msgid "Who"
+msgstr "Kto"
+
+#: RecentChanges.html RecentChangesUsers.html admin/history.html admin/ip/view.html admin/people/edits.html history.html recentchanges/render.html recentchanges/updated_records.html
+msgid "Comment"
+msgstr "Komentarz"
+
+#: history.html
+msgid "Diff"
+msgstr "Różnica"
+
+#: history.html
+msgid "Compare"
+msgstr "Porównaj"
+
+#: history.html
+msgid "See Diff"
+msgstr "Zobacz różnice"
+
+#: history.html lib/history.html
+#, python-format
+msgid "View revision %s"
+msgstr "Zobacz korekty %s"
+
+#: history.html
+msgid "Compare this version..."
+msgstr ""
+
+#: history.html
+#, fuzzy
+msgid "...to this version"
+msgstr "Te wydanie"
+
+#: import_preview.html
+msgid "Import Preview"
+msgstr ""
+
+#: import_preview.html
+#, fuzzy
+msgid "Preview Import"
+msgstr "Wypożycz teraz"
+
+#: import_preview.html
+msgid "Show Raw Import Data"
+msgstr ""
+
+#: import_preview.html
+#, python-format
+msgid "New %(thing_type)s record will be created"
+msgstr ""
+
+#: import_preview.html
+#, python-format
+msgid "Changes to %(key)s"
+msgstr ""
+
+#: internalerror.html
+msgid "Internal Error"
+msgstr ""
+
+#: internalerror.html
+msgid "A Problem Occurred"
+msgstr ""
+
+#: internalerror.html
+msgid "We're sorry, a problem occurred while responding to your request:"
+msgstr ""
+
+#: internalerror.html
+#, python-format
+msgid "The reference code %s and Sentry trace ID %s have been created to track this error and we will investigate as we're able."
+msgstr ""
+
+#: internalerror.html
+#, python-format
+msgid "The reference code %s has been created to track this error and we will investigate as we're able."
+msgstr ""
+
+#: internalerror.html
+msgid "Return to the <a class=\"go-back-link\" href=\"javascript:;\">previous page</a>?"
+msgstr ""
+
+#: interstitial.html
+msgid "You are being redirected to your book"
+msgstr ""
+
+#: interstitial.html
+#, python-format
+msgid "This book is provided by %(book_provider)s, a third-party Open Library Trusted Book Provider"
+msgstr ""
+
+#: interstitial.html
+#, python-format
+msgid "In %(time)s seconds, you will be automatically redirected to: %(url)s"
+msgstr ""
+
+#: CreateListModal.html EditButtons.html account/notifications.html account/password/reset.html account/privacy.html admin/imports-add.html admin/permissions.html books/add.html databarEdit.html interstitial.html merge/authors.html my_books/dropdown_content.html type/list/edit.html type/series/edit.html type/tag/form.html
+msgid "Cancel"
+msgstr "Anuluj"
+
+#: interstitial.html
+msgid "Continue without waiting"
+msgstr ""
+
+#: lib/nav_head.html library_explorer.html
+#, fuzzy
+msgid "Library Explorer"
+msgstr "Biblioteka Kongresu"
+
+#: account/create.html books/custom_carousel.html librarian_dashboard/data_quality_table.html login.html search/work_search_facets.html
+#, fuzzy
+msgid "Loading..."
+msgstr "zapisywanie..."
+
+#: lib/header_dropdown.html lib/nav_head.html login.html
+msgid "Log In"
+msgstr "Zaloguj się"
+
+#: login.html
+msgid "This is a development instance, the default credentials are automatically filled."
+msgstr ""
+
+#: login.html
+#, fuzzy
+msgid "email:"
+msgstr "E-mail"
+
+#: login.html
+#, fuzzy
+msgid "password:"
+msgstr "Hasło"
+
+#: login.html
+msgid "Log in to use your free Open Library card to borrow digital books from the nonprofit Internet Archive"
+msgstr ""
+
+#: account/create.html login.html
+#, fuzzy
+msgid "OR"
+msgstr "lub"
+
+#: account/create.html login.html
+#, python-format
+msgid "You are already logged into Open Library as %(user)s."
+msgstr "Jeśteś już zarejestrowany w Open Library jako %(user)s."
+
+#: account/create.html login.html
+#, fuzzy
+msgid "If you'd like to create a new, different Open Library account, you'll need to <a href=\"javascript:;\" onclick=\"document.forms['hamburger-logout'].submit()\">log out</a> and start the signup process afresh."
+msgstr "Jeśli chcesz utworzyć nowe konto na Open Library <a href=\"javascript:;\" onclick=\"document.forms['logout'].submit()\">Wyloguj się</a> i utwórz nowe konto."
+
+#: login.html
+msgid "Please enter your <a href=\"https://archive.org\">Internet Archive</a> email and password to access your Open Library account."
+msgstr "Wprowadź swój <a href=\"https://archive.org\">Internet Archive</a> e-mail i hasło umożliwiające dostęp do konta Open Library."
+
+#: login.html openlibrary/plugins/upstream/forms.py
+msgid "Email"
+msgstr "E-mail"
+
+#: login.html
+msgid "Forgot your Internet Archive email?"
+msgstr "Nie pamiętasz e-maila z Internet Archive?"
+
+#: account/email/forgot-ia.html login.html openlibrary/plugins/upstream/forms.py
+msgid "Password"
+msgstr "Hasło"
+
+#: login.html
+msgid "Forgot your Password?"
+msgstr "Nie pamiętasz swojego hasła?"
+
+#: account/create.html login.html
+msgid "Toggle Password Visibility"
+msgstr ""
+
+#: login.html
+msgid "Remember me"
+msgstr "\"Zapamniętaj mnie"
+
+#: login.html
+#, fuzzy
+msgid "Don't have an account? <a href=\"/account/create\">Sign up now</a>."
+msgstr "Nie masz jeszcze konta na Open Library? <a href=\"/account/create\">Utwórz konto</a>."
+
+#: messages.html
+#, fuzzy
+msgid "Created new author record."
+msgstr "Utwórz nowy dokument dla"
+
+#: messages.html
+#, fuzzy
+msgid "Created new edition record."
+msgstr "Utwórz nowy dokument dla"
+
+#: messages.html
+#, fuzzy
+msgid "Created new work record."
+msgstr "Utwórz nowy dokument dla"
+
+#: messages.html
+#, fuzzy
+msgid "Added new book."
+msgstr "Dodaj książkę"
+
+#: messages.html
+msgid "Thank you for improving the Open Library catalog!"
+msgstr ""
+
+#: BookPreview.html CreateListModal.html NotesModal.html ObservationsModal.html ShareModal.html covers/author_photo.html covers/book_cover.html covers/change.html lib/exports.html my_books/check_ins/check_in_prompt.html my_books/dropdown_content.html native_dialog.html
+msgid "Close"
+msgstr "Zamknij"
+
+#: notfound.html
+#, python-format
+msgid "%(path)s is not found"
+msgstr ""
+
+#: languages/notfound.html notfound.html
+msgid "404 - Page Not Found"
+msgstr "404 - Strona nie istnieje"
+
+#: notfound.html
+#, python-format
+msgid "%(path)s does not exist."
+msgstr ""
+
+#: notfound.html
+msgid "Create it?"
+msgstr "Utworzyć?"
+
+#: notfound.html
+msgid "Looking for a template/macro?"
+msgstr ""
+
+#: permission.html
+#, python-format
+msgid "Permission of %(key)s"
+msgstr ""
+
+#: permission.html
+#, fuzzy
+msgid "Permission of"
+msgstr "Odmowa zezwolenia."
+
+#: permission.html
+#, fuzzy
+msgid "Permission"
+msgstr "osoba"
+
+#: permission.html
+#, fuzzy
+msgid "Child Permission"
+msgstr "brakuje imienia"
+
+#: permission_denied.html
+#, fuzzy
+msgid "Permission Denied"
+msgstr "Odmowa zezwolenia."
+
+#: permission_denied.html
+msgid "Permission denied."
+msgstr "Odmowa zezwolenia."
+
+#: permission_denied.html
+#, python-format
+msgid "Only logged users are allowed to add records on Open Library. Please <a href=\"%s\">log in</a> to add a book."
+msgstr ""
+
+#: permission_denied.html
+#, python-format
+msgid "Only logged users are allowed to modify records on Open Library. Please <a href=\"%s\">log in</a> to edit this page."
+msgstr ""
+
+#: permission_denied.html
+#, python-format
+msgid "You may <a href=\"%s\">log in</a> if you have the required permissions."
+msgstr "Możesz się <a href=\"%s\">zalogować</a> jeśli masz wymagane uprawnienia."
+
+#: recaptcha.html
+#, fuzzy
+msgid "Please satisfy the reCAPTCHA below. If you have security settings or privacy blockers installed, please disable them to see the reCAPTCHA."
+msgstr "Jeśli nie widzisz reCAPTCHA, wyłącz chwilowo ustawienia zabezpieczeń lub inne programy blokujące prywatność."
+
+#: recaptcha.html
+msgid "Incorrect. Please try again."
+msgstr ""
+
+#: showamazon.html showbwb.html showgoogle_books.html
+msgid "Record details of"
+msgstr ""
+
+#: showamazon.html showbwb.html showgoogle_books.html
+msgid "This record came from"
+msgstr ""
+
+#: showia.html showmarc.html
+#, fuzzy
+msgid "Record ID"
+msgstr "Pole wymagane"
+
+#: showia.html showmarc.html
+#, fuzzy
+msgid "Source"
+msgstr "więcej"
+
+#: books/add.html covers/add.html showia.html type/edition/view.html type/work/view.html
+msgid "Internet Archive"
+msgstr "Internet Archive"
+
+#: showia.html
+#, fuzzy
+msgid "Download MARC XML"
+msgstr "Pobierz DAISY"
+
+#: showia.html
+#, fuzzy
+msgid "Download MARC binary"
+msgstr "Pobierz DAISY"
+
+#: showia.html showmarc.html
+#, fuzzy
+msgid "Invalid MARC record."
+msgstr "Brak głównego dokumentu"
+
+#: showia.html showmarc.html
+#, fuzzy
+msgid "LEADER:"
+msgstr "Starsze"
+
+#: showmarc.html
+#, fuzzy
+msgid "Download Link"
+msgstr "Pobierz"
+
+#: showmarc.html type/tag/index.html
+msgid "Next"
+msgstr "Kolejne"
+
+#: status.html
+#, fuzzy
+msgid "Open Library server status"
+msgstr "Open Library"
+
+#: status.html
+#, fuzzy
+msgid "Server status"
+msgstr "Status"
+
+#: status.html
+msgid "Testing Environment"
+msgstr ""
+
+#: status.html
+msgid "Deploy triggered!"
+msgstr ""
+
+#: status.html
+msgid "View Jenkins progress"
+msgstr ""
+
+#: status.html
+msgid "GitHub status refreshed."
+msgstr ""
+
+#: status.html
+msgid "PR numbers or URLs, space/comma separated"
+msgstr ""
+
+#: status.html
+msgid "Add PR(s)"
+msgstr ""
+
+#: status.html
+msgid "PR"
+msgstr ""
+
+#: books/add.html books/edit.html books/edit/edition.html search/advancedsearch.html status.html type/about/edit.html type/page/edit.html type/template/edit.html
+msgid "Title"
+msgstr "Tytuł"
+
+#: books/add.html books/edit.html books/edit/edition.html openlibrary/plugins/worksearch/code.py search/advancedsearch.html search/search_modal_i18n.html search/work_search_selected_facets.html status.html
+msgid "Author"
+msgstr "Autor"
+
+#: status.html
+msgid "Assignee"
+msgstr ""
+
+#: status.html
+msgid "Pinned Commit"
+msgstr ""
+
+#: status.html
+msgid "Branch HEAD"
+msgstr ""
+
+#: status.html
+#, fuzzy
+msgid "Drift"
+msgstr "Edytuj"
+
+#: status.html
+#, fuzzy
+msgid "Enabled"
+msgstr "Umieść"
+
+#: status.html
+msgid "up to date"
+msgstr ""
+
+#: status.html
+#, fuzzy
+msgid "unknown"
+msgstr "Nieznany autor"
+
+#: status.html
+msgid "1 commit behind"
+msgstr ""
+
+#: status.html
+#, python-format
+msgid "%(count)s commits behind"
+msgstr ""
+
+#: admin/solr.html status.html
+#, fuzzy
+msgid "Update"
+msgstr "Dorzuć się"
+
+#: status.html
+#, fuzzy
+msgid "Enable"
+msgstr "Imię i nazwisko"
+
+#: status.html
+#, fuzzy
+msgid "Disable"
+msgstr "Dla osób z trudnościami w czytaniu druku"
+
+#: lists/lists.html status.html type/list/edit.html type/series/edit.html
+msgid "Remove"
+msgstr "Usuń"
+
+#: status.html
+#, fuzzy
+msgid "Selected PRs"
+msgstr "Wybierz rolę"
+
+#: status.html
+#, fuzzy
+msgid "Refresh"
+msgstr "Seria"
+
+#: status.html
+#, fuzzy
+msgid "Deploy"
+msgstr "Rozwijaj"
+
+#: status.html
+msgid "No PRs in testing set."
+msgstr ""
+
+#: status.html
+msgid "Last Build Result"
+msgstr ""
+
+#: status.html
+msgid "View PRs on GitHub"
+msgstr ""
+
+#: status.html
+#, fuzzy
+msgid "Show changed files"
+msgstr "Nie zmnieniono"
+
+#: admin/inspect/store.html admin/people/index.html status.html type/author/edit.html type/language/view.html
+msgid "Name"
+msgstr "Imię i nazwisko"
+
+#: status.html
+msgid "System information"
+msgstr ""
+
+#: status.html
+msgid "Features enabled"
+msgstr ""
+
+#: subjects.html
+msgid "Edit tag for this subject"
+msgstr ""
+
+#: subjects.html
+msgid "Create tag for this subject"
+msgstr ""
+
+#: subjects.html
+#, fuzzy
+msgid "See all works"
+msgstr "Zobacz wszystkie"
+
+#: merge/authors.html publishers/view.html subjects.html type/author/view.html
+#, fuzzy, python-format
+msgid "%(count)d work"
+msgid_plural "%(count)d works"
+msgstr[0] "%(count)d Lista"
+msgstr[1] "%(count)d Listy"
+
+#: subjects.html
+#, python-format
+msgid "Search for books with subject %(name)s."
+msgstr "Szukaj książek o tematyce %(name)s."
+
+#: subjects.html
+msgid "Disambiguations"
+msgstr ""
+
+#: trending.html
+#, fuzzy
+msgid "Now"
+msgstr "Nie"
+
+#: admin/graphs.html admin/index.html my_books/check_ins/check_in_form.html my_books/check_ins/check_in_prompt.html trending.html
+msgid "Today"
+msgstr ""
+
+#: admin/graphs.html trending.html
+msgid "This Week"
+msgstr ""
+
+#: admin/graphs.html stats/readinglog.html trending.html
+#, fuzzy
+msgid "This Month"
+msgstr "Te wydanie"
+
+#: trending.html
+msgid "This Year"
+msgstr ""
+
+#: admin/index.html books/year_breadcrumb_select.html trending.html
+#, fuzzy
+msgid "All Time"
+msgstr "czas"
+
+#: home/index.html openlibrary/plugins/openlibrary/api.py trending.html
+#, fuzzy
+msgid "Trending Books"
+msgstr "Dziennik Lektur"
+
+#: trending.html
+msgid "See what readers from the community are adding to their bookshelves"
+msgstr ""
+
+#: trending.html
+msgid "Earliest trending data is from October 2017"
+msgstr ""
+
+#. Label for the reading log shelf for books the user plans to read in the
+#. future (bookshelf ID 1). Used as a button label and shelf name.
+#: account/mybooks.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html trending.html
+msgid "Want to Read"
+msgstr "Chcę przeczytać"
+
+#. Display name for the "currently-reading" reading log shelf used in page
+#. headings and breadcrumbs.
+#. Label for the reading log shelf for books the user is actively reading
+#. (bookshelf ID 2). Used as a button label and shelf name.
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html trending.html
+msgid "Currently Reading"
+msgstr "W trakcie czytania"
+
+#: LoanReadForm.html ReadButton.html admin/inspect/memcache.html book_providers/read_button.html books/edit/edition.html trending.html type/list/embed.html widget.html
+msgid "Read"
+msgstr "Przeczytaj"
+
+#. Display name for the "stopped-reading" reading log shelf used in page
+#. headings and breadcrumbs.
+#. Label for the reading log shelf for books the user stopped reading before
+#. finishing (bookshelf ID 4). Used as a button label and shelf name.
+#. Label for the reading log shelf for books the user stopped reading
+#. (bookshelf ID 4). Used as a button label and shelf name.
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html trending.html
+msgid "Stopped Reading"
+msgstr ""
+
+#: trending.html
+#, python-format
+msgid "Someone marked as %(shelf)s %(k_hours_ago)s"
+msgstr ""
+
+#: trending.html
+#, python-format
+msgid "Logged %(count)i times %(time_unit)s"
+msgstr ""
+
+#: verify_human.html
+#, fuzzy
+msgid "Human Verification"
+msgstr "Weryfikacja adresu e-mail nie powiodła się"
+
+#: verify_human.html
+msgid "Please verify you are human to continue."
+msgstr ""
+
+#: verify_human.html
+msgid "Verify you are human"
+msgstr ""
+
+#: verify_human.html
+#, fuzzy
+msgid "Verification failed. Please try again."
+msgstr "E-mail weryfikacyjny został wysłany."
+
+#: verify_human.html
+#, fuzzy
+msgid "Verifying..."
+msgstr "Edytowanie..."
+
+#: viewpage.html
+#, fuzzy
+msgid "Revert to this revision?"
+msgstr "Usuń ten link"
+
+#: viewpage.html
+#, fuzzy
+msgid "Revert to this revision"
+msgstr "Usuń ten link"
+
+#: widget.html
+#, fuzzy, python-format
+msgid "Read \"%(title)s\""
+msgstr "Edytuj %(title)s"
+
+#: widget.html
+#, fuzzy, python-format
+msgid "Borrow \"%(title)s\""
+msgstr "Edytuj %(title)s"
+
+#: ReadButton.html books/edit/edition.html type/list/embed.html widget.html
+msgid "Borrow"
+msgstr "Wypożycz"
+
+#: widget.html
+#, python-format
+msgid "Join waitlist for \"%(title)s\""
+msgstr ""
+
+#: LoanStatus.html widget.html
+msgid "Join Waitlist"
+msgstr ""
+
+#: widget.html
+#, python-format
+msgid "Learn more about \"%(title)s\" at OpenLibrary"
+msgstr ""
+
+#: reading_goals/reading_goal_form.html widget.html
+msgid "Learn More"
+msgstr ""
+
+#: widget.html
+#, python-format
+msgid "on <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"%(link)s\">openlibrary.org</a>"
+msgstr ""
+
+#: work_search.html
+#, fuzzy
+msgid "Search Books"
+msgstr "Wyszukaj w tekscie e-booka"
+
+#: work_search.html
+#, fuzzy
+msgid "Keywords"
+msgstr "Słowa kluczowe"
+
+#: work_search.html
+msgid "This is only visible to super librarians."
+msgstr ""
+
+#: work_search.html
+#, fuzzy
+msgid "Solr Editions"
+msgstr "Większość wydań"
+
+#: design/toggle.html openlibrary/plugins/worksearch/code.py search/availability_i18n.html work_search.html
+#, fuzzy
+msgid "Readable Only"
+msgstr "Tylko administratorzy"
+
+#: work_search.html
+msgid "Filter by availability"
+msgstr ""
+
+#: openlibrary/plugins/worksearch/code.py search/search_modal_i18n.html type/edition/view.html type/work/view.html work_search.html
+msgid "Language"
+msgstr "Język"
+
+#: search/search_modal_i18n.html work_search.html
+#, fuzzy
+msgid "Search languages…"
+msgstr "Wybierz ten język"
+
+#: books/edit/edition.html languages/index.html search/search_modal_i18n.html work_search.html
+#, fuzzy
+msgid "Languages"
+msgstr "Język"
+
+#: work_search.html
+msgid "Filter by language"
+msgstr ""
+
+#: work_search.html
+msgid "The search engine returned an error."
+msgstr ""
+
+#: work_search.html
+msgid "Solr Debugging:"
+msgstr ""
+
+#: work_search.html
+msgid "Full URL:"
+msgstr ""
+
+#: work_search.html
+#, python-format
+msgid "No <strong>%(path_id)s</strong> directly matched your search."
+msgstr ""
+
+#: work_search.html
+#, fuzzy
+msgid "Add a new book?"
+msgstr "Dodaj książkę"
+
+#: search/authors.html search/lists.html search/subjects.html work_search.html
+#, fuzzy
+msgid "Checking Search Inside matches"
+msgstr "Szukaj w"
+
+#: account/reading_log.html search/authors.html search/lists.html search/subjects.html work_search.html
+#, python-format
+msgid "%(count)s hit"
+msgid_plural "%(count)s hits"
+msgstr[0] ""
+msgstr[1] ""
+
+#: work_search.html
+#, python-format
+msgid "Searching solr took %(count)s seconds"
+msgstr ""
+
+#: about/index.html
+#, fuzzy
+msgid "The Open Library Team"
+msgstr "Open Library"
+
+#: about/index.html
+msgid "Open Library is made possible because of a dedicated team of staff and over 100 volunteers from around the globe."
+msgstr ""
+
+#: about/index.html
+msgid "Want to join us?"
+msgstr ""
+
+#: about/index.html
+#, fuzzy
+msgid "Role:"
+msgstr "Problemy"
+
+#: about/index.html type/tag/index.html
+msgid "All"
+msgstr "Wszystkie"
+
+#: about/index.html
+msgid "Staff"
+msgstr ""
+
+#: about/index.html
+msgid "Fellows"
+msgstr ""
+
+#: about/index.html
+#, fuzzy
+msgid "Volunteers"
+msgstr "Tom"
+
+#: about/index.html
+msgid "Department:"
+msgstr ""
+
+#: about/index.html
+#, fuzzy
+msgid "Communications"
+msgstr "Twoje powiadomienia"
+
+#: about/index.html
+#, fuzzy
+msgid "Design"
+msgstr "Wymiary"
+
+#: about/index.html
+msgid "Engineering"
+msgstr ""
+
+#: about/index.html
+msgid "Librarianship"
+msgstr ""
+
+#: about/index.html
+msgid "If you volunteer with Open Library and would like to be listed as part of the team, then complete the <a href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">Open Library team information form</a>."
+msgstr ""
+
+#: account/create.html openlibrary/plugins/upstream/forms.py
+msgid "Must be a valid email address"
+msgstr "Wymagane jest podnanie adresu e-mail."
+
+#: account/create.html openlibrary/plugins/upstream/forms.py
+msgid "Must be between 3 and 20 characters"
+msgstr "Musi składać się z min. 3 i max. 20 znaków."
+
+#: account/create.html
+msgid "Username may only contain numbers, letters, - or _"
+msgstr ""
+
+#: account/create.html
+msgid "A qualifying program must be selected"
+msgstr ""
+
+#: account/create.html
+msgid "Sign Up to Open Library"
+msgstr "Załóż konto na Open Library"
+
+#: account/create.html lib/header_dropdown.html lib/nav_head.html
+msgid "Sign Up"
+msgstr "Załóż konto"
+
+#: account/create.html
+msgid "Get your free Open Library card and borrow digital books from the nonprofit Internet Archive"
+msgstr ""
+
+#: account/create.html type/author/view.html
+msgid "Success!"
+msgstr "Udało się!"
+
+#: account/create.html
+#, fuzzy
+msgid "Your URL"
+msgstr "Twój profil"
+
+#: account/create.html
+#, fuzzy
+msgid "screenname"
+msgstr "Nazwa użytkownika"
+
+#: account/create.html
+msgid "I want to receive news, announcements, and resources from the <a href=\"https://archive.org/\">Internet Archive</a>, the non-profit that runs Open Library."
+msgstr ""
+
+#: account/create.html
+msgid "I want to apply* for <a href=\"https://help.archive.org/help/program-overview/\" target=\"_blank\" rel=\"noopener noreferrer\">special print disability access</a> through a qualifying program."
+msgstr ""
+
+#: account/create.html
+msgid "Select qualifying program"
+msgstr ""
+
+#: account/create.html
+msgid "* Please use the email address associated with this qualifying program. You will receive an email after activation with next steps."
+msgstr ""
+
+#: account/create.html
+msgid "Sign Up with Email"
+msgstr ""
+
+#: account/create.html
+msgid "By signing up, you agree to the Internet Archive's <a class=\"ol-signup-form__link\" href=\"//archive.org/about/terms.php\" target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
+msgstr ""
+
+#: account/create.html
+msgid "Already have an account? <a href=\"/account/login\">Log in</a>"
+msgstr ""
+
+#: account/delete.html
+msgid "Delete Account"
+msgstr "Usuń konto"
+
+#: account/delete.html
+msgid "Sorry, this functionality is not yet implemented."
+msgstr "Przepraszamy, ta funkcjonalność nie jest jeszcze dostępna."
+
+#: account/follows.html
+#, fuzzy
+msgid "There is nothing to see here yet."
+msgstr "Nie ma tu złych odpowiedzi."
+
+#: account/import.html
+msgid "Import from Goodreads"
+msgstr ""
+
+#: account/import.html
+msgid "For instructions on exporting data refer to: <a href=\"https://www.goodreads.com/review/import\">Goodreads Import/Export</a>"
+msgstr ""
+
+#: account/import.html
+msgid "File size limit 10MB and .csv file type only"
+msgstr ""
+
+#: account/import.html
+#, fuzzy
+msgid "Load Books"
+msgstr "Dodaj książkę"
+
+#: account/import.html
+#, fuzzy
+msgid "Export your Reading Log"
+msgstr "Wyświetl lub edytuj Dziennik Lektur"
+
+#: account/import.html
+#, fuzzy
+msgid "Download a copy of your reading log."
+msgstr "Wyświetl lub edytuj Dziennik Lektur"
+
+#: account/import.html
+#, fuzzy
+msgid "What is a reading log?"
+msgstr "Dziennik Lektur"
+
+#: account/import.html
+msgid "Download (.csv format)"
+msgstr ""
+
+#: account/import.html
+#, fuzzy
+msgid "Export your book notes"
+msgstr "Zobacz książki"
+
+#: account/import.html
+msgid "Download a copy of your book notes."
+msgstr ""
+
+#: account/import.html
+#, fuzzy
+msgid "What are book notes?"
+msgstr "Jaki to rodzaj książki?"
+
+#: account/import.html
+msgid "Export your reviews"
+msgstr ""
+
+#: account/import.html
+msgid "Download a copy of your review tags."
+msgstr ""
+
+#: account/import.html
+msgid "What are review tags?"
+msgstr ""
+
+#: account/import.html
+msgid "Export your list overview"
+msgstr ""
+
+#: account/import.html
+msgid "Download a summary of your lists and their contents."
+msgstr ""
+
+#: account/import.html
+#, fuzzy
+msgid "What are lists?"
+msgstr "Aktywne Listy"
+
+#: account/import.html
+msgid "Export your star ratings"
+msgstr ""
+
+#: account/import.html
+msgid "Download a copy of your star ratings."
+msgstr ""
+
+#: account/import.html
+msgid "What are star ratings?"
+msgstr ""
+
+#: account/import.html
+#, fuzzy
+msgid "Importing..."
+msgstr "Edytowanie..."
+
+#: account/import.html
+#, fuzzy
+msgid "Reason"
+msgstr "Korekta"
+
+#: account/import.html
+#, fuzzy
+msgid "No ISBN"
+msgstr "ISBN"
+
+#: account/loan_history.html
+msgid "No loans found in your borrow history."
+msgstr ""
+
+#: account/loan_history.html
+msgid "<a href=\"/search\">Search for a book</a> to borrow."
+msgstr ""
+
+#: account/loans.html
+msgid "You've not checked out any books at this moment."
+msgstr "Obecnie nie masz zaznaczonych żadnych książek."
+
+#: account/loans.html
+#, python-format
+msgid "%(count)d Current Loan"
+msgid_plural "%(count)d Current Loans"
+msgstr[0] ""
+msgstr[1] ""
+
+#: account/loans.html admin/loans_table.html
+msgid "Loan Expires"
+msgstr "Termin zwrotu"
+
+#: account/loans.html
+msgid "Loan actions"
+msgstr "Wypożycz..."
+
+#: account/loans.html
+#, python-format
+msgid "There is %(count)d person waiting for this book."
+msgid_plural "There are %(count)d people waiting for this book."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ManageLoansButtons.html account/loans.html
+msgid "Not yet downloaded."
+msgstr "Jeszcze nie pobrana."
+
+#: ManageLoansButtons.html account/loans.html
+msgid "Download Now"
+msgstr "Pobierz"
+
+#: account/loans.html
+msgid "Return via<br/>Adobe Digital Editions"
+msgstr "Zwróć przez<br/>Adobe Digital Editions"
+
+#: account/loans.html
+msgid "Books You're Waiting For"
+msgstr "Książki, na które czekasz"
+
+#: account/loans.html
+msgid "You are not waiting for any books at this moment."
+msgstr "Obecnie nie czekasz na żadne książki"
+
+#: account/loans.html
+msgid "Leave the Waiting List"
+msgstr "Opuść Listę Oczekujących"
+
+#: account/loans.html
+msgid "Are you sure you want to leave the waiting list of<br/><strong>TITLE</strong>?"
+msgstr ""
+
+#: ProlificAuthors.html account/loans.html authors/index.html lists/list_follow.html lists/showcase.html publishers/view.html search/authors.html search/publishers.html search/subjects.html
+#, fuzzy, python-format
+msgid "%(count)d book"
+msgid_plural "%(count)d books"
+msgstr[0] "%(count)d Lista"
+msgstr[1] "%(count)d Listy"
+
+#: RecentChangesAdmin.html account/loans.html admin/loans_table.html
 msgid "Actions"
 msgstr "Akcje"
 
-#: borrow.html:201
-#, fuzzy, python-format
+#: account/loans.html
+#, python-format
 msgid "Waiting for 1 day"
 msgid_plural "Waiting for %(count)d days"
-msgstr[0] "Oczekujesz %d dzień"
-msgstr[1] "Oczekujesz %d dni"
+msgstr[0] ""
+msgstr[1] ""
 
-#: borrow.html:208
+#: account/loans.html
 msgid "You are the next person to receive this book."
 msgstr "Jesteś pierwszy na liście oczekujących."
 
-#: borrow.html:210
+#: ManageWaitlistButton.html account/loans.html
 #, python-format
 msgid "There is one person ahead of you in the waiting list."
 msgid_plural "There are %(count)d people ahead of you in the waiting list."
 msgstr[0] "Jesteś drugi na liście oczekujących."
 msgstr[1] "Jesteś %(count)d na liscie oczekujących."
 
-#: borrow.html:219
+#: ManageWaitlistButton.html account/loans.html
 msgid "You have less than an hour to borrow it."
 msgstr "Pozostało mniej niż godzina na wypożyczenie tej książki."
 
-#: borrow.html:221
-#, fuzzy, python-format
+#: account/loans.html
+#, python-format
 msgid "You have one more hour to borrow it."
 msgid_plural "You have %(hours)d more hours to borrow it."
-msgstr[0] "Pozostało mniej niż godzina na wypożyczenie tej książki."
+msgstr[0] ""
 msgstr[1] ""
 
-#: borrow.html:228
+#: ManageWaitlistButton.html account/loans.html
 msgid "Borrow Now"
 msgstr "Wypożycz teraz"
 
-#: borrow.html:232
+#: ManageWaitlistButton.html account/loans.html
 msgid "Leave the waiting list?"
 msgstr "Opuścić listę oczekujących?"
 
-#: borrow.html:246
-msgid "There are 2 different sources for borrowing books through Open Library:"
-msgstr "Istnieją 2 źródła, z których możesz wypożyczyć książki przez Opne Library"
-
-#: borrow.html:250
-msgid "Internet Archive"
-msgstr "Internet Archive"
-
-#: borrow.html:252
-msgid "eBooks everywhere"
-msgstr "e-Booki wszędzie"
-
-#: borrow.html:254
-msgid ""
-"The <a href=\"//archive.org/\">Internet Archive</a> and several partner "
-"libraries are offering thousands of eBooks for loan to anyone with an "
-"Open Library account, anywhere in the world."
+#: account/loans.html
+msgid "Looking for a book to borrow?  Check out our staff picks, or search for a book on a specific subject:"
 msgstr ""
-"<a href=\"//archive.org/\">Internet Archive</a> oraz inne partnerskie "
-"biblioteki oferują tysiące e-booków użytkownikom na całym świecie, którzy"
-" posiadają konto na Open Library."
 
-#: borrow.html:260
-msgid "physical books from your local library"
-msgstr "Papierowe wydania książek z Twojej lokalnej biblioteki"
+#: account/loans.html home/index.html
+msgid "Books We Love"
+msgstr "Książki, które kochamy"
 
-#: borrow.html:262
-msgid ""
-"We connect our records to WorldCat wherever possible. You can tell "
-"WorldCat your postcode/zip code, and it will tell you the closest library"
-" with a copy of the book."
+#: account/loans.html
+msgid "Or, check out our <a href=\"/collections\">special collections</a>."
 msgstr ""
-"Na bieżąco udostępiniamy nasze kroniki dla WorldCat. Na WorldCatmożesz "
-"podać swój kod pocztowy i wyszukać najbliższą bibliotekę, z kopią "
-"wybranej książki."
 
-#: borrow.html:267
-msgid "Getting Started"
-msgstr "Zaczynamy"
+#: account/mybooks.html
+msgid "No books are on this shelf"
+msgstr "Ta półka jest pusta"
 
-#: borrow.html:268
-msgid ""
-"All you need to borrow a book scanned at the Internet Archive is an Open "
-"Library account and Adobe Digital Editions."
-msgstr ""
-"Aby wypożyczyć zeskanowaną książkę z Internet Archive potrzebujesz "
-"jedynie konta na Open Library oraz Adobe Digital Editions."
+#: account/mybooks.html account/sidebar.html
+msgid "My Loans"
+msgstr "Wypożyczone przeze mnie"
 
-#: borrow.html:269
-msgid ""
-"Loans through WorldCat are managed through your local libraries, not "
-"through Open Library."
-msgstr ""
-"Wypożyczenia dokonane za pomocą WorldCat są zarządzane przez lokalne "
-"biblioteki, nie przez Open Library."
+#. Display name for the "already-read" reading log shelf used in page headings
+#. and breadcrumbs.
+#. Label for the reading log shelf for books the user has finished reading
+#. (bookshelf ID 3). Used as a button label and shelf name.
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html openlibrary/plugins/upstream/mybooks.py search/sort_options.html
+msgid "Already Read"
+msgstr "Przeczytane"
 
-#: borrow.html:271
-msgid ""
-"Check out the <a href=\"/help/faq#section-borrowing\"><strong>Lending "
-"FAQ</strong></a> for more information."
-msgstr ""
-"Więcej informacji znajdziesz na <a href=\"/help/faq#section-"
-"borrowing\"><strong>Wypożyczanie FAQ</strong></a>."
-
-#: borrow.html:274
-msgid "Which books are available?"
-msgstr "Które książki są dostępne?"
-
-#: borrow.html:275
-#, python-format
-msgid ""
-"Browse all the available books through the <a "
-"href=\"/subjects/lending_library\">\"Lending Library\"</a> subject, or "
-"try a <a href=\"/search?subject_facet=Lending%20library\">search</a>."
-msgstr ""
-"Przeszukaj wszystkie dostępne książki z<a "
-"href=\"/subjects/lending_library\">\"Wypożyczalni\"</a> o danej tematyce,"
-" lub wypróbuj <a "
-"href=\"/search?subject_facet=Lending%20library\">wyszukiwarkę</a>."
-
-#: borrow.html:280
-msgid "Help/Downloads"
-msgstr "Pomoc/Pobrane"
-
-#: borrow.html:282
-msgid "Download Adobe Digital Editions"
-msgstr "Pobierz Adobe Digital Editions"
-
-#: borrow.html:283
-msgid ""
-"<a href=\"http://www.adobe.com/products/digitaleditions/help/\">Help</a> "
-"on adobe.com"
-msgstr ""
-"<a href=\"http://www.adobe.com/products/digitaleditions/help/\">Pomoc</a>"
-" na adobe.com"
-
-#: borrow.html:286
-msgid ""
-"If you work at a library and are interested to find out more about "
-"lending ebooks through Open Library, please <a href=\"/contact\">get in "
-"touch with us</a>!"
-msgstr ""
-"Jeśli jesteś pracownikiem biblioteki i chcesz wiedzieć więcej o "
-"wypożyczaniu książek przez Open Library, <a href=\"/contact\">skontaktuj "
-"się z nami</a>!"
-
-#: create.html:9
-msgid "Sign Up to Open Library"
-msgstr "Załóż konto na Open Library"
-
-#: create.html:12 create.html:96 nav_head.html:109 search_head.html:78
-msgid "Sign Up"
-msgstr "Załóż konto"
-
-#: create.html:14
-msgid "Complete the form below to create a new Internet Archive account."
-msgstr "Wypełnij poniższy formularz, aby utworzyć konto na Internet Archive."
-
-#: create.html:15
-msgid "Each field is required"
-msgstr "Wszystkie pola są wymagane"
-
-#: create.html:57 openlibrary/templates/login.html:18
-#, python-format
-msgid "You are already logged into Open Library as %(user)s."
-msgstr "Jeśteś już zarejestrowany w Open Library jako %(user)s."
-
-#: create.html:58 openlibrary/templates/login.html:19
-msgid ""
-"If you'd like to create a new, different Open Library account, you'll "
-"need to <a href=\"javascript:;\" "
-"onclick=\"document.forms['logout'].submit()\">log out</a> and start the "
-"signup process afresh."
-msgstr ""
-"Jeśli chcesz utworzyć nowe konto na Open Library <a href=\"javascript:;\""
-" onclick=\"document.forms['logout'].submit()\">Wyloguj się</a> i utwórz "
-"nowe konto."
-
-#: create.html:67
+#: account/mybooks.html type/user/view.html
 #, fuzzy
-msgid "screenname"
-msgstr "Nazwa użytkownika"
+msgid "This reader has chosen to make their Reading Log private."
+msgstr "Ten użytkownik postanowił nie udostępniać swojego Dziennika Lektur"
 
-#: create.html:71
+#: account/mybooks.html
 #, python-format
-msgid "Your URL: %s"
+msgid "%(year_span)s reading goal"
 msgstr ""
 
-#: create.html:84
-msgid ""
-"If you have security settings or privacy blockers installed, please "
-"disable them to see the reCAPTCHA."
-msgstr ""
-"Jeśli nie widzisz reCAPTCHA, wyłącz chwilowo ustawienia zabezpieczeń lub "
-"inne programy blokujące prywatność."
-
-#: create.html:88
-msgid "Incorrect. Please try again."
+#: account/mybooks.html
+msgid "View All Lists"
 msgstr ""
 
-#: create.html:92
+#: account/mybooks.html
 #, fuzzy
-msgid ""
-"By signing up, you agree to the Internet Archive's <a "
-"href='//archive.org/about/terms.php' target='_blank'>Terms of "
-"Service</a>."
+msgid "My Stats"
+msgstr "Moje listy"
+
+#: account/mybooks.html account/sidebar.html account/topmenu.html
+#, fuzzy
+msgid "My Reading Stats"
+msgstr "Moje listy lektur:"
+
+#: account/mybooks.html account/sidebar.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
+#, fuzzy
+msgid "Loan History"
+msgstr "Historia"
+
+#: account/mybooks.html account/sidebar.html
+#, fuzzy
+msgid "My Notes"
+msgstr "Notatki:"
+
+#: account/mybooks.html account/sidebar.html
+#, fuzzy
+msgid "My Reviews"
+msgstr "Mój profil"
+
+#: account/mybooks.html account/sidebar.html
+msgid "Import & Export Options"
 msgstr ""
-"Potwierdzam, że moje korzystanie z Open Library podlega warunkom Internet"
-" Archive<a href='//archive.org/about/terms.php' "
-"target='_blank'>Warunki użytkowania</a>."
 
-#: add.html:79 add.html:135 authors.html:125 create.html:97
-#: edit/addfield.html:87 edit/addfield.html:133 edit/addfield.html:177
-#: manage.html:65 notifications.html:59 openlibrary/macros/EditButtons.html:23
-#: password/reset.html:24 privacy.html:56 widget.html:304
-msgid "Cancel"
-msgstr "Anuluj"
-
-#: delete.html:6 delete.html:10
-msgid "Delete Account"
-msgstr "Usuń konto"
-
-#: delete.html:15
-msgid "Sorry, this functionality is not yet implemented."
-msgstr "Przepraszamy, ta funkcjonalność nie jest jeszcze dostępna."
-
-#: not_verified.html:7 not_verified.html:18 verify/failed.html:10
+#: account/not_verified.html account/verify/failed.html
 msgid "Oops!"
 msgstr "Ups!"
 
-#: not_verified.html:36 verify/failed.html:29
+#: account/not_verified.html
+#, fuzzy
+msgid "The email address you signed up with needs to be verified."
+msgstr "E-mail nie mógł zostać zweryfikowany."
+
+#: account/not_verified.html
+#, python-format
+msgid "When you created your account, we sent an email to %(email)s that contained a link for you to verify your email address. We need you to click that link, please."
+msgstr ""
+
+#: account/not_verified.html
+msgid "If you can't find the email, just hit this button to send a fresh one:"
+msgstr ""
+
+#: account/not_verified.html account/verify/failed.html
 msgid "Resend the verification email"
 msgstr "Wyślij e-mail weryfikacyjny ponownie"
 
-#: notifications.html:7 notifications.html:16
+#: account/not_verified.html account/verify/failed.html
+msgid "Thanks!"
+msgstr ""
+
+#: BookByline.html FulltextSearchSuggestionItem.html SearchResultsWork.html account/notes.html account/observations.html
+msgid "Unknown author"
+msgstr "Nieznany autor"
+
+#: account/notes.html
+#, fuzzy
+msgid "My notes for an edition of "
+msgstr "Jest to wydanie książki... "
+
+#: account/notes.html
+#, fuzzy
+msgid "Title Missing"
+msgstr "brakuje imienia"
+
+#: account/notes.html lists/export_as_html.html type/work/editions.html
+msgid "Publish date unknown"
+msgstr ""
+
+#: account/notes.html books/edition-sort.html lists/export_as_html.html type/work/editions.html
+msgid "Publisher unknown"
+msgstr "Wydawnictwo nieznane"
+
+#: account/notes.html
+#, python-format
+msgid "in %(language)s"
+msgstr ""
+
+#: NotesModal.html account/notes.html
+#, fuzzy
+msgid "Delete Note"
+msgstr "Usuń listę"
+
+#: NotesModal.html account/notes.html
+#, fuzzy
+msgid "Save Note"
+msgstr "Zachowaj"
+
+#: account/notes.html
+#, fuzzy
+msgid "No notes found."
+msgstr "Nie znaleziono."
+
+#: account/notifications.html
 msgid "Notifications from Open Library"
 msgstr "Powiadomienia z Open Library"
 
-#: notifications.html:14
+#: account/notifications.html
 msgid "Notifications"
 msgstr "Powiadomienia"
 
-#: notifications.html:31
-msgid ""
-"Notifications are connected to Lists at the moment. If one of the books "
-"on your list gets edited, or a new book comes into the catalog, we'll let"
-" you know, if you want."
-msgstr ""
-"Powiadomienia są teraz związane z Listami. kiedy książka na Twojej liście"
-" będzie edytowana, lub nowa książka jest dodana do katalogu,  dostaniesz "
-"o tym powiadomienie, jeśli chcesz."
+#: account/notifications.html
+msgid "Notifications are connected to Lists at the moment. If one of the books on your list gets edited, or a new book comes into the catalog, we'll let you know, if you want."
+msgstr "Powiadomienia są teraz związane z Listami. kiedy książka na Twojej liście będzie edytowana, lub nowa książka jest dodana do katalogu,  dostaniesz o tym powiadomienie, jeśli chcesz."
 
-#: notifications.html:35
+#: account/notifications.html
 msgid "Would you like to receive very occasional emails from Open Library?"
 msgstr "Czy chciałabyś sporadycznie otrzymywać wiadomości z Open Library?"
 
-#: notifications.html:42
+#: account/notifications.html
 msgid "No, thank you"
 msgstr "Nie, dziękuję"
 
-#: notifications.html:49
+#: account/notifications.html
 msgid "Yes! Please!"
 msgstr "Tak, poproszę!"
 
-#: manage.html:64 notifications.html:57 openlibrary/macros/EditButtons.html:21
-#: privacy.html:54
+#: EditButtons.html account/notifications.html account/privacy.html admin/block.html admin/spamwords.html covers/manage.html
 msgid "Save"
 msgstr "Zachowaj"
 
-#: privacy.html:7
+#: EditionNavBar.html account/observations.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#, fuzzy
+msgid "Reviews"
+msgstr "Wyświetl"
+
+#: account/observations.html admin/inspect/memcache.html
+#, fuzzy
+msgid "Delete"
+msgstr "Usuń listę"
+
+#: account/observations.html
+msgid "Update Reviews"
+msgstr ""
+
+#: account/observations.html
+#, fuzzy
+msgid "No observations found."
+msgstr "Brak wyników."
+
+#: account/privacy.html
 msgid "Your Privacy on Open Library"
 msgstr "Twoja prywatność na Open Library"
 
-#: privacy.html:16
-msgid "Privacy Settings"
+#: account/privacy.html
+#, fuzzy
+msgid "Privacy & Content Moderation Settings"
 msgstr "Ustawienia prywatności"
 
-#: privacy.html:39
+#: account/privacy.html
+msgid "Would you like to make your <a href=\"/account/books\">Reading Log</a> public?"
+msgstr ""
+
+#: account/privacy.html
+msgid "This will enable others to see what books you want to read, are reading, stopped reading, or have already read. Patrons with reading logs set to public may be followed."
+msgstr ""
+
+#: account/privacy.html admin/people/view.html
 msgid "Yes"
 msgstr "Tak"
 
-#: edit/edition.html:399 privacy.html:46
+#: account/privacy.html admin/people/view.html books/edit/edition.html
 msgid "No"
 msgstr "Nie"
 
-#: verify.html:7
+#: account/privacy.html
+msgid "Enable Safe Mode?"
+msgstr ""
+
+#: account/privacy.html
+msgid "Safe Mode blurs book covers that have been flagged as having sensitive imagery."
+msgstr ""
+
+#: account/reading_log.html
+#, python-format
+msgid "Books %(username)s is reading"
+msgstr "Książki, które obecnie czyta %(username)s"
+
+#: account/reading_log.html
+#, python-format
+msgid "%(username)s is reading %(total)d books. Join %(username)s on OpenLibrary.org and tell the world what you're reading."
+msgstr "%(username)s czyta %(total)d książek. Dołącz do %(username)s na OpenLibrary.org i powiedz światu, co czytasz."
+
+#: account/reading_log.html
+#, python-format
+msgid "Books %(username)s wants to read"
+msgstr "Książki, które %(username)s chce przeczytać"
+
+#: account/reading_log.html
+#, python-format
+msgid "%(username)s wants to read %(total)d books. Join %(username)s on OpenLibrary.org and share the books that you'll soon be reading!"
+msgstr "%(username)s chce przeczytać %(total)d książek. Dołącz do %(username)s na OpenLibrary.org i pokaż światu, co będziesz wkrótce czytać!"
+
+#: account/reading_log.html
+#, fuzzy, python-format
+msgid "Books %(username)s stopped reading"
+msgstr "Książki, które obecnie czyta %(username)s"
+
+#: account/reading_log.html
+#, fuzzy, python-format
+msgid "%(username)s stopped reading %(total)d books. Join %(username)s on OpenLibrary.org to share your own reading updates!"
+msgstr "%(username)s chce przeczytać %(total)d książek. Dołącz do %(username)s na OpenLibrary.org i pokaż światu, co będziesz wkrótce czytać!"
+
+#: account/reading_log.html
+#, python-format
+msgid "Books %(username)s has read in %(year)d"
+msgstr ""
+
+#: account/reading_log.html
+#, python-format
+msgid "%(username)s has read %(total)d books in %(year)d. Join %(username)s on OpenLibrary.org and tell the world about the books that you care about."
+msgstr ""
+
+#: account/reading_log.html
+#, python-format
+msgid "Books %(username)s has read"
+msgstr "Książki przeczytane przez %(username)s"
+
+#: account/reading_log.html
+#, python-format
+msgid "%(username)s has read %(total)d books. Join %(username)s on OpenLibrary.org and tell the world about the books that you care about."
+msgstr "%(username)s przeczytał\\(a\\) %(total)d książek. Dołącz do %(username)s na OpenLibrary.org i powiedz światu o książkach, które są dla Ciebie ważne."
+
+#: account/reading_log.html
+#, fuzzy, python-format
+msgid "Books in %(username)s feed"
+msgstr "Książki przeczytane przez %(username)s"
+
+#: account/reading_log.html
+#, python-format
+msgid "Books added by people %(username)s follows"
+msgstr ""
+
+#: account/reading_log.html
+#, fuzzy
+msgid "Search your reading log"
+msgstr "Wyświetl lub edytuj Dziennik Lektur"
+
+#: account/reading_log.html type/author/view.html
+#, python-format
+msgid "— Show <a href=\"%(url)s\">only ebooks</a>?"
+msgstr ""
+
+#: account/reading_log.html
+#, fuzzy, python-format
+msgid "— Show <a href=\"%(url)s\">everything</a> in this shelf?"
+msgstr ""
+
+#: account/reading_log.html
+#, fuzzy
+msgid "No results found in this shelf"
+msgstr "Brak wyników."
+
+#: account/reading_log.html
+#, python-format
+msgid "Search all of Open Library for \"%s\"?"
+msgstr ""
+
+#: account/reading_log.html
+#, fuzzy
+msgid "You haven't marked any books as read for this year."
+msgstr "Obecnie nie masz zaznaczonych żadnych książek."
+
+#: account/reading_log.html
+#, fuzzy
+msgid "You haven't added any books to this shelf yet."
+msgstr "Obecnie nie masz zaznaczonych żadnych książek."
+
+#: account/reading_log.html
+msgid "<a href=\"/search\">Search for a book</a> to add to your reading log. <a href=\"/help/faq/reading-log\">Learn more</a> about the reading log."
+msgstr ""
+
+#: account/reading_log.html
+msgid "There are no recent books in your feed. When you follow public accounts, their book updates will appear here."
+msgstr ""
+
+#. Display name for the "want-to-read" reading log shelf used in page headings
+#. and breadcrumbs.
+#: account/readinglog_shelf_name.html
+#, fuzzy
+msgid "Want To Read"
+msgstr "Chcę przeczytać"
+
+#: account/readinglog_stats.html
+#, python-format
+msgid "My %(shelf_name)s Stats"
+msgstr ""
+
+#: account/readinglog_stats.html home/loans.html lib/nav_head.html
+msgid "My Books"
+msgstr "Moje książki"
+
+#: account/readinglog_stats.html
+#, python-format
+msgid "Displaying stats about <strong>%(works_count)d</strong> books. Note all charts show only the top 20 bars. Note reading log stats are private."
+msgstr ""
+
+#: account/readinglog_stats.html
+#, fuzzy
+msgid "Author Stats"
+msgstr "Autorzy"
+
+#: account/readinglog_stats.html
+#, fuzzy
+msgid "Most Read Authors"
+msgstr "Zobacz autorów"
+
+#: account/readinglog_stats.html
+msgid "Works by Author Sex"
+msgstr ""
+
+#: account/readinglog_stats.html
+msgid "Works by Author Country of Citizenship"
+msgstr ""
+
+#: account/readinglog_stats.html
+msgid "Works by Author Country of Birth"
+msgstr ""
+
+#: account/readinglog_stats.html
+msgid "Demographic statistics powered by <a href=\"https://www.wikidata.org/\">Wikidata</a>. Here's a <a id=\"wd-query-sample\" href=\"\">sample</a> of the query used. <br />Improve these stats by adding the Wikidata author identifier following <a href=\"https://openlibrary.org/help/faq/editing.en#author-identifiers-purpose\">these instructions</a>."
+msgstr ""
+
+#: account/readinglog_stats.html
+#, fuzzy
+msgid "Work Stats"
+msgstr "Status"
+
+#: account/readinglog_stats.html
+#, fuzzy
+msgid "Works by Decade Published"
+msgstr "Wydawnictwo"
+
+#: account/readinglog_stats.html
+#, fuzzy
+msgid "Works by Century Published"
+msgstr "Pierwsza publikacja"
+
+#: account/readinglog_stats.html
+#, fuzzy
+msgid "Works by Subject"
+msgstr "Przeglądaj według tematów"
+
+#: account/readinglog_stats.html
+msgid "Works by People"
+msgstr ""
+
+#: account/readinglog_stats.html
+msgid "Works by Places"
+msgstr ""
+
+#: account/readinglog_stats.html
+msgid "Works by Time Period"
+msgstr ""
+
+#: account/readinglog_stats.html
+#, fuzzy
+msgid "Matching works"
+msgstr "Usuń tę pozycję"
+
+#: account/readinglog_stats.html
+msgid "Click on a bar to see matching works"
+msgstr ""
+
+#: account/sidebar.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#, fuzzy
+msgid "My Feed"
+msgstr "1 plik inicujuący"
+
+#: account/sidebar.html
+#, python-format
+msgid "%(year)d Reading Goal"
+msgstr ""
+
+#: account/sidebar.html
+#, python-format
+msgid "Set %(year_span)s reading goal"
+msgstr ""
+
+#: account/sidebar.html search/sort_options.html type/user/view.html
+msgid "Reading Log"
+msgstr "Dziennik Lektur"
+
+#: account/sidebar.html
+#, fuzzy
+msgid "My lists"
+msgstr "Moje listy"
+
+#: EditionNavBar.html SearchNavigation.html account/sidebar.html lib/nav_head.html lists/home.html recentchanges/index.html type/edition/view.html type/list/embed.html type/user/view.html type/work/view.html
+msgid "Lists"
+msgstr "Listy"
+
+#: account/sidebar.html type/user/view.html
+#, fuzzy
+msgid "See All"
+msgstr "Zobacz wszystkie"
+
+#: account/sidebar.html type/list/edit.html type/series/edit.html
+#, fuzzy
+msgid "Create a list"
+msgstr "Stwórz nową listę"
+
+#: account/sidebar.html
+msgid "Untitled list"
+msgstr ""
+
+#: account/topmenu.html
+msgid "Import & Export"
+msgstr ""
+
+#: account/topmenu.html
+#, python-format
+msgid "Privacy settings: %(public)s"
+msgstr ""
+
+#: account/verify.html
 msgid "Verification email sent"
 msgstr "E-mail weryfikacyjny został wysłany."
 
-#: email/forgot-ia.html:10 email/forgot.html:10
+#: account/password/reset_success.html account/verify.html account/verify/activated.html account/verify/success.html
+#, python-format
+msgid "Hi, %(user)s"
+msgstr "Cześć, %(user)s"
+
+#: account/verify.html
+#, python-format
+msgid "We’ve sent an email to %(email)s containing a link to verify your account. Click/tap on the link to finish creating your Internet Archive account."
+msgstr ""
+
+#: account/verify.html
+msgid "Then, come back to Open Library and find some great books!"
+msgstr ""
+
+#: account/view.html
+#, fuzzy
+msgid "Yearly Reading Goal"
+msgstr "Mój Dziennik Lektur"
+
+#: account/view.html books/mybooks_breadcrumb_select.html
+msgid "Following"
+msgstr ""
+
+#: account/view.html books/mybooks_breadcrumb_select.html
+#, fuzzy
+msgid "Followers"
+msgstr "filtrów"
+
+#: account/view.html type/edition/modal_links.html type/edition/title_and_author.html
+#, fuzzy
+msgid "Share"
+msgstr "Zachowaj"
+
+#: account/view.html
+msgid "Your book notes are private and cannot be viewed by other patrons."
+msgstr ""
+
+#: account/view.html
+msgid "Your book reviews will be shared anonymously with other patrons."
+msgstr ""
+
+#: account/yrg_banner.html
+#, python-format
+msgid "Set your %(year)s Yearly Reading Goal:"
+msgstr ""
+
+#: account/yrg_banner.html
+msgid "Set my goal"
+msgstr ""
+
+#: account/email/forgot-ia.html
 msgid "Forgot Your Internet Archive Email?"
 msgstr "Nie pamiętasz swojego adresu e-mail na Internet Archive?"
 
-#: email/forgot-ia.html:43 password/forgot.html:10
+#: account/email/forgot-ia.html
+msgid "Please enter your Open Library email and password, and we’ll retrieve your Archive.org email."
+msgstr ""
+
+#: account/email/forgot-ia.html
+#, fuzzy
+msgid "Your email is:"
+msgstr "Twój adres e-mail"
+
+#: account/email/forgot-ia.html
+#, fuzzy
+msgid "Return to Log In?"
+msgstr "Przewiń do góry"
+
+#: account/email/forgot-ia.html
+#, fuzzy
+msgid "Open Library Email"
+msgstr "Open Library"
+
+#: account/email/forgot-ia.html
+msgid "Retrieve Archive.org Email"
+msgstr ""
+
+#: account/email/forgot-ia.html account/password/forgot.html
 msgid "Forgot your Archive.org Password?"
 msgstr "Nie pamiętasz swojego hasła na Internet Archive?"
 
-#: email/forgot.html:15
-msgid "Forgot Your Open Library Email?"
-msgstr "Nie pamiętasz swojego adresu e-mail na Open Library?"
-
-#: email/forgot.html:48 openlibrary/templates/login.html:66
-msgid "Forgot your Password?"
-msgstr "Nie pamiętasz swojego hasła?"
-
-#: password/forgot.html:7 password/sent.html:7
+#: account/password/forgot.html account/password/sent.html
 msgid "Username/Password Reminder"
 msgstr "Nazwa użytkownika/Przypomnij hasło"
 
-#: password/forgot.html:11
-msgid "Forgot your Archive.org password?"
-msgstr "Nie pamiętasz swojego hasła na Archive.org?"
+#: account/password/forgot.html
+msgid "Click here."
+msgstr ""
 
-#: password/forgot.html:23
+#: account/password/forgot.html
 msgid "Send It"
 msgstr "Wyślij"
 
-#: password/reset.html:7 password/reset.html:10
+#: account/password/reset.html admin/people/view.html
 msgid "Reset Password"
 msgstr "Zresetuj hasło"
 
-#: password/reset.html:15
+#: account/password/reset.html
 msgid "Please enter a new password for your Open Library account."
 msgstr "Wpisz nowe hasło do Twojego konta na Open Library"
 
-#: password/reset.html:23
+#: account/password/reset.html
 msgid "Reset"
 msgstr "Zresetuj"
 
-#: password/reset_success.html:7
+#: account/password/reset_success.html
 msgid "Password Reset Successful"
 msgstr "Hasło zostało zresetowane"
 
-#: password/reset_success.html:14
-msgid ""
-"Your password has been updated. Please <a "
-"href='/account/login?redirect=/'>log in to continue</a>."
-msgstr ""
-"Twoje hasło zostało uaktualnione, aby kontynuować <a "
-"href='/account/login?redirect=/'>Zaloguj się</a>."
+#: account/password/reset_success.html
+msgid "Your password has been updated. Please <a href='/account/login?redirect=/'>log in to continue</a>."
+msgstr "Twoje hasło zostało uaktualnione, aby kontynuować <a href='/account/login?redirect=/'>Zaloguj się</a>."
 
-#: password/sent.html:10
+#: account/password/sent.html
 msgid "Done."
 msgstr "Gotowe."
 
-#: password/sent.html:14
+#: account/password/sent.html
 #, python-format
-msgid ""
-"We've sent an email to %(email)s with a reminder of your username and "
-"instructions to help you reset your Open Library password. Please check "
-"your inbox for a note from us."
-msgstr ""
-"Wysłaliśmy e-mail na\" %(email)s z przypomnieniem o Twojej nazwie "
-"użytkownika oraz instrukcjami jak zresetować hasło do Open Library. "
-"Sprawdź swoją skrzynkę odbiorczą."
+msgid "We've sent an email to %(email)s with a reminder of your username and instructions to help you reset your Open Library password. Please check your inbox for a note from us."
+msgstr "Wysłaliśmy e-mail na\" %(email)s z przypomnieniem o Twojej nazwie użytkownika oraz instrukcjami jak zresetować hasło do Open Library. Sprawdź swoją skrzynkę odbiorczą."
 
-#: verify/activated.html:7
+#: account/security/check_email.html
+msgid "Account Security Check — 2026-04-28T18Z"
+msgstr ""
+
+#: account/security/check_email.html
+msgid "Account Security Check"
+msgstr ""
+
+#: account/security/check_email.html
+msgid "Incident date: 2026-04-28T18Z"
+msgstr ""
+
+#: account/security/check_email.html
+msgid "Check whether your Open Library account was in a set of accounts requiring attention."
+msgstr ""
+
+#: account/security/check_email.html
+msgid "Please <a href=\"/account/login?redirect=/account/security/2026-04-28T18\">log in</a> to check whether your account was affected."
+msgstr ""
+
+#: account/security/check_email.html
+msgid "Your account is in the affected set."
+msgstr ""
+
+#: account/security/check_email.html
+msgid "Your account was found in our affected accounts list. Please review any recent communications from Open Library and consider updating your password."
+msgstr ""
+
+#: account/security/check_email.html
+msgid "Your account is <em>not</em> in the affected set."
+msgstr ""
+
+#: account/security/check_email.html
+msgid "Your account was <em>not</em> found in the affected accounts list. No action is required."
+msgstr ""
+
+#: account/verify/activated.html
 msgid "Account already activated"
 msgstr "Konto jest już aktywne"
 
-#: verify/activated.html:15
+#: account/verify/activated.html
 #, python-format
-msgid ""
-"Your account has been activated already. Please <a href=\"%s\">log in to "
-"continue</a>."
-msgstr ""
-"Twoje konto jest już aktywne. <a href=\"%s\">Zaloguj się, by "
-"kontynuować</a>."
+msgid "Your account has been activated already. Please <a href=\"%s\">log in to continue</a>."
+msgstr "Twoje konto jest już aktywne. <a href=\"%s\">Zaloguj się, by kontynuować</a>."
 
-#: verify/failed.html:7
+#: account/verify/failed.html
 msgid "Email Verification Failed"
 msgstr "Weryfikacja adresu e-mail nie powiodła się"
 
-#: verify/failed.html:14
-msgid ""
-"Your email address couldn't be verified. Your verification link seems "
-"invalid or expired."
-msgstr ""
-"Twój adres e-mail nie został zweryfikowany. Twój link "
-"weryfikacyjnystracił ważność."
+#: account/verify/failed.html
+msgid "Your email address couldn't be verified. Your verification link seems invalid or expired."
+msgstr "Twój adres e-mail nie został zweryfikowany. Twój link weryfikacyjnystracił ważność."
 
-#: verify/failed.html:22
+#: account/verify/failed.html
+msgid "Fill your email and hit this button to resend a fresh verification email:"
+msgstr ""
+
+#: account/verify/failed.html
 msgid "Enter your email address here"
 msgstr "Wpisz swój adres e-mail tutaj"
 
-#: verify/failed.html:25
+#: account/verify/failed.html
 msgid "No user registered with this email address."
 msgstr "Nie istnieje konto z podanym adresem e-mail."
 
-#: verify/success.html:7
+#: account/verify/success.html
 msgid "Email Verification Successful"
 msgstr "Twój e-mail został zweryfikowany."
 
-#: verify/success.html:15
+#: account/verify/success.html
 #, python-format
-msgid ""
-"Yay! Your email address has been verified. Please <a href='%s'>log in to "
-"continue</a>."
+msgid "Yay! Your email address has been verified. Please <a href='%s'>log in to continue</a>."
+msgstr "Super! Twój e-mail został zweryfikowany.<a href='%s'>Zaloguj się, aby kontynuować</a>."
+
+#: admin/attach_debugger.html
+msgid "Attach Debugger"
 msgstr ""
-"Super! Twój e-mail został zweryfikowany.<a href='%s'>Zaloguj się, aby "
-"kontynuować</a>."
 
-#: add.html:7 check.html:10
-msgid "Add a book"
-msgstr "Dodaj książkę"
-
-#: add.html:11
-msgid "Add a book to Open Library"
-msgstr "Dodaj książkę do Open Library"
-
-#: add.html:13
-msgid ""
-"We require a minimum set of fields to create a new record. These are "
-"those fields."
-msgstr "Aby utworzyć nowy wpis wymagane jest uzupełnienie nastepujących pól."
-
-#: add.html:34 advancedsearch.html:21 edit.html:98 nav_head.html:45
-#: openlibrary/templates/work_search.html:122
-#: openlibrary/templates/work_search.html:202 search_foot.html:9
-#: search_head.html:9
-msgid "Author"
-msgstr "Autor"
-
-#: add.html:34
-msgid ""
-"Like, \"Agatha Christie\" or \"Jean-Paul Sartre.\" We'll also do a live "
-"check to see if we already know the author."
+#: admin/attach_debugger.html
+#, python-format
+msgid "Attach Debugger on Python %(version_number)s"
 msgstr ""
-"Na przykład, \"Agatha Christie\" lub \"Jean-Paul Sartre.\" Jeśli autor "
-"znajduje się na liście - kliknij na jego nazwisko by wybrać."
 
-#: add.html:39 edit/edition.html:130
-msgid "Who is the publisher?"
-msgstr "Wydawnictwo"
+#: admin/attach_debugger.html
+msgid "Start a debugger on port 3000."
+msgstr ""
 
-#: add.html:46 edit/edition.html:140
-msgid "When was it published?"
-msgstr "Data publikacji tego wydania"
+#: admin/attach_debugger.html
+msgid "Waiting for debugger to attach..."
+msgstr ""
 
-#: add.html:46
-msgid "The year it was published is plenty."
-msgstr "Wystarczy podanie roku publikacji tego wydania."
+#: admin/attach_debugger.html
+#, fuzzy
+msgid "Start"
+msgstr "Status"
 
-#: add.html:53
-msgid ""
-"And optionally, an ID number &#151; like an ISBN &#151; would be "
-"helpful..."
-msgstr "Opjonalnie możesz dodać numer identyfikacyjny &#151; np. ISBN &#151"
+#: admin/block.html
+#, fuzzy
+msgid "Block IP address"
+msgstr "Twój adres e-mail"
 
-#: add.html:54
-msgid "ID Type"
-msgstr "Rodzaj numeru identyfikacyjnego"
+#: admin/block.html
+#, python-format
+msgid "IP address %(address)s has been added to the textarea. Please click Save to block that IP."
+msgstr ""
 
-#: add.html:57
-msgid "Select"
-msgstr "Wybierz"
+#: admin/block.html
+msgid "Blocked IP Addresses"
+msgstr ""
 
-#: add.html:70
-msgid "Since you are not logged in, please satisfy the reCAPTCHA below."
-msgstr "Poniważ nie jesteś zalogowana, prosimy o uzupełnienie reCAPTCHA poniżej."
+#: admin/graphs.html
+msgid "Performance Graphs"
+msgstr ""
 
-#: add.html:77
-msgid "Add this book now"
-msgstr "Dodaj tę książkę"
+#: admin/graphs.html
+#, fuzzy
+msgid "Number of Hits"
+msgstr "Liczba stron"
 
-#: add.html:77 edit/addfield.html:85 edit/addfield.html:131
-#: edit/addfield.html:175 edit/edition.html:319 edit/edition.html:483
-#: edit/edition.html:549 edit/excerpts.html:50
+#: admin/graphs.html
+msgid "Page Load Times"
+msgstr ""
+
+#: admin/graphs.html
+msgid "Page Load Times Split"
+msgstr ""
+
+#: admin/graphs.html
+msgid "Infobase Mean"
+msgstr ""
+
+#: admin/history.html admin/imports.html authors/infobox.html type/author/edit.html
+#, fuzzy
+msgid "Date"
+msgstr "Dorzuć się"
+
+#: admin/history.html
+#, fuzzy
+msgid "Page"
+msgstr "miejsce"
+
+#: admin/imports-add.html admin/imports.html admin/imports_by_date.html admin/menu.html
+#, fuzzy
+msgid "Imports"
+msgstr "Tekst"
+
+#: admin/imports-add.html books/add.html books/edit/edition.html books/edit/excerpts.html covers/change.html type/tag/form.html
 msgid "Add"
 msgstr "Dodaj"
 
-#: author-autocomplete.html:13
+#: admin/imports-add.html admin/imports.html
+#, fuzzy
+msgid "Add new books to import queue"
+msgstr "Dodaj nową książkę do Open Library"
+
+#: admin/imports-add.html
+msgid "Please add IA identifiers to be imported, one per line."
+msgstr ""
+
+#: admin/imports-add.html admin/inspect/store.html admin/ip/view.html admin/people/edits.html admin/permissions.html my_books/check_ins/check_in_form.html reading_goals/reading_goal_form.html
+msgid "Submit"
+msgstr "Zatwierdź"
+
+#: admin/imports.html
+msgid "New Books Imported Per Day"
+msgstr ""
+
+#: PublishingHistory.html admin/imports.html publishers/view.html
+msgid "You need to have JavaScript turned on to see the nifty chart!"
+msgstr "Musisz mieć włączony JavaScript, aby zobaczyć fajny wykres!"
+
+#: admin/imports.html admin/imports_by_date.html admin/pd_dashboard.html site/stats.html
+msgid "Summary"
+msgstr ""
+
+#: admin/imports.html
+#, fuzzy
+msgid "Pending Items:"
+msgstr "Moje listy lektur:"
+
+#: admin/imports.html
+#, python-format
+msgid "<strong>Current Import Rate:</strong> %(num)d imports/hour."
+msgstr ""
+
+#: admin/imports.html
+#, fuzzy
+msgid "ETA:"
+msgstr "Grubość"
+
+#: admin/imports.html
+msgid "Summary By Date"
+msgstr ""
+
+#: admin/imports.html
+#, fuzzy
+msgid "total"
+msgstr "Tytuł"
+
+#: admin/imports.html
+#, fuzzy
+msgid "#books created"
+msgstr "Utworzone Listy"
+
+#: admin/imports.html
+msgid "#books already found"
+msgstr ""
+
+#: admin/imports.html
+msgid "#books failed to import"
+msgstr ""
+
+#: admin/imports.html
+msgid "#books pending"
+msgstr ""
+
+#: admin/imports.html
+msgid "Recent Imports"
+msgstr ""
+
+#: admin/imports.html admin/imports_by_date.html
+msgid "Identifier"
+msgstr ""
+
+#: admin/imports.html admin/imports_by_date.html
+msgid "Imported Time"
+msgstr ""
+
+#: admin/imports_by_date.html admin/index.html admin/pd_dashboard.html
+#, fuzzy
+msgid "Total"
+msgstr "Tytuł"
+
+#: admin/imports_by_date.html
+#, fuzzy
+msgid "Created"
+msgstr "Przeczytaj"
+
+#: admin/imports_by_date.html
+#, fuzzy
+msgid "Found"
+msgstr "Nie znaleziono."
+
+#: admin/imports_by_date.html
+#, fuzzy
+msgid "Failed"
+msgstr "filtrów"
+
+#: admin/imports_by_date.html openlibrary/core/edits.py
+msgid "Pending"
+msgstr ""
+
+#: admin/imports_by_date.html
+#, fuzzy
+msgid "Items"
+msgstr "Motywy:"
+
+#: admin/index.html
+msgid "<span class=\"login-counts\">0</span> patrons have logged in at least once over the past 30 days."
+msgstr ""
+
+#: admin/index.html
+#, fuzzy
+msgid "Stats"
+msgstr "Status"
+
+#: admin/index.html
+msgid "Edits Per Day"
+msgstr ""
+
+#: admin/index.html admin/people/index.html
+#, fuzzy
+msgid "Edits"
+msgstr "Edytuj"
+
+#: admin/index.html
+msgid "Yesterday"
+msgstr ""
+
+#: admin/index.html
+msgid "Last 7 days"
+msgstr ""
+
+#: admin/index.html
+msgid "Last 28 days"
+msgstr ""
+
+#: admin/index.html
+msgid "Human"
+msgstr ""
+
+#: admin/index.html admin/people/view.html
+#, fuzzy
+msgid "Bot"
+msgstr "Opis"
+
+#: admin/index.html
+msgid "New Accounts Per Day"
+msgstr ""
+
+#: admin/index.html
+#, fuzzy
+msgid "Members"
+msgstr "Nowi użytkownicy"
+
+#: admin/index.html
+#, fuzzy
+msgid "Items Added"
+msgstr "Dodano"
+
+#: admin/index.html
+#, fuzzy
+msgid "Trend"
+msgstr "Przeczytaj"
+
+#: admin/index.html
+#, fuzzy
+msgid "Works Added"
+msgstr "Dodano"
+
+#: admin/index.html
+#, fuzzy
+msgid "Editions Added"
+msgstr "Wydania opublikowane"
+
+#: admin/index.html
+#, fuzzy
+msgid "Authors Added"
+msgstr "Autorzy"
+
+#: admin/index.html recentchanges/index.html
+msgid "Covers Added"
+msgstr ""
+
+#: admin/index.html home/stats.html
+msgid "New Members"
+msgstr "Nowi użytkownicy"
+
+#: admin/index.html
+#, fuzzy
+msgid "Lists Added"
+msgstr "Utworzone Listy"
+
+#: admin/index.html
+#, fuzzy
+msgid "Books Logged"
+msgstr "Książki, które kochamy"
+
+#: admin/index.html
+msgid "Users Logging"
+msgstr ""
+
+#: admin/index.html
+#, fuzzy
+msgid "Yearly Reading Goals"
+msgstr "Moje listy lektur:"
+
+#: admin/index.html
+msgid "Books Review Tags"
+msgstr ""
+
+#: admin/index.html
+#, fuzzy
+msgid "Books Reviewed"
+msgstr "e-Booki wszędzie"
+
+#: admin/index.html
+msgid "Users Reviewing"
+msgstr ""
+
+#: admin/index.html
+msgid "Patrons Following"
+msgstr ""
+
+#: admin/index.html
+#, fuzzy
+msgid "Notes Created"
+msgstr "Utworzone Listy"
+
+#: admin/index.html
+msgid "Patrons Creating Notes"
+msgstr ""
+
+#: admin/index.html
+#, fuzzy
+msgid "Books Starred"
+msgstr "Wypożyczone e-booki"
+
+#: admin/index.html
+msgid "Star Rating Patrons"
+msgstr ""
+
+#: admin/index.html home/stats.html
+msgid "Unique Visitors"
+msgstr "Szczególni odwiedzający"
+
+#: admin/index.html
+#, fuzzy
+msgid "Unique visitors IPs per day graph"
+msgstr "Szczególni odwiedzający"
+
+#: admin/index.html
+#, fuzzy
+msgid "Borrows"
+msgstr "Wypożycz"
+
+#: admin/index.html
+msgid "Borrows, last 3 months graph"
+msgstr ""
+
+#: admin/index.html
+msgid "Borrows, last 2 years graph"
+msgstr ""
+
+#: admin/index.html
+#, fuzzy
+msgid "Unique Logins"
+msgstr "Szczególni odwiedzający"
+
+#: admin/index.html
+msgid "Gathering login statistics..."
+msgstr ""
+
+#: admin/loans_table.html
+msgid "BookReader"
+msgstr ""
+
+#: admin/loans_table.html book_providers/cita_press_download_options.html book_providers/ia_download_options.html book_providers/openstax_download_options.html book_providers/wikisource_download_options.html books/edit/edition.html
+msgid "PDF"
+msgstr ""
+
+#: admin/loans_table.html book_providers/gutenberg_download_options.html book_providers/ia_download_options.html book_providers/standard_ebooks_download_options.html books/edit/edition.html
+msgid "ePub"
+msgstr ""
+
+#: admin/loans_table.html
+#, fuzzy
+msgid "No current loans."
+msgstr "1 obecnie wypożyczona"
+
+#: admin/loans_table.html
+#, python-format
+msgid "%d Current Loan"
+msgid_plural "%d Current Loans"
+msgstr[0] ""
+msgstr[1] ""
+
+#: RecentChanges.html RecentChangesUsers.html admin/ip/view.html admin/loans_table.html admin/people/edits.html recentchanges/render.html recentchanges/updated_records.html
+msgid "What"
+msgstr "Co"
+
+#: admin/loans_table.html
+#, fuzzy, python-format
+msgid "Waiting since %(date)s"
+msgstr "Dołączył\\(a\\) %(date)s"
+
+#: admin/loans_table.html
+#, python-format
+msgid "#%(num_position)d among %(num_waitlist)d people waiting for this book"
+msgstr ""
+
+#: ManageLoansButtons.html admin/loans_table.html
+#, fuzzy, python-format
+msgid "Borrowed %(date)s"
+msgstr "Dołączył\\(a\\) %(date)s"
+
+#: admin/menu.html
+#, fuzzy
+msgid "Admin Center"
+msgstr "Centrum Rozwoju"
+
+#: RelatedSubjects.html SubjectTags.html admin/menu.html admin/people/index.html admin/people/view.html openlibrary/plugins/worksearch/code.py type/author/view.html type/list/view_body.html
+msgid "People"
+msgstr "Ludzie"
+
+#: admin/menu.html
+msgid "PD Access Requests"
+msgstr ""
+
+#: admin/menu.html
+msgid "Block IPs"
+msgstr ""
+
+#: admin/menu.html admin/spamwords.html
+#, fuzzy
+msgid "Spam Words"
+msgstr "Hasło"
+
+#: admin/menu.html
+#, fuzzy
+msgid "Solr"
+msgstr "lub"
+
+#: admin/menu.html
+msgid "Graphs"
+msgstr ""
+
+#: admin/menu.html
+msgid "Inspect store"
+msgstr ""
+
+#: admin/menu.html
+#, fuzzy
+msgid "Inspect memcache"
+msgstr "Wyszukiwanie tematu"
+
+#: admin/pd_dashboard.html
+msgid "Print Disability Access Requests"
+msgstr ""
+
+#: admin/pd_dashboard.html
+msgid "Breakdown by Qualifying Authority"
+msgstr ""
+
+#: admin/pd_dashboard.html
+msgid "PDA"
+msgstr ""
+
+#: admin/pd_dashboard.html
+#, fuzzy
+msgid "Emailed"
+msgstr "E-mail"
+
+#: admin/pd_dashboard.html
+msgid "Fulfilled"
+msgstr ""
+
+#: admin/pd_dashboard.html
+msgid "Totals"
+msgstr ""
+
+#: admin/permissions.html
+msgid "[Admin Center] Site Permissions"
+msgstr ""
+
+#: admin/permissions.html
+#, fuzzy
+msgid "Site Permissions"
+msgstr "brakuje imienia"
+
+#: admin/permissions.html
+msgid "Change the policy of who can edit the site."
+msgstr ""
+
+#: admin/permissions.html
+#, fuzzy
+msgid "Who can edit Open Library records?"
+msgstr "Ilu nowych użytkowników Open Library powitaliśmy?"
+
+#: admin/permissions.html
+msgid "This applies to /authors/*, /books/* and /works/* records."
+msgstr ""
+
+#: admin/permissions.html
+#, fuzzy
+msgid "Who can edit Open Library pages?"
+msgstr "Open Library"
+
+#: admin/permissions.html
+msgid "This applies to /about/*, /help/*, /dev/*, /docs/* etc."
+msgstr ""
+
+#: admin/permissions.html
+#, fuzzy
+msgid "Update permissions"
+msgstr "Zaktualizuj adres e-mail"
+
+#: admin/permissions.html
+msgid "This updates \"permission\" and \"child_permission\" fields of /, /works, /books and /authors records in the database."
+msgstr ""
+
+#: admin/solr.html
+msgid "Solr Admin"
+msgstr ""
+
+#: admin/solr.html
+msgid "Enter the keys of pages to be updated in OL search engine."
+msgstr ""
+
+#: admin/solr.html
+#, fuzzy
+msgid "Example:"
+msgstr "Na przykład:"
+
+#: admin/solr.html
+msgid "On update, these keys will be added to solr update queue and it'll take about 15 minutes for them to get reindexed in Solr."
+msgstr ""
+
+#: admin/solr.html
+msgid "Enter the keys to reindex in Solr"
+msgstr ""
+
+#: admin/solr.html
+msgid "Write one entry per line"
+msgstr ""
+
+#: admin/spamwords.html
+msgid "[Admin Center] Spam Words"
+msgstr ""
+
+#: admin/spamwords.html
+msgid "Please enter the SPAM regular expressions in the textarea below, one per line."
+msgstr ""
+
+#: admin/spamwords.html
+msgid "Be sure to escape any meta characters that are meant to be character literals."
+msgstr ""
+
+#: admin/spamwords.html
+msgid "If you are adding a domain, prepend the following to the domain:"
+msgstr ""
+
+#: admin/spamwords.html
+msgid "For example, if you want to prevent edits containing the domain <code>t.co</code>, add <code>(|https://|http://)t\\.co</code> to the spamwords list."
+msgstr ""
+
+#: admin/spamwords.html
+#, fuzzy
+msgid "Spam Domains"
+msgstr "Wypożyczone przeze mnie"
+
+#: admin/spamwords.html
+msgid "Please enter domains to blacklist in the textarea below, one per line."
+msgstr ""
+
+#: admin/sync.html
+msgid "Sync"
+msgstr ""
+
+#: admin/sync.html
+msgid "Sync the metadata of various types of Open Library items (e.g. lists, subjects, works) with Archive.org."
+msgstr ""
+
+#: admin/sync.html
+#, fuzzy
+msgid "Add Works to Staff Picks"
+msgstr "Dodaj do Wyboranych przez nas"
+
+#: admin/sync.html
+msgid "This utility will add your work to an Open Library list called `Staff Picks` under the `openlibrary` user. It will then take the added work and explode it into a list of all its readable editions. For each Open Library edition, a metadata field called `openlibrary_subject` will be injected into the archive.org metadata of the edition's corresponding archive.org item."
+msgstr ""
+
+#: admin/sync.html
+#, fuzzy
+msgid "add"
+msgstr "Dodaj"
+
+#: admin/sync.html
+#, fuzzy
+msgid "remove"
+msgstr "Usuń"
+
+#: admin/sync.html
+#, fuzzy
+msgid "Update edition"
+msgstr "O tym wydaniu"
+
+#: admin/sync.html
+msgid "Updates an edition on archive.org by writing in its latest  openlibrary_edition and openlibrary_work identifier values"
+msgstr ""
+
+#: admin/sync.html
+msgid "TODO"
+msgstr ""
+
+#: admin/inspect/memcache.html
+msgid "[Admin Center] Inspect Memcache"
+msgstr ""
+
+#: admin/inspect/memcache.html
+#, fuzzy
+msgid "Inspect Memcache"
+msgstr "Wyszukiwanie tematu"
+
+#: admin/inspect/memcache.html
+msgid "Add one memcache key per line in the text area. Each key must include a '-' as the last character."
+msgstr ""
+
+#: admin/inspect/memcache.html
+msgid "For example, <code>observations-</code> should be entered in the text area if the key is <code>observations</code>."
+msgstr ""
+
+#: admin/inspect/memcache.html
+#, fuzzy
+msgid "Keys:"
+msgstr "Słowa kluczowe"
+
+#: admin/inspect/memcache.html
+#, fuzzy
+msgid "Result"
+msgstr "Zresetuj"
+
+#: admin/inspect/memcache.html
+#, fuzzy
+msgid "No keys selected."
+msgstr "Brak wybranych wydań."
+
+#: admin/inspect/memcache.html
+#, fuzzy
+msgid "Not found."
+msgstr "Nie znaleziono."
+
+#: admin/inspect/store.html
+msgid "Admin Center / Inspect"
+msgstr ""
+
+#: admin/inspect/store.html
+msgid "Inspect Store"
+msgstr ""
+
+#: admin/inspect/store.html
+msgid "Get"
+msgstr ""
+
+#: admin/inspect/store.html
+#, fuzzy
+msgid "Key"
+msgstr "Słowa kluczowe"
+
+#: admin/inspect/store.html
+msgid "Query"
+msgstr ""
+
+#: admin/inspect/store.html
+#, fuzzy
+msgid "Type"
+msgstr "Rodzaj numeru identyfikacyjnego"
+
+#: admin/inspect/store.html
+#, fuzzy
+msgid "Value"
+msgstr "Tom"
+
+#: admin/inspect/store.html
+#, fuzzy
+msgid "Documents"
+msgstr "Treść dokumentu:"
+
+#: admin/inspect/store.html
+#, fuzzy
+msgid "Json"
+msgstr "Wizja"
+
+#: admin/inspect/store.html
+msgid "No results found."
+msgstr "Brak wyników."
+
+#: admin/ip/index.html
+msgid "[Admin Center] IP Addresses"
+msgstr ""
+
+#: admin/ip/index.html
+#, fuzzy
+msgid "IP Addresses"
+msgstr "Twój adres e-mail"
+
+#: admin/ip/index.html
+msgid "List of Banned IPs"
+msgstr ""
+
+#: admin/ip/index.html admin/people/index.html
+#, fuzzy
+msgid "Date/Time"
+msgstr "czas"
+
+#: admin/ip/index.html
+#, fuzzy
+msgid "IP address"
+msgstr "Twój adres e-mail"
+
+#: admin/ip/index.html
+#, fuzzy
+msgid "Admin Comment"
+msgstr "Komentarz"
+
+#: admin/ip/index.html
+#, fuzzy
+msgid "# of edits"
+msgstr "Historia zmian"
+
+#: admin/ip/index.html
+msgid "x minutes ago"
+msgstr ""
+
+#: admin/ip/index.html admin/ip/view.html
+msgid "IP"
+msgstr ""
+
+#: admin/ip/index.html
+#, fuzzy
+msgid "comment"
+msgstr "Komentarz"
+
+#: admin/ip/view.html admin/people/view.html
+#, fuzzy
+msgid "[Admin Center]"
+msgstr "Centrum Rozwoju"
+
+#: admin/ip/view.html
+#, python-format
+msgid "IP %(ip)s is <a href=\"/admin/block\">blocked</a>."
+msgstr ""
+
+#: admin/ip/view.html
+#, python-format
+msgid "Block %(ip)s"
+msgstr ""
+
+#: admin/ip/view.html admin/people/edits.html
+#, fuzzy
+msgid "Please select the changesets to revert."
+msgstr "Wybierz autorów do połączenia."
+
+#: RecentChanges.html admin/ip/view.html admin/people/edits.html recentchanges/render.html
+msgid "When you see numbers here, that's the IP address of the anonymous editor"
+msgstr ""
+
+#: admin/ip/view.html admin/people/edits.html
+#, python-format
+msgid "Reverted by %(revert_author)s"
+msgstr ""
+
+#: EditButtons.html admin/ip/view.html admin/people/edits.html
+msgid "Please, leave a short note about what you changed: <span class=\"small gray\">(Optional, but very useful!)</span>"
+msgstr ""
+
+#: admin/ip/view.html admin/people/edits.html
+msgid "Reverted spam"
+msgstr ""
+
+#: admin/people/edits.html
+#, python-format
+msgid "[Admin Center] Edits of %(user)s"
+msgstr ""
+
+#: admin/people/edits.html
+#, fuzzy
+msgid "people"
+msgstr "Ludzie"
+
+#: admin/people/edits.html
+#, fuzzy
+msgid "edits"
+msgstr "Edytuj"
+
+#: admin/people/index.html
+msgid "[Admin Center] People"
+msgstr ""
+
+#: admin/people/index.html
+#, fuzzy
+msgid "Find Account"
+msgstr "Moje konto"
+
+#: admin/people/index.html admin/people/view.html
+#, fuzzy
+msgid "Email Address:"
+msgstr "Twój adres e-mail"
+
+#: admin/people/index.html
+#, fuzzy
+msgid "Find"
+msgstr "w"
+
+#: admin/people/index.html
+#, fuzzy
+msgid "No account found with this email."
+msgstr "Nie istnieje konto z podanym adresem e-mail."
+
+#: admin/people/index.html
+msgid "IA ID:"
+msgstr ""
+
+#: admin/people/index.html
+msgid "e.g. @foobar"
+msgstr ""
+
+#: admin/people/index.html
+msgid "No account found with this ID."
+msgstr ""
+
+#: admin/people/index.html
+#, fuzzy
+msgid "Recent Accounts"
+msgstr "Usuń konto"
+
+#: admin/people/index.html
+#, fuzzy
+msgid "email"
+msgstr "E-mail"
+
+#: admin/people/index.html
+#, fuzzy
+msgid "profile"
+msgstr "Mój profil"
+
+#: admin/people/index.html admin/people/view.html
+#, fuzzy
+msgid "Edit History"
+msgstr "Usuń listę"
+
+#: admin/people/view.html
+msgid "block and revert all edits"
+msgstr ""
+
+#: admin/people/view.html
+#, fuzzy
+msgid "block this account"
+msgstr "Usuń konto"
+
+#: admin/people/view.html
+#, python-format
+msgid "Registered on <span class=\"time\">%(date)s</span>."
+msgstr ""
+
+#: admin/people/view.html
+msgid "login as this user"
+msgstr ""
+
+#: admin/people/view.html
+#, python-format
+msgid "Activated on <span class=\"time\">%(date)s</span> from <a href=\"/admin/ip/%(ip)s\">%(ip)s</a>."
+msgstr ""
+
+#: admin/people/view.html
+msgid "unblock this account"
+msgstr ""
+
+#: admin/people/view.html
+#, fuzzy
+msgid "activate account"
+msgstr "Usuń konto"
+
+#: CreateListModal.html admin/people/view.html my_books/dropdown_content.html
+msgid "Name:"
+msgstr "Nazwa:"
+
+#: admin/people/view.html
+#, fuzzy
+msgid "view profile"
+msgstr "Mój profil"
+
+#: admin/people/view.html
+#, fuzzy
+msgid "Change"
+msgstr "Nie zmnieniono"
+
+#: admin/people/view.html
+#, fuzzy
+msgid "Admin"
+msgstr "strona administratora"
+
+#: admin/people/view.html
+msgid "Make Human"
+msgstr ""
+
+#: admin/people/view.html
+#, fuzzy
+msgid "Make Bot"
+msgstr "Opis"
+
+#: admin/people/view.html
+msgid "Not available"
+msgstr ""
+
+#: admin/people/view.html
+#, fuzzy
+msgid "# Edits"
+msgstr "Edytuj"
+
+#: admin/people/view.html
+#, fuzzy
+msgid "Member Since:"
+msgstr "\"Zapamniętaj mnie"
+
+#: admin/people/view.html
+msgid "Last Login:"
+msgstr ""
+
+#: admin/people/view.html
+msgid "Tags:"
+msgstr ""
+
+#: admin/people/view.html
+#, fuzzy
+msgid "Anonymize Account:"
+msgstr "Moje konto"
+
+#: admin/people/view.html
+msgid "Dry Run"
+msgstr ""
+
+#: admin/people/view.html
+#, fuzzy
+msgid "Anonymize Account"
+msgstr "Moje konto"
+
+#: admin/people/view.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py type/user/view.html
+msgid "Loans"
+msgstr "Wypożyczone"
+
+#: admin/people/view.html
+#, fuzzy
+msgid "Account not activated yet."
+msgstr "Konto jest już aktywne"
+
+#: admin/people/view.html
+#, fuzzy
+msgid "Waiting Loans"
+msgstr "Pisanie botów"
+
+#: admin/people/view.html
+#, python-format
+msgid "%(num)d edits"
+msgstr ""
+
+#: admin/people/view.html
+msgid "Debug Info"
+msgstr ""
+
+#: admin/people/view.html
+msgid "Account Information"
+msgstr ""
+
+#: admin/people/view.html
+#, fuzzy
+msgid "Verifications Links"
+msgstr "E-mail weryfikacyjny został wysłany."
+
+#: admin/people/view.html
+#, fuzzy
+msgid "None found"
+msgstr "Nie znaleziono."
+
+#: SearchNavigation.html authors/index.html lib/nav_foot.html merge/authors.html publishers/view.html
+msgid "Authors"
+msgstr "Autorzy"
+
+#: authors/index.html
+msgid "Search for an Author"
+msgstr ""
+
+#: authors/index.html lib/nav_head.html lists/home.html publishers/index.html publishers/notfound.html publishers/view.html search/advancedsearch.html search/publishers.html search/search_modal_i18n.html search/searchbox.html type/local_id/view.html
+msgid "Search"
+msgstr "Szukaj"
+
+#: authors/index.html search/authors.html
+#, python-format
+msgid "about %(subjects)s"
+msgstr "o %(subjects)s"
+
+#: authors/index.html search/authors.html
+#, python-format
+msgid "including <i>%(topwork)s</i>"
+msgstr "włączając <i>%(topwork)s</i>"
+
+#: authors/infobox.html
+#, python-format
+msgid "View on %(site)s"
+msgstr ""
+
+#: authors/infobox.html
+#, fuzzy
+msgid "Born"
+msgstr "lub"
+
+#: authors/infobox.html
+#, fuzzy
+msgid "Died"
+msgstr "Zmieniono"
+
+#: book_providers/cita_press_download_options.html book_providers/gutenberg_download_options.html book_providers/ia_download_options.html book_providers/librivox_download_options.html book_providers/openstax_download_options.html book_providers/runeberg_download_options.html book_providers/standard_ebooks_download_options.html book_providers/wikisource_download_options.html
+#, fuzzy
+msgid "Download Options"
+msgstr "Pobierz"
+
+#: book_providers/cita_press_download_options.html
+#, fuzzy
+msgid "Download PDF from Cita Press"
+msgstr "Przeczytaj e-book z Internet Archive"
+
+#: book_providers/cita_press_download_options.html
+msgid "More at Cita Press"
+msgstr ""
+
+#: book_providers/gutenberg_download_options.html
+msgid "Download an HTML from Project Gutenberg"
+msgstr ""
+
+#: book_providers/gutenberg_download_options.html book_providers/runeberg_download_options.html book_providers/standard_ebooks_download_options.html type/list/exports.html
+msgid "HTML"
+msgstr ""
+
+#: book_providers/gutenberg_download_options.html
+#, fuzzy
+msgid "Download a text version from Project Gutenberg"
+msgstr "Przeczytaj e-book z Internet Archive"
+
+#: book_providers/gutenberg_download_options.html book_providers/ia_download_options.html
+msgid "Plain text"
+msgstr ""
+
+#: book_providers/gutenberg_download_options.html
+#, fuzzy
+msgid "Download an ePub from Project Gutenberg"
+msgstr "Przeczytaj e-book z Internet Archive"
+
+#: book_providers/gutenberg_download_options.html
+msgid "Download a Kindle file from Project Gutenberg"
+msgstr ""
+
+#: book_providers/gutenberg_download_options.html
+#, fuzzy
+msgid "Kindle"
+msgstr "Książki dla dzieci"
+
+#: book_providers/gutenberg_download_options.html
+msgid "More at Project Gutenberg"
+msgstr ""
+
+#: book_providers/ia_download_options.html
+#, fuzzy
+msgid "Download a PDF from Internet Archive"
+msgstr "Przeczytaj e-book z Internet Archive"
+
+#: book_providers/ia_download_options.html
+#, fuzzy
+msgid "Download a text version from Internet Archive"
+msgstr "Przeczytaj e-book z Internet Archive"
+
+#: book_providers/ia_download_options.html
+#, fuzzy
+msgid "Download an ePub from Internet Archive"
+msgstr "Przeczytaj e-book z Internet Archive"
+
+#: book_providers/ia_download_options.html
+#, fuzzy
+msgid "Download a MOBI file from Internet Archive"
+msgstr "Przeczytaj e-book z Internet Archive"
+
+#: book_providers/ia_download_options.html
+msgid "MOBI"
+msgstr ""
+
+#: book_providers/ia_download_options.html
+msgid "Download open DAISY from Internet Archive (print-disabled format)"
+msgstr ""
+
+#: book_providers/ia_download_options.html type/list/embed.html
+msgid "DAISY"
+msgstr ""
+
+#: book_providers/librivox_download_options.html
+#, fuzzy
+msgid "Download a ZIP file of the whole book from Internet Archive"
+msgstr "Przeczytaj e-book z Internet Archive"
+
+#: book_providers/librivox_download_options.html
+msgid "Whole Book MP3"
+msgstr ""
+
+#: book_providers/librivox_download_options.html
+msgid "Get the RSS Feed from LibriVox"
+msgstr ""
+
+#: book_providers/librivox_download_options.html
+msgid "RSS Feed"
+msgstr ""
+
+#: book_providers/librivox_download_options.html
+msgid "More at LibriVox"
+msgstr ""
+
+#: book_providers/openstax_download_options.html
+#, fuzzy
+msgid "Download PDF from OpenStax"
+msgstr "Przeczytaj e-book z Internet Archive"
+
+#: book_providers/openstax_download_options.html
+msgid "More at OpenStax"
+msgstr ""
+
+#: book_providers/read_button.html
+#, python-format
+msgid "Listen to a reading from %s"
+msgstr ""
+
+#: book_providers/read_button.html
+#, fuzzy
+msgid "Audiobook"
+msgstr "Losowa książka"
+
+#: book_providers/read_button.html
+#, python-format
+msgid "Read free online from %s"
+msgstr ""
+
+#: book_providers/runeberg_download_options.html
+msgid "Download all scanned images from Project Runeberg"
+msgstr ""
+
+#: book_providers/runeberg_download_options.html
+msgid "Scanned images"
+msgstr ""
+
+#: book_providers/runeberg_download_options.html
+msgid "Download all color images from Project Runeberg"
+msgstr ""
+
+#: book_providers/runeberg_download_options.html
+msgid "Color images"
+msgstr ""
+
+#: book_providers/runeberg_download_options.html
+msgid "Download all HTML files from Project Runeberg"
+msgstr ""
+
+#: book_providers/runeberg_download_options.html
+msgid "Download all text and index files from Project Runeberg"
+msgstr ""
+
+#: book_providers/runeberg_download_options.html
+msgid "Text and index files"
+msgstr ""
+
+#: book_providers/runeberg_download_options.html
+msgid "Download all OCR text from Project Runeberg"
+msgstr ""
+
+#: book_providers/runeberg_download_options.html
+#, fuzzy
+msgid "OCR text"
+msgstr "Tekst"
+
+#: book_providers/runeberg_download_options.html
+msgid "More at Project Runeberg"
+msgstr ""
+
+#: book_providers/standard_ebooks_download_options.html
+msgid "Download an HTML from Standard Ebooks"
+msgstr ""
+
+#: book_providers/standard_ebooks_download_options.html
+#, fuzzy
+msgid "Download an ePub from Standard Ebook."
+msgstr "Przeczytaj e-book z Internet Archive"
+
+#: book_providers/standard_ebooks_download_options.html
+#, fuzzy
+msgid "Download a Kindle file from Standard Ebooks"
+msgstr "Przeczytaj e-book z Internet Archive"
+
+#: book_providers/standard_ebooks_download_options.html
+msgid "Kindle (azw3)"
+msgstr ""
+
+#: book_providers/standard_ebooks_download_options.html
+#, fuzzy
+msgid "Download a Kobo file from Standard Ebooks"
+msgstr "Przeczytaj e-book z Internet Archive"
+
+#: book_providers/standard_ebooks_download_options.html
+msgid "Kobo (kepub)"
+msgstr ""
+
+#: book_providers/standard_ebooks_download_options.html
+msgid "View the source code for this Standard Ebook at GitHub"
+msgstr ""
+
+#: Subnavigation.html book_providers/standard_ebooks_download_options.html
+msgid "Source Code"
+msgstr ""
+
+#: book_providers/standard_ebooks_download_options.html
+msgid "More at Standard Ebooks"
+msgstr ""
+
+#: book_providers/wikisource_download_options.html
+#, fuzzy
+msgid "Download PDF from Wikisource"
+msgstr "Przeczytaj e-book z Internet Archive"
+
+#: book_providers/wikisource_download_options.html
+#, fuzzy
+msgid "Download MOBI from Wikisource"
+msgstr "Przeczytaj e-book z Internet Archive"
+
+#: book_providers/wikisource_download_options.html
+msgid "MOBI (for Kindle)"
+msgstr ""
+
+#: book_providers/wikisource_download_options.html
+#, fuzzy
+msgid "Download EPUB from Wikisource"
+msgstr "Przeczytaj e-book z Internet Archive"
+
+#: book_providers/wikisource_download_options.html
+msgid "EPUB (for most other e-readers)"
+msgstr ""
+
+#: book_providers/wikisource_download_options.html
+msgid "Read at Wikisource"
+msgstr ""
+
+#: books/RelatedWorksCarousel.html
+msgid "You might also like"
+msgstr ""
+
+#: books/RelatedWorksCarousel.html
+msgid "More by this author"
+msgid_plural "More by these authors"
+msgstr[0] ""
+msgstr[1] ""
+
+#: books/add.html books/check.html
+msgid "Add a book"
+msgstr "Dodaj książkę"
+
+#: books/add.html
+msgid "Invalid ISBN checksum digit"
+msgstr ""
+
+#: books/add.html
+#, fuzzy
+msgid "ID must be exactly 10 characters [0-9 or X]. For example 0-19-853453-1 or 0198534531"
+msgstr "ID musi zawierać dokładnie 10 znaków [0-9] lub X."
+
+#: books/add.html
+#, fuzzy
+msgid "ID must be exactly 13 characters [0-9]. For example 978-3-16-148410-0 or 9783161484100"
+msgstr "ID musi zawierać dokładnie 10 znaków [0-9] lub X."
+
+#: books/add.html
+msgid "Invalid LC Control Number format"
+msgstr ""
+
+#: books/add.html
+msgid "Invalid OCLC/WorldCat Control Number format"
+msgstr ""
+
+#: books/add.html
+#, fuzzy
+msgid "Please enter a value for the selected identifier"
+msgstr "Wybierz typ identyfikacji."
+
+#: books/add.html
+msgid "Are you sure that's the published date?"
+msgstr ""
+
+#: books/add.html
+msgid "Add a book to Open Library"
+msgstr "Dodaj książkę do Open Library"
+
+#: books/add.html
+msgid "We require a minimum set of fields to create a new record. These are those fields."
+msgstr "Aby utworzyć nowy wpis wymagane jest uzupełnienie nastepujących pól."
+
+#: books/add.html books/edit.html
+msgid "Use <b><i>Title: Subtitle</i></b> to add a subtitle."
+msgstr "Użyj <b><i>Tytuł: Podtytuł</i></b> aby dodać podtytuł."
+
+#: books/add.html books/edit.html type/author/edit.html type/tag/tag_form_inputs.html
+msgid "Required field"
+msgstr "Pole wymagane"
+
+#: books/add.html
+msgid "Like, \"Agatha Christie\" or \"Jean-Paul Sartre.\" We'll also do a live check to see if we already know the author."
+msgstr "Na przykład, \"Agatha Christie\" lub \"Jean-Paul Sartre.\" Jeśli autor znajduje się na liście - kliknij na jego nazwisko by wybrać."
+
+#: books/add.html books/edit/edition.html
+msgid "Who is the publisher?"
+msgstr "Wydawnictwo"
+
+#: books/add.html books/edit/edition.html
+msgid "For example:"
+msgstr "Na przykład:"
+
+#: books/add.html
+msgid "Oxford University Press; Penguin; W.W. Norton"
+msgstr ""
+
+#: books/add.html books/edit/edition.html
+msgid "When was it published?"
+msgstr "Data publikacji tego wydania"
+
+#: books/add.html books/edit/edition.html
+msgid "You should be able to find this in the first few pages of the book."
+msgstr "Możesz znaleźć te informacje na pierwszych stronach książki."
+
+#: books/add.html
+msgid "And optionally, an ID number &#151; like an ISBN &#151; would be helpful..."
+msgstr "Opjonalnie możesz dodać numer identyfikacyjny &#151; np. ISBN &#151"
+
+#: books/add.html
+msgid "ID Type"
+msgstr "Rodzaj numeru identyfikacyjnego"
+
+#: books/add.html
+msgid "ISBN may be invalid. Click \"Add\" again to submit."
+msgstr ""
+
+#: books/add.html type/tag/tag_form_inputs.html
+msgid "Select"
+msgstr "Wybierz"
+
+#: books/add.html
+#, fuzzy
+msgid "ISBN 10"
+msgstr "ISBN"
+
+#: books/add.html
+#, fuzzy
+msgid "ISBN 13"
+msgstr "ISBN"
+
+#: books/add.html
+msgid "LCCN"
+msgstr ""
+
+#: books/add.html
+msgid "LibriVox"
+msgstr ""
+
+#: books/add.html
+msgid "OCLC/WorldCat"
+msgstr ""
+
+#: books/add.html
+msgid "Project Gutenberg"
+msgstr ""
+
+#: books/add.html books/edit/edition.html
+#, fuzzy
+msgid "Book URL"
+msgstr "E-book"
+
+#: books/add.html
+msgid "Only fill this out if this is a web book"
+msgstr ""
+
+#: books/add.html
+#, python-format
+msgid "By saving a change to this wiki, you agree that your contribution is given freely to the world under <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" target=\"_blank\" rel=\"noopener noreferrer\" title=\"%(cc_link_title)s\">CC0</a>."
+msgstr ""
+
+#: books/add.html
+msgid "This link to Creative Commons will open in a new window"
+msgstr ""
+
+#: books/add.html
+msgid "Add this book now"
+msgstr "Dodaj tę książkę"
+
+#: books/author-autocomplete.html
+#, fuzzy
+msgid "Add a new author"
+msgstr "Dodaj kolejnego autora"
+
+#: books/author-autocomplete.html books/series-autocomplete.html
 msgid "Create a new record for"
 msgstr "Utwórz nowy dokument dla"
 
-#: author-autocomplete.html:42
+#: books/author-autocomplete.html
 msgid "Remove this author"
 msgstr "Usuń tego autora"
 
-#: author-autocomplete.html:43
+#: books/author-autocomplete.html
 msgid "Add another author?"
 msgstr "Dodaj kolejnego autora"
 
-#: check.html:13 nav_foot.html:39 nav_head.html:16 nav_head.html:93
+#: books/check.html lib/nav_foot.html lib/nav_head.html
 msgid "Add a Book"
 msgstr "Dodaj książkę"
 
-#: check.html:15
+#: books/check.html
 #, python-format
-msgid ""
-"One moment... It looks like we already have <em>some potential "
-"matches</em> for <b>%(title)s</b> by <b>%(author)s</b>."
-msgstr ""
-"Chwileczkę... Wydaje się, że mamy już <em>podobną książkę</em> "
-"<b>%(title)s</b> autorstwa <b>%(author)s</b>."
+msgid "One moment... It looks like we already have <em>some potential matches</em> for <b>%(title)s</b> by <b>%(author)s</b>."
+msgstr "Chwileczkę... Wydaje się, że mamy już <em>podobną książkę</em> <b>%(title)s</b> autorstwa <b>%(author)s</b>."
 
-#: check.html:17
-msgid ""
-"Rather than creating a duplicate record, please click through the result "
-"you think best matches your book."
-msgstr ""
-"Nie twórz duplikatu tej książki. Wybierz odpowiedni tytuł z poniższej "
-"listy."
+#: books/check.html
+msgid "Rather than creating a duplicate record, please click through the result you think best matches your book."
+msgstr "Nie twórz duplikatu tej książki. Wybierz odpowiedni tytuł z poniższej listy."
 
-#: check.html:27 check.html:31
+#: books/check.html
 msgid "Select this book"
 msgstr "Wybierz tę książkę"
 
-#: custom_carousel.html:30
+#: SearchResultsWork.html books/check.html merge/authors.html publishers/view.html
+#, python-format
+msgid "%(count)s edition"
+msgid_plural "%(count)s editions"
+msgstr[0] ""
+msgstr[1] ""
+
+#: books/check.html
+#, python-format
+msgid "First published in %(year)d"
+msgstr "Pierwsze wydanie w %(year)d"
+
+#: books/check.html
+msgid "None of these match the book I want to add."
+msgstr ""
+
+#: books/check.html
+#, fuzzy
+msgid "Continue"
+msgstr "Współtwórcy"
+
+#: books/custom_carousel_card.html type/author/view.html
+msgid "name missing"
+msgstr "brakuje imienia"
+
+#: books/custom_carousel_card.html books/mobile_carousel.html
 #, python-format
 msgid " by %(name)s"
 msgstr " autorstwa %(name)s"
 
-#: custom_carousel.html:39
-msgid "Sponsor"
-msgstr "Zasponsoruj"
+#: books/daisy.html
+msgid "Back"
+msgstr "Powrót"
 
-#: edit.html:68 edit.html:71 edit.html:74
+#: books/daisy.html
+#, fuzzy
+msgid "Open Library Home"
+msgstr "Open Library"
+
+#: books/daisy.html
+msgid "There isn't a DAISY file available for "
+msgstr ""
+
+#: books/daisy.html
+#, python-format
+msgid "<a href=\"%(daisy_url)s\"><strong>Download the DAISY.zip</strong></a> for <a href=\"%(url)s\">%(title)s</a>"
+msgstr ""
+
+#: books/daisy.html
+msgid "Books for people who don't read print?"
+msgstr ""
+
+#: books/daisy.html
+msgid "The <a href=\"//archive.org\">Internet Archive</a> is proud to be distributing over 1 million books free in a format called DAISY, designed for those of us who find it challenging to use regular printed media. "
+msgstr ""
+
+#: books/daisy.html
+msgid "There are two types of DAISYs on Open Library: <i>open</i> and <i>protected</i>. Open DAISYs can be read by anyone in the world on many different devices. Protected DAISYs can only be opened using a key issued by the <a href=\"http://www.loc.gov/nls/\">Library of Congress NLS program</a>."
+msgstr ""
+
+#: books/daisy.html lists/home.html
+msgid "Enjoy!"
+msgstr "Baw się dobrze"
+
+#: books/daisy.html
+#, fuzzy
+msgid "What is the DAISY format?"
+msgstr "Wydawnictwo"
+
+#: books/daisy.html
+msgid "The DAISY digital format helps people who have challenges using regular printed media. DAISY digital <span class=\"highlight\">talking books</span> offer the benefits of regular audiobooks, with navigation within the book, to chapters or specific pages."
+msgstr ""
+
+#: books/daisy.html
+#, fuzzy
+msgid "More information at daisy.org"
+msgstr "Uzyskaj więcej informacji o tym wydawcy"
+
+#: books/daisy.html
+#, fuzzy
+msgid "What is the NLS?"
+msgstr "Wydawnictwo"
+
+#: books/daisy.html
+msgid "The Library of Congress <a href=\"http://www.loc.gov/nls/\">National Library Service for the Blind and Physically Handicapped (NLS)</a> administers a free library program of braille and audio materials circulated to eligible borrowers in the United States through a national network of cooperating libraries."
+msgstr ""
+
+#: books/daisy.html
+msgid "Are you eligible to register?"
+msgstr ""
+
+#: books/daisy.html
+#, fuzzy
+msgid "How do I find DAISYs on Open Library?"
+msgstr "Zobacz wszystkich odwiedzających OpenLibrary.org"
+
+#: books/daisy.html
+msgid "In addition to<a href=\"/subjects/accessible_book\" title=\"Subject: Accessible book\"> loads of open DAISYs</a>, the Open Library lists a smaller selection of<a href=\"/subjects/protected_DAISY\" title=\"Subject: Protected DAISY\"> protected DAISY titles</a> accessible to those with a Library of Congress NLS key. These titles are brought to you by the<a href=\"//archive.org/\"> Internet Archive</a>."
+msgstr ""
+
+#: books/daisy.html
+msgid "Looking for a specific title? The best way to find it is to<a href=\"/search\"> search for it</a>."
+msgstr ""
+
+#: books/daisy.html lib/exports.html
+msgid "Need help?"
+msgstr ""
+
+#: books/daisy.html
+msgid " Please read our <a href=\"/help/faq\">FAQ on accessing books through Open Library</a>."
+msgstr ""
+
+#: books/edit.html
 msgid "Add a little more?"
 msgstr "Dodaj nieco więcej?"
 
-#: edit.html:69
+#: books/edit.html
 #, fuzzy
-msgid ""
-"Thank you for adding that book! Any more information you could provide "
-"would be wonderful!"
-msgstr ""
-"<p class=\"alert thanks\">Dziękujemy za dodanie tej książki! Jeśli możesz"
-" udostępnić dodatkowe informacje, będziemy bardzo wdzięczni!</p>"
+msgid "Thank you for adding that book! Any more information you could provide would be wonderful!"
+msgstr "<p class=\"alert thanks\">Dziękujemy za dodanie tej książki! Jeśli możesz udostępnić dodatkowe informacje, będziemy bardzo wdzięczni!</p>"
 
-#: edit.html:72
+#: books/edit.html
+#, python-format
+msgid "We already know about <b>%(work_title)s</b>, but not the <b>%(year)s %(publisher)s edition</b>. Thanks! Do you know any more about this edition?"
+msgstr ""
+
+#: books/edit.html
 #, fuzzy, python-format
-msgid ""
-"We already know about <b>%(work_title)s</b>, but not the <b>%(year)s "
-"%(publisher)s edition</b>. Thanks! Do you know any more about this "
-"edition?"
-msgstr ""
-"Już mamy tę książkę <b>%(work_titles)s</b>, ale nie te "
-"wydanie<b>%(year)s %(publisher)s edition</b>. Dziękujemy! Czy wiesz coś więcej o tym "
-"wydaniu?"
+msgid "We already know about the <b>%(year)s %(publisher)s edition</b> of <b>%(work_title)s</b>, but please, tell us more!"
+msgstr "Już znamy wydanie tej <b>%(year)s %(publisher)s edition</b> książki <b>%(work_title)s</b>, ale prosimy o podanie więcej informacji!"
 
-#: edit.html:75
-#, fuzzy, python-format
-msgid ""
-"We already know about the <b>%(year)s %(publisher)s edition</b> of "
-"<b>%(work_title)s</b>, but please, tell us more!"
-msgstr ""
-"Już znamy wydanie tej <b>%(year)s %(publisher)s edition</b> "
-"książki <b>%(work_title)s</b>, ale prosimy o podanie więcej informacji!"
-
-#: edit.html:77
+#: books/edit.html
 msgid "Editing..."
 msgstr "Edytowanie..."
 
-#: edit.html:92
-msgid "Use <b><i>Title: Subtitle</i></b> to add a subtitle."
-msgstr "Użyj <b><i>Tytuł: Podtytuł</i></b> aby dodać podtytuł."
+#: books/edit.html type/author/edit.html type/tag/form.html type/template/edit.html
+msgid "Delete Record"
+msgstr "Usuń wpis"
 
-#: edit.html:99
-msgid ""
-"You can search by author name (like <em>j k rowling</em>) or by Open "
-"Library ID (like <a href=\"/authors/OL23919A\" "
-"target=\"_blank\"><em>OL23919A</em></a>)."
+#: books/edit.html
+msgid "Work Details"
 msgstr ""
-"Możesz wyszukiwać przez nazwisko autora(like <em>j k rowling</em>) lub "
-"przez numer identyfikacyjny na Open Library(like <a "
-"href=\"/authors/OL23919A\" target=\"_blank\"><em>OL23919A</em></a>)."
 
-#: edit.html:108
-msgid "What's It About?"
-msgstr "O czym jest ta książka?"
+#: books/edit.html
+msgid "Unknown publisher edition"
+msgstr ""
 
-#: edit.html:109
+#: books/edit.html
+#, fuzzy
+msgid "This Work"
+msgstr "Usuń tę pozycję"
+
+#: books/edit.html
+msgid "You can search by author name (like <em>j k rowling</em>) or by Open Library ID (like <a href=\"/authors/OL23919A\" target=\"_blank\" rel=\"noopener noreferrer\"><em>OL23919A</em></a>)."
+msgstr ""
+
+#: books/edit.html
+msgid "Author editing requires javascript"
+msgstr ""
+
+#: books/edit.html
 msgid "Add Excerpts"
 msgstr "Dodaj fragmenty"
 
-#: edit.html:149
-msgid "Delete this book?"
-msgstr "Usunąć tę książkę?"
+#: books/edit.html type/about/edit.html type/author/edit.html
+msgid "Links"
+msgstr "Linki"
 
-#: edition-sort.html:56
-#, fuzzy, python-format
+#: books/edit.html
+#, fuzzy
+msgid "Work Series"
+msgstr "Seria"
+
+#: books/edit.html
+msgid "Series are currently in beta, and this section is only visible to super librarians and admins, like you! Any series you set will be visible by everyone, however. Please report any issues you have on Slack or GitHub."
+msgstr ""
+
+#: books/edit.html
+#, fuzzy
+msgid "Is this work part of a larger series?"
+msgstr "Czy ta książka jest częścią serii?"
+
+#: books/edit.html
+msgid "E.g. Harry Potter, The Sword of Truth"
+msgstr ""
+
+#: books/edit.html type/edition/view.html type/work/view.html
+msgid "Work Identifiers"
+msgstr ""
+
+#: books/edit.html
+#, fuzzy
+msgid "Do you know any identifiers for this work?"
+msgstr "Czy znasz oznaczenia tego wydania?"
+
+#: books/edit.html
+msgid "These identifiers apply to all editions of this work, for example Wikidata work identifiers. For edition-specific identifiers, like ISBN or LCCN, go to the edition tab."
+msgstr ""
+
+#: FulltextSearchSuggestionItem.html IABook.html SearchResultsWork.html books/edition-sort.html jsdef/LazyWorkPreview.html lists/list_overview.html lists/preview.html lists/snippet.html lists/widget.html my_books/dropdown_content.html type/work/editions.html
+#, python-format
+msgid "Cover of: %(title)s"
+msgstr ""
+
+#: books/edition-sort.html
+#, python-format
+msgid "%(title)s: %(subtitle)s"
+msgstr "%(title)s: %(subtitle)s"
+
+#: books/edition-sort.html
+#, python-format
 msgid "Publish date unknown, %(publisher)s"
-msgstr "Data publikacji nieznana, %s"
+msgstr ""
 
-#: edition-sort.html:66
+#: books/edition-sort.html type/work/editions.html
 #, python-format
 msgid "in %(languagelist)s"
 msgstr "opublikowane w językach %(languagelist)s"
 
-#: edition-sort.html:93 openlibrary/macros/AvailabilityButton.html:73
-#: openlibrary/macros/LoanStatus.html:95
-msgid "Not in Library"
-msgstr "Brak w bibliotece"
+#: SearchNavigation.html books/mybooks_breadcrumb_select.html lib/nav_foot.html openlibrary/plugins/upstream/mybooks.py
+msgid "Books"
+msgstr "Książki"
 
-#: edition-sort.html:104
-msgid "Libraries near you:"
-msgstr "Biblioteki w Twoim pobliżu"
+#. Page title for the "Want to Read" shelf page.
+#. Example: "Want to Read (17)". %(count)d is the number of books on this
+#. shelf.
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#, python-format
+msgid "Want to Read (%(count)d)"
+msgstr "Chce przeczytać (%(count)d)"
 
-#: edition-sort.html:108
-msgid "Look for this edition at WorldCat"
-msgstr "Szukaj tego wydania na WorldCat"
+#. Page title for the "Currently Reading" shelf page.
+#. Example: "Currently Reading (42)". %(count)d is the number of books on this
+#. shelf.
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#, python-format
+msgid "Currently Reading (%(count)d)"
+msgstr "Obcenie czyta (%(count)d)"
 
-#: edit/about.html:10
+#. Page title for the "Already Read" shelf page.
+#. Example: "Already Read (203)". %(count)d is the number of books on this
+#. shelf.
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#, python-format
+msgid "Already Read (%(count)d)"
+msgstr "Przeczytał\\(a\\) (%(count)d)"
+
+#. Page title for the "Stopped Reading" shelf page.
+#. Example: "Stopped Reading (8)". %(count)d is the number of books on this
+#. shelf.
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#, fuzzy, python-format
+msgid "Stopped Reading (%(count)d)"
+msgstr "Obcenie czyta (%(count)d)"
+
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/openlibrary/lists.py
+#, fuzzy, python-format
+msgid "Lists (%(count)d)"
+msgstr "Chce przeczytać (%(count)d)"
+
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py type/edition/modal_links.html
+#, fuzzy
+msgid "Notes"
+msgstr "Notatki:"
+
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
+msgid "Imports and Exports"
+msgstr ""
+
+#: books/series-autocomplete.html
+#, fuzzy
+msgid "Add a new series"
+msgstr "Dodaj nową rolę"
+
+#: books/series-autocomplete.html
+#, fuzzy
+msgid "Series name"
+msgstr "Nazwa użytkownika"
+
+#: books/series-autocomplete.html
+#, fuzzy
+msgid "Series position"
+msgstr "Połącz wydania"
+
+#: books/series-autocomplete.html
+#, fuzzy
+msgid "Remove this series"
+msgstr "Usunąć ten plik inicujuący?"
+
+#: books/series-autocomplete.html
+#, fuzzy
+msgid "Add another series?"
+msgstr "Dodaj kolejny obraz"
+
+#: books/edit/about.html
+#, fuzzy
+msgid "Select this subject"
+msgstr "Wybierz tę książkę"
+
+#: books/edit/about.html
 msgid "How would you describe this book?"
 msgstr "Jak opisał\\(a\\)byś tę książkę?"
 
-#: edit/about.html:11
+#: books/edit/about.html
 msgid "There's no wrong answer here."
 msgstr "Nie ma tu złych odpowiedzi."
 
-#: edit/about.html:20
+#: books/edit/about.html
 msgid "Subject keywords?"
 msgstr "Tematyka i słowa kluczowe"
 
-#: edit/about.html:21
+#: books/edit/about.html
 msgid "Please separate with commas."
 msgstr "Wpisuj słowa kluczowe po przecinku."
 
-#: edit/about.html:34
+#: books/edit/about.html
+msgid "For example: <i><a href=\"/subjects/cheese\">cheese</a>, <a href=\"/subjects/roman_empire\">Roman Empire</a>, <a href=\"/subjects/psychology\">psychology</a></i>"
+msgstr ""
+
+#: books/edit/about.html
 msgid "A person? Or, people?"
 msgstr "jedna czy więcej osób?"
 
-#: edit/about.html:48
+#: books/edit/about.html
+msgid "For example: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore Roosevelt</a>, <a href=\"/subjects/person:Julian_of_Norwich\">Julian of Norwich</a>, <a href=\"/subjects/person:Tintin\">Tintin</a></i>"
+msgstr ""
+
+#: books/edit/about.html
 msgid "Note any places mentioned?"
 msgstr "Czy zostały wspomniane jakieś miejsca?"
 
-#: edit/about.html:62
+#: books/edit/about.html
+msgid "For example: <i><a href=\"/subjects/place:London\">London</a>, <a href=\"/subjects/place:Atlantis\">Atlantis</a>, <a href=\"/subjects/place:Omaha\">Omaha</a></i>"
+msgstr ""
+
+#: books/edit/about.html
 msgid "When is it set or about?"
 msgstr "Kiedy odbywa się akcja książki, o czym jest?"
 
-#: edit/addfield.html:70
-msgid "Add a New Contributor Role"
-msgstr "Dodaj nowego wspołtwórcę"
-
-#: edit/addfield.html:77 edit/addfield.html:104 edit/addfield.html:149
-msgid "What should we show in the menu?"
-msgstr "Co powinno znajdować się w menu?"
-
-#: edit/addfield.html:96
-msgid "Add a New Type of Identifier"
-msgstr "Dodaj nowy rodzaj identyfikacji"
-
-#: edit/addfield.html:113
-msgid "If the system has a website, what's the homepage?"
-msgstr "Jeśli system ma stronę interentową, jaki jest jej główny adres?"
-
-#: edit/addfield.html:122
-msgid "Please leave a note: Why is this ID useful?"
-msgstr "Prosimy o uwagi: Dlaczego ten numer identyfikacyjny jest przydatny?"
-
-#: edit/addfield.html:141
-msgid "Add a New Classification System"
-msgstr "Dodaj nowy system klasyfikacji"
-
-#: edit/addfield.html:158
-msgid "Please leave a note: Why is this classification useful?"
-msgstr "Prosimy o uwagi: Dlaczego ten rodzaj kasyfikacji jest przydatny?"
-
-#: edit/addfield.html:167
-msgid ""
-"Can you direct us to more information about this classification system "
-"online?"
+#: books/edit/about.html
+msgid "For example: <i><a href=\"/subjects/time:1984\">1984</a>, <a href=\"/subjects/time:the_middle_ages\">The Middle Ages</a>, <a href=\"/subjects/time:1810-1890\">1810-1890</a></i>"
 msgstr ""
-"Prosimy o podanie elektronicznego źródła informacji o tym systemie "
-"klasyfikacji."
 
-#: edit/edition.html:22
+#: books/edit/edition.html
 msgid "Select this language"
 msgstr "Wybierz ten język"
 
-#: edit/edition.html:31 edit/edition.html:40
+#: books/edit/edition.html
 msgid "Remove this language"
 msgstr "Usuń ten język"
 
-#: edit/edition.html:51
+#: books/edit/edition.html
 msgid "Remove this work"
 msgstr "Usuń tę pozycję"
 
-#: edit/edition.html:59 edit/edition.html:110
+#: books/edit/edition.html
 msgid "-- Move to a new work"
 msgstr "-- Przenieś do nowej pozycji."
 
-#: edit/edition.html:124
-msgid "Publishing Info"
-msgstr "Informacje wydawnicze"
-
-#: edit/edition.html:131
-msgid "For example"
-msgstr "Na przykład"
-
-#: edit/edition.html:141
-msgid "You should be able to find this in the first few pages of the book."
-msgstr "Możesz znaleźć te informacje na pierwszych stronach książki."
-
-#: edit/edition.html:150
-msgid "Where was the book published?"
-msgstr "Miejsce wydania"
-
-#: edit/edition.html:151
-msgid "City, Country please."
-msgstr "Prosimy o podanie państwa i miasta publikacji."
-
-#: edit/edition.html:161
-msgid "Is there a copyright date?"
-msgstr "Data praw autorskich"
-
-#: edit/edition.html:162
-msgid "The year following the copyright statement."
-msgstr "Rok podany po informacji o prawach autorskich."
-
-#: edit/edition.html:171
-msgid "Is the book part of a series?"
-msgstr "Czy ta książka jest częścią serii?"
-
-#: edit/edition.html:172
-msgid "The name of the publisher's series."
-msgstr "Nazwa serii wydawnictwa"
-
-#: edit/edition.html:182
+#: books/edit/edition.html
 msgid "This Edition"
 msgstr "Te wydanie"
 
-#: edit/edition.html:188
-msgid "What work is this an edition of?"
-msgstr "Jest to wydanie książki... "
-
-#: edit/edition.html:190
-msgid ""
-"Sometimes editions can be associated with the wrong work. You can correct"
-" that here."
-msgstr ""
-"Zdarza się, że wydania są skojarzone z niepoprawnymi książkami. Możesz to"
-" poprawić tutaj."
-
-#: edit/edition.html:191
-msgid "You can search by title or by Open Library ID (like"
-msgstr "Możesz wyszukać przez tytuł lub przez ID z Open Library (like"
-
-#: edit/edition.html:194
-msgid "WARNING: Any edits made to the work from this page will be ignored."
-msgstr "OSTRZEŻENIE: Wszystkie zmiany dokonane z tej strony zostaną zignorowane."
-
-#: edit/edition.html:210
+#: books/edit/edition.html
 msgid "Enter the title of this specific edition."
 msgstr "Wpisz tytuł tego wydania."
 
-#: edit/edition.html:219
+#: books/edit/edition.html
 msgid "Subtitle"
 msgstr "Podtytuł"
 
-#: edit/edition.html:220
+#: books/edit/edition.html
 msgid "Usually distinguished by different or smaller type."
 msgstr "Zwykle wydrukowany mniejszą lub inną czcionką."
 
-#: edit/edition.html:230
-msgid ""
-"Use a \"*\" for an indent, a \"|\" to add a column, and line breaks for "
-"new lines. Like this:"
+#: books/edit/edition.html
+msgid "For example: <i>envisioning the next 50 years</i>"
 msgstr ""
-"Użyj \"*\" by zrobić wcięcie, \"|\" by dodać kolumnę oraz zakończenie i "
-"rozpoczęcie nowej linii. W taki sposób:"
 
-#: edit/edition.html:247
-msgid "Is it known by any other titles?"
-msgstr "Czy ta pozycja jest znana pod innymi tytułami?"
+#: books/edit/edition.html
+msgid "Publishing Info"
+msgstr "Informacje wydawnicze"
 
-#: edit/edition.html:248
-msgid ""
-"Use this field if the title is different on the cover or spine. If the "
-"edition is a collection or anthology, you may also add the individual "
-"titles of each work here."
+#: books/edit/edition.html
+msgid "For example <em>Oxford University Press; Penguin; W.W. Norton</em>"
 msgstr ""
-"Wypełnij te pole jeśli tytuł jest inny na okładce lub grzbiecie książki. "
-"Jeśli te wydanie jest kolekcją lub antologią, możesz tutaj także dodać "
-"poszczególne tytuły."
 
-#: edit/edition.html:252
-msgid "is an alternate title for"
-msgstr "jest alternatywnym tytułem dla"
+#: books/edit/edition.html
+msgid "Where was the book published?"
+msgstr "Miejsce wydania"
 
-#: edit/edition.html:262
-msgid "Does this edition have a specific name?"
-msgstr "Czy te wydanie ma specyficzną nazwę?"
+#: books/edit/edition.html
+msgid "City, Country please."
+msgstr "Prosimy o podanie państwa i miasta publikacji."
 
-#: edit/edition.html:282
-msgid "Any notes about this specific edition?"
-msgstr "Dodatkowe uwagi na temat tego wydania?"
+#: books/edit/edition.html
+msgid "For example: <i>New York, USA; Sydney, Australia</i>"
+msgstr ""
 
-#: edit/edition.html:283
-msgid "Anything about the book that may be of interest."
-msgstr "Dodatkowe ciekawe informacje dotyczące tej książki."
+#: books/edit/edition.html
+#, fuzzy
+msgid "What is the copyright date?"
+msgstr "Data praw autorskich"
 
-#: edit/edition.html:297
-msgid "List the people involved"
-msgstr "Wymień zaangażowane osoby"
+#: books/edit/edition.html
+msgid "The year following the copyright statement."
+msgstr "Rok podany po informacji o prawach autorskich."
 
-#: edit/edition.html:307
-msgid "Select role"
-msgstr "Wybierz rolę"
+#: books/edit/edition.html
+msgid "Edition Name (if applicable):"
+msgstr ""
 
-#: edit/edition.html:312
-msgid "Add a new role"
-msgstr "Dodaj nową rolę"
+#: books/edit/edition.html
+msgid "For example: <i>Centennial edition</i>; <i>First edition</i>"
+msgstr ""
 
-#: edit/edition.html:332 edit/edition.html:348
-msgid "Remove this contributor"
-msgstr "Usuń tego współtwórcę"
+#: books/edit/edition.html
+msgid "Series Name (if applicable)"
+msgstr ""
 
-#: edit/edition.html:357
-msgid "Is there a By Statement?"
-msgstr "Czy podany jest autor?"
+#: books/edit/edition.html
+msgid "The name of the publisher's series."
+msgstr "Nazwa serii wydawnictwa"
 
-#: edit/edition.html:373
-msgid "What language is this edition written in?"
-msgstr "Język tego wydania."
+#: books/edit/edition.html
+msgid "For example: <i>The Story of Civilization, Part III</i>"
+msgstr ""
 
-#: edit/edition.html:385
-msgid "Is it a translation of another book?"
-msgstr "Czy jest to tłumaczenie?"
+#: books/edit/edition.html type/edition/view.html type/work/view.html
+msgid "Contributors"
+msgstr "Współtwórcy"
 
-#: edit/edition.html:403
-msgid "Yes, it's a translation"
-msgstr "Tak, to jest tłumaczenie"
-
-#: edit/edition.html:408
-msgid "What's the original book?"
-msgstr "Jaki jest tytuł oryginału?"
-
-#: edit/edition.html:417
-msgid "What language was the original written in?"
-msgstr "W jakim języku napisany jest oryginał książki?"
-
-#: edit/edition.html:435
-msgid "Description of this edition"
-msgstr "Opis tego wydania"
-
-#: edit/edition.html:436
-msgid "Only if it's different from the work's description"
-msgstr "Tylko, jeśli jest inny niż opis tej książki"
-
-#: edit/edition.html:454
-msgid "Do you know any identifiers for this edition?"
-msgstr "Czy znasz oznaczenia tego wydania?"
-
-#: edit/edition.html:455
-msgid "Like, ISBN?"
-msgstr "Np., ISBN"
-
-#: edit/edition.html:528
-msgid "Do you know any classifications of this edition?"
-msgstr "Czy znasz klasyfikacje tego wydania?"
-
-#: edit/edition.html:529
-msgid "Like, Dewey Decimal?"
-msgstr "Np., klasyfikacja dziesiętna Deweya"
-
-#: edit/edition.html:537
-msgid "Select one of many..."
-msgstr "Wybierz jeden z wielu..."
-
-#: edit/edition.html:542
-msgid "Add a new classification type"
-msgstr "Dodaj nowy typ klasyfikacji"
-
-#: edit/edition.html:559 edit/edition.html:568
-msgid "Remove this classification"
-msgstr "Usuń tę klasyfikację"
-
-#: edit/edition.html:585
-msgid "What sort of book is it?"
-msgstr "Jaki to rodzaj książki?"
-
-#: edit/edition.html:586
-msgid "Paperback; Hardcover, etc."
-msgstr "Okładka miękka, twarda, itp."
-
-#: edit/edition.html:594
-msgid "How many pages?"
-msgstr "Ile ma stron?"
-
-#: edit/edition.html:604
-msgid "Pagination?"
-msgstr "Paginacja?"
-
-#: edit/edition.html:605
-msgid "Note the highest number in each pagination pattern."
-msgstr "Zanotuj najwyższą liczbę w każdym wzorze paginacji."
-
-#: edit/edition.html:605 nav_foot.html:43
-msgid "Help"
-msgstr "Pomoc"
-
-#: edit/edition.html:615
-msgid "How much does the book weigh?"
-msgstr "Ile waży ta książka?"
-
-#: edit/edition.html:642
-msgid "Height:"
-msgstr "Wysokość"
-
-#: edit/edition.html:647
-msgid "Width:"
-msgstr "Szerokość"
-
-#: edit/edition.html:652
-msgid "Depth:"
-msgstr "Grubość"
-
-#: edit/edition.html:667 edit/edition.html:681
-msgid "Admin Only"
-msgstr "Tylko administratorzy"
-
-#: edit/edition.html:670
-msgid "Additional Metadata"
-msgstr "Dodatkowe metadane"
-
-#: edit/edition.html:684
-msgid "First sentence"
-msgstr "Pierwsze zdanie"
-
-#: edit/edition.html:710
+#: books/edit/edition.html
 msgid "Please select a role."
 msgstr "Wtybierz rolę."
 
-#: edit/edition.html:714
+#: books/edit/edition.html
 msgid "You need to give this ROLE a name."
 msgstr "Musisz nadać tej roli nazwę."
 
-#: edit/edition.html:727
+#: books/edit/edition.html
+msgid "List the people involved"
+msgstr "Wymień zaangażowane osoby"
+
+#: books/edit/edition.html
+msgid "Select role"
+msgstr "Wybierz rolę"
+
+#: books/edit/edition.html
+msgid "Add a new role"
+msgstr "Dodaj nową rolę"
+
+#: books/edit/edition.html
+msgid "Remove this contributor"
+msgstr "Usuń tego współtwórcę"
+
+#: books/edit/edition.html
+#, fuzzy
+msgid "By Statement:"
+msgstr "Czy podany jest autor?"
+
+#: books/edit/edition.html
+msgid "For example: <em>edited by David Anderson</em>"
+msgstr ""
+
+#: books/edit/edition.html
+msgid "What language is this edition written in?"
+msgstr "Język tego wydania."
+
+#: books/edit/edition.html
+#, fuzzy
+msgid "Add another language?"
+msgstr "Dodaj kolejny obraz"
+
+#: books/edit/edition.html
+msgid "Is it a translation of another book?"
+msgstr "Czy jest to tłumaczenie?"
+
+#: books/edit/edition.html
+msgid "Yes, it's a translation"
+msgstr "Tak, to jest tłumaczenie"
+
+#: books/edit/edition.html
+msgid "What's the original book?"
+msgstr "Jaki jest tytuł oryginału?"
+
+#: books/edit/edition.html
+msgid "What language was the original written in?"
+msgstr "W jakim języku napisany jest oryginał książki?"
+
+#: books/edit/edition.html
+msgid "Description of this edition"
+msgstr "Opis tego wydania"
+
+#: books/edit/edition.html
+msgid "Only if it's different from the work's description"
+msgstr "Tylko, jeśli jest inny niż opis tej książki"
+
+#: books/edit/edition.html type/edition/view.html type/work/view.html
+msgid "Table of Contents"
+msgstr "Spis treści"
+
+#: books/edit/edition.html
+msgid "Use a \"*\" for an indent, a \"|\" to add a column, and line breaks for new lines. Like this:"
+msgstr "Użyj \"*\" by zrobić wcięcie, \"|\" by dodać kolumnę oraz zakończenie i rozpoczęcie nowej linii. W taki sposób:"
+
+#: books/edit/edition.html
+msgid "This table of contents contains extra information like authors or descriptions. We don't have a great user interface for this yet, so editing this data could be difficult. Watch out!"
+msgstr ""
+
+#: books/edit/edition.html
+msgid "Any notes about this specific edition?"
+msgstr "Dodatkowe uwagi na temat tego wydania?"
+
+#: books/edit/edition.html
+msgid "Anything about the book that may be of interest."
+msgstr "Dodatkowe ciekawe informacje dotyczące tej książki."
+
+#: books/edit/edition.html
+#, fuzzy
+msgid "A Plume Book"
+msgstr "Zobacz książki"
+
+#: books/edit/edition.html
+msgid "Is it known by any other titles?"
+msgstr "Czy ta pozycja jest znana pod innymi tytułami?"
+
+#: books/edit/edition.html
+msgid "Use this field if the title is different on the cover or spine. If the edition is a collection or anthology, you may also add the individual titles of each work here."
+msgstr "Wypełnij te pole jeśli tytuł jest inny na okładce lub grzbiecie książki. Jeśli te wydanie jest kolekcją lub antologią, możesz tutaj także dodać poszczególne tytuły."
+
+#: books/edit/edition.html
+msgid "For example: <i>Eaters of the Dead</i> is an alternate title for <i><a href=\"/books/OL24923038M\">The 13th Warrior</a></i>."
+msgstr ""
+
+#: books/edit/edition.html
+msgid "What work is this an edition of?"
+msgstr "Jest to wydanie książki... "
+
+#: books/edit/edition.html
+msgid "Sometimes editions can be associated with the wrong work. You can correct that here."
+msgstr "Zdarza się, że wydania są skojarzone z niepoprawnymi książkami. Możesz to poprawić tutaj."
+
+#: books/edit/edition.html
+msgid "You can search by title or by Open Library ID (like <a href=\"/works/OL262757W\" target=\"_blank\" rel=\"noopener noreferrer\"><em>OL262757W</em></a>)."
+msgstr ""
+
+#: books/edit/edition.html
+msgid "WARNING: Any edits made to the work from this page will be ignored."
+msgstr "OSTRZEŻENIE: Wszystkie zmiany dokonane z tej strony zostaną zignorowane."
+
+#: books/edit/edition.html
+#, fuzzy
+msgid "Copy authors to new work"
+msgstr "-- Przenieś do nowej pozycji."
+
+#: books/edit/edition.html
+#, fuzzy
+msgid "Copy subjects to new work"
+msgstr "-- Przenieś do nowej pozycji."
+
+#: books/edit/edition.html
 msgid "Please select an identifier."
 msgstr "Wybierz typ identyfikacji."
 
-#: edit/edition.html:731
+#: books/edit/edition.html
 msgid "You need to give a value to ID."
 msgstr "Pole ID nie może być puste."
 
-#: edit/edition.html:734
+#: books/edit/edition.html
 msgid "ID ids cannot contain whitespace."
 msgstr "Pole ID nie może zawierać spacji"
 
-#: edit/edition.html:737
+#: books/edit/edition.html
 msgid "ID must be exactly 10 characters [0-9] or X."
 msgstr "ID musi zawierać dokładnie 10 znaków [0-9] lub X."
 
-#: edit/edition.html:740
-msgid "ID must be exactly 13 digits [0-9]."
+#: books/edit/edition.html
+msgid "That ID already exists for this edition."
+msgstr ""
+
+#: books/edit/edition.html
+#, fuzzy
+msgid "ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4"
 msgstr "ID musi zawierać dokładnie 13 znaków [0-9]."
 
-#: edit/edition.html:752
+#: books/edit/edition.html
+#, fuzzy
+msgid "Invalid ID format"
+msgstr "Błędne hasło"
+
+#: books/edit/edition.html type/author/view.html
+msgid "ID Numbers"
+msgstr "Numery indentyfikacyjne"
+
+#: books/edit/edition.html
+msgid "Do you know any identifiers for this edition?"
+msgstr "Czy znasz oznaczenia tego wydania?"
+
+#: books/edit/edition.html
+msgid "Like, ISBN?"
+msgstr "Np., ISBN"
+
+#: books/edit/edition.html
 msgid "Please select a classification."
 msgstr "Wybierz klasyfikację."
 
-#: edit/edition.html:757
+#: books/edit/edition.html
 msgid "You need to give a value to CLASS."
 msgstr "Nadanie wartości KATEGORII jest wymagane."
 
-#: edit/excerpts.html:13
-msgid ""
-"If there are particular (short) passages you feel represent the book "
-"well, please feel free to transcribe them here."
+#: books/edit/edition.html type/edition/view.html type/work/view.html
+msgid "Classifications"
+msgstr "Klasyfikacje"
+
+#: books/edit/edition.html
+msgid "Do you know any classifications of this edition?"
+msgstr "Czy znasz klasyfikacje tego wydania?"
+
+#: books/edit/edition.html
+msgid "Like, Dewey Decimal?"
+msgstr "Np., klasyfikacja dziesiętna Deweya"
+
+#: books/edit/edition.html
+msgid "Select one of many..."
+msgstr "Wybierz jeden z wielu..."
+
+#: books/edit/edition.html
+msgid "Add a new classification type"
+msgstr "Dodaj nowy typ klasyfikacji"
+
+#: books/edit/edition.html
+msgid "Remove this classification"
+msgstr "Usuń tę klasyfikację"
+
+#: books/edit/edition.html type/edition/view.html type/work/view.html
+msgid "The Physical Object"
+msgstr "Obiekt fizyczny"
+
+#: books/edit/edition.html
+msgid "What sort of book is it?"
+msgstr "Jaki to rodzaj książki?"
+
+#: books/edit/edition.html
+msgid "Paperback; Hardcover, etc."
+msgstr "Okładka miękka, twarda, itp."
+
+#: books/edit/edition.html
+msgid "How many pages?"
+msgstr "Ile ma stron?"
+
+#: books/edit/edition.html
+msgid "Pagination?"
+msgstr "Paginacja?"
+
+#: books/edit/edition.html
+msgid "Note the highest number in each pagination pattern."
+msgstr "Zanotuj najwyższą liczbę w każdym wzorze paginacji."
+
+#: books/edit/edition.html lib/nav_foot.html
+msgid "Help"
+msgstr "Pomoc"
+
+#: books/edit/edition.html
+msgid "For example: <em>xii, 346p.</em>"
 msgstr ""
-"Jeśli Twoim zdaniem pewne (krótkie) fragmenty dobrze reprezentują całą "
-"książkę, proszę zacytować je tutaj."
 
-#: edit/excerpts.html:18
-msgid "Page number?"
-msgstr "Jaki jest numer strony?"
+#: books/edit/edition.html
+msgid "How much does the book weigh?"
+msgstr "Ile waży ta książka?"
 
-#: edit/excerpts.html:30
-msgid "Transcribe the excerpt"
-msgstr "Przepisz fragment"
+#: books/edit/edition.html type/edition/view.html type/work/view.html
+msgid "Dimensions"
+msgstr "Wymiary"
 
-#: edit/excerpts.html:31
-msgid "Maximum length is 2000 characters. No HTML allowed."
-msgstr "Maksymalna długość to 2000 znaków. Porszę nie używać HTML."
+#: books/edit/edition.html
+#, fuzzy
+msgid "dimensions"
+msgstr "Wymiary"
 
-#: edit/excerpts.html:41
-msgid "Why did you choose this excerpt?"
-msgstr "Dlaczego wybrałaś ten fragment?"
+#: books/edit/edition.html
+msgid "Height:"
+msgstr "Wysokość"
 
-#: edit/excerpts.html:42
-msgid "Add an optional note."
-msgstr "Dodatkowe uwagi."
+#: books/edit/edition.html
+msgid "Width:"
+msgstr "Szerokość"
 
-#: edit/excerpts.html:56
-msgid "Excerpts so far..."
-msgstr "Wszystkie zamieszczone fragmenty..."
+#: books/edit/edition.html
+msgid "Depth:"
+msgstr "Grubość"
 
-#: edit/excerpts.html:70 edit/excerpts.html:92
-msgid "noted:"
-msgstr "zanotowano:"
+#: books/edit/edition.html
+msgid "Web Book Providers"
+msgstr ""
 
-#: edit/excerpts.html:72 edit/excerpts.html:94
-msgid "An anonymous note:"
-msgstr "Anonimowa notatka:"
+#: books/edit/edition.html
+#, fuzzy
+msgid "Access Type"
+msgstr "Rodzaj strony"
 
-#: edit/excerpts.html:90
-msgid "From page"
-msgstr "Ze strony"
+#: books/edit/edition.html
+#, fuzzy
+msgid "File Format"
+msgstr "Format"
 
-#: edit/excerpts.html:117
+#: books/edit/edition.html
+msgid "Provider Name"
+msgstr ""
+
+#: books/edit/edition.html
+#, fuzzy
+msgid "Buy"
+msgstr "autorstwa"
+
+#: books/edit/edition.html
+#, fuzzy
+msgid "Web"
+msgstr "Strona internetowa"
+
+#: books/edit/edition.html
+#, fuzzy
+msgid "Add a provider"
+msgstr "Dodaj nową rolę"
+
+#: books/edit/edition.html
+msgid "First sentence"
+msgstr "Pierwsze zdanie"
+
+#: books/edit/edition.html
+msgid "The opening line that starts the lead paragraph"
+msgstr ""
+
+#: books/edit/edition.html
+msgid "Admin Only"
+msgstr "Tylko administratorzy"
+
+#: books/edit/edition.html
+msgid "Additional Metadata"
+msgstr "Dodatkowe metadane"
+
+#: books/edit/edition.html
+msgid "This field can accept arbitrary key:value pairs"
+msgstr ""
+
+#: books/edit/excerpts.html
 msgid "Please provide an excerpt."
 msgstr "Proszę wpisać fragment."
 
-#: edit/excerpts.html:120
+#: books/edit/excerpts.html
 msgid "That excerpt is too long."
 msgstr "Ten fragment jest za długi."
 
-#: edit/web.html:13
-msgid ""
-"Please connect Open Library records to <u>good</u><span "
-"class=\"orange\">*</span> online resources."
+#: books/edit/excerpts.html
+msgid "If there are particular (short) passages you feel represent the book well, please feel free to transcribe them here."
+msgstr "Jeśli Twoim zdaniem pewne (krótkie) fragmenty dobrze reprezentują całą książkę, proszę zacytować je tutaj."
+
+#: books/edit/excerpts.html
+msgid "Page number?"
+msgstr "Jaki jest numer strony?"
+
+#: books/edit/excerpts.html
+msgid "For example: <i>23, xi or 433-434</i>"
 msgstr ""
-"Proszę połączyć kroniki Open Library <u>poprawnych</u><span "
-"class=\"orange\">*</span> z zasobami online."
 
-#: edit/web.html:19
-msgid "Give your link a label"
-msgstr "Nadaj etykietę swojemu linkowi."
+#: books/edit/excerpts.html
+msgid "This excerpt is the first sentence of the book."
+msgstr ""
 
-#: edit/web.html:43 edit/web.html:52
-msgid "Remove this link"
-msgstr "Usuń ten link"
+#: books/edit/excerpts.html
+msgid "Transcribe the excerpt"
+msgstr "Przepisz fragment"
 
-#: edit/web.html:72
-msgid "Please provide a URL."
-msgstr "Proszę podać URL."
+#: books/edit/excerpts.html
+msgid "Maximum length is 2000 characters. No HTML allowed."
+msgstr "Maksymalna długość to 2000 znaków. Porszę nie używać HTML."
 
-#: edit/web.html:77
+#: books/edit/excerpts.html
+msgid "Why did you choose this excerpt?"
+msgstr "Dlaczego wybrałaś ten fragment?"
+
+#: books/edit/excerpts.html
+msgid "Add an optional note."
+msgstr "Dodatkowe uwagi."
+
+#: books/edit/excerpts.html
+msgid "Excerpts so far..."
+msgstr "Wszystkie zamieszczone fragmenty..."
+
+#: books/edit/excerpts.html
+msgid "noted:"
+msgstr "zanotowano:"
+
+#: books/edit/excerpts.html
+msgid "An anonymous note:"
+msgstr "Anonimowa notatka:"
+
+#: books/edit/excerpts.html
+msgid "From page"
+msgstr "Ze strony"
+
+#: books/edit/web.html
 msgid "Please provide a label."
 msgstr "Proszę podać etykietę."
 
-#: edit/web.html:90
-msgid ""
-"\"Good\" means no spammy links, please. Keep them relevant to the book. "
-"Irrelevant sites may be removed. Blatant spam will be deleted without "
-"remorse."
-msgstr ""
-"\"Poprwany\" oznacza link bez spamu. Linki muszą być powiązane z tą "
-"książką. Nieistotne strony mogą zostać usunięte. Rażący spam zostanie "
-"usunięty natychmiastowo."
+#: books/edit/web.html
+msgid "Please provide a URL."
+msgstr "Proszę podać URL."
 
-#: add.html:11
-msgid "There are two ways to place an author's image on Open Library"
+#: books/edit/web.html
+#, fuzzy
+msgid "Please enter a valid URL."
+msgstr "Proszę podać URL."
+
+#: books/edit/web.html
+msgid "Please connect Open Library records to <u>good</u><span class=\"orange\">*</span> online resources."
+msgstr "Proszę połączyć kroniki Open Library <u>poprawnych</u><span class=\"orange\">*</span> z zasobami online."
+
+#: books/edit/web.html
+msgid "Give your link a label"
+msgstr "Nadaj etykietę swojemu linkowi."
+
+#: books/edit/web.html
+msgid "For example: <em>New York Times review</em>"
+msgstr ""
+
+#: books/edit/web.html
+msgid "URL"
+msgstr ""
+
+#: books/edit/web.html
+#, fuzzy
+msgid "Add Link"
+msgstr "Dodaj"
+
+#: books/edit/web.html
+msgid "Remove this link"
+msgstr "Usuń ten link"
+
+#: books/edit/web.html
+msgid "\"Good\" means no spammy links, please. Keep them relevant to the book. Irrelevant sites may be removed. Blatant spam will be deleted without remorse."
+msgstr "\"Poprwany\" oznacza link bez spamu. Linki muszą być powiązane z tą książką. Nieistotne strony mogą zostać usunięte. Rażący spam zostanie usunięty natychmiastowo."
+
+#: bulk_search/bulk_search.html search/advancedsearch.html
+msgid "Bulk Search (beta)"
+msgstr ""
+
+#: covers/add.html
+#, fuzzy
+msgid "There are two ways to put an author's image on Open Library."
 msgstr "Istnieją dwa sposoby dodawania zdjęć autora na Open Library."
 
-#: add.html:14 add.html:20
-msgid "There are two ways to get a cover image on Open Library"
+#: covers/add.html
+#, fuzzy
+msgid "Image Guidelines"
+msgstr "Wskazówki dotyczące okładek"
+
+#: covers/add.html
+#, fuzzy
+msgid "There are a few ways to put a cover image on Open Library."
 msgstr "Istnieją dwa sposoby dodawnania zdjęć okładki na Open Library."
 
-#: add.html:17
-msgid "There are three ways to get a cover image on Open Library"
-msgstr "Istnieją trzy sposoby na dodawnania zdjęć okładki na Open Library."
-
-#: add.html:27 add.html:31
-msgid "Please provide a valid image."
-msgstr "Udostępnij poprawny obraz."
-
-#: add.html:29
-msgid "Please provide an image URL."
-msgstr "Podaj ULR tego obrazu."
-
-#: add.html:83
-msgid "<strong>Pick one</strong> from the existing covers,"
-msgstr "<strong>Wybierz</strong> z istniejących okładek."
-
-#: add.html:117
-msgid "Choose a JPG, GIF or PNG on your computer,"
-msgstr "Wybierz plik JPG, GIF lub PNG z Twojego komputera."
-
-#: add.html:126
-msgid "Or, paste in the image URL if it's on the web."
-msgstr "Lub wklej URL obrazu z adresu internetowego."
-
-#: add.html:134
-msgid "Submit"
-msgstr "Zatwierdź"
-
-#: add.html:141
+#: covers/add.html
 msgid "Cover Guidelines"
 msgstr "Wskazówki dotyczące okładek"
 
-#: author_photo.html:20 book_cover.html:39 book_cover_single_edition.html:34
-#: book_cover_work.html:30 change.html:107 markdown.html:12
-#: openlibrary/macros/BookPreview.html:19 widget.html:281
-msgid "Close"
-msgstr "Zamknij"
+#: covers/add.html
+msgid "Please provide a valid image."
+msgstr "Udostępnij poprawny obraz."
 
-#: change.html:79
-msgid "One sec, we're searching for covers..."
-msgstr "Chwileczkę, szukamy okładek..."
+#: covers/add.html
+msgid "Please provide an image URL."
+msgstr "Podaj ULR tego obrazu."
 
-#: manage.html:25
-msgid ""
-"You can drag and drop thumbnails to reorder, or into the trash to delete "
-"them."
+#: covers/add.html
+#, python-format
+msgid "Learn more by reading our <a href=\"/help/faq/editing#picture\" target=\"blank\">%(guidelines)s</a>."
 msgstr ""
-"Możesz przeciągać i upuszczać miniatury w celu zmiany kolejności, lub "
-"przeciągać je do kosza w celu usunięcia"
 
-#: saved.html:25
+#: covers/add.html
+#, fuzzy
+msgid "<strong>Pick one</strong> from the existing covers"
+msgstr "<strong>Wybierz</strong> z istniejących okładek."
+
+#: covers/add.html
+#, fuzzy
+msgid "Use this image"
+msgstr "Zobacz tę listę"
+
+#: covers/add.html
+#, fuzzy
+msgid "Choose a JPG, GIF, PNG or WebP on your computer"
+msgstr "Wybierz plik JPG, GIF lub PNG z Twojego komputera."
+
+#: covers/add.html
+msgid "Upload"
+msgstr ""
+
+#: covers/add.html
+msgid "Or, paste an image from your clipboard"
+msgstr ""
+
+#: covers/add.html
+msgid "Paste image from clipboard"
+msgstr ""
+
+#: covers/add.html
+#, fuzzy
+msgid "Paste Image"
+msgstr "Dodaj kolejny obraz"
+
+#: covers/add.html
+msgid "Upload image"
+msgstr ""
+
+#: covers/add.html covers/external_image.html
+msgid "Upload Image"
+msgstr ""
+
+#: covers/add.html
+#, fuzzy
+msgid "Uploading..."
+msgstr "zapisywanie..."
+
+#: covers/add.html
+#, fuzzy
+msgid "Wikidata"
+msgstr "Wikipedia"
+
+#: covers/author_photo.html
+msgid "Pull up a larger author photo"
+msgstr ""
+
+#: covers/author_photo.html search/authors.html
+#, python-format
+msgid "Photo of %(author)s"
+msgstr ""
+
+#: covers/author_photo.html
+msgid "Click to close"
+msgstr ""
+
+#: covers/author_photo.html
+#, python-format
+msgid "We need a photo of %(author)s"
+msgstr ""
+
+#: covers/book_cover.html
+msgid "Pull up a bigger book cover"
+msgstr ""
+
+#: covers/book_cover.html covers/book_cover_small.html
+#, python-format
+msgid "Cover of: %(title)s by %(authors)s"
+msgstr ""
+
+#: covers/book_cover_small.html
+#, python-format
+msgid "Go to the main page for %(title)s"
+msgstr ""
+
+#: covers/book_cover_small.html
+#, python-format
+msgid "We need a book cover for: %(title)s"
+msgstr ""
+
+#: covers/change.html
+#, fuzzy
+msgid "Author Photos"
+msgstr "Autorzy"
+
+#: covers/change.html
+#, fuzzy
+msgid "Manage Author Photos"
+msgstr "Połącz autorów"
+
+#: covers/change.html
+#, fuzzy
+msgid "Add Author Photo"
+msgstr "Dodaj książkę"
+
+#: covers/change.html
+#, fuzzy
+msgid "Book Covers"
+msgstr "Książki, które kochamy"
+
+#: covers/change.html
+msgid "Manage Covers"
+msgstr ""
+
+#: covers/change.html
+#, fuzzy
+msgid "Add Cover Image"
+msgstr "Dodaj kolejny obraz"
+
+#: covers/change.html
+#, fuzzy
+msgid "Manage"
+msgstr "Język"
+
+#: covers/external_image.html
+#, python-format
+msgid "Or, use an image from %s"
+msgstr ""
+
+#: covers/manage.html
+msgid "You can drag and drop thumbnails to reorder, or into the trash to delete them."
+msgstr "Możesz przeciągać i upuszczać miniatury w celu zmiany kolejności, lub przeciągać je do kosza w celu usunięcia"
+
+#: covers/saved.html
+msgid "New book cover"
+msgstr ""
+
+#: covers/saved.html
 msgid "Saved!"
 msgstr "Zapisano!"
 
-#: saved.html:28
+#: covers/saved.html
 msgid "Notes:"
 msgstr "Notatki:"
 
-#: saved.html:38
+#: covers/saved.html
 msgid "Add another image"
 msgstr "Dodaj kolejny obraz"
 
-#: saved.html:45
+#: covers/saved.html
 msgid "Finished"
 msgstr "Zakończono"
 
-#: comment.html:26
-#, python-format
-msgid "Imported from %(source)s  <a href=\"%(url)s\">%(type)s record</a>."
+#: design/toggle.html
+msgid "Toggle"
 msgstr ""
 
-#: comment.html:28
+#: design/toggle.html
 #, python-format
-msgid "Found a <a href=\"%(url)s\">matching record</a> from %(source)s."
+msgid "The %(tag)s component is a switch with a bold label and an optional greyed sublabel. The whole control is one %(role)s button, so the entire surface is clickable and Enter/Space activate it. It owns its on/off state: clicking flips %(checked)s and fires %(event)s."
 msgstr ""
 
-#: comment.html:35
-msgid "Edited without comment."
-msgstr "Edytowano bez dodania komentarza."
+#: design/toggle.html
+msgid "Default"
+msgstr ""
 
-#: about.html:9
+#: design/toggle.html
+#, python-format
+msgid "A plain toggle: just the switch, a bold %(label)s, and an optional greyed %(sublabel)s."
+msgstr ""
+
+#: design/toggle.html
+msgid "Card variant"
+msgstr ""
+
+#: design/toggle.html
+#, python-format
+msgid "Use %(variant)s for a bordered container. When checked, it fills with a solid primary-blue background and white text — the same treatment as a selected %(chip)s."
+msgstr ""
+
+#: design/toggle.html
+#, fuzzy
+msgid "Custom label content"
+msgstr "Spis treści"
+
+#: design/toggle.html
+#, python-format
+msgid "Put content in the default slot to customize the label instead of using %(label)s / %(sublabel)s. Supply %(accessible_label)s so the switch still has an accessible name."
+msgstr ""
+
+#: design/toggle.html
+msgid "Dark mode"
+msgstr ""
+
+#: design/toggle.html
+msgid "easier on the eyes"
+msgstr ""
+
+#: design/toggle.html
+#, fuzzy
+msgid "Disabled"
+msgstr "Dla osób z trudnościami w czytaniu druku"
+
+#: design/toggle.html
+#, python-format
+msgid "Add %(disabled)s to block interaction."
+msgstr ""
+
+#: design/toggle.html
+msgid "Change event"
+msgstr ""
+
+#: design/toggle.html
+#, python-format
+msgid "Toggling fires %(event)s with the new state in %(detail)s."
+msgstr ""
+
+#: design/toggle.html
+msgid "Checked:"
+msgstr ""
+
+#: email/case_created.html
+#, fuzzy
+msgid "Sent!"
+msgstr "Wyślij"
+
+#: email/case_created.html
+msgid "Thank you for your note. We'll get back to you as soon as possible."
+msgstr ""
+
+#: email/case_created.html
+msgid "It might take us a little while to read it because we receive lots of messages, but rest assured we will, and we'll get back to you if required."
+msgstr ""
+
+#: email/account/pd_request.html
+msgid "Qualifying for Print Disability Special Access"
+msgstr ""
+
+#: history/sources.html
+#, fuzzy
+msgid "record"
+msgstr "Usuń wpis"
+
+#: home/about.html
 msgid "About the Project"
 msgstr "O projekcie"
 
-#: about.html:15
-msgid ""
-"Open Library is an open, editable library catalog, building towards a web"
-" page for every book ever published."
-msgstr ""
-"Open Library to otwarty, edytowalny katalog biblioteczny, dążący do "
-"stworzenia strony internetowej dla każdej kiedykolwiek opublikowanej "
-"książki."
+#: home/about.html
+msgid "Open Library is an open, editable library catalog, building towards a web page for every book ever published."
+msgstr "Open Library to otwarty, edytowalny katalog biblioteczny, dążący do stworzenia strony internetowej dla każdej kiedykolwiek opublikowanej książki."
 
-#: about.html:16 nav_head.html:89 nav_head.html:90
+#: AffiliateLinks.html home/about.html search/work_search_facets.html
 msgid "More"
 msgstr "Więcej"
 
-#: about.html:19
-msgid ""
-"Just like Wikipedia, you can contribute new information or corrections to"
-" the catalog. You can browse by <a href=\"/subjects\">subjects</a>, <a "
-"href=\"/authors\">authors</a> or <a href=\"/lists\">lists</a> members "
-"have created. If you love books, why not help build a library?"
-msgstr ""
-"Tak jak na Wikipedii, możesz dodać nowe informacje lub poprawki do "
-"katalogu. Możesz przeglądać według <a href=\"/subjects\">tematyki</a>, <a"
-" href=\"/authors\">autorów</a> lub <a href=\"/lists\">list</a> "
-"stworzonych przez użytkowników. Jeśli kochasz książki - czemu nie pomóc w"
-" budowie biblioteki?"
+#: home/about.html
+msgid "Just like Wikipedia, you can contribute new information or corrections to the catalog. You can browse by <a href=\"/subjects\">subjects</a>, <a href=\"/authors\">authors</a> or <a href=\"/lists\">lists</a> members have created. If you love books, why not help build a library?"
+msgstr "Tak jak na Wikipedii, możesz dodać nowe informacje lub poprawki do katalogu. Możesz przeglądać według <a href=\"/subjects\">tematyki</a>, <a href=\"/authors\">autorów</a> lub <a href=\"/lists\">list</a> stworzonych przez użytkowników. Jeśli kochasz książki - czemu nie pomóc w budowie biblioteki?"
 
-#: about.html:23
+#: home/about.html
 msgid "Latest Blog Posts"
 msgstr "Najnowsze wpisy na blogu"
 
-#: categories.html:11
+#: home/categories.html
 msgid "Browse by Subject"
 msgstr "Przeglądaj według tematów"
 
-#: categories.html:26
+#: home/categories.html
 #, python-format
-msgid "browse %(subject)s books"
-msgstr "przeglądaj według %(subject)s książek"
-
-#: categories.html:31
-#, python-format
-msgid "1 Book"
+msgid "%(count)s Book"
 msgid_plural "%(count)s Books"
-msgstr[0] "1 książka"
-msgstr[1] "%(count)s książek"
+msgstr[0] ""
+msgstr[1] ""
 
-#: index.html:8
+#: home/index.html home/welcome.html
 msgid "Welcome to Open Library"
 msgstr "Witamy w Open Library"
 
-#: index.html:15
+#: home/index.html openlibrary/plugins/openlibrary/api.py
 msgid "Classic Books"
 msgstr "Literatura klasyczna"
 
-#: index.html:17
-msgid "Books We Love"
-msgstr "Książki, które kochamy"
-
-#: index.html:19
+#: home/index.html
 msgid "Recently Returned"
 msgstr "Ostatnio zwrócone"
 
-#: index.html:21
+#: home/index.html openlibrary/plugins/openlibrary/api.py openlibrary/plugins/openlibrary/home.py
 msgid "Romance"
 msgstr "Romanse"
 
-#: index.html:23
+#: home/index.html openlibrary/plugins/openlibrary/api.py
 msgid "Kids"
 msgstr "Książki dla dzieci"
 
-#: index.html:25
+#: home/index.html openlibrary/plugins/openlibrary/api.py
 msgid "Thrillers"
 msgstr "Dreszczwce"
 
-#: index.html:27
+#: home/index.html openlibrary/plugins/openlibrary/api.py openlibrary/plugins/openlibrary/home.py
 msgid "Textbooks"
 msgstr "Podręczniki"
 
-#: around_the_library.html:52 stats.html:9
+#: home/index.html
+msgid "Authors Alliance & MIT Press"
+msgstr ""
+
+#: home/index.html
+msgid "Books in Local Environment"
+msgstr ""
+
+#: home/loans.html
+#, python-format
+msgid "You can still <a href=\"/subjects/in_library#ebooks=true\">borrow</a> one more book until you've hit the limit!"
+msgid_plural "You can still <a href=\"/subjects/in_library#ebooks=true\">borrow</a> %(count)d more books until you've hit the limit!"
+msgstr[0] ""
+msgstr[1] ""
+
+#: home/loans.html
+msgid "You have reached the borrowing limit. Please return a book to checkout something new."
+msgstr ""
+
+#: home/stats.html
 msgid "Around the Library"
 msgstr "O Open Library"
 
-#: stats.html:10
-msgid ""
-"Here's what's happened over the last 28 days. More <a "
-"href=\"/recentchanges\">recent changes</a>"
-msgstr ""
-"Oto co wydarzyło się w ciągu ostatnich 28 dni. Więcej <a "
-"href=\"/recentchanges\">ostatnich zmian</a>"
+#: home/stats.html
+msgid "Here's what's happened over the last 28 days. More <a href=\"/recentchanges\">recent changes</a>"
+msgstr "Oto co wydarzyło się w ciągu ostatnich 28 dni. Więcej <a href=\"/recentchanges\">ostatnich zmian</a>"
 
-#: stats.html:15 stats.html:17
+#: home/stats.html
 msgid "See all visitors to OpenLibrary.org"
 msgstr "Zobacz wszystkich odwiedzających OpenLibrary.org"
 
-#: stats.html:17
-msgid "Unique Visitors"
-msgstr "Szczególni odwiedzający"
+#: home/stats.html
+msgid "Area graph of recent unique visitors"
+msgstr ""
 
-#: stats.html:22 stats.html:24
+#: home/stats.html
 msgid "How many new Open Library members have we welcomed?"
 msgstr "Ilu nowych użytkowników Open Library powitaliśmy?"
 
-#: stats.html:24
-msgid "New Members"
+#: home/stats.html
+#, fuzzy
+msgid "Area graph of new members"
 msgstr "Nowi użytkownicy"
 
-#: stats.html:28 stats.html:30
+#: home/stats.html
 msgid "People are constantly updating the catalog"
 msgstr "Użytkownicy na bierząco aktualizujący katalog"
 
-#: stats.html:30
+#: home/stats.html
+msgid "Area graph of recent catalog edits"
+msgstr ""
+
+#: home/stats.html
 msgid "Catalog Edits"
 msgstr "Edycje katalogu"
 
-#: stats.html:35 stats.html:37
+#: home/stats.html
 msgid "Members can create Lists"
 msgstr "Użytkownicy mogą tworzyć Listy"
 
-#: stats.html:37
+#: home/stats.html
+msgid "Area graph of lists created recently"
+msgstr ""
+
+#: home/stats.html
 msgid "Lists Created"
 msgstr "Utworzone Listy"
 
-#: stats.html:42 stats.html:44
+#: home/stats.html
 msgid "We're a library, so we lend books, too"
 msgstr "Jesteśmy biblioteką, więc równierz wypożyczamy książki"
 
-#: stats.html:44
+#: home/stats.html
+msgid "Area graph of ebooks borrowed recently"
+msgstr ""
+
+#: home/stats.html
 msgid "eBooks Borrowed"
 msgstr "Wypożyczone e-booki"
 
-#: edit_head.html:17
-msgid "You're in edit mode."
-msgstr "Jesteś w trybie edycji."
+#: home/welcome.html
+msgid "Read Free Library Books Online"
+msgstr ""
 
-#: edit_head.html:18
-msgid "Cancel, and go back."
-msgstr "Anuluj i wróć."
+#: home/welcome.html
+msgid "Millions of books available through Controlled Digital Lending"
+msgstr ""
 
-#: edit_head.html:22 view_head.html:14
+#: home/welcome.html
+msgid "Set a Yearly Reading Goal"
+msgstr ""
+
+#: home/welcome.html
+msgid "Learn how to set a yearly reading goal and track what you read"
+msgstr ""
+
+#: home/welcome.html
+msgid "Keep Track of your Favorite Books"
+msgstr ""
+
+#: home/welcome.html
+msgid "Organize your Books using Lists & the Reading Log"
+msgstr ""
+
+#: home/welcome.html
+msgid "Try the virtual Library Explorer"
+msgstr ""
+
+#: home/welcome.html
+msgid "Digital shelves organized like a physical library"
+msgstr ""
+
+#: home/welcome.html
+#, fuzzy
+msgid "Try Fulltext Search"
+msgstr "Wyszukiwanie pełnotekstowe"
+
+#: home/welcome.html
+msgid "Find matching results within the text of millions of books"
+msgstr ""
+
+#: home/welcome.html
+#, fuzzy
+msgid "Be an Open Librarian"
+msgstr "Open Library"
+
+#: home/welcome.html
+msgid "Dozens of ways you can help improve the library"
+msgstr ""
+
+#: home/welcome.html
+#, fuzzy
+msgid "Volunteer at Open Library"
+msgstr "Witamy w Open Library"
+
+#: home/welcome.html
+msgid "Discover opportunities to improve the library"
+msgstr ""
+
+#: home/welcome.html
+msgid "Send us feedback"
+msgstr ""
+
+#: home/welcome.html
+msgid "Your feedback will help us improve these cards"
+msgstr ""
+
+#: jsdef/LazyWorkPreview.html
+#, fuzzy
+msgid "Select this work"
+msgstr "Wybierz tę książkę"
+
+#: jsdef/LazyWorkPreview.html
+#, fuzzy
+msgid "1 edition"
+msgstr "1 wydanie"
+
+#: jsdef/LazyWorkPreview.html
+#, fuzzy
+msgid "editions"
+msgstr "Wydawnictwo"
+
+#: languages/index.html
+#, python-format
+msgid "%s work"
+msgid_plural "%s works"
+msgstr[0] ""
+msgstr[1] ""
+
+#: languages/index.html
+#, python-format
+msgid "%s ebook edition"
+msgid_plural "%s ebook editions"
+msgstr[0] ""
+msgstr[1] ""
+
+#: languages/notfound.html
+#, fuzzy, python-format
+msgid "%s is not found"
+msgstr "Nie znaleziono %s"
+
+#: languages/notfound.html
+#, fuzzy, python-format
+msgid "%s does not exist."
+msgstr "%s nie istnieje."
+
+#: lib/edit_head.html lib/view_head.html
 msgid "This doc was last edited by"
 msgstr "Ten dokument był ostatnio edytowany przez"
 
-#: edit_head.html:24 view_head.html:16
+#: lib/edit_head.html lib/view_head.html
 msgid "This doc was last edited anonymously"
 msgstr "Ten dokument był ostatnio edytowany anonimowo"
 
-#: history.html:20 openlibrary/macros/databarView.html:29
-#: openlibrary/macros/databarView.html:31
+#: lib/exports.html
+msgid "Download catalog record:"
+msgstr "Pobierz wpis w katalogu:"
+
+#: lib/exports.html
+msgid "RDF"
+msgstr ""
+
+#: lib/exports.html type/list/exports.html
+#, fuzzy
+msgid "JSON"
+msgstr "Wizja"
+
+#: lib/exports.html
+#, fuzzy
+msgid "OPDS"
+msgstr "Ups!"
+
+#: lib/exports.html
+msgid "Cite this on Wikipedia"
+msgstr "Zacytuj to na Wikipedii"
+
+#: lib/exports.html
+msgid "Wikipedia citation"
+msgstr "Cytat z Wikipedii"
+
+#: lib/exports.html
+msgid "Copy and paste this code into your Wikipedia page."
+msgstr "Skopiuj i wklej ten kod na Twojej stronie Wikipedii."
+
+#: lib/exports.html
+#, fuzzy
+msgid "Get instructions at Wikipedia in a new window"
+msgstr "Odwiedź stronę tego autora w nowym oknie"
+
+#: lib/header_dropdown.html
+#, fuzzy
+msgid "My account"
+msgstr "Moje konto"
+
+#: lib/header_dropdown.html type/user/view.html
+#, python-format
+msgid "Joined %(date)s"
+msgstr "Dołączył\\(a\\) %(date)s"
+
+#: lib/header_dropdown.html
+msgid "Menu"
+msgstr ""
+
+#: lib/header_dropdown.html
+#, fuzzy
+msgid "New!"
+msgstr "Nowsze"
+
+#: databarDiff.html databarEdit.html databarTemplate.html databarView.html lib/history.html openlibrary/plugins/openlibrary/home.py
 msgid "History"
 msgstr "Historia"
 
-#: history.html:24
+#: lib/history.html
 #, fuzzy, python-format
 msgid "Created %(date)s"
 msgstr "Dołączył\\(a\\) %(date)s"
 
-#: history.html:31
-#, python-format
-msgid "1 revision"
+#: lib/history.html
+#, fuzzy, python-format
+msgid "%(count)d revision"
 msgid_plural "%(count)d revisions"
-msgstr[0] "1 korekta"
-msgstr[1] "%(count)d korekty"
+msgstr[0] "%(count)d Lista"
+msgstr[1] "%(count)d Listy"
 
-#: history.html:43
-msgid "Download catalog record:"
-msgstr "Pobierz wpis w katalogu:"
-
-#: history.html:51
-msgid "Cite this on Wikipedia"
-msgstr "Zacytuj to na Wikipedii"
-
-#: history.html:51
-msgid "Wikipedia citation"
-msgstr "Cytat z Wikipedii"
-
-#: history.html:61
-msgid "Copy and paste this code into your Wikipedia page."
-msgstr "Skopiuj i wklej ten kod na Twojej stronie Wikipedii."
-
-#: history.html:85 openlibrary/templates/history.html:46
-#, python-format
-msgid "View revision %s"
-msgstr "Zobacz korekty %s"
-
-#: history.html:90 history.html:92
+#: lib/history.html
 msgid "an anonymous user"
 msgstr "anonimowy użytkownik"
 
-#: history.html:94
-#, fuzzy, python-format
+#: lib/history.html
+#, python-format
 msgid "Created by %(user)s"
-msgstr "Utworzony przez %s"
+msgstr ""
 
-#: history.html:96
-#, fuzzy, python-format
+#: lib/history.html
+#, python-format
 msgid "Edited by %(user)s"
-msgstr "Edytowany przez %s"
-
-#: markdown.html:16
-msgid ""
-"We use a system called Markdown to format the text in your edits on Open "
-"Library. Some HTML formatting is also accepted. Paragraphs are "
-"automatically generated from any hard-break returns (blank lines) within "
-"your text. You can preview your work in real time below the editing "
-"field."
 msgstr ""
-"Używamy systemu Markdown do formatowania tekstu w Twoich edycjach w Open "
-"Library. Niektóre formatowanie HTML jest również akceptowane. Akapity są "
-"automatycznie generowane na podstawie zwrotów typu hard-break (puste "
-"linie) w Twoim tekscie. Możesz wyświetlić podgląd swojej pracy w czasie "
-"rzeczywistym poniżej pola edycji."
 
-#: markdown.html:17
-msgid "Formatting marks should envelope the effected text, for example:"
-msgstr "Znaki formatujące powinny otaczać utworzony tekst, na przykład:"
-
-#: markdown.html:76
-msgid ""
-"To \"escape\" any Markdown tags (i.e. use an asterisk as an asterisk "
-"rather than emphasizing text) place a backslash \\ prior to the "
-"character."
+#: lib/message_addbook.html
+msgid "Super!"
 msgstr ""
-"Aby \"uciec\" tagom Markdown (tj. użyć gwiazdki jako gwiazdki zamiast "
-"podkreślenia tekstu) umieść ukośnik \\ przed tym znakiem."
 
-#: nav_foot.html:13
+#: lib/message_addbook.html
+msgid " Your new record is in the library. Thank you!"
+msgstr ""
+
+#: lib/message_addbook.html
+msgid "There are a few other simple things you can add while you're here to improve your new record quickly, and make it much easier for other people to find later."
+msgstr ""
+
+#: lib/message_addbook.html
+#, fuzzy
+msgid "Upload a cover image"
+msgstr "Dodaj kolejny obraz"
+
+#: lib/message_addbook.html
+msgid "Snap a quick photo of the cover to share?"
+msgstr ""
+
+#: lib/message_addbook.html
+#, fuzzy
+msgid "Add an ISBN"
+msgstr "Dodaj książkę"
+
+#: lib/message_addbook.html
+msgid "Help the library connect with other systems, like Amazon."
+msgstr ""
+
+#: lib/message_addbook.html
+#, fuzzy
+msgid "Add some subjects"
+msgstr "Wspólne tematy"
+
+#: lib/message_addbook.html
+msgid "They're just like tags."
+msgstr ""
+
+#: lib/message_addbook.html
+msgid "Describe what the book's about"
+msgstr ""
+
+#: lib/message_addbook.html
+msgid "Just a sentence or two is good."
+msgstr ""
+
+#: lib/nav_foot.html openlibrary/plugins/openlibrary/api.py site/head.html
+msgid "Open Library"
+msgstr "Open Library"
+
+#: lib/nav_foot.html
 msgid "Vision"
 msgstr "Wizja"
 
-#: nav_foot.html:14
+#: lib/nav_foot.html
 msgid "Volunteer"
 msgstr ""
 
-#: nav_foot.html:15
+#: lib/nav_foot.html
+msgid "Partner With Us"
+msgstr ""
+
+#: lib/nav_foot.html
 msgid "Jobs"
 msgstr "Oferty pracy"
 
-#: nav_foot.html:15
+#: lib/nav_foot.html
 msgid "Careers"
 msgstr "Kariera"
 
-#: nav_foot.html:16
+#: lib/nav_foot.html
 msgid "Blog"
 msgstr "Blog"
 
-#: nav_foot.html:17
+#: lib/nav_foot.html
 msgid "Terms of Service"
 msgstr "Warunki świadczenia usług"
 
-#: nav_foot.html:18
+#: lib/nav_foot.html site/alert.html
 msgid "Donate"
 msgstr "Dorzuć się"
 
-#: nav_foot.html:22
+#: lib/nav_foot.html
 msgid "Discover"
 msgstr "Odkrywaj"
 
-#: nav_foot.html:24
+#: lib/nav_foot.html
 msgid "Go home"
 msgstr "Wróć do strony głównej"
 
-#: nav_foot.html:24
+#: lib/nav_foot.html
 msgid "Home"
 msgstr "Strona główna"
 
-#: nav_foot.html:25
+#: lib/nav_foot.html
 msgid "Explore Books"
 msgstr "Zobacz książki"
 
-#: nav_foot.html:25
-msgid "Books"
-msgstr "Książki"
-
-#: nav_foot.html:26
+#: lib/nav_foot.html
 msgid "Explore authors"
 msgstr "Zobacz autorów"
 
-#: authors.html:81 nav_foot.html:26 view.html:135
-msgid "Authors"
-msgstr "Autorzy"
-
-#: nav_foot.html:27
+#: lib/nav_foot.html
 msgid "Explore subjects"
 msgstr "Zobacz książki"
 
-#: advancedsearch.html:7 advancedsearch.html:10 advancedsearch.html:15
-#: nav_foot.html:28 nav_head.html:19 nav_head.html:95
-#: openlibrary/templates/work_search.html:116
+#: RelatedSubjects.html SearchNavigation.html SubjectTags.html lib/nav_foot.html lib/nav_head.html openlibrary/plugins/worksearch/code.py subjects/notfound.html type/author/view.html type/list/view_body.html
+msgid "Subjects"
+msgstr "Tematyka"
+
+#: lib/nav_foot.html
+#, fuzzy
+msgid "Explore collections"
+msgstr "Zobacz książki"
+
+#: lib/nav_foot.html lib/nav_head.html
+#, fuzzy
+msgid "Collections"
+msgstr "Akcje"
+
+#: SearchNavigation.html lib/nav_foot.html lib/nav_head.html search/advancedsearch.html
 msgid "Advanced Search"
 msgstr "Wyszukiwanie zaawansowane"
 
-#: nav_foot.html:29
+#: lib/nav_foot.html
 msgid "Navigate to top of this page"
 msgstr "Wróć na górę tej strony"
 
-#: nav_foot.html:29
+#: lib/nav_foot.html
 msgid "Return to Top"
 msgstr "Przewiń do góry"
 
-#: nav_foot.html:33
+#: lib/nav_foot.html
 msgid "Develop"
 msgstr "Rozwijaj"
 
-#: nav_foot.html:35
-msgid "Explore Open Library Development Center"
+#: lib/nav_foot.html
+#, fuzzy
+msgid "Explore Open Library Developer Center"
 msgstr "Poznaj Centrum Rozwoju Open Library"
 
-#: nav_foot.html:35
-msgid "Development Center"
-msgstr "Centrum Rozwoju"
-
-#: nav_foot.html:36
-msgid "Explore Open Library APIs"
-msgstr "Poznaj API Open Library"
-
-#: nav_foot.html:36
-msgid "API Documentation"
-msgstr "Dokumentacja API"
-
-#: nav_foot.html:37
-msgid "Bulk Open Library data"
-msgstr "Dane zbiorcze Open Library"
-
-#: nav_foot.html:37
-msgid "Bulk Data Dumps"
-msgstr "Zrzuty danych zbiorczych"
-
-#: nav_foot.html:38
-msgid "Write a bot"
-msgstr "Napisz bota"
-
-#: nav_foot.html:38
-msgid "Writing Bots"
-msgstr "Pisanie botów"
-
-#: nav_foot.html:39
-msgid "Add a new book to Open Library"
-msgstr "Dodaj nową książkę do Open Library"
-
-#: nav_foot.html:45
-msgid "Help Center"
-msgstr "Centrum Pomocy"
-
-#: nav_foot.html:46
-msgid "Problems"
-msgstr "Problemy"
-
-#: nav_foot.html:46
-msgid "Report A Problem"
-msgstr "Zgłoś problem"
-
-#: nav_foot.html:47
-msgid "Suggest Edits"
-msgstr "Zaproponuj zmiany"
-
-#: nav_foot.html:47
-msgid "Suggesting Edits"
-msgstr "Zaproponuj zmiany"
-
-#: nav_foot.html:59
-msgid ""
-"Open Library is an initiative of the <a href=\"//archive.org/\">Internet "
-"Archive</a>, a 501(c)(3) non-profit, building a digital library of "
-"Internet sites and other cultural artifacts in  digital form. Other <a "
-"href=\"//archive.org/projects/\">projects</a> include the <a "
-"href=\"//archive.org/web/\">Wayback Machine</a>, <a "
-"href=\"//archive.org/\">archive.org</a> and <a href=\"//archive-it.org"
-"\">archive-it.org</a>"
-msgstr ""
-"Open Library to inicjatywa <a href=\"//archive.org/\">Internet "
-"Archive</a>, 501(c)(3) organizacji non-profit, tworzącej cyfrową "
-"bibliotekę stron internetowych i innych artefaktów kulturowych w formie "
-"cyfrowej. Inne <a href=\"//archive.org/projects/\">projekty</a> obejmują "
-"<a href=\"//archive.org/web/\">Wayback Machine</a>, <a "
-"href=\"//archive.org/\">archive.org</a> oraz <a href=\"//archive-it.org"
-"\">archive-it.org</a>"
-
-#: nav_foot.html:64
-#, python-format
-msgid ""
-"version <a "
-"href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</a>"
-msgstr ""
-"wersja <a "
-"href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</a>"
-
-#: nav_head.html:13 search_head.html:76
-msgid "Log in"
-msgstr "Zaloguj się"
-
-#: nav_head.html:14
-msgid "Sign up"
-msgstr "Utwórz konto"
-
-#: nav_head.html:17 nav_head.html:94
-msgid "Random Book"
-msgstr "Losowa książka"
-
-#: nav_head.html:18 nav_head.html:96
-msgid "Recent Community Edits"
-msgstr "Najnowsze zmiany wprowadzone przez społeczność"
-
-#: nav_head.html:20 nav_head.html:97
+#: lib/nav_foot.html lib/nav_head.html
 msgid "Developer Center"
 msgstr "Centrum programistów"
 
-#: nav_head.html:21 nav_head.html:98
-msgid "Help & Support"
-msgstr "Pomoc i wsparcie"
+#: lib/nav_foot.html
+msgid "Explore Open Library APIs"
+msgstr "Poznaj API Open Library"
 
-#: nav_head.html:43
-msgid "All"
-msgstr "Wszystkie"
+#: lib/nav_foot.html
+msgid "API Documentation"
+msgstr "Dokumentacja API"
 
-#: nav_head.html:46
-msgid "Text"
-msgstr "Tekst"
+#: lib/nav_foot.html
+msgid "Bulk Open Library data"
+msgstr "Dane zbiorcze Open Library"
 
-#: advancedsearch.html:29 nav_head.html:47 search_foot.html:11
-#: search_head.html:11
-msgid "Subject"
-msgstr "Temat"
+#: lib/nav_foot.html
+msgid "Bulk Data Dumps"
+msgstr "Zrzuty danych zbiorczych"
 
-#: nav_head.html:49 search_foot.html:63 search_head.html:29
-msgid "Advanced"
-msgstr "Zaawansowane"
+#: lib/nav_foot.html
+msgid "Write a bot"
+msgstr "Napisz bota"
 
-#: authors.html:48 home.html:25 inside.html:17 lists.html:17 nav_head.html:54
-#: notfound.html:19 openlibrary/templates/subjects.html:27
-#: openlibrary/templates/work_search.html:139 publishers.html:19
-#: search_head.html:24 subjects.html:34 view.html:170
-msgid "Search"
-msgstr "Szukaj"
+#: lib/nav_foot.html
+msgid "Writing Bots"
+msgstr "Pisanie botów"
 
-#: nav_head.html:68 nav_head.html:69
-msgid "Browse"
-msgstr "Przeglądaj"
+#: lib/nav_foot.html
+msgid "Help Center"
+msgstr "Centrum Pomocy"
 
-#: nav_head.html:82 nav_head.html:120
-msgid "My Loans"
-msgstr "Wypożyczone przeze mnie"
+#: lib/nav_foot.html
+#, fuzzy
+msgid "Contact"
+msgstr "Dorzuć się"
 
-#: nav_head.html:83
-msgid "My Reading Log"
-msgstr "Mój Dziennik Lektur"
+#: lib/nav_foot.html
+#, fuzzy
+msgid "Contact Us"
+msgstr "Status"
 
-#: nav_head.html:84 nav_head.html:121
-msgid "My Lists"
-msgstr "Moje listy"
+#: lib/nav_foot.html
+msgid "Suggest Edits"
+msgstr "Zaproponuj zmiany"
 
-#: nav_head.html:108 openlibrary/templates/login.html:10
-#: openlibrary/templates/login.html:62
-msgid "Log In"
-msgstr "Zaloguj się"
+#: lib/nav_foot.html
+msgid "Suggesting Edits"
+msgstr "Zaproponuj zmiany"
 
-#: nav_head.html:116
-msgid "My Account"
-msgstr "Moje konto"
+#: lib/nav_foot.html
+msgid "Add a new book to Open Library"
+msgstr "Dodaj nową książkę do Open Library"
 
-#: nav_head.html:122
+#: lib/nav_foot.html
+#, fuzzy
+msgid "Release Notes"
+msgstr "Związek z tematem"
+
+#: lib/nav_foot.html
+msgid "Bluesky"
+msgstr ""
+
+#: lib/nav_foot.html
+#, fuzzy
+msgid "Open Library on Bluesky"
+msgstr "Open Library"
+
+#: lib/nav_foot.html
+#, fuzzy
+msgid "Twitter"
+msgstr "Tytuł"
+
+#: lib/nav_foot.html
+#, fuzzy
+msgid "Open Library on Twitter"
+msgstr "Open Library"
+
+#: lib/nav_foot.html
+msgid "GitHub"
+msgstr ""
+
+#: lib/nav_foot.html
+#, fuzzy
+msgid "Open Library on GitHub"
+msgstr "Open Library"
+
+#: lib/nav_foot.html site/alert.html
+msgid "Change Website Language"
+msgstr ""
+
+#: lib/nav_foot.html lib/nav_head.html type/list/embed.html
+#, fuzzy
+msgid "Open Library logo"
+msgstr "Open Library"
+
+#: lib/nav_foot.html
+msgid "Open Library is an initiative of the <a href=\"//archive.org/\">Internet Archive</a>, a 501(c)(3) non-profit, building a digital library of Internet sites and other cultural artifacts in  digital form. Other <a href=\"//archive.org/projects/\">projects</a> include the <a href=\"//archive.org/web/\">Wayback Machine</a>, <a href=\"//archive.org/\">archive.org</a> and <a href=\"//archive-it.org\">archive-it.org</a>"
+msgstr "Open Library to inicjatywa <a href=\"//archive.org/\">Internet Archive</a>, 501(c)(3) organizacji non-profit, tworzącej cyfrową bibliotekę stron internetowych i innych artefaktów kulturowych w formie cyfrowej. Inne <a href=\"//archive.org/projects/\">projekty</a> obejmują <a href=\"//archive.org/web/\">Wayback Machine</a>, <a href=\"//archive.org/\">archive.org</a> oraz <a href=\"//archive-it.org\">archive-it.org</a>"
+
+#: lib/nav_foot.html
+#, python-format
+msgid "version <a href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</a>"
+msgstr "wersja <a href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</a>"
+
+#: lib/nav_head.html
+msgid "Loans, Reading Log, Lists, Stats"
+msgstr ""
+
+#: lib/nav_head.html
 msgid "My Profile"
 msgstr "Mój profil"
 
-#: nav_head.html:126
+#: lib/nav_head.html
 msgid "Log out"
 msgstr "Wyloguj się"
 
-#: openlibrary/macros/Pager.html:27 pagination.html:22
-msgid "Previous"
-msgstr "Poprzednie"
+#: lib/nav_head.html
+msgid "Pending Merge Requests"
+msgstr ""
 
-#: openlibrary/macros/Pager.html:34 openlibrary/templates/history.html:90
-#: pagination.html:37
-msgid "Next"
-msgstr "Kolejne"
+#: lib/nav_head.html search/sort_options.html
+#, fuzzy
+msgid "Trending"
+msgstr "Dziennik Lektur"
 
-#: advancedsearch.html:33 search_foot.html:12 search_head.html:12
-msgid "Place"
-msgstr "Miejsce"
+#: lib/nav_head.html
+#, fuzzy
+msgid "K-12 Student Library"
+msgstr "Open Library"
 
-#: advancedsearch.html:37 search_foot.html:13 search_head.html:13
-msgid "Person"
-msgstr "Osoba"
+#: lib/nav_head.html
+#, fuzzy
+msgid "Book Talks"
+msgstr "Książki"
 
-#: advancedsearch.html:41 openlibrary/templates/work_search.html:128
-#: search_foot.html:14 search_head.html:14
-msgid "Publisher"
-msgstr "Wydawca"
+#: lib/nav_head.html
+msgid "Random Book"
+msgstr "Losowa książka"
 
-#: openlibrary/templates/work_search.html:129 search_foot.html:29
-msgid "Language"
-msgstr "Język"
+#: lib/nav_head.html
+msgid "Recent Community Edits"
+msgstr "Najnowsze zmiany wprowadzone przez społeczność"
 
-#: search_foot.html:31
-msgid "any"
-msgstr "dowolny"
+#: lib/nav_head.html
+msgid "Help & Support"
+msgstr "Pomoc i wsparcie"
 
-#: search_foot.html:32
-msgid "English"
-msgstr "Angielski"
+#: lib/nav_head.html
+msgid "Librarians Portal"
+msgstr ""
 
-#: search_foot.html:33
-msgid "German"
-msgstr "Niemiecki"
+#: lib/nav_head.html
+#, fuzzy
+msgid "My Open Library"
+msgstr "Open Library"
 
-#: search_foot.html:34
-msgid "French"
-msgstr "Francuski"
+#: databarWork.html lib/nav_head.html
+msgid "Browse"
+msgstr "Przeglądaj"
 
-#: search_foot.html:35
-msgid "Spanish"
-msgstr "Hiszpański"
+#: lib/nav_head.html
+#, fuzzy
+msgid "Contribute"
+msgstr "Współtwórcy"
 
-#: search_foot.html:36
-msgid "Russian"
-msgstr "Rosyjski"
+#: lib/nav_head.html
+msgid "Resources"
+msgstr ""
 
-#: search_foot.html:37
-msgid "Italian"
-msgstr "Włoski"
+#: lib/nav_head.html
+msgid "The Internet Archive's Open Library: One page for every book"
+msgstr ""
 
-#: search_foot.html:38
-msgid "Chinese"
-msgstr "Chiński"
+#: lib/nav_head.html
+#, fuzzy
+msgid "Search by barcode"
+msgstr "Szukaj w"
 
-#: search_foot.html:39
-msgid "Arabic"
-msgstr "Arabski"
+#: lib/not_logged.html
+msgid "<strong>You are not <a href=\"/account/login\" title=\"Log in now\">logged in</a>.</strong> Open Library will record your IP address and include it in this page's publicly accessible edit history. If you <a href=\"/account/create\" title=\"Create an Open Library account\">create an account</a>, your IP address is concealed and you can more easily keep track of all your edits and additions."
+msgstr ""
 
-#: search_foot.html:40
-msgid "Japanese"
-msgstr "Japoński"
+#: librarian_dashboard/data_quality_table.html
+#, fuzzy
+msgid "Reload"
+msgstr "Przeczytaj"
 
-#: search_foot.html:41
-msgid "Portuguese"
-msgstr "Portugalski"
+#: librarian_dashboard/data_quality_table.html
+msgid "failing"
+msgstr ""
 
-#: search_foot.html:42
-msgid "Polish"
-msgstr "Polski"
+#: librarian_dashboard/data_quality_table.html
+msgid "Data quality table"
+msgstr ""
 
-#: search_foot.html:68 search_head.html:34
-msgid "Only eBooks"
-msgstr "tylko e-booki"
+#: librarian_dashboard/data_quality_table.html
+msgid "Quality Criteria"
+msgstr ""
 
-#: search_foot.html:70 search_head.html:36
-msgid "Search eBook text"
-msgstr "Wyszukaj w tekscie e-booka"
+#: lists/carousel.html lists/home.html lists/showcase.html
+msgid "See all"
+msgstr "Zobacz wszystkie"
 
-#: search_head.html:68
-msgid "Your Profile"
-msgstr "Twój profil"
+#: lists/export_as_html.html
+#, python-format
+msgid "%(list)s - Editions"
+msgstr ""
 
-#: header.html:11 header.html:24 header.html:38 header.html:47 header.html:56
-#, fuzzy, python-format
+#: lists/export_as_html.html type/list/embed.html type/list/view_body.html
+#, fuzzy
+msgid "Unknown authors"
+msgstr "Nieznany autor"
+
+#: lists/export_as_html.html
+#, fuzzy
+msgid "Title unknown"
+msgstr "Wydawnictwo nieznane"
+
+#: lists/export_as_html.html
+msgid "First publish date unknown"
+msgstr ""
+
+#: lists/export_as_html.html
+msgid "Name unknown"
+msgstr ""
+
+#: lists/header.html
+#, python-format
 msgid "<a href=\"%(href)s\">%(name)s</a> / Lists"
-msgstr "<a href=\"$doc.key\">%(name)s</a> / Listy"
+msgstr ""
 
-#: header.html:16
+#: lists/header.html
 #, python-format
 msgid "This author is on <strong>1 list</strong>."
 msgid_plural "This author is on <strong>%(count)s lists</strong>."
 msgstr[0] "Then autor znajduje się na <strong>1 liście</strong>."
 msgstr[1] "Then autor znajduje się na <strong>(count)s listach</strong>."
 
-#: header.html:31
+#: lists/header.html
 #, python-format
 msgid "This is edition is on <strong>1 list</strong>."
 msgid_plural "This edition is on <strong>%(count)s lists</strong>."
 msgstr[0] "Te wydanie znajduje się na <strong>1 liście</strong>."
 msgstr[1] "Te wydanie znajduje się na <strong> %(count)s listach</strong>."
 
-#: header.html:40
+#: lists/header.html
 #, python-format
 msgid "This work is on <strong>1 list</strong>."
 msgid_plural "This work is on <strong>%(count)s lists</strong>."
 msgstr[0] "Ta książka znajduje się na <strong>1 liście</strong>."
 msgstr[1] "Ta książka znajduje się na <strong> %(count)s listach</strong>."
 
-#: header.html:49
-#, fuzzy, python-format
+#: lists/header.html
+#, python-format
 msgid "%(name)s has 1 list."
 msgid_plural "%(name)s has %(count)s lists."
-msgstr[0] "%(name)s ma %(count)s list."
-msgstr[1] "%(name)s ma %(count)s list"
+msgstr[0] ""
+msgstr[1] ""
 
-#: header.html:59
+#: lists/header.html
 #, python-format
 msgid "This subject is on <strong>1 list</strong>."
 msgid_plural "This subject is on <strong>%(count)s lists</strong>."
 msgstr[0] "Ten temat znajduje się na <strong>1 liście</strong>."
 msgstr[1] "Ten temat znajduje się na <strong> %(count)s listach</strong>."
 
-#: header.html:86
+#: lists/header.html
 msgid "Hm. Can't find it."
 msgstr "Hm. Nie możemy tego znaleźć."
 
-#: home.html:16
+#: lists/home.html
 msgid "Create a list of any Subjects, Authors, Works or specific Editions."
 msgstr "Stwórz listę dowolnych tematów, autorów, książek lub wydań."
 
-#: home.html:17
-msgid ""
-"Once you've made a list, you can <strong>watch for updates</strong> or "
-"<strong>export</strong> all the editions in a list as HTML, BibTeX or "
-"JSON. See all your lists and any activity using the \"Lists\" link on "
-"your Account page."
+#: lists/home.html
+msgid "Once you've made a list, you can <strong>watch for updates</strong> or <strong>export</strong> all the editions in a list as HTML, BibTeX or JSON. See all your lists and any activity using the \"Lists\" link on your Account page."
+msgstr "Po utworzeniu listy możesz <strong>obserwować aktualizacje</strong> lub <strong>eksportować</strong> wszystkie wydania z listy jako HTML, BibTeX lub JSON. Zobacz wszystkie swoje listy i wszelkie działania za pomocą linku \"Lists\" na stronie Twojego konta."
+
+#: lists/home.html
+#, python-format
+msgid "For the top 2000+ most requested eBooks in California for the print disabled <a href=\"%(url)s\">click here</a>."
 msgstr ""
-"Po utworzeniu listy możesz <strong>obserwować aktualizacje</strong> lub "
-"<strong>eksportować</strong> wszystkie wydania z listy jako HTML, BibTeX "
-"lub JSON. Zobacz wszystkie swoje listy i wszelkie działania za pomocą "
-"linku \"Lists\" na stronie Twojego konta."
 
-#: home.html:18
-msgid "Enjoy!"
-msgstr "Baw się dobrze"
-
-#: home.html:20
-#, fuzzy, python-format
-msgid ""
-"For the top 2000+ most requested eBooks in California for the print "
-"disabled <a href=\"%(url)s\">click here</a>."
-msgstr ""
-"Aby zobaczyć listę 2000+ najpopularniejszych e-booków w Kalifornii dla "
-"osób z trudnościami w czytaniu druku <a "
-"href=\"../people/sionnac/lists/OL25152L\">kliknij tutaj</a>"
-
-#: home.html:24
+#: lists/home.html
 msgid "Find a list by name"
 msgstr "Wyszukaj nazwę listy"
 
-#: home.html:31
+#: lists/home.html
 msgid "Active Lists"
 msgstr "Aktywne Listy"
 
-#: home.html:45
+#: lists/home.html
 #, python-format
 msgid "from <a href=\"%(key)s\">%(owner)s</a>"
 msgstr "<a href=\"%(key)s\">%(owner)s</a>"
 
-#: home.html:50 preview.html:27 snippet.html:20
+#: lists/home.html lists/preview.html lists/snippet.html type/list/embed.html type/list/view_body.html
+#, fuzzy, python-format
+msgid "%(count)d item"
+msgid_plural "%(count)d items"
+msgstr[0] "%(count)d Lista"
+msgstr[1] "%(count)d Listy"
+
+#: lists/home.html lists/preview.html lists/snippet.html
 #, python-format
 msgid "Last modified %(date)s"
 msgstr "Ostatnio zmodyfikowany %(date)s"
 
-#: home.html:56 snippet.html:26
+#: lists/home.html lists/snippet.html
 msgid "No description."
 msgstr "Brak opisu."
 
-#: lists.html:9
+#: RecentChangesUsers.html lists/home.html lists/lists.html type/user/view.html
+msgid "Recent Activity"
+msgstr "Ostatnia aktywność"
+
+#: lists/list_follow.html
+#, fuzzy
+msgid "Cover of book"
+msgstr "Wypożycz teraz"
+
+#: lists/list_follow.html
+msgid "Avatar of the owner of the list"
+msgstr ""
+
+#: lists/list_follow.html lists/widget.html my_books/dropdown_content.html
+msgid "You"
+msgstr "Ty"
+
+#: lists/list_follow.html
+msgid "This patron has not enabled following"
+msgstr ""
+
+#: lists/list_follow.html
+msgid "🔒︎"
+msgstr ""
+
+#: Follow.html lists/list_follow.html
+msgid "Follow"
+msgstr ""
+
+#: lists/list_follow.html
+#, fuzzy
+msgid "OpenLibrary Logo"
+msgstr "Open Library"
+
+#: lists/list_follow.html
+msgid "Community List"
+msgstr ""
+
+#: lists/list_overview.html lists/widget.html my_books/dropdown_content.html
+msgid "See this list"
+msgstr "Zobacz tę listę"
+
+#: lists/list_overview.html lists/widget.html my_books/dropdown_content.html
+msgid "Remove from your list?"
+msgstr "Usnunąć z listy?"
+
+#: lists/list_overview.html
+#, python-format
+msgid "from <a href=\"%(link)s\">You</a>"
+msgstr ""
+
+#: lists/list_overview.html
+#, python-format
+msgid "from <a href=\"%(link)s\">%(name)s</a>"
+msgstr ""
+
+#: lists/lists.html
 #, python-format
 msgid "%(owner)s / Lists"
 msgstr "%(owner)s / Listy"
 
-#: lists.html:29
+#: lists/lists.html type/list/view_body.html
+msgid "Yes, I'm sure"
+msgstr ""
+
+#: lists/lists.html type/list/view_body.html
+#, fuzzy
+msgid "No, cancel"
+msgstr "Anuluj"
+
+#: lists/lists.html
 msgid "Delete this list"
 msgstr "Usuń tę listę"
 
-#: lists.html:50
+#: lists/lists.html
 msgid "Delete list"
 msgstr "Usuń listę"
 
-#: lists.html:50
+#: lists/lists.html
 msgid "Are you sure you want to delete this list?"
 msgstr "Czy na pewno chcesz usunąć tę listę?"
 
-#: lists.html:57
+#: lists/lists.html
 msgid "Remove this seed?"
 msgstr "Usunąć ten plik inicujuący?"
 
-#: lists.html:98
+#: lists/lists.html
 #, python-format
 msgid "Are you sure you want to remove <strong>%(title)s</strong> from this list?"
 msgstr "Czy na pewno chcesz usunąć<strong>%(title)s</strong> z tej listy?"
 
-#: lists.html:110
-msgid "No lists yet!"
-msgstr "Na razie brak list!"
+#: lists/lists.html
+msgid "This reader hasn't created any lists yet."
+msgstr ""
 
-#: preview.html:17 widget.html:92
-msgid "You"
-msgstr "Ty"
+#: lists/lists.html
+msgid "You haven't created any lists yet."
+msgstr ""
 
-#: preview.html:40
-msgid "Themes:"
-msgstr "Motywy:"
+#: lists/lists.html
+msgid "Learn how to create your first list."
+msgstr ""
 
-#: snippet.html:9 widget.html:81
+#: lists/preview.html
 #, python-format
-msgid "Cover of: %(listname)s"
-msgstr "Okładka : %(listname)s"
+msgid "by <a href=\"%s\">You</a>"
+msgstr ""
 
-#: widget.html:86
-msgid "See this list"
-msgstr "Zobacz tę listę"
+#: lists/showcase.html
+#, fuzzy, python-format
+msgid "My Lists (%(count)d)"
+msgstr "Przeczytał\\(a\\) (%(count)d)"
 
-#: widget.html:89
-msgid "Remove from your list?"
-msgstr "Usnunąć z listy?"
+#: lists/showcase.html
+#, fuzzy
+msgid "You have no lists."
+msgstr "Aktywne Listy"
 
-#: widget.html:112 widget.html:151 widget.html:260
-msgid "Want to Read"
-msgstr "Chcę przeczytać"
+#: lists/widget.html my_books/dropdown_content.html type/type/view.html
+#, fuzzy
+msgid "from"
+msgstr "Ze strony"
 
-#: widget.html:177
-msgid "My Reading Lists:"
-msgstr "Moje listy lektur:"
+#: lists/widget.html
+msgid "Loading<span class=\"loading-ellipsis\">...</span>"
+msgstr ""
 
-#: widget.html:183 widget.html:202 widget.html:280
-msgid "Create a new list"
-msgstr "Stwórz nową listę"
-
-#: widget.html:193
-msgid "Add to List"
-msgstr "Dodaj do listy"
-
-#: widget.html:224
-msgid "watch for edits or export all records"
-msgstr "obserwuj zmiany lub eksportuj wszystkie kroniki"
-
-#: widget.html:231
-#, python-format
-msgid "%(count)d List"
-msgid_plural "%(count)d Lists"
-msgstr[0] "%(count)d Lista"
-msgstr[1] "%(count)d Listy"
-
-#: widget.html:274
-msgid "Remove"
-msgstr "Usuń"
-
-#: widget.html:274
-#, python-format
-msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
-msgstr "Na pewno chcesz usunąć <strong>%(title)s</strong> z Twoich list?"
-
-#: widget.html:286
-msgid "Name:"
-msgstr "Nazwa:"
-
-#: widget.html:294
-msgid "Description:"
-msgstr "Opis"
-
-#: widget.html:302
-msgid "Create new list"
-msgstr "Utwórz nową listę"
-
-#: widget.html:550
-msgid "saving..."
-msgstr "zapisywanie..."
-
-#: authors.html:36 authors.html:39 authors.html:123
+#: merge/authors.html
 msgid "Merge Authors"
 msgstr "Połącz autorów"
 
-#: authors.html:46
+#: merge/authors.html
 msgid "No authors selected."
 msgstr "Brak wybranych autorów"
 
-#: authors.html:50
-msgid "Please select a master author record."
+#: merge/authors.html
+#, fuzzy
+msgid "Please select a primary author record."
 msgstr "Wybierz główny dokument autora."
 
-#: authors.html:52
+#: merge/authors.html
 msgid "Please select some authors to merge."
 msgstr "Wybierz autorów do połączenia."
 
-#: authors.html:55
-msgid "Select a \"master\" record that best represents the author -"
-msgstr "ybierz \"główny\" dokument, który najlepiej reprezentuje tego autora -"
-
-#: authors.html:58
-msgid "Select author records which should be merged with the master"
+#: merge/authors.html
+msgid "Select the oldest profile as primary -"
 msgstr ""
-"Wybierz dokumenty autora, które powinny zostać połączone z głównym "
-"dokumentem"
 
-#: authors.html:62
+#: merge/authors.html
+#, fuzzy
+msgid "Select author records which should be merged with the primary"
+msgstr "Wybierz dokumenty autora, które powinny zostać połączone z głównym dokumentem"
+
+#: merge/authors.html
 msgid "Press MERGE AUTHORS."
 msgstr "Naciśnij POŁĄCZ AUTORÓW."
 
-#: authors.html:66
-msgid "No Master record"
+#: merge/authors.html
+#, fuzzy
+msgid "No primary record"
 msgstr "Brak głównego dokumentu"
 
-#: authors.html:67
-msgid "You must select a master record to point the duplicates toward."
+#: merge/authors.html
+#, fuzzy
+msgid "You must select a primary record to point the duplicates toward."
 msgstr "Musisz wybrać główny dokument, aby skojarzyć z nim duplikaty."
 
-#: authors.html:70
+#: merge/authors.html
 msgid "Please Be Careful..."
 msgstr "Zachowaj ostrożność..."
 
-#: authors.html:71
+#: merge/authors.html
 msgid "<b>Are you sure</b> you want to merge these records?"
 msgstr "<b>Czy na pewno</b> chcesz połączyć te dokumenty?"
 
-#: authors.html:79 editions2.html:23
-msgid "Master"
-msgstr "Dokument główny"
+#: merge/authors.html recentchanges/merge/view.html
+msgid "Primary"
+msgstr ""
 
-#: authors.html:80
+#: merge/authors.html
 msgid "Merge"
 msgstr "Połącz"
 
-#: authors.html:110
+#: merge/authors.html
+msgid "birth/death date"
+msgstr ""
+
+#: merge/authors.html
 msgid "Open in a new window"
 msgstr "Otwórz w nowym oknie"
 
-#: authors.html:112 openlibrary/templates/work_search.html:196
+#: merge/authors.html search/work_search_selected_facets.html
 msgid "First published in"
 msgstr "Pierwsza publikacja w"
 
-#: authors.html:117
+#: merge/authors.html
 msgid "Visit this author's page in a new window"
 msgstr "Odwiedź stronę tego autora w nowym oknie"
 
-#: editions.html:7 editions.html:10 editions2.html:7
-msgid "Merge Editions"
-msgstr "Połącz wydania"
+#: merge/authors.html
+#, fuzzy
+msgid "Comment:"
+msgstr "Komentarz"
 
-#: editions.html:17
-msgid "No editions selected."
-msgstr "Brak wybranych wydań."
+#: merge/authors.html
+#, fuzzy
+msgid "Comment..."
+msgstr "Komentarz"
 
-#: editions2.html:10
-#, fuzzy, python-format
-msgid "Merging %(count)d editions of"
-msgstr "Łączenie %d wydań"
+#: merge/authors.html
+#, fuzzy
+msgid "Request Merge"
+msgstr "Wyszukiwanie autora"
 
-#: editions2.html:43
-msgid "Merge Preview"
+#: merge/authors.html
+#, fuzzy
+msgid "Reject Merge"
+msgstr "Wybierz rolę"
+
+#: merge/works.html
+#, fuzzy
+msgid "Merge Works"
+msgstr "Połącz autorów"
+
+#: merge_request_table/merge_request_table.html
+msgid "Failed to submit comment. Please try again in a few moments."
 msgstr ""
 
-#: editions2.html:45
-msgid "Please review the merged values before saving."
+#: merge_request_table/merge_request_table.html
+msgid "(Optional) Why are you closing this request?"
 msgstr ""
 
-#: history.html:8 history.html:12
-msgid "Merge History"
-msgstr "Połącz historię"
+#: merge_request_table/merge_request_table.html
+#, python-format
+msgid "Showing %(username)s's requests only."
+msgstr ""
 
-#: notfound.html:10
+#: merge_request_table/merge_request_table.html
+msgid "Show all requests"
+msgstr ""
+
+#: merge_request_table/merge_request_table.html
+msgid "Showing all requests."
+msgstr ""
+
+#: merge_request_table/merge_request_table.html
+msgid "Show my requests"
+msgstr ""
+
+#: merge_request_table/merge_request_table.html
+#, fuzzy
+msgid "Community Edit Requests"
+msgstr "Najnowsze zmiany wprowadzone przez społeczność"
+
+#: merge_request_table/merge_request_table.html
+msgid "No entries here!"
+msgstr ""
+
+#: merge_request_table/table_header.html
+#, fuzzy
+msgid "Open"
+msgstr "osoba"
+
+#: merge_request_table/table_header.html
+#, fuzzy
+msgid "Closed"
+msgstr "Zamknij"
+
+#: merge_request_table/table_header.html
+#, fuzzy
+msgid "Status ▾"
+msgstr "Status"
+
+#: merge_request_table/table_header.html
+#, fuzzy
+msgid "Request Status"
+msgstr "Status"
+
+#: merge_request_table/table_header.html openlibrary/core/edits.py
+#, fuzzy
+msgid "Merged"
+msgstr "Połącz"
+
+#: merge_request_table/table_header.html openlibrary/core/edits.py
+msgid "Declined"
+msgstr ""
+
+#: merge_request_table/table_header.html
+#, fuzzy
+msgid "Submitter ▾"
+msgstr "Zatwierdź"
+
+#: merge_request_table/table_header.html
+msgid "Filter submitters"
+msgstr ""
+
+#: merge_request_table/table_header.html
+msgid "Submitted by me"
+msgstr ""
+
+#: merge_request_table/table_header.html
+#, fuzzy
+msgid "Reviewer ▾"
+msgstr "Wypożycz teraz"
+
+#: merge_request_table/table_header.html
+#, fuzzy
+msgid "Reviewer"
+msgstr "Wyświetl"
+
+#: merge_request_table/table_header.html
+#, fuzzy
+msgid "Filter reviewers"
+msgstr "filtrów"
+
+#: merge_request_table/table_header.html
+msgid "Assigned to nobody"
+msgstr ""
+
+#: merge_request_table/table_header.html
+#, fuzzy
+msgid "Sort ▾"
+msgstr "Sortuj"
+
+#: merge_request_table/table_header.html
+#, fuzzy
+msgid "Sort"
+msgstr "lub"
+
+#: merge_request_table/table_header.html
+#, fuzzy
+msgid "Newest"
+msgstr "Nowsze"
+
+#: merge_request_table/table_header.html
+#, fuzzy
+msgid "Oldest"
+msgstr "Starsze"
+
+#: merge_request_table/table_row.html
+msgid "An untitled work"
+msgstr ""
+
+#: merge_request_table/table_row.html
+#, fuzzy
+msgid "An unnamed author"
+msgstr "Nieznany autor"
+
+#: merge_request_table/table_row.html
+msgid "Open request"
+msgstr ""
+
+#: merge_request_table/table_row.html
+msgid "Closed request"
+msgstr ""
+
+#: merge_request_table/table_row.html
+#, fuzzy
+msgid "No comments yet."
+msgstr "Brak zmian. Jak na razie."
+
+#: merge_request_table/table_row.html
+#, fuzzy
+msgid "Add a comment..."
+msgstr "Edytowano bez dodania komentarza."
+
+#: merge_request_table/table_row.html
+msgid "Reply"
+msgstr ""
+
+#: merge_request_table/table_row.html
+#, python-format
+msgid "MR #%(id)s opened %(date)s by <a href=\"/people/%(submitter)s\" class=\"commenter\">@%(submitter)s</a>"
+msgstr ""
+
+#: merge_request_table/table_row.html
+#, fuzzy
+msgid "Click to close this Merge Request"
+msgstr "Kliknij, aby usunąć ten aspekt"
+
+#: merge_request_table/table_row.html
+msgid "Review <!-- (merge request) -->"
+msgstr ""
+
+#: merge_request_table/table_row.html
+#, fuzzy
+msgid "comments"
+msgstr "Komentarz"
+
+#: my_books/dropdown_content.html
+#, fuzzy
+msgid "Remove From Shelf"
+msgstr "Usnunąć z listy?"
+
+#: my_books/dropdown_content.html
+msgid "My Reading Lists:"
+msgstr "Moje listy lektur:"
+
+#: my_books/dropdown_content.html
+#, fuzzy
+msgid "Loading"
+msgstr "Lokalizaja"
+
+#: my_books/dropdown_content.html
+#, fuzzy
+msgid "Use this Work"
+msgstr "Usuń tę pozycję"
+
+#: CreateListModal.html my_books/dropdown_content.html
+msgid "Create a new list"
+msgstr "Stwórz nową listę"
+
+#: CreateListModal.html my_books/dropdown_content.html type/permission/edit.html type/usergroup/edit.html
+msgid "Description:"
+msgstr "Opis"
+
+#: CreateListModal.html my_books/dropdown_content.html type/list/edit.html type/series/edit.html
+msgid "Create new list"
+msgstr "Utwórz nową listę"
+
+#: my_books/dropdown_content.html
+msgid "saving..."
+msgstr "zapisywanie..."
+
+#: my_books/dropdown_content.html
+msgid "Removing this book from your shelves will delete your check-ins for this work.  Continue?"
+msgstr ""
+
+#: my_books/primary_action.html
+msgid "Add to List"
+msgstr "Dodaj do listy"
+
+#: my_books/check_ins/check_in_form.html
+#, fuzzy
+msgid "January"
+msgstr "dowolny"
+
+#: my_books/check_ins/check_in_form.html
+#, fuzzy
+msgid "February"
+msgstr "Open Library"
+
+#: my_books/check_ins/check_in_form.html
+#, fuzzy
+msgid "March"
+msgstr "Szukaj"
+
+#: my_books/check_ins/check_in_form.html
+#, fuzzy
+msgid "April"
+msgstr "E-mail"
+
+#: my_books/check_ins/check_in_form.html
+#, fuzzy
+msgid "May"
+msgstr "dowolny"
+
+#: my_books/check_ins/check_in_form.html
+msgid "June"
+msgstr ""
+
+#: my_books/check_ins/check_in_form.html
+msgid "July"
+msgstr ""
+
+#: my_books/check_ins/check_in_form.html
+msgid "August"
+msgstr ""
+
+#: my_books/check_ins/check_in_form.html
+#, fuzzy
+msgid "September"
+msgstr "\"Zapamniętaj mnie"
+
+#: my_books/check_ins/check_in_form.html
+#, fuzzy
+msgid "October"
+msgstr "Zlokalizuj"
+
+#: my_books/check_ins/check_in_form.html
+#, fuzzy
+msgid "November"
+msgstr "Nowi użytkownicy"
+
+#: my_books/check_ins/check_in_form.html
+#, fuzzy
+msgid "December"
+msgstr "\"Zapamniętaj mnie"
+
+#: my_books/check_ins/check_in_form.html
+msgid "Add an optional check-in date. Check-in dates are used to track yearly reading goals."
+msgstr ""
+
+#: my_books/check_ins/check_in_form.html
+#, fuzzy
+msgid "End Date:"
+msgstr "Wyślij"
+
+#: my_books/check_ins/check_in_form.html
+msgid "Year:"
+msgstr ""
+
+#: my_books/check_ins/check_in_form.html
+#, fuzzy
+msgid "Year"
+msgstr "Szukaj"
+
+#: my_books/check_ins/check_in_form.html
+msgid "Month:"
+msgstr ""
+
+#: my_books/check_ins/check_in_form.html
+msgid "Month"
+msgstr ""
+
+#: my_books/check_ins/check_in_form.html
+msgid "Day:"
+msgstr ""
+
+#: my_books/check_ins/check_in_form.html
+#, fuzzy
+msgid "Day"
+msgstr "dowolny"
+
+#: my_books/check_ins/check_in_form.html
+#, fuzzy
+msgid "Delete Event"
+msgstr "Usuń listę"
+
+#: my_books/check_ins/check_in_prompt.html
+msgid "Failed to delete check-in. Please try again in a few moments."
+msgstr ""
+
+#: my_books/check_ins/check_in_prompt.html
+msgid "Failed to submit check-in. Please try again in a few moments."
+msgstr ""
+
+#: my_books/check_ins/check_in_prompt.html
+#, python-format
+msgid "Read <time class=\"check-in-date\">%(date)s</time>"
+msgstr ""
+
+#: my_books/check_ins/check_in_prompt.html
+#, fuzzy
+msgid "When did you finish this book?"
+msgstr "Jak opisał\\(a\\)byś tę książkę?"
+
+#: my_books/check_ins/check_in_prompt.html
+#, fuzzy
+msgid "Other"
+msgstr "Dodaj kolejną"
+
+#: my_books/check_ins/check_in_prompt.html
+msgid "Check-In"
+msgstr ""
+
+#: observations/review_component.html
+#, fuzzy
+msgid "Community Reviews"
+msgstr "Najnowsze zmiany wprowadzone przez społeczność"
+
+#: observations/review_component.html
+msgid "No community reviews have been submitted for this work."
+msgstr ""
+
+#: observations/review_component.html
+msgid "+ Add your community review"
+msgstr ""
+
+#: observations/review_component.html
+msgid "+ Log in to add your community review"
+msgstr ""
+
+#: publishers/index.html publishers/notfound.html
 msgid "Publishers"
 msgstr "Wydawnictwa"
 
-#: notfound.html:13
-#, fuzzy, python-format
-msgid "We couldn't find any books published by %(publisher)s."
-msgstr "Nie mogliśmy znaleźć żadnych książek opublikowanych przez %s"
+#: publishers/index.html publishers/view.html
+#, fuzzy
+msgid "Publisher Search"
+msgstr "Wyszukiwanie wydawcy"
 
-#: notfound.html:15
+#: publishers/index.html publishers/view.html
+#, fuzzy
+msgid "Try a keyword."
+msgstr "Słowa kluczowe"
+
+#: publishers/notfound.html
+#, python-format
+msgid "We couldn't find any books published by %(publisher)s."
+msgstr ""
+
+#: publishers/notfound.html subjects/notfound.html
 msgid "Try something else?"
 msgstr "Wyszukać inne?"
 
-#: view.html:19
-#, fuzzy, python-format
-msgid "1 ebook"
-msgid_plural "%(count)s ebooks"
-msgstr[0] "1 książka"
-msgstr[1] "%(count)s książek"
+#: publishers/view.html
+#, python-format
+msgid "Publisher: %(name)s"
+msgstr ""
 
-#: openlibrary/templates/subjects.html:44 view.html:32
+#: openlibrary/plugins/worksearch/code.py publishers/view.html search/advancedsearch.html type/edition/view.html type/work/view.html
+msgid "Publisher"
+msgstr "Wydawca"
+
+#: SearchResultsWork.html publishers/view.html
+#, python-format
+msgid "%(count)s ebook"
+msgid_plural "%(count)s ebooks"
+msgstr[0] ""
+msgstr[1] ""
+
+#: publishers/view.html
+#, fuzzy
+msgid "0 ebooks"
+msgstr "E-booki"
+
+#: PublishingHistory.html publishers/view.html
 msgid "Publishing History"
 msgstr "Historia publikacji"
 
-#: view.html:33
-msgid ""
-"This is a chart to show the when this publisher published books. Along "
-"the X axis is time, and on the y axis is the count of editions published."
-" <a href=\"#subjectRelated\">Click here to skip the chart</a>."
-msgstr ""
-"To wykres pokazujący, kiedy ten wydawca opublikował książki. Oś X "
-"wskazuje na czas, oś Y wskazuje liczbę opublikowanych wydań. <a "
-"href=\"#subjectRelated\"> Kliknij tutaj, aby pominąć wykres</a>."
+#: publishers/view.html
+msgid "This is a chart to show the when this publisher published books. Along the X axis is time, and on the y axis is the count of editions published. <a href=\"#subjectRelated\">Click here to skip the chart</a>."
+msgstr "To wykres pokazujący, kiedy ten wydawca opublikował książki. Oś X wskazuje na czas, oś Y wskazuje liczbę opublikowanych wydań. <a href=\"#subjectRelated\"> Kliknij tutaj, aby pominąć wykres</a>."
 
-#: openlibrary/templates/subjects.html:47 view.html:34
+#: PublishingHistory.html publishers/view.html
 msgid "Reset chart"
 msgstr "Zresetuj wykres"
 
-#: openlibrary/templates/subjects.html:47 view.html:34
+#: PublishingHistory.html publishers/view.html
 msgid "or continue zooming in."
 msgstr "lub kontynuuj powiększanie."
 
-#: view.html:35
-msgid ""
-"This graph charts editions from this publisher over time. Click to view a"
-" single year, or drag across a range."
-msgstr ""
-"Ten diagram przedstawia wykresy publikacji tego wydawcy w miarę upływu "
-"czasu. Kliknij, aby wyświetlić pojedynczy rok lub przeciągnij przez cały "
-"zakres."
+#: publishers/view.html
+msgid "This graph charts editions from this publisher over time. Click to view a single year, or drag across a range."
+msgstr "Ten diagram przedstawia wykresy publikacji tego wydawcy w miarę upływu czasu. Kliknij, aby wyświetlić pojedynczy rok lub przeciągnij przez cały zakres."
 
-#: openlibrary/templates/subjects.html:54 view.html:90
+#: PublishingHistory.html publishers/view.html
 msgid "Editions Published"
 msgstr "Wydania opublikowane"
 
-#: openlibrary/templates/subjects.html:56 view.html:92
-msgid "You need to have JavaScript turned on to see the nifty chart!"
-msgstr "Musisz mieć włączony JavaScript, aby zobaczyć fajny wykres!"
-
-#: openlibrary/templates/subjects.html:58 view.html:94
+#: PublishingHistory.html publishers/view.html
 msgid "Year of Publication"
 msgstr "Rok wydania"
 
-#: view.html:100
+#: publishers/view.html
 msgid "Common Subjects"
 msgstr "Wspólne tematy"
 
-#: openlibrary/templates/subjects.html:78 view.html:112
+#: publishers/view.html
+#, python-format
+msgid "Search for books published by %(publisher)s"
+msgstr ""
+
+#: RelatedSubjects.html publishers/view.html
 msgid "None found."
 msgstr "Nie znaleziono."
 
-#: openlibrary/templates/subjects.html:93 view.html:129
+#: ProlificAuthors.html publishers/view.html
 msgid "See more books by, and learn about, this author"
 msgstr "Zobacz więcej książek tego autora i dowiedz się więcej"
 
-#: view.html:136
+#: publishers/view.html
 msgid "published most by this publisher"
 msgstr "Najczęściej publikowana przez tego wydawcę"
 
-#: openlibrary/templates/subjects.html:126 view.html:159
+#: publishers/view.html
 msgid "Get more information about this publisher"
 msgstr "Uzyskaj więcej informacji o tym wydawcy"
 
-#: header.html:31 index.html:7 index.html:13
+#: reading_goals/reading_goal_form.html
+msgid "How many books would you like to read this year?"
+msgstr ""
+
+#: reading_goals/reading_goal_form.html
+msgid "Enter \"0\" to unset your reading goal. Your check-ins will be preserved."
+msgstr ""
+
+#: reading_goals/reading_goal_progress.html
+#, python-format
+msgid "<span class=\"reading-goal-progress__books-read\">%(books_read)d</span>/<span class=\"reading-goal-progress__goal\">%(goal)d</span> Books"
+msgstr ""
+
+#: reading_goals/reading_goal_progress.html
+#, python-format
+msgid "Edit %(year)d Reading Goal"
+msgstr ""
+
+#: recentchanges/header.html
+#, fuzzy
+msgid "By"
+msgstr "autorstwa"
+
+#: recentchanges/header.html
+msgid "Undo All"
+msgstr ""
+
+#: recentchanges/header.html recentchanges/index.html
 msgid "Recent Changes"
 msgstr "Ostatnie zmiany"
 
-#: index.html:34
+#: recentchanges/index.html
+#, fuzzy
+msgid "Books Edited"
+msgstr "Książki, które kochamy"
+
+#: recentchanges/index.html
 #, fuzzy
 msgid "Author Merges"
 msgstr "Wyszukiwanie autora"
 
-#: index.html:35
+#: recentchanges/index.html
+#, fuzzy
+msgid "Work Merges"
+msgstr "Wyszukiwanie autora"
+
+#: recentchanges/index.html
 msgid "Books Added"
 msgstr ""
 
-#: index.html:36
-msgid "Covers Added"
-msgstr ""
-
-#: index.html:57
+#: RecentChanges.html recentchanges/index.html
 msgid "By Humans"
 msgstr ""
 
-#: index.html:58
+#: RecentChanges.html recentchanges/index.html
 msgid "By Bots"
 msgstr ""
 
-#: index.html:59 openlibrary/templates/work_search.html:142
+#: RecentChanges.html recentchanges/index.html
 msgid "Everything"
 msgstr "Wszystko"
 
-#: openlibrary/templates/history.html:30 render.html:30 updated_records.html:28
-msgid "When"
-msgstr "Kiedy"
+#: recentchanges/render.html
+#, fuzzy
+msgid "Admin view"
+msgstr "strona administratora"
 
-#: render.html:31 updated_records.html:29
-msgid "What"
-msgstr "Co"
-
-#: openlibrary/templates/history.html:31 render.html:32
-msgid "Who"
-msgstr "Kto"
-
-#: openlibrary/templates/history.html:32 render.html:33 updated_records.html:30
-msgid "Comment"
-msgstr "Komentarz"
-
-#: render.html:61
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html recentchanges/render.html
 msgid "Older"
 msgstr "Starsze"
 
-#: render.html:64
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html recentchanges/render.html
 msgid "Newer"
 msgstr "Nowsze"
 
-#: around_the_library.html:45 default/message.html:29 edit-book/message.html:29
+#: recentchanges/updated_records.html
+msgid "Review what's changed in from the previous revision"
+msgstr ""
+
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html recentchanges/default/path.html recentchanges/updated_records.html
+#, fuzzy
+msgid "diff"
+msgstr "Różnica"
+
+#: recentchanges/add-book/path.html recentchanges/default/path.html recentchanges/edit-book/path.html recentchanges/merge/path.html
+#, fuzzy
+msgid "expand"
+msgstr "Przeczytaj"
+
+#: recentchanges/default/message.html recentchanges/edit-book/message.html
 msgid "opened a new Open Library account!"
 msgstr "utwórz nowe konto na Open Library"
 
-#: merge-authors/message.html:13
+#: RecentChanges.html RecentChangesUsers.html recentchanges/default/path.html
+msgid "Review what's changed from the previous revision"
+msgstr ""
+
+#: recentchanges/default/view.html recentchanges/merge/view.html recentchanges/undo/view.html
+#, fuzzy
+msgid "Updated Records"
+msgstr "Usuń wpis"
+
+#: recentchanges/merge/comment.html
+#, python-format
+msgid "Merged duplicate %(record_type)s records."
+msgstr ""
+
+#: recentchanges/merge/comment.html
+#, python-format
+msgid "See <a href=\"%s\">details</a>."
+msgstr ""
+
+#: recentchanges/merge/comment.html
+#, python-format
+msgid "Merged %(count)d duplicate %(type)s record into this primary."
+msgid_plural "Merged %(count)d duplicate %(type)s records into this primary."
+msgstr[0] ""
+msgstr[1] ""
+
+#: recentchanges/merge/comment.html
+#, fuzzy
+msgid "Marked as duplicate."
+msgstr "Duplikaty"
+
+#: recentchanges/merge/comment.html
+#, python-format
+msgid "Merged %(page_type)s into primary %(record_type)s record."
+msgstr ""
+
+#: recentchanges/merge/message.html
 #, python-format
 msgid "%(who)s merged one duplicate of %(master)s"
 msgid_plural "%(who)s merged %(count)d duplicates of %(master)s"
 msgstr[0] "%(who)s połączył jeden duplikat %(master)s"
 msgstr[1] "%(who)s połączył %(count)d duplikaty %(master)s"
 
-#: merge-authors/message.html:20
+#: recentchanges/merge/message.html
 #, python-format
 msgid "one duplicate of %(master)s was merged anonymously"
 msgid_plural "%(count)d duplicates of %(master)s were merged anonymously"
 msgstr[0] "jeden duplikat %(master)s został połączony anonimowo"
 msgstr[1] "%(count)d duplikatów %(master)s zostało połączone anonimowo"
 
-#: advancedsearch.html:11
-msgid "Keyword"
-msgstr "Słowa kluczowe"
+#: recentchanges/merge/view.html
+msgid "This merge has been undone."
+msgstr ""
 
-#: advancedsearch.html:25
+#: recentchanges/merge/view.html
+msgid "Details here"
+msgstr ""
+
+#: recentchanges/merge/view.html type/author/view.html
+msgid "Duplicates"
+msgstr "Duplikaty"
+
+#: recentchanges/merge/view.html
+#, python-format
+msgid "%(count)d record modified."
+msgid_plural "%(count)d records modified."
+msgstr[0] ""
+msgstr[1] ""
+
+#: recentchanges/undo/view.html
+#, python-format
+msgid "Undo of <a href=\"$parent.url()\">%(kind)s</a>."
+msgstr ""
+
+#: recentchanges/undo/view.html
+#, python-format
+msgid "%(count)d records modified."
+msgstr ""
+
+#: search/advancedsearch.html
 msgid "ISBN"
 msgstr "ISBN"
 
-#: advancedsearch.html:47
-msgid "Full Text Search"
+#: search/advancedsearch.html
+msgid "Subject"
+msgstr "Temat"
+
+#: search/advancedsearch.html
+msgid "Place"
+msgstr "Miejsce"
+
+#: search/advancedsearch.html
+msgid "Person"
+msgstr "Osoba"
+
+#: search/advancedsearch.html
+#, fuzzy
+msgid "How to search?"
+msgstr "Wyszukiwanie autora"
+
+#: search/advancedsearch.html
+#, fuzzy
+msgid "Full Text Search?"
 msgstr "Wyszukiwanie pełnotekstowe"
 
-#: authors.html:28
+#: search/authors.html
+#, python-format
+msgid "Search Open Library for \"%(query)s\""
+msgstr ""
+
+#: search/authors.html
+#, fuzzy
+msgid "Search Authors"
+msgstr "Połącz autorów"
+
+#: search/authors.html
 msgid "Is the same author listed twice?"
 msgstr "Czy ten sam autor jest wymieniony dwa razy?"
 
-#: authors.html:29
+#: search/authors.html
 msgid "Merge authors"
 msgstr "Połącz autorów"
 
-#: authors.html:32
-msgid "Author Search"
-msgstr "Wyszukiwanie autora"
+#: search/authors.html
+msgid "No <strong>authors</strong> directly matched your search"
+msgstr ""
 
-#: authors.html:37 openlibrary/templates/work_search.html:103
-#: openlibrary/templates/work_search.html:229 subjects.html:27
+#: openlibrary/plugins/worksearch/code.py search/availability_i18n.html
+#, fuzzy
+msgid "All books"
+msgstr "Książki"
+
+#: openlibrary/plugins/worksearch/code.py search/availability_i18n.html
+msgid "Free to read now"
+msgstr ""
+
+#: openlibrary/plugins/worksearch/code.py search/availability_i18n.html
+#, fuzzy
+msgid "Borrow online"
+msgstr "Wypożycz teraz"
+
+#: search/inside.html
 #, python-format
-msgid "1 hit"
-msgid_plural "%(count)s hits"
-msgstr[0] "1 wynik"
-msgstr[1] "%(count)s wyników"
+msgid "Search Open Library for %s"
+msgstr ""
 
-#: authors.html:39
-msgid "No hits"
-msgstr "Brak wyników"
-
-#: authors.html:76
-#, python-format
-msgid "about %(subjects)s"
-msgstr "o %(subjects)s"
-
-#: authors.html:77
-#, python-format
-msgid "including <i>%(topwork)s</i>"
-msgstr "włączając <i>%(topwork)s</i>"
-
-#: inside.html:10
+#: BookSearchInside.html FulltextSearchSuggestion.html SearchNavigation.html search/inside.html search/snippets.html
 msgid "Search Inside"
 msgstr "Szukaj w"
 
-#: inside.html:34
-#, python-format
-msgid "No hits for: %(query)s"
-msgstr "Brak wyników dla: %(query)s"
+#: search/inside.html
+msgid "No <strong>Search Inside</strong> text matched your search"
+msgstr ""
 
-#: inside.html:37
+#: search/inside.html
 #, python-format
-msgid "About 1 result found in %(seconds)s"
-msgid_plural "About %(count)s results found in %(seconds)s"
-msgstr[0] "Znaleziono około 1 wynik w %(seconds)s"
-msgstr[1] "Znaleziono około %(count)s wyników w %(seconds)s"
+msgid "About %(count)s result found"
+msgid_plural "About %(count)s results found"
+msgstr[0] ""
+msgstr[1] ""
 
-#: publishers.html:9
+#: search/inside.html
+#, python-format
+msgid "in %(seconds)s second"
+msgid_plural "in %(seconds)s seconds"
+msgstr[0] ""
+msgstr[1] ""
+
+#: EditionNavBar.html search/layout_options.html site/stats.html
+#, fuzzy
+msgid "Details"
+msgstr "E-mail"
+
+#: search/layout_options.html
+msgid "Grid"
+msgstr ""
+
+#: search/layout_options.html
+#, fuzzy
+msgid "View as: "
+msgstr "Wyświetl"
+
+#: search/lists.html
+msgid "Search results for Lists"
+msgstr ""
+
+#: search/lists.html
+#, fuzzy
+msgid "Search Lists"
+msgstr "Szukaj w"
+
+#: search/lists.html
+msgid "No <strong>lists</strong> directly matched your search"
+msgstr ""
+
+#: search/publishers.html
 msgid "Publishers Search"
 msgstr "Wyszukiwanie wydawcy"
 
-#: subjects.html:19
-msgid "Subject Search"
-msgstr "Wyszukiwanie tematu"
-
-#: subjects.html:74
-msgid "time"
-msgstr "czas"
-
-#: subjects.html:76
-msgid "subject"
-msgstr "temat"
-
-#: subjects.html:78
-msgid "place"
-msgstr "miejsce"
-
-#: subjects.html:80
-msgid "org"
-msgstr "organizacja"
-
-#: subjects.html:82
-msgid "event"
-msgstr "wydarzenie"
-
-#: subjects.html:84
-msgid "person"
-msgstr "osoba"
-
-#: subjects.html:86
-msgid "work"
-msgstr "praca"
-
-#: around_the_library.html:52
-msgid "View all recent changes"
-msgstr "Zobacz wszystkie ostatnie zmiany"
-
-#: body.html:31
-msgid "<strong>Together</strong>, let's build an Open Library for the World."
-msgstr "<strong>Razem</strong>, zbudujmy Open Library dla całego świata."
-
-#: neck.html:15
-msgid "Open Library"
+#: search/search_modal_i18n.html
+#, fuzzy
+msgid "Search Open Library"
 msgstr "Open Library"
 
-#: openlibrary/templates/account.html:16
-msgid "Change Password"
-msgstr "Zmień hasło"
-
-#: openlibrary/templates/account.html:17
-msgid "Update Email Address"
-msgstr "Zaktualizuj adres e-mail"
-
-#: openlibrary/templates/account.html:18
-msgid "Your Notifications"
-msgstr "Twoje powiadomienia"
-
-#: openlibrary/templates/account.html:19
+#: search/search_modal_i18n.html
 #, fuzzy
-msgid "Internet Archive Announcements"
-msgstr "Internet Archive"
+msgid "Search books and authors…"
+msgstr "Wyszukaj w tekscie e-booka"
 
-#: openlibrary/templates/account.html:20
-msgid "Your Privacy Settings"
-msgstr "Twoje ustawienia prywatności"
+#: search/search_modal_i18n.html
+#, fuzzy
+msgid "Close search"
+msgstr "Wyszukiwanie tematu"
 
-#: openlibrary/templates/account.html:21
-msgid "View"
-msgstr "Wyświetl"
+#: search/search_modal_i18n.html
+#, fuzzy
+msgid "Clear search"
+msgstr "Wyszukiwanie autora"
 
-#: openlibrary/templates/account.html:21
-msgid "or"
-msgstr "lub"
+#: search/search_modal_i18n.html
+#, fuzzy
+msgid "See all results"
+msgstr "Zobacz wszystkie"
 
-#: openlibrary/macros/databarHistory.html:17
-#: openlibrary/macros/databarView.html:17 openlibrary/templates/account.html:21
-msgid "Edit"
-msgstr "Edytuj"
-
-#: openlibrary/templates/account.html:21
-msgid "Your Profile Page"
-msgstr "Twój profil"
-
-#: openlibrary/templates/account.html:22
-msgid "View or Edit your Reading Log"
-msgstr "Wyświetl lub edytuj Dziennik Lektur"
-
-#: openlibrary/templates/account.html:23
-msgid "View or Edit your Lists"
-msgstr "Wyświetl lub edytuj Twoje Listy"
-
-#: openlibrary/templates/account.html:25
-msgid "Please contact us if you need help with anything else."
-msgstr "Skontaktuj się z nami, jeśli potrzebujesz pomocy w innej sprawie."
-
-#: openlibrary/templates/diff.html:7
+#: search/search_modal_i18n.html
 #, python-format
-msgid "Diff on %s"
+msgid "See all %s result"
+msgstr ""
+
+#: search/search_modal_i18n.html
+#, python-format
+msgid "See all %s results"
+msgstr ""
+
+#: search/search_modal_i18n.html
+#, fuzzy
+msgid "Clear all"
+msgstr "Zobacz wszystkie"
+
+#: search/search_modal_i18n.html
+#, fuzzy
+msgid "Search filters"
+msgstr "Szukaj w"
+
+#: search/search_modal_i18n.html type/work/editions_datatable.html
+msgid "Availability"
+msgstr ""
+
+#: search/search_modal_i18n.html
+#, fuzzy
+msgid "Searching…"
+msgstr "Szukaj"
+
+#: search/search_modal_i18n.html
+#, fuzzy
+msgid "No results found"
+msgstr "Brak wyników."
+
+#: search/search_modal_i18n.html
+#, python-format
+msgid "Showing %s of %s results"
+msgstr ""
+
+#: search/search_modal_i18n.html
+#, fuzzy
+msgid "Top results"
+msgstr "Brak wyników."
+
+#: search/search_modal_i18n.html
+#, fuzzy
+msgid "Untitled"
+msgstr "Tytuł"
+
+#: search/search_modal_i18n.html
+#, fuzzy
+msgid "Readable"
+msgstr "Przeczytaj"
+
+#: search/search_modal_i18n.html
+#, fuzzy, python-format
+msgid "In %s"
 msgstr "Różnica na %s"
 
-#: openlibrary/templates/diff.html:26
-msgid "Added"
-msgstr "Dodano"
+#: search/search_modal_i18n.html
+#, fuzzy
+msgid "Recent searches"
+msgstr "Ostatnie zmiany"
 
-#: openlibrary/templates/diff.html:27
-msgid "Modified"
-msgstr "Zmieniono"
-
-#: openlibrary/templates/diff.html:28
-msgid "Removed"
-msgstr "Usunięto"
-
-#: openlibrary/templates/diff.html:29
-msgid "Not changed"
-msgstr "Nie zmnieniono"
-
-#: openlibrary/templates/diff.html:39
+#: search/search_modal_i18n.html
 #, python-format
-msgid "Revision %d"
-msgstr "Korekta %d"
+msgid "Remove \"%s\" from recent searches"
+msgstr ""
 
-#: openlibrary/templates/diff.html:44
-msgid "by Anonymous"
-msgstr "Anoninowo"
-
-#: openlibrary/templates/diff.html:110
-msgid "Differences"
-msgstr "Różnice"
-
-#: openlibrary/templates/diff.html:168
-msgid "Both the revisions are identical."
-msgstr "Obydwie korekty są identyczne."
-
-#: openlibrary/templates/history.html:21
-msgid "History of edits to"
-msgstr "Historia zmian"
-
-#: openlibrary/templates/history.html:29
-msgid "Revision"
-msgstr "Korekta"
-
-#: openlibrary/templates/history.html:33
-msgid "Diff"
-msgstr "Różnica"
-
-#: openlibrary/templates/history.html:40 openlibrary/templates/history.html:63
-msgid "Compare"
-msgstr "Porównaj"
-
-#: openlibrary/templates/history.html:40 openlibrary/templates/history.html:63
-msgid "See Diff"
-msgstr "Zobacz różnice"
-
-#: openlibrary/templates/history.html:88
-msgid "Back"
-msgstr "Powrót"
-
-#: openlibrary/templates/internalerror.html:14
-msgid "Sorry. There seems to be a problem with what you were just looking at."
-msgstr "Przepraszamy. Wygląda na to, że jest problem z wyświetleniem treści."
-
-#: openlibrary/templates/internalerror.html:15
+#: search/snippets.html
 #, python-format
-msgid ""
-"We've noted the error %s and will look into it as soon as possible. Head "
-"for <a href=\"/\">home</a>?"
-msgstr ""
-"Zauważyliśmy błąd %s i sprawdzimy go jak najszybciej. Przejść do <a "
-"href=\"/\">home</a>?"
-
-#: openlibrary/templates/login.html:15
-msgid ""
-"Please enter your <a href=\"https://archive.org\">Internet Archive</a> "
-"email and password to access your Open Library account."
-msgstr ""
-"Wprowadź swój <a href=\"https://archive.org\">Internet Archive</a> e-mail"
-" i hasło umożliwiające dostęp do konta Open Library."
-
-#: openlibrary/templates/login.html:29
-msgid "Email"
-msgstr "E-mail"
-
-#: openlibrary/templates/login.html:31
-msgid "Forgot your Internet Archive email?"
-msgstr "Nie pamiętasz e-maila z Internet Archive?"
-
-#: openlibrary/templates/login.html:51
-msgid "Remember me"
-msgstr "\"Zapamniętaj mnie"
-
-#: openlibrary/templates/login.html:68
-msgid "Not a member of Open Library? <a href=\"/account/create\">Sign up now</a>."
-msgstr ""
-"Nie masz jeszcze konta na Open Library? <a "
-"href=\"/account/create\">Utwórz konto</a>."
-
-#: openlibrary/templates/notfound.html:7
-#, fuzzy, python-format
-msgid "%(path)s is not found"
-msgstr "Nie znaleziono %s"
-
-#: openlibrary/templates/notfound.html:14
-msgid "404 - Page Not Found"
-msgstr "404 - Strona nie istnieje"
-
-#: openlibrary/templates/notfound.html:18
-#, fuzzy, python-format
-msgid "%(path)s does not exist."
-msgstr "%s nie istnieje."
-
-#: openlibrary/templates/notfound.html:22
-msgid "Create it?"
-msgstr "Utworzyć?"
-
-#: openlibrary/templates/notfound.html:26
-msgid "Looking for a template/macro?"
+msgid "On leaf number %(page_num)d:"
 msgstr ""
 
-#: openlibrary/templates/permission_denied.html:10
-msgid "Permission denied."
-msgstr "Odmowa zezwolenia."
-
-#: openlibrary/templates/permission_denied.html:30
-#, python-format
-msgid "You may <a href=\"%s\">log in</a> if you have the required permissions."
-msgstr "Możesz się <a href=\"%s\">zalogować</a> jeśli masz wymagane uprawnienia."
-
-#: openlibrary/templates/subjects.html:22
-#, python-format
-msgid "Search for books with subject %(name)s."
-msgstr "Szukaj książek o tematyce %(name)s."
-
-#: openlibrary/templates/subjects.html:46
-msgid ""
-"This is a chart to show the publishing history of editions of works about"
-" this subject. Along the X axis is time, and on the y axis is the count "
-"of editions published. <a href=\"#subjectRelated\">Click here to skip the"
-" chart</a>."
-msgstr ""
-"To wykres pokazujący historię publikacji dzieł na ten temat. Oś X "
-"wskazuje na czas, oś Y wskazuje liczbę publikacji. <a "
-"href=\"#subjectRelated\"> Kliknij tutaj, aby pominąć wykres</a>."
-
-#: openlibrary/templates/subjects.html:48
-msgid "This graph charts editions published on this subject."
-msgstr "Ten diagram przedstawia wydania publikacji na ten temat."
-
-#: openlibrary/templates/subjects.html:64
-msgid "Related..."
-msgstr "Powiązane..."
-
-#: openlibrary/templates/subjects.html:99
-msgid "Prolific Authors"
-msgstr "Autorzy"
-
-#: openlibrary/templates/subjects.html:100
-msgid "who have written the most books on this subject"
-msgstr "którzy napisali najwięcej książek na ten temat"
-
-#: openlibrary/templates/widget.html:33
-#, fuzzy, python-format
-msgid "Read \"%(title)s\""
-msgstr "Edytuj %(title)s"
-
-#: openlibrary/templates/widget.html:38
-#, fuzzy, python-format
-msgid "Borrow \"%(title)s\""
-msgstr "Edytuj %(title)s"
-
-#: openlibrary/templates/widget.html:44
-#, python-format
-msgid "Join waitlist for &quot;%(title)s&quot;"
-msgstr ""
-
-#: openlibrary/macros/AvailabilityButton.html:60
-#: openlibrary/templates/widget.html:44
-msgid "Join Waitlist"
-msgstr ""
-
-#: openlibrary/templates/widget.html:48
-#, python-format
-msgid "Learn more about &quot;%(title)s&quot; at OpenLibrary"
-msgstr ""
-
-#: openlibrary/macros/LoanStatus.html:92 openlibrary/templates/widget.html:48
-msgid "Learn More"
-msgstr ""
-
-#: openlibrary/templates/widget.html:50
-msgid "on "
-msgstr ""
-
-#: openlibrary/templates/work_search.html:108
-#: openlibrary/templates/work_search.html:110
-#: openlibrary/templates/work_search.html:112
-#: openlibrary/templates/work_search.html:114
+#: search/sort_options.html
 msgid "Relevance"
 msgstr "Związek z tematem"
 
-#: openlibrary/templates/work_search.html:121
-msgid "eBook?"
-msgstr "E-book?"
-
-#: openlibrary/templates/work_search.html:127
-msgid "First published"
-msgstr "Pierwsza publikacja"
-
-#: openlibrary/templates/work_search.html:130
-msgid "Classic eBooks"
-msgstr "Kasyczne e-booki"
-
-#: openlibrary/templates/work_search.html:137
+#: search/sort_options.html
 #, fuzzy
-msgid "Keywords"
-msgstr "Słowa kluczowe"
+msgid "Work Count"
+msgstr "Moje konto"
 
-#: openlibrary/templates/work_search.html:144
-msgid "Ebooks"
-msgstr "E-booki"
+#: search/sort_options.html
+#, fuzzy
+msgid "Random"
+msgstr "Losowa książka"
 
-#: openlibrary/templates/work_search.html:146
-msgid "Print Disabled"
-msgstr "Dla osób z trudnościami w czytaniu druku"
-
-#: openlibrary/templates/work_search.html:162
-msgid "eBook"
-msgstr "E-book"
-
-#: openlibrary/templates/work_search.html:165
-msgid "Classic eBook"
-msgstr "Klasyczny e-book"
-
-#: openlibrary/templates/work_search.html:184
-msgid "Explore Classic eBooks"
-msgstr "Przeglądaj klasyczne e-booki"
-
-#: openlibrary/templates/work_search.html:184
-msgid "Only Classic eBooks"
-msgstr "Tylko klasyczne e-booki"
-
-#: openlibrary/templates/work_search.html:188
-#: openlibrary/templates/work_search.html:190
-#: openlibrary/templates/work_search.html:192
-#: openlibrary/templates/work_search.html:194
-#, fuzzy, python-format
-msgid "Explore books about %(subject)s"
-msgstr "o %(subjects)s"
-
-#: openlibrary/templates/work_search.html:198
-msgid "Written in"
-msgstr "Napisane w"
-
-#: openlibrary/templates/work_search.html:200
-msgid "Published by"
-msgstr "Wydane przez"
-
-#: openlibrary/templates/work_search.html:203
-msgid "Click to remove this facet"
-msgstr "Kliknij, aby usunąć ten aspekt"
-
-#: openlibrary/templates/work_search.html:205
-#, python-format
-msgid "%(title)s - search"
+#: search/sort_options.html
+msgid "Name (beta: Librarian only)"
 msgstr ""
 
-#: openlibrary/templates/work_search.html:217
-msgid "No results found."
-msgstr "Brak wyników."
+#: search/sort_options.html
+msgid "Birth Date (oldest) (beta: Librarian only)"
+msgstr ""
 
-#: openlibrary/templates/work_search.html:220
-#, fuzzy, python-format
-msgid "Showing books with similar text to: <strong>%(query)s</strong>"
-msgstr "Książki zawierające tekst podobny do: <strong>%(query)s</strong>"
+#: search/sort_options.html
+msgid "Birth Date (youngest) (beta: Librarian only)"
+msgstr ""
 
-#: openlibrary/templates/work_search.html:258
-msgid "Zoom In"
-msgstr "Powiększ"
+#: search/sort_options.html
+#, fuzzy
+msgid "List Order"
+msgstr "Słuchaj"
 
-#: openlibrary/templates/work_search.html:259
-msgid "Focus your results using these"
-msgstr "Zawęż swoje wyniki za pomocą tych"
+#: search/sort_options.html
+#, fuzzy
+msgid "Last Modified"
+msgstr "Zmieniono"
 
-#: openlibrary/templates/work_search.html:259
-msgid "filters"
-msgstr "filtrów"
+#: search/sort_options.html
+#, fuzzy
+msgid "Language Name"
+msgstr "Język"
 
-#: openlibrary/templates/work_search.html:271
+#: search/sort_options.html
+#, fuzzy
+msgid "Ebook Edition Count"
+msgstr "Uwagi do wydania"
+
+#: search/sort_options.html
+#, fuzzy
+msgid "Date Added (newest)"
+msgstr "Stwórz nową listę"
+
+#: search/sort_options.html
+msgid "Date Added (oldest)"
+msgstr ""
+
+#: search/sort_options.html
+msgid "Most Editions"
+msgstr "Większość wydań"
+
+#: search/sort_options.html
+msgid "First Published"
+msgstr "Data pierwszej publikacji"
+
+#: search/sort_options.html
+msgid "Most Recent"
+msgstr "Najnowsze"
+
+#: search/sort_options.html
+#, fuzzy
+msgid "Top Rated"
+msgstr "Utworzone Listy"
+
+#: search/sort_options.html
+#, fuzzy
+msgid "Any"
+msgstr "dowolny"
+
+#: search/sort_options.html
+msgid "Work Title (beta: Librarian only)"
+msgstr ""
+
+#: search/sort_options.html
+msgid "Sorting by"
+msgstr "Sortuj"
+
+#: search/sort_options.html
+msgid "Shuffle"
+msgstr ""
+
+#: search/subjects.html
+#, fuzzy
+msgid "Search Subjects"
+msgstr "Zobacz książki"
+
+#: search/subjects.html
+msgid "No <strong>subjects</strong> directly matched your search"
+msgstr ""
+
+#: search/subjects.html
+msgid "time"
+msgstr "czas"
+
+#: search/subjects.html
+msgid "subject"
+msgstr "temat"
+
+#: search/subjects.html
+msgid "place"
+msgstr "miejsce"
+
+#: search/subjects.html
+msgid "org"
+msgstr "organizacja"
+
+#: search/subjects.html
+msgid "event"
+msgstr "wydarzenie"
+
+#: search/subjects.html
+msgid "person"
+msgstr "osoba"
+
+#: search/subjects.html
+msgid "work"
+msgstr "praca"
+
+#: search/work_search_facets.html
 msgid "Merge duplicate authors from this search"
 msgstr ""
 
-#: openlibrary/templates/work_search.html:283
+#: search/work_search_facets.html type/work/editions.html
 #, fuzzy
-msgid "yes"
-msgstr "Tak"
+msgid "Merge duplicates"
+msgstr "Duplikaty"
 
-#: openlibrary/templates/work_search.html:285
-msgid "no"
-msgstr ""
+#: search/work_search_facets.html
+#, fuzzy
+msgid "Less"
+msgstr "mniej"
 
-#: openlibrary/templates/work_search.html:286
-msgid "Filter results for ebook availability"
-msgstr ""
-
-#: openlibrary/templates/work_search.html:288
+#: search/work_search_facets.html
 #, python-format
 msgid "Filter results for %(facet)s"
 msgstr ""
 
-#: openlibrary/templates/work_search.html:291
-msgid "more"
-msgstr "więcej"
+#: search/work_search_facets.html
+msgid "Filter results for ebook availability"
+msgstr ""
 
-#: openlibrary/templates/work_search.html:291
-msgid "less"
-msgstr "mniej"
-
-#: openlibrary/macros/AvailabilityButton.html:50
+#: search/work_search_facets.html
 #, fuzzy
-msgid "You're <strong>next</strong> in line"
-msgstr "Jesteś <strong> następny </strong> na liście oczekujących"
+msgid "yes"
+msgstr "Tak"
 
-#: openlibrary/macros/AvailabilityButton.html:52
+#: search/work_search_facets.html
+msgid "no"
+msgstr ""
+
+#: search/work_search_facets.html
+msgid "Zoom In"
+msgstr "Powiększ"
+
+#: search/work_search_facets.html
+msgid "Focus your results using these <a href=\"/search/howto\">filters</a>"
+msgstr ""
+
+#: search/work_search_selected_facets.html
+msgid "Published by"
+msgstr "Wydane przez"
+
+#: search/work_search_selected_facets.html
+msgid "Only Classic eBooks"
+msgstr "Tylko klasyczne e-booki"
+
+#: search/work_search_selected_facets.html
+#, fuzzy
+msgid "Classic eBooks hidden"
+msgstr "Kasyczne e-booki"
+
+#: search/work_search_selected_facets.html
 #, python-format
-msgid "There is <strong>#1</strong> reader ahead of you"
-msgid_plural "There are <strong>#%(count)d</strong> readers ahead of you"
+msgid "%(title)s - search"
+msgstr ""
+
+#: site/alert.html
+#, fuzzy
+msgid "Internet Archive logo"
+msgstr "Internet Archive"
+
+#: site/body.html
+msgid "It looks like you're offline."
+msgstr ""
+
+#: site/head.html
+#, fuzzy
+msgid "Open Library is an open, editable library catalog, building towards a web page for every book ever published. Read, borrow, and discover more than 3M books for free."
+msgstr "Open Library to otwarty, edytowalny katalog biblioteczny, dążący do stworzenia strony internetowej dla każdej kiedykolwiek opublikowanej książki."
+
+#: site/stats.html
+msgid "Debug Stats"
+msgstr ""
+
+#: stats/readinglog.html
+#, fuzzy
+msgid "Reading Log Stats"
+msgstr "Dziennik Lektur"
+
+#: stats/readinglog.html
+#, fuzzy
+msgid "# Books Logged"
+msgstr "Książki, które kochamy"
+
+#: stats/readinglog.html
+msgid "The total number of books logged using the Reading Log feature"
+msgstr ""
+
+#: stats/readinglog.html
+#, fuzzy
+msgid "All time"
+msgstr "czas"
+
+#: stats/readinglog.html
+msgid "# Unique Users Logging Books"
+msgstr ""
+
+#: stats/readinglog.html
+msgid "The total number of unique users who have logged at least one book using the Reading Log feature"
+msgstr ""
+
+#: stats/readinglog.html
+#, fuzzy
+msgid "# Books Starred"
+msgstr "Wypożyczone e-booki"
+
+#: stats/readinglog.html
+msgid "The total number of books which have been starred"
+msgstr ""
+
+#: stats/readinglog.html
+msgid "Total # Unique Raters (all time)"
+msgstr ""
+
+#: stats/readinglog.html
+msgid "Most Wanted Books (This Month)"
+msgstr ""
+
+#: stats/readinglog.html
+#, fuzzy, python-format
+msgid "Added %(count)d time"
+msgid_plural "Added %(count)d times"
+msgstr[0] "%(count)d Lista"
+msgstr[1] "%(count)d Listy"
+
+#: stats/readinglog.html
+msgid "Most Wanted Books (All Time)"
+msgstr ""
+
+#: stats/readinglog.html
+#, fuzzy
+msgid "Most Logged Books"
+msgstr "Większość wydań"
+
+#: stats/readinglog.html
+msgid "Most Read Books (All Time)"
+msgstr ""
+
+#: stats/readinglog.html
+#, fuzzy
+msgid "Most Rated Books"
+msgstr "O tej książce"
+
+#: stats/readinglog.html
+msgid "Most Rated Books (All Time)"
+msgstr ""
+
+#: subjects/notfound.html
+msgid "We couldn't find any books about"
+msgstr ""
+
+#: swagger/swaggerui.html
+msgid "OpenAPI"
+msgstr ""
+
+#: type/about/edit.html type/page/edit.html type/permission/edit.html type/template/edit.html type/usergroup/edit.html
+#, python-format
+msgid "Edit %(title)s"
+msgstr "Edytuj %(title)s"
+
+#: type/about/edit.html
+msgid "This only appears in the document head, and gets attached to bookmark labels"
+msgstr ""
+
+#: type/about/edit.html
+msgid "Intro"
+msgstr ""
+
+#: type/about/edit.html
+msgid "This appears in first column."
+msgstr ""
+
+#: type/about/edit.html
+msgid "This appears in the second column, at top."
+msgstr ""
+
+#: type/about/edit.html
+#, fuzzy
+msgid "Mailing List"
+msgstr "Moje listy lektur:"
+
+#: type/about/edit.html
+msgid "This appears below the links list."
+msgstr ""
+
+#: type/about/view.html
+msgid "For more information"
+msgstr ""
+
+#: type/author/edit.html
+msgid "Edit Author"
+msgstr "Edytuj autora"
+
+#: type/author/edit.html
+msgid "Please use natural order. For example: <strong>Leo Tolstoy</strong> not <strong>Tolstoy, Leo</strong>."
+msgstr "Prosimy o podanie imienia i nazwiska. Na przykład: <strong>Lew Tołstoj</strong> nie <strong>Tołstoj, Lew</strong>. "
+
+#: type/author/edit.html
+msgid "A short bio?"
+msgstr "Krótka biografia?"
+
+#: type/author/edit.html
+msgid "If you \"borrow\" information from somewhere, please make sure to cite the source."
+msgstr "Jeśli \"pożyczasz\" pewne informacje z innych źródeł, prosimy o ich podanie."
+
+#: type/author/edit.html
+msgid "Date of birth"
+msgstr "Data urodzenia"
+
+#: type/author/edit.html
+msgid "Date of death"
+msgstr "Data śmierci"
+
+#: type/author/edit.html
+msgid "We're not storing structured dates (yet) so a date like \"21 May 2000\" is recommended."
+msgstr "Nie przechowujemy (jeszcze) ustrukturyzowanych dat, prosimy o podanie daty w formacie \"21 maj 2000\"."
+
+#: type/author/edit.html
+msgid "This is a deprecated field. You can help improve this record by removing this date and populating the \"Date of birth\" and \"Date of death\" fields. Thanks!"
+msgstr ""
+
+#: type/author/edit.html
+msgid "Does this author go by any other names?"
+msgstr "Czy autor posługiwał się innymi nazwiskami lub pseudonimami?"
+
+#: type/author/edit.html
+msgid "For example: Lev Nikolayevich Tolstoy was also known as Leo Tolstoy. Please list one name per line."
+msgstr ""
+
+#: type/author/edit.html
+msgid "Identifiers"
+msgstr ""
+
+#: type/author/edit.html
+msgid "Author Identifiers Purpose"
+msgstr ""
+
+#: type/author/view.html type/edition/view.html type/work/view.html
+#, python-format
+msgid "%(page_title)s | Open Library"
+msgstr "%(page_title)s | Open Library"
+
+#: type/author/view.html
+#, python-format
+msgid "Author of %(book_titles)s"
+msgstr "Autor %(book_titles)s"
+
+#: type/author/view.html
+msgid "Merging Authors..."
+msgstr "Łączenie autorów..."
+
+#: type/author/view.html
+msgid "In progress..."
+msgstr ""
+
+#: type/author/view.html
+msgid "Refresh the page?"
+msgstr "Odświeżyć stronę?"
+
+#: type/author/view.html
+msgid "OK. The merge is in motion. <i>It will take <u>a few minutes to finish</u> the update.</i>"
+msgstr "OK. Łączenie zostało rozpoczęte. <i>Aktualizacja zakończy się <u>w ciągu kilku minut</u>.</i>"
+
+#: type/author/view.html
+msgid "Argh!"
+msgstr "Ups!"
+
+#: type/author/view.html
+msgid "That merge didn't work. It's our fault, and we've made a note of it."
+msgstr "Te połączenie się nie powiodło. To nasza wina, zarejesterowaliśmy ten błąd."
+
+#: type/author/view.html
+msgid "Add another?"
+msgstr "Dodać kolejną?"
+
+#: type/author/view.html
+#, python-format
+msgid "Search %(author)s books"
+msgstr ""
+
+#: type/author/view.html
+#, fuzzy, python-format
+msgid "— Show <a href=\"%(url)s\">everything</a> by this author?"
+msgstr "Wczytywanie tylko e-booków. Czy chesz zobaczyć <a href=\"%(url)s\">wszystkie</a> prace tego autora?"
+
+#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py type/author/view.html type/list/view_body.html
+msgid "Places"
+msgstr "Miejsca"
+
+#: Profile.html type/author/view.html
+msgid "Time"
+msgstr "Okres"
+
+#: type/author/view.html
+#, fuzzy
+msgid "OLID"
+msgstr "Starsze"
+
+#: type/author/view.html
+msgid "Inventaire.io:"
+msgstr ""
+
+#: type/author/view.html type/edition/view.html type/work/view.html
+#, fuzzy
+msgid "Links <span class=\"gray small sansserif\">outside Open Library</span>"
+msgstr "Linki <span class=\"gray small sansserif\">(spoza Open Library)</span>"
+
+#: type/author/view.html
+msgid "No links yet."
+msgstr "Nie ma jeszcze linków."
+
+#: type/author/view.html
+msgid "Add one"
+msgstr "Dodaj"
+
+#: type/author/view.html
+msgid "Alternative names"
+msgstr "Alternatywne nazwiska"
+
+#: type/delete/view.html
+msgid "This page has been deleted"
+msgstr ""
+
+#: type/delete/view.html
+#, fuzzy
+msgid "What would you like to do?"
+msgstr "Jak opisał\\(a\\)byś tę książkę?"
+
+#: type/delete/view.html
+msgid "Go back where I came from"
+msgstr ""
+
+#: type/delete/view.html
+msgid "View the previous version"
+msgstr ""
+
+#: type/delete/view.html
+#, fuzzy
+msgid "See the page's history"
+msgstr "Zobacz tę listę"
+
+#: type/delete/view.html
+#, fuzzy
+msgid "Recreate it"
+msgstr "Utworzyć?"
+
+#: type/edition/admin_bar.html
+#, fuzzy
+msgid "Add IA Book to Staff Picks"
+msgstr "Dodaj do Wyboranych przez nas"
+
+#: type/edition/admin_bar.html
+msgid "Sync Archive.org ID"
+msgstr ""
+
+#: type/edition/admin_bar.html
+#, fuzzy
+msgid "View Book on Archive.org"
+msgstr "Przeczytaj e-book z Internet Archive"
+
+#: SearchResultsWork.html type/edition/admin_bar.html
+#, fuzzy
+msgid "Orphaned Edition"
+msgstr "Te wydanie"
+
+#: databarHistory.html databarView.html type/edition/compact_title.html
+#, fuzzy
+msgid "Edit this page"
+msgstr "Edytuj ten szablon"
+
+#: type/edition/modal_links.html
+#, fuzzy
+msgid "Review"
+msgstr "Wyświetl"
+
+#: type/edition/modal_links.html
+#, fuzzy
+msgid "reviewing"
+msgstr "Korekta"
+
+#: type/edition/modal_links.html
+#, fuzzy
+msgid "adding notes to"
+msgstr "Dodaj kolejnego autora"
+
+#: type/edition/title_and_author.html
+#, fuzzy
+msgid "An edition of"
+msgstr "1 wydanie"
+
+#: type/edition/title_and_author.html
+#, python-format
+msgid "First published in %s"
+msgstr ""
+
+#: type/edition/title_and_author.html
+#, python-format
+msgid "Book %s"
+msgstr ""
+
+#: type/edition/view.html type/work/view.html
+#, fuzzy
+msgid "Read More"
+msgstr "Usuń"
+
+#: type/edition/view.html type/work/view.html
+msgid "Read Less"
+msgstr ""
+
+#: type/edition/view.html type/work/view.html
+#, python-format
+msgid "This work doesn't have a description yet. Can you <b><a href='%(url)s'>add one</a></b>?"
+msgstr ""
+
+#: type/edition/view.html type/work/view.html
+#, python-format
+msgid "This edition doesn't have a description yet. Can you <b><a href='%(url)s'>add one</a></b>?"
+msgstr ""
+
+#: type/edition/view.html type/work/view.html
+#, fuzzy
+msgid "Publish Date"
+msgstr "Wydawca"
+
+#: type/edition/view.html type/work/view.html
+#, python-format
+msgid "Show other books from %(publisher)s"
+msgstr ""
+
+#: type/edition/view.html type/work/view.html
+#, python-format
+msgid "Search for other books from %(publisher)s"
+msgstr ""
+
+#: type/edition/view.html type/work/view.html
+#, fuzzy
+msgid "Pages"
+msgstr "Miejsca"
+
+#: type/edition/view.html type/work/view.html
+#, fuzzy
+msgid "ISBNs"
+msgstr "ISBN"
+
+#: databarWork.html type/edition/view.html type/work/view.html
+msgid "Buy this book"
+msgstr "Kup tą książkę"
+
+#: type/edition/view.html type/work/view.html
+msgid "Book Details"
+msgstr ""
+
+#: type/edition/view.html type/work/view.html
+msgid "First Sentence"
+msgstr "Pierwsze zdanie"
+
+#: type/edition/view.html type/work/view.html
+msgid "Edition Notes"
+msgstr "Uwagi do wydania"
+
+#: type/edition/view.html type/work/view.html
+#, fuzzy
+msgid "Published in"
+msgstr "Opublikowana"
+
+#: type/edition/view.html type/work/view.html
+msgid "Series"
+msgstr "Seria"
+
+#: type/edition/view.html type/work/view.html
+msgid "Volume"
+msgstr "Tom"
+
+#: type/edition/view.html type/work/view.html
+msgid "Genre"
+msgstr "Gatunek literacki"
+
+#: type/edition/view.html type/work/view.html
+msgid "Other Titles"
+msgstr "Podobe tytuły"
+
+#: type/edition/view.html type/work/view.html
+msgid "Copyright Date"
+msgstr "Data nadania praw autorskich"
+
+#: type/edition/view.html type/work/view.html
+msgid "Translation Of"
+msgstr "Tłumacznie"
+
+#: type/edition/view.html type/work/view.html
+msgid "Translated From"
+msgstr "Przetłumaczono z"
+
+#: type/edition/view.html type/work/view.html
+msgid "External Links"
+msgstr "Linki zewnętrzne"
+
+#: type/edition/view.html type/work/view.html
+msgid "Format"
+msgstr "Format"
+
+#: OlPagination.html OlPaginationArrows.html type/edition/view.html type/work/view.html
+msgid "Pagination"
+msgstr "Paginacja"
+
+#: type/edition/view.html type/work/view.html
+msgid "Number of pages"
+msgstr "Liczba stron"
+
+#: type/edition/view.html type/work/view.html
+msgid "Weight"
+msgstr "Waga"
+
+#: type/edition/view.html type/work/view.html
+#, fuzzy
+msgid "Edition Identifiers"
+msgstr "Uwagi do wydania"
+
+#: type/edition/view.html type/work/view.html
+#, fuzzy
+msgid "Source records"
+msgstr "Brak głównego dokumentu"
+
+#: type/edition/view.html type/work/view.html
+#, fuzzy
+msgid "Work Description"
+msgstr "Brak opisu."
+
+#: type/edition/view.html type/work/view.html
+msgid "Original languages"
+msgstr "Języki oryginału"
+
+#: type/edition/view.html type/work/view.html
+msgid "Excerpts"
+msgstr "Fragmenty"
+
+#: type/edition/view.html type/work/view.html
+#, python-format
+msgid "Page %(page)s"
+msgstr ""
+
+#: type/edition/view.html type/work/view.html
+#, python-format
+msgid "added by %(authorlink)s."
+msgstr ""
+
+#: type/edition/view.html type/work/view.html
+#, fuzzy
+msgid "added anonymously."
+msgstr "dodana anonimowo"
+
+#: type/edition/view.html type/work/view.html
+msgid "Wikipedia"
+msgstr "Wikipedia"
+
+#: type/edition/view.html type/work/view.html
+#, fuzzy
+msgid "Loading Lists"
+msgstr "Moje listy lektur:"
+
+#: type/language/view.html
+#, python-format
+msgid "%(language)s [deprecated]"
+msgstr ""
+
+#: type/language/view.html
+#, fuzzy
+msgid "languages"
+msgstr "Język"
+
+#: type/language/view.html
+#, fuzzy
+msgid "Code"
+msgstr "Starsze"
+
+#: type/language/view.html
+#, fuzzy
+msgid "Current"
+msgstr "1 obecnie wypożyczona"
+
+#: type/language/view.html
+#, python-format
+msgid "Try a <a href=\"%(href)s\">search for readable books in %(language)s</a>?"
+msgstr ""
+
+#: type/list/edit.html type/series/edit.html
+#, fuzzy
+msgid "Create a series"
+msgstr "Stwórz nową listę"
+
+#: type/list/edit.html type/series/edit.html
+#, python-format
+msgid "Editing series: %(list_name)s"
+msgstr ""
+
+#: type/list/edit.html type/series/edit.html
+#, python-format
+msgid "Editing list: %(list_name)s"
+msgstr ""
+
+#: type/list/edit.html type/series/edit.html
+#, fuzzy
+msgid "Edit Series"
+msgstr "Seria"
+
+#: type/list/edit.html type/series/edit.html
+#, fuzzy
+msgid "Edit List"
+msgstr "Usuń listę"
+
+#: type/list/edit.html type/series/edit.html
+#, fuzzy
+msgid "Move..."
+msgstr "Usuń"
+
+#: type/list/edit.html type/series/edit.html
+#, fuzzy
+msgid "Search for a book"
+msgstr "Wyszukaj w tekscie e-booka"
+
+#: type/list/edit.html type/series/edit.html
+msgid "Position (optional), e.g. 1, 2, 1-7"
+msgstr ""
+
+#: type/list/edit.html type/series/edit.html
+msgid "Notes (optional)"
+msgstr ""
+
+#: type/list/edit.html type/series/edit.html
+#, fuzzy
+msgid "List Name"
+msgstr "Słuchaj"
+
+#: type/list/edit.html type/series/edit.html
+#, fuzzy
+msgid "Series Name"
+msgstr "Nazwa użytkownika"
+
+#: type/list/edit.html type/series/edit.html
+#, fuzzy
+msgid "Description (optional)"
+msgstr "Opis tego wydania"
+
+#: type/list/edit.html type/series/edit.html
+#, fuzzy
+msgid "Add another book"
+msgstr "Dodaj kolejną"
+
+#: type/list/edit.html type/series/edit.html
+#, fuzzy
+msgid "Create new series"
+msgstr "Utwórz nową listę"
+
+#: type/list/embed.html
+#, fuzzy
+msgid "Visit Open Library"
+msgstr "Open Library"
+
+#: type/list/embed.html
+msgid "Open in online Book Reader. Downloads available in ePub, DAISY, PDF, TXT formats from main book page"
+msgstr ""
+
+#: type/list/embed.html
+msgid "This book is checked out"
+msgstr ""
+
+#: type/list/embed.html
+msgid "Checked out"
+msgstr ""
+
+#: type/list/embed.html
+#, fuzzy
+msgid "Borrow book"
+msgstr "Wypożycz teraz"
+
+#: type/list/embed.html
+msgid "Protected DAISY"
+msgstr ""
+
+#: BookByline.html type/list/embed.html
+#, fuzzy, python-format
+msgid "by %(name)s"
+msgstr " autorstwa %(name)s"
+
+#: type/list/exports.html
+#, fuzzy
+msgid "BibTex"
+msgstr "Strona internetowa"
+
+#: type/list/exports.html
+#, fuzzy
+msgid "Export"
+msgstr "Tekst"
+
+#: type/list/exports.html
+#, python-format
+msgid "as %(json_link)s, %(html_link)s, or %(bibtex_link)s"
+msgstr ""
+
+#: type/list/exports.html
+msgid "Subscribe"
+msgstr ""
+
+#: type/list/exports.html
+#, python-format
+msgid "Watch activity via <a rel=\"nofollow\" href=\"%s\">Atom feed</a>"
+msgstr ""
+
+#: type/list/exports.html
+msgid "Export Not Available"
+msgstr ""
+
+#: type/list/exports.html
+#, python-format
+msgid "Only lists with up to %(max)s editions can be exported. This one has %(count)s."
+msgstr ""
+
+#: type/list/exports.html
+#, python-format
+msgid "Try removing some seeds for more focus, or look at <a href=\"%s\">bulk download</a> of the catalog."
+msgstr ""
+
+#: type/list/view_body.html
+#, python-format
+msgid "%(name)s | Lists | Open Library"
+msgstr ""
+
+#: type/list/view_body.html
+#, python-format
+msgid "%(title)s: %(description)s"
+msgstr ""
+
+#: type/list/view_body.html
+#, fuzzy
+msgid "View the list on Open Library."
+msgstr "Zobacz wszystkich odwiedzających OpenLibrary.org"
+
+#: type/list/view_body.html
+#, fuzzy
+msgid "Remove this item?"
+msgstr "Usunąć ten plik inicujuący?"
+
+#: type/list/view_body.html
+#, python-format
+msgid "Last modified <span>%(date)s</span>"
+msgstr ""
+
+#: type/list/view_body.html
+#, fuzzy
+msgid "Remove seed"
+msgstr "Usunąć ten plik inicujuący?"
+
+#: type/list/view_body.html
+#, fuzzy
+msgid "Are you sure you want to remove this item from the list?"
+msgstr "Czy na pewno chcesz usunąć tę listę?"
+
+#: type/list/view_body.html
+#, fuzzy
+msgid "Remove Seed"
+msgstr "Usunąć ten plik inicujuący?"
+
+#: type/list/view_body.html
+msgid "You are about to remove the last item in the list. That will delete the whole list. Are you sure you want to continue?"
+msgstr ""
+
+#: type/list/view_body.html
+#, python-format
+msgid "This series contains %(limit)d or more works. Currently, only the first %(limit)d works are displayed."
+msgstr ""
+
+#: type/list/view_body.html
+msgid "There are no items on this list."
+msgstr ""
+
+#: type/list/view_body.html
+msgid "<a href=\"/search\" target=\"_blank\" rel=\"noopener noreferrer\">Search for book, subjects, or authors</a> to add to your list."
+msgstr ""
+
+#: type/list/view_body.html
+msgid "Learn more."
+msgstr ""
+
+#: type/list/view_body.html
+#, fuzzy
+msgid "List Metadata"
+msgstr "Dodatkowe metadane"
+
+#: type/list/view_body.html
+msgid "Derived from seed metadata"
+msgstr ""
+
+#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py type/list/view_body.html
+msgid "Times"
+msgstr "Okres"
+
+#: type/local_id/view.html
+msgid "Local IDs"
+msgstr ""
+
+#: type/local_id/view.html
+msgid "Source Item"
+msgstr ""
+
+#: type/local_id/view.html
+#, fuzzy
+msgid "ID location"
+msgstr "Lokalizaja"
+
+#: type/local_id/view.html
+msgid "Barcode regex"
+msgstr ""
+
+#: type/local_id/view.html
+#, fuzzy
+msgid "URN prefix"
+msgstr "Twój profil"
+
+#: type/local_id/view.html
+#, fuzzy
+msgid "Example"
+msgstr "Na przykład"
+
+#: type/page/edit.html
+msgid "Document Body:"
+msgstr "Treść dokumentu:"
+
+#: type/page/view.html
+#, fuzzy
+msgid "Community"
+msgstr "Komentarz"
+
+#: type/permission/edit.html
+#, fuzzy
+msgid "Readers:"
+msgstr "Przeczytaj"
+
+#: type/permission/edit.html
+#, fuzzy
+msgid "Writers:"
+msgstr "filtrów"
+
+#: type/permission/view.html
+#, fuzzy
+msgid "Readers"
+msgstr "Przeczytaj"
+
+#: type/permission/view.html
+#, fuzzy
+msgid "Writers"
+msgstr "filtrów"
+
+#: type/tag/form.html
+#, fuzzy
+msgid "Edit tag"
+msgstr "Usuń listę"
+
+#: type/tag/form.html
+#, fuzzy
+msgid "Add a tag"
+msgstr "Dodaj książkę"
+
+#: type/tag/form.html
+#, fuzzy
+msgid "Add a tag to Open Library"
+msgstr "Dodaj książkę do Open Library"
+
+#: type/tag/form.html
+#, fuzzy
+msgid "We require a minimum set of fields to create a new collection tag."
+msgstr "Aby utworzyć nowy wpis wymagane jest uzupełnienie nastepujących pól."
+
+#: EditButtons.html type/tag/form.html
+msgid "By saving a change to this wiki, you agree that your contribution is given freely to the world under <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" target=\"_blank\" rel=\"noopener noreferrer\" title=\"This link to Creative Commons will open in a new window\">CC0</a>. Yippee!"
+msgstr ""
+
+#: type/tag/form.html
+#, fuzzy
+msgid "Add this tag now"
+msgstr "Dodaj tę książkę"
+
+#: type/tag/index.html
+#, fuzzy
+msgid "Tags"
+msgstr "Status"
+
+#: type/tag/index.html
+msgid "Tags curated by Open Library librarians."
+msgstr ""
+
+#: type/tag/index.html
+#, fuzzy
+msgid "View subject page"
+msgstr "Zobacz wszystkie ostatnie zmiany"
+
+#: type/tag/index.html
+msgid "Previous"
+msgstr "Poprzednie"
+
+#: type/tag/index.html
+#, fuzzy
+msgid "No tags found."
+msgstr "Brak wyników."
+
+#: type/tag/tag_form_inputs.html
+#, fuzzy
+msgid "Tag Name"
+msgstr "Imię i nazwisko"
+
+#: type/tag/tag_form_inputs.html
+msgid "Human-readable display name (e.g. \"Computer Science\", \"Horror Fiction\")"
+msgstr ""
+
+#: type/tag/tag_form_inputs.html
+msgid "Tag Slugs"
+msgstr ""
+
+#: type/tag/tag_form_inputs.html
+msgid "Comma-separated URL slugs that map to this tag (auto-populated from name). E.g. \"computer_science, cs\""
+msgstr ""
+
+#: type/tag/tag_form_inputs.html
+#, fuzzy
+msgid "Tag Description"
+msgstr "Opis"
+
+#: type/tag/tag_form_inputs.html
+#, fuzzy
+msgid "Page Body"
+msgstr "Rodzaj strony"
+
+#: type/tag/tag_form_inputs.html
+#, fuzzy
+msgid "Tag type"
+msgstr "Rodzaj strony"
+
+#: type/tag/tag_form_inputs.html
+msgid "Tag Deputy"
+msgstr ""
+
+#: type/tag/view.html
+#, python-format
+msgid "<strong>Type:</strong> %(tag_type)s"
+msgstr ""
+
+#: type/tag/view.html type/user/edit.html
+msgid "Description"
+msgstr "Opis"
+
+#: type/tag/view.html
+msgid "Tag Body"
+msgstr ""
+
+#: type/tag/view.html
+msgid "URL Slugs"
+msgstr ""
+
+#: type/tag/view.html
+#, python-format
+msgid "View subject page for %(name)s."
+msgstr ""
+
+#: type/template/edit.html
+#, fuzzy
+msgid "Plugin"
+msgstr "Zaloguj się"
+
+#: type/template/edit.html
+#, fuzzy
+msgid "Document Body"
+msgstr "Treść dokumentu:"
+
+#: type/template/edit.html
+#, fuzzy
+msgid "Delete this template?"
+msgstr "Edytuj ten szablon"
+
+#: type/template/view.html
+#, fuzzy
+msgid "plugin"
+msgstr "Zaloguj się"
+
+#: type/type/view.html
+#, fuzzy
+msgid "Kind"
+msgstr "Książki dla dzieci"
+
+#: type/type/view.html
+#, fuzzy
+msgid "Properties"
+msgstr "Podobe tytuły"
+
+#: type/type/view.html
+#, fuzzy
+msgid "of type"
+msgstr "Rodzaj numeru identyfikacyjnego"
+
+#: type/type/view.html
+#, fuzzy
+msgid "Backreferences"
+msgstr "Różnice"
+
+#: type/user/edit.html
+#, python-format
+msgid "Editing %(name)s"
+msgstr ""
+
+#: type/user/edit.html
+msgid "Currently Editing:"
+msgstr "Obecnie edytujesz: "
+
+#: type/user/edit.html
+msgid "Display Name"
+msgstr "Wyświetl nazwę"
+
+#: type/user/view.html
+msgid "admin page"
+msgstr "strona administratora"
+
+#: type/user/view.html
+#, python-format
+msgid "You are publicly sharing the books you are <a href=\"%(username)s/books/currently-reading\">currently reading</a>, <a href=\"%(username)s/books/already-read\">have already read</a>, <a href=\"%(username)s/books/want-to-read\">want to read</a>, and have <a href=\"%(username)s/books/stopped-reading\">stopped reading</a>!"
+msgstr ""
+
+#: type/user/view.html
+msgid "You have chosen to make your"
+msgstr ""
+
+#: type/user/view.html
+msgid "private"
+msgstr ""
+
+#: type/user/view.html
+msgid "Manage your privacy settings"
+msgstr "Zarządzaj swoimi ustawieniami prywatności"
+
+#: type/user/view.html
+#, python-format
+msgid "Here are the books %(user)s is <a href=\"%(username)s/books/currently-reading\">currently reading</a>, <a href=\"%(username)s/books/already-read\">have already read</a>, <a href=\"%(username)s/books/want-to-read\">want to read</a>, and has <a href=\"%(username)s/books/stopped-reading\">stopped reading</a>!"
+msgstr ""
+
+#: type/user/view.html
+msgid "My Lists"
+msgstr "Moje listy"
+
+#: RecentChangesUsers.html type/user/view.html
+msgid "No edits. Yet."
+msgstr "Brak zmian. Jak na razie."
+
+#: type/usergroup/edit.html
+#, fuzzy
+msgid "Members:"
+msgstr "Nowi użytkownicy"
+
+#: SearchResultsWork.html type/work/editions.html
+#, python-format
+msgid "First published in %(year)s"
+msgstr "Po raz pierwszy opublikowana w %(year)s"
+
+#: type/work/editions.html type/work/editions_datatable.html
+#, python-format
+msgid "Add another edition of %(work)s"
+msgstr ""
+
+#: UserEditRow.html type/work/editions.html
+msgid "Add another"
+msgstr "Dodaj kolejną"
+
+#: type/work/editions.html
+#, fuzzy
+msgid "Title missing"
+msgstr "brakuje imienia"
+
+#: type/work/editions_datatable.html
+#, python-format
+msgid "Showing %(count)d featured edition."
+msgid_plural "Showing %(count)d featured editions."
 msgstr[0] ""
 msgstr[1] ""
 
-#: openlibrary/macros/AvailabilityButton.html:68
-msgid "Be first in line!"
+#: type/work/editions_datatable.html
+#, python-format
+msgid "View all %(count)d editions?"
 msgstr ""
 
-#: openlibrary/macros/AvailabilityButton.html:76
-msgid "Print-disabled access available"
+#: type/work/editions_datatable.html
+msgid "Edition"
+msgstr "Wydawnictwo"
+
+#: type/work/editions_datatable.html
+#, fuzzy
+msgid "No editions available"
+msgstr "Brak wybranych wydań."
+
+#: type/work/editions_datatable.html
+#, fuzzy
+msgid "Add another edition?"
+msgstr "Dodaj kolejne wydanie"
+
+#: AffiliateLinks.html
+#, python-format
+msgid "Look for this edition for sale at %(store)s"
 msgstr ""
 
-#: openlibrary/macros/BookPreview.html:10
-msgid "Preview"
+#: AffiliateLinks.html
+msgid "When you buy books using these links the Internet Archive may earn a <a class=\"nostyle\" href=\"/help/faq/about#selling\">small commission</a>."
 msgstr ""
 
-#: openlibrary/macros/BookPreview.html:17
+#: AffiliateLinksLoadingIndicator.html
+msgid "Fetching prices"
+msgstr ""
+
+#: BatchImportNavigation.html
+msgid "Pending Imports"
+msgstr ""
+
+#: BookByline.html
+#, python-format
+msgid "%(n)s other"
+msgid_plural "%(n)s others"
+msgstr[0] ""
+msgstr[1] ""
+
+#: BookByline.html
+#, fuzzy
+msgid "by an <em>unknown author</em>"
+msgstr "<em>autor nieznany</em>"
+
+#: BookPreview.html
+#, fuzzy
+msgid "Preview Only"
+msgstr "Wypożycz teraz"
+
+#: BookPreview.html
 #, fuzzy
 msgid "Preview Book"
 msgstr "Wypożycz teraz"
 
-#: openlibrary/macros/BookPreview.html:30
-msgid "See more about this book on Archive.org"
+#: DisplayCode.html
+msgid "Templates in the website are disabled now. Editing them will not have any effect on the live website."
 msgstr ""
 
-#: openlibrary/macros/databarHistory.html:16
-#: openlibrary/macros/databarView.html:16
-msgid "Edit this template"
-msgstr "Edytuj ten szablon"
+#: EditionNavBar.html
+msgid "Go to previous section"
+msgstr ""
 
-#: openlibrary/macros/databarHistory.html:22
-#: openlibrary/macros/databarView.html:25
-#, fuzzy, python-format
-msgid "Last edited by %(author_link)s"
-msgstr "%(title)s autorstwa %(authorlist)s"
-
-#: openlibrary/macros/databarHistory.html:24
-#: openlibrary/macros/databarView.html:27
-msgid "Last edited anonymously"
-msgstr "Ostatnio edydowano anonimowo"
-
-#: openlibrary/macros/databarWork.html:51
-msgid "Really return this book?"
-msgstr "Na pewno zwrócić tę książkę?"
-
-#: openlibrary/macros/databarWork.html:65
-msgid "Buy this book"
-msgstr "Kup tą książkę"
-
-#: openlibrary/macros/databarWork.html:83
-msgid "External Links"
-msgstr "Linki zewnętrzne"
-
-#: openlibrary/macros/DownloadOptions.html:17
+#: EditionNavBar.html
 #, fuzzy
-msgid "Download Options"
-msgstr "Pobierz"
+msgid "Overview"
+msgstr "Wyświetl"
 
-#: openlibrary/macros/DownloadOptions.html:20
+#: EditionNavBar.html
+#, python-format
+msgid "View %(count)s Edition"
+msgid_plural "View %(count)s Editions"
+msgstr[0] ""
+msgstr[1] ""
+
+#: EditionNavBar.html
+#, python-format
+msgid "%(reviews)s Review"
+msgid_plural "%(reviews)s Reviews"
+msgstr[0] ""
+msgstr[1] ""
+
+#: EditionNavBar.html
 #, fuzzy
-msgid "Download a PDF from Internet Archive"
-msgstr "Przeczytaj e-book z Internet Archive"
+msgid "Related Books"
+msgstr "Losowa książka"
 
-#: openlibrary/macros/DownloadOptions.html:20
-msgid "PDF"
+#: EditionNavBar.html
+msgid "Go to next section"
 msgstr ""
 
-#: openlibrary/macros/DownloadOptions.html:22
+#: Follow.html
+msgid "Unfollow"
+msgstr ""
+
+#: Follow.html
+msgid "Failed to update followers. Please try again in a few moments."
+msgstr ""
+
+#: FormatExpiry.html
 #, fuzzy
-msgid "Download a text version from Internet Archive"
-msgstr "Przeczytaj e-book z Internet Archive"
+msgid "Expires"
+msgstr "Termin zwrotu"
 
-#: openlibrary/macros/DownloadOptions.html:22
-msgid "Plain text"
+#: FulltextSearchSuggestion.html
+msgid "Checking for Search Inside matches"
 msgstr ""
 
-#: openlibrary/macros/DownloadOptions.html:24
+#: FulltextSearchSuggestion.html
 #, fuzzy
-msgid "Download an ePub from Internet Archive"
-msgstr "Przeczytaj e-book z Internet Archive"
+msgid "Search Inside Icon"
+msgstr "Szukaj w"
 
-#: openlibrary/macros/DownloadOptions.html:24
-msgid "ePub"
-msgstr ""
-
-#: openlibrary/macros/DownloadOptions.html:26
+#: FulltextSearchSuggestion.html
 #, fuzzy
-msgid "Download a MOBI file from Internet Archive"
-msgstr "Przeczytaj e-book z Internet Archive"
+msgid "search inside icon"
+msgstr "Szukaj w"
 
-#: openlibrary/macros/DownloadOptions.html:26
-msgid "MOBI"
+#: FulltextSearchSuggestion.html
+#, python-format
+msgid "%(book_count)s books found with matching passages"
 msgstr ""
 
-#: openlibrary/macros/DownloadOptions.html:27
-msgid "Download open DAISY from Internet Archive (print-disabled format)"
+#: FulltextSearchSuggestion.html
+#, python-format
+msgid "See all %(results_count)s Search Inside Matches"
 msgstr ""
 
-#: openlibrary/macros/EditButtons.html:9
-msgid "Please, leave a short note about what you changed:"
-msgstr "Zostaw krótką notatkę o wprwadzonych przez Ciebie zmianach:"
-
-#: openlibrary/macros/EditButtons.html:9
-msgid "(Optional, but very useful!)"
-msgstr "(Opcjonalne, ale bardzo pomocne!)"
-
-#: openlibrary/macros/EditButtons.html:17
-msgid ""
-"By saving a change to this wiki, you agree that your contribution is "
-"given freely to the world under <a "
-"href=\"https://creativecommons.org/publicdomain/zero/1.0/\" "
-"target=\"_blank\" title=\"This link to Creative Commons will open in a "
-"new window\">CC0</a>. Yippee!"
+#: FulltextSearchSuggestion.html
+msgid "right chevron"
 msgstr ""
-"Zapisując zmianę w tej wiki, zgadzasz się, że Twój wkładjest dobrowolny, "
-"zgodnie z <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" "
-"target=\"_blank\" title=\"Ten link do Creative Commons będzie otwarty w "
-"nowym oknie\">CC0</a>. Hurra!"
 
-#: openlibrary/macros/EditButtons.html:27
-msgid ""
-"<em>Please Note:</em> Only Admins can delete things. <a href=\"/contact\""
-" class=\"blue\">Let us know</a> if there's a problem."
+#: FulltextSnippet.html FulltextSuggestionSnippet.html
+msgid "❝"
 msgstr ""
-"<em>Uwaga:</em> Tylko administratorzy mogą usuwać elementy. <a "
-"href=\"/contact\" class=\"blue\">Daj nam znać</a> jeśli wystąpił problem."
 
-#: openlibrary/macros/LoanStatus.html:46
-#, fuzzy
-msgid "Return eBook"
-msgstr "Przewiń do góry"
+#: FulltextSnippet.html FulltextSuggestionSnippet.html
+msgid "❞"
+msgstr ""
 
-#: openlibrary/macros/LoanStatus.html:63
+#: FulltextSuggestionSnippet.html
+#, python-format
+msgid "Page: %(page)s"
+msgstr ""
+
+#: IABook.html
+#, python-format
+msgid "Borrowed from Internet Archive: %(title)s"
+msgstr ""
+
+#: LoadingIndicator.html
+msgid "Loading indicator"
+msgstr ""
+
+#: LoanStatus.html
 msgid "You are <strong>next</strong> on the waiting list"
 msgstr "Jesteś <strong> następny </strong> na liście oczekujących"
 
-#: openlibrary/macros/LoanStatus.html:65
+#: LoanStatus.html
 #, python-format
 msgid "You are <strong>#%(spot)d</strong> of %(wlsize)d on the waiting list."
 msgstr "Jesteś <strong>#%(spot)d</strong> %(wlsize)d na liście oczekujących."
 
-#: openlibrary/macros/LoanStatus.html:69
+#: LoanStatus.html
 #, fuzzy
 msgid "Leave waiting list"
 msgstr "Opuścić listę oczekujących?"
 
-#: openlibrary/macros/LoanStatus.html:74
+#: LoanStatus.html
 #, python-format
-msgid "Readers waiting for this title: %(count)d"
+msgid "Readers in line: %(count)s"
 msgstr ""
 
-#: openlibrary/macros/LoanStatus.html:76
+#: LoanStatus.html
 msgid "You'll be next in line."
 msgstr ""
 
-#: openlibrary/macros/LoanStatus.html:89
-#, fuzzy, python-format
-msgid "Sponsor eBook"
-msgstr "%s e-book"
-
-#: openlibrary/macros/LoanStatus.html:91
-#, python-format
-msgid ""
-"We don’t have this book yet. You can add it to our Lending Library with a"
-" %(price)s tax deductible donation."
+#: LoanStatus.html
+msgid "This book is currently checked out, please check back later."
 msgstr ""
 
-#: openlibrary/macros/Pager.html:26
-msgid "First"
-msgstr "Pierwszy"
+#: LoanStatus.html
+#, fuzzy
+msgid "Checked Out"
+msgstr "Książki, które zaznaczyłeś"
 
-#: openlibrary/macros/ReadButton.html:10
+#: LocateButton.html
+msgid "Locate"
+msgstr "Zlokalizuj"
+
+#: ManageLoansButtons.html
+#, python-format
+msgid "There is one person waiting for this book."
+msgid_plural "There are %(n)s people waiting for this book."
+msgstr[0] "Jedna osoba oczekuje na wypożyczenie tej książki."
+msgstr[1] "%(n)d osób oczekuje na wypożyczenie tej książki."
+
+#: ManageWaitlistButton.html
+#, fuzzy, python-format
+msgid "Waiting for %d day"
+msgid_plural "Waiting for %d days"
+msgstr[0] "Oczekujesz %d dzień"
+msgstr[1] "Oczekujesz %d dni"
+
+#: ManageWaitlistButton.html
+#, python-format
+msgid "You have %(count)d more hour to borrow it."
+msgid_plural "You have %(count)d more hours to borrow it."
+msgstr[0] ""
+msgstr[1] ""
+
+#: NotInLibrary.html
+msgid "Not in Library"
+msgstr "Brak w bibliotece"
+
+#: NotesModal.html
+#, fuzzy
+msgid "My Book Notes"
+msgstr "Moje książki"
+
+#: NotesModal.html
+#, fuzzy
+msgid "My private notes about this edition:"
+msgstr "Dodatkowe uwagi na temat tego wydania?"
+
+#: OLID.html
+#, python-format
+msgid "by  %(authors)s"
+msgstr ""
+
+#: ObservationsModal.html
+#, fuzzy
+msgid "My Book Review"
+msgstr "Moje książki"
+
+#: OlPagination.html OlPaginationArrows.html
+msgid "Go to previous page"
+msgstr ""
+
+#: OlPagination.html OlPaginationArrows.html
+msgid "Go to next page"
+msgstr ""
+
+#: OlPagination.html
+#, python-brace-format
+msgid "Go to page {page}"
+msgstr ""
+
+#: OlPagination.html
+#, python-brace-format
+msgid "Page {page}, current page"
+msgstr ""
+
+#: Profile.html
+#, fuzzy
+msgid "Component"
+msgstr "Komentarz"
+
+#: ProlificAuthors.html
+msgid "Prolific Authors"
+msgstr "Autorzy"
+
+#: ProlificAuthors.html
+msgid "who have written the most books on this subject"
+msgstr "którzy napisali najwięcej książek na ten temat"
+
+#: PublishingHistory.html
+msgid "This is a chart to show the publishing history of editions of works about this subject. Along the X axis is time, and on the y axis is the count of editions published. <a href=\"#subjectRelated\">Click here to skip the chart</a>."
+msgstr "To wykres pokazujący historię publikacji dzieł na ten temat. Oś X wskazuje na czas, oś Y wskazuje liczbę publikacji. <a href=\"#subjectRelated\"> Kliknij tutaj, aby pominąć wykres</a>."
+
+#: PublishingHistory.html
+msgid "This graph charts editions published on this subject."
+msgstr "Ten diagram przedstawia wydania publikacji na ten temat."
+
+#: RawQueryCarousel.html
+msgid "Loading carousel"
+msgstr ""
+
+#: RawQueryCarousel.html
+msgid "Failed to fetch carousel."
+msgstr ""
+
+#: RawQueryCarousel.html
+msgid "Retry?"
+msgstr ""
+
+#: RawQueryCarousel.html
+msgid "No books match the current filters."
+msgstr ""
+
+#: RawQueryCarousel.html
+msgid "Retry without filters?"
+msgstr ""
+
+#: RawQueryCarousel.html
+#, fuzzy
+msgid "Search collection"
+msgstr "Rok wydania"
+
+#: ReadButton.html
+#, fuzzy
+msgid "Special Access"
+msgstr "Miejsca"
+
+#: ReadButton.html
+msgid "Special ebook access from the Internet Archive for patrons with qualifying print disabilities"
+msgstr ""
+
+#: ReadButton.html
 msgid "Borrow ebook from Internet Archive"
 msgstr "Pożycz e-book z Internet Archive"
 
-#: openlibrary/macros/ReadButton.html:14
+#: ReadButton.html
 msgid "Read ebook from Internet Archive"
 msgstr "Przeczytaj e-book z Internet Archive"
 
-#: openlibrary/macros/ReadButton.html:33
+#: ReadButton.html
 msgid "Listen"
 msgstr "Słuchaj"
 
-#: openlibrary/macros/SearchResultsWork.html:35
-msgid "Unknown author"
-msgstr "Nieznany autor"
+#: RecentChanges.html
+#, fuzzy
+msgid "View MARC"
+msgstr "Wyświetl"
 
-#: openlibrary/macros/SearchResultsWork.html:44
+#: RecentChangesAdmin.html
+#, fuzzy
+msgid "Path"
+msgstr "Grubość"
+
+#: RecentChangesAdmin.html
+#, fuzzy
+msgid "view"
+msgstr "Wyświetl"
+
+#: RecentChangesAdmin.html
+#, fuzzy
+msgid "edit"
+msgstr "Edytuj"
+
+#: RecentChangesAdmin.html RecentChangesUsers.html
+msgid "No edit history available."
+msgstr ""
+
+#: RelatedSubjects.html
+msgid "Related..."
+msgstr "Powiązane..."
+
+#: ReturnForm.html
+msgid "Really return this book?"
+msgstr "Na pewno zwrócić tę książkę?"
+
+#: ReturnForm.html
+#, fuzzy
+msgid "Return book"
+msgstr "Przewiń do góry"
+
+#: SearchResultsWork.html
+#, fuzzy
+msgid "added to"
+msgstr "Dodano"
+
+#: SearchResultsWork.html
 #, python-format
-msgid "- first published in %(year)s"
-msgstr "- po raz pierwszy opublikowany w %(year)s"
+msgid "Book %(position)s"
+msgstr ""
 
-#: openlibrary/macros/SocialShare.html:16
-msgid "Share this book"
-msgstr "Udostępnij tę książkę"
+#: SearchResultsWork.html
+#, fuzzy
+msgid "Show more"
+msgstr "więcej"
 
-#: openlibrary/macros/SocialShare.html:31
+#: SearchResultsWork.html
+#, fuzzy
+msgid "Show less"
+msgstr "mniej"
+
+#: SearchResultsWork.html
+#, python-format
+msgid "Cover of edition %(id)s"
+msgstr ""
+
+#: SearchResultsWork.html
+#, python-format
+msgid "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d language</a>"
+msgid_plural "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d languages</a>"
+msgstr[0] ""
+msgstr[1] ""
+
+#: SearchResultsWork.html TrendingBadge.html
+msgid "This is only visible to librarians."
+msgstr ""
+
+#: SearchResultsWork.html
+#, fuzzy
+msgid "Work Title"
+msgstr "Podobe tytuły"
+
+#: ShareModal.html
+#, python-format
+msgid "Share on %(share_link)s"
+msgstr ""
+
+#: ShareModal.html
 msgid "Embed this book in your website"
 msgstr "Umieść tę książkę na swojej stronie internetowej"
 
-#: openlibrary/macros/SocialShare.html:35
+#: ShareModal.html
+#, fuzzy
+msgid "Embed icon"
+msgstr "Umieść"
+
+#: ShareModal.html
 msgid "Embed"
 msgstr "Umieść"
 
-#: openlibrary/macros/TypeChanger.html:17
+#: ShareModal.html
+msgid "Copy url to clipboard"
+msgstr ""
+
+#: ShareModal.html
+msgid "Copy URL icon"
+msgstr ""
+
+#: ShareModal.html
+msgid "Copy URL"
+msgstr ""
+
+#: ShareModal.html
+msgid "Open QR code"
+msgstr ""
+
+#: ShareModal.html
+msgid "QR code icon"
+msgstr ""
+
+#: ShareModal.html
+msgid "QR Code"
+msgstr ""
+
+#: StarRatings.html
+msgid "leaving a 1 star review for"
+msgstr ""
+
+#: StarRatings.html
+msgid "leaving a 2 star review for"
+msgstr ""
+
+#: StarRatings.html
+msgid "leaving a 3 star review for"
+msgstr ""
+
+#: StarRatings.html
+msgid "leaving a 4 star review for"
+msgstr ""
+
+#: StarRatings.html
+msgid "leaving a 5 star review for"
+msgstr ""
+
+#: StarRatings.html
+msgid "Clear my rating"
+msgstr ""
+
+#: StarRatingsByline.html StarRatingsComponent.html
+#, fuzzy
+msgid "rating"
+msgstr "Sortuj"
+
+#: StarRatingsByline.html StarRatingsComponent.html
+#, fuzzy
+msgid "ratings"
+msgstr "Akcje"
+
+#. Shows the count of readers who added this book to their "Want to read"
+#. shelf, displayed on search result pages. %(want_to_read_count)s is a
+#. formatted integer (may include commas as thousands separators). Example:
+#. "2,389 Want to read".
+#: StarRatingsByline.html
+#, python-format
+msgid "%(want_to_read_count)s Want to read"
+msgstr ""
+
+#: StarRatingsComponent.html
+#, python-format
+msgid "%(ratings_avg)s (%(ratings_count)s %(ratings_label)s)"
+msgstr ""
+
+#. Short label displayed next to the count of readers who want to read this
+#. book, shown in the stats bar on a book page. Example: "2,389 Want to read".
+#: StarRatingsStats.html
+#, fuzzy
+msgid "Want to read"
+msgstr "Chcę przeczytać"
+
+#. Short label displayed next to the count of readers currently reading this
+#. book, shown in the stats bar on a book page. Example: "1,247 Currently
+#. reading".
+#: StarRatingsStats.html
+#, fuzzy
+msgid "Currently reading"
+msgstr "W trakcie czytania"
+
+#. Short label displayed next to the count of readers who have finished this
+#. book, shown in the stats bar on a book page. Example: "15,420 Have read".
+#. This refers to the same shelf as the "Already Read" button.
+#: StarRatingsStats.html
+#, fuzzy
+msgid "Have read"
+msgstr "Przeczytane"
+
+#. Short label displayed next to the count of readers who stopped reading this
+#. book before finishing, shown in the stats bar on a book page. Example: "348
+#. Stopped reading".
+#: StarRatingsStats.html
+msgid "Stopped reading"
+msgstr ""
+
+#: SubjectTags.html
+#, fuzzy
+msgid "Manage Subjects"
+msgstr "Wspólne tematy"
+
+#: Subnavigation.html
+#, fuzzy
+msgid "Developer Center (Home)"
+msgstr "Centrum programistów"
+
+#: Subnavigation.html
+msgid "Web API"
+msgstr ""
+
+#: Subnavigation.html
+#, fuzzy
+msgid "Client Library"
+msgstr "Open Library"
+
+#: Subnavigation.html
+#, fuzzy
+msgid "Data Dumps"
+msgstr "Zrzuty danych zbiorczych"
+
+#: Subnavigation.html
+#, fuzzy
+msgid "Report an Issue"
+msgstr "Zgłoś problem"
+
+#: Subnavigation.html
+#, fuzzy
+msgid "Licensing"
+msgstr "Wymiary"
+
+#: Subnavigation.html
+msgid "Welcome"
+msgstr ""
+
+#: Subnavigation.html
+#, fuzzy
+msgid "Searching Open Library"
+msgstr "Załóż konto na Open Library"
+
+#: Subnavigation.html
+#, fuzzy
+msgid "Reading Books"
+msgstr "Dziennik Lektur"
+
+#: Subnavigation.html
+msgid "Adding & Editing Books"
+msgstr ""
+
+#: Subnavigation.html
+#, fuzzy
+msgid "Using Subjects"
+msgstr "Tematyka"
+
+#: Subnavigation.html
+#, fuzzy
+msgid "Open Library F.A.Q."
+msgstr "Open Library"
+
+#: TableOfContents.html
+#, python-format
+msgid "Page %s"
+msgstr ""
+
+#: TrendingBadge.html
+#, python-format
+msgid "Trending: %(score).2f"
+msgstr ""
+
+#: TypeChanger.html
 msgid "Page Type"
 msgstr "Rodzaj strony"
 
-#: openlibrary/macros/TypeChanger.html:19
+#: TypeChanger.html
 msgid "Huh?"
 msgstr "Wpisz ponownie"
 
-#: openlibrary/macros/TypeChanger.html:22
-msgid ""
-"Every piece of Open Library is defined by the type of content it "
-"displays, usually by content definition (e.g. Authors, Editions, Works) "
-"but sometimes by content use (e.g. macro, template, rawtext). Changing "
-"this for an existing page will alter its presentation and the data fields"
-" available for editing its content."
-msgstr ""
-"Każdy element Open Library jest określony przez rodzaj informacji które "
-"wyświetla, zwykle według definicji treści (np. autorzy, wydania, prace), "
-"a czasem według zawartości (np. makro, szablon, tekst). Zmiany na "
-"istniejącej stronie zmienią jej prezentację i pola danychdostępnych do "
-"edycji jej zawartości."
+#: TypeChanger.html
+msgid "Every piece of Open Library is defined by the type of content it displays, usually by content definition (e.g. Authors, Editions, Works) but sometimes by content use (e.g. macro, template, rawtext). Changing this for an existing page will alter its presentation and the data fields available for editing its content."
+msgstr "Każdy element Open Library jest określony przez rodzaj informacji które wyświetla, zwykle według definicji treści (np. autorzy, wydania, prace), a czasem według zawartości (np. makro, szablon, tekst). Zmiany na istniejącej stronie zmienią jej prezentację i pola danychdostępnych do edycji jej zawartości."
 
-#: openlibrary/macros/TypeChanger.html:22
+#: TypeChanger.html
 msgid "Please use caution changing Page Type!"
 msgstr "Zachowaj ostrożność, zmieniając Typ Strony!"
 
-#: openlibrary/macros/TypeChanger.html:22
-msgid ""
-"(Simplest solution: If you aren't sure whether this should be changed, "
-"don't change it.)"
-msgstr ""
-"(Najprostsze rozwiązanie: jeśli nie masz pewności, czy należy to zmienić,"
-" nie zmieniaj tego.)"
+#: TypeChanger.html
+msgid "(Simplest solution: If you aren't sure whether this should be changed, don't change it.)"
+msgstr "(Najprostsze rozwiązanie: jeśli nie masz pewności, czy należy to zmienić, nie zmieniaj tego.)"
 
-#: openlibrary/macros/WorldcatLink.html:10
+#: WorkInfo.html
+msgid "No link to Wikipedia in your language"
+msgstr ""
+
+#: WorldcatLink.html
 msgid "Check nearby libraries"
 msgstr "Sprawdź pobliskie biblioteki"
 
-#: openlibrary/macros/WorldcatLink.html:14
+#: WorldcatLink.html
 msgid "Check WorldCat for an edition near you"
 msgstr "Przejdź na WorldCat, by znaleźć najbliższa bibliotekę z tym wydaniem."
+
+#: WorldcatLink.html
+msgid "WorldCat"
+msgstr ""
+
+#: databarDiff.html databarEdit.html
+#, fuzzy
+msgid "View the editing history of this page"
+msgstr "Wróć na górę tej strony"
+
+#: databarDiff.html
+msgid "View this page (exit Comparison view)"
+msgstr ""
+
+#: databarEdit.html
+msgid "View this page (exit Edit mode)"
+msgstr ""
+
+#: databarHistory.html databarView.html
+#, python-format
+msgid "Last edited by %(author_link)s"
+msgstr ""
+
+#: databarHistory.html databarView.html
+msgid "Last edited anonymously"
+msgstr "Ostatnio edydowano anonimowo"
+
+#: databarTemplate.html databarView.html
+msgid "View this template's edit history"
+msgstr ""
+
+#: databarTemplate.html
+msgid "Edit this template"
+msgstr "Edytuj ten szablon"
+
+#: databarWork.html
+#, python-format
+msgid "View Volume %(num)d"
+msgstr ""
+
+#: openlibrary/core/bookshelves.py
+msgid "[Record deleted]"
+msgstr ""
+
+#: openlibrary/core/edits.py
+#, fuzzy
+msgid "Unknown"
+msgstr "Nieznany autor"
+
+#: openlibrary/plugins/openlibrary/api.py
+#, fuzzy
+msgid "Search Results"
+msgstr "Szukaj"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Arabic"
+msgstr "Arabski"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Czech"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "German"
+msgstr "Niemiecki"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "English"
+msgstr "Angielski"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Spanish"
+msgstr "Hiszpański"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "French"
+msgstr "Francuski"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Hindi"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+#, fuzzy
+msgid "Croatian"
+msgstr "Lokalizaja"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Italian"
+msgstr "Włoski"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Portuguese"
+msgstr "Portugalski"
+
+#: openlibrary/plugins/openlibrary/code.py
+#, fuzzy
+msgid "Romanian"
+msgstr "Romanse"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Sardinian"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Telugu"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Ukrainian"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Chinese"
+msgstr "Chiński"
+
+#: openlibrary/plugins/openlibrary/code.py
+msgid "Filipino"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Art"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+#, fuzzy
+msgid "Science Fiction"
+msgstr "Klasyfikacje"
+
+#: openlibrary/plugins/openlibrary/home.py
+#, fuzzy
+msgid "Fantasy"
+msgstr "dowolny"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Biographies"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+#, fuzzy
+msgid "Recipes"
+msgstr "Seria"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Children"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+#, fuzzy
+msgid "Medicine"
+msgstr "Wydawnictwo"
+
+#: openlibrary/plugins/openlibrary/home.py
+#, fuzzy
+msgid "Religion"
+msgstr "Korekta"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Mystery and Detective Stories"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+#, fuzzy
+msgid "Plays"
+msgstr "Miejsca"
+
+#: openlibrary/plugins/openlibrary/home.py
+msgid "Music"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/home.py
+#, fuzzy
+msgid "Science"
+msgstr "Anuluj"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "At least 1 subject"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+#, fuzzy
+msgid "At least 1 author"
+msgstr "Edytuj autora"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+#, fuzzy
+msgid "At least 1 edition"
+msgstr "1 wydanie"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+msgid "Has work (orphaned)"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+#, fuzzy
+msgid "Has publication year"
+msgstr "Rok wydania"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+#, fuzzy
+msgid "Has cover"
+msgstr "Odkrywaj"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+#, fuzzy
+msgid "Has language"
+msgstr "Język"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+#, fuzzy
+msgid "Has publisher"
+msgstr "Wydawca"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+#, fuzzy
+msgid "At least 2 editions"
+msgstr "Większość wydań"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+#, fuzzy
+msgid "Has dewey decimal"
+msgstr "Np., klasyfikacja dziesiętna Deweya"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+#, fuzzy
+msgid "Has LoC classification"
+msgstr "Klasyfikacje"
+
+#: openlibrary/plugins/openlibrary/librarian_dashboard.py
+#, fuzzy
+msgid "Has number of pages"
+msgstr "Liczba stron"
+
+#: openlibrary/plugins/openlibrary/lists.py
+#, python-format
+msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
+msgstr "Na pewno chcesz usunąć <strong>%(title)s</strong> z Twoich list?"
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "Better World Books"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid " - includes shipping"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "Amazon"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "Bookshop.org"
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/partials.py
+msgid "This work does not appear on any lists."
+msgstr ""
+
+#: openlibrary/plugins/openlibrary/pd.py
+msgid "I don't have one yet"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "The email address you entered is invalid"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "This account has been blocked"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "This account has been locked"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "No account was found with this email. Please try again"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "The password you entered is incorrect. Please try again"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Wrong password. Please try again"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+#, fuzzy
+msgid "Please verify your Open Library account before logging in"
+msgstr "Wpisz nowe hasło do Twojego konta na Open Library"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Please verify your Internet Archive account before logging in"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Please fill out all fields and try again"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+#, fuzzy
+msgid "This email is already registered"
+msgstr "Podany e-mail jest już zarejestrowany"
+
+#: openlibrary/plugins/upstream/account.py
+#, fuzzy
+msgid "This username is already registered"
+msgstr "Podany e-mail jest już zarejestrowany"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "A problem occurred and we were unable to log you in."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Login attempted with invalid Internet Archive s3 credentials."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Servers are experiencing unusually high traffic, please try again later or email openlibrary@archive.org for help."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+#, fuzzy
+msgid "Email provider not recognized."
+msgstr "Twój dostawca poczty e-mail jest nieznany."
+
+#: openlibrary/plugins/upstream/account.py
+#, fuzzy
+msgid "Password requirements not met."
+msgstr "Hasła nie są identyczne."
+
+#: openlibrary/plugins/upstream/account.py
+msgid "A problem occurred and we were unable to log you in"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Login or registration attempt hit an unexpected error, please try again or contact info@archive.org"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+#, python-format
+msgid "Request failed with error code: %(error_code)s"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Thank you for registering an Open Library account and requesting special print disability access. You should receive an email detailing next steps in the process."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Username unavailable"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py openlibrary/plugins/upstream/forms.py
+msgid "Email already registered"
+msgstr "Podany e-mail jest już zarejestrowany"
+
+#: openlibrary/plugins/upstream/account.py
+msgid "An Internet Archive account already exists with this email"
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Verification failed. The link may be invalid or expired. Please try registering again."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Your email has been verified. You are now logged in."
+msgstr ""
+
+#: openlibrary/plugins/upstream/account.py
+msgid "Notification preferences have been updated successfully."
+msgstr "Preferencje dotyczące powiadomień zostały zaktualizowane."
+
+#: openlibrary/plugins/upstream/borrow.py
+#, fuzzy
+msgid "this book"
+msgstr "Kup tą książkę"
+
+#: openlibrary/plugins/upstream/borrow.py
+#, python-format
+msgid "Unable to return %s. Please try again later or contact info@archive.org."
+msgstr ""
+
+#: openlibrary/plugins/upstream/borrow.py
+#, python-format
+msgid "%s has been returned."
+msgstr ""
+
+#: openlibrary/plugins/upstream/borrow.py
+msgid "Your account has hit a lending limit. Please try again later or contact info@archive.org."
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Username"
+msgstr "Nazwa użytkownika"
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "No user registered with this email address"
+msgstr "Nie istnieje konto z podanym adresem e-mail"
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Disposable email not permitted"
+msgstr "Jednorazowy e-mail jest niedozwolony."
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Your email provider is not recognized."
+msgstr "Twój dostawca poczty e-mail jest nieznany."
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Username already used"
+msgstr "Konto z podaną nazwą użytkownika już istnieje."
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Must be between 3 and 20 letters and numbers"
+msgstr "Musi składać się z min. 3 i max. 20 liter i liczb."
+
+#: openlibrary/plugins/upstream/forms.py
+#, fuzzy
+msgid "Screen Name"
+msgstr "Nazwa użytkownika"
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Public and cannot be changed later."
+msgstr ""
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Invalid password"
+msgstr "Błędne hasło"
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Your email address"
+msgstr "Twój adres e-mail"
+
+#: openlibrary/plugins/upstream/forms.py
+msgid "Choose a password"
+msgstr "Wybierz hasło"
+
+#: openlibrary/plugins/upstream/mybooks.py
+#, python-format
+msgid "Continue <a href=\"%(url)s\" class=\"pending-action-link\" data-action=\"%(raw_action)s\"><strong>%(action)s</strong> <em>%(name)s</em></a>"
+msgstr ""
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "eBook?"
+msgstr "E-book?"
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "First published"
+msgstr "Pierwsza publikacja"
+
+#: openlibrary/plugins/worksearch/code.py
+msgid "Classic eBooks"
+msgstr "Kasyczne e-booki"
 
 #~ msgid "Only letters and numbers, please, and at least 3 characters."
 #~ msgstr "Proszę używać tylko liter i liczb, minimum 3 znaki."
@@ -4092,28 +8777,16 @@ msgstr "Przejdź na WorldCat, by znaleźć najbliższa bibliotekę z tym wydanie
 #~ msgid "Reading Lists"
 #~ msgstr "Listy lektur"
 
-#~ msgid ""
-#~ "Last edited by <a href=\"$author.key\" "
-#~ "rel=\"nofollow\">%(authorname)s</a>"
-#~ msgstr ""
-#~ "Ostatnio edytowane przez <a "
-#~ "href=\"$author.key\" rel=\"nofollow\">%(authorname)s</a>"
+#~ msgid "Last edited by <a href=\"$author.key\" rel=\"nofollow\">%(authorname)s</a>"
+#~ msgstr "Ostatnio edytowane przez <a href=\"$author.key\" rel=\"nofollow\">%(authorname)s</a>"
 
 #~ msgid "Add another edition of"
 #~ msgstr "Dodaj kolejne wydanie"
 
-#~ msgid ""
-#~ "There's no description for this book "
-#~ "yet. Can you <b><a href='%s'>add "
-#~ "one</a></b>?"
-#~ msgstr ""
-#~ "Ta książka nie ma jeszcze opisu. "
-#~ "Czy możesz <b><a href='%s'>dodać opis</a></b>?"
+#~ msgid "There's no description for this book yet. Can you <b><a href='%s'>add one</a></b>?"
+#~ msgstr "Ta książka nie ma jeszcze opisu. Czy możesz <b><a href='%s'>dodać opis</a></b>?"
 
-#~ msgid ""
-#~ "Only lists with up to %(max)s "
-#~ "editions can be exported. This one "
-#~ "has %s(count)."
+#~ msgid "Only lists with up to %(max)s editions can be exported. This one has %s(count)."
 #~ msgstr ""
 
 #~ msgid "First published in %s"
@@ -4156,4 +8829,424 @@ msgstr "Przejdź na WorldCat, by znaleźć najbliższa bibliotekę z tym wydanie
 #~ msgid_plural "%s editions"
 #~ msgstr[0] "%s wydanie"
 #~ msgstr[1] "%s wydań"
+
+#~ msgid "We've sent the verification email to %(email)s. You'll need to read that and click on the verification link to verify your email."
+#~ msgstr "Wysłaliśmy potwierdzenie na adres %(email)s. Przeczytaj je i kliknij zamieszczony link, by potwierdzić swój e-mail."
+
+#~ msgid "Email address is already used."
+#~ msgstr "Ten e-mail jest już w użyciu."
+
+#~ msgid "Your email address couldn't be updated. The specified email address is already used."
+#~ msgstr "Twój e-mail nie został zaktualizowany. Podany e-mail jest już w użyciu."
+
+#~ msgid "Email verification successful."
+#~ msgstr "Twój e-mail został zweryfikowany."
+
+#~ msgid "Your email address has been successfully verified and updated in your account."
+#~ msgstr "Twój e-mail został zweryfikowany i zaktualizowany na Twoimkoncie."
+
+#~ msgid "Your email address couldn't be verified. The verification link seems invalid."
+#~ msgstr "Twój e-mail nie mógł zostać zweryfikowany. Link weryfikacyjny jest nieważny."
+
+#~ msgid "Choose a screen name"
+#~ msgstr "Wybierz nick"
+
+#~ msgid "Letters and numbers only please, and at least 3 characters."
+#~ msgstr "Proszę używać tylko liter i liczb, minimum 3 znaki."
+
+#~ msgid "Confirm password"
+#~ msgstr "Potwierdź hasło"
+
+#~ msgid "Send me a monthly newsletter from the <a href=\"https://archive.org/\">Internet Archive</a>, the non-profit that runs Open Library"
+#~ msgstr ""
+
+#~ msgid "Websites"
+#~ msgstr "Strony internetowe"
+
+#~ msgid "Deprecated"
+#~ msgstr "Przestarzałe"
+
+#~ msgid "Showing all works by author. Would you like to see <a href=\"%(url)s\">only ebooks</a>?"
+#~ msgstr "Wczytywanie wszystkich prac autora. Czy chesz zobaczyć <a href=\"%(url)s\">tylko e-booki</a>?"
+
+#~ msgid "<a href=\"%(url)s\"><strong>1 edition</strong></a> of <strong class=\"booktitle\">%(title)s</strong> found in the catalog."
+#~ msgid_plural "<a href=\"%(url)s\"><strong>%(count)d editions</strong></a> of <strong class=\"booktitle\">%(title)s</strong> found in the catalog."
+#~ msgstr[0] "<a href=\"%(url)s\"><strong>1 wydanie</strong></a><strong class=\"booktitle\">%(title)s</strong> w tym katalogu."
+#~ msgstr[1] "<a href=\"%(url)s\"><strong>%(count)d wydania</strong></a><strong class=\"booktitle\">%(title)s</strong> w tym katalogu."
+
+#~ msgid "Search for subjects about %(place)s"
+#~ msgstr "Szukaj tematów związanych z"
+
+#~ msgid "This book was generously donated by %(donor)s"
+#~ msgstr ""
+
+#~ msgid "This book was generously donated anonymously"
+#~ msgstr "Ten dokument był ostatnio edytowany anonimowo"
+
+#~ msgid "Learn more about Book Sponsorship"
+#~ msgstr ""
+
+#~ msgid "Label"
+#~ msgstr "miejsce"
+
+#~ msgid "- 1 work"
+#~ msgid_plural "- %(count)s works"
+#~ msgstr[0] "1 praca"
+#~ msgstr[1] "%(count)d prace"
+
+#~ msgid "You are about the remove the last item in the list. That will delete the whole list. Are you sure you want to continue?"
+#~ msgstr ""
+
+#~ msgid "Download DAISY eBook for print disabled"
+#~ msgstr ""
+
+#~ msgid "Last updated <span>%(date)s</span>"
+#~ msgstr ""
+
+#~ msgid "Merge editions"
+#~ msgstr "Połącz wydania"
+
+#~ msgid "Subjects: %(subjectlist)s"
+#~ msgstr "Tematyka: %(subjectlist)s"
+
+#~ msgid "People: %(peoplelist)s"
+#~ msgstr "Ludzie: %(peoplelist)s"
+
+#~ msgid "Times: %(timelist)s"
+#~ msgstr "Okres: %(timelist)s"
+
+#~ msgid "Go to the editions section to read or download ebooks."
+#~ msgstr "Przejdź do sekcji wydań by przeczytać lub pobrać e-booki"
+
+#~ msgid "Dewey"
+#~ msgstr "Dewey"
+
+#~ msgid "Sponsorships"
+#~ msgstr "Sponsoring"
+
+#~ msgid "Books %(userdisplayname)s is sponsoring"
+#~ msgstr "Książki sponsorowane przez %(userdisplayname)s"
+
+#~ msgid "Your reading log is currently set to public"
+#~ msgstr "Twój dziennik lektur jest obecnie udostępiniony publicznie"
+
+#~ msgid "Your reading log is currently set to private"
+#~ msgstr "Twój dziennik lektur jest obecnie niewidoczny dla innych"
+
+#~ msgid "You have 5 ebooks out at the moment. That's the limit! You can free up slots by returning books early."
+#~ msgstr "Obecnie masz 5 ebooków. To maksymalna dozwolona ilość! Możesz wypożyczyć więcej e-booków kiedy zwrócisz obecnie wypożyczone."
+
+#~ msgid "How To Return eBooks through Adobe Digital Editions"
+#~ msgstr ""
+
+#~ msgid "Open Adobe Digital Editions"
+#~ msgstr "Pobierz Adobe Digital Editions"
+
+#~ msgid "Click the Library icon at the upper left corner"
+#~ msgstr ""
+
+#~ msgid "Move your mouse over the cover of the eBook you wish to return"
+#~ msgstr ""
+
+#~ msgid "Find the arrow at the upper left of the cover and open the eBook menu"
+#~ msgstr ""
+
+#~ msgid "Click \"Return Borrowed Item\""
+#~ msgstr ""
+
+#~ msgid "Click \"Return\" to confirm"
+#~ msgstr ""
+
+#~ msgid "Done!"
+#~ msgstr "Dodaj"
+
+#~ msgid "1 book"
+#~ msgid_plural "%(count)d books"
+#~ msgstr[0] "1 książka"
+#~ msgstr[1] "%(count)s książek"
+
+#~ msgid "There are 2 different sources for borrowing books through Open Library:"
+#~ msgstr "Istnieją 2 źródła, z których możesz wypożyczyć książki przez Opne Library"
+
+#~ msgid "The <a href=\"//archive.org/\">Internet Archive</a> and several partner libraries are offering thousands of eBooks for loan to anyone with an Open Library account, anywhere in the world."
+#~ msgstr "<a href=\"//archive.org/\">Internet Archive</a> oraz inne partnerskie biblioteki oferują tysiące e-booków użytkownikom na całym świecie, którzy posiadają konto na Open Library."
+
+#~ msgid "physical books from your local library"
+#~ msgstr "Papierowe wydania książek z Twojej lokalnej biblioteki"
+
+#~ msgid "We connect our records to WorldCat wherever possible. You can tell WorldCat your postcode/zip code, and it will tell you the closest library with a copy of the book."
+#~ msgstr "Na bieżąco udostępiniamy nasze kroniki dla WorldCat. Na WorldCatmożesz podać swój kod pocztowy i wyszukać najbliższą bibliotekę, z kopią wybranej książki."
+
+#~ msgid "Getting Started"
+#~ msgstr "Zaczynamy"
+
+#~ msgid "All you need to borrow a book scanned at the Internet Archive is an Open Library account and Adobe Digital Editions."
+#~ msgstr "Aby wypożyczyć zeskanowaną książkę z Internet Archive potrzebujesz jedynie konta na Open Library oraz Adobe Digital Editions."
+
+#~ msgid "Loans through WorldCat are managed through your local libraries, not through Open Library."
+#~ msgstr "Wypożyczenia dokonane za pomocą WorldCat są zarządzane przez lokalne biblioteki, nie przez Open Library."
+
+#~ msgid "Check out the <a href=\"/help/faq#section-borrowing\"><strong>Lending FAQ</strong></a> for more information."
+#~ msgstr "Więcej informacji znajdziesz na <a href=\"/help/faq#section-borrowing\"><strong>Wypożyczanie FAQ</strong></a>."
+
+#~ msgid "Which books are available?"
+#~ msgstr "Które książki są dostępne?"
+
+#~ msgid "Browse all the available books through the <a href=\"/subjects/lending_library\">\"Lending Library\"</a> subject, or try a <a href=\"/search?subject_facet=Lending%20library\">search</a>."
+#~ msgstr "Przeszukaj wszystkie dostępne książki z<a href=\"/subjects/lending_library\">\"Wypożyczalni\"</a> o danej tematyce, lub wypróbuj <a href=\"/search?subject_facet=Lending%20library\">wyszukiwarkę</a>."
+
+#~ msgid "Help/Downloads"
+#~ msgstr "Pomoc/Pobrane"
+
+#~ msgid "Download Adobe Digital Editions"
+#~ msgstr "Pobierz Adobe Digital Editions"
+
+#~ msgid "<a href=\"http://www.adobe.com/products/digitaleditions/help/\">Help</a> on adobe.com"
+#~ msgstr "<a href=\"http://www.adobe.com/products/digitaleditions/help/\">Pomoc</a> na adobe.com"
+
+#~ msgid "If you work at a library and are interested to find out more about lending ebooks through Open Library, please <a href=\"/contact\">get in touch with us</a>!"
+#~ msgstr "Jeśli jesteś pracownikiem biblioteki i chcesz wiedzieć więcej o wypożyczaniu książek przez Open Library, <a href=\"/contact\">skontaktuj się z nami</a>!"
+
+#~ msgid "Complete the form below to create a new Internet Archive account."
+#~ msgstr "Wypełnij poniższy formularz, aby utworzyć konto na Internet Archive."
+
+#~ msgid "Each field is required"
+#~ msgstr "Wszystkie pola są wymagane"
+
+#~ msgid "Your URL: %s"
+#~ msgstr ""
+
+#~ msgid "Forgot Your Open Library Email?"
+#~ msgstr "Nie pamiętasz swojego adresu e-mail na Open Library?"
+
+#~ msgid "Forgot your Archive.org password?"
+#~ msgstr "Nie pamiętasz swojego hasła na Archive.org?"
+
+#~ msgid "The year it was published is plenty."
+#~ msgstr "Wystarczy podanie roku publikacji tego wydania."
+
+#~ msgid "Since you are not logged in, please satisfy the reCAPTCHA below."
+#~ msgstr "Poniważ nie jesteś zalogowana, prosimy o uzupełnienie reCAPTCHA poniżej."
+
+#~ msgid "Sponsor"
+#~ msgstr "Zasponsoruj"
+
+#~ msgid "What's It About?"
+#~ msgstr "O czym jest ta książka?"
+
+#~ msgid "Delete this book?"
+#~ msgstr "Usunąć tę książkę?"
+
+#~ msgid "Libraries near you:"
+#~ msgstr "Biblioteki w Twoim pobliżu"
+
+#~ msgid "Add a New Contributor Role"
+#~ msgstr "Dodaj nowego wspołtwórcę"
+
+#~ msgid "What should we show in the menu?"
+#~ msgstr "Co powinno znajdować się w menu?"
+
+#~ msgid "Add a New Type of Identifier"
+#~ msgstr "Dodaj nowy rodzaj identyfikacji"
+
+#~ msgid "If the system has a website, what's the homepage?"
+#~ msgstr "Jeśli system ma stronę interentową, jaki jest jej główny adres?"
+
+#~ msgid "Please leave a note: Why is this ID useful?"
+#~ msgstr "Prosimy o uwagi: Dlaczego ten numer identyfikacyjny jest przydatny?"
+
+#~ msgid "Add a New Classification System"
+#~ msgstr "Dodaj nowy system klasyfikacji"
+
+#~ msgid "Please leave a note: Why is this classification useful?"
+#~ msgstr "Prosimy o uwagi: Dlaczego ten rodzaj kasyfikacji jest przydatny?"
+
+#~ msgid "Can you direct us to more information about this classification system online?"
+#~ msgstr "Prosimy o podanie elektronicznego źródła informacji o tym systemie klasyfikacji."
+
+#~ msgid "You can search by title or by Open Library ID (like"
+#~ msgstr "Możesz wyszukać przez tytuł lub przez ID z Open Library (like"
+
+#~ msgid "is an alternate title for"
+#~ msgstr "jest alternatywnym tytułem dla"
+
+#~ msgid "Does this edition have a specific name?"
+#~ msgstr "Czy te wydanie ma specyficzną nazwę?"
+
+#~ msgid "There are three ways to get a cover image on Open Library"
+#~ msgstr "Istnieją trzy sposoby na dodawnania zdjęć okładki na Open Library."
+
+#~ msgid "Or, paste in the image URL if it's on the web."
+#~ msgstr "Lub wklej URL obrazu z adresu internetowego."
+
+#~ msgid "One sec, we're searching for covers..."
+#~ msgstr "Chwileczkę, szukamy okładek..."
+
+#~ msgid "Imported from %(source)s  <a href=\"%(url)s\">%(type)s record</a>."
+#~ msgstr ""
+
+#~ msgid "Found a <a href=\"%(url)s\">matching record</a> from %(source)s."
+#~ msgstr ""
+
+#~ msgid "1 Book"
+#~ msgid_plural "%(count)s Books"
+#~ msgstr[0] "1 książka"
+#~ msgstr[1] "%(count)s książek"
+
+#~ msgid "1 revision"
+#~ msgid_plural "%(count)d revisions"
+#~ msgstr[0] "1 korekta"
+#~ msgstr[1] "%(count)d korekty"
+
+#~ msgid "We use a system called Markdown to format the text in your edits on Open Library. Some HTML formatting is also accepted. Paragraphs are automatically generated from any hard-break returns (blank lines) within your text. You can preview your work in real time below the editing field."
+#~ msgstr "Używamy systemu Markdown do formatowania tekstu w Twoich edycjach w Open Library. Niektóre formatowanie HTML jest również akceptowane. Akapity są automatycznie generowane na podstawie zwrotów typu hard-break (puste linie) w Twoim tekscie. Możesz wyświetlić podgląd swojej pracy w czasie rzeczywistym poniżej pola edycji."
+
+#~ msgid "Formatting marks should envelope the effected text, for example:"
+#~ msgstr "Znaki formatujące powinny otaczać utworzony tekst, na przykład:"
+
+#~ msgid "To \"escape\" any Markdown tags (i.e. use an asterisk as an asterisk rather than emphasizing text) place a backslash \\ prior to the character."
+#~ msgstr "Aby \"uciec\" tagom Markdown (tj. użyć gwiazdki jako gwiazdki zamiast podkreślenia tekstu) umieść ukośnik \\ przed tym znakiem."
+
+#~ msgid "Log in"
+#~ msgstr "Zaloguj się"
+
+#~ msgid "Sign up"
+#~ msgstr "Utwórz konto"
+
+#~ msgid "Advanced"
+#~ msgstr "Zaawansowane"
+
+#~ msgid "Russian"
+#~ msgstr "Rosyjski"
+
+#~ msgid "Japanese"
+#~ msgstr "Japoński"
+
+#~ msgid "Polish"
+#~ msgstr "Polski"
+
+#~ msgid "Only eBooks"
+#~ msgstr "tylko e-booki"
+
+#~ msgid "No lists yet!"
+#~ msgstr "Na razie brak list!"
+
+#~ msgid "watch for edits or export all records"
+#~ msgstr "obserwuj zmiany lub eksportuj wszystkie kroniki"
+
+#~ msgid "Select a \"master\" record that best represents the author -"
+#~ msgstr "ybierz \"główny\" dokument, który najlepiej reprezentuje tego autora -"
+
+#~ msgid "Master"
+#~ msgstr "Dokument główny"
+
+#~ msgid "Merge Preview"
+#~ msgstr ""
+
+#~ msgid "Please review the merged values before saving."
+#~ msgstr ""
+
+#~ msgid "Merge History"
+#~ msgstr "Połącz historię"
+
+#~ msgid "1 ebook"
+#~ msgid_plural "%(count)s ebooks"
+#~ msgstr[0] "1 książka"
+#~ msgstr[1] "%(count)s książek"
+
+#~ msgid "1 hit"
+#~ msgid_plural "%(count)s hits"
+#~ msgstr[0] "1 wynik"
+#~ msgstr[1] "%(count)s wyników"
+
+#~ msgid "No hits"
+#~ msgstr "Brak wyników"
+
+#~ msgid "No hits for: %(query)s"
+#~ msgstr "Brak wyników dla: %(query)s"
+
+#~ msgid "About 1 result found in %(seconds)s"
+#~ msgid_plural "About %(count)s results found in %(seconds)s"
+#~ msgstr[0] "Znaleziono około 1 wynik w %(seconds)s"
+#~ msgstr[1] "Znaleziono około %(count)s wyników w %(seconds)s"
+
+#~ msgid "<strong>Together</strong>, let's build an Open Library for the World."
+#~ msgstr "<strong>Razem</strong>, zbudujmy Open Library dla całego świata."
+
+#~ msgid "Internet Archive Announcements"
+#~ msgstr "Internet Archive"
+
+#~ msgid "Your Privacy Settings"
+#~ msgstr "Twoje ustawienia prywatności"
+
+#~ msgid "Sorry. There seems to be a problem with what you were just looking at."
+#~ msgstr "Przepraszamy. Wygląda na to, że jest problem z wyświetleniem treści."
+
+#~ msgid "We've noted the error %s and will look into it as soon as possible. Head for <a href=\"/\">home</a>?"
+#~ msgstr "Zauważyliśmy błąd %s i sprawdzimy go jak najszybciej. Przejść do <a href=\"/\">home</a>?"
+
+#~ msgid "Join waitlist for &quot;%(title)s&quot;"
+#~ msgstr ""
+
+#~ msgid "Learn more about &quot;%(title)s&quot; at OpenLibrary"
+#~ msgstr ""
+
+#~ msgid "on "
+#~ msgstr ""
+
+#~ msgid "Classic eBook"
+#~ msgstr "Klasyczny e-book"
+
+#~ msgid "Explore Classic eBooks"
+#~ msgstr "Przeglądaj klasyczne e-booki"
+
+#~ msgid "Explore books about %(subject)s"
+#~ msgstr "o %(subjects)s"
+
+#~ msgid "Written in"
+#~ msgstr "Napisane w"
+
+#~ msgid "Showing books with similar text to: <strong>%(query)s</strong>"
+#~ msgstr "Książki zawierające tekst podobny do: <strong>%(query)s</strong>"
+
+#~ msgid "You're <strong>next</strong> in line"
+#~ msgstr "Jesteś <strong> następny </strong> na liście oczekujących"
+
+#~ msgid "There is <strong>#1</strong> reader ahead of you"
+#~ msgid_plural "There are <strong>#%(count)d</strong> readers ahead of you"
+#~ msgstr[0] ""
+#~ msgstr[1] ""
+
+#~ msgid "Be first in line!"
+#~ msgstr ""
+
+#~ msgid "Print-disabled access available"
+#~ msgstr ""
+
+#~ msgid "See more about this book on Archive.org"
+#~ msgstr ""
+
+#~ msgid "(Optional, but very useful!)"
+#~ msgstr "(Opcjonalne, ale bardzo pomocne!)"
+
+#~ msgid "<em>Please Note:</em> Only Admins can delete things. <a href=\"/contact\" class=\"blue\">Let us know</a> if there's a problem."
+#~ msgstr "<em>Uwaga:</em> Tylko administratorzy mogą usuwać elementy. <a href=\"/contact\" class=\"blue\">Daj nam znać</a> jeśli wystąpił problem."
+
+#~ msgid "Readers waiting for this title: %(count)d"
+#~ msgstr ""
+
+#~ msgid "Sponsor eBook"
+#~ msgstr "%s e-book"
+
+#~ msgid "We don’t have this book yet. You can add it to our Lending Library with a %(price)s tax deductible donation."
+#~ msgstr ""
+
+#~ msgid "First"
+#~ msgstr "Pierwszy"
+
+#~ msgid "- first published in %(year)s"
+#~ msgstr "- po raz pierwszy opublikowany w %(year)s"
+
+#~ msgid "Share this book"
+#~ msgstr "Udostępnij tę książkę"
 

--- a/openlibrary/i18n/pl/messages.po
+++ b/openlibrary/i18n/pl/messages.po
@@ -7751,7 +7751,7 @@ msgstr "Wypożycz teraz"
 
 #: DisplayCode.html
 msgid "Templates in the website are disabled now. Editing them will not have any effect on the live website."
-msgstr ""
+msgstr "Szablony na stronie są teraz wyłączone. Ich edytowanie nie będzie miało żadnego wpływu na działającą stronę."
 
 #: EditionNavBar.html
 msgid "Go to previous section"
@@ -8700,11 +8700,11 @@ msgstr "Nie można zwrócić %s. Spróbuj ponownie później lub skontaktuj się
 #: openlibrary/plugins/upstream/borrow.py
 #, python-format
 msgid "%s has been returned."
-msgstr ""
+msgstr "%s zostało zwrócone."
 
 #: openlibrary/plugins/upstream/borrow.py
 msgid "Your account has hit a lending limit. Please try again later or contact info@archive.org."
-msgstr ""
+msgstr "Twoje konto osiągnęło limit wypożyczeń. Spróbuj ponownie później lub skontaktuj się z info@archive.org."
 
 #: openlibrary/plugins/upstream/forms.py
 msgid "Username"
@@ -8737,7 +8737,7 @@ msgstr "Nazwa użytkownika"
 
 #: openlibrary/plugins/upstream/forms.py
 msgid "Public and cannot be changed later."
-msgstr ""
+msgstr "Publiczny i nie można tego później zmienić."
 
 #: openlibrary/plugins/upstream/forms.py
 msgid "Invalid password"
@@ -8754,7 +8754,7 @@ msgstr "Wybierz hasło"
 #: openlibrary/plugins/upstream/mybooks.py
 #, python-format
 msgid "Continue <a href=\"%(url)s\" class=\"pending-action-link\" data-action=\"%(raw_action)s\"><strong>%(action)s</strong> <em>%(name)s</em></a>"
-msgstr ""
+msgstr "Kontynuuj <a href=\"%(url)s\" class=\"pending-action-link\" data-action=\"%(raw_action)s\"><strong>%(action)s</strong> <em>%(name)s</em></a>"
 
 #: openlibrary/plugins/worksearch/code.py
 msgid "eBook?"

--- a/openlibrary/i18n/pl/messages.po
+++ b/openlibrary/i18n/pl/messages.po
@@ -2322,7 +2322,7 @@ msgstr "Opis"
 
 #: admin/index.html
 msgid "New Accounts Per Day"
-msgstr ""
+msgstr "Nowe konta dziennie"
 
 #: admin/index.html
 #, fuzzy
@@ -2356,7 +2356,7 @@ msgstr "Autorzy"
 
 #: admin/index.html recentchanges/index.html
 msgid "Covers Added"
-msgstr ""
+msgstr "Dodane okładki"
 
 #: admin/index.html home/stats.html
 msgid "New Members"
@@ -2374,7 +2374,7 @@ msgstr "Książki, które kochamy"
 
 #: admin/index.html
 msgid "Users Logging"
-msgstr ""
+msgstr "Użytkownicy logujący się"
 
 #: admin/index.html
 #, fuzzy
@@ -2383,7 +2383,7 @@ msgstr "Moje listy lektur:"
 
 #: admin/index.html
 msgid "Books Review Tags"
-msgstr ""
+msgstr "Tagi recenzji książek"
 
 #: admin/index.html
 #, fuzzy
@@ -2392,11 +2392,11 @@ msgstr "e-Booki wszędzie"
 
 #: admin/index.html
 msgid "Users Reviewing"
-msgstr ""
+msgstr "Użytkownicy recenzujący"
 
 #: admin/index.html
 msgid "Patrons Following"
-msgstr ""
+msgstr "Obserwujący użytkownicy"
 
 #: admin/index.html
 #, fuzzy
@@ -2414,7 +2414,7 @@ msgstr "Wypożyczone e-booki"
 
 #: admin/index.html
 msgid "Star Rating Patrons"
-msgstr ""
+msgstr "Użytkownicy oceniający gwiazdkami"
 
 #: admin/index.html home/stats.html
 msgid "Unique Visitors"
@@ -2432,11 +2432,11 @@ msgstr "Wypożycz"
 
 #: admin/index.html
 msgid "Borrows, last 3 months graph"
-msgstr ""
+msgstr "Wykres wypożyczeń z ostatnich 3 miesięcy"
 
 #: admin/index.html
 msgid "Borrows, last 2 years graph"
-msgstr ""
+msgstr "Wykres wypożyczeń z ostatnich 2 lat"
 
 #: admin/index.html
 #, fuzzy
@@ -2445,19 +2445,19 @@ msgstr "Szczególni odwiedzający"
 
 #: admin/index.html
 msgid "Gathering login statistics..."
-msgstr ""
+msgstr "Zbieranie statystyk logowania..."
 
 #: admin/loans_table.html
 msgid "BookReader"
-msgstr ""
+msgstr "BookReader"
 
 #: admin/loans_table.html book_providers/cita_press_download_options.html book_providers/ia_download_options.html book_providers/openstax_download_options.html book_providers/wikisource_download_options.html books/edit/edition.html
 msgid "PDF"
-msgstr ""
+msgstr "PDF"
 
 #: admin/loans_table.html book_providers/gutenberg_download_options.html book_providers/ia_download_options.html book_providers/standard_ebooks_download_options.html books/edit/edition.html
 msgid "ePub"
-msgstr ""
+msgstr "ePub"
 
 #: admin/loans_table.html
 #, fuzzy
@@ -2468,8 +2468,8 @@ msgstr "1 obecnie wypożyczona"
 #, python-format
 msgid "%d Current Loan"
 msgid_plural "%d Current Loans"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d aktualne wypożyczenie"
+msgstr[1] "%d aktualne wypożyczenia"
 
 #: RecentChanges.html RecentChangesUsers.html admin/ip/view.html admin/loans_table.html admin/people/edits.html recentchanges/render.html recentchanges/updated_records.html
 msgid "What"
@@ -2483,7 +2483,7 @@ msgstr "Dołączył\\(a\\) %(date)s"
 #: admin/loans_table.html
 #, python-format
 msgid "#%(num_position)d among %(num_waitlist)d people waiting for this book"
-msgstr ""
+msgstr "#%(num_position)d spośród %(num_waitlist)d osób oczekujących na tę książkę"
 
 #: ManageLoansButtons.html admin/loans_table.html
 #, fuzzy, python-format
@@ -2501,11 +2501,11 @@ msgstr "Ludzie"
 
 #: admin/menu.html
 msgid "PD Access Requests"
-msgstr ""
+msgstr "Wnioski o dostęp PD"
 
 #: admin/menu.html
 msgid "Block IPs"
-msgstr ""
+msgstr "Blokuj adresy IP"
 
 #: admin/menu.html admin/spamwords.html
 #, fuzzy
@@ -2519,11 +2519,11 @@ msgstr "lub"
 
 #: admin/menu.html
 msgid "Graphs"
-msgstr ""
+msgstr "Wykresy"
 
 #: admin/menu.html
 msgid "Inspect store"
-msgstr ""
+msgstr "Inspekcja magazynu"
 
 #: admin/menu.html
 #, fuzzy
@@ -2532,15 +2532,15 @@ msgstr "Wyszukiwanie tematu"
 
 #: admin/pd_dashboard.html
 msgid "Print Disability Access Requests"
-msgstr ""
+msgstr "Wnioski o dostęp dla osób z niepełnosprawnością druku"
 
 #: admin/pd_dashboard.html
 msgid "Breakdown by Qualifying Authority"
-msgstr ""
+msgstr "Podział według kwalifikującej instytucji"
 
 #: admin/pd_dashboard.html
 msgid "PDA"
-msgstr ""
+msgstr "PDA"
 
 #: admin/pd_dashboard.html
 #, fuzzy
@@ -2549,15 +2549,15 @@ msgstr "E-mail"
 
 #: admin/pd_dashboard.html
 msgid "Fulfilled"
-msgstr ""
+msgstr "Zrealizowane"
 
 #: admin/pd_dashboard.html
 msgid "Totals"
-msgstr ""
+msgstr "Sumy"
 
 #: admin/permissions.html
 msgid "[Admin Center] Site Permissions"
-msgstr ""
+msgstr "[Centrum administracyjne] Uprawnienia witryny"
 
 #: admin/permissions.html
 #, fuzzy
@@ -2566,7 +2566,7 @@ msgstr "brakuje imienia"
 
 #: admin/permissions.html
 msgid "Change the policy of who can edit the site."
-msgstr ""
+msgstr "Zmień politykę dotyczącą tego, kto może edytować witrynę."
 
 #: admin/permissions.html
 #, fuzzy
@@ -2575,7 +2575,7 @@ msgstr "Ilu nowych użytkowników Open Library powitaliśmy?"
 
 #: admin/permissions.html
 msgid "This applies to /authors/*, /books/* and /works/* records."
-msgstr ""
+msgstr "Dotyczy to rekordów /authors/*, /books/* i /works/*."
 
 #: admin/permissions.html
 #, fuzzy
@@ -2584,7 +2584,7 @@ msgstr "Open Library"
 
 #: admin/permissions.html
 msgid "This applies to /about/*, /help/*, /dev/*, /docs/* etc."
-msgstr ""
+msgstr "Dotyczy to /about/*, /help/*, /dev/*, /docs/* itd."
 
 #: admin/permissions.html
 #, fuzzy
@@ -2593,15 +2593,15 @@ msgstr "Zaktualizuj adres e-mail"
 
 #: admin/permissions.html
 msgid "This updates \"permission\" and \"child_permission\" fields of /, /works, /books and /authors records in the database."
-msgstr ""
+msgstr "Aktualizuje to pola \"permission\" i \"child_permission\" rekordów /, /works, /books i /authors w bazie danych."
 
 #: admin/solr.html
 msgid "Solr Admin"
-msgstr ""
+msgstr "Administrator Solr"
 
 #: admin/solr.html
 msgid "Enter the keys of pages to be updated in OL search engine."
-msgstr ""
+msgstr "Wprowadź klucze stron, które mają zostać zaktualizowane w wyszukiwarce OL."
 
 #: admin/solr.html
 #, fuzzy
@@ -2610,31 +2610,31 @@ msgstr "Na przykład:"
 
 #: admin/solr.html
 msgid "On update, these keys will be added to solr update queue and it'll take about 15 minutes for them to get reindexed in Solr."
-msgstr ""
+msgstr "Po aktualizacji te klucze zostaną dodane do kolejki aktualizacji solr i ponowne indeksowanie w Solr zajmie około 15 minut."
 
 #: admin/solr.html
 msgid "Enter the keys to reindex in Solr"
-msgstr ""
+msgstr "Wprowadź klucze do ponownego zaindeksowania w Solr"
 
 #: admin/solr.html
 msgid "Write one entry per line"
-msgstr ""
+msgstr "Wpisz jeden wpis w wierszu"
 
 #: admin/spamwords.html
 msgid "[Admin Center] Spam Words"
-msgstr ""
+msgstr "[Centrum administracyjne] Słowa spam"
 
 #: admin/spamwords.html
 msgid "Please enter the SPAM regular expressions in the textarea below, one per line."
-msgstr ""
+msgstr "Proszę wprowadzić wyrażenia regularne SPAM w polu tekstowym poniżej, jedno w wierszu."
 
 #: admin/spamwords.html
 msgid "Be sure to escape any meta characters that are meant to be character literals."
-msgstr ""
+msgstr "Pamiętaj, aby eskejpować wszystkie metaznaki, które mają być literałami znakowymi."
 
 #: admin/spamwords.html
 msgid "If you are adding a domain, prepend the following to the domain:"
-msgstr ""
+msgstr "Jeśli dodajesz domenę, poprzedź ją następującym ciągiem:"
 
 #: admin/spamwords.html
 msgid "For example, if you want to prevent edits containing the domain <code>t.co</code>, add <code>(|https://|http://)t\\.co</code> to the spamwords list."
@@ -2647,15 +2647,15 @@ msgstr "Wypożyczone przeze mnie"
 
 #: admin/spamwords.html
 msgid "Please enter domains to blacklist in the textarea below, one per line."
-msgstr ""
+msgstr "Proszę wprowadzić domeny do zablokowania w polu tekstowym poniżej, jedna w wierszu."
 
 #: admin/sync.html
 msgid "Sync"
-msgstr ""
+msgstr "Synchronizuj"
 
 #: admin/sync.html
 msgid "Sync the metadata of various types of Open Library items (e.g. lists, subjects, works) with Archive.org."
-msgstr ""
+msgstr "Synchronizuj metadane różnych typów elementów Open Library (np. listy, tematy, dzieła) z Archive.org."
 
 #: admin/sync.html
 #, fuzzy
@@ -2664,7 +2664,7 @@ msgstr "Dodaj do Wyboranych przez nas"
 
 #: admin/sync.html
 msgid "This utility will add your work to an Open Library list called `Staff Picks` under the `openlibrary` user. It will then take the added work and explode it into a list of all its readable editions. For each Open Library edition, a metadata field called `openlibrary_subject` will be injected into the archive.org metadata of the edition's corresponding archive.org item."
-msgstr ""
+msgstr "To narzędzie doda Twoje dzieło do listy Open Library o nazwie `Staff Picks` pod użytkownikiem `openlibrary`. Następnie weźmie dodane dzieło i rozwinie je na listę wszystkich czytelnych wydań. Dla każdego wydania Open Library pole metadanych o nazwie `openlibrary_subject` zostanie wstrzyknięte do metadanych archive.org odpowiadającego elementu archive.org."
 
 #: admin/sync.html
 #, fuzzy
@@ -2683,15 +2683,15 @@ msgstr "O tym wydaniu"
 
 #: admin/sync.html
 msgid "Updates an edition on archive.org by writing in its latest  openlibrary_edition and openlibrary_work identifier values"
-msgstr ""
+msgstr "Aktualizuje wydanie na archive.org, zapisując najnowsze wartości identyfikatorów openlibrary_edition i openlibrary_work"
 
 #: admin/sync.html
 msgid "TODO"
-msgstr ""
+msgstr "DO ZROBIENIA"
 
 #: admin/inspect/memcache.html
 msgid "[Admin Center] Inspect Memcache"
-msgstr ""
+msgstr "[Centrum administracyjne] Inspekcja Memcache"
 
 #: admin/inspect/memcache.html
 #, fuzzy
@@ -2700,11 +2700,11 @@ msgstr "Wyszukiwanie tematu"
 
 #: admin/inspect/memcache.html
 msgid "Add one memcache key per line in the text area. Each key must include a '-' as the last character."
-msgstr ""
+msgstr "Dodaj jeden klucz memcache w wierszu w polu tekstowym. Każdy klucz musi zawierać '-' jako ostatni znak."
 
 #: admin/inspect/memcache.html
 msgid "For example, <code>observations-</code> should be entered in the text area if the key is <code>observations</code>."
-msgstr ""
+msgstr "Na przykład, <code>observations-</code> należy wprowadzić w polu tekstowym, jeśli klucz to <code>observations</code>."
 
 #: admin/inspect/memcache.html
 #, fuzzy
@@ -2728,15 +2728,15 @@ msgstr "Nie znaleziono."
 
 #: admin/inspect/store.html
 msgid "Admin Center / Inspect"
-msgstr ""
+msgstr "Centrum administracyjne / Inspekcja"
 
 #: admin/inspect/store.html
 msgid "Inspect Store"
-msgstr ""
+msgstr "Inspekcja magazynu"
 
 #: admin/inspect/store.html
 msgid "Get"
-msgstr ""
+msgstr "Pobierz"
 
 #: admin/inspect/store.html
 #, fuzzy
@@ -2745,7 +2745,7 @@ msgstr "Słowa kluczowe"
 
 #: admin/inspect/store.html
 msgid "Query"
-msgstr ""
+msgstr "Zapytanie"
 
 #: admin/inspect/store.html
 #, fuzzy
@@ -2773,7 +2773,7 @@ msgstr "Brak wyników."
 
 #: admin/ip/index.html
 msgid "[Admin Center] IP Addresses"
-msgstr ""
+msgstr "[Centrum administracyjne] Adresy IP"
 
 #: admin/ip/index.html
 #, fuzzy
@@ -2782,7 +2782,7 @@ msgstr "Twój adres e-mail"
 
 #: admin/ip/index.html
 msgid "List of Banned IPs"
-msgstr ""
+msgstr "Lista zablokowanych adresów IP"
 
 #: admin/ip/index.html admin/people/index.html
 #, fuzzy
@@ -2806,11 +2806,11 @@ msgstr "Historia zmian"
 
 #: admin/ip/index.html
 msgid "x minutes ago"
-msgstr ""
+msgstr "x minut temu"
 
 #: admin/ip/index.html admin/ip/view.html
 msgid "IP"
-msgstr ""
+msgstr "IP"
 
 #: admin/ip/index.html
 #, fuzzy
@@ -2825,12 +2825,12 @@ msgstr "Centrum Rozwoju"
 #: admin/ip/view.html
 #, python-format
 msgid "IP %(ip)s is <a href=\"/admin/block\">blocked</a>."
-msgstr ""
+msgstr "Adres IP %(ip)s jest <a href=\"/admin/block\">zablokowany</a>."
 
 #: admin/ip/view.html
 #, python-format
 msgid "Block %(ip)s"
-msgstr ""
+msgstr "Zablokuj %(ip)s"
 
 #: admin/ip/view.html admin/people/edits.html
 #, fuzzy
@@ -2839,25 +2839,25 @@ msgstr "Wybierz autorów do połączenia."
 
 #: RecentChanges.html admin/ip/view.html admin/people/edits.html recentchanges/render.html
 msgid "When you see numbers here, that's the IP address of the anonymous editor"
-msgstr ""
+msgstr "Gdy widzisz tu liczby, jest to adres IP anonimowego edytora"
 
 #: admin/ip/view.html admin/people/edits.html
 #, python-format
 msgid "Reverted by %(revert_author)s"
-msgstr ""
+msgstr "Przywrócone przez %(revert_author)s"
 
 #: EditButtons.html admin/ip/view.html admin/people/edits.html
 msgid "Please, leave a short note about what you changed: <span class=\"small gray\">(Optional, but very useful!)</span>"
-msgstr ""
+msgstr "Proszę, zostaw krótką notatkę o tym, co zmieniłeś: <span class=\"small gray\">(Opcjonalnie, ale bardzo przydatne!)</span>"
 
 #: admin/ip/view.html admin/people/edits.html
 msgid "Reverted spam"
-msgstr ""
+msgstr "Cofnięty spam"
 
 #: admin/people/edits.html
 #, python-format
 msgid "[Admin Center] Edits of %(user)s"
-msgstr ""
+msgstr "[Centrum administracyjne] Edycje użytkownika %(user)s"
 
 #: admin/people/edits.html
 #, fuzzy
@@ -2871,7 +2871,7 @@ msgstr "Edytuj"
 
 #: admin/people/index.html
 msgid "[Admin Center] People"
-msgstr ""
+msgstr "[Centrum administracyjne] Użytkownicy"
 
 #: admin/people/index.html
 #, fuzzy
@@ -2895,15 +2895,15 @@ msgstr "Nie istnieje konto z podanym adresem e-mail."
 
 #: admin/people/index.html
 msgid "IA ID:"
-msgstr ""
+msgstr "ID IA:"
 
 #: admin/people/index.html
 msgid "e.g. @foobar"
-msgstr ""
+msgstr "np. @foobar"
 
 #: admin/people/index.html
 msgid "No account found with this ID."
-msgstr ""
+msgstr "Nie znaleziono konta z tym ID."
 
 #: admin/people/index.html
 #, fuzzy
@@ -2927,7 +2927,7 @@ msgstr "Usuń listę"
 
 #: admin/people/view.html
 msgid "block and revert all edits"
-msgstr ""
+msgstr "zablokuj i cofnij wszystkie edycje"
 
 #: admin/people/view.html
 #, fuzzy
@@ -2937,20 +2937,20 @@ msgstr "Usuń konto"
 #: admin/people/view.html
 #, python-format
 msgid "Registered on <span class=\"time\">%(date)s</span>."
-msgstr ""
+msgstr "Zarejestrowany <span class=\"time\">%(date)s</span>."
 
 #: admin/people/view.html
 msgid "login as this user"
-msgstr ""
+msgstr "zaloguj się jako ten użytkownik"
 
 #: admin/people/view.html
 #, python-format
 msgid "Activated on <span class=\"time\">%(date)s</span> from <a href=\"/admin/ip/%(ip)s\">%(ip)s</a>."
-msgstr ""
+msgstr "Aktywowany <span class=\"time\">%(date)s</span> z <a href=\"/admin/ip/%(ip)s\">%(ip)s</a>."
 
 #: admin/people/view.html
 msgid "unblock this account"
-msgstr ""
+msgstr "odblokuj to konto"
 
 #: admin/people/view.html
 #, fuzzy

--- a/openlibrary/i18n/pl/messages.po
+++ b/openlibrary/i18n/pl/messages.po
@@ -2978,7 +2978,7 @@ msgstr "strona administratora"
 
 #: admin/people/view.html
 msgid "Make Human"
-msgstr ""
+msgstr "Oznacz jako człowieka"
 
 #: admin/people/view.html
 #, fuzzy
@@ -2987,7 +2987,7 @@ msgstr "Opis"
 
 #: admin/people/view.html
 msgid "Not available"
-msgstr ""
+msgstr "Niedostępne"
 
 #: admin/people/view.html
 #, fuzzy
@@ -3001,11 +3001,11 @@ msgstr "\"Zapamniętaj mnie"
 
 #: admin/people/view.html
 msgid "Last Login:"
-msgstr ""
+msgstr "Ostatnie logowanie:"
 
 #: admin/people/view.html
 msgid "Tags:"
-msgstr ""
+msgstr "Tagi:"
 
 #: admin/people/view.html
 #, fuzzy
@@ -3014,7 +3014,7 @@ msgstr "Moje konto"
 
 #: admin/people/view.html
 msgid "Dry Run"
-msgstr ""
+msgstr "Próba sucha"
 
 #: admin/people/view.html
 #, fuzzy
@@ -3038,15 +3038,15 @@ msgstr "Pisanie botów"
 #: admin/people/view.html
 #, python-format
 msgid "%(num)d edits"
-msgstr ""
+msgstr "%(num)d edycji"
 
 #: admin/people/view.html
 msgid "Debug Info"
-msgstr ""
+msgstr "Informacje debugowania"
 
 #: admin/people/view.html
 msgid "Account Information"
-msgstr ""
+msgstr "Informacje o koncie"
 
 #: admin/people/view.html
 #, fuzzy
@@ -3064,7 +3064,7 @@ msgstr "Autorzy"
 
 #: authors/index.html
 msgid "Search for an Author"
-msgstr ""
+msgstr "Wyszukaj autora"
 
 #: authors/index.html lib/nav_head.html lists/home.html publishers/index.html publishers/notfound.html publishers/view.html search/advancedsearch.html search/publishers.html search/search_modal_i18n.html search/searchbox.html type/local_id/view.html
 msgid "Search"
@@ -3083,7 +3083,7 @@ msgstr "włączając <i>%(topwork)s</i>"
 #: authors/infobox.html
 #, python-format
 msgid "View on %(site)s"
-msgstr ""
+msgstr "Wyświetl na %(site)s"
 
 #: authors/infobox.html
 #, fuzzy
@@ -3107,15 +3107,15 @@ msgstr "Przeczytaj e-book z Internet Archive"
 
 #: book_providers/cita_press_download_options.html
 msgid "More at Cita Press"
-msgstr ""
+msgstr "Więcej na Cita Press"
 
 #: book_providers/gutenberg_download_options.html
 msgid "Download an HTML from Project Gutenberg"
-msgstr ""
+msgstr "Pobierz HTML z Project Gutenberg"
 
 #: book_providers/gutenberg_download_options.html book_providers/runeberg_download_options.html book_providers/standard_ebooks_download_options.html type/list/exports.html
 msgid "HTML"
-msgstr ""
+msgstr "HTML"
 
 #: book_providers/gutenberg_download_options.html
 #, fuzzy
@@ -3124,7 +3124,7 @@ msgstr "Przeczytaj e-book z Internet Archive"
 
 #: book_providers/gutenberg_download_options.html book_providers/ia_download_options.html
 msgid "Plain text"
-msgstr ""
+msgstr "Zwykły tekst"
 
 #: book_providers/gutenberg_download_options.html
 #, fuzzy
@@ -3133,7 +3133,7 @@ msgstr "Przeczytaj e-book z Internet Archive"
 
 #: book_providers/gutenberg_download_options.html
 msgid "Download a Kindle file from Project Gutenberg"
-msgstr ""
+msgstr "Pobierz plik Kindle z Project Gutenberg"
 
 #: book_providers/gutenberg_download_options.html
 #, fuzzy
@@ -3142,7 +3142,7 @@ msgstr "Książki dla dzieci"
 
 #: book_providers/gutenberg_download_options.html
 msgid "More at Project Gutenberg"
-msgstr ""
+msgstr "Więcej na Project Gutenberg"
 
 #: book_providers/ia_download_options.html
 #, fuzzy
@@ -3166,15 +3166,15 @@ msgstr "Przeczytaj e-book z Internet Archive"
 
 #: book_providers/ia_download_options.html
 msgid "MOBI"
-msgstr ""
+msgstr "MOBI"
 
 #: book_providers/ia_download_options.html
 msgid "Download open DAISY from Internet Archive (print-disabled format)"
-msgstr ""
+msgstr "Pobierz otwarty DAISY z Internet Archive (format dla osób z niepełnosprawnością druku)"
 
 #: book_providers/ia_download_options.html type/list/embed.html
 msgid "DAISY"
-msgstr ""
+msgstr "DAISY"
 
 #: book_providers/librivox_download_options.html
 #, fuzzy
@@ -3183,19 +3183,19 @@ msgstr "Przeczytaj e-book z Internet Archive"
 
 #: book_providers/librivox_download_options.html
 msgid "Whole Book MP3"
-msgstr ""
+msgstr "Cała książka MP3"
 
 #: book_providers/librivox_download_options.html
 msgid "Get the RSS Feed from LibriVox"
-msgstr ""
+msgstr "Pobierz kanał RSS z LibriVox"
 
 #: book_providers/librivox_download_options.html
 msgid "RSS Feed"
-msgstr ""
+msgstr "Kanał RSS"
 
 #: book_providers/librivox_download_options.html
 msgid "More at LibriVox"
-msgstr ""
+msgstr "Więcej na LibriVox"
 
 #: book_providers/openstax_download_options.html
 #, fuzzy
@@ -3204,12 +3204,12 @@ msgstr "Przeczytaj e-book z Internet Archive"
 
 #: book_providers/openstax_download_options.html
 msgid "More at OpenStax"
-msgstr ""
+msgstr "Więcej na OpenStax"
 
 #: book_providers/read_button.html
 #, python-format
 msgid "Listen to a reading from %s"
-msgstr ""
+msgstr "Posłuchaj czytania z %s"
 
 #: book_providers/read_button.html
 #, fuzzy
@@ -3219,39 +3219,39 @@ msgstr "Losowa książka"
 #: book_providers/read_button.html
 #, python-format
 msgid "Read free online from %s"
-msgstr ""
+msgstr "Czytaj bezpłatnie online z %s"
 
 #: book_providers/runeberg_download_options.html
 msgid "Download all scanned images from Project Runeberg"
-msgstr ""
+msgstr "Pobierz wszystkie zeskanowane obrazy z Project Runeberg"
 
 #: book_providers/runeberg_download_options.html
 msgid "Scanned images"
-msgstr ""
+msgstr "Zeskanowane obrazy"
 
 #: book_providers/runeberg_download_options.html
 msgid "Download all color images from Project Runeberg"
-msgstr ""
+msgstr "Pobierz wszystkie kolorowe obrazy z Project Runeberg"
 
 #: book_providers/runeberg_download_options.html
 msgid "Color images"
-msgstr ""
+msgstr "Kolorowe obrazy"
 
 #: book_providers/runeberg_download_options.html
 msgid "Download all HTML files from Project Runeberg"
-msgstr ""
+msgstr "Pobierz wszystkie pliki HTML z Project Runeberg"
 
 #: book_providers/runeberg_download_options.html
 msgid "Download all text and index files from Project Runeberg"
-msgstr ""
+msgstr "Pobierz wszystkie pliki tekstowe i indeksowe z Project Runeberg"
 
 #: book_providers/runeberg_download_options.html
 msgid "Text and index files"
-msgstr ""
+msgstr "Pliki tekstowe i indeksowe"
 
 #: book_providers/runeberg_download_options.html
 msgid "Download all OCR text from Project Runeberg"
-msgstr ""
+msgstr "Pobierz cały tekst OCR z Project Runeberg"
 
 #: book_providers/runeberg_download_options.html
 #, fuzzy
@@ -3260,11 +3260,11 @@ msgstr "Tekst"
 
 #: book_providers/runeberg_download_options.html
 msgid "More at Project Runeberg"
-msgstr ""
+msgstr "Więcej na Project Runeberg"
 
 #: book_providers/standard_ebooks_download_options.html
 msgid "Download an HTML from Standard Ebooks"
-msgstr ""
+msgstr "Pobierz HTML z Standard Ebooks"
 
 #: book_providers/standard_ebooks_download_options.html
 #, fuzzy
@@ -3278,7 +3278,7 @@ msgstr "Przeczytaj e-book z Internet Archive"
 
 #: book_providers/standard_ebooks_download_options.html
 msgid "Kindle (azw3)"
-msgstr ""
+msgstr "Kindle (azw3)"
 
 #: book_providers/standard_ebooks_download_options.html
 #, fuzzy
@@ -3287,19 +3287,19 @@ msgstr "Przeczytaj e-book z Internet Archive"
 
 #: book_providers/standard_ebooks_download_options.html
 msgid "Kobo (kepub)"
-msgstr ""
+msgstr "Kobo (kepub)"
 
 #: book_providers/standard_ebooks_download_options.html
 msgid "View the source code for this Standard Ebook at GitHub"
-msgstr ""
+msgstr "Zobacz kod źródłowy tej Standard Ebook na GitHub"
 
 #: Subnavigation.html book_providers/standard_ebooks_download_options.html
 msgid "Source Code"
-msgstr ""
+msgstr "Kod źródłowy"
 
 #: book_providers/standard_ebooks_download_options.html
 msgid "More at Standard Ebooks"
-msgstr ""
+msgstr "Więcej na Standard Ebooks"
 
 #: book_providers/wikisource_download_options.html
 #, fuzzy
@@ -3313,7 +3313,7 @@ msgstr "Przeczytaj e-book z Internet Archive"
 
 #: book_providers/wikisource_download_options.html
 msgid "MOBI (for Kindle)"
-msgstr ""
+msgstr "MOBI (dla Kindle)"
 
 #: book_providers/wikisource_download_options.html
 #, fuzzy
@@ -3322,21 +3322,21 @@ msgstr "Przeczytaj e-book z Internet Archive"
 
 #: book_providers/wikisource_download_options.html
 msgid "EPUB (for most other e-readers)"
-msgstr ""
+msgstr "EPUB (dla większości innych czytników e-booków)"
 
 #: book_providers/wikisource_download_options.html
 msgid "Read at Wikisource"
-msgstr ""
+msgstr "Czytaj na Wikisource"
 
 #: books/RelatedWorksCarousel.html
 msgid "You might also like"
-msgstr ""
+msgstr "Może Ci się też spodobać"
 
 #: books/RelatedWorksCarousel.html
 msgid "More by this author"
 msgid_plural "More by these authors"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Więcej od tego autora"
+msgstr[1] "Więcej od tych autorów"
 
 #: books/add.html books/check.html
 msgid "Add a book"
@@ -3344,7 +3344,7 @@ msgstr "Dodaj książkę"
 
 #: books/add.html
 msgid "Invalid ISBN checksum digit"
-msgstr ""
+msgstr "Nieprawidłowa cyfra kontrolna ISBN"
 
 #: books/add.html
 #, fuzzy
@@ -3358,11 +3358,11 @@ msgstr "ID musi zawierać dokładnie 10 znaków [0-9] lub X."
 
 #: books/add.html
 msgid "Invalid LC Control Number format"
-msgstr ""
+msgstr "Nieprawidłowy format numeru kontrolnego LC"
 
 #: books/add.html
 msgid "Invalid OCLC/WorldCat Control Number format"
-msgstr ""
+msgstr "Nieprawidłowy format numeru kontrolnego OCLC/WorldCat"
 
 #: books/add.html
 #, fuzzy
@@ -3371,7 +3371,7 @@ msgstr "Wybierz typ identyfikacji."
 
 #: books/add.html
 msgid "Are you sure that's the published date?"
-msgstr ""
+msgstr "Czy na pewno to jest data wydania?"
 
 #: books/add.html
 msgid "Add a book to Open Library"
@@ -3403,7 +3403,7 @@ msgstr "Na przykład:"
 
 #: books/add.html
 msgid "Oxford University Press; Penguin; W.W. Norton"
-msgstr ""
+msgstr "Oxford University Press; Penguin; W.W. Norton"
 
 #: books/add.html books/edit/edition.html
 msgid "When was it published?"
@@ -3423,7 +3423,7 @@ msgstr "Rodzaj numeru identyfikacyjnego"
 
 #: books/add.html
 msgid "ISBN may be invalid. Click \"Add\" again to submit."
-msgstr ""
+msgstr "ISBN może być nieprawidłowy. Kliknij \"Dodaj\" ponownie, aby przesłać."
 
 #: books/add.html type/tag/tag_form_inputs.html
 msgid "Select"
@@ -3441,19 +3441,19 @@ msgstr "ISBN"
 
 #: books/add.html
 msgid "LCCN"
-msgstr ""
+msgstr "LCCN"
 
 #: books/add.html
 msgid "LibriVox"
-msgstr ""
+msgstr "LibriVox"
 
 #: books/add.html
 msgid "OCLC/WorldCat"
-msgstr ""
+msgstr "OCLC/WorldCat"
 
 #: books/add.html
 msgid "Project Gutenberg"
-msgstr ""
+msgstr "Project Gutenberg"
 
 #: books/add.html books/edit/edition.html
 #, fuzzy
@@ -3462,16 +3462,16 @@ msgstr "E-book"
 
 #: books/add.html
 msgid "Only fill this out if this is a web book"
-msgstr ""
+msgstr "Wypełnij to tylko jeśli jest to e-book internetowy"
 
 #: books/add.html
 #, python-format
 msgid "By saving a change to this wiki, you agree that your contribution is given freely to the world under <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" target=\"_blank\" rel=\"noopener noreferrer\" title=\"%(cc_link_title)s\">CC0</a>."
-msgstr ""
+msgstr "Zapisując zmianę w tym wiki, zgadzasz się, że Twój wkład jest przekazany światu bezpłatnie na zasadzie <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" target=\"_blank\" rel=\"noopener noreferrer\" title=\"%(cc_link_title)s\">CC0</a>."
 
 #: books/add.html
 msgid "This link to Creative Commons will open in a new window"
-msgstr ""
+msgstr "Ten link do Creative Commons otworzy się w nowym oknie"
 
 #: books/add.html
 msgid "Add this book now"
@@ -3515,8 +3515,8 @@ msgstr "Wybierz tę książkę"
 #, python-format
 msgid "%(count)s edition"
 msgid_plural "%(count)s editions"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%(count)s wydanie"
+msgstr[1] "%(count)s wydania"
 
 #: books/check.html
 #, python-format
@@ -3525,7 +3525,7 @@ msgstr "Pierwsze wydanie w %(year)d"
 
 #: books/check.html
 msgid "None of these match the book I want to add."
-msgstr ""
+msgstr "Żadne z nich nie pasuje do książki, którą chcę dodać."
 
 #: books/check.html
 #, fuzzy
@@ -3552,24 +3552,24 @@ msgstr "Open Library"
 
 #: books/daisy.html
 msgid "There isn't a DAISY file available for "
-msgstr ""
+msgstr "Nie ma dostępnego pliku DAISY dla "
 
 #: books/daisy.html
 #, python-format
 msgid "<a href=\"%(daisy_url)s\"><strong>Download the DAISY.zip</strong></a> for <a href=\"%(url)s\">%(title)s</a>"
-msgstr ""
+msgstr "<a href=\"%(daisy_url)s\"><strong>Pobierz DAISY.zip</strong></a> dla <a href=\"%(url)s\">%(title)s</a>"
 
 #: books/daisy.html
 msgid "Books for people who don't read print?"
-msgstr ""
+msgstr "Książki dla osób nieczytelnych w druku?"
 
 #: books/daisy.html
 msgid "The <a href=\"//archive.org\">Internet Archive</a> is proud to be distributing over 1 million books free in a format called DAISY, designed for those of us who find it challenging to use regular printed media. "
-msgstr ""
+msgstr "<a href=\"//archive.org\">Internet Archive</a> z dumą dystrybuuje ponad 1 milion książek bezpłatnie w formacie DAISY, zaprojektowanym dla tych, którym trudno korzystać z tradycyjnych materiałów drukowanych. "
 
 #: books/daisy.html
 msgid "There are two types of DAISYs on Open Library: <i>open</i> and <i>protected</i>. Open DAISYs can be read by anyone in the world on many different devices. Protected DAISYs can only be opened using a key issued by the <a href=\"http://www.loc.gov/nls/\">Library of Congress NLS program</a>."
-msgstr ""
+msgstr "W Open Library dostępne są dwa typy DAISY: <i>otwarte</i> i <i>chronione</i>. Otwarte DAISY mogą być czytane przez każdego na świecie na wielu urządzeniach. Chronione DAISY można otwierać tylko przy użyciu klucza wydanego przez <a href=\"http://www.loc.gov/nls/\">program NLS Biblioteki Kongresu</a>."
 
 #: books/daisy.html lists/home.html
 msgid "Enjoy!"
@@ -3582,7 +3582,7 @@ msgstr "Wydawnictwo"
 
 #: books/daisy.html
 msgid "The DAISY digital format helps people who have challenges using regular printed media. DAISY digital <span class=\"highlight\">talking books</span> offer the benefits of regular audiobooks, with navigation within the book, to chapters or specific pages."
-msgstr ""
+msgstr "Format cyfrowy DAISY pomaga osobom mającym trudności z korzystaniem z tradycyjnych materiałów drukowanych. Cyfrowe <span class=\"highlight\">audiobooki</span> DAISY oferują zalety zwykłych audiobooków, z nawigacją po książce, do rozdziałów lub konkretnych stron."
 
 #: books/daisy.html
 #, fuzzy
@@ -3596,11 +3596,11 @@ msgstr "Wydawnictwo"
 
 #: books/daisy.html
 msgid "The Library of Congress <a href=\"http://www.loc.gov/nls/\">National Library Service for the Blind and Physically Handicapped (NLS)</a> administers a free library program of braille and audio materials circulated to eligible borrowers in the United States through a national network of cooperating libraries."
-msgstr ""
+msgstr "Biblioteka Kongresu <a href=\"http://www.loc.gov/nls/\">National Library Service for the Blind and Physically Handicapped (NLS)</a> administruje bezpłatny program biblioteczny materiałów brajlowskich i audio udostępnianych uprawnionym wypożyczającym w Stanach Zjednoczonych za pośrednictwem krajowej sieci bibliotek współpracujących."
 
 #: books/daisy.html
 msgid "Are you eligible to register?"
-msgstr ""
+msgstr "Czy kwalifikujesz się do rejestracji?"
 
 #: books/daisy.html
 #, fuzzy
@@ -3609,11 +3609,11 @@ msgstr "Zobacz wszystkich odwiedzających OpenLibrary.org"
 
 #: books/daisy.html
 msgid "In addition to<a href=\"/subjects/accessible_book\" title=\"Subject: Accessible book\"> loads of open DAISYs</a>, the Open Library lists a smaller selection of<a href=\"/subjects/protected_DAISY\" title=\"Subject: Protected DAISY\"> protected DAISY titles</a> accessible to those with a Library of Congress NLS key. These titles are brought to you by the<a href=\"//archive.org/\"> Internet Archive</a>."
-msgstr ""
+msgstr "Oprócz<a href=\"/subjects/accessible_book\" title=\"Subject: Accessible book\"> wielu otwartych DAISY</a>, Open Library zawiera mniejszy wybór<a href=\"/subjects/protected_DAISY\" title=\"Subject: Protected DAISY\"> chronionych tytułów DAISY</a> dostępnych dla posiadaczy klucza NLS Biblioteki Kongresu. Te tytuły są dostarczane przez<a href=\"//archive.org/\"> Internet Archive</a>."
 
 #: books/daisy.html
 msgid "Looking for a specific title? The best way to find it is to<a href=\"/search\"> search for it</a>."
-msgstr ""
+msgstr "Szukasz konkretnego tytułu? Najlepszym sposobem jest<a href=\"/search\"> wyszukanie go</a>."
 
 #: books/daisy.html lib/exports.html
 msgid "Need help?"

--- a/openlibrary/i18n/pl/messages.po
+++ b/openlibrary/i18n/pl/messages.po
@@ -7317,31 +7317,31 @@ msgstr "Subskrybuj"
 #: type/list/exports.html
 #, python-format
 msgid "Watch activity via <a rel=\"nofollow\" href=\"%s\">Atom feed</a>"
-msgstr ""
+msgstr "Obserwuj aktywność przez <a rel=\"nofollow\" href=\"%s\">kanał Atom</a>"
 
 #: type/list/exports.html
 msgid "Export Not Available"
-msgstr ""
+msgstr "Eksport niedostępny"
 
 #: type/list/exports.html
 #, python-format
 msgid "Only lists with up to %(max)s editions can be exported. This one has %(count)s."
-msgstr ""
+msgstr "Można eksportować tylko listy z maksymalnie %(max)s wydaniami. Ta lista ma %(count)s."
 
 #: type/list/exports.html
 #, python-format
 msgid "Try removing some seeds for more focus, or look at <a href=\"%s\">bulk download</a> of the catalog."
-msgstr ""
+msgstr "Spróbuj usunąć niektóre źródła dla większej precyzji lub skorzystaj z <a href=\"%s\">masowego pobierania</a> katalogu."
 
 #: type/list/view_body.html
 #, python-format
 msgid "%(name)s | Lists | Open Library"
-msgstr ""
+msgstr "%(name)s | Listy | Open Library"
 
 #: type/list/view_body.html
 #, python-format
 msgid "%(title)s: %(description)s"
-msgstr ""
+msgstr "%(title)s: %(description)s"
 
 #: type/list/view_body.html
 #, fuzzy
@@ -7356,7 +7356,7 @@ msgstr "Usunąć ten plik inicujuący?"
 #: type/list/view_body.html
 #, python-format
 msgid "Last modified <span>%(date)s</span>"
-msgstr ""
+msgstr "Ostatnio zmodyfikowano <span>%(date)s</span>"
 
 #: type/list/view_body.html
 #, fuzzy
@@ -7375,24 +7375,24 @@ msgstr "Usunąć ten plik inicujuący?"
 
 #: type/list/view_body.html
 msgid "You are about to remove the last item in the list. That will delete the whole list. Are you sure you want to continue?"
-msgstr ""
+msgstr "Zamierzasz usunąć ostatni element z listy. Spowoduje to usunięcie całej listy. Czy na pewno chcesz kontynuować?"
 
 #: type/list/view_body.html
 #, python-format
 msgid "This series contains %(limit)d or more works. Currently, only the first %(limit)d works are displayed."
-msgstr ""
+msgstr "Ta seria zawiera %(limit)d lub więcej dzieł. Aktualnie wyświetlane są tylko pierwsze %(limit)d dzieł."
 
 #: type/list/view_body.html
 msgid "There are no items on this list."
-msgstr ""
+msgstr "Na tej liście nie ma żadnych elementów."
 
 #: type/list/view_body.html
 msgid "<a href=\"/search\" target=\"_blank\" rel=\"noopener noreferrer\">Search for book, subjects, or authors</a> to add to your list."
-msgstr ""
+msgstr "<a href=\"/search\" target=\"_blank\" rel=\"noopener noreferrer\">Wyszukaj książki, tematy lub autorów</a>, aby dodać do swojej listy."
 
 #: type/list/view_body.html
 msgid "Learn more."
-msgstr ""
+msgstr "Dowiedz się więcej."
 
 #: type/list/view_body.html
 #, fuzzy
@@ -7401,7 +7401,7 @@ msgstr "Dodatkowe metadane"
 
 #: type/list/view_body.html
 msgid "Derived from seed metadata"
-msgstr ""
+msgstr "Pochodzi z metadanych źródłowych"
 
 #: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py type/list/view_body.html
 msgid "Times"
@@ -7409,11 +7409,11 @@ msgstr "Okres"
 
 #: type/local_id/view.html
 msgid "Local IDs"
-msgstr ""
+msgstr "Lokalne identyfikatory"
 
 #: type/local_id/view.html
 msgid "Source Item"
-msgstr ""
+msgstr "Element źródłowy"
 
 #: type/local_id/view.html
 #, fuzzy
@@ -7422,7 +7422,7 @@ msgstr "Lokalizaja"
 
 #: type/local_id/view.html
 msgid "Barcode regex"
-msgstr ""
+msgstr "Wyrażenie regularne kodu kreskowego"
 
 #: type/local_id/view.html
 #, fuzzy
@@ -7485,7 +7485,7 @@ msgstr "Aby utworzyć nowy wpis wymagane jest uzupełnienie nastepujących pól.
 
 #: EditButtons.html type/tag/form.html
 msgid "By saving a change to this wiki, you agree that your contribution is given freely to the world under <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" target=\"_blank\" rel=\"noopener noreferrer\" title=\"This link to Creative Commons will open in a new window\">CC0</a>. Yippee!"
-msgstr ""
+msgstr "Zapisując zmianę w tym wiki, zgadzasz się, że Twój wkład jest przekazywany swobodnie światu na warunkach <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" target=\"_blank\" rel=\"noopener noreferrer\" title=\"Ten link do Creative Commons otworzy się w nowym oknie\">CC0</a>. Hurra!"
 
 #: type/tag/form.html
 #, fuzzy
@@ -7499,7 +7499,7 @@ msgstr "Status"
 
 #: type/tag/index.html
 msgid "Tags curated by Open Library librarians."
-msgstr ""
+msgstr "Tagi opracowane przez bibliotekarzy Open Library."
 
 #: type/tag/index.html
 #, fuzzy
@@ -7522,15 +7522,15 @@ msgstr "Imię i nazwisko"
 
 #: type/tag/tag_form_inputs.html
 msgid "Human-readable display name (e.g. \"Computer Science\", \"Horror Fiction\")"
-msgstr ""
+msgstr "Czytelna dla człowieka nazwa wyświetlana (np. „Informatyka”, „Horror”)"
 
 #: type/tag/tag_form_inputs.html
 msgid "Tag Slugs"
-msgstr ""
+msgstr "Slugi tagów"
 
 #: type/tag/tag_form_inputs.html
 msgid "Comma-separated URL slugs that map to this tag (auto-populated from name). E.g. \"computer_science, cs\""
-msgstr ""
+msgstr "Slugi URL oddzielone przecinkami, które odwzorowują ten tag (wypełniane automatycznie na podstawie nazwy). Np. „computer_science, cs”"
 
 #: type/tag/tag_form_inputs.html
 #, fuzzy
@@ -7549,12 +7549,12 @@ msgstr "Rodzaj strony"
 
 #: type/tag/tag_form_inputs.html
 msgid "Tag Deputy"
-msgstr ""
+msgstr "Zastępca tagu"
 
 #: type/tag/view.html
 #, python-format
 msgid "<strong>Type:</strong> %(tag_type)s"
-msgstr ""
+msgstr "<strong>Typ:</strong> %(tag_type)s"
 
 #: type/tag/view.html type/user/edit.html
 msgid "Description"
@@ -7562,16 +7562,16 @@ msgstr "Opis"
 
 #: type/tag/view.html
 msgid "Tag Body"
-msgstr ""
+msgstr "Treść tagu"
 
 #: type/tag/view.html
 msgid "URL Slugs"
-msgstr ""
+msgstr "Slugi URL"
 
 #: type/tag/view.html
 #, python-format
 msgid "View subject page for %(name)s."
-msgstr ""
+msgstr "Zobacz stronę tematu dla %(name)s."
 
 #: type/template/edit.html
 #, fuzzy
@@ -7616,7 +7616,7 @@ msgstr "Różnice"
 #: type/user/edit.html
 #, python-format
 msgid "Editing %(name)s"
-msgstr ""
+msgstr "Edytowanie %(name)s"
 
 #: type/user/edit.html
 msgid "Currently Editing:"
@@ -7633,15 +7633,15 @@ msgstr "strona administratora"
 #: type/user/view.html
 #, python-format
 msgid "You are publicly sharing the books you are <a href=\"%(username)s/books/currently-reading\">currently reading</a>, <a href=\"%(username)s/books/already-read\">have already read</a>, <a href=\"%(username)s/books/want-to-read\">want to read</a>, and have <a href=\"%(username)s/books/stopped-reading\">stopped reading</a>!"
-msgstr ""
+msgstr "Publicznie udostępniasz książki, które <a href=\"%(username)s/books/currently-reading\">aktualnie czytasz</a>, <a href=\"%(username)s/books/already-read\">już przeczytałeś/aś</a>, <a href=\"%(username)s/books/want-to-read\">chcesz przeczytać</a> i <a href=\"%(username)s/books/stopped-reading\">przestałeś/aś czytać</a>!"
 
 #: type/user/view.html
 msgid "You have chosen to make your"
-msgstr ""
+msgstr "Wybrałeś/aś, aby Twój"
 
 #: type/user/view.html
 msgid "private"
-msgstr ""
+msgstr "prywatny"
 
 #: type/user/view.html
 msgid "Manage your privacy settings"
@@ -7650,7 +7650,7 @@ msgstr "Zarządzaj swoimi ustawieniami prywatności"
 #: type/user/view.html
 #, python-format
 msgid "Here are the books %(user)s is <a href=\"%(username)s/books/currently-reading\">currently reading</a>, <a href=\"%(username)s/books/already-read\">have already read</a>, <a href=\"%(username)s/books/want-to-read\">want to read</a>, and has <a href=\"%(username)s/books/stopped-reading\">stopped reading</a>!"
-msgstr ""
+msgstr "Oto książki, które %(user)s <a href=\"%(username)s/books/currently-reading\">aktualnie czyta</a>, <a href=\"%(username)s/books/already-read\">już przeczytał/a</a>, <a href=\"%(username)s/books/want-to-read\">chce przeczytać</a> i <a href=\"%(username)s/books/stopped-reading\">przestał/a czytać</a>!"
 
 #: type/user/view.html
 msgid "My Lists"
@@ -7673,7 +7673,7 @@ msgstr "Po raz pierwszy opublikowana w %(year)s"
 #: type/work/editions.html type/work/editions_datatable.html
 #, python-format
 msgid "Add another edition of %(work)s"
-msgstr ""
+msgstr "Dodaj kolejne wydanie %(work)s"
 
 #: UserEditRow.html type/work/editions.html
 msgid "Add another"
@@ -7688,13 +7688,13 @@ msgstr "brakuje imienia"
 #, python-format
 msgid "Showing %(count)d featured edition."
 msgid_plural "Showing %(count)d featured editions."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Wyświetlanie %(count)d wyróżnionego wydania."
+msgstr[1] "Wyświetlanie %(count)d wyróżnionych wydań."
 
 #: type/work/editions_datatable.html
 #, python-format
 msgid "View all %(count)d editions?"
-msgstr ""
+msgstr "Wyświetlić wszystkie %(count)d wydania?"
 
 #: type/work/editions_datatable.html
 msgid "Edition"
@@ -7713,26 +7713,26 @@ msgstr "Dodaj kolejne wydanie"
 #: AffiliateLinks.html
 #, python-format
 msgid "Look for this edition for sale at %(store)s"
-msgstr ""
+msgstr "Poszukaj tego wydania na sprzedaż w %(store)s"
 
 #: AffiliateLinks.html
 msgid "When you buy books using these links the Internet Archive may earn a <a class=\"nostyle\" href=\"/help/faq/about#selling\">small commission</a>."
-msgstr ""
+msgstr "Kupując książki za pomocą tych linków, Internet Archive może otrzymać <a class=\"nostyle\" href=\"/help/faq/about#selling\">małą prowizję</a>."
 
 #: AffiliateLinksLoadingIndicator.html
 msgid "Fetching prices"
-msgstr ""
+msgstr "Pobieranie cen"
 
 #: BatchImportNavigation.html
 msgid "Pending Imports"
-msgstr ""
+msgstr "Oczekujące importy"
 
 #: BookByline.html
 #, python-format
 msgid "%(n)s other"
 msgid_plural "%(n)s others"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%(n)s inny"
+msgstr[1] "%(n)s inne"
 
 #: BookByline.html
 #, fuzzy
@@ -7755,7 +7755,7 @@ msgstr ""
 
 #: EditionNavBar.html
 msgid "Go to previous section"
-msgstr ""
+msgstr "Przejdź do poprzedniej sekcji"
 
 #: EditionNavBar.html
 #, fuzzy
@@ -7766,15 +7766,15 @@ msgstr "Wyświetl"
 #, python-format
 msgid "View %(count)s Edition"
 msgid_plural "View %(count)s Editions"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Wyświetl %(count)s wydanie"
+msgstr[1] "Wyświetl %(count)s wydania"
 
 #: EditionNavBar.html
 #, python-format
 msgid "%(reviews)s Review"
 msgid_plural "%(reviews)s Reviews"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%(reviews)s recenzja"
+msgstr[1] "%(reviews)s recenzje"
 
 #: EditionNavBar.html
 #, fuzzy
@@ -7783,15 +7783,15 @@ msgstr "Losowa książka"
 
 #: EditionNavBar.html
 msgid "Go to next section"
-msgstr ""
+msgstr "Przejdź do następnej sekcji"
 
 #: Follow.html
 msgid "Unfollow"
-msgstr ""
+msgstr "Przestań obserwować"
 
 #: Follow.html
 msgid "Failed to update followers. Please try again in a few moments."
-msgstr ""
+msgstr "Nie udało się zaktualizować obserwujących. Spróbuj ponownie za chwilę."
 
 #: FormatExpiry.html
 #, fuzzy
@@ -7800,7 +7800,7 @@ msgstr "Termin zwrotu"
 
 #: FulltextSearchSuggestion.html
 msgid "Checking for Search Inside matches"
-msgstr ""
+msgstr "Sprawdzanie dopasowań Szukaj w środku"
 
 #: FulltextSearchSuggestion.html
 #, fuzzy
@@ -7815,38 +7815,38 @@ msgstr "Szukaj w"
 #: FulltextSearchSuggestion.html
 #, python-format
 msgid "%(book_count)s books found with matching passages"
-msgstr ""
+msgstr "%(book_count)s książek znalezionych z pasującymi fragmentami"
 
 #: FulltextSearchSuggestion.html
 #, python-format
 msgid "See all %(results_count)s Search Inside Matches"
-msgstr ""
+msgstr "Zobacz wszystkie %(results_count)s dopasowania Szukaj w środku"
 
 #: FulltextSearchSuggestion.html
 msgid "right chevron"
-msgstr ""
+msgstr "strzałka w prawo"
 
 #: FulltextSnippet.html FulltextSuggestionSnippet.html
 msgid "❝"
-msgstr ""
+msgstr "❝"
 
 #: FulltextSnippet.html FulltextSuggestionSnippet.html
 msgid "❞"
-msgstr ""
+msgstr "❞"
 
 #: FulltextSuggestionSnippet.html
 #, python-format
 msgid "Page: %(page)s"
-msgstr ""
+msgstr "Strona: %(page)s"
 
 #: IABook.html
 #, python-format
 msgid "Borrowed from Internet Archive: %(title)s"
-msgstr ""
+msgstr "Wypożyczono z Internet Archive: %(title)s"
 
 #: LoadingIndicator.html
 msgid "Loading indicator"
-msgstr ""
+msgstr "Wskaźnik ładowania"
 
 #: LoanStatus.html
 msgid "You are <strong>next</strong> on the waiting list"
@@ -7865,15 +7865,15 @@ msgstr "Opuścić listę oczekujących?"
 #: LoanStatus.html
 #, python-format
 msgid "Readers in line: %(count)s"
-msgstr ""
+msgstr "Czytelnicy w kolejce: %(count)s"
 
 #: LoanStatus.html
 msgid "You'll be next in line."
-msgstr ""
+msgstr "Będziesz następny/a w kolejce."
 
 #: LoanStatus.html
 msgid "This book is currently checked out, please check back later."
-msgstr ""
+msgstr "Ta książka jest aktualnie wypożyczona, proszę wróć później."
 
 #: LoanStatus.html
 #, fuzzy
@@ -7902,8 +7902,8 @@ msgstr[1] "Oczekujesz %d dni"
 #, python-format
 msgid "You have %(count)d more hour to borrow it."
 msgid_plural "You have %(count)d more hours to borrow it."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Masz jeszcze %(count)d godzinę na wypożyczenie."
+msgstr[1] "Masz jeszcze %(count)d godziny na wypożyczenie."
 
 #: NotInLibrary.html
 msgid "Not in Library"
@@ -7922,7 +7922,7 @@ msgstr "Dodatkowe uwagi na temat tego wydania?"
 #: OLID.html
 #, python-format
 msgid "by  %(authors)s"
-msgstr ""
+msgstr "przez  %(authors)s"
 
 #: ObservationsModal.html
 #, fuzzy
@@ -7931,21 +7931,21 @@ msgstr "Moje książki"
 
 #: OlPagination.html OlPaginationArrows.html
 msgid "Go to previous page"
-msgstr ""
+msgstr "Przejdź do poprzedniej strony"
 
 #: OlPagination.html OlPaginationArrows.html
 msgid "Go to next page"
-msgstr ""
+msgstr "Przejdź do następnej strony"
 
 #: OlPagination.html
 #, python-brace-format
 msgid "Go to page {page}"
-msgstr ""
+msgstr "Przejdź do strony {page}"
 
 #: OlPagination.html
 #, python-brace-format
 msgid "Page {page}, current page"
-msgstr ""
+msgstr "Strona {page}, bieżąca strona"
 
 #: Profile.html
 #, fuzzy
@@ -7970,23 +7970,23 @@ msgstr "Ten diagram przedstawia wydania publikacji na ten temat."
 
 #: RawQueryCarousel.html
 msgid "Loading carousel"
-msgstr ""
+msgstr "Ładowanie karuzeli"
 
 #: RawQueryCarousel.html
 msgid "Failed to fetch carousel."
-msgstr ""
+msgstr "Nie udało się załadować karuzeli."
 
 #: RawQueryCarousel.html
 msgid "Retry?"
-msgstr ""
+msgstr "Spróbować ponownie?"
 
 #: RawQueryCarousel.html
 msgid "No books match the current filters."
-msgstr ""
+msgstr "Żadne książki nie pasują do bieżących filtrów."
 
 #: RawQueryCarousel.html
 msgid "Retry without filters?"
-msgstr ""
+msgstr "Spróbować ponownie bez filtrów?"
 
 #: RawQueryCarousel.html
 #, fuzzy
@@ -8000,7 +8000,7 @@ msgstr "Miejsca"
 
 #: ReadButton.html
 msgid "Special ebook access from the Internet Archive for patrons with qualifying print disabilities"
-msgstr ""
+msgstr "Specjalny dostęp do e-booków z Internet Archive dla czytelników z kwalifikującymi się niepełnosprawnościami druku"
 
 #: ReadButton.html
 msgid "Borrow ebook from Internet Archive"
@@ -8036,7 +8036,7 @@ msgstr "Edytuj"
 
 #: RecentChangesAdmin.html RecentChangesUsers.html
 msgid "No edit history available."
-msgstr ""
+msgstr "Brak historii edycji."
 
 #: RelatedSubjects.html
 msgid "Related..."
@@ -8059,7 +8059,7 @@ msgstr "Dodano"
 #: SearchResultsWork.html
 #, python-format
 msgid "Book %(position)s"
-msgstr ""
+msgstr "Książka %(position)s"
 
 #: SearchResultsWork.html
 #, fuzzy

--- a/openlibrary/i18n/pl/messages.po
+++ b/openlibrary/i18n/pl/messages.po
@@ -821,11 +821,11 @@ msgstr "Włączone funkcje"
 
 #: subjects.html
 msgid "Edit tag for this subject"
-msgstr ""
+msgstr "Edytuj tag dla tego tematu"
 
 #: subjects.html
 msgid "Create tag for this subject"
-msgstr ""
+msgstr "Utwórz tag dla tego tematu"
 
 #: subjects.html
 #, fuzzy
@@ -846,7 +846,7 @@ msgstr "Szukaj książek o tematyce %(name)s."
 
 #: subjects.html
 msgid "Disambiguations"
-msgstr ""
+msgstr "Ujednoznacznienia"
 
 #: trending.html
 #, fuzzy
@@ -855,11 +855,11 @@ msgstr "Nie"
 
 #: admin/graphs.html admin/index.html my_books/check_ins/check_in_form.html my_books/check_ins/check_in_prompt.html trending.html
 msgid "Today"
-msgstr ""
+msgstr "Dziś"
 
 #: admin/graphs.html trending.html
 msgid "This Week"
-msgstr ""
+msgstr "Ten tydzień"
 
 #: admin/graphs.html stats/readinglog.html trending.html
 #, fuzzy
@@ -868,7 +868,7 @@ msgstr "Te wydanie"
 
 #: trending.html
 msgid "This Year"
-msgstr ""
+msgstr "Ten rok"
 
 #: admin/index.html books/year_breadcrumb_select.html trending.html
 #, fuzzy
@@ -882,11 +882,11 @@ msgstr "Dziennik Lektur"
 
 #: trending.html
 msgid "See what readers from the community are adding to their bookshelves"
-msgstr ""
+msgstr "Zobacz, co czytelnicy ze społeczności dodają do swoich półek"
 
 #: trending.html
 msgid "Earliest trending data is from October 2017"
-msgstr ""
+msgstr "Najwcześniejsze dane o trendach pochodzą z października 2017"
 
 #. Label for the reading log shelf for books the user plans to read in the
 #. future (bookshelf ID 1). Used as a button label and shelf name.
@@ -914,17 +914,17 @@ msgstr "Przeczytaj"
 #. (bookshelf ID 4). Used as a button label and shelf name.
 #: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html trending.html
 msgid "Stopped Reading"
-msgstr ""
+msgstr "Przestał czytać"
 
 #: trending.html
 #, python-format
 msgid "Someone marked as %(shelf)s %(k_hours_ago)s"
-msgstr ""
+msgstr "Ktoś oznaczył jako %(shelf)s %(k_hours_ago)s"
 
 #: trending.html
 #, python-format
 msgid "Logged %(count)i times %(time_unit)s"
-msgstr ""
+msgstr "Zarejestrowano %(count)i razy %(time_unit)s"
 
 #: verify_human.html
 #, fuzzy
@@ -933,11 +933,11 @@ msgstr "Weryfikacja adresu e-mail nie powiodła się"
 
 #: verify_human.html
 msgid "Please verify you are human to continue."
-msgstr ""
+msgstr "Proszę potwierdzić, że jesteś człowiekiem, aby kontynuować."
 
 #: verify_human.html
 msgid "Verify you are human"
-msgstr ""
+msgstr "Potwierdź, że jesteś człowiekiem"
 
 #: verify_human.html
 #, fuzzy
@@ -976,25 +976,25 @@ msgstr "Wypożycz"
 #: widget.html
 #, python-format
 msgid "Join waitlist for \"%(title)s\""
-msgstr ""
+msgstr "Dołącz do listy oczekujących na \"%(title)s\""
 
 #: LoanStatus.html widget.html
 msgid "Join Waitlist"
-msgstr ""
+msgstr "Dołącz do listy oczekujących"
 
 #: widget.html
 #, python-format
 msgid "Learn more about \"%(title)s\" at OpenLibrary"
-msgstr ""
+msgstr "Dowiedz się więcej o \"%(title)s\" w OpenLibrary"
 
 #: reading_goals/reading_goal_form.html widget.html
 msgid "Learn More"
-msgstr ""
+msgstr "Dowiedz się więcej"
 
 #: widget.html
 #, python-format
 msgid "on <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"%(link)s\">openlibrary.org</a>"
-msgstr ""
+msgstr "na <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"%(link)s\">openlibrary.org</a>"
 
 #: work_search.html
 #, fuzzy
@@ -1008,7 +1008,7 @@ msgstr "Słowa kluczowe"
 
 #: work_search.html
 msgid "This is only visible to super librarians."
-msgstr ""
+msgstr "To jest widoczne tylko dla super bibliotekarzy."
 
 #: work_search.html
 #, fuzzy
@@ -1022,7 +1022,7 @@ msgstr "Tylko administratorzy"
 
 #: work_search.html
 msgid "Filter by availability"
-msgstr ""
+msgstr "Filtruj według dostępności"
 
 #: openlibrary/plugins/worksearch/code.py search/search_modal_i18n.html type/edition/view.html type/work/view.html work_search.html
 msgid "Language"
@@ -1040,24 +1040,24 @@ msgstr "Język"
 
 #: work_search.html
 msgid "Filter by language"
-msgstr ""
+msgstr "Filtruj według języka"
 
 #: work_search.html
 msgid "The search engine returned an error."
-msgstr ""
+msgstr "Wyszukiwarka zwróciła błąd."
 
 #: work_search.html
 msgid "Solr Debugging:"
-msgstr ""
+msgstr "Debugowanie Solr:"
 
 #: work_search.html
 msgid "Full URL:"
-msgstr ""
+msgstr "Pełny URL:"
 
 #: work_search.html
 #, python-format
 msgid "No <strong>%(path_id)s</strong> directly matched your search."
-msgstr ""
+msgstr "Żaden <strong>%(path_id)s</strong> nie pasuje bezpośrednio do Twojego wyszukiwania."
 
 #: work_search.html
 #, fuzzy
@@ -1073,13 +1073,13 @@ msgstr "Szukaj w"
 #, python-format
 msgid "%(count)s hit"
 msgid_plural "%(count)s hits"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%(count)s wynik"
+msgstr[1] "%(count)s wyniki"
 
 #: work_search.html
 #, python-format
 msgid "Searching solr took %(count)s seconds"
-msgstr ""
+msgstr "Wyszukiwanie w solr zajęło %(count)s sekund"
 
 #: about/index.html
 #, fuzzy
@@ -1088,11 +1088,11 @@ msgstr "Open Library"
 
 #: about/index.html
 msgid "Open Library is made possible because of a dedicated team of staff and over 100 volunteers from around the globe."
-msgstr ""
+msgstr "Open Library jest możliwe dzięki zaangażowanemu zespołowi pracowników i ponad 100 wolontariuszy z całego świata."
 
 #: about/index.html
 msgid "Want to join us?"
-msgstr ""
+msgstr "Chcesz do nas dołączyć?"
 
 #: about/index.html
 #, fuzzy
@@ -1105,11 +1105,11 @@ msgstr "Wszystkie"
 
 #: about/index.html
 msgid "Staff"
-msgstr ""
+msgstr "Personel"
 
 #: about/index.html
 msgid "Fellows"
-msgstr ""
+msgstr "Stypendyści"
 
 #: about/index.html
 #, fuzzy
@@ -1118,7 +1118,7 @@ msgstr "Tom"
 
 #: about/index.html
 msgid "Department:"
-msgstr ""
+msgstr "Dział:"
 
 #: about/index.html
 #, fuzzy
@@ -1132,15 +1132,15 @@ msgstr "Wymiary"
 
 #: about/index.html
 msgid "Engineering"
-msgstr ""
+msgstr "Inżynieria"
 
 #: about/index.html
 msgid "Librarianship"
-msgstr ""
+msgstr "Bibliotekarstwo"
 
 #: about/index.html
 msgid "If you volunteer with Open Library and would like to be listed as part of the team, then complete the <a href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">Open Library team information form</a>."
-msgstr ""
+msgstr "Jeśli wolontariacko pracujesz z Open Library i chcesz być wymieniony jako część zespołu, wypełnij <a href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">formularz informacyjny zespołu Open Library</a>."
 
 #: account/create.html openlibrary/plugins/upstream/forms.py
 msgid "Must be a valid email address"
@@ -1152,11 +1152,11 @@ msgstr "Musi składać się z min. 3 i max. 20 znaków."
 
 #: account/create.html
 msgid "Username may only contain numbers, letters, - or _"
-msgstr ""
+msgstr "Nazwa użytkownika może zawierać tylko cyfry, litery, - lub _"
 
 #: account/create.html
 msgid "A qualifying program must be selected"
-msgstr ""
+msgstr "Należy wybrać kwalifikujący program"
 
 #: account/create.html
 msgid "Sign Up to Open Library"
@@ -1168,7 +1168,7 @@ msgstr "Załóż konto"
 
 #: account/create.html
 msgid "Get your free Open Library card and borrow digital books from the nonprofit Internet Archive"
-msgstr ""
+msgstr "Zdobądź bezpłatną kartę Open Library i wypożyczaj cyfrowe książki od organizacji non-profit Internet Archive"
 
 #: account/create.html type/author/view.html
 msgid "Success!"
@@ -1186,31 +1186,31 @@ msgstr "Nazwa użytkownika"
 
 #: account/create.html
 msgid "I want to receive news, announcements, and resources from the <a href=\"https://archive.org/\">Internet Archive</a>, the non-profit that runs Open Library."
-msgstr ""
+msgstr "Chcę otrzymywać wiadomości, ogłoszenia i zasoby od <a href=\"https://archive.org/\">Internet Archive</a>, organizacji non-profit prowadzącej Open Library."
 
 #: account/create.html
 msgid "I want to apply* for <a href=\"https://help.archive.org/help/program-overview/\" target=\"_blank\" rel=\"noopener noreferrer\">special print disability access</a> through a qualifying program."
-msgstr ""
+msgstr "Chcę ubiegać się* o <a href=\"https://help.archive.org/help/program-overview/\" target=\"_blank\" rel=\"noopener noreferrer\">specjalny dostęp dla osób z niepełnosprawnością druku</a> przez kwalifikujący program."
 
 #: account/create.html
 msgid "Select qualifying program"
-msgstr ""
+msgstr "Wybierz kwalifikujący program"
 
 #: account/create.html
 msgid "* Please use the email address associated with this qualifying program. You will receive an email after activation with next steps."
-msgstr ""
+msgstr "* Proszę użyć adresu e-mail powiązanego z tym kwalifikującym programem. Po aktywacji otrzymasz e-mail z kolejnymi krokami."
 
 #: account/create.html
 msgid "Sign Up with Email"
-msgstr ""
+msgstr "Zarejestruj się przez e-mail"
 
 #: account/create.html
 msgid "By signing up, you agree to the Internet Archive's <a class=\"ol-signup-form__link\" href=\"//archive.org/about/terms.php\" target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
-msgstr ""
+msgstr "Rejestrując się, zgadzasz się z <a class=\"ol-signup-form__link\" href=\"//archive.org/about/terms.php\" target=\"_blank\" rel=\"noopener noreferrer\">Warunkami usługi</a> Internet Archive."
 
 #: account/create.html
 msgid "Already have an account? <a href=\"/account/login\">Log in</a>"
-msgstr ""
+msgstr "Masz już konto? <a href=\"/account/login\">Zaloguj się</a>"
 
 #: account/delete.html
 msgid "Delete Account"
@@ -1227,15 +1227,15 @@ msgstr "Nie ma tu złych odpowiedzi."
 
 #: account/import.html
 msgid "Import from Goodreads"
-msgstr ""
+msgstr "Importuj z Goodreads"
 
 #: account/import.html
 msgid "For instructions on exporting data refer to: <a href=\"https://www.goodreads.com/review/import\">Goodreads Import/Export</a>"
-msgstr ""
+msgstr "Instrukcje dotyczące eksportu danych znajdziesz tutaj: <a href=\"https://www.goodreads.com/review/import\">Goodreads Import/Export</a>"
 
 #: account/import.html
 msgid "File size limit 10MB and .csv file type only"
-msgstr ""
+msgstr "Limit rozmiaru pliku 10 MB, tylko pliki .csv"
 
 #: account/import.html
 #, fuzzy
@@ -1259,7 +1259,7 @@ msgstr "Dziennik Lektur"
 
 #: account/import.html
 msgid "Download (.csv format)"
-msgstr ""
+msgstr "Pobierz (format .csv)"
 
 #: account/import.html
 #, fuzzy
@@ -1268,7 +1268,7 @@ msgstr "Zobacz książki"
 
 #: account/import.html
 msgid "Download a copy of your book notes."
-msgstr ""
+msgstr "Pobierz kopię swoich notatek o książkach."
 
 #: account/import.html
 #, fuzzy
@@ -1277,23 +1277,23 @@ msgstr "Jaki to rodzaj książki?"
 
 #: account/import.html
 msgid "Export your reviews"
-msgstr ""
+msgstr "Eksportuj swoje recenzje"
 
 #: account/import.html
 msgid "Download a copy of your review tags."
-msgstr ""
+msgstr "Pobierz kopię tagów swoich recenzji."
 
 #: account/import.html
 msgid "What are review tags?"
-msgstr ""
+msgstr "Czym są tagi recenzji?"
 
 #: account/import.html
 msgid "Export your list overview"
-msgstr ""
+msgstr "Eksportuj przegląd swoich list"
 
 #: account/import.html
 msgid "Download a summary of your lists and their contents."
-msgstr ""
+msgstr "Pobierz podsumowanie swoich list i ich zawartości."
 
 #: account/import.html
 #, fuzzy
@@ -1302,15 +1302,15 @@ msgstr "Aktywne Listy"
 
 #: account/import.html
 msgid "Export your star ratings"
-msgstr ""
+msgstr "Eksportuj swoje oceny gwiazdkowe"
 
 #: account/import.html
 msgid "Download a copy of your star ratings."
-msgstr ""
+msgstr "Pobierz kopię swoich ocen gwiazdkowych."
 
 #: account/import.html
 msgid "What are star ratings?"
-msgstr ""
+msgstr "Czym są oceny gwiazdkowe?"
 
 #: account/import.html
 #, fuzzy
@@ -1329,11 +1329,11 @@ msgstr "ISBN"
 
 #: account/loan_history.html
 msgid "No loans found in your borrow history."
-msgstr ""
+msgstr "Nie znaleziono wypożyczeń w historii."
 
 #: account/loan_history.html
 msgid "<a href=\"/search\">Search for a book</a> to borrow."
-msgstr ""
+msgstr "<a href=\"/search\">Wyszukaj książkę</a> do wypożyczenia."
 
 #: account/loans.html
 msgid "You've not checked out any books at this moment."
@@ -1343,8 +1343,8 @@ msgstr "Obecnie nie masz zaznaczonych żadnych książek."
 #, python-format
 msgid "%(count)d Current Loan"
 msgid_plural "%(count)d Current Loans"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%(count)d aktualne wypożyczenie"
+msgstr[1] "%(count)d aktualne wypożyczenia"
 
 #: account/loans.html admin/loans_table.html
 msgid "Loan Expires"
@@ -1358,8 +1358,8 @@ msgstr "Wypożycz..."
 #, python-format
 msgid "There is %(count)d person waiting for this book."
 msgid_plural "There are %(count)d people waiting for this book."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Czeka %(count)d osoba na tę książkę."
+msgstr[1] "Czekają %(count)d osoby na tę książkę."
 
 #: ManageLoansButtons.html account/loans.html
 msgid "Not yet downloaded."
@@ -1387,7 +1387,7 @@ msgstr "Opuść Listę Oczekujących"
 
 #: account/loans.html
 msgid "Are you sure you want to leave the waiting list of<br/><strong>TITLE</strong>?"
-msgstr ""
+msgstr "Czy na pewno chcesz opuścić listę oczekujących na<br/><strong>TITLE</strong>?"
 
 #: ProlificAuthors.html account/loans.html authors/index.html lists/list_follow.html lists/showcase.html publishers/view.html search/authors.html search/publishers.html search/subjects.html
 #, fuzzy, python-format
@@ -1404,8 +1404,8 @@ msgstr "Akcje"
 #, python-format
 msgid "Waiting for 1 day"
 msgid_plural "Waiting for %(count)d days"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Oczekuje 1 dzień"
+msgstr[1] "Oczekuje %(count)d dni"
 
 #: account/loans.html
 msgid "You are the next person to receive this book."
@@ -1426,8 +1426,8 @@ msgstr "Pozostało mniej niż godzina na wypożyczenie tej książki."
 #, python-format
 msgid "You have one more hour to borrow it."
 msgid_plural "You have %(hours)d more hours to borrow it."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Masz jeszcze jedną godzinę na wypożyczenie."
+msgstr[1] "Masz jeszcze %(hours)d godziny na wypożyczenie."
 
 #: ManageWaitlistButton.html account/loans.html
 msgid "Borrow Now"
@@ -1439,7 +1439,7 @@ msgstr "Opuścić listę oczekujących?"
 
 #: account/loans.html
 msgid "Looking for a book to borrow?  Check out our staff picks, or search for a book on a specific subject:"
-msgstr ""
+msgstr "Szukasz książki do wypożyczenia? Sprawdź nasze polecenia lub wyszukaj książkę na określony temat:"
 
 #: account/loans.html home/index.html
 msgid "Books We Love"
@@ -1447,7 +1447,7 @@ msgstr "Książki, które kochamy"
 
 #: account/loans.html
 msgid "Or, check out our <a href=\"/collections\">special collections</a>."
-msgstr ""
+msgstr "Lub sprawdź nasze <a href=\"/collections\">specjalne kolekcje</a>."
 
 #: account/mybooks.html
 msgid "No books are on this shelf"
@@ -1473,11 +1473,11 @@ msgstr "Ten użytkownik postanowił nie udostępniać swojego Dziennika Lektur"
 #: account/mybooks.html
 #, python-format
 msgid "%(year_span)s reading goal"
-msgstr ""
+msgstr "Cel czytelniczy %(year_span)s"
 
 #: account/mybooks.html
 msgid "View All Lists"
-msgstr ""
+msgstr "Zobacz wszystkie listy"
 
 #: account/mybooks.html
 #, fuzzy
@@ -1506,7 +1506,7 @@ msgstr "Mój profil"
 
 #: account/mybooks.html account/sidebar.html
 msgid "Import & Export Options"
-msgstr ""
+msgstr "Opcje importu i eksportu"
 
 #: account/not_verified.html account/verify/failed.html
 msgid "Oops!"
@@ -1520,11 +1520,11 @@ msgstr "E-mail nie mógł zostać zweryfikowany."
 #: account/not_verified.html
 #, python-format
 msgid "When you created your account, we sent an email to %(email)s that contained a link for you to verify your email address. We need you to click that link, please."
-msgstr ""
+msgstr "Kiedy tworzyłeś swoje konto, wysłaliśmy e-mail na adres %(email)s zawierający link do weryfikacji Twojego adresu e-mail. Prosimy kliknąć ten link."
 
 #: account/not_verified.html
 msgid "If you can't find the email, just hit this button to send a fresh one:"
-msgstr ""
+msgstr "Jeśli nie możesz znaleźć e-maila, kliknij ten przycisk, aby wysłać nowy:"
 
 #: account/not_verified.html account/verify/failed.html
 msgid "Resend the verification email"
@@ -1532,7 +1532,7 @@ msgstr "Wyślij e-mail weryfikacyjny ponownie"
 
 #: account/not_verified.html account/verify/failed.html
 msgid "Thanks!"
-msgstr ""
+msgstr "Dziękujemy!"
 
 #: BookByline.html FulltextSearchSuggestionItem.html SearchResultsWork.html account/notes.html account/observations.html
 msgid "Unknown author"
@@ -1550,7 +1550,7 @@ msgstr "brakuje imienia"
 
 #: account/notes.html lists/export_as_html.html type/work/editions.html
 msgid "Publish date unknown"
-msgstr ""
+msgstr "Data wydania nieznana"
 
 #: account/notes.html books/edition-sort.html lists/export_as_html.html type/work/editions.html
 msgid "Publisher unknown"
@@ -1559,7 +1559,7 @@ msgstr "Wydawnictwo nieznane"
 #: account/notes.html
 #, python-format
 msgid "in %(language)s"
-msgstr ""
+msgstr "w %(language)s"
 
 #: NotesModal.html account/notes.html
 #, fuzzy

--- a/openlibrary/i18n/pl/messages.po
+++ b/openlibrary/i18n/pl/messages.po
@@ -18,8 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.12.1\n"
 
-#: account.html account/notifications.html account/privacy.html
-#: lib/nav_head.html type/user/view.html
+#: account.html account/notifications.html account/privacy.html lib/nav_head.html type/user/view.html
 msgid "Settings"
 msgstr "Ustawienia"
 
@@ -36,10 +35,7 @@ msgstr "Wyświetl"
 msgid "or"
 msgstr "lub"
 
-#: account.html databarHistory.html databarTemplate.html databarView.html
-#: my_books/check_ins/check_in_prompt.html
-#: reading_goals/reading_goal_progress.html subjects.html
-#: type/edition/compact_title.html type/user/view.html
+#: account.html databarHistory.html databarTemplate.html databarView.html my_books/check_ins/check_in_prompt.html reading_goals/reading_goal_progress.html subjects.html type/edition/compact_title.html type/user/view.html
 msgid "Edit"
 msgstr "Edytuj"
 
@@ -104,22 +100,12 @@ msgid "New Batch Import"
 msgstr "Nowy import zbiorczy"
 
 #: batch_import.html
-msgid ""
-"Attach a JSONL formatted document with import records or copy/paste the "
-"JSONL text into the textarea."
-msgstr ""
-"Załącz dokument w formacie JSONL z rekordami importu lub wklej tekst "
-"JSONL do pola tekstowego."
+msgid "Attach a JSONL formatted document with import records or copy/paste the JSONL text into the textarea."
+msgstr "Załącz dokument w formacie JSONL z rekordami importu lub wklej tekst JSONL do pola tekstowego."
 
 #: batch_import.html
-msgid ""
-"See the <a href=\"https://github.com/internetarchive/openlibrary-"
-"client/tree/master/olclient/schemata\">olclient import schemata</a> for "
-"more."
-msgstr ""
-"Zobacz <a href=\"https://github.com/internetarchive/openlibrary-"
-"client/tree/master/olclient/schemata\">schematy importu olclient</a>, aby"
-" dowiedzieć się więcej."
+msgid "See the <a href=\"https://github.com/internetarchive/openlibrary-client/tree/master/olclient/schemata\">olclient import schemata</a> for more."
+msgstr "Zobacz <a href=\"https://github.com/internetarchive/openlibrary-client/tree/master/olclient/schemata\">schematy importu olclient</a>, aby dowiedzieć się więcej."
 
 #: batch_import.html
 msgid "Attach a file:"
@@ -141,17 +127,11 @@ msgstr "Nie udało się ustawić nowego hasła."
 
 #: batch_import.html
 msgid "No import will be queued until *every* record validates successfully."
-msgstr ""
-"Żaden import nie zostanie dodany do kolejki, dopóki *każdy* rekord nie "
-"przejdzie walidacji pomyślnie."
+msgstr "Żaden import nie zostanie dodany do kolejki, dopóki *każdy* rekord nie przejdzie walidacji pomyślnie."
 
 #: batch_import.html
-msgid ""
-"Please update the JSONL file and reload this page (there should be no "
-"need to reattach the file)."
-msgstr ""
-"Zaktualizuj plik JSONL i odśwież tę stronę (nie powinno być potrzeby "
-"ponownego załączania pliku)."
+msgid "Please update the JSONL file and reload this page (there should be no need to reattach the file)."
+msgstr "Zaktualizuj plik JSONL i odśwież tę stronę (nie powinno być potrzeby ponownego załączania pliku)."
 
 #: batch_import.html
 msgid "Validation errors:"
@@ -194,27 +174,21 @@ msgstr "Oczekujące importy zbiorcze"
 msgid "batch_id"
 msgstr "identyfikator_partii"
 
-#: admin/imports.html admin/imports_by_date.html batch_import_pending_view.html
-#: batch_import_view.html
+#: admin/imports.html admin/imports_by_date.html batch_import_pending_view.html batch_import_view.html
 #, fuzzy
 msgid "Added Time"
 msgstr "Dodano"
 
-#: account/import.html account/loans.html admin/imports.html
-#: admin/imports_by_date.html admin/loans_table.html admin/menu.html
-#: batch_import_pending_view.html batch_import_view.html
-#: librarian_dashboard/data_quality_table.html status.html
+#: account/import.html account/loans.html admin/imports.html admin/imports_by_date.html admin/loans_table.html admin/menu.html batch_import_pending_view.html batch_import_view.html librarian_dashboard/data_quality_table.html status.html
 msgid "Status"
 msgstr "Status"
 
-#: batch_import_pending_view.html batch_import_view.html
-#: merge_request_table/table_header.html
+#: batch_import_pending_view.html batch_import_view.html merge_request_table/table_header.html
 #, fuzzy
 msgid "Submitter"
 msgstr "Zatwierdź"
 
-#: RecentChangesAdmin.html batch_import_pending_view.html
-#: batch_import_view.html
+#: RecentChangesAdmin.html batch_import_pending_view.html batch_import_view.html
 #, fuzzy
 msgid "Comments"
 msgstr "Komentarz"
@@ -260,8 +234,7 @@ msgstr "Importuj elementy"
 msgid "Import Time"
 msgstr "Czas importu"
 
-#: account/import.html admin/imports.html admin/imports_by_date.html
-#: batch_import_view.html librarian_dashboard/data_quality_table.html
+#: account/import.html admin/imports.html admin/imports_by_date.html batch_import_view.html librarian_dashboard/data_quality_table.html
 msgid "Error"
 msgstr "Błąd"
 
@@ -342,8 +315,7 @@ msgstr "Anuluj i wróć."
 msgid "YAML Representation:"
 msgstr "Reprezentacja YAML:"
 
-#: BookPreview.html book_providers/read_button.html books/edit/edition.html
-#: editpage.html import_preview.html
+#: BookPreview.html book_providers/read_button.html books/edit/edition.html editpage.html import_preview.html
 msgid "Preview"
 msgstr "Podgląd"
 
@@ -355,21 +327,15 @@ msgstr "Historia zmian"
 msgid "Revision"
 msgstr "Korekta"
 
-#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
-#: admin/ip/view.html admin/people/edits.html history.html
-#: recentchanges/render.html recentchanges/updated_records.html
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html admin/ip/view.html admin/people/edits.html history.html recentchanges/render.html recentchanges/updated_records.html
 msgid "When"
 msgstr "Kiedy"
 
-#: RecentChanges.html admin/history.html admin/ip/view.html
-#: admin/loans_table.html admin/people/edits.html history.html
-#: recentchanges/render.html
+#: RecentChanges.html admin/history.html admin/ip/view.html admin/loans_table.html admin/people/edits.html history.html recentchanges/render.html
 msgid "Who"
 msgstr "Kto"
 
-#: RecentChanges.html RecentChangesUsers.html admin/history.html
-#: admin/ip/view.html admin/people/edits.html history.html
-#: recentchanges/render.html recentchanges/updated_records.html
+#: RecentChanges.html RecentChangesUsers.html admin/history.html admin/ip/view.html admin/people/edits.html history.html recentchanges/render.html recentchanges/updated_records.html
 msgid "Comment"
 msgstr "Komentarz"
 
@@ -436,29 +402,17 @@ msgstr "Przepraszamy, wystąpił problem podczas przetwarzania Twojego żądania
 
 #: internalerror.html
 #, python-format
-msgid ""
-"The reference code %s and Sentry trace ID %s have been created to track "
-"this error and we will investigate as we're able."
-msgstr ""
-"Kod referencyjny %s i identyfikator śladu Sentry %s zostały utworzone, "
-"aby śledzić ten błąd – zbadamy go w miarę możliwości."
+msgid "The reference code %s and Sentry trace ID %s have been created to track this error and we will investigate as we're able."
+msgstr "Kod referencyjny %s i identyfikator śladu Sentry %s zostały utworzone, aby śledzić ten błąd – zbadamy go w miarę możliwości."
 
 #: internalerror.html
 #, python-format
-msgid ""
-"The reference code %s has been created to track this error and we will "
-"investigate as we're able."
-msgstr ""
-"Kod referencyjny %s został utworzony, aby śledzić ten błąd – zbadamy go w"
-" miarę możliwości."
+msgid "The reference code %s has been created to track this error and we will investigate as we're able."
+msgstr "Kod referencyjny %s został utworzony, aby śledzić ten błąd – zbadamy go w miarę możliwości."
 
 #: internalerror.html
-msgid ""
-"Return to the <a class=\"go-back-link\" href=\"javascript:;\">previous "
-"page</a>?"
-msgstr ""
-"Wróć do <a class=\"go-back-link\" href=\"javascript:;\">poprzedniej "
-"strony</a>?"
+msgid "Return to the <a class=\"go-back-link\" href=\"javascript:;\">previous page</a>?"
+msgstr "Wróć do <a class=\"go-back-link\" href=\"javascript:;\">poprzedniej strony</a>?"
 
 #: interstitial.html
 msgid "You are being redirected to your book"
@@ -466,23 +420,15 @@ msgstr "Za chwilę zostaniesz przekierowany do swojej książki"
 
 #: interstitial.html
 #, python-format
-msgid ""
-"This book is provided by %(book_provider)s, a third-party Open Library "
-"Trusted Book Provider"
-msgstr ""
-"Ta książka jest udostępniana przez %(book_provider)s, zaufanego "
-"zewnętrznego dostawcę książek Open Library"
+msgid "This book is provided by %(book_provider)s, a third-party Open Library Trusted Book Provider"
+msgstr "Ta książka jest udostępniana przez %(book_provider)s, zaufanego zewnętrznego dostawcę książek Open Library"
 
 #: interstitial.html
 #, python-format
 msgid "In %(time)s seconds, you will be automatically redirected to: %(url)s"
 msgstr "Za %(time)s sekund zostaniesz automatycznie przekierowany do: %(url)s"
 
-#: CreateListModal.html EditButtons.html account/notifications.html
-#: account/password/reset.html account/privacy.html admin/imports-add.html
-#: admin/permissions.html books/add.html databarEdit.html interstitial.html
-#: merge/authors.html my_books/dropdown_content.html type/list/edit.html
-#: type/series/edit.html type/tag/form.html
+#: CreateListModal.html EditButtons.html account/notifications.html account/password/reset.html account/privacy.html admin/imports-add.html admin/permissions.html books/add.html databarEdit.html interstitial.html merge/authors.html my_books/dropdown_content.html type/list/edit.html type/series/edit.html type/tag/form.html
 msgid "Cancel"
 msgstr "Anuluj"
 
@@ -495,9 +441,7 @@ msgstr "Kontynuuj bez czekania"
 msgid "Library Explorer"
 msgstr "Biblioteka Kongresu"
 
-#: account/create.html books/custom_carousel.html
-#: librarian_dashboard/data_quality_table.html login.html
-#: search/work_search_facets.html
+#: account/create.html books/custom_carousel.html librarian_dashboard/data_quality_table.html login.html search/work_search_facets.html
 #, fuzzy
 msgid "Loading..."
 msgstr "zapisywanie..."
@@ -507,12 +451,8 @@ msgid "Log In"
 msgstr "Zaloguj się"
 
 #: login.html
-msgid ""
-"This is a development instance, the default credentials are automatically"
-" filled."
-msgstr ""
-"To jest instancja deweloperska – domyślne dane logowania są wypełniane "
-"automatycznie."
+msgid "This is a development instance, the default credentials are automatically filled."
+msgstr "To jest instancja deweloperska – domyślne dane logowania są wypełniane automatycznie."
 
 #: login.html
 #, fuzzy
@@ -525,12 +465,8 @@ msgid "password:"
 msgstr "Hasło"
 
 #: login.html
-msgid ""
-"Log in to use your free Open Library card to borrow digital books from "
-"the nonprofit Internet Archive"
-msgstr ""
-"Zaloguj się, aby używać bezpłatnej karty Open Library do wypożyczania "
-"cyfrowych książek od organizacji non-profit Internet Archive"
+msgid "Log in to use your free Open Library card to borrow digital books from the nonprofit Internet Archive"
+msgstr "Zaloguj się, aby używać bezpłatnej karty Open Library do wypożyczania cyfrowych książek od organizacji non-profit Internet Archive"
 
 #: account/create.html login.html
 #, fuzzy
@@ -544,22 +480,12 @@ msgstr "Jeśteś już zarejestrowany w Open Library jako %(user)s."
 
 #: account/create.html login.html
 #, fuzzy
-msgid ""
-"If you'd like to create a new, different Open Library account, you'll "
-"need to <a href=\"javascript:;\" onclick=\"document.forms['hamburger-"
-"logout'].submit()\">log out</a> and start the signup process afresh."
-msgstr ""
-"Jeśli chcesz utworzyć nowe konto na Open Library <a href=\"javascript:;\""
-" onclick=\"document.forms['logout'].submit()\">Wyloguj się</a> i utwórz "
-"nowe konto."
+msgid "If you'd like to create a new, different Open Library account, you'll need to <a href=\"javascript:;\" onclick=\"document.forms['hamburger-logout'].submit()\">log out</a> and start the signup process afresh."
+msgstr "Jeśli chcesz utworzyć nowe konto na Open Library <a href=\"javascript:;\" onclick=\"document.forms['logout'].submit()\">Wyloguj się</a> i utwórz nowe konto."
 
 #: login.html
-msgid ""
-"Please enter your <a href=\"https://archive.org\">Internet Archive</a> "
-"email and password to access your Open Library account."
-msgstr ""
-"Wprowadź swój <a href=\"https://archive.org\">Internet Archive</a> e-mail"
-" i hasło umożliwiające dostęp do konta Open Library."
+msgid "Please enter your <a href=\"https://archive.org\">Internet Archive</a> email and password to access your Open Library account."
+msgstr "Wprowadź swój <a href=\"https://archive.org\">Internet Archive</a> e-mail i hasło umożliwiające dostęp do konta Open Library."
 
 #: login.html openlibrary/plugins/upstream/forms.py
 msgid "Email"
@@ -569,8 +495,7 @@ msgstr "E-mail"
 msgid "Forgot your Internet Archive email?"
 msgstr "Nie pamiętasz e-maila z Internet Archive?"
 
-#: account/email/forgot-ia.html login.html
-#: openlibrary/plugins/upstream/forms.py
+#: account/email/forgot-ia.html login.html openlibrary/plugins/upstream/forms.py
 msgid "Password"
 msgstr "Hasło"
 
@@ -589,9 +514,7 @@ msgstr "\"Zapamniętaj mnie"
 #: login.html
 #, fuzzy
 msgid "Don't have an account? <a href=\"/account/create\">Sign up now</a>."
-msgstr ""
-"Nie masz jeszcze konta na Open Library? <a "
-"href=\"/account/create\">Utwórz konto</a>."
+msgstr "Nie masz jeszcze konta na Open Library? <a href=\"/account/create\">Utwórz konto</a>."
 
 #: messages.html
 #, fuzzy
@@ -617,10 +540,7 @@ msgstr "Dodaj książkę"
 msgid "Thank you for improving the Open Library catalog!"
 msgstr "Dziękujemy za ulepszanie katalogu Open Library!"
 
-#: BookPreview.html CreateListModal.html NotesModal.html ObservationsModal.html
-#: ShareModal.html covers/author_photo.html covers/book_cover.html
-#: covers/change.html lib/exports.html my_books/check_ins/check_in_prompt.html
-#: my_books/dropdown_content.html native_dialog.html
+#: BookPreview.html CreateListModal.html NotesModal.html ObservationsModal.html ShareModal.html covers/author_photo.html covers/book_cover.html covers/change.html lib/exports.html my_books/check_ins/check_in_prompt.html my_books/dropdown_content.html native_dialog.html
 msgid "Close"
 msgstr "Zamknij"
 
@@ -677,21 +597,13 @@ msgstr "Odmowa zezwolenia."
 
 #: permission_denied.html
 #, python-format
-msgid ""
-"Only logged users are allowed to add records on Open Library. Please <a "
-"href=\"%s\">log in</a> to add a book."
-msgstr ""
-"Tylko zalogowani użytkownicy mogą dodawać rekordy w Open Library. Proszę "
-"<a href=\"%s\">zaloguj się</a>, aby dodać książkę."
+msgid "Only logged users are allowed to add records on Open Library. Please <a href=\"%s\">log in</a> to add a book."
+msgstr "Tylko zalogowani użytkownicy mogą dodawać rekordy w Open Library. Proszę <a href=\"%s\">zaloguj się</a>, aby dodać książkę."
 
 #: permission_denied.html
 #, python-format
-msgid ""
-"Only logged users are allowed to modify records on Open Library. Please "
-"<a href=\"%s\">log in</a> to edit this page."
-msgstr ""
-"Tylko zalogowani użytkownicy mogą modyfikować rekordy w Open Library. "
-"Proszę <a href=\"%s\">zaloguj się</a>, aby edytować tę stronę."
+msgid "Only logged users are allowed to modify records on Open Library. Please <a href=\"%s\">log in</a> to edit this page."
+msgstr "Tylko zalogowani użytkownicy mogą modyfikować rekordy w Open Library. Proszę <a href=\"%s\">zaloguj się</a>, aby edytować tę stronę."
 
 #: permission_denied.html
 #, python-format
@@ -700,12 +612,8 @@ msgstr "Możesz się <a href=\"%s\">zalogować</a> jeśli masz wymagane uprawnie
 
 #: recaptcha.html
 #, fuzzy
-msgid ""
-"Please satisfy the reCAPTCHA below. If you have security settings or "
-"privacy blockers installed, please disable them to see the reCAPTCHA."
-msgstr ""
-"Jeśli nie widzisz reCAPTCHA, wyłącz chwilowo ustawienia zabezpieczeń lub "
-"inne programy blokujące prywatność."
+msgid "Please satisfy the reCAPTCHA below. If you have security settings or privacy blockers installed, please disable them to see the reCAPTCHA."
+msgstr "Jeśli nie widzisz reCAPTCHA, wyłącz chwilowo ustawienia zabezpieczeń lub inne programy blokujące prywatność."
 
 #: recaptcha.html
 msgid "Incorrect. Please try again."
@@ -729,8 +637,7 @@ msgstr "Pole wymagane"
 msgid "Source"
 msgstr "więcej"
 
-#: books/add.html covers/add.html showia.html type/edition/view.html
-#: type/work/view.html
+#: books/add.html covers/add.html showia.html type/edition/view.html type/work/view.html
 msgid "Internet Archive"
 msgstr "Internet Archive"
 
@@ -801,16 +708,11 @@ msgstr "Dodaj PR(y)"
 msgid "PR"
 msgstr "PR"
 
-#: books/add.html books/edit.html books/edit/edition.html
-#: search/advancedsearch.html status.html type/about/edit.html
-#: type/page/edit.html type/template/edit.html
+#: books/add.html books/edit.html books/edit/edition.html search/advancedsearch.html status.html type/about/edit.html type/page/edit.html type/template/edit.html
 msgid "Title"
 msgstr "Tytuł"
 
-#: books/add.html books/edit.html books/edit/edition.html
-#: openlibrary/plugins/worksearch/code.py search/advancedsearch.html
-#: search/search_modal_i18n.html search/work_search_selected_facets.html
-#: status.html
+#: books/add.html books/edit.html books/edit/edition.html openlibrary/plugins/worksearch/code.py search/advancedsearch.html search/search_modal_i18n.html search/work_search_selected_facets.html status.html
 msgid "Author"
 msgstr "Autor"
 
@@ -905,8 +807,7 @@ msgstr "Zobacz PR-y na GitHub"
 msgid "Show changed files"
 msgstr "Nie zmnieniono"
 
-#: admin/inspect/store.html admin/people/index.html status.html
-#: type/author/edit.html type/language/view.html
+#: admin/inspect/store.html admin/people/index.html status.html type/author/edit.html type/language/view.html
 msgid "Name"
 msgstr "Imię i nazwisko"
 
@@ -952,8 +853,7 @@ msgstr "Ujednoznacznienia"
 msgid "Now"
 msgstr "Nie"
 
-#: admin/graphs.html admin/index.html my_books/check_ins/check_in_form.html
-#: my_books/check_ins/check_in_prompt.html trending.html
+#: admin/graphs.html admin/index.html my_books/check_ins/check_in_form.html my_books/check_ins/check_in_prompt.html trending.html
 msgid "Today"
 msgstr "Dziś"
 
@@ -990,8 +890,7 @@ msgstr "Najwcześniejsze dane o trendach pochodzą z października 2017"
 
 #. Label for the reading log shelf for books the user plans to read in the
 #. future (bookshelf ID 1). Used as a button label and shelf name.
-#: account/mybooks.html account/sidebar.html my_books/dropdown_content.html
-#: my_books/primary_action.html search/sort_options.html trending.html
+#: account/mybooks.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html trending.html
 msgid "Want to Read"
 msgstr "Chcę przeczytać"
 
@@ -999,15 +898,11 @@ msgstr "Chcę przeczytać"
 #. headings and breadcrumbs.
 #. Label for the reading log shelf for books the user is actively reading
 #. (bookshelf ID 2). Used as a button label and shelf name.
-#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
-#: my_books/dropdown_content.html my_books/primary_action.html
-#: search/sort_options.html trending.html
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html trending.html
 msgid "Currently Reading"
 msgstr "W trakcie czytania"
 
-#: LoanReadForm.html ReadButton.html admin/inspect/memcache.html
-#: book_providers/read_button.html books/edit/edition.html trending.html
-#: type/list/embed.html widget.html
+#: LoanReadForm.html ReadButton.html admin/inspect/memcache.html book_providers/read_button.html books/edit/edition.html trending.html type/list/embed.html widget.html
 msgid "Read"
 msgstr "Przeczytaj"
 
@@ -1017,9 +912,7 @@ msgstr "Przeczytaj"
 #. finishing (bookshelf ID 4). Used as a button label and shelf name.
 #. Label for the reading log shelf for books the user stopped reading
 #. (bookshelf ID 4). Used as a button label and shelf name.
-#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
-#: my_books/dropdown_content.html my_books/primary_action.html
-#: search/sort_options.html trending.html
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html search/sort_options.html trending.html
 msgid "Stopped Reading"
 msgstr "Przestał czytać"
 
@@ -1100,12 +993,8 @@ msgstr "Dowiedz się więcej"
 
 #: widget.html
 #, python-format
-msgid ""
-"on <a target=\"_blank\" rel=\"noopener noreferrer\" "
-"href=\"%(link)s\">openlibrary.org</a>"
-msgstr ""
-"na <a target=\"_blank\" rel=\"noopener noreferrer\" "
-"href=\"%(link)s\">openlibrary.org</a>"
+msgid "on <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"%(link)s\">openlibrary.org</a>"
+msgstr "na <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"%(link)s\">openlibrary.org</a>"
 
 #: work_search.html
 #, fuzzy
@@ -1126,8 +1015,7 @@ msgstr "To jest widoczne tylko dla super bibliotekarzy."
 msgid "Solr Editions"
 msgstr "Większość wydań"
 
-#: design/toggle.html openlibrary/plugins/worksearch/code.py
-#: search/availability_i18n.html work_search.html
+#: design/toggle.html openlibrary/plugins/worksearch/code.py search/availability_i18n.html work_search.html
 #, fuzzy
 msgid "Readable Only"
 msgstr "Tylko administratorzy"
@@ -1136,8 +1024,7 @@ msgstr "Tylko administratorzy"
 msgid "Filter by availability"
 msgstr "Filtruj według dostępności"
 
-#: openlibrary/plugins/worksearch/code.py search/search_modal_i18n.html
-#: type/edition/view.html type/work/view.html work_search.html
+#: openlibrary/plugins/worksearch/code.py search/search_modal_i18n.html type/edition/view.html type/work/view.html work_search.html
 msgid "Language"
 msgstr "Język"
 
@@ -1146,8 +1033,7 @@ msgstr "Język"
 msgid "Search languages…"
 msgstr "Wybierz ten język"
 
-#: books/edit/edition.html languages/index.html search/search_modal_i18n.html
-#: work_search.html
+#: books/edit/edition.html languages/index.html search/search_modal_i18n.html work_search.html
 #, fuzzy
 msgid "Languages"
 msgstr "Język"
@@ -1171,9 +1057,7 @@ msgstr "Pełny URL:"
 #: work_search.html
 #, python-format
 msgid "No <strong>%(path_id)s</strong> directly matched your search."
-msgstr ""
-"Żaden <strong>%(path_id)s</strong> nie pasuje bezpośrednio do Twojego "
-"wyszukiwania."
+msgstr "Żaden <strong>%(path_id)s</strong> nie pasuje bezpośrednio do Twojego wyszukiwania."
 
 #: work_search.html
 #, fuzzy
@@ -1185,8 +1069,7 @@ msgstr "Dodaj książkę"
 msgid "Checking Search Inside matches"
 msgstr "Szukaj w"
 
-#: account/reading_log.html search/authors.html search/lists.html
-#: search/subjects.html work_search.html
+#: account/reading_log.html search/authors.html search/lists.html search/subjects.html work_search.html
 #, python-format
 msgid "%(count)s hit"
 msgid_plural "%(count)s hits"
@@ -1204,12 +1087,8 @@ msgid "The Open Library Team"
 msgstr "Open Library"
 
 #: about/index.html
-msgid ""
-"Open Library is made possible because of a dedicated team of staff and "
-"over 100 volunteers from around the globe."
-msgstr ""
-"Open Library jest możliwe dzięki zaangażowanemu zespołowi pracowników i "
-"ponad 100 wolontariuszy z całego świata."
+msgid "Open Library is made possible because of a dedicated team of staff and over 100 volunteers from around the globe."
+msgstr "Open Library jest możliwe dzięki zaangażowanemu zespołowi pracowników i ponad 100 wolontariuszy z całego świata."
 
 #: about/index.html
 msgid "Want to join us?"
@@ -1260,16 +1139,8 @@ msgid "Librarianship"
 msgstr "Bibliotekarstwo"
 
 #: about/index.html
-msgid ""
-"If you volunteer with Open Library and would like to be listed as part of"
-" the team, then complete the <a "
-"href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">Open Library team "
-"information form</a>."
-msgstr ""
-"Jeśli wolontariacko pracujesz z Open Library i chcesz być wymieniony jako"
-" część zespołu, wypełnij <a "
-"href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">formularz informacyjny "
-"zespołu Open Library</a>."
+msgid "If you volunteer with Open Library and would like to be listed as part of the team, then complete the <a href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">Open Library team information form</a>."
+msgstr "Jeśli wolontariacko pracujesz z Open Library i chcesz być wymieniony jako część zespołu, wypełnij <a href=\"https://forms.gle/zPyuXGf4Bg6RzbDA7\">formularz informacyjny zespołu Open Library</a>."
 
 #: account/create.html openlibrary/plugins/upstream/forms.py
 msgid "Must be a valid email address"
@@ -1296,12 +1167,8 @@ msgid "Sign Up"
 msgstr "Załóż konto"
 
 #: account/create.html
-msgid ""
-"Get your free Open Library card and borrow digital books from the "
-"nonprofit Internet Archive"
-msgstr ""
-"Zdobądź bezpłatną kartę Open Library i wypożyczaj cyfrowe książki od "
-"organizacji non-profit Internet Archive"
+msgid "Get your free Open Library card and borrow digital books from the nonprofit Internet Archive"
+msgstr "Zdobądź bezpłatną kartę Open Library i wypożyczaj cyfrowe książki od organizacji non-profit Internet Archive"
 
 #: account/create.html type/author/view.html
 msgid "Success!"
@@ -1318,51 +1185,28 @@ msgid "screenname"
 msgstr "Nazwa użytkownika"
 
 #: account/create.html
-msgid ""
-"I want to receive news, announcements, and resources from the <a "
-"href=\"https://archive.org/\">Internet Archive</a>, the non-profit that "
-"runs Open Library."
-msgstr ""
-"Chcę otrzymywać wiadomości, ogłoszenia i zasoby od <a "
-"href=\"https://archive.org/\">Internet Archive</a>, organizacji non-"
-"profit prowadzącej Open Library."
+msgid "I want to receive news, announcements, and resources from the <a href=\"https://archive.org/\">Internet Archive</a>, the non-profit that runs Open Library."
+msgstr "Chcę otrzymywać wiadomości, ogłoszenia i zasoby od <a href=\"https://archive.org/\">Internet Archive</a>, organizacji non-profit prowadzącej Open Library."
 
 #: account/create.html
-msgid ""
-"I want to apply* for <a href=\"https://help.archive.org/help/program-"
-"overview/\" target=\"_blank\" rel=\"noopener noreferrer\">special print "
-"disability access</a> through a qualifying program."
-msgstr ""
-"Chcę ubiegać się* o <a href=\"https://help.archive.org/help/program-"
-"overview/\" target=\"_blank\" rel=\"noopener noreferrer\">specjalny "
-"dostęp dla osób z niepełnosprawnością druku</a> przez kwalifikujący "
-"program."
+msgid "I want to apply* for <a href=\"https://help.archive.org/help/program-overview/\" target=\"_blank\" rel=\"noopener noreferrer\">special print disability access</a> through a qualifying program."
+msgstr "Chcę ubiegać się* o <a href=\"https://help.archive.org/help/program-overview/\" target=\"_blank\" rel=\"noopener noreferrer\">specjalny dostęp dla osób z niepełnosprawnością druku</a> przez kwalifikujący program."
 
 #: account/create.html
 msgid "Select qualifying program"
 msgstr "Wybierz kwalifikujący program"
 
 #: account/create.html
-msgid ""
-"* Please use the email address associated with this qualifying program. "
-"You will receive an email after activation with next steps."
-msgstr ""
-"* Proszę użyć adresu e-mail powiązanego z tym kwalifikującym programem. "
-"Po aktywacji otrzymasz e-mail z kolejnymi krokami."
+msgid "* Please use the email address associated with this qualifying program. You will receive an email after activation with next steps."
+msgstr "* Proszę użyć adresu e-mail powiązanego z tym kwalifikującym programem. Po aktywacji otrzymasz e-mail z kolejnymi krokami."
 
 #: account/create.html
 msgid "Sign Up with Email"
 msgstr "Zarejestruj się przez e-mail"
 
 #: account/create.html
-msgid ""
-"By signing up, you agree to the Internet Archive's <a class=\"ol-signup-"
-"form__link\" href=\"//archive.org/about/terms.php\" target=\"_blank\" "
-"rel=\"noopener noreferrer\">Terms of Service</a>."
-msgstr ""
-"Rejestrując się, zgadzasz się z <a class=\"ol-signup-form__link\" "
-"href=\"//archive.org/about/terms.php\" target=\"_blank\" rel=\"noopener "
-"noreferrer\">Warunkami usługi</a> Internet Archive."
+msgid "By signing up, you agree to the Internet Archive's <a class=\"ol-signup-form__link\" href=\"//archive.org/about/terms.php\" target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
+msgstr "Rejestrując się, zgadzasz się z <a class=\"ol-signup-form__link\" href=\"//archive.org/about/terms.php\" target=\"_blank\" rel=\"noopener noreferrer\">Warunkami usługi</a> Internet Archive."
 
 #: account/create.html
 msgid "Already have an account? <a href=\"/account/login\">Log in</a>"
@@ -1386,14 +1230,8 @@ msgid "Import from Goodreads"
 msgstr "Importuj z Goodreads"
 
 #: account/import.html
-msgid ""
-"For instructions on exporting data refer to: <a "
-"href=\"https://www.goodreads.com/review/import\">Goodreads "
-"Import/Export</a>"
-msgstr ""
-"Instrukcje dotyczące eksportu danych znajdziesz tutaj: <a "
-"href=\"https://www.goodreads.com/review/import\">Goodreads "
-"Import/Export</a>"
+msgid "For instructions on exporting data refer to: <a href=\"https://www.goodreads.com/review/import\">Goodreads Import/Export</a>"
+msgstr "Instrukcje dotyczące eksportu danych znajdziesz tutaj: <a href=\"https://www.goodreads.com/review/import\">Goodreads Import/Export</a>"
 
 #: account/import.html
 msgid "File size limit 10MB and .csv file type only"
@@ -1548,16 +1386,10 @@ msgid "Leave the Waiting List"
 msgstr "Opuść Listę Oczekujących"
 
 #: account/loans.html
-msgid ""
-"Are you sure you want to leave the waiting list "
-"of<br/><strong>TITLE</strong>?"
-msgstr ""
-"Czy na pewno chcesz opuścić listę oczekujących "
-"na<br/><strong>TITLE</strong>?"
+msgid "Are you sure you want to leave the waiting list of<br/><strong>TITLE</strong>?"
+msgstr "Czy na pewno chcesz opuścić listę oczekujących na<br/><strong>TITLE</strong>?"
 
-#: ProlificAuthors.html account/loans.html authors/index.html
-#: lists/list_follow.html lists/showcase.html publishers/view.html
-#: search/authors.html search/publishers.html search/subjects.html
+#: ProlificAuthors.html account/loans.html authors/index.html lists/list_follow.html lists/showcase.html publishers/view.html search/authors.html search/publishers.html search/subjects.html
 #, fuzzy, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
@@ -1606,12 +1438,8 @@ msgid "Leave the waiting list?"
 msgstr "Opuścić listę oczekujących?"
 
 #: account/loans.html
-msgid ""
-"Looking for a book to borrow?  Check out our staff picks, or search for a"
-" book on a specific subject:"
-msgstr ""
-"Szukasz książki do wypożyczenia? Sprawdź nasze polecenia lub wyszukaj "
-"książkę na określony temat:"
+msgid "Looking for a book to borrow?  Check out our staff picks, or search for a book on a specific subject:"
+msgstr "Szukasz książki do wypożyczenia? Sprawdź nasze polecenia lub wyszukaj książkę na określony temat:"
 
 #: account/loans.html home/index.html
 msgid "Books We Love"
@@ -1633,9 +1461,7 @@ msgstr "Wypożyczone przeze mnie"
 #. and breadcrumbs.
 #. Label for the reading log shelf for books the user has finished reading
 #. (bookshelf ID 3). Used as a button label and shelf name.
-#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
-#: my_books/dropdown_content.html my_books/primary_action.html
-#: openlibrary/plugins/upstream/mybooks.py search/sort_options.html
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html my_books/dropdown_content.html my_books/primary_action.html openlibrary/plugins/upstream/mybooks.py search/sort_options.html
 msgid "Already Read"
 msgstr "Przeczytane"
 
@@ -1663,8 +1489,7 @@ msgstr "Moje listy"
 msgid "My Reading Stats"
 msgstr "Moje listy lektur:"
 
-#: account/mybooks.html account/sidebar.html
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
+#: account/mybooks.html account/sidebar.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py
 #, fuzzy
 msgid "Loan History"
 msgstr "Historia"
@@ -1694,14 +1519,8 @@ msgstr "E-mail nie mógł zostać zweryfikowany."
 
 #: account/not_verified.html
 #, python-format
-msgid ""
-"When you created your account, we sent an email to %(email)s that "
-"contained a link for you to verify your email address. We need you to "
-"click that link, please."
-msgstr ""
-"Kiedy tworzyłeś swoje konto, wysłaliśmy e-mail na adres %(email)s "
-"zawierający link do weryfikacji Twojego adresu e-mail. Prosimy kliknąć "
-"ten link."
+msgid "When you created your account, we sent an email to %(email)s that contained a link for you to verify your email address. We need you to click that link, please."
+msgstr "Kiedy tworzyłeś swoje konto, wysłaliśmy e-mail na adres %(email)s zawierający link do weryfikacji Twojego adresu e-mail. Prosimy kliknąć ten link."
 
 #: account/not_verified.html
 msgid "If you can't find the email, just hit this button to send a fresh one:"
@@ -1715,8 +1534,7 @@ msgstr "Wyślij e-mail weryfikacyjny ponownie"
 msgid "Thanks!"
 msgstr "Dziękujemy!"
 
-#: BookByline.html FulltextSearchSuggestionItem.html SearchResultsWork.html
-#: account/notes.html account/observations.html
+#: BookByline.html FulltextSearchSuggestionItem.html SearchResultsWork.html account/notes.html account/observations.html
 msgid "Unknown author"
 msgstr "Nieznany autor"
 
@@ -1734,8 +1552,7 @@ msgstr "brakuje imienia"
 msgid "Publish date unknown"
 msgstr "Data wydania nieznana"
 
-#: account/notes.html books/edition-sort.html lists/export_as_html.html
-#: type/work/editions.html
+#: account/notes.html books/edition-sort.html lists/export_as_html.html type/work/editions.html
 msgid "Publisher unknown"
 msgstr "Wydawnictwo nieznane"
 
@@ -1768,14 +1585,8 @@ msgid "Notifications"
 msgstr "Powiadomienia"
 
 #: account/notifications.html
-msgid ""
-"Notifications are connected to Lists at the moment. If one of the books "
-"on your list gets edited, or a new book comes into the catalog, we'll let"
-" you know, if you want."
-msgstr ""
-"Powiadomienia są teraz związane z Listami. kiedy książka na Twojej liście"
-" będzie edytowana, lub nowa książka jest dodana do katalogu,  dostaniesz "
-"o tym powiadomienie, jeśli chcesz."
+msgid "Notifications are connected to Lists at the moment. If one of the books on your list gets edited, or a new book comes into the catalog, we'll let you know, if you want."
+msgstr "Powiadomienia są teraz związane z Listami. kiedy książka na Twojej liście będzie edytowana, lub nowa książka jest dodana do katalogu,  dostaniesz o tym powiadomienie, jeśli chcesz."
 
 #: account/notifications.html
 msgid "Would you like to receive very occasional emails from Open Library?"
@@ -1789,13 +1600,11 @@ msgstr "Nie, dziękuję"
 msgid "Yes! Please!"
 msgstr "Tak, poproszę!"
 
-#: EditButtons.html account/notifications.html account/privacy.html
-#: admin/block.html admin/spamwords.html covers/manage.html
+#: EditButtons.html account/notifications.html account/privacy.html admin/block.html admin/spamwords.html covers/manage.html
 msgid "Save"
 msgstr "Zachowaj"
 
-#: EditionNavBar.html account/observations.html
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
+#: EditionNavBar.html account/observations.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #, fuzzy
 msgid "Reviews"
 msgstr "Wyświetl"
@@ -1824,22 +1633,12 @@ msgid "Privacy & Content Moderation Settings"
 msgstr "Ustawienia prywatności"
 
 #: account/privacy.html
-msgid ""
-"Would you like to make your <a href=\"/account/books\">Reading Log</a> "
-"public?"
-msgstr ""
-"Czy chcesz upublicznić swój <a href=\"/account/books\">Dziennik "
-"Lektury</a>?"
+msgid "Would you like to make your <a href=\"/account/books\">Reading Log</a> public?"
+msgstr "Czy chcesz upublicznić swój <a href=\"/account/books\">Dziennik Lektury</a>?"
 
 #: account/privacy.html
-msgid ""
-"This will enable others to see what books you want to read, are reading, "
-"stopped reading, or have already read. Patrons with reading logs set to "
-"public may be followed."
-msgstr ""
-"Umożliwi to innym zobaczenie, jakie książki chcesz przeczytać, czytasz, "
-"przestałeś czytać lub już przeczytałeś. Użytkownicy z publicznymi "
-"dziennikami lektury mogą być obserwowani."
+msgid "This will enable others to see what books you want to read, are reading, stopped reading, or have already read. Patrons with reading logs set to public may be followed."
+msgstr "Umożliwi to innym zobaczenie, jakie książki chcesz przeczytać, czytasz, przestałeś czytać lub już przeczytałeś. Użytkownicy z publicznymi dziennikami lektury mogą być obserwowani."
 
 #: account/privacy.html admin/people/view.html
 msgid "Yes"
@@ -1854,12 +1653,8 @@ msgid "Enable Safe Mode?"
 msgstr "Włączyć tryb bezpieczny?"
 
 #: account/privacy.html
-msgid ""
-"Safe Mode blurs book covers that have been flagged as having sensitive "
-"imagery."
-msgstr ""
-"Tryb bezpieczny rozmywa okładki książek oznaczone jako zawierające "
-"wrażliwe treści graficzne."
+msgid "Safe Mode blurs book covers that have been flagged as having sensitive imagery."
+msgstr "Tryb bezpieczny rozmywa okładki książek oznaczone jako zawierające wrażliwe treści graficzne."
 
 #: account/reading_log.html
 #, python-format
@@ -1868,12 +1663,8 @@ msgstr "Książki, które obecnie czyta %(username)s"
 
 #: account/reading_log.html
 #, python-format
-msgid ""
-"%(username)s is reading %(total)d books. Join %(username)s on "
-"OpenLibrary.org and tell the world what you're reading."
-msgstr ""
-"%(username)s czyta %(total)d książek. Dołącz do %(username)s na "
-"OpenLibrary.org i powiedz światu, co czytasz."
+msgid "%(username)s is reading %(total)d books. Join %(username)s on OpenLibrary.org and tell the world what you're reading."
+msgstr "%(username)s czyta %(total)d książek. Dołącz do %(username)s na OpenLibrary.org i powiedz światu, co czytasz."
 
 #: account/reading_log.html
 #, python-format
@@ -1882,12 +1673,8 @@ msgstr "Książki, które %(username)s chce przeczytać"
 
 #: account/reading_log.html
 #, python-format
-msgid ""
-"%(username)s wants to read %(total)d books. Join %(username)s on "
-"OpenLibrary.org and share the books that you'll soon be reading!"
-msgstr ""
-"%(username)s chce przeczytać %(total)d książek. Dołącz do %(username)s na"
-" OpenLibrary.org i pokaż światu, co będziesz wkrótce czytać!"
+msgid "%(username)s wants to read %(total)d books. Join %(username)s on OpenLibrary.org and share the books that you'll soon be reading!"
+msgstr "%(username)s chce przeczytać %(total)d książek. Dołącz do %(username)s na OpenLibrary.org i pokaż światu, co będziesz wkrótce czytać!"
 
 #: account/reading_log.html
 #, fuzzy, python-format
@@ -1896,12 +1683,8 @@ msgstr "Książki, które obecnie czyta %(username)s"
 
 #: account/reading_log.html
 #, fuzzy, python-format
-msgid ""
-"%(username)s stopped reading %(total)d books. Join %(username)s on "
-"OpenLibrary.org to share your own reading updates!"
-msgstr ""
-"%(username)s chce przeczytać %(total)d książek. Dołącz do %(username)s na"
-" OpenLibrary.org i pokaż światu, co będziesz wkrótce czytać!"
+msgid "%(username)s stopped reading %(total)d books. Join %(username)s on OpenLibrary.org to share your own reading updates!"
+msgstr "%(username)s chce przeczytać %(total)d książek. Dołącz do %(username)s na OpenLibrary.org i pokaż światu, co będziesz wkrótce czytać!"
 
 #: account/reading_log.html
 #, python-format
@@ -1910,13 +1693,8 @@ msgstr "Książki przeczytane przez %(username)s w %(year)d"
 
 #: account/reading_log.html
 #, python-format
-msgid ""
-"%(username)s has read %(total)d books in %(year)d. Join %(username)s on "
-"OpenLibrary.org and tell the world about the books that you care about."
-msgstr ""
-"%(username)s przeczytał(a) %(total)d książek w %(year)d. Dołącz do "
-"%(username)s na OpenLibrary.org i opowiedz światu o książkach, które są "
-"dla Ciebie ważne."
+msgid "%(username)s has read %(total)d books in %(year)d. Join %(username)s on OpenLibrary.org and tell the world about the books that you care about."
+msgstr "%(username)s przeczytał(a) %(total)d książek w %(year)d. Dołącz do %(username)s na OpenLibrary.org i opowiedz światu o książkach, które są dla Ciebie ważne."
 
 #: account/reading_log.html
 #, python-format
@@ -1925,13 +1703,8 @@ msgstr "Książki przeczytane przez %(username)s"
 
 #: account/reading_log.html
 #, python-format
-msgid ""
-"%(username)s has read %(total)d books. Join %(username)s on "
-"OpenLibrary.org and tell the world about the books that you care about."
-msgstr ""
-"%(username)s przeczytał\\(a\\) %(total)d książek. Dołącz do %(username)s "
-"na OpenLibrary.org i powiedz światu o książkach, które są dla Ciebie "
-"ważne."
+msgid "%(username)s has read %(total)d books. Join %(username)s on OpenLibrary.org and tell the world about the books that you care about."
+msgstr "%(username)s przeczytał\\(a\\) %(total)d książek. Dołącz do %(username)s na OpenLibrary.org i powiedz światu o książkach, które są dla Ciebie ważne."
 
 #: account/reading_log.html
 #, fuzzy, python-format
@@ -1979,21 +1752,12 @@ msgid "You haven't added any books to this shelf yet."
 msgstr "Obecnie nie masz zaznaczonych żadnych książek."
 
 #: account/reading_log.html
-msgid ""
-"<a href=\"/search\">Search for a book</a> to add to your reading log. <a "
-"href=\"/help/faq/reading-log\">Learn more</a> about the reading log."
-msgstr ""
-"<a href=\"/search\">Wyszukaj książkę</a>, aby dodać ją do dziennika "
-"lektury. <a href=\"/help/faq/reading-log\">Dowiedz się więcej</a> o "
-"dzienniku lektury."
+msgid "<a href=\"/search\">Search for a book</a> to add to your reading log. <a href=\"/help/faq/reading-log\">Learn more</a> about the reading log."
+msgstr "<a href=\"/search\">Wyszukaj książkę</a>, aby dodać ją do dziennika lektury. <a href=\"/help/faq/reading-log\">Dowiedz się więcej</a> o dzienniku lektury."
 
 #: account/reading_log.html
-msgid ""
-"There are no recent books in your feed. When you follow public accounts, "
-"their book updates will appear here."
-msgstr ""
-"W Twoim kanale nie ma ostatnich książek. Gdy zaczniesz obserwować "
-"publiczne konta, ich aktualizacje książek będą się tutaj pojawiać."
+msgid "There are no recent books in your feed. When you follow public accounts, their book updates will appear here."
+msgstr "W Twoim kanale nie ma ostatnich książek. Gdy zaczniesz obserwować publiczne konta, ich aktualizacje książek będą się tutaj pojawiać."
 
 #. Display name for the "want-to-read" reading log shelf used in page headings
 #. and breadcrumbs.
@@ -2013,13 +1777,8 @@ msgstr "Moje książki"
 
 #: account/readinglog_stats.html
 #, python-format
-msgid ""
-"Displaying stats about <strong>%(works_count)d</strong> books. Note all "
-"charts show only the top 20 bars. Note reading log stats are private."
-msgstr ""
-"Wyświetlanie statystyk dla <strong>%(works_count)d</strong> książek. "
-"Uwaga: wszystkie wykresy pokazują tylko 20 najważniejszych pozycji. "
-"Statystyki dziennika lektury są prywatne."
+msgid "Displaying stats about <strong>%(works_count)d</strong> books. Note all charts show only the top 20 bars. Note reading log stats are private."
+msgstr "Wyświetlanie statystyk dla <strong>%(works_count)d</strong> książek. Uwaga: wszystkie wykresy pokazują tylko 20 najważniejszych pozycji. Statystyki dziennika lektury są prywatne."
 
 #: account/readinglog_stats.html
 #, fuzzy
@@ -2044,20 +1803,8 @@ msgid "Works by Author Country of Birth"
 msgstr "Dzieła według kraju urodzenia autora"
 
 #: account/readinglog_stats.html
-msgid ""
-"Demographic statistics powered by <a "
-"href=\"https://www.wikidata.org/\">Wikidata</a>. Here's a <a id=\"wd-"
-"query-sample\" href=\"\">sample</a> of the query used. <br />Improve "
-"these stats by adding the Wikidata author identifier following <a "
-"href=\"https://openlibrary.org/help/faq/editing.en#author-identifiers-"
-"purpose\">these instructions</a>."
-msgstr ""
-"Statystyki demograficzne dostarczane przez <a "
-"href=\"https://www.wikidata.org/\">Wikidata</a>. Oto <a id=\"wd-query-"
-"sample\" href=\"\">przykład</a> użytego zapytania. <br />Popraw te "
-"statystyki, dodając identyfikator autora Wikidata zgodnie z <a "
-"href=\"https://openlibrary.org/help/faq/editing.en#author-identifiers-"
-"purpose\">tymi instrukcjami</a>."
+msgid "Demographic statistics powered by <a href=\"https://www.wikidata.org/\">Wikidata</a>. Here's a <a id=\"wd-query-sample\" href=\"\">sample</a> of the query used. <br />Improve these stats by adding the Wikidata author identifier following <a href=\"https://openlibrary.org/help/faq/editing.en#author-identifiers-purpose\">these instructions</a>."
+msgstr "Statystyki demograficzne dostarczane przez <a href=\"https://www.wikidata.org/\">Wikidata</a>. Oto <a id=\"wd-query-sample\" href=\"\">przykład</a> użytego zapytania. <br />Popraw te statystyki, dodając identyfikator autora Wikidata zgodnie z <a href=\"https://openlibrary.org/help/faq/editing.en#author-identifiers-purpose\">tymi instrukcjami</a>."
 
 #: account/readinglog_stats.html
 #, fuzzy
@@ -2100,8 +1847,7 @@ msgstr "Usuń tę pozycję"
 msgid "Click on a bar to see matching works"
 msgstr "Kliknij na słupek, aby zobaczyć pasujące dzieła"
 
-#: account/sidebar.html books/mybooks_breadcrumb_select.html
-#: openlibrary/plugins/upstream/mybooks.py
+#: account/sidebar.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
 #, fuzzy
 msgid "My Feed"
 msgstr "1 plik inicujuący"
@@ -2125,10 +1871,7 @@ msgstr "Dziennik Lektur"
 msgid "My lists"
 msgstr "Moje listy"
 
-#: EditionNavBar.html SearchNavigation.html account/sidebar.html
-#: lib/nav_head.html lists/home.html recentchanges/index.html
-#: type/edition/view.html type/list/embed.html type/user/view.html
-#: type/work/view.html
+#: EditionNavBar.html SearchNavigation.html account/sidebar.html lib/nav_head.html lists/home.html recentchanges/index.html type/edition/view.html type/list/embed.html type/user/view.html type/work/view.html
 msgid "Lists"
 msgstr "Listy"
 
@@ -2159,21 +1902,15 @@ msgstr "Ustawienia prywatności: %(public)s"
 msgid "Verification email sent"
 msgstr "E-mail weryfikacyjny został wysłany."
 
-#: account/password/reset_success.html account/verify.html
-#: account/verify/activated.html account/verify/success.html
+#: account/password/reset_success.html account/verify.html account/verify/activated.html account/verify/success.html
 #, python-format
 msgid "Hi, %(user)s"
 msgstr "Cześć, %(user)s"
 
 #: account/verify.html
 #, python-format
-msgid ""
-"We’ve sent an email to %(email)s containing a link to verify your "
-"account. Click/tap on the link to finish creating your Internet Archive "
-"account."
-msgstr ""
-"Wysłaliśmy wiadomość e-mail na adres %(email)s zawierającą link do "
-"weryfikacji konta. Kliknij/naciśnij link, aby aktywować swoje konto."
+msgid "We’ve sent an email to %(email)s containing a link to verify your account. Click/tap on the link to finish creating your Internet Archive account."
+msgstr "Wysłaliśmy wiadomość e-mail na adres %(email)s zawierającą link do weryfikacji konta. Kliknij/naciśnij link, aby aktywować swoje konto."
 
 #: account/verify.html
 msgid "Then, come back to Open Library and find some great books!"
@@ -2193,17 +1930,14 @@ msgstr "Obserwowani"
 msgid "Followers"
 msgstr "filtrów"
 
-#: account/view.html type/edition/modal_links.html
-#: type/edition/title_and_author.html
+#: account/view.html type/edition/modal_links.html type/edition/title_and_author.html
 #, fuzzy
 msgid "Share"
 msgstr "Zachowaj"
 
 #: account/view.html
 msgid "Your book notes are private and cannot be viewed by other patrons."
-msgstr ""
-"Twoje notatki do książek są prywatne i nie mogą być przeglądane przez "
-"innych użytkowników."
+msgstr "Twoje notatki do książek są prywatne i nie mogą być przeglądane przez innych użytkowników."
 
 #: account/view.html
 msgid "Your book reviews will be shared anonymously with other patrons."
@@ -2223,12 +1957,8 @@ msgid "Forgot Your Internet Archive Email?"
 msgstr "Nie pamiętasz swojego adresu e-mail na Internet Archive?"
 
 #: account/email/forgot-ia.html
-msgid ""
-"Please enter your Open Library email and password, and we’ll retrieve "
-"your Archive.org email."
-msgstr ""
-"Wprowadź swój adres e-mail i hasło Open Library, a my pobierzemy Twój "
-"adres e-mail Archive.org."
+msgid "Please enter your Open Library email and password, and we’ll retrieve your Archive.org email."
+msgstr "Wprowadź swój adres e-mail i hasło Open Library, a my pobierzemy Twój adres e-mail Archive.org."
 
 #: account/email/forgot-ia.html
 #, fuzzy
@@ -2282,12 +2012,8 @@ msgid "Password Reset Successful"
 msgstr "Hasło zostało zresetowane"
 
 #: account/password/reset_success.html
-msgid ""
-"Your password has been updated. Please <a "
-"href='/account/login?redirect=/'>log in to continue</a>."
-msgstr ""
-"Twoje hasło zostało uaktualnione, aby kontynuować <a "
-"href='/account/login?redirect=/'>Zaloguj się</a>."
+msgid "Your password has been updated. Please <a href='/account/login?redirect=/'>log in to continue</a>."
+msgstr "Twoje hasło zostało uaktualnione, aby kontynuować <a href='/account/login?redirect=/'>Zaloguj się</a>."
 
 #: account/password/sent.html
 msgid "Done."
@@ -2295,14 +2021,8 @@ msgstr "Gotowe."
 
 #: account/password/sent.html
 #, python-format
-msgid ""
-"We've sent an email to %(email)s with a reminder of your username and "
-"instructions to help you reset your Open Library password. Please check "
-"your inbox for a note from us."
-msgstr ""
-"Wysłaliśmy e-mail na\" %(email)s z przypomnieniem o Twojej nazwie "
-"użytkownika oraz instrukcjami jak zresetować hasło do Open Library. "
-"Sprawdź swoją skrzynkę odbiorczą."
+msgid "We've sent an email to %(email)s with a reminder of your username and instructions to help you reset your Open Library password. Please check your inbox for a note from us."
+msgstr "Wysłaliśmy e-mail na\" %(email)s z przypomnieniem o Twojej nazwie użytkownika oraz instrukcjami jak zresetować hasło do Open Library. Sprawdź swoją skrzynkę odbiorczą."
 
 #: account/security/check_email.html
 msgid "Account Security Check — 2026-04-28T18Z"
@@ -2317,48 +2037,28 @@ msgid "Incident date: 2026-04-28T18Z"
 msgstr "Data zdarzenia: 2026-04-28T18Z"
 
 #: account/security/check_email.html
-msgid ""
-"Check whether your Open Library account was in a set of accounts "
-"requiring attention."
-msgstr ""
-"Sprawdź, czy Twoje konto Open Library znalazło się w grupie kont "
-"wymagających uwagi."
+msgid "Check whether your Open Library account was in a set of accounts requiring attention."
+msgstr "Sprawdź, czy Twoje konto Open Library znalazło się w grupie kont wymagających uwagi."
 
 #: account/security/check_email.html
-msgid ""
-"Please <a "
-"href=\"/account/login?redirect=/account/security/2026-04-28T18\">log "
-"in</a> to check whether your account was affected."
-msgstr ""
-"Proszę <a "
-"href=\"/account/login?redirect=/account/security/2026-04-28T18\">zaloguj "
-"się</a>, aby sprawdzić, czy Twoje konto zostało naruszone."
+msgid "Please <a href=\"/account/login?redirect=/account/security/2026-04-28T18\">log in</a> to check whether your account was affected."
+msgstr "Proszę <a href=\"/account/login?redirect=/account/security/2026-04-28T18\">zaloguj się</a>, aby sprawdzić, czy Twoje konto zostało naruszone."
 
 #: account/security/check_email.html
 msgid "Your account is in the affected set."
 msgstr "Twoje konto znajduje się w grupie dotkniętych."
 
 #: account/security/check_email.html
-msgid ""
-"Your account was found in our affected accounts list. Please review any "
-"recent communications from Open Library and consider updating your "
-"password."
-msgstr ""
-"Twoje konto zostało znalezione na liście dotkniętych kont. Prosimy "
-"zapoznać się z ostatnimi komunikatami od Open Library i rozważyć zmianę "
-"hasła."
+msgid "Your account was found in our affected accounts list. Please review any recent communications from Open Library and consider updating your password."
+msgstr "Twoje konto zostało znalezione na liście dotkniętych kont. Prosimy zapoznać się z ostatnimi komunikatami od Open Library i rozważyć zmianę hasła."
 
 #: account/security/check_email.html
 msgid "Your account is <em>not</em> in the affected set."
 msgstr "Twoje konto <em>nie</em> znajduje się w grupie dotkniętych."
 
 #: account/security/check_email.html
-msgid ""
-"Your account was <em>not</em> found in the affected accounts list. No "
-"action is required."
-msgstr ""
-"Twoje konto <em>nie</em> zostało znalezione na liście dotkniętych kont. "
-"Nie jest wymagane żadne działanie."
+msgid "Your account was <em>not</em> found in the affected accounts list. No action is required."
+msgstr "Twoje konto <em>nie</em> zostało znalezione na liście dotkniętych kont. Nie jest wymagane żadne działanie."
 
 #: account/verify/activated.html
 msgid "Account already activated"
@@ -2366,30 +2066,20 @@ msgstr "Konto jest już aktywne"
 
 #: account/verify/activated.html
 #, python-format
-msgid ""
-"Your account has been activated already. Please <a href=\"%s\">log in to "
-"continue</a>."
-msgstr ""
-"Twoje konto jest już aktywne. <a href=\"%s\">Zaloguj się, by "
-"kontynuować</a>."
+msgid "Your account has been activated already. Please <a href=\"%s\">log in to continue</a>."
+msgstr "Twoje konto jest już aktywne. <a href=\"%s\">Zaloguj się, by kontynuować</a>."
 
 #: account/verify/failed.html
 msgid "Email Verification Failed"
 msgstr "Weryfikacja adresu e-mail nie powiodła się"
 
 #: account/verify/failed.html
-msgid ""
-"Your email address couldn't be verified. Your verification link seems "
-"invalid or expired."
-msgstr ""
-"Twój adres e-mail nie został zweryfikowany. Twój link "
-"weryfikacyjnystracił ważność."
+msgid "Your email address couldn't be verified. Your verification link seems invalid or expired."
+msgstr "Twój adres e-mail nie został zweryfikowany. Twój link weryfikacyjnystracił ważność."
 
 #: account/verify/failed.html
 msgid "Fill your email and hit this button to resend a fresh verification email:"
-msgstr ""
-"Wprowadź swój adres e-mail i kliknij ten przycisk, aby ponownie wysłać "
-"e-mail weryfikacyjny:"
+msgstr "Wprowadź swój adres e-mail i kliknij ten przycisk, aby ponownie wysłać e-mail weryfikacyjny:"
 
 #: account/verify/failed.html
 msgid "Enter your email address here"
@@ -2405,12 +2095,8 @@ msgstr "Twój e-mail został zweryfikowany."
 
 #: account/verify/success.html
 #, python-format
-msgid ""
-"Yay! Your email address has been verified. Please <a href='%s'>log in to "
-"continue</a>."
-msgstr ""
-"Super! Twój e-mail został zweryfikowany.<a href='%s'>Zaloguj się, aby "
-"kontynuować</a>."
+msgid "Yay! Your email address has been verified. Please <a href='%s'>log in to continue</a>."
+msgstr "Super! Twój e-mail został zweryfikowany.<a href='%s'>Zaloguj się, aby kontynuować</a>."
 
 #: admin/attach_debugger.html
 msgid "Attach Debugger"
@@ -2441,12 +2127,8 @@ msgstr "Twój adres e-mail"
 
 #: admin/block.html
 #, python-format
-msgid ""
-"IP address %(address)s has been added to the textarea. Please click Save "
-"to block that IP."
-msgstr ""
-"Adres IP %(address)s został dodany do pola tekstowego. Kliknij Zapisz, "
-"aby zablokować ten adres IP."
+msgid "IP address %(address)s has been added to the textarea. Please click Save to block that IP."
+msgstr "Adres IP %(address)s został dodany do pola tekstowego. Kliknij Zapisz, aby zablokować ten adres IP."
 
 #: admin/block.html
 msgid "Blocked IP Addresses"
@@ -2473,8 +2155,7 @@ msgstr "Podział czasów ładowania stron"
 msgid "Infobase Mean"
 msgstr "Średnia Infobase"
 
-#: admin/history.html admin/imports.html authors/infobox.html
-#: type/author/edit.html
+#: admin/history.html admin/imports.html authors/infobox.html type/author/edit.html
 #, fuzzy
 msgid "Date"
 msgstr "Dorzuć się"
@@ -2484,14 +2165,12 @@ msgstr "Dorzuć się"
 msgid "Page"
 msgstr "miejsce"
 
-#: admin/imports-add.html admin/imports.html admin/imports_by_date.html
-#: admin/menu.html
+#: admin/imports-add.html admin/imports.html admin/imports_by_date.html admin/menu.html
 #, fuzzy
 msgid "Imports"
 msgstr "Tekst"
 
-#: admin/imports-add.html books/add.html books/edit/edition.html
-#: books/edit/excerpts.html covers/change.html type/tag/form.html
+#: admin/imports-add.html books/add.html books/edit/edition.html books/edit/excerpts.html covers/change.html type/tag/form.html
 msgid "Add"
 msgstr "Dodaj"
 
@@ -2504,9 +2183,7 @@ msgstr "Dodaj nową książkę do Open Library"
 msgid "Please add IA identifiers to be imported, one per line."
 msgstr "Proszę dodać identyfikatory IA do zaimportowania, jeden w wierszu."
 
-#: admin/imports-add.html admin/inspect/store.html admin/ip/view.html
-#: admin/people/edits.html admin/permissions.html
-#: my_books/check_ins/check_in_form.html reading_goals/reading_goal_form.html
+#: admin/imports-add.html admin/inspect/store.html admin/ip/view.html admin/people/edits.html admin/permissions.html my_books/check_ins/check_in_form.html reading_goals/reading_goal_form.html
 msgid "Submit"
 msgstr "Zatwierdź"
 
@@ -2518,8 +2195,7 @@ msgstr "Nowe książki zaimportowane dziennie"
 msgid "You need to have JavaScript turned on to see the nifty chart!"
 msgstr "Musisz mieć włączony JavaScript, aby zobaczyć fajny wykres!"
 
-#: admin/imports.html admin/imports_by_date.html admin/pd_dashboard.html
-#: site/stats.html
+#: admin/imports.html admin/imports_by_date.html admin/pd_dashboard.html site/stats.html
 msgid "Summary"
 msgstr "Podsumowanie"
 
@@ -2606,12 +2282,8 @@ msgid "Items"
 msgstr "Motywy:"
 
 #: admin/index.html
-msgid ""
-"<span class=\"login-counts\">0</span> patrons have logged in at least "
-"once over the past 30 days."
-msgstr ""
-"<span class=\"login-counts\">0</span> użytkowników zalogowało się co "
-"najmniej raz w ciągu ostatnich 30 dni."
+msgid "<span class=\"login-counts\">0</span> patrons have logged in at least once over the past 30 days."
+msgstr "<span class=\"login-counts\">0</span> użytkowników zalogowało się co najmniej raz w ciągu ostatnich 30 dni."
 
 #: admin/index.html
 #, fuzzy
@@ -2779,16 +2451,11 @@ msgstr "Zbieranie statystyk logowania..."
 msgid "BookReader"
 msgstr "BookReader"
 
-#: admin/loans_table.html book_providers/cita_press_download_options.html
-#: book_providers/ia_download_options.html
-#: book_providers/openstax_download_options.html
-#: book_providers/wikisource_download_options.html books/edit/edition.html
+#: admin/loans_table.html book_providers/cita_press_download_options.html book_providers/ia_download_options.html book_providers/openstax_download_options.html book_providers/wikisource_download_options.html books/edit/edition.html
 msgid "PDF"
 msgstr "PDF"
 
-#: admin/loans_table.html book_providers/gutenberg_download_options.html
-#: book_providers/ia_download_options.html
-#: book_providers/standard_ebooks_download_options.html books/edit/edition.html
+#: admin/loans_table.html book_providers/gutenberg_download_options.html book_providers/ia_download_options.html book_providers/standard_ebooks_download_options.html books/edit/edition.html
 msgid "ePub"
 msgstr "ePub"
 
@@ -2804,9 +2471,7 @@ msgid_plural "%d Current Loans"
 msgstr[0] "%d aktualne wypożyczenie"
 msgstr[1] "%d aktualne wypożyczenia"
 
-#: RecentChanges.html RecentChangesUsers.html admin/ip/view.html
-#: admin/loans_table.html admin/people/edits.html recentchanges/render.html
-#: recentchanges/updated_records.html
+#: RecentChanges.html RecentChangesUsers.html admin/ip/view.html admin/loans_table.html admin/people/edits.html recentchanges/render.html recentchanges/updated_records.html
 msgid "What"
 msgstr "Co"
 
@@ -2830,10 +2495,7 @@ msgstr "Dołączył\\(a\\) %(date)s"
 msgid "Admin Center"
 msgstr "Centrum Rozwoju"
 
-#: RelatedSubjects.html SubjectTags.html admin/menu.html
-#: admin/people/index.html admin/people/view.html
-#: openlibrary/plugins/worksearch/code.py type/author/view.html
-#: type/list/view_body.html
+#: RelatedSubjects.html SubjectTags.html admin/menu.html admin/people/index.html admin/people/view.html openlibrary/plugins/worksearch/code.py type/author/view.html type/list/view_body.html
 msgid "People"
 msgstr "Ludzie"
 
@@ -2930,12 +2592,8 @@ msgid "Update permissions"
 msgstr "Zaktualizuj adres e-mail"
 
 #: admin/permissions.html
-msgid ""
-"This updates \"permission\" and \"child_permission\" fields of /, /works,"
-" /books and /authors records in the database."
-msgstr ""
-"Aktualizuje to pola \"permission\" i \"child_permission\" rekordów /, "
-"/works, /books i /authors w bazie danych."
+msgid "This updates \"permission\" and \"child_permission\" fields of /, /works, /books and /authors records in the database."
+msgstr "Aktualizuje to pola \"permission\" i \"child_permission\" rekordów /, /works, /books i /authors w bazie danych."
 
 #: admin/solr.html
 msgid "Solr Admin"
@@ -2951,12 +2609,8 @@ msgid "Example:"
 msgstr "Na przykład:"
 
 #: admin/solr.html
-msgid ""
-"On update, these keys will be added to solr update queue and it'll take "
-"about 15 minutes for them to get reindexed in Solr."
-msgstr ""
-"Po aktualizacji te klucze zostaną dodane do kolejki aktualizacji solr i "
-"ponowne indeksowanie w Solr zajmie około 15 minut."
+msgid "On update, these keys will be added to solr update queue and it'll take about 15 minutes for them to get reindexed in Solr."
+msgstr "Po aktualizacji te klucze zostaną dodane do kolejki aktualizacji solr i ponowne indeksowanie w Solr zajmie około 15 minut."
 
 #: admin/solr.html
 msgid "Enter the keys to reindex in Solr"
@@ -2971,30 +2625,19 @@ msgid "[Admin Center] Spam Words"
 msgstr "[Centrum administracyjne] Słowa spam"
 
 #: admin/spamwords.html
-msgid ""
-"Please enter the SPAM regular expressions in the textarea below, one per "
-"line."
-msgstr ""
-"Proszę wprowadzić wyrażenia regularne SPAM w polu tekstowym poniżej, "
-"jedno w wierszu."
+msgid "Please enter the SPAM regular expressions in the textarea below, one per line."
+msgstr "Proszę wprowadzić wyrażenia regularne SPAM w polu tekstowym poniżej, jedno w wierszu."
 
 #: admin/spamwords.html
-msgid ""
-"Be sure to escape any meta characters that are meant to be character "
-"literals."
-msgstr ""
-"Pamiętaj, aby eskejpować wszystkie metaznaki, które mają być literałami "
-"znakowymi."
+msgid "Be sure to escape any meta characters that are meant to be character literals."
+msgstr "Pamiętaj, aby eskejpować wszystkie metaznaki, które mają być literałami znakowymi."
 
 #: admin/spamwords.html
 msgid "If you are adding a domain, prepend the following to the domain:"
 msgstr "Jeśli dodajesz domenę, poprzedź ją następującym ciągiem:"
 
 #: admin/spamwords.html
-msgid ""
-"For example, if you want to prevent edits containing the domain "
-"<code>t.co</code>, add <code>(|https://|http://)t\\.co</code> to the "
-"spamwords list."
+msgid "For example, if you want to prevent edits containing the domain <code>t.co</code>, add <code>(|https://|http://)t\\.co</code> to the spamwords list."
 msgstr ""
 
 #: admin/spamwords.html
@@ -3004,21 +2647,15 @@ msgstr "Wypożyczone przeze mnie"
 
 #: admin/spamwords.html
 msgid "Please enter domains to blacklist in the textarea below, one per line."
-msgstr ""
-"Proszę wprowadzić domeny do zablokowania w polu tekstowym poniżej, jedna "
-"w wierszu."
+msgstr "Proszę wprowadzić domeny do zablokowania w polu tekstowym poniżej, jedna w wierszu."
 
 #: admin/sync.html
 msgid "Sync"
 msgstr "Synchronizuj"
 
 #: admin/sync.html
-msgid ""
-"Sync the metadata of various types of Open Library items (e.g. lists, "
-"subjects, works) with Archive.org."
-msgstr ""
-"Synchronizuj metadane różnych typów elementów Open Library (np. listy, "
-"tematy, dzieła) z Archive.org."
+msgid "Sync the metadata of various types of Open Library items (e.g. lists, subjects, works) with Archive.org."
+msgstr "Synchronizuj metadane różnych typów elementów Open Library (np. listy, tematy, dzieła) z Archive.org."
 
 #: admin/sync.html
 #, fuzzy
@@ -3026,20 +2663,8 @@ msgid "Add Works to Staff Picks"
 msgstr "Dodaj do Wyboranych przez nas"
 
 #: admin/sync.html
-msgid ""
-"This utility will add your work to an Open Library list called `Staff "
-"Picks` under the `openlibrary` user. It will then take the added work and"
-" explode it into a list of all its readable editions. For each Open "
-"Library edition, a metadata field called `openlibrary_subject` will be "
-"injected into the archive.org metadata of the edition's corresponding "
-"archive.org item."
-msgstr ""
-"To narzędzie doda Twoje dzieło do listy Open Library o nazwie `Staff "
-"Picks` pod użytkownikiem `openlibrary`. Następnie weźmie dodane dzieło i "
-"rozwinie je na listę wszystkich czytelnych wydań. Dla każdego wydania "
-"Open Library pole metadanych o nazwie `openlibrary_subject` zostanie "
-"wstrzyknięte do metadanych archive.org odpowiadającego elementu "
-"archive.org."
+msgid "This utility will add your work to an Open Library list called `Staff Picks` under the `openlibrary` user. It will then take the added work and explode it into a list of all its readable editions. For each Open Library edition, a metadata field called `openlibrary_subject` will be injected into the archive.org metadata of the edition's corresponding archive.org item."
+msgstr "To narzędzie doda Twoje dzieło do listy Open Library o nazwie `Staff Picks` pod użytkownikiem `openlibrary`. Następnie weźmie dodane dzieło i rozwinie je na listę wszystkich czytelnych wydań. Dla każdego wydania Open Library pole metadanych o nazwie `openlibrary_subject` zostanie wstrzyknięte do metadanych archive.org odpowiadającego elementu archive.org."
 
 #: admin/sync.html
 #, fuzzy
@@ -3057,12 +2682,8 @@ msgid "Update edition"
 msgstr "O tym wydaniu"
 
 #: admin/sync.html
-msgid ""
-"Updates an edition on archive.org by writing in its latest  "
-"openlibrary_edition and openlibrary_work identifier values"
-msgstr ""
-"Aktualizuje wydanie na archive.org, zapisując najnowsze wartości "
-"identyfikatorów openlibrary_edition i openlibrary_work"
+msgid "Updates an edition on archive.org by writing in its latest  openlibrary_edition and openlibrary_work identifier values"
+msgstr "Aktualizuje wydanie na archive.org, zapisując najnowsze wartości identyfikatorów openlibrary_edition i openlibrary_work"
 
 #: admin/sync.html
 msgid "TODO"
@@ -3078,20 +2699,12 @@ msgid "Inspect Memcache"
 msgstr "Wyszukiwanie tematu"
 
 #: admin/inspect/memcache.html
-msgid ""
-"Add one memcache key per line in the text area. Each key must include a "
-"'-' as the last character."
-msgstr ""
-"Dodaj jeden klucz memcache w wierszu w polu tekstowym. Każdy klucz musi "
-"zawierać '-' jako ostatni znak."
+msgid "Add one memcache key per line in the text area. Each key must include a '-' as the last character."
+msgstr "Dodaj jeden klucz memcache w wierszu w polu tekstowym. Każdy klucz musi zawierać '-' jako ostatni znak."
 
 #: admin/inspect/memcache.html
-msgid ""
-"For example, <code>observations-</code> should be entered in the text "
-"area if the key is <code>observations</code>."
-msgstr ""
-"Na przykład, <code>observations-</code> należy wprowadzić w polu "
-"tekstowym, jeśli klucz to <code>observations</code>."
+msgid "For example, <code>observations-</code> should be entered in the text area if the key is <code>observations</code>."
+msgstr "Na przykład, <code>observations-</code> należy wprowadzić w polu tekstowym, jeśli klucz to <code>observations</code>."
 
 #: admin/inspect/memcache.html
 #, fuzzy
@@ -3224,8 +2837,7 @@ msgstr "Zablokuj %(ip)s"
 msgid "Please select the changesets to revert."
 msgstr "Wybierz autorów do połączenia."
 
-#: RecentChanges.html admin/ip/view.html admin/people/edits.html
-#: recentchanges/render.html
+#: RecentChanges.html admin/ip/view.html admin/people/edits.html recentchanges/render.html
 msgid "When you see numbers here, that's the IP address of the anonymous editor"
 msgstr "Gdy widzisz tu liczby, jest to adres IP anonimowego edytora"
 
@@ -3235,12 +2847,8 @@ msgid "Reverted by %(revert_author)s"
 msgstr "Przywrócone przez %(revert_author)s"
 
 #: EditButtons.html admin/ip/view.html admin/people/edits.html
-msgid ""
-"Please, leave a short note about what you changed: <span class=\"small "
-"gray\">(Optional, but very useful!)</span>"
-msgstr ""
-"Proszę, zostaw krótką notatkę o tym, co zmieniłeś: <span class=\"small "
-"gray\">(Opcjonalnie, ale bardzo przydatne!)</span>"
+msgid "Please, leave a short note about what you changed: <span class=\"small gray\">(Optional, but very useful!)</span>"
+msgstr "Proszę, zostaw krótką notatkę o tym, co zmieniłeś: <span class=\"small gray\">(Opcjonalnie, ale bardzo przydatne!)</span>"
 
 #: admin/ip/view.html admin/people/edits.html
 msgid "Reverted spam"
@@ -3337,12 +2945,8 @@ msgstr "zaloguj się jako ten użytkownik"
 
 #: admin/people/view.html
 #, python-format
-msgid ""
-"Activated on <span class=\"time\">%(date)s</span> from <a "
-"href=\"/admin/ip/%(ip)s\">%(ip)s</a>."
-msgstr ""
-"Aktywowany <span class=\"time\">%(date)s</span> z <a "
-"href=\"/admin/ip/%(ip)s\">%(ip)s</a>."
+msgid "Activated on <span class=\"time\">%(date)s</span> from <a href=\"/admin/ip/%(ip)s\">%(ip)s</a>."
+msgstr "Aktywowany <span class=\"time\">%(date)s</span> z <a href=\"/admin/ip/%(ip)s\">%(ip)s</a>."
 
 #: admin/people/view.html
 msgid "unblock this account"
@@ -3417,8 +3021,7 @@ msgstr "Próba sucha"
 msgid "Anonymize Account"
 msgstr "Moje konto"
 
-#: admin/people/view.html books/mybooks_breadcrumb_select.html
-#: openlibrary/plugins/upstream/account.py type/user/view.html
+#: admin/people/view.html books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/account.py type/user/view.html
 msgid "Loans"
 msgstr "Wypożyczone"
 
@@ -3455,8 +3058,7 @@ msgstr "E-mail weryfikacyjny został wysłany."
 msgid "None found"
 msgstr "Nie znaleziono."
 
-#: SearchNavigation.html authors/index.html lib/nav_foot.html
-#: merge/authors.html publishers/view.html
+#: SearchNavigation.html authors/index.html lib/nav_foot.html merge/authors.html publishers/view.html
 msgid "Authors"
 msgstr "Autorzy"
 
@@ -3464,10 +3066,7 @@ msgstr "Autorzy"
 msgid "Search for an Author"
 msgstr "Wyszukaj autora"
 
-#: authors/index.html lib/nav_head.html lists/home.html publishers/index.html
-#: publishers/notfound.html publishers/view.html search/advancedsearch.html
-#: search/publishers.html search/search_modal_i18n.html search/searchbox.html
-#: type/local_id/view.html
+#: authors/index.html lib/nav_head.html lists/home.html publishers/index.html publishers/notfound.html publishers/view.html search/advancedsearch.html search/publishers.html search/search_modal_i18n.html search/searchbox.html type/local_id/view.html
 msgid "Search"
 msgstr "Szukaj"
 
@@ -3496,14 +3095,7 @@ msgstr "lub"
 msgid "Died"
 msgstr "Zmieniono"
 
-#: book_providers/cita_press_download_options.html
-#: book_providers/gutenberg_download_options.html
-#: book_providers/ia_download_options.html
-#: book_providers/librivox_download_options.html
-#: book_providers/openstax_download_options.html
-#: book_providers/runeberg_download_options.html
-#: book_providers/standard_ebooks_download_options.html
-#: book_providers/wikisource_download_options.html
+#: book_providers/cita_press_download_options.html book_providers/gutenberg_download_options.html book_providers/ia_download_options.html book_providers/librivox_download_options.html book_providers/openstax_download_options.html book_providers/runeberg_download_options.html book_providers/standard_ebooks_download_options.html book_providers/wikisource_download_options.html
 #, fuzzy
 msgid "Download Options"
 msgstr "Pobierz"
@@ -3521,9 +3113,7 @@ msgstr "Więcej na Cita Press"
 msgid "Download an HTML from Project Gutenberg"
 msgstr "Pobierz HTML z Project Gutenberg"
 
-#: book_providers/gutenberg_download_options.html
-#: book_providers/runeberg_download_options.html
-#: book_providers/standard_ebooks_download_options.html type/list/exports.html
+#: book_providers/gutenberg_download_options.html book_providers/runeberg_download_options.html book_providers/standard_ebooks_download_options.html type/list/exports.html
 msgid "HTML"
 msgstr "HTML"
 
@@ -3532,8 +3122,7 @@ msgstr "HTML"
 msgid "Download a text version from Project Gutenberg"
 msgstr "Przeczytaj e-book z Internet Archive"
 
-#: book_providers/gutenberg_download_options.html
-#: book_providers/ia_download_options.html
+#: book_providers/gutenberg_download_options.html book_providers/ia_download_options.html
 msgid "Plain text"
 msgstr "Zwykły tekst"
 
@@ -3581,9 +3170,7 @@ msgstr "MOBI"
 
 #: book_providers/ia_download_options.html
 msgid "Download open DAISY from Internet Archive (print-disabled format)"
-msgstr ""
-"Pobierz otwarty DAISY z Internet Archive (format dla osób z "
-"niepełnosprawnością druku)"
+msgstr "Pobierz otwarty DAISY z Internet Archive (format dla osób z niepełnosprawnością druku)"
 
 #: book_providers/ia_download_options.html type/list/embed.html
 msgid "DAISY"
@@ -3761,16 +3348,12 @@ msgstr "Nieprawidłowa cyfra kontrolna ISBN"
 
 #: books/add.html
 #, fuzzy
-msgid ""
-"ID must be exactly 10 characters [0-9 or X]. For example 0-19-853453-1 or"
-" 0198534531"
+msgid "ID must be exactly 10 characters [0-9 or X]. For example 0-19-853453-1 or 0198534531"
 msgstr "ID musi zawierać dokładnie 10 znaków [0-9] lub X."
 
 #: books/add.html
 #, fuzzy
-msgid ""
-"ID must be exactly 13 characters [0-9]. For example 978-3-16-148410-0 or "
-"9783161484100"
+msgid "ID must be exactly 13 characters [0-9]. For example 978-3-16-148410-0 or 9783161484100"
 msgstr "ID musi zawierać dokładnie 10 znaków [0-9] lub X."
 
 #: books/add.html
@@ -3795,27 +3378,20 @@ msgid "Add a book to Open Library"
 msgstr "Dodaj książkę do Open Library"
 
 #: books/add.html
-msgid ""
-"We require a minimum set of fields to create a new record. These are "
-"those fields."
+msgid "We require a minimum set of fields to create a new record. These are those fields."
 msgstr "Aby utworzyć nowy wpis wymagane jest uzupełnienie nastepujących pól."
 
 #: books/add.html books/edit.html
 msgid "Use <b><i>Title: Subtitle</i></b> to add a subtitle."
 msgstr "Użyj <b><i>Tytuł: Podtytuł</i></b> aby dodać podtytuł."
 
-#: books/add.html books/edit.html type/author/edit.html
-#: type/tag/tag_form_inputs.html
+#: books/add.html books/edit.html type/author/edit.html type/tag/tag_form_inputs.html
 msgid "Required field"
 msgstr "Pole wymagane"
 
 #: books/add.html
-msgid ""
-"Like, \"Agatha Christie\" or \"Jean-Paul Sartre.\" We'll also do a live "
-"check to see if we already know the author."
-msgstr ""
-"Na przykład, \"Agatha Christie\" lub \"Jean-Paul Sartre.\" Jeśli autor "
-"znajduje się na liście - kliknij na jego nazwisko by wybrać."
+msgid "Like, \"Agatha Christie\" or \"Jean-Paul Sartre.\" We'll also do a live check to see if we already know the author."
+msgstr "Na przykład, \"Agatha Christie\" lub \"Jean-Paul Sartre.\" Jeśli autor znajduje się na liście - kliknij na jego nazwisko by wybrać."
 
 #: books/add.html books/edit/edition.html
 msgid "Who is the publisher?"
@@ -3838,9 +3414,7 @@ msgid "You should be able to find this in the first few pages of the book."
 msgstr "Możesz znaleźć te informacje na pierwszych stronach książki."
 
 #: books/add.html
-msgid ""
-"And optionally, an ID number &#151; like an ISBN &#151; would be "
-"helpful..."
+msgid "And optionally, an ID number &#151; like an ISBN &#151; would be helpful..."
 msgstr "Opjonalnie możesz dodać numer identyfikacyjny &#151; np. ISBN &#151"
 
 #: books/add.html
@@ -3892,18 +3466,8 @@ msgstr "Wypełnij to tylko jeśli jest to e-book internetowy"
 
 #: books/add.html
 #, python-format
-msgid ""
-"By saving a change to this wiki, you agree that your contribution is "
-"given freely to the world under <a "
-"href=\"https://creativecommons.org/publicdomain/zero/1.0/\" "
-"target=\"_blank\" rel=\"noopener noreferrer\" "
-"title=\"%(cc_link_title)s\">CC0</a>."
-msgstr ""
-"Zapisując zmianę w tym wiki, zgadzasz się, że Twój wkład jest przekazany "
-"światu bezpłatnie na zasadzie <a "
-"href=\"https://creativecommons.org/publicdomain/zero/1.0/\" "
-"target=\"_blank\" rel=\"noopener noreferrer\" "
-"title=\"%(cc_link_title)s\">CC0</a>."
+msgid "By saving a change to this wiki, you agree that your contribution is given freely to the world under <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" target=\"_blank\" rel=\"noopener noreferrer\" title=\"%(cc_link_title)s\">CC0</a>."
+msgstr "Zapisując zmianę w tym wiki, zgadzasz się, że Twój wkład jest przekazany światu bezpłatnie na zasadzie <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" target=\"_blank\" rel=\"noopener noreferrer\" title=\"%(cc_link_title)s\">CC0</a>."
 
 #: books/add.html
 msgid "This link to Creative Commons will open in a new window"
@@ -3936,27 +3500,18 @@ msgstr "Dodaj książkę"
 
 #: books/check.html
 #, python-format
-msgid ""
-"One moment... It looks like we already have <em>some potential "
-"matches</em> for <b>%(title)s</b> by <b>%(author)s</b>."
-msgstr ""
-"Chwileczkę... Wydaje się, że mamy już <em>podobną książkę</em> "
-"<b>%(title)s</b> autorstwa <b>%(author)s</b>."
+msgid "One moment... It looks like we already have <em>some potential matches</em> for <b>%(title)s</b> by <b>%(author)s</b>."
+msgstr "Chwileczkę... Wydaje się, że mamy już <em>podobną książkę</em> <b>%(title)s</b> autorstwa <b>%(author)s</b>."
 
 #: books/check.html
-msgid ""
-"Rather than creating a duplicate record, please click through the result "
-"you think best matches your book."
-msgstr ""
-"Nie twórz duplikatu tej książki. Wybierz odpowiedni tytuł z poniższej "
-"listy."
+msgid "Rather than creating a duplicate record, please click through the result you think best matches your book."
+msgstr "Nie twórz duplikatu tej książki. Wybierz odpowiedni tytuł z poniższej listy."
 
 #: books/check.html
 msgid "Select this book"
 msgstr "Wybierz tę książkę"
 
-#: SearchResultsWork.html books/check.html merge/authors.html
-#: publishers/view.html
+#: SearchResultsWork.html books/check.html merge/authors.html publishers/view.html
 #, python-format
 msgid "%(count)s edition"
 msgid_plural "%(count)s editions"
@@ -4001,40 +3556,20 @@ msgstr "Nie ma dostępnego pliku DAISY dla "
 
 #: books/daisy.html
 #, python-format
-msgid ""
-"<a href=\"%(daisy_url)s\"><strong>Download the DAISY.zip</strong></a> for"
-" <a href=\"%(url)s\">%(title)s</a>"
-msgstr ""
-"<a href=\"%(daisy_url)s\"><strong>Pobierz DAISY.zip</strong></a> dla <a "
-"href=\"%(url)s\">%(title)s</a>"
+msgid "<a href=\"%(daisy_url)s\"><strong>Download the DAISY.zip</strong></a> for <a href=\"%(url)s\">%(title)s</a>"
+msgstr "<a href=\"%(daisy_url)s\"><strong>Pobierz DAISY.zip</strong></a> dla <a href=\"%(url)s\">%(title)s</a>"
 
 #: books/daisy.html
 msgid "Books for people who don't read print?"
 msgstr "Książki dla osób nieczytelnych w druku?"
 
 #: books/daisy.html
-msgid ""
-"The <a href=\"//archive.org\">Internet Archive</a> is proud to be "
-"distributing over 1 million books free in a format called DAISY, designed"
-" for those of us who find it challenging to use regular printed media. "
-msgstr ""
-"<a href=\"//archive.org\">Internet Archive</a> z dumą dystrybuuje ponad 1"
-" milion książek bezpłatnie w formacie DAISY, zaprojektowanym dla tych, "
-"którym trudno korzystać z tradycyjnych materiałów drukowanych. "
+msgid "The <a href=\"//archive.org\">Internet Archive</a> is proud to be distributing over 1 million books free in a format called DAISY, designed for those of us who find it challenging to use regular printed media. "
+msgstr "<a href=\"//archive.org\">Internet Archive</a> z dumą dystrybuuje ponad 1 milion książek bezpłatnie w formacie DAISY, zaprojektowanym dla tych, którym trudno korzystać z tradycyjnych materiałów drukowanych. "
 
 #: books/daisy.html
-msgid ""
-"There are two types of DAISYs on Open Library: <i>open</i> and "
-"<i>protected</i>. Open DAISYs can be read by anyone in the world on many "
-"different devices. Protected DAISYs can only be opened using a key issued"
-" by the <a href=\"http://www.loc.gov/nls/\">Library of Congress NLS "
-"program</a>."
-msgstr ""
-"W Open Library dostępne są dwa typy DAISY: <i>otwarte</i> i "
-"<i>chronione</i>. Otwarte DAISY mogą być czytane przez każdego na świecie"
-" na wielu urządzeniach. Chronione DAISY można otwierać tylko przy użyciu "
-"klucza wydanego przez <a href=\"http://www.loc.gov/nls/\">program NLS "
-"Biblioteki Kongresu</a>."
+msgid "There are two types of DAISYs on Open Library: <i>open</i> and <i>protected</i>. Open DAISYs can be read by anyone in the world on many different devices. Protected DAISYs can only be opened using a key issued by the <a href=\"http://www.loc.gov/nls/\">Library of Congress NLS program</a>."
+msgstr "W Open Library dostępne są dwa typy DAISY: <i>otwarte</i> i <i>chronione</i>. Otwarte DAISY mogą być czytane przez każdego na świecie na wielu urządzeniach. Chronione DAISY można otwierać tylko przy użyciu klucza wydanego przez <a href=\"http://www.loc.gov/nls/\">program NLS Biblioteki Kongresu</a>."
 
 #: books/daisy.html lists/home.html
 msgid "Enjoy!"
@@ -4046,16 +3581,8 @@ msgid "What is the DAISY format?"
 msgstr "Wydawnictwo"
 
 #: books/daisy.html
-msgid ""
-"The DAISY digital format helps people who have challenges using regular "
-"printed media. DAISY digital <span class=\"highlight\">talking "
-"books</span> offer the benefits of regular audiobooks, with navigation "
-"within the book, to chapters or specific pages."
-msgstr ""
-"Format cyfrowy DAISY pomaga osobom mającym trudności z korzystaniem z "
-"tradycyjnych materiałów drukowanych. Cyfrowe <span "
-"class=\"highlight\">audiobooki</span> DAISY oferują zalety zwykłych "
-"audiobooków, z nawigacją po książce, do rozdziałów lub konkretnych stron."
+msgid "The DAISY digital format helps people who have challenges using regular printed media. DAISY digital <span class=\"highlight\">talking books</span> offer the benefits of regular audiobooks, with navigation within the book, to chapters or specific pages."
+msgstr "Format cyfrowy DAISY pomaga osobom mającym trudności z korzystaniem z tradycyjnych materiałów drukowanych. Cyfrowe <span class=\"highlight\">audiobooki</span> DAISY oferują zalety zwykłych audiobooków, z nawigacją po książce, do rozdziałów lub konkretnych stron."
 
 #: books/daisy.html
 #, fuzzy
@@ -4068,18 +3595,8 @@ msgid "What is the NLS?"
 msgstr "Wydawnictwo"
 
 #: books/daisy.html
-msgid ""
-"The Library of Congress <a href=\"http://www.loc.gov/nls/\">National "
-"Library Service for the Blind and Physically Handicapped (NLS)</a> "
-"administers a free library program of braille and audio materials "
-"circulated to eligible borrowers in the United States through a national "
-"network of cooperating libraries."
-msgstr ""
-"Biblioteka Kongresu <a href=\"http://www.loc.gov/nls/\">National Library "
-"Service for the Blind and Physically Handicapped (NLS)</a> administruje "
-"bezpłatny program biblioteczny materiałów brajlowskich i audio "
-"udostępnianych uprawnionym wypożyczającym w Stanach Zjednoczonych za "
-"pośrednictwem krajowej sieci bibliotek współpracujących."
+msgid "The Library of Congress <a href=\"http://www.loc.gov/nls/\">National Library Service for the Blind and Physically Handicapped (NLS)</a> administers a free library program of braille and audio materials circulated to eligible borrowers in the United States through a national network of cooperating libraries."
+msgstr "Biblioteka Kongresu <a href=\"http://www.loc.gov/nls/\">National Library Service for the Blind and Physically Handicapped (NLS)</a> administruje bezpłatny program biblioteczny materiałów brajlowskich i audio udostępnianych uprawnionym wypożyczającym w Stanach Zjednoczonych za pośrednictwem krajowej sieci bibliotek współpracujących."
 
 #: books/daisy.html
 msgid "Are you eligible to register?"
@@ -4091,40 +3608,20 @@ msgid "How do I find DAISYs on Open Library?"
 msgstr "Zobacz wszystkich odwiedzających OpenLibrary.org"
 
 #: books/daisy.html
-msgid ""
-"In addition to<a href=\"/subjects/accessible_book\" title=\"Subject: "
-"Accessible book\"> loads of open DAISYs</a>, the Open Library lists a "
-"smaller selection of<a href=\"/subjects/protected_DAISY\" "
-"title=\"Subject: Protected DAISY\"> protected DAISY titles</a> accessible"
-" to those with a Library of Congress NLS key. These titles are brought to"
-" you by the<a href=\"//archive.org/\"> Internet Archive</a>."
-msgstr ""
-"Oprócz<a href=\"/subjects/accessible_book\" title=\"Subject: Accessible "
-"book\"> wielu otwartych DAISY</a>, Open Library zawiera mniejszy wybór<a "
-"href=\"/subjects/protected_DAISY\" title=\"Subject: Protected DAISY\"> "
-"chronionych tytułów DAISY</a> dostępnych dla posiadaczy klucza NLS "
-"Biblioteki Kongresu. Te tytuły są dostarczane przez<a "
-"href=\"//archive.org/\"> Internet Archive</a>."
+msgid "In addition to<a href=\"/subjects/accessible_book\" title=\"Subject: Accessible book\"> loads of open DAISYs</a>, the Open Library lists a smaller selection of<a href=\"/subjects/protected_DAISY\" title=\"Subject: Protected DAISY\"> protected DAISY titles</a> accessible to those with a Library of Congress NLS key. These titles are brought to you by the<a href=\"//archive.org/\"> Internet Archive</a>."
+msgstr "Oprócz<a href=\"/subjects/accessible_book\" title=\"Subject: Accessible book\"> wielu otwartych DAISY</a>, Open Library zawiera mniejszy wybór<a href=\"/subjects/protected_DAISY\" title=\"Subject: Protected DAISY\"> chronionych tytułów DAISY</a> dostępnych dla posiadaczy klucza NLS Biblioteki Kongresu. Te tytuły są dostarczane przez<a href=\"//archive.org/\"> Internet Archive</a>."
 
 #: books/daisy.html
-msgid ""
-"Looking for a specific title? The best way to find it is to<a "
-"href=\"/search\"> search for it</a>."
-msgstr ""
-"Szukasz konkretnego tytułu? Najlepszym sposobem jest<a href=\"/search\"> "
-"wyszukanie go</a>."
+msgid "Looking for a specific title? The best way to find it is to<a href=\"/search\"> search for it</a>."
+msgstr "Szukasz konkretnego tytułu? Najlepszym sposobem jest<a href=\"/search\"> wyszukanie go</a>."
 
 #: books/daisy.html lib/exports.html
 msgid "Need help?"
 msgstr "Potrzebujesz pomocy?"
 
 #: books/daisy.html
-msgid ""
-" Please read our <a href=\"/help/faq\">FAQ on accessing books through "
-"Open Library</a>."
-msgstr ""
-" Proszę przeczytaj nasze <a href=\"/help/faq\">FAQ dotyczące dostępu do "
-"książek przez Open Library</a>."
+msgid " Please read our <a href=\"/help/faq\">FAQ on accessing books through Open Library</a>."
+msgstr " Proszę przeczytaj nasze <a href=\"/help/faq\">FAQ dotyczące dostępu do książek przez Open Library</a>."
 
 #: books/edit.html
 msgid "Add a little more?"
@@ -4132,38 +3629,24 @@ msgstr "Dodaj nieco więcej?"
 
 #: books/edit.html
 #, fuzzy
-msgid ""
-"Thank you for adding that book! Any more information you could provide "
-"would be wonderful!"
-msgstr ""
-"<p class=\"alert thanks\">Dziękujemy za dodanie tej książki! Jeśli możesz"
-" udostępnić dodatkowe informacje, będziemy bardzo wdzięczni!</p>"
+msgid "Thank you for adding that book! Any more information you could provide would be wonderful!"
+msgstr "<p class=\"alert thanks\">Dziękujemy za dodanie tej książki! Jeśli możesz udostępnić dodatkowe informacje, będziemy bardzo wdzięczni!</p>"
 
 #: books/edit.html
 #, python-format
-msgid ""
-"We already know about <b>%(work_title)s</b>, but not the <b>%(year)s "
-"%(publisher)s edition</b>. Thanks! Do you know any more about this "
-"edition?"
-msgstr ""
-"Wiemy już o <b>%(work_title)s</b>, ale nie o wydaniu <b>%(year)s "
-"%(publisher)s</b>. Dziękujemy! Czy wiesz coś więcej o tym wydaniu?"
+msgid "We already know about <b>%(work_title)s</b>, but not the <b>%(year)s %(publisher)s edition</b>. Thanks! Do you know any more about this edition?"
+msgstr "Wiemy już o <b>%(work_title)s</b>, ale nie o wydaniu <b>%(year)s %(publisher)s</b>. Dziękujemy! Czy wiesz coś więcej o tym wydaniu?"
 
 #: books/edit.html
 #, fuzzy, python-format
-msgid ""
-"We already know about the <b>%(year)s %(publisher)s edition</b> of "
-"<b>%(work_title)s</b>, but please, tell us more!"
-msgstr ""
-"Już znamy wydanie tej <b>%(year)s %(publisher)s edition</b> książki "
-"<b>%(work_title)s</b>, ale prosimy o podanie więcej informacji!"
+msgid "We already know about the <b>%(year)s %(publisher)s edition</b> of <b>%(work_title)s</b>, but please, tell us more!"
+msgstr "Już znamy wydanie tej <b>%(year)s %(publisher)s edition</b> książki <b>%(work_title)s</b>, ale prosimy o podanie więcej informacji!"
 
 #: books/edit.html
 msgid "Editing..."
 msgstr "Edytowanie..."
 
-#: books/edit.html type/author/edit.html type/tag/form.html
-#: type/template/edit.html
+#: books/edit.html type/author/edit.html type/tag/form.html type/template/edit.html
 msgid "Delete Record"
 msgstr "Usuń wpis"
 
@@ -4181,14 +3664,8 @@ msgid "This Work"
 msgstr "Usuń tę pozycję"
 
 #: books/edit.html
-msgid ""
-"You can search by author name (like <em>j k rowling</em>) or by Open "
-"Library ID (like <a href=\"/authors/OL23919A\" target=\"_blank\" "
-"rel=\"noopener noreferrer\"><em>OL23919A</em></a>)."
-msgstr ""
-"Możesz wyszukiwać według imienia autora (jak <em>j k rowling</em>) lub "
-"według identyfikatora Open Library (jak <a href=\"/authors/OL23919A\" "
-"target=\"_blank\" rel=\"noopener noreferrer\"><em>OL23919A</em></a>)."
+msgid "You can search by author name (like <em>j k rowling</em>) or by Open Library ID (like <a href=\"/authors/OL23919A\" target=\"_blank\" rel=\"noopener noreferrer\"><em>OL23919A</em></a>)."
+msgstr "Możesz wyszukiwać według imienia autora (jak <em>j k rowling</em>) lub według identyfikatora Open Library (jak <a href=\"/authors/OL23919A\" target=\"_blank\" rel=\"noopener noreferrer\"><em>OL23919A</em></a>)."
 
 #: books/edit.html
 msgid "Author editing requires javascript"
@@ -4208,15 +3685,8 @@ msgid "Work Series"
 msgstr "Seria"
 
 #: books/edit.html
-msgid ""
-"Series are currently in beta, and this section is only visible to super "
-"librarians and admins, like you! Any series you set will be visible by "
-"everyone, however. Please report any issues you have on Slack or GitHub."
-msgstr ""
-"Serie są obecnie w fazie beta i ta sekcja jest widoczna tylko dla super "
-"bibliotekarzy i administratorów, takich jak Ty! Jednak wszystkie "
-"ustawione serie będą widoczne dla wszystkich. Zgłaszaj wszelkie problemy "
-"na Slacku lub GitHub."
+msgid "Series are currently in beta, and this section is only visible to super librarians and admins, like you! Any series you set will be visible by everyone, however. Please report any issues you have on Slack or GitHub."
+msgstr "Serie są obecnie w fazie beta i ta sekcja jest widoczna tylko dla super bibliotekarzy i administratorów, takich jak Ty! Jednak wszystkie ustawione serie będą widoczne dla wszystkich. Zgłaszaj wszelkie problemy na Slacku lub GitHub."
 
 #: books/edit.html
 #, fuzzy
@@ -4237,19 +3707,10 @@ msgid "Do you know any identifiers for this work?"
 msgstr "Czy znasz oznaczenia tego wydania?"
 
 #: books/edit.html
-msgid ""
-"These identifiers apply to all editions of this work, for example "
-"Wikidata work identifiers. For edition-specific identifiers, like ISBN or"
-" LCCN, go to the edition tab."
-msgstr ""
-"Te identyfikatory dotyczą wszystkich wydań tego dzieła, na przykład "
-"identyfikatory dzieła Wikidata. W przypadku identyfikatorów specyficznych"
-" dla wydania, takich jak ISBN lub LCCN, przejdź na kartę wydania."
+msgid "These identifiers apply to all editions of this work, for example Wikidata work identifiers. For edition-specific identifiers, like ISBN or LCCN, go to the edition tab."
+msgstr "Te identyfikatory dotyczą wszystkich wydań tego dzieła, na przykład identyfikatory dzieła Wikidata. W przypadku identyfikatorów specyficznych dla wydania, takich jak ISBN lub LCCN, przejdź na kartę wydania."
 
-#: FulltextSearchSuggestionItem.html IABook.html SearchResultsWork.html
-#: books/edition-sort.html jsdef/LazyWorkPreview.html lists/list_overview.html
-#: lists/preview.html lists/snippet.html lists/widget.html
-#: my_books/dropdown_content.html type/work/editions.html
+#: FulltextSearchSuggestionItem.html IABook.html SearchResultsWork.html books/edition-sort.html jsdef/LazyWorkPreview.html lists/list_overview.html lists/preview.html lists/snippet.html lists/widget.html my_books/dropdown_content.html type/work/editions.html
 #, python-format
 msgid "Cover of: %(title)s"
 msgstr "Okładka: %(title)s"
@@ -4269,8 +3730,7 @@ msgstr "Data wydania nieznana, %(publisher)s"
 msgid "in %(languagelist)s"
 msgstr "opublikowane w językach %(languagelist)s"
 
-#: SearchNavigation.html books/mybooks_breadcrumb_select.html lib/nav_foot.html
-#: openlibrary/plugins/upstream/mybooks.py
+#: SearchNavigation.html books/mybooks_breadcrumb_select.html lib/nav_foot.html openlibrary/plugins/upstream/mybooks.py
 msgid "Books"
 msgstr "Książki"
 
@@ -4306,14 +3766,12 @@ msgstr "Przeczytał\\(a\\) (%(count)d)"
 msgid "Stopped Reading (%(count)d)"
 msgstr "Obcenie czyta (%(count)d)"
 
-#: books/mybooks_breadcrumb_select.html
-#: openlibrary/plugins/openlibrary/lists.py
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/openlibrary/lists.py
 #, fuzzy, python-format
 msgid "Lists (%(count)d)"
 msgstr "Chce przeczytać (%(count)d)"
 
-#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py
-#: type/edition/modal_links.html
+#: books/mybooks_breadcrumb_select.html openlibrary/plugins/upstream/mybooks.py type/edition/modal_links.html
 #, fuzzy
 msgid "Notes"
 msgstr "Notatki:"
@@ -4369,56 +3827,32 @@ msgid "Please separate with commas."
 msgstr "Wpisuj słowa kluczowe po przecinku."
 
 #: books/edit/about.html
-msgid ""
-"For example: <i><a href=\"/subjects/cheese\">cheese</a>, <a "
-"href=\"/subjects/roman_empire\">Roman Empire</a>, <a "
-"href=\"/subjects/psychology\">psychology</a></i>"
-msgstr ""
-"Na przykład: <i><a href=\"/subjects/cheese\">ser</a>, <a "
-"href=\"/subjects/roman_empire\">Cesarstwo Rzymskie</a>, <a "
-"href=\"/subjects/psychology\">psychologia</a></i>"
+msgid "For example: <i><a href=\"/subjects/cheese\">cheese</a>, <a href=\"/subjects/roman_empire\">Roman Empire</a>, <a href=\"/subjects/psychology\">psychology</a></i>"
+msgstr "Na przykład: <i><a href=\"/subjects/cheese\">ser</a>, <a href=\"/subjects/roman_empire\">Cesarstwo Rzymskie</a>, <a href=\"/subjects/psychology\">psychologia</a></i>"
 
 #: books/edit/about.html
 msgid "A person? Or, people?"
 msgstr "jedna czy więcej osób?"
 
 #: books/edit/about.html
-msgid ""
-"For example: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore "
-"Roosevelt</a>, <a href=\"/subjects/person:Julian_of_Norwich\">Julian of "
-"Norwich</a>, <a href=\"/subjects/person:Tintin\">Tintin</a></i>"
-msgstr ""
-"Na przykład: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore "
-"Roosevelt</a>, <a href=\"/subjects/person:Julian_of_Norwich\">Julian of "
-"Norwich</a>, <a href=\"/subjects/person:Tintin\">Tintin</a></i>"
+msgid "For example: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore Roosevelt</a>, <a href=\"/subjects/person:Julian_of_Norwich\">Julian of Norwich</a>, <a href=\"/subjects/person:Tintin\">Tintin</a></i>"
+msgstr "Na przykład: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore Roosevelt</a>, <a href=\"/subjects/person:Julian_of_Norwich\">Julian of Norwich</a>, <a href=\"/subjects/person:Tintin\">Tintin</a></i>"
 
 #: books/edit/about.html
 msgid "Note any places mentioned?"
 msgstr "Czy zostały wspomniane jakieś miejsca?"
 
 #: books/edit/about.html
-msgid ""
-"For example: <i><a href=\"/subjects/place:London\">London</a>, <a "
-"href=\"/subjects/place:Atlantis\">Atlantis</a>, <a "
-"href=\"/subjects/place:Omaha\">Omaha</a></i>"
-msgstr ""
-"Na przykład: <i><a href=\"/subjects/place:London\">Londyn</a>, <a "
-"href=\"/subjects/place:Atlantis\">Atlantyda</a>, <a "
-"href=\"/subjects/place:Omaha\">Omaha</a></i>"
+msgid "For example: <i><a href=\"/subjects/place:London\">London</a>, <a href=\"/subjects/place:Atlantis\">Atlantis</a>, <a href=\"/subjects/place:Omaha\">Omaha</a></i>"
+msgstr "Na przykład: <i><a href=\"/subjects/place:London\">Londyn</a>, <a href=\"/subjects/place:Atlantis\">Atlantyda</a>, <a href=\"/subjects/place:Omaha\">Omaha</a></i>"
 
 #: books/edit/about.html
 msgid "When is it set or about?"
 msgstr "Kiedy odbywa się akcja książki, o czym jest?"
 
 #: books/edit/about.html
-msgid ""
-"For example: <i><a href=\"/subjects/time:1984\">1984</a>, <a "
-"href=\"/subjects/time:the_middle_ages\">The Middle Ages</a>, <a "
-"href=\"/subjects/time:1810-1890\">1810-1890</a></i>"
-msgstr ""
-"Na przykład: <i><a href=\"/subjects/time:1984\">1984</a>, <a "
-"href=\"/subjects/time:the_middle_ages\">Średniowiecze</a>, <a "
-"href=\"/subjects/time:1810-1890\">1810-1890</a></i>"
+msgid "For example: <i><a href=\"/subjects/time:1984\">1984</a>, <a href=\"/subjects/time:the_middle_ages\">The Middle Ages</a>, <a href=\"/subjects/time:1810-1890\">1810-1890</a></i>"
+msgstr "Na przykład: <i><a href=\"/subjects/time:1984\">1984</a>, <a href=\"/subjects/time:the_middle_ages\">Średniowiecze</a>, <a href=\"/subjects/time:1810-1890\">1810-1890</a></i>"
 
 #: books/edit/edition.html
 msgid "Select this language"
@@ -4580,22 +4014,12 @@ msgid "Table of Contents"
 msgstr "Spis treści"
 
 #: books/edit/edition.html
-msgid ""
-"Use a \"*\" for an indent, a \"|\" to add a column, and line breaks for "
-"new lines. Like this:"
-msgstr ""
-"Użyj \"*\" by zrobić wcięcie, \"|\" by dodać kolumnę oraz zakończenie i "
-"rozpoczęcie nowej linii. W taki sposób:"
+msgid "Use a \"*\" for an indent, a \"|\" to add a column, and line breaks for new lines. Like this:"
+msgstr "Użyj \"*\" by zrobić wcięcie, \"|\" by dodać kolumnę oraz zakończenie i rozpoczęcie nowej linii. W taki sposób:"
 
 #: books/edit/edition.html
-msgid ""
-"This table of contents contains extra information like authors or "
-"descriptions. We don't have a great user interface for this yet, so "
-"editing this data could be difficult. Watch out!"
-msgstr ""
-"Ten spis treści zawiera dodatkowe informacje, takie jak autorzy lub "
-"opisy. Nie mamy jeszcze dobrego interfejsu użytkownika do tego, więc "
-"edycja tych danych może być trudna. Uważaj!"
+msgid "This table of contents contains extra information like authors or descriptions. We don't have a great user interface for this yet, so editing this data could be difficult. Watch out!"
+msgstr "Ten spis treści zawiera dodatkowe informacje, takie jak autorzy lub opisy. Nie mamy jeszcze dobrego interfejsu użytkownika do tego, więc edycja tych danych może być trudna. Uważaj!"
 
 #: books/edit/edition.html
 msgid "Any notes about this specific edition?"
@@ -4615,44 +4039,24 @@ msgid "Is it known by any other titles?"
 msgstr "Czy ta pozycja jest znana pod innymi tytułami?"
 
 #: books/edit/edition.html
-msgid ""
-"Use this field if the title is different on the cover or spine. If the "
-"edition is a collection or anthology, you may also add the individual "
-"titles of each work here."
-msgstr ""
-"Wypełnij te pole jeśli tytuł jest inny na okładce lub grzbiecie książki. "
-"Jeśli te wydanie jest kolekcją lub antologią, możesz tutaj także dodać "
-"poszczególne tytuły."
+msgid "Use this field if the title is different on the cover or spine. If the edition is a collection or anthology, you may also add the individual titles of each work here."
+msgstr "Wypełnij te pole jeśli tytuł jest inny na okładce lub grzbiecie książki. Jeśli te wydanie jest kolekcją lub antologią, możesz tutaj także dodać poszczególne tytuły."
 
 #: books/edit/edition.html
-msgid ""
-"For example: <i>Eaters of the Dead</i> is an alternate title for <i><a "
-"href=\"/books/OL24923038M\">The 13th Warrior</a></i>."
-msgstr ""
-"Na przykład: <i>Eaters of the Dead</i> to alternatywny tytuł dla <i><a "
-"href=\"/books/OL24923038M\">The 13th Warrior</a></i>."
+msgid "For example: <i>Eaters of the Dead</i> is an alternate title for <i><a href=\"/books/OL24923038M\">The 13th Warrior</a></i>."
+msgstr "Na przykład: <i>Eaters of the Dead</i> to alternatywny tytuł dla <i><a href=\"/books/OL24923038M\">The 13th Warrior</a></i>."
 
 #: books/edit/edition.html
 msgid "What work is this an edition of?"
 msgstr "Jest to wydanie książki... "
 
 #: books/edit/edition.html
-msgid ""
-"Sometimes editions can be associated with the wrong work. You can correct"
-" that here."
-msgstr ""
-"Zdarza się, że wydania są skojarzone z niepoprawnymi książkami. Możesz to"
-" poprawić tutaj."
+msgid "Sometimes editions can be associated with the wrong work. You can correct that here."
+msgstr "Zdarza się, że wydania są skojarzone z niepoprawnymi książkami. Możesz to poprawić tutaj."
 
 #: books/edit/edition.html
-msgid ""
-"You can search by title or by Open Library ID (like <a "
-"href=\"/works/OL262757W\" target=\"_blank\" rel=\"noopener "
-"noreferrer\"><em>OL262757W</em></a>)."
-msgstr ""
-"Możesz wyszukiwać według tytułu lub identyfikatora Open Library (jak <a "
-"href=\"/works/OL262757W\" target=\"_blank\" rel=\"noopener "
-"noreferrer\"><em>OL262757W</em></a>)."
+msgid "You can search by title or by Open Library ID (like <a href=\"/works/OL262757W\" target=\"_blank\" rel=\"noopener noreferrer\"><em>OL262757W</em></a>)."
+msgstr "Możesz wyszukiwać według tytułu lub identyfikatora Open Library (jak <a href=\"/works/OL262757W\" target=\"_blank\" rel=\"noopener noreferrer\"><em>OL262757W</em></a>)."
 
 #: books/edit/edition.html
 msgid "WARNING: Any edits made to the work from this page will be ignored."
@@ -4861,12 +4265,8 @@ msgid "That excerpt is too long."
 msgstr "Ten fragment jest za długi."
 
 #: books/edit/excerpts.html
-msgid ""
-"If there are particular (short) passages you feel represent the book "
-"well, please feel free to transcribe them here."
-msgstr ""
-"Jeśli Twoim zdaniem pewne (krótkie) fragmenty dobrze reprezentują całą "
-"książkę, proszę zacytować je tutaj."
+msgid "If there are particular (short) passages you feel represent the book well, please feel free to transcribe them here."
+msgstr "Jeśli Twoim zdaniem pewne (krótkie) fragmenty dobrze reprezentują całą książkę, proszę zacytować je tutaj."
 
 #: books/edit/excerpts.html
 msgid "Page number?"
@@ -4926,12 +4326,8 @@ msgid "Please enter a valid URL."
 msgstr "Proszę podać URL."
 
 #: books/edit/web.html
-msgid ""
-"Please connect Open Library records to <u>good</u><span "
-"class=\"orange\">*</span> online resources."
-msgstr ""
-"Proszę połączyć kroniki Open Library <u>poprawnych</u><span "
-"class=\"orange\">*</span> z zasobami online."
+msgid "Please connect Open Library records to <u>good</u><span class=\"orange\">*</span> online resources."
+msgstr "Proszę połączyć kroniki Open Library <u>poprawnych</u><span class=\"orange\">*</span> z zasobami online."
 
 #: books/edit/web.html
 msgid "Give your link a label"
@@ -4955,14 +4351,8 @@ msgid "Remove this link"
 msgstr "Usuń ten link"
 
 #: books/edit/web.html
-msgid ""
-"\"Good\" means no spammy links, please. Keep them relevant to the book. "
-"Irrelevant sites may be removed. Blatant spam will be deleted without "
-"remorse."
-msgstr ""
-"\"Poprwany\" oznacza link bez spamu. Linki muszą być powiązane z tą "
-"książką. Nieistotne strony mogą zostać usunięte. Rażący spam zostanie "
-"usunięty natychmiastowo."
+msgid "\"Good\" means no spammy links, please. Keep them relevant to the book. Irrelevant sites may be removed. Blatant spam will be deleted without remorse."
+msgstr "\"Poprwany\" oznacza link bez spamu. Linki muszą być powiązane z tą książką. Nieistotne strony mogą zostać usunięte. Rażący spam zostanie usunięty natychmiastowo."
 
 #: bulk_search/bulk_search.html search/advancedsearch.html
 msgid "Bulk Search (beta)"
@@ -4997,12 +4387,8 @@ msgstr "Podaj ULR tego obrazu."
 
 #: covers/add.html
 #, python-format
-msgid ""
-"Learn more by reading our <a href=\"/help/faq/editing#picture\" "
-"target=\"blank\">%(guidelines)s</a>."
-msgstr ""
-"Dowiedz się więcej, czytając nasze <a href=\"/help/faq/editing#picture\" "
-"target=\"blank\">%(guidelines)s</a>."
+msgid "Learn more by reading our <a href=\"/help/faq/editing#picture\" target=\"blank\">%(guidelines)s</a>."
+msgstr "Dowiedz się więcej, czytając nasze <a href=\"/help/faq/editing#picture\" target=\"blank\">%(guidelines)s</a>."
 
 #: covers/add.html
 #, fuzzy
@@ -5131,12 +4517,8 @@ msgid "Or, use an image from %s"
 msgstr "Lub użyj obrazu z %s"
 
 #: covers/manage.html
-msgid ""
-"You can drag and drop thumbnails to reorder, or into the trash to delete "
-"them."
-msgstr ""
-"Możesz przeciągać i upuszczać miniatury w celu zmiany kolejności, lub "
-"przeciągać je do kosza w celu usunięcia"
+msgid "You can drag and drop thumbnails to reorder, or into the trash to delete them."
+msgstr "Możesz przeciągać i upuszczać miniatury w celu zmiany kolejności, lub przeciągać je do kosza w celu usunięcia"
 
 #: covers/saved.html
 msgid "New book cover"
@@ -5164,16 +4546,8 @@ msgstr "Przełącz"
 
 #: design/toggle.html
 #, python-format
-msgid ""
-"The %(tag)s component is a switch with a bold label and an optional "
-"greyed sublabel. The whole control is one %(role)s button, so the entire "
-"surface is clickable and Enter/Space activate it. It owns its on/off "
-"state: clicking flips %(checked)s and fires %(event)s."
-msgstr ""
-"Komponent %(tag)s to przełącznik z pogrubioną etykietą i opcjonalną szarą"
-" podetyketą. Cała kontrolka to jeden przycisk %(role)s, więc cała "
-"powierzchnia jest klikalna, a Enter/Spacja ją aktywuje. Zarządza swoim "
-"stanem włącz/wyłącz: kliknięcie zmienia %(checked)s i wywołuje %(event)s."
+msgid "The %(tag)s component is a switch with a bold label and an optional greyed sublabel. The whole control is one %(role)s button, so the entire surface is clickable and Enter/Space activate it. It owns its on/off state: clicking flips %(checked)s and fires %(event)s."
+msgstr "Komponent %(tag)s to przełącznik z pogrubioną etykietą i opcjonalną szarą podetyketą. Cała kontrolka to jeden przycisk %(role)s, więc cała powierzchnia jest klikalna, a Enter/Spacja ją aktywuje. Zarządza swoim stanem włącz/wyłącz: kliknięcie zmienia %(checked)s i wywołuje %(event)s."
 
 #: design/toggle.html
 msgid "Default"
@@ -5181,12 +4555,8 @@ msgstr "Domyślny"
 
 #: design/toggle.html
 #, python-format
-msgid ""
-"A plain toggle: just the switch, a bold %(label)s, and an optional greyed"
-" %(sublabel)s."
-msgstr ""
-"Prosty przełącznik: tylko przełącznik, pogrubiona %(label)s i opcjonalna "
-"szara %(sublabel)s."
+msgid "A plain toggle: just the switch, a bold %(label)s, and an optional greyed %(sublabel)s."
+msgstr "Prosty przełącznik: tylko przełącznik, pogrubiona %(label)s i opcjonalna szara %(sublabel)s."
 
 #: design/toggle.html
 msgid "Card variant"
@@ -5194,14 +4564,8 @@ msgstr "Wariant kart"
 
 #: design/toggle.html
 #, python-format
-msgid ""
-"Use %(variant)s for a bordered container. When checked, it fills with a "
-"solid primary-blue background and white text — the same treatment as a "
-"selected %(chip)s."
-msgstr ""
-"Użyj %(variant)s dla kontenera z obramowaniem. Po zaznaczeniu wypełnia "
-"się jednolitym niebieskim tłem i białym tekstem — takie samo traktowanie "
-"jak wybrany %(chip)s."
+msgid "Use %(variant)s for a bordered container. When checked, it fills with a solid primary-blue background and white text — the same treatment as a selected %(chip)s."
+msgstr "Użyj %(variant)s dla kontenera z obramowaniem. Po zaznaczeniu wypełnia się jednolitym niebieskim tłem i białym tekstem — takie samo traktowanie jak wybrany %(chip)s."
 
 #: design/toggle.html
 #, fuzzy
@@ -5210,14 +4574,8 @@ msgstr "Spis treści"
 
 #: design/toggle.html
 #, python-format
-msgid ""
-"Put content in the default slot to customize the label instead of using "
-"%(label)s / %(sublabel)s. Supply %(accessible_label)s so the switch still"
-" has an accessible name."
-msgstr ""
-"Umieść zawartość w domyślnym slocie, aby dostosować etykietę zamiast "
-"używać %(label)s / %(sublabel)s. Podaj %(accessible_label)s, aby "
-"przełącznik nadal miał dostępną nazwę."
+msgid "Put content in the default slot to customize the label instead of using %(label)s / %(sublabel)s. Supply %(accessible_label)s so the switch still has an accessible name."
+msgstr "Umieść zawartość w domyślnym slocie, aby dostosować etykietę zamiast używać %(label)s / %(sublabel)s. Podaj %(accessible_label)s, aby przełącznik nadal miał dostępną nazwę."
 
 #: design/toggle.html
 msgid "Dark mode"
@@ -5260,19 +4618,12 @@ msgid "Thank you for your note. We'll get back to you as soon as possible."
 msgstr "Dziękujemy za wiadomość. Odpowiemy tak szybko, jak to możliwe."
 
 #: email/case_created.html
-msgid ""
-"It might take us a little while to read it because we receive lots of "
-"messages, but rest assured we will, and we'll get back to you if "
-"required."
-msgstr ""
-"Przeczytanie wiadomości może nam zająć chwilę, ponieważ otrzymujemy wiele"
-" wiadomości, ale możesz być pewien, że odezwiemy się do Ciebie."
+msgid "It might take us a little while to read it because we receive lots of messages, but rest assured we will, and we'll get back to you if required."
+msgstr "Przeczytanie wiadomości może nam zająć chwilę, ponieważ otrzymujemy wiele wiadomości, ale możesz być pewien, że odezwiemy się do Ciebie."
 
 #: email/account/pd_request.html
 msgid "Qualifying for Print Disability Special Access"
-msgstr ""
-"Kwalifikowanie się do specjalnego dostępu dla osób z niepełnosprawnością "
-"druku"
+msgstr "Kwalifikowanie się do specjalnego dostępu dla osób z niepełnosprawnością druku"
 
 #: history/sources.html
 #, fuzzy
@@ -5284,30 +4635,16 @@ msgid "About the Project"
 msgstr "O projekcie"
 
 #: home/about.html
-msgid ""
-"Open Library is an open, editable library catalog, building towards a web"
-" page for every book ever published."
-msgstr ""
-"Open Library to otwarty, edytowalny katalog biblioteczny, dążący do "
-"stworzenia strony internetowej dla każdej kiedykolwiek opublikowanej "
-"książki."
+msgid "Open Library is an open, editable library catalog, building towards a web page for every book ever published."
+msgstr "Open Library to otwarty, edytowalny katalog biblioteczny, dążący do stworzenia strony internetowej dla każdej kiedykolwiek opublikowanej książki."
 
 #: AffiliateLinks.html home/about.html search/work_search_facets.html
 msgid "More"
 msgstr "Więcej"
 
 #: home/about.html
-msgid ""
-"Just like Wikipedia, you can contribute new information or corrections to"
-" the catalog. You can browse by <a href=\"/subjects\">subjects</a>, <a "
-"href=\"/authors\">authors</a> or <a href=\"/lists\">lists</a> members "
-"have created. If you love books, why not help build a library?"
-msgstr ""
-"Tak jak na Wikipedii, możesz dodać nowe informacje lub poprawki do "
-"katalogu. Możesz przeglądać według <a href=\"/subjects\">tematyki</a>, <a"
-" href=\"/authors\">autorów</a> lub <a href=\"/lists\">list</a> "
-"stworzonych przez użytkowników. Jeśli kochasz książki - czemu nie pomóc w"
-" budowie biblioteki?"
+msgid "Just like Wikipedia, you can contribute new information or corrections to the catalog. You can browse by <a href=\"/subjects\">subjects</a>, <a href=\"/authors\">authors</a> or <a href=\"/lists\">lists</a> members have created. If you love books, why not help build a library?"
+msgstr "Tak jak na Wikipedii, możesz dodać nowe informacje lub poprawki do katalogu. Możesz przeglądać według <a href=\"/subjects\">tematyki</a>, <a href=\"/authors\">autorów</a> lub <a href=\"/lists\">list</a> stworzonych przez użytkowników. Jeśli kochasz książki - czemu nie pomóc w budowie biblioteki?"
 
 #: home/about.html
 msgid "Latest Blog Posts"
@@ -5336,8 +4673,7 @@ msgstr "Literatura klasyczna"
 msgid "Recently Returned"
 msgstr "Ostatnio zwrócone"
 
-#: home/index.html openlibrary/plugins/openlibrary/api.py
-#: openlibrary/plugins/openlibrary/home.py
+#: home/index.html openlibrary/plugins/openlibrary/api.py openlibrary/plugins/openlibrary/home.py
 msgid "Romance"
 msgstr "Romanse"
 
@@ -5349,8 +4685,7 @@ msgstr "Książki dla dzieci"
 msgid "Thrillers"
 msgstr "Dreszczwce"
 
-#: home/index.html openlibrary/plugins/openlibrary/api.py
-#: openlibrary/plugins/openlibrary/home.py
+#: home/index.html openlibrary/plugins/openlibrary/api.py openlibrary/plugins/openlibrary/home.py
 msgid "Textbooks"
 msgstr "Podręczniki"
 
@@ -5364,40 +4699,22 @@ msgstr "Książki w środowisku lokalnym"
 
 #: home/loans.html
 #, python-format
-msgid ""
-"You can still <a href=\"/subjects/in_library#ebooks=true\">borrow</a> one"
-" more book until you've hit the limit!"
-msgid_plural ""
-"You can still <a href=\"/subjects/in_library#ebooks=true\">borrow</a> "
-"%(count)d more books until you've hit the limit!"
-msgstr[0] ""
-"Możesz jeszcze <a "
-"href=\"/subjects/in_library#ebooks=true\">wypożyczyć</a> jedną książkę, "
-"zanim osiągniesz limit!"
-msgstr[1] ""
-"Możesz jeszcze <a "
-"href=\"/subjects/in_library#ebooks=true\">wypożyczyć</a> %(count)d "
-"książki, zanim osiągniesz limit!"
+msgid "You can still <a href=\"/subjects/in_library#ebooks=true\">borrow</a> one more book until you've hit the limit!"
+msgid_plural "You can still <a href=\"/subjects/in_library#ebooks=true\">borrow</a> %(count)d more books until you've hit the limit!"
+msgstr[0] "Możesz jeszcze <a href=\"/subjects/in_library#ebooks=true\">wypożyczyć</a> jedną książkę, zanim osiągniesz limit!"
+msgstr[1] "Możesz jeszcze <a href=\"/subjects/in_library#ebooks=true\">wypożyczyć</a> %(count)d książki, zanim osiągniesz limit!"
 
 #: home/loans.html
-msgid ""
-"You have reached the borrowing limit. Please return a book to checkout "
-"something new."
-msgstr ""
-"Osiągnąłeś/aś limit wypożyczeń. Proszę zwrócić książkę, aby wypożyczyć "
-"coś nowego."
+msgid "You have reached the borrowing limit. Please return a book to checkout something new."
+msgstr "Osiągnąłeś/aś limit wypożyczeń. Proszę zwrócić książkę, aby wypożyczyć coś nowego."
 
 #: home/stats.html
 msgid "Around the Library"
 msgstr "O Open Library"
 
 #: home/stats.html
-msgid ""
-"Here's what's happened over the last 28 days. More <a "
-"href=\"/recentchanges\">recent changes</a>"
-msgstr ""
-"Oto co wydarzyło się w ciągu ostatnich 28 dni. Więcej <a "
-"href=\"/recentchanges\">ostatnich zmian</a>"
+msgid "Here's what's happened over the last 28 days. More <a href=\"/recentchanges\">recent changes</a>"
+msgstr "Oto co wydarzyło się w ciągu ostatnich 28 dni. Więcej <a href=\"/recentchanges\">ostatnich zmian</a>"
 
 #: home/stats.html
 msgid "See all visitors to OpenLibrary.org"
@@ -5466,9 +4783,7 @@ msgstr "Ustaw roczny cel czytelniczy"
 
 #: home/welcome.html
 msgid "Learn how to set a yearly reading goal and track what you read"
-msgstr ""
-"Dowiedz się, jak ustawić roczny cel czytelniczy i śledzić przeczytane "
-"książki"
+msgstr "Dowiedz się, jak ustawić roczny cel czytelniczy i śledzić przeczytane książki"
 
 #: home/welcome.html
 msgid "Keep Track of your Favorite Books"
@@ -5622,8 +4937,7 @@ msgstr "Menu"
 msgid "New!"
 msgstr "Nowsze"
 
-#: databarDiff.html databarEdit.html databarTemplate.html databarView.html
-#: lib/history.html openlibrary/plugins/openlibrary/home.py
+#: databarDiff.html databarEdit.html databarTemplate.html databarView.html lib/history.html openlibrary/plugins/openlibrary/home.py
 msgid "History"
 msgstr "Historia"
 
@@ -5662,13 +4976,8 @@ msgid " Your new record is in the library. Thank you!"
 msgstr " Twój nowy rekord jest w bibliotece. Dziękujemy!"
 
 #: lib/message_addbook.html
-msgid ""
-"There are a few other simple things you can add while you're here to "
-"improve your new record quickly, and make it much easier for other people"
-" to find later."
-msgstr ""
-"Jest kilka innych prostych rzeczy, które możesz dodać podczas wizyty, aby"
-" szybko ulepszyć swój nowy rekord."
+msgid "There are a few other simple things you can add while you're here to improve your new record quickly, and make it much easier for other people to find later."
+msgstr "Jest kilka innych prostych rzeczy, które możesz dodać podczas wizyty, aby szybko ulepszyć swój nowy rekord."
 
 #: lib/message_addbook.html
 #, fuzzy
@@ -5765,9 +5074,7 @@ msgstr "Zobacz autorów"
 msgid "Explore subjects"
 msgstr "Zobacz książki"
 
-#: RelatedSubjects.html SearchNavigation.html SubjectTags.html
-#: lib/nav_foot.html lib/nav_head.html openlibrary/plugins/worksearch/code.py
-#: subjects/notfound.html type/author/view.html type/list/view_body.html
+#: RelatedSubjects.html SearchNavigation.html SubjectTags.html lib/nav_foot.html lib/nav_head.html openlibrary/plugins/worksearch/code.py subjects/notfound.html type/author/view.html type/list/view_body.html
 msgid "Subjects"
 msgstr "Tematyka"
 
@@ -5781,8 +5088,7 @@ msgstr "Zobacz książki"
 msgid "Collections"
 msgstr "Akcje"
 
-#: SearchNavigation.html lib/nav_foot.html lib/nav_head.html
-#: search/advancedsearch.html
+#: SearchNavigation.html lib/nav_foot.html lib/nav_head.html search/advancedsearch.html
 msgid "Advanced Search"
 msgstr "Wyszukiwanie zaawansowane"
 
@@ -5900,31 +5206,13 @@ msgid "Open Library logo"
 msgstr "Open Library"
 
 #: lib/nav_foot.html
-msgid ""
-"Open Library is an initiative of the <a href=\"//archive.org/\">Internet "
-"Archive</a>, a 501(c)(3) non-profit, building a digital library of "
-"Internet sites and other cultural artifacts in  digital form. Other <a "
-"href=\"//archive.org/projects/\">projects</a> include the <a "
-"href=\"//archive.org/web/\">Wayback Machine</a>, <a "
-"href=\"//archive.org/\">archive.org</a> and <a href=\"//archive-it.org"
-"\">archive-it.org</a>"
-msgstr ""
-"Open Library to inicjatywa <a href=\"//archive.org/\">Internet "
-"Archive</a>, 501(c)(3) organizacji non-profit, tworzącej cyfrową "
-"bibliotekę stron internetowych i innych artefaktów kulturowych w formie "
-"cyfrowej. Inne <a href=\"//archive.org/projects/\">projekty</a> obejmują "
-"<a href=\"//archive.org/web/\">Wayback Machine</a>, <a "
-"href=\"//archive.org/\">archive.org</a> oraz <a href=\"//archive-it.org"
-"\">archive-it.org</a>"
+msgid "Open Library is an initiative of the <a href=\"//archive.org/\">Internet Archive</a>, a 501(c)(3) non-profit, building a digital library of Internet sites and other cultural artifacts in  digital form. Other <a href=\"//archive.org/projects/\">projects</a> include the <a href=\"//archive.org/web/\">Wayback Machine</a>, <a href=\"//archive.org/\">archive.org</a> and <a href=\"//archive-it.org\">archive-it.org</a>"
+msgstr "Open Library to inicjatywa <a href=\"//archive.org/\">Internet Archive</a>, 501(c)(3) organizacji non-profit, tworzącej cyfrową bibliotekę stron internetowych i innych artefaktów kulturowych w formie cyfrowej. Inne <a href=\"//archive.org/projects/\">projekty</a> obejmują <a href=\"//archive.org/web/\">Wayback Machine</a>, <a href=\"//archive.org/\">archive.org</a> oraz <a href=\"//archive-it.org\">archive-it.org</a>"
 
 #: lib/nav_foot.html
 #, python-format
-msgid ""
-"version <a "
-"href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</a>"
-msgstr ""
-"wersja <a "
-"href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</a>"
+msgid "version <a href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</a>"
+msgstr "wersja <a href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</a>"
 
 #: lib/nav_head.html
 msgid "Loans, Reading Log, Lists, Stats"
@@ -6001,20 +5289,8 @@ msgid "Search by barcode"
 msgstr "Szukaj w"
 
 #: lib/not_logged.html
-msgid ""
-"<strong>You are not <a href=\"/account/login\" title=\"Log in "
-"now\">logged in</a>.</strong> Open Library will record your IP address "
-"and include it in this page's publicly accessible edit history. If you <a"
-" href=\"/account/create\" title=\"Create an Open Library account\">create"
-" an account</a>, your IP address is concealed and you can more easily "
-"keep track of all your edits and additions."
-msgstr ""
-"<strong>Nie jesteś <a href=\"/account/login\" title=\"Zaloguj się "
-"teraz\">zalogowany/a</a>.</strong> Open Library zapisze Twój adres IP i "
-"uwzględni go w publicznie dostępnej historii edycji tej strony. Jeśli <a "
-"href=\"/account/create\" title=\"Utwórz konto w Open Library\">utworzysz "
-"konto</a>, Twój adres IP zostanie ukryty i będziesz mógł/mogła łatwiej "
-"śledzić wszystkie swoje edycje i dodania."
+msgid "<strong>You are not <a href=\"/account/login\" title=\"Log in now\">logged in</a>.</strong> Open Library will record your IP address and include it in this page's publicly accessible edit history. If you <a href=\"/account/create\" title=\"Create an Open Library account\">create an account</a>, your IP address is concealed and you can more easily keep track of all your edits and additions."
+msgstr "<strong>Nie jesteś <a href=\"/account/login\" title=\"Zaloguj się teraz\">zalogowany/a</a>.</strong> Open Library zapisze Twój adres IP i uwzględni go w publicznie dostępnej historii edycji tej strony. Jeśli <a href=\"/account/create\" title=\"Utwórz konto w Open Library\">utworzysz konto</a>, Twój adres IP zostanie ukryty i będziesz mógł/mogła łatwiej śledzić wszystkie swoje edycje i dodania."
 
 #: librarian_dashboard/data_quality_table.html
 #, fuzzy
@@ -6109,26 +5385,13 @@ msgid "Create a list of any Subjects, Authors, Works or specific Editions."
 msgstr "Stwórz listę dowolnych tematów, autorów, książek lub wydań."
 
 #: lists/home.html
-msgid ""
-"Once you've made a list, you can <strong>watch for updates</strong> or "
-"<strong>export</strong> all the editions in a list as HTML, BibTeX or "
-"JSON. See all your lists and any activity using the \"Lists\" link on "
-"your Account page."
-msgstr ""
-"Po utworzeniu listy możesz <strong>obserwować aktualizacje</strong> lub "
-"<strong>eksportować</strong> wszystkie wydania z listy jako HTML, BibTeX "
-"lub JSON. Zobacz wszystkie swoje listy i wszelkie działania za pomocą "
-"linku \"Lists\" na stronie Twojego konta."
+msgid "Once you've made a list, you can <strong>watch for updates</strong> or <strong>export</strong> all the editions in a list as HTML, BibTeX or JSON. See all your lists and any activity using the \"Lists\" link on your Account page."
+msgstr "Po utworzeniu listy możesz <strong>obserwować aktualizacje</strong> lub <strong>eksportować</strong> wszystkie wydania z listy jako HTML, BibTeX lub JSON. Zobacz wszystkie swoje listy i wszelkie działania za pomocą linku \"Lists\" na stronie Twojego konta."
 
 #: lists/home.html
 #, python-format
-msgid ""
-"For the top 2000+ most requested eBooks in California for the print "
-"disabled <a href=\"%(url)s\">click here</a>."
-msgstr ""
-"Aby zapoznać się z ponad 2000 najczęściej żądanych e-booków w Kalifornii "
-"dla osób z niepełnosprawnością druku, <a href=\"%(url)s\">kliknij "
-"tutaj</a>."
+msgid "For the top 2000+ most requested eBooks in California for the print disabled <a href=\"%(url)s\">click here</a>."
+msgstr "Aby zapoznać się z ponad 2000 najczęściej żądanych e-booków w Kalifornii dla osób z niepełnosprawnością druku, <a href=\"%(url)s\">kliknij tutaj</a>."
 
 #: lists/home.html
 msgid "Find a list by name"
@@ -6143,8 +5406,7 @@ msgstr "Aktywne Listy"
 msgid "from <a href=\"%(key)s\">%(owner)s</a>"
 msgstr "<a href=\"%(key)s\">%(owner)s</a>"
 
-#: lists/home.html lists/preview.html lists/snippet.html type/list/embed.html
-#: type/list/view_body.html
+#: lists/home.html lists/preview.html lists/snippet.html type/list/embed.html type/list/view_body.html
 #, fuzzy, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
@@ -6311,9 +5573,7 @@ msgstr "Wybierz najstarszy profil jako główny -"
 #: merge/authors.html
 #, fuzzy
 msgid "Select author records which should be merged with the primary"
-msgstr ""
-"Wybierz dokumenty autora, które powinny zostać połączone z głównym "
-"dokumentem"
+msgstr "Wybierz dokumenty autora, które powinny zostać połączone z głównym dokumentem"
 
 #: merge/authors.html
 msgid "Press MERGE AUTHORS."
@@ -6534,12 +5794,8 @@ msgstr "Odpowiedz"
 
 #: merge_request_table/table_row.html
 #, python-format
-msgid ""
-"MR #%(id)s opened %(date)s by <a href=\"/people/%(submitter)s\" "
-"class=\"commenter\">@%(submitter)s</a>"
-msgstr ""
-"MR #%(id)s otwarto %(date)s przez <a href=\"/people/%(submitter)s\" "
-"class=\"commenter\">@%(submitter)s</a>"
+msgid "MR #%(id)s opened %(date)s by <a href=\"/people/%(submitter)s\" class=\"commenter\">@%(submitter)s</a>"
+msgstr "MR #%(id)s otwarto %(date)s przez <a href=\"/people/%(submitter)s\" class=\"commenter\">@%(submitter)s</a>"
 
 #: merge_request_table/table_row.html
 #, fuzzy
@@ -6578,13 +5834,11 @@ msgstr "Usuń tę pozycję"
 msgid "Create a new list"
 msgstr "Stwórz nową listę"
 
-#: CreateListModal.html my_books/dropdown_content.html
-#: type/permission/edit.html type/usergroup/edit.html
+#: CreateListModal.html my_books/dropdown_content.html type/permission/edit.html type/usergroup/edit.html
 msgid "Description:"
 msgstr "Opis"
 
-#: CreateListModal.html my_books/dropdown_content.html type/list/edit.html
-#: type/series/edit.html
+#: CreateListModal.html my_books/dropdown_content.html type/list/edit.html type/series/edit.html
 msgid "Create new list"
 msgstr "Utwórz nową listę"
 
@@ -6593,12 +5847,8 @@ msgid "saving..."
 msgstr "zapisywanie..."
 
 #: my_books/dropdown_content.html
-msgid ""
-"Removing this book from your shelves will delete your check-ins for this "
-"work.  Continue?"
-msgstr ""
-"Usunięcie tej książki z półek spowoduje usunięcie Twoich zameldowań dla "
-"tego dzieła. Kontynuować?"
+msgid "Removing this book from your shelves will delete your check-ins for this work.  Continue?"
+msgstr "Usunięcie tej książki z półek spowoduje usunięcie Twoich zameldowań dla tego dzieła. Kontynuować?"
 
 #: my_books/primary_action.html
 msgid "Add to List"
@@ -6662,12 +5912,8 @@ msgid "December"
 msgstr "\"Zapamniętaj mnie"
 
 #: my_books/check_ins/check_in_form.html
-msgid ""
-"Add an optional check-in date. Check-in dates are used to track yearly "
-"reading goals."
-msgstr ""
-"Dodaj opcjonalną datę zameldowania. Daty zameldowań są używane do "
-"śledzenia rocznych celów czytelniczych."
+msgid "Add an optional check-in date. Check-in dates are used to track yearly reading goals."
+msgstr "Dodaj opcjonalną datę zameldowania. Daty zameldowań są używane do śledzenia rocznych celów czytelniczych."
 
 #: my_books/check_ins/check_in_form.html
 #, fuzzy
@@ -6777,8 +6023,7 @@ msgstr "Wyszukać inne?"
 msgid "Publisher: %(name)s"
 msgstr "Wydawca: %(name)s"
 
-#: openlibrary/plugins/worksearch/code.py publishers/view.html
-#: search/advancedsearch.html type/edition/view.html type/work/view.html
+#: openlibrary/plugins/worksearch/code.py publishers/view.html search/advancedsearch.html type/edition/view.html type/work/view.html
 msgid "Publisher"
 msgstr "Wydawca"
 
@@ -6799,14 +6044,8 @@ msgid "Publishing History"
 msgstr "Historia publikacji"
 
 #: publishers/view.html
-msgid ""
-"This is a chart to show the when this publisher published books. Along "
-"the X axis is time, and on the y axis is the count of editions published."
-" <a href=\"#subjectRelated\">Click here to skip the chart</a>."
-msgstr ""
-"To wykres pokazujący, kiedy ten wydawca opublikował książki. Oś X "
-"wskazuje na czas, oś Y wskazuje liczbę opublikowanych wydań. <a "
-"href=\"#subjectRelated\"> Kliknij tutaj, aby pominąć wykres</a>."
+msgid "This is a chart to show the when this publisher published books. Along the X axis is time, and on the y axis is the count of editions published. <a href=\"#subjectRelated\">Click here to skip the chart</a>."
+msgstr "To wykres pokazujący, kiedy ten wydawca opublikował książki. Oś X wskazuje na czas, oś Y wskazuje liczbę opublikowanych wydań. <a href=\"#subjectRelated\"> Kliknij tutaj, aby pominąć wykres</a>."
 
 #: PublishingHistory.html publishers/view.html
 msgid "Reset chart"
@@ -6817,13 +6056,8 @@ msgid "or continue zooming in."
 msgstr "lub kontynuuj powiększanie."
 
 #: publishers/view.html
-msgid ""
-"This graph charts editions from this publisher over time. Click to view a"
-" single year, or drag across a range."
-msgstr ""
-"Ten diagram przedstawia wykresy publikacji tego wydawcy w miarę upływu "
-"czasu. Kliknij, aby wyświetlić pojedynczy rok lub przeciągnij przez cały "
-"zakres."
+msgid "This graph charts editions from this publisher over time. Click to view a single year, or drag across a range."
+msgstr "Ten diagram przedstawia wykresy publikacji tego wydawcy w miarę upływu czasu. Kliknij, aby wyświetlić pojedynczy rok lub przeciągnij przez cały zakres."
 
 #: PublishingHistory.html publishers/view.html
 msgid "Editions Published"
@@ -6864,20 +6098,12 @@ msgstr "Ile książek chcesz przeczytać w tym roku?"
 
 #: reading_goals/reading_goal_form.html
 msgid "Enter \"0\" to unset your reading goal. Your check-ins will be preserved."
-msgstr ""
-"Wpisz „0\", aby usunąć cel czytelniczy. Twoje zameldowania zostaną "
-"zachowane."
+msgstr "Wpisz „0\", aby usunąć cel czytelniczy. Twoje zameldowania zostaną zachowane."
 
 #: reading_goals/reading_goal_progress.html
 #, python-format
-msgid ""
-"<span class=\"reading-goal-progress__books-"
-"read\">%(books_read)d</span>/<span class=\"reading-goal-"
-"progress__goal\">%(goal)d</span> Books"
-msgstr ""
-"<span class=\"reading-goal-progress__books-"
-"read\">%(books_read)d</span>/<span class=\"reading-goal-"
-"progress__goal\">%(goal)d</span> książek"
+msgid "<span class=\"reading-goal-progress__books-read\">%(books_read)d</span>/<span class=\"reading-goal-progress__goal\">%(goal)d</span> Books"
+msgstr "<span class=\"reading-goal-progress__books-read\">%(books_read)d</span>/<span class=\"reading-goal-progress__goal\">%(goal)d</span> książek"
 
 #: reading_goals/reading_goal_progress.html
 #, python-format
@@ -6933,13 +6159,11 @@ msgstr "Wszystko"
 msgid "Admin view"
 msgstr "strona administratora"
 
-#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
-#: recentchanges/render.html
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html recentchanges/render.html
 msgid "Older"
 msgstr "Starsze"
 
-#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
-#: recentchanges/render.html
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html recentchanges/render.html
 msgid "Newer"
 msgstr "Nowsze"
 
@@ -6947,14 +6171,12 @@ msgstr "Nowsze"
 msgid "Review what's changed in from the previous revision"
 msgstr "Sprawdź, co zmieniło się w stosunku do poprzedniej wersji"
 
-#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
-#: recentchanges/default/path.html recentchanges/updated_records.html
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html recentchanges/default/path.html recentchanges/updated_records.html
 #, fuzzy
 msgid "diff"
 msgstr "Różnica"
 
-#: recentchanges/add-book/path.html recentchanges/default/path.html
-#: recentchanges/edit-book/path.html recentchanges/merge/path.html
+#: recentchanges/add-book/path.html recentchanges/default/path.html recentchanges/edit-book/path.html recentchanges/merge/path.html
 #, fuzzy
 msgid "expand"
 msgstr "Przeczytaj"
@@ -6967,8 +6189,7 @@ msgstr "utwórz nowe konto na Open Library"
 msgid "Review what's changed from the previous revision"
 msgstr "Sprawdź, co zmieniło się od poprzedniej wersji"
 
-#: recentchanges/default/view.html recentchanges/merge/view.html
-#: recentchanges/undo/view.html
+#: recentchanges/default/view.html recentchanges/merge/view.html recentchanges/undo/view.html
 #, fuzzy
 msgid "Updated Records"
 msgstr "Usuń wpis"
@@ -7089,9 +6310,7 @@ msgstr "Połącz autorów"
 
 #: search/authors.html
 msgid "No <strong>authors</strong> directly matched your search"
-msgstr ""
-"Żaden <strong>autor</strong> nie pasuje bezpośrednio do Twojego "
-"wyszukiwania"
+msgstr "Żaden <strong>autor</strong> nie pasuje bezpośrednio do Twojego wyszukiwania"
 
 #: openlibrary/plugins/worksearch/code.py search/availability_i18n.html
 #, fuzzy
@@ -7112,16 +6331,13 @@ msgstr "Wypożycz teraz"
 msgid "Search Open Library for %s"
 msgstr "Szukaj w Open Library dla %s"
 
-#: BookSearchInside.html FulltextSearchSuggestion.html SearchNavigation.html
-#: search/inside.html search/snippets.html
+#: BookSearchInside.html FulltextSearchSuggestion.html SearchNavigation.html search/inside.html search/snippets.html
 msgid "Search Inside"
 msgstr "Szukaj w"
 
 #: search/inside.html
 msgid "No <strong>Search Inside</strong> text matched your search"
-msgstr ""
-"Żaden tekst <strong>Szukaj w środku</strong> nie pasuje do Twojego "
-"wyszukiwania"
+msgstr "Żaden tekst <strong>Szukaj w środku</strong> nie pasuje do Twojego wyszukiwania"
 
 #: search/inside.html
 #, python-format
@@ -7162,7 +6378,7 @@ msgstr "Szukaj w"
 
 #: search/lists.html
 msgid "No <strong>lists</strong> directly matched your search"
-msgstr ""
+msgstr "Żadna <strong>lista</strong> nie pasuje bezpośrednio do Twojego wyszukiwania"
 
 #: search/publishers.html
 msgid "Publishers Search"
@@ -7196,12 +6412,12 @@ msgstr "Zobacz wszystkie"
 #: search/search_modal_i18n.html
 #, python-format
 msgid "See all %s result"
-msgstr ""
+msgstr "Zobacz wszystkie %s wyniki"
 
 #: search/search_modal_i18n.html
 #, python-format
 msgid "See all %s results"
-msgstr ""
+msgstr "Zobacz wszystkie %s wyniki"
 
 #: search/search_modal_i18n.html
 #, fuzzy
@@ -7215,7 +6431,7 @@ msgstr "Szukaj w"
 
 #: search/search_modal_i18n.html type/work/editions_datatable.html
 msgid "Availability"
-msgstr ""
+msgstr "Dostępność"
 
 #: search/search_modal_i18n.html
 #, fuzzy
@@ -7230,7 +6446,7 @@ msgstr "Brak wyników."
 #: search/search_modal_i18n.html
 #, python-format
 msgid "Showing %s of %s results"
-msgstr ""
+msgstr "Wyświetlanie %s z %s wyników"
 
 #: search/search_modal_i18n.html
 #, fuzzy
@@ -7260,12 +6476,12 @@ msgstr "Ostatnie zmiany"
 #: search/search_modal_i18n.html
 #, python-format
 msgid "Remove \"%s\" from recent searches"
-msgstr ""
+msgstr "Usuń „%s” z ostatnich wyszukiwań"
 
 #: search/snippets.html
 #, python-format
 msgid "On leaf number %(page_num)d:"
-msgstr ""
+msgstr "Na stronie numer %(page_num)d:"
 
 #: search/sort_options.html
 msgid "Relevance"
@@ -7283,15 +6499,15 @@ msgstr "Losowa książka"
 
 #: search/sort_options.html
 msgid "Name (beta: Librarian only)"
-msgstr ""
+msgstr "Nazwa (beta: tylko dla bibliotekarzy)"
 
 #: search/sort_options.html
 msgid "Birth Date (oldest) (beta: Librarian only)"
-msgstr ""
+msgstr "Data urodzenia (najstarszy) (beta: tylko dla bibliotekarzy)"
 
 #: search/sort_options.html
 msgid "Birth Date (youngest) (beta: Librarian only)"
-msgstr ""
+msgstr "Data urodzenia (najmłodszy) (beta: tylko dla bibliotekarzy)"
 
 #: search/sort_options.html
 #, fuzzy
@@ -7320,7 +6536,7 @@ msgstr "Stwórz nową listę"
 
 #: search/sort_options.html
 msgid "Date Added (oldest)"
-msgstr ""
+msgstr "Data dodania (najstarsza)"
 
 #: search/sort_options.html
 msgid "Most Editions"
@@ -7346,7 +6562,7 @@ msgstr "dowolny"
 
 #: search/sort_options.html
 msgid "Work Title (beta: Librarian only)"
-msgstr ""
+msgstr "Tytuł dzieła (beta: tylko dla bibliotekarzy)"
 
 #: search/sort_options.html
 msgid "Sorting by"
@@ -7354,7 +6570,7 @@ msgstr "Sortuj"
 
 #: search/sort_options.html
 msgid "Shuffle"
-msgstr ""
+msgstr "Losuj"
 
 #: search/subjects.html
 #, fuzzy
@@ -7363,7 +6579,7 @@ msgstr "Zobacz książki"
 
 #: search/subjects.html
 msgid "No <strong>subjects</strong> directly matched your search"
-msgstr ""
+msgstr "Żaden <strong>temat</strong> nie pasuje bezpośrednio do Twojego wyszukiwania"
 
 #: search/subjects.html
 msgid "time"
@@ -7395,7 +6611,7 @@ msgstr "praca"
 
 #: search/work_search_facets.html
 msgid "Merge duplicate authors from this search"
-msgstr ""
+msgstr "Scal zduplikowanych autorów z tego wyszukiwania"
 
 #: search/work_search_facets.html type/work/editions.html
 #, fuzzy
@@ -7410,11 +6626,11 @@ msgstr "mniej"
 #: search/work_search_facets.html
 #, python-format
 msgid "Filter results for %(facet)s"
-msgstr ""
+msgstr "Filtruj wyniki dla %(facet)s"
 
 #: search/work_search_facets.html
 msgid "Filter results for ebook availability"
-msgstr ""
+msgstr "Filtruj wyniki według dostępności e-booków"
 
 #: search/work_search_facets.html
 #, fuzzy
@@ -7423,7 +6639,7 @@ msgstr "Tak"
 
 #: search/work_search_facets.html
 msgid "no"
-msgstr ""
+msgstr "nie"
 
 #: search/work_search_facets.html
 msgid "Zoom In"
@@ -7431,7 +6647,7 @@ msgstr "Powiększ"
 
 #: search/work_search_facets.html
 msgid "Focus your results using these <a href=\"/search/howto\">filters</a>"
-msgstr ""
+msgstr "Zawęź wyniki za pomocą tych <a href=\"/search/howto\">filtrów</a>"
 
 #: search/work_search_selected_facets.html
 msgid "Published by"
@@ -7449,7 +6665,7 @@ msgstr "Kasyczne e-booki"
 #: search/work_search_selected_facets.html
 #, python-format
 msgid "%(title)s - search"
-msgstr ""
+msgstr "%(title)s - wyszukiwanie"
 
 #: site/alert.html
 #, fuzzy
@@ -7458,22 +6674,16 @@ msgstr "Internet Archive"
 
 #: site/body.html
 msgid "It looks like you're offline."
-msgstr ""
+msgstr "Wygląda na to, że jesteś offline."
 
 #: site/head.html
 #, fuzzy
-msgid ""
-"Open Library is an open, editable library catalog, building towards a web"
-" page for every book ever published. Read, borrow, and discover more than"
-" 3M books for free."
-msgstr ""
-"Open Library to otwarty, edytowalny katalog biblioteczny, dążący do "
-"stworzenia strony internetowej dla każdej kiedykolwiek opublikowanej "
-"książki."
+msgid "Open Library is an open, editable library catalog, building towards a web page for every book ever published. Read, borrow, and discover more than 3M books for free."
+msgstr "Open Library to otwarty, edytowalny katalog biblioteczny, dążący do stworzenia strony internetowej dla każdej kiedykolwiek opublikowanej książki."
 
 #: site/stats.html
 msgid "Debug Stats"
-msgstr ""
+msgstr "Statystyki debugowania"
 
 #: stats/readinglog.html
 #, fuzzy
@@ -7487,7 +6697,7 @@ msgstr "Książki, które kochamy"
 
 #: stats/readinglog.html
 msgid "The total number of books logged using the Reading Log feature"
-msgstr ""
+msgstr "Łączna liczba książek zapisanych za pomocą funkcji Dziennik czytelniczy"
 
 #: stats/readinglog.html
 #, fuzzy
@@ -7496,13 +6706,11 @@ msgstr "czas"
 
 #: stats/readinglog.html
 msgid "# Unique Users Logging Books"
-msgstr ""
+msgstr "# Unikalnych użytkowników zapisujących książki"
 
 #: stats/readinglog.html
-msgid ""
-"The total number of unique users who have logged at least one book using "
-"the Reading Log feature"
-msgstr ""
+msgid "The total number of unique users who have logged at least one book using the Reading Log feature"
+msgstr "Łączna liczba unikalnych użytkowników, którzy zapisali co najmniej jedną książkę za pomocą funkcji Dziennik czytelniczy"
 
 #: stats/readinglog.html
 #, fuzzy
@@ -7511,15 +6719,15 @@ msgstr "Wypożyczone e-booki"
 
 #: stats/readinglog.html
 msgid "The total number of books which have been starred"
-msgstr ""
+msgstr "Łączna liczba książek, które zostały oznaczone gwiazdką"
 
 #: stats/readinglog.html
 msgid "Total # Unique Raters (all time)"
-msgstr ""
+msgstr "Łączna liczba unikalnych oceniających (wszystkie czasy)"
 
 #: stats/readinglog.html
 msgid "Most Wanted Books (This Month)"
-msgstr ""
+msgstr "Najbardziej poszukiwane książki (ten miesiąc)"
 
 #: stats/readinglog.html
 #, fuzzy, python-format
@@ -7530,7 +6738,7 @@ msgstr[1] "%(count)d Listy"
 
 #: stats/readinglog.html
 msgid "Most Wanted Books (All Time)"
-msgstr ""
+msgstr "Najbardziej poszukiwane książki (wszystkie czasy)"
 
 #: stats/readinglog.html
 #, fuzzy
@@ -7539,7 +6747,7 @@ msgstr "Większość wydań"
 
 #: stats/readinglog.html
 msgid "Most Read Books (All Time)"
-msgstr ""
+msgstr "Najczęściej czytane książki (wszystkie czasy)"
 
 #: stats/readinglog.html
 #, fuzzy
@@ -7548,39 +6756,36 @@ msgstr "O tej książce"
 
 #: stats/readinglog.html
 msgid "Most Rated Books (All Time)"
-msgstr ""
+msgstr "Najwyżej oceniane książki (wszystkie czasy)"
 
 #: subjects/notfound.html
 msgid "We couldn't find any books about"
-msgstr ""
+msgstr "Nie znaleźliśmy żadnych książek na temat"
 
 #: swagger/swaggerui.html
 msgid "OpenAPI"
-msgstr ""
+msgstr "OpenAPI"
 
-#: type/about/edit.html type/page/edit.html type/permission/edit.html
-#: type/template/edit.html type/usergroup/edit.html
+#: type/about/edit.html type/page/edit.html type/permission/edit.html type/template/edit.html type/usergroup/edit.html
 #, python-format
 msgid "Edit %(title)s"
 msgstr "Edytuj %(title)s"
 
 #: type/about/edit.html
-msgid ""
-"This only appears in the document head, and gets attached to bookmark "
-"labels"
-msgstr ""
+msgid "This only appears in the document head, and gets attached to bookmark labels"
+msgstr "Pojawia się tylko w nagłówku dokumentu i jest dołączane do etykiet zakładek"
 
 #: type/about/edit.html
 msgid "Intro"
-msgstr ""
+msgstr "Wstęp"
 
 #: type/about/edit.html
 msgid "This appears in first column."
-msgstr ""
+msgstr "Pojawia się w pierwszej kolumnie."
 
 #: type/about/edit.html
 msgid "This appears in the second column, at top."
-msgstr ""
+msgstr "Pojawia się w drugiej kolumnie, na górze."
 
 #: type/about/edit.html
 #, fuzzy
@@ -7589,35 +6794,27 @@ msgstr "Moje listy lektur:"
 
 #: type/about/edit.html
 msgid "This appears below the links list."
-msgstr ""
+msgstr "Pojawia się poniżej listy linków."
 
 #: type/about/view.html
 msgid "For more information"
-msgstr ""
+msgstr "Więcej informacji"
 
 #: type/author/edit.html
 msgid "Edit Author"
 msgstr "Edytuj autora"
 
 #: type/author/edit.html
-msgid ""
-"Please use natural order. For example: <strong>Leo Tolstoy</strong> not "
-"<strong>Tolstoy, Leo</strong>."
-msgstr ""
-"Prosimy o podanie imienia i nazwiska. Na przykład: <strong>Lew "
-"Tołstoj</strong> nie <strong>Tołstoj, Lew</strong>. "
+msgid "Please use natural order. For example: <strong>Leo Tolstoy</strong> not <strong>Tolstoy, Leo</strong>."
+msgstr "Prosimy o podanie imienia i nazwiska. Na przykład: <strong>Lew Tołstoj</strong> nie <strong>Tołstoj, Lew</strong>. "
 
 #: type/author/edit.html
 msgid "A short bio?"
 msgstr "Krótka biografia?"
 
 #: type/author/edit.html
-msgid ""
-"If you \"borrow\" information from somewhere, please make sure to cite "
-"the source."
-msgstr ""
-"Jeśli \"pożyczasz\" pewne informacje z innych źródeł, prosimy o ich "
-"podanie."
+msgid "If you \"borrow\" information from somewhere, please make sure to cite the source."
+msgstr "Jeśli \"pożyczasz\" pewne informacje z innych źródeł, prosimy o ich podanie."
 
 #: type/author/edit.html
 msgid "Date of birth"
@@ -7628,37 +6825,28 @@ msgid "Date of death"
 msgstr "Data śmierci"
 
 #: type/author/edit.html
-msgid ""
-"We're not storing structured dates (yet) so a date like \"21 May 2000\" "
-"is recommended."
-msgstr ""
-"Nie przechowujemy (jeszcze) ustrukturyzowanych dat, prosimy o podanie "
-"daty w formacie \"21 maj 2000\"."
+msgid "We're not storing structured dates (yet) so a date like \"21 May 2000\" is recommended."
+msgstr "Nie przechowujemy (jeszcze) ustrukturyzowanych dat, prosimy o podanie daty w formacie \"21 maj 2000\"."
 
 #: type/author/edit.html
-msgid ""
-"This is a deprecated field. You can help improve this record by removing "
-"this date and populating the \"Date of birth\" and \"Date of death\" "
-"fields. Thanks!"
-msgstr ""
+msgid "This is a deprecated field. You can help improve this record by removing this date and populating the \"Date of birth\" and \"Date of death\" fields. Thanks!"
+msgstr "To jest przestarzałe pole. Możesz pomóc ulepszyć ten rekord, usuwając tę datę i wypełniając pola „Data urodzenia” i „Data śmierci”. Dziękujemy!"
 
 #: type/author/edit.html
 msgid "Does this author go by any other names?"
 msgstr "Czy autor posługiwał się innymi nazwiskami lub pseudonimami?"
 
 #: type/author/edit.html
-msgid ""
-"For example: Lev Nikolayevich Tolstoy was also known as Leo Tolstoy. "
-"Please list one name per line."
-msgstr ""
+msgid "For example: Lev Nikolayevich Tolstoy was also known as Leo Tolstoy. Please list one name per line."
+msgstr "Na przykład: Lew Nikołajewicz Tołstoj był również znany jako Lew Tołstoj. Proszę podać jedno imię na wiersz."
 
 #: type/author/edit.html
 msgid "Identifiers"
-msgstr ""
+msgstr "Identyfikatory"
 
 #: type/author/edit.html
 msgid "Author Identifiers Purpose"
-msgstr ""
+msgstr "Cel identyfikatorów autora"
 
 #: type/author/view.html type/edition/view.html type/work/view.html
 #, python-format
@@ -7676,19 +6864,15 @@ msgstr "Łączenie autorów..."
 
 #: type/author/view.html
 msgid "In progress..."
-msgstr ""
+msgstr "W trakcie..."
 
 #: type/author/view.html
 msgid "Refresh the page?"
 msgstr "Odświeżyć stronę?"
 
 #: type/author/view.html
-msgid ""
-"OK. The merge is in motion. <i>It will take <u>a few minutes to "
-"finish</u> the update.</i>"
-msgstr ""
-"OK. Łączenie zostało rozpoczęte. <i>Aktualizacja zakończy się <u>w ciągu "
-"kilku minut</u>.</i>"
+msgid "OK. The merge is in motion. <i>It will take <u>a few minutes to finish</u> the update.</i>"
+msgstr "OK. Łączenie zostało rozpoczęte. <i>Aktualizacja zakończy się <u>w ciągu kilku minut</u>.</i>"
 
 #: type/author/view.html
 msgid "Argh!"
@@ -7696,9 +6880,7 @@ msgstr "Ups!"
 
 #: type/author/view.html
 msgid "That merge didn't work. It's our fault, and we've made a note of it."
-msgstr ""
-"Te połączenie się nie powiodło. To nasza wina, zarejesterowaliśmy ten "
-"błąd."
+msgstr "Te połączenie się nie powiodło. To nasza wina, zarejesterowaliśmy ten błąd."
 
 #: type/author/view.html
 msgid "Add another?"
@@ -7707,17 +6889,14 @@ msgstr "Dodać kolejną?"
 #: type/author/view.html
 #, python-format
 msgid "Search %(author)s books"
-msgstr ""
+msgstr "Szukaj książek %(author)s"
 
 #: type/author/view.html
 #, fuzzy, python-format
 msgid "— Show <a href=\"%(url)s\">everything</a> by this author?"
-msgstr ""
-"Wczytywanie tylko e-booków. Czy chesz zobaczyć <a "
-"href=\"%(url)s\">wszystkie</a> prace tego autora?"
+msgstr "Wczytywanie tylko e-booków. Czy chesz zobaczyć <a href=\"%(url)s\">wszystkie</a> prace tego autora?"
 
-#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py
-#: type/author/view.html type/list/view_body.html
+#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py type/author/view.html type/list/view_body.html
 msgid "Places"
 msgstr "Miejsca"
 
@@ -7732,7 +6911,7 @@ msgstr "Starsze"
 
 #: type/author/view.html
 msgid "Inventaire.io:"
-msgstr ""
+msgstr "Inventaire.io:"
 
 #: type/author/view.html type/edition/view.html type/work/view.html
 #, fuzzy
@@ -7753,7 +6932,7 @@ msgstr "Alternatywne nazwiska"
 
 #: type/delete/view.html
 msgid "This page has been deleted"
-msgstr ""
+msgstr "Ta strona została usunięta"
 
 #: type/delete/view.html
 #, fuzzy
@@ -7762,11 +6941,11 @@ msgstr "Jak opisał\\(a\\)byś tę książkę?"
 
 #: type/delete/view.html
 msgid "Go back where I came from"
-msgstr ""
+msgstr "Wróć, skąd przyszedłem"
 
 #: type/delete/view.html
 msgid "View the previous version"
-msgstr ""
+msgstr "Zobacz poprzednią wersję"
 
 #: type/delete/view.html
 #, fuzzy
@@ -7785,7 +6964,7 @@ msgstr "Dodaj do Wyboranych przez nas"
 
 #: type/edition/admin_bar.html
 msgid "Sync Archive.org ID"
-msgstr ""
+msgstr "Synchronizuj identyfikator Archive.org"
 
 #: type/edition/admin_bar.html
 #, fuzzy
@@ -7825,12 +7004,12 @@ msgstr "1 wydanie"
 #: type/edition/title_and_author.html
 #, python-format
 msgid "First published in %s"
-msgstr ""
+msgstr "Pierwsze wydanie w %s"
 
 #: type/edition/title_and_author.html
 #, python-format
 msgid "Book %s"
-msgstr ""
+msgstr "Książka %s"
 
 #: type/edition/view.html type/work/view.html
 #, fuzzy
@@ -7839,21 +7018,17 @@ msgstr "Usuń"
 
 #: type/edition/view.html type/work/view.html
 msgid "Read Less"
-msgstr ""
+msgstr "Czytaj mniej"
 
 #: type/edition/view.html type/work/view.html
 #, python-format
-msgid ""
-"This work doesn't have a description yet. Can you <b><a "
-"href='%(url)s'>add one</a></b>?"
-msgstr ""
+msgid "This work doesn't have a description yet. Can you <b><a href='%(url)s'>add one</a></b>?"
+msgstr "To dzieło nie ma jeszcze opisu. Czy możesz <b><a href='%(url)s'>dodać jeden</a></b>?"
 
 #: type/edition/view.html type/work/view.html
 #, python-format
-msgid ""
-"This edition doesn't have a description yet. Can you <b><a "
-"href='%(url)s'>add one</a></b>?"
-msgstr ""
+msgid "This edition doesn't have a description yet. Can you <b><a href='%(url)s'>add one</a></b>?"
+msgstr "To wydanie nie ma jeszcze opisu. Czy możesz <b><a href='%(url)s'>dodać jedno</a></b>?"
 
 #: type/edition/view.html type/work/view.html
 #, fuzzy
@@ -7863,12 +7038,12 @@ msgstr "Wydawca"
 #: type/edition/view.html type/work/view.html
 #, python-format
 msgid "Show other books from %(publisher)s"
-msgstr ""
+msgstr "Pokaż inne książki od %(publisher)s"
 
 #: type/edition/view.html type/work/view.html
 #, python-format
 msgid "Search for other books from %(publisher)s"
-msgstr ""
+msgstr "Szukaj innych książek od %(publisher)s"
 
 #: type/edition/view.html type/work/view.html
 #, fuzzy
@@ -7886,7 +7061,7 @@ msgstr "Kup tą książkę"
 
 #: type/edition/view.html type/work/view.html
 msgid "Book Details"
-msgstr ""
+msgstr "Szczegóły książki"
 
 #: type/edition/view.html type/work/view.html
 msgid "First Sentence"
@@ -7937,8 +7112,7 @@ msgstr "Linki zewnętrzne"
 msgid "Format"
 msgstr "Format"
 
-#: OlPagination.html OlPaginationArrows.html type/edition/view.html
-#: type/work/view.html
+#: OlPagination.html OlPaginationArrows.html type/edition/view.html type/work/view.html
 msgid "Pagination"
 msgstr "Paginacja"
 
@@ -7976,12 +7150,12 @@ msgstr "Fragmenty"
 #: type/edition/view.html type/work/view.html
 #, python-format
 msgid "Page %(page)s"
-msgstr ""
+msgstr "Strona %(page)s"
 
 #: type/edition/view.html type/work/view.html
 #, python-format
 msgid "added by %(authorlink)s."
-msgstr ""
+msgstr "dodane przez %(authorlink)s."
 
 #: type/edition/view.html type/work/view.html
 #, fuzzy
@@ -8000,7 +7174,7 @@ msgstr "Moje listy lektur:"
 #: type/language/view.html
 #, python-format
 msgid "%(language)s [deprecated]"
-msgstr ""
+msgstr "%(language)s [przestarzałe]"
 
 #: type/language/view.html
 #, fuzzy
@@ -8020,7 +7194,7 @@ msgstr "1 obecnie wypożyczona"
 #: type/language/view.html
 #, python-format
 msgid "Try a <a href=\"%(href)s\">search for readable books in %(language)s</a>?"
-msgstr ""
+msgstr "Spróbuj <a href=\"%(href)s\">wyszukać czytelne książki w języku %(language)s</a>?"
 
 #: type/list/edit.html type/series/edit.html
 #, fuzzy
@@ -8030,12 +7204,12 @@ msgstr "Stwórz nową listę"
 #: type/list/edit.html type/series/edit.html
 #, python-format
 msgid "Editing series: %(list_name)s"
-msgstr ""
+msgstr "Edytowanie serii: %(list_name)s"
 
 #: type/list/edit.html type/series/edit.html
 #, python-format
 msgid "Editing list: %(list_name)s"
-msgstr ""
+msgstr "Edytowanie listy: %(list_name)s"
 
 #: type/list/edit.html type/series/edit.html
 #, fuzzy
@@ -8059,11 +7233,11 @@ msgstr "Wyszukaj w tekscie e-booka"
 
 #: type/list/edit.html type/series/edit.html
 msgid "Position (optional), e.g. 1, 2, 1-7"
-msgstr ""
+msgstr "Pozycja (opcjonalnie), np. 1, 2, 1-7"
 
 #: type/list/edit.html type/series/edit.html
 msgid "Notes (optional)"
-msgstr ""
+msgstr "Uwagi (opcjonalnie)"
 
 #: type/list/edit.html type/series/edit.html
 #, fuzzy
@@ -8096,18 +7270,16 @@ msgid "Visit Open Library"
 msgstr "Open Library"
 
 #: type/list/embed.html
-msgid ""
-"Open in online Book Reader. Downloads available in ePub, DAISY, PDF, TXT "
-"formats from main book page"
-msgstr ""
+msgid "Open in online Book Reader. Downloads available in ePub, DAISY, PDF, TXT formats from main book page"
+msgstr "Otwórz w czytelniku książek online. Pobieranie dostępne w formatach ePub, DAISY, PDF, TXT ze strony głównej książki"
 
 #: type/list/embed.html
 msgid "This book is checked out"
-msgstr ""
+msgstr "Ta książka jest wypożyczona"
 
 #: type/list/embed.html
 msgid "Checked out"
-msgstr ""
+msgstr "Wypożyczone"
 
 #: type/list/embed.html
 #, fuzzy
@@ -8116,7 +7288,7 @@ msgstr "Wypożycz teraz"
 
 #: type/list/embed.html
 msgid "Protected DAISY"
-msgstr ""
+msgstr "Chroniony DAISY"
 
 #: BookByline.html type/list/embed.html
 #, fuzzy, python-format
@@ -8136,11 +7308,11 @@ msgstr "Tekst"
 #: type/list/exports.html
 #, python-format
 msgid "as %(json_link)s, %(html_link)s, or %(bibtex_link)s"
-msgstr ""
+msgstr "jako %(json_link)s, %(html_link)s lub %(bibtex_link)s"
 
 #: type/list/exports.html
 msgid "Subscribe"
-msgstr ""
+msgstr "Subskrybuj"
 
 #: type/list/exports.html
 #, python-format
@@ -8153,16 +7325,12 @@ msgstr ""
 
 #: type/list/exports.html
 #, python-format
-msgid ""
-"Only lists with up to %(max)s editions can be exported. This one has "
-"%(count)s."
+msgid "Only lists with up to %(max)s editions can be exported. This one has %(count)s."
 msgstr ""
 
 #: type/list/exports.html
 #, python-format
-msgid ""
-"Try removing some seeds for more focus, or look at <a href=\"%s\">bulk "
-"download</a> of the catalog."
+msgid "Try removing some seeds for more focus, or look at <a href=\"%s\">bulk download</a> of the catalog."
 msgstr ""
 
 #: type/list/view_body.html
@@ -8206,16 +7374,12 @@ msgid "Remove Seed"
 msgstr "Usunąć ten plik inicujuący?"
 
 #: type/list/view_body.html
-msgid ""
-"You are about to remove the last item in the list. That will delete the "
-"whole list. Are you sure you want to continue?"
+msgid "You are about to remove the last item in the list. That will delete the whole list. Are you sure you want to continue?"
 msgstr ""
 
 #: type/list/view_body.html
 #, python-format
-msgid ""
-"This series contains %(limit)d or more works. Currently, only the first "
-"%(limit)d works are displayed."
+msgid "This series contains %(limit)d or more works. Currently, only the first %(limit)d works are displayed."
 msgstr ""
 
 #: type/list/view_body.html
@@ -8223,9 +7387,7 @@ msgid "There are no items on this list."
 msgstr ""
 
 #: type/list/view_body.html
-msgid ""
-"<a href=\"/search\" target=\"_blank\" rel=\"noopener noreferrer\">Search "
-"for book, subjects, or authors</a> to add to your list."
+msgid "<a href=\"/search\" target=\"_blank\" rel=\"noopener noreferrer\">Search for book, subjects, or authors</a> to add to your list."
 msgstr ""
 
 #: type/list/view_body.html
@@ -8241,8 +7403,7 @@ msgstr "Dodatkowe metadane"
 msgid "Derived from seed metadata"
 msgstr ""
 
-#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py
-#: type/list/view_body.html
+#: RelatedSubjects.html SubjectTags.html openlibrary/plugins/worksearch/code.py type/list/view_body.html
 msgid "Times"
 msgstr "Okres"
 
@@ -8323,12 +7484,7 @@ msgid "We require a minimum set of fields to create a new collection tag."
 msgstr "Aby utworzyć nowy wpis wymagane jest uzupełnienie nastepujących pól."
 
 #: EditButtons.html type/tag/form.html
-msgid ""
-"By saving a change to this wiki, you agree that your contribution is "
-"given freely to the world under <a "
-"href=\"https://creativecommons.org/publicdomain/zero/1.0/\" "
-"target=\"_blank\" rel=\"noopener noreferrer\" title=\"This link to "
-"Creative Commons will open in a new window\">CC0</a>. Yippee!"
+msgid "By saving a change to this wiki, you agree that your contribution is given freely to the world under <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\" target=\"_blank\" rel=\"noopener noreferrer\" title=\"This link to Creative Commons will open in a new window\">CC0</a>. Yippee!"
 msgstr ""
 
 #: type/tag/form.html
@@ -8365,9 +7521,7 @@ msgid "Tag Name"
 msgstr "Imię i nazwisko"
 
 #: type/tag/tag_form_inputs.html
-msgid ""
-"Human-readable display name (e.g. \"Computer Science\", \"Horror "
-"Fiction\")"
+msgid "Human-readable display name (e.g. \"Computer Science\", \"Horror Fiction\")"
 msgstr ""
 
 #: type/tag/tag_form_inputs.html
@@ -8375,9 +7529,7 @@ msgid "Tag Slugs"
 msgstr ""
 
 #: type/tag/tag_form_inputs.html
-msgid ""
-"Comma-separated URL slugs that map to this tag (auto-populated from "
-"name). E.g. \"computer_science, cs\""
+msgid "Comma-separated URL slugs that map to this tag (auto-populated from name). E.g. \"computer_science, cs\""
 msgstr ""
 
 #: type/tag/tag_form_inputs.html
@@ -8480,12 +7632,7 @@ msgstr "strona administratora"
 
 #: type/user/view.html
 #, python-format
-msgid ""
-"You are publicly sharing the books you are <a href=\"%(username)s/books"
-"/currently-reading\">currently reading</a>, <a href=\"%(username)s/books"
-"/already-read\">have already read</a>, <a href=\"%(username)s/books/want-"
-"to-read\">want to read</a>, and have <a href=\"%(username)s/books"
-"/stopped-reading\">stopped reading</a>!"
+msgid "You are publicly sharing the books you are <a href=\"%(username)s/books/currently-reading\">currently reading</a>, <a href=\"%(username)s/books/already-read\">have already read</a>, <a href=\"%(username)s/books/want-to-read\">want to read</a>, and have <a href=\"%(username)s/books/stopped-reading\">stopped reading</a>!"
 msgstr ""
 
 #: type/user/view.html
@@ -8502,12 +7649,7 @@ msgstr "Zarządzaj swoimi ustawieniami prywatności"
 
 #: type/user/view.html
 #, python-format
-msgid ""
-"Here are the books %(user)s is <a href=\"%(username)s/books/currently-"
-"reading\">currently reading</a>, <a href=\"%(username)s/books/already-"
-"read\">have already read</a>, <a href=\"%(username)s/books/want-to-"
-"read\">want to read</a>, and has <a href=\"%(username)s/books/stopped-"
-"reading\">stopped reading</a>!"
+msgid "Here are the books %(user)s is <a href=\"%(username)s/books/currently-reading\">currently reading</a>, <a href=\"%(username)s/books/already-read\">have already read</a>, <a href=\"%(username)s/books/want-to-read\">want to read</a>, and has <a href=\"%(username)s/books/stopped-reading\">stopped reading</a>!"
 msgstr ""
 
 #: type/user/view.html
@@ -8574,9 +7716,7 @@ msgid "Look for this edition for sale at %(store)s"
 msgstr ""
 
 #: AffiliateLinks.html
-msgid ""
-"When you buy books using these links the Internet Archive may earn a <a "
-"class=\"nostyle\" href=\"/help/faq/about#selling\">small commission</a>."
+msgid "When you buy books using these links the Internet Archive may earn a <a class=\"nostyle\" href=\"/help/faq/about#selling\">small commission</a>."
 msgstr ""
 
 #: AffiliateLinksLoadingIndicator.html
@@ -8610,9 +7750,7 @@ msgid "Preview Book"
 msgstr "Wypożycz teraz"
 
 #: DisplayCode.html
-msgid ""
-"Templates in the website are disabled now. Editing them will not have any"
-" effect on the live website."
+msgid "Templates in the website are disabled now. Editing them will not have any effect on the live website."
 msgstr ""
 
 #: EditionNavBar.html
@@ -8823,15 +7961,8 @@ msgid "who have written the most books on this subject"
 msgstr "którzy napisali najwięcej książek na ten temat"
 
 #: PublishingHistory.html
-msgid ""
-"This is a chart to show the publishing history of editions of works about"
-" this subject. Along the X axis is time, and on the y axis is the count "
-"of editions published. <a href=\"#subjectRelated\">Click here to skip the"
-" chart</a>."
-msgstr ""
-"To wykres pokazujący historię publikacji dzieł na ten temat. Oś X "
-"wskazuje na czas, oś Y wskazuje liczbę publikacji. <a "
-"href=\"#subjectRelated\"> Kliknij tutaj, aby pominąć wykres</a>."
+msgid "This is a chart to show the publishing history of editions of works about this subject. Along the X axis is time, and on the y axis is the count of editions published. <a href=\"#subjectRelated\">Click here to skip the chart</a>."
+msgstr "To wykres pokazujący historię publikacji dzieł na ten temat. Oś X wskazuje na czas, oś Y wskazuje liczbę publikacji. <a href=\"#subjectRelated\"> Kliknij tutaj, aby pominąć wykres</a>."
 
 #: PublishingHistory.html
 msgid "This graph charts editions published on this subject."
@@ -8868,9 +7999,7 @@ msgid "Special Access"
 msgstr "Miejsca"
 
 #: ReadButton.html
-msgid ""
-"Special ebook access from the Internet Archive for patrons with "
-"qualifying print disabilities"
+msgid "Special ebook access from the Internet Archive for patrons with qualifying print disabilities"
 msgstr ""
 
 #: ReadButton.html
@@ -9164,30 +8293,16 @@ msgid "Huh?"
 msgstr "Wpisz ponownie"
 
 #: TypeChanger.html
-msgid ""
-"Every piece of Open Library is defined by the type of content it "
-"displays, usually by content definition (e.g. Authors, Editions, Works) "
-"but sometimes by content use (e.g. macro, template, rawtext). Changing "
-"this for an existing page will alter its presentation and the data fields"
-" available for editing its content."
-msgstr ""
-"Każdy element Open Library jest określony przez rodzaj informacji które "
-"wyświetla, zwykle według definicji treści (np. autorzy, wydania, prace), "
-"a czasem według zawartości (np. makro, szablon, tekst). Zmiany na "
-"istniejącej stronie zmienią jej prezentację i pola danychdostępnych do "
-"edycji jej zawartości."
+msgid "Every piece of Open Library is defined by the type of content it displays, usually by content definition (e.g. Authors, Editions, Works) but sometimes by content use (e.g. macro, template, rawtext). Changing this for an existing page will alter its presentation and the data fields available for editing its content."
+msgstr "Każdy element Open Library jest określony przez rodzaj informacji które wyświetla, zwykle według definicji treści (np. autorzy, wydania, prace), a czasem według zawartości (np. makro, szablon, tekst). Zmiany na istniejącej stronie zmienią jej prezentację i pola danychdostępnych do edycji jej zawartości."
 
 #: TypeChanger.html
 msgid "Please use caution changing Page Type!"
 msgstr "Zachowaj ostrożność, zmieniając Typ Strony!"
 
 #: TypeChanger.html
-msgid ""
-"(Simplest solution: If you aren't sure whether this should be changed, "
-"don't change it.)"
-msgstr ""
-"(Najprostsze rozwiązanie: jeśli nie masz pewności, czy należy to zmienić,"
-" nie zmieniaj tego.)"
+msgid "(Simplest solution: If you aren't sure whether this should be changed, don't change it.)"
+msgstr "(Najprostsze rozwiązanie: jeśli nie masz pewności, czy należy to zmienić, nie zmieniaj tego.)"
 
 #: WorkInfo.html
 msgid "No link to Wikipedia in your language"
@@ -9518,9 +8633,7 @@ msgid "Login attempted with invalid Internet Archive s3 credentials."
 msgstr ""
 
 #: openlibrary/plugins/upstream/account.py
-msgid ""
-"Servers are experiencing unusually high traffic, please try again later "
-"or email openlibrary@archive.org for help."
+msgid "Servers are experiencing unusually high traffic, please try again later or email openlibrary@archive.org for help."
 msgstr ""
 
 #: openlibrary/plugins/upstream/account.py
@@ -9538,9 +8651,7 @@ msgid "A problem occurred and we were unable to log you in"
 msgstr ""
 
 #: openlibrary/plugins/upstream/account.py
-msgid ""
-"Login or registration attempt hit an unexpected error, please try again "
-"or contact info@archive.org"
+msgid "Login or registration attempt hit an unexpected error, please try again or contact info@archive.org"
 msgstr ""
 
 #: openlibrary/plugins/upstream/account.py
@@ -9549,18 +8660,14 @@ msgid "Request failed with error code: %(error_code)s"
 msgstr ""
 
 #: openlibrary/plugins/upstream/account.py
-msgid ""
-"Thank you for registering an Open Library account and requesting special "
-"print disability access. You should receive an email detailing next steps"
-" in the process."
+msgid "Thank you for registering an Open Library account and requesting special print disability access. You should receive an email detailing next steps in the process."
 msgstr ""
 
 #: openlibrary/plugins/upstream/account.py
 msgid "Username unavailable"
 msgstr ""
 
-#: openlibrary/plugins/upstream/account.py
-#: openlibrary/plugins/upstream/forms.py
+#: openlibrary/plugins/upstream/account.py openlibrary/plugins/upstream/forms.py
 msgid "Email already registered"
 msgstr "Podany e-mail jest już zarejestrowany"
 
@@ -9569,9 +8676,7 @@ msgid "An Internet Archive account already exists with this email"
 msgstr ""
 
 #: openlibrary/plugins/upstream/account.py
-msgid ""
-"Verification failed. The link may be invalid or expired. Please try "
-"registering again."
+msgid "Verification failed. The link may be invalid or expired. Please try registering again."
 msgstr ""
 
 #: openlibrary/plugins/upstream/account.py
@@ -9598,9 +8703,7 @@ msgid "%s has been returned."
 msgstr ""
 
 #: openlibrary/plugins/upstream/borrow.py
-msgid ""
-"Your account has hit a lending limit. Please try again later or contact "
-"info@archive.org."
+msgid "Your account has hit a lending limit. Please try again later or contact info@archive.org."
 msgstr ""
 
 #: openlibrary/plugins/upstream/forms.py
@@ -9650,10 +8753,7 @@ msgstr "Wybierz hasło"
 
 #: openlibrary/plugins/upstream/mybooks.py
 #, python-format
-msgid ""
-"Continue <a href=\"%(url)s\" class=\"pending-action-link\" data-"
-"action=\"%(raw_action)s\"><strong>%(action)s</strong> "
-"<em>%(name)s</em></a>"
+msgid "Continue <a href=\"%(url)s\" class=\"pending-action-link\" data-action=\"%(raw_action)s\"><strong>%(action)s</strong> <em>%(name)s</em></a>"
 msgstr ""
 
 #: openlibrary/plugins/worksearch/code.py
@@ -9677,28 +8777,16 @@ msgstr "Kasyczne e-booki"
 #~ msgid "Reading Lists"
 #~ msgstr "Listy lektur"
 
-#~ msgid ""
-#~ "Last edited by <a href=\"$author.key\" "
-#~ "rel=\"nofollow\">%(authorname)s</a>"
-#~ msgstr ""
-#~ "Ostatnio edytowane przez <a "
-#~ "href=\"$author.key\" rel=\"nofollow\">%(authorname)s</a>"
+#~ msgid "Last edited by <a href=\"$author.key\" rel=\"nofollow\">%(authorname)s</a>"
+#~ msgstr "Ostatnio edytowane przez <a href=\"$author.key\" rel=\"nofollow\">%(authorname)s</a>"
 
 #~ msgid "Add another edition of"
 #~ msgstr "Dodaj kolejne wydanie"
 
-#~ msgid ""
-#~ "There's no description for this book "
-#~ "yet. Can you <b><a href='%s'>add "
-#~ "one</a></b>?"
-#~ msgstr ""
-#~ "Ta książka nie ma jeszcze opisu. "
-#~ "Czy możesz <b><a href='%s'>dodać opis</a></b>?"
+#~ msgid "There's no description for this book yet. Can you <b><a href='%s'>add one</a></b>?"
+#~ msgstr "Ta książka nie ma jeszcze opisu. Czy możesz <b><a href='%s'>dodać opis</a></b>?"
 
-#~ msgid ""
-#~ "Only lists with up to %(max)s "
-#~ "editions can be exported. This one "
-#~ "has %s(count)."
+#~ msgid "Only lists with up to %(max)s editions can be exported. This one has %s(count)."
 #~ msgstr ""
 
 #~ msgid "First published in %s"
@@ -9742,41 +8830,23 @@ msgstr "Kasyczne e-booki"
 #~ msgstr[0] "%s wydanie"
 #~ msgstr[1] "%s wydań"
 
-#~ msgid ""
-#~ "We've sent the verification email to "
-#~ "%(email)s. You'll need to read that "
-#~ "and click on the verification link "
-#~ "to verify your email."
-#~ msgstr ""
-#~ "Wysłaliśmy potwierdzenie na adres %(email)s."
-#~ " Przeczytaj je i kliknij zamieszczony "
-#~ "link, by potwierdzić swój e-mail."
+#~ msgid "We've sent the verification email to %(email)s. You'll need to read that and click on the verification link to verify your email."
+#~ msgstr "Wysłaliśmy potwierdzenie na adres %(email)s. Przeczytaj je i kliknij zamieszczony link, by potwierdzić swój e-mail."
 
 #~ msgid "Email address is already used."
 #~ msgstr "Ten e-mail jest już w użyciu."
 
-#~ msgid ""
-#~ "Your email address couldn't be updated."
-#~ " The specified email address is "
-#~ "already used."
+#~ msgid "Your email address couldn't be updated. The specified email address is already used."
 #~ msgstr "Twój e-mail nie został zaktualizowany. Podany e-mail jest już w użyciu."
 
 #~ msgid "Email verification successful."
 #~ msgstr "Twój e-mail został zweryfikowany."
 
-#~ msgid ""
-#~ "Your email address has been successfully"
-#~ " verified and updated in your "
-#~ "account."
+#~ msgid "Your email address has been successfully verified and updated in your account."
 #~ msgstr "Twój e-mail został zweryfikowany i zaktualizowany na Twoimkoncie."
 
-#~ msgid ""
-#~ "Your email address couldn't be verified."
-#~ " The verification link seems invalid."
-#~ msgstr ""
-#~ "Twój e-mail nie mógł zostać "
-#~ "zweryfikowany. Link weryfikacyjny jest "
-#~ "nieważny."
+#~ msgid "Your email address couldn't be verified. The verification link seems invalid."
+#~ msgstr "Twój e-mail nie mógł zostać zweryfikowany. Link weryfikacyjny jest nieważny."
 
 #~ msgid "Choose a screen name"
 #~ msgstr "Wybierz nick"
@@ -9787,11 +8857,7 @@ msgstr "Kasyczne e-booki"
 #~ msgid "Confirm password"
 #~ msgstr "Potwierdź hasło"
 
-#~ msgid ""
-#~ "Send me a monthly newsletter from "
-#~ "the <a href=\"https://archive.org/\">Internet "
-#~ "Archive</a>, the non-profit that runs"
-#~ " Open Library"
+#~ msgid "Send me a monthly newsletter from the <a href=\"https://archive.org/\">Internet Archive</a>, the non-profit that runs Open Library"
 #~ msgstr ""
 
 #~ msgid "Websites"
@@ -9800,33 +8866,13 @@ msgstr "Kasyczne e-booki"
 #~ msgid "Deprecated"
 #~ msgstr "Przestarzałe"
 
-#~ msgid ""
-#~ "Showing all works by author. Would "
-#~ "you like to see <a href=\"%(url)s\">only"
-#~ " ebooks</a>?"
-#~ msgstr ""
-#~ "Wczytywanie wszystkich prac autora. Czy "
-#~ "chesz zobaczyć <a href=\"%(url)s\">tylko "
-#~ "e-booki</a>?"
+#~ msgid "Showing all works by author. Would you like to see <a href=\"%(url)s\">only ebooks</a>?"
+#~ msgstr "Wczytywanie wszystkich prac autora. Czy chesz zobaczyć <a href=\"%(url)s\">tylko e-booki</a>?"
 
-#~ msgid ""
-#~ "<a href=\"%(url)s\"><strong>1 edition</strong></a> "
-#~ "of <strong class=\"booktitle\">%(title)s</strong> "
-#~ "found in the catalog."
-#~ msgid_plural ""
-#~ "<a href=\"%(url)s\"><strong>%(count)d "
-#~ "editions</strong></a> of <strong "
-#~ "class=\"booktitle\">%(title)s</strong> found in the"
-#~ " catalog."
-#~ msgstr[0] ""
-#~ "<a href=\"%(url)s\"><strong>1 wydanie</strong></a><strong"
-#~ " class=\"booktitle\">%(title)s</strong> w tym "
-#~ "katalogu."
-#~ msgstr[1] ""
-#~ "<a href=\"%(url)s\"><strong>%(count)d "
-#~ "wydania</strong></a><strong "
-#~ "class=\"booktitle\">%(title)s</strong> w tym "
-#~ "katalogu."
+#~ msgid "<a href=\"%(url)s\"><strong>1 edition</strong></a> of <strong class=\"booktitle\">%(title)s</strong> found in the catalog."
+#~ msgid_plural "<a href=\"%(url)s\"><strong>%(count)d editions</strong></a> of <strong class=\"booktitle\">%(title)s</strong> found in the catalog."
+#~ msgstr[0] "<a href=\"%(url)s\"><strong>1 wydanie</strong></a><strong class=\"booktitle\">%(title)s</strong> w tym katalogu."
+#~ msgstr[1] "<a href=\"%(url)s\"><strong>%(count)d wydania</strong></a><strong class=\"booktitle\">%(title)s</strong> w tym katalogu."
 
 #~ msgid "Search for subjects about %(place)s"
 #~ msgstr "Szukaj tematów związanych z"
@@ -9848,11 +8894,7 @@ msgstr "Kasyczne e-booki"
 #~ msgstr[0] "1 praca"
 #~ msgstr[1] "%(count)d prace"
 
-#~ msgid ""
-#~ "You are about the remove the last"
-#~ " item in the list. That will "
-#~ "delete the whole list. Are you "
-#~ "sure you want to continue?"
+#~ msgid "You are about the remove the last item in the list. That will delete the whole list. Are you sure you want to continue?"
 #~ msgstr ""
 
 #~ msgid "Download DAISY eBook for print disabled"
@@ -9891,16 +8933,8 @@ msgstr "Kasyczne e-booki"
 #~ msgid "Your reading log is currently set to private"
 #~ msgstr "Twój dziennik lektur jest obecnie niewidoczny dla innych"
 
-#~ msgid ""
-#~ "You have 5 ebooks out at the "
-#~ "moment. That's the limit! You can "
-#~ "free up slots by returning books "
-#~ "early."
-#~ msgstr ""
-#~ "Obecnie masz 5 ebooków. To maksymalna"
-#~ " dozwolona ilość! Możesz wypożyczyć więcej"
-#~ " e-booków kiedy zwrócisz obecnie "
-#~ "wypożyczone."
+#~ msgid "You have 5 ebooks out at the moment. That's the limit! You can free up slots by returning books early."
+#~ msgstr "Obecnie masz 5 ebooków. To maksymalna dozwolona ilość! Możesz wypożyczyć więcej e-booków kiedy zwrócisz obecnie wypożyczone."
 
 #~ msgid "How To Return eBooks through Adobe Digital Editions"
 #~ msgstr ""
@@ -9932,83 +8966,34 @@ msgstr "Kasyczne e-booki"
 #~ msgstr[1] "%(count)s książek"
 
 #~ msgid "There are 2 different sources for borrowing books through Open Library:"
-#~ msgstr ""
-#~ "Istnieją 2 źródła, z których możesz "
-#~ "wypożyczyć książki przez Opne Library"
+#~ msgstr "Istnieją 2 źródła, z których możesz wypożyczyć książki przez Opne Library"
 
-#~ msgid ""
-#~ "The <a href=\"//archive.org/\">Internet Archive</a>"
-#~ " and several partner libraries are "
-#~ "offering thousands of eBooks for loan"
-#~ " to anyone with an Open Library "
-#~ "account, anywhere in the world."
-#~ msgstr ""
-#~ "<a href=\"//archive.org/\">Internet Archive</a> oraz"
-#~ " inne partnerskie biblioteki oferują "
-#~ "tysiące e-booków użytkownikom na całym "
-#~ "świecie, którzy posiadają konto na Open"
-#~ " Library."
+#~ msgid "The <a href=\"//archive.org/\">Internet Archive</a> and several partner libraries are offering thousands of eBooks for loan to anyone with an Open Library account, anywhere in the world."
+#~ msgstr "<a href=\"//archive.org/\">Internet Archive</a> oraz inne partnerskie biblioteki oferują tysiące e-booków użytkownikom na całym świecie, którzy posiadają konto na Open Library."
 
 #~ msgid "physical books from your local library"
 #~ msgstr "Papierowe wydania książek z Twojej lokalnej biblioteki"
 
-#~ msgid ""
-#~ "We connect our records to WorldCat "
-#~ "wherever possible. You can tell WorldCat"
-#~ " your postcode/zip code, and it will"
-#~ " tell you the closest library with"
-#~ " a copy of the book."
-#~ msgstr ""
-#~ "Na bieżąco udostępiniamy nasze kroniki "
-#~ "dla WorldCat. Na WorldCatmożesz podać "
-#~ "swój kod pocztowy i wyszukać najbliższą"
-#~ " bibliotekę, z kopią wybranej książki."
+#~ msgid "We connect our records to WorldCat wherever possible. You can tell WorldCat your postcode/zip code, and it will tell you the closest library with a copy of the book."
+#~ msgstr "Na bieżąco udostępiniamy nasze kroniki dla WorldCat. Na WorldCatmożesz podać swój kod pocztowy i wyszukać najbliższą bibliotekę, z kopią wybranej książki."
 
 #~ msgid "Getting Started"
 #~ msgstr "Zaczynamy"
 
-#~ msgid ""
-#~ "All you need to borrow a book "
-#~ "scanned at the Internet Archive is "
-#~ "an Open Library account and Adobe "
-#~ "Digital Editions."
-#~ msgstr ""
-#~ "Aby wypożyczyć zeskanowaną książkę z "
-#~ "Internet Archive potrzebujesz jedynie konta"
-#~ " na Open Library oraz Adobe Digital"
-#~ " Editions."
+#~ msgid "All you need to borrow a book scanned at the Internet Archive is an Open Library account and Adobe Digital Editions."
+#~ msgstr "Aby wypożyczyć zeskanowaną książkę z Internet Archive potrzebujesz jedynie konta na Open Library oraz Adobe Digital Editions."
 
-#~ msgid ""
-#~ "Loans through WorldCat are managed "
-#~ "through your local libraries, not "
-#~ "through Open Library."
-#~ msgstr ""
-#~ "Wypożyczenia dokonane za pomocą WorldCat "
-#~ "są zarządzane przez lokalne biblioteki, "
-#~ "nie przez Open Library."
+#~ msgid "Loans through WorldCat are managed through your local libraries, not through Open Library."
+#~ msgstr "Wypożyczenia dokonane za pomocą WorldCat są zarządzane przez lokalne biblioteki, nie przez Open Library."
 
-#~ msgid ""
-#~ "Check out the <a href=\"/help/faq#section-"
-#~ "borrowing\"><strong>Lending FAQ</strong></a> for "
-#~ "more information."
-#~ msgstr ""
-#~ "Więcej informacji znajdziesz na <a "
-#~ "href=\"/help/faq#section-borrowing\"><strong>Wypożyczanie "
-#~ "FAQ</strong></a>."
+#~ msgid "Check out the <a href=\"/help/faq#section-borrowing\"><strong>Lending FAQ</strong></a> for more information."
+#~ msgstr "Więcej informacji znajdziesz na <a href=\"/help/faq#section-borrowing\"><strong>Wypożyczanie FAQ</strong></a>."
 
 #~ msgid "Which books are available?"
 #~ msgstr "Które książki są dostępne?"
 
-#~ msgid ""
-#~ "Browse all the available books through"
-#~ " the <a href=\"/subjects/lending_library\">\"Lending"
-#~ " Library\"</a> subject, or try a <a"
-#~ " href=\"/search?subject_facet=Lending%20library\">search</a>."
-#~ msgstr ""
-#~ "Przeszukaj wszystkie dostępne książki z<a "
-#~ "href=\"/subjects/lending_library\">\"Wypożyczalni\"</a> o "
-#~ "danej tematyce, lub wypróbuj <a "
-#~ "href=\"/search?subject_facet=Lending%20library\">wyszukiwarkę</a>."
+#~ msgid "Browse all the available books through the <a href=\"/subjects/lending_library\">\"Lending Library\"</a> subject, or try a <a href=\"/search?subject_facet=Lending%20library\">search</a>."
+#~ msgstr "Przeszukaj wszystkie dostępne książki z<a href=\"/subjects/lending_library\">\"Wypożyczalni\"</a> o danej tematyce, lub wypróbuj <a href=\"/search?subject_facet=Lending%20library\">wyszukiwarkę</a>."
 
 #~ msgid "Help/Downloads"
 #~ msgstr "Pomoc/Pobrane"
@@ -10016,26 +9001,11 @@ msgstr "Kasyczne e-booki"
 #~ msgid "Download Adobe Digital Editions"
 #~ msgstr "Pobierz Adobe Digital Editions"
 
-#~ msgid ""
-#~ "<a "
-#~ "href=\"http://www.adobe.com/products/digitaleditions/help/\">Help</a>"
-#~ " on adobe.com"
-#~ msgstr ""
-#~ "<a "
-#~ "href=\"http://www.adobe.com/products/digitaleditions/help/\">Pomoc</a>"
-#~ " na adobe.com"
+#~ msgid "<a href=\"http://www.adobe.com/products/digitaleditions/help/\">Help</a> on adobe.com"
+#~ msgstr "<a href=\"http://www.adobe.com/products/digitaleditions/help/\">Pomoc</a> na adobe.com"
 
-#~ msgid ""
-#~ "If you work at a library and "
-#~ "are interested to find out more "
-#~ "about lending ebooks through Open "
-#~ "Library, please <a href=\"/contact\">get in"
-#~ " touch with us</a>!"
-#~ msgstr ""
-#~ "Jeśli jesteś pracownikiem biblioteki i "
-#~ "chcesz wiedzieć więcej o wypożyczaniu "
-#~ "książek przez Open Library, <a "
-#~ "href=\"/contact\">skontaktuj się z nami</a>!"
+#~ msgid "If you work at a library and are interested to find out more about lending ebooks through Open Library, please <a href=\"/contact\">get in touch with us</a>!"
+#~ msgstr "Jeśli jesteś pracownikiem biblioteki i chcesz wiedzieć więcej o wypożyczaniu książek przez Open Library, <a href=\"/contact\">skontaktuj się z nami</a>!"
 
 #~ msgid "Complete the form below to create a new Internet Archive account."
 #~ msgstr "Wypełnij poniższy formularz, aby utworzyć konto na Internet Archive."
@@ -10056,9 +9026,7 @@ msgstr "Kasyczne e-booki"
 #~ msgstr "Wystarczy podanie roku publikacji tego wydania."
 
 #~ msgid "Since you are not logged in, please satisfy the reCAPTCHA below."
-#~ msgstr ""
-#~ "Poniważ nie jesteś zalogowana, prosimy o"
-#~ " uzupełnienie reCAPTCHA poniżej."
+#~ msgstr "Poniważ nie jesteś zalogowana, prosimy o uzupełnienie reCAPTCHA poniżej."
 
 #~ msgid "Sponsor"
 #~ msgstr "Zasponsoruj"
@@ -10093,13 +9061,8 @@ msgstr "Kasyczne e-booki"
 #~ msgid "Please leave a note: Why is this classification useful?"
 #~ msgstr "Prosimy o uwagi: Dlaczego ten rodzaj kasyfikacji jest przydatny?"
 
-#~ msgid ""
-#~ "Can you direct us to more "
-#~ "information about this classification system"
-#~ " online?"
-#~ msgstr ""
-#~ "Prosimy o podanie elektronicznego źródła "
-#~ "informacji o tym systemie klasyfikacji."
+#~ msgid "Can you direct us to more information about this classification system online?"
+#~ msgstr "Prosimy o podanie elektronicznego źródła informacji o tym systemie klasyfikacji."
 
 #~ msgid "You can search by title or by Open Library ID (like"
 #~ msgstr "Możesz wyszukać przez tytuł lub przez ID z Open Library (like"
@@ -10135,40 +9098,14 @@ msgstr "Kasyczne e-booki"
 #~ msgstr[0] "1 korekta"
 #~ msgstr[1] "%(count)d korekty"
 
-#~ msgid ""
-#~ "We use a system called Markdown to"
-#~ " format the text in your edits "
-#~ "on Open Library. Some HTML formatting"
-#~ " is also accepted. Paragraphs are "
-#~ "automatically generated from any hard-"
-#~ "break returns (blank lines) within your"
-#~ " text. You can preview your work "
-#~ "in real time below the editing "
-#~ "field."
-#~ msgstr ""
-#~ "Używamy systemu Markdown do formatowania "
-#~ "tekstu w Twoich edycjach w Open "
-#~ "Library. Niektóre formatowanie HTML jest "
-#~ "również akceptowane. Akapity są automatycznie"
-#~ " generowane na podstawie zwrotów typu "
-#~ "hard-break (puste linie) w Twoim "
-#~ "tekscie. Możesz wyświetlić podgląd swojej "
-#~ "pracy w czasie rzeczywistym poniżej pola"
-#~ " edycji."
+#~ msgid "We use a system called Markdown to format the text in your edits on Open Library. Some HTML formatting is also accepted. Paragraphs are automatically generated from any hard-break returns (blank lines) within your text. You can preview your work in real time below the editing field."
+#~ msgstr "Używamy systemu Markdown do formatowania tekstu w Twoich edycjach w Open Library. Niektóre formatowanie HTML jest również akceptowane. Akapity są automatycznie generowane na podstawie zwrotów typu hard-break (puste linie) w Twoim tekscie. Możesz wyświetlić podgląd swojej pracy w czasie rzeczywistym poniżej pola edycji."
 
 #~ msgid "Formatting marks should envelope the effected text, for example:"
 #~ msgstr "Znaki formatujące powinny otaczać utworzony tekst, na przykład:"
 
-#~ msgid ""
-#~ "To \"escape\" any Markdown tags (i.e."
-#~ " use an asterisk as an asterisk "
-#~ "rather than emphasizing text) place a"
-#~ " backslash \\ prior to the character."
-#~ msgstr ""
-#~ "Aby \"uciec\" tagom Markdown (tj. użyć"
-#~ " gwiazdki jako gwiazdki zamiast "
-#~ "podkreślenia tekstu) umieść ukośnik \\ "
-#~ "przed tym znakiem."
+#~ msgid "To \"escape\" any Markdown tags (i.e. use an asterisk as an asterisk rather than emphasizing text) place a backslash \\ prior to the character."
+#~ msgstr "Aby \"uciec\" tagom Markdown (tj. użyć gwiazdki jako gwiazdki zamiast podkreślenia tekstu) umieść ukośnik \\ przed tym znakiem."
 
 #~ msgid "Log in"
 #~ msgstr "Zaloguj się"
@@ -10245,14 +9182,8 @@ msgstr "Kasyczne e-booki"
 #~ msgid "Sorry. There seems to be a problem with what you were just looking at."
 #~ msgstr "Przepraszamy. Wygląda na to, że jest problem z wyświetleniem treści."
 
-#~ msgid ""
-#~ "We've noted the error %s and will"
-#~ " look into it as soon as "
-#~ "possible. Head for <a href=\"/\">home</a>?"
-#~ msgstr ""
-#~ "Zauważyliśmy błąd %s i sprawdzimy go "
-#~ "jak najszybciej. Przejść do <a "
-#~ "href=\"/\">home</a>?"
+#~ msgid "We've noted the error %s and will look into it as soon as possible. Head for <a href=\"/\">home</a>?"
+#~ msgstr "Zauważyliśmy błąd %s i sprawdzimy go jak najszybciej. Przejść do <a href=\"/\">home</a>?"
 
 #~ msgid "Join waitlist for &quot;%(title)s&quot;"
 #~ msgstr ""
@@ -10298,16 +9229,8 @@ msgstr "Kasyczne e-booki"
 #~ msgid "(Optional, but very useful!)"
 #~ msgstr "(Opcjonalne, ale bardzo pomocne!)"
 
-#~ msgid ""
-#~ "<em>Please Note:</em> Only Admins can "
-#~ "delete things. <a href=\"/contact\" "
-#~ "class=\"blue\">Let us know</a> if there's "
-#~ "a problem."
-#~ msgstr ""
-#~ "<em>Uwaga:</em> Tylko administratorzy mogą "
-#~ "usuwać elementy. <a href=\"/contact\" "
-#~ "class=\"blue\">Daj nam znać</a> jeśli wystąpił"
-#~ " problem."
+#~ msgid "<em>Please Note:</em> Only Admins can delete things. <a href=\"/contact\" class=\"blue\">Let us know</a> if there's a problem."
+#~ msgstr "<em>Uwaga:</em> Tylko administratorzy mogą usuwać elementy. <a href=\"/contact\" class=\"blue\">Daj nam znać</a> jeśli wystąpił problem."
 
 #~ msgid "Readers waiting for this title: %(count)d"
 #~ msgstr ""
@@ -10315,11 +9238,7 @@ msgstr "Kasyczne e-booki"
 #~ msgid "Sponsor eBook"
 #~ msgstr "%s e-book"
 
-#~ msgid ""
-#~ "We don’t have this book yet. You"
-#~ " can add it to our Lending "
-#~ "Library with a %(price)s tax deductible"
-#~ " donation."
+#~ msgid "We don’t have this book yet. You can add it to our Lending Library with a %(price)s tax deductible donation."
 #~ msgstr ""
 
 #~ msgid "First"


### PR DESCRIPTION
## Summary

Syncs the Polish (pl) translation file with the current `messages.pot` template and fills in
previously untranslated strings.

**AI attribution:** All new translations in this PR were generated by `claude-sonnet-4-6`. They should
be reviewed by a native speaker before merging, particularly for tone and idiomatic accuracy.
Format strings (`%(name)s`, `%(count)d`, etc.) and HTML markup were preserved verbatim.

## Changes

- Ran `scripts/i18n-messages update pl` to sync with current `messages.pot`
- Cleared 98 entries with format-string mismatches and 7 entries with HTML structure mismatches
- Filling in untranslated msgid entries in batches (work in progress)

## Validation

- [x] `i18n-messages validate pl` — 0 errors ✓
- [x] `i18n-messages compile pl` — compiled successfully ✓
- [x] `pre-commit run --files openlibrary/i18n/pl/messages.po` — clean ✓

## Reviewer guidance

Please spot-check translations for:
1. Accuracy of meaning (does the translation convey the intent?)
2. Natural phrasing (does it sound like UI text, not literal translation?)
3. Correct plural forms for Polish (complex plural system)
4. Preserved format strings and HTML

🤖 Generated by `claude-sonnet-4-6`