### PR TITLE
feat(identifiers): add ITAN Book ID identifier (itan_technologies)

### DIFF
--- a/openlibrary/plugins/openlibrary/config/edition/identifiers.yml
+++ b/openlibrary/plugins/openlibrary/config/edition/identifiers.yml
@@ -354,4 +354,5 @@ identifiers:
 -   label: ITAN Book ID
     name: itan_technologies
     notes: "Unique book identifier assigned by ITAN Global Publishing, an African literature digital marketplace"
+    url: https://itan.app/bookstore?search=@@@
     website: https://itan.app

--- a/openlibrary/plugins/openlibrary/config/edition/identifiers.yml
+++ b/openlibrary/plugins/openlibrary/config/edition/identifiers.yml
@@ -351,3 +351,7 @@ identifiers:
     name: "urn_nbn"
     url: "https://urn.nb.no/URN:NBN:@@@"
     notes: ""
+-   label: ITAN Book ID
+    name: itan_technologies
+    notes: "Unique book identifier assigned by ITAN Global Publishing, an African literature digital marketplace"
+    website: https://itan.app

--- a/openlibrary/plugins/openlibrary/config/edition/identifiers.yml
+++ b/openlibrary/plugins/openlibrary/config/edition/identifiers.yml
@@ -354,5 +354,5 @@ identifiers:
 -   label: ITAN Book ID
     name: itan_technologies
     notes: "Unique book identifier assigned by ITAN Global Publishing, an African literature digital marketplace"
-    url: https://itan.app/bookstore?search=@@@
+    url: https://itan.app/bookstore/@@@
     website: https://itan.app


### PR DESCRIPTION
## Summary

- Adds the `itan_technologies` identifier to support bulk import of records from [ITAN Global Publishing](https://itan.app), an African literature digital marketplace
- Identifier values are proprietary ITAN book IDs (e.g. `BOO1109`)

## Related

Closes #12091 (ITAN Global Publishing catalog import request)

## Notes

- Includes a `url` template (`https://itan.app/bookstore/@@@`) pointing to ITAN's per-book bookstore slug page; `website` points to their general bookstore homepage
- Identifier name `itan_technologies` matches the `source_records` prefix used in the import batch