### PR TITLE
Add Matomo analytics to search filters and the header search modal

### DIFF
--- a/openlibrary/plugins/openlibrary/js/SearchFilterBar.js
+++ b/openlibrary/plugins/openlibrary/js/SearchFilterBar.js
@@ -136,6 +136,17 @@ export function initSearchFilterBar(container) {
         availabilityEl.addEventListener('ol-toggle-change', (e) => {
             const value = e.detail.checked ? 'readable' : DEFAULT_AVAILABILITY;
             writeStoredAvailability(value);
+            // Track the toggle via OL's Matomo wrapper. ol-toggle uses Shadow
+            // DOM, so Matomo's selector-based click triggers can't see the
+            // inner button — we listen to the composed `ol-toggle-change` event
+            // and send the event manually instead. Fire before navigateWithParams
+            // unloads the page, and guard in case the analytics CDN didn't load.
+            if (window.archive_analytics) {
+                window.archive_analytics.ol_send_event_ping({
+                    category: 'SearchFilter',
+                    action: e.detail.checked ? 'AvailabilityOn' : 'AvailabilityOff',
+                });
+            }
             const mapped = AVAILABILITY_TO_PARAMS[value] || {};
             navigateWithParams((params) => {
                 AVAILABILITY_PARAM_KEYS.forEach((key) => params.delete(key));

--- a/openlibrary/plugins/openlibrary/js/search-modal/SearchModal.js
+++ b/openlibrary/plugins/openlibrary/js/search-modal/SearchModal.js
@@ -941,12 +941,13 @@ export class SearchModal extends LitElement {
         // never opens during a drag (clicking ends the drag) and the drop is lost.
         trigger.addEventListener('dragover', (e) => {
             e.preventDefault();
-            if (!this.open) this._openModal();
+            if (!this.open) this._openModal('drag');
         });
     }
 
-    _openModal() {
+    _openModal(trigger = 'click') {
         this.open = true;
+        this._track('Open', trigger);
         if (!this._allLangsLoaded && !this._langsLoading) {
             this._loadAllLanguages();
         }
@@ -1160,11 +1161,11 @@ export class SearchModal extends LitElement {
             <div class="results ${this._navigatingKey ? 'is-navigating' : ''}" @keydown=${this._onResultsKeydown}>
                 ${this._authorSuggestions.length ? html`
                     <ul class="results-list author-suggestion">
-                        ${repeat(this._authorSuggestions, a => a.key, a => this._renderAuthorSuggestion(a))}
+                        ${repeat(this._authorSuggestions, a => a.key, (a, i) => this._renderAuthorSuggestion(a, i))}
                     </ul>
                 ` : nothing}
                 <h3 class="results-heading">${this._i18n.topResults}</h3>
-                <ul class="results-list">${repeat(this._results, r => r.key, r => this._renderResult(r))}</ul>
+                <ul class="results-list">${repeat(this._results, r => r.key, (r, i) => this._renderResult(r, i))}</ul>
             </div>
         `;
     }
@@ -1233,13 +1234,13 @@ export class SearchModal extends LitElement {
     // A "go to the author page" row shown above the works for each top-result
     // author the query names (see deriveAuthors). The whole row is a single link
     // to the author page, so it's a plain anchor (no nested-link concern).
-    _renderAuthorSuggestion(author) {
+    _renderAuthorSuggestion(author, index = 0) {
         const href = `/authors/${author.key}`;
         return html`<li>
                 <a
                     class="result ${this._navigatingKey === href ? 'is-target' : ''}"
                     href=${href}
-                    @click=${(e) => this._onResultPress(e, href)}
+                    @click=${(e) => this._onResultPress(e, href, { type: 'author', rank: index + 1 })}
                 >
                     <span class="result__avatar">
                         ${SearchModal._personIcon}
@@ -1286,7 +1287,7 @@ export class SearchModal extends LitElement {
     // The whole row is a single link to the work — the author is surfaced in
     // its own suggestion row, so there's no separate author link here (which
     // also keeps this a plain anchor with no nested-link concern).
-    _renderResult(work) {
+    _renderResult(work, index = 0) {
         // Promote the hit to the specific edition that best matches the query —
         // its OL edition page — so the result opens on (and displays) that copy
         // rather than the work page. The edition is editions.docs[0] from the
@@ -1396,7 +1397,7 @@ export class SearchModal extends LitElement {
                 <a
                     class="result ${this._navigatingKey === href ? 'is-target' : ''}"
                     href=${href}
-                    @click=${(e) => this._onResultPress(e, href)}
+                    @click=${(e) => this._onResultPress(e, href, { type: display === edition ? 'edition' : 'work', rank: index + 1 })}
                 >
                     <span class="result__cover-link">
                         <img class="result__cover" src=${cover} srcset=${coverSrcset} alt="" loading="lazy" width="36" height="50" @error=${this._onCoverError}/>
@@ -1428,6 +1429,16 @@ export class SearchModal extends LitElement {
 
     // ── Event handlers ───────────────────────────────────────────────────
 
+    // Send a Matomo event through OL's wrapper. The modal renders in Shadow
+    // DOM, so Matomo's selector-based click triggers can't see its controls —
+    // we emit events manually instead. Guarded so a missing analytics CDN can't
+    // break an interaction. Labels carry only the *shape* of the interaction
+    // (counts, positions, types) — never the query text the patron typed.
+    _track(action, label) {
+        if (!window.archive_analytics) return;
+        window.archive_analytics.ol_send_event_ping({ category: 'SearchModal', action, label });
+    }
+
     _onDialogOpened() {
         this.renderRoot.querySelector('.search-input')?.focus();
     }
@@ -1447,9 +1458,13 @@ export class SearchModal extends LitElement {
     // shows its loading treatment (cover spinner, dimmed siblings) during that
     // gap. Modified clicks (open in new tab/window) don't navigate this page —
     // leave them untreated.
-    _onResultPress(e, key) {
+    _onResultPress(e, key, meta) {
         if (e.defaultPrevented || e.button !== 0) return;
         if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+        // Track which row was chosen by type + 1-based rank (e.g. "work:3",
+        // "author:1") — never the title. New-tab/modified clicks return above,
+        // so this counts the in-window navigations the typeahead drove.
+        if (meta) this._track('ResultClick', `${meta.type}:${meta.rank}`);
         this._saveCurrentSearch();
         this._navigatingKey = key;
     }
@@ -1584,6 +1599,10 @@ export class SearchModal extends LitElement {
         this._saveCurrentSearch();
         const url = this._buildSearchUrl();
         if (!url) return;
+        // Distinguish a fall-through from the typeahead (results were showing)
+        // from a blind jump to /search (no inline results yet) — the ratio of
+        // this to ResultClick tells us whether the typeahead satisfies intent.
+        this._track('SeeAllResults', this._results.length ? 'hasResults' : 'noResults');
         // Flag the footer button so its spinner shows during the navigation
         // delay (the page keeps painting until /search arrives). Mirrors how a
         // pressed result sets _navigatingKey before the window navigates.
@@ -1632,6 +1651,10 @@ export class SearchModal extends LitElement {
                 if (this._availability === 'readable') this._readableCount = this._numFound;
                 this._loading           = false;
                 this._hasSearched       = true;
+                // A settled autocomplete that came back empty — a content/
+                // discovery gap signal. Count only; the query text stays out of
+                // analytics (it's in server search logs if ever needed).
+                if (this._results.length === 0) this._track('NoResults');
             })
             .catch(() => {
                 if (this._activeFetchKey !== fetchKey) return;

--- a/openlibrary/plugins/openlibrary/js/search-modal/SearchModal.js
+++ b/openlibrary/plugins/openlibrary/js/search-modal/SearchModal.js
@@ -1651,10 +1651,18 @@ export class SearchModal extends LitElement {
                 if (this._availability === 'readable') this._readableCount = this._numFound;
                 this._loading           = false;
                 this._hasSearched       = true;
-                // A settled autocomplete that came back empty — a content/
-                // discovery gap signal. Count only; the query text stays out of
-                // analytics (it's in server search logs if ever needed).
-                if (this._results.length === 0) this._track('NoResults');
+                // A settled autocomplete that came back empty. Label by which
+                // filter *category* was active so we can tell a genuine catalog
+                // gap (`unfiltered`) from a user who over-constrained themselves
+                // (`availability`/`language`/`availability+language`). Categories
+                // only — never the filter values or query text; that catalog-gap
+                // detail belongs in the server search logs, not analytics labels.
+                if (this._results.length === 0) {
+                    const active = [];
+                    if (this._availability !== DEFAULT_AVAILABILITY) active.push('availability');
+                    if (this._languages.length > 0) active.push('language');
+                    this._track('NoResults', active.length ? active.join('+') : 'unfiltered');
+                }
             })
             .catch(() => {
                 if (this._activeFetchKey !== fetchKey) return;


### PR DESCRIPTION
Part of #12913 (search-modal fast-follow tracker) — addresses the analytics task on that list. Does not close the issue; other fast-follow items remain.

Adds Matomo event tracking to the search experience — the availability toggle on the `/search` results page, and the four core interactions in the header search modal. 

| Event | Captured (category/action/label) |
|---|---|
| Modal open | `SearchModal / Open / click` |
| Result click | `SearchModal / ResultClick / edition:3` (3rd row, edition-promoted) |
| See all results | `SearchModal / SeeAllResults / hasResults` |
| No results | `SearchModal / NoResults` |
| Availability toggle | `SearchFilter / AvailabilityOn` and `AvailabilityOff` |


### Why these events (the analytics reasoning)

**Modal open** — the denominator for every rate below (engagement = opens → any action; abandonment = opens − outcomes). It only fires on real opens (not page load), so volume is moderate. Splitting by trigger (`click` vs `drag`) tells us whether the drag-to-search affordance is ever used or is dead weight.

**Result click** — this is the whole point of a typeahead: let people jump straight to a book without a full results page. Without this event you literally cannot tell if the modal succeeds. The killer dimension is **rank** — which position got clicked. Clicks clustering at #1–2 = good ranking; positions 7–10 never clicked = `RESULTS_LIMIT=10` is too generous and we can trim it (less to render). The `edition`/`work`/`author` type split tells us whether the author-suggestion (B-zero) row earns its place.

**See all results** — the ratio we actually care about is **ResultClick : SeeAllResults**. High direct-click ratio = the typeahead satisfies intent. Heavy "See all" = the typeahead is just a launchpad and the full page is where the work happens — which changes where we invest. Also catches the case where the button is being ignored entirely.

**No results** — a pure-count rate of zero-result autocompletes is one of the best content/discovery signals OL has: "how often does our top-of-funnel search come up empty?" A rising rate is an alarm. (We deliberately do **not** log the query text here even though it's tempting — content-gap analysis should go through search logs, not analytics labels.)

The toggle event on `/search` (`SearchFilter` / `AvailabilityOn|Off`) is the same idea for the results-page filter.

### Shadow DOM & keeping components pure

`ol-toggle` and the modal's controls render in **Shadow DOM**, so Matomo's selector/DOM-based click triggers can't see the inner elements. Rather than work around that by injecting tracking into the components, the reusable UI primitives (`ol-toggle`, `ol-select-popover`) stay **pure presentation** with no analytics inside them.

All tracking lives in the feature code that consumes them — `SearchFilterBar.js` listens for the toggle's composed `ol-toggle-change` event, and `SearchModal.js` emits from its own interaction handlers. The components stay clean and reusable; the app owns its analytics.

### Technical

- A single guarded `_track()` helper per consumer routes through OL's existing `archive_analytics.ol_send_event_ping()` wrapper (category `SearchModal` / `SearchFilter`).
- Events that precede navigation fire **before** `window.location.assign` — `ol_send_event_ping` uses a beacon, and `_onResultPress` already runs synchronously ahead of the native-anchor navigation, so it's a clean, beacon-safe hook.
- Guarded on `window.archive_analytics` so a missing/blocked analytics CDN can never break a search interaction.

### Testing

Verified each event end-to-end in the browser by spying on both `ol_send_event_ping` and the underlying `send_ping` beacon:

| Event | Captured (category/action/label) |
|---|---|
| Modal open | `SearchModal / Open / click` |
| Result click | `SearchModal / ResultClick / edition:3` (3rd row, edition-promoted) |
| See all results | `SearchModal / SeeAllResults / hasResults` |
| No results | `SearchModal / NoResults` |
| Availability toggle | `SearchFilter / AvailabilityOn` and `AvailabilityOff` |

All reached the `send_ping` network layer with the correct `ec`/`ea`, and the pre-navigation events fired before the page unloaded.

### Screenshot

No UI change — analytics events only.

### Stakeholders

@mekarpeles @cdrini 

Note: the new `SearchModal` / `SearchFilter` event categories (and the `type:rank` label dimension) may need corresponding setup on the Matomo admin side to report cleanly, similar to the registration-age custom dimension in #12144.

