### PR TITLE
remove unused carousel i18n input

### DIFF
--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -1,16 +1,5 @@
 $def with(books=[], title="", url="", key="", min_books=1, load_more=None, test=False, compact_mode=False, secondary_action=False, layout='carousel')
 
-$def carousel_i18n_input():
-  $ show_carousel_i18n_strings=  {
-  $ "loading": _("Loading...")
-  $ }
-
-  <input type="hidden" name="carousel-i18n-strings" value="$json_encode(show_carousel_i18n_strings)">
-
-
-$if render_once('books/custom_carousel.i18n-strings'):
-  $:carousel_i18n_input()
-
 $if test or (books and len(books) >= min_books):
     <div class="carousel-section">
       $if title and url:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #12870 

refactor


### Technical
Removes the unused carousel_i18n_input() helper and the associated render_once block from openlibrary/templates/books/custom_carousel.html.

Since #12853 embeds translation strings directly into each carousel's config.i18n, the shared hidden input is no longer required. No functional changes are introduced.

### Testing
Start Open Library locally.
Visit pages containing book carousels.
Verify that carousels load correctly.
Verify that loading text and other translated strings continue to appear as expected.
Confirm there are no JavaScript console errors related to carousel i18n.

### Screenshot
N/A (no UI changes)

### Stakeholders
@lokesh


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
