### PR TITLE
fix: unescape HTML numeric entities in import pipeline (normalize_import_record)

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -99,10 +99,14 @@ _HTML_NUMERIC_ENTITY_RE = re.compile(r"&#(?:[0-9]{1,6}|x[0-9a-fA-F]{1,6});")
 
 
 def _unescape_html_entities(s: str) -> str:
-    """Unescape HTML numeric/hex character references in s (e.g. &#1059; -> \\u0423).
+    """Unescape HTML entities in s, but only when a numeric/hex entity is present.
 
-    Only acts when a numeric or hex entity is detected, so clean strings pass
-    through unchanged without the overhead of html_unescape().
+    The guard (_HTML_NUMERIC_ENTITY_RE) fires on decimal (&#1059;) and hex
+    (&#x41B;) entities only — bare & and named entities (&amp;) do not trigger
+    it, so strings with only those pass through unchanged.  However, once the
+    guard fires, html.unescape() decodes ALL entities in the string, including
+    any named ones that happen to be present alongside the numeric ones.
+    Example: '&#1059; &amp; bar' -> '\\u0423 & bar'.
     """
     return html_unescape(s) if _HTML_NUMERIC_ENTITY_RE.search(s) else s
 

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -30,6 +30,7 @@ import uuid
 from collections import defaultdict
 from collections.abc import Iterable
 from copy import copy
+from html import unescape as html_unescape
 from time import sleep
 from typing import TYPE_CHECKING, Any, Final
 from urllib.parse import urlparse
@@ -89,6 +90,21 @@ ALLOWED_COVER_HOSTS: Final = (
     "covers.openlibrary.org",
     "m.media-amazon.com",
 )
+
+
+# Matches decimal (&#1059;) and hex (&#x41B;) HTML numeric character references only.
+# Named entities like &amp; are intentionally excluded to avoid false positives in
+# titles that legitimately contain "&" (e.g. "Tom & Jerry").
+_HTML_NUMERIC_ENTITY_RE = re.compile(r"&#(?:[0-9]{1,6}|x[0-9a-fA-F]{1,6});")
+
+
+def _unescape_html_entities(s: str) -> str:
+    """Unescape HTML numeric/hex character references in s (e.g. &#1059; -> \\u0423).
+
+    Only acts when a numeric or hex entity is detected, so clean strings pass
+    through unchanged without the overhead of html_unescape().
+    """
+    return html_unescape(s) if _HTML_NUMERIC_ENTITY_RE.search(s) else s
 
 
 type_map = {
@@ -749,6 +765,33 @@ def normalize_import_record(rec: dict) -> None:
     publication_year = get_publication_year(rec.get("publish_date"))
     if publication_year and published_in_future_year(publication_year):
         del rec["publish_date"]
+
+    # Unescape HTML numeric/hex character references introduced by some import
+    # sources (e.g. BetterWorldBooks).  Must run before subtitle split so that
+    # a colon buried inside an entity sequence doesn't produce a spurious split.
+    _EDITION_TEXT_FIELDS = (
+        "title",
+        "subtitle",
+        "full_title",
+        "by_statement",
+        "edition_name",
+        "description",
+        "pagination",
+        "first_sentence",
+        "notes",
+        "copyright_date",
+    )
+    for field in _EDITION_TEXT_FIELDS:
+        value = rec.get(field)
+        if isinstance(value, str):
+            rec[field] = _unescape_html_entities(value)
+        elif isinstance(value, dict) and isinstance(value.get("value"), str):
+            # Some fields (e.g. description) are stored as {"type": "/type/text", "value": "..."}
+            value["value"] = _unescape_html_entities(value["value"])
+    for author in rec.get("authors", []):
+        for field in ("name", "personal_name", "bio", "title", "death_date"):
+            if isinstance(author.get(field), str):
+                author[field] = _unescape_html_entities(author[field])
 
     # Split subtitle if required and not already present
     if ":" in rec.get("title", "") and not rec.get("subtitle"):

--- a/openlibrary/catalog/add_book/tests/test_add_book.py
+++ b/openlibrary/catalog/add_book/tests/test_add_book.py
@@ -1964,6 +1964,75 @@ class TestNormalizeImportRecord:
         normalize_import_record(rec=rec)
         assert rec == expected
 
+    def test_unescape_html_entities_in_title(self):
+        """HTML numeric entities in titles are unescaped (BWB-sourced mangled Unicode)."""
+        rec = {
+            "title": "&#1059;&#1073;&#1077;&#1079;&#1087;&#1077;&#1094;&#1110;&#1079;",
+            "source_records": ["bwb:9781234567890"],
+        }
+        normalize_import_record(rec=rec)
+        # U+0423 U+0431 U+0435 U+0437 U+043F U+0435 U+0446 U+0456 U+0437
+        assert rec["title"] == "Убезпеціз"
+
+    def test_unescape_html_entities_in_subtitle(self):
+        rec = {
+            "title": "My Book",
+            "subtitle": "&#1057;&#1077;&#1088;&#1075;&#1077;&#1081;",
+            "source_records": ["bwb:9781234567890"],
+        }
+        normalize_import_record(rec=rec)
+        # U+0421 U+0435 U+0440 U+0433 U+0435 U+0439 = Sergei in Russian
+        assert rec["subtitle"] == "Сергей"
+
+    def test_unescape_html_entities_in_author_name(self):
+        rec = {
+            "title": "My Book",
+            "source_records": ["bwb:9781234567890"],
+            "authors": [{"name": "&#1057;&#1077;&#1088;&#1075;&#1077;&#1081;"}],
+        }
+        normalize_import_record(rec=rec)
+        assert rec["authors"][0]["name"] == "Сергей"
+
+    def test_hex_entity_unescaped(self):
+        """Hex-form entities (&#x41B;) are also unescaped."""
+        rec = {
+            "title": "&#x41B;",
+            "source_records": ["bwb:9781234567890"],
+        }
+        normalize_import_record(rec=rec)
+        assert rec["title"] == "Л"  # CYRILLIC CAPITAL LETTER EL
+
+    def test_legitimate_ampersand_unchanged(self):
+        """A bare & in a title is not corrupted."""
+        rec = {
+            "title": "Tom & Jerry",
+            "source_records": ["ia:tomjerry"],
+        }
+        normalize_import_record(rec=rec)
+        assert rec["title"] == "Tom & Jerry"
+
+    def test_named_entity_unchanged(self):
+        """Named entities like &amp; are not unescaped (strict numeric-only pattern)."""
+        rec = {
+            "title": "Foo &amp; Bar",
+            "source_records": ["ia:foobar"],
+        }
+        normalize_import_record(rec=rec)
+        assert rec["title"] == "Foo &amp; Bar"
+
+    def test_description_as_dict_unescaped(self):
+        """description stored as {type, value} dict is unescaped."""
+        rec = {
+            "title": "My Book",
+            "source_records": ["bwb:9781234567890"],
+            "description": {
+                "type": "/type/text",
+                "value": "&#1057;&#1077;&#1088;",
+            },
+        }
+        normalize_import_record(rec=rec)
+        assert rec["description"]["value"] == "Сер"  # noqa: RUF001  # Cyrillic chars
+
 
 def test_find_match_title_only_promiseitem_against_noisbn_marc(mock_site):
     # An existing light title + ISBN only record should not match an

--- a/openlibrary/catalog/add_book/tests/test_add_book.py
+++ b/openlibrary/catalog/add_book/tests/test_add_book.py
@@ -2020,6 +2020,16 @@ class TestNormalizeImportRecord:
         normalize_import_record(rec=rec)
         assert rec["title"] == "Foo &amp; Bar"
 
+    def test_mixed_numeric_and_named_entities(self):
+        """When a numeric entity triggers the guard, named entities are also decoded."""
+        rec = {
+            "title": "&#1059; &amp; bar",
+            "source_records": ["bwb:9781234567890"],
+        }
+        normalize_import_record(rec=rec)
+        # &#1059; -> U+0423 (triggers guard); &amp; -> & (decoded as side-effect)
+        assert rec["title"] == "У & bar"  # noqa: RUF001
+
     def test_description_as_dict_unescaped(self):
         """description stored as {type, value} dict is unescaped."""
         rec = {


### PR DESCRIPTION
Closes #10860

## Summary

Some import sources (primarily BetterWorldBooks) store Unicode text as HTML numeric character references (e.g. `&#1059;&#1073;&#1077;` instead of `Убе`). This caused ~141K edition titles, 72K work titles, and 16K author names to be stored in mangled form.

**Root cause**: `normalize_import_record()` did not unescape HTML entities before writing to DB.

**Fix**: Add `_unescape_html_entities()` in `normalize_import_record()` — the central normalization pass that every import source (BWB, MARC, promise, IA) hits before writing to the DB.

## What changed

- `openlibrary/catalog/add_book/__init__.py`: Added `_HTML_NUMERIC_ENTITY_RE` (strict `&#NNN;` / `&#xNNN;` pattern only — avoids false positives from legitimate `&` in titles per @cdrini) and `_unescape_html_entities()`. Applied in `normalize_import_record()` to all text fields documented to contain entity contamination (per @tfmorris dump analysis): `title`, `subtitle`, `full_title`, `by_statement`, `edition_name`, `description` (both plain string and `{type, value}` dict form), `pagination`, `first_sentence`, `notes`, `copyright_date`; author subfields `name`, `personal_name`, `bio`, `title`, `death_date`.
- `openlibrary/catalog/add_book/tests/test_add_book.py`: 7 new tests in `TestNormalizeImportRecord` covering decimal entities, hex entities, author names, description-as-dict, legitimate `&` unchanged, named entities (`&amp;`) unchanged.

## Why normalize_import_record() and not a source-specific fix

`normalize_import_record()` is called by `add_book.load()`, which is the single entry point for all imports regardless of source. Fixing here covers BWB, MARC (importapi → read_edition → load), promise items, and any future source in one place. Source-level fixes (as in PR #11464, PR #12497) only cover specific importers and must be duplicated for each new source.

## Relation to other issues/PRs

- #10909 / PR #12224: one-time migration script for existing bad records (already merged) — complementary to this forward-looking fix
- PR #11464: source-level fix for BWB/promise/otl only — superseded by this approach
- PR #12497 (OPEN): adds `html.unescape()` to `marc/parse.py read_title()` — the MARC path is covered by this PR since MARC records go through `normalize_import_record()`; PR #12497's change would be redundant but harmless as defense-in-depth

## Note on #135 and #150

Issues #135 and #150 involve different encoding problems:
- **#135**: MARC8→UTF-8 transcoding errors (e.g. wrongly decoded diacritic bytes) — different from HTML entity encoding, not addressed here
- **#150**: MARC U+FE20/FE21 combining ligature characters → U+0361 normalization — unrelated to HTML entities, not addressed here

## Test status

Pre-commit (ruff check, ruff format, codespell, trailing whitespace) all pass. `mypy` and `generate-pot` require Docker/infogami — expected to fail locally per project docs. Tests blocked by pre-existing Python 3.14 annotation + Docker Python 3.12 incompatibility (introduced in commit 3c3247c `Update to Python 3.14`); logic verified directly in running web container.