### PR TITLE
Migrate work bookshelves to FastAPI

### DIFF
--- a/openlibrary/fastapi/internal/api.py
+++ b/openlibrary/fastapi/internal/api.py
@@ -34,6 +34,7 @@ from openlibrary.fastapi.models import (
 )
 from openlibrary.plugins.openlibrary.api import bestbook_award, get_price_data_async
 from openlibrary.plugins.openlibrary.api import ratings as legacy_ratings
+from openlibrary.plugins.openlibrary.api import work_bookshelves as legacy_work_bookshelves
 from openlibrary.utils import extract_numeric_id_from_olid
 from openlibrary.views.loanstats import SINCE_DAYS, get_trending_books
 
@@ -265,8 +266,31 @@ async def booknotes_post(
     return BooknoteResponse(success="note added")
 
 
-async def work_bookshelves():
-    pass
+@router.get("/works/OL{work_id}W/bookshelves.json")
+def get_work_bookshelves(work_id: Annotated[int, Path(gt=0)]) -> dict:
+    """Get reading-log shelf counts for a work."""
+    return legacy_work_bookshelves.get_bookshelves_summary(work_id)
+
+
+@router.post("/works/OL{work_id}W/bookshelves.json")
+def post_work_bookshelves(
+    work_id: Annotated[int, Path(gt=0)],
+    user: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],
+    query_edition_id: Annotated[str | None, Query(alias="edition_id", pattern=r"(?i)^(?:/books/)?OL\d+M$")] = None,
+    query_bookshelf_id: Annotated[str | None, Query(alias="bookshelf_id")] = None,
+    query_dont_remove: Annotated[bool | None, Query(alias="dont_remove")] = None,
+    form_edition_id: Annotated[str | None, Form(alias="edition_id", pattern=r"(?i)^(?:/books/)?OL\d+M$")] = None,
+    form_bookshelf_id: Annotated[str | None, Form(alias="bookshelf_id")] = None,
+    form_dont_remove: Annotated[bool | None, Form(alias="dont_remove")] = None,
+) -> dict:
+    """Add a work to, move a work between, or remove a work from a reading-log shelf."""
+    return legacy_work_bookshelves.process_work_bookshelves(
+        username=user.username,
+        work_id=work_id,
+        bookshelf_id=form_bookshelf_id if form_bookshelf_id is not None else query_bookshelf_id,
+        edition_id=form_edition_id if form_edition_id is not None else query_edition_id,
+        dont_remove=form_dont_remove if form_dont_remove is not None else query_dont_remove or False,
+    )
 
 
 async def work_editions():

--- a/openlibrary/fastapi/internal/api.py
+++ b/openlibrary/fastapi/internal/api.py
@@ -276,20 +276,17 @@ def get_work_bookshelves(work_id: Annotated[int, Path(gt=0)]) -> dict:
 def post_work_bookshelves(
     work_id: Annotated[int, Path(gt=0)],
     user: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],
-    query_edition_id: Annotated[str | None, Query(alias="edition_id", pattern=r"(?i)^(?:/books/)?OL\d+M$")] = None,
-    query_bookshelf_id: Annotated[str | None, Query(alias="bookshelf_id")] = None,
-    query_dont_remove: Annotated[bool | None, Query(alias="dont_remove")] = None,
-    form_edition_id: Annotated[str | None, Form(alias="edition_id", pattern=r"(?i)^(?:/books/)?OL\d+M$")] = None,
-    form_bookshelf_id: Annotated[str | None, Form(alias="bookshelf_id")] = None,
-    form_dont_remove: Annotated[bool | None, Form(alias="dont_remove")] = None,
+    bookshelf_id: Annotated[str | None, Form()] = None,
+    edition_id: Annotated[str | None, Form(pattern=r"(?i)^(?:/books/)?OL\d+M$")] = None,
+    dont_remove: Annotated[bool | None, Form()] = None,
 ) -> dict:
     """Add a work to, move a work between, or remove a work from a reading-log shelf."""
     return legacy_work_bookshelves.process_work_bookshelves(
         username=user.username,
         work_id=work_id,
-        bookshelf_id=form_bookshelf_id if form_bookshelf_id is not None else query_bookshelf_id,
-        edition_id=form_edition_id if form_edition_id is not None else query_edition_id,
-        dont_remove=form_dont_remove if form_dont_remove is not None else query_dont_remove or False,
+        bookshelf_id=bookshelf_id,
+        edition_id=edition_id,
+        dont_remove=dont_remove or False,
     )
 
 

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -30,7 +30,6 @@ from openlibrary.core import helpers as h
 from openlibrary.core.admin import get_cached_unique_logins_since
 from openlibrary.core.auth import ExpiredTokenError, HMACToken
 from openlibrary.core.bestbook import Bestbook
-from openlibrary.core.bookshelves_events import BookshelvesEvents
 from openlibrary.core.follows import PubSub
 from openlibrary.core.helpers import NothingEncoder
 from openlibrary.core.models import (
@@ -146,32 +145,43 @@ class work_bookshelves(delegate.page):
     def get_bookshelves_summary(work_id):
         from openlibrary.core.models import Bookshelves
 
-        return {"counts": Bookshelves.get_work_summary(work_id)}
+        return {"counts": Bookshelves.get_work_summary(str(work_id))}
 
     @staticmethod
     def process_work_bookshelves(username, work_id, bookshelf_id, edition_id=None, dont_remove=False):
         from openlibrary.core.models import Bookshelves
 
-        current_status = Bookshelves.get_users_read_status_of_work(username, work_id)
+        if bookshelf_id is None:
+            return {"error": "Invalid bookshelf"}
+
+        work_id_str = str(work_id)
+        current_status = Bookshelves.get_users_read_status_of_work(username, work_id_str)
 
         try:
-            bookshelf_id = int(bookshelf_id)
+            bookshelf_id_val = int(bookshelf_id)
             shelf_ids = Bookshelves.PRESET_BOOKSHELVES.values()
-            if bookshelf_id != -1 and bookshelf_id not in shelf_ids:
-                raise ValueError
+            if bookshelf_id_val != -1 and bookshelf_id_val not in shelf_ids:
+                return {"error": "Invalid bookshelf"}
         except TypeError, ValueError:
             return {"error": "Invalid bookshelf"}
 
-        if ((not dont_remove) and bookshelf_id == current_status) or bookshelf_id == -1:
-            work_bookshelf = Bookshelves.remove(username=username, work_id=work_id, bookshelf_id=current_status)
-            BookshelvesEvents.delete_by_username_and_work(username, work_id)
+        if ((not dont_remove) and bookshelf_id_val == current_status) or bookshelf_id_val == -1:
+            from openlibrary.core.bookshelves_events import BookshelvesEvents
 
+            work_bookshelf = Bookshelves.remove(
+                username=username,
+                work_id=work_id_str,
+                bookshelf_id=str(current_status) if current_status else None,
+            )
+            BookshelvesEvents.delete_by_username_and_work(username, work_id_str)
         else:
+            from openlibrary.utils import extract_numeric_id_from_olid
+
             resolved_edition_id = int(extract_numeric_id_from_olid(edition_id)) if edition_id else None
             work_bookshelf = Bookshelves.add(
                 username=username,
-                bookshelf_id=bookshelf_id,
-                work_id=work_id,
+                bookshelf_id=str(bookshelf_id_val),
+                work_id=work_id_str,
                 edition_id=resolved_edition_id,
             )
 

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -133,15 +133,49 @@ class booknotes(delegate.page):
 # not a value tied to this logged in user. This is being used as debugging.
 
 
+@deprecated("migrated to fastapi")
 class work_bookshelves(delegate.page):
     path = r"/works/OL(\d+)W/bookshelves"
     encoding = "json"
 
     @jsonapi
     def GET(self, work_id):
+        return json.dumps(self.get_bookshelves_summary(work_id))
+
+    @staticmethod
+    def get_bookshelves_summary(work_id):
         from openlibrary.core.models import Bookshelves
 
-        return json.dumps({"counts": Bookshelves.get_work_summary(work_id)})
+        return {"counts": Bookshelves.get_work_summary(work_id)}
+
+    @staticmethod
+    def process_work_bookshelves(username, work_id, bookshelf_id, edition_id=None, dont_remove=False):
+        from openlibrary.core.models import Bookshelves
+
+        current_status = Bookshelves.get_users_read_status_of_work(username, work_id)
+
+        try:
+            bookshelf_id = int(bookshelf_id)
+            shelf_ids = Bookshelves.PRESET_BOOKSHELVES.values()
+            if bookshelf_id != -1 and bookshelf_id not in shelf_ids:
+                raise ValueError
+        except TypeError, ValueError:
+            return {"error": "Invalid bookshelf"}
+
+        if ((not dont_remove) and bookshelf_id == current_status) or bookshelf_id == -1:
+            work_bookshelf = Bookshelves.remove(username=username, work_id=work_id, bookshelf_id=current_status)
+            BookshelvesEvents.delete_by_username_and_work(username, work_id)
+
+        else:
+            resolved_edition_id = int(extract_numeric_id_from_olid(edition_id)) if edition_id else None
+            work_bookshelf = Bookshelves.add(
+                username=username,
+                bookshelf_id=bookshelf_id,
+                work_id=work_id,
+                edition_id=resolved_edition_id,
+            )
+
+        return {"bookshelves_affected": work_bookshelf}
 
     def POST(self, work_id):
         """
@@ -158,8 +192,6 @@ class work_bookshelves(delegate.page):
         :rtype: json
         :return: a list of bookshelves_affected
         """
-        from openlibrary.core.models import Bookshelves
-
         user = accounts.get_current_user()
         i = web.input(
             edition_id=None,
@@ -174,36 +206,18 @@ class work_bookshelves(delegate.page):
             raise web.seeother("/account/login?redirect=%s" % key)
 
         username = user.key.split("/")[2]
-        current_status = Bookshelves.get_users_read_status_of_work(username, work_id)
-
-        try:
-            bookshelf_id = int(i.bookshelf_id)
-            shelf_ids = Bookshelves.PRESET_BOOKSHELVES.values()
-            if bookshelf_id != -1 and bookshelf_id not in shelf_ids:
-                raise ValueError
-        except TypeError, ValueError:
-            return delegate.RawText(
-                json.dumps({"error": "Invalid bookshelf"}),
-                content_type="application/json",
-            )
-
-        if ((not i.dont_remove) and bookshelf_id == current_status) or bookshelf_id == -1:
-            work_bookshelf = Bookshelves.remove(username=username, work_id=work_id, bookshelf_id=current_status)
-            BookshelvesEvents.delete_by_username_and_work(username, work_id)
-
-        else:
-            edition_id = int(i.edition_id.split("/")[2][2:-1]) if i.edition_id else None
-            work_bookshelf = Bookshelves.add(
-                username=username,
-                bookshelf_id=bookshelf_id,
-                work_id=work_id,
-                edition_id=edition_id,
-            )
+        response = self.process_work_bookshelves(
+            username=username,
+            work_id=work_id,
+            bookshelf_id=i.bookshelf_id,
+            edition_id=i.edition_id,
+            dont_remove=i.dont_remove,
+        )
 
         if i.redir:
             raise web.seeother(key)
         return delegate.RawText(
-            json.dumps({"bookshelves_affected": work_bookshelf}),
+            json.dumps(response),
             content_type="application/json",
         )
 

--- a/openlibrary/tests/fastapi/test_work_bookshelves.py
+++ b/openlibrary/tests/fastapi/test_work_bookshelves.py
@@ -1,0 +1,230 @@
+"""Tests for the FastAPI work bookshelves endpoints."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+import web
+
+from openlibrary.plugins.openlibrary.api import work_bookshelves as legacy_work_bookshelves
+
+
+class FakeLegacyUser:
+    def __init__(self, username: str = "testuser"):
+        self.key = f"/people/{username}"
+
+
+def mock_web_input_func(data):
+    def _mock_web_input(*args, **kwargs):
+        return web.storage(kwargs | data)
+
+    return _mock_web_input
+
+
+def legacy_bookshelves_json(data, work_id=123):
+    with (
+        patch("web.input", side_effect=mock_web_input_func(data)),
+        patch("openlibrary.accounts.get_current_user", return_value=FakeLegacyUser()),
+        pytest.deprecated_call(match="migrated to fastapi"),
+    ):
+        return json.loads(legacy_work_bookshelves().POST(str(work_id))["rawtext"])
+
+
+def post_fastapi_bookshelves(fastapi_client, data, *, use_query_params=False):
+    if use_query_params:
+        return fastapi_client.post("/works/OL123W/bookshelves.json", params=data)
+    return fastapi_client.post("/works/OL123W/bookshelves.json", data=data)
+
+
+@pytest.fixture
+def mock_bookshelves_model():
+    with (
+        patch("openlibrary.core.models.Bookshelves.get_users_read_status_of_work") as read_status_mock,
+        patch("openlibrary.core.models.Bookshelves.add") as add_mock,
+        patch("openlibrary.core.models.Bookshelves.remove") as remove_mock,
+        patch("openlibrary.plugins.openlibrary.api.BookshelvesEvents.delete_by_username_and_work") as delete_events_mock,
+    ):
+        read_status_mock.return_value = None
+        yield read_status_mock, add_mock, remove_mock, delete_events_mock
+
+
+class TestWorkBookshelvesGet:
+    def test_get_work_bookshelves_returns_summary(self, fastapi_client):
+        counts = {
+            "want_to_read": 2,
+            "currently_reading": 3,
+            "already_read": 5,
+            "stopped_reading": 1,
+        }
+
+        with patch("openlibrary.core.models.Bookshelves.get_work_summary", return_value=counts) as summary_mock:
+            response = fastapi_client.get("/works/OL123W/bookshelves.json")
+
+        assert response.status_code == 200
+        assert response.json() == {"counts": counts}
+        summary_mock.assert_called_once_with(123)
+
+
+class TestWorkBookshelvesPost:
+    def test_post_adds_work_to_bookshelf(self, fastapi_client, mock_authenticated_user, mock_bookshelves_model):
+        read_status_mock, add_mock, remove_mock, delete_events_mock = mock_bookshelves_model
+        add_mock.return_value = 1
+
+        response = fastapi_client.post(
+            "/works/OL123W/bookshelves.json",
+            data={"bookshelf_id": "1", "edition_id": "/books/OL42M"},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"bookshelves_affected": 1}
+        read_status_mock.assert_called_once_with("testuser", 123)
+        add_mock.assert_called_once_with(username="testuser", bookshelf_id=1, work_id=123, edition_id=42)
+        remove_mock.assert_not_called()
+        delete_events_mock.assert_not_called()
+
+    def test_post_accepts_edition_olid_without_path_prefix(self, fastapi_client, mock_authenticated_user, mock_bookshelves_model):
+        _, add_mock, _, _ = mock_bookshelves_model
+        add_mock.return_value = 1
+
+        response = fastapi_client.post(
+            "/works/OL123W/bookshelves.json",
+            data={"bookshelf_id": "2", "edition_id": "OL42M"},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"bookshelves_affected": 1}
+        add_mock.assert_called_once_with(username="testuser", bookshelf_id=2, work_id=123, edition_id=42)
+
+    def test_form_values_override_query_values(self, fastapi_client, mock_authenticated_user, mock_bookshelves_model):
+        _, add_mock, remove_mock, delete_events_mock = mock_bookshelves_model
+        add_mock.return_value = 1
+
+        response = fastapi_client.post(
+            "/works/OL123W/bookshelves.json",
+            params={"bookshelf_id": "-1", "edition_id": "/books/OL1M", "dont_remove": "false"},
+            data={"bookshelf_id": "3", "edition_id": "/books/OL42M", "dont_remove": "true"},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"bookshelves_affected": 1}
+        add_mock.assert_called_once_with(username="testuser", bookshelf_id=3, work_id=123, edition_id=42)
+        remove_mock.assert_not_called()
+        delete_events_mock.assert_not_called()
+
+    def test_post_removes_work_from_bookshelf(self, fastapi_client, mock_authenticated_user, mock_bookshelves_model):
+        read_status_mock, add_mock, remove_mock, delete_events_mock = mock_bookshelves_model
+        read_status_mock.return_value = 2
+        remove_mock.return_value = 1
+
+        response = fastapi_client.post("/works/OL123W/bookshelves.json", data={"bookshelf_id": "-1"})
+
+        assert response.status_code == 200
+        assert response.json() == {"bookshelves_affected": 1}
+        remove_mock.assert_called_once_with(username="testuser", work_id=123, bookshelf_id=2)
+        delete_events_mock.assert_called_once_with("testuser", 123)
+        add_mock.assert_not_called()
+
+    def test_post_toggles_current_bookshelf_off(self, fastapi_client, mock_authenticated_user, mock_bookshelves_model):
+        read_status_mock, add_mock, remove_mock, delete_events_mock = mock_bookshelves_model
+        read_status_mock.return_value = 2
+        remove_mock.return_value = 1
+
+        response = fastapi_client.post("/works/OL123W/bookshelves.json", data={"bookshelf_id": "2"})
+
+        assert response.status_code == 200
+        assert response.json() == {"bookshelves_affected": 1}
+        remove_mock.assert_called_once_with(username="testuser", work_id=123, bookshelf_id=2)
+        delete_events_mock.assert_called_once_with("testuser", 123)
+        add_mock.assert_not_called()
+
+    def test_dont_remove_prevents_toggle_removal(self, fastapi_client, mock_authenticated_user, mock_bookshelves_model):
+        read_status_mock, add_mock, remove_mock, delete_events_mock = mock_bookshelves_model
+        read_status_mock.return_value = 2
+        add_mock.return_value = 1
+
+        response = fastapi_client.post("/works/OL123W/bookshelves.json", data={"bookshelf_id": "2", "dont_remove": "true"})
+
+        assert response.status_code == 200
+        assert response.json() == {"bookshelves_affected": 1}
+        add_mock.assert_called_once_with(username="testuser", bookshelf_id=2, work_id=123, edition_id=None)
+        remove_mock.assert_not_called()
+        delete_events_mock.assert_not_called()
+
+    @pytest.mark.parametrize("data", [{"bookshelf_id": "5"}, {}])
+    def test_invalid_or_missing_bookshelf_returns_error(self, fastapi_client, mock_authenticated_user, mock_bookshelves_model, data):
+        _, add_mock, remove_mock, delete_events_mock = mock_bookshelves_model
+
+        response = fastapi_client.post("/works/OL123W/bookshelves.json", data=data)
+
+        assert response.status_code == 200
+        assert response.json() == {"error": "Invalid bookshelf"}
+        add_mock.assert_not_called()
+        remove_mock.assert_not_called()
+        delete_events_mock.assert_not_called()
+
+    def test_post_requires_authentication(self, fastapi_client):
+        response = fastapi_client.post("/works/OL123W/bookshelves.json", data={"bookshelf_id": "1"})
+
+        assert response.status_code == 401
+
+    @pytest.mark.parametrize("path", ["/works/OLnot-a-numberW/bookshelves.json", "/works/OL0W/bookshelves.json"])
+    def test_post_rejects_invalid_work_id(self, fastapi_client, mock_authenticated_user, path):
+        response = fastapi_client.post(path, data={"bookshelf_id": "1"})
+
+        assert response.status_code == 422
+
+    @pytest.mark.parametrize("edition_id", ["bad", "/works/OL42W", "/books/not-a-number"])
+    def test_post_rejects_malformed_edition_id(self, fastapi_client, mock_authenticated_user, edition_id):
+        response = fastapi_client.post("/works/OL123W/bookshelves.json", data={"bookshelf_id": "1", "edition_id": edition_id})
+
+        assert response.status_code == 422
+
+
+class TestWorkBookshelvesLegacyParity:
+    @pytest.mark.parametrize("use_query_params", [False, True])
+    def test_add_response_matches_legacy(self, fastapi_client, mock_authenticated_user, mock_bookshelves_model, use_query_params):
+        _, add_mock, _, _ = mock_bookshelves_model
+        add_mock.return_value = 1
+        data = {"bookshelf_id": "1", "edition_id": "/books/OL42M"}
+
+        legacy_response = legacy_bookshelves_json(data)
+        fastapi_response = post_fastapi_bookshelves(fastapi_client, data, use_query_params=use_query_params)
+
+        assert fastapi_response.status_code == 200
+        assert fastapi_response.json() == legacy_response
+
+    @pytest.mark.parametrize("use_query_params", [False, True])
+    def test_remove_response_matches_legacy(self, fastapi_client, mock_authenticated_user, mock_bookshelves_model, use_query_params):
+        read_status_mock, _, remove_mock, _ = mock_bookshelves_model
+        read_status_mock.return_value = 2
+        remove_mock.return_value = 1
+        data = {"bookshelf_id": "-1"}
+
+        legacy_response = legacy_bookshelves_json(data)
+        fastapi_response = post_fastapi_bookshelves(fastapi_client, data, use_query_params=use_query_params)
+
+        assert fastapi_response.status_code == 200
+        assert fastapi_response.json() == legacy_response
+
+    @pytest.mark.parametrize("use_query_params", [False, True])
+    def test_invalid_bookshelf_response_matches_legacy(self, fastapi_client, mock_authenticated_user, mock_bookshelves_model, use_query_params):
+        data = {"bookshelf_id": "99"}
+
+        legacy_response = legacy_bookshelves_json(data)
+        fastapi_response = post_fastapi_bookshelves(fastapi_client, data, use_query_params=use_query_params)
+
+        assert fastapi_response.status_code == 200
+        assert fastapi_response.json() == legacy_response
+
+    @pytest.mark.parametrize("use_query_params", [False, True])
+    def test_dont_remove_response_matches_legacy(self, fastapi_client, mock_authenticated_user, mock_bookshelves_model, use_query_params):
+        read_status_mock, add_mock, _, _ = mock_bookshelves_model
+        read_status_mock.return_value = 2
+        add_mock.return_value = 1
+        data = {"bookshelf_id": "2", "dont_remove": "true"}
+
+        legacy_response = legacy_bookshelves_json(data)
+        fastapi_response = post_fastapi_bookshelves(fastapi_client, data, use_query_params=use_query_params)
+
+        assert fastapi_response.status_code == 200
+        assert fastapi_response.json() == legacy_response

--- a/openlibrary/tests/fastapi/test_work_bookshelves.py
+++ b/openlibrary/tests/fastapi/test_work_bookshelves.py
@@ -23,17 +23,11 @@ def mock_web_input_func(data):
 
 def legacy_bookshelves_json(data, work_id=123):
     with (
-        patch("web.input", side_effect=mock_web_input_func(data)),
+        patch("openlibrary.plugins.openlibrary.api.web.input", side_effect=mock_web_input_func(data)),
         patch("openlibrary.accounts.get_current_user", return_value=FakeLegacyUser()),
         pytest.deprecated_call(match="migrated to fastapi"),
     ):
         return json.loads(legacy_work_bookshelves().POST(str(work_id))["rawtext"])
-
-
-def post_fastapi_bookshelves(fastapi_client, data, *, use_query_params=False):
-    if use_query_params:
-        return fastapi_client.post("/works/OL123W/bookshelves.json", params=data)
-    return fastapi_client.post("/works/OL123W/bookshelves.json", data=data)
 
 
 @pytest.fixture
@@ -42,7 +36,7 @@ def mock_bookshelves_model():
         patch("openlibrary.core.models.Bookshelves.get_users_read_status_of_work") as read_status_mock,
         patch("openlibrary.core.models.Bookshelves.add") as add_mock,
         patch("openlibrary.core.models.Bookshelves.remove") as remove_mock,
-        patch("openlibrary.plugins.openlibrary.api.BookshelvesEvents.delete_by_username_and_work") as delete_events_mock,
+        patch("openlibrary.core.bookshelves_events.BookshelvesEvents.delete_by_username_and_work") as delete_events_mock,
     ):
         read_status_mock.return_value = None
         yield read_status_mock, add_mock, remove_mock, delete_events_mock
@@ -62,7 +56,7 @@ class TestWorkBookshelvesGet:
 
         assert response.status_code == 200
         assert response.json() == {"counts": counts}
-        summary_mock.assert_called_once_with(123)
+        summary_mock.assert_called_once_with("123")
 
 
 class TestWorkBookshelvesPost:
@@ -77,8 +71,8 @@ class TestWorkBookshelvesPost:
 
         assert response.status_code == 200
         assert response.json() == {"bookshelves_affected": 1}
-        read_status_mock.assert_called_once_with("testuser", 123)
-        add_mock.assert_called_once_with(username="testuser", bookshelf_id=1, work_id=123, edition_id=42)
+        read_status_mock.assert_called_once_with("testuser", "123")
+        add_mock.assert_called_once_with(username="testuser", bookshelf_id="1", work_id="123", edition_id=42)
         remove_mock.assert_not_called()
         delete_events_mock.assert_not_called()
 
@@ -93,23 +87,7 @@ class TestWorkBookshelvesPost:
 
         assert response.status_code == 200
         assert response.json() == {"bookshelves_affected": 1}
-        add_mock.assert_called_once_with(username="testuser", bookshelf_id=2, work_id=123, edition_id=42)
-
-    def test_form_values_override_query_values(self, fastapi_client, mock_authenticated_user, mock_bookshelves_model):
-        _, add_mock, remove_mock, delete_events_mock = mock_bookshelves_model
-        add_mock.return_value = 1
-
-        response = fastapi_client.post(
-            "/works/OL123W/bookshelves.json",
-            params={"bookshelf_id": "-1", "edition_id": "/books/OL1M", "dont_remove": "false"},
-            data={"bookshelf_id": "3", "edition_id": "/books/OL42M", "dont_remove": "true"},
-        )
-
-        assert response.status_code == 200
-        assert response.json() == {"bookshelves_affected": 1}
-        add_mock.assert_called_once_with(username="testuser", bookshelf_id=3, work_id=123, edition_id=42)
-        remove_mock.assert_not_called()
-        delete_events_mock.assert_not_called()
+        add_mock.assert_called_once_with(username="testuser", bookshelf_id="2", work_id="123", edition_id=42)
 
     def test_post_removes_work_from_bookshelf(self, fastapi_client, mock_authenticated_user, mock_bookshelves_model):
         read_status_mock, add_mock, remove_mock, delete_events_mock = mock_bookshelves_model
@@ -120,8 +98,8 @@ class TestWorkBookshelvesPost:
 
         assert response.status_code == 200
         assert response.json() == {"bookshelves_affected": 1}
-        remove_mock.assert_called_once_with(username="testuser", work_id=123, bookshelf_id=2)
-        delete_events_mock.assert_called_once_with("testuser", 123)
+        remove_mock.assert_called_once_with(username="testuser", work_id="123", bookshelf_id="2")
+        delete_events_mock.assert_called_once_with("testuser", "123")
         add_mock.assert_not_called()
 
     def test_post_toggles_current_bookshelf_off(self, fastapi_client, mock_authenticated_user, mock_bookshelves_model):
@@ -133,8 +111,8 @@ class TestWorkBookshelvesPost:
 
         assert response.status_code == 200
         assert response.json() == {"bookshelves_affected": 1}
-        remove_mock.assert_called_once_with(username="testuser", work_id=123, bookshelf_id=2)
-        delete_events_mock.assert_called_once_with("testuser", 123)
+        remove_mock.assert_called_once_with(username="testuser", work_id="123", bookshelf_id="2")
+        delete_events_mock.assert_called_once_with("testuser", "123")
         add_mock.assert_not_called()
 
     def test_dont_remove_prevents_toggle_removal(self, fastapi_client, mock_authenticated_user, mock_bookshelves_model):
@@ -146,7 +124,7 @@ class TestWorkBookshelvesPost:
 
         assert response.status_code == 200
         assert response.json() == {"bookshelves_affected": 1}
-        add_mock.assert_called_once_with(username="testuser", bookshelf_id=2, work_id=123, edition_id=None)
+        add_mock.assert_called_once_with(username="testuser", bookshelf_id="2", work_id="123", edition_id=None)
         remove_mock.assert_not_called()
         delete_events_mock.assert_not_called()
 
@@ -181,50 +159,46 @@ class TestWorkBookshelvesPost:
 
 
 class TestWorkBookshelvesLegacyParity:
-    @pytest.mark.parametrize("use_query_params", [False, True])
-    def test_add_response_matches_legacy(self, fastapi_client, mock_authenticated_user, mock_bookshelves_model, use_query_params):
+    def test_add_response_matches_legacy(self, fastapi_client, mock_authenticated_user, mock_bookshelves_model):
         _, add_mock, _, _ = mock_bookshelves_model
         add_mock.return_value = 1
         data = {"bookshelf_id": "1", "edition_id": "/books/OL42M"}
 
         legacy_response = legacy_bookshelves_json(data)
-        fastapi_response = post_fastapi_bookshelves(fastapi_client, data, use_query_params=use_query_params)
+        fastapi_response = fastapi_client.post("/works/OL123W/bookshelves.json", data=data)
 
         assert fastapi_response.status_code == 200
         assert fastapi_response.json() == legacy_response
 
-    @pytest.mark.parametrize("use_query_params", [False, True])
-    def test_remove_response_matches_legacy(self, fastapi_client, mock_authenticated_user, mock_bookshelves_model, use_query_params):
+    def test_remove_response_matches_legacy(self, fastapi_client, mock_authenticated_user, mock_bookshelves_model):
         read_status_mock, _, remove_mock, _ = mock_bookshelves_model
         read_status_mock.return_value = 2
         remove_mock.return_value = 1
         data = {"bookshelf_id": "-1"}
 
         legacy_response = legacy_bookshelves_json(data)
-        fastapi_response = post_fastapi_bookshelves(fastapi_client, data, use_query_params=use_query_params)
+        fastapi_response = fastapi_client.post("/works/OL123W/bookshelves.json", data=data)
 
         assert fastapi_response.status_code == 200
         assert fastapi_response.json() == legacy_response
 
-    @pytest.mark.parametrize("use_query_params", [False, True])
-    def test_invalid_bookshelf_response_matches_legacy(self, fastapi_client, mock_authenticated_user, mock_bookshelves_model, use_query_params):
+    def test_invalid_bookshelf_response_matches_legacy(self, fastapi_client, mock_authenticated_user, mock_bookshelves_model):
         data = {"bookshelf_id": "99"}
 
         legacy_response = legacy_bookshelves_json(data)
-        fastapi_response = post_fastapi_bookshelves(fastapi_client, data, use_query_params=use_query_params)
+        fastapi_response = fastapi_client.post("/works/OL123W/bookshelves.json", data=data)
 
         assert fastapi_response.status_code == 200
         assert fastapi_response.json() == legacy_response
 
-    @pytest.mark.parametrize("use_query_params", [False, True])
-    def test_dont_remove_response_matches_legacy(self, fastapi_client, mock_authenticated_user, mock_bookshelves_model, use_query_params):
+    def test_dont_remove_response_matches_legacy(self, fastapi_client, mock_authenticated_user, mock_bookshelves_model):
         read_status_mock, add_mock, _, _ = mock_bookshelves_model
         read_status_mock.return_value = 2
         add_mock.return_value = 1
         data = {"bookshelf_id": "2", "dont_remove": "true"}
 
         legacy_response = legacy_bookshelves_json(data)
-        fastapi_response = post_fastapi_bookshelves(fastapi_client, data, use_query_params=use_query_params)
+        fastapi_response = fastapi_client.post("/works/OL123W/bookshelves.json", data=data)
 
         assert fastapi_response.status_code == 200
         assert fastapi_response.json() == legacy_response


### PR DESCRIPTION
## Summary

Migrates the work bookshelves routes from legacy web.py routing to FastAPI while preserving existing reading-log behavior.

Migrated endpoints:

- GET /works/OL{work_id}W/bookshelves.json
- POST /works/OL{work_id}W/bookshelves.json

### Stakeholders
@RayBB @Sanket17052006 