### PR TITLE
chore(deps): consolidate Python dependency upgrades (2026-06-16)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiofiles==25.1.0
 amightygirl.paapi5-python-sdk==1.0.0
 APScheduler==3.11.2
 Babel==2.18.0
-beautifulsoup4==4.14.3
+beautifulsoup4==4.15.0
 eventer==0.1.1
 fastapi==0.136.3
 feedparser==6.0.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ python-multipart==0.0.32
 PyYAML==6.0.3
 qrcode==7.4.2
 requests==2.34.2
-sentry-sdk[fastapi]==2.61.1
+sentry-sdk[fastapi]==2.62.0
 simplejson==3.20.2
 statsd==4.0.1
 uvicorn[standard]==0.49.0


### PR DESCRIPTION
## Summary

Consolidates open Renovate PRs into a single tested upgrade. All packages installed and verified in Docker before opening this PR.

## Packages upgraded

| Package | Before | After | Severity | Closes |
|---------|--------|-------|----------|--------|
| beautifulsoup4 | 4.14.3 | 4.15.0 | Patch | #12929 (partial) |
| sentry-sdk[fastapi] | 2.61.1 | 2.62.0 | Patch | #12929 (partial) |

## Excluded packages

| Package | Reason |
|---------|--------|
| luqum | 0.11.0 → 0.14.0 changes query parenthesization behaviour, breaking `test_luqum_parser` and `test_process_user_query[Operators]`. Needs a dedicated fix before upgrading. |

## Testing

- `beautifulsoup4 4.15.0`: installed in Docker web container, import + HTML parsing assertions pass
- `sentry-sdk 2.62.0`: installed in Docker web container, import + `FastApiIntegration` init pass
- `luqum`: confirmed as the failure source by inspecting the CI log for PR #12929 (`python_tests` fails with `AssertionError` on parenthesization)

## Checklist

- [x] All packages install cleanly in Docker
- [x] Package versions verified at correct values in container
- [x] pre-commit clean on `requirements.txt`
- [ ] CI passing