### PR TITLE
chore(deps): bump datatables.net-dt from 1.13.11 to 2.3.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "core-js": "^3.37.1",
         "css-loader": "^7.1.4",
         "css-minimizer-webpack-plugin": "^8.0.0",
-        "datatables.net-dt": "1.13.11",
+        "datatables.net-dt": "2.3.8",
         "details-polyfill": "1.2.0",
         "diff": "^4.0.4",
         "eslint": "^9.39.4",
@@ -8196,24 +8196,24 @@
       }
     },
     "node_modules/datatables.net": {
-      "version": "1.13.11",
-      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.13.11.tgz",
-      "integrity": "sha512-AE6RkMXziRaqzPcu/pl3SJXeRa6fmXQG/fVjuRESujvkzqDCYEeKTTpPMuVJSGYJpPi32WGSphVNNY1G4nSN/g==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-2.3.8.tgz",
+      "integrity": "sha512-uhViowhlDlheAuo5a8TrkQqADsjrtGeOyvrigvr4t0+K3MyAWqClORXWAYIcN9VLX6iIX0C8O9gwJNd01hITRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "jquery": "1.8 - 4"
+        "jquery": ">=1.7"
       }
     },
     "node_modules/datatables.net-dt": {
-      "version": "1.13.11",
-      "resolved": "https://registry.npmjs.org/datatables.net-dt/-/datatables.net-dt-1.13.11.tgz",
-      "integrity": "sha512-4GpS4OFLwIMfhb5UdJh6bEnh0E52jIJOlx7KLKs1pSce/xpHjvcmucbUWNaEndQIpHXtIxmVPoqcDB0ZbiVB+A==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/datatables.net-dt/-/datatables.net-dt-2.3.8.tgz",
+      "integrity": "sha512-GD4on0YvNlUS/l+mrXeA1OC2JDzF2/GGbehVv4AacwtiFaoTwqxZseiR0cED6w59u/lgpVrZRC2RwuubUX996Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "datatables.net": "1.13.11",
-        "jquery": "1.8 - 4"
+        "datatables.net": "2.3.8",
+        "jquery": ">=1.7"
       }
     },
     "node_modules/date-fns": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "core-js": "^3.37.1",
     "css-loader": "^7.1.4",
     "css-minimizer-webpack-plugin": "^8.0.0",
-    "datatables.net-dt": "1.13.11",
+    "datatables.net-dt": "2.3.8",
     "details-polyfill": "1.2.0",
     "diff": "^4.0.4",
     "eslint": "^9.39.4",


### PR DESCRIPTION
## Summary

Bumps `datatables.net-dt` from 1.13.11 to 2.3.8 (major version upgrade — v2.x).

Closes #12829

## Changes

| Package | Before | After | Notes |
|---------|--------|-------|-------|
| datatables.net-dt | 1.13.11 | 2.3.8 | Major: v2 migration required updated lockfile only; no OL code changes needed |

## Excluded packages

| Package | Reason |
|---------|--------|
| chart.js | v4 removed the default export; `readinglog_stats.js` uses `import Chart from 'chart.js'` which becomes `undefined` at runtime. Needs a code fix in that file before bumping. |
| chartjs-plugin-datalabels | Depends on chart.js v4; excluded alongside chart.js. |

## Testing

- `npm install` regenerated a clean lockfile (only datatables changed)
- `make js` compiled successfully (0 webpack errors)
- `npm run test:js` — 467/467 tests passed
- `slick-carousel` confirmed pinned to `"1.6.0"` (exact) throughout

## Checklist

- [x] All packages install cleanly
- [x] Webpack compiles with 0 errors
- [x] 467/467 Jest tests pass
- [x] `slick-carousel` pinned to `1.6.0` — not bumped
- [ ] CI passing