### PR TITLE
Migrate work editions and author works

### DIFF
--- a/openlibrary/fastapi/internal/api.py
+++ b/openlibrary/fastapi/internal/api.py
@@ -13,9 +13,9 @@ from datetime import datetime
 from typing import Annotated, Any, Literal
 from urllib.parse import urlencode
 
-from fastapi import APIRouter, Depends, Form, HTTPException, Path, Query, status
+from fastapi import APIRouter, Depends, Form, HTTPException, Path, Query, Request, status
 from pydantic import BaseModel, BeforeValidator, Field
-from starlette.responses import RedirectResponse
+from starlette.responses import JSONResponse, RedirectResponse
 
 from openlibrary import accounts
 from openlibrary.core import lending, models
@@ -32,10 +32,18 @@ from openlibrary.fastapi.models import (
     Pagination,
     parse_comma_separated_list,
 )
-from openlibrary.plugins.openlibrary.api import bestbook_award, get_price_data_async
+from openlibrary.plugins.openlibrary.api import (
+    bestbook_award,
+    get_author_works_data,
+    get_author_works_pagination,
+    get_price_data_async,
+    get_work_editions_data,
+    get_work_editions_pagination,
+)
 from openlibrary.plugins.openlibrary.api import ratings as legacy_ratings
 from openlibrary.plugins.openlibrary.api import work_bookshelves as legacy_work_bookshelves
 from openlibrary.utils import extract_numeric_id_from_olid
+from openlibrary.utils.request_context import site
 from openlibrary.views.loanstats import SINCE_DAYS, get_trending_books
 
 SHOW_INTERNAL_IN_SCHEMA = os.getenv("LOCAL_DEV") is not None
@@ -46,6 +54,29 @@ router = APIRouter(tags=["internal"], include_in_schema=SHOW_INTERNAL_IN_SCHEMA)
 # This guarantees that our path parameter validated by FastAPI is always
 # a safe dictionary key when we pass it to the legacy backend function.
 TrendingPeriod = Literal["now", "daily", "weekly", "monthly", "yearly", "forever"]
+
+
+def _request_fullpath(request: Request) -> str:
+    if request.url.query:
+        return f"{request.url.path}?{request.url.query}"
+    return request.url.path
+
+
+def _changequery_for_request(request: Request, **kw) -> str:
+    query = dict(request.query_params)
+    for key, value in kw.items():
+        if value is None:
+            query.pop(key, None)
+        else:
+            query[key] = str(value)
+
+    if query:
+        return f"{request.url.path}?{urlencode(query)}"
+    return request.url.path
+
+
+def _json_not_found() -> JSONResponse:
+    return JSONResponse(content={}, status_code=status.HTTP_404_NOT_FOUND)
 
 
 class AvailabilityStatusV2(BaseModel):
@@ -290,12 +321,52 @@ def post_work_bookshelves(
     )
 
 
-async def work_editions():
-    pass
+@router.get("/works/OL{work_id}W/editions.json")
+def work_editions(
+    request: Request,
+    work_id: Annotated[int, Path(gt=0)],
+    limit: Annotated[str | None, Query()] = "50",
+    offset: Annotated[str | None, Query()] = "0",
+) -> Any:
+    """Get paginated editions for a work."""
+    current_site = site.get()
+    work = current_site.get(f"/works/OL{work_id}W")
+    if not work or work.type.key != "/type/work":
+        return _json_not_found()
+
+    resolved_limit, resolved_offset = get_work_editions_pagination(limit, offset)
+    return get_work_editions_data(
+        work,
+        limit=resolved_limit,
+        offset=resolved_offset,
+        current_site=current_site,
+        fullpath=_request_fullpath(request),
+        changequery=lambda **kw: _changequery_for_request(request, **kw),
+    )
 
 
-async def author_works():
-    pass
+@router.get("/authors/OL{author_id}A/works.json")
+def author_works(
+    request: Request,
+    author_id: Annotated[int, Path(gt=0)],
+    limit: Annotated[str | None, Query()] = "50",
+    offset: Annotated[str | None, Query()] = "0",
+) -> Any:
+    """Get paginated works for an author."""
+    current_site = site.get()
+    author = current_site.get(f"/authors/OL{author_id}A")
+    if not author or author.type.key != "/type/author":
+        return _json_not_found()
+
+    resolved_limit, resolved_offset = get_author_works_pagination(limit, offset)
+    return get_author_works_data(
+        author,
+        limit=resolved_limit,
+        offset=resolved_offset,
+        current_site=current_site,
+        fullpath=_request_fullpath(request),
+        changequery=lambda **kw: _changequery_for_request(request, **kw),
+    )
 
 
 class PriceResponse(BaseModel):

--- a/openlibrary/fastapi/internal/api.py
+++ b/openlibrary/fastapi/internal/api.py
@@ -32,18 +32,12 @@ from openlibrary.fastapi.models import (
     Pagination,
     parse_comma_separated_list,
 )
-from openlibrary.plugins.openlibrary.api import (
-    bestbook_award,
-    get_author_works_data,
-    get_author_works_pagination,
-    get_price_data_async,
-    get_work_editions_data,
-    get_work_editions_pagination,
-)
+from openlibrary.plugins.openlibrary.api import author_works as legacy_author_works
+from openlibrary.plugins.openlibrary.api import bestbook_award, get_price_data_async
 from openlibrary.plugins.openlibrary.api import ratings as legacy_ratings
 from openlibrary.plugins.openlibrary.api import work_bookshelves as legacy_work_bookshelves
+from openlibrary.plugins.openlibrary.api import work_editions as legacy_work_editions
 from openlibrary.utils import extract_numeric_id_from_olid
-from openlibrary.utils.request_context import site
 from openlibrary.views.loanstats import SINCE_DAYS, get_trending_books
 
 SHOW_INTERNAL_IN_SCHEMA = os.getenv("LOCAL_DEV") is not None
@@ -54,29 +48,6 @@ router = APIRouter(tags=["internal"], include_in_schema=SHOW_INTERNAL_IN_SCHEMA)
 # This guarantees that our path parameter validated by FastAPI is always
 # a safe dictionary key when we pass it to the legacy backend function.
 TrendingPeriod = Literal["now", "daily", "weekly", "monthly", "yearly", "forever"]
-
-
-def _request_fullpath(request: Request) -> str:
-    if request.url.query:
-        return f"{request.url.path}?{request.url.query}"
-    return request.url.path
-
-
-def _changequery_for_request(request: Request, **kw) -> str:
-    query = dict(request.query_params)
-    for key, value in kw.items():
-        if value is None:
-            query.pop(key, None)
-        else:
-            query[key] = str(value)
-
-    if query:
-        return f"{request.url.path}?{urlencode(query)}"
-    return request.url.path
-
-
-def _json_not_found() -> JSONResponse:
-    return JSONResponse(content={}, status_code=status.HTTP_404_NOT_FOUND)
 
 
 class AvailabilityStatusV2(BaseModel):
@@ -321,52 +292,42 @@ def post_work_bookshelves(
     )
 
 
-@router.get("/works/OL{work_id}W/editions.json")
+@router.get("/works/OL{work_id}W/editions.json", response_model=None)
 def work_editions(
     request: Request,
     work_id: Annotated[int, Path(ge=0)],
-    limit: Annotated[str | None, Query()] = "50",
-    offset: Annotated[str | None, Query()] = "0",
-) -> Any:
+    limit: Annotated[int, Query(description="Maximum number of editions to return")] = 50,
+    offset: Annotated[int, Query(description="Number of editions to skip")] = 0,
+) -> dict[str, Any] | JSONResponse:
     """Get paginated editions for a work."""
-    current_site = site.get()
-    work = current_site.get(f"/works/OL{work_id}W")
-    if not work or work.type.key != "/type/work":
-        return _json_not_found()
-
-    resolved_limit, resolved_offset = get_work_editions_pagination(limit, offset)
-    return get_work_editions_data(
-        work,
-        limit=resolved_limit,
-        offset=resolved_offset,
-        current_site=current_site,
-        fullpath=_request_fullpath(request),
-        changequery=lambda **kw: _changequery_for_request(request, **kw),
+    data = legacy_work_editions.get_editions_data(
+        f"/works/OL{work_id}W",
+        url=request.url,
+        limit=limit,
+        offset=offset,
     )
+    if data is None:
+        return JSONResponse(content={}, status_code=status.HTTP_404_NOT_FOUND)
+    return data
 
 
-@router.get("/authors/OL{author_id}A/works.json")
+@router.get("/authors/OL{author_id}A/works.json", response_model=None)
 def author_works(
     request: Request,
     author_id: Annotated[int, Path(ge=0)],
-    limit: Annotated[str | None, Query()] = "50",
-    offset: Annotated[str | None, Query()] = "0",
-) -> Any:
+    limit: Annotated[int, Query(description="Maximum number of works to return")] = 50,
+    offset: Annotated[int, Query(description="Number of works to skip")] = 0,
+) -> dict[str, Any] | JSONResponse:
     """Get paginated works for an author."""
-    current_site = site.get()
-    author = current_site.get(f"/authors/OL{author_id}A")
-    if not author or author.type.key != "/type/author":
-        return _json_not_found()
-
-    resolved_limit, resolved_offset = get_author_works_pagination(limit, offset)
-    return get_author_works_data(
-        author,
-        limit=resolved_limit,
-        offset=resolved_offset,
-        current_site=current_site,
-        fullpath=_request_fullpath(request),
-        changequery=lambda **kw: _changequery_for_request(request, **kw),
+    data = legacy_author_works.get_works_data(
+        f"/authors/OL{author_id}A",
+        url=request.url,
+        limit=limit,
+        offset=offset,
     )
+    if data is None:
+        return JSONResponse(content={}, status_code=status.HTTP_404_NOT_FOUND)
+    return data
 
 
 class PriceResponse(BaseModel):

--- a/openlibrary/fastapi/internal/api.py
+++ b/openlibrary/fastapi/internal/api.py
@@ -15,7 +15,7 @@ from urllib.parse import urlencode
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Path, Query, Request, status
 from pydantic import BaseModel, BeforeValidator, Field
-from starlette.responses import JSONResponse, RedirectResponse
+from starlette.responses import RedirectResponse
 
 from openlibrary import accounts
 from openlibrary.core import lending, models
@@ -292,13 +292,19 @@ def post_work_bookshelves(
     )
 
 
-@router.get("/works/OL{work_id}W/editions.json", response_model=None)
+class PaginatedGroupEntryResponse(BaseModel):
+    links: dict[str, str]
+    size: int
+    entries: list[dict]
+
+
+@router.get("/works/OL{work_id}W/editions.json", response_model=PaginatedGroupEntryResponse, response_model_exclude_none=True)
 def work_editions(
     request: Request,
     work_id: Annotated[int, Path(ge=0)],
-    limit: Annotated[int, Query(description="Maximum number of editions to return")] = 50,
-    offset: Annotated[int, Query(description="Number of editions to skip")] = 0,
-) -> dict[str, Any] | JSONResponse:
+    limit: Annotated[int, Query(ge=0, le=1000, description="Maximum number of editions to return")] = 50,
+    offset: Annotated[int, Query(ge=0, description="Number of editions to skip")] = 0,
+) -> PaginatedGroupEntryResponse:
     """Get paginated editions for a work."""
     data = legacy_work_editions.get_editions_data(
         f"/works/OL{work_id}W",
@@ -307,17 +313,17 @@ def work_editions(
         offset=offset,
     )
     if data is None:
-        return JSONResponse(content={}, status_code=status.HTTP_404_NOT_FOUND)
-    return data
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    return PaginatedGroupEntryResponse(**data)
 
 
-@router.get("/authors/OL{author_id}A/works.json", response_model=None)
+@router.get("/authors/OL{author_id}A/works.json", response_model=PaginatedGroupEntryResponse, response_model_exclude_none=True)
 def author_works(
     request: Request,
     author_id: Annotated[int, Path(ge=0)],
-    limit: Annotated[int, Query(description="Maximum number of works to return")] = 50,
-    offset: Annotated[int, Query(description="Number of works to skip")] = 0,
-) -> dict[str, Any] | JSONResponse:
+    limit: Annotated[int, Query(ge=0, le=1000, description="Maximum number of works to return")] = 50,
+    offset: Annotated[int, Query(ge=0, description="Number of works to skip")] = 0,
+) -> PaginatedGroupEntryResponse:
     """Get paginated works for an author."""
     data = legacy_author_works.get_works_data(
         f"/authors/OL{author_id}A",
@@ -326,8 +332,8 @@ def author_works(
         offset=offset,
     )
     if data is None:
-        return JSONResponse(content={}, status_code=status.HTTP_404_NOT_FOUND)
-    return data
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    return PaginatedGroupEntryResponse(**data)
 
 
 class PriceResponse(BaseModel):

--- a/openlibrary/fastapi/internal/api.py
+++ b/openlibrary/fastapi/internal/api.py
@@ -324,7 +324,7 @@ def post_work_bookshelves(
 @router.get("/works/OL{work_id}W/editions.json")
 def work_editions(
     request: Request,
-    work_id: Annotated[int, Path(gt=0)],
+    work_id: Annotated[int, Path(ge=0)],
     limit: Annotated[str | None, Query()] = "50",
     offset: Annotated[str | None, Query()] = "0",
 ) -> Any:
@@ -348,7 +348,7 @@ def work_editions(
 @router.get("/authors/OL{author_id}A/works.json")
 def author_works(
     request: Request,
-    author_id: Annotated[int, Path(gt=0)],
+    author_id: Annotated[int, Path(ge=0)],
     limit: Annotated[str | None, Query()] = "50",
     offset: Annotated[str | None, Query()] = "0",
 ) -> Any:

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -8,12 +8,12 @@ import io
 import json
 import logging
 from collections import defaultdict
-from collections.abc import Callable
 from typing import Any, Literal
 from warnings import deprecated
 
 import qrcode
 import web
+from starlette.datastructures import URL
 
 from infogami import config  # noqa: F401 side effects may be needed
 from infogami.infobase.client import ClientException
@@ -51,76 +51,6 @@ from openlibrary.utils.isbn import normalize_isbn
 from openlibrary.utils.request_context import req_context, site
 
 logger = logging.getLogger(__name__)
-
-
-def get_work_editions_pagination(limit, offset):
-    return h.safeint(limit) or 50, h.safeint(offset) or 0
-
-
-def get_author_works_pagination(limit, offset):
-    return h.safeint(limit, 50), h.safeint(offset, 0)
-
-
-def get_work_editions_data(work, limit, offset, *, current_site=None, fullpath: str | None = None, changequery: Callable[..., str] | None = None):
-    current_site = current_site or web.ctx.site
-    fullpath = fullpath or web.ctx.fullpath
-    changequery = changequery or web.changequery
-    limit = min(limit, 1000)
-
-    keys = current_site.things(
-        {
-            "type": "/type/edition",
-            "works": work.key,
-            "limit": limit,
-            "offset": offset,
-        }
-    )
-    editions = current_site.get_many(keys, raw=True)
-
-    size = work.edition_count
-    links = {
-        "self": fullpath,
-        "work": work.key,
-    }
-
-    if offset > 0:
-        links["prev"] = changequery(offset=min(0, offset - limit))
-
-    if offset + len(editions) < size:
-        links["next"] = changequery(offset=offset + limit)
-
-    return {"links": links, "size": size, "entries": editions}
-
-
-def get_author_works_data(author, limit, offset, *, current_site=None, fullpath: str | None = None, changequery: Callable[..., str] | None = None):
-    current_site = current_site or web.ctx.site
-    fullpath = fullpath or web.ctx.fullpath
-    changequery = changequery or web.changequery
-    limit = min(limit, 1000)
-
-    keys = current_site.things(
-        {
-            "type": "/type/work",
-            "authors": {"author": {"key": author.key}},
-            "limit": limit,
-            "offset": offset,
-        }
-    )
-    works = current_site.get_many(keys, raw=True)
-
-    size = author.get_work_count()
-    links = {
-        "self": fullpath,
-        "author": author.key,
-    }
-
-    if offset > 0:
-        links["prev"] = changequery(offset=min(0, offset - limit))
-
-    if offset + len(works) < size:
-        links["next"] = changequery(offset=offset + limit)
-
-    return {"links": links, "size": size, "entries": works}
 
 
 class ratings:
@@ -309,19 +239,46 @@ class work_editions(delegate.page):
     encoding = "json"
 
     def GET(self, key):
-        doc = web.ctx.site.get(key)
-        if not doc or doc.type.key != "/type/work":
+        i = web.input(limit=50, offset=0)
+        data = self.get_editions_data(
+            key,
+            url=URL(web.ctx.fullpath),
+            limit=h.safeint(i.limit) or 50,
+            offset=h.safeint(i.offset) or 0,
+        )
+        if data is None:
             raise web.HTTPError("404 Not Found", {"Content-Type": "application/json"}, data="{}")
-        else:
-            i = web.input(limit=50, offset=0)
-            limit, offset = get_work_editions_pagination(i.limit, i.offset)
-
-            data = self.get_editions_data(doc, limit=limit, offset=offset)
-            return delegate.RawText(json.dumps(data), content_type="application/json")
+        return delegate.RawText(json.dumps(data), content_type="application/json")
 
     @staticmethod
-    def get_editions_data(work, limit, offset):
-        return get_work_editions_data(work, limit, offset)
+    def get_editions_data(key: str, url: URL, limit: int, offset: int) -> dict[str, Any] | None:
+        current_site = site.get()
+        work = current_site.get(key)
+        if not work or work.type.key != "/type/work":
+            return None
+
+        limit = min(limit or 50, 1000)
+        keys = current_site.things(
+            {
+                "type": "/type/edition",
+                "works": work.key,
+                "limit": limit,
+                "offset": offset,
+            }
+        )
+        editions = current_site.get_many(keys, raw=True)
+
+        url = url.replace(scheme="", netloc="")
+        links = {
+            "self": str(url),
+            "work": work.key,
+        }
+        if offset > 0:
+            links["prev"] = str(url.include_query_params(offset=min(0, offset - limit)))
+        if offset + len(editions) < work.edition_count:
+            links["next"] = str(url.include_query_params(offset=offset + limit))
+
+        return {"links": links, "size": work.edition_count, "entries": editions}
 
 
 @deprecated("migrated to fastapi")
@@ -330,19 +287,47 @@ class author_works(delegate.page):
     encoding = "json"
 
     def GET(self, key):
-        doc = web.ctx.site.get(key)
-        if not doc or doc.type.key != "/type/author":
+        i = web.input(limit=50, offset=0)
+        data = self.get_works_data(
+            key,
+            url=URL(web.ctx.fullpath),
+            limit=h.safeint(i.limit, 50),
+            offset=h.safeint(i.offset, 0),
+        )
+        if data is None:
             raise web.HTTPError("404 Not Found", {"Content-Type": "application/json"}, data="{}")
-        else:
-            i = web.input(limit=50, offset=0)
-            limit, offset = get_author_works_pagination(i.limit, i.offset)
-
-            data = self.get_works_data(doc, limit=limit, offset=offset)
-            return delegate.RawText(json.dumps(data), content_type="application/json")
+        return delegate.RawText(json.dumps(data), content_type="application/json")
 
     @staticmethod
-    def get_works_data(author, limit, offset):
-        return get_author_works_data(author, limit, offset)
+    def get_works_data(key: str, url: URL, limit: int, offset: int) -> dict[str, Any] | None:
+        current_site = site.get()
+        author = current_site.get(key)
+        if not author or author.type.key != "/type/author":
+            return None
+
+        limit = min(limit, 1000)
+        keys = current_site.things(
+            {
+                "type": "/type/work",
+                "authors": {"author": {"key": author.key}},
+                "limit": limit,
+                "offset": offset,
+            }
+        )
+        works = current_site.get_many(keys, raw=True)
+        size = author.get_work_count()
+
+        url = url.replace(scheme="", netloc="")
+        links = {
+            "self": str(url),
+            "author": author.key,
+        }
+        if offset > 0:
+            links["prev"] = str(url.include_query_params(offset=min(0, offset - limit)))
+        if offset + len(works) < size:
+            links["next"] = str(url.include_query_params(offset=offset + limit))
+
+        return {"links": links, "size": size, "entries": works}
 
 
 async def get_price_data_async(isbn: str, asin: str) -> dict[str, Any]:

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -8,6 +8,7 @@ import io
 import json
 import logging
 from collections import defaultdict
+from collections.abc import Callable
 from typing import Any, Literal
 from warnings import deprecated
 
@@ -50,6 +51,76 @@ from openlibrary.utils.isbn import normalize_isbn
 from openlibrary.utils.request_context import req_context, site
 
 logger = logging.getLogger(__name__)
+
+
+def get_work_editions_pagination(limit, offset):
+    return h.safeint(limit) or 50, h.safeint(offset) or 0
+
+
+def get_author_works_pagination(limit, offset):
+    return h.safeint(limit, 50), h.safeint(offset, 0)
+
+
+def get_work_editions_data(work, limit, offset, *, current_site=None, fullpath: str | None = None, changequery: Callable[..., str] | None = None):
+    current_site = current_site or web.ctx.site
+    fullpath = fullpath or web.ctx.fullpath
+    changequery = changequery or web.changequery
+    limit = min(limit, 1000)
+
+    keys = current_site.things(
+        {
+            "type": "/type/edition",
+            "works": work.key,
+            "limit": limit,
+            "offset": offset,
+        }
+    )
+    editions = current_site.get_many(keys, raw=True)
+
+    size = work.edition_count
+    links = {
+        "self": fullpath,
+        "work": work.key,
+    }
+
+    if offset > 0:
+        links["prev"] = changequery(offset=min(0, offset - limit))
+
+    if offset + len(editions) < size:
+        links["next"] = changequery(offset=offset + limit)
+
+    return {"links": links, "size": size, "entries": editions}
+
+
+def get_author_works_data(author, limit, offset, *, current_site=None, fullpath: str | None = None, changequery: Callable[..., str] | None = None):
+    current_site = current_site or web.ctx.site
+    fullpath = fullpath or web.ctx.fullpath
+    changequery = changequery or web.changequery
+    limit = min(limit, 1000)
+
+    keys = current_site.things(
+        {
+            "type": "/type/work",
+            "authors": {"author": {"key": author.key}},
+            "limit": limit,
+            "offset": offset,
+        }
+    )
+    works = current_site.get_many(keys, raw=True)
+
+    size = author.get_work_count()
+    links = {
+        "self": fullpath,
+        "author": author.key,
+    }
+
+    if offset > 0:
+        links["prev"] = changequery(offset=min(0, offset - limit))
+
+    if offset + len(works) < size:
+        links["next"] = changequery(offset=offset + limit)
+
+    return {"links": links, "size": size, "entries": works}
 
 
 class ratings:
@@ -232,6 +303,7 @@ class work_bookshelves(delegate.page):
         )
 
 
+@deprecated("migrated to fastapi")
 class work_editions(delegate.page):
     path = r"(/works/OL\d+W)/editions"
     encoding = "json"
@@ -242,41 +314,17 @@ class work_editions(delegate.page):
             raise web.HTTPError("404 Not Found", {"Content-Type": "application/json"}, data="{}")
         else:
             i = web.input(limit=50, offset=0)
-            limit = h.safeint(i.limit) or 50
-            offset = h.safeint(i.offset) or 0
+            limit, offset = get_work_editions_pagination(i.limit, i.offset)
 
             data = self.get_editions_data(doc, limit=limit, offset=offset)
             return delegate.RawText(json.dumps(data), content_type="application/json")
 
     @staticmethod
     def get_editions_data(work, limit, offset):
-        limit = min(limit, 1000)
-
-        keys = web.ctx.site.things(
-            {
-                "type": "/type/edition",
-                "works": work.key,
-                "limit": limit,
-                "offset": offset,
-            }
-        )
-        editions = web.ctx.site.get_many(keys, raw=True)
-
-        size = work.edition_count
-        links = {
-            "self": web.ctx.fullpath,
-            "work": work.key,
-        }
-
-        if offset > 0:
-            links["prev"] = web.changequery(offset=min(0, offset - limit))
-
-        if offset + len(editions) < size:
-            links["next"] = web.changequery(offset=offset + limit)
-
-        return {"links": links, "size": size, "entries": editions}
+        return get_work_editions_data(work, limit, offset)
 
 
+@deprecated("migrated to fastapi")
 class author_works(delegate.page):
     path = r"(/authors/OL\d+A)/works"
     encoding = "json"
@@ -287,39 +335,14 @@ class author_works(delegate.page):
             raise web.HTTPError("404 Not Found", {"Content-Type": "application/json"}, data="{}")
         else:
             i = web.input(limit=50, offset=0)
-            limit = h.safeint(i.limit, 50)
-            offset = h.safeint(i.offset, 0)
+            limit, offset = get_author_works_pagination(i.limit, i.offset)
 
             data = self.get_works_data(doc, limit=limit, offset=offset)
             return delegate.RawText(json.dumps(data), content_type="application/json")
 
     @staticmethod
     def get_works_data(author, limit, offset):
-        limit = min(limit, 1000)
-
-        keys = web.ctx.site.things(
-            {
-                "type": "/type/work",
-                "authors": {"author": {"key": author.key}},
-                "limit": limit,
-                "offset": offset,
-            }
-        )
-        works = web.ctx.site.get_many(keys, raw=True)
-
-        size = author.get_work_count()
-        links = {
-            "self": web.ctx.fullpath,
-            "author": author.key,
-        }
-
-        if offset > 0:
-            links["prev"] = web.changequery(offset=min(0, offset - limit))
-
-        if offset + len(works) < size:
-            links["next"] = web.changequery(offset=offset + limit)
-
-        return {"links": links, "size": size, "entries": works}
+        return get_author_works_data(author, limit, offset)
 
 
 async def get_price_data_async(isbn: str, asin: str) -> dict[str, Any]:

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -274,7 +274,7 @@ class work_editions(delegate.page):
             "work": work.key,
         }
         if offset > 0:
-            links["prev"] = str(url.include_query_params(offset=min(0, offset - limit)))
+            links["prev"] = str(url.include_query_params(offset=max(0, offset - limit)))
         if offset + len(editions) < work.edition_count:
             links["next"] = str(url.include_query_params(offset=offset + limit))
 
@@ -323,7 +323,7 @@ class author_works(delegate.page):
             "author": author.key,
         }
         if offset > 0:
-            links["prev"] = str(url.include_query_params(offset=min(0, offset - limit)))
+            links["prev"] = str(url.include_query_params(offset=max(0, offset - limit)))
         if offset + len(works) < size:
             links["next"] = str(url.include_query_params(offset=offset + limit))
 

--- a/openlibrary/tests/fastapi/test_work_editions_author_works.py
+++ b/openlibrary/tests/fastapi/test_work_editions_author_works.py
@@ -99,14 +99,14 @@ class TestWorkEditions:
 
         with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
             site_context.get.return_value = current_site
-            response = fastapi_client.get("/works/OL123W/editions.json?limit=5000&offset=25")
+            response = fastapi_client.get("/works/OL123W/editions.json?limit=1000&offset=25")
 
         assert response.status_code == 200
         assert response.json()["links"] == {
-            "self": "/works/OL123W/editions.json?limit=5000&offset=25",
+            "self": "/works/OL123W/editions.json?limit=1000&offset=25",
             "work": "/works/OL123W",
-            "prev": "/works/OL123W/editions.json?limit=5000&offset=-975",
-            "next": "/works/OL123W/editions.json?limit=5000&offset=1025",
+            "prev": "/works/OL123W/editions.json?limit=1000&offset=-975",
+            "next": "/works/OL123W/editions.json?limit=1000&offset=1025",
         }
         current_site.things.assert_called_once_with(
             {
@@ -166,7 +166,7 @@ class TestWorkEditions:
         )
 
     @pytest.mark.parametrize("doc", [None, make_doc("/authors/OL1A", "/type/author")])
-    def test_work_editions_returns_legacy_json_404(self, fastapi_client, doc):
+    def test_work_editions_returns_404(self, fastapi_client, doc):
         current_site = make_site(doc, [], [])
 
         with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
@@ -174,11 +174,10 @@ class TestWorkEditions:
             response = fastapi_client.get("/works/OL123W/editions.json")
 
         assert response.status_code == 404
-        assert response.json() == {}
         current_site.things.assert_not_called()
         current_site.get_many.assert_not_called()
 
-    def test_work_editions_allows_zero_id_and_returns_legacy_json_404(self, fastapi_client):
+    def test_work_editions_allows_zero_id_and_returns_404(self, fastapi_client):
         current_site = make_site(None, [], [])
 
         with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
@@ -186,7 +185,6 @@ class TestWorkEditions:
             response = fastapi_client.get("/works/OL0W/editions.json")
 
         assert response.status_code == 404
-        assert response.json() == {}
         current_site.get.assert_called_once_with("/works/OL0W")
         current_site.things.assert_not_called()
         current_site.get_many.assert_not_called()
@@ -246,14 +244,14 @@ class TestAuthorWorks:
 
         with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
             site_context.get.return_value = current_site
-            response = fastapi_client.get("/authors/OL456A/works.json?limit=5000&offset=25")
+            response = fastapi_client.get("/authors/OL456A/works.json?limit=1000&offset=25")
 
         assert response.status_code == 200
         assert response.json()["links"] == {
-            "self": "/authors/OL456A/works.json?limit=5000&offset=25",
+            "self": "/authors/OL456A/works.json?limit=1000&offset=25",
             "author": "/authors/OL456A",
-            "prev": "/authors/OL456A/works.json?limit=5000&offset=-975",
-            "next": "/authors/OL456A/works.json?limit=5000&offset=1025",
+            "prev": "/authors/OL456A/works.json?limit=1000&offset=-975",
+            "next": "/authors/OL456A/works.json?limit=1000&offset=1025",
         }
         current_site.things.assert_called_once_with(
             {
@@ -313,7 +311,7 @@ class TestAuthorWorks:
         )
 
     @pytest.mark.parametrize("doc", [None, make_doc("/works/OL1W", "/type/work")])
-    def test_author_works_returns_legacy_json_404(self, fastapi_client, doc):
+    def test_author_works_returns_404(self, fastapi_client, doc):
         current_site = make_site(doc, [], [])
 
         with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
@@ -321,11 +319,10 @@ class TestAuthorWorks:
             response = fastapi_client.get("/authors/OL456A/works.json")
 
         assert response.status_code == 404
-        assert response.json() == {}
         current_site.things.assert_not_called()
         current_site.get_many.assert_not_called()
 
-    def test_author_works_allows_zero_id_and_returns_legacy_json_404(self, fastapi_client):
+    def test_author_works_allows_zero_id_and_returns_404(self, fastapi_client):
         current_site = make_site(None, [], [])
 
         with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
@@ -333,7 +330,6 @@ class TestAuthorWorks:
             response = fastapi_client.get("/authors/OL0A/works.json")
 
         assert response.status_code == 404
-        assert response.json() == {}
         current_site.get.assert_called_once_with("/authors/OL0A")
         current_site.things.assert_not_called()
         current_site.get_many.assert_not_called()

--- a/openlibrary/tests/fastapi/test_work_editions_author_works.py
+++ b/openlibrary/tests/fastapi/test_work_editions_author_works.py
@@ -47,12 +47,10 @@ def legacy_get_work_editions_json(current_site, data=None):
     data = data or {}
     path = "/works/OL123W/editions.json"
     fullpath = path if not data else f"{path}?{urlencode(data)}"
-
-    web.ctx.site = current_site
-    web.ctx.path = path
-    web.ctx.fullpath = fullpath
+    ctx = web.storage(site=current_site, path=path, fullpath=fullpath)
 
     with (
+        patch("openlibrary.plugins.openlibrary.api.web.ctx", ctx),
         patch("openlibrary.plugins.openlibrary.api.web.input", side_effect=mock_web_input_func(data)),
         patch("openlibrary.plugins.openlibrary.api.web.changequery", side_effect=lambda **kw: changequery(path, data, **kw)),
         pytest.deprecated_call(match="migrated to fastapi"),
@@ -64,12 +62,10 @@ def legacy_get_author_works_json(current_site, data=None):
     data = data or {}
     path = "/authors/OL456A/works.json"
     fullpath = path if not data else f"{path}?{urlencode(data)}"
-
-    web.ctx.site = current_site
-    web.ctx.path = path
-    web.ctx.fullpath = fullpath
+    ctx = web.storage(site=current_site, path=path, fullpath=fullpath)
 
     with (
+        patch("openlibrary.plugins.openlibrary.api.web.ctx", ctx),
         patch("openlibrary.plugins.openlibrary.api.web.input", side_effect=mock_web_input_func(data)),
         patch("openlibrary.plugins.openlibrary.api.web.changequery", side_effect=lambda **kw: changequery(path, data, **kw)),
         pytest.deprecated_call(match="migrated to fastapi"),
@@ -160,6 +156,19 @@ class TestWorkEditions:
 
         assert response.status_code == 404
         assert response.json() == {}
+        current_site.things.assert_not_called()
+        current_site.get_many.assert_not_called()
+
+    def test_work_editions_allows_zero_id_and_returns_legacy_json_404(self, fastapi_client):
+        current_site = make_site(None, [], [])
+
+        with patch("openlibrary.fastapi.internal.api.site") as site_context:
+            site_context.get.return_value = current_site
+            response = fastapi_client.get("/works/OL0W/editions.json")
+
+        assert response.status_code == 404
+        assert response.json() == {}
+        current_site.get.assert_called_once_with("/works/OL0W")
         current_site.things.assert_not_called()
         current_site.get_many.assert_not_called()
 
@@ -264,6 +273,19 @@ class TestAuthorWorks:
 
         assert response.status_code == 404
         assert response.json() == {}
+        current_site.things.assert_not_called()
+        current_site.get_many.assert_not_called()
+
+    def test_author_works_allows_zero_id_and_returns_legacy_json_404(self, fastapi_client):
+        current_site = make_site(None, [], [])
+
+        with patch("openlibrary.fastapi.internal.api.site") as site_context:
+            site_context.get.return_value = current_site
+            response = fastapi_client.get("/authors/OL0A/works.json")
+
+        assert response.status_code == 404
+        assert response.json() == {}
+        current_site.get.assert_called_once_with("/authors/OL0A")
         current_site.things.assert_not_called()
         current_site.get_many.assert_not_called()
 

--- a/openlibrary/tests/fastapi/test_work_editions_author_works.py
+++ b/openlibrary/tests/fastapi/test_work_editions_author_works.py
@@ -23,19 +23,6 @@ def make_site(doc, keys, entries):
     return current_site
 
 
-def changequery(path: str, query: dict[str, str], **kw) -> str:
-    updated = dict(query)
-    for key, value in kw.items():
-        if value is None:
-            updated.pop(key, None)
-        else:
-            updated[key] = str(value)
-
-    if updated:
-        return f"{path}?{urlencode(updated)}"
-    return path
-
-
 def mock_web_input_func(data):
     def _mock_web_input(*args, **kwargs):
         return web.storage(kwargs | data)
@@ -51,10 +38,11 @@ def legacy_get_work_editions_json(current_site, data=None):
 
     with (
         patch("openlibrary.plugins.openlibrary.api.web.ctx", ctx),
+        patch("openlibrary.plugins.openlibrary.api.site") as site_context,
         patch("openlibrary.plugins.openlibrary.api.web.input", side_effect=mock_web_input_func(data)),
-        patch("openlibrary.plugins.openlibrary.api.web.changequery", side_effect=lambda **kw: changequery(path, data, **kw)),
         pytest.deprecated_call(match="migrated to fastapi"),
     ):
+        site_context.get.return_value = current_site
         return json.loads(legacy_api.work_editions().GET("/works/OL123W")["rawtext"])
 
 
@@ -66,10 +54,11 @@ def legacy_get_author_works_json(current_site, data=None):
 
     with (
         patch("openlibrary.plugins.openlibrary.api.web.ctx", ctx),
+        patch("openlibrary.plugins.openlibrary.api.site") as site_context,
         patch("openlibrary.plugins.openlibrary.api.web.input", side_effect=mock_web_input_func(data)),
-        patch("openlibrary.plugins.openlibrary.api.web.changequery", side_effect=lambda **kw: changequery(path, data, **kw)),
         pytest.deprecated_call(match="migrated to fastapi"),
     ):
+        site_context.get.return_value = current_site
         return json.loads(legacy_api.author_works().GET("/authors/OL456A")["rawtext"])
 
 
@@ -79,7 +68,7 @@ class TestWorkEditions:
         entries = [{"key": "/books/OL1M", "title": "Test Edition"}]
         current_site = make_site(work, ["/books/OL1M"], entries)
 
-        with patch("openlibrary.fastapi.internal.api.site") as site_context:
+        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
             site_context.get.return_value = current_site
             response = fastapi_client.get("/works/OL123W/editions.json")
 
@@ -108,7 +97,7 @@ class TestWorkEditions:
         entries = [{"key": "/books/OL1M"}]
         current_site = make_site(work, ["/books/OL1M"], entries)
 
-        with patch("openlibrary.fastapi.internal.api.site") as site_context:
+        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
             site_context.get.return_value = current_site
             response = fastapi_client.get("/works/OL123W/editions.json?limit=5000&offset=25")
 
@@ -128,13 +117,25 @@ class TestWorkEditions:
             }
         )
 
-    def test_work_editions_falls_back_for_invalid_pagination(self, fastapi_client):
+    def test_work_editions_rejects_invalid_pagination(self, fastapi_client):
         work = make_doc("/works/OL123W", "/type/work", edition_count=0)
         current_site = make_site(work, [], [])
 
-        with patch("openlibrary.fastapi.internal.api.site") as site_context:
+        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
             site_context.get.return_value = current_site
             response = fastapi_client.get("/works/OL123W/editions.json?limit=abc&offset=xyz")
+
+        assert response.status_code == 422
+        current_site.get.assert_not_called()
+        current_site.things.assert_not_called()
+
+    def test_work_editions_zero_limit_uses_legacy_default(self, fastapi_client):
+        work = make_doc("/works/OL123W", "/type/work", edition_count=0)
+        current_site = make_site(work, [], [])
+
+        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
+            site_context.get.return_value = current_site
+            response = fastapi_client.get("/works/OL123W/editions.json?limit=0")
 
         assert response.status_code == 200
         current_site.things.assert_called_once_with(
@@ -146,11 +147,29 @@ class TestWorkEditions:
             }
         )
 
+    def test_work_editions_accepts_negative_offset(self, fastapi_client):
+        work = make_doc("/works/OL123W", "/type/work", edition_count=0)
+        current_site = make_site(work, [], [])
+
+        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
+            site_context.get.return_value = current_site
+            response = fastapi_client.get("/works/OL123W/editions.json?limit=10&offset=-5")
+
+        assert response.status_code == 200
+        current_site.things.assert_called_once_with(
+            {
+                "type": "/type/edition",
+                "works": "/works/OL123W",
+                "limit": 10,
+                "offset": -5,
+            }
+        )
+
     @pytest.mark.parametrize("doc", [None, make_doc("/authors/OL1A", "/type/author")])
     def test_work_editions_returns_legacy_json_404(self, fastapi_client, doc):
         current_site = make_site(doc, [], [])
 
-        with patch("openlibrary.fastapi.internal.api.site") as site_context:
+        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
             site_context.get.return_value = current_site
             response = fastapi_client.get("/works/OL123W/editions.json")
 
@@ -162,7 +181,7 @@ class TestWorkEditions:
     def test_work_editions_allows_zero_id_and_returns_legacy_json_404(self, fastapi_client):
         current_site = make_site(None, [], [])
 
-        with patch("openlibrary.fastapi.internal.api.site") as site_context:
+        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
             site_context.get.return_value = current_site
             response = fastapi_client.get("/works/OL0W/editions.json")
 
@@ -181,7 +200,7 @@ class TestWorkEditions:
         legacy_response = legacy_get_work_editions_json(legacy_site, data)
 
         fastapi_site = make_site(work, ["/books/OL1M"], entries)
-        with patch("openlibrary.fastapi.internal.api.site") as site_context:
+        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
             site_context.get.return_value = fastapi_site
             fastapi_response = fastapi_client.get("/works/OL123W/editions.json?limit=1&offset=0")
 
@@ -195,7 +214,7 @@ class TestAuthorWorks:
         entries = [{"key": "/works/OL1W", "title": "Test Work"}]
         current_site = make_site(author, ["/works/OL1W"], entries)
 
-        with patch("openlibrary.fastapi.internal.api.site") as site_context:
+        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
             site_context.get.return_value = current_site
             response = fastapi_client.get("/authors/OL456A/works.json")
 
@@ -225,7 +244,7 @@ class TestAuthorWorks:
         entries = [{"key": "/works/OL1W"}]
         current_site = make_site(author, ["/works/OL1W"], entries)
 
-        with patch("openlibrary.fastapi.internal.api.site") as site_context:
+        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
             site_context.get.return_value = current_site
             response = fastapi_client.get("/authors/OL456A/works.json?limit=5000&offset=25")
 
@@ -249,7 +268,7 @@ class TestAuthorWorks:
         author = make_doc("/authors/OL456A", "/type/author", get_work_count=Mock(return_value=0))
         current_site = make_site(author, [], [])
 
-        with patch("openlibrary.fastapi.internal.api.site") as site_context:
+        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
             site_context.get.return_value = current_site
             response = fastapi_client.get("/authors/OL456A/works.json?limit=0&offset=0")
 
@@ -263,11 +282,41 @@ class TestAuthorWorks:
             }
         )
 
+    def test_author_works_rejects_invalid_pagination(self, fastapi_client):
+        author = make_doc("/authors/OL456A", "/type/author", get_work_count=Mock(return_value=0))
+        current_site = make_site(author, [], [])
+
+        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
+            site_context.get.return_value = current_site
+            response = fastapi_client.get("/authors/OL456A/works.json?limit=abc&offset=xyz")
+
+        assert response.status_code == 422
+        current_site.get.assert_not_called()
+        current_site.things.assert_not_called()
+
+    def test_author_works_accepts_negative_offset(self, fastapi_client):
+        author = make_doc("/authors/OL456A", "/type/author", get_work_count=Mock(return_value=0))
+        current_site = make_site(author, [], [])
+
+        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
+            site_context.get.return_value = current_site
+            response = fastapi_client.get("/authors/OL456A/works.json?limit=10&offset=-5")
+
+        assert response.status_code == 200
+        current_site.things.assert_called_once_with(
+            {
+                "type": "/type/work",
+                "authors": {"author": {"key": "/authors/OL456A"}},
+                "limit": 10,
+                "offset": -5,
+            }
+        )
+
     @pytest.mark.parametrize("doc", [None, make_doc("/works/OL1W", "/type/work")])
     def test_author_works_returns_legacy_json_404(self, fastapi_client, doc):
         current_site = make_site(doc, [], [])
 
-        with patch("openlibrary.fastapi.internal.api.site") as site_context:
+        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
             site_context.get.return_value = current_site
             response = fastapi_client.get("/authors/OL456A/works.json")
 
@@ -279,7 +328,7 @@ class TestAuthorWorks:
     def test_author_works_allows_zero_id_and_returns_legacy_json_404(self, fastapi_client):
         current_site = make_site(None, [], [])
 
-        with patch("openlibrary.fastapi.internal.api.site") as site_context:
+        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
             site_context.get.return_value = current_site
             response = fastapi_client.get("/authors/OL0A/works.json")
 
@@ -298,7 +347,7 @@ class TestAuthorWorks:
         legacy_response = legacy_get_author_works_json(legacy_site, data)
 
         fastapi_site = make_site(author, ["/works/OL1W"], entries)
-        with patch("openlibrary.fastapi.internal.api.site") as site_context:
+        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
             site_context.get.return_value = fastapi_site
             fastapi_response = fastapi_client.get("/authors/OL456A/works.json?limit=1&offset=0")
 

--- a/openlibrary/tests/fastapi/test_work_editions_author_works.py
+++ b/openlibrary/tests/fastapi/test_work_editions_author_works.py
@@ -105,7 +105,7 @@ class TestWorkEditions:
         assert response.json()["links"] == {
             "self": "/works/OL123W/editions.json?limit=1000&offset=25",
             "work": "/works/OL123W",
-            "prev": "/works/OL123W/editions.json?limit=1000&offset=-975",
+            "prev": "/works/OL123W/editions.json?limit=1000&offset=0",
             "next": "/works/OL123W/editions.json?limit=1000&offset=1025",
         }
         current_site.things.assert_called_once_with(
@@ -147,7 +147,7 @@ class TestWorkEditions:
             }
         )
 
-    def test_work_editions_accepts_negative_offset(self, fastapi_client):
+    def test_work_editions_rejects_negative_offset(self, fastapi_client):
         work = make_doc("/works/OL123W", "/type/work", edition_count=0)
         current_site = make_site(work, [], [])
 
@@ -155,15 +155,10 @@ class TestWorkEditions:
             site_context.get.return_value = current_site
             response = fastapi_client.get("/works/OL123W/editions.json?limit=10&offset=-5")
 
-        assert response.status_code == 200
-        current_site.things.assert_called_once_with(
-            {
-                "type": "/type/edition",
-                "works": "/works/OL123W",
-                "limit": 10,
-                "offset": -5,
-            }
-        )
+        assert response.status_code == 422
+        current_site.get.assert_not_called()
+        current_site.things.assert_not_called()
+        current_site.get_many.assert_not_called()
 
     @pytest.mark.parametrize("doc", [None, make_doc("/authors/OL1A", "/type/author")])
     def test_work_editions_returns_404(self, fastapi_client, doc):
@@ -250,7 +245,7 @@ class TestAuthorWorks:
         assert response.json()["links"] == {
             "self": "/authors/OL456A/works.json?limit=1000&offset=25",
             "author": "/authors/OL456A",
-            "prev": "/authors/OL456A/works.json?limit=1000&offset=-975",
+            "prev": "/authors/OL456A/works.json?limit=1000&offset=0",
             "next": "/authors/OL456A/works.json?limit=1000&offset=1025",
         }
         current_site.things.assert_called_once_with(
@@ -292,7 +287,7 @@ class TestAuthorWorks:
         current_site.get.assert_not_called()
         current_site.things.assert_not_called()
 
-    def test_author_works_accepts_negative_offset(self, fastapi_client):
+    def test_author_works_rejects_negative_offset(self, fastapi_client):
         author = make_doc("/authors/OL456A", "/type/author", get_work_count=Mock(return_value=0))
         current_site = make_site(author, [], [])
 
@@ -300,15 +295,10 @@ class TestAuthorWorks:
             site_context.get.return_value = current_site
             response = fastapi_client.get("/authors/OL456A/works.json?limit=10&offset=-5")
 
-        assert response.status_code == 200
-        current_site.things.assert_called_once_with(
-            {
-                "type": "/type/work",
-                "authors": {"author": {"key": "/authors/OL456A"}},
-                "limit": 10,
-                "offset": -5,
-            }
-        )
+        assert response.status_code == 422
+        current_site.get.assert_not_called()
+        current_site.things.assert_not_called()
+        current_site.get_many.assert_not_called()
 
     @pytest.mark.parametrize("doc", [None, make_doc("/works/OL1W", "/type/work")])
     def test_author_works_returns_404(self, fastapi_client, doc):

--- a/openlibrary/tests/fastapi/test_work_editions_author_works.py
+++ b/openlibrary/tests/fastapi/test_work_editions_author_works.py
@@ -1,0 +1,284 @@
+"""Tests for the FastAPI work editions and author works endpoints."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+from urllib.parse import urlencode
+
+import pytest
+import web
+
+from openlibrary.plugins.openlibrary import api as legacy_api
+
+
+def make_doc(key: str, type_key: str, **attrs):
+    return SimpleNamespace(key=key, type=SimpleNamespace(key=type_key), **attrs)
+
+
+def make_site(doc, keys, entries):
+    current_site = Mock()
+    current_site.get.return_value = doc
+    current_site.things.return_value = keys
+    current_site.get_many.return_value = entries
+    return current_site
+
+
+def changequery(path: str, query: dict[str, str], **kw) -> str:
+    updated = dict(query)
+    for key, value in kw.items():
+        if value is None:
+            updated.pop(key, None)
+        else:
+            updated[key] = str(value)
+
+    if updated:
+        return f"{path}?{urlencode(updated)}"
+    return path
+
+
+def mock_web_input_func(data):
+    def _mock_web_input(*args, **kwargs):
+        return web.storage(kwargs | data)
+
+    return _mock_web_input
+
+
+def legacy_get_work_editions_json(current_site, data=None):
+    data = data or {}
+    path = "/works/OL123W/editions.json"
+    fullpath = path if not data else f"{path}?{urlencode(data)}"
+
+    web.ctx.site = current_site
+    web.ctx.path = path
+    web.ctx.fullpath = fullpath
+
+    with (
+        patch("openlibrary.plugins.openlibrary.api.web.input", side_effect=mock_web_input_func(data)),
+        patch("openlibrary.plugins.openlibrary.api.web.changequery", side_effect=lambda **kw: changequery(path, data, **kw)),
+        pytest.deprecated_call(match="migrated to fastapi"),
+    ):
+        return json.loads(legacy_api.work_editions().GET("/works/OL123W")["rawtext"])
+
+
+def legacy_get_author_works_json(current_site, data=None):
+    data = data or {}
+    path = "/authors/OL456A/works.json"
+    fullpath = path if not data else f"{path}?{urlencode(data)}"
+
+    web.ctx.site = current_site
+    web.ctx.path = path
+    web.ctx.fullpath = fullpath
+
+    with (
+        patch("openlibrary.plugins.openlibrary.api.web.input", side_effect=mock_web_input_func(data)),
+        patch("openlibrary.plugins.openlibrary.api.web.changequery", side_effect=lambda **kw: changequery(path, data, **kw)),
+        pytest.deprecated_call(match="migrated to fastapi"),
+    ):
+        return json.loads(legacy_api.author_works().GET("/authors/OL456A")["rawtext"])
+
+
+class TestWorkEditions:
+    def test_work_editions_uses_default_pagination(self, fastapi_client):
+        work = make_doc("/works/OL123W", "/type/work", edition_count=1)
+        entries = [{"key": "/books/OL1M", "title": "Test Edition"}]
+        current_site = make_site(work, ["/books/OL1M"], entries)
+
+        with patch("openlibrary.fastapi.internal.api.site") as site_context:
+            site_context.get.return_value = current_site
+            response = fastapi_client.get("/works/OL123W/editions.json")
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "links": {
+                "self": "/works/OL123W/editions.json",
+                "work": "/works/OL123W",
+            },
+            "size": 1,
+            "entries": entries,
+        }
+        current_site.get.assert_called_once_with("/works/OL123W")
+        current_site.things.assert_called_once_with(
+            {
+                "type": "/type/edition",
+                "works": "/works/OL123W",
+                "limit": 50,
+                "offset": 0,
+            }
+        )
+        current_site.get_many.assert_called_once_with(["/books/OL1M"], raw=True)
+
+    def test_work_editions_caps_limit_and_preserves_legacy_links(self, fastapi_client):
+        work = make_doc("/works/OL123W", "/type/work", edition_count=2000)
+        entries = [{"key": "/books/OL1M"}]
+        current_site = make_site(work, ["/books/OL1M"], entries)
+
+        with patch("openlibrary.fastapi.internal.api.site") as site_context:
+            site_context.get.return_value = current_site
+            response = fastapi_client.get("/works/OL123W/editions.json?limit=5000&offset=25")
+
+        assert response.status_code == 200
+        assert response.json()["links"] == {
+            "self": "/works/OL123W/editions.json?limit=5000&offset=25",
+            "work": "/works/OL123W",
+            "prev": "/works/OL123W/editions.json?limit=5000&offset=-975",
+            "next": "/works/OL123W/editions.json?limit=5000&offset=1025",
+        }
+        current_site.things.assert_called_once_with(
+            {
+                "type": "/type/edition",
+                "works": "/works/OL123W",
+                "limit": 1000,
+                "offset": 25,
+            }
+        )
+
+    def test_work_editions_falls_back_for_invalid_pagination(self, fastapi_client):
+        work = make_doc("/works/OL123W", "/type/work", edition_count=0)
+        current_site = make_site(work, [], [])
+
+        with patch("openlibrary.fastapi.internal.api.site") as site_context:
+            site_context.get.return_value = current_site
+            response = fastapi_client.get("/works/OL123W/editions.json?limit=abc&offset=xyz")
+
+        assert response.status_code == 200
+        current_site.things.assert_called_once_with(
+            {
+                "type": "/type/edition",
+                "works": "/works/OL123W",
+                "limit": 50,
+                "offset": 0,
+            }
+        )
+
+    @pytest.mark.parametrize("doc", [None, make_doc("/authors/OL1A", "/type/author")])
+    def test_work_editions_returns_legacy_json_404(self, fastapi_client, doc):
+        current_site = make_site(doc, [], [])
+
+        with patch("openlibrary.fastapi.internal.api.site") as site_context:
+            site_context.get.return_value = current_site
+            response = fastapi_client.get("/works/OL123W/editions.json")
+
+        assert response.status_code == 404
+        assert response.json() == {}
+        current_site.things.assert_not_called()
+        current_site.get_many.assert_not_called()
+
+    def test_work_editions_response_matches_legacy(self, fastapi_client):
+        work = make_doc("/works/OL123W", "/type/work", edition_count=2)
+        entries = [{"key": "/books/OL1M"}]
+        data = {"limit": "1", "offset": "0"}
+
+        legacy_site = make_site(work, ["/books/OL1M"], entries)
+        legacy_response = legacy_get_work_editions_json(legacy_site, data)
+
+        fastapi_site = make_site(work, ["/books/OL1M"], entries)
+        with patch("openlibrary.fastapi.internal.api.site") as site_context:
+            site_context.get.return_value = fastapi_site
+            fastapi_response = fastapi_client.get("/works/OL123W/editions.json?limit=1&offset=0")
+
+        assert fastapi_response.status_code == 200
+        assert fastapi_response.json() == legacy_response
+
+
+class TestAuthorWorks:
+    def test_author_works_uses_default_pagination_and_work_count(self, fastapi_client):
+        author = make_doc("/authors/OL456A", "/type/author", get_work_count=Mock(return_value=1))
+        entries = [{"key": "/works/OL1W", "title": "Test Work"}]
+        current_site = make_site(author, ["/works/OL1W"], entries)
+
+        with patch("openlibrary.fastapi.internal.api.site") as site_context:
+            site_context.get.return_value = current_site
+            response = fastapi_client.get("/authors/OL456A/works.json")
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "links": {
+                "self": "/authors/OL456A/works.json",
+                "author": "/authors/OL456A",
+            },
+            "size": 1,
+            "entries": entries,
+        }
+        current_site.get.assert_called_once_with("/authors/OL456A")
+        current_site.things.assert_called_once_with(
+            {
+                "type": "/type/work",
+                "authors": {"author": {"key": "/authors/OL456A"}},
+                "limit": 50,
+                "offset": 0,
+            }
+        )
+        current_site.get_many.assert_called_once_with(["/works/OL1W"], raw=True)
+        author.get_work_count.assert_called_once_with()
+
+    def test_author_works_caps_limit_and_preserves_legacy_links(self, fastapi_client):
+        author = make_doc("/authors/OL456A", "/type/author", get_work_count=Mock(return_value=2000))
+        entries = [{"key": "/works/OL1W"}]
+        current_site = make_site(author, ["/works/OL1W"], entries)
+
+        with patch("openlibrary.fastapi.internal.api.site") as site_context:
+            site_context.get.return_value = current_site
+            response = fastapi_client.get("/authors/OL456A/works.json?limit=5000&offset=25")
+
+        assert response.status_code == 200
+        assert response.json()["links"] == {
+            "self": "/authors/OL456A/works.json?limit=5000&offset=25",
+            "author": "/authors/OL456A",
+            "prev": "/authors/OL456A/works.json?limit=5000&offset=-975",
+            "next": "/authors/OL456A/works.json?limit=5000&offset=1025",
+        }
+        current_site.things.assert_called_once_with(
+            {
+                "type": "/type/work",
+                "authors": {"author": {"key": "/authors/OL456A"}},
+                "limit": 1000,
+                "offset": 25,
+            }
+        )
+
+    def test_author_works_accepts_zero_limit_like_legacy(self, fastapi_client):
+        author = make_doc("/authors/OL456A", "/type/author", get_work_count=Mock(return_value=0))
+        current_site = make_site(author, [], [])
+
+        with patch("openlibrary.fastapi.internal.api.site") as site_context:
+            site_context.get.return_value = current_site
+            response = fastapi_client.get("/authors/OL456A/works.json?limit=0&offset=0")
+
+        assert response.status_code == 200
+        current_site.things.assert_called_once_with(
+            {
+                "type": "/type/work",
+                "authors": {"author": {"key": "/authors/OL456A"}},
+                "limit": 0,
+                "offset": 0,
+            }
+        )
+
+    @pytest.mark.parametrize("doc", [None, make_doc("/works/OL1W", "/type/work")])
+    def test_author_works_returns_legacy_json_404(self, fastapi_client, doc):
+        current_site = make_site(doc, [], [])
+
+        with patch("openlibrary.fastapi.internal.api.site") as site_context:
+            site_context.get.return_value = current_site
+            response = fastapi_client.get("/authors/OL456A/works.json")
+
+        assert response.status_code == 404
+        assert response.json() == {}
+        current_site.things.assert_not_called()
+        current_site.get_many.assert_not_called()
+
+    def test_author_works_response_matches_legacy(self, fastapi_client):
+        author = make_doc("/authors/OL456A", "/type/author", get_work_count=Mock(return_value=2))
+        entries = [{"key": "/works/OL1W"}]
+        data = {"limit": "1", "offset": "0"}
+
+        legacy_site = make_site(author, ["/works/OL1W"], entries)
+        legacy_response = legacy_get_author_works_json(legacy_site, data)
+
+        fastapi_site = make_site(author, ["/works/OL1W"], entries)
+        with patch("openlibrary.fastapi.internal.api.site") as site_context:
+            site_context.get.return_value = fastapi_site
+            fastapi_response = fastapi_client.get("/authors/OL456A/works.json?limit=1&offset=0")
+
+        assert fastapi_response.status_code == 200
+        assert fastapi_response.json() == legacy_response

--- a/openlibrary/tests/fastapi/test_work_editions_author_works.py
+++ b/openlibrary/tests/fastapi/test_work_editions_author_works.py
@@ -1,341 +1,275 @@
 """Tests for the FastAPI work editions and author works endpoints."""
 
-import json
-from types import SimpleNamespace
 from unittest.mock import Mock, patch
-from urllib.parse import urlencode
 
 import pytest
-import web
+from starlette.datastructures import URL
 
 from openlibrary.plugins.openlibrary import api as legacy_api
 
 
-def make_doc(key: str, type_key: str, **attrs):
-    return SimpleNamespace(key=key, type=SimpleNamespace(key=type_key), **attrs)
-
-
-def make_site(doc, keys, entries):
+def make_test_site(
+    doc_key: str,
+    doc_type: str,
+    thing_keys: list[str] | None = None,
+    entries: list[dict] | None = None,
+    **doc_attrs,
+) -> Mock:
+    """Create a mock site with a doc, thing query results, and get_many entries."""
+    doc = Mock(key=doc_key, type=Mock(key=doc_type), spec=[])
+    for k, v in doc_attrs.items():
+        setattr(doc, k, v)
     current_site = Mock()
     current_site.get.return_value = doc
-    current_site.things.return_value = keys
-    current_site.get_many.return_value = entries
+    current_site.things.return_value = thing_keys or []
+    current_site.get_many.return_value = entries or []
     return current_site
 
 
-def mock_web_input_func(data):
-    def _mock_web_input(*args, **kwargs):
-        return web.storage(kwargs | data)
-
-    return _mock_web_input
-
-
-def legacy_get_work_editions_json(current_site, data=None):
-    data = data or {}
-    path = "/works/OL123W/editions.json"
-    fullpath = path if not data else f"{path}?{urlencode(data)}"
-    ctx = web.storage(site=current_site, path=path, fullpath=fullpath)
-
-    with (
-        patch("openlibrary.plugins.openlibrary.api.web.ctx", ctx),
-        patch("openlibrary.plugins.openlibrary.api.site") as site_context,
-        patch("openlibrary.plugins.openlibrary.api.web.input", side_effect=mock_web_input_func(data)),
-        pytest.deprecated_call(match="migrated to fastapi"),
-    ):
-        site_context.get.return_value = current_site
-        return json.loads(legacy_api.work_editions().GET("/works/OL123W")["rawtext"])
-
-
-def legacy_get_author_works_json(current_site, data=None):
-    data = data or {}
-    path = "/authors/OL456A/works.json"
-    fullpath = path if not data else f"{path}?{urlencode(data)}"
-    ctx = web.storage(site=current_site, path=path, fullpath=fullpath)
-
-    with (
-        patch("openlibrary.plugins.openlibrary.api.web.ctx", ctx),
-        patch("openlibrary.plugins.openlibrary.api.site") as site_context,
-        patch("openlibrary.plugins.openlibrary.api.web.input", side_effect=mock_web_input_func(data)),
-        pytest.deprecated_call(match="migrated to fastapi"),
-    ):
-        site_context.get.return_value = current_site
-        return json.loads(legacy_api.author_works().GET("/authors/OL456A")["rawtext"])
+@pytest.fixture
+def patched_site():
+    with patch("openlibrary.plugins.openlibrary.api.site") as m:
+        yield m
 
 
 class TestWorkEditions:
-    def test_work_editions_uses_default_pagination(self, fastapi_client):
-        work = make_doc("/works/OL123W", "/type/work", edition_count=1)
-        entries = [{"key": "/books/OL1M", "title": "Test Edition"}]
-        current_site = make_site(work, ["/books/OL1M"], entries)
+    DOC_KEY = "/works/OL123W"
+    DOC_TYPE = "/type/work"
+    ENDPOINT = "/works/OL123W/editions.json"
+    LINK_KEY = "work"
 
-        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
-            site_context.get.return_value = current_site
-            response = fastapi_client.get("/works/OL123W/editions.json")
+    def _things_query(self, limit, offset):
+        return {
+            "type": "/type/edition",
+            "works": self.DOC_KEY,
+            "limit": limit,
+            "offset": offset,
+        }
+
+    def test_uses_default_pagination(self, fastapi_client, patched_site):
+        entries = [{"key": "/books/OL1M", "title": "Test Edition"}]
+        current_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, edition_count=1, thing_keys=["/books/OL1M"], entries=entries)
+        patched_site.get.return_value = current_site
+        response = fastapi_client.get(self.ENDPOINT)
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "links": {"self": self.ENDPOINT, self.LINK_KEY: self.DOC_KEY},
+            "size": 1,
+            "entries": entries,
+        }
+        current_site.things.assert_called_once_with(self._things_query(50, 0))
+        current_site.get_many.assert_called_once_with(["/books/OL1M"], raw=True)
+
+    def test_caps_limit_and_preserves_legacy_links(self, fastapi_client, patched_site):
+        entries = [{"key": "/books/OL1M"}]
+        current_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, edition_count=2000, thing_keys=["/books/OL1M"], entries=entries)
+        patched_site.get.return_value = current_site
+        response = fastapi_client.get(f"{self.ENDPOINT}?limit=1000&offset=25")
 
         assert response.status_code == 200
         assert response.json() == {
             "links": {
-                "self": "/works/OL123W/editions.json",
-                "work": "/works/OL123W",
+                "self": f"{self.ENDPOINT}?limit=1000&offset=25",
+                self.LINK_KEY: self.DOC_KEY,
+                "prev": f"{self.ENDPOINT}?limit=1000&offset=0",
+                "next": f"{self.ENDPOINT}?limit=1000&offset=1025",
             },
+            "size": 2000,
+            "entries": entries,
+        }
+        current_site.things.assert_called_once_with(self._things_query(1000, 25))
+
+    def test_rejects_invalid_pagination(self, fastapi_client, patched_site):
+        current_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, edition_count=0)
+        patched_site.get.return_value = current_site
+        response = fastapi_client.get(f"{self.ENDPOINT}?limit=abc&offset=xyz")
+
+        assert response.status_code == 422
+        current_site.get.assert_not_called()
+
+    def test_zero_limit_defaults_to_50(self, fastapi_client, patched_site):
+        entries = [{"key": "/books/OL1M"}]
+        current_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, edition_count=1, thing_keys=["/books/OL1M"], entries=entries)
+        patched_site.get.return_value = current_site
+        response = fastapi_client.get(f"{self.ENDPOINT}?limit=0")
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "links": {"self": f"{self.ENDPOINT}?limit=0", self.LINK_KEY: self.DOC_KEY},
             "size": 1,
             "entries": entries,
         }
-        current_site.get.assert_called_once_with("/works/OL123W")
-        current_site.things.assert_called_once_with(
-            {
-                "type": "/type/edition",
-                "works": "/works/OL123W",
-                "limit": 50,
-                "offset": 0,
-            }
-        )
-        current_site.get_many.assert_called_once_with(["/books/OL1M"], raw=True)
+        current_site.things.assert_called_once_with(self._things_query(50, 0))
 
-    def test_work_editions_caps_limit_and_preserves_legacy_links(self, fastapi_client):
-        work = make_doc("/works/OL123W", "/type/work", edition_count=2000)
-        entries = [{"key": "/books/OL1M"}]
-        current_site = make_site(work, ["/books/OL1M"], entries)
-
-        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
-            site_context.get.return_value = current_site
-            response = fastapi_client.get("/works/OL123W/editions.json?limit=1000&offset=25")
-
-        assert response.status_code == 200
-        assert response.json()["links"] == {
-            "self": "/works/OL123W/editions.json?limit=1000&offset=25",
-            "work": "/works/OL123W",
-            "prev": "/works/OL123W/editions.json?limit=1000&offset=0",
-            "next": "/works/OL123W/editions.json?limit=1000&offset=1025",
-        }
-        current_site.things.assert_called_once_with(
-            {
-                "type": "/type/edition",
-                "works": "/works/OL123W",
-                "limit": 1000,
-                "offset": 25,
-            }
-        )
-
-    def test_work_editions_rejects_invalid_pagination(self, fastapi_client):
-        work = make_doc("/works/OL123W", "/type/work", edition_count=0)
-        current_site = make_site(work, [], [])
-
-        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
-            site_context.get.return_value = current_site
-            response = fastapi_client.get("/works/OL123W/editions.json?limit=abc&offset=xyz")
+    def test_rejects_negative_offset(self, fastapi_client, patched_site):
+        current_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, edition_count=0)
+        patched_site.get.return_value = current_site
+        response = fastapi_client.get(f"{self.ENDPOINT}?limit=10&offset=-5")
 
         assert response.status_code == 422
         current_site.get.assert_not_called()
-        current_site.things.assert_not_called()
 
-    def test_work_editions_zero_limit_uses_legacy_default(self, fastapi_client):
-        work = make_doc("/works/OL123W", "/type/work", edition_count=0)
-        current_site = make_site(work, [], [])
-
-        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
-            site_context.get.return_value = current_site
-            response = fastapi_client.get("/works/OL123W/editions.json?limit=0")
-
-        assert response.status_code == 200
-        current_site.things.assert_called_once_with(
-            {
-                "type": "/type/edition",
-                "works": "/works/OL123W",
-                "limit": 50,
-                "offset": 0,
-            }
-        )
-
-    def test_work_editions_rejects_negative_offset(self, fastapi_client):
-        work = make_doc("/works/OL123W", "/type/work", edition_count=0)
-        current_site = make_site(work, [], [])
-
-        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
-            site_context.get.return_value = current_site
-            response = fastapi_client.get("/works/OL123W/editions.json?limit=10&offset=-5")
-
-        assert response.status_code == 422
-        current_site.get.assert_not_called()
-        current_site.things.assert_not_called()
-        current_site.get_many.assert_not_called()
-
-    @pytest.mark.parametrize("doc", [None, make_doc("/authors/OL1A", "/type/author")])
-    def test_work_editions_returns_404(self, fastapi_client, doc):
-        current_site = make_site(doc, [], [])
-
-        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
-            site_context.get.return_value = current_site
-            response = fastapi_client.get("/works/OL123W/editions.json")
+    @pytest.mark.parametrize("doc_key", [None, "/authors/OL1A"])
+    def test_returns_404_for_missing_or_wrong_type(self, fastapi_client, doc_key, patched_site):
+        if doc_key is None:
+            current_site = make_test_site(self.DOC_KEY, self.DOC_TYPE)
+            current_site.get.return_value = None
+        else:
+            current_site = make_test_site(doc_key, "/type/author")
+        patched_site.get.return_value = current_site
+        response = fastapi_client.get(self.ENDPOINT)
 
         assert response.status_code == 404
         current_site.things.assert_not_called()
-        current_site.get_many.assert_not_called()
 
-    def test_work_editions_allows_zero_id_and_returns_404(self, fastapi_client):
-        current_site = make_site(None, [], [])
-
-        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
-            site_context.get.return_value = current_site
-            response = fastapi_client.get("/works/OL0W/editions.json")
+    def test_allows_zero_olid_but_returns_404(self, fastapi_client, patched_site):
+        current_site = make_test_site(self.DOC_KEY, self.DOC_TYPE)
+        current_site.get.return_value = None
+        patched_site.get.return_value = current_site
+        response = fastapi_client.get("/works/OL0W/editions.json")
 
         assert response.status_code == 404
         current_site.get.assert_called_once_with("/works/OL0W")
         current_site.things.assert_not_called()
-        current_site.get_many.assert_not_called()
 
-    def test_work_editions_response_matches_legacy(self, fastapi_client):
-        work = make_doc("/works/OL123W", "/type/work", edition_count=2)
+    def test_response_matches_legacy(self, fastapi_client, patched_site):
         entries = [{"key": "/books/OL1M"}]
-        data = {"limit": "1", "offset": "0"}
 
-        legacy_site = make_site(work, ["/books/OL1M"], entries)
-        legacy_response = legacy_get_work_editions_json(legacy_site, data)
+        legacy_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, edition_count=2, thing_keys=["/books/OL1M"], entries=entries)
+        patched_site.get.return_value = legacy_site
+        legacy_response = legacy_api.work_editions.get_editions_data(
+            self.DOC_KEY,
+            url=URL(f"{self.ENDPOINT}?limit=1&offset=0"),
+            limit=1,
+            offset=0,
+        )
 
-        fastapi_site = make_site(work, ["/books/OL1M"], entries)
-        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
-            site_context.get.return_value = fastapi_site
-            fastapi_response = fastapi_client.get("/works/OL123W/editions.json?limit=1&offset=0")
+        fastapi_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, edition_count=2, thing_keys=["/books/OL1M"], entries=entries)
+        patched_site.get.return_value = fastapi_site
+        fastapi_response = fastapi_client.get(f"{self.ENDPOINT}?limit=1&offset=0")
 
         assert fastapi_response.status_code == 200
         assert fastapi_response.json() == legacy_response
 
 
 class TestAuthorWorks:
-    def test_author_works_uses_default_pagination_and_work_count(self, fastapi_client):
-        author = make_doc("/authors/OL456A", "/type/author", get_work_count=Mock(return_value=1))
-        entries = [{"key": "/works/OL1W", "title": "Test Work"}]
-        current_site = make_site(author, ["/works/OL1W"], entries)
+    DOC_KEY = "/authors/OL456A"
+    DOC_TYPE = "/type/author"
+    ENDPOINT = "/authors/OL456A/works.json"
+    LINK_KEY = "author"
 
-        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
-            site_context.get.return_value = current_site
-            response = fastapi_client.get("/authors/OL456A/works.json")
+    def _things_query(self, limit, offset):
+        return {
+            "type": "/type/work",
+            "authors": {"author": {"key": self.DOC_KEY}},
+            "limit": limit,
+            "offset": offset,
+        }
+
+    def test_uses_default_pagination(self, fastapi_client, patched_site):
+        entries = [{"key": "/works/OL1W", "title": "Test Work"}]
+        current_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, get_work_count=Mock(return_value=1), thing_keys=["/works/OL1W"], entries=entries)
+        patched_site.get.return_value = current_site
+        response = fastapi_client.get(self.ENDPOINT)
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "links": {"self": self.ENDPOINT, self.LINK_KEY: self.DOC_KEY},
+            "size": 1,
+            "entries": entries,
+        }
+        current_site.things.assert_called_once_with(self._things_query(50, 0))
+        current_site.get_many.assert_called_once_with(["/works/OL1W"], raw=True)
+        current_site.get.return_value.get_work_count.assert_called_once_with()
+
+    def test_caps_limit_and_preserves_legacy_links(self, fastapi_client, patched_site):
+        entries = [{"key": "/works/OL1W"}]
+        current_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, get_work_count=Mock(return_value=2000), thing_keys=["/works/OL1W"], entries=entries)
+        patched_site.get.return_value = current_site
+        response = fastapi_client.get(f"{self.ENDPOINT}?limit=1000&offset=25")
 
         assert response.status_code == 200
         assert response.json() == {
             "links": {
-                "self": "/authors/OL456A/works.json",
-                "author": "/authors/OL456A",
+                "self": f"{self.ENDPOINT}?limit=1000&offset=25",
+                self.LINK_KEY: self.DOC_KEY,
+                "prev": f"{self.ENDPOINT}?limit=1000&offset=0",
+                "next": f"{self.ENDPOINT}?limit=1000&offset=1025",
             },
+            "size": 2000,
+            "entries": entries,
+        }
+        current_site.things.assert_called_once_with(self._things_query(1000, 25))
+
+    def test_zero_limit_passed_through(self, fastapi_client, patched_site):
+        entries = [{"key": "/works/OL1W"}]
+        current_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, get_work_count=Mock(return_value=1), thing_keys=["/works/OL1W"], entries=entries)
+        patched_site.get.return_value = current_site
+        response = fastapi_client.get(f"{self.ENDPOINT}?limit=0&offset=0")
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "links": {"self": f"{self.ENDPOINT}?limit=0&offset=0", self.LINK_KEY: self.DOC_KEY},
             "size": 1,
             "entries": entries,
         }
-        current_site.get.assert_called_once_with("/authors/OL456A")
-        current_site.things.assert_called_once_with(
-            {
-                "type": "/type/work",
-                "authors": {"author": {"key": "/authors/OL456A"}},
-                "limit": 50,
-                "offset": 0,
-            }
-        )
-        current_site.get_many.assert_called_once_with(["/works/OL1W"], raw=True)
-        author.get_work_count.assert_called_once_with()
+        current_site.things.assert_called_once_with(self._things_query(0, 0))
 
-    def test_author_works_caps_limit_and_preserves_legacy_links(self, fastapi_client):
-        author = make_doc("/authors/OL456A", "/type/author", get_work_count=Mock(return_value=2000))
-        entries = [{"key": "/works/OL1W"}]
-        current_site = make_site(author, ["/works/OL1W"], entries)
-
-        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
-            site_context.get.return_value = current_site
-            response = fastapi_client.get("/authors/OL456A/works.json?limit=1000&offset=25")
-
-        assert response.status_code == 200
-        assert response.json()["links"] == {
-            "self": "/authors/OL456A/works.json?limit=1000&offset=25",
-            "author": "/authors/OL456A",
-            "prev": "/authors/OL456A/works.json?limit=1000&offset=0",
-            "next": "/authors/OL456A/works.json?limit=1000&offset=1025",
-        }
-        current_site.things.assert_called_once_with(
-            {
-                "type": "/type/work",
-                "authors": {"author": {"key": "/authors/OL456A"}},
-                "limit": 1000,
-                "offset": 25,
-            }
-        )
-
-    def test_author_works_accepts_zero_limit_like_legacy(self, fastapi_client):
-        author = make_doc("/authors/OL456A", "/type/author", get_work_count=Mock(return_value=0))
-        current_site = make_site(author, [], [])
-
-        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
-            site_context.get.return_value = current_site
-            response = fastapi_client.get("/authors/OL456A/works.json?limit=0&offset=0")
-
-        assert response.status_code == 200
-        current_site.things.assert_called_once_with(
-            {
-                "type": "/type/work",
-                "authors": {"author": {"key": "/authors/OL456A"}},
-                "limit": 0,
-                "offset": 0,
-            }
-        )
-
-    def test_author_works_rejects_invalid_pagination(self, fastapi_client):
-        author = make_doc("/authors/OL456A", "/type/author", get_work_count=Mock(return_value=0))
-        current_site = make_site(author, [], [])
-
-        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
-            site_context.get.return_value = current_site
-            response = fastapi_client.get("/authors/OL456A/works.json?limit=abc&offset=xyz")
+    def test_rejects_invalid_pagination(self, fastapi_client, patched_site):
+        current_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, get_work_count=Mock(return_value=0))
+        patched_site.get.return_value = current_site
+        response = fastapi_client.get(f"{self.ENDPOINT}?limit=abc&offset=xyz")
 
         assert response.status_code == 422
         current_site.get.assert_not_called()
-        current_site.things.assert_not_called()
 
-    def test_author_works_rejects_negative_offset(self, fastapi_client):
-        author = make_doc("/authors/OL456A", "/type/author", get_work_count=Mock(return_value=0))
-        current_site = make_site(author, [], [])
-
-        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
-            site_context.get.return_value = current_site
-            response = fastapi_client.get("/authors/OL456A/works.json?limit=10&offset=-5")
+    def test_rejects_negative_offset(self, fastapi_client, patched_site):
+        current_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, get_work_count=Mock(return_value=0))
+        patched_site.get.return_value = current_site
+        response = fastapi_client.get(f"{self.ENDPOINT}?limit=10&offset=-5")
 
         assert response.status_code == 422
         current_site.get.assert_not_called()
-        current_site.things.assert_not_called()
-        current_site.get_many.assert_not_called()
 
-    @pytest.mark.parametrize("doc", [None, make_doc("/works/OL1W", "/type/work")])
-    def test_author_works_returns_404(self, fastapi_client, doc):
-        current_site = make_site(doc, [], [])
-
-        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
-            site_context.get.return_value = current_site
-            response = fastapi_client.get("/authors/OL456A/works.json")
+    @pytest.mark.parametrize("doc_key", [None, "/works/OL1W"])
+    def test_returns_404_for_missing_or_wrong_type(self, fastapi_client, doc_key, patched_site):
+        if doc_key is None:
+            current_site = make_test_site(self.DOC_KEY, self.DOC_TYPE)
+            current_site.get.return_value = None
+        else:
+            current_site = make_test_site(doc_key, "/type/work")
+        patched_site.get.return_value = current_site
+        response = fastapi_client.get(self.ENDPOINT)
 
         assert response.status_code == 404
         current_site.things.assert_not_called()
-        current_site.get_many.assert_not_called()
 
-    def test_author_works_allows_zero_id_and_returns_404(self, fastapi_client):
-        current_site = make_site(None, [], [])
-
-        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
-            site_context.get.return_value = current_site
-            response = fastapi_client.get("/authors/OL0A/works.json")
+    def test_allows_zero_olid_but_returns_404(self, fastapi_client, patched_site):
+        current_site = make_test_site(self.DOC_KEY, self.DOC_TYPE)
+        current_site.get.return_value = None
+        patched_site.get.return_value = current_site
+        response = fastapi_client.get("/authors/OL0A/works.json")
 
         assert response.status_code == 404
         current_site.get.assert_called_once_with("/authors/OL0A")
         current_site.things.assert_not_called()
-        current_site.get_many.assert_not_called()
 
-    def test_author_works_response_matches_legacy(self, fastapi_client):
-        author = make_doc("/authors/OL456A", "/type/author", get_work_count=Mock(return_value=2))
+    def test_response_matches_legacy(self, fastapi_client, patched_site):
         entries = [{"key": "/works/OL1W"}]
-        data = {"limit": "1", "offset": "0"}
 
-        legacy_site = make_site(author, ["/works/OL1W"], entries)
-        legacy_response = legacy_get_author_works_json(legacy_site, data)
+        legacy_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, get_work_count=Mock(return_value=2), thing_keys=["/works/OL1W"], entries=entries)
+        patched_site.get.return_value = legacy_site
+        legacy_response = legacy_api.author_works.get_works_data(
+            self.DOC_KEY,
+            url=URL(f"{self.ENDPOINT}?limit=1&offset=0"),
+            limit=1,
+            offset=0,
+        )
 
-        fastapi_site = make_site(author, ["/works/OL1W"], entries)
-        with patch("openlibrary.plugins.openlibrary.api.site") as site_context:
-            site_context.get.return_value = fastapi_site
-            fastapi_response = fastapi_client.get("/authors/OL456A/works.json?limit=1&offset=0")
+        fastapi_site = make_test_site(self.DOC_KEY, self.DOC_TYPE, get_work_count=Mock(return_value=2), thing_keys=["/works/OL1W"], entries=entries)
+        patched_site.get.return_value = fastapi_site
+        fastapi_response = fastapi_client.get(f"{self.ENDPOINT}?limit=1&offset=0")
 
         assert fastapi_response.status_code == 200
         assert fastapi_response.json() == legacy_response


### PR DESCRIPTION
## Summary

Migrates the work editions and author works routes from legacy web.py routing to FastAPI while preserving existing JSON response and pagination behavior.

Migrated endpoints:

- GET /works/OL{work_id}W/editions.json
- GET /authors/OL{author_id}A/works.json

### Stakeholders
@RayBB 