### PR TITLE
Regression: Fix lists/series edition-awareness by copying contextvars through async bridge

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -41,7 +41,7 @@ from openlibrary.plugins.worksearch.search import get_solr
 from openlibrary.solr.query_utils import fully_escape_query
 from openlibrary.utils.async_utils import async_bridge
 from openlibrary.utils.isbn import normalize_isbn
-from openlibrary.utils.request_context import req_context
+from openlibrary.utils.request_context import get_request_lang, req_context
 from openlibrary.utils.solr import (
     DEFAULT_PASS_TIME_ALLOWED,
     DEFAULT_SOLR_TIMEOUT_SECONDS,
@@ -206,17 +206,8 @@ def _get_readable_count(param: dict, search_response) -> int | None:
     return resp.num_found
 
 
-@public
-def get_request_lang() -> str:
-    """The request's UI language, safe to call from templates rendered on
-    either the legacy web.py server or the FastAPI server. The Templetor
-    global `get_lang()` reads `web.ctx.lang` directly, which isn't populated
-    by FastAPI — partials rendered there would AttributeError. Reading from
-    the unified `req_context` works on both. Falls back to 'en'."""
-    try:
-        return req_context.get().lang or "en"
-    except LookupError:
-        return "en"
+# Make public
+public(get_request_lang)
 
 
 async def get_solr_works_async(work_keys: set[str], fields: Iterable[str] | None = None, editions=False) -> dict[str, web.storage]:

--- a/openlibrary/plugins/worksearch/schemes/__init__.py
+++ b/openlibrary/plugins/worksearch/schemes/__init__.py
@@ -3,7 +3,6 @@ import typing
 from collections.abc import Callable
 from types import MappingProxyType
 
-import web
 from luqum.exceptions import ParseError
 
 from openlibrary.solr.query_utils import (
@@ -11,6 +10,7 @@ from openlibrary.solr.query_utils import (
     fully_escape_query,
     luqum_parser,
 )
+from openlibrary.utils.request_context import get_request_lang
 
 if typing.TYPE_CHECKING:
     import luqum.tree
@@ -42,8 +42,7 @@ class SearchScheme:
     lang: str
 
     def __init__(self, lang: str | None = None):
-        # Fall back to web.ctx.lang until we move away from it
-        self.lang = lang or getattr(web.ctx, "lang", None) or "en"
+        self.lang = lang or get_request_lang()
 
     def is_search_field(self, field: str):
         return field in self.all_fields or field in self.field_name_map

--- a/openlibrary/utils/async_utils.py
+++ b/openlibrary/utils/async_utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextvars
 import threading
 from collections.abc import Callable, Coroutine
 from typing import Any, ParamSpec, TypeVar
@@ -24,7 +25,12 @@ class AsyncBridge:
         self._thread.start()
 
     def run[T](self, coro: Coroutine[Any, Any, T]) -> T:
-        return asyncio.run_coroutine_threadsafe(coro, self._loop).result()
+        ctx = contextvars.copy_context()
+
+        async def _in_ctx() -> T:
+            return await asyncio.get_running_loop().create_task(coro, context=ctx)
+
+        return asyncio.run_coroutine_threadsafe(_in_ctx(), self._loop).result()
 
     def wrap(
         self,

--- a/openlibrary/utils/request_context.py
+++ b/openlibrary/utils/request_context.py
@@ -275,3 +275,15 @@ def web_ctx_ip(ip: str = "127.0.0.1"):
         yield
     finally:
         web.ctx.ip = original_ip
+
+
+def get_request_lang() -> str:
+    """The request's UI language, safe to call from templates rendered on
+    either the legacy web.py server or the FastAPI server. The Templetor
+    global `get_lang()` reads `web.ctx.lang` directly, which isn't populated
+    by FastAPI — partials rendered there would AttributeError. Reading from
+    the unified `req_context` works on both. Falls back to 'en'."""
+    try:
+        return req_context.get().lang or "en"
+    except LookupError:
+        return "en"


### PR DESCRIPTION
Noticed that series/lists were no longer adapting to the user language; eg https://openlibrary.org/series/OL326107L/The_Inheritance_Cycle?lang=fr .


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
This should now show french editions: https://testing.openlibrary.org/series/OL326107L/The_Inheritance_Cycle?lang=fr
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
