### PR TITLE
Experiment with JS i18n pipeline using gettext.js and Babel extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ openlibrary/components/dev/_dev.js
 .vscode/
 *.swp
 *.mo
+openlibrary/i18n/*/messages.json
 var/
 usr/
 static/build/

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,11 @@ lit-components:
 
 i18n:
 	python ./scripts/i18n-messages compile
+	for po in openlibrary/i18n/*/messages.po; do \
+		grep -v '^#~' $$po \
+			| msggrep -N 'openlibrary/components/lit/*.js' /dev/stdin \
+			| node node_modules/gettext.js/bin/po2json /dev/stdin $$(dirname $$po)/messages.json >/dev/null; \
+	done
 
 git:
 	git submodule init

--- a/docker/Dockerfile.oldev
+++ b/docker/Dockerfile.oldev
@@ -8,8 +8,10 @@ ARG HTTPS_PROXY
 
 WORKDIR /openlibrary
 
-COPY --chown=openlibrary:openlibrary requirements*.txt ./
 USER root
+RUN apt-get -qq update && apt-get install -y gettext
+
+COPY --chown=openlibrary:openlibrary requirements*.txt ./
 RUN uv pip install -r requirements_test.txt
 
 # For i18n scripts, which run as root (to modify the host filesystem) and need these packages.

--- a/openlibrary/components/lit/OLReadMore.js
+++ b/openlibrary/components/lit/OLReadMore.js
@@ -1,4 +1,5 @@
 import { LitElement, html, css } from 'lit';
+import { _ } from './utils/i18n.js';
 
 /**
  * OLReadMore - A web component for expandable/collapsible content
@@ -125,8 +126,8 @@ export class OLReadMore extends LitElement {
     constructor() {
         super();
         this.maxHeight = '80px';
-        this.moreText = 'Read More';
-        this.lessText = 'Read Less';
+        this.moreText = _('Read More');
+        this.lessText = _('Read Less');
         this.backgroundColor = null;
         this.labelSize = 'medium';
         this._expanded = false;

--- a/openlibrary/components/lit/OlBanner.js
+++ b/openlibrary/components/lit/OlBanner.js
@@ -1,4 +1,5 @@
 import { LitElement, html } from 'lit';
+import { _ } from './utils/i18n.js';
 
 /**
  * A callout-style announcement banner.
@@ -105,7 +106,7 @@ export class OlBanner extends LitElement {
         this.appearance = 'outlined';
         this.dismissId = '';
         this.dismissible = false;
-        this.labelClose = 'Close';
+        this.labelClose = _('Close');
         this._closing = false;
     }
 

--- a/openlibrary/components/lit/utils/i18n.js
+++ b/openlibrary/components/lit/utils/i18n.js
@@ -1,0 +1,10 @@
+import i18nFactory from 'gettext.js';
+
+const i18n = i18nFactory();
+
+if (window.__OL_I18N__) {
+    i18n.loadJSON(window.__OL_I18N__, 'messages');
+}
+
+export const _ = (s, ...args) => i18n.__(s, ...args);
+export const _n = (s, plural, n, ...args) => i18n._n(s, plural, n, ...args);

--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -149,6 +149,22 @@ def extract_templetor(fileobj, keywords, comment_tags, options):
     return extract_python(f, keywords, comment_tags, options)
 
 
+def get_js_i18n_data(lang: str) -> str:
+    """Return the JS i18n JSON for the given locale as a script-safe string.
+
+    Returns '{}' if no messages.json exists for the locale (e.g. English,
+    which falls back to the source strings in the JS components themselves).
+    """
+    import json as _json
+
+    json_path = os.path.join(root, lang, "messages.json")
+    if os.path.exists(json_path):
+        with open(json_path) as f:
+            data = _json.load(f)
+        return _json.dumps(data, ensure_ascii=False).replace("</", r"<\/")
+    return "{}"
+
+
 def extract_messages(sources: list[str], verbose: bool, skip_untracked: bool):
     # The creation date is hard-coded to prevent merge conflicts from i18n auto-updates.
     # Occasional manual bumps are fine to make it more up-to-date
@@ -162,12 +178,13 @@ def extract_messages(sources: list[str], verbose: bool, skip_untracked: bool):
         ("**.py", "python"),
         ("**.html", "openlibrary.i18n:extract_templetor"),
         ("**.jinja", "jinja2.ext:babel_extract"),
+        ("**.js", "javascript"),
     ]
     COMMENT_TAGS = ["NOTE:"]
 
     skipped_files = set()
     if skip_untracked:
-        skipped_files = get_untracked_files(sources, (".py", ".html", ".jinja"))
+        skipped_files = get_untracked_files(sources, (".py", ".html", ".jinja", ".js"))
 
     for source in map(Path, sources):
         counts: dict[Path, int] = {}

--- a/openlibrary/i18n/fr/messages.po
+++ b/openlibrary/i18n/fr/messages.po
@@ -299,8 +299,7 @@ msgstr "Pagination"
 msgid "Popover"
 msgstr "Supprimer"
 
-#: design.html type/edition/view.html type/work/view.html
-#, fuzzy
+#: design.html type/edition/view.html type/work/view.html openlibrary/components/lit/OLReadMore.js
 msgid "Read More"
 msgstr "Lire plus"
 
@@ -1094,7 +1093,7 @@ msgstr "Merci beaucoup d'avoir amélioré cette entrée !"
 #: ShareModal.html covers/author_photo.html covers/book_cover.html
 #: covers/change.html design/banner.html design/toast.html lib/exports.html
 #: my_books/check_ins/check_in_prompt.html my_books/dropdown_content.html
-#: native_dialog.html
+#: native_dialog.html openlibrary/components/lit/OlBanner.js
 msgid "Close"
 msgstr "Fermer"
 
@@ -8377,8 +8376,7 @@ msgstr "Première publication en %s"
 msgid "Book %s"
 msgstr ""
 
-#: type/edition/view.html type/work/view.html
-#, fuzzy
+#: type/edition/view.html type/work/view.html openlibrary/components/lit/OLReadMore.js
 msgid "Read Less"
 msgstr "Lire moins"
 

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -562,6 +562,7 @@ msgstr ""
 #: ShareModal.html covers/author_photo.html covers/book_cover.html
 #: covers/change.html lib/exports.html my_books/check_ins/check_in_prompt.html
 #: my_books/dropdown_content.html native_dialog.html
+#: openlibrary/components/lit/OlBanner.js
 msgid "Close"
 msgstr ""
 
@@ -7016,14 +7017,6 @@ msgid "Book %s"
 msgstr ""
 
 #: type/edition/view.html type/work/view.html
-msgid "Read More"
-msgstr ""
-
-#: type/edition/view.html type/work/view.html
-msgid "Read Less"
-msgstr ""
-
-#: type/edition/view.html type/work/view.html
 #, python-format
 msgid ""
 "This work doesn't have a description yet. Can you <b><a "
@@ -8706,5 +8699,13 @@ msgstr ""
 
 #: openlibrary/plugins/worksearch/code.py
 msgid "Classic eBooks"
+msgstr ""
+
+#: openlibrary/components/lit/OLReadMore.js
+msgid "Read More"
+msgstr ""
+
+#: openlibrary/components/lit/OLReadMore.js
+msgid "Read Less"
 msgstr ""
 

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -24,6 +24,7 @@ from openlibrary.core import db
 from openlibrary.core.batch_imports import (
     batch_import,
 )
+from openlibrary.i18n import get_js_i18n_data
 from openlibrary.i18n import gettext as _
 from openlibrary.plugins.upstream.utils import get_coverstore_public_url, setup_requests
 from openlibrary.utils.request_context import (
@@ -942,6 +943,12 @@ class new:
 
 
 api and api.add_hook("new", new)
+
+
+@public
+def js_i18n_data() -> str:
+    """Return JS i18n JSON for the current locale, safe to embed in a <script> tag."""
+    return get_js_i18n_data(web.ctx.get("lang", "en"))
 
 
 @public

--- a/openlibrary/templates/site/footer.html
+++ b/openlibrary/templates/site/footer.html
@@ -22,6 +22,7 @@ $if show_ol_shell:
 $if not is_bot():
   <script src="/cdn/archive.org/athena.js" type="text/javascript"></script>
 
+<script>window.__OL_I18N__ = $:js_i18n_data();</script> $# detect-missing-i18n-skip-line
 <script src="$static_url('build/js/all.js')" type="text/javascript"></script>
 <script src="$static_url('build/lit-components/production/ol-components.js')" type="module"></script>
 <div class="analytics-stats-time-calculator" data-time="$total_time"></div>

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -236,7 +236,7 @@ $ worldcat_link = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_number=oclc_
           $ overview_desc = edition.description
         $else:
           $ overview_desc = work.description
-        <ol-read-more class="book-description" more-text="$_('Read More')" less-text="$_('Read Less')">
+        <ol-read-more class="book-description">
           $:sanitize(format(overview_desc))
         </ol-read-more>
       $elif edition:
@@ -362,7 +362,7 @@ $ worldcat_link = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_number=oclc_
             <div class="section">
               <h3>$_("Table of Contents")</h3>
               $ component_times['TableOfContents'] = time()
-              <ol-read-more max-height="200px" style="min-height: 241px" more-text="$_('Read More')" less-text="$_('Read Less')">
+              <ol-read-more max-height="200px" style="min-height: 241px">
                 $:macros.TableOfContents(table_of_contents, ocaid)
               </ol-read-more>
               $ component_times['TableOfContents'] = time() - component_times['TableOfContents']
@@ -481,7 +481,7 @@ $ worldcat_link = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_number=oclc_
 
             $if work.description and work.description != overview_desc:
               <h4>$_("Work Description")</h4>
-              <ol-read-more more-text="$_('Read More')" less-text="$_('Read Less')">
+              <ol-read-more>
                 $:sanitize(format(work.description))
               </ol-read-more>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "eslint-plugin-no-jquery": "^3.1.1",
         "eslint-plugin-vue": "^9.32.0",
         "flot": "0.8.3",
+        "gettext.js": "^2.0.3",
         "glob": "^7.2.3",
         "globals": "^15.14.0",
         "isbn3": "1.2.19",
@@ -8501,6 +8502,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.22.2",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.2.tgz",
@@ -9693,6 +9704,54 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gettext-parser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-2.0.0.tgz",
+      "integrity": "sha512-FDs/7XjNw58ToQwJFO7avZZbPecSYgw8PBYhd0An+4JtZSrSzKhEvTsVV2uqdO7VziWTOGSgLGD5YRPdsCjF7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encoding": "^0.1.12",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/gettext-to-messageformat": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/gettext-to-messageformat/-/gettext-to-messageformat-0.3.1.tgz",
+      "integrity": "sha512-UyqIL3Ul4NryU95Wome/qtlcuVIqgEWVIFw0zi7Lv14ACLXfaVDCbrjZ7o+3BZ7u+4NS1mP/2O1eXZoHCoas8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "gettext-parser": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gettext-to-messageformat/node_modules/gettext-parser": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+      "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encoding": "^0.1.12",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/gettext.js": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/gettext.js/-/gettext.js-2.0.3.tgz",
+      "integrity": "sha512-11gyttZWBUBkenEVgPMqJTL9TIKaH4PW6ZCMZr+lNXrgiYHXBg+bOGAc8OjfLE8lvi0dgwtqrSfScd310PlKJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "po2json": "^1.0.0-beta-3"
+      },
+      "bin": {
+        "po2json-gettextjs": "bin/po2json"
       }
     },
     "node_modules/gl-matrix": {
@@ -13074,6 +13133,39 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/po2json": {
+      "version": "1.0.0-beta-3",
+      "resolved": "https://registry.npmjs.org/po2json/-/po2json-1.0.0-beta-3.tgz",
+      "integrity": "sha512-taS8y6ZEGzPAs0rygW9CuUPY8C3Zgx6cBy31QXxG2JlWS3fLxj/kuD3cbIfXBg30PuYN7J5oyBa/TIRjyqFFtg==",
+      "dev": true,
+      "license": "LGPL-2.0-or-later",
+      "dependencies": {
+        "commander": "^6.0.0",
+        "gettext-parser": "2.0.0",
+        "gettext-to-messageformat": "0.3.1"
+      },
+      "bin": {
+        "po2json": "bin/po2json"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "peerDependencies": {
+        "commander": "^6.0.0",
+        "gettext-parser": "2.0.0",
+        "gettext-to-messageformat": "0.3.1"
+      }
+    },
+    "node_modules/po2json/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -14426,6 +14518,27 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "eslint-plugin-no-jquery": "^3.1.1",
     "eslint-plugin-vue": "^9.32.0",
     "flot": "0.8.3",
+    "gettext.js": "^2.0.3",
     "glob": "^7.2.3",
     "globals": "^15.14.0",
     "isbn3": "1.2.19",

--- a/scripts/i18n-messages
+++ b/scripts/i18n-messages
@@ -37,11 +37,20 @@ def main(cmd, args):
             text=True,
         ).stdout.splitlines()
 
+        js_sources = subprocess.run(
+            "grep -wrlF '_(' openlibrary/components/lit/ --include '*.js'",
+            shell=True,
+            capture_output=True,
+            check=False,
+            text=True,
+        ).stdout.splitlines()
+
         message_sources = [
             "openlibrary/templates/",
             "openlibrary/macros/",
             # grep can return things in an inconsistent order depending on the system
             *sorted(py_sources),
+            *sorted(js_sources),
         ]
 
         i18n.extract_messages(


### PR DESCRIPTION
Closes #2607 

As we're moving more and more to having large chunks of the UI in JS code, we'll need a pattern to make internationalization as easy for JS as it is for html/python.

Establishes an end-to-end i18n pipeline for Lit web components, so translatable strings in JS components flow through the same babel/GNU gettext workflow already used for Python/HTML.

### Technical

How it works:

1. **Extraction**: Using Babel's built-in `javascript` extractor! Any call to `_("string")` in a Lit component is picked up and written into `messages.pot`, just like Python and HTML strings.

2. **Build (`make i18n`)**:  After compiling `.po` → `.mo` as before, also generates a `messages.json` file with *only* strings that appear in .js files using `gettext.js`.

3. **Runtime (server → browser)**: Inline the `messages.json` in the footer before the rest of the javascript in `window.__OL_I18N__`.

4. **Components (`utils/i18n.js`)**: In js/lit components, you can use `_` and `_n` from `utils/i18n.js`, which are light wrappers around `gettext.js`.

**Infrastructure**
- `gettext.js` added as a dev dependency (provides `po2json` CLI)
- `gettext` system package added to `Dockerfile.oldev` (provides `msggrep`)
- `openlibrary/i18n/*/messages.json` added to `.gitignore` (generated, like `.mo` files)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

`OlBanner` and `OLReadMore` are the migrated to show the flow: they now call `_('Close')`, `_('Read More')`, `_('Read Less')` as property defaults, and their callers in templates no longer need to pass translated strings as attributes.

TODO:

* Confirm variables in string work
* Test named variables
* Test plurals

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

Note "Lire plus" being correctly translated, despite the i18n attributes being removed from the html source.

<img width="1527" height="442" alt="image" src="https://github.com/user-attachments/assets/6e4d1ab6-79e1-4735-b92e-cac15a3bcef5" />

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@lokesh @tfmorris 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
