### PR TITLE
feat(accounts): redirect to My Books after email verification

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -741,11 +741,13 @@ class account_verify(delegate.page):
     path = "/account/verify"
 
     def GET(self):
-        i = web.input(t=None)
+        i = web.input(t=None, redirect="")
         if not i.t:
             raise web.seeother("/account/create")
         r = InternetArchiveAccount.verify(token=i.t)
         if "error" in r:
+            if accounts.get_current_user():
+                raise web.seeother("/account/books")
             add_flash_message(
                 "error",
                 _("Verification failed. The link may be invalid or expired. Please try registering again."),
@@ -755,6 +757,7 @@ class account_verify(delegate.page):
         return account_login().login(
             access=r["s3"]["access"],
             secret=r["s3"]["secret"],
+            redirect=i.redirect or "/account/books",
         )
 
 

--- a/openlibrary/plugins/upstream/tests/test_account.py
+++ b/openlibrary/plugins/upstream/tests/test_account.py
@@ -193,8 +193,8 @@ class TestAccountVerify:
     @mock.patch("openlibrary.plugins.upstream.account.add_flash_message")
     @mock.patch("openlibrary.plugins.upstream.account._", lambda x, **kw: x)
     @mock.patch("openlibrary.plugins.upstream.account.web")
-    def test_valid_token_calls_login_with_s3_keys(self, mock_web, mock_flash, mock_login_cls, mock_ia_account):
-        mock_web.input.return_value = web.storage(t="validtoken")
+    def test_valid_token_redirects_to_my_books(self, mock_web, mock_flash, mock_login_cls, mock_ia_account):
+        mock_web.input.return_value = web.storage(t="validtoken", redirect="")
         mock_ia_account.verify.return_value = {
             "email": "test@example.com",
             "s3": {"access": "ACCESSKEY", "secret": "SECRETKEY"},
@@ -208,29 +208,70 @@ class TestAccountVerify:
         login_instance.login.assert_called_once_with(
             access="ACCESSKEY",
             secret="SECRETKEY",
+            redirect="/account/books",
         )
 
+    @mock.patch("openlibrary.plugins.upstream.account.InternetArchiveAccount")
+    @mock.patch("openlibrary.plugins.upstream.account.account_login")
+    @mock.patch("openlibrary.plugins.upstream.account.add_flash_message")
+    @mock.patch("openlibrary.plugins.upstream.account._", lambda x, **kw: x)
+    @mock.patch("openlibrary.plugins.upstream.account.web")
+    def test_valid_token_honors_redirect_param(self, mock_web, mock_flash, mock_login_cls, mock_ia_account):
+        mock_web.input.return_value = web.storage(t="validtoken", redirect="/works/OL1W")
+        mock_ia_account.verify.return_value = {
+            "email": "test@example.com",
+            "s3": {"access": "ACCESSKEY", "secret": "SECRETKEY"},
+        }
+        login_instance = mock.MagicMock()
+        mock_login_cls.return_value = login_instance
+
+        self._make_handler().GET()
+
+        login_instance.login.assert_called_once_with(
+            access="ACCESSKEY",
+            secret="SECRETKEY",
+            redirect="/works/OL1W",
+        )
+
+    @mock.patch("openlibrary.plugins.upstream.account.accounts")
     @mock.patch("openlibrary.plugins.upstream.account.InternetArchiveAccount")
     @mock.patch("openlibrary.plugins.upstream.account.add_flash_message")
     @mock.patch("openlibrary.plugins.upstream.account._", lambda x, **kw: x)
     @mock.patch("openlibrary.plugins.upstream.account.web")
-    def test_invalid_token_redirects_to_create(self, mock_web, mock_flash, mock_ia_account):
-        mock_web.input.return_value = web.storage(t="badtoken")
+    def test_invalid_token_redirects_to_create_when_not_logged_in(self, mock_web, mock_flash, mock_ia_account, mock_accounts):
+        mock_web.input.return_value = web.storage(t="badtoken", redirect="")
         mock_ia_account.verify.return_value = {"error": "invalid_token"}
+        mock_accounts.get_current_user.return_value = None
         mock_web.seeother.side_effect = Exception("redirect")
 
         with pytest.raises(Exception, match="redirect"):
             self._make_handler().GET()
 
         mock_flash.assert_called_once()
-        flash_args = mock_flash.call_args[0]
-        assert flash_args[0] == "error"
+        assert mock_flash.call_args[0][0] == "error"
         mock_web.seeother.assert_called_once_with("/account/create")
+
+    @mock.patch("openlibrary.plugins.upstream.account.accounts")
+    @mock.patch("openlibrary.plugins.upstream.account.InternetArchiveAccount")
+    @mock.patch("openlibrary.plugins.upstream.account.add_flash_message")
+    @mock.patch("openlibrary.plugins.upstream.account._", lambda x, **kw: x)
+    @mock.patch("openlibrary.plugins.upstream.account.web")
+    def test_invalid_token_redirects_to_my_books_when_logged_in(self, mock_web, mock_flash, mock_ia_account, mock_accounts):
+        mock_web.input.return_value = web.storage(t="usedtoken", redirect="")
+        mock_ia_account.verify.return_value = {"error": "already_verified"}
+        mock_accounts.get_current_user.return_value = mock.MagicMock()
+        mock_web.seeother.side_effect = Exception("redirect")
+
+        with pytest.raises(Exception, match="redirect"):
+            self._make_handler().GET()
+
+        mock_flash.assert_not_called()
+        mock_web.seeother.assert_called_once_with("/account/books")
 
     @mock.patch("openlibrary.plugins.upstream.account.add_flash_message")
     @mock.patch("openlibrary.plugins.upstream.account.web")
     def test_missing_token_redirects_to_create(self, mock_web, mock_flash):
-        mock_web.input.return_value = web.storage(t=None)
+        mock_web.input.return_value = web.storage(t=None, redirect="")
         mock_web.seeother.side_effect = Exception("redirect")
 
         with pytest.raises(Exception, match="redirect"):


### PR DESCRIPTION
## Summary

When a patron follows their email verification link (`/account/verify?t=TOKEN`):

- **Success**: redirects to `/account/books` (My Books) instead of the home page — the user has just verified their account and is ready to start using the library
- **Error + already logged in**: redirects to `/account/books` instead of `/account/create` — handles the "link already used" case gracefully; a logged-in user doesn't need to see the create-account page
- **Honors `?redirect=...`**: if a `redirect` query param is present in the verify URL, it is forwarded to the post-login redirect (preserves intent when deep-linked)

Followup to:
* #10262
* #12764 

## Changes

- `openlibrary/plugins/upstream/account.py`: 4-line change to `account_verify.GET()`
- `openlibrary/plugins/upstream/tests/test_account.py`: updated 3 existing tests + 2 new tests

## Test plan

- Updated `test_valid_token_redirects_to_my_books` — asserts `redirect="/account/books"` is passed to `login()`
- New `test_valid_token_honors_redirect_param` — asserts an explicit `?redirect=` param is honored
- Updated `test_invalid_token_redirects_to_create_when_not_logged_in` — adds `get_current_user()` mock
- New `test_invalid_token_redirects_to_my_books_when_logged_in` — asserts logged-in users go to My Books on error
- Updated `test_missing_token_redirects_to_create` — adds `redirect=""` to `web.input` storage

**Note:** Local Docker test runs against these tests are blocked by two pre-existing issues in master:
1. `from warnings import deprecated` in `account.py` (added in #12889) — `warnings.deprecated` is Python 3.13+ only; Docker image is 3.12
2. Python 2 `except A, B:` syntax in the import chain — being fixed separately in #12969

The tests themselves are logically sound and will pass in CI (which uses a compatible environment). This PR should be merged after #12969.