### PR TITLE
Warm nexus cache before parallel docker pull in deploy

### DIFF
--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -508,6 +508,23 @@ deploy_images() {
         echo "✓ ($OLBASE_DIGEST)"
     fi
 
+    # Pull on one node first to warm the nexus cache, avoiding Docker Hub rate limits
+    # when all servers pull in parallel.
+    local FIRST_SERVER
+    FIRST_SERVER=$(echo "$HOSTNAMES" | awk '{print $1}')
+    echo -n "   Warming nexus cache on ${FIRST_SERVER} ... "
+    local WARM_OUTPUT
+    WARM_OUTPUT=$(ssh "${FIRST_SERVER}${SERVER_SUFFIX}" "docker pull openlibrary/olbase@${OLBASE_DIGEST}" 2>&1)
+    if [ $? -eq 0 ]; then
+        echo "✓"
+    else
+        echo "✗"
+        echo "Failed to warm nexus cache on ${FIRST_SERVER}"
+        echo "Output:"
+        echo "$WARM_OUTPUT"
+        return 1
+    fi
+
     local pids=()
     local output_files=()
     for SERVER_NAME in $HOSTNAMES; do


### PR DESCRIPTION
We tested this in the last deploy and it worked well. Not drastically faster but maybe a bit faster? And regardless it seems better for performance on nexus.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
