### PR TITLE
Add infrastructure endpoints for serving robots.txt and include infra…

### DIFF
--- a/openlibrary/asgi_app.py
+++ b/openlibrary/asgi_app.py
@@ -219,6 +219,7 @@ def create_app() -> FastAPI | None:
     from openlibrary.fastapi.cdn import router as cdn_router
     from openlibrary.fastapi.checkins import router as checkins_router
     from openlibrary.fastapi.importapi import router as importapi_router
+    from openlibrary.fastapi.infrastructure import router as infrastructure_router
     from openlibrary.fastapi.internal.api import router as internal_router
     from openlibrary.fastapi.languages import router as languages_router
     from openlibrary.fastapi.lists import router as lists_router
@@ -238,6 +239,7 @@ def create_app() -> FastAPI | None:
     app.include_router(cdn_router)
     app.include_router(checkins_router)
     app.include_router(importapi_router)
+    app.include_router(infrastructure_router)
     app.include_router(internal_router)
     app.include_router(languages_router)
     app.include_router(lists_router)

--- a/openlibrary/fastapi/infrastructure.py
+++ b/openlibrary/fastapi/infrastructure.py
@@ -8,13 +8,14 @@ import asyncio
 from pathlib import Path
 
 from fastapi import APIRouter, Request
+from fastapi.responses import PlainTextResponse
 
 import infogami
 
 router = APIRouter()
 
 
-@router.get("/robots.txt")
+@router.get("/robots.txt", response_class=PlainTextResponse)
 async def get_robots_txt(request: Request) -> str:
     """
     Serve robots.txt based on environment.

--- a/openlibrary/fastapi/infrastructure.py
+++ b/openlibrary/fastapi/infrastructure.py
@@ -1,0 +1,38 @@
+"""
+FastAPI endpoints for infrastructure and utility paths.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from fastapi import APIRouter, Request
+
+import infogami
+
+router = APIRouter()
+
+
+@router.get("/robots.txt")
+async def get_robots_txt(request: Request) -> str:
+    """
+    Serve robots.txt based on environment.
+
+    In development (dev in features or non-openlibrary.org host), serves norobots.txt.
+    In production, serves robots.txt.
+
+    Returns:
+        str: Content of robots.txt or norobots.txt with text/plain content type
+    """
+    is_dev = "dev" in infogami.config.features or request.headers.get("host", "").split(":")[0] != "openlibrary.org"
+
+    robots_file = "norobots.txt" if is_dev else "robots.txt"
+
+    static_dir = Path(__file__).parent.parent.parent / "static"
+    robots_path = static_dir / robots_file
+
+    # Use asyncio.to_thread to avoid blocking the event loop with file I/O
+    content = await asyncio.to_thread(robots_path.read_text)
+
+    return content

--- a/openlibrary/plugins/openlibrary/deprecated_handler.py
+++ b/openlibrary/plugins/openlibrary/deprecated_handler.py
@@ -84,6 +84,7 @@ class DeprecatedJSONEndpointHandler(DeprecatedEndpointHandler):
 
 # List of deprecated paths and encodings
 DEPRECATED_PATHS: list[tuple[str, str | None]] = [
+    (r"/robots.txt", None),
     (r"/search", "json"),
     (r"/search/lists", "json"),
     (r"/search/subjects", "json"),


### PR DESCRIPTION
…structure router in FastAPI app

<!-- What issue does this PR close? -->
As a part of migrating the codebase to FastAPI, I tried writing an endpoint in FastAPI

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
achieve migrating the /robots.txt endpoint to fastapi successfully

### Technical
<!-- What should be noted about the implementation? -->
This is just a basic implementation of migrating the /robots.txt in fastapi

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
To verify that it works , set up the dev environment locally , and make the test script like 
```
#!/usr/bin/env bash
# Temporary comparison script — delete before merging.
ENDPOINT="/robots.txt"

OLD=$(curl -s "http://localhost:8080${ENDPOINT}")
NEW=$(curl -s "http://localhost:18080${ENDPOINT}")

if [ "$OLD" = "$NEW" ]; then
  echo "✅ Outputs match"
else
  echo "❌ Outputs differ"
  diff <(echo "$OLD" | python3 -m json.tool) <(echo "$NEW" | python3 -m json.tool)
fi
```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="1920" height="1080" alt="Screenshot From 2026-06-18 23-22-35" src="https://github.com/user-attachments/assets/ec4333f3-ac95-47d5-9f32-226b0cfb6a6b" />
<img width="1920" height="1080" alt="Screenshot From 2026-06-18 23-22-45" src="https://github.com/user-attachments/assets/fc2197f5-26b2-4476-9d0e-66e48238418f" />


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
