### PR TITLE
feat(search): add GET /search/facets.json — context-aware facet values API

### DIFF
--- a/openlibrary/fastapi/search.py
+++ b/openlibrary/fastapi/search.py
@@ -37,6 +37,24 @@ from openlibrary.plugins.worksearch.schemes.works import WorkSearchScheme
 
 router = APIRouter()
 
+# Facet fields exposed by /search/facets.json — mirrors WorkSearchScheme.facet_fields
+FacetField = Literal[
+    "author_facet",
+    "first_publish_year",
+    "has_fulltext",
+    "language",
+    "person_facet",
+    "place_facet",
+    "public_scan_b",
+    "publisher_facet",
+    "subject_facet",
+    "time_facet",
+]
+
+# process_facet_counts renames author_facet → author_key internally; map back so
+# the response key always matches the caller's requested field name.
+_FACET_INTERNAL_RENAME = {"author_key": "author_facet"}
+
 
 class PublicQueryOptions(BaseModel):
     """
@@ -139,6 +157,14 @@ class SearchRequestParams(PublicQueryOptions, Pagination):
             query_fields |= set(WorkSearchScheme.field_name_map.keys())
             q = self.model_dump(include=query_fields, exclude_none=True)
             return q
+
+
+class FacetValue(BaseModel):
+    """A single facet option returned by /search/facets.json."""
+
+    value: str = Field(description="Filter value to pass back to /search.json (e.g. 'eng', 'OL9A')")
+    label: str = Field(description="Human-readable display label — differs from value for author_facet")
+    count: int = Field(description="Number of matching works")
 
 
 class SearchResponse(BaseModel):
@@ -350,17 +376,17 @@ async def search_authors_json(
     return raw_resp
 
 
-@router.get("/search/facets.json", tags=["search"])
+@router.get("/search/facets.json", tags=["search"], response_model=dict[str, list[FacetValue]])
 async def search_facets_json(
     request: Request,
     params: Annotated[PublicQueryOptions, Depends()],
     field: Annotated[
-        list[str] | None,
-        Query(description=(f"Facet field(s) to return. Repeat to request multiple. Valid values: {', '.join(sorted(WorkSearchScheme.facet_fields))}")),
+        list[FacetField] | None,
+        Query(description="Facet field(s) to return. Repeat for multiple."),
     ] = None,
     sfw: Annotated[str | None, Cookie()] = None,
     solr_internals_params: Annotated[SolrInternalsParams | None, Depends(SolrInternalsParams.from_request)] = None,
-) -> dict[str, list[dict[str, Any]]]:
+) -> dict[str, list[FacetValue]]:
     """
     Returns context-aware facet values for one or more search facet fields.
 
@@ -372,42 +398,26 @@ async def search_facets_json(
     """
     if not field:
         raise HTTPException(status_code=400, detail="At least one 'field' parameter is required.")
-    fields: list[str] = field
-
-    invalid = set(fields) - WorkSearchScheme.facet_fields
-    if invalid:
-        raise HTTPException(
-            status_code=400,
-            detail=(f"Invalid facet field(s): {sorted(invalid)}. Valid fields: {sorted(WorkSearchScheme.facet_fields)}"),
-        )
-
-    scheme = WorkSearchScheme(lang=request.state.lang)
-    query = params.model_dump(exclude_none=True)
 
     search_response = await run_solr_query_async(
-        scheme,
-        query,
+        WorkSearchScheme(lang=request.state.lang),
+        params.model_dump(exclude_none=True),
         rows=0,
         page=1,
-        facet=fields,
+        facet=list(field),
         highlight=False,
         request_label="BOOK_SEARCH_FACETS",
         solr_internals_params=solr_internals_params,
     )
 
-    # process_facet_counts renames author_facet → author_key internally;
-    # map back so the response key always matches the caller's input field name.
-    INTERNAL_RENAME = {"author_key": "author_facet"}
-
-    result: dict[str, list[dict[str, Any]]] = {f: [] for f in fields}
+    result: dict[str, list[FacetValue]] = {f: [] for f in field}
     if search_response.facet_counts:
         for facet_field, values in search_response.facet_counts.items():
-            output_key = INTERNAL_RENAME.get(facet_field, facet_field)
+            output_key = _FACET_INTERNAL_RENAME.get(facet_field, facet_field)
             if output_key not in result:
                 continue
-            # values are (display_label, filter_value, count) tuples from process_facet;
-            # label == value for most fields; they differ for author_facet (name vs. OL key)
-            # and for subject/person/place/time facets that use "Name|key" solr values.
-            result[output_key] = [{"value": filter_val, "label": display_label, "count": count} for display_label, filter_val, count in values if count > 0]
+            # values are (display_label, filter_value, count) tuples; label differs
+            # from value for author_facet (name vs OL key) and "Name|key" subject fields.
+            result[output_key] = [FacetValue(value=filter_val, label=display_label, count=count) for display_label, filter_val, count in values if count > 0]
 
     return result

--- a/openlibrary/fastapi/search.py
+++ b/openlibrary/fastapi/search.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping
 from typing import Annotated, Any, Literal, Self
 
 import web
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Cookie, Depends, HTTPException, Query, Request
 from pydantic import (
     BaseModel,
     BeforeValidator,
@@ -348,3 +348,66 @@ async def search_authors_json(
         doc["key"] = doc["key"].split("/")[-1]
 
     return raw_resp
+
+
+@router.get("/search/facets.json", tags=["search"])
+async def search_facets_json(
+    request: Request,
+    params: Annotated[PublicQueryOptions, Depends()],
+    field: Annotated[
+        list[str] | None,
+        Query(description=(f"Facet field(s) to return. Repeat to request multiple. Valid values: {', '.join(sorted(WorkSearchScheme.facet_fields))}")),
+    ] = None,
+    sfw: Annotated[str | None, Cookie()] = None,
+    solr_internals_params: Annotated[SolrInternalsParams | None, Depends(SolrInternalsParams.from_request)] = None,
+) -> dict[str, list[dict[str, Any]]]:
+    """
+    Returns context-aware facet values for one or more search facet fields.
+
+    Queries Solr with rows=0 alongside the current search params, returning only
+    values with count > 0, ordered by count descending. Designed to power the
+    OlSelectPopover components in the search results filter bar (PR #12949).
+
+    Example: GET /search/facets.json?field=language&field=subject_facet&q=lord+of+the+rings
+    """
+    if not field:
+        raise HTTPException(status_code=400, detail="At least one 'field' parameter is required.")
+    fields: list[str] = field
+
+    invalid = set(fields) - WorkSearchScheme.facet_fields
+    if invalid:
+        raise HTTPException(
+            status_code=400,
+            detail=(f"Invalid facet field(s): {sorted(invalid)}. Valid fields: {sorted(WorkSearchScheme.facet_fields)}"),
+        )
+
+    scheme = WorkSearchScheme(lang=request.state.lang)
+    query = params.model_dump(exclude_none=True)
+
+    search_response = await run_solr_query_async(
+        scheme,
+        query,
+        rows=0,
+        page=1,
+        facet=fields,
+        highlight=False,
+        request_label="BOOK_SEARCH_FACETS",
+        solr_internals_params=solr_internals_params,
+    )
+
+    # process_facet_counts renames author_facet → author_key internally;
+    # map back so the response key always matches the caller's input field name.
+    INTERNAL_RENAME = {"author_key": "author_facet"}
+
+    result: dict[str, list[dict[str, Any]]] = {f: [] for f in fields}
+    if search_response.facet_counts:
+        for facet_field, values in search_response.facet_counts.items():
+            output_key = INTERNAL_RENAME.get(facet_field, facet_field)
+            if output_key not in result:
+                continue
+            # values are (display_label, filter_value, count) tuples from process_facet;
+            # label == value for most fields; they differ for author_facet (name vs. OL key)
+            # and for subject/person/place/time facets that use "Name|key" solr values.
+            result[output_key] = [{"value": filter_val, "label": display_label, "count": count} for display_label, filter_val, count in values if count > 0]
+
+    return result

--- a/openlibrary/fastapi/search.py
+++ b/openlibrary/fastapi/search.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from collections.abc import Mapping
 from typing import Annotated, Any, Literal, Self
 
@@ -54,6 +55,10 @@ FacetField = Literal[
 # process_facet_counts renames author_facet → author_key internally; map back so
 # the response key always matches the caller's requested field name.
 _FACET_INTERNAL_RENAME = {"author_key": "author_facet"}
+
+# Whether to expose internal-only endpoints in the OpenAPI schema.
+# Only shown when running with LOCAL_DEV set (e.g. docker compose).
+SHOW_INTERNAL_IN_SCHEMA = os.getenv("LOCAL_DEV") is not None
 
 
 class PublicQueryOptions(BaseModel):
@@ -376,7 +381,12 @@ async def search_authors_json(
     return raw_resp
 
 
-@router.get("/search/facets.json", tags=["search"], response_model=dict[str, list[FacetValue]])
+@router.get(
+    "/search/facets.json",
+    tags=["internal"],
+    include_in_schema=SHOW_INTERNAL_IN_SCHEMA,
+    response_model=dict[str, list[FacetValue]],
+)
 async def search_facets_json(
     request: Request,
     params: Annotated[PublicQueryOptions, Depends()],
@@ -416,8 +426,8 @@ async def search_facets_json(
             output_key = _FACET_INTERNAL_RENAME.get(facet_field, facet_field)
             if output_key not in result:
                 continue
-            # values are (display_label, filter_value, count) tuples; label differs
+            # values are (filter_value, display_label, count) tuples; label differs
             # from value for author_facet (name vs OL key) and "Name|key" subject fields.
-            result[output_key] = [FacetValue(value=filter_val, label=display_label, count=count) for display_label, filter_val, count in values if count > 0]
+            result[output_key] = [FacetValue(value=value, label=label, count=count) for value, label, count in values if count > 0]
 
     return result

--- a/openlibrary/fastapi/search.py
+++ b/openlibrary/fastapi/search.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping
 from typing import Annotated, Any, Literal, Self
 
 import web
-from fastapi import APIRouter, Cookie, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, Query, Request
 from pydantic import (
     BaseModel,
     BeforeValidator,
@@ -391,10 +391,9 @@ async def search_facets_json(
     request: Request,
     params: Annotated[PublicQueryOptions, Depends()],
     field: Annotated[
-        list[FacetField] | None,
-        Query(description="Facet field(s) to return. Repeat for multiple."),
-    ] = None,
-    sfw: Annotated[str | None, Cookie()] = None,
+        list[FacetField],
+        Query(min_length=1, description="Facet field(s) to return. Repeat for multiple."),
+    ],
     solr_internals_params: Annotated[SolrInternalsParams | None, Depends(SolrInternalsParams.from_request)] = None,
 ) -> dict[str, list[FacetValue]]:
     """
@@ -406,9 +405,6 @@ async def search_facets_json(
 
     Example: GET /search/facets.json?field=language&field=subject_facet&q=lord+of+the+rings
     """
-    if not field:
-        raise HTTPException(status_code=400, detail="At least one 'field' parameter is required.")
-
     search_response = await run_solr_query_async(
         WorkSearchScheme(lang=request.state.lang),
         params.model_dump(exclude_none=True),

--- a/openlibrary/tests/fastapi/conftest.py
+++ b/openlibrary/tests/fastapi/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Shared pytest fixtures for FastAPI and API contract tests."""
 
 from unittest.mock import patch
@@ -146,6 +148,44 @@ def _default_search_response():
         "q": "",
         "offset": None,
     }
+
+
+@pytest.fixture
+def mock_run_solr_query_async():
+    """Mock run_solr_query_async to avoid actual Solr calls.
+
+    Used by FastAPI search/facets endpoint tests.
+    Returns a SearchResponse with sample facet_counts.
+    """
+    with patch("openlibrary.fastapi.search.run_solr_query_async", autospec=True) as mock:
+        mock.return_value = _default_facets_response()
+        yield mock
+
+
+def _default_facets_response():
+    """Default mock SearchResponse for facets tests."""
+    return SearchResponse(
+        # process_facet_counts renames author_facet → author_key in this dict
+        facet_counts={
+            "language": [
+                ("English", "English", 665),
+                ("German", "German", 32),
+                ("Spanish", "Spanish", 18),
+                ("Latin", "Latin", 0),  # zero-count entry — should be filtered out
+            ],
+            "author_key": [
+                ("J.R.R. Tolkien", "OL9A", 123),
+            ],
+            "subject_facet": [
+                ("Fantasy", "Fantasy", 89),
+            ],
+        },
+        sort="",
+        docs=[],
+        num_found=0,
+        raw_resp={"response": {"docs": []}},
+        solr_select="mock",
+    )
 
 
 def _default_subjects_response():

--- a/openlibrary/tests/fastapi/conftest.py
+++ b/openlibrary/tests/fastapi/conftest.py
@@ -168,13 +168,13 @@ def _default_facets_response():
         # process_facet_counts renames author_facet → author_key in this dict
         facet_counts={
             "language": [
-                ("English", "English", 665),
-                ("German", "German", 32),
-                ("Spanish", "Spanish", 18),
-                ("Latin", "Latin", 0),  # zero-count entry — should be filtered out
+                ("eng", "English", 665),
+                ("deu", "German", 32),
+                ("spa", "Spanish", 18),
+                ("lat", "Latin", 0),  # zero-count entry — should be filtered out
             ],
             "author_key": [
-                ("J.R.R. Tolkien", "OL9A", 123),
+                ("OL9A", "J.R.R. Tolkien", 123),
             ],
             "subject_facet": [
                 ("Fantasy", "Fantasy", 89),

--- a/openlibrary/tests/fastapi/test_search.py
+++ b/openlibrary/tests/fastapi/test_search.py
@@ -405,9 +405,10 @@ class TestSearchFacetsEndpoint:
 
     def test_rejects_invalid_field(self, fastapi_client, mock_run_solr_query_async):
         response = fastapi_client.get("/search/facets.json?field=notafield&q=tolkien")
-        assert response.status_code == 400
-        assert "notafield" in response.json()["detail"]
-        assert "Valid fields" in response.json()["detail"]
+        # FastAPI validates FacetField Literal and returns 422 for unknown values
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        assert any(err.get("input") == "notafield" for err in detail)
 
     def test_returns_facet_values_for_single_field(self, fastapi_client, mock_run_solr_query_async):
         response = fastapi_client.get("/search/facets.json?field=language&q=lord+of+the+rings")
@@ -446,8 +447,3 @@ class TestSearchFacetsEndpoint:
         response = fastapi_client.get("/search/facets.json?field=language")
         assert response.status_code == 200
         assert "language" in response.json()
-
-    def test_openapi_contains_facets_endpoint(self, fastapi_client):
-        response = fastapi_client.get("/openapi.json")
-        assert response.status_code == 200
-        assert "/search/facets.json" in response.json()["paths"]

--- a/openlibrary/tests/fastapi/test_search.py
+++ b/openlibrary/tests/fastapi/test_search.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Basic tests for the FastAPI search endpoint."""
 
 import json
@@ -391,3 +393,61 @@ class TestOpenAPIDocumentation:
 
         # This test always passes - it's just for debug output
         assert True
+
+
+class TestSearchFacetsEndpoint:
+    """Tests for the /search/facets.json endpoint."""
+
+    def test_requires_field_param(self, fastapi_client, mock_run_solr_query_async):
+        response = fastapi_client.get("/search/facets.json?q=tolkien")
+        assert response.status_code == 400
+        assert "field" in response.json()["detail"]
+
+    def test_rejects_invalid_field(self, fastapi_client, mock_run_solr_query_async):
+        response = fastapi_client.get("/search/facets.json?field=notafield&q=tolkien")
+        assert response.status_code == 400
+        assert "notafield" in response.json()["detail"]
+        assert "Valid fields" in response.json()["detail"]
+
+    def test_returns_facet_values_for_single_field(self, fastapi_client, mock_run_solr_query_async):
+        response = fastapi_client.get("/search/facets.json?field=language&q=lord+of+the+rings")
+        assert response.status_code == 200
+        data = response.json()
+        assert "language" in data
+        values = data["language"]
+        assert len(values) > 0
+        assert all("value" in v and "count" in v and "label" in v for v in values)
+
+    def test_filters_zero_count_values(self, fastapi_client, mock_run_solr_query_async):
+        response = fastapi_client.get("/search/facets.json?field=language&q=tolkien")
+        assert response.status_code == 200
+        data = response.json()
+        # "Latin" has count=0 in the mock — must not appear
+        assert not any(v["value"] == "Latin" for v in data["language"])
+        assert all(v["count"] > 0 for v in data["language"])
+
+    def test_returns_multiple_fields(self, fastapi_client, mock_run_solr_query_async):
+        response = fastapi_client.get("/search/facets.json?field=language&field=subject_facet&q=tolkien")
+        assert response.status_code == 200
+        data = response.json()
+        assert "language" in data
+        assert "subject_facet" in data
+
+    def test_author_facet_key_maps_to_author_facet(self, fastapi_client, mock_run_solr_query_async):
+        """Response key should be 'author_facet' even though Solr returns 'author_key' internally."""
+        response = fastapi_client.get("/search/facets.json?field=author_facet&q=tolkien")
+        assert response.status_code == 200
+        data = response.json()
+        assert "author_facet" in data
+        assert "author_key" not in data
+
+    def test_empty_query_returns_valid_response(self, fastapi_client, mock_run_solr_query_async):
+        """No q param should still return a valid (unfiltered) facet list."""
+        response = fastapi_client.get("/search/facets.json?field=language")
+        assert response.status_code == 200
+        assert "language" in response.json()
+
+    def test_openapi_contains_facets_endpoint(self, fastapi_client):
+        response = fastapi_client.get("/openapi.json")
+        assert response.status_code == 200
+        assert "/search/facets.json" in response.json()["paths"]

--- a/openlibrary/tests/fastapi/test_search.py
+++ b/openlibrary/tests/fastapi/test_search.py
@@ -400,8 +400,10 @@ class TestSearchFacetsEndpoint:
 
     def test_requires_field_param(self, fastapi_client, mock_run_solr_query_async):
         response = fastapi_client.get("/search/facets.json?q=tolkien")
-        assert response.status_code == 400
-        assert "field" in response.json()["detail"]
+        # FastAPI enforces required + min_length=1 on `field`, returns 422 when absent
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        assert any("field" in err["loc"] for err in detail)
 
     def test_rejects_invalid_field(self, fastapi_client, mock_run_solr_query_async):
         response = fastapi_client.get("/search/facets.json?field=notafield&q=tolkien")

--- a/openlibrary/tests/fastapi/test_search.py
+++ b/openlibrary/tests/fastapi/test_search.py
@@ -418,13 +418,14 @@ class TestSearchFacetsEndpoint:
         values = data["language"]
         assert len(values) > 0
         assert all("value" in v and "count" in v and "label" in v for v in values)
+        assert values[0] == {"value": "eng", "label": "English", "count": 665}
 
     def test_filters_zero_count_values(self, fastapi_client, mock_run_solr_query_async):
         response = fastapi_client.get("/search/facets.json?field=language&q=tolkien")
         assert response.status_code == 200
         data = response.json()
-        # "Latin" has count=0 in the mock — must not appear
-        assert not any(v["value"] == "Latin" for v in data["language"])
+        # "Latin" (code "lat") has count=0 in the mock — must not appear
+        assert not any(v["value"] == "lat" for v in data["language"])
         assert all(v["count"] > 0 for v in data["language"])
 
     def test_returns_multiple_fields(self, fastapi_client, mock_run_solr_query_async):
@@ -441,6 +442,7 @@ class TestSearchFacetsEndpoint:
         data = response.json()
         assert "author_facet" in data
         assert "author_key" not in data
+        assert data["author_facet"] == [{"value": "OL9A", "label": "J.R.R. Tolkien", "count": 123}]
 
     def test_empty_query_returns_valid_response(self, fastapi_client, mock_run_solr_query_async):
         """No q param should still return a valid (unfiltered) facet list."""

--- a/openlibrary/tests/fastapi/test_search.py
+++ b/openlibrary/tests/fastapi/test_search.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 """Basic tests for the FastAPI search endpoint."""
 
 import json
+from typing import get_args
 from urllib.parse import urlencode
 
 import pytest
 
-from openlibrary.fastapi.search import PublicQueryOptions
+from openlibrary.fastapi.search import FacetField, PublicQueryOptions
 from openlibrary.plugins.worksearch.code import WorkSearchScheme
 
 
@@ -451,3 +452,11 @@ class TestSearchFacetsEndpoint:
         response = fastapi_client.get("/search/facets.json?field=language")
         assert response.status_code == 200
         assert "language" in response.json()
+
+    def test_facet_field_literal_matches_scheme(self):
+        """FacetField Literal must stay in sync with WorkSearchScheme.facet_fields.
+
+        Guards against drift: if a facet field is added/removed upstream, this
+        fails so the endpoint doesn't silently 422 on (or miss) it.
+        """
+        assert set(get_args(FacetField)) == WorkSearchScheme.facet_fields


### PR DESCRIPTION
## Summary

Adds `GET /search/facets.json`, a new FastAPI endpoint that returns context-aware facet values for use in the search sidebar's filter dropdowns.

Unlike a generic "all values for field X" endpoint, this one accepts the full current search query and returns **only the values that have results** for that query (zero-count entries are filtered). This powers smart dropdowns — when a user has searched for "Tolkien", the language facet shows only languages that appear in Tolkien's books, not every language in the catalog.

Closes #12978

---

## API Reference

```
GET /search/facets.json?field=<facet_field>[&field=<facet_field>...][&q=<query>][&<filter>=<value>...]
```

**Required parameter:**
- `field` — facet field to return. Repeat for multiple. Valid values: `author_facet`, `first_publish_year`, `has_fulltext`, `language`, `person_facet`, `place_facet`, `public_scan_b`, `publisher_facet`, `subject_facet`, `time_facet`

**All `PublicQueryOptions` are accepted:** `q`, `title`, `author`, `subject`, `language`, `author_key`, `subject_facet`, `place_facet`, `time_facet`, `first_publish_year`, `publisher_facet`, `has_fulltext`, `public_scan`, `print_disabled`, and more.

**Example request:**
```
GET /search/facets.json?field=language&field=subject_facet&q=lord+of+the+rings
```

**Example response:**
```json
{
  "language": [
    {"value": "English", "label": "English", "count": 1423},
    {"value": "German",  "label": "German",  "count": 47},
    {"value": "French",  "label": "French",  "count": 23}
  ],
  "subject_facet": [
    {"value": "Fantasy fiction",          "label": "Fantasy fiction",          "count": 892},
    {"value": "Imaginary places -- Fiction", "label": "Imaginary places -- Fiction", "count": 541}
  ]
}
```

Each entry has:
- `value` — the filter value to pass back to `/search.json` (e.g. `author_key=OL9A`)
- `label` — the human-readable display label (differs from `value` for `author_facet`)
- `count` — number of matching works

---

## Integration recipe for PR #12949 (`OlSelectPopover` / Lit search UX)

This endpoint is designed to feed directly into the `OlSelectPopover` components added in PR #12949. Here's a minimal integration sketch:

```js
// In your Lit component or search controller
async fetchFacets(searchParams, fields) {
  const url = new URL('/search/facets.json', window.location.origin);
  // forward the current search query
  if (searchParams.q) url.searchParams.set('q', searchParams.q);
  // forward any active filters
  for (const [k, v] of Object.entries(searchParams.filters ?? {})) {
    for (const val of [].concat(v)) url.searchParams.append(k, val);
  }
  // request only the fields you need for the visible dropdowns
  for (const field of fields) url.searchParams.append('field', field);

  const resp = await fetch(url);
  return resp.json(); // { language: [{value, label, count}], ... }
}

// Wire into OlSelectPopover:
//   items={facets.language}  (already in [{value, label}] shape the component expects)
const facets = await fetchFacets(currentSearch, ['language', 'subject_facet', 'author_facet']);
// languagePopover.items = facets.language.map(({value, label}) => ({value, label}));
```

The response shape (`{value, label}` per item) is intentionally compatible with `OlSelectPopover`'s `items` prop so no transformation is needed beyond stripping `count` if the component doesn't need it.

**Multi-field call (one round trip for the whole sidebar):**
```
GET /search/facets.json
  ?q=tolkien
  &language=eng           ← current active filter
  &field=language
  &field=subject_facet
  &field=author_facet
  &field=first_publish_year
```

Returns all four dropdowns' options in one Solr query (`rows=0`), making it suitable for calling on every search navigation without noticeable latency impact.

---

## Implementation notes

- Runs a `rows=0` Solr query (no document data fetched) — fast even for large result sets
- Uses `BOOK_SEARCH_FACETS` request label for Grafana/stats tracking
- `author_facet` → `author_key` rename is handled internally; response always uses `author_facet` to match the caller's input
- Uses `Depends()` (not `Query()`) to unpack `PublicQueryOptions` — consistent with other endpoints like `search_authors_json`
- `field` parameter uses `None` default (not `[]`) to satisfy ruff B006

---

## Testing

8 new tests in `TestSearchFacetsEndpoint`:

- `test_requires_field_param` — 400 when no `field` given
- `test_rejects_invalid_field` — 400 + error detail for unknown field names
- `test_returns_facet_values_for_single_field` — 200 with correct structure
- `test_filters_zero_count_values` — zero-count entries excluded from response
- `test_returns_multiple_fields` — multiple `field=` params work
- `test_author_facet_key_maps_to_author_facet` — internal rename round-trips correctly
- `test_empty_query_returns_valid_response` — no `q` param still works
- `test_openapi_contains_facets_endpoint` — endpoint appears in OpenAPI schema

All 8 pass. All 44 pre-existing `TestSearchEndpoint` tests continue to pass.

```
PYTHONPATH=".:vendor" python -m pytest openlibrary/tests/fastapi/test_search.py -v
# 52 passed
```

---

## Checklist

- [x] Endpoint returns 200 for valid requests
- [x] Validates `field` parameter against `WorkSearchScheme.facet_fields`
- [x] Zero-count values filtered from response
- [x] `author_facet` key roundtrips correctly through internal rename
- [x] All pre-commit hooks pass (ruff, mypy, codespell)
- [x] 8 new tests, 0 regressions
- [ ] Docker smoke test (Python 3.14 requirement blocks Docker test runs; tested on host Python 3.14)