### PR TITLE
fix: use diacritic-aware sort key for language names

### DIFF
--- a/openlibrary/plugins/worksearch/languages.py
+++ b/openlibrary/plugins/worksearch/languages.py
@@ -1,6 +1,7 @@
 """Language pages"""
 
 import logging
+import unicodedata
 from dataclasses import dataclass
 from typing import Literal, override
 
@@ -15,6 +16,12 @@ from openlibrary.utils.async_utils import async_bridge
 from . import search, subjects
 
 logger = logging.getLogger("openlibrary.worksearch")
+
+
+def _name_sort_key(name: str) -> str:
+    """Sort key for language names: strips diacritics and case-folds for correct alphabetical order."""
+    nfd = unicodedata.normalize("NFD", name)
+    return "".join(c for c in nfd if unicodedata.category(c) != "Mn").casefold()
 
 
 async def get_top_languages(
@@ -33,7 +40,7 @@ async def get_top_languages(
         )
         for (lang_key, count) in await get_all_language_counts("work")
     ]
-    results.sort(key=lambda x: x[sort].casefold() if sort == "name" else x[sort], reverse=sort in ("count", "ebook_edition_count"))
+    results.sort(key=lambda x: _name_sort_key(x[sort]) if sort == "name" else x[sort], reverse=sort in ("count", "ebook_edition_count"))
     return results[:limit]
 
 

--- a/openlibrary/plugins/worksearch/tests/test_languages.py
+++ b/openlibrary/plugins/worksearch/tests/test_languages.py
@@ -1,0 +1,24 @@
+"""Tests for openlibrary.plugins.worksearch.languages."""
+
+from openlibrary.plugins.worksearch.languages import _name_sort_key
+
+
+class TestNameSortKey:
+    def test_case_insensitive(self):
+        assert _name_sort_key("English") == _name_sort_key("english")
+
+    def test_diacritics_sort_with_base_letter(self):
+        # "É" should sort the same as "E", not after "Z"
+        assert _name_sort_key("Église") == _name_sort_key("eglise")
+
+    def test_diacritic_order(self):
+        # "Ébène" should sort before "F", not after "Z"
+        names = ["French", "Ébène", "German"]
+        sorted_names = sorted(names, key=_name_sort_key)
+        assert sorted_names == ["Ébène", "French", "German"]
+
+    def test_mixed_case_order(self):
+        # uppercase should not sort before lowercase
+        names = ["afrikaans", "English", "Zulu"]
+        sorted_names = sorted(names, key=_name_sort_key)
+        assert sorted_names == ["afrikaans", "English", "Zulu"]


### PR DESCRIPTION
Closes #11962                                                                                                       
                                                                                                                      
  fix: sort language names with diacritic-aware collation so accented characters sort correctly alongside their base  
  letters

**Technical**

  The `/languages?sort=name` endpoint was sorting language names using `.casefold()` as the sort key. This handled
  case-insensitivity but left diacritical characters (e.g. `é, ü, ñ`) sorting by their raw Unicode code points, placing
  them far after `Z` rather than alongside their base letters.

  Added a `_name_sort_key()` helper in `openlibrary/plugins/worksearch/languages.py` that:
  1. Decomposes names to NFD form via `unicodedata.normalize("NFD", name)` — splitting e.g. `é` into `e` + combining accent
  2. Strips combining characters (`unicodedata.category(c) != "Mn"`)
  3. Applies `.casefold()` for case-insensitive ordering

  Uses only Python stdlib (`unicodedata`) — no new dependencies.

**Testing**

1. Navigate to `/languages?sort=name`
2. Verify languages starting with accented characters (e.g. `Ébène`) appear near their base letter (`E`) rather than at the bottom of the list
3. Verify case-insensitive ordering — e.g. `afrikaans` and `Afrikaans` sort identically

Unit tests added in `openlibrary/plugins/worksearch/tests/test_languages.py` covering:

- Case-insensitive sorting
- Diacritics sorting with base letter
- Correct relative ordering of accented vs. unaccented names

  **Screenshot**

  No UI changes — this fix affects sort order only, no visual layout changes.

  **Stakeholders**

  @RayBB @tanisan101