### PR TITLE
refactor: convert Follow.html macro to template with safe attribute interpolation

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -4698,6 +4698,18 @@ msgstr ""
 msgid "Qualifying for Print Disability Special Access"
 msgstr ""
 
+#: follow/follow.html lists/list_follow.html
+msgid "Follow"
+msgstr ""
+
+#: follow/follow.html
+msgid "Unfollow"
+msgstr ""
+
+#: follow/follow.html
+msgid "Failed to update followers. Please try again in a few moments."
+msgstr ""
+
 #: history/sources.html
 msgid "record"
 msgstr ""
@@ -5526,10 +5538,6 @@ msgstr ""
 
 #: lists/list_follow.html
 msgid "🔒︎"
-msgstr ""
-
-#: Follow.html lists/list_follow.html
-msgid "Follow"
 msgstr ""
 
 #: lists/list_follow.html
@@ -7760,14 +7768,6 @@ msgstr ""
 
 #: EditionNavBar.html
 msgid "Go to next section"
-msgstr ""
-
-#: Follow.html
-msgid "Unfollow"
-msgstr ""
-
-#: Follow.html
-msgid "Failed to update followers. Please try again in a few moments."
 msgstr ""
 
 #: FormatExpiry.html

--- a/openlibrary/templates/account/follows.html
+++ b/openlibrary/templates/account/follows.html
@@ -13,7 +13,7 @@ $if follows:
         </div>
         <div>
           $if manage:
-            $:macros.Follow(follow['publisher'], following=1, link_track='FollowsPage|Follow')
+            $:render_template('follow/follow', follow['publisher'], following=1, link_track='FollowsPage|Follow')
         </div>
       </li>
     </ul>

--- a/openlibrary/templates/account/view.html
+++ b/openlibrary/templates/account/view.html
@@ -62,7 +62,7 @@ $var title: $header_title
       </div>
 
       $if not mb.is_my_page and mb.is_subscribed != -1:
-        $:macros.Follow(mb.username, following=mb.is_subscribed, link_track='MyBooksPageHeader|Follow')
+        $:render_template('follow/follow', mb.username, following=mb.is_subscribed, link_track='MyBooksPageHeader|Follow')
 
       $if 'followers' in mb.counts:
         <div class="social-wrapper">

--- a/openlibrary/templates/follow/follow.html
+++ b/openlibrary/templates/follow/follow.html
@@ -9,7 +9,6 @@ $ }
 $ user = get_current_user()
 $ subscriber = user and user.key
 $ custom_request_path = request_path if request_path != '' else request.fullpath
-$ link_track_attr = 'data-ol-link-track="%s"' % link_track.replace('"', '&quot;') if link_track else ''
 $ data_attr = get_preserve_intent_attrs(_("Follow"), publisher, "patron", custom_request_path) if not following else ''
 
 <div>
@@ -20,8 +19,14 @@ $ data_attr = get_preserve_intent_attrs(_("Follow"), publisher, "patron", custom
       <input type="hidden" value="$publisher" name="publisher"/>
       <input type="hidden" value="$custom_request_path" name="redir_url"/>
       $ css_treatment = 'delete' if following else 'primary'
-      <button type="submit" class="cta-btn cta-btn--$(css_treatment)" data-i18n="$json_encode(i18n_strings)" $link_track_attr $:data_attr>$(_("Unfollow") if following else _("Follow"))</button>
+      <button type="submit" class="cta-btn cta-btn--$(css_treatment)" data-i18n="$json_encode(i18n_strings)"
+        $if link_track:
+          data-ol-link-track="$link_track"
+        $:data_attr>$(_("Unfollow") if following else _("Follow"))</button>
     </form>
   $else:
-    <a class="cta-btn cta-btn--primary js-login-intent" href="/account/login?redirect=$(urlquote(custom_request_path))" $link_track_attr $:data_attr>$_("Follow")</a>
+    <a class="cta-btn cta-btn--primary js-login-intent" href="/account/login?redirect=$(urlquote(custom_request_path))"
+      $if link_track:
+        data-ol-link-track="$link_track"
+      $:data_attr>$_("Follow")</a>
 </div>

--- a/openlibrary/templates/lists/list_follow.html
+++ b/openlibrary/templates/lists/list_follow.html
@@ -2,7 +2,7 @@ $def with(lists, limit, user_key)
 
 $def render_follow_button(owner_username, is_subscribed):
   $ request = "/people/" + owner_username
-  $:macros.Follow(owner_username, following=is_subscribed, request_path=request, link_track='ListCardCarousel|Follow')
+  $:render_template('follow/follow', owner_username, following=is_subscribed, request_path=request, link_track='ListCardCarousel|Follow')
 
 $def list_card(list, owner, own_list):
     $ has_owner = owner

--- a/openlibrary/templates/type/user/view.html
+++ b/openlibrary/templates/type/user/view.html
@@ -16,7 +16,7 @@ $else:
 
 <div id="contentHead">
     $if is_public and not owners_page:
-        <div class="right">$:macros.Follow(username, following=is_subscribed, link_track='PatronPage|Follow')</div>
+        <div class="right">$:render_template('follow/follow', username, following=is_subscribed, link_track='PatronPage|Follow')</div>
     $:macros.databarView(page)
     <h1>$page.displayname</h1>
     <div class="small sansserif">


### PR DESCRIPTION
Closes #12634

refactor: convert `Follow.html` from macro to proper web.py template, eliminating unsafe `%`-string HTML attribute
building

  **Technical**

  The original `openlibrary/macros/Follow.html` built the `data-ol-link-track` attribute via Python `%` string formatting
  with a manual `.replace('"', '&quot;')` workaround (added in #12367). This only escaped double quotes, leaving angle
  brackets unescaped — a potential XSS vector.

  **Changes:**

  - Created `openlibrary/templates/follow/follow.html` — same logic as the macro, but uses web.py's native `$variable`
  interpolation inside attributes, which auto-escapes all special characters. The conditional `link_track` attribute is
  handled using a `$if link_track`: block inside the element tag (consistent with the pattern in
  `templates/home/onboarding_card.html`), avoiding string building entirely
  - Removed `openlibrary/macros/Follow.html`
  - Updated all 4 call sites from `$:macros.Follow(...)` to `$:render_template('follow/follow', ...)`

  Note: `templates/type/edition/modal_links.html` uses the same unsafe `%`-string pattern for `data-ol-link-track` — left
  out of scope for this PR but worth a follow-up.

  **Testing**

1. Navigate to a public patron page (e.g.` /people/<username>`) — verify Follow/Unfollow button renders correctly
2. Navigate to `/account/follows` — verify Follow button renders in the manage view
3. Navigate to your own My Books page while viewing another patron — verify the Follow button in the header
4. Navigate to a list card carousel — verify the Follow button renders on list cards
5. Confirm` data-ol-link-track` attribute is present on the rendered button with the correct value

  **Screenshot**

  No visual changes — this is a structural refactor. Button appearance and behaviour are identical.

  **Stakeholders**

  @mekarpeles @Saad259