### PR TITLE
Make community_edits_queue require login ; causing db strain

### DIFF
--- a/openlibrary/plugins/upstream/edits.py
+++ b/openlibrary/plugins/upstream/edits.py
@@ -7,7 +7,7 @@ import web
 
 from infogami.infobase.client import ClientException
 from infogami.utils import delegate
-from infogami.utils.view import render_template
+from infogami.utils.view import render_template, require_login
 from openlibrary import accounts
 from openlibrary.core.edits import ApiMode, CommunityEditsQueue, get_status_for_view
 from openlibrary.utils.request_context import site
@@ -80,6 +80,7 @@ def perform_merge_update(mrid: str | None, olids: str, comment: str | None) -> N
 class community_edits_queue(delegate.page):
     path = "/merges"
 
+    @require_login
     def GET(self) -> str | web.HTTPError:
         i = web.input(
             page=1,
@@ -132,6 +133,7 @@ class community_edits_queue(delegate.page):
             merge_requests=merge_requests,
         )
 
+    @require_login
     def POST(self):
         if not (user := accounts.get_current_user()) or not user.is_member_of_any(ALLOWED_USERGROUPS):
             raise web.unauthorized()


### PR DESCRIPTION
Seeing perf strain with workers saturated on db requests. Saw a lot of queries like `SELECT DISTINCT reviewer FROM community_edits_queue WHERE reviewer IS NOT NULL`, which come from the /merges page. Making that require login, it doesn't serve much value to non logged in users.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Confirmed still works and can filter when logged in.

Confirmed logged out get redirect to login page.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

<img width="1890" height="342" alt="image" src="https://github.com/user-attachments/assets/8b7155f9-db66-4a45-964b-f816a47bbedd" />


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
