### PR TITLE
Enable keepalive from nginx to haproxy to reduce www0 CPU

### DIFF
--- a/docker/web_nginx.conf
+++ b/docker/web_nginx.conf
@@ -49,6 +49,11 @@ map $request_uri $probably_requires_referer {
 # Provides $should_challenge
 include /olsystem/etc/nginx/verify_human.conf;
 
+upstream web_haproxy {
+    server web_haproxy:7072;
+    keepalive 64;
+}
+
 # Keep in sync with covers_nginx.conf
 server {
     listen 80 default;
@@ -170,16 +175,12 @@ server {
         }
 
         # Haproxy to better handle load/traffic
-        proxy_pass http://web_haproxy:7072;
+        proxy_pass http://web_haproxy;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
         proxy_set_header Host $http_host;
-
-        # Gunicorn takes IP from this header
         proxy_set_header X-Forwarded-For $remote_addr;
-
-        # Hack to make the app pick the right url scheme even when the
-        # app server is http only.
         proxy_set_header X-Scheme $scheme;
-
     }
 
     location ~ ^(/api/.*|.*\.json)$ {
@@ -207,7 +208,9 @@ server {
         }
 
         # Haproxy to better handle load/traffic
-        proxy_pass http://web_haproxy:7072;
+        proxy_pass http://web_haproxy;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header X-Scheme $scheme;


### PR DESCRIPTION
Perf improvement to help with ol-www0 strain. Keepalive TCP connections between nginx and haproxy.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
