### PR TITLE
Migrate account anonymize endpoint to FastAPI

### DIFF
--- a/openlibrary/accounts/__init__.py
+++ b/openlibrary/accounts/__init__.py
@@ -39,18 +39,29 @@ class RunAs:
         if not self.tmp_account:
             raise KeyError("Invalid username")
 
+    def _set_conn_auth_token(self, token: str | None) -> None:
+        """Set the auth token on all available connections.
+
+        The canonical connection lives on ``site.get()._conn`` (set by both
+        web.py and FastAPI middleware).  Some legacy code also reads
+        ``web.ctx.conn`` directly, so we set it there too when available.
+        """
+        site.get()._conn.set_auth_token(token)
+        if hasattr(web.ctx, "conn"):
+            web.ctx.conn.set_auth_token(token)
+
     def __enter__(self):
         # Save token of currently logged in user (or no-user)
         account = get_current_user()
         self.calling_user_auth_token = account and account.generate_login_code()
 
         # Temporarily become user
-        web.ctx.conn.set_auth_token(self.tmp_account.generate_login_code())
+        self._set_conn_auth_token(self.tmp_account.generate_login_code())
         return self.tmp_account
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         # Return auth token to original user or no-user
-        web.ctx.conn.set_auth_token(self.calling_user_auth_token)
+        self._set_conn_auth_token(self.calling_user_auth_token)
 
 
 # Confirmed functions (these have to be here)

--- a/openlibrary/fastapi/account.py
+++ b/openlibrary/fastapi/account.py
@@ -4,17 +4,21 @@ FastAPI account endpoints for authentication.
 
 from __future__ import annotations
 
+import logging
 import os
 from typing import Annotated
 from urllib.parse import unquote, urlparse
 
+import web
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request, Response, status
 from pydantic import BaseModel, Field
 
 from infogami import config
 from openlibrary import accounts
+from openlibrary.accounts import InternetArchiveAccount, OpenLibraryAccount, RunAs
 from openlibrary.accounts.model import audit_accounts, generate_login_code_for_user
 from openlibrary.core import stats
+from openlibrary.core.auth import ExpiredTokenError, HMACToken, MissingKeyError
 from openlibrary.fastapi.auth import (
     AuthenticatedUser,
     get_authenticated_user,
@@ -22,10 +26,29 @@ from openlibrary.fastapi.auth import (
 )
 from openlibrary.plugins.upstream import account as legacy_account
 from openlibrary.plugins.upstream.account import get_login_error
+from openlibrary.utils.request_context import site
+
+logger = logging.getLogger("openlibrary.fastapi.account")
 
 router = APIRouter()
 
 SHOW_INTERNAL_IN_SCHEMA = os.getenv("LOCAL_DEV") is not None
+
+# Allow overriding ia_sync_secret via env var (for dev/test environments).
+# Legacy production config sets this value outside the repo.
+_ia_sync_secret = os.getenv("IA_SYNC_SECRET")
+if _ia_sync_secret:
+    config.ia_sync_secret = _ia_sync_secret
+
+
+class AnonymizeResponse(BaseModel):
+    new_username: str = Field(description="The new anonymous username assigned to the patron")
+    booknotes_count: int = Field(description="Number of booknotes deleted")
+    ratings_count: int = Field(description="Number of ratings anonymized")
+    observations_count: int = Field(description="Number of observations anonymized")
+    bookshelves_count: int = Field(description="Number of bookshelf entries anonymized")
+    merge_request_count: int = Field(description="Number of merge requests updated")
+    bestbooks_count: int = Field(description="Number of bestbook entries anonymized")
 
 
 def _safe_redirect(url: str, default: str = "/") -> str:
@@ -321,3 +344,71 @@ async def logout(request: Request) -> Response:
     response.delete_cookie("sfw")
 
     return response
+
+
+@router.post(
+    "/account/anonymize.json",
+    response_model=AnonymizeResponse,
+    tags=["internal"],
+    include_in_schema=SHOW_INTERNAL_IN_SCHEMA,
+)
+async def anonymize_account(
+    request: Request,
+    test: Annotated[str, Form()] = "false",
+    digest: Annotated[str, Form()] = "",
+    msg: Annotated[str, Form()] = "",
+) -> AnonymizeResponse:
+    test_mode = test == "true"
+
+    try:
+        if not HMACToken.verify(digest, msg, "ia_sync_secret", delimiter=":", unix_time=True):
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Bad Request")
+    except ExpiredTokenError:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+    except MissingKeyError:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Service Unavailable")
+
+    auth_header = request.headers.get("authorization", "")
+    try:
+        _, keys = auth_header.split("LOW ", 1)
+        s3_access, s3_secret = keys.split(":", 1)
+        s3_access = s3_access.strip()
+        s3_secret = s3_secret.strip()
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Malformed Authorization Header")
+
+    xauthn_response = InternetArchiveAccount.s3auth(s3_access, s3_secret)
+    if "error" in xauthn_response:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not Found")
+
+    s = site.get()
+    _old_site = getattr(web.ctx, "site", None)
+    _old_conn = getattr(web.ctx, "conn", None)
+    _had_site = hasattr(web.ctx, "site")
+    _had_conn = hasattr(web.ctx, "conn")
+    web.ctx.site = s
+    web.ctx.conn = s._conn
+    try:
+        ol_account = OpenLibraryAccount.get_by_link(xauthn_response.get("itemname", ""))
+        if not ol_account:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not Found")
+
+        try:
+            with RunAs(ol_account.username):
+                result = ol_account.anonymize(test=test_mode)
+        except Exception as e:  # noqa: BLE001
+            logger.error(e)
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal Server Error")
+    finally:
+        if _had_site:
+            web.ctx.site = _old_site
+        else:
+            web.ctx.pop("site", None)
+        if _had_conn:
+            web.ctx.conn = _old_conn
+        else:
+            web.ctx.pop("conn", None)
+
+    return AnonymizeResponse(**result)

--- a/openlibrary/fastapi/account.py
+++ b/openlibrary/fastapi/account.py
@@ -6,11 +6,9 @@ from __future__ import annotations
 
 import logging
 import os
-from contextlib import contextmanager
 from typing import Annotated
 from urllib.parse import unquote, urlparse
 
-import web
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request, Response, status
 from pydantic import BaseModel, Field
 
@@ -27,7 +25,6 @@ from openlibrary.fastapi.auth import (
 )
 from openlibrary.plugins.upstream import account as legacy_account
 from openlibrary.plugins.upstream.account import get_login_error
-from openlibrary.utils.request_context import site
 
 logger = logging.getLogger("openlibrary.fastapi.account")
 
@@ -50,34 +47,6 @@ class AnonymizeResponse(BaseModel):
     bookshelves_count: int = Field(description="Number of bookshelf entries anonymized")
     merge_request_count: int = Field(description="Number of merge requests updated")
     bestbooks_count: int = Field(description="Number of bestbook entries anonymized")
-
-
-@contextmanager
-def _web_ctx_from_site():
-    """
-    Temporarily configure web.ctx.site and web.ctx.conn for legacy code
-    (e.g. RunAs, OpenLibraryAccount.get_by_link) that accesses them
-    directly.  In FastAPI handlers the ``site`` ContextVar is set by
-    middleware but ``web.ctx`` is not.
-    """
-    s = site.get()
-    _old_site = getattr(web.ctx, "site", None)
-    _old_conn = getattr(web.ctx, "conn", None)
-    _had_site = hasattr(web.ctx, "site")
-    _had_conn = hasattr(web.ctx, "conn")
-    web.ctx.site = s
-    web.ctx.conn = s._conn
-    try:
-        yield
-    finally:
-        if _had_site:
-            web.ctx.site = _old_site
-        else:
-            web.ctx.pop("site", None)
-        if _had_conn:
-            web.ctx.conn = _old_conn
-        else:
-            web.ctx.pop("conn", None)
 
 
 def _safe_redirect(url: str, default: str = "/") -> str:
@@ -412,21 +381,19 @@ async def anonymize_account(
     if "error" in xauthn_response:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not Found")
 
-    with _web_ctx_from_site():
-        ol_account = OpenLibraryAccount.get_by_link(xauthn_response.get("itemname", ""))
-        if not ol_account:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not Found")
+    ol_account = OpenLibraryAccount.get_by_link(xauthn_response.get("itemname", ""))
+    if not ol_account:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not Found")
 
-        try:
-            # RunAs is needed because anonymize() writes to infobase
-            # (removes from usergroups, deletes profile, clears store entries)
-            # using web.ctx.conn, which requires the target user's auth token.
-            # This endpoint authenticates via HMAC+S3, not a user session, so
-            # there is no auth token on the connection without RunAs.
-            with RunAs(ol_account.username):
-                result = ol_account.anonymize(test=test_mode)
-        except Exception as e:  # noqa: BLE001
-            logger.error(e)
-            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal Server Error")
+    try:
+        # RunAs sets the auth token on the connection (via site ContextVar)
+        # so that anonymize() can write to infobase as the target user.
+        # This endpoint authenticates via HMAC+S3, not a user session, so
+        # there is no auth token on the connection without RunAs.
+        with RunAs(ol_account.username):
+            result = ol_account.anonymize(test=test_mode)
+    except Exception as e:  # noqa: BLE001
+        logger.error(e)
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal Server Error")
 
     return AnonymizeResponse(**result)

--- a/openlibrary/fastapi/account.py
+++ b/openlibrary/fastapi/account.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import logging
 import os
+from contextlib import contextmanager
 from typing import Annotated
 from urllib.parse import unquote, urlparse
 
@@ -38,7 +39,7 @@ SHOW_INTERNAL_IN_SCHEMA = os.getenv("LOCAL_DEV") is not None
 # Legacy production config sets this value outside the repo.
 _ia_sync_secret = os.getenv("IA_SYNC_SECRET")
 if _ia_sync_secret:
-    config.ia_sync_secret = _ia_sync_secret
+    config.ia_sync_secret = _ia_sync_secret  # type: ignore[attr-defined]
 
 
 class AnonymizeResponse(BaseModel):
@@ -49,6 +50,34 @@ class AnonymizeResponse(BaseModel):
     bookshelves_count: int = Field(description="Number of bookshelf entries anonymized")
     merge_request_count: int = Field(description="Number of merge requests updated")
     bestbooks_count: int = Field(description="Number of bestbook entries anonymized")
+
+
+@contextmanager
+def _web_ctx_from_site():
+    """
+    Temporarily configure web.ctx.site and web.ctx.conn for legacy code
+    (e.g. RunAs, OpenLibraryAccount.get_by_link) that accesses them
+    directly.  In FastAPI handlers the ``site`` ContextVar is set by
+    middleware but ``web.ctx`` is not.
+    """
+    s = site.get()
+    _old_site = getattr(web.ctx, "site", None)
+    _old_conn = getattr(web.ctx, "conn", None)
+    _had_site = hasattr(web.ctx, "site")
+    _had_conn = hasattr(web.ctx, "conn")
+    web.ctx.site = s
+    web.ctx.conn = s._conn
+    try:
+        yield
+    finally:
+        if _had_site:
+            web.ctx.site = _old_site
+        else:
+            web.ctx.pop("site", None)
+        if _had_conn:
+            web.ctx.conn = _old_conn
+        else:
+            web.ctx.pop("conn", None)
 
 
 def _safe_redirect(url: str, default: str = "/") -> str:
@@ -383,32 +412,21 @@ async def anonymize_account(
     if "error" in xauthn_response:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not Found")
 
-    s = site.get()
-    _old_site = getattr(web.ctx, "site", None)
-    _old_conn = getattr(web.ctx, "conn", None)
-    _had_site = hasattr(web.ctx, "site")
-    _had_conn = hasattr(web.ctx, "conn")
-    web.ctx.site = s
-    web.ctx.conn = s._conn
-    try:
+    with _web_ctx_from_site():
         ol_account = OpenLibraryAccount.get_by_link(xauthn_response.get("itemname", ""))
         if not ol_account:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not Found")
 
         try:
+            # RunAs is needed because anonymize() writes to infobase
+            # (removes from usergroups, deletes profile, clears store entries)
+            # using web.ctx.conn, which requires the target user's auth token.
+            # This endpoint authenticates via HMAC+S3, not a user session, so
+            # there is no auth token on the connection without RunAs.
             with RunAs(ol_account.username):
                 result = ol_account.anonymize(test=test_mode)
         except Exception as e:  # noqa: BLE001
             logger.error(e)
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal Server Error")
-    finally:
-        if _had_site:
-            web.ctx.site = _old_site
-        else:
-            web.ctx.pop("site", None)
-        if _had_conn:
-            web.ctx.conn = _old_conn
-        else:
-            web.ctx.pop("conn", None)
 
     return AnonymizeResponse(**result)

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -1327,6 +1327,7 @@ class account_waitlist(delegate.page):
 #         return render.notfound(path, create=False)
 
 
+@deprecated("migrated to fastapi")
 class account_anonymization_json(delegate.page):
     path = "/account/anonymize"
     encoding = "json"

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -25,7 +25,6 @@ from infogami.utils.view import (
 )
 from openlibrary import accounts  # noqa: F401 side effects may be needed
 from openlibrary.plugins.upstream import (
-    account,  # noqa: F401 side effects may be needed
     addbook,
     addtag,
     borrow,  # noqa: F401 side effects may be needed

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -25,6 +25,7 @@ from infogami.utils.view import (
 )
 from openlibrary import accounts  # noqa: F401 side effects may be needed
 from openlibrary.plugins.upstream import (
+    account,  # noqa: F401 side effects may be needed
     addbook,
     addtag,
     borrow,  # noqa: F401 side effects may be needed

--- a/openlibrary/tests/fastapi/test_account.py
+++ b/openlibrary/tests/fastapi/test_account.py
@@ -2,15 +2,92 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-from fastapi.testclient import TestClient
+from openlibrary.core.auth import ExpiredTokenError, MissingKeyError
+from openlibrary.utils.request_context import RequestContextVars, req_context, site
 
-from openlibrary.asgi_app import app
+_DEFAULT_HEADER = "LOW ak:sk"
+_SENTINEL = object()
 
 
-def test_login_deletes_pending_action_cookie_on_valid_redirect():
-    client = TestClient(app)
+def _anonymize_post(
+    client,
+    *,
+    data=None,
+    headers=None,
+    hmac_return_value=True,
+    hmac_side_effect=None,
+    s3auth_result=None,
+    get_by_link_result=_SENTINEL,
+    anonymize_return_value=None,
+    anonymize_side_effect=None,
+):
+    if data is None:
+        data = {"digest": "d", "msg": "m"}
+    if headers is None:
+        headers = {"Authorization": _DEFAULT_HEADER}
+
+    hmac_kw = {}
+    if hmac_side_effect is not None:
+        hmac_kw["side_effect"] = hmac_side_effect
+    else:
+        hmac_kw["return_value"] = hmac_return_value
+
+    if s3auth_result is None:
+        s3auth_result = {"itemname": "test-item"}
+
+    if get_by_link_result is _SENTINEL:
+        mock_account = MagicMock()
+        mock_account.username = "testuser"
+        mock_account.anonymize.return_value = anonymize_return_value or {
+            "new_username": "anonymous-abc123",
+            "booknotes_count": 0,
+            "ratings_count": 0,
+            "observations_count": 0,
+            "bookshelves_count": 0,
+            "merge_request_count": 0,
+            "bestbooks_count": 0,
+        }
+        get_by_link_return = mock_account
+    else:
+        mock_account = get_by_link_result
+        get_by_link_return = get_by_link_result
+
+    if anonymize_side_effect is not None:
+        mock_account.anonymize.side_effect = anonymize_side_effect
+
+    _site_token = site.set(MagicMock())
+    _req_token = req_context.set(
+        RequestContextVars(
+            x_forwarded_for=None,
+            user_agent=None,
+            lang="en",
+            solr_editions=True,
+            print_disabled=False,
+        )
+    )
+    try:
+        with (
+            patch("openlibrary.fastapi.account.HMACToken.verify", **hmac_kw),
+            patch("openlibrary.fastapi.account.InternetArchiveAccount.s3auth", return_value=s3auth_result),
+            patch("openlibrary.fastapi.account.OpenLibraryAccount.get_by_link", return_value=get_by_link_return),
+            patch("openlibrary.fastapi.account.RunAs"),
+            patch("openlibrary.fastapi.account.logger"),
+        ):
+            response = client.post(
+                "/account/anonymize.json",
+                data=data,
+                headers=headers,
+            )
+    finally:
+        site.reset(_site_token)
+        req_context.reset(_req_token)
+
+    return response, mock_account
+
+
+def test_login_deletes_pending_action_cookie_on_valid_redirect(fastapi_client):
     with (
         patch("openlibrary.fastapi.account.audit_accounts") as mock_audit,
         patch("openlibrary.fastapi.account.generate_login_code_for_user") as mock_gen_code,
@@ -18,8 +95,7 @@ def test_login_deletes_pending_action_cookie_on_valid_redirect():
         mock_audit.return_value = {"ol_username": "testuser"}
         mock_gen_code.return_value = "token"
 
-        # Case 1: Valid redirect -> deletes preserve intent cookie
-        response = client.post(
+        response = fastapi_client.post(
             "/account/login",
             data={"username": "testuser", "password": "password", "redirect": "/books"},
             follow_redirects=False,
@@ -27,12 +103,10 @@ def test_login_deletes_pending_action_cookie_on_valid_redirect():
         assert response.status_code == 303
         assert response.headers["Location"] == "/books"
 
-        # Check if the set-cookie header deletes "pending_action"
         set_cookies = [val for key, val in response.headers.multi_items() if key.lower() == "set-cookie"]
         assert any("pending_action=" in header for header in set_cookies)
 
-        # Case 2: Invalid/unsafe redirect -> does not delete cookie, redirects to home /
-        response = client.post(
+        response = fastapi_client.post(
             "/account/login",
             data={
                 "username": "testuser",
@@ -46,3 +120,78 @@ def test_login_deletes_pending_action_cookie_on_valid_redirect():
 
         set_cookies = [val for key, val in response.headers.multi_items() if key.lower() == "set-cookie"]
         assert not any("pending_action=" in header for header in set_cookies)
+
+
+class TestAnonymizeAccount:
+    def test_success(self, fastapi_client):
+        resp, mock_account = _anonymize_post(fastapi_client)
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["new_username"] == "anonymous-abc123"
+        mock_account.anonymize.assert_called_once_with(test=False)
+
+    def test_success_with_test_mode(self, fastapi_client):
+        resp, mock_account = _anonymize_post(
+            fastapi_client,
+            data={"test": "true", "digest": "d", "msg": "m"},
+        )
+
+        assert resp.status_code == 200
+        mock_account.anonymize.assert_called_once_with(test=True)
+
+    def test_hmac_failure(self, fastapi_client):
+        resp, _ = _anonymize_post(fastapi_client, hmac_return_value=False)
+
+        assert resp.status_code == 401
+        assert resp.json()["detail"] == "Unauthorized"
+
+    def test_expired_token(self, fastapi_client):
+        resp, _ = _anonymize_post(fastapi_client, hmac_side_effect=ExpiredTokenError())
+
+        assert resp.status_code == 401
+        assert resp.json()["detail"] == "Unauthorized"
+
+    def test_missing_key(self, fastapi_client):
+        resp, _ = _anonymize_post(fastapi_client, hmac_side_effect=MissingKeyError())
+
+        assert resp.status_code == 503
+        assert resp.json()["detail"] == "Service Unavailable"
+
+    def test_bad_hmac_format(self, fastapi_client):
+        resp, _ = _anonymize_post(fastapi_client, hmac_side_effect=ValueError())
+
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Bad Request"
+
+    def test_malformed_auth_header(self, fastapi_client):
+        resp, _ = _anonymize_post(fastapi_client, headers={"Authorization": "BAD bad_format"})
+
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Malformed Authorization Header"
+
+    def test_missing_auth_header(self, fastapi_client):
+        resp, _ = _anonymize_post(fastapi_client, headers={})
+
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Malformed Authorization Header"
+
+    def test_s3_auth_failure(self, fastapi_client):
+        resp, _ = _anonymize_post(fastapi_client, s3auth_result={"error": "not found"})
+
+        assert resp.status_code == 404
+
+    def test_account_not_found(self, fastapi_client):
+        resp, _ = _anonymize_post(fastapi_client, get_by_link_result=None)
+
+        assert resp.status_code == 404
+
+    def test_internal_error(self, fastapi_client):
+        mock_account = MagicMock()
+        mock_account.username = "testuser"
+        mock_account.anonymize.side_effect = RuntimeError("something went wrong")
+
+        resp, _ = _anonymize_post(fastapi_client, get_by_link_result=mock_account)
+
+        assert resp.status_code == 500
+        assert resp.json()["detail"] == "Internal Server Error"

--- a/openlibrary/tests/fastapi/test_account.py
+++ b/openlibrary/tests/fastapi/test_account.py
@@ -95,6 +95,7 @@ def test_login_deletes_pending_action_cookie_on_valid_redirect(fastapi_client):
         mock_audit.return_value = {"ol_username": "testuser"}
         mock_gen_code.return_value = "token"
 
+        # Case 1: Valid redirect -> deletes preserve intent cookie
         response = fastapi_client.post(
             "/account/login",
             data={"username": "testuser", "password": "password", "redirect": "/books"},
@@ -103,9 +104,11 @@ def test_login_deletes_pending_action_cookie_on_valid_redirect(fastapi_client):
         assert response.status_code == 303
         assert response.headers["Location"] == "/books"
 
+        # Check if the set-cookie header deletes "pending_action"
         set_cookies = [val for key, val in response.headers.multi_items() if key.lower() == "set-cookie"]
         assert any("pending_action=" in header for header in set_cookies)
 
+        # Case 2: Invalid/unsafe redirect -> does not delete cookie, redirects to home /
         response = fastapi_client.post(
             "/account/login",
             data={


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR migrates `account_anonymization_json` to FastAPI as part of the ongoing web.py to FastAPI migration effort across OL.

### Technical
<!-- What should be noted about the implementation? -->

- Add `POST /account/anonymize.json` FastAPI endpoint
- `AnonymizeResponse` Pydantic model with 7 typed fields
- HMAC verification via HMACToken (unix_time=True, delimiter=':') matching legacy behaviour
- S3 auth via `InternetArchiveAccount.s3auth,` account lookup via `get_by_link`
- Legacy `account_anonymization_json` marked `@deprecated("migrated to fastapi")`

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
`docker compose run --rm home pytest openlibrary/tests/fastapi/test_account.py -v`

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
