### PR TITLE
fix(solr): replace hanging temp-Solr migration with fast-fail error message

### DIFF
--- a/docker/ol-local-solr-start.sh
+++ b/docker/ol-local-solr-start.sh
@@ -2,8 +2,9 @@
 set -euo pipefail
 
 # Solr startup wrapper for local dev
-# Compares OL schema file to Solr's core schema file, deletes core if different
-# Then runs solr-precreate which creates new core or uses existing
+# Compares OL schema file to Solr's core schema file; exits with a clear error
+# message if they differ (Solr 10 does not support automatic core migration).
+# Then runs solr-precreate which creates new core or uses existing.
 # Only runs in dev mode (LOCAL_DEV=true)
 
 PREFIX="[ol-local-solr-start]"
@@ -28,28 +29,13 @@ fi
 if [ -f "$OL_SCHEMA_FILE" ] && [ -f "$SOLR_SCHEMA_FILE" ]; then
     # If the schema files differ
     if ! diff -q "$OL_SCHEMA_FILE" "$SOLR_SCHEMA_FILE" >/dev/null 2>&1; then
-        echo "${PREFIX} Schema files has been updated. Attempting to resolve by deleting and recreating Solr core..."
-
-        # Start Solr in background (on tmp port 8989)
-        TMP_SOLR_PORT=8989
-        solr start -p $TMP_SOLR_PORT
-        # Wait for solr core to be ready for searching
-        until curl -s -o /dev/null -w "%{http_code}" "http://localhost:${TMP_SOLR_PORT}/solr/${CORE_NAME}/select?q=*:*&rows=0&wt=json" | grep -q "200"; do
-            sleep 1;
-        done
-
-        TOTAL_SOLR_DOCS=$(curl -s "http://localhost:${TMP_SOLR_PORT}/solr/${CORE_NAME}/select?q=*:*&rows=0&wt=json" | grep -oE '"numFound":[0-9]+' | grep -oE '[0-9]+')
-        echo "${PREFIX} Current Solr core has $TOTAL_SOLR_DOCS documents"
-
-        # If there are more than 10000 documents, error and exit instead of deleting core
-        if [ "$TOTAL_SOLR_DOCS" -gt 10000 ]; then
-            echo "${PREFIX} ERROR: Solr core has more than 10000 documents. Refusing to delete core to prevent data loss."
-            solr stop -p $TMP_SOLR_PORT
-            exit 1
-        fi
-
-        solr delete -c "$CORE_NAME" --solr-url "http://localhost:$TMP_SOLR_PORT"
-        solr stop -p $TMP_SOLR_PORT
+        echo "${PREFIX} ERROR: managed-schema.xml has changed since the Solr core was created."
+        echo "${PREFIX} Solr 10 does not support automatic core migration."
+        echo "${PREFIX} To apply the new schema, delete the Solr data volume and restart:"
+        echo "${PREFIX}   docker compose down -v && docker compose up -d"
+        echo "${PREFIX} WARNING: this deletes your local Solr index. Safe in local dev;"
+        echo "${PREFIX} the index will be rebuilt on next startup via 'make reindex-solr'."
+        exit 1
     fi
 fi
 

--- a/docker/ol-local-solr-start.sh
+++ b/docker/ol-local-solr-start.sh
@@ -2,8 +2,7 @@
 set -euo pipefail
 
 # Solr startup wrapper for local dev
-# Compares OL schema file to Solr's core schema file; exits with a clear error
-# message if they differ (Solr 10 does not support automatic core migration).
+# Check for config file changes that require a new solr data volume.
 # Then runs solr-precreate which creates new core or uses existing.
 # Only runs in dev mode (LOCAL_DEV=true)
 
@@ -18,6 +17,17 @@ OL_SCHEMA_FILE="${CONFIG_PATH}/conf/managed-schema.xml"
 CORE_NAME="openlibrary"
 SOLR_SCHEMA_FILE="/var/solr/data/${CORE_NAME}/conf/managed-schema.xml"
 
+echo_reset_instructions() {
+    echo "${PREFIX}"
+    echo "${PREFIX} To fix this, delete the Solr data volume and restart:"
+    echo "${PREFIX}     docker compose down"
+    echo "${PREFIX}     docker volume rm openlibrary_solr-data openlibrary_solr-updater-data"
+    echo "${PREFIX}     docker compose up -d"
+    echo "${PREFIX}"
+    echo "${PREFIX} Note this deletes your local Solr index. Safe in local dev;"
+    echo "${PREFIX} the index will be rebuilt on next startup."
+}
+
 echo "${PREFIX} Running"
 
 if [ "$LOCAL_DEV" != "true" ]; then
@@ -30,13 +40,25 @@ if [ -f "$OL_SCHEMA_FILE" ] && [ -f "$SOLR_SCHEMA_FILE" ]; then
     # If the schema files differ
     if ! diff -q "$OL_SCHEMA_FILE" "$SOLR_SCHEMA_FILE" >/dev/null 2>&1; then
         echo "${PREFIX} ERROR: managed-schema.xml has changed since the Solr core was created."
-        echo "${PREFIX} Solr 10 does not support automatic core migration."
-        echo "${PREFIX} To apply the new schema, delete the Solr data volume and restart:"
-        echo "${PREFIX}   docker compose down -v && docker compose up -d"
-        echo "${PREFIX} WARNING: this deletes your local Solr index. Safe in local dev;"
-        echo "${PREFIX} the index will be rebuilt on next startup via 'make reindex-solr'."
+        diff "$OL_SCHEMA_FILE" "$SOLR_SCHEMA_FILE" 2>&1 | sed "s/^/${PREFIX} /"
+        echo_reset_instructions
         exit 1
     fi
+fi
+
+# Check Solr version against the stamp written on first startup.
+# $SOLR_VERSION is provided by the official Solr Docker image.
+SOLR_VERSION_FILE="/var/solr/data/.ol_local_solr_version"
+
+if [ -f "$SOLR_VERSION_FILE" ]; then
+    STORED_VERSION=$(cat "$SOLR_VERSION_FILE")
+    if [ "$STORED_VERSION" != "$SOLR_VERSION" ]; then
+        echo "${PREFIX} ERROR: Solr data volume was created with Solr ${STORED_VERSION}, but the current image is Solr ${SOLR_VERSION}."
+        echo_reset_instructions
+        exit 1
+    fi
+else
+    echo "$SOLR_VERSION" > "$SOLR_VERSION_FILE"
 fi
 
 # In all cases, exec into precreate

--- a/docker/ol-local-solr-start.sh
+++ b/docker/ol-local-solr-start.sh
@@ -40,14 +40,16 @@ if [ -f "$OL_SCHEMA_FILE" ] && [ -f "$SOLR_SCHEMA_FILE" ]; then
     # If the schema files differ
     if ! diff -q "$OL_SCHEMA_FILE" "$SOLR_SCHEMA_FILE" >/dev/null 2>&1; then
         echo "${PREFIX} ERROR: managed-schema.xml has changed since the Solr core was created."
-        diff "$OL_SCHEMA_FILE" "$SOLR_SCHEMA_FILE" 2>&1 | sed "s/^/${PREFIX} /"
+        echo "${PREFIX}"
+        echo "${PREFIX} Diff:"
+        diff "$OL_SCHEMA_FILE" "$SOLR_SCHEMA_FILE" 2>&1 | sed "s/^/${PREFIX} /" || true
         echo_reset_instructions
         exit 1
     fi
 fi
 
 # Check Solr version against the stamp written on first startup.
-# $SOLR_VERSION is provided by the official Solr Docker image.
+SOLR_VERSION=$(solr --version 2>/dev/null)
 SOLR_VERSION_FILE="/var/solr/data/.ol_local_solr_version"
 
 if [ -f "$SOLR_VERSION_FILE" ]; then


### PR DESCRIPTION
Closes #12952
Closes #12792
Closes #12795

## Problem

`docker/ol-local-solr-start.sh` detects when `managed-schema.xml` has changed and tries to migrate the core by starting a temporary Solr instance on port 8989. In Solr 9 this worked. In Solr 10, `solr start -p 8989` inside the Docker container does not bring up a responsive Solr instance — the `until curl ... | grep -q "200"` loop on line 37 hangs indefinitely, blocking all other services from starting.

This is distinct from the version-mismatch hang in #12792 — it occurs **even when the Solr version is unchanged**, any time `managed-schema.xml` is modified.

## Fix

Remove the temp-Solr migration path entirely. When a schema diff is detected, print a clear error message with the exact fix command and exit 1 immediately:

```
[ol-local-solr-start] Running
[ol-local-solr-start] ERROR: managed-schema.xml has changed since the Solr core was created.
[ol-local-solr-start]
[ol-local-solr-start] Diff:
[ol-local-solr-start] 1273d1272
[ol-local-solr-start] < <!-- test change -->
[ol-local-solr-start]
[ol-local-solr-start] To fix this, delete the Solr data volume and restart:
[ol-local-solr-start]     docker compose down
[ol-local-solr-start]     docker volume rm openlibrary_solr-data openlibrary_solr-updater-data
[ol-local-solr-start]     docker compose up -d
[ol-local-solr-start]
[ol-local-solr-start] Note this deletes your local Solr index. Safe in local dev;
[ol-local-solr-start] the index will be rebuilt on next startup.
```

This is the fix @cdrini proposed in #12952. The container fails fast and visibly instead of hanging, and the developer gets the exact command needed.

## Testing

The happy path (no schema change, or first startup with no existing core) is unchanged — only the schema-diff branch is modified. The fix can be verified by:
1. Starting with an existing Solr volume
2. Making any change to `conf/solr/conf/managed-schema.xml`
3. Running `docker compose up solr` — should exit immediately with the error message above instead of hanging