### PR TITLE
docs(ai/tag-system): add Tags system domain knowledge base

### DIFF
--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -172,6 +172,13 @@ These companion docs cover specific areas in depth:
 - [Web Component Standards](web-components.md) — When to build a component, Lit conventions, accessibility, events, focus + shadow DOM
 - [Internationalization](i18n.md) — `$_()` in templates, the `data-i18n` bridge for client-rendered strings
 
+## Domain Knowledge Bases
+
+Deep-dive references for major system domains. Each covers production architecture, key files, how it works, endpoints/APIs, debug playbook, open issues, and PR review expectations.
+
+- [Solr](solr/index.md) — search index, solr-updater, schema, search endpoints, facets
+- [Imports](imports/index.md) — import pipeline, DataProvider/DataProviderRecord pattern, batch import, importapi endpoints, adding new sources
+
 ## Key File Locations
 
 | What | Where |

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -178,6 +178,7 @@ Deep-dive references for major system domains. Each covers production architectu
 
 - [Solr](solr/index.md) — search index, solr-updater, schema, search endpoints, facets
 - [Imports](imports/index.md) — import pipeline, DataProvider/DataProviderRecord pattern, batch import, importapi endpoints, adding new sources
+- [Tags](tag-system/index.md) — Tag objects (`/tags/OLnT`), legacy subject system, subject→Tag lookup, community tags/observations, Solr implications, Phase 3 integration checklist
 
 ## Key File Locations
 

--- a/docs/ai/imports/index.md
+++ b/docs/ai/imports/index.md
@@ -71,6 +71,10 @@ Used for large partner ingestions. Accepts a JSONL file where each line is an `O
 
 The `batchName` parameter (PR #12657) lets repeated calls accumulate into the same batch instead of creating orphan batches.
 
+**Preferred path for new sources.** The direct single-record endpoint (`POST /api/import`) writes immediately to the catalog and is planned for deprecation in BookWorm Phase 3. New source adapters should submit through the batch queue instead.
+
+**Trust level.** Batches submitted by non-admin users land in `status="needs_review"` and wait for manual admin approval at `/import/batch/pending`. There is currently no trusted-partner tier. Admin accounts bypass this and go straight to `status="pending"` (processed by ImportBot). See [Roadmap: BookWorm](#roadmap-bookworm) for the planned `import_source` trust registry.
+
 ### Bulk adapter pattern (openlibrary-client + openlibrary-bots)
 
 For new external data sources, the pattern is:
@@ -139,6 +143,37 @@ Before batch submission for a source with a proprietary ID (not ISBN/OCLC/LCCN):
 
 Reference: [PR #12947](https://github.com/internetarchive/openlibrary/pull/12947) — ITAN identifier (`itan_technologies`).
 
+## Known Limitations
+
+These are current-state constraints that affect new source adapters. They are not bugs to fix immediately — most are addressed by the BookWorm roadmap — but every new adapter must account for them.
+
+### Cover URL allowlist
+
+`catalog/add_book/__init__.py` has a hardcoded allowlist:
+
+```python
+ALLOWED_COVER_HOSTS = (
+    "archive.org", "books.google.com", "commons.wikimedia.org",
+    "covers.openlibrary.org", "m.media-amazon.com"
+)
+```
+
+If a source's cover URL is not on this list, `check_cover_url_host()` returns `False` and the cover is silently set to `None` — the record imports fine but cover-less. There is no error or warning. Most partner CDNs (ucarecdn.com, imagedelivery.net, etc.) are not on the list. Options per source: (a) expand the allowlist via PR, (b) have the adapter fetch and re-host the image on IA/covers.openlibrary.org before submitting, or (c) accept cover-less imports for now.
+
+### `ol import` CLI does not exist
+
+The `ol import --provider ...` command described in `pm/workflows/import_workflow.md` is aspirational — it is not implemented in `openlibrary-client/olclient/cli.py`. The current CLI only supports `--get_book`, `--get_work`, `--get_author_works`, `--create`, and `--configure`. Batch submission today requires a Python script that calls `DataProvider.iter_ol_records()` directly and POSTs the results to `/import/batch/new`.
+
+### Identifier registration requires a deploy
+
+Adding a new identifier type to `identifiers.yml` requires a PR merge followed by the weekly OL deploy cycle. Until the deploy, any `identifiers` key in submitted records that references the new type is **silently dropped** — no error, no warning. Design implication: if a source has a proprietary ID, either (a) block batch submission until after the identifier PR deploys, or (b) submit records without the `identifiers` field and run an update pass afterward.
+
+### Local dev ImportBot does not run
+
+The `import_batch` and `import_item` tables exist in the local dev DB, but `scripts/manage-imports.py` (ImportBot) is not wired into the Docker Compose setup. Records submitted to `/import/batch/new` locally will queue but never be processed. To test the full queue→process loop, either call `add_book.load()` directly in tests or test against a staging environment. Tracked in [#7236](https://github.com/internetarchive/openlibrary/issues/7236).
+
+---
+
 ## Debug Playbook
 
 ### Record not appearing after import
@@ -159,6 +194,23 @@ curl -s -X POST "http://localhost:8080/api/import?preview=true" \
 ### Deduplication mismatch
 
 `add_book.load()` matches existing editions by: ISBN-13, ISBN-10, LCCN, OCLC, then `source_records` prefix. If a record already exists under a different identifier, it will update rather than create. Use `preview=true` to see what `add_book.load()` would match before committing.
+
+### Cover not appearing on imported edition
+
+If an edition was created but has no cover, the cover URL was probably from a non-allowlisted host. Check whether the source URL's domain is in `ALLOWED_COVER_HOSTS` (see [Known Limitations](#known-limitations)). To diagnose:
+
+```bash
+# Quick check: does the source URL's host appear in the allowlist?
+python3 -c "
+from urllib.parse import urlparse
+ALLOWED = ('archive.org','books.google.com','commons.wikimedia.org','covers.openlibrary.org','m.media-amazon.com')
+url = 'https://your-cover-url.example.com/image.jpg'
+host = urlparse(url).hostname
+print('ALLOWED' if host in ALLOWED else f'BLOCKED — {host} not in allowlist')
+"
+```
+
+No error is raised. The `cover` field is silently set to `None` in `add_book.load()`.
 
 ### ValidationError from OLImportRecord
 
@@ -192,6 +244,31 @@ for i, rec in enumerate(ITANProvider().iter_ol_records()):
 "
 ```
 
+## Roadmap: BookWorm
+
+[#12655](https://github.com/internetarchive/openlibrary/issues/12655) is the epic for modernizing the import pipeline. Implementation lives at [ArchiveLabs/openlibrary-bookworm](https://github.com/ArchiveLabs/openlibrary-bookworm). **Not yet live — reference material only.**
+
+Three layers:
+
+**1. `openlibrary_imports` DB** — a separate Postgres instance offloading `import_batch`/`import_item` from the production DB. Adds a slim `import_item_history` table (no data blob) to keep the active queue fast, and an `import_source` trust registry.
+
+**2. BookWorm** — standalone FastAPI service replacing `affiliate_server.py`. Exposes:
+- `POST /v1/imports/batch` — create a named batch
+- `POST /v1/imports/batch/{id}` — append JSONL items to an existing batch
+- `GET  /v1/imports/batch/{id}` — batch status
+- `POST /v1/lookup/isbn/{isbn}` — Amazon/Google Books metadata lookup (async)
+
+Auth via API keys scoped to `import_source.name`. The `import_source.trust_level` field (`'pending'` | `'review'`) replaces the current admin-or-`needs_review` binary — solving the trusted-partner fast-path problem.
+
+**3. BWB OPDS real-time bot** — replaces the monthly CSV dump with a ~10-minute polling cron against BWB's OPDS feed, submitting new records to BookWorm. Runs in an `ol-imports-cron` Docker container on `ol-home0`.
+
+**Phase plan (from #12655):**
+- Phase 1: provision DB + BookWorm skeleton + trust registry + wire `/import/batch/new` UI to BookWorm
+- Phase 2: migrate AffiliateServer lookups to BookWorm, build BWB OPDS bot
+- Phase 3: update ImportBot to read from `openlibrary_imports`, deprecate `POST /api/import` for external callers
+
+---
+
 ## Open Issues and Active PRs
 
 | PR / Issue | Status | What |
@@ -201,7 +278,11 @@ for i, rec in enumerate(ITANProvider().iter_ol_records()):
 | [#12657](https://github.com/internetarchive/openlibrary/pull/12657) | Open | `batchName` param for `/import/batch/new` |
 | [#12953](https://github.com/internetarchive/openlibrary/pull/12953) | Ready to merge | HTML numeric entity unescape in `normalize_import_record` |
 | [#12945](https://github.com/internetarchive/openlibrary/pull/12945) | Draft | `work_identifiers` support for work-level matching |
-| [#12091](https://github.com/internetarchive/openlibrary/issues/12091) | Open, 47d stale | ITAN import request — needs response |
+| [#12091](https://github.com/internetarchive/openlibrary/issues/12091) | Open | ITAN import request |
+| [#12655](https://github.com/internetarchive/openlibrary/issues/12655) | Open, not ready for action | Epic: BookWorm — modernize import pipeline |
+| [#12656](https://github.com/internetarchive/openlibrary/issues/12656) | Open | Spec for `batchName` param (implemented by #12657) |
+| [#7236](https://github.com/internetarchive/openlibrary/issues/7236) | Open | Local dev ImportBot doesn't run |
+| [#8542](https://github.com/internetarchive/openlibrary/issues/8542) | Open | Batch import documentation gap |
 
 **Identifier PR before adapter PR**: #12947 must merge and deploy before the ITAN adapter PR (#447) can submit a batch. `itan_technologies` keys are silently dropped until the identifier is registered.
 

--- a/docs/ai/imports/index.md
+++ b/docs/ai/imports/index.md
@@ -1,0 +1,217 @@
+# Import Pipeline
+
+Open Library's import pipeline ingests book records from external sources — Internet Archive items, partner catalogs, bulk JSONL feeds, MARC files, and more — and creates or updates Editions and Works in the OL database.
+
+## Architecture Overview
+
+Two separate flows share the same final step (`catalog/add_book.py`):
+
+```
+External source (JSONL/API/IA)
+        │
+        ▼
+DataProvider / DataProviderRecord        ← olclient (openlibrary-client repo)
+(JSONLProvider, PaginatedAPIProvider)
+        │
+        ▼
+OLImportRecord  ──────────────────────── POST /api/import  ← importapi plugin
+                                          POST /api/import/ia
+                                          POST /import/batch/new
+        │
+        ▼
+    add_book.load()                       ← openlibrary/catalog/add_book.py
+        │
+        ▼
+    OL database (Work + Edition)
+```
+
+**Multi-repo layout:**
+
+| Repo | Purpose |
+|------|---------|
+| `internetarchive/openlibrary-client` | `olclient/imports.py` — base classes (DataProvider, DataProviderRecord, OLImportRecord) |
+| `internetarchive/openlibrary-bots` | `sources/<slug>/` — concrete source adapters |
+| `internetarchive/openlibrary` | `plugins/importapi/` — HTTP endpoints; `core/batch_imports.py` — batch processing; `catalog/add_book.py` — record creation |
+
+## Key Files
+
+| File | What it does |
+|------|-------------|
+| `openlibrary-client/olclient/imports.py` | `DataProvider`, `DataProviderRecord`, `OLImportRecord`, `JSONLProvider`, `PaginatedAPIProvider` — the abstract import framework |
+| `openlibrary/plugins/importapi/code.py` | HTTP handlers for `/api/import`, `/api/import/ia`. Parses JSON/MARC/RDF/OPDS, calls `add_book.load()`. |
+| `openlibrary/plugins/importapi/import_edition_builder.py` | Converts parsed data into an edition dict for `add_book.load()` |
+| `openlibrary/plugins/importapi/import_validator.py` | Validates edition dicts against `import.schema.json` |
+| `openlibrary/core/batch_imports.py` | Processes JSONL POST to `/import/batch/new`; validates each line; accumulates into a named `Batch` |
+| `openlibrary/core/imports.py` | `Batch` model — OL's internal batch queue |
+| `openlibrary/catalog/add_book.py` | Final record creation: match existing editions by identifier, create or update Work/Edition, resolve authors |
+| `openlibrary/schemata/import.schema.json` | Canonical JSON schema (`additionalProperties: false`). `OLImportRecord` mirrors it exactly. |
+| `openlibrary-bots/sources/itan/provider.py` | Example concrete `JSONLProvider` for ITAN Global Publishing |
+| `openlibrary-bots/sources/itan/record.py` | Example concrete `DataProviderRecord` for ITAN |
+
+## How It Works
+
+### Single-record import (`POST /api/import`)
+
+Accepts JSON, MARC binary, MARC XML, RDF, or OPDS format. The handler in `importapi/code.py::importapi.POST()`:
+
+1. Calls `parse_data(raw_bytes)` — dispatches to format-specific parsers
+2. Normalizes to an edition dict via `import_edition_builder`
+3. Calls `add_book.load(edition)` which deduplicates by identifier and writes to Infobase
+
+The `?preview=true` query param runs the full parse + dedup without writing.
+
+### Batch import (`POST /import/batch/new`)
+
+Used for large partner ingestions. Accepts a JSONL file where each line is an `OLImportRecord`-shaped JSON object. Flow in `core/batch_imports.py::batch_import()`:
+
+1. Parse each JSONL line into an `OLImportRecord` via Pydantic
+2. Validate against `import.schema.json`
+3. Add valid records to a named `Batch` (`{username}:{batchName}`, default `{username}:main`)
+4. Return a `BatchResult` with the `Batch` and any per-line `BatchImportError`s
+
+The `batchName` parameter (PR #12657) lets repeated calls accumulate into the same batch instead of creating orphan batches.
+
+### Bulk adapter pattern (openlibrary-client + openlibrary-bots)
+
+For new external data sources, the pattern is:
+
+```python
+# sources/<slug>/record.py
+class MyRecord(DataProviderRecord):
+    # Source-native fields as Pydantic attrs
+    title: str
+    authors: list[dict]
+    ...
+    def to_ol_import(self) -> OLImportRecord | None:
+        ...  # map source fields → OLImportRecord; return None to skip
+
+# sources/<slug>/provider.py
+class MyProvider(JSONLProvider):
+    SOURCE_SLUG = "myslug"          # prefix for source_records, e.g. "myslug:ID123"
+    SOURCE_URL = "https://..."      # JSONL URL
+    RECORD_CLASS = MyRecord
+```
+
+`DataProvider.iter_ol_records()` chains traversal + mapping, yielding only non-None results. Each record's `source_records` field (`["myslug:ID123"]`) is the deduplication key — submitting the same value twice is idempotent.
+
+### IA import (`POST /api/import/ia`)
+
+Specialized path for Archive.org items: accepts an `ocaid` identifier, fetches MARC from IA, converts with `catalog/marc/parse.py`, then calls `add_book.load()`. Subclasses `importapi` in `importapi/code.py`.
+
+## API Endpoints
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| `POST` | `/api/import` | write access | Import one record (JSON/MARC/RDF/OPDS). Body = raw record. `?preview=true` dry-run. |
+| `POST` | `/api/import/ia` | write access | Import one IA item by `ocaid`. Body = `{"identifier": "ocaid"}`. |
+| `POST` | `/import/batch/new` | logged in | Batch JSONL import. `multipart/form-data` with `jsonl` file and optional `batchName`. |
+
+**`/api/import` response:**
+
+```json
+{"success": true, "edition": {"key": "/books/OL123M", "status": "created"}}
+// or
+{"success": false, "error_code": "missing-required-field", "error": "..."}
+```
+
+**Required fields in every import record:**
+
+```
+title, source_records, authors, publishers, publish_date
+```
+
+`source_records` format: `["<slug>:<source-id>"]` — e.g. `["itan_technologies:BOO1017"]`. This is the deduplication key.
+
+`publish_date` must be EDTF: `"2023"`, `"2023-04"`, `"2023-04-15"` are valid. `"April 2023"` is not.
+
+## Adding a New Identifier Type
+
+Before batch submission for a source with a proprietary ID (not ISBN/OCLC/LCCN):
+
+1. Add to `openlibrary/plugins/openlibrary/config/edition/identifiers.yml`:
+   ```yaml
+   - label: My Source ID
+     name: my_source_id     # snake_case, stable, unique
+     url: https://example.com/books/@@@
+   ```
+2. Open a PR for the identifier. **This PR must merge and deploy before batch submission** — OL silently drops unknown identifier keys rather than erroring.
+3. Verify the identifier appears on a test edition at `https://openlibrary.org/books/OL1M` before batching.
+
+Reference: [PR #12947](https://github.com/internetarchive/openlibrary/pull/12947) — ITAN identifier (`itan_technologies`).
+
+## Debug Playbook
+
+### Record not appearing after import
+
+```bash
+# Check the import API response directly
+curl -s -X POST http://localhost:8080/api/import \
+  -H "Content-Type: application/json" \
+  -d '{"title":"Test","source_records":["test:1"],"authors":[{"name":"A"}],"publishers":["B"],"publish_date":"2020"}' \
+  | python3 -m json.tool
+
+# Preview mode — parse + dedup without writing
+curl -s -X POST "http://localhost:8080/api/import?preview=true" \
+  -H "Content-Type: application/json" \
+  -d '@record.json' | python3 -m json.tool
+```
+
+### Deduplication mismatch
+
+`add_book.load()` matches existing editions by: ISBN-13, ISBN-10, LCCN, OCLC, then `source_records` prefix. If a record already exists under a different identifier, it will update rather than create. Use `preview=true` to see what `add_book.load()` would match before committing.
+
+### ValidationError from OLImportRecord
+
+`OLImportRecord` uses `extra="forbid"` — any field not in `import.schema.json` causes a `ValidationError`. Check the schema at `openlibrary/schemata/import.schema.json`. Common culprits: `ebook_access` (ITAN-specific, must be stripped in `to_ol_import()`), `cover_url` (use `cover` instead), non-EDTF dates.
+
+### Batch: records not accumulating
+
+If repeated POSTs to `/import/batch/new` create orphan batches rather than accumulating, pass `batchName` in the form data. Without it, the default is `{username}:main` (after PR #12657 merges — previously a SHA hash).
+
+### Testing locally
+
+```bash
+# Single record via API (Docker must be running)
+curl -s -X POST "http://localhost:8080/api/import" \
+  -H "Content-Type: application/json" \
+  --cookie "session=..." \
+  -d @sample_record.json
+
+# Run import-related tests
+docker compose run --rm home python -m pytest openlibrary/plugins/importapi/tests/ -xvs
+docker compose run --rm home python -m pytest openlibrary/tests/core/test_batch_imports.py -xvs
+docker compose run --rm home python -m pytest openlibrary/catalog/add_book/tests/ -xvs
+
+# Test a DataProvider locally (from openlibrary-bots)
+cd ~/Projects/openlibrary-bots
+python3 -c "
+from sources.itan.provider import ITANProvider
+for i, rec in enumerate(ITANProvider().iter_ol_records()):
+    print(rec.model_dump(exclude_none=True))
+    if i >= 4: break
+"
+```
+
+## Open Issues and Active PRs
+
+| PR / Issue | Status | What |
+|------------|--------|------|
+| [#12947](https://github.com/internetarchive/openlibrary/pull/12947) | Ready to merge | `itan_technologies` identifier |
+| [#447 (bots)](https://github.com/internetarchive/openlibrary-bots/pull/447) | CI infra failures (not our code) | ITAN source adapter |
+| [#12657](https://github.com/internetarchive/openlibrary/pull/12657) | Open | `batchName` param for `/import/batch/new` |
+| [#12953](https://github.com/internetarchive/openlibrary/pull/12953) | Ready to merge | HTML numeric entity unescape in `normalize_import_record` |
+| [#12945](https://github.com/internetarchive/openlibrary/pull/12945) | Draft | `work_identifiers` support for work-level matching |
+| [#12091](https://github.com/internetarchive/openlibrary/issues/12091) | Open, 47d stale | ITAN import request — needs response |
+
+**Identifier PR before adapter PR**: #12947 must merge and deploy before the ITAN adapter PR (#447) can submit a batch. `itan_technologies` keys are silently dropped until the identifier is registered.
+
+## PR Review Expectations
+
+When reviewing import-related PRs:
+
+- **`source_records` prefix** — must be a stable slug. Once records are submitted, changing it creates duplicates. Verify the slug is documented and consistent with any registered identifier name.
+- **`to_ol_import()` return None** — skipping a record is the right behavior for bad data. Verify the skip criteria are documented and not too aggressive.
+- **`extra="forbid"` on OLImportRecord** — any new field in a record class must map to a field in `import.schema.json`. Check the schema before approving a new field.
+- **Identifier registration** — if the PR introduces a new `identifiers` key, confirm there's a corresponding entry in `identifiers.yml` already merged, or the PR includes one.
+- **Batch submission is irreversible** — `source_records` deduplication prevents exact re-imports, but bad data (wrong authors, wrong dates) that passes validation will land in OL. Require a dry-run output (`?preview=true` or local validation) in the PR description for any new source adapter.
+- **Date formats** — `publish_date` must be EDTF. Reject `"Month YYYY"` formats; they are common bugs in new adapters.

--- a/docs/ai/tag-system/debugging.md
+++ b/docs/ai/tag-system/debugging.md
@@ -1,0 +1,161 @@
+# Tags System — Debugging Guide
+
+Common failure modes and how to diagnose them.
+
+---
+
+## CI Failures
+
+### `ModuleNotFoundError` during test collection
+
+```
+ERROR tests/test_migrate.py -- ModuleNotFoundError: No module named 'requests'
+ERROR tests/test_api_db.py  -- ModuleNotFoundError: No module named 'pydantic'
+```
+
+**Cause:** Missing dev dependencies — `requests` (used by `scripts/migrate_subjects.py`) and `pydantic` (used by `api/models.py`) must be in `[project.optional-dependencies].dev`.
+
+**Fix:** `pip install -e ".[dev]"` — if still failing, check `pyproject.toml` to confirm `requests` and `pydantic` are listed.
+
+---
+
+### `AssertionError: mapping value 'Fantasy' is not a slug`
+
+```
+FAILED tests/test_vocabulary.py::TestMappingsSchema::test_all_values_are_slugs[genres-...]
+AssertionError: genres/mappings.json has non-slug values: [('fantasy fiction', 'Fantasy')]
+```
+
+**Cause:** `mappings.json` values must be slugs (`"fantasy"`), not display names (`"Fantasy"`). This often happens when new mappings are added by hand without checking the contract.
+
+**Fix:**
+```bash
+python3 scripts/normalize_mapping_values.py --dry-run   # preview
+python3 scripts/normalize_mapping_values.py             # apply
+pytest tests/test_vocabulary.py                          # verify
+```
+
+---
+
+### `AssertionError: <type>/mappings.json has duplicate keys`
+
+```
+FAILED tests/test_vocabulary.py::TestMappingsSchema::test_no_duplicate_keys[literary_themes-...]
+AssertionError: literary_themes/mappings.json has duplicate keys
+assert 64 == 63
+```
+
+**Cause:** The same key appears twice in a `mappings.json`. Python's `json.load` silently uses the last value, but the test catches it by comparing the raw key list vs. the set.
+
+**Fix:** Open the file and search for the duplicated key. Remove the earlier (incorrect) entry, keeping the one with the right slug value.
+
+---
+
+### `AssertionError: values that are not valid slugs in vocabulary.json`
+
+```
+FAILED tests/test_vocabulary.py::TestMappingsSchema::test_values_reference_valid_slugs[audience-...]
+AssertionError: audience/mappings.json values that are not valid slugs in vocabulary.json:
+  [('juvenile fiction', 'Juvenile'), ...]
+```
+
+**Cause:** The mapping value (`"Juvenile"`) doesn't match any `slug` field in `vocabulary.json`. Either the slug was renamed, or the value was written as a display name instead of a slug.
+
+**Fix:** Check `tag_types/<type>/vocabulary.json` for the correct slug, update `mappings.json`.
+
+---
+
+## Classification Bugs
+
+### Subject not being classified
+
+```python
+from tags import load_all
+tt_map = {tt.name: tt for tt in load_all()}
+result = tt_map["genres"].classify({"subjects": ["My mystery novel"]})
+# returns []
+```
+
+**Diagnosis steps:**
+
+1. **Check normalize output** — the mapping lookup is case-insensitive and strips whitespace, but also NFC-normalizes Unicode:
+   ```python
+   from tags.tag_type import normalize
+   print(normalize("My mystery novel"))   # "my mystery novel"
+   # is this key in mappings.json?
+   ```
+
+2. **Check the mappings file directly:**
+   ```python
+   import json
+   m = json.load(open("tag_types/genres/mappings.json"))
+   print(m.get("my mystery novel"))   # None = not mapped
+   ```
+
+3. **Check if the type has a classify.py plugin** — if so, the plugin runs INSTEAD of the default mapping lookup for subjects it handles. Read `tag_types/<type>/classify.py` to see if your subject would be caught or fall through.
+
+4. **Check droppable.json** — if the subject appears in `tag_types/droppable.json`, it's silently discarded before classification:
+   ```python
+   import json
+   droppable = set(json.load(open("tag_types/droppable.json")))
+   print(normalize("My mystery novel") in droppable)
+   ```
+
+---
+
+### Wrong slug returned from classify()
+
+If `classify()` returns a slug that doesn't match `vocabulary.json`, the most likely cause is a `classify.py` plugin returning a hardcoded display name instead of a slug.
+
+**Check:** `TagMatch.value` must always be a slug. Verify the plugin:
+
+```python
+result = tt.classify({"subjects": ["Children: Grades 1-2"]})
+print(result[0].value)   # should be "children", not "Children"
+```
+
+**Fix:** Update the `classify.py` to return the slug from `vocabulary.json` (`"children"`, `"young-adult"`, etc.) not the display name.
+
+---
+
+### Conflict resolution not working (literary_form)
+
+If a work with both `"Historical fiction"` and `"biography"` subjects gets classified as `fiction` when you expect `nonfiction`:
+
+The `literary_form/classify.py` conflict resolution fires only when **both** `fiction` AND `nonfiction` signals appear. If only one side matches, there's no conflict to resolve — the single match wins.
+
+To inspect:
+```python
+from tags import load_all
+tt = {t.name: t for t in load_all()}["literary_form"]
+result = tt.classify({"subjects": ["Historical fiction", "Biography"]})
+print([(m.value, m.reason) for m in result])
+```
+
+Strong nonfiction override signals: `biography`, `biographies`, `biographical`, `autobiography`, `memoir`, `memoirs`, `autobiographical`, `autobiographies`.
+
+---
+
+## Backfill Script Issues
+
+### Phase 1 scan produces no output
+
+```bash
+python3 scripts/backfill_genre_tags.py scan --dump ol_dump.txt.gz
+# (no output)
+```
+
+**Diagnosis:**
+- Confirm the dump format: OL dumps are tab-separated with 5 fields — `type\tkey\trevision\tlast_modified\tjson`. Records with fewer than 5 fields are skipped.
+- Confirm the file is uncompressed if not `.gz`: plain `.txt` files use `open()` not `gzip.open()`.
+- Run on a small sample: `head -10000 dump.txt | python3 scripts/backfill_genre_tags.py scan --dump /dev/stdin`
+
+### Phase 2 live mode rejected by OL
+
+```
+requests.exceptions.HTTPError: 403 Client Error
+```
+
+**Cause:** The OL account lacks write permission, or the login cookie was rejected.
+
+**Fix:** Confirm the credentials work at `https://openlibrary.org/account/login` in a browser. The account must have write access to Works. **Do not run live mode without @mekarpeles sign-off.**

--- a/docs/ai/tag-system/dev-setup.md
+++ b/docs/ai/tag-system/dev-setup.md
@@ -1,0 +1,104 @@
+# Tags System — Dev Setup
+
+How to run the tags classification system locally for development and testing.
+
+---
+
+## Repo
+
+```bash
+git clone https://github.com/Open-Book-Genome-Project/tags.git
+cd tags
+```
+
+## Install
+
+```bash
+pip install -e ".[dev]"
+# Installs: pytest, pytest-cov, requests, pydantic + the tags package itself
+```
+
+## Run Tests
+
+```bash
+pytest
+# Expected: 200+ passed, 1 skipped (the skipped test requires a live OL connection)
+```
+
+Targeted subsets:
+
+```bash
+pytest tests/test_vocabulary.py   # data contract checks (slug values, no duplicate keys, etc.)
+pytest tests/test_loader.py       # tag type loading, registry, priority ordering
+pytest tests/test_migrate.py      # SubjectClassifier unit tests
+pytest tests/test_api_db.py       # SQLite FTS5 search index
+pytest tests/test_tag_type.py     # TagType dataclass, TagMatch, normalize(), default_classify()
+```
+
+## Directory Layout
+
+```
+tag_types/
+  <type>/
+    vocabulary.json     ← canonical slugs (controlled types only)
+    vocabulary.md       ← human-readable companion
+    mappings.json       ← subject string → slug lookup
+    classify.py         ← optional pattern-matching plugin
+    README.md           ← decision rules for this type
+    proposals.md        ← proposal history (accepted / rejected / deferred)
+tags/
+  __init__.py           ← load_all() — classification engine entry point
+  tag_type.py           ← TagType dataclass, TagMatch, default_classify()
+scripts/
+  migrate_subjects.py   ← SubjectClassifier — classifies OL work subjects
+  normalize_mapping_values.py ← converts Title Case mapping values to slugs
+  backfill_genre_tags.py      ← two-phase script to write genre:slug prefixes to OL
+tests/
+```
+
+## CLI
+
+```bash
+# Classify a single work by OL ID
+tags analyze OL82563W
+
+# Show unmapped subjects across the corpus (requires a dump file)
+tags unmapped --dump ol_dump_works_latest.txt.gz | head -50
+```
+
+## Classifying a Work Programmatically
+
+```python
+from tags import load_all
+
+tag_types = load_all()
+work = {"subjects": ["Fantasy fiction", "Pirates--Fiction", "Dragons"]}
+
+for tt in tag_types:
+    matches = tt.classify(work)
+    if matches:
+        print(f"{tt.name}: {[m.value for m in matches]}")
+# genres: ['fantasy']
+# literary_form: ['fiction']
+```
+
+## Data Contract (key rules)
+
+- `mappings.json` keys must be lowercase + NFC-normalized (`normalize()` from `tags.tag_type`)
+- `mappings.json` values must be slugs (lowercase, hyphenated) — NOT display names
+- `vocabulary.json` slugs and `mappings.json` values must agree
+- No duplicate keys in any JSON file
+- `vocabulary.json` and `vocabulary.md` must be kept in sync
+
+Run `pytest tests/test_vocabulary.py` after any data change to verify the contract.
+
+## Normalizing Mapping Values
+
+If a `mappings.json` has Title Case values:
+
+```bash
+python3 scripts/normalize_mapping_values.py --dry-run   # preview
+python3 scripts/normalize_mapping_values.py             # apply
+git diff --stat                                          # verify only values changed
+pytest tests/test_vocabulary.py                          # confirm green
+```

--- a/docs/ai/tag-system/index.md
+++ b/docs/ai/tag-system/index.md
@@ -1,0 +1,286 @@
+# Tags System
+
+Domain reference for Open Library's tag system. Covers the two-tier tag architecture (legacy subjects + Tag objects), how they relate, how Tag objects are created, Solr implications, and community tags.
+
+**Status as of June 2026:** The Tag object infrastructure (created by Jayden, GSoC 2023) is live in production. The controlled vocabulary project (`Open-Book-Genome-Project/tags`) is in Phase 1-2. OL integration (Phase 3) has not started.
+
+---
+
+## Background: Two Tag Systems in Production
+
+OL has two tag systems running in parallel — the legacy subject system and the new Tag object system:
+
+| System | Where stored | Schema | Created by |
+|--------|-------------|--------|-----------|
+| **Legacy subjects** | `works.subjects` (flat string list) | Plain strings | Anyone editing a work |
+| **Tag objects** | Infogami: `/tags/OL123T` | Typed JSON documents | Curators and admins only |
+
+They are linked by name lookup — a subject string `"cooking"` can map to a Tag document whose `slugs` field contains `"cooking"`. But most subjects have no corresponding Tag document yet.
+
+---
+
+## Legacy Subject System
+
+Works store subjects as flat string arrays:
+
+```json
+{
+  "key": "/works/OL82563W",
+  "subjects": ["Wizards", "Magic", "Fantasy fiction"],
+  "subject_people": ["Harry Potter", "Hermione Granger"],
+  "subject_places": ["Hogwarts", "England"],
+  "subject_times": ["20th century"]
+}
+```
+
+- `subjects` — the catch-all; everything from genres to LC call numbers to noise
+- `subject_people`, `subject_places`, `subject_times` — semi-typed variants added years ago
+- Prefix convention (partially adopted): `people:`, `place:`, `collection:` — subject strings with a prefix denoting type
+
+**The problem:** `"new-york"`, `"newyork"`, and `"place:new_york"` all coexist. There's no deduplication, no controlled vocabulary, no i18n, no hierarchy.
+
+---
+
+## Tag Objects (Infogami `/type/tag`)
+
+Tag objects are first-class Infogami documents at `/tags/OL123T`. They were introduced by Jayden's GSoC 2023 project ("Supercharging Subject Pages").
+
+### Schema
+
+```json
+{
+  "key": "/tags/OL32T",
+  "type": {"key": "/type/tag"},
+  "name": "cooking",
+  "tag_type": "subject",
+  "tag_description": "Works substantially about cooking.",
+  "body": "<description of the cooking tag>",
+  "slugs": ["cooking", "cook", "cookery"],
+  "deputy": "/people/somelibrarian"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Display name (used in URL suffix) |
+| `tag_type` | string | Yes | One of the controlled types (see below) |
+| `tag_description` | string | Yes | One-sentence description |
+| `body` | string | Yes | Rich text content for the subject page |
+| `slugs` | string[] | Yes | Normalized lookup keys (see subject→Tag lookup below) |
+| `deputy` | string | No | Key of a librarian with edit permission |
+
+### Tag Types
+
+Defined in `openlibrary/plugins/upstream/addtag.py`:
+
+```python
+SUBJECT_SUB_TYPES = [
+    "subject", "person", "place", "time",
+    "genre", "subgenre", "content_format", "literary_form", "mood",
+]
+TAG_TYPES = SUBJECT_SUB_TYPES + ["collection"]
+```
+
+- **Subject types** (`SUBJECT_SUB_TYPES`): can be linked to subject pages (`/subjects/genre:horror`)
+- **Collection type**: for curated collection pages; not linked to subject strings
+
+### How Subject String → Tag Object Lookup Works
+
+```python
+# Tag.find() in openlibrary/core/models.py
+q = {"type": "/type/tag", "slugs": Tag.normalize(subject_string)}
+if tag_type:
+    q["tag_type"] = tag_type
+matches = list(site.get().things(q))
+```
+
+The flow:
+1. Normalize the subject string: `Tag.normalize("Cooking")` → `"cooking"` (via `normalize_subject_name`)
+2. Query Infogami for Tag documents whose `slugs` array contains `"cooking"`
+3. Subject pages fetch this Tag and use its `body` / `tag_description` to enrich the page
+
+The `slugs` field is many-to-one: multiple subject strings can map to one Tag. This is how `"cooking"`, `"cook"`, and `"cookery"` all resolve to `/tags/OL32T`.
+
+**Pattern by URL:**
+- `/subjects/cooking` — OL resolves via subject string lookup
+- `/tags/-/subject:cooking` → redirects to the canonical Tag document if one exists
+- `/tags/OL32T` — direct access by key
+
+---
+
+## How to Create a Tag Object
+
+### Via the UI
+
+1. Visit `/tag/add` (requires curator or admin membership)
+2. Fill in: name, tag type, description, body, additional slugs
+3. On save: OL assigns a new `/tags/OL123T` key and persists the document
+
+Alternatively, visit a subject page and click "Edit" — if no Tag exists, it creates one.
+
+### Programmatically
+
+```python
+from openlibrary.plugins.upstream.models import Tag
+
+tag_dict = {
+    "name": "horror",
+    "tag_type": "genre",
+    "tag_description": "Works whose primary intent is to produce fear.",
+    "body": "<p>Horror fiction...</p>",
+    "slugs": ["horror", "horror-fiction", "gothic-horror"],
+}
+tag = Tag.create(tag_dict, comment="Creating canonical genre tag")
+# Returns the new Tag document; tag.key will be "/tags/OL456T"
+```
+
+### Permissions
+
+- **Create:** curator or admin
+- **Edit:** curator, admin, or the tag's `deputy` (if subject-type tag)
+- **Delete:** curator or admin (via edit form)
+
+---
+
+## How Tags Relate to Works
+
+### Current (June 2026): Subjects only
+
+Works do not reference Tag objects directly. Tags are fetched by name from subject strings. When you view `/subjects/cooking`, OL looks up the Tag document and enriches the page — but the Work record itself only has `"cooking"` as a string in `subjects`.
+
+### Future (Phase 3, gated on GH #11610): Typed fields on Work records
+
+The plan is to add explicit typed fields to Work records:
+
+```json
+{
+  "key": "/works/OL82563W",
+  "subjects": ["...legacy strings..."],
+  "genres": ["horror", "thriller"],
+  "moods": ["dark", "atmospheric"],
+  "content_warnings": ["graphic-violence"]
+}
+```
+
+Each value in these fields will be a canonical slug from the controlled vocabulary (`Open-Book-Genome-Project/tags`), and each slug will have a corresponding Tag document.
+
+**GH issue:** [internetarchive/openlibrary#11610](https://github.com/internetarchive/openlibrary/issues/11610)
+
+---
+
+## Tags and Solr
+
+### Current Solr fields (from `managed-schema.xml`)
+
+| Field | Source | Purpose |
+|-------|--------|---------|
+| `subject` | `works.subjects` | FT search on subject strings |
+| `subject_facet` | `works.subjects` | Faceting by subject |
+| `subject_key` | `works.subjects` | Exact slug lookup |
+| `subject_type` | — | Subject type (person/place/etc.) |
+| `top_subjects` | — | Top subjects stored for display |
+
+Defined in `openlibrary/solr/updater/work.py:build_subjects()`:
+
+```python
+field_map = {
+    "subjects": "subject",
+    "subject_places": "place",
+    "subject_times": "time",
+    "subject_people": "person",
+}
+```
+
+**Tag objects are NOT indexed in Solr.** Solr only knows about subject strings. Tag documents live in Infobase and are fetched on demand for subject page enrichment.
+
+### Future Solr Changes (Phase 3)
+
+When typed fields are added to Work records, the Solr updater and schema will need:
+- New fields: `genre`, `genre_facet`, `genre_key`, `mood`, `mood_facet`, etc.
+- Schema file: `conf/solr/conf/managed-schema.xml`
+- Updater: `openlibrary/solr/updater/work.py` — extend `build_subjects()` or add `build_genres()`
+- This requires a **Special Deploy** — new Solr fields must be created on the prod Solr core before the updater code is deployed
+
+---
+
+## Community Tags (Observations)
+
+### What they are
+
+The "observations" or "community reviews" system lets patrons personally tag books with a fixed set of vocabulary. Stored in the `observations` psql table (patron → work → type_id → value_id).
+
+### Why they're underutilized
+
+The vocabulary is hardcoded in `openlibrary/core/observations.py` as a Python dict (OBSERVATIONS). It's a fixed list of ~12 types (Pace, Enjoyability, etc.) with predefined values. Patrons cannot:
+- Propose new tag types or values
+- Search by community tag
+- Create open-ended tags
+
+The UI is buried inside the book review flow. Community tags don't appear in Solr, don't power subject pages, and aren't discoverable.
+
+### Planned migration
+
+The design doc proposes migrating from `observations` (hardcoded strings) to actual Tag objects:
+
+```sql
+-- Current (observations table): patron + work + hardcoded type_id + value_id
+-- Future (community_tags table): patron + work + tag_id (references /tags/OL123T)
+```
+
+This would let librarians define the community tag vocabulary in Tag documents, patrons add any Tag to any work, and community tag counts surface in Solr. Implementation is deferred — no open PR as of June 2026.
+
+---
+
+## Key Files
+
+### `internetarchive/openlibrary`
+
+| File | Purpose |
+|------|---------|
+| `openlibrary/core/models.py:Tag` | `Tag` base class — `find()`, `create()`, `normalize()` |
+| `openlibrary/plugins/upstream/addtag.py` | Routes: `/tag/add`, `/tags/OL*T/edit`, `/tags/-/type:name`, `/tags` index |
+| `openlibrary/plugins/upstream/models.py:Tag` | OL-specific `Tag` subclass (currently just passes to parent) |
+| `openlibrary/templates/type/tag/` | Templates: `view.html`, `form.html`, `index.html`, `tag_form_inputs.html` |
+| `openlibrary/plugins/worksearch/subjects.py` | `subject_name_to_key()` — maps subject strings to `/subjects/*` URLs |
+| `openlibrary/solr/updater/work.py:build_subjects()` | Indexes `subjects`, `subject_people`, `subject_places`, `subject_times` into Solr |
+| `openlibrary/core/observations.py` | Hardcoded community tag vocabulary; `Observations` CRUD |
+| `openlibrary/plugins/openlibrary/bulk_tag.py` | ILE bulk tagger endpoint |
+| `conf/solr/conf/managed-schema.xml` | Solr field definitions (subject, subject_facet, subject_key) |
+
+### `Open-Book-Genome-Project/tags`
+
+See `pm/workflows/tag-system.md` for full breakdown.
+
+| File | Purpose |
+|------|---------|
+| `*/vocabulary.json` | Controlled vocabulary per type (genres, moods, etc.) |
+| `api/` | FastAPI autocomplete service (not yet deployed) |
+| `scripts/migrate_subjects.py` | Migrate legacy subjects → typed canonical tags |
+| `mappings/genres.json` | legacy subject string → canonical genre slug |
+
+---
+
+## Integration Path (Phase 3 Checklist)
+
+When ready to wire the controlled vocabulary into OL:
+
+```markdown
+- [ ] Add `genres` field to olclient work schema (GH #11610)
+- [ ] Update infogami type registry to accept `genres: List[Tag]`
+- [ ] Update Work editing UI — tag input chips + autocomplete from Tags API
+- [ ] Add `genre`, `genre_facet`, `genre_key` fields to Solr managed-schema.xml
+- [ ] Update `openlibrary/solr/updater/work.py:build_subjects()` to index `genres`
+- [ ] Create OL Tag documents for each canonical slug (e.g. `/tags/OL_T` for `genre:horror`)
+- [ ] Write migration script: scan works dump → classify genres → batch-write to OL
+- [ ] Smoke-test: verify `/subjects/genre:horror` renders Tag-enriched page
+- [ ] Solr reindex required (new fields → special deploy needed)
+```
+
+---
+
+## Open Questions
+
+1. **Work storage:** Will `genres` be stored as slugs (`"horror"`) or Tag document references (`{"key": "/tags/OL32T"}`)? The design doc shows slugs; consistency with how `subject_people` stores plain strings suggests slugs are simpler for V0.
+2. **Search routing:** Will `/subjects/genre:horror` continue to work, or will there be a redirect to `/tags/-/genre:horror`?
+3. **Slug stability:** When a tag is renamed, `old_slugs` in vocabulary.json preserves the old slug. Does the OL Tag document's `slugs` field need to be updated too?
+4. **Community tags timeline:** No concrete PR or issue for the observations → Tag migration. Deferred.

--- a/docs/ai/tag-system/index.md
+++ b/docs/ai/tag-system/index.md
@@ -4,6 +4,11 @@ Domain reference for Open Library's tag system. Covers the two-tier tag architec
 
 **Status as of June 2026:** The Tag object infrastructure (created by Jayden, GSoC 2023) is live in production. The controlled vocabulary project (`Open-Book-Genome-Project/tags`) is in Phase 1-2. OL integration (Phase 3) has not started.
 
+**See also:**
+- [Dev Setup](dev-setup.md) — local install, test commands, CLI usage, data contract rules
+- [Debugging Guide](debugging.md) — CI failures, classification bugs, backfill script issues
+- [Known Issues](known-issues.md) — data quality gaps, architectural limitations, open questions
+
 ---
 
 ## Background: Two Tag Systems in Production

--- a/docs/ai/tag-system/known-issues.md
+++ b/docs/ai/tag-system/known-issues.md
@@ -1,0 +1,97 @@
+# Tags System — Known Issues
+
+Current data quality gaps, architectural limitations, and open questions. Updated June 2026.
+
+---
+
+## Data Quality
+
+### Title Case mapping values (resolved June 2026)
+
+**Status: fixed** — PR #28 normalized all mapping values to slugs across 5 types (`audience`, `content_formats`, `literary_themes`, `literary_tropes`, `main_topics`). The data contract test (`test_all_values_are_slugs`) now enforces this going forward.
+
+---
+
+### audience/classify.py returned Title Case TagMatch values (resolved June 2026)
+
+**Status: fixed** — PR #30 corrected the classify plugin to return slugs (`"children"`, `"young-adult"`) instead of display names.
+
+---
+
+### literary_form has no mappings or classify plugin
+
+**Status: in progress** — PR #33 adds `mappings.json` (38 entries) and `classify.py` (LCSH suffix extraction, conflict resolution). Awaiting review.
+
+Until PR #33 merges, `literary_form` classification relies on the `SubjectClassifier` in `scripts/migrate_subjects.py` only — it will not fire through the `TagType.classify()` path.
+
+---
+
+### audience/mappings.json Title Case values from contributor expansion
+
+When shoaib-inamdar's audience mappings (PR #13) were merged, the values were Title Case (`"Juvenile"`, `"Children"`, etc.). These were normalized by PR #28. However, the `classify.py` plugin added in the same PR also had Title Case values — fixed by PR #30.
+
+**Lesson:** When reviewing contributor PRs that add mappings or classify plugins, verify that all values are slugs before merging.
+
+---
+
+### main_topics vocabulary is "open" (no vocabulary.json)
+
+`main_topics`, `literary_themes`, `literary_tropes`, and `moods` are open types — they have `mappings.json` but no controlled `vocabulary.json`. This means:
+
+- `test_values_reference_valid_slugs` is not run for these types (no vocabulary to check against)
+- Mapping values are only checked for slug format (`test_all_values_are_slugs`), not for semantic correctness
+- New mapping entries can introduce misspellings or inconsistencies without a test catching them
+
+**No immediate fix planned** — these types are intentionally open-ended. The data contract test for slug format is the guard.
+
+---
+
+## Architectural Limitations
+
+### SubjectClassifier and TagType.classify() are separate codepaths
+
+`scripts/migrate_subjects.py::SubjectClassifier` and `tags/__init__.py::load_all() + TagType.classify()` overlap in purpose but are not wired together. The script was written before the plugin architecture matured.
+
+**Impact:** Improvements to a type's `classify.py` plugin don't automatically improve the migration script — `SubjectClassifier` has its own hardcoded logic. The two should eventually be unified.
+
+**Near-term workaround:** Keep `SubjectClassifier` in sync manually. The backfill script (`scripts/backfill_genre_tags.py`) uses `SubjectClassifier` — make sure its mappings match what's in `tag_types/`.
+
+---
+
+### No classify.py plugins in most types
+
+As of June 2026, only two types have `classify.py` plugins:
+
+| Type | Plugin covers |
+|---|---|
+| `audience` | Grade-band patterns, LCSH juvenile suffix |
+| `literary_form` | LCSH `--` suffix, conflict resolution (PR #33, pending) |
+
+All other types (genres, subgenres, content_formats, literary_themes, etc.) rely on exact mapping lookups only. Complex LCSH subject strings with topic subdivisions (e.g. `"Dragons--Fiction"` → genres:fantasy) are not yet handled.
+
+---
+
+### Contributor PR #4 (modi02) used old architecture
+
+modi02's `raj/literary-form-pack` PR (still open) implements a `LiteraryFormPack` using an older `RulePack` / `SubjectClassifier` architecture that predates the `tag_types/` layout. It cannot be merged as-is. The valuable LCSH suffix and conflict resolution logic was ported to PR #33.
+
+**Action for Mek:** close PR #4 with a thank-you note pointing to PR #33.
+
+---
+
+## CI / Workflow
+
+### Workflow file must be on main to trigger
+
+GitHub only discovers `.github/workflows/` from the default branch. A workflow file added only to a feature branch will never fire. This is why CI was silent on early PRs — the workflow file (PR #17) had to merge to main before CI became active on subsequent PRs.
+
+---
+
+## Open Questions
+
+| Question | Context |
+|---|---|
+| Should `literary_form` mappings include `"juvenile literature"` → `fiction`? | Currently excluded — juvenile literature is a format not a literary form. But it appears commonly in LCSH. |
+| Process genres and subgenres in one backfill pass or separately? | Issue #14. One pass is simpler; separate passes allow piloting by type. |
+| What batch size for `save_many()` during backfill? | Issue #14. Needs load testing against staging before production run. |
+| Should `TagMatch.value` ever be a display name? | No — always a slug. The `default_classify` path and all `classify.py` plugins must return slugs. |


### PR DESCRIPTION
## Summary

Adds `docs/ai/tag-system/index.md` — a domain knowledge base for the OL tag system, following the same pattern as `docs/ai/solr/index.md` and `docs/ai/imports/index.md`.

Covers:
- The two-tier architecture: legacy subjects (flat strings on Works) vs. Infogami Tag objects (`/tags/OLnT`)
- Why subjects are insufficient today (no types, no i18n, no deduplication, no documents)
- How subject string → Tag object lookup works (via the `slugs` field + `Tag.find()`)
- How to create a Tag object and what it's for (enriching subject pages; requires curator/admin)
- Community tags / observations — what they are, why they're underutilized, planned migration
- Current Solr field layout (`subject`, `subject_facet`, `subject_key`) and what changes when typed tag fields land
- Phase 3 integration checklist for wiring the controlled vocabulary into OL search and editing UI

Also adds a one-line entry to `docs/ai/README.md` linking to this doc.

**Note:** Directory is named `tag-system/` (not `tags/`) because `.gitignore` has a bare `TAGS` entry (for ctags) which on macOS case-insensitive filesystems also ignores any path containing `tags/`.

## Test plan

- [ ] Verify links in `docs/ai/README.md` → `tag-system/index.md` resolve correctly
- [ ] Spot-check key claims against source: `Tag.find()` in `core/models.py:1249`, `SUBJECT_SUB_TYPES` in `addtag.py:26`, `build_subjects()` in `solr/updater/work.py`, `OBSERVATIONS` dict in `core/observations.py`