### PR TITLE
chore(deps): consolidate Python dependency upgrades (June 2026)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ python-multipart==0.0.32
 PyYAML==6.0.3
 qrcode==7.4.2
 requests==2.34.2
-sentry-sdk[fastapi]==2.61.1
+sentry-sdk[fastapi]==2.62.0
 simplejson==3.20.2
 statsd==4.0.1
 uvicorn[standard]==0.49.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiofiles==25.1.0
 amightygirl.paapi5-python-sdk==1.0.0
 APScheduler==3.11.2
 Babel==2.18.0
-beautifulsoup4==4.14.3
+beautifulsoup4==4.15.0
 cryptography==44.0.2
 eventer==0.1.1
 fastapi==0.136.3

--- a/requirements_scripts.txt
+++ b/requirements_scripts.txt
@@ -3,5 +3,5 @@
 # uv pip install -r requirements_scripts.txt && PYTHONPATH=. python ./path/to/script.py optional_args... && uv pip uninstall -y -r requirements_scripts.txt
 
 mwparserfromhell==0.7.2
-nameparser==1.1.3
+nameparser==1.2.0
 wikitextparser==0.56.4

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,7 +6,7 @@
 debugpy>=1.6.4
 mypy==2.1.0
 pymemcache==4.0.0
-pytest==9.0.3
+pytest==9.1.0
 pytest-asyncio==1.4.0
 pytest-httpx==0.36.2
 ruff==0.15.16

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -9,5 +9,5 @@ pymemcache==4.0.0
 pytest==9.1.0
 pytest-asyncio==1.4.0
 pytest-httpx==0.36.2
-ruff==0.15.16
+ruff==0.15.17
 WebTest==3.0.7


### PR DESCRIPTION
## Summary

Consolidates open Renovate PRs for Python packages into a single tested upgrade. All packages installed and tested in Docker before opening this PR.

Closes #12929.

## Packages upgraded

| Package | Before | After | Severity | File |
|---------|--------|-------|----------|------|
| beautifulsoup4 | 4.14.3 | 4.15.0 | Low | requirements.txt |
| sentry-sdk | 2.61.1 | 2.62.0 | Low | requirements.txt |
| nameparser | 1.1.3 | 1.2.0 | Low | requirements_scripts.txt |
| pytest | 9.0.3 | 9.1.0 | Low | requirements_test.txt |
| ruff | 0.15.16 | 0.15.17 | Low | requirements_test.txt |

## Excluded packages

| Package | Current | Available | Reason |
|---------|---------|-----------|--------|
| luqum | 0.11.0 | 0.14.0 | **Breaks `test_luqum_parser`** — 0.14.x changed query parenthesization behaviour (`by:(boo blah blah)` → `by:boo blah blah`). Needs a dedicated fix before bumping. |
| fastapi | 0.136.3 | 0.137.1 | **Breaks FastAPI tests** — 0.137.x introduced `_IncludedRouter` which lacks a `.path` attribute. `prometheus_fastapi_instrumentator==7.1.0` calls `route.path` unconditionally and crashes on it. Needs a coordinated bump with `prometheus-fastapi-instrumentator` (7.1.0 → 8.x). |

## Testing

- All 5 packages installed in Docker and verified at correct versions ✓
- `openlibrary/tests/solr/test_query_utils.py` — 10/10 passed ✓
- luqum 0.14.0 confirmed failing `test_luqum_parser` (excluded for this reason) ✓
- fastapi 0.137.1 confirmed breaking FastAPI test suite via CI (`_IncludedRouter` + prometheus-fastapi-instrumentator incompatibility) ✓

## Checklist

- [x] All packages install cleanly
- [x] App serves HTTP 200
- [x] Tests passing (query_utils)
- [x] CI passing (after fastapi exclusion)