### PR TITLE
fix(a11y): add title attributes to iframes (WCAG 2.4.1 H64)

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -1242,6 +1242,10 @@ msgstr ""
 msgid "There is nothing to see here yet."
 msgstr ""
 
+#: account/ia_thirdparty_logins.html
+msgid "Sign in with a third-party account"
+msgstr ""
+
 #: account/import.html
 msgid "Import from Goodreads"
 msgstr ""
@@ -7724,6 +7728,10 @@ msgstr ""
 
 #: BookPreview.html
 msgid "Preview Book"
+msgstr ""
+
+#: BookPreview.html
+msgid "Book preview"
 msgstr ""
 
 #: DisplayCode.html

--- a/openlibrary/macros/BookPreview.html
+++ b/openlibrary/macros/BookPreview.html
@@ -21,7 +21,7 @@ $if render_once('book-preview-floater'):
           <a class="dialog--close" data-key="book_preview">&times;<span class="shift">$_("Close")</span></a>
         </div>
         <div>
-          <iframe style="width:100%; height:515px"></iframe>
+          <iframe title="$_('Book preview')" style="width:100%; height:515px"></iframe>
           <p class="learn-more">
             <a data-key="book_preview_learn_more"
              data-ol-link-track="book_preview_learn_more">

--- a/openlibrary/templates/account/ia_thirdparty_logins.html
+++ b/openlibrary/templates/account/ia_thirdparty_logins.html
@@ -3,6 +3,7 @@ $def with ()
 $ params = {'origin': request.home.replace('http:', 'https:')}
 <iframe
     id="ia-third-party-logins"
+    title="$_('Sign in with a third-party account')"
     src="https://$get_ia_host(allow_dev=True)/account/login.thirdparty.php?$(urlencode(params))"
     style="border:0; width: auto; height: 44px"
 ></iframe>


### PR DESCRIPTION
## Summary

Iframes must have a `title` attribute so assistive technology users can identify their purpose before deciding to navigate into them (WCAG 2.4.1 H64, `frame-title` axe rule, impact=serious).

Two iframes fixed:

| File | Iframe | Title added |
|------|--------|-------------|
| `templates/account/ia_thirdparty_logins.html` | IA social login widget (login + signup pages) | `"Sign in with a third-party account"` |
| `macros/BookPreview.html` | Book preview floating dialog | `"Book preview"` |

**Excluded**: the reCAPTCHA iframe on the signup page is injected by Google's JS library — its title is not under OL template control.

## What this changes

```diff
- <iframe id="ia-third-party-logins" src="...">
+ <iframe id="ia-third-party-logins" title="Sign in with a third-party account" src="...">

- <iframe style="width:100%; height:515px"></iframe>
+ <iframe title="Book preview" style="width:100%; height:515px"></iframe>
```

## Test plan

Playwright regression tests (`frame-title.spec.ts`) are staged on branch `12885/playwright-e2e-tests` (PR #12998). Once the Playwright e2e infrastructure merges, CI will assert zero `frame-title` violations on login, signup, and work pages.

To verify manually:
```bash
OL_BASE_URL=https://openlibrary.org npx playwright test a11y/frame-title
# Will fail until this PR deploys (expected — proves the tests work)
```

## Related

- Tracking issue: #13008 (iframes missing title)
- Playwright infrastructure: #12998
- Violation class: `frame-title` / WCAG 2.4.1 H64