### PR TITLE
fix(marc): apply NFC normalization to MARC8 translation output

### DIFF
--- a/openlibrary/catalog/marc/marc_binary.py
+++ b/openlibrary/catalog/marc/marc_binary.py
@@ -61,7 +61,7 @@ class BinaryDataField(MarcFieldBase):
         """
         if self.rec.marc8():
             data = mnemonics.read(data)
-            return marc8.translate(data)
+            return normalize("NFC", marc8.translate(data))
         return normalize("NFC", data.decode("utf8"))
 
     def ind1(self) -> str:


### PR DESCRIPTION
## Summary

`BinaryDataField.translate()` in `catalog/marc/marc_binary.py` documents that it returns an "NFC normalized unicode str" but the MARC8 branch was missing the explicit `normalize("NFC", ...)` call. The UTF-8 branch applied NFC normalization correctly; the MARC8 branch did not.

The one-line fix makes both branches explicitly symmetric:

```python
# Before:
return marc8.translate(data)

# After:
return normalize("NFC", marc8.translate(data))
```

`normalize` is already imported from `unicodedata` at the top of the file.

## Empirical finding

Testing with pymarc 5.3.1 shows that `MARC8ToUnicode` already outputs NFC for all standard combining character sequences (precomposed forms where they exist; base + non-decomposable combining character otherwise). The fix is therefore **defensive** rather than correcting an observed runtime bug — it:

- Makes the code match its own docstring
- Makes both encoding branches explicitly symmetric
- Defends against any future changes in pymarc's normalization behavior

## Testing

```bash
# 7/7 MARC binary tests pass
python -m pytest openlibrary/catalog/marc/tests/test_marc_binary.py \
                 openlibrary/catalog/marc/tests/test_mnemonics.py \
                 --noconftest -q
# 7 passed in 0.43s

# Verify NFC behavior
python3 -c "
from unicodedata import normalize
from pymarc import MARC8ToUnicode
marc8 = MARC8ToUnicode(quiet=True)
result = marc8.translate(b'\xe2e')  # MARC8 combining acute + e
print('Before fix — is NFC:', result == normalize('NFC', result))  # True (pymarc is good)
print('After fix — no change in output for this case, but docstring now accurate')
"
```

## Related

Closes #13014