### PR TITLE
fix(add_book): fix walrus operator precedence bug in author dedup (#13015)

### DIFF
--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -240,9 +240,9 @@ def find_author(author: AuthorImportDict) -> list[Author]:
     # If author has dates, we only consider dated candidates,
     # otherwise only include undated candidates.
     for a in things:
-        if key := a["key"] in seen:
+        if a["key"] in seen:
             continue
-        seen.add(key)
+        seen.add(a["key"])
         if has_dates(author) != has_dates(a):
             continue
         assert a.type.key == "/type/author"

--- a/openlibrary/catalog/add_book/tests/test_load_book.py
+++ b/openlibrary/catalog/add_book/tests/test_load_book.py
@@ -268,6 +268,44 @@ class TestImportAuthor:
         found = author_import_record_to_author(searched_author)
         assert found.key == author_with_birth_and_death["key"]
 
+    def test_duplicate_candidates_are_deduplicated(self, mock_site, monkeypatch):
+        """
+        Regression test for #13015: if the same candidate author is found via
+        multiple name queries (e.g. matched on both its name and an alternate
+        name), it must be deduplicated. Otherwise it's appended twice to the
+        match list, incorrectly triggering pick_from_matches() even though
+        there's only one real candidate.
+        """
+        existing_author = {
+            "name": "William Brewer",
+            "key": "/authors/OL3A",
+            "type": {"key": "/type/author"},
+            "alternate_names": ["Bill Brewer"],
+            "birth_date": "1829",
+            "death_date": "1910",
+        }
+        mock_site.save(existing_author)
+
+        # Both the primary name and the alternate name below match the SAME
+        # existing author record above, via two separate query iterations.
+        searched_author = {
+            "name": "William Brewer",
+            "alternate_names": ["Bill Brewer"],
+            "birth_date": "1829",
+            "death_date": "1910",
+        }
+
+        def fail_if_called(author, matches):
+            raise AssertionError("pick_from_matches() should not be called when only one unique candidate exists — deduplication must have failed.")
+
+        # pick_from_matches() is only invoked when there's more than one
+        # *unique* candidate — patch it to fail the test if dedup didn't happen.
+        monkeypatch.setattr(load_book, "pick_from_matches", fail_if_called)
+
+        found = load_book.find_author(searched_author)
+        assert len(found) == 1
+        assert found[0].key == existing_author["key"]
+
     def test_non_matching_birth_death_creates_new_author(self, mock_site):
         """
         If a year in birth or death date isn't an exact match, create a new record,


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #13015

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Note: the issue locates the bug in `import_record_to_edition()`, but the
actual buggy loop is in `find_author()` (same file). `import_record_to_edition()`
is just the entry point that triggers it, via
`author_import_record_to_author()` → `find_entity()` → `find_author()`.
This PR fixes it at its real location.

The author deduplication loop in `find_author()` used a walrus operator
with incorrect precedence:

    if key := a["key"] in seen:

Because `:=` binds looser than `in`, this parsed as
`key := (a["key"] in seen)`, assigning a boolean to `key` instead of the
author's key string. As a result, `seen` only ever held `True`/`False`,
and deduplication never worked for records with more than one author
candidate.

### Technical
Fixed by removing the walrus operator and assigning the actual key:

    if a["key"] in seen:
        continue
    seen.add(a["key"])
    
### Testing
Added a regression test, `test_duplicate_candidates_are_deduplicated`, in
`openlibrary/catalog/add_book/tests/test_load_book.py`. It sets up one
existing author who matches a searched record on both their primary name
and an alternate name (two separate query iterations hitting the same
candidate), and patches `pick_from_matches()` to raise if called — which
only happens if a duplicate candidate slips through. Passes with the fix,
would fail without it.

docker compose run --rm home pytest openlibrary/catalog/add_book/tests/test_load_book.py -v

### Screenshot
N/A — backend-only change.

### Stakeholders
     @mekarpeles


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
