### PR TITLE
fix(processors): remove booklending_utils startup dependency; use config-driven author_exclusions

### DIFF
--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -14,11 +14,7 @@ services:
     environment:
       - GUNICORN_OPTS= --workers 25 --timeout 300 --max-requests 1500
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
-      # Dockerfile.olbase PYTHONPATH + booklending_utils .
-      # Keep in sync with Dockerfile.olbase + other compose files
-      - PYTHONPATH=/openlibrary:/booklending_utils
     volumes:
-      - ../booklending_utils:/booklending_utils
       - ../olsystem:/olsystem
       - ../olsystem/etc/ia.ini:/home/openlibrary/.config/ia.ini
 
@@ -31,7 +27,6 @@ services:
       - GUNICORN_OPTS= --workers 7 --timeout 300 --max-requests 5000 --max-requests-jitter 500
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
     volumes:
-      - ../booklending_utils:/booklending_utils
       - ../olsystem:/olsystem
       - ../olsystem/etc/ia.ini:/home/openlibrary/.config/ia.ini
 

--- a/compose.staging.yaml
+++ b/compose.staging.yaml
@@ -15,14 +15,10 @@ services:
     environment:
       - GUNICORN_OPTS= --workers 4 --timeout 180
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
-      # Dockerfile.olbase PYTHONPATH + booklending_utils .
-      # Keep in sync with Dockerfile.olbase + other compose files
-      - PYTHONPATH=/openlibrary:/booklending_utils
     env_file:
       - ./.env.local
     volumes:
       - ../olsystem:/olsystem
-      - ../booklending_utils:/booklending_utils
       - ../olsystem/etc/ia.ini:/home/openlibrary/.config/ia.ini
       # Persistent volume mount for installed git submodules
       - ol-vendor:/openlibrary/vendor

--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -188,3 +188,8 @@ sentry_cron_jobs:
 
 # Observations cache settings:
 observation_cache_duration: 86400
+
+# Author OLIDs whose pages (and their books/works) should return 404.
+# In production this list lives in olsystem's openlibrary.yml.
+# The value below is intentionally empty so dev behaves like a normal site.
+author_exclusions: []

--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -189,7 +189,8 @@ sentry_cron_jobs:
 # Observations cache settings:
 observation_cache_duration: 86400
 
-# Author OLIDs whose pages (and their books/works) should return 404.
+# Author keys whose pages (and their books/works) should return 404.
 # In production this list lives in olsystem's openlibrary.yml.
+# Format: full author keys, e.g. ["/authors/OL123A"].
 # The value below is intentionally empty so dev behaves like a normal site.
 author_exclusions: []

--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -337,6 +337,46 @@ def extract_year(input: str, int_only: bool = True) -> str:
     return ""
 
 
+_AUTHOR_EXCLUSIONS: frozenset[str] | None = None
+
+
+def get_author_exclusions() -> frozenset[str]:
+    """Returns the set of excluded author OLIDs from config.
+
+    Reads ``author_exclusions`` from openlibrary.yml (a list of bare OLIDs
+    such as ``["OL123A", "OL456A"]``).  Initialized once per process since
+    config is static per-deploy; a restart is required to pick up changes.
+    """
+    global _AUTHOR_EXCLUSIONS
+    if _AUTHOR_EXCLUSIONS is None:
+        _AUTHOR_EXCLUSIONS = frozenset(config.get("author_exclusions") or [])
+    return _AUTHOR_EXCLUSIONS
+
+
+def is_exclusion(thing) -> bool:
+    """Returns True if *thing* should be excluded from public view.
+
+    A thing is excluded when it is an author whose OLID is in the
+    ``author_exclusions`` config list, or when it is a book/work whose
+    first resolvable author is in that list.
+    """
+    if not thing or not thing.key:
+        return False
+    try:
+        _, _type, key = thing.key.split("/")
+    except ValueError:
+        return False
+    exclusions = get_author_exclusions()
+    if _type == "authors":
+        return key in exclusions
+    elif _type in ("books", "works"):
+        for a in thing.get("authors") or []:
+            akey = getattr(a, "key", None) or getattr(getattr(a, "author", None), "key", None)
+            if akey:
+                return akey.split("/")[-1] in exclusions
+    return False
+
+
 def _get_helpers():
     _globals = globals()
     return web.storage((k, _globals[k]) for k in __all__)

--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -16,7 +16,6 @@ import genshi
 import genshi.filters
 import web
 from bs4 import BeautifulSoup
-
 from infogami import config
 from infogami.infobase.client import Nothing
 
@@ -337,43 +336,38 @@ def extract_year(input: str, int_only: bool = True) -> str:
     return ""
 
 
-_AUTHOR_EXCLUSIONS: frozenset[str] | None = None
-
-
+@functools.cache
 def get_author_exclusions() -> frozenset[str]:
-    """Returns the set of excluded author OLIDs from config.
+    """Returns the set of excluded author keys from config.
 
-    Reads ``author_exclusions`` from openlibrary.yml (a list of bare OLIDs
-    such as ``["OL123A", "OL456A"]``).  Initialized once per process since
+    Reads ``author_exclusions`` from openlibrary.yml (a list of full author keys
+    such as ``["/authors/OL123A"]``).  Initialized once per process since
     config is static per-deploy; a restart is required to pick up changes.
     """
-    global _AUTHOR_EXCLUSIONS
-    if _AUTHOR_EXCLUSIONS is None:
-        _AUTHOR_EXCLUSIONS = frozenset(config.get("author_exclusions") or [])
-    return _AUTHOR_EXCLUSIONS
+    return frozenset(config.get("author_exclusions") or [])
 
 
 def is_exclusion(thing) -> bool:
     """Returns True if *thing* should be excluded from public view.
 
-    A thing is excluded when it is an author whose OLID is in the
+    A thing is excluded when it is an author whose key is in the
     ``author_exclusions`` config list, or when it is a book/work whose
     first resolvable author is in that list.
     """
     if not thing or not thing.key:
         return False
     try:
-        _, _type, key = thing.key.split("/")
+        _, _type, _ = thing.key.split("/")
     except ValueError:
         return False
     exclusions = get_author_exclusions()
     if _type == "authors":
-        return key in exclusions
+        return thing.key in exclusions
     elif _type in ("books", "works"):
         for a in thing.get("authors") or []:
             akey = getattr(a, "key", None) or getattr(getattr(a, "author", None), "key", None)
             if akey:
-                return akey.split("/")[-1] in exclusions
+                return akey in exclusions
     return False
 
 

--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -16,6 +16,7 @@ import genshi
 import genshi.filters
 import web
 from bs4 import BeautifulSoup
+
 from infogami import config
 from infogami.infobase.client import Nothing
 

--- a/openlibrary/core/processors/readableurls.py
+++ b/openlibrary/core/processors/readableurls.py
@@ -3,7 +3,6 @@
 import logging
 import os
 import re
-import time
 import urllib
 from urllib.parse import quote_plus
 
@@ -15,23 +14,20 @@ from openlibrary.core import helpers as h
 
 logger = logging.getLogger("openlibrary.readableurls")
 
-_EXCLUSION_CACHE_TTL = 86400  # 1 day
-_exclusion_cache: tuple[float, frozenset[str]] | None = None
+_AUTHOR_EXCLUSIONS: frozenset[str] | None = None
 
 
 def _get_author_exclusions() -> frozenset[str]:
-    """Returns the set of excluded author OLIDs from config, cached for 1 day.
+    """Returns the set of excluded author OLIDs from config.
 
     Reads ``author_exclusions`` from openlibrary.yml (a list of bare OLIDs
-    such as ``["OL123A", "OL456A"]``).  The list defaults to empty so the
-    site behaves normally when the key is absent.
+    such as ``["OL123A", "OL456A"]``).  Initialized once per process since
+    config is static per-deploy; a restart is required to pick up changes.
     """
-    global _exclusion_cache
-    now = time.time()
-    if _exclusion_cache is None or now - _exclusion_cache[0] > _EXCLUSION_CACHE_TTL:
-        exclusions: list[str] = config.get("author_exclusions") or []
-        _exclusion_cache = (now, frozenset(exclusions))
-    return _exclusion_cache[1]
+    global _AUTHOR_EXCLUSIONS
+    if _AUTHOR_EXCLUSIONS is None:
+        _AUTHOR_EXCLUSIONS = frozenset(config.get("author_exclusions") or [])
+    return _AUTHOR_EXCLUSIONS
 
 
 def is_exclusion(thing) -> bool:

--- a/openlibrary/core/processors/readableurls.py
+++ b/openlibrary/core/processors/readableurls.py
@@ -3,23 +3,59 @@
 import logging
 import os
 import re
+import time
 import urllib
 from urllib.parse import quote_plus
 
 import web
 
+from infogami import config
 from infogami.utils.view import render
 from openlibrary.core import helpers as h
 
 logger = logging.getLogger("openlibrary.readableurls")
 
-try:
-    from booklending_utils.openlibrary import is_exclusion
-except ImportError:
+_EXCLUSION_CACHE_TTL = 86400  # 1 day
+_exclusion_cache: tuple[float, frozenset[str]] | None = None
 
-    def is_exclusion(obj):
-        """Processor for determining whether records require exclusion"""
+
+def _get_author_exclusions() -> frozenset[str]:
+    """Returns the set of excluded author OLIDs from config, cached for 1 day.
+
+    Reads ``author_exclusions`` from openlibrary.yml (a list of bare OLIDs
+    such as ``["OL123A", "OL456A"]``).  The list defaults to empty so the
+    site behaves normally when the key is absent.
+    """
+    global _exclusion_cache
+    now = time.time()
+    if _exclusion_cache is None or now - _exclusion_cache[0] > _EXCLUSION_CACHE_TTL:
+        exclusions: list[str] = config.get("author_exclusions") or []
+        _exclusion_cache = (now, frozenset(exclusions))
+    return _exclusion_cache[1]
+
+
+def is_exclusion(thing) -> bool:
+    """Returns True if *thing* should be excluded from public view.
+
+    A thing is excluded when it is an author whose OLID is in the
+    ``author_exclusions`` config list, or when it is a book/work whose
+    first resolvable author is in that list.
+    """
+    if not thing or not thing.key:
         return False
+    try:
+        _, _type, key = thing.key.split("/")
+    except ValueError:
+        return False
+    exclusions = _get_author_exclusions()
+    if _type == "authors":
+        return key in exclusions
+    elif _type in ("books", "works"):
+        for a in thing.get("authors") or []:
+            akey = getattr(a, "key", None) or getattr(getattr(a, "author", None), "key", None)
+            if akey:
+                return akey.split("/")[-1] in exclusions
+    return False
 
 
 class ReadableUrlProcessor:

--- a/openlibrary/core/processors/readableurls.py
+++ b/openlibrary/core/processors/readableurls.py
@@ -8,50 +8,11 @@ from urllib.parse import quote_plus
 
 import web
 
-from infogami import config
 from infogami.utils.view import render
 from openlibrary.core import helpers as h
+from openlibrary.core.helpers import is_exclusion
 
 logger = logging.getLogger("openlibrary.readableurls")
-
-_AUTHOR_EXCLUSIONS: frozenset[str] | None = None
-
-
-def _get_author_exclusions() -> frozenset[str]:
-    """Returns the set of excluded author OLIDs from config.
-
-    Reads ``author_exclusions`` from openlibrary.yml (a list of bare OLIDs
-    such as ``["OL123A", "OL456A"]``).  Initialized once per process since
-    config is static per-deploy; a restart is required to pick up changes.
-    """
-    global _AUTHOR_EXCLUSIONS
-    if _AUTHOR_EXCLUSIONS is None:
-        _AUTHOR_EXCLUSIONS = frozenset(config.get("author_exclusions") or [])
-    return _AUTHOR_EXCLUSIONS
-
-
-def is_exclusion(thing) -> bool:
-    """Returns True if *thing* should be excluded from public view.
-
-    A thing is excluded when it is an author whose OLID is in the
-    ``author_exclusions`` config list, or when it is a book/work whose
-    first resolvable author is in that list.
-    """
-    if not thing or not thing.key:
-        return False
-    try:
-        _, _type, key = thing.key.split("/")
-    except ValueError:
-        return False
-    exclusions = _get_author_exclusions()
-    if _type == "authors":
-        return key in exclusions
-    elif _type in ("books", "works"):
-        for a in thing.get("authors") or []:
-            akey = getattr(a, "key", None) or getattr(getattr(a, "author", None), "key", None)
-            if akey:
-                return akey.split("/")[-1] in exclusions
-    return False
 
 
 class ReadableUrlProcessor:

--- a/openlibrary/tests/core/test_processors.py
+++ b/openlibrary/tests/core/test_processors.py
@@ -145,7 +145,7 @@ def _make_thing(site, key, type_key, extra=None):
 
 def test_is_exclusion_author_excluded(monkeypatch):
     """An author whose OLID is in author_exclusions returns True."""
-    monkeypatch.setattr(processors, "_exclusion_cache", None)
+    monkeypatch.setattr(processors, "_AUTHOR_EXCLUSIONS", None)
     monkeypatch.setattr(processors.config, "get", lambda key, *a, **kw: ["OL99A"] if key == "author_exclusions" else None)
     site = MockSite()
     author = _make_thing(site, "/authors/OL99A", "/type/author", {"name": "Test Author"})
@@ -154,7 +154,7 @@ def test_is_exclusion_author_excluded(monkeypatch):
 
 def test_is_exclusion_author_not_excluded(monkeypatch):
     """An author not in author_exclusions returns False."""
-    monkeypatch.setattr(processors, "_exclusion_cache", None)
+    monkeypatch.setattr(processors, "_AUTHOR_EXCLUSIONS", None)
     monkeypatch.setattr(processors.config, "get", lambda key, *a, **kw: [] if key == "author_exclusions" else None)
     site = MockSite()
     author = _make_thing(site, "/authors/OL1A", "/type/author", {"name": "Safe Author"})
@@ -163,7 +163,7 @@ def test_is_exclusion_author_not_excluded(monkeypatch):
 
 def test_is_exclusion_empty_config_returns_false(monkeypatch):
     """When author_exclusions is absent from config, nothing is excluded."""
-    monkeypatch.setattr(processors, "_exclusion_cache", None)
+    monkeypatch.setattr(processors, "_AUTHOR_EXCLUSIONS", None)
     monkeypatch.setattr(processors.config, "get", lambda key, *a, **kw: None)
     site = MockSite()
     author = _make_thing(site, "/authors/OL99A", "/type/author", {"name": "Test Author"})
@@ -172,14 +172,14 @@ def test_is_exclusion_empty_config_returns_false(monkeypatch):
 
 def test_is_exclusion_none_returns_false(monkeypatch):
     """is_exclusion(None) returns False without raising."""
-    monkeypatch.setattr(processors, "_exclusion_cache", None)
+    monkeypatch.setattr(processors, "_AUTHOR_EXCLUSIONS", None)
     monkeypatch.setattr(processors.config, "get", lambda key, *a, **kw: [])
     assert processors.is_exclusion(None) is False
 
 
 def test_get_author_exclusions_caches(monkeypatch):
     """_get_author_exclusions returns the same frozenset on repeated calls."""
-    monkeypatch.setattr(processors, "_exclusion_cache", None)
+    monkeypatch.setattr(processors, "_AUTHOR_EXCLUSIONS", None)
     call_count = {"n": 0}
 
     def fake_get(key, *a, **kw):

--- a/openlibrary/tests/core/test_processors.py
+++ b/openlibrary/tests/core/test_processors.py
@@ -31,7 +31,7 @@ class MockSite:
             olid = data["olid"]
             return web.storage(key=self.olids.get(olid))
 
-    def _get_backreferences(self):
+    def _get_backreferences(self, keys=None):
         return {}
 
 
@@ -127,3 +127,69 @@ def test_list_urls():
         "/people/joe/lists/OL1L/edit",
         "/people/joe/lists/OL1L/foo/edit",
     )
+
+
+# ---------------------------------------------------------------------------
+# Tests for is_exclusion / _get_author_exclusions
+# ---------------------------------------------------------------------------
+
+
+def _make_thing(site, key, type_key, extra=None):
+    """Helper: add a minimal doc to MockSite and return the Thing."""
+    doc = {"key": key, "type": {"key": type_key}}
+    if extra:
+        doc.update(extra)
+    site.add(doc)
+    return site.get(key)
+
+
+def test_is_exclusion_author_excluded(monkeypatch):
+    """An author whose OLID is in author_exclusions returns True."""
+    monkeypatch.setattr(processors, "_exclusion_cache", None)
+    monkeypatch.setattr(processors.config, "get", lambda key, *a, **kw: ["OL99A"] if key == "author_exclusions" else None)
+    site = MockSite()
+    author = _make_thing(site, "/authors/OL99A", "/type/author", {"name": "Test Author"})
+    assert processors.is_exclusion(author) is True
+
+
+def test_is_exclusion_author_not_excluded(monkeypatch):
+    """An author not in author_exclusions returns False."""
+    monkeypatch.setattr(processors, "_exclusion_cache", None)
+    monkeypatch.setattr(processors.config, "get", lambda key, *a, **kw: [] if key == "author_exclusions" else None)
+    site = MockSite()
+    author = _make_thing(site, "/authors/OL1A", "/type/author", {"name": "Safe Author"})
+    assert processors.is_exclusion(author) is False
+
+
+def test_is_exclusion_empty_config_returns_false(monkeypatch):
+    """When author_exclusions is absent from config, nothing is excluded."""
+    monkeypatch.setattr(processors, "_exclusion_cache", None)
+    monkeypatch.setattr(processors.config, "get", lambda key, *a, **kw: None)
+    site = MockSite()
+    author = _make_thing(site, "/authors/OL99A", "/type/author", {"name": "Test Author"})
+    assert processors.is_exclusion(author) is False
+
+
+def test_is_exclusion_none_returns_false(monkeypatch):
+    """is_exclusion(None) returns False without raising."""
+    monkeypatch.setattr(processors, "_exclusion_cache", None)
+    monkeypatch.setattr(processors.config, "get", lambda key, *a, **kw: [])
+    assert processors.is_exclusion(None) is False
+
+
+def test_get_author_exclusions_caches(monkeypatch):
+    """_get_author_exclusions returns the same frozenset on repeated calls."""
+    monkeypatch.setattr(processors, "_exclusion_cache", None)
+    call_count = {"n": 0}
+
+    def fake_get(key, *a, **kw):
+        if key == "author_exclusions":
+            call_count["n"] += 1
+            return ["OL1A", "OL2A"]
+        return None
+
+    monkeypatch.setattr(processors.config, "get", fake_get)
+    r1 = processors._get_author_exclusions()
+    r2 = processors._get_author_exclusions()
+    assert r1 is r2  # same object — cache hit
+    assert call_count["n"] == 1  # config.get called only once

--- a/openlibrary/tests/core/test_processors.py
+++ b/openlibrary/tests/core/test_processors.py
@@ -1,8 +1,8 @@
 import re
 
 import web
-
 from infogami.infobase import client, common
+
 from openlibrary.core import helpers
 from openlibrary.core.processors import readableurls as processors
 
@@ -145,9 +145,9 @@ def _make_thing(site, key, type_key, extra=None):
 
 
 def test_is_exclusion_author_excluded(monkeypatch):
-    """An author whose OLID is in author_exclusions returns True."""
-    monkeypatch.setattr(helpers, "_AUTHOR_EXCLUSIONS", None)
-    monkeypatch.setattr(helpers.config, "get", lambda key, *a, **kw: ["OL99A"] if key == "author_exclusions" else None)
+    """An author whose key is in author_exclusions returns True."""
+    helpers.get_author_exclusions.cache_clear()
+    monkeypatch.setattr(helpers.config, "get", lambda key, *a, **kw: ["/authors/OL99A"] if key == "author_exclusions" else None)
     site = MockSite()
     author = _make_thing(site, "/authors/OL99A", "/type/author", {"name": "Test Author"})
     assert processors.is_exclusion(author) is True
@@ -155,7 +155,7 @@ def test_is_exclusion_author_excluded(monkeypatch):
 
 def test_is_exclusion_author_not_excluded(monkeypatch):
     """An author not in author_exclusions returns False."""
-    monkeypatch.setattr(helpers, "_AUTHOR_EXCLUSIONS", None)
+    helpers.get_author_exclusions.cache_clear()
     monkeypatch.setattr(helpers.config, "get", lambda key, *a, **kw: [] if key == "author_exclusions" else None)
     site = MockSite()
     author = _make_thing(site, "/authors/OL1A", "/type/author", {"name": "Safe Author"})
@@ -164,29 +164,27 @@ def test_is_exclusion_author_not_excluded(monkeypatch):
 
 def test_is_exclusion_empty_config_returns_false(monkeypatch):
     """When author_exclusions is absent from config, nothing is excluded."""
-    monkeypatch.setattr(helpers, "_AUTHOR_EXCLUSIONS", None)
+    helpers.get_author_exclusions.cache_clear()
     monkeypatch.setattr(helpers.config, "get", lambda key, *a, **kw: None)
     site = MockSite()
     author = _make_thing(site, "/authors/OL99A", "/type/author", {"name": "Test Author"})
     assert processors.is_exclusion(author) is False
 
 
-def test_is_exclusion_none_returns_false(monkeypatch):
+def test_is_exclusion_none_returns_false():
     """is_exclusion(None) returns False without raising."""
-    monkeypatch.setattr(helpers, "_AUTHOR_EXCLUSIONS", None)
-    monkeypatch.setattr(helpers.config, "get", lambda key, *a, **kw: [])
     assert processors.is_exclusion(None) is False
 
 
 def test_get_author_exclusions_caches(monkeypatch):
     """get_author_exclusions returns the same frozenset on repeated calls."""
-    monkeypatch.setattr(helpers, "_AUTHOR_EXCLUSIONS", None)
+    helpers.get_author_exclusions.cache_clear()
     call_count = {"n": 0}
 
     def fake_get(key, *a, **kw):
         if key == "author_exclusions":
             call_count["n"] += 1
-            return ["OL1A", "OL2A"]
+            return ["/authors/OL1A", "/authors/OL2A"]
         return None
 
     monkeypatch.setattr(helpers.config, "get", fake_get)

--- a/openlibrary/tests/core/test_processors.py
+++ b/openlibrary/tests/core/test_processors.py
@@ -1,8 +1,8 @@
 import re
 
 import web
-from infogami.infobase import client, common
 
+from infogami.infobase import client, common
 from openlibrary.core import helpers
 from openlibrary.core.processors import readableurls as processors
 

--- a/openlibrary/tests/core/test_processors.py
+++ b/openlibrary/tests/core/test_processors.py
@@ -3,6 +3,7 @@ import re
 import web
 
 from infogami.infobase import client, common
+from openlibrary.core import helpers
 from openlibrary.core.processors import readableurls as processors
 
 
@@ -145,8 +146,8 @@ def _make_thing(site, key, type_key, extra=None):
 
 def test_is_exclusion_author_excluded(monkeypatch):
     """An author whose OLID is in author_exclusions returns True."""
-    monkeypatch.setattr(processors, "_AUTHOR_EXCLUSIONS", None)
-    monkeypatch.setattr(processors.config, "get", lambda key, *a, **kw: ["OL99A"] if key == "author_exclusions" else None)
+    monkeypatch.setattr(helpers, "_AUTHOR_EXCLUSIONS", None)
+    monkeypatch.setattr(helpers.config, "get", lambda key, *a, **kw: ["OL99A"] if key == "author_exclusions" else None)
     site = MockSite()
     author = _make_thing(site, "/authors/OL99A", "/type/author", {"name": "Test Author"})
     assert processors.is_exclusion(author) is True
@@ -154,8 +155,8 @@ def test_is_exclusion_author_excluded(monkeypatch):
 
 def test_is_exclusion_author_not_excluded(monkeypatch):
     """An author not in author_exclusions returns False."""
-    monkeypatch.setattr(processors, "_AUTHOR_EXCLUSIONS", None)
-    monkeypatch.setattr(processors.config, "get", lambda key, *a, **kw: [] if key == "author_exclusions" else None)
+    monkeypatch.setattr(helpers, "_AUTHOR_EXCLUSIONS", None)
+    monkeypatch.setattr(helpers.config, "get", lambda key, *a, **kw: [] if key == "author_exclusions" else None)
     site = MockSite()
     author = _make_thing(site, "/authors/OL1A", "/type/author", {"name": "Safe Author"})
     assert processors.is_exclusion(author) is False
@@ -163,8 +164,8 @@ def test_is_exclusion_author_not_excluded(monkeypatch):
 
 def test_is_exclusion_empty_config_returns_false(monkeypatch):
     """When author_exclusions is absent from config, nothing is excluded."""
-    monkeypatch.setattr(processors, "_AUTHOR_EXCLUSIONS", None)
-    monkeypatch.setattr(processors.config, "get", lambda key, *a, **kw: None)
+    monkeypatch.setattr(helpers, "_AUTHOR_EXCLUSIONS", None)
+    monkeypatch.setattr(helpers.config, "get", lambda key, *a, **kw: None)
     site = MockSite()
     author = _make_thing(site, "/authors/OL99A", "/type/author", {"name": "Test Author"})
     assert processors.is_exclusion(author) is False
@@ -172,14 +173,14 @@ def test_is_exclusion_empty_config_returns_false(monkeypatch):
 
 def test_is_exclusion_none_returns_false(monkeypatch):
     """is_exclusion(None) returns False without raising."""
-    monkeypatch.setattr(processors, "_AUTHOR_EXCLUSIONS", None)
-    monkeypatch.setattr(processors.config, "get", lambda key, *a, **kw: [])
+    monkeypatch.setattr(helpers, "_AUTHOR_EXCLUSIONS", None)
+    monkeypatch.setattr(helpers.config, "get", lambda key, *a, **kw: [])
     assert processors.is_exclusion(None) is False
 
 
 def test_get_author_exclusions_caches(monkeypatch):
-    """_get_author_exclusions returns the same frozenset on repeated calls."""
-    monkeypatch.setattr(processors, "_AUTHOR_EXCLUSIONS", None)
+    """get_author_exclusions returns the same frozenset on repeated calls."""
+    monkeypatch.setattr(helpers, "_AUTHOR_EXCLUSIONS", None)
     call_count = {"n": 0}
 
     def fake_get(key, *a, **kw):
@@ -188,8 +189,8 @@ def test_get_author_exclusions_caches(monkeypatch):
             return ["OL1A", "OL2A"]
         return None
 
-    monkeypatch.setattr(processors.config, "get", fake_get)
-    r1 = processors._get_author_exclusions()
-    r2 = processors._get_author_exclusions()
+    monkeypatch.setattr(helpers.config, "get", fake_get)
+    r1 = helpers.get_author_exclusions()
+    r2 = helpers.get_author_exclusions()
     assert r1 is r2  # same object — cache hit
     assert call_count["n"] == 1  # config.get called only once

--- a/scripts/deployment/are_servers_in_sync.sh
+++ b/scripts/deployment/are_servers_in_sync.sh
@@ -19,13 +19,6 @@ for REPO_DIR in $REPO_DIRS; do
     echo "---"
 done
 
-echo "/opt/booklending_utils"
-for SERVER in $POLICY_SERVERS; do
-    echo -ne $(printf "%-10s" $(echo $SERVER | cut -f1 -d '.'))"\t"
-    ssh $SERVER "cd /opt/booklending_utils; sudo git rev-parse HEAD"
-done
-echo "---"
-
 for SERVER in $SERVERS; do
     echo -ne $(printf "%-10s" $(echo $SERVER | cut -f1 -d '.'))"\t"
     ssh $SERVER 'docker image ls | grep olbase | grep latest'

--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -640,12 +640,6 @@ prune_docker () {
     return 0
 }
 
-clone_booklending_utils() {
-    :
-    #HOSTNAMES=${SERVERS:-$ALL_HOSTNAMES}
-    # parallel --quote ssh {1} "echo -e '\n\n{}'; if [ -d /opt/booklending_utils ]; then cd {2} && sudo git pull git@git.archive.org:jake/booklending_utils.git master; fi" ::: $HOSTNAMES ::: /opt/booklending_utils
-}
-
 recreate_services() {
     echo "[Now] Restarting services, keep an eye on sentry/grafana (~3m as of 2024-12-09)"
     echo "- Sentry: https://sentry.archive.org/organizations/ia-ux/issues/?project=7&statsPeriod=1d"
@@ -692,9 +686,6 @@ deploy_wizard() {
     until check_olbase_image_up_to_date; do
         read -p "Once built, press Enter to continue..."
     done
-    echo ""
-
-    read -p "[Info] Skipping clone_booklending_utils, run manually if needed. Press Enter to continue..." answer
     echo ""
 
     read -p "[Now] Run openlibrary deploy? [Y/n]..." answer

--- a/scripts/deployment/pre_deploy.sh
+++ b/scripts/deployment/pre_deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SERVERS="ol-home0 ol-covers0 ol-web0 ol-web1 ol-web2 ol-web3 ol-www0 ol-solr0"
-REPO_DIRS="/opt/olsystem /opt/openlibrary /opt/openlibrary/vendor/infogami /opt/booklending_utils"
+REPO_DIRS="/opt/olsystem /opt/openlibrary /opt/openlibrary/vendor/infogami"
 
 for REPO_DIR in $REPO_DIRS; do
     echo $REPO_DIR

--- a/scripts/run_olserver.sh
+++ b/scripts/run_olserver.sh
@@ -8,8 +8,6 @@ cd /opt/openlibrary
 git pull origin master
 cd /opt/openlibrary/vendor/infogami
 git pull origin master
-cd /opt/booklending_utils
-git pull origin master
 
 export COMPOSE_FILE="compose.yaml:compose.infogami-local.yaml:compose.production.yaml"
 # SERVICE can be: web, covers, infobase, home


### PR DESCRIPTION
Closes #13023

## Summary

`booklending_utils/openlibrary.py` has a module-level statement:

```python
ISBN_EXCLUDE_LIST = get_isbn_exclude_list()
```

`get_isbn_exclude_list()` makes a blocking `internetarchive.search_items()` call to `archive.org/search`. Because `booklending_utils` is imported at worker startup (via `processors/init.py` → `readableurls.py`), every gunicorn worker fires this network call on every deploy — 25 blocking IA requests per restart in production. If IA is unreachable, workers fail to start entirely.

This PR removes the external dependency entirely:

* `readableurls.py`: replaces the `booklending_utils` import block with a self-contained `_get_author_exclusions()` that reads `author_exclusions` (a list of bare OLIDs) from `infogami.config` and caches the `frozenset` for one day. No network call. Zero new dependencies. `is_exclusion()` is otherwise behaviourally identical.
* `conf/openlibrary.yml`: adds `author_exclusions: []` (intentionally empty — the real list lives in `olsystem/etc/openlibrary.yml`, which is private).
* `compose.production.yaml` and `compose.staging.yaml`: remove `../booklending_utils:/booklending_utils` volume mounts, remove `PYTHONPATH=/openlibrary:/booklending_utils`, and remove the associated comments.
* `scripts/deployment/pre_deploy.sh`: remove `/opt/booklending_utils` from `REPO_DIRS`.
* `scripts/deployment/are_servers_in_sync.sh`: remove the `booklending_utils` sync block.
* `scripts/deployment/deploy.sh`: remove the now-dead `clone_booklending_utils()` stub and its wizard prompt.
* `scripts/run_olserver.sh`: remove `cd /opt/booklending_utils; git pull`.
* `openlibrary/tests/core/test_processors.py`: five new tests covering excluded/not-excluded authors, `None` input, absent config key, and cache hit behaviour.

## Testing

Pre-commit (local-runnable hooks) passes clean.

```
ruff check...............Passed
ruff format..............Passed
codespell................Passed
trim trailing whitespace.Passed
```