### PR TITLE
Fix #12799: URL encode special characters in subject links and escape…

### DIFF
--- a/openlibrary/plugins/worksearch/schemes/subjects.py
+++ b/openlibrary/plugins/worksearch/schemes/subjects.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from types import MappingProxyType
 
 from openlibrary.plugins.worksearch.schemes import SearchScheme
+from openlibrary.solr.query_utils import fully_escape_query
 
 if typing.TYPE_CHECKING:
     from openlibrary.fastapi.models import SolrInternalsParams
@@ -54,7 +55,7 @@ class SubjectSearchScheme(SearchScheme):
         solr_internals_params: SolrInternalsParams | None = None,
     ) -> list[tuple[str, str]]:
         return [
-            ("q", q),
+            ("q", fully_escape_query(q)),
             ("q.op", "AND"),
             ("defType", "edismax"),
         ]

--- a/openlibrary/templates/search/subjects.html
+++ b/openlibrary/templates/search/subjects.html
@@ -41,7 +41,7 @@ $if q and response and not response.error and response.num_found:
     <ul class="subjectList">
     $for doc in response.docs:
         $ n = doc['name']
-        $ key = '/subjects/' + url_map.get(doc['subject_type'], '') + n.lower().replace(' ', '_').replace('?', '').replace(',', '').replace('/', '')
+        $ key = '/subjects/' + url_map.get(doc['subject_type'], '') + url_quote(n.lower().replace(' ', '_'))
 
         <li>
             <a href="$key">$n</a>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Fixes #12799

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

### Technical
<!-- What should be noted about the implementation? -->
**UI Links:** Updated `openlibrary/templates/search/subjects.html` to wrap subject URL generation in `url_quote()`. This prevents the browser from incorrectly treating special characters like `#` as an anchor fragment (e.g., generating `/subjects/c#` which breaks routing because the browser only requests `/subjects/c`). It now safely generates correctly encoded links like `/subjects/c%23`.

*Note: The backend database currently still normalizes "C#" into the "c" bucket, this PR addresses the immediate front-end routing bugs and broken links.*

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Navigate to `/search/subjects?q=C%23`
2. Inspect or click the "C#" subject link in the results.
3. Verify the link safely points to `/subjects/c%23` (instead of truncating to `/subjects/c`) and correctly routes to the subject page with "C#" displayed as the title.

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->