### PR TITLE
fix(a11y): fix color contrast in OlToggle sublabel and nav-bar work-menu (WCAG 1.4.3)

### DIFF
--- a/openlibrary/components/lit/OlToggle.js
+++ b/openlibrary/components/lit/OlToggle.js
@@ -64,7 +64,7 @@ export class OlToggle extends FocusableHostMixin(LitElement) {
                by [checked] and by the [variant="card"] container states. */
             --_toggle-bg: transparent;
             --_toggle-fg: var(--dark-grey);
-            --_toggle-sublabel-fg: #777;
+            --_toggle-sublabel-fg: var(--accessible-grey);
             --_toggle-border: transparent;
             --_toggle-track: var(--lighter-grey);
             --_toggle-knob: var(--white);

--- a/static/css/components/nav-bar.css
+++ b/static/css/components/nav-bar.css
@@ -124,7 +124,9 @@
 @media (hover: hover) and (pointer: fine) {
   /* stylelint-disable max-nesting-depth */
   .nav-bar-wrapper .nav-bar.work-menu li:hover {
-    background-color: var(--header-nav-hover-color); /* hsl(207, 83%, 33%) — passes 4.5:1 with white */
+    background-color: var(
+      --header-nav-hover-color
+    ); /* hsl(207, 83%, 33%) — passes 4.5:1 with white */
   }
 
   .nav-bar-wrapper .nav-bar.work-menu li:hover a {
@@ -133,7 +135,9 @@
 }
 
 .nav-bar-wrapper .nav-bar.work-menu li.selected {
-  background-color: var(--primary-blue); /* hsl(202, 96%, 37%) — passes 4.5:1 with white */
+  background-color: var(
+    --primary-blue
+  ); /* hsl(202, 96%, 37%) — passes 4.5:1 with white */
 }
 
 .nav-bar-wrapper .nav-bar.work-menu li.selected a {

--- a/static/css/components/nav-bar.css
+++ b/static/css/components/nav-bar.css
@@ -124,7 +124,7 @@
 @media (hover: hover) and (pointer: fine) {
   /* stylelint-disable max-nesting-depth */
   .nav-bar-wrapper .nav-bar.work-menu li:hover {
-    background-color: hsl(212, 39%, 45%); /* darken(@blue-5e88B9, 10%) */
+    background-color: var(--header-nav-hover-color); /* hsl(207, 83%, 33%) — passes 4.5:1 with white */
   }
 
   .nav-bar-wrapper .nav-bar.work-menu li:hover a {
@@ -133,7 +133,7 @@
 }
 
 .nav-bar-wrapper .nav-bar.work-menu li.selected {
-  background-color: var(--blue-5e88B9);
+  background-color: var(--primary-blue); /* hsl(202, 96%, 37%) — passes 4.5:1 with white */
 }
 
 .nav-bar-wrapper .nav-bar.work-menu li.selected a {


### PR DESCRIPTION
## Summary

Two WCAG 1.4.3 (Contrast Minimum) violations fixed, both caught by axe-core in our Playwright a11y scans.

### 1. `OlToggle.js` — sublabel text

The `toggle__sublabel` (shows result count like "68" on search filters) used hardcoded `#777` which computes to **4.47:1** against a white background — just below the 4.5:1 AA threshold.

**Fix**: `--_toggle-sublabel-fg: #777` → `--_toggle-sublabel-fg: var(--accessible-grey)`

`--accessible-grey` (`hsl(0, 0%, 46.3%)`) is already defined in `tokens/colors.css` with a comment noting it's the minimum grey for white-background accessibility. CSS custom properties inherit through Shadow DOM, so this works correctly inside the Lit component.

### 2. `nav-bar.css` — work-menu selected tab

The selected book page nav tab (Overview, Editions, Details, etc.) used `--blue-5e88B9` (`hsl(212, 39%, 55%)`) as background with white text — contrast **3.4:1**, well below 4.5:1.

| State | Before | Contrast | After | Contrast |
|-------|--------|----------|-------|----------|
| Selected | `--blue-5e88B9` hsl(212,39%,55%) | 3.4:1 ❌ | `--primary-blue` hsl(202,96%,37%) | 4.82:1 ✅ |
| Hover | `hsl(212, 39%, 45%)` (hardcoded) | ~4.25:1 ❌ | `--header-nav-hover-color` hsl(207,83%,33%) | 6.56:1 ✅ |

### Known pa11y-only issue (not in this PR)

`.star.star--small` gold (`hsl(50, 100%, 50%)`) on white = ~1.4:1. This is not caught by axe-core (axe skips the gradient/text-fill technique). The stars are decorative — the rating value is always conveyed in adjacent text. Fixing this requires a design decision (darken gold token or explicit pa11y exclusion for decorative elements). Tracked separately in #13009.

## Test plan

Playwright regression tests (`color-contrast.spec.ts`) staged on branch `12885/playwright-e2e-tests` (PR #12998). Both tests currently fail against openlibrary.org (confirming the violations exist); will pass once this PR deploys.

```bash
OL_BASE_URL=https://openlibrary.org npx playwright test a11y/color-contrast
# 2 failed (expected — violations present on live site)
```

## Related

- Tracking issue: #13009 (contrast violations)
- Playwright infrastructure: #12998
- Violation class: `color-contrast` / WCAG 1.4.3