### PR TITLE
fix(a11y): use --link-blue for secondary login button (contrast WCAG 1.4.3)

### DIFF
--- a/static/css/components/header-bar.css
+++ b/static/css/components/header-bar.css
@@ -184,8 +184,8 @@
 }
 
 .header-bar .app-drawer .login-links .login-links__secondary {
-  color: var(--primary-blue);
-  border: 2px solid var(--primary-blue);
+  color: var(--link-blue);
+  border: 2px solid var(--link-blue);
 }
 
 .header-bar .app-drawer .login-links .login-links__secondary:hover {


### PR DESCRIPTION
## Summary

- `.login-links__secondary` renders on the `--light-beige` app-drawer background.
- `--primary-blue` (`hsl(202, 96%, 37%)`) against `--light-beige` (`hsl(48, 29%, 93%)`) = **4.27:1** — fails WCAG 1.4.3 AA (4.5:1 required).
- Fix: use `--link-blue` (`hsl(202, 96%, 28%)`) — **6.51:1** against `--light-beige` and **7.41:1** against white (hover state). Both pass AA.

The primary button already uses `--link-blue` in its hover state (visual intent unchanged — same family, just slightly darker at rest).

## Test plan

- [ ] Open the hamburger menu (header app-drawer) on any page — "Sign In" (primary) and "Sign Up" (secondary) buttons should both look correct.
- [ ] Inspect secondary button at rest: `color: var(--link-blue)`, `border: 2px solid var(--link-blue)`.
- [ ] Run axe on any page with the header open — no `color-contrast` violations on `.login-links__secondary`.

Part of WCAG 2.1 AA a11y remediation — tracked in https://github.com/internetarchive/openlibrary/issues/13009