### PR TITLE
fix(a11y): remove role=option from slick carousel slides (nested-interactive WCAG 4.1.2)

### DIFF
--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -87,6 +87,21 @@ export class Carousel {
                 }))
         });
 
+        // Slick's accessibility mode adds role="listbox" to the track and
+        // role="option" to each slide. When slides contain links this creates
+        // nested-interactive violations (WCAG 4.1.2). role="listbox" without
+        // an accessible name also causes aria-input-field-name failures.
+        // Removing both roles keeps the carousel presentational; keyboard
+        // navigation via prev/next buttons is unaffected.
+        // A MutationObserver covers dynamically added slides (loadMore path).
+        const removeCarouselRoles = () => {
+            this.$container.find('.slick-track[role]').removeAttr('role');
+            this.$container.find('.slick-slide[role]').removeAttr('role');
+        };
+        removeCarouselRoles();
+        const observer = new MutationObserver(removeCarouselRoles);
+        observer.observe(this.$container[0], { subtree: true, attributeFilter: ['role'] });
+
         // Slick internally changes the click handlers on the next/prev buttons,
         // so we listen via the container instead
         this.$container.on('click', '.slick-next', (ev) => {

--- a/static/css/components/header-bar.css
+++ b/static/css/components/header-bar.css
@@ -184,8 +184,8 @@
 }
 
 .header-bar .app-drawer .login-links .login-links__secondary {
-  color: var(--primary-blue);
-  border: 2px solid var(--primary-blue);
+  color: var(--link-blue);
+  border: 2px solid var(--link-blue);
 }
 
 .header-bar .app-drawer .login-links .login-links__secondary:hover {


### PR DESCRIPTION
## Summary

- Slick carousel adds `role="option"` + `tabindex="-1"` to each slide (when `accessibility: true`, the default).
- When slides contain links or buttons, this creates **nested-interactive** violations — `role="option"` makes the slide an interactive element, and interactive elements cannot contain other interactive elements per WCAG 4.1.2.
- Home page had **9 violations**: 3 from the tutorial carousel, 6 from the category carousel.

**Fix:** After slick initializes, remove `role="option"` from all `.slick-slide` elements. A `MutationObserver` handles dynamically added slides (the `loadMore` path). Slick's prev/next keyboard navigation and arrow key support are unaffected — those are driven by the `slick-next`/`slick-prev` buttons, not the `role="listbox"` pattern.

## Test plan

- [ ] Visit `/` — inspect carousel slides: no `role="option"` attribute.
- [ ] Keyboard tab through home page — prev/next carousel buttons still reachable and functional.
- [ ] Playwright regression test added in `12885/playwright-e2e-tests` worktree (see PR #12998).
- [ ] Run axe on `/` — no `nested-interactive` violations.

Part of WCAG 2.1 AA a11y remediation — tracked in https://github.com/internetarchive/openlibrary/issues/13009