### PR TITLE
fix(add_book): use _data.pop to strip infobase metadata from matched author

### DIFF
--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -322,8 +322,7 @@ def author_import_record_to_author(author_import_record_dict: dict, eastern=Fals
     if existing := find_entity(author_import_record):
         assert existing.type.key == "/type/author"
         for k in "last_modified", "id", "revision", "created":
-            if existing.k:
-                del existing.k
+            existing._data.pop(k, None)
         new = existing
         if "death_date" in author_import_record and "death_date" not in existing:
             new["death_date"] = author_import_record["death_date"]

--- a/openlibrary/catalog/add_book/tests/test_load_book.py
+++ b/openlibrary/catalog/add_book/tests/test_load_book.py
@@ -428,3 +428,25 @@ class TestImportAuthor:
         }
         found = author_import_record_to_author(searched_author)
         assert found.key == author["key"]
+
+    def test_infobase_metadata_keys_stripped_from_existing_author(self, mock_site):
+        """
+        Infobase metadata keys are removed from an existing author before it is returned.
+
+        When find_entity() returns a match, Infobase decorates the record with
+        last_modified, revision, and created. These must be stripped so that
+        save_many() does not receive stale metadata in the update payload.
+        """
+        mock_site.save(
+            {
+                "name": "Jane Doe",
+                "key": "/authors/OL99A",
+                "type": {"key": "/type/author"},
+            }
+        )
+
+        result = author_import_record_to_author({"name": "Jane Doe"})
+
+        assert "last_modified" not in result
+        assert "revision" not in result
+        assert "created" not in result


### PR DESCRIPTION
Closes #13016

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] --> 
`**Fix**`
                                                                                                                      
  The metadata cleanup loop in `author_import_record_to_author()` was broken in two ways:

  1. `existing.k` accessed a literal attribute named `"k"` (always `Nothing`/falsy) instead of the loop variable `k`,
  so the condition was never `True`.
  2. Even with the condition corrected, `del existing[k]` raises `AttributeError` because Infogami `Thing` objects
  have no `__delitem__`.

  Fix: use `existing._data.pop(k, None)` to remove the metadata keys (`last_modified`, `id`, `revision`, `created`)
  directly from the underlying data dict, which is the only supported mutation path on a `Thing`.

  ### Technical

  - `Thing.__setitem__` delegates to `self._getdata()[key]`, but there is no `__delitem__` — mutation must go through
  `_data` directly.
  - The `mock_site.save()` helper automatically appends `revision`, `last_modified`, and `created` to every saved
  document, so tests that return a matched author exercised this code path in CI.
  - No behaviour changes to the matching logic itself — only the post-match metadata strip is fixed.

  ### Testing

  1. Run the affected test file:
     pytest openlibrary/catalog/add_book/tests/test_load_book.py -v
  All 35 tests should pass, including the new `test_infobase_metadata_keys_stripped_from_existing_author` which
  directly verifies that `last_modified`, `revision`, and `created` are absent from the returned author when a match
  is found.

  2. Before this fix, 7 tests in that file failed with `AttributeError: __delitem__` whenever `find_entity()` returned
   a match. All now pass.

  ### Screenshot

  N/A — no UI changes.

  ### Stakeholders

  <!-- @ tag the lead as labeled on the issue -->
