### PR TITLE
Add sentry frontend performance tracking to see user-time performance

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -54,7 +54,7 @@
     },
     {
       "path": "static/build/js/all.js",
-      "maxSize": "130KB"
+      "maxSize": "155KB"
     },
     {
       "path": "static/build/css/page-admin.css",

--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -177,8 +177,14 @@ sentry:
     # Dummy endpoint; where sentry logs are sent to
     dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0'
     traces_sample_rate: 1.0
-    profiles_sample_rate: 0.001
+    profiles_sample_rate: 0.05
     environment: 'local'
+
+    frontend:
+        dsn: 'https://examplePublicKey@o0.ingest.sentry.io/1'
+        # Inherits same rates from above
+        # In JS, this controls error sample rate
+        sample_rate: 0.01
 
 sentry_cron_jobs:
     enabled: false

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -24,6 +24,7 @@ module.exports = [
       "vendor/",
       "tests/screenshots/",
       "venv/",
+      ".venv/",
       "eslint.config.cjs",
     ],
   },

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -55,6 +55,7 @@ from openlibrary.core.models import Edition
 from openlibrary.plugins.openlibrary import processors
 from openlibrary.plugins.openlibrary.stats import increment_error_count
 from openlibrary.utils.isbn import canonical, isbn_10_to_isbn_13, isbn_13_to_isbn_10
+from openlibrary.utils.sentry import get_sentry
 
 
 def setup_contextvars(handler):
@@ -1135,6 +1136,7 @@ def setup_template_globals():
             "get_book_provider": get_book_provider,
             "get_book_provider_by_name": get_book_provider_by_name,
             "get_cover_url": get_cover_url,
+            "get_sentry": get_sentry,
             # bad use of globals
             "is_bot": is_bot,
             "time": time,

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -1,3 +1,4 @@
+import initSentry from './sentry';
 import 'jquery';
 import { exposeGlobally } from './jsdef';
 import initAnalytics from './ol.analytics';
@@ -37,6 +38,8 @@ document.addEventListener('click', function(e) {
         }
     }
 }, true);
+
+initSentry();
 
 // Init the service worker first since it does caching
 initServiceWorker();

--- a/openlibrary/plugins/openlibrary/js/sentry.js
+++ b/openlibrary/plugins/openlibrary/js/sentry.js
@@ -1,0 +1,28 @@
+import * as Sentry from '@sentry/browser';
+
+export default function initSentry() {
+    const config = window.OL_SENTRY;
+    if (!config || !config.dsn) return;
+
+    Sentry.init({
+        dsn: config.dsn,
+        environment: config.environment,
+        release: config.release,
+        sampleRate: config.sampleRate,
+        tracesSampleRate: config.tracesSampleRate,
+        integrations: [
+            Sentry.browserTracingIntegration({
+                // Use the server's normalised route name (e.g. "/type/edition") so browser
+                // pageload spans group the same way as the server-side transactions.
+                beforeStartSpan: (options) => ({
+                    ...options,
+                    name: config.transactionName ?? options.name,
+                }),
+            }),
+        ],
+        // Performance monitoring only — drop all error events
+        beforeSend: () => null,
+        // Inject sentry-trace/baggage headers on same-origin requests for distributed tracing
+        tracePropagationTargets: [/^\//],
+    });
+}

--- a/openlibrary/plugins/openlibrary/js/sentry.js
+++ b/openlibrary/plugins/openlibrary/js/sentry.js
@@ -12,7 +12,7 @@ export default function initSentry() {
         tracesSampleRate: config.tracesSampleRate,
         integrations: [
             Sentry.browserTracingIntegration({
-                // Use the server's normalised route name (e.g. "/type/edition") so browser
+                // Use the server's normalized route name (e.g. "^/books/[^/]*$") so browser
                 // pageload spans group the same way as the server-side transactions.
                 beforeStartSpan: (options) => ({
                     ...options,
@@ -20,8 +20,13 @@ export default function initSentry() {
                 }),
             }),
         ],
-        // Performance monitoring only — drop all error events
-        beforeSend: () => null,
+        beforeSend(event) {
+            // Apply the same normalized name to error events so they group consistently too.
+            if (config.transactionName) {
+                event.transaction = config.transactionName;
+            }
+            return event;
+        },
         // Inject sentry-trace/baggage headers on same-origin requests for distributed tracing
         tracePropagationTargets: [/^\//],
     });

--- a/openlibrary/templates/site/head.html
+++ b/openlibrary/templates/site/head.html
@@ -111,4 +111,11 @@ $def with (title)
 
     $for tag in ctx.get("metatags", []):
         $:tag
+
+    $ sentry = get_sentry()
+    $if sentry and sentry.enabled:
+        <meta name="sentry-trace" content="$sentry.get_traceparent()">
+        <meta name="baggage" content="$sentry.get_baggage()">
+        $# detect-missing-i18n-skip-line
+        <script>window.OL_SENTRY = $:json_encode(sentry.get_frontend_config());</script>
 </head>

--- a/openlibrary/utils/__init__.py
+++ b/openlibrary/utils/__init__.py
@@ -1,5 +1,6 @@
 """Generic utilities"""
 
+import functools
 import re
 from collections.abc import Callable, Iterable
 from enum import Enum
@@ -185,6 +186,7 @@ def is_number(s):
         return False
 
 
+@functools.cache
 def get_software_version() -> str:
     """
     assert get_software_version()  # Should never return a falsy value

--- a/openlibrary/utils/sentry.py
+++ b/openlibrary/utils/sentry.py
@@ -130,13 +130,19 @@ class Sentry:
             return {}
         config = {} | self.config | self.config["frontend"]
         del config["frontend"]
-        return {
+        result: dict = {
             "dsn": config.get("dsn"),
             "environment": config.get("environment"),
             "tracesSampleRate": config.get("traces_sample_rate", 0.0),
             "sampleRate": config.get("sample_rate", 0.0),
             "release": get_software_version(),
         }
+        # The Hub-based processor (WebPySentryProcessor) stashes the normalized route name on
+        # web.ctx so it's reachable here without fighting sentry_sdk 2.x scope threading.
+        if route_name := getattr(web.ctx, "sentry_route_name", None):
+            result["transactionName"] = route_name
+
+        return result
 
     def get_traceparent(self) -> str | None:
         """Return sentry-trace header value for the active transaction (for meta tag injection)."""
@@ -186,6 +192,7 @@ class WebPySentryProcessor:
             )
 
             with hub.start_transaction(transaction):
+                web.ctx.sentry_route_name = route_name
                 try:
                     return handler()
                 finally:

--- a/openlibrary/utils/sentry.py
+++ b/openlibrary/utils/sentry.py
@@ -124,6 +124,28 @@ class Sentry:
 
         DB._db_execute = _db_execute
 
+    def get_frontend_config(self) -> dict:
+        """Return Sentry config for browser SDK initialization."""
+        if not self.config.get("frontend"):
+            return {}
+        config = {} | self.config | self.config["frontend"]
+        del config["frontend"]
+        return {
+            "dsn": config.get("dsn"),
+            "environment": config.get("environment"),
+            "tracesSampleRate": config.get("traces_sample_rate", 0.0),
+            "sampleRate": config.get("sample_rate", 0.0),
+            "release": get_software_version(),
+        }
+
+    def get_traceparent(self) -> str | None:
+        """Return sentry-trace header value for the active transaction (for meta tag injection)."""
+        return sentry_sdk.get_traceparent()
+
+    def get_baggage(self) -> str | None:
+        """Return W3C baggage header value for the active transaction (for meta tag injection)."""
+        return sentry_sdk.get_baggage()
+
 
 @dataclass
 class InfogamiRoute:
@@ -207,6 +229,11 @@ class InfogamiSentryProcessor(WebPySentryProcessor):
 
 
 _sentry: Sentry | None = None
+
+
+def get_sentry() -> Sentry | None:
+    """Return the active Sentry singleton, or None if not initialized / disabled."""
+    return _sentry
 
 
 def init_sentry(config_dict: dict) -> Sentry:

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@ericblade/quagga2": "^1.7.4",
         "@eslint/js": "^9.39.4",
         "@internetarchive/elements": "^0.2.5",
+        "@sentry/browser": "^10.60.0",
         "@tiptap/core": "^3.20.4",
         "@tiptap/extension-image": "^3.22.1",
         "@tiptap/extension-placeholder": "^3.20.4",
@@ -4989,6 +4990,87 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.60.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.60.0.tgz",
+      "integrity": "sha512-20vzPKGrmupJPCaWd+soCOLkZRwKZxt0AVF4XGPNoGp7D7wVPRlHf+FWwVMx+rRRkahKupFefM2D9YoiUiBeag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.60.0",
+        "@sentry/core": "10.60.0",
+        "@sentry/feedback": "10.60.0",
+        "@sentry/replay": "10.60.0",
+        "@sentry/replay-canvas": "10.60.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser-utils": {
+      "version": "10.60.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.60.0.tgz",
+      "integrity": "sha512-YhdPeMJnMaKVi5NQ2tD9RJ2AxU7cav5khmiMHFppmbP3I3Os2EHVaQjAVb6/ePAINr/d5mj5SxpnWmFX17iXsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.60.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.60.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.60.0.tgz",
+      "integrity": "sha512-szN7ccOJAEaLb1BBQzCQhABGMTJmKNUk0G2sc7rWhajeXoZoMKIbNkI9RvJrFuV69cbad/d/BKGBjbpJhySAzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/feedback": {
+      "version": "10.60.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.60.0.tgz",
+      "integrity": "sha512-RcGUgaI8yrIXunhNLpdNLsBUJIDvnEGDRmFhC5v0oMltoGtovrIqrEhPXEiSWQvNB0x4q33ejkLeJRJoSDOp2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.60.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "10.60.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.60.0.tgz",
+      "integrity": "sha512-j+w774BP1p+v/ga1hJAJSn0cXgTiB2VWwQCAxukF7AEXscny/OCXzTTsaPxdovw9kDHI641vKV+/yixLV2nKIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.60.0",
+        "@sentry/core": "10.60.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay-canvas": {
+      "version": "10.60.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.60.0.tgz",
+      "integrity": "sha512-mYyQRJbhRRaqUkRvkJZyqt9AWdomh4108LOAph1YJvV1jW7tKYPPFNAUveJd7YkYCyhUOtekN0DKNJveK802qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.60.0",
+        "@sentry/replay": "10.60.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.49",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@ericblade/quagga2": "^1.7.4",
     "@eslint/js": "^9.39.4",
     "@internetarchive/elements": "^0.2.5",
+    "@sentry/browser": "^10.60.0",
     "@tiptap/core": "^3.20.4",
     "@tiptap/extension-image": "^3.22.1",
     "@tiptap/extension-placeholder": "^3.20.4",


### PR DESCRIPTION
We've been experiencing performance issues which are invisible to our normal grafana dashboards. I think having performance measured by the browser will give a much clearer picture of exactly when users hit performance issues.

Requires https://github.com/internetarchive/olsystem/pull/383


### Technical
<!-- What should be noted about the implementation? -->

Known issue: monitoring on the homepage might not be working correctly due to caching, but can fix in a future issue/PR.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Up on testing and working correctly!

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

https://sentry.archive.org/organizations/ia-ux/insights/frontend/pageloads/?environment=ol-dev&project=82&statsPeriod=1h

<img width="1821" height="833" alt="image" src="https://github.com/user-attachments/assets/03a33f46-d0b9-42ce-94f0-3aa9a579a0a9" />

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@scottbarnes 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
