### PR TITLE
docs(ai/imports): update for PR #12999 — importbot now runnable locally

### DIFF
--- a/docs/ai/imports/debugging.md
+++ b/docs/ai/imports/debugging.md
@@ -27,9 +27,45 @@ The `ol import --provider ...` command described in `pm/workflows/import_workflo
 
 Adding a new identifier type to `identifiers.yml` requires a PR merge followed by the weekly OL deploy cycle. Until the deploy, any `identifiers` key in submitted records that references the new type is **silently dropped** — no error, no warning. Design implication: either (a) block batch submission until after the identifier PR deploys, or (b) submit records without the `identifiers` field and run an update pass afterward.
 
-### Local dev ImportBot does not run
+### Running ImportBot locally (fixed in PR #12999)
 
-`scripts/manage-imports.py` (ImportBot) is not wired into the Docker Compose dev setup. Records submitted to `/import/batch/new` locally will queue but never be processed. To test the full queue→process loop, either call `add_book.load()` directly in tests or test against a staging environment. Tracked in [#7236](https://github.com/internetarchive/openlibrary/issues/7236).
+ImportBot (`scripts/manage-imports.py`) is now included in `compose.near-prod.yaml`. To run the full queue→process loop locally:
+
+```bash
+# Start web stack plus importbot
+COMPOSE_FILE="compose.yaml:compose.override.yaml:compose.near-prod.yaml" \
+  docker compose up -d web infobase db memcached home importbot
+
+# Windows: use semicolons in COMPOSE_FILE
+# COMPOSE_FILE="compose.yaml;compose.override.yaml;compose.near-prod.yaml"
+```
+
+The `importbot` service sets `LOCAL_DEV=true` which makes `manage-imports.py` log in as
+`openlibrary@example.com` / `admin123` (the seeded dev account). It polls the `import_item`
+table every 15 seconds (`OL_IMPORT_ALL_SLEEP=15`) with a single worker process
+(`OL_IMPORT_ALL_PROCESSES=1`) to avoid SQLite lock contention.
+
+Key env vars for the importbot service (all have defaults in `compose.near-prod.yaml`):
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `LOCAL_DEV` | `true` | Login as dev account instead of using `.rcfile` |
+| `OL_IMPORT_ALL_SLEEP` | `15` (local) / `60` (prod default) | Seconds between polls when queue is empty |
+| `OL_IMPORT_ALL_PROCESSES` | `1` (local) / `8` (prod default) | Worker pool size — keep at 1 locally to avoid db lock issues |
+
+To submit a record and watch it process:
+
+```bash
+# 1. Submit to the batch queue (must be logged in)
+curl -s -X POST "http://localhost:8080/import/batch/new" \
+  --cookie "session=..." \
+  -F 'batch=@records.jsonl'
+
+# 2. Watch importbot pick it up
+docker compose logs -f importbot
+```
+
+Previously tracked as [#7236](https://github.com/internetarchive/openlibrary/issues/7236).
 
 ---
 

--- a/docs/ai/imports/index.md
+++ b/docs/ai/imports/index.md
@@ -63,7 +63,8 @@ get_from_archive_bulk() → MarcBinary → read_edition() → add_book.load()
 | `openlibrary/schemata/import.schema.json` | Canonical JSON schema (`additionalProperties: false`). `OLImportRecord` mirrors it exactly. |
 | `openlibrary-bots/sources/itan/provider.py` | Example concrete `JSONLProvider` for ITAN Global Publishing |
 | `openlibrary-bots/sources/itan/record.py` | Example concrete `DataProviderRecord` for ITAN |
-| `scripts/manage-imports.py` | ImportBot: processes pending batch items in an 8-worker multiprocessing pool; not wired into Docker dev |
+| `scripts/manage-imports.py` | ImportBot: processes pending batch items in a configurable multiprocessing pool; runnable locally via `compose.near-prod.yaml` (PR #12999) |
+| `compose.near-prod.yaml` | Near-prod compose override — adds `importbot` service and Solr replication; use with `COMPOSE_FILE="compose.yaml:compose.override.yaml:compose.near-prod.yaml"` |
 
 ## Sub-docs
 
@@ -89,7 +90,7 @@ get_from_archive_bulk() → MarcBinary → read_edition() → add_book.load()
 | [#12091](https://github.com/internetarchive/openlibrary/issues/12091) | Open | ITAN import request |
 | [#12655](https://github.com/internetarchive/openlibrary/issues/12655) | Open, not ready for action | Epic: BookWorm — modernize import pipeline |
 | [#10756](https://github.com/internetarchive/openlibrary/issues/10756) | Open, proposal posted | `not-differentiable` for pre-ISBN IA items; proposed `IABook` validator |
-| [#7236](https://github.com/internetarchive/openlibrary/issues/7236) | Open | Local dev ImportBot doesn't run |
+| [#7236](https://github.com/internetarchive/openlibrary/issues/7236) | Fixed in PR #12999 | Local dev ImportBot now runnable via `compose.near-prod.yaml` |
 | [#8542](https://github.com/internetarchive/openlibrary/issues/8542) | Open | Batch import documentation gap |
 
 **Identifier PR before adapter PR**: #12947 must merge and deploy before the ITAN adapter PR (#447) can submit a batch. `itan_technologies` keys are silently dropped until the identifier is registered.


### PR DESCRIPTION
## Summary

Updates the import pipeline AI docs to reflect PR #12999 ("Fix importbot + make runnable locally" by @cdrini, now merged).

**Changes:**

- `docs/ai/imports/index.md` — updates `manage-imports.py` description; adds `compose.near-prod.yaml` to the key files table; marks #7236 as fixed
- `docs/ai/imports/debugging.md` — replaces the "Local dev ImportBot does not run" limitation with a full how-to guide including the `COMPOSE_FILE` command, env vars (`LOCAL_DEV`, `OL_IMPORT_ALL_SLEEP`, `OL_IMPORT_ALL_PROCESSES`), and login credential change

## What PR #12999 changed

- Added `importbot` service to `compose.near-prod.yaml` (sets `LOCAL_DEV=true`, single worker, 15s poll)
- Fixed `manage-imports.py` local login: `("admin","admin123")` → `("openlibrary@example.com","admin123")`
- Made sleep/worker count configurable via env vars
- Fixed `import_data` method indentation (was accidentally de-indented to top-level by Copilot in #12902)

Closes #7236