### PR TITLE
test(solr): add unit tests for cover_width/cover_height in Work and Edition builders

### DIFF
--- a/openlibrary/tests/solr/updater/test_edition.py
+++ b/openlibrary/tests/solr/updater/test_edition.py
@@ -4,6 +4,17 @@ from openlibrary.solr.updater.edition import EditionSolrBuilder, EditionSolrUpda
 from openlibrary.tests.solr.test_update import FakeDataProvider, make_edition
 
 
+class FakeDataProviderWithCovers(FakeDataProvider):
+    """FakeDataProvider with controllable cover dimensions."""
+
+    def __init__(self, docs=None, cover_dimensions: dict[int, tuple[int, int] | None] | None = None):
+        super().__init__(docs)
+        self._cover_dimensions_map = cover_dimensions or {}
+
+    def get_cover_dimensions(self, cover_id: int) -> tuple[int, int] | None:
+        return self._cover_dimensions_map.get(cover_id)
+
+
 class TestEditionSolrUpdater:
     @pytest.mark.asyncio
     async def test_deletes_old_orphans(self):
@@ -53,3 +64,39 @@ class TestEditionSolrBuilder:
         assert EditionSolrBuilder(edition).identifiers == {
             "id_some_weird_key": ["id-1", "id-2"],
         }
+
+
+class TestEditionSolrBuilderCoverDimensions:
+    def test_cover_width_and_height_none_when_no_covers_field(self):
+        """Edition with no covers field → cover_i None → dimensions None."""
+        edition = make_edition()
+        esb = EditionSolrBuilder(edition)
+        assert esb.cover_i is None
+        assert esb.cover_width is None
+        assert esb.cover_height is None
+
+    def test_cover_width_and_height_none_without_data_provider(self):
+        """Edition has a cover id but no data_provider → dimensions are None."""
+        edition = make_edition(covers=[55])
+        esb = EditionSolrBuilder(edition, data_provider=None)
+        assert esb.cover_i == 55
+        assert esb.cover_width is None
+        assert esb.cover_height is None
+
+    def test_cover_width_and_height_from_data_provider(self):
+        """Edition has cover id and data_provider returns valid dimensions."""
+        edition = make_edition(covers=[55])
+        dp = FakeDataProviderWithCovers(cover_dimensions={55: (640, 960)})
+        esb = EditionSolrBuilder(edition, data_provider=dp)
+        assert esb.cover_i == 55
+        assert esb.cover_width == 640
+        assert esb.cover_height == 960
+
+    def test_sentinel_cover_id_minus_one_skipped(self):
+        """cover id -1 is the sentinel for 'no cover'; it must be skipped."""
+        edition = make_edition(covers=[-1, 88])
+        dp = FakeDataProviderWithCovers(cover_dimensions={88: (320, 480)})
+        esb = EditionSolrBuilder(edition, data_provider=dp)
+        assert esb.cover_i == 88
+        assert esb.cover_width == 320
+        assert esb.cover_height == 480

--- a/openlibrary/tests/solr/updater/test_work.py
+++ b/openlibrary/tests/solr/updater/test_work.py
@@ -528,3 +528,50 @@ class Test_Sort_Editions_Ocaids:
         )
 
         assert sorted(wsb.ia_collection) == sorted(["americanlibraries", "blah"])
+
+
+class FakeDataProviderWithCovers(FakeDataProvider):
+    """FakeDataProvider that returns controllable cover dimensions."""
+
+    def __init__(self, docs=None, cover_dimensions: dict[int, tuple[int, int] | None] | None = None):
+        super().__init__(docs)
+        self._cover_dimensions = cover_dimensions or {}
+
+    def get_cover_dimensions(self, cover_id: int) -> tuple[int, int] | None:
+        return self._cover_dimensions.get(cover_id)
+
+
+class TestWorkSolrBuilderCoverDimensions:
+    def test_cover_width_and_height_none_when_no_cover(self):
+        """Work with no covers field → cover_i is None → dimensions are None."""
+        wsb = make_work_solr_builder(work=make_work())
+        assert wsb.cover_i is None
+        assert wsb.cover_width is None
+        assert wsb.cover_height is None
+
+    def test_cover_width_and_height_none_when_cover_not_in_db(self):
+        """Work has a cover id but coverstore returns None (not in DB)."""
+        work = make_work(covers=[42])
+        dp = FakeDataProviderWithCovers(cover_dimensions={})
+        wsb = make_work_solr_builder(work=work, data_provider=dp)
+        assert wsb.cover_i == 42
+        assert wsb.cover_width is None
+        assert wsb.cover_height is None
+
+    def test_cover_width_and_height_from_data_provider(self):
+        """Work has a cover id and coverstore returns valid dimensions."""
+        work = make_work(covers=[99])
+        dp = FakeDataProviderWithCovers(cover_dimensions={99: (800, 1200)})
+        wsb = make_work_solr_builder(work=work, data_provider=dp)
+        assert wsb.cover_i == 99
+        assert wsb.cover_width == 800
+        assert wsb.cover_height == 1200
+
+    def test_sentinel_cover_id_minus_one_skipped(self):
+        """cover id -1 is the sentinel for 'no cover'; it must be skipped."""
+        work = make_work(covers=[-1, 77])
+        dp = FakeDataProviderWithCovers(cover_dimensions={77: (400, 600)})
+        wsb = make_work_solr_builder(work=work, data_provider=dp)
+        assert wsb.cover_i == 77
+        assert wsb.cover_width == 400
+        assert wsb.cover_height == 600


### PR DESCRIPTION
## Summary

PR #12916 (merged) added `cover_width` and `cover_height` fields to both `WorkSolrBuilder` and `EditionSolrBuilder`, but the PR description explicitly noted: *"the solr-builder changes aren't tested."*

This PR adds 8 unit tests covering the missing paths:

**`TestWorkSolrBuilderCoverDimensions`**
- `test_cover_width_and_height_none_when_no_cover` — no `covers` field → `cover_i` is `None` → both dimensions `None`
- `test_cover_width_and_height_none_when_cover_not_in_db` — cover id present but coverstore returns nothing → `None`
- `test_cover_width_and_height_from_data_provider` — valid cover id → correct `(w, h)` returned
- `test_sentinel_cover_id_minus_one_skipped` — `-1` sentinel in `covers` list is skipped; real id used

**`TestEditionSolrBuilderCoverDimensions`**
- Same four cases, plus: `test_cover_width_and_height_none_without_data_provider` — edition has a cover id but `data_provider=None` → `None` (guards the `if not self._data_provider` branch in `EditionSolrBuilder._cover_dimensions`)

A `FakeDataProviderWithCovers` stub avoids any coverstore DB dependency.

## Testing

```
8 passed in 0.27s
```

Run with:
```bash
docker compose run --no-deps --rm home python -m pytest \
  openlibrary/tests/solr/updater/test_work.py::TestWorkSolrBuilderCoverDimensions \
  openlibrary/tests/solr/updater/test_edition.py::TestEditionSolrBuilderCoverDimensions \
  -v
```

## Related

Closes the test gap noted in #12916.