### PR TITLE
Fix search-funnel analytics: report to Matomo via _paq + sendBeacon

### DIFF
--- a/openlibrary/plugins/openlibrary/js/SearchFilterBar.js
+++ b/openlibrary/plugins/openlibrary/js/SearchFilterBar.js
@@ -137,12 +137,6 @@ export function initSearchFilterBar(container) {
         availabilityEl.addEventListener('ol-toggle-change', (e) => {
             const value = e.detail.checked ? 'readable' : DEFAULT_AVAILABILITY;
             writeStoredAvailability(value);
-            // Track the toggle. ol-toggle uses Shadow DOM, so Matomo's
-            // selector-based click triggers can't see the inner button — we
-            // listen to the composed `ol-toggle-change` event and report via
-            // trackEvent(), which pushes onto Matomo's `_paq` queue. Fire before
-            // navigateWithParams unloads the page; trackEvent guards internally
-            // if the analytics script didn't load.
             trackEvent('SearchFilter', e.detail.checked ? 'AvailabilityOn' : 'AvailabilityOff');
             const mapped = AVAILABILITY_TO_PARAMS[value] || {};
             navigateWithParams((params) => {

--- a/openlibrary/plugins/openlibrary/js/SearchFilterBar.js
+++ b/openlibrary/plugins/openlibrary/js/SearchFilterBar.js
@@ -35,6 +35,7 @@ import {
     readStoredLanguages,
 } from './search-modal/constants.js';
 import { fetchLanguageOptions } from './search-modal/languages.js';
+import { trackEvent } from './ol.analytics.js';
 
 // Every query param the availability filter owns, across all of its values.
 // Cleared before applying a new value so stale availability filters don't
@@ -136,17 +137,13 @@ export function initSearchFilterBar(container) {
         availabilityEl.addEventListener('ol-toggle-change', (e) => {
             const value = e.detail.checked ? 'readable' : DEFAULT_AVAILABILITY;
             writeStoredAvailability(value);
-            // Track the toggle via OL's Matomo wrapper. ol-toggle uses Shadow
-            // DOM, so Matomo's selector-based click triggers can't see the
-            // inner button — we listen to the composed `ol-toggle-change` event
-            // and send the event manually instead. Fire before navigateWithParams
-            // unloads the page, and guard in case the analytics CDN didn't load.
-            if (window.archive_analytics) {
-                window.archive_analytics.ol_send_event_ping({
-                    category: 'SearchFilter',
-                    action: e.detail.checked ? 'AvailabilityOn' : 'AvailabilityOff',
-                });
-            }
+            // Track the toggle. ol-toggle uses Shadow DOM, so Matomo's
+            // selector-based click triggers can't see the inner button — we
+            // listen to the composed `ol-toggle-change` event and report via
+            // trackEvent(), which pushes onto Matomo's `_paq` queue. Fire before
+            // navigateWithParams unloads the page; trackEvent guards internally
+            // if the analytics script didn't load.
+            trackEvent('SearchFilter', e.detail.checked ? 'AvailabilityOn' : 'AvailabilityOff');
             const mapped = AVAILABILITY_TO_PARAMS[value] || {};
             navigateWithParams((params) => {
                 AVAILABILITY_PARAM_KEYS.forEach((key) => params.delete(key));

--- a/openlibrary/plugins/openlibrary/js/ol.analytics.js
+++ b/openlibrary/plugins/openlibrary/js/ol.analytics.js
@@ -5,6 +5,31 @@
 *
 */
 
+/**
+ * Report a custom interaction event to Matomo from JS.
+ *
+ * Use this for interactions that Matomo's DOM-based trigger can't see — chiefly
+ * Shadow DOM controls (Lit components), where a `data-ol-link-track` attribute
+ * on an inner element is invisible to Matomo's selector-based click trigger. We
+ * push a `trackEvent` straight onto Matomo's `_paq` queue — the same path that
+ * trigger ultimately uses, so the event lands in Matomo under the given
+ * category/action/label. (Athena does not forward into Matomo, so the `_paq`
+ * push is what actually makes these events report.)
+ *
+ * Guarded so a blocked or absent analytics script can never break the
+ * interaction that triggered it.
+ *
+ * @param {string} category  Event category, e.g. 'SearchModal'
+ * @param {string} action    Event action, e.g. 'ResultClick'
+ * @param {string} [label]   Optional event label, e.g. 'edition:3'
+ */
+export function trackEvent(category, action, label) {
+    if (!window._paq) return;
+    const event = ['trackEvent', category, action];
+    if (label) event.push(label);
+    window._paq.push(event);
+}
+
 export default function initAnalytics() {
     var vs, i;
     var startTime = new Date();

--- a/openlibrary/plugins/openlibrary/js/search-modal/SearchModal.js
+++ b/openlibrary/plugins/openlibrary/js/search-modal/SearchModal.js
@@ -1430,12 +1430,7 @@ export class SearchModal extends LitElement {
 
     // ── Event handlers ───────────────────────────────────────────────────
 
-    // Send a Matomo event. The modal renders in Shadow DOM, so Matomo's
-    // selector-based click triggers can't see its controls — we emit events
-    // manually via trackEvent(), which pushes onto Matomo's `_paq` queue.
-    // Guarded internally so a missing analytics script can't break an
-    // interaction. Labels carry only the *shape* of the interaction (counts,
-    // positions, types) — never the query text the patron typed.
+    /** Send a Matomo analytics event */
     _track(action, label) {
         trackEvent('SearchModal', action, label);
     }

--- a/openlibrary/plugins/openlibrary/js/search-modal/SearchModal.js
+++ b/openlibrary/plugins/openlibrary/js/search-modal/SearchModal.js
@@ -8,6 +8,7 @@ import { repeat } from 'lit/directives/repeat.js';
 import { debounce } from '../nonjquery_utils.js';
 import { sprintf } from '../i18n.js';
 import { mode as searchMode } from '../SearchUtils.js';
+import { trackEvent } from '../ol.analytics.js';
 import {
     AVAILABILITY_OPTIONS,
     AVAILABILITY_TO_PARAMS,
@@ -1429,14 +1430,14 @@ export class SearchModal extends LitElement {
 
     // ── Event handlers ───────────────────────────────────────────────────
 
-    // Send a Matomo event through OL's wrapper. The modal renders in Shadow
-    // DOM, so Matomo's selector-based click triggers can't see its controls —
-    // we emit events manually instead. Guarded so a missing analytics CDN can't
-    // break an interaction. Labels carry only the *shape* of the interaction
-    // (counts, positions, types) — never the query text the patron typed.
+    // Send a Matomo event. The modal renders in Shadow DOM, so Matomo's
+    // selector-based click triggers can't see its controls — we emit events
+    // manually via trackEvent(), which pushes onto Matomo's `_paq` queue.
+    // Guarded internally so a missing analytics script can't break an
+    // interaction. Labels carry only the *shape* of the interaction (counts,
+    // positions, types) — never the query text the patron typed.
     _track(action, label) {
-        if (!window.archive_analytics) return;
-        window.archive_analytics.ol_send_event_ping({ category: 'SearchModal', action, label });
+        trackEvent('SearchModal', action, label);
     }
 
     _onDialogOpened() {

--- a/openlibrary/templates/site/head.html
+++ b/openlibrary/templates/site/head.html
@@ -57,6 +57,10 @@ $def with (title)
    // Dimension 1 (visit-scoped): "Days Since Registration" — ID must match Matomo admin config (issue #12144)
    var _paq = window._paq = window._paq || [];
    _paq.push(['setCustomDimension', 1, $:json_encode(get_days_registered(ctx.user))]);
+   // Send every tracking request via navigator.sendBeacon so events fired right
+   // before a navigation (e.g. the search modal's result-click / "see all", the
+   // availability toggle) survive the page unload instead of being cancelled.
+   _paq.push(['alwaysUseSendBeacon']);
 
    var _mtm = window._mtm = window._mtm || [];
    _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});

--- a/openlibrary/templates/site/head.html
+++ b/openlibrary/templates/site/head.html
@@ -57,10 +57,6 @@ $def with (title)
    // Dimension 1 (visit-scoped): "Days Since Registration" — ID must match Matomo admin config (issue #12144)
    var _paq = window._paq = window._paq || [];
    _paq.push(['setCustomDimension', 1, $:json_encode(get_days_registered(ctx.user))]);
-   // Send every tracking request via navigator.sendBeacon so events fired right
-   // before a navigation (e.g. the search modal's result-click / "see all", the
-   // availability toggle) survive the page unload instead of being cancelled.
-   _paq.push(['alwaysUseSendBeacon']);
 
    var _mtm = window._mtm = window._mtm || [];
    _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #13020

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
**fix** — The search-funnel events added in #12948 emitted but never landed in Matomo.

They were sent through `archive_analytics.ol_send_event_ping`, which pings **Athena** — and Athena doesn't forward events into Matomo (confirmed by @scottbarnes on #13020). Matomo normally ingests OL events via a tag-manager DOM trigger on `data-ol-link-track`, but that trigger can't see inside **Shadow DOM**, where the Lit search modal and `ol-toggle` live. So these controls had no path into Matomo.

### Technical
- New `trackEvent(category, action, label)` helper in `ol.analytics.js` pushes onto Matomo's `_paq` queue directly — the same path the DOM trigger uses, so events report regardless of Shadow DOM. `SearchModal._track()` and the `SearchFilterBar` toggle route through it; the Athena ping is dropped.
- `head.html` now pushes `['alwaysUseSendBeacon']`, so events that fire right before a navigation (result-click, "see all", toggle) are sent via `navigator.sendBeacon()` and survive the page unload.

### Testing
With a Matomo-enabled environment, spy on the queue in DevTools: `const o = _paq.push.bind(_paq); _paq.push = (...a) => { console.log('PAQ', ...a); return o(...a); };`

1. Open the search modal → `['trackEvent', 'SearchModal', 'Open', 'click']`.
2. Type a query, click a result → `ResultClick / edition:3`; "See all" → `SeeAllResults / hasResults`; no-results query → `NoResults`.
3. On `/search`, toggle Readable Only → `SearchFilter / AvailabilityOn|Off`.
4. Admin-side (@cdrini, per the issue): confirm these appear under Behaviour → Events.

### Screenshot
No UI changes — analytics wiring only.

### Stakeholders
@cdrini (Matomo admin; suggested the `_paq` approach on the issue)
