### PR TITLE
fix: remove redundant merge-authors feature flag

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -62,9 +62,6 @@ features:
     dev: enabled
     history_v2: admin
     lists: enabled
-    merge-authors:
-        filter: usergroup
-        usergroup: /usergroup/librarians
     publishers: enabled
     recentchanges_v2: enabled
     stats: enabled

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -970,6 +970,15 @@ class User(Thing):
     def is_super_librarian(self) -> bool:
         return self.is_usergroup_member("/usergroup/super-librarians")
 
+    def is_librarian_or_higher(self) -> bool:
+        return self.is_member_of_any(
+            [
+                "/usergroup/librarians",
+                "/usergroup/super-librarians",
+                "/usergroup/admin",
+            ]
+        )
+
     def is_beta_tester(self) -> bool:
         return self.is_usergroup_member("/usergroup/beta-testers")
 

--- a/openlibrary/fastapi/auth.py
+++ b/openlibrary/fastapi/auth.py
@@ -155,7 +155,7 @@ async def require_librarian(
             return {"message": "You have librarian access!"}
     """
     user = get_current_user()
-    if not (user and (user.is_admin() or user.is_librarian() or user.is_super_librarian())):
+    if not (user and user.is_librarian_or_higher()):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Insufficient permissions",

--- a/openlibrary/plugins/importapi/import_ui.py
+++ b/openlibrary/plugins/importapi/import_ui.py
@@ -25,7 +25,7 @@ class import_preview(delegate.page):
 
         if user is None:
             raise web.unauthorized()
-        has_access = user and ((user.is_admin() or user.is_librarian()) or user.is_super_librarian())
+        has_access = user and user.is_librarian_or_higher()
         if not has_access:
             raise web.forbidden()
 
@@ -39,7 +39,7 @@ class import_preview(delegate.page):
 
         if user is None:
             raise web.unauthorized()
-        has_access = user and ((user.is_admin() or user.is_librarian()) or user.is_super_librarian())
+        has_access = user and user.is_librarian_or_higher()
         if not has_access:
             raise web.forbidden()
 
@@ -74,7 +74,7 @@ class import_preview_json(delegate.page):
 
         if user is None:
             raise web.unauthorized()
-        has_access = user and ((user.is_admin() or user.is_librarian()) or user.is_super_librarian())
+        has_access = user and user.is_librarian_or_higher()
         if not has_access:
             raise web.forbidden()
 
@@ -94,7 +94,7 @@ class import_preview_json(delegate.page):
 
         if user is None:
             raise web.unauthorized()
-        has_access = user and ((user.is_admin() or user.is_librarian()) or user.is_super_librarian())
+        has_access = user and user.is_librarian_or_higher()
         if not has_access:
             raise web.forbidden()
 

--- a/openlibrary/plugins/openlibrary/partials.py
+++ b/openlibrary/plugins/openlibrary/partials.py
@@ -331,7 +331,7 @@ class SearchFacetsPartial:
     @classmethod
     async def generate_async(cls, data: dict, sfw: bool = False) -> dict:
         user = get_current_user()
-        show_merge_authors = user and (user.is_librarian() or user.is_super_librarian() or user.is_admin())
+        show_merge_authors = user and user.is_librarian_or_higher()
 
         path = data.get("path")
         query = data.get("query", "")

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -128,7 +128,7 @@ class merge_work(delegate.page):
 
         if user is None:
             raise web.unauthorized()
-        has_access = user and ((user.is_admin() or user.is_librarian()) or user.is_super_librarian())
+        has_access = user and user.is_librarian_or_higher()
         if not has_access:
             raise web.forbidden()
 

--- a/openlibrary/plugins/upstream/merge_authors.py
+++ b/openlibrary/plugins/upstream/merge_authors.py
@@ -214,7 +214,7 @@ class merge_authors(delegate.page):
 
     def is_enabled(self):
         user = site.get().get_user()
-        return user and (user.is_librarian() or user.is_admin() or user.is_super_librarian())
+        return user and user.is_librarian_or_higher()
 
     def filter_authors(self, keys):
         docs = site.get().get_many(["/authors/" + k for k in keys])
@@ -319,7 +319,7 @@ class merge_authors_json(delegate.page):
 
     def is_enabled(self):
         user = site.get().get_user()
-        return user and (user.is_librarian() or user.is_admin() or user.is_super_librarian())
+        return user and user.is_librarian_or_higher()
 
     def POST(self):
         data = json.loads(web.data())

--- a/openlibrary/plugins/upstream/merge_authors.py
+++ b/openlibrary/plugins/upstream/merge_authors.py
@@ -214,7 +214,7 @@ class merge_authors(delegate.page):
 
     def is_enabled(self):
         user = site.get().get_user()
-        return "merge-authors" in web.ctx.features or (user and user.is_admin())
+        return user and (user.is_librarian() or user.is_admin() or user.is_super_librarian())
 
     def filter_authors(self, keys):
         docs = site.get().get_many(["/authors/" + k for k in keys])
@@ -319,7 +319,7 @@ class merge_authors_json(delegate.page):
 
     def is_enabled(self):
         user = site.get().get_user()
-        return "merge-authors" in web.ctx.features or (user and user.is_admin())
+        return user and (user.is_librarian() or user.is_admin() or user.is_super_librarian())
 
     def POST(self):
         data = json.loads(web.data())

--- a/openlibrary/templates/authors/infobox.html
+++ b/openlibrary/templates/authors/infobox.html
@@ -1,6 +1,6 @@
 $def with (page, edit_view: bool = False, imagesId=0)
 
-$ is_librarian = ctx.user and (ctx.user.is_librarian() or ctx.user.is_super_librarian() or ctx.user.is_admin())
+$ is_librarian = ctx.user and ctx.user.is_librarian_or_higher()
 
 $if edit_view:
     $ wikidata = page.wikidata(bust_cache=True, fetch_missing=True)

--- a/openlibrary/templates/books/add.html
+++ b/openlibrary/templates/books/add.html
@@ -79,7 +79,7 @@ $ i18n_strings = {
             </div>
         </div>
 
-        $if ctx.user and (ctx.user.is_admin() or ctx.user.is_super_librarian() or ctx.user.is_librarian()):
+        $if ctx.user and ctx.user.is_librarian_or_higher():
             <div class="formElement">
                 <div class="label">
                     <label for="web_book_url">$_("Book URL")</label> <span class="tip">$_("Only fill this out if this is a web book")</span></span>

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -4,7 +4,7 @@ $ edition_config = get_identifier_config('edition')
 $ is_librarian = ctx.user and ctx.user.is_librarian()
 $ is_admin = ctx.user and ctx.user.is_admin()
 $ is_super_librarian = ctx.user and ctx.user.is_super_librarian()
-$ is_privileged_user = is_librarian or is_super_librarian or is_admin
+$ is_privileged_user = ctx.user and ctx.user.is_librarian_or_higher()
 
 $def radiobuttons(name, options, value):
     $for v in options:

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -1,5 +1,5 @@
 $def with (page)
-$ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_super_librarian() or ctx.user.is_librarian())
+$ is_privileged_user = ctx.user and ctx.user.is_librarian_or_higher()
 <header id="header-bar" class="header-bar">
 
 

--- a/openlibrary/templates/search/authors.html
+++ b/openlibrary/templates/search/authors.html
@@ -28,7 +28,7 @@ $var title: $_('Search Open Library for "%(query)s"', query=q)
             <div class="search-results-stats">$ungettext('%(count)s hit', '%(count)s hits', results.num_found, count=commify(results.num_found))
               $if results.num_found > 1:
                 $:render_template("search/sort_options.html", selected_sort=sort, search_scheme="authors")
-              $ user_can_merge = ctx.user and ("merge-authors" in ctx.features or ctx.user.is_admin())
+              $ user_can_merge = ctx.user and (ctx.user.is_librarian() or ctx.user.is_admin() or ctx.user.is_super_librarian())
               $if results.num_found >= 2 and user_can_merge:
                 $ keys = ','.join(doc['key'].split("/")[-1] for doc in results.docs)
                 <div class="mergeThis">$_('Is the same author listed twice?') <a class="large sansserif" href="/authors/merge?records=$keys">$_('Merge authors')</a></div>

--- a/openlibrary/templates/search/authors.html
+++ b/openlibrary/templates/search/authors.html
@@ -28,7 +28,7 @@ $var title: $_('Search Open Library for "%(query)s"', query=q)
             <div class="search-results-stats">$ungettext('%(count)s hit', '%(count)s hits', results.num_found, count=commify(results.num_found))
               $if results.num_found > 1:
                 $:render_template("search/sort_options.html", selected_sort=sort, search_scheme="authors")
-              $ user_can_merge = ctx.user and (ctx.user.is_librarian() or ctx.user.is_admin() or ctx.user.is_super_librarian())
+              $ user_can_merge = ctx.user and ctx.user.is_librarian_or_higher()
               $if results.num_found >= 2 and user_can_merge:
                 $ keys = ','.join(doc['key'].split("/")[-1] for doc in results.docs)
                 <div class="mergeThis">$_('Is the same author listed twice?') <a class="large sansserif" href="/authors/merge?records=$keys">$_('Merge authors')</a></div>

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -59,7 +59,7 @@ $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_libra
 </div>
 
 <div id="contentBody">
-    $if ctx.user and ("merge-authors" in ctx.features or ctx.user.is_admin()) and query_param('merge', 'false') == 'true':
+    $if ctx.user and (ctx.user.is_librarian() or ctx.user.is_admin() or ctx.user.is_super_librarian()) and query_param('merge', 'false') == 'true':
         $ mrid = query_param('mrid', None)
         $ comment = query_param('comment', None)
         $ duplicate_olids = query_param('duplicates', '').split(',')

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -59,7 +59,7 @@ $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_libra
 </div>
 
 <div id="contentBody">
-    $if ctx.user and (ctx.user.is_librarian() or ctx.user.is_admin() or ctx.user.is_super_librarian()) and query_param('merge', 'false') == 'true':
+    $if ctx.user and ctx.user.is_librarian_or_higher() and query_param('merge', 'false') == 'true':
         $ mrid = query_param('mrid', None)
         $ comment = query_param('comment', None)
         $ duplicate_olids = query_param('duplicates', '').split(',')
@@ -100,7 +100,7 @@ $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_libra
         </div>
 
     <div class="contentTwothird" style="margin-bottom:0;">
-        $ show_dashboard = ctx.user and (ctx.user.is_librarian() or ctx.user.is_super_librarian() or ctx.user.is_admin())
+        $ show_dashboard = ctx.user and ctx.user.is_librarian_or_higher()
         $if show_dashboard:
           $:render_template("librarian_dashboard/data_quality_table", books_count)
         <div itemprop="description">

--- a/openlibrary/templates/type/delete/view.html
+++ b/openlibrary/templates/type/delete/view.html
@@ -17,7 +17,7 @@ $var title: $page.key
         $# Prevent crawling; only show to logged-in users
         <li><a href="$url(v=page.revision - 1)">$_("View the previous version")</a></li>
         <li><a href="$url(m='history')">$_("See the page's history")</a></li>
-        $if (ctx.user.is_librarian() or ctx.user.is_super_librarian() or ctx.user.is_admin()):
+        $if ctx.user.is_librarian_or_higher():
             <li><a href="$url(m='edit', v=page.revision - 1)">$_("Recreate it")</a></li>
     </ul>
 </div>

--- a/openlibrary/templates/type/user/view.html
+++ b/openlibrary/templates/type/user/view.html
@@ -76,10 +76,9 @@ $else:
         </div>
         <div class="clearfix"></div>
 
-    $ is_admin = ctx.user and ctx.user.is_admin()
-    $ is_librarian = ctx.user and (ctx.user.is_librarian() or ctx.user.is_super_librarian())
+    $ is_librarian_or_higher = ctx.user and ctx.user.is_librarian_or_higher()
 
-    $if owners_page or is_admin or is_librarian:
+    $if owners_page or is_librarian_or_higher:
         $if "recentchanges_v2" in ctx.features:
             $ changes = render_template("recentchanges/render", author=page.key, limit=25)
             $if changes.length > 1:

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -10,7 +10,7 @@ $ bodyclass.append('search-page')
     </div>
 
 <div id="contentBody">
-  $ show_dashboard = ctx.user and (ctx.user.is_librarian() or ctx.user.is_super_librarian() or ctx.user.is_admin())
+  $ show_dashboard = ctx.user and ctx.user.is_librarian_or_higher()
   $if show_dashboard:
     $:render_template("librarian_dashboard/data_quality_table", search_response.num_found)
 
@@ -20,7 +20,7 @@ $ bodyclass.append('search-page')
     <form method="get" action="/search" class="siteSearch search-row olform">
       <label for="q" class="hidden">$_('Keywords')</label>
       $:render_template("search/searchbox", q=q_param, autofocus=True)
-      $if ctx.user and (ctx.user.is_admin() or ctx.user.is_super_librarian() or ctx.user.is_librarian()):
+      $if ctx.user and ctx.user.is_librarian_or_higher():
         <div style="display: flex; justify-content: flex-end"  title="$_('This is only visible to super librarians.')">
             <label
             style="padding: 4px; display: inline-block;"

--- a/openlibrary/tests/core/test_models.py
+++ b/openlibrary/tests/core/test_models.py
@@ -1,9 +1,95 @@
+from unittest.mock import PropertyMock
+
 import pytest
 import web
 
 from openlibrary.core import models
 from openlibrary.mocks import mock_infobase
 from openlibrary.utils.request_context import site as site_var
+
+
+class _FakeGroup:
+    def __init__(self, key: str):
+        self.key = key
+
+
+class TestUserGroupMembership:
+    @pytest.mark.parametrize(
+        ("group_keys", "check_groups", "expected"),
+        [
+            ([], ["/usergroup/librarians"], False),
+            ([], ["/usergroup/librarians", "/usergroup/admin"], False),
+            (["/usergroup/librarians"], ["/usergroup/librarians"], True),
+            (["/usergroup/librarians"], ["/usergroup/admin"], False),
+            (["/usergroup/librarians", "/usergroup/admin"], ["/usergroup/librarians"], True),
+            (["/usergroup/admin"], ["/usergroup/librarians", "/usergroup/admin"], True),
+            (["/usergroup/admin"], ["/usergroup/librarians", "/usergroup/super-librarians"], False),
+            ([], [], False),
+        ],
+    )
+    def test_is_member_of_any(self, monkeypatch, group_keys, check_groups, expected):
+        groups = [_FakeGroup(k) for k in group_keys]
+        user = models.User(MockSite(), "/people/test", data={})
+        monkeypatch.setattr(
+            models.User,
+            "usergroups",
+            PropertyMock(return_value=groups),
+        )
+        assert user.is_member_of_any(check_groups) == expected
+
+    @pytest.mark.parametrize(
+        ("group_keys", "check_group", "expected"),
+        [
+            ([], "librarians", False),
+            ([], "/usergroup/librarians", False),
+            (["/usergroup/librarians"], "librarians", True),
+            (["/usergroup/librarians"], "/usergroup/librarians", True),
+            (["/usergroup/librarians"], "admin", False),
+            (["/usergroup/librarians"], "/usergroup/admin", False),
+            (["/usergroup/admin"], "librarians", False),
+            (["/usergroup/super-librarians"], "super-librarians", True),
+        ],
+    )
+    def test_is_usergroup_member(self, monkeypatch, group_keys, check_group, expected):
+        groups = [_FakeGroup(k) for k in group_keys]
+        user = models.User(MockSite(), "/people/test", data={})
+        monkeypatch.setattr(
+            models.User,
+            "usergroups",
+            PropertyMock(return_value=groups),
+        )
+        assert user.is_usergroup_member(check_group) == expected
+
+    def test_is_librarian_or_higher(self, monkeypatch):
+        user = models.User(MockSite(), "/people/test", data={})
+
+        monkeypatch.setattr(
+            models.User,
+            "usergroups",
+            PropertyMock(return_value=[_FakeGroup("/usergroup/librarians")]),
+        )
+        assert user.is_librarian_or_higher() is True
+
+        monkeypatch.setattr(
+            models.User,
+            "usergroups",
+            PropertyMock(return_value=[_FakeGroup("/usergroup/admin")]),
+        )
+        assert user.is_librarian_or_higher() is True
+
+        monkeypatch.setattr(
+            models.User,
+            "usergroups",
+            PropertyMock(return_value=[_FakeGroup("/usergroup/super-librarians")]),
+        )
+        assert user.is_librarian_or_higher() is True
+
+        monkeypatch.setattr(
+            models.User,
+            "usergroups",
+            PropertyMock(return_value=[]),
+        )
+        assert user.is_librarian_or_higher() is False
 
 
 class MockSite:

--- a/openlibrary/tests/fastapi/test_auth.py
+++ b/openlibrary/tests/fastapi/test_auth.py
@@ -144,9 +144,7 @@ def test_require_librarian_returns_403_for_regular_user():
 
     with patch("openlibrary.fastapi.auth.get_current_user") as mock_get_user:
         user = MagicMock()
-        user.is_admin.return_value = False
-        user.is_librarian.return_value = False
-        user.is_super_librarian.return_value = False
+        user.is_librarian_or_higher.return_value = False
         mock_get_user.return_value = user
 
         client = TestClient(app, raise_server_exceptions=False)
@@ -164,9 +162,7 @@ def test_require_librarian_allows_admin():
 
     with patch("openlibrary.fastapi.auth.get_current_user") as mock_get_user:
         user = MagicMock()
-        user.is_admin.return_value = True
-        user.is_librarian.return_value = False
-        user.is_super_librarian.return_value = False
+        user.is_librarian_or_higher.return_value = True
         mock_get_user.return_value = user
 
         client = TestClient(app, raise_server_exceptions=False)
@@ -184,9 +180,7 @@ def test_require_librarian_allows_librarian():
 
     with patch("openlibrary.fastapi.auth.get_current_user") as mock_get_user:
         user = MagicMock()
-        user.is_admin.return_value = False
-        user.is_librarian.return_value = True
-        user.is_super_librarian.return_value = False
+        user.is_librarian_or_higher.return_value = True
         mock_get_user.return_value = user
 
         client = TestClient(app, raise_server_exceptions=False)
@@ -204,9 +198,7 @@ def test_require_librarian_allows_super_librarian():
 
     with patch("openlibrary.fastapi.auth.get_current_user") as mock_get_user:
         user = MagicMock()
-        user.is_admin.return_value = False
-        user.is_librarian.return_value = False
-        user.is_super_librarian.return_value = True
+        user.is_librarian_or_higher.return_value = True
         mock_get_user.return_value = user
 
         client = TestClient(app, raise_server_exceptions=False)

--- a/openlibrary/tests/fastapi/test_importapi.py
+++ b/openlibrary/tests/fastapi/test_importapi.py
@@ -47,9 +47,7 @@ def mock_user_factory(monkeypatch):
         is_super_librarian: bool = False,
     ):
         user = MagicMock()
-        user.is_admin.return_value = is_admin
-        user.is_librarian.return_value = is_librarian
-        user.is_super_librarian.return_value = is_super_librarian
+        user.is_librarian_or_higher.return_value = is_admin or is_librarian or is_super_librarian
         monkeypatch.setattr("openlibrary.fastapi.auth.get_current_user", lambda: user)
         return user
 

--- a/openlibrary/tests/fastapi/test_merge_authors.py
+++ b/openlibrary/tests/fastapi/test_merge_authors.py
@@ -37,9 +37,7 @@ def mock_user_factory(monkeypatch):
         is_super_librarian: bool = False,
     ):
         user = MagicMock()
-        user.is_admin.return_value = is_admin
-        user.is_librarian.return_value = is_librarian
-        user.is_super_librarian.return_value = is_super_librarian
+        user.is_librarian_or_higher.return_value = is_admin or is_librarian or is_super_librarian
         monkeypatch.setattr(
             "openlibrary.fastapi.auth.get_current_user",
             lambda: user,

--- a/openlibrary/tests/test_templates.py
+++ b/openlibrary/tests/test_templates.py
@@ -56,6 +56,48 @@ def test_login_template_does_not_bind_password_value():
     assert "$form.password.value" not in template
 
 
+def test_no_role_trio_in_source():
+    """No source file should use all three of is_admin(), is_librarian(),
+    is_super_librarian() on the same line -- use is_librarian_or_higher() instead.
+    """
+    excluded = {"vendor", "node_modules", ".git", "__pycache__", "tests"}
+    source_roots = [
+        "openlibrary/plugins",
+        "openlibrary/templates",
+        "openlibrary/macros",
+        "openlibrary/core",
+        "openlibrary/fastapi",
+        "openlibrary/code.py",
+        "openlibrary/asgi_app.py",
+    ]
+
+    violations = {}
+    for root in source_roots:
+        if root.endswith(".py"):
+            files = [Path(root)]
+        else:
+            files = glob.glob(f"{root}/**/*", recursive=True)
+
+        for path in files:
+            p = Path(path)
+            if any(part in excluded for part in p.parts):
+                continue
+            if p.suffix not in (".py", ".html"):
+                continue
+            if not p.is_file():
+                continue
+
+            for i, line in enumerate(p.read_text(encoding="utf-8").splitlines(), 1):
+                if "is_librarian_or_higher" in line:
+                    continue
+                if "is_admin" in line and "is_librarian" in line and "is_super_librarian" in line:
+                    violations[f"{p}:{i}"] = line.strip()
+
+    assert not violations, "Found lines using all three role checks. Use is_librarian_or_higher() instead:\n" + "\n".join(
+        f"  {k}: {v}" for k, v in sorted(violations.items())
+    )
+
+
 def test_all_jinja_templates_compile(subtests):
     """Every ``.html.jinja`` template in the project should compile.
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Part of #12946 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR removes the redundant `merge-authors` feature flag and replaces it with direct role checks.


### Technical
<!-- What should be noted about the implementation? -->

- Removed `merge-authors` from `conf/openlibrary.yml`.
- Replaced `"merge-authors" in ctx.features` checks with direct user role checks (`is_librarian()`, `is_admin()`, or `is_super_librarian()`) in `openlibrary/plugins/upstream/merge_authors.py`.
- Updated `search/authors.html` and `type/author/view.html` templates to use the same user role logic instead of checking `ctx.features`.
- 
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
`docker compose run --rm home pytest openlibrary/plugins/upstream/tests/test_merge_authors.py openlibrary/tests/fastapi/test_merge_authors.py -v`

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
