### PR TITLE
Migrate monthly logins to FastAPI

### DIFF
--- a/openlibrary/core/admin.py
+++ b/openlibrary/core/admin.py
@@ -166,6 +166,7 @@ def get_stats(ndays=30, use_mock_data=False):
     }
 
 
+@cache.memoize(engine="memcache", key="logins_since", expires=12 * 60 * 60)
 def get_unique_logins_since(since_days=30):
     since_date = datetime.now() - timedelta(days=since_days)
     date_str = since_date.strftime("%Y-%m-%d")
@@ -183,20 +184,6 @@ def get_unique_logins_since(since_days=30):
     if not results:
         return 0
     return results[0].get("count", 0)
-
-
-def get_cached_unique_logins_since(since_days=30):
-    from openlibrary.plugins.openlibrary.home import caching_prethread
-
-    twelve_hours = 60 * 60 * 12
-    key_prefix = "logins_since"
-    mc = cache.memcache_memoize(
-        get_unique_logins_since,
-        key_prefix=key_prefix,
-        timeout=twelve_hours,
-        prethread=caching_prethread(),
-    )
-    return mc(since_days=since_days)
 
 
 def mock_get_stats():

--- a/openlibrary/fastapi/internal/api.py
+++ b/openlibrary/fastapi/internal/api.py
@@ -13,12 +13,14 @@ from datetime import datetime
 from typing import Annotated, Any, Literal
 from urllib.parse import urlencode
 
-from fastapi import APIRouter, Depends, Form, HTTPException, Path, Query, status
+import web
+from fastapi import APIRouter, Depends, Form, HTTPException, Path, Query, Request, status
 from pydantic import BaseModel, BeforeValidator, Field
 from starlette.responses import RedirectResponse
 
 from openlibrary import accounts
 from openlibrary.core import lending, models
+from openlibrary.core.admin import get_cached_unique_logins_since
 from openlibrary.core.bestbook import Bestbook
 from openlibrary.core.follows import PubSub
 from openlibrary.core.models import Booknotes
@@ -448,5 +450,14 @@ async def unlink_ia_ol():
     pass
 
 
-async def monthly_logins():
-    pass
+class MonthlyLoginsResponse(BaseModel):
+    """Response model for the /api/monthly_logins.json endpoint."""
+
+    loginCount: int
+
+
+@router.get("/api/monthly_logins.json", response_model=MonthlyLoginsResponse)
+def monthly_logins(request: Request) -> MonthlyLoginsResponse:
+    """Return the cached unique monthly login count for the admin stats UI."""
+    web.ctx.host = request.url.netloc
+    return MonthlyLoginsResponse(loginCount=get_cached_unique_logins_since())

--- a/openlibrary/fastapi/internal/api.py
+++ b/openlibrary/fastapi/internal/api.py
@@ -13,14 +13,13 @@ from datetime import datetime
 from typing import Annotated, Any, Literal
 from urllib.parse import urlencode
 
-import web
-from fastapi import APIRouter, Depends, Form, HTTPException, Path, Query, Request, status
+from fastapi import APIRouter, Depends, Form, HTTPException, Path, Query, status
 from pydantic import BaseModel, BeforeValidator, Field
 from starlette.responses import RedirectResponse
 
 from openlibrary import accounts
 from openlibrary.core import lending, models
-from openlibrary.core.admin import get_cached_unique_logins_since
+from openlibrary.core.admin import get_unique_logins_since
 from openlibrary.core.bestbook import Bestbook
 from openlibrary.core.follows import PubSub
 from openlibrary.core.models import Booknotes
@@ -457,7 +456,6 @@ class MonthlyLoginsResponse(BaseModel):
 
 
 @router.get("/api/monthly_logins.json", response_model=MonthlyLoginsResponse)
-def monthly_logins(request: Request) -> MonthlyLoginsResponse:
+def monthly_logins() -> MonthlyLoginsResponse:
     """Return the cached unique monthly login count for the admin stats UI."""
-    web.ctx.host = request.url.netloc
-    return MonthlyLoginsResponse(loginCount=get_cached_unique_logins_since())
+    return MonthlyLoginsResponse(loginCount=get_unique_logins_since())

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -27,7 +27,7 @@ from openlibrary.accounts.model import (
 )
 from openlibrary.core import cache
 from openlibrary.core import helpers as h
-from openlibrary.core.admin import get_cached_unique_logins_since
+from openlibrary.core.admin import get_unique_logins_since
 from openlibrary.core.auth import ExpiredTokenError, HMACToken
 from openlibrary.core.bestbook import Bestbook
 from openlibrary.core.follows import PubSub
@@ -960,6 +960,6 @@ class monthly_logins(delegate.page):
 
     def GET(self):
         return delegate.RawText(
-            json.dumps({"loginCount": get_cached_unique_logins_since()}),
+            json.dumps({"loginCount": get_unique_logins_since()}),
             content_type="application/json",
         )

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -953,6 +953,7 @@ class link_ia_ol(delegate.page):
             web.ctx.site.save(data, "Associate OCAID with record", action="edit-edition-ocaid")
 
 
+@deprecated("migrated to fastapi")
 class monthly_logins(delegate.page):
     path = "/api/monthly_logins"
     encoding = "json"

--- a/openlibrary/tests/fastapi/test_monthly_logins.py
+++ b/openlibrary/tests/fastapi/test_monthly_logins.py
@@ -4,13 +4,12 @@ import json
 from unittest.mock import patch
 
 import pytest
-import web
 
 from openlibrary.plugins.openlibrary.api import monthly_logins as legacy_monthly_logins
 
 
 def test_monthly_logins_returns_cached_count(fastapi_client):
-    with patch("openlibrary.fastapi.internal.api.get_cached_unique_logins_since", return_value=12345) as get_logins_mock:
+    with patch("openlibrary.fastapi.internal.api.get_unique_logins_since", return_value=12345) as get_logins_mock:
         response = fastapi_client.get("/api/monthly_logins.json")
 
     assert response.status_code == 200
@@ -20,8 +19,8 @@ def test_monthly_logins_returns_cached_count(fastapi_client):
 
 def test_monthly_logins_response_matches_legacy(fastapi_client):
     with (
-        patch("openlibrary.plugins.openlibrary.api.get_cached_unique_logins_since", return_value=12345) as legacy_get_logins_mock,
-        patch("openlibrary.fastapi.internal.api.get_cached_unique_logins_since", return_value=12345) as fastapi_get_logins_mock,
+        patch("openlibrary.plugins.openlibrary.api.get_unique_logins_since", return_value=12345) as legacy_get_logins_mock,
+        patch("openlibrary.fastapi.internal.api.get_unique_logins_since", return_value=12345) as fastapi_get_logins_mock,
         pytest.deprecated_call(match="migrated to fastapi"),
     ):
         legacy_response = json.loads(legacy_monthly_logins().GET()["rawtext"])
@@ -31,26 +30,3 @@ def test_monthly_logins_response_matches_legacy(fastapi_client):
     assert fastapi_response.json() == legacy_response
     legacy_get_logins_mock.assert_called_once_with()
     fastapi_get_logins_mock.assert_called_once_with()
-
-
-def test_monthly_logins_sets_web_ctx_host_for_cached_helper(fastapi_client, request_context_fixture, monkeypatch):
-    request_context_fixture(lang="en")
-    captured_hosts = []
-
-    def memcache_memoize_mock(func, key_prefix, timeout=None, prethread=None):
-        captured_hosts.append(web.ctx.host)
-        assert prethread is not None
-
-        def get_count(since_days=30):
-            assert since_days == 30
-            return 12345
-
-        return get_count
-
-    monkeypatch.setattr("openlibrary.core.admin.cache.memcache_memoize", memcache_memoize_mock)
-
-    response = fastapi_client.get("/api/monthly_logins.json")
-
-    assert response.status_code == 200
-    assert response.json() == {"loginCount": 12345}
-    assert captured_hosts == ["testserver"]

--- a/openlibrary/tests/fastapi/test_monthly_logins.py
+++ b/openlibrary/tests/fastapi/test_monthly_logins.py
@@ -7,21 +7,6 @@ import pytest
 import web
 
 from openlibrary.plugins.openlibrary.api import monthly_logins as legacy_monthly_logins
-from openlibrary.utils.request_context import RequestContextVars, req_context
-
-
-@pytest.fixture(autouse=True)
-def _setup_request_context():
-    """Set ContextVars for the legacy cached helper used by monthly_logins."""
-    req_context.set(
-        RequestContextVars(
-            x_forwarded_for=None,
-            user_agent=None,
-            lang="en",
-            solr_editions=True,
-            print_disabled=False,
-        )
-    )
 
 
 def test_monthly_logins_returns_cached_count(fastapi_client):
@@ -48,7 +33,8 @@ def test_monthly_logins_response_matches_legacy(fastapi_client):
     fastapi_get_logins_mock.assert_called_once_with()
 
 
-def test_monthly_logins_sets_web_ctx_host_for_cached_helper(fastapi_client, monkeypatch):
+def test_monthly_logins_sets_web_ctx_host_for_cached_helper(fastapi_client, request_context_fixture, monkeypatch):
+    request_context_fixture(lang="en")
     captured_hosts = []
 
     def memcache_memoize_mock(func, key_prefix, timeout=None, prethread=None):

--- a/openlibrary/tests/fastapi/test_monthly_logins.py
+++ b/openlibrary/tests/fastapi/test_monthly_logins.py
@@ -1,0 +1,70 @@
+"""Tests for the FastAPI monthly logins endpoint."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+import web
+
+from openlibrary.plugins.openlibrary.api import monthly_logins as legacy_monthly_logins
+from openlibrary.utils.request_context import RequestContextVars, req_context
+
+
+@pytest.fixture(autouse=True)
+def _setup_request_context():
+    """Set ContextVars for the legacy cached helper used by monthly_logins."""
+    req_context.set(
+        RequestContextVars(
+            x_forwarded_for=None,
+            user_agent=None,
+            lang="en",
+            solr_editions=True,
+            print_disabled=False,
+        )
+    )
+
+
+def test_monthly_logins_returns_cached_count(fastapi_client):
+    with patch("openlibrary.fastapi.internal.api.get_cached_unique_logins_since", return_value=12345) as get_logins_mock:
+        response = fastapi_client.get("/api/monthly_logins.json")
+
+    assert response.status_code == 200
+    assert response.json() == {"loginCount": 12345}
+    get_logins_mock.assert_called_once_with()
+
+
+def test_monthly_logins_response_matches_legacy(fastapi_client):
+    with (
+        patch("openlibrary.plugins.openlibrary.api.get_cached_unique_logins_since", return_value=12345) as legacy_get_logins_mock,
+        patch("openlibrary.fastapi.internal.api.get_cached_unique_logins_since", return_value=12345) as fastapi_get_logins_mock,
+        pytest.deprecated_call(match="migrated to fastapi"),
+    ):
+        legacy_response = json.loads(legacy_monthly_logins().GET()["rawtext"])
+        fastapi_response = fastapi_client.get("/api/monthly_logins.json")
+
+    assert fastapi_response.status_code == 200
+    assert fastapi_response.json() == legacy_response
+    legacy_get_logins_mock.assert_called_once_with()
+    fastapi_get_logins_mock.assert_called_once_with()
+
+
+def test_monthly_logins_sets_web_ctx_host_for_cached_helper(fastapi_client, monkeypatch):
+    captured_hosts = []
+
+    def memcache_memoize_mock(func, key_prefix, timeout=None, prethread=None):
+        captured_hosts.append(web.ctx.host)
+        assert prethread is not None
+
+        def get_count(since_days=30):
+            assert since_days == 30
+            return 12345
+
+        return get_count
+
+    monkeypatch.setattr("openlibrary.core.admin.cache.memcache_memoize", memcache_memoize_mock)
+
+    response = fastapi_client.get("/api/monthly_logins.json")
+
+    assert response.status_code == 200
+    assert response.json() == {"loginCount": 12345}
+    assert captured_hosts == ["testserver"]


### PR DESCRIPTION
## Summary

Migrates the monthly logins route from legacy web.py routing to FastAPI while preserving the existing admin stats JSON response shape.

Migrated endpoint:

- GET /api/monthly_logins.json

### Stakeholders
@RayBB