### PR TITLE
fix(catalog): remove internal metadata keys before saving matched aut…

### DIFF
--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -322,8 +322,8 @@ def author_import_record_to_author(author_import_record_dict: dict, eastern=Fals
     if existing := find_entity(author_import_record):
         assert existing.type.key == "/type/author"
         for k in "last_modified", "id", "revision", "created":
-            if existing.k:
-                del existing.k
+            if k in existing:
+                del existing[k]
         new = existing
         if "death_date" in author_import_record and "death_date" not in existing:
             new["death_date"] = author_import_record["death_date"]


### PR DESCRIPTION


<!-- What issue does this PR close? -->
Closes #13016

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
Fixed a bug in catalog/add_book/load_book.py where the cleanup loop incorrectly accessed a literal attribute (existing.k) instead of using the loop variable as a dictionary key. The implementation now correctly removes the internal metadata keys (last_modified, id, revision, and created) from matched author records before they are passed to save_many().
### Testing
1. Verified that the cleanup loop removes the metadata keys when they are present in existing.
2. Verified that no error is raised when one or more of the keys are absent.
3. Confirmed that the rest of the author resolution flow remains unchanged.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
