### PR TITLE
chore(tests): replace deprecated BeautifulSoup findAll with find_all

### DIFF
--- a/openlibrary/plugins/openlibrary/tests/test_home.py
+++ b/openlibrary/plugins/openlibrary/tests/test_home.py
@@ -51,7 +51,7 @@ class TestHomeTemplates:
 
         blog = BeautifulSoup(html, "lxml").find("ul", {"id": "olBlog"})
         assert blog is not None
-        assert len(blog.findAll("li")) == 0
+        assert len(blog.find_all("li")) == 0
 
         posts = [
             web.storage(
@@ -69,7 +69,7 @@ class TestHomeTemplates:
 
         blog = BeautifulSoup(html, "lxml").find("ul", {"id": "olBlog"})
         assert blog is not None
-        assert len(blog.findAll("li")) == 1
+        assert len(blog.find_all("li")) == 1
 
     def test_stats_template(self, render_template):
         # Make sure that it works fine without any input (skipping section)


### PR DESCRIPTION
Switches from the deprecated  method to  in the home template tests, eliminating BeautifulSoup  noise in test output.