### PR TITLE
feat(search): author suggestion row above /search results

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -756,10 +756,10 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: books/add.html books/edit.html books/edit/edition.html
-#: openlibrary/plugins/worksearch/code.py search/advancedsearch.html
-#: search/search_modal_i18n.html search/work_search_selected_facets.html
-#: status.html
+#: SearchAuthorSuggestion.html books/add.html books/edit.html
+#: books/edit/edition.html openlibrary/plugins/worksearch/code.py
+#: search/advancedsearch.html search/search_modal_i18n.html
+#: search/work_search_selected_facets.html status.html
 msgid "Author"
 msgstr ""
 
@@ -1079,6 +1079,14 @@ msgstr ""
 msgid "Filter by language"
 msgstr ""
 
+#: account/reading_log.html search/authors.html search/lists.html
+#: search/subjects.html work_search.html
+#, python-format
+msgid "%(count)s hit"
+msgid_plural "%(count)s hits"
+msgstr[0] ""
+msgstr[1] ""
+
 #: work_search.html
 msgid "The search engine returned an error."
 msgstr ""
@@ -1104,13 +1112,15 @@ msgstr ""
 msgid "Checking Search Inside matches"
 msgstr ""
 
-#: account/reading_log.html search/authors.html search/lists.html
-#: search/subjects.html work_search.html
-#, python-format
-msgid "%(count)s hit"
-msgid_plural "%(count)s hits"
-msgstr[0] ""
-msgstr[1] ""
+#: SearchNavigation.html authors/index.html lib/nav_foot.html
+#: merge/authors.html publishers/view.html work_search.html
+msgid "Authors"
+msgstr ""
+
+#: SearchNavigation.html books/mybooks_breadcrumb_select.html lib/nav_foot.html
+#: openlibrary/plugins/upstream/mybooks.py work_search.html
+msgid "Books"
+msgstr ""
 
 #: work_search.html
 #, python-format
@@ -3099,11 +3109,6 @@ msgstr ""
 msgid "None found"
 msgstr ""
 
-#: SearchNavigation.html authors/index.html lib/nav_foot.html
-#: merge/authors.html publishers/view.html
-msgid "Authors"
-msgstr ""
-
 #: authors/index.html
 msgid "Search for an Author"
 msgstr ""
@@ -3814,11 +3819,6 @@ msgstr ""
 #: books/edition-sort.html type/work/editions.html
 #, python-format
 msgid "in %(languagelist)s"
-msgstr ""
-
-#: SearchNavigation.html books/mybooks_breadcrumb_select.html lib/nav_foot.html
-#: openlibrary/plugins/upstream/mybooks.py
-msgid "Books"
 msgstr ""
 
 #. Page title for the "Want to Read" shelf page.

--- a/openlibrary/macros/SearchAuthorSuggestion.html
+++ b/openlibrary/macros/SearchAuthorSuggestion.html
@@ -1,0 +1,27 @@
+$def with (authors)
+
+$# An "I want that author" row shown above the book results when the query names
+$# the author of one of the top works (see worksearch/author_suggestion.py).
+$# Mirrors the author result markup in templates/search/authors.html and the
+$# header search modal (SearchModal.js _renderAuthorSuggestion), which must be
+$# kept in sync.
+<ul class="authorList search-author-suggestion">
+  $for author in authors:
+    $ olid = author['key']
+    $ name = author['name']
+    $ url = '/authors/%s/%s' % (olid, urlsafe(name))
+    <li class="searchResultItem">
+      $# A person-icon placeholder sits behind the photo. The photo is requested
+      $# with ?default=false so a missing photo 404s (rather than returning
+      $# coverstore's blank 1x1 default); index.js then hides the broken <img>,
+      $# revealing the placeholder — mirroring the modal's _onAvatarError.
+      <span class="sas-avatar">
+        <svg class="sas-avatar__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+        <img class="sas-avatar__photo" src="$get_coverstore_public_url()/a/olid/$(olid)-M.jpg?default=false" alt="" loading="lazy">
+      </span>
+      <div class="details">
+        <a href="$url" class="larger">$name</a><br />
+        <span class="small grey">$_("Author")</span>
+      </div>
+    </li>
+</ul>

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -345,6 +345,17 @@ jQuery(function() {
             .then((module) => module.initSearchFilterBar(searchFilterBar));
     }
 
+    // Author-suggestion avatars request photos with ?default=false, so a missing
+    // photo 404s; hide the broken <img> to reveal the placeholder icon behind it
+    // (mirrors the header search modal's _onAvatarError).
+    for (const img of document.querySelectorAll('.search-author-suggestion .sas-avatar__photo')) {
+        if (img.complete && img.naturalWidth === 0) {
+            img.hidden = true;
+        } else {
+            img.addEventListener('error', () => { img.hidden = true; }, { once: true });
+        }
+    }
+
     // Conditionally load Integrated Librarian Environment
     if (document.getElementsByClassName('show-librarian-tools').length) {
         import(/* webpackChunkName: "ile" */ './ile')

--- a/openlibrary/plugins/openlibrary/js/list_books.js
+++ b/openlibrary/plugins/openlibrary/js/list_books.js
@@ -28,7 +28,9 @@ export class ListBooks {
     }
 
     static init() {
-        // Assume only one list-books/layout per page
+        // Assume only one list-books/layout per page. The author-suggestion row
+        // is deliberately not a `.list-books` (it's not books), so this only
+        // ever matches the work results list.
         new ListBooks(
             document.querySelector('.list-books'),
             document.querySelector('.tools--layout'),

--- a/openlibrary/plugins/worksearch/author_suggestion.py
+++ b/openlibrary/plugins/worksearch/author_suggestion.py
@@ -1,0 +1,82 @@
+"""Author suggestions ("B-zero") for the work search results page.
+
+No extra request: when the query names the author of one of the top works the
+Solr search already returned, we surface a row linking straight to that author's
+page. This covers the common "type a name -> I want that author" case (the old
+Author facet) without a second Solr round-trip.
+
+Matching the query against each top result's author is self-protecting: a title
+search ("dune") returns that author's works, but the title isn't part of their
+name, so nothing is surfaced. Only queries that actually name an author produce
+a row.
+
+This is a Python port of the header search modal's
+``openlibrary/plugins/openlibrary/js/search-modal/authorSuggestion.js``; the two
+implement the same matching rules and must be kept in sync.
+"""
+
+import unicodedata
+
+# Only the top few results are relevant enough to surface their author.
+AUTHOR_SCAN_LIMIT = 5
+
+# At most this many author rows, so an ambiguous one-word query ("smith") can't
+# flood the list.
+AUTHOR_SUGGESTION_MAX = 3
+
+
+def _fold(s: str) -> str:
+    """Lowercase and strip diacritics so "garcia" matches "García"."""
+    normalized = unicodedata.normalize("NFD", s or "")
+    return "".join(c for c in normalized if not unicodedata.combining(c)).lower()
+
+
+def query_matches_name(query: str, name: str) -> bool:
+    """True when the query names the author.
+
+    Matches on word boundaries only, so a query can't match mid-word ("art" must
+    not surface "Bart ..."):
+     - the full name starts with the query ("leo tol" -> "Leo Tolstoy"),
+     - the query contains the full name as whole words ("books by leo tolstoy"),
+     - or a query word is a prefix of a name word, 3+ chars to skip
+       initials/particles like "de" ("asimov"/"asim" -> "Isaac Asimov").
+    """
+    q = _fold(query).strip()
+    full = _fold(name).strip()
+    if not q or not full:
+        return False
+    if full.startswith(q):
+        return True
+    if f" {full} " in f" {q} ":
+        return True
+    name_tokens = full.split()
+    return any(len(token) >= 3 and any(nt.startswith(token) for nt in name_tokens) for token in q.split())
+
+
+def derive_authors(docs, query: str) -> list[dict[str, str]]:
+    """Return the authors to suggest for the given query.
+
+    Given the work docs from the Solr response and the query, return the authors
+    of the top results whose name the query matches, in rank order, deduped by
+    key and capped. Empty when the query names none of them.
+
+    Each returned author is ``{"key": <OLxxxA>, "name": <author name>}``.
+    """
+    if not docs:
+        return []
+
+    seen: set[str] = set()
+    authors: list[dict[str, str]] = []
+    for doc in docs[:AUTHOR_SCAN_LIMIT]:
+        author_key = doc.get("author_key") or []
+        author_name = doc.get("author_name") or []
+        key = author_key[0] if author_key else None
+        name = author_name[0] if author_name else None
+        if not key or not name or key in seen:
+            continue
+        if query_matches_name(query, name):
+            seen.add(key)
+            authors.append({"key": key, "name": name})
+            if len(authors) >= AUTHOR_SUGGESTION_MAX:
+                break
+    return authors

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -30,6 +30,7 @@ from openlibrary.plugins.upstream.utils import (
     safeget,
     urlencode,
 )
+from openlibrary.plugins.worksearch.author_suggestion import derive_authors
 from openlibrary.plugins.worksearch.schemes.authors import AuthorSearchScheme
 from openlibrary.plugins.worksearch.schemes.editions import EditionSearchScheme
 from openlibrary.plugins.worksearch.schemes.lists import ListSearchScheme
@@ -873,14 +874,21 @@ class search(delegate.page):
 
         readable_count = _get_readable_count(param, search_response)
 
+        # Surface an author row above the results when the query names the author
+        # of one of the top works (see author_suggestion.derive_authors). No extra
+        # Solr round-trip: it reuses the docs this same search already returned.
+        q_joined = " ".join(q_list)
+        author_suggestions = derive_authors(search_response.docs, q_joined)
+
         return render.work_search(
-            " ".join(q_list),
+            q_joined,
             search_response,
             get_doc,
             param,
             page,
             rows,
             readable_count,
+            author_suggestions,
             has_solr_editions_enabled=req_context.get().solr_editions,
         )
 

--- a/openlibrary/plugins/worksearch/tests/test_author_suggestion.py
+++ b/openlibrary/plugins/worksearch/tests/test_author_suggestion.py
@@ -1,0 +1,108 @@
+"""Mirror of tests/unit/js/searchModalAuthor.test.js.
+
+The Python port (worksearch/author_suggestion.py) and the JS source
+(search-modal/authorSuggestion.js) implement the same matching rules, so these
+cases are kept in lockstep with the JS test to lock parity.
+"""
+
+from openlibrary.plugins.worksearch.author_suggestion import (
+    AUTHOR_SUGGESTION_MAX,
+    derive_authors,
+    query_matches_name,
+)
+
+
+def work(key, author_name=None, author_key=None):
+    """Build a Solr-style work doc with a single primary author."""
+    doc = {"key": key, "title": f"Work {key}"}
+    if author_name:
+        doc["author_name"] = [author_name]
+    if author_key:
+        doc["author_key"] = [author_key]
+    return doc
+
+
+class TestQueryMatchesName:
+    def test_matches_a_surname_substring_of_the_full_name(self):
+        assert query_matches_name("asimov", "Isaac Asimov") is True
+
+    def test_matches_the_full_name_typed_out(self):
+        assert query_matches_name("octavia butler", "Octavia E. Butler") is True
+
+    def test_matches_on_a_shared_whole_word(self):
+        assert query_matches_name("le guin", "Ursula K. Le Guin") is True
+
+    def test_matches_a_query_that_is_a_prefix_of_a_name_word(self):
+        assert query_matches_name("asim", "Isaac Asimov") is True
+        assert query_matches_name("leo tol", "Leo Tolstoy") is True
+
+    def test_does_not_match_a_query_mid_word_inside_a_name_token(self):
+        assert query_matches_name("art", "Bart Giamatti") is False
+
+    def test_does_not_match_a_title_that_skews_to_one_author(self):
+        assert query_matches_name("dune", "Frank Herbert") is False
+        assert query_matches_name("the great gatsby", "F. Scott Fitzgerald") is False
+
+    def test_ignores_short_shared_tokens_like_particles_initials(self):
+        assert query_matches_name("the de la", "Walter de la Mare") is False
+
+    def test_folds_diacritics(self):
+        assert query_matches_name("gabriel garcia marquez", "Gabriel García Márquez") is True
+
+    def test_is_empty_safe(self):
+        assert query_matches_name("", "Isaac Asimov") is False
+        assert query_matches_name("asimov", "") is False
+        assert query_matches_name("", "") is False
+
+
+class TestDeriveAuthors:
+    def test_surfaces_a_named_author_even_with_a_single_book(self):
+        docs = [
+            work("/works/OL1W", "Octavia E. Butler", "OL11A"),
+            work("/works/OL2W", "Someone Else", "OL22A"),
+        ]
+        assert derive_authors(docs, "octavia butler") == [{"key": "OL11A", "name": "Octavia E. Butler"}]
+
+    def test_surfaces_multiple_distinct_authors_for_an_ambiguous_given_name(self):
+        docs = [
+            work("/works/OL1W", "Stephen King", "OL19A"),
+            work("/works/OL2W", "Stephen Hawking", "OL20A"),
+            work("/works/OL3W", "Stephen King", "OL19A"),  # dupe key -> collapsed
+        ]
+        assert derive_authors(docs, "stephen") == [
+            {"key": "OL19A", "name": "Stephen King"},
+            {"key": "OL20A", "name": "Stephen Hawking"},
+        ]
+
+    def test_dedupes_a_prolific_author_to_a_single_row(self):
+        docs = [work(f"/works/OL{i}W", "Isaac Asimov", "OL34221A") for i in range(4)]
+        assert derive_authors(docs, "asimov") == [{"key": "OL34221A", "name": "Isaac Asimov"}]
+
+    def test_caps_the_number_of_author_rows(self):
+        docs = [
+            work("/works/OL1W", "John Smith", "OL1A"),
+            work("/works/OL2W", "Jane Smith", "OL2A"),
+            work("/works/OL3W", "Adam Smith", "OL3A"),
+            work("/works/OL4W", "Zadie Smith", "OL4A"),
+        ]
+        assert len(derive_authors(docs, "smith")) == AUTHOR_SUGGESTION_MAX
+
+    def test_only_scans_the_top_results_not_the_whole_page(self):
+        # Asimov is the 6th result -- past the scan window -- so no row.
+        docs = [
+            *(work(f"/works/OL{i}W", "Filler Writer", f"OL9{i}A") for i in range(5)),
+            work("/works/OLaW", "Isaac Asimov", "OL34221A"),
+        ]
+        assert derive_authors(docs, "asimov") == []
+
+    def test_returns_nothing_for_a_title_search(self):
+        docs = [work(f"/works/OL{i}W", "Frank Herbert", "OL79034A") for i in range(5)]
+        assert derive_authors(docs, "dune") == []
+
+    def test_ignores_docs_missing_an_author_key(self):
+        docs = [work("/works/OL1W", "Isaac Asimov", None)]
+        assert derive_authors(docs, "asimov") == []
+
+    def test_is_empty_safe(self):
+        assert derive_authors([], "asimov") == []
+        assert derive_authors(None, "asimov") == []

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -1,4 +1,4 @@
-$def with (q_param, search_response, get_doc, param, page, rows, readable_count, has_solr_editions_enabled)
+$def with (q_param, search_response, get_doc, param, page, rows, readable_count, author_suggestions, has_solr_editions_enabled)
 
 $ layout = get_remembered_layout()
 $ bodyclass = ctx.setdefault('bodyclass', [])
@@ -15,7 +15,7 @@ $ bodyclass.append('search-page')
     $:render_template("librarian_dashboard/data_quality_table", search_response.num_found)
 
   $:macros.SearchNavigation()
-  <div class="section">
+  <div class="search-controls">
 
     <form method="get" action="/search" class="siteSearch search-row olform">
       <label for="q" class="hidden">$_('Keywords')</label>
@@ -71,6 +71,17 @@ $ bodyclass.append('search-page')
         <span class="selected-search-facets-container">
             $:render_template('search/work_search_selected_facets', param, search_response, q_param, query=param)
         </span>
+
+        $if param and not search_response.error and len(search_response.docs):
+          <div class="search-results-stats">
+            $ungettext('%(count)s hit', '%(count)s hits', search_response.num_found, count=commify(search_response.num_found))
+
+            $if search_response.num_found > 1:
+              $:render_template("search/sort_options.html", search_response.sort)
+
+            $if search_response.num_found > 0:
+              $:render_template("search/layout_options.html", selected_layout=layout)
+          </div>
     </div>
 
 
@@ -107,17 +118,16 @@ $ bodyclass.append('search-page')
         </div>
 
     $elif param and not search_response.error and len(search_response.docs):
-        <div class="search-results-stats">
-          $ungettext('%(count)s hit', '%(count)s hits', search_response.num_found, count=commify(search_response.num_found))
-
-          $if search_response.num_found > 1:
-            $:render_template("search/sort_options.html", search_response.sort)
-
-          $if search_response.num_found > 0:
-            $:render_template("search/layout_options.html", selected_layout=layout)
-        </div>
         <div class="resultsContainer search-results-container">
         <div id="searchResults">
+          $# When the query names an author, label the two result groups so the
+          $# author row and the work list read as distinct sections. Skip the
+          $# labels entirely when there are no author suggestions to keep the
+          $# common case (just books) unchanged.
+          $if author_suggestions:
+            <h2 class="search-results-section-label">$_("Authors")</h2>
+            $:macros.SearchAuthorSuggestion(author_suggestions)
+            <h2 class="search-results-section-label">$_("Books")</h2>
           <ul class="list-books $cond(layout == 'grid', 'list-books--grid')">
             $ works = [get_doc(d) for d in search_response.docs]
             $ add_availability([(w.get('editions') or [None])[0] or w for w in works])

--- a/static/css/legacy.css
+++ b/static/css/legacy.css
@@ -843,7 +843,7 @@ div#searchResults .list-books {
   min-width: 0;
   flex: 1;
   margin-left: 0;
-  margin-bottom: var(--spacing-stack-sm);
+  margin-bottom: var(--spacing-stack-md);
 }
 
 /* openlibrary/templates/books/check.html */
@@ -909,6 +909,69 @@ div#searchResults .SRPCoverBlank a {
 .authorList .cover {
   max-width: 120px;
   border-radius: 4px;
+}
+
+/* Section labels ("Authors"/"Books") shown above the work search result */
+/* groups when the query names an author. */
+/* openlibrary/templates/work_search.html */
+.search-results-section-label {
+  margin-top: 0;
+  margin-bottom: var(--spacing-stack-xs);
+  font-size: 0.75em;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--accessible-grey);
+}
+
+/* Author suggestion row shown above work search results. */
+/* openlibrary/macros/SearchAuthorSuggestion.html */
+.search-author-suggestion {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: var(--spacing-stack-sm);
+  margin-top: 0;
+  margin-bottom: var(--spacing-stack-lg);
+}
+
+.search-author-suggestion li {
+  margin-bottom: 0;
+  max-width: none;
+  gap: var(--spacing-inline-lg);
+  /* Keep the avatar to the left of the name on mobile too; the shared */
+  /* .searchResultItem stacks (flex-direction: column) below the tablet */
+  /* breakpoint, which would center the avatar on top. */
+  flex-direction: row;
+}
+
+/* Avatar: a person-icon placeholder layered behind the author photo. The photo */
+/* covers it when it loads; a missing photo (?default=false 404) is hidden by */
+/* index.js, revealing the icon. Mirrors the modal's .result__avatar. */
+.search-author-suggestion .sas-avatar {
+  position: relative;
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  overflow: hidden;
+  color: var(--accessible-grey);
+  background: var(--lightest-grey);
+  border-radius: var(--border-radius-avatar);
+}
+
+.search-author-suggestion .sas-avatar__icon {
+  width: 26px;
+  height: 26px;
+}
+
+.search-author-suggestion .sas-avatar__photo {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 /* openlibrary/templates/languages/index.html */

--- a/static/css/page-user.css
+++ b/static/css/page-user.css
@@ -67,13 +67,37 @@ div.siteSearch.darker {
   background-color: var(--grey-f3f3f3);
   padding-right: 22px;
 }
-/* Availability + language filter popovers below the search input. */
+/* Stack the search box, filter row, selected-facet chips, and results stats */
+/* with a single gap; the rows carry no vertical margins of their own. */
+.search-controls {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-stack-sm);
+  margin-bottom: var(--spacing-stack-md);
+}
+
+/* The chips container renders empty (whitespace, then an empty async wrapper) */
+/* when no facets are selected; drop it so it doesn't claim a gap slot. */
+.search-controls
+  .selected-search-facets-container:not(:has(.selected-search-facets)) {
+  display: none;
+}
+
+/* Spacing between the rows is owned by the parent's gap. */
+.search-controls > form {
+  margin-bottom: 0;
+}
+
+.search-controls .search-results-stats {
+  padding-bottom: 0;
+}
+
 .search-filter-row {
   display: flex;
   flex-wrap: wrap;
   gap: var(--spacing-sm);
   align-items: center;
-  margin: var(--spacing-md) 0;
+  margin: 0;
 }
 
 /* On the search page, enlarge the in-page search box to match the header


### PR DESCRIPTION
Part of #12913 — fast-follow refinements after #12797.

Surfaces an author suggestion above the results on the `/search` page,
mirroring the search modal's "B-zero" author row. When the query names the
author of one of the top works the search already returned, an author row
(linking straight to the author's page) appears above the book results —
covering the "type a name → I want that author" case.

<img width="811" height="570" alt="image" src="https://github.com/user-attachments/assets/33369476-5aa5-4068-98aa-890a6e39c8da" />

(ignore broken cover images, local env problem)

<img width="724" height="586" alt="image" src="https://github.com/user-attachments/assets/cc0facc4-a341-4b53-8470-5b405573ec4c" />


### Technical
- No extra Solr round-trip: it reuses the docs the search already returned.
- The modal's matching rules (`deriveAuthors` / `queryMatchesName`) are ported
  to Python (`worksearch/author_suggestion.py`) and unit-tested; the two
  implementations must be kept in sync.

### Testing
1. Go to `/search?q=tolkien` (or any author name).
2. An **Authors** section with the matching author appears above the **Books** results.
3. Try a title-only query like `/search?q=dune` — no author row appears.

### Screenshot
<!-- TODO: add before/after screenshot -->

### Stakeholders
@mekarpeles @cdrini cc: @RayBB @tfmorris 
