### PR TITLE
Redirect DAISY pages to Archive item pages

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -9,12 +9,12 @@ import urllib.parse
 from typing import TYPE_CHECKING, Literal, NoReturn, overload
 
 import web
+
 from infogami import config
 from infogami.core.db import ValidationException
 from infogami.infobase.client import ClientException
 from infogami.utils import delegate
 from infogami.utils.view import add_flash_message, safeint
-
 from openlibrary import accounts
 from openlibrary.core.helpers import uniq
 from openlibrary.i18n import gettext as _  # noqa: F401 side effects may be needed

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -5,16 +5,16 @@ import datetime
 import io
 import logging
 import re
-import urllib
+import urllib.parse
 from typing import TYPE_CHECKING, Literal, NoReturn, overload
 
 import web
-
 from infogami import config
 from infogami.core.db import ValidationException
 from infogami.infobase.client import ClientException
 from infogami.utils import delegate
 from infogami.utils.view import add_flash_message, safeint
+
 from openlibrary import accounts
 from openlibrary.core.helpers import uniq
 from openlibrary.i18n import gettext as _  # noqa: F401 side effects may be needed
@@ -966,6 +966,10 @@ class daisy(delegate.page):
 
         if not page:
             raise web.notfound()
+
+        if page.ocaid:
+            ia_item_url = f"https://archive.org/details/{urllib.parse.quote(page.ocaid, safe='')}"
+            raise web.seeother(ia_item_url)
 
         return render_template("books/daisy", page)
 

--- a/openlibrary/plugins/upstream/tests/test_addbook.py
+++ b/openlibrary/plugins/upstream/tests/test_addbook.py
@@ -1,5 +1,6 @@
 """py.test tests for addbook"""
 
+import pytest
 import web
 
 from openlibrary import accounts
@@ -487,6 +488,55 @@ class TestSaveBookHelper:
         # Should ignore authors/subjects by default
         assert not new_work.authors
         assert not new_work.subjects
+
+
+class TestDaisyPage:
+    def setup_method(self, method):
+        web.ctx.site = MockSite()
+
+    def test_redirects_to_archive_item_for_edition_with_ocaid(self, monkeypatch):
+        web.ctx.site.save(
+            {
+                "type": {"key": "/type/edition"},
+                "key": "/books/OL1M",
+                "title": "Accessible Book",
+                "ocaid": "testitem00archive",
+            }
+        )
+
+        redirects = []
+
+        def seeother(url):
+            redirects.append(url)
+            raise RuntimeError("redirect")
+
+        monkeypatch.setattr(addbook.web, "seeother", seeother)
+
+        with pytest.raises(RuntimeError, match="redirect"):
+            addbook.daisy().GET("/books/OL1M")
+        assert redirects == ["https://archive.org/details/testitem00archive"]
+
+    def test_redirect_escapes_archive_item_identifier(self, monkeypatch):
+        web.ctx.site.save(
+            {
+                "type": {"key": "/type/edition"},
+                "key": "/books/OL1M",
+                "title": "Accessible Book",
+                "ocaid": "test item/archive",
+            }
+        )
+
+        redirects = []
+
+        def seeother(url):
+            redirects.append(url)
+            raise RuntimeError("redirect")
+
+        monkeypatch.setattr(addbook.web, "seeother", seeother)
+
+        with pytest.raises(RuntimeError, match="redirect"):
+            addbook.daisy().GET("/books/OL1M")
+        assert redirects == ["https://archive.org/details/test%20item%2Farchive"]
 
 
 class TestMakeWork:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Refs #9439

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes the stale `/books/.../daisy` flow by redirecting editions with an `ocaid` to their Internet Archive item page instead of rendering the old page with a guessed `_daisy.zip` download URL.

### Technical
- Adds a redirect from the DAISY route to `https://archive.org/details/{ocaid}` when an edition has an Archive identifier.
- URL-escapes the Archive identifier path segment before redirecting.
- Keeps the existing no-`ocaid` fallback page behavior.

### Testing
- `python -m py_compile openlibrary/plugins/upstream/addbook.py openlibrary/plugins/upstream/tests/test_addbook.py`
- `python -m ruff check openlibrary/plugins/upstream/addbook.py openlibrary/plugins/upstream/tests/test_addbook.py`
- Attempted targeted pytest locally, but this machine only has Python 3.13 while Open Library requires Python 3.14; pytest import fails under 3.13 before reaching this test because annotations in `openlibrary/core/helpers.py` are evaluated differently.

### Screenshot
Not applicable; this is a redirect behavior change.

### Stakeholders
@mekarpeles