### PR TITLE
Fix json encode potential XSS when in script tags

### DIFF
--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -40,7 +40,6 @@ __all__ = [
     "extract_year",
     "format_date",
     "format_decimal",
-    "json_encode",
     "parse_datetime",  # function imported from elsewhere
     "percentage",
     "private_collection_in",
@@ -103,15 +102,6 @@ class NothingEncoder(json.JSONEncoder):
         if isinstance(obj, date):
             return obj.isoformat()
         return super().default(obj)
-
-
-def json_encode(d, **kw) -> str:
-    """Calls json.dumps on the given data d.
-    If d is a Nothing object, passes an empty list to json.dumps.
-
-    Returns the json.dumps results.
-    """
-    return json.dumps([] if isinstance(d, Nothing) else d, **kw)
 
 
 def safesort(iterable: Iterable, key: Callable | None = None, reverse: bool = False) -> list:

--- a/openlibrary/plugins/upstream/tests/test_utils.py
+++ b/openlibrary/plugins/upstream/tests/test_utils.py
@@ -386,3 +386,10 @@ def test_get_language_name(add_languages):  # noqa: F811
     assert utils.get_language_name("/languages/ger", "en") == "German"
     # Falls back to name when translation missing for requested language
     assert utils.get_language_name("/languages/ger", "fr") == "Deutsch"
+
+
+def test_json_encode():
+    assert utils.json_encode({"a": 1, "b": 2}) == '{"a": 1, "b": 2}'
+    assert utils.json_encode({"description": "</script><script>alert('xss')</script>"}) == (
+        '{"description": "\\u003c/script\\u003e\\u003cscript\\u003ealert(\'xss\')\\u003c/script\\u003e"}'
+    )

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -302,8 +302,13 @@ def commify_list(items: Iterable[Any]) -> str:
 
 
 @public
-def json_encode(d, indent=0) -> str:
-    return json.dumps(d, indent=indent)
+def json_encode(d, indent: int | str | None = None, sort_keys: bool = False) -> str:
+    if isinstance(d, Nothing):
+        d = []
+
+    # Escape < and > so the output is safe inside <script> tags with unescaped $: output.
+    # </> are valid JSON unicode escapes; all parsers decode them correctly.
+    return json.dumps(d, indent=indent, sort_keys=sort_keys).replace("<", "\\u003c").replace(">", "\\u003e")
 
 
 @public


### PR DESCRIPTION
We often use `<script>$:json_encode(...)</script>` , but this is susceptible to XSS if the the object being JSON-stringified contains closing script tags, eg

```html
<script>
    var x = $:json_encode({"description": "user input</script><script>alert('xss')</script>"});
</script>
```

Becomes:


```html
<script>
    var x = {"description": "user input</script><script>alert('xss')</script>"};
</script>
```

Here we also replace `<` / `>` with `\u003c` and `\u003e` to prevent it being interpreted as a closing script tag:

```html
<script>
    var x = {"description": "user input\u003c/script\u003e\u003cscript\u003ealert('xss')\u003c/script\u003e"};
</script>
```

### Technical
<!-- What should be noted about the implementation? -->

DRY'd up our two implementation of json_encode so the fix would only need to happen in one spot.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Also tested by adding the above html sample to the status page locally, and confirmed it no longer XSS's.

Confirmed reading log stats, where we use this pattern, renders correctly.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
