### PR TITLE
Fix metadata cleanup loop to use variable k instead of literal attribute

### DIFF
--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -322,8 +322,8 @@ def author_import_record_to_author(author_import_record_dict: dict, eastern=Fals
     if existing := find_entity(author_import_record):
         assert existing.type.key == "/type/author"
         for k in "last_modified", "id", "revision", "created":
-            if existing.k:
-                del existing.k
+            if k in existing:
+                del existing[k]
         new = existing
         if "death_date" in author_import_record and "death_date" not in existing:
             new["death_date"] = author_import_record["death_date"]


### PR DESCRIPTION
## Summary

Fixes #13016

The loop in `author_import_record_to_author` (load_book.py:324) was using `existing.k` which attempts to access a literal attribute named `"k"` rather than the loop variable `k`. Since no such attribute exists, the condition was always false and the metadata fields (`last_modified`, `id`, `revision`, `created`) were never cleaned up.

## Change

```python
# Before
for k in "last_modified", "id", "revision", "created":
    if existing.k:
        del existing.k

# After
for k in "last_modified", "id", "revision", "created":
    if k in existing:
        del existing[k]
```

This ensures the loop variable is used correctly as a dictionary key, so the metadata cleanup actually runs.