### PR TITLE
Fix metadata cleanup 
    loop using dict access

### DIFF
--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -322,8 +322,8 @@ def author_import_record_to_author(author_import_record_dict: dict, eastern=Fals
     if existing := find_entity(author_import_record):
         assert existing.type.key == "/type/author"
         for k in "last_modified", "id", "revision", "created":
-            if existing.k:
-                del existing.k
+            if existing.get(k):
+                del existing[k]
         new = existing
         if "death_date" in author_import_record and "death_date" not in existing:
             new["death_date"] = author_import_record["death_date"]


### PR DESCRIPTION
Changed `existing.k` to 
    `existing.get(k)` and `del existing.k` to `del existing[k]` so the 
    loop variable `k` is used instead of a literal attribute name.