### PR TITLE
fix: restore cryptography dependency to requirements.txt (#13055)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ amightygirl.paapi5-python-sdk==1.0.0
 APScheduler==3.11.2
 Babel==2.18.0
 beautifulsoup4==4.14.3
+cryptography==44.0.2
 eventer==0.1.1
 fastapi==0.136.3
 feedparser==6.0.12


### PR DESCRIPTION
Restores cryptography==44.0.2 to requirements.txt (alphabetically under beautifulsoup4).

<!-- What issue does this PR close? -->
Closes #13055

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

### Technical
<!-- What should be noted about the implementation? -->
- **PR #12860** (merged 2026-06-25) introduced session cookie encryption for S3 keys, importing `cryptography.fernet.Fernet` and pinning `cryptography==44.0.2` in `requirements.txt`.
- **PR #12724** (merged 2026-06-27) updated outbound request proxies, but its `requirements.txt` diff accidentally omitted/removed `cryptography==44.0.2` during dependency updates.
- The imports in `openlibrary/accounts/model.py` are still live, meaning fresh environments or clean builds that pull dependencies from `requirements.txt` crash with a `ModuleNotFoundError` on `/account/login`.
- This PR restores the `cryptography==44.0.2` requirement alphabetically.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Rebuild the development containers to fetch and install the restored dependency:
   ```bash
   docker compose build --no-cache && docker compose up -d
   ```
2. Navigate to `http://localhost:8080/account/login` and verify that the page loads and login succeeds smoothly.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A (Backend dependency fix. Traceback screenshot is available in #13055)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
