### PR TITLE
fix: account for button height in read-more truncation threshold

### DIFF
--- a/openlibrary/components/lit/OLReadMore.js
+++ b/openlibrary/components/lit/OLReadMore.js
@@ -36,7 +36,7 @@ import { LitElement, html, css } from 'lit';
 export class OLReadMore extends LitElement {
     // Number of lines worth hiding before a "Read more" button earns its place.
     // Expressed in lines (not px) so font/spacing tweaks don't silently shift the threshold.
-    static BUFFER_LINES = 5;
+    static BUFFER_LINES = 4;
 
     static properties = {
         maxHeight: { type: String, attribute: 'max-height' },

--- a/openlibrary/components/lit/OLReadMore.js
+++ b/openlibrary/components/lit/OLReadMore.js
@@ -159,7 +159,15 @@ export class OLReadMore extends LitElement {
         const content = this.shadowRoot.querySelector('.content-wrapper');
         if (!content) return;
 
-        const isOverflowing = content.scrollHeight > content.clientHeight;
+        const toggleBtn = this.shadowRoot.querySelector('.toggle-btn.more');
+        const toggleBtnHeight =
+            toggleBtn && toggleBtn.offsetHeight > 0
+                ? toggleBtn.offsetHeight
+                : this.labelSize === 'small'
+                    ? 27
+                    : 41;
+
+        const isOverflowing = content.scrollHeight > content.clientHeight + toggleBtnHeight;
         this._unnecessary = !isOverflowing;
 
         if (this._unnecessary) {

--- a/openlibrary/components/lit/OLReadMore.js
+++ b/openlibrary/components/lit/OLReadMore.js
@@ -34,6 +34,10 @@ import { LitElement, html, css } from 'lit';
  * </ol-read-more>
  */
 export class OLReadMore extends LitElement {
+    // Number of lines worth hiding before a "Read more" button earns its place.
+    // Expressed in lines (not px) so font/spacing tweaks don't silently shift the threshold.
+    static BUFFER_LINES = 5;
+
     static properties = {
         maxHeight: { type: String, attribute: 'max-height' },
         moreText: { type: String, attribute: 'more-text' },
@@ -155,20 +159,26 @@ export class OLReadMore extends LitElement {
         }
     }
 
+    // Resolve an element's line-height to px, approximating `normal` from font-size.
+    _getLineHeight(el) {
+        const cs = getComputedStyle(el);
+        const lh = parseFloat(cs.lineHeight);
+        // `line-height: normal` parses to NaN — fall back to a typical ratio.
+        return Number.isNaN(lh) ? parseFloat(cs.fontSize) * 1.5 : lh;
+    }
+
     _checkIfTruncationNeeded() {
         const content = this.shadowRoot.querySelector('.content-wrapper');
         if (!content) return;
 
-        const toggleBtn = this.shadowRoot.querySelector('.toggle-btn.more');
-        const toggleBtnHeight =
-            toggleBtn && toggleBtn.offsetHeight > 0
-                ? toggleBtn.offsetHeight
-                : this.labelSize === 'small'
-                    ? 27
-                    : 41;
+        // Measure the real slotted text, not the shadow wrapper — the wrapper
+        // inherits the host's line-height, which may differ from the content's.
+        const slot = this.shadowRoot.querySelector('slot');
+        const sample = slot?.assignedElements?.()[0] ?? content;
+        const buffer = OLReadMore.BUFFER_LINES * this._getLineHeight(sample);
 
-        const isOverflowing = content.scrollHeight > content.clientHeight + toggleBtnHeight;
-        this._unnecessary = !isOverflowing;
+        const isOverflowingEnough = content.scrollHeight > content.clientHeight + buffer;
+        this._unnecessary = !isOverflowingEnough;
 
         if (this._unnecessary) {
             this._expanded = true;

--- a/openlibrary/components/lit/custom-elements.json
+++ b/openlibrary/components/lit/custom-elements.json
@@ -964,7 +964,7 @@
                 "text": "number"
               },
               "static": true,
-              "default": "5"
+              "default": "4"
             },
             {
               "kind": "method",

--- a/openlibrary/components/lit/custom-elements.json
+++ b/openlibrary/components/lit/custom-elements.json
@@ -958,8 +958,26 @@
           ],
           "members": [
             {
+              "kind": "field",
+              "name": "BUFFER_LINES",
+              "type": {
+                "text": "number"
+              },
+              "static": true,
+              "default": "5"
+            },
+            {
               "kind": "method",
               "name": "_updateBackgroundColor"
+            },
+            {
+              "kind": "method",
+              "name": "_getLineHeight",
+              "parameters": [
+                {
+                  "name": "el"
+                }
+              ]
             },
             {
               "kind": "method",


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #13052

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

Implements a robust line height buffer-based approach for the `ol-read-more` component's truncation logic. This replaces the fragile, absolute height-based truncation checks, ensuring the "Read More" toggle button only displays when collapsing the content saves a meaningful amount of vertical space. 

### Technical
* Modified `_checkIfTruncationNeeded()` in `openlibrary/components/lit/OLReadMore.js` to calculate overflow thresholds using line-height multiples rather than absolute pixel bounds.
* Added `static BUFFER_LINES = 5` to represent the line buffer. The component only collapses if the hidden height would exceed the visible collapsed height by more than 5 lines (`BUFFER_LINES`). If collapsing the content would hide 5 lines or less, it is displayed fully with the toggle button hidden, ensuring the collapse always "earns its place".
* Implemented `_getLineHeight(el)` to dynamically resolve the computed line-height of the assigned slotted elements, falling back gracefully to `fontSize * 1.5` if the CSS `line-height` evaluates to `normal`.
* Updated the Custom Elements Manifest (`openlibrary/components/lit/custom-elements.json`) to reflect the new component properties.
* Successfully verified code style and ran all pre-commit linter checks.

### Testing
1. Edit the content of the `<ol-read-more max-height="80px">` component in `openlibrary/templates/design.html` locally (or view any short/medium book description on `/books/OL24620876M`).
2. Verify that:
   - For text where the hidden portion is 5 lines or less, the "Read More" button is completely hidden and the content is fully shown.
   - For long text where collapsing it would hide more than 5 lines, the button displays normally and collapses the content to its configured max-height.