### PR TITLE
Fix author_dates_match comparing only year, ignoring month/day

### DIFF
--- a/openlibrary/catalog/utils/__init__.py
+++ b/openlibrary/catalog/utils/__init__.py
@@ -67,6 +67,9 @@ def author_dates_match(a: AuthorImportDict, b: dict | Author) -> bool:
             return False
         m2 = re_year.search(b[k])
         if m2 and m1.group(1) == m2.group(1):
+            year_str = m1.group(1)
+            if a[k] != year_str and b[k] != year_str and a[k] != b[k]:
+                return False
             continue
         return False
     return True

--- a/openlibrary/tests/catalog/test_utils.py
+++ b/openlibrary/tests/catalog/test_utils.py
@@ -76,8 +76,7 @@ def test_author_dates_match():
     # This method only compares dates and ignores names
     assert author_dates_match(no_dates, different_name)
     assert author_dates_match(basic, non_match) is False
-    # FIXME: the following should properly be False:
-    assert author_dates_match(full_different, full_dates)  # this shows matches are only occurring on year, full dates are ignored!
+    assert author_dates_match(full_different, full_dates) is False
 
 
 def test_flip_name():


### PR DESCRIPTION
Closes #13065

fix
Fixes author_dates_match() returning True for authors with different full dates that happen to share the same year. The function was only comparing 4-digit years, ignoring month/day. A bare year like "1650" still matches any full date in that year — the fix only rejects a match when both records have fully specified dates with genuinely different content.
Technical
After extracting years from both date strings and finding they match, the fix adds a check: if both original strings contain more than just the year (e.g. "01 December 1650" not "1650"), and the full strings differ, return False. This preserves the imprecise-date fallback while catching real mismatches.

Testing
- test_author_dates_match() — all existing assertions still pass
- The previously-broken assertion now correctly expects False instead of True
- Run: pytest openlibrary/tests/catalog/test_utils.py
