### PR TITLE
feat(i18n): dispatch to openlibrary-i18n when messages.pot changes

### DIFF
--- a/.github/workflows/trigger-i18n.yml
+++ b/.github/workflows/trigger-i18n.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - "openlibrary/i18n/messages.pot"
 
+permissions: {}
+
 jobs:
   dispatch:
     runs-on: ubuntu-latest

--- a/.github/workflows/trigger-i18n.yml
+++ b/.github/workflows/trigger-i18n.yml
@@ -1,0 +1,19 @@
+name: Trigger i18n pipeline
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "openlibrary/i18n/messages.pot"
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify openlibrary-i18n of pot change
+        env:
+          GH_TOKEN: ${{ secrets.OL_BOT_PAT }}
+        run: |
+          gh api repos/internetarchive/openlibrary-i18n/dispatches \
+            -f event_type=openlibrary-pot-updated \
+            -f "client_payload[sha]=$GITHUB_SHA"


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that fires a `repository_dispatch` event to `internetarchive/openlibrary-i18n` whenever `messages.pot` changes on master. This triggers the AI translation pipeline to fill newly untranslated strings automatically.

## How it works

```
PR merges to master
  → generate-pot pre-commit hook regenerates messages.pot
  → this workflow detects the change
  → fires repository_dispatch: openlibrary-pot-updated
  → openlibrary-i18n translate.yml picks it up
  → AI agents translate new strings, open PRs to openlibrary-i18n
```

## Files changed

- **`.github/workflows/trigger-i18n.yml`** — new workflow; triggers only on `openlibrary/i18n/messages.pot` path changes on master

## Dependencies

- **`OL_BOT_PAT`** secret must be set in this repo (already done — `@openlibrary-bot` PAT with `repo` scope)
- **`internetarchive/openlibrary-i18n`** must have its `translate.yml` workflow on `main` (pending merge of openlibrary-i18n PR #1)

## Related

- [openlibrary-i18n PR #1](https://github.com/internetarchive/openlibrary-i18n/pull/1) — translation pipeline infrastructure (must merge first)
- [#13061](https://github.com/internetarchive/openlibrary/issues/13061) — i18n pipeline extraction epic
- Companion: `i18n/olbase-pull-translations` PR — bakes translations into olbase at image build time