### PR TITLE
feat(i18n): pull latest translations from openlibrary-i18n in olbase

### DIFF
--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -83,6 +83,15 @@ COPY --chown=openlibrary:openlibrary package*.json ./
 RUN npm ci --no-audit
 
 COPY --chown=openlibrary:openlibrary . /openlibrary
+
+# Pull latest translations from openlibrary-i18n (kept current by AI pipeline)
+RUN git clone --depth=1 https://github.com/internetarchive/openlibrary-i18n /tmp/i18n \
+ && for lang in /tmp/i18n/locale/*/; do \
+      lang_code=$(basename "$lang"); \
+      cp "$lang/messages.po" /openlibrary/openlibrary/i18n/${lang_code}/messages.po; \
+    done \
+ && rm -rf /tmp/i18n
+
 # run make to initialize git submodules, build css and js files
 RUN ln -s vendor/infogami/infogami infogami \
  && make


### PR DESCRIPTION
## Summary

Adds a `git clone` step to `Dockerfile.olbase` that fetches the current `messages.po` for all languages from `internetarchive/openlibrary-i18n` at image build time. olbase rebuilds weekly (Tuesdays) and on `workflow_dispatch`, so translations stay fresh without any changes to this repo.

## How it fits into the pipeline

```
messages.pot changes on master
  → trigger-i18n.yml fires repository_dispatch
  → openlibrary-i18n AI pipeline runs, fills untranslated strings, merges PRs
  → olbase weekly rebuild: git clone openlibrary-i18n → bakes fresh .po files into image
  → deployed containers have current translations
```

## Local dev

Volume-mount via `OL_MOUNT_DIR` still serves the `.po` files committed in this repo — the baked-in translations are only used in production images. Removing the committed `.po` files (so local dev also pulls from `openlibrary-i18n`) is a **separate future phase** and requires a `make i18n-sync` or similar mechanism first.

## Files changed

- **`docker/Dockerfile.olbase`** — one `RUN git clone` block after `COPY . /openlibrary`

## Dependencies

- `internetarchive/openlibrary-i18n` must exist and have translations on `main` (already true — PRs #2–#4 merged)
- No secrets required (public repo clone over HTTPS)

## Related

- [openlibrary-i18n PR #1](https://github.com/internetarchive/openlibrary-i18n/pull/1) — pipeline infrastructure
- [openlibrary PR #13069](https://github.com/internetarchive/openlibrary/pull/13069) — dispatch trigger (companion)
- [#13061](https://github.com/internetarchive/openlibrary/issues/13061) — i18n pipeline extraction epic