### PR TITLE
test(e2e): add minimal Playwright smoke suite for core OL pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@ericblade/quagga2": "^1.7.4",
         "@eslint/js": "^9.39.4",
         "@internetarchive/elements": "^0.2.5",
+        "@playwright/test": "^1.60.0",
         "@sentry/browser": "^10.60.0",
         "@tiptap/core": "^3.20.4",
         "@tiptap/extension-image": "^3.22.1",
@@ -4242,6 +4243,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -13139,6 +13156,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plur": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "lint-fix:css": "stylelint --fix \"static/**/*.css\" \"openlibrary/**/*.css\"",
     "serve": "node openlibrary/components/dev/serve-component.js && cd openlibrary/components/dev && vite",
     "test": "npm run test:js && bundlesize",
-    "test:js": "jest"
+    "test:js": "jest",
+    "test:e2e": "playwright test"
   },
   "devDependencies": {
     "@babel/core": "^7.24.7",
@@ -35,6 +36,7 @@
     "@ericblade/quagga2": "^1.7.4",
     "@eslint/js": "^9.39.4",
     "@internetarchive/elements": "^0.2.5",
+    "@playwright/test": "^1.60.0",
     "@sentry/browser": "^10.60.0",
     "@tiptap/core": "^3.20.4",
     "@tiptap/extension-image": "^3.22.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,10 +2,13 @@ import { defineConfig, devices } from '@playwright/test';
 
 /**
  * Run tests against a local Docker instance:
- *   cd ~/Projects/openlibrary-<slug>
  *   OL_MOUNT_DIR="$(pwd)" docker compose up -d web infobase db memcached home covers
- *   npx playwright install chromium
+ *   npx playwright install chromium chromium-headless-shell
  *   npm run test:e2e
+ *
+ * Projects are split so nothing runs twice: the core smoke tests run on the
+ * `desktop` project only, while tests tagged `@mobile` (responsive-layout
+ * checks) run on the `mobile` project only.
  */
 export default defineConfig({
   testDir: './tests/e2e',
@@ -15,14 +18,13 @@ export default defineConfig({
 
   use: {
     baseURL: process.env.OL_BASE_URL || 'http://localhost:8080',
-    // Collect browser console errors for assertion in tests
-    // (each test sets up its own listener)
     headless: true,
   },
 
   projects: [
     {
       name: 'desktop',
+      grepInvert: /@mobile/,
       use: {
         ...devices['Desktop Chrome'],
         viewport: { width: 1280, height: 800 },
@@ -30,6 +32,7 @@ export default defineConfig({
     },
     {
       name: 'mobile',
+      grep: /@mobile/,
       use: {
         // Use Pixel 5 (Chromium) instead of iPhone 12 (WebKit).
         // WebKit headless launch times out on some macOS systems; Chromium is more reliable.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Run tests against a local Docker instance:
+ *   cd ~/Projects/openlibrary-<slug>
+ *   OL_MOUNT_DIR="$(pwd)" docker compose up -d web infobase db memcached home covers
+ *   npx playwright install chromium
+ *   npm run test:e2e
+ */
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 30_000,
+  retries: 0,
+  reporter: [['list'], ['html', { open: 'never' }]],
+
+  use: {
+    baseURL: process.env.OL_BASE_URL || 'http://localhost:8080',
+    // Collect browser console errors for assertion in tests
+    // (each test sets up its own listener)
+    headless: true,
+  },
+
+  projects: [
+    {
+      name: 'desktop',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1280, height: 800 },
+      },
+    },
+    {
+      name: 'mobile',
+      use: {
+        // Use Pixel 5 (Chromium) instead of iPhone 12 (WebKit).
+        // WebKit headless launch times out on some macOS systems; Chromium is more reliable.
+        ...devices['Pixel 5'],
+        viewport: { width: 390, height: 844 },
+      },
+    },
+  ],
+});

--- a/tests/e2e/author.spec.ts
+++ b/tests/e2e/author.spec.ts
@@ -25,17 +25,6 @@ test.describe('Author page @smoke', () => {
         expect(errors()).toHaveLength(0);
     });
 
-    test('shows content body', async ({ page }) => {
-        await skipIfNotFound({ page });
-        await expect(page.locator('#contentBody')).toBeVisible();
-    });
-
-    test('has a works section', async ({ page }) => {
-        await skipIfNotFound({ page });
-        // #works is the works section container in type/author/view.html
-        await expect(page.locator('#works')).toBeAttached();
-    });
-
     test('works list renders at least one item when Solr is available', async ({ page }) => {
         await skipIfNotFound({ page });
         const resultsList = page.locator('#searchResults .list-books li, #searchResults .searchResultItem');
@@ -50,18 +39,5 @@ test.describe('Author page @smoke', () => {
         const response = await page.goto('/authors/OL999999999A');
         expect(response?.status()).not.toBe(500);
         await expect(page.locator('#header-bar').first()).toBeVisible();
-    });
-
-    test('mobile: author name is visible without horizontal overflow', async ({ page, isMobile }) => {
-        if (!isMobile) test.skip();
-        const response = await page.goto(AUTHOR_URL);
-        test.skip(response?.status() === 404, 'Author not in this environment\'s DB');
-        const heading = page.locator('h1[itemprop="name"]');
-        await expect(heading).toBeVisible();
-        const box = await heading.boundingBox();
-        expect(box).not.toBeNull();
-        expect(box!.x).toBeGreaterThanOrEqual(0);
-        const viewport = page.viewportSize();
-        expect(box!.x + box!.width).toBeLessThanOrEqual(viewport!.width + 1);
     });
 });

--- a/tests/e2e/author.spec.ts
+++ b/tests/e2e/author.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test';
+import { collectConsoleErrors } from './helpers';
+
+// OL23919A = J.K. Rowling (reliable on production).
+// In local dev the seed DB may not include this author — tests skip gracefully on 404.
+const AUTHOR_URL = '/authors/OL23919A';
+
+const skipIfNotFound = async ({ page }: { page: import('@playwright/test').Page }) => {
+    const response = await page.goto(AUTHOR_URL);
+    if (response?.status() === 404) {
+        test.skip(true, 'Author not in this environment\'s DB — skipping');
+    }
+};
+
+test.describe('Author page @smoke', () => {
+    test('loads with author name in heading', async ({ page }) => {
+        const errors = collectConsoleErrors(page);
+        const response = await page.goto(AUTHOR_URL);
+        test.skip(response?.status() === 404, 'Author not in this environment\'s DB');
+        // h1[itemprop="name"] is the author name heading in type/author/view.html
+        const heading = page.locator('h1[itemprop="name"]');
+        await expect(heading).toBeVisible();
+        const text = await heading.textContent();
+        expect(text?.trim().length).toBeGreaterThan(0);
+        expect(errors()).toHaveLength(0);
+    });
+
+    test('shows content body', async ({ page }) => {
+        await skipIfNotFound({ page });
+        await expect(page.locator('#contentBody')).toBeVisible();
+    });
+
+    test('has a works section', async ({ page }) => {
+        await skipIfNotFound({ page });
+        // #works is the works section container in type/author/view.html
+        await expect(page.locator('#works')).toBeAttached();
+    });
+
+    test('works list renders at least one item when Solr is available', async ({ page }) => {
+        await skipIfNotFound({ page });
+        const resultsList = page.locator('#searchResults .list-books li, #searchResults .searchResultItem');
+        const count = await resultsList.count();
+        if (count === 0) {
+            test.skip(true, 'No Solr data — works list empty in this environment');
+        }
+        expect(count).toBeGreaterThan(0);
+    });
+
+    test('unknown author shows a page (not 500)', async ({ page }) => {
+        const response = await page.goto('/authors/OL999999999A');
+        expect(response?.status()).not.toBe(500);
+        await expect(page.locator('#header-bar').first()).toBeVisible();
+    });
+
+    test('mobile: author name is visible without horizontal overflow', async ({ page, isMobile }) => {
+        if (!isMobile) test.skip();
+        const response = await page.goto(AUTHOR_URL);
+        test.skip(response?.status() === 404, 'Author not in this environment\'s DB');
+        const heading = page.locator('h1[itemprop="name"]');
+        await expect(heading).toBeVisible();
+        const box = await heading.boundingBox();
+        expect(box).not.toBeNull();
+        expect(box!.x).toBeGreaterThanOrEqual(0);
+        const viewport = page.viewportSize();
+        expect(box!.x + box!.width).toBeLessThanOrEqual(viewport!.width + 1);
+    });
+});

--- a/tests/e2e/edition.spec.ts
+++ b/tests/e2e/edition.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test';
+import { collectConsoleErrors } from './helpers';
+
+// OL3421846M is present in the dev DB seed data (referenced in lists unit tests).
+// OL7353617M is a known production edition (The Fellowship of the Ring).
+const EDITION_URL = process.env.OL_BASE_URL?.startsWith('https')
+    ? '/books/OL7353617M'
+    : '/books/OL3421846M';
+
+const skipIfNotFound = async ({ page }: { page: import('@playwright/test').Page }) => {
+    const response = await page.goto(EDITION_URL);
+    if (response?.status() === 404) {
+        test.skip(true, 'Edition not in this environment\'s DB — skipping');
+    }
+};
+
+test.describe('Edition page @smoke', () => {
+    test('loads with book title in heading', async ({ page }) => {
+        const errors = collectConsoleErrors(page);
+        const response = await page.goto(EDITION_URL);
+        test.skip(response?.status() === 404, 'Edition not in this environment\'s DB');
+        // h1.work-title is the book title heading in type/edition/title_and_author.html
+        const title = page.locator('h1.work-title').filter({ visible: true });
+        await expect(title).toBeVisible();
+        const text = await title.textContent();
+        expect(text?.trim().length).toBeGreaterThan(0);
+        expect(errors()).toHaveLength(0);
+    });
+
+    test('shows work details section', async ({ page }) => {
+        await skipIfNotFound({ page });
+        await expect(page.locator('.workDetails')).toBeVisible();
+    });
+
+    test('renders the edition cover or placeholder', async ({ page }) => {
+        await skipIfNotFound({ page });
+        // .editionCover is the cover container in type/edition/view.html
+        const cover = page.locator('.editionCover').first();
+        await expect(cover).toBeAttached();
+    });
+
+    test('has a link back to the parent work', async ({ page }) => {
+        await skipIfNotFound({ page });
+        // The edition page links to its parent work via .work-title-and-author
+        const workLink = page.locator('.work-title-and-author a[href*="/works/"]').first();
+        await expect(workLink).toBeAttached();
+    });
+
+    test('shows edition metadata (publisher, date, or pages)', async ({ page }) => {
+        await skipIfNotFound({ page });
+        // .edition-omniline contains publisher, publish date, page count
+        const omniline = page.locator('.edition-omniline');
+        await expect(omniline).toBeAttached();
+    });
+
+    test('unknown edition shows a page (not 500)', async ({ page }) => {
+        const response = await page.goto('/books/OL999999999M');
+        expect(response?.status()).not.toBe(500);
+        await expect(page.locator('#header-bar').first()).toBeVisible();
+    });
+
+    test('mobile: book title is visible without horizontal overflow', async ({ page, isMobile }) => {
+        if (!isMobile) test.skip();
+        const response = await page.goto(EDITION_URL);
+        test.skip(response?.status() === 404, 'Edition not in this environment\'s DB');
+        const title = page.locator('h1.work-title').filter({ visible: true });
+        await expect(title).toBeVisible();
+        const box = await title.boundingBox();
+        expect(box).not.toBeNull();
+        const viewport = page.viewportSize();
+        expect(box!.x + box!.width).toBeLessThanOrEqual(viewport!.width + 1);
+    });
+});

--- a/tests/e2e/edition.spec.ts
+++ b/tests/e2e/edition.spec.ts
@@ -7,13 +7,6 @@ const EDITION_URL = process.env.OL_BASE_URL?.startsWith('https')
     ? '/books/OL7353617M'
     : '/books/OL3421846M';
 
-const skipIfNotFound = async ({ page }: { page: import('@playwright/test').Page }) => {
-    const response = await page.goto(EDITION_URL);
-    if (response?.status() === 404) {
-        test.skip(true, 'Edition not in this environment\'s DB — skipping');
-    }
-};
-
 test.describe('Edition page @smoke', () => {
     test('loads with book title in heading', async ({ page }) => {
         const errors = collectConsoleErrors(page);
@@ -27,47 +20,9 @@ test.describe('Edition page @smoke', () => {
         expect(errors()).toHaveLength(0);
     });
 
-    test('shows work details section', async ({ page }) => {
-        await skipIfNotFound({ page });
-        await expect(page.locator('.workDetails')).toBeVisible();
-    });
-
-    test('renders the edition cover or placeholder', async ({ page }) => {
-        await skipIfNotFound({ page });
-        // .editionCover is the cover container in type/edition/view.html
-        const cover = page.locator('.editionCover').first();
-        await expect(cover).toBeAttached();
-    });
-
-    test('has a link back to the parent work', async ({ page }) => {
-        await skipIfNotFound({ page });
-        // The edition page links to its parent work via .work-title-and-author
-        const workLink = page.locator('.work-title-and-author a[href*="/works/"]').first();
-        await expect(workLink).toBeAttached();
-    });
-
-    test('shows edition metadata (publisher, date, or pages)', async ({ page }) => {
-        await skipIfNotFound({ page });
-        // .edition-omniline contains publisher, publish date, page count
-        const omniline = page.locator('.edition-omniline');
-        await expect(omniline).toBeAttached();
-    });
-
     test('unknown edition shows a page (not 500)', async ({ page }) => {
         const response = await page.goto('/books/OL999999999M');
         expect(response?.status()).not.toBe(500);
         await expect(page.locator('#header-bar').first()).toBeVisible();
-    });
-
-    test('mobile: book title is visible without horizontal overflow', async ({ page, isMobile }) => {
-        if (!isMobile) test.skip();
-        const response = await page.goto(EDITION_URL);
-        test.skip(response?.status() === 404, 'Edition not in this environment\'s DB');
-        const title = page.locator('h1.work-title').filter({ visible: true });
-        await expect(title).toBeVisible();
-        const box = await title.boundingBox();
-        expect(box).not.toBeNull();
-        const viewport = page.viewportSize();
-        expect(box!.x + box!.width).toBeLessThanOrEqual(viewport!.width + 1);
     });
 });

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1,0 +1,34 @@
+import type { Page } from '@playwright/test';
+
+// Console messages that are infrastructure/environment noise, not JS bugs.
+// - "Failed to load resource:" — fetch/XHR calls that hit unavailable external services
+//   (e.g. IA availability API, CDN assets) in local dev or test environments.
+// - "violates the following Content Security Policy" — CSP violations for archive.org
+//   iframes that are blocked on localhost but not on openlibrary.org.
+const CONSOLE_NOISE_PATTERNS = [
+    'Failed to load resource:',
+    'violates the following Content Security Policy',
+];
+
+/**
+ * Attach a console-error collector to a page.
+ * Returns a getter for all JS errors collected so far (network resource errors excluded).
+ *
+ * Usage:
+ *   const errors = collectConsoleErrors(page);
+ *   await page.goto('/');
+ *   expect(errors()).toHaveLength(0);
+ */
+export function collectConsoleErrors(page: Page): () => string[] {
+    const errors: string[] = [];
+    page.on('console', msg => {
+        if (msg.type() === 'error') {
+            const text = msg.text();
+            if (!CONSOLE_NOISE_PATTERNS.some(pat => text.includes(pat))) {
+                errors.push(text);
+            }
+        }
+    });
+    page.on('pageerror', err => errors.push(err.message));
+    return () => errors;
+}

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+import { collectConsoleErrors } from './helpers';
+
+test.describe('Home page @smoke', () => {
+    test('loads with correct title and header', async ({ page }) => {
+        const errors = collectConsoleErrors(page);
+        await page.goto('/');
+        await expect(page).toHaveTitle(/Open Library/i);
+        // Global site header must be visible
+        await expect(page.locator('#header-bar').first()).toBeVisible();
+        expect(errors()).toHaveLength(0);
+    });
+
+    test('shows main content body', async ({ page }) => {
+        await page.goto('/');
+        await expect(page.locator('#contentBody')).toBeVisible();
+    });
+
+    test('header search trigger is present', async ({ page }) => {
+        await page.goto('/');
+        // The search bar is a Lit web component — the visible affordance is a trigger button
+        // that opens a search dialog; there is no plain <input> in the DOM until the dialog opens.
+        const searchTrigger = page.locator('.search-bar-component, button.search-bar-trigger').first();
+        await expect(searchTrigger).toBeAttached();
+    });
+
+    test('footer is rendered', async ({ page }) => {
+        await page.goto('/');
+        await expect(page.locator('#footer-content, footer').first()).toBeVisible();
+    });
+});

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -11,21 +11,11 @@ test.describe('Home page @smoke', () => {
         expect(errors()).toHaveLength(0);
     });
 
-    test('shows main content body', async ({ page }) => {
-        await page.goto('/');
-        await expect(page.locator('#contentBody')).toBeVisible();
-    });
-
     test('header search trigger is present', async ({ page }) => {
         await page.goto('/');
         // The search bar is a Lit web component — the visible affordance is a trigger button
         // that opens a search dialog; there is no plain <input> in the DOM until the dialog opens.
         const searchTrigger = page.locator('.search-bar-component, button.search-bar-trigger').first();
         await expect(searchTrigger).toBeAttached();
-    });
-
-    test('footer is rendered', async ({ page }) => {
-        await page.goto('/');
-        await expect(page.locator('#footer-content, footer').first()).toBeVisible();
     });
 });

--- a/tests/e2e/login.spec.ts
+++ b/tests/e2e/login.spec.ts
@@ -20,20 +20,6 @@ test.describe('Login page @smoke', () => {
         await expect(page.locator('input[name="password"]')).toBeVisible();
     });
 
-    test('submit button is present and labeled', async ({ page }) => {
-        await page.goto('/account/login');
-        const btn = page.locator('button[name="login"]');
-        await expect(btn).toBeVisible();
-        const label = await btn.textContent();
-        expect(label?.trim().length).toBeGreaterThan(0);
-    });
-
-    test('sign up link is present', async ({ page }) => {
-        await page.goto('/account/login');
-        const signupLink = page.locator('a[href="/account/create"]').first();
-        await expect(signupLink).toBeAttached();
-    });
-
     test('invalid credentials do not crash the page', async ({ page }) => {
         await page.goto('/account/login');
         await page.fill('input[name="username"]', 'nobody@example.com');
@@ -46,8 +32,7 @@ test.describe('Login page @smoke', () => {
         expect(status).not.toContain('500');
     });
 
-    test('mobile: form fields are visible and not clipped', async ({ page, isMobile }) => {
-        if (!isMobile) test.skip();
+    test('mobile: form fields are visible and not clipped @mobile', async ({ page }) => {
         await page.goto('/account/login');
         const emailInput = page.locator('input[name="username"]');
         await expect(emailInput).toBeVisible();

--- a/tests/e2e/login.spec.ts
+++ b/tests/e2e/login.spec.ts
@@ -5,8 +5,11 @@ test.describe('Login page @smoke', () => {
     test('loads with Log In heading', async ({ page }) => {
         const errors = collectConsoleErrors(page);
         await page.goto('/account/login');
-        await expect(page.locator('h1.ol-signup-hero__title')).toBeVisible();
-        const heading = await page.locator('h1.ol-signup-hero__title').textContent();
+        // The hero title renders in the DOM on every viewport but is hidden by responsive
+        // CSS on narrow (mobile) layouts, so assert it's attached rather than visible.
+        const title = page.locator('h1.ol-signup-hero__title');
+        await expect(title).toBeAttached();
+        const heading = await title.textContent();
         expect(heading?.trim()).toMatch(/log in/i);
         expect(errors()).toHaveLength(0);
     });

--- a/tests/e2e/login.spec.ts
+++ b/tests/e2e/login.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+import { collectConsoleErrors } from './helpers';
+
+test.describe('Login page @smoke', () => {
+    test('loads with Log In heading', async ({ page }) => {
+        const errors = collectConsoleErrors(page);
+        await page.goto('/account/login');
+        await expect(page.locator('h1.ol-signup-hero__title')).toBeVisible();
+        const heading = await page.locator('h1.ol-signup-hero__title').textContent();
+        expect(heading?.trim()).toMatch(/log in/i);
+        expect(errors()).toHaveLength(0);
+    });
+
+    test('email and password inputs are present', async ({ page }) => {
+        await page.goto('/account/login');
+        await expect(page.locator('input[name="username"]')).toBeVisible();
+        await expect(page.locator('input[name="password"]')).toBeVisible();
+    });
+
+    test('submit button is present and labeled', async ({ page }) => {
+        await page.goto('/account/login');
+        const btn = page.locator('button[name="login"]');
+        await expect(btn).toBeVisible();
+        const label = await btn.textContent();
+        expect(label?.trim().length).toBeGreaterThan(0);
+    });
+
+    test('sign up link is present', async ({ page }) => {
+        await page.goto('/account/login');
+        const signupLink = page.locator('a[href="/account/create"]').first();
+        await expect(signupLink).toBeAttached();
+    });
+
+    test('invalid credentials do not crash the page', async ({ page }) => {
+        await page.goto('/account/login');
+        await page.fill('input[name="username"]', 'nobody@example.com');
+        await page.fill('input[name="password"]', 'wrongpassword123');
+        await page.click('button[name="login"]');
+        // Should stay on login-related page (not crash to 500)
+        await expect(page.locator('#header-bar').first()).toBeVisible({ timeout: 10_000 });
+        const status = page.url();
+        // Should not redirect to a 500 page
+        expect(status).not.toContain('500');
+    });
+
+    test('mobile: form fields are visible and not clipped', async ({ page, isMobile }) => {
+        if (!isMobile) test.skip();
+        await page.goto('/account/login');
+        const emailInput = page.locator('input[name="username"]');
+        await expect(emailInput).toBeVisible();
+        const box = await emailInput.boundingBox();
+        expect(box).not.toBeNull();
+        // Input should be fully within the viewport horizontally
+        const viewport = page.viewportSize();
+        expect(box!.x + box!.width).toBeLessThanOrEqual(viewport!.width + 1);
+    });
+});

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+import { collectConsoleErrors } from './helpers';
+
+const SEARCH_URL = '/search?q=tolkien';
+
+// Helper: skip if this environment has no Solr data (empty results page)
+const skipIfNoSolrData = async ({ page }: { page: import('@playwright/test').Page }) => {
+    await page.goto(SEARCH_URL);
+    const title = await page.title();
+    if (!title.toLowerCase().includes('tolkien')) {
+        test.skip(true, 'No Solr data indexed in this environment — search results unavailable');
+    }
+};
+
+test.describe('Search page @smoke', () => {
+    test('loads results for a known query', async ({ page }) => {
+        const errors = collectConsoleErrors(page);
+        await page.goto(SEARCH_URL);
+        test.skip(!(await page.title()).toLowerCase().includes('tolkien'), 'No Solr data indexed in this environment');
+        // Result list must appear
+        await expect(page.locator('.search-results, #searchResults').first()).toBeVisible();
+        expect(errors()).toHaveLength(0);
+    });
+
+    test('shows at least one result item', async ({ page }) => {
+        await skipIfNoSolrData({ page });
+        await page.locator('.searchResultItem, .search-result-item').first().waitFor({ timeout: 10_000 });
+        const count = await page.locator('.searchResultItem, .search-result-item').count();
+        expect(count).toBeGreaterThan(0);
+    });
+
+    test('displays search result stats', async ({ page }) => {
+        await skipIfNoSolrData({ page });
+        await expect(page.locator('.search-results-stats')).toBeVisible();
+    });
+
+    test('empty query shows no error page', async ({ page }) => {
+        const response = await page.goto('/search?q=');
+        expect(response?.status()).not.toBe(500);
+        // Should not crash — either redirect to home or show empty state
+        await expect(page.locator('#header-bar').first()).toBeVisible();
+    });
+
+    test('search form is present for a new query', async ({ page }) => {
+        await page.goto(SEARCH_URL);
+        // A search form or input should still be visible so the user can refine
+        const input = page.locator('input[name="q"]').first();
+        await expect(input).toBeVisible();
+    });
+});

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -29,22 +29,10 @@ test.describe('Search page @smoke', () => {
         expect(count).toBeGreaterThan(0);
     });
 
-    test('displays search result stats', async ({ page }) => {
-        await skipIfNoSolrData({ page });
-        await expect(page.locator('.search-results-stats')).toBeVisible();
-    });
-
     test('empty query shows no error page', async ({ page }) => {
         const response = await page.goto('/search?q=');
         expect(response?.status()).not.toBe(500);
         // Should not crash — either redirect to home or show empty state
         await expect(page.locator('#header-bar').first()).toBeVisible();
-    });
-
-    test('search form is present for a new query', async ({ page }) => {
-        await page.goto(SEARCH_URL);
-        // A search form or input should still be visible so the user can refine
-        const input = page.locator('input[name="q"]').first();
-        await expect(input).toBeVisible();
     });
 });

--- a/tests/e2e/subjects.spec.ts
+++ b/tests/e2e/subjects.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+import { collectConsoleErrors } from './helpers';
+
+const SUBJECT_URL = '/subjects/fiction';
+
+// Subjects pages require a healthy Solr index.
+// In local dev with no Solr data they may return 404, or return 200 with an error page.
+// Guard: skip if the page returned a non-OL page (no #header-bar) or a 404.
+const skipIfNoSolr = async ({ page }: { page: import('@playwright/test').Page }) => {
+    const response = await page.goto(SUBJECT_URL);
+    if (response?.status() === 404) {
+        test.skip(true, 'Subjects require Solr data — not available in this environment');
+    }
+    const hasHeader = await page.locator('#header-bar').isVisible().catch(() => false);
+    if (!hasHeader) {
+        test.skip(true, 'Subjects page returned an error (Solr likely unhealthy) — skipping');
+    }
+};
+
+test.describe('Subjects page @smoke', () => {
+    test('loads with subject heading', async ({ page }) => {
+        const errors = collectConsoleErrors(page);
+        const response = await page.goto(SUBJECT_URL);
+        test.skip(response?.status() === 404, 'Subjects require Solr data — not available in this environment');
+        const hasHeader = await page.locator('#header-bar').isVisible().catch(() => false);
+        test.skip(!hasHeader, 'Subjects page returned an error (Solr likely unhealthy) — skipping');
+        // h1.inline is the subject name heading (from subjects.html template)
+        const heading = page.locator('h1.inline, h1').first();
+        await expect(heading).toBeVisible();
+        const text = await heading.textContent();
+        expect(text?.trim().length).toBeGreaterThan(0);
+        expect(errors()).toHaveLength(0);
+    });
+
+    test('shows book count for the subject', async ({ page }) => {
+        await skipIfNoSolr({ page });
+        // #coversCount shows the number of works with this subject
+        const count = page.locator('#coversCount');
+        await expect(count).toBeVisible();
+    });
+
+    test('renders the content body with works', async ({ page }) => {
+        await skipIfNoSolr({ page });
+        await expect(page.locator('#contentBody')).toBeVisible();
+    });
+
+    test('has a search form for books with this subject', async ({ page }) => {
+        await skipIfNoSolr({ page });
+        // subjects.html includes a search form bound to /search
+        const form = page.locator('form[action="/search"]');
+        await expect(form).toBeAttached();
+    });
+
+    test('unknown subject shows a page (not 500)', async ({ page }) => {
+        // First confirm the subjects system is healthy; if not, skip (Solr down causes 500 everywhere).
+        await skipIfNoSolr({ page });
+        const response = await page.goto('/subjects/xyzzy_nonexistent_subject_12345');
+        expect(response?.status()).not.toBe(500);
+        await expect(page.locator('#header-bar').first()).toBeVisible();
+    });
+});

--- a/tests/e2e/subjects.spec.ts
+++ b/tests/e2e/subjects.spec.ts
@@ -39,19 +39,6 @@ test.describe('Subjects page @smoke', () => {
         await expect(count).toBeVisible();
     });
 
-    test('renders the content body with works', async ({ page }) => {
-        await skipIfNoSolr({ page });
-        // The subjects template wraps content in <div class="contentBody"> (a class, not an id).
-        await expect(page.locator('.contentBody')).toBeVisible();
-    });
-
-    test('has a search form for books with this subject', async ({ page }) => {
-        await skipIfNoSolr({ page });
-        // subjects.html includes a search form bound to /search
-        const form = page.locator('form[action="/search"]');
-        await expect(form).toBeAttached();
-    });
-
     test('unknown subject shows a page (not 500)', async ({ page }) => {
         // First confirm the subjects system is healthy; if not, skip (Solr down causes 500 everywhere).
         await skipIfNoSolr({ page });

--- a/tests/e2e/subjects.spec.ts
+++ b/tests/e2e/subjects.spec.ts
@@ -41,7 +41,8 @@ test.describe('Subjects page @smoke', () => {
 
     test('renders the content body with works', async ({ page }) => {
         await skipIfNoSolr({ page });
-        await expect(page.locator('#contentBody')).toBeVisible();
+        // The subjects template wraps content in <div class="contentBody"> (a class, not an id).
+        await expect(page.locator('.contentBody')).toBeVisible();
     });
 
     test('has a search form for books with this subject', async ({ page }) => {

--- a/tests/e2e/work.spec.ts
+++ b/tests/e2e/work.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+import { collectConsoleErrors } from './helpers';
+
+// OL286811W is present in the dev DB seed data; OL45883W is the production fallback
+// Playwright follows the 301 redirect to the slug URL automatically
+const WORK_URL = process.env.OL_BASE_URL?.startsWith('https')
+    ? '/works/OL45883W'
+    : '/works/OL286811W';
+
+test.describe('Book (Work) page @smoke', () => {
+    test('loads with a title in the heading', async ({ page }) => {
+        const errors = collectConsoleErrors(page);
+        await page.goto(WORK_URL);
+        // h1.work-title exists in both mobile and desktop DOM; filter to the visible one
+        const title = page.locator('h1.work-title').filter({ visible: true });
+        await expect(title).toBeVisible();
+        const titleText = await title.textContent();
+        expect(titleText?.trim().length).toBeGreaterThan(0);
+        expect(errors()).toHaveLength(0);
+    });
+
+    test('shows work details section', async ({ page }) => {
+        await page.goto(WORK_URL);
+        await expect(page.locator('.workDetails')).toBeVisible();
+    });
+
+    test('renders the book cover or placeholder', async ({ page }) => {
+        await page.goto(WORK_URL);
+        // .editionCover is the outer container; .SRPCoverBlank is shown when no image exists
+        const cover = page.locator('.editionCover, .coverMagic').first();
+        await expect(cover).toBeAttached();
+    });
+
+    test('has a readable editions section or link', async ({ page }) => {
+        await page.goto(WORK_URL);
+        // Editions section, tab, or link should exist
+        const editions = page.locator('a[href*="editions"], .editions, #editions').first();
+        await expect(editions).toBeAttached();
+    });
+
+    test('mobile: work title is visible without horizontal scroll', async ({ page, isMobile }) => {
+        if (!isMobile) test.skip();
+        await page.goto(WORK_URL);
+        const title = page.locator('h1.work-title').filter({ visible: true });
+        await expect(title).toBeVisible();
+        const box = await title.boundingBox();
+        expect(box).not.toBeNull();
+        // Title should not overflow the viewport width
+        expect(box!.x).toBeGreaterThanOrEqual(0);
+    });
+});

--- a/tests/e2e/work.spec.ts
+++ b/tests/e2e/work.spec.ts
@@ -24,22 +24,7 @@ test.describe('Book (Work) page @smoke', () => {
         await expect(page.locator('.workDetails')).toBeVisible();
     });
 
-    test('renders the book cover or placeholder', async ({ page }) => {
-        await page.goto(WORK_URL);
-        // .editionCover is the outer container; .SRPCoverBlank is shown when no image exists
-        const cover = page.locator('.editionCover, .coverMagic').first();
-        await expect(cover).toBeAttached();
-    });
-
-    test('has a readable editions section or link', async ({ page }) => {
-        await page.goto(WORK_URL);
-        // Editions section, tab, or link should exist
-        const editions = page.locator('a[href*="editions"], .editions, #editions').first();
-        await expect(editions).toBeAttached();
-    });
-
-    test('mobile: work title is visible without horizontal scroll', async ({ page, isMobile }) => {
-        if (!isMobile) test.skip();
+    test('mobile: work title is visible without horizontal scroll @mobile', async ({ page }) => {
         await page.goto(WORK_URL);
         const title = page.locator('h1.work-title').filter({ visible: true });
         await expect(title).toBeVisible();


### PR DESCRIPTION
Closes #12885

Adds a minimal **Playwright** smoke suite that loads Open Library's core pages — home, search, login, work, edition, author, subjects — in a real browser and confirms they render and work. [feature]

Today the only way to know a change didn't quietly break the home page or search is to click around by hand. This gives a one-command check of the core pages in ~15s, so regressions get caught before they ship. It's a deliberate first step: tests are **run by hand**, **don't run in CI**, and **block no PR** — the goal is to get the tool in place before wiring it into anything.

Scoped down from #12998 (see [that thread](https://github.com/internetarchive/openlibrary/pull/12998) for the hand-off). Accessibility (axe) scans and CI integration are intentionally deferred to their own follow-ups.

Mobile tests video:
https://github.com/user-attachments/assets/fc4e78b3-bdaa-419d-951b-e4c3a966cd9c

Desktop tests video:
https://github.com/user-attachments/assets/c58fd921-b372-4219-a292-1e3ce87aec3a



### Technical

- Adds `@playwright/test` as a **devDependency** only — no runtime/app code touched. `npm install` picks it up (~few MB, no browser download unless you run `playwright install`).
- New `npm run test:e2e` script; the default `npm test` (jest + bundlesize) is unchanged, so nothing new runs in CI.
- `playwright.config.ts` defines two projects split by grep so **nothing runs twice**: core tests run on `desktop` only (`grepInvert: /@mobile/`); two responsive-layout checks tagged `@mobile` run on `mobile` only (`grep: /@mobile/`).
- Base URL is configurable via `OL_BASE_URL` (defaults to `http://localhost:8080`) — point it at staging/production to spot-check any environment.
- Each page's anchor test collects browser console errors (shared `tests/e2e/helpers.ts`), so a JS error that isn't visually obvious still fails the test. Known infra/CSP noise is filtered.
- Tests that need Solr or specific seed data `test.skip()` gracefully when it's absent, so a bare dev setup won't drown you in red.

**What's covered** (~20 checks, one strong "loads + no console errors" anchor per page plus only the checks that catch a *distinct* failure mode):

| Page | Checks |
|------|--------|
| Home | loads (title + header, no console errors); search web-component renders |
| Search | results load; ≥1 result item; empty query doesn't 500 |
| Login | Log In heading; email/password inputs; invalid creds don't crash (real form POST) |
| Work | title loads; work details section |
| Edition | title loads; unknown id doesn't 500 |
| Author | name loads; works list renders; unknown id doesn't 500 |
| Subjects | subject heading loads; book count; unknown subject doesn't 500 |

### Testing

> ⚠️ These run on your **host machine**, not inside Docker. Docker's only job is to serve the app on `:8080`; Playwright runs on the host and points a browser at it.

```bash
# 1. bring the app up
docker compose up -d web infobase db memcached home covers

# 2. one-time browser setup
npm install
npx playwright install chromium chromium-headless-shell   # ~150 MB, cached

# 3. run
npm run test:e2e                                # everything
npx playwright test tests/e2e/home.spec.ts      # one page
npx playwright test -g "invalid credentials"    # one test by name
npx playwright test --headed                    # watch it in a visible browser

# point at another environment instead of local Docker:
OL_BASE_URL=https://openlibrary.org npm run test:e2e
```

Results print a per-test summary (passed / skipped / failed) and write an HTML report — open with `npx playwright show-report` (includes screenshots of any failure).

**Verified:** core pages pass against local Docker; Solr/seed-dependent tests skip cleanly when that data is absent.

### Screenshot

N/A — this PR adds tests only; no user-facing UI changes.

### Stakeholders

@mekarpeles (lead on #12885; original author of #12998, which this scopes down)
