### PR TITLE
Write select participation scores to statsd

### DIFF
--- a/openlibrary/admin/stats.py
+++ b/openlibrary/admin/stats.py
@@ -11,6 +11,7 @@ import web
 import yaml
 
 from openlibrary.admin import numbers
+from openlibrary.admin.vitals import gather_participation_scores, write_to_statsd
 
 logger = logging.getLogger(__name__)
 
@@ -166,4 +167,10 @@ def main(infobase_config, openlibrary_config, coverstore_config, ndays=1):
         store_data(data, start.strftime("%Y-%m-%d"))
         end = start
         start = end - datetime.timedelta(days=1)
+
+    # Gather participation scores for the previous hour
+    if ndays == 1:
+        pscores = gather_participation_scores()
+        write_to_statsd(openlibrary_config, pscores)
+
     return 0

--- a/openlibrary/admin/stats.py
+++ b/openlibrary/admin/stats.py
@@ -169,7 +169,7 @@ def main(infobase_config, openlibrary_config, coverstore_config, ndays=1):
         start = end - datetime.timedelta(days=1)
 
     # Gather participation scores for the previous hour
-    if ndays == 1:
+    if int(ndays) == 1:
         pscores = gather_participation_scores()
         write_to_statsd(openlibrary_config, pscores)
 

--- a/openlibrary/admin/vitals.py
+++ b/openlibrary/admin/vitals.py
@@ -1,0 +1,125 @@
+import yaml
+from statsd import StatsClient
+
+from openlibrary.core import db
+
+
+def write_to_statsd(configfile, stats):
+    def configure_statsd(_configfile):
+        configs = yaml.safe_load(_configfile)
+        url = configs.get("admin", {}).get("statsd_server", None)
+        if not url:
+            raise KeyError("StatsD server not configured")
+        split_url = url.split(":")
+        return StatsClient(split_url[0], split_url[1])
+
+    statsd = configure_statsd(configfile)
+    # Star ratings
+    statsd.gauge("participation.star_ratings.hourly.total", stats.get("star_ratings"))
+    statsd.gauge("participation.star_ratings.distinct.hourly.total", stats.get("distinct_star_ratings"))
+    # List creation
+    statsd.gauge("participation.lists.hourly.total", stats.get("list_counts"))
+    statsd.gauge("participation.lists.distinct.hourly.total", stats.get("distinct_list_counts"))
+    # Reading log counts
+    statsd.gauge("participation.reading_logs.want_to_read.hourly.total", stats.get("reading_logs", {}).get("want_to_read"))
+    statsd.gauge("participation.reading_logs.currently_reading.hourly.total", stats.get("reading_logs", {}).get("currently_reading"))
+    statsd.gauge("participation.reading_logs.already_read.hourly.total", stats.get("reading_logs", {}).get("already_read"))
+    statsd.gauge("participation.reading_logs.stopped_reading.hourly.total", stats.get("reading_logs", {}).get("stopped_reading"))
+    statsd.gauge("participation.reading_logs.want_to_read.distinct.hourly.total", stats.get("distinct_reading_logs", {}).get("want_to_read"))
+    statsd.gauge("participation.reading_logs.currently_reading.distinct.hourly.total", stats.get("distinct_reading_logs", {}).get("currently_reading"))
+    statsd.gauge("participation.reading_logs.already_read.distinct.hourly.total", stats.get("distinct_reading_logs", {}).get("already_read"))
+    statsd.gauge("participation.reading_logs.stopped_reading.distinct.hourly.total", stats.get("distinct_reading_logs", {}).get("stopped_reading"))
+
+def gather_participation_scores() -> dict[str, str]:
+    results = {}
+    results.update(calc_star_rating_counts())
+    results.update(calc_reading_log_counts())
+    results.update(calc_list_counts())
+    return results
+
+def calc_star_rating_counts() -> dict[str, str]:
+    results = {}
+    oldb = db.get_db()
+    total_ratings_query = """
+        select count(*) from ratings
+        WHERE created >= date_trunc('hour', now() - interval '1 hour')
+            AND created <  date_trunc('hour', now());
+    """
+    totals = oldb.query(total_ratings_query)
+    results['star_ratings'] = list(totals)[0]['count']
+
+    distinct_raters_query = """
+        select count(distinct username) from ratings
+        WHERE created >= date_trunc('hour', now() - interval '1 hour')
+            AND created <  date_trunc('hour', now());
+    """
+    distinct_totals = oldb.query(distinct_raters_query)
+    results["distinct_star_ratings"] = list(distinct_totals)[0]['count']
+
+    return results
+
+def calc_reading_log_counts() -> dict[str, str]:
+    def normalize_shelf_name(shelf_name: str) -> str:
+        return shelf_name.lower().replace(" ", "_")
+
+    results = {}
+    oldb = db.get_db()
+    total_books_logged_query = """
+        select count(bb.bookshelf_id) as cnt,
+               b.name as bookshelf_name
+        from bookshelves b
+        left join bookshelves_books bb
+            on bb.bookshelf_id = b.id
+            and bb.created >= date_trunc('hour', now() - interval '1 hour')
+            and bb.created <  date_trunc('hour', now())
+        group by b.id, b.name
+        order by b.id;
+    """
+    totals = oldb.query(total_books_logged_query)
+    results['reading_logs'] = {
+        normalize_shelf_name(i.bookshelf_name): i.cnt for i in totals
+    }
+
+    distinct_readers_logging_query = """
+        select count(distinct bb.username) as cnt,
+           b.name as bookshelf_name
+        from bookshelves b
+        left join bookshelves_books bb
+            on bb.bookshelf_id = b.id
+            and bb.created >= date_trunc('hour', now() - interval '1 hour')
+            and bb.created <  date_trunc('hour', now())
+        group by b.id, b.name
+        order by b.id;
+    """
+    distinct_totals = oldb.query(distinct_readers_logging_query)
+    results["distinct_reading_logs"] = {
+        normalize_shelf_name(i.bookshelf_name): i.cnt for i in distinct_totals
+    }
+
+    return results
+
+def calc_list_counts() -> dict[str, str]:
+    results = {}
+    oldb = db.get_db()
+    total_lists_query = """
+        select count(*) from thing where type = (select id from thing where key = '/type/list')
+            AND created >= date_trunc('hour', now() - interval '1 hour')
+            AND created <  date_trunc('hour', now());
+    """
+    totals = oldb.query(total_lists_query)
+    results["list_counts"] = list(totals)[0]['count']
+
+    distinct_creators_query = """
+        SELECT COUNT(DISTINCT split_part(key, '/', 3)) AS distinct_list_creators
+        FROM thing
+        WHERE type = (SELECT id FROM thing WHERE key = '/type/list')
+            AND created >= date_trunc('hour', now() - interval '1 hour')
+            AND created <  date_trunc('hour', now());
+    """
+    distinct_totals = oldb.query(distinct_creators_query)
+    results["distinct_list_counts"] = list(distinct_totals)[0]['distinct_list_creators']
+
+    return results
+
+def calc_edit_counts() -> dict[str, str]:
+    raise NotImplementedError()

--- a/openlibrary/admin/vitals.py
+++ b/openlibrary/admin/vitals.py
@@ -2,6 +2,8 @@ import yaml
 from statsd import StatsClient
 
 from openlibrary.core import db
+from openlibrary.core.bookshelves import Bookshelves
+from openlibrary.core.ratings import Ratings
 
 STATSD_EVENT_PREFIX = "stats.ol.participation"
 
@@ -73,70 +75,9 @@ def write_to_statsd(configfile, stats):
 
 def gather_participation_scores() -> dict[str, int | dict[str, int]]:
     results = {}
-    results.update(calc_star_rating_counts())
-    results.update(calc_reading_log_counts())
+    results.update(Ratings.calc_star_rating_counts())
+    results.update(Bookshelves.calc_reading_log_counts())
     results.update(calc_list_counts())
-    return results
-
-def calc_star_rating_counts() -> dict[str, int]:
-    results = {}
-    oldb = db.get_db()
-    total_ratings_query = """
-        select count(*) from ratings
-        WHERE created >= date_trunc('hour', now() - interval '1 hour')
-            AND created <  date_trunc('hour', now());
-    """
-    totals = oldb.query(total_ratings_query)
-    results['star_ratings'] = next(iter(totals))['count']
-
-    distinct_raters_query = """
-        select count(distinct username) from ratings
-        WHERE created >= date_trunc('hour', now() - interval '1 hour')
-            AND created <  date_trunc('hour', now());
-    """
-    distinct_totals = oldb.query(distinct_raters_query)
-    results["distinct_star_ratings"] = next(iter(distinct_totals))['count']
-
-    return results
-
-def calc_reading_log_counts() -> dict[str, dict[str, int]]:
-    def normalize_shelf_name(shelf_name: str) -> str:
-        return shelf_name.lower().replace(" ", "_")
-
-    results = {}
-    oldb = db.get_db()
-    total_books_logged_query = """
-        select count(bb.bookshelf_id) as cnt,
-               b.name as bookshelf_name
-        from bookshelves b
-        left join bookshelves_books bb
-            on bb.bookshelf_id = b.id
-            and bb.created >= date_trunc('hour', now() - interval '1 hour')
-            and bb.created <  date_trunc('hour', now())
-        group by b.id, b.name
-        order by b.id;
-    """
-    totals = oldb.query(total_books_logged_query)
-    results['reading_logs'] = {
-        normalize_shelf_name(i.bookshelf_name): i.cnt for i in totals
-    }
-
-    distinct_readers_logging_query = """
-        select count(distinct bb.username) as cnt,
-           b.name as bookshelf_name
-        from bookshelves b
-        left join bookshelves_books bb
-            on bb.bookshelf_id = b.id
-            and bb.created >= date_trunc('hour', now() - interval '1 hour')
-            and bb.created <  date_trunc('hour', now())
-        group by b.id, b.name
-        order by b.id;
-    """
-    distinct_totals = oldb.query(distinct_readers_logging_query)
-    results["distinct_reading_logs"] = {
-        normalize_shelf_name(i.bookshelf_name): i.cnt for i in distinct_totals
-    }
-
     return results
 
 def calc_list_counts() -> dict[str, int]:
@@ -161,6 +102,3 @@ def calc_list_counts() -> dict[str, int]:
     results["distinct_list_counts"] = next(iter(distinct_totals))['distinct_list_creators']
 
     return results
-
-def calc_edit_counts() -> dict[str, str]:
-    raise NotImplementedError()

--- a/openlibrary/admin/vitals.py
+++ b/openlibrary/admin/vitals.py
@@ -3,10 +3,12 @@ from statsd import StatsClient
 
 from openlibrary.core import db
 
+STATSD_EVENT_PREFIX = "stats.ol.participation"
 
 def write_to_statsd(configfile, stats):
     def configure_statsd(_configfile):
-        configs = yaml.safe_load(_configfile)
+        with open(_configfile) as f:
+            configs = yaml.safe_load(f)
         url = configs.get("admin", {}).get("statsd_server", None)
         if not url:
             raise KeyError("StatsD server not configured")
@@ -14,30 +16,69 @@ def write_to_statsd(configfile, stats):
         return StatsClient(split_url[0], split_url[1])
 
     statsd = configure_statsd(configfile)
-    # Star ratings
-    statsd.gauge("participation.star_ratings.hourly.total", stats.get("star_ratings"))
-    statsd.gauge("participation.star_ratings.distinct.hourly.total", stats.get("distinct_star_ratings"))
-    # List creation
-    statsd.gauge("participation.lists.hourly.total", stats.get("list_counts"))
-    statsd.gauge("participation.lists.distinct.hourly.total", stats.get("distinct_list_counts"))
-    # Reading log counts
-    statsd.gauge("participation.reading_logs.want_to_read.hourly.total", stats.get("reading_logs", {}).get("want_to_read"))
-    statsd.gauge("participation.reading_logs.currently_reading.hourly.total", stats.get("reading_logs", {}).get("currently_reading"))
-    statsd.gauge("participation.reading_logs.already_read.hourly.total", stats.get("reading_logs", {}).get("already_read"))
-    statsd.gauge("participation.reading_logs.stopped_reading.hourly.total", stats.get("reading_logs", {}).get("stopped_reading"))
-    statsd.gauge("participation.reading_logs.want_to_read.distinct.hourly.total", stats.get("distinct_reading_logs", {}).get("want_to_read"))
-    statsd.gauge("participation.reading_logs.currently_reading.distinct.hourly.total", stats.get("distinct_reading_logs", {}).get("currently_reading"))
-    statsd.gauge("participation.reading_logs.already_read.distinct.hourly.total", stats.get("distinct_reading_logs", {}).get("already_read"))
-    statsd.gauge("participation.reading_logs.stopped_reading.distinct.hourly.total", stats.get("distinct_reading_logs", {}).get("stopped_reading"))
 
-def gather_participation_scores() -> dict[str, str]:
+    # Star ratings
+    statsd.gauge(
+        f"{STATSD_EVENT_PREFIX}.star_ratings.hourly.total",
+        stats.get("star_ratings")
+    )
+    statsd.gauge(
+        f"{STATSD_EVENT_PREFIX}.star_ratings.distinct.hourly.total",
+        stats.get("distinct_star_ratings")
+    )
+
+    # List creation
+    statsd.gauge(
+        f"{STATSD_EVENT_PREFIX}.lists.hourly.total",
+        stats.get("list_counts")
+    )
+    statsd.gauge(
+        f"{STATSD_EVENT_PREFIX}.lists.distinct.hourly.total",
+        stats.get("distinct_list_counts")
+    )
+
+    # Reading log counts
+    statsd.gauge(
+        f"{STATSD_EVENT_PREFIX}.reading_logs.want_to_read.hourly.total",
+        stats.get("reading_logs", {}).get("want_to_read")
+    )
+    statsd.gauge(
+        f"{STATSD_EVENT_PREFIX}.reading_logs.currently_reading.hourly.total",
+        stats.get("reading_logs", {}).get("currently_reading")
+    )
+    statsd.gauge(
+        f"{STATSD_EVENT_PREFIX}.reading_logs.already_read.hourly.total",
+        stats.get("reading_logs", {}).get("already_read")
+    )
+    statsd.gauge(
+        f"{STATSD_EVENT_PREFIX}.reading_logs.stopped_reading.hourly.total",
+        stats.get("reading_logs", {}).get("stopped_reading")
+    )
+    statsd.gauge(
+        f"{STATSD_EVENT_PREFIX}.reading_logs.want_to_read.distinct.hourly.total",
+        stats.get("distinct_reading_logs", {}).get("want_to_read")
+    )
+    statsd.gauge(
+        f"{STATSD_EVENT_PREFIX}.reading_logs.currently_reading.distinct.hourly.total",
+        stats.get("distinct_reading_logs", {}).get("currently_reading")
+    )
+    statsd.gauge(
+        f"{STATSD_EVENT_PREFIX}.reading_logs.already_read.distinct.hourly.total",
+             stats.get("distinct_reading_logs", {}).get("already_read")
+    )
+    statsd.gauge(
+        f"{STATSD_EVENT_PREFIX}.reading_logs.stopped_reading.distinct.hourly.total",
+        stats.get("distinct_reading_logs", {}).get("stopped_reading")
+    )
+
+def gather_participation_scores() -> dict[str, int | dict[str, int]]:
     results = {}
     results.update(calc_star_rating_counts())
     results.update(calc_reading_log_counts())
     results.update(calc_list_counts())
     return results
 
-def calc_star_rating_counts() -> dict[str, str]:
+def calc_star_rating_counts() -> dict[str, int]:
     results = {}
     oldb = db.get_db()
     total_ratings_query = """
@@ -46,7 +87,7 @@ def calc_star_rating_counts() -> dict[str, str]:
             AND created <  date_trunc('hour', now());
     """
     totals = oldb.query(total_ratings_query)
-    results['star_ratings'] = list(totals)[0]['count']
+    results['star_ratings'] = next(iter(totals))['count']
 
     distinct_raters_query = """
         select count(distinct username) from ratings
@@ -54,11 +95,11 @@ def calc_star_rating_counts() -> dict[str, str]:
             AND created <  date_trunc('hour', now());
     """
     distinct_totals = oldb.query(distinct_raters_query)
-    results["distinct_star_ratings"] = list(distinct_totals)[0]['count']
+    results["distinct_star_ratings"] = next(iter(distinct_totals))['count']
 
     return results
 
-def calc_reading_log_counts() -> dict[str, str]:
+def calc_reading_log_counts() -> dict[str, dict[str, int]]:
     def normalize_shelf_name(shelf_name: str) -> str:
         return shelf_name.lower().replace(" ", "_")
 
@@ -98,7 +139,7 @@ def calc_reading_log_counts() -> dict[str, str]:
 
     return results
 
-def calc_list_counts() -> dict[str, str]:
+def calc_list_counts() -> dict[str, int]:
     results = {}
     oldb = db.get_db()
     total_lists_query = """
@@ -107,7 +148,7 @@ def calc_list_counts() -> dict[str, str]:
             AND created <  date_trunc('hour', now());
     """
     totals = oldb.query(total_lists_query)
-    results["list_counts"] = list(totals)[0]['count']
+    results["list_counts"] = next(iter(totals))['count']
 
     distinct_creators_query = """
         SELECT COUNT(DISTINCT split_part(key, '/', 3)) AS distinct_list_creators
@@ -117,7 +158,7 @@ def calc_list_counts() -> dict[str, str]:
             AND created <  date_trunc('hour', now());
     """
     distinct_totals = oldb.query(distinct_creators_query)
-    results["distinct_list_counts"] = list(distinct_totals)[0]['distinct_list_creators']
+    results["distinct_list_counts"] = next(iter(distinct_totals))['distinct_list_creators']
 
     return results
 

--- a/openlibrary/admin/vitals.py
+++ b/openlibrary/admin/vitals.py
@@ -7,6 +7,7 @@ from openlibrary.core.ratings import Ratings
 
 STATSD_EVENT_PREFIX = "stats.ol.participation"
 
+
 def write_to_statsd(configfile, stats):
     def configure_statsd(_configfile):
         with open(_configfile) as f:
@@ -20,58 +21,23 @@ def write_to_statsd(configfile, stats):
     statsd = configure_statsd(configfile)
 
     # Star ratings
-    statsd.gauge(
-        f"{STATSD_EVENT_PREFIX}.star_ratings.hourly.total",
-        stats.get("star_ratings")
-    )
-    statsd.gauge(
-        f"{STATSD_EVENT_PREFIX}.star_ratings.distinct.hourly.total",
-        stats.get("distinct_star_ratings")
-    )
+    statsd.gauge(f"{STATSD_EVENT_PREFIX}.star_ratings.hourly.total", stats.get("star_ratings"))
+    statsd.gauge(f"{STATSD_EVENT_PREFIX}.star_ratings.distinct.hourly.total", stats.get("distinct_star_ratings"))
 
     # List creation
-    statsd.gauge(
-        f"{STATSD_EVENT_PREFIX}.lists.hourly.total",
-        stats.get("list_counts")
-    )
-    statsd.gauge(
-        f"{STATSD_EVENT_PREFIX}.lists.distinct.hourly.total",
-        stats.get("distinct_list_counts")
-    )
+    statsd.gauge(f"{STATSD_EVENT_PREFIX}.lists.hourly.total", stats.get("list_counts"))
+    statsd.gauge(f"{STATSD_EVENT_PREFIX}.lists.distinct.hourly.total", stats.get("distinct_list_counts"))
 
     # Reading log counts
-    statsd.gauge(
-        f"{STATSD_EVENT_PREFIX}.reading_logs.want_to_read.hourly.total",
-        stats.get("reading_logs", {}).get("want_to_read")
-    )
-    statsd.gauge(
-        f"{STATSD_EVENT_PREFIX}.reading_logs.currently_reading.hourly.total",
-        stats.get("reading_logs", {}).get("currently_reading")
-    )
-    statsd.gauge(
-        f"{STATSD_EVENT_PREFIX}.reading_logs.already_read.hourly.total",
-        stats.get("reading_logs", {}).get("already_read")
-    )
-    statsd.gauge(
-        f"{STATSD_EVENT_PREFIX}.reading_logs.stopped_reading.hourly.total",
-        stats.get("reading_logs", {}).get("stopped_reading")
-    )
-    statsd.gauge(
-        f"{STATSD_EVENT_PREFIX}.reading_logs.want_to_read.distinct.hourly.total",
-        stats.get("distinct_reading_logs", {}).get("want_to_read")
-    )
-    statsd.gauge(
-        f"{STATSD_EVENT_PREFIX}.reading_logs.currently_reading.distinct.hourly.total",
-        stats.get("distinct_reading_logs", {}).get("currently_reading")
-    )
-    statsd.gauge(
-        f"{STATSD_EVENT_PREFIX}.reading_logs.already_read.distinct.hourly.total",
-             stats.get("distinct_reading_logs", {}).get("already_read")
-    )
-    statsd.gauge(
-        f"{STATSD_EVENT_PREFIX}.reading_logs.stopped_reading.distinct.hourly.total",
-        stats.get("distinct_reading_logs", {}).get("stopped_reading")
-    )
+    statsd.gauge(f"{STATSD_EVENT_PREFIX}.reading_logs.want_to_read.hourly.total", stats.get("reading_logs", {}).get("want_to_read"))
+    statsd.gauge(f"{STATSD_EVENT_PREFIX}.reading_logs.currently_reading.hourly.total", stats.get("reading_logs", {}).get("currently_reading"))
+    statsd.gauge(f"{STATSD_EVENT_PREFIX}.reading_logs.already_read.hourly.total", stats.get("reading_logs", {}).get("already_read"))
+    statsd.gauge(f"{STATSD_EVENT_PREFIX}.reading_logs.stopped_reading.hourly.total", stats.get("reading_logs", {}).get("stopped_reading"))
+    statsd.gauge(f"{STATSD_EVENT_PREFIX}.reading_logs.want_to_read.distinct.hourly.total", stats.get("distinct_reading_logs", {}).get("want_to_read"))
+    statsd.gauge(f"{STATSD_EVENT_PREFIX}.reading_logs.currently_reading.distinct.hourly.total", stats.get("distinct_reading_logs", {}).get("currently_reading"))
+    statsd.gauge(f"{STATSD_EVENT_PREFIX}.reading_logs.already_read.distinct.hourly.total", stats.get("distinct_reading_logs", {}).get("already_read"))
+    statsd.gauge(f"{STATSD_EVENT_PREFIX}.reading_logs.stopped_reading.distinct.hourly.total", stats.get("distinct_reading_logs", {}).get("stopped_reading"))
+
 
 def gather_participation_scores() -> dict[str, int | dict[str, int]]:
     results = {}
@@ -79,6 +45,7 @@ def gather_participation_scores() -> dict[str, int | dict[str, int]]:
     results.update(Bookshelves.calc_reading_log_counts())
     results.update(calc_list_counts())
     return results
+
 
 def calc_list_counts() -> dict[str, int]:
     results = {}
@@ -89,7 +56,7 @@ def calc_list_counts() -> dict[str, int]:
             AND created <  date_trunc('hour', now());
     """
     totals = oldb.query(total_lists_query)
-    results["list_counts"] = next(iter(totals))['count']
+    results["list_counts"] = next(iter(totals))["count"]
 
     distinct_creators_query = """
         SELECT COUNT(DISTINCT split_part(key, '/', 3)) AS distinct_list_creators
@@ -99,6 +66,6 @@ def calc_list_counts() -> dict[str, int]:
             AND created <  date_trunc('hour', now());
     """
     distinct_totals = oldb.query(distinct_creators_query)
-    results["distinct_list_counts"] = next(iter(distinct_totals))['distinct_list_creators']
+    results["distinct_list_counts"] = next(iter(distinct_totals))["distinct_list_creators"]
 
     return results

--- a/openlibrary/admin/vitals.py
+++ b/openlibrary/admin/vitals.py
@@ -40,7 +40,7 @@ def write_to_statsd(configfile, stats):
 
 
 def gather_participation_scores() -> dict[str, int | dict[str, int]]:
-    results = {}
+    results: dict[str, int | dict[str, int]] = {}
     results.update(Ratings.calc_star_rating_counts())
     results.update(Bookshelves.calc_reading_log_counts())
     results.update(calc_list_counts())

--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -719,3 +719,44 @@ class Bookshelves(db.CommonExtras):
         )
         result = oldb.query(query)
         return list(result)
+
+    @classmethod
+    def calc_reading_log_counts(cls) -> dict[str, dict[str, int]]:
+        def normalize_shelf_name(shelf_name: str) -> str:
+            return shelf_name.lower().replace(" ", "_")
+
+        results = {}
+        oldb = db.get_db()
+        total_books_logged_query = """
+            select count(bb.bookshelf_id) as cnt,
+                   b.name as bookshelf_name
+            from bookshelves b
+            left join bookshelves_books bb
+                on bb.bookshelf_id = b.id
+                and bb.created >= date_trunc('hour', now() - interval '1 hour')
+                and bb.created <  date_trunc('hour', now())
+            group by b.id, b.name
+            order by b.id;
+        """
+        totals = oldb.query(total_books_logged_query)
+        results['reading_logs'] = {
+            normalize_shelf_name(i.bookshelf_name): i.cnt for i in totals
+        }
+
+        distinct_readers_logging_query = """
+            select count(distinct bb.username) as cnt,
+                b.name as bookshelf_name
+            from bookshelves b
+            left join bookshelves_books bb
+                on bb.bookshelf_id = b.id
+                and bb.created >= date_trunc('hour', now() - interval '1 hour')
+                and bb.created <  date_trunc('hour', now())
+            group by b.id, b.name
+            order by b.id;
+        """
+        distinct_totals = oldb.query(distinct_readers_logging_query)
+        results["distinct_reading_logs"] = {
+            normalize_shelf_name(i.bookshelf_name): i.cnt for i in distinct_totals
+        }
+
+        return results

--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -739,9 +739,7 @@ class Bookshelves(db.CommonExtras):
             order by b.id;
         """
         totals = oldb.query(total_books_logged_query)
-        results['reading_logs'] = {
-            normalize_shelf_name(i.bookshelf_name): i.cnt for i in totals
-        }
+        results["reading_logs"] = {normalize_shelf_name(i.bookshelf_name): i.cnt for i in totals}
 
         distinct_readers_logging_query = """
             select count(distinct bb.username) as cnt,
@@ -755,8 +753,6 @@ class Bookshelves(db.CommonExtras):
             order by b.id;
         """
         distinct_totals = oldb.query(distinct_readers_logging_query)
-        results["distinct_reading_logs"] = {
-            normalize_shelf_name(i.bookshelf_name): i.cnt for i in distinct_totals
-        }
+        results["distinct_reading_logs"] = {normalize_shelf_name(i.bookshelf_name): i.cnt for i in distinct_totals}
 
         return results

--- a/openlibrary/core/ratings.py
+++ b/openlibrary/core/ratings.py
@@ -203,7 +203,7 @@ class Ratings(db.CommonExtras):
                 AND created < date_trunc('hour', now());
         """
         totals = oldb.query(total_ratings_query)
-        results['star_ratings'] = next(iter(totals))['count']
+        results["star_ratings"] = next(iter(totals))["count"]
 
         distinct_raters_query = """
             select count(distinct username) from ratings
@@ -211,6 +211,6 @@ class Ratings(db.CommonExtras):
                 AND created < date_trunc('hour', now());
         """
         distinct_totals = oldb.query(distinct_raters_query)
-        results["distinct_star_ratings"] = next(iter(distinct_totals))['count']
+        results["distinct_star_ratings"] = next(iter(distinct_totals))["count"]
 
         return results

--- a/openlibrary/core/ratings.py
+++ b/openlibrary/core/ratings.py
@@ -192,3 +192,25 @@ class Ratings(db.CommonExtras):
         else:
             where = "work_id=$work_id AND username=$username"
             return oldb.update("ratings", where=where, rating=rating, vars=data)
+
+    @classmethod
+    def calc_star_rating_counts(cls) -> dict[str, int]:
+        results = {}
+        oldb = db.get_db()
+        total_ratings_query = """
+            select count(*) from ratings
+            WHERE created >= date_trunc('hour', now() - interval '1 hour')
+                AND created < date_trunc('hour', now());
+        """
+        totals = oldb.query(total_ratings_query)
+        results['star_ratings'] = next(iter(totals))['count']
+
+        distinct_raters_query = """
+            select count(distinct username) from ratings
+            WHERE created >= date_trunc('hour', now() - interval '1 hour')
+                AND created < date_trunc('hour', now());
+        """
+        distinct_totals = oldb.query(distinct_raters_query)
+        results["distinct_star_ratings"] = next(iter(distinct_totals))['count']
+
+        return results


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Advances #12281

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Gathers and writes the following statistics to `statsd`:

- Total lists created during the last hour
- Total distinct list creators during the last hour
- Total star ratings left during the last hour
- Total distinct star raters during the last hour
- Total reading log events during the last hour
- Total distinct patrons logging books during the last hour

Reading log event counts are broken down by shelf name.

These stats will only be gathered/persisted during the **hourly** store counts cron jobs (where `ndays == 1`).

Data returned by the new function will look something like this:
```
{
  'star_ratings': 7, 
  'distinct_star_ratings': 2, 
  'reading_logs': {
    'want_to_read': 80, 
    'currently_reading': 38, 
    'already_read': 8, 
    'stopped_reading': 0
  }, 
  'distinct_reading_logs': {
    'want_to_read': 52, 
    'currently_reading': 10, 
    'already_read': 3, 
    'stopped_reading': 0
  }, 
  'list_counts': 3, 
  'distinct_list_counts': 3
}
```

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
