### PR TITLE
fix(markdown): stop WYSIWYG hard breaks rendering as literal "<br />"

### DIFF
--- a/openlibrary/components/lit/editor-core.js
+++ b/openlibrary/components/lit/editor-core.js
@@ -8,6 +8,7 @@ import { Markdown } from 'tiptap-markdown';
 import Placeholder from '@tiptap/extension-placeholder';
 import Image from '@tiptap/extension-image';
 import { HtmlBlock } from './html-block.js';
+import { OLHardBreak } from './hard-break.js';
 
 /**
  * Creates a configured Tiptap editor instance.
@@ -29,8 +30,12 @@ export function createEditor({ element, content, placeholder, onUpdate, onTransa
                 codeBlock: enableCode ? undefined : false,
                 code: enableCode ? undefined : false,
                 link: { openOnClick: false, autolink: true },
-                strike: false
+                strike: false,
+                // Replaced with OLHardBreak below so hard breaks serialize to
+                // OLMarkdown's dialect (a bare newline, not CommonMark "\").
+                hardBreak: false
             }),
+            OLHardBreak,
             Markdown.configure({
                 breaks: true,
                 linkify: true

--- a/openlibrary/components/lit/hard-break.js
+++ b/openlibrary/components/lit/hard-break.js
@@ -1,0 +1,34 @@
+import { HardBreak } from '@tiptap/extension-hard-break';
+
+/**
+ * OLHardBreak – a hard-break node that serializes to OLMarkdown's dialect.
+ *
+ * The server-side display renderer (OLMarkdown, a vendored Python-Markdown)
+ * treats every newline inside a paragraph as a `<br>` and has no escape syntax
+ * for hard breaks. tiptap-markdown's default serializer emits CommonMark's
+ * `\<newline>`; that trailing backslash makes OLMarkdown escape the `<` of the
+ * `<br/>` it injects, so readers see the literal text `<br />`.
+ *
+ * Emitting a bare newline instead keeps the two renderers in agreement, and
+ * re-saving a page through the editor cleans up any legacy backslash/`<br>`
+ * cruft. See internetarchive/openlibrary#13074.
+ */
+export const OLHardBreak = HardBreak.extend({
+    addStorage() {
+        return {
+            markdown: {
+                serialize(state, node, parent, index) {
+                    for (let i = index + 1; i < parent.childCount; i++) {
+                        if (parent.child(i).type !== node.type) {
+                            state.write('\n');
+                            return;
+                        }
+                    }
+                },
+                parse: {
+                    // handled by markdown-it
+                },
+            },
+        };
+    },
+});

--- a/openlibrary/core/olmarkdown.py
+++ b/openlibrary/core/olmarkdown.py
@@ -64,12 +64,28 @@ FENCED_CODE_PREPROCESSOR = FencedCodePreprocessor()
 class LineBreaksPreprocessor(markdown.Preprocessor):
     def run(self, lines):
         for i in range(len(lines) - 1):
-            # append <br/> to all lines expect blank lines and the line before blankline.
+            # Only consider non-blank lines followed by another non-blank line,
+            # and never touch indented code (tabbed) lines.
+            if not (lines[i].strip() and lines[i + 1].strip()):
+                continue
+            if markdown.RE.regExp["tabbed"].match(lines[i]):
+                continue
+
+            # A lone trailing backslash is CommonMark's hard-break marker, which
+            # the Tiptap WYSIWYG editor emits between wrapped lines. OLMarkdown
+            # has no such syntax: left alone the backslash either escapes the "<"
+            # of the <br /> we append (so the tag renders as the literal text
+            # "<br />" to readers) or shows as a stray "\". Drop it either way so
+            # the two renderers agree. See issue #13074.
+            lines[i] = re.sub(r"(?<!\\)\\$", "", lines[i])
+
             if (
-                lines[i].strip()
-                and lines[i + 1].strip()
-                and not markdown.RE.regExp["tabbed"].match(lines[i])
-                and not LINK_REFERENCE_RE.match(lines[i])
+                not LINK_REFERENCE_RE.match(lines[i])
+                # Don't glue a hard break onto a line that immediately precedes a
+                # link-reference definition. This runs before REFERENCE_PREPROCESSOR
+                # strips those definitions, so a <br /> appended here gets orphaned
+                # inside the reference block and leaks into the page as literal markup.
+                and not LINK_REFERENCE_RE.match(lines[i + 1])
                 and not lines[i].lstrip().startswith(">")
             ):
                 lines[i] += "<br />"

--- a/openlibrary/tests/core/test_olmarkdown.py
+++ b/openlibrary/tests/core/test_olmarkdown.py
@@ -18,6 +18,63 @@ def test_olmarkdown():
     assert md("a\nb") == p("a<br/>\n   b")
 
 
+def test_olmarkdown_no_br_leak_into_reference_block():
+    """Regression: a hard line break must not be glued onto a line that
+    immediately precedes a markdown link-reference definition.
+
+    LineBreaksPreprocessor runs before REFERENCE_PREPROCESSOR strips the
+    ``[id]: url`` definitions, so a ``<br />`` appended to the line above a
+    reference block gets orphaned inside it and leaks into the rendered page
+    as literal markup. This was visible at the bottom of /help/faq/editing
+    (internetarchive/openlibrary#13074), where a wrapped/malformed footnote
+    block rendered ``...Tortilla<br /> [24]:`` etc.
+    """
+
+    def md(text):
+        return OLMarkdown(text).convert().strip()
+
+    # Text line immediately followed by a reference definition: no <br>.
+    assert md("foo\n  [1]: https://example.com") == "<p>foo\n</p>"
+
+    # A wrapped reference value (continuation line sitting between two
+    # definitions, carrying the editor's "\" hard-break marker) must come out
+    # clean: no leaked <br /> and no stray backslash.
+    body = (
+        "intro\n\n"
+        "  [23]: https://openlibrary.org/works/OL23185W/Short_Novels\n"
+        "(Cannery_Row_Of_Mice_and_Men_Tortilla\\\n"
+        "  [24]: https://openlibrary.org/works/OL14876179W/Adventures\n"
+    )
+    rendered = md(body)
+    assert "<br" not in rendered
+    assert "\\" not in rendered
+
+    # Sanity: an ordinary line break between two plain lines is untouched.
+    assert md("a\nb") == "<p>a<br/>\n   b\n</p>"
+
+
+def test_olmarkdown_commonmark_hard_break_does_not_leak_br():
+    """Regression: a CommonMark hard break (trailing ``\\``) must render as a
+    line break, not the literal text ``<br />``.
+
+    The Tiptap WYSIWYG editor serializes hard breaks as ``\\`` + newline. With
+    no handling, OLMarkdown appends its own ``<br />`` right after the
+    backslash, the backslash escapes the ``<``, and readers see the literal
+    string ``<br />`` (internetarchive/openlibrary#13074).
+    """
+
+    def md(text):
+        return OLMarkdown(text).convert().strip()
+
+    out = md("first line\\\nsecond line")
+    assert "&lt;br" not in out  # no escaped/literal <br /> shown to the reader
+    assert "\\" not in out  # the hard-break backslash is consumed
+    assert out == "<p>first line<br/>\n   second line\n</p>"
+
+    # A genuine escaped backslash (``\\``) is preserved, not swallowed.
+    assert "\\" in md("a\\\\b\nc")
+
+
 def test_fenced_code_preprocessor():
     pre = FencedCodePreprocessor()
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@internetarchive/elements": "^0.2.5",
         "@sentry/browser": "^10.60.0",
         "@tiptap/core": "^3.20.4",
+        "@tiptap/extension-hard-break": "^3.26.0",
         "@tiptap/extension-image": "^3.22.1",
         "@tiptap/extension-placeholder": "^3.20.4",
         "@tiptap/pm": "^3.20.4",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@internetarchive/elements": "^0.2.5",
     "@sentry/browser": "^10.60.0",
     "@tiptap/core": "^3.20.4",
+    "@tiptap/extension-hard-break": "^3.26.0",
     "@tiptap/extension-image": "^3.22.1",
     "@tiptap/extension-placeholder": "^3.20.4",
     "@tiptap/pm": "^3.20.4",

--- a/tests/unit/js/OLMarkdownEditor.test.js
+++ b/tests/unit/js/OLMarkdownEditor.test.js
@@ -13,6 +13,7 @@ import StarterKit from '@tiptap/starter-kit';
 import { Markdown } from 'tiptap-markdown';
 import Image from '@tiptap/extension-image';
 import { HtmlBlock } from '../../../openlibrary/components/lit/html-block.js';
+import { OLHardBreak } from '../../../openlibrary/components/lit/hard-break.js';
 
 /* ------------------------------------------------------------------ */
 /*  Helper: create an editor identical to production, roundtrip text   */
@@ -30,8 +31,10 @@ function createTestEditor(markdownContent, { enableCode = false } = {}) {
                 codeBlock: enableCode ? undefined : false,
                 code: enableCode ? undefined : false,
                 link: { openOnClick: false, autolink: true },
-                strike: false
+                strike: false,
+                hardBreak: false
             }),
+            OLHardBreak,
             Markdown.configure({
                 breaks: true,
                 linkify: true
@@ -438,6 +441,26 @@ Visit [the website](https://example.org) for more.
         // Should contain the same content
         expect(output.length).toBeGreaterThan(input.length * 0.9);
         expect(output).toContain('books and reading');
+    });
+
+    /* ---------- hard breaks (OLMarkdown dialect) ---------- */
+
+    test('hard break serializes as a bare newline, not CommonMark "\\"', () => {
+        // OLMarkdown treats every newline as a <br>. Emitting CommonMark's
+        // "\<newline>" makes the display renderer escape its own injected
+        // <br/> and show a literal "<br />" to readers. Regression for
+        // internetarchive/openlibrary#13074.
+        const output = roundTrip('first line\nsecond line');
+        expect(output).not.toContain('\\');
+        expect(output).not.toContain('<br');
+        expect(normalize(output)).toBe('first line\nsecond line');
+    });
+
+    test('multi-line paragraph round-trips without backslashes', () => {
+        const input = 'line one\nline two\nline three';
+        const output = roundTrip(input);
+        expect(output).not.toContain('\\');
+        expect(normalize(output)).toBe(input);
     });
 });
 


### PR DESCRIPTION
## Closes #13074

### Problem
The help/FAQ pages (e.g. [`/help/faq/editing`](https://openlibrary.org/help/faq/editing)) render literal `<br />` as visible text. The root cause is that Open Library has **two markdown engines that disagree on hard breaks**:

| | Engine | Hard break |
|---|---|---|
| **Display** | `OLMarkdown` (vendored Python-Markdown) | every newline → injected `<br/>`; no escape syntax |
| **Editing** | Tiptap WYSIWYG (`tiptap-markdown` / markdown-it) | serializes a hard break as CommonMark `\` + newline |

When editor-saved content is displayed, OLMarkdown appends its `<br/>` right after the editor's trailing `\`. The backslash escapes the `<`, so the tag renders as the literal text `<br />`. Verified against the real renderer:

```
editor saves:  'first line\\\nsecond line'
OLMarkdown  →  'first line&lt;br /&gt;\n   second line'   # literal <br /> shown to the reader
```

This affects **every multi-line paragraph edited via the WYSIWYG editor**, not just the orphaned footnote block on that FAQ page (the page history's *"stray forward slashes removal"* edit is the same backslashes).

### Steps to reproduce

**Via the WYSIWYG editor** (the real-world path — any page that mounts `<ol-markdown-editor>`: a `/type/page` wiki/help page, or a work description):
1. Open the editor and type a line, press **Shift+Enter** (a *hard break* — plain **Enter** makes a new paragraph, which is fine), type a second line.
2. Save, then view the rendered page → the line break shows as the literal text `<br />`.
   - Opening an *existing* multi-line page in the editor and simply re-saving also reproduces it: with `breaks: true`, markdown-it turns every existing single-newline line break into a hard-break node, so a plain open→save corrupts the whole page at once.

**Renderer only** (no editor needed) — save page source with a line ending in a single backslash:
```
first line\
second line
```
→ view it and the literal `<br />` appears.

### Fix (editor + renderer)
- **Editor** — new `OLHardBreak` node (`openlibrary/components/lit/hard-break.js`, wired into `editor-core.js`) serializes hard breaks as a bare newline (OLMarkdown's dialect) instead of CommonMark `\`. Re-saving a page through the editor now also **cleans up** legacy backslash/`<br>` cruft.
- **Renderer** — `LineBreaksPreprocessor` (`olmarkdown.py`) normalizes away a lone trailing CommonMark hard-break `\`, so **already-corrupted pages display correctly without needing a re-save** (no leaked `<br />`, no stray `\`). It also no longer glues a `<br/>` onto the line directly above a link-reference definition.
- Added `@tiptap/extension-hard-break` as an explicit dependency (was a transitive/phantom dep via `starter-kit`).

### Tests
- JS round-trip tests (`tests/unit/js/OLMarkdownEditor.test.js`): hard breaks serialize without backslashes/`<br>`.
- Python render tests (`openlibrary/tests/core/test_olmarkdown.py`): the hard-break and reference-block cases.
- Both new test sets were confirmed to **fail without the fix** (see the [verification comment](https://github.com/internetarchive/openlibrary/pull/13076#issuecomment-4848519127) for before/after rendered output and red/green results).

### Notes
- The orphaned footnote block on the FAQ page is still worth deleting from the wiki source; this change makes the renderer degrade gracefully instead of emitting literal markup.
- Longer term, converging on a single markdown engine (e.g. `markdown-it-py` server-side, to match the editor) would remove the dialect mismatch entirely — worth a separate issue.

### Testing
- [x] `npm run test:js` — 88 passed (OLMarkdownEditor suite)
- [x] `pytest openlibrary/tests/core/test_olmarkdown.py` — 5 passed
- [x] `pre-commit` (ruff / mypy / eslint / POT) clean
- [x] Manual before/after on a local dev instance (literal `<br />` → clean line breaks)
