### PR TITLE
Auto-run npm ci when JS dependencies change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,14 +15,17 @@ all: git css js components lit-components i18n
 
 frontend: css js components lit-components
 
-css:
+node_modules: package-lock.json package.json
+	npm ci --no-audit --no-fund
+
+css: node_modules
 	mkdir -p $(BUILD)/css_new
 	BUILD_DIR=$(BUILD)/css_new NODE_ENV=production npx webpack --config webpack.config.css.js
 	mkdir -p $(BUILD)/css
 	rm -rf $(BUILD)/css
 	mv $(BUILD)/css_new $(BUILD)/css
 
-js:
+js: node_modules
 	mkdir -p $(BUILD)/js_new
 	BUILD_DIR=$(BUILD)/js_new NODE_ENV=production npx webpack
 	# This adds FSF licensing for AGPLv3 to our js (for librejs)
@@ -34,14 +37,14 @@ js:
 	rm -rf $(BUILD)/js
 	mv $(BUILD)/js_new $(BUILD)/js
 
-components:
+components: node_modules
 	mkdir -p $(BUILD)/components_new
 	BUILD_DIR=$(BUILD)/components_new npx vite build -c openlibrary/components/vite.config.mjs
 	mkdir -p $(BUILD)/components
 	rm -rf $(BUILD)/components
 	mv $(BUILD)/components_new $(BUILD)/components
 
-lit-components:
+lit-components: node_modules
 	# Regenerate the Custom Elements Manifest (committed; consumed by /developers/design)
 	npx cem analyze
 	mkdir -p $(BUILD)/lit-components_new


### PR DESCRIPTION
## Problem

When a contributor updates `package.json` / `package-lock.json` (adding or updating a JS dependency), the next person who runs `make js`, `make css`, `make frontend`, or the `build-assets` npm script will get a build error — `node_modules` is stale and the new package is missing. This is a common footgun in local dev and CI.

## Solution

Use Make's native timestamp-based dependency tracking to gate `npm ci`:

```makefile
node_modules: package-lock.json package.json
	npm ci --no-audit --no-fund

css: node_modules
js: node_modules
components: node_modules
lit-components: node_modules
```

### How it works

- Make compares `node_modules/`'s mtime against `package-lock.json` and `package.json`.
- If either file is **newer** than `node_modules`, `npm ci` runs before the build target.
- If `node_modules` is already up to date, the rule is skipped — zero overhead.

`npm ci` is used over `npm install` because:
- It installs **exactly** what's in `package-lock.json` (deterministic).
- It fails hard if `package-lock.json` and `package.json` are out of sync.
- It skips the resolution step, making it faster on clean runs.

## How to test

### 1. Idempotent build (no unnecessary installs)

```bash
# Run a build — should NOT trigger npm ci (node_modules is already fresh)
make -n js
# Confirm no "npm ci" line appears, just the webpack build
```

### 2. Stale deps trigger auto-install

```bash
# Simulate a dependency change by touching the lock file
touch package-lock.json

# Dry run confirms npm ci would run
make -n js
# Expected output starts with: npm ci --no-audit --no-fund

# Real run installs deps then builds
make js

# Subsequent runs skip npm ci again
make -n js
# No "npm ci" line
```

### 3. All build targets are covered

```bash
make -n css
make -n components
make -n lit-components
# None of these should show "npm ci" when node_modules is fresh
```

## Trade-offs considered

| Approach | Verdict |
|---|---|
| **`post-checkout` git hook** | Requires every dev to configure it; easy to sidestep. |
| **`prepare` npm script** | Runs on `npm install` only, not on `git pull` with new deps. |
| **Unconditional `npm ci` per build** | Adds ~30s+ to every build when `node_modules` is already fresh. |
| **Make timestamp target (this PR)** | Zero overhead in the common case, automatic, uses existing build tooling. |

Note: Many modern projects sidestep this problem entirely by using **pnpm** (which has a content-addressable store — `pnpm install` is sub-second when the cache is warm, so they just run it unconditionally before every build) or **Yarn Berry Zero-Installs** (zipped packages committed to git — deps are always present after `git pull`). Switching package managers is out of scope here, but worth knowing those options exist if the team ever evaluates alternatives. Docker dev images (install once at image build time) are another common approach. |