### PR TITLE
feat: add progress bar to OlToast and improve alignment of OlToast and OlBanner

### DIFF
--- a/openlibrary/components/lit/OlToast.js
+++ b/openlibrary/components/lit/OlToast.js
@@ -150,9 +150,14 @@ export class OlToast extends LitElement {
             :host {
                 transition: none;
             }
+            .toast__progress {
+                display: none;
+            }
         }
 
         .toast {
+            position: relative;
+            overflow: hidden;
             display: flex;
             align-items: flex-start;
             gap: var(--spacing-inline-md);
@@ -172,6 +177,19 @@ export class OlToast extends LitElement {
                 0 2px 4px 0 var(--icon-link-grey);
         }
 
+        .toast__progress {
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            width: 100%;
+            height: 2px;
+            background-color: currentColor;
+            opacity: 0.35;
+            transform-origin: left;
+            transform: scaleX(var(--toast-progress-scale, 1));
+            transition: transform var(--toast-progress-time, 0ms) linear;
+        }
+
         :host([data-stacked]) .toast {
             width: 100%;
         }
@@ -186,7 +204,7 @@ export class OlToast extends LitElement {
             flex-shrink: 0;
             width: 20px;
             height: 20px;
-            margin-top: 1px; /* optically center against the first text line */
+            margin-top: 4px; /* Centered against the first line of text */
             border-radius: 50%;
             color: var(--white);
         }
@@ -210,6 +228,12 @@ export class OlToast extends LitElement {
                content gets the same treatment */
             font-size: var(--font-size-body-large);
             font-weight: 500;
+
+            /* Align single-line text to center of 28px close button height */
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            min-height: 28px;
         }
 
         .toast__message {
@@ -309,6 +333,15 @@ export class OlToast extends LitElement {
             requestAnimationFrame(() => {
                 this.setAttribute('data-mounted', '');
                 this._announce = true;
+
+                // Start the progress bar transition after the element is mounted and visible
+                if (!this.persistent && this._timerId) {
+                    requestAnimationFrame(() => {
+                        if (this._closing || this._timerId === null) return;
+                        this.style.setProperty('--toast-progress-scale', '0');
+                        this.style.setProperty('--toast-progress-time', `${this._remainingMs}ms`);
+                    });
+                }
             });
         });
     }
@@ -341,7 +374,11 @@ export class OlToast extends LitElement {
     pauseTimer() {
         if (this._timerId) {
             this._clearTimer();
-            this._remainingMs -= Date.now() - this._timerStartedAt;
+            const elapsed = Date.now() - this._timerStartedAt;
+            this._remainingMs = Math.max(0, this._remainingMs - elapsed);
+            const fraction = this._remainingMs / this.timeout;
+            this.style.setProperty('--toast-progress-scale', String(fraction));
+            this.style.setProperty('--toast-progress-time', '0ms');
         }
     }
 
@@ -356,6 +393,16 @@ export class OlToast extends LitElement {
         if (this.closest('ol-toast-region')?.expanded) return;
         this._timerStartedAt = Date.now();
         this._timerId = setTimeout(() => this.close('timeout'), Math.max(0, this._remainingMs));
+
+        // Only schedule progress animation immediately if the element has already mounted.
+        // If not mounted yet, connectedCallback's requestAnimationFrame chain will start it.
+        if (this.hasAttribute('data-mounted')) {
+            requestAnimationFrame(() => {
+                if (this._closing || this._timerId === null) return;
+                this.style.setProperty('--toast-progress-scale', '0');
+                this.style.setProperty('--toast-progress-time', `${this._remainingMs}ms`);
+            });
+        }
     }
 
     /**
@@ -413,6 +460,7 @@ export class OlToast extends LitElement {
                     aria-label=${this.labelClose}
                     @click=${() => this.close('close-button')}
                 >${OlToast._closeIcon}</button>
+                ${!this.persistent ? html`<div class="toast__progress"></div>` : ''}
             </div>
         `;
     }

--- a/openlibrary/components/lit/OlToast.js
+++ b/openlibrary/components/lit/OlToast.js
@@ -376,9 +376,10 @@ export class OlToast extends LitElement {
             this._clearTimer();
             const elapsed = Date.now() - this._timerStartedAt;
             this._remainingMs = Math.max(0, this._remainingMs - elapsed);
-            const fraction = this._remainingMs / this.timeout;
-            this.style.setProperty('--toast-progress-scale', String(fraction));
+            const denom = this.timeout > 0 ? this.timeout : 1;
+            const fraction = Math.max(0, Math.min(1, this._remainingMs / denom));
             this.style.setProperty('--toast-progress-time', '0ms');
+            this.style.setProperty('--toast-progress-scale', String(fraction));
         }
     }
 

--- a/static/css/components/ol-banner.css
+++ b/static/css/components/ol-banner.css
@@ -88,7 +88,7 @@ ol-banner > .ol-banner__icon {
   flex-shrink: 0;
   width: 20px;
   height: 20px;
-  margin-top: 1px; /* optically center against the first text line */
+  margin-top: 4px; /* optically center against the first text line */
   border-radius: var(--border-radius-circle);
   background-color: var(--banner-accent);
   color: var(--white);
@@ -102,6 +102,10 @@ ol-banner:not([hydrated]) > [slot="icon"] {
 
 ol-banner > .ol-banner__content {
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-height: 28px;
 }
 
 /* Reserve the close button's column pre-hydration so it doesn't reflow


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
### refactor
This is a follow-up to PR #12868. It enhances the visual presentation and usability of the `OlToast` and `OlBanner` components:
- Adds an animated visual progress bar to auto-dismissing (non-persistent) `OlToast` notifications.
- Appropriately pauses/resumes the progress bar animation when pausing/resuming the toast timer.
- Improves layout alignment and optical centering of the text content against the close button/icon.

### Technical
<!-- What should be noted about the implementation? -->
- Integrates a `.toast__progress` element absolute-positioned at the bottom of the toast, scaling down horizontally based on the remaining dismiss time via CSS custom properties (`--toast-progress-scale` and `--toast-progress-time`).
- Refines optical alignment in `ol-banner` by setting `margin-top: 4px` on the icon and adjusting content layout (`min-height: 28px` + flex layout) to center the text content against the close button.
- Applies similar layout centering adjustments to `OlToast` body layout.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Verified that all unit tests pass: `npm run test:js`
- Verified that formatting/lint rules are adhered to: `npm run lint` and `pre-commit run`

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@lokesh 
