### PR TITLE
Remove redundant publishers feature flag

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -62,7 +62,6 @@ features:
     dev: enabled
     history_v2: admin
     lists: enabled
-    publishers: enabled
     recentchanges_v2: enabled
     stats: enabled
     stats-header: enabled

--- a/openlibrary/core/features.py
+++ b/openlibrary/core/features.py
@@ -30,7 +30,6 @@ class Features(BaseSettings):
     # dev: bool # Warning: this is setup locally but not in testing/production
     # history_v2: bool # is set to admin in local/testing but in production it's "librarians". We might want to get rid of the flag?
     lists: bool  # we probably want to get rid of this one...
-    publishers: bool  # we probably want to get rid of this one...
     recentchanges_v2: bool  # might be able to get rid of this one, but it's used in infogami..
     stats: bool
     stats_header: bool

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -6174,10 +6174,6 @@ msgstr ""
 msgid "published most by this publisher"
 msgstr ""
 
-#: publishers/view.html
-msgid "Get more information about this publisher"
-msgstr ""
-
 #: reading_goals/reading_goal_form.html
 msgid "How many books would you like to read this year?"
 msgstr ""
@@ -7096,11 +7092,6 @@ msgstr ""
 #: type/edition/view.html type/work/view.html
 #, python-format
 msgid "Show other books from %(publisher)s"
-msgstr ""
-
-#: type/edition/view.html type/work/view.html
-#, python-format
-msgid "Search for other books from %(publisher)s"
 msgstr ""
 
 #: type/edition/view.html type/work/view.html

--- a/openlibrary/plugins/worksearch/publishers.py
+++ b/openlibrary/plugins/worksearch/publishers.py
@@ -31,18 +31,12 @@ class publishers(subjects.subjects):
 
         return render_template("publishers/view", page)
 
-    def is_enabled(self):
-        return "publishers" in web.ctx.features
-
 
 class index(delegate.page):
     path = "/publishers"
 
     def GET(self):
         return render_template("publishers/index")
-
-    def is_enabled(self):
-        return "publishers" in web.ctx.features
 
 
 class publisher_search(delegate.page):

--- a/openlibrary/templates/publishers/view.html
+++ b/openlibrary/templates/publishers/view.html
@@ -86,15 +86,10 @@ $jsdef renderAuthors(authors):
     </div>
 </div>
 
-$ publishers_feature_enabled = "publishers" in ctx.features
-
 $jsdef renderPublishers(publishers):
     $for p in publishers:
         <span class="tag">
-            $if publishers_feature_enabled:
-                <a href="$p.key">$p.name</a>,
-            $else:
-                <a href="/search?${page.subject_type}_facet=$page.name.replace('&','%26')&amp;publisher_facet=$p.name.replace('"', '\\"').replace('&','%26')" title="$_('Get more information about this publisher')">$p.name</a>,
+            <a href="$p.key">$p.name</a>,
         </span>
         <span class="count">$ungettext("%(count)s edition", "%(count)s editions", p.count, count=commify(p.count))</span>
          <br/>

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -263,14 +263,9 @@ $ worldcat_link = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_number=oclc_
                 <div>$_("Publisher")</div>
                 <span>
                 $for p in edition.publishers:
-                  $if "publishers" in ctx.features:
-                    <a itemprop="publisher" href="/publishers/$p.replace(' ', '_')"
-                       title="$_('Show other books from %(publisher)s', publisher=p)"
-                       >$p</a>$cond(loop.last, "", ", ")
-                  $else:
-                    <a itemprop="publisher" href="/search?publisher_facet=$p.replace('&','%26')"
-                       title="$_('Search for other books from %(publisher)s', publisher=p)"
-                       >$p</a>$cond(loop.last, "", ", ")
+                  <a itemprop="publisher" href="/publishers/$p.replace(' ', '_')"
+                     title="$_('Show other books from %(publisher)s', publisher=p)"
+                     >$p</a>$cond(loop.last, "", ", ")
                 </span>
               </div>
             $if edition.languages:

--- a/openlibrary/tests/core/test_features.py
+++ b/openlibrary/tests/core/test_features.py
@@ -14,7 +14,6 @@ from openlibrary.core.features import Features
 def _full_config(**overrides: str) -> str:
     values = {
         "lists": "true",
-        "publishers": "false",
         "recentchanges_v2": "false",
         "stats": "true",
         "stats-header": "true",
@@ -48,7 +47,6 @@ class TestConstructor:
     def test_kwargs_only(self):
         f = Features(
             lists=True,
-            publishers=False,
             recentchanges_v2=False,
             stats=True,
             stats_header=True,
@@ -59,7 +57,6 @@ class TestConstructor:
     def test_extra_fields_are_ignored(self):
         f = Features(
             lists=True,
-            publishers=False,
             recentchanges_v2=False,
             stats=True,
             stats_header=True,
@@ -78,7 +75,6 @@ class TestFromYaml:
         assert f.stats is True
         assert f.stats_header is True
         assert f.lists is True
-        assert f.publishers is False
         assert f.recentchanges_v2 is False
         assert f.superfast is False
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Part of #12946 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR removes the `publishers` feature flag since it's `enabled` across all environments.

### Technical
<!-- What should be noted about the implementation? -->
- Removed `publishers: enabled` from `conf/openlibrary.yml`.
- Removed `publishers` field from pydantic-settings `Features` model in `openlibrary/core/features.py`.
- Removed `is_enabled()` overrides from `publishers` and `index` classes in `openlibrary/plugins/worksearch/publishers.py` — parent `delegate.page` defaults to `True`, matching the always-on behavior.
- Simplified `openlibrary/templates/publishers/view.html` and `openlibrary/templates/type/edition/view.html` by removing the `"publishers" in ctx.features` branches. The `/publishers/<name>` URL path is now the default — the old `/search?publisher_facet=...` fallback is deleted.
- Removed obsolete i18n strings from `messages.pot` and cleaned up test fixtures in `test_features.py`.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- `make test-py-uv PYTEST_ARGS="openlibrary/tests/core/test_features.py"`
- Grepped for `"publishers" in ctx.features` and `"publishers" in web.ctx.features` — zero remaining



### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
