### PR TITLE
Update xauthn `issue_key` key name

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -964,7 +964,7 @@ class InternetArchiveAccount(web.storage):
         if itemname:
             kwargs["itemname"] = itemname
         if token:
-            kwargs["token"] = token
+            kwargs["issuer_token"] = token
         response = cls.xauth(**kwargs)
         return response.get("s3") or None
 

--- a/openlibrary/tests/accounts/test_models.py
+++ b/openlibrary/tests/accounts/test_models.py
@@ -124,9 +124,9 @@ def test_verify_success(mock_xauth):
     assert result["email"] == "test@example.com"
     assert result["s3"]["access"] == "AKIAIOSFODNN7EXAMPLE"
     assert result["s3"]["secret"] == "wJalrXUtnFEMI"
-    # Confirm token from activate was forwarded to issue_key
+    # Confirm token from activate was forwarded to issue_key as issuer_token
     issue_key_call = mock_xauth.call_args_list[1]
-    assert issue_key_call.kwargs.get("token") == "tok_abc123"
+    assert issue_key_call.kwargs.get("issuer_token") == "tok_abc123"
 
 
 @mock.patch.object(InternetArchiveAccount, "xauth")


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Follows #12860

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Updates our xauthn `issue_key` call to send the token as `issuer_token`.  `token` is no longer a valid parameter for `issue_key` requests.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
