### PR TITLE
Remove redundant lists feature flag

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -61,7 +61,6 @@ features:
     debug: enabled
     dev: enabled
     history_v2: admin
-    lists: enabled
     recentchanges_v2: enabled
     stats: enabled
     stats-header: enabled

--- a/openlibrary/core/features.py
+++ b/openlibrary/core/features.py
@@ -29,7 +29,6 @@ class Features(BaseSettings):
     # debug: bool # disabled because we should probably get rid of it but we still have a `features.is_enabled("debug")` to deal with we didn't see in #12884
     # dev: bool # Warning: this is setup locally but not in testing/production
     # history_v2: bool # is set to admin in local/testing but in production it's "librarians". We might want to get rid of the flag?
-    lists: bool  # we probably want to get rid of this one...
     stats: bool
     stats_header: bool
     # undo: bool # Warning: this is enabled locally but a usergroup of librarians in testing/production

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -280,9 +280,6 @@ class lists(delegate.page):
 
     path = "(/(?:people|books|works|authors|subjects)/[^/]+)/lists"
 
-    def is_enabled(self):
-        return "lists" in web.ctx.features
-
     def GET(self, path):
         # If logged in patron is viewing their lists page, use MyBooksTemplate
         if path.startswith("/people/"):

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -1,9 +1,6 @@
 $def with (page, include_rating=True, read_status=None, exclude_own_lists=False, async_load=False)
 
 <div class="lists-widget-container">
-$if "lists" not in ctx.features:
-    $return
-
 $if render_once('lists/widget.i18n-strings'):
   $ show_list_i18n_strings = {
     $ "cover_of": _('Cover of: %(title)s', title=''),

--- a/openlibrary/templates/recentchanges/index.html
+++ b/openlibrary/templates/recentchanges/index.html
@@ -29,8 +29,7 @@ $def subnav():
     $     (path + "/add-cover", _("Covers Added")),
     $ ]
 
-    $if "lists" in ctx.features:
-        $nav_items.append((path + "/lists", _("Lists")))
+    $nav_items.append((path + "/lists", _("Lists")))
 
     $:render_template("lib/subnavigation", nav_items)
 

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -175,10 +175,9 @@ $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_libra
             $:render_subjects(_("Time"), books.facet_counts.get('time_facet'), 'time:')
         <!-- /SUBJECTS -->
 
-        $if "lists" in ctx.features:
-            <div class="section Tools">
-                $:render_template("lists/widget", page, include_rating=False, async_load=True)
-            </div>
+        <div class="section Tools">
+            $:render_template("lists/widget", page, include_rating=False, async_load=True)
+        </div>
 
         <div class="section">
             <h3>$_('ID Numbers')</h3>

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -527,7 +527,7 @@ $ worldcat_link = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_number=oclc_
       <a id="lists-section" class="section-anchor"></a>
       $# pages like /books/ia:foo00bar are fake records created from metadata API.
       $# Adding them to lists doesn't work. Disabling it to avoid any issues.
-      $if "lists" in ctx.features and not page.is_fake_record():
+      $if not page.is_fake_record():
         $ component_times['Lists section'] = time()
         $code:
           data_ids = {}

--- a/openlibrary/templates/type/user/view.html
+++ b/openlibrary/templates/type/user/view.html
@@ -9,10 +9,7 @@ $ is_subscribed = ctx.user and ctx.user.is_subscribed_user(username)
 $if days_since(page.created) < 30:
   $ putctx('robots', 'noindex')
 
-$if "lists" in ctx.features:
-    $ lists = page.get_lists(limit=3)
-$else:
-    $ lists = []
+$ lists = page.get_lists(limit=3)
 
 <div id="contentHead">
     $if is_public and not owners_page:
@@ -30,7 +27,7 @@ $else:
     $elif ctx.user and ctx.user.is_admin():
         &bull;
         <span class="adminOnly"><a href="/admin$page.key">$_('admin page')</a></span>
-    $if "lists" in ctx.features and lists:
+    $if lists:
         &bull;
         <a href="$homepath()$page.key/lists">$_("Lists")</a>
     </div>
@@ -62,7 +59,7 @@ $else:
         $else:
             <p>$_('This reader has chosen to make their Reading Log private.')</p>
 
-    $if "lists" in ctx.features and lists:
+    $if lists:
         <div id="listsDisplay">
             <h2>$(_('My Lists') if owners_page else _('Lists'))
             <span class="sansserif small"><a href="$page.key/lists">$(_('Edit') if owners_page else _('See All'))</a></span>

--- a/openlibrary/tests/core/test_features.py
+++ b/openlibrary/tests/core/test_features.py
@@ -13,7 +13,6 @@ from openlibrary.core.features import Features
 
 def _full_config(**overrides: str) -> str:
     values = {
-        "lists": "true",
         "stats": "true",
         "stats-header": "true",
     }
@@ -44,7 +43,6 @@ class TestConstructor:
 
     def test_kwargs_only(self):
         f = Features(
-            lists=True,
             stats=True,
             stats_header=True,
         )
@@ -52,7 +50,6 @@ class TestConstructor:
 
     def test_extra_fields_are_ignored(self):
         f = Features(
-            lists=True,
             stats=True,
             stats_header=True,
             nonexistent=True,
@@ -68,7 +65,6 @@ class TestFromYaml:
         f = Features.from_yaml(tmp_path / "openlibrary.yml")
         assert f.stats is True
         assert f.stats_header is True
-        assert f.lists is True
 
     def test_missing_field_raises(self, tmp_path: Path):
         config = tmp_path / "openlibrary.yml"


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Part of #12946 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR removes the `lists` feature flag since it's `enabled` across all environments.

### Technical
<!-- What should be noted about the implementation? -->
- Removed `lists: enabled` from `conf/openlibrary.yml`.
- Removed `lists` field from pydantic-settings `Features` model in `openlibrary/core/features.py`.
- Removed `is_enabled()` override from `lists` class in `openlibrary/plugins/openlibrary/lists.py` — parent `delegate.page` defaults to `True`, matching the always-on behavior.
- Simplified `openlibrary/templates/type/user/view.html` — `page.get_lists(limit=3)` now always runs (was already the case in production); the `$else: lists = []` dead branch is removed.
- Simplified `openlibrary/templates/lists/widget.html` by removing the early return guard.
- Simplified `openlibrary/templates/type/edition/view.html`, `openlibrary/templates/type/author/view.html`, and `openlibrary/templates/recentchanges/index.html` by removing the `"lists" in ctx.features` branches.
- Removed `lists` from test fixtures in `test_features.py`.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Ran `make test-py-uv PYTEST_ARGS="openlibrary/tests/core/test_features.py"` 
- Grepped for `"lists" in ctx.features` and `"lists" in web.ctx.features` none remains

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
