### PR TITLE
fix: resolve download record bar overflowing containers globally

### DIFF
--- a/static/css/components/page-history.css
+++ b/static/css/components/page-history.css
@@ -15,8 +15,12 @@
 
 .pageHistory__tools {
   font-size: 0.7em;
-  float: right;
-  padding-top: 8px;
+  padding-top: var(--spacing-inset-sm);
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  gap: var(--spacing-inline-sm);
+  margin-bottom: calc(-1 * var(--spacing-sm));
 }
 
 /* We assume list items in page history will only have 2 items */


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #13090

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

### Technical
<!-- What should be noted about the implementation? -->
- Added a structural `clearfix` container (`<div class="clearfix"></div>`) inside the shared `openlibrary/templates/lib/exports.html` template.
- Applied the negative margin calculation (`margin-bottom: calc(-1 * var(--contentBody-padding));`) inline to pull the downloads bar up and align it cleanly against the container's bottom edge (negating the default `#contentBody` bottom padding).
- This resolves the uncontained float (`.pageHistory__tools`) globally for all views utilizing the exports template (Edition view, Work view, and Author view) without duplicating layout fixes across multiple templates.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Visit the local book detail page: `http://localhost:8080/books/OL24620876M/Responsive_Web_Design` (or any other book detail page).
2. Verify that the "Download catalog record" bar at the bottom is fully contained inside the white container and aligns perfectly with the bottom border.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

<img width="1396" height="448" alt="image" src="https://github.com/user-attachments/assets/d2ae4f24-d919-4e3d-8b6a-a6375aa36955" />
