### PR TITLE
fix: resolve volumes multiget endpoint failing with .json extension

### DIFF
--- a/openlibrary/fastapi/books.py
+++ b/openlibrary/fastapi/books.py
@@ -6,8 +6,6 @@ the best practices like Response Models because JSONP makes it quite complicated
 
 from __future__ import annotations
 
-import re
-import urllib.parse
 from typing import Annotated, Any, Literal
 
 import web
@@ -96,9 +94,6 @@ async def get_books(
     return wrap_jsonp(request, result_str)
 
 
-MULTIGET_PATH_RE = re.compile(r"/api/volumes/(brief|full)/json/(.+)")
-
-
 @router.get("/api/volumes/{brief_or_full}/json/{req}", include_in_schema=False)
 @router.get("/api/volumes/{brief_or_full}/json/{req}.json")
 async def get_volumes_multiget(
@@ -116,16 +111,6 @@ async def get_volumes_multiget(
         GET /api/volumes/brief/json/isbn:059035342X|oclc:123456.json
     """
     web.ctx.home = f"{request.url.scheme}://{request.url.netloc}"
-
-    raw_uri = request.url.path
-
-    decoded_path = urllib.parse.unquote(raw_uri)
-
-    m = MULTIGET_PATH_RE.match(decoded_path)
-    if not m or len(m.groups()) != 2:
-        return {}
-
-    _brief_or_full, req = m.groups()
 
     result = await readlinks.readlinks(req, {})
     return wrap_jsonp(request, result)

--- a/openlibrary/tests/fastapi/test_books.py
+++ b/openlibrary/tests/fastapi/test_books.py
@@ -316,20 +316,21 @@ class TestGetVolumesMultiget:
         response = client.get("/api/volumes/brief/json/isbn:0452010586.json")
 
         assert response.status_code == 200
-        mock_readlinks.assert_called_once()
+        mock_readlinks.assert_called_once_with("isbn:0452010586", {})
 
     def test_multiple_identifiers(self, client, mock_readlinks):
         """Verify pipe-separated identifiers are passed through."""
         response = client.get("/api/volumes/brief/json/isbn:0452010586|lccn:88037464.json")
 
         assert response.status_code == 200
-        mock_readlinks.assert_called_once()
+        mock_readlinks.assert_called_once_with("isbn:0452010586|lccn:88037464", {})
 
     def test_jsonp_callback(self, client, mock_readlinks):
         """Verify JSONP callback wrapping works for multiget endpoint."""
         response = client.get("/api/volumes/brief/json/isbn:0452010586.json?callback=jQueryCb")
 
         assert response.status_code == 200
+        mock_readlinks.assert_called_once_with("isbn:0452010586", {})
         data = extract_jsonp(response.text, "jQueryCb")
         assert isinstance(data, dict)
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #13092

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

### Technical
<!-- What should be noted about the implementation? -->
- Removed the manual URL regex parsing code (`MULTIGET_PATH_RE`) in `get_volumes_multiget` (in `openlibrary/fastapi/books.py`). FastAPI/Starlette already parses the `req` parameter and automatically strips the `.json` extension from the URL.
- Bypassed the custom regex block to directly pass the pre-parsed `req` parameter to `readlinks.readlinks(req, {})`.
- Removed the unused `import re` and `import urllib.parse` at the top of `books.py` (cleaned up automatically via Ruff linter).
- Updated all three unit test methods under `TestGetVolumesMultiget` in `openlibrary/tests/fastapi/test_books.py` to assert the exact arguments passed to the mocked `readlinks` function, eliminating mock testing gaps and preventing future regressions.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Run the local development environment.
2. Verify the multiget volumes API works with the `.json` extension:
   ```bash
   curl -i http://localhost:8080/api/volumes/brief/json/oclc:19683037.json
   ```
   **Expected**: Returns the full metadata JSON block for the OCLC record.
   **Actual (Before)**: Returned `{}` empty response.
3. Run unit tests inside the Docker container to ensure all mock assertions pass successfully:
   ```bash
   docker compose run --rm home pytest openlibrary/tests/fastapi/test_books.py
   ```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A (This is a backend API bug fix).