### PR TITLE
Remove redundant recentchanges_v2 feature flag

### DIFF
--- a/openlibrary/core/features.py
+++ b/openlibrary/core/features.py
@@ -30,7 +30,6 @@ class Features(BaseSettings):
     # dev: bool # Warning: this is setup locally but not in testing/production
     # history_v2: bool # is set to admin in local/testing but in production it's "librarians". We might want to get rid of the flag?
     lists: bool  # we probably want to get rid of this one...
-    recentchanges_v2: bool  # might be able to get rid of this one, but it's used in infogami..
     stats: bool
     stats_header: bool
     superfast: bool

--- a/openlibrary/plugins/upstream/recentchanges.py
+++ b/openlibrary/plugins/upstream/recentchanges.py
@@ -31,17 +31,11 @@ class index2(delegate.page):
     path = "/recentchanges"
 
     def GET(self):
-        if features.is_enabled("recentchanges_v2"):
-            return index().render()
-        else:
-            return render.recentchanges()
+        return index().render()
 
 
 class index(delegate.page):
     path = "/recentchanges(/[^/0-9][^/]*)"
-
-    def is_enabled(self):
-        return features.is_enabled("recentchanges_v2")
 
     def GET(self, kind):
         return self.render(kind=kind)
@@ -129,9 +123,6 @@ class index_with_date(index):
 class recentchanges_redirect(delegate.page):
     path = r"/recentchanges/goto/(\d+)"
 
-    def is_enabled(self):
-        return features.is_enabled("recentchanges_v2")
-
     def GET(self, id):
         id = int(id)
         change = web.ctx.site.get_change(id)
@@ -144,9 +135,6 @@ class recentchanges_redirect(delegate.page):
 
 class recentchanges_view(delegate.page):
     path = r"/recentchanges/\d\d\d\d/\d\d/\d\d/[^/]*/(\d+)"
-
-    def is_enabled(self):
-        return features.is_enabled("recentchanges_v2")
 
     def get_change_url(self, change):
         t = change.timestamp

--- a/openlibrary/templates/type/user/view.html
+++ b/openlibrary/templates/type/user/view.html
@@ -79,13 +79,10 @@ $else:
     $ is_librarian_or_higher = ctx.user and ctx.user.is_librarian_or_higher()
 
     $if owners_page or is_librarian_or_higher:
-        $if "recentchanges_v2" in ctx.features:
-            $ changes = render_template("recentchanges/render", author=page.key, limit=25)
-            $if changes.length > 1:
-                <h2>$_('Recent Activity')</h2>
-                $:changes
-            $else:
-                <p>$_("No edits. Yet.")</p>
+        $ changes = render_template("recentchanges/render", author=page.key, limit=25)
+        $if changes.length > 1:
+            <h2>$_('Recent Activity')</h2>
+            $:changes
         $else:
-            $:macros.RecentChangesUsers(author=page, limit=25)
+            <p>$_("No edits. Yet.")</p>
 </div>

--- a/openlibrary/tests/core/test_features.py
+++ b/openlibrary/tests/core/test_features.py
@@ -14,7 +14,6 @@ from openlibrary.core.features import Features
 def _full_config(**overrides: str) -> str:
     values = {
         "lists": "true",
-        "recentchanges_v2": "false",
         "stats": "true",
         "stats-header": "true",
         "superfast": "false",
@@ -47,7 +46,6 @@ class TestConstructor:
     def test_kwargs_only(self):
         f = Features(
             lists=True,
-            recentchanges_v2=False,
             stats=True,
             stats_header=True,
             superfast=False,
@@ -57,7 +55,6 @@ class TestConstructor:
     def test_extra_fields_are_ignored(self):
         f = Features(
             lists=True,
-            recentchanges_v2=False,
             stats=True,
             stats_header=True,
             superfast=False,
@@ -75,7 +72,6 @@ class TestFromYaml:
         assert f.stats is True
         assert f.stats_header is True
         assert f.lists is True
-        assert f.recentchanges_v2 is False
         assert f.superfast is False
 
     def test_missing_field_raises(self, tmp_path: Path):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Part of #12946

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR removes the `recentchanges_v2` feature flag from the openlibrary codebase.

### Technical
<!-- What should be noted about the implementation? -->
- Removed `recentchanges_v2` field from pydantic-settings `Features` model in `openlibrary/core/features.py`.
- Removed `features.is_enabled("recentchanges_v2")` conditional in `openlibrary/plugins/upstream/recentchanges.py` — `index2` no longer falls back to the legacy template; `index`, `recentchanges_redirect`, and `recentchanges_view` no longer have `is_enabled()` overrides (parent `delegate.page` defaults to `True`, matching the always-on behavior).
- Simplified `openlibrary/templates/type/user/view.html` by removing the `"recentchanges_v2" in ctx.features` branch — the v2 template is now always rendered instead of falling back to `macros.RecentChangesUsers`.
- Removed `recentchanges_v2` from test fixtures in `test_features.py`.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Ran `make test-py-uv PYTEST_ARGS="openlibrary/tests/core/test_features.py"`
- Grepped for "recentchanges_v2" across openlibrary/ — no remaining references (conf/openlibrary.yml is kept for vendor compatibility).

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
