### PR TITLE
Remove redundant superfast feature flag

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -65,7 +65,6 @@ features:
     recentchanges_v2: enabled
     stats: enabled
     stats-header: enabled
-    superfast: enabled
     undo: enabled
 
 upstream_to_www_migration: true

--- a/openlibrary/core/features.py
+++ b/openlibrary/core/features.py
@@ -32,7 +32,6 @@ class Features(BaseSettings):
     lists: bool  # we probably want to get rid of this one...
     stats: bool
     stats_header: bool
-    superfast: bool
     # undo: bool # Warning: this is enabled locally but a usergroup of librarians in testing/production
 
     @classmethod

--- a/openlibrary/macros/databarView.html
+++ b/openlibrary/macros/databarView.html
@@ -11,10 +11,7 @@ $else:
 
 <div id="editTools" class="edit">
     <div id="editInfo">
-        $if "superfast" in ctx.features:
-            $ author = page.get_most_recent_change().author
-        $else:
-            $ author = get_recent_author(page)
+        $ author = page.get_most_recent_change().author
         $if author:
             <div class="brown smaller sansserif">$:_('Last edited by %(author_link)s', author_link=author.render_link())</div>
         $else:

--- a/openlibrary/templates/lib/history.html
+++ b/openlibrary/templates/lib/history.html
@@ -1,7 +1,7 @@
 $def with (page)
 
 $ h = None
-$if "superfast" in ctx.features and "history_v2" not in ctx.features:
+$if "history_v2" not in ctx.features:
     $ h = page.get_history_preview()
 $if not h:
     $ h = get_history(page)

--- a/openlibrary/templates/viewpage.html
+++ b/openlibrary/templates/viewpage.html
@@ -19,8 +19,7 @@ $if ctx.user and (ctx.user.is_admin() or ctx.user.is_super_librarian()):
             $ ctx.links.append('<link rel="alternate" type="application/rdf+xml" href="' + request.home + page.key + '.rdf"/>')
             $ ctx.links.append('<link rel="canonical" type="text/html" href="' + request.home + page.url() + '"/>')
 
-$if "superfast" in ctx.features:
-    $page.prefetch()
+$page.prefetch()
 
 $ view = thingview(page)
 

--- a/openlibrary/tests/core/test_features.py
+++ b/openlibrary/tests/core/test_features.py
@@ -16,7 +16,6 @@ def _full_config(**overrides: str) -> str:
         "lists": "true",
         "stats": "true",
         "stats-header": "true",
-        "superfast": "false",
     }
     values.update(overrides)
     lines = ["features:"]
@@ -48,7 +47,6 @@ class TestConstructor:
             lists=True,
             stats=True,
             stats_header=True,
-            superfast=False,
         )
         assert f.stats is True
 
@@ -57,7 +55,6 @@ class TestConstructor:
             lists=True,
             stats=True,
             stats_header=True,
-            superfast=False,
             nonexistent=True,
         )
         assert f.stats is True
@@ -72,7 +69,6 @@ class TestFromYaml:
         assert f.stats is True
         assert f.stats_header is True
         assert f.lists is True
-        assert f.superfast is False
 
     def test_missing_field_raises(self, tmp_path: Path):
         config = tmp_path / "openlibrary.yml"


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Part of #12946 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR is made to remove the  redundant `superfast` feature flag

### Technical
<!-- What should be noted about the implementation? -->
- Removes the `superfast` feature flag which was always enabled
- Unconditionally uses the "fast" paths: `page.prefetch()`, `page.get_most_recent_change().author`, and `page.get_history_preview()`

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Ran `make test-py-uv PYTEST_ARGS="openlibrary/tests/core/test_features.py"` 
- No references to `superfast` remain anywhere in the codebase

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
