### PR TITLE
Update environment of cron service

### DIFF
--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -155,6 +155,8 @@ services:
     hostname: "$HOSTNAME"
     user: root
     command: docker/ol-cron-start.sh
+    environment:
+      - OL_CONFIG=/olsystem/etc/openlibrary.yml
     restart: unless-stopped
     volumes:
       - ../olsystem/etc/cron.d/openlibrary.ol_home0:/etc/cron.d/openlibrary.ol_home0:ro

--- a/docker/ol-cron-start.sh
+++ b/docker/ol-cron-start.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 
+# Expose `OL_CONFIG` to cron
+printenv | grep "^OL_CONFIG=" >> /etc/environment
+
 crontab /etc/cron.d/openlibrary.ol_home0
 cron -f -L2

--- a/docker/ol-cron-start.sh
+++ b/docker/ol-cron-start.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 # Expose `OL_CONFIG` to cron
-printenv | grep "^OL_CONFIG=" >> /etc/environment
-
+if [ -n "${OL_CONFIG:-}" ]; then
+  touch /etc/environment
+  grep -q '^OL_CONFIG=' /etc/environment || echo "OL_CONFIG=$OL_CONFIG" >> /etc/environment
+fi
 crontab /etc/cron.d/openlibrary.ol_home0
 cron -f -L2


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #13108

Attempts to read the config YAML in the cron job container were resulting in `PermissionErrors`.  Adding the `OL_CONFIG` environment variable to the cron service, then forwarding said variable to cron's environment appears to have solved the issue.

Note that the `ol-cron-start.sh` changes have not been tested, _per se_ -- I ran `echo "OL_CONFIG=/olsystem/etc/openlibrary.yml" >> /etc/environment` inside of the container in order to test these changes.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
