### PR TITLE
feat: Make Preview / Search Inside more visible on books page

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -58,8 +58,7 @@
     },
     {
       "path": "static/build/css/page-admin.css",
-      "maxSize": "27KB"
-
+      "maxSize": "28KB"
     },
     {
       "path": "static/build/css/page-book.css",

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -315,8 +315,8 @@ msgstr ""
 msgid "YAML Representation:"
 msgstr ""
 
-#: BookPreview.html book_providers/read_button.html books/edit/edition.html
-#: editpage.html import_preview.html
+#: BookPreview.html PreviewSearchInside.html book_providers/read_button.html
+#: books/edit/edition.html editpage.html import_preview.html
 msgid "Preview"
 msgstr ""
 
@@ -469,11 +469,12 @@ msgstr ""
 msgid "In %(time)s seconds, you will be automatically redirected to: %(url)s"
 msgstr ""
 
-#: CreateListModal.html EditButtons.html account/notifications.html
-#: account/password/reset.html account/privacy.html admin/imports-add.html
-#: admin/permissions.html books/add.html databarEdit.html interstitial.html
-#: merge/authors.html my_books/dropdown_content.html type/list/edit.html
-#: type/series/edit.html type/tag/form.html
+#: CreateListModal.html EditButtons.html PreviewSearchInside.html
+#: account/notifications.html account/password/reset.html account/privacy.html
+#: admin/imports-add.html admin/permissions.html books/add.html
+#: databarEdit.html interstitial.html merge/authors.html
+#: my_books/dropdown_content.html type/list/edit.html type/series/edit.html
+#: type/tag/form.html
 msgid "Cancel"
 msgstr ""
 
@@ -586,9 +587,9 @@ msgstr ""
 msgid "Thank you for improving the Open Library catalog!"
 msgstr ""
 
-#: BookPreview.html CreateListModal.html NotesModal.html ObservationsModal.html
-#: ShareModal.html covers/author_photo.html covers/book_cover.html
-#: covers/change.html lib/exports.html my_books/check_ins/check_in_prompt.html
+#: CreateListModal.html NotesModal.html ObservationsModal.html ShareModal.html
+#: covers/author_photo.html covers/book_cover.html covers/change.html
+#: lib/exports.html my_books/check_ins/check_in_prompt.html
 #: my_books/dropdown_content.html native_dialog.html
 msgid "Close"
 msgstr ""
@@ -3117,10 +3118,10 @@ msgstr ""
 msgid "Search for an Author"
 msgstr ""
 
-#: authors/index.html lib/nav_head.html lists/home.html publishers/index.html
-#: publishers/notfound.html publishers/view.html search/advancedsearch.html
-#: search/publishers.html search/search_modal_i18n.html search/searchbox.html
-#: type/local_id/view.html
+#: PreviewSearchInside.html authors/index.html lib/nav_head.html
+#: lists/home.html publishers/index.html publishers/notfound.html
+#: publishers/view.html search/advancedsearch.html search/publishers.html
+#: search/search_modal_i18n.html search/searchbox.html type/local_id/view.html
 msgid "Search"
 msgstr ""
 
@@ -6445,8 +6446,8 @@ msgstr ""
 msgid "Search Open Library for %s"
 msgstr ""
 
-#: BookSearchInside.html FulltextSearchSuggestion.html SearchNavigation.html
-#: search/inside.html search/snippets.html
+#: FulltextSearchSuggestion.html SearchNavigation.html search/inside.html
+#: search/snippets.html
 msgid "Search Inside"
 msgstr ""
 
@@ -7801,12 +7802,16 @@ msgstr ""
 msgid "Preview Only"
 msgstr ""
 
-#: BookPreview.html
+#: BookPreviewFloater.html
 msgid "Preview Book"
 msgstr ""
 
-#: BookPreview.html
-msgid "Book preview"
+#: BookPreviewFloater.html
+msgid "Book Preview"
+msgstr ""
+
+#: BookPreviewFloater.html
+msgid "See more about this book on Archive.org"
 msgstr ""
 
 #: DisplayCode.html
@@ -7997,6 +8002,14 @@ msgstr ""
 #: OlPagination.html
 #, python-brace-format
 msgid "Page {page}, current page"
+msgstr ""
+
+#: PreviewSearchInside.html
+msgid "Search inside book"
+msgstr ""
+
+#: PreviewSearchInside.html
+msgid "Search inside"
 msgstr ""
 
 #: Profile.html

--- a/openlibrary/macros/BookPreview.html
+++ b/openlibrary/macros/BookPreview.html
@@ -1,41 +1,15 @@
-$def with (ocaid, analytics_attr=None, show_only=False)
+$def with (ocaid, show_only=False)
 $# :param str ocaid:
-
-$ track_action = "PreviewSearchInsideBefore|PreviewOnly" if show_only else "PreviewSearchInsideBefore|Preview"
-$if analytics_attr:
-    $ default_attr = analytics_attr("Preview")
-    $if "CTAClick|Preview" in str(default_attr):
-        $ analytics = 'data-ol-link-track="%s"' % track_action
-    $else:
-        $ analytics = default_attr
-$else:
-    $ analytics = 'data-ol-link-track="%s"' % track_action
+$# :param bool show_only: If True, label reads "Preview Only" instead of "Preview"
 
 $if ocaid:
   <div class="cta-button-group">
     <a class="cta-btn cta-btn--preview"
+      href="#bookPreview"
       data-book-preview
       data-iframe-src="https://archive.org/details/$ocaid?view=theater&wrapper=false"
       data-iframe-link="https://archive.org/details/$ocaid"
-      $:analytics href="#bookPreview">$(_('Preview Only') if show_only else _('Preview'))</a>
+      data-ol-link-track="CTAClick|Preview">$(_('Preview Only') if show_only else _('Preview'))</a>
   </div>
 
-$if render_once('book-preview-floater'):
-  <div class="hidden">
-    <div id="bookPreview">
-      <div class="book-preview">
-        <div class="floaterHead">
-          <h2>$_('Preview Book')</h2>
-          <a class="dialog--close" data-key="book_preview">&times;<span class="shift">$_("Close")</span></a>
-        </div>
-        <div>
-          <iframe title="$_('Book preview')" style="width:100%; height:515px"></iframe>
-          <p class="learn-more">
-            <a data-key="book_preview_learn_more"
-             data-ol-link-track="book_preview_learn_more">
-            </a>
-          </p>
-        </div>
-      </div>
-    </div>
-  </div>
+$:macros.BookPreviewFloater()

--- a/openlibrary/macros/BookPreviewFloater.html
+++ b/openlibrary/macros/BookPreviewFloater.html
@@ -1,0 +1,12 @@
+$def with ()
+
+$if render_once('book-preview-floater'):
+  <ol-dialog id="bookPreview" label="$_('Preview Book')" width="large">
+    <div class="book-preview">
+      <iframe width="100%" style="border: 0;" title="$_('Book Preview')"></iframe>
+      <!-- <p class="learn-more">
+        <a data-key="book_preview_learn_more"
+           data-ol-link-track="book_preview_learn_more">$_("See more about this book on Archive.org")</a>
+      </p> -->
+    </div>
+  </ol-dialog>

--- a/openlibrary/macros/BookSearchInside.html
+++ b/openlibrary/macros/BookSearchInside.html
@@ -1,6 +1,0 @@
-$def with(ocaid, q="")
-  <form action="/borrow/ia/$(ocaid)">
-    <input class="cta-btn cta-btn--shell" type="text" name="q"
-           data-ol-link-track="CTAClick|ReadSearchInside"
-           placeholder="$_('Search Inside')">
-  </form>

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -71,24 +71,24 @@ $elif lending_state == 'open':
   $# Open / Publicly Readable (Unrestricted)
   $:macros.ReadButton(ocaid, analytics_attr, listen=listen, edition_key=edition_key, book_title=book_title)
   $if secondary_action:
-    $:macros.BookSearchInside(ocaid)
+    $:macros.PreviewSearchInside(ocaid)
 
 $elif lending_state == 'printdisabled':
   $# Exemptions for patrons with Print Disabilities
   $ pd_eligible = availability and availability.get('is_printdisabled')
   $ std_borrow = availability.get("available_to_borrow") or availability.get("available_to_browse")
   $if secondary_action and (availability.get('is_printdisabled') or availability.get('is_lendable')):
-    $:macros.BookPreview(ocaid, analytics_attr, show_only=False)
+    $:macros.PreviewSearchInside(ocaid)
   $:macros.ReadButton(ocaid, analytics_attr, borrow=pd_eligible, printdisabled=not std_borrow, listen=listen, edition_key=edition_key, book_title=book_title)
 
 $elif lending_state == 'borrowable':
   $if secondary_action:
-    $:macros.BookPreview(ocaid, analytics_attr, show_only=False)
+    $:macros.PreviewSearchInside(ocaid)
   $:macros.ReadButton(ocaid, analytics_attr, borrow=True, listen=listen, edition_key=edition_key, book_title=book_title)
 
 $elif lending_state == 'waitlist':
   $if secondary_action:
-    $:macros.BookPreview(ocaid, analytics_attr, show_only=False)
+    $:macros.PreviewSearchInside(ocaid)
   $if waiting_loan:
     $if secondary_action:
       <p class="waitinglist-message">
@@ -137,7 +137,7 @@ $elif lending_state == 'waitlist':
 
 $elif lending_state == 'checkedout':
   $if secondary_action:
-    $:macros.BookPreview(ocaid, analytics_attr, show_only=False)
+    $:macros.PreviewSearchInside(ocaid)
   $# Checked out: Show checkout out + preview if secondary, else just preview
   <div class="cta-button-group">
     <a
@@ -149,9 +149,9 @@ $elif lending_state == 'checkedout':
   </div>
 
 $elif lending_state == 'preview_only':
-  $:macros.BookPreview(ocaid, analytics_attr, show_only=True)
+  $:macros.BookPreview(ocaid, show_only=True)
   $if secondary_action:
-      $:macros.BookSearchInside(ocaid)
+    $:macros.PreviewSearchInside(ocaid)
 
 $else:
   $# Only render LocateButton instead of NotInLibrary when not on an edition's page, for that specific edition.

--- a/openlibrary/macros/PreviewSearchInside.html
+++ b/openlibrary/macros/PreviewSearchInside.html
@@ -26,10 +26,10 @@ $if ocaid:
     <!-- Search Inside Input Form -->
     <form class="search-inside-form" data-ocaid="$ocaid" role="search" aria-label="$_('Search inside book')" style="display: none;">
       <input class="search-inside-input" type="text" name="q" placeholder="$_('Search inside')" required />
-      <button type="submit" class="search-submit-btn" title="$_('Search')">
+      <button type="submit" class="search-submit-btn" title="$_('Search')" aria-label="$_('Search')">
         <svg class="search-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960" height="18px" width="18px" fill="var(--primary-blue)"><path d="M765-144 526-383q-30 22-65.79 34.5-35.79 12.5-76.18 12.5Q284-336 214-406t-70-170q0-100 70-170t170-70q100 0 170 70t70 170.03q0 40.39-12.5 76.18Q599-464 577-434l239 239-51 51ZM384-408q70 0 119-49t49-119q0-70-49-119t-119-49q-70 0-119 49t-49 119q0 70 49 119t119 49Z"/></svg>
       </button>
-      <button type="button" class="search-cancel-btn" title="$_('Cancel')">
+      <button type="button" class="search-cancel-btn" title="$_('Cancel')" aria-label="$_('Cancel')">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
       </button>
     </form>

--- a/openlibrary/macros/PreviewSearchInside.html
+++ b/openlibrary/macros/PreviewSearchInside.html
@@ -1,0 +1,38 @@
+$def with (ocaid)
+$# :param str ocaid:
+
+
+$if ocaid:
+  <div class="cta-button-group book-preview-buttons">
+    <!-- Preview Button -->
+    <ol-button variant="secondary" full-width size="small" class="preview-btn"
+      data-book-preview
+      data-iframe-src="https://archive.org/details/$ocaid?view=theater&wrapper=false"
+      data-iframe-link="https://archive.org/details/$ocaid"
+      data-ol-link-track="BookOptions|Preview">
+      <svg xmlns="http://www.w3.org/2000/svg" height="18px" viewBox="0 -960 960 960" width="18px" fill="currentColor"><path d="M599-361q49-49 49-119t-49-119q-49-49-119-49t-119 49q-49 49-49 119t49 119q49 49 119 49t119-49Zm-187-51q-28-28-28-68t28-68q28-28 68-28t68 28q28 28 28 68t-28 68q-28 28-68 28t-68-28ZM220-270.5Q103-349 48-480q55-131 172-209.5T480-768q143 0 260 78.5T912-480q-55 131-172 209.5T480-192q-143 0-260-78.5ZM480-480Zm207 158q95-58 146-158-51-100-146-158t-207-58q-112 0-207 58T127-480q51 100 146 158t207 58q112 0 207-58Z"/></svg>
+      $_('Preview')
+    </ol-button>
+
+    <!-- Search Trigger Button -->
+    <ol-button variant="secondary" full-width size="small" class="search-inside-trigger-btn"
+      data-search-trigger
+      aria-expanded="false"
+      data-ol-link-track="BookOptions|SearchInside">
+      <svg xmlns="http://www.w3.org/2000/svg" height="18px" viewBox="0 -960 960 960" width="18px" fill="currentColor"><path d="m592-168 72 72H264q-29.7 0-50.85-21.15Q192-138.3 192-168v-624q0-29.7 21.15-50.85Q234.3-864 264-864h312l192 192v476q0 36-5.5 54T746-116L553-309q-15 10-34 14.5t-39 4.5q-60 0-102-42t-42-102q0-60 42-102t102-42q60 0 102 42t42 102q0 20-5 39.5T604-360l92 92v-374L546-792H264v624h328Zm-61-215.21q21-21.21 21-51T530.79-485q-21.21-21-51-21T429-484.79q-21 21.21-21 51T429.21-383q21.21 21 51 21T531-383.21ZM480-444Zm0 0Z"/></svg>
+      $_('Search')
+    </ol-button>
+
+    <!-- Search Inside Input Form -->
+    <form class="search-inside-form" data-ocaid="$ocaid" role="search" aria-label="$_('Search inside book')" style="display: none;">
+      <input class="search-inside-input" type="text" name="q" placeholder="$_('Search inside')" required />
+      <button type="submit" class="search-submit-btn" title="$_('Search')">
+        <svg class="search-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960" height="18px" width="18px" fill="var(--primary-blue)"><path d="M765-144 526-383q-30 22-65.79 34.5-35.79 12.5-76.18 12.5Q284-336 214-406t-70-170q0-100 70-170t170-70q100 0 170 70t70 170.03q0 40.39-12.5 76.18Q599-464 577-434l239 239-51 51ZM384-408q70 0 119-49t49-119q0-70-49-119t-119-49q-70 0-119 49t-49 119q0 70 49 119t119 49Z"/></svg>
+      </button>
+      <button type="button" class="search-cancel-btn" title="$_('Cancel')">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+      </button>
+    </form>
+  </div>
+
+$:macros.BookPreviewFloater()

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -74,7 +74,7 @@ $code:
           $:cond(seq_index is not None and seq_index > 3, 'loading="lazy"')
 	  /></a>
       $if ocaid:
-        $:macros.BookPreview(ocaid, show_only=False)
+        $:macros.BookPreview(ocaid)
     </span>
 
     <div class="details">

--- a/openlibrary/plugins/openlibrary/js/dialog.js
+++ b/openlibrary/plugins/openlibrary/js/dialog.js
@@ -49,6 +49,17 @@ function initConfirmationDialogs() {
 }
 
 
+/**
+ * Collapses the search-inside form back to the button state.
+ * @param {jQuery} $btnGroup - The .cta-button-group container.
+ */
+function collapseSearchForm($btnGroup) {
+    $btnGroup.find('.search-inside-form').hide();
+    $btnGroup.find('.search-inside-input').val('');
+    $btnGroup.find('.preview-btn, .search-inside-trigger-btn').show();
+    $btnGroup.find('[data-search-trigger]').attr('aria-expanded', 'false');
+}
+
 export function initPreviewDialogs() {
     // Delegated click handler for Book Preview buttons.
     // Uses event delegation so dynamically-added buttons (e.g. from
@@ -56,23 +67,73 @@ export function initPreviewDialogs() {
     $(document).off('click.bookPreview').on('click.bookPreview', '[data-book-preview]', function(e) {
         e.preventDefault();
         const $button = $(this);
-        $.colorbox({
-            width: '100%',
-            maxWidth: '640px',
-            inline: true,
-            opacity: '0.5',
-            href: '#bookPreview',
-            onOpen() {
-                const $iframe = $('#bookPreview iframe');
-                $iframe.prop('src', $button.data('iframe-src'));
+        const dialog = document.getElementById('bookPreview');
+        if (!dialog) return;
 
-                const $link = $('#bookPreview .learn-more a');
-                $link[0].href = $button.data('iframe-link');
-            },
-            onCleanup() {
-                $('#bookPreview iframe').prop('src', '');
-            },
-        });
+        const iframe = dialog.querySelector('iframe');
+        if (iframe) {
+            iframe.src = $button.data('iframe-src');
+        }
+
+        const link = dialog.querySelector('.learn-more a');
+        if (link) {
+            link.href = $button.data('iframe-link');
+        }
+
+        dialog.open = true;
+    });
+
+    $(document).off('ol-close.bookPreview').on('ol-close.bookPreview', '#bookPreview', function() {
+        const iframe = this.querySelector('iframe');
+        if (iframe) {
+            iframe.src = '';
+        }
+    });
+
+    // Handle clicking the "Search Inside" button to expand it to the input form
+    $(document).off('click.bookSearchTrigger').on('click.bookSearchTrigger', '[data-search-trigger]', function(e) {
+        e.preventDefault();
+        const $triggerBtn = $(this);
+        const $btnGroup = $triggerBtn.closest('.cta-button-group');
+        $triggerBtn.attr('aria-expanded', 'true');
+        $btnGroup.find('.preview-btn, .search-inside-trigger-btn').hide();
+        $btnGroup.find('.search-inside-form').show().find('.search-inside-input').trigger('focus');
+    });
+
+    // Handle pressing Escape to collapse the search inside input form back
+    $(document).off('keydown.bookSearchInput').on('keydown.bookSearchInput', '.search-inside-input', function(e) {
+        if (e.key === 'Escape') {
+            const $btnGroup = $(this).closest('.cta-button-group');
+            collapseSearchForm($btnGroup);
+            e.stopPropagation();
+        }
+    });
+
+    // Handle clicking the cancel (&times;) button to collapse the form back
+    $(document).off('click.bookSearchCancel').on('click.bookSearchCancel', '.search-cancel-btn', function(e) {
+        e.preventDefault();
+        collapseSearchForm($(this).closest('.cta-button-group'));
+    });
+
+    // Handle search form submission to open query inside preview dialog modal
+    $(document).off('submit.bookSearchForm').on('submit.bookSearchForm', '.search-inside-form', function(e) {
+        e.preventDefault();
+        const $form = $(this);
+        const query = $form.find('.search-inside-input').val();
+        const ocaid = $form.data('ocaid');
+        const dialog = document.getElementById('bookPreview');
+        if (dialog) {
+            const iframe = dialog.querySelector('iframe');
+            if (iframe) {
+                iframe.src = `https://archive.org/details/${ocaid}?view=theater&wrapper=false&q=${encodeURIComponent(query)}`;
+            }
+            const link = dialog.querySelector('.learn-more a');
+            if (link) {
+                link.href = `https://archive.org/details/${ocaid}`;
+            }
+            dialog.open = true;
+        }
+        collapseSearchForm($form.closest('.cta-button-group'));
     });
 }
 

--- a/openlibrary/plugins/openlibrary/tests/test_home.py
+++ b/openlibrary/plugins/openlibrary/tests/test_home.py
@@ -129,6 +129,7 @@ class TestHomeTemplates:
 
         macros = web.template.Template.globals.setdefault("macros", web.storage())
         macros.BookPreview = lambda *args, **kwargs: '<div id="bookPreview"></div>'
+        macros.BookPreviewFloater = lambda *args, **kwargs: '<div id="bookPreview"></div>'
         html = str(render_template("home/index", stats=stats, test=True))
 
         assert "Recently Returned" in html

--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -14,7 +14,7 @@ $add_metatag(property="og:site_name", content="Open Library")
 
 <div id="contentBody">
 
-  $:macros.BookPreview('')
+  $:macros.BookPreviewFloater()
 
   $:render_template("home/welcome")
 

--- a/static/css/components/buttonCta.css
+++ b/static/css/components/buttonCta.css
@@ -291,3 +291,95 @@ form.return-form .cta-btn {
   margin-left: 1px;
   border-radius: 2px 6px 6px 2px;
 }
+
+/**
+ * Preview + Search Inside Buttons
+ */
+
+.book-preview-buttons {
+  gap: 6px;
+}
+
+/* stylelint-disable selector-max-specificity */
+.book-preview-buttons ol-button > button > .ol-btn-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+/* stylelint-enable selector-max-specificity */
+
+/**
+ * Search Inside Form
+ */
+
+.search-inside-form {
+  position: relative;
+  width: 100%;
+}
+
+.search-inside-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 6px 50px 6px 10px;
+  border: 1.5px solid var(--color-border-subtle);
+  border-radius: 4px;
+  font-size: var(--font-size-body-medium);
+}
+
+.search-submit-btn {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  right: 28px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+}
+
+.search-cancel-btn {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  right: 8px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: var(--dark-grey);
+  display: flex;
+  align-items: center;
+}
+
+.search-cancel-btn svg {
+  width: 18px;
+  height: 18px;
+  stroke: currentColor;
+}
+
+/**
+ * Book Preview Modal Content
+ */
+
+.book-preview {
+  display: flex;
+  flex-direction: column;
+  /* Max height of content fits viewport without scrolling the dialog body */
+  height: calc(100dvh - var(--ol-dialog-top-offset, 64px) - 160px);
+  min-height: 380px;
+  max-height: 515px;
+}
+
+.book-preview iframe {
+  flex: 1 1 auto;
+  width: 100%;
+  height: 100%;
+}
+
+.book-preview .learn-more {
+  margin-top: var(--spacing-md);
+  margin-bottom: 0;
+  text-align: center;
+}


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #12881

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR implements the unified "Preview" and inline "Search Inside" UI for books (Option C from the original design options in #12881). Based on design and triage discussions, it was decided that a full A/B/C test is not necessary; explicitly separating the buttons provides the most clarity and value to patrons.

### Technical
- Migrated legacy Colorbox book preview popup to the modern `<ol-dialog>` Lit component.
- Extracted the dialog container to a shared `macros/BookPreviewFloater.html` macro to avoid markup duplication and prevent container-clipping/stacking context issues inside carousels.
- Appended responsive container styling to `buttonCta.css` (using `calc(100dvh - offset - margins)`) to eliminate vertical scrollbars inside the modal wrapper.
- Cleaned up event handlers in `dialog.js` by introducing a `collapseSearchForm` helper.
- Added accessibility improvements (WCAG compliant iframe title, aria-expanded triggers, search form role/aria-label).
- Updated translation keys by generating POT files containing `"See more about this book on Archive.org"`.

### Testing
1. Visit a book search results page or detail page featuring books with ocaids.
2. Verify the "Preview" and "Search" buttons are rendered inline using the new `<ol-button>` style.
3. Click "Search" and check that the inline search form expands in place, correctly focusing the input. Press Escape or click the close icon to verify form collapse.
4. Submit a search query. The `<ol-dialog>` modal should open and display the Archive.org theater frame pre-populated with your search query highlighting.
5. Click "Preview" to open the standard book preview dialog.
6. Verify no vertical scrollbars are visible on the modal container itself.

### UI
<img width="645" height="885" alt="image" src="https://github.com/user-attachments/assets/f8ef80d0-e685-4f86-b8b3-11d355fc0fec" />
<img width="462" height="863" alt="image" src="https://github.com/user-attachments/assets/ccf07366-d9d9-4fd3-a012-8cdbfa2a48ce" />
<img width="1918" height="990" alt="image" src="https://github.com/user-attachments/assets/0a482aff-cbf6-4adb-a614-ee9c3b0648aa" />
<img width="1918" height="982" alt="image" src="https://github.com/user-attachments/assets/fb813f8c-f3cb-4ea5-82f7-40677712013f" />

### Stakeholders
@mekarpeles @lokesh
