### PR TITLE
feat(search-modal): add ResultsShown analytics event

### DIFF
--- a/openlibrary/plugins/openlibrary/js/search-modal/SearchModal.js
+++ b/openlibrary/plugins/openlibrary/js/search-modal/SearchModal.js
@@ -909,11 +909,11 @@ export class SearchModal extends LitElement {
         this._debouncedFetch = debounce(() => this._fetchResults(), 400, false);
         this._activeFetchKey = null;
         this._allLangsLoaded = false;
-        // NoResults analytics: keys (query+filters) already counted empty this
-        // modal session, so re-settling the same dead-end — a filter toggled off
-        // and back, an edit-and-undo — never re-fires. Reset per open.
-        this._noResultsTracked = new Set();
-        this._noResultsTimer   = null;
+        // Search-outcome analytics (NoResults / ResultsShown): keys already
+        // counted this modal session, so re-settling the same query — a filter
+        // toggled off and back, an edit-and-undo — never re-fires. Reset per open.
+        this._outcomeTracked = new Set();
+        this._outcomeTimer   = null;
     }
 
     connectedCallback() {
@@ -930,7 +930,7 @@ export class SearchModal extends LitElement {
 
     disconnectedCallback() {
         window.removeEventListener('pageshow', this._onPageShow);
-        clearTimeout(this._noResultsTimer);
+        clearTimeout(this._outcomeTimer);
         super.disconnectedCallback();
     }
 
@@ -954,7 +954,7 @@ export class SearchModal extends LitElement {
 
     _openModal(trigger = 'click') {
         this.open = true;
-        this._noResultsTracked.clear();
+        this._outcomeTracked.clear();
         this._track('Open', trigger);
         if (!this._allLangsLoaded && !this._langsLoading) {
             this._loadAllLanguages();
@@ -976,7 +976,7 @@ export class SearchModal extends LitElement {
     // (false); `clearReadableCount` is false in the main fetch's error path,
     // where the separate readable-count request owns that field.
     _resetResults({ hasSearched, clearReadableCount = true } = {}) {
-        clearTimeout(this._noResultsTimer);
+        clearTimeout(this._outcomeTimer);
         this._results           = [];
         this._authorSuggestions = [];
         this._numFound          = null;
@@ -1449,27 +1449,30 @@ export class SearchModal extends LitElement {
         trackEvent('SearchModal', action, label);
     }
 
-    // Fire NoResults only for a query the patron has settled on. Deferring the
-    // event behind a short idle window — and re-checking _activeFetchKey when it
-    // fires — drops the transient empties a query passes through while being
-    // typed: each keystroke starts a fresh fetch that supersedes this key, so
-    // only the query left standing counts (rather than every partial string on
-    // the way to it). The per-session Set collapses repeat settles of the same
-    // (query+filters) key — a filter toggled off and back, an edit-and-undo — to
-    // one event. Label by active filter *category* only (never the filter values
-    // or query text; that catalog-gap detail belongs in the server search logs,
-    // not analytics labels) so a genuine catalog gap (`unfiltered`) reads apart
-    // from an over-constrained search (`availability`/`language`/`availability+language`).
-    _scheduleNoResultsTrack(fetchKey) {
-        clearTimeout(this._noResultsTimer);
-        this._noResultsTimer = setTimeout(() => {
+    // Fire a search-outcome event — `ResultsShown` or `NoResults` — only for a
+    // query the patron has settled on. Deferring behind a short idle window (and
+    // re-checking _activeFetchKey when it fires) drops the transient states a
+    // query passes through while being typed: each keystroke starts a fresh fetch
+    // that supersedes this key, so only the query left standing counts (rather
+    // than every partial string on the way to it). The per-session Set collapses
+    // repeat settles of the same key — a filter toggled off and back, an
+    // edit-and-undo — to one event. Both outcomes carry the same active-filter
+    // *category* label (never the filter values or query text; that catalog-gap
+    // detail belongs in the server search logs) so a genuine catalog gap
+    // (`unfiltered`) reads apart from an over-constrained search — and so the
+    // no-results rate NoResults / (NoResults + ResultsShown) is sliceable by
+    // filter state.
+    _scheduleOutcomeTrack(action, fetchKey) {
+        clearTimeout(this._outcomeTimer);
+        this._outcomeTimer = setTimeout(() => {
             if (this._activeFetchKey !== fetchKey) return;   // query moved on
-            if (this._noResultsTracked.has(fetchKey)) return;
-            this._noResultsTracked.add(fetchKey);
+            const key = `${action}:${fetchKey}`;
+            if (this._outcomeTracked.has(key)) return;
+            this._outcomeTracked.add(key);
             const active = [];
             if (this._availability !== DEFAULT_AVAILABILITY) active.push('availability');
             if (this._languages.length > 0) active.push('language');
-            this._track('NoResults', active.length ? active.join('+') : 'unfiltered');
+            this._track(action, active.length ? active.join('+') : 'unfiltered');
         }, 1200);
     }
 
@@ -1480,9 +1483,9 @@ export class SearchModal extends LitElement {
     _onDialogClosed() {
         this.open = false;
         this._navigatingKey = null;
-        // Drop any pending NoResults timer so a search interrupted by closing
-        // the modal doesn't fire a phantom event after the fact.
-        clearTimeout(this._noResultsTimer);
+        // Drop any pending outcome timer so a search interrupted by closing the
+        // modal doesn't fire a phantom event after the fact.
+        clearTimeout(this._outcomeTimer);
         // Drop any in-flight spinner so a search interrupted by closing the
         // modal doesn't show a stale "Searching…" on reopen. The next keystroke
         // would clear it, but reopening to a frozen spinner looks broken.
@@ -1688,12 +1691,10 @@ export class SearchModal extends LitElement {
                 if (this._availability === 'readable') this._readableCount = this._numFound;
                 this._loading           = false;
                 this._hasSearched       = true;
-                // A settled autocomplete that came back empty — schedule (don't
-                // immediately fire) the NoResults event, so only a query the
-                // patron actually stops on is counted. See _scheduleNoResultsTrack.
-                if (this._results.length === 0) {
-                    this._scheduleNoResultsTrack(fetchKey);
-                }
+                // Record the settled outcome — ResultsShown or NoResults —
+                // deferred so only a query the patron actually stops on counts
+                // (not each partial typed on the way). See _scheduleOutcomeTrack.
+                this._scheduleOutcomeTrack(this._results.length === 0 ? 'NoResults' : 'ResultsShown', fetchKey);
             })
             .catch(() => {
                 if (this._activeFetchKey !== fetchKey) return;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
**feature** — Adds a `ResultsShown` analytics event to the search modal so search outcomes have a **denominator**.

Today the modal tracks when a search finds *nothing* (`NoResults`) but not when it *does* find something. That means we can count dead-ends but can't turn them into a rate — a rising `NoResults` count could just mean more searches, not worse search. This adds the missing "results were shown" event so we can finally ask:

> **no-results rate = `NoResults` / (`NoResults` + `ResultsShown`)**

`ResultsShown` carries the **same filter-category labels** as `NoResults` (`unfiltered` / `availability` / `language` / `availability+language`), so the rate is sliceable by filter state (e.g. "does *Readable Only* push people into more dead-ends?"). It also unlocks a click-through rate (`ResultClick` / `ResultsShown`) — i.e. "when we show results, do people pick one?"

To keep the two comparable, `ResultsShown` fires exactly like `NoResults`: once the patron settles on a query (not per keystroke), deduped per modal session.

> [!NOTE]
> Stacked on #13114 — that fix introduced the settle-and-dedupe machinery this reuses. The diff includes its commit until it merges.

### Stakeholders
@mekarpeles @cdrini @Armansiddiqui9 

