### PR TITLE
fix(a11y): add aria-label to ReadButton dropdown summary (WCAG 4.1.2)

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -8032,6 +8032,10 @@ msgid "Read ebook from Internet Archive"
 msgstr ""
 
 #: ReadButton.html
+msgid "More reading options"
+msgstr ""
+
+#: ReadButton.html
 msgid "Listen"
 msgstr ""
 

--- a/openlibrary/macros/ReadButton.html
+++ b/openlibrary/macros/ReadButton.html
@@ -33,7 +33,7 @@ $if any(menu_items) and not is_carousel:
           data-userid="$(loan['userid'])"
         >$label</a>
     <details class="cta-btn cta-btn--available">
-      <summary></summary>
+      <summary aria-label="$_('More reading options')"></summary>
       <ul class="dropper-menu">
         $if listen:
           <li>


### PR DESCRIPTION
## Summary

The "More reading options" `<details>`/`<summary>` dropdown on book lending buttons renders an empty `<summary>` with no accessible name — a **WCAG 4.1.2** violation (axe `summary-name`, `wcag2a`/`wcag412`, impact=serious) affecting screen reader users on **every search result page, author works page, and any book page** with listen/locate options.

The `<summary>` was intentionally left empty because it's styled as a chevron icon via CSS — but that leaves AT users with no way to know what the control does.

```diff
- <summary></summary>
+ <summary aria-label="$_('More reading options')"></summary>
```

Also adds the `More reading options` string to `messages.pot`.

## Note

This replaces #13011, which accidentally bundled ~80 unrelated files (a ruff `target-version` py314→py312 downgrade and the churn it triggered) and was not mergeable. This branch is cut fresh off current `master` and contains **only** the `ReadButton.html` fix + its i18n string.

## Test plan

Playwright regression test (`summary-name.spec.ts`) is staged on branch `12885/playwright-e2e-tests` (#12998). Once that infrastructure merges, CI will run axe-core against search results, author works, and book pages and assert 0 `summary-name` violations.

Manual:
```bash
OL_BASE_URL=http://localhost:8080 npx playwright test a11y/summary-name
```

## Related

- Tracking issue: #13007
- Playwright infrastructure: #12998
- Replaces: #13011
- Violation class: `summary-name` / WCAG 4.1.2
