### PR TITLE
Fix: Added want to read button on trending page

### DIFF
--- a/openlibrary/templates/trending.html
+++ b/openlibrary/templates/trending.html
@@ -28,7 +28,7 @@ $ page = int(input(page=1).page)
           $else:
             $ extra = ungettext('Logged %(count)i time %(time_unit)s', 'Logged %(count)i times %(time_unit)s', entry['cnt'], count=entry['cnt'], time_unit=pages[mode])
 
-          $:macros.SearchResultsWork(entry['work'], extra=extra, availability=entry['work'].get('availability'), seq_index=loop.index0)
+          $:macros.SearchResultsWork(entry['work'], extra=extra, availability=entry['work'].get('availability'), seq_index=loop.index0, include_dropper=True)
     </ul>
   </div>
   $:macros.OlPagination(page, total_pages=200 // 20)


### PR DESCRIPTION
Closes #12810

### Technical
The `SearchResultsWork` macro call in `trending.html` was missing the `include_dropper=True` parameter, so the reading-log widget (which renders the "Want to Read" button) was never rendered on trending pages. Every other listing page that shows this widget (`work_search.html`, `type/author/view.html`, `type/list/view_body.html`) already passes this flag.

Added `include_dropper=True` to the macro call at `openlibrary/templates/trending.html:31`. No changes needed elsewhere — the dropper uses `async_load=True` internally, so reading-log state is fetched client-side, and trending pages already provide Solr work documents via the `solr_work` code path in `SearchResultsWork.html`.

```diff
- $:macros.SearchResultsWork(entry['work'], extra=extra, availability=entry['work'].get('availability'), seq_index=loop.index0)
+ $:macros.SearchResultsWork(entry['work'], extra=extra, availability=entry['work'].get('availability'), seq_index=loop.index0, include_dropper=True)
```

### Testing
1. Log in and visit `/trending/now`.
2. Confirm each book in the list now shows a "Want to Read" button.
3. Click the button and confirm it opens the reading-log dropdown and updates state as expected (matching behavior on `/search`).
4. Check the other trending sub-pages (e.g. `/trending/daily`, `/trending/weekly`, `/trending/yearly`) to confirm the button appears there too.
5. Log out and revisit `/trending/now` to confirm logged-out behavior is unaffected/consistent with other listing pages.



### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
