### PR TITLE
Replace history_v2 feature flag with is_librarian_or_higher() check

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -60,7 +60,6 @@ http_request_timeout: 10
 features:
     debug: enabled
     dev: enabled
-    history_v2: admin
     recentchanges_v2: enabled
     stats: enabled
     stats-header: enabled

--- a/openlibrary/core/features.py
+++ b/openlibrary/core/features.py
@@ -28,7 +28,6 @@ class Features(BaseSettings):
 
     # debug: bool # disabled because we should probably get rid of it but we still have a `features.is_enabled("debug")` to deal with we didn't see in #12884
     # dev: bool # Warning: this is setup locally but not in testing/production
-    # history_v2: bool # is set to admin in local/testing but in production it's "librarians". We might want to get rid of the flag?
     stats: bool
     stats_header: bool
     # undo: bool # Warning: this is enabled locally but a usergroup of librarians in testing/production

--- a/openlibrary/templates/history/comment.html
+++ b/openlibrary/templates/history/comment.html
@@ -2,7 +2,7 @@ $def with (v)
 
 $ v = process_version(v)
 
-$if 'history_v2' in ctx.features:
+$if ctx.user and ctx.user.is_librarian_or_higher():
     $ kind = 'merge' if v.kind.startswith('merge-') else v.kind
     $ page = v.thing
 $else:

--- a/openlibrary/templates/lib/history.html
+++ b/openlibrary/templates/lib/history.html
@@ -1,7 +1,7 @@
 $def with (page)
 
 $ h = None
-$if "history_v2" not in ctx.features:
+$if not (ctx.user and ctx.user.is_librarian_or_higher()):
     $ h = page.get_history_preview()
 $if not h:
     $ h = get_history(page)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Part of #12946 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR removes the `history_v2` feature flag with a direct `is_librarian_or_higher()` permission check and removes the YAML entry.

The old flag was `admin` locally and in testing but `librarians` in production. Neither `is_admin()` nor `is_librarian()` alone matches all the environments. `is_librarian_or_higher()` covers all trusted roles (librarians, super-librarians, admins)

### Technical
<!-- What should be noted about the implementation? -->
- Removes `history_v2: admin` from `conf/openlibrary.yml`
- `openlibrary/templates/history/comment.html`: replaces `'history_v2' in ctx.features` with `ctx.user and ctx.user.is_librarian_or_higher()`
- `openlibrary/templates/lib/history.html`: replaces `"history_v2" not in ctx.features` with `not (ctx.user and ctx.user.is_librarian_or_higher())`
- Removes `# history_v2: bool` comment from `openlibrary/core/features.py` 

- Test left unchanged : `test_unknown_key_is_ignored` in `test_features.py` still uses `history_v2: admin` as the example unknown key. This is correct — `history_v2` is now an unknown key to the Features model, so the test still validates the same behavior.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
`make test-py-uv PYTEST_ARGS="openlibrary/tests/core/test_features.py`

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
