### PR TITLE
Remove leftover recentchanges_v2 feature flag from openlibrary.yml

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -60,7 +60,6 @@ http_request_timeout: 10
 features:
     debug: enabled
     dev: enabled
-    recentchanges_v2: enabled
     stats: enabled
     stats-header: enabled
     undo: enabled


### PR DESCRIPTION
Part of #12946

Follow-up to #13094, which removed the `recentchanges_v2` flag from the code but left its declaration behind in the in-repo dev config.

### Technical
- #13094 deleted every reader of `recentchanges_v2`: the field in `openlibrary/core/features.py`, the `features.is_enabled("recentchanges_v2")` gates in `openlibrary/plugins/upstream/recentchanges.py`, its use in `templates/type/user/view.html`, and its test. But the flag was still declared under `features:` in `conf/openlibrary.yml`.
- With nothing reading it, that line is dead config. The new pydantic `Features` loader already skips YAML keys that aren't model fields (`from_yaml` does `if normalized_key not in cls.model_fields: continue`), so the entry was being silently ignored — this just removes it so the flag is fully gone.
- This matches the complete-removal pattern already used for the `superfast` flag in #13100, which removed both the code and the `conf/openlibrary.yml` entry.
- Only the `recentchanges_v2` line is removed. `debug`, `dev`, `stats`, `stats-header`, and `undo` are left untouched — each of those is still read by live code.

### Testing
- `grep -rn recentchanges_v2` across the tree (excluding `vendor/` and `node_modules/`) returns nothing after this change.
- Confirmed `conf/openlibrary.yml` still parses and that `Features.from_yaml("conf/openlibrary.yml")` loads cleanly with the entry removed (`stats` / `stats-header` still resolve, and the process-wide singleton loads).
- No behaviour change and no test added or removed — this deletes dead configuration only. The existing feature-flag tests in `openlibrary/tests/core/test_features.py` are unaffected.

### Screenshot
N/A — configuration cleanup, no UI change.

### Stakeholders
Part of the Feature Flags Migration epic (#12946). cc @RayBB, who reviewed and merged the earlier `Part of #12946` flag-removal PRs.

---
🤖 Opened with [Superhuman](https://github.com/gaurav0107/superhuman), an open-source contribution agent.