### PR TITLE
Replace dev feature flag with LOCAL_DEV

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -59,7 +59,6 @@ http_request_timeout: 10
 
 features:
     debug: enabled
-    dev: enabled
     stats: enabled
     stats-header: enabled
     undo: enabled

--- a/openlibrary/core/admin.py
+++ b/openlibrary/core/admin.py
@@ -6,8 +6,8 @@ from datetime import date, datetime, timedelta
 import requests
 import web
 
-from infogami import config
 from openlibrary.core import cache
+from openlibrary.core.env import get_ol_env
 
 from . import db
 
@@ -88,7 +88,7 @@ class LoanStats(Stats):
 
     def get_counts(self, ndays=28, times=False):
         # Let dev.openlibrary.org show the true state of things
-        if "dev" in config.features:
+        if get_ol_env().LOCAL_DEV:
             return Stats.get_counts(self, ndays, times)
 
         if graphite_data := _get_loan_counts_from_graphite(ndays):

--- a/openlibrary/core/features.py
+++ b/openlibrary/core/features.py
@@ -27,7 +27,6 @@ class Features(BaseSettings):
     model_config = {"extra": "ignore"}
 
     # debug: bool # disabled because we should probably get rid of it but we still have a `features.is_enabled("debug")` to deal with we didn't see in #12884
-    # dev: bool # Warning: this is setup locally but not in testing/production
     stats: bool
     stats_header: bool
     # undo: bool # Warning: this is enabled locally but a usergroup of librarians in testing/production

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -24,6 +24,7 @@ from openlibrary.core import db
 from openlibrary.core.batch_imports import (
     batch_import,
 )
+from openlibrary.core.env import get_ol_env
 from openlibrary.core.features import features as ol_features
 from openlibrary.core.jinja import render_jinja_template
 from openlibrary.i18n import gettext as _
@@ -369,7 +370,7 @@ class robotstxt(delegate.page):
 
     def GET(self):
         web.header("Content-Type", "text/plain")
-        is_dev = "dev" in infogami.config.features or web.ctx.host != "openlibrary.org"
+        is_dev = get_ol_env().LOCAL_DEV or web.ctx.host != "openlibrary.org"
         robots_file = "norobots.txt" if is_dev else "robots.txt"
         return web.ok(open(f"static/{robots_file}").read())
 
@@ -1142,6 +1143,7 @@ def setup_template_globals():
             "ol_features": ol_features,
             "render_jinja_template": render_jinja_template,
             "get_sentry": get_sentry,
+            "get_ol_env": get_ol_env,
             # bad use of globals
             "is_bot": is_bot,
             "time": time,

--- a/openlibrary/plugins/openlibrary/deprecated_handler.py
+++ b/openlibrary/plugins/openlibrary/deprecated_handler.py
@@ -8,14 +8,14 @@ This is temporary while we migrate to fastapi and have two containers running.
 import httpx
 import web
 
-import infogami
 from infogami.utils import delegate
+from openlibrary.core.env import get_ol_env
 
 
 def handle_deprecated_request():
     """Handle the deprecated endpoint request."""
     # Check if we're in dev environment
-    if "dev" in infogami.config.features:
+    if get_ol_env().LOCAL_DEV:
         return proxy_to_fastapi()
     else:
         # Raise a loud error in production

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -9,7 +9,7 @@ from infogami import config  # noqa: F401 side effects may be needed
 from infogami.infobase.client import storify
 from infogami.utils import delegate
 from infogami.utils.view import public, render_template
-from openlibrary.core import admin, cache, ia, lending
+from openlibrary.core import admin, cache, env, ia, lending
 from openlibrary.i18n import gettext as _
 from openlibrary.plugins.upstream.utils import (
     convert_iso_to_marc,
@@ -69,7 +69,7 @@ def get_cached_homepage():
         key += ".bot"
 
     mc = cache.memcache_memoize(get_homepage, key, timeout=five_minutes, prethread=caching_prethread())
-    devmode = "dev" in web.ctx.features
+    devmode = env.get_ol_env().LOCAL_DEV
     page = mc(devmode)
 
     if not page:
@@ -109,7 +109,7 @@ class home(delegate.page):
     path = "/"
 
     def GET(self):
-        if devmode := "dev" in web.ctx.features:
+        if devmode := env.get_ol_env().LOCAL_DEV:
             homepage_data = get_homepage(devmode)
         else:
             homepage_data = get_cached_homepage()

--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -35,7 +35,7 @@ $add_metatag(property="og:site_name", content="Open Library")
     $:macros.QueryCarousel(title=_('Textbooks'), key="textbooks", query="subject_key:textbooks publish_year:[1990 TO *] ebook_access:[borrowable TO *]", url="/subjects/textbooks", sort='trending', user_lang_only=True)
     $:macros.QueryCarousel(title=_("Authors Alliance & MIT Press"), key="authorsalliance_mit_press", query='(subject:authorsalliance OR publisher:"MIT Press" OR subject:mitpress) ebook_access:[borrowable TO *]', sort='trending', user_lang_only=True)
 
-  $if "dev" in ctx.features:
+  $if get_ol_env().LOCAL_DEV:
     $:macros.QueryCarousel(title=_('Books in Local Environment'), query='*', use_cache=False)
 
   $:render_template("home/categories", test=test)

--- a/openlibrary/templates/login.html
+++ b/openlibrary/templates/login.html
@@ -8,7 +8,7 @@ $putctx("cssfile", "signup")
 
 $var title: $_("Log In")
 
-$if "dev" in ctx.features:
+$if get_ol_env().LOCAL_DEV:
     <div class="flash-messages" id="autofill-dev-credentials">
         <div class="info ol-signup-form__info-box">
             <span>

--- a/openlibrary/templates/site/head.html
+++ b/openlibrary/templates/site/head.html
@@ -86,7 +86,7 @@ $def with (title)
  */
   </script>
 
-    $if "dev" in ctx.features:
+    $if get_ol_env().LOCAL_DEV:
         <link href="$static_url('build/css/page-dev.css')" rel="stylesheet" type="text/css"/>
 
     <meta name="google-site-verification" content="KrqcZD4l5BLNVyjzSi2sjZBiwgmkJ1W7n6w7ThD7A74" />


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Part of #12946 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR replaces the legacy `"dev" in ctx.features` / `"dev" in config.features` checks with `get_ol_env().LOCAL_DEV`, as it's an environment indicator (only enabled locally,not in testing/production). 


### Technical
<!-- What should be noted about the implementation? -->
- Removed `dev: enabled` from `conf/openlibrary.yml` 
- Replaced all `"dev" in ... features` checks with `get_ol_env().LOCAL_DEV`.
- Added `get_ol_env` to `web.template.Template.globals` for template access
- Removed stale `# dev: bool` comment from the pydantic `Features` model.
- Unused `import infogami` removed from `admin.py` and `deprecated_handler.py`

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
No behavioral change: `LOCAL_DEV` is never set in production, same as old `dev` flag

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
