### PR TITLE
Update S3 key removal script

### DIFF
--- a/scripts/purge_s3_keys.py
+++ b/scripts/purge_s3_keys.py
@@ -12,36 +12,109 @@ With --dry-run, prints accounts that would be modified without writing.
 """
 
 import argparse
+import json
 import sys
 
-import web
+from psycopg2 import DatabaseError
+
+from openlibrary.core import db
+from openlibrary.setup import setup_for_script
+from scripts.utils.graceful_shutdown import init_signal_handler, was_shutdown_requested
 
 
-def purge_s3_keys(dry_run: bool = False) -> None:
-    modified = 0
-    skipped = 0
+DEFAULT_CONFIG_PATH = "/olsystem/etc/openlibrary.yml"
 
-    for doc in web.ctx.site.store.values(type="account"):
-        if "s3_keys" not in doc:
-            skipped += 1
-            continue
-        key = doc["_key"]
-        if dry_run:
-            print(f"[dry-run] would remove s3_keys from {key}")
-        else:
-            del doc["s3_keys"]
-            web.ctx.site.store[key] = doc
-            print(f"removed s3_keys from {key}")
-        modified += 1
+def setup(config_path=DEFAULT_CONFIG_PATH):
+    setup_for_script(config_path)
+    init_signal_handler()
 
-    print(f"\nDone: {modified} modified, {skipped} skipped (no s3_keys).")
+def get_all_affected_keys():
+    query = """
+        SELECT key FROM store
+        WHERE id IN (
+            SELECT store_id FROM store_index
+            WHERE type = 'account'
+                AND name = 's3_keys.access'
+        )
+    """
+    oldb = db.get_db()
+    rs = oldb.query(query)
+    return iter(rs)
 
+def get_affected_keys_batch(limit=100_000):
+    query = """
+        SELECT key FROM store
+        WHERE id IN (
+            SELECT store_id FROM store_index
+            WHERE type = 'account'
+                AND name = 's3_keys.access'
+            LIMIT $limit
+        )
+    """
+    oldb = db.get_db()
+    rs = oldb.query(query, vars={"limit": limit})
+    return iter(rs)
+
+def update_record(key: str) -> bool:
+    acct_rec_query = "SELECT id, json FROM store WHERE key = $key"
+    acct_rec_update_query = "UPDATE store SET json = $json WHERE key = $key"
+    store_index_delete_query = """
+       DELETE FROM store_index
+       WHERE
+           store_id = $store_id 
+           AND name IN ('s3_keys.access', 's3_keys.secret')
+   """
+
+    oldb = db.get_db()
+    t = oldb.transaction()
+    try:
+        # Fetch account record:
+        rs = oldb.query(acct_rec_query, vars={"key": key})
+        result = next(iter(rs))
+        acct_rec_json = result.get('json')
+        store_id = result.get('id')
+
+        # Update account record
+        acct_rec = json.loads(acct_rec_json)
+        if 's3_keys' in acct_rec:
+            del acct_rec['s3_keys']
+        oldb.query(
+            acct_rec_update_query,
+            vars={"key": key, "json": json.dumps(acct_rec)}
+        )
+
+        # Delete keys from store_index
+        oldb.query(store_index_delete_query, vars={"store_id": store_id})
+        t.commit()
+    except DatabaseError as e:
+        t.rollback()
+        return False
+
+    return True
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--dry-run", action="store_true", help="Print accounts without writing")
     args = parser.parse_args()
-    purge_s3_keys(dry_run=args.dry_run)
+
+    setup()
+
+    if args.dry_run:
+        it = get_all_affected_keys()
+        for record in it:
+            print(record["key"])
+            if was_shutdown_requested():
+                return 130
+    else:
+        while (it := get_affected_keys_batch()) and len(it):
+            for record in it:
+                key = record["key"]
+                success = update_record(key)
+                if not success:
+                    print(f"Failed to update {key}")
+                if was_shutdown_requested():
+                    return 130
+
     return 0
 
 

--- a/scripts/purge_s3_keys.py
+++ b/scripts/purge_s3_keys.py
@@ -45,6 +45,7 @@ def get_affected_keys(limit: int | None = 100_000):
 
 
 def update_record(key: str) -> bool:
+    """Key is a user account of the shape account/mekBot"""
     acct_rec_query = "SELECT id, json FROM store WHERE key = $key"
     acct_rec_update_query = "UPDATE store SET json = $json WHERE key = $key"
     store_index_delete_query = """

--- a/scripts/purge_s3_keys.py
+++ b/scripts/purge_s3_keys.py
@@ -28,20 +28,7 @@ def setup(config_path=DEFAULT_CONFIG_PATH):
     setup_for_script(config_path)
     init_signal_handler()
 
-def get_all_affected_keys():
-    query = """
-        SELECT key FROM store
-        WHERE id IN (
-            SELECT store_id FROM store_index
-            WHERE type = 'account'
-                AND name = 's3_keys.access'
-        )
-    """
-    oldb = db.get_db()
-    rs = oldb.query(query)
-    return iter(rs)
-
-def get_affected_keys_batch(limit=100_000):
+def get_affected_keys(limit: int|None=100_000):
     query = """
         SELECT key FROM store
         WHERE id IN (
@@ -100,13 +87,13 @@ def main():
     setup()
 
     if args.dry_run:
-        it = get_all_affected_keys()
+        it = get_affected_keys(limit=None)
         for record in it:
             print(record["key"])
             if was_shutdown_requested():
                 return 130
     else:
-        while (it := get_affected_keys_batch()) and len(it):
+        while (it := get_affected_keys()) and len(it):
             for record in it:
                 key = record["key"]
                 success = update_record(key)

--- a/scripts/purge_s3_keys.py
+++ b/scripts/purge_s3_keys.py
@@ -21,14 +21,15 @@ from openlibrary.core import db
 from openlibrary.setup import setup_for_script
 from scripts.utils.graceful_shutdown import init_signal_handler, was_shutdown_requested
 
-
 DEFAULT_CONFIG_PATH = "/olsystem/etc/openlibrary.yml"
+
 
 def setup(config_path=DEFAULT_CONFIG_PATH):
     setup_for_script(config_path)
     init_signal_handler()
 
-def get_affected_keys(limit: int|None=100_000):
+
+def get_affected_keys(limit: int | None = 100_000):
     query = """
         SELECT key FROM store
         WHERE id IN (
@@ -42,13 +43,14 @@ def get_affected_keys(limit: int|None=100_000):
     rs = oldb.query(query, vars={"limit": limit})
     return iter(rs)
 
+
 def update_record(key: str) -> bool:
     acct_rec_query = "SELECT id, json FROM store WHERE key = $key"
     acct_rec_update_query = "UPDATE store SET json = $json WHERE key = $key"
     store_index_delete_query = """
        DELETE FROM store_index
        WHERE
-           store_id = $store_id 
+           store_id = $store_id
            AND name IN ('s3_keys.access', 's3_keys.secret')
    """
 
@@ -58,26 +60,24 @@ def update_record(key: str) -> bool:
         # Fetch account record:
         rs = oldb.query(acct_rec_query, vars={"key": key})
         result = next(iter(rs))
-        acct_rec_json = result.get('json')
-        store_id = result.get('id')
+        acct_rec_json = result.get("json")
+        store_id = result.get("id")
 
         # Update account record
         acct_rec = json.loads(acct_rec_json)
-        if 's3_keys' in acct_rec:
-            del acct_rec['s3_keys']
-        oldb.query(
-            acct_rec_update_query,
-            vars={"key": key, "json": json.dumps(acct_rec)}
-        )
+        if "s3_keys" in acct_rec:
+            del acct_rec["s3_keys"]
+        oldb.query(acct_rec_update_query, vars={"key": key, "json": json.dumps(acct_rec)})
 
         # Delete keys from store_index
         oldb.query(store_index_delete_query, vars={"store_id": store_id})
         t.commit()
-    except DatabaseError as e:
+    except DatabaseError:
         t.rollback()
         return False
 
     return True
+
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Follows #12860

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Makes the following updates to `purge_s3_keys.py`:
- Gracefully shuts down on `KeyboardInterrupt`
- Affected rows are updated using DML

### Technical
<!-- What should be noted about the implementation? -->
Using the store API to update all items of a type is error-prone. Most store methods will only return 1,000 items, and the methods return rows ordered by `ID` descending.  If an object with key `k` is updated using the store API, the updated record will get a new `ID` (IDs in the store table are not stable).  For these reasons, I've opted to updated the affected rows using DML queries.

The original `purge_s3_keys` function has been replaced by two new functions:

`get_affected_keys` returns the keys of affected store table entries.  By default, 100,000 keys will be returned when this is called.  Passing `limit=None` when calling this function will return _all_ affected keys (this is used when the script's `--dry-run` flag is present).

`update_record` removes the given account's S3 keys from the `store` and `store_index` tables. Each account's keys will be removed in a single transaction.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
