### PR TITLE
Fix author date precision matching

### DIFF
--- a/openlibrary/catalog/utils/__init__.py
+++ b/openlibrary/catalog/utils/__init__.py
@@ -40,6 +40,56 @@ re_l_in_date = re.compile(r"(l\d|\dl)")
 re_end_dot = re.compile(r"[^ .][^ .]\.$", re.UNICODE)
 re_marc_name = re.compile("^(.*?),+ (.*)$")
 re_year = re.compile(r"\b(\d{4})\b")
+re_iso_date = re.compile(r"\b(?P<year>\d{4})-(?P<month>\d{1,2})-(?P<day>\d{1,2})\b")
+re_numeric_date = re.compile(r"\b(?P<month>\d{1,2})/(?P<day>\d{1,2})/(?P<year>\d{4})\b")
+re_day_month_year = re.compile(r"\b(?P<day>\d{1,2})(?:st|nd|rd|th)?[,\s]+(?P<month>[A-Za-z.]+)[,\s]+(?P<year>\d{4})\b", re.IGNORECASE)
+re_month_day_year = re.compile(r"\b(?P<month>[A-Za-z.]+)[,\s]+(?P<day>\d{1,2})(?:st|nd|rd|th)?[,]?\s+(?P<year>\d{4})\b", re.IGNORECASE)
+
+MONTHS = {
+    "jan": 1,
+    "january": 1,
+    "feb": 2,
+    "february": 2,
+    "mar": 3,
+    "march": 3,
+    "apr": 4,
+    "april": 4,
+    "may": 5,
+    "jun": 6,
+    "june": 6,
+    "jul": 7,
+    "july": 7,
+    "aug": 8,
+    "august": 8,
+    "sep": 9,
+    "sept": 9,
+    "september": 9,
+    "oct": 10,
+    "october": 10,
+    "nov": 11,
+    "november": 11,
+    "dec": 12,
+    "december": 12,
+}
+
+
+def full_date_parts(date: str) -> tuple[int, int, int] | None:
+    for regex in (re_iso_date, re_numeric_date, re_day_month_year, re_month_day_year):
+        if m := regex.search(date):
+            year = int(m.group("year"))
+            day = int(m.group("day"))
+            month_value = m.group("month")
+            month: int | None
+            if month_value.isdigit():
+                month = int(month_value)
+            else:
+                month = MONTHS.get(month_value.strip(".").lower())
+            if month is None:
+                return None
+
+            if 1 <= month <= 12 and 1 <= day <= 31:
+                return (year, month, day)
+    return None
 
 
 def key_int(rec):
@@ -62,6 +112,12 @@ def author_dates_match(a: AuthorImportDict, b: dict | Author) -> bool:
             continue
         if a[k] == b[k] or a[k].startswith(b[k]) or b[k].startswith(a[k]):
             continue
+        full_date_a = full_date_parts(a[k])
+        full_date_b = full_date_parts(b[k])
+        if full_date_a and full_date_b:
+            if full_date_a == full_date_b:
+                continue
+            return False
         m1 = re_year.search(a[k])
         if not m1:
             return False

--- a/openlibrary/tests/catalog/test_utils.py
+++ b/openlibrary/tests/catalog/test_utils.py
@@ -76,8 +76,11 @@ def test_author_dates_match():
     # This method only compares dates and ignores names
     assert author_dates_match(no_dates, different_name)
     assert author_dates_match(basic, non_match) is False
-    # FIXME: the following should properly be False:
-    assert author_dates_match(full_different, full_dates)  # this shows matches are only occurring on year, full dates are ignored!
+    assert author_dates_match(full_different, full_dates) is False
+    assert author_dates_match(
+        {"birth_date": "September 14th, 1829", "death_date": "11/2/1910"},
+        {"birth_date": "1829-09-14", "death_date": "November 1910"},
+    )
 
 
 def test_flip_name():


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #13065

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes author date matching so two fully specified dates with different month/day values no longer match just because they share the same year. Year-only and partial-date comparisons still fall back to the existing year-based behavior for import tolerance.

### Technical
<!-- What should be noted about the implementation? -->
- Adds normalization for common full date formats used by catalog/import data: `YYYY-MM-DD`, `M/D/YYYY`, `day month year`, and `month day year`.
- Compares normalized full-date tuples before falling back to year-only matching.
- Updates the existing FIXME test to assert the correct non-match behavior and preserves a mixed-format import case.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- `docker compose run --rm --no-deps -e PYTHONPATH=/openlibrary/vendor/infogami home python -m ruff check openlibrary/catalog/utils/__init__.py openlibrary/tests/catalog/test_utils.py`
- `docker compose run --rm --no-deps -e PYTHONPATH=/openlibrary/vendor/infogami home python -m pytest openlibrary/tests/catalog/test_utils.py openlibrary/catalog/utils/tests/test_catalog_utils.py openlibrary/catalog/add_book/tests/test_load_book.py::TestImportAuthor::test_birth_and_death_date_match_is_on_year_strings -q`
- `docker compose run --rm --no-deps -e PYTHONPATH=/openlibrary/vendor/infogami home python -m pytest openlibrary/catalog/add_book/tests/test_load_book.py -q`

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@jimchamp

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->