### PR TITLE
perf: avoid duplicate IA loan API call in get_loan

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -636,10 +636,14 @@ def get_loan(identifier: str, user_key: str | None = None):
     except Exception:  # TODO: Narrow exception scope
         logger.exception(f"get_loan({identifier}) 1 of 2")
 
-    try:
-        _loan = _get_ia_loan(identifier, account and account.itemname)
-    except Exception:  # TODO: Narrow exception scope
-        logger.exception(f"get_loan({identifier}) 2 of 2")
+    # Only look up by the linked IA account when the OL-username lookup found
+    # nothing; an unconditional second call would duplicate the anonymous query
+    # and overwrite a loan found above.
+    if account and account.itemname and not _loan:
+        try:
+            _loan = _get_ia_loan(identifier, account.itemname)
+        except Exception:  # TODO: Narrow exception scope
+            logger.exception(f"get_loan({identifier}) 2 of 2")
 
     return _loan
 

--- a/openlibrary/tests/core/test_lending.py
+++ b/openlibrary/tests/core/test_lending.py
@@ -101,3 +101,54 @@ class TestGetAvailability:
             assert mock_get.call_count == 2
             assert mock_get.call_args[1]["params"]["identifier"] == "bar"
             assert r3 == {"foo": foo_expected, "bar": bar_expected}
+
+
+class TestGetLoan:
+    """get_loan should make at most the necessary IA loan-API calls."""
+
+    @pytest.fixture(autouse=True)
+    def setup_mocks(self, monkeypatch):
+        mock_site = Mock()
+        mock_site.get.return_value.store.get.return_value = None
+        monkeypatch.setattr(lending, "site", mock_site)
+        self.mock_get_ia_loan = Mock(return_value=None)
+        monkeypatch.setattr(lending, "_get_ia_loan", self.mock_get_ia_loan)
+
+    def make_account(self, monkeypatch, username="mek", itemname="@mek"):
+        account = Mock()
+        account.username = username
+        account.itemname = itemname
+        monkeypatch.setattr(lending.OpenLibraryAccount, "get_by_key", Mock(return_value=account))
+        return account
+
+    def test_anonymous_lookup_calls_api_once(self):
+        loan = Mock()
+        self.mock_get_ia_loan.return_value = loan
+
+        assert lending.get_loan("foo00bar") is loan
+        self.mock_get_ia_loan.assert_called_once_with("foo00bar", None)
+
+    def test_loan_found_by_username_is_not_clobbered(self, monkeypatch):
+        self.make_account(monkeypatch)
+        loan = Mock()
+        self.mock_get_ia_loan.return_value = loan
+
+        assert lending.get_loan("foo00bar", user_key="/people/mek") is loan
+        self.mock_get_ia_loan.assert_called_once_with("foo00bar", "ol:mek")
+
+    def test_falls_back_to_itemname_when_username_finds_nothing(self, monkeypatch):
+        self.make_account(monkeypatch)
+        loan = Mock()
+        self.mock_get_ia_loan.side_effect = [None, loan]
+
+        assert lending.get_loan("foo00bar", user_key="/people/mek") is loan
+        assert self.mock_get_ia_loan.call_args_list == [
+            (("foo00bar", "ol:mek"),),
+            (("foo00bar", "@mek"),),
+        ]
+
+    def test_account_without_itemname_calls_api_once(self, monkeypatch):
+        self.make_account(monkeypatch, itemname=None)
+
+        assert lending.get_loan("foo00bar", user_key="/people/mek") is None
+        self.mock_get_ia_loan.assert_called_once_with("foo00bar", "ol:mek")


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Performance fix (with a correctness fix included): removes a redundant blocking HTTP POST to the archive.org loan API from every edition-page loan check.

### Estimated performance gain

**~30–150 ms off server render time (p50–p90) for every anonymous edition-page loan check, and worst-case stalls halved from 2× to 1× the API timeout.** The loan check is a synchronous cross-service POST on the render path; this PR halves the number of calls, so the saving is one full loan-API round-trip. Estimates assume typical same-datacenter latency to the IA loan service; measure with the existing `stats` timing on `get_loan` callers to confirm.

```mermaid
xychart-beta
    title "Blocking loan-API calls per anonymous loan check"
    x-axis ["Before", "After"]
    y-axis "sequential HTTP POSTs" 0 --> 2
    bar [2, 1]
```

For user-scoped lookups the second call still happens, but only when it can matter (linked `@itemname` and the first lookup found nothing) — previously it ran unconditionally.

### Technical

**Problem.** `get_loan()` in `openlibrary/core/lending.py` made two sequential, unconditional calls to `_get_ia_loan()`, each a blocking `requests.post` to the IA loan API, and the second call unconditionally overwrote the first's result:

```python
try:
    _loan = _get_ia_loan(identifier, account and userkey2userid(account.username))
except Exception: ...
try:
    _loan = _get_ia_loan(identifier, account and account.itemname)  # clobbers!
except Exception: ...
```

This had three concrete consequences:

1. **Duplicate identical call for anonymous lookups.** When `user_key is None` (the common case — `get_edition_loans()` in `plugins/upstream/borrow.py` calls `get_loan(ocaid)` with no user on edition-page renders, and `is_loaned_out_on_ol()` does the same), `account` is `None`, so both calls were byte-for-byte identical POSTs. Every loan-status check paid for two round-trips to the loan API where one suffices.
2. **A found loan could be clobbered.** If the first (ol:username) lookup found a loan and the second (itemname) lookup returned `None`, the function returned `None` — losing a real loan.
3. **Unfiltered fallback for accounts without a linked IA item.** When `account.itemname` is `None`, the second call was made with `userid=None`, i.e. an *unfiltered* query that returns any loan on the identifier — so a user-scoped `get_loan(identifier, user_key)` could return another patron's loan.

**Fix.** The second lookup now runs only when it can produce new, correctly-scoped information: `if account and account.itemname and not _loan`. Anonymous lookups make exactly one API call; user-scoped lookups fall back to the `@itemname` query only when the `ol:username` query found nothing.

**Out of scope (pre-existing, noted for reviewers):** the store-loan block just above (`d = site.get().store.get("loan-" + identifier)`) constructs a `Loan(d)` that is never returned when unexpired; that dead code predates this PR and is untouched.

### Testing

New `TestGetLoan` in `openlibrary/tests/core/test_lending.py` (mocks `lending.site` and `lending._get_ia_loan`):
- anonymous lookup → exactly one API call, result propagated
- account lookup that finds a loan under `ol:username` → no second call, loan not clobbered
- account lookup that finds nothing → falls back to exactly one `@itemname` call
- account with no linked `itemname` → exactly one call

Reproduce: `make test-py-uv PYTEST_ARGS="openlibrary/tests/core/test_lending.py"` — 8 passed. `pre-commit run --files openlibrary/core/lending.py openlibrary/tests/core/test_lending.py` — all hooks pass (incl. mypy, ruff).

### Screenshot
N/A — no UI change.

### Stakeholders
Part of a performance-review series; see the review report branch `claude/performance-review-top-changes-5wcs7g`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ky5Sc19MGPkDgbgTWWWET