### PR TITLE
perf: batch the per-doc ratings lookup on the reading log

### DIFF
--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -1316,10 +1316,9 @@ class LoggedBooksData:
         The intent of this is so that there is no need to query ratings from the
         template, as the docs and ratings are together when needed.
         """
-        for doc in self.docs:
-            work_id = extract_numeric_id_from_olid(doc.key)
-            rating = Ratings.get_users_rating_for_work(self.username, work_id)
-            self.ratings.append(rating or 0)
+        work_ids = [extract_numeric_id_from_olid(doc.key) for doc in self.docs]
+        users_ratings = Ratings.get_users_ratings_for_works(self.username, work_ids)
+        self.ratings += [users_ratings.get(int(work_id), 0) for work_id in work_ids]
 
 
 def register_models():

--- a/openlibrary/core/ratings.py
+++ b/openlibrary/core/ratings.py
@@ -151,6 +151,16 @@ class Ratings(db.CommonExtras):
         return rating
 
     @classmethod
+    def get_users_ratings_for_works(cls, username: str, work_ids: list[str] | list[int]) -> dict[int, int]:
+        """Returns a map of work_id to rating for all of work_ids the user has rated."""
+        if not work_ids:
+            return {}
+        oldb = db.get_db()
+        data = {"username": username, "work_ids": [int(work_id) for work_id in work_ids]}
+        query = "SELECT work_id, rating from ratings where username=$username AND work_id IN $work_ids"
+        return {row.work_id: row.rating for row in oldb.query(query, vars=data)}
+
+    @classmethod
     def remove(cls, username, work_id):
         oldb = db.get_db()
         where = {"username": username, "work_id": int(work_id)}

--- a/openlibrary/tests/core/test_db.py
+++ b/openlibrary/tests/core/test_db.py
@@ -502,3 +502,40 @@ class TestYearlyReadingGoals:
         assert len(list(self.db.select(self.TABLENAME, where={"username": "@billy_pilgrim"}))) == 2
         YearlyReadingGoals.delete_by_username("@billy_pilgrim")
         assert len(list(self.db.select(self.TABLENAME, where={"username": "@billy_pilgrim"}))) == 0
+
+
+class TestGetUsersRatingsForWorks:
+    @classmethod
+    def setup_class(cls):
+        web.config.db_parameters = {"dbn": "sqlite", "db": ":memory:"}
+        db = get_db()
+        has_ratings_table = list(db.query("SELECT name FROM sqlite_master WHERE type='table' AND name='ratings'"))
+        if not has_ratings_table:
+            db.query(RATINGS_DDL)
+
+    def setup_method(self):
+        self.db = get_db()
+        self.db.multiple_insert(
+            "ratings",
+            [
+                {"username": "@kilgore_trout", "work_id": 1, "edition_id": 1, "rating": 4},
+                {"username": "@kilgore_trout", "work_id": 3, "edition_id": 3, "rating": 5},
+                {"username": "@billy_pilgrim", "work_id": 2, "edition_id": 2, "rating": 2},
+            ],
+        )
+
+    def teardown_method(self):
+        self.db.query("delete from ratings;")
+
+    def test_batch_lookup_returns_only_users_rated_works(self):
+        ratings = Ratings.get_users_ratings_for_works("@kilgore_trout", ["1", "2", "3"])
+        assert ratings == {1: 4, 3: 5}
+
+    def test_batch_lookup_accepts_ints(self):
+        assert Ratings.get_users_ratings_for_works("@billy_pilgrim", [1, 2, 3]) == {2: 2}
+
+    def test_empty_work_ids_makes_no_query(self):
+        assert Ratings.get_users_ratings_for_works("@kilgore_trout", []) == {}
+
+    def test_unknown_user_has_no_ratings(self):
+        assert Ratings.get_users_ratings_for_works("@montana_wildhack", ["1", "2", "3"]) == {}

--- a/openlibrary/tests/core/test_models.py
+++ b/openlibrary/tests/core/test_models.py
@@ -257,3 +257,29 @@ class TestWork:
             assert resolved_work.key == work4_key, f"Should be work4.key: {resolved_work}"
         finally:
             site_var.reset(token)
+
+
+class TestLoggedBooksDataLoadRatings:
+    def test_ratings_align_with_docs_and_default_to_zero(self, monkeypatch):
+        docs = [
+            web.storage(key="/works/OL3W"),
+            web.storage(key="/works/OL1W"),
+            web.storage(key="/works/OL2W"),
+        ]
+        logged_books = models.LoggedBooksData(
+            username="@kilgore_trout",
+            page_size=25,
+            total_results=3,
+            shelf_totals={},
+            docs=docs,
+        )
+        monkeypatch.setattr(
+            models.Ratings,
+            "get_users_ratings_for_works",
+            classmethod(lambda cls, username, work_ids: {3: 5, 2: 1}),
+        )
+
+        logged_books.load_ratings()
+
+        # One rating per doc, in doc order, 0 for unrated works.
+        assert logged_books.ratings == [5, 0, 1]


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Performance fix: collapses a classic N+1 query pattern on the My Books reading log — one `SELECT` per displayed book — into a single batched query.

### Estimated performance gain

**~12–50 ms off server render time for every own already-read shelf page view.** The page runs up to 25 sequential rating lookups; each is a full Postgres round-trip (assume ~0.5–2 ms each in-datacenter including driver overhead, executed serially on the render path). Batching removes 24 of the 25 round-trips, so the saving is roughly 24 × per-query latency. The win grows on any future page-size increase and under DB load, when per-query latency inflates.

```mermaid
xychart-beta
    title "Ratings DB queries per reading-log page view (25 books/page)"
    x-axis ["Before", "After"]
    y-axis "sequential SELECTs" 0 --> 25
    bar [25, 1]
```

### Technical

**Problem.** `LoggedBooksData.load_ratings()` in `openlibrary/core/models.py` looped over the page's docs calling `Ratings.get_users_rating_for_work()` for each one:

```python
for doc in self.docs:
    work_id = extract_numeric_id_from_olid(doc.key)
    rating = Ratings.get_users_rating_for_work(self.username, work_id)  # 1 query each
    self.ratings.append(rating or 0)
```

Each call is a separate `SELECT * from ratings where username=$username AND work_id=$work_id` round-trip to Postgres. This runs when a patron views their own **already-read shelf** (`plugins/upstream/mybooks.py`, gated on `mb.key == "already-read" and mb.is_my_page`), where `RESULTS_PER_PAGE = 25` — i.e. up to 25 sequential queries per page view, all to fetch a handful of small ints.

**Fix.** New `Ratings.get_users_ratings_for_works(username, work_ids) -> dict[int, int]` in `openlibrary/core/ratings.py` fetches everything in one query:

```sql
SELECT work_id, rating from ratings where username=$username AND work_id IN $work_ids
```

This mirrors the existing batch pattern in `Bookshelves.get_users_read_status_of_works` (web.py expands the list var into `IN (...)`). It guards the empty-`work_ids` case with an early `{}` return, so no invalid `IN ()` SQL can be generated. `load_ratings()` now makes one call and rebuilds the list in doc order with the same `0` default for unrated works, so template `zip` behavior is unchanged.

### Testing

- New `TestGetUsersRatingsForWorks` in `openlibrary/tests/core/test_db.py` (existing sqlite `:memory:` + `RATINGS_DDL` pattern): returns only the requested user's ratings keyed by int work_id; accepts str or int ids; `[]` → `{}` with no query; unknown user → `{}`.
- New `TestLoggedBooksDataLoadRatings` in `openlibrary/tests/core/test_models.py`: ratings come back aligned with doc order and default to 0 for unrated works.

Reproduce: `make test-py-uv PYTEST_ARGS="openlibrary/tests/core/test_db.py openlibrary/tests/core/test_ratings.py openlibrary/tests/core/test_models.py"` — 74 passed. `pre-commit` — all hooks pass (incl. mypy, ruff).

### Screenshot
N/A — no UI change; identical ratings rendered on the reading log.

### Stakeholders
Part of a performance-review series; see the review report branch `claude/performance-review-top-changes-5wcs7g`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ky5Sc19MGPkDgbgTWWWET