### PR TITLE
Add issue labeling exclusion for GitHub bot accounts

### DIFF
--- a/.github/workflows/config/new_comment_digest.json
+++ b/.github/workflows/config/new_comment_digest.json
@@ -45,5 +45,11 @@
       "leadLabel": "Lead: @lokesh",
       "slackId": "<@U09NTCSNVNG>"
     }
+  ],
+  "bots": [
+    {
+      "githubUsername": "openlibrary-bot",
+      "triggersNeedsResponse": false
+    }
   ]
 }

--- a/scripts/gh_scripts/issue_comment_bot.py
+++ b/scripts/gh_scripts/issue_comment_bot.py
@@ -394,7 +394,7 @@ def start_job():
         config = read_config(args.config)
         leads = config.get("leads", [])
         bots = config.get("bots", [])
-    except (OSError, json.JSONDecodeError):
+    except OSError, json.JSONDecodeError:
         raise ConfigurationError("An error occurred while parsing the configuration file.")
 
     print("Fetching issues from GitHub...")

--- a/scripts/gh_scripts/issue_comment_bot.py
+++ b/scripts/gh_scripts/issue_comment_bot.py
@@ -97,12 +97,12 @@ def fetch_issues():
     return results
 
 
-def filter_issues(issues: list, hours: int, leads: list[dict[str, str]]):
+def filter_issues(issues: list, hours: int, leads: list[dict[str, str]], bots: list[dict[str, str|bool]]):
     """
     Returns list of issues that have the following criteria:
     - Issues have at least one comment
     - Issues have been last updated since the given number of hours
-    - Latest comment is not from an issue lead
+    - Latest comment is not from an issue lead, nor an excluded bot account
 
     Checking who left the last comment requires making up to two calls to
     GitHub's REST API.
@@ -176,7 +176,7 @@ def filter_issues(issues: list, hours: int, leads: list[dict[str, str]]):
         if created > since:
             # Next step: Determine if the last commenter is a lead
             last_commenter = last_comment["user"]["login"]
-            if last_commenter not in [lead["githubUsername"] for lead in leads]:
+            if should_label_issue(last_commenter, leads, bots):
                 lead_label = find_lead_label(i.get("labels", []))
                 results.append(
                     {
@@ -189,6 +189,15 @@ def filter_issues(issues: list, hours: int, leads: list[dict[str, str]]):
                 )
 
     return results
+
+
+def should_label_issue(last_commenter: str, leads: list[dict[str, str]], bots: list[dict[str, str|bool]]) -> bool:
+    if last_commenter in (lead["githubUsername"] for lead in leads):
+        return False
+    bot_acct = next((bot for bot in bots if bot["githubUsername"] == last_commenter), None)
+    if bot_acct and not bot_acct["triggersNeedsResponse"]:
+        return False
+    return True
 
 
 def find_lead_label(labels: list[dict[str, Any]]) -> str:
@@ -384,6 +393,7 @@ def start_job():
         print("Reading configuration file...")
         config = read_config(args.config)
         leads = config.get("leads", [])
+        bots = config.get("bots", [])
     except OSError, json.JSONDecodeError:
         raise ConfigurationError("An error occurred while parsing the configuration file.")
 
@@ -392,7 +402,7 @@ def start_job():
     print(f"{len(issues)} found")
 
     print("Filtering issues...")
-    filtered_issues = filter_issues(issues, args.hours, leads)
+    filtered_issues = filter_issues(issues, args.hours, leads, bots)
     print(f"{len(filtered_issues)} remain after filtering.")
 
     all_issues_labeled = True

--- a/scripts/gh_scripts/issue_comment_bot.py
+++ b/scripts/gh_scripts/issue_comment_bot.py
@@ -394,7 +394,7 @@ def start_job():
         config = read_config(args.config)
         leads = config.get("leads", [])
         bots = config.get("bots", [])
-    except OSError, json.JSONDecodeError:
+    except (OSError, json.JSONDecodeError):
         raise ConfigurationError("An error occurred while parsing the configuration file.")
 
     print("Fetching issues from GitHub...")

--- a/scripts/gh_scripts/issue_comment_bot.py
+++ b/scripts/gh_scripts/issue_comment_bot.py
@@ -97,7 +97,7 @@ def fetch_issues():
     return results
 
 
-def filter_issues(issues: list, hours: int, leads: list[dict[str, str]], bots: list[dict[str, str|bool]]):
+def filter_issues(issues: list, hours: int, leads: list[dict[str, str]], bots: list[dict[str, str | bool]]):
     """
     Returns list of issues that have the following criteria:
     - Issues have at least one comment
@@ -191,7 +191,7 @@ def filter_issues(issues: list, hours: int, leads: list[dict[str, str]], bots: l
     return results
 
 
-def should_label_issue(last_commenter: str, leads: list[dict[str, str]], bots: list[dict[str, str|bool]]) -> bool:
+def should_label_issue(last_commenter: str, leads: list[dict[str, str]], bots: list[dict[str, str | bool]]) -> bool:
     if last_commenter in (lead["githubUsername"] for lead in leads):
         return False
     bot_acct = next((bot for bot in bots if bot["githubUsername"] == last_commenter), None)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #13138

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Updates the `issue_comment_bot` script to prevent adding "Needs: Response" labels to issues if @openlibrary-bot was the last commenter.

A new `bots` list has been added to the script's configuration file.  Each `bots` entry is an object with a string `githubUsername` and a boolean `triggersNeedsResponse` (the bot's comments will trigger "Needs: Response" labeling if this is true).

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
