### PR TITLE
Fix SIM103 lint error in issue_comment_bot.py

### DIFF
--- a/scripts/gh_scripts/issue_comment_bot.py
+++ b/scripts/gh_scripts/issue_comment_bot.py
@@ -195,9 +195,7 @@ def should_label_issue(last_commenter: str, leads: list[dict[str, str]], bots: l
     if last_commenter in (lead["githubUsername"] for lead in leads):
         return False
     bot_acct = next((bot for bot in bots if bot["githubUsername"] == last_commenter), None)
-    if bot_acct and not bot_acct["triggersNeedsResponse"]:
-        return False
-    return True
+    return not (bot_acct and not bot_acct["triggersNeedsResponse"])
 
 
 def find_lead_label(labels: list[dict[str, Any]]) -> str:


### PR DESCRIPTION
## Problem

`should_label_issue()` in `scripts/gh_scripts/issue_comment_bot.py` (added in #13139) trips ruff's `SIM103`:

```
SIM103 Return the negated condition directly
   --> scripts/gh_scripts/issue_comment_bot.py:198
```

Because pre-commit.ci lints the whole repo (`--all-files`), this failure surfaces on **every open PR**, not just #13139. The fix isn't auto-applicable (it's a ruff "unsafe" fix), so pre-commit.ci can't self-heal it.

## Fix

Collapse the `if ...: return False / return True` into a single negated return. No behavior change.

```python
bot_acct = next((bot for bot in bots if bot["githubUsername"] == last_commenter), None)
return not (bot_acct and not bot_acct["triggersNeedsResponse"])
```

`ruff check` passes clean.