### PR TITLE
Remove unnecessary feature and test

### DIFF
--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -321,8 +321,6 @@ def author_import_record_to_author(author_import_record_dict: dict, eastern=Fals
         do_flip(author_import_record)
     if existing := find_entity(author_import_record):
         assert existing.type.key == "/type/author"
-        for k in "last_modified", "id", "revision", "created":
-            existing._data.pop(k, None)
         new = existing
         if "death_date" in author_import_record and "death_date" not in existing:
             new["death_date"] = author_import_record["death_date"]

--- a/openlibrary/catalog/add_book/tests/test_load_book.py
+++ b/openlibrary/catalog/add_book/tests/test_load_book.py
@@ -428,25 +428,3 @@ class TestImportAuthor:
         }
         found = author_import_record_to_author(searched_author)
         assert found.key == author["key"]
-
-    def test_infobase_metadata_keys_stripped_from_existing_author(self, mock_site):
-        """
-        Infobase metadata keys are removed from an existing author before it is returned.
-
-        When find_entity() returns a match, Infobase decorates the record with
-        last_modified, revision, and created. These must be stripped so that
-        save_many() does not receive stale metadata in the update payload.
-        """
-        mock_site.save(
-            {
-                "name": "Jane Doe",
-                "key": "/authors/OL99A",
-                "type": {"key": "/type/author"},
-            }
-        )
-
-        result = author_import_record_to_author({"name": "Jane Doe"})
-
-        assert "last_modified" not in result
-        assert "revision" not in result
-        assert "created" not in result


### PR DESCRIPTION
closes #13016
`id` is not a field on Authors, and the core infogami fields do not need to be stripped, or touched by OL.

The 'fixed' code from #13016 never ran in the history of the project, with no impact. The correct fix is to delete it, rather than enable code that strips non-existent fields like `id`.

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
