### PR TITLE
Don't save empty identifiers

### DIFF
--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -271,7 +271,7 @@ class Edition(models.Edition):
             else:
                 self.identifiers[name] = value
 
-        if not d.items():
+        if not self.identifiers:
             self.identifiers = None
 
     def get_classifications(self):

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -240,8 +240,6 @@ class Edition(models.Edition):
             "lccn",
             "oclc_numbers",
             "ocaid",
-            "dewey_decimal_class",
-            "lc_classifications",
         )
 
         d = {}


### PR DESCRIPTION

<!-- What issue does this PR close? -->
Closes #1946

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

* Only touches Edition.set_identifiers() as that is the only one affected by the #1946 issue
* Removes two classifications from the Edition identifiers list 

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Tested locally saving various no-op changes, before this change `identifiers: {}` was saved on http://localhost:8080/books/OL23269118M/Alice's_adventures_in_Wonderland

After this change,  empty `identifiers` are _not_ created, and any existing empty `{}` dicts are cleared.
 

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
