### PR TITLE
Add genres and subgenres fields to work type definition and schema

### DIFF
--- a/openlibrary/plugins/openlibrary/types/work.type
+++ b/openlibrary/plugins/openlibrary/types/work.type
@@ -216,6 +216,26 @@
                 "key": "/type/property"
             },
             "name": "covers"
+        },
+        {
+            "expected_type": {
+                "key": "/type/string"
+            },
+            "unique": false,
+            "type": {
+                "key": "/type/property"
+            },
+            "name": "genres"
+        },
+        {
+            "expected_type": {
+                "key": "/type/string"
+            },
+            "unique": false,
+            "type": {
+                "key": "/type/property"
+            },
+            "name": "subgenres"
         }
     ],
     "revision": 14

--- a/openlibrary/plugins/openlibrary/types/work.type
+++ b/openlibrary/plugins/openlibrary/types/work.type
@@ -219,7 +219,7 @@
         },
         {
             "expected_type": {
-                "key": "/type/string"
+                "key": "/type/tag"
             },
             "unique": false,
             "type": {
@@ -229,7 +229,7 @@
         },
         {
             "expected_type": {
-                "key": "/type/string"
+                "key": "/type/tag"
             },
             "unique": false,
             "type": {

--- a/openlibrary/schemata/work.schema.json
+++ b/openlibrary/schemata/work.schema.json
@@ -38,6 +38,8 @@
     },
     "lc_classifications":  { "$ref": "shared_definitions.json#/string_array" },
     "subjects":            { "$ref": "shared_definitions.json#/string_array" },
+    "genres":              { "$ref": "shared_definitions.json#/string_array" },
+    "subgenres":           { "$ref": "shared_definitions.json#/string_array" },
 
     "first_publish_date": { "type": "string" },
 


### PR DESCRIPTION
## Summary

Add `genres` and `subgenres` fields to the Work type definition and JSON schema — the first step of Stage 3 (Schema & Work Processing) for the Canonical Tags project ([tags issue #14](https://github.com/Open-Book-Genome-Project/tags/issues/14)).

These fields will store Tag key references (e.g., `["/tags/OL179T"]`) on work records, enabling structured genre/subgenre tagging that replaces the current flat, inconsistent subject strings.

## Changes

**`openlibrary/plugins/openlibrary/types/work.type`**
- Added `genres` property (string array, non-unique)
- Added `subgenres` property (string array, non-unique)
- Both follow the same pattern as `subjects`, `subject_places`, etc.

**`openlibrary/schemata/work.schema.json`**
- Added `genres` and `subgenres` entries referencing `shared_definitions.json#/string_array`

## Notes

- `revision`, `latest_revision`, and `last_modified` in `work.type` were left as-is since Infogami auto-updates these when the document is saved to the database.
- This PR only covers the core type and schema changes. Downstream consumers that may also need updating (Solr updater in `work.py`, `subject_fields` in `add_book/__init__.py`, copy-subjects list in `addbook.py`, and `import.schema.json`) are not included here but can be addressed in follow-ups if needed.
- References the [tags repo](https://github.com/Open-Book-Genome-Project/tags) vocabulary and migration tooling that will write to these fields once the schema is in place.

## Related

- Closes the schema prerequisite for [tags issue #14](https://github.com/Open-Book-Genome-Project/tags/issues/14)
- Part of [OL issue #11610](https://github.com/internetarchive/openlibrary/issues/11610) (Canonical Tags)

## Stakeholders
@mekarpeles, @cdrini 