### PR TITLE
fix(agentic): allow non-write actors to trigger issue enrichment

### DIFF
--- a/.github/workflows/issue_enrichment.yml
+++ b/.github/workflows/issue_enrichment.yml
@@ -43,3 +43,9 @@ jobs:
             Bash(gh issue list:*) Bash(gh pr list:*) Bash(gh api:*) Bash(gh label list:*)"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.OL_BOT_PAT }}
+          # Issues are opened by any public contributor, most of whom have only
+          # read access. claude-code-action's default actor-permission check
+          # requires write access, so it rejects every issue except ones filed
+          # by maintainers -- defeating the workflow's purpose. Bypass is safe
+          # here since --allowedTools is already scoped to issue-only operations.
+          allowed_non_write_users: "*"


### PR DESCRIPTION
## Summary

`issue_enrichment.yml` has been failing for every issue opened by a non-maintainer since it started running against real issues (2026-07-07 onward) — i.e. almost every issue on a public repo.

## Root cause

Not a workflow `permissions:` problem — the workflow's own block (`contents: read`, `issues: write`, `id-token: write`) is fine. The failure is `anthropics/claude-code-action@v1`'s built-in actor-authorization gate: it checks whether the issue's author has **write** access to the repo via the provided `github_token`, and rejects the run otherwise.

```
Checking permissions for actor: adomersontan
Permission level retrieved: read
##[warning]Actor has insufficient permissions: read
##[error]Action failed with error: Actor does not have write permissions to the repository
```

Confirmed against run history: the one successful `issues`-triggered run was for an issue opened by a maintainer (write access); every run opened by an external contributor failed identically. This predates #13117 (which only added the `workflow_dispatch` trigger) — it just hadn't surfaced yet because too few real issues had gone through.

Since the entire point of this workflow is to auto-enrich issues from *any* contributor, including first-time/external ones, the default write-only gate defeats the workflow's purpose.

## Fix

Set `allowed_non_write_users: "*"`, the action's purpose-built escape hatch for this exact case (only works because `github_token` is explicitly provided, which it already is).

## Security note

This does bypass the action's actor-authorization check on a public repo using a token with `issues: write`. Mitigating factor: `claude_args` already scopes `--allowedTools` to issue-only `gh` commands (`comment`/`edit`/`close`/`view`/`list`), so a hijacked prompt from a malicious issue body could at most manipulate issue state — not touch code, PRs, or secrets. Flagging for visibility since this is a deliberate security tradeoff, not an oversight.

## Testing

No Docker/browser verification needed (workflow-only YAML change). Validated:
- `pre-commit run --files .github/workflows/issue_enrichment.yml` passes (yaml check, codespell, etc.)
- Root cause confirmed directly against `gh run view --log-failed` output and cross-referenced against `checkWritePermissions` in `anthropics/claude-code-action` source