### PR TITLE
Fix: Add FastAPI validation bounds and test suites for patron check-ins and yearly goals endpoints (#13150)

### DIFF
--- a/openlibrary/fastapi/checkins.py
+++ b/openlibrary/fastapi/checkins.py
@@ -4,17 +4,18 @@ FastAPI endpoints for patron check-ins.
 
 from __future__ import annotations
 
+from datetime import date as datetime_date
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
-from pydantic import BaseModel, field_validator, model_validator
+from fastapi import APIRouter, Depends, HTTPException, Path, Response, status
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from openlibrary.core.bookshelves_events import BookshelfEvent, BookshelvesEvents
 from openlibrary.fastapi.auth import (
     AuthenticatedUser,
     require_authenticated_user,
 )
-from openlibrary.plugins.upstream.checkins import make_date_string
+from openlibrary.plugins.upstream.checkins import is_valid_date, make_date_string
 from openlibrary.utils import extract_numeric_id_from_olid
 
 router = APIRouter()
@@ -23,11 +24,15 @@ router = APIRouter()
 class CheckInRequest(BaseModel):
     """Request model for creating/updating check-in events."""
 
-    event_type: int
-    year: int
-    month: int | None = None
-    day: int | None = None
-    edition_key: str | None = None
+    event_type: int = Field(..., description="Event type enum value (1=start, 2=update, 3=finish)")
+    year: int = Field(..., gt=0, le=9999, description="Four-digit year (1-9999)")
+    month: int | None = Field(None, ge=1, le=12, description="Month (1-12)")
+    day: int | None = Field(None, ge=1, le=31, description="Day (1-31)")
+    edition_key: str | None = Field(
+        None,
+        pattern=r"(?i)^(?:/books/)?OL\d+M$",
+        description="Edition OLID (e.g. OL123M)",
+    )
     event_id: int | None = None
 
     @field_validator("event_type")
@@ -41,6 +46,13 @@ class CheckInRequest(BaseModel):
     def validate_date(self) -> CheckInRequest:
         if self.day and not self.month:
             raise ValueError("Month is required when day is provided")
+        if not is_valid_date(self.year, self.month, self.day):
+            raise ValueError("Invalid calendar date combination")
+        if self.month and self.day:
+            try:
+                datetime_date(self.year, self.month, self.day)
+            except ValueError:
+                raise ValueError("Invalid calendar date combination")
         return self
 
 
@@ -54,7 +66,7 @@ class CheckInResponse(BaseModel):
 @router.post("/works/OL{work_id}W/check-ins")
 @router.post("/works/OL{work_id}W/check-ins.json")
 async def create_or_update_patron_check_in(
-    work_id: int,
+    work_id: Annotated[int, Path(gt=0)],
     data: CheckInRequest,
     user: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],
 ) -> CheckInResponse:
@@ -64,7 +76,9 @@ async def create_or_update_patron_check_in(
     """
     edition_id = None
     if data.edition_key:
-        edition_id = extract_numeric_id_from_olid(data.edition_key)
+        raw_id = extract_numeric_id_from_olid(data.edition_key)
+        if raw_id is not None:
+            edition_id = int(raw_id)
 
     date_str = make_date_string(data.year, data.month, data.day)
 
@@ -93,7 +107,7 @@ async def create_or_update_patron_check_in(
 
 @router.delete("/check-ins/{check_in_id}")
 async def delete_patron_check_in(
-    check_in_id: int,
+    check_in_id: Annotated[int, Path(gt=0)],
     user: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],
 ) -> Response:
     """Delete a check-in event by ID.

--- a/openlibrary/fastapi/yearly_reading_goals.py
+++ b/openlibrary/fastapi/yearly_reading_goals.py
@@ -24,7 +24,7 @@ MAX_READING_GOAL = 10_000
 class ReadingGoalItem(BaseModel):
     """A single reading goal entry."""
 
-    year: int = Field(..., description="The year for this reading goal")
+    year: int = Field(..., gt=0, le=9999, description="The year for this reading goal (1-9999)")
     goal: int = Field(..., description="The target number of books to read")
 
 
@@ -56,6 +56,8 @@ class ReadingGoalForm(BaseModel):
     )
     year: int | None = Field(
         default=None,
+        gt=0,
+        le=9999,
         description="Year for this reading goal. Defaults to current year for creates, required for updates.",
     )
     is_update: str | None = Field(
@@ -84,7 +86,7 @@ class ReadingGoalForm(BaseModel):
 @router.get("/reading-goal.json", response_model=ReadingGoalsResponse)
 async def get_reading_goals_endpoint(
     user: Annotated[AuthenticatedUser, Depends(require_authenticated_user)],
-    year: Annotated[int | None, Query(description="The year to filter goals by")] = None,
+    year: Annotated[int | None, Query(gt=0, le=9999, description="The year to filter goals by")] = None,
 ) -> ReadingGoalsResponse:
     """Get reading goals for the authenticated user."""
     if year:

--- a/openlibrary/tests/fastapi/test_checkins.py
+++ b/openlibrary/tests/fastapi/test_checkins.py
@@ -1,0 +1,70 @@
+"""Tests for the FastAPI patron check-ins endpoints."""
+
+from unittest.mock import patch
+
+from openlibrary.core.bookshelves_events import BookshelfEvent
+
+
+def test_create_checkin_success(fastapi_client, mock_authenticated_user):
+    payload = {
+        "event_type": BookshelfEvent.START,
+        "year": 2026,
+        "month": 5,
+        "day": 10,
+        "edition_key": "OL100M",
+    }
+    with patch("openlibrary.fastapi.checkins.BookshelvesEvents.create_event", return_value=123) as mock_create:
+        response = fastapi_client.post("/works/OL1W/check-ins", json=payload)
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "id": 123}
+    mock_create.assert_called_once_with("testuser", 1, 100, "2026-05-10", event_type=BookshelfEvent.START)
+
+
+def test_create_checkin_invalid_month_or_day(fastapi_client, mock_authenticated_user):
+    payload = {
+        "event_type": BookshelfEvent.START,
+        "year": 2026,
+        "month": 99,
+        "day": 99,
+    }
+    response = fastapi_client.post("/works/OL1W/check-ins", json=payload)
+    assert response.status_code == 422
+
+
+def test_create_checkin_invalid_calendar_date(fastapi_client, mock_authenticated_user):
+    # Feb 31st is an invalid calendar date
+    payload = {
+        "event_type": BookshelfEvent.START,
+        "year": 2026,
+        "month": 2,
+        "day": 31,
+    }
+    response = fastapi_client.post("/works/OL1W/check-ins", json=payload)
+    assert response.status_code == 422
+
+
+def test_create_checkin_invalid_edition_key(fastapi_client, mock_authenticated_user):
+    payload = {
+        "event_type": BookshelfEvent.START,
+        "year": 2026,
+        "month": 5,
+        "day": 10,
+        "edition_key": "invalid_key",
+    }
+    response = fastapi_client.post("/works/OL1W/check-ins", json=payload)
+    assert response.status_code == 422
+
+
+def test_create_checkin_invalid_work_id(fastapi_client, mock_authenticated_user):
+    payload = {
+        "event_type": BookshelfEvent.START,
+        "year": 2026,
+    }
+    response = fastapi_client.post("/works/OL0W/check-ins", json=payload)
+    assert response.status_code == 422
+
+
+def test_delete_checkin_invalid_id(fastapi_client, mock_authenticated_user):
+    response = fastapi_client.delete("/check-ins/0")
+    assert response.status_code == 422

--- a/openlibrary/tests/fastapi/test_yearly_reading_goals.py
+++ b/openlibrary/tests/fastapi/test_yearly_reading_goals.py
@@ -1,0 +1,53 @@
+"""Tests for the FastAPI yearly reading goals endpoints."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def test_get_reading_goals_success(fastapi_client, mock_authenticated_user):
+    fake_records = [SimpleNamespace(year=2026, target=25)]
+    with patch("openlibrary.fastapi.yearly_reading_goals.YearlyReadingGoals.select_by_username", return_value=fake_records):
+        response = fastapi_client.get("/reading-goal.json")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "goal": [{"year": 2026, "goal": 25}]}
+
+
+def test_get_reading_goals_with_year(fastapi_client, mock_authenticated_user):
+    fake_records = [SimpleNamespace(year=2026, target=25)]
+    with patch("openlibrary.fastapi.yearly_reading_goals.YearlyReadingGoals.select_by_username_and_year", return_value=fake_records):
+        response = fastapi_client.get("/reading-goal.json?year=2026")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "goal": [{"year": 2026, "goal": 25}]}
+
+
+def test_get_reading_goals_invalid_year(fastapi_client, mock_authenticated_user):
+    response = fastapi_client.get("/reading-goal.json?year=-500")
+    assert response.status_code == 422
+
+
+def test_create_reading_goal_success(fastapi_client, mock_authenticated_user):
+    with patch("openlibrary.fastapi.yearly_reading_goals.YearlyReadingGoals.create") as mock_create:
+        response = fastapi_client.post("/reading-goal.json", data={"goal": 25, "year": 2026})
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+    mock_create.assert_called_once_with("testuser", 2026, 25)
+
+
+def test_create_reading_goal_invalid_year(fastapi_client, mock_authenticated_user):
+    response = fastapi_client.post("/reading-goal.json", data={"goal": 25, "year": -500})
+    assert response.status_code == 422
+
+
+def test_update_reading_goal_success(fastapi_client, mock_authenticated_user):
+    with patch("openlibrary.fastapi.yearly_reading_goals.YearlyReadingGoals.update_target") as mock_update:
+        response = fastapi_client.post(
+            "/reading-goal.json",
+            data={"goal": 30, "year": 2026, "is_update": "1"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+    mock_update.assert_called_once_with("testuser", 2026, 30)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #13150

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR fixes missing date range bounds, malformed edition key crashes, and unvalidated path parameters in FastAPI patron check-ins (`openlibrary/fastapi/checkins.py`) and yearly reading goals (`openlibrary/fastapi/yearly_reading_goals.py`) endpoints, and adds two dedicated unit test suites.

### Technical
<!-- What should be noted about the implementation? -->
1. In `openlibrary/fastapi/checkins.py`:
   - Added Pydantic range bounds to `CheckInRequest`: `year` (`gt=0, le=9999`), `month` (`ge=1, le=12`), and `day` (`ge=1, le=31`).
   - Added regex pattern matching for edition OLIDs: `edition_key: Field(None, pattern=r"(?i)^(?:/books/)?OL\d+M$")`.
   - Integrated `is_valid_date` and `datetime.date(y, m, d)` in `@model_validator(mode="after")` to reject invalid calendar dates (e.g., Feb 31st).
   - Added `Annotated[int, Path(gt=0)]` constraints to `work_id` and `check_in_id` path parameters.
   - Safely cast numeric `edition_id` as `int` before passing to `BookshelvesEvents`.
 
2. In `openlibrary/fastapi/yearly_reading_goals.py`:
   - Added `gt=0, le=9999` bounds to `ReadingGoalItem.year`, `ReadingGoalForm.year`, and the `GET /reading-goal.json?year=` query parameter.

3. In `[NEW] openlibrary/tests/fastapi/test_checkins.py` and `[NEW] openlibrary/tests/fastapi/test_yearly_reading_goals.py`:
   - Added dedicated unit test suites asserting HTTP 200 OK for valid inputs and HTTP 422 Unprocessable Entity responses for invalid date ranges, bad days, malformed OLIDs, and non-positive path/query params.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. **Automated Unit Tests**:

   ```bash
   docker compose run --rm home pytest openlibrary/tests/fastapi/test_checkins.py openlibrary/tests/fastapi/test_yearly_reading_goals.py
   ```
   *Output: `12 passed, 5 warnings in 6.03s`*

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A (Backend FastAPI validation & test suite implementation).

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@jimchamp

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
