### PR TITLE
Refactor daily project management slack digest

### DIFF
--- a/.github/workflows/needs_response_labeler.yml
+++ b/.github/workflows/needs_response_labeler.yml
@@ -1,0 +1,55 @@
+name: Label issues needing a response
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  label:
+    # Continue only if this executed on the main repo
+    if: ${{ github.repository == 'internetarchive/openlibrary' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: 'Add "Needs: Response" unless the commenter is a lead or excluded bot'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const config = JSON.parse(
+              fs.readFileSync('.github/workflows/config/new_comment_digest.json', 'utf8')
+            );
+
+            const commenter = context.payload.comment.user.login;
+            const isLead = (config.leads || []).some((lead) => lead.githubUsername === commenter);
+            const bot = (config.bots || []).find((b) => b.githubUsername === commenter);
+            const isExcludedBot = Boolean(bot) && !bot.triggersNeedsResponse;
+
+            if (context.payload.issue.state !== 'open' || isLead || isExcludedBot) {
+              core.info(`Skipping issue #${context.payload.issue.number} (commenter: ${commenter})`);
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              labels: ['Needs: Response'],
+            });
+
+  publish_error_to_slack:
+    needs: label
+    if: ${{ failure() }}
+    uses: ./.github/workflows/publish_slack_thread_digest.yml
+    with:
+      channel: ${{ secrets.SLACK_CHANNEL_ABC_TEAM_PLUS }}
+      message: >-
+        Failed to auto-label <${{ github.event.issue.html_url }}|issue #${{ github.event.issue.number }}>
+        as "Needs: Response" — check manually.
+    secrets:
+      slack_token: ${{ secrets.SLACK_TOKEN }}

--- a/.github/workflows/pm_new_comment_digest.yml
+++ b/.github/workflows/pm_new_comment_digest.yml
@@ -1,0 +1,148 @@
+name: pm_new_comment_digest
+on:
+  schedule:  # 08:45 daily
+    - cron: '45 8 * * *'
+  workflow_dispatch:
+    inputs:
+      slack_channel:
+        description: 'Digest is published to this channel. Include leading `#` symbol in channel name.  Entering an empty string will skip publishing to Slack.'
+        type: string
+      verbose_mode:
+        description: 'Log detailed information about the issues found? (Verbose mode)'
+        type: choice
+        default: 'No'
+        options:
+        - 'Yes'
+        - 'No'
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  gather_digest:
+    # Continue only if this executed on the main repo
+    if: ${{ github.repository == 'internetarchive/openlibrary' }}
+    runs-on: ubuntu-latest
+    env:
+      CHANNEL: ${{ secrets.SLACK_CHANNEL_ABC_TEAM_PLUS }}
+      VERBOSE: 'No'
+    outputs:
+      channel: ${{ steps.channel.outputs.channel }}
+      parent_message: ${{ steps.gather.outputs.parent_message }}
+      replies_json: ${{ steps.gather.outputs.replies_json }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Apply workflow_dispatch overrides
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          INPUT_CHANNEL: ${{ inputs.slack_channel }}
+          INPUT_VERBOSE: ${{ inputs.verbose_mode }}
+        run: |
+          echo "CHANNEL=$INPUT_CHANNEL" >> "$GITHUB_ENV"
+          echo "VERBOSE=$INPUT_VERBOSE" >> "$GITHUB_ENV"
+      - id: channel
+        run: echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+      - id: gather
+        name: 'Find open issues/PRs currently labeled "Needs: Response"'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const config = JSON.parse(
+              fs.readFileSync('.github/workflows/config/new_comment_digest.json', 'utf8')
+            );
+            const leads = config.leads || [];
+            const verbose = process.env.VERBOSE === 'Yes';
+
+            const findLeadLabel = (labels) => {
+              const match = labels.find((label) => {
+                const name = typeof label === 'string' ? label : label.name || '';
+                return name.startsWith('Lead:');
+              });
+              if (!match) return '';
+              return typeof match === 'string' ? match : match.name;
+            };
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'Needs: Response',
+              per_page: 100,
+            });
+
+            core.info(`${issues.length} issue(s)/PR(s) currently labeled "Needs: Response".`);
+
+            const results = [];
+            for (const issue of issues) {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                per_page: 100,
+              });
+
+              if (comments.length === 0) {
+                continue;
+              }
+
+              const lastComment = comments[comments.length - 1];
+              results.push({
+                number: issue.number,
+                commentUrl: lastComment.html_url,
+                commenter: lastComment.user.login,
+                issueTitle: issue.title,
+                leadLabel: findLeadLabel(issue.labels),
+              });
+            }
+
+            const replies = results.map((result) => {
+              const lead = leads.find((l) => l.leadLabel === result.leadLabel);
+              let leadLine;
+              if (lead) {
+                leadLine = `Lead: ${lead.slackId}`;
+              } else if (result.leadLabel) {
+                leadLine = result.leadLabel;
+              } else {
+                leadLine = 'Unknown lead';
+              }
+              return `<${result.commentUrl}|Latest comment for: *${result.issueTitle}*>\n${leadLine}\nCommenter: *${result.commenter}*`;
+            });
+
+            if (verbose) {
+              for (const result of results) {
+                core.info(`Issue #${result.number}: ${result.issueTitle}`);
+                core.info(`\t${result.leadLabel}`);
+                core.info(`\tCommenter: ${result.commenter}`);
+                core.info(`\tComment URL: ${result.commentUrl}`);
+              }
+            }
+
+            core.setOutput('parent_message', `${results.length} open issue(s)/PR(s) currently need a response`);
+            core.setOutput('replies_json', JSON.stringify(replies));
+
+  publish_digest:
+    needs: gather_digest
+    if: ${{ needs.gather_digest.outputs.channel != '' }}
+    uses: ./.github/workflows/publish_slack_thread_digest.yml
+    with:
+      channel: ${{ needs.gather_digest.outputs.channel }}
+      message: ${{ needs.gather_digest.outputs.parent_message }}
+      replies_json: ${{ needs.gather_digest.outputs.replies_json }}
+    secrets:
+      slack_token: ${{ secrets.SLACK_TOKEN }}
+
+  publish_error_to_slack:
+    needs: gather_digest
+    if: ${{ failure() }}
+    uses: ./.github/workflows/publish_slack_thread_digest.yml
+    with:
+      channel: ${{ secrets.SLACK_CHANNEL_ABC_TEAM_PLUS }}
+      message: >-
+        Failed to fetch issues for Slack digest.
+        <https://github.com/internetarchive/openlibrary/issues?q=is%3Aopen+label%3A%22Needs%3A+Response%22|These issues>
+        should be manually checked and labeled.
+    secrets:
+      slack_token: ${{ secrets.SLACK_TOKEN }}

--- a/.github/workflows/publish_slack_thread_digest.yml
+++ b/.github/workflows/publish_slack_thread_digest.yml
@@ -1,0 +1,93 @@
+name: Publish Slack thread
+
+on:
+  workflow_call:
+    inputs:
+      channel:
+        description: Slack channel to publish to.
+        type: string
+        required: true
+      message:
+        description: >
+          Posted as a new parent message when thread_ts is not given, or as a
+          reply into the thread when thread_ts is given.
+        type: string
+        required: false
+      thread_ts:
+        description: Existing thread timestamp to post into. Omit to start a new thread.
+        type: string
+        required: false
+      replies_json:
+        description: JSON-encoded array of additional strings to post as threaded replies.
+        type: string
+        required: false
+        default: '[]'
+    secrets:
+      slack_token:
+        required: true
+    outputs:
+      ts:
+        description: >
+          Timestamp of the parent/thread used. Pass this back in as thread_ts
+          to keep posting to the same thread in a later call.
+        value: ${{ jobs.publish_parent.outputs.ts }}
+
+jobs:
+  publish_parent:
+    runs-on: ubuntu-latest
+    outputs:
+      ts: ${{ steps.resolve.outputs.ts }}
+    steps:
+      # Values are wrapped in toJson() rather than interpolated as "${{ ... }}" directly:
+      # message/reply text can contain real newlines and arbitrary characters (issue titles,
+      # quotes, colons), and toJson() properly escapes both so the resulting payload stays
+      # valid YAML/JSON. Without it, a stray '"' would break the payload, and embedded
+      # newlines would get silently flattened to spaces by YAML's line-folding rules.
+      - name: Start a new thread
+        if: ${{ inputs.thread_ts == '' && inputs.message != '' }}
+        id: new_thread
+        uses: slackapi/slack-github-action@v3
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.slack_token }}
+          payload: |
+            channel: ${{ toJson(inputs.channel) }}
+            text: ${{ toJson(inputs.message) }}
+      - name: Reply into an existing thread
+        if: ${{ inputs.thread_ts != '' && inputs.message != '' }}
+        uses: slackapi/slack-github-action@v3
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.slack_token }}
+          payload: |
+            channel: ${{ toJson(inputs.channel) }}
+            thread_ts: ${{ toJson(inputs.thread_ts) }}
+            text: ${{ toJson(inputs.message) }}
+      - id: resolve
+        run: echo "ts=${{ inputs.thread_ts != '' && inputs.thread_ts || steps.new_thread.outputs.ts }}" >> "$GITHUB_OUTPUT"
+
+  publish_replies:
+    needs: publish_parent
+    # The inputs.replies_json != '[]' check is deliberate, not just a ts guard: GitHub's docs
+    # don't confirm that a matrix sourced from an empty JSON array ([]) cleanly skips the job
+    # rather than erroring, so we avoid relying on that undocumented behavior. Both callers
+    # that don't post replies (the two failure-notification jobs) rely on this to skip cleanly.
+    if: ${{ needs.publish_parent.outputs.ts != '' && inputs.replies_json != '[]' }}
+    runs-on: ubuntu-latest
+    strategy:
+      # fail-fast: false so one bad reply doesn't cancel the rest (matrix default would).
+      # max-parallel: 1 keeps replies paced against Slack's rate limit; posting order doesn't
+      # matter for this workflow's callers.
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        reply: ${{ fromJson(inputs.replies_json) }}
+    steps:
+      - uses: slackapi/slack-github-action@v3
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.slack_token }}
+          payload: |
+            channel: ${{ toJson(inputs.channel) }}
+            thread_ts: ${{ toJson(needs.publish_parent.outputs.ts) }}
+            text: ${{ toJson(matrix.reply) }}


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Refactors existing daily project management digest workflow, removing the need for [`issue_comment_bot.py`](https://github.com/internetarchive/openlibrary/blob/master/scripts/gh_scripts/issue_comment_bot.py).

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
