### PR TITLE
fix(agentic): exclude openlibrary-bot from issue enrichment

### DIFF
--- a/.github/workflows/issue_enrichment.md
+++ b/.github/workflows/issue_enrichment.md
@@ -24,7 +24,8 @@ Blessed staff list: `mekarpeles`, `lokesh`, `cdrini`, `scottbarnes`, `RayBB`, `s
 
 **Always skip if**:
 - Any existing comment contains `<!-- ol-issue-bot -->`
-- The author login ends in `[bot]`
+- The author login is `openlibrary-bot` — our own bot account. **Note**: `openlibrary-bot`'s account `type` is `"User"`, not `"Bot"` — do not rely on account type to detect it. Always check the literal login string.
+- The author login ends in `[bot]` — catches genuine GitHub Apps (dependabot, renovate, etc.)
 - The issue has the label `agentic-workflows`
 
 ---

--- a/.github/workflows/issue_enrichment.yml
+++ b/.github/workflows/issue_enrichment.yml
@@ -22,9 +22,14 @@ concurrency:
 jobs:
   enrich:
     runs-on: ubuntu-latest
+    # openlibrary-bot's account type is "User", not "Bot" (confirmed via the
+    # GitHub API), so `user.type != 'Bot'` alone does NOT exclude it -- it
+    # only catches genuine GitHub Apps (dependabot[bot], renovate[bot], etc).
+    # The explicit login check below is required to skip our own bot's issues.
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event.issue.user.type != 'Bot' &&
+       github.event.issue.user.login != 'openlibrary-bot' &&
        !contains(github.event.issue.labels.*.name, 'agentic-workflows'))
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

`openlibrary-bot`'s GitHub account `type` is `"User"`, not `"Bot"` (confirmed via `gh api users/openlibrary-bot -q '.type'`), and its login doesn't end in `[bot]`. Both the workflow-level `if:` gate and the prompt's documented skip conditions in `issue_enrichment.yml`/`.md` rely on exactly those two signals — so an issue opened by `openlibrary-bot` is currently NOT excluded from enrichment, contrary to intent.

Fixes #13165.

## Fix

Adds an explicit `user.login != 'openlibrary-bot'` check alongside the existing type/`[bot]`-suffix checks, at both the workflow `if:` level (cheap, structural) and in the prompt's documented skip conditions (so the reasoning stays correct if someone edits the trigger logic later without re-checking the YAML).

Same fix already applied to the not-yet-merged PR auto-responder (#13164) before it merged, and to `pr-prereview.md` (the source doc for the PR-side flow, in the private `pm` PAM repo).

## Related

- #13160 — Epic: AI Workflows (parent)
- #13161 — separate bug from the same investigation (write-permission bypass, opposite-direction failure of the same account-type assumption)
- #13138 — prior instance of the general "ignore openlibrary-bot's own actions" problem class

## Testing

`pre-commit run` passes on both changed files. Not independently verified against a live issue opened by `openlibrary-bot` (would require the bot to actually open one) — the `if:` logic change is a straightforward boolean addition, low risk.
