### PR TITLE
feat(ci): add weekly on-call Slack notification workflow

### DIFF
--- a/.github/workflows/config/pm_config.json
+++ b/.github/workflows/config/pm_config.json
@@ -1,0 +1,18 @@
+{
+    "onCallNotificationJob": {
+        "personnel": [
+            {
+                "name": "mek",
+                "slackId": "<@U0AB3N5L7>"
+            },
+            {
+                "name": "jchamp",
+                "slackId": "<@U01ARTHG9EV>"
+            },
+            {
+                "name": "cdrini",
+                "slackId": "<@U709VCNLD>"
+            }
+        ]
+    }
+}

--- a/.github/workflows/notify_slack.yml
+++ b/.github/workflows/notify_slack.yml
@@ -1,0 +1,93 @@
+name: Publish to Slack
+
+on:
+  workflow_call:
+    inputs:
+      channel:
+        description: Slack channel to publish to.
+        type: string
+        required: true
+      message:
+        description: >
+          Posted as a new parent message when thread_ts is not given, or as a
+          reply into the thread when thread_ts is given.
+        type: string
+        required: false
+      thread_ts:
+        description: Existing thread timestamp to post into. Omit to start a new thread.
+        type: string
+        required: false
+      replies_json:
+        description: JSON-encoded array of additional strings to post as threaded replies.
+        type: string
+        required: false
+        default: '[]'
+    secrets:
+      slack_token:
+        required: true
+    outputs:
+      ts:
+        description: >
+          Timestamp of the parent/thread used. Pass this back in as thread_ts
+          to keep posting to the same thread in a later call.
+        value: ${{ jobs.publish_parent.outputs.ts }}
+
+jobs:
+  publish_parent:
+    runs-on: ubuntu-latest
+    outputs:
+      ts: ${{ steps.resolve.outputs.ts }}
+    steps:
+      # Values are wrapped in toJson() rather than interpolated as "${{ ... }}" directly:
+      # message/reply text can contain real newlines and arbitrary characters (issue titles,
+      # quotes, colons), and toJson() properly escapes both so the resulting payload stays
+      # valid YAML/JSON. Without it, a stray '"' would break the payload, and embedded
+      # newlines would get silently flattened to spaces by YAML's line-folding rules.
+      - name: Start a new thread
+        if: ${{ inputs.thread_ts == '' && inputs.message != '' }}
+        id: new_thread
+        uses: slackapi/slack-github-action@v3
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.slack_token }}
+          payload: |
+            channel: ${{ toJson(inputs.channel) }}
+            text: ${{ toJson(inputs.message) }}
+      - name: Reply into an existing thread
+        if: ${{ inputs.thread_ts != '' && inputs.message != '' }}
+        uses: slackapi/slack-github-action@v3
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.slack_token }}
+          payload: |
+            channel: ${{ toJson(inputs.channel) }}
+            thread_ts: ${{ toJson(inputs.thread_ts) }}
+            text: ${{ toJson(inputs.message) }}
+      - id: resolve
+        run: echo "ts=${{ inputs.thread_ts != '' && inputs.thread_ts || steps.new_thread.outputs.ts }}" >> "$GITHUB_OUTPUT"
+
+  publish_replies:
+    needs: publish_parent
+    # The inputs.replies_json != '[]' check is deliberate, not just a ts guard: GitHub's docs
+    # don't confirm that a matrix sourced from an empty JSON array ([]) cleanly skips the job
+    # rather than erroring, so we avoid relying on that undocumented behavior. Both callers
+    # that don't post replies (the two failure-notification jobs) rely on this to skip cleanly.
+    if: ${{ needs.publish_parent.outputs.ts != '' && inputs.replies_json != '[]' }}
+    runs-on: ubuntu-latest
+    strategy:
+      # fail-fast: false so one bad reply doesn't cancel the rest (matrix default would).
+      # max-parallel: 1 keeps replies paced against Slack's rate limit; posting order doesn't
+      # matter for this workflow's callers.
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        reply: ${{ fromJson(inputs.replies_json) }}
+    steps:
+      - uses: slackapi/slack-github-action@v3
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.slack_token }}
+          payload: |
+            channel: ${{ toJson(inputs.channel) }}
+            thread_ts: ${{ toJson(needs.publish_parent.outputs.ts) }}
+            text: ${{ toJson(matrix.reply) }}

--- a/.github/workflows/pm_on_call_notification.yml
+++ b/.github/workflows/pm_on_call_notification.yml
@@ -1,0 +1,51 @@
+name: pm_on_call_notification
+
+on:
+  schedule:  # 08:30 UTC, Monday and Tuesday
+    - cron: '30 8 * * 1,2'
+
+permissions:
+  contents: read
+
+jobs:
+  build_message:
+    if: ${{ github.repository == 'internetarchive/openlibrary' }}
+    runs-on: ubuntu-latest
+    outputs:
+      message: ${{ steps.build.outputs.result }}
+    steps:
+      - uses: actions/checkout@v7
+      - id: build
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+            const fs = require('fs');
+            const { onCallNotificationJob: { personnel } } = JSON.parse(
+              fs.readFileSync('.github/workflows/config/pm_config.json', 'utf8')
+            );
+
+            const daysSinceEpoch = Math.floor(Date.now() / 86400000);
+            const weekIndex = Math.floor(daysSinceEpoch / 7);
+            const lead = personnel[weekIndex % personnel.length].slackId;
+            const secondary = personnel[(weekIndex + 1) % personnel.length].slackId;
+
+            // getUTCDay(): 0=Sun, 1=Mon, 2=Tue, ...
+            const dow = { 1: 'monday', 2: 'tuesday' }[new Date().getUTCDay()] ?? 'none';
+
+            if (dow === 'monday') {
+              return `${lead} is on-call this week.  ${secondary} is the back-up.`;
+            } else if (dow === 'tuesday') {
+              return `Reminder: ${lead} will lead this week's deployment.`;
+            }
+            return '';
+
+  publish:
+    needs: build_message
+    if: ${{ needs.build_message.outputs.message != '' }}
+    uses: ./.github/workflows/notify_slack.yml
+    with:
+      channel: ${{ secrets.SLACK_CHANNEL_ABC_TEAM_PLUS }}
+      message: ${{ needs.build_message.outputs.message }}
+    secrets:
+      slack_token: ${{ secrets.SLACK_TOKEN }}


### PR DESCRIPTION
Posts an on-call announcement every Monday and a deployment-lead reminder every Tuesday, @mentioning people from the roster in pm_config.json. Lead/secondary rotate weekly, computed from days-since-Unix-epoch rather than ISO week number so the rotation doesn't glitch at year boundaries -- no stored index needed.

Adds notify_slack.yml, a reusable workflow wrapping slackapi/slack-github-action for posting (and optionally threading replies to) a Slack message, so future workflows can publish to Slack without duplicating that logic.