### PR TITLE
Remove Work level classifications from Editions

### DIFF
--- a/openlibrary/plugins/openlibrary/types/edition.type
+++ b/openlibrary/plugins/openlibrary/types/edition.type
@@ -137,16 +137,6 @@
         },
         {
             "expected_type": {
-                "key": "/type/string"
-            },
-            "unique": false,
-            "type": {
-                "key": "/type/property"
-            },
-            "name": "genres"
-        },
-        {
-            "expected_type": {
                 "key": "/type/toc_item"
             },
             "unique": false,
@@ -274,26 +264,6 @@
                 "key": "/type/property"
             },
             "name": "isbn_13"
-        },
-        {
-            "expected_type": {
-                "key": "/type/string"
-            },
-            "unique": false,
-            "type": {
-                "key": "/type/property"
-            },
-            "name": "dewey_decimal_class"
-        },
-        {
-            "expected_type": {
-                "key": "/type/string"
-            },
-            "unique": false,
-            "type": {
-                "key": "/type/property"
-            },
-            "name": "lc_classifications"
         },
         {
             "expected_type": {

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -624,15 +624,14 @@ class SaveBookHelper:
                     ):
                         if val := getattr(self.work, field, None):
                             new_work[field] = val
+                classifications = edition_data.pop("classifications", [])
+                new_work.set_classifications(classifications)
 
                 self.work = new_work
                 saveutil.save(self.work)
 
             identifiers = edition_data.pop("identifiers", [])
             self.edition.set_identifiers(identifiers)
-
-            classifications = edition_data.pop("classifications", [])
-            self.edition.set_classifications(classifications)
 
             self.edition.set_physical_dimensions(edition_data.pop("physical_dimensions", None))
             self.edition.set_weight(edition_data.pop("weight", None))

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -271,7 +271,7 @@ class Edition(models.Edition):
             else:
                 self.identifiers[name] = value
 
-        if not d.items():
+        if not self.identifiers:
             self.identifiers = None
 
     def get_classifications(self):

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -240,8 +240,6 @@ class Edition(models.Edition):
             "lccn",
             "oclc_numbers",
             "ocaid",
-            "dewey_decimal_class",
-            "lc_classifications",
         )
 
         d = {}

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -272,35 +272,6 @@ class Edition(models.Edition):
         if not self.identifiers:
             self.identifiers = None
 
-    def get_classifications(self):
-        names = ["dewey_decimal_class", "lc_classifications"]
-        return self._process_identifiers(
-            get_identifier_config("edition").classifications,
-            names,
-            self.classifications,
-        )
-
-    def set_classifications(self, classifications):
-        names = ["dewey_decimal_class", "lc_classifications"]
-        d = defaultdict(list)
-        for c in classifications:
-            if "name" not in c or "value" not in c or not re.compile("[a-z0-9_]*").match(c["name"]):
-                continue
-            d[c["name"]].append(c["value"])
-
-        for name in names:
-            self._getdata().pop(name, None)
-        self.classifications = {}
-
-        for name, value in d.items():
-            if name in names:
-                self[name] = value
-            else:
-                self.classifications[name] = value
-
-        if not self.classifications.items():
-            self.classifications = None
-
     def get_weight(self):
         """returns weight as a storage object with value and units fields."""
         w = self.weight

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -338,35 +338,6 @@ class Edition(models.Edition):
         if not self.identifiers:
             self.identifiers = None
 
-    def get_classifications(self):
-        names = ["dewey_decimal_class", "lc_classifications"]
-        return self._process_identifiers(
-            get_identifier_config("edition").classifications,
-            names,
-            self.classifications,
-        )
-
-    def set_classifications(self, classifications):
-        names = ["dewey_decimal_class", "lc_classifications"]
-        d = defaultdict(list)
-        for c in classifications:
-            if "name" not in c or "value" not in c or not re.compile("[a-z0-9_]*").match(c["name"]):
-                continue
-            d[c["name"]].append(c["value"])
-
-        for name in names:
-            self._getdata().pop(name, None)
-        self.classifications = {}
-
-        for name, value in d.items():
-            if name in names:
-                self[name] = value
-            else:
-                self.classifications[name] = value
-
-        if not self.classifications.items():
-            self.classifications = None
-
     def get_weight(self):
         """returns weight as a storage object with value and units fields."""
         w = self.weight

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -1,7 +1,6 @@
 import logging
 import re
 import sys
-from collections import defaultdict
 from datetime import datetime
 from functools import cached_property
 from typing import cast

--- a/openlibrary/schemata/edition.schema.json
+++ b/openlibrary/schemata/edition.schema.json
@@ -138,12 +138,6 @@
     "publish_places":      { "$ref": "shared_definitions.json#/string_array" },
     "publishers":          { "$ref": "shared_definitions.json#/string_array" },
     "contributions":       { "$ref": "shared_definitions.json#/string_array" },
-    "dewey_decimal_class": { "$ref": "shared_definitions.json#/string_array" },
-    "genres":              { "$ref": "shared_definitions.json#/string_array" },
-    "lc_classifications":  {
-      "type": "array",
-      "items": { "$ref": "shared_definitions.json#/lc_classification" }
-    },
     "other_titles":        { "$ref": "shared_definitions.json#/string_array" },
     "series":              { "$ref": "shared_definitions.json#/string_array" },
     "source_records":      { "$ref": "shared_definitions.json#/string_array" },

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -386,7 +386,7 @@ $ lending_state = get_lending_state(edition or work, check_loan_status=bool(ctx.
                 </dl>
             </div>
 
-          $ classifications = edition.get_classifications().multi_items()
+          $ classifications = work.get_classifications().multi_items()
           $if classifications:
             <div class="section">
                 <h3>$_("Classifications")</h3>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Fixes #1946 
builds on, #13149

Addresses comment https://github.com/internetarchive/openlibrary/issues/1946#issuecomment-4959701629 in terms of data model.

All tests still pass, the UI might need some work if it allows adding classification on Editions.


<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

Removes work level properties from the Edition schema and model:
* `dewey_decimal_class`
* `genres`
* `lc_classifications`

It's not clear that these were used for anything, as classifications belong at the work level, and Edition fields tend not to be indexed in Solr. 

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labelled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
