### PR TITLE
fix(ci): pass Slack channel as a secret, not a with: input

### DIFF
--- a/.github/workflows/notify_slack.yml
+++ b/.github/workflows/notify_slack.yml
@@ -50,7 +50,7 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.slack_token }}
           payload: |
-            channel: ${{ toJson(secrets.channel) }}
+            channel: ${{ secrets.channel }}
             text: ${{ toJson(inputs.message) }}
       - name: Reply into an existing thread
         if: ${{ inputs.thread_ts != '' && inputs.message != '' }}
@@ -59,7 +59,7 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.slack_token }}
           payload: |
-            channel: ${{ toJson(secrets.channel) }}
+            channel: ${{ secrets.channel }}
             thread_ts: ${{ toJson(inputs.thread_ts) }}
             text: ${{ toJson(inputs.message) }}
       - id: resolve
@@ -87,6 +87,6 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.slack_token }}
           payload: |
-            channel: ${{ toJson(secrets.channel) }}
+            channel: ${{ secrets.channel }}
             thread_ts: ${{ toJson(needs.publish_parent.outputs.ts) }}
             text: ${{ toJson(matrix.reply) }}

--- a/.github/workflows/notify_slack.yml
+++ b/.github/workflows/notify_slack.yml
@@ -3,10 +3,6 @@ name: Publish to Slack
 on:
   workflow_call:
     inputs:
-      channel:
-        description: Slack channel to publish to.
-        type: string
-        required: true
       message:
         description: >
           Posted as a new parent message when thread_ts is not given, or as a
@@ -24,6 +20,9 @@ on:
         default: '[]'
     secrets:
       slack_token:
+        required: true
+      channel:
+        description: Slack channel to publish to.
         required: true
     outputs:
       ts:
@@ -51,7 +50,7 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.slack_token }}
           payload: |
-            channel: ${{ toJson(inputs.channel) }}
+            channel: ${{ toJson(secrets.channel) }}
             text: ${{ toJson(inputs.message) }}
       - name: Reply into an existing thread
         if: ${{ inputs.thread_ts != '' && inputs.message != '' }}
@@ -60,7 +59,7 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.slack_token }}
           payload: |
-            channel: ${{ toJson(inputs.channel) }}
+            channel: ${{ toJson(secrets.channel) }}
             thread_ts: ${{ toJson(inputs.thread_ts) }}
             text: ${{ toJson(inputs.message) }}
       - id: resolve
@@ -88,6 +87,6 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.slack_token }}
           payload: |
-            channel: ${{ toJson(inputs.channel) }}
+            channel: ${{ toJson(secrets.channel) }}
             thread_ts: ${{ toJson(needs.publish_parent.outputs.ts) }}
             text: ${{ toJson(matrix.reply) }}

--- a/.github/workflows/pm_on_call_notification.yml
+++ b/.github/workflows/pm_on_call_notification.yml
@@ -45,7 +45,7 @@ jobs:
     if: ${{ needs.build_message.outputs.message != '' }}
     uses: ./.github/workflows/notify_slack.yml
     with:
-      channel: ${{ secrets.SLACK_CHANNEL_ABC_TEAM_PLUS }}
       message: ${{ needs.build_message.outputs.message }}
     secrets:
       slack_token: ${{ secrets.SLACK_TOKEN }}
+      channel: ${{ secrets.SLACK_CHANNEL_ABC_TEAM_PLUS }}


### PR DESCRIPTION
## Summary

`pm_on_call_notification.yml` (added 2026-07-15 in 60b94c8) has been failing on every single push to the repo since it was added — not just on its Monday/Tuesday schedule. GitHub Actions validates every workflow file on every push regardless of that workflow's own trigger, and this one is structurally invalid, so it fails immediately with 0 jobs ever created.

Root cause: the `publish` job calls the reusable workflow `notify_slack.yml` and passes the channel through `with:`:

```yaml
with:
  channel: ${{ secrets.SLACK_CHANNEL_ABC_TEAM_PLUS }}
```

The `secrets` context is not available inside a reusable-workflow call's `with:` block — only `github`, `needs`, `strategy`, `matrix`, `vars`, and `inputs` are valid there. GitHub's own validator confirms:

```
Invalid workflow file: (Line: 48, Col: 16): Unrecognized named-value: 'secrets'.
Located at position 1 within expression: secrets.SLACK_CHANNEL_ABC_TEAM_PLUS
```

Fix: move `channel` from `notify_slack.yml`'s `inputs:` to its `secrets:`, and pass it through the caller's `secrets:` block instead of `with:`. This also matches the only other place `SLACK_CHANNEL_ABC_TEAM_PLUS` is used in the repo (`new_comment_digest.yml`), which already treats it as a secret rather than a variable — so this keeps the identifier's treatment consistent repo-wide.

## Testing

- `actionlint` on both changed files: exit 0, no findings
- `python3 -c "import yaml; yaml.safe_load(open(f))"` on both files: valid YAML
- Local reasoning verified against GitHub's documented reusable-workflow context rules (secrets context is only valid in a job's own `secrets:` mapping, not `with:`)
- Not runnable end-to-end locally — `workflow_call`/`schedule` triggers require a live push to internetarchive/openlibrary to fully validate; will confirm on this branch's own push that GitHub no longer reports "Invalid workflow file" for these two files.

## Related

Discovered while investigating why `pm_on_call_notification.yml` runs were failing at 0s on every push (e.g. run 29536311315).