### PR TITLE
Volume mount `olsystem` in read-only mode in `cron-jobs` service

### DIFF
--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -160,7 +160,7 @@ services:
     restart: unless-stopped
     volumes:
       - ../olsystem/etc/cron.d/openlibrary.ol_home0:/etc/cron.d/openlibrary.ol_home0:ro
-      - ../olsystem:/olsystem
+      - ../olsystem:/olsystem:ro
       - /1/var/tmp:/1/var/tmp
     networks:
       - webnet


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Follows #4387

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Changes `olsystem` volume mount for production `cron-jobs` service from `read-write` to `read-only`.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
