### PR TITLE
fix(docker): source build_env.sh from /olsystem + wire PIP_INDEX_URL as a build arg

### DIFF
--- a/compose.staging.yaml
+++ b/compose.staging.yaml
@@ -10,6 +10,8 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.oldev
+      args:
+        - PIP_INDEX_URL=${PIP_INDEX_URL:-}
     restart: unless-stopped
     hostname: "$HOSTNAME"
     environment:
@@ -35,6 +37,8 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.oldev
+      args:
+        - PIP_INDEX_URL=${PIP_INDEX_URL:-}
     restart: unless-stopped
     hostname: "$HOSTNAME"
     environment:

--- a/docker/ol-install-missing-deps.sh
+++ b/docker/ol-install-missing-deps.sh
@@ -18,4 +18,11 @@
 # Remove this file once the associated PR branch is merged and the new
 # image has been published.
 
+# Don't rely on the host shell having sourced build_env.sh before `docker
+# compose up` — /olsystem is already bind-mounted into the container, so
+# pick up PIP_INDEX_URL directly from there if it wasn't already set.
+if [ -z "$PIP_INDEX_URL" ] && [ -f /olsystem/bin/build_env.sh ]; then
+  source /olsystem/bin/build_env.sh
+fi
+
 python -c "import pydantic_settings" 2>/dev/null || python -m pip install -q --user --index-url "${PIP_INDEX_URL:-https://pypi.org/simple/}" 'pydantic-settings==2.9.1'


### PR DESCRIPTION
## Summary

Follow-up to #13178 (merged) — that PR's first commit fixed the runtime `pydantic-settings` fallback, but two more commits were pushed to the same branch *after* it had already merged, so they never landed in master. Re-opening as a fresh PR for those two.

1. **Don't depend on the operator's shell state**: the fix in #13178 only routes through Archive's internal Nexus mirror if `PIP_INDEX_URL` happens to already be exported in whatever shell runs `docker compose up`. Confirmed live on `ol-dev1`: a `docker compose up` without first sourcing `/opt/olsystem/bin/build_env.sh` reproduced the identical original failure. Since `/olsystem` is already bind-mounted into the container, `docker/ol-install-missing-deps.sh` now sources `build_env.sh` from there directly when `PIP_INDEX_URL` isn't already set.

2. **`PIP_INDEX_URL` also needs to be a *build* arg, not just a runtime env var**: after fixing the runtime fallback, a rebuild on `ol-dev1` still failed with `ModuleNotFoundError: No module named 'web'`. `web.py` installs from a git source (`git+https://github.com/webpy/webpy.git@...`) at **build time** via `Dockerfile.oldev`'s `RUN uv pip install -r requirements_test.txt`, with no runtime fallback at all. `Dockerfile.oldev` already declares `ARG PIP_INDEX_URL`/`ARG UV_DEFAULT_INDEX` for this, but `compose.staging.yaml` never wired it into the `build:` section — only into the runtime environment. Added `args: - PIP_INDEX_URL=${PIP_INDEX_URL:-}` to both `web` and `fast_web`.

## Testing

- Verified the `/olsystem` auto-source fallback against the real `openlibrary/olbase:latest` image with a stand-in `build_env.sh`, confirming it's only sourced when `PIP_INDEX_URL` isn't already set (host-provided value takes precedence).
- Ran a real `docker build -f docker/Dockerfile.oldev --build-arg PIP_INDEX_URL=https://pypi.org/simple/`: completes successfully, and `import web` succeeds in the resulting image.
- Live-tested on `ol-dev1`: confirmed the `ModuleNotFoundError: No module named 'web'` failure is exactly the build-arg gap this PR fixes. Awaiting confirmation of a full rebuild + boot with this PR's changes applied.

Pre-commit passed clean on all changed files (locally-runnable hooks; `mypy`/`generate-pot` fail locally as documented — they require Docker/the `infogami` submodule).

## Related

Follow-up to #13178