### PR TITLE
feat(api): allow /api/unlink caller to specify op type (dark vs mismatch)

### DIFF
--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -845,10 +845,7 @@ class opds_home(delegate.page):
         return delegate.RawText(json.dumps(get_cached_homepage()))
 
 
-UNLINK_COMMENTS = {
-    "dark": "Unlink OCAID: Item no longer available",
-    "mismatch": "Unlink OCAID: Wrong Item",
-}
+DEFAULT_UNLINK_COMMENT = "Unlink OCAID: Item no longer available"
 
 
 class unlink_ia_ol(delegate.page):
@@ -856,7 +853,7 @@ class unlink_ia_ol(delegate.page):
     encoding = "json"
 
     def POST(self):
-        i = web.input(digest="", msg="", op="dark")
+        i = web.input(digest="", msg="", comment="")
 
         digest = i.digest
         msg = i.msg
@@ -889,7 +886,7 @@ class unlink_ia_ol(delegate.page):
         # Update records
         try:
             for edition in editions:
-                self.make_dark(edition, ocaid, i.op)
+                self.make_dark(edition, ocaid, i.comment)
         except ClientException as e:
             logger.error(f"Failed to disassociate record with key {edition.key}", exc_info=True)
             raise web.HTTPError(
@@ -901,7 +898,7 @@ class unlink_ia_ol(delegate.page):
         return delegate.RawText(json.dumps({"status": "ok"}))
 
     @staticmethod
-    def make_dark(edition, ocaid, op="dark"):
+    def make_dark(edition, ocaid, comment=""):
         data = edition.dict()
         if "ocaid" in data and data["ocaid"] == ocaid:
             del data["ocaid"]
@@ -909,12 +906,11 @@ class unlink_ia_ol(delegate.page):
         data["source_records"] = [rec for rec in source_records if rec != f"ia:{ocaid}"]
         if not data["source_records"]:
             del data["source_records"]
-        comment = UNLINK_COMMENTS.get(op, UNLINK_COMMENTS["dark"])
         with accounts.RunAs("ImportBot"):
             web.ctx.ip = web.ctx.ip or "127.0.0.1"
             web.ctx.site.save(
                 data,
-                comment,
+                comment or DEFAULT_UNLINK_COMMENT,
                 action="edit-edition-ocaid",
             )
 

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -845,12 +845,18 @@ class opds_home(delegate.page):
         return delegate.RawText(json.dumps(get_cached_homepage()))
 
 
+UNLINK_COMMENTS = {
+    "dark": "Unlink OCAID: Item no longer available",
+    "mismatch": "Unlink OCAID: Wrong Item",
+}
+
+
 class unlink_ia_ol(delegate.page):
     path = "/api/unlink"
     encoding = "json"
 
     def POST(self):
-        i = web.input(digest="", msg="")
+        i = web.input(digest="", msg="", op="dark")
 
         digest = i.digest
         msg = i.msg
@@ -883,7 +889,7 @@ class unlink_ia_ol(delegate.page):
         # Update records
         try:
             for edition in editions:
-                self.make_dark(edition, ocaid)
+                self.make_dark(edition, ocaid, i.op)
         except ClientException as e:
             logger.error(f"Failed to disassociate record with key {edition.key}", exc_info=True)
             raise web.HTTPError(
@@ -895,7 +901,7 @@ class unlink_ia_ol(delegate.page):
         return delegate.RawText(json.dumps({"status": "ok"}))
 
     @staticmethod
-    def make_dark(edition, ocaid):
+    def make_dark(edition, ocaid, op="dark"):
         data = edition.dict()
         if "ocaid" in data and data["ocaid"] == ocaid:
             del data["ocaid"]
@@ -903,11 +909,12 @@ class unlink_ia_ol(delegate.page):
         data["source_records"] = [rec for rec in source_records if rec != f"ia:{ocaid}"]
         if not data["source_records"]:
             del data["source_records"]
+        comment = UNLINK_COMMENTS.get(op, UNLINK_COMMENTS["dark"])
         with accounts.RunAs("ImportBot"):
             web.ctx.ip = web.ctx.ip or "127.0.0.1"
             web.ctx.site.save(
                 data,
-                "Remove OCAID: Item no longer available to borrow.",
+                comment,
                 action="edit-edition-ocaid",
             )
 

--- a/openlibrary/plugins/openlibrary/tests/test_unlinkapi.py
+++ b/openlibrary/plugins/openlibrary/tests/test_unlinkapi.py
@@ -22,8 +22,8 @@ class FakeEdition:
         return dict(self._data)
 
 
-def test_make_dark_default_op_uses_dark_comment():
-    """Omitting op keeps existing behavior: the "dark" comment."""
+def test_make_dark_no_comment_uses_default():
+    """Omitting comment keeps existing behavior: a sensible default comment."""
     edition = FakeEdition({"key": "/books/OL1M", "ocaid": "foo123", "source_records": ["ia:foo123"]})
 
     with (
@@ -39,7 +39,7 @@ def test_make_dark_default_op_uses_dark_comment():
         assert comment == "Unlink OCAID: Item no longer available"
 
 
-def test_make_dark_op_dark_uses_dark_comment():
+def test_make_dark_empty_comment_uses_default():
     edition = FakeEdition({"key": "/books/OL1M", "ocaid": "foo123", "source_records": ["ia:foo123"]})
 
     with (
@@ -49,13 +49,14 @@ def test_make_dark_op_dark_uses_dark_comment():
         mock_web_ctx.ip = "127.0.0.1"
         mock_web_ctx.site = MagicMock()
 
-        unlink_ia_ol.make_dark(edition, "foo123", op="dark")
+        unlink_ia_ol.make_dark(edition, "foo123", comment="")
 
         comment = mock_web_ctx.site.save.call_args[0][1]
         assert comment == "Unlink OCAID: Item no longer available"
 
 
-def test_make_dark_op_mismatch_uses_mismatch_comment():
+def test_make_dark_uses_caller_supplied_comment_verbatim():
+    """The caller's comment is passed straight through -- no OL-side vocabulary/whitelist."""
     edition = FakeEdition({"key": "/books/OL1M", "ocaid": "foo123", "source_records": ["ia:foo123"]})
 
     with (
@@ -65,31 +66,14 @@ def test_make_dark_op_mismatch_uses_mismatch_comment():
         mock_web_ctx.ip = "127.0.0.1"
         mock_web_ctx.site = MagicMock()
 
-        unlink_ia_ol.make_dark(edition, "foo123", op="mismatch")
+        unlink_ia_ol.make_dark(edition, "foo123", comment="Wrong item linked during digitization")
 
         comment = mock_web_ctx.site.save.call_args[0][1]
-        assert comment == "Unlink OCAID: Wrong Item"
-
-
-def test_make_dark_unknown_op_falls_back_to_dark_comment():
-    """An unrecognized op doesn't 400 -- it falls back to the dark comment."""
-    edition = FakeEdition({"key": "/books/OL1M", "ocaid": "foo123", "source_records": ["ia:foo123"]})
-
-    with (
-        patch("openlibrary.plugins.openlibrary.api.accounts.RunAs"),
-        patch("web.ctx") as mock_web_ctx,
-    ):
-        mock_web_ctx.ip = "127.0.0.1"
-        mock_web_ctx.site = MagicMock()
-
-        unlink_ia_ol.make_dark(edition, "foo123", op="bogus")
-
-        comment = mock_web_ctx.site.save.call_args[0][1]
-        assert comment == "Unlink OCAID: Item no longer available"
+        assert comment == "Wrong item linked during digitization"
 
 
 def test_make_dark_still_strips_ocaid_and_source_record():
-    """The op param only changes the comment -- the edit itself is unchanged."""
+    """The comment param only changes the save comment -- the edit itself is unchanged."""
     edition = FakeEdition({"key": "/books/OL1M", "ocaid": "foo123", "source_records": ["ia:foo123", "other:xyz"]})
 
     with (
@@ -99,22 +83,22 @@ def test_make_dark_still_strips_ocaid_and_source_record():
         mock_web_ctx.ip = "127.0.0.1"
         mock_web_ctx.site = MagicMock()
 
-        unlink_ia_ol.make_dark(edition, "foo123", op="mismatch")
+        unlink_ia_ol.make_dark(edition, "foo123", comment="Wrong Item")
 
         data = mock_web_ctx.site.save.call_args[0][0]
         assert "ocaid" not in data
         assert data["source_records"] == ["other:xyz"]
 
 
-def test_post_passes_op_query_param_through_to_make_dark():
-    """/api/unlink threads the op web.input param through to make_dark."""
+def test_post_passes_comment_through_to_make_dark():
+    """/api/unlink threads the comment web.input param through to make_dark."""
     with (
         patch("web.input") as mock_web_input,
         patch("openlibrary.plugins.openlibrary.api.HMACToken.verify") as mock_verify,
         patch("openlibrary.plugins.openlibrary.api.unlink_ia_ol.make_dark") as mock_make_dark,
         patch("web.ctx") as mock_web_ctx,
     ):
-        mock_web_input.side_effect = mock_web_input_func({"digest": "abc", "msg": "foo123|123456", "op": "mismatch"})
+        mock_web_input.side_effect = mock_web_input_func({"digest": "abc", "msg": "foo123|123456", "comment": "Wrong item, mismatched during digitization"})
         mock_verify.return_value = True
         mock_web_ctx.site = MagicMock()
         mock_web_ctx.site.things.side_effect = [["/books/OL1M"], []]
@@ -123,11 +107,11 @@ def test_post_passes_op_query_param_through_to_make_dark():
         result = json.loads(unlink_ia_ol().POST()["rawtext"])
 
         assert result == {"status": "ok"}
-        mock_make_dark.assert_called_once_with(mock_web_ctx.site.get.return_value, "foo123", "mismatch")
+        mock_make_dark.assert_called_once_with(mock_web_ctx.site.get.return_value, "foo123", "Wrong item, mismatched during digitization")
 
 
-def test_post_default_op_is_dark():
-    """Omitting op on the request still calls make_dark with the "dark" default."""
+def test_post_missing_comment_passes_empty_string_through():
+    """Omitting comment on the request still calls make_dark, which applies the default."""
     with (
         patch("web.input") as mock_web_input,
         patch("openlibrary.plugins.openlibrary.api.HMACToken.verify") as mock_verify,
@@ -142,4 +126,4 @@ def test_post_default_op_is_dark():
 
         json.loads(unlink_ia_ol().POST()["rawtext"])
 
-        mock_make_dark.assert_called_once_with(mock_web_ctx.site.get.return_value, "foo123", "dark")
+        mock_make_dark.assert_called_once_with(mock_web_ctx.site.get.return_value, "foo123", "")

--- a/openlibrary/plugins/openlibrary/tests/test_unlinkapi.py
+++ b/openlibrary/plugins/openlibrary/tests/test_unlinkapi.py
@@ -1,0 +1,145 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import web
+
+from openlibrary.plugins.openlibrary.api import unlink_ia_ol
+
+
+def mock_web_input_func(data):
+    def _mock_web_input(*args, **kwargs):
+        return web.storage(kwargs | data)
+
+    return _mock_web_input
+
+
+class FakeEdition:
+    def __init__(self, data):
+        self.key = data.get("key", "/books/OL1M")
+        self._data = data
+
+    def dict(self):
+        return dict(self._data)
+
+
+def test_make_dark_default_op_uses_dark_comment():
+    """Omitting op keeps existing behavior: the "dark" comment."""
+    edition = FakeEdition({"key": "/books/OL1M", "ocaid": "foo123", "source_records": ["ia:foo123"]})
+
+    with (
+        patch("openlibrary.plugins.openlibrary.api.accounts.RunAs"),
+        patch("web.ctx") as mock_web_ctx,
+    ):
+        mock_web_ctx.ip = "127.0.0.1"
+        mock_web_ctx.site = MagicMock()
+
+        unlink_ia_ol.make_dark(edition, "foo123")
+
+        comment = mock_web_ctx.site.save.call_args[0][1]
+        assert comment == "Unlink OCAID: Item no longer available"
+
+
+def test_make_dark_op_dark_uses_dark_comment():
+    edition = FakeEdition({"key": "/books/OL1M", "ocaid": "foo123", "source_records": ["ia:foo123"]})
+
+    with (
+        patch("openlibrary.plugins.openlibrary.api.accounts.RunAs"),
+        patch("web.ctx") as mock_web_ctx,
+    ):
+        mock_web_ctx.ip = "127.0.0.1"
+        mock_web_ctx.site = MagicMock()
+
+        unlink_ia_ol.make_dark(edition, "foo123", op="dark")
+
+        comment = mock_web_ctx.site.save.call_args[0][1]
+        assert comment == "Unlink OCAID: Item no longer available"
+
+
+def test_make_dark_op_mismatch_uses_mismatch_comment():
+    edition = FakeEdition({"key": "/books/OL1M", "ocaid": "foo123", "source_records": ["ia:foo123"]})
+
+    with (
+        patch("openlibrary.plugins.openlibrary.api.accounts.RunAs"),
+        patch("web.ctx") as mock_web_ctx,
+    ):
+        mock_web_ctx.ip = "127.0.0.1"
+        mock_web_ctx.site = MagicMock()
+
+        unlink_ia_ol.make_dark(edition, "foo123", op="mismatch")
+
+        comment = mock_web_ctx.site.save.call_args[0][1]
+        assert comment == "Unlink OCAID: Wrong Item"
+
+
+def test_make_dark_unknown_op_falls_back_to_dark_comment():
+    """An unrecognized op doesn't 400 -- it falls back to the dark comment."""
+    edition = FakeEdition({"key": "/books/OL1M", "ocaid": "foo123", "source_records": ["ia:foo123"]})
+
+    with (
+        patch("openlibrary.plugins.openlibrary.api.accounts.RunAs"),
+        patch("web.ctx") as mock_web_ctx,
+    ):
+        mock_web_ctx.ip = "127.0.0.1"
+        mock_web_ctx.site = MagicMock()
+
+        unlink_ia_ol.make_dark(edition, "foo123", op="bogus")
+
+        comment = mock_web_ctx.site.save.call_args[0][1]
+        assert comment == "Unlink OCAID: Item no longer available"
+
+
+def test_make_dark_still_strips_ocaid_and_source_record():
+    """The op param only changes the comment -- the edit itself is unchanged."""
+    edition = FakeEdition({"key": "/books/OL1M", "ocaid": "foo123", "source_records": ["ia:foo123", "other:xyz"]})
+
+    with (
+        patch("openlibrary.plugins.openlibrary.api.accounts.RunAs"),
+        patch("web.ctx") as mock_web_ctx,
+    ):
+        mock_web_ctx.ip = "127.0.0.1"
+        mock_web_ctx.site = MagicMock()
+
+        unlink_ia_ol.make_dark(edition, "foo123", op="mismatch")
+
+        data = mock_web_ctx.site.save.call_args[0][0]
+        assert "ocaid" not in data
+        assert data["source_records"] == ["other:xyz"]
+
+
+def test_post_passes_op_query_param_through_to_make_dark():
+    """/api/unlink threads the op web.input param through to make_dark."""
+    with (
+        patch("web.input") as mock_web_input,
+        patch("openlibrary.plugins.openlibrary.api.HMACToken.verify") as mock_verify,
+        patch("openlibrary.plugins.openlibrary.api.unlink_ia_ol.make_dark") as mock_make_dark,
+        patch("web.ctx") as mock_web_ctx,
+    ):
+        mock_web_input.side_effect = mock_web_input_func({"digest": "abc", "msg": "foo123|123456", "op": "mismatch"})
+        mock_verify.return_value = True
+        mock_web_ctx.site = MagicMock()
+        mock_web_ctx.site.things.side_effect = [["/books/OL1M"], []]
+        mock_web_ctx.site.get.return_value = FakeEdition({"key": "/books/OL1M"})
+
+        result = json.loads(unlink_ia_ol().POST()["rawtext"])
+
+        assert result == {"status": "ok"}
+        mock_make_dark.assert_called_once_with(mock_web_ctx.site.get.return_value, "foo123", "mismatch")
+
+
+def test_post_default_op_is_dark():
+    """Omitting op on the request still calls make_dark with the "dark" default."""
+    with (
+        patch("web.input") as mock_web_input,
+        patch("openlibrary.plugins.openlibrary.api.HMACToken.verify") as mock_verify,
+        patch("openlibrary.plugins.openlibrary.api.unlink_ia_ol.make_dark") as mock_make_dark,
+        patch("web.ctx") as mock_web_ctx,
+    ):
+        mock_web_input.side_effect = mock_web_input_func({"digest": "abc", "msg": "foo123|123456"})
+        mock_verify.return_value = True
+        mock_web_ctx.site = MagicMock()
+        mock_web_ctx.site.things.side_effect = [["/books/OL1M"], []]
+        mock_web_ctx.site.get.return_value = FakeEdition({"key": "/books/OL1M"})
+
+        json.loads(unlink_ia_ol().POST()["rawtext"])
+
+        mock_make_dark.assert_called_once_with(mock_web_ctx.site.get.return_value, "foo123", "dark")


### PR DESCRIPTION
Closes #13171.

## What changed (revised per @hornc's review — see issue thread)

`/api/unlink` now accepts a **`comment`** field — plain free text, supplied directly by the caller — instead of an `op` code. The initial draft of this PR used an `op` param (`dark`/`mismatch`) mapped internally to fixed comment strings, but @hornc correctly flagged that as a separation-of-concerns violation: OL doesn't need an archive.org-specific vocabulary when the caller can just supply the actual comment text, the same way any other edit already works. Mek confirmed: implement it that way instead.

- `comment` is a separate, **unsigned** `web.input()` field — not folded into the HMAC-signed `msg`. It's free text with no OL-side whitelist.
- If omitted, falls back to a default: `"Unlink OCAID: Item no longer available"` (replacing the old, hardcoded `"Remove OCAID: Item no longer available to borrow."`) — so existing/not-yet-updated callers keep working unchanged.
- `link_ia_ol` / `/api/link` is untouched (confirmed out of scope during discovery — see issue thread).

**Consequence for archive.org's callers**: to get distinct, meaningful messaging per scenario (MARC disassociation, wrong-item mismatch, digitization re-link), the archive.org-side tooling will need a caller-side change to actually send that comment text. Until then, callers that don't send `comment` get the default above. That coordination is tracked separately (Slack), not part of this PR.

## Files changed

- `openlibrary/plugins/openlibrary/api.py` — `unlink_ia_ol` class: `DEFAULT_UNLINK_COMMENT` constant, `comment` threaded from `POST` into `make_dark`.
- `openlibrary/plugins/openlibrary/tests/test_unlinkapi.py` (new) — 6 tests covering default/empty/custom comment, that the ocaid/source_records strip behavior is unchanged, and that `POST` threads `comment` (or empty string) through to `make_dark`.

## Testing

- New tests: 6/6 passing.
- Full `make test-py` suite: 5655 passed, 39 skipped, 0 regressions.
- `mypy` clean on changed files (run in Docker).
- Verified against a real seeded DB edition (`/books/OL24218089M`) via a bootstrapped `infogami` shell in the `web` container for the original `op`-based design — confirmed the real edition is read correctly; stopped short of a full authenticated HTTP round-trip and the final `site.save()` due to two **pre-existing, unrelated** dev-environment gaps (no local `ia_sync_secret`, no seeded `ImportBot` account). Same boundary applies to this revised design; see PR comments for detail.
- No secrets in diff.
- **Browser/a11y verification: not applicable** — this is a backend JSON API change with no template/frontend surface.

## Out of scope (confirmed during discovery, see issue thread)

- `link_ia_ol` / `/api/link` — shares the same `msg`-parsing pattern, not touched.
- Embedding `comment` in the signed `msg` — a separate unsigned field was chosen for the same reason as the earlier `op` design: no tamper-protection need, and no out-of-repo signed-message-format change required.
- `except ValueError, ExpiredTokenError:` — valid Python 3 syntax (implicit tuple-except), not a bug.
- The dead/unwired FastAPI stub `unlink_ia_ol` in `fastapi/internal/api.py`.

**This PR is intentionally being kept in draft** per the coordinator, pending confirmation the design now satisfies @hornc.