### PR TITLE
chore(docker): parameterize hardcoded dev ports for parallel worktrees

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -9,7 +9,7 @@ services:
       dockerfile: docker/Dockerfile.oldev
     ports:
       # Debugger
-      - 127.0.0.1:3000:3000
+      - 127.0.0.1:${WEB_DEBUG_PORT:-3000}:3000
     volumes:
       # Persistent volume mount for installed git submodules
       - ol-vendor:/openlibrary/vendor
@@ -37,7 +37,7 @@ services:
       dockerfile: docker/Dockerfile.oldev
     ports:
       # Debugger
-      - 127.0.0.1:3001:3000
+      - 127.0.0.1:${FAST_WEB_DEBUG_PORT:-3001}:3000
     volumes:
       # Persistent volume mount for generated css and js
       - ol-build:/openlibrary/static/build
@@ -67,7 +67,7 @@ services:
     volumes:
       - ./docker/ol-local-solr-start.sh:/docker/ol-solr-start.sh:ro
     ports:
-      - 8983:8983
+      - ${SOLR_PORT:-8983}:8983
     # Run the wrapper script which handles schema migrations in dev mode
     command: /docker/ol-solr-start.sh
 
@@ -113,7 +113,7 @@ services:
       context: .
       dockerfile: docker/Dockerfile.oldev
     ports:
-      - 7075:7075
+      - ${COVERS_PORT:-7075}:7075
     volumes:
       - ol-vendor:/openlibrary/vendor
       - ${OL_MOUNT_DIR:-.}:/openlibrary
@@ -173,7 +173,7 @@ services:
       - webnet
     ports:
       # mailpit web UI — browse captured email at http://localhost:8025
-      - 8025:8025
+      - ${MOCKSERVICES_PORT:-8025}:8025
     healthcheck:
       # wget is purged from the image after installing mailpit (see Dockerfile);
       # use python, which is always present in the python:3.12-slim base, instead.


### PR DESCRIPTION
## Summary
Five ports in `compose.override.yaml` were hardcoded with no override, so a second concurrent `git worktree` checkout fails to bind them: `web`/`fast_web` debugger ports, `solr`, `covers`, `mockservices`. This mirrors the existing `WEB_PORT`/`FAST_WEB_PORT` env-var-with-default pattern already proven in `compose.yaml` for the other two:

| Service | Before | After |
|---|---|---|
| `web` debugger | `127.0.0.1:3000:3000` | `127.0.0.1:${WEB_DEBUG_PORT:-3000}:3000` |
| `fast_web` debugger | `127.0.0.1:3001:3000` | `127.0.0.1:${FAST_WEB_DEBUG_PORT:-3001}:3000` |
| `solr` | `8983:8983` | `${SOLR_PORT:-8983}:8983` |
| `covers` | `7075:7075` | `${COVERS_PORT:-7075}:7075` |
| `mockservices` | `8025:8025` | `${MOCKSERVICES_PORT:-8025}:8025` |

The `127.0.0.1:` host-bind prefix on the two debugger ports is kept as a literal part of the compose line (not folded into the env var default) so the localhost-only bind is preserved even when the port is overridden — verified this holds under override, not just under defaults.

## Testing (completed)
- `docker compose config` with no env vars set → resolved ports for all five services match today's hardcoded values exactly.
- `docker compose config` with each new env var set individually → each shows the overridden port, `127.0.0.1` host-bind preserved on the debugger ports, no other services affected.
- Full stack (`web infobase db memcached home covers mockservices solr`) started with all seven ports overridden simultaneously (`WEB_PORT=8091 FAST_WEB_PORT=18091 WEB_DEBUG_PORT=3021 FAST_WEB_DEBUG_PORT=3022 SOLR_PORT=8993 COVERS_PORT=7085 MOCKSERVICES_PORT=8035`), while another live worktree held all five default ports (8080/3000/8983/7075/8025) — the exact collision this PR fixes. All containers bound to the overridden ports; `curl http://localhost:8091` → `200`.
- Pre-commit clean on full branch diff; no secrets in diff.

## Out of scope
- Sharing a single Solr instance across multiple worktrees (separate design effort, per the issue).
- `compose.yaml`/`compose.production.yaml`/`compose.staging.yaml`/`compose.near-prod.yaml`/`compose.selinux.yaml`/`compose.infogami-local.yaml` — this only touches the local-dev-only `compose.override.yaml`.

Closes #13184.