### PR TITLE
fix: safe attribute construction for data-ol-link-track in 4 templates

### DIFF
--- a/openlibrary/templates/home/onboarding_card.html
+++ b/openlibrary/templates/home/onboarding_card.html
@@ -9,15 +9,12 @@ $# href           : str : `href` for the card
 $# ol_link_track  : str : Event name for analytics
 $# attribution    : str : Attribution for the image used in the card
 
-$ data_ol_link_track = ''
-$if ol_link_track:
-  $ data_ol_link_track = 'data-ol-link-track="%s"' % ol_link_track
-
 <div class="carousel__item tutorial__item">
   <a
     href="$href"
     tabindex="0"
-    $data_ol_link_track
+    $if ol_link_track:
+      data-ol-link-track="$ol_link_track"
   >
     <img src="$img_src"
       alt=""

--- a/openlibrary/templates/lib/header_dropdown.html
+++ b/openlibrary/templates/lib/header_dropdown.html
@@ -17,8 +17,11 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_super_li
 <div class="$(props['name'])-component header-dropdown">
   $if singleton:
     $ link = props['links'][0]
-    $ tracker = 'data-ol-link-track=%s|%s' % (track_prefix, link['track']) if (track_prefix and link.get('track')) else ''
-    <a href="$link['href']" $tracker>$(props['label'])</a>
+    $ tracker_value = '%s|%s' % (track_prefix, link['track']) if (track_prefix and link.get('track')) else ''
+    <a href="$link['href']"
+      $if tracker_value:
+        data-ol-link-track="$tracker_value"
+    >$(props['label'])</a>
   $else:
     <details>
       <summary $:cond(props['name'] == 'hamburger', 'data-ol-link-track="HeaderBar|Hamburger"')>
@@ -45,7 +48,7 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_super_li
       >
         <ul class="dropdown-menu $(props['name'])-dropdown-menu">
           $for link in props['links']:
-            $ tracker = 'data-ol-link-track=%s|%s' % (track_prefix, link['track']) if (track_prefix and link.get('track')) else ''
+            $ tracker_value = '%s|%s' % (track_prefix, link['track']) if (track_prefix and link.get('track')) else ''
             $if 'subsection' in link:
               <li class="subsection">
                 $(link['subsection'])
@@ -60,13 +63,19 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_super_li
               $if 'post' in link:
                 $ name = 'name=%s' % link['name'] if 'name' in link else ''
                 <form $name action="$(link['post'])" method="post">
-                  <button $(tracker)>$(link["text"])</button>
+                  <button
+                    $if tracker_value:
+                      data-ol-link-track="$tracker_value"
+                  >$(link["text"])</button>
                 </form>
               $else:
                 $if is_privileged_user:
                   $if 'badge' in link and cached_get_counts_by_mode(mode='open') > 0:
                     <div class="app-drawer__badge">$(cached_get_counts_by_mode(mode='open'))</div>
-                <a href="$(link['href'])" $(tracker)>
+                <a href="$(link['href'])"
+                  $if tracker_value:
+                    data-ol-link-track="$tracker_value"
+                >
                   $if 'new' in link and props['name'] == 'hamburger':
                     <span>$(link['text'])</span><span class="app-drawer__badge">$_('New!')</span>
                   $else:

--- a/openlibrary/templates/tests/icon_link_pattern_check.html
+++ b/openlibrary/templates/tests/icon_link_pattern_check.html
@@ -1,0 +1,10 @@
+$def with (ga_data)
+$# Test-only fixture. Mirrors the icon_link() attribute-construction pattern
+$# duplicated in type/edition/modal_links.html and type/edition/title_and_author.html.
+$# Those files' real call sites only ever pass hardcoded literal ga_data, so there's
+$# no top-level parameter to drive an end-to-end injection test through them directly.
+$# See openlibrary/tests/test_link_track_attribute_escaping.py.
+<a href="javascript:;" class="icon-link"
+  $if ga_data:
+    data-ol-link-track="$ga_data"
+>link</a>

--- a/openlibrary/templates/type/edition/modal_links.html
+++ b/openlibrary/templates/type/edition/modal_links.html
@@ -12,9 +12,10 @@ $def icon_link(link_class, img_src, link_text, login_redirect=True, ga_data=None
     $ link_class = '%s--redirect js-login-intent' % link_class
     $ href = '/account/login?redirect=%s' % ctx.path
 
-  $ ga_attr = 'data-ol-link-track=%s' % ga_data if ga_data else ''
-
-  <a href="$href" class="$link_class icon-link" $ga_attr $:data_attr>
+  <a href="$href" class="$link_class icon-link"
+    $if ga_data:
+      data-ol-link-track="$ga_data"
+    $:data_attr>
     <img class="icon-link__image" src="$img_src" alt="">
     <div class="icon-link__text">$link_text</div>
   </a>

--- a/openlibrary/templates/type/edition/title_and_author.html
+++ b/openlibrary/templates/type/edition/title_and_author.html
@@ -3,8 +3,10 @@ $def with (page, work, edition, ocaid, work_title, star_ratings_stats, for_deskt
 $def icon_link(link_class, img_src, link_text, login_redirect=True, ga_data=None):
   $ href = 'javascript:;'
 
-  $ ga_attr = 'data-ol-link-track=%s' % ga_data if ga_data else ''
-  <a href="$href" class="$link_class icon-link" $ga_attr>
+  <a href="$href" class="$link_class icon-link"
+    $if ga_data:
+      data-ol-link-track="$ga_data"
+    >
     <img class="icon-link__image" src="$img_src" alt="">
     <div class="icon-link__text">$link_text</div>
   </a>

--- a/openlibrary/tests/test_link_track_attribute_escaping.py
+++ b/openlibrary/tests/test_link_track_attribute_escaping.py
@@ -1,0 +1,71 @@
+"""Regression tests for issue #13186 (follow-up to PR #12985's Follow.html fix).
+
+Templetor's bare `$var` substitution HTML-escapes `<`, `>`, `&`, `"` but not
+whitespace. Before this fix, onboarding_card.html, header_dropdown.html,
+modal_links.html, and title_and_author.html each built the tracking attribute
+as a single pre-formatted "attr=value" string spliced into the tag unquoted --
+so a value containing a space (e.g. "x onmouseover=alert(1)//") injects a real
+new HTML attribute, because the escaped `"` characters become inert `&quot;`
+text rather than real quote delimiters. The fix places the value inside a
+*static*, template-source quote character instead, which can't be broken out
+of regardless of what the value contains.
+"""
+
+from bs4 import BeautifulSoup
+
+INJECTION_PAYLOAD = "x onmouseover=alert(document.cookie)//"
+
+
+def test_onboarding_card_blocks_attribute_injection(render_template, request_context_fixture):
+    request_context_fixture(lang="en")
+    html = str(
+        render_template(
+            "home/onboarding_card",
+            "Title",
+            "Body",
+            "/img.png",
+            "/href",
+            ol_link_track=INJECTION_PAYLOAD,
+        )
+    )
+    a = BeautifulSoup(html, "lxml").find("a")
+    assert a.get("onmouseover") is None
+    assert a["data-ol-link-track"] == INJECTION_PAYLOAD
+
+
+def test_header_dropdown_singleton_blocks_attribute_injection(render_template, request_context_fixture):
+    request_context_fixture(lang="en")
+    props = {"name": "test-dropdown", "label": "Test", "links": [{"href": "/x", "track": INJECTION_PAYLOAD}]}
+    html = str(render_template("lib/header_dropdown", props, track_prefix="Test"))
+    a = BeautifulSoup(html, "lxml").find("a")
+    assert a.get("onmouseover") is None
+    assert a["data-ol-link-track"] == f"Test|{INJECTION_PAYLOAD}"
+
+
+def test_header_dropdown_menu_item_blocks_attribute_injection(render_template, request_context_fixture):
+    request_context_fixture(lang="en")
+    props = {
+        "name": "test-dropdown",
+        "label": "Test",
+        "links": [
+            {"href": "/x", "track": INJECTION_PAYLOAD, "text": "Item one"},
+            {"href": "/y", "track": INJECTION_PAYLOAD, "text": "Item two"},
+        ],
+    }
+    html = str(render_template("lib/header_dropdown", props, track_prefix="Test"))
+    links = BeautifulSoup(html, "lxml").find_all("a", href=True)
+    menu_links = [a for a in links if a["href"] in ("/x", "/y")]
+    assert len(menu_links) == 2
+    for a in menu_links:
+        assert a.get("onmouseover") is None
+        assert a["data-ol-link-track"] == f"Test|{INJECTION_PAYLOAD}"
+
+
+def test_icon_link_pattern_blocks_attribute_injection(render_template, request_context_fixture):
+    """Covers the icon_link() pattern duplicated in modal_links.html and
+    title_and_author.html -- see openlibrary/templates/tests/icon_link_pattern_check.html."""
+    request_context_fixture(lang="en")
+    html = str(render_template("tests/icon_link_pattern_check", ga_data=INJECTION_PAYLOAD))
+    a = BeautifulSoup(html, "lxml").find("a")
+    assert a.get("onmouseover") is None
+    assert a["data-ol-link-track"] == INJECTION_PAYLOAD


### PR DESCRIPTION
Closes #13186. Follow-up to #12985's review, which found the same unsafe pattern in `modal_links.html` and flagged it out of scope. A full sweep during that review turned up 3 more instances of the identical bug.

## Problem

`openlibrary/templates/type/edition/modal_links.html`, `title_and_author.html`, `home/onboarding_card.html`, and `lib/header_dropdown.html` each built their tracking attribute (`data-ol-link-track`) via Python `%`-string formatting, then spliced the whole `attr="value"` fragment into the tag as a single unquoted token.

**The real, confirmed mechanism** (not tag/script breakout — Open Library's `render_template` pipeline already HTML-escapes `<`, `>`, `&`, `"` for a bare `$var`): a value containing a **space** injects a real new HTML attribute, because the escaped `"` characters become inert `&quot;` text rather than actual quote delimiters once escaped, effectively making the "quoted" attribute unquoted. E.g. `ga_data = "x onmouseover=alert(document.cookie)//"` renders as:

```html
<a data-ol-link-track="x" onmouseover="alert(document.cookie)//">
```

Confirmed via a real test render against the *prior* code (see the added test file — verified red against old code, green against the fix, not just reasoned about). None of today's real callers pass anything but hardcoded string literals, so this isn't attacker-reachable through any live code path right now — same defense-in-depth situation Follow.html was in before #12985.

## Fix

Same pattern as #12985: place the value inside a *static*, template-source literal quote character via `$if var: attr="$var"`, instead of building the whole `attr="value"` fragment in Python and splicing it in unquoted. This can't be broken out of regardless of what characters (including whitespace) the value contains.

## Testing

- `openlibrary/tests/test_link_track_attribute_escaping.py` — new tests for all 4 fixes, each proving the injection is blocked with a real payload (`x onmouseover=alert(document.cookie)//`) rendered through the actual template engine and parsed with BeautifulSoup. Verified red against the pre-fix code, green after.
- `modal_links.html`/`title_and_author.html` duplicate an internal `icon_link()` helper not reachable with dynamic data through any real top-level call site today, so those two are covered via a small dedicated test fixture (`openlibrary/templates/tests/icon_link_pattern_check.html`) that mirrors the exact fixed pattern.
- Full `openlibrary/tests/test_templates.py` suite (769 tests) green. Broader regression sweep (`openlibrary/tests/`, `openlibrary/plugins/upstream/tests/`, `openlibrary/plugins/openlibrary/tests/`, 1920+ tests) green aside from 3 pre-existing, unrelated failures (missing `site` context, reproducible in isolation on a clean checkout, nothing to do with any file this PR touches).
- **Browser-verified**: home page (onboarding carousel), header nav (hamburger dropdown), and a work page (icon links: Share/Review/Notes) all render correctly post-fix — screenshots taken, no visual regressions, all `data-ol-link-track` attributes present with the expected values.
- **A11y check skipped, noting explicitly rather than silently**: `openlibrary/scripts/a11y/pa11y_runner.py` referenced in internal docs doesn't exist in this codebase currently, so it couldn't be run. Risk is low regardless — this change only alters how an existing non-semantic analytics attribute is constructed internally; no DOM structure, semantics, or interactive elements changed.
- No visual changes — this only changes how the attribute is constructed internally, not any class, structure, or rendered content.