### PR TITLE
fix: dropper AttributeError when redirect stub has no title

### DIFF
--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -279,7 +279,7 @@ class Bookshelves(db.CommonExtras):
         for key in missing_keys.copy():
             if not work_to_edition_keys.get(key):
                 missing_keys.remove(key)
-                solr_docs.append(web.storage({"key": key}))
+                solr_docs.append(web.storage({"key": key, "title": ""}))
 
         edition_keys_to_query = [work_to_edition_keys[key].split("/")[2] for key in missing_keys]
         fq = f"edition_key:({' OR '.join(edition_keys_to_query)})"

--- a/openlibrary/templates/my_books/dropper.html
+++ b/openlibrary/templates/my_books/dropper.html
@@ -26,7 +26,7 @@ $if not ctx.user:
 
 $ data = { "work-key": work_key or "" }
 
-$ title = work.title if work else (edition.get('title', '') if edition else '')
+$ title = work.get('title', '') if work else (edition.get('title', '') if edition else '')
 $ primary_action = render_template('my_books/primary_action', work_key, edition_key, (ctx.user and ctx.user.key), users_work_read_status, page_url, title)
 $ dropdown_content = render_template('my_books/dropdown_content', user_lists, seed_key, work_key, edition_key, users_work_read_status, async_load=async_load)
 $ dropper_label = _('More reading options for %(title)s', title=title) if title else _('More reading options')


### PR DESCRIPTION
Closes #13169

fix

### Technical

`add_storage_items_for_redirects` in `bookshelves.py` inserts a bare `web.storage({"key": key})` stub for any reading log work that is missing from Solr and has no edition key. That stub then flows into `dropper.html` where line 29 does `work.title` — but `web.storage.__getattr__` raises `AttributeError` for any missing key, producing the reported template error.

Two-part fix:

1. **`bookshelves.py` (line 282)** — include `"title": ""` in the stub, consistent with how `add_storage_items_for_deletes` always includes a title in its stubs.
2. **`dropper.html` (line 29)** — switch from `work.title` to `work.get('title', '')` for defense in depth; this is already how `edition` is handled on the same line.

### Testing

Reproduce: have a reading log entry whose work has been redirected to another OL key and was added without a specific edition. Open `/people/<username>/books/want-to-read`.

- Before: `AttributeError: 'title'` in template, falls back to default template
- After: page renders normally; the redirected entry shows with no title (empty string)

### Screenshot

Backend-only fix, no UI change.

### Stakeholders

@cdrini @mekarpeles