### PR TITLE
feat: add statsd and matomo tracking for signup and activation funnel

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -376,7 +376,7 @@ class account_create(delegate.page):
                     verified=False,
                     retries=USERNAME_RETRIES,
                 )
-                stats.increment("ol.account.created")
+                stats.increment("ol.account.verified")
                 if "pd_request" in web.input() and web.input().get("pd_program"):
                     web.setcookie("pda", web.input().get("pd_program"))
                 return render["account/verify"](username=f.username.value, email=f.email.value)

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -376,6 +376,7 @@ class account_create(delegate.page):
                     verified=False,
                     retries=USERNAME_RETRIES,
                 )
+                stats.increment("ol.account.created")
                 if "pd_request" in web.input() and web.input().get("pd_program"):
                     web.setcookie("pda", web.input().get("pd_program"))
                 return render["account/verify"](username=f.username.value, email=f.email.value)
@@ -809,6 +810,7 @@ class account_verify(delegate.page):
             raise web.seeother("/account/create")
         r = InternetArchiveAccount.verify(token=i.t)
         if "error" in r:
+            stats.increment("ol.account.verify.fail")
             if accounts.get_current_user():
                 raise web.seeother("/account/books")
             add_flash_message(
@@ -817,6 +819,8 @@ class account_verify(delegate.page):
             )
             raise web.seeother("/account/create")
         add_flash_message("success", _("Your email has been verified. You are now logged in."))
+        stats.increment("ol.account.verify.success")
+        web.setcookie("ol_activation", "1", expires=300)
         kwargs = {"access": r["s3"]["access"], "secret": r["s3"]["secret"]}
         if i.redirect:
             kwargs["redirect"] = i.redirect

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -376,7 +376,6 @@ class account_create(delegate.page):
                     verified=False,
                     retries=USERNAME_RETRIES,
                 )
-                stats.increment("ol.account.verified")
                 if "pd_request" in web.input() and web.input().get("pd_program"):
                     web.setcookie("pda", web.input().get("pd_program"))
                 return render["account/verify"](username=f.username.value, email=f.email.value)

--- a/openlibrary/templates/account/verify.html
+++ b/openlibrary/templates/account/verify.html
@@ -15,3 +15,8 @@ $var title: $_("Verification email sent")
   </p>
 
 </div>
+
+<script>
+  var _paq = window._paq = window._paq || [];
+  _paq.push(['trackEvent', 'Account', 'RegistrationSuccess']);
+</script>

--- a/openlibrary/templates/site/head.html
+++ b/openlibrary/templates/site/head.html
@@ -63,6 +63,12 @@ $def with (title)
    // Dimension 1 (visit-scoped): "Days Since Registration" — ID must match Matomo admin config (issue #12144)
    var _paq = window._paq = window._paq || [];
    _paq.push(['setCustomDimension', 1, $:json_encode(get_days_registered(ctx.user))]);
+   // One-shot ActivationSuccess: cookie set by /account/verify on successful email activation.
+   // Cleared immediately so it only fires once per activation.
+   if (document.cookie.match(/(?:^|;\s*)ol_activation=1/)) {
+     _paq.push(['trackEvent', 'Account', 'ActivationSuccess']);
+     document.cookie = 'ol_activation=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
+   }
 
    var _mtm = window._mtm = window._mtm || [];
    _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});


### PR DESCRIPTION
Closes #

This PR adds statsd counters and Matomo event tracking to measure the signup-to-verification funnel — i.e. what percentage of users who create an account actually complete email verification, along with device classification.

**Background / Hunch:**
Currently there is no way to compute a signup funnel rate in Grafana. `admin_range__members` in `admin/numbers.py` counts new `/type/user` records daily, but a user record is only created *after* successful verification and first login — so it's already post-dropoff. There's no counter for attempted signups.

The hypothesis being investigated: when a user signs up on one device but hasn't logged into their email on that device, clicking the verification link either opens a new browser session with no context, or forces an app switch. This cross-device friction likely causes a meaningful portion of signups to bounce before verifying. Tracking mobile vs desktop at both the signup and verification steps will let us quantify this before deciding whether to invest in an OTP-based alternative (which would let users type a short code instead of clicking a link).

### Proposed Changes

#### 1. Statsd Funnel & Ops Counters (Backend)
Added to `openlibrary/plugins/upstream/account.py`:
- `ol.account.created`: Incremented upon successful submission of the registration form.
- `ol.account.verify.success`: Incremented when the email verification link is successfully clicked and the account is activated.
- `ol.account.verify.fail`: Incremented if the verification link fails (invalid or expired token) for outage and TTL failure detection.
- Sets a short-lived (`300s`) `ol_activation` cookie upon successful verification to communicate activation status to the frontend.

#### 2. Matomo Event Tracking (Frontend)
Added to layout/templates to capture device analytics natively within Matomo (e.g. mobile vs desktop via User-Agent):
- `RegistrationSuccess` (in `openlibrary/templates/account/verify.html`): Fires on the "check your email" page load.
- `ActivationSuccess` (in `openlibrary/templates/site/head.html`): Reads the `ol_activation` cookie, tracks the event, and immediately clears the cookie.

### Testing
- Existing test suite passed.
- Verified that the cookie-based redirection flow does not interrupt core user session logins.

### Stakeholders
@mek
