### PR TITLE
Percent encode whitespace in `mailto` hrefs

### DIFF
--- a/openlibrary/templates/account.html
+++ b/openlibrary/templates/account.html
@@ -28,7 +28,7 @@ $ mb = MyBooksTemplate(username, 'Settings')
       <p class="sansserif larger"><a href="//archive.org/account/index.php?settings=1">$_("Update Email Address")</a></p>
       <p class="sansserif larger"><a href="//openlibrary.org/help/faq/troubleshooting#deleteaccount">$_("Deactivate Account")</a></p>
       <br/>
-      <p class="sansserif larger"><a href="mailto:openlibrary@archive.org?subject=Support Case">$_("Please contact us if you need help with anything else.")</a></p>
+      <p class="sansserif larger"><a href="mailto:openlibrary@archive.org?subject=Support%20Case">$_("Please contact us if you need help with anything else.")</a></p>
     </div>
   </div>
 </div>

--- a/openlibrary/templates/lib/nav_foot.html
+++ b/openlibrary/templates/lib/nav_foot.html
@@ -40,7 +40,7 @@ $def with (page)
         <h2>$_("Help")</h2>
         <ul>
           <li><a href="/help">$_("Help Center")</a></li>
-          <li><a href="mailto:openlibrary@archive.org?subject=Support Case" title="$_('Contact')">$_("Contact Us")</a></li>
+          <li><a href="mailto:openlibrary@archive.org?subject=Support%20Case" title="$_('Contact')">$_("Contact Us")</a></li>
           <li><a href="/help/faq/editing" title="$_('Suggest Edits')">$_("Suggesting Edits")</a></li>
           <li><a href="/books/add" title="$_('Add a new book to Open Library')">$_("Add a Book")</a></li>
           <li><a href="https://github.com/internetarchive/openlibrary/releases" title="$_('Release Notes')">$_("Release Notes")</a></li>


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
The space character in our `mailto` links is causing validation errors.  Spaces are illegal characters for `href` values.

**Please close if not needed**

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
