### PR TITLE
Use docker compose extra_hosts to work around ol-home0 issues

### DIFF
--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -17,6 +17,10 @@ services:
     volumes:
       - ../olsystem:/olsystem
       - ../olsystem/etc/ia.ini:/home/openlibrary/.config/ia.ini
+    extra_hosts:
+      # openlibrary.yml needs to reference the service name, to avoid some issues with how we
+      # use hostname, and a cyclical networks request (or something)
+      infobase_nginx: 207.241.234.145  # ol-home0.us.archive.org
 
   fast_web:
     profiles: ["ol-web0", "ol-web1", "ol-web2", "ol-web3"]
@@ -29,6 +33,10 @@ services:
     volumes:
       - ../olsystem:/olsystem
       - ../olsystem/etc/ia.ini:/home/openlibrary/.config/ia.ini
+    extra_hosts:
+      # openlibrary.yml needs to reference the service name, to avoid some issues with how we
+      # use hostname, and a cyclical networks request (or something)
+      infobase_nginx: 207.241.234.145  # ol-home0.us.archive.org
 
   solr:
     # Disabled until next solr reindex due to solr version upgrade
@@ -102,6 +110,10 @@ services:
     volumes:
       - ../olsystem:/olsystem
       - /1:/1
+    extra_hosts:
+      # openlibrary.yml needs to reference the service name, to avoid some issues with how we
+      # use hostname, and a cyclical networks request (or something)
+      infobase_nginx: 207.241.234.145  # ol-home0.us.archive.org
     deploy:
       # Note: the replicas here must be kept in sync with the `upstream covers_backend`
       # value in `docker/covers_nginx.conf`.


### PR DESCRIPTION
Part of #5143

ol-home0 services are unable to make requests to other containers when accessing through the FQDN. This work around allows us to change the openlibrary.yml to use infobase_nginx:7000, which will work for ol-home0 nodes since they are on the same docker network, and we use extra_hosts for non-ol-home0 nodes that need to access infobase.


See https://github.com/internetarchive/olsystem/pull/400

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
