### PR TITLE
fix(docker): guard PIP_INDEX_URL test against set -u nounset

### DIFF
--- a/docker/ol-install-missing-deps.sh
+++ b/docker/ol-install-missing-deps.sh
@@ -21,7 +21,7 @@
 # Don't rely on the host shell having sourced build_env.sh before `docker
 # compose up` — /olsystem is already bind-mounted into the container, so
 # pick up PIP_INDEX_URL directly from there if it wasn't already set.
-if [ -z "$PIP_INDEX_URL" ] && [ -f /olsystem/bin/build_env.sh ]; then
+if [ -z "${PIP_INDEX_URL:-}" ] && [ -f /olsystem/bin/build_env.sh ]; then
   source /olsystem/bin/build_env.sh
 fi
 


### PR DESCRIPTION
## Summary

Follow-up bugfix to #13180.

`docker/ol-web-fastapi-start.sh` runs with `set -euo pipefail`, which propagates into any `source`d script. The guard added in #13180:

```bash
if [ -z "$PIP_INDEX_URL" ] && [ -f /olsystem/bin/build_env.sh ]; then
```

uses a bare `$PIP_INDEX_URL` reference. Under `set -u` (nounset), bash raises `PIP_INDEX_URL: unbound variable` and exits **before** it can source `build_env.sh` to populate the variable — defeating the entire point of the guard.

**Fix:** use `${PIP_INDEX_URL:-}` (default-empty expansion), which is safe under `set -u`.

```bash
# before
if [ -z "$PIP_INDEX_URL" ] && [ -f /olsystem/bin/build_env.sh ]; then

# after
if [ -z "${PIP_INDEX_URL:-}" ] && [ -f /olsystem/bin/build_env.sh ]; then
```

## Reproduces as

```
Python 3.14.5
docker/ol-install-missing-deps.sh: line 24: PIP_INDEX_URL: unbound variable
```

seen on ol-web0 after #13180 landed.

## Testing

- One-character change; behaviour is identical when `PIP_INDEX_URL` is already set.
- When unset and `set -u` is active, the guard now evaluates correctly and sources `build_env.sh` rather than crashing.