### PR TITLE
Add genre reference property to /type/tag schema

### DIFF
--- a/openlibrary/plugins/openlibrary/types/tag.type
+++ b/openlibrary/plugins/openlibrary/types/tag.type
@@ -57,11 +57,11 @@
             "unique": true
         },
         {
-            "expected_type": { 
+            "expected_type": {
                 "key": "/type/tag",
             },
             "name": "genre",
-            "type": { 
+            "type": {
                 "key": "/type/property"
             },
             "unique": false

--- a/openlibrary/plugins/openlibrary/types/tag.type
+++ b/openlibrary/plugins/openlibrary/types/tag.type
@@ -56,6 +56,16 @@
             },
             "unique": true
         },
+        {
+            "expected_type": { 
+                "key": "/type/tag",
+            },
+            "name": "genre",
+            "type": { 
+                "key": "/type/property"
+            },
+            "unique": false
+        },
     ],
     "revision": 3
 }


### PR DESCRIPTION
# Add `genre` reference property to `/type/tag` schema

## This is tracked in [issue #13158](https://github.com/internetarchive/openlibrary/issues/13158) — step 1 of the Genre Explorer phasing plan.

## Summary

Adds a `genre` field to the Tag type definition so subgenre Tags can reference their parent genre Tag. This is the schema-level prerequisite for the Genre Explorer feature, which needs to query the subgenre→genre hierarchy to build its bookshelf UI.

## What changed

**File modified:** `openlibrary/plugins/openlibrary/types/tag.type`

Added a new `genre` property to the Tag type with:
- `expected_type: /type/tag` — it references another Tag object (not a plain string)
- `unique: false` — a subgenre can have multiple parent genres (e.g. Gothic → Horror, Romance, Literary)

## Why this is needed

Our subgenre vocabulary already tracks parent genres as string names (`parent_genres: ["Sci-Fi"]`), but the Tag objects on Open Library have no way to express this relationship. The Genre Explorer needs to query "give me all subgenres that belong to genre X" — which requires a typed reference from each subgenre Tag to its parent genre Tag.

Without this field, the Genre Explorer cannot build the genre→subgenre→books hierarchy that powers its bookshelf UI.

## How it works

1. Each subgenre Tag (e.g. `/tags/OL268T` — Biopunk) will have a `genre` field pointing to its parent genre Tag (e.g. `{"key": "/tags/OL272T"}` — Sci-Fi)
2. The Genre Explorer queries all subgenre Tags whose `genre` field references a given genre Tag
3. This builds the bookshelf: genres are bookcases, subgenres are shelves, books on each shelf ordered by Dewey

## Example

**Before (current Tag object):**
```json
{
  "key": "/tags/OL268T",
  "name": "Biopunk",
  "tag_type": "subgenres",
  "tag_description": "Focuses on biotechnology, genetic engineering..."
}
```

**After (with genre reference):**
```json
{
  "key": "/tags/OL268T",
  "name": "Biopunk",
  "tag_type": "subgenres",
  "tag_description": "Focuses on biotechnology, genetic engineering...",
  "genre": {"key": "/tags/OL272T"}
}
```

## What comes next
Once this is merged, I'll run a backfill script to populate the `genre` field on our 23 existing `subgenre` Tags, using the parent genre mapping from our vocabulary (`parent_genres` field in `tag_types/subgenres/vocabulary.json`).

## Stakeholders
@mekarpeles 