### PR TITLE
Fix issue #13202: Handle URLs with parentheses in markdown links and autolinks

### DIFF
--- a/openlibrary/core/olmarkdown.py
+++ b/openlibrary/core/olmarkdown.py
@@ -150,6 +150,7 @@ class LinkPatternWithBalancedParens(markdown.LinkPattern):
         if len(parts) > 1:
             title = '"' + parts[1].strip()
             from infogami.utils.markdown import markdown as md_module
+
             if hasattr(md_module, "dequote"):
                 title = md_module.dequote(title)
             el.setAttribute("title", title)
@@ -161,19 +162,19 @@ class LinkPatternWithBalancedParens(markdown.LinkPattern):
         # Count opening and closing parens in the URL
         open_parens = url.count("(")
         close_parens = url.count(")")
-        
+
         if open_parens <= close_parens:
             return url
-        
+
         # Need to add closing parens from the full text
         # Find where the URL ends in the full text
         url_end_idx = full_text.find(url) + len(url)
         remaining_text = full_text[url_end_idx:]
-        
+
         # Add closing parens while we need them and they're available
         needed_close = open_parens - close_parens
         extended_url = url
-        
+
         for char in remaining_text:
             if char == ")" and needed_close > 0:
                 extended_url += char
@@ -181,7 +182,7 @@ class LinkPatternWithBalancedParens(markdown.LinkPattern):
             elif char not in "\"' \t\n":
                 # Stop if we hit a non-paren, non-quote, non-space character
                 break
-        
+
         return extended_url
 
 
@@ -206,19 +207,19 @@ class OLMarkdown(markdown.Markdown):
     def _patch(self):
         patterns = self.inlinePatterns
         autolink = markdown.AutolinkPattern(markdown.AUTOLINK_RE.replace("http", "https?"))
-        
+
         # Replace AUTOLINK_PATTERN
         for i, pattern in enumerate(patterns):
             if pattern.__class__.__name__ == "AutolinkPattern":
                 patterns[i] = autolink
                 break
-        
+
         # Replace ALL LinkPattern instances with our custom one
         link_pattern_instance = LinkPatternWithBalancedParens(markdown.LINK_RE)
         for i, pattern in enumerate(patterns):
             if pattern.__class__.__name__ == "LinkPattern":
                 patterns[i] = link_pattern_instance
-        
+
         p = self.preprocessors
         p.insert(0, FENCED_CODE_PREPROCESSOR)
         p[p.index(markdown.LINE_BREAKS_PREPROCESSOR)] = LINE_BREAKS_PREPROCESSOR

--- a/openlibrary/core/olmarkdown.py
+++ b/openlibrary/core/olmarkdown.py
@@ -17,7 +17,9 @@ from openlibrary.core import helpers as h
 # regexp to match urls and emails.
 # Adopted from github-flavored-markdown (BSD-style open source license)
 # http://github.com/github/github-flavored-markdown/blob/gh-pages/scripts/showdown.js#L158
-AUTOLINK_RE = r"""(^|\s)(https?\:\/\/[^"\s<>]*[^.,;'">\:\s\<\>\)\]\!]|[a-z0-9_\-+=.]+@[a-z0-9\-]+(?:\.[a-z0-9-]+)+)"""
+# Modified to allow closing parentheses in URLs (for Wikipedia links, etc.)
+# Removed ) from the exclusion set at the end
+AUTOLINK_RE = r"""(^|\s)(https?\:\/\/[^"\s<>]*[^.,;'">\:\s\<\>\]\!]|[a-z0-9_\-+=.]+@[a-z0-9\-]+(?:\.[a-z0-9-]+)+)"""
 
 LINK_REFERENCE_RE = re.compile(r" *\[[^\[\] ]*\] *:")
 
@@ -108,6 +110,84 @@ class AutolinkPreprocessor(markdown.Preprocessor):
 AUTOLINK_PREPROCESSOR = AutolinkPreprocessor()
 
 
+class LinkPatternWithBalancedParens(markdown.LinkPattern):
+    r"""Custom LinkPattern that handles balanced parentheses in URLs.
+
+    The default markdown LINK_RE pattern uses [^\)]* to match URL content,
+    which stops at the first closing paren. This breaks URLs like:
+    https://en.wikipedia.org/wiki/Name_(descriptor)
+
+    We use a more flexible regex and post-process in handleMatch to find
+    balanced parentheses.
+    """
+
+    def __init__(self, original_link_re):
+        # Replace \(([^\)]*)\) with \(([^'\"]*)\) - greedy match
+        # This allows most URLs to match correctly
+        new_pattern = original_link_re.replace(r"\(([^\)]*)\)", r"\(([^'\"]*)\)")
+        super().__init__(new_pattern)
+
+    def handleMatch(self, m, doc):
+        """Override to handle balanced parentheses in URL."""
+        el = doc.createElement("a")
+        el.appendChild(doc.createTextNode(m.group(2)))
+
+        url_and_title = m.group(9)
+        if not url_and_title:
+            el.setAttribute("href", "")
+            return el
+
+        # Split on quote if there's a title
+        parts = url_and_title.split('"', 1)
+        url = parts[0].strip()
+
+        # Fix the URL by extending it to include balanced parentheses
+        # that the non-greedy regex may have cut off
+        url_fixed = self._extend_balanced_url(url, url_and_title)
+
+        el.setAttribute("href", url_fixed)
+
+        if len(parts) > 1:
+            title = '"' + parts[1].strip()
+            from infogami.utils.markdown import markdown as md_module
+            if hasattr(md_module, "dequote"):
+                title = md_module.dequote(title)
+            el.setAttribute("title", title)
+
+        return el
+
+    def _extend_balanced_url(self, url, full_text):
+        """Extend URL to include balanced closing parens."""
+        # Count opening and closing parens in the URL
+        open_parens = url.count("(")
+        close_parens = url.count(")")
+        
+        if open_parens <= close_parens:
+            return url
+        
+        # Need to add closing parens from the full text
+        # Find where the URL ends in the full text
+        url_end_idx = full_text.find(url) + len(url)
+        remaining_text = full_text[url_end_idx:]
+        
+        # Add closing parens while we need them and they're available
+        needed_close = open_parens - close_parens
+        extended_url = url
+        
+        for char in remaining_text:
+            if char == ")" and needed_close > 0:
+                extended_url += char
+                needed_close -= 1
+            elif char not in "\"' \t\n":
+                # Stop if we hit a non-paren, non-quote, non-space character
+                break
+        
+        return extended_url
+
+
+LINK_PATTERN_WITH_BALANCED_PARENS = LinkPatternWithBalancedParens(markdown.LINK_RE)
+
+
 class OLMarkdown(markdown.Markdown):
     """Open Library flavored Markdown, inspired by [Github Flavored Markdown][GFM].
 
@@ -126,7 +206,19 @@ class OLMarkdown(markdown.Markdown):
     def _patch(self):
         patterns = self.inlinePatterns
         autolink = markdown.AutolinkPattern(markdown.AUTOLINK_RE.replace("http", "https?"))
-        patterns[patterns.index(markdown.AUTOLINK_PATTERN)] = autolink
+        
+        # Replace AUTOLINK_PATTERN
+        for i, pattern in enumerate(patterns):
+            if pattern.__class__.__name__ == "AutolinkPattern":
+                patterns[i] = autolink
+                break
+        
+        # Replace ALL LinkPattern instances with our custom one
+        link_pattern_instance = LinkPatternWithBalancedParens(markdown.LINK_RE)
+        for i, pattern in enumerate(patterns):
+            if pattern.__class__.__name__ == "LinkPattern":
+                patterns[i] = link_pattern_instance
+        
         p = self.preprocessors
         p.insert(0, FENCED_CODE_PREPROCESSOR)
         p[p.index(markdown.LINE_BREAKS_PREPROCESSOR)] = LINE_BREAKS_PREPROCESSOR

--- a/openlibrary/tests/core/test_olmarkdown.py
+++ b/openlibrary/tests/core/test_olmarkdown.py
@@ -159,3 +159,37 @@ def test_olmarkdown_fenced_code():
     # The broken render-shape from the bug report must not appear.
     assert "`<br" not in out
     assert "`\n" not in out
+
+
+def test_olmarkdown_urls_with_parentheses():
+    """Test that URLs with parentheses are properly handled.
+    
+    Issue #13202: Links to URLs with parentheses weren't being rendered correctly.
+    URLs with parentheses are common, especially on Wikipedia and similar sites.
+    """
+    def md(text):
+        return OLMarkdown(text).convert().strip()
+
+    def p(html):
+        # markdown always wraps the result in <p>.
+        return "<p>%s\n</p>" % html
+
+    # Test 1: Link with parentheses in URL
+    result = md("[George A. Kennedy](https://en.wikipedia.org/wiki/George_A._Kennedy_(sinologist))")
+    assert '<a href="https://en.wikipedia.org/wiki/George_A._Kennedy_(sinologist)"' in result
+    assert "rel=\"nofollow\"" in result
+    # Should render as a link, not raw markdown
+    assert "[George A. Kennedy]" not in result
+
+    # Test 2: Plain autolink with parentheses in URL
+    result = md("https://en.wikipedia.org/wiki/George_A._Kennedy_(sinologist)")
+    assert '<a href="https://en.wikipedia.org/wiki/George_A._Kennedy_(sinologist)"' in result
+    assert "rel=\"nofollow\"" in result
+
+    # Test 3: Multiple parentheses in URL
+    result = md("https://example.com/path(first)(second)")
+    assert '<a href="https://example.com/path(first)(second)"' in result
+
+    # Test 4: Nested parentheses in URL
+    result = md("https://example.com/path(with(nested)parens)")
+    assert '<a href="https://example.com/path(with(nested)parens)"' in result

--- a/openlibrary/tests/core/test_olmarkdown.py
+++ b/openlibrary/tests/core/test_olmarkdown.py
@@ -163,10 +163,11 @@ def test_olmarkdown_fenced_code():
 
 def test_olmarkdown_urls_with_parentheses():
     """Test that URLs with parentheses are properly handled.
-    
+
     Issue #13202: Links to URLs with parentheses weren't being rendered correctly.
     URLs with parentheses are common, especially on Wikipedia and similar sites.
     """
+
     def md(text):
         return OLMarkdown(text).convert().strip()
 
@@ -177,14 +178,14 @@ def test_olmarkdown_urls_with_parentheses():
     # Test 1: Link with parentheses in URL
     result = md("[George A. Kennedy](https://en.wikipedia.org/wiki/George_A._Kennedy_(sinologist))")
     assert '<a href="https://en.wikipedia.org/wiki/George_A._Kennedy_(sinologist)"' in result
-    assert "rel=\"nofollow\"" in result
+    assert 'rel="nofollow"' in result
     # Should render as a link, not raw markdown
     assert "[George A. Kennedy]" not in result
 
     # Test 2: Plain autolink with parentheses in URL
     result = md("https://en.wikipedia.org/wiki/George_A._Kennedy_(sinologist)")
     assert '<a href="https://en.wikipedia.org/wiki/George_A._Kennedy_(sinologist)"' in result
-    assert "rel=\"nofollow\"" in result
+    assert 'rel="nofollow"' in result
 
     # Test 3: Multiple parentheses in URL
     result = md("https://example.com/path(first)(second)")


### PR DESCRIPTION
## Problem

When URLs contain unescaped parentheses (common in Wikipedia and other sites), the markdown parser was incorrectly truncating them at the first closing parenthesis. This caused links like `https://en.wikipedia.org/wiki/Name_(descriptor)` to not render correctly.

### Example of the bug:
- Input: `[George A. Kennedy](https://en.wikipedia.org/wiki/George_A._Kennedy_(sinologist))`
- Expected: A clickable link to the Wikipedia URL
- Actual: Raw markdown displayed because the URL was truncated to `..._(sinologist` (missing final `)`), breaking the markdown link syntax

## Root Cause

The markdown link regex pattern `LINK_RE` used `\(([^\)]*)\)` to match URLs, which stops matching at the first `)`. Similarly, the autolink pattern `AUTOLINK_RE` explicitly excluded `)` from valid URL characters.

## Solution

1. **For markdown links** (`[text](url)`): Modified `LinkPatternWithBalancedParens` to use a greedy character class `[^'\"]*` instead of `[^\)]*`, allowing the regex to match through closing parentheses while still stopping at title quotes or delimiters.

2. **For autolinks** (`plain url`): Updated `AUTOLINK_RE` to remove `)` from the exclusion character set at the end of the URL pattern, allowing URLs to end with closing parentheses.

## Changes

- `openlibrary/core/olmarkdown.py`:
  - Created `LinkPatternWithBalancedParens` class to handle balanced parentheses in markdown links
  - Updated `AUTOLINK_RE` pattern to accept parentheses
  - Updated `_patch()` method to use custom LinkPattern for all LinkPattern instances

- `openlibrary/tests/core/test_olmarkdown.py`:
  - Added comprehensive tests for URLs with single, multiple, and nested parentheses

## Testing

All existing markdown tests pass, plus new tests verify:
- ✅ Markdown links with parentheses in URLs
- ✅ Plain autolinks with parentheses
- ✅ Multiple parentheses pairs in URLs
- ✅ Nested parentheses in URLs

Examples now rendering correctly:
- `[George A. Kennedy](https://en.wikipedia.org/wiki/George_A._Kennedy_(sinologist))` → clickable link
- `https://en.wikipedia.org/wiki/George_A._Kennedy_(sinologist)` → auto-linked

Fixes #13202