### PR TITLE
Feed Registry & Acquisitions integration prototype (#12844)

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -183,8 +183,47 @@ services:
       timeout: 3s
       retries: 5
 
+  # --- BookWorm staging pipeline (#12655 / #12844) ---
+  # Isolated staging DB so bulk feed harvesting never contends with the
+  # production Open Library database.
+  staging-db:
+    image: postgres:${POSTGRES_VERSION:-18.3}
+    networks:
+      - dbnet
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
+    volumes:
+      # schema.sql runs on first init (staged_record + bookworm import queue)
+      - ./docker/staging-db/schema.sql:/docker-entrypoint-initdb.d/staging-schema.sql
+      - staging-postgres:/var/lib/postgresql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 30s
+      start_interval: 1s
+      start_period: 20s
+      timeout: 1s
+      retries: 24
+
+  # Dedicated service that owns the harvest cron: harvest feeds into staging,
+  # then promote into the import queue. Point its db at staging-db.
+  bookworm:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.oldev
+    command: python scripts/bookworm.py conf/openlibrary.yml --interval 3600
+    networks:
+      - dbnet
+      - webnet
+    depends_on:
+      staging-db:
+        condition: service_healthy
+    volumes:
+      - ol-vendor:/openlibrary/vendor
+      - ${OL_MOUNT_DIR:-.}:/openlibrary
+
 volumes:
   ol-vendor:
   ol-build:
   ol-nodemodules:
   ol-postgres:
+  staging-postgres:

--- a/docker/mockservices/main.py
+++ b/docker/mockservices/main.py
@@ -386,6 +386,79 @@ async def amazon_get_items(request: Request) -> JSONResponse:
 
 
 # ---------------------------------------------------------------------------
+# Better World Books OPDS 2.0 feed  (synthetic — for #12844 feed-registry /
+# acquisitions ingestion tests). Lets scripts/bwb_opds_imports.py run
+# end-to-end against a deterministic feed instead of the live BWB endpoint.
+# Point the importer at it with:
+#   python scripts/bwb_opds_imports.py <conf> \
+#       --feed-url http://mockservices:8090/services/bwb/opds
+# ---------------------------------------------------------------------------
+
+_BWB_OPDS_PUBLICATION_TEMPLATE = {
+    "9781737408802": {
+        "title": "The Brick House Apparent Quarterly, Vol. 1",
+        "authors": ["The Brick House Cooperative", "Maria Bustillos"],
+        "published": "2021-08-03",
+        "modified": "2026-06-16T10:59:50.140040-04:00",
+        "price": 1.25,
+    },
+    "9798995425007": {
+        "title": "Vanishing Culture: A Report on Our Fragile Cultural Record",
+        "authors": ["Chris Freeland", "Luca Messarra"],
+        "published": "2026-01-01",
+        "modified": "2026-06-16T13:02:54.457688-04:00",
+        "price": 1.01,
+    },
+}
+
+
+def _bwb_opds_publication(isbn_13: str, info: dict) -> dict:
+    base = "https://www.betterworldbooks.com"
+    return {
+        "metadata": {
+            "type": "http://schema.org/Book",
+            "title": info["title"],
+            "identifier": f"urn:isbn:{isbn_13}",
+            "author": [{"name": name} for name in info["authors"]],
+            "language": ["en"],
+            "published": info["published"],
+            "modified": info["modified"],
+        },
+        "links": [
+            {"rel": "self", "href": f"{base}/opds/publication/{isbn_13}", "type": "application/opds-publication+json"},
+            {
+                "rel": "http://opds-spec.org/acquisition/buy",
+                "href": f"{base}/purchase/{isbn_13}",
+                "type": "text/html",
+                "properties": {
+                    "indirectAcquisition": [{"type": "application/epub+zip"}],
+                    "price": {"currency": "USD", "value": info["price"]},
+                },
+            },
+        ],
+        "images": [{"href": f"{base}/covers/{isbn_13}.jpg", "type": "image/jpeg", "rel": "cover"}],
+    }
+
+
+@app.get("/services/bwb/opds")
+async def bwb_opds_feed() -> JSONResponse:
+    """Synthetic Better World Books OPDS 2.0 feed (single page, no ``next``)."""
+    publications = [_bwb_opds_publication(isbn, info) for isbn, info in _BWB_OPDS_PUBLICATION_TEMPLATE.items()]
+    return JSONResponse(
+        {
+            "metadata": {
+                "title": "Better World Books",
+                "numberOfItems": len(publications),
+                "itemsPerPage": 50,
+                "currentPage": 1,
+            },
+            "links": [{"rel": "self", "href": "http://mockservices:8090/services/bwb/opds", "type": "application/opds+json"}],
+            "publications": publications,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
 # Health check
 # ---------------------------------------------------------------------------
 

--- a/docker/mockservices/tests/test_e2e.py
+++ b/docker/mockservices/tests/test_e2e.py
@@ -198,3 +198,27 @@ class TestLoanChangesFeed:
     def test_missing_action_returns_422(self):
         resp = _get("/services/loans/loan/")
         assert resp.status_code == 422
+
+
+class TestBwbOpdsFeed:
+    """Synthetic BWB OPDS feed for #12844 feed-registry/acquisitions tests."""
+
+    def test_feed_shape(self):
+        resp = _get("/services/bwb/opds")
+        assert resp.status_code == 200
+        feed = resp.json()
+        assert feed["metadata"]["title"] == "Better World Books"
+        isbns = {p["metadata"]["identifier"] for p in feed["publications"]}
+        assert isbns == {"urn:isbn:9781737408802", "urn:isbn:9798995425007"}
+
+    def test_publications_carry_buy_price(self):
+        feed = _get("/services/bwb/opds").json()
+        for pub in feed["publications"]:
+            buy = next(link for link in pub["links"] if link["rel"] == "http://opds-spec.org/acquisition/buy")
+            assert buy["properties"]["price"]["currency"] == "USD"
+            assert buy["properties"]["price"]["value"] > 0
+
+    def test_feed_is_single_page(self):
+        # No `next` link -> a crawl terminates (deterministic for idempotency runs).
+        feed = _get("/services/bwb/opds").json()
+        assert not any(link.get("rel") == "next" for link in feed["links"])

--- a/docker/staging-db/schema.sql
+++ b/docker/staging-db/schema.sql
@@ -1,0 +1,57 @@
+-- Schema for the isolated BookWorm staging database (#12655 / #12844).
+--
+-- This DB is separate from production Open Library so bulk feed harvesting
+-- never contends with the live catalog. The bookworm service points its DB
+-- connection here.
+--
+-- Contents:
+--   * tbp_staged_record — raw normalized feed records (+ acquisition metadata)
+--     awaiting promotion into the catalog.
+--   * import_batch / import_item — the bookworm-side import queue; manage-imports
+--     drains BOTH these and the legacy main-schema tables (dual-source).
+
+CREATE TABLE tbp_staged_record (
+    id serial primary key,
+    provider_name text not null,
+    local_id text not null,
+    -- the normalized import record (the "olbook")
+    record jsonb not null,
+    -- provider acquisition metadata (price/formats/url); travels with the
+    -- record so the post-import step can attach it once the edition exists.
+    acquisition jsonb default null,
+    status text not null default 'staged',  -- staged | promoted | failed
+    created timestamp without time zone default (current_timestamp at time zone 'utc'),
+    updated timestamp without time zone default (current_timestamp at time zone 'utc'),
+    UNIQUE (provider_name, local_id)
+);
+
+CREATE INDEX tbp_staged_record_status_idx ON tbp_staged_record (status);
+
+-- Bookworm-side import queue (mirrors the main-schema import tables so
+-- manage-imports can drain both).
+CREATE TABLE import_batch (
+    id serial primary key,
+    name text,
+    submitter text,
+    submit_time timestamp without time zone default (current_timestamp at time zone 'utc')
+);
+
+CREATE INDEX import_batch_name ON import_batch (name);
+
+CREATE TABLE import_item (
+    id serial primary key,
+    batch_id integer references import_batch,
+    added_time timestamp without time zone default (current_timestamp at time zone 'utc'),
+    import_time timestamp without time zone,
+    status text default 'pending',
+    error text,
+    ia_id text,
+    data text,
+    ol_key text,
+    comments text,
+    submitter text,
+    UNIQUE (batch_id, ia_id)
+);
+
+CREATE INDEX import_item_ia_id ON import_item (ia_id);
+CREATE INDEX import_item_status ON import_item (status);

--- a/openlibrary/catalog/opds2.py
+++ b/openlibrary/catalog/opds2.py
@@ -1,0 +1,264 @@
+"""Generic Open Library adapter for OPDS 2.0 feeds.
+
+Parses an OPDS 2.0 JSON feed (publications with metadata + acquisition links)
+into Open Library import records and provider acquisition metadata. One adapter
+serves ANY OPDS 2.0 feed registered in the Trusted Book Provider feed registry;
+per-source quirks (import source-id prefix, quality filters) are supplied via a
+small :class:`Source` config rather than a bespoke per-feed script.
+
+This is the OPDS **2.0 / JSON** path. ``openlibrary/plugins/importapi/import_opds.py``
+is the separate OPDS **1.x / Atom-XML** parser used by the import API.
+
+See https://github.com/internetarchive/openlibrary/issues/12844.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+import time
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from typing import Any
+
+import requests
+
+from openlibrary.plugins.upstream.utils import get_marc21_language
+from openlibrary.utils.isbn import to_isbn_13
+
+logger = logging.getLogger("openlibrary.catalog.opds2")
+
+ACQUISITION_REL = "http://opds-spec.org/acquisition/buy"
+ISBN_URN_PREFIX = "urn:isbn:"
+EPOCH = datetime.datetime(1970, 1, 1, tzinfo=datetime.UTC)
+REQUEST_TIMEOUT = 60
+PAGE_SLEEP_SECONDS = 1.0
+
+
+@dataclass(frozen=True)
+class Source:
+    """Per-feed configuration that specializes the generic OPDS 2.0 adapter.
+
+    :param provider_name: acquisitions/registry provider key (e.g. ``"betterworldbooks"``).
+    :param source_id_prefix: import ``source_records`` slug prefix — ``"bwb"`` yields
+        ``"bwb:{isbn_13}"``, reusing the source's existing import identity.
+    :param record_filter: optional predicate returning ``True`` to EXCLUDE a mapped
+        record (e.g. partner quality filters). ``None`` keeps everything.
+    """
+
+    provider_name: str
+    source_id_prefix: str
+    record_filter: Callable[[dict[str, Any]], bool] | None = None
+
+
+def parse_iso(value: str) -> datetime.datetime:
+    """Parse an ISO 8601 timestamp, normalising to a tz-aware UTC datetime.
+
+    Feeds emit high-precision offsets like ``2026-05-19T14:47:58.5476301-04:00``
+    which ``datetime.fromisoformat`` accepts on Python 3.11+.
+    """
+    dt = datetime.datetime.fromisoformat(value)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=datetime.UTC)
+    return dt.astimezone(datetime.UTC)
+
+
+def extract_isbn(metadata: dict[str, Any]) -> str | None:
+    """Return the ISBN-13 from an OPDS ``metadata.identifier`` URN, or None."""
+    identifier = metadata.get("identifier") or ""
+    if not identifier.startswith(ISBN_URN_PREFIX):
+        return None
+    return to_isbn_13(identifier[len(ISBN_URN_PREFIX) :])
+
+
+def extract_price(publication: dict[str, Any]) -> dict[str, Any] | None:
+    """Return ``{currency, value}`` from the first buy-acquisition link, or None."""
+    for link in publication.get("links", []) or []:
+        if link.get("rel") != ACQUISITION_REL:
+            continue
+        properties = link.get("properties") or {}
+        price = properties.get("price") or {}
+        if price.get("value") is not None and price.get("currency"):
+            return {"currency": price["currency"], "value": price["value"]}
+    return None
+
+
+def build_acquisition_data(publication: dict[str, Any]) -> dict[str, Any]:
+    """Extract provider acquisition metadata (price, buy url, formats).
+
+    Stored verbatim in the ``acquisitions.data`` blob for a resolved edition so
+    downstream indexing can search by price/format (issues #12844, #11264).
+    """
+    data: dict[str, Any] = {}
+    if price := extract_price(publication):
+        data["price"] = price
+    for link in publication.get("links", []) or []:
+        if link.get("rel") != ACQUISITION_REL:
+            continue
+        if href := link.get("href"):
+            data["url"] = href
+        properties = link.get("properties") or {}
+        formats = [fmt["type"] for fmt in (properties.get("indirectAcquisition") or []) if fmt.get("type")]
+        if formats:
+            data["formats"] = formats
+        break
+    return data
+
+
+def extract_cover(publication: dict[str, Any]) -> str | None:
+    for image in publication.get("images", []) or []:
+        if image.get("rel") == "cover" and image.get("href"):
+            return image["href"]
+    return None
+
+
+def publication_id(publication: dict[str, Any]) -> str:
+    """Return the publication's ``self`` link or raw identifier, for logging."""
+    for link in publication.get("links", []) or []:
+        if link.get("rel") == "self" and link.get("href"):
+            return link["href"]
+    return (publication.get("metadata") or {}).get("identifier") or "<unknown>"
+
+
+def map_publication_to_olbook(publication: dict[str, Any], source: Source) -> dict[str, Any] | None:
+    """Convert an OPDS publication to an OL import record for ``source``.
+
+    Returns None when the publication lacks ISBN-13, title, or authors — the
+    import API requires all three. ``source_records`` uses the source's slug
+    prefix (e.g. ``bwb:{isbn}``) so records reuse the source's import identity.
+    """
+    metadata = publication.get("metadata") or {}
+    isbn_13 = extract_isbn(metadata)
+    if not isbn_13:
+        logger.warning("Skipping publication with no usable ISBN: %s", publication_id(publication))
+        return None
+
+    title = metadata.get("title")
+    authors = [{"name": a["name"]} for a in (metadata.get("author") or []) if a.get("name")]
+    if not title or not authors:
+        logger.warning("Skipping publication missing title/authors: %s", publication_id(publication))
+        return None
+
+    languages = [marc for code in (metadata.get("language") or []) if code and (marc := get_marc21_language(code))]
+
+    olbook: dict[str, Any] = {
+        "title": title,
+        "isbn_13": [isbn_13],
+        "source_records": [f"{source.source_id_prefix}:{isbn_13}"],
+        "authors": authors,
+        "languages": languages,
+        "publish_date": metadata.get("published", ""),
+        "publishers": [],  # OPDS feed does not include publisher
+    }
+    if cover := extract_cover(publication):
+        olbook["cover"] = cover
+    return olbook
+
+
+def excluded(olbook: dict[str, Any], source: Source) -> bool:
+    """Apply the source's quality filter (if any); True means drop the record."""
+    if not source.record_filter or not olbook.get("title"):
+        return False
+    try:
+        return bool(source.record_filter(olbook))
+    except (KeyError, ValueError, TypeError) as e:
+        logger.warning("record_filter failed for %s: %s", olbook.get("isbn_13"), e)
+        return False
+
+
+def find_next_url(feed: dict[str, Any]) -> str | None:
+    for link in feed.get("links", []) or []:
+        if link.get("rel") == "next" and link.get("href"):
+            return link["href"]
+    return None
+
+
+def iter_pages(start_url: str, session: requests.Session, max_pages: int | None = None) -> Iterator[dict[str, Any]]:
+    """Yield successive OPDS feed pages, following ``rel=next`` links."""
+    url: str | None = start_url
+    seen: set[str] = set()
+    page_num = 0
+    while url:
+        if url in seen:
+            logger.warning("Cycle detected in OPDS pagination at %s; stopping.", url)
+            return
+        seen.add(url)
+        page_num += 1
+        if max_pages is not None and page_num > max_pages:
+            logger.info("Reached max_pages=%s; stopping pagination.", max_pages)
+            return
+        logger.info("Fetching OPDS page %d: %s", page_num, url)
+        resp = session.get(url, timeout=REQUEST_TIMEOUT, headers={"Accept": "application/opds+json"})
+        resp.raise_for_status()
+        feed = resp.json()
+        yield feed
+        url = find_next_url(feed)
+        if url and PAGE_SLEEP_SECONDS:
+            time.sleep(PAGE_SLEEP_SECONDS)
+
+
+def process_feed(
+    feed_url: str,
+    since: datetime.datetime,
+    prices_out_fh,
+    source: Source,
+    max_pages: int | None = None,
+    early_stop: bool = False,
+    acquisitions_out: list[tuple[str, dict[str, Any]]] | None = None,
+) -> tuple[list[dict[str, Any]], datetime.datetime]:
+    """Crawl the OPDS feed and return ``(olbooks, max_modified_seen)``.
+
+    Records are filtered to those with ``metadata.modified > since``. Price rows
+    are written to ``prices_out_fh``; acquisition ``(isbn_13, data)`` pairs are
+    appended to ``acquisitions_out`` when provided. The cursor advances on every
+    publication newer than ``since`` even when mapping fails, so an unmappable
+    but newer record never forces every future run to re-scan it.
+
+    ``source.record_filter`` drops low-quality/out-of-scope records the same way
+    the source's legacy importer does.
+
+    ``early_stop`` (off by default): halt pagination once a whole page contains
+    nothing newer than ``since``. OPDS does not mandate sort-by-modified, so
+    leave off until a feed's ordering is confirmed, else an out-of-order stale
+    page would skip fresh records on later pages.
+    """
+    session = requests.Session()
+    olbooks: list[dict[str, Any]] = []
+    max_modified = since
+
+    for feed in iter_pages(feed_url, session, max_pages=max_pages):
+        fresh_in_page = 0
+        for publication in feed.get("publications", []) or []:
+            metadata = publication.get("metadata") or {}
+            modified_raw = metadata.get("modified")
+            if not modified_raw:
+                continue
+            try:
+                modified = parse_iso(modified_raw)
+            except ValueError:
+                logger.warning("Skipping publication with unparsable modified=%r", modified_raw)
+                continue
+            if modified <= since:
+                continue
+            fresh_in_page += 1
+            max_modified = max(max_modified, modified)
+
+            olbook = map_publication_to_olbook(publication, source)
+            if not olbook:
+                continue
+            if excluded(olbook, source):
+                continue
+            olbooks.append(olbook)
+
+            if acquisitions_out is not None and (acq_data := build_acquisition_data(publication)):
+                acquisitions_out.append((olbook["isbn_13"][0], acq_data))
+
+            if price := extract_price(publication):
+                prices_out_fh.write(json.dumps({"isbn_13": olbook["isbn_13"][0], "price": price["value"], "currency": price["currency"]}) + "\n")
+
+        if early_stop and fresh_in_page == 0:
+            logger.info("Page contains no records newer than %s; stopping (feed is modified-desc).", since.isoformat())
+            break
+
+    return olbooks, max_modified

--- a/openlibrary/catalog/tests/test_opds2.py
+++ b/openlibrary/catalog/tests/test_opds2.py
@@ -1,0 +1,206 @@
+import datetime
+import io
+
+from openlibrary.catalog import opds2
+from openlibrary.catalog.opds2 import (
+    EPOCH,
+    Source,
+    build_acquisition_data,
+    extract_cover,
+    extract_isbn,
+    extract_price,
+    find_next_url,
+    iter_pages,
+    map_publication_to_olbook,
+    parse_iso,
+    process_feed,
+)
+
+# A generic test source (no real provider); the BWB specifics live in the caller.
+TEST_SOURCE = Source(provider_name="testprovider", source_id_prefix="test")
+
+SAMPLE_PUBLICATION = {
+    "metadata": {
+        "type": "http://schema.org/Book",
+        "title": "The Brick House Apparent Quarterly, Vol. 1",
+        "identifier": "urn:isbn:9781737408802",
+        "author": [{"name": "The Brick House Cooperative"}, {"name": "Maria Bustillos"}],
+        "language": ["en"],
+        "published": "2021-08-03",
+        "modified": "2026-05-19T14:47:58.547630-04:00",
+    },
+    "links": [
+        {"rel": "self", "href": "https://example.org/opds/publication/9781737408802"},
+        {
+            "rel": "http://opds-spec.org/acquisition/buy",
+            "href": "https://example.org/purchase/9781737408802",
+            "properties": {
+                "indirectAcquisition": [{"type": "application/epub+zip"}],
+                "price": {"currency": "USD", "value": 1.1},
+            },
+        },
+    ],
+    "images": [{"href": "https://example.com/cover.jpg", "rel": "cover"}],
+}
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        pass
+
+
+class FakeSession:
+    def __init__(self, pages_by_url):
+        self.pages_by_url = pages_by_url
+        self.calls = []
+
+    def get(self, url, **kwargs):
+        self.calls.append(url)
+        return FakeResponse(self.pages_by_url[url])
+
+
+def test_extract_isbn():
+    assert extract_isbn({"identifier": "urn:isbn:9781737408802"}) == "9781737408802"
+    assert extract_isbn({"identifier": "urn:uuid:abc"}) is None
+    assert extract_isbn({}) is None
+    # ISBN-10 is promoted to 13.
+    assert extract_isbn({"identifier": "urn:isbn:0140328726"}) == "9780140328721"
+
+
+def test_extract_price():
+    assert extract_price(SAMPLE_PUBLICATION) == {"currency": "USD", "value": 1.1}
+    assert extract_price({"links": [{"rel": "self", "href": "x"}]}) is None
+    assert extract_price({}) is None
+    missing = {"links": [{"rel": "http://opds-spec.org/acquisition/buy", "href": "x"}]}
+    assert extract_price(missing) is None
+
+
+def test_extract_cover():
+    assert extract_cover(SAMPLE_PUBLICATION) == "https://example.com/cover.jpg"
+    assert extract_cover({"images": [{"href": "x", "rel": "thumbnail"}]}) is None
+    assert extract_cover({}) is None
+
+
+def test_build_acquisition_data():
+    data = build_acquisition_data(SAMPLE_PUBLICATION)
+    assert data["price"] == {"currency": "USD", "value": 1.1}
+    assert data["url"] == "https://example.org/purchase/9781737408802"
+    assert data["formats"] == ["application/epub+zip"]
+
+
+def test_map_publication_uses_source_prefix():
+    olbook = map_publication_to_olbook(SAMPLE_PUBLICATION, TEST_SOURCE)
+    assert olbook is not None
+    assert olbook["isbn_13"] == ["9781737408802"]
+    # source_records slug comes from the Source, not hard-coded.
+    assert olbook["source_records"] == ["test:9781737408802"]
+    assert olbook["languages"] == ["eng"]
+    assert olbook["cover"] == "https://example.com/cover.jpg"
+
+
+def test_map_publication_slug_is_per_source():
+    bwbish = Source(provider_name="betterworldbooks", source_id_prefix="bwb")
+    olbook = map_publication_to_olbook(SAMPLE_PUBLICATION, bwbish)
+    assert olbook["source_records"] == ["bwb:9781737408802"]
+
+
+def test_map_publication_skips_incomplete():
+    assert map_publication_to_olbook({"metadata": {"title": "No ISBN", "author": [{"name": "x"}]}}, TEST_SOURCE) is None
+    no_title = {"metadata": {"identifier": "urn:isbn:9781737408802", "author": [{"name": "x"}]}}
+    no_authors = {"metadata": {"identifier": "urn:isbn:9781737408802", "title": "x"}}
+    assert map_publication_to_olbook(no_title, TEST_SOURCE) is None
+    assert map_publication_to_olbook(no_authors, TEST_SOURCE) is None
+
+
+def test_parse_iso_handles_offset_and_naive():
+    dt = parse_iso("2026-05-19T14:47:58.547630-04:00")
+    assert dt == datetime.datetime(2026, 5, 19, 18, 47, 58, 547630, tzinfo=datetime.UTC)
+    assert parse_iso("2026-05-19T14:47:58").tzinfo is datetime.UTC
+
+
+def test_find_next_url():
+    assert find_next_url({"links": [{"rel": "next", "href": "https://x/p2"}]}) == "https://x/p2"
+    assert find_next_url({"links": [{"rel": "self", "href": "x"}]}) is None
+    assert find_next_url({}) is None
+
+
+def test_iter_pages_follows_next_and_breaks_on_cycle(monkeypatch):
+    monkeypatch.setattr(opds2, "PAGE_SLEEP_SECONDS", 0)
+    pages = {
+        "https://x/p1": {"publications": [{"id": 1}], "links": [{"rel": "next", "href": "https://x/p2"}]},
+        "https://x/p2": {"publications": [{"id": 2}], "links": [{"rel": "next", "href": "https://x/p1"}]},
+    }
+    session = FakeSession(pages)
+    fetched = list(iter_pages("https://x/p1", session))
+    assert [f["publications"][0]["id"] for f in fetched] == [1, 2]
+    assert session.calls == ["https://x/p1", "https://x/p2"]
+
+
+def test_iter_pages_respects_max_pages(monkeypatch):
+    monkeypatch.setattr(opds2, "PAGE_SLEEP_SECONDS", 0)
+    pages = {
+        "https://x/p1": {"publications": [], "links": [{"rel": "next", "href": "https://x/p2"}]},
+        "https://x/p2": {"publications": [], "links": [{"rel": "next", "href": "https://x/p3"}]},
+        "https://x/p3": {"publications": [], "links": []},
+    }
+    assert len(list(iter_pages("https://x/p1", FakeSession(pages), max_pages=2))) == 2
+
+
+def _run(monkeypatch, pages, since, source=TEST_SOURCE, **kwargs):
+    monkeypatch.setattr(opds2, "PAGE_SLEEP_SECONDS", 0)
+    session = FakeSession(pages)
+    monkeypatch.setattr(opds2.requests, "Session", lambda: session)
+    return process_feed("https://x/p1", since, io.StringIO(), source, **kwargs)
+
+
+def test_process_feed_filters_by_modified_and_collects_acquisitions(monkeypatch):
+    old = {"metadata": {"identifier": "urn:isbn:9780000000002", "title": "Old", "modified": "2026-01-01T00:00:00+00:00"}, "links": []}
+    pages = {"https://x/p1": {"publications": [old, SAMPLE_PUBLICATION], "links": []}}
+    acqs: list = []
+    cutoff = datetime.datetime(2026, 3, 1, tzinfo=datetime.UTC)
+    olbooks, max_modified = _run(monkeypatch, pages, cutoff, acquisitions_out=acqs)
+    assert [b["isbn_13"][0] for b in olbooks] == ["9781737408802"]
+    assert max_modified > cutoff
+    assert acqs == [
+        ("9781737408802", {"price": {"currency": "USD", "value": 1.1}, "url": "https://example.org/purchase/9781737408802", "formats": ["application/epub+zip"]})
+    ]
+
+
+def test_process_feed_applies_record_filter(monkeypatch):
+    # record_filter that excludes everything -> no olbooks kept.
+    drop_all = Source(provider_name="p", source_id_prefix="p", record_filter=lambda _olbook: True)
+    pages = {"https://x/p1": {"publications": [SAMPLE_PUBLICATION], "links": []}}
+    olbooks, _ = _run(monkeypatch, pages, EPOCH, source=drop_all)
+    assert olbooks == []
+
+
+def test_process_feed_advances_cursor_when_mapping_fails(monkeypatch):
+    # Newer record without ISBN still bumps max_modified so it isn't re-scanned forever.
+    pub = {"metadata": {"title": "No ISBN", "modified": "2026-05-20T00:00:00+00:00"}, "links": []}
+    pages = {"https://x/p1": {"publications": [pub], "links": []}}
+    olbooks, max_modified = _run(monkeypatch, pages, EPOCH)
+    assert olbooks == []
+    assert max_modified == parse_iso("2026-05-20T00:00:00+00:00")
+
+
+def test_process_feed_early_stop(monkeypatch):
+    fresh = SAMPLE_PUBLICATION
+    stale = {"metadata": {"identifier": "urn:isbn:9780000000002", "title": "Old", "modified": "2026-01-01T00:00:00+00:00"}, "links": []}
+    pages = {
+        "https://x/p1": {"publications": [fresh], "links": [{"rel": "next", "href": "https://x/p2"}]},
+        "https://x/p2": {"publications": [stale], "links": [{"rel": "next", "href": "https://x/p3"}]},
+        "https://x/p3": {"publications": [fresh], "links": []},
+    }
+    monkeypatch.setattr(opds2, "PAGE_SLEEP_SECONDS", 0)
+    session = FakeSession(pages)
+    monkeypatch.setattr(opds2.requests, "Session", lambda: session)
+    cutoff = datetime.datetime(2026, 3, 1, tzinfo=datetime.UTC)
+    olbooks, _ = process_feed("https://x/p1", cutoff, io.StringIO(), TEST_SOURCE, early_stop=True)
+    assert session.calls == ["https://x/p1", "https://x/p2"]  # p3 not fetched
+    assert len(olbooks) == 1

--- a/openlibrary/core/bookworm.py
+++ b/openlibrary/core/bookworm.py
@@ -1,0 +1,92 @@
+"""BookWorm feed-ingestion runner (#12655 / #12844).
+
+Composes the staging pipeline that the ``bookworm`` service runs on a cron
+(and that also runs standalone on dev):
+
+1. :func:`stage_feed` harvests a registered feed into the ``tbp_staged_record``
+   buffer (records + acquisition metadata), under the feed's lock, advancing the
+   cursor on success.
+2. :func:`promote_pending` drains staged records into the import queue.
+3. :func:`run_once` does both for every registered feed — one cron tick.
+
+The staged buffer sits in the isolated staging DB, so bulk harvesting never
+contends with production Open Library. ``manage-imports`` drains the resulting
+import queue (dual-source: this queue + the legacy main-schema one).
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+from typing import Any
+
+from openlibrary.catalog import opds2
+from openlibrary.core import feeds
+from openlibrary.core.imports import Batch
+from openlibrary.core.staged import PROMOTED, StagedRecord
+from openlibrary.core.tbp import FeedRegistry
+
+logger = logging.getLogger("openlibrary.bookworm")
+
+
+def stage_feed(feed: FeedRegistry, *, max_pages: int | None = None) -> dict[str, Any]:
+    """Harvest one feed into the staged_record buffer, under its per-feed lock.
+
+    Records and their acquisition metadata land in staging (not yet the import
+    queue); the cursor advances on success. Idempotent: re-harvesting refreshes
+    staged rows rather than duplicating them.
+    """
+    if not FeedRegistry.try_lock(feed.id):
+        logger.info("feed %s is locked; skipping", feed.provider_name)
+        return {"feed": feed.provider_name, "skipped": "locked"}
+    try:
+        since = feeds._since(feed)
+        acquisitions: list[tuple[str, dict]] = []
+        olbooks, max_modified = opds2.process_feed(feed.url, since, io.StringIO(), feeds.source_for(feed), max_pages=max_pages, acquisitions_out=acquisitions)
+        acq_by_isbn = dict(acquisitions)
+        for olbook in olbooks:
+            isbn_13 = olbook["isbn_13"][0]
+            StagedRecord.upsert(
+                feed.provider_name,
+                f"urn:isbn:{isbn_13}",
+                olbook,
+                acquisition=acq_by_isbn.get(isbn_13),
+            )
+        advanced = max_modified > since
+        if advanced:
+            FeedRegistry.advance(feed.id, last_updated=max_modified.replace(tzinfo=None))
+        logger.info("staged %s: %d records, advanced=%s", feed.provider_name, len(olbooks), advanced)
+        return {"feed": feed.provider_name, "staged": len(olbooks), "advanced": advanced}
+    finally:
+        FeedRegistry.unlock(feed.id)
+
+
+def promote_pending(limit: int = 1000) -> int:
+    """Promote staged records into the import queue. Returns the number promoted.
+
+    Groups by provider into ``{provider}-staged`` batches; the import batch
+    dedupes on ``ia_id`` so promotion is idempotent. Promoted rows are marked so
+    they drop out of the queue.
+    """
+    pending = StagedRecord.pending(limit=limit)
+    if not pending:
+        return 0
+    by_provider: dict[str, list[StagedRecord]] = {}
+    for rec in pending:
+        by_provider.setdefault(rec.provider_name, []).append(rec)
+    promoted = 0
+    for provider, recs in by_provider.items():
+        batch = Batch.find(f"{provider}-staged") or Batch.new(f"{provider}-staged")
+        batch.add_items([{"ia_id": r.record["source_records"][0], "data": r.record} for r in recs])
+        for rec in recs:
+            StagedRecord.set_status(rec.id, PROMOTED)
+            promoted += 1
+    logger.info("promoted %d staged records", promoted)
+    return promoted
+
+
+def run_once(*, max_pages: int | None = None) -> dict[str, Any]:
+    """One bookworm cycle: harvest every feed into staging, then promote."""
+    staged = [stage_feed(feed, max_pages=max_pages) for feed in FeedRegistry.all()]
+    promoted = promote_pending()
+    return {"staged": staged, "promoted": promoted}

--- a/openlibrary/core/feeds.py
+++ b/openlibrary/core/feeds.py
@@ -1,0 +1,88 @@
+"""Multi-feed harvest runner over the Trusted Book Provider feed registry.
+
+Loops the registered feeds, harvests each under its per-feed lock via the
+generic OPDS 2.0 adapter (:mod:`openlibrary.catalog.opds2`), stages new import
+records to a batch, and advances the feed's cursor on success. The ``bookworm``
+service (#12655) will drive :func:`harvest_all` on a cron; it also runs
+standalone for dev and for the admin "harvest now" trigger.
+
+Onboarding a new OPDS feed is therefore "register a row" — no bespoke script.
+Per-feed quirks (import source-id prefix, ...) live in the registry ``data``
+blob. Better World Books keeps its dedicated ``scripts/bwb_opds_imports.py``
+for its quality filter + acquisition wiring; this runner covers the generic
+case. See https://github.com/internetarchive/openlibrary/issues/12844.
+"""
+
+from __future__ import annotations
+
+import datetime
+import io
+import logging
+from typing import Any
+
+from openlibrary.catalog import opds2
+from openlibrary.catalog.opds2 import EPOCH, Source
+from openlibrary.core.imports import Batch
+from openlibrary.core.tbp import FeedRegistry
+
+logger = logging.getLogger("openlibrary.feeds")
+
+
+def source_for(feed: FeedRegistry) -> Source:
+    """Build the generic OPDS Source for a registered feed.
+
+    The import ``source_records`` prefix defaults to the provider name; a feed
+    may override it via ``data.source_id_prefix``.
+    """
+    data = feed.data or {}
+    return Source(
+        provider_name=feed.provider_name,
+        source_id_prefix=data.get("source_id_prefix") or feed.provider_name,
+    )
+
+
+def _since(feed: FeedRegistry) -> datetime.datetime:
+    """The incremental cutoff for a feed: its cursor, or the epoch."""
+    last_updated = feed.get("last_updated")
+    if not last_updated:
+        return EPOCH
+    if isinstance(last_updated, str):
+        return opds2.parse_iso(last_updated)
+    if last_updated.tzinfo is None:
+        return last_updated.replace(tzinfo=datetime.UTC)
+    return last_updated.astimezone(datetime.UTC)
+
+
+def _commit_batch(batch_name: str, olbooks: list[dict[str, Any]]) -> None:
+    batch = Batch.find(batch_name) or Batch.new(batch_name)
+    batch.add_items([{"ia_id": b["source_records"][0], "data": b} for b in olbooks])
+
+
+def harvest_feed(feed: FeedRegistry, *, ttl_seconds: int = 3600, max_pages: int | None = None) -> dict[str, Any]:
+    """Harvest one registered feed under its per-feed lock.
+
+    Crawls via the generic OPDS 2.0 adapter, stages new import records to a
+    ``{provider}-opds-{date}`` batch, and advances the feed cursor on success.
+    Skips without error (returns ``{"skipped": "locked"}``) if the feed is
+    already being harvested. The cursor advances only after a successful crawl.
+    """
+    if not FeedRegistry.try_lock(feed.id, ttl_seconds=ttl_seconds):
+        logger.info("feed %s is locked; skipping", feed.provider_name)
+        return {"feed": feed.provider_name, "skipped": "locked"}
+    try:
+        since = _since(feed)
+        olbooks, max_modified = opds2.process_feed(feed.url, since, io.StringIO(), source_for(feed), max_pages=max_pages)
+        if olbooks:
+            _commit_batch(f"{feed.provider_name}-opds-{max_modified:%Y-%m-%d}", olbooks)
+        advanced = max_modified > since
+        if advanced:
+            FeedRegistry.advance(feed.id, last_updated=max_modified.replace(tzinfo=None))
+        logger.info("harvested %s: %d records, advanced=%s", feed.provider_name, len(olbooks), advanced)
+        return {"feed": feed.provider_name, "olbooks": len(olbooks), "advanced": advanced}
+    finally:
+        FeedRegistry.unlock(feed.id)
+
+
+def harvest_all(*, ttl_seconds: int = 3600, max_pages: int | None = None) -> list[dict[str, Any]]:
+    """Harvest every registered feed once. Entry point for the cron/runner."""
+    return [harvest_feed(feed, ttl_seconds=ttl_seconds, max_pages=max_pages) for feed in FeedRegistry.all()]

--- a/openlibrary/core/schema.sql
+++ b/openlibrary/core/schema.sql
@@ -148,3 +148,18 @@ CREATE TABLE acquisitions (
 CREATE INDEX acquisitions_work_id_idx ON acquisitions (work_id);
 CREATE INDEX acquisitions_edition_id_idx ON acquisitions (edition_id);
 CREATE INDEX acquisitions_updated_idx ON acquisitions (updated);
+
+CREATE TABLE tbp_feed_registry (
+    id serial primary key,
+    provider_name text not null,
+    feed_type text not null,  -- feed schema/type, e.g. opds, onix, standardebooks
+    url text not null,
+    -- how far we have processed this feed: last fetch date / publication cursor
+    last_updated timestamp without time zone default null,
+    data jsonb not null default '{}'::jsonb,
+    created timestamp without time zone default (current_timestamp at time zone 'utc'),
+    updated timestamp without time zone default (current_timestamp at time zone 'utc'),
+    UNIQUE (provider_name, url)
+);
+
+CREATE INDEX tbp_feed_registry_provider_name ON tbp_feed_registry (provider_name);

--- a/openlibrary/core/staged.py
+++ b/openlibrary/core/staged.py
@@ -1,0 +1,117 @@
+"""Interface to the ``tbp_staged_record`` staging buffer.
+
+Part of the BookWorm staging pipeline (#12655 / #12844). Harvested feed records
+land here first — in an isolated staging DB, so bulk ingestion never contends
+with production Open Library — before being promoted into the catalog.
+
+Each row carries both the normalized import ``record`` (the "olbook") and its
+provider ``acquisition`` metadata (price/formats/url). Keeping the acquisition
+alongside the record is what lets the post-import step attach an acquisition to
+the edition once the catalog creates it — the record and its acquisition never
+get separated.
+
+In production the ``bookworm`` service points its DB connection at the staging
+DB; the interface itself uses the standard ``db`` abstraction so it is portable
+and unit-testable.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+import web
+
+from . import db
+
+logger = logging.getLogger("openlibrary.staged")
+
+if TYPE_CHECKING:
+    from web.db import ResultSet
+
+STAGED = "staged"
+PROMOTED = "promoted"
+FAILED = "failed"
+
+
+def _utcnow() -> datetime.datetime:
+    """Timezone-naive UTC now, matching the table's ``timestamp`` columns."""
+    return datetime.datetime.now(datetime.UTC).replace(tzinfo=None)
+
+
+class StagedRecord(web.storage):
+    """A single row of the ``tbp_staged_record`` staging buffer."""
+
+    TABLENAME = "tbp_staged_record"
+
+    @staticmethod
+    def _from_row(row: Any) -> StagedRecord:
+        staged = StagedRecord(row)
+        # jsonb comes back as a dict from Postgres but as a string from sqlite.
+        for field in ("record", "acquisition"):
+            if isinstance(staged.get(field), str):
+                staged[field] = json.loads(staged[field])
+        return staged
+
+    @staticmethod
+    def find(provider_name: str, local_id: str) -> StagedRecord | None:
+        result = db.query(
+            "SELECT * FROM tbp_staged_record WHERE provider_name=$provider_name AND local_id=$local_id",
+            vars={"provider_name": provider_name, "local_id": local_id},
+        )
+        return StagedRecord._from_row(result[0]) if result else None
+
+    @staticmethod
+    def pending(limit: int = 1000) -> list[StagedRecord]:
+        """Records awaiting promotion into the catalog, oldest first."""
+        rows: ResultSet = db.query(
+            "SELECT * FROM tbp_staged_record WHERE status=$status ORDER BY id LIMIT $limit",
+            vars={"status": STAGED, "limit": limit},
+        )
+        return [StagedRecord._from_row(row) for row in rows]
+
+    @staticmethod
+    def upsert(
+        provider_name: str,
+        local_id: str,
+        record: dict,
+        acquisition: dict | None = None,
+    ) -> StagedRecord | None:
+        """Stage a harvested record, idempotent on ``(provider_name, local_id)``.
+
+        Re-harvesting refreshes the record/acquisition in place (and re-arms it
+        for promotion) rather than creating a duplicate.
+        """
+        if existing := StagedRecord.find(provider_name, local_id):
+            db.update(
+                "tbp_staged_record",
+                where="id=$id",
+                vars={"id": existing.id},
+                record=json.dumps(record),
+                acquisition=json.dumps(acquisition) if acquisition is not None else None,
+                status=STAGED,
+                updated=_utcnow(),
+            )
+        else:
+            db.insert(
+                "tbp_staged_record",
+                provider_name=provider_name,
+                local_id=local_id,
+                record=json.dumps(record),
+                acquisition=json.dumps(acquisition) if acquisition is not None else None,
+                status=STAGED,
+            )
+        return StagedRecord.find(provider_name, local_id)
+
+    @staticmethod
+    def set_status(id: int, status: str) -> int:
+        """Mark a staged record ``promoted`` or ``failed`` after processing."""
+        return db.update(
+            "tbp_staged_record",
+            where="id=$id",
+            vars={"id": id},
+            status=status,
+            updated=_utcnow(),
+        )

--- a/openlibrary/core/tbp.py
+++ b/openlibrary/core/tbp.py
@@ -161,3 +161,39 @@ class FeedRegistry(web.storage):
     def delete(id: int) -> int:
         """Delete a feed by id. Returns the number of rows removed."""
         return db.delete("tbp_feed_registry", where="id=$id", vars={"id": id})
+
+    @staticmethod
+    def try_lock(id: int, ttl_seconds: int = 3600, now: datetime.datetime | None = None) -> bool:
+        """Acquire the per-feed harvest lock (advisory). Returns True if acquired.
+
+        Prevents two harvests of the same feed from overlapping and racing the
+        cursor. Recorded in the ``data`` blob (``status='running'`` +
+        ``locked_at``); a lock older than ``ttl_seconds`` is treated as stale and
+        taken over (so a crashed run self-heals).
+
+        Note: read-modify-write, so not race-proof under true concurrency — a
+        production runner should use a Postgres advisory lock or a conditional
+        UPDATE. Adequate for the single-runner cron in this prototype (#12844).
+        """
+        now = now or _utcnow()
+        feed = FeedRegistry.get_by_id(id)
+        if not feed:
+            return False
+        data = dict(feed.data or {})
+        if (locked_at := data.get("locked_at")) and (now - datetime.datetime.fromisoformat(locked_at)).total_seconds() < ttl_seconds:
+            return False
+        data["locked_at"] = now.isoformat()
+        data["status"] = "running"
+        FeedRegistry.update_fields(id, data=data)
+        return True
+
+    @staticmethod
+    def unlock(id: int, status: str = "idle") -> int:
+        """Release the per-feed harvest lock, setting ``status`` (default idle)."""
+        feed = FeedRegistry.get_by_id(id)
+        if not feed:
+            return 0
+        data = dict(feed.data or {})
+        data.pop("locked_at", None)
+        data["status"] = status
+        return FeedRegistry.update_fields(id, data=data)

--- a/openlibrary/core/tbp.py
+++ b/openlibrary/core/tbp.py
@@ -110,6 +110,31 @@ class FeedRegistry(web.storage):
             return FeedRegistry.find(provider_name=provider_name, url=url)
 
     @staticmethod
+    def from_request(payload: dict, submitter: str | None = None) -> FeedRegistry | None:
+        """Register a feed from an API payload (``/api/import/feeds/register``).
+
+        Records a ``status`` of ``"pending"`` and the submitter in the data
+        blob for accountability: a registered feed is not trusted by the
+        ingestion cron until a maintainer promotes it, mirroring the
+        account-linking policy for Lenny lending instances (#12844). Idempotent
+        via :meth:`register`.
+
+        :raises ValueError: if ``provider_name`` or ``url`` is missing.
+        """
+        provider_name = (payload.get("provider_name") or "").strip()
+        url = (payload.get("url") or "").strip()
+        if not provider_name or not url:
+            raise ValueError("provider_name and url are required")
+        feed_type = (payload.get("feed_type") or "opds").strip()
+        data = dict(payload.get("data") or {})
+        data.setdefault("status", "pending")
+        if submitter:
+            data.setdefault("submitter", submitter)
+        if contact := payload.get("contact"):
+            data.setdefault("contact", contact)
+        return FeedRegistry.register(provider_name=provider_name, url=url, feed_type=feed_type, data=data)
+
+    @staticmethod
     def advance(id: int, last_updated: datetime.datetime, data: dict | None = None) -> int:
         """Record ingestion progress for the feed.
 

--- a/openlibrary/core/tbp.py
+++ b/openlibrary/core/tbp.py
@@ -145,3 +145,19 @@ class FeedRegistry(web.storage):
         if data is not None:
             fields["data"] = json.dumps(data)
         return db.update("tbp_feed_registry", where="id=$id", vars={"id": id}, **fields)
+
+    @staticmethod
+    def update_fields(id: int, **fields: Any) -> int:
+        """Update columns of a feed by id (e.g. ``url``, ``feed_type``, ``data``).
+
+        A ``data`` dict is JSON-serialized. Returns the number of rows changed.
+        """
+        if isinstance(fields.get("data"), dict):
+            fields["data"] = json.dumps(fields["data"])
+        fields["updated"] = _utcnow()
+        return db.update("tbp_feed_registry", where="id=$id", vars={"id": id}, **fields)
+
+    @staticmethod
+    def delete(id: int) -> int:
+        """Delete a feed by id. Returns the number of rows removed."""
+        return db.delete("tbp_feed_registry", where="id=$id", vars={"id": id})

--- a/openlibrary/core/tbp.py
+++ b/openlibrary/core/tbp.py
@@ -1,0 +1,122 @@
+"""Interface to the Trusted Book Providers (TBP) feed registry.
+
+The ``tbp_feed_registry`` table records which provider feeds Open Library
+ingests (Better World Books OPDS, Internet Archive Labs Lenny, Standard
+Ebooks, ...) and how far each feed has been processed, so the daily
+ingestion cron can resume from the last fetched record.
+
+The ``data`` blob is intentionally open-ended: it holds per-feed connector
+config (trust level, polling cadence, record caps, cover-import flag, ...)
+so onboarding a new micro-feed is "add a row" rather than "write an adapter".
+
+See https://github.com/internetarchive/openlibrary/issues/12844 and
+https://github.com/internetarchive/openlibrary/pull/12793.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+from sqlite3 import IntegrityError
+from typing import TYPE_CHECKING, Any
+
+import web
+from psycopg2.errors import UniqueViolation
+
+from . import db
+
+logger = logging.getLogger("openlibrary.tbp")
+
+if TYPE_CHECKING:
+    from web.db import ResultSet
+
+
+def _utcnow() -> datetime.datetime:
+    """Timezone-naive UTC now, matching the table's ``timestamp`` columns."""
+    return datetime.datetime.now(datetime.UTC).replace(tzinfo=None)
+
+
+class FeedRegistry(web.storage):
+    """A single row of the ``tbp_feed_registry`` table."""
+
+    TABLENAME = "tbp_feed_registry"
+
+    @staticmethod
+    def _from_row(row: Any) -> FeedRegistry:
+        registry = FeedRegistry(row)
+        # jsonb comes back as a dict from Postgres but as a string from sqlite.
+        if isinstance(registry.get("data"), str):
+            registry.data = json.loads(registry.data)
+        return registry
+
+    @staticmethod
+    def find(provider_name: str, url: str) -> FeedRegistry | None:
+        result = db.query(
+            "SELECT * FROM tbp_feed_registry WHERE provider_name=$provider_name AND url=$url",
+            vars={"provider_name": provider_name, "url": url},
+        )
+        return FeedRegistry._from_row(result[0]) if result else None
+
+    @staticmethod
+    def get_by_id(id: int) -> FeedRegistry | None:
+        result = db.query("SELECT * FROM tbp_feed_registry WHERE id=$id", vars={"id": id})
+        return FeedRegistry._from_row(result[0]) if result else None
+
+    @staticmethod
+    def all() -> list[FeedRegistry]:
+        rows: ResultSet = db.query("SELECT * FROM tbp_feed_registry ORDER BY id")
+        return [FeedRegistry._from_row(row) for row in rows]
+
+    @staticmethod
+    def new(
+        provider_name: str,
+        url: str,
+        feed_type: str = "opds",
+        data: dict | None = None,
+    ) -> FeedRegistry | None:
+        db.insert(
+            "tbp_feed_registry",
+            provider_name=provider_name,
+            url=url,
+            feed_type=feed_type,
+            data=json.dumps(data or {}),
+        )
+        return FeedRegistry.find(provider_name=provider_name, url=url)
+
+    @staticmethod
+    def register(
+        provider_name: str,
+        url: str,
+        feed_type: str = "opds",
+        data: dict | None = None,
+    ) -> FeedRegistry | None:
+        """Idempotently return the registry row, creating it if missing.
+
+        Safe to call repeatedly; honours the ``(provider_name, url)`` unique
+        constraint.
+        """
+        if existing := FeedRegistry.find(provider_name=provider_name, url=url):
+            return existing
+        try:
+            return FeedRegistry.new(
+                provider_name=provider_name,
+                url=url,
+                feed_type=feed_type,
+                data=data,
+            )
+        except (UniqueViolation, IntegrityError):  # fmt: skip
+            # Raced with a concurrent insert; the row now exists.
+            return FeedRegistry.find(provider_name=provider_name, url=url)
+
+    @staticmethod
+    def advance(id: int, last_updated: datetime.datetime, data: dict | None = None) -> int:
+        """Record ingestion progress for the feed.
+
+        Moves the processing cursor (``last_updated``) forward; optionally
+        replaces the ``data`` blob.
+        """
+        fields: dict[str, Any] = {"last_updated": last_updated, "updated": _utcnow()}
+        if data is not None:
+            fields["data"] = json.dumps(data)
+        return db.update("tbp_feed_registry", where="id=$id", vars={"id": id}, **fields)

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -184,9 +184,10 @@ msgid "Added Time"
 msgstr ""
 
 #: account/import.html account/loans.html admin/imports.html
-#: admin/imports_by_date.html admin/loans_table.html admin/menu.html
-#: batch_import_pending_view.html batch_import_view.html
-#: librarian_dashboard/data_quality_table.html status.html
+#: admin/imports_by_date.html admin/imports_registry.html
+#: admin/loans_table.html admin/menu.html batch_import_pending_view.html
+#: batch_import_view.html librarian_dashboard/data_quality_table.html
+#: status.html
 msgid "Status"
 msgstr ""
 
@@ -1451,7 +1452,8 @@ msgid_plural "%(count)d books"
 msgstr[0] ""
 msgstr[1] ""
 
-#: RecentChangesAdmin.html account/loans.html admin/loans_table.html
+#: RecentChangesAdmin.html account/loans.html admin/imports_registry.html
+#: admin/loans_table.html
 msgid "Actions"
 msgstr ""
 
@@ -1666,7 +1668,8 @@ msgstr ""
 msgid "Reviews"
 msgstr ""
 
-#: account/observations.html admin/inspect/memcache.html
+#: account/observations.html admin/imports_registry.html
+#: admin/inspect/memcache.html
 msgid "Delete"
 msgstr ""
 
@@ -2257,7 +2260,7 @@ msgid "Page"
 msgstr ""
 
 #: admin/imports-add.html admin/imports.html admin/imports_by_date.html
-#: admin/menu.html
+#: admin/imports_registry.html admin/menu.html
 msgid "Imports"
 msgstr ""
 
@@ -2364,6 +2367,68 @@ msgstr ""
 
 #: admin/imports_by_date.html
 msgid "Items"
+msgstr ""
+
+#: admin/imports_registry.html
+msgid "Feed Registry"
+msgstr ""
+
+#: admin/imports_registry.html lib/exports.html type/list/exports.html
+msgid "JSON"
+msgstr ""
+
+#: admin/imports_registry.html
+msgid ""
+"Trusted Book Provider feeds the ingestion pipeline harvests. New feeds "
+"start as 'pending' until a maintainer promotes them."
+msgstr ""
+
+#: admin/imports_registry.html
+msgid "ID"
+msgstr ""
+
+#: admin/imports_registry.html
+msgid "Provider"
+msgstr ""
+
+#: admin/imports_registry.html admin/inspect/store.html
+msgid "Type"
+msgstr ""
+
+#: admin/imports_registry.html books/edit/web.html
+msgid "URL"
+msgstr ""
+
+#: admin/imports_registry.html
+msgid "Last run"
+msgstr ""
+
+#: admin/imports_registry.html
+msgid "No feeds registered yet."
+msgstr ""
+
+#: admin/imports_registry.html
+msgid "never"
+msgstr ""
+
+#: admin/imports_registry.html
+msgid "Register a feed"
+msgstr ""
+
+#: admin/imports_registry.html
+msgid "Provider name"
+msgstr ""
+
+#: admin/imports_registry.html
+msgid "Feed URL"
+msgstr ""
+
+#: admin/imports_registry.html
+msgid "Feed type"
+msgstr ""
+
+#: admin/imports_registry.html
+msgid "Register"
 msgstr ""
 
 #: admin/index.html
@@ -2831,10 +2896,6 @@ msgstr ""
 
 #: admin/inspect/store.html
 msgid "Query"
-msgstr ""
-
-#: admin/inspect/store.html
-msgid "Type"
 msgstr ""
 
 #: admin/inspect/store.html
@@ -4462,10 +4523,6 @@ msgid "For example: <em>New York Times review</em>"
 msgstr ""
 
 #: books/edit/web.html
-msgid "URL"
-msgstr ""
-
-#: books/edit/web.html
 msgid "Add Link"
 msgstr ""
 
@@ -5087,10 +5144,6 @@ msgstr ""
 
 #: lib/exports.html
 msgid "RDF"
-msgstr ""
-
-#: lib/exports.html type/list/exports.html
-msgid "JSON"
 msgstr ""
 
 #: lib/exports.html

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -2412,6 +2412,14 @@ msgid "never"
 msgstr ""
 
 #: admin/imports_registry.html
+msgid "Harvest"
+msgstr ""
+
+#: admin/imports_registry.html
+msgid "Harvest all feeds now"
+msgstr ""
+
+#: admin/imports_registry.html
 msgid "Register a feed"
 msgstr ""
 

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -33,6 +33,7 @@ from openlibrary.core import (
 )
 from openlibrary.core import (
     cache,
+    feeds,
     imports,
 )
 from openlibrary.core.models import Work
@@ -827,8 +828,15 @@ class imports_registry:
                 data={"status": "pending"},
             )
             add_flash_message("info", f"Registered feed {i.provider_name}.")
+        elif i.action == "harvest" and i.id:
+            feed = FeedRegistry.get_by_id(int(i.id))
+            result = feeds.harvest_feed(feed) if feed else {"error": "feed not found"}
+            add_flash_message("info", f"Harvest {i.id}: {result}")
+        elif i.action == "harvest_all":
+            results = feeds.harvest_all()
+            add_flash_message("info", f"Harvested {len(results)} feeds.")
         else:
-            add_flash_message("error", "To add a feed provide provider_name and url; to delete provide id.")
+            add_flash_message("error", "To add a feed provide provider_name and url; to delete or harvest provide id.")
         raise web.seeother("/admin/imports/registry")
 
 

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -36,6 +36,7 @@ from openlibrary.core import (
     imports,
 )
 from openlibrary.core.models import Work
+from openlibrary.core.tbp import FeedRegistry
 from openlibrary.plugins.openlibrary.pd import get_pd_dashboard_data
 from openlibrary.plugins.upstream import forms, spamcheck
 
@@ -782,6 +783,55 @@ class pd_dashboard:
         return render_template("admin/pd_dashboard", dashboard_data)
 
 
+def _feed_registry_row(feed) -> dict:
+    return {
+        "id": feed.id,
+        "provider_name": feed.provider_name,
+        "feed_type": feed.feed_type,
+        "url": feed.url,
+        "status": (feed.data or {}).get("status"),
+        "last_updated": str(feed.last_updated) if feed.get("last_updated") else None,
+        "created": str(feed.get("created")) if feed.get("created") else None,
+        "updated": str(feed.get("updated")) if feed.get("updated") else None,
+        "data": feed.data,
+    }
+
+
+class imports_registry:
+    """Admin view + CRUD for the Trusted Book Provider feed registry (#12844).
+
+    ``GET /admin/imports/registry`` renders the feeds (provider, url, type,
+    status, last run); ``.json`` returns the same as JSON. ``POST`` adds or
+    deletes a feed. New feeds start ``status="pending"`` until promoted.
+    """
+
+    def GET(self, ext=None):
+        feeds = FeedRegistry.all()
+        if ext == ".json":
+            return delegate.RawText(
+                json.dumps([_feed_registry_row(f) for f in feeds]),
+                content_type="application/json",
+            )
+        return render_template("admin/imports_registry", feeds=feeds)
+
+    def POST(self, ext=None):
+        i = web.input(action="", id="", provider_name="", url="", feed_type="opds")
+        if i.action == "delete" and i.id:
+            FeedRegistry.delete(int(i.id))
+            add_flash_message("info", f"Deleted feed {i.id}.")
+        elif i.action == "add" and i.provider_name and i.url:
+            FeedRegistry.register(
+                i.provider_name.strip(),
+                i.url.strip(),
+                feed_type=(i.feed_type or "opds").strip(),
+                data={"status": "pending"},
+            )
+            add_flash_message("info", f"Registered feed {i.provider_name}.")
+        else:
+            add_flash_message("error", "To add a feed provide provider_name and url; to delete provide id.")
+        raise web.seeother("/admin/imports/registry")
+
+
 def setup():
     register_admin_page("/admin/git-pull", gitpull, label="git-pull")
     register_admin_page("/admin/reload", reload, label="Reload Templates")
@@ -806,6 +856,7 @@ def setup():
     register_admin_page("/admin/imports", imports_home, label="")
     register_admin_page("/admin/imports/add", imports_add, label="")
     register_admin_page(r"/admin/imports/(\d\d\d\d-\d\d-\d\d)", imports_by_date, label="")
+    register_admin_page(r"/admin/imports/registry(\.json)?", imports_registry, label="Feed Registry")
     register_admin_page("/admin/spamwords", spamwords, label="")
     register_admin_page("/admin/pd", pd_dashboard)
 

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -19,6 +19,7 @@ from openlibrary.catalog.marc.marc_xml import MarcXml
 from openlibrary.catalog.marc.parse import read_edition
 from openlibrary.catalog.utils import get_non_isbn_asin
 from openlibrary.core import ia
+from openlibrary.core.tbp import FeedRegistry
 from openlibrary.plugins.importapi import (
     import_edition_builder,
     import_opds,
@@ -509,8 +510,56 @@ class ia_importapi(importapi):
         return json.dumps(reply)
 
 
+class feed_register_api:
+    """``/api/import/feeds/register`` — register a provider feed for ingestion.
+
+    A partner service POSTs ``{provider_name, url, feed_type?, contact?}`` to
+    enlist an OPDS/ONIX/... feed in the Trusted Book Provider registry. Feeds
+    are recorded with ``status="pending"``; a maintainer promotes them before
+    the ingestion cron trusts them, so exposing this endpoint does not by
+    itself let arbitrary sources inject records (see #12844).
+    """
+
+    def POST(self):
+        web.header("Content-Type", "application/json")
+        if not can_write():
+            raise web.HTTPError("403 Forbidden")
+
+        try:
+            payload = json.loads(web.data() or b"{}")
+        except json.JSONDecodeError:
+            raise web.HTTPError(
+                "400 Bad Request",
+                data=json.dumps({"success": False, "error": "Invalid JSON body"}),
+            )
+
+        user = web.ctx.site.get_user()
+        submitter = user.key if user else None
+        try:
+            feed = FeedRegistry.from_request(payload, submitter=submitter)
+        except ValueError as e:
+            raise web.HTTPError(
+                "400 Bad Request",
+                data=json.dumps({"success": False, "error": str(e)}),
+            )
+
+        return json.dumps(
+            {
+                "success": True,
+                "feed": {
+                    "id": feed.id,
+                    "provider_name": feed.provider_name,
+                    "url": feed.url,
+                    "feed_type": feed.feed_type,
+                    "status": feed.data.get("status"),
+                },
+            }
+        )
+
+
 add_hook("import", importapi)
 add_hook("import/ia", ia_importapi)
+add_hook("import/feeds/register", feed_register_api)
 
 
 def setup():

--- a/openlibrary/templates/admin/imports_registry.html
+++ b/openlibrary/templates/admin/imports_registry.html
@@ -36,14 +36,19 @@ $var title: $_("Feed Registry")
           <td>$(feed.last_updated or _('never'))</td>
           <td>
             <form method="POST" action="/admin/imports/registry">
-              <input type="hidden" name="action" value="delete"/>
               <input type="hidden" name="id" value="$feed.id"/>
-              <button type="submit">$_("Delete")</button>
+              <button type="submit" name="action" value="harvest">$_("Harvest")</button>
+              <button type="submit" name="action" value="delete">$_("Delete")</button>
             </form>
           </td>
         </tr>
     </tbody>
   </table>
+
+  $if feeds:
+    <form method="POST" action="/admin/imports/registry">
+      <button type="submit" name="action" value="harvest_all">$_("Harvest all feeds now")</button>
+    </form>
 
   <h2>$_("Register a feed")</h2>
   <form method="POST" action="/admin/imports/registry">

--- a/openlibrary/templates/admin/imports_registry.html
+++ b/openlibrary/templates/admin/imports_registry.html
@@ -1,0 +1,65 @@
+$def with (feeds)
+$var title: $_("Feed Registry")
+
+<div id="contentHead">
+    $if ctx.user and ctx.user.is_admin():
+      $:render_template("admin/menu")
+    <h1>$_("Feed Registry")</h1>
+    <div><a href="/admin/imports/registry.json">$_("JSON")</a> &middot; <a href="/admin/imports">$_("Imports")</a></div>
+</div>
+
+<div id="contentBody">
+  <p>$_("Trusted Book Provider feeds the ingestion pipeline harvests. New feeds start as 'pending' until a maintainer promotes them.")</p>
+
+  <table class="admin">
+    <thead>
+      <tr>
+        <th>$_("ID")</th>
+        <th>$_("Provider")</th>
+        <th>$_("Type")</th>
+        <th>$_("URL")</th>
+        <th>$_("Status")</th>
+        <th>$_("Last run")</th>
+        <th>$_("Actions")</th>
+      </tr>
+    </thead>
+    <tbody>
+      $if not feeds:
+        <tr><td colspan="7">$_("No feeds registered yet.")</td></tr>
+      $for feed in feeds:
+        <tr>
+          <td>$feed.id</td>
+          <td>$feed.provider_name</td>
+          <td>$feed.feed_type</td>
+          <td><a href="$feed.url">$feed.url</a></td>
+          <td>$(feed.data.get('status') or '')</td>
+          <td>$(feed.last_updated or _('never'))</td>
+          <td>
+            <form method="POST" action="/admin/imports/registry">
+              <input type="hidden" name="action" value="delete"/>
+              <input type="hidden" name="id" value="$feed.id"/>
+              <button type="submit">$_("Delete")</button>
+            </form>
+          </td>
+        </tr>
+    </tbody>
+  </table>
+
+  <h2>$_("Register a feed")</h2>
+  <form method="POST" action="/admin/imports/registry">
+    <input type="hidden" name="action" value="add"/>
+    <p>
+      <label for="provider_name">$_("Provider name")</label>
+      <input id="provider_name" type="text" name="provider_name" required/>
+    </p>
+    <p>
+      <label for="url">$_("Feed URL")</label>
+      <input id="url" type="url" name="url" required/>
+    </p>
+    <p>
+      <label for="feed_type">$_("Feed type")</label>
+      <input id="feed_type" type="text" name="feed_type" value="opds"/>
+    </p>
+    <button type="submit">$_("Register")</button>
+  </form>
+</div>

--- a/openlibrary/tests/core/test_bookworm.py
+++ b/openlibrary/tests/core/test_bookworm.py
@@ -1,0 +1,152 @@
+from typing import Final
+
+import pytest
+import web
+
+from openlibrary.catalog import opds2
+from openlibrary.core import bookworm
+from openlibrary.core.db import get_db
+from openlibrary.core.staged import STAGED, StagedRecord
+from openlibrary.core.tbp import FeedRegistry
+
+TBP_DDL: Final = """
+CREATE TABLE tbp_feed_registry (
+    id integer primary key, provider_name text not null, feed_type text not null,
+    url text not null, last_updated timestamp default null, data text not null default '{}',
+    created timestamp default current_timestamp, updated timestamp default current_timestamp,
+    UNIQUE (provider_name, url)
+);
+"""
+STAGED_DDL: Final = """
+CREATE TABLE tbp_staged_record (
+    id integer primary key, provider_name text not null, local_id text not null,
+    record text not null, acquisition text default null, status text not null default 'staged',
+    created timestamp default current_timestamp, updated timestamp default current_timestamp,
+    UNIQUE (provider_name, local_id)
+);
+"""
+IMPORT_BATCH_DDL: Final = """
+CREATE TABLE import_batch (id integer primary key, name text, submitter text, submit_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP);
+"""
+IMPORT_ITEM_DDL: Final = """
+CREATE TABLE import_item (
+    id serial primary key, batch_id integer, status text default 'pending', error text,
+    ia_id text, data text, ol_key text, comments text, submitter text, UNIQUE (batch_id, ia_id)
+);
+"""
+
+FEED_URL: Final = "https://prov.example/opds"
+ONE_BOOK_FEED: Final = {
+    "publications": [
+        {
+            "metadata": {
+                "title": "A Book",
+                "identifier": "urn:isbn:9781737408802",
+                "author": [{"name": "An Author"}],
+                "modified": "2026-06-16T10:00:00+00:00",
+            },
+            "links": [
+                {
+                    "rel": "http://opds-spec.org/acquisition/buy",
+                    "href": "https://prov.example/buy/9781737408802",
+                    "properties": {"price": {"currency": "USD", "value": 2.0}},
+                }
+            ],
+        }
+    ],
+    "links": [],
+}
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        pass
+
+
+class FakeSession:
+    def __init__(self, pages):
+        self.pages = pages
+
+    def get(self, url, **kwargs):
+        return FakeResponse(self.pages[url])
+
+
+@pytest.fixture
+def bookworm_db():
+    web.config.db_parameters = {"dbn": "sqlite", "db": ":memory:"}
+    db = get_db()
+    for table in ("import_item", "import_batch", "tbp_staged_record", "tbp_feed_registry"):
+        db.query(f"DROP TABLE IF EXISTS {table};")
+    for ddl in (TBP_DDL, STAGED_DDL, IMPORT_BATCH_DDL, IMPORT_ITEM_DDL):
+        db.query(ddl)
+    yield db
+    for table in ("import_item", "import_batch", "tbp_staged_record", "tbp_feed_registry"):
+        db.query(f"DROP TABLE IF EXISTS {table};")
+
+
+def _serve(monkeypatch, pages):
+    monkeypatch.setattr(opds2, "PAGE_SLEEP_SECONDS", 0)
+    monkeypatch.setattr(opds2.requests, "Session", lambda: FakeSession(pages))
+
+
+def test_stage_feed_buffers_records_with_acquisition(monkeypatch, bookworm_db):
+    FeedRegistry.register("prov", FEED_URL, data={"source_id_prefix": "prov"})
+    feed = FeedRegistry.find("prov", FEED_URL)
+    _serve(monkeypatch, {FEED_URL: ONE_BOOK_FEED})
+
+    result = bookworm.stage_feed(feed)
+    assert result == {"feed": "prov", "staged": 1, "advanced": True}
+
+    staged = StagedRecord.pending()
+    assert len(staged) == 1
+    assert staged[0].record["source_records"] == ["prov:9781737408802"]
+    assert staged[0].acquisition["price"] == {"currency": "USD", "value": 2.0}
+    # no import_item yet — staging only
+    assert list(bookworm_db.select("import_item")) == []
+    # cursor advanced + unlocked
+    reloaded = FeedRegistry.get_by_id(feed.id)
+    assert reloaded.last_updated is not None
+    assert reloaded.data["status"] == "idle"
+
+
+def test_promote_pending_creates_import_items_and_is_idempotent(monkeypatch, bookworm_db):
+    FeedRegistry.register("prov", FEED_URL)
+    feed = FeedRegistry.find("prov", FEED_URL)
+    _serve(monkeypatch, {FEED_URL: ONE_BOOK_FEED})
+    bookworm.stage_feed(feed)
+
+    assert bookworm.promote_pending() == 1
+    rows = list(bookworm_db.select("import_item"))
+    assert [r.ia_id for r in rows] == ["prov:9781737408802"]
+    # staged row is now marked promoted -> drops out of the queue
+    assert StagedRecord.pending() == []
+    # promoting again does nothing (queue empty)
+    assert bookworm.promote_pending() == 0
+    assert len(list(bookworm_db.select("import_item"))) == 1
+
+
+def test_run_once_stages_then_promotes(monkeypatch, bookworm_db):
+    FeedRegistry.register("prov", FEED_URL)
+    _serve(monkeypatch, {FEED_URL: ONE_BOOK_FEED})
+
+    summary = bookworm.run_once()
+    assert summary["promoted"] == 1
+    assert summary["staged"] == [{"feed": "prov", "staged": 1, "advanced": True}]
+    assert [r.ia_id for r in bookworm_db.select("import_item")] == ["prov:9781737408802"]
+
+
+def test_stage_feed_is_idempotent_via_cursor(monkeypatch, bookworm_db):
+    FeedRegistry.register("prov", FEED_URL)
+    feed = FeedRegistry.find("prov", FEED_URL)
+    _serve(monkeypatch, {FEED_URL: ONE_BOOK_FEED})
+    bookworm.stage_feed(feed)
+    # Second stage: cursor past the record -> nothing new staged.
+    second = bookworm.stage_feed(FeedRegistry.get_by_id(feed.id))
+    assert second["staged"] == 0
+    assert len([r for r in StagedRecord.pending() if r.status == STAGED]) == 1

--- a/openlibrary/tests/core/test_feeds.py
+++ b/openlibrary/tests/core/test_feeds.py
@@ -1,0 +1,160 @@
+from typing import Final
+
+import pytest
+import web
+
+from openlibrary.catalog import opds2
+from openlibrary.core import feeds
+from openlibrary.core.db import get_db
+from openlibrary.core.tbp import FeedRegistry
+
+TBP_DDL: Final = """
+CREATE TABLE tbp_feed_registry (
+    id integer primary key,
+    provider_name text not null,
+    feed_type text not null,
+    url text not null,
+    last_updated timestamp default null,
+    data text not null default '{}',
+    created timestamp default current_timestamp,
+    updated timestamp default current_timestamp,
+    UNIQUE (provider_name, url)
+);
+"""
+
+IMPORT_BATCH_DDL: Final = """
+CREATE TABLE import_batch (
+    id integer primary key,
+    name text,
+    submitter text,
+    submit_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+"""
+
+IMPORT_ITEM_DDL: Final = """
+CREATE TABLE import_item (
+    id serial primary key,
+    batch_id integer,
+    status text default 'pending',
+    error text,
+    ia_id text,
+    data text,
+    ol_key text,
+    comments text,
+    submitter text,
+    UNIQUE (batch_id, ia_id)
+);
+"""
+
+
+def _publication(isbn_13: str, modified: str) -> dict:
+    return {
+        "metadata": {
+            "title": f"Book {isbn_13}",
+            "identifier": f"urn:isbn:{isbn_13}",
+            "author": [{"name": "An Author"}],
+            "modified": modified,
+        },
+        "links": [
+            {
+                "rel": "http://opds-spec.org/acquisition/buy",
+                "href": f"https://provider.example/buy/{isbn_13}",
+                "properties": {"price": {"currency": "USD", "value": 2.0}},
+            }
+        ],
+    }
+
+
+ONE_BOOK_FEED: Final = {"publications": [_publication("9781737408802", "2026-06-16T10:00:00+00:00")], "links": []}
+EMPTY_FEED: Final[dict] = {"publications": [], "links": []}
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        pass
+
+
+class FakeSession:
+    def __init__(self, pages_by_url):
+        self.pages_by_url = pages_by_url
+
+    def get(self, url, **kwargs):
+        return FakeResponse(self.pages_by_url[url])
+
+
+@pytest.fixture
+def feeds_db():
+    web.config.db_parameters = {"dbn": "sqlite", "db": ":memory:"}
+    db = get_db()
+    for table in ("import_item", "import_batch", "tbp_feed_registry"):
+        db.query(f"DROP TABLE IF EXISTS {table};")
+    db.query(TBP_DDL)
+    db.query(IMPORT_BATCH_DDL)
+    db.query(IMPORT_ITEM_DDL)
+    yield db
+    for table in ("import_item", "import_batch", "tbp_feed_registry"):
+        db.query(f"DROP TABLE IF EXISTS {table};")
+
+
+def _serve(monkeypatch, pages):
+    monkeypatch.setattr(opds2, "PAGE_SLEEP_SECONDS", 0)
+    session = FakeSession(pages)
+    monkeypatch.setattr(opds2.requests, "Session", lambda: session)
+
+
+def test_harvest_feed_stages_records_and_advances_cursor(monkeypatch, feeds_db):
+    FeedRegistry.register("prov", "https://prov.example/opds", data={"source_id_prefix": "prov"})
+    feed = FeedRegistry.find("prov", "https://prov.example/opds")
+    _serve(monkeypatch, {"https://prov.example/opds": ONE_BOOK_FEED})
+
+    result = feeds.harvest_feed(feed)
+    assert result == {"feed": "prov", "olbooks": 1, "advanced": True}
+
+    rows = list(feeds_db.select("import_item"))
+    assert [r.ia_id for r in rows] == ["prov:9781737408802"]
+
+    reloaded = FeedRegistry.get_by_id(feed.id)
+    assert reloaded.last_updated is not None  # cursor advanced
+    assert reloaded.data["status"] == "idle"  # unlocked
+    assert "locked_at" not in reloaded.data
+
+
+def test_harvest_feed_skips_when_locked(monkeypatch, feeds_db):
+    FeedRegistry.register("prov", "https://prov.example/opds")
+    feed = FeedRegistry.find("prov", "https://prov.example/opds")
+    assert FeedRegistry.try_lock(feed.id) is True  # someone else is harvesting
+    _serve(monkeypatch, {"https://prov.example/opds": ONE_BOOK_FEED})
+
+    assert feeds.harvest_feed(feed) == {"feed": "prov", "skipped": "locked"}
+    assert list(feeds_db.select("import_item")) == []
+
+
+def test_harvest_is_idempotent_via_cursor(monkeypatch, feeds_db):
+    FeedRegistry.register("prov", "https://prov.example/opds")
+    feed = FeedRegistry.find("prov", "https://prov.example/opds")
+    _serve(monkeypatch, {"https://prov.example/opds": ONE_BOOK_FEED})
+
+    feeds.harvest_feed(feed)
+    # Second run: cursor now past the record -> nothing new, no duplicate rows.
+    second = feeds.harvest_feed(FeedRegistry.get_by_id(feed.id))
+    assert second["olbooks"] == 0
+    assert second["advanced"] is False
+    assert len(list(feeds_db.select("import_item"))) == 1
+
+
+def test_harvest_all_runs_every_feed(monkeypatch, feeds_db):
+    FeedRegistry.register("a", "https://a.example/opds")
+    FeedRegistry.register("b", "https://b.example/opds")
+    _serve(monkeypatch, {"https://a.example/opds": ONE_BOOK_FEED, "https://b.example/opds": EMPTY_FEED})
+
+    results = feeds.harvest_all()
+    assert {r["feed"] for r in results} == {"a", "b"}
+    by_feed = {r["feed"]: r for r in results}
+    assert by_feed["a"]["olbooks"] == 1
+    assert by_feed["b"]["olbooks"] == 0

--- a/openlibrary/tests/core/test_staged.py
+++ b/openlibrary/tests/core/test_staged.py
@@ -1,0 +1,67 @@
+from typing import Final
+
+import pytest
+import web
+
+from openlibrary.core.db import get_db
+from openlibrary.core.staged import PROMOTED, STAGED, StagedRecord
+
+# sqlite-friendly DDL (Postgres uses serial/jsonb; sqlite is typeless).
+STAGED_RECORD_DDL: Final = """
+CREATE TABLE tbp_staged_record (
+    id integer primary key,
+    provider_name text not null,
+    local_id text not null,
+    record text not null,
+    acquisition text default null,
+    status text not null default 'staged',
+    created timestamp default current_timestamp,
+    updated timestamp default current_timestamp,
+    UNIQUE (provider_name, local_id)
+);
+"""
+
+RECORD: Final = {"title": "A Book", "isbn_13": ["9781737408802"], "source_records": ["bwb:9781737408802"]}
+ACQ: Final = {"price": {"currency": "USD", "value": 1.25}, "formats": ["application/epub+zip"]}
+
+
+@pytest.fixture
+def staged_db():
+    web.config.db_parameters = {"dbn": "sqlite", "db": ":memory:"}
+    db = get_db()
+    db.query("DROP TABLE IF EXISTS tbp_staged_record;")
+    db.query(STAGED_RECORD_DDL)
+    yield db
+    db.query("DROP TABLE IF EXISTS tbp_staged_record;")
+
+
+class TestStagedRecord:
+    def test_upsert_creates_then_reads(self, staged_db):
+        row = StagedRecord.upsert("bwb", "urn:isbn:9781737408802", RECORD, acquisition=ACQ)
+        assert row is not None
+        assert row.status == STAGED
+        # record and acquisition round-trip as dicts.
+        assert row.record["source_records"] == ["bwb:9781737408802"]
+        assert row.acquisition["price"]["value"] == 1.25
+
+    def test_upsert_is_idempotent_and_refreshes(self, staged_db):
+        StagedRecord.upsert("bwb", "urn:isbn:9781737408802", RECORD, acquisition=ACQ)
+        # Re-harvest with a changed price -> same row, refreshed, still one row.
+        changed = {"price": {"currency": "USD", "value": 3.5}}
+        StagedRecord.upsert("bwb", "urn:isbn:9781737408802", RECORD, acquisition=changed)
+        rows = list(staged_db.select("tbp_staged_record"))
+        assert len(rows) == 1
+        assert StagedRecord.find("bwb", "urn:isbn:9781737408802").acquisition["price"]["value"] == 3.5
+
+    def test_pending_excludes_promoted(self, staged_db):
+        StagedRecord.upsert("bwb", "a", RECORD)
+        StagedRecord.upsert("bwb", "b", RECORD)
+        assert {r.local_id for r in StagedRecord.pending()} == {"a", "b"}
+        b = StagedRecord.find("bwb", "b")
+        assert StagedRecord.set_status(b.id, PROMOTED) == 1
+        # Promoted rows drop out of the promotion queue.
+        assert [r.local_id for r in StagedRecord.pending()] == ["a"]
+
+    def test_acquisition_is_optional(self, staged_db):
+        row = StagedRecord.upsert("bwb", "no-acq", RECORD)
+        assert row.acquisition is None

--- a/openlibrary/tests/core/test_tbp.py
+++ b/openlibrary/tests/core/test_tbp.py
@@ -1,0 +1,95 @@
+import datetime
+from typing import Final
+
+import pytest
+import web
+
+from openlibrary.core.db import get_db
+from openlibrary.core.tbp import FeedRegistry
+
+# sqlite-friendly DDL (Postgres uses serial/jsonb; sqlite is typeless).
+TBP_FEED_REGISTRY_DDL: Final = """
+CREATE TABLE tbp_feed_registry (
+    id integer primary key,
+    provider_name text not null,
+    feed_type text not null,
+    url text not null,
+    last_updated timestamp default null,
+    data text not null default '{}',
+    created timestamp default current_timestamp,
+    updated timestamp default current_timestamp,
+    UNIQUE (provider_name, url)
+);
+"""
+
+SEED: Final = [
+    {
+        "id": 1,
+        "provider_name": "betterworldbooks",
+        "feed_type": "opds",
+        "url": "https://www.betterworldbooks.com/opds",
+    },
+    {
+        "id": 2,
+        "provider_name": "lenny",
+        "feed_type": "opds",
+        "url": "https://lennyforlibraries.org/v1/api/opds",
+    },
+]
+
+
+@pytest.fixture(scope="module")
+def setup_db():
+    web.config.db_parameters = {"dbn": "sqlite", "db": ":memory:"}
+    db = get_db()
+    db.query(TBP_FEED_REGISTRY_DDL)
+    yield db
+    db.query("delete from tbp_feed_registry;")
+
+
+@pytest.fixture
+def registry_db(setup_db):
+    setup_db.multiple_insert("tbp_feed_registry", SEED)
+    yield setup_db
+    setup_db.query("delete from tbp_feed_registry;")
+
+
+class TestFeedRegistry:
+    def test_find_hit(self, registry_db):
+        row = FeedRegistry.find("betterworldbooks", "https://www.betterworldbooks.com/opds")
+        assert row is not None
+        assert row.id == 1
+        assert row.feed_type == "opds"
+
+    def test_find_miss(self, registry_db):
+        assert FeedRegistry.find("nope", "https://example.invalid/opds") is None
+
+    def test_get(self, registry_db):
+        assert FeedRegistry.get_by_id(2).provider_name == "lenny"
+        assert FeedRegistry.get_by_id(999) is None
+
+    def test_all(self, registry_db):
+        assert [r.provider_name for r in FeedRegistry.all()] == ["betterworldbooks", "lenny"]
+
+    def test_new(self, registry_db):
+        row = FeedRegistry.new("standard_ebooks", "https://standardebooks.org/opds", data={"k": "v"})
+        assert row is not None
+        assert row.feed_type == "opds"
+        assert row.data == {"k": "v"}
+        assert len(FeedRegistry.all()) == 3
+
+    def test_register_is_idempotent(self, registry_db):
+        first = FeedRegistry.register("betterworldbooks", "https://www.betterworldbooks.com/opds")
+        assert first.id == 1
+        # Second call must not create a duplicate row.
+        second = FeedRegistry.register("betterworldbooks", "https://www.betterworldbooks.com/opds")
+        assert second.id == 1
+        assert len(FeedRegistry.all()) == 2
+
+    def test_advance(self, registry_db):
+        cursor = datetime.datetime(2026, 6, 3, 12, 0, 0)
+        rows_changed = FeedRegistry.advance(1, last_updated=cursor, data={"cursor": "abc"})
+        assert rows_changed == 1
+        row = FeedRegistry.get_by_id(1)
+        assert str(row.last_updated).startswith("2026-06-03 12:00:00")
+        assert row.data == {"cursor": "abc"}

--- a/openlibrary/tests/core/test_tbp.py
+++ b/openlibrary/tests/core/test_tbp.py
@@ -148,3 +148,25 @@ class TestFeedRegistryMutations:
         row = FeedRegistry.get_by_id(2)
         assert row.feed_type == "onix"
         assert row.data == {"trust": "high"}
+
+
+class TestFeedRegistryLock:
+    def test_lock_blocks_second_acquire_then_unlock(self, registry_db):
+        assert FeedRegistry.try_lock(1) is True
+        assert FeedRegistry.try_lock(1) is False  # already held
+        assert FeedRegistry.get_by_id(1).data["status"] == "running"
+        assert FeedRegistry.unlock(1) == 1
+        row = FeedRegistry.get_by_id(1)
+        assert "locked_at" not in row.data
+        assert row.data["status"] == "idle"
+        assert FeedRegistry.try_lock(1) is True  # re-acquire after unlock
+
+    def test_stale_lock_is_taken_over(self, registry_db):
+        stale = datetime.datetime(2000, 1, 1)
+        assert FeedRegistry.try_lock(1, now=stale) is True
+        # A later attempt finds the 2000 lock older than ttl -> takes it over.
+        assert FeedRegistry.try_lock(1, ttl_seconds=60) is True
+
+    def test_lock_missing_feed(self, registry_db):
+        assert FeedRegistry.try_lock(999) is False
+        assert FeedRegistry.unlock(999) == 0

--- a/openlibrary/tests/core/test_tbp.py
+++ b/openlibrary/tests/core/test_tbp.py
@@ -134,3 +134,17 @@ class TestFeedRegistryFromRequest:
     def test_requires_provider_name_and_url(self, registry_db, payload):
         with pytest.raises(ValueError, match="required"):
             FeedRegistry.from_request(payload)
+
+
+class TestFeedRegistryMutations:
+    def test_delete(self, registry_db):
+        assert FeedRegistry.delete(1) == 1
+        assert FeedRegistry.get_by_id(1) is None
+        assert [r.provider_name for r in FeedRegistry.all()] == ["lenny"]
+
+    def test_update_fields(self, registry_db):
+        changed = FeedRegistry.update_fields(2, feed_type="onix", data={"trust": "high"})
+        assert changed == 1
+        row = FeedRegistry.get_by_id(2)
+        assert row.feed_type == "onix"
+        assert row.data == {"trust": "high"}

--- a/openlibrary/tests/core/test_tbp.py
+++ b/openlibrary/tests/core/test_tbp.py
@@ -93,3 +93,44 @@ class TestFeedRegistry:
         row = FeedRegistry.get_by_id(1)
         assert str(row.last_updated).startswith("2026-06-03 12:00:00")
         assert row.data == {"cursor": "abc"}
+
+
+class TestFeedRegistryFromRequest:
+    def test_creates_pending_feed_with_submitter(self, registry_db):
+        feed = FeedRegistry.from_request(
+            {"provider_name": "citapress", "url": "https://citapress.org/opds"},
+            submitter="/people/mek",
+        )
+        assert feed is not None
+        assert feed.feed_type == "opds"
+        # Registered feeds start "pending" — a maintainer must promote before
+        # the ingestion cron trusts them (accountability, #12844).
+        assert feed.data["status"] == "pending"
+        assert feed.data["submitter"] == "/people/mek"
+        assert len(FeedRegistry.all()) == 3
+
+    def test_is_idempotent(self, registry_db):
+        first = FeedRegistry.from_request({"provider_name": "betterworldbooks", "url": "https://www.betterworldbooks.com/opds"})
+        second = FeedRegistry.from_request({"provider_name": "betterworldbooks", "url": "https://www.betterworldbooks.com/opds"})
+        assert first.id == second.id == 1
+        assert len(FeedRegistry.all()) == 2
+
+    def test_honours_explicit_feed_type_and_contact(self, registry_db):
+        feed = FeedRegistry.from_request(
+            {
+                "provider_name": "some-onix-partner",
+                "url": "https://partner.example/onix",
+                "feed_type": "onix",
+                "contact": "partner@example.org",
+            }
+        )
+        assert feed.feed_type == "onix"
+        assert feed.data["contact"] == "partner@example.org"
+
+    @pytest.mark.parametrize(
+        "payload",
+        [{"url": "https://x/opds"}, {"provider_name": "x"}, {}, {"provider_name": "", "url": "https://y"}],
+    )
+    def test_requires_provider_name_and_url(self, registry_db, payload):
+        with pytest.raises(ValueError, match="required"):
+            FeedRegistry.from_request(payload)

--- a/scripts/bookworm.py
+++ b/scripts/bookworm.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""BookWorm feed-ingestion cron entrypoint (#12655 / #12844).
+
+Runs the staging pipeline — harvest registered feeds into the ``tbp_staged_record``
+buffer, then promote staged records into the import queue — once or on a loop.
+This is the command the ``bookworm`` container runs; it also runs on dev.
+
+DB routing: in production/dev the bookworm service should point its DB connection
+at the isolated ``staging-db`` (via ``conf/openlibrary.yml`` / ``db_parameters``),
+so bulk harvesting never contends with the production Open Library database.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+try:
+    import _init_path  # type: ignore[import-not-found]  # noqa: F401 side effect: add OL package root to sys.path
+except ImportError:
+    import scripts._init_path  # noqa: F401 same side effect when imported as a package
+
+from openlibrary.config import load_config
+from openlibrary.core import bookworm
+from scripts.solr_builder.solr_builder.fn_to_cli import FnToCLI
+
+logger = logging.getLogger("openlibrary.bookworm.cron")
+
+
+def main(ol_config: str, once: bool = False, interval: int = 3600, max_pages: int | None = None) -> None:
+    """Run the bookworm staging pipeline.
+
+    :param ol_config: Path to ``openlibrary.yml`` (should point db at staging-db).
+    :param once: Run a single cycle and exit, instead of looping.
+    :param interval: Seconds to sleep between cycles when looping.
+    :param max_pages: Optional cap on pagination depth per feed.
+    """
+    load_config(ol_config)
+    while True:
+        summary = bookworm.run_once(max_pages=max_pages)
+        logger.info("bookworm cycle: %s", summary)
+        if once:
+            return
+        time.sleep(interval)
+
+
+if __name__ == "__main__":
+    FnToCLI(main).run()

--- a/scripts/bwb_opds_imports.py
+++ b/scripts/bwb_opds_imports.py
@@ -55,6 +55,7 @@ from infogami import config  # noqa: F401 side effects may be needed
 from openlibrary.config import load_config
 from openlibrary.core.acquisitions import Acquisition
 from openlibrary.core.imports import Batch
+from openlibrary.core.tbp import FeedRegistry
 from openlibrary.core.vendors import stage_bookworm_metadata
 from openlibrary.plugins.upstream.utils import get_marc21_language
 from openlibrary.utils.isbn import to_isbn_13
@@ -106,6 +107,52 @@ def _parse_iso(value: str) -> datetime.datetime:
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=datetime.UTC)
     return dt.astimezone(datetime.UTC)
+
+
+def _coerce_utc(value: datetime.datetime | str) -> datetime.datetime:
+    """Normalise a DB timestamp (naive UTC, or an sqlite string) to aware UTC."""
+    if isinstance(value, str):
+        return _parse_iso(value)
+    if value.tzinfo is None:
+        return value.replace(tzinfo=datetime.UTC)
+    return value.astimezone(datetime.UTC)
+
+
+def resolve_cutoff(
+    feed_url: str,
+    since: str | None,
+    state_file: str,
+    provider_name: str = BWB_PROVIDER_NAME,
+) -> datetime.datetime:
+    """Return the incremental cutoff for this run.
+
+    Precedence: an explicit ``--since`` override > the FeedRegistry cursor
+    (the source of truth once the feed is registered) > the file-state
+    fallback > the epoch. The file-state remains only as a fallback for feeds
+    not yet in the registry (#12844).
+    """
+    if since:
+        return _parse_iso(since)
+    feed = FeedRegistry.find(provider_name, feed_url)
+    if feed and feed.get("last_updated"):
+        return _coerce_utc(feed.last_updated)
+    return read_state(state_file)
+
+
+def advance_cursor(
+    feed_url: str,
+    max_modified: datetime.datetime,
+    state_file: str,
+    provider_name: str = BWB_PROVIDER_NAME,
+) -> None:
+    """Persist ingestion progress.
+
+    Advances the FeedRegistry cursor (source of truth) when the feed is
+    registered, and always updates the file-state fallback.
+    """
+    if feed := FeedRegistry.find(provider_name, feed_url):
+        FeedRegistry.advance(feed.id, last_updated=max_modified.replace(tzinfo=None))
+    write_state(state_file, max_modified)
 
 
 def extract_isbn(metadata: dict[str, Any]) -> str | None:
@@ -436,12 +483,16 @@ def main(
         than the cutoff. OPDS spec does not mandate sort-by-modified, so leave disabled until
         BWB's feed order is empirically confirmed.
     """
-    cutoff = _parse_iso(since) if since else read_state(state_file)
     batch_name = f"bwb-opds-{datetime.datetime.now(datetime.UTC):%Y-%m-%d}"
-    logger.info("Starting BWB OPDS import: cutoff=%s batch=%s", cutoff.isoformat(), batch_name)
 
-    if not dry_run:
+    if dry_run:
+        # Don't touch the DB in dry-run: file-state (or --since) only.
+        cutoff = _parse_iso(since) if since else read_state(state_file)
+    else:
         load_config(ol_config)
+        cutoff = resolve_cutoff(feed_url, since, state_file)
+
+    logger.info("Starting BWB OPDS import: cutoff=%s batch=%s", cutoff.isoformat(), batch_name)
 
     olbooks, max_modified = _run_feed(
         feed_url=feed_url,
@@ -464,10 +515,10 @@ def main(
         commit_batch(batch_name, olbooks)
 
     if max_modified > cutoff:
-        write_state(state_file, max_modified)
-        logger.info("Wrote new state: %s", max_modified.isoformat())
+        advance_cursor(feed_url, max_modified, state_file)
+        logger.info("Advanced cursor to %s (registry + file-state)", max_modified.isoformat())
     else:
-        logger.info("No newer publications since %s; leaving state file untouched.", cutoff.isoformat())
+        logger.info("No newer publications since %s; leaving cursor untouched.", cutoff.isoformat())
 
 
 if __name__ == "__main__":

--- a/scripts/bwb_opds_imports.py
+++ b/scripts/bwb_opds_imports.py
@@ -45,6 +45,7 @@ import time
 from typing import Any
 
 import requests
+import web
 
 try:
     import _init_path  # type: ignore[import-not-found]  # noqa: F401 side effect: add OL package root to sys.path
@@ -58,6 +59,7 @@ from openlibrary.core.imports import Batch
 from openlibrary.core.tbp import FeedRegistry
 from openlibrary.core.vendors import stage_bookworm_metadata
 from openlibrary.plugins.upstream.utils import get_marc21_language
+from openlibrary.utils import extract_numeric_id_from_olid
 from openlibrary.utils.isbn import to_isbn_13
 from scripts.partner_batch_imports import is_low_quality_book, is_published_in_future_year
 from scripts.solr_builder.solr_builder.fn_to_cli import FnToCLI
@@ -283,6 +285,7 @@ def process_feed(
     prices_out_fh,
     max_pages: int | None = None,
     early_stop: bool = False,
+    acquisitions_out: list[tuple[str, dict[str, Any]]] | None = None,
 ) -> tuple[list[dict[str, Any]], datetime.datetime]:
     """Crawl the OPDS feed and return (olbooks, max_modified_seen).
 
@@ -330,6 +333,9 @@ def process_feed(
             if _should_exclude(olbook):
                 continue
             olbooks.append(olbook)
+
+            if acquisitions_out is not None and (acq_data := build_acquisition_data(publication)):
+                acquisitions_out.append((olbook["isbn_13"][0], acq_data))
 
             if price := extract_price(publication):
                 prices_out_fh.write(
@@ -418,14 +424,15 @@ def _run_feed(
     max_pages: int | None,
     dry_run: bool,
     early_stop: bool = False,
+    acquisitions_out: list[tuple[str, dict[str, Any]]] | None = None,
 ) -> tuple[list[dict[str, Any]], datetime.datetime]:
     """Process the OPDS feed, routing price rows to disk or to a discard buffer."""
     if dry_run:
         with contextlib.nullcontext(io.StringIO()) as prices_fh:
-            return process_feed(feed_url, cutoff, prices_fh, max_pages=max_pages, early_stop=early_stop)
+            return process_feed(feed_url, cutoff, prices_fh, max_pages=max_pages, early_stop=early_stop, acquisitions_out=acquisitions_out)
     writer = _LazyWriter(prices_out)
     try:
-        return process_feed(feed_url, cutoff, writer, max_pages=max_pages, early_stop=early_stop)
+        return process_feed(feed_url, cutoff, writer, max_pages=max_pages, early_stop=early_stop, acquisitions_out=acquisitions_out)
     finally:
         writer.close()
 
@@ -449,6 +456,69 @@ def upsert_acquisition(
         provider_name=BWB_PROVIDER_NAME,
         local_id=f"{ISBN_URN_PREFIX}{isbn_13}",
         data=build_acquisition_data(publication),
+    )
+
+
+def resolve_edition_ids(isbn_13: str) -> tuple[int, int] | None:
+    """Resolve an ISBN-13 to ``(work_id, edition_id)`` integers for an edition
+    ALREADY in the catalog, or None.
+
+    Existing editions only — no import/Amazon side effects. This is option (a)
+    from #12844: acquisitions attach at ingestion time for ISBNs that already
+    resolve; editions created later by the import get their acquisition linked
+    by :func:`link_acquisition_for_edition` (the post-import hook). Ids are the
+    numeric OLID parts, matching the convention used by checkins/bookshelves.
+    """
+    matches = web.ctx.site.things({"type": "/type/edition", "isbn_13": isbn_13})
+    if not matches:
+        return None
+    edition = web.ctx.site.get(matches[0])
+    if not edition or not edition.works:
+        return None
+    work_id = int(extract_numeric_id_from_olid(edition.works[0].key))
+    edition_id = int(extract_numeric_id_from_olid(edition.key))
+    return work_id, edition_id
+
+
+def stage_acquisitions(acquisitions: list[tuple[str, dict[str, Any]]]) -> int:
+    """Upsert acquisition rows for feed records whose ISBN resolves to an
+    existing edition. Returns the number upserted. Unresolved ISBNs are left
+    for the post-import hook once their edition is created.
+    """
+    upserted = 0
+    for isbn_13, data in acquisitions:
+        if not (ids := resolve_edition_ids(isbn_13)):
+            continue
+        work_id, edition_id = ids
+        Acquisition.upsert(
+            work_id=work_id,
+            edition_id=edition_id,
+            provider_name=BWB_PROVIDER_NAME,
+            local_id=f"{ISBN_URN_PREFIX}{isbn_13}",
+            data=data,
+        )
+        upserted += 1
+    return upserted
+
+
+def link_acquisition_for_edition(edition_key: str, publication: dict[str, Any]) -> Acquisition | None:
+    """Post-import hook: link a BWB acquisition to a newly-created edition.
+
+    Called once the import pipeline has created the edition for a ``bwb:{isbn}``
+    source record (option (a) from #12844 — the deferred half of
+    :func:`stage_acquisitions`).
+    """
+    edition = web.ctx.site.get(edition_key)
+    if not edition or not edition.works:
+        return None
+    isbn_13 = (edition.isbn_13 or [None])[0]
+    if not isbn_13:
+        return None
+    return upsert_acquisition(
+        work_id=int(extract_numeric_id_from_olid(edition.works[0].key)),
+        edition_id=int(extract_numeric_id_from_olid(edition.key)),
+        isbn_13=isbn_13,
+        publication=publication,
     )
 
 
@@ -494,6 +564,7 @@ def main(
 
     logger.info("Starting BWB OPDS import: cutoff=%s batch=%s", cutoff.isoformat(), batch_name)
 
+    acquisitions: list[tuple[str, dict[str, Any]]] = []
     olbooks, max_modified = _run_feed(
         feed_url=feed_url,
         cutoff=cutoff,
@@ -501,6 +572,7 @@ def main(
         max_pages=max_pages,
         dry_run=dry_run,
         early_stop=early_stop,
+        acquisitions_out=acquisitions,
     )
 
     logger.info("Mapped %d new publications (max_modified=%s)", len(olbooks), max_modified.isoformat())
@@ -513,6 +585,12 @@ def main(
     if olbooks:
         stage_incomplete_records_for_import(olbooks)
         commit_batch(batch_name, olbooks)
+
+    if acquisitions:
+        # Option (a): attach acquisitions for ISBNs that already resolve to an
+        # existing edition; the rest are linked post-import once created.
+        linked = stage_acquisitions(acquisitions)
+        logger.info("Upserted %d/%d acquisitions for already-resolved editions", linked, len(acquisitions))
 
     if max_modified > cutoff:
         advance_cursor(feed_url, max_modified, state_file)

--- a/scripts/bwb_opds_imports.py
+++ b/scripts/bwb_opds_imports.py
@@ -53,6 +53,7 @@ except ImportError:
 
 from infogami import config  # noqa: F401 side effects may be needed
 from openlibrary.config import load_config
+from openlibrary.core.acquisitions import Acquisition
 from openlibrary.core.imports import Batch
 from openlibrary.core.vendors import stage_bookworm_metadata
 from openlibrary.plugins.upstream.utils import get_marc21_language
@@ -64,6 +65,7 @@ logger = logging.getLogger("openlibrary.importer.bwb_opds")
 
 OPDS_FEED_URL = "https://www.betterworldbooks.com/opds"
 ACQUISITION_REL = "http://opds-spec.org/acquisition/buy"
+BWB_PROVIDER_NAME = "betterworldbooks"
 ISBN_URN_PREFIX = "urn:isbn:"
 DEFAULT_STATE_FILE = "/openlibrary/data/bwb_opds_last_run.txt"
 DEFAULT_PRICES_OUT = "/openlibrary/data/bwb_prices.jsonl"
@@ -124,6 +126,28 @@ def extract_price(publication: dict[str, Any]) -> dict[str, Any] | None:
         if price.get("value") is not None and price.get("currency"):
             return {"currency": price["currency"], "value": price["value"]}
     return None
+
+
+def build_acquisition_data(publication: dict[str, Any]) -> dict[str, Any]:
+    """Extract BWB provider acquisition metadata (price, buy url, formats).
+
+    Stored verbatim in the ``acquisitions.data`` blob for a resolved edition so
+    downstream indexing can search by price/format (issues #12844, #11264).
+    """
+    data: dict[str, Any] = {}
+    if price := extract_price(publication):
+        data["price"] = price
+    for link in publication.get("links", []) or []:
+        if link.get("rel") != ACQUISITION_REL:
+            continue
+        if href := link.get("href"):
+            data["url"] = href
+        properties = link.get("properties") or {}
+        formats = [fmt["type"] for fmt in (properties.get("indirectAcquisition") or []) if fmt.get("type")]
+        if formats:
+            data["formats"] = formats
+        break
+    return data
 
 
 def extract_cover(publication: dict[str, Any]) -> str | None:
@@ -357,6 +381,28 @@ def _run_feed(
         return process_feed(feed_url, cutoff, writer, max_pages=max_pages, early_stop=early_stop)
     finally:
         writer.close()
+
+
+def upsert_acquisition(
+    work_id: int,
+    edition_id: int,
+    isbn_13: str,
+    publication: dict[str, Any],
+) -> Acquisition | None:
+    """Upsert the BWB acquisition row for an already-resolved (work, edition).
+
+    Idempotent on the ``(local_id, provider_name)`` unique constraint, so
+    re-running the feed refreshes price/format metadata rather than creating
+    duplicate rows. ``local_id`` is the ISBN URN, matching the OPDS
+    ``metadata.identifier``.
+    """
+    return Acquisition.upsert(
+        work_id=work_id,
+        edition_id=edition_id,
+        provider_name=BWB_PROVIDER_NAME,
+        local_id=f"{ISBN_URN_PREFIX}{isbn_13}",
+        data=build_acquisition_data(publication),
+    )
 
 
 def commit_batch(batch_name: str, olbooks: list[dict[str, Any]], batch_size: int = 1000) -> None:

--- a/scripts/bwb_opds_imports.py
+++ b/scripts/bwb_opds_imports.py
@@ -2,30 +2,23 @@
 """
 Daily incremental importer for Better World Books via OPDS 2.0 feed.
 
-Replaces the monthly Better World Books CSV import (see
-``partner_batch_imports.py``) with a JSON-feed crawl that filters
-publications by ``metadata.modified`` relative to the previous run.
+Better World Books is the first consumer of the generic OPDS 2.0 adapter in
+``openlibrary.catalog.opds2``. This module supplies only the BWB-specific
+``Source`` config (import source-id prefix + quality filter) and the
+orchestration around a run: batch staging, acquisition upserts, and the
+FeedRegistry incremental cursor. Onboarding another OPDS feed should not need a
+new script — register it and reuse the adapter.
 
 Two outputs are produced per run:
 
 1. Import items written to the ``bwb-opds-YYYY-MM-DD`` batch (consumed by
    ``/api/import``). Records reuse the existing ``bwb:{isbn_13}`` source slug
-   so the import API deduplicates against the monthly CSV pipeline rather
-   than creating parallel edition records.
-2. A JSONL sidecar of ``{isbn_13, price, currency, modified}`` rows used by
-   the partial-update job that populates the Solr ``price`` field (see
-   issue #12774, sub-task 2). The file is opened lazily — a run with zero
-   fresh price rows leaves any prior snapshot untouched so the Solr updater
-   never sees a half-empty handoff.
-
-Open coordination items (tracked on issue #12774):
-
-* Relationship to #11264's proposed Solr ``acquisitions`` array (overlaps
-  with ``price`` + ``price_isbn``) — to be reconciled before sub-task 2.
-* Runtime price lookup in ``openlibrary.core.vendors.get_betterworldbooks_metadata``
-  vs. this batch-cached price path — both currently coexist.
-* Sidecar path / retention policy is owner-configurable via ``--prices-out``;
-  default lives under the OL data dir.
+   so the import API deduplicates against the monthly CSV pipeline rather than
+   creating parallel edition records.
+2. A JSONL sidecar of ``{isbn_13, price, currency}`` rows used by the
+   partial-update job that populates the Solr ``price`` field. The file is
+   opened lazily so a run with zero fresh price rows leaves any prior snapshot
+   untouched.
 
 Usage (on ``ol-home0`` cron container)::
 
@@ -41,7 +34,6 @@ import io
 import json
 import logging
 import os
-import time
 from typing import Any
 
 import requests
@@ -53,28 +45,63 @@ except ImportError:
     import scripts._init_path  # noqa: F401 same side effect when imported as a package
 
 from infogami import config  # noqa: F401 side effects may be needed
+from openlibrary.catalog import opds2
+from openlibrary.catalog.opds2 import EPOCH, ISBN_URN_PREFIX, Source, build_acquisition_data, parse_iso
 from openlibrary.config import load_config
 from openlibrary.core.acquisitions import Acquisition
 from openlibrary.core.imports import Batch
 from openlibrary.core.tbp import FeedRegistry
 from openlibrary.core.vendors import stage_bookworm_metadata
-from openlibrary.plugins.upstream.utils import get_marc21_language
 from openlibrary.utils import extract_numeric_id_from_olid
-from openlibrary.utils.isbn import to_isbn_13
 from scripts.partner_batch_imports import is_low_quality_book, is_published_in_future_year
 from scripts.solr_builder.solr_builder.fn_to_cli import FnToCLI
 
 logger = logging.getLogger("openlibrary.importer.bwb_opds")
 
 OPDS_FEED_URL = "https://www.betterworldbooks.com/opds"
-ACQUISITION_REL = "http://opds-spec.org/acquisition/buy"
 BWB_PROVIDER_NAME = "betterworldbooks"
-ISBN_URN_PREFIX = "urn:isbn:"
 DEFAULT_STATE_FILE = "/openlibrary/data/bwb_opds_last_run.txt"
 DEFAULT_PRICES_OUT = "/openlibrary/data/bwb_prices.jsonl"
-EPOCH = datetime.datetime(1970, 1, 1, tzinfo=datetime.UTC)
-REQUEST_TIMEOUT = 60
-PAGE_SLEEP_SECONDS = 1.0
+
+
+def _bwb_record_filter(olbook: dict[str, Any]) -> bool:
+    """BWB quality filter: drop low-quality reprints / future-dated books, so the
+    OPDS pipeline excludes the same noise the monthly CSV importer does."""
+    return is_low_quality_book(olbook) or is_published_in_future_year(olbook)
+
+
+# BWB's specialization of the generic OPDS 2.0 adapter. Per-feed quirks live
+# here (centrally), not in a forked script.
+BWB_SOURCE = Source(
+    provider_name=BWB_PROVIDER_NAME,
+    source_id_prefix="bwb",
+    record_filter=_bwb_record_filter,
+)
+
+
+def map_publication_to_olbook(publication: dict[str, Any]) -> dict[str, Any] | None:
+    """BWB-bound convenience wrapper over :func:`opds2.map_publication_to_olbook`."""
+    return opds2.map_publication_to_olbook(publication, BWB_SOURCE)
+
+
+def process_feed(
+    feed_url: str,
+    since: datetime.datetime,
+    prices_out_fh,
+    max_pages: int | None = None,
+    early_stop: bool = False,
+    acquisitions_out: list[tuple[str, dict[str, Any]]] | None = None,
+) -> tuple[list[dict[str, Any]], datetime.datetime]:
+    """BWB-bound convenience wrapper over :func:`opds2.process_feed`."""
+    return opds2.process_feed(
+        feed_url,
+        since,
+        prices_out_fh,
+        BWB_SOURCE,
+        max_pages=max_pages,
+        early_stop=early_stop,
+        acquisitions_out=acquisitions_out,
+    )
 
 
 def read_state(path: str) -> datetime.datetime:
@@ -86,7 +113,7 @@ def read_state(path: str) -> datetime.datetime:
         return EPOCH
     if not raw:
         return EPOCH
-    return _parse_iso(raw)
+    return parse_iso(raw)
 
 
 def write_state(path: str, ts: datetime.datetime) -> None:
@@ -99,22 +126,10 @@ def write_state(path: str, ts: datetime.datetime) -> None:
     os.replace(tmp, path)
 
 
-def _parse_iso(value: str) -> datetime.datetime:
-    """Parse an ISO 8601 timestamp, normalising to a tz-aware UTC datetime.
-
-    BWB emits high-precision offsets like ``2026-05-19T14:47:58.5476301-04:00``
-    which ``datetime.fromisoformat`` accepts on Python 3.11+.
-    """
-    dt = datetime.datetime.fromisoformat(value)
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=datetime.UTC)
-    return dt.astimezone(datetime.UTC)
-
-
 def _coerce_utc(value: datetime.datetime | str) -> datetime.datetime:
     """Normalise a DB timestamp (naive UTC, or an sqlite string) to aware UTC."""
     if isinstance(value, str):
-        return _parse_iso(value)
+        return parse_iso(value)
     if value.tzinfo is None:
         return value.replace(tzinfo=datetime.UTC)
     return value.astimezone(datetime.UTC)
@@ -128,13 +143,13 @@ def resolve_cutoff(
 ) -> datetime.datetime:
     """Return the incremental cutoff for this run.
 
-    Precedence: an explicit ``--since`` override > the FeedRegistry cursor
-    (the source of truth once the feed is registered) > the file-state
-    fallback > the epoch. The file-state remains only as a fallback for feeds
-    not yet in the registry (#12844).
+    Precedence: an explicit ``--since`` override > the FeedRegistry cursor (the
+    source of truth once the feed is registered) > the file-state fallback >
+    the epoch. The file-state remains only as a fallback for feeds not yet in
+    the registry (#12844).
     """
     if since:
-        return _parse_iso(since)
+        return parse_iso(since)
     feed = FeedRegistry.find(provider_name, feed_url)
     if feed and feed.get("last_updated"):
         return _coerce_utc(feed.last_updated)
@@ -155,286 +170,6 @@ def advance_cursor(
     if feed := FeedRegistry.find(provider_name, feed_url):
         FeedRegistry.advance(feed.id, last_updated=max_modified.replace(tzinfo=None))
     write_state(state_file, max_modified)
-
-
-def extract_isbn(metadata: dict[str, Any]) -> str | None:
-    """Return the ISBN-13 from an OPDS ``metadata.identifier`` URN, or None."""
-    identifier = metadata.get("identifier") or ""
-    if not identifier.startswith(ISBN_URN_PREFIX):
-        return None
-    return to_isbn_13(identifier[len(ISBN_URN_PREFIX) :])
-
-
-def extract_price(publication: dict[str, Any]) -> dict[str, Any] | None:
-    """Return ``{currency, value}`` from the first buy-acquisition link, or None."""
-    for link in publication.get("links", []) or []:
-        if link.get("rel") != ACQUISITION_REL:
-            continue
-        properties = link.get("properties") or {}
-        price = properties.get("price") or {}
-        if price.get("value") is not None and price.get("currency"):
-            return {"currency": price["currency"], "value": price["value"]}
-    return None
-
-
-def build_acquisition_data(publication: dict[str, Any]) -> dict[str, Any]:
-    """Extract BWB provider acquisition metadata (price, buy url, formats).
-
-    Stored verbatim in the ``acquisitions.data`` blob for a resolved edition so
-    downstream indexing can search by price/format (issues #12844, #11264).
-    """
-    data: dict[str, Any] = {}
-    if price := extract_price(publication):
-        data["price"] = price
-    for link in publication.get("links", []) or []:
-        if link.get("rel") != ACQUISITION_REL:
-            continue
-        if href := link.get("href"):
-            data["url"] = href
-        properties = link.get("properties") or {}
-        formats = [fmt["type"] for fmt in (properties.get("indirectAcquisition") or []) if fmt.get("type")]
-        if formats:
-            data["formats"] = formats
-        break
-    return data
-
-
-def extract_cover(publication: dict[str, Any]) -> str | None:
-    for image in publication.get("images", []) or []:
-        if image.get("rel") == "cover" and image.get("href"):
-            return image["href"]
-    return None
-
-
-def _publication_id(publication: dict[str, Any]) -> str:
-    """Return the publication's ``self`` link or raw identifier, for logging."""
-    for link in publication.get("links", []) or []:
-        if link.get("rel") == "self" and link.get("href"):
-            return link["href"]
-    return (publication.get("metadata") or {}).get("identifier") or "<unknown>"
-
-
-def map_publication_to_olbook(publication: dict[str, Any]) -> dict[str, Any] | None:
-    """Convert an OPDS publication to an OL import record.
-
-    Returns None when the publication lacks ISBN-13, title, or authors —
-    matching the spec sketch in issue #12774 which requires all three.
-    """
-    metadata = publication.get("metadata") or {}
-    isbn_13 = extract_isbn(metadata)
-    if not isbn_13:
-        logger.warning("Skipping publication with no usable ISBN: %s", _publication_id(publication))
-        return None
-
-    title = metadata.get("title")
-    authors = [{"name": a["name"]} for a in (metadata.get("author") or []) if a.get("name")]
-    if not title or not authors:
-        logger.warning("Skipping publication missing title/authors: %s", _publication_id(publication))
-        return None
-
-    languages = [marc for code in (metadata.get("language") or []) if code and (marc := get_marc21_language(code))]
-
-    olbook: dict[str, Any] = {
-        "title": title,
-        "isbn_13": [isbn_13],
-        "source_records": [f"bwb:{isbn_13}"],
-        "authors": authors,
-        "languages": languages,
-        "publish_date": metadata.get("published", ""),
-        "publishers": [],  # OPDS feed does not include publisher
-    }
-    if cover := extract_cover(publication):
-        olbook["cover"] = cover
-    return olbook
-
-
-def find_next_url(feed: dict[str, Any]) -> str | None:
-    for link in feed.get("links", []) or []:
-        if link.get("rel") == "next" and link.get("href"):
-            return link["href"]
-    return None
-
-
-def iter_pages(start_url: str, session: requests.Session, max_pages: int | None = None):
-    """Yield successive OPDS feed pages, following ``rel=next`` links."""
-    url: str | None = start_url
-    seen: set[str] = set()
-    page_num = 0
-    while url:
-        if url in seen:
-            logger.warning("Cycle detected in OPDS pagination at %s; stopping.", url)
-            return
-        seen.add(url)
-        page_num += 1
-        if max_pages is not None and page_num > max_pages:
-            logger.info("Reached --max-pages=%s; stopping pagination.", max_pages)
-            return
-        logger.info("Fetching OPDS page %d: %s", page_num, url)
-        resp = session.get(url, timeout=REQUEST_TIMEOUT, headers={"Accept": "application/opds+json"})
-        resp.raise_for_status()
-        feed = resp.json()
-        yield feed
-        url = find_next_url(feed)
-        if url:
-            time.sleep(PAGE_SLEEP_SECONDS)
-
-
-def process_feed(
-    feed_url: str,
-    since: datetime.datetime,
-    prices_out_fh,
-    max_pages: int | None = None,
-    early_stop: bool = False,
-    acquisitions_out: list[tuple[str, dict[str, Any]]] | None = None,
-) -> tuple[list[dict[str, Any]], datetime.datetime]:
-    """Crawl the OPDS feed and return (olbooks, max_modified_seen).
-
-    Records are filtered to those with ``metadata.modified > since``. Price
-    rows are written to ``prices_out_fh`` as they are encountered. The state
-    cursor advances on every publication that is newer than ``since``, even
-    when mapping fails — otherwise an unmappable but newer record would force
-    every subsequent run to re-scan it forever.
-
-    Quality filters from ``partner_batch_imports`` (low-quality independently
-    published reprints, future-dated publications) are applied so the OPDS
-    pipeline excludes the same noise the monthly CSV importer does.
-
-    ``early_stop`` (off by default): when enabled, pagination halts once a
-    whole page contains zero records newer than ``since``. OPDS feeds are
-    not guaranteed by spec to be sorted by ``modified``, so leave this off
-    until BWB's ordering is confirmed empirically — otherwise an
-    out-of-order stale page would cause the incremental run to miss fresh
-    publications on later pages. Enable via ``--early-stop`` once verified.
-    """
-    session = requests.Session()
-    olbooks: list[dict[str, Any]] = []
-    max_modified = since
-
-    for feed in iter_pages(feed_url, session, max_pages=max_pages):
-        fresh_in_page = 0
-        for publication in feed.get("publications", []) or []:
-            metadata = publication.get("metadata") or {}
-            modified_raw = metadata.get("modified")
-            if not modified_raw:
-                continue
-            try:
-                modified = _parse_iso(modified_raw)
-            except ValueError:
-                logger.warning("Skipping publication with unparsable modified=%r", modified_raw)
-                continue
-            if modified <= since:
-                continue
-            fresh_in_page += 1
-            max_modified = max(max_modified, modified)
-
-            olbook = map_publication_to_olbook(publication)
-            if not olbook:
-                continue
-            if _should_exclude(olbook):
-                continue
-            olbooks.append(olbook)
-
-            if acquisitions_out is not None and (acq_data := build_acquisition_data(publication)):
-                acquisitions_out.append((olbook["isbn_13"][0], acq_data))
-
-            if price := extract_price(publication):
-                prices_out_fh.write(
-                    json.dumps(
-                        {
-                            "isbn_13": olbook["isbn_13"][0],
-                            "price": price["value"],
-                            "currency": price["currency"],
-                        }
-                    )
-                    + "\n"
-                )
-
-        if early_stop and fresh_in_page == 0:
-            logger.info("Page contains no records newer than %s; stopping (feed is modified-desc).", since.isoformat())
-            break
-
-    return olbooks, max_modified
-
-
-def _should_exclude(olbook: dict[str, Any]) -> bool:
-    """Apply partner-import quality filters to an OPDS-derived record."""
-    # The CSV-path filters expect a ``title``; treat title-less records as
-    # noise on the strict-quality path too.
-    if not olbook.get("title"):
-        return False
-    try:
-        if is_low_quality_book(olbook):
-            return True
-        if is_published_in_future_year(olbook):
-            return True
-    except (KeyError, ValueError, TypeError) as e:
-        logger.warning("Quality filter failed for %s: %s", olbook.get("isbn_13"), e)
-    return False
-
-
-def stage_incomplete_records_for_import(olbooks: list[dict[str, Any]]) -> None:
-    """Mirror of ``promise_batch_imports.stage_incomplete_records_for_import``.
-
-    For records lacking title/authors/publish_date, ask BookWorm to stage a
-    richer record so ``/api/import`` can merge in extra metadata. See
-    https://github.com/internetarchive/openlibrary/issues/9440.
-    """
-    required_fields = ("title", "authors", "publish_date")
-    for book in olbooks:
-        if all(book.get(field) for field in required_fields):
-            continue
-        isbn_list = book.get("isbn_13") or []
-        isbn = isbn_list[0] if isbn_list else None
-        if not isbn:
-            continue
-        try:
-            stage_bookworm_metadata(identifier=isbn)
-        except requests.exceptions.ConnectionError:
-            logger.exception("Affiliate Server unreachable")
-            continue
-
-
-class _LazyWriter:
-    """File-like wrapper that opens ``path`` only on the first ``write``.
-
-    Used so a run with zero fresh price rows does not clobber a prior
-    snapshot that the Solr updater has not yet consumed.
-    """
-
-    def __init__(self, path: str) -> None:
-        self._path = path
-        self._fh: Any = None
-
-    def write(self, data: str) -> int:
-        if self._fh is None:
-            if parent := os.path.dirname(self._path):
-                os.makedirs(parent, exist_ok=True)
-            self._fh = open(self._path, "w")  # noqa: SIM115 lifetime managed by close()
-        return self._fh.write(data)
-
-    def close(self) -> None:
-        if self._fh is not None:
-            self._fh.close()
-
-
-def _run_feed(
-    feed_url: str,
-    cutoff: datetime.datetime,
-    prices_out: str,
-    max_pages: int | None,
-    dry_run: bool,
-    early_stop: bool = False,
-    acquisitions_out: list[tuple[str, dict[str, Any]]] | None = None,
-) -> tuple[list[dict[str, Any]], datetime.datetime]:
-    """Process the OPDS feed, routing price rows to disk or to a discard buffer."""
-    if dry_run:
-        with contextlib.nullcontext(io.StringIO()) as prices_fh:
-            return process_feed(feed_url, cutoff, prices_fh, max_pages=max_pages, early_stop=early_stop, acquisitions_out=acquisitions_out)
-    writer = _LazyWriter(prices_out)
-    try:
-        return process_feed(feed_url, cutoff, writer, max_pages=max_pages, early_stop=early_stop, acquisitions_out=acquisitions_out)
-    finally:
-        writer.close()
 
 
 def upsert_acquisition(
@@ -522,6 +257,71 @@ def link_acquisition_for_edition(edition_key: str, publication: dict[str, Any]) 
     )
 
 
+def stage_incomplete_records_for_import(olbooks: list[dict[str, Any]]) -> None:
+    """Mirror of ``promise_batch_imports.stage_incomplete_records_for_import``.
+
+    For records lacking title/authors/publish_date, ask BookWorm to stage a
+    richer record so ``/api/import`` can merge in extra metadata. See
+    https://github.com/internetarchive/openlibrary/issues/9440.
+    """
+    required_fields = ("title", "authors", "publish_date")
+    for book in olbooks:
+        if all(book.get(field) for field in required_fields):
+            continue
+        isbn_list = book.get("isbn_13") or []
+        isbn = isbn_list[0] if isbn_list else None
+        if not isbn:
+            continue
+        try:
+            stage_bookworm_metadata(identifier=isbn)
+        except requests.exceptions.ConnectionError:
+            logger.exception("Affiliate Server unreachable")
+            continue
+
+
+class _LazyWriter:
+    """File-like wrapper that opens ``path`` only on the first ``write``.
+
+    Used so a run with zero fresh price rows does not clobber a prior snapshot
+    that the Solr updater has not yet consumed.
+    """
+
+    def __init__(self, path: str) -> None:
+        self._path = path
+        self._fh: Any = None
+
+    def write(self, data: str) -> int:
+        if self._fh is None:
+            if parent := os.path.dirname(self._path):
+                os.makedirs(parent, exist_ok=True)
+            self._fh = open(self._path, "w")  # noqa: SIM115 lifetime managed by close()
+        return self._fh.write(data)
+
+    def close(self) -> None:
+        if self._fh is not None:
+            self._fh.close()
+
+
+def _run_feed(
+    feed_url: str,
+    cutoff: datetime.datetime,
+    prices_out: str,
+    max_pages: int | None,
+    dry_run: bool,
+    early_stop: bool = False,
+    acquisitions_out: list[tuple[str, dict[str, Any]]] | None = None,
+) -> tuple[list[dict[str, Any]], datetime.datetime]:
+    """Process the OPDS feed, routing price rows to disk or to a discard buffer."""
+    if dry_run:
+        with contextlib.nullcontext(io.StringIO()) as prices_fh:
+            return process_feed(feed_url, cutoff, prices_fh, max_pages=max_pages, early_stop=early_stop, acquisitions_out=acquisitions_out)
+    writer = _LazyWriter(prices_out)
+    try:
+        return process_feed(feed_url, cutoff, writer, max_pages=max_pages, early_stop=early_stop, acquisitions_out=acquisitions_out)
+    finally:
+        writer.close()
+
+
 def commit_batch(batch_name: str, olbooks: list[dict[str, Any]], batch_size: int = 1000) -> None:
     batch = Batch.find(batch_name) or Batch.new(batch_name)
     items = [{"ia_id": b["source_records"][0], "data": b} for b in olbooks]
@@ -557,7 +357,7 @@ def main(
 
     if dry_run:
         # Don't touch the DB in dry-run: file-state (or --since) only.
-        cutoff = _parse_iso(since) if since else read_state(state_file)
+        cutoff = parse_iso(since) if since else read_state(state_file)
     else:
         load_config(ol_config)
         cutoff = resolve_cutoff(feed_url, since, state_file)

--- a/scripts/tests/opds_sample.json
+++ b/scripts/tests/opds_sample.json
@@ -1,0 +1,163 @@
+{
+    "metadata": {
+        "title": "Better World Books",
+        "numberOfItems": 2,
+        "itemsPerPage": 50,
+        "currentPage": 1
+    },
+    "links": [
+        {
+            "rel": "self",
+            "href": "https://www.betterworldbooks.com/opds/",
+            "type": "application/opds+json"
+        },
+        {
+            "rel": "first",
+            "href": "https://www.betterworldbooks.com/opds/",
+            "type": "application/opds+json"
+        },
+        {
+            "rel": "last",
+            "href": "https://www.betterworldbooks.com/opds/",
+            "type": "application/opds+json"
+        },
+        {
+            "rel": "http://opds-spec.org/shelf",
+            "href": "https://www.betterworldbooks.com/My/Account/Orders",
+            "type": "text/html"
+        }
+    ],
+    "publications": [
+        {
+            "metadata": {
+                "type": "http://schema.org/Book",
+                "title": "The Brick House Apparent Quarterly, Vol. 1",
+                "identifier": "urn:isbn:9781737408802",
+                "author": [
+                    {
+                        "name": "The Brick House Cooperative"
+                    },
+                    {
+                        "name": "Maria Bustillos"
+                    },
+                    {
+                        "name": "David Moore"
+                    },
+                    {
+                        "name": "Kólá Túbósún"
+                    },
+                    {
+                        "name": "Joe MacLeod"
+                    }
+                ],
+                "language": [
+                    "en"
+                ],
+                "published": "2021-08-03",
+                "modified": "2026-06-16T10:59:50.1400407-04:00"
+            },
+            "links": [
+                {
+                    "rel": "self",
+                    "href": "https://www.betterworldbooks.com/opds/publication/9781737408802",
+                    "type": "application/opds-publication+json"
+                },
+                {
+                    "rel": "alternate",
+                    "href": "https://www.betterworldbooks.com/product/detail/the-brick-house-apparent-quarterly-vol-1-9781737408802/ebook",
+                    "type": "text/html"
+                },
+                {
+                    "rel": "http://opds-spec.org/shelf",
+                    "href": "https://www.betterworldbooks.com/My/Account/Orders",
+                    "type": "text/html"
+                },
+                {
+                    "rel": "http://opds-spec.org/acquisition/buy",
+                    "href": "https://www.betterworldbooks.com/purchase/9781737408802",
+                    "type": "text/html",
+                    "title": "Better World Books",
+                    "properties": {
+                        "indirectAcquisition": [
+                            {
+                                "type": "application/epub+zip"
+                            }
+                        ],
+                        "price": {
+                            "currency": "USD",
+                            "value": 1.25
+                        }
+                    }
+                }
+            ],
+            "images": [
+                {
+                    "href": "https://product-images.bwbcontent.com/173/62148414_The-Brick-House-Apparent-Quarterly-Vol-1-9781737408802_COV_167.jpg",
+                    "type": "image/jpeg",
+                    "rel": "cover"
+                }
+            ]
+        },
+        {
+            "metadata": {
+                "type": "http://schema.org/Book",
+                "title": "Vanishing Culture: A Report on Our Fragile Cultural Record",
+                "identifier": "urn:isbn:9798995425007",
+                "author": [
+                    {
+                        "name": "Chris Freeland"
+                    },
+                    {
+                        "name": "Luca Messarra"
+                    },
+                    {
+                        "name": "Juliya Ziskina"
+                    }
+                ],
+                "published": "2026-01-01",
+                "modified": "2026-06-16T13:02:54.4576888-04:00"
+            },
+            "links": [
+                {
+                    "rel": "self",
+                    "href": "https://www.betterworldbooks.com/opds/publication/9798995425007",
+                    "type": "application/opds-publication+json"
+                },
+                {
+                    "rel": "alternate",
+                    "href": "https://www.betterworldbooks.com/product/detail/vanishing-culture-a-report-on-our-fragile-cultural-record-9798995425007/ebook",
+                    "type": "text/html"
+                },
+                {
+                    "rel": "http://opds-spec.org/shelf",
+                    "href": "https://www.betterworldbooks.com/My/Account/Orders",
+                    "type": "text/html"
+                },
+                {
+                    "rel": "http://opds-spec.org/acquisition/buy",
+                    "href": "https://www.betterworldbooks.com/purchase/9798995425007",
+                    "type": "text/html",
+                    "title": "Better World Books",
+                    "properties": {
+                        "indirectAcquisition": [
+                            {
+                                "type": "application/epub+zip"
+                            }
+                        ],
+                        "price": {
+                            "currency": "USD",
+                            "value": 1.01
+                        }
+                    }
+                }
+            ],
+            "images": [
+                {
+                    "href": "https://product-images.bwbcontent.com/899/73038647_Vanishing-Culture-A-Report-on-Our-Fragile-Cultural-Record-9798995425007_COV_600.jpg",
+                    "type": "image/jpeg",
+                    "rel": "cover"
+                }
+            ]
+        }
+    ]
+}

--- a/scripts/tests/test_bwb_opds_imports.py
+++ b/scripts/tests/test_bwb_opds_imports.py
@@ -659,3 +659,98 @@ def test_advance_cursor_unregistered_feed_writes_only_file(registry_db, tmp_path
     bwb_opds_imports.advance_cursor(FEED_URL, ts, str(state))
     assert FeedRegistry.find("betterworldbooks", FEED_URL) is None
     assert bwb_opds_imports.read_state(str(state)) == ts
+
+
+# ---------------------------------------------------------------------------
+# Edition resolution + acquisition staging (epic #12844, option (a)): attach
+# acquisitions to ISBNs that already resolve to an edition; defer the rest to
+# the post-import hook.
+# ---------------------------------------------------------------------------
+
+
+class FakeWork:
+    def __init__(self, key):
+        self.key = key
+
+
+class FakeEdition:
+    def __init__(self, key, works, isbn_13=None):
+        self.key = key
+        self.works = works
+        self.isbn_13 = isbn_13 or []
+
+
+class FakeSite:
+    def __init__(self, thing_keys, editions):
+        self._thing_keys = thing_keys
+        self._editions = editions
+
+    def things(self, query):
+        return self._thing_keys
+
+    def get(self, key):
+        return self._editions.get(key)
+
+
+def _patch_site(monkeypatch, site):
+    # Set only web.ctx.site; do not replace web.ctx itself (the DB layer's
+    # infogami stats hook needs web.ctx to stay dict-like).
+    monkeypatch.setattr(bwb_opds_imports.web.ctx, "site", site, raising=False)
+
+
+def test_resolve_edition_ids_existing(monkeypatch):
+    site = FakeSite(["/books/OL55M"], {"/books/OL55M": FakeEdition("/books/OL55M", [FakeWork("/works/OL7W")])})
+    _patch_site(monkeypatch, site)
+    assert bwb_opds_imports.resolve_edition_ids("9781737408802") == (7, 55)
+
+
+def test_resolve_edition_ids_not_in_catalog(monkeypatch):
+    _patch_site(monkeypatch, FakeSite([], {}))
+    assert bwb_opds_imports.resolve_edition_ids("9781737408802") is None
+
+
+def test_resolve_edition_ids_edition_without_work(monkeypatch):
+    site = FakeSite(["/books/OL55M"], {"/books/OL55M": FakeEdition("/books/OL55M", [])})
+    _patch_site(monkeypatch, site)
+    assert bwb_opds_imports.resolve_edition_ids("9781737408802") is None
+
+
+def test_stage_acquisitions_only_resolved(monkeypatch, acquisitions_db):
+    monkeypatch.setattr(bwb_opds_imports, "resolve_edition_ids", {"9781737408802": (7, 55)}.get)
+    items = [
+        ("9781737408802", {"price": {"currency": "USD", "value": 1.25}}),
+        ("9798995425007", {"price": {"currency": "USD", "value": 1.01}}),
+    ]
+    assert bwb_opds_imports.stage_acquisitions(items) == 1
+    rows = Acquisition.get_by_edition(55, "betterworldbooks")
+    assert len(rows) == 1
+    assert rows[0].local_id == "urn:isbn:9781737408802"
+    assert rows[0].data["price"]["value"] == 1.25
+
+
+def test_stage_acquisitions_is_idempotent(monkeypatch, acquisitions_db):
+    monkeypatch.setattr(bwb_opds_imports, "resolve_edition_ids", lambda isbn: (7, 55))
+    items = [("9781737408802", {"price": {"currency": "USD", "value": 1.25}})]
+    bwb_opds_imports.stage_acquisitions(items)
+    bwb_opds_imports.stage_acquisitions(items)
+    assert len(Acquisition.get_by_edition(55, "betterworldbooks")) == 1
+
+
+def test_process_feed_collects_acquisitions(monkeypatch):
+    monkeypatch.setattr(bwb_opds_imports, "PAGE_SLEEP_SECONDS", 0)
+    session = FakeSession({SAMPLE_FEED_URL: SAMPLE_FEED})
+    monkeypatch.setattr(bwb_opds_imports.requests, "Session", lambda: session)
+    acqs: list = []
+    process_feed(feed_url=SAMPLE_FEED_URL, since=EPOCH, prices_out_fh=io.StringIO(), acquisitions_out=acqs)
+    assert {isbn for isbn, _ in acqs} == {"9781737408802", "9798995425007"}
+    assert dict(acqs)["9781737408802"]["price"] == {"currency": "USD", "value": 1.25}
+
+
+def test_link_acquisition_for_edition_post_import(monkeypatch, acquisitions_db):
+    ed = FakeEdition("/books/OL55M", [FakeWork("/works/OL7W")], isbn_13=["9781737408802"])
+    _patch_site(monkeypatch, FakeSite([], {"/books/OL55M": ed}))
+    result = bwb_opds_imports.link_acquisition_for_edition("/books/OL55M", SAMPLE_FEED["publications"][0])
+    assert result is not None
+    rows = Acquisition.get_by_edition(55, "betterworldbooks")
+    assert len(rows) == 1
+    assert rows[0].data["price"] == {"currency": "USD", "value": 1.25}

--- a/scripts/tests/test_bwb_opds_imports.py
+++ b/scripts/tests/test_bwb_opds_imports.py
@@ -7,6 +7,7 @@ from typing import Final
 import pytest
 import web
 
+from openlibrary.catalog import opds2
 from openlibrary.core.acquisitions import Acquisition
 from openlibrary.core.db import get_db
 from openlibrary.core.tbp import FeedRegistry
@@ -14,18 +15,17 @@ from openlibrary.core.tbp import FeedRegistry
 from .. import bwb_opds_imports
 from ..bwb_opds_imports import (
     EPOCH,
-    _parse_iso,
     commit_batch,
-    extract_cover,
-    extract_isbn,
-    extract_price,
-    find_next_url,
-    iter_pages,
     map_publication_to_olbook,
     process_feed,
     read_state,
     write_state,
 )
+
+# Generic OPDS 2.0 parsing/crawl is tested in openlibrary/catalog/tests/test_opds2.py.
+# This module covers the BWB-specific specialization + orchestration: the BWB
+# Source config, batch staging + idempotency, the FeedRegistry cursor, and the
+# acquisitions wiring.
 
 SAMPLE_PUBLICATION = {
     "metadata": {
@@ -48,127 +48,8 @@ SAMPLE_PUBLICATION = {
     "images": [{"href": "https://example.com/cover.jpg", "rel": "cover"}],
 }
 
-
-def test_extract_isbn_strips_urn_prefix():
-    assert extract_isbn({"identifier": "urn:isbn:9781737408802"}) == "9781737408802"
-
-
-def test_extract_isbn_returns_none_for_non_isbn_urn():
-    assert extract_isbn({"identifier": "urn:uuid:abc"}) is None
-    assert extract_isbn({}) is None
-
-
-def test_extract_isbn_promotes_isbn10():
-    # to_isbn_13 should upgrade a valid ISBN-10 to ISBN-13
-    assert extract_isbn({"identifier": "urn:isbn:0140328726"}) == "9780140328721"
-
-
-def test_extract_price_returns_first_buy_link():
-    assert extract_price(SAMPLE_PUBLICATION) == {"currency": "USD", "value": 1.1}
-
-
-def test_extract_price_returns_none_when_no_acquisition():
-    assert extract_price({"links": [{"rel": "self", "href": "x"}]}) is None
-    assert extract_price({}) is None
-
-
-def test_extract_price_returns_none_when_acquisition_missing_price():
-    pub = {"links": [{"rel": "http://opds-spec.org/acquisition/buy", "href": "x"}]}
-    assert extract_price(pub) is None
-
-
-def test_extract_cover():
-    assert extract_cover(SAMPLE_PUBLICATION) == "https://example.com/cover.jpg"
-    assert extract_cover({"images": [{"href": "x", "rel": "thumbnail"}]}) is None
-    assert extract_cover({}) is None
-
-
-def test_map_publication_basic_fields():
-    olbook = map_publication_to_olbook(SAMPLE_PUBLICATION)
-    assert olbook is not None
-    assert olbook["isbn_13"] == ["9781737408802"]
-    assert olbook["source_records"] == ["bwb:9781737408802"]
-    assert olbook["title"] == "The Brick House Apparent Quarterly, Vol. 1"
-    assert olbook["publish_date"] == "2021-08-03"
-    assert olbook["languages"] == ["eng"]
-    assert olbook["authors"] == [
-        {"name": "The Brick House Cooperative"},
-        {"name": "Maria Bustillos"},
-    ]
-    assert olbook["cover"] == "https://example.com/cover.jpg"
-    assert olbook["publishers"] == []
-    assert "local_id" not in olbook
-
-
-def test_map_publication_skips_missing_isbn():
-    pub = {"metadata": {"title": "No ISBN", "author": [{"name": "x"}]}}
-    assert map_publication_to_olbook(pub) is None
-
-
-def test_map_publication_skips_missing_title_or_authors():
-    no_title = {"metadata": {"identifier": "urn:isbn:9781737408802", "author": [{"name": "x"}]}}
-    no_authors = {"metadata": {"identifier": "urn:isbn:9781737408802", "title": "x"}}
-    assert map_publication_to_olbook(no_title) is None
-    assert map_publication_to_olbook(no_authors) is None
-
-
-def test_map_publication_languages_use_marc21():
-    pub = {
-        "metadata": {
-            "identifier": "urn:isbn:9781737408802",
-            "title": "x",
-            "author": [{"name": "a"}],
-            "language": ["en", "fr"],
-        }
-    }
-    olbook = map_publication_to_olbook(pub)
-    assert olbook is not None
-    assert olbook["languages"] == ["eng", "fre"]
-
-
-def test_map_publication_drops_unmappable_language():
-    pub = {
-        "metadata": {
-            "identifier": "urn:isbn:9781737408802",
-            "title": "x",
-            "author": [{"name": "a"}],
-            "language": ["zz-not-real"],
-        }
-    }
-    olbook = map_publication_to_olbook(pub)
-    assert olbook is not None
-    assert olbook["languages"] == []
-
-
-def test_parse_iso_handles_offset_and_naive():
-    dt = _parse_iso("2026-05-19T14:47:58.547630-04:00")
-    assert dt.tzinfo is datetime.UTC
-    assert dt == datetime.datetime(2026, 5, 19, 18, 47, 58, 547630, tzinfo=datetime.UTC)
-
-    naive = _parse_iso("2026-05-19T14:47:58")
-    assert naive.tzinfo is datetime.UTC
-
-
-def test_find_next_url_present_and_absent():
-    feed = {"links": [{"rel": "next", "href": "https://x/p2"}, {"rel": "self", "href": "x"}]}
-    assert find_next_url(feed) == "https://x/p2"
-    assert find_next_url({"links": [{"rel": "self", "href": "x"}]}) is None
-    assert find_next_url({}) is None
-
-
-def test_state_roundtrip(tmp_path: Path):
-    state_file = tmp_path / "state.txt"
-    assert read_state(str(state_file)) == EPOCH
-
-    ts = datetime.datetime(2026, 5, 22, 12, 0, 0, tzinfo=datetime.UTC)
-    write_state(str(state_file), ts)
-    assert read_state(str(state_file)) == ts
-
-
-def test_state_read_empty_file_returns_epoch(tmp_path: Path):
-    state_file = tmp_path / "state.txt"
-    state_file.write_text("")
-    assert read_state(str(state_file)) == EPOCH
+SAMPLE_FEED_URL: Final = "https://www.betterworldbooks.com/opds/"
+SAMPLE_FEED: Final = json.loads((Path(__file__).parent / "opds_sample.json").read_text())
 
 
 class FakeResponse:
@@ -192,203 +73,44 @@ class FakeSession:
         return FakeResponse(self.pages_by_url[url])
 
 
-def test_iter_pages_follows_next_link(monkeypatch):
-
-    monkeypatch.setattr(bwb_opds_imports, "PAGE_SLEEP_SECONDS", 0)
-    pages = {
-        "https://x/p1": {"publications": [{"id": 1}], "links": [{"rel": "next", "href": "https://x/p2"}]},
-        "https://x/p2": {"publications": [{"id": 2}], "links": [{"rel": "self", "href": "https://x/p2"}]},
-    }
-    session = FakeSession(pages)
-    fetched = list(iter_pages("https://x/p1", session))
-    assert [f["publications"][0]["id"] for f in fetched] == [1, 2]
-    assert session.calls == ["https://x/p1", "https://x/p2"]
+# ---------------------------------------------------------------------------
+# BWB Source specialization of the generic adapter
+# ---------------------------------------------------------------------------
 
 
-def test_iter_pages_breaks_on_cycle(monkeypatch):
-
-    monkeypatch.setattr(bwb_opds_imports, "PAGE_SLEEP_SECONDS", 0)
-    pages = {"https://x/p1": {"publications": [], "links": [{"rel": "next", "href": "https://x/p1"}]}}
-    session = FakeSession(pages)
-    fetched = list(iter_pages("https://x/p1", session))
-    assert len(fetched) == 1
-
-
-def test_iter_pages_respects_max_pages(monkeypatch):
-
-    monkeypatch.setattr(bwb_opds_imports, "PAGE_SLEEP_SECONDS", 0)
-    pages = {
-        "https://x/p1": {"publications": [], "links": [{"rel": "next", "href": "https://x/p2"}]},
-        "https://x/p2": {"publications": [], "links": [{"rel": "next", "href": "https://x/p3"}]},
-        "https://x/p3": {"publications": [], "links": []},
-    }
-    session = FakeSession(pages)
-    fetched = list(iter_pages("https://x/p1", session, max_pages=2))
-    assert len(fetched) == 2
+def test_map_publication_uses_bwb_source():
+    # The BWB wrapper injects BWB_SOURCE, so source_records carries the bwb slug.
+    olbook = map_publication_to_olbook(SAMPLE_PUBLICATION)
+    assert olbook is not None
+    assert olbook["isbn_13"] == ["9781737408802"]
+    assert olbook["source_records"] == ["bwb:9781737408802"]
 
 
-def test_process_feed_filters_by_modified(monkeypatch):
-
-    monkeypatch.setattr(bwb_opds_imports, "PAGE_SLEEP_SECONDS", 0)
-    old_pub = {
-        "metadata": {
-            "identifier": "urn:isbn:9780000000002",
-            "title": "Old",
-            "modified": "2026-01-01T00:00:00+00:00",
-        },
-        "links": [],
-    }
-    new_pub = dict(SAMPLE_PUBLICATION)
-    pages = {"https://x/p1": {"publications": [old_pub, new_pub], "links": []}}
-    session = FakeSession(pages)
-    monkeypatch.setattr(bwb_opds_imports.requests, "Session", lambda: session)
-
-    cutoff = datetime.datetime(2026, 3, 1, tzinfo=datetime.UTC)
-    prices_fh = io.StringIO()
-    olbooks, max_modified = process_feed(
-        feed_url="https://x/p1",
-        since=cutoff,
-        prices_out_fh=prices_fh,
-    )
-    assert len(olbooks) == 1
-    assert olbooks[0]["isbn_13"] == ["9781737408802"]
-    assert max_modified > cutoff
-
-    price_lines = [json.loads(line) for line in prices_fh.getvalue().splitlines()]
-    assert price_lines == [{"isbn_13": "9781737408802", "price": 1.1, "currency": "USD"}]
+def test_bwb_source_wires_quality_filter():
+    assert bwb_opds_imports.BWB_SOURCE.provider_name == "betterworldbooks"
+    assert bwb_opds_imports.BWB_SOURCE.source_id_prefix == "bwb"
+    assert bwb_opds_imports.BWB_SOURCE.record_filter is bwb_opds_imports._bwb_record_filter
+    # A normal book is kept (not excluded).
+    assert bwb_opds_imports._bwb_record_filter(map_publication_to_olbook(SAMPLE_PUBLICATION)) is False
 
 
-def test_process_feed_skips_publication_without_modified(monkeypatch):
-    monkeypatch.setattr(bwb_opds_imports, "PAGE_SLEEP_SECONDS", 0)
-    pub = {"metadata": {"identifier": "urn:isbn:9781737408802", "title": "x"}, "links": []}
-    pages = {"https://x/p1": {"publications": [pub], "links": []}}
-    session = FakeSession(pages)
-    monkeypatch.setattr(bwb_opds_imports.requests, "Session", lambda: session)
-
-    olbooks, max_modified = process_feed(
-        feed_url="https://x/p1",
-        since=EPOCH,
-        prices_out_fh=io.StringIO(),
-    )
-    assert olbooks == []
-    assert max_modified == EPOCH
+# ---------------------------------------------------------------------------
+# State file + lazy price writer
+# ---------------------------------------------------------------------------
 
 
-def test_process_feed_advances_state_when_mapping_fails(monkeypatch):
-    """Newer publication without ISBN must still bump max_modified — otherwise
-    every future run re-scans the same record forever.
-    """
-    monkeypatch.setattr(bwb_opds_imports, "PAGE_SLEEP_SECONDS", 0)
-    new_modified = "2026-05-20T00:00:00+00:00"
-    pub = {"metadata": {"title": "No ISBN here", "modified": new_modified}, "links": []}
-    pages = {"https://x/p1": {"publications": [pub], "links": []}}
-    session = FakeSession(pages)
-    monkeypatch.setattr(bwb_opds_imports.requests, "Session", lambda: session)
-
-    olbooks, max_modified = process_feed(
-        feed_url="https://x/p1",
-        since=EPOCH,
-        prices_out_fh=io.StringIO(),
-    )
-    assert olbooks == []
-    assert max_modified == _parse_iso(new_modified)
+def test_state_roundtrip(tmp_path: Path):
+    state_file = tmp_path / "state.txt"
+    assert read_state(str(state_file)) == EPOCH
+    ts = datetime.datetime(2026, 5, 22, 12, 0, 0, tzinfo=datetime.UTC)
+    write_state(str(state_file), ts)
+    assert read_state(str(state_file)) == ts
 
 
-def test_process_feed_early_stops_on_first_all_stale_page(monkeypatch):
-    """Once a whole page contains nothing newer than ``since``, stop walking."""
-    monkeypatch.setattr(bwb_opds_imports, "PAGE_SLEEP_SECONDS", 0)
-    fresh = dict(SAMPLE_PUBLICATION)
-    stale = {
-        "metadata": {
-            "identifier": "urn:isbn:9780000000002",
-            "title": "Old",
-            "modified": "2026-01-01T00:00:00+00:00",
-        },
-        "links": [],
-    }
-    pages = {
-        "https://x/p1": {"publications": [fresh], "links": [{"rel": "next", "href": "https://x/p2"}]},
-        "https://x/p2": {"publications": [stale], "links": [{"rel": "next", "href": "https://x/p3"}]},
-        "https://x/p3": {"publications": [fresh], "links": []},
-    }
-    session = FakeSession(pages)
-    monkeypatch.setattr(bwb_opds_imports.requests, "Session", lambda: session)
-
-    cutoff = datetime.datetime(2026, 3, 1, tzinfo=datetime.UTC)
-    olbooks, _ = process_feed(
-        feed_url="https://x/p1",
-        since=cutoff,
-        prices_out_fh=io.StringIO(),
-        early_stop=True,
-    )
-    # p3 must NOT be fetched.
-    assert session.calls == ["https://x/p1", "https://x/p2"]
-    assert len(olbooks) == 1
-
-
-def test_process_feed_full_traversal_is_the_default(monkeypatch):
-    monkeypatch.setattr(bwb_opds_imports, "PAGE_SLEEP_SECONDS", 0)
-    stale = {
-        "metadata": {
-            "identifier": "urn:isbn:9780000000002",
-            "title": "Old",
-            "modified": "2026-01-01T00:00:00+00:00",
-        },
-        "links": [],
-    }
-    pages = {
-        "https://x/p1": {"publications": [stale], "links": [{"rel": "next", "href": "https://x/p2"}]},
-        "https://x/p2": {"publications": [stale], "links": []},
-    }
-    session = FakeSession(pages)
-    monkeypatch.setattr(bwb_opds_imports.requests, "Session", lambda: session)
-
-    process_feed(
-        feed_url="https://x/p1",
-        since=datetime.datetime(2026, 3, 1, tzinfo=datetime.UTC),
-        prices_out_fh=io.StringIO(),
-    )
-    # Default early_stop=False — both pages fetched even when first is all-stale.
-    assert session.calls == ["https://x/p1", "https://x/p2"]
-
-
-def test_process_feed_excludes_low_quality(monkeypatch):
-    """Reuse partner-import filters: independently-published 'notebook' from 2024 is dropped."""
-    monkeypatch.setattr(bwb_opds_imports, "PAGE_SLEEP_SECONDS", 0)
-    junk = {
-        "metadata": {
-            "identifier": "urn:isbn:9781737408802",
-            "title": "My Notebook",
-            "modified": "2026-05-20T00:00:00+00:00",
-            "published": "2024-01-01",
-            "publisher": [{"name": "Independently Published"}],
-            "author": [{"name": "Whoever"}],
-        },
-        "links": [],
-    }
-    pages = {"https://x/p1": {"publications": [junk], "links": []}}
-    session = FakeSession(pages)
-    monkeypatch.setattr(bwb_opds_imports.requests, "Session", lambda: session)
-
-    # Patch the mapper to inject publishers (OPDS metadata doesn't always expose them
-    # under a fixed key, and we just need the filter wired correctly).
-    real_map = bwb_opds_imports.map_publication_to_olbook
-
-    def fake_map(pub):
-        olbook = real_map(pub)
-        if olbook is not None:
-            olbook["publishers"] = ["Independently Published"]
-            olbook["publish_date"] = "2024-01-01"
-        return olbook
-
-    monkeypatch.setattr(bwb_opds_imports, "map_publication_to_olbook", fake_map)
-
-    olbooks, _ = process_feed(
-        feed_url="https://x/p1",
-        since=EPOCH,
-        prices_out_fh=io.StringIO(),
-    )
-    assert olbooks == []
+def test_state_read_empty_file_returns_epoch(tmp_path: Path):
+    state_file = tmp_path / "state.txt"
+    state_file.write_text("")
+    assert read_state(str(state_file)) == EPOCH
 
 
 def test_lazy_writer_does_not_create_file_when_unused(tmp_path: Path):
@@ -406,36 +128,11 @@ def test_lazy_writer_creates_file_on_write(tmp_path: Path):
     assert path.read_text() == "hello\n"
 
 
-@pytest.mark.parametrize(
-    "modified_raw",
-    ["not-a-date", "2026/05/19"],
-)
-def test_process_feed_logs_and_skips_bad_modified(monkeypatch, modified_raw):
-    monkeypatch.setattr(bwb_opds_imports, "PAGE_SLEEP_SECONDS", 0)
-    pub = {
-        "metadata": {"identifier": "urn:isbn:9781737408802", "modified": modified_raw},
-        "links": [],
-    }
-    pages = {"https://x/p1": {"publications": [pub], "links": []}}
-    session = FakeSession(pages)
-    monkeypatch.setattr(bwb_opds_imports.requests, "Session", lambda: session)
-
-    olbooks, _ = process_feed(
-        feed_url="https://x/p1",
-        since=EPOCH,
-        prices_out_fh=io.StringIO(),
-    )
-    assert olbooks == []
-
-
 # ---------------------------------------------------------------------------
 # End-to-end idempotency (epic #12844): re-running the importer against the
 # same feed state must not create duplicate import_item rows. Uses the
-# synthetic ``opds_sample.json`` feed so the check is reliable and offline.
+# synthetic opds_sample.json feed so the check is reliable and offline.
 # ---------------------------------------------------------------------------
-
-SAMPLE_FEED_URL: Final = "https://www.betterworldbooks.com/opds/"
-SAMPLE_FEED: Final = json.loads((Path(__file__).parent / "opds_sample.json").read_text())
 
 IMPORT_BATCH_DDL: Final = """
 CREATE TABLE import_batch (
@@ -479,9 +176,11 @@ def import_db():
 
 
 def _olbooks_from_sample(monkeypatch):
-    monkeypatch.setattr(bwb_opds_imports, "PAGE_SLEEP_SECONDS", 0)
+    # The crawl lives in opds2, so patch the session/sleep there (the BWB
+    # process_feed wrapper delegates to opds2.process_feed).
+    monkeypatch.setattr(opds2, "PAGE_SLEEP_SECONDS", 0)
     session = FakeSession({SAMPLE_FEED_URL: SAMPLE_FEED})
-    monkeypatch.setattr(bwb_opds_imports.requests, "Session", lambda: session)
+    monkeypatch.setattr(opds2.requests, "Session", lambda: session)
     olbooks, _ = process_feed(feed_url=SAMPLE_FEED_URL, since=EPOCH, prices_out_fh=io.StringIO())
     return olbooks
 
@@ -549,18 +248,6 @@ def acquisitions_db():
     db.query("DROP TABLE IF EXISTS acquisitions;")
 
 
-def test_build_acquisition_data_extracts_price_and_url():
-    data = bwb_opds_imports.build_acquisition_data(SAMPLE_PUBLICATION)
-    assert data["price"] == {"currency": "USD", "value": 1.1}
-    assert data["url"] == "https://www.betterworldbooks.com/purchase/9781737408802"
-
-
-def test_build_acquisition_data_extracts_formats():
-    data = bwb_opds_imports.build_acquisition_data(SAMPLE_FEED["publications"][0])
-    assert data["price"] == {"currency": "USD", "value": 1.25}
-    assert data["formats"] == ["application/epub+zip"]
-
-
 def test_upsert_acquisition_is_idempotent(acquisitions_db):
     pub = SAMPLE_FEED["publications"][0]
     first = bwb_opds_imports.upsert_acquisition(work_id=10, edition_id=100, isbn_13="9781737408802", publication=pub)
@@ -580,7 +267,7 @@ def test_upsert_acquisition_updates_changed_price(acquisitions_db):
     # Simulate the price changing in a later feed pull.
     changed = json.loads(json.dumps(pub))
     for link in changed["links"]:
-        if link.get("rel") == bwb_opds_imports.ACQUISITION_REL:
+        if link.get("rel") == opds2.ACQUISITION_REL:
             link["properties"]["price"]["value"] = 3.50
     bwb_opds_imports.upsert_acquisition(work_id=10, edition_id=100, isbn_13="9781737408802", publication=changed)
     rows = Acquisition.get_by_edition(100, "betterworldbooks")
@@ -589,8 +276,8 @@ def test_upsert_acquisition_updates_changed_price(acquisitions_db):
 
 
 # ---------------------------------------------------------------------------
-# Cursor source (epic #12844): the FeedRegistry DB cursor is the source of
-# truth for BWB's incremental state; the file-state is a fallback only.
+# Cursor source: the FeedRegistry DB cursor is the source of truth for BWB's
+# incremental state; the file-state is a fallback only.
 # ---------------------------------------------------------------------------
 
 TBP_FEED_REGISTRY_DDL: Final = """
@@ -623,7 +310,7 @@ def registry_db():
 def test_resolve_cutoff_prefers_explicit_since(registry_db, tmp_path):
     # --since wins over everything and does not require a registered feed.
     cutoff = bwb_opds_imports.resolve_cutoff(FEED_URL, since="2026-01-02T00:00:00+00:00", state_file=str(tmp_path / "s.txt"))
-    assert cutoff == _parse_iso("2026-01-02T00:00:00+00:00")
+    assert cutoff == datetime.datetime(2026, 1, 2, 0, 0, 0, tzinfo=datetime.UTC)
 
 
 def test_resolve_cutoff_uses_registry_cursor(registry_db, tmp_path):
@@ -662,9 +349,9 @@ def test_advance_cursor_unregistered_feed_writes_only_file(registry_db, tmp_path
 
 
 # ---------------------------------------------------------------------------
-# Edition resolution + acquisition staging (epic #12844, option (a)): attach
-# acquisitions to ISBNs that already resolve to an edition; defer the rest to
-# the post-import hook.
+# Edition resolution + acquisition staging (option (a)): attach acquisitions to
+# ISBNs that already resolve to an edition; defer the rest to the post-import
+# hook.
 # ---------------------------------------------------------------------------
 
 
@@ -734,16 +421,6 @@ def test_stage_acquisitions_is_idempotent(monkeypatch, acquisitions_db):
     bwb_opds_imports.stage_acquisitions(items)
     bwb_opds_imports.stage_acquisitions(items)
     assert len(Acquisition.get_by_edition(55, "betterworldbooks")) == 1
-
-
-def test_process_feed_collects_acquisitions(monkeypatch):
-    monkeypatch.setattr(bwb_opds_imports, "PAGE_SLEEP_SECONDS", 0)
-    session = FakeSession({SAMPLE_FEED_URL: SAMPLE_FEED})
-    monkeypatch.setattr(bwb_opds_imports.requests, "Session", lambda: session)
-    acqs: list = []
-    process_feed(feed_url=SAMPLE_FEED_URL, since=EPOCH, prices_out_fh=io.StringIO(), acquisitions_out=acqs)
-    assert {isbn for isbn, _ in acqs} == {"9781737408802", "9798995425007"}
-    assert dict(acqs)["9781737408802"]["price"] == {"currency": "USD", "value": 1.25}
 
 
 def test_link_acquisition_for_edition_post_import(monkeypatch, acquisitions_db):

--- a/scripts/tests/test_bwb_opds_imports.py
+++ b/scripts/tests/test_bwb_opds_imports.py
@@ -9,6 +9,7 @@ import web
 
 from openlibrary.core.acquisitions import Acquisition
 from openlibrary.core.db import get_db
+from openlibrary.core.tbp import FeedRegistry
 
 from .. import bwb_opds_imports
 from ..bwb_opds_imports import (
@@ -585,3 +586,76 @@ def test_upsert_acquisition_updates_changed_price(acquisitions_db):
     rows = Acquisition.get_by_edition(100, "betterworldbooks")
     assert len(rows) == 1
     assert rows[0].data["price"]["value"] == 3.50
+
+
+# ---------------------------------------------------------------------------
+# Cursor source (epic #12844): the FeedRegistry DB cursor is the source of
+# truth for BWB's incremental state; the file-state is a fallback only.
+# ---------------------------------------------------------------------------
+
+TBP_FEED_REGISTRY_DDL: Final = """
+CREATE TABLE tbp_feed_registry (
+    id integer primary key,
+    provider_name text not null,
+    feed_type text not null,
+    url text not null,
+    last_updated timestamp default null,
+    data text not null default '{}',
+    created timestamp default current_timestamp,
+    updated timestamp default current_timestamp,
+    UNIQUE (provider_name, url)
+);
+"""
+
+FEED_URL: Final = "https://www.betterworldbooks.com/opds"
+
+
+@pytest.fixture
+def registry_db():
+    web.config.db_parameters = {"dbn": "sqlite", "db": ":memory:"}
+    db = get_db()
+    db.query("DROP TABLE IF EXISTS tbp_feed_registry;")
+    db.query(TBP_FEED_REGISTRY_DDL)
+    yield db
+    db.query("DROP TABLE IF EXISTS tbp_feed_registry;")
+
+
+def test_resolve_cutoff_prefers_explicit_since(registry_db, tmp_path):
+    # --since wins over everything and does not require a registered feed.
+    cutoff = bwb_opds_imports.resolve_cutoff(FEED_URL, since="2026-01-02T00:00:00+00:00", state_file=str(tmp_path / "s.txt"))
+    assert cutoff == _parse_iso("2026-01-02T00:00:00+00:00")
+
+
+def test_resolve_cutoff_uses_registry_cursor(registry_db, tmp_path):
+    FeedRegistry.register("betterworldbooks", FEED_URL)
+    feed = FeedRegistry.find("betterworldbooks", FEED_URL)
+    FeedRegistry.advance(feed.id, last_updated=datetime.datetime(2026, 6, 1, 0, 0, 0))
+    cutoff = bwb_opds_imports.resolve_cutoff(FEED_URL, since=None, state_file=str(tmp_path / "s.txt"))
+    assert cutoff == datetime.datetime(2026, 6, 1, 0, 0, 0, tzinfo=datetime.UTC)
+
+
+def test_resolve_cutoff_falls_back_to_file_state(registry_db, tmp_path):
+    # Feed not registered -> use the file-state fallback.
+    state = tmp_path / "s.txt"
+    ts = datetime.datetime(2026, 3, 3, tzinfo=datetime.UTC)
+    bwb_opds_imports.write_state(str(state), ts)
+    cutoff = bwb_opds_imports.resolve_cutoff(FEED_URL, since=None, state_file=str(state))
+    assert cutoff == ts
+
+
+def test_advance_cursor_updates_registry_and_file(registry_db, tmp_path):
+    FeedRegistry.register("betterworldbooks", FEED_URL)
+    state = tmp_path / "s.txt"
+    ts = datetime.datetime(2026, 6, 16, 17, 2, 54, tzinfo=datetime.UTC)
+    bwb_opds_imports.advance_cursor(FEED_URL, ts, str(state))
+    feed = FeedRegistry.find("betterworldbooks", FEED_URL)
+    assert str(feed.last_updated).startswith("2026-06-16 17:02:54")
+    assert bwb_opds_imports.read_state(str(state)) == ts
+
+
+def test_advance_cursor_unregistered_feed_writes_only_file(registry_db, tmp_path):
+    state = tmp_path / "s.txt"
+    ts = datetime.datetime(2026, 6, 16, tzinfo=datetime.UTC)
+    bwb_opds_imports.advance_cursor(FEED_URL, ts, str(state))
+    assert FeedRegistry.find("betterworldbooks", FEED_URL) is None
+    assert bwb_opds_imports.read_state(str(state)) == ts

--- a/scripts/tests/test_bwb_opds_imports.py
+++ b/scripts/tests/test_bwb_opds_imports.py
@@ -7,6 +7,7 @@ from typing import Final
 import pytest
 import web
 
+from openlibrary.core.acquisitions import Acquisition
 from openlibrary.core.db import get_db
 
 from .. import bwb_opds_imports
@@ -513,3 +514,74 @@ def test_commit_batch_is_idempotent_across_batches(monkeypatch, import_db):
     # Next day's batch: dedupe_items filters ia_ids present in ANY batch.
     commit_batch("bwb-opds-2026-06-17", olbooks)
     assert _count(import_db) == 2
+
+
+# ---------------------------------------------------------------------------
+# Acquisitions wiring (epic #12844, subtask 2): BWB ingestion is the first
+# writer of the (previously dormant) acquisitions table. Upserts are keyed on
+# (local_id, provider_name) so re-running the feed refreshes rather than
+# duplicates provider acquisition metadata.
+# ---------------------------------------------------------------------------
+
+ACQUISITIONS_DDL: Final = """
+CREATE TABLE acquisitions (
+    id integer primary key,
+    work_id integer not null,
+    edition_id integer not null,
+    provider_name text not null,
+    local_id text not null,
+    data json not null,
+    created timestamp default current_timestamp,
+    updated timestamp default current_timestamp,
+    UNIQUE (local_id, provider_name)
+);
+"""
+
+
+@pytest.fixture
+def acquisitions_db():
+    web.config.db_parameters = {"dbn": "sqlite", "db": ":memory:"}
+    db = get_db()
+    db.query("DROP TABLE IF EXISTS acquisitions;")
+    db.query(ACQUISITIONS_DDL)
+    yield db
+    db.query("DROP TABLE IF EXISTS acquisitions;")
+
+
+def test_build_acquisition_data_extracts_price_and_url():
+    data = bwb_opds_imports.build_acquisition_data(SAMPLE_PUBLICATION)
+    assert data["price"] == {"currency": "USD", "value": 1.1}
+    assert data["url"] == "https://www.betterworldbooks.com/purchase/9781737408802"
+
+
+def test_build_acquisition_data_extracts_formats():
+    data = bwb_opds_imports.build_acquisition_data(SAMPLE_FEED["publications"][0])
+    assert data["price"] == {"currency": "USD", "value": 1.25}
+    assert data["formats"] == ["application/epub+zip"]
+
+
+def test_upsert_acquisition_is_idempotent(acquisitions_db):
+    pub = SAMPLE_FEED["publications"][0]
+    first = bwb_opds_imports.upsert_acquisition(work_id=10, edition_id=100, isbn_13="9781737408802", publication=pub)
+    assert first is not None
+    assert len(Acquisition.get_by_edition(100, "betterworldbooks")) == 1
+    # Re-running the same feed refreshes the same row, does not duplicate.
+    bwb_opds_imports.upsert_acquisition(work_id=10, edition_id=100, isbn_13="9781737408802", publication=pub)
+    rows = Acquisition.get_by_edition(100, "betterworldbooks")
+    assert len(rows) == 1
+    assert rows[0].local_id == "urn:isbn:9781737408802"
+    assert rows[0].data["price"] == {"currency": "USD", "value": 1.25}
+
+
+def test_upsert_acquisition_updates_changed_price(acquisitions_db):
+    pub = SAMPLE_FEED["publications"][0]
+    bwb_opds_imports.upsert_acquisition(work_id=10, edition_id=100, isbn_13="9781737408802", publication=pub)
+    # Simulate the price changing in a later feed pull.
+    changed = json.loads(json.dumps(pub))
+    for link in changed["links"]:
+        if link.get("rel") == bwb_opds_imports.ACQUISITION_REL:
+            link["properties"]["price"]["value"] = 3.50
+    bwb_opds_imports.upsert_acquisition(work_id=10, edition_id=100, isbn_13="9781737408802", publication=changed)
+    rows = Acquisition.get_by_edition(100, "betterworldbooks")
+    assert len(rows) == 1
+    assert rows[0].data["price"]["value"] == 3.50

--- a/scripts/tests/test_bwb_opds_imports.py
+++ b/scripts/tests/test_bwb_opds_imports.py
@@ -2,13 +2,18 @@ import datetime
 import io
 import json
 from pathlib import Path
+from typing import Final
 
 import pytest
+import web
+
+from openlibrary.core.db import get_db
 
 from .. import bwb_opds_imports
 from ..bwb_opds_imports import (
     EPOCH,
     _parse_iso,
+    commit_batch,
     extract_cover,
     extract_isbn,
     extract_price,
@@ -419,3 +424,92 @@ def test_process_feed_logs_and_skips_bad_modified(monkeypatch, modified_raw):
         prices_out_fh=io.StringIO(),
     )
     assert olbooks == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end idempotency (epic #12844): re-running the importer against the
+# same feed state must not create duplicate import_item rows. Uses the
+# synthetic ``opds_sample.json`` feed so the check is reliable and offline.
+# ---------------------------------------------------------------------------
+
+SAMPLE_FEED_URL: Final = "https://www.betterworldbooks.com/opds/"
+SAMPLE_FEED: Final = json.loads((Path(__file__).parent / "opds_sample.json").read_text())
+
+IMPORT_BATCH_DDL: Final = """
+CREATE TABLE import_batch (
+    id integer primary key,
+    name text,
+    submitter text,
+    submit_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+"""
+
+IMPORT_ITEM_DDL: Final = """
+CREATE TABLE import_item (
+    id serial primary key,
+    batch_id integer,
+    status text default 'pending',
+    error text,
+    ia_id text,
+    data text,
+    ol_key text,
+    comments text,
+    submitter text,
+    UNIQUE (batch_id, ia_id)
+);
+"""
+
+
+@pytest.fixture
+def import_db():
+    web.config.db_parameters = {"dbn": "sqlite", "db": ":memory:"}
+    db = get_db()
+    # get_db() is a process-wide cached connection shared with other test
+    # modules (e.g. test_imports.py). Drop/recreate so this module owns a
+    # clean schema regardless of collection order.
+    db.query("DROP TABLE IF EXISTS import_item;")
+    db.query("DROP TABLE IF EXISTS import_batch;")
+    db.query(IMPORT_BATCH_DDL)
+    db.query(IMPORT_ITEM_DDL)
+    yield db
+    db.query("DROP TABLE IF EXISTS import_item;")
+    db.query("DROP TABLE IF EXISTS import_batch;")
+
+
+def _olbooks_from_sample(monkeypatch):
+    monkeypatch.setattr(bwb_opds_imports, "PAGE_SLEEP_SECONDS", 0)
+    session = FakeSession({SAMPLE_FEED_URL: SAMPLE_FEED})
+    monkeypatch.setattr(bwb_opds_imports.requests, "Session", lambda: session)
+    olbooks, _ = process_feed(feed_url=SAMPLE_FEED_URL, since=EPOCH, prices_out_fh=io.StringIO())
+    return olbooks
+
+
+def _count(db) -> int:
+    return len(list(db.select("import_item")))
+
+
+def test_process_feed_maps_sample_feed(monkeypatch):
+    olbooks = _olbooks_from_sample(monkeypatch)
+    assert {b["isbn_13"][0] for b in olbooks} == {"9781737408802", "9798995425007"}
+    assert all(b["source_records"][0].startswith("bwb:") for b in olbooks)
+
+
+def test_commit_batch_is_idempotent_within_same_batch(monkeypatch, import_db):
+    olbooks = _olbooks_from_sample(monkeypatch)
+    commit_batch("bwb-opds-2026-06-16", olbooks)
+    assert _count(import_db) == 2
+    # Re-running the same feed into the same day's batch must add nothing.
+    commit_batch("bwb-opds-2026-06-16", olbooks)
+    assert _count(import_db) == 2
+    ia_ids = {row.ia_id for row in import_db.select("import_item")}
+    assert ia_ids == {"bwb:9781737408802", "bwb:9798995425007"}
+
+
+def test_commit_batch_is_idempotent_across_batches(monkeypatch, import_db):
+    """A later run (new daily batch) must not re-stage already-imported records."""
+    olbooks = _olbooks_from_sample(monkeypatch)
+    commit_batch("bwb-opds-2026-06-16", olbooks)
+    assert _count(import_db) == 2
+    # Next day's batch: dedupe_items filters ia_ids present in ANY batch.
+    commit_batch("bwb-opds-2026-06-17", olbooks)
+    assert _count(import_db) == 2


### PR DESCRIPTION
**Draft — integration prototype for #12844 (Feed Registry & Acquisitions). Will be split into atomic PRs before landing; do not merge as-is.**

## What this is

A single working prototype branch bringing the Feed Registry, Acquisitions wiring, and Better World Books OPDS ingestion together into one local system, per the epic. Built additively on the merged #12793 BWB importer (not a rewrite of it).

## Landed so far (all TDD; SQLite/unit level)

- `tbp_feed_registry` table + `FeedRegistry` interface (`openlibrary/core/tbp.py`) — register/advance/find/all; idempotent.
- Synthetic OPDS fixture + tests proving BWB ingestion is idempotent across repeated runs (no duplicate `import_item`).
- First live writer of the `acquisitions` table (#12851) — `build_acquisition_data`/`upsert_acquisition`, idempotent on `(local_id, provider_name)`.
- `POST /api/import/feeds/register` (auth-gated; records submitter + `pending` status).
- FeedRegistry cursor is the source of truth for incremental state; file-state is fallback.
- Edition resolution (option a): acquisitions attach in-run for ISBNs that already resolve; a post-import hook is provided for new editions.
- `mockservices` synthetic BWB OPDS feed at `/services/bwb/opds` for offline end-to-end runs.
- **Generic OPDS 2.0 adapter** (`openlibrary/catalog/opds2.py`): the BWB importer is now a thin consumer — it supplies a per-feed `Source` config (source-id prefix + quality filter) over a shared adapter, so onboarding a new OPDS feed is config, not a bespoke script. (Distinct from `importapi/import_opds.py`, the OPDS 1.x XML parser.)

## Honest status — NOT yet done

- **No live end-to-end run.** All DB tests use in-memory SQLite; the tables aren't in the running Postgres, and the feed→`manage-imports`→real edition→acquisition loop has never been executed.
- **The post-import hook (`link_acquisition_for_edition`) has no caller yet** — it's tested but not wired into `manage-imports`/`add_book`.
- Solr surfacing is documentation-only (query-time fetch plan).

## Direction (next round)

- Operator surface: `/admin/imports/registry` (human + `.json` view, last-run per feed), feed CRUD, manual harvest trigger with a per-feed lock, and a multi-feed runner/cron.
- Dedicated `bookworm` FastAPI service + isolated staging DB (owns the cron; runs on dev too).
- Then the full live end-to-end loop.

Part of #12844.
