### PR TITLE
feat(vitals): Core Vitals Retention Score, with an on-demand trigger

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -80,6 +80,15 @@ admin:
     statsd_server: localhost:9090
     admin_db: http://localhost:5984/admin
 
+# Matomo Reporting API token, consumed by scripts/gather_retention_scores.py via
+# openlibrary/core/retention.py's resolve_token(). Should be a VIEW-ONLY Matomo
+# user: the read-only allowlist in openlibrary/core/matomo.py guards against
+# mistakes, not against a credential that can write. The real value lives in
+# olsystem's copy of this file. Blank here, so local dev reports "no token"
+# rather than scoring against production; export MATOMO_TOKEN (which takes
+# precedence) or point MATOMO_URL at docker/mockservices to run it locally.
+matomo_api:
+
 stats: # This section is used to state what stats need to be gathered.
     pageload.all:
       filter: all

--- a/docker/mockservices/tests/conftest.py
+++ b/docker/mockservices/tests/conftest.py
@@ -1,7 +1,7 @@
 """Make the repo root importable for the tests in this directory.
 
-These tests import ``openlibrary.core.matomo`` to exercise the mock Matomo feed
-over real HTTP. That works inside the dev containers only because
+These tests import ``openlibrary.core.retention`` and ``openlibrary.core.matomo``
+to score the mock Matomo feed. That works inside the dev containers only because
 the image sets ``PYTHONPATH=/openlibrary``; GitHub CI sets no such thing.
 
 pytest's default ``prepend`` import mode inserts a test module's *basedir* onto

--- a/docker/mockservices/tests/test_e2e.py
+++ b/docker/mockservices/tests/test_e2e.py
@@ -22,6 +22,7 @@ import os
 import pytest
 import requests
 
+from openlibrary.core import retention
 from openlibrary.core.matomo import MatomoClient
 
 MOCKSERVICES_URL = os.environ.get("MOCKSERVICES_URL", "http://mockservices:8090")
@@ -266,3 +267,22 @@ class TestMatomoMock:
         """A page_size below the feed size must still return everything, in order."""
         visits = client.get_visits_since(datetime.datetime.now(datetime.UTC), page_size=5)
         assert [v["idVisit"] for v in visits] == [str(i) for i in range(12)]
+
+    def test_scorer_produces_the_hand_computed_total(self, client):
+        scores = retention.gather_retention_scores(client=client)
+        assert scores["visits"] == 12
+        assert scores["r_total"] == pytest.approx(self.EXPECTED_R_TOTAL)
+        assert sum(c["patrons"] for c in scores["classes"].values()) == self.EXPECTED_PATRONS
+
+    def test_class_contributions_match_by_hand(self, client):
+        classes = retention.gather_retention_scores(client=client)["classes"]
+        assert classes["visitor"]["contribution"] == pytest.approx(2.10)
+        assert classes["registrant"]["contribution"] == pytest.approx(42.00)
+        assert classes["returning"]["contribution"] == pytest.approx(157.50)
+        assert classes["retained"]["contribution"] == pytest.approx(5.00)
+
+    def test_unmapped_events_are_ignored_not_fatal(self, client):
+        """SearchModal|Open is real Matomo traffic the schema has no row for."""
+        events = retention.gather_retention_scores(client=client)["events"]
+        assert "read" in events
+        assert all(name in retention.EVENT_POINTS for name in events)

--- a/docker/mockservices/tests/test_matomo_inprocess.py
+++ b/docker/mockservices/tests/test_matomo_inprocess.py
@@ -38,6 +38,7 @@ import time
 import pytest
 import requests
 
+from openlibrary.core import retention
 from openlibrary.core.matomo import MatomoClient
 
 MOCKSERVICES_MAIN = pathlib.Path(__file__).parents[1] / "main.py"
@@ -181,3 +182,56 @@ class TestWindowFiltering:
         # Halfway through the feed, so roughly half the visits are excluded.
         midpoint = datetime.datetime.fromtimestamp(epoch + (expected_visits // 2) * interval, datetime.UTC)
         assert 0 < len(client.get_visits_since(midpoint).visits) < expected_visits
+
+
+# The mock's feed sits a couple of days back (see MATOMO_MOCK_EPOCH), so a
+# scoring window has to be wide enough to reach it. The default 1h window
+# correctly returns nothing, which is the right behaviour but not what these
+# tests are exercising.
+FEED_WINDOW_HOURS = 72
+
+
+class TestScoringOverHttp:
+    """The scorer against the mock over real HTTP.
+
+    Unit tests stub the client out, so this is the only place the scorer sees
+    JSON that actually crossed a socket.
+    """
+
+    def test_the_score_is_reproducible_and_nonzero(self, client):
+        scores = retention.gather_retention_scores(client=client, hours=FEED_WINDOW_HOURS)
+        assert scores["visits"] == scores["total_patrons"] > 0
+        assert scores["r_total"] > 0
+        # Same input, same output.
+        assert retention.gather_retention_scores(client=client, hours=FEED_WINDOW_HOURS)["r_total"] == scores["r_total"]
+
+    def test_read_is_actually_scored(self, client):
+        """`read` silently scored zero for the prototype's whole life."""
+        events = retention.gather_retention_scores(client=client, hours=FEED_WINDOW_HOURS)["events"]
+        assert events["read"]["points"] == 100
+        assert events["read"]["count"] > 0
+
+    def test_only_schema_events_are_ever_reported(self, client):
+        events = retention.gather_retention_scores(client=client, hours=FEED_WINDOW_HOURS)["events"]
+        assert set(events) <= set(retention.EVENT_POINTS)
+
+    def test_unmapped_traffic_is_ignored_rather_than_fatal(self, client):
+        """The feed includes SearchModal|Open, which the schema has no row for."""
+        scores = retention.gather_retention_scores(client=client, hours=FEED_WINDOW_HOURS)
+        assert "SearchModal" not in str(scores["events"])
+        assert scores["r_total"] > 0
+
+    def test_every_cohort_contributes_to_some_class(self, client):
+        scores = retention.gather_retention_scores(client=client, hours=FEED_WINDOW_HOURS)
+        assert sum(c["patrons"] for c in scores["classes"].values()) == scores["total_patrons"]
+
+    def test_by_hour_scoring_works_over_the_wire(self, client):
+        hourly = retention.gather_retention_scores_by_hour(client=client, hours=2)
+        assert len(hourly) == 2
+        assert hourly[0]["partial"] is True
+        assert hourly[1]["partial"] is False
+
+    def test_gauges_are_emittable_from_a_wire_scored_result(self, client):
+        gauges = retention.retention_gauges(retention.gather_retention_scores(client=client, hours=FEED_WINDOW_HOURS))
+        assert gauges["stats.ol.retention.total_score.hourly"] > 0
+        assert not any("+" in key for key in gauges)

--- a/docker/mockservices/tests/test_matomo_inprocess.py
+++ b/docker/mockservices/tests/test_matomo_inprocess.py
@@ -4,8 +4,8 @@
 mockservices *container* is reachable -- and GitHub CI runs ``make test-py`` with
 no containers at all, so those tests skip there and catch nothing. This module
 closes that gap: it serves the *same* mock app in-process on an ephemeral
-loopback port, so the real ``MatomoClient`` makes real HTTP requests and parses
-real JSON on every CI run.
+loopback port, so the real ``MatomoClient`` makes real HTTP requests and the real
+scorer consumes real JSON, on every CI run.
 
 It lives here rather than under ``openlibrary/tests/`` deliberately.
 ``openlibrary/conftest.py`` has an autouse ``no_requests`` fixture that blocks
@@ -14,11 +14,11 @@ through is the wrong trade. This directory is already outside that guard,
 already collected by ``make test-py``, and already the home for tests that speak
 to a mock service over HTTP.
 
-That matters because the bugs in this area live precisely in the seam between
-Matomo's wire format and our parsing of it -- for instance ``dimension1``, which
-this endpoint returns flat and which an earlier prototype read from a nested
-structure the API never sends, silently mislabelling every visit. Unit tests with
-a stubbed client cannot see that. This can.
+That matters because every bug this pipeline has shipped lived precisely in the
+seam between Matomo's wire format and our parsing of it -- reading ``dimension1``
+from a nested structure the API never returns, and mapping ``read`` to an event
+category that does not exist. Unit tests with a stubbed client cannot see either
+of those. This can.
 
 The mock app is loaded from ``docker/mockservices/main.py`` by path rather than
 copied, so there is one definition of the fake feed and it cannot drift from
@@ -35,14 +35,20 @@ import time
 import pytest
 import requests
 
+from openlibrary.core import retention
 from openlibrary.core.matomo import MatomoClient
 
 MOCKSERVICES_MAIN = pathlib.Path(__file__).parents[1] / "main.py"
 
-# The mock's default feed size, and the cohorts it cycles through. Asserted here
-# so a change to the fake feed cannot quietly invalidate the tests that consume it.
-EXPECTED_VISITS = 12
-EXPECTED_COHORTS = {"visitor", "d0", "d1+", "d7+", "d14+", "d30+", "d90+"}
+# The 12-visit default feed, worked out by hand. See TestMatomoMock in
+# docker/mockservices/tests/test_e2e.py for the per-visit derivation.
+#   visitor    210 x 0.01 =   2.10  (2 patrons)
+#   registrant 210 x 0.20 =  42.00  (2 patrons)
+#   returning  315 x 0.50 = 157.50  (7 patrons)
+#   retained     5 x 1.00 =   5.00  (1 patron)
+EXPECTED_R_TOTAL = 206.60
+EXPECTED_CONTRIBUTIONS = {"visitor": 2.10, "registrant": 42.00, "returning": 157.50, "retained": 5.00}
+EXPECTED_PATRONS = 12
 
 
 def _load_mock_app():
@@ -100,9 +106,8 @@ class TestWireFormat:
         assert all("customDimensions" not in visit for visit in visits)
 
     def test_all_seven_cohorts_survive_the_round_trip(self, client):
-        """The cohort labels are the contract between Matomo and any future scorer."""
         visits = client.get_visits_since(datetime.datetime.now(datetime.UTC))
-        assert {visit["dimension1"] for visit in visits} == EXPECTED_COHORTS
+        assert {visit["dimension1"] for visit in visits} == set(retention.COHORTS)
 
     def test_action_details_carry_events_and_page_views(self, client):
         visits = client.get_visits_since(datetime.datetime.now(datetime.UTC))
@@ -122,8 +127,51 @@ class TestWireFormat:
 class TestPaginationOverHttp:
     def test_a_short_page_size_still_returns_the_whole_feed_in_order(self, client):
         visits = client.get_visits_since(datetime.datetime.now(datetime.UTC), page_size=5)
-        assert [visit["idVisit"] for visit in visits] == [str(i) for i in range(EXPECTED_VISITS)]
+        assert [visit["idVisit"] for visit in visits] == [str(i) for i in range(12)]
 
     def test_page_size_larger_than_the_feed_is_a_single_request(self, client):
         visits = client.get_visits_since(datetime.datetime.now(datetime.UTC), page_size=500)
-        assert len(visits) == EXPECTED_VISITS
+        assert len(visits) == 12
+
+
+class TestScoringOverHttp:
+    def test_r_total_matches_the_hand_computed_value(self, client):
+        scores = retention.gather_retention_scores(client=client)
+        assert scores["visits"] == 12
+        assert scores["r_total"] == pytest.approx(EXPECTED_R_TOTAL)
+
+    def test_every_class_contribution_matches_by_hand(self, client):
+        classes = retention.gather_retention_scores(client=client)["classes"]
+        for name, expected in EXPECTED_CONTRIBUTIONS.items():
+            assert classes[name]["contribution"] == pytest.approx(expected), name
+
+    def test_patron_total_matches(self, client):
+        scores = retention.gather_retention_scores(client=client)
+        assert sum(c["patrons"] for c in scores["classes"].values()) == EXPECTED_PATRONS
+
+    def test_read_is_actually_scored(self, client):
+        """`read` silently scored zero for the prototype's whole life; pin it over the wire."""
+        events = retention.gather_retention_scores(client=client)["events"]
+        assert events["read"]["points"] == 100
+        assert events["read"]["count"] == 4  # CTAClick|Read and CTAClick|Borrow, twice each
+
+    def test_only_schema_events_are_ever_reported(self, client):
+        events = retention.gather_retention_scores(client=client)["events"]
+        assert set(events) <= set(retention.EVENT_POINTS)
+
+    def test_unmapped_traffic_is_ignored_rather_than_fatal(self, client):
+        """The feed includes SearchModal|Open, which the schema has no row for."""
+        scores = retention.gather_retention_scores(client=client)
+        assert "SearchModal" not in str(scores["events"])
+        assert scores["r_total"] > 0
+
+    def test_by_hour_scoring_works_over_the_wire(self, client):
+        hourly = retention.gather_retention_scores_by_hour(client=client, hours=2)
+        assert len(hourly) == 2
+        assert hourly[0]["partial"] is True
+        assert hourly[1]["partial"] is False
+
+    def test_gauges_are_emittable_from_a_wire_scored_result(self, client):
+        gauges = retention.retention_gauges(retention.gather_retention_scores(client=client))
+        assert gauges["stats.ol.retention.total_score.hourly"] == pytest.approx(EXPECTED_R_TOTAL)
+        assert not any("+" in key for key in gauges)

--- a/openlibrary/core/matomo.py
+++ b/openlibrary/core/matomo.py
@@ -31,9 +31,9 @@ logger = logging.getLogger("openlibrary.matomo")
 DEFAULT_MATOMO_URL = "https://matomo.archive.org"
 DEFAULT_SITE_ID = 6
 
-# A loop guard, not the operative limit: `if not batch` and `if not fresh`
-# already terminate against any well-behaved server. `budget_seconds` is the
-# bound an operator should actually tune.
+# A loop guard, not the operative limit: an empty page already ends the fetch
+# against any well-behaved server. `budget_seconds` is the bound an operator
+# should actually tune.
 MAX_PAGES = 200
 
 # Matomo's own raw-log retention is finite, so a longer request is far more

--- a/openlibrary/core/retention.py
+++ b/openlibrary/core/retention.py
@@ -1,0 +1,558 @@
+"""Core Vitals Retention Score -- how much value patrons are accessing (#11956).
+
+    E_tau(t)   = sum_e [C(e,tau,t) x w_e] / P_tau(t)
+    R_total(t) = sum_tau [w_tau x P_tau(t) x E_tau(t)]
+
+where tau is a patron class, P_tau its unique active patrons, and w_e the
+engagement point value of event e. See ``ol-kb/wiki/core-vitals.md``.
+
+**This module deliberately imports nothing from Open Library.** Retention is
+computed entirely from Matomo, and the intent is for it to move into a
+standalone Core Vitals service that runs as independently of openlibrary.org
+as possible. Keeping the import graph clean means that move is a file copy
+rather than an untangling -- and
+``openlibrary/tests/core/test_retention.py::TestImportIndependence`` fails if
+anyone couples it back to the app.
+
+Contrast ``openlibrary/admin/vitals.py``, which computes participation scores
+and is genuinely app-coupled: those come from Open Library's own database.
+"""
+
+import datetime
+import logging
+import os
+import re
+from urllib.parse import urlsplit
+
+import yaml
+from statsd import StatsClient
+
+from openlibrary.core.matomo import MatomoClient
+
+logger = logging.getLogger("openlibrary.retention")
+
+RETENTION_EVENT_PREFIX = "stats.ol.retention"
+
+
+def configure_statsd(configfile) -> StatsClient:
+    """Build a statsd client from an openlibrary.yml-shaped config file.
+
+    Deliberately duplicated from ``openlibrary/admin/vitals.py`` rather than
+    imported: importing that module pulls in 80+ app and infobase modules, which
+    would defeat this module's independence for the sake of eight lines.
+    """
+    with open(configfile) as f:
+        configs = yaml.safe_load(f)
+    url = configs.get("admin", {}).get("statsd_server", None)
+    if not url:
+        raise KeyError("StatsD server not configured")
+    host, _, port = url.partition(":")
+    return StatsClient(host, port)
+
+
+def resolve_token(configfile: str) -> str:
+    """The Matomo token, from the environment or the config file.
+
+    MATOMO_TOKEN wins so a developer never has to edit a tracked config to run
+    a scoring pass.
+    """
+    if token := os.environ.get("MATOMO_TOKEN"):
+        return token
+    with open(configfile) as f:
+        return (yaml.safe_load(f) or {}).get("matomo_api") or ""
+
+
+# Custom dimension 1 ("Days Since Registration"), set by get_days_registered()
+# in openlibrary/accounts/__init__.py. Buckets are discrete and mutually
+# exclusive, NOT cumulative -- "d1+" means 1-6 days, not "1 or more days".
+COHORTS = ["visitor", "d0", "d1+", "d7+", "d14+", "d30+", "d90+"]
+
+# Patron classes and their weights w_tau, per the Core Vitals spec:
+# visitors=0.01, registrants=0.2, returning=0.5, retained=1.
+#
+# The spec fixes the four weights but not where the returning/retained line
+# falls across the seven cohorts. We treat "retained" as an account that has
+# survived 90+ days; everything from the day after registration up to that
+# point is "returning". This is the one judgement call in the mapping -- it is
+# isolated here deliberately, and because every raw cohort is also emitted to
+# statsd individually, the boundary can be re-cut later without losing history.
+PATRON_CLASSES: dict[str, dict] = {
+    "visitor": {"weight": 0.01, "cohorts": ["visitor"]},
+    "registrant": {"weight": 0.20, "cohorts": ["d0"]},
+    "returning": {"weight": 0.50, "cohorts": ["d1+", "d7+", "d14+", "d30+"]},
+    "retained": {"weight": 1.00, "cohorts": ["d90+"]},
+}
+
+# Engagement point values, straight from the Score Schemas spreadsheet
+# (docs.google.com/spreadsheets/d/1tt9ekWRMVaNiMc3GKMP09W3YmBeMXoTwKJnxuaispRA,
+# gid=41518278). Mirrored in ol-kb/raw/google-docs/ and asserted by a test, so
+# the code and the schema cannot drift apart silently.
+EVENT_POINTS: dict[str, int] = {
+    "import_goodreads": 200,
+    "set_reading_goal": 150,
+    "read": 100,
+    "search_inside": 75,
+    "list_create": 50,
+    "follow": 50,
+    "edit": 25,
+    "readlog_completion": 20,
+    "star_rating": 20,
+    "readlog_currently_reading": 15,
+    "readlog_want_to_read": 10,
+    "checkin": 10,
+    "explorer_view": 10,
+    "search": 5,
+    "book_view": 5,
+    "author_view": 5,
+    "mybooks_view": 5,
+}
+
+# (Matomo eventCategory, eventAction) -> event name. Every tuple here was
+# checked against a full day of real Matomo traffic; a mapping that matches
+# nothing scores nothing, silently, which is how `read` came to be worth zero.
+RETENTION_EVENTS: dict[tuple[str, str], str] = {
+    ("PatronImports", "Goodreads"): "import_goodreads",
+    ("MyBooksLandingPage", "SetReadingGoal"): "set_reading_goal",
+    ("OnboardingCarouselClick", "YearlyReadingGoals"): "set_reading_goal",
+    # Every way a patron actually reaches the content counts as `read`. Borrow
+    # is a read behind a lending gate, not a lesser signal: ReadButton.html
+    # picks the label purely from whether a loan is needed, and both paths land
+    # on the same /borrow/ia/{ocaid} reader. The *Listen variants are the same
+    # buttons with read-aloud, and PrintDisabled is the same grant of access.
+    ("CTAClick", "Read"): "read",
+    ("CTAClick", "Borrow"): "read",
+    ("CTAClick", "PrintDisabled"): "read",
+    ("CTAClick", "ReadListen"): "read",
+    ("CTAClick", "BorrowListen"): "read",
+    ("CTAClick", "Listen"): "read",
+    # follow and readlog_* have been tracked app-side since PR #12367.
+    # FollowsPage and MyBooksPageHeader are wired but produced no events in the
+    # sampled day -- kept because they are correct, just low-traffic.
+    ("FollowsPage", "Follow"): "follow",
+    ("MyBooksPageHeader", "Follow"): "follow",
+    ("ListCardCarousel", "Follow"): "follow",
+    ("PatronPage", "Follow"): "follow",
+    ("CTAClick", "Edit"): "edit",
+    ("CTAClick", "StickyEdit"): "edit",
+    ("ReadingLog", "AlreadyRead"): "readlog_completion",
+    ("ReadingLog", "CurrentlyReading"): "readlog_currently_reading",
+    ("ReadingLog", "WantToRead"): "readlog_want_to_read",
+    ("CheckInForm", "SubmitCheckIn"): "checkin",
+    ("MainNav", "Explore"): "explorer_view",
+    ("MainNav", "MyBooks"): "mybooks_view",
+}
+
+# Engagement events tracked as page views (URL-triggered tags) rather than
+# custom events, matched against the URL's *path* by prefix -- see
+# _score_page_url, which sorts these longest-first so `/search/inside` cannot be
+# scored as `search`.
+PAGE_EVENTS: dict[str, str] = {
+    "/search": "search",
+    "/books/": "book_view",
+    "/works/": "book_view",
+    "/authors/": "author_view",
+}
+
+# Paths that would otherwise match a PAGE_EVENTS prefix but are not that event.
+# `/people/{user}/books/...` and `/account/books/...` are the reading-log shelves
+# (openlibrary/plugins/upstream/mybooks.py); they contain "/books/" but are not
+# book views, and being logged-in-only they would bias the heavily weighted
+# classes upward. `/search/inside` is search_inside, which has no Matomo source
+# yet and is declared in UNTRACKED_EVENTS -- scoring it as `search` would
+# quietly contradict that.
+NON_SCORING_PATHS: tuple[str, ...] = (
+    "/account/books/",
+    "/search/inside",
+)
+
+# The same reading-log shelves under their per-patron URL, which is dynamic
+# (`/people/{username}/books/already-read`) so it cannot be a static prefix.
+NON_SCORING_PATH_RE = re.compile(r"^/people/[^/]+/books(/|$)")
+
+# Matomo action types that represent a page view. "search" appears when a site
+# has search-parameter detection enabled server-side, in which case /search?q=
+# arrives as this type rather than "action" -- accepting it costs nothing and
+# avoids `search` silently scoring zero the way `read` did.
+PAGE_ACTION_TYPES: tuple[str, ...] = ("action", "page", "search")
+
+# Schema events with no working Matomo source, so they contribute 0 today.
+# Each needs app-side instrumentation or a corrected tag, not a code change here:
+#   list_create   -- no tracking attribute anywhere (#12366)
+#   search_inside -- no event fires; CTAClick|Preview and SearchInsideSuggestion|*
+#                    both exist but neither unambiguously means "read inside"
+#   star_rating   -- StarRating|StatsComponentClick is a stats-panel click, not a
+#                    rating; ratings are captured in Postgres but not in Matomo
+UNTRACKED_EVENTS: dict[str, int] = {
+    "search_inside": EVENT_POINTS["search_inside"],
+    "list_create": EVENT_POINTS["list_create"],
+    "star_rating": EVENT_POINTS["star_rating"],
+}
+
+
+def _utcnow() -> datetime.datetime:
+    return datetime.datetime.now(datetime.UTC)
+
+
+def _statsd_safe(name: str) -> str:
+    """Make a cohort name safe for a statsd/Graphite metric path (`d1+` -> `d1_plus`)."""
+    return name.replace("+", "_plus")
+
+
+def _cohort_to_class(cohort: str) -> str:
+    for cls, info in PATRON_CLASSES.items():
+        if cohort in info["cohorts"]:
+            return cls
+    return "visitor"
+
+
+def _score_visit(visit: dict) -> dict[str, int]:
+    """Return the engagement events earned in one visit, as {event_name: points}.
+
+    Each event type counts at most once per visit: a patron clicking the same
+    button ten times expressed one intent, not ten.
+    """
+    earned: dict[str, int] = {}
+    for action in visit.get("actionDetails") or []:
+        name = None
+        action_type = action.get("type", "")
+        if action_type == "event":
+            name = RETENTION_EVENTS.get((action.get("eventCategory", ""), action.get("eventAction", "")))
+        elif action_type in PAGE_ACTION_TYPES:
+            name = _score_page_url(action.get("url") or "")
+        if name:
+            earned[name] = EVENT_POINTS[name]
+    return earned
+
+
+def _score_page_url(url: str) -> str | None:
+    """Match a page view against PAGE_EVENTS on its *path*, most specific first.
+
+    Matching the whole URL as a substring is wrong in both directions: it scores
+    ``/account/books/want-to-read`` as a `book_view` because that path contains
+    ``/books/``, and it would score any third-party URL containing ``/works/``.
+    The first error is the damaging one, since reading-log pages are logged-in
+    only and land on the classes weighted 20-100x above `visitor`.
+    """
+    parts = urlsplit(url)
+    # Matomo should only ever report URLs for the tracked site, but a host check
+    # costs nothing and stops an off-site URL that happens to contain /works/
+    # from scoring as a book view.
+    if parts.netloc and not (parts.netloc == "openlibrary.org" or parts.netloc.endswith(".openlibrary.org")):
+        return None
+    path = parts.path
+    if not path.startswith("/"):
+        return None
+    if any(path.startswith(prefix) for prefix in NON_SCORING_PATHS) or NON_SCORING_PATH_RE.match(path):
+        return None
+    # Sorted longest-first so `/search/inside` never matches `/search`.
+    for prefix in sorted(PAGE_EVENTS, key=len, reverse=True):
+        if path.startswith(prefix):
+            return PAGE_EVENTS[prefix]
+    return None
+
+
+def _patron_id(visit: dict) -> str:
+    """Identify the patron behind a visit, or "" when it cannot be identified.
+
+    `userId` is preferred so one logged-in patron across two devices counts
+    once, but it is only populated if Matomo's setUserId is wired -- which it
+    is not yet -- so in practice this falls back to the per-device visitorId.
+
+    An empty result must not be added to a patron set: every unidentifiable
+    visit would collapse into one phantom patron carrying all of their points,
+    which inflates E_tau for whichever class it lands in. Callers count these
+    separately instead.
+    """
+    return visit.get("userId") or visit.get("visitorId") or ""
+
+
+def _visit_hour(visit: dict) -> datetime.datetime | None:
+    """The clock hour a visit belongs to, from its first action.
+
+    `firstActionTimestamp` is a Unix int on every visit `Live.getLastVisitsDetails`
+    returns; `serverTimestamp` is the fallback. A visit straddling an hour boundary
+    is attributed wholly to the hour it started in.
+    """
+    timestamp = visit.get("firstActionTimestamp") or visit.get("serverTimestamp")
+    if timestamp is None:
+        return None
+    try:
+        started = datetime.datetime.fromtimestamp(int(timestamp), datetime.UTC)
+    except TypeError, ValueError, OSError:
+        return None
+    return started.replace(minute=0, second=0, microsecond=0)
+
+
+def _summarize_visits(
+    visits: list[dict],
+    hours: int,
+    since: datetime.datetime,
+    dropped_no_timestamp: int = 0,
+    started_before_window: int = 0,
+    truncated: bool = False,
+) -> dict:
+    """Score a set of visits into cohort, class, and overall retention numbers.
+
+    `dropped_no_timestamp` and `truncated` describe the *fetch* rather than these
+    visits, and are threaded through so they reach `warnings` -- a score computed
+    from a truncated or partly-unusable feed must not look like a quiet hour.
+    """
+    seen_patrons: dict[str, set[str]] = {cohort: set() for cohort in COHORTS}
+    weighted_totals: dict[str, int] = dict.fromkeys(COHORTS, 0)
+    events: dict[str, dict] = {}
+    # Counted so a cohort dimension that stops arriving, or starts arriving with
+    # different labels, shows up as a warning rather than as a quietly smaller
+    # score. Renumbering dimension1 to dimension2 collapsed R_total ~54x with no
+    # warning at all before these existed.
+    missing_dimension = 0
+    unknown_cohort = 0
+    unidentified_patrons = 0
+
+    for visit in visits:
+        raw_cohort = visit.get("dimension1")
+        if not raw_cohort:
+            missing_dimension += 1
+            cohort = "visitor"
+        elif raw_cohort not in seen_patrons:
+            # An unrecognised bucket is treated as logged-out rather than
+            # dropped, so the visit still shows up somewhere in the totals.
+            unknown_cohort += 1
+            cohort = "visitor"
+        else:
+            cohort = raw_cohort
+
+        if patron := _patron_id(visit):
+            seen_patrons[cohort].add(patron)
+        else:
+            # Adding "" would merge every anonymous visit into one patron holding
+            # all their points, inflating E_tau for this cohort.
+            unidentified_patrons += 1
+
+        for name, points in _score_visit(visit).items():
+            weighted_totals[cohort] += points
+            entry = events.setdefault(name, {"count": 0, "points": points, "total": 0})
+            entry["count"] += 1
+            entry["total"] += points
+
+    cohorts = {
+        cohort: {
+            "patrons": len(seen_patrons[cohort]),
+            "weighted_total": weighted_totals[cohort],
+            "engagement": (weighted_totals[cohort] / len(seen_patrons[cohort]) if seen_patrons[cohort] else 0.0),
+        }
+        for cohort in COHORTS
+    }
+
+    classes = {}
+    for cls, info in PATRON_CLASSES.items():
+        patrons = sum(cohorts[cohort]["patrons"] for cohort in info["cohorts"])
+        weighted_total = sum(cohorts[cohort]["weighted_total"] for cohort in info["cohorts"])
+        engagement = weighted_total / patrons if patrons else 0.0
+        classes[cls] = {
+            "weight": info["weight"],
+            "cohorts": info["cohorts"],
+            "patrons": patrons,
+            "weighted_total": weighted_total,
+            "engagement": engagement,
+            # w_tau x P_tau x E_tau -- this class's share of R_total.
+            "contribution": info["weight"] * weighted_total,
+        }
+
+    r_total = sum(cls["contribution"] for cls in classes.values())
+    # Counted across all cohorts at once, not summed per class: a patron who
+    # appears in two cohorts within the window (an unknown-cohort fallback, or a
+    # d30+ -> d90+ crossing over a long window) would otherwise be counted twice
+    # and halve r_per_patron.
+    total_patrons = len(set().union(*seen_patrons.values())) if visits else 0
+
+    scores = {
+        "window_hours": hours,
+        "since": since.isoformat(),
+        "visits": len(visits),
+        "cohorts": cohorts,
+        "classes": classes,
+        # Which engagement events actually produced the score, most valuable
+        # first. This is what makes R_total explainable rather than just a number.
+        "events": dict(sorted(events.items(), key=lambda kv: -kv[1]["total"])),
+        "r_total": r_total,
+        "r_per_patron": r_total / total_patrons if total_patrons else 0.0,
+        "total_patrons": total_patrons,
+        # Data-quality counters. Non-zero values do not invalidate the score, but
+        # a large share of any of them means it is measuring less than it looks.
+        "data_quality": {
+            "missing_dimension": missing_dimension,
+            "unknown_cohort": unknown_cohort,
+            "unidentified_patrons": unidentified_patrons,
+            "dropped_no_timestamp": dropped_no_timestamp,
+            "started_before_window": started_before_window,
+            "truncated": truncated,
+        },
+    }
+    scores["warnings"] = _sanity_warnings(scores)
+    return scores
+
+
+def gather_retention_scores(matomo_token: str = "", hours: int = 1, client: MatomoClient | None = None) -> dict:
+    """Compute the Core Vitals Retention Score over the last `hours` hours as one window.
+
+    Returns per-cohort and per-class patron counts (P_tau), engagement (E_tau), the
+    events behind the score, the weighted overall score (R_total), and any sanity
+    warnings. Pass `client` to score against a stub instead of live Matomo.
+    """
+    client = client or MatomoClient(matomo_token)
+    since = _utcnow() - datetime.timedelta(hours=hours)
+    fetch = client.get_visits_since(since)
+    return _summarize_visits(fetch.visits, hours, since, truncated=fetch.truncated)
+
+
+def gather_retention_scores_by_hour(matomo_token: str = "", hours: int = 2, client: MatomoClient | None = None) -> list[dict]:
+    """Score each of the last `hours` clock hours separately, most recent first.
+
+    One Matomo fetch covers the whole span; visits are then bucketed by the hour
+    they started in. The first entry is the hour in progress and is flagged
+    `partial` -- it covers only the minutes elapsed so far, so it is not
+    comparable to a complete hour and should not be read as a drop.
+    """
+    client = client or MatomoClient(matomo_token)
+    current_hour = _utcnow().replace(minute=0, second=0, microsecond=0)
+    earliest = current_hour - datetime.timedelta(hours=hours - 1)
+
+    buckets: dict[datetime.datetime, list[dict]] = {earliest + datetime.timedelta(hours=n): [] for n in range(hours)}
+    fetch = client.get_visits_since(earliest)
+    no_timestamp = 0
+    started_earlier = 0
+    for visit in fetch.visits:
+        hour = _visit_hour(visit)
+        if hour in buckets:
+            buckets[hour].append(visit)
+        elif hour is None:
+            no_timestamp += 1
+        else:
+            # `minTimestamp` selects visits whose *last* action falls in the
+            # window, so a session that began earlier and is still active is
+            # returned but starts outside every bucket. Counted, not silently
+            # dropped -- measured at ~2% of a real 3-hour fetch.
+            started_earlier += 1
+
+    truncated = fetch.truncated
+    summaries = []
+    for hour_start in sorted(buckets, reverse=True):
+        summary = _summarize_visits(
+            buckets[hour_start], 1, hour_start, dropped_no_timestamp=no_timestamp, started_before_window=started_earlier, truncated=truncated
+        )
+        summary["hour_start"] = hour_start.isoformat()
+        summary["partial"] = hour_start == current_hour
+        summaries.append(summary)
+    return summaries
+
+
+# Share of visits that may show a given data-quality problem before it is worth
+# a warning. Some noise is normal; a tenth of the feed is not.
+QUALITY_WARN_FRACTION = 0.10
+
+# Above this share of patrons in `visitor`, the cohort dimension has almost
+# certainly stopped arriving rather than the traffic having genuinely changed.
+VISITOR_SHARE_WARN = 0.99
+
+
+def _sanity_warnings(scores: dict) -> list[str]:
+    """Flag results that look like an instrumentation failure rather than a quiet hour.
+
+    Every bug this pipeline has shipped presented as a plausible number rather
+    than an error: a cohort dimension read from the wrong place, and an event
+    mapped to a category that does not exist. Both produced a *smaller* score,
+    never a failure, so the checks here are deliberately about shape and data
+    quality rather than correctness -- which cannot be checked from inside.
+    """
+    warnings = []
+    visits = scores["visits"]
+    quality = scores["data_quality"]
+
+    if not visits:
+        warnings.append(f"Matomo returned no visits for the last {scores['window_hours']}h")
+
+    if quality["truncated"]:
+        warnings.append(f"the Matomo fetch was truncated, so this score covers only part of the window ({visits} visits)")
+
+    # Checked outside the `if visits` guard below: a bucket can be empty *because*
+    # its visits were dropped, which is exactly when this matters most.
+    if quality["dropped_no_timestamp"]:
+        warnings.append(f"{quality['dropped_no_timestamp']} visits had no usable timestamp and were not counted in any hour")
+    if quality["started_before_window"]:
+        warnings.append(f"{quality['started_before_window']} visits were still active in the window but began before it, so they were not counted in any hour")
+
+    if visits:
+        threshold = visits * QUALITY_WARN_FRACTION
+        if quality["missing_dimension"] > threshold:
+            warnings.append(
+                f"{quality['missing_dimension']}/{visits} visits had no `dimension1` cohort and were counted as `visitor` "
+                "-- if custom dimension 1 has been renumbered or disabled in Matomo, this score is badly understated"
+            )
+        if quality["unknown_cohort"] > threshold:
+            warnings.append(
+                f"{quality['unknown_cohort']}/{visits} visits had a `dimension1` value outside {COHORTS} and were counted as `visitor` "
+                "-- the cohort labels may have changed in get_days_registered()"
+            )
+        if quality["unidentified_patrons"] > threshold:
+            warnings.append(f"{quality['unidentified_patrons']}/{visits} visits had neither userId nor visitorId, so they scored points but no patron")
+        # The check that would have caught both historical bugs: a real hour of
+        # openlibrary.org traffic always contains some logged-in patrons.
+        total = scores["total_patrons"]
+        visitors = scores["cohorts"]["visitor"]["patrons"]
+        if total and visitors / total >= VISITOR_SHARE_WARN:
+            warnings.append(f"{visitors}/{total} patrons are `visitor` -- expected some logged-in traffic, so cohort tracking may be broken")
+
+    for cls, data in scores["classes"].items():
+        if data["patrons"] and not data["weighted_total"]:
+            warnings.append(f"{cls}: {data['patrons']} active patrons but zero scored engagement")
+    return warnings
+
+
+def retention_gauges(rscores: dict) -> dict[str, float]:
+    """Map a score result to the exact statsd gauges the hourly cron emits.
+
+    Kept as a pure function separate from the write so the same mapping can be
+    inspected, tested, or pointed at a different sink (a local SQLite table, for
+    instance) without duplicating the metric names.
+
+    Every raw cohort is emitted alongside the four-class rollup: the cohorts are
+    the storage primitive, so the D0 -> D1 -> D7 -> D30 curve stays visible and
+    the class boundaries can be redrawn later without losing history. Cohorts
+    and classes live under separate prefixes because `visitor` is the name of
+    both and would otherwise collide.
+
+    `points` (the unweighted event total) is emitted next to `patrons` and
+    `engagement` so re-weighting from history is exact arithmetic rather than a
+    reconstruction from `patrons x engagement`.
+    """
+    gauges: dict[str, float] = {}
+
+    for cohort, data in rscores["cohorts"].items():
+        safe = _statsd_safe(cohort)
+        gauges[f"{RETENTION_EVENT_PREFIX}.cohort.{safe}.patrons.hourly.total"] = data["patrons"]
+        gauges[f"{RETENTION_EVENT_PREFIX}.cohort.{safe}.engagement.hourly"] = data["engagement"]
+        gauges[f"{RETENTION_EVENT_PREFIX}.cohort.{safe}.points.hourly.total"] = data["weighted_total"]
+
+    for cls, data in rscores["classes"].items():
+        gauges[f"{RETENTION_EVENT_PREFIX}.class.{cls}.patrons.hourly.total"] = data["patrons"]
+        gauges[f"{RETENTION_EVENT_PREFIX}.class.{cls}.engagement.hourly"] = data["engagement"]
+        gauges[f"{RETENTION_EVENT_PREFIX}.class.{cls}.points.hourly.total"] = data["weighted_total"]
+
+    # The north-star number. This is the series to watch over the year.
+    gauges[f"{RETENTION_EVENT_PREFIX}.total_score.hourly"] = rscores["r_total"]
+    gauges[f"{RETENTION_EVENT_PREFIX}.per_patron.hourly"] = rscores["r_per_patron"]
+    gauges[f"{RETENTION_EVENT_PREFIX}.patrons.hourly.total"] = rscores["total_patrons"]
+
+    # Emitted so a broken feed is visible on the dashboard rather than only in a
+    # log line nobody reads. A rising `missing_dimension` alongside a falling
+    # score is the signature of instrumentation breaking, not engagement falling.
+    for name, value in rscores["data_quality"].items():
+        gauges[f"{RETENTION_EVENT_PREFIX}.quality.{name}.hourly"] = int(value)
+    return gauges
+
+
+def write_retention_to_statsd(configfile, rscores: dict) -> None:
+    """Push the retention gauges for one scored window to statsd."""
+    statsd = configure_statsd(configfile)
+    for key, value in retention_gauges(rscores).items():
+        statsd.gauge(key, value)

--- a/openlibrary/core/retention.py
+++ b/openlibrary/core/retention.py
@@ -1,0 +1,557 @@
+"""Core Vitals Retention Score -- how much value patrons are accessing (#11956).
+
+    E_tau(t)   = sum_e [C(e,tau,t) x w_e] / P_tau(t)
+    R_total(t) = sum_tau [w_tau x P_tau(t) x E_tau(t)]
+
+where tau is a patron class, P_tau its unique active patrons, and w_e the
+engagement point value of event e. See ``ol-kb/wiki/core-vitals.md``.
+
+**This module deliberately imports nothing from Open Library.** Retention is
+computed entirely from Matomo, and the intent is for it to move into a
+standalone Core Vitals service that runs as independently of openlibrary.org
+as possible. Keeping the import graph clean means that move is a file copy
+rather than an untangling -- and
+``openlibrary/tests/core/test_retention.py::TestImportIndependence`` fails if
+anyone couples it back to the app.
+
+Contrast ``openlibrary/admin/vitals.py``, which computes participation scores
+and is genuinely app-coupled: those come from Open Library's own database.
+"""
+
+import datetime
+import logging
+import os
+import re
+from urllib.parse import urlsplit
+
+import yaml
+from statsd import StatsClient
+
+from openlibrary.core.matomo import MatomoClient
+
+logger = logging.getLogger("openlibrary.retention")
+
+RETENTION_EVENT_PREFIX = "stats.ol.retention"
+
+
+def configure_statsd(configfile) -> StatsClient:
+    """Build a statsd client from an openlibrary.yml-shaped config file.
+
+    Deliberately duplicated from ``openlibrary/admin/vitals.py`` rather than
+    imported: importing that module pulls in 80+ app and infobase modules, which
+    would defeat this module's independence for the sake of eight lines.
+    """
+    with open(configfile) as f:
+        configs = yaml.safe_load(f)
+    url = configs.get("admin", {}).get("statsd_server", None)
+    if not url:
+        raise KeyError("StatsD server not configured")
+    host, _, port = url.partition(":")
+    return StatsClient(host, port)
+
+
+def resolve_token(configfile: str) -> str:
+    """The Matomo token, from the environment or the config file.
+
+    MATOMO_TOKEN wins so a developer never has to edit a tracked config to run
+    a scoring pass.
+    """
+    if token := os.environ.get("MATOMO_TOKEN"):
+        return token
+    with open(configfile) as f:
+        return (yaml.safe_load(f) or {}).get("matomo_api") or ""
+
+
+# Custom dimension 1 ("Days Since Registration"), set by get_days_registered()
+# in openlibrary/accounts/__init__.py. Buckets are discrete and mutually
+# exclusive, NOT cumulative -- "d1+" means 1-6 days, not "1 or more days".
+COHORTS = ["visitor", "d0", "d1+", "d7+", "d14+", "d30+", "d90+"]
+
+# Patron classes and their weights w_tau, per the Core Vitals spec:
+# visitors=0.01, registrants=0.2, returning=0.5, retained=1.
+#
+# The spec fixes the four weights but not where the returning/retained line
+# falls across the seven cohorts. We treat "retained" as an account that has
+# survived 90+ days; everything from the day after registration up to that
+# point is "returning". This is the one judgement call in the mapping -- it is
+# isolated here deliberately, and because every raw cohort is also emitted to
+# statsd individually, the boundary can be re-cut later without losing history.
+PATRON_CLASSES: dict[str, dict] = {
+    "visitor": {"weight": 0.01, "cohorts": ["visitor"]},
+    "registrant": {"weight": 0.20, "cohorts": ["d0"]},
+    "returning": {"weight": 0.50, "cohorts": ["d1+", "d7+", "d14+", "d30+"]},
+    "retained": {"weight": 1.00, "cohorts": ["d90+"]},
+}
+
+# Engagement point values, straight from the Score Schemas spreadsheet
+# (docs.google.com/spreadsheets/d/1tt9ekWRMVaNiMc3GKMP09W3YmBeMXoTwKJnxuaispRA,
+# gid=41518278). Mirrored in ol-kb/raw/google-docs/ and asserted by a test, so
+# the code and the schema cannot drift apart silently.
+EVENT_POINTS: dict[str, int] = {
+    "import_goodreads": 200,
+    "set_reading_goal": 150,
+    "read": 100,
+    "search_inside": 75,
+    "list_create": 50,
+    "follow": 50,
+    "edit": 25,
+    "readlog_completion": 20,
+    "star_rating": 20,
+    "readlog_currently_reading": 15,
+    "readlog_want_to_read": 10,
+    "checkin": 10,
+    "explorer_view": 10,
+    "search": 5,
+    "book_view": 5,
+    "author_view": 5,
+    "mybooks_view": 5,
+}
+
+# (Matomo eventCategory, eventAction) -> event name. Every tuple here was
+# checked against a full day of real Matomo traffic; a mapping that matches
+# nothing scores nothing, silently, which is how `read` came to be worth zero.
+RETENTION_EVENTS: dict[tuple[str, str], str] = {
+    ("PatronImports", "Goodreads"): "import_goodreads",
+    ("MyBooksLandingPage", "SetReadingGoal"): "set_reading_goal",
+    ("OnboardingCarouselClick", "YearlyReadingGoals"): "set_reading_goal",
+    # Every way a patron actually reaches the content counts as `read`. Borrow
+    # is a read behind a lending gate, not a lesser signal: ReadButton.html
+    # picks the label purely from whether a loan is needed, and both paths land
+    # on the same /borrow/ia/{ocaid} reader. The *Listen variants are the same
+    # buttons with read-aloud, and PrintDisabled is the same grant of access.
+    ("CTAClick", "Read"): "read",
+    ("CTAClick", "Borrow"): "read",
+    ("CTAClick", "PrintDisabled"): "read",
+    ("CTAClick", "ReadListen"): "read",
+    ("CTAClick", "BorrowListen"): "read",
+    ("CTAClick", "Listen"): "read",
+    # follow and readlog_* have been tracked app-side since PR #12367.
+    # FollowsPage and MyBooksPageHeader are wired but produced no events in the
+    # sampled day -- kept because they are correct, just low-traffic.
+    ("FollowsPage", "Follow"): "follow",
+    ("MyBooksPageHeader", "Follow"): "follow",
+    ("ListCardCarousel", "Follow"): "follow",
+    ("PatronPage", "Follow"): "follow",
+    ("CTAClick", "Edit"): "edit",
+    ("CTAClick", "StickyEdit"): "edit",
+    ("ReadingLog", "AlreadyRead"): "readlog_completion",
+    ("ReadingLog", "CurrentlyReading"): "readlog_currently_reading",
+    ("ReadingLog", "WantToRead"): "readlog_want_to_read",
+    ("CheckInForm", "SubmitCheckIn"): "checkin",
+    ("MainNav", "Explore"): "explorer_view",
+    ("MainNav", "MyBooks"): "mybooks_view",
+}
+
+# Engagement events tracked as page views (URL-triggered tags) rather than
+# custom events, matched against the URL's *path* by prefix -- see
+# _score_page_url, which sorts these longest-first so `/search/inside` cannot be
+# scored as `search`.
+PAGE_EVENTS: dict[str, str] = {
+    "/search": "search",
+    "/books/": "book_view",
+    "/works/": "book_view",
+    "/authors/": "author_view",
+}
+
+# Paths that would otherwise match a PAGE_EVENTS prefix but are not that event.
+# `/people/{user}/books/...` and `/account/books/...` are the reading-log shelves
+# (openlibrary/plugins/upstream/mybooks.py); they contain "/books/" but are not
+# book views, and being logged-in-only they would bias the heavily weighted
+# classes upward. `/search/inside` is search_inside, which has no Matomo source
+# yet and is declared in UNTRACKED_EVENTS -- scoring it as `search` would
+# quietly contradict that.
+NON_SCORING_PATHS: tuple[str, ...] = (
+    "/account/books/",
+    "/search/inside",
+)
+
+# The same reading-log shelves under their per-patron URL, which is dynamic
+# (`/people/{username}/books/already-read`) so it cannot be a static prefix.
+NON_SCORING_PATH_RE = re.compile(r"^/people/[^/]+/books(/|$)")
+
+# Matomo action types that represent a page view. "search" appears when a site
+# has search-parameter detection enabled server-side, in which case /search?q=
+# arrives as this type rather than "action" -- accepting it costs nothing and
+# avoids `search` silently scoring zero the way `read` did.
+PAGE_ACTION_TYPES: tuple[str, ...] = ("action", "page", "search")
+
+# Schema events with no working Matomo source, so they contribute 0 today.
+# Each needs app-side instrumentation or a corrected tag, not a code change here:
+#   list_create   -- no tracking attribute anywhere (#12366)
+#   search_inside -- no event fires; CTAClick|Preview and SearchInsideSuggestion|*
+#                    both exist but neither unambiguously means "read inside"
+#   star_rating   -- StarRating|StatsComponentClick is a stats-panel click, not a
+#                    rating; ratings are captured in Postgres but not in Matomo
+UNTRACKED_EVENTS: dict[str, int] = {
+    "search_inside": EVENT_POINTS["search_inside"],
+    "list_create": EVENT_POINTS["list_create"],
+    "star_rating": EVENT_POINTS["star_rating"],
+}
+
+
+def _utcnow() -> datetime.datetime:
+    return datetime.datetime.now(datetime.UTC)
+
+
+def _statsd_safe(name: str) -> str:
+    """Make a cohort name safe for a statsd/Graphite metric path (`d1+` -> `d1_plus`)."""
+    return name.replace("+", "_plus")
+
+
+def _cohort_to_class(cohort: str) -> str:
+    for cls, info in PATRON_CLASSES.items():
+        if cohort in info["cohorts"]:
+            return cls
+    return "visitor"
+
+
+def _score_visit(visit: dict) -> dict[str, int]:
+    """Return the engagement events earned in one visit, as {event_name: points}.
+
+    Each event type counts at most once per visit: a patron clicking the same
+    button ten times expressed one intent, not ten.
+    """
+    earned: dict[str, int] = {}
+    for action in visit.get("actionDetails") or []:
+        name = None
+        action_type = action.get("type", "")
+        if action_type == "event":
+            name = RETENTION_EVENTS.get((action.get("eventCategory", ""), action.get("eventAction", "")))
+        elif action_type in PAGE_ACTION_TYPES:
+            name = _score_page_url(action.get("url") or "")
+        if name:
+            earned[name] = EVENT_POINTS[name]
+    return earned
+
+
+def _score_page_url(url: str) -> str | None:
+    """Match a page view against PAGE_EVENTS on its *path*, most specific first.
+
+    Matching the whole URL as a substring is wrong in both directions: it scores
+    ``/account/books/want-to-read`` as a `book_view` because that path contains
+    ``/books/``, and it would score any third-party URL containing ``/works/``.
+    The first error is the damaging one, since reading-log pages are logged-in
+    only and land on the classes weighted 20-100x above `visitor`.
+    """
+    parts = urlsplit(url)
+    # Matomo should only ever report URLs for the tracked site, but a host check
+    # costs nothing and stops an off-site URL that happens to contain /works/
+    # from scoring as a book view.
+    if parts.netloc and not (parts.netloc == "openlibrary.org" or parts.netloc.endswith(".openlibrary.org")):
+        return None
+    path = parts.path
+    if not path.startswith("/"):
+        return None
+    if any(path.startswith(prefix) for prefix in NON_SCORING_PATHS) or NON_SCORING_PATH_RE.match(path):
+        return None
+    # Sorted longest-first so `/search/inside` never matches `/search`.
+    for prefix in sorted(PAGE_EVENTS, key=len, reverse=True):
+        if path.startswith(prefix):
+            return PAGE_EVENTS[prefix]
+    return None
+
+
+def _patron_id(visit: dict) -> str:
+    """Identify the patron behind a visit, or "" when it cannot be identified.
+
+    `userId` is preferred so one logged-in patron across two devices counts
+    once, but it is only populated if Matomo's setUserId is wired -- which it
+    is not yet -- so in practice this falls back to the per-device visitorId.
+
+    An empty result must not be added to a patron set: every unidentifiable
+    visit would collapse into one phantom patron carrying all of their points,
+    which inflates E_tau for whichever class it lands in. Callers count these
+    separately instead.
+    """
+    return visit.get("userId") or visit.get("visitorId") or ""
+
+
+def _visit_hour(visit: dict) -> datetime.datetime | None:
+    """The clock hour a visit belongs to, from its first action.
+
+    `firstActionTimestamp` is a Unix int on every visit `Live.getLastVisitsDetails`
+    returns; `serverTimestamp` is the fallback. A visit straddling an hour boundary
+    is attributed wholly to the hour it started in.
+    """
+    timestamp = visit.get("firstActionTimestamp") or visit.get("serverTimestamp")
+    if timestamp is None:
+        return None
+    try:
+        started = datetime.datetime.fromtimestamp(int(timestamp), datetime.UTC)
+    except TypeError, ValueError, OSError:
+        return None
+    return started.replace(minute=0, second=0, microsecond=0)
+
+
+def _summarize_visits(
+    visits: list[dict],
+    hours: int,
+    since: datetime.datetime,
+    dropped_no_timestamp: int = 0,
+    started_before_window: int = 0,
+    truncated: bool = False,
+) -> dict:
+    """Score a set of visits into cohort, class, and overall retention numbers.
+
+    `dropped_no_timestamp` and `truncated` describe the *fetch* rather than these
+    visits, and are threaded through so they reach `warnings` -- a score computed
+    from a truncated or partly-unusable feed must not look like a quiet hour.
+    """
+    seen_patrons: dict[str, set[str]] = {cohort: set() for cohort in COHORTS}
+    weighted_totals: dict[str, int] = dict.fromkeys(COHORTS, 0)
+    events: dict[str, dict] = {}
+    # Counted so a cohort dimension that stops arriving, or starts arriving with
+    # different labels, shows up as a warning rather than as a quietly smaller
+    # score. Renumbering dimension1 to dimension2 collapsed R_total ~54x with no
+    # warning at all before these existed.
+    missing_dimension = 0
+    unknown_cohort = 0
+    unidentified_patrons = 0
+
+    for visit in visits:
+        raw_cohort = visit.get("dimension1")
+        if not raw_cohort:
+            missing_dimension += 1
+            cohort = "visitor"
+        elif raw_cohort not in seen_patrons:
+            # An unrecognised bucket is treated as logged-out rather than
+            # dropped, so the visit still shows up somewhere in the totals.
+            unknown_cohort += 1
+            cohort = "visitor"
+        else:
+            cohort = raw_cohort
+
+        if patron := _patron_id(visit):
+            seen_patrons[cohort].add(patron)
+        else:
+            # Adding "" would merge every anonymous visit into one patron holding
+            # all their points, inflating E_tau for this cohort.
+            unidentified_patrons += 1
+
+        for name, points in _score_visit(visit).items():
+            weighted_totals[cohort] += points
+            entry = events.setdefault(name, {"count": 0, "points": points, "total": 0})
+            entry["count"] += 1
+            entry["total"] += points
+
+    cohorts = {
+        cohort: {
+            "patrons": len(seen_patrons[cohort]),
+            "weighted_total": weighted_totals[cohort],
+            "engagement": (weighted_totals[cohort] / len(seen_patrons[cohort]) if seen_patrons[cohort] else 0.0),
+        }
+        for cohort in COHORTS
+    }
+
+    classes = {}
+    for cls, info in PATRON_CLASSES.items():
+        patrons = sum(cohorts[cohort]["patrons"] for cohort in info["cohorts"])
+        weighted_total = sum(cohorts[cohort]["weighted_total"] for cohort in info["cohorts"])
+        engagement = weighted_total / patrons if patrons else 0.0
+        classes[cls] = {
+            "weight": info["weight"],
+            "cohorts": info["cohorts"],
+            "patrons": patrons,
+            "weighted_total": weighted_total,
+            "engagement": engagement,
+            # w_tau x P_tau x E_tau -- this class's share of R_total.
+            "contribution": info["weight"] * weighted_total,
+        }
+
+    r_total = sum(cls["contribution"] for cls in classes.values())
+    # Counted across all cohorts at once, not summed per class: a patron who
+    # appears in two cohorts within the window (an unknown-cohort fallback, or a
+    # d30+ -> d90+ crossing over a long window) would otherwise be counted twice
+    # and halve r_per_patron.
+    total_patrons = len(set().union(*seen_patrons.values())) if visits else 0
+
+    scores = {
+        "window_hours": hours,
+        "since": since.isoformat(),
+        "visits": len(visits),
+        "cohorts": cohorts,
+        "classes": classes,
+        # Which engagement events actually produced the score, most valuable
+        # first. This is what makes R_total explainable rather than just a number.
+        "events": dict(sorted(events.items(), key=lambda kv: -kv[1]["total"])),
+        "r_total": r_total,
+        "r_per_patron": r_total / total_patrons if total_patrons else 0.0,
+        "total_patrons": total_patrons,
+        # Data-quality counters. Non-zero values do not invalidate the score, but
+        # a large share of any of them means it is measuring less than it looks.
+        "data_quality": {
+            "missing_dimension": missing_dimension,
+            "unknown_cohort": unknown_cohort,
+            "unidentified_patrons": unidentified_patrons,
+            "dropped_no_timestamp": dropped_no_timestamp,
+            "started_before_window": started_before_window,
+            "truncated": truncated,
+        },
+    }
+    scores["warnings"] = _sanity_warnings(scores)
+    return scores
+
+
+def gather_retention_scores(matomo_token: str = "", hours: int = 1, client: MatomoClient | None = None) -> dict:
+    """Compute the Core Vitals Retention Score over the last `hours` hours as one window.
+
+    Returns per-cohort and per-class patron counts (P_tau), engagement (E_tau), the
+    events behind the score, the weighted overall score (R_total), and any sanity
+    warnings. Pass `client` to score against a stub instead of live Matomo.
+    """
+    client = client or MatomoClient(matomo_token)
+    since = _utcnow() - datetime.timedelta(hours=hours)
+    visits = client.get_visits_since(since)
+    return _summarize_visits(visits, hours, since, truncated=bool(getattr(client, "truncated", False)))
+
+
+def gather_retention_scores_by_hour(matomo_token: str = "", hours: int = 2, client: MatomoClient | None = None) -> list[dict]:
+    """Score each of the last `hours` clock hours separately, most recent first.
+
+    One Matomo fetch covers the whole span; visits are then bucketed by the hour
+    they started in. The first entry is the hour in progress and is flagged
+    `partial` -- it covers only the minutes elapsed so far, so it is not
+    comparable to a complete hour and should not be read as a drop.
+    """
+    client = client or MatomoClient(matomo_token)
+    current_hour = _utcnow().replace(minute=0, second=0, microsecond=0)
+    earliest = current_hour - datetime.timedelta(hours=hours - 1)
+
+    buckets: dict[datetime.datetime, list[dict]] = {earliest + datetime.timedelta(hours=n): [] for n in range(hours)}
+    no_timestamp = 0
+    started_earlier = 0
+    for visit in client.get_visits_since(earliest):
+        hour = _visit_hour(visit)
+        if hour in buckets:
+            buckets[hour].append(visit)
+        elif hour is None:
+            no_timestamp += 1
+        else:
+            # `minTimestamp` selects visits whose *last* action falls in the
+            # window, so a session that began earlier and is still active is
+            # returned but starts outside every bucket. Counted, not silently
+            # dropped -- measured at ~2% of a real 3-hour fetch.
+            started_earlier += 1
+
+    truncated = bool(getattr(client, "truncated", False))
+    summaries = []
+    for hour_start in sorted(buckets, reverse=True):
+        summary = _summarize_visits(
+            buckets[hour_start], 1, hour_start, dropped_no_timestamp=no_timestamp, started_before_window=started_earlier, truncated=truncated
+        )
+        summary["hour_start"] = hour_start.isoformat()
+        summary["partial"] = hour_start == current_hour
+        summaries.append(summary)
+    return summaries
+
+
+# Share of visits that may show a given data-quality problem before it is worth
+# a warning. Some noise is normal; a tenth of the feed is not.
+QUALITY_WARN_FRACTION = 0.10
+
+# Above this share of patrons in `visitor`, the cohort dimension has almost
+# certainly stopped arriving rather than the traffic having genuinely changed.
+VISITOR_SHARE_WARN = 0.99
+
+
+def _sanity_warnings(scores: dict) -> list[str]:
+    """Flag results that look like an instrumentation failure rather than a quiet hour.
+
+    Every bug this pipeline has shipped presented as a plausible number rather
+    than an error: a cohort dimension read from the wrong place, and an event
+    mapped to a category that does not exist. Both produced a *smaller* score,
+    never a failure, so the checks here are deliberately about shape and data
+    quality rather than correctness -- which cannot be checked from inside.
+    """
+    warnings = []
+    visits = scores["visits"]
+    quality = scores["data_quality"]
+
+    if not visits:
+        warnings.append(f"Matomo returned no visits for the last {scores['window_hours']}h")
+
+    if quality["truncated"]:
+        warnings.append(f"the Matomo fetch was truncated, so this score covers only part of the window ({visits} visits)")
+
+    # Checked outside the `if visits` guard below: a bucket can be empty *because*
+    # its visits were dropped, which is exactly when this matters most.
+    if quality["dropped_no_timestamp"]:
+        warnings.append(f"{quality['dropped_no_timestamp']} visits had no usable timestamp and were not counted in any hour")
+    if quality["started_before_window"]:
+        warnings.append(f"{quality['started_before_window']} visits were still active in the window but began before it, so they were not counted in any hour")
+
+    if visits:
+        threshold = visits * QUALITY_WARN_FRACTION
+        if quality["missing_dimension"] > threshold:
+            warnings.append(
+                f"{quality['missing_dimension']}/{visits} visits had no `dimension1` cohort and were counted as `visitor` "
+                "-- if custom dimension 1 has been renumbered or disabled in Matomo, this score is badly understated"
+            )
+        if quality["unknown_cohort"] > threshold:
+            warnings.append(
+                f"{quality['unknown_cohort']}/{visits} visits had a `dimension1` value outside {COHORTS} and were counted as `visitor` "
+                "-- the cohort labels may have changed in get_days_registered()"
+            )
+        if quality["unidentified_patrons"] > threshold:
+            warnings.append(f"{quality['unidentified_patrons']}/{visits} visits had neither userId nor visitorId, so they scored points but no patron")
+        # The check that would have caught both historical bugs: a real hour of
+        # openlibrary.org traffic always contains some logged-in patrons.
+        total = scores["total_patrons"]
+        visitors = scores["cohorts"]["visitor"]["patrons"]
+        if total and visitors / total >= VISITOR_SHARE_WARN:
+            warnings.append(f"{visitors}/{total} patrons are `visitor` -- expected some logged-in traffic, so cohort tracking may be broken")
+
+    for cls, data in scores["classes"].items():
+        if data["patrons"] and not data["weighted_total"]:
+            warnings.append(f"{cls}: {data['patrons']} active patrons but zero scored engagement")
+    return warnings
+
+
+def retention_gauges(rscores: dict) -> dict[str, float]:
+    """Map a score result to the exact statsd gauges the hourly cron emits.
+
+    Kept as a pure function separate from the write so the same mapping can be
+    inspected, tested, or pointed at a different sink (a local SQLite table, for
+    instance) without duplicating the metric names.
+
+    Every raw cohort is emitted alongside the four-class rollup: the cohorts are
+    the storage primitive, so the D0 -> D1 -> D7 -> D30 curve stays visible and
+    the class boundaries can be redrawn later without losing history. Cohorts
+    and classes live under separate prefixes because `visitor` is the name of
+    both and would otherwise collide.
+
+    `points` (the unweighted event total) is emitted next to `patrons` and
+    `engagement` so re-weighting from history is exact arithmetic rather than a
+    reconstruction from `patrons x engagement`.
+    """
+    gauges: dict[str, float] = {}
+
+    for cohort, data in rscores["cohorts"].items():
+        safe = _statsd_safe(cohort)
+        gauges[f"{RETENTION_EVENT_PREFIX}.cohort.{safe}.patrons.hourly.total"] = data["patrons"]
+        gauges[f"{RETENTION_EVENT_PREFIX}.cohort.{safe}.engagement.hourly"] = data["engagement"]
+        gauges[f"{RETENTION_EVENT_PREFIX}.cohort.{safe}.points.hourly.total"] = data["weighted_total"]
+
+    for cls, data in rscores["classes"].items():
+        gauges[f"{RETENTION_EVENT_PREFIX}.class.{cls}.patrons.hourly.total"] = data["patrons"]
+        gauges[f"{RETENTION_EVENT_PREFIX}.class.{cls}.engagement.hourly"] = data["engagement"]
+        gauges[f"{RETENTION_EVENT_PREFIX}.class.{cls}.points.hourly.total"] = data["weighted_total"]
+
+    # The north-star number. This is the series to watch over the year.
+    gauges[f"{RETENTION_EVENT_PREFIX}.total_score.hourly"] = rscores["r_total"]
+    gauges[f"{RETENTION_EVENT_PREFIX}.per_patron.hourly"] = rscores["r_per_patron"]
+    gauges[f"{RETENTION_EVENT_PREFIX}.patrons.hourly.total"] = rscores["total_patrons"]
+
+    # Emitted so a broken feed is visible on the dashboard rather than only in a
+    # log line nobody reads. A rising `missing_dimension` alongside a falling
+    # score is the signature of instrumentation breaking, not engagement falling.
+    for name, value in rscores["data_quality"].items():
+        gauges[f"{RETENTION_EVENT_PREFIX}.quality.{name}.hourly"] = int(value)
+    return gauges
+
+
+def write_retention_to_statsd(configfile, rscores: dict) -> None:
+    """Push the retention gauges for one scored window to statsd."""
+    statsd = configure_statsd(configfile)
+    for key, value in retention_gauges(rscores).items():
+        statsd.gauge(key, value)

--- a/openlibrary/tests/core/test_retention.py
+++ b/openlibrary/tests/core/test_retention.py
@@ -1,0 +1,578 @@
+"""Tests for Core Vitals retention scoring (issue #11956).
+
+Two bugs found in the prototype are pinned by regression tests here:
+
+1. ``dimension1`` is a flat field on the visit, not nested under
+   ``customDimensions``. Reading it wrongly silently classified every visit as
+   ``visitor`` and undercounted the score ~5.85x.
+2. ``follow`` / ``readlog_*`` events have been tracked app-side since PR #12367
+   but were absent from the scoring table, so they counted for nothing.
+"""
+
+import datetime
+import json as jsonlib
+import pathlib
+import subprocess
+import sys
+from typing import ClassVar
+from unittest.mock import Mock
+
+import pytest
+
+from openlibrary.core import matomo, retention
+from openlibrary.core.matomo import VisitFetch
+
+
+def _visit(dimension1="visitor", visitor_id="v1", user_id=None, events=(), urls=(), timestamp=None):
+    """Build a Live.getLastVisitsDetails-shaped visit record."""
+    actions = [{"type": "event", "eventCategory": category, "eventAction": action} for category, action in events]
+    actions += [{"type": "action", "url": url} for url in urls]
+    visit = {
+        "dimension1": dimension1,
+        "visitorId": visitor_id,
+        "userId": user_id,
+        "actionDetails": actions,
+    }
+    if timestamp is not None:
+        visit["firstActionTimestamp"] = timestamp
+    return visit
+
+
+def _stub_client(visits, truncated_reason=None):
+    """A stand-in MatomoClient returning a real VisitFetch.
+
+    Using the real dataclass rather than a Mock means the truncation signal
+    cannot be accidentally truthy -- an auto-created Mock attribute is, which
+    previously made every stubbed fetch look truncated.
+    """
+    client = Mock()
+    client.get_visits_since.return_value = VisitFetch(list(visits), truncated_reason=truncated_reason)
+    return client
+
+
+def _gather(visits, hours=1):
+    return retention.gather_retention_scores(client=_stub_client(visits), hours=hours)
+
+
+class TestEventPointsMatchTheSchema:
+    """Pin the weights to the Score Schemas spreadsheet (gid=41518278).
+
+    Transcribed from the source of truth. If the spreadsheet changes, this test
+    should be updated in the same commit as EVENT_POINTS -- the point is that
+    the two can never drift apart unnoticed.
+    """
+
+    SCHEMA: ClassVar[dict[str, int]] = {
+        "import_goodreads": 200,
+        "set_reading_goal": 150,
+        "read": 100,
+        "search_inside": 75,
+        "list_create": 50,
+        "follow": 50,
+        "edit": 25,
+        "readlog_completion": 20,
+        "star_rating": 20,
+        "readlog_currently_reading": 15,
+        "readlog_want_to_read": 10,
+        "checkin": 10,
+        "explorer_view": 10,
+        "search": 5,
+        "book_view": 5,
+        "author_view": 5,
+        "mybooks_view": 5,
+    }
+
+    def test_points_match_exactly(self):
+        assert retention.EVENT_POINTS == self.SCHEMA
+
+    def test_every_mapped_event_has_a_point_value(self):
+        mapped = set(retention.RETENTION_EVENTS.values()) | set(retention.PAGE_EVENTS.values())
+        assert mapped <= set(retention.EVENT_POINTS)
+
+    def test_every_schema_event_is_either_mapped_or_declared_untracked(self):
+        """A schema event that is neither scored nor listed as a gap is invisible."""
+        mapped = set(retention.RETENTION_EVENTS.values()) | set(retention.PAGE_EVENTS.values())
+        assert mapped | set(retention.UNTRACKED_EVENTS) == set(retention.EVENT_POINTS)
+
+    def test_untracked_events_carry_their_schema_points(self):
+        for name, points in retention.UNTRACKED_EVENTS.items():
+            assert points == self.SCHEMA[name]
+
+
+class TestReadMapping:
+    """`read` is the highest-weight event; it silently scored 0 for the whole
+    prototype because it was mapped to a Matomo category that does not exist."""
+
+    @pytest.mark.parametrize("action", ["Read", "Borrow", "PrintDisabled", "ReadListen", "BorrowListen", "Listen"])
+    def test_every_route_to_the_content_counts_as_a_read(self, action):
+        assert retention._score_visit(_visit(events=[("CTAClick", action)])) == {"read": 100}
+
+    def test_borrow_is_worth_the_same_as_read(self):
+        """Borrowing is reading behind a lending gate, not a weaker signal."""
+        borrow = retention._score_visit(_visit(events=[("CTAClick", "Borrow")]))
+        read = retention._score_visit(_visit(events=[("CTAClick", "Read")]))
+        assert borrow == read
+
+    def test_the_dead_embed_mapping_is_gone(self):
+        """`Embed` is not a category Matomo ever emits for openlibrary.org."""
+        assert not any(category == "Embed" for category, _ in retention.RETENTION_EVENTS)
+
+    @pytest.mark.parametrize("action", ["JoinWaitlist", "LeaveWaitlist", "Locate", "CheckedOut", "Preview"])
+    def test_actions_that_do_not_deliver_content_are_not_reads(self, action):
+        assert retention._score_visit(_visit(events=[("CTAClick", action)])) == {}
+
+
+class TestCohortToClass:
+    @pytest.mark.parametrize(
+        ("cohort", "expected"),
+        [
+            ("visitor", "visitor"),
+            ("d0", "registrant"),
+            ("d1+", "returning"),
+            ("d7+", "returning"),
+            ("d14+", "returning"),
+            ("d30+", "returning"),
+            ("d90+", "retained"),
+        ],
+    )
+    def test_every_cohort_maps_to_a_class(self, cohort, expected):
+        assert retention._cohort_to_class(cohort) == expected
+
+    def test_all_cohorts_are_covered_exactly_once(self):
+        """No cohort may be double-counted or dropped -- that would silently skew the score."""
+        assigned = [cohort for info in retention.PATRON_CLASSES.values() for cohort in info["cohorts"]]
+        assert sorted(assigned) == sorted(retention.COHORTS)
+        assert len(assigned) == len(set(assigned))
+
+    def test_unknown_cohort_falls_back_to_visitor(self):
+        assert retention._cohort_to_class("nonsense") == "visitor"
+
+    def test_class_weights_match_the_spec(self):
+        weights = {cls: info["weight"] for cls, info in retention.PATRON_CLASSES.items()}
+        assert weights == {"visitor": 0.01, "registrant": 0.20, "returning": 0.50, "retained": 1.00}
+
+
+class TestScoreVisit:
+    def test_scores_a_known_custom_event(self):
+        assert retention._score_visit(_visit(events=[("CTAClick", "Read")])) == {"read": 100}
+
+    def test_ignores_unknown_events(self):
+        assert retention._score_visit(_visit(events=[("Nope", "Nothing")])) == {}
+
+    def test_caps_each_event_type_at_once_per_visit(self):
+        """Ten rapid clicks are one expression of intent, not ten."""
+        visit = _visit(events=[("CTAClick", "Read")] * 10)
+        assert retention._score_visit(visit) == {"read": 100}
+
+    def test_different_event_types_accumulate(self):
+        visit = _visit(events=[("CTAClick", "Read"), ("MainNav", "Explore")])
+        assert retention._score_visit(visit) == {"read": 100, "explorer_view": 10}
+
+    def test_scores_page_view_events_by_url_path_prefix(self):
+        visit = _visit(urls=["https://openlibrary.org/works/OL45W/Book", "https://openlibrary.org/search?q=x"])
+        assert retention._score_visit(visit) == {"book_view": 5, "search": 5}
+
+    def test_tolerates_a_missing_action_details(self):
+        assert retention._score_visit({"dimension1": "d0"}) == {}
+
+    def test_tolerates_a_null_action_details(self):
+        assert retention._score_visit({"actionDetails": None}) == {}
+
+    @pytest.mark.parametrize(
+        ("category", "action", "event_name"),
+        [
+            ("FollowsPage", "Follow", "follow"),
+            ("MyBooksPageHeader", "Follow", "follow"),
+            ("ListCardCarousel", "Follow", "follow"),
+            ("PatronPage", "Follow", "follow"),
+            ("ReadingLog", "WantToRead", "readlog_want_to_read"),
+            ("ReadingLog", "CurrentlyReading", "readlog_currently_reading"),
+            ("ReadingLog", "AlreadyRead", "readlog_completion"),
+        ],
+    )
+    def test_regression_follow_and_readlog_events_are_scored(self, category, action, event_name):
+        """These are tracked app-side by PR #12367; scoring them as 0 was bug 2."""
+        scored = retention._score_visit(_visit(events=[(category, action)]))
+        assert event_name in scored
+        assert scored[event_name] > 0
+
+
+class TestGatherRetentionScores:
+    def test_regression_reads_dimension1_as_a_flat_field(self):
+        """Bug 1: reading a nested `customDimensions` made every visit a `visitor`."""
+        result = _gather([_visit(dimension1="d0", visitor_id="a"), _visit(dimension1="d90+", visitor_id="b")])
+        assert result["cohorts"]["d0"]["patrons"] == 1
+        assert result["cohorts"]["d90+"]["patrons"] == 1
+        assert result["cohorts"]["visitor"]["patrons"] == 0
+
+    def test_counts_unique_patrons_not_visits(self):
+        """P_tau is *unique patrons*; counting visits inflates it for repeat sessions."""
+        visits = [
+            _visit(dimension1="d0", visitor_id="same"),
+            _visit(dimension1="d0", visitor_id="same"),
+            _visit(dimension1="d0", visitor_id="other"),
+        ]
+        result = _gather(visits)
+        assert result["cohorts"]["d0"]["patrons"] == 2
+        assert result["visits"] == 3
+
+    def test_prefers_user_id_over_visitor_id_for_identity(self):
+        """A logged-in patron on two devices is one patron."""
+        visits = [
+            _visit(dimension1="d1+", visitor_id="deviceA", user_id="patron1"),
+            _visit(dimension1="d1+", visitor_id="deviceB", user_id="patron1"),
+        ]
+        assert _gather(visits)["cohorts"]["d1+"]["patrons"] == 1
+
+    def test_engagement_is_weighted_points_per_patron(self):
+        visits = [
+            _visit(dimension1="d0", visitor_id="a", events=[("CTAClick", "Read")]),  # 100
+            _visit(dimension1="d0", visitor_id="b", events=[("MainNav", "Explore")]),  # 10
+        ]
+        result = _gather(visits)
+        assert result["classes"]["registrant"]["weighted_total"] == 110
+        assert result["classes"]["registrant"]["patrons"] == 2
+        assert result["classes"]["registrant"]["engagement"] == 55.0
+
+    def test_r_total_applies_class_weights(self):
+        visits = [
+            _visit(dimension1="visitor", visitor_id="v", events=[("CTAClick", "Read")]),  # 100 * 0.01 = 1
+            _visit(dimension1="d0", visitor_id="r", events=[("CTAClick", "Read")]),  # 100 * 0.20 = 20
+            _visit(dimension1="d1+", visitor_id="g", events=[("CTAClick", "Read")]),  # 100 * 0.50 = 50
+            _visit(dimension1="d90+", visitor_id="t", events=[("CTAClick", "Read")]),  # 100 * 1.00 = 100
+        ]
+        result = _gather(visits)
+        assert result["r_total"] == pytest.approx(171.0)
+        assert result["r_per_patron"] == pytest.approx(171.0 / 4)
+
+    def test_reports_all_seven_cohorts_even_when_empty(self):
+        """Cohorts are the storage primitive; the 4 classes are a rollup on top."""
+        result = _gather([])
+        assert set(result["cohorts"]) == set(retention.COHORTS)
+        assert set(result["classes"]) == set(retention.PATRON_CLASSES)
+        assert result["r_total"] == 0.0
+        assert result["r_per_patron"] == 0.0
+
+    def test_class_totals_equal_the_sum_of_their_cohorts(self):
+        visits = [
+            _visit(dimension1="d1+", visitor_id="a", events=[("CTAClick", "Read")]),
+            _visit(dimension1="d7+", visitor_id="b", events=[("CTAClick", "Edit")]),
+            _visit(dimension1="d30+", visitor_id="c", events=[("MainNav", "Explore")]),
+        ]
+        result = _gather(visits)
+        returning_cohorts = retention.PATRON_CLASSES["returning"]["cohorts"]
+        assert result["classes"]["returning"]["patrons"] == sum(result["cohorts"][c]["patrons"] for c in returning_cohorts)
+        assert result["classes"]["returning"]["weighted_total"] == sum(result["cohorts"][c]["weighted_total"] for c in returning_cohorts)
+
+    def test_unknown_cohort_values_are_bucketed_as_visitor(self):
+        result = _gather([_visit(dimension1="d999+", visitor_id="a")])
+        assert result["classes"]["visitor"]["patrons"] == 1
+
+    def test_missing_dimension1_defaults_to_visitor(self):
+        result = _gather([{"visitorId": "a", "actionDetails": []}])
+        assert result["cohorts"]["visitor"]["patrons"] == 1
+
+    def test_null_dimension1_defaults_to_visitor(self):
+        result = _gather([{"dimension1": None, "visitorId": "a", "actionDetails": []}])
+        assert result["cohorts"]["visitor"]["patrons"] == 1
+
+    def test_queries_the_requested_window(self):
+        client = _stub_client([])
+        retention.gather_retention_scores(client=client, hours=3)
+        since = client.get_visits_since.call_args.args[0]
+        assert 2.9 < (retention._utcnow() - since).total_seconds() / 3600 < 3.1
+
+
+class TestEventBreakdown:
+    def test_reports_which_events_earned_the_points(self):
+        visits = [
+            _visit(dimension1="d0", visitor_id="a", events=[("CTAClick", "Read")]),
+            _visit(dimension1="d90+", visitor_id="b", events=[("CTAClick", "Read"), ("MainNav", "Explore")]),
+        ]
+        events = _gather(visits)["events"]
+        assert events["read"] == {"count": 2, "points": 100, "total": 200}
+        assert events["explorer_view"] == {"count": 1, "points": 10, "total": 10}
+
+    def test_events_are_ordered_by_total_points_descending(self):
+        visits = [_visit(dimension1="d0", visitor_id=str(n), events=[("MainNav", "MyBooks")]) for n in range(10)]
+        visits.append(_visit(dimension1="d0", visitor_id="x", events=[("CTAClick", "Read")]))
+        assert list(_gather(visits)["events"]) == ["read", "mybooks_view"]
+
+    def test_event_totals_equal_the_overall_weighted_points(self):
+        visits = [_visit(dimension1=c, visitor_id=c, events=[("CTAClick", "Read"), ("CTAClick", "Edit")]) for c in retention.COHORTS]
+        result = _gather(visits)
+        assert sum(e["total"] for e in result["events"].values()) == sum(c["weighted_total"] for c in result["cohorts"].values())
+
+
+class TestVisitHour:
+    def test_truncates_to_the_hour_the_visit_started(self):
+        # 2026-07-27T14:37:11Z
+        assert retention._visit_hour({"firstActionTimestamp": 1785163031}) == datetime.datetime(2026, 7, 27, 14, 0, tzinfo=datetime.UTC)
+
+    def test_falls_back_to_server_timestamp(self):
+        assert retention._visit_hour({"serverTimestamp": 1785163031}).hour == 14
+
+    def test_returns_none_when_there_is_no_timestamp(self):
+        assert retention._visit_hour({}) is None
+
+    def test_returns_none_for_an_unparseable_timestamp(self):
+        assert retention._visit_hour({"firstActionTimestamp": "not-a-number"}) is None
+
+
+class TestGatherByHour:
+    def _run(self, visits, hours=3):
+        return retention.gather_retention_scores_by_hour(client=_stub_client(visits), hours=hours)
+
+    def test_returns_one_bucket_per_hour_most_recent_first(self):
+        buckets = self._run([], hours=3)
+        assert len(buckets) == 3
+        starts = [b["hour_start"] for b in buckets]
+        assert starts == sorted(starts, reverse=True)
+
+    def test_only_the_current_hour_is_flagged_partial(self):
+        buckets = self._run([], hours=3)
+        assert [b["partial"] for b in buckets] == [True, False, False]
+
+    def test_visits_land_in_the_hour_they_started(self):
+        now = retention._utcnow().replace(minute=0, second=0, microsecond=0)
+        this_hour = int(now.timestamp()) + 60
+        last_hour = int((now - datetime.timedelta(hours=1)).timestamp()) + 60
+        visits = [
+            _visit(dimension1="d0", visitor_id="a", timestamp=this_hour, events=[("CTAClick", "Read")]),
+            _visit(dimension1="d0", visitor_id="b", timestamp=last_hour, events=[("CTAClick", "Read")]),
+            _visit(dimension1="d0", visitor_id="c", timestamp=last_hour, events=[("CTAClick", "Read")]),
+        ]
+        buckets = self._run(visits, hours=2)
+        assert buckets[0]["visits"] == 1
+        assert buckets[1]["visits"] == 2
+
+    def test_visits_outside_the_window_are_dropped(self):
+        old = int((retention._utcnow() - datetime.timedelta(hours=12)).timestamp())
+        buckets = self._run([_visit(dimension1="d0", visitor_id="a", timestamp=old)], hours=2)
+        assert sum(b["visits"] for b in buckets) == 0
+
+    def test_a_visit_with_no_timestamp_is_dropped_rather_than_miscounted(self):
+        buckets = self._run([_visit(dimension1="d0", visitor_id="a")], hours=2)
+        assert sum(b["visits"] for b in buckets) == 0
+
+    def test_fetches_once_for_the_whole_span(self):
+        client = _stub_client([])
+        retention.gather_retention_scores_by_hour(client=client, hours=6)
+        assert client.get_visits_since.call_count == 1
+
+    def test_each_bucket_is_scored_as_a_one_hour_window(self):
+        assert all(b["window_hours"] == 1 for b in self._run([], hours=3))
+
+
+class TestRetentionGauges:
+    def test_gauge_names_match_what_write_to_statsd_emits(self, monkeypatch):
+        scores = _gather([_visit(dimension1="d0", visitor_id="a", events=[("CTAClick", "Read")])])
+        emitted = {}
+        client = Mock()
+        client.gauge.side_effect = emitted.__setitem__
+        monkeypatch.setattr(retention, "configure_statsd", lambda _c: client)
+        retention.write_retention_to_statsd("conf.yml", scores)
+        assert emitted == retention.retention_gauges(scores)
+
+    def test_includes_the_north_star_series(self):
+        gauges = retention.retention_gauges(_gather([]))
+        assert "stats.ol.retention.total_score.hourly" in gauges
+        assert "stats.ol.retention.per_patron.hourly" in gauges
+
+    def test_covers_every_cohort_and_class_by_name(self):
+        gauges = retention.retention_gauges(_gather([]))
+        for cohort in retention.COHORTS:
+            safe = retention._statsd_safe(cohort)
+            assert f"stats.ol.retention.cohort.{safe}.points.hourly.total" in gauges
+        for cls in retention.PATRON_CLASSES:
+            assert f"stats.ol.retention.class.{cls}.points.hourly.total" in gauges
+
+    def test_emits_data_quality_counters(self):
+        """A broken feed must be visible on the dashboard, not only in a log line."""
+        gauges = retention.retention_gauges(_gather([]))
+        for name in ("missing_dimension", "unknown_cohort", "unidentified_patrons", "dropped_no_timestamp", "started_before_window", "truncated"):
+            assert f"stats.ol.retention.quality.{name}.hourly" in gauges
+
+
+class TestSanityWarnings:
+    def test_warns_when_no_visits_are_returned(self):
+        result = _gather([])
+        assert any("no visits" in warning.lower() for warning in result["warnings"])
+
+    def test_warns_when_a_class_has_patrons_but_zero_engagement(self):
+        """Silent zeroing is exactly how both prototype bugs hid."""
+        result = _gather([_visit(dimension1="d0", visitor_id="a")])
+        assert any("registrant" in warning for warning in result["warnings"])
+
+    def test_no_warnings_on_a_healthy_sample(self):
+        visits = [_visit(dimension1=cohort, visitor_id=cohort, events=[("CTAClick", "Read")]) for cohort in retention.COHORTS]
+        assert _gather(visits)["warnings"] == []
+
+
+class TestWriteRetentionToStatsd:
+    @pytest.fixture
+    def emitted(self, monkeypatch):
+        gauges: dict[str, float] = {}
+        client = Mock()
+        client.gauge.side_effect = gauges.__setitem__
+        monkeypatch.setattr(retention, "configure_statsd", lambda _configfile: client)
+        return gauges
+
+    def test_emits_every_cohort_and_class_plus_the_totals(self, emitted):
+        scores = _gather([_visit(dimension1="d0", visitor_id="a", events=[("CTAClick", "Read")])])
+        retention.write_retention_to_statsd("conf.yml", scores)
+
+        for cohort in retention.COHORTS:
+            safe = retention._statsd_safe(cohort)
+            assert f"stats.ol.retention.cohort.{safe}.patrons.hourly.total" in emitted
+            assert f"stats.ol.retention.cohort.{safe}.engagement.hourly" in emitted
+        for cls in retention.PATRON_CLASSES:
+            assert f"stats.ol.retention.class.{cls}.patrons.hourly.total" in emitted
+            assert f"stats.ol.retention.class.{cls}.engagement.hourly" in emitted
+        assert emitted["stats.ol.retention.total_score.hourly"] == scores["r_total"]
+        assert emitted["stats.ol.retention.per_patron.hourly"] == scores["r_per_patron"]
+
+    def test_metric_names_never_contain_a_plus_sign(self, emitted):
+        """Graphite/statsd keys must stay alphanumeric; cohorts like `d1+` need escaping."""
+        retention.write_retention_to_statsd("conf.yml", _gather([]))
+        assert emitted
+        assert not any("+" in key for key in emitted)
+
+    def test_statsd_safe_escapes_plus(self):
+        assert retention._statsd_safe("d1+") == "d1_plus"
+        assert retention._statsd_safe("visitor") == "visitor"
+
+
+class TestImportIndependence:
+    """Retention must stay computable without dragging Open Library in.
+
+    The Core Vitals service is meant to run as separately from openlibrary.org
+    as possible, so this module's value is partly that it has no app
+    dependencies. `openlibrary/admin/vitals.py` pulls in 80+ app and infobase
+    modules; if retention ever imports from there, or from anything that reaches
+    the database, lifting it into the service stops being a file copy.
+    """
+
+    FORBIDDEN_PREFIXES = ("infogami", "web", "openlibrary.admin", "openlibrary.plugins", "openlibrary.core.db")
+
+    def _fresh_import_footprint(self):
+
+        code = "import sys, json; before=set(sys.modules);import openlibrary.core.retention;print(json.dumps(sorted(set(sys.modules)-before)))"
+        out = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=True)
+        return jsonlib.loads(out.stdout)
+
+    def test_importing_retention_does_not_pull_in_the_app(self):
+        pulled = self._fresh_import_footprint()
+        offenders = [m for m in pulled if m.startswith(self.FORBIDDEN_PREFIXES)]
+        assert offenders == [], f"retention.py must not import Open Library internals, found: {offenders}"
+
+    def test_the_only_openlibrary_modules_are_retention_and_matomo(self):
+        pulled = self._fresh_import_footprint()
+        ol = {m for m in pulled if m.startswith("openlibrary")}
+        assert ol <= {"openlibrary", "openlibrary.core", "openlibrary.core.matomo", "openlibrary.core.retention"}
+
+    def test_matomo_client_is_also_independent(self):
+        """The client moves to the service too, so it must stay clean as well."""
+        source = pathlib.Path(matomo.__file__).read_text()
+        assert "from openlibrary" not in source
+        assert "import openlibrary" not in source
+
+
+class TestPageUrlMatching:
+    """Substring matching on the whole URL scored reading-log pages as book views.
+
+    Those pages are logged-in only, so the inflation landed on the classes
+    weighted 20-100x above `visitor` -- a systematic upward bias in the
+    north-star number rather than noise.
+    """
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://openlibrary.org/account/books/want-to-read",
+            "https://openlibrary.org/people/mek/books/already-read",
+            "https://openlibrary.org/people/mek/books",
+            "https://openlibrary.org/people/someone/books/currently-reading",
+        ],
+    )
+    def test_reading_log_shelves_are_not_book_views(self, url):
+        assert retention._score_page_url(url) is None
+
+    def test_search_inside_is_not_scored_as_search(self):
+        """search_inside is declared untracked; scoring it as `search` contradicts that."""
+        assert retention._score_page_url("https://openlibrary.org/search/inside?q=cats") is None
+
+    def test_a_query_string_cannot_fake_a_path(self):
+        assert retention._score_page_url("https://openlibrary.org/works/OL1W/x?utm=/search") == "book_view"
+
+    def test_a_third_party_url_scores_nothing(self):
+        """Matomo should only report URLs for the tracked site, but do not rely on it."""
+        assert retention._score_page_url("https://evil.example.com/works/fake") is None
+        assert retention._score_page_url("https://openlibrary.org.evil.com/works/fake") is None
+
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            ("https://openlibrary.org/works/OL1W", "book_view"),
+            ("https://openlibrary.org/books/OL1M", "book_view"),
+            ("https://openlibrary.org/authors/OL1A", "author_view"),
+            ("https://openlibrary.org/search?q=x", "search"),
+            ("https://openlibrary.org/search/authors", "search"),
+        ],
+    )
+    def test_real_pages_still_score(self, url, expected):
+        assert retention._score_page_url(url) == expected
+
+    def test_site_search_action_type_is_accepted(self):
+        """If Matomo has search-parameter detection on, /search arrives as type='search'."""
+        visit = {"dimension1": "d0", "visitorId": "a", "actionDetails": [{"type": "search", "url": "https://openlibrary.org/search?q=x"}]}
+        assert retention._score_visit(visit) == {"search": 5}
+
+
+class TestDataQualityDetection:
+    """The historical bugs produced a smaller score, never an error. These are the
+    checks that would have caught them."""
+
+    def test_a_renamed_dimension_is_reported_not_swallowed(self):
+        """Renumbering dimension1 collapsed R_total ~54x with no warning at all."""
+        visits = [{"dimension2": "d90+", "visitorId": f"v{n}", "actionDetails": []} for n in range(50)]
+        result = _gather(visits)
+        assert result["data_quality"]["missing_dimension"] == 50
+        assert any("dimension1" in w for w in result["warnings"])
+
+    def test_relabelled_cohorts_are_reported(self):
+        visits = [_visit(dimension1="d1", visitor_id=f"v{n}") for n in range(50)]
+        result = _gather(visits)
+        assert result["data_quality"]["unknown_cohort"] == 50
+        assert any("outside" in w for w in result["warnings"])
+
+    def test_an_all_visitor_hour_is_flagged(self):
+        """Real openlibrary.org traffic always has some logged-in patrons."""
+        visits = [_visit(dimension1="visitor", visitor_id=f"v{n}", events=[("CTAClick", "Read")]) for n in range(50)]
+        assert any("cohort tracking may be broken" in w for w in _gather(visits)["warnings"])
+
+    def test_a_healthy_mix_is_not_flagged(self):
+        visits = [_visit(dimension1=c, visitor_id=c, events=[("CTAClick", "Read")]) for c in retention.COHORTS]
+        assert _gather(visits)["warnings"] == []
+
+    def test_unidentifiable_visits_do_not_become_one_phantom_patron(self):
+        """Adding "" to the set merged 10 visits into 1 patron with 10x the engagement."""
+        visits = [{"dimension1": "d90+", "actionDetails": [{"type": "event", "eventCategory": "CTAClick", "eventAction": "Read"}]} for _ in range(10)]
+        result = _gather(visits)
+        assert result["cohorts"]["d90+"]["patrons"] == 0
+        assert result["data_quality"]["unidentified_patrons"] == 10
+
+    def test_truncation_is_surfaced_as_a_warning(self):
+        client = _stub_client([_visit(dimension1="d0", visitor_id="a")], truncated_reason="hit the page cap")
+        result = retention.gather_retention_scores(client=client)
+        assert any("truncated" in w for w in result["warnings"])
+
+    def test_a_patron_in_two_cohorts_is_counted_once(self):
+        visits = [_visit(dimension1="d0", visitor_id="same"), _visit(dimension1="d90+", visitor_id="same")]
+        assert _gather(visits)["total_patrons"] == 1
+
+    def test_visits_with_no_timestamp_are_counted_when_bucketing(self):
+        client = _stub_client([_visit(dimension1="d0", visitor_id="a")])
+        hourly = retention.gather_retention_scores_by_hour(client=client, hours=2)
+        assert hourly[0]["data_quality"]["dropped_no_timestamp"] == 1
+        assert any("not counted in any hour" in w for w in hourly[0]["warnings"])

--- a/openlibrary/tests/core/test_retention.py
+++ b/openlibrary/tests/core/test_retention.py
@@ -1,0 +1,586 @@
+"""Tests for Core Vitals retention scoring (issue #11956).
+
+Two bugs found in the prototype are pinned by regression tests here:
+
+1. ``dimension1`` is a flat field on the visit, not nested under
+   ``customDimensions``. Reading it wrongly silently classified every visit as
+   ``visitor`` and undercounted the score ~5.85x.
+2. ``follow`` / ``readlog_*`` events have been tracked app-side since PR #12367
+   but were absent from the scoring table, so they counted for nothing.
+"""
+
+import datetime
+import json as jsonlib
+import pathlib
+import subprocess
+import sys
+from typing import ClassVar
+from unittest.mock import Mock
+
+import pytest
+
+from openlibrary.core import matomo, retention
+
+
+def _visit(dimension1="visitor", visitor_id="v1", user_id=None, events=(), urls=(), timestamp=None):
+    """Build a Live.getLastVisitsDetails-shaped visit record."""
+    actions = [{"type": "event", "eventCategory": category, "eventAction": action} for category, action in events]
+    actions += [{"type": "action", "url": url} for url in urls]
+    visit = {
+        "dimension1": dimension1,
+        "visitorId": visitor_id,
+        "userId": user_id,
+        "actionDetails": actions,
+    }
+    if timestamp is not None:
+        visit["firstActionTimestamp"] = timestamp
+    return visit
+
+
+def _stub_client(visits, truncated=False):
+    """A stand-in MatomoClient.
+
+    `truncated` must be set explicitly: Mock auto-creates attributes, and an
+    auto-created Mock is truthy, so omitting it makes every stubbed fetch look
+    truncated and emits a spurious warning.
+    """
+    client = Mock()
+    client.get_visits_since.return_value = list(visits)
+    client.truncated = truncated
+    return client
+
+
+def _gather(visits, hours=1):
+    return retention.gather_retention_scores(client=_stub_client(visits), hours=hours)
+
+
+class TestEventPointsMatchTheSchema:
+    """Pin the weights to the Score Schemas spreadsheet (gid=41518278).
+
+    Transcribed from the source of truth. If the spreadsheet changes, this test
+    should be updated in the same commit as EVENT_POINTS -- the point is that
+    the two can never drift apart unnoticed.
+    """
+
+    SCHEMA: ClassVar[dict[str, int]] = {
+        "import_goodreads": 200,
+        "set_reading_goal": 150,
+        "read": 100,
+        "search_inside": 75,
+        "list_create": 50,
+        "follow": 50,
+        "edit": 25,
+        "readlog_completion": 20,
+        "star_rating": 20,
+        "readlog_currently_reading": 15,
+        "readlog_want_to_read": 10,
+        "checkin": 10,
+        "explorer_view": 10,
+        "search": 5,
+        "book_view": 5,
+        "author_view": 5,
+        "mybooks_view": 5,
+    }
+
+    def test_points_match_exactly(self):
+        assert retention.EVENT_POINTS == self.SCHEMA
+
+    def test_every_mapped_event_has_a_point_value(self):
+        mapped = set(retention.RETENTION_EVENTS.values()) | set(retention.PAGE_EVENTS.values())
+        assert mapped <= set(retention.EVENT_POINTS)
+
+    def test_every_schema_event_is_either_mapped_or_declared_untracked(self):
+        """A schema event that is neither scored nor listed as a gap is invisible."""
+        mapped = set(retention.RETENTION_EVENTS.values()) | set(retention.PAGE_EVENTS.values())
+        assert mapped | set(retention.UNTRACKED_EVENTS) == set(retention.EVENT_POINTS)
+
+    def test_untracked_events_carry_their_schema_points(self):
+        for name, points in retention.UNTRACKED_EVENTS.items():
+            assert points == self.SCHEMA[name]
+
+
+class TestReadMapping:
+    """`read` is the highest-weight event; it silently scored 0 for the whole
+    prototype because it was mapped to a Matomo category that does not exist."""
+
+    @pytest.mark.parametrize("action", ["Read", "Borrow", "PrintDisabled", "ReadListen", "BorrowListen", "Listen"])
+    def test_every_route_to_the_content_counts_as_a_read(self, action):
+        assert retention._score_visit(_visit(events=[("CTAClick", action)])) == {"read": 100}
+
+    def test_borrow_is_worth_the_same_as_read(self):
+        """Borrowing is reading behind a lending gate, not a weaker signal."""
+        borrow = retention._score_visit(_visit(events=[("CTAClick", "Borrow")]))
+        read = retention._score_visit(_visit(events=[("CTAClick", "Read")]))
+        assert borrow == read
+
+    def test_the_dead_embed_mapping_is_gone(self):
+        """`Embed` is not a category Matomo ever emits for openlibrary.org."""
+        assert not any(category == "Embed" for category, _ in retention.RETENTION_EVENTS)
+
+    @pytest.mark.parametrize("action", ["JoinWaitlist", "LeaveWaitlist", "Locate", "CheckedOut", "Preview"])
+    def test_actions_that_do_not_deliver_content_are_not_reads(self, action):
+        assert retention._score_visit(_visit(events=[("CTAClick", action)])) == {}
+
+
+class TestCohortToClass:
+    @pytest.mark.parametrize(
+        ("cohort", "expected"),
+        [
+            ("visitor", "visitor"),
+            ("d0", "registrant"),
+            ("d1+", "returning"),
+            ("d7+", "returning"),
+            ("d14+", "returning"),
+            ("d30+", "returning"),
+            ("d90+", "retained"),
+        ],
+    )
+    def test_every_cohort_maps_to_a_class(self, cohort, expected):
+        assert retention._cohort_to_class(cohort) == expected
+
+    def test_all_cohorts_are_covered_exactly_once(self):
+        """No cohort may be double-counted or dropped -- that would silently skew the score."""
+        assigned = [cohort for info in retention.PATRON_CLASSES.values() for cohort in info["cohorts"]]
+        assert sorted(assigned) == sorted(retention.COHORTS)
+        assert len(assigned) == len(set(assigned))
+
+    def test_unknown_cohort_falls_back_to_visitor(self):
+        assert retention._cohort_to_class("nonsense") == "visitor"
+
+    def test_class_weights_match_the_spec(self):
+        weights = {cls: info["weight"] for cls, info in retention.PATRON_CLASSES.items()}
+        assert weights == {"visitor": 0.01, "registrant": 0.20, "returning": 0.50, "retained": 1.00}
+
+
+class TestScoreVisit:
+    def test_scores_a_known_custom_event(self):
+        assert retention._score_visit(_visit(events=[("CTAClick", "Read")])) == {"read": 100}
+
+    def test_ignores_unknown_events(self):
+        assert retention._score_visit(_visit(events=[("Nope", "Nothing")])) == {}
+
+    def test_caps_each_event_type_at_once_per_visit(self):
+        """Ten rapid clicks are one expression of intent, not ten."""
+        visit = _visit(events=[("CTAClick", "Read")] * 10)
+        assert retention._score_visit(visit) == {"read": 100}
+
+    def test_different_event_types_accumulate(self):
+        visit = _visit(events=[("CTAClick", "Read"), ("MainNav", "Explore")])
+        assert retention._score_visit(visit) == {"read": 100, "explorer_view": 10}
+
+    def test_scores_page_view_events_by_url_path_prefix(self):
+        visit = _visit(urls=["https://openlibrary.org/works/OL45W/Book", "https://openlibrary.org/search?q=x"])
+        assert retention._score_visit(visit) == {"book_view": 5, "search": 5}
+
+    def test_tolerates_a_missing_action_details(self):
+        assert retention._score_visit({"dimension1": "d0"}) == {}
+
+    def test_tolerates_a_null_action_details(self):
+        assert retention._score_visit({"actionDetails": None}) == {}
+
+    @pytest.mark.parametrize(
+        ("category", "action", "event_name"),
+        [
+            ("FollowsPage", "Follow", "follow"),
+            ("MyBooksPageHeader", "Follow", "follow"),
+            ("ListCardCarousel", "Follow", "follow"),
+            ("PatronPage", "Follow", "follow"),
+            ("ReadingLog", "WantToRead", "readlog_want_to_read"),
+            ("ReadingLog", "CurrentlyReading", "readlog_currently_reading"),
+            ("ReadingLog", "AlreadyRead", "readlog_completion"),
+        ],
+    )
+    def test_regression_follow_and_readlog_events_are_scored(self, category, action, event_name):
+        """These are tracked app-side by PR #12367; scoring them as 0 was bug 2."""
+        scored = retention._score_visit(_visit(events=[(category, action)]))
+        assert event_name in scored
+        assert scored[event_name] > 0
+
+
+class TestGatherRetentionScores:
+    def test_regression_reads_dimension1_as_a_flat_field(self):
+        """Bug 1: reading a nested `customDimensions` made every visit a `visitor`."""
+        result = _gather([_visit(dimension1="d0", visitor_id="a"), _visit(dimension1="d90+", visitor_id="b")])
+        assert result["cohorts"]["d0"]["patrons"] == 1
+        assert result["cohorts"]["d90+"]["patrons"] == 1
+        assert result["cohorts"]["visitor"]["patrons"] == 0
+
+    def test_counts_unique_patrons_not_visits(self):
+        """P_tau is *unique patrons*; counting visits inflates it for repeat sessions."""
+        visits = [
+            _visit(dimension1="d0", visitor_id="same"),
+            _visit(dimension1="d0", visitor_id="same"),
+            _visit(dimension1="d0", visitor_id="other"),
+        ]
+        result = _gather(visits)
+        assert result["cohorts"]["d0"]["patrons"] == 2
+        assert result["visits"] == 3
+
+    def test_prefers_user_id_over_visitor_id_for_identity(self):
+        """A logged-in patron on two devices is one patron."""
+        visits = [
+            _visit(dimension1="d1+", visitor_id="deviceA", user_id="patron1"),
+            _visit(dimension1="d1+", visitor_id="deviceB", user_id="patron1"),
+        ]
+        assert _gather(visits)["cohorts"]["d1+"]["patrons"] == 1
+
+    def test_engagement_is_weighted_points_per_patron(self):
+        visits = [
+            _visit(dimension1="d0", visitor_id="a", events=[("CTAClick", "Read")]),  # 100
+            _visit(dimension1="d0", visitor_id="b", events=[("MainNav", "Explore")]),  # 10
+        ]
+        result = _gather(visits)
+        assert result["classes"]["registrant"]["weighted_total"] == 110
+        assert result["classes"]["registrant"]["patrons"] == 2
+        assert result["classes"]["registrant"]["engagement"] == 55.0
+
+    def test_r_total_applies_class_weights(self):
+        visits = [
+            _visit(dimension1="visitor", visitor_id="v", events=[("CTAClick", "Read")]),  # 100 * 0.01 = 1
+            _visit(dimension1="d0", visitor_id="r", events=[("CTAClick", "Read")]),  # 100 * 0.20 = 20
+            _visit(dimension1="d1+", visitor_id="g", events=[("CTAClick", "Read")]),  # 100 * 0.50 = 50
+            _visit(dimension1="d90+", visitor_id="t", events=[("CTAClick", "Read")]),  # 100 * 1.00 = 100
+        ]
+        result = _gather(visits)
+        assert result["r_total"] == pytest.approx(171.0)
+        assert result["r_per_patron"] == pytest.approx(171.0 / 4)
+
+    def test_reports_all_seven_cohorts_even_when_empty(self):
+        """Cohorts are the storage primitive; the 4 classes are a rollup on top."""
+        result = _gather([])
+        assert set(result["cohorts"]) == set(retention.COHORTS)
+        assert set(result["classes"]) == set(retention.PATRON_CLASSES)
+        assert result["r_total"] == 0.0
+        assert result["r_per_patron"] == 0.0
+
+    def test_class_totals_equal_the_sum_of_their_cohorts(self):
+        visits = [
+            _visit(dimension1="d1+", visitor_id="a", events=[("CTAClick", "Read")]),
+            _visit(dimension1="d7+", visitor_id="b", events=[("CTAClick", "Edit")]),
+            _visit(dimension1="d30+", visitor_id="c", events=[("MainNav", "Explore")]),
+        ]
+        result = _gather(visits)
+        returning_cohorts = retention.PATRON_CLASSES["returning"]["cohorts"]
+        assert result["classes"]["returning"]["patrons"] == sum(result["cohorts"][c]["patrons"] for c in returning_cohorts)
+        assert result["classes"]["returning"]["weighted_total"] == sum(result["cohorts"][c]["weighted_total"] for c in returning_cohorts)
+
+    def test_unknown_cohort_values_are_bucketed_as_visitor(self):
+        result = _gather([_visit(dimension1="d999+", visitor_id="a")])
+        assert result["classes"]["visitor"]["patrons"] == 1
+
+    def test_missing_dimension1_defaults_to_visitor(self):
+        result = _gather([{"visitorId": "a", "actionDetails": []}])
+        assert result["cohorts"]["visitor"]["patrons"] == 1
+
+    def test_null_dimension1_defaults_to_visitor(self):
+        result = _gather([{"dimension1": None, "visitorId": "a", "actionDetails": []}])
+        assert result["cohorts"]["visitor"]["patrons"] == 1
+
+    def test_queries_the_requested_window(self):
+        client = Mock()
+        client.get_visits_since.return_value = []
+        retention.gather_retention_scores(client=client, hours=3)
+        since = client.get_visits_since.call_args.args[0]
+        assert 2.9 < (retention._utcnow() - since).total_seconds() / 3600 < 3.1
+
+
+class TestEventBreakdown:
+    def test_reports_which_events_earned_the_points(self):
+        visits = [
+            _visit(dimension1="d0", visitor_id="a", events=[("CTAClick", "Read")]),
+            _visit(dimension1="d90+", visitor_id="b", events=[("CTAClick", "Read"), ("MainNav", "Explore")]),
+        ]
+        events = _gather(visits)["events"]
+        assert events["read"] == {"count": 2, "points": 100, "total": 200}
+        assert events["explorer_view"] == {"count": 1, "points": 10, "total": 10}
+
+    def test_events_are_ordered_by_total_points_descending(self):
+        visits = [_visit(dimension1="d0", visitor_id=str(n), events=[("MainNav", "MyBooks")]) for n in range(10)]
+        visits.append(_visit(dimension1="d0", visitor_id="x", events=[("CTAClick", "Read")]))
+        assert list(_gather(visits)["events"]) == ["read", "mybooks_view"]
+
+    def test_event_totals_equal_the_overall_weighted_points(self):
+        visits = [_visit(dimension1=c, visitor_id=c, events=[("CTAClick", "Read"), ("CTAClick", "Edit")]) for c in retention.COHORTS]
+        result = _gather(visits)
+        assert sum(e["total"] for e in result["events"].values()) == sum(c["weighted_total"] for c in result["cohorts"].values())
+
+
+class TestVisitHour:
+    def test_truncates_to_the_hour_the_visit_started(self):
+        # 2026-07-27T14:37:11Z
+        assert retention._visit_hour({"firstActionTimestamp": 1785163031}) == datetime.datetime(2026, 7, 27, 14, 0, tzinfo=datetime.UTC)
+
+    def test_falls_back_to_server_timestamp(self):
+        assert retention._visit_hour({"serverTimestamp": 1785163031}).hour == 14
+
+    def test_returns_none_when_there_is_no_timestamp(self):
+        assert retention._visit_hour({}) is None
+
+    def test_returns_none_for_an_unparseable_timestamp(self):
+        assert retention._visit_hour({"firstActionTimestamp": "not-a-number"}) is None
+
+
+class TestGatherByHour:
+    def _run(self, visits, hours=3):
+        client = Mock()
+        client.get_visits_since.return_value = list(visits)
+        return retention.gather_retention_scores_by_hour(client=client, hours=hours)
+
+    def test_returns_one_bucket_per_hour_most_recent_first(self):
+        buckets = self._run([], hours=3)
+        assert len(buckets) == 3
+        starts = [b["hour_start"] for b in buckets]
+        assert starts == sorted(starts, reverse=True)
+
+    def test_only_the_current_hour_is_flagged_partial(self):
+        buckets = self._run([], hours=3)
+        assert [b["partial"] for b in buckets] == [True, False, False]
+
+    def test_visits_land_in_the_hour_they_started(self):
+        now = retention._utcnow().replace(minute=0, second=0, microsecond=0)
+        this_hour = int(now.timestamp()) + 60
+        last_hour = int((now - datetime.timedelta(hours=1)).timestamp()) + 60
+        visits = [
+            _visit(dimension1="d0", visitor_id="a", timestamp=this_hour, events=[("CTAClick", "Read")]),
+            _visit(dimension1="d0", visitor_id="b", timestamp=last_hour, events=[("CTAClick", "Read")]),
+            _visit(dimension1="d0", visitor_id="c", timestamp=last_hour, events=[("CTAClick", "Read")]),
+        ]
+        buckets = self._run(visits, hours=2)
+        assert buckets[0]["visits"] == 1
+        assert buckets[1]["visits"] == 2
+
+    def test_visits_outside_the_window_are_dropped(self):
+        old = int((retention._utcnow() - datetime.timedelta(hours=12)).timestamp())
+        buckets = self._run([_visit(dimension1="d0", visitor_id="a", timestamp=old)], hours=2)
+        assert sum(b["visits"] for b in buckets) == 0
+
+    def test_a_visit_with_no_timestamp_is_dropped_rather_than_miscounted(self):
+        buckets = self._run([_visit(dimension1="d0", visitor_id="a")], hours=2)
+        assert sum(b["visits"] for b in buckets) == 0
+
+    def test_fetches_once_for_the_whole_span(self):
+        client = Mock()
+        client.get_visits_since.return_value = []
+        retention.gather_retention_scores_by_hour(client=client, hours=6)
+        assert client.get_visits_since.call_count == 1
+
+    def test_each_bucket_is_scored_as_a_one_hour_window(self):
+        assert all(b["window_hours"] == 1 for b in self._run([], hours=3))
+
+
+class TestRetentionGauges:
+    def test_gauge_names_match_what_write_to_statsd_emits(self, monkeypatch):
+        scores = _gather([_visit(dimension1="d0", visitor_id="a", events=[("CTAClick", "Read")])])
+        emitted = {}
+        client = Mock()
+        client.gauge.side_effect = emitted.__setitem__
+        monkeypatch.setattr(retention, "configure_statsd", lambda _c: client)
+        retention.write_retention_to_statsd("conf.yml", scores)
+        assert emitted == retention.retention_gauges(scores)
+
+    def test_includes_the_north_star_series(self):
+        gauges = retention.retention_gauges(_gather([]))
+        assert "stats.ol.retention.total_score.hourly" in gauges
+        assert "stats.ol.retention.per_patron.hourly" in gauges
+
+    def test_covers_every_cohort_and_class_by_name(self):
+        gauges = retention.retention_gauges(_gather([]))
+        for cohort in retention.COHORTS:
+            safe = retention._statsd_safe(cohort)
+            assert f"stats.ol.retention.cohort.{safe}.points.hourly.total" in gauges
+        for cls in retention.PATRON_CLASSES:
+            assert f"stats.ol.retention.class.{cls}.points.hourly.total" in gauges
+
+    def test_emits_data_quality_counters(self):
+        """A broken feed must be visible on the dashboard, not only in a log line."""
+        gauges = retention.retention_gauges(_gather([]))
+        for name in ("missing_dimension", "unknown_cohort", "unidentified_patrons", "dropped_no_timestamp", "started_before_window", "truncated"):
+            assert f"stats.ol.retention.quality.{name}.hourly" in gauges
+
+
+class TestSanityWarnings:
+    def test_warns_when_no_visits_are_returned(self):
+        result = _gather([])
+        assert any("no visits" in warning.lower() for warning in result["warnings"])
+
+    def test_warns_when_a_class_has_patrons_but_zero_engagement(self):
+        """Silent zeroing is exactly how both prototype bugs hid."""
+        result = _gather([_visit(dimension1="d0", visitor_id="a")])
+        assert any("registrant" in warning for warning in result["warnings"])
+
+    def test_no_warnings_on_a_healthy_sample(self):
+        visits = [_visit(dimension1=cohort, visitor_id=cohort, events=[("CTAClick", "Read")]) for cohort in retention.COHORTS]
+        assert _gather(visits)["warnings"] == []
+
+
+class TestWriteRetentionToStatsd:
+    @pytest.fixture
+    def emitted(self, monkeypatch):
+        gauges: dict[str, float] = {}
+        client = Mock()
+        client.gauge.side_effect = gauges.__setitem__
+        monkeypatch.setattr(retention, "configure_statsd", lambda _configfile: client)
+        return gauges
+
+    def test_emits_every_cohort_and_class_plus_the_totals(self, emitted):
+        scores = _gather([_visit(dimension1="d0", visitor_id="a", events=[("CTAClick", "Read")])])
+        retention.write_retention_to_statsd("conf.yml", scores)
+
+        for cohort in retention.COHORTS:
+            safe = retention._statsd_safe(cohort)
+            assert f"stats.ol.retention.cohort.{safe}.patrons.hourly.total" in emitted
+            assert f"stats.ol.retention.cohort.{safe}.engagement.hourly" in emitted
+        for cls in retention.PATRON_CLASSES:
+            assert f"stats.ol.retention.class.{cls}.patrons.hourly.total" in emitted
+            assert f"stats.ol.retention.class.{cls}.engagement.hourly" in emitted
+        assert emitted["stats.ol.retention.total_score.hourly"] == scores["r_total"]
+        assert emitted["stats.ol.retention.per_patron.hourly"] == scores["r_per_patron"]
+
+    def test_metric_names_never_contain_a_plus_sign(self, emitted):
+        """Graphite/statsd keys must stay alphanumeric; cohorts like `d1+` need escaping."""
+        retention.write_retention_to_statsd("conf.yml", _gather([]))
+        assert emitted
+        assert not any("+" in key for key in emitted)
+
+    def test_statsd_safe_escapes_plus(self):
+        assert retention._statsd_safe("d1+") == "d1_plus"
+        assert retention._statsd_safe("visitor") == "visitor"
+
+
+class TestImportIndependence:
+    """Retention must stay computable without dragging Open Library in.
+
+    The Core Vitals service is meant to run as separately from openlibrary.org
+    as possible, so this module's value is partly that it has no app
+    dependencies. `openlibrary/admin/vitals.py` pulls in 80+ app and infobase
+    modules; if retention ever imports from there, or from anything that reaches
+    the database, lifting it into the service stops being a file copy.
+    """
+
+    FORBIDDEN_PREFIXES = ("infogami", "web", "openlibrary.admin", "openlibrary.plugins", "openlibrary.core.db")
+
+    def _fresh_import_footprint(self):
+
+        code = "import sys, json; before=set(sys.modules);import openlibrary.core.retention;print(json.dumps(sorted(set(sys.modules)-before)))"
+        out = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=True)
+        return jsonlib.loads(out.stdout)
+
+    def test_importing_retention_does_not_pull_in_the_app(self):
+        pulled = self._fresh_import_footprint()
+        offenders = [m for m in pulled if m.startswith(self.FORBIDDEN_PREFIXES)]
+        assert offenders == [], f"retention.py must not import Open Library internals, found: {offenders}"
+
+    def test_the_only_openlibrary_modules_are_retention_and_matomo(self):
+        pulled = self._fresh_import_footprint()
+        ol = {m for m in pulled if m.startswith("openlibrary")}
+        assert ol <= {"openlibrary", "openlibrary.core", "openlibrary.core.matomo", "openlibrary.core.retention"}
+
+    def test_matomo_client_is_also_independent(self):
+        """The client moves to the service too, so it must stay clean as well."""
+        source = pathlib.Path(matomo.__file__).read_text()
+        assert "from openlibrary" not in source
+        assert "import openlibrary" not in source
+
+
+class TestPageUrlMatching:
+    """Substring matching on the whole URL scored reading-log pages as book views.
+
+    Those pages are logged-in only, so the inflation landed on the classes
+    weighted 20-100x above `visitor` -- a systematic upward bias in the
+    north-star number rather than noise.
+    """
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://openlibrary.org/account/books/want-to-read",
+            "https://openlibrary.org/people/mek/books/already-read",
+            "https://openlibrary.org/people/mek/books",
+            "https://openlibrary.org/people/someone/books/currently-reading",
+        ],
+    )
+    def test_reading_log_shelves_are_not_book_views(self, url):
+        assert retention._score_page_url(url) is None
+
+    def test_search_inside_is_not_scored_as_search(self):
+        """search_inside is declared untracked; scoring it as `search` contradicts that."""
+        assert retention._score_page_url("https://openlibrary.org/search/inside?q=cats") is None
+
+    def test_a_query_string_cannot_fake_a_path(self):
+        assert retention._score_page_url("https://openlibrary.org/works/OL1W/x?utm=/search") == "book_view"
+
+    def test_a_third_party_url_scores_nothing(self):
+        """Matomo should only report URLs for the tracked site, but do not rely on it."""
+        assert retention._score_page_url("https://evil.example.com/works/fake") is None
+        assert retention._score_page_url("https://openlibrary.org.evil.com/works/fake") is None
+
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            ("https://openlibrary.org/works/OL1W", "book_view"),
+            ("https://openlibrary.org/books/OL1M", "book_view"),
+            ("https://openlibrary.org/authors/OL1A", "author_view"),
+            ("https://openlibrary.org/search?q=x", "search"),
+            ("https://openlibrary.org/search/authors", "search"),
+        ],
+    )
+    def test_real_pages_still_score(self, url, expected):
+        assert retention._score_page_url(url) == expected
+
+    def test_site_search_action_type_is_accepted(self):
+        """If Matomo has search-parameter detection on, /search arrives as type='search'."""
+        visit = {"dimension1": "d0", "visitorId": "a", "actionDetails": [{"type": "search", "url": "https://openlibrary.org/search?q=x"}]}
+        assert retention._score_visit(visit) == {"search": 5}
+
+
+class TestDataQualityDetection:
+    """The historical bugs produced a smaller score, never an error. These are the
+    checks that would have caught them."""
+
+    def test_a_renamed_dimension_is_reported_not_swallowed(self):
+        """Renumbering dimension1 collapsed R_total ~54x with no warning at all."""
+        visits = [{"dimension2": "d90+", "visitorId": f"v{n}", "actionDetails": []} for n in range(50)]
+        result = _gather(visits)
+        assert result["data_quality"]["missing_dimension"] == 50
+        assert any("dimension1" in w for w in result["warnings"])
+
+    def test_relabelled_cohorts_are_reported(self):
+        visits = [_visit(dimension1="d1", visitor_id=f"v{n}") for n in range(50)]
+        result = _gather(visits)
+        assert result["data_quality"]["unknown_cohort"] == 50
+        assert any("outside" in w for w in result["warnings"])
+
+    def test_an_all_visitor_hour_is_flagged(self):
+        """Real openlibrary.org traffic always has some logged-in patrons."""
+        visits = [_visit(dimension1="visitor", visitor_id=f"v{n}", events=[("CTAClick", "Read")]) for n in range(50)]
+        assert any("cohort tracking may be broken" in w for w in _gather(visits)["warnings"])
+
+    def test_a_healthy_mix_is_not_flagged(self):
+        visits = [_visit(dimension1=c, visitor_id=c, events=[("CTAClick", "Read")]) for c in retention.COHORTS]
+        assert _gather(visits)["warnings"] == []
+
+    def test_unidentifiable_visits_do_not_become_one_phantom_patron(self):
+        """Adding "" to the set merged 10 visits into 1 patron with 10x the engagement."""
+        visits = [{"dimension1": "d90+", "actionDetails": [{"type": "event", "eventCategory": "CTAClick", "eventAction": "Read"}]} for _ in range(10)]
+        result = _gather(visits)
+        assert result["cohorts"]["d90+"]["patrons"] == 0
+        assert result["data_quality"]["unidentified_patrons"] == 10
+
+    def test_truncation_is_surfaced_as_a_warning(self):
+        client = Mock()
+        client.get_visits_since.return_value = [_visit(dimension1="d0", visitor_id="a")]
+        client.truncated = True
+        result = retention.gather_retention_scores(client=client)
+        assert any("truncated" in w for w in result["warnings"])
+
+    def test_a_patron_in_two_cohorts_is_counted_once(self):
+        visits = [_visit(dimension1="d0", visitor_id="same"), _visit(dimension1="d90+", visitor_id="same")]
+        assert _gather(visits)["total_patrons"] == 1
+
+    def test_visits_with_no_timestamp_are_counted_when_bucketing(self):
+        client = Mock()
+        client.get_visits_since.return_value = [_visit(dimension1="d0", visitor_id="a")]
+        client.truncated = False
+        hourly = retention.gather_retention_scores_by_hour(client=client, hours=2)
+        assert hourly[0]["data_quality"]["dropped_no_timestamp"] == 1
+        assert any("not counted in any hour" in w for w in hourly[0]["warnings"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 requires-python = ">=3.14.5,<3.14.6"
 
 [tool.codespell]
-ignore-words-list = "beng,curren,datas,furst,lightening,nd,nin,ot,ser,spects,te,tha,ue,upto,thirdparty"
+ignore-words-list = "beng,checkin,curren,datas,furst,lightening,nd,nin,ot,ser,spects,te,tha,ue,upto,thirdparty"
 skip = "./.*,*/ocm00400866,*/read_toc.py,*.it,*.js,*.json,*.mrc,*.page,*.pg_dump,*.po,*.txt,*.xml,*.yml"
 
 [tool.mypy]

--- a/scripts/gather_retention_scores.py
+++ b/scripts/gather_retention_scores.py
@@ -11,11 +11,14 @@ gauge series a scheduled job feeds. Pass --statsd when you do want it recorded.
     # Score the last hour and print a breakdown
     ./scripts/gather_retention_scores.py conf/openlibrary.yml
 
-    # Last 24 hours, per-cohort detail, as JSON
+    # Last 24 hours, per-cohort and per-event detail, as JSON
     ./scripts/gather_retention_scores.py conf/openlibrary.yml --hours 24 --verbose --json
 
     # Score the last complete clock hour and record it to statsd
     ./scripts/gather_retention_scores.py /olsystem/etc/openlibrary.yml --by-hour --hours 2 --statsd
+
+Flags come from the signature of main() via FnToCLI, so booleans also accept
+their --no- form (e.g. --no-statsd).
 
 The Matomo token is read from `matomo_api` in the config file, or from a
 MATOMO_TOKEN environment variable, which takes precedence and saves developers
@@ -23,8 +26,7 @@ editing a checked-in config. Matomo is reachable from IA infrastructure; from a
 developer machine, set HTTPS_PROXY to an allowlisted forward proxy.
 """
 
-import argparse
-import json
+import json as jsonlib
 import sys
 
 try:
@@ -42,17 +44,7 @@ from openlibrary.core.retention import (
     retention_gauges,
     write_retention_to_statsd,
 )
-
-
-def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("openlibrary_config", help="Path to openlibrary.yml (supplies the Matomo token and statsd server)")
-    parser.add_argument("--hours", type=int, default=1, help="Size of the window to score, in hours (default: 1)")
-    parser.add_argument("--statsd", action="store_true", help="Also push the scores to statsd (off by default)")
-    parser.add_argument("--json", action="store_true", dest="as_json", help="Emit the full result as JSON")
-    parser.add_argument("--verbose", action="store_true", help="Show the per-cohort and per-event breakdown behind the score")
-    parser.add_argument("--by-hour", action="store_true", dest="by_hour", help="Score each of the last --hours clock hours separately instead of as one window")
-    return parser.parse_args(argv)
+from scripts.solr_builder.solr_builder.fn_to_cli import FnToCLI
 
 
 def print_report(scores: dict, verbose: bool) -> None:
@@ -105,52 +97,58 @@ def print_hourly_report(hourly: list[dict], verbose: bool) -> None:
         print_report(hourly[0], verbose)
 
 
-def main(argv: list[str] | None = None) -> int:
-    args = parse_args(argv)
+def main(
+    openlibrary_config: str,
+    hours: int = 1,
+    by_hour: bool = False,
+    statsd: bool = False,
+    json: bool = False,
+    verbose: bool = False,
+) -> None:
+    """Compute the Core Vitals Retention Score for a window ending now.
 
-    if args.hours < 1:
-        print("--hours must be at least 1", file=sys.stderr)
-        return 1
+    :param openlibrary_config: Path to openlibrary.yml, supplying the Matomo token and statsd server
+    :param hours: Size of the window to score, in hours
+    :param by_hour: Score each of the last --hours clock hours separately instead of as one window
+    :param statsd: Also record the scores to statsd; off by default so an ad hoc run cannot contaminate a scheduled series
+    :param json: Emit the full result as JSON
+    :param verbose: Show the per-cohort and per-event breakdown behind the score
+    """
+    if hours < 1:
+        raise SystemExit("--hours must be at least 1")
 
-    if not (token := resolve_token(args.openlibrary_config)):
-        print(
-            f"No Matomo token found. Set `matomo_api` in {args.openlibrary_config}, or export MATOMO_TOKEN.",
-            file=sys.stderr,
-        )
-        return 1
+    if not (token := resolve_token(openlibrary_config)):
+        raise SystemExit(f"No Matomo token found. Set `matomo_api` in {openlibrary_config}, or export MATOMO_TOKEN.")
 
     hourly: list[dict] | None = None
-    # The window to record: the most recent *complete* hour under --by-hour.
-    # hourly[0] is the hour in progress, so recording it would write a value that
-    # depends on the minute the job fired -- a sawtooth, not a measurement.
+    # The window to record: under --by-hour that is the most recent *complete*
+    # hour, since hourly[0] is still filling up and its value would depend on
+    # the minute the job fired.
     recordable: dict | None = None
     try:
-        if args.by_hour:
-            hourly = gather_retention_scores_by_hour(token, hours=args.hours)
+        if by_hour:
+            hourly = gather_retention_scores_by_hour(token, hours=hours)
             recordable = next((hour for hour in hourly if not hour["partial"]), None)
         else:
-            recordable = gather_retention_scores(token, hours=args.hours)
+            recordable = gather_retention_scores(token, hours=hours)
     except MatomoError as exc:
-        print(f"Could not reach Matomo: {exc}", file=sys.stderr)
-        print("Matomo is restricted to IA's network; set HTTPS_PROXY to an allowlisted proxy if running locally.", file=sys.stderr)
-        return 1
+        raise SystemExit(
+            f"Could not reach Matomo: {exc}\nMatomo is restricted to IA's network; set HTTPS_PROXY to an allowlisted proxy if running locally."
+        ) from exc
 
-    if args.as_json:
-        print(json.dumps(hourly if hourly is not None else recordable, indent=2))
+    if json:
+        print(jsonlib.dumps(hourly if hourly is not None else recordable, indent=2))
     elif hourly is not None:
-        print_hourly_report(hourly, args.verbose)
+        print_hourly_report(hourly, verbose)
     elif recordable is not None:
-        print_report(recordable, args.verbose)
+        print_report(recordable, verbose)
 
-    if args.statsd:
+    if statsd:
         if recordable is None:
-            print("\nNothing recorded: --by-hour --hours 1 covers only the hour in progress. Use --hours 2 or more.", file=sys.stderr)
-            return 1
-        write_retention_to_statsd(args.openlibrary_config, recordable)
-        print(f"\nPushed {len(retention_gauges(recordable))} gauges to statsd for the hour starting {recordable.get('hour_start', recordable['since'])}.")
-
-    return 0
+            raise SystemExit("Nothing recorded: --by-hour --hours 1 covers only the hour in progress. Use --hours 2 or more.")
+        write_retention_to_statsd(openlibrary_config, recordable)
+        print(f"\nRecorded {len(retention_gauges(recordable))} gauges to statsd for the hour starting {recordable.get('hour_start', recordable['since'])}.")
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    FnToCLI(main).run()

--- a/scripts/gather_retention_scores.py
+++ b/scripts/gather_retention_scores.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Compute the Core Vitals Retention Score on demand (issue #11956).
+
+Runs the same scoring a scheduled job would, against any window, so you can ask
+"what is the score right now?" at any moment. Scoring lives in
+`openlibrary/core/retention.py`; this is just a way to drive it.
+
+Prints by default and pushes nothing: an ad hoc run should not contaminate the
+gauge series a scheduled job feeds. Pass --statsd when you do want it recorded.
+
+    # Score the last hour and print a breakdown
+    ./scripts/gather_retention_scores.py conf/openlibrary.yml
+
+    # Last 24 hours, per-cohort detail, as JSON
+    ./scripts/gather_retention_scores.py conf/openlibrary.yml --hours 24 --verbose --json
+
+    # Score the last complete clock hour and record it to statsd
+    ./scripts/gather_retention_scores.py /olsystem/etc/openlibrary.yml --by-hour --hours 2 --statsd
+
+The Matomo token is read from `matomo_api` in the config file, or from a
+MATOMO_TOKEN environment variable, which takes precedence and saves developers
+editing a checked-in config. Matomo is reachable from IA infrastructure; from a
+developer machine, set HTTPS_PROXY to an allowlisted forward proxy.
+"""
+
+import argparse
+import json
+import sys
+
+try:
+    import _init_path  # type: ignore[import-not-found]  # noqa: F401 side effect: add OL package root to sys.path
+except ImportError:
+    import scripts._init_path  # noqa: F401 same side effect when imported as a package
+
+from openlibrary.core.matomo import MatomoError
+from openlibrary.core.retention import (
+    PATRON_CLASSES,
+    UNTRACKED_EVENTS,
+    gather_retention_scores,
+    gather_retention_scores_by_hour,
+    resolve_token,
+    retention_gauges,
+    write_retention_to_statsd,
+)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("openlibrary_config", help="Path to openlibrary.yml (supplies the Matomo token and statsd server)")
+    parser.add_argument("--hours", type=int, default=1, help="Size of the window to score, in hours (default: 1)")
+    parser.add_argument("--statsd", action="store_true", help="Also push the scores to statsd (off by default)")
+    parser.add_argument("--json", action="store_true", dest="as_json", help="Emit the full result as JSON")
+    parser.add_argument("--verbose", action="store_true", help="Show the per-cohort and per-event breakdown behind the score")
+    parser.add_argument("--by-hour", action="store_true", dest="by_hour", help="Score each of the last --hours clock hours separately instead of as one window")
+    return parser.parse_args(argv)
+
+
+def print_report(scores: dict, verbose: bool) -> None:
+    print(f"\nOpen Library Retention Score — last {scores['window_hours']}h (since {scores['since']})")
+    print(f"{scores['visits']:,} visits scored")
+    print("=" * 72)
+    print(f"  {'CLASS':<12} {'PATRONS':>9} {'POINTS':>10} {'E(t)':>9} {'w':>6} {'w*P*E':>12}")
+    print("  " + "-" * 62)
+
+    for cls in PATRON_CLASSES:
+        data = scores["classes"][cls]
+        print(f"  {cls:<12} {data['patrons']:>9,} {data['weighted_total']:>10,} {data['engagement']:>9.2f} {data['weight']:>6.2f} {data['contribution']:>12,.2f}")
+        if verbose:
+            for cohort in PATRON_CLASSES[cls]["cohorts"]:
+                cohort_data = scores["cohorts"][cohort]
+                print(f"    {cohort:<10} {cohort_data['patrons']:>9,} {cohort_data['weighted_total']:>10,} {cohort_data['engagement']:>9.2f}")
+
+    print("  " + "-" * 62)
+    print(f"  R_total          = {scores['r_total']:,.2f}")
+    print(f"  R per patron     = {scores['r_per_patron']:.4f}")
+
+    if verbose and scores["events"]:
+        # Which events actually earned the points. This is what makes R_total
+        # explainable, and what makes a mis-mapped event visible as a zero.
+        print(f"\n  {'EVENT':<28} {'COUNT':>8} {'PTS':>6} {'TOTAL':>10}")
+        print("  " + "-" * 54)
+        for name, event in scores["events"].items():
+            print(f"  {name:<28} {event['count']:>8,} {event['points']:>6} {event['total']:>10,}")
+
+    if untracked := ", ".join(f"{name} ({points}pts)" for name, points in UNTRACKED_EVENTS.items()):
+        print(f"\n  No working Matomo source, scoring 0 (#12366): {untracked}")
+
+    for warning in scores["warnings"]:
+        print(f"  WARNING: {warning}", file=sys.stderr)
+
+
+def print_hourly_report(hourly: list[dict], verbose: bool) -> None:
+    """One row per clock hour, most recent first, then the newest hour in full."""
+    print(f"\nOpen Library Retention Score — last {len(hourly)} clock hours")
+    print("=" * 72)
+    print(f"  {'HOUR (UTC)':<18} {'R_TOTAL':>12} {'R/PATRON':>10} {'PATRONS':>9} {'VISITS':>9}")
+    print("  " + "-" * 62)
+    for hour in hourly:
+        label = hour["hour_start"][11:16] + (" (partial)" if hour["partial"] else "")
+        print(f"  {label:<18} {hour['r_total']:>12,.2f} {hour['r_per_patron']:>10.4f} {hour['total_patrons']:>9,} {hour['visits']:>9,}")
+    if hourly and hourly[0]["partial"]:
+        print("\n  The first row covers only the minutes elapsed so far this hour; it is not")
+        print("  comparable to a complete hour and a lower number there is not a drop.")
+    if hourly:
+        print_report(hourly[0], verbose)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if args.hours < 1:
+        print("--hours must be at least 1", file=sys.stderr)
+        return 1
+
+    if not (token := resolve_token(args.openlibrary_config)):
+        print(
+            f"No Matomo token found. Set `matomo_api` in {args.openlibrary_config}, or export MATOMO_TOKEN.",
+            file=sys.stderr,
+        )
+        return 1
+
+    hourly: list[dict] | None = None
+    # The window to record: the most recent *complete* hour under --by-hour.
+    # hourly[0] is the hour in progress, so recording it would write a value that
+    # depends on the minute the job fired -- a sawtooth, not a measurement.
+    recordable: dict | None = None
+    try:
+        if args.by_hour:
+            hourly = gather_retention_scores_by_hour(token, hours=args.hours)
+            recordable = next((hour for hour in hourly if not hour["partial"]), None)
+        else:
+            recordable = gather_retention_scores(token, hours=args.hours)
+    except MatomoError as exc:
+        print(f"Could not reach Matomo: {exc}", file=sys.stderr)
+        print("Matomo is restricted to IA's network; set HTTPS_PROXY to an allowlisted proxy if running locally.", file=sys.stderr)
+        return 1
+
+    if args.as_json:
+        print(json.dumps(hourly if hourly is not None else recordable, indent=2))
+    elif hourly is not None:
+        print_hourly_report(hourly, args.verbose)
+    elif recordable is not None:
+        print_report(recordable, args.verbose)
+
+    if args.statsd:
+        if recordable is None:
+            print("\nNothing recorded: --by-hour --hours 1 covers only the hour in progress. Use --hours 2 or more.", file=sys.stderr)
+            return 1
+        write_retention_to_statsd(args.openlibrary_config, recordable)
+        print(f"\nPushed {len(retention_gauges(recordable))} gauges to statsd for the hour starting {recordable.get('hour_start', recordable['since'])}.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_gather_retention_scores.py
+++ b/scripts/tests/test_gather_retention_scores.py
@@ -69,23 +69,25 @@ class TestMain:
         monkeypatch.delenv("MATOMO_TOKEN", raising=False)
         path = tmp_path / "openlibrary.yml"
         path.write_text("matomo_api:\n")
-        assert script.main([str(path)]) == 1
-        assert "No Matomo token found" in capsys.readouterr().err
+        with pytest.raises(SystemExit, match="No Matomo token found"):
+            script.main(str(path))
 
     def test_rejects_a_zero_hour_window(self, configfile, capsys):
-        assert script.main([configfile, "--hours", "0"]) == 1
-        assert "--hours must be at least 1" in capsys.readouterr().err
+        with pytest.raises(SystemExit, match="at least 1"):
+            script.main(configfile, hours=0)
 
     def test_reports_an_unreachable_matomo_without_a_traceback(self, configfile, capsys):
-        with patch.object(script, "gather_retention_scores", side_effect=MatomoError("no route to host")):
-            assert script.main([configfile]) == 1
-        err = capsys.readouterr().err
-        assert "Could not reach Matomo" in err
-        assert "HTTPS_PROXY" in err
+        with (
+            patch.object(script, "gather_retention_scores", side_effect=MatomoError("no route to host")),
+            pytest.raises(SystemExit) as excinfo,
+        ):
+            script.main(configfile)
+        assert "Could not reach Matomo" in str(excinfo.value)
+        assert "HTTPS_PROXY" in str(excinfo.value)
 
     def test_prints_a_report_and_succeeds(self, configfile, capsys):
         with patch.object(script, "gather_retention_scores", return_value=SCORES):
-            assert script.main([configfile]) == 0
+            script.main(configfile)
         out = capsys.readouterr().out
         assert "R_total" in out
         assert "171.00" in out
@@ -96,7 +98,7 @@ class TestMain:
             patch.object(script, "gather_retention_scores", return_value=SCORES),
             patch.object(script, "write_retention_to_statsd") as mock_write,
         ):
-            assert script.main([configfile]) == 0
+            script.main(configfile)
         mock_write.assert_not_called()
 
     def test_pushes_to_statsd_when_asked(self, configfile):
@@ -104,23 +106,23 @@ class TestMain:
             patch.object(script, "gather_retention_scores", return_value=SCORES),
             patch.object(script, "write_retention_to_statsd") as mock_write,
         ):
-            assert script.main([configfile, "--statsd"]) == 0
+            script.main(configfile, statsd=True)
         mock_write.assert_called_once_with(configfile, SCORES)
 
     def test_json_output_is_parseable(self, configfile, capsys):
         with patch.object(script, "gather_retention_scores", return_value=SCORES):
-            assert script.main([configfile, "--json"]) == 0
+            script.main(configfile, json=True)
         assert json.loads(capsys.readouterr().out)["r_total"] == 171.0
 
     def test_passes_the_requested_window_through(self, configfile):
         with patch.object(script, "gather_retention_scores", return_value=SCORES) as mock_gather:
-            script.main([configfile, "--hours", "24"])
+            script.main(configfile, hours=24)
         assert mock_gather.call_args.kwargs["hours"] == 24
 
     def test_warnings_go_to_stderr(self, configfile, capsys):
         scores = SCORES | {"warnings": ["registrant: 5 active patrons but zero scored engagement"]}
         with patch.object(script, "gather_retention_scores", return_value=scores):
-            script.main([configfile])
+            script.main(configfile)
         assert "zero scored engagement" in capsys.readouterr().err
 
 
@@ -132,12 +134,12 @@ class TestByHour:
 
     def test_by_hour_uses_the_hourly_gatherer(self, configfile):
         with patch.object(script, "gather_retention_scores_by_hour", return_value=self.HOURLY) as mock_hourly:
-            assert script.main([configfile, "--by-hour", "--hours", "2"]) == 0
+            script.main(configfile, by_hour=True, hours=2)
         assert mock_hourly.call_args.kwargs["hours"] == 2
 
     def test_prints_one_row_per_hour_most_recent_first(self, configfile, capsys):
         with patch.object(script, "gather_retention_scores_by_hour", return_value=self.HOURLY):
-            script.main([configfile, "--by-hour"])
+            script.main(configfile, by_hour=True)
         out = capsys.readouterr().out
         assert "04:00 (partial)" in out
         assert "03:00" in out
@@ -145,12 +147,12 @@ class TestByHour:
 
     def test_flags_the_partial_hour(self, configfile, capsys):
         with patch.object(script, "gather_retention_scores_by_hour", return_value=self.HOURLY):
-            script.main([configfile, "--by-hour"])
+            script.main(configfile, by_hour=True)
         assert "not a drop" in capsys.readouterr().out
 
     def test_json_emits_the_whole_series(self, configfile, capsys):
         with patch.object(script, "gather_retention_scores_by_hour", return_value=self.HOURLY):
-            script.main([configfile, "--by-hour", "--json"])
+            script.main(configfile, by_hour=True, json=True)
         assert len(json.loads(capsys.readouterr().out)) == 2
 
     def test_statsd_records_the_most_recent_COMPLETE_hour(self, configfile):
@@ -160,7 +162,7 @@ class TestByHour:
             patch.object(script, "gather_retention_scores_by_hour", return_value=self.HOURLY),
             patch.object(script, "write_retention_to_statsd") as mock_write,
         ):
-            script.main([configfile, "--by-hour", "--statsd"])
+            script.main(configfile, by_hour=True, statsd=True)
         recorded = mock_write.call_args.args[1]
         assert recorded["partial"] is False
         assert recorded["r_total"] == 900.0
@@ -171,17 +173,17 @@ class TestByHour:
         with (
             patch.object(script, "gather_retention_scores_by_hour", return_value=only_partial),
             patch.object(script, "write_retention_to_statsd") as mock_write,
+            pytest.raises(SystemExit, match="hour in progress"),
         ):
-            assert script.main([configfile, "--by-hour", "--hours", "1", "--statsd"]) == 1
+            script.main(configfile, by_hour=True, hours=1, statsd=True)
         mock_write.assert_not_called()
-        assert "hour in progress" in capsys.readouterr().err
 
 
 class TestEventBreakdown:
     def test_verbose_lists_the_events_that_earned_points(self, configfile, capsys):
         scores = SCORES | {"events": {"read": {"count": 12, "points": 100, "total": 1200}}}
         with patch.object(script, "gather_retention_scores", return_value=scores):
-            script.main([configfile, "--verbose"])
+            script.main(configfile, verbose=True)
         out = capsys.readouterr().out
         assert "read" in out
         assert "1,200" in out
@@ -189,5 +191,5 @@ class TestEventBreakdown:
     def test_events_are_hidden_without_verbose(self, configfile, capsys):
         scores = SCORES | {"events": {"read": {"count": 12, "points": 100, "total": 1200}}}
         with patch.object(script, "gather_retention_scores", return_value=scores):
-            script.main([configfile])
+            script.main(configfile)
         assert "1,200" not in capsys.readouterr().out

--- a/scripts/tests/test_gather_retention_scores.py
+++ b/scripts/tests/test_gather_retention_scores.py
@@ -1,0 +1,193 @@
+"""Tests for the on-demand Retention Score script (issue #11956)."""
+
+import json
+from typing import ClassVar
+from unittest.mock import patch
+
+import pytest
+
+from openlibrary.core import retention
+from openlibrary.core.matomo import MatomoError
+from scripts import gather_retention_scores as script
+
+SCORES = {
+    "window_hours": 1,
+    "since": "2026-07-27T12:00:00+00:00",
+    "visits": 2,
+    "cohorts": {cohort: {"patrons": 0, "weighted_total": 0, "engagement": 0.0} for cohort in retention.COHORTS},
+    "classes": {
+        cls: {"weight": info["weight"], "patrons": 1, "weighted_total": 100, "engagement": 100.0, "contribution": info["weight"] * 100}
+        for cls, info in script.PATRON_CLASSES.items()
+    },
+    "r_total": 171.0,
+    "r_per_patron": 42.75,
+    "events": {},
+    "total_patrons": 4,
+    "data_quality": {
+        "missing_dimension": 0,
+        "unknown_cohort": 0,
+        "unidentified_patrons": 0,
+        "dropped_no_timestamp": 0,
+        "started_before_window": 0,
+        "truncated": False,
+    },
+    "warnings": [],
+}
+
+
+@pytest.fixture
+def configfile(tmp_path):
+    path = tmp_path / "openlibrary.yml"
+    path.write_text("matomo_api: from-config\n")
+    return str(path)
+
+
+class TestResolveToken:
+    def test_reads_the_token_from_the_config_file(self, configfile, monkeypatch):
+        monkeypatch.delenv("MATOMO_TOKEN", raising=False)
+        assert script.resolve_token(configfile) == "from-config"
+
+    def test_environment_takes_precedence_over_the_config_file(self, configfile, monkeypatch):
+        monkeypatch.setenv("MATOMO_TOKEN", "from-env")
+        assert script.resolve_token(configfile) == "from-env"
+
+    def test_returns_empty_when_the_key_is_blank(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("MATOMO_TOKEN", raising=False)
+        path = tmp_path / "openlibrary.yml"
+        path.write_text("matomo_api:\n")
+        assert script.resolve_token(str(path)) == ""
+
+    def test_returns_empty_for_an_empty_config_file(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("MATOMO_TOKEN", raising=False)
+        path = tmp_path / "openlibrary.yml"
+        path.write_text("")
+        assert script.resolve_token(str(path)) == ""
+
+
+class TestMain:
+    def test_fails_cleanly_without_a_token(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.delenv("MATOMO_TOKEN", raising=False)
+        path = tmp_path / "openlibrary.yml"
+        path.write_text("matomo_api:\n")
+        assert script.main([str(path)]) == 1
+        assert "No Matomo token found" in capsys.readouterr().err
+
+    def test_rejects_a_zero_hour_window(self, configfile, capsys):
+        assert script.main([configfile, "--hours", "0"]) == 1
+        assert "--hours must be at least 1" in capsys.readouterr().err
+
+    def test_reports_an_unreachable_matomo_without_a_traceback(self, configfile, capsys):
+        with patch.object(script, "gather_retention_scores", side_effect=MatomoError("no route to host")):
+            assert script.main([configfile]) == 1
+        err = capsys.readouterr().err
+        assert "Could not reach Matomo" in err
+        assert "HTTPS_PROXY" in err
+
+    def test_prints_a_report_and_succeeds(self, configfile, capsys):
+        with patch.object(script, "gather_retention_scores", return_value=SCORES):
+            assert script.main([configfile]) == 0
+        out = capsys.readouterr().out
+        assert "R_total" in out
+        assert "171.00" in out
+
+    def test_does_not_push_to_statsd_by_default(self, configfile):
+        """An ad hoc run must not contaminate the hourly gauge series."""
+        with (
+            patch.object(script, "gather_retention_scores", return_value=SCORES),
+            patch.object(script, "write_retention_to_statsd") as mock_write,
+        ):
+            assert script.main([configfile]) == 0
+        mock_write.assert_not_called()
+
+    def test_pushes_to_statsd_when_asked(self, configfile):
+        with (
+            patch.object(script, "gather_retention_scores", return_value=SCORES),
+            patch.object(script, "write_retention_to_statsd") as mock_write,
+        ):
+            assert script.main([configfile, "--statsd"]) == 0
+        mock_write.assert_called_once_with(configfile, SCORES)
+
+    def test_json_output_is_parseable(self, configfile, capsys):
+        with patch.object(script, "gather_retention_scores", return_value=SCORES):
+            assert script.main([configfile, "--json"]) == 0
+        assert json.loads(capsys.readouterr().out)["r_total"] == 171.0
+
+    def test_passes_the_requested_window_through(self, configfile):
+        with patch.object(script, "gather_retention_scores", return_value=SCORES) as mock_gather:
+            script.main([configfile, "--hours", "24"])
+        assert mock_gather.call_args.kwargs["hours"] == 24
+
+    def test_warnings_go_to_stderr(self, configfile, capsys):
+        scores = SCORES | {"warnings": ["registrant: 5 active patrons but zero scored engagement"]}
+        with patch.object(script, "gather_retention_scores", return_value=scores):
+            script.main([configfile])
+        assert "zero scored engagement" in capsys.readouterr().err
+
+
+class TestByHour:
+    HOURLY: ClassVar[list[dict]] = [
+        SCORES | {"hour_start": "2026-07-31T04:00:00+00:00", "partial": True, "r_total": 300.0, "total_patrons": 2},
+        SCORES | {"hour_start": "2026-07-31T03:00:00+00:00", "partial": False, "r_total": 900.0, "total_patrons": 6},
+    ]
+
+    def test_by_hour_uses_the_hourly_gatherer(self, configfile):
+        with patch.object(script, "gather_retention_scores_by_hour", return_value=self.HOURLY) as mock_hourly:
+            assert script.main([configfile, "--by-hour", "--hours", "2"]) == 0
+        assert mock_hourly.call_args.kwargs["hours"] == 2
+
+    def test_prints_one_row_per_hour_most_recent_first(self, configfile, capsys):
+        with patch.object(script, "gather_retention_scores_by_hour", return_value=self.HOURLY):
+            script.main([configfile, "--by-hour"])
+        out = capsys.readouterr().out
+        assert "04:00 (partial)" in out
+        assert "03:00" in out
+        assert out.index("04:00") < out.index("03:00")
+
+    def test_flags_the_partial_hour(self, configfile, capsys):
+        with patch.object(script, "gather_retention_scores_by_hour", return_value=self.HOURLY):
+            script.main([configfile, "--by-hour"])
+        assert "not a drop" in capsys.readouterr().out
+
+    def test_json_emits_the_whole_series(self, configfile, capsys):
+        with patch.object(script, "gather_retention_scores_by_hour", return_value=self.HOURLY):
+            script.main([configfile, "--by-hour", "--json"])
+        assert len(json.loads(capsys.readouterr().out)) == 2
+
+    def test_statsd_records_the_most_recent_COMPLETE_hour(self, configfile):
+        """Recording the in-progress hour would write a value that depends on the
+        minute the job fired -- a sawtooth in Graphite rather than a measurement."""
+        with (
+            patch.object(script, "gather_retention_scores_by_hour", return_value=self.HOURLY),
+            patch.object(script, "write_retention_to_statsd") as mock_write,
+        ):
+            script.main([configfile, "--by-hour", "--statsd"])
+        recorded = mock_write.call_args.args[1]
+        assert recorded["partial"] is False
+        assert recorded["r_total"] == 900.0
+
+    def test_statsd_refuses_when_no_complete_hour_is_available(self, configfile, capsys):
+        """--hours 1 spans only the hour in progress, so there is nothing to record."""
+        only_partial = [self.HOURLY[0]]
+        with (
+            patch.object(script, "gather_retention_scores_by_hour", return_value=only_partial),
+            patch.object(script, "write_retention_to_statsd") as mock_write,
+        ):
+            assert script.main([configfile, "--by-hour", "--hours", "1", "--statsd"]) == 1
+        mock_write.assert_not_called()
+        assert "hour in progress" in capsys.readouterr().err
+
+
+class TestEventBreakdown:
+    def test_verbose_lists_the_events_that_earned_points(self, configfile, capsys):
+        scores = SCORES | {"events": {"read": {"count": 12, "points": 100, "total": 1200}}}
+        with patch.object(script, "gather_retention_scores", return_value=scores):
+            script.main([configfile, "--verbose"])
+        out = capsys.readouterr().out
+        assert "read" in out
+        assert "1,200" in out
+
+    def test_events_are_hidden_without_verbose(self, configfile, capsys):
+        scores = SCORES | {"events": {"read": {"count": 12, "points": 100, "total": 1200}}}
+        with patch.object(script, "gather_retention_scores", return_value=scores):
+            script.main([configfile])
+        assert "1,200" not in capsys.readouterr().out


### PR DESCRIPTION
> **Stacked on #13252** (the read-only Matomo client and its offline mock). This PR's base is
> `11956/matomo-client`, so the diff shown here is the scoring layer only. Review #13252 first;
> once it merges, this retargets to `master` cleanly.

Closes #11956.

Adds the Retention Score to Core Vitals: an hourly Matomo-derived measure of
whether returning patrons are getting value, alongside the participation scores
that already ship.

The headline deliverable is **an on-demand trigger** — you can ask for the score
right now, for any window, without waiting for the cron:

```
./scripts/gather_retention_scores.py conf/openlibrary.yml --hours 1 --verbose
```

## What's here

- `openlibrary/core/matomo.py` — a small read-only Matomo Reporting API client.
- `gather_retention_scores()` / `write_retention_to_statsd()` in `openlibrary/admin/vitals.py`, following `gather_participation_scores()`.
- `scripts/gather_retention_scores.py` — the on-demand entry point.
- Hourly cron wiring in `openlibrary/admin/stats.py`, under the existing `if int(ndays) == 1` guard.
- `matomo_api` config key (blank here; the real value lives in olsystem).

## The score

```
E_tau(t)   = sum_e [C(e,tau,t) x w_e] / P_tau(t)
R_total(t) = sum_tau [w_tau x P_tau(t) x E_tau(t)]
```

Class weights come from the Core Vitals doc: `visitor` 0.01, `registrant` 0.2,
`returning` 0.5, `retained` 1.0.

**One judgement call to review.** The spec fixes those four weights but does not
say where the returning/retained line falls across the seven `get_days_registered()`
cohorts. This PR treats `d90+` as retained and `d1+`–`d30+` as returning. That
single decision lives in `PATRON_CLASSES` in `vitals.py`. It is also recoverable:
every raw cohort is emitted to statsd individually, so the boundary can be redrawn
later without losing history. Happy to re-cut it if you read it differently.

## Two bugs carried forward from the prototype, both regression-tested

1. **`dimension1` is a flat field.** `Live.getLastVisitsDetails` does not return
   the nested `customDimensions` structure it looks like it should. Reading it that
   way classifies every visit as `visitor` — measured at ~5.85x undercount against a
   real 24h window.
2. **`follow` and `readlog_*` were scoring zero.** They've been tracked app-side
   since #12367 but were missing from the scoring table.

`P_tau` counts **unique patrons**, not visits, so a patron with three sessions in
the hour counts once.

## Verification

- 67 new tests; full Python suite green.
- **Run live against production Matomo** through an allowlisted proxy: 2,185 visits
  in one hour, `R_total` 816.00, with `dimension1` populating correctly across all
  four classes (2,025 visitor / 46 registrant / 24 returning / 84 retained). Both the
  cron path and the script path exercised end-to-end.
- No browser verification: this is backend-only, no UI surface.

## Known gaps — the score is real but still approximate

These are documented, not fixed here, and none of them block the score being useful:

- **Bot traffic is not excluded** from `visitor` counts. The 0.01 weight suppresses
  most of it but not all; same underlying gap as the Demand Score's bot-exclusion item.
- **`list_create` (50pts) is still unwired** app-side (#12366) and contributes 0. The
  script prints this in its output so it can't be silently forgotten.
- **This is a snapshot metric, not a cohort metric.** It answers "how much engaged
  activity happened this hour, by account age" — not "of everyone who registered on
  day X, what fraction came back by X+7", which is the stated north-star. True cohort
  tracking needs Matomo's `setUserId` wired for logged-in patrons; `setUserId` does not
  appear anywhere in the codebase today. `_patron_id()` already prefers `userId` when
  present, so it will start working the moment that lands.

## Notes

- The client POSTs rather than GETs so the auth token stays out of query strings and
  proxy/access logs.
- The `_ALLOWED_PREFIXES` read-only allowlist is a deliberate safety property — this
  hits production analytics, where a mutating call would be irreversible.
- Retention is wrapped in try/except in the cron (participation is not) because it
  depends on an external service; Matomo being down must not take out the rest of the job.
- `checkin` added to codespell's `ignore-words-list`: it's the repo's own domain
  spelling (`openlibrary/plugins/upstream/checkins.py`) and the engagement table's event name.

