### PR TITLE
fix: keep catalog export links in a row below floated columns (author page)

### DIFF
--- a/static/css/components/page-history.css
+++ b/static/css/components/page-history.css
@@ -13,13 +13,14 @@
   font-size: 0.8em;
 }
 
+/* Rendered as a row at the end of author and book pages, after the floated
+   content columns; `clear` keeps it below them instead of alongside. */
 .pageHistory__tools {
+  display: block;
+  clear: both;
+  text-align: right;
   font-size: 0.7em;
   padding-top: var(--spacing-inset-sm);
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-end;
-  gap: var(--spacing-inline-sm);
   margin-bottom: calc(-1 * var(--spacing-sm));
 }
 


### PR DESCRIPTION
Closes #13218

### Problem

On author pages the "Download catalog record" bar rendered at the top right, squeezed to ~38px wide over the sidebar, instead of as a row at the bottom.

#13091 replaced the bar's `float: right` with `display: flex`. The bar follows two floated columns (`.contentTwothird` / `.contentOnethird`, `float: left` at ≥960px), and an in-flow block is laid out *beside* floats rather than below them.

### Fix

```css
.pageHistory__tools {
  display: block;
  clear: both;
  text-align: right;
}
```

`clear: both` drops the bar below the floated columns. A block formatting context (`flow-root`, `overflow: hidden`, `display: flex`) is not an alternative — a BFC box gets narrowed to fit beside floats, which is the bug itself. `text-align: right` replaces the flex row since this is one line of text, not a layout row. #13091's spacing is unchanged, so #13090 stays fixed.

### Testing

`/authors/OL648A` and `/books/OL755M`: full-width, right-aligned, below both columns, inside `#contentBody` with no overlap or overflow. Wraps in narrow containers. Below 960px the columns aren't floated, so `clear` is a no-op.

**Before / after:**
<img width="1187" height="795" alt="SCR-20260728-szlw" src="https://github.com/user-attachments/assets/da17b2a2-4532-4ffc-8660-777119f7ff31" />

FIXED:
<img width="1127" height="904" alt="SCR-20260728-szhm" src="https://github.com/user-attachments/assets/3fd8bb14-68da-463d-a713-29efb88b293f" />



<!-- screenshots -->
