### PR TITLE
Persist comments when books are deleted

### DIFF
--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -558,13 +558,13 @@ function isValidURL(url) {
  */
 export function initRecordDeletion(elems) {
     for (const elem of elems) {
-        elem.addEventListener("click", (event) => {
-            event.preventDefault()
-            const form = elem.form
-            const commentInput = document.querySelector("input[name=_comment]")
-            form.appendChild(commentInput)
+        elem.addEventListener('click', (event) => {
+            event.preventDefault();
+            const form = elem.form;
+            const commentInput = document.querySelector('input[name=_comment]');
+            form.appendChild(commentInput);
             // pass elem as submitter so its name/value pair is included in the submission
-            form.requestSubmit(elem)
-        })
+            form.requestSubmit(elem);
+        });
     }
 }

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -552,3 +552,19 @@ function isValidURL(url) {
         return false;
     }
 }
+
+/**
+ * @param {NodeList<HTMLElement>} elems
+ */
+export function initRecordDeletion(elems) {
+    for (const elem of elems) {
+        elem.addEventListener("click", (event) => {
+            event.preventDefault()
+            const form = elem.form
+            const commentInput = document.querySelector("input[name=_comment]")
+            form.appendChild(commentInput)
+            // pass elem as submitter so its name/value pair is included in the submission
+            form.requestSubmit(elem)
+        })
+    }
+}

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -80,6 +80,7 @@ jQuery(function() {
     const classifications = document.querySelector('#classifications');
     const excerpts = document.getElementById('excerpts');
     const links = document.getElementById('links');
+    const deleteRecordButtons = document.querySelectorAll(".delete-record")
 
     // conditionally load for user edit page
     if (
@@ -87,7 +88,7 @@ jQuery(function() {
         autocompleteAuthor || autocompleteSeries || autocompleteLanguage || autocompleteWorks ||
         autocompleteSeeds || autocompleteSubjects ||
         addRowButton || roles || classifications ||
-        excerpts || links
+        excerpts || links || deleteRecordButtons.length
     ) {
         import(/* webpackChunkName: "user-website" */ './edit')
             .then(module => {
@@ -126,6 +127,9 @@ jQuery(function() {
                 }
                 if (autocompleteSeeds) {
                     module.initSeedsMultiInputAutocomplete();
+                }
+                if (deleteRecordButtons.length) {
+                    module.initRecordDeletion(deleteRecordButtons)
                 }
             });
     }

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -80,7 +80,7 @@ jQuery(function() {
     const classifications = document.querySelector('#classifications');
     const excerpts = document.getElementById('excerpts');
     const links = document.getElementById('links');
-    const deleteRecordButtons = document.querySelectorAll(".delete-record")
+    const deleteRecordButtons = document.querySelectorAll('.delete-record');
 
     // conditionally load for user edit page
     if (
@@ -129,7 +129,7 @@ jQuery(function() {
                     module.initSeedsMultiInputAutocomplete();
                 }
                 if (deleteRecordButtons.length) {
-                    module.initRecordDeletion(deleteRecordButtons)
+                    module.initRecordDeletion(deleteRecordButtons);
                 }
             });
     }

--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -43,7 +43,7 @@ $:macros.HiddenSaveButton("addWork")
     $if ctx.user and (ctx.user.is_admin() or ctx.user.is_super_librarian()):
         <span class="adminOnly right">
             <form method="post" id="delete-record" name="delete">
-                <button type="submit" name="_delete" value="true" id="delete-btn">$_("Delete Record")</button>
+                <button type="submit" name="_delete" value="true" id="delete-btn" class="delete-record">$_("Delete Record")</button>
             </form>
         </span>
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #13207

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds click handler to the "Delete Record" button, found on book edit pages.  On click, the `_comment` input is appended to the form prior to submission.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
