### PR TITLE
feat(search): make Solr timeouts and partial results attributable

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -293,17 +293,51 @@ def process_facet_counts(
         yield field, list(process_facet(field, web.group(facets, 2)))
 
 
+def describe_solr_query(solr_path: str, params: dict | list[tuple[str, Any]]) -> dict[str, Any]:
+    """
+    Summarize a Solr query by its *shape*, for logging.
+
+    Deliberately excludes the user's query text, so the result is safe to send to
+    Sentry and to aggregate. Two queries with the same shape should have roughly the
+    same cost, which is what makes this useful for grouping timeouts.
+
+    Deep paging (a large `start`) and large boolean queries are the usual culprits, so
+    those are reported as-is rather than bucketed.
+    """
+    pairs = list(params.items()) if isinstance(params, dict) else list(params)
+    values: dict[str, list[str]] = {}
+    for key, value in pairs:
+        values.setdefault(key, []).append(str(value))
+
+    def first(key: str, default: str = "") -> str:
+        return values.get(key, [default])[0]
+
+    # Count boolean clauses without retaining any of the terms. `key:(A OR B OR ...)`
+    # queries built from reading logs can approach maxBooleanClauses.
+    clauses = sum(v.count(" OR ") + v.count("+OR+") for vs in values.values() for v in vs)
+
+    return {
+        "path": solr_path,
+        "label": first("ol.label", "UNLABELLED"),
+        "start": safeint(first("start", "0"), 0),
+        "rows": safeint(first("rows", "0"), 0),
+        # Field names only — never the values they're filtered on.
+        "fq_fields": sorted({fq.split(":", 1)[0] for fq in values.get("fq", [])}),
+        "facet_fields": len(values.get("facet.field", [])),
+        "or_clauses": clauses,
+        "spellcheck": first("spellcheck") == "true",
+        # Block-join / subquery expansion is the expensive part of editions search.
+        "block_join": any("{!parent" in v for vs in values.values() for v in vs),
+        "subquery": any("[subquery]" in v for vs in values.values() for v in vs),
+    }
+
+
 async def execute_solr_query_async(
     solr_path: str,
     params: dict | list[tuple[str, Any]],
     _timeout: int | None = DEFAULT_SOLR_TIMEOUT_SECONDS,
     _pass_time_allowed: bool = DEFAULT_PASS_TIME_ALLOWED,
 ) -> httpx.Response | None:
-    url = solr_path
-    if params:
-        url += "&" if "?" in url else "?"
-        url += urlencode(params)
-
     try:
         response = await get_solr().raw_request(
             solr_path,
@@ -312,7 +346,11 @@ async def execute_solr_query_async(
             _pass_time_allowed=_pass_time_allowed,
         )
     except httpx.HTTPError:
-        logger.exception("Failed solr query")
+        shape = describe_solr_query(solr_path, params)
+        # The label is interpolated into the message so that Sentry groups these by
+        # request type instead of collapsing every Solr failure into one issue. The
+        # shape goes in `extra` to keep issue cardinality bounded.
+        logger.exception("Failed solr query [%(label)s]" % shape, extra={"solr_query_shape": shape})
         return None
     return response
 
@@ -481,7 +519,21 @@ def _process_solr_response_and_enrich(
         if non_solr_fields:
             scheme.add_non_solr_fields(non_solr_fields, solr_result)
 
-    return SearchResponse.from_solr_result(solr_result, sort, url, time=duration)
+    search_response = SearchResponse.from_solr_result(solr_result, sort, url, time=duration)
+
+    # Solr sets partialResults when it gave up early (usually hitting timeAllowed) and
+    # returned an incomplete result set with a 200. Without this it is silent: the
+    # patron sees truncated results presented as complete.
+    if search_response.partial_results:
+        header = solr_result.get("responseHeader", {})
+        logger.warning(
+            "Solr returned partial results (reason=%s, solr QTime=%sms, wall=%.0fms)",
+            header.get("partialResultsDetails", "unknown"),
+            header.get("QTime"),
+            duration * 1000,
+        )
+
+    return search_response
 
 
 async def run_solr_query_async(
@@ -557,6 +609,14 @@ class SearchResponse:
     error: str = None
     time: float = None
     """Seconds to execute the query"""
+    partial_results: bool = False
+    """Solr gave up early (usually `timeAllowed`) and returned an incomplete result set."""
+
+    @staticmethod
+    def _is_partial(solr_result: dict | None) -> bool:
+        """Solr has reported this as both a bool and a string over the years."""
+        flag = (solr_result or {}).get("responseHeader", {}).get("partialResults", False)
+        return str(flag).lower() == "true"
 
     @staticmethod
     def from_solr_result(
@@ -587,6 +647,7 @@ class SearchResponse:
                 highlighting=highlighting,
                 solr_select=solr_select,
                 time=time,
+                partial_results=SearchResponse._is_partial(solr_result),
             )
 
     @staticmethod

--- a/openlibrary/plugins/worksearch/tests/test_worksearch.py
+++ b/openlibrary/plugins/worksearch/tests/test_worksearch.py
@@ -3,8 +3,10 @@ from unittest.mock import patch
 import web
 
 from openlibrary.plugins.worksearch.code import (
+    SearchResponse,
     _get_readable_count,
     _prepare_solr_query_params,
+    describe_solr_query,
     get_doc,
     process_facet,
 )
@@ -232,3 +234,85 @@ def test_get_readable_count_queries_with_readable_filter_when_toggle_off():
     assert readable_param["has_fulltext"] == "true"
     assert "public_scan" not in readable_param
     assert mock_query.call_args.kwargs["rows"] == 0
+
+
+def test_describe_solr_query_omits_user_query_text():
+    """The shape is logged to Sentry, so it must not carry what the patron typed."""
+    secret = "my private search terms"
+    shape = describe_solr_query(
+        "/solr/openlibrary/select",
+        [
+            ("q", "({!edismax v=$workQuery})"),
+            ("workQuery", secret),
+            ("ol.label", "WorkSearch"),
+            ("fq", "type:work"),
+            ("fq", "author_key:OL874808A"),
+            ("start", "0"),
+            ("rows", "20"),
+        ],
+    )
+    assert secret not in repr(shape)
+    assert shape["label"] == "WorkSearch"
+    # Field names are kept; the values they filter on are not.
+    assert shape["fq_fields"] == ["author_key", "type"]
+    assert "OL874808A" not in repr(shape)
+
+
+def test_describe_solr_query_flags_expensive_shapes():
+    shape = describe_solr_query(
+        "/solr/openlibrary/select",
+        [
+            ("ol.label", "ReadingLog"),
+            ("q", "key:(/works/OL1W OR /works/OL2W OR /works/OL3W)"),
+            ("start", "100000"),
+            ("rows", "100"),
+            ("facet.field", "subject_facet"),
+            ("facet.field", "person_facet"),
+            ("spellcheck", "true"),
+        ],
+    )
+    # Deep paging and large boolean queries are the usual culprits.
+    assert shape["start"] == 100000
+    assert shape["or_clauses"] == 2
+    assert shape["facet_fields"] == 2
+    assert shape["spellcheck"] is True
+
+
+def test_describe_solr_query_detects_block_join():
+    shape = describe_solr_query(
+        "/solr/openlibrary/select",
+        [
+            ("q", '_query_:"{!parent which=type:work v=$fullEdQuery}"'),
+            ("fl", "key,editions:[subquery]"),
+        ],
+    )
+    assert shape["block_join"] is True
+    assert shape["subquery"] is True
+    assert shape["label"] == "UNLABELLED"
+
+
+def test_search_response_flags_partial_results():
+    """Solr returns 200 + partialResults when it gives up early; don't swallow it."""
+    solr_result = {
+        "responseHeader": {"QTime": 10001, "partialResults": True},
+        "response": {"docs": [{"key": "/works/OL1W"}], "numFound": 1},
+    }
+    resp = SearchResponse.from_solr_result(solr_result, "", "", time=10.5)
+    assert resp.partial_results is True
+    assert resp.num_found == 1
+
+
+def test_search_response_partial_results_accepts_string_flag():
+    solr_result = {
+        "responseHeader": {"partialResults": "true"},
+        "response": {"docs": [], "numFound": 0},
+    }
+    assert SearchResponse.from_solr_result(solr_result, "", "", time=1.0).partial_results is True
+
+
+def test_search_response_complete_results_not_flagged_partial():
+    solr_result = {
+        "responseHeader": {"QTime": 12},
+        "response": {"docs": [], "numFound": 0},
+    }
+    assert SearchResponse.from_solr_result(solr_result, "", "", time=0.1).partial_results is False


### PR DESCRIPTION
Groundwork for diagnosing slow-Solr incidents. Two Solr failure modes are currently invisible, in different ways.

### 1. Client-side timeout — logged, but anonymised

`httpx.ReadTimeout` → `TimeoutException` → `TransportError` → `RequestError` → `HTTPError`, so it *is* caught:

```python
except httpx.HTTPError:
    logger.exception("Failed solr query")
    return None
```

That message names no query. Meanwhile the query was sitting in a local `url` variable **three lines above**, built and then never used — clearly intended for exactly this.

Because `sentry_sdk.init()` is called without an `integrations` override, the default `LoggingIntegration` promotes ERROR-level logs to events. So these *do* reach Sentry — but every Solr timeout on the site collapses into one issue with no discriminating fingerprint, which is why Sentry hasn't been useful for this.

### 2. Server-side `timeAllowed` trip — not recorded at all

`partialResults` appeared **zero times** in the codebase. When Solr gives up at `timeAllowed` (10s, from `DEFAULT_SOLR_TIMEOUT_SECONDS`) it returns HTTP 200 with `responseHeader.partialResults=true` and raises nothing. Truncated results were served to patrons as complete, and no counter moved.

Worth noting the patron-facing effect of (1) too: on timeout `from_solr_result(None, …)` yields `error=None, docs=[], num_found=None`, and every template gates its error path on `search_response.error`. So a Solr timeout currently renders as **"no results found"** rather than an error — which is part of why these incidents generate no reports.

### Changes

- **`describe_solr_query()`** — summarises a query by its *shape*: label, path, `start`, `rows`, `fq` field names, facet count, OR-clause count, `spellcheck`, block-join and subquery flags. It deliberately excludes the patron's query text so it's safe for Sentry and safe to aggregate. `start` and `or_clauses` are reported as-is rather than bucketed, since deep paging and large boolean queries (we run `maxBooleanClauses=30000`, and reading-log queries build `key:(/works/OL1W OR …)`) are the usual culprits.
- **Timeout log carries the label in the message**, so Sentry groups by request type instead of collapsing; the shape rides along in `extra`, keeping issue cardinality bounded to the label enum. The dead `url` local is removed.
- **`SearchResponse.partial_results`**, read from the response header (Solr has reported this as both a bool and a string over the years), plus a warning logging **both** Solr's `QTime` and the client-side wall clock. The gap between those two is what separates a genuinely slow query from a saturated/queueing cluster — `QTime` starts only once a Jetty worker picks the request up, so it cannot show queueing on its own.

### Testing

6 tests added, 16 pass in the file. Run in the `openlibrary/olbase` image.

Verified end-to-end against a mocked `httpx.ReadTimeout`:

```
log message: Failed solr query [SearchInside]
label in message (Sentry grouping key): True
shape extra: {'path': '/solr/openlibrary/select', 'label': 'SearchInside', 'start': 50000,
              'rows': 20, 'fq_fields': ['type'], 'facet_fields': 0, 'or_clauses': 0,
              'spellcheck': False, 'block_join': False, 'subquery': False}
exc_info attached (Sentry event): True
no patron query text leaked: OK
```

A planted patron query string appears in neither the message nor the shape — there's an explicit test asserting that, since this data goes to Sentry.

### Scope

Deliberately no behaviour change: partial results are still returned, timeouts still degrade to empty. This only makes both observable. Whether a partial-result response should tell the patron their results are incomplete is a separate UX question worth having.