### PR TITLE
Use --no-install-recommends in dockerfiles

### DIFF
--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -23,7 +23,7 @@ RUN groupadd --system --gid 999 openlibrary \
   && useradd --no-log-init --system -u 999 --gid openlibrary --create-home openlibrary
 
 # Misc OL dependencies
-RUN apt-get -qq update && apt-get install -y \
+RUN apt-get -qq update && apt-get install -y --no-install-recommends \
     postgresql-client \
     build-essential \
     git \

--- a/scripts/monitoring/Dockerfile
+++ b/scripts/monitoring/Dockerfile
@@ -14,7 +14,7 @@ RUN \
     # and it causes issues with some of the various prod protections we have in place.
     # apt-get update && \
     # Add Docker's official GPG key:
-    apt-get install ca-certificates curl && \
+    apt-get install --no-install-recommends ca-certificates curl && \
     install -m 0755 -d /etc/apt/keyrings && \
     curl -fsSL ${DOCKER_KEY_URL} -o /etc/apt/keyrings/docker.asc && \
     chmod a+r /etc/apt/keyrings/docker.asc && \
@@ -25,7 +25,7 @@ RUN \
 # Only apt-update the docker source list, to avoid checking the others which might not be accessible
 RUN apt-get update -o Dir::Etc::sourcelist="sources.list.d/docker.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" && \
     # We just need the CLI since we're running in a container with socket access
-    apt-get install -y docker-ce-cli
+    apt-get install -y --no-install-recommends docker-ce-cli
 
 
 # Install netcat
@@ -44,7 +44,7 @@ RUN if [ -n "$APT_MIRROR" ]; \
     else \
         apt-get update; \
   fi && \
-    apt-get install -y netcat-traditional
+    apt-get install -y --no-install-recommends netcat-traditional
 
 # Install requirements.txt
 COPY --chown=openlibrary:openlibrary scripts/monitoring/requirements.txt scripts/monitoring/requirements.txt


### PR DESCRIPTION
Closes #2656

Adds \--no-install-recommends\ flag to all \pt-get install\ commands in Dockerfiles to reduce image size.

- \docker/Dockerfile.olbase\
- \scripts/monitoring/Dockerfile\

Other Dockerfiles already had the flag.