### PR TITLE
Fix #13202: render markdown links whose URL contains parentheses

### DIFF
--- a/openlibrary/core/olmarkdown.py
+++ b/openlibrary/core/olmarkdown.py
@@ -108,6 +108,92 @@ class AutolinkPreprocessor(markdown.Preprocessor):
 AUTOLINK_PREPROCESSOR = AutolinkPreprocessor()
 
 
+# Placeholders used to hide parentheses that belong to a link's URL/title
+# from the paren-matching that closes the `(...)` part of `[text](...)`.
+# Private-use-area code points, so they can't collide with real content.
+_LPAREN_PLACEHOLDER = ""
+_RPAREN_PLACEHOLDER = ""
+
+
+class LinkParenPreprocessor(markdown.Preprocessor):
+    """Let `[text](url)` URLs contain parentheses.
+
+    The vendored LINK_RE (`\\(([^\\)]*)\\)`) stops at the first `)`, so it
+    can't parse a URL such as
+    https://en.wikipedia.org/wiki/George_A._Kennedy_(sinologist)
+    and cuts the link short at the first unescaped `)`. WYSIWYG-edited pages
+    also produce a backslash-escaped form of the same URL
+    (`..._Kennedy_\\(sinologist\\)`), which the base parser doesn't unescape
+    inside a link target either.
+
+    This preprocessor scans each `[text](...)` occurrence and hides every
+    parenthesis that belongs to the URL/title - whether escaped or balanced
+    - behind placeholder characters, leaving only the link's real closing
+    paren as a literal `)`. That lets the unmodified LINK_RE and LinkPattern
+    do the rest. `OLMarkdown.convert` swaps the placeholders back to literal
+    parentheses once rendering is done.
+    """
+
+    def run(self, lines):
+        return [line if markdown.RE.regExp["tabbed"].match(line) else self._process_line(line) for line in lines]
+
+    def _process_line(self, line):
+        out = []
+        i = 0
+        n = len(line)
+        while i < n:
+            if line[i] == "]" and i + 1 < n and line[i + 1] == "(":
+                out.append("](")
+                content, i, closed = self._hide_parens(line, i + 2)
+                out.append(content)
+                if closed:
+                    out.append(")")
+                continue
+            out.append(line[i])
+            i += 1
+        return "".join(out)
+
+    @staticmethod
+    def _hide_parens(line, start):
+        """Hide the link content's parentheses behind placeholders.
+
+        Returns `(hidden_content, next_index, closed)`. `closed` is True
+        when a real closing paren was found; `next_index` then points just
+        past it (the paren itself is not included in `hidden_content`, so
+        the caller can re-append it as a literal `)`). When no closing
+        paren is found, `next_index` is the end of the line and `closed`
+        is False.
+        """
+        depth = 0
+        out = []
+        i = start
+        n = len(line)
+        while i < n:
+            ch = line[i]
+            if ch == "\\" and i + 1 < n and line[i + 1] in "()":
+                out.append(_LPAREN_PLACEHOLDER if line[i + 1] == "(" else _RPAREN_PLACEHOLDER)
+                i += 2
+                continue
+            if ch == "(":
+                depth += 1
+                out.append(_LPAREN_PLACEHOLDER)
+                i += 1
+                continue
+            if ch == ")":
+                if depth == 0:
+                    return "".join(out), i + 1, True
+                depth -= 1
+                out.append(_RPAREN_PLACEHOLDER)
+                i += 1
+                continue
+            out.append(ch)
+            i += 1
+        return "".join(out), i, False
+
+
+LINK_PAREN_PREPROCESSOR = LinkParenPreprocessor()
+
+
 class OLMarkdown(markdown.Markdown):
     """Open Library flavored Markdown, inspired by [Github Flavored Markdown][GFM].
 
@@ -127,11 +213,14 @@ class OLMarkdown(markdown.Markdown):
         patterns = self.inlinePatterns
         autolink = markdown.AutolinkPattern(markdown.AUTOLINK_RE.replace("http", "https?"))
         patterns[patterns.index(markdown.AUTOLINK_PATTERN)] = autolink
+
         p = self.preprocessors
         p.insert(0, FENCED_CODE_PREPROCESSOR)
+        p.insert(1, LINK_PAREN_PREPROCESSOR)
         p[p.index(markdown.LINE_BREAKS_PREPROCESSOR)] = LINE_BREAKS_PREPROCESSOR
         p.append(AUTOLINK_PREPROCESSOR)
 
     def convert(self):
         html = markdown.Markdown.convert(self)
+        html = html.replace(_LPAREN_PLACEHOLDER, "(").replace(_RPAREN_PLACEHOLDER, ")")
         return h.sanitize(html)

--- a/openlibrary/tests/core/test_olmarkdown.py
+++ b/openlibrary/tests/core/test_olmarkdown.py
@@ -159,3 +159,47 @@ def test_olmarkdown_fenced_code():
     # The broken render-shape from the bug report must not appear.
     assert "`<br" not in out
     assert "`\n" not in out
+
+
+def test_olmarkdown_link_url_with_parentheses():
+    """Regression: a ``[text](url)`` link whose URL contains parentheses must
+    render as a link, not as raw markdown source.
+
+    The vendored ``LINK_RE`` (``\\(([^\\)]*)\\)``) stops at the first ``)``, so a
+    URL such as ``..._Kennedy_(sinologist)`` cut the link short, and the
+    backslash-escaped form the Tiptap WYSIWYG editor saves
+    (``..._Kennedy_\\(sinologist\\)``) matched nothing at all. The editor showed
+    a link while the saved author page showed literal markdown
+    (internetarchive/openlibrary#13202).
+    """
+
+    def md(text):
+        return OLMarkdown(text).convert().strip()
+
+    def p(html):
+        # markdown always wraps the result in <p>.
+        return "<p>%s\n</p>" % html
+
+    wiki = "https://en.wikipedia.org/wiki/George_A._Kennedy_(sinologist)"
+    anchor = '<a href="%s" rel="nofollow">George A. Kennedy</a>' % wiki
+
+    # The three forms named in the issue render identically, as they do in
+    # CommonMark and on GitHub: as typed, backslash-escaped (what the editor
+    # saves), and percent-encoded.
+    assert md("[George A. Kennedy](%s)" % wiki) == p(anchor)
+    assert md(r"[George A. Kennedy](https://en.wikipedia.org/wiki/George_A._Kennedy_\(sinologist\))") == p(anchor)
+    assert md("[George A. Kennedy](https://en.wikipedia.org/wiki/George_A._Kennedy_%28sinologist%29)") == p(
+        '<a href="https://en.wikipedia.org/wiki/George_A._Kennedy_%28sinologist%29" rel="nofollow">George A. Kennedy</a>'
+    )
+
+    # The link ends at its own closing paren: surrounding prose, including
+    # later parentheses, stays outside the anchor.
+    body = r"spouse of [George A. Kennedy](https://en.wikipedia.org/wiki/George_A._Kennedy_\(sinologist\)), a scholar."
+    assert md(body) == p("spouse of %s, a scholar." % anchor)
+    assert md("[link](https://example.com/a(b)) then (unrelated) text.") == p('<a href="https://example.com/a(b)" rel="nofollow">link</a> then (unrelated) text.')
+
+    # Links without parentheses, titled links, and parenthesised prose are
+    # unaffected.
+    assert md("[plain](https://example.com/foo)") == p('<a href="https://example.com/foo" rel="nofollow">plain</a>')
+    assert md('[a link](https://example.com/foo "a title")') == p('<a href="https://example.com/foo" title="a title" rel="nofollow">a link</a>')
+    assert md("no link here (just parens) at all") == p("no link here (just parens) at all")


### PR DESCRIPTION
Closes #13202 

Renders `[text](url)` links whose URL contains parentheses as links instead of raw markdown. [fix]

### Technical
The vendored Python-Markdown 1.6b `LINK_RE` is `\(([^\)]*)\)`, which stops at the first `)`. So a URL like `..._Kennedy_(sinologist)` cut the link short. The backslash-escaped form the Tiptap editor saves, `..._Kennedy_\(sinologist\)`, is not unescaped inside a link target at all, so it matched nothing and reached the page as literal markdown.

I added `LinkParenPreprocessor` in `openlibrary/core/olmarkdown.py`. It runs before parsing and hides any parenthesis belonging to the URL or title behind placeholder characters, so only the link's real closing paren is left for `LINK_RE` to match. `convert()` puts the parentheses back before sanitizing.

This leaves the vendored parser, autolinks, and the rest of the markdown behavior untouched. All three forms listed in the issue now render the same way.

### Testing
`docker compose run --rm home make test-py PYTEST_ARGS="openlibrary/tests/core/test_olmarkdown.py"`

Go to an author page, click Edit, and use the link button to add `https://en.wikipedia.org/wiki/George_A._Kennedy_(sinologist)`. Save and view the page. Before the fix it shows raw markdown. After, it shows a working link.

Currently broken in prod: https://openlibrary.org/authors/OL1962708A/Jean_Wilson_Kennedy

### Stakeholders
@lokesh 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->