### PR TITLE
feat: add Bookdash import scraper

### DIFF
--- a/scripts/import_bookdash.py
+++ b/scripts/import_bookdash.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python
+import json
+import re
+import time
+from typing import Any
+from xml.etree import ElementTree as ET
+
+import requests
+from bs4 import BeautifulSoup
+
+from openlibrary.config import load_config
+from openlibrary.core.imports import Batch
+from scripts.solr_builder.solr_builder.fn_to_cli import FnToCLI
+
+SITEMAP_URL = "https://bookdash.org/books-sitemap.xml"
+SITEMAP_NS = {"ns": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+ISBN_RE = re.compile(r"ISBN:\s*([\d\-Xx]+)")
+
+
+def get_sitemap_urls() -> list[str]:
+    """Fetches and returns all Bookdash book page URLs from their sitemap."""
+    response = requests.get(SITEMAP_URL)
+    response.raise_for_status()
+    root = ET.fromstring(response.content)
+    urls = [loc.text for loc in root.findall(".//ns:loc", SITEMAP_NS)]
+    # The sitemap includes the /books/ index page itself; only keep individual book pages.
+    return [url for url in urls if url and url.rstrip("/") != "https://bookdash.org/books"]
+
+
+def scrape_book_page(url: str) -> dict[str, Any]:
+    """Fetches a single Bookdash book page and extracts its raw metadata."""
+    response = requests.get(url)
+    response.raise_for_status()
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    title = soup.find("h1").get_text(strip=True)
+
+    cover_img = soup.find("picture").find("img")
+    cover_url = cover_img.get("data-src") or cover_img.get("src")
+
+    description_tag = soup.find("meta", attrs={"property": "og:description"})
+    description = description_tag["content"] if description_tag else ""
+
+    languages = [a["href"].removeprefix("/languages/") for a in soup.find_all("a", href=True) if a["href"].startswith("/languages/")]
+
+    subjects = [a.get_text(strip=True) for a in soup.find_all("a", href=True) if a["href"].startswith("/themes/")]
+
+    authors = [a.get_text(strip=True) for a in soup.find_all("a", href=True) if "/team-members/" in a["href"]]
+
+    isbn_match = ISBN_RE.search(soup.get_text())
+    isbn = isbn_match.group(1) if isbn_match else None
+
+    return {
+        "url": url,
+        "title": title,
+        "cover_url": cover_url,
+        "description": description,
+        "languages": languages,
+        "subjects": subjects,
+        "authors": authors,
+        "isbn": isbn,
+    }
+
+
+def strip_author_role(name: str) -> str:
+    """Strips a trailing role annotation, e.g. "Jane Doe(Illustrator)" -> "Jane Doe"."""
+    return re.sub(r"\s*\([^)]*\)\s*$", "", name).strip()
+
+
+def map_data(scraped: dict[str, Any]) -> dict[str, Any]:
+    """Maps a scraped Bookdash book dict to an Open Library import object."""
+    slug = scraped["url"].rstrip("/").split("/")[-1]
+
+    import_record: dict[str, Any] = {
+        "title": scraped["title"],
+        "source_records": [f"bookdash:{slug}"],
+        "publishers": ["Bookdash"],
+        "authors": [{"name": strip_author_role(name)} for name in scraped["authors"]],
+        "languages": scraped["languages"],
+        "subjects": scraped["subjects"],
+        "description": scraped["description"],
+    }
+
+    if scraped.get("isbn"):
+        import_record["identifiers"] = {"isbn_13": [scraped["isbn"]]}
+
+    if scraped.get("cover_url"):
+        import_record["cover"] = scraped["cover_url"]
+
+    return import_record
+
+
+def create_batch(records: list[dict[str, Any]]) -> None:
+    """Creates the Bookdash batch import job.
+
+    Attempts to find an existing Bookdash import batch. If nothing is
+    found, a new batch is created. All of the given import records are
+    added to the batch job as JSON strings.
+    """
+    now = time.gmtime(time.time())
+    batch_name = f"bookdash-{now.tm_year}{now.tm_mon}"
+    batch = Batch.find(batch_name) or Batch.new(batch_name)
+    batch.add_items([{"ia_id": r["source_records"][0], "data": r} for r in records])
+
+
+def import_job(
+    ol_config: str,
+    dry_run: bool = False,
+    limit: int | None = None,
+) -> None:
+    """
+    :param str ol_config: Path to openlibrary.yml file
+    :param bool dry_run: If true, only print out records to import
+    :param int limit: If set, only process the first N URLs (useful for testing)
+    """
+    load_config(ol_config)
+
+    urls = get_sitemap_urls()
+    if limit:
+        urls = urls[:limit]
+
+    records = []
+    for url in urls:
+        scraped = scrape_book_page(url)
+        records.append(map_data(scraped))
+        time.sleep(0.5)  # be polite to Bookdash's server
+
+    if not dry_run:
+        create_batch(records)
+        print(f"{len(records)} entries added to the batch import job.")
+    else:
+        for record in records:
+            print(json.dumps(record))
+
+
+if __name__ == "__main__":
+    print("Start: Bookdash import job")
+    FnToCLI(import_job).run()
+    print("End: Bookdash import job")

--- a/scripts/import_bookdash.py
+++ b/scripts/import_bookdash.py
@@ -15,11 +15,12 @@ from scripts.solr_builder.solr_builder.fn_to_cli import FnToCLI
 SITEMAP_URL = "https://bookdash.org/books-sitemap.xml"
 SITEMAP_NS = {"ns": "http://www.sitemaps.org/schemas/sitemap/0.9"}
 ISBN_RE = re.compile(r"ISBN:\s*([\d\-Xx]+)")
+REQUEST_TIMEOUT = 30
 
 
 def get_sitemap_urls() -> list[str]:
     """Fetches and returns all Bookdash book page URLs from their sitemap."""
-    response = requests.get(SITEMAP_URL)
+    response = requests.get(SITEMAP_URL, timeout=REQUEST_TIMEOUT)
     response.raise_for_status()
     root = ET.fromstring(response.content)
     urls = [loc.text for loc in root.findall(".//ns:loc", SITEMAP_NS)]
@@ -29,14 +30,18 @@ def get_sitemap_urls() -> list[str]:
 
 def scrape_book_page(url: str) -> dict[str, Any]:
     """Fetches a single Bookdash book page and extracts its raw metadata."""
-    response = requests.get(url)
+    response = requests.get(url, timeout=REQUEST_TIMEOUT)
     response.raise_for_status()
     soup = BeautifulSoup(response.text, "html.parser")
 
-    title = soup.find("h1").get_text(strip=True)
+    title_tag = soup.find("h1")
+    if not title_tag:
+        raise ValueError(f"Missing <h1> title on {url}")
+    title = title_tag.get_text(strip=True)
 
-    cover_img = soup.find("picture").find("img")
-    cover_url = cover_img.get("data-src") or cover_img.get("src")
+    cover_url = None
+    if (picture := soup.find("picture")) and (cover_img := picture.find("img")):
+        cover_url = cover_img.get("data-src") or cover_img.get("src")
 
     description_tag = soup.find("meta", attrs={"property": "og:description"})
     description = description_tag["content"] if description_tag else ""

--- a/scripts/tests/test_import_bookdash.py
+++ b/scripts/tests/test_import_bookdash.py
@@ -1,4 +1,23 @@
-from scripts.import_bookdash import map_data, strip_author_role
+from unittest.mock import Mock, patch
+
+from scripts.import_bookdash import map_data, scrape_book_page, strip_author_role
+
+BOOK_PAGE_HTML = """
+<html>
+<head>
+<meta property="og:description" content="It's a beautiful day for a picnic.">
+</head>
+<body>
+<h1>A Beautiful Day</h1>
+<picture><img data-src="https://bookdash.org/wp-content/uploads/2016/01/cover.jpg" src="placeholder.jpg"></picture>
+<a href="/languages/eng">English</a>
+<a href="/themes/family-friends-and-home">Family, friends, and home</a>
+<a href="/team-members/raeesah-vawda">Raeesah Vawda(Designer)</a>
+<a href="/team-members/elana-bregin">Elana Bregin(Writer)</a>
+<p>ISBN: 978-1-928318-15-6</p>
+</body>
+</html>
+"""
 
 SAMPLE_1 = {
     "url": "https://bookdash.org/books/a-beautiful-day/",
@@ -10,6 +29,22 @@ SAMPLE_1 = {
     "authors": ["Raeesah Vawda(Designer)", "Lindy Pelzl(Illustrator)", "Elana Bregin(Writer)"],
     "isbn": "978-1-928318-15-6",
 }
+
+
+@patch("scripts.import_bookdash.requests.get")
+def test_scrape_book_page(mock_get):
+    mock_get.return_value = Mock(text=BOOK_PAGE_HTML, status_code=200)
+    scraped = scrape_book_page("https://bookdash.org/books/a-beautiful-day/")
+    assert scraped == {
+        "url": "https://bookdash.org/books/a-beautiful-day/",
+        "title": "A Beautiful Day",
+        "cover_url": "https://bookdash.org/wp-content/uploads/2016/01/cover.jpg",
+        "description": "It's a beautiful day for a picnic.",
+        "languages": ["eng"],
+        "subjects": ["Family, friends, and home"],
+        "authors": ["Raeesah Vawda(Designer)", "Elana Bregin(Writer)"],
+        "isbn": "978-1-928318-15-6",
+    }
 
 
 def test_strip_author_role():

--- a/scripts/tests/test_import_bookdash.py
+++ b/scripts/tests/test_import_bookdash.py
@@ -1,6 +1,14 @@
 from unittest.mock import Mock, patch
 
-from scripts.import_bookdash import map_data, scrape_book_page, strip_author_role
+from scripts.import_bookdash import get_sitemap_urls, map_data, scrape_book_page, strip_author_role
+
+SITEMAP_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<url><loc>https://bookdash.org/books/</loc></url>
+<url><loc>https://bookdash.org/books/a-beautiful-day/</loc></url>
+<url><loc>https://bookdash.org/books/usuku-oluhle/</loc></url>
+</urlset>
+"""
 
 BOOK_PAGE_HTML = """
 <html>
@@ -29,6 +37,16 @@ SAMPLE_1 = {
     "authors": ["Raeesah Vawda(Designer)", "Lindy Pelzl(Illustrator)", "Elana Bregin(Writer)"],
     "isbn": "978-1-928318-15-6",
 }
+
+
+@patch("scripts.import_bookdash.requests.get")
+def test_get_sitemap_urls(mock_get):
+    mock_get.return_value = Mock(content=SITEMAP_XML.encode(), status_code=200)
+    urls = get_sitemap_urls()
+    assert urls == [
+        "https://bookdash.org/books/a-beautiful-day/",
+        "https://bookdash.org/books/usuku-oluhle/",
+    ]
 
 
 @patch("scripts.import_bookdash.requests.get")

--- a/scripts/tests/test_import_bookdash.py
+++ b/scripts/tests/test_import_bookdash.py
@@ -1,0 +1,43 @@
+from scripts.import_bookdash import map_data, strip_author_role
+
+SAMPLE_1 = {
+    "url": "https://bookdash.org/books/a-beautiful-day/",
+    "title": "A Beautiful Day",
+    "cover_url": "https://bookdash.org/wp-content/uploads/2016/01/a-beautiful-day_cover_20160104.jpg",
+    "description": "It’s a beautiful day for a picnic. Everyone wants to join in the fun.",  # noqa: RUF001
+    "languages": ["eng"],
+    "subjects": ["Family, friends, and home", "Let's go on an adventure"],
+    "authors": ["Raeesah Vawda(Designer)", "Lindy Pelzl(Illustrator)", "Elana Bregin(Writer)"],
+    "isbn": "978-1-928318-15-6",
+}
+
+
+def test_strip_author_role():
+    assert strip_author_role("Raeesah Vawda(Designer)") == "Raeesah Vawda"
+    assert strip_author_role("Elana Bregin (Writer)") == "Elana Bregin"
+    assert strip_author_role("Jane Doe") == "Jane Doe"
+
+
+def test_map_data():
+    assert map_data(SAMPLE_1) == {
+        "title": "A Beautiful Day",
+        "source_records": ["bookdash:a-beautiful-day"],
+        "publishers": ["Bookdash"],
+        "authors": [
+            {"name": "Raeesah Vawda"},
+            {"name": "Lindy Pelzl"},
+            {"name": "Elana Bregin"},
+        ],
+        "languages": ["eng"],
+        "subjects": ["Family, friends, and home", "Let's go on an adventure"],
+        "description": "It’s a beautiful day for a picnic. Everyone wants to join in the fun.",  # noqa: RUF001
+        "identifiers": {"isbn_13": ["978-1-928318-15-6"]},
+        "cover": "https://bookdash.org/wp-content/uploads/2016/01/a-beautiful-day_cover_20160104.jpg",
+    }
+
+
+def test_map_data_no_isbn_or_cover():
+    scraped = {**SAMPLE_1, "isbn": None, "cover_url": None}
+    record = map_data(scraped)
+    assert "identifiers" not in record
+    assert "cover" not in record


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #10856

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
[feature] Adds a scraper script to import books from bookdash.org into Open Library's import pipeline. It fetches the site's WordPress sitemap, scrapes each book page, and maps the extracted metadata to the Open Library import schema.

### Technical
<!-- What should be noted about the implementation? -->
- `scripts/import_bookdash.py` fetches `https://bookdash.org/books-sitemap.xml`, filters out the non-book index URL, and scrapes each book page with BeautifulSoup.
- Author names are cleaned of role annotations (e.g. `"Jane Doe(Illustrator)"` → `"Jane Doe"`) before mapping, to avoid creating duplicate/incorrect author records on import.
- Scraped data is mapped to the Open Library import schema and submitted via `openlibrary.core.imports.Batch`.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Unit tests added in `scripts/tests/test_import_bookdash.py` covering sitemap parsing, page scraping, and author-name cleanup.
- Run: `make test-py-uv PYTEST_ARGS="scripts/tests/test_import_bookdash.py"`

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A — no UI changes.

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->